### PR TITLE
fix(extensions-library): rename bark env_vars 'name' to 'key'

### DIFF
--- a/resources/dev/extensions-library/services/bark/manifest.yaml
+++ b/resources/dev/extensions-library/services/bark/manifest.yaml
@@ -17,13 +17,13 @@ service:
   category: optional
   depends_on: []
   env_vars:
-    - name: BARK_USE_SMALL_MODELS
+    - key: BARK_USE_SMALL_MODELS
       description: Use smaller/faster Bark models (less VRAM, slightly lower quality)
       default: "false"
-    - name: BARK_OFFLOAD_CPU
+    - key: BARK_OFFLOAD_CPU
       description: Offload Bark models to CPU between requests (reduces VRAM usage)
       default: "false"
-    - name: BARK_API_KEY
+    - key: BARK_API_KEY
       description: API key for Bark TTS service authentication (optional; leave empty to disable auth)
       default: ""
   description: |


### PR DESCRIPTION
## What
Renames the `name:` field to `key:` in all three bark manifest `env_vars` entries.

## Why
The `service-manifest.v1` schema requires `env_vars` items to use the `key` field (`required: ["key"]`, `additionalProperties: false`). Bark's manifest used `name:` instead, causing schema validation failures and preventing tooling from discovering bark's environment variables.

## How
Surgical rename of three lines in `services/bark/manifest.yaml`:
- `name: BARK_USE_SMALL_MODELS` → `key: BARK_USE_SMALL_MODELS`
- `name: BARK_OFFLOAD_CPU` → `key: BARK_OFFLOAD_CPU`
- `name: BARK_API_KEY` → `key: BARK_API_KEY`

## Scope
All changes within `resources/dev/extensions-library/services/bark/`.

## Testing
- Schema validation passes (`jsonschema` against `service-manifest.v1.json`)
- Verified all other manifests already use `key:` — bark was the only offender
- No compose or runtime changes

## Merge Order
No dependencies on other open PRs. Can merge independently.