### PR TITLE
fix(amd): OpenClaw schema + dashboard-api health for Lemonade

### DIFF
--- a/dream-server/config/openclaw/openclaw-strix-halo.json
+++ b/dream-server/config/openclaw/openclaw-strix-halo.json
@@ -1,29 +1,37 @@
 {
   "$schema": "https://raw.githubusercontent.com/openclaw/openclaw/main/schemas/openclaw.json",
-  "version": "1.0",
-  "agent": {
-    "name": "Dream Agent (Strix Halo)",
-    "model": "local-llama/__LLM_MODEL__",
-    "systemPrompt": "You are Dream Agent, a powerful local AI assistant running on AMD Strix Halo with unified memory. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning. Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself. Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it."
-  },
-  "providers": {
-    "local-llama": {
-      "type": "openai-compatible",
-      "baseUrl": "http://llama-server:8080/api/v1",
-      "apiKey": "none",
-      "models": {
-        "__LLM_MODEL__": {
-          "contextWindow": 131072,
-          "supportsTools": true
-        }
+  "models": {
+    "providers": {
+      "local-llama": {
+        "type": "openai-compatible",
+        "baseUrl": "http://litellm:4000/v1",
+        "apiKey": "__LITELLM_KEY__",
+        "models": [
+          {
+            "id": "__LLM_MODEL__",
+            "contextWindow": 131072,
+            "supportsTools": true
+          }
+        ]
       }
     }
   },
-  "subagent": {
-    "enabled": true,
-    "model": "local-llama/__LLM_MODEL__",
-    "maxConcurrent": 20,
-    "timeoutSeconds": 600
+  "agents": {
+    "defaults": {
+      "name": "Dream Agent (Strix Halo)",
+      "model": {
+        "primary": "local-llama/__LLM_MODEL__"
+      },
+      "models": {
+        "local-llama/__LLM_MODEL__": {}
+      },
+      "systemPrompt": "You are Dream Agent, a powerful local AI assistant running on AMD Strix Halo with unified memory. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning. Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself. Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it.",
+      "subagents": {
+        "model": "local-llama/__LLM_MODEL__",
+        "maxConcurrent": 20,
+        "timeoutSeconds": 600
+      }
+    }
   },
   "tools": {
     "exec": {
@@ -46,7 +54,6 @@
   },
   "gateway": {
     "port": 7860,
-    "host": "127.0.0.1",
     "controlUi": {
       "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -136,6 +136,13 @@ SERVICES = MANIFEST_SERVICES
 if not SERVICES:
     logger.error("No services loaded from manifests in %s — dashboard will have no services", EXTENSIONS_DIR)
 
+# Lemonade serves at /api/v1 instead of llama.cpp's /v1. Override the
+# health path so the dashboard poll loop hits the correct endpoint.
+LLM_BACKEND = os.environ.get("LLM_BACKEND", "")
+if LLM_BACKEND == "lemonade" and "llama-server" in SERVICES:
+    SERVICES["llama-server"]["health"] = "/api/v1/health"
+    logger.info("Lemonade backend detected — overriding llama-server health to /api/v1/health")
+
 # --- Features ---
 
 FEATURES = MANIFEST_FEATURES

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -13,8 +13,11 @@ from typing import Optional
 import aiohttp
 import httpx
 
-from config import SERVICES, INSTALL_DIR, DATA_DIR
+from config import SERVICES, INSTALL_DIR, DATA_DIR, LLM_BACKEND
 from models import ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus
+
+# Lemonade serves at /api/v1 instead of llama.cpp's /v1
+_LLM_API_PREFIX = "/api/v1" if LLM_BACKEND == "lemonade" else "/v1"
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +135,7 @@ async def get_loaded_model() -> Optional[str]:
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
         client = await _get_httpx_client()
-        resp = await client.get(f"http://{host}:{port}/v1/models")
+        resp = await client.get(f"http://{host}:{port}{_LLM_API_PREFIX}/models")
         models = resp.json().get("data", [])
         for m in models:
             status = m.get("status", {})

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -112,6 +112,8 @@ else
         _sed_i "s|__LLM_MODEL__|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
         _sed_i "s|Qwen/Qwen2.5-[^\"]*|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
         _sed_i "s|local-ollama|${_oc_prov_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
+        _oc_key_esc=$(_sed_escape "${LITELLM_KEY:-none}")
+        _sed_i "s|__LITELLM_KEY__|${_oc_key_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"
         log "Installed OpenClaw config: $OPENCLAW_CONFIG -> openclaw.json (model: $OPENCLAW_MODEL)"
         mkdir -p "$INSTALL_DIR/data/openclaw/home/agents/main/sessions"
         # Generate OpenClaw home config with local llama-server provider


### PR DESCRIPTION
## Summary

- **Issue 12:** Update `openclaw-strix-halo.json` to OpenClaw 2026.3.8 schema. Old schema keys (`agent`, `providers`, `subagent`, `version`, `gateway.host`) replaced with new schema (`agents.defaults`, `models.providers`, `agents.defaults.subagents`). Routes through LiteLLM (`litellm:4000/v1`) instead of direct `llama-server:8080/api/v1`. Adds `__LITELLM_KEY__` placeholder resolved by sed at install time.

- **Issue 2b:** Dashboard-api overrides llama-server health path from `/health` to `/api/v1/health` when `LLM_BACKEND=lemonade`. Also fixes `get_loaded_model()` to query `/api/v1/models` instead of `/v1/models`. Metrics and props endpoints stay at root (llama.cpp-specific, gracefully handled if unavailable).

## Files changed (4)

- `config/openclaw/openclaw-strix-halo.json` — new OpenClaw 2026.3.8 schema
- `extensions/services/dashboard-api/config.py` — Lemonade health path override
- `extensions/services/dashboard-api/helpers.py` — `_LLM_API_PREFIX` for model queries
- `installers/phases/06-directories.sh` — sed replacement for `__LITELLM_KEY__`

## Non-AMD paths: zero change

- `LLM_BACKEND` defaults to empty string — health override doesn't fire
- `_LLM_API_PREFIX` defaults to `/v1` — same as before
- Other OpenClaw configs (`openclaw.json`, `pro.json`) untouched

## Test plan

- [ ] Fresh AMD install: dashboard shows llama-server as healthy
- [ ] Fresh AMD install: OpenClaw starts without crash-loop
- [ ] Fresh AMD install: dashboard inference metrics populate
- [ ] Fresh NVIDIA install: zero behavioral change

🤖 Generated with [Claude Code](https://claude.com/claude-code)