### PR TITLE
fix(installer): CPU backend wrongly overridden to nvidia when capability profile loaded

### DIFF
--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -113,6 +113,8 @@ if [[ "${CAP_PROFILE_LOADED:-false}" == "true" ]]; then
     case "${CAP_LLM_BACKEND:-}" in
         amd)   GPU_BACKEND="amd" ;;
         intel) GPU_BACKEND="intel" ;;
+        cpu)   GPU_BACKEND="cpu" ;;
+        apple) GPU_BACKEND="apple" ;;
         *) GPU_BACKEND="nvidia" ;;
     esac
     [[ -n "${CAP_GPU_MEMORY_TYPE:-}" ]] && GPU_MEMORY_TYPE="${CAP_GPU_MEMORY_TYPE}"


### PR DESCRIPTION
On CPU-only Linux machines, when the capability profile loads with CAP_LLM_BACKEND=cpu, 
the case statement in 02-detection.sh didn't handle cpu or apple — they fell through 
to the default and set GPU_BACKEND=nvidia.

This caused:
- Misleading preflight warning: "NVIDIA backend selected but no NVIDIA GPU VRAM was detected"
- Wrong backend passed to preflight checks

Fix: Add explicit cpu and apple cases so the correct backend is preserved.