### PR TITLE
feat: add configurable health check timeouts to manifest schema

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -149,7 +149,8 @@ cmd_status() {
         # Launch health check in background
         (
             url="http://localhost:${port}${health}"
-            if curl -sf --max-time 5 "$url" > /dev/null 2>&1; then
+            timeout="${SERVICE_HEALTH_TIMEOUTS[$sid]:-5}"
+            if curl -sf --max-time "$timeout" "$url" > /dev/null 2>&1; then
                 echo "healthy|$name" > "$tmpdir/$sid"
             else
                 echo "unhealthy|$name" > "$tmpdir/$sid"

--- a/dream-server/extensions/services/comfyui/manifest.yaml
+++ b/dream-server/extensions/services/comfyui/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: COMFYUI_PORT
   external_port_default: 8188
   health: /
+  health_timeout: 30  # ComfyUI can be slow to start, especially on Tier 0/1 hardware
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/n8n/manifest.yaml
+++ b/dream-server/extensions/services/n8n/manifest.yaml
@@ -14,6 +14,7 @@ service:
   external_port_env: N8N_PORT
   external_port_default: 5678
   health: /healthz
+  health_timeout: 15  # n8n can take time to initialize database and workflows
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -19,6 +19,7 @@ declare -A SERVICE_COMPOSE      # service_id → compose file path
 declare -A SERVICE_CATEGORIES   # service_id → core|recommended|optional
 declare -A SERVICE_DEPENDS      # service_id → space-separated dependency IDs
 declare -A SERVICE_HEALTH       # service_id → health endpoint path
+declare -A SERVICE_HEALTH_TIMEOUTS  # service_id → health check timeout in seconds
 declare -A SERVICE_PORTS        # service_id → external port (what the user hits on localhost)
 declare -A SERVICE_PORT_ENVS    # service_id → env var name for the external port
 declare -A SERVICE_NAMES        # service_id → display name
@@ -126,9 +127,11 @@ for service_dir in sorted(ext_dir.iterdir()):
         print(f'SERVICE_CATEGORIES["{_esc(sid)}"]="{_esc(category)}"')
         print(f'SERVICE_DEPENDS["{_esc(sid)}"]="{_esc(" ".join(str(d) for d in depends))}"')
         health = s.get("health", "/health")
+        health_timeout = s.get("health_timeout", 5)  # Default 5 seconds
         port = s.get("external_port_default", s.get("port", 0))
         port_env = s.get("external_port_env", "")
         print(f'SERVICE_HEALTH["{_esc(sid)}"]="{_esc(health)}"')
+        print(f'SERVICE_HEALTH_TIMEOUTS["{_esc(sid)}"]="{_esc(health_timeout)}"')
         print(f'SERVICE_PORTS["{_esc(sid)}"]="{_esc(port)}"')
         print(f'SERVICE_PORT_ENVS["{_esc(sid)}"]="{_esc(port_env)}"')
         print(f'SERVICE_NAMES["{_esc(sid)}"]="{_esc(s.get("name", sid))}"')

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -117,6 +117,7 @@ test_service() {
     local port_env="${SERVICE_PORT_ENVS[$sid]}"
     local default_port="${SERVICE_PORTS[$sid]}"
     local health="${SERVICE_HEALTH[$sid]}"
+    local timeout="${SERVICE_HEALTH_TIMEOUTS[$sid]:-$TIMEOUT}"
 
     # Resolve port
     local port="$default_port"
@@ -124,7 +125,7 @@ test_service() {
 
     [[ -z "$health" || "$port" == "0" ]] && return 1
 
-    if curl -sf --max-time $TIMEOUT "http://localhost:${port}${health}" >/dev/null 2>&1; then
+    if curl -sf --max-time "$timeout" "http://localhost:${port}${health}" >/dev/null 2>&1; then
         result_set "$sid" "ok"
         return 0
     fi


### PR DESCRIPTION
## Summary
Adds optional `health_timeout` field to service manifest schema, allowing services to specify custom health check timeouts. Prevents false negatives on low-end hardware where services like ComfyUI and n8n can take longer to start.

## Changes
- Add `health_timeout` field to service manifest schema (defaults to 5s)
- Add `SERVICE_HEALTH_TIMEOUTS` associative array to service registry
- Update `dream-cli` to use service-specific timeouts in parallel health checks
- Update `scripts/health-check.sh` to use service-specific timeouts
- Set n8n timeout to 15s (database initialization can be slow)
- Set ComfyUI timeout to 30s (slow startup on Tier 0/1 hardware)

## Testing
- Bash syntax validated
- Backward compatible (defaults to 5s if not specified)
- No breaking changes to existing manifests

## Impact
- Prevents false "unhealthy" reports on Tier 0/1 hardware
- Improves reliability of health checks for slow-starting services
- Allows services to self-document their startup characteristics

Total LOC: ~9 lines (2 manifest updates + 7 implementation lines)