### PR TITLE
fix(extensions-library): namespace paperless-ngx sidecars and remove exposed ports

### DIFF
--- a/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
@@ -8,9 +8,9 @@ services:
     environment:
       - PAPERLESS_PORT=8000
       - PAPERLESS_HOST=${PAPERLESS_HOST:-paperless}
-      - PAPERLESS_DBHOST=${PAPERLESS_DBHOST:-postgres}
+      - PAPERLESS_DBHOST=${PAPERLESS_DBHOST:-paperless-postgres}
       - PAPERLESS_DBPORT=${PAPERLESS_DBPORT:-5432}
-      - PAPERLESS_REDISHOST=${PAPERLESS_REDISHOST:-redis}
+      - PAPERLESS_REDISHOST=${PAPERLESS_REDISHOST:-paperless-redis}
       - PAPERLESS_REDISPORT=${PAPERLESS_REDISPORT:-6379}
       - PAPERLESS_SECRET_KEY=${PAPERLESS_SECRET_KEY:-change-me}
       - PAPERLESS_URL=http://${PAPERLESS_HOST:-paperless}:${PAPERLESS_PORT:-7807}
@@ -27,8 +27,10 @@ services:
       retries: 3
       start_period: 180s
     depends_on:
-      - postgres
-      - redis
+      paperless-postgres:
+        condition: service_healthy
+      paperless-redis:
+        condition: service_healthy
     networks:
       - dream-network
     deploy:
@@ -40,7 +42,7 @@ services:
           cpus: '0.5'
           memory: 1G
 
-  postgres:
+  paperless-postgres:
     image: docker.io/library/postgres:16-alpine
     container_name: dream-paperless-postgres
     restart: unless-stopped
@@ -52,8 +54,6 @@ services:
       - POSTGRES_PASSWORD=${PAPERLESS_DB_PASSWORD:-paperless}
     volumes:
       - ./data/paperless/postgres:/var/lib/postgresql/data
-    ports:
-      - "5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U paperless -d paperless"]
       interval: 10s
@@ -71,7 +71,7 @@ services:
           cpus: '0.25'
           memory: 512M
 
-  redis:
+  paperless-redis:
     image: docker.io/library/redis:7-alpine
     container_name: dream-paperless-redis
     restart: unless-stopped
@@ -79,8 +79,6 @@ services:
       - no-new-privileges:true
     volumes:
       - ./data/paperless/redis:/data
-    ports:
-      - "6379"
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
       interval: 10s


### PR DESCRIPTION
## What
Rename paperless-ngx sidecar service keys from generic `postgres`/`redis` to `paperless-postgres`/`paperless-redis`, remove exposed sidecar ports, and upgrade `depends_on` to condition-based health checks.

## Why
**Security:** The single-value `ports:` syntax (`- "5432"`, `- "6379"`) publishes container ports on random ephemeral host ports on 0.0.0.0, exposing the PostgreSQL database (with default password `paperless`) and Redis to the entire local network.

**Collision:** Generic service names `postgres` and `redis` collide with other extensions (e.g. immich) when Docker Compose merges multiple `-f` files. One definition silently overwrites the other.

## How
- Renamed service keys: `postgres` → `paperless-postgres`, `redis` → `paperless-redis`
- Removed `ports:` directives from both sidecars (they only need `dream-network` access)
- Updated `depends_on` to use condition-based format with `service_healthy`
- Updated env var defaults: `PAPERLESS_DBHOST` → `paperless-postgres`, `PAPERLESS_REDISHOST` → `paperless-redis`

## Scope
All changes within `resources/dev/extensions-library/services/paperless-ngx/compose.yaml`.

## Testing
- YAML validation: passed
- `docker compose config` validation: passed
- Manifest validation: passed
- Manual: start paperless-ngx, verify postgres/redis are not exposed on host ports, verify paperless connects correctly

## Merging Order
This PR has a minor merge conflict with:
- **PR #537** (paperless depends_on health conditions) — both touch `depends_on`. This PR already includes the condition-based format, so if this merges first, #537 becomes a partial duplicate for depends_on. If #537 merges first, this PR needs a trivial rebase to rename the service names in the condition-based block.

**Suggested order:** This PR first (or simultaneously with #537), then #526 (paperless secret key — no conflict).

Independent of: #538, #539, #529, #530, all other open PRs.