### PR TITLE
feat(installer): add compose stack validation before container launch

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -262,6 +262,19 @@ MODELS_INI_EOF
         ai_ok "All service dependencies satisfied"
     fi
 
+    # Validate compose stack syntax before launching
+    dream_progress 80 "services" "Validating compose stack"
+    ai "Validating Docker Compose configuration..."
+    if $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" config --quiet >> "$LOG_FILE" 2>&1; then
+        ai_ok "Compose stack validated"
+    else
+        ai_bad "Compose stack validation failed"
+        ai "Check compose files for syntax errors:"
+        ai "  docker compose config"
+        ai "Log: $LOG_FILE"
+        exit 1
+    fi
+
     # Launch containers
     dream_progress 81 "services" "Launching containers"
     echo ""


### PR DESCRIPTION
## Summary
- Adds `docker compose config --quiet` validation before launching containers in phase 11
- Catches manifest syntax errors, invalid compose files, and configuration issues early
- Provides clear error message with troubleshooting steps
- Prevents cryptic runtime failures from malformed compose configurations

## Test plan
- [x] Verified validation logic
- [ ] Test with valid compose stack
- [ ] Test with invalid compose syntax
- [ ] Test with missing service dependencies
- [ ] Verify error message clarity and log output