### PR TITLE
fix: add .get() defaults for optional feature fields in features.py

### DIFF
--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -106,6 +106,9 @@ def load_extension_manifests(manifest_dir: Path, gpu_backend: str) -> tuple[dict
                     if gpu_backend != "apple" and gpu_backend not in supported and "all" not in supported:
                         continue
                     if feature.get("id") and feature.get("name"):
+                        missing = [f for f in ("description", "icon", "category", "setup_time", "priority") if f not in feature]
+                        if missing:
+                            logger.warning("Feature '%s' in %s missing optional fields: %s", feature["id"], path, ", ".join(missing))
                         features.append(feature)
 
             loaded += 1

--- a/dream-server/extensions/services/dashboard-api/routers/features.py
+++ b/dream-server/extensions/services/dashboard-api/routers/features.py
@@ -74,9 +74,9 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
     return {
         "id": feature["id"],
         "name": feature["name"],
-        "description": feature["description"],
-        "icon": feature["icon"],
-        "category": feature["category"],
+        "description": feature.get("description", ""),
+        "icon": feature.get("icon", "Package"),
+        "category": feature.get("category", "other"),
         "status": status,
         "enabled": is_enabled,
         "requirements": {
@@ -90,8 +90,8 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
             "servicesMissing": services_missing,
             "servicesOk": services_ok,
         },
-        "setupTime": feature["setup_time"],
-        "priority": feature["priority"]
+        "setupTime": feature.get("setup_time", "Unknown"),
+        "priority": feature.get("priority", 99)
     }
 
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_config.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for config.py — manifest loading and service discovery."""
 
+import logging
+
 import pytest
 
 from config import load_extension_manifests, _read_manifest_file
@@ -196,3 +198,24 @@ class TestLoadExtensionManifests:
 
         _, features = load_extension_manifests(tmp_path, "apple")
         assert any(f["id"] == "gpu-feat" for f in features)
+
+    def test_warns_on_missing_optional_feature_fields(self, tmp_path, caplog):
+        """A feature missing optional fields is loaded but a warning is logged."""
+        svc_dir = tmp_path / "sparse-svc"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n  id: sparse-svc\n  name: Sparse\n  port: 80\n"
+            "features:\n"
+            "  - id: sparse-feat\n    name: Sparse Feature\n"
+        )
+
+        with caplog.at_level(logging.WARNING, logger="config"):
+            _, features = load_extension_manifests(tmp_path, "nvidia")
+
+        assert any(f["id"] == "sparse-feat" for f in features)
+        warning_msgs = [r.message for r in caplog.records if "missing optional fields" in r.message]
+        assert len(warning_msgs) == 1
+        assert "sparse-feat" in warning_msgs[0]
+        for field in ("description", "icon", "category", "setup_time", "priority"):
+            assert field in warning_msgs[0]

--- a/dream-server/extensions/services/dashboard-api/tests/test_features.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_features.py
@@ -3,6 +3,29 @@
 import os
 from unittest.mock import patch, AsyncMock
 
+from routers.features import calculate_feature_status
+
+
+class TestCalculateFeatureStatusDefaults:
+    """calculate_feature_status uses .get() defaults for optional feature fields."""
+
+    def test_missing_optional_fields_use_defaults(self):
+        """A feature with only id, name, and requirements should not KeyError."""
+        minimal_feature = {
+            "id": "minimal",
+            "name": "Minimal Feature",
+            "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+        }
+        result = calculate_feature_status(minimal_feature, [], None)
+
+        assert result["id"] == "minimal"
+        assert result["name"] == "Minimal Feature"
+        assert result["description"] == ""
+        assert result["icon"] == "Package"
+        assert result["category"] == "other"
+        assert result["setupTime"] == "Unknown"
+        assert result["priority"] == 99
+
 
 class TestCalculateFeatureStatusAppleFallback:
 


### PR DESCRIPTION
## What
Add `.get()` with sensible defaults for 5 optional feature fields in `calculate_feature_status()` that previously used bare `[]` dict access.

## Why
Any extension manifest feature missing `description`, `icon`, `category`, `setup_time`, or `priority` crashes the `/api/features` endpoint with `KeyError → HTTP 500`. While stock manifests include all fields, the extension system is user-extensible — third-party manifests may omit optional fields.

## How
- **`routers/features.py`**: Replace 5 bare `feature["field"]` accesses with `.get()` defaults: `""`, `"Package"`, `"other"`, `"Unknown"`, `99`
- **`config.py`**: Add warning log in `load_extension_manifests()` when optional fields are missing — features still load, but authors get visibility

## Testing
- `test_features.py`: `test_missing_optional_fields_use_defaults` — minimal feature dict (id/name/requirements only), asserts all 5 defaults
- `test_config.py`: `test_warns_on_missing_optional_feature_fields` — verifies warning log fires with feature ID and all 5 field names
- Full test suite: 21/21 passed, 0 regressions

## Review
Critique Guardian: ✅ APPROVED (after addressing initial warnings re: icon default and test coverage)

## Known Considerations
- `feature["requirements"]` is still a bare access (pre-existing, out of scope) — a manifest feature without `requirements` would still crash. Could be addressed separately.
- `"Package"` icon falls back to `MessageSquare` via the frontend's `|| MessageSquare` guard in `FeatureDiscovery.jsx`

## Platform Impact
- All platforms (Python, no platform-specific code)

Closes #272