### PR TITLE
fix(extensions-library): change ollama category from core to optional

### DIFF
--- a/resources/dev/extensions-library/services/ollama/manifest.yaml
+++ b/resources/dev/extensions-library/services/ollama/manifest.yaml
@@ -14,7 +14,7 @@ service:
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml
-  category: core
+  category: optional
   depends_on: []
   env_vars:
     - key: OLLAMA_MODEL


### PR DESCRIPTION
## What
Change ollama manifest's `category` from `core` to `optional`.

## Why
Ollama is not a core service — `llama-server` is the production core LLM. With `category: core`, `dream enable ollama` prints "ollama is a core service (always enabled)" and returns immediately, skipping all activation logic. The service appears enabled but is never actually activated.

## How
Changed `category: core` to `category: optional`. Per the schema: `core = always on, recommended = enabled by default, optional = user opts in`. Ollama is clearly user-opt-in.

## Scope
All changes within `resources/dev/extensions-library/`.
- `services/ollama/manifest.yaml` — 1 line changed

## Testing
- YAML syntax validated
- Cross-checked: no other service uses `category: core` (core services live in the main compose stack, not extensions-library)
- `anythingllm` depends on ollama — this is a pre-existing dependency relationship, unaffected by this change

## Review
Critique Guardian: APPROVED