### PR TITLE
fix(security): bind extension service ports to 127.0.0.1

### DIFF
--- a/resources/dev/extensions-library/services/audiocraft/compose.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/compose.yaml
@@ -16,7 +16,7 @@ services:
       - ./data/audiocraft:/app/outputs:rw
       - ./data/audiocraft/models:/root/.cache/audiocraft:rw
     ports:
-      - "${AUDIOCRAFT_PORT:-7860}:7860"
+      - "127.0.0.1:${AUDIOCRAFT_PORT:-7860}:7860"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:7860/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/bark/compose.yaml
+++ b/resources/dev/extensions-library/services/bark/compose.yaml
@@ -10,7 +10,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "${BARK_PORT:-9200}:9200"
+      - "127.0.0.1:${BARK_PORT:-9200}:9200"
     environment:
       # Use small models (faster, less VRAM) — set to false for full quality
       - SUNO_USE_SMALL_MODELS=${BARK_USE_SMALL_MODELS:-false}

--- a/resources/dev/extensions-library/services/baserow/compose.yaml
+++ b/resources/dev/extensions-library/services/baserow/compose.yaml
@@ -35,7 +35,7 @@ services:
     volumes:
       - ./data/baserow:/baserow/data:rw
     ports:
-      - "${BASEROW_PORT:-3006}:80"
+      - "127.0.0.1:${BASEROW_PORT:-3006}:80"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost/api/_health/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/chromadb/compose.yaml
+++ b/resources/dev/extensions-library/services/chromadb/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: chromadb/chroma:1.5.3
     container_name: chromadb
     ports:
-      - "${CHROMADB_PORT:-8000}:8000"
+      - "127.0.0.1:${CHROMADB_PORT:-8000}:8000"
     volumes:
       - ./data/chromadb:/chromadb
     environment:

--- a/resources/dev/extensions-library/services/continue/compose.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.yaml
@@ -25,7 +25,7 @@ services:
       - ./config/continue/nginx.conf:/etc/nginx/conf.d/default.conf:ro
       - ./config/continue/entrypoint.sh:/docker-entrypoint.d/50-continue-init.sh:ro
     ports:
-      - "${CONTINUE_PORT:-8890}:8080"
+      - "127.0.0.1:${CONTINUE_PORT:-8890}:8080"
     networks:
       - dream-network
     healthcheck:

--- a/resources/dev/extensions-library/services/crewai/compose.yaml
+++ b/resources/dev/extensions-library/services/crewai/compose.yaml
@@ -42,7 +42,7 @@ services:
       # App data (SQLite DB, crew configs, history) lives under /app in the container
       - ./data/crewai:/app:rw
     ports:
-      - "${CREWAI_PORT:-8501}:8501"
+      - "127.0.0.1:${CREWAI_PORT:-8501}:8501"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8501/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/fooocus/compose.yaml
+++ b/resources/dev/extensions-library/services/fooocus/compose.yaml
@@ -11,7 +11,7 @@ services:
     volumes:
       - ./data/fooocus:/app/outputs:rw
     ports:
-      - "${FOOOCUS_PORT:-7865}:7865"
+      - "127.0.0.1:${FOOOCUS_PORT:-7865}:7865"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:7865/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/forge/compose.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.yaml
@@ -15,7 +15,7 @@ services:
       - ./data/forge/models:/opt/stable-diffusion-webui-forge/models:rw
       - ./data/forge/outputs:/opt/stable-diffusion-webui-forge/outputs:rw
     ports:
-      - "${FORGE_PORT:-7861}:7861"
+      - "127.0.0.1:${FORGE_PORT:-7861}:7861"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7861/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/frigate/compose.yaml
+++ b/resources/dev/extensions-library/services/frigate/compose.yaml
@@ -9,7 +9,7 @@ services:
       - no-new-privileges:true
     shm_size: "128mb"
     ports:
-      - "${FRIGATE_PORT:-8971}:5000"
+      - "127.0.0.1:${FRIGATE_PORT:-8971}:5000"
       - "${FRIGATE_RTSP_PORT:-8554}:8554"
       - "${FRIGATE_WEBRTC_PORT:-8555}:8555/tcp"
       - "${FRIGATE_WEBRTC_PORT:-8555}:8555/udp"

--- a/resources/dev/extensions-library/services/gitea/compose.yaml
+++ b/resources/dev/extensions-library/services/gitea/compose.yaml
@@ -29,8 +29,8 @@ services:
     volumes:
       - ./data/gitea:/var/lib/gitea:rw
     ports:
-      - "${GITEA_PORT:-7830}:3000"
-      - "${GITEA_SSH_PORT:-2222}:2222"
+      - "127.0.0.1:${GITEA_PORT:-7830}:3000"
+      - "127.0.0.1:${GITEA_SSH_PORT:-2222}:2222"
     healthcheck:
       test: ["CMD", "/usr/local/bin/gitea", "healthcheck"]
       interval: 30s

--- a/resources/dev/extensions-library/services/immich/compose.yaml
+++ b/resources/dev/extensions-library/services/immich/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: ghcr.io/immich-app/immich-server:v1.131.3
     container_name: immich
     ports:
-      - "${IMMICH_PORT:-2283}:2283"
+      - "127.0.0.1:${IMMICH_PORT:-2283}:2283"
     volumes:
       - ./data/immich/upload:/usr/src/app/upload
       - ./data/immich/backup:/usr/src/app/backup

--- a/resources/dev/extensions-library/services/invokeai/compose.yaml
+++ b/resources/dev/extensions-library/services/invokeai/compose.yaml
@@ -12,7 +12,7 @@ services:
     volumes:
       - ./data/invokeai:/invokeai:rw
     ports:
-      - "${INVOKEAI_PORT:-9090}:9090"
+      - "127.0.0.1:${INVOKEAI_PORT:-9090}:9090"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/health"]
       interval: 30s

--- a/resources/dev/extensions-library/services/jupyter/compose.yaml
+++ b/resources/dev/extensions-library/services/jupyter/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: jupyter/scipy-notebook:python-3.11
     container_name: jupyter
     ports:
-      - "${JUPYTER_PORT:-8888}:8888"
+      - "127.0.0.1:${JUPYTER_PORT:-8888}:8888"
     volumes:
       - ./data/jupyter/workspace:/home/jovyan/work
       - ./data/jupyter/notebooks:/home/jovyan/notebooks

--- a/resources/dev/extensions-library/services/label-studio/compose.yaml
+++ b/resources/dev/extensions-library/services/label-studio/compose.yaml
@@ -17,7 +17,7 @@ services:
       - ./media:/label-studio/media:rw
       - ./www:/label-studio/www:rw
     ports:
-      - "${LABEL_STUDIO_PORT:-8085}:8080"
+      - "127.0.0.1:${LABEL_STUDIO_PORT:-8085}:8080"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
       interval: 30s

--- a/resources/dev/extensions-library/services/langflow/compose.yaml
+++ b/resources/dev/extensions-library/services/langflow/compose.yaml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./data/langflow:/app/data
     ports:
-      - "${LANGFLOW_PORT:-7802}:7860"
+      - "127.0.0.1:${LANGFLOW_PORT:-7802}:7860"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:7860/health"]
       interval: 30s

--- a/resources/dev/extensions-library/services/librechat/compose.yaml
+++ b/resources/dev/extensions-library/services/librechat/compose.yaml
@@ -55,7 +55,7 @@ services:
       - ./data/librechat/logs:/app/api/logs:rw
       - ./data/librechat/uploads:/app/uploads:rw
     ports:
-      - "${LIBRECHAT_PORT:-3080}:3080"
+      - "127.0.0.1:${LIBRECHAT_PORT:-3080}:3080"
     depends_on:
       librechat-mongodb:
         condition: service_healthy

--- a/resources/dev/extensions-library/services/localai/compose.yaml
+++ b/resources/dev/extensions-library/services/localai/compose.yaml
@@ -5,7 +5,7 @@ services:
     networks:
       - dream-network
     ports:
-      - "${LOCALAI_EXTERNAL_PORT:-7803}:8080"
+      - "127.0.0.1:${LOCALAI_EXTERNAL_PORT:-7803}:8080"
     volumes:
       - ./data/localai/models:/models
       - ./data/localai/builds:/builds

--- a/resources/dev/extensions-library/services/milvus/compose.yaml
+++ b/resources/dev/extensions-library/services/milvus/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: milvusdb/milvus:v2.4.5
     container_name: dream-milvus
     ports:
-      - "${MILVUS_PORT:-19530}:19530"
+      - "127.0.0.1:${MILVUS_PORT:-19530}:19530"
     volumes:
       - ./data/milvus:/var/lib/milvus
     environment:

--- a/resources/dev/extensions-library/services/ollama/compose.yaml
+++ b/resources/dev/extensions-library/services/ollama/compose.yaml
@@ -6,7 +6,7 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "${OLLAMA_PORT:-7804}:11434"
+      - "127.0.0.1:${OLLAMA_PORT:-7804}:11434"
     volumes:
       - ./data/ollama:/root/.ollama
     environment:

--- a/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
@@ -19,7 +19,7 @@ services:
       - ./data/paperless/export:/usr/src/paperless/export
       - ./data/paperless/media:/usr/src/paperless/media
     ports:
-      - "${PAPERLESS_PORT:-7807}:8000"
+      - "127.0.0.1:${PAPERLESS_PORT:-7807}:8000"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/accounts/login/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/piper-audio/compose.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: lscr.io/linuxserver/piper:1.6.3
     container_name: dream-piper-audio
     ports:
-      - "${PIPER_PORT:-10200}:10200"
+      - "127.0.0.1:${PIPER_PORT:-10200}:10200"
     volumes:
       - ./data/piper:/config/piper
     environment:

--- a/resources/dev/extensions-library/services/privacy_shield/compose.yaml
+++ b/resources/dev/extensions-library/services/privacy_shield/compose.yaml
@@ -19,7 +19,7 @@ services:
     volumes:
       - ./data/privacy-shield:/data
     ports:
-      - "${SHIELD_PORT:-7808}:8085"
+      - "127.0.0.1:${SHIELD_PORT:-7808}:8085"
     deploy:
       resources:
         limits:

--- a/resources/dev/extensions-library/services/rvc/compose.yaml
+++ b/resources/dev/extensions-library/services/rvc/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: aladdin1234/rvc-webui:0.1@sha256:0127333111eccb00ee97e12052f2c9efc7739d74841dbdec771d4f469273a0c2
     container_name: rvc
     ports:
-      - "${RVC_PORT:-7809}:7865"
+      - "127.0.0.1:${RVC_PORT:-7809}:7865"
     volumes:
       - ./data/rvc/weights:/app/assets/weights
       - ./data/rvc/opt:/app/opt

--- a/resources/dev/extensions-library/services/sillytavern/compose.yaml
+++ b/resources/dev/extensions-library/services/sillytavern/compose.yaml
@@ -11,7 +11,7 @@ services:
       - ./config/sillytavern:/home/node/app/config:rw
       - ./data/sillytavern:/home/node/app/data:rw
     ports:
-      - "${SILLYTAVERN_PORT:-8001}:8000"
+      - "127.0.0.1:${SILLYTAVERN_PORT:-8001}:8000"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8000/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/text-generation-webui/compose.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/compose.yaml
@@ -10,8 +10,8 @@ services:
     security_opt:
       - no-new-privileges:true
     ports:
-      - "${TEXT_GEN_WEBUI_PORT:-7862}:7860"
-      - "${TEXT_GEN_WEBUI_API_PORT:-5001}:5001"  # OpenAI-compatible API
+      - "127.0.0.1:${TEXT_GEN_WEBUI_PORT:-7862}:7860"
+      - "127.0.0.1:${TEXT_GEN_WEBUI_API_PORT:-5001}:5001"  # OpenAI-compatible API
     environment:
       - EXTRA_LAUNCH_ARGS=--api --listen --listen-port 7860 --api-port ${TEXT_GEN_WEBUI_API_PORT:-5001} --extensions openai
     volumes:

--- a/resources/dev/extensions-library/services/xtts/compose.yaml
+++ b/resources/dev/extensions-library/services/xtts/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: daswer123/xtts-api-server:latest
     container_name: dream-xtts
     ports:
-      - "${XTTS_PORT:-8100}:80"
+      - "127.0.0.1:${XTTS_PORT:-8100}:80"
     volumes:
       - ./data/xtts:/app/tts_models
     environment:


### PR DESCRIPTION
## What
Add `127.0.0.1` prefix to all host port bindings across 26 extension services, preventing unintended LAN exposure.

## Why
All extension services bound ports to `0.0.0.0` (Docker default), exposing LLM inference, AI workflows, code execution (Jupyter), git servers, photo libraries, and vector databases to anyone on the same network — without authentication for most services.

## How
Systematic transform across 26 compose.yaml files:
```yaml
# Before
- "${PORT:-XXXX}:XXXX"
# After
- "127.0.0.1:${PORT:-XXXX}:XXXX"
```

### Intentional exceptions
- **Frigate RTSP (8554) and WebRTC (8555)**: Left on `0.0.0.0` — Frigate is an NVR that must receive RTSP streams from LAN IP cameras. Web UI port (8971) is localhost-bound.

### Services in related PRs (not in this diff)
- open-interpreter, anythingllm, flowise, weaviate, dify: port binding included in their respective security PRs

### Internal-only ports unaffected
- librechat MongoDB/Meilisearch: no host port mappings (container-to-container only)
- immich postgres/redis: no host port mappings

## Testing
- [x] YAML syntax validation on all 26 files
- [x] All port bindings verified to have 127.0.0.1 prefix
- [x] Frigate RTSP/WebRTC verified NOT localhost-bound

## Platform Impact
All platforms equally affected — compose port binding fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)