### PR TITLE
fix(extensions): correct gpu_backends and features format for 4 CPU services

### DIFF
--- a/resources/dev/extensions-library/services/librechat/manifest.yaml
+++ b/resources/dev/extensions-library/services/librechat/manifest.yaml
@@ -12,29 +12,49 @@ service:
   external_port_default: 3080
   health: /health
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   category: optional
   depends_on: [librechat-mongodb, librechat-meilisearch]
+  compose_file: compose.yaml
   description: |
-    LibreChat is an enhanced ChatGPT clone with multi-LLM support, 
-    agents, RAG, and file uploads. Supports OpenAI, Anthropic, Google, 
+    LibreChat is an enhanced ChatGPT clone with multi-LLM support,
+    agents, RAG, and file uploads. Supports OpenAI, Anthropic, Google,
     Azure, Groq, Mistral, OpenRouter, and custom endpoints.
-  
-  features:
-    chat:
-      description: Multi-provider AI chat interface
-      vram_required_mb: 0
-    rag:
-      description: Built-in RAG with file uploads and search
-      vram_required_mb: 0
-    agents:
-      description: AI agents and plugins support
-      vram_required_mb: 0
-    
-  tags:
-    - chat
-    - ui
-    - multi-provider
-    - rag
-    - agents
-    - openai-compatible
+
+features:
+  - id: chat
+    name: Multi-Provider Chat
+    description: Multi-provider AI chat interface
+    icon: MessageSquare
+    category: chat
+    requirements:
+      services: [librechat]
+      vram_gb: 0
+    enabled_services_all: [librechat]
+    setup_time: ~2 minutes
+    priority: 5
+    gpu_backends: [amd, nvidia, apple]
+  - id: rag
+    name: RAG with File Uploads
+    description: Built-in RAG with file uploads and search
+    icon: FileSearch
+    category: ai
+    requirements:
+      services: [librechat]
+      vram_gb: 0
+    enabled_services_all: [librechat]
+    setup_time: ~2 minutes
+    priority: 6
+    gpu_backends: [amd, nvidia, apple]
+  - id: agents
+    name: AI Agents & Plugins
+    description: AI agents and plugins support
+    icon: Bot
+    category: ai
+    requirements:
+      services: [librechat]
+      vram_gb: 0
+    enabled_services_all: [librechat]
+    setup_time: ~2 minutes
+    priority: 7
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 7805
   health: /health
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   category: optional
   depends_on: []
   compose_file: compose.yaml
@@ -20,25 +20,53 @@ service:
     Open Interpreter lets LLMs run code locally (Python, JavaScript, Shell, etc.).
     It provides a ChatGPT-like interface in your terminal and can control Chrome,
     create/edit files, analyze datasets, and more. Fully local, no API costs.
-  
-  features:
-    code-exec:
-      description: Run Python, JavaScript, Shell code locally
-      vram_required_mb: 0
-    browser:
-      description: Control Chrome browser for research tasks
-      vram_required_mb: 0
-    file-ops:
-      description: Create and edit files, photos, videos, PDFs
-      vram_required_mb: 0
-    data-analysis:
-      description: Plot, clean, and analyze large datasets
-      vram_required_mb: 0
-    
-  tags:
-    - code
-    - local
-    - terminal
-    - browser
-    - file-ops
-    - data
+
+features:
+  - id: code-exec
+    name: Local Code Execution
+    description: Run Python, JavaScript, Shell code locally
+    icon: Terminal
+    category: development
+    requirements:
+      services: [open-interpreter]
+      vram_gb: 0
+    enabled_services_all: [open-interpreter]
+    setup_time: ~1 minute
+    priority: 9
+    gpu_backends: [amd, nvidia, apple]
+  - id: browser
+    name: Browser Control
+    description: Control Chrome browser for research tasks
+    icon: Globe
+    category: development
+    requirements:
+      services: [open-interpreter]
+      vram_gb: 0
+    enabled_services_all: [open-interpreter]
+    setup_time: ~1 minute
+    priority: 10
+    gpu_backends: [amd, nvidia, apple]
+  - id: file-ops
+    name: File Operations
+    description: Create and edit files, photos, videos, PDFs
+    icon: FileEdit
+    category: development
+    requirements:
+      services: [open-interpreter]
+      vram_gb: 0
+    enabled_services_all: [open-interpreter]
+    setup_time: ~1 minute
+    priority: 11
+    gpu_backends: [amd, nvidia, apple]
+  - id: data-analysis
+    name: Data Analysis
+    description: Plot, clean, and analyze large datasets
+    icon: BarChart
+    category: development
+    requirements:
+      services: [open-interpreter]
+      vram_gb: 0
+    enabled_services_all: [open-interpreter]
+    setup_time: ~1 minute
+    priority: 12
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/paperless-ngx/manifest.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 7807
   health: /accounts/login/
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -22,24 +22,52 @@ service:
     documents into a searchable online archive. OCR, tagging, automatic
     classification, and full-text search for PDFs and images.
 
-  features:
-    ocr:
-      description: Automatic OCR for scanned PDFs and images
-      vram_required_mb: 0
-    document-tags:
-      description: Auto and manual tagging for organization
-      vram_required_mb: 0
-    fulltext-search:
-      description: Search inside all your documents
-      vram_required_mb: 0
-    email-import:
-      description: Import documents via email
-      vram_required_mb: 0
-
-  tags:
-    - documents
-    - ocr
-    - archive
-    - pdf
-    - search
-    - productivity
+features:
+  - id: ocr
+    name: Automatic OCR
+    description: Automatic OCR for scanned PDFs and images
+    icon: Scan
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 13
+    gpu_backends: [amd, nvidia, apple]
+  - id: document-tags
+    name: Document Tagging
+    description: Auto and manual tagging for organization
+    icon: Tag
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 14
+    gpu_backends: [amd, nvidia, apple]
+  - id: fulltext-search
+    name: Full-Text Search
+    description: Search inside all your documents
+    icon: Search
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 15
+    gpu_backends: [amd, nvidia, apple]
+  - id: email-import
+    name: Email Import
+    description: Import documents via email
+    icon: Mail
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 16
+    gpu_backends: [amd, nvidia, apple]

--- a/resources/dev/extensions-library/services/weaviate/manifest.yaml
+++ b/resources/dev/extensions-library/services/weaviate/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 7811
   health: /v1/.well-known/ready
   type: docker
-  gpu_backends: [none]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -22,21 +22,40 @@ service:
     Supports semantic search, hybrid search, structured filtering, and multi-tenancy.
     A cloud-native alternative to ChromaDB with gRPC support and horizontal scaling.
 
-  features:
-    vector-search:
-      description: Semantic similarity search with vector embeddings
-      vram_required_mb: 0
-    hybrid-search:
-      description: Combine vector similarity with keyword matching
-      vram_required_mb: 0
-    multi-tenancy:
-      description: Isolated data spaces for different users/organizations
-      vram_required_mb: 0
-
-  tags:
-    - vector-database
-    - semantic-search
-    - embeddings
-    - open-source
-    - scalable
-    - local
+features:
+  - id: vector-search
+    name: Semantic Vector Search
+    description: Semantic similarity search with vector embeddings
+    icon: Search
+    category: data
+    requirements:
+      services: [weaviate]
+      vram_gb: 0
+    enabled_services_all: [weaviate]
+    setup_time: ~1 minute
+    priority: 9
+    gpu_backends: [amd, nvidia, apple]
+  - id: hybrid-search
+    name: Hybrid Search
+    description: Combine vector similarity with keyword matching
+    icon: GitMerge
+    category: data
+    requirements:
+      services: [weaviate]
+      vram_gb: 0
+    enabled_services_all: [weaviate]
+    setup_time: ~1 minute
+    priority: 10
+    gpu_backends: [amd, nvidia, apple]
+  - id: multi-tenancy
+    name: Multi-Tenancy
+    description: Isolated data spaces for different users/organizations
+    icon: Users
+    category: data
+    requirements:
+      services: [weaviate]
+      vram_gb: 0
+    enabled_services_all: [weaviate]
+    setup_time: ~1 minute
+    priority: 11
+    gpu_backends: [amd, nvidia, apple]


### PR DESCRIPTION
## What
Fix 4 CPU service manifests with invalid gpu_backends, wrong features format, and missing compose_file.

## Why
- `gpu_backends: [none]` is schema-invalid — services invisible on dashboards
- Features nested as dict under `service:` — dashboard-api expects top-level arrays
- Missing `compose_file` prevents compose stack discovery

## Changes
- **All 4 services** (librechat, open-interpreter, paperless-ngx, weaviate): `gpu_backends: [none]` → `[amd, nvidia, apple]`
- **All 4**: Features converted from dict-under-service to top-level array with full schema fields
- **librechat**: Added `compose_file: compose.yaml`
- **All 4**: Removed non-schema `tags` arrays

## Testing
- All YAML files parse cleanly
- All required feature fields present and valid
- Schema spot-check passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)