### PR TITLE
feat(backup): add sha256 integrity manifest + verify

### DIFF
--- a/dream-server/dream-backup.sh
+++ b/dream-server/dream-backup.sh
@@ -33,7 +33,12 @@ usage() {
     cat << EOF
 Dream Server Backup Utility
 
-Usage: $(basename "$0") [OPTIONS]
+Usage: $(basename "$0") <command> [OPTIONS]
+
+Commands:
+    backup                   Create a backup (default)
+    verify <backup_id>        Verify checksums for an existing backup
+
 
 OPTIONS:
     -h, --help              Show this help message
@@ -50,10 +55,13 @@ BACKUP TYPES:
     config      Backup only configuration files
 
 EXAMPLES:
-    $(basename "$0")                          # Full backup with default settings
-    $(basename "$0") -t user-data -c          # Compressed user data backup
+    $(basename "$0")                          # Backup (default: user-data)
+    $(basename "$0") -t full -c               # Compressed full backup
     $(basename "$0") -l                       # List all backups
     $(basename "$0") -d 20260212-071500       # Delete specific backup
+    $(basename "$0") verify 20260212-071500   # Verify checksum integrity
+    $(basename "$0") verify 20260212-071500.tar.gz
+    $(basename "$0") backup -t config         # Explicit backup subcommand
 
 EOF
 }
@@ -230,6 +238,41 @@ backup_config() {
     fi
 }
 
+# Generate a SHA256 manifest for all backed up files
+# Writes: $backup_dir/checksums.sha256 (format: sha256  relative/path)
+create_checksums() {
+    local backup_dir="$1"
+    log_info "Generating checksums..."
+
+    local checksum_file="$backup_dir/checksums.sha256"
+
+    if command -v sha256sum >/dev/null 2>&1; then
+        (
+            cd "$backup_dir"
+            # Deterministic ordering; exclude the checksum file itself.
+            find . -type f ! -name "checksums.sha256" -print0 \
+                | sort -z \
+                | xargs -0 sha256sum \
+                | sed 's#  \./#  #' \
+                > "$(basename "$checksum_file")"
+        )
+    elif command -v shasum >/dev/null 2>&1; then
+        (
+            cd "$backup_dir"
+            find . -type f ! -name "checksums.sha256" -print0 \
+                | sort -z \
+                | xargs -0 shasum -a 256 \
+                | sed 's#  \./#  #' \
+                > "$(basename "$checksum_file")"
+        )
+    else
+        log_warn "Skipping checksums: sha256sum/shasum not found"
+        return 0
+    fi
+
+    log_info "Wrote checksums.sha256"
+}
+
 # Backup cache (optional, for full backups)
 backup_cache() {
     local backup_dir="$1"
@@ -340,6 +383,9 @@ do_backup() {
             ;;
     esac
 
+    # Generate checksums after files are copied into place
+    create_checksums "$backup_dir"
+
     # Compress if requested
     if [[ "$compress" == "true" ]]; then
         compress_backup "$backup_dir"
@@ -355,17 +401,101 @@ do_backup() {
     echo "  dream-restore.sh $backup_id"
 }
 
+# Verify checksums for an existing backup directory or archive
+verify_backup() {
+    local backup_id="$1"
+
+    # Reject path traversal attempts
+    if [[ "$backup_id" == *..* || "$backup_id" == */* || "$backup_id" == *\\* ]]; then
+        log_error "Invalid backup ID: $backup_id"
+        return 1
+    fi
+
+    local target="$BACKUP_ROOT/$backup_id"
+
+    if [[ -d "$target" ]]; then
+        if [[ ! -f "$target/checksums.sha256" ]]; then
+            log_error "checksums.sha256 not found for backup: $backup_id"
+            return 1
+        fi
+
+        (
+            cd "$target"
+            if command -v sha256sum >/dev/null 2>&1; then
+                sha256sum -c "checksums.sha256"
+            else
+                shasum -a 256 -c "checksums.sha256"
+            fi
+        )
+        log_success "Backup verified: $backup_id"
+        return 0
+    fi
+
+    if [[ -f "$target" && "$target" == *.tar.gz ]]; then
+        local tmpdir
+        tmpdir=$(mktemp -d)
+        trap 'rm -rf "$tmpdir"' RETURN
+
+        # Extract checksums first (fast fail if missing)
+        local archive_name="${backup_id%.tar.gz}"
+        if ! tar xzf "$target" -C "$tmpdir" "${archive_name}/checksums.sha256" >/dev/null 2>&1; then
+            log_error "checksums.sha256 not found in archive: $backup_id"
+            return 1
+        fi
+
+        tar xzf "$target" -C "$tmpdir"
+
+        (
+            cd "$tmpdir/$archive_name"
+            if command -v sha256sum >/dev/null 2>&1; then
+                sha256sum -c "checksums.sha256"
+            else
+                shasum -a 256 -c "checksums.sha256"
+            fi
+        )
+
+        log_success "Backup verified: $backup_id"
+        return 0
+    fi
+
+    log_error "Backup not found: $backup_id"
+    return 1
+}
+
 # Main entry point
 main() {
+    local subcommand="backup"
+
+    # Allow subcommands to appear either first (e.g. `verify ...`) or after options
+    # (e.g. `--output /path verify ...`). We'll detect `backup`/`verify` during arg parsing.
+
+
     local backup_type="user-data"
     local compress="false"
     local description=""
     local list_mode="false"
     local delete_id=""
+    local verify_id=""
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
         case "$1" in
+            backup)
+                subcommand="backup"
+                shift
+                ;;
+            verify)
+                subcommand="verify"
+                shift
+                verify_id="${1:-}"
+                if [[ -z "$verify_id" ]]; then
+                    log_error "Usage: $(basename "$0") verify <backup_id|backup_id.tar.gz>"
+                    exit 1
+                fi
+                shift
+                # No more flags after verify are supported
+                break
+                ;;
             -h|--help)
                 usage
                 exit 0
@@ -412,6 +542,15 @@ main() {
     if [[ -n "$delete_id" ]]; then
         delete_backup "$delete_id"
         exit 0
+    fi
+
+    # Verify mode
+    if [[ "$subcommand" == "verify" ]]; then
+        # Create backup root so --output works even if dir doesn't exist yet
+        mkdir -p "$BACKUP_ROOT"
+
+        verify_backup "$verify_id"
+        exit $?
     fi
 
     # Check if running in Dream Server directory

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1120,7 +1120,16 @@ cmd_backup() {
         error "dream-backup.sh not found or not executable"
     fi
 
-    # Pass all arguments to dream-backup.sh
+    local action="${1:-}"
+    if [[ "$action" == "verify" ]]; then
+        shift
+        local id="${1:-}"
+        [[ -z "$id" ]] && error "Usage: dream backup verify <backup_id|backup_id.tar.gz>"
+        "$INSTALL_DIR/dream-backup.sh" verify "$id"
+        return
+    fi
+
+    # Default: create backup (pass all args through)
     "$INSTALL_DIR/dream-backup.sh" "$@"
 }
 
@@ -1155,6 +1164,7 @@ ${CYAN}Commands:${NC}
   model [current|list|swap]
                       View or change the local LLM model tier
   backup [options]    Create a backup of user data and config
+  backup verify <id>   Verify checksum integrity for a backup
   restore [backup_id] Restore from a backup
   logs <service>      Tail logs for a service
   restart [service]   Restart services (all if no service specified)
@@ -1225,6 +1235,7 @@ ${CYAN}Examples:${NC}
   dream backup                    # Create a backup
   dream backup -c                 # Create compressed backup
   dream backup -l                 # List all backups
+  dream backup verify <id>        # Verify backup integrity
   dream restore                   # Interactive restore
   dream restore 20260309-120000   # Restore specific backup
   dream logs llm                  # Watch llama-server logs (via alias)

--- a/dream-server/tests/test-backup-integrity.sh
+++ b/dream-server/tests/test-backup-integrity.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Basic integrity test for dream-backup.sh checksums + verify
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DREAM_BACKUP="$SCRIPT_DIR/../dream-backup.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; exit 1; }
+info() { echo -e "${BLUE}ℹ${NC} $1"; }
+
+if [[ ! -x "$DREAM_BACKUP" ]]; then
+  fail "dream-backup.sh not found or not executable at $DREAM_BACKUP"
+fi
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+# Create a minimal fake Dream directory with some data
+FAKE_DREAM="$TMP_ROOT/dream"
+mkdir -p "$FAKE_DREAM/data/open-webui"
+mkdir -p "$FAKE_DREAM/config"
+
+# Required by create_manifest()
+echo "test" > "$FAKE_DREAM/.version"
+
+# Add files
+echo "hello" > "$FAKE_DREAM/data/open-webui/file.txt"
+echo "world" > "$FAKE_DREAM/config/settings.json"
+
+BACKUPS_DIR="$TMP_ROOT/backups"
+
+info "Creating backup"
+DREAM_DIR="$FAKE_DREAM" "$DREAM_BACKUP" --output "$BACKUPS_DIR" --type full >/dev/null
+
+backup_id="$(ls -1 "$BACKUPS_DIR" | head -n 1)"
+[[ -n "$backup_id" ]] || fail "No backup created"
+
+[[ -f "$BACKUPS_DIR/$backup_id/checksums.sha256" ]] || fail "checksums.sha256 not created"
+pass "checksums.sha256 created"
+
+info "Verifying backup"
+DREAM_DIR="$FAKE_DREAM" "$DREAM_BACKUP" --output "$BACKUPS_DIR" verify "$backup_id" >/dev/null
+pass "verify passes on untampered backup"
+
+info "Tampering with a file and expecting verify to fail"
+echo "tampered" >> "$BACKUPS_DIR/$backup_id/data/open-webui/file.txt"
+
+set +e
+DREAM_DIR="$FAKE_DREAM" "$DREAM_BACKUP" --output "$BACKUPS_DIR" verify "$backup_id" >/dev/null 2>&1
+rc=$?
+set -e
+
+if [[ $rc -eq 0 ]]; then
+  fail "verify unexpectedly succeeded after tampering"
+fi
+
+pass "verify fails after tampering"

--- a/dream-server/tests/test-backup-restore-cli.sh
+++ b/dream-server/tests/test-backup-restore-cli.sh
@@ -154,7 +154,9 @@ test_restore_delegation() {
 # Test 11: Verify argument passing
 test_argument_passing() {
     info "Test 11: Checking if arguments are passed through"
-    if grep -A10 "^cmd_backup()" "$DREAM_CLI" 2>/dev/null | grep -q '\$@'; then
+    # cmd_backup may special-case subcommands (e.g. verify) but should still pass args through
+    # in its default path.
+    if grep -A25 "^cmd_backup()" "$DREAM_CLI" 2>/dev/null | grep -q '\$@'; then
         pass "cmd_backup passes arguments correctly"
         return 0
     else


### PR DESCRIPTION
## Summary
Adds basic backup integrity protection by generating a SHA256 checksum manifest for each backup, plus a `verify` command to detect tampering/corruption.

## What’s included
- `dream-backup.sh` now writes `checksums.sha256` into each backup (SHA256 for all backed-up files).
- New verification flow:
  - `dream-backup.sh verify <backup_id|backup_id.tar.gz>`
  - Verifies either an extracted backup directory or a compressed `.tar.gz` backup (extracts to a temp dir for verification).
- `dream-cli` support:
  - `dream backup verify <backup_id|backup_id.tar.gz>`
- Tests:
  - Adds `tests/test-backup-integrity.sh` to ensure:
    - checksums are created
    - verify passes for untouched backups
    - verify fails after file tampering

## Why
Backups are most useful when you can trust them. A checksum manifest provides a simple, low-overhead way to confirm a backup hasn’t been corrupted or modified before restore.

## How to use
```bash
dream backup
dream backup -c
dream backup verify 20260316-123456
dream backup verify 20260316-123456.tar.gz
