### PR TITLE
fix(installer): add -u and pipefail to install-core.sh

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -14,7 +14,7 @@
 # See each module's header for what it expects and provides.
 # ============================================================================
 
-set -e
+set -euo pipefail
 
 #=============================================================================
 # Cleanup on Failure

--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -39,7 +39,7 @@ if ! command -v curl &> /dev/null; then
         *)      error "curl is required but not installed. Install with: sudo apt install curl" ;;
     esac
 fi
-log "curl: $(curl --version | head -1)"
+log "curl: $(curl --version 2>/dev/null | sed -n '1p')"
 
 # Check optional tools (warn but don't fail)
 OPTIONAL_TOOLS_MISSING=""

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -195,6 +195,7 @@ if [[ "$INTERACTIVE" == "true" ]]; then
         2) SPEED_EST=45; USERS_EST="3-5" ;;
         3) SPEED_EST=55; USERS_EST="5-8" ;;
         4) SPEED_EST=40; USERS_EST="10-15" ;;
+        *)          SPEED_EST=30;  USERS_EST="varies" ;;
     esac
     show_tier_recommendation "$TIER" "$LLM_MODEL" "$SPEED_EST" "$USERS_EST"
 else


### PR DESCRIPTION
## What

Adds missing `-u` (nounset) and `-o pipefail` flags to `install-core.sh`, the Linux installer orchestrator that sources and runs all 13 install phases.

## Why

`install-core.sh` only had `set -e`. Per the project's own convention (CLAUDE.md), all shell scripts require `set -euo pipefail`. Without `-u`, unset variable references silently expand to empty strings across all 13 sourced phases. Without `pipefail`, a failed command in any pipeline is silently ignored.

## How

Three files changed:

1. **`install-core.sh`**: `set -e` → `set -euo pipefail`
2. **`installers/phases/02-detection.sh`**: Add `*)` default to the `case $TIER` block that sets `SPEED_EST`/`USERS_EST`. The missing default would cause an unbound variable crash under `-u` for any unrecognised tier value
3. **`installers/phases/01-preflight.sh`**: Replace `curl --version | head -1` with `curl --version 2>/dev/null | sed -n '1p'`. `head -1` closes the pipe after one line, causing curl to receive SIGPIPE (exit 141) which `pipefail` would propagate and abort the install on its very first log line

## Testing

- [x] `make test`: 36 passed, 0 failed
- [x] `make lint`: no new failures (pre-existing token-spy error only)
- [ ] Manual: run `./install.sh` on Linux to verify phases 01 and 02 complete normally

## Review

- Critique Guardian verdict: ✅ APPROVED (after companion fixes)

## Platform Impact

- [ ] macOS (Apple Silicon): not affected (uses separate install-macos.sh entry point)
- [x] Linux: install-core.sh is the Linux orchestrator — all installs affected
- [ ] Windows: not applicable

Closes Light-Heart-Labs/DreamServer#159