### PR TITLE
fix(windows): add zip integrity validation and retry logic for install

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -442,17 +442,33 @@ if ($DryRun) {
             $llamaZip = Join-Path $env:TEMP $script:LLAMA_CPP_VULKAN_ASSET
             if (-not (Test-Path $script:LLAMA_SERVER_EXE)) {
                 if (-not (Test-Path $llamaZip)) {
-                    $dlOk = Show-ProgressDownload -Url $script:LLAMA_CPP_VULKAN_URL `
+                    $dlOk = Invoke-DownloadWithRetry -Url $script:LLAMA_CPP_VULKAN_URL `
                         -Destination $llamaZip -Label "Downloading llama-server (Vulkan)"
                     if (-not $dlOk) {
-                        Write-AIError "llama-server download failed."
+                        Write-AIError "Failed to download llama-server after retries."
                         exit 1
                     }
                 }
-                # Extract
+
+                # Validate zip integrity before extraction
+                Write-AI "Validating llama-server archive..."
+                $zipValid = Test-ZipIntegrity -Path $llamaZip
+                if (-not $zipValid.Valid) {
+                    Write-AIWarn "Archive is corrupt: $($zipValid.ErrorMessage)"
+                    Remove-Item -Path $llamaZip -Force -ErrorAction SilentlyContinue
+                    Write-AIError "Corrupted download. Please re-run the installer."
+                    exit 1
+                }
+
+                # Extract with retry
                 Write-AI "Extracting llama-server..."
                 New-Item -ItemType Directory -Path $script:LLAMA_SERVER_DIR -Force | Out-Null
-                Expand-Archive -Path $llamaZip -DestinationPath $script:LLAMA_SERVER_DIR -Force
+
+                if (-not (Invoke-ExtractionWithRetry -ZipPath $llamaZip -DestinationPath $script:LLAMA_SERVER_DIR)) {
+                    Write-AIError "Failed to extract llama-server after retries."
+                    exit 1
+                }
+
                 # The zip may contain a subdirectory -- find llama-server.exe
                 $exeFound = Get-ChildItem -Path $script:LLAMA_SERVER_DIR -Recurse -Filter "llama-server.exe" |
                     Select-Object -First 1
@@ -465,7 +481,7 @@ if ($DryRun) {
                     Write-AIError "llama-server.exe not found after extraction."
                     exit 1
                 }
-                Write-AISuccess "Extracted llama-server.exe"
+                Write-AISuccess "llama-server extracted successfully"
             } else {
                 Write-AISuccess "llama-server.exe already present"
             }
@@ -650,28 +666,38 @@ if ($DryRun) {
                 Write-AI "Installing OpenCode v$($script:OPENCODE_VERSION)..."
                 $ocZipPath = Join-Path $env:TEMP $script:OPENCODE_ZIP
                 if (-not (Test-Path $ocZipPath)) {
-                    $dlOk = Show-ProgressDownload -Url $script:OPENCODE_URL `
+                    $dlOk = Invoke-DownloadWithRetry -Url $script:OPENCODE_URL `
                         -Destination $ocZipPath -Label "Downloading OpenCode"
                     if (-not $dlOk) {
-                        Write-AIWarn "OpenCode download failed -- skipping (install later manually)"
+                        Write-AIWarn "OpenCode download failed after retries -- skipping (install later manually)"
                     }
                 }
                 if (Test-Path $ocZipPath) {
-                    New-Item -ItemType Directory -Path $script:OPENCODE_BIN -Force | Out-Null
-                    Expand-Archive -Path $ocZipPath -DestinationPath $script:OPENCODE_BIN -Force
-                    if (Test-Path $script:OPENCODE_EXE) {
-                        Write-AISuccess "Extracted opencode.exe"
+                    # Validate zip integrity
+                    Write-AI "Validating OpenCode archive..."
+                    $zipValid = Test-ZipIntegrity -Path $ocZipPath
+                    if (-not $zipValid.Valid) {
+                        Write-AIWarn "OpenCode archive is corrupt: $($zipValid.ErrorMessage)"
+                        Remove-Item -Path $ocZipPath -Force -ErrorAction SilentlyContinue
+                        Write-AIWarn "Skipping OpenCode installation (install later manually)"
                     } else {
-                        # Zip may contain a subdirectory -- find the exe
-                        $ocFound = Get-ChildItem -Path $script:OPENCODE_BIN -Recurse -Filter "opencode.exe" |
-                            Select-Object -First 1
-                        if ($ocFound -and $ocFound.DirectoryName -ne $script:OPENCODE_BIN) {
-                            Move-Item -Path $ocFound.FullName -Destination $script:OPENCODE_EXE -Force
-                        }
-                        if (Test-Path $script:OPENCODE_EXE) {
-                            Write-AISuccess "Extracted opencode.exe"
+                        # Extract with retry
+                        New-Item -ItemType Directory -Path $script:OPENCODE_BIN -Force | Out-Null
+
+                        if (Invoke-ExtractionWithRetry -ZipPath $ocZipPath -DestinationPath $script:OPENCODE_BIN) {
+                            # Zip may contain a subdirectory -- find the exe
+                            $ocFound = Get-ChildItem -Path $script:OPENCODE_BIN -Recurse -Filter "opencode.exe" |
+                                Select-Object -First 1
+                            if ($ocFound -and $ocFound.DirectoryName -ne $script:OPENCODE_BIN) {
+                                Move-Item -Path $ocFound.FullName -Destination $script:OPENCODE_EXE -Force
+                            }
+                            if (Test-Path $script:OPENCODE_EXE) {
+                                Write-AISuccess "OpenCode extracted successfully"
+                            } else {
+                                Write-AIWarn "opencode.exe not found after extraction -- skipping"
+                            }
                         } else {
-                            Write-AIWarn "opencode.exe not found after extraction -- skipping"
+                            Write-AIWarn "OpenCode extraction failed after retries -- skipping"
                         }
                     }
                 }

--- a/dream-server/installers/windows/lib/detection.ps1
+++ b/dream-server/installers/windows/lib/detection.ps1
@@ -271,6 +271,76 @@ function Test-ModelIntegrity {
     }
 }
 
+function Test-ZipIntegrity {
+    <#
+    .SYNOPSIS
+        Validate a zip file's structure without extracting it.
+    .DESCRIPTION
+        Uses System.IO.Compression.ZipFile to verify the zip file can be opened
+        and has a valid central directory. Catches the "Central Directory corrupt"
+        error that occurs with incomplete or corrupted downloads.
+    .PARAMETER Path
+        Full path to the zip file to validate.
+    .OUTPUTS
+        @{ Valid; ErrorMessage; SizeBytes }
+    #>
+    param(
+        [string]$Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        return @{
+            Valid        = $false
+            ErrorMessage = "File not found"
+            SizeBytes    = 0
+        }
+    }
+
+    $fileInfo = Get-Item $Path
+    $sizeBytes = $fileInfo.Length
+
+    # Check for empty or suspiciously small files
+    if ($sizeBytes -lt 100) {
+        return @{
+            Valid        = $false
+            ErrorMessage = "File is too small to be a valid zip archive ($sizeBytes bytes)"
+            SizeBytes    = $sizeBytes
+        }
+    }
+
+    # Load System.IO.Compression.FileSystem if not already loaded
+    Add-Type -AssemblyName System.IO.Compression.FileSystem -ErrorAction SilentlyContinue
+
+    try {
+        # Attempt to open the zip file (validates central directory)
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($Path)
+        $entryCount = $zip.Entries.Count
+        $zip.Dispose()
+
+        return @{
+            Valid        = $true
+            ErrorMessage = ""
+            SizeBytes    = $sizeBytes
+        }
+    }
+    catch [System.IO.InvalidDataException] {
+        # This is the "Central Directory corrupt" error from issue #209
+        return @{
+            Valid        = $false
+            ErrorMessage = "Central Directory is invalid or corrupt"
+            SizeBytes    = $sizeBytes
+        }
+    }
+    catch {
+        # Other errors (permissions, file locked, etc.)
+        return @{
+            Valid        = $false
+            ErrorMessage = $_.Exception.Message
+            SizeBytes    = $sizeBytes
+        }
+    }
+}
+
 function Test-DiskSpace {
     <#
     .SYNOPSIS

--- a/dream-server/installers/windows/lib/ui.ps1
+++ b/dream-server/installers/windows/lib/ui.ps1
@@ -103,6 +103,132 @@ function Show-ProgressDownload {
     }
 }
 
+function Invoke-DownloadWithRetry {
+    <#
+    .SYNOPSIS
+        Download a file with automatic retry on failure.
+    .DESCRIPTION
+        Wraps Show-ProgressDownload with exponential backoff retry logic.
+        Retries up to MaxRetries times with increasing delays (2s, 5s, 10s).
+    .PARAMETER Url
+        URL to download from.
+    .PARAMETER Destination
+        Local file path to save to.
+    .PARAMETER Label
+        Display label for progress messages (default: "Downloading").
+    .PARAMETER MaxRetries
+        Maximum number of retry attempts (default: 3).
+    .OUTPUTS
+        $true on success, $false on final failure.
+    #>
+    param(
+        [string]$Url,
+        [string]$Destination,
+        [string]$Label = "Downloading",
+        [int]$MaxRetries = 3
+    )
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        if ($attempt -gt 1) {
+            $delay = @(2, 5, 10)[$attempt - 2]
+            Write-AI "Retry attempt $attempt of $MaxRetries (waiting ${delay}s)..."
+            Start-Sleep -Seconds $delay
+        }
+
+        $success = Show-ProgressDownload -Url $Url -Destination $Destination -Label $Label
+
+        if ($success) {
+            # Verify file exists and has content
+            if ((Test-Path $Destination) -and ((Get-Item $Destination).Length -gt 0)) {
+                return $true
+            } else {
+                Write-AIWarn "Download reported success but file is missing or empty"
+            }
+        }
+    }
+
+    Write-AIError "Download failed after $MaxRetries attempts"
+    return $false
+}
+
+function Invoke-ExtractionWithRetry {
+    <#
+    .SYNOPSIS
+        Extract a zip file with validation and retry on failure.
+    .DESCRIPTION
+        Validates zip integrity before extraction, retries on failure,
+        and cleans up partial extractions. Uses Test-ZipIntegrity to
+        catch corrupted downloads before attempting extraction.
+    .PARAMETER ZipPath
+        Path to the zip file to extract.
+    .PARAMETER DestinationPath
+        Directory to extract files into.
+    .PARAMETER MaxRetries
+        Maximum number of extraction attempts (default: 3).
+    .OUTPUTS
+        $true on success, $false on final failure.
+    #>
+    param(
+        [string]$ZipPath,
+        [string]$DestinationPath,
+        [int]$MaxRetries = 3
+    )
+
+    for ($attempt = 1; $attempt -le $MaxRetries; $attempt++) {
+        if ($attempt -gt 1) {
+            Write-AI "Extraction retry attempt $attempt of $MaxRetries..."
+        }
+
+        # Validate zip integrity before attempting extraction
+        $zipValid = Test-ZipIntegrity -Path $ZipPath
+        if (-not $zipValid.Valid) {
+            Write-AIWarn "Zip validation failed: $($zipValid.ErrorMessage)"
+            if ($attempt -lt $MaxRetries) {
+                Write-AI "Zip file may be corrupted, will retry..."
+                Start-Sleep -Seconds 2
+                continue
+            } else {
+                Write-AIError "Zip file is corrupt after $MaxRetries attempts"
+                return $false
+            }
+        }
+
+        # Attempt extraction
+        try {
+            # Remove partial extraction if it exists
+            if (Test-Path $DestinationPath) {
+                Write-AI "Cleaning up previous extraction attempt..."
+                Remove-Item -Path $DestinationPath -Recurse -Force -ErrorAction Stop
+            }
+
+            # Create parent directory if needed
+            $parentDir = Split-Path -Parent $DestinationPath
+            if (-not (Test-Path $parentDir)) {
+                New-Item -ItemType Directory -Path $parentDir -Force | Out-Null
+            }
+
+            # Extract
+            Expand-Archive -Path $ZipPath -DestinationPath $DestinationPath -Force -ErrorAction Stop
+
+            # Verify extraction succeeded (check if directory exists and has content)
+            if ((Test-Path $DestinationPath) -and ((Get-ChildItem $DestinationPath).Count -gt 0)) {
+                return $true
+            } else {
+                Write-AIWarn "Extraction completed but destination is empty"
+            }
+        }
+        catch {
+            Write-AIWarn "Extraction failed: $($_.Exception.Message)"
+            if ($attempt -lt $MaxRetries) {
+                Start-Sleep -Seconds 2
+            }
+        }
+    }
+
+    Write-AIError "Extraction failed after $MaxRetries attempts"
+    return $false
+}
+
 function Write-SuccessCard {
     param(
         [string]$WebUIPort = "3000",


### PR DESCRIPTION
…ler downloads## Fixes Windows installer "Central Directory corrupt" error

Addresses issue #209 - Windows users on stock Win11 encounter "Central Directory corrupt" error when extracting llama-server.zip, preventing successful installation.

### Problem
The installer downloads zip files but has no integrity validation before extraction. When downloads are incomplete or corrupted (network interruption, data corruption), PowerShell's `Expand-Archive` fails with cryptic errors and leaves the system in a broken state with no recovery path.

### Solution
Added three layers of protection:

1. **Pre-extraction validation** - New `Test-ZipIntegrity` function validates zip structure using System.IO.Compression.ZipFile before attempting extraction
2. **Automatic retry** - New `Invoke-DownloadWithRetry` function retries failed downloads with exponential backoff (2s, 5s, 10s)
3. **Safe extraction** - New `Invoke-ExtractionWithRetry` function validates integrity, cleans up partial extractions on failure, and retries

### Changes
- `lib/detection.ps1`: Add `Test-ZipIntegrity` function (~70 LOC)
- `lib/ui.ps1`: Add `Invoke-DownloadWithRetry` and `Invoke-ExtractionWithRetry` functions (~126 LOC)
- `install-windows.ps1`: Update llama-server and OpenCode download/extraction to use new retry functions (~46 LOC modified)

### Benefits
- Catches corrupted downloads before extraction (prevents cryptic PowerShell errors)
- Automatic retry on transient network failures
- Clean recovery path with clear error messages
- No breaking changes to existing installer behavior

### Testing
Syntax validated with PowerShell parser. Manual testing scenarios:
- Normal installation (happy path)
- Simulated network failure (verify retry logic)
- Simulated corrupted zip (verify validation catches corruption)
- Extraction failure (verify cleanup and retry)

Total changes: 242 insertions, 20 deletions across 3 files.
