### PR TITLE
fix: agent_monitor logger, workflow tests, update endpoint, and Ruff so API and lint pass

### DIFF
--- a/dream-server/extensions/services/dashboard-api/agent_monitor.py
+++ b/dream-server/extensions/services/dashboard-api/agent_monitor.py
@@ -5,11 +5,14 @@ Collects real-time metrics on agent swarms, sessions, and throughput.
 
 import asyncio
 import json
+import logging
+import os
 from datetime import datetime, timedelta
 from typing import List
-import os
 
 import aiohttp
+
+logger = logging.getLogger(__name__)
 
 TOKEN_SPY_URL = os.environ.get("TOKEN_SPY_URL", "http://token-spy:8080")
 TOKEN_SPY_API_KEY = os.environ.get("TOKEN_SPY_API_KEY", "")

--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -84,6 +84,8 @@ async def get_release_manifest():
 @router.post("/api/update")
 async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks, api_key: str = Depends(verify_api_key)):
     """Trigger update actions via dashboard (non-blocking subprocess)."""
+    if action.action not in ("check", "backup", "update"):
+        raise HTTPException(status_code=400, detail=f"Unknown action: {action.action}")
     script_path = Path(INSTALL_DIR).parent / "scripts" / "dream-update.sh"
     if not script_path.exists():
         install_script = Path(INSTALL_DIR) / "install.sh"
@@ -122,7 +124,8 @@ async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks
         except OSError:
             logger.exception("Backup failed")
             raise HTTPException(status_code=500, detail="Backup failed")
-    elif action.action == "update":
+    else:
+        # action.action == "update"
         async def run_update():
             proc = await asyncio.create_subprocess_exec(
                 str(script_path), "update",
@@ -131,5 +134,3 @@ async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks
             await proc.communicate()
         background_tasks.add_task(run_update)
         return {"success": True, "message": "Update started in background. Check logs for progress."}
-    else:
-        raise HTTPException(status_code=400, detail=f"Unknown action: {action.action}")

--- a/dream-server/extensions/services/dashboard-api/tests/test_updates.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_updates.py
@@ -1,7 +1,6 @@
 """Tests for updates router endpoints."""
 
 from unittest.mock import patch, MagicMock
-from pathlib import Path
 
 
 def test_get_version_requires_auth(test_client):
@@ -23,8 +22,6 @@ def test_get_version_authenticated(test_client):
 
 def test_get_version_with_mock_github(test_client):
     """GET /api/version with mocked GitHub API → returns update info."""
-    import urllib.request
-
     mock_response = MagicMock()
     mock_response.read.return_value = b'{"tag_name": "v2.0.0", "html_url": "https://github.com/test"}'
     mock_response.__enter__ = lambda self: self

--- a/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
@@ -1,8 +1,5 @@
 """Tests for workflows router endpoints."""
 
-from unittest.mock import patch, AsyncMock
-
-
 def test_workflows_requires_auth(test_client):
     """GET /api/workflows without auth → 401."""
     resp = test_client.get("/api/workflows")
@@ -21,32 +18,33 @@ def test_workflows_authenticated(test_client):
 
 
 def test_workflow_categories_requires_auth(test_client):
-    """GET /api/workflows/categories without auth → 401."""
-    resp = test_client.get("/api/workflows/categories")
+    """GET /api/workflows without auth → 401 (categories are in same endpoint)."""
+    resp = test_client.get("/api/workflows")
     assert resp.status_code == 401
 
 
 def test_workflow_categories_authenticated(test_client):
-    """GET /api/workflows/categories with auth → 200, returns categories."""
-    resp = test_client.get("/api/workflows/categories", headers=test_client.auth_headers)
+    """GET /api/workflows with auth → 200, returns categories in response."""
+    resp = test_client.get("/api/workflows", headers=test_client.auth_headers)
     assert resp.status_code == 200
     data = resp.json()
-    assert isinstance(data, dict)
+    assert "categories" in data
+    assert isinstance(data["categories"], dict)
 
 
 def test_n8n_status_requires_auth(test_client):
-    """GET /api/workflows/n8n/status without auth → 401."""
-    resp = test_client.get("/api/workflows/n8n/status")
+    """GET /api/workflows without auth → 401 (n8n info is in same endpoint)."""
+    resp = test_client.get("/api/workflows")
     assert resp.status_code == 401
 
 
 def test_n8n_status_authenticated(test_client):
-    """GET /api/workflows/n8n/status with auth → 200, returns n8n status."""
-    resp = test_client.get("/api/workflows/n8n/status", headers=test_client.auth_headers)
+    """GET /api/workflows with auth → 200, returns n8nAvailable and n8nUrl."""
+    resp = test_client.get("/api/workflows", headers=test_client.auth_headers)
     assert resp.status_code == 200
     data = resp.json()
-    assert "available" in data
-    assert "workflow_count" in data
+    assert "n8nAvailable" in data
+    assert "n8nUrl" in data
 
 
 def test_workflow_enable_requires_auth(test_client):
@@ -56,6 +54,6 @@ def test_workflow_enable_requires_auth(test_client):
 
 
 def test_workflow_disable_requires_auth(test_client):
-    """POST /api/workflows/{id}/disable without auth → 401."""
-    resp = test_client.post("/api/workflows/test-workflow/disable")
+    """DELETE /api/workflows/{id} without auth → 401."""
+    resp = test_client.delete("/api/workflows/test-workflow")
     assert resp.status_code == 401

--- a/dream-server/scripts/healthcheck.py
+++ b/dream-server/scripts/healthcheck.py
@@ -54,7 +54,7 @@ import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
-from typing import Iterable, List, Optional, Sequence, Set, Tuple
+from typing import List, Optional, Sequence, Set, Tuple
 
 
 # -----------------------------

--- a/dream-server/scripts/validate-sim-summary.py
+++ b/dream-server/scripts/validate-sim-summary.py
@@ -32,7 +32,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 Json = Union[None, bool, int, float, str, List["Json"], Dict[str, "Json"]]
 

--- a/dream-server/tests/contracts/test-port-contracts.py
+++ b/dream-server/tests/contracts/test-port-contracts.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import re
-import sys
 from pathlib import Path
 
 


### PR DESCRIPTION
- agent_monitor.py: add logger = logging.getLogger(__name__) (fixes NameError in test_agent_monitor).
- Workflow tests: align with API — use GET /api/workflows for categories and n8n info, DELETE /api/workflows/{id} for disable auth check.
- Updates router: validate action before script path check so unknown action returns 400 (fixes test_trigger_update_unknown_action).
- Ruff: remove unused imports in dashboard-api tests (test_updates, test_workflows), scripts/healthcheck.py, scripts/validate-sim-summary.py, tests/contracts/test-port-contracts.py.