### PR TITLE
fix(macos): add readiness sidecar for native llama-server before open-webui starts

### DIFF
--- a/dream-server/installers/macos/docker-compose.macos.yml
+++ b/dream-server/installers/macos/docker-compose.macos.yml
@@ -10,6 +10,40 @@ services:
     deploy:
       replicas: 0    # Disabled -- running natively on macOS host via Metal
 
+  # Readiness sidecar — polls native llama-server on the macOS host.
+  # Docker Compose cannot express depends_on for a host process, so this
+  # lightweight container bridges the gap.  open-webui waits on its
+  # healthcheck before starting.
+  llama-server-ready:
+    image: busybox:latest
+    container_name: dream-llama-ready
+    restart: unless-stopped
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    entrypoint:
+      - sh
+      - -c
+      - |
+        echo "Waiting for native llama-server on host..."
+        while ! wget -qO- "http://host.docker.internal:${OLLAMA_PORT:-8080}/health" >/dev/null 2>&1; do
+          sleep 2
+        done
+        echo "llama-server is ready"
+        sleep infinity
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://host.docker.internal:${OLLAMA_PORT:-8080}/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+      start_period: 5s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 32M
+    security_opt:
+      - no-new-privileges:true
+
   dashboard-api:
     environment:
       - OLLAMA_URL=http://host.docker.internal:8080
@@ -22,5 +56,8 @@ services:
       - HOST_RAM_GB=${HOST_RAM_GB:-0}   # explicit override; base.yml also carries this for other platforms
 
   open-webui:
+    depends_on:
+      llama-server-ready:
+        condition: service_healthy
     environment:
       OPENAI_API_BASE_URL: "http://host.docker.internal:8080/v1"


### PR DESCRIPTION
## What
Added a lightweight busybox sidecar service (`llama-server-ready`) to the macOS compose overlay that polls the native llama-server on the host before open-webui starts.

## Why
On macOS, llama-server runs natively on the host with Metal acceleration (not in Docker). Docker Compose cannot express `depends_on` for a host process, so open-webui started immediately and tried to reach `host.docker.internal:8080` before llama-server finished loading the model. On first boot with large models (30s-120s load time), users see connection errors and may assume the install failed.

## How
- Added `llama-server-ready` sidecar in `docker-compose.macos.yml`:
  - Polls `host.docker.internal:${OLLAMA_PORT:-8080}/health` every 2s
  - Healthcheck with 60 retries × 10s interval (10-minute window)
  - Resource limits: 0.1 CPU, 32M RAM
  - `security_opt: no-new-privileges:true`
- open-webui now has `depends_on: llama-server-ready: condition: service_healthy`
- Uses `OLLAMA_PORT` env var (host/.env level) for correct port resolution

## Testing
- Compose YAML validates with `docker compose config`
- macOS-only overlay — does not affect Linux or cloud mode

## Files Changed
- `installers/macos/docker-compose.macos.yml`

## Platform Impact
- **macOS**: Fixes first-boot race condition
- **Linux/Windows**: Not affected (different compose overlays)

🤖 Generated with [Claude Code](https://claude.com/claude-code)