### PR TITLE
fix(extensions-library): add setup hooks for jupyter and dify

### DIFF
--- a/resources/dev/extensions-library/services/dify/manifest.yaml
+++ b/resources/dev/extensions-library/services/dify/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml.disabled
   category: optional
   depends_on: []
+  setup_hook: setup.sh
   env_vars:
     - key: DIFY_SECRET_KEY
       required: true

--- a/resources/dev/extensions-library/services/dify/setup.sh
+++ b/resources/dev/extensions-library/services/dify/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Dify — generate secret key if not already set
+# Usage: setup.sh INSTALL_DIR GPU_BACKEND
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+append_if_missing() {
+  key="$1"
+  value="$2"
+  if [ -f "$ENV_FILE" ] && grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    return 0
+  fi
+  echo "${key}=${value}" >> "$ENV_FILE"
+}
+
+append_if_missing "DIFY_SECRET_KEY" "$(openssl rand -hex 32)"

--- a/resources/dev/extensions-library/services/jupyter/manifest.yaml
+++ b/resources/dev/extensions-library/services/jupyter/manifest.yaml
@@ -16,9 +16,10 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  setup_hook: setup.sh
   env_vars:
     - key: JUPYTER_TOKEN
-      required: false
+      required: true
       secret: true
       description: Access token for Jupyter
 

--- a/resources/dev/extensions-library/services/jupyter/setup.sh
+++ b/resources/dev/extensions-library/services/jupyter/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Jupyter — generate access token if not already set
+# Usage: setup.sh INSTALL_DIR GPU_BACKEND
+
+set -eu
+
+ENV_FILE="${1:-.}/.env"
+
+append_if_missing() {
+  key="$1"
+  value="$2"
+  if [ -f "$ENV_FILE" ] && grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
+    return 0
+  fi
+  echo "${key}=${value}" >> "$ENV_FILE"
+}
+
+append_if_missing "JUPYTER_TOKEN" "$(openssl rand -hex 32)"


### PR DESCRIPTION
## What
Fix jupyter manifest contradiction and add setup.sh hooks for jupyter and dify.

## Why
- jupyter: manifest declared `JUPYTER_TOKEN` as `required: false` but compose uses `:?` (hard fail). Users hit a compose error despite the manifest suggesting the token is optional.
- dify: has `DIFY_SECRET_KEY` correctly declared as required but no auto-generation. Service is disabled (`compose.yaml.disabled`) but the hook prepares secrets for when users enable it.

## How
- jupyter: changed `required: false` to `required: true` in manifest, added `setup_hook: setup.sh`
- dify: added `setup_hook: setup.sh` to manifest
- Created `setup.sh` scripts using `openssl rand -hex 32` for both services
- Scripts are POSIX sh, idempotent

## Scope
All changes within `resources/dev/extensions-library/services/{jupyter,dify}/`.

## Testing
- Automated: shellcheck, YAML validation
- Manual: fresh install with jupyter enabled, verify token in `.env`, verify compose starts, verify Jupyter UI accepts generated token

## Review
Critique Guardian: APPROVED WITH WARNINGS (minor: dify hook runs on all installs even when disabled — intentional)

## Suggested merge order
Independent of other batch C PRs.