### PR TITLE
Replace silent error suppression with proper logging

### DIFF
--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -96,7 +96,7 @@ detect_gpu() {
     # Try NVIDIA first
     if command -v nvidia-smi &> /dev/null; then
         local raw
-        if raw=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) && [[ -n "$raw" ]]; then
+        if raw=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>>"$LOG_FILE") && [[ -n "$raw" ]]; then
             GPU_BACKEND="nvidia"
             GPU_MEMORY_TYPE="discrete"
             GPU_INFO="$raw"
@@ -106,7 +106,7 @@ detect_gpu() {
             GPU_VRAM=$(echo "$GPU_INFO" | cut -d',' -f2 | grep -oP '\d+' | awk '{s+=$1} END {print s+0}')
             # Extract PCI device ID from first GPU
             local pci_id
-            pci_id=$(nvidia-smi --query-gpu=pci.device_id --format=csv,noheader 2>/dev/null | head -1 | xargs)
+            pci_id=$(nvidia-smi --query-gpu=pci.device_id --format=csv,noheader 2>>"$LOG_FILE" | head -1 | xargs)
             [[ -n "$pci_id" ]] && GPU_DEVICE_ID="${pci_id:0:6}"
             if [[ $GPU_COUNT -gt 1 ]]; then
                 # Build a display name for multi-GPU (e.g. "RTX 3090 + RTX 4090" or "RTX 4090 × 2")
@@ -128,12 +128,12 @@ detect_gpu() {
     fi
 
     # Try Intel Arc via lspci + sysfs
-    if lspci 2>/dev/null | grep -qi 'VGA.*Intel.*Arc'; then
+    if command -v lspci &>/dev/null && lspci 2>>"$LOG_FILE" | grep -qi 'VGA.*Intel.*Arc'; then
         for card_dir in /sys/class/drm/card*/device; do
             [[ -d "$card_dir" ]] || continue
             local vendor device
-            vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
-            device=$(cat "$card_dir/device" 2>/dev/null) || continue
+            vendor=$(cat "$card_dir/vendor" 2>>"$LOG_FILE") || continue
+            device=$(cat "$card_dir/device" 2>>"$LOG_FILE") || continue
             # Intel vendor ID: 0x8086, Arc device IDs: 0x56a0-0x56c1 (Alchemist), 0x5690-0x569f (DG2)
             if [[ "$vendor" == "0x8086" ]] && [[ "$device" =~ ^0x(56[a-c][0-9a-f]|569[0-9a-f])$ ]]; then
                 GPU_BACKEND="intel"
@@ -142,11 +142,11 @@ detect_gpu() {
                 GPU_COUNT=1
                 # Try to get VRAM size from sysfs (lmem_total_bytes on Arc)
                 local vram_bytes
-                vram_bytes=$(cat "$card_dir/lmem_total_bytes" 2>/dev/null) || vram_bytes=0
+                vram_bytes=$(cat "$card_dir/lmem_total_bytes" 2>>"$LOG_FILE") || vram_bytes=0
                 GPU_VRAM=$(( vram_bytes / 1048576 ))  # in MB
                 # Try marketing name from sysfs or lspci
                 if [[ -f "$card_dir/product_name" ]]; then
-                    GPU_NAME=$(cat "$card_dir/product_name" 2>/dev/null) || GPU_NAME="Intel Arc"
+                    GPU_NAME=$(cat "$card_dir/product_name" 2>>"$LOG_FILE") || GPU_NAME="Intel Arc"
                 else
                     GPU_NAME=$(lspci | grep -i 'VGA.*Intel.*Arc' | sed 's/.*: //' | head -1)
                     [[ -z "$GPU_NAME" ]] && GPU_NAME="Intel Arc ($GPU_DEVICE_ID)"
@@ -161,16 +161,16 @@ detect_gpu() {
     for card_dir in /sys/class/drm/card*/device; do
         [[ -d "$card_dir" ]] || continue
         local vendor
-        vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
+        vendor=$(cat "$card_dir/vendor" 2>>"$LOG_FILE") || continue
         if [[ "$vendor" == "0x1002" ]]; then
             local vram_bytes gtt_bytes
-            vram_bytes=$(cat "$card_dir/mem_info_vram_total" 2>/dev/null) || vram_bytes=0
-            gtt_bytes=$(cat "$card_dir/mem_info_gtt_total" 2>/dev/null) || gtt_bytes=0
+            vram_bytes=$(cat "$card_dir/mem_info_vram_total" 2>>"$LOG_FILE") || vram_bytes=0
+            gtt_bytes=$(cat "$card_dir/mem_info_gtt_total" 2>>"$LOG_FILE") || gtt_bytes=0
             local gtt_gb=$(( gtt_bytes / 1073741824 ))
             local vram_gb=$(( vram_bytes / 1073741824 ))
 
             # Read device ID from sysfs
-            GPU_DEVICE_ID=$(cat "$card_dir/device" 2>/dev/null) || GPU_DEVICE_ID="unknown"
+            GPU_DEVICE_ID=$(cat "$card_dir/device" 2>>"$LOG_FILE") || GPU_DEVICE_ID="unknown"
 
             # Detect APU: small VRAM + large GTT = unified memory
             if [[ $gtt_gb -ge 16 && $vram_gb -le 4 ]] || [[ $gtt_gb -ge 32 ]] || [[ $vram_gb -ge 32 ]]; then
@@ -205,7 +205,7 @@ MIN_DRIVER_VERSION=570
 
 fix_nvidia_secure_boot() {
     # Step 1: Is there even NVIDIA hardware on this machine?
-    if ! lspci 2>/dev/null | grep -qi 'nvidia'; then
+    if ! command -v lspci &>/dev/null || ! lspci 2>>"$LOG_FILE" | grep -qi 'nvidia'; then
         return 1  # No hardware — nothing to fix
     fi
 

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -34,11 +34,11 @@ if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
     GPU_COUNT=0
     GPU_MEMORY_TYPE="none"
     TIER="CLOUD"
-    if grep -qi microsoft /proc/version 2>/dev/null; then
+    if [[ -f /proc/version ]] && grep -qi microsoft /proc/version 2>>"$LOG_FILE"; then
         _wsl_ram_bytes=""
         if command -v powershell.exe &>/dev/null; then
             _wsl_ram_bytes=$(powershell.exe -NoProfile -Command \
-                "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" 2>/dev/null | tr -d '\r')
+                "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" 2>>"$LOG_FILE" | tr -d '\r')
         fi
         if [[ -n "$_wsl_ram_bytes" && "$_wsl_ram_bytes" =~ ^[0-9]+$ ]]; then
             RAM_KB=$((_wsl_ram_bytes / 1024))
@@ -70,17 +70,17 @@ ai "Reading hardware telemetry..."
 load_capability_profile || true
 
 # RAM Detection (WSL2-aware: query Windows host RAM if available)
-if grep -qi microsoft /proc/version 2>/dev/null; then
+if [[ -f /proc/version ]] && grep -qi microsoft /proc/version 2>>"$LOG_FILE"; then
     _wsl_ram_kb=""
     if command -v powershell.exe &>/dev/null; then
         _wsl_ram_bytes=$(powershell.exe -NoProfile -Command \
-            "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" 2>/dev/null | tr -d '\r')
+            "(Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory" 2>>"$LOG_FILE" | tr -d '\r')
         if [[ -n "$_wsl_ram_bytes" && "$_wsl_ram_bytes" =~ ^[0-9]+$ ]]; then
             _wsl_ram_kb=$((_wsl_ram_bytes / 1024))
         fi
     fi
     if [[ -z "$_wsl_ram_kb" ]] && command -v wmic.exe &>/dev/null; then
-        _wsl_ram_kb=$(wmic.exe OS get TotalVisibleMemorySize /value 2>/dev/null \
+        _wsl_ram_kb=$(wmic.exe OS get TotalVisibleMemorySize /value 2>>"$LOG_FILE" \
             | grep -oE '[0-9]+' | sed -n '1p')
     fi
     if [[ -n "$_wsl_ram_kb" && "$_wsl_ram_kb" =~ ^[0-9]+$ ]]; then

--- a/dream-server/installers/phases/04-requirements.sh
+++ b/dream-server/installers/phases/04-requirements.sh
@@ -148,20 +148,20 @@ check_port_conflict() {
     # Try lsof first (most reliable for getting process info)
     if command -v lsof &> /dev/null; then
         if lsof -i ":${port}" -sTCP:LISTEN >/dev/null 2>&1; then
-            PORT_CONFLICT_PID=$(lsof -t -i ":${port}" -sTCP:LISTEN 2>/dev/null | head -1)
-            PORT_CONFLICT_PROC=$(ps -p "$PORT_CONFLICT_PID" -o comm= 2>/dev/null || echo "unknown")
+            PORT_CONFLICT_PID=$(lsof -t -i ":${port}" -sTCP:LISTEN 2>>"$LOG_FILE" | head -1)
+            PORT_CONFLICT_PROC=$(ps -p "$PORT_CONFLICT_PID" -o comm= 2>>"$LOG_FILE" || echo "unknown")
             PORT_CONFLICT=true
             return 0
         fi
     # Fallback to ss (faster but less detailed)
     elif command -v ss &> /dev/null; then
-        if ss -tln 2>/dev/null | grep -qE ":${port}(\s|$)"; then
+        if command -v ss &>/dev/null && ss -tln 2>>"$LOG_FILE" | grep -qE ":${port}(\s|$)"; then
             # Try to extract PID from ss output (format: users:(("process",pid=1234,fd=5)))
             local ss_line
-            ss_line=$(ss -tlnp 2>/dev/null | grep -E ":${port}(\s|$)" | head -1)
+            ss_line=$(ss -tlnp 2>>"$LOG_FILE" | grep -E ":${port}(\s|$)" | head -1)
             if [[ "$ss_line" =~ pid=([0-9]+) ]]; then
                 PORT_CONFLICT_PID="${BASH_REMATCH[1]}"
-                PORT_CONFLICT_PROC=$(ps -p "$PORT_CONFLICT_PID" -o comm= 2>/dev/null || echo "unknown")
+                PORT_CONFLICT_PROC=$(ps -p "$PORT_CONFLICT_PID" -o comm= 2>>"$LOG_FILE" || echo "unknown")
             else
                 PORT_CONFLICT_PROC="unknown"
             fi
@@ -170,10 +170,10 @@ check_port_conflict() {
         fi
     # Fallback to netstat
     elif command -v netstat &> /dev/null; then
-        if netstat -tln 2>/dev/null | grep -qE ":${port}(\s|$)"; then
+        if command -v netstat &>/dev/null && netstat -tln 2>>"$LOG_FILE" | grep -qE ":${port}(\s|$)"; then
             # netstat -tlnp requires root, so we may not get PID
             local netstat_line
-            netstat_line=$(netstat -tlnp 2>/dev/null | grep -E ":${port}(\s|$)" | head -1)
+            netstat_line=$(netstat -tlnp 2>>"$LOG_FILE" | grep -E ":${port}(\s|$)" | head -1)
             if [[ "$netstat_line" =~ ([0-9]+)/([^ ]+) ]]; then
                 PORT_CONFLICT_PID="${BASH_REMATCH[1]}"
                 PORT_CONFLICT_PROC="${BASH_REMATCH[2]}"
@@ -215,7 +215,7 @@ if $OLLAMA_RUNNING; then
     if $INTERACTIVE && ! $DRY_RUN; then
         read -r -p "  Stop Ollama for this session? [Y/n] " ollama_choice
         if [[ ! "$ollama_choice" =~ ^[nN] ]]; then
-            kill "$OLLAMA_PID" 2>/dev/null || sudo kill "$OLLAMA_PID" 2>/dev/null || true
+            kill "$OLLAMA_PID" 2>>"$LOG_FILE" || sudo kill "$OLLAMA_PID" 2>>"$LOG_FILE" || true
             sleep 2
             if pgrep -x ollama >/dev/null 2>&1; then
                 ai_warn "Ollama restarted automatically. Stop it manually: sudo systemctl stop ollama"

--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -69,7 +69,7 @@ else
         sudo usermod -aG docker "$target_user"
 
         # In most cases group membership won't take effect until a new login shell.
-        if ! id -nG "$target_user" 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
+        if ! id -nG "$target_user" 2>>"$LOG_FILE" | tr ' ' '\n' | grep -qx docker; then
             DOCKER_NEEDS_SUDO=true
         fi
     fi
@@ -271,7 +271,7 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
         ai "Installing NVIDIA Container Toolkit..."
         if ! $DRY_RUN; then
             # Add NVIDIA GPG key (used by apt and as trust anchor)
-            curl -fsSL --max-time 60 https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg 2>/dev/null || true
+            curl -fsSL --max-time 60 https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg 2>>"$LOG_FILE" || true
 
             # Distro-aware repo setup + install
             case "$PKG_MANAGER" in
@@ -280,7 +280,7 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
                         sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
                         sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
                     # Verify we got a valid repo file, not an HTML 404
-                    if grep -q '<html' /etc/apt/sources.list.d/nvidia-container-toolkit.list 2>/dev/null; then
+                    if [[ -f /etc/apt/sources.list.d/nvidia-container-toolkit.list ]] && grep -q '<html' /etc/apt/sources.list.d/nvidia-container-toolkit.list 2>>"$LOG_FILE"; then
                         warn "Failed to download NVIDIA Container Toolkit repo list. Trying fallback..."
                         echo "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/\$(ARCH) /" | \
                             sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
@@ -312,7 +312,7 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
                     fi
                     ;;
                 zypper)
-                    sudo zypper addrepo https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo 2>/dev/null || true
+                    sudo zypper addrepo https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo 2>>"$LOG_FILE" || true
                     sudo zypper --non-interactive --gpg-auto-import-keys refresh 2>>"$LOG_FILE"
                     if ! sudo zypper --non-interactive install nvidia-container-toolkit 2>>"$LOG_FILE"; then
                         error "Failed to install NVIDIA Container Toolkit."


### PR DESCRIPTION
## Summary
- Replaces `2>/dev/null` with `2>>"$LOG_FILE"` in critical installer phases
- Improves debuggability by capturing errors in log files
- Maintains clean user experience while enabling troubleshooting

## Changes
- **installers/lib/detection.sh**: GPU detection error logging (NVIDIA, Intel Arc, AMD)
- **installers/phases/02-detection.sh**: WSL2 RAM detection error logging
- **installers/phases/04-requirements.sh**: Port conflict check error logging
- **installers/phases/05-docker.sh**: Docker setup error logging

## Rationale
Silent error suppression (`2>/dev/null`) hides failures that are critical for debugging installer issues. By redirecting to `$LOG_FILE`, we maintain the clean UX while capturing diagnostic information.

## Test plan
- [x] Verify installer still runs cleanly on systems without errors
- [x] Verify errors are now captured in install.log
- [x] Check that user-facing output remains clean
