### PR TITLE
feat: wire GUI progress protocol into installer phases

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -72,6 +72,7 @@ source "$SCRIPT_DIR/installers/lib/detection.sh"
 source "$SCRIPT_DIR/installers/lib/tier-map.sh"
 source "$SCRIPT_DIR/installers/lib/compose-select.sh"
 source "$SCRIPT_DIR/installers/lib/packaging.sh"
+source "$SCRIPT_DIR/installers/lib/progress.sh"
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
     source "$SCRIPT_DIR/lib/service-registry.sh" 
     sr_load 

--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -14,6 +14,7 @@
 #   Add new pre-flight checks (e.g., kernel version) here.
 # ============================================================================
 
+dream_progress 5 "preflight" "Running preflight checks"
 show_phase 1 6 "Pre-flight Checks" "~30 seconds"
 ai "I'm scanning your system for required components..."
 

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -22,6 +22,7 @@
 #   Change tier auto-detection thresholds or add new hardware classes here.
 # ============================================================================
 
+dream_progress 12 "detection" "Detecting GPU hardware"
 chapter "SYSTEM DETECTION"
 
 # Cloud mode: skip GPU detection entirely

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -15,6 +15,7 @@
 #   Add new optional features to the Custom menu here.
 # ============================================================================
 
+dream_progress 18 "features" "Selecting features"
 if $INTERACTIVE && ! $DRY_RUN; then
     show_phase 2 6 "Feature Selection" "~1 minute"
     show_install_menu

--- a/dream-server/installers/phases/04-requirements.sh
+++ b/dream-server/installers/phases/04-requirements.sh
@@ -16,6 +16,7 @@
 #   Change minimum RAM/disk thresholds per tier here.
 # ============================================================================
 
+dream_progress 25 "requirements" "Checking system requirements"
 chapter "REQUIREMENTS CHECK"
 
 [[ -f "${SCRIPT_DIR:-}/lib/safe-env.sh" ]] && . "${SCRIPT_DIR}/lib/safe-env.sh"

--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -16,6 +16,7 @@
 #   Multi-distro: uses packaging.sh for distro-agnostic package installs.
 # ============================================================================
 
+dream_progress 30 "docker" "Setting up Docker"
 show_phase 3 6 "Docker Setup" "~2 minutes"
 ai "Preparing container runtime..."
 

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -23,6 +23,7 @@
 #   or change directory layout here.
 # ============================================================================
 
+dream_progress 38 "directories" "Preparing installation directory"
 chapter "SETTING UP INSTALLATION"
 
 if $DRY_RUN; then

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -14,6 +14,7 @@
 #   Add new developer tools or change installation methods here.
 # ============================================================================
 
+dream_progress 42 "devtools" "Installing developer tools"
 if $DRY_RUN; then
     log "[DRY RUN] Would install AI developer tools (Claude Code, Codex CLI, OpenCode)"
     log "[DRY RUN] Would configure OpenCode for local llama-server (user-level systemd service on port 3003)"

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -15,6 +15,7 @@
 #   Add new container images or change image tags here.
 # ============================================================================
 
+dream_progress 48 "images" "Downloading container images"
 show_phase 4 6 "Downloading Modules" "~5-10 minutes"
 
 # Build image list with cinematic labels

--- a/dream-server/installers/phases/09-offline.sh
+++ b/dream-server/installers/phases/09-offline.sh
@@ -13,6 +13,7 @@
 #   Add offline-specific configuration or bundled models here.
 # ============================================================================
 
+dream_progress 65 "offline" "Configuring offline mode"
 if [[ "$OFFLINE_MODE" == "true" ]] && $DRY_RUN; then
     log "[DRY RUN] Would configure offline/air-gapped mode (M1)"
     log "[DRY RUN] Would create offline mode marker, disable cloud features"

--- a/dream-server/installers/phases/10-amd-tuning.sh
+++ b/dream-server/installers/phases/10-amd-tuning.sh
@@ -13,6 +13,7 @@
 #   Add new AMD-specific tuning parameters or kernel options here.
 # ============================================================================
 
+dream_progress 70 "amd-tuning" "Tuning AMD GPU settings"
 if [[ "$GPU_BACKEND" == "amd" ]] && $DRY_RUN; then
     log "[DRY RUN] Would apply AMD APU system tuning:"
     log "[DRY RUN]   - Install systemd user timers (session cleanup, memory shepherd)"

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -17,6 +17,7 @@
 #   Change model download logic or compose launch flags here.
 # ============================================================================
 
+dream_progress 75 "services" "Starting services"
 show_phase 5 6 "Starting Services" "~2-3 minutes"
 
 if $DRY_RUN; then

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -21,6 +21,7 @@
 . "$SCRIPT_DIR/lib/service-registry.sh"
 sr_load
 
+dream_progress 85 "health" "Checking service health"
 show_phase 6 6 "Systems Online" "~1-2 minutes"
 
 if $DRY_RUN; then

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -21,6 +21,8 @@
 #   shortcut here.
 # ============================================================================
 
+dream_progress 98 "summary" "Finishing up"
+
 # Source service registry for port resolution
 . "$SCRIPT_DIR/lib/service-registry.sh"
 sr_load


### PR DESCRIPTION
## Summary

- Sources `installers/lib/progress.sh` in `install-core.sh` (after other libs)
- Adds one `dream_progress` call at the top of each of the 13 installer phases
- Emits `DREAM_PROGRESS:<percent>:<phase>:<message>` lines when `DREAM_INSTALLER_GUI=1` is set
- **Complete no-op for terminal installs** — the function checks the env var and returns immediately if unset

## Changes

14 files, 15 insertions, 0 deletions. One line per phase file + one source line in install-core.sh.

| Phase | % | Message |
|-------|---|---------|
| 01-preflight | 5 | Running preflight checks |
| 02-detection | 12 | Detecting GPU hardware |
| 03-features | 18 | Selecting features |
| 04-requirements | 25 | Checking system requirements |
| 05-docker | 30 | Setting up Docker |
| 06-directories | 38 | Preparing installation directory |
| 07-devtools | 42 | Installing developer tools |
| 08-images | 48 | Downloading container images |
| 09-offline | 65 | Configuring offline mode |
| 10-amd-tuning | 70 | Tuning AMD GPU settings |
| 11-services | 75 | Starting services |
| 12-health | 85 | Checking service health |
| 13-summary | 98 | Finishing up |

## Test plan

- [ ] `make test` — existing installer tests pass (dream_progress is a no-op without DREAM_INSTALLER_GUI)
- [ ] `make simulate` — dry-run simulation unaffected
- [ ] `DREAM_INSTALLER_GUI=1 bash install-core.sh --dry-run` — verify DREAM_PROGRESS lines appear in stdout

🤖 Generated with [Claude Code](https://claude.com/claude-code)