### PR TITLE
fix(amd): resolve blockers 7, 8, 11 for Lemonade

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -38,6 +38,7 @@ services:
       - HSA_OVERRIDE_GFX_VERSION=11.5.1
       - ROCBLAS_USE_HIPBLASLT=0
       - LEMONADE_LLAMACPP_BACKEND=rocm
+      - LEMONADE_CTX_SIZE=${CTX_SIZE:-131072}
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://localhost:8080/api/v1/health"]
       interval: 15s
@@ -53,9 +54,12 @@ services:
           cpus: '4.0'
           memory: 8G
 
-  # Services no longer need /api/v1 overrides here — they route through
-  # LiteLLM (DREAM_MODE=lemonade sets LLM_API_URL=http://litellm:4000).
+  # Services route through LiteLLM (DREAM_MODE=lemonade sets LLM_API_URL=http://litellm:4000).
   # LiteLLM handles the /api/v1 translation to Lemonade internally.
+
+  open-webui:
+    environment:
+      - OPENAI_API_KEY=${LITELLM_KEY}
 
   dashboard-api:
     environment:

--- a/dream-server/extensions/services/perplexica/compose.yaml
+++ b/dream-server/extensions/services/perplexica/compose.yaml
@@ -8,7 +8,7 @@ services:
     environment:
       - SEARXNG_API_URL=http://searxng:8080
       - OPENAI_BASE_URL=${LLM_API_URL:-http://llama-server:8080}/v1
-      - OPENAI_API_KEY=no-key
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-no-key}
     volumes:
       - perplexica-data:/home/perplexica/data
       - perplexica-uploads:/home/perplexica/uploads

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -301,8 +301,11 @@ LLM_API_URL=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local"
 
 #=== Cloud API Keys ===
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-OPENAI_API_KEY=${OPENAI_API_KEY:-}
+OPENAI_API_KEY=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "$LITELLM_KEY"; else echo "${OPENAI_API_KEY:-}"; fi)
 TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
+
+#=== Service Auth (LiteLLM proxy) ===
+TARGET_API_KEY=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "$LITELLM_KEY"; else echo "not-needed"; fi)
 
 #=== LLM Settings (llama-server) ===
 LLM_MODEL=${LLM_MODEL}

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -316,6 +316,7 @@ MODELS_INI_EOF
     _build_count=0
     _build_services=(dashboard dashboard-api ape token-spy privacy-shield)
     [[ "$ENABLE_COMFYUI" == "true" ]] && _build_services+=(comfyui)
+    [[ "$GPU_BACKEND" == "amd" ]] && _build_services+=(llama-server)
     _build_total=${#_build_services[@]}
     for _svc in "${_build_services[@]}"; do
         _build_count=$((_build_count + 1))


### PR DESCRIPTION
## Summary

- **Issue 7:** Add llama-server to Phase 11 build list when `GPU_BACKEND=amd` — Dockerfile.amd was never built, compose tried to pull non-existent image from Docker Hub
- **Issue 8:** Propagate `LITELLM_KEY` as bearer token to Open WebUI, Perplexica, Privacy Shield when routing through LiteLLM on AMD
- **Issue 11:** Pass `LEMONADE_CTX_SIZE` env var to Lemonade container — was defaulting to 4096 tokens, breaking OpenCode's 10K+ token prompts

## Files changed (4)

- `installers/phases/11-services.sh` — add llama-server to AMD build list
- `extensions/services/perplexica/compose.yaml` — make OPENAI_API_KEY env-substitutable
- `installers/phases/06-directories.sh` — set OPENAI_API_KEY/TARGET_API_KEY to LITELLM_KEY for AMD
- `docker-compose.amd.yml` — Open WebUI API key override + CTX_SIZE env var

## Non-AMD paths: zero change

- NVIDIA/CPU: llama-server not in build list (gated by GPU_BACKEND=amd)
- Perplexica: defaults to `no-key` when OPENAI_API_KEY not in .env
- TARGET_API_KEY: defaults to `not-needed` for non-AMD
- CTX_SIZE: only in AMD compose overlay

## Test plan

- [ ] Fresh AMD install: `docker compose build` includes llama-server → image exists
- [ ] Fresh AMD install: Perplexica, Open WebUI, Privacy Shield authenticate to LiteLLM
- [ ] Fresh AMD install: OpenCode prompt doesn't overflow context (CTX_SIZE=131072)
- [ ] Fresh NVIDIA install: zero behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)