### PR TITLE
fix(macos): rename LLAMA_MEMORY_LIMIT to LLAMA_SERVER_MEMORY_LIMIT in apple overlay

### DIFF
--- a/dream-server/docker-compose.apple.yml
+++ b/dream-server/docker-compose.apple.yml
@@ -15,7 +15,7 @@ services:
       resources:
         limits:
           cpus: '${LLAMA_CPU_LIMIT:-8.0}'
-          memory: ${LLAMA_MEMORY_LIMIT:-32G}
+          memory: ${LLAMA_SERVER_MEMORY_LIMIT:-32G}
         reservations:
           cpus: '2.0'
           memory: 4G


### PR DESCRIPTION
## What

Fixes a variable name mismatch in `docker-compose.apple.yml` that caused the user's `LLAMA_SERVER_MEMORY_LIMIT` setting to be silently ignored on macOS.

## Why

`docker-compose.apple.yml` used `${LLAMA_MEMORY_LIMIT:-32G}` (wrong name), while `.env.example`, `.env.schema.json`, `docker-compose.nvidia.yml`, and the llama-server README all document `LLAMA_SERVER_MEMORY_LIMIT` as the canonical variable name. There are zero other uses of `LLAMA_MEMORY_LIMIT` in the codebase — the mismatch existed only in this one file.

A user setting `LLAMA_SERVER_MEMORY_LIMIT=48G` in their `.env` would see it silently ignored on macOS, with the container always capped at the hardcoded 32G fallback.

## How

One-line rename: `LLAMA_MEMORY_LIMIT` → `LLAMA_SERVER_MEMORY_LIMIT` in `docker-compose.apple.yml`. Default value `32G` is preserved — intentionally lower than NVIDIA's `64G` since this is CPU-only Docker inference on macOS where system RAM is shared.

## Testing

- [x] `docker compose config --quiet --no-interpolate` validates successfully
- [x] Grep confirms zero remaining uses of `LLAMA_MEMORY_LIMIT` in the codebase after fix

## Review

- Critique Guardian verdict: ✅ APPROVED

## Platform Impact

- [x] macOS (Apple Silicon): fixes memory limit application on CPU inference path
- [ ] Linux: not affected
- [ ] Windows: not applicable

Closes Light-Heart-Labs/DreamServer#158