### PR TITLE
fix(extensions-library): require PAPERLESS_SECRET_KEY instead of defaulting to 'change-me'

### DIFF
--- a/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
@@ -12,7 +12,7 @@ services:
       - PAPERLESS_DBPORT=${PAPERLESS_DBPORT:-5432}
       - PAPERLESS_REDISHOST=${PAPERLESS_REDISHOST:-redis}
       - PAPERLESS_REDISPORT=${PAPERLESS_REDISPORT:-6379}
-      - PAPERLESS_SECRET_KEY=${PAPERLESS_SECRET_KEY:-change-me}
+      - "PAPERLESS_SECRET_KEY=${PAPERLESS_SECRET_KEY:?PAPERLESS_SECRET_KEY must be set – generate with: python3 -c \"import secrets; print(secrets.token_urlsafe(50))\"}"
       - PAPERLESS_URL=http://${PAPERLESS_HOST:-paperless}:${PAPERLESS_PORT:-7807}
     volumes:
       - ./data/paperless/data:/usr/src/paperless/data


### PR DESCRIPTION
## What
Replace the default `change-me` value for `PAPERLESS_SECRET_KEY` with a `:?` guard that forces explicit configuration.

## Why
The `SECRET_KEY` was defaulting to the well-known string `change-me` via `${:-change-me}`, allowing session/CSRF token forgery. Django uses this key for cryptographic signing of sessions, CSRF tokens, and password reset tokens.

## How
Switch from `${PAPERLESS_SECRET_KEY:-change-me}` to `${PAPERLESS_SECRET_KEY:?...}` so Compose fails fast when the variable is unset. The error message includes a generation command. The entire env var line is quoted to prevent YAML parsing issues with the colon in the error message.

## Scope
All changes are within `resources/dev/extensions-library/`.
- `services/paperless-ngx/compose.yaml` — 1 line changed

## Testing
- YAML validation: `python3 -c "import yaml; yaml.safe_load(...)"`  passed
- Critique Guardian: REJECTED initial version (colon broke YAML), fixed with quoting, re-verified

## Review
Critique Guardian verdict: APPROVED (after fix)

## Merge Order
- **Merge before PR #537** (`ext/fix-paperless-depends-on`) — same file (`paperless-ngx/compose.yaml`), different lines. This PR must land first.
- No other conflicts with open PRs.