### PR TITLE
docs: fix broken links in docs index

### DIFF
--- a/dream-server/docs/COMPOSABILITY-EXECUTION-BOARD.md
+++ b/dream-server/docs/COMPOSABILITY-EXECUTION-BOARD.md
@@ -92,7 +92,7 @@ Status: `DONE`
 Owner: Infra  
 Effort: 2-4 days  
 Files:
-- [`docker-compose.strix-halo.yml`](../docker-compose.strix-halo.yml)
+- `docker-compose.strix-halo.yml` (historical; removed/renamed)
 - `docker-compose.base.yml` (new)
 - `docker-compose.nvidia.yml` (new)
 - `docker-compose.amd.yml` (new)
@@ -134,7 +134,7 @@ Effort: 3-5 days
 Files:
 - `extensions/schema/service-manifest.v1.json` (new)
 - `extensions/services/*.yaml` (new examples)
-- [`dashboard-api/main.py`](../dashboard-api/main.py)
+- [`dashboard-api/main.py`](../extensions/services/dashboard-api/main.py)
 Acceptance:
 - API can load service definitions from manifests.
 - Health checks and feature cards reference manifest data, not hardcoded lists.
@@ -171,8 +171,8 @@ Status: `DONE`
 Owner: Frontend  
 Effort: 3-4 days  
 Files:
-- [`dashboard/src/App.jsx`](../dashboard/src/App.jsx)
-- [`dashboard/src/components/Sidebar.jsx`](../dashboard/src/components/Sidebar.jsx)
+- [`dashboard/src/App.jsx`](../extensions/services/dashboard/src/App.jsx)
+- [`dashboard/src/components/Sidebar.jsx`](../extensions/services/dashboard/src/components/Sidebar.jsx)
 - `dashboard/src/plugins/registry.js` (new)
 - `dashboard/src/plugins/core.js` (new)
 Acceptance:
@@ -188,8 +188,8 @@ Status: `DONE`
 Owner: Frontend + API  
 Effort: 2-3 days  
 Files:
-- [`dashboard/src/pages/Dashboard.jsx`](../dashboard/src/pages/Dashboard.jsx)
-- [`dashboard-api/main.py`](../dashboard-api/main.py)
+- [`dashboard/src/pages/Dashboard.jsx`](../extensions/services/dashboard/src/pages/Dashboard.jsx)
+- [`dashboard-api/main.py`](../extensions/services/dashboard-api/main.py)
 Acceptance:
 - Feature tiles derive from API metadata.
 - Ports/URLs are not hardcoded in JSX.
@@ -207,7 +207,7 @@ Owner: API + Docs
 Effort: 1-2 days  
 Files:
 - `config/n8n/catalog.json` (planned; not yet created)
-- [`dashboard-api/main.py`](../dashboard-api/main.py)
+- [`dashboard-api/main.py`](../extensions/services/dashboard-api/main.py)
 - [`docs/INTEGRATION-GUIDE.md`](../docs/INTEGRATION-GUIDE.md)
 Acceptance:
 - One canonical workflow path in code/docs.
@@ -285,7 +285,7 @@ Owner: Release
 Effort: 2-3 days  
 Files:
 - `manifest.json` (new)
-- [`dashboard-api/main.py`](../dashboard-api/main.py)
+- [`dashboard-api/main.py`](../extensions/services/dashboard-api/main.py)
 - [`dream-update.sh`](../dream-update.sh)
 Acceptance:
 - Update path validates version compatibility and rollback point.

--- a/dream-server/docs/FAQ.md
+++ b/dream-server/docs/FAQ.md
@@ -2,7 +2,7 @@
 
 Quick answers to common questions.
 
-> **Looking for troubleshooting?** See the main [`FAQ.md`](../FAQ.md) for installation issues, service logs, and technical fixes.
+> **Looking for install/runtime troubleshooting?** See [TROUBLESHOOTING.md](TROUBLESHOOTING.md) and [INSTALL-TROUBLESHOOTING.md](INSTALL-TROUBLESHOOTING.md).
 
 ---
 

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -7,7 +7,7 @@
 | [HOW-DREAM-SERVER-WORKS.md](HOW-DREAM-SERVER-WORKS.md) | **Everyone** | **The friendly guide — what Dream Server is, why it exists, how every piece fits together, and how to make it your own. No technical background required.** |
 | [../README.md](../README.md) | Everyone | Project overview, quickstart, architecture |
 | [../QUICKSTART.md](../QUICKSTART.md) | Operators | Step-by-step first install |
-| [../EDGE-QUICKSTART.md](../EDGE-QUICKSTART.md) | Operators | Pi 5 / Mac Mini / edge devices (planned) |
+| [../EDGE-QUICKSTART.md](../EDGE-QUICKSTART.md) | Operators | Pi 5 / Mac Mini / edge devices (**planned**) — currently a placeholder doc |
 | [../.env.example](../.env.example) | Operators | All environment variables with defaults |
 
 ## Building & Extending


### PR DESCRIPTION
## Summary

This PR fixes a handful of broken / misleading documentation links that have accumulated as the project evolved (notably the dashboard + dashboard-api path moves). The goal is to reduce “dead-end” clicks for new users and contributors and make the docs index more reliable.

## What changed

- **Fixed broken internal links** in `dream-server/docs/COMPOSABILITY-EXECUTION-BOARD.md`:
  - Updated `dashboard-api/main.py` references to the current location under `extensions/services/dashboard-api/`
  - Updated `dashboard/src/*` references to the current location under `extensions/services/dashboard/`
  - Marked `docker-compose.strix-halo.yml` as historical/removed (it no longer exists)

- **Clarified planned/placeholder docs** in `dream-server/docs/README.md`:
  - The “Edge Quickstart” entry is now explicitly labeled as planned/placeholder so readers don’t assume it’s a working install path.

- **Corrected troubleshooting guidance** in `dream-server/docs/FAQ.md`:
  - Replaced a confusing link to the “main FAQ” with direct pointers to `TROUBLESHOOTING.md` and `INSTALL-TROUBLESHOOTING.md`.

## Why

Docs are frequently the first touchpoint for new users and external contributors. Broken links and ambiguous pointers slow onboarding and create unnecessary friction, especially when paths change during active development.

## Verification

- Ran a local markdown link existence check across `README.md` and `dream-server/docs/*.md` to ensure no missing local link targets remain after the updates.

## Scope

Docs-only change. No runtime code, configs, or behavior changes.
