### PR TITLE
fix(amd): pin Lemonade image to v10.0.0

### DIFF
--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -121,7 +121,7 @@ The installer **automatically detects your GPU** and selects the right configura
 
 Both tiers use `qwen2.5:7b` as a bootstrap model for instant startup. The full model downloads in the background via GGUF from HuggingFace.
 
-**Inference backend:** Lemonade Server via ROCm (Docker image: `ghcr.io/lemonade-sdk/lemonade-server:latest`)
+**Inference backend:** Lemonade Server via ROCm (Docker image: `ghcr.io/lemonade-sdk/lemonade-server:v10.0.0`)
 
 ### NVIDIA (Discrete GPU)
 

--- a/dream-server/extensions/services/llama-server/Dockerfile.amd
+++ b/dream-server/extensions/services/llama-server/Dockerfile.amd
@@ -1,4 +1,4 @@
-FROM ghcr.io/lemonade-sdk/lemonade-server:latest
+FROM ghcr.io/lemonade-sdk/lemonade-server:v10.0.0
 
 # ROCm llama-server binary requires libatomic1 which is missing from the
 # upstream Lemonade image. Without it, lemonade-server starts but inference

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -22,7 +22,7 @@ show_phase 4 6 "Downloading Modules" "~5-10 minutes"
 # Format: "image|friendly_name"
 PULL_LIST=()
 if [[ "$GPU_BACKEND" == "amd" ]]; then
-    PULL_LIST+=("ghcr.io/lemonade-sdk/lemonade-server:latest|LEMONADE — downloading the brain (AMD ROCm)")
+    PULL_LIST+=("ghcr.io/lemonade-sdk/lemonade-server:v10.0.0|LEMONADE — downloading the brain (AMD ROCm)")
     [[ "$ENABLE_COMFYUI" == "true" ]] && PULL_LIST+=("ignatberesnev/comfyui-gfx1151:v0.2|COMFYUI — image generation engine (gfx1151)")
 elif [[ "$GPU_BACKEND" == "cpu" ]]; then
     PULL_LIST+=("ghcr.io/ggml-org/llama.cpp:server-b8248|LLAMA-SERVER — downloading the brain (CPU)")

--- a/dream-server/memory-shepherd/baselines/dream-agent-MEMORY.md
+++ b/dream-server/memory-shepherd/baselines/dream-agent-MEMORY.md
@@ -12,7 +12,7 @@
 - **Model:** qwen3-coder-next (80B MoE, 3B active params, ~52GB)
 - **Format:** GGUF (Q4_K_M quantization, from unsloth/Qwen3-Coder-Next-GGUF)
 - **Backend:** Lemonade Server via ROCm (NOT Ollama, NOT Vulkan)
-- **Container:** ghcr.io/lemonade-sdk/lemonade-server:latest
+- **Container:** ghcr.io/lemonade-sdk/lemonade-server:v10.0.0
 - **Context:** 32,768 tokens
 - **Key flags:** `-fa on --no-mmap -ngl 999 --jinja`
 - **Env:** `ROCBLAS_USE_HIPBLASLT=0`, `HSA_OVERRIDE_GFX_VERSION=11.5.1`


### PR DESCRIPTION
## Summary

- Pins `ghcr.io/lemonade-sdk/lemonade-server` from `:latest` to `:v10.0.0` across all references
- Prevents upstream Lemonade releases from silently breaking DreamServer installs
- The `:latest` tag already shipped without `libatomic1` — pinning ensures we only use a tested version

## Changed files

| File | Change |
|---|---|
| `Dockerfile.amd` | `FROM` tag `:latest` → `:v10.0.0` |
| `08-images.sh` | Pre-pull tag `:latest` → `:v10.0.0` |
| `README.md` | Doc reference updated |
| `dream-agent-MEMORY.md` | Doc reference updated |

## Upgrade process

When a new Lemonade version releases:
1. Test on Strix Halo
2. Confirm no regressions
3. Bump the tag in these 4 files

## Test plan

- [ ] `docker compose -f docker-compose.base.yml -f docker-compose.amd.yml config` resolves correct image
- [ ] `docker compose build llama-server` pulls v10.0.0 and builds successfully
- [ ] NVIDIA/CPU paths unaffected (don't reference this image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)