### PR TITLE
fix(extensions): correct fooocus gpu_backends to nvidia-only

### DIFF
--- a/resources/dev/extensions-library/services/fooocus/manifest.yaml
+++ b/resources/dev/extensions-library/services/fooocus/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 7865
   health: /
   type: docker
-  gpu_backends: [amd, nvidia]
+  gpu_backends: [nvidia]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -30,4 +30,4 @@ features:
     enabled_services_all: [fooocus]
     setup_time: ~3 minutes
     priority: 8
-    gpu_backends: [amd, nvidia]
+    gpu_backends: [nvidia]


### PR DESCRIPTION
## What
Remove false AMD GPU backend claim from fooocus manifest.

## Why
The fooocus manifest declared `gpu_backends: [amd, nvidia]` but the Docker image (`runpod/fooocus:2.5.3`) is CUDA-only — no ROCm variant exists. AMD users enabling this service would get silent GPU failure.

## How
Changed `gpu_backends: [amd, nvidia]` → `[nvidia]` at both service level and feature level in `fooocus/manifest.yaml`.

## Testing
- [x] YAML syntax validation
- [x] Schema enum validation (`nvidia` is valid)

## Platform Impact
- **AMD**: Fooocus will no longer appear as GPU-compatible on AMD systems (truthful)
- **NVIDIA/macOS/CPU**: No change

🤖 Generated with [Claude Code](https://claude.com/claude-code)