### PR TITLE
fix(macos): make docker compose failure diagnostic reachable under pipefail

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -610,11 +610,14 @@ else
     # ── Start Docker services ──
     chapter "STARTING SERVICES"
     ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d"
+    set +o pipefail  # pipefail would abort on compose exit before PIPESTATUS is read; capture it first
     docker compose "${COMPOSE_FLAGS[@]}" up -d 2>&1 | while IFS= read -r line; do
         echo "  $line"
     done
+    compose_exit="${PIPESTATUS[0]}"
+    set -o pipefail
 
-    if [[ "${PIPESTATUS[0]}" -ne 0 ]]; then
+    if [[ "$compose_exit" -ne 0 ]]; then
         ai_err "docker compose up failed"
         exit 1
     fi


### PR DESCRIPTION
## Summary

- `${PIPESTATUS[0]}` was dead code: `set -euo pipefail` caused the shell to abort on compose failure before the `if` block was reached
- Fix: disable `pipefail` around the compose pipeline, capture exit code into `compose_exit`, re-enable `pipefail`, then check `compose_exit`
- Added explanatory comment so future readers understand why `pipefail` is temporarily disabled

## Test plan

- [ ] On macOS: run install with an intentionally bad compose file — confirm the installer now prints `docker compose up failed` and exits non-zero instead of continuing
- [ ] Run `make lint` (shellcheck) — confirm no new shellcheck errors

Closes Light-Heart-Labs/DreamServer#140

🤖 Generated with [Claude Code](https://claude.com/claude-code)