### PR TITLE
fix(extensions-library): require JUPYTER_TOKEN instead of defaulting to guessable value

### DIFF
--- a/resources/dev/extensions-library/services/jupyter/compose.yaml
+++ b/resources/dev/extensions-library/services/jupyter/compose.yaml
@@ -11,9 +11,9 @@ services:
       - ./data/jupyter/notebooks:/home/jovyan/notebooks
     environment:
       - LLM_API_URL=${LLM_API_URL:-http://localhost:8000}
-      - JUPYTER_TOKEN=${JUPYTER_TOKEN:-jupyter}
+      - JUPYTER_TOKEN=${JUPYTER_TOKEN:?JUPYTER_TOKEN must be set}
       - NB_PREFIX=/
-    command: start.sh jupyter lab --NotebookApp.token=${JUPYTER_TOKEN:-jupyter} --NotebookApp.password='' --NotebookApp.port=8888 --NotebookApp.ip=0.0.0.0 --NotebookApp.open_browser=False
+    command: start.sh jupyter lab --NotebookApp.token=${JUPYTER_TOKEN:?JUPYTER_TOKEN must be set} --NotebookApp.password='' --NotebookApp.port=8888 --NotebookApp.ip=0.0.0.0 --NotebookApp.open_browser=False
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## What
Replace guessable default Jupyter token with mandatory `:?` requirement.

## Why
`JUPYTER_TOKEN` defaulted to the literal string `"jupyter"` in both the environment variable and the `--NotebookApp.token` CLI argument. This trivially guessable token grants full Jupyter Lab access with arbitrary code execution to anyone who can reach the port.

## How
Changed both occurrences of `${JUPYTER_TOKEN:-jupyter}` to `${JUPYTER_TOKEN:?JUPYTER_TOKEN must be set}`. The container will refuse to start without an explicitly set token.

## Scope
All changes are within `resources/dev/extensions-library/services/jupyter/compose.yaml`.

## Testing
- Verified both environment and command line use consistent `:?` syntax
- Pattern matches 6+ other services in the library (Dify, Weaviate, Flowise, etc.)
- Critique Guardian: APPROVED

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.