### PR TITLE
feat: add download robustness to macOS installer

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -360,43 +360,26 @@ else
 
         if [[ -f "$MODEL_PATH" ]]; then
             # Verify integrity if hash is available
-            if [[ -n "$GGUF_SHA256" ]]; then
-                ai "Verifying model integrity (SHA256)..."
-                ACTUAL_HASH=$(shasum -a 256 "$MODEL_PATH" 2>/dev/null | awk '{print $1}')
-                if [[ "$ACTUAL_HASH" == "$GGUF_SHA256" ]]; then
-                    ai_ok "Model verified: ${GGUF_FILE}"
-                else
-                    ai_warn "Model file is corrupt (hash mismatch)."
-                    ai "  Expected: ${GGUF_SHA256}"
-                    ai "  Got:      ${ACTUAL_HASH}"
-                    ai "Removing corrupt file and re-downloading..."
-                    rm -f "$MODEL_PATH"
-                fi
+            if verify_sha256 "$MODEL_PATH" "$GGUF_SHA256" "Model ${GGUF_FILE}"; then
+                ai_ok "Model already present and verified: ${GGUF_FILE}"
             else
-                ai_ok "Model already downloaded: ${GGUF_FILE}"
+                ai "Removing corrupt file and re-downloading..."
+                rm -f "$MODEL_PATH"
             fi
         fi
 
         if [[ ! -f "$MODEL_PATH" ]]; then
-            download_with_progress "$GGUF_URL" "$MODEL_PATH" "Downloading ${GGUF_FILE}" || {
-                ai_err "Model download failed. Re-run the installer to resume."
+            # Download with retry logic (built into download_with_progress)
+            if ! download_with_progress "$GGUF_URL" "$MODEL_PATH" "Downloading ${GGUF_FILE}"; then
+                ai_err "Model download failed after retries. Re-run the installer to try again."
                 exit 1
-            }
+            fi
 
             # Verify freshly downloaded file
-            if [[ -n "$GGUF_SHA256" ]]; then
-                ai "Verifying download integrity (SHA256)..."
-                ACTUAL_HASH=$(shasum -a 256 "$MODEL_PATH" 2>/dev/null | awk '{print $1}')
-                if [[ "$ACTUAL_HASH" == "$GGUF_SHA256" ]]; then
-                    ai_ok "Download verified OK"
-                else
-                    ai_err "Downloaded file is corrupt (SHA256 mismatch)."
-                    ai "  Expected: ${GGUF_SHA256}"
-                    ai "  Got:      ${ACTUAL_HASH}"
-                    rm -f "$MODEL_PATH"
-                    ai_err "Re-run the installer to download again."
-                    exit 1
-                fi
+            if ! verify_sha256 "$MODEL_PATH" "$GGUF_SHA256" "Downloaded ${GGUF_FILE}"; then
+                rm -f "$MODEL_PATH"
+                ai_err "Downloaded file is corrupt. Re-run the installer to try again."
+                exit 1
             fi
         fi
     fi

--- a/dream-server/installers/macos/lib/ui.sh
+++ b/dream-server/installers/macos/lib/ui.sh
@@ -67,25 +67,89 @@ show_dream_banner() {
     echo ""
 }
 
-# Download with curl and resume support
+# Download with curl, resume support, and retry logic
 download_with_progress() {
     local url="$1"
     local destination="$2"
     local label="${3:-Downloading}"
+    local max_retries="${4:-3}"
 
-    ai "${label}..."
     local part_file="${destination}.part"
-    if curl -C - -L --progress-bar \
-        --connect-timeout 10 \
-        --speed-time 30 --speed-limit 10240 \
-        -o "$part_file" "$url"; then
-        mv "$part_file" "$destination"
-        ai_ok "${label} complete"
+    local attempt=1
+
+    while [[ $attempt -le $max_retries ]]; do
+        if [[ $attempt -gt 1 ]]; then
+            local wait_time=$((2 ** (attempt - 1)))  # Exponential backoff: 2, 4, 8 seconds
+            ai "Retry attempt $attempt of $max_retries (waiting ${wait_time}s)..."
+            sleep $wait_time
+        else
+            ai "${label}..."
+        fi
+
+        if curl -C - -L --progress-bar \
+            --connect-timeout 10 \
+            --speed-time 30 --speed-limit 10240 \
+            -o "$part_file" "$url"; then
+            mv "$part_file" "$destination"
+            ai_ok "${label} complete"
+            return 0
+        else
+            local rc=$?
+            if [[ $attempt -eq $max_retries ]]; then
+                ai_err "${label} failed after $max_retries attempts (curl exit code: ${rc})"
+                ai "Re-run the installer to resume the download."
+                return 1
+            else
+                ai_warn "${label} failed (attempt $attempt/$max_retries, curl exit code: ${rc})"
+            fi
+        fi
+
+        attempt=$((attempt + 1))
+    done
+}
+
+# Verify file integrity using SHA256 checksum
+verify_sha256() {
+    local file_path="$1"
+    local expected_hash="$2"
+    local label="${3:-File}"
+
+    if [[ ! -f "$file_path" ]]; then
+        ai_err "${label} not found: $file_path"
+        return 1
+    fi
+
+    if [[ -z "$expected_hash" ]]; then
+        ai_warn "No SHA256 hash provided for ${label}, skipping verification"
+        return 0
+    fi
+
+    ai "Verifying ${label} integrity (SHA256)..."
+
+    local actual_hash
+    if command -v shasum &>/dev/null; then
+        # macOS native shasum
+        actual_hash=$(shasum -a 256 "$file_path" 2>/dev/null | awk '{print $1}')
+    elif command -v sha256sum &>/dev/null; then
+        # GNU coreutils (if installed via Homebrew)
+        actual_hash=$(sha256sum "$file_path" 2>/dev/null | awk '{print $1}')
+    else
+        ai_warn "Neither shasum nor sha256sum available, skipping verification"
+        return 0
+    fi
+
+    if [[ -z "$actual_hash" ]]; then
+        ai_warn "Could not compute checksum for ${label}"
+        return 2
+    fi
+
+    if [[ "$actual_hash" == "$expected_hash" ]]; then
+        ai_ok "${label} verified OK"
         return 0
     else
-        local rc=$?
-        ai_err "${label} failed (curl exit code: ${rc})"
-        ai "Re-run the installer to resume the download."
+        ai_err "${label} is corrupt (SHA256 mismatch)"
+        ai "  Expected: $expected_hash"
+        ai "  Got:      $actual_hash"
         return 1
     fi
 }


### PR DESCRIPTION
## Summary
Adds retry logic and SHA256 verification to macOS installer downloads, bringing it to parity with the Linux installer's robustness.

## Changes
- Add retry logic with exponential backoff (2s, 4s, 8s) to `download_with_progress()`
- Add `verify_sha256()` function for integrity checking (supports shasum/sha256sum)
- Update model download logic to use new robust functions
- Handles network failures and corrupted downloads gracefully

## Testing
- Bash syntax validated
- Follows existing macOS installer patterns
- Compatible with macOS native `shasum` and Homebrew `sha256sum`

## Impact
- Prevents installation failures from transient network issues
- Detects corrupted downloads before extraction
- Improves UX with clear error messages and retry feedback

Total LOC: ~87 lines (47 new function code + 40 simplified download logic)