### PR TITLE
bugfix: llama: unbound variable in a shell script

### DIFF
--- a/dream-server/installers/phases/04-requirements.sh
+++ b/dream-server/installers/phases/04-requirements.sh
@@ -19,6 +19,7 @@
 chapter "REQUIREMENTS CHECK"
 
 [[ -f "${SCRIPT_DIR:-}/lib/safe-env.sh" ]] && . "${SCRIPT_DIR}/lib/safe-env.sh"
+[[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]] && . "$SCRIPT_DIR/lib/service-registry.sh"
 
 REQUIREMENTS_MET=true
 TIER_RANK="$(tier_rank "$TIER")"
@@ -219,8 +220,7 @@ if $OLLAMA_RUNNING; then
 fi
 
 # Port conflict detection with detailed process information
-declare -A PORTS_TO_CHECK
-PORTS_TO_CHECK="${SERVICE_PORTS["llama-server"]:-8080} ${SERVICE_PORTS["open-webui"]:-3000}"
+PORTS_TO_CHECK="${SERVICE_PORTS[llama-server]:-8080} ${SERVICE_PORTS[open-webui]:-3000}"
 [[ "$ENABLE_VOICE" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[whisper]:-9000} ${SERVICE_PORTS[tts]:-8880}"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[n8n]:-5678}"
 [[ "$ENABLE_RAG" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[qdrant]:-6333}"


### PR DESCRIPTION
In the 4th phase of the installer, source service-registry.sh before using SERVICE_PORTS, this fixes a bug where this error appears on installs
```
line 222: llama: unbound variable in a shell script
```
