### PR TITLE
fix(extensions-library): add credentials to librechat MongoDB URI

### DIFF
--- a/resources/dev/extensions-library/services/librechat/compose.yaml
+++ b/resources/dev/extensions-library/services/librechat/compose.yaml
@@ -8,7 +8,7 @@ services:
     environment:
       - HOST=0.0.0.0
       - PORT=3080
-      - MONGO_URI=mongodb://librechat-mongodb:27017/LibreChat
+      - MONGO_URI=mongodb://librechat:${LIBRECHAT_MONGO_PASSWORD}@librechat-mongodb:27017/LibreChat?authSource=admin
       - MEILI_HOST=http://librechat-meilisearch:7700
       - MEILI_HTTP_ADDR=librechat-meilisearch:7700
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}


### PR DESCRIPTION
## What
Add authentication credentials to LibreChat's MongoDB connection URI.

## Why
`MONGO_URI` was set to `mongodb://librechat-mongodb:27017/LibreChat` without credentials, but the bundled MongoDB container requires authentication (`MONGO_INITDB_ROOT_USERNAME=librechat`, `MONGO_INITDB_ROOT_PASSWORD` required via `:?`). LibreChat could not connect to its database — the service was non-functional with default configuration.

## How
Updated MONGO_URI to include username, password (from the same env var used by MongoDB), and `authSource=admin` (correct for `MONGO_INITDB_ROOT_*` users).

## Scope
All changes are within `resources/dev/extensions-library/services/librechat/compose.yaml`.

## Testing
- Verified credentials match MongoDB container's init vars
- `authSource=admin` is correct for root users created via MONGO_INITDB_ROOT_*
- `LIBRECHAT_MONGO_PASSWORD` is already required by MongoDB container's `:?` — no new env var needed
- Critique Guardian: APPROVED

## Merge Order
- **Merge before PR #535** (`ext/fix-librechat-creds-key`) — same file (`librechat/compose.yaml`), different lines. This PR must land first.
- No other conflicts with open PRs.