### PR TITLE
fix(installer): distro-native Docker install + PyYAML for Arch/Void/Alpine

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -75,7 +75,12 @@ source "$SCRIPT_DIR/installers/lib/packaging.sh"
 source "$SCRIPT_DIR/installers/lib/progress.sh"
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
     source "$SCRIPT_DIR/lib/service-registry.sh" 
-    sr_load 
+    sr_load
+    if [[ "${_SR_FAILED:-}" == "true" ]]; then
+        warn "Service registry failed to load. Will retry after dependencies are installed."
+        _SR_LOADED=false
+        _SR_FAILED=false
+    fi
 fi
 
 #=============================================================================

--- a/dream-server/installers/lib/packaging.sh
+++ b/dream-server/installers/lib/packaging.sh
@@ -131,12 +131,14 @@ pkg_resolve() {
         apt)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose-plugin" ;;
+                python3-pyyaml)        echo "python3-yaml" ;;
                 *) echo "$canonical" ;;
             esac
             ;;
         dnf)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose-plugin" ;;
+                python3-pyyaml)        echo "python3-pyyaml" ;;
                 build-essential)       echo "gcc gcc-c++ make" ;;
                 *) echo "$canonical" ;;
             esac
@@ -144,6 +146,7 @@ pkg_resolve() {
         pacman)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose" ;;
+                python3-pyyaml)        echo "python-yaml" ;;
                 build-essential)       echo "base-devel" ;;
                 *) echo "$canonical" ;;
             esac
@@ -151,6 +154,7 @@ pkg_resolve() {
         zypper)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose" ;;
+                python3-pyyaml)        echo "python3-PyYAML" ;;
                 build-essential)       echo "devel_basis" ;;
                 *) echo "$canonical" ;;
             esac
@@ -158,6 +162,7 @@ pkg_resolve() {
         xbps)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-compose" ;;
+                python3-pyyaml)        echo "python3-yaml" ;;
                 build-essential)       echo "base-devel" ;;
                 *) echo "$canonical" ;;
             esac
@@ -165,6 +170,7 @@ pkg_resolve() {
         apk)
             case "$canonical" in
                 docker-compose-plugin) echo "docker-cli-compose" ;;
+                python3-pyyaml)        echo "py3-yaml" ;;
                 build-essential)       echo "build-base" ;;
                 *) echo "$canonical" ;;
             esac

--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -57,12 +57,42 @@ else
     if $DRY_RUN; then
         log "[DRY RUN] Would install Docker via official script"
     else
-        tmpfile=$(mktemp /tmp/install-docker.XXXXXX.sh)
-        if ! curl -fsSL --max-time 300 https://get.docker.com -o "$tmpfile" || ! sh "$tmpfile"; then
-            rm -f "$tmpfile"
-            error "Docker installation failed. Check network connectivity and try again."
-        fi
-        rm -f "$tmpfile"
+        case "$PKG_MANAGER" in
+            apt|dnf|zypper)
+                # Docker CE via get.docker.com (supports Debian/Ubuntu/Fedora/RHEL/SLES)
+                tmpfile=$(mktemp /tmp/install-docker.XXXXXX.sh)
+                if ! curl -fsSL --max-time 300 https://get.docker.com -o "$tmpfile" || ! sh "$tmpfile"; then
+                    rm -f "$tmpfile"
+                    error "Docker installation failed. Check network connectivity and try again."
+                fi
+                rm -f "$tmpfile"
+                ;;
+            pacman)
+                # Arch/Manjaro/CachyOS/EndeavourOS -- Docker is in the official repos
+                pkg_install docker
+                sudo systemctl enable --now docker.service 2>>"$LOG_FILE" || true
+                ;;
+            xbps)
+                # Void Linux -- runit service management
+                pkg_install docker
+                sudo ln -s /etc/sv/docker /var/service/ 2>/dev/null || true
+                ;;
+            apk)
+                # Alpine -- OpenRC service management
+                pkg_install docker
+                sudo rc-update add docker boot 2>>"$LOG_FILE" || true
+                sudo service docker start 2>>"$LOG_FILE" || true
+                ;;
+            *)
+                # Unknown distro -- try get.docker.com as best-effort fallback
+                tmpfile=$(mktemp /tmp/install-docker.XXXXXX.sh)
+                if ! curl -fsSL --max-time 300 https://get.docker.com -o "$tmpfile" || ! sh "$tmpfile"; then
+                    rm -f "$tmpfile"
+                    error "Docker installation failed. Your distro (${DISTRO_ID:-unknown}) may not be supported. Install Docker manually and re-run with --skip-docker."
+                fi
+                rm -f "$tmpfile"
+                ;;
+        esac
 
         # Add the invoking user (not root) to the docker group
         target_user="${SUDO_USER:-$USER}"

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -4,6 +4,7 @@
 
 EXTENSIONS_DIR="${SCRIPT_DIR:-$(pwd)}/extensions/services"
 _SR_LOADED=false
+_SR_FAILED=false
 _SR_CACHE="/tmp/dream-service-registry.$$.sh"
 
 # Caching for compose flags (session-level)
@@ -43,7 +44,24 @@ sr_load() {
         PYTHON_CMD="python"
     fi
 
-    "$PYTHON_CMD" - "$EXTENSIONS_DIR" <<'PYEOF' > "$_SR_CACHE"
+    # Ensure PyYAML is available (Arch, Void, Alpine don't ship it by default)
+    if ! "$PYTHON_CMD" -c "import yaml" 2>/dev/null; then
+        if declare -f pkg_install &>/dev/null && declare -f pkg_resolve &>/dev/null; then
+            [[ -z "${PKG_MANAGER:-}" ]] && declare -f detect_pkg_manager &>/dev/null && detect_pkg_manager
+            declare -f log &>/dev/null && log "PyYAML not found; installing system package..."
+            # shellcheck disable=SC2046
+            pkg_install $(pkg_resolve python3-pyyaml) 2>>"${LOG_FILE:-/dev/null}" || true
+        fi
+        if ! "$PYTHON_CMD" -c "import yaml" 2>/dev/null; then
+            declare -f warn &>/dev/null && warn "PyYAML not available. Service registry will be incomplete."
+            declare -f warn &>/dev/null && warn "Install manually: pip3 install pyyaml"
+            _SR_LOADED=true  # Prevent repeated retries
+            _SR_FAILED=true
+            return 0
+        fi
+    fi
+
+    if ! "$PYTHON_CMD" - "$EXTENSIONS_DIR" <<'PYEOF' > "$_SR_CACHE"
 import yaml, sys, os
 from pathlib import Path
 
@@ -151,6 +169,13 @@ for service_dir in sorted(ext_dir.iterdir()):
         print(f'# ERROR: failed to parse {manifest_path}: {exc}', file=sys.stderr)
         continue
 PYEOF
+    then
+        rm -f "$_SR_CACHE"
+        declare -f warn &>/dev/null && warn "Service registry: manifest parser failed"
+        _SR_LOADED=true  # Prevent repeated retries
+        _SR_FAILED=true
+        return 0
+    fi
 
     # Source the generated registry (one subprocess for all manifests)
     [[ -f "$_SR_CACHE" ]] && . "$_SR_CACHE"


### PR DESCRIPTION
## Summary

- **Fixes #546** — Docker installation fails on Arch Linux with `ERROR: Unsupported distribution 'arch'`
- **Fixes #545** — `ModuleNotFoundError: No module named 'yaml'` on Arch Linux

Both bugs share the same root cause: the installer assumes Debian/Fedora defaults and doesn't use its own distro-aware packaging abstraction (`packaging.sh`) for Docker installation and PyYAML dependency management. Arch, Void, and Alpine are all affected.

## Changes

### Docker install — `05-docker.sh` (+42/-7)
The installer unconditionally used `get.docker.com`, which only supports Debian/Ubuntu/Fedora/RHEL/SLES. Added a `case "$PKG_MANAGER"` dispatch:

| Package manager | Distros | Install method |
|---|---|---|
| `apt\|dnf\|zypper` | Ubuntu, Debian, Fedora, RHEL, openSUSE | `get.docker.com` **(unchanged)** |
| `pacman` | Arch, Manjaro, CachyOS, EndeavourOS | `pkg_install docker` + systemd enable |
| `xbps` | Void Linux | `pkg_install docker` + runit service link |
| `apk` | Alpine | `pkg_install docker` + OpenRC enable |
| `*` | Unknown | `get.docker.com` fallback with improved error |

Follows the same pattern already used for NVIDIA Container Toolkit (lines 310-352 of the same file).

### PyYAML dependency — `service-registry.sh`, `packaging.sh`, `install-core.sh` (+33/-1)
The service registry's Python manifest parser (`sr_load`) requires PyYAML, which Debian/Fedora ship by default but Arch/Void/Alpine do not.

- Added `python3-pyyaml` canonical name to `pkg_resolve()` for all 6 package managers
- `sr_load()` now checks `python3 -c "import yaml"` before running the parser
- Auto-installs the correct package when packaging functions are available (installer context)
- Uses `declare -f` guards so dream-cli (which doesn't load `packaging.sh`) isn't affected
- **Bonus fix:** The original heredoc pattern silently swallowed Python failures — `_SR_LOADED=true` was set even when Python crashed, leaving `SERVICE_*` arrays empty for the rest of the install. Now wrapped in `if !` to detect failure, with `_SR_FAILED` flag for the caller to check.

### Regression safety
- `apt|dnf|zypper` Docker path is the **exact same code** — zero change for Ubuntu/Debian/Fedora/RHEL
- PyYAML check is a **no-op** on distros where it's already installed (the `import yaml` succeeds, entire block skipped)
- `dream-cli` never crashes — `sr_load` always returns 0, signals failure via `_SR_FAILED` flag
- All 4 files pass `bash -n` syntax validation

## Test plan

- [ ] **Ubuntu/Debian regression**: Run installer — confirm `get.docker.com` is used, no PyYAML install attempt
- [ ] **Fedora/RHEL regression**: Same as above
- [ ] **Arch Linux (#546)**: Fresh install — confirm `pacman -S docker` and `systemctl enable --now docker.service`
- [ ] **Arch Linux (#545)**: Fresh install — confirm `pacman -S python-yaml`, `sr_load` succeeds, health checks use correct ports
- [ ] **`--skip-docker`**: Confirm Docker install block is entirely skipped
- [ ] **`--dry-run`**: Confirm dry-run logging works
- [ ] **`dream-cli status`**: Confirm service registry loads correctly post-install
- [ ] **`make lint && make test`**: No shell syntax or contract violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)