### PR TITLE
Fix Settings page version reference v1.0 → v2.0

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
@@ -68,7 +68,7 @@ export default function Settings() {
   }
 
   const handleCheckUpdates = () => {
-    setNotice({ type: 'info', text: 'Update channel not wired yet (v1.0).' })
+    setNotice({ type: 'info', text: 'Update channel not wired yet (v2.0).' })
   }
 
   const handleExportConfig = async () => {


### PR DESCRIPTION
## Summary
The dashboard Settings page had a user-facing notice saying "Update channel not wired yet (v1.0)." — updated to v2.0.

This was the last stale version reference in active code. All others (`package.json`, mock data, backup manifest format, OpenClaw configs) are internal/unrelated version numbers that should stay as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)