### PR TITLE
feat(voice-settings): add GET/PATCH /api/settings/voice with schema validation

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -212,7 +212,21 @@
     "WHISPER_MODEL": {
       "type": "string",
       "description": "Whisper STT model size",
+      "enum": [
+        "tiny", "tiny.en",
+        "base", "base.en",
+        "small", "small.en",
+        "medium", "medium.en",
+        "large", "large-v2", "large-v3", "large-v3-turbo"
+      ],
       "default": "base"
+    },
+    "WHISPER_VAD_THRESHOLD": {
+      "type": "number",
+      "description": "Voice-activity detection threshold for Whisper STT (0.0–1.0). Lower values detect more speech; higher values require stronger signal.",
+      "minimum": 0.0,
+      "maximum": 1.0,
+      "default": 0.5
     },
     "TIMEZONE": {
       "type": "string",

--- a/dream-server/extensions/services/dashboard-api/env_utils.py
+++ b/dream-server/extensions/services/dashboard-api/env_utils.py
@@ -1,0 +1,125 @@
+"""Shared helpers for reading and writing Dream Server's .env and loading .env.schema.json.
+
+These utilities are intentionally free of shell evaluation — all reads and
+writes are done with plain Python regex so that key names and values with
+spaces, quotes, or special characters are handled safely.
+"""
+
+import json
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Resolved once at import time; can be overridden via environment variables for
+# testing or non-standard deployment layouts.
+_INSTALL_DIR = Path(os.environ.get("DREAM_INSTALL_DIR", os.path.expanduser("~/dream-server")))
+_ENV_PATH = Path(os.environ.get("DREAM_ENV_FILE", str(_INSTALL_DIR / ".env")))
+_SCHEMA_PATH = Path(os.environ.get("DREAM_SCHEMA_FILE", str(_INSTALL_DIR / ".env.schema.json")))
+
+# Matches bare KEY=value lines (no leading spaces, no shell constructs).
+_KEY_RE = re.compile(r'^([A-Za-z_][A-Za-z0-9_]*)=(.*)', re.MULTILINE)
+
+
+def read_env() -> dict[str, str]:
+    """Parse .env into a {key: value} dict.
+
+    Comments (#…) and blank lines are ignored.  Surrounding single- or
+    double-quotes are stripped from values so callers always get the raw
+    string.
+    """
+    env: dict[str, str] = {}
+    if not _ENV_PATH.exists():
+        logger.warning(".env not found at %s", _ENV_PATH)
+        return env
+
+    for line in _ENV_PATH.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        m = _KEY_RE.match(stripped)
+        if not m:
+            continue
+        key, val = m.group(1), m.group(2)
+        if len(val) >= 2 and val[0] == val[-1] and val[0] in ('"', "'"):
+            val = val[1:-1]
+        env[key] = val
+    return env
+
+
+def write_env_key(key: str, value: str) -> None:
+    """Update *key* in .env to *value*, or append it if the key is absent.
+
+    The update is done with a single regex substitution on the raw file text
+    so line order and comments are preserved.  No shell evaluation is
+    performed.
+    """
+    if not _ENV_PATH.exists():
+        logger.warning(".env not found at %s — cannot write key %s", _ENV_PATH, key)
+        return
+
+    text = _ENV_PATH.read_text(encoding="utf-8")
+    pattern = re.compile(rf'^{re.escape(key)}=.*$', re.MULTILINE)
+    replacement = f"{key}={value}"
+    if pattern.search(text):
+        new_text = pattern.sub(replacement, text, count=1)
+    else:
+        new_text = text.rstrip("\n") + f"\n{replacement}\n"
+    _ENV_PATH.write_text(new_text, encoding="utf-8")
+
+
+def load_schema() -> dict[str, Any]:
+    """Load and return the parsed .env.schema.json.
+
+    Returns an empty dict on any failure and emits a warning so callers can
+    degrade gracefully (e.g. skip schema validation rather than crashing).
+    """
+    if not _SCHEMA_PATH.exists():
+        logger.warning(".env.schema.json not found at %s", _SCHEMA_PATH)
+        return {}
+    try:
+        return json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.warning("Failed to parse .env.schema.json: %s", exc)
+        return {}
+
+
+def validate_against_schema(
+    field_name: str,
+    env_key: str,
+    value: object,
+    schema: dict[str, Any],
+) -> str | None:
+    """Check *value* against the schema property for *env_key*.
+
+    Returns an error string when the value violates a schema constraint, or
+    ``None`` when the value is valid (or the key has no schema entry).
+
+    Supported constraints: ``enum``, ``minimum``, ``maximum``, ``type``
+    (number coercion only — string and boolean fields are accepted as-is).
+    """
+    prop = schema.get("properties", {}).get(env_key, {})
+    if not prop:
+        return None  # No schema rule — allow any value.
+
+    allowed = prop.get("enum")
+    if allowed is not None and value not in allowed:
+        return f"{field_name} must be one of: {', '.join(str(v) for v in allowed)}"
+
+    prop_type = prop.get("type")
+    if prop_type == "number":
+        try:
+            numeric = float(str(value))
+        except ValueError:
+            return f"{field_name} must be a number"
+        minimum = prop.get("minimum")
+        maximum = prop.get("maximum")
+        if minimum is not None and numeric < minimum:
+            return f"{field_name} must be >= {minimum}"
+        if maximum is not None and numeric > maximum:
+            return f"{field_name} must be <= {maximum}"
+
+    return None

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -43,7 +43,7 @@ from helpers import (
 from agent_monitor import collect_metrics
 
 # --- Router imports ---
-from routers import workflows, features, setup, updates, agents, privacy
+from routers import workflows, features, setup, updates, agents, privacy, voice_settings
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +92,7 @@ app.include_router(setup.router)
 app.include_router(updates.router)
 app.include_router(agents.router)
 app.include_router(privacy.router)
+app.include_router(voice_settings.router)
 
 
 # ================================================================

--- a/dream-server/extensions/services/dashboard-api/models.py
+++ b/dream-server/extensions/services/dashboard-api/models.py
@@ -104,3 +104,26 @@ class PrivacyShieldStatus(BaseModel):
 
 class PrivacyShieldToggle(BaseModel):
     enable: bool
+
+
+# --- Voice settings ---
+
+class VoiceSettingsResponse(BaseModel):
+    whisper_model: str
+    tts_voice: Optional[str] = None
+    whisper_vad_threshold: float
+    allowed_whisper_models: list[str] = Field(
+        default_factory=list,
+        description="Valid WHISPER_MODEL values from .env.schema.json",
+    )
+
+
+class VoiceSettingsPatch(BaseModel):
+    whisper_model: Optional[str] = None
+    tts_voice: Optional[str] = None
+    whisper_vad_threshold: Optional[float] = Field(
+        None,
+        ge=0.0,
+        le=1.0,
+        description="VAD threshold (0.0–1.0); authoritative bounds are re-checked against schema",
+    )

--- a/dream-server/extensions/services/dashboard-api/routers/voice_settings.py
+++ b/dream-server/extensions/services/dashboard-api/routers/voice_settings.py
@@ -1,0 +1,129 @@
+"""Voice-settings endpoints.
+
+GET  /api/settings/voice  — return current Whisper/TTS configuration
+PATCH /api/settings/voice  — update one or more voice settings; each field is
+                              validated against .env.schema.json before being
+                              written to .env.
+
+Managed .env keys
+-----------------
+WHISPER_MODEL          : Whisper STT model size  (schema: enum)
+TTS_VOICE              : Kokoro TTS voice string  (schema: string, free-form)
+WHISPER_VAD_THRESHOLD  : VAD sensitivity 0.0–1.0  (schema: number + bounds)
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from env_utils import load_schema, read_env, validate_against_schema, write_env_key
+from models import VoiceSettingsPatch, VoiceSettingsResponse
+from security import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["settings"])
+
+# Keys managed by this router, in the order they appear in the response model.
+_VOICE_ENV_KEYS = ("WHISPER_MODEL", "TTS_VOICE", "WHISPER_VAD_THRESHOLD")
+
+
+def _build_response(env: dict[str, str], schema: dict) -> VoiceSettingsResponse:
+    """Construct a VoiceSettingsResponse from a parsed .env dict and schema."""
+    props = schema.get("properties", {})
+
+    whisper_model: str = (
+        env.get("WHISPER_MODEL")
+        or props.get("WHISPER_MODEL", {}).get("default", "base")
+    )
+
+    tts_voice: str | None = env.get("TTS_VOICE") or None
+
+    raw_vad = env.get("WHISPER_VAD_THRESHOLD")
+    whisper_vad_threshold: float
+    if raw_vad:
+        try:
+            whisper_vad_threshold = float(raw_vad)
+        except ValueError:
+            logger.warning("Invalid WHISPER_VAD_THRESHOLD in .env: %r — using default", raw_vad)
+            whisper_vad_threshold = float(
+                props.get("WHISPER_VAD_THRESHOLD", {}).get("default", 0.5)
+            )
+    else:
+        whisper_vad_threshold = float(
+            props.get("WHISPER_VAD_THRESHOLD", {}).get("default", 0.5)
+        )
+
+    allowed_whisper_models: list[str] = props.get("WHISPER_MODEL", {}).get("enum", [])
+
+    return VoiceSettingsResponse(
+        whisper_model=whisper_model,
+        tts_voice=tts_voice,
+        whisper_vad_threshold=whisper_vad_threshold,
+        allowed_whisper_models=allowed_whisper_models,
+    )
+
+
+@router.get("/api/settings/voice", response_model=VoiceSettingsResponse)
+async def get_voice_settings(api_key: str = Depends(verify_api_key)):
+    """Return current voice settings read from .env.
+
+    Falls back to schema defaults when a key is absent.  Also returns
+    ``allowed_whisper_models`` so clients can populate a drop-down without
+    hard-coding the list.
+    """
+    return _build_response(read_env(), load_schema())
+
+
+@router.patch("/api/settings/voice", response_model=VoiceSettingsResponse)
+async def patch_voice_settings(
+    patch: VoiceSettingsPatch,
+    api_key: str = Depends(verify_api_key),
+):
+    """Update one or more voice settings and write them to .env.
+
+    Every supplied field is validated against .env.schema.json before any
+    write is performed.  If *any* field fails validation the whole request is
+    rejected with HTTP 422 and a list of error messages.
+    """
+    schema = load_schema()
+    errors: list[str] = []
+    updates: dict[str, str] = {}
+
+    if patch.whisper_model is not None:
+        err = validate_against_schema(
+            "whisper_model", "WHISPER_MODEL", patch.whisper_model, schema
+        )
+        if err:
+            errors.append(err)
+        else:
+            updates["WHISPER_MODEL"] = patch.whisper_model
+
+    if patch.tts_voice is not None:
+        stripped = patch.tts_voice.strip()
+        if not stripped:
+            errors.append("tts_voice must not be blank")
+        else:
+            updates["TTS_VOICE"] = stripped
+
+    if patch.whisper_vad_threshold is not None:
+        err = validate_against_schema(
+            "whisper_vad_threshold",
+            "WHISPER_VAD_THRESHOLD",
+            patch.whisper_vad_threshold,
+            schema,
+        )
+        if err:
+            errors.append(err)
+        else:
+            updates["WHISPER_VAD_THRESHOLD"] = str(patch.whisper_vad_threshold)
+
+    if errors:
+        raise HTTPException(status_code=422, detail=errors)
+
+    for env_key, value in updates.items():
+        write_env_key(env_key, value)
+        logger.info("Voice setting updated: %s", env_key)
+
+    # Re-read .env so the response always reflects the on-disk state.
+    return _build_response(read_env(), schema)


### PR DESCRIPTION
## Summary

- **`GET /api/settings/voice`** — reads `WHISPER_MODEL`, `TTS_VOICE`, and `WHISPER_VAD_THRESHOLD` from `.env`, falls back to schema defaults when a key is absent, and returns `allowed_whisper_models` so clients can populate a model picker without hard-coding values.
- **`PATCH /api/settings/voice`** — accepts a partial update, validates every supplied field against `.env.schema.json` before touching disk (all-or-nothing), rejects with HTTP 422 + a list of error messages on any violation, then re-reads `.env` so the response always reflects the true on-disk state.
- **`env_utils.py`** (new shared module) — safe `.env` read/write helpers (`read_env`, `write_env_key`) and a `load_schema` / `validate_against_schema` pair that other routers can import instead of duplicating the logic.
- **`.env.schema.json`** extended with a `WHISPER_MODEL` enum (`tiny` → `large-v3-turbo`, including `.en` variants) and a new `WHISPER_VAD_THRESHOLD` property (`number`, `0.0`–`1.0`, default `0.5`).
- **`models.py`** — added `VoiceSettingsResponse` and `VoiceSettingsPatch` Pydantic models; `VoiceSettingsPatch.whisper_vad_threshold` carries a Pydantic `ge/le` guard as a first-pass check before schema validation.

## Validation layers

| Layer | What it catches |
|---|---|
| Pydantic (`ge=0.0, le=1.0`) | Clearly out-of-range VAD values before business logic runs |
| `validate_against_schema` | Enum violations for `WHISPER_MODEL`, numeric bounds from schema for `WHISPER_VAD_THRESHOLD`, blank `TTS_VOICE` |

All validation errors are collected before any write, so a multi-field PATCH either fully succeeds or returns the complete error list in one response.

## Test plan

- [ ] `GET /api/settings/voice` returns defaults when keys are absent from `.env`
- [ ] `GET /api/settings/voice` returns `allowed_whisper_models` populated from schema enum
- [ ] `PATCH` with `whisper_model: "small"` writes `WHISPER_MODEL=small` to `.env`
- [ ] `PATCH` with `whisper_model: "invalid"` returns HTTP 422 with enum error
- [ ] `PATCH` with `whisper_vad_threshold: 1.5` returns HTTP 422 (Pydantic + schema both reject)
- [ ] `PATCH` with `whisper_vad_threshold: 0.0` accepts and writes `WHISPER_VAD_THRESHOLD=0.0`
- [ ] `PATCH` with `tts_voice: ""` (blank) returns HTTP 422
- [ ] Multi-field PATCH with one invalid field rejects all changes (no partial write)
- [ ] `GET` after a successful `PATCH` reflects the updated values