### PR TITLE
feat(images): add Docker daemon health check before image pulls

### DIFF
--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -18,6 +18,20 @@
 dream_progress 48 "images" "Downloading container images"
 show_phase 4 6 "Downloading Modules" "~5-10 minutes"
 
+# Verify Docker daemon is responsive before attempting pulls
+if ! $DRY_RUN; then
+    ai "Verifying Docker daemon health..."
+    if ! ${DOCKER_CMD:-docker} info &>/dev/null; then
+        ai_bad "Docker daemon is not responding"
+        ai "Common fixes:"
+        ai "  - Linux (systemd): sudo systemctl start docker"
+        ai "  - WSL2: ensure Docker Desktop is running"
+        ai "  - Check: docker info"
+        exit 1
+    fi
+    ai_ok "Docker daemon is healthy"
+fi
+
 # Build image list with cinematic labels
 # Format: "image|friendly_name"
 PULL_LIST=()


### PR DESCRIPTION
## Summary
Add Docker daemon health check before attempting image pulls to fail fast with clear error messages.

## Problem
When Docker daemon is not running or not accessible, image pull phase produces cryptic errors that are hard to diagnose. Users waste time troubleshooting pull failures when the real issue is daemon availability.

## Solution
- Added `docker info` health check before image pull phase
- Provides clear error message with platform-specific fixes
- Fails fast instead of attempting pulls that will fail

## Impact
- Better UX: clear error messages for common Docker issues
- Faster failure detection (seconds vs minutes)
- Reduces support burden for daemon-related issues

