### PR TITLE
feat: add automatic backup and rollback for updates

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -383,16 +383,61 @@ cmd_update() {
     local -a flags
     read -ra flags <<< "$flags_str"
 
+    # Create automatic backup before update
+    log "Creating pre-update backup..."
+    local backup_id
+    if backup_id=$("$INSTALL_DIR/dream-backup.sh" --type config --description "Pre-update backup $(date)" 2>&1 | grep -o '[0-9]\{8\}-[0-9]\{6\}' | tail -1); then
+        log "Pre-update backup created: $backup_id"
+        echo "$backup_id" > "$INSTALL_DIR/.last-backup-id"
+    else
+        log_warn "Failed to create pre-update backup, continuing anyway..."
+    fi
+
     log "Pulling latest images..."
-    docker compose "${flags[@]}" pull
+    if ! docker compose "${flags[@]}" pull; then
+        error "Failed to pull latest images"
+    fi
 
     log "Recreating containers with new images..."
-    docker compose "${flags[@]}" up -d --force-recreate
+    if ! docker compose "${flags[@]}" up -d --force-recreate; then
+        error "Failed to recreate containers. Run 'dream rollback' to restore previous state."
+    fi
 
-    success "Update complete"
+    log "Waiting for services to stabilize..."
+    sleep 10
 
-    log "Checking health..."
-    sleep 5
+    # Verify update was successful
+    log "Verifying update..."
+    local failed_services=0
+    local total_services=0
+
+    # Check each service health
+    while IFS= read -r service; do
+        [[ -z "$service" ]] && continue
+        ((total_services++))
+
+        local container
+        container=$(sr_container "$service" 2>/dev/null || echo "")
+        if [[ -n "$container" ]]; then
+            if ! docker ps --filter "name=$container" --filter "status=running" --format "{{.Names}}" | grep -q "^$container$"; then
+                log_warn "Service $service ($container) is not running"
+                ((failed_services++))
+            fi
+        fi
+    done < <(sr_list_enabled)
+
+    if [[ $failed_services -gt 0 ]]; then
+        log_error "Update verification failed: $failed_services/$total_services services are not running"
+        log_error "Run 'dream rollback' to restore previous state"
+        log_error "Or run 'dream status' to check service health"
+        exit 1
+    fi
+
+    success "Update complete and verified ($total_services services running)"
+
+    # Clean up backup ID file on successful update
+    rm -f "$INSTALL_DIR/.last-backup-id"
+
     cmd_status
 }
 
@@ -1356,6 +1401,61 @@ cmd_restore() {
     "$INSTALL_DIR/dream-restore.sh" "$@"
 }
 
+cmd_rollback() {
+    check_install
+    cd "$INSTALL_DIR"
+
+    if [[ ! -f "$INSTALL_DIR/.last-backup-id" ]]; then
+        error "No rollback point found. Rollback is only available after a failed update."
+    fi
+
+    local backup_id
+    backup_id=$(cat "$INSTALL_DIR/.last-backup-id")
+
+    if [[ -z "$backup_id" ]]; then
+        error "Invalid rollback point (empty backup ID)"
+    fi
+
+    log "Rolling back to pre-update state (backup: $backup_id)..."
+    echo ""
+    log_warn "This will restore configuration from before the last update."
+    read -p "Continue with rollback? [y/N] " -n 1 -r
+    echo ""
+
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        log "Rollback cancelled"
+        return 0
+    fi
+
+    # Stop services before rollback
+    log "Stopping services..."
+    local flags_str
+    flags_str=$(get_compose_flags)
+    local -a flags
+    read -ra flags <<< "$flags_str"
+    docker compose "${flags[@]}" down 2>/dev/null || true
+
+    # Restore from backup
+    if "$INSTALL_DIR/dream-restore.sh" "$backup_id"; then
+        success "Configuration restored from backup: $backup_id"
+
+        # Restart services with restored configuration
+        log "Restarting services with restored configuration..."
+        if docker compose "${flags[@]}" up -d; then
+            success "Rollback complete"
+            rm -f "$INSTALL_DIR/.last-backup-id"
+
+            log "Checking service health..."
+            sleep 5
+            cmd_status
+        else
+            error "Failed to restart services after rollback. Check 'docker compose logs' for details."
+        fi
+    else
+        error "Failed to restore from backup. Your system may be in an inconsistent state."
+    fi
+}
+
 cmd_help() {
     sr_load
     cat << EOF
@@ -1377,6 +1477,7 @@ ${CYAN}Commands:${NC}
   backup [options]    Create a backup of user data and config
   backup verify <id>   Verify checksum integrity for a backup
   restore [backup_id] Restore from a backup
+  rollback            Rollback to pre-update state (after failed update)
   logs <service>      Tail logs for a service
   restart [service]   Restart services (all if no service specified)
   start [service]     Start services
@@ -1449,6 +1550,7 @@ ${CYAN}Examples:${NC}
   dream backup verify <id>        # Verify backup integrity
   dream restore                   # Interactive restore
   dream restore 20260309-120000   # Restore specific backup
+  dream rollback                  # Rollback after failed update
   dream logs llm                  # Watch llama-server logs (via alias)
   dream restart stt               # Restart Whisper (via alias)
   dream chat "What is 2+2?"      # Quick LLM test
@@ -1475,6 +1577,7 @@ case "${1:-help}" in
     model)       shift; cmd_model "$@" ;;
     backup)      shift; cmd_backup "$@" ;;
     restore)     shift; cmd_restore "$@" ;;
+    rollback)    cmd_rollback ;;
     logs|log|l)  shift; cmd_logs "$@" ;;
     restart|r)   shift; cmd_restart "$@" ;;
     start)       shift; cmd_start "$@" ;;


### PR DESCRIPTION
## Summary
- Adds automatic config backup before updates
- Verifies service health after updates  
- Provides `dream rollback` command to restore pre-update state
- Prevents data loss from failed updates

## Features

### Automatic Pre-Update Backup
- `dream update` now creates a config backup before pulling new images
- Backup ID is stored in `.last-backup-id` for rollback reference
- Backup includes `.env`, compose files, and config directory

### Update Verification
- After recreating containers, verifies all enabled services are running
- If verification fails, displays error and suggests rollback
- On success, clears the backup ID file

### Rollback Command
- `dream rollback` restores configuration from pre-update backup
- Stops services, restores config, restarts with restored configuration
- Requires confirmation before proceeding
- Only available after an update (when `.last-backup-id` exists)

## Test plan
- [x] Added automatic backup to `cmd_update()`
- [x] Added service verification after update
- [x] Implemented `cmd_rollback()` command
- [x] Added rollback to CLI routing and help text
- [x] Syntax check passes
- [ ] Test update workflow on live system
- [ ] Test rollback after simulated failure
- [ ] Verify backup creation and restoration
