### PR TITLE
feat(installer): add Intel Arc SYCL tier map (ARC / ARC_LITE)

### DIFF
--- a/dream-server/docker-compose.intel.yml
+++ b/dream-server/docker-compose.intel.yml
@@ -1,0 +1,57 @@
+# Dream Server — Intel Arc GPU Overlay (SYCL backend)
+# Requires: Intel Arc GPU with oneAPI Level Zero runtime on host
+# Use with: docker compose -f docker-compose.base.yml -f docker-compose.intel.yml up -d
+#
+# Supported hardware:
+#   ARC tier      — Arc A770 16 GB  (and future Arc B-series ≥12 GB)
+#   ARC_LITE tier — Arc A750 8 GB, A380 6 GB
+#
+# Host prerequisites:
+#   apt install intel-opencl-icd intel-level-zero-gpu level-zero
+#   usermod -aG video,render $USER   (then re-login)
+#   # Verify: clinfo | grep -i "intel arc"
+
+services:
+  llama-server:
+    image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-intel-b8248}
+    devices:
+      - /dev/dri:/dev/dri
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-992}"
+    environment:
+      # Level Zero selects the Intel Arc GPU; persistent cache avoids
+      # recompiling SYCL kernels on every container start.
+      - ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+      - SYCL_CACHE_PERSISTENT=1
+      # Enable Intel GPU System Management Interface for telemetry
+      - ZES_ENABLE_SYSMAN=1
+    command:
+      - --model
+      - /models/${GGUF_FILE:-Qwen3-8B-Q4_K_M.gguf}
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+      - --n-gpu-layers
+      - "${N_GPU_LAYERS:-99}"
+      - --ctx-size
+      - "${CTX_SIZE:-32768}"
+      - --metrics
+    deploy:
+      resources:
+        limits:
+          cpus: '16.0'
+          memory: ${LLAMA_SERVER_MEMORY_LIMIT:-24G}
+        reservations:
+          cpus: '2.0'
+          memory: 4G
+
+  dashboard-api:
+    environment:
+      # Hard-code sycl backend so the dashboard uses Intel sysfs GPU detection
+      # regardless of .env state.
+      - GPU_BACKEND=sycl
+    volumes:
+      - /sys/class/drm:/sys/class/drm:ro
+      - /sys/class/hwmon:/sys/class/hwmon:ro

--- a/dream-server/installers/lib/compose-select.sh
+++ b/dream-server/installers/lib/compose-select.sh
@@ -56,6 +56,11 @@ resolve_compose_config() {
                 COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.amd.yml"
                 COMPOSE_FILE="docker-compose.amd.yml"
             fi
+        elif [[ "$TIER" == "ARC" || "$TIER" == "ARC_LITE" || "$GPU_BACKEND" == "intel" || "$GPU_BACKEND" == "sycl" ]]; then
+            if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.intel.yml" ]]; then
+                COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.intel.yml"
+                COMPOSE_FILE="docker-compose.intel.yml"
+            fi
         else
             if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.nvidia.yml" ]]; then
                 COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.nvidia.yml"

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -51,7 +51,7 @@ normalize_profile_tier() {
         T2) echo "2" ;;
         T3) echo "3" ;;
         T4) echo "4" ;;
-        NV_ULTRA|SH_LARGE|SH_COMPACT) echo "$1" ;;
+        NV_ULTRA|SH_LARGE|SH_COMPACT|ARC|ARC_LITE) echo "$1" ;;
         *) echo "" ;;
     esac
 }
@@ -61,8 +61,8 @@ tier_rank() {
         NV_ULTRA|SH_LARGE) echo 5 ;;
         4) echo 4 ;;
         SH_COMPACT|3) echo 3 ;;
-        2) echo 2 ;;
-        1) echo 1 ;;
+        ARC|2) echo 2 ;;
+        ARC_LITE|1) echo 1 ;;
         0) echo 0 ;;
         *) echo 1 ;;
     esac

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -24,6 +24,30 @@ resolve_tier_config() {
             GGUF_SHA256=""
             MAX_CONTEXT=200000
             ;;
+        ARC)
+            # Intel Arc A770 (16 GB) and future Arc B-series (≥12 GB VRAM)
+            # llama.cpp SYCL backend: N_GPU_LAYERS=99 offloads all layers to GPU
+            TIER_NAME="Intel Arc"
+            LLM_MODEL="qwen3-8b"
+            GGUF_FILE="Qwen3-8B-Q4_K_M.gguf"
+            GGUF_URL="https://huggingface.co/unsloth/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q4_K_M.gguf"
+            GGUF_SHA256="120307ba529eb2439d6c430d94104dabd578497bc7bfe7e322b5d9933b449bd4"
+            MAX_CONTEXT=32768
+            GPU_BACKEND="sycl"
+            N_GPU_LAYERS=99
+            ;;
+        ARC_LITE)
+            # Intel Arc A750 (8 GB), A380 (6 GB) — smaller VRAM, lighter model
+            # llama.cpp SYCL backend: N_GPU_LAYERS=99 offloads all layers to GPU
+            TIER_NAME="Intel Arc Lite"
+            LLM_MODEL="qwen3-4b"
+            GGUF_FILE="Qwen3-4B-Q4_K_M.gguf"
+            GGUF_URL="https://huggingface.co/unsloth/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf"
+            GGUF_SHA256="f6f851777709861056efcdad3af01da38b31223a3ba26e61a4f8bf3a2195813a"
+            MAX_CONTEXT=16384
+            GPU_BACKEND="sycl"
+            N_GPU_LAYERS=99
+            ;;
         NV_ULTRA)
             TIER_NAME="NVIDIA Ultra (90GB+)"
             LLM_MODEL="qwen3-coder-next"
@@ -89,7 +113,7 @@ resolve_tier_config() {
             MAX_CONTEXT=131072
             ;;
         *)
-            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT"
+            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE"
             # NOTE for modders: add your tier above this line and update this message.
             ;;
     esac
@@ -99,15 +123,17 @@ resolve_tier_config() {
 tier_to_model() {
     local t="$1"
     case "$t" in
-        CLOUD)      echo "anthropic/claude-sonnet-4-5-20250514" ;;
-        NV_ULTRA)   echo "qwen3-coder-next" ;;
-        SH_LARGE)   echo "qwen3-coder-next" ;;
-        SH_COMPACT|SH) echo "qwen3-30b-a3b" ;;
-        0|T0)       echo "qwen3.5-2b" ;;
-        1|T1)       echo "qwen3-8b" ;;
-        2|T2)       echo "qwen3-8b" ;;
-        3|T3)       echo "qwen3-14b" ;;
-        4|T4)       echo "qwen3-30b-a3b" ;;
-        *)          echo "" ;;
+        CLOUD)          echo "anthropic/claude-sonnet-4-5-20250514" ;;
+        NV_ULTRA)       echo "qwen3-coder-next" ;;
+        SH_LARGE)       echo "qwen3-coder-next" ;;
+        SH_COMPACT|SH)  echo "qwen3-30b-a3b" ;;
+        ARC)            echo "qwen3-8b" ;;
+        ARC_LITE)       echo "qwen3-4b" ;;
+        0|T0)           echo "qwen3.5-2b" ;;
+        1|T1)           echo "qwen3-8b" ;;
+        2|T2)           echo "qwen3-8b" ;;
+        3|T3)           echo "qwen3-14b" ;;
+        4|T4)           echo "qwen3-30b-a3b" ;;
+        *)              echo "" ;;
     esac
 }

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -192,6 +192,15 @@ if [[ -z "$TIER" ]]; then
     PROFILE_TIER="$(normalize_profile_tier "${CAP_RECOMMENDED_TIER:-}")"
     if [[ -n "$PROFILE_TIER" ]]; then
         TIER="$PROFILE_TIER"
+    elif [[ "$GPU_BACKEND" == "intel" ]]; then
+        # Intel Arc discrete GPU (SYCL backend via llama.cpp)
+        # A770 = 16 GB → ARC; A750 = 8 GB, A380 = 6 GB → ARC_LITE
+        arc_vram_gb=$((GPU_VRAM / 1024))
+        if [[ $arc_vram_gb -ge 12 ]]; then
+            TIER="ARC"
+        else
+            TIER="ARC_LITE"
+        fi
     elif [[ "$GPU_BACKEND" == "amd" && "$GPU_MEMORY_TYPE" == "unified" ]]; then
         # Strix Halo binary tier system
         unified_gb=$((GPU_VRAM / 1024))
@@ -247,6 +256,8 @@ if [[ "$INTERACTIVE" == "true" ]]; then
         NV_ULTRA)   SPEED_EST=50; USERS_EST="10-20" ;;
         SH_LARGE)   SPEED_EST=40; USERS_EST="5-10" ;;
         SH_COMPACT) SPEED_EST=80; USERS_EST="5-10" ;;
+        ARC)        SPEED_EST=35; USERS_EST="3-5" ;;
+        ARC_LITE)   SPEED_EST=20; USERS_EST="1-2" ;;
         0) SPEED_EST=50; USERS_EST="1" ;;
         1) SPEED_EST=25; USERS_EST="1-2" ;;
         2) SPEED_EST=45; USERS_EST="3-5" ;;

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -272,6 +272,7 @@ GGUF_FILE=${GGUF_FILE}
 MAX_CONTEXT=${MAX_CONTEXT}
 CTX_SIZE=${MAX_CONTEXT}
 GPU_BACKEND=${GPU_BACKEND}
+N_GPU_LAYERS=${N_GPU_LAYERS:-99}
 
 $(if [[ "$GPU_BACKEND" == "amd" ]]; then cat << AMD_ENV
 #=== GPU Group IDs (for container device access) ===
@@ -282,6 +283,17 @@ RENDER_GID=$(getent group render 2>/dev/null | cut -d: -f3 || echo 992)
 HSA_OVERRIDE_GFX_VERSION=11.5.1
 ROCBLAS_USE_HIPBLASLT=0
 AMD_ENV
+fi)
+$(if [[ "$GPU_BACKEND" == "sycl" ]]; then cat << INTEL_ENV
+#=== GPU Group IDs (for container device access) ===
+VIDEO_GID=$(getent group video 2>/dev/null | cut -d: -f3 || echo 44)
+RENDER_GID=$(getent group render 2>/dev/null | cut -d: -f3 || echo 992)
+
+#=== Intel Arc / oneAPI SYCL Settings ===
+ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+SYCL_CACHE_PERSISTENT=1
+ZES_ENABLE_SYSMAN=1
+INTEL_ENV
 fi)
 
 #=== Ports ===

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -36,6 +36,7 @@ run_tier() {
     TIER="$tier_val"
     # Reset globals
     TIER_NAME="" LLM_MODEL="" GGUF_FILE="" GGUF_URL="" MAX_CONTEXT=""
+    GPU_BACKEND="" N_GPU_LAYERS=""
     resolve_tier_config
 }
 
@@ -113,6 +114,28 @@ assert_eq "GGUF_FILE"   "Qwen3-30B-A3B-Q4_K_M.gguf"          "$GGUF_FILE"
 assert_eq "MAX_CONTEXT"  "131072"                               "$MAX_CONTEXT"
 echo ""
 
+# --- ARC ---
+echo "ARC (Intel Arc ≥12 GB, e.g. A770 16 GB):"
+run_tier ARC
+assert_eq "TIER_NAME"    "Intel Arc"                           "$TIER_NAME"
+assert_eq "LLM_MODEL"    "qwen3-8b"                           "$LLM_MODEL"
+assert_eq "GGUF_FILE"    "Qwen3-8B-Q4_K_M.gguf"              "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "32768"                               "$MAX_CONTEXT"
+assert_eq "GPU_BACKEND"  "sycl"                                "$GPU_BACKEND"
+assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
+echo ""
+
+# --- ARC_LITE ---
+echo "ARC_LITE (Intel Arc <12 GB, e.g. A750 8 GB / A380 6 GB):"
+run_tier ARC_LITE
+assert_eq "TIER_NAME"    "Intel Arc Lite"                      "$TIER_NAME"
+assert_eq "LLM_MODEL"    "qwen3-4b"                           "$LLM_MODEL"
+assert_eq "GGUF_FILE"    "Qwen3-4B-Q4_K_M.gguf"              "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "16384"                               "$MAX_CONTEXT"
+assert_eq "GPU_BACKEND"  "sycl"                                "$GPU_BACKEND"
+assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
+echo ""
+
 # --- Invalid tier should fail ---
 echo "Invalid tier (should fail):"
 if TIER="INVALID" resolve_tier_config 2>/dev/null; then
@@ -126,7 +149,7 @@ echo ""
 
 # --- GGUF_URL should be set for all tiers ---
 echo "GGUF_URL populated for all tiers:"
-for t in 0 1 2 3 4 NV_ULTRA SH_LARGE SH_COMPACT; do
+for t in 0 1 2 3 4 NV_ULTRA SH_LARGE SH_COMPACT ARC ARC_LITE; do
     run_tier "$t"
     if [[ -n "$GGUF_URL" && "$GGUF_URL" == https://* ]]; then
         echo "  PASS: Tier $t has valid GGUF_URL"


### PR DESCRIPTION
## Summary

Adds first-class Intel Arc GPU support to the Dream Server installer via two new named tiers (`ARC` / `ARC_LITE`) that target the llama.cpp SYCL backend.

- **`ARC`** — Arc A770 16 GB and any future Arc ≥12 GB VRAM → Qwen3 8B Q4_K_M, 32 k context
- **`ARC_LITE`** — Arc A750 8 GB / A380 6 GB (<12 GB VRAM) → Qwen3 4B Q4_K_M, 16 k context
- Both tiers force `GPU_BACKEND=sycl` and `N_GPU_LAYERS=99` (full GPU offload via llama.cpp SYCL)

## Changed Files

| File | Change |
|---|---|
| `installers/lib/tier-map.sh` | Added `ARC` and `ARC_LITE` cases to `resolve_tier_config()` and `tier_to_model()`; sets `GPU_BACKEND=sycl`, `N_GPU_LAYERS=99` |
| `installers/lib/detection.sh` | `normalize_profile_tier()` passes `ARC`/`ARC_LITE` through; `tier_rank()` maps them to ranks 2 and 1 |
| `installers/phases/02-detection.sh` | Auto-selects `ARC` or `ARC_LITE` when `GPU_BACKEND==intel`; adds tok/s and user estimates for both tiers |
| `installers/lib/compose-select.sh` | Routes `ARC`/`ARC_LITE` (and `GPU_BACKEND==intel\|sycl`) to `docker-compose.intel.yml` overlay |
| `installers/phases/06-directories.sh` | Writes `N_GPU_LAYERS` to `.env`; adds Intel SYCL block (`VIDEO_GID`, `RENDER_GID`, `ONEAPI_DEVICE_SELECTOR`, `SYCL_CACHE_PERSISTENT`, `ZES_ENABLE_SYSMAN`) when `GPU_BACKEND==sycl` |
| `docker-compose.intel.yml` | **New** — Intel Arc overlay; SYCL llama.cpp image, `/dev/dri` passthrough, Level Zero env, `--n-gpu-layers ${N_GPU_LAYERS:-99}` |
| `tests/test-tier-map.sh` | Added `ARC` / `ARC_LITE` test blocks; resets `GPU_BACKEND` and `N_GPU_LAYERS` per run; adds both tiers to GGUF_URL loop |

## Tier Map

| Tier | Hardware | Model | VRAM | Context | Backend |
|---|---|---|---|---|---|
| `ARC` | Arc A770 (16 GB), Arc B-series ≥12 GB | Qwen3 8B Q4_K_M | ≥12 GB | 32 768 | sycl |
| `ARC_LITE` | Arc A750 (8 GB), A380 (6 GB) | Qwen3 4B Q4_K_M | <12 GB | 16 384 | sycl |

## Host Prerequisites (for manual installs)

```bash
apt install intel-opencl-icd intel-level-zero-gpu level-zero
usermod -aG video,render $USER   # re-login after
```

## Test Plan

- [ ] Run `bash tests/test-tier-map.sh` — all ARC / ARC_LITE assertions pass
- [ ] On a machine with an Arc A770: install with default flags, confirm `TIER=ARC`, `GPU_BACKEND=sycl`, `N_GPU_LAYERS=99` in generated `.env`
- [ ] On a machine with an Arc A750: confirm `TIER=ARC_LITE` and `LLM_MODEL=qwen3-4b`
- [ ] Confirm `docker-compose.intel.yml` is selected in `COMPOSE_FLAGS`
- [ ] Confirm llama-server container starts and `/health` returns 200 on the SYCL image
- [ ] Pass `--tier ARC` flag explicitly and confirm it overrides auto-detection