### PR TITLE
security: harden service registry, fix db exception, improve PII scrubber

### DIFF
--- a/dream-server/extensions/services/privacy-shield/pii_scrubber.py
+++ b/dream-server/extensions/services/privacy-shield/pii_scrubber.py
@@ -30,7 +30,7 @@ class PIIDetector:
     PATTERNS = {
         'email': re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b'),
         'phone': re.compile(r'\b(?:\+?1[-.\s]?)?\(?[0-9]{3}\)?[-.\s]?[0-9]{3}[-.\s]?[0-9]{4}\b'),
-        'ssn': re.compile(r'\b\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b'),
+        'ssn': re.compile(r'\b(?!(?:19|20)\d{2}[-.\s]?\d{2}[-.\s]?\d{4}\b)\d{3}[-.\s]?\d{2}[-.\s]?\d{4}\b'),
         'ip_address': re.compile(
             r'\b(?:\d{1,3}\.){3}\d{1,3}\b'  # IPv4
             r'|'
@@ -45,6 +45,21 @@ class PIIDetector:
         'api_key': re.compile(r'\b(?:api[_-]?key|apikey|token)[\s]*[=:]\s*["\']?[a-zA-Z0-9_\-]{16,}["\']?\b', re.IGNORECASE),
         'credit_card': re.compile(r'\b(?:\d{4}[-\s]?){3}\d{4}\b'),
     }
+
+    @staticmethod
+    def _luhn_check(number_str: str) -> bool:
+        """Validate a credit card number using the Luhn algorithm."""
+        digits = [int(d) for d in number_str if d.isdigit()]
+        if len(digits) != 16:
+            return False
+        checksum = 0
+        for i, d in enumerate(reversed(digits)):
+            if i % 2 == 1:
+                d *= 2
+                if d > 9:
+                    d -= 9
+            checksum += d
+        return checksum % 10 == 0
 
     def _generate_token(self, pii_type: str, original: str) -> str:
         """Generate a unique token for PII."""
@@ -66,6 +81,10 @@ class PIIDetector:
             for match in matches:
                 if isinstance(match, tuple):
                     match = match[0]  # Handle groups
+
+                # Credit card: validate with Luhn to reduce false positives
+                if pii_type == 'credit_card' and not self._luhn_check(match):
+                    continue
 
                 # Check if we've seen this PII before
                 existing_token = None

--- a/dream-server/extensions/services/privacy-shield/tests/test_pii_scrubber.py
+++ b/dream-server/extensions/services/privacy-shield/tests/test_pii_scrubber.py
@@ -1,0 +1,223 @@
+"""Unit tests for the deployed PII scrubber regex patterns."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add parent dir so pii_scrubber can be imported
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from pii_scrubber import PIIDetector, PrivacyShield
+
+
+@pytest.fixture
+def detector():
+    return PIIDetector()
+
+
+@pytest.fixture
+def shield():
+    return PrivacyShield()
+
+
+# ── Email detection ──────────────────────────────────────────────────────────
+
+class TestEmailDetection:
+    def test_basic_email(self, detector):
+        text = "Contact me at user@example.com please"
+        result = detector.scrub(text)
+        assert "user@example.com" not in result
+        assert "<PII_email_" in result
+
+    def test_email_with_plus(self, detector):
+        text = "Send to user+tag@example.com"
+        result = detector.scrub(text)
+        assert "user+tag@example.com" not in result
+
+    def test_email_with_dots(self, detector):
+        text = "john.doe.jr@subdomain.example.co.uk"
+        result = detector.scrub(text)
+        assert "john.doe.jr@subdomain.example.co.uk" not in result
+
+    def test_no_false_positive_at_sign(self, detector):
+        text = "Use @mentions in chat"
+        result = detector.scrub(text)
+        assert result == text
+
+
+# ── Phone detection ──────────────────────────────────────────────────────────
+
+class TestPhoneDetection:
+    def test_us_phone_dashes(self, detector):
+        text = "Call 555-123-4567"
+        result = detector.scrub(text)
+        assert "555-123-4567" not in result
+        assert "<PII_phone_" in result
+
+    def test_us_phone_dots(self, detector):
+        text = "Call 555.123.4567"
+        result = detector.scrub(text)
+        assert "555.123.4567" not in result
+
+    def test_us_phone_with_country_code(self, detector):
+        text = "Call +1-555-123-4567"
+        result = detector.scrub(text)
+        assert "555-123-4567" not in result
+
+    def test_us_phone_parens(self, detector):
+        text = "Call (555) 123-4567"
+        result = detector.scrub(text)
+        assert "123-4567" not in result
+
+
+# ── SSN detection ────────────────────────────────────────────────────────────
+
+class TestSSNDetection:
+    def test_ssn_with_dashes(self, detector):
+        text = "SSN: 123-45-6789"
+        result = detector.scrub(text)
+        assert "123-45-6789" not in result
+        assert "<PII_ssn_" in result
+
+    def test_ssn_with_dots(self, detector):
+        text = "SSN: 123.45.6789"
+        result = detector.scrub(text)
+        assert "123.45.6789" not in result
+
+    def test_ssn_no_separators(self, detector):
+        text = "SSN: 123456789"
+        result = detector.scrub(text)
+        assert "123456789" not in result
+
+    def test_ssn_no_false_positive_date(self, detector):
+        """Dates starting with 19xx or 20xx should not match as SSNs."""
+        text = "Date: 2024-01-2345 is not an SSN"
+        result = detector.scrub(text)
+        # The date-like string should NOT be scrubbed as an SSN
+        assert "<PII_ssn_" not in result
+
+
+# ── IP address detection ─────────────────────────────────────────────────────
+
+class TestIPDetection:
+    def test_ipv4(self, detector):
+        text = "Server at 192.168.1.100"
+        result = detector.scrub(text)
+        assert "192.168.1.100" not in result
+        assert "<PII_ip_address_" in result
+
+    def test_ipv4_localhost(self, detector):
+        text = "Listening on 127.0.0.1"
+        result = detector.scrub(text)
+        assert "127.0.0.1" not in result
+
+    def test_full_ipv6(self, detector):
+        text = "IPv6: 2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        result = detector.scrub(text)
+        assert "2001:0db8:85a3:0000:0000:8a2e:0370:7334" not in result
+
+
+# ── API key detection ────────────────────────────────────────────────────────
+
+class TestAPIKeyDetection:
+    def test_api_key_equals(self, detector):
+        text = "api_key=sk-abc123xyz789abcdef"
+        result = detector.scrub(text)
+        assert "sk-abc123xyz789abcdef" not in result
+        assert "<PII_api_key_" in result
+
+    def test_api_key_colon(self, detector):
+        text = "token: abcdef1234567890abcdef"
+        result = detector.scrub(text)
+        assert "abcdef1234567890abcdef" not in result
+
+    def test_short_value_not_matched(self, detector):
+        text = "api_key=short"
+        result = detector.scrub(text)
+        assert result == text
+
+
+# ── Credit card detection ────────────────────────────────────────────────────
+
+class TestCreditCardDetection:
+    def test_visa_with_spaces(self, detector):
+        text = "Card: 4111 1111 1111 1111"
+        result = detector.scrub(text)
+        assert "4111 1111 1111 1111" not in result
+        assert "<PII_credit_card_" in result
+
+    def test_visa_with_dashes(self, detector):
+        text = "Card: 4111-1111-1111-1111"
+        result = detector.scrub(text)
+        assert "4111-1111-1111-1111" not in result
+
+    def test_visa_no_separators(self, detector):
+        text = "Card: 4111111111111111"
+        result = detector.scrub(text)
+        assert "4111111111111111" not in result
+
+    def test_luhn_invalid_not_matched(self, detector):
+        """A 16-digit number that fails Luhn should not be scrubbed."""
+        text = "Number: 1234567890123456"
+        result = detector.scrub(text)
+        # 1234567890123456 fails Luhn — should NOT be treated as credit card
+        assert "<PII_credit_card_" not in result
+
+    def test_luhn_check_static(self):
+        """Verify the Luhn algorithm implementation directly."""
+        assert PIIDetector._luhn_check("4111111111111111") is True  # Valid Visa test number
+        assert PIIDetector._luhn_check("5500000000000004") is True  # Valid MC test number
+        assert PIIDetector._luhn_check("1234567890123456") is False  # Invalid
+
+
+# ── Round-trip (scrub + restore) ─────────────────────────────────────────────
+
+class TestRoundTrip:
+    def test_full_round_trip(self, shield):
+        original = (
+            "Contact john@example.com or call 555-123-4567. "
+            "SSN: 123-45-6789. Server: 192.168.1.100. "
+            "api_key=sk-abc123xyz789abcdef"
+        )
+        scrubbed, meta = shield.process_request(original)
+        assert meta["scrubbed"] is True
+        assert meta["pii_count"] > 0
+        restored = shield.process_response(scrubbed)
+        assert restored == original
+
+    def test_no_pii_unchanged(self, shield):
+        text = "Hello, this is a normal message with no PII."
+        scrubbed, meta = shield.process_request(text)
+        assert meta["scrubbed"] is False
+        assert scrubbed == text
+
+    def test_deterministic_tokens(self, detector):
+        """Same PII should produce same token within a session."""
+        text1 = "Email: test@example.com"
+        text2 = "Also: test@example.com"
+        result1 = detector.scrub(text1)
+        result2 = detector.scrub(text2)
+        # Extract the token from result1
+        import re
+        tokens1 = re.findall(r'<PII_email_[a-f0-9]+>', result1)
+        tokens2 = re.findall(r'<PII_email_[a-f0-9]+>', result2)
+        assert len(tokens1) == 1
+        assert len(tokens2) == 1
+        assert tokens1[0] == tokens2[0]
+
+
+# ── Stats ────────────────────────────────────────────────────────────────────
+
+class TestStats:
+    def test_stats_after_scrub(self, detector):
+        detector.scrub("Email: a@b.com, Phone: 555-123-4567")
+        stats = detector.get_stats()
+        assert stats["unique_pii_count"] >= 2
+        assert "email" in stats["pii_types"]
+        assert "phone" in stats["pii_types"]
+
+    def test_stats_empty(self, detector):
+        stats = detector.get_stats()
+        assert stats["unique_pii_count"] == 0
+        assert stats["pii_types"] == []

--- a/dream-server/extensions/services/token-spy/db.py
+++ b/dream-server/extensions/services/token-spy/db.py
@@ -76,8 +76,11 @@ def init_db():
         try:
             conn.execute(f"ALTER TABLE usage ADD COLUMN {col} {typedef}")
             conn.commit()
-        except sqlite3.OperationalError:
-            pass  # Column already exists
+        except sqlite3.OperationalError as e:
+            if "duplicate column" in str(e).lower():
+                pass  # Column already exists
+            else:
+                raise  # Re-raise unexpected errors (disk full, permissions, etc.)
 
 
 def log_usage(entry: dict):

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -28,6 +28,19 @@ sr_load() {
 import yaml, sys, os
 from pathlib import Path
 
+import re as _re
+
+_SAFE_VALUE = _re.compile(r'^[a-zA-Z0-9 _./:@,=-]*$')
+
+def _esc(value):
+    """Escape a value for safe inclusion in double-quoted bash assignment.
+    Rejects values with characters that could enable shell injection."""
+    s = str(value)
+    if _SAFE_VALUE.match(s):
+        return s
+    # Strip characters that are dangerous in double-quoted bash strings
+    return s.replace('\\', '\\\\').replace('"', '\\"').replace('$', '\\$').replace('`', '\\`').replace('!', '\\!')
+
 ext_dir = Path(sys.argv[1])
 if not ext_dir.exists():
     sys.exit(0)
@@ -46,17 +59,38 @@ for service_dir in sorted(ext_dir.iterdir()):
     try:
         with open(manifest_path) as f:
             m = yaml.safe_load(f)
+        if not isinstance(m, dict):
+            print(f'# SKIP: {manifest_path}: not a valid YAML mapping', file=sys.stderr)
+            continue
         if m.get("schema_version") != "dream.services.v1":
             continue
-        s = m.get("service", {})
+        s = m.get("service")
+        if not isinstance(s, dict):
+            print(f'# SKIP: {manifest_path}: missing or invalid "service" section', file=sys.stderr)
+            continue
         sid = s.get("id", "")
         if not sid:
+            print(f'# SKIP: {manifest_path}: missing required "id" field', file=sys.stderr)
             continue
+
+        # Validate service ID — must be safe for use as bash associative array key
+        if not _re.match(r'^[a-zA-Z0-9_-]+$', sid):
+            print(f'# SKIP: invalid service id: {sid!r}', file=sys.stderr)
+            continue
+
         aliases = s.get("aliases", [])
         container = s.get("container_name", f"dream-{sid}")
         compose_file = s.get("compose_file", "")
         category = s.get("category", "optional")
         depends = s.get("depends_on", [])
+
+        # Validate aliases
+        valid_aliases = []
+        for a in aliases:
+            if _re.match(r'^[a-zA-Z0-9_-]+$', str(a)):
+                valid_aliases.append(str(a))
+            else:
+                print(f'# SKIP alias: invalid alias {a!r} in {sid}', file=sys.stderr)
 
         # Resolve compose path (relative to extension dir)
         compose_path = ""
@@ -65,30 +99,31 @@ for service_dir in sorted(ext_dir.iterdir()):
             if full.exists():
                 compose_path = str(full)
 
-        # Emit sourceable lines
-        print(f'SERVICE_IDS+=("{sid}")')
-        print(f'SERVICE_ALIASES["{sid}"]="{sid}"')
-        for a in aliases:
-            print(f'SERVICE_ALIASES["{a}"]="{sid}"')
-        print(f'SERVICE_CONTAINERS["{sid}"]="{container}"')
-        print(f'SERVICE_COMPOSE["{sid}"]="{compose_path}"')
-        print(f'SERVICE_CATEGORIES["{sid}"]="{category}"')
-        print(f'SERVICE_DEPENDS["{sid}"]="{" ".join(depends)}"')
+        # Emit sourceable lines — all values escaped for safe double-quoting
+        print(f'SERVICE_IDS+=("{_esc(sid)}")')
+        print(f'SERVICE_ALIASES["{_esc(sid)}"]="{_esc(sid)}"')
+        for a in valid_aliases:
+            print(f'SERVICE_ALIASES["{_esc(a)}"]="{_esc(sid)}"')
+        print(f'SERVICE_CONTAINERS["{_esc(sid)}"]="{_esc(container)}"')
+        print(f'SERVICE_COMPOSE["{_esc(sid)}"]="{_esc(compose_path)}"')
+        print(f'SERVICE_CATEGORIES["{_esc(sid)}"]="{_esc(category)}"')
+        print(f'SERVICE_DEPENDS["{_esc(sid)}"]="{_esc(" ".join(str(d) for d in depends))}"')
         health = s.get("health", "/health")
         port = s.get("external_port_default", s.get("port", 0))
         port_env = s.get("external_port_env", "")
-        print(f'SERVICE_HEALTH["{sid}"]="{health}"')
-        print(f'SERVICE_PORTS["{sid}"]="{port}"')
-        print(f'SERVICE_PORT_ENVS["{sid}"]="{port_env}"')
-        print(f'SERVICE_NAMES["{sid}"]="{s.get("name", sid)}"')
+        print(f'SERVICE_HEALTH["{_esc(sid)}"]="{_esc(health)}"')
+        print(f'SERVICE_PORTS["{_esc(sid)}"]="{_esc(port)}"')
+        print(f'SERVICE_PORT_ENVS["{_esc(sid)}"]="{_esc(port_env)}"')
+        print(f'SERVICE_NAMES["{_esc(sid)}"]="{_esc(s.get("name", sid))}"')
         setup_hook = s.get("setup_hook", "")
         setup_path = ""
         if setup_hook:
             full = service_dir / setup_hook
             if full.exists():
                 setup_path = str(full)
-        print(f'SERVICE_SETUP_HOOKS["{sid}"]="{setup_path}"')
-    except Exception:
+        print(f'SERVICE_SETUP_HOOKS["{_esc(sid)}"]="{_esc(setup_path)}"')
+    except Exception as exc:
+        print(f'# ERROR: failed to parse {manifest_path}: {exc}', file=sys.stderr)
         continue
 PYEOF
 


### PR DESCRIPTION
## Summary
- **service-registry.sh** — shell injection prevention via input sanitization
- **db.py** — narrowed duplicate-column exception to specific `OperationalError`
- **pii_scrubber.py** — Luhn checksum validation for credit cards + improved SSN regex
- **test_pii_scrubber.py** — new comprehensive test suite for PII scrubber

## Test plan
- [x] `bash tests/test-tier-map.sh` — 34/36 pass (2 pre-existing GGUF case failures on main)
- [ ] `make lint` — shell + python syntax check
- [ ] CI: ShellCheck, Python lint, secret scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)