### PR TITLE
fix(windows): add placeholder image to llama-server in AMD overlay

### DIFF
--- a/dream-server/installers/windows/docker-compose.windows-amd.yml
+++ b/dream-server/installers/windows/docker-compose.windows-amd.yml
@@ -6,6 +6,7 @@
 
 services:
   llama-server:
+    image: hello-world:latest   # Placeholder -- container never runs (replicas: 0)
     deploy:
       replicas: 0    # Disabled -- running natively on Windows host via Vulkan
 


### PR DESCRIPTION
## Summary
- Add `image: hello-world:latest` placeholder to llama-server in the Windows AMD overlay
- Container never runs (replicas: 0) but Docker Compose requires an image on every service definition for validation

## Context
Tester on Windows AMD (NucBox K12, Ryzen 7 H 255, Vega 8 iGPU) hit `docker compose up` failure with: `service "llama-server" has neither an image nor a build context specified: invalid compose project`. The base compose defines llama-server as a stub (no image), and the AMD overlay sets replicas: 0 but doesn't provide an image. Compose validates before applying replica counts.

Same root cause as the NVIDIA GPU passthrough issue (#562) but on the AMD path.

## Test plan
- [ ] `docker compose -f docker-compose.base.yml -f installers/windows/docker-compose.windows-amd.yml config` validates clean
- [ ] Full install on Windows AMD machine — compose should succeed
- [ ] NVIDIA and CPU paths unaffected (they provide their own images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)