### PR TITLE
fix(extensions-library): add enabled: false flag to jan manifest

### DIFF
--- a/resources/dev/extensions-library/services/jan/manifest.yaml
+++ b/resources/dev/extensions-library/services/jan/manifest.yaml
@@ -14,6 +14,7 @@ service:
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml.disabled
+  enabled: false
   category: optional
   depends_on: []
   env_vars: []


### PR DESCRIPTION
## What
Adds `enabled: false` to the jan service manifest.

## Why
The jan service has `compose_file: compose.yaml.disabled` but no explicit flag indicating the service is not deployable. Service discovery tooling would list jan as available, then fail when trying to use the non-standard compose file extension.

## How
Added `enabled: false` to the service section of `services/jan/manifest.yaml`, positioned after the `compose_file` field. The schema allows this (`additionalProperties: true` on the service object).

**Note:** This field is currently metadata for human readers and future tooling. No existing consumer code reads `enabled:` from manifests today — the `.disabled` file extension remains the operational mechanism. This change makes the intent explicit and machine-readable for when service discovery is enhanced.

## Scope
All changes within `resources/dev/extensions-library/services/jan/`.

## Testing
- Schema validation passes
- Single line addition, no runtime impact

## Merge Order
No dependencies on other open PRs. Can merge independently.