### PR TITLE
fix(installer): add SHA256 integrity check to Linux GGUF model download

### DIFF
--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -7,7 +7,7 @@
 #
 # Expects: TIER (set by detection phase), error()
 # Provides: resolve_tier_config() → sets TIER_NAME, LLM_MODEL, GGUF_FILE,
-#           GGUF_URL, MAX_CONTEXT
+#           GGUF_URL, GGUF_SHA256, MAX_CONTEXT
 #
 # Modder notes:
 #   Add new tiers or change model assignments here.
@@ -21,6 +21,7 @@ resolve_tier_config() {
             LLM_MODEL="anthropic/claude-sonnet-4-5-20250514"
             GGUF_FILE=""
             GGUF_URL=""
+            GGUF_SHA256=""
             MAX_CONTEXT=200000
             ;;
         NV_ULTRA)
@@ -28,6 +29,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-coder-next"
             GGUF_FILE="qwen3-coder-next-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
+            GGUF_SHA256="9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090"
             MAX_CONTEXT=131072
             ;;
         SH_LARGE)
@@ -35,6 +37,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-coder-next"
             GGUF_FILE="qwen3-coder-next-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
+            GGUF_SHA256="9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090"
             MAX_CONTEXT=131072
             ;;
         SH_COMPACT)
@@ -42,6 +45,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-30b-a3b"
             GGUF_FILE="qwen3-30b-a3b-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
+            GGUF_SHA256="9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
             MAX_CONTEXT=131072
             ;;
         1)
@@ -49,6 +53,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-8b"
             GGUF_FILE="Qwen3-8B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf"
+            GGUF_SHA256="120307ba529eb2439d6c430d94104dabd578497bc7bfe7e322b5d9933b449bd4"
             MAX_CONTEXT=16384
             ;;
         2)
@@ -56,6 +61,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-8b"
             GGUF_FILE="Qwen3-8B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf"
+            GGUF_SHA256="120307ba529eb2439d6c430d94104dabd578497bc7bfe7e322b5d9933b449bd4"
             MAX_CONTEXT=32768
             ;;
         3)
@@ -63,6 +69,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-14b"
             GGUF_FILE="Qwen3-14B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf"
+            GGUF_SHA256="5eaa0870bd81ed3b58a630a271234cfa604e43ffb3a19cd68e54a80dd9d52a66"
             MAX_CONTEXT=32768
             ;;
         4)
@@ -70,6 +77,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-30b-a3b"
             GGUF_FILE="qwen3-30b-a3b-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
+            GGUF_SHA256="9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
             MAX_CONTEXT=131072
             ;;
         *)

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -7,7 +7,7 @@
 #          Docker Compose stack
 #
 # Expects: DRY_RUN, INSTALL_DIR, LOG_FILE, GPU_BACKEND,
-#           GGUF_FILE, GGUF_URL, LLM_MODEL, MAX_CONTEXT,
+#           GGUF_FILE, GGUF_URL, GGUF_SHA256, LLM_MODEL, MAX_CONTEXT,
 #           DOCKER_COMPOSE_CMD, COMPOSE_FLAGS, BGRN, RED, AMB, NC,
 #           show_phase(), bootline(), signal(), ai(), ai_ok(), ai_bad(),
 #           ai_warn(), log(), spin_task()
@@ -42,6 +42,16 @@ else
 
     # Download GGUF model if not already present (with retry)
     GGUF_DIR="$INSTALL_DIR/data/models"
+
+    # Verify existing model integrity before trusting it
+    if [[ "${DREAM_MODE:-local}" != "cloud" && -f "$GGUF_DIR/$GGUF_FILE" && -n "${GGUF_SHA256:-}" ]]; then
+        existing_hash=$(sha256sum "$GGUF_DIR/$GGUF_FILE" | awk '{print $1}')
+        if [[ "$existing_hash" != "$GGUF_SHA256" ]]; then
+            ai_warn "Existing model file hash mismatch — re-downloading"
+            rm -f "$GGUF_DIR/$GGUF_FILE"
+        fi
+    fi
+
     if [[ "${DREAM_MODE:-local}" != "cloud" && ! -f "$GGUF_DIR/$GGUF_FILE" && -n "$GGUF_URL" ]]; then
         ai "Downloading GGUF model: $GGUF_FILE"
         signal "This is the big one. I've got it — sit back."
@@ -57,6 +67,17 @@ else
 
             if spin_task $dl_pid "Downloading $GGUF_FILE"; then
                 mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE"
+                # Verify downloaded model integrity
+                if [[ -n "${GGUF_SHA256:-}" ]]; then
+                    actual_hash=$(sha256sum "$GGUF_DIR/$GGUF_FILE" | awk '{print $1}')
+                    if [[ "$actual_hash" != "$GGUF_SHA256" ]]; then
+                        rm -f "$GGUF_DIR/$GGUF_FILE"
+                        printf "\r  ${RED}✗${NC} %-60s\n" "Integrity check failed (SHA256 mismatch)"
+                        ai "  Expected: $GGUF_SHA256"
+                        ai "  Got:      $actual_hash"
+                        continue
+                    fi
+                fi
                 printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
                 _dl_success=true
                 break


### PR DESCRIPTION
## What

Adds SHA256 integrity checking to the Linux GGUF model download, closing a platform parity gap with macOS and Windows which already had full verification.

## Why

`installers/phases/11-services.sh` downloaded the GGUF model with no integrity check. A truncated or corrupted download (CDN issue, disk full, network interruption) was silently promoted and passed to llama-server, which would crash or produce garbage output at startup with no clear error.

## How

- **`installers/lib/tier-map.sh`**: Added `GGUF_SHA256` to all 8 tiers. Hashes for shared models (Qwen3-8B, Qwen3-30B-A3B) are byte-identical to macOS tier-map values (already in production). Hashes for Linux-only models (Qwen3-14B tier 3, Qwen3-Coder-Next NV_ULTRA/SH_LARGE) verified against HuggingFace Tree API LFS oids.
- **`installers/phases/11-services.sh`**: Added pre-download check (verify existing file before reuse, delete on mismatch) and post-download check (verify freshly downloaded file, delete + retry on mismatch). Integrates cleanly with the existing 3-attempt retry loop. Uses `sha256sum` (Linux-only, correct for this Linux-only phase).

## Testing

- [x] `make test`: 36 passed, 0 failed
- [x] `make lint`: no new failures (pre-existing token-spy error only)
- [ ] Manual: install on Linux NV_ULTRA tier to verify hash check passes for Qwen3-Coder-Next

## Review

- Critique Guardian verdict: ✅ APPROVED (after hash verification against HF Tree API)

## Platform Impact

- [ ] macOS (Apple Silicon): not affected (uses separate install-macos.sh with its own SHA256 checks)
- [x] Linux: all tiers now have integrity checking
- [ ] Windows: not affected (uses Test-ModelIntegrity in PowerShell)

## Known Considerations

FLUX model downloads (4 safetensors files, ~34GB) in phase 11 still have no integrity checks. That is a separate, lower-priority enhancement not included in this PR.

Closes Light-Heart-Labs/DreamServer#163