### PR TITLE
Improve dream-cli portability and harden env/compose handling in scripts

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -352,7 +352,7 @@ cmd_chat() {
 
     # Get model from llama-server if not specified
     if [[ -z "$model" ]]; then
-        model=$(curl -s "http://localhost:${_llm_port}/v1/models" | grep -oP '"id":\s*"\K[^"]+' | head -1)
+        model=$(curl -s "http://localhost:${_llm_port}/v1/models" | jq -r '.data[0].id // "local"')
     fi
 
     log "Sending to $model..."

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -13,7 +13,20 @@ if [[ -f "$ROOT_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$ROOT_DIR"
     . "$ROOT_DIR/lib/service-registry.sh"
     sr_load
-    [[ -f "$ROOT_DIR/.env" ]] && set -a && . "$ROOT_DIR/.env" && set +a
+    if [[ -f "$ROOT_DIR/.env" ]]; then
+        set -a
+        while IFS='=' read -r key value; do
+            [[ "$key" =~ ^[[:space:]]*# ]] && continue
+            [[ -z "$key" ]] && continue
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            export "$key=$value"
+        done < "$ROOT_DIR/.env"
+        set +a
+    fi
 fi
 _DASHBOARD_PORT="${SERVICE_PORTS[dashboard]:-3001}"
 _WEBUI_PORT="${SERVICE_PORTS[open-webui]:-3000}"

--- a/dream-server/scripts/dream-preflight.sh
+++ b/dream-server/scripts/dream-preflight.sh
@@ -11,8 +11,28 @@ cd "$SCRIPT_DIR"
 . "$SCRIPT_DIR/lib/service-registry.sh"
 sr_load
 
-# Source .env for port overrides
-[[ -f "$SCRIPT_DIR/.env" ]] && set -a && . "$SCRIPT_DIR/.env" && set +a
+# Safe .env loading for port overrides
+if [[ -f "$SCRIPT_DIR/.env" ]]; then
+    set -a
+    while IFS='=' read -r key value; do
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "$key" ]] && continue
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        value="${value%\"}"
+        value="${value#\"}"
+        value="${value%\'}"
+        value="${value#\'}"
+        export "$key=$value"
+    done < "$SCRIPT_DIR/.env"
+    set +a
+fi
+
+# Resolve compose flags for accurate status checks
+COMPOSE_FLAGS=""
+if [[ -x "$SCRIPT_DIR/scripts/resolve-compose-stack.sh" ]]; then
+    COMPOSE_FLAGS=$("$SCRIPT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}")
+fi
 
 # Colors
 RED='\033[0;31m'
@@ -25,8 +45,8 @@ echo -e "${CYAN}Dream Server Preflight Check${NC}"
 echo "=============================="
 echo ""
 
-# Resolve ports from registry
-LLM_PORT="${SERVICE_PORTS[llama-server]:-8080}"
+# Resolve ports from registry + env overrides
+LLM_PORT="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-${SERVICE_PORTS[llama-server]:-8080}}}"
 LLM_HEALTH="${SERVICE_HEALTH[llama-server]:-/health}"
 LLM_CONTAINER="${SERVICE_CONTAINERS[llama-server]:-dream-llama-server}"
 WEBUI_PORT="${SERVICE_PORTS[open-webui]:-3000}"
@@ -44,7 +64,7 @@ fi
 
 # Check containers are up
 echo -n "Core containers... "
-if docker compose ps | grep -q "$LLM_CONTAINER"; then
+if docker compose $COMPOSE_FLAGS ps | grep -q "$LLM_CONTAINER"; then
     echo -e "${GREEN}✓ running${NC}"
 else
     echo -e "${RED}✗ not running${NC}"
@@ -83,7 +103,7 @@ fi
 for sid in "${SERVICE_IDS[@]}"; do
     [[ "${SERVICE_CATEGORIES[$sid]}" == "core" ]] && continue
     container="${SERVICE_CONTAINERS[$sid]}"
-    docker compose ps 2>/dev/null | grep -q "$container" || continue
+    docker compose $COMPOSE_FLAGS ps 2>/dev/null | grep -q "$container" || continue
 
     port="${SERVICE_PORTS[$sid]:-0}"
     health="${SERVICE_HEALTH[$sid]:-/}"

--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -25,7 +25,20 @@ if [[ -f "$_FT_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$_FT_DIR"
     . "$_FT_DIR/lib/service-registry.sh"
     sr_load
-    [[ -f "$_FT_DIR/.env" ]] && set -a && . "$_FT_DIR/.env" && set +a
+    if [[ -f "$_FT_DIR/.env" ]]; then
+        set -a
+        while IFS='=' read -r key value; do
+            [[ "$key" =~ ^[[:space:]]*# ]] && continue
+            [[ -z "$key" ]] && continue
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            export "$key=$value"
+        done < "$_FT_DIR/.env"
+        set +a
+    fi
 fi
 
 # Service endpoints — resolved from registry

--- a/dream-server/scripts/dream-test.sh
+++ b/dream-server/scripts/dream-test.sh
@@ -36,7 +36,20 @@ if [[ -f "$_DT_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$_DT_DIR"
     . "$_DT_DIR/lib/service-registry.sh"
     sr_load
-    [[ -f "$_DT_DIR/.env" ]] && set -a && . "$_DT_DIR/.env" && set +a
+    if [[ -f "$_DT_DIR/.env" ]]; then
+        set -a
+        while IFS='=' read -r key value; do
+            [[ "$key" =~ ^[[:space:]]*# ]] && continue
+            [[ -z "$key" ]] && continue
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            export "$key=$value"
+        done < "$_DT_DIR/.env"
+        set +a
+    fi
 fi
 
 # Service endpoints — resolved from registry

--- a/dream-server/scripts/first-boot-demo.sh
+++ b/dream-server/scripts/first-boot-demo.sh
@@ -27,7 +27,20 @@ if [[ -f "$_DEMO_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$_DEMO_DIR"
     . "$_DEMO_DIR/lib/service-registry.sh"
     sr_load
-    [[ -f "$_DEMO_DIR/.env" ]] && set -a && . "$_DEMO_DIR/.env" && set +a
+    if [[ -f "$_DEMO_DIR/.env" ]]; then
+        set -a
+        while IFS='=' read -r key value; do
+            [[ "$key" =~ ^[[:space:]]*# ]] && continue
+            [[ -z "$key" ]] && continue
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            export "$key=$value"
+        done < "$_DEMO_DIR/.env"
+        set +a
+    fi
 fi
 
 LLM_URL="${LLM_URL:-http://localhost:${SERVICE_PORTS[llama-server]:-8080}}"

--- a/dream-server/scripts/showcase.sh
+++ b/dream-server/scripts/showcase.sh
@@ -24,7 +24,20 @@ if [[ -f "$DREAM_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$DREAM_DIR"
     . "$DREAM_DIR/lib/service-registry.sh"
     sr_load
-    [[ -f "$DREAM_DIR/.env" ]] && set -a && . "$DREAM_DIR/.env" && set +a
+    if [[ -f "$DREAM_DIR/.env" ]]; then
+        set -a
+        while IFS='=' read -r key value; do
+            [[ "$key" =~ ^[[:space:]]*# ]] && continue
+            [[ -z "$key" ]] && continue
+            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+            value="${value%\"}"
+            value="${value#\"}"
+            value="${value%\'}"
+            value="${value#\'}"
+            export "$key=$value"
+        done < "$DREAM_DIR/.env"
+        set +a
+    fi
 fi
 
 # URLs — resolved from registry

--- a/dream-server/scripts/validate.sh
+++ b/dream-server/scripts/validate.sh
@@ -48,6 +48,13 @@ LLM_HEALTH="${SERVICE_HEALTH[llama-server]:-/health}"
 WEBUI_PORT="${WEBUI_PORT:-${SERVICE_PORTS[open-webui]:-3000}}"
 WEBUI_HEALTH="${WEBUI_HEALTH:-${SERVICE_HEALTH[open-webui]:-/}}"
 
+# Resolve compose flags to match actual stack
+COMPOSE_FLAGS=""
+if [[ -x "$PROJECT_DIR/scripts/resolve-compose-stack.sh" ]]; then
+    COMPOSE_FLAGS=$("$PROJECT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$PROJECT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}")
+fi
+
 echo ""
 echo "╔═══════════════════════════════════════════╗"
 echo "║     Dream Server Validation Test          ║"
@@ -73,8 +80,8 @@ check() {
 
 echo "1. Container Status"
 echo "───────────────────"
-check "llama-server running" "docker compose ps llama-server 2>/dev/null | grep -q 'Up\|running'"
-check "Open WebUI running" "docker compose ps open-webui 2>/dev/null | grep -q 'Up\|running'"
+check "llama-server running" "docker compose $COMPOSE_FLAGS ps llama-server 2>/dev/null | grep -q 'Up\|running'"
+check "Open WebUI running" "docker compose $COMPOSE_FLAGS ps open-webui 2>/dev/null | grep -q 'Up\|running'"
 
 echo ""
 echo "2. Health Endpoints"
@@ -130,7 +137,7 @@ for sid in "${SERVICE_IDS[@]}"; do
     [[ -z "$_health" || "$_port" == "0" ]] && continue
 
     # Check if container is running
-    if docker compose ps "$sid" 2>/dev/null | grep -q "Up\|running"; then
+    if docker compose $COMPOSE_FLAGS ps "$sid" 2>/dev/null | grep -q "Up\|running"; then
         check "$_name" "curl -sf http://localhost:${_port}${_health}"
     else
         printf "  %-30s ${YELLOW}○ SKIP (not enabled)${NC}\n" "$_name..."


### PR DESCRIPTION
- Use `jq` instead of `grep -oP` in `dream-cli` `cmd_chat` to select the model from `/v1/models`, improving cross-platform compatibility.
- Replace direct `.env` sourcing with a safe loader in `showcase.sh`, `dream-test.sh`, `dream-test-functional.sh`, `first-boot-demo.sh`, `dream-preflight.sh`, and `dream-doctor.sh`.
- In `dream-preflight.sh` and `validate.sh`, resolve compose flags via `scripts/resolve-compose-stack.sh` and use them for all `docker compose` calls so checks match the actual running stack.