### PR TITLE
fix(extensions-library): sanitize stderr in open-interpreter HTTP 500 responses

### DIFF
--- a/resources/dev/extensions-library/services/open-interpreter/server.py
+++ b/resources/dev/extensions-library/services/open-interpreter/server.py
@@ -3,6 +3,7 @@
 
 import hmac
 import json
+import logging
 import os
 import re
 import subprocess
@@ -131,9 +132,13 @@ def chat(req: ChatRequest, _auth=Depends(verify_api_key)):
         )
 
         if result.returncode != 0:
+            logging.getLogger("open-interpreter").error(
+                "Interpreter subprocess failed (exit %d): %s",
+                result.returncode, result.stderr,
+            )
             raise HTTPException(
                 status_code=500,
-                detail=f"Interpreter error: {result.stderr}",
+                detail="Interpreter execution failed",
             )
 
         return {"output": result.stdout}


### PR DESCRIPTION
## What
Stop leaking raw subprocess stderr in HTTP 500 response bodies from the open-interpreter API.

## Why
When the interpreter subprocess fails, raw stderr (Python stack traces, file paths, installed package versions, potential credential fragments) was returned verbatim to any API caller — an information disclosure vulnerability.

## How
- Log the full stderr server-side via `logging.getLogger("open-interpreter").error(...)` for debugging
- Return only a generic message to the client: `"Interpreter execution failed"`

```python
# Before — leaks internals
detail=f"Interpreter error: {result.stderr}"

# After — logs internally, generic to client
logging.getLogger("open-interpreter").error(
    "Interpreter subprocess failed (exit %d): %s",
    result.returncode, result.stderr,
)
detail="Interpreter execution failed"
```

## Scope
All changes are within `resources/dev/extensions-library/services/open-interpreter/`.

## Testing
- Python syntax check passes
- Send a request causing subprocess failure → verify 500 body contains only generic message
- Verify server logs contain full error with exit code and stderr

## Review
Critique Guardian verdict: **APPROVED** — direct security improvement.

## Known Considerations
The streaming endpoint (`/chat/stream`) uses `stderr=subprocess.STDOUT` with an `SSE:` prefix filter that provides incidental protection. A future hardening pass should address that separately.

## Merge Order
- Independent of PR #532 (`ext/open-interpreter-pin-deps`) which touches only the Dockerfile
- No conflicts with other B2 PRs