### PR TITLE
fix(extensions-library): use multi-arch base image for bark Dockerfile

### DIFF
--- a/resources/dev/extensions-library/services/bark/Dockerfile
+++ b/resources/dev/extensions-library/services/bark/Dockerfile
@@ -1,6 +1,7 @@
 # Bark TTS — builds a minimal FastAPI server wrapping suno-ai/bark
-# Pinned: bark==0.1.5, pytorch 2.3.1, CUDA 12.1
-FROM pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime@sha256:2d1dee23cc95bf01aad2a292c10f051b01ddc6e7fa7535620cc8a7457720794c
+# Multi-arch base (amd64 + arm64). Default pip wheels include CUDA support
+# on amd64; the compose.nvidia.yaml overlay provides GPU device access.
+FROM python:3.10-slim
 
 WORKDIR /app
 
@@ -11,6 +12,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     libsndfile1 \
     && rm -rf /var/lib/apt/lists/*
+
+# Install PyTorch — default wheels include CUDA on amd64, CPU-only on arm64
+RUN pip install --no-cache-dir torch torchaudio
 
 # Install Python dependencies — pinned versions
 RUN pip install --no-cache-dir \

--- a/resources/dev/extensions-library/services/bark/README.md
+++ b/resources/dev/extensions-library/services/bark/README.md
@@ -61,6 +61,8 @@ Bark understands non-verbal cues in brackets:
 | Small models (`BARK_USE_SMALL_MODELS=true`) | ~2GB |
 | CPU offload | <1GB VRAM (slow) |
 
+> **Apple Silicon / ARM64:** Bark runs in CPU mode on Apple Silicon. Inference is slower than GPU but fully functional.
+
 ## Environment Variables
 
 | Variable | Default | Description |


### PR DESCRIPTION
## Summary
- Replace amd64-only `pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime` with `python:3.10-slim` (multi-arch)
- Install PyTorch via default pip (auto-resolves: CUDA wheels on amd64, CPU-only on arm64)
- Preserves NVIDIA GPU acceleration — default pip wheels include CUDA, nvidia compose overlay provides device access
- Enables bark to build and run on Apple Silicon (ARM64) in CPU mode

## Changed files
- `services/bark/Dockerfile` — base image + PyTorch install method
- `services/bark/README.md` — added note about Apple Silicon/ARM64 CPU mode

## Not changed (verified correct)
- `compose.yaml` — no GPU config in base, works without GPU
- `compose.nvidia.yaml` — exists as separate GPU overlay
- `manifest.yaml` — `gpu_backends: [nvidia]` correct for GPU acceleration

## Test plan
- [x] Dockerfile uses multi-arch base image (no pinned hash)
- [x] PyTorch install uses default index (not CPU-only)
- [x] All original dependencies preserved
- [x] CG review: APPROVED (after fixing CPU-only index URL blocking issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)