### PR TITLE
fix(extensions-library): correct text-generation-webui manifest port to 7860

### DIFF
--- a/resources/dev/extensions-library/services/text-generation-webui/manifest.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/manifest.yaml
@@ -7,7 +7,7 @@ service:
   container_name: dream-text-generation-webui
   host_env: TEXT_GEN_WEBUI_HOST
   default_host: text-generation-webui
-  port: 7862
+  port: 7860
   external_port_env: TEXT_GEN_WEBUI_PORT
   external_port_default: 7862
   health: /


### PR DESCRIPTION
## What
Change `port: 7862` to `port: 7860` in the text-generation-webui manifest.

## Why
The manifest `port` field should hold the internal container port. The container listens on 7860 (confirmed by compose port mapping, healthcheck, and `--listen-port 7860` launch arg). 7862 is the external/host-side default, correctly stored in `external_port_default`.

## How
Single line change in `manifest.yaml`. `external_port_default: 7862` unchanged.

## Scope
All changes within `resources/dev/extensions-library/services/text-generation-webui/manifest.yaml`.

## Testing
- YAML validation: passed
- Cross-checked port convention against ollama (11434), frigate (5000), immich (2283) — all use internal container port
- Critique Guardian: APPROVED

## Review
Critique Guardian verdict: APPROVED — correct per project convention, verified against compose/healthcheck/launch args.

Originally reported in yasinBursali/DreamServer#83

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.