### PR TITLE
fix: replace 2>/dev/null with LOG_FILE logging in lib/ modules

### DIFF
--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -59,7 +59,7 @@ CURSOR='█'               # Block cursor for typing
 # BSD sed (macOS) requires `sed -i ''` while GNU sed uses `sed -i`.
 # Usage: _sed_i "s/old/new/g" file
 _sed_i() {
-    if sed --version 2>/dev/null | grep -q GNU; then
+    if sed --version 2>>"${LOG_FILE:-/dev/null}" | grep -q GNU; then
         sed -i "$@"
     else
         sed -i '' "$@"

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -96,7 +96,7 @@ detect_gpu() {
     # Try NVIDIA first
     if command -v nvidia-smi &> /dev/null; then
         local raw
-        if raw=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) && [[ -n "$raw" ]]; then
+        if raw=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>>"${LOG_FILE:-/dev/null}") && [[ -n "$raw" ]]; then
             GPU_BACKEND="nvidia"
             GPU_MEMORY_TYPE="discrete"
             GPU_INFO="$raw"
@@ -106,7 +106,7 @@ detect_gpu() {
             GPU_VRAM=$(echo "$GPU_INFO" | cut -d',' -f2 | grep -oP '\d+' | awk '{s+=$1} END {print s+0}')
             # Extract PCI device ID from first GPU
             local pci_id
-            pci_id=$(nvidia-smi --query-gpu=pci.device_id --format=csv,noheader 2>/dev/null | head -1 | xargs)
+            pci_id=$(nvidia-smi --query-gpu=pci.device_id --format=csv,noheader 2>>"${LOG_FILE:-/dev/null}" | head -1 | xargs)
             [[ -n "$pci_id" ]] && GPU_DEVICE_ID="${pci_id:0:6}"
             if [[ $GPU_COUNT -gt 1 ]]; then
                 # Build a display name for multi-GPU (e.g. "RTX 3090 + RTX 4090" or "RTX 4090 × 2")
@@ -128,12 +128,12 @@ detect_gpu() {
     fi
 
     # Try Intel Arc via lspci + sysfs
-    if lspci 2>/dev/null | grep -qi 'VGA.*Intel.*Arc'; then
+    if command -v lspci &>/dev/null && lspci 2>>"${LOG_FILE:-/dev/null}" | grep -qi 'VGA.*Intel.*Arc'; then
         for card_dir in /sys/class/drm/card*/device; do
             [[ -d "$card_dir" ]] || continue
             local vendor device
-            vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
-            device=$(cat "$card_dir/device" 2>/dev/null) || continue
+            vendor=$(cat "$card_dir/vendor" 2>>"${LOG_FILE:-/dev/null}") || continue
+            device=$(cat "$card_dir/device" 2>>"${LOG_FILE:-/dev/null}") || continue
             # Intel vendor ID: 0x8086, Arc device IDs: 0x56a0-0x56c1 (Alchemist), 0x5690-0x569f (DG2)
             if [[ "$vendor" == "0x8086" ]] && [[ "$device" =~ ^0x(56[a-c][0-9a-f]|569[0-9a-f])$ ]]; then
                 GPU_BACKEND="intel"
@@ -142,11 +142,11 @@ detect_gpu() {
                 GPU_COUNT=1
                 # Try to get VRAM size from sysfs (lmem_total_bytes on Arc)
                 local vram_bytes
-                vram_bytes=$(cat "$card_dir/lmem_total_bytes" 2>/dev/null) || vram_bytes=0
+                vram_bytes=$(cat "$card_dir/lmem_total_bytes" 2>>"${LOG_FILE:-/dev/null}") || vram_bytes=0
                 GPU_VRAM=$(( vram_bytes / 1048576 ))  # in MB
                 # Try marketing name from sysfs or lspci
                 if [[ -f "$card_dir/product_name" ]]; then
-                    GPU_NAME=$(cat "$card_dir/product_name" 2>/dev/null) || GPU_NAME="Intel Arc"
+                    GPU_NAME=$(cat "$card_dir/product_name" 2>>"${LOG_FILE:-/dev/null}") || GPU_NAME="Intel Arc"
                 else
                     GPU_NAME=$(lspci | grep -i 'VGA.*Intel.*Arc' | sed 's/.*: //' | head -1)
                     [[ -z "$GPU_NAME" ]] && GPU_NAME="Intel Arc ($GPU_DEVICE_ID)"
@@ -161,16 +161,16 @@ detect_gpu() {
     for card_dir in /sys/class/drm/card*/device; do
         [[ -d "$card_dir" ]] || continue
         local vendor
-        vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
+        vendor=$(cat "$card_dir/vendor" 2>>"${LOG_FILE:-/dev/null}") || continue
         if [[ "$vendor" == "0x1002" ]]; then
             local vram_bytes gtt_bytes
-            vram_bytes=$(cat "$card_dir/mem_info_vram_total" 2>/dev/null) || vram_bytes=0
-            gtt_bytes=$(cat "$card_dir/mem_info_gtt_total" 2>/dev/null) || gtt_bytes=0
+            vram_bytes=$(cat "$card_dir/mem_info_vram_total" 2>>"${LOG_FILE:-/dev/null}") || vram_bytes=0
+            gtt_bytes=$(cat "$card_dir/mem_info_gtt_total" 2>>"${LOG_FILE:-/dev/null}") || gtt_bytes=0
             local gtt_gb=$(( gtt_bytes / 1073741824 ))
             local vram_gb=$(( vram_bytes / 1073741824 ))
 
             # Read device ID from sysfs
-            GPU_DEVICE_ID=$(cat "$card_dir/device" 2>/dev/null) || GPU_DEVICE_ID="unknown"
+            GPU_DEVICE_ID=$(cat "$card_dir/device" 2>>"${LOG_FILE:-/dev/null}") || GPU_DEVICE_ID="unknown"
 
             # Detect APU: small VRAM + large GTT = unified memory
             if [[ $gtt_gb -ge 16 && $vram_gb -le 4 ]] || [[ $gtt_gb -ge 32 ]] || [[ $vram_gb -ge 32 ]]; then
@@ -180,7 +180,7 @@ detect_gpu() {
                 GPU_COUNT=1
                 # Try marketing name
                 if [[ -f "$card_dir/product_name" ]]; then
-                    GPU_NAME=$(cat "$card_dir/product_name" 2>/dev/null) || GPU_NAME="AMD APU"
+                    GPU_NAME=$(cat "$card_dir/product_name" 2>>"${LOG_FILE:-/dev/null}") || GPU_NAME="AMD APU"
                 else
                     GPU_NAME="AMD APU ($GPU_DEVICE_ID)"
                 fi
@@ -205,7 +205,7 @@ MIN_DRIVER_VERSION=570
 
 fix_nvidia_secure_boot() {
     # Step 1: Is there even NVIDIA hardware on this machine?
-    if ! lspci 2>/dev/null | grep -qi 'nvidia'; then
+    if ! command -v lspci &>/dev/null || ! lspci 2>>"${LOG_FILE:-/dev/null}" | grep -qi 'nvidia'; then
         return 1  # No hardware — nothing to fix
     fi
 
@@ -213,7 +213,7 @@ fix_nvidia_secure_boot() {
 
     # Step 2: Ensure a driver package is installed
     local installed_driver
-    installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>/dev/null \
+    installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>>"${LOG_FILE:-/dev/null}" \
                        | grep -oP 'nvidia-driver-\K\d+' | sort -n | tail -1 || true)
 
     if [[ -z "$installed_driver" ]]; then
@@ -224,7 +224,7 @@ fix_nvidia_secure_boot() {
         else
             sudo apt-get install -y "nvidia-driver-${MIN_DRIVER_VERSION}" 2>>"$LOG_FILE" || true
         fi
-        installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>/dev/null \
+        installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>>"${LOG_FILE:-/dev/null}" \
                            | grep -oP 'nvidia-driver-\K\d+' | sort -n | tail -1 || true)
         if [[ -z "$installed_driver" ]]; then
             ai_bad "Failed to install NVIDIA driver."
@@ -294,7 +294,7 @@ fix_nvidia_secure_boot() {
         fi
     done
     if [[ -z "$sign_file" ]]; then
-        sign_file=$(find /usr/src /usr/lib -name sign-file -executable 2>/dev/null | head -1)
+        sign_file=$(find /usr/src /usr/lib -name sign-file -executable 2>>"${LOG_FILE:-/dev/null}" | head -1)
     fi
     if [[ -z "$sign_file" ]]; then
         ai_bad "Cannot find kernel sign-file tool."

--- a/dream-server/installers/lib/path-utils.sh
+++ b/dream-server/installers/lib/path-utils.sh
@@ -33,10 +33,10 @@ normalize_path() {
     # Resolve symlinks and normalize (remove .., ., //)
     if command -v realpath &>/dev/null; then
         # GNU realpath (Linux)
-        realpath -m "$path" 2>/dev/null || echo "$path"
+        realpath -m "$path" 2>>"${LOG_FILE:-/dev/null}" || echo "$path"
     elif command -v grealpath &>/dev/null; then
         # GNU realpath via Homebrew (macOS)
-        grealpath -m "$path" 2>/dev/null || echo "$path"
+        grealpath -m "$path" 2>>"${LOG_FILE:-/dev/null}" || echo "$path"
     else
         # Fallback: basic normalization without external dependencies
         # This handles most cases but doesn't resolve all edge cases
@@ -97,7 +97,7 @@ validate_install_path() {
     if command -v df &>/dev/null; then
         # Use df -Pk (POSIX) which returns KB, then convert to GB
         local avail_kb
-        avail_kb=$(df -Pk "$parent_dir" 2>/dev/null | tail -1 | awk '{print $4}' || echo "0")
+        avail_kb=$(df -Pk "$parent_dir" 2>>"${LOG_FILE:-/dev/null}" | tail -1 | awk '{print $4}' || echo "0")
         avail_gb=$((avail_kb / 1048576))  # KB to GB (1024*1024)
         if [[ "$avail_gb" -lt "$required_gb" ]]; then
             echo "WARNING: Low disk space. Available: ${avail_gb}GB, Required: ${required_gb}GB" >&2


### PR DESCRIPTION
## Summary

Replace silent error suppression in lib/ modules with proper logging to $LOG_FILE. This improves debuggability for hardware detection and path utilities while preserving fallback behavior.

## Changes

### detection.sh
- Log nvidia-smi query errors
- Log lspci command errors
- Log sysfs file read errors (vendor, device, VRAM, product_name)
- Log dpkg-query errors for driver detection
- Log find command errors for kernel signing tools

### path-utils.sh
- Log realpath/grealpath command errors
- Log df command errors for disk space checks

### constants.sh
- Log sed version detection errors

## Implementation

All error redirects now use `${LOG_FILE:-/dev/null}` pattern:
- Logs errors to $LOG_FILE when set (installer context)
- Falls back to /dev/null when LOG_FILE is unset (standalone usage)

## Intentionally Preserved

Kept `2>/dev/null` in ui.sh for:
- `clear` command (terminal compatibility, not an error)
- `kill -0` checks (process existence tests, expected to fail)

## Testing

- Syntax validation passed for all modified files
- No breaking changes to detection logic
- Fallback behavior preserved for standalone usage