### PR TITLE
fix(amd): LLM_API_URL heredoc evaluates shell var not .env value

### DIFF
--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -297,7 +297,7 @@ DREAM_VERSION=${VERSION:-2.3.4}
 
 #=== LLM Backend Mode ===
 DREAM_MODE=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo "${DREAM_MODE:-local}"; fi)
-LLM_API_URL=$(if [[ "${DREAM_MODE:-local}" == "local" ]]; then echo "http://llama-server:8080"; else echo "http://litellm:4000"; fi)
+LLM_API_URL=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "http://litellm:4000"; elif [[ "${DREAM_MODE:-local}" == "local" ]]; then echo "http://llama-server:8080"; else echo "http://litellm:4000"; fi)
 
 #=== Cloud API Keys ===
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}


### PR DESCRIPTION
## Summary

- Line 299 writes `DREAM_MODE=lemonade` into the .env as **text**
- Line 300 evaluates `${DREAM_MODE:-local}` as the **shell variable**, which is still `local`
- Result: AMD gets `LLM_API_URL=http://llama-server:8080` — services bypass LiteLLM, model aliasing doesn't work
- **Fix:** Mirror line 299's `GPU_BACKEND == "amd"` check so AMD correctly gets `http://litellm:4000`

Found by Mike's audit of PR #586.

## Test plan

- [ ] AMD install: .env contains `LLM_API_URL=http://litellm:4000`
- [ ] NVIDIA install: .env contains `LLM_API_URL=http://llama-server:8080`
- [ ] Cloud mode on AMD: .env contains `LLM_API_URL=http://litellm:4000` (cloud.yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)