### PR TITLE
Security hardening and installer resilience audit (#72)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ dream-server/.claude/
 dream-server/.pytest_cache/
 dream-server/tests/__pycache__/
 dream-server/internal/
+
+# ============================================
+# Archived / deprecated code (pre-v2.0)
+# ============================================
+archive/

--- a/dream-server/dream-backup.sh
+++ b/dream-server/dream-backup.sh
@@ -20,6 +20,7 @@ NC='\033[0m' # No Color
 
 # Prerequisites check
 command -v rsync >/dev/null 2>&1 || { echo -e "${RED}Error: rsync is required but not installed.${NC}" >&2; echo "Install with: apt install rsync (Debian/Ubuntu) or brew install rsync (macOS)" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo -e "${RED}Error: jq is required but not installed.${NC}" >&2; echo "Install with: apt install jq (Debian/Ubuntu) or brew install jq (macOS)" >&2; exit 1; }
 
 # Logging functions
 log_info() { echo -e "${BLUE}[INFO]${NC} $*"; }
@@ -126,31 +127,42 @@ create_manifest() {
     local version
     version=$(cat "$DREAM_DIR/.version" 2>/dev/null || echo "unknown")
 
-    cat > "$backup_dir/manifest.json" << EOF
-{
-  "manifest_version": "1.0",
-  "backup_date": "$(date -Iseconds)",
-  "backup_id": "$(basename "$backup_dir")",
-  "backup_type": "$backup_type",
-  "dream_version": "$version",
-  "hostname": "$(hostname)",
-  "description": "$description",
-  "contents": {
-    "user_data": $( [[ "$backup_type" == "full" || "$backup_type" == "user-data" ]] && echo "true" || echo "false" ),
-    "config": $( [[ "$backup_type" == "full" || "$backup_type" == "config" ]] && echo "true" || echo "false" ),
-    "cache": $( [[ "$backup_type" == "full" ]] && echo "true" || echo "false" )
-  },
-  "paths": {
-    "data_open_webui": "data/open-webui",
-    "data_n8n": "data/n8n",
-    "data_qdrant": "data/qdrant",
-    "data_openclaw": "data/openclaw",
-    "env": ".env",
-    "compose": "docker-compose.yml",
-    "config": "config"
-  }
-}
-EOF
+    # Use jq to safely construct JSON (prevents injection via $description)
+    local has_user_data="false" has_config="false" has_cache="false"
+    [[ "$backup_type" == "full" || "$backup_type" == "user-data" ]] && has_user_data="true"
+    [[ "$backup_type" == "full" || "$backup_type" == "config" ]] && has_config="true"
+    [[ "$backup_type" == "full" ]] && has_cache="true"
+
+    jq -n \
+        --arg mv "1.0" \
+        --arg bd "$(date -Iseconds)" \
+        --arg bi "$(basename "$backup_dir")" \
+        --arg bt "$backup_type" \
+        --arg dv "$version" \
+        --arg hn "$(hostname)" \
+        --arg desc "$description" \
+        --argjson ud "$has_user_data" \
+        --argjson cfg "$has_config" \
+        --argjson ca "$has_cache" \
+        '{
+          manifest_version: $mv,
+          backup_date: $bd,
+          backup_id: $bi,
+          backup_type: $bt,
+          dream_version: $dv,
+          hostname: $hn,
+          description: $desc,
+          contents: { user_data: $ud, config: $cfg, cache: $ca },
+          paths: {
+            data_open_webui: "data/open-webui",
+            data_n8n: "data/n8n",
+            data_qdrant: "data/qdrant",
+            data_openclaw: "data/openclaw",
+            env: ".env",
+            compose: "docker-compose.yml",
+            config: "config"
+          }
+        }' > "$backup_dir/manifest.json"
     log_info "Created backup manifest"
 }
 

--- a/dream-server/dream-preflight.sh
+++ b/dream-server/dream-preflight.sh
@@ -10,10 +10,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DREAM_DIR="$SCRIPT_DIR"
 LOG_FILE="$DREAM_DIR/preflight-$(date +%Y%m%d-%H%M%S).log"
 
-# Load config from .env if available
+# Load config from .env safely (line-by-line, no eval/source)
 if [ -f "$DREAM_DIR/.env" ]; then
-    # shellcheck source=/dev/null
-    source "$DREAM_DIR/.env" 2>/dev/null || true
+    while IFS='=' read -r key value; do
+        # Skip comments and empty lines
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$key" ]] && continue
+        # Only allow safe variable names
+        key=$(echo "$key" | xargs)  # trim whitespace
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        # Strip surrounding quotes from value
+        value="${value%\"}" && value="${value#\"}"
+        value="${value%\'}" && value="${value#\'}"
+        export "$key=$value"
+    done < "$DREAM_DIR/.env"
 fi
 SERVICE_HOST="${SERVICE_HOST:-localhost}"
 

--- a/dream-server/dream-restore.sh
+++ b/dream-server/dream-restore.sh
@@ -150,9 +150,18 @@ extract_backup() {
     fi
 
     if [[ -f "$compressed" ]]; then
+        # Validate: reject archives with absolute paths or path traversal
+        if tar -tzf "$compressed" 2>/dev/null | grep -qE '(^/|\.\./)'; then
+            log_error "Backup archive contains unsafe paths (absolute or ../) — refusing to extract"
+            return 1
+        fi
         log_info "Extracting compressed backup..."
         mkdir -p "$uncompressed"
-        tar xzf "$compressed" -C "$BACKUP_ROOT"
+        if ! tar xzf "$compressed" --no-same-owner -C "$BACKUP_ROOT"; then
+            log_error "Failed to extract backup archive"
+            rm -rf "$uncompressed"
+            return 1
+        fi
         echo "$uncompressed"
         return 0
     fi

--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# dream-uninstall.sh - Dream Server Clean Uninstaller
+# Removes all Dream Server components, data, and system modifications.
+# Usage: ./dream-uninstall.sh [--keep-models] [--keep-data] [--force]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/dream-server}"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log_info()  { echo -e "${BLUE}[INFO]${NC} $*"; }
+log_ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
+log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+KEEP_MODELS=false
+KEEP_DATA=false
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --keep-models) KEEP_MODELS=true; shift ;;
+        --keep-data)   KEEP_DATA=true; shift ;;
+        --force)       FORCE=true; shift ;;
+        -h|--help)
+            cat << EOF
+Dream Server Uninstaller
+
+Usage: $(basename "$0") [OPTIONS]
+
+Options:
+    --keep-models   Keep downloaded AI models (saves re-download time)
+    --keep-data     Keep user data (chat history, n8n workflows, etc.)
+    --force         Skip confirmation prompts
+    -h, --help      Show this help
+
+This will remove:
+    - Docker containers, images, and volumes for Dream Server
+    - Installation directory ($INSTALL_DIR)
+    - Systemd user services (opencode-web, openclaw timers)
+    - CLI symlink (/usr/local/bin/dream-cli)
+    - Backup directory (~/.dream-server)
+
+EOF
+            exit 0
+            ;;
+        *) log_error "Unknown option: $1"; exit 1 ;;
+    esac
+done
+
+echo ""
+echo -e "${RED}╔══════════════════════════════════════════════════╗${NC}"
+echo -e "${RED}║         DREAM SERVER UNINSTALLER                ║${NC}"
+echo -e "${RED}╚══════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# Detect install dir
+if [[ -d "$SCRIPT_DIR" && -f "$SCRIPT_DIR/dream-cli" ]]; then
+    INSTALL_DIR="$SCRIPT_DIR"
+fi
+
+if [[ ! -d "$INSTALL_DIR" ]]; then
+    log_error "Install directory not found: $INSTALL_DIR"
+    exit 1
+fi
+
+log_info "Install directory: $INSTALL_DIR"
+$KEEP_MODELS && log_info "Keeping models (--keep-models)"
+$KEEP_DATA && log_info "Keeping user data (--keep-data)"
+echo ""
+
+if [[ "$FORCE" != "true" ]]; then
+    echo -e "${YELLOW}This will permanently remove Dream Server and its components.${NC}"
+    read -rp "Are you sure? Type 'yes' to confirm: " confirm
+    if [[ "$confirm" != "yes" ]]; then
+        log_info "Uninstall cancelled."
+        exit 0
+    fi
+    echo ""
+fi
+
+# 1. Stop and remove Docker containers
+log_info "Stopping Docker containers..."
+cd "$INSTALL_DIR" 2>/dev/null || true
+if command -v docker &>/dev/null; then
+    # Try docker compose first, fall back to finding dream containers
+    docker compose down --remove-orphans 2>/dev/null || true
+
+    # Remove any remaining dream-* containers
+    dream_containers=$(docker ps -a --filter "name=dream-" --format "{{.Names}}" 2>/dev/null || true)
+    if [[ -n "$dream_containers" ]]; then
+        log_info "Removing Dream Server containers..."
+        echo "$dream_containers" | xargs -r docker rm -f 2>/dev/null || true
+    fi
+
+    # Remove dream-specific Docker volumes
+    dream_volumes=$(docker volume ls --filter "name=dream" --format "{{.Name}}" 2>/dev/null || true)
+    if [[ -n "$dream_volumes" ]]; then
+        log_info "Removing Docker volumes..."
+        echo "$dream_volumes" | xargs -r docker volume rm 2>/dev/null || true
+    fi
+
+    log_ok "Docker cleanup complete"
+else
+    log_warn "Docker not found — skipping container cleanup"
+fi
+
+# 2. Stop and remove systemd user services
+log_info "Removing systemd user services..."
+SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
+for unit in opencode-web.service openclaw-session-cleanup.timer openclaw-session-manager.timer \
+            memory-shepherd-workspace.timer memory-shepherd-memory.timer \
+            openclaw-session-cleanup.service openclaw-session-manager.service \
+            memory-shepherd-workspace.service memory-shepherd-memory.service; do
+    if [[ -f "$SYSTEMD_USER_DIR/$unit" ]]; then
+        systemctl --user disable --now "$unit" 2>/dev/null || true
+        rm -f "$SYSTEMD_USER_DIR/$unit"
+    fi
+done
+systemctl --user daemon-reload 2>/dev/null || true
+log_ok "Systemd services removed"
+
+# 3. Remove CLI symlink
+if [[ -L "/usr/local/bin/dream-cli" ]]; then
+    log_info "Removing CLI symlink..."
+    sudo rm -f /usr/local/bin/dream-cli 2>/dev/null || rm -f /usr/local/bin/dream-cli 2>/dev/null || true
+    log_ok "CLI symlink removed"
+fi
+
+# 4. Remove desktop file
+DESKTOP_FILE="$HOME/.local/share/applications/dream-server.desktop"
+if [[ -f "$DESKTOP_FILE" ]]; then
+    rm -f "$DESKTOP_FILE"
+    log_ok "Desktop entry removed"
+fi
+
+# 5. Remove install directory (with optional data/model preservation)
+log_info "Removing installation directory..."
+if $KEEP_MODELS && [[ -d "$INSTALL_DIR/data/models" ]]; then
+    MODELS_BACKUP="$HOME/.dream-server-models-backup"
+    mkdir -p "$MODELS_BACKUP"
+    mv "$INSTALL_DIR/data/models"/* "$MODELS_BACKUP/" 2>/dev/null || true
+    log_info "Models preserved at: $MODELS_BACKUP"
+fi
+
+if $KEEP_DATA; then
+    # Remove everything except data/
+    find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 ! -name 'data' -exec rm -rf {} + 2>/dev/null || true
+    log_info "User data preserved at: $INSTALL_DIR/data/"
+else
+    rm -rf "$INSTALL_DIR"
+fi
+log_ok "Installation directory cleaned"
+
+# 6. Remove backup directory
+if [[ -d "$HOME/.dream-server" ]]; then
+    log_info "Removing backup directory..."
+    rm -rf "$HOME/.dream-server"
+    log_ok "Backups removed"
+fi
+
+# 7. Remove OpenCode config (if we created it)
+OPENCODE_CONFIG="$HOME/.config/opencode/opencode.json"
+if [[ -f "$OPENCODE_CONFIG" ]] && grep -q "llama-server" "$OPENCODE_CONFIG" 2>/dev/null; then
+    rm -f "$OPENCODE_CONFIG"
+    log_ok "OpenCode config removed"
+fi
+
+echo ""
+echo -e "${GREEN}╔══════════════════════════════════════════════════╗${NC}"
+echo -e "${GREEN}║     Dream Server has been uninstalled.           ║${NC}"
+echo -e "${GREEN}╚══════════════════════════════════════════════════╝${NC}"
+echo ""
+if $KEEP_MODELS; then
+    echo "Your models were saved to: $HOME/.dream-server-models-backup"
+    echo "To reuse them on reinstall, move them back to ~/dream-server/data/models/"
+fi
+if $KEEP_DATA; then
+    echo "Your user data was preserved at: $INSTALL_DIR/data/"
+fi

--- a/dream-server/dream-update.sh
+++ b/dream-server/dream-update.sh
@@ -12,6 +12,9 @@
 
 set -euo pipefail
 
+# Prerequisites
+command -v jq >/dev/null 2>&1 || { echo "Error: jq is required but not installed." >&2; echo "Install with: apt install jq (Debian/Ubuntu) or brew install jq (macOS)" >&2; exit 1; }
+
 #==============================================================================
 # CONFIGURATION
 #==============================================================================
@@ -94,13 +97,13 @@ cmd_check() {
     
     # Fetch latest release from GitHub
     local api_url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
-    local auth_header=""
-    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
-        auth_header="-H \"Authorization: Bearer ${GITHUB_TOKEN}\""
-    fi
-    
     local response
-    if ! response=$(curl -sf ${auth_header} "${api_url}" 2>/dev/null); then
+    local curl_args=(-sf)
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        curl_args+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    fi
+
+    if ! response=$(curl "${curl_args[@]}" "${api_url}" 2>/dev/null); then
         log_error "Failed to check for updates. Check network or GITHUB_TOKEN."
         return 1
     fi
@@ -221,16 +224,15 @@ cmd_backup() {
         ((files_backed_up++))
     fi
     
-    # Generate metadata
-    cat > "$backup_path/metadata.json" << EOF
-{
-    "backup_id": "${backup_id}",
-    "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-    "version": "$(get_current_version)",
-    "files_count": ${files_backed_up},
-    "install_dir": "${INSTALL_DIR}"
-}
-EOF
+    # Generate metadata (use jq for safe JSON construction)
+    jq -n \
+        --arg bid "$backup_id" \
+        --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        --arg ver "$(get_current_version)" \
+        --argjson fc "$files_backed_up" \
+        --arg dir "$INSTALL_DIR" \
+        '{backup_id: $bid, timestamp: $ts, version: $ver, files_count: $fc, install_dir: $dir}' \
+        > "$backup_path/metadata.json"
     
     log_ok "Backup created: ${backup_path}"
     log_info "Files backed up: ${files_backed_up}"

--- a/dream-server/extensions/services/dashboard/entrypoint.sh
+++ b/dream-server/extensions/services/dashboard/entrypoint.sh
@@ -24,9 +24,11 @@ fi
 # We need to substitute it with the actual value
 if [ -n "$API_KEY" ]; then
     echo "[dashboard] Configuring nginx with API key auth injection"
+    # Escape sed special characters in the API key to prevent injection
+    ESCAPED_KEY=$(printf '%s\n' "$API_KEY" | sed 's/[&/\]/\\&/g')
     # Replace the placeholder (envsubst already ran, but may have left empty value)
-    sed -i "s|Bearer \${DASHBOARD_API_KEY}|Bearer $API_KEY|g" "$NGINX_CONF"
-    sed -i "s|Bearer \"\"|Bearer \"$API_KEY\"|g" "$NGINX_CONF"
+    sed -i "s|Bearer \${DASHBOARD_API_KEY}|Bearer ${ESCAPED_KEY}|g" "$NGINX_CONF"
+    sed -i "s|Bearer \"\"|Bearer \"${ESCAPED_KEY}\"|g" "$NGINX_CONF"
 else
     echo "[dashboard] WARNING: No DASHBOARD_API_KEY found in env or $KEY_FILE"
     echo "[dashboard] API calls will fail with 401 until key is configured"

--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -17,6 +17,27 @@
 set -e
 
 #=============================================================================
+# Cleanup on Failure
+#=============================================================================
+# Track what phases have completed so we can provide useful context on failure.
+export INSTALL_PHASE="init"
+cleanup_on_error() {
+    local exit_code=$?
+    echo ""
+    echo -e "\033[0;31m[ERROR] Installation failed during phase: ${INSTALL_PHASE}\033[0m"
+    echo -e "\033[0;33m        Log file: ${LOG_FILE:-/tmp/dream-server-install.log}\033[0m"
+    echo ""
+    echo "The install did not complete. Partial state may exist at:"
+    echo "  ${INSTALL_DIR:-~/dream-server}"
+    echo ""
+    echo "To retry, run the installer again. It will resume safely."
+    echo "To start fresh, remove the install directory first:"
+    echo "  rm -rf ${INSTALL_DIR:-~/dream-server} && ./install.sh"
+    exit "$exit_code"
+}
+trap cleanup_on_error ERR
+
+#=============================================================================
 # Interrupt Protection
 #=============================================================================
 # Accidental keypresses (Ctrl+C, Ctrl+Z) shouldn't silently kill the install.
@@ -143,16 +164,16 @@ $DRY_RUN && echo -e "${AMB}>>> DRY RUN MODE — I will simulate everything. No c
 #=============================================================================
 # Run phases
 #=============================================================================
-source "$SCRIPT_DIR/installers/phases/01-preflight.sh"
-source "$SCRIPT_DIR/installers/phases/02-detection.sh"
-source "$SCRIPT_DIR/installers/phases/03-features.sh"
-source "$SCRIPT_DIR/installers/phases/04-requirements.sh"
-source "$SCRIPT_DIR/installers/phases/05-docker.sh"
-source "$SCRIPT_DIR/installers/phases/06-directories.sh"
-source "$SCRIPT_DIR/installers/phases/07-devtools.sh"
-source "$SCRIPT_DIR/installers/phases/08-images.sh"
-source "$SCRIPT_DIR/installers/phases/09-offline.sh"
-source "$SCRIPT_DIR/installers/phases/10-amd-tuning.sh"
-source "$SCRIPT_DIR/installers/phases/11-services.sh"
-source "$SCRIPT_DIR/installers/phases/12-health.sh"
-source "$SCRIPT_DIR/installers/phases/13-summary.sh"
+INSTALL_PHASE="01-preflight";    source "$SCRIPT_DIR/installers/phases/01-preflight.sh"
+INSTALL_PHASE="02-detection";    source "$SCRIPT_DIR/installers/phases/02-detection.sh"
+INSTALL_PHASE="03-features";     source "$SCRIPT_DIR/installers/phases/03-features.sh"
+INSTALL_PHASE="04-requirements"; source "$SCRIPT_DIR/installers/phases/04-requirements.sh"
+INSTALL_PHASE="05-docker";       source "$SCRIPT_DIR/installers/phases/05-docker.sh"
+INSTALL_PHASE="06-directories";  source "$SCRIPT_DIR/installers/phases/06-directories.sh"
+INSTALL_PHASE="07-devtools";     source "$SCRIPT_DIR/installers/phases/07-devtools.sh"
+INSTALL_PHASE="08-images";       source "$SCRIPT_DIR/installers/phases/08-images.sh"
+INSTALL_PHASE="09-offline";      source "$SCRIPT_DIR/installers/phases/09-offline.sh"
+INSTALL_PHASE="10-amd-tuning";   source "$SCRIPT_DIR/installers/phases/10-amd-tuning.sh"
+INSTALL_PHASE="11-services";     source "$SCRIPT_DIR/installers/phases/11-services.sh"
+INSTALL_PHASE="12-health";       source "$SCRIPT_DIR/installers/phases/12-health.sh"
+INSTALL_PHASE="13-summary";      source "$SCRIPT_DIR/installers/phases/13-summary.sh"

--- a/dream-server/installers/phases/04-requirements.sh
+++ b/dream-server/installers/phases/04-requirements.sh
@@ -122,12 +122,21 @@ else
 fi
 
 # Port availability check (handles IPv4 and IPv6)
+_port_check_warned=false
 check_port() {
     local port=$1
     if command -v ss &> /dev/null; then
         ss -tln 2>/dev/null | grep -qE ":${port}(\s|$)" && return 1
     elif command -v netstat &> /dev/null; then
         netstat -tln 2>/dev/null | grep -qE ":${port}(\s|$)" && return 1
+    else
+        # Neither tool available — warn once, then skip port checks
+        if [[ "$_port_check_warned" != "true" ]]; then
+            warn "Neither 'ss' nor 'netstat' found — cannot verify port availability"
+            warn "Install iproute2 (for ss) or net-tools (for netstat) to enable port checks"
+            _port_check_warned=true
+        fi
+        return 0  # Can't check, assume free but user is warned
     fi
     return 0
 }

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -88,9 +88,13 @@ else
         OPENCLAW_PROVIDER_URL="${OPENCLAW_PROVIDER_URL_DEFAULT}"
 
         # Replace model and provider placeholders to match what the inference backend actually serves
-        sed -i "s|__LLM_MODEL__|${OPENCLAW_MODEL}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
-        sed -i "s|Qwen/Qwen2.5-[^\"]*|${OPENCLAW_MODEL}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
-        sed -i "s|local-ollama|${OPENCLAW_PROVIDER_NAME}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
+        # Escape sed special chars in variable values to prevent injection
+        _sed_escape() { printf '%s\n' "$1" | sed 's/[&/\]/\\&/g'; }
+        _oc_model_esc=$(_sed_escape "$OPENCLAW_MODEL")
+        _oc_prov_esc=$(_sed_escape "$OPENCLAW_PROVIDER_NAME")
+        sed -i "s|__LLM_MODEL__|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
+        sed -i "s|Qwen/Qwen2.5-[^\"]*|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
+        sed -i "s|local-ollama|${_oc_prov_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
         log "Installed OpenClaw config: $OPENCLAW_CONFIG -> openclaw.json (model: $OPENCLAW_MODEL)"
         mkdir -p "$INSTALL_DIR/data/openclaw/home/agents/main/sessions"
         # Generate OpenClaw home config with local llama-server provider
@@ -206,13 +210,44 @@ MODELS_EOF
         chown -R 1000:1000 "$INSTALL_DIR/data/openclaw" "$INSTALL_DIR/config/openclaw/workspace" 2>/dev/null || true
     fi
 
-    # Generate secure secrets
-    WEBUI_SECRET=$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)
-    N8N_PASS=$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)
-    LITELLM_KEY="sk-dream-$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)"
-    LIVEKIT_SECRET=$(openssl rand -base64 32 2>/dev/null || head -c 32 /dev/urandom | base64)
-    DASHBOARD_API_KEY=$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)
-    OPENCODE_SERVER_PASSWORD=
+    # ── .env merge logic: preserve user-configured values on re-install ──
+    # If an existing .env exists, read user-editable values so we don't
+    # destroy API keys, custom ports, or manually-set secrets.
+    _env_existing=""
+    if [[ -f "$INSTALL_DIR/.env" ]]; then
+        _env_existing="$INSTALL_DIR/.env"
+        log "Found existing .env — preserving user-configured values"
+    fi
+
+    # Safe reader: extract a value from existing .env without sourcing it
+    _env_get() {
+        local key="$1" default="${2:-}"
+        if [[ -n "$_env_existing" ]]; then
+            local val
+            val=$(grep -m1 "^${key}=" "$_env_existing" 2>/dev/null | cut -d= -f2- || true)
+            # Strip surrounding quotes
+            val="${val%\"}" && val="${val#\"}"
+            val="${val%\'}" && val="${val#\'}"
+            if [[ -n "$val" ]]; then
+                echo "$val"
+                return
+            fi
+        fi
+        echo "$default"
+    }
+
+    # Secrets: reuse existing values, generate only if missing
+    WEBUI_SECRET=$(_env_get WEBUI_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
+    N8N_PASS=$(_env_get N8N_PASS "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
+    LITELLM_KEY=$(_env_get LITELLM_KEY "sk-dream-$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LIVEKIT_SECRET=$(_env_get LIVEKIT_API_SECRET "$(openssl rand -base64 32 2>/dev/null || head -c 32 /dev/urandom | base64)")
+    DASHBOARD_API_KEY=$(_env_get DASHBOARD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
+    OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "")
+
+    # Preserve user-supplied cloud API keys
+    ANTHROPIC_API_KEY=$(_env_get ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}")
+    OPENAI_API_KEY=$(_env_get OPENAI_API_KEY "${OPENAI_API_KEY:-}")
+    TOGETHER_API_KEY=$(_env_get TOGETHER_API_KEY "${TOGETHER_API_KEY:-}")
 
     # Generate .env file
     cat > "$INSTALL_DIR/.env" << ENV_EOF
@@ -235,7 +270,6 @@ GGUF_FILE=${GGUF_FILE}
 MAX_CONTEXT=${MAX_CONTEXT}
 CTX_SIZE=${MAX_CONTEXT}
 GPU_BACKEND=${GPU_BACKEND}
-LLAMA_SERVER_PORT=8080
 
 $(if [[ "$GPU_BACKEND" == "amd" ]]; then cat << AMD_ENV
 #=== GPU Group IDs (for container device access) ===
@@ -266,7 +300,7 @@ DASHBOARD_API_KEY=${DASHBOARD_API_KEY}
 N8N_USER=admin
 N8N_PASS=${N8N_PASS}
 LITELLM_KEY=${LITELLM_KEY}
-LIVEKIT_API_KEY=$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)
+LIVEKIT_API_KEY=$(_env_get LIVEKIT_API_KEY "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
 LIVEKIT_API_SECRET=${LIVEKIT_SECRET}
 OPENCLAW_TOKEN=${OPENCLAW_TOKEN:-$(openssl rand -hex 24 2>/dev/null || head -c 24 /dev/urandom | xxd -p)}
 OPENCODE_SERVER_PASSWORD=${OPENCODE_SERVER_PASSWORD}

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -128,8 +128,11 @@ OPENCODE_EOF
 
             svc_tmp="/tmp/opencode-web.service.$$"
             cp "$INSTALL_DIR/opencode/opencode-web.service" "$svc_tmp"
-            sed -i "s|__HOME__|$HOME|g" "$svc_tmp"
-            sed -i "s|__OPENCODE_SERVER_PASSWORD__|${OPENCODE_SERVER_PASSWORD}|g" "$svc_tmp"
+            # Escape sed special chars to prevent injection from path or password values
+            _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&/\]/\\&/g')
+            _pass_esc=$(printf '%s\n' "${OPENCODE_SERVER_PASSWORD}" | sed 's/[&/\]/\\&/g')
+            sed -i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
+            sed -i "s|__OPENCODE_SERVER_PASSWORD__|${_pass_esc}|g" "$svc_tmp"
             cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
             rm -f "$svc_tmp"
 

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -29,8 +29,8 @@ else
     if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
         ai "Cloud mode — skipping model download"
         # Auto-enable litellm extension
-        local litellm_cf="$INSTALL_DIR/extensions/services/litellm/compose.yaml"
-        local litellm_disabled="${litellm_cf}.disabled"
+        litellm_cf="$INSTALL_DIR/extensions/services/litellm/compose.yaml"
+        litellm_disabled="${litellm_cf}.disabled"
         if [[ -f "$litellm_disabled" && ! -f "$litellm_cf" ]]; then
             mv "$litellm_disabled" "$litellm_cf"
             ai_ok "Auto-enabled litellm for cloud mode"
@@ -40,24 +40,34 @@ else
     # Ensure model directory exists
     mkdir -p "$INSTALL_DIR/data/models"
 
-    # Download GGUF model if not already present
+    # Download GGUF model if not already present (with retry)
     GGUF_DIR="$INSTALL_DIR/data/models"
     if [[ "${DREAM_MODE:-local}" != "cloud" && ! -f "$GGUF_DIR/$GGUF_FILE" && -n "$GGUF_URL" ]]; then
         ai "Downloading GGUF model: $GGUF_FILE"
         signal "This is the big one. I've got it — sit back."
         echo ""
 
-        # Run wget in background, pipe through spin_task for clean UI
-        wget -c -q -O "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_URL" \
-            >> "$INSTALL_DIR/logs/model-download.log" 2>&1 &
-        dl_pid=$!
+        # Retry loop: up to 3 attempts with resume support (-c flag)
+        _dl_success=false
+        for _attempt in 1 2 3; do
+            [[ $_attempt -gt 1 ]] && ai "Retry attempt $_attempt of 3..."
+            wget -c -q -O "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_URL" \
+                >> "$INSTALL_DIR/logs/model-download.log" 2>&1 &
+            dl_pid=$!
 
-        if spin_task $dl_pid "Downloading $GGUF_FILE"; then
-            mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE"
-            printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
-        else
-            printf "\r  ${RED}✗${NC} %-60s\n" "Download failed: $GGUF_FILE"
-            ai "Retry: wget -c -O '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_URL' && mv '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_DIR/$GGUF_FILE'"
+            if spin_task $dl_pid "Downloading $GGUF_FILE"; then
+                mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE"
+                printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
+                _dl_success=true
+                break
+            fi
+            printf "\r  ${AMB}⚠${NC} %-60s\n" "Download attempt $_attempt failed"
+            sleep 3
+        done
+
+        if [[ "$_dl_success" != "true" ]]; then
+            printf "\r  ${RED}✗${NC} %-60s\n" "Download failed after 3 attempts: $GGUF_FILE"
+            ai "Manual retry: wget -c -O '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_URL' && mv '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_DIR/$GGUF_FILE'"
         fi
     elif [[ -f "$GGUF_DIR/$GGUF_FILE" ]]; then
         ai_ok "GGUF model already present: $GGUF_FILE"

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -41,12 +41,20 @@ ai "Linking services... standby."
 
 sleep 5
 
-# Health checks are best-effort — don't let set -e kill the script if a service is slow
+# Health checks are best-effort — track failures but don't let set -e kill the install.
+# Services may need more startup time; we report all failures at the end.
+HEALTH_FAILURES=0
+_check_health() {
+    if ! check_service "$@"; then
+        HEALTH_FAILURES=$((HEALTH_FAILURES + 1))
+    fi
+}
+
 # Core service health checks
-check_service "llama-server" "http://localhost:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 120 || true
-check_service "Open WebUI" "http://localhost:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 60 || true
-check_service "Perplexica" "http://localhost:${SERVICE_PORTS[perplexica]:-3004}${SERVICE_HEALTH[perplexica]:-/}" 30 || true
-check_service "ComfyUI" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 120 || true
+_check_health "llama-server" "http://localhost:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 120
+_check_health "Open WebUI" "http://localhost:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 60
+_check_health "Perplexica" "http://localhost:${SERVICE_PORTS[perplexica]:-3004}${SERVICE_HEALTH[perplexica]:-/}" 30
+_check_health "ComfyUI" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 120
 
 # Perplexica auto-config: seed chat model + embedding model on first boot.
 # The slim-latest image stores config in a database, not just config.json.
@@ -101,10 +109,10 @@ print('ok')
     fi
 fi
 
-[[ "$ENABLE_OPENCLAW" == "true" ]] && check_service "OpenClaw" "http://localhost:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 30 || true
-systemctl is-active opencode-web &>/dev/null && check_service "OpenCode Web" "http://localhost:3003/" 10 || true
-[[ "$ENABLE_VOICE" == "true" ]] && check_service "Whisper (STT)" "http://localhost:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 60 || true
-[[ "$ENABLE_VOICE" == "true" ]] && check_service "Kokoro (TTS)" "http://localhost:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 30 || true
+[[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://localhost:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 30
+systemctl is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://localhost:3003/" 10
+[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://localhost:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 60
+[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Kokoro (TTS)" "http://localhost:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 30
 
 # Pre-download the Whisper STT model so first transcription is instant.
 # Speaches lazy-downloads on first request, but that causes a long delay +
@@ -128,9 +136,15 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     fi
 fi
 
-[[ "$ENABLE_WORKFLOWS" == "true" ]] && check_service "n8n" "http://localhost:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 30 || true
-[[ "$ENABLE_RAG" == "true" ]] && check_service "Qdrant" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 30 || true
+[[ "$ENABLE_WORKFLOWS" == "true" ]] && _check_health "n8n" "http://localhost:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 30
+[[ "$ENABLE_RAG" == "true" ]] && _check_health "Qdrant" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 30
 
 echo ""
-signal "All systems nominal."
-ai_ok "Sovereign intelligence is online."
+if [[ "$HEALTH_FAILURES" -gt 0 ]]; then
+    ai_warn "${HEALTH_FAILURES} service(s) did not pass health checks."
+    ai_warn "Some services may still be starting. Check with: dream status"
+    ai_warn "Logs: docker compose logs <service-name>"
+else
+    signal "All systems nominal."
+    ai_ok "Sovereign intelligence is online."
+fi


### PR DESCRIPTION
- Prevent .env overwrite on re-install: _env_get() merges existing user secrets/API keys instead of regenerating them
- Add ERR trap with phase tracking to install-core.sh for actionable failure diagnostics
- Replace unsafe `source .env` with line-by-line parser in dream-preflight.sh
- Fix sed injection in 4 files (dashboard entrypoint, 06-directories, 07-devtools) by escaping special characters before substitution
- Fix JSON injection in dream-backup.sh and dream-update.sh by using jq --arg instead of heredoc interpolation
- Add tar path traversal protection in dream-restore.sh
- Fix curl auth header quoting in dream-update.sh (array instead of string)
- Add jq prerequisite check to dream-backup.sh and dream-update.sh
- Add model download retry (3 attempts with resume) in 11-services.sh
- Fix `local` keyword used outside function in 11-services.sh
- Track health check failures with counter instead of swallowing via || true
- Add port check fallback warning when ss/netstat missing
- Remove duplicate LLAMA_SERVER_PORT from generated .env
- Preserve LIVEKIT_API_KEY on re-install via _env_get
- Add dream-uninstall.sh for clean removal
- Add archive/ to .gitignore