### PR TITLE
Fix ShellCheck error and warnings in dream-server shell scripts

### DIFF
--- a/dream-server/extensions/services/token-spy/session-manager.sh
+++ b/dream-server/extensions/services/token-spy/session-manager.sh
@@ -280,7 +280,7 @@ for agent_entry in "${AGENTS[@]}"; do
   log "Checking $agent (port $port)"
 
   status_json=$(query_status "$agent" "$port")
-  local pycmd="python3"
+  pycmd="python3"
   if [[ -f "$(dirname "$0")/../../../lib/python-cmd.sh" ]]; then
     . "$(dirname "$0")/../../../lib/python-cmd.sh"
     pycmd="$(ds_detect_python_cmd)"

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -90,7 +90,8 @@ generate_dream_env() {
     webui_secret=$(new_secure_hex 32)
     local n8n_pass
     n8n_pass=$(new_secure_base64 16)
-    local litellm_key="sk-dream-$(new_secure_hex 16)"
+    local litellm_key
+    litellm_key="sk-dream-$(new_secure_hex 16)"
     local livekit_secret
     livekit_secret=$(new_secure_base64 32)
     local livekit_api_key

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -28,21 +28,21 @@ else
             apt)
                 tmpfile=$(mktemp /tmp/nodesource-setup.XXXXXX.sh)
                 if curl -fsSL --max-time 300 https://deb.nodesource.com/setup_22.x -o "$tmpfile" 2>/dev/null; then
-                    sudo -E bash "$tmpfile" >> "$LOG_FILE" 2>&1 || true
+                    sudo -E bash "$tmpfile" 2>&1 | tee -a "$LOG_FILE" || true
                 fi
                 rm -f "$tmpfile"
-                sudo apt-get install -y nodejs >> "$LOG_FILE" 2>&1 || true
+                sudo apt-get install -y nodejs 2>&1 | tee -a "$LOG_FILE" || true
                 ;;
             dnf)
-                sudo dnf module install -y nodejs:22 >> "$LOG_FILE" 2>&1 || \
-                    sudo dnf install -y nodejs >> "$LOG_FILE" 2>&1 || true
+                sudo dnf module install -y nodejs:22 2>&1 | tee -a "$LOG_FILE" || \
+                    sudo dnf install -y nodejs 2>&1 | tee -a "$LOG_FILE" || true
                 ;;
             pacman)
-                sudo pacman -S --noconfirm --needed nodejs npm >> "$LOG_FILE" 2>&1 || true
+                sudo pacman -S --noconfirm --needed nodejs npm 2>&1 | tee -a "$LOG_FILE" || true
                 ;;
             zypper)
-                sudo zypper --non-interactive install nodejs22 >> "$LOG_FILE" 2>&1 || \
-                    sudo zypper --non-interactive install nodejs >> "$LOG_FILE" 2>&1 || true
+                sudo zypper --non-interactive install nodejs22 2>&1 | tee -a "$LOG_FILE" || \
+                    sudo zypper --non-interactive install nodejs 2>&1 | tee -a "$LOG_FILE" || true
                 ;;
             *)
                 ai_warn "Unknown package manager — cannot install Node.js automatically"

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -23,7 +23,7 @@ show_phase 5 6 "Starting Services" "~2-3 minutes"
 if $DRY_RUN; then
     log "[DRY RUN] Would start services: $DOCKER_COMPOSE_CMD $COMPOSE_FLAGS up -d"
 else
-    cd "$INSTALL_DIR"
+    cd "$INSTALL_DIR" || exit 1
     # Convert COMPOSE_FLAGS string to array for safe word-splitting
     read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
     mkdir -p "$INSTALL_DIR/logs"

--- a/dream-server/lib/progress.sh
+++ b/dream-server/lib/progress.sh
@@ -119,7 +119,8 @@ print_phase() {
     local phase=$1
     local desc=$2
     local estimate=${PHASE_ESTIMATES[$phase]:-0}
-    local duration=$(format_duration $estimate)
+    local duration
+    duration=$(format_duration $estimate)
     
     echo -e "\n${BOLD}${BLUE}▶ $desc${NC} ${CYAN}(~$duration)${NC}"
 }
@@ -183,7 +184,8 @@ monitor_model_download() {
     
     while true; do
         if [[ -d "$model_dir" ]]; then
-            local current_bytes=$(du -sb "$model_dir" 2>/dev/null | cut -f1)
+            local current_bytes
+            current_bytes=$(du -sb "$model_dir" 2>/dev/null | cut -f1)
             current_bytes=${current_bytes:-0}
             
             if [[ $current_bytes -ge $expected_size_bytes ]]; then

--- a/dream-server/lib/qrcode.sh
+++ b/dream-server/lib/qrcode.sh
@@ -10,7 +10,8 @@
 # Falls back to plain text if qrencode not available
 print_dashboard_qr() {
     local url=${1:-"http://localhost:3001"}
-    local hostname=$(hostname 2>/dev/null || echo "localhost")
+    local hostname
+    hostname=$(hostname 2>/dev/null || echo "localhost")
     
     # Try to get LAN IP for remote access
     local lan_ip=""
@@ -125,7 +126,8 @@ print_install_summary() {
     local end_time=$4
     
     local duration=$((end_time - start_time))
-    local duration_str=$(format_duration $duration)
+    local duration_str
+    duration_str=$(format_duration $duration)
     
     echo ""
     echo -e "${GREEN}═══════════════════════════════════════════════════════════════${NC}"

--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -280,7 +280,8 @@ detect_apple() {
 
 # Get CPU info
 detect_cpu() {
-    local os=$(detect_os)
+    local os
+    os=$(detect_os)
     case $os in
         macos)
             sysctl -n machdep.cpu.brand_string 2>/dev/null || echo "Unknown"
@@ -293,7 +294,8 @@ detect_cpu() {
 
 # Get CPU cores
 detect_cores() {
-    local os=$(detect_os)
+    local os
+    os=$(detect_os)
     case $os in
         macos)
             sysctl -n hw.ncpu 2>/dev/null || echo "0"
@@ -306,7 +308,8 @@ detect_cores() {
 
 # Get RAM in GB
 detect_ram() {
-    local os=$(detect_os)
+    local os
+    os=$(detect_os)
     case $os in
         macos)
             sysctl -n hw.memsize 2>/dev/null | awk '{print int($1/1024/1024/1024)}'
@@ -512,7 +515,8 @@ main() {
     if [[ "$memory_type" == "unified" && "$gpu_type" == "amd" ]]; then
         tier=$(get_strix_halo_tier "$ram")
     elif [[ "$gpu_type" == "apple" ]]; then
-        local unified_gb=$((gpu_vram_mb / 1024))
+        local unified_gb
+        unified_gb=$((gpu_vram_mb / 1024))
         tier=$(get_apple_tier "$unified_gb")
     else
         tier=$(get_tier "$gpu_vram_mb")
@@ -520,7 +524,8 @@ main() {
     tier_desc=$(tier_description "$tier")
     recommended_model=$(tier_model "$tier")
 
-    local gpu_vram_gb=$((gpu_vram_mb / 1024))
+    local gpu_vram_gb
+    gpu_vram_gb=$((gpu_vram_mb / 1024))
 
     if $json_output; then
         # Emit JSON with escaping to avoid breaking downstream parsers.

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -95,12 +95,15 @@ _now_ms() {
 
 # llama-server: critical path — performs an actual inference test
 test_llm() {
-    local start=$(_now_ms)
-    local response=$(curl -sf --max-time $TIMEOUT \
+    local start
+    start=$(_now_ms)
+    local response
+    response=$(curl -sf --max-time $TIMEOUT \
         -H "Content-Type: application/json" \
         -d '{"model":"default","prompt":"Hi","max_tokens":1}' \
         "http://${LLM_HOST}:${LLM_PORT}/v1/completions" 2>/dev/null)
-    local end=$(_now_ms)
+    local end
+    end=$(_now_ms)
 
     if echo "$response" | grep -q '"text"'; then
         result_set "llm" "ok"
@@ -139,7 +142,8 @@ test_service() {
 # System-level: GPU
 test_gpu() {
     if command -v nvidia-smi &>/dev/null; then
-        local gpu_info=$(nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu,temperature.gpu --format=csv,noheader,nounits 2>/dev/null | head -1)
+        local gpu_info
+        gpu_info=$(nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu,temperature.gpu --format=csv,noheader,nounits 2>/dev/null | head -1)
         if [ -n "$gpu_info" ]; then
             IFS=',' read -r mem_used mem_total gpu_util temp <<< "$gpu_info"
             result_set "gpu" "ok"
@@ -164,7 +168,8 @@ test_gpu() {
 
 # System-level: Disk
 test_disk() {
-    local usage=$(df -h "$INSTALL_DIR" 2>/dev/null | tail -1 | awk '{print $5}' | tr -d '%')
+    local usage
+    usage=$(df -h "$INSTALL_DIR" 2>/dev/null | tail -1 | awk '{print $5}' | tr -d '%')
     if [ -n "$usage" ]; then
         result_set "disk" "ok"
         result_set "disk_usage" "$usage"

--- a/dream-server/scripts/llm-cold-storage.sh
+++ b/dream-server/scripts/llm-cold-storage.sh
@@ -33,7 +33,8 @@ PROTECTED_MODELS=(
 )
 
 log() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
+    local msg
+    msg="[$(date '+%Y-%m-%d %H:%M:%S')] $*"
     echo "$msg" | tee -a "$LOG_FILE"
 }
 

--- a/dream-server/scripts/migrate-config.sh
+++ b/dream-server/scripts/migrate-config.sh
@@ -91,8 +91,9 @@ compare_versions() {
 cmd_backup() {
     log_info "Backing up current configuration..."
     
-    local backup_name="config-$(date +%Y%m%d-%H%M%S)"
-    local backup_path="${BACKUP_DIR}/${backup_name}"
+    local backup_name backup_path
+    backup_name="config-$(date +%Y%m%d-%H%M%S)"
+    backup_path="${BACKUP_DIR}/${backup_name}"
     
     mkdir -p "$backup_path"
     
@@ -161,8 +162,9 @@ cmd_check() {
     log_info "Last migrated: $last_migrated"
     
     compare_versions "$current_version" "$last_migrated"
-    local result=$?
-    
+    local result
+    result=$?
+
     if [[ $result -eq 2 ]]; then
         log_warn "Migration needed: $last_migrated → $current_version"
         

--- a/dream-server/scripts/pre-download.sh
+++ b/dream-server/scripts/pre-download.sh
@@ -126,8 +126,9 @@ detect_ram_gb() {
 }
 
 recommend_tier() {
-    local vram=$(detect_vram_gb)
-    local ram=$(detect_ram_gb)
+    local vram ram
+    vram=$(detect_vram_gb)
+    ram=$(detect_ram_gb)
     
     if [[ $vram -ge 40 ]]; then
         echo "cluster"
@@ -225,8 +226,8 @@ verify_cache() {
     local missing=0
     
     for tier in nano edge pro cluster; do
-        local model="${TIER_MODELS[$tier]}"
-        if verify_model "$model" 2>/dev/null; then
+        local tier_model="${TIER_MODELS[$tier]}"
+        if verify_model "$tier_model" 2>/dev/null; then
             ((found++))
         else
             echo -e "  ${RED}✗${NC} $tier: Not cached"
@@ -270,7 +271,8 @@ download_tier() {
     echo ""
     
     # Estimate time
-    local est_minutes=$((size * 2))  # ~0.5GB/min on average connection
+    local est_minutes
+    est_minutes=$((size * 2))  # ~0.5GB/min on average connection
     warn "Estimated download time: ${est_minutes}-$((est_minutes * 2)) minutes (depends on connection)"
     echo ""
     
@@ -302,9 +304,10 @@ interactive_menu() {
     print_banner
     check_dependencies
     
-    local recommended=$(recommend_tier)
-    local vram=$(detect_vram_gb)
-    local ram=$(detect_ram_gb)
+    local recommended vram ram
+    recommended=$(recommend_tier)
+    vram=$(detect_vram_gb)
+    ram=$(detect_ram_gb)
     
     echo -e "${BOLD}Detected Hardware:${NC}"
     echo "  RAM:  ${ram}GB"

--- a/dream-server/scripts/upgrade-model.sh
+++ b/dream-server/scripts/upgrade-model.sh
@@ -88,25 +88,29 @@ NC='\033[0m'
 #-----------------------------------------------------------------------------
 
 log() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+    local msg
+    msg="[$(date '+%Y-%m-%d %H:%M:%S')] $1"
     echo "$msg" >> "$LOG_FILE"
     echo -e "${BLUE}[INFO]${NC} $1"
 }
 
 success() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] SUCCESS: $1"
+    local msg
+    msg="[$(date '+%Y-%m-%d %H:%M:%S')] SUCCESS: $1"
     echo "$msg" >> "$LOG_FILE"
     echo -e "${GREEN}[OK]${NC} $1"
 }
 
 warn() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] WARN: $1"
+    local msg
+    msg="[$(date '+%Y-%m-%d %H:%M:%S')] WARN: $1"
     echo "$msg" >> "$LOG_FILE"
     echo -e "${YELLOW}[WARN]${NC} $1"
 }
 
 error() {
-    local msg="[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1"
+    local msg
+    msg="[$(date '+%Y-%m-%d %H:%M:%S')] ERROR: $1"
     echo "$msg" >> "$LOG_FILE"
     echo -e "${RED}[ERROR]${NC} $1" >&2
 }
@@ -271,9 +275,10 @@ cmd_list() {
     if [[ -d "$MODELS_DIR" ]]; then
         for model_dir in "$MODELS_DIR"/*/; do
             if [[ -f "${model_dir}config.json" ]]; then
-                local model_name=$(basename "$model_dir")
-                local size=$(du -sh "$model_dir" 2>/dev/null | cut -f1)
-                local current=$(get_current_model)
+                local model_name size current
+                model_name=$(basename "$model_dir")
+                size=$(du -sh "$model_dir" 2>/dev/null | cut -f1)
+                current=$(get_current_model)
                 
                 if [[ "$model_name" == "$current" ]]; then
                     echo -e "  ${GREEN}● $model_name${NC} ($size) [ACTIVE]"

--- a/dream-server/tests/benchmark-status-performance.sh
+++ b/dream-server/tests/benchmark-status-performance.sh
@@ -60,22 +60,25 @@ trap cleanup_mock_services EXIT
 
 # Simulate sequential health checks (old implementation)
 benchmark_sequential() {
-    local start=$(_now_ms)
+    local start
+    start=$(_now_ms)
 
     # Simulate 13 sequential curl calls with 1 second timeout each
     for i in {1..13}; do
         curl -sf --max-time 1 http://localhost:8080/health > /dev/null 2>&1 || true
     done
 
-    local end=$(_now_ms)
-    local duration=$(( end - start ))
+    local end duration
+    end=$(_now_ms)
+    duration=$(( end - start ))
     echo $duration
 }
 
 # Simulate parallel health checks (new implementation)
 benchmark_parallel() {
-    local start=$(_now_ms)
-    local tmpdir=$(mktemp -d)
+    local start tmpdir
+    start=$(_now_ms)
+    tmpdir=$(mktemp -d)
     local -a pids=()
 
     # Launch 13 parallel curl calls
@@ -89,8 +92,9 @@ benchmark_parallel() {
         wait "$pid" 2>/dev/null || true
     done
 
-    local end=$(_now_ms)
-    local duration=$(( end - start ))
+    local end duration
+    end=$(_now_ms)
+    duration=$(( end - start ))
     rm -rf "$tmpdir"
     echo $duration
 }

--- a/dream-server/tests/test-dashboard-integration.sh
+++ b/dream-server/tests/test-dashboard-integration.sh
@@ -31,7 +31,8 @@ echo "0" > "$FAIL_FILE"
 increment_pass() {
     (
         flock -x 200
-        local count=$(cat "$PASS_FILE")
+        local count
+        count=$(cat "$PASS_FILE")
         echo $((count + 1)) > "$PASS_FILE"
     ) 200>"$PASS_FILE.lock"
 }
@@ -39,7 +40,8 @@ increment_pass() {
 increment_fail() {
     (
         flock -x 200
-        local count=$(cat "$FAIL_FILE")
+        local count
+        count=$(cat "$FAIL_FILE")
         echo $((count + 1)) > "$FAIL_FILE"
     ) 200>"$FAIL_FILE.lock"
 }
@@ -181,7 +183,7 @@ echo -e "  Results: ${GREEN}$(get_passed) passed${NC}, ${RED}$(get_failed) faile
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
 
-if [ $(get_failed) -gt 0 ]; then
+if [ "$(get_failed)" -gt 0 ]; then
     exit 1
 fi
 

--- a/dream-server/tests/test-integration.sh
+++ b/dream-server/tests/test-integration.sh
@@ -55,7 +55,7 @@ test_http() {
     local method="${4:-GET}"
     local data="${5:-}"
     
-    local args=(-s -o /dev/null -w "%{http_code}" --max-time $TIMEOUT)
+    local args=(-s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT")
     [[ -n "$data" ]] && args+=(-X "$method" -H "Content-Type: application/json" -d "$data")
     
     local code

--- a/dream-server/tests/test-model-integrity.sh
+++ b/dream-server/tests/test-model-integrity.sh
@@ -47,7 +47,8 @@ test_tier_map_has_sha256() {
     fi
 
     # Check that at least some tiers have non-empty checksums
-    local checksum_count=$(grep 'GGUF_SHA256="[a-f0-9]\{64\}"' "$tier_map" | wc -l)
+    local checksum_count
+    checksum_count=$(grep 'GGUF_SHA256="[a-f0-9]\{64\}"' "$tier_map" | wc -l)
     if [[ $checksum_count -lt 2 ]]; then
         fail "tier-map.sh has too few valid SHA256 checksums (found: $checksum_count)"
         return
@@ -112,18 +113,21 @@ test_corrupt_file_handling() {
 test_checksum_verification() {
     info "Testing checksum verification with test data..."
 
-    local tmpdir=$(mktemp -d)
-    trap "rm -rf $tmpdir" RETURN
+    local tmpdir
+    tmpdir=$(mktemp -d)
+    trap 'rm -rf "$tmpdir"' RETURN
 
     # Create test file with known content
     echo "test content" > "$tmpdir/test.gguf"
 
     # Calculate actual hash
-    local actual_hash=$(sha256sum "$tmpdir/test.gguf" | awk '{print $1}')
+    local actual_hash
+    actual_hash=$(sha256sum "$tmpdir/test.gguf" | awk '{print $1}')
 
     # Test matching hash
     local test_hash="$actual_hash"
-    local result=$(sha256sum "$tmpdir/test.gguf" | awk '{print $1}')
+    local result
+    result=$(sha256sum "$tmpdir/test.gguf" | awk '{print $1}')
 
     if [[ "$result" != "$test_hash" ]]; then
         fail "sha256sum verification failed for matching hash"
@@ -166,7 +170,8 @@ test_dual_verification() {
     local phase11="$ROOT_DIR/installers/phases/11-services.sh"
 
     # Count verification blocks
-    local verify_count=$(grep -c "Verifying.*integrity" "$phase11" || echo "0")
+    local verify_count
+    verify_count=$(grep -c "Verifying.*integrity" "$phase11" || echo "0")
 
     if [[ $verify_count -lt 2 ]]; then
         fail "phase 11 should verify integrity before and after download (found: $verify_count)"

--- a/dream-server/tests/test-network-timeouts.sh
+++ b/dream-server/tests/test-network-timeouts.sh
@@ -42,7 +42,8 @@ test_file_has_timeout() {
     fi
 
     # Find lines matching the pattern
-    local matches=$(grep -n "$pattern" "$file" 2>/dev/null || true)
+    local matches
+    matches=$(grep -n "$pattern" "$file" 2>/dev/null || true)
 
     if [[ -z "$matches" ]]; then
         echo -e "${YELLOW}SKIP (no matches)${NC}"
@@ -52,8 +53,9 @@ test_file_has_timeout() {
     # Check if timeout is present on the same line or nearby
     local has_timeout=false
     while IFS= read -r line; do
-        local line_num=$(echo "$line" | cut -d: -f1)
-        local line_content=$(echo "$line" | cut -d: -f2-)
+        local line_num line_content
+        line_num=$(echo "$line" | cut -d: -f1)
+        line_content=$(echo "$line" | cut -d: -f2-)
 
         # Check if timeout is on the same line (use grep -F for fixed string)
         if echo "$line_content" | grep -qF -- "$timeout_pattern"; then
@@ -63,8 +65,9 @@ test_file_has_timeout() {
 
         # Check next 2 lines for multiline commands
         for offset in 1 2; do
-            local check_line=$((line_num + offset))
-            local next_line=$(sed -n "${check_line}p" "$file" 2>/dev/null || true)
+            local check_line next_line
+            check_line=$((line_num + offset))
+            next_line=$(sed -n "${check_line}p" "$file" 2>/dev/null || true)
             if echo "$next_line" | grep -qF -- "$timeout_pattern"; then
                 has_timeout=true
                 break 2


### PR DESCRIPTION
- Fix the ShellCheck error that fails CI: remove invalid `local` in token-spy session-manager.sh (SC2168).
- Fix ShellCheck warnings across dream-server shell scripts (SC2155, SC2164, SC2024, SC2064, SC2046, SC2206, SC2178) so the shell lint job is clean.

Scope: only dream-server *.sh files; no Python, docs, or installer env content changes.