### PR TITLE
fix(extensions-library): isolate privacy-shield sessions by client IP

### DIFF
--- a/resources/dev/extensions-library/services/privacy-shield/proxy.py
+++ b/resources/dev/extensions-library/services/privacy-shield/proxy.py
@@ -80,14 +80,10 @@ class CachedPrivacyShield(PrivacyShield):
 
 def get_session(request: Request) -> CachedPrivacyShield:
     """Get or create session-specific PrivacyShield."""
-    # Use Authorization header or IP as session key
-    auth = request.headers.get("Authorization", "")
-    # Use SHA256 for deterministic, stable session keying (hash() is not deterministic across restarts)
-    if auth:
-        session_key = hashlib.sha256(auth.encode()).hexdigest()
-    else:
-        client_info = str(request.client.host if request.client else "default")
-        session_key = hashlib.sha256(client_info.encode()).hexdigest()
+    # Key on client IP to isolate PII between different callers.
+    # The shared SHIELD_API_KEY cannot differentiate users.
+    client_ip = request.client.host if request.client else "default"
+    session_key = hashlib.sha256(client_ip.encode()).hexdigest()
     
     if session_key not in sessions:
         sessions[session_key] = CachedPrivacyShield()


### PR DESCRIPTION
## What
Change privacy-shield session key derivation from Authorization header to client IP address.

## Why
`get_session()` derived the session key from the `Authorization` header, but all clients authenticate with the same shared `SHIELD_API_KEY`. This caused every caller to hash to the identical session key, sharing one `CachedPrivacyShield` instance. PII scrubbed from User A's requests could be restored into User B's responses.

## How
Key sessions on `request.client.host` (client IP) instead of the Authorization header. Different callers now get isolated `CachedPrivacyShield` instances with separate PII maps.

## Scope
All changes are within `resources/dev/extensions-library/services/privacy-shield/proxy.py`.

## Testing
- Verified diff is minimal (+4 −8 lines)
- Critique Guardian: APPROVED WITH WARNINGS (NAT edge case — non-blocking for Docker-internal deployment)

## Known Considerations
- Multiple users behind the same NAT/reverse proxy will still share a session. Acceptable for the Docker-internal deployment model; can be upgraded to per-user token headers if needed in future.

## Merge Order
- **Merge before PR #542** (`ext/fix-proxy-utf8-decode`) — same file (`proxy.py`), different code area. This PR must land first.
- No other conflicts with open PRs.