### PR TITLE
fix(extensions): create AMD GPU overlay files for 5 services

### DIFF
--- a/resources/dev/extensions-library/services/invokeai/compose.amd.yaml
+++ b/resources/dev/extensions-library/services/invokeai/compose.amd.yaml
@@ -1,0 +1,10 @@
+services:
+  invokeai:
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/kfd:/dev/kfd
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-992}"
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}

--- a/resources/dev/extensions-library/services/ollama/compose.amd.yaml
+++ b/resources/dev/extensions-library/services/ollama/compose.amd.yaml
@@ -1,0 +1,10 @@
+services:
+  ollama:
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/kfd:/dev/kfd
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-992}"
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}

--- a/resources/dev/extensions-library/services/rvc/compose.amd.yaml
+++ b/resources/dev/extensions-library/services/rvc/compose.amd.yaml
@@ -1,0 +1,10 @@
+services:
+  rvc:
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/kfd:/dev/kfd
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-992}"
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}

--- a/resources/dev/extensions-library/services/text-generation-webui/compose.amd.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/compose.amd.yaml
@@ -1,0 +1,11 @@
+services:
+  text-generation-webui:
+    image: atinoda/text-generation-webui:default-rocm-v4.0@sha256:686c42a9b964625d8b9c47ca9d9162314993a7f8b41109367fd7a94c7377f0b1
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/kfd:/dev/kfd
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-992}"
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}

--- a/resources/dev/extensions-library/services/xtts/compose.amd.yaml
+++ b/resources/dev/extensions-library/services/xtts/compose.amd.yaml
@@ -1,0 +1,10 @@
+services:
+  xtts:
+    devices:
+      - /dev/dri:/dev/dri
+      - /dev/kfd:/dev/kfd
+    group_add:
+      - "${VIDEO_GID:-44}"
+      - "${RENDER_GID:-992}"
+    environment:
+      - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}


### PR DESCRIPTION
## What
Create `compose.amd.yaml` overlay files for 5 services that support AMD GPUs per their manifests, providing ROCm device passthrough.

## Why
These services declare `gpu_backends: [amd, nvidia]` in their manifests but had no AMD overlay — meaning AMD GPU users could not utilize GPU acceleration.

## How
Created `compose.amd.yaml` for each service with:
- `/dev/dri` and `/dev/kfd` device passthrough (ROCm)
- `group_add` for video/render groups
- `HSA_OVERRIDE_GFX_VERSION` environment variable

### Services
| Service | Image swap | Notes |
|---------|-----------|-------|
| ollama | No | Official image supports AMD natively |
| text-generation-webui | Yes → `default-rocm-v4.0` (SHA pinned) | Base uses NVIDIA-specific image tag |
| xtts | No | Device passthrough only; ROCm compatibility unverified |
| invokeai | No | Official image has ROCm support |
| rvc | No | Device passthrough only; ROCm compatibility unverified |

### Excluded services (with rationale)
- **fooocus**: `runpod/fooocus:2.5.3` is CUDA-only, no ROCm variant exists
- **immich**: GPU accel requires `immich-machine-learning` sidecar which is not yet in the extensions library compose

### Known limitations
- **rvc** and **xtts**: Base Docker images may be CUDA-built. AMD device passthrough is provided but GPU acceleration may silently fall back to CPU if the image lacks ROCm PyTorch. Should be verified before production promotion.

## Merge Order
```
#379-#383 (manifest fixes) → #385 (NVIDIA extraction) → THIS PR → #387 (structural fixes)
```
**This PR MUST merge after #385 (NVIDIA extraction)**. Three base compose files (ollama, text-gen-webui, rvc) currently contain `driver: nvidia` device reservations. #385 removes those. If this PR merges first, Docker Compose would merge both NVIDIA and AMD device entries, causing runtime errors on AMD systems.

## Testing
- [x] `docker compose config` validation passed for all 5 services (base + AMD overlay)
- [x] Service IDs verified matching base compose.yaml keys
- [x] text-gen-webui uses correct `default-rocm-v4.0` tag (verified exists on Docker Hub) with SHA pin
- [x] Critique Guardian: APPROVED WITH WARNINGS (image compatibility for rvc/xtts noted above)

## Platform Impact
- **AMD**: GPU acceleration now available for 5 services
- **NVIDIA**: No change (separate overlay)
- **macOS / CPU-only**: No change (overlay not applied)