### PR TITLE
security: harden token-spy settings + SSH command injection

### DIFF
--- a/dream-server/extensions/services/token-spy/main.py
+++ b/dream-server/extensions/services/token-spy/main.py
@@ -13,6 +13,7 @@ import logging
 import os
 import re
 import secrets
+import shlex
 import tempfile
 import time
 from pathlib import Path
@@ -1041,7 +1042,7 @@ def _get_local_session_status(agent: str) -> dict:
                     history_chars += sum(len(str(x)) for x in c)
                 elif isinstance(c, str):
                     history_chars += len(c)
-        except Exception:
+        except (json.JSONDecodeError, KeyError, TypeError):
             pass  # skip malformed JSONL lines
 
     limit = get_agent_setting(agent, "session_char_limit") or AUTO_RESET_HISTORY_CHARS
@@ -1110,7 +1111,7 @@ def _get_local_accumulated_turns(agent: str) -> int:
                                 user_turns += 1
                             elif role == "assistant":
                                 assistant_turns += 1
-                    except Exception:
+                    except (json.JSONDecodeError, KeyError, TypeError):
                         pass  # skip malformed JSONL lines
         except Exception:
             log.warning(f"[SESSION] Failed to read session file: {fpath}")
@@ -1189,7 +1190,6 @@ def _get_remote_session_status(agent: str) -> dict:
         " 'file_bytes': os.path.getsize(largest), 'total_lines': len(lines), 'files': len(files)}))"
     )
     try:
-        import shlex
         remote_cmd = f"python3 - {shlex.quote(sessions_dir)}"
         result = subprocess.run(
             ["ssh", "-o", "ConnectTimeout=3", "-o", "StrictHostKeyChecking=accept-new",
@@ -1271,7 +1271,6 @@ def _kill_remote_session(agent: str, reason: str = "dashboard") -> dict:
         "    print(json.dumps({'action': 'killed', 'session_id': sid, 'size_bytes': size}))"
     )
     try:
-        import shlex
         remote_cmd = f"python3 - {shlex.quote(sessions_dir)}"
         result = subprocess.run(
             ["ssh", "-o", "ConnectTimeout=3", "-o", "StrictHostKeyChecking=accept-new",


### PR DESCRIPTION
## Summary
Split from original review — addresses fcntl portability, locking, and SSH injection concerns.

**Reworks applied:**
- **Remove `fcntl` file locking** — `fcntl.flock` is Linux-only, breaking macOS/Windows. Removed entirely.
- **Simplify `save_settings()`** — Keep atomic write (mkstemp + os.replace) without flock. Original locking was flawed anyway (locked temp file, not settings file). Single-writer in practice.
- **Fix SSH command injection** — Replace `python3 -c {shlex.quote(script)}` with `python3 -` stdin pipe (`input=script`). Avoids script content in command-line args entirely.
- **Narrow `_kill_session` exception** — `except Exception` → `except (FileNotFoundError, json.JSONDecodeError, OSError)` for sessions.json cleanup.

**Preserved from original PR:**
- Logging improvements replacing silent `pass` blocks
- `except (FileNotFoundError, json.JSONDecodeError)` in local session reader
- Script bodies using `sys.argv[1]` for safe path passing

## Test plan
- [x] `grep fcntl` / `grep flock` — zero matches (removed)
- [x] `grep 'python3 -c'` — zero matches (replaced with stdin)
- [x] `grep 'input=script'` — 2 matches (both SSH functions)
- [x] `py_compile` passes on all modified files
- [ ] CI: Python lint, ShellCheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)