### PR TITLE
fix: make installer idempotent — re-run to update/repair

### DIFF
--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -3,9 +3,9 @@
 # Dream Server Installer — Phase 01: Pre-flight Checks
 # ============================================================================
 # Part of: installers/phases/
-# Purpose: Root/OS/tools checks, existing installation check
+# Purpose: Root/OS/tools checks, existing installation detection
 #
-# Expects: SCRIPT_DIR, INSTALL_DIR, LOG_FILE, INTERACTIVE, DRY_RUN, FORCE,
+# Expects: SCRIPT_DIR, INSTALL_DIR, LOG_FILE, INTERACTIVE, DRY_RUN,
 #           PKG_MANAGER,
 #           show_phase(), ai(), ai_ok(), signal(), log(), warn(), error()
 # Provides: OS sourced from /etc/os-release, OPTIONAL_TOOLS_MISSING
@@ -65,21 +65,10 @@ if [[ ! -f "$SCRIPT_DIR/docker-compose.yml" ]] && [[ ! -f "$SCRIPT_DIR/docker-co
     error "No compose files found in $SCRIPT_DIR. Please run from the dream-server directory."
 fi
 
-# Check for existing installation
-if [[ -d "$INSTALL_DIR" && "$FORCE" != "true" ]]; then
-    if $INTERACTIVE && ! $DRY_RUN; then
-        warn "Existing installation found at $INSTALL_DIR"
-        read -p "  Overwrite and start fresh? [y/N] " -r
-        if [[ $REPLY =~ ^[Yy]$ ]]; then
-            log "User chose to overwrite existing installation"
-            FORCE=true
-        else
-            log "User chose not to overwrite. Exiting."
-            exit 0
-        fi
-    else
-        error "Installation already exists at $INSTALL_DIR. Use --force to overwrite."
-    fi
+# Existing installation — update in place (secrets and data are preserved)
+if [[ -d "$INSTALL_DIR" ]]; then
+    log "Existing installation found at $INSTALL_DIR — updating in place"
+    signal "Existing install detected. Secrets and data will be preserved."
 fi
 
 ai_ok "Pre-flight checks passed."

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -78,15 +78,34 @@ function New-DreamEnv {
         [string]$LlamaServerImage = ""
     )
 
-    # Generate secrets
-    $webuiSecret     = New-SecureHex -Bytes 32
-    $n8nPass         = New-SecureBase64 -Bytes 16
-    $litellmKey      = "sk-dream-$(New-SecureHex -Bytes 16)"
-    $livekitSecret   = New-SecureBase64 -Bytes 32
-    $livekitApiKey   = New-SecureHex -Bytes 16
-    $dashboardApiKey = New-SecureHex -Bytes 32
-    $openclawToken   = New-SecureHex -Bytes 24
-    $searxngSecret   = New-SecureHex -Bytes 32
+    # Preserve existing secrets on re-install (mirrors Linux _env_get logic)
+    $existingEnv = @{}
+    $envPath = Join-Path $InstallDir ".env"
+    if (Test-Path $envPath) {
+        Get-Content $envPath | ForEach-Object {
+            if ($_ -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
+                $existingEnv[$Matches[1]] = $Matches[2]
+            }
+        }
+    }
+
+    # Helper: reuse existing value or generate new
+    function Get-EnvOrNew { param([string]$Key, [string]$Default)
+        if ($existingEnv.ContainsKey($Key) -and $existingEnv[$Key]) {
+            return $existingEnv[$Key]
+        }
+        return $Default
+    }
+
+    # Generate secrets (reuse existing on re-install)
+    $webuiSecret     = Get-EnvOrNew "WEBUI_SECRET"       (New-SecureHex -Bytes 32)
+    $n8nPass         = Get-EnvOrNew "N8N_PASS"           (New-SecureBase64 -Bytes 16)
+    $litellmKey      = Get-EnvOrNew "LITELLM_KEY"        "sk-dream-$(New-SecureHex -Bytes 16)"
+    $livekitSecret   = Get-EnvOrNew "LIVEKIT_API_SECRET" (New-SecureBase64 -Bytes 32)
+    $livekitApiKey   = Get-EnvOrNew "LIVEKIT_API_KEY"    (New-SecureHex -Bytes 16)
+    $dashboardApiKey = Get-EnvOrNew "DASHBOARD_API_KEY"  (New-SecureHex -Bytes 32)
+    $openclawToken   = Get-EnvOrNew "OPENCLAW_TOKEN"     (New-SecureHex -Bytes 24)
+    $searxngSecret   = Get-EnvOrNew "SEARXNG_SECRET"     (New-SecureHex -Bytes 32)
 
     # Determine LLM API URL based on backend
     # AMD on Windows: llama-server runs natively, containers reach it via host.docker.internal
@@ -154,9 +173,9 @@ DREAM_MODE=$DreamMode
 LLM_API_URL=$llmApiUrl
 
 #=== Cloud API Keys ===
-ANTHROPIC_API_KEY=
-OPENAI_API_KEY=
-TOGETHER_API_KEY=
+ANTHROPIC_API_KEY=$(Get-EnvOrNew "ANTHROPIC_API_KEY" "")
+OPENAI_API_KEY=$(Get-EnvOrNew "OPENAI_API_KEY" "")
+TOGETHER_API_KEY=$(Get-EnvOrNew "TOGETHER_API_KEY" "")
 
 #=== LLM Settings (llama-server) ===
 LLM_MODEL=$($TierConfig.LlmModel)


### PR DESCRIPTION
## Summary

- Remove the existing-installation gate in `01-preflight.sh` that bailed with "Installation already exists. Use --force to overwrite." The installer is already designed for updates: secrets merge via `_env_get`, models skip if present, Docker recreates containers.
- Add `.env` preservation to the Windows `env-generator.ps1` (matching Linux `_env_get` logic) so re-installs reuse existing secrets and user-entered API keys instead of regenerating everything.

Broken build? Just re-run the installer.

## Test plan

- [ ] Run installer on fresh system — generates new secrets
- [ ] Re-run installer on existing install — preserves secrets, updates files
- [ ] Verify API keys (ANTHROPIC_API_KEY, etc.) survive re-install

🤖 Generated with [Claude Code](https://claude.com/claude-code)