### PR TITLE
fix(healthcheck): replace broad exception handler with specific types

### DIFF
--- a/dream-server/scripts/healthcheck.py
+++ b/dream-server/scripts/healthcheck.py
@@ -213,7 +213,7 @@ def check_http(
                     body = resp.read(1024 * 1024)  # 1 MiB cap
                     try:
                         text = body.decode("utf-8", errors="replace")
-                    except Exception:
+                    except (UnicodeDecodeError, AttributeError):
                         text = str(body)
                     if not body_regex.search(text):
                         return (False, f"http {m}: body regex did not match", status)


### PR DESCRIPTION
## Summary
- Replaces `except Exception:` with specific exception types
- Complies with CLAUDE.md: "Narrow exceptions at I/O boundaries are fine" but "No broad or silent catches"
- Makes error handling explicit and debuggable

## Changes
- **body.decode()** (line 216): `except (UnicodeDecodeError, AttributeError)` instead of `except Exception`

## Rationale
The original code used a broad `except Exception:` handler when decoding HTTP response bodies. The decode operation has two specific failure modes:
1. `UnicodeDecodeError` - malformed bytes that can't be decoded as UTF-8
2. `AttributeError` - body is not bytes (e.g., already a string)

Both map to the same fallback behavior: `str(body)`. Making these explicit improves debuggability.

## Test plan
- [x] Python syntax check passes
- [ ] Manual test: healthcheck handles malformed UTF-8 in response body
- [ ] Manual test: healthcheck handles non-bytes response body