### PR TITLE
fix: read OLLAMA_PORT from .env in Linux OpenCode config

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -106,6 +106,11 @@ else
         OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
         mkdir -p "$OPENCODE_CONFIG_DIR"
         if [[ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]]; then
+            # Read OLLAMA_PORT from the .env generated in phase 06
+            # (it's not exported as a shell variable, only written to the file)
+            if [[ -z "${OLLAMA_PORT:-}" && -f "$INSTALL_DIR/.env" ]]; then
+                OLLAMA_PORT=$(grep -m1 '^OLLAMA_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            fi
             cat > "$OPENCODE_CONFIG_DIR/opencode.json" <<OPENCODE_EOF
 {
   "\$schema": "https://opencode.ai/config.json",


### PR DESCRIPTION
## Summary

Follow-up to #131. Phase 06 writes `OLLAMA_PORT=8080` to the `.env` file but never exports it as a shell variable. Phase 07 builds the OpenCode config using `${OLLAMA_PORT:-8080}`, which always hit the fallback since the variable was never in the shell environment.

This means if a user customized `OLLAMA_PORT` in `.env` (e.g., `OLLAMA_PORT=9090` to avoid conflicts), OpenCode would still point to port `8080` and fail to connect.

**Fix:** Read `OLLAMA_PORT` from the generated `.env` before using it, matching the existing pattern used for `OPENCODE_SERVER_PASSWORD` on line 152 of the same file.

```bash
# Read OLLAMA_PORT from the .env generated in phase 06
if [[ -z "${OLLAMA_PORT:-}" && -f "$INSTALL_DIR/.env" ]]; then
    OLLAMA_PORT=$(grep -m1 '^OLLAMA_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
fi
```

## Test plan

- [ ] Run `./install.sh --all --non-interactive` on Linux — verify OpenCode connects
- [ ] Set `OLLAMA_PORT=9090` before install — verify OpenCode config uses `9090`
- [ ] Verify default install still uses `8080` when no custom port is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)