### PR TITLE
fix(extensions-library): add missing required fields to localai features

### DIFF
--- a/resources/dev/extensions-library/services/localai/manifest.yaml
+++ b/resources/dev/extensions-library/services/localai/manifest.yaml
@@ -21,20 +21,50 @@ features:
   - id: text-generation
     name: Text Generation
     description: Generate text with local LLMs via OpenAI-compatible API
-    vram_mb: 4096
+    icon: MessageSquare
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 4
+    enabled_services_all: [localai]
+    priority: 5
   - id: image-generation
     name: Image Generation
     description: Generate images with local diffusion models
-    vram_mb: 8192
+    icon: Image
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 8
+    enabled_services_all: [localai]
+    priority: 6
   - id: audio-generation
     name: Audio Generation
     description: Generate audio with local models
-    vram_mb: 4096
+    icon: Music
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 4
+    enabled_services_all: [localai]
+    priority: 7
   - id: video-generation
     name: Video Generation
     description: Generate video with local models
-    vram_mb: 16384
+    icon: Video
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 16
+    enabled_services_all: [localai]
+    priority: 8
   - id: voice-cloning
     name: Voice Cloning
     description: Clone voices for TTS with local models
-    vram_mb: 4096
+    icon: Mic
+    category: voice
+    requirements:
+      services: [localai]
+      vram_gb: 4
+    enabled_services_all: [localai]
+    priority: 9


### PR DESCRIPTION
## What
Adds the 4 missing required fields (`icon`, `category`, `requirements`, `priority`) to all 5 localai feature items and adds `enabled_services_all` for peer consistency.

## Why
The `service-manifest.v1` schema requires feature items to have `id`, `name`, `description`, `icon`, `category`, `requirements`, and `priority`. Localai's features only had `id`, `name`, `description`, and a top-level `vram_mb` — causing schema validation failures and preventing dashboard/CLI from rendering feature cards correctly.

## How
For each of the 5 features (`text-generation`, `image-generation`, `audio-generation`, `video-generation`, `voice-cloning`):
- Added `icon` (MessageSquare, Image, Music, Video, Mic)
- Added `category` (ai or voice)
- Moved `vram_mb` into `requirements` block as `vram_gb` (converted: 4096→4, 8192→8, 16384→16) to match production code expectations (`features.py` reads `vram_gb`)
- Added `priority` (5–9)
- Added `enabled_services_all: [localai]` matching peer manifests

## Scope
All changes within `resources/dev/extensions-library/services/localai/`.

## Testing
- Schema validation passes
- All features use `vram_gb` (not `vram_mb`) — verified no occurrences of `vram_mb` remain
- Values checked against peer manifests (open-interpreter, rvc)

## Merge Order
No dependencies on other open PRs. Can merge independently.