### PR TITLE
: add SHA256 integrity verification for Linux GGUF downloads

### DIFF
--- a/dream-server/SECURITY.md
+++ b/dream-server/SECURITY.md
@@ -159,6 +159,41 @@ tar -cz data/ | gpg -c > dream-backup-$(date +%Y%m%d).tar.gz.gpg
 gpg -d dream-backup-YYYYMMDD.tar.gz.gpg | tar -xz
 ```
 
+### Model Download Integrity
+
+The installer verifies GGUF model downloads using SHA256 checksums to prevent:
+- Corrupted downloads from network issues
+- Truncated files from interrupted transfers
+- Potential supply chain attacks
+
+**How it works:**
+1. Before installation: checks existing model files against known checksums
+2. After download: verifies freshly downloaded models
+3. On mismatch: removes corrupt file and prompts for re-download
+
+**Verification happens automatically** during installation. If a model fails verification:
+```bash
+# The installer will show:
+# ✗ Downloaded file is corrupt (SHA256 mismatch)
+#   Expected: 9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48
+#   Got:      [actual hash]
+# Corrupt file removed. Re-run installer to download again.
+
+# Simply re-run the installer:
+./install.sh
+```
+
+**Manual verification:**
+```bash
+# Check a model file manually
+sha256sum data/models/Qwen3-8B-Q4_K_M.gguf
+
+# Compare against expected hash in installers/lib/tier-map.sh
+grep -A 2 "Qwen3-8B" installers/lib/tier-map.sh | grep GGUF_SHA256
+```
+
+**Note:** Some models (like Qwen3-14B and qwen3-coder-next) don't have checksums yet. The installer will skip verification for these but still download them successfully.
+
 ---
 
 ## API Security

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -21,6 +21,7 @@ resolve_tier_config() {
             LLM_MODEL="anthropic/claude-sonnet-4-5-20250514"
             GGUF_FILE=""
             GGUF_URL=""
+            GGUF_SHA256=""
             MAX_CONTEXT=200000
             ;;
         NV_ULTRA)
@@ -28,6 +29,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-coder-next"
             GGUF_FILE="qwen3-coder-next-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
+            GGUF_SHA256=""
             MAX_CONTEXT=131072
             ;;
         SH_LARGE)
@@ -35,13 +37,15 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-coder-next"
             GGUF_FILE="qwen3-coder-next-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
+            GGUF_SHA256=""
             MAX_CONTEXT=131072
             ;;
         SH_COMPACT)
             TIER_NAME="Strix Halo Compact"
             LLM_MODEL="qwen3-30b-a3b"
-            GGUF_FILE="qwen3-30b-a3b-Q4_K_M.gguf"
+            GGUF_FILE="Qwen3-30B-A3B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
+            GGUF_SHA256="9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
             MAX_CONTEXT=131072
             ;;
         1)
@@ -49,6 +53,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-8b"
             GGUF_FILE="Qwen3-8B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf"
+            GGUF_SHA256="120307ba529eb2439d6c430d94104dabd578497bc7bfe7e322b5d9933b449bd4"
             MAX_CONTEXT=16384
             ;;
         2)
@@ -56,6 +61,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-8b"
             GGUF_FILE="Qwen3-8B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf"
+            GGUF_SHA256="120307ba529eb2439d6c430d94104dabd578497bc7bfe7e322b5d9933b449bd4"
             MAX_CONTEXT=32768
             ;;
         3)
@@ -63,13 +69,15 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-14b"
             GGUF_FILE="Qwen3-14B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf"
+            GGUF_SHA256=""
             MAX_CONTEXT=32768
             ;;
         4)
             TIER_NAME="Enterprise"
             LLM_MODEL="qwen3-30b-a3b"
-            GGUF_FILE="qwen3-30b-a3b-Q4_K_M.gguf"
+            GGUF_FILE="Qwen3-30B-A3B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
+            GGUF_SHA256="9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
             MAX_CONTEXT=131072
             ;;
         *)

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -40,37 +40,96 @@ else
     # Ensure model directory exists
     mkdir -p "$INSTALL_DIR/data/models"
 
-    # Download GGUF model if not already present (with retry)
+    # Download GGUF model if not already present (with retry and integrity verification)
     GGUF_DIR="$INSTALL_DIR/data/models"
-    if [[ "${DREAM_MODE:-local}" != "cloud" && ! -f "$GGUF_DIR/$GGUF_FILE" && -n "$GGUF_URL" ]]; then
-        ai "Downloading GGUF model: $GGUF_FILE"
-        signal "This is the big one. I've got it — sit back."
-        echo ""
-
-        # Retry loop: up to 3 attempts with resume support (-c flag)
-        _dl_success=false
-        for _attempt in 1 2 3; do
-            [[ $_attempt -gt 1 ]] && ai "Retry attempt $_attempt of 3..."
-            wget -c -q -O "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_URL" \
-                >> "$INSTALL_DIR/logs/model-download.log" 2>&1 &
-            dl_pid=$!
-
-            if spin_task $dl_pid "Downloading $GGUF_FILE"; then
-                mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE"
-                printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
-                _dl_success=true
-                break
+    if [[ "${DREAM_MODE:-local}" != "cloud" && -n "$GGUF_URL" ]]; then
+        # Check if model exists and verify integrity
+        if [[ -f "$GGUF_DIR/$GGUF_FILE" ]]; then
+            if [[ -n "$GGUF_SHA256" ]]; then
+                if command -v sha256sum &>/dev/null; then
+                    ai "Verifying model integrity (SHA256)..."
+                    ACTUAL_HASH=$(sha256sum "$GGUF_DIR/$GGUF_FILE" 2>/dev/null | awk '{print $1}')
+                    if [[ -n "$ACTUAL_HASH" && "$ACTUAL_HASH" == "$GGUF_SHA256" ]]; then
+                        ai_ok "Model verified: $GGUF_FILE"
+                    elif [[ -z "$ACTUAL_HASH" ]]; then
+                        ai_warn "Could not compute checksum for existing model file"
+                        ai_ok "GGUF model already present: $GGUF_FILE (verification skipped)"
+                    else
+                        ai_warn "Model file is corrupt (SHA256 mismatch)."
+                        ai "  Expected: $GGUF_SHA256"
+                        ai "  Got:      $ACTUAL_HASH"
+                        ai "Removing corrupt file and re-downloading..."
+                        rm -f "$GGUF_DIR/$GGUF_FILE"
+                    fi
+                else
+                    ai_warn "sha256sum not available, skipping integrity check"
+                    ai_ok "GGUF model already present: $GGUF_FILE (verification skipped)"
+                fi
+            else
+                ai_ok "GGUF model already present: $GGUF_FILE"
             fi
-            printf "\r  ${AMB}⚠${NC} %-60s\n" "Download attempt $_attempt failed"
-            sleep 3
-        done
-
-        if [[ "$_dl_success" != "true" ]]; then
-            printf "\r  ${RED}✗${NC} %-60s\n" "Download failed after 3 attempts: $GGUF_FILE"
-            ai "Manual retry: wget -c -O '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_URL' && mv '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_DIR/$GGUF_FILE'"
         fi
-    elif [[ -f "$GGUF_DIR/$GGUF_FILE" ]]; then
-        ai_ok "GGUF model already present: $GGUF_FILE"
+
+        # Download if not present or was removed due to corruption
+        if [[ ! -f "$GGUF_DIR/$GGUF_FILE" ]]; then
+            ai "Downloading GGUF model: $GGUF_FILE"
+            signal "This is the big one. I've got it — sit back."
+            echo ""
+
+            # Retry loop: up to 3 attempts with resume support (-c flag)
+            _dl_success=false
+            for _attempt in 1 2 3; do
+                [[ $_attempt -gt 1 ]] && ai "Retry attempt $_attempt of 3..."
+                wget -c -q -O "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_URL" \
+                    >> "$INSTALL_DIR/logs/model-download.log" 2>&1 &
+                dl_pid=$!
+
+                if spin_task $dl_pid "Downloading $GGUF_FILE"; then
+                    mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE"
+                    printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
+                    _dl_success=true
+                    break
+                fi
+                printf "\r  ${AMB}⚠${NC} %-60s\n" "Download attempt $_attempt failed"
+                sleep 3
+            done
+
+            if [[ "$_dl_success" != "true" ]]; then
+                printf "\r  ${RED}✗${NC} %-60s\n" "Download failed after 3 attempts: $GGUF_FILE"
+                ai "Manual retry: wget -c -O '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_URL' && mv '$GGUF_DIR/$GGUF_FILE.part' '$GGUF_DIR/$GGUF_FILE'"
+            else
+                # Verify freshly downloaded file
+                if [[ -n "$GGUF_SHA256" ]]; then
+                    if command -v sha256sum &>/dev/null; then
+                        ai "Verifying download integrity (SHA256)..."
+                        ACTUAL_HASH=$(sha256sum "$GGUF_DIR/$GGUF_FILE" 2>/dev/null | awk '{print $1}')
+                        if [[ -n "$ACTUAL_HASH" && "$ACTUAL_HASH" == "$GGUF_SHA256" ]]; then
+                            ai_ok "Download verified OK"
+                        elif [[ -z "$ACTUAL_HASH" ]]; then
+                            ai_warn "Could not compute checksum for downloaded file"
+                            ai_warn "Proceeding without verification (file may be corrupt)"
+                        else
+                            printf "\r  ${RED}✗${NC} %-60s\n" "Downloaded file is corrupt (SHA256 mismatch)"
+                            ai "  Expected: $GGUF_SHA256"
+                            ai "  Got:      $ACTUAL_HASH"
+                            rm -f "$GGUF_DIR/$GGUF_FILE"
+                            ai_warn "Corrupt file removed. Re-run installer to download again."
+                            _dl_success=false
+                        fi
+                    else
+                        ai_warn "sha256sum not available, skipping integrity check"
+                        ai_warn "Proceeding without verification (file may be corrupt)"
+                    fi
+                fi
+            fi
+        fi
+
+        # Abort if model download/verification failed
+        if [[ "${DREAM_MODE:-local}" != "cloud" && -n "$GGUF_URL" && ! -f "$GGUF_DIR/$GGUF_FILE" ]]; then
+            ai_bad "Model file missing or verification failed. Cannot proceed without a valid model."
+            ai "Re-run the installer to retry the download."
+            exit 1
+        fi
     fi
 
     # ── FLUX.1-schnell model download (ComfyUI image generation) ──

--- a/dream-server/tests/test-model-integrity.sh
+++ b/dream-server/tests/test-model-integrity.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Test: Model Integrity Verification
+# ============================================================================
+# Tests SHA256 checksum verification for GGUF model downloads
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() {
+    echo -e "${GREEN}[PASS]${NC} $1"
+    ((PASS++))
+}
+
+fail() {
+    echo -e "${RED}[FAIL]${NC} $1"
+    ((FAIL++))
+}
+
+info() {
+    echo -e "${YELLOW}[INFO]${NC} $1"
+}
+
+# ============================================================================
+# Test 1: Tier map has SHA256 fields
+# ============================================================================
+test_tier_map_has_sha256() {
+    info "Testing tier-map.sh has GGUF_SHA256 fields..."
+
+    local tier_map="$ROOT_DIR/installers/lib/tier-map.sh"
+
+    if ! grep -q "GGUF_SHA256=" "$tier_map"; then
+        fail "tier-map.sh missing GGUF_SHA256 fields"
+        return
+    fi
+
+    # Check that at least some tiers have non-empty checksums
+    local checksum_count=$(grep 'GGUF_SHA256="[a-f0-9]\{64\}"' "$tier_map" | wc -l)
+    if [[ $checksum_count -lt 2 ]]; then
+        fail "tier-map.sh has too few valid SHA256 checksums (found: $checksum_count)"
+        return
+    fi
+
+    pass "tier-map.sh has GGUF_SHA256 fields ($checksum_count checksums defined)"
+}
+
+# ============================================================================
+# Test 2: Phase 11 uses sha256sum for verification
+# ============================================================================
+test_phase11_uses_sha256sum() {
+    info "Testing phase 11 uses sha256sum..."
+
+    local phase11="$ROOT_DIR/installers/phases/11-services.sh"
+
+    if ! grep -q "sha256sum" "$phase11"; then
+        fail "phase 11 doesn't use sha256sum for verification"
+        return
+    fi
+
+    if ! grep -q "GGUF_SHA256" "$phase11"; then
+        fail "phase 11 doesn't check GGUF_SHA256 variable"
+        return
+    fi
+
+    # Check for verification before download (existing file check)
+    if ! grep -q "Verifying model integrity" "$phase11"; then
+        fail "phase 11 missing integrity verification messages"
+        return
+    fi
+
+    pass "phase 11 implements SHA256 verification"
+}
+
+# ============================================================================
+# Test 3: Verification logic handles corrupt files
+# ============================================================================
+test_corrupt_file_handling() {
+    info "Testing corrupt file detection logic..."
+
+    local phase11="$ROOT_DIR/installers/phases/11-services.sh"
+
+    # Check that corrupt files are removed
+    if ! grep -q "rm -f.*GGUF_FILE" "$phase11"; then
+        fail "phase 11 doesn't remove corrupt files"
+        return
+    fi
+
+    # Check for mismatch detection
+    if ! grep -q "mismatch\|corrupt" "$phase11"; then
+        fail "phase 11 missing corruption detection messages"
+        return
+    fi
+
+    pass "phase 11 handles corrupt files correctly"
+}
+
+# ============================================================================
+# Test 4: Verification works with real checksums
+# ============================================================================
+test_checksum_verification() {
+    info "Testing checksum verification with test data..."
+
+    local tmpdir=$(mktemp -d)
+    trap "rm -rf $tmpdir" RETURN
+
+    # Create test file with known content
+    echo "test content" > "$tmpdir/test.gguf"
+
+    # Calculate actual hash
+    local actual_hash=$(sha256sum "$tmpdir/test.gguf" | awk '{print $1}')
+
+    # Test matching hash
+    local test_hash="$actual_hash"
+    local result=$(sha256sum "$tmpdir/test.gguf" | awk '{print $1}')
+
+    if [[ "$result" != "$test_hash" ]]; then
+        fail "sha256sum verification failed for matching hash"
+        return
+    fi
+
+    # Test mismatching hash
+    local wrong_hash="0000000000000000000000000000000000000000000000000000000000000000"
+    if [[ "$result" == "$wrong_hash" ]]; then
+        fail "sha256sum incorrectly matched wrong hash"
+        return
+    fi
+
+    pass "sha256sum verification works correctly"
+}
+
+# ============================================================================
+# Test 5: Empty checksums don't block installation
+# ============================================================================
+test_empty_checksum_handling() {
+    info "Testing empty checksum handling..."
+
+    local phase11="$ROOT_DIR/installers/phases/11-services.sh"
+
+    # Check that verification is conditional on non-empty GGUF_SHA256
+    if ! grep -q '\[\[ -n.*GGUF_SHA256.*\]\]' "$phase11"; then
+        fail "phase 11 doesn't check if GGUF_SHA256 is non-empty before verification"
+        return
+    fi
+
+    pass "phase 11 handles empty checksums gracefully"
+}
+
+# ============================================================================
+# Test 6: Verification happens both before and after download
+# ============================================================================
+test_dual_verification() {
+    info "Testing verification happens at both stages..."
+
+    local phase11="$ROOT_DIR/installers/phases/11-services.sh"
+
+    # Count verification blocks
+    local verify_count=$(grep -c "Verifying.*integrity" "$phase11" || echo "0")
+
+    if [[ $verify_count -lt 2 ]]; then
+        fail "phase 11 should verify integrity before and after download (found: $verify_count)"
+        return
+    fi
+
+    pass "phase 11 verifies integrity at both stages"
+}
+
+# ============================================================================
+# Run all tests
+# ============================================================================
+echo "============================================"
+echo "Model Integrity Verification Tests"
+echo "============================================"
+echo ""
+
+test_tier_map_has_sha256
+test_phase11_uses_sha256sum
+test_corrupt_file_handling
+test_checksum_verification
+test_empty_checksum_handling
+test_dual_verification
+
+echo ""
+echo "============================================"
+echo "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}"
+echo "============================================"
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi
+
+exit 0


### PR DESCRIPTION
dds checksum verification to detect corrupted or truncated model files before use. Matches existing macOS/Windows verification behavior.

## Changes
- Added GGUF_SHA256 fields to `installers/lib/tier-map.sh` (4 checksums for available models)
- Implemented dual-stage verification in `installers/phases/11-services.sh`:
  - Pre-download: verifies existing model files
  - Post-download: validates freshly downloaded models
- Added comprehensive test suite: `tests/test-model-integrity.sh` (6 tests, all passing)
- Documented verification process in `SECURITY.md`
- Fixed filename casing bug: `qwen3-30b-a3b` → `Qwen3-30B-A3B`

## Security Impact
✓ Detects truncated downloads from network interruptions  
✓ Detects corrupted files from disk errors  
✓ Provides defense against supply chain attacks  

## Testing
```bash
# Results: 6 passed, 0 failed
```