### PR TITLE
fix(linux): pre-pull Lemonade image for AMD instead of old toolbox

### DIFF
--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -121,7 +121,7 @@ The installer **automatically detects your GPU** and selects the right configura
 
 Both tiers use `qwen2.5:7b` as a bootstrap model for instant startup. The full model downloads in the background via GGUF from HuggingFace.
 
-**Inference backend:** llama-server via ROCm 7.2 (Docker image: `kyuz0/amd-strix-halo-toolboxes:rocm-7.2`)
+**Inference backend:** Lemonade Server via ROCm (Docker image: `ghcr.io/lemonade-sdk/lemonade-server:latest`)
 
 ### NVIDIA (Discrete GPU)
 

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -22,7 +22,7 @@ show_phase 4 6 "Downloading Modules" "~5-10 minutes"
 # Format: "image|friendly_name"
 PULL_LIST=()
 if [[ "$GPU_BACKEND" == "amd" ]]; then
-    PULL_LIST+=("kyuz0/amd-strix-halo-toolboxes:rocm-7.2|LLAMA-SERVER — downloading the brain (AMD ROCm)")
+    PULL_LIST+=("ghcr.io/lemonade-sdk/lemonade-server:latest|LEMONADE — downloading the brain (AMD ROCm)")
     [[ "$ENABLE_COMFYUI" == "true" ]] && PULL_LIST+=("ignatberesnev/comfyui-gfx1151:v0.2|COMFYUI — image generation engine (gfx1151)")
 elif [[ "$GPU_BACKEND" == "cpu" ]]; then
     PULL_LIST+=("ghcr.io/ggml-org/llama.cpp:server-b8248|LLAMA-SERVER — downloading the brain (CPU)")

--- a/dream-server/memory-shepherd/baselines/dream-agent-MEMORY.md
+++ b/dream-server/memory-shepherd/baselines/dream-agent-MEMORY.md
@@ -11,8 +11,8 @@
 ### Inference Stack
 - **Model:** qwen3-coder-next (80B MoE, 3B active params, ~52GB)
 - **Format:** GGUF (Q4_K_M quantization, from unsloth/Qwen3-Coder-Next-GGUF)
-- **Backend:** llama-server via ROCm 7.2 (NOT Ollama, NOT Vulkan)
-- **Container:** kyuz0/amd-strix-halo-toolboxes:rocm-7.2
+- **Backend:** Lemonade Server via ROCm (NOT Ollama, NOT Vulkan)
+- **Container:** ghcr.io/lemonade-sdk/lemonade-server:latest
 - **Context:** 32,768 tokens
 - **Key flags:** `-fa on --no-mmap -ngl 999 --jinja`
 - **Env:** `ROCBLAS_USE_HIPBLASLT=0`, `HSA_OVERRIDE_GFX_VERSION=11.5.1`


### PR DESCRIPTION
## Summary

- Linux installer Phase 4/6 (08-images.sh) was pre-pulling the old `kyuz0/amd-strix-halo-toolboxes:rocm-7.2` image instead of `ghcr.io/lemonade-sdk/lemonade-server:latest`
- PR #579 updated `docker-compose.amd.yml` to Lemonade but missed the pre-pull list
- Result: ~8GB wasted download, then compose had to pull Lemonade separately at startup
- Also updates README and agent memory baseline to reflect Lemonade backend

## Confirmed on

Strix Halo (Ubuntu, 124GB RAM, AMD Ryzen AI MAX+ 395) — detection, tier selection, and compose selection all correct; only the pre-pull was stale.

## Test plan

- [ ] `grep -r "kyuz0" dream-server/installers/` returns zero matches
- [ ] Image in `08-images.sh` matches `docker-compose.amd.yml` line 10 exactly
- [ ] On Strix Halo: Phase 4/6 shows "LEMONADE — downloading the brain (AMD ROCm)"
- [ ] NVIDIA/CPU paths unchanged (different branches in the same if/elif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)