### PR TITLE
fix: add missing backslash line continuations in bootstrap launch

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -363,15 +363,15 @@ MODELS_INI_EOF
                 . "$SCRIPT_DIR/installers/lib/background-tasks.sh"
             fi
 
-            nohup bash "$SCRIPT_DIR/scripts/bootstrap-upgrade.sh" 
-                "$INSTALL_DIR" "$FULL_GGUF_FILE" "$FULL_GGUF_URL" 
-                "$FULL_GGUF_SHA256" "$FULL_LLM_MODEL" "$FULL_MAX_CONTEXT" 
+            nohup bash "$SCRIPT_DIR/scripts/bootstrap-upgrade.sh" \
+                "$INSTALL_DIR" "$FULL_GGUF_FILE" "$FULL_GGUF_URL" \
+                "$FULL_GGUF_SHA256" "$FULL_LLM_MODEL" "$FULL_MAX_CONTEXT" \
                 > "$INSTALL_DIR/logs/model-upgrade.log" 2>&1 &
             _upgrade_pid=$!
 
             if command -v bg_task_start &>/dev/null; then
-                bg_task_start "full-model-download" "$_upgrade_pid" 
-                    "Full model download: $FULL_LLM_MODEL" 
+                bg_task_start "full-model-download" "$_upgrade_pid" \
+                    "Full model download: $FULL_LLM_MODEL" \
                     "$INSTALL_DIR/logs/model-upgrade.log"
             fi
 


### PR DESCRIPTION
## Summary
- The `nohup` and `bg_task_start` calls in phase 11 had trailing spaces but no backslashes for line continuation
- Bash treated each line as a separate command — `nohup` ran `bootstrap-upgrade.sh` with no args, then `$INSTALL_DIR` was executed as a command
- `set -euo pipefail` caught the failure and killed the installer

**This is a one-character-per-line fix (adding `\`) that unblocks all Tier 1+ installs with bootstrap mode.**

Found by a user's Claude instance running a live install on a Strix Halo machine.

## Test plan
- [ ] `bash -n installers/phases/11-services.sh` passes
- [ ] Tier 1+ install completes through phase 11 without crash
- [ ] Background model download launches with correct arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>