### PR TITLE
Add Guardian — self-healing process watchdog for LLM infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Periodic memory reset for persistent LLM agents. Agents accumulate scratch notes
 
 Defines a `---` separator convention: everything above is operator-controlled identity (rules, capabilities, pointers), everything below is agent scratch space that gets archived and cleared.
 
+### Guardian
+Self-healing process watchdog for LLM infrastructure. Runs as a root systemd service that agents cannot kill or modify. Monitors processes, systemd services, Docker containers, and file integrity — automatically restoring from known-good backups when things break.
+
+Supports tiered health checks (port listening, HTTP endpoints, custom commands, JSON validation), a recovery cascade (soft restart → backup restore → restart), generational backups with immutable flags, and restart delegation chains. Everything is config-driven via an INI file.
+
 ### Architecture Docs
 Deep-dive documentation on how OpenClaw talks to vLLM, why the proxy exists, how session files work, and the five failure points that kill local setups.
 
@@ -247,6 +252,14 @@ LightHeart-OpenClaw/
 │   ├── baselines/                     # Baseline MEMORY.md templates
 │   └── docs/
 │       └── WRITING-BASELINES.md       # Guide to writing effective baselines
+├── guardian/                           # Self-healing process watchdog
+│   ├── guardian.sh                    # Config-driven watchdog script
+│   ├── guardian.conf.example          # Sanitized example config
+│   ├── guardian.service               # Systemd unit template
+│   ├── install.sh                     # Installer (systemd + immutable flags)
+│   ├── uninstall.sh                   # Uninstaller
+│   └── docs/
+│       └── HEALTH-CHECKS.md           # Health check & recovery reference
 ├── docs/
 │   ├── SETUP.md                       # Full local setup guide
 │   ├── ARCHITECTURE.md                # How it all fits together

--- a/guardian/README.md
+++ b/guardian/README.md
@@ -1,0 +1,384 @@
+# Guardian — Self-Healing Process Watchdog
+
+An auto-healing process watchdog for LLM infrastructure. Monitors services, detects failures, and restores from known-good backups — all without human intervention.
+
+---
+
+## The Problem
+
+Persistent LLM agents break things:
+
+- **Services crash.** Gateways, API proxies, and vector databases go down. The agent can't call LLMs, can't search memory, can't function.
+- **Configs get corrupted.** Agents modify their own model settings, break JSON configs, or overwrite critical files.
+- **Processes disappear.** Background services get killed by OOM, stale PIDs, or the agent itself.
+- **Nobody notices.** By the time you check, the agent has been running degraded for hours.
+
+Guardian fixes all of this automatically.
+
+---
+
+## Design Principles
+
+1. **Agents can't touch it.** Guardian runs as a root systemd service. Agents (unprivileged users) cannot kill, modify, or interfere with it.
+2. **It knows what healthy looks like.** Configuration defines the desired state. Generational backups preserve known-good file contents.
+3. **It heals automatically.** Soft restart first, then restore from backup and restart. No human intervention needed.
+4. **It logs everything.** Every failure, every restart, every restore is logged with timestamps. You always know what broke and when.
+
+---
+
+## Supported Monitoring Types
+
+| Type | Monitors | Restarts via |
+|------|----------|-------------|
+| `process` | `pgrep -f` pattern match | `start_cmd` (kill + restart) |
+| `systemd-user` | `systemctl --user is-active` | `systemctl --user restart` |
+| `docker` | `docker inspect` container state | `docker restart` |
+| `file-integrity` | File existence, size, JSON validity | Restore from backup |
+
+All types support additional health checks: `required_ports`, `health_url`, `health_port`, `health_cmd`.
+
+---
+
+## Prerequisites
+
+- **Linux with systemd** (Ubuntu, Debian, Fedora, RHEL, etc.)
+- **ext4 or xfs filesystem** (for `chattr +i` immutable flags — btrfs/zfs use different mechanisms)
+- **python3** (for JSON validation in `file-integrity` checks)
+- **curl** (for `health_url` checks)
+- **iproute2** (`ss` command, for port checks — installed by default on most distros)
+- **e2fsprogs** (`chattr`/`lsattr` commands — installed by default on most distros)
+- **psmisc** (`fuser` command, for freeing ports during process restarts)
+- **docker** (optional, only needed if monitoring Docker containers)
+
+```bash
+# Debian/Ubuntu — install anything missing
+sudo apt install python3 curl iproute2 e2fsprogs psmisc
+
+# RHEL/Fedora
+sudo dnf install python3 curl iproute e2fsprogs psmisc
+```
+
+---
+
+## Quick Start
+
+```bash
+# Clone (or copy the guardian/ directory)
+git clone https://github.com/Light-Heart-Labs/LightHeart-OpenClaw.git
+cd LightHeart-OpenClaw/guardian
+
+# Copy and edit the config
+cp guardian.conf.example guardian.conf
+nano guardian.conf
+# All sections ship as enabled=false — enable the ones you need
+
+# IMPORTANT: Update ReadWritePaths in the systemd service
+nano guardian.service
+# ProtectSystem=strict blocks ALL writes outside listed paths.
+# You MUST add every directory Guardian needs to read/write:
+#   ReadWritePaths=/var/log /var/lib/guardian /tmp /home/deploy /opt/myapp
+# Without this, Guardian will silently fail to backup, restore, or
+# restart anything in unlisted directories.
+
+# Install (requires root)
+sudo ./install.sh
+
+# Verify it's running
+sudo systemctl status guardian
+sudo tail -f /var/log/guardian.log
+```
+
+### Editing config after install
+
+```bash
+sudo chattr -i /etc/guardian/guardian.conf   # unlock
+sudo nano /etc/guardian/guardian.conf         # edit
+sudo chattr +i /etc/guardian/guardian.conf    # re-lock
+sudo systemctl restart guardian              # apply
+```
+
+### Editing ReadWritePaths after install
+
+```bash
+sudo chattr -i /etc/systemd/system/guardian.service
+sudo nano /etc/systemd/system/guardian.service   # add paths to ReadWritePaths
+sudo chattr +i /etc/systemd/system/guardian.service
+sudo systemctl daemon-reload
+sudo systemctl restart guardian
+```
+
+---
+
+## Configuration Reference
+
+Guardian uses INI-style config files. Each section (except `[general]`) defines a monitored resource.
+
+### `[general]` section
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `check_interval` | `60` | Seconds between monitoring cycles |
+| `log_file` | `/var/log/guardian.log` | Log file path |
+| `max_log_size` | `10485760` | Log rotation threshold (bytes, default 10MB) |
+| `backup_dir` | `/var/lib/guardian/backups` | Backup storage directory |
+| `backup_generations` | `5` | Number of backup generations to keep |
+
+### Resource section keys
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `enabled` | `false` | Must be `true` to monitor |
+| `type` | — | `process`, `systemd-user`, `docker`, or `file-integrity` |
+| `description` | section name | Human-readable label for logs |
+| `max_soft_restarts` | `3` | Attempts before falling back to backup restore |
+| `restart_grace` | `10` | Seconds to wait after restart |
+| `restart_via` | — | Delegate restart to another section |
+| `protected_files` | — | Comma-separated paths to backup/monitor |
+| `protected_service` | — | Systemd service file to backup |
+| `skip_immutable` | `false` | Don't set immutable flag on restored files |
+| `required_ports` | — | Ports that must be listening |
+| `health_url` | — | URL that must return HTTP 2xx |
+| `health_port` | — | Single port that must be listening |
+| `health_cmd` | — | Shell command that must exit 0 |
+| `process_match` | — | `pgrep -f` pattern (type=process) |
+| `start_cmd` | — | Start script (type=process) |
+| `start_dir` | — | Working directory (type=process) |
+| `start_user` | `$(whoami)` | Unix user to run as (type=process). **See warning below.** |
+| `start_venv` | — | Python venv path (type=process) |
+| `service` | — | Systemd unit name (type=systemd-user) |
+| `systemd_user` | — | Unix user (type=systemd-user, required) |
+| `container_name` | — | Docker container (type=docker) |
+| `required_json_keys` | — | Required top-level keys in JSON files |
+| `required_json_values` | — | Pinned `path=value` pairs in JSON files |
+
+See [docs/HEALTH-CHECKS.md](docs/HEALTH-CHECKS.md) for detailed examples of each type.
+
+### Warning: `start_user` defaults to root in production
+
+`start_user` defaults to `$(whoami)`. When Guardian runs as a systemd service (which runs as root), this means **processes will be started as root** unless you set `start_user` explicitly. Always set it:
+
+```ini
+start_user=deploy
+```
+
+---
+
+## Recovery Cascade
+
+```
+UNHEALTHY detected
+  │
+  ├─ failure_count <= max_soft_restarts?
+  │   └─ YES → Soft restart (kill + restart or systemctl restart)
+  │              Wait restart_grace seconds
+  │
+  └─ NO (exhausted)
+      └─ Restore all protected_files from backup
+         Restart the service
+         Reset failure counter
+```
+
+Failure counters are persistent across cycles and reset when a resource recovers.
+
+---
+
+## Backup System
+
+- **Snapshots on health.** Every cycle a resource is healthy, Guardian diffs live files against the latest backup and takes a new snapshot if they changed.
+- **Generational rotation.** Up to N generations (default 5). Oldest is deleted when a new snapshot arrives.
+- **Immutable backups.** All backup files are root-owned, mode 600, and `chattr +i`. Agents cannot modify or delete them.
+- **Service files too.** `protected_service` paths are backed up alongside application files.
+
+```
+/var/lib/guardian/backups/
+└── my-gateway/
+    ├── openclaw.json        ← latest healthy
+    ├── openclaw.json.1      ← previous
+    ├── openclaw.json.2
+    └── ...
+```
+
+---
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        systemd (PID 1)                          │
+│                                                                  │
+│  ┌──────────────────────────────────────────────────────────┐    │
+│  │  guardian.service (root)                                  │    │
+│  │                                                          │    │
+│  │  ┌─────────────┐   every Ns    ┌───────────────────┐    │    │
+│  │  │ guardian.sh  │ ────────────→ │ check_section()   │    │    │
+│  │  │             │               │                   │    │    │
+│  │  │  • INI parse │               │ • process match   │    │    │
+│  │  │  • log rotate│               │ • systemd status  │    │    │
+│  │  │  • self-check│               │ • docker inspect  │    │    │
+│  │  └─────────────┘               │ • file integrity  │    │    │
+│  │                                │ • port checks     │    │    │
+│  │                                │ • URL checks      │    │    │
+│  │                                │ • custom commands  │    │    │
+│  │                                └───────┬───────────┘    │    │
+│  │                                        │                │    │
+│  │                            ┌───────────┴───────────┐    │    │
+│  │                            │                       │    │    │
+│  │                     ┌──────▼──────┐    ┌───────────▼┐   │    │
+│  │                     │   HEALTHY   │    │  UNHEALTHY │   │    │
+│  │                     │             │    │            │   │    │
+│  │                     │ • snapshot  │    │ • restart  │   │    │
+│  │                     │ • reset ctr │    │ • restore  │   │    │
+│  │                     └─────────────┘    └────────────┘   │    │
+│  │                                                          │    │
+│  └──────────────────────────────────────────────────────────┘    │
+│                                                                  │
+│  ┌──────────────────┐  ┌──────────────────┐                     │
+│  │ /var/lib/guardian │  │ /var/log/        │                     │
+│  │ └── backups/     │  │ └── guardian.log  │                     │
+│  │ └── state/       │  └──────────────────┘                     │
+│  └──────────────────┘                                           │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Security Model
+
+- **Root ownership.** `guardian.sh`, config, and systemd service are owned by root with immutable flags (`chattr +i`).
+- **ProtectSystem=strict.** Systemd sandboxing prevents writes outside explicitly allowed paths.
+- **PrivateTmp=true.** Guardian gets its own `/tmp` namespace.
+- **Self-integrity checks.** Every cycle, Guardian verifies its own immutable flags are intact and re-sets them if cleared.
+- **Immutable backups.** Backup files are root:root, mode 600, chattr +i. Agents cannot read, modify, or delete them.
+
+---
+
+## Extension Points
+
+Guardian is designed to be extended via the config file and by forking the script.
+
+### Custom health checks
+
+Use `health_cmd` to run any validation logic:
+
+```ini
+health_cmd=/opt/myapp/deep-health-check.sh
+```
+
+### Model pinning
+
+Use `file-integrity` with `required_json_values` to prevent agents from changing their own model config:
+
+```ini
+[model-pin]
+type=file-integrity
+protected_files=/home/deploy/.openclaw/openclaw.json
+required_json_values=agents.defaults.model.primary=gpt-4
+restart_via=my-gateway
+```
+
+### Restart delegation
+
+Chain restarts through parent processes:
+
+```ini
+restart_via=parent-section-name
+```
+
+### Adding custom sync logic (e.g. model propagation)
+
+If you need Guardian to do more than monitor and restart — for example, querying a vLLM `/v1/models` endpoint and propagating the current model name to downstream config files and databases — add a custom function to the main loop.
+
+The pattern: write a function that reads its own config section, does the sync work, and call it from the `while true` loop in `main()`:
+
+```bash
+# In guardian.sh, add your function above main():
+sync_my_models() {
+    local section="my-model-sync"
+    local enabled
+    enabled=$(cfg "$section" enabled "false")
+    [[ "$enabled" != "true" ]] && return 0
+
+    # Query your model server, update downstream configs, etc.
+    # Use cfg() to read config, log() to log, clear_immutable()/set_immutable()
+    # to manage protected files, and secure_backup() to update backups.
+}
+
+# In the main loop, call it alongside check_section:
+while true; do
+    rotate_log
+    check_self_integrity
+    sync_my_models          # <-- your custom sync
+    for section in "${SECTIONS[@]}"; do
+        # ...
+    done
+    sleep "$interval"
+done
+```
+
+This is how the production version handles vLLM model sync — a ~200 line function that queries `/v1/models`, updates agent config files, and patches workflow databases. It was too infrastructure-specific to include here, but the pattern is straightforward: read config, do work, update backups.
+
+---
+
+## Troubleshooting
+
+### Check the log first
+
+```bash
+sudo tail -50 /var/log/guardian.log
+```
+
+### What healthy looks like
+
+```
+[2025-07-15 14:30:00] [INFO] ==========================================
+[2025-07-15 14:30:00] [INFO] Guardian starting
+[2025-07-15 14:30:00] [INFO]   Config: /etc/guardian/guardian.conf
+[2025-07-15 14:30:00] [INFO]   Monitoring: 4 resources
+[2025-07-15 14:30:00] [INFO]   Interval: 60s
+[2025-07-15 14:30:00] [INFO]   Backups: /var/lib/guardian/backups (5 generations)
+[2025-07-15 14:30:00] [INFO] ==========================================
+[2025-07-15 14:30:00] [INFO] Taking initial snapshots of all protected resources...
+[2025-07-15 14:30:01] [INFO] [my-gateway] Snapshot updated: openclaw.json
+[2025-07-15 14:30:01] [INFO] Initial snapshots complete.
+```
+
+### What a failure + recovery looks like
+
+```
+[2025-07-15 15:31:00] [WARN] [my-api-server] API Server UNHEALTHY: process not found (match: uvicorn main:app.*8080) (failure #1)
+[2025-07-15 15:31:00] [INFO] [my-api-server] Soft restart (1/3)
+[2025-07-15 15:31:00] [INFO] [my-api-server] Starting: start.sh (user=deploy)
+[2025-07-15 15:32:00] [INFO] [my-api-server] API Server RECOVERED. Resetting failure counter.
+[2025-07-15 15:32:00] [INFO] [my-api-server] Snapshot updated: main.py
+```
+
+### What backup restore looks like
+
+```
+[2025-07-15 16:35:00] [WARN] [my-settings] Application Settings UNHEALTHY: file integrity check failed (failure #4)
+[2025-07-15 16:35:00] [WARN] [my-settings] Soft restarts exhausted. RESTORING FROM BACKUP.
+[2025-07-15 16:35:00] [WARN] [my-settings] RESTORED: settings.json
+[2025-07-15 16:35:00] [INFO] [my-settings] Backup restored. Restarting...
+```
+
+### Common problems
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Guardian can't read/write monitored files | `ProtectSystem=strict` blocks unlisted paths | Add directories to `ReadWritePaths` in `guardian.service`, run `systemctl daemon-reload && systemctl restart guardian` |
+| Process starts as root | `start_user` defaults to `$(whoami)` = root in systemd | Set `start_user=youruser` explicitly in config |
+| "FATAL: Config not found" | Config not at expected path | Set `GUARDIAN_CONF=/path/to/guardian.conf` in the systemd service `Environment=` line |
+| `chattr` errors on btrfs/zfs | Immutable flags are ext4/xfs-specific | Guardian still works but immutable protection is unavailable; files can be modified by agents |
+| JSON validation fails but file looks correct | Trailing commas or comments in JSON | Python's `json.load()` is strict — no trailing commas, no comments |
+| "No systemd_user defined" | `systemd_user` is required for `systemd-user` type | Add `systemd_user=youruser` to the section |
+| Log fills up with failures for example services | Example config has services that don't exist on your system | Set `enabled=false` on sections you haven't configured (the example config ships this way) |
+
+---
+
+## Uninstall
+
+```bash
+sudo ./uninstall.sh
+```
+
+Stops the service, removes the systemd unit, clears immutable flags, and removes installed files. Backups and logs are preserved (instructions to remove them are printed).

--- a/guardian/docs/HEALTH-CHECKS.md
+++ b/guardian/docs/HEALTH-CHECKS.md
@@ -1,0 +1,347 @@
+# Health Checks Reference
+
+How Guardian monitors resources and recovers from failures.
+
+---
+
+## The Tier System
+
+Organize your config sections by dependency criticality. Guardian checks all sections every cycle, but tiers help you reason about what matters most:
+
+| Tier | Purpose | Example |
+|------|---------|---------|
+| **Tier 1** | Agent lifeline — agent is dead without these | Gateways, core services |
+| **Tier 2** | API routing — agent can't think without these | Proxies, API servers |
+| **Tier 3** | Memory & context — agent loses state without these | Databases, config files |
+| **Tier 4** | Helpers — degraded but alive without these | Monitoring, bots, utilities |
+
+Guardian doesn't enforce tiers — they're an organizational convention. Every enabled section gets checked every cycle regardless of tier.
+
+---
+
+## Monitoring Types
+
+### `process`
+
+Matches a running process by command-line pattern (via `pgrep -f`). If the process isn't found, Guardian restarts it using `start_cmd`.
+
+```ini
+[my-api-server]
+enabled=true
+type=process
+description=My API Server
+process_match=uvicorn main:app.*8080
+start_cmd=start.sh
+start_dir=/opt/myapp
+start_user=deploy
+start_venv=/opt/myapp/venv
+required_ports=8080
+health_url=http://127.0.0.1:8080/health
+protected_files=/opt/myapp/main.py,/opt/myapp/start.sh
+max_soft_restarts=3
+restart_grace=10
+```
+
+**Recovery flow:**
+1. Kill existing process (`pkill -f`, then `pkill -9` after 2s)
+2. Free required ports (`fuser -k`)
+3. Activate virtualenv if `start_venv` is set
+4. `cd` to `start_dir` if set
+5. Run `start_cmd` as `start_user` via `nohup` (`.py` files use `python3`, others use `bash`)
+
+### `systemd-user`
+
+Monitors a systemd user service via `systemctl --user is-active`. Restarts via `systemctl --user restart`.
+
+```ini
+[my-gateway]
+enabled=true
+type=systemd-user
+description=OpenClaw Gateway
+service=openclaw-gateway.service
+systemd_user=deploy
+required_ports=3100
+health_port=3100
+protected_files=/home/deploy/.openclaw/openclaw.json
+protected_service=/home/deploy/.config/systemd/user/openclaw-gateway.service
+max_soft_restarts=3
+restart_grace=15
+skip_immutable=true
+```
+
+**Important:** `systemd_user` is required — Guardian needs to know which user's systemd instance to interact with.
+
+### `docker`
+
+Monitors a Docker container via `docker inspect`. Restarts via `docker restart`.
+
+```ini
+[my-database]
+enabled=true
+type=docker
+description=Vector Database
+container_name=qdrant-prod
+required_ports=6333
+health_url=http://127.0.0.1:6333/healthz
+max_soft_restarts=3
+restart_grace=15
+```
+
+### `file-integrity`
+
+Validates that files exist, are non-empty, and optionally contain valid JSON with required keys and values. Recovery restores from backup.
+
+```ini
+[my-settings]
+enabled=true
+type=file-integrity
+description=Application Settings
+protected_files=/opt/myapp/settings.json,/opt/myapp/config.yaml
+required_json_keys=session_limit,poll_interval
+required_json_values=database.host=localhost
+max_soft_restarts=1
+restart_grace=5
+```
+
+---
+
+## Config Key Reference
+
+### Common Keys (all types)
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `enabled` | yes | `false` | Must be `true` to monitor this section |
+| `type` | yes | — | `process`, `systemd-user`, `docker`, or `file-integrity` |
+| `description` | no | section name | Human-readable description for logs |
+| `max_soft_restarts` | no | `3` | Soft restarts before falling back to backup restore |
+| `restart_grace` | no | `10` | Seconds to wait after a restart before rechecking |
+| `restart_via` | no | — | Delegate restart to another section (by section name) |
+| `protected_files` | no | — | Comma-separated file paths to backup and monitor |
+| `protected_service` | no | — | Systemd service file path to backup |
+| `skip_immutable` | no | `false` | If `true`, don't set immutable flag on restored files |
+| `required_ports` | no | — | Comma-separated ports that must be listening |
+| `health_url` | no | — | URL that must return HTTP 2xx |
+| `health_port` | no | — | Port that must be listening (simpler than `required_ports`) |
+| `health_cmd` | no | — | Shell command that must exit 0 |
+
+### Process-Specific Keys
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `process_match` | yes | — | Pattern for `pgrep -f` matching |
+| `start_cmd` | yes | — | Script/binary to start (`.py` → python3, else bash) |
+| `start_dir` | no | — | Working directory for `start_cmd` |
+| `start_user` | no | `$(whoami)` | Unix user to run as. **Warning:** defaults to `root` when Guardian runs as a systemd service — always set this explicitly. |
+| `start_venv` | no | — | Python virtualenv path to activate before starting |
+
+### Systemd-User Keys
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `service` | yes | — | Systemd service unit name |
+| `systemd_user` | yes | — | Unix user whose systemd instance to manage |
+
+### Docker Keys
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `container_name` | yes | — | Docker container name |
+
+### File-Integrity Keys
+
+| Key | Required | Default | Description |
+|-----|----------|---------|-------------|
+| `required_json_keys` | no | — | Comma-separated top-level keys that must exist in JSON files |
+| `required_json_values` | no | — | Comma-separated `path=value` pairs to validate in JSON files |
+
+---
+
+## The Recovery Cascade
+
+When Guardian detects an unhealthy resource, it follows this sequence:
+
+```
+UNHEALTHY detected
+  │
+  ├─ failure_count <= max_soft_restarts?
+  │   └─ YES → Soft restart (just restart the service/process)
+  │              Wait restart_grace seconds
+  │
+  └─ NO (soft restarts exhausted)
+      └─ Restore protected_files from backup
+         Restart the service/process
+         Wait restart_grace seconds
+         Reset failure counter to 0
+```
+
+**Failure tracking** is persistent across cycles. Each section gets a failure counter file in `/var/lib/guardian/state/`. When a resource recovers (detected healthy after being unhealthy), the counter resets to 0.
+
+### Example timeline for `process` / `systemd-user` / `docker`
+
+With `max_soft_restarts=3`:
+
+| Cycle | Status | Action |
+|-------|--------|--------|
+| 1 | Unhealthy | Soft restart #1 (just restart the service) |
+| 2 | Unhealthy | Soft restart #2 |
+| 3 | Unhealthy | Soft restart #3 |
+| 4 | Unhealthy | Restore files from backup, then restart service |
+| 5 | Healthy | Reset counter, take snapshot |
+
+### How `file-integrity` differs
+
+For `file-integrity` sections, the "restart" action IS a backup restore (there's no process to restart — the recovery is restoring the file). This means the soft restart and the backup-restore fallback both do the same thing: restore from backup.
+
+In practice, use `max_soft_restarts=0` for file-integrity sections. This skips the redundant "soft restart" phase and goes straight to restore:
+
+```ini
+[my-config-files]
+type=file-integrity
+max_soft_restarts=0    # Go straight to restore — no process to "soft restart"
+```
+
+If you set `max_soft_restarts=3` on a file-integrity section, Guardian will restore from backup 3 times (one per cycle), then restore again on cycle 4. It's not harmful, but the extra attempts are redundant.
+
+If the file-integrity section has a `restart_via` pointing to a process or service section, the cascade makes more sense — the soft restart phase restores the file and then restarts the delegated service:
+
+```ini
+[my-pinned-config]
+type=file-integrity
+protected_files=/opt/myapp/config.json
+required_json_values=model.primary=gpt-4
+restart_via=my-api-server    # After restoring the file, restart this service
+max_soft_restarts=0
+```
+
+---
+
+## File Integrity and JSON Validation
+
+The `file-integrity` type goes beyond checking that files exist. It can validate JSON structure:
+
+### `required_json_keys`
+
+Checks that top-level keys exist in all `.json` files in `protected_files`:
+
+```ini
+required_json_keys=session_limit,poll_interval,agents
+```
+
+Guardian will flag files that are missing any of these keys.
+
+### `required_json_values`
+
+Pins specific values at dot-notation paths:
+
+```ini
+required_json_values=agents.defaults.model.primary=gpt-4,database.port=5432
+```
+
+Guardian traverses nested objects using the dot-separated path. If the actual value doesn't match the expected value, the file is considered corrupted and will be restored from backup.
+
+This is useful for preventing agents from changing their own model configuration or other critical settings.
+
+---
+
+## Restart Delegation (`restart_via`)
+
+Sometimes a process is a child of another service. Instead of restarting the child directly, you want to restart the parent:
+
+```ini
+[ollama]
+enabled=true
+type=process
+description=Ollama LLM Server
+process_match=ollama serve
+required_ports=11434
+restart_via=my-gateway
+```
+
+When `ollama` is unhealthy, Guardian restarts `my-gateway` instead — which will respawn ollama as a child process. The delegation follows the `restart_via` chain (can delegate multiple levels deep).
+
+---
+
+## Custom Health Commands (`health_cmd`)
+
+For checks that don't fit the built-in patterns, use `health_cmd`:
+
+```ini
+health_cmd=/opt/myapp/health-check.sh
+```
+
+The command runs in bash. **Exit code 0 = healthy**, non-zero = unhealthy. The first 120 characters of stdout/stderr are included in the log message on failure.
+
+Examples:
+- Check a database connection: `health_cmd=pg_isready -h localhost`
+- Validate a complex config: `health_cmd=python3 /opt/myapp/validate_config.py`
+- Check disk space: `health_cmd=test $(df --output=pcent /data | tail -1 | tr -d '% ') -lt 90`
+
+---
+
+## Immutable Flag Management
+
+Guardian uses Linux `chattr +i` (immutable attribute) to prevent agents from modifying critical files. When immutable is set, even root must explicitly clear it before writing.
+
+### Default behavior
+
+- Backup files are always immutable (root-owned, mode 600)
+- Restored files get immutable set after restore
+- Guardian's own files (`guardian.sh`, config, service file) are kept immutable via `check_self_integrity()`
+
+### `skip_immutable=true`
+
+Some files need to be writable by the application (e.g., config files that agents legitimately update). Set `skip_immutable=true` to prevent Guardian from setting the immutable flag after restore:
+
+```ini
+skip_immutable=true
+```
+
+The file is still backed up and can be restored — it just won't be locked after restoration.
+
+### Editing protected files
+
+To edit a file Guardian is protecting:
+
+```bash
+# 1. Clear the immutable flag
+sudo chattr -i /etc/guardian/guardian.conf
+
+# 2. Edit the file
+sudo nano /etc/guardian/guardian.conf
+
+# 3. Re-set the flag (or let Guardian do it on next cycle)
+sudo chattr +i /etc/guardian/guardian.conf
+
+# 4. Restart guardian to pick up config changes
+sudo systemctl restart guardian
+```
+
+---
+
+## Backup System
+
+Guardian maintains generational backups of all `protected_files` and `protected_service` files.
+
+### Snapshot behavior
+
+- On each healthy cycle, Guardian compares the live file to the latest backup
+- If the file has changed, it rotates existing backups and takes a new snapshot
+- Backups are stored in `/var/lib/guardian/backups/<section-name>/`
+
+### Generations
+
+With `backup_generations=5`, backups are named:
+
+```
+settings.json      ← current (most recent healthy state)
+settings.json.1    ← previous
+settings.json.2    ← two versions ago
+settings.json.3
+settings.json.4
+settings.json.5    ← oldest (deleted when a new snapshot is taken)
+```
+
+### Restore behavior
+
+When soft restarts are exhausted, Guardian restores all `protected_files` from the most recent backup (the un-numbered copy). File ownership is set to `start_user` or `systemd_user` from the section config.

--- a/guardian/guardian.conf.example
+++ b/guardian/guardian.conf.example
@@ -1,0 +1,135 @@
+# ============================================================================
+# Guardian — Desired State Configuration
+# ============================================================================
+# This file defines what "healthy" looks like. Guardian checks every cycle
+# and auto-heals anything that deviates. Agents cannot modify this file
+# (owned by root, run as system service).
+#
+# Format: INI-style sections. Each section is a protected resource.
+#
+# Organize sections by dependency criticality:
+#
+#   TIER 1 — AGENT LIFELINE (agent is dead without these)
+#   TIER 2 — API ROUTING (agent can't think without these)
+#   TIER 3 — MEMORY & CONTEXT (agent loses memory without these)
+#   TIER 4 — HELPERS (degraded but alive without these)
+#
+# See docs/HEALTH-CHECKS.md for the full reference.
+#
+# IMPORTANT: All example sections ship as enabled=false. Enable only
+# the sections you've configured for your infrastructure.
+# ============================================================================
+
+[general]
+check_interval=60
+log_file=/var/log/guardian.log
+max_log_size=10485760
+backup_dir=/var/lib/guardian/backups
+backup_generations=5
+
+# ============================================================================
+# TIER 1 — AGENT LIFELINE
+# ============================================================================
+
+# Example: systemd user service (e.g. an OpenClaw gateway)
+[my-gateway]
+enabled=false
+type=systemd-user
+description=My OpenClaw Gateway
+service=openclaw-gateway.service
+systemd_user=deploy
+required_ports=3100
+health_port=3100
+protected_files=/home/deploy/.openclaw/openclaw.json,/home/deploy/.openclaw/agents/main/agent/models.json
+protected_service=/home/deploy/.config/systemd/user/openclaw-gateway.service
+max_soft_restarts=3
+restart_grace=15
+skip_immutable=true
+
+# ============================================================================
+# TIER 2 — API ROUTING
+# ============================================================================
+
+# Example: standalone process (matched by pgrep, started via start_cmd)
+[my-api-server]
+enabled=false
+type=process
+description=API Server
+process_match=uvicorn main:app.*8080
+required_ports=8080
+health_url=http://127.0.0.1:8080/health
+start_cmd=start.sh
+start_dir=/opt/myapp
+start_user=deploy
+start_venv=/opt/myapp/venv
+protected_files=/opt/myapp/main.py,/opt/myapp/start.sh
+max_soft_restarts=3
+restart_grace=10
+
+# ============================================================================
+# TIER 3 — MEMORY & CONTEXT
+# ============================================================================
+
+# Example: docker container
+[my-database]
+enabled=false
+type=docker
+description=Vector Database
+container_name=qdrant-prod
+required_ports=6333
+health_url=http://127.0.0.1:6333/healthz
+max_soft_restarts=3
+restart_grace=15
+
+# Example: file integrity with JSON validation
+[my-settings]
+enabled=false
+type=file-integrity
+description=Application Settings (must be valid JSON)
+protected_files=/opt/myapp/data/settings.json
+required_json_keys=session_limit,poll_interval,agents
+# Pin specific JSON values (dot-notation path=expected_value)
+# required_json_values=agents.defaults.model.primary=gpt-4
+max_soft_restarts=1
+restart_grace=5
+
+# ============================================================================
+# TIER 4 — HELPERS
+# ============================================================================
+
+# Example: process with restart delegation
+# When ollama dies, restart the gateway (which will respawn ollama)
+[ollama]
+enabled=false
+type=process
+description=Ollama Local LLM Server
+process_match=ollama serve
+required_ports=11434
+health_url=http://127.0.0.1:11434/api/tags
+max_soft_restarts=2
+restart_grace=15
+restart_via=my-gateway
+
+# Example: file integrity for scripts (no JSON validation)
+[my-scripts]
+enabled=false
+type=file-integrity
+description=Operational Scripts
+protected_files=/opt/myapp/backup.sh,/opt/myapp/monitor.py
+max_soft_restarts=0
+restart_grace=10
+skip_immutable=true
+
+# Example: custom health command
+# health_cmd runs in bash; non-zero exit = unhealthy
+[my-custom-check]
+enabled=false
+type=process
+description=Service with custom health check
+process_match=myservice
+health_cmd=/opt/myapp/health-check.sh
+start_cmd=myservice.sh
+start_dir=/opt/myapp
+start_user=deploy
+max_soft_restarts=3
+restart_grace=10

--- a/guardian/guardian.service
+++ b/guardian/guardian.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=Guardian — Self-Healing Process Watchdog
+Documentation=file:///etc/guardian/guardian.conf
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/guardian.sh
+Restart=always
+RestartSec=10
+
+# Guardian runs as root; unprivileged users cannot kill or modify it
+ProtectSystem=strict
+# IMPORTANT: ProtectSystem=strict blocks ALL writes outside these paths.
+# You MUST add every directory Guardian needs to read, backup, or restore.
+# Without this, Guardian will silently fail to protect files in unlisted dirs.
+# Example: ReadWritePaths=/var/log /var/lib/guardian /tmp /home/deploy /opt/myapp
+ReadWritePaths=/var/log /var/lib/guardian /tmp
+PrivateTmp=true
+
+# Environment
+Environment=GUARDIAN_CONF=/etc/guardian/guardian.conf
+
+[Install]
+WantedBy=multi-user.target

--- a/guardian/guardian.sh
+++ b/guardian/guardian.sh
@@ -1,0 +1,726 @@
+#!/bin/bash
+# ============================================================================
+# Guardian — Self-Healing Process Watchdog
+# ============================================================================
+# Runs as a root-level systemd service. Agents cannot kill, modify, or
+# interfere with this process. It monitors all critical infrastructure
+# and auto-heals from known-good backups when things break.
+#
+# Design principles:
+#   1. Agents CAN'T touch guardian (root-owned, system service)
+#   2. Guardian KNOWS what healthy looks like (config + backups)
+#   3. Guardian HEALS automatically (restart -> restore -> restart)
+#   4. Guardian LOGS everything (so you know what broke and when)
+#
+# Supported types:
+#   process        — match by pgrep, restart via start_cmd
+#   systemd-user   — systemctl --user service
+#   docker         — docker container, restart via docker restart
+#   file-integrity — validate file exists and is valid (JSON, etc.)
+# ============================================================================
+
+set -uo pipefail
+
+# ── Config file search order ──────────────────────────────────────────────
+# 1. $GUARDIAN_CONF env var (explicit override)
+# 2. ./guardian.conf (local development / testing)
+# 3. /etc/guardian/guardian.conf (installed location)
+
+if [[ -n "${GUARDIAN_CONF:-}" ]]; then
+    CONF_FILE="$GUARDIAN_CONF"
+elif [[ -f "./guardian.conf" ]]; then
+    CONF_FILE="./guardian.conf"
+else
+    CONF_FILE="/etc/guardian/guardian.conf"
+fi
+
+BACKUP_DIR="/var/lib/guardian/backups"
+STATE_DIR="/var/lib/guardian/state"
+LOG_FILE="/var/log/guardian.log"
+MAX_LOG_SIZE=10485760  # 10MB
+BACKUP_GENERATIONS=5
+
+# ── Logging ────────────────────────────────────────────────────────────────
+
+log() {
+    local level="$1"; shift
+    local msg="$*"
+    local ts
+    ts=$(date '+%Y-%m-%d %H:%M:%S')
+    echo "[$ts] [$level] $msg" >> "$LOG_FILE"
+    echo "[$level] $msg"
+}
+
+rotate_log() {
+    if [[ -f "$LOG_FILE" ]] && (( $(stat -c%s "$LOG_FILE" 2>/dev/null || echo 0) > MAX_LOG_SIZE )); then
+        mv "$LOG_FILE" "${LOG_FILE}.1"
+        log INFO "Log rotated"
+    fi
+}
+
+# ── Config Parser ──────────────────────────────────────────────────────────
+
+declare -A CONFIG
+SECTIONS=()
+
+parse_config() {
+    local section=""
+    while IFS= read -r line; do
+        line="${line%%#*}"
+        line="${line## }"
+        line="${line%% }"
+        [[ -z "$line" ]] && continue
+
+        if [[ "$line" =~ ^\[([a-zA-Z0-9_-]+)\]$ ]]; then
+            section="${BASH_REMATCH[1]}"
+            SECTIONS+=("$section")
+            continue
+        fi
+
+        if [[ "$line" =~ ^([a-zA-Z_][a-zA-Z0-9_]*)=(.*)$ ]]; then
+            CONFIG["${section}.${BASH_REMATCH[1]}"]="${BASH_REMATCH[2]}"
+        fi
+    done < "$CONF_FILE"
+}
+
+cfg() {
+    local key="${1}.${2}"
+    local default="${3:-}"
+    echo "${CONFIG[$key]:-$default}"
+}
+
+# ── Immutable Flag Helpers ─────────────────────────────────────────────────
+# All protected files and backups are chattr +i (immutable). Guardian runs
+# as root and must temporarily clear the flag before writing, then re-set it.
+
+clear_immutable() {
+    local file="$1"
+    [[ -f "$file" ]] && chattr -i "$file" 2>/dev/null || true
+}
+
+set_immutable() {
+    local file="$1"
+    [[ -f "$file" ]] && chattr +i "$file" 2>/dev/null || true
+}
+
+secure_backup() {
+    # Ensure backup file is root-owned, locked down, and immutable
+    local file="$1"
+    chown root:root "$file" 2>/dev/null || true
+    chmod 600 "$file" 2>/dev/null || true
+    set_immutable "$file"
+}
+
+# ── Self-Integrity Check ──────────────────────────────────────────────────
+# Verify guardian's own files haven't been tampered with. If immutable
+# flags have been removed (e.g. agent used sudo chattr -i), re-set them.
+# Paths are derived from the install location and config file path.
+
+check_self_integrity() {
+    local conf_dir
+    conf_dir=$(dirname "$CONF_FILE")
+    local files=( /usr/local/bin/guardian.sh "$CONF_FILE" /etc/systemd/system/guardian.service )
+    for f in "${files[@]}"; do
+        if [[ -f "$f" ]]; then
+            local attrs
+            attrs=$(lsattr "$f" 2>/dev/null || echo "")
+            if [[ -n "$attrs" ]] && [[ ! "$attrs" =~ ^....i ]]; then
+                chattr +i "$f" 2>/dev/null || true
+                log WARN "[self-integrity] Immutable flag was missing on $f — RESTORED"
+            fi
+        fi
+    done
+}
+
+# ── Backup Management ──────────────────────────────────────────────────────
+
+rotate_backups() {
+    # Rotate backup generations: current -> .1 -> .2 -> ... -> .$BACKUP_GENERATIONS
+    local snap_dir="$1"
+    local bname="$2"
+    local max_gen="$BACKUP_GENERATIONS"
+
+    # Delete oldest generation
+    local oldest="$snap_dir/${bname}.${max_gen}"
+    if [[ -f "$oldest" ]]; then
+        clear_immutable "$oldest"
+        rm -f "$oldest"
+    fi
+
+    # Shift generations up: .4 -> .5, .3 -> .4, etc.
+    local i=$((max_gen - 1))
+    while (( i >= 1 )); do
+        local src="$snap_dir/${bname}.${i}"
+        local dst="$snap_dir/${bname}.$((i + 1))"
+        if [[ -f "$src" ]]; then
+            clear_immutable "$src"
+            mv "$src" "$dst"
+            secure_backup "$dst"
+        fi
+        i=$((i - 1))
+    done
+
+    # Current backup -> .1
+    local current="$snap_dir/$bname"
+    if [[ -f "$current" ]]; then
+        clear_immutable "$current"
+        cp -p "$current" "$snap_dir/${bname}.1"
+        secure_backup "$snap_dir/${bname}.1"
+    fi
+}
+
+take_snapshot() {
+    local section="$1"
+    local files_csv
+    files_csv=$(cfg "$section" protected_files "")
+    [[ -z "$files_csv" ]] && return 0
+
+    local snap_dir="$BACKUP_DIR/$section"
+    mkdir -p "$snap_dir"
+
+    IFS=',' read -ra files <<< "$files_csv"
+    for filepath in "${files[@]}"; do
+        filepath="${filepath## }"
+        filepath="${filepath%% }"
+        [[ ! -f "$filepath" ]] && continue
+
+        local bname
+        bname=$(basename "$filepath")
+        local backup_path="$snap_dir/$bname"
+
+        if [[ ! -f "$backup_path" ]] || ! diff -q "$filepath" "$backup_path" &>/dev/null; then
+            rotate_backups "$snap_dir" "$bname"
+            clear_immutable "$backup_path"
+            cp -p "$filepath" "$backup_path"
+            secure_backup "$backup_path"
+            log INFO "[$section] Snapshot updated: $bname"
+        fi
+    done
+
+    # Snapshot systemd service file if defined
+    local svc_file
+    svc_file=$(cfg "$section" protected_service "")
+    if [[ -n "$svc_file" && -f "$svc_file" ]]; then
+        local svc_bname
+        svc_bname=$(basename "$svc_file")
+        local svc_backup="$snap_dir/$svc_bname"
+        if [[ ! -f "$svc_backup" ]] || ! diff -q "$svc_file" "$svc_backup" &>/dev/null; then
+            rotate_backups "$snap_dir" "$svc_bname"
+            clear_immutable "$svc_backup"
+            cp -p "$svc_file" "$svc_backup"
+            secure_backup "$svc_backup"
+            log INFO "[$section] Service file snapshot: $svc_bname"
+        fi
+    fi
+}
+
+restore_from_backup() {
+    local section="$1"
+    local files_csv
+    files_csv=$(cfg "$section" protected_files "")
+    [[ -z "$files_csv" ]] && return 1
+
+    local snap_dir="$BACKUP_DIR/$section"
+    [[ ! -d "$snap_dir" ]] && { log ERROR "[$section] No backup directory!"; return 1; }
+
+    local svc_user
+    svc_user=$(cfg "$section" start_user "$(cfg "$section" systemd_user "")")
+
+    IFS=',' read -ra files <<< "$files_csv"
+    local restored=0
+    for filepath in "${files[@]}"; do
+        filepath="${filepath## }"
+        filepath="${filepath%% }"
+        local bname
+        bname=$(basename "$filepath")
+        local backup_path="$snap_dir/$bname"
+
+        if [[ -f "$backup_path" ]]; then
+            clear_immutable "$filepath"
+            if cp -p "$backup_path" "$filepath" 2>/dev/null; then
+                if [[ -n "$svc_user" ]]; then
+                    chown "$svc_user:$svc_user" "$filepath" 2>/dev/null || true
+                fi
+                local skip_imm
+                skip_imm=$(cfg "$section" skip_immutable "")
+                if [[ "$skip_imm" != "true" ]]; then
+                    set_immutable "$filepath"
+                fi
+                restored=1
+                log WARN "[$section] RESTORED: $bname"
+            else
+                log ERROR "[$section] FAILED to restore $bname (write error)"
+            fi
+        fi
+    done
+
+    # Restore service file
+    local svc_file
+    svc_file=$(cfg "$section" protected_service "")
+    if [[ -n "$svc_file" ]]; then
+        local svc_bname
+        svc_bname=$(basename "$svc_file")
+        local svc_backup="$snap_dir/$svc_bname"
+        if [[ -f "$svc_backup" ]]; then
+            clear_immutable "$svc_file"
+            if cp -p "$svc_backup" "$svc_file" 2>/dev/null; then
+                set_immutable "$svc_file"
+                log WARN "[$section] RESTORED service file: $svc_bname (immutable flag re-set)"
+            else
+                log ERROR "[$section] FAILED to restore service file: $svc_bname (write error)"
+            fi
+        fi
+    fi
+
+    (( restored )) && return 0 || return 1
+}
+
+# ── Health Checks ──────────────────────────────────────────────────────────
+
+check_ports() {
+    local ports_csv="$1"
+    [[ -z "$ports_csv" ]] && return 0
+    IFS=',' read -ra ports <<< "$ports_csv"
+    for port in "${ports[@]}"; do
+        port="${port## }"
+        port="${port%% }"
+        [[ -z "$port" ]] && continue
+        if ! ss -tlnp | grep -q ":${port} " 2>/dev/null; then
+            return 1
+        fi
+    done
+    return 0
+}
+
+check_health_url() {
+    local url="$1"
+    [[ -z "$url" ]] && return 0
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null || echo "000")
+    [[ "$code" =~ ^2[0-9][0-9]$ ]]
+}
+
+check_health_port() {
+    local port="$1"
+    [[ -z "$port" ]] && return 0
+    ss -tlnp | grep -q ":${port} " 2>/dev/null
+}
+
+check_systemd_service() {
+    local service="$1"
+    local user="$2"
+    sudo -u "$user" XDG_RUNTIME_DIR="/run/user/$(id -u "$user")" systemctl --user is-active "$service" &>/dev/null
+}
+
+check_process() {
+    local match="$1"
+    [[ -z "$match" ]] && return 0
+    pgrep -f "$match" &>/dev/null
+}
+
+check_docker() {
+    local container="$1"
+    [[ -z "$container" ]] && return 0
+    local status
+    status=$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null || echo "false")
+    [[ "$status" == "true" ]]
+}
+
+check_file_integrity() {
+    local section="$1"
+    local files_csv
+    files_csv=$(cfg "$section" protected_files "")
+    [[ -z "$files_csv" ]] && return 0
+
+    IFS=',' read -ra files <<< "$files_csv"
+    for filepath in "${files[@]}"; do
+        filepath="${filepath## }"
+        filepath="${filepath%% }"
+        # File must exist
+        [[ ! -f "$filepath" ]] && return 1
+        # File must not be empty
+        [[ ! -s "$filepath" ]] && return 1
+    done
+
+    # If JSON keys are required, validate them
+    local json_keys
+    json_keys=$(cfg "$section" required_json_keys "")
+    if [[ -n "$json_keys" ]]; then
+        for filepath in "${files[@]}"; do
+            filepath="${filepath## }"
+            filepath="${filepath%% }"
+            [[ "$filepath" != *.json ]] && continue
+            # Must be valid JSON
+            if ! python3 -c "import json; json.load(open('$filepath'))" 2>/dev/null; then
+                return 1
+            fi
+            # Must have required keys
+            IFS=',' read -ra keys <<< "$json_keys"
+            for key in "${keys[@]}"; do
+                key="${key## }"
+                key="${key%% }"
+                if ! python3 -c "import json; d=json.load(open('$filepath')); assert '$key' in d" 2>/dev/null; then
+                    return 1
+                fi
+            done
+        done
+    fi
+
+    # If JSON values are pinned, validate them
+    local json_values
+    json_values=$(cfg "$section" required_json_values "")
+    if [[ -n "$json_values" ]]; then
+        for filepath in "${files[@]}"; do
+            filepath="${filepath## }"
+            filepath="${filepath%% }"
+            [[ "$filepath" != *.json ]] && continue
+            IFS="," read -ra pairs <<< "$json_values"
+            for pair in "${pairs[@]}"; do
+                pair="${pair## }"
+                pair="${pair%% }"
+                local jpath="${pair%%=*}"
+                local expected="${pair#*=}"
+                local actual
+                actual=$(python3 -c "
+import json, functools
+d = json.load(open('$filepath'))
+keys = '$jpath'.split('.')
+val = functools.reduce(lambda o, k: o[k], keys, d)
+print(val if isinstance(val, str) else json.dumps(val))
+" 2>/dev/null || echo "__MISSING__")
+                if [[ "$actual" != "$expected" ]]; then
+                    log WARN "[$section] JSON value mismatch in $(basename $filepath): $jpath expected='$expected' got='$actual'"
+                    return 1
+                fi
+            done
+        done
+    fi
+    return 0
+}
+
+# ── Recovery Actions ───────────────────────────────────────────────────────
+
+restart_process() {
+    local section="$1"
+    local start_cmd
+    start_cmd=$(cfg "$section" start_cmd "")
+    local start_dir
+    start_dir=$(cfg "$section" start_dir "")
+    local start_user
+    start_user=$(cfg "$section" start_user "$(whoami)")
+    local start_venv
+    start_venv=$(cfg "$section" start_venv "")
+
+    if [[ -z "$start_cmd" ]]; then
+        log ERROR "[$section] No start_cmd defined"
+        return 1
+    fi
+
+    # Kill existing
+    local match
+    match=$(cfg "$section" process_match "")
+    if [[ -n "$match" ]]; then
+        pkill -f "$match" 2>/dev/null || true
+        sleep 2
+        pkill -9 -f "$match" 2>/dev/null || true
+        sleep 1
+    fi
+
+    # Free ports
+    local ports_csv
+    ports_csv=$(cfg "$section" required_ports "")
+    if [[ -n "$ports_csv" ]]; then
+        IFS=',' read -ra ports <<< "$ports_csv"
+        for port in "${ports[@]}"; do
+            port="${port## }"
+            [[ -n "$port" ]] && fuser -k "${port}/tcp" 2>/dev/null || true
+        done
+        sleep 1
+    fi
+
+    # Build the start command
+    local run_cmd=""
+    if [[ -n "$start_venv" ]]; then
+        run_cmd="source '$start_venv/bin/activate' && "
+    fi
+    if [[ -n "$start_dir" ]]; then
+        run_cmd="${run_cmd}cd '$start_dir' && "
+    fi
+
+    # Determine how to run: .py files get python, .sh files get bash
+    if [[ "$start_cmd" == *.py ]]; then
+        run_cmd="${run_cmd}nohup python3 '$start_cmd' > /tmp/guardian-${section}.log 2>&1 &"
+    else
+        run_cmd="${run_cmd}nohup bash '$start_cmd' > /tmp/guardian-${section}.log 2>&1 &"
+    fi
+
+    log INFO "[$section] Starting: $start_cmd (user=$start_user)"
+    sudo -u "$start_user" bash -c "$run_cmd"
+    return 0
+}
+
+restart_systemd_service() {
+    local section="$1"
+    local service
+    service=$(cfg "$section" service "")
+    local user
+    user=$(cfg "$section" systemd_user "")
+
+    if [[ -z "$service" ]]; then
+        log ERROR "[$section] No service defined"
+        return 1
+    fi
+
+    if [[ -z "$user" ]]; then
+        log ERROR "[$section] No systemd_user defined"
+        return 1
+    fi
+
+    local uid
+    uid=$(id -u "$user")
+
+    log INFO "[$section] Restarting systemd: $service"
+    sudo -u "$user" XDG_RUNTIME_DIR="/run/user/$uid" systemctl --user daemon-reload 2>/dev/null || true
+    sudo -u "$user" XDG_RUNTIME_DIR="/run/user/$uid" systemctl --user restart "$service" 2>/dev/null
+}
+
+restart_docker() {
+    local section="$1"
+    local container
+    container=$(cfg "$section" container_name "")
+
+    if [[ -z "$container" ]]; then
+        log ERROR "[$section] No container_name defined"
+        return 1
+    fi
+
+    log INFO "[$section] Restarting docker container: $container"
+    docker restart "$container" 2>/dev/null
+}
+
+do_restart() {
+    local section="$1"
+    local type="$2"
+
+    # Check if this section delegates restart to another section
+    local restart_via
+    restart_via=$(cfg "$section" restart_via "")
+    if [[ -n "$restart_via" ]]; then
+        local via_type
+        via_type=$(cfg "$restart_via" type "")
+        log INFO "[$section] Delegating restart to [$restart_via]"
+        do_restart "$restart_via" "$via_type"
+        return $?
+    fi
+
+    case "$type" in
+        process)        restart_process "$section" ;;
+        systemd-user)   restart_systemd_service "$section" ;;
+        docker)         restart_docker "$section" ;;
+        file-integrity) restore_from_backup "$section" ;;
+        *)              log ERROR "[$section] Unknown type: $type"; return 1 ;;
+    esac
+}
+
+# ── Main Check for a Single Section ───────────────────────────────────────
+
+check_section() {
+    local section="$1"
+    local enabled
+    enabled=$(cfg "$section" enabled "false")
+    [[ "$enabled" != "true" ]] && return 0
+
+    local type
+    type=$(cfg "$section" type "")
+    local desc
+    desc=$(cfg "$section" description "$section")
+    local max_soft
+    max_soft=$(cfg "$section" max_soft_restarts "3")
+    local grace
+    grace=$(cfg "$section" restart_grace "10")
+
+    # Track failure count
+    local fail_file="$STATE_DIR/${section}.failures"
+    local fail_count=0
+    [[ -f "$fail_file" ]] && fail_count=$(cat "$fail_file" 2>/dev/null || echo 0)
+
+    # ── Determine health ──
+    local healthy=true
+    local reason=""
+
+    case "$type" in
+        process)
+            local match
+            match=$(cfg "$section" process_match "")
+            if [[ -n "$match" ]] && ! check_process "$match"; then
+                healthy=false
+                reason="process not found (match: $match)"
+            fi
+            ;;
+        systemd-user)
+            local service
+            service=$(cfg "$section" service "")
+            local user
+            user=$(cfg "$section" systemd_user "")
+            if [[ -n "$service" && -n "$user" ]] && ! check_systemd_service "$service" "$user"; then
+                healthy=false
+                reason="systemd service $service not active"
+            fi
+            ;;
+        docker)
+            local container
+            container=$(cfg "$section" container_name "")
+            if [[ -n "$container" ]] && ! check_docker "$container"; then
+                healthy=false
+                reason="docker container $container not running"
+            fi
+            ;;
+        file-integrity)
+            if ! check_file_integrity "$section"; then
+                healthy=false
+                reason="file integrity check failed"
+            fi
+            ;;
+    esac
+
+    # Check ports (all types)
+    if $healthy; then
+        local ports
+        ports=$(cfg "$section" required_ports "")
+        if [[ -n "$ports" ]] && ! check_ports "$ports"; then
+            healthy=false
+            reason="required ports not listening ($ports)"
+        fi
+    fi
+
+    # Check health URL (all types)
+    if $healthy; then
+        local health_url
+        health_url=$(cfg "$section" health_url "")
+        if [[ -n "$health_url" ]] && ! check_health_url "$health_url"; then
+            healthy=false
+            reason="health check failed ($health_url)"
+        fi
+    fi
+
+    # Check health port (all types)
+    if $healthy; then
+        local health_port
+        health_port=$(cfg "$section" health_port "")
+        if [[ -n "$health_port" ]] && ! check_health_port "$health_port"; then
+            healthy=false
+            reason="health port not listening ($health_port)"
+        fi
+    fi
+
+    # Check health command (all types) — runs a custom script, non-zero = unhealthy
+    if $healthy; then
+        local health_cmd
+        health_cmd=$(cfg "$section" health_cmd "")
+        if [[ -n "$health_cmd" ]]; then
+            local cmd_output
+            cmd_output=$(bash -c "$health_cmd" 2>&1)
+            if [[ $? -ne 0 ]]; then
+                healthy=false
+                reason="health_cmd failed: ${cmd_output:0:120}"
+            fi
+        fi
+    fi
+
+    # ── Healthy ──
+    if $healthy; then
+        if (( fail_count > 0 )); then
+            log INFO "[$section] $desc RECOVERED. Resetting failure counter."
+            echo 0 > "$fail_file"
+        fi
+        take_snapshot "$section"
+        return 0
+    fi
+
+    # ── UNHEALTHY — recover ──
+    fail_count=$((fail_count + 1))
+    echo "$fail_count" > "$fail_file"
+    log WARN "[$section] $desc UNHEALTHY: $reason (failure #$fail_count)"
+
+    if (( fail_count <= max_soft )); then
+        log INFO "[$section] Soft restart ($fail_count/$max_soft)"
+        do_restart "$section" "$type"
+        sleep "$grace"
+    else
+        log WARN "[$section] Soft restarts exhausted. RESTORING FROM BACKUP."
+        if restore_from_backup "$section"; then
+            log INFO "[$section] Backup restored. Restarting..."
+            do_restart "$section" "$type"
+            sleep "$grace"
+            echo 0 > "$fail_file"
+        else
+            log ERROR "[$section] NO BACKUP AVAILABLE. Manual intervention required."
+        fi
+    fi
+}
+
+# ── Initial Snapshot ───────────────────────────────────────────────────────
+
+initial_snapshot() {
+    log INFO "Taking initial snapshots of all protected resources..."
+    for section in "${SECTIONS[@]}"; do
+        [[ "$section" == "general" ]] && continue
+        local enabled
+        enabled=$(cfg "$section" enabled "false")
+        [[ "$enabled" != "true" ]] && continue
+        take_snapshot "$section"
+    done
+    log INFO "Initial snapshots complete."
+}
+
+# ── Main ───────────────────────────────────────────────────────────────────
+
+main() {
+    mkdir -p "$BACKUP_DIR" "$STATE_DIR" "$(dirname "$LOG_FILE")"
+
+    if [[ ! -f "$CONF_FILE" ]]; then
+        echo "FATAL: Config not found: $CONF_FILE" >&2
+        echo "Searched: \$GUARDIAN_CONF, ./guardian.conf, /etc/guardian/guardian.conf" >&2
+        exit 1
+    fi
+    parse_config
+
+    LOG_FILE=$(cfg general log_file "$LOG_FILE")
+    MAX_LOG_SIZE=$(cfg general max_log_size "$MAX_LOG_SIZE")
+    BACKUP_DIR=$(cfg general backup_dir "$BACKUP_DIR")
+    BACKUP_GENERATIONS=$(cfg general backup_generations "$BACKUP_GENERATIONS")
+    mkdir -p "$BACKUP_DIR" "$STATE_DIR"
+
+    local interval
+    interval=$(cfg general check_interval "60")
+
+    # Count monitored sections
+    local count=0
+    for section in "${SECTIONS[@]}"; do
+        [[ "$section" == "general" ]] && continue
+        [[ "$(cfg "$section" enabled "false")" == "true" ]] && count=$((count + 1))
+    done
+
+    log INFO "=========================================="
+    log INFO "Guardian starting"
+    log INFO "  Config: $CONF_FILE"
+    log INFO "  Monitoring: $count resources"
+    log INFO "  Interval: ${interval}s"
+    log INFO "  Backups: $BACKUP_DIR (${BACKUP_GENERATIONS} generations)"
+    log INFO "=========================================="
+
+    initial_snapshot
+
+    while true; do
+        rotate_log
+        check_self_integrity
+        for section in "${SECTIONS[@]}"; do
+            [[ "$section" == "general" ]] && continue
+            check_section "$section"
+        done
+        sleep "$interval"
+    done
+}
+
+trap 'log INFO "Guardian shutting down (signal received)"; exit 0' SIGTERM SIGINT
+main "$@"

--- a/guardian/install.sh
+++ b/guardian/install.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# ============================================================================
+# Guardian — Installer
+# ============================================================================
+# Installs guardian.sh, config, and systemd service.
+# Must be run as root (or with sudo).
+#
+# Usage:
+#   sudo ./install.sh              # Install and start
+#   sudo ./install.sh --dry-run    # Show what would be done
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+INSTALL_BIN="/usr/local/bin/guardian.sh"
+INSTALL_CONF_DIR="/etc/guardian"
+INSTALL_CONF="$INSTALL_CONF_DIR/guardian.conf"
+INSTALL_SERVICE="/etc/systemd/system/guardian.service"
+STATE_DIR="/var/lib/guardian"
+LOG_FILE="/var/log/guardian.log"
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+run() {
+    if $DRY_RUN; then
+        echo "[dry-run] $*"
+    else
+        "$@"
+    fi
+}
+
+info() { echo "[install] $*"; }
+warn() { echo "[install] WARNING: $*"; }
+
+# ── Preflight ──────────────────────────────────────────────────────────────
+
+if [[ $EUID -ne 0 ]] && ! $DRY_RUN; then
+    echo "ERROR: Must be run as root (use sudo)" >&2
+    exit 1
+fi
+
+if [[ ! -f "$SCRIPT_DIR/guardian.sh" ]]; then
+    echo "ERROR: guardian.sh not found in $SCRIPT_DIR" >&2
+    exit 1
+fi
+
+# ── Install ────────────────────────────────────────────────────────────────
+
+info "Installing Guardian..."
+
+# 1. Create directories
+info "Creating directories..."
+run mkdir -p "$INSTALL_CONF_DIR"
+run mkdir -p "$STATE_DIR/backups"
+run mkdir -p "$STATE_DIR/state"
+
+# 2. Copy guardian.sh
+info "Installing $INSTALL_BIN"
+if [[ -f "$INSTALL_BIN" ]]; then
+    run chattr -i "$INSTALL_BIN" 2>/dev/null || true
+fi
+run cp "$SCRIPT_DIR/guardian.sh" "$INSTALL_BIN"
+run chmod 755 "$INSTALL_BIN"
+run chown root:root "$INSTALL_BIN"
+run chattr +i "$INSTALL_BIN"
+
+# 3. Copy config (don't overwrite existing)
+if [[ -f "$INSTALL_CONF" ]] && ! $DRY_RUN; then
+    info "Config already exists at $INSTALL_CONF — skipping (edit manually)"
+else
+    local_conf="$SCRIPT_DIR/guardian.conf"
+    if [[ ! -f "$local_conf" ]]; then
+        local_conf="$SCRIPT_DIR/guardian.conf.example"
+    fi
+    if [[ -f "$local_conf" ]]; then
+        info "Installing config: $INSTALL_CONF"
+        if [[ -f "$INSTALL_CONF" ]]; then
+            run chattr -i "$INSTALL_CONF" 2>/dev/null || true
+        fi
+        run cp "$local_conf" "$INSTALL_CONF"
+        run chmod 644 "$INSTALL_CONF"
+        run chown root:root "$INSTALL_CONF"
+        run chattr +i "$INSTALL_CONF"
+    else
+        warn "No guardian.conf or guardian.conf.example found — create $INSTALL_CONF manually"
+    fi
+fi
+
+# 4. Install systemd service
+info "Installing systemd service: $INSTALL_SERVICE"
+if [[ -f "$INSTALL_SERVICE" ]]; then
+    run chattr -i "$INSTALL_SERVICE" 2>/dev/null || true
+fi
+run cp "$SCRIPT_DIR/guardian.service" "$INSTALL_SERVICE"
+run chmod 644 "$INSTALL_SERVICE"
+run chown root:root "$INSTALL_SERVICE"
+run chattr +i "$INSTALL_SERVICE"
+
+# 5. Create log file
+if [[ ! -f "$LOG_FILE" ]] || $DRY_RUN; then
+    info "Creating log file: $LOG_FILE"
+    run touch "$LOG_FILE"
+fi
+
+# 6. Enable and start
+info "Enabling and starting guardian.service..."
+run systemctl daemon-reload
+run systemctl enable guardian.service
+run systemctl start guardian.service
+
+# ── Done ───────────────────────────────────────────────────────────────────
+
+echo ""
+if $DRY_RUN; then
+    info "Dry run complete. No changes were made."
+else
+    info "Guardian installed successfully!"
+    info ""
+    info "  Config:  $INSTALL_CONF"
+    info "  Script:  $INSTALL_BIN"
+    info "  Service: $INSTALL_SERVICE"
+    info "  Logs:    $LOG_FILE"
+    info ""
+    info "IMPORTANT: Edit $INSTALL_CONF to define your monitored resources."
+    info "           Then update ReadWritePaths in $INSTALL_SERVICE"
+    info "           to include your application directories."
+    info ""
+    info "After editing:"
+    info "  sudo chattr -i $INSTALL_CONF   # unlock config"
+    info "  sudo nano $INSTALL_CONF        # edit"
+    info "  sudo chattr +i $INSTALL_CONF   # re-lock"
+    info "  sudo systemctl restart guardian"
+fi

--- a/guardian/uninstall.sh
+++ b/guardian/uninstall.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# ============================================================================
+# Guardian — Uninstaller
+# ============================================================================
+# Stops service, removes systemd unit, clears immutable flags, removes files.
+# Must be run as root (or with sudo).
+#
+# Usage:
+#   sudo ./uninstall.sh
+# ============================================================================
+
+set -euo pipefail
+
+INSTALL_BIN="/usr/local/bin/guardian.sh"
+INSTALL_CONF_DIR="/etc/guardian"
+INSTALL_CONF="$INSTALL_CONF_DIR/guardian.conf"
+INSTALL_SERVICE="/etc/systemd/system/guardian.service"
+STATE_DIR="/var/lib/guardian"
+LOG_FILE="/var/log/guardian.log"
+
+info() { echo "[uninstall] $*"; }
+
+if [[ $EUID -ne 0 ]]; then
+    echo "ERROR: Must be run as root (use sudo)" >&2
+    exit 1
+fi
+
+# ── Stop and disable service ──────────────────────────────────────────────
+
+info "Stopping guardian.service..."
+systemctl stop guardian.service 2>/dev/null || true
+systemctl disable guardian.service 2>/dev/null || true
+
+# ── Clear immutable flags and remove files ────────────────────────────────
+
+info "Removing installed files..."
+
+for f in "$INSTALL_BIN" "$INSTALL_CONF" "$INSTALL_SERVICE"; do
+    if [[ -f "$f" ]]; then
+        chattr -i "$f" 2>/dev/null || true
+        rm -f "$f"
+        info "  Removed: $f"
+    fi
+done
+
+# Remove config directory if empty
+if [[ -d "$INSTALL_CONF_DIR" ]]; then
+    rmdir "$INSTALL_CONF_DIR" 2>/dev/null && info "  Removed: $INSTALL_CONF_DIR" || \
+        info "  $INSTALL_CONF_DIR not empty — skipping"
+fi
+
+# ── Reload systemd ────────────────────────────────────────────────────────
+
+systemctl daemon-reload
+
+# ── State and logs (optional) ─────────────────────────────────────────────
+
+echo ""
+info "Guardian service removed."
+info ""
+info "The following are NOT removed automatically (they contain your backups/logs):"
+info "  State dir: $STATE_DIR"
+info "  Log file:  $LOG_FILE"
+info ""
+info "To remove them manually:"
+info "  sudo chattr -Ri $STATE_DIR && sudo rm -rf $STATE_DIR"
+info "  sudo rm -f $LOG_FILE $LOG_FILE.1"


### PR DESCRIPTION
Root-level systemd service that monitors processes, systemd services, Docker containers, and file integrity. Auto-heals via a recovery cascade (soft restart → backup restore → restart) with generational backups protected by immutable flags. Config-driven INI format with tiered health checks (ports, HTTP, custom commands, JSON validation).