### PR TITLE
fix(amd): Lemonade /api/v1 path overrides for Perplexica, Privacy Shield, OpenClaw

### DIFF
--- a/dream-server/config/openclaw/openclaw-strix-halo.json
+++ b/dream-server/config/openclaw/openclaw-strix-halo.json
@@ -9,7 +9,7 @@
   "providers": {
     "local-llama": {
       "type": "openai-compatible",
-      "baseUrl": "http://llama-server:8080/v1",
+      "baseUrl": "http://llama-server:8080/api/v1",
       "apiKey": "none",
       "models": {
         "__LLM_MODEL__": {

--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -55,6 +55,14 @@ services:
       # Lemonade serves at /api/v1, override base compose's /v1 path
       OPENAI_API_BASE_URL: "http://llama-server:8080/api/v1"
 
+  perplexica:
+    environment:
+      OPENAI_BASE_URL: "http://llama-server:8080/api/v1"
+
+  privacy-shield:
+    environment:
+      TARGET_API_URL: "http://llama-server:8080/api/v1"
+
   dashboard-api:
     environment:
       - GPU_BACKEND=amd


### PR DESCRIPTION
## Summary

- Lemonade serves at `/api/v1` while llama-server uses `/v1`
- AMD overlay already overrode Open WebUI and dashboard-api, but 3 services were missed
- **Perplexica**: `OPENAI_BASE_URL` → deep search was broken
- **Privacy Shield**: `TARGET_API_URL` → privacy proxy was broken  
- **OpenClaw**: `openclaw-strix-halo.json` baseUrl → agents were broken

## Changes

- `docker-compose.amd.yml`: added Perplexica + Privacy Shield environment overrides (follows existing Open WebUI pattern)
- `config/openclaw/openclaw-strix-halo.json`: updated baseUrl to `/api/v1` (config only used on Strix Halo tiers which always get the AMD/Lemonade overlay)

## What's NOT changed

- Base compose files for Perplexica/Privacy Shield stay at `/v1` (correct for NVIDIA/CPU)
- Other OpenClaw configs (`openclaw.json`, `pro.json`) stay at `/v1` (used by non-AMD tiers)
- NVIDIA and CPU paths completely untouched

## Test plan

- [ ] `docker compose -f docker-compose.base.yml -f docker-compose.amd.yml config` validates
- [ ] `docker compose -f docker-compose.base.yml -f docker-compose.nvidia.yml config` still validates
- [ ] On Strix Halo: Perplexica search, Privacy Shield proxy, OpenClaw agents all connect to Lemonade

🤖 Generated with [Claude Code](https://claude.com/claude-code)