### PR TITLE
Fix dream-cli chat port initialization and harden validate.sh env handling

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -312,10 +312,12 @@ cmd_chat() {
     local message="${1:-Hello}"
     local model="${2:-}"
 
+    # Resolve llama-server port once, regardless of how the model is provided
+    local _llm_port="${SERVICE_PORTS[llama-server]:-8080}"
+    _llm_port="${LLAMA_SERVER_PORT:-$_llm_port}"
+
     # Get model from llama-server if not specified
     if [[ -z "$model" ]]; then
-        local _llm_port="${SERVICE_PORTS[llama-server]:-8080}"
-        _llm_port="${LLAMA_SERVER_PORT:-$_llm_port}"
         model=$(curl -s "http://localhost:${_llm_port}/v1/models" | grep -oP '"id":\s*"\K[^"]+' | head -1)
     fi
 

--- a/dream-server/scripts/validate.sh
+++ b/dream-server/scripts/validate.sh
@@ -18,14 +18,35 @@ export SCRIPT_DIR="$PROJECT_DIR"
 . "$PROJECT_DIR/lib/service-registry.sh"
 sr_load
 
-# Source .env for port overrides
-[[ -f "$PROJECT_DIR/.env" ]] && set -a && . "$PROJECT_DIR/.env" && set +a
+# Safe .env loading (aligns with dream-cli pattern)
+load_env_safe() {
+    local env_file="$PROJECT_DIR/.env"
+    [[ -f "$env_file" ]] || return 0
+    set -a
+    while IFS='=' read -r key value; do
+        # Skip comments and empty lines
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$key" ]] && continue
+        # Only allow alphanumeric + underscore in key names
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        # Strip surrounding quotes from value
+        value="${value%\"}"
+        value="${value#\"}"
+        value="${value%\'}"
+        value="${value#\'}"
+        export "$key=$value"
+    done < "$env_file"
+    set +a
+}
 
-# Resolve core ports from registry
-LLM_PORT="${SERVICE_PORTS[llama-server]:-8080}"
+# Load .env for port overrides (if present)
+load_env_safe
+
+# Resolve core ports from registry (honoring any env overrides)
+LLM_PORT="${LLAMA_SERVER_PORT:-${SERVICE_PORTS[llama-server]:-8080}}"
 LLM_HEALTH="${SERVICE_HEALTH[llama-server]:-/health}"
-WEBUI_PORT="${SERVICE_PORTS[open-webui]:-3000}"
-WEBUI_HEALTH="${SERVICE_HEALTH[open-webui]:-/}"
+WEBUI_PORT="${WEBUI_PORT:-${SERVICE_PORTS[open-webui]:-3000}}"
+WEBUI_HEALTH="${WEBUI_HEALTH:-${SERVICE_HEALTH[open-webui]:-/}}"
 
 echo ""
 echo "╔═══════════════════════════════════════════╗"
@@ -40,7 +61,8 @@ check() {
     local name="$1"
     local cmd="$2"
     printf "  %-30s " "$name..."
-    if eval "$cmd" > /dev/null 2>&1; then
+    # Run fixed command string via bash -c (no eval)
+    if bash -c "$cmd" > /dev/null 2>&1; then
         echo -e "${GREEN}✓ PASS${NC}"
         ((PASSED++))
     else


### PR DESCRIPTION
  ## Summary

- Fix `dream-cli` `cmd_chat` so `_llm_port` is always initialized, even when a model is provided explicitly (e.g. `dream chat "Hi" my-model`), by resolving the llama-server port once at the start of the function.
- Harden `dream-server/scripts/validate.sh`:
  - Replace direct `. .env` sourcing with a safe loader that only accepts valid key names and strips surrounding quotes (mirrors the pattern used in `dream-cli`).
  - Respect env-based overrides for `LLAMA_SERVER_PORT` and `WEBUI_PORT` while still defaulting to the registry values.
  - Replace `eval "$cmd"` in `check()` with `bash -c "$cmd"` for fixed command strings.

## Testing

- `bash -n dream-server/dream-cli`
- `bash -n dream-server/scripts/validate.sh`