### PR TITLE
fix(extensions-library): harden audiocraft Dockerfile (non-root user, healthcheck, digest pin)

### DIFF
--- a/resources/dev/extensions-library/services/audiocraft/Dockerfile
+++ b/resources/dev/extensions-library/services/audiocraft/Dockerfile
@@ -1,9 +1,8 @@
-FROM python:3.10-slim-bookworm
+FROM python:3.10-slim-bookworm@sha256:4efa69bf17cfbd5eb44b170e40bb8091b1c0fadf3833aeb87b655512e24268e5
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     git \
-    wget \
     libsndfile1 \
     ffmpeg \
     && rm -rf /var/lib/apt/lists/*
@@ -138,6 +137,15 @@ EOF
 # Create outputs directory
 RUN mkdir -p /app/outputs
 
+# Create non-root user
+RUN useradd -m -s /bin/bash appuser \
+    && chown -R appuser:appuser /app
+
+USER appuser
+
 EXPOSE 7860
+
+HEALTHCHECK --interval=30s --timeout=15s --start-period=120s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:7860/')" || exit 1
 
 CMD ["python", "/app/app.py"]


### PR DESCRIPTION
## What
Security-harden the audiocraft Dockerfile with three improvements.

## Why
Container ran as root (compromise = full access), had no healthcheck (unhealthy containers stay in rotation), and used an unpinned base image (content changes silently between rebuilds).

## How
1. Pin base image with `@sha256:` digest for reproducible builds
2. Add non-root `appuser` (created after all privileged build steps)
3. Add `HEALTHCHECK` using Python urllib on port 7860 (Gradio)
4. Remove unused `wget` package (reduces image footprint and attack surface)

## Scope
All changes are within `resources/dev/extensions-library/`.
- `services/audiocraft/Dockerfile` — 10 additions, 2 deletions

## Testing
- Dockerfile syntax verified
- Critique Guardian: APPROVED WITH WARNINGS (wget removal applied)

## Known Considerations
- `start-period=120s` may need tuning for slower networks (ML model download on first start)
- Models cache to `~/.cache/huggingface/hub` — writable by appuser via `useradd -m`

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.