### PR TITLE
fix(dashboard-api): close socket with context manager to prevent FD leak

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -166,11 +166,10 @@ async def preflight_ports(request: PortCheckRequest):
 
     conflicts = []
     for port in request.ports:
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.settimeout(1)
         try:
-            sock.bind(("0.0.0.0", port))
-            sock.close()
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(1)
+                sock.bind(("0.0.0.0", port))
         except socket.error:
             conflicts.append({"port": port, "service": port_services.get(port, "Unknown"), "in_use": True})
     return {"conflicts": conflicts, "available": len(conflicts) == 0}


### PR DESCRIPTION
## Summary

- Socket file descriptor was opened outside the `try` block in `preflight_ports`, causing an FD leak on bind failure
- Replaced with `with socket.socket(...) as sock:` context manager that guarantees cleanup on both success and error paths

## Root cause

`socket.socket()` allocates an OS file descriptor. When `bind()` raises `socket.error` (port in use), the except branch appended to `conflicts` but never closed the socket, leaking one FD per checked port per conflict.

## Test plan

- [ ] Run the dashboard installer preflight check against a port that is already in use — confirm no FD accumulation
- [ ] Run existing dashboard-api tests: `cd extensions/services/dashboard-api && python -m pytest tests/`

Closes Light-Heart-Labs/DreamServer#142

🤖 Generated with [Claude Code](https://claude.com/claude-code)