### PR TITLE
fix(extensions-library): require CREDS_KEY and CREDS_IV for librechat encryption

### DIFF
--- a/resources/dev/extensions-library/services/librechat/compose.yaml
+++ b/resources/dev/extensions-library/services/librechat/compose.yaml
@@ -34,8 +34,8 @@ services:
       - BINGAI_TOKEN=${BINGAI_TOKEN:-}
       - DALLE3_API_KEY=${DALLE3_API_KEY:-}
       - DALLE3_BASEURL=${DALLE3_BASEURL:-}
-      - CREDS_KEY=${CREDS_KEY:-}
-      - CREDS_IV=${CREDS_IV:-}
+      - "CREDS_KEY=${CREDS_KEY:?CREDS_KEY must be set – generate with: openssl rand -hex 32}"
+      - "CREDS_IV=${CREDS_IV:?CREDS_IV must be set – generate with: openssl rand -hex 16}"
       - JWT_SECRET=${JWT_SECRET:?JWT_SECRET must be set}
       - JWT_REFRESH_SECRET=${JWT_REFRESH_SECRET:?JWT_REFRESH_SECRET must be set}
       - APP_TITLE=${APP_TITLE:-LibreChat}


### PR DESCRIPTION
## What
Mark `CREDS_KEY` and `CREDS_IV` as required (`:?`) instead of defaulting to empty strings.

## Why
Empty AES-256 key and IV defeat encryption of stored cloud API keys (OpenAI, Anthropic, etc.) in MongoDB. Credentials are effectively plaintext.

## How
Changed `${CREDS_KEY:-}` → `${CREDS_KEY:?...}` and `${CREDS_IV:-}` → `${CREDS_IV:?...}` with generation hints (`openssl rand -hex 32/16`). Matches the existing pattern used by `JWT_SECRET`, `JWT_REFRESH_SECRET`, and `LIBRECHAT_MONGO_PASSWORD`.

## Scope
All changes within `resources/dev/extensions-library/services/librechat/compose.yaml`.

## Upgrade Notes
- **Breaking change**: Containers will refuse to start until `CREDS_KEY` and `CREDS_IV` are set.
- Credentials previously stored under the empty key cannot be decrypted with a new key — users must re-enter their API keys in LibreChat after setting real encryption keys.

## Merging Order
Merge **after** PR #527 (librechat MongoDB auth) — same file, different lines, no textual conflict.

## Testing
- YAML validation: passed
- Pattern consistency check against other `:?` vars in same file: passed
- Critique Guardian: APPROVED

## Review
Critique Guardian verdict: APPROVED — correct `:?` pattern, correct key sizes, YAML quoting verified.

Originally reported in yasinBursali/DreamServer#76