### PR TITLE
docs: add yasinBursali to community contributors

### DIFF
--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -410,6 +410,10 @@ Thanks to [kyuz0](https://github.com/kyuz0) for [amd-strix-halo-toolboxes](https
 *   [Speaches](https://github.com/speaches-ai/speaches) — Speech-to-text
 *   [Strix Halo Home Lab](https://strixhalo-homelab.d7.wtf/) — Community knowledge base
 
+### Community Contributors
+
+*   [Yasin Bursali (yasinBursali)](https://github.com/yasinBursali) — Fixed CI workflow discovery, added dashboard-api router test coverage with security-focused tests (auth enforcement, path traversal protection), and documented all 14 undocumented extension services
+
 If we missed anyone, [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues). We want to get this right.
 
 ---


### PR DESCRIPTION
## Summary

Adds Yasin Bursali as the first community contributor in the Acknowledgments section of the main README.

Contributions recognized:
- Fixed CI workflow discovery (#63) — 4 workflows were in `dream-server/.github/` where GitHub Actions can't find them
- Added 19 dashboard-api router tests with security coverage — auth enforcement, path traversal protection, mocked Privacy Shield
- Documented all 14 undocumented extension services with thorough READMEs (#64)

## Test plan

- [x] Docs-only change, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)