### PR TITLE
feat: add ui_path and health_timeout to manifest schema

### DIFF
--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -46,6 +46,17 @@
         "external_port_env": { "type": "string" },
         "external_port_default": { "type": "integer", "minimum": 0, "maximum": 65535 },
         "health": { "type": "string", "minLength": 1 },
+        "health_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300,
+          "description": "Health check timeout in seconds (default: 10)"
+        },
+        "ui_path": {
+          "type": "string",
+          "pattern": "^/.*",
+          "description": "Path to the service UI (e.g. /dashboard, /)"
+        },
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
         "gpu_backends": {
           "type": "array",


### PR DESCRIPTION
## Summary

Enhances the service manifest schema with two commonly-used optional fields that were previously undocumented.

## Changes

### Added Fields

**ui_path** (optional string)
- Path to the service UI (e.g. `/dashboard`, `/`)
- Must start with `/`
- Used by dashboard API to generate external links
- Pattern validation: `^/.*`

**health_timeout** (optional integer)
- Health check timeout in seconds
- Range: 1-300 seconds
- Default: 10 seconds if not specified
- Used by `scripts/health-check.sh` for service validation

## Rationale

These fields are already used in many existing manifests but were not formally defined in the schema:
- `ui_path`: Used in 15+ service manifests
- `health_timeout`: Used in llama-server and other critical services

Adding them to the schema:
- Improves validation coverage
- Documents expected behavior
- Enables better tooling support
- Catches typos and invalid values

## Testing

- Schema is valid JSON
- Existing manifests remain valid
- `scripts/validate-manifests.sh` runs successfully
