### PR TITLE
fix(windows): resolve install failures from Session 2 test report

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,16 @@ cd DreamServer/dream-server
 Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) with WSL2 backend enabled.
 **Install Docker Desktop first and make sure it is running before you start.**
 
+Open **PowerShell as Administrator** and run:
+
 ```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 git clone https://github.com/Light-Heart-Labs/DreamServer.git
 cd DreamServer
 .\install.ps1
 ```
+
+> The `Set-ExecutionPolicy` command allows the installer script to run in the current session. It does not change your system-wide policy.
 
 The installer detects your GPU, picks the right model, generates credentials, starts all services, and creates a Desktop shortcut to the Dashboard. Manage with `.\dream-server\installers\windows\dream.ps1 status`.
 

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -85,7 +85,9 @@ function Get-ComposeFlags {
     }
 
     # Fallback: detect from available files
-    $flags = @()
+    # --env-file explicit: Docker Compose V2 on Windows may not auto-discover
+    # .env from the project directory when multiple -f flags are used.
+    $flags = @("--env-file", ".env")
     $base = Join-Path $InstallDir "docker-compose.base.yml"
     $nvidia = Join-Path $InstallDir "docker-compose.nvidia.yml"
     $mono = Join-Path $InstallDir "docker-compose.yml"

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -124,6 +124,11 @@ if ($dryRun) {
     Write-AI "[DRY RUN] Would run: docker compose up -d"
 } else {
     Push-Location $installDir
+    # Sync .NET CWD so in-process .NET API calls using relative paths (e.g., Test-Path
+    # internals, [IO.File] methods) resolve against $installDir, not the launch directory.
+    # PowerShell's Push-Location does not update [Environment]::CurrentDirectory.
+    $_previousCwd = [Environment]::CurrentDirectory
+    [Environment]::CurrentDirectory = $installDir
 
     try {
         # ── Bootstrap fast-start ──────────────────────────────────────────────
@@ -287,7 +292,11 @@ if ($dryRun) {
         # ── Assemble Docker Compose flags ─────────────────────────────────────
         # NOTE: Blackwell GPUs (sm_120) work with the standard server-cuda image
         # via PTX JIT compilation. No special image override is needed.
-        $composeFlags = @("-f", "docker-compose.base.yml")
+        #
+        # --env-file is explicit: Docker Compose V2 on Windows may not auto-discover
+        # .env from the project directory when multiple -f flags are used. Explicitly
+        # passing --env-file removes ambiguity in .env resolution.
+        $composeFlags = @("--env-file", ".env", "-f", "docker-compose.base.yml")
 
         if ($cloudMode) {
             $composeFlags += @("-f", "installers/windows/docker-compose.windows-amd.yml")
@@ -394,6 +403,15 @@ if ($dryRun) {
 
         # ── Start Docker services ─────────────────────────────────────────────
         Write-Chapter "STARTING SERVICES"
+
+        # Pre-flight: verify .env is readable from CWD before compose up
+        $_envCheck = Join-Path $installDir ".env"
+        if (-not (Test-Path $_envCheck)) {
+            Write-AIError ".env file not found at $_envCheck -- cannot start services."
+            Write-AI "  Re-run the installer to regenerate the .env file."
+            exit 1
+        }
+
         Write-AI "Running: docker compose $($composeFlags -join ' ') up -d"
         # PS 5.1 treats ANY stderr output from native commands as NativeCommandError.
         # Silence stderr-as-error so $LASTEXITCODE reflects the real compose exit code.
@@ -452,6 +470,7 @@ exec bash "$bashScript" "$bashInstallDir" "$($fullTierConfig.GgufFile)" "$($full
 
     } finally {
         Pop-Location
+        [Environment]::CurrentDirectory = $_previousCwd
     }
 }
 

--- a/dream-server/installers/windows/lib/tier-map.ps1
+++ b/dream-server/installers/windows/lib/tier-map.ps1
@@ -120,11 +120,12 @@ function ConvertTo-TierFromGpu {
     $backend = $GpuInfo.Backend
     $vramMB  = $GpuInfo.VramMB
 
-    # No GPU detected -- use Tier 0 for local inference on low-RAM machines,
-    # otherwise fall back to CLOUD (API) mode
+    # No GPU detected -- use CPU-only local inference.
+    # CLOUD mode requires the explicit --Cloud flag; never auto-select it
+    # because it needs an API key the user may not have.
     if ($backend -eq "none") {
-        if ($SystemRamGB -lt 12) { return "0" }
-        return "CLOUD"
+        if ($SystemRamGB -lt 8) { return "0" }
+        return "1"
     }
 
     # AMD Strix Halo -- tier based on system RAM (unified memory)

--- a/dream-server/installers/windows/phases/03-features.ps1
+++ b/dream-server/installers/windows/phases/03-features.ps1
@@ -86,11 +86,17 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
     }
 }
 
-# Tier safety net: disable ComfyUI on Tier 0/1 in non-interactive mode.
+# Tier safety net: disable ComfyUI on Tier 0/1 or CLOUD in non-interactive mode.
 # Interactive mode has its own tier checks in the menu — this catches -NonInteractive.
 if ($nonInteractive -and $enableComfyui -and ($selectedTier -eq "0" -or $selectedTier -eq "1")) {
     $enableComfyui = $false
     Write-AI "ComfyUI auto-disabled for Tier $selectedTier (insufficient RAM for shm_size 8GB)"
+}
+
+# CLOUD tier cannot use ComfyUI (no local GPU for image generation)
+if ($enableComfyui -and $selectedTier -eq "CLOUD") {
+    $enableComfyui = $false
+    Write-AIWarn "ComfyUI disabled for CLOUD tier (requires local GPU for image generation)"
 }
 
 # ── Feature summary ───────────────────────────────────────────────────────────

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -126,6 +126,35 @@ $envResult = New-DreamEnv `
     -LlamaServerImage $llamaServerImage
 Write-AISuccess "Generated .env with secure secrets"
 
+# ── Post-generation validation: verify all required keys are present with values ──
+# Defense-in-depth: catches silent failures in env generation before docker compose
+# hits the ${VAR:?} hard-fail syntax and produces a confusing error.
+# NOTE: Only checks keys that use :? (required non-empty) in compose files.
+# Keys like ANTHROPIC_API_KEY= are intentionally empty and not checked here.
+$_envPath = Join-Path $installDir ".env"
+$_requiredKeys = @("WEBUI_SECRET", "N8N_PASS", "LITELLM_KEY", "OPENCLAW_TOKEN", "DASHBOARD_API_KEY")
+$_envLines = @{}
+if (Test-Path $_envPath) {
+    Get-Content $_envPath | ForEach-Object {
+        if ($_ -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
+            $_envLines[$Matches[1]] = $Matches[2]
+        }
+    }
+}
+$_missingKeys = @()
+foreach ($_k in $_requiredKeys) {
+    if (-not $_envLines.ContainsKey($_k) -or -not $_envLines[$_k]) {
+        $_missingKeys += $_k
+    }
+}
+if ($_missingKeys.Count -gt 0) {
+    Write-AIError ".env is missing required keys: $($_missingKeys -join ', ')"
+    Write-AI "  This will cause docker compose to fail. The .env file may be corrupted."
+    Write-AI "  Try deleting $(Join-Path $installDir '.env') and re-running the installer."
+    exit 1
+}
+Write-AISuccess "Verified .env contains all required secrets"
+
 # ── Generate SearXNG config ───────────────────────────────────────────────────
 $_searxngPath = New-SearxngConfig -InstallDir $installDir -SecretKey $envResult.SearxngSecret
 Write-AISuccess "Generated SearXNG config ($_searxngPath)"

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -139,42 +139,21 @@ if (Test-Path $script:OPENCODE_EXE) {
         Write-AISuccess "OpenCode config already exists -- preserving existing configuration"
     }
 
-    # ── VBS launcher (no console window on startup) ───────────────────────────
-    # Uses VBScript rather than a .ps1 shortcut to avoid the PowerShell window
-    # flashing on Windows login. WshShell.Run 0=hidden, False=async.
+    # ── VBS launcher (available for manual startup) ──────────────────────────
+    # Creates a VBS script users can run to start OpenCode without a console
+    # window. NOT added to Windows Startup -- OpenCode is a developer tool,
+    # not a core service, so it should be opt-in.
     $_vbsContent = @"
-' Dream Server -- OpenCode Web Server (silent startup launcher)
-' Starts opencode.exe in web mode without a visible console window on login.
+' Dream Server -- OpenCode Web Server (silent launcher)
+' Run this script to start OpenCode without a visible console window.
 Set WshShell = CreateObject("WScript.Shell")
 WshShell.CurrentDirectory = WshShell.ExpandEnvironmentStrings("%USERPROFILE%\.opencode")
 WshShell.Run """%USERPROFILE%\.opencode\bin\opencode.exe"" web --port $($script:OPENCODE_PORT) --hostname 127.0.0.1", 0, False
 "@
     $_vbsPath = Join-Path $script:OPENCODE_DIR "start-opencode.vbs"
     Write-Utf8NoBom -Path $_vbsPath -Content $_vbsContent
-
-    # Copy VBS launcher to Windows Startup folder so it runs on next login
-    $_startupDir = Join-Path $env:APPDATA "Microsoft\Windows\Start Menu\Programs\Startup"
-    $_startupVbs = Join-Path $_startupDir "DreamServer-OpenCode.vbs"
-    Copy-Item -Path $_vbsPath -Destination $_startupVbs -Force
-    Write-AISuccess "Added OpenCode to Windows Startup (launches on next login)"
-
-    # ── Start OpenCode now (for this session) ─────────────────────────────────
-    # Stop any stale OpenCode process first
-    $null = Get-Process -Name "opencode" -ErrorAction SilentlyContinue |
-        Stop-Process -Force -ErrorAction SilentlyContinue
-    Start-Sleep -Milliseconds 500
-
-    Write-AI "Starting OpenCode web server on port $($script:OPENCODE_PORT)..."
-    $ocProc = Start-Process `
-        -FilePath    $script:OPENCODE_EXE `
-        -ArgumentList "web --port $($script:OPENCODE_PORT) --hostname 127.0.0.1" `
-        -WindowStyle Hidden `
-        -PassThru
-    if ($ocProc) {
-        Write-AISuccess "OpenCode started (PID $($ocProc.Id)) -- http://localhost:$($script:OPENCODE_PORT)"
-    } else {
-        Write-AIWarn "OpenCode may not have started. Check manually: $($script:OPENCODE_EXE) web --port $($script:OPENCODE_PORT)"
-    }
+    Write-AISuccess "OpenCode ready -- start manually: $($script:OPENCODE_EXE) web --port $($script:OPENCODE_PORT)"
+    Write-AI "  Or run: $($_vbsPath) (silent, no console window)"
 }
 
 # ── Node.js / npm tools (Claude Code + Codex CLI) ────────────────────────────


### PR DESCRIPTION
## Summary

Fixes all issues identified in Adem's Session 2 install test report (HP Omen 15 / Win11 + HP EliteBook / Win10, both v2.3.4).

- **LITELLM_KEY blocker (100% repro):** Key was correctly generated in `.env` but Docker Compose V2 on Windows failed to auto-discover it when using multiple `-f` flags. Fix: pass `--env-file .env` explicitly to all `docker compose` invocations (installer + dream.ps1 CLI). Also syncs `[Environment]::CurrentDirectory` after `Push-Location` and adds post-generation `.env` validation that catches missing required keys before compose runs.
- **CLOUD tier silently selected on no-GPU machines:** `ConvertTo-TierFromGpu` returned `CLOUD` for any machine with ≥12GB RAM and no GPU, assigning an API model the user has no key for. Fix: no-GPU machines now get Tier 0/1 (local CPU inference). CLOUD requires explicit `--Cloud` flag, matching Linux installer behavior.
- **OpenCode auto-start during install:** Phase 07 started OpenCode and registered it in Windows Startup without user consent, consuming resources during Docker startup. Fix: VBS launcher still created for manual use, but auto-start and Startup registration removed.
- **ComfyUI enabled for CLOUD tier:** No safety check disabled ComfyUI when tier was CLOUD. Fix: added CLOUD to the ComfyUI disable check.
- **ExecutionPolicy undocumented:** Windows install instructions now include `Set-ExecutionPolicy` command.

## Caveat

The `--env-file` fix is the best available mitigation but the exact Docker Compose V2 behavior that causes `.env` auto-discovery to fail on Windows with multiple `-f` flags is not fully understood. If the LITELLM_KEY error persists after this fix, the next step is to capture `docker compose config` output with and without `--env-file` on the test machines.

## Test plan

- [ ] Re-test on HP Omen 15 (Win11, NVIDIA GTX 1050 Ti) — should get Tier 1 CPU fallback + all services start
- [ ] Re-test on HP EliteBook (Win10, no GPU) — should get Tier 1 (not CLOUD) + all services start
- [ ] Verify `--Cloud` flag still works explicitly on a no-GPU machine
- [ ] Verify OpenCode is NOT running after fresh install
- [ ] Verify `.env` contains all required keys after Phase 06
- [ ] Linux install unaffected (no changes to bash installer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)