### PR TITLE
fix: eliminate dashboard health counter blinking (0/17 ↔ 16/17)

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -17,6 +17,21 @@ from models import ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus
 
 logger = logging.getLogger(__name__)
 
+# --- Shared HTTP session (connection pooling) ---
+# Re-using a single ClientSession avoids creating/destroying 17+ TCP
+# connections every poll cycle and prevents file-descriptor exhaustion.
+
+_aio_session: Optional[aiohttp.ClientSession] = None
+_HEALTH_TIMEOUT = aiohttp.ClientTimeout(total=5)   # match Docker's own 5 s timeout
+
+
+async def _get_aio_session() -> aiohttp.ClientSession:
+    """Return (and lazily create) a module-level aiohttp session."""
+    global _aio_session
+    if _aio_session is None or _aio_session.closed:
+        _aio_session = aiohttp.ClientSession(timeout=_HEALTH_TIMEOUT)
+    return _aio_session
+
 
 # --- Token Tracking ---
 
@@ -56,15 +71,19 @@ def _get_lifetime_tokens() -> int:
 
 # --- LLM Metrics ---
 
-async def get_llama_metrics() -> dict:
-    """Get inference metrics from llama-server Prometheus /metrics endpoint."""
+async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
+    """Get inference metrics from llama-server Prometheus /metrics endpoint.
+
+    Accepts an optional *model_hint* so callers that already resolved the
+    loaded model name can avoid a redundant HTTP round-trip.
+    """
     try:
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
-        model_name = await get_loaded_model() or ""
+        model_name = model_hint if model_hint is not None else (await get_loaded_model() or "")
         url = f"http://{host}:{port}/metrics"
         params = {"model": model_name} if model_name else {}
-        async with httpx.AsyncClient(timeout=3.0) as client:
+        async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(url, params=params)
 
         metrics = {}
@@ -99,7 +118,7 @@ async def get_loaded_model() -> Optional[str]:
     try:
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
-        async with httpx.AsyncClient(timeout=3.0) as client:
+        async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(f"http://{host}:{port}/v1/models")
         models = resp.json().get("data", [])
         for m in models:
@@ -113,16 +132,20 @@ async def get_loaded_model() -> Optional[str]:
     return None
 
 
-async def get_llama_context_size() -> Optional[int]:
-    """Query llama-server /props for the actual n_ctx."""
+async def get_llama_context_size(model_hint: Optional[str] = None) -> Optional[int]:
+    """Query llama-server /props for the actual n_ctx.
+
+    Accepts an optional *model_hint* to skip the redundant
+    ``get_loaded_model()`` call when the caller already has it.
+    """
     try:
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
-        loaded = await get_loaded_model()
+        loaded = model_hint if model_hint is not None else await get_loaded_model()
         url = f"http://{host}:{port}/props"
         if loaded:
             url += f"?model={loaded}"
-        async with httpx.AsyncClient(timeout=3.0) as client:
+        async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(url)
         n_ctx = resp.json().get("default_generation_settings", {}).get("n_ctx")
         return int(n_ctx) if n_ctx else None
@@ -143,11 +166,11 @@ async def check_service_health(service_id: str, config: dict) -> ServiceStatus:
     response_time = None
 
     try:
+        session = await _get_aio_session()
         start = asyncio.get_event_loop().time()
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
-            async with session.get(url) as resp:
-                response_time = (asyncio.get_event_loop().time() - start) * 1000
-                status = "healthy" if resp.status < 500 else "unhealthy"
+        async with session.get(url) as resp:
+            response_time = (asyncio.get_event_loop().time() - start) * 1000
+            status = "healthy" if resp.status < 500 else "unhealthy"
     except asyncio.TimeoutError:
         # Service is reachable but slow — report degraded rather than down
         # to avoid false "offline" flashes during startup or heavy load.
@@ -176,11 +199,11 @@ async def _check_host_service_health(service_id: str, config: dict) -> ServiceSt
     status = "down"
     response_time = None
     try:
+        session = await _get_aio_session()
         start = asyncio.get_event_loop().time()
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
-            async with session.get(url) as resp:
-                response_time = (asyncio.get_event_loop().time() - start) * 1000
-                status = "healthy" if resp.status < 500 else "unhealthy"
+        async with session.get(url) as resp:
+            response_time = (asyncio.get_event_loop().time() - start) * 1000
+            status = "healthy" if resp.status < 500 else "unhealthy"
     except aiohttp.ClientConnectorError:
         status = "down"
     except Exception as e:
@@ -194,9 +217,26 @@ async def _check_host_service_health(service_id: str, config: dict) -> ServiceSt
 
 
 async def get_all_services() -> list[ServiceStatus]:
-    """Get all service health statuses."""
+    """Get all service health statuses.
+
+    Uses ``return_exceptions=True`` so that one misbehaving service
+    cannot take down the entire status response.
+    """
     tasks = [check_service_health(sid, cfg) for sid, cfg in SERVICES.items()]
-    return await asyncio.gather(*tasks)
+    results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    statuses: list[ServiceStatus] = []
+    for (sid, cfg), result in zip(SERVICES.items(), results):
+        if isinstance(result, BaseException):
+            logger.warning("Health check for %s raised %s: %s", sid, type(result).__name__, result)
+            statuses.append(ServiceStatus(
+                id=sid, name=cfg["name"], port=cfg["port"],
+                external_port=cfg.get("external_port", cfg["port"]),
+                status="down", response_time_ms=None,
+            ))
+        else:
+            statuses.append(result)
+    return statuses
 
 
 # --- System Metrics ---

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -234,13 +234,44 @@ async def status(api_key: str = Depends(verify_api_key)):
 
 @app.get("/api/status")
 async def api_status(api_key: str = Depends(verify_api_key)):
-    """Dashboard-compatible status endpoint."""
+    """Dashboard-compatible status endpoint.
+
+    Wrapped in a top-level try/except so that a transient failure in any
+    sub-call (GPU, health checks, llama metrics …) never returns a raw 500
+    to the dashboard — the frontend would flash "0/17" otherwise.
+    """
+    try:
+        return await _build_api_status()
+    except Exception:
+        logger.exception("/api/status handler failed — returning safe fallback")
+        return {
+            "gpu": None, "services": [], "model": None,
+            "bootstrap": None, "uptime": 0,
+            "version": app.version, "tier": "Unknown",
+            "cpu": {"percent": 0, "temp_c": None},
+            "ram": {"used_gb": 0, "total_gb": 0, "percent": 0},
+            "inference": {"tokensPerSecond": 0, "lifetimeTokens": 0,
+                          "loadedModel": None, "contextSize": None},
+        }
+
+
+async def _build_api_status() -> dict:
+    """Build the full status payload.
+
+    Resolves the loaded model name *once* and threads it through the
+    metrics and context-size helpers to avoid redundant HTTP round-trips
+    to llama-server (previously 5 sequential calls, now 3 parallel).
+    """
     gpu_info = get_gpu_info()
     service_statuses = await get_all_services()
     model_info = get_model_info()
     bootstrap_info = get_bootstrap_status()
-    llama_metrics_data, loaded_model, context_size = await asyncio.gather(
-        get_llama_metrics(), get_loaded_model(), get_llama_context_size(),
+
+    # Resolve the loaded model name once, then fan it out.
+    loaded_model = await get_loaded_model()
+    llama_metrics_data, context_size = await asyncio.gather(
+        get_llama_metrics(model_hint=loaded_model),
+        get_llama_context_size(model_hint=loaded_model),
     )
 
     gpu_data = None

--- a/dream-server/extensions/services/dashboard/src/hooks/useSystemStatus.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useSystemStatus.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 
 const POLL_INTERVAL = 5000 // 5 seconds
 
@@ -50,6 +50,10 @@ export function useSystemStatus() {
   })
   const [loading, setLoading] = useState(!USE_MOCK_DATA)
   const [error, setError] = useState(null)
+  // Guard against overlapping fetches — if the API is slow (e.g.
+  // llama-server under inference load) we skip the next poll rather
+  // than stacking concurrent requests that can amplify the problem.
+  const fetchInFlight = useRef(false)
 
   useEffect(() => {
     const fetchStatus = async () => {
@@ -59,6 +63,10 @@ export function useSystemStatus() {
         return
       }
 
+      // Skip this tick if the previous fetch hasn't returned yet.
+      if (fetchInFlight.current) return
+      fetchInFlight.current = true
+
       try {
         const response = await fetch('/api/status')
         if (!response.ok) throw new Error('Failed to fetch status')
@@ -67,8 +75,9 @@ export function useSystemStatus() {
         setError(null)
       } catch (err) {
         setError(err.message)
-        // No silent fallback - let error propagate to UI
+        // Keep previous status on error so the UI doesn't flash
       } finally {
+        fetchInFlight.current = false
         setLoading(false)
       }
     }


### PR DESCRIPTION
## Summary
- **Prevents the dashboard health counter from blinking between 0/17 and 16/17** when llama-server is under inference load
- Root cause was a cascade of 6 interacting issues across backend and frontend

## Changes

### Backend (`dashboard-api/helpers.py`)
- `asyncio.gather(*tasks, return_exceptions=True)` — one failing service no longer crashes all 17 health results
- Health check timeout bumped **3s → 5s** to match Docker's own healthcheck timeout
- **Shared `aiohttp.ClientSession`** with connection pooling instead of creating/destroying 17 sessions per poll
- `get_llama_metrics()` and `get_llama_context_size()` accept `model_hint` param to avoid redundant `get_loaded_model()` calls (5 sequential HTTP calls → 3 parallel)

### Backend (`dashboard-api/main.py`)
- Top-level `try/except` on `/api/status` returns safe fallback instead of raw 500
- Resolves loaded model name **once** and threads it through metrics + context helpers

### Frontend (`useSystemStatus.js`)
- `useRef` guard skips poll tick if previous `fetch()` is still in-flight — prevents request pileup when the API is slow

## Test plan
- [ ] Load the dashboard while llama-server is actively running inference
- [ ] Verify the health counter remains stable (no 0/17 flashes)
- [ ] Verify degraded services show correctly (e.g., llama-server under heavy load shows 16/17 not 0/17)
- [ ] Verify all services report healthy when idle

🤖 Generated with [Claude Code](https://claude.com/claude-code)