### PR TITLE
fix(extensions-library): declare required API keys in weaviate and open-interpreter manifests

### DIFF
--- a/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
@@ -16,6 +16,11 @@ service:
   category: optional
   depends_on: []
   compose_file: compose.yaml
+  env_vars:
+    - key: OPEN_INTERPRETER_API_KEY
+      description: API key for Open Interpreter authentication (required — compose will fail without it)
+      required: true
+      secret: true
   description: |
     Open Interpreter lets LLMs run code locally (Python, JavaScript, Shell, etc.).
     It provides a ChatGPT-like interface in your terminal and can control Chrome,

--- a/resources/dev/extensions-library/services/weaviate/manifest.yaml
+++ b/resources/dev/extensions-library/services/weaviate/manifest.yaml
@@ -16,7 +16,11 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
-  env_vars: []
+  env_vars:
+    - key: WEAVIATE_API_KEY
+      description: API key for Weaviate authentication (required — compose will fail without it)
+      required: true
+      secret: true
   description: |
     Weaviate is an open-source vector database that stores both objects and vectors.
     Supports semantic search, hybrid search, structured filtering, and multi-tenancy.


### PR DESCRIPTION
## What
Adds missing `env_vars` entries for required API keys in weaviate and open-interpreter manifests.

## Why
Both services use Docker's `:?` syntax to require API keys at startup (`WEAVIATE_API_KEY` and `OPEN_INTERPRETER_API_KEY`), but neither manifest declared these in `env_vars`. Setup wizards and CLIs reading manifests had no way to prompt users for these keys, causing cryptic Docker failures like `WEAVIATE_API_KEY must be set`.

## How
- **weaviate/manifest.yaml**: Replaced `env_vars: []` with `WEAVIATE_API_KEY` entry (`required: true`, `secret: true`)
- **open-interpreter/manifest.yaml**: Added `env_vars` section with `OPEN_INTERPRETER_API_KEY` entry (`required: true`, `secret: true`)

Both entries include descriptive text explaining the key is required and compose will fail without it.

## Scope
All changes within `resources/dev/extensions-library/services/weaviate/` and `resources/dev/extensions-library/services/open-interpreter/`.

## Testing
- Schema validation passes for both manifests
- Verified compose files — only `:?` variables are the two declared keys; other env vars use `:-` (optional defaults) and don't need manifest entries
- No compose or runtime changes

## Merge Order
No dependencies on other open PRs. Can merge independently.