### PR TITLE
fix(extensions-library): remove wildcard CORS from continue nginx config

### DIFF
--- a/resources/dev/extensions-library/services/continue/config/continue/nginx.conf
+++ b/resources/dev/extensions-library/services/continue/config/continue/nginx.conf
@@ -15,13 +15,11 @@ server {
     # Serve the pre-built config.yaml
     location /config.yaml {
         add_header Content-Type application/yaml;
-        add_header Access-Control-Allow-Origin *;
         try_files /config.yaml =404;
     }
 
     # Serve static assets (setup page, icons, etc.)
     location / {
         try_files $uri $uri/ /index.html;
-        add_header Access-Control-Allow-Origin *;
     }
 }


### PR DESCRIPTION
## What
Remove `Access-Control-Allow-Origin: *` from both `/config.yaml` and `/` locations in the Continue nginx config.

## Why
Wildcard CORS allowed any website to fetch `config.yaml` via JavaScript, exposing internal LLM API URLs and server topology. The Continue VS Code extension uses Node.js HTTP client (not browser fetch), so CORS headers are unnecessary.

## How
Removed 2 lines: `add_header Access-Control-Allow-Origin *;` from both location blocks.

## Scope
All changes within `resources/dev/extensions-library/services/continue/config/continue/nginx.conf`.

## Testing
- CORS headers confirmed absent from resulting file
- Nginx structure validated (all location blocks intact)
- Critique Guardian: APPROVED

## Review
Critique Guardian verdict: APPROVED — no functional impact on VS Code extension, meaningful security improvement.

Originally reported in yasinBursali/DreamServer#91

## Merge Order
- No conflicts with any other open PRs — can merge independently in any order.