### PR TITLE
Fix OpenClaw workspace permission denied on fresh install

### DIFF
--- a/dream-server/install.sh
+++ b/dream-server/install.sh
@@ -1229,9 +1229,11 @@ AUTH_EOF
 }
 MODELS_EOF
         log "Generated OpenClaw home config (model: $OPENCLAW_MODEL, gateway token set)"
-        # Copy workspace personality files (SOUL.md etc.)
+        # Create workspace directory (must exist before Docker Compose,
+        # otherwise Docker auto-creates it as root and the container can't write to it)
+        mkdir -p "$INSTALL_DIR/config/openclaw/workspace"
+        # Copy workspace personality files (SOUL.md etc.) if the repo ships any
         if [[ -d "$SCRIPT_DIR/config/openclaw/workspace" ]]; then
-            mkdir -p "$INSTALL_DIR/config/openclaw/workspace"
             cp -r "$SCRIPT_DIR/config/openclaw/workspace"/* "$INSTALL_DIR/config/openclaw/workspace/" 2>/dev/null || true
             log "Installed OpenClaw workspace files (agent personality)"
         fi


### PR DESCRIPTION
## Summary
- Create workspace directory unconditionally before Docker Compose runs
- Prevents Docker from auto-creating it as root:root, which causes `EACCES: Permission denied` when OpenClaw tries to write `AGENTS.md`
- Affects every fresh install where the repo doesn't ship workspace files

## Root Cause
The `mkdir -p` was inside a conditional (`if [[ -d .../workspace ]]`) that only triggered when the repo contained workspace files to copy. The repo doesn't ship any by default, so the directory was never created by the installer — Docker auto-created it as root, and the container (running as uid 1000) couldn't write to it.

## Test plan
- [ ] Fresh install on clean machine — OpenClaw starts without permission errors
- [ ] Install with workspace files present in repo — files are still copied correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)