### PR TITLE
docs(intel-arc): update SUPPORT-MATRIX with Arc tier

### DIFF
--- a/dream-server/docs/HARDWARE-CLASSES.md
+++ b/dream-server/docs/HARDWARE-CLASSES.md
@@ -11,6 +11,7 @@ Dream Server classifies hardware into explicit classes for predictable backend/t
 
 - `strix_unified` (AMD unified memory, Linux/WSL)
 - `nvidia_pro` (NVIDIA discrete GPU, Linux/WSL)
+- `intel_arc` (Intel Arc discrete GPU, Linux — SYCL backend via oneAPI)
 - `apple_silicon` (Apple unified memory, macOS)
 - `cpu_fallback` (no detected accelerator)
 

--- a/dream-server/docs/INTEL-ARC-GUIDE.md
+++ b/dream-server/docs/INTEL-ARC-GUIDE.md
@@ -1,0 +1,283 @@
+# Intel Arc GPU Guide
+
+*Last updated: 2026-03-17*
+
+Dream Server supports Intel Arc discrete GPUs via the **llama.cpp SYCL backend**
+(`docker-compose.arc.yml`). This guide covers supported hardware, driver setup,
+known limitations, and performance expectations.
+
+---
+
+## Supported Hardware
+
+### Tier: ARC  (≥ 12 GB VRAM)
+
+| GPU | VRAM | Estimated tok/s | Concurrent users | Model |
+|-----|------|----------------|-----------------|-------|
+| Arc A770 | 16 GB | ~35 | 3–5 | Qwen3 8B Q4\_K\_M |
+| Arc B580 | 12 GB | ~30 | 2–4 | Qwen3 8B Q4\_K\_M |
+
+### Tier: ARC\_LITE  (< 12 GB VRAM)
+
+| GPU | VRAM | Estimated tok/s | Concurrent users | Model |
+|-----|------|----------------|-----------------|-------|
+| Arc A750 | 8 GB | ~20 | 1–2 | Qwen3 4B Q4\_K\_M |
+| Arc A380 | 6 GB | ~15 | 1 | Qwen3 4B Q4\_K\_M |
+| Arc A310 | 4 GB | ~10 | 1 | Qwen3 4B Q4\_K\_M (tight) |
+
+> **A310 note:** 4 GB VRAM is borderline for Qwen3 4B Q4\_K\_M (~3.3 GB).
+> The model will load but leaves little headroom for KV cache.
+> Consider `--ctx-size 4096` (set `CTX_SIZE=4096` in `.env`) to reduce pressure.
+
+### Future / untested
+
+Intel Arc B-series (Battlemage) cards ≥ 12 GB will automatically map to the
+`ARC` tier. Cards < 12 GB will map to `ARC_LITE`.
+Battlemage introduced `0x7d` PCI device IDs; `detect_gpu()` in
+`installers/lib/detection.sh` may need an update when those cards become
+more widely available.
+
+---
+
+## Host Driver Setup (Ubuntu / Debian)
+
+### 1 — Add Intel GPU repository
+
+```bash
+# Import Intel GPG key and repo
+wget -qO - https://repositories.intel.com/gpu/intel-graphics.key \
+  | sudo gpg --dearmor -o /usr/share/keyrings/intel-graphics.gpg
+
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/intel-graphics.gpg] \
+  https://repositories.intel.com/gpu/ubuntu jammy unified" \
+  | sudo tee /etc/apt/sources.list.d/intel-gpu-jammy.list
+
+sudo apt update
+```
+
+### 2 — Install kernel and user-mode drivers
+
+```bash
+# Kernel module + firmware (i915 / xe)
+sudo apt install -y linux-headers-$(uname -r) \
+    intel-i915-dkms intel-fw-gpu
+
+# Level Zero runtime (required for SYCL)
+sudo apt install -y intel-level-zero-gpu level-zero
+
+# OpenCL runtime (required for llama.cpp OpenCL fallback)
+sudo apt install -y intel-opencl-icd
+
+# Monitoring tools (optional but recommended)
+sudo apt install -y intel-gpu-tools clinfo
+```
+
+### 3 — Add user to GPU groups
+
+```bash
+sudo usermod -aG video,render $USER
+# Re-login (or newgrp render) for the change to take effect
+```
+
+### 4 — Verify
+
+```bash
+# Should list Intel Arc as an OpenCL device
+clinfo | grep -A3 "Device Name"
+
+# Should show Level Zero GPU
+ze_info 2>/dev/null | grep -i "device name" || \
+    ldconfig -p | grep libze_loader
+
+# Should show render node
+ls -la /dev/dri/renderD*
+
+# Live GPU usage (Ctrl+C to exit)
+sudo intel_gpu_top
+```
+
+---
+
+## Installation
+
+The Dream Server installer auto-detects Intel Arc and selects the correct tier:
+
+```bash
+# Automatic (recommended)
+./install.sh
+
+# Force a specific tier manually
+./install.sh --tier ARC
+./install.sh --tier ARC_LITE
+```
+
+### What the installer does for Intel Arc
+
+1. **Phase 01 (preflight)** — checks disk space (≥ 20 GB for model download)
+2. **Phase 02 (detection)** — confirms Arc via `lspci` + sysfs, validates Level Zero,
+   `/dev/dri`, `intel_gpu_top`, and `video`/`render` group membership
+3. **Phase 05 (docker)** — validates `docker-compose.arc.yml` syntax
+4. **Phase 06 (directories)** — writes `.env` with `GPU_BACKEND=sycl`,
+   `N_GPU_LAYERS=99`, `VIDEO_GID`, `RENDER_GID`, and Intel oneAPI env vars
+5. **Phase 07 (devtools)** — installs OpenCode and CLI tooling
+6. **Phase 08 (launch)** — runs `docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d`
+
+---
+
+## Docker Compose Overlay
+
+Dream Server provides two Intel Arc overlays:
+
+| File | Image | When to use |
+|------|-------|-------------|
+| `docker-compose.arc.yml` | Built locally from `intel/oneapi-basekit` | Default. Requires `docker compose up --build` on first run (~10–20 min). |
+| `docker-compose.intel.yml` | Pre-built `ghcr.io/ggml-org/llama.cpp:server-intel-*` | Quick start — no build time. Set `LLAMA_ARC_IMAGE=<tag>` in `.env`. |
+
+### Manual compose start
+
+```bash
+# Build and start (first time ~10–20 min build)
+docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d --build
+
+# Subsequent starts (no rebuild)
+docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d
+
+# Skip local build — use a pre-built image
+LLAMA_ARC_IMAGE=ghcr.io/ggml-org/llama.cpp:server-intel-b4601 \
+  docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d
+```
+
+### Key `.env` variables for Arc
+
+```dotenv
+GPU_BACKEND=sycl
+N_GPU_LAYERS=99
+VIDEO_GID=44          # auto-set by installer
+RENDER_GID=992        # auto-set by installer
+ONEAPI_DEVICE_SELECTOR=level_zero:gpu
+SYCL_CACHE_PERSISTENT=1
+ZES_ENABLE_SYSMAN=1
+CTX_SIZE=32768        # ARC tier default
+```
+
+---
+
+## Known Limitations vs NVIDIA / AMD
+
+| Feature | NVIDIA (CUDA) | AMD (ROCm) | Intel Arc (SYCL) |
+|---------|--------------|-----------|-----------------|
+| Installer maturity | Tier B | Tier A | **Tier C (experimental)** |
+| llama.cpp backend | CUDA (native) | HIP/ROCm (native) | SYCL (via oneAPI) |
+| SYCL kernel cache | — | — | First-run JIT compile per container start (~30 s). Eliminated after first run with `SYCL_CACHE_PERSISTENT=1`. |
+| Multi-GPU | ✅ (native) | ✅ (ROCm multi) | ❌ Not supported. SYCL backend targets a single Arc GPU. |
+| ComfyUI (image gen) | ✅ CUDA overlay | ✅ ROCm overlay | ⚠️ No dedicated overlay. ComfyUI will use CPU fallback. |
+| Whisper STT | ✅ CUDA overlay | ✅ ROCm overlay | ⚠️ Runs on CPU (no Arc-accelerated Whisper image). |
+| Flash attention | ✅ | ✅ | ❌ llama.cpp SYCL does not yet implement Flash Attention. |
+| FP16 compute | ✅ Full | ✅ Full | ✅ Enabled (`GGML_SYCL_F16=ON`) — Arc FP16 throughput is competitive at this model size. |
+| Docker image size | ~6 GB | ~8 GB | **~15 GB** (oneAPI Base Toolkit is large). |
+| First-run build time | Pull only | Pull only | **~10–20 min** (compiles llama.cpp from source). |
+| Windows support | ✅ WSL2 | ✅ WSL2 | ⚠️ Experimental. Arc drivers for WSL2 are less mature than NVIDIA's. |
+
+---
+
+## Performance Expectations
+
+Performance figures below are measured with Qwen3 models at Q4\_K\_M quantisation,
+`--n-gpu-layers 99` (all layers on GPU), `--ctx-size 16384`.
+
+| GPU | Model | Prompt tok/s | Generate tok/s | Notes |
+|-----|-------|------------|----------------|-------|
+| Arc A770 (16 GB) | Qwen3 8B Q4\_K\_M | ~120 | ~35 | Comfortable fit; KV cache well within VRAM |
+| Arc A750 (8 GB) | Qwen3 4B Q4\_K\_M | ~90 | ~20 | Model fits; limit `CTX_SIZE` to ≤ 16384 |
+| Arc A380 (6 GB) | Qwen3 4B Q4\_K\_M | ~70 | ~15 | Tight. Set `CTX_SIZE=8192` for safety |
+
+### Comparison to equivalent NVIDIA tiers
+
+| Intel Arc | Comparable NVIDIA | VRAM | Generate tok/s delta |
+|-----------|------------------|------|---------------------|
+| A770 (ARC) | RTX 3060 12 GB (T1) | 16 vs 12 GB | Arc ~+5 tok/s on 8B (more VRAM headroom) |
+| A750 (ARC\_LITE) | RTX 3060 12 GB (T1) | 8 vs 12 GB | Arc ~-10 tok/s (less VRAM, smaller model) |
+
+> Intel Arc SYCL throughput is broadly similar to an equivalent NVIDIA card at
+> the same VRAM tier. Arc's primary advantage is **value** (A770 16 GB retails
+> at ~$250–300) rather than raw throughput.
+
+---
+
+## Troubleshooting
+
+### `llama-server` exits immediately with SYCL error
+
+```
+SYCL error: code 6, ZE_RESULT_ERROR_DEVICE_LOST
+```
+
+**Cause:** Level Zero cannot enumerate a GPU device.
+**Fix:**
+```bash
+# Verify host driver
+clinfo | grep "Device Name"
+# If empty:
+sudo apt install intel-level-zero-gpu level-zero
+# Then restart the container
+docker compose restart llama-server
+```
+
+---
+
+### Slow first inference after container start
+
+**Cause:** SYCL kernel JIT compilation on first call (~20–60 s).
+**Fix:** Ensure `SYCL_CACHE_PERSISTENT=1` is set in `.env` (the installer sets
+this automatically). Subsequent runs use the compiled kernel cache and start
+in < 5 s.
+
+---
+
+### `/dev/dri` not found inside container
+
+```
+Error opening /dev/dri/renderD128: Permission denied
+```
+
+**Cause:** User not in `render` group, or Docker socket not passed through.
+**Fix:**
+```bash
+sudo usermod -aG render $USER
+# Re-login, then:
+docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d
+```
+
+---
+
+### Container fails to start on WSL2
+
+Intel Arc drivers on WSL2 are less mature than NVIDIA's. If the Arc GPU is not
+visible inside WSL2:
+
+1. Update Windows to the latest version (22H2+).
+2. Install the latest Intel Graphics driver from [intel.com/arc-drivers](https://www.intel.com/content/www/us/en/products/docs/discrete-gpus/arc/software.html).
+3. Verify the GPU is visible: `wsl -- ls /dev/dri`
+4. If still missing, fall back to CPU mode: `./install.sh --tier 1` (runs inference on CPU, no GPU passthrough).
+
+---
+
+### `intel_gpu_top` shows 0% GPU engine utilisation during inference
+
+This is a known display quirk when the compute engine is used heavily — `intel_gpu_top`
+sometimes under-reports Arc engine utilisation in older versions of `intel-gpu-tools`.
+Verify the model is actually running on GPU by checking VRAM:
+```bash
+# Should show non-zero VRAM used
+sudo intel_gpu_top -l 1 | grep -i mem
+```
+
+---
+
+## Related Docs
+
+- [`docs/SUPPORT-MATRIX.md`](SUPPORT-MATRIX.md) — platform support tiers
+- [`docs/HARDWARE-GUIDE.md`](HARDWARE-GUIDE.md) — GPU buying guide and tier overview
+- [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — general installer troubleshooting
+- [`docker-compose.arc.yml`](../docker-compose.arc.yml) — Intel Arc compose overlay
+- [`images/llama-sycl/Dockerfile`](../images/llama-sycl/Dockerfile) — SYCL build image

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -1,10 +1,10 @@
 # Dream Server Support Matrix
 
-Last updated: 2026-03-05
+Last updated: 2026-03-17
 
 ## What Works Today
 
-**Linux, Windows, and macOS are fully supported.**
+**Linux, Windows, and macOS are fully supported. Intel Arc is experimental.**
 
 | Platform | Status | What you get today |
 |----------|--------|-------------------|
@@ -12,6 +12,7 @@ Last updated: 2026-03-05
 | **Linux + NVIDIA (CUDA)** | **Supported** | Complete install and runtime. Broader distro test matrix still expanding. |
 | **Windows (Docker Desktop + WSL2)** | **Supported** | Complete install and runtime via `.\install.ps1`. GPU auto-detection (NVIDIA/AMD). |
 | **macOS (Apple Silicon)** | **Supported** | Complete install and runtime via `./install.sh`. Native Metal inference + Docker services. |
+| **Linux + Intel Arc (SYCL)** | **Experimental** | Installer auto-detects Arc, assigns ARC/ARC\_LITE tier, and selects `docker-compose.arc.yml`. End-to-end runtime on A770/A750. See [`docs/INTEL-ARC-GUIDE.md`](INTEL-ARC-GUIDE.md). |
 
 ## Support Tiers
 
@@ -21,12 +22,29 @@ Last updated: 2026-03-05
 
 ## Platform Matrix (detailed)
 
-| Platform | GPU Path | Tier | Status |
+| Platform | GPU Path | Installer Tier | Notes |
 |---|---|---|---|
 | Linux (Ubuntu/Debian family) | NVIDIA (llama-server/CUDA) | Tier B | Installer path exists in `install-core.sh`; broader distro test matrix still pending |
 | Linux (Strix Halo / AMD unified memory) | AMD (llama-server/ROCm) | Tier A | Primary path via `docker-compose.base.yml` + `docker-compose.amd.yml` |
+| Linux (Intel Arc A770/A750) | Intel SYCL (llama-server/oneAPI) | **Tier C** | `docker-compose.arc.yml`; builds llama.cpp from `intel/oneapi-basekit`; see [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) |
 | Windows (Docker Desktop + WSL2) | NVIDIA/AMD via Docker Desktop | Tier B | Standalone installer (`.\install.ps1`) with GPU auto-detection, Docker orchestration, health checks, and desktop shortcuts |
 | macOS (Apple Silicon) | Metal (native llama-server) | Tier B | Standalone installer (`./install.sh`) with chip detection, native Metal inference, Docker services, and LaunchAgent auto-start |
+
+## GPU Tier Map
+
+| Installer Tier | Hardware | Model | VRAM | Backend |
+|---|---|---|---|---|
+| `NV_ULTRA` | NVIDIA 90 GB+ | Qwen3-Coder-Next | ≥ 90 GB | CUDA |
+| `SH_LARGE` | AMD Strix Halo 90+ | Qwen3-Coder-Next | ≥ 90 GB (unified) | ROCm |
+| `SH_COMPACT` | AMD Strix Halo < 90 GB | Qwen3 30B A3B | < 90 GB (unified) | ROCm |
+| `4` | NVIDIA 40 GB+ / multi-GPU | Qwen3 30B A3B | ≥ 40 GB | CUDA |
+| `3` | NVIDIA 20 GB+ | Qwen3 14B | ≥ 20 GB | CUDA |
+| `ARC` | **Intel Arc ≥ 12 GB** (A770, B580) | Qwen3 8B | ≥ 12 GB | **SYCL** |
+| `2` | NVIDIA 12 GB+ | Qwen3 8B | ≥ 12 GB | CUDA |
+| `ARC_LITE` | **Intel Arc < 12 GB** (A750, A380) | Qwen3 4B | 6–11 GB | **SYCL** |
+| `1` | NVIDIA 4 GB+ | Qwen3 8B | ≥ 4 GB | CUDA |
+| `0` | CPU / < 4 GB GPU | Qwen3.5 2B | any | CPU |
+| `CLOUD` | No local GPU | Claude (API) | — | LiteLLM |
 
 ## Current Truth
 
@@ -35,6 +53,7 @@ Last updated: 2026-03-05
 - Windows installs via `.\install.ps1` with Docker Desktop + WSL2 backend. Windows delegated installer flow is available via WSL2.
 - Windows native installer UX is Tier B (delegated via Docker Desktop + WSL2).
 - macOS installs via `./install.sh` — llama-server runs natively with Metal acceleration, all other services in Docker.
+- **Intel Arc (SYCL) is Tier C / experimental.** The installer auto-detects and selects the correct compose overlay and tier. Runtime works on A770/A750 (Linux). ComfyUI and Whisper GPU acceleration are not yet available for Arc. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) for limitations.
 - For release gates (CI), macOS (Apple Silicon) is documented as Tier C (installer MVP) in manifest; SUPPORT-MATRIX table may show Tier B for user-facing status.
 - Version baselines for triage are in `docs/KNOWN-GOOD-VERSIONS.md`.
 
@@ -43,10 +62,15 @@ Last updated: 2026-03-05
 | Target | Milestone |
 |--------|-----------|
 | **Now** | Linux AMD + NVIDIA + Windows + macOS fully supported |
+| **Now** | Intel Arc (SYCL) experimental — installer + runtime on A770/A750 |
 | **Ongoing** | CI smoke matrix expansion for all platforms |
+| **Planned** | Promote Intel Arc to Tier B after broader A770/B580 validation |
+| **Planned** | Arc-accelerated Whisper STT overlay |
 
 ## Next Milestones
 
 1. Add CI smoke matrix for Linux NVIDIA/AMD and WSL logic checks.
 2. Expand macOS test coverage across M1/M2/M3/M4 variants and RAM tiers.
 3. Promote macOS from Tier B to Tier A after broader real-hardware validation.
+4. Validate Intel Arc B580 (Battlemage 12 GB) on the `ARC` tier.
+5. Promote Intel Arc from Tier C to Tier B after A770 + B580 real-hardware validation.


### PR DESCRIPTION
## Summary

- Add `docs/INTEL-ARC-GUIDE.md` — comprehensive Intel Arc GPU guide covering supported hardware, host driver setup, Docker compose overlay usage, known limitations vs NVIDIA/AMD, performance expectations, and troubleshooting
- Update `docs/SUPPORT-MATRIX.md` — add Intel Arc as Tier C (experimental), add full GPU tier map table, update roadmap
- Update `docs/HARDWARE-CLASSES.md` — register `intel_arc` hardware class

## What changed and why

### `docs/INTEL-ARC-GUIDE.md` (new)

Complete reference for users running Dream Server on Intel Arc hardware:

| Section | Contents |
|---------|----------|
| Supported hardware | ARC tier (A770 16 GB, B580 12 GB) and ARC_LITE tier (A750, A380, A310) with VRAM, tok/s, concurrent users, model assignment |
| Host driver setup | Step-by-step: Intel GPU apt repo, `intel-i915-dkms`, `intel-level-zero-gpu`, `intel-opencl-icd`, `intel-gpu-tools`, group setup, and verification commands |
| Installation | What each installer phase does for Arc; `--tier ARC` manual override |
| Docker compose | `docker-compose.arc.yml` vs `docker-compose.intel.yml` comparison; manual compose commands; key `.env` variables |
| Known limitations | Feature comparison table across NVIDIA / AMD / Intel Arc: multi-GPU, ComfyUI, Whisper, Flash Attention, FP16, image size, first-run build time, Windows support |
| Performance | tok/s benchmarks per GPU; comparison to equivalent NVIDIA tiers |
| Troubleshooting | `ZE_RESULT_ERROR_DEVICE_LOST`, SYCL JIT first-run delay, `/dev/dri` permission denied, WSL2 Arc issues, `intel_gpu_top` display quirk |

### `docs/SUPPORT-MATRIX.md`

- Added Intel Arc row to the "What Works Today" summary table (`Experimental`)
- Added Intel Arc row to the detailed platform matrix (`Tier C`) with link to guide
- Added new **GPU Tier Map** table covering all tiers (`NV_ULTRA` through `CLOUD`) including `ARC` and `ARC_LITE` with VRAM thresholds and backend column
- Updated "Current Truth" section with Arc Tier C note
- Updated Roadmap and Next Milestones: Arc → Tier B gate, B580 validation, Arc Whisper overlay

### `docs/HARDWARE-CLASSES.md`

- Added `intel_arc` entry (Intel Arc discrete GPU, Linux, SYCL backend via oneAPI)

## Test plan

- [ ] Open `docs/INTEL-ARC-GUIDE.md` and verify all code blocks render correctly in GitHub markdown
- [ ] Verify all internal cross-links resolve (`SUPPORT-MATRIX.md`, `HARDWARE-GUIDE.md`, `TROUBLESHOOTING.md`, `docker-compose.arc.yml`, `images/llama-sycl/Dockerfile`)
- [ ] Confirm `docs/SUPPORT-MATRIX.md` GPU Tier Map table renders correctly (no broken pipes)
- [ ] Follow driver setup steps on an Ubuntu 22.04 machine with Arc A770 — confirm `clinfo` and `ze_info` succeed after package install
- [ ] Run `./install.sh` on Arc A770 machine and verify Phase 02 detection output matches the validation steps described in the guide