### PR TITLE
Add YouTube demo to README and bump version to v2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ![Dream Server Dashboard](docs/images/dashboard.png)
 
+[![Watch the demo](https://img.shields.io/badge/Demo-Watch%20on%20YouTube-red?logo=youtube)](https://youtu.be/nO8xFNHX-HA)
+
 </div>
 
 ---

--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,28 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-03-04
+
+### Added
+- AMD Strix Halo support with ROCm 7.2 and unified memory tiers (SH_LARGE, SH_COMPACT)
+- NVIDIA ultra tier (NV_ULTRA) for 90GB+ multi-GPU configurations
+- Qwen3 Coder Next (80B MoE) model support for high-memory systems
+- Product landing page README with screenshots and YouTube demo
+- Dashboard screenshots, installer GIF, and download sequence images
+- Architecture Decision Record for Docker image tag pinning
+- 55 pytest unit tests for dashboard-api (GPU, helpers, config, agent monitor, security)
+- CI workflow for dashboard-api tests
+
+### Changed
+- README rewritten as product landing page (feature highlights, comparison table, screenshots)
+- CONTRIBUTING.md updated from legacy "Lighthouse AI" branding to "Dream Server"
+- Repository About section updated with new description, website, and topics
+
+### Fixed
+- Timing attack vulnerability in privacy-shield API key comparison (now uses `secrets.compare_digest`)
+- `HTTPBearer(auto_error=False)` in privacy-shield silently passing `None` instead of returning 401
+- Dependency version bounds added to privacy-shield and token-spy requirements.txt
+
 ## [2.0.0] - 2026-03-03
 
 ### Added

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.0.0",
+    "version": "2.1.0",
     "channel": "stable",
-    "date": "2026-03-03"
+    "date": "2026-03-04"
   },
   "compatibility": {
     "os": {


### PR DESCRIPTION
- Added YouTube demo badge link below the hero screenshot
- Bumped manifest.json version from 2.0.0 to 2.1.0
- Added v2.1.0 changelog entry covering: Strix Halo support, NV_ULTRA tier, Qwen3 Coder Next, README rewrite, screenshots, pytest infrastructure, security fixes, and dependency pinning