### PR TITLE
fix(amd): model alias, OpenClaw auth, OpenCode reinstall (issues 15-17)

### DIFF
--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -65,6 +65,22 @@ try {
 
     if (providerName && config.models.providers[providerName]) {
       const provider = config.models.providers[providerName];
+
+      // Route through LiteLLM when OLLAMA_URL points to it, and pass credentials
+      const ollamaUrl = process.env.OLLAMA_URL || '';
+      const litellmKey = process.env.LITELLM_KEY || '';
+      if (ollamaUrl) {
+        const newBase = ollamaUrl.replace(/\/$/, '') + '/v1';
+        if (provider.baseUrl !== newBase) {
+          console.log(`[inject-token] updated provider baseUrl: ${provider.baseUrl} -> ${newBase}`);
+          provider.baseUrl = newBase;
+        }
+        if (litellmKey && provider.apiKey !== litellmKey) {
+          provider.apiKey = litellmKey;
+          console.log(`[inject-token] updated provider apiKey from env`);
+        }
+      }
+
       // Update model list — replace the first model's id
       if (Array.isArray(provider.models) && provider.models.length > 0) {
         const oldId = provider.models[0].id;

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -12,6 +12,7 @@ services:
       - LLM_MODEL=${LLM_MODEL:-qwen3:30b-a3b}
       - BOOTSTRAP_MODEL=${BOOTSTRAP_MODEL:-qwen3:8b-q4_K_M}
       - OLLAMA_URL=${LLM_API_URL:-http://llama-server:8080}
+      - LITELLM_KEY=${LITELLM_KEY:-}
       - SEARXNG_BASE_URL=http://searxng:8080
     entrypoint: ["/bin/sh", "-c", "node /config/inject-token.js; exec docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured --bind lan"]
     volumes:

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -416,7 +416,15 @@ ENV_EOF
         mkdir -p "$INSTALL_DIR/config/litellm"
         cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
 model_list:
+  # Tier model alias → bootstrap GGUF (upgraded later by background download)
   - model_name: "${LLM_MODEL}"
+    litellm_params:
+      model: "openai/extra.${_lemonade_gguf}"
+      api_base: http://llama-server:8080/api/v1
+      api_key: sk-lemonade
+
+  # Bootstrap model alias → same GGUF (services use this after Phase 10 overwrites LLM_MODEL)
+  - model_name: "${BOOTSTRAP_LLM_MODEL}"
     litellm_params:
       model: "openai/extra.${_lemonade_gguf}"
       api_base: http://llama-server:8080/api/v1

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -106,21 +106,22 @@ else
     if [[ -x "$HOME/.opencode/bin/opencode" ]]; then
         OPENCODE_CONFIG_DIR="$HOME/.config/opencode"
         mkdir -p "$OPENCODE_CONFIG_DIR"
+        # Read OLLAMA_PORT and DREAM_MODE from .env generated in phase 06
+        if [[ -f "$INSTALL_DIR/.env" ]]; then
+            [[ -z "${OLLAMA_PORT:-}" ]] && OLLAMA_PORT=$(grep -m1 '^OLLAMA_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            [[ -z "${DREAM_MODE:-}" ]] && DREAM_MODE=$(grep -m1 '^DREAM_MODE=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            [[ -z "${LITELLM_KEY:-}" ]] && LITELLM_KEY=$(grep -m1 '^LITELLM_KEY=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+        fi
+        # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise
+        if [[ "${DREAM_MODE:-local}" == "lemonade" ]]; then
+            _opencode_url="http://127.0.0.1:4000/v1"
+            _opencode_key="${LITELLM_KEY:-no-key}"
+        else
+            _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1"
+            _opencode_key="no-key"
+        fi
+
         if [[ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]]; then
-            # Read OLLAMA_PORT and DREAM_MODE from .env generated in phase 06
-            if [[ -f "$INSTALL_DIR/.env" ]]; then
-                [[ -z "${OLLAMA_PORT:-}" ]] && OLLAMA_PORT=$(grep -m1 '^OLLAMA_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
-                [[ -z "${DREAM_MODE:-}" ]] && DREAM_MODE=$(grep -m1 '^DREAM_MODE=' "$INSTALL_DIR/.env" | cut -d= -f2-)
-                [[ -z "${LITELLM_KEY:-}" ]] && LITELLM_KEY=$(grep -m1 '^LITELLM_KEY=' "$INSTALL_DIR/.env" | cut -d= -f2-)
-            fi
-            # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise
-            if [[ "${DREAM_MODE:-local}" == "lemonade" ]]; then
-                _opencode_url="http://127.0.0.1:4000/v1"
-                _opencode_key="${LITELLM_KEY:-no-key}"
-            else
-                _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1"
-                _opencode_key="no-key"
-            fi
             cat > "$OPENCODE_CONFIG_DIR/opencode.json" <<OPENCODE_EOF
 {
   "\$schema": "https://opencode.ai/config.json",
@@ -147,12 +148,15 @@ else
   }
 }
 OPENCODE_EOF
-            # OpenCode reads config.json, not opencode.json
-            cp "$OPENCODE_CONFIG_DIR/opencode.json" "$OPENCODE_CONFIG_DIR/config.json"
             ai_ok "OpenCode configured for local llama-server (model: ${LLM_MODEL})"
         else
-            ai_ok "OpenCode config already exists — skipping"
+            # Reinstall: update API key and URL in existing config (key may have changed)
+            _sed_i "s|\"apiKey\":.*|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+            _sed_i "s|\"baseURL\":.*|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+            ai_ok "OpenCode config updated (API key and URL refreshed)"
         fi
+        # OpenCode reads config.json, not opencode.json — always sync
+        cp "$OPENCODE_CONFIG_DIR/opencode.json" "$OPENCODE_CONFIG_DIR/config.json"
 
         # Install OpenCode Web UI as user-level systemd service (no sudo required)
         if [[ -f "$INSTALL_DIR/opencode/opencode-web.service" ]]; then


### PR DESCRIPTION
## Summary

- **Issue 15**: LiteLLM config now aliases both tier model name (`qwen3-coder-next`) and bootstrap model name (`qwen3.5-2b`) to the same GGUF. Services work immediately after Phase 10 overwrites LLM_MODEL.
- **Issue 16**: inject-token.js patches OpenClaw provider `baseUrl` and `apiKey` from `OLLAMA_URL` and `LITELLM_KEY` env vars. OpenClaw compose now passes `LITELLM_KEY` to the container.
- **Issue 17**: OpenCode API key and URL are always refreshed on reinstall (not skipped when config exists). `config.json` copy always runs to stay in sync.

## Changes

| File | Change |
|---|---|
| `installers/phases/06-directories.sh` | Add bootstrap model alias entry to LiteLLM lemonade.yaml |
| `config/openclaw/inject-token.js` | Patch provider baseUrl + apiKey from OLLAMA_URL + LITELLM_KEY |
| `extensions/services/openclaw/compose.yaml` | Pass LITELLM_KEY to container |
| `installers/phases/07-devtools.sh` | Always refresh API key/URL on reinstall, always sync config.json |

## Test plan

- [ ] Fresh AMD install: LiteLLM resolves both `qwen3-coder-next` and `qwen3.5-2b`
- [ ] OpenClaw: inject-token.js logs show updated baseUrl and apiKey
- [ ] OpenCode reinstall: API key matches current LITELLM_KEY
- [ ] NVIDIA/CPU: zero behavioral change (all changes gated by AMD/lemonade checks or harmless defaults)

🤖 Generated with [Claude Code](https://claude.com/claude-code)