### PR TITLE
feat(extensions-library): add manifest validation scripts and update schema

### DIFF
--- a/resources/dev/extensions-library/schema/service-manifest.v1.json
+++ b/resources/dev/extensions-library/schema/service-manifest.v1.json
@@ -32,7 +32,7 @@
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
         "gpu_backends": {
           "type": "array",
-          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all"] },
+          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] },
           "minItems": 1
         },
         "compose_file": {
@@ -65,6 +65,10 @@
           },
           "description": "Environment variables used by this service"
         },
+        "description": {
+          "type": "string",
+          "description": "Human-readable service description"
+        },
         "setup_hook": {
           "type": "string",
           "description": "Relative path to a setup script run during installation (e.g. setup.sh)"
@@ -89,6 +93,7 @@
               "services": { "type": "array", "items": { "type": "string" } },
               "services_any": { "type": "array", "items": { "type": "string" } },
               "vram_gb": { "type": "number", "minimum": 0 },
+              "vram_mb": { "type": "number", "minimum": 0 },
               "disk_gb": { "type": "number", "minimum": 0 }
             },
             "additionalProperties": true
@@ -99,12 +104,16 @@
           "priority": { "type": "integer", "minimum": 1 },
           "gpu_backends": {
             "type": "array",
-            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all"] },
-            "minItems": 1
+            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] }
           }
         },
         "additionalProperties": true
       }
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+      "description": "Categorization tags for service discovery"
     }
   },
   "additionalProperties": true

--- a/resources/dev/extensions-library/validate-compose.sh
+++ b/resources/dev/extensions-library/validate-compose.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BOLD='\033[1m'
+RESET='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVICES_DIR="${SCRIPT_DIR}/services"
+
+# Check docker availability
+if ! command -v docker >/dev/null 2>&1; then
+    printf "%bERROR%b: docker not found in PATH\n" "$RED" "$RESET" >&2
+    exit 2
+fi
+if ! docker compose version >/dev/null 2>&1; then
+    printf "%bERROR%b: docker compose plugin not available\n" "$RED" "$RESET" >&2
+    exit 2
+fi
+
+if [ ! -d "$SERVICES_DIR" ]; then
+    printf "%bERROR%b: services directory not found: %s\n" "$RED" "$RESET" "$SERVICES_DIR" >&2
+    exit 2
+fi
+
+total=0
+passed=0
+failed=0
+
+validate_compose() {
+    local file="$1"
+    local extra_file="${2:-}"
+
+    if [ -n "$extra_file" ]; then
+        docker compose -f "$file" -f "$extra_file" config --quiet
+    else
+        docker compose -f "$file" config --quiet
+    fi
+}
+
+for service_dir in "${SERVICES_DIR}"/*/; do
+    service_name="$(basename "$service_dir")"
+    base_compose="${service_dir}compose.yaml"
+
+    # Skip if no compose.yaml
+    if [ ! -f "$base_compose" ]; then
+        if [ -f "${base_compose}.disabled" ]; then
+            printf "SKIP  %s (compose.yaml.disabled)\n" "$service_name"
+        fi
+        continue
+    fi
+
+    # Validate base compose
+    total=$((total + 1))
+    if validate_compose "$base_compose"; then
+        printf "%bPASS%b  %s (base)\n" "$GREEN" "$RESET" "$service_name"
+        passed=$((passed + 1))
+    else
+        printf "%bFAIL%b  %s (base)\n" "$RED" "$RESET" "$service_name"
+        failed=$((failed + 1))
+    fi
+
+    # Validate nvidia overlay if present
+    nvidia_overlay="${service_dir}compose.nvidia.yaml"
+    if [ -f "$nvidia_overlay" ]; then
+        total=$((total + 1))
+        if validate_compose "$base_compose" "$nvidia_overlay"; then
+            printf "%bPASS%b  %s (base + nvidia)\n" "$GREEN" "$RESET" "$service_name"
+            passed=$((passed + 1))
+        else
+            printf "%bFAIL%b  %s (base + nvidia)\n" "$RED" "$RESET" "$service_name"
+            failed=$((failed + 1))
+        fi
+    fi
+
+    # Validate amd overlay if present
+    amd_overlay="${service_dir}compose.amd.yaml"
+    if [ -f "$amd_overlay" ]; then
+        total=$((total + 1))
+        if validate_compose "$base_compose" "$amd_overlay"; then
+            printf "%bPASS%b  %s (base + amd)\n" "$GREEN" "$RESET" "$service_name"
+            passed=$((passed + 1))
+        else
+            printf "%bFAIL%b  %s (base + amd)\n" "$RED" "$RESET" "$service_name"
+            failed=$((failed + 1))
+        fi
+    fi
+done
+
+printf "\n%b========================================%b\n" "$BOLD" "$RESET"
+printf "Total: %d  Passed: %d  Failed: %d\n" "$total" "$passed" "$failed"
+
+if [ "$failed" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/resources/dev/extensions-library/validate-manifests.py
+++ b/resources/dev/extensions-library/validate-manifests.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate all service manifests against the JSON schema."""
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError:
+    print("ERROR: jsonschema package not installed. Run: pip install jsonschema")
+    sys.exit(2)
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: PyYAML package not installed. Run: pip install pyyaml")
+    sys.exit(2)
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCHEMA_PATH = SCRIPT_DIR / "schema" / "service-manifest.v1.json"
+SERVICES_DIR = SCRIPT_DIR / "services"
+
+
+def main():
+    # Load schema
+    if not SCHEMA_PATH.exists():
+        print(f"ERROR: Schema not found at {SCHEMA_PATH}")
+        sys.exit(2)
+
+    with open(SCHEMA_PATH) as f:
+        schema = json.load(f)
+
+    if not SERVICES_DIR.is_dir():
+        print(f"ERROR: Services directory not found: {SERVICES_DIR}")
+        sys.exit(2)
+
+    # Find manifests
+    manifests = sorted(SERVICES_DIR.glob("*/manifest.yaml"))
+    if not manifests:
+        print("WARNING: No manifest files found")
+        sys.exit(0)
+
+    total = 0
+    passed = 0
+    failed = 0
+
+    for manifest_path in manifests:
+        service_name = manifest_path.parent.name
+        total += 1
+
+        try:
+            with open(manifest_path) as f:
+                data = yaml.safe_load(f)
+        except yaml.YAMLError as e:
+            print(f"FAIL  {service_name}: YAML parse error: {e}")
+            failed += 1
+            continue
+
+        if data is None:
+            print(f"FAIL  {service_name}: Empty manifest")
+            failed += 1
+            continue
+
+        errors = list(jsonschema.Draft202012Validator(schema).iter_errors(data))
+        if errors:
+            failed += 1
+            print(f"FAIL  {service_name}:")
+            for err in errors:
+                path = ".".join(str(p) for p in err.absolute_path) or "(root)"
+                print(f"        {path}: {err.message}")
+        else:
+            passed += 1
+            print(f"PASS  {service_name}")
+
+    print(f"\n{'=' * 40}")
+    print(f"Total: {total}  Passed: {passed}  Failed: {failed}")
+
+    sys.exit(1 if failed > 0 else 0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What
Add automated validation tooling for the extensions-library and make safe schema updates.

## Why
No automated validation exists — contributors can submit broken manifests or invalid compose files and nobody catches it until runtime. Additionally, the schema is missing `"none"` in the gpu_backends enum, which CPU-only services like open-interpreter need.

## How
- **validate-manifests.py**: Validates all `services/*/manifest.yaml` against `schema/service-manifest.v1.json` using `jsonschema.Draft202012Validator`. Reports PASS/FAIL per service. Exit 0 = all pass, 1 = any fail, 2 = setup error.
- **validate-compose.sh**: Validates all compose files (base + nvidia/amd overlays) via `docker compose config`. Shellcheck clean, BSD/GNU compatible.
- **Schema updates** (backwards-compatible only):
  - Added `"none"` to service-level and feature-level gpu_backends enum
  - Removed `minItems: 1` from feature-level gpu_backends (allows empty arrays)
  - Added optional fields: `description` (service), `tags` (top-level), `vram_mb` (requirements)

## Scope
All changes within `resources/dev/extensions-library/`. No manifest files modified.

## Testing
- `validate-manifests.py` runs successfully: 28/33 pass, 5 pre-existing failures (bugs addressed in companion PRs)
- `validate-compose.sh` passes shellcheck with zero warnings
- Schema is valid JSON, changes are backwards-compatible
- Critique Guardian: **APPROVED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)