### PR TITLE
fix: add ENABLE_IMAGE_GENERATION to .env schema

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -156,3 +156,6 @@ LANGFUSE_ENABLED=false
 
 # llama-server memory limit (Docker)
 # LLAMA_SERVER_MEMORY_LIMIT=64G
+
+# Image generation (ComfyUI + FLUX)
+# ENABLE_IMAGE_GENERATION=true

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -414,6 +414,11 @@
       "type": "string",
       "description": "Langfuse initial admin user password",
       "secret": true
+    },
+    "ENABLE_IMAGE_GENERATION": {
+      "type": "string",
+      "description": "Enable image generation in Open WebUI (requires ComfyUI)",
+      "default": "true"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds `ENABLE_IMAGE_GENERATION` to `.env.schema.json` and `.env.example`.

## Problem

PR #513 (optional ComfyUI) added this var to the `.env` generator in phase 06 but not to the schema. Schema validation fails during install:

```
[ERROR] Generated .env failed schema validation.
```

## Fix

Two files, 8 lines added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)