### PR TITLE
fix(amd): absolute path for lemonade-server entrypoint

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -8,7 +8,7 @@ services:
     # Lemonade Docker image with ROCm support
     # Service name stays "llama-server" for compose dependency compatibility
     image: ghcr.io/lemonade-sdk/lemonade-server:latest
-    entrypoint: ["lemonade-server"]
+    entrypoint: ["/opt/lemonade/lemonade-server"]
     command:
       - serve
       - --port


### PR DESCRIPTION
## Summary

- `lemonade-server` binary is at `/opt/lemonade/lemonade-server` inside the container but `/opt/lemonade` is not in `$PATH`
- Bare entrypoint `["lemonade-server"]` fails with: "executable file not found in $PATH"
- Fix: use absolute path `["/opt/lemonade/lemonade-server"]`

## Test plan

- [ ] `docker compose -f docker-compose.base.yml -f docker-compose.amd.yml config` validates
- [ ] On Strix Halo: `dream-llama-server` container starts successfully
- [ ] Upstream issue: `lemonade-sdk/lemonade` should add `/opt/lemonade` to `$PATH` in their Dockerfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)