### PR TITLE
feat: add SHA256 checksums for remaining GGUF models

### DIFF
--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -29,7 +29,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-coder-next"
             GGUF_FILE="qwen3-coder-next-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
-            GGUF_SHA256=""
+            GGUF_SHA256="9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090"
             MAX_CONTEXT=131072
             ;;
         SH_LARGE)
@@ -37,7 +37,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-coder-next"
             GGUF_FILE="qwen3-coder-next-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
-            GGUF_SHA256=""
+            GGUF_SHA256="9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090"
             MAX_CONTEXT=131072
             ;;
         SH_COMPACT)
@@ -69,7 +69,7 @@ resolve_tier_config() {
             LLM_MODEL="qwen3-14b"
             GGUF_FILE="Qwen3-14B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf"
-            GGUF_SHA256=""
+            GGUF_SHA256="5eaa0870bd81ed3b58a630a271234cfa604e43ffb3a19cd68e54a80dd9d52a66"
             MAX_CONTEXT=32768
             ;;
         4)


### PR DESCRIPTION
Follow-up to PR #169. Adds verified checksums for the 3 models that were left empty.

## Changes
- NV_ULTRA (qwen3-coder-next): `9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090`
- SH_LARGE (qwen3-coder-next): `9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090`
- Tier 3 (Qwen3-14B): `5eaa0870bd81ed3b58a630a271234cfa604e43ffb3a19cd68e54a80dd9d52a66`

Completes integrity verification coverage for all available models.

## Testing
```bash
./tests/test-model-integrity.sh
# Results: 6 passed, 0 failed
# Checksums defined: 7 (up from 4)
```

## Source
Checksums verified and sourced from PR #165 as recommended by @Lightheartdevs in PR #169 review.

**Files changed:** 1 file, 3 lines modified