### PR TITLE
fix(extensions): correct features format, env_vars, and port for 5 GPU services

### DIFF
--- a/resources/dev/extensions-library/services/anythingllm/manifest.yaml
+++ b/resources/dev/extensions-library/services/anythingllm/manifest.yaml
@@ -13,31 +13,60 @@ service:
   health: /api/health
   type: docker
   gpu_backends: [nvidia, amd]
+  compose_file: compose.yaml
   category: optional
   depends_on: [ollama]
   description: |
     All-in-one AI productivity tool for RAG chat with documents.
     Built-in vector database, supports multiple LLM providers,
     and runs entirely on-device for privacy.
-  
-  features:
-    rag:
-      description: RAG chat with uploaded documents
-      vram_required_mb: 0
-    chat:
-      description: Chat interface with multiple LLM providers
-      vram_required_mb: 0
-    embed:
-      description: Built-in embedding and vector search
-      vram_required_mb: 0
-    agents:
-      description: AI agents for automated workflows
-      vram_required_mb: 2048
-    
-  tags:
-    - chat
-    - rag
-    - documents
-    - vector-db
-    - privacy
-    - local
+
+features:
+  - id: rag
+    name: RAG Document Chat
+    description: RAG chat with uploaded documents
+    icon: FileSearch
+    category: ai
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [anythingllm]
+    setup_time: ~2 minutes
+    requirements:
+      services: [anythingllm]
+      vram_gb: 0
+    priority: 6
+  - id: chat
+    name: Multi-Provider Chat
+    description: Chat interface with multiple LLM providers
+    icon: MessageSquare
+    category: chat
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [anythingllm]
+    setup_time: ~2 minutes
+    requirements:
+      services: [anythingllm]
+      vram_gb: 0
+    priority: 7
+  - id: embed
+    name: Built-in Embeddings
+    description: Built-in embedding and vector search
+    icon: Database
+    category: data
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [anythingllm]
+    setup_time: ~2 minutes
+    requirements:
+      services: [anythingllm]
+      vram_gb: 0
+    priority: 8
+  - id: agents
+    name: AI Workflow Agents
+    description: AI agents for automated workflows
+    icon: Bot
+    category: ai
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [anythingllm]
+    setup_time: ~2 minutes
+    requirements:
+      services: [anythingllm]
+      vram_gb: 2
+    priority: 9

--- a/resources/dev/extensions-library/services/bark/manifest.yaml
+++ b/resources/dev/extensions-library/services/bark/manifest.yaml
@@ -17,14 +17,15 @@ service:
   category: optional
   depends_on: []
   env_vars:
-    - name: BARK_USE_SMALL_MODELS
+    - key: BARK_USE_SMALL_MODELS
       description: Use smaller/faster Bark models (less VRAM, slightly lower quality)
       default: "false"
-    - name: BARK_OFFLOAD_CPU
+    - key: BARK_OFFLOAD_CPU
       description: Offload Bark models to CPU between requests (reduces VRAM usage)
       default: "false"
-    - name: BARK_API_KEY
+    - key: BARK_API_KEY
       description: API key for Bark TTS service authentication (optional; leave empty to disable auth)
+      secret: true
       default: ""
   description: |
     Bark is a transformer-based text-to-audio model by Suno AI. Unlike
@@ -36,22 +37,40 @@ service:
 
     Note: First startup downloads ~5GB of models. Subsequent starts are fast.
 
-  features:
-    expressive-tts:
-      description: Highly realistic speech with laughter, sighs, and emotion
-      vram_required_mb: 4000
-    multilingual:
-      description: 13 language voice presets (English, German, Spanish, French, etc.)
-      vram_required_mb: 4000
-    sound-effects:
-      description: Generate music snippets and ambient sound effects
-      vram_required_mb: 4000
-
-  tags:
-    - tts
-    - voice
-    - speech
-    - audio
-    - multilingual
-    - expressive
-    - suno
+features:
+  - id: expressive-tts
+    name: Expressive Text-to-Speech
+    description: Highly realistic speech with laughter, sighs, and emotion
+    icon: Volume2
+    category: voice
+    gpu_backends: [nvidia]
+    enabled_services_all: [bark]
+    setup_time: ~2 minutes
+    requirements:
+      services: [bark]
+      vram_gb: 4
+    priority: 8
+  - id: multilingual
+    name: Multilingual Voice
+    description: 13 language voice presets (English, German, Spanish, French, etc.)
+    icon: Globe
+    category: voice
+    gpu_backends: [nvidia]
+    enabled_services_all: [bark]
+    setup_time: ~2 minutes
+    requirements:
+      services: [bark]
+      vram_gb: 4
+    priority: 9
+  - id: sound-effects
+    name: Sound Effects Generation
+    description: Generate music snippets and ambient sound effects
+    icon: Music
+    category: voice
+    gpu_backends: [nvidia]
+    enabled_services_all: [bark]
+    setup_time: ~2 minutes
+    requirements:
+      services: [bark]
+      vram_gb: 4
+    priority: 10

--- a/resources/dev/extensions-library/services/forge/manifest.yaml
+++ b/resources/dev/extensions-library/services/forge/manifest.yaml
@@ -13,6 +13,7 @@ service:
   health: /
   type: docker
   gpu_backends: [nvidia]
+  compose_file: compose.yaml
   category: optional
   depends_on: []
   description: |
@@ -20,23 +21,52 @@ service:
     Features extensive model support, extensions, inpainting, outpainting,
     and professional-grade image generation capabilities. GPU required.
 
-  features:
-    image-generation:
-      description: Full Stable Diffusion control with advanced settings
-      vram_required_mb: 8192
-    inpainting:
-      description: Inpainting with mask support
-      vram_required_mb: 8192
-    outpainting:
-      description: Outpainting beyond image boundaries
-      vram_required_mb: 8192
-    upscaling:
-      description: High-resolution upscaling with multiple engines
-      vram_required_mb: 4096
-
-  tags:
-    - image
-    - stable-diffusion
-    - webui
-    - generative
-    - professional
+features:
+  - id: image-generation
+    name: Stable Diffusion Generation
+    description: Full Stable Diffusion control with advanced settings
+    icon: Image
+    category: creative
+    gpu_backends: [nvidia]
+    enabled_services_all: [forge]
+    setup_time: ~2 minutes
+    requirements:
+      services: [forge]
+      vram_gb: 8
+    priority: 5
+  - id: inpainting
+    name: Image Inpainting
+    description: Inpainting with mask support
+    icon: Paintbrush
+    category: creative
+    gpu_backends: [nvidia]
+    enabled_services_all: [forge]
+    setup_time: ~2 minutes
+    requirements:
+      services: [forge]
+      vram_gb: 8
+    priority: 6
+  - id: outpainting
+    name: Image Outpainting
+    description: Outpainting beyond image boundaries
+    icon: Maximize
+    category: creative
+    gpu_backends: [nvidia]
+    enabled_services_all: [forge]
+    setup_time: ~2 minutes
+    requirements:
+      services: [forge]
+      vram_gb: 8
+    priority: 7
+  - id: upscaling
+    name: Image Upscaling
+    description: High-resolution upscaling with multiple engines
+    icon: ZoomIn
+    category: creative
+    gpu_backends: [nvidia]
+    enabled_services_all: [forge]
+    setup_time: ~2 minutes
+    requirements:
+      services: [forge]
+      vram_gb: 4
+    priority: 8

--- a/resources/dev/extensions-library/services/frigate/manifest.yaml
+++ b/resources/dev/extensions-library/services/frigate/manifest.yaml
@@ -22,24 +22,52 @@ service:
     local object detection for IP cameras. It uses AI to detect people,
     vehicles, and other objects without sending video to the cloud.
 
-  features:
-    object-detection:
-      description: Real-time AI object detection on camera streams
-      vram_required_mb: 512
-    recording:
-      description: Continuous or event-based video recording
-      vram_required_mb: 0
-    notifications:
-      description: Alerts when objects are detected
-      vram_required_mb: 0
-    restreaming:
-      description: RTSP/WebRTC restreaming of camera feeds
-      vram_required_mb: 0
-
-  tags:
-    - nvr
-    - camera
-    - security
-    - object-detection
-    - surveillance
-    - video
+features:
+  - id: object-detection
+    name: Real-Time Object Detection
+    description: Real-time AI object detection on camera streams
+    icon: Eye
+    category: security
+    gpu_backends: [nvidia]
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    requirements:
+      services: [frigate]
+      vram_gb: 0.5
+    priority: 8
+  - id: recording
+    name: Video Recording
+    description: Continuous or event-based video recording
+    icon: Video
+    category: security
+    gpu_backends: [nvidia]
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    requirements:
+      services: [frigate]
+      vram_gb: 0
+    priority: 9
+  - id: notifications
+    name: Detection Alerts
+    description: Alerts when objects are detected
+    icon: Bell
+    category: security
+    gpu_backends: [nvidia]
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    requirements:
+      services: [frigate]
+      vram_gb: 0
+    priority: 10
+  - id: restreaming
+    name: Camera Restreaming
+    description: RTSP/WebRTC restreaming of camera feeds
+    icon: Cast
+    category: security
+    gpu_backends: [nvidia]
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    requirements:
+      services: [frigate]
+      vram_gb: 0
+    priority: 11

--- a/resources/dev/extensions-library/services/text-generation-webui/manifest.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/manifest.yaml
@@ -7,7 +7,7 @@ service:
   container_name: dream-text-generation-webui
   host_env: TEXT_GEN_WEBUI_HOST
   default_host: text-generation-webui
-  port: 7862
+  port: 7860
   external_port_env: TEXT_GEN_WEBUI_PORT
   external_port_default: 7862
   health: /
@@ -24,28 +24,64 @@ service:
     loading, and advanced generation parameters. The goto tool for power users
     who need full control over inference settings.
 
-  features:
-    inference:
-      description: Load and run GGUF, GPTQ, AWQ, EXL2, and HF transformer models
-      vram_required_mb: 0
-    chat-ui:
-      description: Instruct and chat mode UI with character support
-      vram_required_mb: 0
-    openai-api:
-      description: OpenAI-compatible API server (port 5001)
-      vram_required_mb: 0
-    extensions:
-      description: Built-in extensions for Whisper STT, Silero TTS, and more
-      vram_required_mb: 512
-    lora:
-      description: LoRA adapter loading and merging
-      vram_required_mb: 0
-
-  tags:
-    - llm
-    - inference
-    - oobabooga
-    - chat
-    - api
-    - gguf
-    - gptq
+features:
+  - id: inference
+    name: Multi-Format Model Loading
+    description: Load and run GGUF, GPTQ, AWQ, EXL2, and HF transformer models
+    icon: Cpu
+    category: ai
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [text-generation-webui]
+    setup_time: ~2 minutes
+    requirements:
+      services: [text-generation-webui]
+      vram_gb: 0
+    priority: 5
+  - id: chat-ui
+    name: Chat Interface
+    description: Instruct and chat mode UI with character support
+    icon: MessageSquare
+    category: chat
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [text-generation-webui]
+    setup_time: ~2 minutes
+    requirements:
+      services: [text-generation-webui]
+      vram_gb: 0
+    priority: 6
+  - id: openai-api
+    name: OpenAI-Compatible API
+    description: OpenAI-compatible API server (port 5001)
+    icon: Code
+    category: ai
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [text-generation-webui]
+    setup_time: ~2 minutes
+    requirements:
+      services: [text-generation-webui]
+      vram_gb: 0
+    priority: 7
+  - id: extensions
+    name: Extensions Marketplace
+    description: Built-in extensions for Whisper STT, Silero TTS, and more
+    icon: Puzzle
+    category: ai
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [text-generation-webui]
+    setup_time: ~2 minutes
+    requirements:
+      services: [text-generation-webui]
+      vram_gb: 0.5
+    priority: 8
+  - id: lora
+    name: LoRA Adapter Loading
+    description: LoRA adapter loading and merging
+    icon: Layers
+    category: ai
+    gpu_backends: [nvidia, amd]
+    enabled_services_all: [text-generation-webui]
+    setup_time: ~2 minutes
+    requirements:
+      services: [text-generation-webui]
+      vram_gb: 0
+    priority: 9


### PR DESCRIPTION
## What
Fix 5 GPU service manifests with wrong features format, invalid env_var field names, incorrect port, and missing compose_file.

## Why
- Features nested as dict under `service:` — dashboard-api expects top-level arrays
- `env_vars` using `name:` instead of `key:` violates schema (`additionalProperties: false`)
- text-generation-webui `port: 7862` doesn't match container port 7860
- Missing `compose_file` prevents compose stack discovery

## Changes
- **All 5 services** (bark, anythingllm, text-generation-webui, forge, frigate): Features converted to top-level array with full schema fields
- **bark**: `env_vars` `name:` → `key:` (3 entries); added `secret: true` to BARK_API_KEY
- **text-generation-webui**: `port: 7862` → `7860` (actual container port per compose)
- **anythingllm, forge**: Added `compose_file: compose.yaml`
- **text-gen-webui, frigate**: Fixed `vram_gb` rounding (512MB = 0.5, not 1)
- **All 5**: Removed non-schema `tags` arrays

## Testing
- All YAML files parse cleanly
- All required feature fields present (id, name, description, icon, category, requirements, priority)
- Port fix verified against compose.yaml mapping (`${TEXT_GEN_WEBUI_PORT:-7862}:7860`)
- env_vars field name verified against schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)