### PR TITLE
Feat/preset import export

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -664,8 +664,81 @@ META
             success "Preset '${name}' deleted."
             ;;
 
+        export|e)
+            [[ -z "$name" ]] && { log "Usage: dream preset export <name> <output.tar.gz>"; exit 1; }
+            local output="${3:-}"
+            [[ -z "$output" ]] && { log "Usage: dream preset export <name> <output.tar.gz>"; exit 1; }
+            local preset_dir="${PRESETS_DIR}/${name}"
+            [[ -d "$preset_dir" ]] || error "Preset not found: $name"
+
+            # Validate preset has required files
+            [[ -f "$preset_dir/meta.txt" ]] || error "Invalid preset: missing meta.txt"
+            [[ -f "$preset_dir/extensions.list" ]] || error "Invalid preset: missing extensions.list"
+
+            log "Exporting preset '${name}'..."
+
+            # Create archive (relative to presets dir to avoid absolute paths)
+            cd "$PRESETS_DIR"
+            if tar czf "$output" "$name" 2>/dev/null; then
+                local size
+                size=$(du -h "$output" 2>/dev/null | cut -f1)
+                success "Preset exported to: $output ($size)"
+            else
+                error "Failed to create archive"
+            fi
+            cd "$INSTALL_DIR"
+            ;;
+
+        import|i)
+            local archive="${2:-}"
+            [[ -z "$archive" ]] && { log "Usage: dream preset import <preset.tar.gz>"; exit 1; }
+            [[ -f "$archive" ]] || error "Archive not found: $archive"
+
+            log "Validating archive..."
+
+            # Security: Check for path traversal
+            if tar tzf "$archive" 2>/dev/null | grep -qE '(^/|\.\./|\.\.\\)'; then
+                error "Archive contains unsafe paths (absolute or ../) — refusing to import"
+            fi
+
+            # Validate archive structure
+            local archive_name
+            archive_name=$(tar tzf "$archive" 2>/dev/null | head -1 | cut -d/ -f1)
+            [[ -z "$archive_name" ]] && error "Invalid archive structure"
+
+            # Check if preset already exists
+            if [[ -d "${PRESETS_DIR}/${archive_name}" ]]; then
+                warn "Preset '${archive_name}' already exists"
+                read -p "Overwrite? [y/N] " -n 1 -r
+                echo ""
+                [[ $REPLY =~ ^[Yy]$ ]] || { log "Cancelled."; return 0; }
+                rm -rf "${PRESETS_DIR}/${archive_name}"
+            fi
+
+            # Extract archive
+            mkdir -p "$PRESETS_DIR"
+            cd "$PRESETS_DIR"
+            if tar xzf "$archive" 2>/dev/null; then
+                # Validate extracted preset
+                if [[ ! -f "${archive_name}/meta.txt" ]]; then
+                    rm -rf "${archive_name}"
+                    error "Invalid preset: missing meta.txt"
+                fi
+                if [[ ! -f "${archive_name}/extensions.list" ]]; then
+                    rm -rf "${archive_name}"
+                    error "Invalid preset: missing extensions.list"
+                fi
+
+                success "Preset '${archive_name}' imported successfully"
+                log "Use 'dream preset load ${archive_name}' to apply it"
+            else
+                error "Failed to extract archive"
+            fi
+            cd "$INSTALL_DIR"
+            ;;
+
         *)
-            log "Usage: dream preset <save|load|list|delete> [name]"
+            log "Usage: dream preset <save|load|list|delete|export|import> [name]"
             ;;
     esac
 }
@@ -818,7 +891,7 @@ ${CYAN}Commands:${NC}
   list                List all services and their status
   enable <service>    Enable an extension service
   disable <service>   Disable an extension service
-  preset <action>     Save/load/list/delete configuration presets
+  preset <action>     Save/load/list/delete/export/import presets
   mode [local|cloud|hybrid]
                       Switch between local/cloud/hybrid modes
   model [current|list|swap]
@@ -838,10 +911,14 @@ ${CYAN}Commands:${NC}
   help                Show this help
 
 ${CYAN}Preset Commands:${NC}
-  preset save <name>  Snapshot current config (env, mode, extensions)
-  preset load <name>  Restore a saved preset
-  preset list         Show all saved presets
-  preset delete <name> Delete a saved preset
+  preset save <name>     Snapshot current config (env, mode, extensions)
+  preset load <name>     Restore a saved preset
+  preset list            Show all saved presets
+  preset delete <name>   Delete a saved preset
+  preset export <name> <file.tar.gz>
+                         Export preset to shareable archive
+  preset import <file.tar.gz>
+                         Import preset from archive
 
 ${CYAN}Mode Commands:${NC}
   mode                Show current mode
@@ -881,6 +958,10 @@ ${CYAN}Examples:${NC}
   dream mode local                # Switch to local mode
   dream preset save my-setup      # Snapshot your config
   dream preset load my-setup      # Restore it later
+  dream preset export my-setup my-setup.tar.gz
+                                  # Export preset for sharing
+  dream preset import shared.tar.gz
+                                  # Import preset from file
   dream backup                    # Create a backup
   dream backup -c                 # Create compressed backup
   dream backup -l                 # List all backups

--- a/dream-server/tests/test-preset-import-export.sh
+++ b/dream-server/tests/test-preset-import-export.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# Test suite for preset import/export functionality
+# Validates export and import commands work correctly
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DREAM_CLI="$SCRIPT_DIR/../dream-cli"
+TEST_DIR="$(mktemp -d)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Test counters
+PASSED=0
+FAILED=0
+
+# Cleanup on exit
+cleanup() {
+    rm -rf "$TEST_DIR"
+}
+trap cleanup EXIT
+
+# Test helpers
+pass() {
+    echo -e "${GREEN}✓${NC} $1"
+    ((PASSED++))
+}
+
+fail() {
+    echo -e "${RED}✗${NC} $1"
+    ((FAILED++))
+}
+
+info() {
+    echo -e "${BLUE}ℹ${NC} $1"
+}
+
+# Test 1: Verify dream-cli syntax
+test_syntax() {
+    info "Test 1: Validating dream-cli syntax"
+    if bash -n "$DREAM_CLI" 2>/dev/null; then
+        pass "dream-cli syntax is valid"
+    else
+        fail "dream-cli has syntax errors"
+    fi
+}
+
+# Test 2: Verify export command exists in help
+test_export_in_help() {
+    info "Test 2: Checking if 'export' appears in preset help"
+    if grep -q "preset export" "$DREAM_CLI" 2>/dev/null; then
+        pass "'preset export' command documented"
+        return 0
+    else
+        fail "'preset export' command not documented"
+        return 0
+    fi
+}
+
+# Test 3: Verify import command exists in help
+test_import_in_help() {
+    info "Test 3: Checking if 'import' appears in preset help"
+    if grep -q "preset import" "$DREAM_CLI" 2>/dev/null; then
+        pass "'preset import' command documented"
+        return 0
+    else
+        fail "'preset import' command not documented"
+        return 0
+    fi
+}
+
+# Test 4: Verify export case exists
+test_export_case() {
+    info "Test 4: Checking if 'export' case exists in cmd_preset"
+    if grep -A2 "export|e)" "$DREAM_CLI" 2>/dev/null | grep -q "preset export"; then
+        pass "'export' case exists in cmd_preset"
+        return 0
+    else
+        fail "'export' case missing from cmd_preset"
+        return 0
+    fi
+}
+
+# Test 5: Verify import case exists
+test_import_case() {
+    info "Test 5: Checking if 'import' case exists in cmd_preset"
+    if grep -A2 "import|i)" "$DREAM_CLI" 2>/dev/null | grep -q "preset import"; then
+        pass "'import' case exists in cmd_preset"
+        return 0
+    else
+        fail "'import' case missing from cmd_preset"
+        return 0
+    fi
+}
+
+# Test 6: Verify export uses tar
+test_export_uses_tar() {
+    info "Test 6: Checking if export uses tar for archiving"
+    if grep -A20 "export|e)" "$DREAM_CLI" 2>/dev/null | grep -q "tar czf"; then
+        pass "Export uses tar for archiving"
+        return 0
+    else
+        fail "Export does not use tar"
+        return 0
+    fi
+}
+
+# Test 7: Verify import validates path traversal
+test_import_security() {
+    info "Test 7: Checking if import validates against path traversal"
+    if grep -A30 "import|i)" "$DREAM_CLI" 2>/dev/null | grep -q "path traversal"; then
+        pass "Import checks for path traversal attacks"
+        return 0
+    else
+        fail "Import missing path traversal validation"
+        return 0
+    fi
+}
+
+# Test 8: Verify export validates preset exists
+test_export_validation() {
+    info "Test 8: Checking if export validates preset exists"
+    if grep -A10 "export|e)" "$DREAM_CLI" 2>/dev/null | grep -q "Preset not found"; then
+        pass "Export validates preset existence"
+        return 0
+    else
+        fail "Export missing preset validation"
+        return 0
+    fi
+}
+
+# Test 9: Verify import validates archive structure
+test_import_validation() {
+    info "Test 9: Checking if import validates archive structure"
+    if grep -A50 "import|i)" "$DREAM_CLI" 2>/dev/null | grep -q "meta.txt"; then
+        pass "Import validates archive structure"
+        return 0
+    else
+        fail "Import missing structure validation"
+        return 0
+    fi
+}
+
+# Test 10: Verify export creates relative paths
+test_export_relative_paths() {
+    info "Test 10: Checking if export avoids absolute paths"
+    if grep -A15 "export|e)" "$DREAM_CLI" 2>/dev/null | grep -q "cd.*PRESETS_DIR"; then
+        pass "Export creates relative paths"
+        return 0
+    else
+        fail "Export may create absolute paths"
+        return 0
+    fi
+}
+
+# Test 11: Verify import handles overwrite confirmation
+test_import_overwrite() {
+    info "Test 11: Checking if import handles existing presets"
+    if grep -A30 "import|i)" "$DREAM_CLI" 2>/dev/null | grep -q "already exists"; then
+        pass "Import handles overwrite confirmation"
+        return 0
+    else
+        fail "Import missing overwrite handling"
+        return 0
+    fi
+}
+
+# Test 12: Verify usage messages updated
+test_usage_updated() {
+    info "Test 12: Checking if usage message includes export/import"
+    if grep "preset.*export.*import" "$DREAM_CLI" 2>/dev/null; then
+        pass "Usage message includes export/import"
+        return 0
+    else
+        fail "Usage message not updated"
+        return 0
+    fi
+}
+
+# Run all tests
+echo ""
+echo -e "${BLUE}━━━ Preset Import/Export Tests ━━━${NC}"
+echo ""
+
+test_syntax
+test_export_in_help
+test_import_in_help
+test_export_case
+test_import_case
+test_export_uses_tar
+test_import_security
+test_export_validation
+test_import_validation
+test_export_relative_paths
+test_import_overwrite
+test_usage_updated
+
+# Summary
+echo ""
+echo -e "${BLUE}━━━ Test Summary ━━━${NC}"
+echo ""
+echo -e "  ${GREEN}Passed:${NC} $PASSED"
+if [[ $FAILED -gt 0 ]]; then
+    echo -e "  ${RED}Failed:${NC} $FAILED"
+fi
+echo ""
+
+if [[ $FAILED -eq 0 ]]; then
+    echo -e "${GREEN}✓ All tests passed${NC}"
+    exit 0
+else
+    echo -e "${RED}✗ Some tests failed${NC}"
+    exit 1
+fi


### PR DESCRIPTION
Adds dream preset export and dream preset import to make presets portable and easier to share across installations. 

Export packages a preset as a tar.gz archive, while import validates archive structure, blocks unsafe paths, and handles existing preset conflicts more safely. 

Also updates help text and adds test coverage for the new CLI flow.