### PR TITLE
Fix version to 2.0.0-strix-halo, purge Lighthouse-AI refs, add YouTub…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug in Lighthouse AI (Dream Server, Guardian, Memory Shepherd, Token Spy)
+description: Report a bug in Dream Server
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: "Question / Help"
-    url: "https://github.com/Light-Heart-Labs/Lighthouse-AI/discussions"
+    url: "https://github.com/Light-Heart-Labs/DreamServer/discussions"
     about: "Ask questions and get help from the community"

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,18 +1,18 @@
 name: Feature Request
-description: Suggest a new feature or improvement for Lighthouse AI
+description: Suggest a new feature or improvement for Dream Server
 labels: ["enhancement"]
 body:
   - type: markdown
     attributes:
       value: |
-        Have an idea that would make Lighthouse AI better? We'd love to hear it.
+        Have an idea that would make Dream Server better? We'd love to hear it.
 
   - type: textarea
     id: description
     attributes:
       label: Description
       description: A clear description of the feature you'd like.
-      placeholder: What should Lighthouse AI do?
+      placeholder: What should Dream Server do?
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 
 ![Dream Server Dashboard](docs/images/dashboard.png)
 
+[![Watch the demo](https://img.shields.io/badge/Demo-Watch%20on%20YouTube-red?logo=youtube)](https://youtu.be/nO8xFNHX-HA)
+
 </div>
 
 ---

--- a/dream-server/examples/sample-doc.txt
+++ b/dream-server/examples/sample-doc.txt
@@ -37,8 +37,8 @@ Dream Server automatically detects your GPU and configures appropriate models:
 ## Installation
 
 ```bash
-git clone https://github.com/Light-Heart-Labs/Lighthouse-AI.git
-cd Lighthouse-AI/dream-server
+git clone https://github.com/Light-Heart-Labs/DreamServer.git
+cd DreamServer/dream-server
 ./install.sh
 ```
 

--- a/dream-server/extensions/services/dashboard-api/Dockerfile
+++ b/dream-server/extensions/services/dashboard-api/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM python:3.11-slim
 
-LABEL org.opencontainers.image.source="https://github.com/Light-Heart-Labs/Lighthouse-AI"
+LABEL org.opencontainers.image.source="https://github.com/Light-Heart-Labs/DreamServer"
 LABEL org.opencontainers.image.description="Dream Server Dashboard API"
 
 WORKDIR /app

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -51,7 +51,7 @@ logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="Dream Server Dashboard API",
-    version="1.0.0",
+    version="2.0.0",
     description="System status API for Dream Server Dashboard"
 )
 

--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -26,7 +26,7 @@ async def get_version():
     result = {"current": current, "latest": None, "update_available": False, "changelog_url": None, "checked_at": datetime.now(timezone.utc).isoformat() + "Z"}
 
     try:
-        req = urllib.request.Request("https://api.github.com/repos/Light-Heart-Labs/Lighthouse-AI/releases/latest", headers={"Accept": "application/vnd.github.v3+json"})
+        req = urllib.request.Request("https://api.github.com/repos/Light-Heart-Labs/DreamServer/releases/latest", headers={"Accept": "application/vnd.github.v3+json"})
         with urllib.request.urlopen(req, timeout=5) as resp:
             data = json.loads(resp.read())
             latest = data.get("tag_name", "").lstrip("v")
@@ -51,7 +51,7 @@ async def get_release_manifest():
     import urllib.error
 
     try:
-        req = urllib.request.Request("https://api.github.com/repos/Light-Heart-Labs/Lighthouse-AI/releases?per_page=5", headers={"Accept": "application/vnd.github.v3+json"})
+        req = urllib.request.Request("https://api.github.com/repos/Light-Heart-Labs/DreamServer/releases?per_page=5", headers={"Accept": "application/vnd.github.v3+json"})
         with urllib.request.urlopen(req, timeout=5) as resp:
             releases = json.loads(resp.read())
             return {
@@ -65,7 +65,7 @@ async def get_release_manifest():
         version_file = Path(INSTALL_DIR) / ".version"
         current = version_file.read_text().strip() if version_file.exists() else "0.0.0"
         return {
-            "releases": [{"version": current, "date": datetime.now(timezone.utc).isoformat() + "Z", "title": f"Dream Server {current}", "changelog": "Release information unavailable. Check GitHub directly.", "url": "https://github.com/Light-Heart-Labs/Lighthouse-AI/releases", "prerelease": False}],
+            "releases": [{"version": current, "date": datetime.now(timezone.utc).isoformat() + "Z", "title": f"Dream Server {current}", "changelog": "Release information unavailable. Check GitHub directly.", "url": "https://github.com/Light-Heart-Labs/DreamServer/releases", "prerelease": False}],
             "checked_at": datetime.now(timezone.utc).isoformat() + "Z",
             "error": "Could not fetch release information"
         }

--- a/dream-server/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
@@ -254,7 +254,7 @@ export function TroubleshootingAssistant({ serviceStatus }) {
         <p className="text-xs text-zinc-500">
           Still stuck? Check the{' '}
           <a 
-            href="https://github.com/Light-Heart-Labs/Lighthouse-AI/tree/main/dream-server#troubleshooting" 
+            href="https://github.com/Light-Heart-Labs/DreamServer/tree/main/dream-server#troubleshooting" 
             target="_blank"
             rel="noopener noreferrer"
             className="text-indigo-400 hover:text-indigo-300"

--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.1.0-strix-halo"
+VERSION="2.0.0-strix-halo"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 INSTALL_DIR="${INSTALL_DIR:-$HOME/dream-server}"
 LOG_FILE="${LOG_FILE:-/tmp/dream-server-install.log}"

--- a/dream-server/scripts/llm-cold-storage.sh
+++ b/dream-server/scripts/llm-cold-storage.sh
@@ -2,7 +2,7 @@
 #
 # llm-cold-storage.sh — Archive idle HuggingFace models to cold storage
 #
-# Part of Lighthouse AI tooling.
+# Part of Dream Server tooling.
 #
 # Models not accessed in 7+ days are moved to cold storage on a backup drive.
 # A symlink replaces the original so HuggingFace cache resolution still works.


### PR DESCRIPTION
…e demo

Version:
- constants.sh: 2.1.0-strix-halo → 2.0.0-strix-halo
- dashboard-api main.py: FastAPI version 1.0.0 → 2.0.0

Branding (Lighthouse-AI → DreamServer):
- dashboard-api updates.py: 3 GitHub API URLs
- dashboard-api Dockerfile: OCI image source label
- dashboard TroubleshootingAssistant.jsx: troubleshooting link
- .github/ISSUE_TEMPLATE: bug_report, feature_request, config
- scripts/llm-cold-storage.sh: header comment
- examples/sample-doc.txt: clone instructions

README:
- Added YouTube demo badge linking to installer walkthrough

Archive files intentionally left unchanged (historical).