### PR TITLE
fix: strip optional services from tier0 overlay (Compose v5 compat)

### DIFF
--- a/dream-server/docker-compose.tier0.yml
+++ b/dream-server/docker-compose.tier0.yml
@@ -1,15 +1,23 @@
 # Tier 0 memory overlay — reduces memory limits and reservations
 # for machines with < 8GB RAM. Layered on top of base + GPU overlay.
 #
-# Default reservations total ~7.6GB which exceeds Tier 0 hardware.
-# This overlay reduces reservations to ~2.4GB total so services can
-# coexist on 4-7GB machines alongside the Qwen3.5-2B model (~1.5GB).
+# Only overrides services defined in docker-compose.base.yml.
+# Optional services (n8n, qdrant, whisper, etc.) set their own
+# limits in their per-service compose files.
 #
-# Services will use less memory but may be slower under pressure.
-# Docker's OOM killer handles the worst case gracefully.
+# NOTE: Docker Compose v5+ errors if an overlay references a service
+# not defined in any included compose file. Do NOT add optional
+# services here — they may not be in the stack.
 
 services:
-  # === Base services ===
+  llama-server:
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+        reservations:
+          memory: 512M
+
   dashboard:
     deploy:
       resources:
@@ -26,99 +34,7 @@ services:
         reservations:
           memory: 128M
 
-  # === Extension services ===
-  # These overrides only apply if the service is included in the stack.
-  # Docker Compose ignores overrides for services not defined in base.
-
   open-webui:
-    deploy:
-      resources:
-        limits:
-          memory: 1G
-        reservations:
-          memory: 256M
-
-  n8n:
-    deploy:
-      resources:
-        limits:
-          memory: 1G
-        reservations:
-          memory: 256M
-
-  qdrant:
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-        reservations:
-          memory: 128M
-
-  embeddings:
-    deploy:
-      resources:
-        limits:
-          memory: 1G
-        reservations:
-          memory: 256M
-
-  litellm:
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-        reservations:
-          memory: 128M
-
-  openclaw:
-    deploy:
-      resources:
-        limits:
-          memory: 1G
-        reservations:
-          memory: 256M
-
-  perplexica:
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-        reservations:
-          memory: 128M
-
-  privacy-shield:
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-        reservations:
-          memory: 128M
-
-  searxng:
-    deploy:
-      resources:
-        limits:
-          memory: 256M
-        reservations:
-          memory: 64M
-
-  token-spy:
-    deploy:
-      resources:
-        limits:
-          memory: 512M
-        reservations:
-          memory: 128M
-
-  tts:
-    deploy:
-      resources:
-        limits:
-          memory: 1G
-        reservations:
-          memory: 256M
-
-  whisper:
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

- Docker Compose v5+ errors when an overlay references a service not defined in any included compose file
- `docker-compose.tier0.yml` referenced 12 optional services (qdrant, n8n, whisper, tts, etc.) that may not be in the stack
- The comment "Docker Compose ignores overrides for services not defined in base" was true for Compose v2 but is **false for v5**
- Now only overrides the 4 base services: `llama-server`, `dashboard`, `dashboard-api`, `open-webui`

## Reproduction

```
docker compose -f docker-compose.base.yml -f docker-compose.nvidia.yml -f docker-compose.tier0.yml config --services
# ERROR: service "qdrant" has neither an image nor a build context specified
```

## Test plan

- [x] `docker compose config --services` passes with base + nvidia + tier0 (no extensions)
- [x] `docker compose config --services` passes with base + nvidia + extensions + tier0
- [ ] Full Tier 0 install completes on Windows (Docker Compose v5)
- [ ] Full Tier 0 install completes on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)