### PR TITLE
fix(extensions-library): pin open-interpreter pip dependencies to specific versions

### DIFF
--- a/resources/dev/extensions-library/services/open-interpreter/Dockerfile
+++ b/resources/dev/extensions-library/services/open-interpreter/Dockerfile
@@ -1,7 +1,11 @@
 FROM python:3.12-slim@sha256:ccc7089399c8bb65dd1fb3ed6d55efa538a3f5e7fca3f5988ac3b5b87e593bf0
 
 # Install dependencies
-RUN pip install --no-cache-dir open-interpreter fastapi uvicorn pydantic
+RUN pip install --no-cache-dir \
+    open-interpreter==0.4.3 \
+    fastapi==0.135.1 \
+    uvicorn==0.42.0 \
+    pydantic==2.12.5
 
 # Create non-root user
 RUN useradd -m -s /bin/bash appuser


### PR DESCRIPTION
## What
Pin all four Python packages in the open-interpreter Dockerfile to specific versions.

## Why
All packages were installed without version constraints (`pip install open-interpreter fastapi uvicorn pydantic`). The `open-interpreter` package has frequent breaking API changes. A rebuild on any future date could pull incompatible versions.

## How
Pin to current stable releases:
- `open-interpreter==0.4.3`
- `fastapi==0.135.1`
- `uvicorn==0.42.0`
- `pydantic==2.12.5`

Verified server.py uses Pydantic v2 API (`field_validator`, `BaseModel`) — compatible with pydantic 2.12.5.

## Scope
All changes are within `resources/dev/extensions-library/`.
- `services/open-interpreter/Dockerfile` — 5 additions, 1 deletion

## Testing
- Dockerfile syntax verified
- Critique Guardian: APPROVED

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.