### PR TITLE
fix: add missing external_port_env to token-spy and dashboard manifests

### DIFF
--- a/dream-server/extensions/services/dashboard/manifest.yaml
+++ b/dream-server/extensions/services/dashboard/manifest.yaml
@@ -7,6 +7,7 @@ service:
   container_name: dream-dashboard
   default_host: dashboard
   port: 3001
+  external_port_env: DASHBOARD_PORT
   external_port_default: 3001
   health: /
   type: docker

--- a/dream-server/extensions/services/token-spy/manifest.yaml
+++ b/dream-server/extensions/services/token-spy/manifest.yaml
@@ -7,6 +7,7 @@ service:
   container_name: dream-token-spy
   default_host: token-spy
   port: 8080
+  external_port_env: TOKEN_SPY_PORT
   external_port_default: 3005
   health: /health
   type: docker


### PR DESCRIPTION
## What
Add missing `external_port_env` field to the `token-spy` and `dashboard` service manifests.

## Why
Both manifests defined `external_port_default` but omitted `external_port_env`. Without it, `dashboard-api/config.py` always hardcodes the default port for these two services — so `dream status`, health-check.sh, and the dashboard probe the wrong port whenever `TOKEN_SPY_PORT` or `DASHBOARD_PORT` is overridden in `.env`. All 14 other configurable-port manifests have this field; these two were the only ones missing it.

## How
Added one line to each manifest so `external_port_env` leads before `external_port_default`, matching the field ordering convention established across all other service manifests.

## Testing
- Diff scope: exactly +2 lines, 2 files — nothing else touched
- Env var names verified against `token-spy/compose.yaml`, `docker-compose.base.yml`, and `.env.schema.json`
- Field ordering verified against all 14 other manifests
- Pre-commit hooks passed (gitleaks, detect-private-key, large-file check)
- Pre-existing test/lint failures confirmed unrelated to this change

## Review
Critique Guardian verdict: ✅ APPROVED

## Known Considerations
Two pre-existing companion issues flagged during review (separate PR):
- `.env.schema.json` TOKEN_SPY_PORT default is `3003` but should be `3005`
- `TOKEN_SPY_PORT` absent from `.env.example` Ports section

## Platform Impact
All platforms — manifest metadata only, no platform-specific behavior.

Closes #189