### PR TITLE
fix(ci): resolve 4 pre-existing CI failures blocking all PRs

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -15,4 +15,5 @@
   paths = [
     '''dream-server/installers/phases/06-directories\.sh''',
     '''dream-server/installers/macos/lib/env-generator\.sh''',
+    '''dream-server/installers/windows/lib/env-generator\.ps1''',
   ]

--- a/dream-server/config/ports.json
+++ b/dream-server/config/ports.json
@@ -3,114 +3,133 @@
   "description": "Canonical external port contract for Dream Server services.",
   "ports": [
     {
-      "env": "OLLAMA_PORT",
-      "default": 8080,
+      "env_var": "OLLAMA_PORT",
+      "external_default": 8080,
       "service_id": "llama-server",
-      "container_port": 8080
+      "internal_port": 8080,
+      "manifest_service": "llama-server",
+      "include_in_example": false
     },
     {
-      "env": "WEBUI_PORT",
-      "default": 3000,
+      "env_var": "WEBUI_PORT",
+      "external_default": 3000,
       "service_id": "open-webui",
-      "container_port": 8080
+      "internal_port": 8080,
+      "manifest_service": "open-webui",
+      "include_in_example": false
     },
     {
-      "env": "SEARXNG_PORT",
-      "default": 8888,
+      "env_var": "SEARXNG_PORT",
+      "external_default": 8888,
       "service_id": "searxng",
-      "container_port": 8080
+      "internal_port": 8080,
+      "manifest_service": "searxng"
     },
     {
-      "env": "PERPLEXICA_PORT",
-      "default": 3004,
+      "env_var": "PERPLEXICA_PORT",
+      "external_default": 3004,
       "service_id": "perplexica",
-      "container_port": 3000
+      "internal_port": 3000,
+      "manifest_service": "perplexica"
     },
     {
-      "env": "WHISPER_PORT",
-      "default": 9000,
+      "env_var": "WHISPER_PORT",
+      "external_default": 9000,
       "service_id": "whisper",
-      "container_port": 8000
+      "internal_port": 8000,
+      "manifest_service": "whisper"
     },
     {
-      "env": "TTS_PORT",
-      "default": 8880,
+      "env_var": "TTS_PORT",
+      "external_default": 8880,
       "service_id": "tts",
-      "container_port": 8880
+      "internal_port": 8880,
+      "manifest_service": "tts"
     },
     {
-      "env": "N8N_PORT",
-      "default": 5678,
+      "env_var": "N8N_PORT",
+      "external_default": 5678,
       "service_id": "n8n",
-      "container_port": 5678
+      "internal_port": 5678,
+      "manifest_service": "n8n"
     },
     {
-      "env": "QDRANT_PORT",
-      "default": 6333,
+      "env_var": "QDRANT_PORT",
+      "external_default": 6333,
       "service_id": "qdrant",
-      "container_port": 6333
+      "internal_port": 6333,
+      "manifest_service": "qdrant"
     },
     {
-      "env": "QDRANT_GRPC_PORT",
-      "default": 6334,
+      "env_var": "QDRANT_GRPC_PORT",
+      "external_default": 6334,
       "service_id": "qdrant",
-      "container_port": 6334,
-      "skip_manifest": true
+      "internal_port": 6334,
+      "include_in_example": false
     },
     {
-      "env": "EMBEDDINGS_PORT",
-      "default": 8090,
+      "env_var": "EMBEDDINGS_PORT",
+      "external_default": 8090,
       "service_id": "embeddings",
-      "container_port": 80
+      "internal_port": 80,
+      "manifest_service": "embeddings"
     },
     {
-      "env": "LITELLM_PORT",
-      "default": 4000,
+      "env_var": "LITELLM_PORT",
+      "external_default": 4000,
       "service_id": "litellm",
-      "container_port": 4000
+      "internal_port": 4000,
+      "manifest_service": "litellm"
     },
     {
-      "env": "OPENCLAW_PORT",
-      "default": 7860,
+      "env_var": "OPENCLAW_PORT",
+      "external_default": 7860,
       "service_id": "openclaw",
-      "container_port": 18789
+      "internal_port": 18789,
+      "manifest_service": "openclaw"
     },
     {
-      "env": "SHIELD_PORT",
-      "default": 8085,
+      "env_var": "SHIELD_PORT",
+      "external_default": 8085,
       "service_id": "privacy-shield",
-      "container_port": 8085
+      "internal_port": 8085,
+      "manifest_service": "privacy-shield"
     },
     {
-      "env": "DASHBOARD_API_PORT",
-      "default": 3002,
+      "env_var": "DASHBOARD_API_PORT",
+      "external_default": 3002,
       "service_id": "dashboard-api",
-      "container_port": 3002
+      "internal_port": 3002,
+      "manifest_service": "dashboard-api"
     },
     {
-      "env": "DASHBOARD_PORT",
-      "default": 3001,
+      "env_var": "DASHBOARD_PORT",
+      "external_default": 3001,
       "service_id": "dashboard",
-      "container_port": 3001
+      "internal_port": 3001,
+      "manifest_service": "dashboard"
     },
     {
-      "env": "COMFYUI_PORT",
-      "default": 8188,
+      "env_var": "COMFYUI_PORT",
+      "external_default": 8188,
       "service_id": "comfyui",
-      "container_port": 8188
+      "internal_port": 8188,
+      "manifest_service": "comfyui"
     },
     {
-      "env": "TOKEN_SPY_PORT",
-      "default": 3005,
+      "env_var": "TOKEN_SPY_PORT",
+      "external_default": 3005,
       "service_id": "token-spy",
-      "container_port": 8080
+      "internal_port": 8080,
+      "manifest_service": "token-spy"
     },
     {
-      "env": "OPENCODE_PORT",
-      "default": 3003,
+      "env_var": "OPENCODE_PORT",
+      "external_default": 3003,
       "service_id": "opencode",
-      "container_port": 3003,
-      "require_compose": false
+      "internal_port": 3003,
+      "compose_managed": false,
+      "manifest_service": "opencode"
     }
   ]
 }

--- a/dream-server/extensions/services/dashboard-api/tests/test_routers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_routers.py
@@ -338,6 +338,11 @@ def test_agents_metrics_authenticated(test_client):
     """GET /api/agents/metrics with auth → 200, returns agent metrics with seeded data."""
     from agent_monitor import agent_metrics, throughput
 
+    # Reset singletons to avoid cross-test contamination
+    throughput.data_points = []
+    agent_metrics.session_count = 0
+    agent_metrics.tokens_per_second = 0.0
+
     # Seed non-default values to test actual aggregation
     agent_metrics.session_count = 5
     agent_metrics.tokens_per_second = 123.45
@@ -410,6 +415,10 @@ def test_agents_metrics_html_xss_escaping(test_client):
     """GET /api/agents/metrics.html escapes HTML special chars to prevent XSS."""
     from agent_monitor import agent_metrics, throughput
 
+    # Reset singletons to avoid cross-test contamination
+    throughput.data_points = []
+    agent_metrics.session_count = 0
+
     # Inject XSS payload into agent metrics
     agent_metrics.session_count = 999
     throughput.add_sample(42.0)
@@ -440,6 +449,9 @@ def test_agents_metrics_html_xss_escaping(test_client):
 def test_agents_throughput_authenticated(test_client):
     """GET /api/agents/throughput with auth → 200, returns throughput stats with real data."""
     from agent_monitor import throughput
+
+    # Reset singleton to avoid cross-test contamination
+    throughput.data_points = []
 
     # Seed throughput data to test actual behavior
     throughput.add_sample(42.0)

--- a/dream-server/extensions/services/llama-server/manifest.yaml
+++ b/dream-server/extensions/services/llama-server/manifest.yaml
@@ -12,7 +12,7 @@ service:
   default_host: llama-server
   port: 8080
   external_port_env: OLLAMA_PORT
-  external_port_default: 11434
+  external_port_default: 8080
   health: /health
   ui_path: /
   health_timeout: 15

--- a/dream-server/scripts/session-cleanup.sh
+++ b/dream-server/scripts/session-cleanup.sh
@@ -107,7 +107,7 @@ for f in "$SESSIONS_DIR"/*.jsonl; do
         REMOVED_INACTIVE=$((REMOVED_INACTIVE + 1))
     else
         # Portable stat: Linux uses -c%s, macOS uses -f%z
-        local stat_exit=0
+        stat_exit=0
         if [ "$(uname -s)" = "Darwin" ]; then
             SIZE_BYTES=$(stat -f%z "$f" 2>&1) || stat_exit=$?
         else


### PR DESCRIPTION
1. ShellCheck SC2168: remove 'local' keyword used outside function in scripts/session-cleanup.sh:110

2. gitleaks false positive: add Windows env-generator.ps1 to the allowlist in .gitleaks.toml (Linux/macOS scripts were already covered, Windows was missing)

3. Dashboard API test isolation: throughput singleton leaks state between tests — test_agents_metrics adds samples (100, 150) that pollute test_agents_throughput (expects peak=55, gets peak=150). Reset data_points before each test that seeds the singleton.

4. Port contract schema mismatch: ports.json used field names (env, default, container_port) that don't match the contract test's expected schema (env_var, external_default, internal_port). Also fixes llama-server manifest port (11434→8080) to match the compose default and .env.schema.json.