### PR TITLE
feat(restore): safety prompts + partial backup warnings

### DIFF
--- a/dream-server/dream-restore.sh
+++ b/dream-server/dream-restore.sh
@@ -199,6 +199,31 @@ validate_backup() {
         sed 's/^[[:space:]]*/  /' | sed 's/"//g' | sed 's/,//'
     echo ""
 
+    # Warn if backup looks partial / missing common paths.
+    # (Informational only; older/minimal backups are still valid.)
+    local -a expected_data=(
+        "data/open-webui"
+        "data/n8n"
+        "data/qdrant"
+        "data/openclaw"
+        "data/litellm"
+        "data/livekit"
+        "data/ollama"
+    )
+
+    local missing_any=false
+    for p in "${expected_data[@]}"; do
+        if [[ ! -d "$backup_dir/$p" ]]; then
+            missing_any=true
+            break
+        fi
+    done
+
+    if [[ "$missing_any" == "true" ]]; then
+        log_warn "This backup does not contain some common data directories."
+        log_warn "That may be normal (services not used), but restore will be partial for missing paths."
+    fi
+
     log_success "Backup validated"
     return 0
 }
@@ -268,15 +293,23 @@ restore_user_data() {
 
     local data_dirs=("data/open-webui" "data/n8n" "data/qdrant" "data/openclaw" "data/litellm" "data/livekit" "data/ollama")
 
+    local restored_any=false
     for dir in "${data_dirs[@]}"; do
         if [[ -d "$backup_dir/$dir" ]]; then
+            restored_any=true
             mkdir -p "$DREAM_DIR/$(dirname "$dir")"
             # Note: Using -a without --delete to preserve any new files created after backup
             # Use --force flag or manually delete target if you need exact restoration
             rsync -a "$backup_dir/$dir" "$DREAM_DIR/$(dirname "$dir")/"
             log_success "Restored: $dir"
+        else
+            log_warn "Skipped (not in backup): $dir"
         fi
     done
+
+    if [[ "$restored_any" == "false" ]]; then
+        log_warn "No user data directories were found in this backup."
+    fi
 }
 
 # Restore configuration
@@ -284,20 +317,30 @@ restore_config() {
     local backup_dir="$1"
     log_step "Restoring configuration..."
 
+    local restored_any=false
+
     # Dynamically discover config files (dotfiles + compose overlays + scripts)
     for file in "$backup_dir"/.env "$backup_dir"/.version "$backup_dir"/docker-compose*.y*ml "$backup_dir"/dream-*.sh; do
         if [[ -f "$file" ]]; then
+            restored_any=true
             cp "$file" "$DREAM_DIR/"
             log_success "Restored: $(basename "$file")"
         fi
     done
 
     if [[ -d "$backup_dir/config" ]]; then
+        restored_any=true
         if [[ -d "$DREAM_DIR/config" ]]; then
             rm -rf "$DREAM_DIR/config"
         fi
         cp -r "$backup_dir/config" "$DREAM_DIR/"
         log_success "Restored: config/"
+    else
+        log_warn "Skipped (not in backup): config/"
+    fi
+
+    if [[ "$restored_any" == "false" ]]; then
+        log_warn "No configuration files were found in this backup."
     fi
 }
 
@@ -361,10 +404,11 @@ do_restore() {
     # Confirmation
     if [[ "$force" != "true" ]]; then
         echo ""
-        log_warn "⚠️  This will OVERWRITE current Dream Server data!"
+        log_warn "This will copy backup data into: $DREAM_DIR"
+        log_warn "Existing files may be overwritten."
         echo ""
-        read -rp "Are you sure you want to continue? [y/N] " confirm
-        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+        read -rp "Type the backup ID ('$backup_id') to continue, or press Enter to cancel: " confirm
+        if [[ "$confirm" != "$backup_id" ]]; then
             log_info "Restore cancelled"
             return 0
         fi

--- a/dream-server/tests/test-restore-safety-ux.sh
+++ b/dream-server/tests/test-restore-safety-ux.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Minimal tests for restore safety UX behaviors.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DREAM_RESTORE="$SCRIPT_DIR/../dream-restore.sh"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+pass() { echo -e "${GREEN}✓${NC} $1"; }
+fail() { echo -e "${RED}✗${NC} $1"; exit 1; }
+info() { echo -e "${BLUE}ℹ${NC} $1"; }
+
+[[ -x "$DREAM_RESTORE" ]] || fail "dream-restore.sh not found or not executable"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+FAKE_DREAM="$TMP/dream"
+mkdir -p "$FAKE_DREAM/.backups"
+# minimal marker so 'is this a Dream dir' check passes
+mkdir -p "$FAKE_DREAM/data"
+
+# Create a minimal backup (manifest only, no data dirs)
+BID="20260101-000000"
+B="$FAKE_DREAM/.backups/$BID"
+mkdir -p "$B"
+cat > "$B/manifest.json" <<'JSON'
+{
+  "manifest_version": "1.0",
+  "backup_date": "2026-01-01T00:00:00Z",
+  "backup_id": "20260101-000000",
+  "backup_type": "user-data",
+  "dream_version": "test",
+  "hostname": "test",
+  "description": "test",
+  "contents": {"user_data": true, "config": false, "cache": false}
+}
+JSON
+
+info "Restore should cancel unless backup ID is typed"
+set +e
+out=$(DREAM_DIR="$FAKE_DREAM" bash "$DREAM_RESTORE" "$BID" 2>&1 <<< $'\n')
+rc=$?
+set -e
+
+# Cancel is not an error (returns 0)
+[[ $rc -eq 0 ]] || fail "Expected rc=0 on cancel, got $rc"
+
+echo "$out" | grep -q "Restore cancelled" || fail "Expected 'Restore cancelled' message"
+pass "Restore cancels if confirmation doesn't match backup id"
+
+info "Restore proceeds when backup ID is typed"
+set +e
+out=$(DREAM_DIR="$FAKE_DREAM" bash "$DREAM_RESTORE" -f "$BID" 2>&1)
+rc=$?
+set -e
+
+[[ $rc -eq 0 ]] || fail "Expected rc=0 on forced restore, got $rc"
+pass "Forced restore runs without interactive confirmation"


### PR DESCRIPTION
## Summary
Hardens the restore flow to prevent accidental destructive restores and improves UX for partial backups.

## Changes
- Safer interactive confirmation:
  - When not using `--force`, restore now requires typing the exact backup ID to continue.
  - This reduces the risk of accidentally restoring the wrong backup or restoring unintentionally.
- Partial backup warnings:
  - During validation, warn if common data directories are missing (informational; older/minimal backups are still valid).
  - During restore, log `Skipped (not in backup)` for missing expected data dirs and missing `config/` so users understand what will/won’t be restored.
- Tests:
  - Adds `tests/test-restore-safety-ux.sh` to verify cancel behavior and `--force` behavior.

## Why
Restore operations are inherently risky. This PR makes the “are you sure?” step harder to bypass by mistake and makes partial restores more transparent.

## How to test
```bash
bash dream-server/tests/test-restore-safety-ux.sh
bash -n dream-server/dream-restore.sh
