### PR TITLE
fix(extensions-library): correct continue config volume mount paths

### DIFF
--- a/resources/dev/extensions-library/services/continue/compose.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.yaml
@@ -22,8 +22,8 @@ services:
       - CONTINUE_PORT=${CONTINUE_PORT:-8890}
     volumes:
       - ./data/continue:/usr/share/nginx/html:rw
-      - ./config/continue/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./config/continue/entrypoint.sh:/docker-entrypoint.d/50-continue-init.sh:ro
+      - ./extensions/services/continue/config/continue/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./extensions/services/continue/config/continue/entrypoint.sh:/docker-entrypoint.d/50-continue-init.sh:ro
     ports:
       - "127.0.0.1:${CONTINUE_PORT:-8890}:8080"
     networks:


### PR DESCRIPTION
## What
Fix the volume mount paths for nginx.conf and entrypoint.sh in the continue extension compose file.

## Why
dream-cli runs `docker compose` from `$INSTALL_DIR` (the project root). The compose volume paths `./config/continue/nginx.conf` and `./config/continue/entrypoint.sh` resolve to `$INSTALL_DIR/config/continue/` which does not exist. The actual files are at `$INSTALL_DIR/extensions/services/continue/config/continue/`.

This causes the continue extension to be completely non-functional: nginx starts with default config (no /health endpoint, no config.yaml generation), and dream reports the service as unhealthy.

## How
Changed volume paths from:
```
./config/continue/nginx.conf → ./extensions/services/continue/config/continue/nginx.conf
./config/continue/entrypoint.sh → ./extensions/services/continue/config/continue/entrypoint.sh
```

## Scope
`resources/dev/extensions-library/services/continue/compose.yaml` — 2 lines changed.

## Testing
- YAML validation: passed
- Manual: start continue extension, verify `/health` returns 200 and `/config.yaml` is served

## Review
Critique Guardian verdict: **APPROVED** (no warnings).

## Merging Order
No conflicts with any open PRs. PR #539 (continue CORS) modifies nginx.conf content, not the compose volume paths — independent.

Can merge in any order relative to other PRs.