### PR TITLE
fix(amd): harden dashboard for AMD/Arch-based systems

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -25,5 +25,11 @@ services:
           memory: 8G
 
   dashboard-api:
+    environment:
+      # Hard-code AMD backend so the dashboard uses amd sysfs GPU detection
+      # regardless of .env state (e.g. if the installer ran without sudo
+      # and couldn't write GPU_BACKEND=amd to .env).
+      - GPU_BACKEND=amd
     volumes:
       - /sys/class/drm:/sys/class/drm:ro
+      - /sys/class/hwmon:/sys/class/hwmon:ro

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -148,6 +148,10 @@ async def check_service_health(service_id: str, config: dict) -> ServiceStatus:
             async with session.get(url) as resp:
                 response_time = (asyncio.get_event_loop().time() - start) * 1000
                 status = "healthy" if resp.status < 500 else "unhealthy"
+    except asyncio.TimeoutError:
+        # Service is reachable but slow — report degraded rather than down
+        # to avoid false "offline" flashes during startup or heavy load.
+        status = "degraded"
     except aiohttp.ClientConnectorError as e:
         if "Name or service not known" in str(e) or "nodename nor servname" in str(e):
             status = "not_deployed"


### PR DESCRIPTION
Related to #33

## Problem
Two issues observed on AMD Strix Halo with CachyOS:

**1. GPU_BACKEND not guaranteed in AMD overlay**
`docker-compose.amd.yml` relied on the installer writing `GPU_BACKEND=amd` to `.env`. If the installer ran without full sudo (as reported in #33 — no access to write sysctl tuning files), `.env` might not have this set, causing `dashboard-api` to default to `GPU_BACKEND=nvidia` and fall through to failed NVIDIA detection.

**2. Intermittent "all services offline" flashes**
`check_service_health()` caught all exceptions as `"down"`, including `asyncio.TimeoutError`. A slow-starting service (common during startup) would briefly report as fully offline rather than just slow, causing the dashboard to flash all-services-offline before recovering.

## Changes

**`docker-compose.amd.yml`**
- Hard-code `GPU_BACKEND=amd` for `dashboard-api` in the AMD overlay — always correct for AMD systems, removes `.env` dependency
- Add `/sys/class/hwmon:/sys/class/hwmon:ro` mount so AMD GPU power/temperature readings resolve correctly through sysfs symlinks inside the container (needed for `_find_hwmon_dir()` and CPU thermal zone detection)

**`extensions/services/dashboard-api/helpers.py`**
- Catch `asyncio.TimeoutError` separately and return `status="degraded"` instead of `"down"`
- Connection refused → `"down"`, DNS failure → `"not_deployed"`, timeout → `"degraded"`
- Prevents slow services from appearing fully offline during startup and heavy load