### PR TITLE
fix(extensions-library): correct default ports in bark, piper, rvc workflows

### DIFF
--- a/resources/dev/extensions-library/workflows/bark/list-voices.json
+++ b/resources/dev/extensions-library/workflows/bark/list-voices.json
@@ -17,7 +17,7 @@
     },
     {
       "parameters": {
-        "url": "={{ 'http://' + ($env.BARK_HOST || 'localhost') + ':' + ($env.BARK_PORT || '8000') + '/voices' }}",
+        "url": "={{ 'http://' + ($env.BARK_HOST || 'localhost') + ':' + ($env.BARK_PORT || '9200') + '/voices' }}",
         "method": "GET",
         "options": {
           "timeout": 30000

--- a/resources/dev/extensions-library/workflows/bark/tts-synthesize.json
+++ b/resources/dev/extensions-library/workflows/bark/tts-synthesize.json
@@ -17,7 +17,7 @@
     },
     {
       "parameters": {
-        "url": "={{ 'http://' + ($env.BARK_HOST || 'localhost') + ':' + ($env.BARK_PORT || '8000') + '/tts' }}",
+        "url": "={{ 'http://' + ($env.BARK_HOST || 'localhost') + ':' + ($env.BARK_PORT || '9200') + '/tts' }}",
         "method": "POST",
         "headers": {
           "list": [

--- a/resources/dev/extensions-library/workflows/piper/tts-convert.json
+++ b/resources/dev/extensions-library/workflows/piper/tts-convert.json
@@ -17,7 +17,7 @@
     },
     {
       "parameters": {
-        "url": "={{ 'http://' + ($env.PIPER_HOST || 'localhost') + ':' + ($env.PIPER_PORT || '5000') + '/api/tts' }}",
+        "url": "={{ 'http://' + ($env.PIPER_HOST || 'localhost') + ':' + ($env.PIPER_PORT || '10200') + '/api/tts' }}",
         "method": "POST",
         "headers": {
           "list": [

--- a/resources/dev/extensions-library/workflows/rvc/voice-convert.json
+++ b/resources/dev/extensions-library/workflows/rvc/voice-convert.json
@@ -17,7 +17,7 @@
     },
     {
       "parameters": {
-        "url": "={{ 'http://' + ($env.RVC_HOST || 'localhost') + ':' + ($env.RVC_PORT || '8001') + '/voice-convert' }}",
+        "url": "={{ 'http://' + ($env.RVC_HOST || 'localhost') + ':' + ($env.RVC_PORT || '7809') + '/voice-convert' }}",
         "method": "POST",
         "headers": {
           "list": [


### PR DESCRIPTION
## What
Fix wrong default port numbers in 4 workflow JSON files.

## Why
Workflow JSON files hardcoded incorrect default ports that don't match their respective service compose.yaml port mappings. All affected workflows fail to connect out of the box:
- Bark workflows used port 8000 (correct: 9200)
- Piper workflow used port 5000 (correct: 10200)
- RVC workflow used port 8001 (correct: 7809)

## How
Updated the fallback port value in each workflow's URL template expression:
- `workflows/bark/tts-synthesize.json`: `'8000'` → `'9200'`
- `workflows/bark/list-voices.json`: `'8000'` → `'9200'`
- `workflows/piper/tts-convert.json`: `'5000'` → `'10200'`
- `workflows/rvc/voice-convert.json`: `'8001'` → `'7809'`

## Scope
All changes are within `resources/dev/extensions-library/workflows/`.

## Testing
- Cross-checked every port against compose.yaml: bark (9200), piper-audio (10200), rvc (7809)
- All JSON files remain syntactically valid
- Critique Guardian: APPROVED

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.