### PR TITLE
fix(amd): add libatomic1 to Lemonade image for ROCm inference

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -5,9 +5,12 @@
 
 services:
   llama-server:
-    # Lemonade Docker image with ROCm support
+    # Lemonade Docker image with ROCm support + libatomic1 fix
     # Service name stays "llama-server" for compose dependency compatibility
-    image: ghcr.io/lemonade-sdk/lemonade-server:latest
+    build:
+      context: ./extensions/services/llama-server
+      dockerfile: Dockerfile.amd
+    image: dream-lemonade-server:latest
     entrypoint: ["/opt/lemonade/lemonade-server"]
     command:
       - serve

--- a/dream-server/extensions/services/llama-server/Dockerfile.amd
+++ b/dream-server/extensions/services/llama-server/Dockerfile.amd
@@ -1,0 +1,7 @@
+FROM ghcr.io/lemonade-sdk/lemonade-server:latest
+
+# ROCm llama-server binary requires libatomic1 which is missing from the
+# upstream Lemonade image. Without it, lemonade-server starts but inference
+# requests crash the llama-server subprocess with exit code 127.
+RUN apt-get update && apt-get install -y --no-install-recommends libatomic1 \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Summary

- ROCm `llama-server` binary inside the Lemonade image requires `libatomic.so.1`
- Upstream `ghcr.io/lemonade-sdk/lemonade-server:latest` doesn't include it
- Lemonade server starts fine, but inference requests crash the llama-server subprocess with exit code 127
- **Fix:** Thin `Dockerfile.amd` extends the upstream image with `apt-get install libatomic1`
- `docker-compose.amd.yml` switches from `image:` to `build:` so the patched image is built locally
- Tagged as `dream-lemonade-server:latest` so rebuilds only happen when the upstream image or Dockerfile changes
- NVIDIA/CPU/Apple paths untouched — `Dockerfile.amd` and `docker-compose.amd.yml` only used on AMD

## Test plan

- [ ] On Strix Halo: inference requests return completions instead of exit code 127
- [ ] `docker compose -f docker-compose.base.yml -f docker-compose.amd.yml config` validates
- [ ] `docker compose -f docker-compose.base.yml -f docker-compose.nvidia.yml config` still validates (untouched)
- [ ] First build adds ~10s for apt-get; subsequent runs use cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)