### PR TITLE
fix(privacy-shield): replace broad exception handlers with specific types

### DIFF
--- a/dream-server/extensions/services/privacy-shield/key_management.py
+++ b/dream-server/extensions/services/privacy-shield/key_management.py
@@ -18,7 +18,7 @@ def load_persisted_key(path: str) -> Optional[str]:
         with open(path, "r", encoding="utf-8") as f:
             key = f.read().strip()
         return key or None
-    except Exception:
+    except (FileNotFoundError, IOError, PermissionError):
         logging.exception("Failed to read persisted SHIELD_API_KEY")
         return None
 
@@ -30,10 +30,10 @@ def persist_key(path: str, key: str) -> None:
             f.write(key)
         try:
             os.chmod(path, 0o600)
-        except Exception:
+        except (OSError, PermissionError):
             # Best-effort only (may fail on some mounts/platforms)
             pass
-    except Exception:
+    except (IOError, PermissionError, OSError):
         logging.exception("Failed to persist generated SHIELD_API_KEY")
 
 


### PR DESCRIPTION
## Summary
- Replaces all `except Exception:` with specific exception types
- Complies with CLAUDE.md: "Narrow exceptions at I/O boundaries are fine" but "No broad or silent catches"
- Makes error handling explicit and debuggable

## Changes
- **load_persisted_key** (line 21): `except (FileNotFoundError, IOError, PermissionError)` instead of `except Exception`
- **persist_key chmod** (line 33): `except (OSError, PermissionError)` instead of `except Exception`
- **persist_key outer** (line 36): `except (IOError, PermissionError, OSError)` instead of `except Exception`

## Rationale
The original code used broad `except Exception:` handlers at I/O boundaries. While catching exceptions at I/O boundaries is acceptable per CLAUDE.md, they must be specific exception types that map to distinct, meaningful statuses.

## Test plan
- [x] Python syntax check passes
- [ ] Manual test: privacy-shield handles missing key file
- [ ] Manual test: privacy-shield handles permission errors on read
- [ ] Manual test: privacy-shield handles permission errors on write