### PR TITLE
docs: fix broken links and link consistency across dream-server/docs

### DIFF
--- a/dream-server/docs/BACKEND-CONTRACT.md
+++ b/dream-server/docs/BACKEND-CONTRACT.md
@@ -34,4 +34,4 @@ The modular installer loads backend contracts in `installers/lib/detection.sh` v
 - OpenClaw provider wiring (`installers/phases/06-directories.sh`)
 - LLM API summary endpoint (`installers/phases/13-summary.sh`)
 
-See [docs/INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) for the full module map.
+See [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) for the full module map.

--- a/dream-server/docs/COMPOSABILITY-EXECUTION-BOARD.md
+++ b/dream-server/docs/COMPOSABILITY-EXECUTION-BOARD.md
@@ -113,9 +113,9 @@ Status: `DONE`
 Owner: Docs + Infra  
 Effort: 1 day  
 Files:
-- [`docs/PROFILES.md`](../docs/PROFILES.md)
-- [`docs/TROUBLESHOOTING.md`](../docs/TROUBLESHOOTING.md)
-- [`docs/INTEGRATION-GUIDE.md`](../docs/INTEGRATION-GUIDE.md)
+- [PROFILES.md](PROFILES.md)
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
+- [INTEGRATION-GUIDE.md](INTEGRATION-GUIDE.md)
 Acceptance:
 - `docker compose` style standardized.
 - Compose examples match canonical contract from W3-M1.
@@ -208,7 +208,7 @@ Effort: 1-2 days
 Files:
 - `config/n8n/catalog.json` (planned; not yet created)
 - [`dashboard-api/main.py`](../extensions/services/dashboard-api/main.py)
-- [`docs/INTEGRATION-GUIDE.md`](../docs/INTEGRATION-GUIDE.md)
+- [INTEGRATION-GUIDE.md](INTEGRATION-GUIDE.md)
 Acceptance:
 - One canonical workflow path in code/docs.
 - Catalog supports both templates and metadata cleanly.

--- a/dream-server/docs/EXTENSIONS.md
+++ b/dream-server/docs/EXTENSIONS.md
@@ -5,7 +5,7 @@
 | I want to... | Type | Start here |
 |---|---|---|
 | Add a Docker service (new container, health check, dashboard tile) | Service extension | This guide (below) |
-| Change the installer itself (new tier, swap theme, add/skip phase) | Installer mod | [docs/INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) |
+| Change the installer itself (new tier, swap theme, add/skip phase) | Installer mod | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) |
 
 This guide is the fastest path to extend Dream Server without editing core internals.
 

--- a/dream-server/docs/INTEL-ARC-GUIDE.md
+++ b/dream-server/docs/INTEL-ARC-GUIDE.md
@@ -276,8 +276,8 @@ sudo intel_gpu_top -l 1 | grep -i mem
 
 ## Related Docs
 
-- [`docs/SUPPORT-MATRIX.md`](SUPPORT-MATRIX.md) — platform support tiers
-- [`docs/HARDWARE-GUIDE.md`](HARDWARE-GUIDE.md) — GPU buying guide and tier overview
-- [`docs/TROUBLESHOOTING.md`](TROUBLESHOOTING.md) — general installer troubleshooting
+- [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md) — platform support tiers
+- [HARDWARE-GUIDE.md](HARDWARE-GUIDE.md) — GPU buying guide and tier overview
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) — general installer troubleshooting
 - [`docker-compose.arc.yml`](../docker-compose.arc.yml) — Intel Arc compose overlay
 - [`images/llama-sycl/Dockerfile`](../images/llama-sycl/Dockerfile) — SYCL build image

--- a/dream-server/docs/OSS-LAUNCH-CHECKLIST.md
+++ b/dream-server/docs/OSS-LAUNCH-CHECKLIST.md
@@ -10,25 +10,25 @@ Scope: `/home/user/dream-server` (Strix Halo variant)
 - [x] Add installer capability profile contract and loader wiring:
   - [`config/capability-profile.schema.json`](../config/capability-profile.schema.json)
   - [`scripts/build-capability-profile.sh`](../scripts/build-capability-profile.sh)
-  - [`docs/CAPABILITY-PROFILE.md`](../docs/CAPABILITY-PROFILE.md)
+  - [CAPABILITY-PROFILE.md](CAPABILITY-PROFILE.md)
 - [x] Add capability-aware preflight and machine-readable reporting:
   - [`scripts/preflight-engine.sh`](../scripts/preflight-engine.sh)
-  - [`docs/PREFLIGHT-ENGINE.md`](../docs/PREFLIGHT-ENGINE.md)
+  - [PREFLIGHT-ENGINE.md](PREFLIGHT-ENGINE.md)
 - [x] Add backend runtime contracts and loader:
   - [`config/backends/`](../config/backends)
   - [`scripts/load-backend-contract.sh`](../scripts/load-backend-contract.sh)
-  - [`docs/BACKEND-CONTRACT.md`](../docs/BACKEND-CONTRACT.md)
+  - [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md)
 - [x] Upgrade Windows/macOS installer stubs to MVP flows:
   - [`installers/windows.ps1`](../installers/windows.ps1) (WSL delegation)
   - [`installers/macos.sh`](../installers/macos.sh) (doctor/preflight)
 - [x] Add Dream Doctor diagnostics report:
   - [`scripts/dream-doctor.sh`](../scripts/dream-doctor.sh)
-  - [`docs/DREAM-DOCTOR.md`](../docs/DREAM-DOCTOR.md)
+  - [DREAM-DOCTOR.md](DREAM-DOCTOR.md)
 - [x] Add one-command installer simulation harness:
   - [`scripts/simulate-installers.sh`](../scripts/simulate-installers.sh)
   - Outputs: `artifacts/installer-sim/summary.json`, `artifacts/installer-sim/SUMMARY.md`
 - [x] Add launch-claim truth table:
-  - [`docs/PLATFORM-TRUTH-TABLE.md`](../docs/PLATFORM-TRUTH-TABLE.md)
+  - [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md)
 
 ## P0: Must Fix Before OSS Launch
 
@@ -77,14 +77,14 @@ Scope: `/home/user/dream-server` (Strix Halo variant)
 1. **Split NVIDIA vs Strix docs or add clear command matrix**
 - Why: mixed instructions (legacy llama-server and current `llama-server:8080`) create operator confusion.
 - Evidence:
-  - [`README.md`](../README.md), [`FAQ.md`](../FAQ.md), [`docs/TROUBLESHOOTING.md`](../docs/TROUBLESHOOTING.md)
+  - [`README.md`](../README.md), [`FAQ.md`](../FAQ.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md)
 - Owner: Docs Maintainer
 - Effort: M (0.5-1 day)
 
 2. **Modernize old `docker-compose` command style in docs**
 - Why: docs mix `docker-compose` and `docker compose`; standardizing reduces support friction.
 - Evidence:
-  - [`docs/PROFILES.md`](../docs/PROFILES.md)
+  - [PROFILES.md](PROFILES.md)
 - Owner: Docs Maintainer
 - Effort: S (1-2 hours)
 

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -1,5 +1,7 @@
 # Dream Server Documentation Index
 
+Links from this directory use `../` for the repo root (e.g. `../README.md`, `../QUICKSTART.md`) and bare filenames for other docs in this directory (e.g. `EXTENSIONS.md`, `TROUBLESHOOTING.md`). **FAQ:** `../FAQ.md` is the installation and usage FAQ at repo root; `FAQ.md` in this directory is the hardware and requirements FAQ.
+
 ## Getting Started
 
 | Doc | Audience | Description |

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -12,7 +12,7 @@ Last updated: 2026-03-17
 | **Linux + NVIDIA (CUDA)** | **Supported** | Complete install and runtime. Broader distro test matrix still expanding. |
 | **Windows (Docker Desktop + WSL2)** | **Supported** | Complete install and runtime via `.\install.ps1`. GPU auto-detection (NVIDIA/AMD). |
 | **macOS (Apple Silicon)** | **Supported** | Complete install and runtime via `./install.sh`. Native Metal inference + Docker services. |
-| **Linux + Intel Arc (SYCL)** | **Experimental** | Installer auto-detects Arc, assigns ARC/ARC\_LITE tier, and selects `docker-compose.arc.yml`. End-to-end runtime on A770/A750. See [`docs/INTEL-ARC-GUIDE.md`](INTEL-ARC-GUIDE.md). |
+| **Linux + Intel Arc (SYCL)** | **Experimental** | Installer auto-detects Arc, assigns ARC/ARC\_LITE tier, and selects `docker-compose.arc.yml`. End-to-end runtime on A770/A750. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md). |
 
 ## Support Tiers
 


### PR DESCRIPTION
Summary
Improves link consistency and clarity in dream-server/docs/ so all internal doc links use the same style and readers can tell which FAQ is which.

Changes
- Link style: Use bare filenames for docs in the same directory (e.g. [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md)) instead of docs/ or ../docs/ in SUPPORT-MATRIX, INTEL-ARC-GUIDE, COMPOSABILITY-EXECUTION-BOARD, OSS-LAUNCH-CHECKLIST, EXTENSIONS, and BACKEND-CONTRACT.
- docs/README.md: Add a short “link convention” note (use ../ for repo root, bare names for same-directory docs) and clarify that ../FAQ.md is the installation/usage FAQ at repo root and FAQ.md in this directory is the hardware/requirements FAQ.

Scope
- Touched: 7 files under dream-server/docs/.
- Theme: Doc links and link consistency only; no content or code changes.
- Verification: All link targets were checked; no broken links, only normalization and clarification.