### PR TITLE
docs: update hardware requirements for Tier 0 support

### DIFF
--- a/dream-server/docs/FAQ.md
+++ b/dream-server/docs/FAQ.md
@@ -10,7 +10,13 @@ Quick answers to common questions.
 
 ### What hardware do I need?
 
-**Minimum (functional but slow):**
+**Lightweight (runs on anything):**
+- GPU: Any (or CPU-only)
+- RAM: 4GB+
+- Storage: 15GB free
+- Model: Qwen3.5 2B (auto-selected)
+
+**Minimum (comfortable):**
 - GPU: RTX 3060 12GB or RTX 4060 8GB
 - RAM: 32GB
 - Storage: 500GB NVMe SSD

--- a/dream-server/docs/HARDWARE-GUIDE.md
+++ b/dream-server/docs/HARDWARE-GUIDE.md
@@ -10,6 +10,7 @@ What to buy for local AI at different budgets.
 
 | Tier | GPU | RAM | What You Get |
 |------|-----|-----|--------------|
+| Lightweight (any) | Any GPU or CPU-only | 4GB+ | 2B model, personal chat |
 | Entry ($800-1,200) | RTX 3060 12GB | 32GB | 7B-14B models, basic chat |
 | Prosumer ($2,000-3,000) | RTX 4070 Ti Super 16GB | 64GB | 32B models, voice, 5-8 users |
 | Pro ($4,000-6,000) | RTX 4090 24GB | 128GB | 70B models, 10-20 users |
@@ -193,7 +194,7 @@ Rule: 2x your model size minimum
 ❌ **AMD discrete GPUs (RX 7900 etc.)** — ROCm support limited; AMD Strix Halo APUs are fully supported (see README)
 ❌ **Intel Arc** — Driver problems, limited support
 ❌ **Cloud GPUs (H100/A100)** — Can't buy, rental only
-❌ **8GB cards** — Too limited for serious use  
+⚠️ **8GB cards** — Limited to smaller models (2B-7B) but functional with Tier 0
 
 ---
 

--- a/dream-server/docs/WINDOWS-QUICKSTART.md
+++ b/dream-server/docs/WINDOWS-QUICKSTART.md
@@ -16,7 +16,7 @@ The Windows installer (`install.ps1`) checks your system readiness and generates
 Invoke-WebRequest -Uri "https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/install.ps1" -OutFile install.ps1; .\install.ps1
 ```
 
-**Prerequisites:** Windows 10 2004+ or Windows 11, NVIDIA GPU, 16GB+ RAM.
+**Prerequisites:** Windows 10 2004+ or Windows 11. NVIDIA GPU recommended but not required (CPU-only works with smaller models). 4GB+ RAM minimum, 16GB+ recommended.
 
 This will verify:
 - WSL2 is installed and set to version 2

--- a/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
+++ b/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
@@ -22,9 +22,9 @@
 
 **Required:**
 - Windows 10 (version 2004 or newer) OR Windows 11
-- NVIDIA graphics card (GPU) with 8GB+ memory
-- 16GB+ system RAM (32GB recommended)
-- 50GB free disk space
+- NVIDIA graphics card (GPU) recommended (CPU-only works with smaller models)
+- 4GB+ system RAM (16GB+ recommended, 32GB ideal)
+- 15GB+ free disk space (50GB recommended)
 - Internet connection
 
 **Not Required (Common Confusion):**


### PR DESCRIPTION
## Summary
- Following #284 (Tier 0 with Qwen3.5-2B), docs still told users they needed 16GB RAM and an 8GB GPU
- Updated 4 docs to reflect that DreamServer now runs on 4GB+ RAM with CPU-only:
  - **HARDWARE-GUIDE.md**: Added "Lightweight (any)" row to TL;DR table, softened "8GB cards too limited" to "functional with Tier 0"
  - **FAQ.md**: Added "Lightweight (runs on anything)" minimum spec section above the existing minimum
  - **WINDOWS-QUICKSTART.md**: Softened prerequisites — GPU recommended not required, 4GB+ minimum
  - **WINDOWS-TROUBLESHOOTING-GUIDE.md**: Lowered stated minimums to 4GB RAM, 15GB disk

## Test plan
- [ ] Verify all 4 docs render correctly on GitHub
- [ ] Confirm messaging is consistent with Tier 0 thresholds in tier-map.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)