### PR TITLE
fix(amd): correct path to bootstrap-model.sh in Phase 06

### DIFF
--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -411,7 +411,7 @@ ENV_EOF
     # Uses BOOTSTRAP_GGUF_FILE because the full model may still be downloading
     # when services first start. Background upgrade will update this config later.
     if [[ "$GPU_BACKEND" == "amd" ]]; then
-        source "$SCRIPT_DIR/lib/bootstrap-model.sh"
+        source "$SCRIPT_DIR/installers/lib/bootstrap-model.sh"
         _lemonade_gguf="${BOOTSTRAP_GGUF_FILE}"
         mkdir -p "$INSTALL_DIR/config/litellm"
         cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF


### PR DESCRIPTION
## Summary

- Phase 06 line 414 sourced `$SCRIPT_DIR/lib/bootstrap-model.sh` — file doesn't exist at that path
- Correct path is `$SCRIPT_DIR/installers/lib/bootstrap-model.sh`
- Crashes AMD installs at Phase 06 due to `set -euo pipefail`

## Test plan

- [ ] AMD install passes Phase 06 without crashing
- [ ] NVIDIA/CPU installs unaffected (line only executes when `GPU_BACKEND=amd`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)