### PR TITLE
fix(wsl2): detect Windows host RAM instead of VM memory

### DIFF
--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -33,7 +33,20 @@ if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
     GPU_COUNT=0
     GPU_MEMORY_TYPE="none"
     TIER="CLOUD"
-    RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    if grep -qi microsoft /proc/version 2>/dev/null; then
+        _wsl_ram_bytes=""
+        if command -v powershell.exe &>/dev/null; then
+            _wsl_ram_bytes=$(powershell.exe -NoProfile -Command \
+                "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" 2>/dev/null | tr -d '\r')
+        fi
+        if [[ -n "$_wsl_ram_bytes" && "$_wsl_ram_bytes" =~ ^[0-9]+$ ]]; then
+            RAM_KB=$((_wsl_ram_bytes / 1024))
+        else
+            RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+        fi
+    else
+        RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    fi
     RAM_GB=$((RAM_KB / 1024 / 1024))
     DISK_AVAIL=$(df -BG "$HOME" | tail -1 | awk '{print $4}' | tr -d 'G')
     BACKEND_ID="cpu"
@@ -55,10 +68,37 @@ ai "Reading hardware telemetry..."
 
 load_capability_profile || true
 
-# RAM Detection
-RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
-RAM_GB=$((RAM_KB / 1024 / 1024))
-log "RAM: ${RAM_GB}GB"
+# RAM Detection (WSL2-aware: query Windows host RAM if available)
+if grep -qi microsoft /proc/version 2>/dev/null; then
+    _wsl_ram_kb=""
+    if command -v powershell.exe &>/dev/null; then
+        _wsl_ram_bytes=$(powershell.exe -NoProfile -Command \
+            "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" 2>/dev/null | tr -d '\r')
+        if [[ -n "$_wsl_ram_bytes" && "$_wsl_ram_bytes" =~ ^[0-9]+$ ]]; then
+            _wsl_ram_kb=$((_wsl_ram_bytes / 1024))
+        fi
+    fi
+    if [[ -z "$_wsl_ram_kb" ]] && command -v wmic.exe &>/dev/null; then
+        _wsl_ram_kb=$(wmic.exe OS get TotalVisibleMemorySize /value 2>/dev/null \
+            | grep -oE '[0-9]+' | sed -n '1p')
+    fi
+    if [[ -n "$_wsl_ram_kb" && "$_wsl_ram_kb" =~ ^[0-9]+$ ]]; then
+        RAM_KB="$_wsl_ram_kb"
+        RAM_GB=$((RAM_KB / 1024 / 1024))
+        _wsl_vm_kb=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+        _wsl_vm_gb=$((_wsl_vm_kb / 1024 / 1024))
+        log "WSL2 detected — Windows host RAM: ${RAM_GB}GB (WSL2 VM sees: ${_wsl_vm_gb}GB)"
+    else
+        RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+        RAM_GB=$((RAM_KB / 1024 / 1024))
+        log "WSL2 detected — could not query Windows host RAM (VM sees: ${RAM_GB}GB)"
+        log "For correct tier selection: use --tier N or configure .wslconfig"
+    fi
+else
+    RAM_KB=$(grep MemTotal /proc/meminfo | awk '{print $2}')
+    RAM_GB=$((RAM_KB / 1024 / 1024))
+    log "RAM: ${RAM_GB}GB"
+fi
 
 # Disk Detection
 DISK_AVAIL=$(df -BG "$HOME" | tail -1 | awk '{print $4}' | tr -d 'G')


### PR DESCRIPTION
## What
Add WSL2-aware RAM detection to `02-detection.sh` — query Windows host physical RAM instead of relying on `/proc/meminfo` which reports VM allocation.

## Why
On WSL2, `/proc/meminfo` reports VM memory (default 4-8GB), not host RAM. Users with 32-64GB Windows machines get Tier 1 model selection instead of the correct Tier 3-4.

## How
- Detect WSL2 via `grep -qi microsoft /proc/version`
- Try `powershell.exe` (Get-CimInstance → bytes → KB)
- Fall back to `wmic.exe` (returns KB directly, using `grep -oE '[0-9]+'`)
- Final fallback to `/proc/meminfo` with warning message
- Both cloud mode and normal detection paths are WSL2-aware
- `sed -n '1p'` instead of `head -1` (SIGPIPE safe under pipefail)

## Testing
- shellcheck: clean (only pre-existing warnings)
- `bash -n` syntax check: pass
- Critique Guardian: APPROVED WITH WARNINGS (two rounds — grep quantifier + cloud mode fixes)

## Platform Impact
- **Windows/WSL2**: Fixed (primary target)
- **Linux**: No change (non-WSL path)
- **macOS**: Not affected (separate installer)

Closes #254