### PR TITLE
fix(extensions-library): correct PII type extraction for multi-word types

### DIFF
--- a/resources/dev/extensions-library/services/privacy-shield/pii_scrubber.py
+++ b/resources/dev/extensions-library/services/privacy-shield/pii_scrubber.py
@@ -99,7 +99,8 @@ class PIIDetector:
         return {
             'unique_pii_count': len(self.pii_map),
             'pii_types': list(set(
-                token.split('_')[1] for token in self.pii_map.keys()
+                token.lstrip('<').split('_', 1)[1].rsplit('_', 1)[0]
+                for token in self.pii_map.keys()
             ))
         }
 


### PR DESCRIPTION
## What
Fix `get_stats()` in `pii_scrubber.py` to correctly extract multi-word PII type names.

## Why
`token.split('_')[1]` only gets the first word after the `PII_` prefix. For multi-word types like `api_key`, `ip_address`, `credit_card`, and `phone_number`, the stats endpoint returns truncated labels (`api`, `ip`, `credit`, `phone`).

## How
Replace the naive split with proper prefix/suffix stripping:
```python
# Before — breaks on multi-word types
token.split('_')[1]

# After — handles any type name correctly
token.lstrip('<').split('_', 1)[1].rsplit('_', 1)[0]
```

Token format is `<PII_{type}_{12hex}>`. The new code:
1. Strips the leading `<`
2. Splits on first `_` to skip `PII` prefix
3. Reverse-splits on last `_` to separate type from 12-char hex hash

Verified against all 6 PII types in `PATTERNS`: `email`, `phone`, `ssn`, `ip_address`, `api_key`, `credit_card`.

## Scope
All changes are within `resources/dev/extensions-library/services/privacy-shield/`.

## Testing
- Python syntax check passes
- Logic test with all PII types returns correct labels
- The 12-char hash is SHA256 hexdigest (`[0-9a-f]` only, no underscores), so `rsplit('_', 1)` is safe

## Review
Critique Guardian verdict: **APPROVED** — data integrity fix, mathematically correct.

## Merge Order
- No conflicts with any open PRs
- Can merge independently in any order