### PR TITLE
fix(privacy-shield): persist generated shield api key

### DIFF
--- a/dream-server/extensions/services/privacy-shield/README.md
+++ b/dream-server/extensions/services/privacy-shield/README.md
@@ -60,6 +60,10 @@ Environment variables (set in `.env`):
 | `PII_CACHE_ENABLED` | true | Enable session PII caching |
 | `PII_CACHE_SIZE` | 1000 | Max cached sessions |
 | `PII_CACHE_TTL` | 300 | Session TTL in seconds |
+| `SHIELD_API_KEY` | (auto) | API key required by the proxy endpoints. Set explicitly in `.env` for production. |
+| `SHIELD_API_KEY_PATH` | `/data/shield_api_key` | Where an auto-generated key is persisted (mounted volume) to survive restarts. |
+
+> If `SHIELD_API_KEY` is not set, Privacy Shield will generate one and persist it to `SHIELD_API_KEY_PATH` so clients don't break after container restarts.
 
 ### API Usage
 

--- a/dream-server/extensions/services/privacy-shield/proxy.py
+++ b/dream-server/extensions/services/privacy-shield/proxy.py
@@ -20,11 +20,51 @@ from cachetools import TTLCache
 from pii_scrubber import PrivacyShield
 
 # Security: API Key Authentication
+# Prefer explicit env var, but persist a generated key to the mounted /data volume
+# to avoid breaking clients across container restarts.
 SHIELD_API_KEY = os.environ.get("SHIELD_API_KEY")
+
+DEFAULT_KEY_PATH = os.environ.get("SHIELD_API_KEY_PATH", "/data/shield_api_key")
+
+
+def _load_persisted_key(path: str) -> str | None:
+    try:
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            key = f.read().strip()
+        return key or None
+    except Exception:
+        logging.exception("Failed to read persisted SHIELD_API_KEY")
+        return None
+
+
+def _persist_key(path: str, key: str) -> None:
+    try:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(key)
+        try:
+            os.chmod(path, 0o600)
+        except Exception:
+            # Best-effort only (may fail on some mounts/platforms)
+            pass
+    except Exception:
+        logging.exception("Failed to persist generated SHIELD_API_KEY")
+
+
 if not SHIELD_API_KEY:
-    SHIELD_API_KEY = secrets.token_urlsafe(32)
-    logging.warning("SHIELD_API_KEY not set. Generated temporary key (not logging for security). "
-                   "Set SHIELD_API_KEY in .env for production.")
+    persisted = _load_persisted_key(DEFAULT_KEY_PATH)
+    if persisted:
+        SHIELD_API_KEY = persisted
+        logging.info("Loaded persisted SHIELD_API_KEY from disk")
+    else:
+        SHIELD_API_KEY = secrets.token_urlsafe(32)
+        _persist_key(DEFAULT_KEY_PATH, SHIELD_API_KEY)
+        logging.warning(
+            "SHIELD_API_KEY not set. Generated a key and persisted it for reuse. "
+            "Set SHIELD_API_KEY in .env to manage it explicitly."
+        )
 
 security_scheme = HTTPBearer()
 


### PR DESCRIPTION
## Summary

Privacy Shield requires an API key (`SHIELD_API_KEY`) for its proxy endpoints. When the variable is not set, the service currently generates a new random key on every startup, which can break clients after container restarts.

This PR makes the generated key stable across restarts by persisting it to the mounted `/data` volume.

## What changed

- **`privacy-shield/proxy.py`**
  - If `SHIELD_API_KEY` is set: use it as-is (no behavior change)
  - Otherwise:
    - Load a persisted key from `SHIELD_API_KEY_PATH` (default: `/data/shield_api_key`) if present
    - If no persisted key exists, generate one and write it to `SHIELD_API_KEY_PATH` (best-effort `chmod 0600`)

- **`privacy-shield/README.md`**
  - Documented `SHIELD_API_KEY` and the persistence behavior via `SHIELD_API_KEY_PATH`

## Why

This improves operator experience and reliability: the proxy’s auth key no longer changes unexpectedly on restarts unless the operator explicitly chooses to rotate it.

## Scope

Small, isolated change limited to the Privacy Shield service and its documentation.
No installer, registry, or dashboard UI changes.
