### PR TITLE
test: integration compose checks accept webui naming

### DIFF
--- a/dream-server/tests/integration-test.sh
+++ b/dream-server/tests/integration-test.sh
@@ -125,21 +125,29 @@ else
             fi
         fi
 
-        # Verify core services are defined
+        # Verify core services are defined (behaviorally)
+        # The WebUI service name has changed over time (webui -> open-webui). We accept either.
         compose_config=$(docker compose $COMPOSE_FLAGS --env-file "$PROJECT_DIR/.env.example" config 2>/dev/null || docker compose $COMPOSE_FLAGS config 2>/dev/null || true)
-        if [[ "$(basename "$COMPOSE_FILE")" == "docker-compose.amd.yml" ]]; then
-            core_services=("llama-server" "open-webui")
+
+        if echo "$compose_config" | grep -qE "^\s{2}llama-server:$" 2>/dev/null || \
+           grep -qE "^[[:space:]]*llama-server:" "$COMPOSE_FILE" 2>/dev/null; then
+            pass "Core service defined: llama-server"
         else
-            core_services=("llama-server" "webui")
+            fail "Core service missing: llama-server"
         fi
-        for service in "${core_services[@]}"; do
-            if echo "$compose_config" | grep -qE "^\\s{2}${service}:$" 2>/dev/null || \
-               grep -qE "^[[:space:]]*${service}:" "$COMPOSE_FILE" 2>/dev/null; then
-                pass "Core service defined: $service"
-            else
-                fail "Core service missing: $service"
-            fi
-        done
+
+        if echo "$compose_config" | grep -qE "^\s{2}(open-webui|webui):$" 2>/dev/null || \
+           grep -qE "^[[:space:]]*(open-webui|webui):" "$COMPOSE_FILE" 2>/dev/null; then
+            pass "Core service defined: web UI (open-webui or webui)"
+        else
+            fail "Core service missing: web UI (open-webui or webui)"
+        fi
+
+        # Optional: if both are present, report it (not a failure).
+        if echo "$compose_config" | grep -qE "^\s{2}open-webui:$" 2>/dev/null && \
+           echo "$compose_config" | grep -qE "^\s{2}webui:$" 2>/dev/null; then
+            pass "Both web UI service names present (open-webui + webui)"
+        fi
     else
         skip "Docker not installed — cannot validate compose syntax"
     fi


### PR DESCRIPTION
## Summary

This PR makes the integration test suite resilient to the WebUI service naming change (`webui` → `open-webui`).

Instead of hardcoding the expected WebUI service name based on the compose overlay, the test now validates the intent of the stack contract: there must be an LLM service and a chat UI service.

## What changed

- Updated `dream-server/tests/integration-test.sh` core service checks:
  - Still requires `llama-server`
  - Accepts **either** `open-webui` **or** `webui` as the Web UI service
  - If both are present, it reports that as a pass (not a failure)

## Why

The service name has changed over time and can vary depending on compose overlays and extensions. Hardcoded expectations cause false-negative CI failures for contributors even when the stack is valid.

## Verification

- `bash -n dream-server/tests/integration-test.sh`
- `bash dream-server/tests/integration-test.sh` (suite still has known pre-existing failures unrelated to this change)
