### PR TITLE
docs: add model switching guide to README and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,33 @@ Skip bootstrap: `./install.sh --no-bootstrap`
 
 ---
 
+## Switching Models
+
+The installer picks a model for your hardware, but you can switch anytime:
+
+```bash
+dream model current              # What's running now?
+dream model list                 # Show all available tiers
+dream model swap T3              # Switch to a different tier
+```
+
+If the new model isn't downloaded yet, pre-fetch it first:
+
+```bash
+./scripts/pre-download.sh --tier 3    # Download before switching
+dream model swap T3                    # Then swap (restarts llama-server)
+```
+
+Already have a GGUF you want to use? Drop it in `data/models/`, update `GGUF_FILE` and `LLM_MODEL` in `.env`, and restart:
+
+```bash
+docker compose restart llama-server
+```
+
+Rollback is automatic — if a new model fails to load, Dream Server reverts to your previous model.
+
+---
+
 ## Extensibility
 
 Dream Server is designed to be modded. Every service is an extension — a folder with a `manifest.yaml` and a `compose.yaml`. The dashboard, CLI, health checks, and compose stack all discover extensions automatically.

--- a/dream-server/FAQ.md
+++ b/dream-server/FAQ.md
@@ -93,6 +93,45 @@ This hot-swaps from the 1.5B bootstrap model to your full model without downtime
 
 This downloads the full model first. You'll wait longer before first use.
 
+### How do I switch to a different model?
+Use the `dream` CLI:
+```bash
+dream model current              # See what's running
+dream model list                 # Show available tiers and models
+dream model swap T3              # Switch to Tier 3 (e.g., Qwen3 14B)
+```
+
+The model file must already be downloaded. If it isn't, pre-fetch it first:
+```bash
+./scripts/pre-download.sh --tier 3
+```
+
+### Can I use my own GGUF model?
+Yes. Drop the `.gguf` file into `data/models/`, then update `.env`:
+```bash
+GGUF_FILE=my-model.gguf
+LLM_MODEL=my-model
+```
+Restart the inference server:
+```bash
+docker compose restart llama-server
+```
+The model will load in ~30-120 seconds depending on size. If it fails, Dream Server automatically rolls back to the previous model.
+
+### What models are available?
+The installer auto-selects based on your GPU, but you can switch between any tier:
+
+| Tier | Model | Min VRAM |
+|------|-------|----------|
+| T1 | Qwen3 8B | 8 GB |
+| T2 | Qwen3 8B | 12 GB |
+| T3 | Qwen3 14B | 20 GB |
+| T4 | Qwen3 30B-A3B (MoE) | 40 GB |
+| SH_COMPACT | Qwen3 30B-A3B (MoE) | 64 GB unified |
+| SH_LARGE | Qwen3 Coder Next 80B (MoE) | 90 GB unified |
+
+Run `dream model list` for the full list on your system.
+
 ### NVIDIA GPU not detected
 **Check driver:**
 ```bash
@@ -356,11 +395,9 @@ docker compose down -v
 ## Advanced
 
 ### How do I add a custom model?
-1. Download model to `data/models/` directory
-2. Edit `.env` — change `LLM_MODEL` and `GGUF_FILE` variables
-3. Restart: `docker compose up -d llama-server`
+See [How do I switch to a different model?](#how-do-i-switch-to-a-different-model) and [Can I use my own GGUF model?](#can-i-use-my-own-gguf-model) above.
 
-Supported formats: AWQ, GPTQ, EXL2, GGUF (via llama.cpp adapter)
+**Short version:** Drop your `.gguf` file into `data/models/`, set `GGUF_FILE` and `LLM_MODEL` in `.env`, run `docker compose restart llama-server`. Rollback is automatic on failure.
 
 ### How do I enable HTTPS?
 For production deployments, use a reverse proxy (nginx, Caddy, Traefik) in front of Dream Server:
@@ -486,4 +523,4 @@ Copy the output into your GitHub issue.
 
 ---
 
-*Last updated: 2026-02-11*
+*Last updated: 2026-03-05*


### PR DESCRIPTION
## Summary
- **README**: New "Switching Models" section with `dream model swap` examples, pre-download workflow, custom GGUF instructions, and automatic rollback note
- **FAQ**: Three new entries covering model switching via CLI, custom GGUF models, and a tier/model/VRAM reference table
- **FAQ**: Consolidated the existing thin "How do I add a custom model?" entry to cross-reference the new detailed entries

## Why
Community feedback showed model switching is a top interest but the existing docs didn't surface it. The `dream model swap` command worked fine — people just didn't know it existed. The CLI reference mentioned it, but the README and FAQ (where people actually look first) did not.

## Changes
- `README.md`: +27 lines (new Switching Models section)
- `dream-server/FAQ.md`: +42 lines net (3 new entries, 1 consolidated)

## Test plan
- [ ] Verify README renders correctly on GitHub — section appears between Bootstrap Mode and Extensibility
- [ ] Verify FAQ anchor links work (`#how-do-i-switch-to-a-different-model`, `#can-i-use-my-own-gguf-model`)
- [ ] Verify tier table matches current `tier-map.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)