### PR TITLE
fix: remove OpenCode password for localhost-only service

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -163,19 +163,11 @@ OPENCODE_EOF
             SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
             mkdir -p "$SYSTEMD_USER_DIR"
 
-            # Read OPENCODE_SERVER_PASSWORD from .env
-            OPENCODE_SERVER_PASSWORD=""
-            if [[ -f "$INSTALL_DIR/.env" ]]; then
-                OPENCODE_SERVER_PASSWORD=$(grep -m1 '^OPENCODE_SERVER_PASSWORD=' "$INSTALL_DIR/.env" | cut -d= -f2-)
-            fi
-
             svc_tmp="/tmp/opencode-web.service.$$"
             cp "$INSTALL_DIR/opencode/opencode-web.service" "$svc_tmp"
-            # Escape sed special chars to prevent injection from path or password values
+            # Escape sed special chars to prevent injection from path values
             _home_esc=$(printf '%s\n' "$HOME" | sed 's/[&/\]/\\&/g')
-            _pass_esc=$(printf '%s\n' "${OPENCODE_SERVER_PASSWORD}" | sed 's/[&/\]/\\&/g')
             _sed_i "s|__HOME__|${_home_esc}|g" "$svc_tmp"
-            _sed_i "s|__OPENCODE_SERVER_PASSWORD__|${_pass_esc}|g" "$svc_tmp"
             cp "$svc_tmp" "$SYSTEMD_USER_DIR/opencode-web.service"
             rm -f "$svc_tmp"
 
@@ -183,8 +175,6 @@ OPENCODE_EOF
             systemctl --user enable --now opencode-web.service >> "$LOG_FILE" 2>&1 && \
                 ai_ok "OpenCode Web UI service installed (user-level, port 3003)" || \
                 ai_warn "OpenCode Web UI service failed to start"
-            [[ -n "${OPENCODE_SERVER_PASSWORD}" ]] && \
-                ai "OpenCode web UI password: ${OPENCODE_SERVER_PASSWORD}"
 
             # Enable lingering so service survives logout
             loginctl enable-linger "$(whoami)" 2>/dev/null || \

--- a/dream-server/opencode/opencode-web.service
+++ b/dream-server/opencode/opencode-web.service
@@ -13,7 +13,6 @@ RestartSec=5
 # Environment
 Environment=HOME=__HOME__
 Environment=PATH=__HOME__/.opencode/bin:/usr/local/bin:/usr/bin:/bin
-Environment=OPENCODE_SERVER_PASSWORD=__OPENCODE_SERVER_PASSWORD__
 
 # Hardening
 NoNewPrivileges=true


### PR DESCRIPTION
## Summary

- Removes `OPENCODE_SERVER_PASSWORD` from the systemd unit template and installer substitution logic
- The service binds to `--hostname 127.0.0.1` (hardcoded in template line 9) — inaccessible from the network
- A password on a localhost-only service adds a login prompt with no security benefit

## Changes

| File | Change |
|---|---|
| `opencode/opencode-web.service` | Remove `Environment=OPENCODE_SERVER_PASSWORD=__OPENCODE_SERVER_PASSWORD__` |
| `installers/phases/07-devtools.sh` | Remove password read from .env, remove sed substitution, remove password display |

## Test plan

- [ ] Fresh install: OpenCode web UI on port 3003 loads without login prompt
- [ ] Reinstall: no regression — service starts clean
- [ ] If service is ever changed to bind 0.0.0.0, password should be re-added

🤖 Generated with [Claude Code](https://claude.com/claude-code)