### PR TITLE
fix(windows): retry and validate zip downloads before extraction

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -441,18 +441,12 @@ if ($DryRun) {
             # Download llama.cpp Vulkan build
             $llamaZip = Join-Path $env:TEMP $script:LLAMA_CPP_VULKAN_ASSET
             if (-not (Test-Path $script:LLAMA_SERVER_EXE)) {
-                if (-not (Test-Path $llamaZip)) {
-                    $dlOk = Show-ProgressDownload -Url $script:LLAMA_CPP_VULKAN_URL `
-                        -Destination $llamaZip -Label "Downloading llama-server (Vulkan)"
-                    if (-not $dlOk) {
-                        Write-AIError "llama-server download failed."
-                        exit 1
-                    }
+                $ok = Install-ZipAsset -Url $script:LLAMA_CPP_VULKAN_URL -ZipPath $llamaZip `
+                    -DestinationPath $script:LLAMA_SERVER_DIR -Label "llama-server (Vulkan)" -MaxAttempts 3
+                if (-not $ok) {
+                    Write-DownloadTroubleshooting -Label "llama-server (Vulkan)" -Url $script:LLAMA_CPP_VULKAN_URL -ZipPath $llamaZip
+                    exit 1
                 }
-                # Extract
-                Write-AI "Extracting llama-server..."
-                New-Item -ItemType Directory -Path $script:LLAMA_SERVER_DIR -Force | Out-Null
-                Expand-Archive -Path $llamaZip -DestinationPath $script:LLAMA_SERVER_DIR -Force
                 # The zip may contain a subdirectory -- find llama-server.exe
                 $exeFound = Get-ChildItem -Path $script:LLAMA_SERVER_DIR -Recurse -Filter "llama-server.exe" |
                     Select-Object -First 1
@@ -657,22 +651,35 @@ if ($DryRun) {
                     }
                 }
                 if (Test-Path $ocZipPath) {
-                    New-Item -ItemType Directory -Path $script:OPENCODE_BIN -Force | Out-Null
-                    Expand-Archive -Path $ocZipPath -DestinationPath $script:OPENCODE_BIN -Force
+                    # Validate zip to avoid "Central Directory corrupt" failures.
+                    $zipOk = Test-ZipFile -Path $ocZipPath
+                    if (-not $zipOk.Valid) {
+                        Write-AIWarn "OpenCode archive is invalid ($($zipOk.Reason)). Removing and retrying download."
+                        Remove-Item -Path $ocZipPath -Force -ErrorAction SilentlyContinue
+                    }
+                }
+
+                if (-not (Test-Path $script:OPENCODE_EXE)) {
+                    $ok = Install-ZipAsset -Url $script:OPENCODE_URL -ZipPath $ocZipPath `
+                        -DestinationPath $script:OPENCODE_BIN -Label "OpenCode" -MaxAttempts 3
+                    if (-not $ok) {
+                        Write-AIWarn "OpenCode download/extract failed -- skipping (install later manually)"
+                    }
+                }
+
+                if (Test-Path $script:OPENCODE_EXE) {
+                    Write-AISuccess "Extracted opencode.exe"
+                } else {
+                    # Zip may contain a subdirectory -- find the exe
+                    $ocFound = Get-ChildItem -Path $script:OPENCODE_BIN -Recurse -Filter "opencode.exe" |
+                        Select-Object -First 1
+                    if ($ocFound -and $ocFound.DirectoryName -ne $script:OPENCODE_BIN) {
+                        Move-Item -Path $ocFound.FullName -Destination $script:OPENCODE_EXE -Force
+                    }
                     if (Test-Path $script:OPENCODE_EXE) {
                         Write-AISuccess "Extracted opencode.exe"
                     } else {
-                        # Zip may contain a subdirectory -- find the exe
-                        $ocFound = Get-ChildItem -Path $script:OPENCODE_BIN -Recurse -Filter "opencode.exe" |
-                            Select-Object -First 1
-                        if ($ocFound -and $ocFound.DirectoryName -ne $script:OPENCODE_BIN) {
-                            Move-Item -Path $ocFound.FullName -Destination $script:OPENCODE_EXE -Force
-                        }
-                        if (Test-Path $script:OPENCODE_EXE) {
-                            Write-AISuccess "Extracted opencode.exe"
-                        } else {
-                            Write-AIWarn "opencode.exe not found after extraction -- skipping"
-                        }
+                        Write-AIWarn "opencode.exe not found after extraction -- skipping"
                     }
                 }
             } else {

--- a/dream-server/installers/windows/lib/ui.ps1
+++ b/dream-server/installers/windows/lib/ui.ps1
@@ -86,21 +86,141 @@ function Show-ProgressDownload {
     )
     Write-AI "$Label..."
     # Use curl.exe (ships with Windows 10+) for resume-capable download with progress
-    # Direct invocation (&) instead of Start-Process so the progress bar is visible
+    # Notes:
+    # - --fail makes HTTP 4xx/5xx return non-zero (prevents saving HTML error pages as "successful" downloads)
+    # - --retry reduces transient network failures
     $partFile = "$Destination.part"
-    & curl.exe -C - -L --progress-bar -o $partFile $Url
+    & curl.exe -C - -L --fail --retry 3 --retry-delay 2 --retry-all-errors --progress-bar -o $partFile $Url
     $curlExit = $LASTEXITCODE
     if ($curlExit -eq 0 -and (Test-Path $partFile)) {
         Move-Item -Path $partFile -Destination $Destination -Force
         Write-AISuccess "$Label complete"
         return $true
     } else {
-        $curlErrors = @{ 6="Could not resolve host"; 7="Connection refused"; 18="Partial transfer"; 28="Timeout"; 35="SSL error"; 56="Network failure" }
+        $curlErrors = @{ 6="Could not resolve host"; 7="Connection refused"; 18="Partial transfer"; 22="HTTP error"; 28="Timeout"; 35="SSL error"; 56="Network failure" }
         $hint = $(if ($curlErrors.ContainsKey($curlExit)) { " ($($curlErrors[$curlExit]))" } else { "" })
         Write-AIError "$Label failed (curl exit code: $curlExit$hint)"
         Write-AI "Re-run the installer to resume the download."
         return $false
     }
+}
+
+function Test-ZipFile {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        return @{ Valid = $false; Reason = "File not found" }
+    }
+
+    try {
+        $fi = Get-Item -Path $Path
+        if ($fi.Length -lt 1024) {
+            return @{ Valid = $false; Reason = "File too small to be a valid zip" }
+        }
+
+        $fs = [System.IO.File]::OpenRead($Path)
+        try {
+            $header = New-Object byte[] 4
+            $read = $fs.Read($header, 0, 4)
+            if ($read -lt 2 -or $header[0] -ne 0x50 -or $header[1] -ne 0x4B) {
+                return @{ Valid = $false; Reason = "Missing ZIP header (PK)" }
+            }
+        } finally {
+            $fs.Close()
+        }
+
+        Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue | Out-Null
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+        try {
+            if ($zip.Entries.Count -lt 1) {
+                return @{ Valid = $false; Reason = "Zip has no entries" }
+            }
+        } finally {
+            $zip.Dispose()
+        }
+
+        return @{ Valid = $true; Reason = "OK" }
+    } catch {
+        return @{ Valid = $false; Reason = $_.Exception.Message }
+    }
+}
+
+function Expand-ZipSafe {
+    param(
+        [string]$ZipPath,
+        [string]$DestinationPath,
+        [string]$Label = "Extracting"
+    )
+
+    Write-AI "$Label..."
+    try {
+        New-Item -ItemType Directory -Path $DestinationPath -Force | Out-Null
+        Expand-Archive -Path $ZipPath -DestinationPath $DestinationPath -Force
+        return $true
+    } catch {
+        Write-AIError "$Label failed: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Install-ZipAsset {
+    param(
+        [string]$Url,
+        [string]$ZipPath,
+        [string]$DestinationPath,
+        [string]$Label,
+        [int]$MaxAttempts = 2
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        if (Test-Path $ZipPath) {
+            $zipOk = Test-ZipFile -Path $ZipPath
+            if (-not $zipOk.Valid) {
+                Write-AIWarn "$Label archive is invalid ($($zipOk.Reason)). Removing and re-downloading (attempt $attempt/$MaxAttempts)."
+                Remove-Item -Path $ZipPath -Force -ErrorAction SilentlyContinue
+            }
+        }
+
+        if (-not (Test-Path $ZipPath)) {
+            $dlOk = Show-ProgressDownload -Url $Url -Destination $ZipPath -Label "Downloading $Label"
+            if (-not $dlOk) {
+                if ($attempt -ge $MaxAttempts) { return $false }
+                continue
+            }
+        }
+
+        $zipOk2 = Test-ZipFile -Path $ZipPath
+        if (-not $zipOk2.Valid) {
+            Write-AIWarn "$Label download looks corrupt ($($zipOk2.Reason)). Removing and retrying (attempt $attempt/$MaxAttempts)."
+            Remove-Item -Path $ZipPath -Force -ErrorAction SilentlyContinue
+            if ($attempt -ge $MaxAttempts) { return $false }
+            continue
+        }
+
+        $extractOk = Expand-ZipSafe -ZipPath $ZipPath -DestinationPath $DestinationPath -Label "Extracting $Label"
+        if ($extractOk) {
+            return $true
+        }
+
+        # Extraction failed (e.g., Central Directory corrupt). Remove zip and retry.
+        Remove-Item -Path $ZipPath -Force -ErrorAction SilentlyContinue
+    }
+
+    return $false
+}
+
+function Write-DownloadTroubleshooting {
+    param(
+        [string]$Label,
+        [string]$Url,
+        [string]$ZipPath
+    )
+
+    Write-Host "";
+    Write-AIError "$Label could not be downloaded/extracted reliably."
+    Write-AI "Common causes: proxy/antivirus modifying downloads, GitHub rate limits, or a partial transfer."
+    Write-AI "You can manually download the file and place it here: $ZipPath"
+    Write-AI "URL: $Url"
 }
 
 function Write-SuccessCard {


### PR DESCRIPTION
## Summary

Fixes a Windows installer failure on AMD Strix Halo where extracting the downloaded llama.cpp Vulkan zip can crash with:

> "Central Directory corrupt."

This error typically occurs when the downloaded `.zip` is partially transferred, truncated, or replaced by an HTML error page (proxy/GitHub rate limit/etc.). The installer previously trusted any “successful” download and attempted to `Expand-Archive` immediately.

This PR hardens the Windows installer’s zip download + extraction flow to validate archives before extraction and automatically recover by deleting and re-downloading corrupted zips.

Fixes #209.

## What changed

### Windows download robustness
- Updated the `curl.exe` download helper to:
  - **fail on HTTP 4xx/5xx** (prevents saving HTML error responses as “zip” files)
  - **retry transient failures** to reduce flaky-network install breakage

### Zip validation + safe extraction
- Added small PS 5.1-compatible helpers to:
  - validate that a file is a real zip (header + .NET ZipArchive open)
  - wrap extraction in a safe try/catch
  - retry the full download/extract cycle when corruption is detected

### Applied to affected install paths
- The native **llama-server (Vulkan)** download/extract path now uses the hardened flow.
- The **OpenCode** zip extraction path was updated as well to prevent the same class of failures.

## Why this is useful

- Prevents hard installer crashes on Windows with confusing “Central Directory corrupt” exceptions
- Automatically repairs common failure modes (bad cached zip, partial download, HTTP error content)
- Keeps changes isolated to Windows installer zip handling (no impact on Linux installer or runtime services)

## Scope / Compatibility

- Windows installer only (`install-windows.ps1` + `lib/ui.ps1`)
- PowerShell 5.1 compatible
- No changes to service runtime behavior
