### PR TITLE
fix(windows): use GGUF filename as OpenCode model ID

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -638,10 +638,12 @@ if ($DryRun) {
                 $ocConfigFile = Join-Path $script:OPENCODE_CONFIG_DIR "opencode.json"
                 if (-not (Test-Path $ocConfigFile)) {
                     $llamaPort = $(if ($gpuInfo.Backend -eq "amd") { "8080" } else { "11434" })
+                    # NOTE: llama-server exposes models by GGUF filename, not friendly name
+                    $ocModelId = $tierConfig.GgufFile
                     $ocConfig = @"
 {
   "`$schema": "https://opencode.ai/config.json",
-  "model": "llama-server/$($tierConfig.LlmModel)",
+  "model": "llama-server/$ocModelId",
   "provider": {
     "llama-server": {
       "npm": "@ai-sdk/openai-compatible",
@@ -651,7 +653,7 @@ if ($DryRun) {
         "apiKey": "no-key"
       },
       "models": {
-        "$($tierConfig.LlmModel)": {
+        "$ocModelId": {
           "name": "$($tierConfig.LlmModel)",
           "limit": {
             "context": $($tierConfig.MaxContext),


### PR DESCRIPTION
## Summary

- llama-server's OpenAI-compatible API exposes models by GGUF filename (`Qwen3-14B-Q4_K_M.gguf`), not the friendly tier name (`qwen3-14b`)
- OpenCode was configured with the friendly name → every prompt returned **"model 'qwen3-14b' not found"**
- Fix: use `$tierConfig.GgufFile` as the model ID, keep friendly name as display name

## Test plan

- [x] Verified `curl localhost:11434/v1/models` returns GGUF filename as model ID
- [x] Updated local opencode.json, confirmed OpenCode resolves the model
- [ ] Full clean install to verify config generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)