### PR TITLE
fix(macos): move embeddings platform override into service compose

### DIFF
--- a/dream-server/extensions/services/embeddings/compose.yaml
+++ b/dream-server/extensions/services/embeddings/compose.yaml
@@ -1,6 +1,7 @@
 services:
   embeddings:
     image: ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1
+    platform: linux/amd64  # TEI has no arm64 image -- Rosetta 2 on Apple Silicon
     container_name: dream-embeddings
     restart: unless-stopped
     security_opt:

--- a/dream-server/installers/macos/docker-compose.macos.yml
+++ b/dream-server/installers/macos/docker-compose.macos.yml
@@ -21,7 +21,3 @@ services:
   open-webui:
     environment:
       OPENAI_API_BASE_URL: "http://host.docker.internal:8080/v1"
-
-  # TEI has no arm64 image -- run under Rosetta 2 emulation
-  embeddings:
-    platform: linux/amd64


### PR DESCRIPTION
## Summary

- **Remove** the `embeddings` block from `docker-compose.macos.yml` (macOS overlay)
- **Add** `platform: linux/amd64` directly in `extensions/services/embeddings/compose.yaml`

The macOS overlay defined an `embeddings:` service block solely to set `platform: linux/amd64` (Rosetta 2 for TEI's x86-only image). When RAG is disabled, the embeddings compose file is excluded from the stack — but the overlay still references the service. Docker Compose treats this as an orphaned service definition and the install fails.

Moving the platform directive into the canonical service compose file means it only appears when the service is actually included.

### Platform behavior

| Scenario | Behavior |
|----------|----------|
| RAG disabled (any platform) | Embeddings compose excluded entirely → clean, no orphan |
| RAG enabled, Apple Silicon | `platform: linux/amd64` triggers Rosetta 2 emulation (desired) |
| RAG enabled, amd64 Linux | `platform: linux/amd64` is a no-op (native arch) |

## Test plan

- [ ] macOS install with RAG **disabled** — verify no Docker Compose errors about orphaned `embeddings` service
- [ ] macOS install with RAG **enabled** — verify embeddings container starts under Rosetta 2
- [ ] Linux install with RAG enabled — verify no regression (platform directive is a no-op)

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)