### PR TITLE
fix: add CPU-only compose overlay for machines without GPU

### DIFF
--- a/dream-server/config/hardware-classes.json
+++ b/dream-server/config/hardware-classes.json
@@ -148,7 +148,7 @@
       "recommended": {
         "backend": "cpu",
         "tier": "T1",
-        "compose_overlays": ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
+        "compose_overlays": ["docker-compose.base.yml", "docker-compose.cpu.yml"]
       }
     }
   ]

--- a/dream-server/docker-compose.cpu.yml
+++ b/dream-server/docker-compose.cpu.yml
@@ -1,0 +1,39 @@
+# Dream Server — CPU-Only Overlay (Linux / no GPU)
+# Uses llama.cpp server CPU build. No NVIDIA/AMD/Intel GPU required.
+# For low-RAM systems, set LLAMA_SERVER_MEMORY_LIMIT=4G in .env
+#
+# Use with: docker compose -f docker-compose.base.yml -f docker-compose.cpu.yml up -d
+
+services:
+  llama-server:
+    image: ${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}
+    command:
+      - --model
+      - /models/${GGUF_FILE:-Qwen3-8B-Q4_K_M.gguf}
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8080"
+      - --n-gpu-layers
+      - "0"
+      - --ctx-size
+      - "${CTX_SIZE:-8192}"
+      - --batch-size
+      - "${LLAMA_BATCH_SIZE:-512}"
+      - --threads
+      - "${LLAMA_THREADS:-4}"
+      - --parallel
+      - "${LLAMA_PARALLEL:-1}"
+      - --metrics
+    deploy:
+      resources:
+        limits:
+          cpus: '${LLAMA_CPU_LIMIT:-8.0}'
+          memory: ${LLAMA_SERVER_MEMORY_LIMIT:-6G}
+        reservations:
+          cpus: '1.0'
+          memory: 2G
+
+  open-webui:
+    environment:
+      AUDIO_STT_MODEL: "deepdml/faster-whisper-large-v3-turbo-ct2"

--- a/dream-server/installers/lib/compose-select.sh
+++ b/dream-server/installers/lib/compose-select.sh
@@ -66,6 +66,11 @@ resolve_compose_config() {
                 COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.intel.yml"
                 COMPOSE_FILE="docker-compose.intel.yml"
             fi
+        elif [[ "$GPU_BACKEND" == "cpu" ]]; then
+            if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.cpu.yml" ]]; then
+                COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.cpu.yml"
+                COMPOSE_FILE="docker-compose.cpu.yml"
+            fi
         else
             if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.nvidia.yml" ]]; then
                 COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.nvidia.yml"

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -24,6 +24,8 @@ PULL_LIST=()
 if [[ "$GPU_BACKEND" == "amd" ]]; then
     PULL_LIST+=("kyuz0/amd-strix-halo-toolboxes:rocm-7.2|LLAMA-SERVER — downloading the brain (AMD ROCm)")
     PULL_LIST+=("ignatberesnev/comfyui-gfx1151:v0.2|COMFYUI — image generation engine (gfx1151)")
+elif [[ "$GPU_BACKEND" == "cpu" ]]; then
+    PULL_LIST+=("ghcr.io/ggml-org/llama.cpp:server-b8248|LLAMA-SERVER — downloading the brain (CPU)")
 else
     PULL_LIST+=("ghcr.io/ggml-org/llama.cpp:server-cuda-b8248|LLAMA-SERVER — downloading the brain (NVIDIA CUDA)")
 fi

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -53,6 +53,7 @@
       "canonical": [
         "docker-compose.base.yml",
         "docker-compose.amd.yml",
+        "docker-compose.cpu.yml",
         "docker-compose.nvidia.yml",
         "docker-compose.apple.yml",
         "docker-compose.arc.yml"

--- a/dream-server/scripts/build-capability-profile.sh
+++ b/dream-server/scripts/build-capability-profile.sh
@@ -112,7 +112,7 @@ elif gpu_type == "apple":
     overlays = ["docker-compose.base.yml", "docker-compose.amd.yml"]
 else:
     llm_backend = "cpu"
-    overlays = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
+    overlays = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
 
 tier = (hardware.get("tier") or "T1").upper()
 if tier in {"T1", "T2", "T3", "T4"}:

--- a/dream-server/scripts/classify-hardware.sh
+++ b/dream-server/scripts/classify-hardware.sh
@@ -73,12 +73,12 @@ with open(db_path, "r", encoding="utf-8") as f:
     db = json.load(f)
 
 # --- Compose overlay mapping (backend → default overlays) ---
-# CPU backend uses nvidia overlay: llama-server image works in CPU-only mode (n-gpu-layers=0)
+# CPU backend uses cpu overlay: CPU-only llama.cpp image, no GPU reservation
 OVERLAY_MAP = {
     "amd":    ["docker-compose.base.yml", "docker-compose.amd.yml"],
     "nvidia": ["docker-compose.base.yml", "docker-compose.nvidia.yml"],
     "apple":  ["docker-compose.base.yml", "docker-compose.apple.yml"],
-    "cpu":    ["docker-compose.base.yml", "docker-compose.nvidia.yml"],
+    "cpu":    ["docker-compose.base.yml", "docker-compose.cpu.yml"],
 }
 
 # --- Pass 1: Match known_gpus by device_id then name_patterns ---

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -95,6 +95,13 @@ elif gpu_backend == "amd":
     if existing(["docker-compose.base.yml", "docker-compose.amd.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
         primary = "docker-compose.amd.yml"
+elif gpu_backend == "cpu":
+    if existing(["docker-compose.base.yml", "docker-compose.cpu.yml"]):
+        resolved = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
+        primary = "docker-compose.cpu.yml"
+    elif existing(["docker-compose.base.yml"]):
+        resolved = ["docker-compose.base.yml"]
+        primary = "docker-compose.base.yml"
 else:
     if existing(["docker-compose.base.yml", "docker-compose.nvidia.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]

--- a/dream-server/tests/bats-tests/compose-select.bats
+++ b/dream-server/tests/bats-tests/compose-select.bats
@@ -29,6 +29,7 @@ STUB
     touch "$SCRIPT_DIR/docker-compose.yml"
     touch "$SCRIPT_DIR/docker-compose.base.yml"
     touch "$SCRIPT_DIR/docker-compose.nvidia.yml"
+    touch "$SCRIPT_DIR/docker-compose.cpu.yml"
     touch "$SCRIPT_DIR/docker-compose.amd.yml"
     touch "$SCRIPT_DIR/docker-compose.apple.yml"
 
@@ -80,6 +81,16 @@ STUB
     resolve_compose_config
     assert_equal "$COMPOSE_FLAGS" "-f docker-compose.base.yml -f docker-compose.amd.yml"
     assert_equal "$COMPOSE_FILE" "docker-compose.amd.yml"
+}
+
+# ── CPU backend (no GPU) ────────────────────────────────────────────────────
+
+@test "resolve_compose_config: CPU backend selects base + cpu overlay" {
+    TIER=T1
+    GPU_BACKEND=cpu
+    resolve_compose_config
+    assert_equal "$COMPOSE_FLAGS" "-f docker-compose.base.yml -f docker-compose.cpu.yml"
+    assert_equal "$COMPOSE_FILE" "docker-compose.cpu.yml"
 }
 
 # ── Numeric tiers (default NVIDIA path) ────────────────────────────────────


### PR DESCRIPTION
Problem: On CPU-only Linux machines, the installer used docker-compose.nvidia.yml, which reserves NVIDIA GPU devices. Docker cannot start containers without a GPU, leading to container launch failures (e.g., 4 failed containers and 9 health check failures).

Solution: Add a dedicated docker-compose.cpu.yml overlay that:

> Uses ghcr.io/ggml-org/llama.cpp:server-b8248 (CPU build) instead of the CUDA image
> Forces --n-gpu-layers 0 for CPU-only inference
> Sets memory limits suitable for Tier 1 / low-RAM (e.g., 7GB)
> Avoids any GPU device reservations

Changes:

> Add docker-compose.cpu.yml (CPU overlay)
> Update config/hardware-classes.json so cpu_fallback uses the CPU overlay
> Update scripts/classify-hardware.sh OVERLAY_MAP for cpu backend
> Update scripts/build-capability-profile.sh fallback for cpu backend
> Update installers/lib/compose-select.sh for GPU_BACKEND=cpu
> Update scripts/resolve-compose-stack.sh for cpu backend
> Update installers/phases/08-images.sh to pull the CPU image when GPU_BACKEND=cpu
> Add docker-compose.cpu.yml to manifest.json canonical compose list
> Add BATS test for CPU backend compose selection

Testing:

> ./tests/test-cpu-only-path.sh — 9 passed
> ./tests/test-hardware-compatibility.sh — 32 passed
> ./scripts/resolve-compose-stack.sh --script-dir . --gpu-backend cpu — returns base + cpu overlays