### PR TITLE
ci: add service registry tests to Linux workflow

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Tier Map Unit Tests
         run: bash tests/test-tier-map.sh
 
+      - name: Service Registry Tests
+        run: bash tests/test-service-registry.sh
+
       - name: Installer Contract Checks
         run: |
           bash tests/contracts/test-installer-contracts.sh


### PR DESCRIPTION
Adds test-service-registry.sh to the CI pipeline to validate service registry functionality on every PR and push to main.

Related: #168