### PR TITLE
docs: add yasinBursali to community contributors (root README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,10 @@ Thanks to [kyuz0](https://github.com/kyuz0) for [amd-strix-halo-toolboxes](https
 *   [Speaches](https://github.com/speaches-ai/speaches) — Speech-to-text
 *   [Strix Halo Home Lab](https://strixhalo-homelab.d7.wtf/) — Community knowledge base
 
+### Community Contributors
+
+*   [Yasin Bursali (yasinBursali)](https://github.com/yasinBursali) — Fixed CI workflow discovery, added dashboard-api router test coverage with security-focused tests (auth enforcement, path traversal protection), and documented all 14 undocumented extension services
+
 If we missed anyone, [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues). We want to get this right.
 
 ---


### PR DESCRIPTION
## Summary

Adds Yasin Bursali to Community Contributors in the **root** README.md (the one GitHub displays on the repo page). PR #65 only updated `dream-server/README.md`.

## Test plan

- [x] Docs-only, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)