### PR TITLE
security: add non-root users to token-spy and dashboard containers

### DIFF
--- a/dream-server/extensions/services/dashboard/Dockerfile
+++ b/dream-server/extensions/services/dashboard/Dockerfile
@@ -32,6 +32,19 @@ COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY entrypoint.sh /entrypoint.sh
 RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
+# Create non-root user and set permissions for nginx
+RUN addgroup -g 1000 dreamer && \
+    adduser -D -u 1000 -G dreamer dreamer && \
+    chown -R dreamer:dreamer /usr/share/nginx/html && \
+    chown -R dreamer:dreamer /var/cache/nginx && \
+    chown -R dreamer:dreamer /var/log/nginx && \
+    chown -R dreamer:dreamer /etc/nginx/conf.d && \
+    touch /var/run/nginx.pid && \
+    chown -R dreamer:dreamer /var/run/nginx.pid && \
+    sed -i '/^user/d' /etc/nginx/nginx.conf
+
+USER dreamer
+
 # Expose port 3001
 EXPOSE 3001
 

--- a/dream-server/extensions/services/token-spy/Dockerfile
+++ b/dream-server/extensions/services/token-spy/Dockerfile
@@ -9,6 +9,12 @@ COPY . .
 
 RUN mkdir -p /app/data
 
+# Create non-root user and set ownership
+RUN adduser --system --no-create-home --uid 1000 dreamer && \
+    chown -R dreamer:nogroup /app
+
+USER dreamer
+
 EXPOSE 8080
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \


### PR DESCRIPTION
## Summary

Adds non-root user (UID 1000) to token-spy and dashboard Dockerfiles to follow container security best practices. Containers should not run as root to minimize attack surface.

## Changes

### token-spy
- Add `dreamer` system user (UID 1000)
- Set ownership of `/app` directory
- Switch to non-root user before CMD

### dashboard
- Add `dreamer` user and group (UID/GID 1000)
- Configure nginx for non-root operation:
  - Set ownership of nginx directories (html, cache, logs, conf.d)
  - Create and own nginx.pid file
  - Remove `user` directive from nginx.conf (runs as current user)
- Switch to non-root user before ENTRYPOINT

## Security Impact

Both containers now run as UID 1000 (dreamer) instead of root, reducing the attack surface if a container is compromised.

## Testing

- Dockerfiles build successfully
- No functional changes to application logic
- Follows Alpine Linux conventions (adduser/addgroup)

## Related

- Related to #295 (container hardening initiative)
- Complements existing HEALTHCHECK directives