### PR TITLE
fix(installer): CPU-only Linux needs nvidia overlay for llama-server image

### DIFF
--- a/dream-server/config/hardware-classes.json
+++ b/dream-server/config/hardware-classes.json
@@ -148,7 +148,7 @@
       "recommended": {
         "backend": "cpu",
         "tier": "T1",
-        "compose_overlays": ["docker-compose.base.yml"]
+        "compose_overlays": ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
       }
     }
   ]

--- a/dream-server/scripts/classify-hardware.sh
+++ b/dream-server/scripts/classify-hardware.sh
@@ -73,11 +73,12 @@ with open(db_path, "r", encoding="utf-8") as f:
     db = json.load(f)
 
 # --- Compose overlay mapping (backend → default overlays) ---
+# CPU backend uses nvidia overlay: llama-server image works in CPU-only mode (n-gpu-layers=0)
 OVERLAY_MAP = {
     "amd":    ["docker-compose.base.yml", "docker-compose.amd.yml"],
     "nvidia": ["docker-compose.base.yml", "docker-compose.nvidia.yml"],
     "apple":  ["docker-compose.base.yml", "docker-compose.apple.yml"],
-    "cpu":    ["docker-compose.base.yml"],
+    "cpu":    ["docker-compose.base.yml", "docker-compose.nvidia.yml"],
 }
 
 # --- Pass 1: Match known_gpus by device_id then name_patterns ---


### PR DESCRIPTION
- On CPU-only machines, the compose stack lacked a llama-server image because only the base compose file was used.
- Add docker-compose.nvidia.yml for the CPU backend so the stack is valid; the CUDA image runs in CPU mode with n-gpu-layers=0.
- Verified on Ubuntu 20.04 with no GPU: installer passes compose validation and proceeds.