### PR TITLE
fix(security): harden credentials for flowise, weaviate, anythingllm, dify

### DIFF
--- a/resources/dev/extensions-library/services/anythingllm/compose.yaml
+++ b/resources/dev/extensions-library/services/anythingllm/compose.yaml
@@ -9,7 +9,7 @@ services:
       - no-new-privileges:true
     environment:
       - STORAGE_DIR=/app/server/storage
-      - JWT_SECRET=${ANYTHINGLLM_JWT_SECRET}
+      - JWT_SECRET=${ANYTHINGLLM_JWT_SECRET:?ANYTHINGLLM_JWT_SECRET must be set}
       - LLM_PROVIDER=${ANYTHINGLLM_LLM_PROVIDER:-ollama}
       - OLLAMA_BASE_PATH=${OLLAMA_BASE_PATH:-http://ollama:11434}
       - OLLAMA_MODEL_PREF=${OLLAMA_MODEL_PREF:-llama3.2}
@@ -22,11 +22,11 @@ services:
       - WHISPER_PROVIDER=${ANYTHINGLLM_WHISPER_PROVIDER:-local}
       - TTS_PROVIDER=${ANYTHINGLLM_TTS_PROVIDER:-native}
       - PASSWORDMINCHAR=${ANYTHINGLLM_PASSWORD_MIN:-8}
-      - AUTH_TOKEN=${ANYTHINGLLM_AUTH_TOKEN:-}
+      - AUTH_TOKEN=${ANYTHINGLLM_AUTH_TOKEN:?ANYTHINGLLM_AUTH_TOKEN must be set}
     volumes:
       - ./data/anythingllm:/app/server/storage:rw
     ports:
-      - "${ANYTHINGLLM_PORT:-7800}:3001"
+      - "127.0.0.1:${ANYTHINGLLM_PORT:-7800}:3001"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3001/api/health"]
       interval: 30s

--- a/resources/dev/extensions-library/services/dify/compose.yaml
+++ b/resources/dev/extensions-library/services/dify/compose.yaml
@@ -29,7 +29,7 @@ services:
       - SECRET_KEY=${DIFY_SECRET_KEY:?DIFY_SECRET_KEY must be set in .env}
       - INIT_PASSWORD=${DIFY_INIT_PASSWORD:-}
       - DEPLOY_ENV=PRODUCTION
-      - CHECK_UPDATE_URL=https://updates.dify.ai
+      - CHECK_UPDATE_URL=${DIFY_CHECK_UPDATE_URL:-}
       - OPENAI_API_BASE=${DIFY_OPENAI_API_BASE:-http://llama-server:8080/v1}
       - OPENAI_API_KEY=${DIFY_OPENAI_API_KEY:-change-me-to-a-valid-openai-api-key}
       - EMBEDDING_PROVIDER=local
@@ -41,7 +41,7 @@ services:
       - ./data/dify:/app/data:rw
       - ./logs/dify:/app/logs:rw
     ports:
-      - "${DIFY_PORT:-8002}:5001"
+      - "127.0.0.1:${DIFY_PORT:-8002}:5001"
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/health')"]
       interval: 30s

--- a/resources/dev/extensions-library/services/flowise/compose.yaml
+++ b/resources/dev/extensions-library/services/flowise/compose.yaml
@@ -12,15 +12,15 @@ services:
       - SECRETKEY_PATH=${FLOWISE_SECRETKEY_PATH:-/root/.flowise/secretkey}
       - LOG_PATH=/root/.flowise/logs
       - BLOB_STORAGE_PATH=/root/.flowise/storage
-      - FLOWISE_USERNAME=${FLOWISE_USERNAME:-}
-      - FLOWISE_PASSWORD=${FLOWISE_PASSWORD:-}
+      - FLOWISE_USERNAME=${FLOWISE_USERNAME:?FLOWISE_USERNAME must be set}
+      - FLOWISE_PASSWORD=${FLOWISE_PASSWORD:?FLOWISE_PASSWORD must be set}
       - FLOWISE_SECRETKEY_OVERWRITE=${FLOWISE_SECRETKEY_OVERWRITE:-}
       - IFRAME_ORIGINS=${FLOWISE_IFRAME_ORIGINS:-}
       - DISABLE_FLOWISE_TELEMETRY=${FLOWISE_DISABLE_TELEMETRY:-true}
     volumes:
       - ./data/flowise:/root/.flowise:rw
     ports:
-      - "${FLOWISE_PORT:-7801}:3000"
+      - "127.0.0.1:${FLOWISE_PORT:-7801}:3000"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/v1/health"]
       interval: 30s

--- a/resources/dev/extensions-library/services/weaviate/compose.yaml
+++ b/resources/dev/extensions-library/services/weaviate/compose.yaml
@@ -7,13 +7,15 @@ services:
       - no-new-privileges:true
     environment:
       - QUERY_DEFAULTS_LIMIT=25
-      - AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true
+      - AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=false
+      - AUTHENTICATION_APIKEY_ENABLED=true
+      - AUTHENTICATION_APIKEY_ALLOWED_KEYS=${WEAVIATE_API_KEY:?WEAVIATE_API_KEY must be set}
       - PERSISTENCE_DATA_PATH=/var/lib/weaviate
     volumes:
       - ./data/weaviate:/var/lib/weaviate
     ports:
-      - "${WEAVIATE_PORT:-7811}:8080"
-      - "${WEAVIATE_GRPC_PORT:-50051}:50051"
+      - "127.0.0.1:${WEAVIATE_PORT:-7811}:8080"
+      - "127.0.0.1:${WEAVIATE_GRPC_PORT:-50051}:50051"
     healthcheck:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/v1/.well-known/ready"]
       interval: 30s


### PR DESCRIPTION
## What
Harden credential defaults for 4 extension services that had empty or weak authentication configurations.

## Why
These services started with no authentication or predictable credentials on fresh installs:
- **Flowise**: Empty username/password = unauthenticated access to all flows
- **Weaviate**: Anonymous access enabled = anyone can read/write/delete vector embeddings
- **AnythingLLM**: Empty AUTH_TOKEN = unauthenticated API access; bare JWT_SECRET = forgeable JWTs
- **Dify**: Hardcoded phone-home URL to `updates.dify.ai` (privacy violation)

## How

### Credential fail-fast (`:?` syntax)
Services won't start without required credentials configured:
- **flowise**: `FLOWISE_USERNAME` and `FLOWISE_PASSWORD` → `:?` fail-fast
- **anythingllm**: `AUTH_TOKEN` and `JWT_SECRET` → `:?` fail-fast
- **weaviate**: `WEAVIATE_API_KEY` → `:?` fail-fast

### Weaviate auth hardening
- `AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=false` (was `true`)
- `AUTHENTICATION_APIKEY_ENABLED=true`
- `AUTHENTICATION_APIKEY_ALLOWED_KEYS=${WEAVIATE_API_KEY:?...}`

### Dify privacy fix
- `CHECK_UPDATE_URL` changed from hardcoded `https://updates.dify.ai` to `${DIFY_CHECK_UPDATE_URL:-}` (opt-in, empty = disabled)

### Port binding
All 4 services also get `127.0.0.1` port binding (localhost only).

## Testing
- [x] YAML syntax validation on all 4 files
- [x] `:?` syntax verified correct
- [x] No hardcoded secrets

## Platform Impact
All platforms equally affected — compose security configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)