### PR TITLE
fix(extensions): correct gpu_backends and container_names for 6 CPU services

### DIFF
--- a/resources/dev/extensions-library/services/aider/compose.yaml
+++ b/resources/dev/extensions-library/services/aider/compose.yaml
@@ -3,7 +3,7 @@ name: aider
 services:
   aider:
     image: paulgauthier/aider:v0.86.2
-    container_name: aider
+    container_name: dream-aider
     volumes:
       - ./data/aider:/app
       # Note: Mount git/ssh configs manually if needed:

--- a/resources/dev/extensions-library/services/aider/manifest.yaml
+++ b/resources/dev/extensions-library/services/aider/manifest.yaml
@@ -4,7 +4,7 @@ service:
   id: aider
   name: Aider
   aliases: [aider-chat, pair-programming]
-  container_name: aider
+  container_name: dream-aider
   host_env: AIDER_HOST
   default_host: aider
   port: 0
@@ -12,7 +12,7 @@ service:
   external_port_default: 0
   health: ""
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -38,4 +38,4 @@ features:
     enabled_services_all: [aider]
     setup_time: ~1 minute
     priority: 11
-    gpu_backends: []
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/chromadb/compose.yaml
+++ b/resources/dev/extensions-library/services/chromadb/compose.yaml
@@ -3,7 +3,7 @@ name: chromadb
 services:
   chromadb:
     image: chromadb/chroma:1.5.3
-    container_name: chromadb
+    container_name: dream-chromadb
     ports:
       - "${CHROMADB_PORT:-8000}:8000"
     volumes:

--- a/resources/dev/extensions-library/services/chromadb/manifest.yaml
+++ b/resources/dev/extensions-library/services/chromadb/manifest.yaml
@@ -4,7 +4,7 @@ service:
   id: chromadb
   name: ChromaDB
   aliases: [chroma, vector-db]
-  container_name: chromadb
+  container_name: dream-chromadb
   host_env: CHROMADB_HOST
   default_host: chromadb
   port: 8000
@@ -12,7 +12,7 @@ service:
   external_port_default: 8000
   health: /api/v1/heartbeat
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -30,4 +30,4 @@ features:
     enabled_services_all: [chromadb]
     setup_time: ~1 minute
     priority: 9
-    gpu_backends: []
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/label-studio/manifest.yaml
+++ b/resources/dev/extensions-library/services/label-studio/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 8085
   health: /health
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -33,7 +33,7 @@ features:
     enabled_services_all: [label-studio]
     setup_time: ~1 minute
     priority: 15
-    gpu_backends: []
+    gpu_backends: [amd, nvidia, apple]
 
 tags:
   - labeling

--- a/resources/dev/extensions-library/services/milvus/manifest.yaml
+++ b/resources/dev/extensions-library/services/milvus/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 19530
   health: /healthz
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: recommended
   depends_on: []

--- a/resources/dev/extensions-library/services/piper-audio/manifest.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 10200
   health: ""
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -33,4 +33,4 @@ features:
     enabled_services_all: [piper-audio]
     setup_time: ~1 minute
     priority: 10
-    gpu_backends: []
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/sillytavern/manifest.yaml
+++ b/resources/dev/extensions-library/services/sillytavern/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 8001
   health: /
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -30,4 +30,4 @@ features:
     enabled_services_all: [sillytavern]
     setup_time: ~1 minute
     priority: 6
-    gpu_backends: []
+    gpu_backends: [amd, nvidia, apple]


### PR DESCRIPTION
## What
Fix 6 CPU service manifests with invalid `gpu_backends` and missing `dream-` container name prefix.

## Why
- `gpu_backends: [none]` is not a valid schema enum value — causes services to be invisible on dashboards
- `container_name` without `dream-` prefix breaks CLI container lookup (`dream shell`, `dream status`)

## Changes
- **All 6 services** (aider, chromadb, label-studio, milvus, piper-audio, sillytavern): `gpu_backends: [none]` → `[amd, nvidia, apple]`
- **Feature-level** `gpu_backends: []` → `[amd, nvidia, apple]` (prevents features from being filtered out)
- **aider**: `container_name` → `dream-aider` (manifest + compose)
- **chromadb**: `container_name` → `dream-chromadb` (manifest + compose)

## Testing
- All YAML files parse cleanly
- Schema spot-check: valid gpu_backends enum, dream- prefix, features at top level
- Manifest/compose container_names verified in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)