### PR TITLE
feat(model-swap): add POST /api/model/swap with SSE progress streaming

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -43,7 +43,7 @@ from helpers import (
 from agent_monitor import collect_metrics
 
 # --- Router imports ---
-from routers import workflows, features, setup, updates, agents, privacy
+from routers import workflows, features, setup, updates, agents, privacy, voice_settings, model_swap
 
 logger = logging.getLogger(__name__)
 
@@ -92,6 +92,8 @@ app.include_router(setup.router)
 app.include_router(updates.router)
 app.include_router(agents.router)
 app.include_router(privacy.router)
+app.include_router(voice_settings.router)
+app.include_router(model_swap.router)
 
 
 # ================================================================

--- a/dream-server/extensions/services/dashboard-api/models.py
+++ b/dream-server/extensions/services/dashboard-api/models.py
@@ -104,3 +104,36 @@ class PrivacyShieldStatus(BaseModel):
 
 class PrivacyShieldToggle(BaseModel):
     enable: bool
+
+
+# --- Voice settings ---
+
+class VoiceSettingsResponse(BaseModel):
+    whisper_model: str
+    tts_voice: Optional[str] = None
+    whisper_vad_threshold: float
+    allowed_whisper_models: list[str] = Field(
+        default_factory=list,
+        description="Valid WHISPER_MODEL values from .env.schema.json",
+    )
+
+
+class VoiceSettingsPatch(BaseModel):
+    whisper_model: Optional[str] = None
+    tts_voice: Optional[str] = None
+    whisper_vad_threshold: Optional[float] = Field(
+        None,
+        ge=0.0,
+        le=1.0,
+        description="VAD threshold (0.0–1.0); authoritative bounds are re-checked against schema",
+    )
+
+
+# --- Model swap ---
+
+class ModelSwapRequest(BaseModel):
+    tier: str = Field(..., description="Target hardware tier (e.g. T2, T3, NV_ULTRA)")
+    restart: bool = Field(
+        True,
+        description="Restart llama-server after updating .env (recommended)",
+    )

--- a/dream-server/extensions/services/dashboard-api/routers/model_swap.py
+++ b/dream-server/extensions/services/dashboard-api/routers/model_swap.py
@@ -1,0 +1,217 @@
+"""Model-swap endpoint.
+
+POST /api/model/swap
+  Body : { "tier": "<tier>", "restart": true }
+  Response: text/event-stream (Server-Sent Events)
+
+Each SSE event is a JSON object on a ``data:`` line:
+
+  {"type": "log",      "message": "<line from dream-cli>"}
+  {"type": "progress", "step": "restart", "status": "running"}
+  {"type": "done",     "success": true,  "tier": "T2", "restarted": true}
+  {"type": "error",    "message": "...", "step": "swap"|"restart"}
+
+The endpoint runs two subprocesses through the existing ``dream-cli`` script so
+that tier-resolution logic stays in a single place:
+
+  1. ``bash dream-cli model swap <tier>``  — updates .env in-place
+  2. ``bash dream-cli restart llama-server`` — (optional) hot-reloads the model
+"""
+
+import json
+import logging
+import re
+import subprocess
+from collections.abc import Generator
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+
+from config import INSTALL_DIR
+from models import ModelSwapRequest
+from security import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["model"])
+
+# ---------------------------------------------------------------------------
+# Valid tier names — kept in sync with installers/lib/tier-map.sh.
+# Tier validation happens here so malformed strings never reach the shell.
+# ---------------------------------------------------------------------------
+_VALID_TIERS: frozenset[str] = frozenset({
+    # Numeric aliases (accepted by tier_to_model / dream model swap)
+    "0", "1", "2", "3", "4",
+    # T-prefixed aliases
+    "T0", "T1", "T2", "T3", "T4",
+    # Named tiers
+    "CLOUD",
+    "NV_ULTRA",
+    "SH", "SH_COMPACT", "SH_LARGE",
+    "ARC", "ARC_LITE",
+})
+
+# Strip ANSI escape codes that dream-cli injects for terminal colour output.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*[mGKHF]")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
+
+
+def _find_dream_cli() -> Path | None:
+    """Return the path to the dream-cli script inside INSTALL_DIR, or None."""
+    candidate = Path(INSTALL_DIR) / "dream-cli"
+    return candidate if candidate.exists() else None
+
+
+def _sse(data: dict) -> str:
+    """Format *data* as a single SSE event string."""
+    return f"data: {json.dumps(data)}\n\n"
+
+
+def _run_streamed(
+    args: list[str],
+    cwd: str,
+) -> Generator[tuple[str, int], None, None]:
+    """Run *args* as a subprocess and yield (line, returncode_or_-1) pairs.
+
+    Yields ``(line, -1)`` for each stdout/stderr line while the process runs,
+    then ``("", returncode)`` once when the process exits.
+
+    The caller is responsible for treating a non-zero returncode as a failure.
+    """
+    proc = subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        cwd=cwd,
+    )
+    try:
+        assert proc.stdout is not None
+        for raw in proc.stdout:
+            yield (raw.rstrip(), -1)
+        proc.wait()
+    finally:
+        if proc.stdout:
+            proc.stdout.close()
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait()
+    yield ("", proc.returncode)
+
+
+def _generate_swap_events(
+    tier: str,
+    restart: bool,
+    cli_path: Path,
+) -> Generator[str, None, None]:
+    """Sync generator that drives both dream-cli subprocesses and yields SSE strings."""
+
+    install_dir = str(cli_path.parent)
+    cli = str(cli_path)
+
+    # ------------------------------------------------------------------
+    # Step 1 — model swap
+    # ------------------------------------------------------------------
+    yield _sse({"type": "log", "message": f"Applying model tier {tier}…"})
+
+    swap_rc = 0
+    for line, rc in _run_streamed(["bash", cli, "model", "swap", tier], cwd=install_dir):
+        if rc == -1:
+            clean = _strip_ansi(line)
+            if clean:
+                yield _sse({"type": "log", "message": clean})
+        else:
+            swap_rc = rc
+
+    if swap_rc != 0:
+        yield _sse({
+            "type": "error",
+            "message": f"'dream model swap {tier}' exited with code {swap_rc}",
+            "step": "swap",
+        })
+        return
+
+    if not restart:
+        yield _sse({"type": "done", "success": True, "tier": tier, "restarted": False})
+        return
+
+    # ------------------------------------------------------------------
+    # Step 2 — restart llama-server
+    # ------------------------------------------------------------------
+    yield _sse({"type": "log", "message": "Restarting llama-server…"})
+    yield _sse({"type": "progress", "step": "restart", "status": "running"})
+
+    restart_rc = 0
+    for line, rc in _run_streamed(
+        ["bash", cli, "restart", "llama-server"], cwd=install_dir
+    ):
+        if rc == -1:
+            clean = _strip_ansi(line)
+            if clean:
+                yield _sse({"type": "log", "message": clean})
+        else:
+            restart_rc = rc
+
+    if restart_rc != 0:
+        yield _sse({
+            "type": "error",
+            "message": f"llama-server restart exited with code {restart_rc}",
+            "step": "restart",
+        })
+        return
+
+    yield _sse({"type": "done", "success": True, "tier": tier, "restarted": True})
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+@router.post("/api/model/swap")
+async def swap_model(
+    request: ModelSwapRequest,
+    api_key: str = Depends(verify_api_key),
+) -> StreamingResponse:
+    """Swap the active model tier and optionally restart llama-server.
+
+    Streams SSE progress events until the operation completes.  Each event is
+    a JSON object on a ``data:`` line; the final event has ``type == "done"``
+    or ``type == "error"``.
+
+    ``restart`` (default ``true``) triggers ``dream restart llama-server``
+    after updating ``.env``.  Set to ``false`` to update the env only, then
+    apply the change yourself via ``dream restart llama-server``.
+    """
+    tier = request.tier.strip().upper()
+    if tier not in _VALID_TIERS:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"Unknown tier '{request.tier}'. "
+                f"Valid tiers: {', '.join(sorted(_VALID_TIERS))}"
+            ),
+        )
+
+    cli_path = _find_dream_cli()
+    if cli_path is None:
+        raise HTTPException(
+            status_code=501,
+            detail=f"dream-cli not found in INSTALL_DIR ({INSTALL_DIR}). "
+                   "Ensure the Dream Server is fully installed.",
+        )
+
+    logger.info("Model swap requested: tier=%s restart=%s", tier, request.restart)
+
+    return StreamingResponse(
+        _generate_swap_events(tier, request.restart, cli_path),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # Disable nginx buffering for SSE
+        },
+    )


### PR DESCRIPTION
## Summary

- **`POST /api/model/swap`** — accepts `{ "tier": "<tier>", "restart": true }` and streams Server-Sent Events (SSE) until the operation completes. Runs two `dream-cli` subprocesses in sequence: `dream model swap <tier>` to update `.env`, then `dream restart llama-server` (skipped when `restart: false`).
- **`routers/model_swap.py`** (new) — self-contained router following the same subprocess pattern as `routers/updates.py`, extended with a sync SSE streaming generator consistent with `routers/setup.py`.
- **`ModelSwapRequest`** added to `models.py` (`tier: str`, `restart: bool = True`).
- `voice_settings` and `model_swap` routers registered in `main.py`.

## SSE event schema

| `type` | Additional fields | Meaning |
|---|---|---|
| `log` | `message` | Raw output line from `dream-cli` (ANSI stripped) |
| `progress` | `step`, `status` | Restart subprocess started |
| `done` | `success`, `tier`, `restarted` | Clean completion |
| `error` | `message`, `step` | Non-zero exit from `swap` or `restart` phase |

## Security

- Tier string is upper-cased and checked against a `_VALID_TIERS` frozenset before any subprocess is spawned — no unsanitised input ever reaches the shell.
- Returns **HTTP 422** for unknown tiers with the full valid-tier list in the error detail.
- Returns **HTTP 501** if `dream-cli` is not present in `INSTALL_DIR`.

## HTTP response headers

`Cache-Control: no-cache` and `X-Accel-Buffering: no` are set so nginx/proxies do not buffer the stream.

## Test plan

- [ ] `POST /api/model/swap` with `tier: "T2"` streams `log` events ending in `done`
- [ ] `POST /api/model/swap` with `tier: "invalid"` returns HTTP 422 with valid-tier list
- [ ] `POST /api/model/swap` with `restart: false` skips restart phase; `done.restarted` is `false`
- [ ] Verify `.env` contains updated `LLM_MODEL`, `TIER`, `GGUF_FILE`, `CTX_SIZE` after swap
- [ ] Non-zero exit from `dream model swap` emits `error` event with `step: "swap"` and does not attempt restart
- [ ] Non-zero exit from `dream restart` emits `error` event with `step: "restart"`
- [ ] `Cache-Control: no-cache` and `X-Accel-Buffering: no` present in response headers
- [ ] ANSI escape codes absent from all `log` message strings