### PR TITLE
fix(health): add timeouts to all curl calls in health check phase

### DIFF
--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -79,13 +79,13 @@ if docker inspect dream-perplexica &>/dev/null; then
         PYTHON_CMD="python"
     fi
 
-    PERPLEXICA_SETUP=$(curl -sf "${PERPLEXICA_URL}/api/config" 2>/dev/null | \
+    PERPLEXICA_SETUP=$(curl -sf --max-time 10 "${PERPLEXICA_URL}/api/config" 2>/dev/null | \
         "$PYTHON_CMD" -c "import sys,json;d=json.load(sys.stdin);print('done' if d['values']['setupComplete'] else 'needed')" 2>/dev/null || echo "skip")
 
     if [[ "$PERPLEXICA_SETUP" == "needed" ]]; then
         ai "Configuring Perplexica for ${LLM_MODEL}..."
         # Query current config to get provider UUIDs, then set model + preferences via API
-        curl -sf "${PERPLEXICA_URL}/api/config" 2>/dev/null | \
+        curl -sf --max-time 10 "${PERPLEXICA_URL}/api/config" 2>/dev/null | \
         "$PYTHON_CMD" -c "
 import sys, json, urllib.request
 


### PR DESCRIPTION
## Summary
Adds explicit timeouts to all curl calls in phase 12 health checks, preventing installer hangs when services are unresponsive.

## Problem
Several curl calls in the health check phase lacked explicit timeouts:
- Perplexica config API calls (2 locations)
- These could hang indefinitely if the service is unresponsive
- Blocks installer progress and creates poor UX

## Solution
Added `--max-time 10` to all Perplexica config curl calls:
- Line 82: Perplexica setup status check
- Line 88: Perplexica config query for provider UUIDs

**Already had timeouts (verified):**
- STT model check: `--max-time 10`
- STT model download: `--max-time 120`
- check_service() function: configurable timeout parameter

## Implementation
```bash
# Before
curl -sf "${PERPLEXICA_URL}/api/config" 2>/dev/null

# After
curl -sf --max-time 10 "${PERPLEXICA_URL}/api/config" 2>/dev/null
```

## Testing
Validated that:
- Shell syntax is correct (bash -n)
- Timeout values are appropriate (10s for config checks)
- Existing timeouts preserved

## Impact
- Prevents installer hangs on unresponsive services
- Consistent timeout behavior across all health checks
- Fails fast with clear error messages
- No breaking changes to existing installations