### PR TITLE
feat(ci): add release-gate workflow and update local gate script

### DIFF
--- a/.github/workflows/release-gate.yml
+++ b/.github/workflows/release-gate.yml
@@ -1,0 +1,231 @@
+# =============================================================================
+# Release Gate
+#
+# Runs on every v* tag push.  ALL jobs below are classified P0 — a single
+# failure blocks the release.  The final `release-gate` job aggregates
+# results and writes a Markdown summary to the workflow run page.
+#
+# Local equivalent (sequential):
+#   cd dream-server && bash scripts/release-gate.sh
+#
+# To enforce this as a required status check, add "Release gate — all P0
+# checks passed" to your branch / tag protection rules.
+# =============================================================================
+
+name: Release Gate
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+# Cancel any in-progress gate run for the same tag (e.g. force-pushed tag)
+concurrency:
+  group: release-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── P0 · Shell syntax ──────────────────────────────────────────────────────
+  shell-syntax:
+    name: "P0 · Shell syntax"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dream-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: bash -n all .sh files
+        run: |
+          mapfile -t sh_files < <(git ls-files '*.sh')
+          if [[ "${#sh_files[@]}" -eq 0 ]]; then
+            echo "No .sh files found — nothing to check."
+            exit 0
+          fi
+          echo "Checking ${#sh_files[@]} shell scripts…"
+          failed=0
+          for f in "${sh_files[@]}"; do
+            if bash -n "$f" 2>&1; then
+              echo "  OK  $f"
+            else
+              echo "  FAIL $f"
+              failed=1
+            fi
+          done
+          if [[ "$failed" -ne 0 ]]; then
+            echo ""
+            echo "One or more shell scripts have syntax errors."
+            exit 1
+          fi
+          echo ""
+          echo "All shell scripts passed syntax check."
+
+  # ── P0 · Manifest compatibility + release claims ───────────────────────────
+  compatibility-claims:
+    name: "P0 · Compatibility & release claims"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dream-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Manifest compatibility check
+        run: bash scripts/check-compatibility.sh
+
+      - name: Release claims check
+        run: bash scripts/check-release-claims.sh
+
+  # ── P0 · Installer contracts ───────────────────────────────────────────────
+  contracts:
+    name: "P0 · Installer contracts"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dream-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Installer contract tests
+        run: bash tests/contracts/test-installer-contracts.sh
+
+      - name: Preflight fixture tests
+        run: bash tests/contracts/test-preflight-fixtures.sh
+
+  # ── P0 · Linux smoke (AMD · NVIDIA · WSL) ─────────────────────────────────
+  smoke-linux:
+    name: "P0 · Linux smoke"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dream-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: AMD path smoke
+        run: bash tests/smoke/linux-amd.sh
+
+      - name: NVIDIA path smoke
+        run: bash tests/smoke/linux-nvidia.sh
+
+      - name: WSL logic smoke
+        run: bash tests/smoke/wsl-logic.sh
+
+  # ── P0 · macOS smoke ───────────────────────────────────────────────────────
+  smoke-macos:
+    name: "P0 · macOS smoke"
+    runs-on: macos-latest
+    defaults:
+      run:
+        working-directory: dream-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: macOS dispatch smoke
+        run: bash tests/smoke/macos-dispatch.sh
+
+  # ── P0 · Installer simulation ──────────────────────────────────────────────
+  installer-sim:
+    name: "P0 · Installer simulation"
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: dream-server
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run installer simulation
+        run: bash scripts/simulate-installers.sh
+
+      - name: Validate simulation summary
+        run: python3 scripts/validate-sim-summary.py artifacts/installer-sim/summary.json
+
+      # Upload artifacts even on failure so engineers can inspect partial output
+      - name: Upload simulation artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: installer-sim-${{ github.ref_name }}
+          path: |
+            dream-server/artifacts/installer-sim/summary.json
+            dream-server/artifacts/installer-sim/SUMMARY.md
+            dream-server/artifacts/installer-sim/linux-dryrun.log
+            dream-server/artifacts/installer-sim/macos-installer.log
+            dream-server/artifacts/installer-sim/windows-preflight-sim.json
+            dream-server/artifacts/installer-sim/macos-preflight.json
+            dream-server/artifacts/installer-sim/macos-doctor.json
+            dream-server/artifacts/installer-sim/doctor.json
+
+  # ── Gate · aggregate all P0 results ───────────────────────────────────────
+  #
+  # `if: always()` ensures this job runs even when upstream jobs fail, so the
+  # Markdown summary is always written and the exit code reflects the true
+  # overall outcome rather than being skipped.
+  release-gate:
+    name: "Release gate — all P0 checks passed"
+    needs:
+      - shell-syntax
+      - compatibility-claims
+      - contracts
+      - smoke-linux
+      - smoke-macos
+      - installer-sim
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Evaluate P0 results and write summary
+        env:
+          R_SHELL_SYNTAX:   ${{ needs.shell-syntax.result }}
+          R_COMPAT_CLAIMS:  ${{ needs.compatibility-claims.result }}
+          R_CONTRACTS:      ${{ needs.contracts.result }}
+          R_SMOKE_LINUX:    ${{ needs.smoke-linux.result }}
+          R_SMOKE_MACOS:    ${{ needs.smoke-macos.result }}
+          R_INSTALLER_SIM:  ${{ needs.installer-sim.result }}
+        run: |
+          TAG="${{ github.ref_name }}"
+          SUMMARY="$GITHUB_STEP_SUMMARY"
+
+          echo "## Release Gate — ${TAG}" >> "$SUMMARY"
+          echo "" >> "$SUMMARY"
+          echo "| # | Check | Result |" >> "$SUMMARY"
+          echo "|---|-------|--------|" >> "$SUMMARY"
+
+          failed=0
+          idx=0
+
+          report_row() {
+            local label="$1" result="$2"
+            idx=$(( idx + 1 ))
+            if [[ "$result" == "success" ]]; then
+              echo "| ${idx} | ${label} | ✅ passed |" >> "$SUMMARY"
+            else
+              echo "| ${idx} | ${label} | ❌ ${result} |" >> "$SUMMARY"
+              failed=1
+            fi
+          }
+
+          report_row "Shell syntax (bash -n)"       "$R_SHELL_SYNTAX"
+          report_row "Compatibility & release claims" "$R_COMPAT_CLAIMS"
+          report_row "Installer contracts"           "$R_CONTRACTS"
+          report_row "Linux smoke (AMD · NVIDIA · WSL)" "$R_SMOKE_LINUX"
+          report_row "macOS smoke (dispatch)"        "$R_SMOKE_MACOS"
+          report_row "Installer simulation"          "$R_INSTALLER_SIM"
+
+          echo "" >> "$SUMMARY"
+
+          if [[ "$failed" -ne 0 ]]; then
+            echo "**❌ Release BLOCKED — one or more P0 checks failed for \`${TAG}\`.**" >> "$SUMMARY"
+            echo "::error::Release gate FAILED for ${TAG} — see summary for which P0 checks did not pass."
+            exit 1
+          fi
+
+          echo "**✅ All P0 checks passed — \`${TAG}\` is cleared for release.**" >> "$SUMMARY"
+          echo "Release gate PASSED for ${TAG}."

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -1,39 +1,114 @@
 #!/usr/bin/env bash
+# =============================================================================
+# release-gate.sh — local equivalent of .github/workflows/release-gate.yml
+#
+# Run every P0 check sequentially before pushing a release tag.
+# CI runs the same checks in parallel; this script is for local pre-flight.
+#
+# Usage:
+#   cd dream-server && bash scripts/release-gate.sh
+# =============================================================================
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-echo "[gate] shell syntax"
-mapfile -t sh_files < <(git ls-files '*.sh')
-for f in "${sh_files[@]}"; do
-  bash -n "$f"
-done
+# ── Helpers ──────────────────────────────────────────────────────────────────
 
-echo "[gate] compatibility + claims"
-bash scripts/check-compatibility.sh
-bash scripts/check-release-claims.sh
+pass_count=0
+fail_count=0
+failed_checks=()
 
-echo "[gate] contracts"
-bash tests/contracts/test-installer-contracts.sh
-bash tests/contracts/test-preflight-fixtures.sh
+run_check() {
+  local label="$1"
+  shift
+  echo ""
+  echo "━━━ P0 · ${label} ━━━"
+  if "$@"; then
+    echo "  [PASS] ${label}"
+    pass_count=$(( pass_count + 1 ))
+  else
+    echo "  [FAIL] ${label}"
+    fail_count=$(( fail_count + 1 ))
+    failed_checks+=("${label}")
+    # Do not exit immediately — collect all failures for the summary
+  fi
+}
 
-echo "[gate] smoke"
-bash tests/smoke/linux-amd.sh
-bash tests/smoke/linux-nvidia.sh
-bash tests/smoke/wsl-logic.sh
-bash tests/smoke/macos-dispatch.sh
+# ── P0 · Shell syntax ─────────────────────────────────────────────────────────
 
-echo "[gate] installer simulation"
-bash scripts/simulate-installers.sh
-PYTHON_CMD="python3"
-if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then
-  . "$ROOT_DIR/lib/python-cmd.sh"
-  PYTHON_CMD="$(ds_detect_python_cmd)"
-elif command -v python >/dev/null 2>&1; then
-  PYTHON_CMD="python"
+_check_shell_syntax() {
+  mapfile -t sh_files < <(git ls-files '*.sh')
+  if [[ "${#sh_files[@]}" -eq 0 ]]; then
+    echo "  No .sh files found."
+    return 0
+  fi
+  local inner_fail=0
+  for f in "${sh_files[@]}"; do
+    if ! bash -n "$f" 2>&1; then
+      echo "  syntax error: $f"
+      inner_fail=1
+    fi
+  done
+  return "$inner_fail"
+}
+
+run_check "Shell syntax (bash -n)" _check_shell_syntax
+
+# ── P0 · Manifest compatibility + release claims ─────────────────────────────
+
+run_check "Compatibility check"   bash scripts/check-compatibility.sh
+run_check "Release claims check"  bash scripts/check-release-claims.sh
+
+# ── P0 · Installer contracts ──────────────────────────────────────────────────
+
+run_check "Installer contracts"   bash tests/contracts/test-installer-contracts.sh
+run_check "Preflight fixtures"    bash tests/contracts/test-preflight-fixtures.sh
+
+# ── P0 · Smoke tests ──────────────────────────────────────────────────────────
+
+run_check "Linux AMD smoke"       bash tests/smoke/linux-amd.sh
+run_check "Linux NVIDIA smoke"    bash tests/smoke/linux-nvidia.sh
+run_check "WSL logic smoke"       bash tests/smoke/wsl-logic.sh
+run_check "macOS dispatch smoke"  bash tests/smoke/macos-dispatch.sh
+
+# ── P0 · Installer simulation ─────────────────────────────────────────────────
+
+_check_installer_sim() {
+  bash scripts/simulate-installers.sh
+
+  local PYTHON_CMD="python3"
+  if [[ -f "${ROOT_DIR}/lib/python-cmd.sh" ]]; then
+    . "${ROOT_DIR}/lib/python-cmd.sh"
+    PYTHON_CMD="$(ds_detect_python_cmd)"
+  elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
+  fi
+
+  "$PYTHON_CMD" scripts/validate-sim-summary.py artifacts/installer-sim/summary.json
+}
+
+run_check "Installer simulation"  _check_installer_sim
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "════════════════════════════════════════════"
+echo "  Release Gate Summary"
+echo "════════════════════════════════════════════"
+echo "  Passed : ${pass_count}"
+echo "  Failed : ${fail_count}"
+
+if [[ "$fail_count" -ne 0 ]]; then
+  echo ""
+  echo "  Blocking P0 failures:"
+  for c in "${failed_checks[@]}"; do
+    echo "    ✗ ${c}"
+  done
+  echo ""
+  echo "  [BLOCKED] Release gate FAILED — fix the checks above before tagging."
+  exit 1
 fi
 
-"$PYTHON_CMD" scripts/validate-sim-summary.py artifacts/installer-sim/summary.json
-
-echo "[PASS] release gate"
+echo ""
+echo "  [PASS] All P0 checks passed — safe to push the release tag."


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release-gate.yml` that triggers on every `v*` tag push, runs six P0 check jobs in parallel, and blocks the release if any single check fails
- Rewrite `scripts/release-gate.sh` to match the same six check groups, collect all failures before exiting, and print a structured pass/fail summary — consistent with what CI reports

## What the workflow does

Six jobs run in parallel on every `v*` tag push. All are classified **P0** — a single failure blocks the release:

| Job | Runner | Checks |
|-----|--------|--------|
| Shell syntax | ubuntu-latest | `bash -n` on every `.sh` via `git ls-files` |
| Compatibility & release claims | ubuntu-latest | `check-compatibility.sh`, `check-release-claims.sh` |
| Installer contracts | ubuntu-latest | `test-installer-contracts.sh`, `test-preflight-fixtures.sh` |
| Linux smoke | ubuntu-latest | `linux-amd.sh`, `linux-nvidia.sh`, `wsl-logic.sh` |
| macOS smoke | macos-latest | `macos-dispatch.sh` |
| Installer simulation | ubuntu-latest | `simulate-installers.sh` + `validate-sim-summary.py` |

A final `release-gate` job (`if: always()`) aggregates all results, writes a Markdown table to the workflow summary page, and exits non-zero if any P0 check did not pass — emitting a `::error::` annotation in the GitHub UI.

Simulation artifacts are uploaded with `if: always()` so engineers can inspect partial output even on failure.

## Enforcing as a hard block

To make this gate mandatory before a GitHub Release can be published, add `"Release gate — all P0 checks passed"` as a required status check in **Settings → Branches / Tags → Protection rules** for the `v*` tag pattern.

## Local usage

The local script now mirrors the six CI check groups, accumulates all failures instead of stopping on the first, and prints a full summary at the end.

## Test plan

- [ ] Push a `v*` tag on a clean branch and confirm all six jobs appear in the Actions tab
- [ ] Introduce a deliberate `bash -n` syntax error in a `.sh` file, tag, and confirm the gate job exits with `❌ Release BLOCKED`
- [ ] Fix the error, re-tag, and confirm the gate job exits with `✅ All P0 checks passed`
- [ ] Run `bash scripts/release-gate.sh` locally and confirm the summary prints correctly
- [ ] Verify simulation artifacts are uploaded even when a job fails