### PR TITLE
scripts: make session-cleanup.sh portable (grep, stat, numfmt)

### DIFF
--- a/dream-server/scripts/session-cleanup.sh
+++ b/dream-server/scripts/session-cleanup.sh
@@ -31,8 +31,8 @@ if [ ! -d "$SESSIONS_DIR" ]; then
     exit 0
 fi
 
-# ── Extract active session IDs ─────────────────────────────────
-ACTIVE_IDS=$(grep -oP '"sessionId":\s*"\K[^"]+' "$SESSIONS_JSON" 2>/dev/null || true)
+# ── Extract active session IDs (portable: no grep -P) ─────────
+ACTIVE_IDS=$(grep -oE '"sessionId"[[:space:]]*:[[:space:]]*"[^"]+"' "$SESSIONS_JSON" 2>/dev/null | sed -E 's/.*"sessionId"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/' || true)
 
 echo "[$(date)] Session cleanup starting"
 echo "[$(date)] Sessions dir: $SESSIONS_DIR"
@@ -70,10 +70,16 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
         rm -f "$f"
         REMOVED_INACTIVE=$((REMOVED_INACTIVE + 1))
     else
-        SIZE_BYTES=$(stat -c%s "$f" 2>/dev/null || echo 0)
+        # Portable stat: Linux uses -c%s, macOS uses -f%z
+        if [ "$(uname -s)" = "Darwin" ]; then
+            SIZE_BYTES=$(stat -f%z "$f" 2>/dev/null || echo 0)
+        else
+            SIZE_BYTES=$(stat -c%s "$f" 2>/dev/null || echo 0)
+        fi
         if [ "$SIZE_BYTES" -gt "$MAX_SIZE" ]; then
             SIZE=$(du -h "$f" | cut -f1)
-            echo "[$(date)] Session $BASENAME is bloated ($SIZE > $(numfmt --to=iec $MAX_SIZE 2>/dev/null || echo "${MAX_SIZE}B")), deleting to force fresh session"
+            SIZE_LABEL=$(command -v numfmt >/dev/null 2>&1 && numfmt --to=iec "$MAX_SIZE" || echo "${MAX_SIZE}B")
+            echo "[$(date)] Session $BASENAME is bloated ($SIZE > ${SIZE_LABEL}), deleting to force fresh session"
             rm -f "$f"
             WIPE_IDS="$WIPE_IDS $BASENAME"
             REMOVED_BLOATED=$((REMOVED_BLOATED + 1))


### PR DESCRIPTION
Makes session-cleanup.sh work on macOS/BSD and systems without GNU coreutils:
- Replace grep -oP with portable grep -oE + sed
- Use stat -f%z on Darwin, stat -c%s on Linux
- Use numfmt only when available; fallback to raw bytes label