### PR TITLE
Improve dream-cli status and config UX (status-json, config validate, mode summary)

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -201,6 +201,102 @@ cmd_status() {
     fi
 }
 
+cmd_status_json() {
+    check_install
+    cd "$INSTALL_DIR"
+    sr_load
+    load_env
+
+    local flags
+    flags=$(get_compose_flags)
+
+    # Capture running services for optional-service checks (best-effort)
+    local running_services=""
+    if docker compose $flags ps --format "{{.Service}}" >/dev/null 2>&1; then
+        running_services=$(docker compose $flags ps --format "{{.Service}}")
+    elif command -v docker-compose >/dev/null 2>&1; then
+        running_services=$(docker-compose ps --services --filter "status=running" 2>/dev/null || true)
+    fi
+
+    # Temp file to accumulate per-service JSON objects
+    local tmp
+    tmp=$(mktemp)
+    trap 'rm -f "$tmp"' RETURN
+
+    for sid in "${SERVICE_IDS[@]}"; do
+        local cat="${SERVICE_CATEGORIES[$sid]}"
+        local health="${SERVICE_HEALTH[$sid]}"
+        local port_env="${SERVICE_PORT_ENVS[$sid]}"
+        local default_port="${SERVICE_PORTS[$sid]}"
+        local name="${SERVICE_NAMES[$sid]:-$sid}"
+
+        # Skip services with no health endpoint or port configured
+        [[ -z "$health" || "$default_port" == "0" ]] && continue
+
+        # Resolve port from env var or default
+        local port="$default_port"
+        if [[ -n "$port_env" ]]; then
+            port="${!port_env:-$default_port}"
+        fi
+        local container_status="unknown"
+        local status="unknown"
+
+        # Determine container status (running/stopped) when we have ps output
+        if [[ -n "$running_services" ]]; then
+            if grep -qE "(^|[[:space:]])${sid}([[:space:]]|$)" <<<"$running_services"; then
+                container_status="running"
+            else
+                container_status="stopped"
+            fi
+        fi
+
+        # For non-core services that are clearly stopped, avoid HTTP probe
+        if [[ "$cat" != "core" && "$container_status" == "stopped" ]]; then
+            status="stopped"
+        else
+            local url="http://localhost:${port}${health}"
+            if curl -sf --max-time 5 "$url" > /dev/null 2>&1; then
+                status="healthy"
+            else
+                status="unhealthy"
+            fi
+        fi
+
+        jq -n \
+            --arg id "$sid" \
+            --arg name "$name" \
+            --arg category "$cat" \
+            --arg port "$port" \
+            --arg status "$status" \
+            --arg containerStatus "$container_status" \
+            '{id: $id, name: $name, category: $category, port: $port, status: $status, containerStatus: $containerStatus}' >> "$tmp"
+    done
+
+    # GPU summary (optional)
+    local gpu_summary_json="null"
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        # Represent each GPU line as raw strings in an array
+        gpu_summary_json=$(nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu \
+            --format=csv,noheader,nounits 2>/dev/null | jq -R -s 'split("\n") | map(select(length > 0))')
+    fi
+
+    # Aggregate into a single document
+    jq -s \
+        --arg installDir "$INSTALL_DIR" \
+        --arg composeFlags "$flags" \
+        --arg mode "${DREAM_MODE:-local}" \
+        --arg tier "${TIER:-}" \
+        --arg currentModel "${LLM_MODEL:-}" \
+        --argjson gpu "$gpu_summary_json" \
+        '{installDir: $installDir,
+          composeFlags: $composeFlags,
+          mode: $mode,
+          tier: $tier,
+          currentModel: $currentModel,
+          gpu: $gpu,
+          services: .}' "$tmp"
+}
+
 cmd_logs() {
     check_install
     cd "$INSTALL_DIR"
@@ -336,8 +432,17 @@ cmd_config() {
             ${EDITOR:-nano} "$INSTALL_DIR/.env"
             warn "Restart services for changes to take effect: dream restart"
             ;;
+        validate)
+            cd "$INSTALL_DIR"
+            if [[ -x "$INSTALL_DIR/scripts/validate-env.sh" ]]; then
+                "$INSTALL_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$INSTALL_DIR/.env.schema.json"
+            else
+                warn "validate-env.sh not found at $INSTALL_DIR/scripts/validate-env.sh"
+                warn "Make sure you're on a recent Dream Server release."
+            fi
+            ;;
         *)
-            log "Usage: dream config [show|edit]"
+            log "Usage: dream config [show|edit|validate]"
             ;;
     esac
 }
@@ -757,9 +862,15 @@ cmd_mode() {
         # Show current mode
         local current=$(grep "^DREAM_MODE=" .env 2>/dev/null | cut -d= -f2)
         current="${current:-local}"
+        local api_url=$(grep "^LLM_API_URL=" .env 2>/dev/null | cut -d= -f2)
+        local model=$(grep "^LLM_MODEL=" .env 2>/dev/null | cut -d= -f2)
+        local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2)
         echo -e "${BLUE}━━━ Dream Server Mode ━━━${NC}"
         echo ""
         echo -e "Current mode: ${GREEN}${current}${NC}"
+        [[ -n "$api_url" ]] && echo "LLM_API_URL: $api_url"
+        [[ -n "$model" ]] && echo "Model: $model"
+        [[ -n "$tier" ]] && echo "Tier: $tier"
         echo ""
 
         case "$current" in
@@ -795,10 +906,13 @@ cmd_mode() {
     # Update .env
     _env_set "DREAM_MODE" "$mode"
 
+    local api_url
     if [[ "$mode" == "local" ]]; then
-        _env_set "LLM_API_URL" "http://llama-server:8080"
+        api_url="http://llama-server:8080"
+        _env_set "LLM_API_URL" "$api_url"
     else
-        _env_set "LLM_API_URL" "http://litellm:4000"
+        api_url="http://litellm:4000"
+        _env_set "LLM_API_URL" "$api_url"
         # Auto-enable litellm
         local litellm_cf="$INSTALL_DIR/extensions/services/litellm/compose.yaml"
         local litellm_disabled="${litellm_cf}.disabled"
@@ -815,6 +929,9 @@ cmd_mode() {
         fi
     fi
 
+    echo -e "${BLUE}━━━ Mode updated ━━━${NC}"
+    echo "  DREAM_MODE  = $mode"
+    echo "  LLM_API_URL = $api_url"
     success "Switched to $mode mode. Run 'dream restart' to apply."
 }
 
@@ -825,7 +942,9 @@ cmd_model() {
     case "$subcmd" in
         current)
             local model=$(grep "^LLM_MODEL=" .env 2>/dev/null | cut -d= -f2)
+            local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2)
             echo "Current model: ${model:-<not set>}"
+            [[ -n "$tier" ]] && echo "Current tier: $tier"
             ;;
         list)
             echo -e "${BLUE}━━━ Available Tiers ━━━${NC}"
@@ -891,6 +1010,7 @@ Usage: dream <command> [options]
 
 ${CYAN}Commands:${NC}
   status              Show service health and GPU status
+  status-json         Machine-readable status (JSON) with mode/tier/model
   list                List all services and their status
   enable <service>    Enable an extension service
   disable <service>   Disable an extension service
@@ -907,7 +1027,8 @@ ${CYAN}Commands:${NC}
   stop [service]      Stop services
   update              Pull latest images and restart
   shell <service>     Open shell in container
-  config [show|edit]  View or edit configuration
+  config [show|edit|validate]
+                      View, edit, or validate configuration
   chat "<message>"    Quick chat with the LLM
   benchmark           Run a quick performance test
   doctor [report]     Run diagnostics and write JSON report
@@ -955,6 +1076,7 @@ EOF
 
 ${CYAN}Examples:${NC}
   dream status                    # Check all services
+  dream status-json               # JSON summary (mode/tier/model + services)
   dream list                      # See all available services
   dream enable n8n                # Enable the n8n extension
   dream disable whisper           # Disable Whisper STT
@@ -974,6 +1096,7 @@ ${CYAN}Examples:${NC}
   dream restart stt               # Restart Whisper (via alias)
   dream chat "What is 2+2?"      # Quick LLM test
   dream config edit               # Edit .env file
+  dream config validate           # Validate .env against schema
 
 ${CYAN}Environment:${NC}
   DREAM_HOME          Installation directory (default: ~/dream-server)
@@ -986,6 +1109,7 @@ EOF
 #=============================================================================
 case "${1:-help}" in
     status|s)    cmd_status ;;
+    status-json) cmd_status_json ;;
     list|ls)     cmd_list ;;
     enable)      shift; cmd_enable "$@" ;;
     disable)     shift; cmd_disable "$@" ;;


### PR DESCRIPTION
## Summary

- Add `dream status-json` to output a machine-readable JSON summary including installDir, compose flags, current mode/tier/model, GPU summary (when available), and per-service status/containerStatus.
- Extend `dream config` with `validate` to run `scripts/validate-env.sh` against `.env` and `.env.schema.json`, and update help/examples accordingly.
- Improve `dream mode` and `dream model current` UX by showing current LLM endpoint, model, and tier, and printing a clear summary after mode changes.

## Details

- `status-json` uses the service registry and safe `.env` loader, detects running containers, and only probes HTTP health for core or running optional services.
- `config validate` is a thin wrapper around the existing `scripts/validate-env.sh` script; it prints a warning if the script is missing.
- `mode` now shows `DREAM_MODE`, `LLM_API_URL`, `LLM_MODEL`, and `TIER` when available, and prints a short “Mode updated” block after switching; `model current` also includes the current tier.

## Notes

- All changes are limited to `dream-server/dream-cli` (Bash). Python/JS behavior is unchanged.