### PR TITLE
fix(macos): check disk space on INSTALL_DIR instead of $HOME

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -115,7 +115,7 @@ fi
 ai_ok "Docker Desktop running (v${DOCKER_VERSION})"
 
 # Disk space
-test_disk_space "$HOME" 30
+test_disk_space "$INSTALL_DIR" 30
 info_box "Disk free:" "${DISK_FREE_GB} GB"
 if ! $DISK_SUFFICIENT; then
     ai_err "At least ${DISK_REQUIRED_GB} GB free space required. Found ${DISK_FREE_GB} GB."
@@ -196,7 +196,7 @@ elif [[ "$GGUF_FILE" =~ 14B ]]; then
 else
     NEEDED_GB=23
 fi
-test_disk_space "$HOME" "$NEEDED_GB"
+test_disk_space "$INSTALL_DIR" "$NEEDED_GB"
 if ! $DISK_SUFFICIENT; then
     ai_warn "Tier ${SELECTED_TIER} needs ~${NEEDED_GB} GB (model + Docker images). Only ${DISK_FREE_GB} GB free."
     if ! $FORCE; then exit 1; fi

--- a/dream-server/installers/macos/lib/detection.sh
+++ b/dream-server/installers/macos/lib/detection.sh
@@ -111,6 +111,9 @@ test_disk_space() {
     local path="${1:-$HOME}"
     local required_gb="${2:-30}"
 
+    # Walk up to nearest existing parent if path doesn't exist yet (first install)
+    while [[ ! -d "$path" ]]; do path="$(dirname "$path")"; done
+
     # macOS df with -g flag shows GB
     local free_gb
     free_gb=$(df -g "$path" 2>/dev/null | tail -1 | awk '{print $4}')


### PR DESCRIPTION
## Summary

- **Pass `$INSTALL_DIR`** (not `$HOME`) to `test_disk_space()` at both call sites in `install-macos.sh`
- **Add parent-directory traversal** in `test_disk_space()` so `df` resolves to the nearest existing mount point when the target directory hasn't been created yet (first install)

The disk-space preflight always checked `$HOME`, which reports the wrong volume when the user sets `DS_INSTALL_DIR` to an external drive. This caused installs to proceed even when the target volume was full, or to block installs when the boot volume was full but the target had plenty of space.

### Safety

- **Default installs** (`$HOME/dream-server`): traversal reaches `$HOME` (exists) → identical behavior to before
- **External volume**: traversal reaches the mount point → `df` reports the correct volume
- **Root edge case**: `dirname "/"` = `/`, which exists → loop always terminates

## Test plan

- [ ] Install with default `DS_INSTALL_DIR` (unchanged behavior)
- [ ] Install with `DS_INSTALL_DIR` pointing to an external volume — verify disk check reports that volume's free space
- [ ] Install with `DS_INSTALL_DIR` pointing to a non-existent nested path (`/Volumes/ExtDrive/deep/nested/path`) — verify traversal resolves to `/Volumes/ExtDrive`

Fixes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)