### PR TITLE
fix: add cross-platform _sed_i helper for BSD/GNU sed compatibility

### DIFF
--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -8,7 +8,7 @@
 # Expects: (nothing — first file sourced)
 # Provides: VERSION, SCRIPT_DIR, INSTALL_DIR, LOG_FILE, color codes,
 #           SYSTEM_TZ, CAPABILITY_PROFILE_FILE, PREFLIGHT_REPORT_FILE,
-#           INSTALL_START_EPOCH
+#           INSTALL_START_EPOCH, _sed_i()
 #
 # Modder notes:
 #   Change VERSION for custom builds. Add new color codes here.
@@ -42,3 +42,17 @@ AMB='\033[0;33m'         # Amber — warnings, ETA labels
 WHT='\033[1;37m'         # White — key URLs
 NC='\033[0m'             # Reset
 CURSOR='█'               # Block cursor for typing
+
+#=============================================================================
+# Cross-platform helpers
+#=============================================================================
+
+# BSD sed (macOS) requires `sed -i ''` while GNU sed uses `sed -i`.
+# Usage: _sed_i "s/old/new/g" file
+_sed_i() {
+    if sed --version 2>/dev/null | grep -q GNU; then
+        sed -i "$@"
+    else
+        sed -i '' "$@"
+    fi
+}

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -92,9 +92,9 @@ else
         _sed_escape() { printf '%s\n' "$1" | sed 's/[&/\]/\\&/g'; }
         _oc_model_esc=$(_sed_escape "$OPENCLAW_MODEL")
         _oc_prov_esc=$(_sed_escape "$OPENCLAW_PROVIDER_NAME")
-        sed -i "s|__LLM_MODEL__|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
-        sed -i "s|Qwen/Qwen2.5-[^\"]*|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
-        sed -i "s|local-ollama|${_oc_prov_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
+        _sed_i "s|__LLM_MODEL__|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
+        _sed_i "s|Qwen/Qwen2.5-[^\"]*|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
+        _sed_i "s|local-ollama|${_oc_prov_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
         log "Installed OpenClaw config: $OPENCLAW_CONFIG -> openclaw.json (model: $OPENCLAW_MODEL)"
         mkdir -p "$INSTALL_DIR/data/openclaw/home/agents/main/sessions"
         # Generate OpenClaw home config with local llama-server provider

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -157,8 +157,8 @@ OPENCODE_EOF
             # Escape sed special chars to prevent injection from path or password values
             _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&/\]/\\&/g')
             _pass_esc=$(printf '%s\n' "${OPENCODE_SERVER_PASSWORD}" | sed 's/[&/\]/\\&/g')
-            sed -i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
-            sed -i "s|__OPENCODE_SERVER_PASSWORD__|${_pass_esc}|g" "$svc_tmp"
+            _sed_i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
+            _sed_i "s|__OPENCODE_SERVER_PASSWORD__|${_pass_esc}|g" "$svc_tmp"
             cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
             rm -f "$svc_tmp"
 

--- a/dream-server/installers/phases/09-offline.sh
+++ b/dream-server/installers/phases/09-offline.sh
@@ -25,9 +25,9 @@ elif [[ "$OFFLINE_MODE" == "true" ]] && ! $DRY_RUN; then
     touch "$INSTALL_DIR/.offline-mode"
 
     # Disable any cloud-dependent features in .env
-    sed -i 's/^BRAVE_API_KEY=.*/BRAVE_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
-    sed -i 's/^ANTHROPIC_API_KEY=.*/ANTHROPIC_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
-    sed -i 's/^OPENAI_API_KEY=.*/OPENAI_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
+    _sed_i 's/^BRAVE_API_KEY=.*/BRAVE_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
+    _sed_i 's/^ANTHROPIC_API_KEY=.*/ANTHROPIC_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
+    _sed_i 's/^OPENAI_API_KEY=.*/OPENAI_API_KEY=/' "$INSTALL_DIR/.env" 2>/dev/null || true
 
     # Add offline mode config
     cat >> "$INSTALL_DIR/.env" << 'OFFLINE_EOF'


### PR DESCRIPTION
## What
Add `_sed_i()` helper to `installers/lib/constants.sh` and replace all 8 bare `sed -i` calls in phases 06, 07, and 09.

## Why
BSD sed (macOS) requires `sed -i ''` while GNU sed uses `sed -i`. The bare calls leave literal `__LLM_MODEL__`, `__HOME__`, and `__OPENCODE_SERVER_PASSWORD__` placeholders unsubstituted if `install-core.sh` is invoked on macOS.

## How
- `_sed_i()` detects GNU vs BSD sed via `sed --version 2>/dev/null | grep -q GNU`
- Placed in `constants.sh` (first lib sourced, available to all phases)
- 3 replacements in phase 06, 2 in phase 07, 3 in phase 09
- Container-level `sed -i` calls (Docker/entrypoint.sh) correctly left untouched

## Testing
- shellcheck on all 4 modified files: clean (only pre-existing warnings)
- Critique Guardian: APPROVED

## Platform Impact
- **macOS**: Fixed (if install-core.sh path is used)
- **Linux**: No behavioral change (GNU sed path taken)
- **Windows**: Not affected

Closes #252