### PR TITLE
fix(ape): replace curl healthcheck with python urllib

### DIFF
--- a/dream-server/extensions/services/ape/compose.yaml
+++ b/dream-server/extensions/services/ape/compose.yaml
@@ -28,7 +28,7 @@ services:
           cpus: '0.1'
           memory: 64M
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:7890/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:7890/health')"]
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
## Summary

- APE container uses `python:3.12-slim` which doesn't include `curl`
- Healthcheck in `compose.yaml` uses `curl` → container runs fine but Docker reports it as unhealthy
- Replace with `python3 -c "import urllib.request; urllib.request.urlopen(...)"` using stdlib
- Only APE is affected — other services with curl healthchecks (embeddings, comfyui) use images that include it

## Test plan

- [ ] APE container reports healthy after start
- [ ] `docker inspect dream-ape --format='{{.State.Health.Status}}'` returns `healthy`
- [ ] No other services affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)