### PR TITLE
Integrate backup and restore into dream-cli

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -782,6 +782,30 @@ cmd_model() {
     esac
 }
 
+cmd_backup() {
+    check_install
+    cd "$INSTALL_DIR"
+
+    if [[ ! -x "$INSTALL_DIR/dream-backup.sh" ]]; then
+        error "dream-backup.sh not found or not executable"
+    fi
+
+    # Pass all arguments to dream-backup.sh
+    "$INSTALL_DIR/dream-backup.sh" "$@"
+}
+
+cmd_restore() {
+    check_install
+    cd "$INSTALL_DIR"
+
+    if [[ ! -x "$INSTALL_DIR/dream-restore.sh" ]]; then
+        error "dream-restore.sh not found or not executable"
+    fi
+
+    # Pass all arguments to dream-restore.sh
+    "$INSTALL_DIR/dream-restore.sh" "$@"
+}
+
 cmd_help() {
     sr_load
     cat << EOF
@@ -799,6 +823,8 @@ ${CYAN}Commands:${NC}
                       Switch between local/cloud/hybrid modes
   model [current|list|swap]
                       View or change the local LLM model tier
+  backup [options]    Create a backup of user data and config
+  restore [backup_id] Restore from a backup
   logs <service>      Tail logs for a service
   restart [service]   Restart services (all if no service specified)
   start [service]     Start services
@@ -855,6 +881,11 @@ ${CYAN}Examples:${NC}
   dream mode local                # Switch to local mode
   dream preset save my-setup      # Snapshot your config
   dream preset load my-setup      # Restore it later
+  dream backup                    # Create a backup
+  dream backup -c                 # Create compressed backup
+  dream backup -l                 # List all backups
+  dream restore                   # Interactive restore
+  dream restore 20260309-120000   # Restore specific backup
   dream logs llm                  # Watch llama-server logs (via alias)
   dream restart stt               # Restart Whisper (via alias)
   dream chat "What is 2+2?"      # Quick LLM test
@@ -877,6 +908,8 @@ case "${1:-help}" in
     preset|p)    shift; cmd_preset "$@" ;;
     mode|m)      shift; cmd_mode "$@" ;;
     model)       shift; cmd_model "$@" ;;
+    backup)      shift; cmd_backup "$@" ;;
+    restore)     shift; cmd_restore "$@" ;;
     logs|log|l)  shift; cmd_logs "$@" ;;
     restart|r)   shift; cmd_restart "$@" ;;
     start)       shift; cmd_start "$@" ;;

--- a/dream-server/tests/test-backup-restore-cli.sh
+++ b/dream-server/tests/test-backup-restore-cli.sh
@@ -1,0 +1,199 @@
+#!/bin/bash
+# Test suite for backup/restore CLI integration
+# Validates that dream-cli properly delegates to dream-backup.sh and dream-restore.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DREAM_CLI="$SCRIPT_DIR/../dream-cli"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Test counters
+PASSED=0
+FAILED=0
+
+# Test helpers
+pass() {
+    echo -e "${GREEN}✓${NC} $1"
+    ((PASSED++))
+}
+
+fail() {
+    echo -e "${RED}✗${NC} $1"
+    ((FAILED++))
+}
+
+info() {
+    echo -e "${BLUE}ℹ${NC} $1"
+}
+
+# Test 1: Verify dream-cli syntax
+test_syntax() {
+    info "Test 1: Validating dream-cli syntax"
+    if bash -n "$DREAM_CLI" 2>/dev/null; then
+        pass "dream-cli syntax is valid"
+    else
+        fail "dream-cli has syntax errors"
+    fi
+}
+
+# Test 2: Verify backup command exists in help
+test_backup_in_help() {
+    info "Test 2: Checking if 'backup' appears in help text"
+    if grep -q "backup.*Create a backup" "$DREAM_CLI" 2>/dev/null; then
+        pass "'backup' command listed in help"
+        return 0
+    else
+        fail "'backup' command not found in help"
+        return 0
+    fi
+}
+
+# Test 3: Verify restore command exists in help
+test_restore_in_help() {
+    info "Test 3: Checking if 'restore' appears in help text"
+    if grep -q "restore.*Restore from a backup" "$DREAM_CLI" 2>/dev/null; then
+        pass "'restore' command listed in help"
+        return 0
+    else
+        fail "'restore' command not found in help"
+        return 0
+    fi
+}
+
+# Test 4: Verify backup examples in help
+test_backup_examples() {
+    info "Test 4: Checking for backup examples in help text"
+    if grep -q "dream backup" "$DREAM_CLI" 2>/dev/null; then
+        pass "Backup examples present in help"
+        return 0
+    else
+        fail "Backup examples missing from help"
+        return 0
+    fi
+}
+
+# Test 5: Verify cmd_backup function exists
+test_cmd_backup_exists() {
+    info "Test 5: Checking if cmd_backup function is defined"
+    if grep -q "^cmd_backup()" "$DREAM_CLI" 2>/dev/null; then
+        pass "cmd_backup function is defined"
+        return 0
+    else
+        fail "cmd_backup function not found"
+        return 0
+    fi
+}
+
+# Test 6: Verify cmd_restore function exists
+test_cmd_restore_exists() {
+    info "Test 6: Checking if cmd_restore function is defined"
+    if grep -q "^cmd_restore()" "$DREAM_CLI" 2>/dev/null; then
+        pass "cmd_restore function is defined"
+        return 0
+    else
+        fail "cmd_restore function not found"
+        return 0
+    fi
+}
+
+# Test 7: Verify backup case in main switch
+test_backup_case() {
+    info "Test 7: Checking if 'backup' is in main case statement"
+    if grep -q "backup)" "$DREAM_CLI" 2>/dev/null; then
+        pass "'backup' case exists in main switch"
+        return 0
+    else
+        fail "'backup' case missing from main switch"
+        return 0
+    fi
+}
+
+# Test 8: Verify restore case in main switch
+test_restore_case() {
+    info "Test 8: Checking if 'restore' is in main case statement"
+    if grep -q "restore)" "$DREAM_CLI" 2>/dev/null; then
+        pass "'restore' case exists in main switch"
+        return 0
+    else
+        fail "'restore' case missing from main switch"
+        return 0
+    fi
+}
+
+# Test 9: Verify backup delegates to dream-backup.sh
+test_backup_delegation() {
+    info "Test 9: Checking if cmd_backup delegates to dream-backup.sh"
+    if grep -A5 "^cmd_backup()" "$DREAM_CLI" 2>/dev/null | grep -q "dream-backup.sh"; then
+        pass "cmd_backup delegates to dream-backup.sh"
+        return 0
+    else
+        fail "cmd_backup does not delegate to dream-backup.sh"
+        return 0
+    fi
+}
+
+# Test 10: Verify restore delegates to dream-restore.sh
+test_restore_delegation() {
+    info "Test 10: Checking if cmd_restore delegates to dream-restore.sh"
+    if grep -A5 "^cmd_restore()" "$DREAM_CLI" 2>/dev/null | grep -q "dream-restore.sh"; then
+        pass "cmd_restore delegates to dream-restore.sh"
+        return 0
+    else
+        fail "cmd_restore does not delegate to dream-restore.sh"
+        return 0
+    fi
+}
+
+# Test 11: Verify argument passing
+test_argument_passing() {
+    info "Test 11: Checking if arguments are passed through"
+    if grep -A10 "^cmd_backup()" "$DREAM_CLI" 2>/dev/null | grep -q '\$@'; then
+        pass "cmd_backup passes arguments correctly"
+        return 0
+    else
+        fail "cmd_backup does not pass arguments"
+        return 0
+    fi
+}
+
+# Run all tests
+echo ""
+echo -e "${BLUE}━━━ Backup/Restore CLI Integration Tests ━━━${NC}"
+echo ""
+
+test_syntax
+test_backup_in_help
+test_restore_in_help
+test_backup_examples
+test_cmd_backup_exists
+test_cmd_restore_exists
+test_backup_case
+test_restore_case
+test_backup_delegation
+test_restore_delegation
+test_argument_passing
+
+# Summary
+echo ""
+echo -e "${BLUE}━━━ Test Summary ━━━${NC}"
+echo ""
+echo -e "  ${GREEN}Passed:${NC} $PASSED"
+if [[ $FAILED -gt 0 ]]; then
+    echo -e "  ${RED}Failed:${NC} $FAILED"
+fi
+echo ""
+
+if [[ $FAILED -eq 0 ]]; then
+    echo -e "${GREEN}✓ All tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}✗ Some tests failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Exposes the existing backup and restore scripts through dream-cli so users can discover and use them from the main command interface. 

This adds dream backup and dream restore, updates help text and examples, and keeps the implementation lightweight by delegating to the current scripts without changing their behavior.