### PR TITLE
fix(extensions-library): correct jan compose_file to compose.yaml

### DIFF
--- a/resources/dev/extensions-library/services/jan/manifest.yaml
+++ b/resources/dev/extensions-library/services/jan/manifest.yaml
@@ -13,7 +13,7 @@ service:
   health: /health
   type: docker
   gpu_backends: [amd, nvidia]
-  compose_file: compose.yaml.disabled
+  compose_file: compose.yaml
   category: optional
   depends_on: []
   env_vars: []


### PR DESCRIPTION
## What
Change jan manifest's `compose_file` from `compose.yaml.disabled` to `compose.yaml`.

## Why
After `dream enable jan` renames `compose.yaml.disabled` to `compose.yaml`, the manifest still points to the old filename. The service-registry checks the manifest path, finds no file at `compose.yaml.disabled`, and silently excludes jan from compose flags. The service appears enabled but cannot start.

## How
Changed `compose_file: compose.yaml.disabled` to `compose_file: compose.yaml`. The enable/disable mechanism is purely file-rename based; the manifest should always reference the active name. This aligns jan with all 26 other service manifests.

## Scope
All changes within `resources/dev/extensions-library/`.
- `services/jan/manifest.yaml` — 1 line changed

## Testing
- YAML syntax validated
- JSON schema validated against `service-manifest.v1.json`
- Confirmed all other manifests declare `compose_file: compose.yaml`

## Review
Critique Guardian: APPROVED