### PR TITLE
Add test coverage for workflows router endpoints

### DIFF
--- a/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
@@ -59,3 +59,36 @@ def test_workflow_disable_requires_auth(test_client):
     """POST /api/workflows/{id}/disable without auth → 401."""
     resp = test_client.post("/api/workflows/test-workflow/disable")
     assert resp.status_code == 401
+
+
+def test_workflow_executions_requires_auth(test_client):
+    """GET /api/workflows/{id}/executions without auth → 401."""
+    resp = test_client.get("/api/workflows/test-workflow/executions")
+    assert resp.status_code == 401
+
+
+def test_workflow_enable_authenticated(test_client):
+    """POST /api/workflows/{id}/enable with auth → 404 when workflow not in catalog."""
+    resp = test_client.post(
+        "/api/workflows/nonexistent-workflow/enable",
+        headers=test_client.auth_headers
+    )
+    assert resp.status_code == 404
+
+
+def test_workflow_disable_authenticated(test_client):
+    """DELETE /api/workflows/{id} with auth → 404 when workflow not in catalog."""
+    resp = test_client.delete(
+        "/api/workflows/nonexistent-workflow",
+        headers=test_client.auth_headers
+    )
+    assert resp.status_code == 404
+
+
+def test_workflow_executions_authenticated(test_client):
+    """GET /api/workflows/{id}/executions with auth → 404 when workflow not in catalog."""
+    resp = test_client.get(
+        "/api/workflows/nonexistent-workflow/executions",
+        headers=test_client.auth_headers
+    )
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- Add missing test coverage for workflows router endpoints (DELETE, GET executions)
- Add authenticated endpoint tests for enable/disable/executions

## Motivation
Workflows router had 4 endpoints but incomplete test coverage:
- `DELETE /api/workflows/{id}` - zero tests
- `GET /api/workflows/{id}/executions` - zero tests
- `POST /api/workflows/{id}/enable` - only auth test, missing authenticated test

All other routers have comprehensive test coverage following the pattern: auth enforcement tests + authenticated endpoint tests.

## Changes
Added 4 new tests:
- `test_workflow_executions_requires_auth` - auth enforcement for executions endpoint
- `test_workflow_enable_authenticated` - authenticated test (404 on missing workflow)
- `test_workflow_disable_authenticated` - authenticated test for DELETE endpoint
- `test_workflow_executions_authenticated` - authenticated test for executions endpoint

## Testing
Tests follow the same pattern as other routers:
- Auth enforcement tests verify 401 without credentials
- Authenticated tests verify proper error handling (404 for nonexistent workflows)