### PR TITLE
fix(resolve-compose): emit stderr warning on manifest parse failure

### DIFF
--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -133,7 +133,8 @@ if ext_dir.exists():
             gpu_overlay = service_dir / f"compose.{gpu_backend}.yaml"
             if gpu_overlay.exists():
                 resolved.append(str(gpu_overlay.relative_to(script_dir)))
-        except Exception:
+        except Exception as e:
+            print(f"WARNING: skipping {service_dir.name}: {e}", file=sys.stderr)
             continue
 
 # Include docker-compose.override.yml if it exists (user customizations)


### PR DESCRIPTION
## Summary

- Silent `except Exception: continue` in `resolve-compose-stack.sh` discarded all extension manifest parse errors with no output
- Now prints `WARNING: skipping <service>: <error>` to stderr, preserving resilience while enabling diagnosis

## Test plan

- [ ] Create a malformed `manifest.yaml` in a test extension directory — confirm `WARNING: skipping ...` appears on stderr
- [ ] Valid manifests continue to load silently (no change in output)
- [ ] Run `make lint` — confirm no shellcheck or Python compile errors

Closes Light-Heart-Labs/DreamServer#143

🤖 Generated with [Claude Code](https://claude.com/claude-code)