### PR TITLE
Extension catalog and schema docs

### DIFF
--- a/dream-server/extensions/CATALOG.md
+++ b/dream-server/extensions/CATALOG.md
@@ -1,0 +1,80 @@
+# Dream Server Extension Catalog
+
+This catalog lists all **bundled extensions** (services) that ship with Dream Server. Each extension has a `manifest.yaml` that declares its id, ports, health endpoint, and **version compatibility** (`compatibility.dream_min` / `dream_max`) so they work seamlessly for the Dream Server version you are on.
+
+For adding or authoring extensions, see [EXTENSIONS.md](../docs/EXTENSIONS.md) and [schema/README.md](schema/README.md).
+
+## Catalog overview
+
+| Service ID      | Name                     | Category    | Default port | GPU backends   | Description |
+|-----------------|--------------------------|------------|-------------|----------------|-------------|
+| llama-server    | llama-server (LLM)       | core       | 8080        | amd, nvidia    | Main LLM inference API (Ollama-compatible). |
+| open-webui      | Open WebUI (Chat)        | core       | 3000        | amd, nvidia    | Chat UI; talks to llama-server. |
+| dashboard       | Dashboard (Control Center) | core     | 3001        | amd, nvidia    | Control center and status. |
+| dashboard-api   | Dashboard API            | core       | 3002        | amd, nvidia    | Backend API for the dashboard. |
+| litellm         | LiteLLM (API Gateway)   | recommended | 4000       | amd, nvidia    | Unified API gateway for multiple backends. |
+| searxng         | SearXNG (Web Search)     | recommended | 8888      | amd, nvidia    | Metasearch for web. |
+| token-spy       | Token Spy (Usage Monitor) | recommended | 3005     | amd, nvidia    | Token and usage monitoring. |
+| n8n             | n8n (Workflows)          | optional   | 5678        | amd, nvidia    | Workflow automation. |
+| qdrant          | Qdrant (Vector DB)       | optional   | 6333        | amd, nvidia    | Vector store for RAG. |
+| whisper         | Whisper (STT)            | optional   | 9000        | amd, nvidia    | Speech-to-text. |
+| tts             | Kokoro (TTS)             | optional   | 8880        | amd, nvidia    | Text-to-speech. |
+| comfyui         | ComfyUI (Image Gen)      | optional   | 8188        | amd, nvidia    | Image generation (e.g. FLUX). |
+| openclaw        | OpenClaw (Agents)        | optional   | 7860        | amd, nvidia    | Agent with tools. |
+| perplexica      | Perplexica (Deep Research) | optional | 3004        | amd, nvidia    | Deep research UI. |
+| embeddings      | TEI (Embeddings)        | optional   | 8090        | amd, nvidia    | Text embeddings for RAG. |
+| privacy-shield  | Privacy Shield           | optional   | 8085        | amd, nvidia    | PII detection and protection. |
+| opencode        | OpenCode (IDE)           | optional   | 3003        | amd, nvidia    | In-browser IDE integration. |
+
+## Categories
+
+- **core** — Always part of the base stack (llama-server, open-webui, dashboard, dashboard-api).
+- **recommended** — Enabled by default in the installer; can be disabled (litellm, searxng, token-spy).
+- **optional** — User opts in during install or later (n8n, qdrant, whisper, tts, comfyui, openclaw, perplexica, embeddings, privacy-shield, opencode).
+
+## Ports and .env
+
+Each service’s external port can be overridden in `.env` via the `external_port_env` field in its manifest (e.g. `WEBUI_PORT`, `OLLAMA_PORT`/`LLAMA_SERVER_PORT`). Defaults are in the table above and in `.env.example`.
+
+The installer (phase 04) checks that these ports are free before proceeding. The service registry (`lib/service-registry.sh`) and scripts like `health-check.sh` use these ports for health checks and URLs.
+
+## Version compatibility
+
+All bundled extensions declare `compatibility.dream_min: "2.0.0"` (or equivalent) so that:
+
+- `scripts/validate-manifests.sh` and `dream config validate` can report whether each extension is compatible with the current Dream Server version.
+- Future core releases can enforce or warn when an extension’s `dream_min` is newer than the installed core, or when `dream_max` is older.
+
+See [schema/README.md](schema/README.md) for the manifest schema and compatibility block.
+
+## Where manifests live
+
+```
+extensions/services/
+  open-webui/manifest.yaml
+  llama-server/manifest.yaml
+  dashboard/manifest.yaml
+  dashboard-api/manifest.yaml
+  n8n/manifest.yaml
+  qdrant/manifest.yaml
+  whisper/manifest.yaml
+  tts/manifest.yaml
+  comfyui/manifest.yaml
+  openclaw/manifest.yaml
+  perplexica/manifest.yaml
+  embeddings/manifest.yaml
+  litellm/manifest.yaml
+  searxng/manifest.yaml
+  token-spy/manifest.yaml
+  privacy-shield/manifest.yaml
+  opencode/manifest.yaml
+```
+
+Each directory typically also has a `compose.yaml` (and optional overlay like `compose.nvidia.yaml`). The resolver `scripts/resolve-compose-stack.sh` builds the full compose command from enabled extensions and the selected GPU backend.
+
+## Enabling and disabling
+
+- **During install:** Phase 03 (features) lets you enable optional features; the installer enables the corresponding extensions.
+- **After install:** Use `dream-cli` (e.g. `dream enable n8n`, `dream disable comfyui`) or enable/disable by renaming `compose.yaml` to `compose.yaml.disabled` (and back) in the service directory under the install path.
+
+The service registry only loads manifests for extensions that are “enabled” (compose file present), so disabled extensions do not appear in `sr_list_enabled` or port checks.

--- a/dream-server/extensions/schema/README.md
+++ b/dream-server/extensions/schema/README.md
@@ -1,0 +1,118 @@
+# Dream Server Service Manifest Schema (v1)
+
+This directory contains the JSON Schema for Dream Server extension manifests: `service-manifest.v1.json`. Manifests are YAML files (`manifest.yaml`) in each service under `extensions/services/<service-id>/`. The schema defines the structure used by the service registry, `scripts/validate-manifests.sh`, and `dream config validate` so that **extensions work seamlessly for the Dream Server version you are on**.
+
+## Schema version
+
+Every manifest must set:
+
+```yaml
+schema_version: dream.services.v1
+```
+
+The validator and compatibility checks use this to ensure they are reading a v1 manifest.
+
+---
+
+## Root-level blocks
+
+### `compatibility` (optional)
+
+Declares which Dream Server core versions this extension supports. Used by `scripts/validate-manifests.sh` and the installer summary to report compatible/incompatible extensions.
+
+| Field       | Type   | Required | Description |
+|------------|--------|----------|-------------|
+| `dream_min`| string | no       | Minimum Dream Server version (semver, e.g. `"2.0.0"`). If set, the validator compares it to the core version from `manifest.json`. |
+| `dream_max`| string | no       | Maximum Dream Server version tested (semver). Optional; if set and core is newer, the extension may be marked incompatible or warned. |
+
+Pattern for both: `^\d+\.\d+\.\d+$` (exactly three numeric segments). Pre-release suffixes (e.g. `2.0.0-beta`) are not in the schema; the validator may treat them as the base version.
+
+Example:
+
+```yaml
+compatibility:
+  dream_min: "2.0.0"
+  # dream_max: "2.1.0"   # optional
+```
+
+If `compatibility` is omitted, the validator reports "ok-no-metadata" (assumed compatible). All bundled extensions in this repo set `dream_min: "2.0.0"`.
+
+---
+
+### `service` (required for runtime)
+
+Identifies the service and how the registry and compose resolver use it.
+
+| Field                 | Type    | Required | Description |
+|-----------------------|---------|----------|-------------|
+| `id`                  | string  | yes      | Unique service id (lowercase, digits, hyphens). Used in `SERVICE_PORTS`, compose selection, and CLI. |
+| `name`                | string  | yes      | Human-readable name (e.g. "Open WebUI (Chat)"). |
+| `aliases`             | array   | no       | Shorthand ids for CLI (e.g. `[webui, ui]`). |
+| `container_name`      | string  | no       | Docker container name (e.g. `dream-webui`). |
+| `host_env`            | string  | no       | Env var for host override. |
+| `default_host`        | string  | no       | Default hostname inside the stack. |
+| `port`                | integer | yes      | Internal port (0–65535). |
+| `external_port_env`   | string  | no       | Env var for external port (e.g. `WEBUI_PORT`). |
+| `external_port_default` | integer | no     | Default external port; used by registry and health checks. |
+| `health`              | string  | yes      | Health path (e.g. `/health`, `/`). No leading slash is normalized by consumers. |
+| `type`                | string  | no       | `docker` or `host-systemd`. |
+| `gpu_backends`         | array   | no       | `amd`, `nvidia`, `apple`, `all`. Used for compose overlay selection. |
+| `compose_file`        | string  | no       | Relative path to compose fragment (e.g. `compose.yaml`). |
+| `category`            | string  | no       | `core`, `recommended`, or `optional`. Affects default enable/disable. |
+| `depends_on`          | array   | no       | List of service ids this service depends on. |
+| `env_vars`            | array   | no       | List of `{ key, required?, secret?, description?, default? }` for documentation and validation. |
+| `setup_hook`          | string  | no       | Relative path to a setup script run during installation. |
+
+The service registry (`lib/service-registry.sh`) builds `SERVICE_PORTS`, `SERVICE_HEALTH`, and related maps from these fields. The compose resolver includes only enabled services (compose file present) in the stack.
+
+---
+
+### `features` (optional)
+
+Used by the installer and dashboard to show feature toggles (e.g. "Voice", "Workflows", "RAG"). Each feature has an id, name, description, icon, category, requirements (services, VRAM, disk), and priority.
+
+| Field (per feature) | Type   | Description |
+|--------------------|--------|-------------|
+| `id`               | string | Feature id (e.g. `voice`). |
+| `name`             | string | Display name. |
+| `description`      | string | Short description. |
+| `icon`             | string | Icon identifier. |
+| `category`         | string | Grouping (e.g. `voice`, `creative`). |
+| `requirements`     | object | `services`, `services_any`, `vram_gb`, `disk_gb`. |
+| `priority`         | integer| Sort order. |
+| `gpu_backends`     | array  | Same as service. |
+
+Schema allows additional properties on feature objects for future use.
+
+---
+
+## Validation
+
+- **Schema validation:** If the system has Python with `pyyaml` and `jsonschema`, `scripts/validate-manifests.sh` validates each manifest against `service-manifest.v1.json`. Missing modules result in a warning and only compatibility checks run.
+- **Compatibility check:** The script reads the core version from `manifest.json` and compares it to each extension’s `compatibility.dream_min` / `dream_max`, then prints a summary (ok, incompatible, ok-no-metadata).
+- **Running validation:** From the repo root: `bash scripts/validate-manifests.sh`. From an install: `./dream-cli config validate` (runs both env and manifest validation).
+
+---
+
+## Example minimal manifest
+
+```yaml
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: my-service
+  name: My Service
+  port: 9000
+  health: /health
+  type: docker
+  gpu_backends: [amd, nvidia]
+  category: optional
+  compose_file: compose.yaml
+  external_port_env: MY_SERVICE_PORT
+  external_port_default: 9000
+```
+
+See `extensions/services/open-webui/manifest.yaml` and the rest of `extensions/services/*/manifest.yaml` for full examples. The catalog is in [../CATALOG.md](../CATALOG.md).


### PR DESCRIPTION
## Summary
- **extensions/CATALOG.md** — Catalog of bundled extensions and metadata.
- **extensions/schema/README.md** — Documentation for extension manifest schema.

## Scope
- `dream-server/extensions/CATALOG.md` (new)
- `dream-server/extensions/schema/README.md` (new)

Part of the split-PR set (PR4). Optional follow-up: add `dream_min` to all 13 extension manifests in a separate PR if desired.