### PR TITLE
fix(privacy-shield): persist api key and add tests

### DIFF
--- a/dream-server/extensions/services/privacy-shield/compose.yaml
+++ b/dream-server/extensions/services/privacy-shield/compose.yaml
@@ -10,8 +10,9 @@ services:
       - no-new-privileges:true
     environment:
       - TARGET_API_URL=${LLM_API_URL:-http://llama-server:8080}/v1
-      - TARGET_API_KEY=not-needed
+      - TARGET_API_KEY=${TARGET_API_KEY:-not-needed}
       - SHIELD_PORT=${SHIELD_PORT:-8085}
+      - SHIELD_API_KEY_PATH=${SHIELD_API_KEY_PATH:-/data/shield_api_key}
       - PII_CACHE_ENABLED=${PII_CACHE_ENABLED:-true}
       - PII_CACHE_SIZE=${PII_CACHE_SIZE:-1000}
       - PII_CACHE_TTL=${PII_CACHE_TTL:-300}

--- a/dream-server/extensions/services/privacy-shield/key_management.py
+++ b/dream-server/extensions/services/privacy-shield/key_management.py
@@ -1,0 +1,63 @@
+"""Small utilities for managing Privacy Shield credentials.
+
+Kept separate from proxy.py so it can be unit-tested without importing FastAPI/httpx.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+from typing import Optional
+
+
+def load_persisted_key(path: str) -> Optional[str]:
+    try:
+        if not os.path.exists(path):
+            return None
+        with open(path, "r", encoding="utf-8") as f:
+            key = f.read().strip()
+        return key or None
+    except Exception:
+        logging.exception("Failed to read persisted SHIELD_API_KEY")
+        return None
+
+
+def persist_key(path: str, key: str) -> None:
+    try:
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(key)
+        try:
+            os.chmod(path, 0o600)
+        except Exception:
+            # Best-effort only (may fail on some mounts/platforms)
+            pass
+    except Exception:
+        logging.exception("Failed to persist generated SHIELD_API_KEY")
+
+
+def resolve_shield_api_key(env_key: Optional[str], key_path: str) -> str:
+    """Resolve the API key used by Privacy Shield.
+
+    Precedence:
+    1) Explicit env var (preferred)
+    2) Persisted key file (to survive restarts)
+    3) Generated key (persisted for future reuse)
+    """
+
+    if env_key:
+        return env_key
+
+    persisted = load_persisted_key(key_path)
+    if persisted:
+        logging.info("Loaded persisted SHIELD_API_KEY from disk")
+        return persisted
+
+    key = secrets.token_urlsafe(32)
+    persist_key(key_path, key)
+    logging.warning(
+        "SHIELD_API_KEY not set. Generated a key and persisted it for reuse. "
+        "Set SHIELD_API_KEY in .env to manage it explicitly."
+    )
+    return key

--- a/dream-server/extensions/services/privacy-shield/proxy.py
+++ b/dream-server/extensions/services/privacy-shield/proxy.py
@@ -18,13 +18,11 @@ import uvicorn
 from cachetools import TTLCache
 
 from pii_scrubber import PrivacyShield
+from key_management import resolve_shield_api_key
 
 # Security: API Key Authentication
-SHIELD_API_KEY = os.environ.get("SHIELD_API_KEY")
-if not SHIELD_API_KEY:
-    SHIELD_API_KEY = secrets.token_urlsafe(32)
-    logging.warning("SHIELD_API_KEY not set. Generated temporary key (not logging for security). "
-                   "Set SHIELD_API_KEY in .env for production.")
+DEFAULT_KEY_PATH = os.environ.get("SHIELD_API_KEY_PATH", "/data/shield_api_key")
+SHIELD_API_KEY = resolve_shield_api_key(os.environ.get("SHIELD_API_KEY"), DEFAULT_KEY_PATH)
 
 security_scheme = HTTPBearer()
 

--- a/dream-server/extensions/services/privacy-shield/tests/test_key_management.py
+++ b/dream-server/extensions/services/privacy-shield/tests/test_key_management.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import tempfile
+import unittest
+
+# Allow running this test from repo root without installing the service as a package.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from key_management import resolve_shield_api_key, persist_key
+
+
+class TestKeyManagement(unittest.TestCase):
+    def test_env_key_wins(self):
+        with tempfile.TemporaryDirectory() as d:
+            key_path = os.path.join(d, "shield_api_key")
+            persist_key(key_path, "persisted")
+            self.assertEqual(resolve_shield_api_key("from_env", key_path), "from_env")
+
+    def test_loads_persisted_key(self):
+        with tempfile.TemporaryDirectory() as d:
+            key_path = os.path.join(d, "shield_api_key")
+            persist_key(key_path, "persisted")
+            self.assertEqual(resolve_shield_api_key(None, key_path), "persisted")
+
+    def test_generates_and_persists_key(self):
+        with tempfile.TemporaryDirectory() as d:
+            key_path = os.path.join(d, "shield_api_key")
+            key = resolve_shield_api_key(None, key_path)
+            self.assertTrue(isinstance(key, str) and len(key) > 0)
+            with open(key_path, "r", encoding="utf-8") as f:
+                self.assertEqual(f.read().strip(), key)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Privacy Shield requires an API key (`SHIELD_API_KEY`) for its proxy endpoints. If the key isn’t set, the service previously generated a new random key on every startup, which can break clients after container restarts.

This PR makes the behavior stable and operator-friendly by persisting an auto-generated key to the mounted `/data` volume, wiring the key path through compose, and adding unit tests to prevent regressions.

## What changed

- **Key management module + tests**
  - Added `key_management.py` containing the key resolution logic (env → persisted file → generated+persisted)
  - Added unit tests covering precedence and persistence behavior

- **Privacy Shield proxy**
  - `proxy.py` now uses `SHIELD_API_KEY_PATH` (default: `/data/shield_api_key`) to load/persist the key when `SHIELD_API_KEY` is not set

- **Compose wiring**
  - `compose.yaml` now passes:
    - `SHIELD_API_KEY_PATH=${SHIELD_API_KEY_PATH:-/data/shield_api_key}`
    - `TARGET_API_KEY=${TARGET_API_KEY:-not-needed}` (instead of hardcoded)

## Why

- Prevents client breakage across Privacy Shield container restarts
- Makes key location/configuration explicit and configurable
- Adds test coverage for this security-sensitive behavior without touching installer/registry/dashboard surfaces

## Scope

Changes are isolated to `dream-server/extensions/services/privacy-shield/**`.
No installer, service-registry, or dashboard UI changes.
