### PR TITLE
fix(extensions-library): rename immich service key and namespace sidecars

### DIFF
--- a/resources/dev/extensions-library/services/immich/compose.yaml
+++ b/resources/dev/extensions-library/services/immich/compose.yaml
@@ -1,5 +1,5 @@
 services:
-  immich-server:
+  immich:
     image: ghcr.io/immich-app/immich-server:v1.131.3
     container_name: dream-immich
     ports:
@@ -9,16 +9,16 @@ services:
       - ./data/immich/backup:/usr/src/app/backup
     environment:
       - LLM_API_URL=${LLM_API_URL:-http://localhost:8000}
-      - DB_HOSTNAME=${IMMICH_DB_HOST:-postgres}
+      - DB_HOSTNAME=${IMMICH_DB_HOST:-immich-postgres}
       - DB_USERNAME=${IMMICH_DB_USER:-postgres}
-      - DB_PASSWORD=${IMMICH_DB_PASS:-postgres}
+      - DB_PASSWORD=${IMMICH_DB_PASSWORD:-postgres}
       - DB_DATABASE_NAME=${IMMICH_DB_NAME:-immich}
-      - REDIS_HOSTNAME=${IMMICH_REDIS_HOST:-redis}
+      - REDIS_HOSTNAME=${IMMICH_REDIS_HOST:-immich-redis}
       - REDIS_PORT=${IMMICH_REDIS_PORT:-6379}
     depends_on:
-      postgres:
+      immich-postgres:
         condition: service_healthy
-      redis:
+      immich-redis:
         condition: service_healthy
     restart: unless-stopped
     security_opt:
@@ -37,7 +37,7 @@ services:
     networks:
       - dream-network
 
-  postgres:
+  immich-postgres:
     image: postgres:16-alpine
     container_name: immich-postgres
     volumes:
@@ -62,7 +62,7 @@ services:
     networks:
       - dream-network
 
-  redis:
+  immich-redis:
     image: redis:7-alpine
     container_name: immich-redis
     volumes:

--- a/resources/dev/extensions-library/services/immich/manifest.yaml
+++ b/resources/dev/extensions-library/services/immich/manifest.yaml
@@ -6,7 +6,7 @@ service:
   aliases: [photos, media-backup]
   container_name: dream-immich
   host_env: IMMICH_HOST
-  default_host: immich-server
+  default_host: immich
   port: 2283
   external_port_env: IMMICH_PORT
   external_port_default: 2283


### PR DESCRIPTION
## What
Rename the immich compose service key from `immich-server` to `immich` to match the manifest ID, and namespace sidecar services from generic `postgres`/`redis` to `immich-postgres`/`immich-redis`.

## Why
**Service key mismatch:** dream-cli uses the manifest `id` field to run `docker compose up -d <id>`. The manifest says `id: immich` but the compose service key was `immich-server`, causing the command to fail with "service immich is not defined".

**Collision:** Generic `postgres`/`redis` service names collide with other extensions (e.g. paperless-ngx) when Docker Compose merges multiple `-f` files.

## How
- Renamed compose service key: `immich-server` → `immich`
- Renamed sidecar keys: `postgres` → `immich-postgres`, `redis` → `immich-redis`
- Updated `depends_on` references in immich service
- Updated env defaults: `DB_HOSTNAME` → `immich-postgres`, `REDIS_HOSTNAME` → `immich-redis`
- Updated manifest `default_host` from `immich-server` to `immich`

## Scope
- `resources/dev/extensions-library/services/immich/compose.yaml`
- `resources/dev/extensions-library/services/immich/manifest.yaml`

## Testing
- YAML validation: passed
- `docker compose config` validation: passed
- Manifest validation: passed
- Manual: `dream start immich` should now find the correct service name

## Merging Order
This PR has a minor context overlap with:
- **PR #538** (immich DB password unification) — touches the `DB_PASSWORD` env line in the same file. If both merge, a trivial rebase resolves the context conflict.

**Suggested order:** Either order works. If #538 merges first, rebase this PR. If this merges first, #538 needs a trivial rebase.

Should merge alongside or after **PR #560** (paperless-ngx namespace) to fully resolve the cross-extension collision bug.