### PR TITLE
fix(dashboard): add ui_path to sidebar links so services open at their UI page

### DIFF
--- a/dream-server/extensions/services/ape/manifest.yaml
+++ b/dream-server/extensions/services/ape/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: APE_PORT
   external_port_default: 7890
   health: /health
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/comfyui/manifest.yaml
+++ b/dream-server/extensions/services/comfyui/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: COMFYUI_PORT
   external_port_default: 8188
   health: /
+  ui_path: /
   health_timeout: 30  # ComfyUI can be slow to start, especially on Tier 0/1 hardware
   type: docker
   gpu_backends: [amd, nvidia]

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -102,6 +102,7 @@ def load_extension_manifests(
                     "external_port": external_port,
                     "health": service.get("health", "/health"),
                     "name": service.get("name", service_id),
+                    "ui_path": service.get("ui_path", "/"),
                     **({"type": service["type"]} if "type" in service else {}),
                 }
 

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -431,6 +431,7 @@ async def get_external_links(api_key: str = Depends(verify_api_key)):
             continue
         links.append({
             "id": sid, "label": cfg.get("name", sid), "port": ext_port,
+            "ui_path": cfg.get("ui_path", "/"),
             "icon": SIDEBAR_ICONS.get(sid, "ExternalLink"),
             "healthNeedles": [sid, cfg.get("name", sid).lower()],
         })

--- a/dream-server/extensions/services/dashboard-api/manifest.yaml
+++ b/dream-server/extensions/services/dashboard-api/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: DASHBOARD_API_PORT
   external_port_default: 3002
   health: /health
+  ui_path: /health
   type: docker
   gpu_backends: [amd, nvidia]
   category: core

--- a/dream-server/extensions/services/dashboard/manifest.yaml
+++ b/dream-server/extensions/services/dashboard/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: DASHBOARD_PORT
   external_port_default: 3001
   health: /
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia]
   category: core

--- a/dream-server/extensions/services/dashboard/src/plugins/registry.js
+++ b/dream-server/extensions/services/dashboard/src/plugins/registry.js
@@ -63,7 +63,7 @@ export function getSidebarExternalLinks(context = {}) {
       label: link.label,
       icon: typeof link.icon === 'string' ? (ICON_MAP[link.icon] || ExternalLink) : (link.icon || ExternalLink),
       healthy,
-      url: typeof getExternalUrl === 'function' ? getExternalUrl(link.port) : `http://localhost:${link.port}`,
+      url: (typeof getExternalUrl === 'function' ? getExternalUrl(link.port) : `http://localhost:${link.port}`) + (link.ui_path && link.ui_path !== '/' ? link.ui_path : ''),
     }
   })
 }

--- a/dream-server/extensions/services/embeddings/manifest.yaml
+++ b/dream-server/extensions/services/embeddings/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: EMBEDDINGS_PORT
   external_port_default: 8090
   health: /health
+  ui_path: /info
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/langfuse/manifest.yaml
+++ b/dream-server/extensions/services/langfuse/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: LANGFUSE_PORT
   external_port_default: 3006
   health: /api/public/health
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/litellm/manifest.yaml
+++ b/dream-server/extensions/services/litellm/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: LITELLM_PORT
   external_port_default: 4000
   health: /health/readiness
+  ui_path: /ui/
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/llama-server/manifest.yaml
+++ b/dream-server/extensions/services/llama-server/manifest.yaml
@@ -14,6 +14,7 @@ service:
   external_port_env: OLLAMA_PORT
   external_port_default: 8080
   health: /health
+  ui_path: /
   health_timeout: 15
   type: docker
   gpu_backends: [amd, nvidia]

--- a/dream-server/extensions/services/n8n/manifest.yaml
+++ b/dream-server/extensions/services/n8n/manifest.yaml
@@ -14,6 +14,7 @@ service:
   external_port_env: N8N_PORT
   external_port_default: 5678
   health: /healthz
+  ui_path: /
   health_timeout: 15  # n8n can take time to initialize database and workflows
   type: docker
   gpu_backends: [amd, nvidia]

--- a/dream-server/extensions/services/open-webui/manifest.yaml
+++ b/dream-server/extensions/services/open-webui/manifest.yaml
@@ -14,6 +14,7 @@ service:
   external_port_env: WEBUI_PORT
   external_port_default: 3000
   health: /health
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia]
   category: core

--- a/dream-server/extensions/services/openclaw/manifest.yaml
+++ b/dream-server/extensions/services/openclaw/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: OPENCLAW_PORT
   external_port_default: 7860
   health: /
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/perplexica/manifest.yaml
+++ b/dream-server/extensions/services/perplexica/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: PERPLEXICA_PORT
   external_port_default: 3004
   health: /
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/privacy-shield/manifest.yaml
+++ b/dream-server/extensions/services/privacy-shield/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: SHIELD_PORT
   external_port_default: 8085
   health: /health
+  ui_path: /docs
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/qdrant/manifest.yaml
+++ b/dream-server/extensions/services/qdrant/manifest.yaml
@@ -14,6 +14,7 @@ service:
   external_port_env: QDRANT_PORT
   external_port_default: 6333
   health: /
+  ui_path: /dashboard
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/searxng/manifest.yaml
+++ b/dream-server/extensions/services/searxng/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: SEARXNG_PORT
   external_port_default: 8888
   health: /healthz
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/token-spy/manifest.yaml
+++ b/dream-server/extensions/services/token-spy/manifest.yaml
@@ -10,6 +10,7 @@ service:
   external_port_env: TOKEN_SPY_PORT
   external_port_default: 3005
   health: /health
+  ui_path: /dashboard
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/tts/manifest.yaml
+++ b/dream-server/extensions/services/tts/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: TTS_PORT
   external_port_default: 8880
   health: /health
+  ui_path: /docs
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/whisper/manifest.yaml
+++ b/dream-server/extensions/services/whisper/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: WHISPER_PORT
   external_port_default: 9000
   health: /health
+  ui_path: /
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml


### PR DESCRIPTION
## Problem

Dashboard sidebar links all services to their root URL (`localhost:{port}/`), which is often blank, returns JSON, or shows a 403/404. Users click a sidebar link and get a broken page.

| Service | Before | What users saw |
|---|---|---|
| Token Spy | `:3005/` | Blank page |
| Qdrant | `:6333/` | JSON API response |
| LiteLLM | `:4000/` | Auth error JSON |
| Privacy Shield | `:8085/` | 403 Forbidden |
| Kokoro TTS | `:8880/` | 404 Not Found |
| Embeddings | `:8090/` | Blank page |

## Fix

Added `ui_path` field to all 18 service manifests specifying where each service's browser-accessible UI lives. The dashboard-api reads it from manifests and includes it in the `/api/external-links` response. The frontend appends it to the sidebar URL.

| Service | After |
|---|---|
| Token Spy | `:3005/dashboard` |
| Qdrant | `:6333/dashboard` |
| LiteLLM | `:4000/ui/` |
| Privacy Shield | `:8085/docs` |
| Kokoro TTS | `:8880/docs` |
| Embeddings | `:8090/info` |

Services with `ui_path: /` (n8n, Open WebUI, Perplexica, etc.) are unchanged.

## Changes

- 18 manifests: added `ui_path` field
- `config.py`: read `ui_path` from manifest into SERVICES dict (1 line)
- `main.py`: include `ui_path` in `/api/external-links` response (1 line)
- `registry.js`: append `ui_path` to sidebar link URL (1 line)

## Verified

Tested on a fresh macOS install — all 6 broken links now open usable pages. Confirmed via `curl` against `/api/external-links` and browser testing.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)