### PR TITLE
fix(amd): override health endpoint for Lemonade in service registry

### DIFF
--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -194,6 +194,11 @@ sr_resolve_ports() {
             SERVICE_PORTS[$_sid]="${!_port_env}"
         fi
     done
+
+    # Lemonade (AMD) serves health at /api/v1/health, not /health
+    if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
+        SERVICE_HEALTH[llama-server]="/api/v1/health"
+    fi
 }
 
 # Resolve a user-provided name to a compose service ID


### PR DESCRIPTION
## Summary

- Lemonade (AMD) serves health at `/api/v1/health`, not `/health`
- The llama-server manifest has `/health` (correct for llama.cpp, wrong for Lemonade)
- Installer Phase 12 gets stuck ~200s retrying the wrong health endpoint on Strix Halo
- **Fix:** 4 lines in `sr_resolve_ports()` override `SERVICE_HEALTH[llama-server]` when `GPU_BACKEND=amd`
- Single-point fix covers all 7+ scripts that poll service health (installer, validate, preflight, health-check, capability profile, showcase, dream-cli)
- NVIDIA/CPU/Apple paths completely untouched — override only fires when `GPU_BACKEND=amd`

## Test plan

- [ ] AMD/Lemonade: Phase 12 health check hits `/api/v1/health` and passes immediately
- [ ] NVIDIA: `SERVICE_HEALTH[llama-server]` remains `/health` — zero behavioral change
- [ ] CPU-only: same — zero behavioral change
- [ ] `make test` passes
- [ ] `make smoke` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)