### PR TITLE
fix(extensions-library): correct README ports and add privacy-shield collision warning

### DIFF
--- a/resources/dev/extensions-library/services/paperless-ngx/README.md
+++ b/resources/dev/extensions-library/services/paperless-ngx/README.md
@@ -15,12 +15,12 @@ Paperless-ngx automatically organizes scanned documents with OCR, categorization
 
 ## Configuration
 
-- **Port**: `PAPERLESS_PORT` (default: 8000)
+- **Port**: `PAPERLESS_PORT` (default: 7807)
 - **Data Directory**: `./data/paperless`
 
 ## Usage
 
-After installation, access the web interface at `http://localhost:8000`
+After installation, access the web interface at `http://localhost:7807`
 
 ## Requirements
 

--- a/resources/dev/extensions-library/services/privacy-shield/README.md
+++ b/resources/dev/extensions-library/services/privacy-shield/README.md
@@ -1,5 +1,11 @@
 # Privacy Shield
 
+> **Warning**: This service already ships in the production
+> `dream-server/extensions/services/privacy-shield/` directory. Copying
+> this library version into your installation will **overwrite** the
+> production copy. Only proceed if you intend to replace the existing
+> production setup.
+
 API PII Protection for Dream Server
 
 ## Overview

--- a/resources/dev/extensions-library/services/weaviate/README.md
+++ b/resources/dev/extensions-library/services/weaviate/README.md
@@ -15,12 +15,12 @@ Weaviate is a scalable vector database that powers semantic search, generative A
 
 ## Configuration
 
-- **Port**: `WEAVIATE_PORT` (default: 8080)
+- **Port**: `WEAVIATE_PORT` (default: 7811)
 - **Data Directory**: `./data/weaviate`
 
 ## Usage
 
-After installation, access the GraphQL API at `http://localhost:8080/v1/graphql`
+After installation, access the GraphQL API at `http://localhost:7811/v1/graphql`
 
 ## Requirements
 


### PR DESCRIPTION
## What
Fix incorrect default ports in paperless-ngx and weaviate READMEs, and add a collision warning to privacy-shield README.

## Why
- paperless-ngx README documented port 8000 (internal container port) instead of 7807 (external host port from compose)
- weaviate README documented port 8080 (internal) instead of 7811 (external)
- privacy-shield exists in both the extensions-library and production `dream-server/extensions/services/` with the same service ID — copying would overwrite the production version

## How
- paperless-ngx/README.md: 8000 → 7807 in config table and usage URL
- weaviate/README.md: 8080 → 7811 in config table and usage URL
- privacy-shield/README.md: added warning block about service ID collision with production version

## Scope
All changes within `resources/dev/extensions-library/services/{paperless-ngx,weaviate,privacy-shield}/`.

## Testing
Visual review only — documentation changes.

## Review
Critique Guardian: APPROVED

## Suggested merge order
Independent of all other PRs. Can merge at any time.