### PR TITLE
feat: add bash completion for dream-cli

### DIFF
--- a/dream-server/completions/dream-cli.bash
+++ b/dream-server/completions/dream-cli.bash
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Bash completion for dream-cli
+# Source this file or place in /etc/bash_completion.d/ or ~/.local/share/bash-completion/completions/
+
+_dream_completion() {
+    local cur prev words cword
+    _init_completion || return
+
+    # Main commands and their aliases
+    local main_commands="status status-json list enable disable preset mode model backup restore logs restart start stop update shell config chat benchmark doctor help version"
+    local aliases="s ls p m l r u sh cfg c bench b diag d h v"
+
+    # Service names (from dream-cli aliases section)
+    local services="ape policy guard embeddings embed llama-server llm n8n workflows open-webui web ui webui opencode opencode-web qdrant vector searxng search tts kokoro whisper voice stt"
+
+    case $cword in
+        1)
+            # Complete main commands and aliases
+            COMPREPLY=($(compgen -W "$main_commands $aliases" -- "$cur"))
+            return 0
+            ;;
+        2)
+            case $prev in
+                preset|p)
+                    COMPREPLY=($(compgen -W "save load list delete export import" -- "$cur"))
+                    return 0
+                    ;;
+                mode|m)
+                    COMPREPLY=($(compgen -W "local cloud hybrid" -- "$cur"))
+                    return 0
+                    ;;
+                model)
+                    COMPREPLY=($(compgen -W "current list swap" -- "$cur"))
+                    return 0
+                    ;;
+                config|cfg)
+                    COMPREPLY=($(compgen -W "show edit validate" -- "$cur"))
+                    return 0
+                    ;;
+                backup)
+                    COMPREPLY=($(compgen -W "verify -c -l --compress --list" -- "$cur"))
+                    return 0
+                    ;;
+                doctor|diag|d)
+                    COMPREPLY=($(compgen -W "--json" -- "$cur"))
+                    return 0
+                    ;;
+                enable|disable|logs|log|l|restart|r|start|stop|shell|sh)
+                    # Complete with service names
+                    COMPREPLY=($(compgen -W "$services" -- "$cur"))
+                    return 0
+                    ;;
+                restore)
+                    # Complete with backup IDs (if .backups directory exists)
+                    local backup_dir="${DREAM_HOME:-$HOME/dream-server}/.backups"
+                    if [[ -d "$backup_dir" ]]; then
+                        local backup_ids=$(ls -1 "$backup_dir" 2>/dev/null | grep -E '^[0-9]{8}-[0-9]{6}' | sort -r)
+                        COMPREPLY=($(compgen -W "$backup_ids" -- "$cur"))
+                    fi
+                    return 0
+                    ;;
+            esac
+            ;;
+        3)
+            case "${words[1]}" in
+                preset|p)
+                    case $prev in
+                        save|load|delete)
+                            # Complete with existing preset names
+                            local preset_dir="${DREAM_HOME:-$HOME/dream-server}/.presets"
+                            if [[ -d "$preset_dir" ]]; then
+                                local presets=$(ls -1 "$preset_dir" 2>/dev/null | sed 's/\.preset$//')
+                                COMPREPLY=($(compgen -W "$presets" -- "$cur"))
+                            fi
+                            return 0
+                            ;;
+                        export)
+                            # Complete with existing preset names for export
+                            local preset_dir="${DREAM_HOME:-$HOME/dream-server}/.presets"
+                            if [[ -d "$preset_dir" ]]; then
+                                local presets=$(ls -1 "$preset_dir" 2>/dev/null | sed 's/\.preset$//')
+                                COMPREPLY=($(compgen -W "$presets" -- "$cur"))
+                            fi
+                            return 0
+                            ;;
+                        import)
+                            # Complete with .tar.gz files
+                            COMPREPLY=($(compgen -f -X '!*.tar.gz' -- "$cur"))
+                            return 0
+                            ;;
+                    esac
+                    ;;
+                model)
+                    case $prev in
+                        swap)
+                            # Complete with available tiers (0-4)
+                            COMPREPLY=($(compgen -W "0 1 2 3 4" -- "$cur"))
+                            return 0
+                            ;;
+                    esac
+                    ;;
+                backup)
+                    case $prev in
+                        verify)
+                            # Complete with backup IDs for verification
+                            local backup_dir="${DREAM_HOME:-$HOME/dream-server}/.backups"
+                            if [[ -d "$backup_dir" ]]; then
+                                local backup_ids=$(ls -1 "$backup_dir" 2>/dev/null | grep -E '^[0-9]{8}-[0-9]{6}' | sort -r)
+                                COMPREPLY=($(compgen -W "$backup_ids" -- "$cur"))
+                            fi
+                            return 0
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+        4)
+            case "${words[1]}" in
+                preset|p)
+                    case "${words[2]}" in
+                        export)
+                            # Complete with .tar.gz filename for export destination
+                            COMPREPLY=($(compgen -f -X '!*.tar.gz' -- "$cur"))
+                            return 0
+                            ;;
+                    esac
+                    ;;
+            esac
+            ;;
+    esac
+
+    # Default to no completion
+    return 0
+}
+
+# Register the completion function
+complete -F _dream_completion dream
+complete -F _dream_completion ./dream-cli
+
+# Also register for common installation paths
+complete -F _dream_completion ~/dream-server/dream-cli
+complete -F _dream_completion /opt/dream-server/dream-cli

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -181,6 +181,26 @@ DESKTOP_EOF
     ai_ok "Desktop shortcut created: Dream Server"
 fi
 
+#=============================================================================
+# Bash Completion Setup
+#=============================================================================
+if ! $DRY_RUN; then
+    COMPLETION_FILE="$INSTALL_DIR/completions/dream-cli.bash"
+    if [[ -f "$COMPLETION_FILE" ]]; then
+        # Add completion sourcing to .bashrc if not already present
+        if ! grep -q "dream-cli.bash" "$HOME/.bashrc" 2>/dev/null; then
+            cat >> "$HOME/.bashrc" << 'BASHRC_EOF'
+
+# Dream Server CLI bash completion
+if [[ -f "$HOME/dream-server/completions/dream-cli.bash" ]]; then
+    . "$HOME/dream-server/completions/dream-cli.bash"
+fi
+BASHRC_EOF
+            ai_ok "Bash completion enabled for dream-cli"
+        fi
+    fi
+fi
+
 echo ""
 signal "Broadcast stable. You're free now."
 echo ""


### PR DESCRIPTION
## Summary
- Adds comprehensive bash completion support for the `dream` CLI command
- Auto-installs during installer phase 13 by adding source line to `~/.bashrc`
- Improves CLI UX by reducing typing and preventing typos

## Features
- Completes all main commands and their aliases (status/s, list/ls, preset/p, etc.)
- Completes subcommands:
  - `preset save/load/list/delete/export/import`
  - `mode local/cloud/hybrid`
  - `model current/list/swap <tier>`
  - `config show/edit/validate`
  - `backup verify/--compress/--list`
- Completes service names for `enable/disable/logs/restart/start/stop/shell`
- Dynamically completes backup IDs from `.backups/` directory
- Dynamically completes preset names from `.presets/` directory
- Completes file paths for preset import/export operations

## Test plan
- [x] Created completion script with comprehensive command coverage
- [x] Added auto-installation to phase 13 of installer
- [ ] Test completion after fresh install: `dream <TAB><TAB>`
- [ ] Test service name completion: `dream logs <TAB><TAB>`
- [ ] Test backup ID completion: `dream restore <TAB><TAB>`
- [ ] Test preset name completion: `dream preset load <TAB><TAB>`