### PR TITLE
docs(extensions-library): add README.md for forge, gitea, langflow, localai, milvus

### DIFF
--- a/resources/dev/extensions-library/services/forge/README.md
+++ b/resources/dev/extensions-library/services/forge/README.md
@@ -1,0 +1,69 @@
+# Forge / A1111
+
+Forge (based on Automatic1111) is the original Stable Diffusion web UI. Features extensive model support, extensions, inpainting, outpainting, and professional-grade image generation capabilities. GPU required.
+
+## What It Does
+
+- Full Stable Diffusion image generation with advanced settings
+- Inpainting with mask support
+- Outpainting beyond image boundaries
+- High-resolution upscaling with multiple engines
+- Extensive extension ecosystem
+- REST API for integration with external workflows
+
+## Quick Start
+
+```bash
+dream enable forge
+dream start forge
+```
+
+Open **http://localhost:7861** to access the Forge web UI.
+
+**Note:** First startup may download several GB of model files. Subsequent starts are instant.
+
+## API Usage
+
+### Generate via txt2img API
+
+```bash
+curl -X POST http://localhost:7861/sdapi/v1/txt2img \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "a photo of a cat in a garden",
+    "steps": 20,
+    "width": 512,
+    "height": 512
+  }'
+```
+
+### Check Progress
+
+```bash
+curl http://localhost:7861/sdapi/v1/progress
+```
+
+## VRAM Requirements
+
+| Feature | VRAM |
+|---------|------|
+| Image Generation | 8 GB |
+| Inpainting | 8 GB |
+| Outpainting | 8 GB |
+| Upscaling | 4 GB |
+
+**GPU:** NVIDIA only.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FORGE_PORT` | `7861` | External port |
+| `FORGE_PORT_HOST` | `7861` | Internal port binding |
+| `FORGE_ARGS` | `--api --listen` | Launch arguments |
+| `AUTO_UPDATE` | `false` | Auto-update on startup |
+
+## Data Persistence
+
+- `./data/forge/models/` — Stable Diffusion models, LoRAs, VAEs
+- `./data/forge/outputs/` — Generated images

--- a/resources/dev/extensions-library/services/gitea/README.md
+++ b/resources/dev/extensions-library/services/gitea/README.md
@@ -1,0 +1,60 @@
+# Gitea
+
+Self-hosted lightweight Git server with code review, issue tracking, CI/CD, and wiki — a GitHub/GitLab alternative that runs on minimal resources.
+
+## What It Does
+
+- Git repository hosting with web interface
+- Pull requests and code review
+- Issue tracking and project boards
+- Built-in CI/CD (Gitea Actions, compatible with GitHub Actions)
+- Wiki per repository
+- SQLite backend (zero external database dependencies)
+
+## Quick Start
+
+```bash
+dream enable gitea
+dream start gitea
+```
+
+Open **http://localhost:7830** to access the Gitea web UI.
+
+**Note:** Registration is disabled by default. Set `GITEA_ADMIN_USER` and `GITEA_ADMIN_PASSWORD` environment variables before first run to create the admin account.
+
+### Clone via SSH
+
+```bash
+git clone ssh://git@localhost:2222/username/repo.git
+```
+
+## API Usage
+
+### List Repositories
+
+```bash
+curl -H "Authorization: token YOUR_TOKEN" \
+  http://localhost:7830/api/v1/repos/search
+```
+
+### Health Check
+
+```bash
+curl http://localhost:7830/api/healthz
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `GITEA_HOST` | `localhost` | Hostname for Gitea server |
+| `GITEA_PORT` | `7830` | External port for web interface |
+| `GITEA_SSH_PORT` | `2222` | External port for SSH access |
+| `GITEA_APP_NAME` | `Dream Server Git` | Display name for the instance |
+| `GITEA_ADMIN_USER` | _(empty)_ | Admin username (created on first run) |
+| `GITEA_ADMIN_PASSWORD` | _(empty)_ | Admin password (created on first run) |
+| `GITEA_ADMIN_EMAIL` | `admin@localhost` | Admin email address |
+
+## Data Persistence
+
+- `./data/gitea/` — Repositories, database, configuration, and uploads

--- a/resources/dev/extensions-library/services/langflow/README.md
+++ b/resources/dev/extensions-library/services/langflow/README.md
@@ -1,0 +1,49 @@
+# Langflow
+
+Visual LLM workflow builder that lets you create complex AI workflows with a drag-and-drop interface. Supports LangChain components, custom components, and real-time testing.
+
+## What It Does
+
+- Visual drag-and-drop workflow builder for LLM pipelines
+- Build RAG (Retrieval Augmented Generation) pipelines visually
+- Create and test AI agents with no code
+- LangChain component library built in
+- Real-time testing and debugging of workflows
+- Export workflows as Python code or API endpoints
+
+## Quick Start
+
+```bash
+dream enable langflow
+dream start langflow
+```
+
+Open **http://localhost:7802** to access the Langflow UI.
+
+## API Usage
+
+### Run a Flow
+
+```bash
+curl -X POST http://localhost:7802/api/v1/run/<flow_id> \
+  -H "Content-Type: application/json" \
+  -d '{"input_value": "Hello, what can you help me with?"}'
+```
+
+### Health Check
+
+```bash
+curl http://localhost:7802/health
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LANGFLOW_HOST` | `0.0.0.0` | Bind address |
+| `LANGFLOW_PORT` | `7802` | External port |
+| `LLM_API_URL` | `http://llama-server:8080` | Backend LLM API endpoint |
+
+## Data Persistence
+
+- `./data/langflow/` — Flows, components, and configuration

--- a/resources/dev/extensions-library/services/localai/README.md
+++ b/resources/dev/extensions-library/services/localai/README.md
@@ -1,0 +1,72 @@
+# LocalAI
+
+OpenAI-compatible local inference API. Run LLMs, generate images, audio, video, and clone voices — all through the same API format as OpenAI, entirely on your own hardware.
+
+## What It Does
+
+- Text generation via OpenAI-compatible `/v1/chat/completions` API
+- Image generation with local diffusion models
+- Audio generation and transcription
+- Video generation with local models
+- Voice cloning for text-to-speech
+- Drop-in replacement for OpenAI API in existing applications
+
+## Quick Start
+
+```bash
+dream enable localai
+dream start localai
+```
+
+Open **http://localhost:7803** to access the LocalAI web interface.
+
+## API Usage
+
+### Chat Completion (OpenAI-compatible)
+
+```bash
+curl -X POST http://localhost:7803/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "gpt-4",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+### List Available Models
+
+```bash
+curl http://localhost:7803/v1/models
+```
+
+### Health Check
+
+```bash
+curl http://localhost:7803/healthz
+```
+
+## VRAM Requirements
+
+| Feature | VRAM |
+|---------|------|
+| Text Generation | 4 GB |
+| Audio Generation | 4 GB |
+| Voice Cloning | 4 GB |
+| Image Generation | 8 GB |
+| Video Generation | 16 GB |
+
+**GPU:** AMD or NVIDIA. CPU fallback available (slower).
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LOCALAI_EXTERNAL_PORT` | `7803` | External port |
+| `MODELS_PATH` | `/models` | Path to model files |
+| `CONFIG_PATH` | `/builds` | Path to build configs |
+| `LLM_API_URL` | `http://llama-server:8080` | Backend LLM API endpoint |
+
+## Data Persistence
+
+- `./data/localai/models/` — Downloaded model files
+- `./data/localai/builds/` — Build configurations and cached artifacts

--- a/resources/dev/extensions-library/services/milvus/README.md
+++ b/resources/dev/extensions-library/services/milvus/README.md
@@ -1,0 +1,72 @@
+# Milvus
+
+Production-grade open-source vector database built for scalable similarity search. Supports billion-scale vector data with high performance.
+
+## What It Does
+
+- Vector similarity search (L2, IP, cosine)
+- Hybrid search combining vector and scalar filtering
+- Multi-vector index support (IVF, HNSW, DiskANN)
+- Scalar field filtering and metadata queries
+- Standalone mode for single-node deployments
+- gRPC and RESTful API interfaces
+
+## Quick Start
+
+```bash
+dream enable milvus
+dream start milvus
+```
+
+Milvus listens on **port 19530** (gRPC) by default. Use any Milvus SDK to connect.
+
+### Python Quick Start
+
+```python
+from pymilvus import connections, Collection
+
+connections.connect(host="localhost", port="19530")
+```
+
+## API Usage
+
+### Health Check
+
+```bash
+docker exec dream-milvus curl -sf http://localhost:9091/healthz
+```
+
+> **Note:** The health endpoint (port 9091) is internal to the container and not exposed to the host. DreamServer monitors health automatically via the compose healthcheck.
+
+### Create Collection (via REST)
+
+```bash
+curl -X POST http://localhost:19530/v2/vectordb/collections/create \
+  -H "Content-Type: application/json" \
+  -d '{
+    "collectionName": "my_collection",
+    "dimension": 768
+  }'
+```
+
+### Insert Vectors (via REST)
+
+```bash
+curl -X POST http://localhost:19530/v2/vectordb/entities/insert \
+  -H "Content-Type: application/json" \
+  -d '{
+    "collectionName": "my_collection",
+    "data": [{"vector": [0.1, 0.2, ...]}]
+  }'
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `MILVUS_PORT` | `19530` | External gRPC port |
+| `MODE` | `standalone` | Deployment mode (`standalone` or `cluster`) |
+
+## Data Persistence
+
+- `./data/milvus/` — Index files, metadata, and WAL logs


### PR DESCRIPTION
## Summary
- Create missing README.md for 5 services that had no documentation
- Each follows the established template structure (bark README as reference)
- All use correct CLI command: `dream enable <service>` (verified from source)

## New files
| Service | Lines | Key details |
|---------|-------|-------------|
| **forge** | 69 | NVIDIA GPU, image gen, inpainting, VRAM table |
| **gitea** | 60 | Git hosting, SSH clone, admin setup |
| **langflow** | 49 | Visual LLM workflow builder, flow API |
| **localai** | 72 | OpenAI-compatible API, 5-feature VRAM table |
| **milvus** | 70 | Vector DB, REST + Python SDK examples |

## Test plan
- [x] All ports, env vars, volume paths cross-referenced against compose.yaml and manifest.yaml
- [x] All use `dream enable` (correct), not `dream extensions enable`
- [x] No existing files modified — only new files added
- [x] Milvus health check uses `docker exec` (port 9091 is internal, not host-exposed)
- [x] CG review: APPROVED (after fixing Milvus health check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)