### PR TITLE
fix(comfyui): harden port binding and security options

### DIFF
--- a/dream-server/extensions/services/comfyui/compose.amd.yaml
+++ b/dream-server/extensions/services/comfyui/compose.amd.yaml
@@ -9,10 +9,8 @@ services:
     group_add:
       - "${VIDEO_GID:-44}"
       - "${RENDER_GID:-992}"
-    cap_add:
-      - SYS_PTRACE
     security_opt:
-      - seccomp:unconfined
+      - no-new-privileges:true
     shm_size: 8g
     environment:
       - HSA_OVERRIDE_GFX_VERSION=11.5.1
@@ -21,7 +19,7 @@ services:
     volumes:
       - ./data/comfyui/ComfyUI:/opt/ComfyUI
     ports:
-      - "${COMFYUI_PORT:-8188}:8188"
+      - "127.0.0.1:${COMFYUI_PORT:-8188}:8188"
     command: >-
       /bin/sh -c "/opt/comfyui-gfx1151-utils/check-comfyui.sh &&
       python3 /opt/ComfyUI/main.py --listen 0.0.0.0 --use-flash-attention"

--- a/dream-server/extensions/services/comfyui/compose.nvidia.yaml
+++ b/dream-server/extensions/services/comfyui/compose.nvidia.yaml
@@ -5,8 +5,10 @@ services:
       dockerfile: Dockerfile
     container_name: dream-comfyui
     restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
     ports:
-      - "${COMFYUI_PORT:-8188}:8188"
+      - "127.0.0.1:${COMFYUI_PORT:-8188}:8188"
     volumes:
       - ./data/comfyui/models:/models
       - ./data/comfyui/output:/output
@@ -15,6 +17,9 @@ services:
     shm_size: '8g'
     deploy:
       resources:
+        limits:
+          cpus: '16.0'
+          memory: 24G
         reservations:
           devices:
             - driver: nvidia


### PR DESCRIPTION
## What

Hardens ComfyUI's Docker Compose security configuration across both AMD and NVIDIA overlays.

## Why

ComfyUI was the only service in the stack binding to `0.0.0.0`, exposing its unauthenticated web UI to the LAN on every install. The AMD overlay also shipped with `SYS_PTRACE` + `seccomp:unconfined` — effectively a kernel debugging configuration — with no legitimate justification for an inference workload. The NVIDIA overlay was missing the `no-new-privileges` flag and had no resource limits.

## How

- **Port binding**: Added `127.0.0.1:` prefix to both AMD and NVIDIA port mappings, matching the universal project convention
- **AMD capabilities**: Removed `cap_add: SYS_PTRACE` and replaced `security_opt: seccomp:unconfined` with `security_opt: no-new-privileges:true`. Evidence that these are unnecessary: the AMD llama-server overlay runs the same ROCm 7.2 stack without either capability
- **NVIDIA hardening**: Added `security_opt: no-new-privileges:true` and `deploy.resources.limits` (16 CPUs, 24G host RAM), matching the AMD overlay's pattern

## Testing

- [x] `docker compose config --quiet --no-interpolate` validates for both AMD and NVIDIA compose stacks
- [x] No secrets in diff
- [ ] Manual: AMD gfx1151 hardware — verify ComfyUI starts and GPU inference works after seccomp change (see Known Considerations)

## Review

- Critique Guardian verdict: ⚠️ APPROVED WITH WARNINGS

## Known Considerations

The `seccomp:unconfined` removal on the AMD overlay has not been smoke-tested on physical AMD gfx1151 hardware. The change is well-evidenced (llama-server AMD uses identical ROCm stack without these caps) but the custom ComfyUI image uses `PYTORCH_TUNABLEOP_ENABLED=1` and `TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1` which enable ROCm code paths that auto-tune kernels at runtime. If ComfyUI fails to start or silently falls back to CPU inference on AMD hardware after this change, reverting the seccomp line is the first step to try.

## Platform Impact

- [x] macOS (Apple Silicon): not affected (ComfyUI not in macOS overlay)
- [x] Linux AMD: affected — port binding + capability hardening
- [x] Linux NVIDIA: affected — port binding + security_opt + resource limits
- [ ] Windows: not applicable

Closes Light-Heart-Labs/DreamServer#156