### PR TITLE
feat: granular progress sub-milestones for GUI installer

### DIFF
--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -51,6 +51,7 @@ if [[ "$SKIP_DOCKER" == "true" ]]; then
 elif command -v docker &> /dev/null; then
     ai_ok "Docker already installed: $(docker --version)"
 else
+    dream_progress 31 "docker" "Installing Docker engine"
     ai "Installing Docker..."
 
     if $DRY_RUN; then
@@ -98,6 +99,7 @@ DOCKER_CMD="${DOCKER_CMD:-docker}"
 DOCKER_COMPOSE_CMD="${DOCKER_COMPOSE_CMD:-docker compose}"
 
 # Docker Compose check (v2 preferred, v1 fallback)
+dream_progress 33 "docker" "Checking Docker Compose"
 if docker_compose_run version &> /dev/null 2>&1; then
     ai_ok "Docker Compose v2 available"
 elif command -v docker-compose &> /dev/null; then
@@ -253,10 +255,12 @@ _docker_post_install_checks() {
     fi
 }
 
+dream_progress 35 "docker" "Running Docker post-install checks"
 _docker_post_install_checks
 
 # NVIDIA Container Toolkit (skip for AMD — uses /dev/dri + /dev/kfd passthrough)
 if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
+    dream_progress 36 "docker" "Checking NVIDIA Container Toolkit"
     if command -v nvidia-container-cli &> /dev/null 2>&1; then
         ai_ok "NVIDIA Container Toolkit installed"
         # Always regenerate CDI spec — driver version may have changed since last run

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -35,12 +35,14 @@ if $DRY_RUN; then
     log "[DRY RUN] Would validate .env against schema"
 else
     # Create directories
+    dream_progress 38 "directories" "Creating directory structure"
     mkdir -p "$INSTALL_DIR"/{config,data,models}
     mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models}
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
     # Copy entire source tree to install dir (skip if same directory)
+    dream_progress 39 "directories" "Copying source files"
     if [[ "$SCRIPT_DIR" != "$INSTALL_DIR" ]]; then
         ai "Copying source files to $INSTALL_DIR..."
         if command -v rsync &>/dev/null; then
@@ -213,6 +215,7 @@ MODELS_EOF
     fi
 
     # ── .env merge logic: preserve user-configured values on re-install ──
+    dream_progress 40 "directories" "Generating secrets and configuration"
     # If an existing .env exists, read user-editable values so we don't
     # destroy API keys, custom ports, or manually-set secrets.
     _env_existing=""
@@ -379,6 +382,7 @@ ENV_EOF
     ai_ok "Generated secure secrets in .env (permissions: 600)"
 
     # Validate generated .env against schema (fails fast on missing/unknown keys).
+    dream_progress 41 "directories" "Validating configuration"
     if [[ -f "$SCRIPT_DIR/scripts/validate-env.sh" && -f "$SCRIPT_DIR/.env.schema.json" ]]; then
         if bash "$SCRIPT_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$SCRIPT_DIR/.env.schema.json" >> "$LOG_FILE" 2>&1; then
             ai_ok "Validated .env against .env.schema.json"

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -63,6 +63,10 @@ else
         label="${entry##*|}"
         pull_count=$((pull_count + 1))
 
+        # Sub-milestone: interpolate progress 48-64% across image pulls
+        _img_pct=$(( 48 + (pull_count - 1) * 16 / pull_total ))
+        dream_progress "$_img_pct" "images" "Pulling image $pull_count/$pull_total"
+
         if ! pull_with_progress "$img" "$label" "$pull_count" "$pull_total"; then
             ai_warn "Failed to pull $img — will retry on next start"
             pull_failed=$((pull_failed + 1))

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -44,6 +44,7 @@ else
     mkdir -p "$INSTALL_DIR/data/models"
 
     # Download GGUF model if not already present (with retry and integrity verification)
+    dream_progress 76 "services" "Checking AI model"
     GGUF_DIR="$INSTALL_DIR/data/models"
     if [[ "${DREAM_MODE:-local}" != "cloud" && -n "$GGUF_URL" ]]; then
         # Check if model exists and verify integrity
@@ -75,6 +76,7 @@ else
 
         # Download if not present or was removed due to corruption
         if [[ ! -f "$GGUF_DIR/$GGUF_FILE" ]]; then
+            dream_progress 77 "services" "Downloading AI model"
             ai "Downloading GGUF model: $GGUF_FILE"
             signal "This is the big one. I've got it — sit back."
             echo ""
@@ -136,6 +138,7 @@ else
     fi
 
     # ── FLUX.1-schnell model download (ComfyUI image generation) ──
+    dream_progress 79 "services" "Checking image generation models"
     if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
         ai "Cloud mode — skipping FLUX model download"
     elif [[ "$GPU_BACKEND" == "amd" ]]; then
@@ -260,6 +263,7 @@ MODELS_INI_EOF
     fi
 
     # Launch containers
+    dream_progress 81 "services" "Launching containers"
     echo ""
     signal "Waking the stack..."
     ai "I'm bringing systems online. You can breathe."
@@ -293,6 +297,7 @@ MODELS_INI_EOF
         ai_warn "Log file: $LOG_FILE"
     fi
 
+    dream_progress 83 "services" "Running extension setup hooks"
     # ── Run extension setup hooks ──
     if [[ -f "$INSTALL_DIR/lib/service-registry.sh" ]]; then
         _HOOK_DIR="$INSTALL_DIR"

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -54,12 +54,16 @@ _check_health() {
 # Core service health checks with adaptive timeouts
 # Format: _check_health "name" "url" max_attempts timeout_per_request
 # llama-server: 60 attempts * adaptive backoff (2s->8s) = up to 5 minutes (model loading can be slow)
+dream_progress 86 "health" "Waiting for LLM engine"
 _check_health "llama-server" "http://localhost:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 60 15
 # Open WebUI: 30 attempts * adaptive backoff = up to 2 minutes
+dream_progress 89 "health" "Waiting for Chat UI"
 _check_health "Open WebUI" "http://localhost:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 30 10
 # Perplexica: 20 attempts * adaptive backoff = up to 1 minute
+dream_progress 91 "health" "Waiting for Research engine"
 _check_health "Perplexica" "http://localhost:${SERVICE_PORTS[perplexica]:-3004}${SERVICE_HEALTH[perplexica]:-/}" 20 10
 # ComfyUI: 60 attempts * adaptive backoff = up to 5 minutes (FLUX model loading is slow)
+dream_progress 93 "health" "Waiting for Image generation"
 _check_health "ComfyUI" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 60 15
 
 # Perplexica auto-config: seed chat model + embedding model on first boot.
@@ -124,9 +128,11 @@ print('ok')
 fi
 
 # Extension service health checks with adaptive timeouts
+dream_progress 94 "health" "Checking extension services"
 [[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://localhost:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 20 10
 systemctl is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://localhost:3003/" 10 5
 # Whisper: 40 attempts * adaptive backoff = up to 3 minutes (model download on first start)
+dream_progress 95 "health" "Checking voice services"
 [[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://localhost:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 40 10
 [[ "$ENABLE_VOICE" == "true" ]] && _check_health "Kokoro (TTS)" "http://localhost:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 20 10
 
@@ -152,9 +158,11 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     fi
 fi
 
+dream_progress 96 "health" "Checking workflow and RAG services"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && _check_health "n8n" "http://localhost:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 20 10
 [[ "$ENABLE_RAG" == "true" ]] && _check_health "Qdrant" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 20 10
 
+dream_progress 97 "health" "Health checks complete"
 echo ""
 if [[ "$HEALTH_FAILURES" -gt 0 ]]; then
     ai_warn "${HEALTH_FAILURES} service(s) did not pass health checks."


### PR DESCRIPTION
## Summary

- Adds **22 new `dream_progress()` calls** within the 5 heaviest installer phases, bringing the total from 13 to **35 milestones**
- Progress bar now updates smoothly during long operations instead of jumping between phases
- Phase 08 (image pulls) dynamically interpolates progress 48-64% across each image
- Phase 12 (health checks) reports per-service progress as each comes online
- **Zero impact on terminal installs** — all calls are no-ops when `DREAM_INSTALLER_GUI` is unset

### Progress curve
```
Phase 05 (Docker):       30% → 31% → 33% → 35% → 36%
Phase 06 (Directories):  38% → 39% → 40% → 41%
Phase 08 (Images):       48% → dynamically interpolated → 64%
Phase 11 (Services):     75% → 76% → 77% → 79% → 81% → 83%
Phase 12 (Health):       85% → 86% → 89% → 91% → 93% → 94% → 95% → 96% → 97%
Phase 13 (Summary):      98%
```

## Test plan

- [ ] `make lint` — shellcheck passes on modified files
- [ ] `make test` — installer contract tests pass
- [ ] Terminal install unchanged (dream_progress is no-op without DREAM_INSTALLER_GUI=1)
- [ ] GUI installer shows smooth progress bar updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)