### PR TITLE
fix(detection): sum VRAM across all GPUs in multi-GPU systems

### DIFF
--- a/dream-server/extensions/services/dashboard-api/gpu.py
+++ b/dream-server/extensions/services/dashboard-api/gpu.py
@@ -110,7 +110,11 @@ def get_gpu_info_amd() -> Optional[GPUInfo]:
 
 
 def get_gpu_info_nvidia() -> Optional[GPUInfo]:
-    """Get GPU metrics from nvidia-smi."""
+    """Get GPU metrics from nvidia-smi.
+
+    Handles multi-GPU systems by summing VRAM across all GPUs and
+    reporting aggregate utilization and peak temperature.
+    """
     success, output = run_command([
         "nvidia-smi",
         "--query-gpu=name,memory.used,memory.total,utilization.gpu,temperature.gpu,power.draw",
@@ -120,27 +124,78 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
     if not success or not output:
         return None
 
+    # nvidia-smi returns one line per GPU; split before parsing
+    lines = [l.strip() for l in output.strip().splitlines() if l.strip()]
+    if not lines:
+        return None
+
     try:
-        parts = [p.strip() for p in output.split(",")]
-        if len(parts) >= 5:
-            mem_used = int(parts[1])
-            mem_total = int(parts[2])
+        gpus = []
+        for line in lines:
+            parts = [p.strip() for p in line.split(",")]
+            if len(parts) < 5:
+                continue
             power_w = None
             if len(parts) >= 6 and parts[5] not in ("[N/A]", "[Not Supported]", "N/A", "Not Supported", ""):
                 try:
                     power_w = round(float(parts[5]), 1)
                 except (ValueError, TypeError):
                     pass
+            gpus.append({
+                "name": parts[0],
+                "mem_used": int(parts[1]),
+                "mem_total": int(parts[2]),
+                "util": int(parts[3]),
+                "temp": int(parts[4]),
+                "power_w": power_w,
+            })
+
+        if not gpus:
+            return None
+
+        if len(gpus) == 1:
+            g = gpus[0]
+            mem_used, mem_total = g["mem_used"], g["mem_total"]
             return GPUInfo(
-                name=parts[0],
+                name=g["name"],
                 memory_used_mb=mem_used,
                 memory_total_mb=mem_total,
                 memory_percent=round(mem_used / mem_total * 100, 1) if mem_total > 0 else 0,
-                utilization_percent=int(parts[3]),
-                temperature_c=int(parts[4]),
-                power_w=power_w,
+                utilization_percent=g["util"],
+                temperature_c=g["temp"],
+                power_w=g["power_w"],
                 gpu_backend="nvidia",
             )
+
+        # Multi-GPU: aggregate across all GPUs
+        mem_used = sum(g["mem_used"] for g in gpus)
+        mem_total = sum(g["mem_total"] for g in gpus)
+        avg_util = round(sum(g["util"] for g in gpus) / len(gpus))
+        max_temp = max(g["temp"] for g in gpus)
+        total_power: Optional[float] = None
+        power_values = [g["power_w"] for g in gpus if g["power_w"] is not None]
+        if power_values:
+            total_power = round(sum(power_values), 1)
+
+        # Build a display name: "RTX 4090 × 2" or "RTX 3090 + RTX 4090"
+        names = [g["name"] for g in gpus]
+        if len(set(names)) == 1:
+            display_name = f"{names[0]} \u00d7 {len(gpus)}"
+        else:
+            display_name = " + ".join(names[:2])
+            if len(names) > 2:
+                display_name += f" + {len(names) - 2} more"
+
+        return GPUInfo(
+            name=display_name,
+            memory_used_mb=mem_used,
+            memory_total_mb=mem_total,
+            memory_percent=round(mem_used / mem_total * 100, 1) if mem_total > 0 else 0,
+            utilization_percent=avg_util,
+            temperature_c=max_temp,
+            power_w=total_power,
+            gpu_backend="nvidia",
+        )
     except (ValueError, IndexError):
         pass
 

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -93,13 +93,28 @@ detect_gpu() {
         if raw=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) && [[ -n "$raw" ]]; then
             GPU_INFO="$raw"
             GPU_NAME=$(echo "$GPU_INFO" | head -1 | cut -d',' -f1 | xargs)
-            GPU_VRAM=$(echo "$GPU_INFO" | head -1 | cut -d',' -f2 | grep -oP '\d+' | head -1)
             GPU_COUNT=$(echo "$GPU_INFO" | wc -l)
-            # Extract PCI device ID
+            # Sum VRAM across all GPUs (each line = one GPU)
+            GPU_VRAM=$(echo "$GPU_INFO" | cut -d',' -f2 | grep -oP '\d+' | awk '{s+=$1} END {print s+0}')
+            # Extract PCI device ID from first GPU
             local pci_id
             pci_id=$(nvidia-smi --query-gpu=pci.device_id --format=csv,noheader 2>/dev/null | head -1 | xargs)
             [[ -n "$pci_id" ]] && GPU_DEVICE_ID="${pci_id:0:6}"
-            log "GPU: $GPU_NAME (${GPU_VRAM}MB VRAM) x${GPU_COUNT}"
+            if [[ $GPU_COUNT -gt 1 ]]; then
+                # Build a display name for multi-GPU (e.g. "RTX 3090 + RTX 4090" or "RTX 4090 × 2")
+                local first_name second_name
+                first_name=$(echo "$GPU_INFO" | sed -n '1p' | cut -d',' -f1 | xargs)
+                second_name=$(echo "$GPU_INFO" | sed -n '2p' | cut -d',' -f1 | xargs)
+                if [[ "$first_name" == "$second_name" ]]; then
+                    GPU_NAME="${first_name} × ${GPU_COUNT}"
+                else
+                    GPU_NAME="${first_name} + ${second_name}"
+                    [[ $GPU_COUNT -gt 2 ]] && GPU_NAME="${GPU_NAME} + $((GPU_COUNT - 2)) more"
+                fi
+                log "GPU: ${GPU_COUNT}x NVIDIA (${GPU_VRAM}MB total VRAM) — ${GPU_NAME}"
+            else
+                log "GPU: $GPU_NAME (${GPU_VRAM}MB VRAM)"
+            fi
             return 0
         fi
     fi


### PR DESCRIPTION
Fixes #55

## Problem
Both the installer and the dashboard API read only the **first GPU's VRAM** when multiple NVIDIA GPUs are present.

- `detection.sh` line 96: `head -1` before parsing — `GPU_VRAM` was always a single card's value regardless of `GPU_COUNT`
- `gpu.py`: `output.split(",")` treated the entire multi-line nvidia-smi output as one record

For a 3090 + 4090 system (48 GB combined), the installer displayed 24 GB and the dashboard showed a single GPU. The tier selection did correctly fire Tier 4 via the `GPU_COUNT >= 2` branch, but the hardware summary was misleading.

## Changes

**`installers/lib/detection.sh`**
- Switch from `head -1 | cut | grep` to `awk '{s+=$1} END {print s}'` to sum VRAM across all GPU lines
- Build a readable multi-GPU display name: `RTX 3090 + RTX 4090` or `RTX 4090 × 2` for identical cards

**`extensions/services/dashboard-api/gpu.py`**
- Split nvidia-smi output by newline before parsing
- Single GPU: identical behavior to before
- Multi-GPU: sum `mem_used`/`mem_total`, average utilization, take peak temperature, sum power draw; display name uses same logic as the installer