### PR TITLE
fix: add missing env vars to .env.schema.json

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -31,6 +31,20 @@
       "description": "URL where all services send LLM requests",
       "default": "http://llama-server:8080"
     },
+    "LLM_BACKEND": {
+      "type": "string",
+      "description": "Inference backend: llama-server or lemonade",
+      "default": "llama-server"
+    },
+    "LLM_API_BASE_PATH": {
+      "type": "string",
+      "description": "Base API path for the inference backend",
+      "default": "/v1"
+    },
+    "TARGET_API_KEY": {
+      "type": "string",
+      "description": "API key for Privacy Shield upstream target (set to LITELLM_KEY in lemonade mode)"
+    },
     "ANTHROPIC_API_KEY": {
       "type": "string",
       "description": "Anthropic API key (cloud/hybrid modes)"


### PR DESCRIPTION
## Summary

- `TARGET_API_KEY` — added by PR #589 (Issue 8, LiteLLM auth), missing from schema
- `LLM_BACKEND` — present in .env.example, written by Phase 06, missing from schema
- `LLM_API_BASE_PATH` — present in .env.example, written by Phase 06, missing from schema

All three cause schema validation to crash the installer with "Unknown keys not defined in schema."

## Test plan

- [ ] AMD install passes schema validation in Phase 06
- [ ] NVIDIA/CPU installs unaffected (these keys are written for all modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)