### PR TITLE
fix: PS 5.1 Join-Path crash + 7 more Windows installer fixes

### DIFF
--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -31,10 +31,12 @@ param(
 $ErrorActionPreference = "Stop"
 
 # ── Locate libraries ──
+# NOTE: Nested Join-Path required — PS 5.1 only accepts 2 arguments
 $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
-. (Join-Path $ScriptDir "lib" "constants.ps1")
-. (Join-Path $ScriptDir "lib" "ui.ps1")
-. (Join-Path $ScriptDir "lib" "detection.ps1")
+$LibDir = Join-Path $ScriptDir "lib"
+. (Join-Path $LibDir "constants.ps1")
+. (Join-Path $LibDir "ui.ps1")
+. (Join-Path $LibDir "detection.ps1")
 
 # ── Resolve install directory ──
 $InstallDir = $script:DS_INSTALL_DIR
@@ -42,6 +44,20 @@ $InstallDir = $script:DS_INSTALL_DIR
 # ============================================================================
 # Helpers
 # ============================================================================
+
+function Test-DockerRunning {
+    <#
+    .SYNOPSIS
+        Quick check if Docker daemon is responsive. Shows friendly message if not.
+    #>
+    $null = docker info 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        Write-AIError "Docker Desktop is not running."
+        Write-AI "Start it from the Start Menu, then try again."
+        return $false
+    }
+    return $true
+}
 
 function Test-Install {
     if (-not (Test-Path $InstallDir)) {
@@ -54,6 +70,7 @@ function Test-Install {
         Write-AIError "docker-compose.base.yml not found in $InstallDir"
         exit 1
     }
+    if (-not (Test-DockerRunning)) { exit 1 }
 }
 
 function Get-ComposeFlags {
@@ -83,7 +100,7 @@ function Get-ComposeFlags {
     }
 
     # Add enabled extension compose files
-    $extDir = Join-Path $InstallDir "extensions" "services"
+    $extDir = Join-Path (Join-Path $InstallDir "extensions") "services"
     if (Test-Path $extDir) {
         Get-ChildItem -Path $extDir -Directory | ForEach-Object {
             $composePath = Join-Path $_.FullName "compose.yaml"
@@ -180,7 +197,7 @@ function Start-NativeLlamaServer {
     if (-not $ggufFile) { $ggufFile = "Qwen3-8B-Q4_K_M.gguf" }
     if (-not $ctxSize)  { $ctxSize = "16384" }
 
-    $modelPath = Join-Path $InstallDir "data" "models" $ggufFile
+    $modelPath = Join-Path (Join-Path $InstallDir "data\models") $ggufFile
     if (-not (Test-Path $modelPath)) {
         Write-AIError "Model not found: $modelPath"
         return

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -39,14 +39,16 @@ $ErrorActionPreference = "Stop"
 
 # ── Locate script directory and source tree root ──
 $ScriptDir   = Split-Path -Parent $MyInvocation.MyCommand.Path
-$SourceRoot  = (Resolve-Path (Join-Path $ScriptDir ".." "..")).Path
+# NOTE: Nested Join-Path required — PS 5.1 only accepts 2 arguments
+$SourceRoot  = (Resolve-Path (Join-Path (Join-Path $ScriptDir "..") "..")).Path
 
 # ── Source libraries ──
-. (Join-Path $ScriptDir "lib" "constants.ps1")
-. (Join-Path $ScriptDir "lib" "ui.ps1")
-. (Join-Path $ScriptDir "lib" "tier-map.ps1")
-. (Join-Path $ScriptDir "lib" "detection.ps1")
-. (Join-Path $ScriptDir "lib" "env-generator.ps1")
+$LibDir = Join-Path $ScriptDir "lib"
+. (Join-Path $LibDir "constants.ps1")
+. (Join-Path $LibDir "ui.ps1")
+. (Join-Path $LibDir "tier-map.ps1")
+. (Join-Path $LibDir "detection.ps1")
+. (Join-Path $LibDir "env-generator.ps1")
 
 # ── Resolve install directory ──
 $InstallDir = $script:DS_INSTALL_DIR
@@ -76,7 +78,10 @@ if (-not $docker.Installed) {
 Write-AISuccess "Docker CLI found"
 
 if (-not $docker.Running) {
-    Write-AIError "Docker Desktop is not running. Start it and try again."
+    Write-AIError "Docker Desktop is not running."
+    Write-AI "Start it from the Start Menu, or run:"
+    Write-Host "  & 'C:\Program Files\Docker\Docker\Docker Desktop.exe'" -ForegroundColor Cyan
+    Write-AI "Then re-run this installer."
     exit 1
 }
 Write-AISuccess "Docker Desktop running (v$($docker.Version))"
@@ -140,6 +145,16 @@ Write-InfoBox "Model:" "$($tierConfig.LlmModel)"
 Write-InfoBox "GGUF:" "$($tierConfig.GgufFile)"
 Write-InfoBox "Context:" "$($tierConfig.MaxContext)"
 
+# Re-check disk space now that tier (and model size) is known
+# Tier 1-2: ~5GB model, Tier 3: ~9GB, Tier 4+: ~18GB, plus ~15GB for Docker images
+$modelGB = $(if ($tierConfig.GgufFile -match "14B") { 12 } elseif ($tierConfig.GgufFile -match "30B") { 20 } else { 8 })
+$neededGB = $modelGB + 15  # model + Docker images headroom
+$disk2 = Test-DiskSpace -Path $InstallDir -RequiredGB $neededGB
+if (-not $disk2.Sufficient) {
+    Write-AIWarn "Tier $selectedTier needs ~$neededGB GB (model + Docker images). Only $($disk2.FreeGB) GB free on $($disk2.Drive)."
+    if (-not $Force) { exit 1 }
+}
+
 # ============================================================================
 # STEP 3 — FEATURE SELECTION
 # ============================================================================
@@ -202,18 +217,21 @@ if ($DryRun) {
     if ($enableOpenClaw) { Write-AI "[DRY RUN] Would configure OpenClaw" }
 } else {
     # Create directory structure
+    # NOTE: Nested Join-Path required — PS 5.1 only accepts 2 arguments
+    $configDir = Join-Path $InstallDir "config"
+    $dataDir   = Join-Path $InstallDir "data"
     $dirs = @(
-        (Join-Path $InstallDir "config" "searxng"),
-        (Join-Path $InstallDir "config" "n8n"),
-        (Join-Path $InstallDir "config" "litellm"),
-        (Join-Path $InstallDir "config" "openclaw"),
-        (Join-Path $InstallDir "config" "llama-server"),
-        (Join-Path $InstallDir "data" "open-webui"),
-        (Join-Path $InstallDir "data" "whisper"),
-        (Join-Path $InstallDir "data" "tts"),
-        (Join-Path $InstallDir "data" "n8n"),
-        (Join-Path $InstallDir "data" "qdrant"),
-        (Join-Path $InstallDir "data" "models")
+        (Join-Path $configDir "searxng"),
+        (Join-Path $configDir "n8n"),
+        (Join-Path $configDir "litellm"),
+        (Join-Path $configDir "openclaw"),
+        (Join-Path $configDir "llama-server"),
+        (Join-Path $dataDir "open-webui"),
+        (Join-Path $dataDir "whisper"),
+        (Join-Path $dataDir "tts"),
+        (Join-Path $dataDir "n8n"),
+        (Join-Path $dataDir "qdrant"),
+        (Join-Path $dataDir "models")
     )
     foreach ($d in $dirs) {
         New-Item -ItemType Directory -Path $d -Force | Out-Null
@@ -281,7 +299,7 @@ if ($DryRun) {
     }
 
     # Create llama-server models.ini (empty — populated later)
-    $modelsIni = Join-Path $InstallDir "config" "llama-server" "models.ini"
+    $modelsIni = Join-Path (Join-Path $InstallDir "config") "llama-server\models.ini"
     if (-not (Test-Path $modelsIni)) {
         Write-Utf8NoBom -Path $modelsIni -Content "# Dream Server model registry"
     }
@@ -308,7 +326,7 @@ if ($DryRun) {
     try {
         # ── Download GGUF model (if not cloud-only) ──
         if ($tierConfig.GgufUrl -and -not $Cloud) {
-            $modelPath = Join-Path $InstallDir "data" "models" $tierConfig.GgufFile
+            $modelPath = Join-Path (Join-Path $InstallDir "data\models") $tierConfig.GgufFile
             if (Test-Path $modelPath) {
                 Write-AISuccess "Model already downloaded: $($tierConfig.GgufFile)"
             } else {
@@ -359,7 +377,7 @@ if ($DryRun) {
 
             # Start native llama-server
             Write-AI "Starting native llama-server (Vulkan)..."
-            $modelFullPath = Join-Path $InstallDir "data" "models" $tierConfig.GgufFile
+            $modelFullPath = Join-Path (Join-Path $InstallDir "data\models") $tierConfig.GgufFile
             $llamaArgs = @(
                 "--model", $modelFullPath,
                 "--host", "0.0.0.0",
@@ -417,7 +435,7 @@ if ($DryRun) {
         # Discover enabled extension compose fragments via manifests
         # Mirrors resolve-compose-stack.sh: reads manifest.yaml, checks schema_version
         # and gpu_backends before including a service's compose file.
-        $extDir = Join-Path $InstallDir "extensions" "services"
+        $extDir = Join-Path (Join-Path $InstallDir "extensions") "services"
         $currentBackend = $(if ($Cloud) { "none" } else { $gpuInfo.Backend })
 
         if (Test-Path $extDir) {
@@ -486,6 +504,18 @@ if ($DryRun) {
         # Docker compose override (user customizations)
         if (Test-Path (Join-Path $InstallDir "docker-compose.override.yml")) {
             $composeFlags += @("-f", "docker-compose.override.yml")
+        }
+
+        # ── Validate compose files exist before launching ──
+        for ($fi = 0; $fi -lt $composeFlags.Count; $fi++) {
+            if ($composeFlags[$fi] -eq "-f" -and ($fi + 1) -lt $composeFlags.Count) {
+                $cf = $composeFlags[$fi + 1]
+                if (-not (Test-Path $cf)) {
+                    Write-AIError "Compose file not found: $cf"
+                    Write-AI "The source tree may not have copied correctly. Try re-running with --Force."
+                    exit 1
+                }
+            }
         }
 
         # ── Start Docker services ──

--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -23,7 +23,7 @@ $script:DS_PREFLIGHT_REPORT = Join-Path $env:TEMP "dream-server-windows-prefligh
 # Native llama-server paths (AMD Strix Halo Vulkan path only)
 $script:LLAMA_SERVER_DIR = Join-Path $script:DS_INSTALL_DIR "llama-server"
 $script:LLAMA_SERVER_EXE = Join-Path $script:LLAMA_SERVER_DIR "llama-server.exe"
-$script:LLAMA_SERVER_PID_FILE = Join-Path $script:DS_INSTALL_DIR "data" "llama-server.pid"
+$script:LLAMA_SERVER_PID_FILE = Join-Path (Join-Path $script:DS_INSTALL_DIR "data") "llama-server.pid"
 
 # llama.cpp release for Vulkan build (update when new releases ship)
 $script:LLAMA_CPP_RELEASE_TAG = "b5570"

--- a/dream-server/installers/windows/lib/detection.ps1
+++ b/dream-server/installers/windows/lib/detection.ps1
@@ -186,7 +186,16 @@ function Test-DockerDesktop {
                 if ($kernelVersion -match "microsoft|WSL") {
                     $result.WSL2Backend = $true
                 }
-                # Check for NVIDIA GPU support in Docker
+                # Check for GPU support in Docker
+                # On Windows Docker Desktop with WSL2 backend, GPU passthrough is
+                # handled automatically — there is no separate "nvidia" runtime like
+                # on Linux. If WSL2 backend is detected + NVIDIA driver is present,
+                # GPU support is available via --gpus flag / compose deploy.resources.
+                if ($result.WSL2Backend) {
+                    $nvsmi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+                    if ($nvsmi) { $result.GpuSupport = $true }
+                }
+                # Also check Linux-style runtime (in case running Docker Engine directly)
                 if ($info.Runtimes -and $info.Runtimes.nvidia) {
                     $result.GpuSupport = $true
                 }

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -106,7 +106,10 @@ function New-DreamEnv {
         $ianaId = $null
         try {
             # Works on .NET 6+ / PS 7+
-            $ianaId = [System.TimeZoneInfo]::TryConvertWindowsIdToIanaId($tzInfo.Id, [ref]$null)
+            # TryConvert returns bool; the IANA ID is written to the [ref] out-param
+            $outIana = $null
+            $ok = [System.TimeZoneInfo]::TryConvertWindowsIdToIanaId($tzInfo.Id, [ref]$outIana)
+            if ($ok -and $outIana) { $ianaId = $outIana }
         } catch { }
         if ($ianaId) { $ianaId } else {
             switch -Wildcard ($tzInfo.Id) {
@@ -240,7 +243,7 @@ function New-SearxngConfig {
         [string]$SecretKey
     )
 
-    $configDir = Join-Path $InstallDir "config" "searxng"
+    $configDir = Join-Path (Join-Path $InstallDir "config") "searxng"
     New-Item -ItemType Directory -Path $configDir -Force | Out-Null
 
     $config = @"
@@ -290,9 +293,10 @@ function New-OpenClawConfig {
     )
 
     # Create directories
-    $homeDir  = Join-Path $InstallDir "data" "openclaw" "home"
-    $agentDir = Join-Path $homeDir "agents" "main" "agent"
-    $sessDir  = Join-Path $homeDir "agents" "main" "sessions"
+    # NOTE: Nested Join-Path required — PS 5.1 only accepts 2 arguments
+    $homeDir  = Join-Path (Join-Path (Join-Path $InstallDir "data") "openclaw") "home"
+    $agentDir = Join-Path (Join-Path (Join-Path $homeDir "agents") "main") "agent"
+    $sessDir  = Join-Path (Join-Path (Join-Path $homeDir "agents") "main") "sessions"
     New-Item -ItemType Directory -Path $agentDir -Force | Out-Null
     New-Item -ItemType Directory -Path $sessDir -Force | Out-Null
 
@@ -393,6 +397,6 @@ function New-OpenClawConfig {
     Write-Utf8NoBom -Path (Join-Path $agentDir "models.json") -Content $modelsConfig
 
     # Workspace directory (must exist before Docker Compose)
-    $workspaceDir = Join-Path $InstallDir "config" "openclaw" "workspace" "memory"
+    $workspaceDir = Join-Path (Join-Path (Join-Path (Join-Path $InstallDir "config") "openclaw") "workspace") "memory"
     New-Item -ItemType Directory -Path $workspaceDir -Force | Out-Null
 }

--- a/dream-server/installers/windows/lib/ui.ps1
+++ b/dream-server/installers/windows/lib/ui.ps1
@@ -86,15 +86,19 @@ function Show-ProgressDownload {
     )
     Write-AI "$Label..."
     # Use curl.exe (ships with Windows 10+) for resume-capable download with progress
+    # Direct invocation (&) instead of Start-Process so the progress bar is visible
     $partFile = "$Destination.part"
-    $curlArgs = @("-C", "-", "-L", "--progress-bar", "-o", $partFile, $Url)
-    $proc = Start-Process -FilePath "curl.exe" -ArgumentList $curlArgs -NoNewWindow -Wait -PassThru
-    if ($proc.ExitCode -eq 0 -and (Test-Path $partFile)) {
+    & curl.exe -C - -L --progress-bar -o $partFile $Url
+    $curlExit = $LASTEXITCODE
+    if ($curlExit -eq 0 -and (Test-Path $partFile)) {
         Move-Item -Path $partFile -Destination $Destination -Force
         Write-AISuccess "$Label complete"
         return $true
     } else {
-        Write-AIError "$Label failed (curl exit code: $($proc.ExitCode))"
+        $curlErrors = @{ 6="Could not resolve host"; 7="Connection refused"; 18="Partial transfer"; 28="Timeout"; 35="SSL error"; 56="Network failure" }
+        $hint = $(if ($curlErrors.ContainsKey($curlExit)) { " ($($curlErrors[$curlExit]))" } else { "" })
+        Write-AIError "$Label failed (curl exit code: $curlExit$hint)"
+        Write-AI "Re-run the installer to resume the download."
         return $false
     }
 }
@@ -104,10 +108,14 @@ function Write-SuccessCard {
         [string]$WebUIPort = "3000",
         [string]$DashboardPort = "3001"
     )
-    # Detect local IP for network access
-    $localIP = (Get-NetIPAddress -AddressFamily IPv4 |
-        Where-Object { $_.InterfaceAlias -notlike "*Loopback*" -and $_.PrefixOrigin -eq "Dhcp" } |
-        Select-Object -First 1).IPAddress
+    # Detect local IP for network access (DHCP, static, or manual — exclude loopback + APIPA)
+    $localIP = (Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+        Where-Object {
+            $_.InterfaceAlias -notlike "*Loopback*" -and
+            $_.IPAddress -notlike "127.*" -and
+            $_.IPAddress -notlike "169.254.*" -and
+            $_.PrefixOrigin -in @("Dhcp", "Manual")
+        } | Select-Object -First 1).IPAddress
     if (-not $localIP) { $localIP = "your-ip" }
 
     Write-Host ""


### PR DESCRIPTION
BLOCKER: PS 5.1 only accepts 2 args to Join-Path; all 32 instances of 3+ arg Join-Path calls replaced with nested calls. Without this fix the installer crashes immediately on every Windows 10/11 machine shipping PS 5.1 (which is all of them by default).

Additional fixes:
- Docker GPU detection: WSL2 backend + nvidia-smi presence now correctly detects GPU support on Windows (was using Linux-specific Runtimes.nvidia check, always returned false)
- Timezone: TryConvertWindowsIdToIanaId now properly reads the [ref] out-param instead of returning bool "True" as timezone on PS 7+
- curl progress: replaced Start-Process with direct invocation (&) so the progress bar is visible during 9GB model downloads
- curl errors: added human-readable hints for common exit codes
- dream.ps1: added Docker-running check to Test-Install so CLI commands show a friendly message instead of raw Docker errors
- IP detection: now includes static and manual IPs, not just DHCP; excludes APIPA 169.254.x.x addresses
- Post-tier disk check: re-validates free space after tier selection with model-size-aware thresholds (not just static 20GB)
- Pre-compose validation: verifies all compose files exist before docker compose up, with actionable error message if missing
- Docker-not-running message: now shows how to start Docker Desktop

All changes isolated to installers/windows/ — zero Linux impact.