### PR TITLE
fix: align Windows OpenCode and health check ports with OLLAMA_PORT

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -684,7 +684,8 @@ if ($DryRun) {
                 New-Item -ItemType Directory -Path $script:OPENCODE_CONFIG_DIR -Force | Out-Null
                 $ocConfigFile = Join-Path $script:OPENCODE_CONFIG_DIR "opencode.json"
                 if (-not (Test-Path $ocConfigFile)) {
-                    $llamaPort = $(if ($gpuInfo.Backend -eq "amd") { "8080" } else { "11434" })
+                    # OLLAMA_PORT in .env is always 8080; AMD native also uses 8080
+                    $llamaPort = "8080"
                     # NOTE: llama-server exposes models by GGUF filename, not friendly name
                     $ocModelId = $tierConfig.GgufFile
                     $ocConfig = @"
@@ -772,8 +773,8 @@ if ($DryRun) {
 }
 
 # Health check loop
-# NOTE: NVIDIA maps llama-server to host port 11434; AMD runs natively on 8080
-$llamaHealthPort = $(if ($gpuInfo.Backend -eq "amd") { "8080" } else { "11434" })
+# NOTE: OLLAMA_PORT is always 8080 in .env; both NVIDIA Docker and AMD native use 8080
+$llamaHealthPort = "8080"
 $healthChecks = @(
     @{ Name = "LLM (llama-server)"; Url = "http://localhost:${llamaHealthPort}/health" }
     @{ Name = "Chat UI (Open WebUI)"; Url = "http://localhost:3000" }


### PR DESCRIPTION
## Summary

- The `.env` generator sets `OLLAMA_PORT=8080`, and `docker-compose.base.yml` maps `127.0.0.1:${OLLAMA_PORT:-11434}:8080` — so the actual host port is **8080**
- The OpenCode config generator (line 687) and installer health check (line 776) hardcoded `11434` for NVIDIA, causing two bugs:
  - **OpenCode fails to connect to llama-server** ("Unable to connect" error on first use)
  - **Installer health check times out** for llama-server during Phase 6 verification
- This aligns both references with the actual `OLLAMA_PORT` value written to `.env`

## Test plan

- [ ] Run `.\install.ps1 -All -NonInteractive` on Windows with NVIDIA GPU
- [ ] Verify OpenCode connects to llama-server without manual config edits
- [ ] Verify installer health check passes for llama-server in Phase 6
- [ ] Run `.\install.ps1 -DryRun` to confirm no regression in dry-run output

🤖 Generated with [Claude Code](https://claude.com/claude-code)