### PR TITLE
feat(health): add retry logic to STT model download

### DIFF
--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -150,9 +150,18 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     # Only download if model isn't already loaded
     if ! curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" &>/dev/null; then
         ai "Downloading STT model (${STT_MODEL})..."
-        curl -sf --max-time 120 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >> "$LOG_FILE" 2>&1 && \
-            printf "\r  ${BGRN}✓${NC} %-60s\n" "STT model cached (${STT_MODEL})" || \
-            printf "\r  ${AMB}⚠${NC} %-60s\n" "STT model will download on first use"
+        _stt_success=false
+        for _attempt in 1 2 3; do
+            [[ $_attempt -gt 1 ]] && ai "Retry attempt $_attempt of 3..." && sleep $((2 ** (_attempt - 1)))
+            if curl -sf --max-time 120 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >> "$LOG_FILE" 2>&1; then
+                printf "\r  ${BGRN}✓${NC} %-60s\n" "STT model cached (${STT_MODEL})"
+                _stt_success=true
+                break
+            fi
+        done
+        if [[ "$_stt_success" != "true" ]]; then
+            printf "\r  ${AMB}⚠${NC} %-60s\n" "STT model will download on first use (3 attempts failed)"
+        fi
     else
         printf "\r  ${BGRN}✓${NC} %-60s\n" "STT model already cached (${STT_MODEL})"
     fi


### PR DESCRIPTION
## Summary
Add 3-attempt retry with exponential backoff to Whisper STT model pre-download during health check phase.

## Problem
STT model download during installer health checks had no retry mechanism. Network failures cause the download to fail, resulting in long delays on first transcription (poor voice UX).

## Solution
- Added retry loop (3 attempts) with exponential backoff (1s, 2s, 4s)
- Applies to both CUDA (faster-whisper-large-v3-turbo) and CPU (faster-whisper-base) models
- Matches retry pattern used for GGUF and FLUX downloads

## Impact
- Improves voice service reliability
- Reduces first-transcription delays from network issues
- Better UX for voice-enabled installations
