### PR TITLE
fix(extensions): correct gpu_backends, features format, and compose_file for 4 CPU services

### DIFF
--- a/resources/dev/extensions-library/services/baserow/manifest.yaml
+++ b/resources/dev/extensions-library/services/baserow/manifest.yaml
@@ -12,32 +12,61 @@ service:
   external_port_default: 3006
   health: /api/_health/
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   category: optional
   depends_on: []
+  compose_file: compose.yaml
   description: |
     Open-source no-code database tool and Airtable alternative.
     Create databases, tables, and views with a spreadsheet-like interface.
     Self-hosted with no storage restrictions. MIT licensed.
-  
-  features:
-    database:
-      description: No-code database with spreadsheet interface
-      vram_required_mb: 0
-    views:
-      description: Grid, gallery, form, and calendar views
-      vram_required_mb: 0
-    api:
-      description: Headless REST API for all data
-      vram_required_mb: 0
-    collaboration:
-      description: Real-time collaboration and permissions
-      vram_required_mb: 0
-    
-  tags:
-    - database
-    - nocde
-    - airtable
-    - spreadsheet
-    - collaboration
-    - productivity
+
+features:
+  - id: database
+    name: No-Code Database
+    description: No-code database with spreadsheet interface
+    icon: Database
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 14
+    gpu_backends: [amd, nvidia, apple]
+  - id: views
+    name: Multiple View Types
+    description: Grid, gallery, form, and calendar views
+    icon: LayoutGrid
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 15
+    gpu_backends: [amd, nvidia, apple]
+  - id: api
+    name: REST API
+    description: Headless REST API for all data
+    icon: Code
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 16
+    gpu_backends: [amd, nvidia, apple]
+  - id: collaboration
+    name: Real-Time Collaboration
+    description: Real-time collaboration and permissions
+    icon: Users
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 17
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/crewai/manifest.yaml
+++ b/resources/dev/extensions-library/services/crewai/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 8501
   health: /
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   category: optional
   depends_on: []
   env_vars: []
@@ -23,27 +23,64 @@ service:
     complex problems. Perfect for building agent teams that simulate real-world
     collaboration and decision-making.
 
-  features:
-    multi-agent:
-      description: Teams of autonomous AI agents working together
-      vram_required_mb: 0
-    task-delegation:
-      description: Automatic task distribution between agents
-      vram_required_mb: 0
-    sequential-process:
-      description: Step-by-step task execution with defined order
-      vram_required_mb: 0
-    hierarchical-process:
-      description: Manager-led coordination with validation
-      vram_required_mb: 0
-    flows:
-      description: Event-driven workflows for complex automations
-      vram_required_mb: 0
-
-  tags:
-    - multi-agent
-    - orchestration
-    - automation
-    - autonomous-agents
-    - workflow
-    - python
+features:
+  - id: multi-agent
+    name: Multi-Agent Teams
+    description: Teams of autonomous AI agents working together
+    icon: Users
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 8
+    gpu_backends: [amd, nvidia, apple]
+  - id: task-delegation
+    name: Automatic Task Delegation
+    description: Automatic task distribution between agents
+    icon: GitBranch
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 9
+    gpu_backends: [amd, nvidia, apple]
+  - id: sequential-process
+    name: Sequential Process
+    description: Step-by-step task execution with defined order
+    icon: ListOrdered
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 10
+    gpu_backends: [amd, nvidia, apple]
+  - id: hierarchical-process
+    name: Hierarchical Process
+    description: Manager-led coordination with validation
+    icon: Network
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 11
+    gpu_backends: [amd, nvidia, apple]
+  - id: flows
+    name: Event-Driven Flows
+    description: Event-driven workflows for complex automations
+    icon: Workflow
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 12
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/flowise/manifest.yaml
+++ b/resources/dev/extensions-library/services/flowise/manifest.yaml
@@ -12,29 +12,49 @@ service:
   external_port_default: 7801
   health: /api/v1/health
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   category: optional
   depends_on: []
+  compose_file: compose.yaml
   description: |
     Visual LLM workflow builder with drag-and-drop interface.
     Build AI agents, chatbots, and automation flows without code.
     Integrates with OpenAI, Anthropic, local models, and 100+ tools.
-  
-  features:
-    workflow:
-      description: Visual drag-and-drop workflow builder
-      vram_required_mb: 0
-    agents:
-      description: Build AI agents with tools and memory
-      vram_required_mb: 0
-    integration:
-      description: 100+ integrations (databases, APIs, LLMs)
-      vram_required_mb: 0
-    
-  tags:
-    - workflow
-    - visual
-    - nocode
-    - agents
-    - automation
-    - lowcode
+
+features:
+  - id: workflow
+    name: Visual Workflow Builder
+    description: Visual drag-and-drop workflow builder
+    icon: Workflow
+    category: ai
+    requirements:
+      services: [flowise]
+      vram_gb: 0
+    enabled_services_all: [flowise]
+    setup_time: ~1 minute
+    priority: 7
+    gpu_backends: [amd, nvidia, apple]
+  - id: agents
+    name: AI Agent Builder
+    description: Build AI agents with tools and memory
+    icon: Bot
+    category: ai
+    requirements:
+      services: [flowise]
+      vram_gb: 0
+    enabled_services_all: [flowise]
+    setup_time: ~1 minute
+    priority: 8
+    gpu_backends: [amd, nvidia, apple]
+  - id: integration
+    name: 100+ Integrations
+    description: 100+ integrations (databases, APIs, LLMs)
+    icon: Plug
+    category: ai
+    requirements:
+      services: [flowise]
+      vram_gb: 0
+    enabled_services_all: [flowise]
+    setup_time: ~1 minute
+    priority: 9
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/langflow/manifest.yaml
+++ b/resources/dev/extensions-library/services/langflow/manifest.yaml
@@ -12,29 +12,49 @@ service:
   external_port_default: 7802
   health: /health
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   category: optional
   depends_on: []
+  compose_file: compose.yaml
   description: |
     Langflow is a visual LLM workflow builder that lets you create
     complex AI workflows with a drag-and-drop interface. Supports
     LangChain components, custom components, and real-time testing.
-  
-  features:
-    visual-workflow:
-      description: Visual LLM workflow builder with drag-and-drop
-      vram_required_mb: 0
-    rag:
-      description: Build RAG pipelines visually
-      vram_required_mb: 0
-    agents:
-      description: Create and test AI agents visually
-      vram_required_mb: 0
-    
-  tags:
-    - visual
-    - workflow
-    - langchain
-    - rag
-    - agents
-    - low-code
+
+features:
+  - id: visual-workflow
+    name: Visual LLM Workflow Builder
+    description: Visual LLM workflow builder with drag-and-drop
+    icon: Workflow
+    category: ai
+    requirements:
+      services: [langflow]
+      vram_gb: 0
+    enabled_services_all: [langflow]
+    setup_time: ~1 minute
+    priority: 8
+    gpu_backends: [amd, nvidia, apple]
+  - id: rag
+    name: Visual RAG Pipelines
+    description: Build RAG pipelines visually
+    icon: Database
+    category: ai
+    requirements:
+      services: [langflow]
+      vram_gb: 0
+    enabled_services_all: [langflow]
+    setup_time: ~1 minute
+    priority: 9
+    gpu_backends: [amd, nvidia, apple]
+  - id: agents
+    name: AI Agent Testing
+    description: Create and test AI agents visually
+    icon: Bot
+    category: ai
+    requirements:
+      services: [langflow]
+      vram_gb: 0
+    enabled_services_all: [langflow]
+    setup_time: ~1 minute
+    priority: 10
+    gpu_backends: [amd, nvidia, apple]


### PR DESCRIPTION
## What
Fix 4 CPU service manifests with invalid gpu_backends, wrong features format, and missing compose_file.

## Why
- `gpu_backends: [none]` is schema-invalid — services invisible on dashboards
- Features nested as dict under `service:` instead of top-level array — dashboard-api expects arrays, dict format causes parse errors
- Missing `compose_file` prevents `resolve-compose-stack.sh` from discovering compose fragments

## Changes
- **All 4 services** (baserow, crewai, flowise, langflow): `gpu_backends: [none]` → `[amd, nvidia, apple]`
- **All 4**: Features converted from dict-under-service to top-level array with all required schema fields (id, name, description, icon, category, requirements, priority, gpu_backends)
- **baserow, flowise, langflow**: Added `compose_file: compose.yaml`
- **All 4**: Removed non-schema `tags` arrays

## Testing
- All YAML files parse cleanly
- All required feature fields present and valid
- Schema spot-check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)