### PR TITLE
Add HEALTHCHECK to APE Dockerfile

### DIFF
--- a/dream-server/extensions/services/ape/Dockerfile
+++ b/dream-server/extensions/services/ape/Dockerfile
@@ -11,6 +11,9 @@ RUN adduser --system --no-create-home ape
 
 EXPOSE 7890
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:7890/health')" || exit 1
+
 USER ape
 
 CMD ["python", "main.py"]


### PR DESCRIPTION
## Summary
Adds Docker HEALTHCHECK directive to APE service for consistency with other services.

## Changes
- Added HEALTHCHECK to APE Dockerfile matching the pattern used in dashboard-api, token-spy, privacy-shield, and comfyui
- Interval: 30s, timeout: 5s, start-period: 5s, retries: 3
- Probes `/health` endpoint using Python urllib

## Consistency
All other Python services in the stack have healthchecks:
- dashboard-api: curl-based healthcheck
- token-spy: Python urllib healthcheck  
- privacy-shield: Python urllib healthcheck
- comfyui: wget-based healthcheck

APE was the only Python service missing this directive.