### PR TITLE
fix(features): fall back to HOST_RAM_GB for VRAM gate on Apple Silicon

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/features.py
+++ b/dream-server/extensions/services/dashboard-api/routers/features.py
@@ -1,14 +1,17 @@
 """Feature discovery endpoints."""
 
+import logging
+import os
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 
-import os
 from config import FEATURES, GPU_BACKEND, SERVICES
 from gpu import get_gpu_info, get_gpu_tier
 from models import GPUInfo
 from security import verify_api_key
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["features"])
 
@@ -131,6 +134,11 @@ async def api_features(api_key: str = Depends(verify_api_key)):
             gpu_vram_gb = float(os.environ.get("HOST_RAM_GB", "0") or "0")
         except (ValueError, TypeError):
             pass
+        if gpu_vram_gb == 0:
+            logger.warning(
+                "Apple Silicon VRAM fallback: HOST_RAM_GB is 0 or unset; "
+                "all features will show insufficient_vram"
+            )
         memory_type = "unified"
 
     tier_recommendations = []

--- a/dream-server/extensions/services/dashboard-api/tests/test_features.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_features.py
@@ -2,7 +2,7 @@
 
 import os
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 
 
 class TestCalculateFeatureStatusAppleFallback:
@@ -54,3 +54,21 @@ class TestCalculateFeatureStatusAppleFallback:
                 result = calculate_feature_status(feature, [], None)
         # gpu_info is None, so gpu_vram_gb=0, which is < 8 → insufficient_vram on nvidia
         assert result["status"] == "insufficient_vram"
+
+
+class TestApiFeaturesAppleFallback:
+    """Tests for the endpoint-level Apple Silicon VRAM fallback in api_features()."""
+
+    def test_api_features_apple_fallback_gpu_summary(self, test_client):
+        """api_features() endpoint applies Apple Silicon HOST_RAM_GB fallback for GPU summary."""
+        with patch.dict(os.environ, {"HOST_RAM_GB": "16", "GPU_BACKEND": "apple"}):
+            with patch("routers.features.GPU_BACKEND", "apple"):
+                with patch("routers.features.get_gpu_info", return_value=None):
+                    with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
+                        response = test_client.get(
+                            "/api/features",
+                            headers=test_client.auth_headers,
+                        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["gpu"]["vramGb"] == 16.0


### PR DESCRIPTION
## What

Fall back to `HOST_RAM_GB` for VRAM gating on Apple Silicon when `get_gpu_info_apple()` returns None.

## Why

When `HOST_CHIP` env var is empty/missing, `get_gpu_info_apple()` returns `None`, causing `gpu_vram_gb=0`. Every feature with a VRAM requirement is then marked `insufficient_vram` even on machines with 24–128 GB unified memory. Apple Silicon uses unified memory where RAM = VRAM.

## How

- In `calculate_feature_status()`: when `gpu_vram_gb == 0` and `GPU_BACKEND == "apple"`, read `HOST_RAM_GB` as the VRAM proxy.
- Same fallback applied in `api_features()` endpoint-level GPU summary, with `memory_type = "unified"`, so the dashboard GPU card is also consistent.
- Warning logged once per request (in `api_features()`) when fallback fires but `HOST_RAM_GB` is still 0, so operators can diagnose the issue.
- Import block reordered to PEP 8: stdlib → third-party → local; `logger` moved after all imports.
- New `tests/test_features.py` with 4 tests: fallback enables features when RAM ≥ requirement, blocks when RAM < requirement, does not fire on nvidia backend, and endpoint-level fallback returns correct vramGb.

## Testing

- [x] Python syntax check: PASS
- [x] pytest: 4 passed, 0 failed
- [x] Secret scan: CLEAN
- [ ] Manual: verify feature cards show correct VRAM status on macOS M4 with missing HOST_CHIP

## Platform Impact

- macOS (Apple Silicon): targeted fix
- Linux: unaffected — fallback is gated by `GPU_BACKEND == "apple"`
- Windows: not applicable

Closes Light-Heart-Labs/DreamServer#119