### PR TITLE
fix: preflight dual-GPU detection, Whisper bind-mount race, pin image tags

### DIFF
--- a/dream-server/dream-preflight.sh
+++ b/dream-server/dream-preflight.sh
@@ -27,23 +27,39 @@ if [ -f "$DREAM_DIR/.env" ]; then
 fi
 SERVICE_HOST="${SERVICE_HOST:-localhost}"
 
-# Auto-detect backend from .env or running containers
+# Auto-detect backend from .env or hardware probing.
+# Priority: .env setting → nvidia-smi → AMD sysfs (any card).
+# On dual-GPU systems (AMD iGPU + NVIDIA dGPU) we must prefer
+# NVIDIA when present, since it is always the inference target.
 detect_backend() {
-    # Check .env first
+    # 1. Trust .env if the installer already wrote it.
     if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
         echo "amd"
         return
     fi
-    # Check if llama-server container is running
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q 'llama-server'; then
-        echo "amd"
+    if [[ "${GPU_BACKEND:-}" == "nvidia" ]]; then
+        echo "nvidia"
         return
     fi
-    # Fall back to hardware detection
-    if [[ -d /sys/class/drm/card1/device ]] && [[ "$(cat /sys/class/drm/card1/device/vendor 2>/dev/null)" == "0x1002" ]]; then
-        echo "amd"
-        return
+
+    # 2. Probe NVIDIA first (matches installer's detect_gpu order).
+    if command -v nvidia-smi &> /dev/null; then
+        if nvidia-smi --query-gpu=name --format=csv,noheader &> /dev/null; then
+            echo "nvidia"
+            return
+        fi
     fi
+
+    # 3. Probe AMD sysfs — scan all DRM cards, not just card1.
+    for card_dir in /sys/class/drm/card*/device; do
+        [[ -d "$card_dir" ]] || continue
+        if [[ "$(cat "$card_dir/vendor" 2>/dev/null)" == "0x1002" ]]; then
+            echo "amd"
+            return
+        fi
+    done
+
+    # 4. Default to nvidia (installer would have set .env anyway).
     echo "nvidia"
 }
 

--- a/dream-server/extensions/services/whisper/compose.nvidia.yaml
+++ b/dream-server/extensions/services/whisper/compose.nvidia.yaml
@@ -1,6 +1,6 @@
 services:
   whisper:
-    image: ghcr.io/speaches-ai/speaches:latest-cuda
+    image: ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda
     deploy:
       resources:
         reservations:

--- a/dream-server/extensions/services/whisper/compose.yaml
+++ b/dream-server/extensions/services/whisper/compose.yaml
@@ -1,13 +1,16 @@
 services:
   whisper:
-    image: ghcr.io/speaches-ai/speaches:latest-cpu
+    image: ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu
     container_name: dream-whisper
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     environment:
       - WHISPER__TTL=86400
-    entrypoint: ["/app/docker-entrypoint.sh"]
+    # Use a shell wrapper to wait for the bind-mounted entrypoint to
+    # become visible.  On fast compose-up the container can start before
+    # the mount is ready, causing transient "permission denied" errors.
+    entrypoint: ["/bin/sh", "-c", "until [ -x /app/docker-entrypoint.sh ]; do sleep 0.5; done; exec /app/docker-entrypoint.sh"]
     volumes:
       - ./data/whisper:/home/ubuntu/.cache/huggingface/hub
       - ./extensions/services/whisper/docker-entrypoint.sh:/app/docker-entrypoint.sh:ro


### PR DESCRIPTION
## Summary
Three issues reported from a Linux NVIDIA Blackwell RTX PRO 6000 install:

### 1. Preflight GPU detection bug on dual-GPU systems
- **Problem:** `dream-preflight.sh` hardcoded `/sys/class/drm/card1` and checked AMD vendor first — on systems with an AMD Raphael iGPU + NVIDIA discrete GPU, it misidentified the backend as AMD. Also had a bogus heuristic: "llama-server container running" → AMD.
- **Fix:** Rewrote `detect_backend()` to match the installer's own priority: `.env` setting → `nvidia-smi` → AMD sysfs scan (all cards, not just card1)

### 2. Whisper entrypoint transient "permission denied" errors
- **Problem:** 6 transient failures on startup because the Docker bind mount (`docker-entrypoint.sh:/app/docker-entrypoint.sh:ro`) wasn't visible at container exec time during fast `compose up`
- **Fix:** Shell wrapper polls `until [ -x /app/docker-entrypoint.sh ]` before exec'ing — eliminates the race without adding latency to normal starts

### 3. Floating Whisper image tags
- **Problem:** Whisper was the only ML-inference service using `:latest-cpu` / `:latest-cuda` while all peers (TTS, LiteLLM, n8n, Qdrant, Embeddings) pin exact versions
- **Fix:** Pinned to `0.9.0-rc.3-cpu` and `0.9.0-rc.3-cuda`

## Test plan
- [ ] Verify `detect_backend()` returns `nvidia` on a dual-GPU system (AMD iGPU + NVIDIA dGPU)
- [ ] Verify `detect_backend()` returns `amd` on an AMD-only Strix Halo system
- [ ] Verify Whisper starts cleanly without transient "permission denied" errors
- [ ] Verify pinned Whisper images pull and run correctly on both CPU and NVIDIA

🤖 Generated with [Claude Code](https://claude.com/claude-code)