### PR TITLE
fix(extensions-library): bind frigate RTSP/WebRTC to localhost, require password

### DIFF
--- a/resources/dev/extensions-library/services/frigate/compose.yaml
+++ b/resources/dev/extensions-library/services/frigate/compose.yaml
@@ -8,11 +8,11 @@ services:
     shm_size: "128mb"
     ports:
       - "127.0.0.1:${FRIGATE_PORT:-8971}:5000"
-      - "${FRIGATE_RTSP_PORT:-8554}:8554"
-      - "${FRIGATE_WEBRTC_PORT:-8555}:8555/tcp"
-      - "${FRIGATE_WEBRTC_PORT:-8555}:8555/udp"
+      - "127.0.0.1:${FRIGATE_RTSP_PORT:-8554}:8554"
+      - "127.0.0.1:${FRIGATE_WEBRTC_PORT:-8555}:8555/tcp"
+      - "127.0.0.1:${FRIGATE_WEBRTC_PORT:-8555}:8555/udp"
     environment:
-      - FRIGATE_RTSP_PASSWORD=${FRIGATE_RTSP_PASSWORD:-}
+      - FRIGATE_RTSP_PASSWORD=${FRIGATE_RTSP_PASSWORD:?FRIGATE_RTSP_PASSWORD must be set}
     volumes:
       - ./data/frigate/config:/config
       - ./data/frigate/storage:/media/frigate


### PR DESCRIPTION
## What
Bind frigate RTSP and WebRTC ports to 127.0.0.1 and require FRIGATE_RTSP_PASSWORD.

## Why
RTSP (8554) and WebRTC (8555 tcp+udp) ports were bound to 0.0.0.0, exposing live camera streams to the entire LAN. The RTSP password defaulted to empty, allowing unauthenticated access. The web UI port was already fixed with 127.0.0.1 in a prior PR, but the streaming ports were missed.

## How
- Add `127.0.0.1:` prefix to RTSP and both WebRTC port bindings
- Change `FRIGATE_RTSP_PASSWORD` from `:-` (empty default) to `:?` (required)

## Scope
All changes are within `resources/dev/extensions-library/services/frigate/compose.yaml`.

## Testing
- Verified all 4 port bindings now use 127.0.0.1
- `:?` syntax validated — Compose will refuse to start without FRIGATE_RTSP_PASSWORD set
- Critique Guardian: APPROVED

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.