### PR TITLE
feat(nvidia): Blackwell GPU support + SHA256 model verification

### DIFF
--- a/dream-server/docker-compose.nvidia.yml
+++ b/dream-server/docker-compose.nvidia.yml
@@ -5,7 +5,7 @@
 
 services:
   llama-server:
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
## Summary

- **Configurable llama-server image**: `docker-compose.nvidia.yml` now uses `${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}`, allowing Blackwell GPU users to override the image
- **Blackwell GPU auto-detection**: Installer queries `nvidia-smi --query-gpu=compute_cap` to detect sm_120+ (Blackwell) GPUs and auto-configures the CUDA 13 image (`server-cuda13`) which includes native `120a-real` kernels
- **SHA256 model verification**: After downloading GGUF model files, the installer verifies integrity against known SHA256 hashes from HuggingFace. Detects corruption from partial/resumed `curl -C -` transfers and auto-re-downloads
- **LLAMA_SERVER_IMAGE in .env**: Generated `.env` includes the image override variable (active for Blackwell, commented-out default for others)

## Context

Tested on Lenovo Legion laptop with RTX 5090 Laptop GPU (24GB, compute capability 12.0). The default `server-cuda` Docker image (CUDA 12.4) lacks sm_120 kernels, causing silent failures. The upstream `server-cuda13` image (CUDA 13.1, merged Dec 2025) includes Blackwell support natively.

During testing, a 9GB model download was corrupted by `curl -C -` resume (149MB too large, every token decoded to `?`). The SHA256 verification catches this immediately.

## Files changed

- `docker-compose.nvidia.yml` — configurable image via env var (from first commit)
- `installers/windows/install-windows.ps1` — Blackwell detection flow, SHA256 verification after download, .env patching
- `installers/windows/lib/detection.ps1` — `ComputeCap`/`IsBlackwell` fields, `Test-ModelIntegrity` function
- `installers/windows/lib/env-generator.ps1` — `LlamaServerImage` parameter, writes to .env
- `installers/windows/lib/tier-map.ps1` — `GgufSha256` for all tier configs

## Test plan

- [x] Verified on RTX 5090 (sm_120): `nvidia-smi --query-gpu=compute_cap` returns `12.0`
- [x] SHA256 of known-good Qwen3-14B-Q4_K_M.gguf matches HuggingFace API hash
- [x] All 16/16 Docker services healthy with `LLAMA_SERVER_IMAGE=llama-server-cuda-blackwell`
- [x] LLM generating real text at 38 tok/s on RTX 5090
- [ ] Test on non-Blackwell NVIDIA GPU (should use default `server-cuda` image)
- [ ] Test fresh install end-to-end with SHA256 verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)