### PR TITLE
feat(windows): upgrade Tier 3 default to Qwen3-30B-A3B MoE

### DIFF
--- a/dream-server/installers/windows/lib/tier-map.ps1
+++ b/dream-server/installers/windows/lib/tier-map.ps1
@@ -49,7 +49,7 @@ function Resolve-TierConfig {
             return @{
                 TierName   = "Strix Halo Compact"
                 LlmModel   = "qwen3-30b-a3b"
-                GgufFile   = "qwen3-30b-a3b-Q4_K_M.gguf"
+                GgufFile   = "Qwen3-30B-A3B-Q4_K_M.gguf"
                 GgufUrl    = "https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
                 GgufSha256 = "9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
                 MaxContext = 131072
@@ -78,10 +78,10 @@ function Resolve-TierConfig {
         "3" {
             return @{
                 TierName   = "Pro"
-                LlmModel   = "qwen3-14b"
-                GgufFile   = "Qwen3-14B-Q4_K_M.gguf"
-                GgufUrl    = "https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf"
-                GgufSha256 = "5eaa0870bd81ed3b58a630a271234cfa604e43ffb3a19cd68e54a80dd9d52a66"
+                LlmModel   = "qwen3-30b-a3b"
+                GgufFile   = "Qwen3-30B-A3B-Q4_K_M.gguf"
+                GgufUrl    = "https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
+                GgufSha256 = "9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
                 MaxContext = 32768
             }
         }
@@ -89,7 +89,7 @@ function Resolve-TierConfig {
             return @{
                 TierName   = "Enterprise"
                 LlmModel   = "qwen3-30b-a3b"
-                GgufFile   = "qwen3-30b-a3b-Q4_K_M.gguf"
+                GgufFile   = "Qwen3-30B-A3B-Q4_K_M.gguf"
                 GgufUrl    = "https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
                 GgufSha256 = "9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
                 MaxContext = 131072
@@ -143,7 +143,7 @@ function ConvertTo-ModelFromTier {
         "^(SH_COMPACT|SH)$"     { return "qwen3-30b-a3b" }
         "^(1|T1)$"               { return "qwen3-8b" }
         "^(2|T2)$"               { return "qwen3-8b" }
-        "^(3|T3)$"               { return "qwen3-14b" }
+        "^(3|T3)$"               { return "qwen3-30b-a3b" }
         "^(4|T4)$"               { return "qwen3-30b-a3b" }
         default                  { return "" }
     }


### PR DESCRIPTION
## Summary

- **Tier 3 (Pro, 20-39GB VRAM)**: `qwen3-14b` (8.4GB) → `qwen3-30b-a3b` (17.3GB)
- Qwen3-30B-A3B is a Mixture-of-Experts model: 30B total params, 3B active per token — better quality than dense 14B at comparable inference speed
- Fixed `GgufFile` casing across Tier 3, Tier 4, and SH_COMPACT to match HuggingFace (`Qwen3-30B-A3B-Q4_K_M.gguf`)
- Tier 3 keeps `MaxContext=32768` (safe for 24GB); Tier 4 gets `131072`

## Test plan

- [x] Downloaded and loaded Qwen3-30B-A3B-Q4_K_M.gguf on RTX 5090 (24GB VRAM)
- [x] Inference verified via `/v1/chat/completions` API
- [x] OpenCode connected and working with the MoE model
- [x] 17.3GB GGUF fits in 24GB VRAM with headroom for other services

🤖 Generated with [Claude Code](https://claude.com/claude-code)