### PR TITLE
security: passive static analysis audit — 1 Critical, 3 High findings

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -28,8 +28,8 @@ The Critical finding should be addressed immediately — format-valid credential
 **Detected by:** gitleaks (generic-api-key)
 
 ```python
-API_KEY    = 'APIRUdt5f4Hp87o'
-API_SECRET = 'bTpgs0RC42jjluOevB9D64zcYhZFG7qEdU0T1m1QMNX'
+API_KEY    = 'APIRUdt****'
+API_SECRET = 'bTpgs0****'
 ```
 
 The file header reads `Deploy to: /home/michael/hvac-token-server.py`. The org contact on GitHub is `michael@lightheartlabs.com`. The credentials are format-valid:
@@ -191,7 +191,7 @@ The fallback LiveKit URL uses `ws://` (unencrypted WebSocket). All voice audio i
 
 ---
 
-### M5 — `local` keyword used outside function scope
+### M5 — `local` keyword used outside function scope *(addressed in PR #72)*
 
 **File:** `dream-server/installers/phases/11-services.sh:32-33`
 **Detected by:** shellcheck (SC2168, severity: error)


### PR DESCRIPTION
## Summary

Passive security audit of the DreamServer codebase performed with gitleaks 8.x, bandit 1.9.4, semgrep (auto config), and shellcheck. No live infrastructure was accessed — Apache 2.0 license permits full static analysis.

**Findings:**

| Severity | Count |
|----------|-------|
| Critical | 1 |
| High | 3 |
| Medium | 5 |
| Low | 2 |

### Critical — C1: Likely real LiveKit credentials committed to public repo

`resources/frameworks/voice-agent/core/hvac-token-server.py:19-20` contains format-valid LiveKit credentials (15-char API key, 43-char secret). The file header reads `Deploy to: /home/michael/hvac-token-server.py`. These match the format of real LiveKit credentials exactly and appear to be production values, not placeholders.

**Recommended action:** Rotate at console.livekit.io immediately, then purge from git history.

### High findings

- **H1:** SearXNG ships a static `secret_key` in `settings.yml` — session forgery possible on all default installs
- **H2:** `eval "$env_out"` in the installer ingests GPU metadata from nvidia-smi — command injection surface if the pipeline is influenced
- **H3:** OpenClaw `dangerouslyDisableDeviceAuth: true` still present (separate from PR #67 which fixed the binding issue)

### Medium / Low

SQL injection pattern in token-spy, containers running as root, nginx H2C smuggling conditions, insecure `ws://` WebSocket fallback, `local` keyword outside function scope (shellcheck SC2168), missing SRI on CDN scripts, missing security headers on dreamserver.ai.

## Full report

See `SECURITY_AUDIT.md` in this PR for complete findings, file locations, and remediation guidance for each item.

## Notes

- No live infrastructure was accessed or tested
- The C1 credential finding is a responsible disclosure — recommend rotating before merging/publicizing
- PRs #67–#70 from this contributor address several of the High findings directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)