### PR TITLE
fix(macos): resolve llama-server DNS for LiteLLM via extra_hosts

### DIFF
--- a/dream-server/installers/macos/docker-compose.macos.yml
+++ b/dream-server/installers/macos/docker-compose.macos.yml
@@ -61,3 +61,7 @@ services:
         condition: service_healthy
     environment:
       OPENAI_API_BASE_URL: "http://host.docker.internal:8080/v1"
+
+  litellm:
+    extra_hosts:
+      - "llama-server:host-gateway"


### PR DESCRIPTION
## What
Add `extra_hosts: ["llama-server:host-gateway"]` to the LiteLLM service in the macOS compose overlay.

## Why
On macOS (Apple Silicon), `llama-server` runs natively on the host with Metal acceleration — the macOS compose overlay sets `replicas: 0` to disable the containerized version. However, LiteLLM's config files (`local.yaml`, `hybrid.yaml`) hardcode `api_base: http://llama-server:8080/v1`, which relies on Docker's internal DNS. Since `llama-server` is not a running Docker service on macOS, that DNS name doesn't resolve, and all LiteLLM inference requests fail with 500 "Connection error".

On Linux this works fine because `llama-server` runs as a Docker container and the DNS name resolves normally.

## How
Added `extra_hosts: ["llama-server:host-gateway"]` to the `litellm` service in `installers/macos/docker-compose.macos.yml`. This makes the `llama-server` hostname resolve to the Docker host IP inside the LiteLLM container on macOS.

This is the same pattern already used by `llama-server-ready` in the same file (`extra_hosts: ["host.docker.internal:host-gateway"]`). No LiteLLM config file changes needed — the fix is scoped entirely to the macOS overlay.

## Testing
- Compose config validates cleanly when layering base + litellm extension + macOS overlay
- `extra_hosts` only applies on macOS — Linux compose stack is completely unaffected
- No conflict with disabled `llama-server` container (`replicas: 0` means Docker never registers the name in DNS, so `extra_hosts` is the sole resolution path)

## Review
Critique Guardian: ✅ APPROVED — pattern consistent with existing macOS overlay, no security concerns

## Platform Impact
- Linux (NVIDIA/AMD): ✅ Not affected — llama-server runs as container, DNS resolves normally
- macOS: ✅ Fixes LiteLLM → llama-server connectivity
- Windows: ✅ Not affected — separate installer

🤖 Generated with [Claude Code](https://claude.com/claude-code)