### PR TITLE
fix: initialize service-registry in install-core.sh

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -72,6 +72,10 @@ source "$SCRIPT_DIR/installers/lib/detection.sh"
 source "$SCRIPT_DIR/installers/lib/tier-map.sh"
 source "$SCRIPT_DIR/installers/lib/compose-select.sh"
 source "$SCRIPT_DIR/installers/lib/packaging.sh"
+if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
+    source "$SCRIPT_DIR/lib/service-registry.sh" 
+    sr_load 
+fi
 
 #=============================================================================
 # Command Line Args

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -18,14 +18,16 @@ for arg in "$@"; do
 done
 
 # Config (defaults; .env overrides after load_env_file below)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" 
+if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
+    . "$SCRIPT_DIR/lib/service-registry.sh" 
+    sr_load 
+fi
 INSTALL_DIR="${INSTALL_DIR:-$HOME/dream-server}"
 LLM_HOST="${LLM_HOST:-localhost}"
 LLM_PORT="${LLM_PORT:-8080}"
 TIMEOUT="${TIMEOUT:-5}"
 
-# Source service registry
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-. "$SCRIPT_DIR/lib/service-registry.sh"
 sr_load
 
 # Safe .env loading for port overrides (no eval; use lib/safe-env.sh)


### PR DESCRIPTION
The installers/phases/04-requirements.sh script accesses the SERVICE_PORTS associative array (e.g., at line 222). This array is declared and populated in lib/service-registry.sh, but that library was not being sourced by the main installer entrypoint.

This resulted in "unbound variable" errors in shells with 'set -u' enabled.

This change sources lib/service-registry.sh and calls sr_load() in install-core.sh to ensure service metadata is available to all install phases.