### PR TITLE
security: bind OpenClaw Pro gateway to localhost only

### DIFF
--- a/dream-server/config/openclaw/pro.json
+++ b/dream-server/config/openclaw/pro.json
@@ -46,7 +46,7 @@
   },
   "gateway": {
     "port": 7860,
-    "host": "0.0.0.0",
+    "host": "127.0.0.1",
     "controlUi": {
       "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,


### PR DESCRIPTION
## Summary

One-line fix: `pro.json` gateway host `0.0.0.0` → `127.0.0.1`

## Problem

The Pro OpenClaw config bound the gateway to all interfaces (`0.0.0.0`) with `dangerouslyDisableDeviceAuth: true`. This exposed the OpenClaw control UI to the network without authentication.

The other two configs (`openclaw.json`, `openclaw-strix-halo.json`) already bind to `127.0.0.1`. This was simply missed in `pro.json`.

## Why dangerouslyDisableDeviceAuth is fine with localhost

With `127.0.0.1` binding, only local processes can reach the gateway. Docker containers communicate via the internal Docker network, not via the host binding. The "dangerous" flags are needed because OpenClaw expects a browser-based device auth flow that doesn't work in a headless container environment.

## Test plan

- [ ] Verify OpenClaw starts and is accessible from Open WebUI (via Docker internal network)
- [ ] Verify OpenClaw is NOT accessible from another machine on the LAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)