### PR TITLE
fix(extensions): add missing NVIDIA GPU overlay for invokeai

### DIFF
--- a/resources/dev/extensions-library/services/invokeai/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/invokeai/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  invokeai:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]


### PR DESCRIPTION
## What

Add `compose.nvidia.yaml` for the invokeai extension service.

## Why

InvokeAI declares `gpu_backends: [amd, nvidia]` in its manifest and already has `compose.amd.yaml` (added in #386), but was missing the NVIDIA overlay. `resolve-compose-stack.sh` discovers GPU overlays by filesystem convention (`compose.{gpu_backend}.yaml`), so NVIDIA users would get no GPU passthrough — the service starts CPU-only despite claiming NVIDIA support.

## How

Single new file following the established pattern used by bark, ollama, rvc, xtts, and other extensions-library services:

```yaml
services:
  invokeai:
    deploy:
      resources:
        reservations:
          devices:
            - driver: nvidia
              count: 1
              capabilities: [gpu]
```

## Testing

- `docker compose -f compose.yaml -f compose.nvidia.yaml config` validates successfully
- GPU device reservation appears in merged output
- Pattern matches all other NVIDIA overlays in `resources/dev/extensions-library/`

## Review

Critique Guardian verdict: **APPROVED** — minimal, pattern-consistent, no security concerns.

## Platform Impact

- **Linux (NVIDIA):** Fixes missing GPU passthrough
- **Linux (AMD):** No change (overlay already exists)
- **macOS / Windows:** No change (not applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)