### PR TITLE
docs: improve international accessibility of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/d
 
 Open **http://localhost:3000** and start chatting.
 
+> **No GPU?** Dream Server also runs in cloud mode — same full stack, powered by OpenAI/Anthropic/Together APIs instead of local inference:
+> ```bash
+> ./install.sh --cloud
+> ```
+
 > **Port conflicts?** Every port is configurable via environment variables. See [`.env.example`](dream-server/.env.example) for the full list, or override at install time:
 > ```bash
 > WEBUI_PORT=9090 ./install.sh
@@ -102,7 +107,7 @@ For a working setup today, use Linux.
 ## What You Get
 
 ### Chat & Inference
-- **Open WebUI** — full-featured chat interface with conversation history, web search, and document upload
+- **Open WebUI** — full-featured chat interface with conversation history, web search, document upload, and [30+ languages](https://docs.openwebui.com)
 - **llama-server** — high-performance LLM inference with continuous batching, auto-selected for your GPU
 - **LiteLLM** — API gateway supporting local/cloud/hybrid modes
 
@@ -155,7 +160,7 @@ Override tier selection: `./install.sh --tier 3`
 
 ## Bootstrap Mode
 
-No staring at download bars. Dream Server uses bootstrap mode by default:
+No waiting for large downloads. Dream Server uses bootstrap mode by default:
 
 1. Downloads a tiny 1.5B model in under a minute
 2. You start chatting immediately
@@ -166,7 +171,7 @@ No staring at download bars. Dream Server uses bootstrap mode by default:
 
 ![Installer downloading modules](docs/images/installer-download.png)
 
-*The installer pulls all services in parallel — "Take a break for ten minutes. I've got this."*
+*The installer pulls all services in parallel. Downloads are resume-capable — interrupted downloads pick up where they left off.*
 
 </div>
 


### PR DESCRIPTION
## Summary
- Add **cloud mode callout** (`./install.sh --cloud`) right below the install command — surfaces the no-GPU option for international audiences where GPU hardware is expensive or scarce
- Mention **Open WebUI's 30+ language support** in the Chat & Inference feature list — a differentiator for non-English-speaking users
- Replace **English idioms** with clearer phrasing ("No staring at download bars" → "No waiting for large downloads")
- Note **resume-capable downloads** — important for users on slower connections where multi-GB model downloads may be interrupted

## Why
LinkedIn ad campaigns target senior engineers in India, Indonesia, Philippines, Brazil, Ukraine, Poland, Egypt, Vietnam, and Bangladesh. Two things matter for these audiences:
1. Not everyone has an RTX 4090 — cloud mode needs to be visible, not buried
2. The chat UI working in their language is a real selling point

## Changes
- `README.md`: +8 lines, -3 lines (net +5)

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify Open WebUI docs link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)