### PR TITLE
fix: load all docker services on macOS (apple backend filter regression)

### DIFF
--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -72,8 +72,12 @@ def load_extension_manifests(manifest_dir: Path, gpu_backend: str) -> tuple[dict
                 service_id = service.get("id")
                 if not service_id:
                     raise ValueError("service.id is required")
-                supported = service.get("gpu_backends", ["amd", "nvidia"])
-                if gpu_backend not in supported and "all" not in supported:
+                supported = service.get("gpu_backends", ["amd", "nvidia", "apple"])
+                if gpu_backend == "apple":
+                    if service.get("type") == "host-systemd":
+                        continue  # Linux-only service, not available on macOS
+                    # All docker services run on macOS regardless of gpu_backends declaration
+                elif gpu_backend not in supported and "all" not in supported:
                     continue
 
                 host_env = service.get("host_env")
@@ -98,8 +102,8 @@ def load_extension_manifests(manifest_dir: Path, gpu_backend: str) -> tuple[dict
                 for feature in manifest_features:
                     if not isinstance(feature, dict):
                         continue
-                    supported = feature.get("gpu_backends", ["amd", "nvidia"])
-                    if gpu_backend not in supported and "all" not in supported:
+                    supported = feature.get("gpu_backends", ["amd", "nvidia", "apple"])
+                    if gpu_backend != "apple" and gpu_backend not in supported and "all" not in supported:
                         continue
                     if feature.get("id") and feature.get("name"):
                         features.append(feature)

--- a/dream-server/extensions/services/dashboard-api/tests/test_config.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_config.py
@@ -116,3 +116,83 @@ class TestLoadExtensionManifests:
         feature_ids = [f["id"] for f in features]
         assert "both-feat" in feature_ids
         assert "amd-feat" not in feature_ids
+
+    def test_apple_backend_discovers_services_without_explicit_list(self, tmp_path):
+        """Services with no gpu_backends key default to [amd, nvidia, apple]."""
+        svc_dir = tmp_path / "generic-svc"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n  id: generic-svc\n  name: Generic\n  port: 80\n"
+        )
+
+        services, _ = load_extension_manifests(tmp_path, "apple")
+        assert "generic-svc" in services
+
+    def test_apple_backend_filtered_by_explicit_nvidia_amd_list(self, tmp_path):
+        """Docker service explicitly listing [amd, nvidia] is still loaded for apple backend."""
+        svc_dir = tmp_path / "gpu-only-svc"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n  id: gpu-only-svc\n  name: GPU Only\n  port: 80\n"
+            "  gpu_backends: [amd, nvidia]\n"
+        )
+
+        services, _ = load_extension_manifests(tmp_path, "apple")
+        assert "gpu-only-svc" in services
+
+    def test_apple_backend_discovers_service_explicitly_listing_apple(self, tmp_path):
+        """Service that lists apple in gpu_backends is discovered for apple backend."""
+        svc_dir = tmp_path / "apple-svc"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n  id: apple-svc\n  name: Apple Svc\n  port: 80\n"
+            "  gpu_backends: [amd, nvidia, apple]\n"
+        )
+
+        services, _ = load_extension_manifests(tmp_path, "apple")
+        assert "apple-svc" in services
+
+    def test_apple_backend_feature_default_discovered(self, tmp_path):
+        """Features with no gpu_backends key default to include apple."""
+        svc_dir = tmp_path / "svc-with-feature"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n  id: svc\n  name: Svc\n  port: 80\n"
+            "features:\n"
+            "  - id: default-feat\n    name: Default Feature\n"
+        )
+
+        _, features = load_extension_manifests(tmp_path, "apple")
+        assert any(f["id"] == "default-feat" for f in features)
+
+    def test_apple_backend_excludes_host_systemd(self, tmp_path):
+        """Services with type: host-systemd are excluded on apple backend."""
+        svc_dir = tmp_path / "systemd-svc"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n  id: systemd-svc\n  name: Systemd Svc\n  port: 80\n"
+            "  type: host-systemd\n"
+            "  gpu_backends: [amd, nvidia]\n"
+        )
+
+        services, _ = load_extension_manifests(tmp_path, "apple")
+        assert "systemd-svc" not in services
+
+    def test_apple_backend_loads_all_features(self, tmp_path):
+        """Features with gpu_backends: [amd, nvidia] are loaded for apple backend."""
+        svc_dir = tmp_path / "svc-with-gpu-feature"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n  id: svc\n  name: Svc\n  port: 80\n"
+            "features:\n"
+            "  - id: gpu-feat\n    name: GPU Feature\n    gpu_backends: [amd, nvidia]\n"
+        )
+
+        _, features = load_extension_manifests(tmp_path, "apple")
+        assert any(f["id"] == "gpu-feat" for f in features)


### PR DESCRIPTION
## What

Load all Docker-managed services and features on macOS regardless of gpu_backends declaration.

## Why

`config.py`'s `load_extension_manifests()` checked `if gpu_backend not in supported`, which filtered out every service declaring `gpu_backends: [amd, nvidia]`. On macOS (`GPU_BACKEND=apple`), this resulted in 0 services loaded — a full regression introduced by #102.

## How

- When `gpu_backend == "apple"`, skip only `type: host-systemd` services (Linux-only); load all Docker services unconditionally.
- Feature filter: prepend `gpu_backend != "apple"` guard so all features load on apple.
- Updated existing test assertion (was asserting filtered-out, now asserts loaded).
- Added 2 new tests: `test_apple_backend_excludes_host_systemd` and `test_apple_backend_loads_all_features`.

## Testing

- [x] Python syntax check: PASS
- [x] pytest: 102 passed, 0 failed
- [x] Secret scan: CLEAN
- [ ] Manual: verify dashboard loads all services on macOS M4

## Review

- Critique Guardian verdict: ✅ APPROVED (second pass after warning remediation)

## Platform Impact

- macOS (Apple Silicon): targeted fix — addresses the regression
- Linux: unaffected — new branches are inside `if gpu_backend == "apple"` guards
- Windows: not applicable

Fixes #118