### PR TITLE
fix: add MinIO bucket init container for Langfuse

### DIFF
--- a/dream-server/extensions/services/langfuse/compose.yaml.disabled
+++ b/dream-server/extensions/services/langfuse/compose.yaml.disabled
@@ -51,6 +51,8 @@ services:
         condition: service_healthy
       langfuse-minio:
         condition: service_healthy
+      langfuse-minio-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3000/api/public/health"]
       interval: 30s
@@ -104,6 +106,8 @@ services:
         condition: service_healthy
       langfuse-minio:
         condition: service_healthy
+      langfuse-minio-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "wget --quiet --tries=1 --spider http://localhost:3030/api/health"]
       interval: 30s
@@ -236,6 +240,36 @@ services:
           memory: 256m
         reservations:
           cpus: '0.1'
+          memory: 128m
+
+  langfuse-minio-init:
+    image: minio/mc:RELEASE.2025-09-07T16-13-09Z
+    container_name: dream-langfuse-minio-init
+    restart: "no"
+    security_opt:
+      - no-new-privileges:true
+    entrypoint: /bin/sh
+    command:
+      - -c
+      - |
+        until mc alias set local http://langfuse-minio:9000 "$${MINIO_ROOT_USER}" "$${MINIO_ROOT_PASSWORD}"; do
+          echo "Waiting for MinIO..."
+          sleep 2
+        done
+        mc mb local/langfuse-events --ignore-existing
+        echo "Bucket langfuse-events ready"
+    environment:
+      MINIO_ROOT_USER: "${LANGFUSE_MINIO_ACCESS_KEY}"
+      MINIO_ROOT_PASSWORD: "${LANGFUSE_MINIO_SECRET_KEY}"
+    depends_on:
+      langfuse-minio:
+        condition: service_healthy
+    networks:
+      - langfuse-internal
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
           memory: 128m
 
   # Inject Langfuse credentials into LiteLLM when this extension is active.


### PR DESCRIPTION
## What
Add a one-shot `langfuse-minio-init` container that creates the `langfuse-events` S3 bucket in MinIO before Langfuse services start.

## Why
After a fresh stack startup, the MinIO container starts with an empty data directory. The `langfuse-events` bucket referenced by `LANGFUSE_S3_EVENT_UPLOAD_BUCKET` does not exist. Langfuse does not auto-create the bucket, so the first trace ingestion fails with `500 Internal Server Error`:
```
Failed to upload event to S3
Error: Failed to upload events to blob storage, aborting event processing
```

## How
Added to `extensions/services/langfuse/compose.yaml.disabled`:

- **`langfuse-minio-init`** service: uses `minio/mc` (dedicated MinIO Client image) to create the bucket via `mc mb local/langfuse-events --ignore-existing`
- Waits for MinIO to be healthy (`depends_on: langfuse-minio: condition: service_healthy`)
- One-shot container (`restart: "no"`) that exits after bucket creation
- **`langfuse-web`** and **`langfuse-worker`** now depend on `langfuse-minio-init: condition: service_completed_successfully` to prevent race conditions
- Follows project conventions: `security_opt: no-new-privileges:true`, resource limits, `langfuse-internal` network only

## Testing
- YAML syntax validated via `python3 yaml.safe_load`
- Init container is idempotent (`--ignore-existing` flag)
- `service_completed_successfully` ensures web/worker block until bucket exists

## Review
Critique Guardian: ✅ APPROVED (second pass after fixing race condition and image choice)
- First review caught: (1) missing `depends_on` from web/worker → init, (2) wrong image (`minio/minio` → `minio/mc`)
- Both issues resolved and re-reviewed

## Platform Impact
- Linux (NVIDIA/AMD): ✅ Langfuse is platform-agnostic
- macOS: ✅ Same behavior
- Windows: ✅ Same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)