### PR TITLE
fix: remove duplicate network definition in docker-compose.base.yml

### DIFF
--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -216,5 +216,3 @@ services:
 networks:
   default:
     name: dream-network
-  dream-network:
-    name: dream-network

--- a/dream-server/extensions/templates/compose-template.yaml
+++ b/dream-server/extensions/templates/compose-template.yaml
@@ -10,7 +10,7 @@
 #   - The top-level key MUST be "services:" (standard Compose format)
 #   - The service name MUST match the "id" in your manifest.yaml
 #   - Use ${VAR:-default} syntax for user-configurable values
-#   - Join the shared network: dream-network (defined in base.yml)
+#   - Services join dream-network automatically via the default network in base.yml
 #   - Mount data under ./data/<service-name>/ (relative to project root)
 #   - Always set restart, security_opt, and a healthcheck
 #
@@ -60,9 +60,6 @@ services:
       # External port (user-facing) : Internal port (container)
       - "${MY_SERVICE_PORT:-1234}:1234"
 
-    networks:
-      - dream-network
-
     deploy:
       resources:
         limits:
@@ -86,6 +83,5 @@ services:
 #   my-service-data:
 #     driver: local
 
-networks:
-  dream-network:
-    external: true
+# No networks section needed — services join the default network
+# (named "dream-network" in docker-compose.base.yml) automatically.


### PR DESCRIPTION
## What
Remove the duplicate `dream-network` key from the `networks:` section in `docker-compose.base.yml`. Update the extension compose template to reflect that services join the network automatically.

## Why
The `networks:` section defined both `default` and `dream-network` keys, both mapping to `name: dream-network`. Docker Compose assigns different internal labels to each key (`default` vs `dream-network`). On fresh installs where the network doesn't exist yet, Compose creates it with the first key's label, then the second key sees a mismatched label and fails with:
```
network dream-network was found but has incorrect label com.docker.compose.network
```

## How
- Removed the duplicate `dream-network:` key from `docker-compose.base.yml`, keeping only `default: name: dream-network`
- Updated `extensions/templates/compose-template.yaml` to remove the now-incorrect `networks: [dream-network]` guidance and `networks: dream-network: external: true` block
- No extension compose files reference `dream-network` explicitly, so no other changes needed

## Testing
- `docker compose -f docker-compose.base.yml -f docker-compose.nvidia.yml config` validates cleanly
- Grep confirms zero remaining explicit `dream-network` references in extension compose files

## Review
Critique Guardian: ✅ APPROVED — verified no extension compose files reference dream-network explicitly

## Platform Impact
- Linux (NVIDIA/AMD): ✅ No change — services join default network implicitly
- macOS: ✅ No change — macOS overlay does not reference dream-network
- Windows: ✅ No change

🤖 Generated with [Claude Code](https://claude.com/claude-code)