### PR TITLE
docs: add distro support list and port config guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 > | **macOS** (Apple Silicon) | **Coming soon** — target mid-March 2026 |
 > | **Windows** | **Coming soon** — target end of March 2026 |
 >
+> **Tested Linux distros:** Ubuntu 24.04/22.04, Debian 12, Fedora 41+, Arch Linux, CachyOS, openSUSE Tumbleweed. Other distros using apt, dnf, pacman, or zypper should also work — [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues) if yours doesn't.
+>
 > macOS and Windows installers currently provide system diagnostics and preflight checks only.
 > Full runtime support for both platforms is in active development.
 > For a working setup today, use Linux. See the [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) for details.
@@ -48,6 +50,11 @@ curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/d
 ```
 
 Open **http://localhost:3000** and start chatting.
+
+> **Port conflicts?** Every port is configurable via environment variables. See [`.env.example`](dream-server/.env.example) for the full list, or override at install time:
+> ```bash
+> WEBUI_PORT=9090 ./install.sh
+> ```
 
 <div align="center">
 

--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -96,6 +96,10 @@ Tiers:
     3 - Pro           (24GB+ VRAM, 32B models)
     4 - Enterprise    (48GB+ VRAM or dual GPU, 72B models)
 
+Port Configuration:
+    All service ports are configurable via .env (see .env.example).
+    Example: WEBUI_PORT=8080 OLLAMA_PORT=11435 ./install.sh
+
 Examples:
     $0                           # Interactive setup
     $0 --tier 2 --voice          # Tier 2 with voice


### PR DESCRIPTION
## Summary
- **README**: Add tested distro list (Ubuntu, Debian, Fedora, Arch, CachyOS, openSUSE) to the Platform Support table
- **README**: Add port override example right below the install command, with link to `.env.example`
- **`--help`**: Add Port Configuration section showing how to override ports via env vars

## Why
Community feedback (Reddit, GitHub issues) showed that:
1. Users don't know which distros are supported beyond Ubuntu
2. Users assume port 8080 is hardcoded when it's actually the *internal* container port — all external ports are configurable via env vars, but this wasn't discoverable

## Changes
- `README.md`: +7 lines (distro list + port config callout)
- `install-core.sh`: +4 lines (port config in `--help`)

## Test plan
- [ ] Verify `./install.sh --help` shows the new Port Configuration section
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)