### PR TITLE
fix(windows): update Vulkan llama-server binary to b8248

### DIFF
--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -10,7 +10,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-$script:DS_VERSION = "2.0.0-strix-halo"
+$script:DS_VERSION = "2.3.0"
 
 # Install location (override via $env:DREAM_HOME)
 # NOTE: $(if ...) syntax required for PS 5.1 compatibility (bare if-as-expression is PS 7+ only)
@@ -26,7 +26,7 @@ $script:LLAMA_SERVER_EXE = Join-Path $script:LLAMA_SERVER_DIR "llama-server.exe"
 $script:LLAMA_SERVER_PID_FILE = Join-Path (Join-Path $script:DS_INSTALL_DIR "data") "llama-server.pid"
 
 # llama.cpp release for Vulkan build (update when new releases ship)
-$script:LLAMA_CPP_RELEASE_TAG = "b5570"
+$script:LLAMA_CPP_RELEASE_TAG = "b8248"
 $script:LLAMA_CPP_VULKAN_ASSET = "llama-$($script:LLAMA_CPP_RELEASE_TAG)-bin-win-vulkan-x64.zip"
 $script:LLAMA_CPP_VULKAN_URL = "https://github.com/ggml-org/llama.cpp/releases/download/$($script:LLAMA_CPP_RELEASE_TAG)/$($script:LLAMA_CPP_VULKAN_ASSET)"
 


### PR DESCRIPTION
## Summary

- Updates `LLAMA_CPP_RELEASE_TAG` from `b5570` → `b8248` in Windows installer constants
- Syncs `DS_VERSION` from `2.0.0-strix-halo` → `2.3.0`

## Problem

The Vulkan Windows binary for llama.cpp release `b5570` no longer exists on GitHub. Every Windows AMD install (Strix Halo) downloads a 9-byte 404 response, saves it as a zip, and crashes with "Central Directory corrupt."

Confirmed: `curl -sI` on b5570 returns HTTP 404. b8248 returns HTTP 302 (valid redirect to CDN).

## Why b8248

- Matches the Linux Docker image tag (`ghcr.io/ggml-org/llama.cpp:server-cuda-b8248`)
- CLI flags used by the installer (`--model`, `--host`, `--port`, `--n-gpu-layers`, `--ctx-size`) are stable across both versions
- Health endpoint (`/health`) unchanged
- Installer already handles nested zip structures via recursive search

## Test plan

- [ ] Verify `llama-b8248-bin-win-vulkan-x64.zip` downloads and extracts correctly
- [ ] Verify `llama-server.exe` starts with `--model` + Vulkan on Strix Halo hardware
- [ ] Verify health check passes at `http://localhost:8080/health`

**Needs testing on actual AMD Strix Halo hardware before merge.**

Fixes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)