### PR TITLE
security: add checksum verification to restore operations

### DIFF
--- a/dream-server/dream-restore.sh
+++ b/dream-server/dream-restore.sh
@@ -99,6 +99,7 @@ OPTIONS:
     -s, --stop-containers   Stop containers before restore (recommended)
     --data-only             Restore only user data, not config
     --config-only           Restore only config, not user data
+    --skip-verify           Skip checksum verification (NOT RECOMMENDED)
 
 BACKUP_ID:
     The backup identifier to restore from (e.g., 20260212-071500)
@@ -232,6 +233,7 @@ extract_backup() {
 # Validate backup
 validate_backup() {
     local backup_dir="$1"
+    local skip_checksum="${2:-false}"
     local manifest="$backup_dir/manifest.json"
 
     log_step "Validating backup..."
@@ -257,6 +259,46 @@ validate_backup() {
     grep -E '"(backup_date|backup_type|dream_version|description)"' "$manifest" | \
         sed 's/^[[:space:]]*/  /' | sed 's/"//g' | sed 's/,//'
     echo ""
+
+    # Verify checksums (CRITICAL SECURITY CHECK)
+    if [[ "$skip_checksum" != "true" ]]; then
+        local checksum_file="$backup_dir/checksums.sha256"
+        if [[ -f "$checksum_file" ]]; then
+            log_info "Verifying backup integrity (SHA256)..."
+
+            local verify_cmd=""
+            if command -v sha256sum >/dev/null 2>&1; then
+                verify_cmd="sha256sum -c"
+            elif command -v shasum >/dev/null 2>&1; then
+                verify_cmd="shasum -a 256 -c"
+            else
+                log_warn "Neither sha256sum nor shasum available, skipping checksum verification"
+                log_warn "Use --skip-verify to suppress this warning"
+            fi
+
+            if [[ -n "$verify_cmd" ]]; then
+                (
+                    cd "$backup_dir"
+                    if $verify_cmd "checksums.sha256" >/dev/null 2>&1; then
+                        log_success "Backup integrity verified (all checksums match)"
+                    else
+                        log_error "Backup integrity check FAILED - checksums do not match"
+                        log_error "This backup may be corrupted or tampered with"
+                        log_error "Use --skip-verify to restore anyway (NOT RECOMMENDED)"
+                        return 1
+                    fi
+                )
+                if [[ $? -ne 0 ]]; then
+                    return 1
+                fi
+            fi
+        else
+            log_warn "No checksums.sha256 found in backup (older backup format)"
+            log_warn "Cannot verify backup integrity - proceed with caution"
+        fi
+    else
+        log_warn "Checksum verification SKIPPED (--skip-verify flag used)"
+    fi
 
     # Warn if backup looks partial / missing common paths.
     # (Informational only; older/minimal backups are still valid.)
@@ -441,6 +483,7 @@ do_restore() {
     local stop_first="$4"
     local restore_data="$5"
     local restore_config="$6"
+    local skip_verify="$7"
 
     log_info "Starting restore from backup: $backup_id"
 
@@ -453,8 +496,8 @@ do_restore() {
     local backup_dir
     backup_dir=$(extract_backup "$backup_id")
 
-    # Validate backup
-    if ! validate_backup "$backup_dir"; then
+    # Validate backup (with optional checksum verification)
+    if ! validate_backup "$backup_dir" "$skip_verify"; then
         log_error "Backup validation failed"
         return 1
     fi
@@ -512,6 +555,7 @@ main() {
     local restore_data="true"
     local restore_config="true"
     local list_mode="false"
+    local skip_verify="false"
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -537,11 +581,17 @@ main() {
                 shift
                 ;;
             --data-only)
+                restore_data="true"
                 restore_config="false"
                 shift
                 ;;
             --config-only)
                 restore_data="false"
+                restore_config="true"
+                shift
+                ;;
+            --skip-verify)
+                skip_verify="true"
                 shift
                 ;;
             -*)
@@ -585,7 +635,7 @@ main() {
     fi
 
     # Perform restore
-    do_restore "$backup_id" "$force" "$dry_run" "$stop_first" "$restore_data" "$restore_config"
+    do_restore "$backup_id" "$force" "$dry_run" "$stop_first" "$restore_data" "$restore_config" "$skip_verify"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
**CRITICAL SECURITY FIX**: Restore operations now verify backup integrity before restoring data. This prevents restoring corrupted or tampered backups.

## Changes
- Add SHA256 checksum verification to `validate_backup()`
- Verify all files match `checksums.sha256` before restore
- Add `--skip-verify` flag to bypass verification (NOT RECOMMENDED)
- Clear error messages when checksums don't match
- Backward compatible with older backups (warning only)

## Security Impact
- Prevents restoring corrupted backups (data integrity)
- Prevents restoring tampered backups (security)
- Detects incomplete/partial backup extractions
- Protects against supply chain attacks on backup files

## Testing
- Bash syntax validated
- Compatible with sha256sum (Linux) and shasum (macOS)
- Graceful fallback for systems without checksum tools

Total LOC: ~53 lines