### PR TITLE
security: remove hardcoded LiveKit credentials and SearXNG static secret

### DIFF
--- a/dream-server/config/searxng/settings.yml
+++ b/dream-server/config/searxng/settings.yml
@@ -1,6 +1,6 @@
 use_default_settings: true
 server:
-  secret_key: "9d0e105e00289d066f0532614b135e5df22eeb2b6e0228bd4c0a4426ae3f39f0"
+  secret_key: "CHANGEME-run-the-installer-to-generate-a-secure-key"
   bind_address: "0.0.0.0"
   port: 8080
   limiter: false

--- a/resources/frameworks/voice-agent/core/hvac-token-server.py
+++ b/resources/frameworks/voice-agent/core/hvac-token-server.py
@@ -14,11 +14,20 @@ import base64
 import time
 import os
 
-# HVAC LiveKit credentials - UPDATE THESE FROM YOUR HVAC LIVEKIT PROJECT
-# Create a new project at https://cloud.livekit.io
-API_KEY = 'APIRUdt5f4Hp87o'
-API_SECRET = 'bTpgs0RC42jjluOevB9D64zcYhZFG7qEdU0T1m1QMNX'
-LIVEKIT_URL = 'wss://grace-hvac-jtcdy0sb.livekit.cloud'
+# HVAC LiveKit credentials — read from environment variables.
+# Create a new project at https://cloud.livekit.io and set these:
+#   export LIVEKIT_API_KEY="your-api-key"
+#   export LIVEKIT_API_SECRET="your-api-secret"
+#   export LIVEKIT_URL="wss://your-project.livekit.cloud"
+API_KEY = os.environ.get('LIVEKIT_API_KEY', '')
+API_SECRET = os.environ.get('LIVEKIT_API_SECRET', '')
+LIVEKIT_URL = os.environ.get('LIVEKIT_URL', 'ws://localhost:7880')
+
+if not API_KEY or not API_SECRET:
+    raise RuntimeError(
+        "LIVEKIT_API_KEY and LIVEKIT_API_SECRET must be set as environment variables. "
+        "Create a project at https://cloud.livekit.io to obtain credentials."
+    )
 
 def base64url_encode(data):
     """Base64URL encode without padding"""


### PR DESCRIPTION
## Summary
- **LiveKit Cloud credentials removed** from `resources/frameworks/voice-agent/core/hvac-token-server.py` — real API key and secret were committed in plaintext. Replaced with `os.environ.get()` reads that fail fast if not set.
- **SearXNG static secret_key replaced** in `dream-server/config/searxng/settings.yml` — the hardcoded hex value is now a `CHANGEME` placeholder. All three installers (Linux/Windows/macOS) already generate a random key at install time.

## ⚠️ ACTION REQUIRED after merge
1. **Rotate the LiveKit Cloud credentials immediately** at https://cloud.livekit.io for project `grace-hvac-jtcdy0sb` — the old key (`APIRUdt5f4Hp87o`) and secret are still in git history
2. Consider running `git filter-repo` or BFG Repo Cleaner to purge the credentials from git history (optional but recommended since the credentials will be rotated anyway)

## Test plan
- [ ] Verify `hvac-token-server.py` raises `RuntimeError` when env vars are not set
- [ ] Verify SearXNG starts correctly after running any of the three installers (which overwrite `settings.yml` with a generated secret)
- [ ] Verify the `CHANGEME` placeholder is obvious enough to prevent accidental use without the installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)