### PR TITLE
Safe .env loading everywhere: add load_env_file(), fix token-spy, unify scripts, add test

### DIFF
--- a/dream-server/docs/EXTENSIONS.md
+++ b/dream-server/docs/EXTENSIONS.md
@@ -316,3 +316,4 @@ npm run build
 - Unknown/malformed manifests are skipped with warnings, not fatal crashes.
 - Keep extension files ASCII and small; one service per directory is preferred.
 - The service registry (`lib/service-registry.sh`) provides bash functions for resolving aliases and discovering enabled services.
+- **Scripts that load `.env`:** Source `lib/safe-env.sh` and use `load_env_file "<path>"`; do not use `eval` or `export $(grep ... .env | xargs)` (injection risk).

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -41,26 +41,6 @@ _env_set() {
     fi
 }
 
-# B6 fix: Safe .env loading (prevents shell injection)
-load_env() {
-    [[ -f "$INSTALL_DIR/.env" ]] || return 0
-    set -a
-    while IFS='=' read -r key value; do
-        # Skip comments and empty lines
-        [[ "$key" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "$key" ]] && continue
-        # Only allow alphanumeric + underscore in key names
-        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        # Strip quotes from value
-        value="${value%\"}"
-        value="${value#\"}"
-        value="${value%\'}"
-        value="${value#\'}"
-        export "$key=$value"
-    done < "$INSTALL_DIR/.env"
-    set +a
-}
-
 check_install() {
     if [[ ! -d "$INSTALL_DIR" ]]; then
         error "Dream Server not found at $INSTALL_DIR. Set DREAM_HOME or run installer first."
@@ -72,6 +52,12 @@ check_install() {
         fi
     fi
 }
+
+#=============================================================================
+# Safe .env loading (no eval; use lib/safe-env.sh)
+#=============================================================================
+[[ -f "$SCRIPT_DIR/lib/safe-env.sh" ]] && . "$SCRIPT_DIR/lib/safe-env.sh"
+load_env() { load_env_file "${INSTALL_DIR}/.env"; }
 
 #=============================================================================
 # Service Registry

--- a/dream-server/dream-preflight.sh
+++ b/dream-server/dream-preflight.sh
@@ -10,21 +10,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DREAM_DIR="$SCRIPT_DIR"
 LOG_FILE="$DREAM_DIR/preflight-$(date +%Y%m%d-%H%M%S).log"
 
-# Load config from .env safely (line-by-line, no eval/source)
-if [ -f "$DREAM_DIR/.env" ]; then
-    while IFS='=' read -r key value; do
-        # Skip comments and empty lines
-        [[ "$key" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "$key" ]] && continue
-        # Only allow safe variable names
-        key=$(echo "$key" | xargs)  # trim whitespace
-        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        # Strip surrounding quotes from value
-        value="${value%\"}" && value="${value#\"}"
-        value="${value%\'}" && value="${value#\'}"
-        export "$key=$value"
-    done < "$DREAM_DIR/.env"
-fi
+# Safe .env loading (no eval; use lib/safe-env.sh)
+[[ -f "$DREAM_DIR/lib/safe-env.sh" ]] && . "$DREAM_DIR/lib/safe-env.sh"
+load_env_file "$DREAM_DIR/.env"
+
 SERVICE_HOST="${SERVICE_HOST:-localhost}"
 
 # Auto-detect backend from .env or hardware probing.

--- a/dream-server/extensions/services/token-spy/start.sh
+++ b/dream-server/extensions/services/token-spy/start.sh
@@ -16,10 +16,10 @@ set -e
 cd "$(dirname "$0")"
 mkdir -p data
 
-# Load env file if exists
-if [ -f .env ]; then
-    export $(grep -v '^#' .env | xargs)
-fi
+# Safe .env loading (no eval; use Dream Server lib/safe-env.sh)
+DREAM_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+[[ -f "$DREAM_ROOT/lib/safe-env.sh" ]] && . "$DREAM_ROOT/lib/safe-env.sh"
+load_env_file "$(pwd)/.env"
 
 # Database backend (sqlite or postgres)
 export DB_BACKEND="${DB_BACKEND:-sqlite}"

--- a/dream-server/lib/safe-env.sh
+++ b/dream-server/lib/safe-env.sh
@@ -2,11 +2,33 @@
 # ============================================================================
 # Dream Server — Safe environment loading (no eval)
 # ============================================================================
-# Parses KEY="value" lines (with \" and \\ escapes) from stdin and exports
-# them in the current shell. Use instead of eval for output from
-# build-capability-profile.sh, preflight-engine.sh, resolve-compose-stack.sh,
-# load-backend-contract.sh, etc.
+# Scripts that need to load .env should use load_env_file from this script.
+# Do not use eval or "export $(grep ... .env | xargs)" — they allow injection.
+#
+# - load_env_file <path>  — parse a .env file and export vars (safe keys, no eval)
+# - load_env_from_output  — parse KEY="value" lines from stdin (for script output)
 # ============================================================================
+
+# Load a .env file safely: comments and empty lines skipped; key names must be
+# valid identifiers; values may be unquoted or quoted; no eval or word-splitting.
+load_env_file() {
+    local path="$1"
+    [[ -f "$path" ]] || return 0
+    local key value
+    while IFS='=' read -r key value; do
+        [[ "$key" =~ ^[[:space:]]*# ]] && continue
+        key="${key#"${key%%[![:space:]]*}"}"
+        key="${key%"${key##*[![:space:]]}"}"
+        [[ -z "$key" ]] && continue
+        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        value="${value# }"
+        value="${value%\"}"
+        value="${value#\"}"
+        value="${value%\'}"
+        value="${value#\'}"
+        export "$key=$value"
+    done < "$path"
+}
 
 load_env_from_output() {
     local line key value

--- a/dream-server/scripts/dream-preflight.sh
+++ b/dream-server/scripts/dream-preflight.sh
@@ -11,21 +11,9 @@ cd "$SCRIPT_DIR"
 . "$SCRIPT_DIR/lib/service-registry.sh"
 sr_load
 
-# Safe .env loading for port overrides
-if [[ -f "$SCRIPT_DIR/.env" ]]; then
-    set -a
-    while IFS='=' read -r key value; do
-        [[ "$key" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "$key" ]] && continue
-        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        value="${value%\"}"
-        value="${value#\"}"
-        value="${value%\'}"
-        value="${value#\'}"
-        export "$key=$value"
-    done < "$SCRIPT_DIR/.env"
-    set +a
-fi
+# Safe .env loading for port overrides (no eval; use lib/safe-env.sh)
+[[ -f "$SCRIPT_DIR/lib/safe-env.sh" ]] && . "$SCRIPT_DIR/lib/safe-env.sh"
+load_env_file "$SCRIPT_DIR/.env"
 
 # Resolve compose flags for accurate status checks
 COMPOSE_FLAGS=""

--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -25,20 +25,8 @@ if [[ -f "$_FT_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$_FT_DIR"
     . "$_FT_DIR/lib/service-registry.sh"
     sr_load
-    if [[ -f "$_FT_DIR/.env" ]]; then
-        set -a
-        while IFS='=' read -r key value; do
-            [[ "$key" =~ ^[[:space:]]*# ]] && continue
-            [[ -z "$key" ]] && continue
-            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-            value="${value%\"}"
-            value="${value#\"}"
-            value="${value%\'}"
-            value="${value#\'}"
-            export "$key=$value"
-        done < "$_FT_DIR/.env"
-        set +a
-    fi
+    [[ -f "$_FT_DIR/lib/safe-env.sh" ]] && . "$_FT_DIR/lib/safe-env.sh"
+    load_env_file "$_FT_DIR/.env"
 fi
 
 # Service endpoints — resolved from registry

--- a/dream-server/scripts/dream-test.sh
+++ b/dream-server/scripts/dream-test.sh
@@ -36,20 +36,8 @@ if [[ -f "$_DT_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$_DT_DIR"
     . "$_DT_DIR/lib/service-registry.sh"
     sr_load
-    if [[ -f "$_DT_DIR/.env" ]]; then
-        set -a
-        while IFS='=' read -r key value; do
-            [[ "$key" =~ ^[[:space:]]*# ]] && continue
-            [[ -z "$key" ]] && continue
-            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-            value="${value%\"}"
-            value="${value#\"}"
-            value="${value%\'}"
-            value="${value#\'}"
-            export "$key=$value"
-        done < "$_DT_DIR/.env"
-        set +a
-    fi
+    [[ -f "$_DT_DIR/lib/safe-env.sh" ]] && . "$_DT_DIR/lib/safe-env.sh"
+    load_env_file "$_DT_DIR/.env"
 fi
 
 # Service endpoints — resolved from registry
@@ -98,11 +86,8 @@ RESULTS_DETAILS=()
 #--------------------------------------------------------------------------
 
 load_env() {
-    if [[ -f "$ENV_FILE" ]]; then
-        set -a
-        source "$ENV_FILE" 2>/dev/null || true
-        set +a
-    fi
+    [[ -f "$_DT_DIR/lib/safe-env.sh" ]] && . "$_DT_DIR/lib/safe-env.sh"
+    load_env_file "$ENV_FILE"
 }
 
 log() {

--- a/dream-server/scripts/first-boot-demo.sh
+++ b/dream-server/scripts/first-boot-demo.sh
@@ -27,20 +27,8 @@ if [[ -f "$_DEMO_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$_DEMO_DIR"
     . "$_DEMO_DIR/lib/service-registry.sh"
     sr_load
-    if [[ -f "$_DEMO_DIR/.env" ]]; then
-        set -a
-        while IFS='=' read -r key value; do
-            [[ "$key" =~ ^[[:space:]]*# ]] && continue
-            [[ -z "$key" ]] && continue
-            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-            value="${value%\"}"
-            value="${value#\"}"
-            value="${value%\'}"
-            value="${value#\'}"
-            export "$key=$value"
-        done < "$_DEMO_DIR/.env"
-        set +a
-    fi
+    [[ -f "$_DEMO_DIR/lib/safe-env.sh" ]] && . "$_DEMO_DIR/lib/safe-env.sh"
+    load_env_file "$_DEMO_DIR/.env"
 fi
 
 LLM_URL="${LLM_URL:-http://localhost:${SERVICE_PORTS[llama-server]:-8080}}"

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -28,20 +28,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 . "$SCRIPT_DIR/lib/service-registry.sh"
 sr_load
 
-# Load env for port overrides
-ENV_FILE="${INSTALL_DIR}/.env"
-if [[ -f "$ENV_FILE" ]]; then
-    set -a
-    while IFS='=' read -r key value; do
-        [[ "$key" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "$key" ]] && continue
-        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        value="${value%\"}"
-        value="${value#\"}"
-        export "$key=$value"
-    done < "$ENV_FILE"
-    set +a
-fi
+# Safe .env loading for port overrides (no eval; use lib/safe-env.sh)
+[[ -f "$SCRIPT_DIR/lib/safe-env.sh" ]] && . "$SCRIPT_DIR/lib/safe-env.sh"
+load_env_file "${INSTALL_DIR}/.env"
 
 # Colors (disabled for JSON/quiet)
 if $JSON_OUTPUT || $QUIET; then

--- a/dream-server/scripts/showcase.sh
+++ b/dream-server/scripts/showcase.sh
@@ -24,20 +24,8 @@ if [[ -f "$DREAM_DIR/lib/service-registry.sh" ]]; then
     export SCRIPT_DIR="$DREAM_DIR"
     . "$DREAM_DIR/lib/service-registry.sh"
     sr_load
-    if [[ -f "$DREAM_DIR/.env" ]]; then
-        set -a
-        while IFS='=' read -r key value; do
-            [[ "$key" =~ ^[[:space:]]*# ]] && continue
-            [[ -z "$key" ]] && continue
-            [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-            value="${value%\"}"
-            value="${value#\"}"
-            value="${value%\'}"
-            value="${value#\'}"
-            export "$key=$value"
-        done < "$DREAM_DIR/.env"
-        set +a
-    fi
+    [[ -f "$DREAM_DIR/lib/safe-env.sh" ]] && . "$DREAM_DIR/lib/safe-env.sh"
+    load_env_file "$DREAM_DIR/.env"
 fi
 
 # URLs — resolved from registry

--- a/dream-server/scripts/validate.sh
+++ b/dream-server/scripts/validate.sh
@@ -18,29 +18,9 @@ export SCRIPT_DIR="$PROJECT_DIR"
 . "$PROJECT_DIR/lib/service-registry.sh"
 sr_load
 
-# Safe .env loading (aligns with dream-cli pattern)
-load_env_safe() {
-    local env_file="$PROJECT_DIR/.env"
-    [[ -f "$env_file" ]] || return 0
-    set -a
-    while IFS='=' read -r key value; do
-        # Skip comments and empty lines
-        [[ "$key" =~ ^[[:space:]]*# ]] && continue
-        [[ -z "$key" ]] && continue
-        # Only allow alphanumeric + underscore in key names
-        [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
-        # Strip surrounding quotes from value
-        value="${value%\"}"
-        value="${value#\"}"
-        value="${value%\'}"
-        value="${value#\'}"
-        export "$key=$value"
-    done < "$env_file"
-    set +a
-}
-
-# Load .env for port overrides (if present)
-load_env_safe
+# Safe .env loading (no eval; use lib/safe-env.sh)
+[[ -f "$PROJECT_DIR/lib/safe-env.sh" ]] && . "$PROJECT_DIR/lib/safe-env.sh"
+load_env_file "$PROJECT_DIR/.env"
 
 # Resolve core ports from registry (honoring any env overrides)
 LLM_PORT="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-${SERVICE_PORTS[llama-server]:-8080}}}"

--- a/dream-server/tests/test-safe-env.sh
+++ b/dream-server/tests/test-safe-env.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Test lib/safe-env.sh: load_env_file and load_env_from_output
+# Ensures .env loading is safe (no eval, no injection) and consistent.
+#
+# Run from repo root:  bash dream-server/tests/test-safe-env.sh
+# Or from dream-server: bash tests/test-safe-env.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+# Source the implementation
+[[ -f "$ROOT_DIR/lib/safe-env.sh" ]] || fail "lib/safe-env.sh not found"
+. "$ROOT_DIR/lib/safe-env.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ---- load_env_file: valid keys and values ----
+echo "Test 1: load_env_file parses valid KEY=value and exports"
+cat > "$tmpdir/.env" << 'EOF'
+# comment
+SOME_KEY=simple_value
+ANOTHER=with-dash_123
+QUOTED_DOUBLE="value with spaces"
+QUOTED_SINGLE='single quoted'
+# empty above
+EMPTY_VAL=
+EOF
+load_env_file "$tmpdir/.env"
+[[ "${SOME_KEY:-}" == "simple_value" ]] || fail "SOME_KEY not set (got: ${SOME_KEY:-})"
+[[ "${ANOTHER:-}" == "with-dash_123" ]] || fail "ANOTHER not set"
+[[ "${QUOTED_DOUBLE:-}" == "value with spaces" ]] || fail "QUOTED_DOUBLE not set"
+[[ "${QUOTED_SINGLE:-}" == "single quoted" ]] || fail "QUOTED_SINGLE not set"
+pass "load_env_file exports valid vars"
+
+# ---- load_env_file: dangerous line must not be executed ----
+echo "Test 2: load_env_file skips/invalidates dangerous key names (no eval)"
+# Key with shell metacharacters should be skipped by our key regex
+cat > "$tmpdir/.env2" << 'EOF'
+SAFE_VAR=ok
+EVIL_KEY$(echo injected)=value
+NORMAL_AFTER=works
+EOF
+unset SAFE_VAR EVIL_KEY NORMAL_AFTER 2>/dev/null || true
+load_env_file "$tmpdir/.env2"
+[[ "${SAFE_VAR:-}" == "ok" ]] || fail "SAFE_VAR not set"
+[[ "${NORMAL_AFTER:-}" == "works" ]] || fail "NORMAL_AFTER not set"
+# EVIL_KEY... should not be set (key regex rejects it)
+pass "load_env_file rejects invalid key names"
+
+# ---- load_env_file: missing file is no-op ----
+echo "Test 3: load_env_file missing file is no-op"
+load_env_file "$tmpdir/nonexistent.env"
+pass "load_env_file missing file returns 0"
+
+# ---- load_env_file: empty file ----
+echo "Test 4: load_env_file empty file is no-op"
+touch "$tmpdir/empty.env"
+load_env_file "$tmpdir/empty.env"
+pass "load_env_file empty file is no-op"
+
+# ---- load_env_from_output: stdin (must run in current shell so export persists) ----
+echo "Test 5: load_env_from_output parses KEY=\"value\" from stdin"
+unset FROM_STDIN 2>/dev/null || true
+load_env_from_output < <(echo 'FROM_STDIN="hello from stdin"')
+[[ "${FROM_STDIN:-}" == "hello from stdin" ]] || fail "FROM_STDIN not set (got: ${FROM_STDIN:-})"
+pass "load_env_from_output exports from stdin"
+
+echo ""
+echo "All safe-env tests passed."


### PR DESCRIPTION
## Summary
Single safe way to load `.env` across the repo: new `load_env_file()` in `lib/safe-env.sh`. Replaces duplicated manual parsing and removes unsafe `export $(grep ... | xargs)` in token-spy. All affected scripts now use `safe-env`; behavior is covered by a dedicated test.

## Changes
- **lib/safe-env.sh**: Add `load_env_file("<path>")` for safe .env parsing (comments/empty lines skipped, strict key names, no eval). Document that scripts must use this (or `load_env_from_output`) and not `eval` or `export $(grep ... | xargs)`.
- **Scripts switched to safe-env + load_env_file**: dream-cli, dream-preflight.sh (root + scripts/), validate.sh, showcase.sh, health-check.sh, first-boot-demo.sh, dream-test.sh, dream-test-functional.sh.
- **extensions/services/token-spy/start.sh**: Remove unsafe `export $(grep -v '^#' .env | xargs)`; use Dream Server `lib/safe-env.sh` and `load_env_file`.
- **docs/EXTENSIONS.md**: Note that scripts loading .env should use `lib/safe-env.sh` and `load_env_file`.
- **tests/test-safe-env.sh**: New test for `load_env_file` and `load_env_from_output` (valid vars, comments, dangerous keys skipped, missing/empty file).

## Testing
- `bash dream-server/tests/test-safe-env.sh` — all 5 tests pass.