### PR TITLE
feat(update): add --dry-run flag showing version, images, and .env diff without applying

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -650,19 +650,26 @@ cmd_dry_run() {
     read -ra flags <<< "$flags_str"
 
     # Prefer API response; fall back to parsing compose files directly.
+    # Use process substitution so flags like images_shown update in this shell (not a pipe subshell).
     local images_shown=false
     if [[ -n "$api_json" ]] && echo "$api_json" | jq -e '.images | length > 0' >/dev/null 2>&1; then
-        echo "$api_json" | jq -r '.images[]' | sort -u | while read -r img; do
-            echo "  ${img}"
-        done
-        images_shown=true
+        local _img_line _any_api=false
+        while IFS= read -r _img_line || [[ -n "$_img_line" ]]; do
+            [[ -z "$_img_line" ]] && continue
+            echo "  ${_img_line}"
+            _any_api=true
+        done < <(echo "$api_json" | jq -r '.images[]' | sort -u)
+        [[ "$_any_api" == "true" ]] && images_shown=true
     fi
     if [[ "$images_shown" == "false" ]]; then
-        if docker compose "${flags[@]}" config 2>/dev/null \
-                | grep -E '^\s+image:' | sed 's/.*image:\s*//' | sort -u \
-                | while read -r img; do echo "  ${img}"; done; then
-            images_shown=true
-        fi
+        local _img_line _any_compose=false
+        while IFS= read -r _img_line || [[ -n "$_img_line" ]]; do
+            [[ -z "$_img_line" ]] && continue
+            echo "  ${_img_line}"
+            _any_compose=true
+        done < <(docker compose "${flags[@]}" config 2>/dev/null \
+            | grep -E '^\s+image:' | sed 's/.*image:\s*//' | sort -u)
+        [[ "$_any_compose" == "true" ]] && images_shown=true
     fi
     [[ "$images_shown" == "false" ]] && echo "  (could not resolve compose config)"
 
@@ -712,10 +719,14 @@ cmd_update() {
 
     # Parse flags
     local dry_run="false"
+    local force_flag="false"
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --dry-run|-n) dry_run="true"; shift ;;
-            *) shift ;;
+            --force|-f) force_flag="true"; shift ;;
+            --*) error "Unknown option: $1" ;;
+            -*) error "Unknown option: $1" ;;
+            *) error "Unexpected argument: $1" ;;
         esac
     done
 

--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -5,6 +5,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 import httpx
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
@@ -119,8 +120,8 @@ async def get_update_dry_run():
             pass
 
     # ── latest version from GitHub ────────────────────────────────────────────
-    latest: str | None = None
-    changelog_url: str | None = None
+    latest: Optional[str] = None
+    changelog_url: Optional[str] = None
     update_available = False
 
     try:


### PR DESCRIPTION
## Summary

- `dream update --dry-run` (alias `-n`) previews what an update would change without pulling images or restarting any containers
- New `GET /api/update/dry-run` endpoint in `routers/updates.py` returns version comparison, configured image tags, and update-relevant `.env` keys as structured JSON
- CLI output is divided into four sections: **Version** (installed vs. latest, changelog URL), **Image tags** (what `docker compose pull` would fetch), **Model configuration** (TIER, LLM_MODEL, GGUF_FILE, CTX_SIZE, GPU_BACKEND, N_GPU_LAYERS), and **.env keys** the update path reads/writes
- Dashboard API is queried first to avoid a duplicate GitHub call; GitHub releases API is used as a direct fallback when the API is unreachable
- `cmd_update()` dispatcher now passes `"$@"` so all flags reach the function

## Files changed

- `routers/updates.py` — added `GET /api/update/dry-run` endpoint and `_UPDATE_ENV_KEYS` constant
- `dream-cli` — added `cmd_dry_run()`, wired `--dry-run/-n` into `cmd_update()`, fixed dispatcher arg forwarding, added help example

## Test plan

- [ ] `dream update --dry-run` on an up-to-date install → shows "up to date", lists current images and .env keys, exits 0
- [ ] `dream update --dry-run` when a newer GitHub release exists → shows "update available" with version diff and changelog URL
- [ ] `dream update -n` (short flag) works identically
- [ ] `dream update` (no flag) still performs the real update unchanged
- [ ] `GET /api/update/dry-run` via dashboard API returns `dry_run: true`, correct `current_version`, `images` list, and `env_keys`
- [ ] With dashboard API unreachable, CLI falls back to GitHub API and local compose parsing without error
- [ ] No containers are started, stopped, or re-created during dry run (verify with `docker events`)