### PR TITLE
fix(macos): read port conflict list from extension manifests

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -146,8 +146,17 @@ if $OLLAMA_RUNNING; then
     fi
 fi
 
-# Port conflict checks
-for port_check in 8080 11434 3000 3001 3003; do
+# Port conflict checks — dynamically read from extension manifests
+_conflict_ports=(8080 11434)  # llama-server (native) + Ollama default (host conflict, no manifest)
+for _manifest in "${SOURCE_ROOT}/extensions/services/"*/manifest.yaml; do
+    [[ -f "$_manifest" ]] || continue
+    _port=$(grep 'external_port_default:' "$_manifest" 2>/dev/null | awk '{print $2}' | tr -d '"') || true
+    if [[ -n "$_port" && "$_port" =~ ^[0-9]+$ && "$_port" -ne 8080 ]]; then
+        _conflict_ports+=("$_port")
+    fi
+done
+
+for port_check in "${_conflict_ports[@]}"; do
     if check_port_conflict "$port_check"; then
         ai_warn "Port ${port_check} is in use by ${PORT_CONFLICT_PROC} (PID ${PORT_CONFLICT_PID})"
     fi


### PR DESCRIPTION
## What
Replace hardcoded 5-port conflict check with dynamic manifest reading in the macOS installer.

## Why
The installer only checked ports 8080, 11434, 3000, 3001, 3003. Twelve extension services (n8n, ComfyUI, Whisper, TTS, Qdrant, SearXNG, etc.) had no port conflict warning, causing silent startup failures.

## How
- Read `external_port_default` from all `extensions/services/*/manifest.yaml`
- Seed 8080 (llama-server, native on macOS) and 11434 (Ollama default, no manifest)
- Guard grep pipeline with `|| true` under `set -euo pipefail`
- Bash 3.2 compatible (macOS system bash)

## Testing
- `bash -n` syntax check: pass
- shellcheck: only pre-existing SC2153 info (unrelated)
- Critique Guardian: APPROVED (after two rounds — port 11434 restoration + `|| true` fix)

## Platform Impact
- **macOS**: Fixed (primary target)
- **Linux**: Not affected (different installer)
- **Windows**: Not affected

Closes #251