### PR TITLE
fix(windows): fix bootstrap-upgrade.sh argument passing

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -413,9 +413,10 @@ if ($dryRun) {
                 $bashInstallDir = ($installDir -replace "\\", "/" -replace "^([A-Za-z]):", '/$1').ToLower()
                 $bashScript = ($upgradeScript -replace "\\", "/" -replace "^([A-Za-z]):", '/$1').ToLower()
 
-                $bashArgs = "$bashScript `"$bashInstallDir`" `"$($fullTierConfig.GgufFile)`" `"$($fullTierConfig.GgufUrl)`" `"$($fullTierConfig.GgufSha256)`" `"$($fullTierConfig.LlmModel)`" `"$($fullTierConfig.MaxContext)`""
+                # Pass as a single -c string so bash receives all arguments correctly
+                $bashCmd = "'$bashScript' '$bashInstallDir' '$($fullTierConfig.GgufFile)' '$($fullTierConfig.GgufUrl)' '$($fullTierConfig.GgufSha256)' '$($fullTierConfig.LlmModel)' '$($fullTierConfig.MaxContext)'"
 
-                Start-Process -FilePath "bash" -ArgumentList "-c", $bashArgs `
+                Start-Process -FilePath "bash" -ArgumentList @("-c", $bashCmd) `
                     -WindowStyle Hidden `
                     -RedirectStandardOutput $upgradeLog `
                     -RedirectStandardError $upgradeErrLog


### PR DESCRIPTION
## Summary

Fixes `$1: unbound variable` crash in bootstrap-upgrade.sh when launched from the Windows installer.

`Start-Process -ArgumentList "-c", $bashArgs` passes them as separate arguments, but `bash -c` needs the entire command as a single string argument. Changed to single-quoted args inside the `-c` string.

**Before:** `bash` receives `-c` as arg1, script path as arg2, install_dir as arg3... but bash only executes arg2 as the command and ignores the rest.

**After:** `bash` receives `-c` as arg1, `'script' 'arg1' 'arg2' ...` as arg2 — all arguments are part of the command string.

Tested manually: bootstrap-upgrade.sh starts correctly and begins downloading the full model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)