### PR TITLE
fix: treat HTTP 4xx as unhealthy in dashboard health checks

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -172,7 +172,7 @@ async def check_service_health(service_id: str, config: dict) -> ServiceStatus:
         start = asyncio.get_event_loop().time()
         async with session.get(url) as resp:
             response_time = (asyncio.get_event_loop().time() - start) * 1000
-            status = "healthy" if resp.status < 500 else "unhealthy"
+            status = "healthy" if resp.status < 400 else "unhealthy"
     except asyncio.TimeoutError:
         # Service is reachable but slow — report degraded rather than down
         # to avoid false "offline" flashes during startup or heavy load.
@@ -205,7 +205,7 @@ async def _check_host_service_health(service_id: str, config: dict) -> ServiceSt
         start = asyncio.get_event_loop().time()
         async with session.get(url) as resp:
             response_time = (asyncio.get_event_loop().time() - start) * 1000
-            status = "healthy" if resp.status < 500 else "unhealthy"
+            status = "healthy" if resp.status < 400 else "unhealthy"
     except aiohttp.ClientConnectorError:
         status = "down"
     except Exception as e:


### PR DESCRIPTION
## What
Change health check threshold from `resp.status < 500` to `resp.status < 400` in both `check_service_health()` and `_check_host_service_health()`.

## Why
Services returning 401/403/404 on their health endpoint were shown as healthy (green) in the dashboard. Misconfigured services appeared to work fine, hiding real issues from users.

## How
- Two-line change in `helpers.py` (lines 175 and 208)
- Only 2xx/3xx responses are now "healthy"
- aiohttp follows redirects by default, so 3xx is rarely observed directly
- No service in the stack legitimately returns 4xx on its health endpoint

## Testing
- `py_compile` validation: pass
- Checked `test_helpers.py` — no tests reference health check threshold (pre-existing gap)
- Critique Guardian: APPROVED WITH WARNINGS (note: `check_n8n_available()` in workflows.py still uses `< 500` — deliberate, softer probe for informational field only)

## Platform Impact
- **All platforms**: Fixed

Closes #255