### PR TITLE
fix(security): bind OpenClaw gateway to localhost only

### DIFF
--- a/dream-server/config/openclaw/openclaw-strix-halo.json
+++ b/dream-server/config/openclaw/openclaw-strix-halo.json
@@ -46,7 +46,7 @@
   },
   "gateway": {
     "port": 7860,
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "controlUi": {
       "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,

--- a/dream-server/config/openclaw/openclaw.json
+++ b/dream-server/config/openclaw/openclaw.json
@@ -46,7 +46,7 @@
   },
   "gateway": {
     "port": 7860,
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "controlUi": {
       "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -13,14 +13,14 @@ services:
       - BOOTSTRAP_MODEL=${BOOTSTRAP_MODEL:-qwen3:8b-q4_K_M}
       - OLLAMA_URL=${LLM_API_URL:-http://llama-server:8080}
       - SEARXNG_BASE_URL=http://searxng:8080
-    entrypoint: ["/bin/sh", "-c", "node /config/inject-token.js; exec docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured --bind lan"]
+    entrypoint: ["/bin/sh", "-c", "node /config/inject-token.js; exec docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured --bind localhost"]
     volumes:
       - ./config/openclaw:/config:ro
       - ./data/openclaw:/data
       - ./data/openclaw/home:/home/node/.openclaw
       - ./config/openclaw/workspace:/home/node/.openclaw/workspace
     ports:
-      - "${OPENCLAW_PORT:-7860}:18789"
+      - "127.0.0.1:${OPENCLAW_PORT:-7860}:18789"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Fixes #22

## Problem
OpenClaw was bound to `0.0.0.0` in **two places** — fixing just the JSON config would not have been enough:

1. `gateway.host` in both `openclaw.json` and `openclaw-strix-halo.json`
2. `--bind lan` in the container entrypoint (this flag overrides the config file)
3. Docker port mapping `${OPENCLAW_PORT}:18789` (binds to all interfaces by default)

On any machine with a public IP or port-forward, all three exposed the OpenClaw gateway — including its `exec`, `read`, `write`, and sub-agent tools — to unauthenticated remote access.

## Changes
- `config/openclaw/openclaw.json`: `"host": "0.0.0.0"` → `"host": "127.0.0.1"`
- `config/openclaw/openclaw-strix-halo.json`: same
- `extensions/services/openclaw/compose.yaml`: `--bind lan` → `--bind localhost`
- `extensions/services/openclaw/compose.yaml`: port binding → `127.0.0.1:${OPENCLAW_PORT:-7860}:18789`

## Notes
Users who need remote access should use an SSH tunnel or a reverse proxy with authentication in front of port 7860. This is the standard pattern for services with local-only bindings.