### PR TITLE
fix(amd): add lemonade to DREAM_MODE enum in schema

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -17,11 +17,12 @@
     },
     "DREAM_MODE": {
       "type": "string",
-      "description": "LLM backend mode: local, cloud, or hybrid",
+      "description": "LLM backend mode: local, cloud, hybrid, or lemonade (AMD)",
       "enum": [
         "local",
         "cloud",
-        "hybrid"
+        "hybrid",
+        "lemonade"
       ],
       "default": "local"
     },


### PR DESCRIPTION
## Summary

- PR #586 sets `DREAM_MODE=lemonade` for AMD installs
- `.env.schema.json` only allows `["local", "cloud", "hybrid"]`
- Phase 06 validates .env against schema → installer crashes on AMD
- **Fix:** Add `"lemonade"` to the enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)