### PR TITLE
fix(compose): add health check dependencies for privacy-shield and litellm services

### DIFF
--- a/dream-server/extensions/services/litellm/compose.yaml
+++ b/dream-server/extensions/services/litellm/compose.yaml
@@ -3,6 +3,9 @@ services:
     image: ghcr.io/berriai/litellm:v1.81.3-stable
     container_name: dream-litellm
     restart: unless-stopped
+    depends_on:
+      llama-server:
+        condition: service_healthy
     security_opt:
       - no-new-privileges:true
     environment:

--- a/dream-server/extensions/services/privacy-shield/compose.yaml
+++ b/dream-server/extensions/services/privacy-shield/compose.yaml
@@ -5,6 +5,9 @@ services:
       dockerfile: Dockerfile
     container_name: dream-privacy-shield
     restart: unless-stopped
+    depends_on:
+      llama-server:
+        condition: service_healthy
     user: "${UID:-1000}:${GID:-1000}"
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## Summary

Enforces service dependency health checks for services that depend on llama-server, ensuring proper startup order and preventing connection failures during initialization.

## Changes

**Modified: `extensions/services/privacy-shield/compose.yaml`**
- Added `depends_on` with `condition: service_healthy` for llama-server
- Privacy Shield proxies requests to llama-server, so it must wait for llama-server to be healthy

**Modified: `extensions/services/litellm/compose.yaml`**
- Added `depends_on` with `condition: service_healthy` for llama-server
- LiteLLM routes to llama-server in local mode, so it must wait for llama-server to be healthy

**Existing dependencies (already correct):**
- `open-webui` → depends on `llama-server` (service_healthy)
- `dashboard` → depends on `dashboard-api` (service_healthy)
- `perplexica` → depends on `searxng` (service_healthy)
- `openclaw` → depends on `searxng` (service_healthy)

## Problem Solved

Services that depend on llama-server would start immediately and fail with connection errors:
- Privacy Shield would fail to proxy requests (connection refused to llama-server:8080)
- LiteLLM would fail health checks (cannot reach upstream llama-server)
- Services would restart repeatedly until llama-server became healthy
- Logs filled with connection error noise

Without health condition dependencies, Docker Compose starts all services in parallel, leading to race conditions where dependent services try to connect before their dependencies are ready.

## Dependency Graph

```
llama-server (core)
  ├─> open-webui (waits for llama-server healthy)
  ├─> privacy-shield (waits for llama-server healthy) [NEW]
  └─> litellm (waits for llama-server healthy) [NEW]

searxng (core)
  ├─> perplexica (waits for searxng healthy)
  └─> openclaw (waits for searxng healthy)

dashboard-api (core)
  └─> dashboard (waits for dashboard-api healthy)
```

## How It Works

Docker Compose `depends_on` with `condition: service_healthy`:
1. Checks the dependency's healthcheck endpoint
2. Waits for healthcheck to return success (exit code 0)
3. Only then starts the dependent service
4. If dependency never becomes healthy, dependent service never starts

This prevents:
- Connection refused errors during startup
- Unnecessary restart loops
- Log noise from failed connection attempts
- Race conditions in service initialization

## Testing

- Compose syntax validated with `docker compose config`
- Dependency order verified: llama-server must have healthcheck defined (it does)
- Existing dependencies preserved (open-webui, dashboard, perplexica, openclaw)

## Impact

- Cleaner startup sequence with proper ordering
- Fewer connection errors in logs
- Services start only when their dependencies are ready
- Maintains existing behavior for services without dependencies
- No breaking changes (only adds wait conditions)

## Future Work

Consider adding health condition dependencies for:
- Services that use embeddings service (if any)
- Services that use qdrant (if any)
- Services that use whisper/tts (if any)

Currently these are optional services and failures are handled gracefully, so health dependencies are not critical.

---

**Files changed:**
- `dream-server/extensions/services/privacy-shield/compose.yaml` (+3 lines)
- `dream-server/extensions/services/litellm/compose.yaml` (+3 lines)