### PR TITLE
fix(security): bind OpenCode to 127.0.0.1 and generate random password

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -22,6 +22,9 @@ LITELLM_KEY=CHANGEME
 # OpenClaw agent framework token (generate: openssl rand -hex 24)
 OPENCLAW_TOKEN=CHANGEME
 
+# OpenCode web UI password (generate: openssl rand -base64 16)
+OPENCODE_SERVER_PASSWORD=CHANGEME
+
 # ═══════════════════════════════════════════════════════════════════
 # LLM Backend Mode
 # ═══════════════════════════════════════════════════════════════════

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -56,6 +56,8 @@ generate_dream_env() {
     dashboard_api_key=$(new_secure_hex 32)
     local openclaw_token
     openclaw_token=$(new_secure_hex 24)
+    local opencode_password
+    opencode_password=$(new_secure_base64 16)
     local searxng_secret
     searxng_secret=$(new_secure_hex 32)
     # macOS: llama-server runs natively, containers reach it via host.docker.internal
@@ -112,7 +114,7 @@ OPENCLAW_TOKEN=${openclaw_token}
 
 #=== OpenCode Settings ===
 OPENCODE_PORT=3003
-OPENCODE_SERVER_PASSWORD=
+OPENCODE_SERVER_PASSWORD=${opencode_password}
 
 #=== Voice Settings ===
 WHISPER_MODEL=base

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -243,7 +243,7 @@ MODELS_EOF
     LIVEKIT_SECRET=$(_env_get LIVEKIT_API_SECRET "$(openssl rand -base64 32 2>/dev/null || head -c 32 /dev/urandom | base64)")
     DASHBOARD_API_KEY=$(_env_get DASHBOARD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
     DIFY_SECRET_KEY=$(_env_get DIFY_SECRET_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
-    OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "")
+    OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
 
     # Preserve user-supplied cloud API keys
     ANTHROPIC_API_KEY=$(_env_get ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}")

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -106,7 +106,8 @@ function New-DreamEnv {
     $dashboardApiKey = Get-EnvOrNew "DASHBOARD_API_KEY"  (New-SecureHex -Bytes 32)
     $openclawToken   = Get-EnvOrNew "OPENCLAW_TOKEN"     (New-SecureHex -Bytes 24)
     $searxngSecret   = Get-EnvOrNew "SEARXNG_SECRET"     (New-SecureHex -Bytes 32)
-    $difySecretKey   = Get-EnvOrNew "DIFY_SECRET_KEY"    (New-SecureHex -Bytes 32)
+    $difySecretKey    = Get-EnvOrNew "DIFY_SECRET_KEY"           (New-SecureHex -Bytes 32)
+    $opencodePassword = Get-EnvOrNew "OPENCODE_SERVER_PASSWORD" (New-SecureBase64 -Bytes 16)
 
     # Determine LLM API URL based on backend
     # AMD on Windows: llama-server runs natively, containers reach it via host.docker.internal
@@ -207,7 +208,7 @@ LITELLM_KEY=$litellmKey
 LIVEKIT_API_KEY=$livekitApiKey
 LIVEKIT_API_SECRET=$livekitSecret
 OPENCLAW_TOKEN=$openclawToken
-OPENCODE_SERVER_PASSWORD=
+OPENCODE_SERVER_PASSWORD=$opencodePassword
 OPENCODE_PORT=3003
 DIFY_SECRET_KEY=$difySecretKey
 

--- a/dream-server/opencode/opencode-web.service
+++ b/dream-server/opencode/opencode-web.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=__HOME__
-ExecStart=__HOME__/.opencode/bin/opencode web --port 3003 --hostname 0.0.0.0
+ExecStart=__HOME__/.opencode/bin/opencode web --port 3003 --hostname 127.0.0.1
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## What

Fixes OpenCode web UI binding to all interfaces (0.0.0.0:3003) with no password on Linux, and missing password generation on all platforms.

## Why

`opencode-web.service` started OpenCode with `--hostname 0.0.0.0`, making it reachable from any machine on the LAN. All three installer paths (Linux, macOS, Windows) wrote an empty `OPENCODE_SERVER_PASSWORD` to `.env`, leaving the service open to anyone who could reach the port. Windows already used `127.0.0.1` in its install script but also lacked a generated password.

## How

1. Changed `--hostname 0.0.0.0` → `--hostname 127.0.0.1` in the Linux systemd service template. Confirmed via OpenCode source (`server.ts`) that this flag controls the TCP bind address, not a cosmetic label.
2. Added password generation on all three platforms using `openssl rand -base64 16` (128-bit entropy, same pattern as `N8N_PASS`). Uses `_env_get` / `Get-EnvOrNew` so existing passwords survive re-installation.
3. Added `OPENCODE_SERVER_PASSWORD` to `.env.example` with a regeneration hint, matching the style of all other secrets in the REQUIRED section.

## Testing

- [x] `shellcheck` passes on all modified `.sh` files — zero new warnings
- [x] Diff reviewed — no hardcoded secrets, only `$(openssl rand ...)` expressions
- [x] `--hostname` flag verified against OpenCode `server.ts` source (controls TCP bind address)
- [x] `.env.schema.json` already contains `OPENCODE_SERVER_PASSWORD` with `"secret": true` — no schema change needed
- [x] `_env_get` / `Get-EnvOrNew` idempotency verified — existing passwords preserved on reinstall
- [ ] Manual: fresh install → verify non-empty `OPENCODE_SERVER_PASSWORD` in `.env`
- [ ] Manual: `ss -tlnp | grep 3003` shows `127.0.0.1:3003` post-install on Linux
- [ ] Manual: connection from LAN to port 3003 refused

## Review

- Critique Guardian verdict: ✅ APPROVED (all warnings resolved)
- `--hostname` binding confirmed against upstream OpenCode source

## Platform Impact

- [x] Linux: hostname binding fixed (`0.0.0.0` → `127.0.0.1`) + password generated
- [x] macOS: password generated (no service file — OpenCode is Linux/Windows only per `manifest.yaml`)
- [x] Windows: password generated (already used `127.0.0.1` in install script)

Closes #166