### PR TITLE
fix: fresh install fails on missing WEBUI_SECRET

### DIFF
--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -75,7 +75,7 @@ services:
       OPENAI_API_BASE_URL: "${LLM_API_URL:-http://llama-server:8080}/v1"
       OPENAI_API_KEY: ""
       WEBUI_AUTH: "${WEBUI_AUTH:-true}"
-      WEBUI_SECRET_KEY: "${WEBUI_SECRET:?Set WEBUI_SECRET in .env}"
+      WEBUI_SECRET_KEY: "${WEBUI_SECRET:-changeme}"
       ENABLE_WEB_SEARCH: "true"
       WEB_SEARCH_ENGINE: "searxng"
       SEARXNG_QUERY_URL: "http://searxng:8080/search?q=<query>&format=json"

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -325,8 +325,9 @@ fi
 # Resolve compose overlay files
 resolve_compose_config
 
-# Validate compose stack syntax before proceeding
-if [[ -n "${COMPOSE_FLAGS:-}" ]]; then
+# Validate compose stack syntax before proceeding (skip on fresh install — .env
+# is not generated until phase 06, so variable interpolation would fail)
+if [[ -n "${COMPOSE_FLAGS:-}" ]] && [[ -f "$INSTALL_DIR/.env" ]]; then
     ai "Validating compose stack configuration..."
     if "$SCRIPT_DIR/scripts/validate-compose-stack.sh" --compose-flags "$COMPOSE_FLAGS" --quiet >> "$LOG_FILE" 2>&1; then
         ai_ok "Compose stack validated"


### PR DESCRIPTION
## Summary
- Fixes #369 — fresh installs crash at compose selection with `required variable WEBUI_SECRET is missing a value`
- Root cause: `docker compose config` runs in **phase 02** (detection) but `.env` is not generated until **phase 06** (directories)
- `WEBUI_SECRET` was the only variable in `docker-compose.base.yml` using `:?` (crash-on-missing) syntax — every other variable uses `:-default`

## Changes
- **`docker-compose.base.yml`**: Replace `${WEBUI_SECRET:?...}` with `${WEBUI_SECRET:-changeme}` — the real secret (openssl rand -hex 32) is always written to `.env` in phase 06 before services start in phase 11, so the placeholder is never used at runtime
- **`installers/phases/02-detection.sh`**: Skip compose validation when `.env` doesn't exist yet (fresh install) — validation can't succeed without it

## Test plan
- [ ] Fresh install on a clean machine — should no longer fail at compose selection
- [ ] Re-install on existing machine (`.env` already exists) — compose validation still runs
- [ ] Verify `WEBUI_SECRET` in `.env` after full install is a real 64-char hex string, not "changeme"

🤖 Generated with [Claude Code](https://claude.com/claude-code)