### PR TITLE
fix: add compose.local.yaml for services with dependencies

### DIFF
--- a/dream-server/extensions/services/dashboard/compose.local.yaml
+++ b/dream-server/extensions/services/dashboard/compose.local.yaml
@@ -1,0 +1,5 @@
+services:
+  dashboard:
+    depends_on:
+      dashboard-api:
+        condition: service_healthy

--- a/dream-server/extensions/services/open-webui/compose.local.yaml
+++ b/dream-server/extensions/services/open-webui/compose.local.yaml
@@ -1,0 +1,5 @@
+services:
+  open-webui:
+    depends_on:
+      llama-server:
+        condition: service_healthy

--- a/dream-server/extensions/services/privacy-shield/compose.local.yaml
+++ b/dream-server/extensions/services/privacy-shield/compose.local.yaml
@@ -1,0 +1,5 @@
+services:
+  privacy-shield:
+    depends_on:
+      llama-server:
+        condition: service_healthy


### PR DESCRIPTION
Adds compose.local.yaml files for three services that declare dependencies in their manifests but were missing the local mode override. This fixes broken local development where Docker Compose doesn't wait for dependencies to be healthy without explicit condition: service_healthy.

Services fixed:
- dashboard (core) - depends on dashboard-api
- open-webui (core) - depends on llama-server
- privacy-shield (optional) - depends on llama-server

Follows the established pattern from litellm, openclaw, and perplexica. Local mode now works correctly for all services with dependencies.

Total LOC: 15 lines (5 lines × 3 files)

Testing:
- YAML syntax validated
- make lint passes
- Service registry tests pass