### PR TITLE
fix(extensions-library): remove invalid depends_on from librechat manifest

### DIFF
--- a/resources/dev/extensions-library/services/librechat/manifest.yaml
+++ b/resources/dev/extensions-library/services/librechat/manifest.yaml
@@ -14,7 +14,7 @@ service:
   type: docker
   gpu_backends: [amd, nvidia, apple]
   category: optional
-  depends_on: [librechat-mongodb, librechat-meilisearch]
+  depends_on: []
   description: |
     LibreChat is an enhanced ChatGPT clone with multi-LLM support,
     agents, RAG, and file uploads. Supports OpenAI, Anthropic, Google,


### PR DESCRIPTION
## What
Remove `librechat-mongodb` and `librechat-meilisearch` from the librechat manifest's `depends_on` field.

## Why
These are internal Docker Compose service names defined within librechat's own `compose.yaml`, not DreamServer extension IDs. When `dream enable librechat` runs, the CLI tries to auto-enable these as separate extensions, fails with `Unknown service`, and aborts.

## How
Changed `depends_on: [librechat-mongodb, librechat-meilisearch]` to `depends_on: []`. Internal compose-level `depends_on` in librechat's compose.yaml already handles startup ordering for MongoDB and Meilisearch.

## Scope
All changes within `resources/dev/extensions-library/`.
- `services/librechat/manifest.yaml` — 1 line changed

## Testing
- YAML syntax validated
- JSON schema validated against `service-manifest.v1.json`
- Cross-checked: all other manifests use `depends_on` for extension IDs only

## Review
Critique Guardian: APPROVED