### PR TITLE
Fix manifest.json and changelog version to 2.0.0

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-## [2.1.0] - 2026-03-04
+## [2.0.0-strix-halo] - 2026-03-04
 
 ### Added
 - AMD Strix Halo support with ROCm 7.2 and unified memory tiers (SH_LARGE, SH_COMPACT)

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.1.0",
+    "version": "2.0.0",
     "channel": "stable",
     "date": "2026-03-04"
   },


### PR DESCRIPTION
## Summary
Cleanup from the version merge order — PR #27 put `2.1.0` in manifest.json and CHANGELOG before PR #28 corrected constants.sh to `2.0.0-strix-halo`. This PR fixes the remaining mismatch.

- `manifest.json`: `2.1.0` → `2.0.0`
- `CHANGELOG.md`: `[2.1.0]` → `[2.0.0-strix-halo]`

Now all version strings are consistent: `2.0.0-strix-halo` in constants.sh, `2.0.0` in manifest.json, `[2.0.0-strix-halo]` in CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)