### PR TITLE
fix(windows): CPU fallback when NVIDIA GPU passthrough fails

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -292,7 +292,15 @@ if ($dryRun) {
         if ($cloudMode) {
             $composeFlags += @("-f", "installers/windows/docker-compose.windows-amd.yml")
         } elseif ($gpuInfo.Backend -eq "nvidia") {
-            $composeFlags += @("-f", "docker-compose.nvidia.yml")
+            if ($script:gpuPassthroughFailed) {
+                Write-AIWarn "NVIDIA GPU passthrough unavailable -- falling back to CPU-only inference."
+                Write-AI "  Inference will be slower but functional. To fix GPU passthrough:"
+                Write-AI "  1. Restart Docker Desktop and WSL: wsl --shutdown"
+                Write-AI "  2. Verify: docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi"
+                $composeFlags += @("-f", "docker-compose.cpu.yml")
+            } else {
+                $composeFlags += @("-f", "docker-compose.nvidia.yml")
+            }
         } elseif ($gpuInfo.Backend -eq "amd") {
             $composeFlags += @("-f", "installers/windows/docker-compose.windows-amd.yml")
         }
@@ -351,7 +359,7 @@ if ($dryRun) {
                 $relPath = $composePath.Substring($installDir.Length + 1) -replace "\\", "/"
                 $composeFlags += @("-f", $relPath)
 
-                if ($currentBackend -eq "nvidia") {
+                if ($currentBackend -eq "nvidia" -and -not $script:gpuPassthroughFailed) {
                     $gpuOverlay = Join-Path $svcDir.FullName "compose.nvidia.yaml"
                     if (Test-Path $gpuOverlay) {
                         $relOverlay = $gpuOverlay.Substring($installDir.Length + 1) -replace "\\", "/"

--- a/dream-server/installers/windows/phases/04-requirements.ps1
+++ b/dream-server/installers/windows/phases/04-requirements.ps1
@@ -125,7 +125,7 @@ if ($selectedTier -notin @("0", "CLOUD") -and $gpuInfo.Backend -eq "none") {
 # Build list of ports to check based on enabled features.
 # Default service ports match .env.example; overridden ports are not checked here.
 $_portsToCheck = [ordered]@{
-    "llama-server (LLM)"  = 8080
+    "llama-server (LLM)"  = 11434
     "Open WebUI (chat)"   = 3000
     "Dashboard"           = 3001
     "Dashboard API"       = 3002

--- a/dream-server/installers/windows/phases/05-docker.ps1
+++ b/dream-server/installers/windows/phases/05-docker.ps1
@@ -99,8 +99,9 @@ if ($dryRun) {
     # ── NVIDIA GPU passthrough smoke test ─────────────────────────────────────
     # Only run if NVIDIA GPU detected AND WSL2 backend is confirmed.
     # This test starts a minimal container with --gpus all and checks that
-    # nvidia-smi is accessible. It is non-fatal -- some valid configurations
-    # (e.g., very new drivers + WSL2) pass at runtime even if this quick test fails.
+    # nvidia-smi is accessible. If it fails, Phase 08 falls back to CPU-only
+    # inference (docker-compose.cpu.yml) instead of crashing docker compose up.
+    $script:gpuPassthroughFailed = $false
     if ($gpuInfo.Backend -eq "nvidia" -and $preflight_docker -and $preflight_docker.WSL2Backend) {
         Write-AI "Testing NVIDIA GPU passthrough in Docker (non-fatal)..."
         $prevEAP = $ErrorActionPreference
@@ -111,10 +112,13 @@ if ($dryRun) {
 
         if ($gpuTestExit -eq 0) {
             Write-AISuccess "NVIDIA GPU passthrough confirmed in Docker"
+            $script:gpuPassthroughFailed = $false
         } else {
             Write-AIWarn "NVIDIA GPU passthrough smoke test failed (exit: $gpuTestExit)."
-            Write-AI "  This may be a false alarm on first run while Docker Desktop initializes."
-            Write-AI "  If inference fails later, check: docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi"
+            Write-AI "  Installer will fall back to CPU-only inference."
+            Write-AI "  To fix GPU passthrough later, restart Docker Desktop and WSL:"
+            Write-AI "  wsl --shutdown && docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi"
+            $script:gpuPassthroughFailed = $true
         }
     }
 }


### PR DESCRIPTION
## Summary
- When NVIDIA GPU passthrough smoke test fails (exit 125), fall back to `docker-compose.cpu.yml` instead of crashing `docker compose up` with exit code 1
- Skip NVIDIA extension overlays (whisper, comfyui `compose.nvidia.yaml`) when GPU is inaccessible — base compose files use CPU images
- Fix port conflict check from 8080 → 11434 to match `OLLAMA_PORT` default, eliminating false wslrelay warning on WSL2

## Context
A tester on GTX 1050 Ti / Windows 11 / WSL2 got `docker compose up` exit code 1 on every install attempt (Full Stack, Core Only, Custom) across v2.3.2 and v2.3.3. Root cause: the nvidia overlay requires `deploy.resources.reservations.devices: [{driver: nvidia, count: all}]` which fails when Docker can't allocate the GPU. The smoke test in phase 05 detected this but treated it as non-fatal, allowing compose to crash.

Systems with working GPU passthrough are completely unaffected — the fallback only triggers when the smoke test fails.

## Test plan
- [ ] RTX 5090 (working GPU): installer uses nvidia overlay as before, no CPU fallback
- [ ] GTX 1050 Ti (broken passthrough): installer falls back to CPU overlay, compose succeeds
- [ ] Port check no longer warns about wslrelay on port 8080
- [ ] PowerShell syntax check passes on all 3 modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)