### PR TITLE
fix(extensions): correct Milvus health port and add Ollama Apple Silicon support

### DIFF
--- a/resources/dev/extensions-library/services/milvus/manifest.yaml
+++ b/resources/dev/extensions-library/services/milvus/manifest.yaml
@@ -7,7 +7,7 @@ service:
   container_name: dream-milvus
   host_env: MILVUS_HOST
   default_host: milvus
-  port: 19530
+  port: 9091
   external_port_env: MILVUS_PORT
   external_port_default: 19530
   health: /healthz

--- a/resources/dev/extensions-library/services/ollama/manifest.yaml
+++ b/resources/dev/extensions-library/services/ollama/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 7804
   health: /api/tags
   type: docker
-  gpu_backends: [amd, nvidia]
+  gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml
   category: core
   depends_on: []
@@ -33,4 +33,4 @@ features:
     enabled_services_all: [ollama]
     setup_time: ~2 minutes
     priority: 5
-    gpu_backends: [amd, nvidia]
+    gpu_backends: [amd, nvidia, apple]


### PR DESCRIPTION
## What
- Milvus manifest `port` corrected from 19530 (gRPC) to 9091 (HTTP metrics)
- Ollama manifest `gpu_backends` updated to include `apple` at service and feature level

## Why
Dashboard-api constructs health check URLs as `http://{host}:{port}{health}` (`helpers.py:166`).
Milvus serves `/healthz` on port 9091 (HTTP metrics endpoint), not 19530 (gRPC). The compose
healthcheck already uses `http://localhost:9091/healthz` — the manifest port must match or
dashboard health checks silently fail against the gRPC port.

Ollama has native Apple Silicon Metal support but its manifest only declared `[amd, nvidia]`.
The `continue` service already declares `[amd, nvidia, apple]` as precedent.

## How
- Changed `service.port` from `19530` to `9091` in milvus manifest
- `external_port_default: 19530` preserved for user-facing gRPC access
- Added `apple` to `gpu_backends` in ollama manifest (service + feature sections)

## Testing
- YAML syntax validated
- Manifest field values verified programmatically
- Critique Guardian review: approved

## Known Considerations
- `port` is returned in `ServiceStatus` to the dashboard UI — Milvus will display `:9091`
  instead of `:19530`. Non-issue for dev library; a `health_port` schema field is recommended
  before production promotion.
- Ollama compose still declares NVIDIA GPU reservation in `deploy.resources` — harmless on
  macOS (Docker silently ignores), but should get an Apple overlay before production promotion.

## Platform Impact
- macOS: Ollama now correctly declares Apple Silicon support
- Linux (NVIDIA/AMD): No change
- Windows: No change

## Merge Order
Can merge independently — touches different lines than other open PRs on this directory.

🤖 Generated with [Claude Code](https://claude.ai/code)