### PR TITLE
fix(amd): remove LiteLLM auth + fix stale DREAM_MODE (Issues 16, 18)

### DIFF
--- a/dream-server/config/litellm/lemonade.yaml
+++ b/dream-server/config/litellm/lemonade.yaml
@@ -14,9 +14,6 @@ model_list:
       api_base: http://llama-server:8080/api/v1
       api_key: sk-lemonade
 
-general_settings:
-  master_key: os.environ/LITELLM_MASTER_KEY
-
 litellm_settings:
   drop_params: true
   set_verbose: false

--- a/dream-server/extensions/services/litellm/compose.yaml
+++ b/dream-server/extensions/services/litellm/compose.yaml
@@ -6,7 +6,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - LITELLM_MASTER_KEY=${LITELLM_KEY:?LITELLM_KEY must be set in .env}
+      - LITELLM_MASTER_KEY=${LITELLM_KEY:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -303,11 +303,11 @@ LLM_API_URL=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local"
 
 #=== Cloud API Keys ===
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
-OPENAI_API_KEY=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "$LITELLM_KEY"; else echo "${OPENAI_API_KEY:-}"; fi)
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
 TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
 
 #=== Service Auth (LiteLLM proxy) ===
-TARGET_API_KEY=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "$LITELLM_KEY"; else echo "not-needed"; fi)
+TARGET_API_KEY=not-needed
 
 #=== LLM Settings (llama-server) ===
 LLM_MODEL=${LLM_MODEL}
@@ -435,9 +435,6 @@ model_list:
       model: openai/*
       api_base: http://llama-server:8080/api/v1
       api_key: sk-lemonade
-
-general_settings:
-  master_key: os.environ/LITELLM_MASTER_KEY
 
 litellm_settings:
   drop_params: true

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -109,13 +109,15 @@ else
         # Read OLLAMA_PORT and DREAM_MODE from .env generated in phase 06
         if [[ -f "$INSTALL_DIR/.env" ]]; then
             [[ -z "${OLLAMA_PORT:-}" ]] && OLLAMA_PORT=$(grep -m1 '^OLLAMA_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
-            [[ -z "${DREAM_MODE:-}" ]] && DREAM_MODE=$(grep -m1 '^DREAM_MODE=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            # Always re-read DREAM_MODE from .env — Phase 06 may have changed it
+            # (e.g. "local" → "lemonade" for AMD) but the shell variable is stale.
+            DREAM_MODE=$(grep -m1 '^DREAM_MODE=' "$INSTALL_DIR/.env" | cut -d= -f2-)
             [[ -z "${LITELLM_KEY:-}" ]] && LITELLM_KEY=$(grep -m1 '^LITELLM_KEY=' "$INSTALL_DIR/.env" | cut -d= -f2-)
         fi
         # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise
         if [[ "${DREAM_MODE:-local}" == "lemonade" ]]; then
             _opencode_url="http://127.0.0.1:4000/v1"
-            _opencode_key="${LITELLM_KEY:-no-key}"
+            _opencode_key="no-key"  # LiteLLM auth removed for local-only installs
         else
             _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1"
             _opencode_key="no-key"


### PR DESCRIPTION
## Summary

- **Issue 16 (revised):** Remove LiteLLM auth requirement for lemonade mode. All ports bind to 127.0.0.1 — no external exposure, no auth needed. Eliminates the entire auth cascade (Issues 8, 9b, 17b).
- **Issue 18:** Phase 07 reads stale `DREAM_MODE=local` from shell instead of `DREAM_MODE=lemonade` from .env. OpenCode gets wrong URL/key. Fix: unconditionally re-read from .env.

## Changes

- `config/litellm/lemonade.yaml` — remove `general_settings.master_key`
- `extensions/services/litellm/compose.yaml` — `LITELLM_MASTER_KEY` now optional (`:-}` instead of `:?`)
- `installers/phases/06-directories.sh` — remove master_key from generated config, stop overwriting OPENAI_API_KEY/TARGET_API_KEY for AMD
- `installers/phases/07-devtools.sh` — unconditionally re-read DREAM_MODE from .env, use `no-key` for lemonade OpenCode

## Test plan

- [ ] AMD/Lemonade: all services connect to LiteLLM without auth errors
- [ ] AMD/Lemonade: OpenCode gets `http://127.0.0.1:4000/v1` (not port 8080)
- [ ] NVIDIA: LiteLLM still starts (LITELLM_MASTER_KEY empty but not required)
- [ ] NVIDIA: OpenCode gets `http://127.0.0.1:8080/v1` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)