### PR TITLE
feat: add Langfuse LLM observability extension (foundation)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,11 @@
+[[rules]]
+  id = "langfuse-project-public-key"
+  description = "Langfuse project public key"
+  regex = '''pk-lf-[0-9a-f]+'''
+  keywords = ["pk-lf-"]
+
+[[rules]]
+  id = "langfuse-project-secret-key"
+  description = "Langfuse project secret key"
+  regex = '''sk-lf-[0-9a-f]+'''
+  keywords = ["sk-lf-"]

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -94,6 +94,14 @@ WEBUI_PORT=3000            # Open WebUI (external → internal 8080)
 # WEBUI_AUTH=true
 
 # ═══════════════════════════════════════════════════════════════════
+# Langfuse (LLM Observability) — optional, disabled by default
+# ═══════════════════════════════════════════════════════════════════
+
+LANGFUSE_PORT=3006
+LANGFUSE_ENABLED=false
+# Remaining LANGFUSE_* secrets are auto-generated during install
+
+# ═══════════════════════════════════════════════════════════════════
 # Optional — Voice, Web UI, n8n
 # ═══════════════════════════════════════════════════════════════════
 

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -328,6 +328,79 @@
       "type": "string",
       "description": "Dify secret key for API access",
       "secret": true
+    },
+    "LANGFUSE_PORT": {
+      "type": "integer",
+      "description": "Langfuse web UI external port",
+      "default": 3006
+    },
+    "LANGFUSE_ENABLED": {
+      "type": "boolean",
+      "description": "Enable Langfuse LLM observability",
+      "default": false
+    },
+    "LANGFUSE_NEXTAUTH_SECRET": {
+      "type": "string",
+      "description": "Langfuse NextAuth session signing secret",
+      "secret": true
+    },
+    "LANGFUSE_SALT": {
+      "type": "string",
+      "description": "Langfuse password hashing salt",
+      "secret": true
+    },
+    "LANGFUSE_ENCRYPTION_KEY": {
+      "type": "string",
+      "description": "Langfuse data encryption key",
+      "secret": true
+    },
+    "LANGFUSE_DB_PASSWORD": {
+      "type": "string",
+      "description": "Langfuse PostgreSQL database password",
+      "secret": true
+    },
+    "LANGFUSE_CLICKHOUSE_PASSWORD": {
+      "type": "string",
+      "description": "Langfuse ClickHouse database password",
+      "secret": true
+    },
+    "LANGFUSE_REDIS_PASSWORD": {
+      "type": "string",
+      "description": "Langfuse Redis authentication password",
+      "secret": true
+    },
+    "LANGFUSE_MINIO_ACCESS_KEY": {
+      "type": "string",
+      "description": "Langfuse MinIO S3 access key",
+      "secret": true
+    },
+    "LANGFUSE_MINIO_SECRET_KEY": {
+      "type": "string",
+      "description": "Langfuse MinIO S3 secret key",
+      "secret": true
+    },
+    "LANGFUSE_PROJECT_PUBLIC_KEY": {
+      "type": "string",
+      "description": "Langfuse project public API key"
+    },
+    "LANGFUSE_PROJECT_SECRET_KEY": {
+      "type": "string",
+      "description": "Langfuse project secret API key",
+      "secret": true
+    },
+    "LANGFUSE_INIT_PROJECT_ID": {
+      "type": "string",
+      "description": "Langfuse initial project identifier"
+    },
+    "LANGFUSE_INIT_USER_EMAIL": {
+      "type": "string",
+      "description": "Langfuse initial admin user email",
+      "default": "admin@dreamserver.local"
+    },
+    "LANGFUSE_INIT_USER_PASSWORD": {
+      "type": "string",
+      "description": "Langfuse initial admin user password",
+      "secret": true
     }
   }
 }

--- a/dream-server/extensions/services/langfuse/compose.yaml.disabled
+++ b/dream-server/extensions/services/langfuse/compose.yaml.disabled
@@ -1,0 +1,241 @@
+services:
+  langfuse-web:
+    image: langfuse/langfuse:3.159.0
+    container_name: dream-langfuse-web
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      TELEMETRY_ENABLED: "false"
+      NEXT_TELEMETRY_DISABLED: "1"
+      DATABASE_URL: "postgresql://langfuse:${LANGFUSE_DB_PASSWORD}@langfuse-postgres:5432/langfuse"
+      CLICKHOUSE_MIGRATION_URL: "clickhouse://langfuse-clickhouse:9000"
+      CLICKHOUSE_URL: "http://langfuse-clickhouse:8123"
+      CLICKHOUSE_USER: "langfuse"
+      CLICKHOUSE_PASSWORD: "${LANGFUSE_CLICKHOUSE_PASSWORD}"
+      REDIS_HOST: "langfuse-redis"
+      REDIS_AUTH: "${LANGFUSE_REDIS_PASSWORD}"
+      LANGFUSE_S3_EVENT_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: "http://langfuse-minio:9000"
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: "${LANGFUSE_MINIO_ACCESS_KEY}"
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: "${LANGFUSE_MINIO_SECRET_KEY}"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-events"
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: "us-east-1"
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      NEXTAUTH_SECRET: "${LANGFUSE_NEXTAUTH_SECRET}"
+      SALT: "${LANGFUSE_SALT}"
+      ENCRYPTION_KEY: "${LANGFUSE_ENCRYPTION_KEY}"
+      NEXTAUTH_URL: "http://localhost:${LANGFUSE_PORT:-3006}"
+      LANGFUSE_INIT_ORG_ID: "dream-server"
+      LANGFUSE_INIT_ORG_NAME: "DreamServer"
+      LANGFUSE_INIT_PROJECT_ID: "${LANGFUSE_INIT_PROJECT_ID}"
+      LANGFUSE_INIT_PROJECT_NAME: "DreamServer Traces"
+      LANGFUSE_INIT_PROJECT_PUBLIC_KEY: "${LANGFUSE_PROJECT_PUBLIC_KEY}"
+      LANGFUSE_INIT_PROJECT_SECRET_KEY: "${LANGFUSE_PROJECT_SECRET_KEY}"
+      LANGFUSE_INIT_USER_EMAIL: "${LANGFUSE_INIT_USER_EMAIL:-admin@dreamserver.local}"
+      LANGFUSE_INIT_USER_NAME: "DreamServer Admin"
+      LANGFUSE_INIT_USER_PASSWORD: "${LANGFUSE_INIT_USER_PASSWORD}"
+    ports:
+      - "127.0.0.1:${LANGFUSE_PORT:-3006}:3000"
+    networks:
+      - default
+      - langfuse-internal
+    depends_on:
+      langfuse-postgres:
+        condition: service_healthy
+      langfuse-clickhouse:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://$$HOSTNAME:3000/api/public/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 90s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1g
+        reservations:
+          cpus: '0.25'
+          memory: 256m
+
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3.159.0
+    container_name: dream-langfuse-worker
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      DATABASE_URL: "postgresql://langfuse:${LANGFUSE_DB_PASSWORD}@langfuse-postgres:5432/langfuse"
+      CLICKHOUSE_MIGRATION_URL: "clickhouse://langfuse-clickhouse:9000"
+      CLICKHOUSE_URL: "http://langfuse-clickhouse:8123"
+      CLICKHOUSE_USER: "langfuse"
+      CLICKHOUSE_PASSWORD: "${LANGFUSE_CLICKHOUSE_PASSWORD}"
+      REDIS_HOST: "langfuse-redis"
+      REDIS_AUTH: "${LANGFUSE_REDIS_PASSWORD}"
+      LANGFUSE_S3_EVENT_UPLOAD_ENABLED: "true"
+      LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT: "http://langfuse-minio:9000"
+      LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID: "${LANGFUSE_MINIO_ACCESS_KEY}"
+      LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY: "${LANGFUSE_MINIO_SECRET_KEY}"
+      LANGFUSE_S3_EVENT_UPLOAD_BUCKET: "langfuse-events"
+      LANGFUSE_S3_EVENT_UPLOAD_REGION: "us-east-1"
+      LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE: "true"
+      CLICKHOUSE_CLUSTER_ENABLED: "false"
+      SALT: "${LANGFUSE_SALT}"
+      ENCRYPTION_KEY: "${LANGFUSE_ENCRYPTION_KEY}"
+      TELEMETRY_ENABLED: "false"
+      NEXT_TELEMETRY_DISABLED: "1"
+    networks:
+      - langfuse-internal
+    depends_on:
+      langfuse-postgres:
+        condition: service_healthy
+      langfuse-clickhouse:
+        condition: service_healthy
+      langfuse-redis:
+        condition: service_healthy
+      langfuse-minio:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://$$HOSTNAME:3030/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 1g
+        reservations:
+          cpus: '0.25'
+          memory: 256m
+
+  langfuse-postgres:
+    image: postgres:17.9-alpine
+    container_name: dream-langfuse-postgres
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      POSTGRES_USER: "langfuse"
+      POSTGRES_PASSWORD: "${LANGFUSE_DB_PASSWORD}"
+      POSTGRES_DB: "langfuse"
+    volumes:
+      - ./data/langfuse/postgres:/var/lib/postgresql/data
+    networks:
+      - langfuse-internal
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "langfuse"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512m
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+  langfuse-clickhouse:
+    image: clickhouse/clickhouse-server:26.2.4.23
+    container_name: dream-langfuse-clickhouse
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      CLICKHOUSE_USER: "langfuse"
+      CLICKHOUSE_PASSWORD: "${LANGFUSE_CLICKHOUSE_PASSWORD}"
+    volumes:
+      - ./data/langfuse/clickhouse:/var/lib/clickhouse
+    networks:
+      - langfuse-internal
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    healthcheck:
+      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "http://localhost:8123/ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 90s
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 2g
+        reservations:
+          cpus: '0.5'
+          memory: 256m
+
+  langfuse-redis:
+    image: redis:7.4.8-alpine
+    container_name: dream-langfuse-redis
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      LANGFUSE_REDIS_PASSWORD: "${LANGFUSE_REDIS_PASSWORD}"
+    command: redis-server --requirepass ${LANGFUSE_REDIS_PASSWORD}
+    volumes:
+      - ./data/langfuse/redis:/data
+    networks:
+      - langfuse-internal
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli -a $${LANGFUSE_REDIS_PASSWORD} ping"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 512m
+        reservations:
+          cpus: '0.1'
+          memory: 64m
+
+  langfuse-minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: dream-langfuse-minio
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: "${LANGFUSE_MINIO_ACCESS_KEY}"
+      MINIO_ROOT_PASSWORD: "${LANGFUSE_MINIO_SECRET_KEY}"
+      MINIO_TELEMETRY_DISABLED: "1"
+    volumes:
+      - ./data/langfuse/minio:/data
+    networks:
+      - langfuse-internal
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9000/minio/health/live"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 60s
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256m
+        reservations:
+          cpus: '0.1'
+          memory: 128m
+
+networks:
+  langfuse-internal:
+    internal: true

--- a/dream-server/extensions/services/langfuse/manifest.yaml
+++ b/dream-server/extensions/services/langfuse/manifest.yaml
@@ -1,0 +1,31 @@
+schema_version: dream.services.v1
+
+service:
+  id: langfuse
+  name: Langfuse (LLM Observability)
+  aliases: [observability, traces]
+  container_name: dream-langfuse-web
+  default_host: langfuse-web
+  port: 3000
+  external_port_env: LANGFUSE_PORT
+  external_port_default: 3006
+  health: /api/public/health
+  type: docker
+  gpu_backends: [amd, nvidia]
+  compose_file: compose.yaml
+  category: optional
+
+features:
+  - id: observability
+    name: LLM Observability
+    description: Full traces, evaluations, and prompt management for all LLM calls
+    icon: BarChart2
+    category: monitoring
+    requirements:
+      services: [langfuse]
+      services_any: [litellm]
+    enabled_services_all: [langfuse]
+    enabled_services_any: []
+    setup_time: ~2 minutes
+    priority: 10
+    gpu_backends: [amd, nvidia]

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -282,6 +282,10 @@ else
     mkdir -p "${INSTALL_DIR}/data/n8n"
     mkdir -p "${INSTALL_DIR}/data/qdrant"
     mkdir -p "${INSTALL_DIR}/data/models"
+    mkdir -p "${INSTALL_DIR}/data/langfuse/postgres"
+    mkdir -p "${INSTALL_DIR}/data/langfuse/clickhouse"
+    mkdir -p "${INSTALL_DIR}/data/langfuse/redis"
+    mkdir -p "${INSTALL_DIR}/data/langfuse/minio"
     mkdir -p "${INSTALL_DIR}/bin"
     ai_ok "Created directory structure"
 

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -62,6 +62,33 @@ generate_dream_env() {
     opencode_password=$(new_secure_base64 16)
     local searxng_secret
     searxng_secret=$(new_secure_hex 32)
+    # Langfuse (LLM Observability)
+    # NOTE: macOS env-generator always regenerates secrets (no merge logic).
+    # If reinstalling with existing Langfuse data, run: rm -rf data/langfuse/
+    local langfuse_nextauth_secret
+    langfuse_nextauth_secret=$(new_secure_hex 32)
+    local langfuse_salt
+    langfuse_salt=$(new_secure_hex 32)
+    local langfuse_encryption_key
+    langfuse_encryption_key=$(new_secure_hex 32)
+    local langfuse_db_password
+    langfuse_db_password=$(new_secure_hex 16)
+    local langfuse_clickhouse_password
+    langfuse_clickhouse_password=$(new_secure_hex 16)
+    local langfuse_redis_password
+    langfuse_redis_password=$(new_secure_hex 16)
+    local langfuse_minio_access_key
+    langfuse_minio_access_key=$(new_secure_hex 16)
+    local langfuse_minio_secret_key
+    langfuse_minio_secret_key=$(new_secure_hex 32)
+    local langfuse_project_public_key
+    langfuse_project_public_key="pk-lf-dream-$(new_secure_hex 16)"
+    local langfuse_project_secret_key
+    langfuse_project_secret_key="sk-lf-dream-$(new_secure_hex 16)"
+    local langfuse_init_project_id
+    langfuse_init_project_id=$(new_secure_hex 16)
+    local langfuse_init_user_password
+    langfuse_init_user_password=$(new_secure_hex 16)
     # macOS: llama-server runs natively, containers reach it via host.docker.internal
     local llm_api_url="http://host.docker.internal:8080"
 
@@ -104,6 +131,7 @@ QDRANT_GRPC_PORT=6334
 LITELLM_PORT=4000
 OPENCLAW_PORT=7860
 SEARXNG_PORT=8888
+LANGFUSE_PORT=3006
 
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=${webui_secret}
@@ -134,6 +162,22 @@ N8N_AUTH=true
 N8N_HOST=localhost
 N8N_WEBHOOK_URL=http://localhost:5678
 TIMEZONE=${tz}
+
+#=== Langfuse (LLM Observability) ===
+LANGFUSE_ENABLED=false
+LANGFUSE_NEXTAUTH_SECRET=${langfuse_nextauth_secret}
+LANGFUSE_SALT=${langfuse_salt}
+LANGFUSE_ENCRYPTION_KEY=${langfuse_encryption_key}
+LANGFUSE_DB_PASSWORD=${langfuse_db_password}
+LANGFUSE_CLICKHOUSE_PASSWORD=${langfuse_clickhouse_password}
+LANGFUSE_REDIS_PASSWORD=${langfuse_redis_password}
+LANGFUSE_MINIO_ACCESS_KEY=${langfuse_minio_access_key}
+LANGFUSE_MINIO_SECRET_KEY=${langfuse_minio_secret_key}
+LANGFUSE_PROJECT_PUBLIC_KEY=${langfuse_project_public_key}
+LANGFUSE_PROJECT_SECRET_KEY=${langfuse_project_secret_key}
+LANGFUSE_INIT_PROJECT_ID=${langfuse_init_project_id}
+LANGFUSE_INIT_USER_EMAIL=admin@dreamserver.local
+LANGFUSE_INIT_USER_PASSWORD=${langfuse_init_user_password}
 ENVEOF
 
     # Restrict .env to current user only (chmod 600)

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -36,6 +36,7 @@ else
     # Create directories
     mkdir -p "$INSTALL_DIR"/{config,data,models}
     mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models}
+    mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
     # Copy entire source tree to install dir (skip if same directory)
@@ -246,6 +247,23 @@ MODELS_EOF
     QDRANT_API_KEY=$(_env_get QDRANT_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
     OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
 
+    # Langfuse (LLM Observability)
+    LANGFUSE_PORT=$(_env_get LANGFUSE_PORT "3006")
+    LANGFUSE_ENABLED=$(_env_get LANGFUSE_ENABLED "false")
+    LANGFUSE_NEXTAUTH_SECRET=$(_env_get LANGFUSE_NEXTAUTH_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    LANGFUSE_SALT=$(_env_get LANGFUSE_SALT "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    LANGFUSE_ENCRYPTION_KEY=$(_env_get LANGFUSE_ENCRYPTION_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    LANGFUSE_DB_PASSWORD=$(_env_get LANGFUSE_DB_PASSWORD "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LANGFUSE_CLICKHOUSE_PASSWORD=$(_env_get LANGFUSE_CLICKHOUSE_PASSWORD "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LANGFUSE_REDIS_PASSWORD=$(_env_get LANGFUSE_REDIS_PASSWORD "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LANGFUSE_MINIO_ACCESS_KEY=$(_env_get LANGFUSE_MINIO_ACCESS_KEY "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LANGFUSE_MINIO_SECRET_KEY=$(_env_get LANGFUSE_MINIO_SECRET_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    LANGFUSE_PROJECT_PUBLIC_KEY=$(_env_get LANGFUSE_PROJECT_PUBLIC_KEY "pk-lf-dream-$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LANGFUSE_PROJECT_SECRET_KEY=$(_env_get LANGFUSE_PROJECT_SECRET_KEY "sk-lf-dream-$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LANGFUSE_INIT_PROJECT_ID=$(_env_get LANGFUSE_INIT_PROJECT_ID "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+    LANGFUSE_INIT_USER_EMAIL=$(_env_get LANGFUSE_INIT_USER_EMAIL "admin@dreamserver.local")
+    LANGFUSE_INIT_USER_PASSWORD=$(_env_get LANGFUSE_INIT_USER_PASSWORD "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
+
     # Preserve user-supplied cloud API keys
     ANTHROPIC_API_KEY=$(_env_get ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}")
     OPENAI_API_KEY=$(_env_get OPENAI_API_KEY "${OPENAI_API_KEY:-}")
@@ -295,6 +313,7 @@ QDRANT_GRPC_PORT=6334
 LITELLM_PORT=4000
 OPENCLAW_PORT=7860
 SEARXNG_PORT=8888
+LANGFUSE_PORT=${LANGFUSE_PORT}
 
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=${WEBUI_SECRET}
@@ -324,6 +343,22 @@ N8N_AUTH=true
 N8N_HOST=localhost
 N8N_WEBHOOK_URL=http://localhost:5678
 TIMEZONE=${SYSTEM_TZ:-UTC}
+
+#=== Langfuse (LLM Observability) ===
+LANGFUSE_ENABLED=${LANGFUSE_ENABLED}
+LANGFUSE_NEXTAUTH_SECRET=${LANGFUSE_NEXTAUTH_SECRET}
+LANGFUSE_SALT=${LANGFUSE_SALT}
+LANGFUSE_ENCRYPTION_KEY=${LANGFUSE_ENCRYPTION_KEY}
+LANGFUSE_DB_PASSWORD=${LANGFUSE_DB_PASSWORD}
+LANGFUSE_CLICKHOUSE_PASSWORD=${LANGFUSE_CLICKHOUSE_PASSWORD}
+LANGFUSE_REDIS_PASSWORD=${LANGFUSE_REDIS_PASSWORD}
+LANGFUSE_MINIO_ACCESS_KEY=${LANGFUSE_MINIO_ACCESS_KEY}
+LANGFUSE_MINIO_SECRET_KEY=${LANGFUSE_MINIO_SECRET_KEY}
+LANGFUSE_PROJECT_PUBLIC_KEY=${LANGFUSE_PROJECT_PUBLIC_KEY}
+LANGFUSE_PROJECT_SECRET_KEY=${LANGFUSE_PROJECT_SECRET_KEY}
+LANGFUSE_INIT_PROJECT_ID=${LANGFUSE_INIT_PROJECT_ID}
+LANGFUSE_INIT_USER_EMAIL=${LANGFUSE_INIT_USER_EMAIL}
+LANGFUSE_INIT_USER_PASSWORD=${LANGFUSE_INIT_USER_PASSWORD}
 ENV_EOF
 
     chmod 600 "$INSTALL_DIR/.env"  # Secure secrets file

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -35,4 +35,17 @@ for s in scripts/build-capability-profile.sh scripts/classify-hardware.sh script
   test -x "$s" || { echo "[FAIL] script not executable: $s"; exit 1; }
 done
 
+echo "[contract] Langfuse telemetry suppression"
+grep -q 'TELEMETRY_ENABLED.*false' extensions/services/langfuse/compose.yaml.disabled 2>/dev/null || \
+  grep -q 'TELEMETRY_ENABLED.*false' extensions/services/langfuse/compose.yaml 2>/dev/null || \
+  { echo "[FAIL] Langfuse app telemetry not disabled"; exit 1; }
+
+grep -q 'NEXT_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml.disabled 2>/dev/null || \
+  grep -q 'NEXT_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml 2>/dev/null || \
+  { echo "[FAIL] Next.js telemetry not disabled"; exit 1; }
+
+grep -q 'MINIO_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml.disabled 2>/dev/null || \
+  grep -q 'MINIO_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml 2>/dev/null || \
+  { echo "[FAIL] MinIO telemetry not disabled"; exit 1; }
+
 echo "[PASS] installer contracts"


### PR DESCRIPTION
## What
Add Langfuse as an opt-in LLM observability extension under `extensions/services/langfuse/`. Ships disabled — users enable via `dream enable langfuse`.

## Why
DreamServer has no centralized observability for LLM inference traffic. Langfuse provides full traces, token counts, latency, cost estimates, and prompt management — all stored locally (privacy-first).

## How
- 6-container stack: langfuse-web, worker, postgres, clickhouse, redis, minio
- All images pinned to exact semver with ARM64 support
- Network isolation: `langfuse-internal` (internal:true) for infra containers
- Privacy: `TELEMETRY_ENABLED=false`, `NEXT_TELEMETRY_DISABLED=1`, `MINIO_TELEMETRY_DISABLED=1` (hardcoded)
- 15 env vars registered in `.env.schema.json`, generated by both Linux and macOS installers
- Contract tests assert all 3 telemetry vectors are suppressed
- Gitleaks rules detect `pk-lf-*` and `sk-lf-*` key patterns

## Three Pillars Impact
- **Install Reliability:** Zero impact on default install (opt-in only). Secrets generated idempotently via `_env_get` on Linux. macOS regenerates (documented).
- **Broad Compatibility:** All images ARM64-confirmed. 16GB minimum when enabled, 32GB recommended. ClickHouse capped at 2GB.
- **Extension Coherence:** Follows `dream.services.v1` manifest pattern, `dream-*` container naming, standard enable/disable mechanism.

## New Files
- `extensions/services/langfuse/manifest.yaml` — service manifest with observability feature
- `extensions/services/langfuse/compose.yaml.disabled` — 6-container compose (shipped disabled)
- `.gitleaks.toml` — secret detection rules for Langfuse key patterns

## Modified Files
- `.env.schema.json` — 15 `LANGFUSE_*` entries
- `.env.example` — `LANGFUSE_PORT=3006`, `LANGFUSE_ENABLED=false`
- `installers/phases/06-directories.sh` — secret generation + data dirs
- `installers/macos/lib/env-generator.sh` — macOS secret generation
- `installers/macos/install-macos.sh` — macOS data dir creation
- `tests/contracts/test-installer-contracts.sh` — 3 telemetry assertions

## Testing
### Verified end-to-end on Apple Silicon (M4 Mac Mini)
- All 6 containers reach healthy status
- `curl localhost:3006/api/public/health` → `{"status":"OK","version":"3.159.0"}`
- Pre-seeded admin user and "DreamServer Traces" project created via headless init
- Trace ingestion via API confirmed working
- MinIO bucket creation and S3 event upload functional

### Automated
- shellcheck, make lint, docker compose config (nvidia + amd): all pass
- Contract tests pass (including new Langfuse telemetry assertions)
- Pre-commit hooks pass

## Known Limitations
- Memory ceiling ~5.25GB when enabled — requires 16GB+ system RAM
- macOS reinstall regenerates secrets — requires `rm -rf data/langfuse/` if data exists
- ClickHouse ARM64 migration stability unconfirmed (upstream Issue #4683)

## Platform Impact
| Platform | Status |
|----------|--------|
| Linux (NVIDIA) | Supported |
| Linux (AMD) | Supported |
| macOS (Apple Silicon) | Supported (verified on M4) |
| Windows (WSL2) | Expected to work (not tested) |

## Sequence
PR 1 of 2 for Langfuse integration. PR 2 (LiteLLM wiring + dashboard) depends on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)