### PR TITLE
fix(installer): correct dependency validation path during installation

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -73,9 +73,12 @@ source "$SCRIPT_DIR/installers/lib/tier-map.sh"
 source "$SCRIPT_DIR/installers/lib/compose-select.sh"
 source "$SCRIPT_DIR/installers/lib/packaging.sh"
 source "$SCRIPT_DIR/installers/lib/progress.sh"
-if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
-    source "$SCRIPT_DIR/lib/service-registry.sh" 
-    sr_load 
+if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then
+    source "$SCRIPT_DIR/lib/service-registry.sh"
+    sr_load
+fi
+if [[ -f "$SCRIPT_DIR/lib/validate-dependencies.sh" ]]; then
+    source "$SCRIPT_DIR/lib/validate-dependencies.sh"
 fi
 
 #=============================================================================

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -247,10 +247,11 @@ MODELS_INI_EOF
     fi
 
     # Validate service dependencies before launching
-    if [[ -f "$INSTALL_DIR/lib/service-registry.sh" && -f "$INSTALL_DIR/lib/validate-dependencies.sh" ]]; then
-        . "$INSTALL_DIR/lib/service-registry.sh"
-        . "$INSTALL_DIR/lib/validate-dependencies.sh"
-        sr_load
+    if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" && -f "$SCRIPT_DIR/lib/validate-dependencies.sh" ]]; then
+        # Service registry already loaded in install-core.sh, just load validator
+        if ! declare -F validate_service_dependencies >/dev/null 2>&1; then
+            . "$SCRIPT_DIR/lib/validate-dependencies.sh"
+        fi
 
         ai "Validating service dependencies..."
         if ! validate_service_dependencies; then


### PR DESCRIPTION
## Summary
Fixes a bug where service dependency validation was silently skipped during installation due to incorrect path checking.

## Problem
Phase 11 checks for validation libraries in `$INSTALL_DIR/lib/` but during installation these files are in `$SCRIPT_DIR/lib/`. This caused the validation block to never execute, allowing installations to proceed with unsatisfied service dependencies.

## Solution
- Changed path check from `$INSTALL_DIR` to `$SCRIPT_DIR`
- Avoid re-sourcing service-registry.sh (already loaded in install-core.sh)
- Check if function exists before sourcing to prevent duplicate loads
- Ensure validation runs before `docker compose up`

## Testing
Validated that:
- Dependency validation now executes during installation
- Services with missing dependencies are caught before compose launch
- No duplicate sourcing of libraries

## Impact
- Prevents compose failures due to missing service dependencies
- Provides clear error messages when dependencies are not satisfied
- No breaking changes to existing installations