### PR TITLE
feat: add port conflict and Ollama detection for Linux installer

### DIFF
--- a/dream-server/installers/phases/04-requirements.sh
+++ b/dream-server/installers/phases/04-requirements.sh
@@ -124,6 +124,9 @@ else
 fi
 
 # Port conflict detection with process details
+# Warn-once guard for missing port-check tools
+_port_check_warned=false
+
 check_port_conflict() {
     local port="$1"
     PORT_CONFLICT=false
@@ -170,8 +173,11 @@ check_port_conflict() {
         fi
     else
         # No tools available
-        warn "Neither 'lsof', 'ss', nor 'netstat' found — cannot verify port availability"
-        warn "Install lsof, iproute2 (for ss), or net-tools (for netstat) to enable port checks"
+        if [[ "${_port_check_warned}" != "true" ]]; then
+            _port_check_warned=true
+            warn "Neither 'lsof', 'ss', nor 'netstat' found — cannot verify port availability"
+            warn "Install lsof, iproute2 (for ss), or net-tools (for netstat) to enable port checks"
+        fi
         return 1
     fi
 
@@ -193,7 +199,7 @@ check_ollama_conflict() {
 check_ollama_conflict
 if $OLLAMA_RUNNING; then
     ai_warn "Ollama is running (PID ${OLLAMA_PID}) and may conflict with Dream Server."
-    ai "  Both use port 11434/8080. Ollama will shadow llama-server."
+    ai "  Note: this is usually not a port collision. Open WebUI may auto-discover Ollama (11434) and prefer it over the local llama-server (8080)."
     if $INTERACTIVE && ! $DRY_RUN; then
         read -r -p "  Stop Ollama for this session? [Y/n] " ollama_choice
         if [[ ! "$ollama_choice" =~ ^[nN] ]]; then

--- a/dream-server/tests/test-port-ollama-detection.sh
+++ b/dream-server/tests/test-port-ollama-detection.sh
@@ -27,11 +27,18 @@ echo "║   Port & Ollama Detection Test Suite     ║"
 echo "╚═══════════════════════════════════════════╝"
 echo ""
 
-# Source the phase script to get the functions
-source "$ROOT_DIR/installers/phases/04-requirements.sh" 2>/dev/null || {
-    echo -e "${RED}✗ FAIL${NC} - Cannot source 04-requirements.sh"
+# Source only the functions under test (phase scripts expect installer env).
+source <(sed -n '/^check_port_conflict\s*()\s*{/,/^}/p;/^check_ollama_conflict\s*()\s*{/,/^}/p' \
+  "$ROOT_DIR/installers/phases/04-requirements.sh") || {
+    echo -e "${RED}✗ FAIL${NC} - Cannot load functions from 04-requirements.sh"
     exit 1
 }
+
+# Provide warn() to satisfy check_port_conflict() tool-missing path.
+warn() { :; }
+
+# Default warn-once guard expected by the function.
+_port_check_warned=false
 
 echo "1. Function Existence Tests"
 echo "────────────────────────────"
@@ -40,20 +47,20 @@ echo "────────────────────────�
 printf "  %-50s " "check_port_conflict function exists..."
 if declare -f check_port_conflict >/dev/null; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 2: check_ollama_conflict function exists
 printf "  %-50s " "check_ollama_conflict function exists..."
 if declare -f check_ollama_conflict >/dev/null; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 echo ""
@@ -64,10 +71,10 @@ echo "────────────────────────�
 printf "  %-50s " "Unused port returns false..."
 if ! check_port_conflict 59999; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 4: check_port_conflict sets PORT_CONFLICT=false for unused port
@@ -75,10 +82,10 @@ printf "  %-50s " "PORT_CONFLICT=false for unused port..."
 check_port_conflict 59998 || true
 if [[ "$PORT_CONFLICT" == "false" ]]; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 5: Start a test server and detect it
@@ -90,37 +97,37 @@ sleep 1
 
 if check_port_conflict 59997; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 6: PORT_CONFLICT=true for used port
 printf "  %-50s " "PORT_CONFLICT=true for used port..."
 if [[ "$PORT_CONFLICT" == "true" ]]; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 7: PORT_CONFLICT_PID is set
 printf "  %-50s " "PORT_CONFLICT_PID is set..."
 if [[ -n "$PORT_CONFLICT_PID" ]]; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 8: PORT_CONFLICT_PROC is set
 printf "  %-50s " "PORT_CONFLICT_PROC is set..."
 if [[ -n "$PORT_CONFLICT_PROC" ]] && [[ "$PORT_CONFLICT_PROC" != "unknown" ]]; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${YELLOW}⚠ SKIP${NC} (may require lsof)"
 fi
@@ -137,20 +144,20 @@ echo "────────────────────────�
 printf "  %-50s " "check_ollama_conflict runs without error..."
 if check_ollama_conflict; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
-    echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    echo -e "${RED}✗ FAIL${NC}"
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 10: OLLAMA_RUNNING is set (true or false)
 printf "  %-50s " "OLLAMA_RUNNING variable is set..."
 if [[ "$OLLAMA_RUNNING" == "true" ]] || [[ "$OLLAMA_RUNNING" == "false" ]]; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 11: If Ollama is running, OLLAMA_PID is set
@@ -158,10 +165,10 @@ printf "  %-50s " "OLLAMA_PID set when Ollama running..."
 if [[ "$OLLAMA_RUNNING" == "true" ]]; then
     if [[ -n "$OLLAMA_PID" ]]; then
         echo -e "${GREEN}✓ PASS${NC}"
-        ((PASSED++))
+        PASSED=$((PASSED + 1))
     else
         echo -e "${RED}✗ FAIL${NC}"
-        ((FAILED++))
+        FAILED=$((FAILED + 1))
     fi
 else
     echo -e "${YELLOW}⚠ SKIP${NC} (Ollama not running)"
@@ -175,30 +182,30 @@ echo "────────────────────"
 printf "  %-50s " "Phase script calls check_ollama_conflict..."
 if grep -q "check_ollama_conflict" "$ROOT_DIR/installers/phases/04-requirements.sh"; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 13: Phase script uses check_port_conflict
 printf "  %-50s " "Phase script calls check_port_conflict..."
 if grep -q "check_port_conflict" "$ROOT_DIR/installers/phases/04-requirements.sh"; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 # Test 14: Phase script shows process details in warnings
 printf "  %-50s " "Phase script shows PORT_CONFLICT_PROC..."
 if grep -q "PORT_CONFLICT_PROC" "$ROOT_DIR/installers/phases/04-requirements.sh"; then
     echo -e "${GREEN}✓ PASS${NC}"
-    ((PASSED++))
+    PASSED=$((PASSED + 1))
 else
     echo -e "${RED}✗ FAIL${NC}"
-    ((FAILED++))
+    FAILED=$((FAILED + 1))
 fi
 
 echo ""


### PR DESCRIPTION
# Linux Port Conflict and Ollama Detection

## Summary

Adds detailed port conflict detection and Ollama conflict detection to the Linux installer, matching macOS installer behavior and improving installation reliability.

## Problem

The Linux installer lacked port conflict detection and Ollama conflict detection that the macOS installer already had:
- No detailed process information when ports are in use
- No detection of running Ollama instances that conflict with Dream Server
- Users encounter installation failures without clear guidance on what's blocking ports
- Platform inconsistency: macOS has these features, Linux doesn't

## Solution

Added comprehensive port and Ollama detection to Phase 04 (requirements check):

### Port Conflict Detection
- New `check_port_conflict()` function with process details (PID, process name)
- Three-tier fallback: lsof → ss → netstat
- Shows which process is using conflicting ports in warning messages
- Checks all required ports: 8080, 3000, 9000, 8880, 5678, 6333 (based on enabled features)

### Ollama Conflict Detection
- New `check_ollama_conflict()` function to detect running Ollama instances
- Interactive prompt to stop Ollama before installation
- Clear warning about port conflicts (11434/8080)
- Matches macOS installer UX

## Implementation Details

```bash
# Port conflict detection with process details
check_port_conflict() {
    local port="$1"
    PORT_CONFLICT=false
    PORT_CONFLICT_PID=""
    PORT_CONFLICT_PROC=""

    # Try lsof first (most reliable for getting process info)
    if command -v lsof &> /dev/null; then
        if lsof -i ":${port}" -sTCP:LISTEN >/dev/null 2>&1; then
            PORT_CONFLICT_PID=$(lsof -t -i ":${port}" -sTCP:LISTEN 2>/dev/null | head -1)
            PORT_CONFLICT_PROC=$(ps -p "$PORT_CONFLICT_PID" -o comm= 2>/dev/null || echo "unknown")
            PORT_CONFLICT=true
            return 0
        fi
    # Fallback to ss (faster but less detailed)
    elif command -v ss &> /dev/null; then
        # Extract PID from ss output
        ...
    # Fallback to netstat
    elif command -v netstat &> /dev/null; then
        ...
    fi
}

# Ollama conflict detection
check_ollama_conflict() {
    OLLAMA_RUNNING=false
    OLLAMA_PID=""

    if pgrep -x ollama >/dev/null 2>&1; then
        OLLAMA_RUNNING=true
        OLLAMA_PID=$(pgrep -x ollama | head -1)
    fi
}
```

## Files Modified

- `installers/phases/04-requirements.sh` (+88 lines, -17 lines)
  - Added `check_port_conflict()` function
  - Added `check_ollama_conflict()` function
  - Enhanced port checking with detailed process information
  - Added Ollama detection and interactive stop prompt

- `tests/test-port-ollama-detection.sh` (NEW, +217 lines)
  - 14 comprehensive test cases
  - Tests function existence, port detection, Ollama detection, integration

## Testing

Created comprehensive test suite with 14 test cases:

```bash
./tests/test-port-ollama-detection.sh
```

**Test coverage:**
- Function existence tests (2 tests)
- Port conflict detection tests (6 tests)
- Ollama detection tests (3 tests)
- Integration tests (3 tests)

**Test results:** ✅ All 14 tests pass

## Benefits

1. **Prevents installation failures** - Detects port conflicts before installation starts
2. **Better user experience** - Shows which process is blocking ports with PID and name
3. **Platform parity** - Matches macOS installer behavior
4. **Reduces support burden** - Users can identify and resolve conflicts themselves
5. **Ollama compatibility** - Handles common Ollama conflicts gracefully

## Backward Compatibility

✅ Fully backward compatible:
- Graceful fallback if lsof/ss/netstat not available
- Non-interactive mode still works (shows warnings but doesn't prompt)
- Existing port checking logic preserved as fallback

## Related Work

Closes gap identified in codebase analysis where Linux installer lacked port/Ollama detection that macOS installer already had (see `installers/macos/install-macos.sh:150` and `installers/macos/lib/detection.sh:134`).

---

**Testing Instructions:**
```bash
# Run test suite
./tests/test-port-ollama-detection.sh

# Test with port conflict (start a test server first)
python3 -m http.server 8080 &
./install.sh --dry-run

# Test with Ollama running (if installed)
ollama serve &
./install.sh --dry-run
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)