### PR TITLE
fix(amd): disable LiteLLM auth via env var override

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -56,10 +56,15 @@ services:
 
   # Services route through LiteLLM (DREAM_MODE=lemonade sets LLM_API_URL=http://litellm:4000).
   # LiteLLM handles the /api/v1 translation to Lemonade internally.
+  # Auth disabled — all ports bind to 127.0.0.1, no external exposure.
+
+  litellm:
+    environment:
+      - LITELLM_MASTER_KEY=
 
   open-webui:
     environment:
-      - OPENAI_API_KEY=${LITELLM_KEY}
+      - OPENAI_API_KEY=no-key
 
   dashboard-api:
     environment:


### PR DESCRIPTION
## Summary

Issue 16 fix was incomplete. Removing `master_key` from `lemonade.yaml` config wasn't enough — LiteLLM reads `LITELLM_MASTER_KEY` env var directly and enables auth if non-empty. Phase 06 always generates `LITELLM_KEY`, so the env var was always set.

Fix: AMD compose overlay sets `LITELLM_MASTER_KEY=` (empty string), which disables auth at the env var level. Base compose still passes the key for NVIDIA multi-model profile.

Also changes Open WebUI `OPENAI_API_KEY` from `${LITELLM_KEY}` to `no-key` since auth is no longer needed.

## Test plan

- [ ] AMD/Lemonade: OpenClaw connects to LiteLLM without 400 errors
- [ ] AMD/Lemonade: All services reach LiteLLM without Bearer tokens
- [ ] NVIDIA multi-model: LiteLLM still has auth via base compose key

🤖 Generated with [Claude Code](https://claude.com/claude-code)