### PR TITLE
fix(extensions): dify network isolation, credential hardening, name field cleanup

### DIFF
--- a/resources/dev/extensions-library/services/anythingllm/compose.yaml
+++ b/resources/dev/extensions-library/services/anythingllm/compose.yaml
@@ -1,5 +1,3 @@
-name: anythingllm
-
 services:
   anythingllm:
     image: mintplexlabs/anythingllm:1.11.1
@@ -9,7 +7,7 @@ services:
       - no-new-privileges:true
     environment:
       - STORAGE_DIR=/app/server/storage
-      - JWT_SECRET=${ANYTHINGLLM_JWT_SECRET}
+      - JWT_SECRET=${ANYTHINGLLM_JWT_SECRET:?ANYTHINGLLM_JWT_SECRET must be set}
       - LLM_PROVIDER=${ANYTHINGLLM_LLM_PROVIDER:-ollama}
       - OLLAMA_BASE_PATH=${OLLAMA_BASE_PATH:-http://ollama:11434}
       - OLLAMA_MODEL_PREF=${OLLAMA_MODEL_PREF:-llama3.2}
@@ -47,4 +45,3 @@ services:
 networks:
   dream-network:
     external: true
-    name: dream-network

--- a/resources/dev/extensions-library/services/chromadb/compose.yaml
+++ b/resources/dev/extensions-library/services/chromadb/compose.yaml
@@ -1,5 +1,3 @@
-name: chromadb
-
 services:
   chromadb:
     image: chromadb/chroma:1.5.3
@@ -31,4 +29,3 @@ services:
 networks:
   dream-network:
     external: true
-    name: dream-network

--- a/resources/dev/extensions-library/services/dify/compose.yaml
+++ b/resources/dev/extensions-library/services/dify/compose.yaml
@@ -48,6 +48,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    networks:
+      - dream-network
     deploy:
       resources:
         limits:
@@ -56,3 +58,7 @@ services:
         reservations:
           cpus: '0.2'
           memory: 512M
+
+networks:
+  dream-network:
+    external: true

--- a/resources/dev/extensions-library/services/immich/compose.yaml
+++ b/resources/dev/extensions-library/services/immich/compose.yaml
@@ -1,5 +1,3 @@
-name: immich
-
 services:
   immich-server:
     image: ghcr.io/immich-app/immich-server:v1.131.3
@@ -88,4 +86,3 @@ services:
 networks:
   dream-network:
     external: true
-    name: dream-network

--- a/resources/dev/extensions-library/services/librechat/compose.yaml
+++ b/resources/dev/extensions-library/services/librechat/compose.yaml
@@ -36,8 +36,8 @@ services:
       - DALLE3_BASEURL=${DALLE3_BASEURL:-}
       - CREDS_KEY=${CREDS_KEY:-}
       - CREDS_IV=${CREDS_IV:-}
-      - JWT_SECRET=${JWT_SECRET:-}
-      - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET:-}
+      - JWT_SECRET=${JWT_SECRET:?JWT_SECRET must be set}
+      - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET:?JWT_REFRESH_SECRET must be set}
       - APP_TITLE=${APP_TITLE:-LibreChat}
       - DOMAIN_CLIENT=${DOMAIN_CLIENT:-}
       - DOMAIN_SERVER=${DOMAIN_SERVER:-}
@@ -86,7 +86,7 @@ services:
       - no-new-privileges:true
     environment:
       - MONGO_INITDB_ROOT_USERNAME=librechat
-      - MONGO_INITDB_ROOT_PASSWORD=${LIBRECHAT_MONGO_PASSWORD:-librechat123}
+      - MONGO_INITDB_ROOT_PASSWORD=${LIBRECHAT_MONGO_PASSWORD:?LIBRECHAT_MONGO_PASSWORD must be set}
     volumes:
       - ./data/librechat/mongodb:/data/db:rw
     healthcheck:
@@ -114,7 +114,7 @@ services:
       - no-new-privileges:true
     environment:
       - MEILI_ENV=production
-      - MEILI_MASTER_KEY=${LIBRECHAT_MEILI_KEY:-librechat_meili_master_key}
+      - MEILI_MASTER_KEY=${LIBRECHAT_MEILI_KEY:?LIBRECHAT_MEILI_KEY must be set}
     volumes:
       - ./data/librechat/meilisearch:/meili_data:rw
     healthcheck:

--- a/resources/dev/extensions-library/services/milvus/compose.yaml
+++ b/resources/dev/extensions-library/services/milvus/compose.yaml
@@ -1,5 +1,3 @@
-name: milvus
-
 services:
   milvus:
     image: milvusdb/milvus:v2.4.5
@@ -30,4 +28,3 @@ services:
 networks:
   dream-network:
     external: true
-    name: dream-network


### PR DESCRIPTION
## What
Fix 3 categories of compose structural issues across 6 services in the extensions library.

## Why
1. **dify** was completely isolated from `dream-network` — could not communicate with any other service in the stack
2. **librechat** had hardcoded credential defaults (`librechat123`, `librechat_meili_master_key`) and empty JWT secrets — silent security degradation on fresh installs
3. **anythingllm** had no fail-fast on JWT_SECRET — empty secret = broken auth
4. Top-level `name:` fields in compose files cause project name conflicts when Docker Compose layers files

## How

### Network isolation fix
- **dify/compose.yaml**: Added `networks: [dream-network]` to the service + top-level `networks:` declaration

### Credential hardening (fail-fast with `:?`)
- **librechat**: `MONGO_INITDB_ROOT_PASSWORD`, `MEILI_MASTER_KEY`, `JWT_SECRET`, `JWT_REFRESH_SECRET` — all changed from `:-default` or `:-` to `:?VARNAME must be set`
- **anythingllm**: `JWT_SECRET` — changed from `${ANYTHINGLLM_JWT_SECRET}` to `${ANYTHINGLLM_JWT_SECRET:?...}`

### Name field cleanup
- Removed top-level `name:` from: chromadb, milvus, anythingllm, immich
- Removed redundant `name: dream-network` from network declarations in same files

### Scope notes
- **container_name fixes**: Already handled by PRs #379, #383 — not duplicated here
- **Remaining `name:` fields**: PR #385 handles 7 more services (bark, forge, text-gen-webui, rvc, audiocraft, frigate, xtts). Remaining services (aider, crewai, invokeai, etc.) are a follow-up
- **Pre-existing issues NOT in scope**: librechat MONGO_URI missing credentials in connection string, anythingllm AUTH_TOKEN empty default, dify OPENAI_API_KEY placeholder

## Merge Order
```
#379-#383 (manifest fixes) → #385 (NVIDIA extraction) → #386 (AMD overlays) → THIS PR
```
This PR can technically merge independently of #385/#386 (different files), but for clean ordering, merge last.

## Testing
- [x] YAML syntax validation passed for all 6 files
- [x] No hardcoded `librechat123` or `librechat_meili_master_key` remaining
- [x] No container_name changes (verified — handled by #379, #383)
- [x] dify network config follows same pattern as other services
- [x] `:?` error message format consistent across all 5 hardened variables
- [x] Critique Guardian: APPROVED

## Platform Impact
- All platforms equally affected — these are compose config fixes, not GPU-specific