### PR TITLE
fix: Windows installer PS 5.1 compat + 7 critical bugs

### DIFF
--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -25,7 +25,7 @@ param(
     [string]$Command = "help",
 
     [Parameter(Position = 1, ValueFromRemainingArguments = $true)]
-    [string[]]$Args
+    [string[]]$Arguments
 )
 
 $ErrorActionPreference = "Stop"
@@ -257,7 +257,7 @@ function Invoke-Status {
         if (Test-Path $script:LLAMA_SERVER_PID_FILE) {
             $nativeStatus = Get-NativeLlamaStatus
             if ($nativeStatus.Running) {
-                $healthStr = if ($nativeStatus.Healthy) { "healthy" } else { "loading" }
+                $healthStr = $(if ($nativeStatus.Healthy) { "healthy" } else { "loading" })
                 Write-AISuccess "llama-server (native): running PID $($nativeStatus.Pid) ($healthStr)"
             } else {
                 Write-AIWarn "llama-server (native): not running (stale PID cleaned)"
@@ -534,16 +534,16 @@ function Show-Help {
 
 switch ($Command.ToLower()) {
     "status"  { Invoke-Status }
-    "start"   { Invoke-Start -Service ($Args | Select-Object -First 1) }
-    "stop"    { Invoke-Stop -Service ($Args | Select-Object -First 1) }
-    "restart" { Invoke-Restart -Service ($Args | Select-Object -First 1) }
+    "start"   { Invoke-Start -Service ($Arguments | Select-Object -First 1) }
+    "stop"    { Invoke-Stop -Service ($Arguments | Select-Object -First 1) }
+    "restart" { Invoke-Restart -Service ($Arguments | Select-Object -First 1) }
     "logs"    {
-        $svc = $Args | Select-Object -First 1
-        $n = if ($Args.Count -ge 2) { [int]$Args[1] } else { 100 }
+        $svc = $Arguments | Select-Object -First 1
+        $n = $(if ($Arguments.Count -ge 2) { [int]$Arguments[1] } else { 100 })
         Invoke-Logs -Service $svc -Lines $n
     }
     "config"  {
-        $action = ($Args | Select-Object -First 1)
+        $action = ($Arguments | Select-Object -First 1)
         if ($action -eq "edit") {
             Test-Install
             & notepad (Join-Path $InstallDir ".env")
@@ -551,7 +551,7 @@ switch ($Command.ToLower()) {
             Invoke-ConfigShow
         }
     }
-    "chat"    { Invoke-Chat -Message ($Args -join " ") }
+    "chat"    { Invoke-Chat -Message ($Arguments -join " ") }
     "update"  { Invoke-Update }
     "version" { Write-Host "Dream Server v$($script:DS_VERSION) (Windows)" -ForegroundColor Green }
     "help"    { Show-Help }

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -241,8 +241,22 @@ if ($DryRun) {
         Write-AI "Running in-place, skipping file copy"
     }
 
+    # Copy dream.ps1 CLI to install root so users can run .\dream.ps1
+    $dreamSrc = Join-Path $ScriptDir "dream.ps1"
+    $dreamDst = Join-Path $InstallDir "dream.ps1"
+    if (Test-Path $dreamSrc) {
+        Copy-Item -Path $dreamSrc -Destination $dreamDst -Force
+        # Also copy the lib/ directory dream.ps1 needs
+        $libSrc = Join-Path $ScriptDir "lib"
+        $libDst = Join-Path $InstallDir "lib"
+        New-Item -ItemType Directory -Path $libDst -Force | Out-Null
+        Copy-Item -Path (Join-Path $libSrc "*") -Destination $libDst -Recurse -Force
+        Write-AISuccess "Installed dream.ps1 CLI"
+    }
+
     # Generate .env
-    $dreamMode = if ($Cloud) { "cloud" } else { "local" }
+    # NOTE: $(if ...) syntax required for PS 5.1 compatibility
+    $dreamMode = $(if ($Cloud) { "cloud" } else { "local" })
     $envResult = New-DreamEnv -InstallDir $InstallDir -TierConfig $tierConfig `
         -Tier $selectedTier -GpuBackend $gpuInfo.Backend -DreamMode $dreamMode
     Write-AISuccess "Generated .env with secure secrets"
@@ -253,11 +267,11 @@ if ($DryRun) {
 
     # Generate OpenClaw configs (if enabled)
     if ($enableOpenClaw) {
-        $providerUrl = if ($gpuInfo.Backend -eq "amd") {
+        $providerUrl = $(if ($gpuInfo.Backend -eq "amd") {
             "http://host.docker.internal:8080"
         } else {
             "http://llama-server:8080"
-        }
+        })
         New-OpenClawConfig -InstallDir $InstallDir `
             -LlmModel $tierConfig.LlmModel `
             -MaxContext $tierConfig.MaxContext `
@@ -269,7 +283,7 @@ if ($DryRun) {
     # Create llama-server models.ini (empty — populated later)
     $modelsIni = Join-Path $InstallDir "config" "llama-server" "models.ini"
     if (-not (Test-Path $modelsIni)) {
-        Set-Content -Path $modelsIni -Value "# Dream Server model registry" -Encoding UTF8
+        Write-Utf8NoBom -Path $modelsIni -Content "# Dream Server model registry"
     }
 }
 
@@ -391,43 +405,79 @@ if ($DryRun) {
         # ── Assemble Docker Compose flags ──
         $composeFlags = @("-f", "docker-compose.base.yml")
 
-        if ($gpuInfo.Backend -eq "nvidia" -and -not $Cloud) {
+        if ($Cloud) {
+            # Cloud mode: disable llama-server (no GPU overlay, no local model)
+            $composeFlags += @("-f", "installers/windows/docker-compose.windows-amd.yml")
+        } elseif ($gpuInfo.Backend -eq "nvidia") {
             $composeFlags += @("-f", "docker-compose.nvidia.yml")
-        } elseif ($gpuInfo.Backend -eq "amd" -and -not $Cloud) {
-            $amdOverlay = Join-Path "installers" "windows" "docker-compose.windows-amd.yml"
-            $composeFlags += @("-f", $amdOverlay)
+        } elseif ($gpuInfo.Backend -eq "amd") {
+            $composeFlags += @("-f", "installers/windows/docker-compose.windows-amd.yml")
         }
 
-        # Discover enabled extension compose fragments
+        # Discover enabled extension compose fragments via manifests
+        # Mirrors resolve-compose-stack.sh: reads manifest.yaml, checks schema_version
+        # and gpu_backends before including a service's compose file.
         $extDir = Join-Path $InstallDir "extensions" "services"
-        if (Test-Path $extDir) {
-            $extServices = Get-ChildItem -Path $extDir -Directory
-            foreach ($svcDir in $extServices) {
-                $composePath = Join-Path $svcDir.FullName "compose.yaml"
-                if (Test-Path $composePath) {
-                    # Check if service should be enabled based on feature flags
-                    $svcName = $svcDir.Name
-                    $skip = $false
-                    switch ($svcName) {
-                        "whisper"    { if (-not $enableVoice) { $skip = $true } }
-                        "tts"        { if (-not $enableVoice) { $skip = $true } }
-                        "n8n"        { if (-not $enableWorkflows) { $skip = $true } }
-                        "qdrant"     { if (-not $enableRag) { $skip = $true } }
-                        "embeddings" { if (-not $enableRag) { $skip = $true } }
-                        "openclaw"   { if (-not $enableOpenClaw) { $skip = $true } }
-                    }
-                    if (-not $skip) {
-                        $relPath = $composePath.Substring($InstallDir.Length + 1) -replace "\\", "/"
-                        $composeFlags += @("-f", $relPath)
+        $currentBackend = $(if ($Cloud) { "none" } else { $gpuInfo.Backend })
 
-                        # GPU-specific overlay for this extension
-                        if ($gpuInfo.Backend -eq "nvidia" -and -not $Cloud) {
-                            $gpuOverlay = Join-Path $svcDir.FullName "compose.nvidia.yaml"
-                            if (Test-Path $gpuOverlay) {
-                                $relOverlay = $gpuOverlay.Substring($InstallDir.Length + 1) -replace "\\", "/"
-                                $composeFlags += @("-f", $relOverlay)
-                            }
-                        }
+        if (Test-Path $extDir) {
+            $extServices = Get-ChildItem -Path $extDir -Directory | Sort-Object Name
+            foreach ($svcDir in $extServices) {
+                # Read manifest (YAML parsed as simple key-value — no YAML lib needed)
+                $manifestPath = Join-Path $svcDir.FullName "manifest.yaml"
+                if (-not (Test-Path $manifestPath)) {
+                    $manifestPath = Join-Path $svcDir.FullName "manifest.yml"
+                }
+                if (-not (Test-Path $manifestPath)) { continue }
+
+                $manifestLines = Get-Content $manifestPath -ErrorAction SilentlyContinue
+                if (-not $manifestLines) { continue }
+
+                # Quick manifest validation: must contain schema_version: dream.services.v1
+                $hasSchema = $manifestLines | Where-Object { $_ -match "schema_version:\s*dream\.services\.v1" }
+                if (-not $hasSchema) { continue }
+
+                # Check gpu_backends compatibility
+                $backendsLine = $manifestLines | Where-Object { $_ -match "gpu_backends:" }
+                if ($backendsLine -and $currentBackend -ne "none") {
+                    $backendsStr = ($backendsLine -split "gpu_backends:")[1]
+                    if ($backendsStr -notmatch $currentBackend -and $backendsStr -notmatch "all") {
+                        continue  # Service not compatible with current GPU
+                    }
+                }
+
+                # Find compose file reference in manifest
+                $composeFile = "compose.yaml"  # default
+                $composeRefLine = $manifestLines | Where-Object { $_ -match "compose_file:" }
+                if ($composeRefLine) {
+                    $composeFile = (($composeRefLine -split "compose_file:")[1]).Trim().Trim('"').Trim("'")
+                }
+
+                $composePath = Join-Path $svcDir.FullName $composeFile
+                if (-not (Test-Path $composePath)) { continue }
+
+                # Check feature flags
+                $svcName = $svcDir.Name
+                $skip = $false
+                switch ($svcName) {
+                    "whisper"    { if (-not $enableVoice) { $skip = $true } }
+                    "tts"        { if (-not $enableVoice) { $skip = $true } }
+                    "n8n"        { if (-not $enableWorkflows) { $skip = $true } }
+                    "qdrant"     { if (-not $enableRag) { $skip = $true } }
+                    "embeddings" { if (-not $enableRag) { $skip = $true } }
+                    "openclaw"   { if (-not $enableOpenClaw) { $skip = $true } }
+                }
+                if ($skip) { continue }
+
+                $relPath = $composePath.Substring($InstallDir.Length + 1) -replace "\\", "/"
+                $composeFlags += @("-f", $relPath)
+
+                # GPU-specific overlay for this extension (filesystem discovery)
+                if ($currentBackend -eq "nvidia") {
+                    $gpuOverlay = Join-Path $svcDir.FullName "compose.nvidia.yaml"
+                    if (Test-Path $gpuOverlay) {
+                        $relOverlay = $gpuOverlay.Substring($InstallDir.Length + 1) -replace "\\", "/"
+                        $composeFlags += @("-f", $relOverlay)
                     }
                 }
             }
@@ -448,9 +498,9 @@ if ($DryRun) {
         }
         Write-AISuccess "Docker services started"
 
-        # Save compose flags for dream.ps1
+        # Save compose flags for dream.ps1 (BOM-free for reliable parsing)
         $flagsFile = Join-Path $InstallDir ".compose-flags"
-        Set-Content -Path $flagsFile -Value ($composeFlags -join " ") -Encoding UTF8
+        Write-Utf8NoBom -Path $flagsFile -Content ($composeFlags -join " ")
 
     } finally {
         Pop-Location
@@ -542,6 +592,7 @@ if ($SummaryJsonPath) {
         healthy     = $allHealthy
         timestamp   = (Get-Date -Format "o")
     }
-    $summary | ConvertTo-Json -Depth 3 | Set-Content -Path $SummaryJsonPath -Encoding UTF8
+    $jsonContent = $summary | ConvertTo-Json -Depth 3
+    Write-Utf8NoBom -Path $SummaryJsonPath -Content $jsonContent
     Write-AI "Summary written to $SummaryJsonPath"
 }

--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -13,7 +13,8 @@
 $script:DS_VERSION = "2.0.0-strix-halo"
 
 # Install location (override via $env:DREAM_HOME)
-$script:DS_INSTALL_DIR = if ($env:DREAM_HOME) { $env:DREAM_HOME } else { Join-Path $env:USERPROFILE "dream-server" }
+# NOTE: $(if ...) syntax required for PS 5.1 compatibility (bare if-as-expression is PS 7+ only)
+$script:DS_INSTALL_DIR = $(if ($env:DREAM_HOME) { $env:DREAM_HOME } else { Join-Path $env:USERPROFILE "dream-server" })
 
 # Logging
 $script:DS_LOG_FILE = Join-Path $env:TEMP "dream-server-install.log"

--- a/dream-server/installers/windows/lib/detection.ps1
+++ b/dream-server/installers/windows/lib/detection.ps1
@@ -101,7 +101,7 @@ function Get-GpuInfo {
                 Name          = $gpuName
                 VramMB        = $effectiveVramMB
                 Count         = @($gpus).Count
-                MemoryType    = if ($isUnified) { "unified" } else { "discrete" }
+                MemoryType    = $(if ($isUnified) { "unified" } else { "discrete" })
                 DeviceId      = $deviceId
                 DriverVersion = $driverVer
                 DriverMajor   = 0

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -12,6 +12,20 @@
 #   All secrets use cryptographic RNG — never use Get-Random for secrets.
 # ============================================================================
 
+function Write-Utf8NoBom {
+    <#
+    .SYNOPSIS
+        Write text to file as UTF-8 WITHOUT BOM. PS 5.1's Set-Content -Encoding UTF8
+        writes a BOM which corrupts Docker Compose .env parsing and YAML files.
+    #>
+    param(
+        [string]$Path,
+        [string]$Content
+    )
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+}
+
 function New-SecureHex {
     <#
     .SYNOPSIS
@@ -76,29 +90,52 @@ function New-DreamEnv {
     # Determine LLM API URL based on backend
     # AMD on Windows: llama-server runs natively, containers reach it via host.docker.internal
     # NVIDIA: llama-server runs in Docker, containers reach it via service name
-    $llmApiUrl = if ($GpuBackend -eq "amd") {
+    # NOTE: $(if ...) syntax required for PS 5.1 compatibility
+    $llmApiUrl = $(if ($GpuBackend -eq "amd") {
         "http://host.docker.internal:8080"
     } elseif ($DreamMode -eq "cloud") {
         "http://litellm:4000"
     } else {
         "http://llama-server:8080"
-    }
+    })
 
-    # Timezone
-    $tz = try {
+    # Timezone — convert Windows timezone ID to IANA for Docker containers
+    $tz = $(try {
         $tzInfo = [System.TimeZoneInfo]::Local
-        # Convert Windows timezone to IANA (best effort)
-        # Common mappings; Docker containers expect IANA
-        switch -Wildcard ($tzInfo.Id) {
-            "*Eastern*"  { "America/New_York" }
-            "*Central*"  { "America/Chicago" }
-            "*Mountain*" { "America/Denver" }
-            "*Pacific*"  { "America/Los_Angeles" }
-            "*UTC*"      { "UTC" }
-            "*GMT*"      { "Europe/London" }
-            default      { "UTC" }
+        # .NET 6+ has TimeZoneInfo.TryConvertWindowsIdToIanaId; fall back to common mappings
+        $ianaId = $null
+        try {
+            # Works on .NET 6+ / PS 7+
+            $ianaId = [System.TimeZoneInfo]::TryConvertWindowsIdToIanaId($tzInfo.Id, [ref]$null)
+        } catch { }
+        if ($ianaId) { $ianaId } else {
+            switch -Wildcard ($tzInfo.Id) {
+                "*Eastern*"    { "America/New_York" }
+                "*Central*"    { "America/Chicago" }
+                "*Mountain*"   { "America/Denver" }
+                "*Pacific*"    { "America/Los_Angeles" }
+                "*Alaska*"     { "America/Anchorage" }
+                "*Hawaii*"     { "Pacific/Honolulu" }
+                "*UTC*"        { "UTC" }
+                "*GMT*"        { "Europe/London" }
+                "*W. Europe*"  { "Europe/Berlin" }
+                "*Romance*"    { "Europe/Paris" }
+                "*India*"      { "Asia/Kolkata" }
+                "*China*"      { "Asia/Shanghai" }
+                "*Tokyo*"      { "Asia/Tokyo" }
+                "*Korea*"      { "Asia/Seoul" }
+                "*AUS Eastern*"  { "Australia/Sydney" }
+                "*E. South America*" { "America/Sao_Paulo" }
+                "*SE Asia*"    { "Asia/Bangkok" }
+                "*Arab*"       { "Asia/Riyadh" }
+                "*Egypt*"      { "Africa/Cairo" }
+                "*South Africa*" { "Africa/Johannesburg" }
+                "*E. Europe*"  { "Europe/Bucharest" }
+                "*FLE*"        { "Europe/Kiev" }
+                default        { "UTC" }
+            }
         }
-    } catch { "UTC" }
+    } catch { "UTC" })
 
     $timestamp = Get-Date -Format "o"
 
@@ -123,7 +160,6 @@ GGUF_FILE=$($TierConfig.GgufFile)
 MAX_CONTEXT=$($TierConfig.MaxContext)
 CTX_SIZE=$($TierConfig.MaxContext)
 GPU_BACKEND=$GpuBackend
-LLAMA_SERVER_PORT=8080
 
 #=== Ports ===
 LLAMA_SERVER_PORT=8080
@@ -169,7 +205,7 @@ TIMEZONE=$tz
     # Those are Linux-only for AMD ROCm container device access
 
     $envPath = Join-Path $InstallDir ".env"
-    Set-Content -Path $envPath -Value $envContent -Encoding UTF8 -Force
+    Write-Utf8NoBom -Path $envPath -Content $envContent
 
     # Restrict .env to current user only (Windows ACL equivalent of chmod 600)
     try {
@@ -235,7 +271,7 @@ engines:
 "@
 
     $settingsPath = Join-Path $configDir "settings.yml"
-    Set-Content -Path $settingsPath -Value $config -Encoding UTF8 -Force
+    Write-Utf8NoBom -Path $settingsPath -Content $config
     return $settingsPath
 }
 
@@ -306,7 +342,7 @@ function New-OpenClawConfig {
   }
 }
 "@
-    Set-Content -Path (Join-Path $homeDir "openclaw.json") -Value $homeConfig -Encoding UTF8 -Force
+    Write-Utf8NoBom -Path (Join-Path $homeDir "openclaw.json") -Content $homeConfig
 
     # Auth profiles
     $authProfiles = @"
@@ -323,7 +359,7 @@ function New-OpenClawConfig {
   "usageStats": {}
 }
 "@
-    Set-Content -Path (Join-Path $agentDir "auth-profiles.json") -Value $authProfiles -Encoding UTF8 -Force
+    Write-Utf8NoBom -Path (Join-Path $agentDir "auth-profiles.json") -Content $authProfiles
 
     # Models config
     $modelsConfig = @"
@@ -354,7 +390,7 @@ function New-OpenClawConfig {
   }
 }
 "@
-    Set-Content -Path (Join-Path $agentDir "models.json") -Value $modelsConfig -Encoding UTF8 -Force
+    Write-Utf8NoBom -Path (Join-Path $agentDir "models.json") -Content $modelsConfig
 
     # Workspace directory (must exist before Docker Compose)
     $workspaceDir = Join-Path $InstallDir "config" "openclaw" "workspace" "memory"

--- a/dream-server/installers/windows/lib/ui.ps1
+++ b/dream-server/installers/windows/lib/ui.ps1
@@ -18,7 +18,7 @@ function Write-DreamBanner {
 
 "@
     Write-Host $banner -ForegroundColor Green
-    Write-Host "  DREAMGATE Windows Installer v$DS_VERSION" -ForegroundColor White
+    Write-Host "  DREAMGATE Windows Installer v$($script:DS_VERSION)" -ForegroundColor White
     Write-Host "  One command to a full local AI stack." -ForegroundColor DarkGray
     Write-Host ""
 }


### PR DESCRIPTION
## Summary
- **PS 5.1 syntax**: Wrapped all bare `$x = if (...) {}` expressions with `$x = $(if (...) {})` across 5 files — PS 5.1 doesn't support bare `if` as an expression
- **UTF-8 BOM corruption**: Replaced all `Set-Content -Encoding UTF8` with `Write-Utf8NoBom` helper using `[System.IO.File]::WriteAllText()` — PS 5.1's UTF8 encoding writes a BOM that corrupts Docker Compose `.env` and YAML parsing
- **dream.ps1 unreachable after install**: Installer now copies `dream.ps1` + `lib/` to the install root so `.\dream.ps1` works from the user's install directory
- **Duplicate LLAMA_SERVER_PORT**: Removed duplicate entry from .env template
- **Extension discovery blind scan**: Now reads `manifest.yaml` for `schema_version` validation and `gpu_backends` compatibility checking
- **`$Args` shadowing**: Renamed parameter to `$Arguments` to avoid shadowing PowerShell's automatic `$args` variable
- **Cloud mode failure**: Cloud mode now uses `docker-compose.windows-amd.yml` overlay (replicas: 0) to properly disable llama-server
- **Timezone coverage**: Expanded from 6 to 22 timezone mappings for international users

All changes isolated to `installers/windows/` — zero impact on Linux installer.

## Test plan
- [ ] Run `.\install-windows.ps1 --DryRun` on PowerShell 5.1 (ships with Windows 10/11)
- [ ] Run `.\install-windows.ps1 --DryRun` on PowerShell 7+
- [ ] Verify `.env` file has no BOM (`[byte[]](Get-Content .env -Encoding Byte -TotalCount 3)` should NOT be `0xEF 0xBB 0xBF`)
- [ ] Verify `dream.ps1` is copied to install root and runs from there
- [ ] Verify cloud mode (`--Cloud`) doesn't try to start llama-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)