### PR TITLE
feat(nvidia): make llama-server image configurable via env var

### DIFF
--- a/dream-server/docker-compose.nvidia.yml
+++ b/dream-server/docker-compose.nvidia.yml
@@ -5,7 +5,7 @@
 
 services:
   llama-server:
-    image: ghcr.io/ggml-org/llama.cpp:server-cuda
+    image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda}
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Allow overriding the llama-server Docker image with LLAMA_SERVER_IMAGE env var, defaulting to the existing ghcr.io/ggml-org/llama.cpp:server-cuda.

This is needed for NVIDIA Blackwell (RTX 50xx, sm_120) GPUs where the pre-built server-cuda image lacks native CUDA kernels. Users with Blackwell GPUs can build a custom image with sm_120 support and set LLAMA_SERVER_IMAGE in their .env to use it.

Non-Blackwell NVIDIA and AMD users are unaffected -- the default image is unchanged.