### PR TITLE
fix: exclude not_deployed services from sidebar service count

### DIFF
--- a/dream-server/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -46,9 +46,10 @@ export default function Sidebar({ status, collapsed, onToggle }) {
 
   // Service counts with degraded nuance
   const services = status?.services || []
-  const onlineCount = services.filter(s => s.status === 'healthy' || s.status === 'degraded').length
-  const degradedCount = services.filter(s => s.status === 'degraded').length
-  const totalCount = services.length
+  const deployed = services.filter(s => s.status !== 'not_deployed')
+  const onlineCount = deployed.filter(s => s.status === 'healthy' || s.status === 'degraded').length
+  const degradedCount = deployed.filter(s => s.status === 'degraded').length
+  const totalCount = deployed.length
 
   // Memory bar: use unified (RAM) stats on APUs, VRAM on discrete
   const isUnified = status?.gpu?.memoryType === 'unified'


### PR DESCRIPTION
## What

Exclude `not_deployed` services from the sidebar service count denominator.

## Why

`Sidebar.jsx` counted all services (including `not_deployed`) as `totalCount`, while `Dashboard.jsx` filtered out `not_deployed` first. This caused mismatched counts — e.g., header showed "10/10" but sidebar showed "10/17".

## How

- Filter `services` into a `deployed` array excluding `status === 'not_deployed'`
- Derive `onlineCount`, `degradedCount`, and `totalCount` from `deployed` instead of raw `services`

## Testing

- [x] Python syntax check: PASS
- [x] pytest: 102 passed, 0 failed
- [x] Secret scan: CLEAN
- [ ] Manual: verify sidebar and header counts match on macOS M4

## Review

- Critique Guardian verdict: ✅ APPROVED (second pass after warning remediation)

## Platform Impact

- macOS (Apple Silicon): targeted fix
- Linux: same filtering logic applies, no regression
- Windows: not applicable

Fixes #116