### PR TITLE
fix(extensions-library): correct localai health endpoint to /healthz

### DIFF
--- a/resources/dev/extensions-library/services/localai/manifest.yaml
+++ b/resources/dev/extensions-library/services/localai/manifest.yaml
@@ -10,7 +10,7 @@ service:
   port: 8080
   external_port_env: LOCALAI_EXTERNAL_PORT
   external_port_default: 7803
-  health: /
+  health: /healthz
   type: docker
   gpu_backends: [amd, nvidia]
   compose_file: compose.yaml


### PR DESCRIPTION
## What
Change localai manifest's `health` from `/` to `/healthz`.

## Why
The manifest declared `health: /` but the compose.yaml healthcheck probes `/healthz`. This mismatch caused `dream status` to potentially report incorrect health for localai, since `/` may or may not return 200 depending on LocalAI version.

## How
Changed `health: /` to `health: /healthz` to match the compose healthcheck endpoint. After this fix, all service manifests align with their respective compose healthchecks.

## Scope
All changes within `resources/dev/extensions-library/`.
- `services/localai/manifest.yaml` — 1 line changed

## Testing
- YAML syntax validated
- Cross-referenced with compose.yaml healthcheck: `wget -qO- http://localhost:8080/healthz`
- Confirmed zero remaining manifest/compose health endpoint mismatches across all 33 services

## Review
Critique Guardian: APPROVED