### PR TITLE
fix(extensions-library): pin invokeai and xtts image tags to specific versions

### DIFF
--- a/resources/dev/extensions-library/services/invokeai/compose.yaml
+++ b/resources/dev/extensions-library/services/invokeai/compose.yaml
@@ -2,7 +2,7 @@ name: invokeai
 
 services:
   invokeai:
-    image: ghcr.io/invoke-ai/invokeai:latest
+    image: ghcr.io/invoke-ai/invokeai:v6.11.1
     container_name: dream-invokeai
     restart: unless-stopped
     security_opt:

--- a/resources/dev/extensions-library/services/xtts/compose.yaml
+++ b/resources/dev/extensions-library/services/xtts/compose.yaml
@@ -1,6 +1,6 @@
 services:
   xtts:
-    image: daswer123/xtts-api-server:latest
+    image: daswer123/xtts-api-server@sha256:491e0a198fc56c46d3dbb300ab993d29cc699813ea8fd1c6ee77aa80ab133e3e
     container_name: dream-xtts
     ports:
       - "127.0.0.1:${XTTS_PORT:-8100}:80"


### PR DESCRIPTION
## What
Pin InvokeAI and XTTS Docker image tags instead of using `:latest`.

## Why
Both services used `:latest` tags, making deployments non-reproducible and vulnerable to silent breaking upstream changes. XTTS is particularly risky as a community-maintained image with no stability guarantees.

## How
- InvokeAI: `ghcr.io/invoke-ai/invokeai:latest` → `ghcr.io/invoke-ai/invokeai:v6.11.1` (current stable, verified via GitHub API)
- XTTS: `daswer123/xtts-api-server:latest` → `daswer123/xtts-api-server@sha256:491e0a19...` (digest pin — Docker Hub has no versioned tags, only `:latest`)

## Scope
All changes are within `resources/dev/extensions-library/`.
- `services/invokeai/compose.yaml` — 1 line changed
- `services/xtts/compose.yaml` — 1 line changed

## Testing
- YAML validation: passed for both files
- Critique Guardian: APPROVED

## Known Considerations
- XTTS uses digest pin (no semver tags available upstream) — upgrades require updating the digest manually

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.