### PR TITLE
docs: fix NVIDIA model table to match actual tier-map

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ The installer detects your GPU and picks the optimal model automatically. No man
 
 | VRAM | Model | Example GPUs |
 |------|-------|--------------|
-| 8–11 GB | Qwen 2.5 7B (Q4_K_M) | RTX 4060 Ti, RTX 3060 12GB |
-| 12–20 GB | Qwen 2.5 14B (Q4_K_M) | RTX 3090, RTX 4080 |
-| 20–40 GB | Qwen 2.5 32B (Q4_K_M) | RTX 4090, A6000 |
-| 40+ GB | Qwen 2.5 72B (Q4_K_M) | A100, multi-GPU |
-| 90+ GB | Qwen3 Coder Next 80B MoE | Multi-GPU A100/H100 |
+| 8–11 GB | Qwen3 8B (Q4_K_M) | RTX 4060 Ti, RTX 3060 12GB |
+| 12–20 GB | Qwen3 8B (Q4_K_M) | RTX 3090, RTX 4080 |
+| 20–40 GB | Qwen3 14B (Q4_K_M) | RTX 4090, A6000 |
+| 40+ GB | Qwen3 30B-A3B (MoE, Q4_K_M) | A100, multi-GPU |
+| 90+ GB | Qwen3 Coder Next (80B MoE, Q4_K_M) | Multi-GPU A100/H100 |
 
 ### AMD Strix Halo (Unified Memory)
 


### PR DESCRIPTION
## Summary
- The NVIDIA model table in the README still listed **Qwen 2.5** models (7B/14B/32B/72B) but the installer tier-map was updated to **Qwen3** across the board
- Updated all 5 NVIDIA rows to match `installers/lib/tier-map.sh`:
  - 8–11 GB: Qwen 2.5 7B → **Qwen3 8B**
  - 12–20 GB: Qwen 2.5 14B → **Qwen3 8B** (same model, more context)
  - 20–40 GB: Qwen 2.5 32B → **Qwen3 14B**
  - 40+ GB: Qwen 2.5 72B → **Qwen3 30B-A3B** (MoE)
  - 90+ GB: formatting consistency for Qwen3 Coder Next
- AMD Strix Halo and Apple Silicon tables were already correct

## Test plan
- [ ] Verify table renders correctly on GitHub
- [ ] Cross-check each row against `installers/lib/tier-map.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)