### PR TITLE
Feat/hardware detection hardening

### DIFF
--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -40,7 +40,7 @@ first_line() {
 json_escape() {
     local s="$1"
     s=${s//\\/\\\\}
-    s=${s//"/\\"}
+    s=${s//\"/\\\"}
     s=${s//$'\n'/\\n}
     s=${s//$'\r'/\\r}
     s=${s//$'\t'/\\t}
@@ -590,4 +590,6 @@ EOF
     fi
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/dream-server/tests/integration-test.sh
+++ b/dream-server/tests/integration-test.sh
@@ -88,6 +88,18 @@ else
                 fail "JSON missing required field: $field"
             fi
         done
+
+        # Regression test: json_escape must handle quoted GPU names correctly
+        escaped_output=$(bash -lc '
+            . "'"$PROJECT_DIR"'/scripts/detect-hardware.sh"
+            escaped=$(json_escape '\''NVIDIA "GeForce" RTX 4090'\'')
+            printf "{\"gpu_name\":\"%s\"}\n" "$escaped"
+        ' 2>/dev/null) || true
+        if echo "$escaped_output" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['gpu_name'] == 'NVIDIA \"GeForce\" RTX 4090'" 2>/dev/null; then
+            pass "json_escape handles embedded double quotes"
+        else
+            fail "json_escape does not escape embedded double quotes correctly" "$escaped_output"
+        fi
     else
         fail "detect-hardware.sh --json does not produce valid JSON" "$json_output"
     fi


### PR DESCRIPTION
This PR hardens detect-hardware.sh so its machine-readable output remains stable across more environments and edge cases. It also fixes a JSON escaping bug called out in review and adds regression coverage for quoted GPU names.

# Why:
The hardware detector feeds installer logic and tests, so malformed JSON or fragile parsing can ripple through the entire setup flow. Review specifically identified a bug in json_escape when handling embedded double quotes.

# What changed:

Enabled stricter shell behavior for more deterministic execution
Improved platform detection for native, WSL2, and containerized environments
Improved NVIDIA and AMD parsing logic
Fixed json_escape so embedded double quotes are escaped correctly
Guarded direct execution so helper functions can be sourced in tests
Added a regression test for quoted GPU names in JSON output
# Validation:

bash -n scripts/detect-hardware.sh
bash -n tests/integration-test.sh
direct round-trip validation for json_escape with NVIDIA "GeForce" RTX 4090
./scripts/detect-hardware.sh --json | python3 -m json.tool
# Notes:

This addresses the upstream review request on PR #211 about the bash quoting bug in json_escape.