### PR TITLE
fix(extensions-library): reassign 3 default ports that conflict with production services

### DIFF
--- a/resources/dev/extensions-library/services/audiocraft/README.md
+++ b/resources/dev/extensions-library/services/audiocraft/README.md
@@ -26,7 +26,7 @@ AudioCraft is a PyTorch library for deep learning research on audio generation. 
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `AUDIOCRAFT_PORT` | 7860 | External port for the UI |
+| `AUDIOCRAFT_PORT` | 7863 | External port for the UI |
 | `AUDIOCRAFT_HOST` | audiocraft | Hostname for service discovery |
 
 ## Data Persistence
@@ -37,7 +37,7 @@ AudioCraft is a PyTorch library for deep learning research on audio generation. 
 ## Usage
 
 1. Enable the extension in the Dream Dashboard
-2. Access the UI at `http://localhost:7860`
+2. Access the UI at `http://localhost:7863`
 3. Use the MusicGen tab to generate music
 4. Use the AudioGen tab to generate sound effects
 

--- a/resources/dev/extensions-library/services/audiocraft/compose.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/compose.yaml
@@ -14,7 +14,7 @@ services:
       - ./data/audiocraft:/app/outputs:rw
       - ./data/audiocraft/models:/root/.cache/audiocraft:rw
     ports:
-      - "127.0.0.1:${AUDIOCRAFT_PORT:-7860}:7860"
+      - "127.0.0.1:${AUDIOCRAFT_PORT:-7863}:7860"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:7860/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/audiocraft/manifest.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/manifest.yaml
@@ -9,7 +9,7 @@ service:
   default_host: audiocraft
   port: 7860
   external_port_env: AUDIOCRAFT_PORT
-  external_port_default: 7860
+  external_port_default: 7863
   health: /
   type: docker
   gpu_backends: [nvidia]

--- a/resources/dev/extensions-library/services/jupyter/README.md
+++ b/resources/dev/extensions-library/services/jupyter/README.md
@@ -11,13 +11,13 @@ Jupyter Notebook provides an interactive environment for scientific computing, d
 - **Interactive Notebooks**: Create and share documents with code and visualizations
 - **Multiple Languages**: Python, R, Julia support
 - **Scientific Stack**: NumPy, SciPy, Pandas, Matplotlib, Scikit-learn pre-installed
-- **Web Interface**: Access via web browser on port 8888
+- **Web Interface**: Access via web browser on port 8889
 
 ## Configuration
 
 ### Environment Variables
 
-- `JUPYTER_PORT` - Port for web interface (default: 8888)
+- `JUPYTER_PORT` - Port for web interface (default: 8889)
 - `JUPYTER_TOKEN` - Authentication token (default: jupyter)
 - `LLM_API_URL` - URL for your LLM API (from .env)
 
@@ -29,7 +29,7 @@ Jupyter Notebook provides an interactive environment for scientific computing, d
 
 ### Ports
 
-- `8888` - Web interface
+- `8889` - Web interface
 
 ## Quick Start
 
@@ -49,7 +49,7 @@ docker-compose -f extensions/services/jupyter/compose.yaml up -d
 
 ### Web Interface
 
-Access the web interface at `http://localhost:8888`.
+Access the web interface at `http://localhost:8889`.
 
 Default token: `jupyter`
 

--- a/resources/dev/extensions-library/services/jupyter/compose.yaml
+++ b/resources/dev/extensions-library/services/jupyter/compose.yaml
@@ -5,7 +5,7 @@ services:
     image: jupyter/scipy-notebook:python-3.11
     container_name: dream-jupyter
     ports:
-      - "127.0.0.1:${JUPYTER_PORT:-8888}:8888"
+      - "127.0.0.1:${JUPYTER_PORT:-8889}:8888"
     volumes:
       - ./data/jupyter/workspace:/home/jovyan/work
       - ./data/jupyter/notebooks:/home/jovyan/notebooks

--- a/resources/dev/extensions-library/services/jupyter/manifest.yaml
+++ b/resources/dev/extensions-library/services/jupyter/manifest.yaml
@@ -9,7 +9,7 @@ service:
   default_host: jupyter
   port: 8888
   external_port_env: JUPYTER_PORT
-  external_port_default: 8888
+  external_port_default: 8889
   health: /tree
   type: docker
   gpu_backends: [amd, nvidia]

--- a/resources/dev/extensions-library/services/label-studio/README.md
+++ b/resources/dev/extensions-library/services/label-studio/README.md
@@ -14,12 +14,12 @@ Open source data labeling tool for machine learning.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `LABEL_STUDIO_HOST` | `label-studio` | Hostname for service |
-| `LABEL_STUDIO_PORT` | `8085` | External port for UI |
+| `LABEL_STUDIO_PORT` | `8086` | External port for UI |
 
 ## Usage
 
 1. Start the service: `docker compose up -d`
-2. Access at `http://localhost:8085`
+2. Access at `http://localhost:8086`
 3. Create a project and import data for labeling
 
 ## Data Persistence

--- a/resources/dev/extensions-library/services/label-studio/compose.yaml
+++ b/resources/dev/extensions-library/services/label-studio/compose.yaml
@@ -17,7 +17,7 @@ services:
       - ./media:/label-studio/media:rw
       - ./www:/label-studio/www:rw
     ports:
-      - "127.0.0.1:${LABEL_STUDIO_PORT:-8085}:8080"
+      - "127.0.0.1:${LABEL_STUDIO_PORT:-8086}:8080"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
       interval: 30s

--- a/resources/dev/extensions-library/services/label-studio/manifest.yaml
+++ b/resources/dev/extensions-library/services/label-studio/manifest.yaml
@@ -9,7 +9,7 @@ service:
   default_host: label-studio
   port: 8080
   external_port_env: LABEL_STUDIO_PORT
-  external_port_default: 8085
+  external_port_default: 8086
   health: /health
   type: docker
   gpu_backends: [none]


### PR DESCRIPTION
## What
Reassign default external ports for 3 extensions-library services that collide with production services.

## Why
When a user enables these extensions alongside the default DreamServer stack, Docker fails with a port bind error because two services try to claim the same host port.

| Library Service | Old Port | Production Conflict | New Port |
|----------------|----------|-------------------|----------|
| audiocraft | 7860 | openclaw (7860) | **7863** |
| label-studio | 8085 | privacy-shield (8085) | **8086** |
| jupyter | 8888 | searxng (8888) | **8889** |

## How
Updated `external_port_default` in each service's manifest.yaml, the port binding in each compose.yaml, and all port references in README.md files.

Internal container ports are unchanged. Users who already customised the port via env vars are unaffected.

## Scope
- `resources/dev/extensions-library/services/audiocraft/` (manifest, compose, README)
- `resources/dev/extensions-library/services/label-studio/` (manifest, compose, README)
- `resources/dev/extensions-library/services/jupyter/` (manifest, compose, README)

## Testing
- YAML validation: passed
- Manifest validation: passed
- Port conflict cross-check: 7863, 8086, 8889 verified free in both production and extensions-library
- All services retain 127.0.0.1 binding

## Review
Critique Guardian Round 1: APPROVED WITH WARNINGS (stale README ports).
Round 2 fix applied: all 8 README lines updated.

## Known Considerations
The issue also reported baserow (3006) conflicting with langfuse (3006), but langfuse does not exist in production services. This was a false positive — baserow's port is unchanged.

## Merging Order
No conflicts with open PRs. PR #529 (jupyter token) touches different lines in jupyter/compose.yaml. PR #530 (audiocraft Dockerfile) touches a different file.

Can merge in any order.