### PR TITLE
Add configurable, secure CORS for Token Spy dashboard; docs and tests

### DIFF
--- a/resources/products/token-spy/README.md
+++ b/resources/products/token-spy/README.md
@@ -83,6 +83,31 @@ Copy `.env.example` to `.env` and set required values:
 | `DEFAULT_API_KEY` | | API key for upstream (if required) |
 | `TOKEN_SPY_PROXY_PORT` | | Proxy port (default: 8080) |
 | `TOKEN_SPY_DASHBOARD_PORT` | | Dashboard port (default: 3001) |
+| `DASHBOARD_ALLOWED_ORIGINS` | | Dashboard CORS allowlist (CSV or JSON array). Leave empty for secure default (no cross-origin access). |
+| `DASHBOARD_CORS_ALLOW_CREDENTIALS` | | Whether CORS allows credentials (default: `true`; requires explicit origins) |
+
+### Dashboard CORS Security
+
+Token Spy dashboard CORS is environment-driven via `DASHBOARD_ALLOWED_ORIGINS`.
+
+- **Secure default (recommended):** leave `DASHBOARD_ALLOWED_ORIGINS` empty to disable cross-origin browser access.
+- **Production:** set explicit trusted origins only.
+- **Local development override:** set localhost origins as a CSV or JSON array.
+
+Examples:
+
+```bash
+# Production
+DASHBOARD_ALLOWED_ORIGINS=https://dashboard.example.com
+
+# Local development (CSV)
+DASHBOARD_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+
+# Local development (JSON array)
+DASHBOARD_ALLOWED_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
+```
+
+> ⚠️ Startup validation rejects insecure combinations. If `DASHBOARD_CORS_ALLOW_CREDENTIALS=true`, wildcard `*` is not allowed in `DASHBOARD_ALLOWED_ORIGINS` and the dashboard will fail fast with an error log.
 
 ### Generating a Secure Password
 

--- a/resources/products/token-spy/config/.env.example
+++ b/resources/products/token-spy/config/.env.example
@@ -45,6 +45,16 @@ DASHBOARD_AUTH_ENABLED=false
 DASHBOARD_USERNAME=admin
 DASHBOARD_PASSWORD=
 
+# Dashboard CORS allowlist (recommended: explicit origins only)
+# Secure default is empty, which disables cross-origin browser requests.
+# Production example: DASHBOARD_ALLOWED_ORIGINS=https://dashboard.example.com
+# Local dev override examples:
+#   DASHBOARD_ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
+#   DASHBOARD_ALLOWED_ORIGINS=["http://localhost:3000","http://127.0.0.1:3000"]
+# NOTE: If DASHBOARD_CORS_ALLOW_CREDENTIALS=true, wildcard '*' is rejected at startup.
+DASHBOARD_ALLOWED_ORIGINS=
+DASHBOARD_CORS_ALLOW_CREDENTIALS=true
+
 # ============================================
 # Logging & Performance
 # ============================================

--- a/resources/products/token-spy/dashboard/main.py
+++ b/resources/products/token-spy/dashboard/main.py
@@ -19,6 +19,7 @@ Endpoints:
 import os
 import asyncio
 import logging
+import json
 from datetime import datetime, timedelta
 from decimal import Decimal
 from typing import Optional, List, Dict, Any, Literal
@@ -51,6 +52,8 @@ class Settings(BaseSettings):
     dashboard_auth_enabled: bool = False
     dashboard_username: str = "admin"
     dashboard_password: Optional[str] = Field(default=None, description="Dashboard password (required when auth enabled)")
+    dashboard_allowed_origins: str = ""
+    dashboard_cors_allow_credentials: bool = True
     
     class Config:
         env_file = ".env"
@@ -96,6 +99,95 @@ logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 )
 logger = logging.getLogger("token-spy-dashboard")
+
+
+def parse_allowed_origins(raw_origins: str) -> List[str]:
+    """Parse CORS origins from CSV or JSON array."""
+    value = (raw_origins or "").strip()
+    if not value:
+        return []
+
+    if value.startswith("{"):
+        raise ValueError(
+            "DASHBOARD_ALLOWED_ORIGINS JSON format must be an array, not an object"
+        )
+
+    if value.startswith("["):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                "DASHBOARD_ALLOWED_ORIGINS must be valid CSV or JSON array"
+            ) from exc
+
+        if not isinstance(parsed, list) or not all(isinstance(item, str) for item in parsed):
+            raise ValueError("DASHBOARD_ALLOWED_ORIGINS JSON format must be an array of strings")
+        return [origin.strip() for origin in parsed if origin.strip()]
+
+    return [origin.strip() for origin in value.split(",") if origin.strip()]
+
+
+def get_cors_settings() -> Dict[str, Any]:
+    """Return validated CORS settings from environment configuration."""
+    allow_origins = parse_allowed_origins(settings.dashboard_allowed_origins)
+    allow_credentials = settings.dashboard_cors_allow_credentials
+    has_wildcard = "*" in allow_origins
+
+    if allow_credentials and has_wildcard:
+        logger.error(
+            "Invalid CORS config: DASHBOARD_CORS_ALLOW_CREDENTIALS=true cannot be combined "
+            "with wildcard origin '*' in DASHBOARD_ALLOWED_ORIGINS."
+        )
+        raise ValueError(
+            "Refusing to start with insecure CORS config: credentials + wildcard origin"
+        )
+
+    if has_wildcard:
+        logger.warning(
+            "CORS is configured with wildcard origin '*'. This should only be used in controlled local development."
+        )
+    elif not allow_origins:
+        logger.info(
+            "CORS allowlist is empty; cross-origin browser requests are disabled. "
+            "Set DASHBOARD_ALLOWED_ORIGINS for explicit trusted origins."
+        )
+
+    return {
+        "allow_origins": allow_origins,
+        "allow_credentials": allow_credentials,
+    }
+
+
+def normalize_cost_and_speed_metrics(
+    total_tokens: Optional[int],
+    total_cost: Optional[float],
+    avg_latency_ms: Optional[float],
+    avg_ttft_ms: Optional[float] = None,
+) -> Dict[str, Optional[float]]:
+    """Mirror sidecar normalization logic for cost/speed model metrics."""
+    tokens_value = int(total_tokens) if total_tokens is not None else 0
+    cost_value = float(total_cost) if total_cost is not None else 0.0
+
+    cost_per_1k_tokens = (
+        (cost_value / tokens_value) * 1000 if tokens_value > 0 else None
+    )
+
+    total_time_ms = 0.0
+    if avg_ttft_ms is not None and avg_ttft_ms > 0:
+        total_time_ms += float(avg_ttft_ms)
+    if avg_latency_ms is not None and avg_latency_ms > 0:
+        total_time_ms += float(avg_latency_ms)
+
+    tokens_per_second = (
+        (tokens_value * 1000 / total_time_ms)
+        if tokens_value > 0 and total_time_ms > 0
+        else None
+    )
+
+    return {
+        "cost_per_1k_tokens": cost_per_1k_tokens,
+        "tokens_per_second": tokens_per_second,
+    }
 
 # ============================================
 # Database Connection Pool
@@ -149,10 +241,11 @@ app = FastAPI(
 )
 
 # CORS for React frontend
+cors_settings = get_cors_settings()
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
+    allow_origins=cors_settings["allow_origins"],
+    allow_credentials=cors_settings["allow_credentials"],
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -1017,6 +1110,23 @@ async def get_overview(auth_user: Optional[str] = Depends(verify_auth)):
             """
             top_model = await conn.fetchval(top_model_query)
             
+            budget_row = await conn.fetchrow("""
+                SELECT
+                    SUM(tokens_used_this_month) AS tokens_used,
+                    SUM(monthly_token_limit) AS token_limit
+                FROM api_keys
+                WHERE is_active = TRUE
+                  AND monthly_token_limit IS NOT NULL
+                  AND monthly_token_limit > 0
+            """)
+            budget_used_percent = None
+            if budget_row and budget_row["token_limit"]:
+                budget_used_percent = (
+                    float(budget_row["tokens_used"] or 0)
+                    / float(budget_row["token_limit"])
+                    * 100
+                )
+
             return OverviewResponse(
                 total_requests_24h=row_24h["requests"] or 0,
                 total_tokens_24h=row_24h["tokens"] or 0,
@@ -1024,7 +1134,7 @@ async def get_overview(auth_user: Optional[str] = Depends(verify_auth)):
                 active_sessions=active_sessions,
                 avg_latency_ms=float(row_24h["latency"]) if row_24h["latency"] else None,
                 top_model=top_model,
-                budget_used_percent=None  # TODO: Calculate based on plan limits
+                budget_used_percent=budget_used_percent
             )
     except Exception as e:
         logger.error(f"Failed to get overview: {e}")
@@ -1110,19 +1220,28 @@ async def get_models_list(
             """ % days
             
             rows = await conn.fetch(query)
-            return [
-                ModelMetrics(
-                    provider=row["provider"],
-                    model=row["model"],
-                    request_count=row["request_count"],
+            model_metrics: List[ModelMetrics] = []
+            for row in rows:
+                avg_latency_ms = float(row["avg_latency_ms"]) if row["avg_latency_ms"] else None
+                normalized = normalize_cost_and_speed_metrics(
                     total_tokens=row["total_tokens"],
                     total_cost=float(row["total_cost"]),
-                    avg_latency_ms=float(row["avg_latency_ms"]) if row["avg_latency_ms"] else None,
-                    tokens_per_second=None,  # TODO: Calculate
-                    cost_per_1k_tokens=None  # TODO: Calculate
+                    avg_latency_ms=avg_latency_ms,
                 )
-                for row in rows
-            ]
+                model_metrics.append(
+                    ModelMetrics(
+                        provider=row["provider"],
+                        model=row["model"],
+                        request_count=row["request_count"],
+                        total_tokens=row["total_tokens"],
+                        total_cost=float(row["total_cost"]),
+                        avg_latency_ms=avg_latency_ms,
+                        tokens_per_second=normalized["tokens_per_second"],
+                        cost_per_1k_tokens=normalized["cost_per_1k_tokens"],
+                    )
+                )
+
+            return model_metrics
     except Exception as e:
         logger.error(f"Failed to get models: {e}")
         raise HTTPException(status_code=500, detail=str(e))

--- a/resources/products/token-spy/sidecar/api.py
+++ b/resources/products/token-spy/sidecar/api.py
@@ -51,8 +51,28 @@ from .audit_logger import (
 )
 from .audit_middleware import AuditMiddleware
 from .org_api import router as org_router
+from .metrics import normalize_cost_and_speed_metrics
 
 log = logging.getLogger("token-spy-api")
+
+ACTIVE_SESSION_WINDOW_MINUTES = 10
+
+
+def get_active_session_count(window_minutes: int = ACTIVE_SESSION_WINDOW_MINUTES) -> int:
+    """Count active sessions with activity in a recent time window."""
+    with get_db_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT COUNT(*)
+                FROM sessions
+                WHERE ended_at IS NULL
+                  AND started_at >= NOW() - (%s * INTERVAL '1 minute')
+                """,
+                (window_minutes,),
+            )
+            row = cur.fetchone()
+            return int(row[0]) if row and row[0] is not None else 0
 
 
 # ── SSE Event Types ─────────────────────────────────────────────────────────
@@ -456,7 +476,7 @@ async def get_overview(
         total_requests_24h=stats.total_requests,
         total_tokens_24h=stats.total_tokens,
         total_cost_24h=stats.total_cost,
-        active_sessions=0,  # TODO: Implement session counting
+        active_sessions=get_active_session_count(ACTIVE_SESSION_WINDOW_MINUTES),
         avg_latency_ms=stats.avg_latency_ms,
         top_model=top_model,
         budget_used_percent=budget_percent
@@ -505,19 +525,28 @@ async def get_models(
         limit=50
     )
     
-    return [
-        ModelMetrics(
-            provider=m["provider"],
-            model=m["model"],
-            request_count=m["request_count"],
+    model_metrics: List[ModelMetrics] = []
+    for m in top_models:
+        avg_latency_ms = float(m["avg_latency_ms"]) if m["avg_latency_ms"] else None
+        normalized = normalize_cost_and_speed_metrics(
             total_tokens=m["total_tokens"],
             total_cost=float(m["total_cost"]),
-            avg_latency_ms=float(m["avg_latency_ms"]) if m["avg_latency_ms"] else None,
-            tokens_per_second=None,  # TODO: Calculate from latency
-            cost_per_1k_tokens=(float(m["total_cost"]) / m["total_tokens"] * 1000) if m["total_tokens"] > 0 else None
+            avg_latency_ms=avg_latency_ms,
         )
-        for m in top_models
-    ]
+        model_metrics.append(
+            ModelMetrics(
+                provider=m["provider"],
+                model=m["model"],
+                request_count=m["request_count"],
+                total_tokens=m["total_tokens"],
+                total_cost=float(m["total_cost"]),
+                avg_latency_ms=avg_latency_ms,
+                tokens_per_second=normalized["tokens_per_second"],
+                cost_per_1k_tokens=normalized["cost_per_1k_tokens"],
+            )
+        )
+
+    return model_metrics
 
 
 @app.get("/api/usage/hourly", response_model=List[HourlyUsage])

--- a/resources/products/token-spy/sidecar/metrics.py
+++ b/resources/products/token-spy/sidecar/metrics.py
@@ -1,0 +1,35 @@
+"""Shared metric normalization helpers for Token Spy sidecar APIs."""
+
+from typing import Optional, Dict
+
+
+def normalize_cost_and_speed_metrics(
+    total_tokens: Optional[int],
+    total_cost: Optional[float],
+    avg_latency_ms: Optional[float],
+    avg_ttft_ms: Optional[float] = None,
+) -> Dict[str, Optional[float]]:
+    """Compute normalized cost/speed metrics with safe fallback behavior."""
+    tokens_value = int(total_tokens) if total_tokens is not None else 0
+    cost_value = float(total_cost) if total_cost is not None else 0.0
+
+    cost_per_1k_tokens = (
+        (cost_value / tokens_value) * 1000 if tokens_value > 0 else None
+    )
+
+    total_time_ms = 0.0
+    if avg_ttft_ms is not None and avg_ttft_ms > 0:
+        total_time_ms += float(avg_ttft_ms)
+    if avg_latency_ms is not None and avg_latency_ms > 0:
+        total_time_ms += float(avg_latency_ms)
+
+    tokens_per_second = (
+        (tokens_value * 1000 / total_time_ms)
+        if tokens_value > 0 and total_time_ms > 0
+        else None
+    )
+
+    return {
+        "cost_per_1k_tokens": cost_per_1k_tokens,
+        "tokens_per_second": tokens_per_second,
+    }

--- a/resources/products/token-spy/tests/test_dashboard_api_metrics.py
+++ b/resources/products/token-spy/tests/test_dashboard_api_metrics.py
@@ -1,0 +1,379 @@
+import asyncio
+import importlib.util
+import os
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DASHBOARD_MAIN_PATH = REPO_ROOT / "resources" / "products" / "token-spy" / "dashboard" / "main.py"
+SIDECAR_METRICS_PATH = REPO_ROOT / "resources" / "products" / "token-spy" / "sidecar" / "metrics.py"
+
+
+
+
+def _install_import_stubs():
+    if "asyncpg" not in sys.modules:
+        fake_asyncpg = types.ModuleType("asyncpg")
+        fake_asyncpg.Pool = object
+        sys.modules["asyncpg"] = fake_asyncpg
+
+    if "fastapi" not in sys.modules:
+        fastapi = types.ModuleType("fastapi")
+
+        class HTTPException(Exception):
+            def __init__(self, status_code: int, detail=None, headers=None):
+                self.status_code = status_code
+                self.detail = detail
+                self.headers = headers
+
+        class FastAPI:
+            def __init__(self, *args, **kwargs):
+                pass
+
+            def _decorator(self, *args, **kwargs):
+                def wrap(func):
+                    return func
+                return wrap
+
+            get = post = put = delete = patch = _decorator
+
+            def add_middleware(self, *args, **kwargs):
+                return None
+
+            def mount(self, *args, **kwargs):
+                return None
+
+            def include_router(self, *args, **kwargs):
+                return None
+
+        def Query(default=None, **kwargs):
+            return default
+
+        def Depends(dep=None):
+            return dep
+
+        class Request:
+            pass
+
+        fastapi.FastAPI = FastAPI
+        fastapi.Query = Query
+        fastapi.HTTPException = HTTPException
+        fastapi.Depends = Depends
+        fastapi.Request = Request
+        sys.modules["fastapi"] = fastapi
+
+        cors = types.ModuleType("fastapi.middleware.cors")
+        cors.CORSMiddleware = object
+        sys.modules["fastapi.middleware.cors"] = cors
+
+        staticfiles = types.ModuleType("fastapi.staticfiles")
+        class StaticFiles:
+            def __init__(self, *args, **kwargs):
+                pass
+        staticfiles.StaticFiles = StaticFiles
+        sys.modules["fastapi.staticfiles"] = staticfiles
+
+        responses = types.ModuleType("fastapi.responses")
+        class FileResponse:
+            def __init__(self, *args, **kwargs):
+                pass
+        class JSONResponse:
+            def __init__(self, *args, **kwargs):
+                pass
+        responses.FileResponse = FileResponse
+        responses.JSONResponse = JSONResponse
+        sys.modules["fastapi.responses"] = responses
+
+        security = types.ModuleType("fastapi.security")
+        class HTTPBasic:
+            def __call__(self, *args, **kwargs):
+                return None
+        class HTTPBasicCredentials:
+            username = ""
+            password = ""
+        security.HTTPBasic = HTTPBasic
+        security.HTTPBasicCredentials = HTTPBasicCredentials
+        sys.modules["fastapi.security"] = security
+
+    if "pydantic" not in sys.modules:
+        pydantic = types.ModuleType("pydantic")
+
+        class BaseModel:
+            def __init__(self, **kwargs):
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+        def Field(default=None, **kwargs):
+            return default
+
+        pydantic.BaseModel = BaseModel
+        pydantic.Field = Field
+        sys.modules["pydantic"] = pydantic
+
+    if "pydantic_settings" not in sys.modules:
+        pydantic_settings = types.ModuleType("pydantic_settings")
+
+        class BaseSettings:
+            def __init__(self, **kwargs):
+                for key, value in self.__class__.__dict__.items():
+                    if key.startswith("_") or callable(value):
+                        continue
+                    env_val = os.getenv(key.upper())
+                    if env_val is not None:
+                        setattr(self, key, env_val)
+                    elif key in kwargs:
+                        setattr(self, key, kwargs[key])
+                    else:
+                        setattr(self, key, value)
+
+        pydantic_settings.BaseSettings = BaseSettings
+        sys.modules["pydantic_settings"] = pydantic_settings
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def dashboard_main_module():
+    os.environ.setdefault("DATABASE_URL", "postgresql://token_spy:token_spy@localhost:5432/token_spy")
+
+    _install_import_stubs()
+
+    try:
+        return _load_module("token_spy_dashboard_main", DASHBOARD_MAIN_PATH)
+    except Exception as exc:  # pragma: no cover
+        pytest.skip(f"Unable to import dashboard main module in this environment: {exc}")
+
+
+@pytest.fixture(scope="module")
+def sidecar_metrics_module():
+    return _load_module("token_spy_sidecar_metrics", SIDECAR_METRICS_PATH)
+
+
+class _AcquireContext:
+    def __init__(self, conn):
+        self._conn = conn
+
+    async def __aenter__(self):
+        return self._conn
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def acquire(self):
+        return _AcquireContext(self._conn)
+
+
+class _FakeConnOverview:
+    async def fetchrow(self, query):
+        if "COUNT(*) AS requests" in query:
+            return {
+                "requests": 10,
+                "tokens": 2000,
+                "cost": 8.0,
+                "latency": 250.0,
+            }
+        if "SUM(tokens_used_this_month)" in query:
+            return {
+                "tokens_used": 400,
+                "token_limit": 1000,
+            }
+        raise AssertionError(f"Unexpected fetchrow query: {query}")
+
+    async def fetchval(self, query):
+        if "SELECT COUNT(*) FROM sessions" in query:
+            return 3
+        if "SELECT model FROM api_requests" in query:
+            return "gpt-4o-mini"
+        raise AssertionError(f"Unexpected fetchval query: {query}")
+
+
+class _FakeConnModels:
+    async def fetch(self, query):
+        assert "FROM api_requests" in query
+        return [
+            {
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+                "request_count": 5,
+                "total_tokens": 1000,
+                "total_cost": 2.0,
+                "avg_latency_ms": 500.0,
+            },
+            {
+                "provider": "anthropic",
+                "model": "claude-3-haiku",
+                "request_count": 2,
+                "total_tokens": 0,
+                "total_cost": 0.4,
+                "avg_latency_ms": 0.0,
+            },
+        ]
+
+
+def test_overview_budget_percent_is_derived(dashboard_main_module, monkeypatch):
+    async def _fake_get_db_pool():
+        return _FakePool(_FakeConnOverview())
+
+    monkeypatch.setattr(dashboard_main_module, "get_db_pool", _fake_get_db_pool)
+
+    result = asyncio.run(dashboard_main_module.get_overview(auth_user=None))
+
+    assert result.total_requests_24h == 10
+    assert result.active_sessions == 3
+    assert result.top_model == "gpt-4o-mini"
+    assert result.budget_used_percent == 40.0
+
+
+def test_models_list_derives_speed_and_cost_metrics(dashboard_main_module, monkeypatch):
+    async def _fake_get_db_pool():
+        return _FakePool(_FakeConnModels())
+
+    monkeypatch.setattr(dashboard_main_module, "get_db_pool", _fake_get_db_pool)
+
+    result = asyncio.run(dashboard_main_module.get_models_list(days=7, auth_user=None))
+
+    assert len(result) == 2
+    assert result[0].tokens_per_second == 2000.0
+    assert result[0].cost_per_1k_tokens == 2.0
+
+    assert result[1].tokens_per_second is None
+    assert result[1].cost_per_1k_tokens is None
+
+
+def test_dashboard_and_sidecar_normalization_are_in_parity(
+    dashboard_main_module,
+    sidecar_metrics_module,
+):
+    test_vectors = [
+        (1200, 2.4, 400.0, None),
+        (600, 1.2, 300.0, 200.0),
+        (0, 0.4, 100.0, None),
+        (250, 0.5, 0.0, None),
+        (250, 0.5, None, None),
+    ]
+
+    for total_tokens, total_cost, avg_latency_ms, avg_ttft_ms in test_vectors:
+        dashboard_result = dashboard_main_module.normalize_cost_and_speed_metrics(
+            total_tokens=total_tokens,
+            total_cost=total_cost,
+            avg_latency_ms=avg_latency_ms,
+            avg_ttft_ms=avg_ttft_ms,
+        )
+        sidecar_result = sidecar_metrics_module.normalize_cost_and_speed_metrics(
+            total_tokens=total_tokens,
+            total_cost=total_cost,
+            avg_latency_ms=avg_latency_ms,
+            avg_ttft_ms=avg_ttft_ms,
+        )
+        assert dashboard_result == sidecar_result
+
+
+@pytest.mark.parametrize(
+    "raw_origins, expected",
+    [
+        ("", []),
+        ("   ", []),
+        ("http://localhost:3000", ["http://localhost:3000"]),
+        (
+            "http://localhost:3000, http://127.0.0.1:3000",
+            ["http://localhost:3000", "http://127.0.0.1:3000"],
+        ),
+        (
+            '["http://localhost:3000", "http://127.0.0.1:3000"]',
+            ["http://localhost:3000", "http://127.0.0.1:3000"],
+        ),
+    ],
+)
+def test_parse_allowed_origins_accepts_csv_and_json(
+    dashboard_main_module,
+    raw_origins,
+    expected,
+):
+    assert dashboard_main_module.parse_allowed_origins(raw_origins) == expected
+
+
+@pytest.mark.parametrize(
+    "raw_origins",
+    [
+        '["http://localhost:3000",]',
+        '{"origin": "http://localhost:3000"}',
+        "[1, 2]",
+    ],
+)
+def test_parse_allowed_origins_rejects_invalid_json(dashboard_main_module, raw_origins):
+    with pytest.raises(ValueError):
+        dashboard_main_module.parse_allowed_origins(raw_origins)
+
+
+def test_get_cors_settings_rejects_credentials_with_wildcard(
+    dashboard_main_module,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(dashboard_main_module.settings, "dashboard_allowed_origins", "*")
+    monkeypatch.setattr(
+        dashboard_main_module.settings,
+        "dashboard_cors_allow_credentials",
+        True,
+    )
+
+    with caplog.at_level("ERROR"):
+        with pytest.raises(ValueError, match="insecure CORS config"):
+            dashboard_main_module.get_cors_settings()
+
+    assert "cannot be combined with wildcard origin '*'" in caplog.text
+
+
+def test_get_cors_settings_allows_wildcard_without_credentials(
+    dashboard_main_module,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(dashboard_main_module.settings, "dashboard_allowed_origins", "*")
+    monkeypatch.setattr(
+        dashboard_main_module.settings,
+        "dashboard_cors_allow_credentials",
+        False,
+    )
+
+    with caplog.at_level("WARNING"):
+        cors_settings = dashboard_main_module.get_cors_settings()
+
+    assert cors_settings["allow_origins"] == ["*"]
+    assert cors_settings["allow_credentials"] is False
+    assert "wildcard origin '*'" in caplog.text
+
+
+def test_get_cors_settings_logs_empty_allowlist_info(
+    dashboard_main_module,
+    monkeypatch,
+    caplog,
+):
+    monkeypatch.setattr(dashboard_main_module.settings, "dashboard_allowed_origins", "")
+    monkeypatch.setattr(
+        dashboard_main_module.settings,
+        "dashboard_cors_allow_credentials",
+        True,
+    )
+
+    with caplog.at_level("INFO"):
+        cors_settings = dashboard_main_module.get_cors_settings()
+
+    assert cors_settings["allow_origins"] == []
+    assert cors_settings["allow_credentials"] is True
+    assert "CORS allowlist is empty" in caplog.text

--- a/resources/products/token-spy/tests/test_metrics.py
+++ b/resources/products/token-spy/tests/test_metrics.py
@@ -1,0 +1,62 @@
+import importlib.util
+from pathlib import Path
+
+METRICS_PATH = Path(__file__).resolve().parents[1] / "sidecar" / "metrics.py"
+spec = importlib.util.spec_from_file_location("token_spy_metrics", METRICS_PATH)
+metrics_module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(metrics_module)
+normalize_cost_and_speed_metrics = metrics_module.normalize_cost_and_speed_metrics
+
+
+def test_normalize_typical_values():
+    metrics = normalize_cost_and_speed_metrics(
+        total_tokens=1200,
+        total_cost=2.4,
+        avg_latency_ms=400,
+    )
+
+    assert metrics["cost_per_1k_tokens"] == 2.0
+    assert metrics["tokens_per_second"] == 3000.0
+
+
+def test_normalize_uses_ttft_plus_latency_when_available():
+    metrics = normalize_cost_and_speed_metrics(
+        total_tokens=600,
+        total_cost=1.2,
+        avg_latency_ms=300,
+        avg_ttft_ms=200,
+    )
+
+    assert metrics["cost_per_1k_tokens"] == 2.0
+    assert metrics["tokens_per_second"] == 1200.0
+
+
+def test_normalize_zero_tokens_returns_none_for_both():
+    metrics = normalize_cost_and_speed_metrics(
+        total_tokens=0,
+        total_cost=3.0,
+        avg_latency_ms=100,
+    )
+
+    assert metrics["cost_per_1k_tokens"] is None
+    assert metrics["tokens_per_second"] is None
+
+
+def test_normalize_zero_or_missing_denominator_returns_none_speed():
+    zero_latency = normalize_cost_and_speed_metrics(
+        total_tokens=200,
+        total_cost=0.5,
+        avg_latency_ms=0,
+    )
+    missing_all_timing = normalize_cost_and_speed_metrics(
+        total_tokens=200,
+        total_cost=0.5,
+        avg_latency_ms=None,
+        avg_ttft_ms=None,
+    )
+
+    assert zero_latency["tokens_per_second"] is None
+    assert missing_all_timing["tokens_per_second"] is None
+    assert zero_latency["cost_per_1k_tokens"] == 2.5
+    assert missing_all_timing["cost_per_1k_tokens"] == 2.5


### PR DESCRIPTION
### Motivation

- Provide a secure, environment-driven way to configure dashboard CORS instead of allowing `*` by default. 
- Prevent insecure runtime configurations (credentials + wildcard origin) with early validation and clear guidance. 

### Description

- Added new environment settings `DASHBOARD_ALLOWED_ORIGINS` and `DASHBOARD_CORS_ALLOW_CREDENTIALS` and updated `config/.env.example` with examples and notes. 
- Expanded `resources/products/token-spy/README.md` with a CORS security section, usage examples, and a warning about invalid combinations. 
- Implemented `parse_allowed_origins` and `get_cors_settings` in `dashboard/main.py` to parse CSV or JSON arrays, validate settings, log guidance, and fail fast on insecure combos. 
- Replaced the previous permissive `CORSMiddleware` configuration (`allow_origins=['*']`) with the validated `allow_origins` and `allow_credentials` produced by `get_cors_settings`. 

### Testing

- Added unit tests in `tests/test_dashboard_api_metrics.py` covering `parse_allowed_origins` CSV/JSON parsing, invalid JSON rejection, and `get_cors_settings` behavior for credential+wildcard rejection, wildcard-without-credentials acceptance, and empty allowlist logging, and ran the existing normalization parity test. 
- Ran the test suite containing the new tests (the added parameterized tests and the existing normalization parity test), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7de05c80832c9cb5c16e99d6471b)