### PR TITLE
fix(extensions-library): handle non-UTF-8 upstream responses in privacy shield proxy

### DIFF
--- a/resources/dev/extensions-library/services/privacy-shield/proxy.py
+++ b/resources/dev/extensions-library/services/privacy-shield/proxy.py
@@ -165,7 +165,7 @@ async def proxy(request: Request, path: str):
             )
         
         # Read response
-        response_body = resp.content.decode('utf-8')
+        response_body = resp.content.decode('utf-8', errors='replace')
         
         # Restore PII in response
         restored_body = shield.process_response(response_body)


### PR DESCRIPTION
## What
Add `errors='replace'` to `resp.content.decode('utf-8')` in the privacy shield proxy.

## Why
If the upstream LLM API returns binary content, non-UTF-8 encoding, or compressed error payloads, the proxy crashes with `UnicodeDecodeError` — returning an opaque 500 instead of passing through the response.

## How
Single-line change at `proxy.py:168`:
```python
# Before
response_body = resp.content.decode('utf-8')
# After
response_body = resp.content.decode('utf-8', errors='replace')
```

Invalid bytes are replaced with U+FFFD rather than crashing the proxy.

## Scope
All changes are within `resources/dev/extensions-library/services/privacy-shield/`.

## Testing
- Python syntax check passes
- Manual test: point proxy at a service returning non-UTF-8 bytes, verify no crash

## Review
Critique Guardian verdict: **APPROVED** — improves availability, no security regression.

## Merge Order
- **Merge after PR #524** (`ext/fix-privacy-shield-session`) — same file (`proxy.py`), different code area (session isolation vs decode handling). No logical conflict but textual overlap possible.
- No conflicts with other B2 PRs