### PR TITLE
fix(extensions-library): bulk manifest corrections across 19 services

### DIFF
--- a/resources/dev/extensions-library/services/aider/manifest.yaml
+++ b/resources/dev/extensions-library/services/aider/manifest.yaml
@@ -38,4 +38,3 @@ features:
     enabled_services_all: [aider]
     setup_time: ~1 minute
     priority: 11
-    gpu_backends: []

--- a/resources/dev/extensions-library/services/anythingllm/manifest.yaml
+++ b/resources/dev/extensions-library/services/anythingllm/manifest.yaml
@@ -14,6 +14,7 @@ service:
   type: docker
   gpu_backends: [nvidia, amd]
   category: optional
+  compose_file: compose.yaml
   depends_on: [ollama]
   description: |
     All-in-one AI productivity tool for RAG chat with documents.

--- a/resources/dev/extensions-library/services/bark/manifest.yaml
+++ b/resources/dev/extensions-library/services/bark/manifest.yaml
@@ -36,17 +36,6 @@ service:
 
     Note: First startup downloads ~5GB of models. Subsequent starts are fast.
 
-  features:
-    expressive-tts:
-      description: Highly realistic speech with laughter, sighs, and emotion
-      vram_required_mb: 4000
-    multilingual:
-      description: 13 language voice presets (English, German, Spanish, French, etc.)
-      vram_required_mb: 4000
-    sound-effects:
-      description: Generate music snippets and ambient sound effects
-      vram_required_mb: 4000
-
   tags:
     - tts
     - voice
@@ -55,3 +44,41 @@ service:
     - multilingual
     - expressive
     - suno
+
+features:
+  - id: expressive-tts
+    name: Expressive TTS
+    description: Highly realistic speech with laughter, sighs, and emotion
+    icon: Volume2
+    category: voice
+    requirements:
+      services: [bark]
+      vram_gb: 4
+    enabled_services_all: [bark]
+    setup_time: ~2 minutes
+    priority: 16
+    gpu_backends: [nvidia]
+  - id: multilingual
+    name: Multilingual
+    description: 13 language voice presets (English, German, Spanish, French, etc.)
+    icon: Globe
+    category: voice
+    requirements:
+      services: [bark]
+      vram_gb: 4
+    enabled_services_all: [bark]
+    setup_time: ~2 minutes
+    priority: 17
+    gpu_backends: [nvidia]
+  - id: sound-effects
+    name: Sound Effects
+    description: Generate music snippets and ambient sound effects
+    icon: Music
+    category: voice
+    requirements:
+      services: [bark]
+      vram_gb: 4
+    enabled_services_all: [bark]
+    setup_time: ~2 minutes
+    priority: 18
+    gpu_backends: [nvidia]

--- a/resources/dev/extensions-library/services/baserow/manifest.yaml
+++ b/resources/dev/extensions-library/services/baserow/manifest.yaml
@@ -12,27 +12,14 @@ service:
   external_port_default: 3006
   health: /api/_health/
   type: docker
-  gpu_backends: [none]
   category: optional
+  compose_file: compose.yaml
   depends_on: []
   description: |
     Open-source no-code database tool and Airtable alternative.
     Create databases, tables, and views with a spreadsheet-like interface.
     Self-hosted with no storage restrictions. MIT licensed.
   
-  features:
-    database:
-      description: No-code database with spreadsheet interface
-      vram_required_mb: 0
-    views:
-      description: Grid, gallery, form, and calendar views
-      vram_required_mb: 0
-    api:
-      description: Headless REST API for all data
-      vram_required_mb: 0
-    collaboration:
-      description: Real-time collaboration and permissions
-      vram_required_mb: 0
     
   tags:
     - database
@@ -41,3 +28,49 @@ service:
     - spreadsheet
     - collaboration
     - productivity
+
+features:
+  - id: database
+    name: No-Code Database
+    description: No-code database with spreadsheet interface
+    icon: Database
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 16
+  - id: views
+    name: Multiple Views
+    description: Grid, gallery, form, and calendar views
+    icon: LayoutGrid
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 17
+  - id: api
+    name: REST API
+    description: Headless REST API for all data
+    icon: Globe
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 18
+  - id: collaboration
+    name: Collaboration
+    description: Real-time collaboration and permissions
+    icon: Users
+    category: productivity
+    requirements:
+      services: [baserow]
+      vram_gb: 0
+    enabled_services_all: [baserow]
+    setup_time: ~1 minute
+    priority: 19

--- a/resources/dev/extensions-library/services/chromadb/manifest.yaml
+++ b/resources/dev/extensions-library/services/chromadb/manifest.yaml
@@ -30,4 +30,3 @@ features:
     enabled_services_all: [chromadb]
     setup_time: ~1 minute
     priority: 9
-    gpu_backends: []

--- a/resources/dev/extensions-library/services/crewai/manifest.yaml
+++ b/resources/dev/extensions-library/services/crewai/manifest.yaml
@@ -12,7 +12,6 @@ service:
   external_port_default: 8501
   health: /
   type: docker
-  gpu_backends: [none]
   category: optional
   depends_on: []
   env_vars: []
@@ -23,23 +22,6 @@ service:
     complex problems. Perfect for building agent teams that simulate real-world
     collaboration and decision-making.
 
-  features:
-    multi-agent:
-      description: Teams of autonomous AI agents working together
-      vram_required_mb: 0
-    task-delegation:
-      description: Automatic task distribution between agents
-      vram_required_mb: 0
-    sequential-process:
-      description: Step-by-step task execution with defined order
-      vram_required_mb: 0
-    hierarchical-process:
-      description: Manager-led coordination with validation
-      vram_required_mb: 0
-    flows:
-      description: Event-driven workflows for complex automations
-      vram_required_mb: 0
-
   tags:
     - multi-agent
     - orchestration
@@ -47,3 +29,60 @@ service:
     - autonomous-agents
     - workflow
     - python
+
+features:
+  - id: multi-agent
+    name: Multi-Agent Teams
+    description: Teams of autonomous AI agents working together
+    icon: Users
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 16
+  - id: task-delegation
+    name: Task Delegation
+    description: Automatic task distribution between agents
+    icon: GitBranch
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 17
+  - id: sequential-process
+    name: Sequential Process
+    description: Step-by-step task execution with defined order
+    icon: ListOrdered
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 18
+  - id: hierarchical-process
+    name: Hierarchical Process
+    description: Manager-led coordination with validation
+    icon: GitBranch
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 19
+  - id: flows
+    name: Event-Driven Flows
+    description: Event-driven workflows for complex automations
+    icon: Workflow
+    category: ai
+    requirements:
+      services: [crewai]
+      vram_gb: 0
+    enabled_services_all: [crewai]
+    setup_time: ~1 minute
+    priority: 20

--- a/resources/dev/extensions-library/services/flowise/manifest.yaml
+++ b/resources/dev/extensions-library/services/flowise/manifest.yaml
@@ -14,6 +14,7 @@ service:
   type: docker
   gpu_backends: [amd, nvidia, apple]
   category: optional
+  compose_file: compose.yaml
   depends_on: []
   description: |
     Visual LLM workflow builder with drag-and-drop interface.

--- a/resources/dev/extensions-library/services/forge/manifest.yaml
+++ b/resources/dev/extensions-library/services/forge/manifest.yaml
@@ -14,25 +14,12 @@ service:
   type: docker
   gpu_backends: [nvidia]
   category: optional
+  compose_file: compose.yaml
   depends_on: []
   description: |
     Forge (based on Automatic1111) is the original Stable Diffusion web UI.
     Features extensive model support, extensions, inpainting, outpainting,
     and professional-grade image generation capabilities. GPU required.
-
-  features:
-    image-generation:
-      description: Full Stable Diffusion control with advanced settings
-      vram_required_mb: 8192
-    inpainting:
-      description: Inpainting with mask support
-      vram_required_mb: 8192
-    outpainting:
-      description: Outpainting beyond image boundaries
-      vram_required_mb: 8192
-    upscaling:
-      description: High-resolution upscaling with multiple engines
-      vram_required_mb: 4096
 
   tags:
     - image
@@ -40,3 +27,53 @@ service:
     - webui
     - generative
     - professional
+
+features:
+  - id: image-generation
+    name: Image Generation
+    description: Full Stable Diffusion control with advanced settings
+    icon: Image
+    category: media
+    requirements:
+      services: [forge]
+      vram_gb: 8
+    enabled_services_all: [forge]
+    setup_time: ~3 minutes
+    priority: 16
+    gpu_backends: [nvidia]
+  - id: inpainting
+    name: Inpainting
+    description: Inpainting with mask support
+    icon: Paintbrush
+    category: media
+    requirements:
+      services: [forge]
+      vram_gb: 8
+    enabled_services_all: [forge]
+    setup_time: ~3 minutes
+    priority: 17
+    gpu_backends: [nvidia]
+  - id: outpainting
+    name: Outpainting
+    description: Outpainting beyond image boundaries
+    icon: Maximize
+    category: media
+    requirements:
+      services: [forge]
+      vram_gb: 8
+    enabled_services_all: [forge]
+    setup_time: ~3 minutes
+    priority: 18
+    gpu_backends: [nvidia]
+  - id: upscaling
+    name: Upscaling
+    description: High-resolution upscaling with multiple engines
+    icon: ArrowUp
+    category: media
+    requirements:
+      services: [forge]
+      vram_gb: 4
+    enabled_services_all: [forge]
+    setup_time: ~3 minutes
+    priority: 19
+    gpu_backends: [nvidia]

--- a/resources/dev/extensions-library/services/frigate/manifest.yaml
+++ b/resources/dev/extensions-library/services/frigate/manifest.yaml
@@ -22,20 +22,6 @@ service:
     local object detection for IP cameras. It uses AI to detect people,
     vehicles, and other objects without sending video to the cloud.
 
-  features:
-    object-detection:
-      description: Real-time AI object detection on camera streams
-      vram_required_mb: 512
-    recording:
-      description: Continuous or event-based video recording
-      vram_required_mb: 0
-    notifications:
-      description: Alerts when objects are detected
-      vram_required_mb: 0
-    restreaming:
-      description: RTSP/WebRTC restreaming of camera feeds
-      vram_required_mb: 0
-
   tags:
     - nvr
     - camera
@@ -43,3 +29,53 @@ service:
     - object-detection
     - surveillance
     - video
+
+features:
+  - id: object-detection
+    name: Object Detection
+    description: Real-time AI object detection on camera streams
+    icon: Eye
+    category: security
+    requirements:
+      services: [frigate]
+      vram_gb: 1
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    priority: 16
+    gpu_backends: [nvidia]
+  - id: recording
+    name: Recording
+    description: Continuous or event-based video recording
+    icon: Video
+    category: security
+    requirements:
+      services: [frigate]
+      vram_gb: 0
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    priority: 17
+    gpu_backends: [nvidia]
+  - id: notifications
+    name: Notifications
+    description: Alerts when objects are detected
+    icon: Bell
+    category: security
+    requirements:
+      services: [frigate]
+      vram_gb: 0
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    priority: 18
+    gpu_backends: [nvidia]
+  - id: restreaming
+    name: Restreaming
+    description: RTSP/WebRTC restreaming of camera feeds
+    icon: Cast
+    category: security
+    requirements:
+      services: [frigate]
+      vram_gb: 0
+    enabled_services_all: [frigate]
+    setup_time: ~2 minutes
+    priority: 19
+    gpu_backends: [nvidia]

--- a/resources/dev/extensions-library/services/gitea/manifest.yaml
+++ b/resources/dev/extensions-library/services/gitea/manifest.yaml
@@ -12,7 +12,6 @@ service:
   external_port_default: 7830
   health: /api/healthz
   type: docker
-  gpu_backends: []
   compose_file: compose.yaml
   category: optional
   depends_on: []

--- a/resources/dev/extensions-library/services/label-studio/manifest.yaml
+++ b/resources/dev/extensions-library/services/label-studio/manifest.yaml
@@ -12,7 +12,6 @@ service:
   external_port_default: 8086
   health: /health
   type: docker
-  gpu_backends: [none]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -33,7 +32,6 @@ features:
     enabled_services_all: [label-studio]
     setup_time: ~1 minute
     priority: 15
-    gpu_backends: []
 
 tags:
   - labeling

--- a/resources/dev/extensions-library/services/langflow/manifest.yaml
+++ b/resources/dev/extensions-library/services/langflow/manifest.yaml
@@ -14,6 +14,7 @@ service:
   type: docker
   gpu_backends: [amd, nvidia, apple]
   category: optional
+  compose_file: compose.yaml
   depends_on: []
   description: |
     Langflow is a visual LLM workflow builder that lets you create

--- a/resources/dev/extensions-library/services/librechat/manifest.yaml
+++ b/resources/dev/extensions-library/services/librechat/manifest.yaml
@@ -14,6 +14,7 @@ service:
   type: docker
   gpu_backends: [amd, nvidia, apple]
   category: optional
+  compose_file: compose.yaml
   depends_on: []
   description: |
     LibreChat is an enhanced ChatGPT clone with multi-LLM support,

--- a/resources/dev/extensions-library/services/milvus/manifest.yaml
+++ b/resources/dev/extensions-library/services/milvus/manifest.yaml
@@ -12,7 +12,6 @@ service:
   external_port_default: 19530
   health: /healthz
   type: docker
-  gpu_backends: [none]
   compose_file: compose.yaml
   category: recommended
   depends_on: []

--- a/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
@@ -12,7 +12,6 @@ service:
   external_port_default: 7805
   health: /health
   type: docker
-  gpu_backends: [none]
   category: optional
   depends_on: []
   compose_file: compose.yaml

--- a/resources/dev/extensions-library/services/paperless-ngx/manifest.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/manifest.yaml
@@ -12,7 +12,6 @@ service:
   external_port_default: 7807
   health: /accounts/login/
   type: docker
-  gpu_backends: [none]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -22,20 +21,6 @@ service:
     documents into a searchable online archive. OCR, tagging, automatic
     classification, and full-text search for PDFs and images.
 
-  features:
-    ocr:
-      description: Automatic OCR for scanned PDFs and images
-      vram_required_mb: 0
-    document-tags:
-      description: Auto and manual tagging for organization
-      vram_required_mb: 0
-    fulltext-search:
-      description: Search inside all your documents
-      vram_required_mb: 0
-    email-import:
-      description: Import documents via email
-      vram_required_mb: 0
-
   tags:
     - documents
     - ocr
@@ -43,3 +28,49 @@ service:
     - pdf
     - search
     - productivity
+
+features:
+  - id: ocr
+    name: OCR
+    description: Automatic OCR for scanned PDFs and images
+    icon: FileText
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 16
+  - id: document-tags
+    name: Document Tags
+    description: Auto and manual tagging for organization
+    icon: Tag
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 17
+  - id: fulltext-search
+    name: Full-Text Search
+    description: Search inside all your documents
+    icon: Search
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 18
+  - id: email-import
+    name: Email Import
+    description: Import documents via email
+    icon: Mail
+    category: productivity
+    requirements:
+      services: [paperless-ngx]
+      vram_gb: 0
+    enabled_services_all: [paperless-ngx]
+    setup_time: ~1 minute
+    priority: 19

--- a/resources/dev/extensions-library/services/piper-audio/manifest.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/manifest.yaml
@@ -33,4 +33,3 @@ features:
     enabled_services_all: [piper-audio]
     setup_time: ~1 minute
     priority: 10
-    gpu_backends: []

--- a/resources/dev/extensions-library/services/sillytavern/manifest.yaml
+++ b/resources/dev/extensions-library/services/sillytavern/manifest.yaml
@@ -30,4 +30,3 @@ features:
     enabled_services_all: [sillytavern]
     setup_time: ~1 minute
     priority: 6
-    gpu_backends: []

--- a/resources/dev/extensions-library/services/weaviate/manifest.yaml
+++ b/resources/dev/extensions-library/services/weaviate/manifest.yaml
@@ -12,7 +12,6 @@ service:
   external_port_default: 7811
   health: /v1/.well-known/ready
   type: docker
-  gpu_backends: [none]
   compose_file: compose.yaml
   category: optional
   depends_on: []
@@ -22,17 +21,6 @@ service:
     Supports semantic search, hybrid search, structured filtering, and multi-tenancy.
     A cloud-native alternative to ChromaDB with gRPC support and horizontal scaling.
 
-  features:
-    vector-search:
-      description: Semantic similarity search with vector embeddings
-      vram_required_mb: 0
-    hybrid-search:
-      description: Combine vector similarity with keyword matching
-      vram_required_mb: 0
-    multi-tenancy:
-      description: Isolated data spaces for different users/organizations
-      vram_required_mb: 0
-
   tags:
     - vector-database
     - semantic-search
@@ -40,3 +28,38 @@ service:
     - open-source
     - scalable
     - local
+
+features:
+  - id: vector-search
+    name: Vector Search
+    description: Semantic similarity search with vector embeddings
+    icon: Search
+    category: data
+    requirements:
+      services: [weaviate]
+      vram_gb: 0
+    enabled_services_all: [weaviate]
+    setup_time: ~1 minute
+    priority: 16
+  - id: hybrid-search
+    name: Hybrid Search
+    description: Combine vector similarity with keyword matching
+    icon: Filter
+    category: data
+    requirements:
+      services: [weaviate]
+      vram_gb: 0
+    enabled_services_all: [weaviate]
+    setup_time: ~1 minute
+    priority: 17
+  - id: multi-tenancy
+    name: Multi-Tenancy
+    description: Isolated data spaces for different users/organizations
+    icon: Users
+    category: data
+    requirements:
+      services: [weaviate]
+      vram_gb: 0
+    enabled_services_all: [weaviate]
+    setup_time: ~1 minute
+    priority: 18


### PR DESCRIPTION
## What
Bulk corrections to 19 service manifests fixing three categories of issues:
invalid `gpu_backends` values, malformed feature declarations, and missing
`compose_file` fields.

## Why
Several manifests contain schema-invalid data that breaks validation:
- `gpu_backends: [none]` and `gpu_backends: []` are not valid enum values
  (schema allows: amd, nvidia, apple, all)
- Features declared as dicts nested under `service:` instead of top-level
  arrays are invisible to consumers
- Missing `compose_file` prevents the compose resolver from locating service
  compose files

## How

**A. Remove invalid gpu_backends (8 service-level + 5 feature-level)**
Services: aider, baserow, chromadb, crewai, gitea, label-studio, milvus,
open-interpreter, paperless-ngx, piper-audio, sillytavern, weaviate

**B. Convert nested dict features → top-level array (7 services)**
Services: bark, baserow, crewai, forge, frigate, paperless-ngx, weaviate
Each converted feature includes all schema-required fields (id, name,
description, icon, category, requirements, priority). GPU services include
`gpu_backends` on every feature matching the service-level declaration.

**C. Add missing compose_file (4 services)**
Services: anythingllm, flowise, langflow, librechat

## Scope
All changes are within `resources/dev/extensions-library/services/`.

## Testing
- All 33 manifests parse as valid YAML
- All converted features pass schema required-fields check against
  `service-manifest.v1.json`
- No remaining invalid `gpu_backends` values in any manifest
- No remaining nested dict features under `service:`
- No remaining services with `compose.yaml` missing `compose_file`
- No secrets in diff

## Merging Order
This PR can be merged independently. If any of the following PRs merge first,
a minor rebase may be needed (they touch different sections of overlapping files):
- #547 (bark env_vars)
- #549 (weaviate + open-interpreter env_vars)
- #537 (paperless-ngx depends_on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)