### PR TITLE
chore: bump version to v2.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ We built Dream Server so you don't have to.
 - **Fully moddable** — every service is an extension. Drop in a folder, run `dream enable`, done
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.3.0/dream-server/get-dream-server.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.3.1/dream-server/get-dream-server.sh | bash
 ```
 
 Open **http://localhost:3000** and start chatting.

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -39,7 +39,7 @@ Known-good version baselines: [`docs/KNOWN-GOOD-VERSIONS.md`](docs/KNOWN-GOOD-VE
 
 ```bash
 # One-line install (Linux — NVIDIA or AMD)
-curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.3.0/get-dream-server.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.3.1/get-dream-server.sh | bash
 ```
 
 Or manually:

--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Dream Server Bootstrap Installer
-# curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.3.0/get-dream-server.sh | bash
+# curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.3.1/get-dream-server.sh | bash
 #
 # Detects OS, clones repo, runs installer.
 

--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.3.0"
+VERSION="2.3.1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Source path utilities for cross-platform path resolution

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -293,7 +293,7 @@ MODELS_EOF
 # Tier: ${TIER} (${TIER_NAME})
 
 #=== Dream Server Version (used by dream-cli update for version-compat checks) ===
-DREAM_VERSION=${VERSION:-2.3.0}
+DREAM_VERSION=${VERSION:-2.3.1}
 
 #=== LLM Backend Mode ===
 DREAM_MODE=${DREAM_MODE:-local}

--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -10,7 +10,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-$script:DS_VERSION = "2.3.0"
+$script:DS_VERSION = "2.3.1"
 
 # Install location (override via $env:DREAM_HOME)
 # NOTE: $(if ...) syntax required for PS 5.1 compatibility (bare if-as-expression is PS 7+ only)


### PR DESCRIPTION
## Summary

Bump all version references from 2.3.0 → 2.3.1 for tagging.

## Changelog since v2.3.0

- security: bind OpenClaw Pro gateway to localhost only (#514)
- feat: make ComfyUI + FLUX optional, saves ~34GB when disabled (#513)
- fix(windows): update Vulkan llama-server binary to b8248 (#512)
- fix: add missing backslash line continuations in bootstrap launch (#511)
- fix: correct model path in upgrade-model.sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)