### PR TITLE
Add secret scanning guardrails

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,23 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Scan for secrets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,21 @@ config.yaml.bak
 *.tmp
 *.swp
 
+# Secrets and credentials (global)
+.env
+.env.*
+!.env.example
+*.key
+*.pem
+*.p12
+*.pfx
+*.crt
+credentials.*
+secrets.*
+secrets/
+*.keystore
+
 # Token Spy runtime
-token-spy/.env
 token-spy/data/
 token-spy/*.db
 token-spy/*.sqlite

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,5 @@
+# Gitleaks ignore file
+# Add fingerprints of known false positives here (one per line)
+# Get fingerprints from gitleaks output when a false positive is detected
+#
+# Example: abc123def456...

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# Pre-commit hooks for secret scanning
+# Install: pip install pre-commit && pre-commit install
+# Run manually: pre-commit run --all-files
+
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.21.2
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: detect-private-key
+      - id: check-added-large-files
+        args: ['--maxkb=500']


### PR DESCRIPTION
## Summary
- **Pre-commit hooks** (`.pre-commit-config.yaml`): gitleaks + detect-private-key run locally before any commit
- **GitHub Actions workflow** (`.github/workflows/secret-scan.yml`): gitleaks scans every PR and push to main
- **Expanded `.gitignore`**: global patterns for `.env`, `*.key`, `*.pem`, `*.pfx`, `*.crt`, `credentials.*`, `secrets.*`, `*.keystore`

Prevents agents and contributors from accidentally committing API keys, tokens, certificates, and other sensitive data.

## Test plan
- [ ] Verify the GitHub Actions workflow runs on this PR
- [ ] Confirm `.env.example` files are NOT ignored (negation rule `!.env.example`)
- [ ] Install pre-commit locally and verify gitleaks hook catches test secrets

?? Generated with [Claude Code](https://claude.com/claude-code)