### PR TITLE
fix: add try/finally to prevent subprocess leak on client disconnect in setup.py

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/setup.py
+++ b/dream-server/extensions/services/dashboard-api/routers/setup.py
@@ -143,10 +143,20 @@ async def run_setup_diagnostics(api_key: str = Depends(verify_api_key)):
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             text=True, bufsize=1, universal_newlines=True
         )
-        for line in process.stdout:
-            yield line
-        process.wait()
-        yield f"\n{'All tests passed!' if process.returncode == 0 else 'Some tests failed.'}\n"
+        try:
+            for line in process.stdout:
+                yield line
+            process.wait()
+            yield f"\n{'All tests passed!' if process.returncode == 0 else 'Some tests failed.'}\n"
+        finally:
+            if process.stdout:
+                process.stdout.close()
+            if process.poll() is None:
+                try:
+                    process.kill()
+                except OSError:
+                    pass
+                process.wait()
 
     return StreamingResponse(run_tests(), media_type="text/plain")
 


### PR DESCRIPTION
## What
Wrapped the `run_tests()` streaming generator in `try/finally` to ensure subprocess cleanup when clients disconnect mid-stream.

## Why
`POST /api/setup/test` creates a `subprocess.Popen` and streams its stdout via a generator. If the client disconnects before the script finishes, FastAPI/Starlette stops iterating the generator — but `process.stdout` was never closed and `process.wait()` was never called. The subprocess continued running as a zombie, leaking a file descriptor and a bash process per abandoned request.

## How
```python
def run_tests():
    process = subprocess.Popen(...)
    try:
        for line in process.stdout:
            yield line
        process.wait()
        yield f"\n{'...'}\n"
    finally:
        if process.stdout:
            process.stdout.close()
        if process.poll() is None:
            try:
                process.kill()
            except OSError:
                pass  # TOCTOU: process may exit between poll() and kill()
            process.wait()
```

- `finally` block guaranteed to run on `GeneratorExit` (client disconnect)
- `process.kill()` wrapped in `try/except OSError` to handle TOCTOU race
- `process.stdout.close()` is idempotent per Python spec

## Testing
- `py_compile` passes
- `ruff check` passes
- No existing tests for this endpoint (pre-existing gap)

## Files Changed
- `extensions/services/dashboard-api/routers/setup.py`

## Platform Impact
- **All platforms**: Prevents zombie process accumulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)