### PR TITLE
feat(preflight): add disk space check requiring minimum 50GB

### DIFF
--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -66,6 +66,29 @@ if [[ ! -f "$SCRIPT_DIR/docker-compose.yml" ]] && [[ ! -f "$SCRIPT_DIR/docker-co
     error "No compose files found in $SCRIPT_DIR. Please run from the dream-server directory."
 fi
 
+# Disk space check - require minimum 50GB free for installation
+INSTALL_PARENT=$(dirname "$INSTALL_DIR")
+if [[ -d "$INSTALL_PARENT" ]]; then
+    AVAILABLE_GB=$(df -BG "$INSTALL_PARENT" 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//')
+    if [[ -n "$AVAILABLE_GB" && "$AVAILABLE_GB" =~ ^[0-9]+$ ]]; then
+        if [[ "$AVAILABLE_GB" -lt 50 ]]; then
+            error "Insufficient disk space. Need at least 50GB free, found ${AVAILABLE_GB}GB at $INSTALL_PARENT"
+        fi
+        log "Disk space check: ${AVAILABLE_GB}GB available at $INSTALL_PARENT"
+    else
+        warn "Could not determine available disk space at $INSTALL_PARENT"
+    fi
+else
+    # Parent doesn't exist yet, check root filesystem
+    AVAILABLE_GB=$(df -BG / 2>/dev/null | awk 'NR==2 {print $4}' | sed 's/G//')
+    if [[ -n "$AVAILABLE_GB" && "$AVAILABLE_GB" =~ ^[0-9]+$ ]]; then
+        if [[ "$AVAILABLE_GB" -lt 50 ]]; then
+            error "Insufficient disk space. Need at least 50GB free, found ${AVAILABLE_GB}GB on root filesystem"
+        fi
+        log "Disk space check: ${AVAILABLE_GB}GB available on root filesystem"
+    fi
+fi
+
 # Existing installation — update in place (secrets and data are preserved)
 if [[ -d "$INSTALL_DIR" ]]; then
     log "Existing installation found at $INSTALL_DIR — updating in place"


### PR DESCRIPTION
## Summary
Adds early disk space validation to prevent installation failures when storage runs out during model downloads or image pulls.

## Problem
Installations can fail mid-process when disk space is exhausted:
- Model downloads (2-15GB) fail silently
- FLUX models (~34GB) consume significant space
- Docker image pulls can fail
- Users waste time on partial installations that must be cleaned up

Current installer has no disk space validation, leading to cryptic failures.

## Solution
Added preflight disk space check in phase 01:
- Check available space at install location (or root filesystem if parent doesn't exist)
- Require minimum 50GB free before proceeding
- Fail fast with clear error message
- Log available space for diagnostics

## Disk Space Breakdown
**Minimum 50GB rationale:**
- Base Docker images: ~5-10GB
- GGUF models: 2-15GB (tier-dependent)
- FLUX.1-schnell models: ~34GB (optional, GPU only)
- Docker volumes and logs: ~5GB
- Safety margin: ~10GB

## Implementation
```bash
AVAILABLE_GB=$(df -BG "$INSTALL_PARENT" | awk 'NR==2 {print $4}' | sed 's/G//')
if [[ "$AVAILABLE_GB" -lt 50 ]]; then
    error "Insufficient disk space. Need at least 50GB free, found ${AVAILABLE_GB}GB"
fi
```

## Testing
Validated that:
- Shell syntax is correct (bash -n)
- Check works when install parent exists
- Check falls back to root filesystem when parent doesn't exist
- Error message is clear and actionable

## Impact
- Prevents wasted time on doomed installations
- Reduces support burden from disk space failures
- Clear error message guides users to free up space
- No breaking changes to existing installations