### PR TITLE
feat: add .dockerignore files to all custom Dockerfiles

### DIFF
--- a/dream-server/extensions/services/ape/.dockerignore
+++ b/dream-server/extensions/services/ape/.dockerignore
@@ -1,0 +1,56 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.venv/
+venv/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Logs
+*.log
+logs/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Tests
+tests/
+test_*.py
+*_test.py

--- a/dream-server/extensions/services/comfyui/.dockerignore
+++ b/dream-server/extensions/services/comfyui/.dockerignore
@@ -1,0 +1,71 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.venv/
+venv/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Logs
+*.log
+logs/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Tests
+tests/
+test_*.py
+*_test.py
+
+# ComfyUI specific - models are downloaded at runtime
+models/
+input/
+output/
+temp/
+user/
+
+# Large files that shouldn't be in build context
+*.safetensors
+*.ckpt
+*.pt
+*.pth
+*.bin
+*.onnx

--- a/dream-server/extensions/services/dashboard-api/.dockerignore
+++ b/dream-server/extensions/services/dashboard-api/.dockerignore
@@ -1,0 +1,63 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.venv/
+venv/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Logs
+*.log
+logs/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Tests
+tests/
+test_*.py
+*_test.py
+pytest.ini
+.pytest_cache/
+
+# Data (runtime generated)
+data/
+*.db
+*.sqlite

--- a/dream-server/extensions/services/dashboard/.dockerignore
+++ b/dream-server/extensions/services/dashboard/.dockerignore
@@ -1,0 +1,66 @@
+# Node
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.npm/
+.yarn/
+
+# Build outputs
+dist/
+build/
+.cache/
+.parcel-cache/
+.vite/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Logs
+*.log
+logs/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Tests
+tests/
+test/
+__tests__/
+*.test.js
+*.test.jsx
+*.test.ts
+*.test.tsx
+*.spec.js
+*.spec.jsx
+*.spec.ts
+*.spec.tsx
+coverage/
+
+# Source maps (not needed in production)
+*.map

--- a/dream-server/extensions/services/privacy-shield/.dockerignore
+++ b/dream-server/extensions/services/privacy-shield/.dockerignore
@@ -1,0 +1,62 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.venv/
+venv/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Logs
+*.log
+logs/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Tests
+tests/
+test_*.py
+*_test.py
+
+# Data (runtime generated)
+data/
+*.db
+*.sqlite
+sessions/

--- a/dream-server/extensions/services/token-spy/.dockerignore
+++ b/dream-server/extensions/services/token-spy/.dockerignore
@@ -1,0 +1,61 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+.venv/
+venv/
+ENV/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Documentation
+README.md
+*.md
+docs/
+
+# CI/CD
+.github/
+.gitlab-ci.yml
+.travis.yml
+
+# Logs
+*.log
+logs/
+
+# Environment
+.env
+.env.*
+!.env.example
+
+# Tests
+tests/
+test_*.py
+*_test.py
+
+# Data (runtime generated)
+data/
+*.db
+*.sqlite


### PR DESCRIPTION
## Summary
- Adds .dockerignore files to 6 services with custom Dockerfiles
- Improves build performance, security, and image size

## Changes
Added .dockerignore to:
- comfyui: Excludes models, temp files, large ML artifacts
- dashboard: Excludes node_modules, build artifacts, source maps
- dashboard-api: Excludes tests, venv, cache files
- token-spy: Excludes tests, data, cache files
- ape: Excludes tests, venv, cache files
- privacy-shield: Excludes tests, data, sessions, cache files

## Benefits
- Faster builds: Smaller Docker build context
- Security: Prevents accidental inclusion of sensitive files
- Smaller images: Excludes unnecessary files
- Better caching: Improves layer caching efficiency
