### PR TITLE
Introduce compatibility shim for token-spy DB backend, move canonical backend to sidecar, add tests and README notes

### DIFF
--- a/resources/products/token-spy/README.md
+++ b/resources/products/token-spy/README.md
@@ -118,6 +118,13 @@ openssl rand -base64 32
 - **TimescaleDB**: Time-series database for metrics
 - **Redis**: Caching and rate limiting
 
+
+## Database Backend Modules
+
+- **Canonical DB layer:** `resources/products/token-spy/sidecar/db_backend.py` is the runtime backend API used by the sidecar (`get_db`, `DatabaseBackend`, pool lifecycle, usage/API/provider/tenant models).
+- **Deprecated compatibility module:** `resources/products/token-spy/db_backend.py` is now a thin import-forwarding shim for legacy scripts.
+- **Migration status:** new code should import from `sidecar.db_backend`; the top-level module remains only for backward compatibility and will be removed in a future cleanup once downstream scripts are migrated.
+
 ## Make Commands
 
 ```bash

--- a/resources/products/token-spy/db_backend.py
+++ b/resources/products/token-spy/db_backend.py
@@ -1,436 +1,187 @@
-"""Database abstraction layer for Token Spy.
+"""Compatibility shim for Token Spy database access.
 
-Supports both SQLite (development/single-tenant) and PostgreSQL with TimescaleDB
-(production/multi-tenant) backends.
+Canonical database backend now lives in ``sidecar/db_backend.py``.
+This module is kept as an import-forwarder so existing scripts that import
+``db_backend`` continue to work during migration.
 """
 
-import os
+from __future__ import annotations
+
+import importlib.util
 import logging
-from abc import ABC, abstractmethod
-from typing import Dict, List, Optional, Any
-from contextlib import contextmanager
+import warnings
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 logger = logging.getLogger(__name__)
 
-# Database backend selection
-DB_BACKEND = os.environ.get("DB_BACKEND", "sqlite").lower()
-DB_PATH = os.environ.get("DB_PATH", "data/usage.db")
+warnings.warn(
+    "resources/products/token-spy/db_backend.py is deprecated; import from sidecar.db_backend instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
-# PostgreSQL configuration
-PG_HOST = os.environ.get("PG_HOST", "localhost")
-PG_PORT = int(os.environ.get("PG_PORT", "5432"))
-PG_DB = os.environ.get("PG_DB", "token_spy")
-PG_USER = os.environ.get("PG_USER", "token_spy")
-PG_PASSWORD = os.environ.get("PG_PASSWORD", "")
-PG_POOL_SIZE = int(os.environ.get("PG_POOL_SIZE", "10"))
-
-
-class DatabaseBackend(ABC):
-    """Abstract base class for database backends."""
-    
-    @abstractmethod
-    def init_db(self) -> None:
-        """Initialize database schema."""
-        pass
-    
-    @abstractmethod
-    def log_usage(self, entry: Dict[str, Any]) -> None:
-        """Log a usage entry."""
-        pass
-    
-    @abstractmethod
-    def query_usage(self, agent: Optional[str] = None, 
-                   start_time: Optional[str] = None,
-                   end_time: Optional[str] = None,
-                   limit: int = 100) -> List[Dict[str, Any]]:
-        """Query usage records."""
-        pass
-    
-    @abstractmethod
-    def query_summary(self, hours: int = 24) -> Dict[str, Any]:
-        """Get usage summary for time period."""
-        pass
-    
-    @abstractmethod
-    def query_session_status(self, agent: str) -> Dict[str, Any]:
-        """Get session status for an agent."""
-        pass
+def _load_canonical_module():
+    module_path = Path(__file__).resolve().parent / "sidecar" / "db_backend.py"
+    spec = importlib.util.spec_from_file_location("token_spy_sidecar_db_backend", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load canonical db backend from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
-class SQLiteBackend(DatabaseBackend):
-    """SQLite backend for single-tenant deployments."""
-    
-    def __init__(self, db_path: str = DB_PATH):
-        self.db_path = db_path
-        self._local = threading.local()
-    
-    def _get_conn(self):
-        import sqlite3
-        if not hasattr(self._local, "conn") or self._local.conn is None:
-            os.makedirs(os.path.dirname(self.db_path), exist_ok=True)
-            self._local.conn = sqlite3.connect(self.db_path)
-            self._local.conn.execute("PRAGMA journal_mode=WAL")
-            self._local.conn.execute("PRAGMA busy_timeout=5000")
-            self._local.conn.row_factory = sqlite3.Row
-        return self._local.conn
-    
-    def init_db(self) -> None:
-        """Initialize SQLite schema (legacy single-tenant)."""
-        conn = self._get_conn()
-        conn.executescript("""
-            CREATE TABLE IF NOT EXISTS usage (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
-                agent TEXT NOT NULL,
-                model TEXT,
-                request_body_bytes INTEGER DEFAULT 0,
-                message_count INTEGER DEFAULT 0,
-                user_message_count INTEGER DEFAULT 0,
-                assistant_message_count INTEGER DEFAULT 0,
-                tool_count INTEGER DEFAULT 0,
-                system_prompt_total_chars INTEGER DEFAULT 0,
-                workspace_agents_chars INTEGER DEFAULT 0,
-                workspace_soul_chars INTEGER DEFAULT 0,
-                workspace_tools_chars INTEGER DEFAULT 0,
-                workspace_identity_chars INTEGER DEFAULT 0,
-                workspace_user_chars INTEGER DEFAULT 0,
-                workspace_heartbeat_chars INTEGER DEFAULT 0,
-                workspace_bootstrap_chars INTEGER DEFAULT 0,
-                workspace_memory_chars INTEGER DEFAULT 0,
-                skill_injection_chars INTEGER DEFAULT 0,
-                base_prompt_chars INTEGER DEFAULT 0,
-                conversation_history_chars INTEGER DEFAULT 0,
-                input_tokens INTEGER DEFAULT 0,
-                output_tokens INTEGER DEFAULT 0,
-                cache_read_tokens INTEGER DEFAULT 0,
-                cache_write_tokens INTEGER DEFAULT 0,
-                estimated_cost_usd REAL DEFAULT 0,
-                duration_ms INTEGER DEFAULT 0,
-                stop_reason TEXT
-            );
-            CREATE INDEX IF NOT EXISTS idx_usage_timestamp ON usage(timestamp);
-            CREATE INDEX IF NOT EXISTS idx_usage_agent ON usage(agent);
-        """)
-        conn.commit()
-        logger.info(f"SQLite database initialized at {self.db_path}")
-    
-    def log_usage(self, entry: Dict[str, Any]) -> None:
-        """Log usage to SQLite."""
-        conn = self._get_conn()
-        cols = [
-            "agent", "model",
-            "request_body_bytes", "message_count", "user_message_count",
-            "assistant_message_count", "tool_count",
-            "system_prompt_total_chars",
-            "workspace_agents_chars", "workspace_soul_chars", "workspace_tools_chars",
-            "workspace_identity_chars", "workspace_user_chars", "workspace_heartbeat_chars",
-            "workspace_bootstrap_chars", "workspace_memory_chars",
-            "skill_injection_chars", "base_prompt_chars",
-            "conversation_history_chars",
-            "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-            "estimated_cost_usd", "duration_ms", "stop_reason"
-        ]
-        placeholders = ", ".join(["?"] * len(cols))
-        sql = f"INSERT INTO usage ({', '.join(cols)}) VALUES ({placeholders})"
-        values = [entry.get(c, 0) if c != "agent" and c != "model" and c != "stop_reason" else entry.get(c, "") for c in cols]
-        conn.execute(sql, values)
-        conn.commit()
-    
-    def query_usage(self, agent: Optional[str] = None,
-                   start_time: Optional[str] = None,
-                   end_time: Optional[str] = None,
-                   limit: int = 100) -> List[Dict[str, Any]]:
-        """Query usage from SQLite."""
-        conn = self._get_conn()
-        sql = "SELECT * FROM usage WHERE 1=1"
-        params = []
-        if agent:
-            sql += " AND agent = ?"
-            params.append(agent)
-        if start_time:
-            sql += " AND timestamp >= ?"
-            params.append(start_time)
-        if end_time:
-            sql += " AND timestamp <= ?"
-            params.append(end_time)
-        sql += " ORDER BY timestamp DESC LIMIT ?"
-        params.append(limit)
-        
-        cursor = conn.execute(sql, params)
-        return [dict(row) for row in cursor.fetchall()]
-    
-    def query_summary(self, hours: int = 24) -> Dict[str, Any]:
-        """Get usage summary from SQLite."""
-        conn = self._get_conn()
-        cursor = conn.execute("""
-            SELECT 
-                COUNT(*) as request_count,
-                SUM(input_tokens) as total_input_tokens,
-                SUM(output_tokens) as total_output_tokens,
-                SUM(estimated_cost_usd) as total_cost,
-                AVG(duration_ms) as avg_duration_ms
-            FROM usage 
-            WHERE timestamp >= datetime('now', '-{} hours')
-        """.format(hours))
-        row = cursor.fetchone()
-        return dict(row) if row else {}
-    
-    def query_session_status(self, agent: str) -> Dict[str, Any]:
-        """Get session status from SQLite."""
-        conn = self._get_conn()
-        cursor = conn.execute("""
-            SELECT 
-                COUNT(*) as message_count,
-                SUM(input_tokens + output_tokens) as total_tokens,
-                SUM(conversation_history_chars) as conversation_chars,
-                MAX(timestamp) as last_activity
-            FROM usage 
-            WHERE agent = ?
-            AND timestamp >= datetime('now', '-1 hour')
-        """, (agent,))
-        row = cursor.fetchone()
-        if not row:
-            return {"message_count": 0, "total_tokens": 0, "conversation_chars": 0}
-        return dict(row)
+_canonical = _load_canonical_module()
+
+# Re-export canonical symbols for compatibility.
+DatabaseBackend = _canonical.DatabaseBackend
+UsageEntry = _canonical.UsageEntry
+UsageStats = _canonical.UsageStats
+APIKey = _canonical.APIKey
+ProviderKey = _canonical.ProviderKey
+Tenant = _canonical.Tenant
+User = _canonical.User
+Team = _canonical.Team
+TeamMembership = _canonical.TeamMembership
+OrganizationSettings = _canonical.OrganizationSettings
+RealDictCursor = getattr(_canonical, "RealDictCursor", None)
+get_db_connection = _canonical.get_db_connection
+init_pool = _canonical.init_pool
+get_connection = _canonical.get_connection
+put_connection = _canonical.put_connection
+decrypt_provider_key = _canonical.decrypt_provider_key
 
 
-class PostgreSQLBackend(DatabaseBackend):
-    """PostgreSQL with TimescaleDB backend for multi-tenant deployments."""
-    
-    def __init__(self, host: str = PG_HOST, port: int = PG_PORT,
-                 db: str = PG_DB, user: str = PG_USER, 
-                 password: str = PG_PASSWORD):
-        self.dsn = f"postgresql://{user}:{password}@{host}:{port}/{db}"
-        self._pool = None
-    
-    def _get_pool(self):
-        """Get or create connection pool."""
-        if self._pool is None:
-            try:
-                import asyncpg
-                import asyncio
-                # Note: asyncpg requires async context, use sync wrapper
-                self._pool = None  # Will use psycopg2 for sync
-            except ImportError:
-                pass
-        return self._pool
-    
-    def init_db(self) -> None:
-        """Initialize PostgreSQL schema with TimescaleDB."""
-        try:
-            import psycopg2
-            conn = psycopg2.connect(self.dsn)
-            conn.autocommit = True
-            cursor = conn.cursor()
-            
-            # Check if TimescaleDB extension is available
-            cursor.execute("SELECT 1 FROM pg_extension WHERE extname = 'timescaledb'")
-            has_timescale = cursor.fetchone() is not None
-            
-            if not has_timescale:
-                logger.warning("TimescaleDB extension not found. Creating without hypertable.")
-            
-            # Create schema (simplified - full schema in sql files)
-            cursor.execute("""
-                CREATE TABLE IF NOT EXISTS requests (
-                    id BIGSERIAL PRIMARY KEY,
-                    timestamp TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    tenant_id UUID NOT NULL,
-                    api_key_id UUID,
-                    agent_id TEXT,
-                    model TEXT,
-                    input_tokens BIGINT DEFAULT 0,
-                    output_tokens BIGINT DEFAULT 0,
-                    cache_read_tokens BIGINT DEFAULT 0,
-                    cache_write_tokens BIGINT DEFAULT 0,
-                    cost_usd NUMERIC(12,8) DEFAULT 0,
-                    duration_ms INTEGER DEFAULT 0,
-                    stop_reason TEXT
-                );
-            """)
-            
-            if has_timescale:
-                # Convert to hypertable for time-series optimization
-                cursor.execute("""
-                    SELECT create_hypertable('requests', 'timestamp', 
-                        chunk_time_interval => INTERVAL '1 day',
-                        if_not_exists => TRUE
-                    );
-                """)
-            
-            # Create indexes
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_requests_tenant ON requests(tenant_id);")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_requests_timestamp ON requests(timestamp);")
-            cursor.execute("CREATE INDEX IF NOT EXISTS idx_requests_agent ON requests(agent_id);")
-            
-            conn.commit()
-            cursor.close()
-            conn.close()
-            logger.info("PostgreSQL database initialized with TimescaleDB support")
-            
-        except ImportError:
-            logger.error("psycopg2 not installed. Run: pip install psycopg2-binary")
-            raise
-        except Exception as e:
-            logger.error(f"Failed to initialize PostgreSQL: {e}")
-            raise
-    
-    def log_usage(self, entry: Dict[str, Any]) -> None:
-        """Log usage to PostgreSQL."""
-        import psycopg2
-        conn = psycopg2.connect(self.dsn)
-        cursor = conn.cursor()
-        
-        # Map entry fields to PostgreSQL schema
-        cursor.execute("""
-            INSERT INTO requests 
-            (tenant_id, agent_id, model, input_tokens, output_tokens,
-             cache_read_tokens, cache_write_tokens, cost_usd, duration_ms, stop_reason)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-        """, (
-            entry.get("tenant_id", "00000000-0000-0000-0000-000000000000"),
-            entry.get("agent"),
-            entry.get("model"),
-            entry.get("input_tokens", 0),
-            entry.get("output_tokens", 0),
-            entry.get("cache_read_tokens", 0),
-            entry.get("cache_write_tokens", 0),
-            entry.get("estimated_cost_usd", 0),
-            entry.get("duration_ms", 0),
-            entry.get("stop_reason")
-        ))
-        
-        conn.commit()
-        cursor.close()
-        conn.close()
-    
-    def query_usage(self, agent: Optional[str] = None,
-                   start_time: Optional[str] = None,
-                   end_time: Optional[str] = None,
-                   limit: int = 100) -> List[Dict[str, Any]]:
-        """Query usage from PostgreSQL."""
-        import psycopg2
-        conn = psycopg2.connect(self.dsn)
-        cursor = conn.cursor()
-        
-        sql = "SELECT * FROM requests WHERE 1=1"
-        params = []
-        
-        if agent:
-            sql += " AND agent_id = %s"
-            params.append(agent)
-        if start_time:
-            sql += " AND timestamp >= %s"
-            params.append(start_time)
-        if end_time:
-            sql += " AND timestamp <= %s"
-            params.append(end_time)
-        
-        sql += " ORDER BY timestamp DESC LIMIT %s"
-        params.append(limit)
-        
-        cursor.execute(sql, params)
-        columns = [desc[0] for desc in cursor.description]
-        rows = cursor.fetchall()
-        
-        cursor.close()
-        conn.close()
-        
-        return [dict(zip(columns, row)) for row in rows]
-    
-    def query_summary(self, hours: int = 24) -> Dict[str, Any]:
-        """Get usage summary from PostgreSQL."""
-        import psycopg2
-        conn = psycopg2.connect(self.dsn)
-        cursor = conn.cursor()
-        
-        cursor.execute("""
-            SELECT 
-                COUNT(*) as request_count,
-                SUM(input_tokens) as total_input_tokens,
-                SUM(output_tokens) as total_output_tokens,
-                SUM(cost_usd) as total_cost,
-                AVG(duration_ms) as avg_duration_ms
-            FROM requests 
-            WHERE timestamp >= NOW() - INTERVAL '%s hours'
-        """, (hours,))
-        
-        columns = [desc[0] for desc in cursor.description]
-        row = cursor.fetchone()
-        
-        cursor.close()
-        conn.close()
-        
-        return dict(zip(columns, row)) if row else {}
-    
-    def query_session_status(self, agent: str) -> Dict[str, Any]:
-        """Get session status from PostgreSQL."""
-        import psycopg2
-        conn = psycopg2.connect(self.dsn)
-        cursor = conn.cursor()
-        
-        cursor.execute("""
-            SELECT 
-                COUNT(*) as message_count,
-                SUM(input_tokens + output_tokens) as total_tokens,
-                MAX(timestamp) as last_activity
-            FROM requests 
-            WHERE agent_id = %s
-            AND timestamp >= NOW() - INTERVAL '1 hour'
-        """, (agent,))
-        
-        columns = [desc[0] for desc in cursor.description]
-        row = cursor.fetchone()
-        
-        cursor.close()
-        conn.close()
-        
-        return dict(zip(columns, row)) if row else {"message_count": 0, "total_tokens": 0}
-
-
-# Global backend instance
-_backend: Optional[DatabaseBackend] = None
+def _cursor_kwargs() -> Dict[str, Any]:
+    return {"cursor_factory": RealDictCursor} if RealDictCursor is not None else {}
 
 
 def get_backend() -> DatabaseBackend:
-    """Get the configured database backend."""
-    global _backend
-    if _backend is None:
-        if DB_BACKEND == "postgresql":
-            _backend = PostgreSQLBackend()
-        else:
-            _backend = SQLiteBackend()
-    return _backend
+    """Legacy accessor for the canonical singleton backend."""
+    return _canonical.get_db()
 
 
-def init_db():
-    """Initialize the database."""
-    backend = get_backend()
-    backend.init_db()
+def init_db() -> None:
+    """Legacy schema initialization entrypoint."""
+    get_backend().init_db()
 
 
-def log_usage(entry: Dict[str, Any]):
-    """Log usage entry."""
-    backend = get_backend()
-    backend.log_usage(entry)
+def _to_usage_entry(entry: Dict[str, Any]) -> UsageEntry:
+    request_id = entry.get("request_id") or f"legacy-{uuid4()}"
+    prompt_tokens = int(entry.get("prompt_tokens", entry.get("input_tokens", 0)) or 0)
+    completion_tokens = int(entry.get("completion_tokens", entry.get("output_tokens", 0)) or 0)
+    total_tokens = int(entry.get("total_tokens", prompt_tokens + completion_tokens) or 0)
+
+    return UsageEntry(
+        session_id=entry.get("session_id"),
+        request_id=request_id,
+        provider=entry.get("provider", "legacy"),
+        model=entry.get("model", "unknown"),
+        api_key_prefix=entry.get("api_key_prefix"),
+        tenant_id=entry.get("tenant_id"),
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=total_tokens,
+        total_cost=float(entry.get("total_cost", entry.get("estimated_cost_usd", 0.0)) or 0.0),
+        latency_ms=entry.get("latency_ms", entry.get("duration_ms")),
+        status_code=int(entry.get("status_code", 200) or 200),
+        finish_reason=entry.get("finish_reason", entry.get("stop_reason")),
+    )
 
 
-def query_usage(agent: Optional[str] = None,
-               start_time: Optional[str] = None,
-               end_time: Optional[str] = None,
-               limit: int = 100) -> List[Dict[str, Any]]:
-    """Query usage records."""
-    backend = get_backend()
-    return backend.query_usage(agent, start_time, end_time, limit)
+def log_usage(entry: Dict[str, Any] | UsageEntry) -> None:
+    """Legacy usage logger adapter.
+
+    Accepts either the old dict payload shape or canonical ``UsageEntry``.
+    """
+    usage_entry = entry if isinstance(entry, UsageEntry) else _to_usage_entry(entry)
+    get_backend().log_usage(usage_entry)
+
+
+def query_usage(
+    agent: Optional[str] = None,
+    start_time: Optional[str] = None,
+    end_time: Optional[str] = None,
+    limit: int = 100,
+) -> List[Dict[str, Any]]:
+    """Compatibility query helper over canonical PostgreSQL tables."""
+    sql = """
+        SELECT
+            request_id,
+            timestamp,
+            provider,
+            model,
+            prompt_tokens AS input_tokens,
+            completion_tokens AS output_tokens,
+            total_tokens,
+            total_cost AS estimated_cost_usd,
+            latency_ms AS duration_ms,
+            finish_reason AS stop_reason,
+            tenant_id
+        FROM api_requests
+        WHERE 1=1
+    """
+    params: List[Any] = []
+    if agent:
+        sql += " AND session_id = %s"
+        params.append(agent)
+    if start_time:
+        sql += " AND timestamp >= %s"
+        params.append(start_time)
+    if end_time:
+        sql += " AND timestamp <= %s"
+        params.append(end_time)
+    sql += " ORDER BY timestamp DESC LIMIT %s"
+    params.append(limit)
+
+    with get_db_connection() as conn:
+        with conn.cursor(**_cursor_kwargs()) as cur:
+            cur.execute(sql, tuple(params))
+            return [dict(row) for row in cur.fetchall()]
 
 
 def query_summary(hours: int = 24) -> Dict[str, Any]:
-    """Get usage summary."""
-    backend = get_backend()
-    return backend.query_summary(hours)
+    """Legacy summary shape backed by canonical api_requests table."""
+    with get_db_connection() as conn:
+        with conn.cursor(**_cursor_kwargs()) as cur:
+            cur.execute(
+                """
+                SELECT
+                    COUNT(*) AS request_count,
+                    COALESCE(SUM(prompt_tokens), 0) AS total_input_tokens,
+                    COALESCE(SUM(completion_tokens), 0) AS total_output_tokens,
+                    COALESCE(SUM(total_cost), 0) AS total_cost,
+                    AVG(latency_ms) AS avg_duration_ms
+                FROM api_requests
+                WHERE timestamp >= NOW() - (%s || ' hours')::interval
+                """,
+                (hours,),
+            )
+            row = cur.fetchone()
+            return dict(row) if row else {}
 
 
 def query_session_status(agent: str) -> Dict[str, Any]:
-    """Get session status."""
-    backend = get_backend()
-    return backend.query_session_status(agent)
+    """Legacy per-session status helper.
+
+    ``agent`` is interpreted as legacy session identifier.
+    """
+    with get_db_connection() as conn:
+        with conn.cursor(**_cursor_kwargs()) as cur:
+            cur.execute(
+                """
+                SELECT
+                    COUNT(*) AS message_count,
+                    COALESCE(SUM(total_tokens), 0) AS total_tokens,
+                    MAX(timestamp) AS last_activity
+                FROM api_requests
+                WHERE session_id = %s
+                  AND timestamp >= NOW() - INTERVAL '1 hour'
+                """,
+                (agent,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return {"message_count": 0, "total_tokens": 0}
+            return dict(row)

--- a/resources/products/token-spy/sidecar/db_backend.py
+++ b/resources/products/token-spy/sidecar/db_backend.py
@@ -29,9 +29,8 @@ log = logging.getLogger("token-spy-db")
 
 DATABASE_URL = os.environ.get("DATABASE_URL")
 if not DATABASE_URL:
-    raise RuntimeError(
-        "DATABASE_URL environment variable is required. "
-        "Example: postgresql://token_spy:yourpassword@localhost:5432/token_spy"
+    log.warning(
+        "DATABASE_URL is not set. Database connections will fail until it is configured."
     )
 
 # Encryption key for provider keys (must match dashboard)
@@ -233,6 +232,11 @@ def init_pool(database_url: Optional[str] = None, min_conn: int = 10, max_conn: 
     
     if _pool is None:
         url = database_url or DATABASE_URL
+        if not url:
+            raise RuntimeError(
+                "DATABASE_URL environment variable is required. "
+                "Example: postgresql://token_spy:yourpassword@localhost:5432/token_spy"
+            )
         _pool = ThreadedConnectionPool(min_conn, max_conn, url)
         log.info(f"Database pool initialized (min={min_conn}, max={max_conn})")
     return _pool

--- a/resources/products/token-spy/tests/test_db_backend_compat.py
+++ b/resources/products/token-spy/tests/test_db_backend_compat.py
@@ -1,0 +1,138 @@
+import importlib.util
+import warnings
+from contextlib import contextmanager
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+COMPAT_DB_BACKEND_PATH = REPO_ROOT / "resources" / "products" / "token-spy" / "db_backend.py"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_compat_module_imports_and_emits_deprecation_warning():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        module = _load_module("token_spy_db_backend_compat_warn", COMPAT_DB_BACKEND_PATH)
+
+    assert hasattr(module, "DatabaseBackend")
+    assert hasattr(module, "get_backend")
+    assert any(issubclass(w.category, DeprecationWarning) for w in caught)
+
+
+def test_log_usage_adapts_legacy_dict_payload():
+    module = _load_module("token_spy_db_backend_compat_log", COMPAT_DB_BACKEND_PATH)
+
+    class _FakeBackend:
+        def __init__(self):
+            self.logged = None
+
+        def log_usage(self, usage_entry):
+            self.logged = usage_entry
+
+    fake_backend = _FakeBackend()
+    module.get_backend = lambda: fake_backend
+
+    module.log_usage(
+        {
+            "session_id": "agent-1",
+            "provider": "openai",
+            "model": "gpt-4o-mini",
+            "input_tokens": 12,
+            "output_tokens": 30,
+            "estimated_cost_usd": 0.123,
+            "duration_ms": 222,
+            "stop_reason": "stop",
+        }
+    )
+
+    assert fake_backend.logged is not None
+    assert fake_backend.logged.prompt_tokens == 12
+    assert fake_backend.logged.completion_tokens == 30
+    assert fake_backend.logged.total_tokens == 42
+    assert fake_backend.logged.total_cost == 0.123
+    assert fake_backend.logged.latency_ms == 222
+    assert fake_backend.logged.finish_reason == "stop"
+
+
+class _FakeCursor:
+    def __init__(self, fetchall_result=None, fetchone_result=None):
+        self.fetchall_result = fetchall_result or []
+        self.fetchone_result = fetchone_result
+        self.executed = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def execute(self, sql, params):
+        self.executed.append((sql, params))
+
+    def fetchall(self):
+        return self.fetchall_result
+
+    def fetchone(self):
+        return self.fetchone_result
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self, **kwargs):
+        return self._cursor
+
+
+@contextmanager
+def _fake_db_connection(cursor):
+    yield _FakeConnection(cursor)
+
+
+def test_query_helpers_keep_legacy_shape():
+    module = _load_module("token_spy_db_backend_compat_query", COMPAT_DB_BACKEND_PATH)
+
+    usage_rows = [
+        {
+            "request_id": "r1",
+            "input_tokens": 1,
+            "output_tokens": 2,
+            "estimated_cost_usd": 0.1,
+            "duration_ms": 11,
+            "stop_reason": "stop",
+        }
+    ]
+    summary_row = {
+        "request_count": 10,
+        "total_input_tokens": 100,
+        "total_output_tokens": 200,
+        "total_cost": 1.5,
+        "avg_duration_ms": 30,
+    }
+    session_row = {
+        "message_count": 2,
+        "total_tokens": 30,
+        "last_activity": "2026-01-01T00:00:00Z",
+    }
+
+    usage_cursor = _FakeCursor(fetchall_result=usage_rows)
+    module.get_db_connection = lambda: _fake_db_connection(usage_cursor)
+    usage = module.query_usage(agent="agent-1", start_time="2026-01-01", end_time="2026-01-02", limit=5)
+    assert usage == usage_rows
+
+    summary_cursor = _FakeCursor(fetchone_result=summary_row)
+    module.get_db_connection = lambda: _fake_db_connection(summary_cursor)
+    summary = module.query_summary(hours=12)
+    assert summary == summary_row
+
+    session_cursor = _FakeCursor(fetchone_result=session_row)
+    module.get_db_connection = lambda: _fake_db_connection(session_cursor)
+    session_status = module.query_session_status(agent="agent-1")
+    assert session_status == session_row


### PR DESCRIPTION
### Motivation
- Provide a migration path so existing scripts importing `resources/products/token-spy/db_backend.py` continue to work while the canonical implementation is relocated to `sidecar/db_backend.py`.
- Make the new canonical PostgreSQL/TimescaleDB-backed API the single source-of-truth while preserving legacy shapes and helpers for older tooling.
- Clarify documentation about the new module layout in the `token-spy` README.

### Description
- Added a deprecating compatibility shim at `resources/products/token-spy/db_backend.py` that dynamically loads the canonical implementation from `sidecar/db_backend.py`, emits a `DeprecationWarning`, and re-exports key types and helpers (e.g. `DatabaseBackend`, `get_db_connection`, `init_pool`, etc.).
- Implemented adapters in the shim to accept legacy dict payloads via `log_usage`, convert them to the canonical `UsageEntry` shape, and provide compatibility query helpers `query_usage`, `query_summary`, and `query_session_status` that query the canonical `api_requests` table shape.
- Updated `resources/products/token-spy/sidecar/db_backend.py` to improve pool initialization by warning when `DATABASE_URL` is not set and delaying the hard failure until `init_pool` is invoked, and restructured some logging and configuration messages.
- Documented the new layout in `resources/products/token-spy/README.md` under a new "Database Backend Modules" section explaining the canonical layer and the top-level deprecated shim.
- Added unit tests at `resources/products/token-spy/tests/test_db_backend_compat.py` which validate that the compatibility module imports and emits a deprecation warning, adapt legacy dict payloads for `log_usage`, and preserve legacy query shapes for `query_usage`, `query_summary`, and `query_session_status`.

### Testing
- Ran the added unit tests `resources/products/token-spy/tests/test_db_backend_compat.py`; the tests completed successfully and all assertions passed.
- The tests exercise import-time deprecation warnings, the legacy-dict-to-`UsageEntry` adapter for `log_usage`, and the legacy-shaped query helper functions, and they all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7dec11a0832cb6442c5b01370582)