### PR TITLE
fix(extensions): extract NVIDIA GPU config into overlay files for 8 services

### DIFF
--- a/resources/dev/extensions-library/services/audiocraft/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  audiocraft:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/audiocraft/compose.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/compose.yaml
@@ -1,5 +1,3 @@
-name: audiocraft
-
 services:
   audiocraft:
     build:
@@ -33,10 +31,6 @@ services:
         reservations:
           cpus: '1.0'
           memory: 4G
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
 networks:
   dream-network:

--- a/resources/dev/extensions-library/services/bark/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/bark/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  bark:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/bark/compose.yaml
+++ b/resources/dev/extensions-library/services/bark/compose.yaml
@@ -1,5 +1,3 @@
-name: bark
-
 services:
   bark:
     build:
@@ -37,10 +35,6 @@ services:
         reservations:
           cpus: '0.5'
           memory: 4G
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
 networks:
   dream-network:

--- a/resources/dev/extensions-library/services/forge/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  forge:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/forge/compose.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.yaml
@@ -1,5 +1,3 @@
-name: forge
-
 services:
   forge:
     image: ghcr.io/ai-dock/stable-diffusion-webui-forge@sha256:36a8b82c9ddec17a88303d933f3d08d2c1d1286617f5642281859f64d40beddc
@@ -32,10 +30,6 @@ services:
         reservations:
           cpus: '1.0'
           memory: 4G
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
 networks:
   dream-network:

--- a/resources/dev/extensions-library/services/frigate/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/frigate/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  frigate:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/frigate/compose.yaml
+++ b/resources/dev/extensions-library/services/frigate/compose.yaml
@@ -1,5 +1,3 @@
-name: frigate
-
 services:
   frigate:
     image: ghcr.io/blakeblackshear/frigate:0.15.0
@@ -38,10 +36,6 @@ services:
         reservations:
           cpus: '1.0'
           memory: 2G
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
 networks:
   dream-network:

--- a/resources/dev/extensions-library/services/ollama/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/ollama/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  ollama:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/ollama/compose.yaml
+++ b/resources/dev/extensions-library/services/ollama/compose.yaml
@@ -21,10 +21,6 @@ services:
         reservations:
           cpus: '1'
           memory: 2G
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:11434/api/tags"]
       interval: 30s

--- a/resources/dev/extensions-library/services/rvc/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/rvc/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  rvc:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/rvc/compose.yaml
+++ b/resources/dev/extensions-library/services/rvc/compose.yaml
@@ -1,5 +1,3 @@
-name: rvc
-
 services:
   rvc:
     image: aladdin1234/rvc-webui:0.1@sha256:0127333111eccb00ee97e12052f2c9efc7739d74841dbdec771d4f469273a0c2
@@ -22,11 +20,6 @@ services:
         limits:
           memory: 8G
           cpus: '4.0'
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:7865"]
       interval: 30s

--- a/resources/dev/extensions-library/services/text-generation-webui/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  text-generation-webui:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/text-generation-webui/compose.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/compose.yaml
@@ -1,5 +1,3 @@
-name: text-generation-webui
-
 services:
   text-generation-webui:
     # atinoda/text-generation-webui is the most widely-used community image.
@@ -37,10 +35,6 @@ services:
         reservations:
           cpus: '1.0'
           memory: 4G
-          devices:
-            - driver: nvidia
-              count: 1
-              capabilities: [gpu]
 
 networks:
   dream-network:

--- a/resources/dev/extensions-library/services/xtts/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/xtts/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  xtts:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]

--- a/resources/dev/extensions-library/services/xtts/compose.yaml
+++ b/resources/dev/extensions-library/services/xtts/compose.yaml
@@ -1,5 +1,3 @@
-name: xtts
-
 services:
   xtts:
     image: daswer123/xtts-api-server:latest
@@ -22,8 +20,6 @@ services:
         reservations:
           cpus: '0.5'
           memory: 1G
-          devices:
-            - capabilities: ["gpu"]
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:80/health')"]
       interval: 30s


### PR DESCRIPTION
## What
Extract hardcoded `driver: nvidia` GPU device reservations from 8 services' base `compose.yaml` into separate `compose.nvidia.yaml` overlay files, following the DreamServer GPU overlay pattern.

## Why
Base compose files with NVIDIA-specific config crash on AMD, macOS, and CPU-only setups because Docker cannot satisfy the NVIDIA device reservation. The correct pattern (used by production services like comfyui) separates GPU config into overlay files that are conditionally layered by `resolve-compose-stack.sh`.

## How
For each of the 8 services:
1. Removed `deploy.resources.reservations.devices` block from base `compose.yaml` (kept `limits` and cpu/memory `reservations`)
2. Created `compose.nvidia.yaml` with the extracted NVIDIA device reservation
3. Removed top-level `name:` field (prevents conflicts when layering compose files)

### Services affected
| Service | GPU count | `name:` removed |
|---------|-----------|----------------|
| bark | 1 | yes |
| ollama | all | no (didn't have one) |
| text-generation-webui | 1 | yes |
| forge | 1 | yes |
| rvc | all | yes |
| audiocraft | 1 | yes |
| frigate | 1 | yes |
| xtts | 1 | yes |

### Note on xtts
The original base had `capabilities: ["gpu"]` without `driver: nvidia` — a driver-agnostic GPU request. The new overlay explicitly specifies `driver: nvidia`, making it NVIDIA-specific. This is intentional: the base should be GPU-agnostic, and GPU-specific config belongs in overlays.

## Merge Order
```
#379-#383 (manifest fixes) → THIS PR → #386 (AMD overlays) → #387 (structural fixes)
```
**This PR must merge before #386 (AMD overlays)** — AMD overlays cannot work if NVIDIA device reservations remain in base compose files (Docker Compose merges `deploy` sections additively).

## Testing
- [x] `docker compose config` validation passed for all 8 services (base only)
- [x] `docker compose config` validation passed for all 8 services (base + nvidia overlay)
- [x] Verified `deploy.resources.limits` preserved in all base files
- [x] Verified `count: all` preserved for ollama and rvc overlays
- [x] Critique Guardian: APPROVED WITH WARNINGS (xtts semantic change documented above)

## Platform Impact
- **NVIDIA**: No change — overlay restores identical GPU config
- **AMD**: Base compose no longer crashes; AMD overlays (separate PR) can now be applied
- **macOS / CPU-only**: Base compose no longer crashes; services run without GPU