### PR TITLE
fix: replace GNU-only date +%s%N with portable millisecond timestamps

### DIFF
--- a/dream-server/scripts/dream-test.sh
+++ b/dream-server/scripts/dream-test.sh
@@ -94,6 +94,11 @@ log() {
     [[ "$VERBOSE" == "true" ]] && echo "$@" >&2
 }
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 print_header() {
     if [[ "$JSON_OUTPUT" != "true" ]]; then
         echo ""
@@ -156,8 +161,8 @@ test_http() {
     local response_code
     local start_time end_time duration_ms
     
-    start_time=$(date +%s%N)
-    
+    start_time=$(_now_ms)
+
     if [[ -n "$payload" && "$method" == "POST" ]]; then
         response_code=$(curl -s -o /dev/null -w "%{http_code}" \
             --max-time "$custom_timeout" \
@@ -170,9 +175,9 @@ test_http() {
             "$url" 2>/dev/null || echo "000")
     fi
     
-    end_time=$(date +%s%N)
-    duration_ms=$(( (end_time - start_time) / 1000000 ))
-    
+    end_time=$(_now_ms)
+    duration_ms=$(( end_time - start_time ))
+
     if [[ "$response_code" == "$expected" ]]; then
         record_result "$name" "pass" "${duration_ms}ms"
         print_test "$name" "pass" "${duration_ms}ms"
@@ -437,8 +442,8 @@ test_voice_roundtrip() {
     fi
     
     local start_time end_time duration_ms
-    start_time=$(date +%s%N)
-    
+    start_time=$(_now_ms)
+
     local llm_payload='{"model": "Qwen/Qwen2.5-32B-Instruct-AWQ", "messages": [{"role": "user", "content": "What is the weather today?"}], "max_tokens": 50}'
     local llm_response
     llm_response=$(curl -s --max-time 15 \
@@ -460,9 +465,9 @@ test_voice_roundtrip() {
         -H "Content-Type: application/json" \
         -d "$tts_payload" 2>/dev/null)
     
-    end_time=$(date +%s%N)
-    duration_ms=$(( (end_time - start_time) / 1000000 ))
-    
+    end_time=$(_now_ms)
+    duration_ms=$(( end_time - start_time ))
+
     if [[ -n "$tts_response" ]] && [[ ${#tts_response} -gt 100 ]]; then
         record_result "Voice Round-Trip" "pass" "${duration_ms}ms"
         print_test "Voice Round-Trip" "pass" "${duration_ms}ms"

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -46,16 +46,21 @@ ANY_FAIL=false
 
 log() { $QUIET || echo -e "$1"; }
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 # ── Test functions ──────────────────────────────────────────────────────────
 
 # llama-server: critical path — performs an actual inference test
 test_llm() {
-    local start=$(date +%s%3N)
+    local start=$(_now_ms)
     local response=$(curl -sf --max-time $TIMEOUT \
         -H "Content-Type: application/json" \
         -d '{"model":"default","prompt":"Hi","max_tokens":1}' \
         "http://${LLM_HOST}:${LLM_PORT}/v1/completions" 2>/dev/null)
-    local end=$(date +%s%3N)
+    local end=$(_now_ms)
 
     if echo "$response" | grep -q '"text"'; then
         RESULTS[llm]="ok"

--- a/dream-server/tests/benchmark-status-performance.sh
+++ b/dream-server/tests/benchmark-status-performance.sh
@@ -14,6 +14,11 @@ CYAN='\033[0;36m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 echo -e "${BLUE}━━━ Dream Status Performance Benchmark ━━━${NC}"
 echo ""
 
@@ -55,21 +60,21 @@ trap cleanup_mock_services EXIT
 
 # Simulate sequential health checks (old implementation)
 benchmark_sequential() {
-    local start=$(date +%s%N)
+    local start=$(_now_ms)
 
     # Simulate 13 sequential curl calls with 1 second timeout each
     for i in {1..13}; do
         curl -sf --max-time 1 http://localhost:8080/health > /dev/null 2>&1 || true
     done
 
-    local end=$(date +%s%N)
-    local duration=$(( (end - start) / 1000000 ))
+    local end=$(_now_ms)
+    local duration=$(( end - start ))
     echo $duration
 }
 
 # Simulate parallel health checks (new implementation)
 benchmark_parallel() {
-    local start=$(date +%s%N)
+    local start=$(_now_ms)
     local tmpdir=$(mktemp -d)
     local -a pids=()
 
@@ -84,8 +89,8 @@ benchmark_parallel() {
         wait "$pid" 2>/dev/null || true
     done
 
-    local end=$(date +%s%N)
-    local duration=$(( (end - start) / 1000000 ))
+    local end=$(_now_ms)
+    local duration=$(( end - start ))
     rm -rf "$tmpdir"
     echo $duration
 }

--- a/dream-server/tests/test-concurrency.sh
+++ b/dream-server/tests/test-concurrency.sh
@@ -6,6 +6,11 @@ LLAMA_SERVER_URL="http://localhost:8080"
 MODEL="qwen2.5-32b-instruct"
 CONCURRENT_REQUESTS=5
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 echo "=== M8 Test: Concurrency ($CONCURRENT_REQUESTS parallel requests) ==="
 
 # Create temp directory for responses
@@ -13,7 +18,7 @@ TEMP_DIR=$(mktemp -d)
 
 # Launch concurrent requests
 echo "  Launching $CONCURRENT_REQUESTS parallel requests..."
-START=$(date +%s%N)
+START=$(_now_ms)
 
 for i in $(seq 1 $CONCURRENT_REQUESTS); do
   (
@@ -29,8 +34,8 @@ done
 
 # Wait for all to complete
 wait
-END=$(date +%s%N)
-TOTAL_TIME=$(( (END - START) / 1000000 ))
+END=$(_now_ms)
+TOTAL_TIME=$(( END - START ))
 
 # Count successes
 SUCCESS=0

--- a/dream-server/tests/test-embeddings-full.sh
+++ b/dream-server/tests/test-embeddings-full.sh
@@ -4,20 +4,25 @@
 
 LLAMA_SERVER_URL="http://localhost:8080"
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 echo "=== M8 Test: Embeddings Full ==="
 
 TEST_TEXT="The quick brown fox jumps over the lazy dog"
 
 # Test embeddings endpoint
-START=$(date +%s%N)
+START=$(_now_ms)
 RESPONSE=$(curl -s -X POST "$LLAMA_SERVER_URL/v1/embeddings" \
   -H "Content-Type: application/json" \
   -d "{
     \"model\": \"qwen2.5-32b-instruct\",
     \"input\": \"$TEST_TEXT\"
   }" 2>/dev/null)
-END=$(date +%s%N)
-LATENCY=$(( (END - START) / 1000000 ))
+END=$(_now_ms)
+LATENCY=$(( END - START ))
 
 # Check for embedding array
 if echo "$RESPONSE" | grep -q '"embedding":\['; then

--- a/dream-server/tests/test-streaming.sh
+++ b/dream-server/tests/test-streaming.sh
@@ -5,10 +5,15 @@
 LLAMA_SERVER_URL="http://localhost:8080"
 MODEL="qwen2.5-32b-instruct"
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 echo "=== M8 Test: Streaming ==="
 
 # Test streaming endpoint
-START=$(date +%s%N)
+START=$(_now_ms)
 RESPONSE=$(curl -s -N -X POST "$LLAMA_SERVER_URL/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d "{
@@ -17,8 +22,8 @@ RESPONSE=$(curl -s -N -X POST "$LLAMA_SERVER_URL/v1/chat/completions" \
     \"stream\": true,
     \"max_tokens\": 20
   }" 2>/dev/null | head -c 500)
-END=$(date +%s%N)
-LATENCY=$(( (END - START) / 1000000 ))
+END=$(_now_ms)
+LATENCY=$(( END - START ))
 
 # Check for streaming data prefix (should contain "data:")
 if echo "$RESPONSE" | grep -q "data:"; then

--- a/dream-server/tests/test-stt-full.sh
+++ b/dream-server/tests/test-stt-full.sh
@@ -4,6 +4,11 @@
 
 WHISPER_URL="http://localhost:9000"
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 echo "=== M8 Test: STT Full (Whisper Inference) ==="
 
 # Create a small test audio file (silence + tone)
@@ -22,13 +27,13 @@ TEST_AUDIO="/tmp/test_audio.wav"
 ffmpeg -f lavfi -i anullsrc=r=16000:cl=mono -t 1 -acodec pcm_s16le "$TEST_AUDIO" -y 2>/dev/null
 
 # Test STT endpoint
-START=$(date +%s%N)
+START=$(_now_ms)
 RESPONSE=$(curl -s -X POST "$WHISPER_URL/v1/audio/transcriptions" \
   -H "Content-Type: multipart/form-data" \
   -F "file=@$TEST_AUDIO" \
   -F "model=whisper-1" 2>/dev/null)
-END=$(date +%s%N)
-LATENCY=$(( (END - START) / 1000000 ))
+END=$(_now_ms)
+LATENCY=$(( END - START ))
 
 # Cleanup
 rm -f "$TEST_AUDIO"

--- a/dream-server/tests/test-tts-full.sh
+++ b/dream-server/tests/test-tts-full.sh
@@ -4,10 +4,15 @@
 
 KOKORO_URL="http://localhost:8880"
 
+# Portable millisecond timestamp (macOS BSD date lacks %N)
+_now_ms() {
+    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
+}
+
 echo "=== M8 Test: TTS Full (Kokoro Inference) ==="
 
 # Test TTS endpoint with simple text
-START=$(date +%s%N)
+START=$(_now_ms)
 RESPONSE=$(curl -s -X POST "$KOKORO_URL/v1/audio/speech" \
   -H "Content-Type: application/json" \
   -d '{
@@ -16,8 +21,8 @@ RESPONSE=$(curl -s -X POST "$KOKORO_URL/v1/audio/speech" \
     "voice": "af_bella",
     "response_format": "mp3"
   }' 2>/dev/null)
-END=$(date +%s%N)
-LATENCY=$(( (END - START) / 1000000 ))
+END=$(_now_ms)
+LATENCY=$(( END - START ))
 
 # Check if we got audio data (MP3 starts with ID3 or empty binary)
 if echo "$RESPONSE" | head -c 10 | xxd | grep -qE "ID3|fffb|5249"; then


### PR DESCRIPTION
## What
Replaced `date +%s%3N` and `date +%s%N` (GNU coreutils extensions) with a portable `_now_ms()` helper across all scripts that measure timing.

## Why
macOS ships BSD `date` which does not support `%N` or `%3N`. On macOS, these output literal strings like `1741234567%3N` instead of numeric values, breaking all arithmetic operations under `set -euo pipefail`. Health check latency metrics produce garbage or the script aborts entirely.

## How
Added a `_now_ms()` helper function to each affected script:
```bash
_now_ms() {
    python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo "$(date +%s)000"
}
```
- Primary: uses python3 for millisecond-precision timestamps (cross-platform)
- Fallback: second-precision with appended zeros if python3 unavailable
- Removed `/1000000` division where nanoseconds were previously converted to milliseconds

## Testing
- shellcheck: all 8 files pass (no new warnings)
- Zero remaining `date +%s%N` or `date +%s%3N` in the codebase

## Files Changed (8)
- `scripts/health-check.sh` — 2 instances
- `scripts/dream-test.sh` — 4 instances + 2 arithmetic fixes
- `tests/test-tts-full.sh`, `test-concurrency.sh`, `test-streaming.sh`, `benchmark-status-performance.sh`, `test-stt-full.sh`, `test-embeddings-full.sh` — 14 instances total

## Platform Impact
- **macOS**: Fixes broken timing — was the primary target
- **Linux**: No change in behavior (python3 returns same precision)
- **Windows/WSL**: No change

🤖 Generated with [Claude Code](https://claude.com/claude-code)