### PR TITLE
fix(extensions-library): correct CLI commands in 12 service READMEs

### DIFF
--- a/resources/dev/extensions-library/services/aider/README.md
+++ b/resources/dev/extensions-library/services/aider/README.md
@@ -18,7 +18,7 @@ Aider is AI pair programming in your terminal. It allows you to edit code in you
 ### Enable the extension
 
 ```bash
-dream extensions enable aider
+dream enable aider
 ```
 
 ### Run Aider
@@ -69,7 +69,7 @@ Aider works with:
 ## Uninstall
 
 ```bash
-dream extensions disable aider
+dream disable aider
 ```
 
 Your projects in `./data/aider/` are preserved.

--- a/resources/dev/extensions-library/services/anythingllm/README.md
+++ b/resources/dev/extensions-library/services/anythingllm/README.md
@@ -49,7 +49,7 @@ Set `ANYTHINGLLM_LLM_PROVIDER` to one of:
 
 ```bash
 # Enable the extension
-dream extensions enable anythingllm
+dream enable anythingllm
 
 # Start the service
 docker compose up -d anythingllm
@@ -60,7 +60,7 @@ docker compose up -d anythingllm
 
 ## Setup Steps
 
-1. **Enable**: `dream extensions enable anythingllm`
+1. **Enable**: `dream enable anythingllm`
 2. **Start**: `docker compose up -d anythingllm`
 3. **Open**: Visit http://localhost:3001
 4. **Create workspace**: Click "New Workspace"

--- a/resources/dev/extensions-library/services/bark/README.md
+++ b/resources/dev/extensions-library/services/bark/README.md
@@ -13,7 +13,7 @@ Suno AI's transformer-based text-to-audio model. Generates highly expressive, re
 ## Quick Start
 
 ```bash
-dream extensions enable bark
+dream enable bark
 ```
 
 **Note:** First startup downloads ~5GB of models. This can take 10-20 minutes depending on your connection. Subsequent starts are instant.

--- a/resources/dev/extensions-library/services/chromadb/README.md
+++ b/resources/dev/extensions-library/services/chromadb/README.md
@@ -17,7 +17,7 @@ ChromaDB is an AI-native open-source vector database designed for building embed
 ### Enable the extension
 
 ```bash
-dream extensions enable chromadb
+dream enable chromadb
 ```
 
 ### Access the API
@@ -62,7 +62,7 @@ curl -X POST http://localhost:8000/api/v1/collections/my_collection/add \
 ## Uninstall
 
 ```bash
-dream extensions disable chromadb
+dream disable chromadb
 ```
 
 This removes the container. Your data in `./data/chromadb/` is preserved.

--- a/resources/dev/extensions-library/services/flowise/README.md
+++ b/resources/dev/extensions-library/services/flowise/README.md
@@ -46,7 +46,7 @@ FLOWISE_PASSWORD=your-secure-password
 
 ```bash
 # Enable the extension
-dream extensions enable flowise
+dream enable flowise
 
 # Start the service
 docker compose up -d flowise
@@ -56,7 +56,7 @@ docker compose up -d flowise
 
 ## Quick Start
 
-1. **Enable**: `dream extensions enable flowise`
+1. **Enable**: `dream enable flowise`
 2. **Open**: Visit http://localhost:3002
 3. **Create Chatflow**: Click "Add New" → "Chatflow"
 4. **Add Nodes**: Drag LLM, memory, and tool nodes

--- a/resources/dev/extensions-library/services/fooocus/README.md
+++ b/resources/dev/extensions-library/services/fooocus/README.md
@@ -29,7 +29,7 @@ Fooocus uses sensible defaults. No manual configuration needed.
 
 ## Usage
 
-1. Enable the extension: `dream extensions enable fooocus`
+1. Enable the extension: `dream enable fooocus`
 2. Access the UI at `http://localhost:7865`
 3. Start generating images with natural language prompts
 
@@ -39,6 +39,6 @@ Fooocus runs as a standalone image generation service. It does not connect to Dr
 
 ## Uninstall
 
-Disable the extension: `dream extensions disable fooocus`
+Disable the extension: `dream disable fooocus`
 
 This will remove the container but preserve your generated images in `./data/fooocus/`.

--- a/resources/dev/extensions-library/services/librechat/README.md
+++ b/resources/dev/extensions-library/services/librechat/README.md
@@ -50,7 +50,7 @@ Set any of these to enable the corresponding provider:
 
 ```bash
 # Enable the extension
-dream extensions enable librechat
+dream enable librechat
 
 # Start the services
 docker compose up -d librechat

--- a/resources/dev/extensions-library/services/ollama/README.md
+++ b/resources/dev/extensions-library/services/ollama/README.md
@@ -16,7 +16,7 @@ Ollama is a simple way to run open-source LLMs locally. This extension provides 
 ### Enable the extension
 
 ```bash
-dream extensions enable ollama
+dream enable ollama
 ```
 
 ### Load a different model
@@ -50,7 +50,7 @@ Ollama works with:
 ## Uninstall
 
 ```bash
-dream extensions disable ollama
+dream disable ollama
 ```
 
 This removes the container and stops the service. Your downloaded models in `./data/ollama/` are preserved.

--- a/resources/dev/extensions-library/services/piper-audio/README.md
+++ b/resources/dev/extensions-library/services/piper-audio/README.md
@@ -17,7 +17,7 @@ Piper is a fast, local neural text-to-speech system that sounds great and is opt
 ### Enable the extension
 
 ```bash
-dream extensions enable piper-audio
+dream enable piper-audio
 ```
 
 ### Wyoming Protocol Endpoint
@@ -62,7 +62,7 @@ Piper integrates with:
 ## Uninstall
 
 ```bash
-dream extensions disable piper-audio
+dream disable piper-audio
 ```
 
 Voice models in `./data/piper/` are preserved.

--- a/resources/dev/extensions-library/services/sillytavern/README.md
+++ b/resources/dev/extensions-library/services/sillytavern/README.md
@@ -16,7 +16,7 @@ SillyTavern is a character/roleplay chat UI that connects to local LLMs. This ex
 ### Enable the extension
 
 ```bash
-dream extensions enable sillytavern
+dream enable sillytavern
 ```
 
 ### Access the UI
@@ -48,7 +48,7 @@ SillyTavern works with:
 ## Uninstall
 
 ```bash
-dream extensions disable sillytavern
+dream disable sillytavern
 ```
 
 Character files in `./data/sillytavern/` are preserved.

--- a/resources/dev/extensions-library/services/text-generation-webui/README.md
+++ b/resources/dev/extensions-library/services/text-generation-webui/README.md
@@ -14,7 +14,7 @@ The most feature-complete local LLM inference UI. Supports GGUF, GPTQ, AWQ, EXL2
 ## Quick Start
 
 ```bash
-dream extensions enable text-generation-webui
+dream enable text-generation-webui
 ```
 
 Then open **http://localhost:7862** and load a model via the Model tab.

--- a/resources/dev/extensions-library/workflows/sillytavern/README.md
+++ b/resources/dev/extensions-library/workflows/sillytavern/README.md
@@ -25,7 +25,7 @@ SillyTavern is a character-based roleplay chat interface. Unlike API-first servi
 
 SillyTavern is accessed directly via web browser:
 
-1. Enable the extension: `dream extensions enable sillytavern`
+1. Enable the extension: `dream enable sillytavern`
 2. Access at: `http://localhost:8001` (or your configured port)
 3. Configure your AI backend in the SillyTavern UI
 4. Create or import character cards


### PR DESCRIPTION
## Summary
- Replace `dream extensions enable` with `dream enable` across all affected READMEs
- The `extensions` subcommand does not exist in `dream-cli` — verified from source code (`dream-server/dream-cli` line 987)
- 12 files fixed, 20 replacements total

## Affected Files
**10 services from issue:** aider, anythingllm, bark, chromadb, flowise, librechat, ollama, piper-audio, sillytavern, text-generation-webui
**2 additional finds:** fooocus/README.md, workflows/sillytavern/README.md

## Test plan
- [x] `grep -r "dream extensions" resources/dev/extensions-library/` returns zero matches
- [x] No whitespace, formatting, or content changes beyond the command strings
- [x] CG review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)