### PR TITLE
fix: align Linux OpenCode config and manifest port with OLLAMA_PORT

### DIFF
--- a/dream-server/extensions/services/llama-server/manifest.yaml
+++ b/dream-server/extensions/services/llama-server/manifest.yaml
@@ -9,7 +9,7 @@ service:
   default_host: llama-server
   port: 8080
   external_port_env: OLLAMA_PORT
-  external_port_default: 11434
+  external_port_default: 8080
   health: /health
   type: docker
   gpu_backends: [amd, nvidia]

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -115,7 +115,7 @@ else
       "npm": "@ai-sdk/openai-compatible",
       "name": "llama-server (local)",
       "options": {
-        "baseURL": "http://127.0.0.1:${OLLAMA_PORT:-11434}/v1",
+        "baseURL": "http://127.0.0.1:${OLLAMA_PORT:-8080}/v1",
         "apiKey": "no-key"
       },
       "models": {


### PR DESCRIPTION
## Summary

Follow-up to #130 (Windows fix). The same stale `11434` default existed in two more places:

- **Linux OpenCode config** (`installers/phases/07-devtools.sh` line 118): Used `${OLLAMA_PORT:-11434}` but `OLLAMA_PORT` is never exported to the shell environment (only written to `.env` file), so the `11434` fallback always triggered. Changed to `:-8080`.
- **llama-server manifest.yaml**: `external_port_default` was `11434`, now `8080`. The service registry reads this value into `SERVICE_PORTS[llama-server]`, which is used by phase 12 health checks and the `dream-cli`.

Both `.env` generators (Linux phase 06 and Windows) write `OLLAMA_PORT=8080`, so all references should default to `8080`.

## Test plan

- [ ] Run `./install.sh --all --non-interactive` on Linux with NVIDIA GPU
- [ ] Verify OpenCode connects to llama-server without manual config edits
- [ ] Verify `dream status` health checks use correct port
- [ ] Run `./install.sh --dry-run` to confirm no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)