### PR TITLE
fix: add USER directive to token-spy Dockerfile for security hardening

### DIFF
--- a/dream-server/extensions/services/token-spy/Dockerfile
+++ b/dream-server/extensions/services/token-spy/Dockerfile
@@ -9,6 +9,11 @@ COPY . .
 
 RUN mkdir -p /app/data
 
+# Create non-root user
+RUN useradd -m -u 1000 dreamer && chown -R dreamer:dreamer /app
+
+USER dreamer
+
 EXPOSE 8080
 
 CMD ["sh", "-c", "uvicorn main:app --host 0.0.0.0 --port ${UVICORN_PORT:-8080} --log-level info"]


### PR DESCRIPTION
## Summary
- Adds non-root user execution to token-spy service
- Addresses security gap where token-spy was running as root

## Changes
- Creates 'dreamer' user (UID 1000) before switching context
- Sets proper ownership of /app directory
- Runs uvicorn as non-root user

## Context
Token-spy was the only Python service running as root. Other services (dashboard-api, privacy-shield, ape) already run as non-root users. This PR brings token-spy in line with the rest of the stack.

## Benefits
- Reduces attack surface by limiting container privileges
- Follows principle of least privilege
- Consistent with other services in the stack
- Aligns with container security best practices

## Test Plan
- Verified user creation and ownership changes
- Confirmed uvicorn can run as non-root on port 8080 (non-privileged)
- Follows same pattern as dashboard-api and other Python services
