### PR TITLE
fix(amd): unset LITELLM_MASTER_KEY to truly disable auth

### DIFF
--- a/dream-server/extensions/services/litellm/compose.amd.yaml
+++ b/dream-server/extensions/services/litellm/compose.amd.yaml
@@ -1,7 +1,24 @@
 # LiteLLM AMD overlay — disable auth for local-only Lemonade installs.
 # All LiteLLM ports bind to 127.0.0.1 — no external exposure.
-# Loads after compose.yaml via GPU overlay discovery, so this wins.
+# LiteLLM checks `is not None` (not truthiness), so empty string still
+# enables auth. The only way to disable it is to unset the env var entirely.
+# Loads after compose.yaml via GPU overlay discovery, so entrypoint wins.
 services:
   litellm:
-    environment:
-      - LITELLM_MASTER_KEY=
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        unset LITELLM_MASTER_KEY
+        if [ "$$LANGFUSE_ENABLED" = "true" ]; then
+          python3 -c "
+        import yaml
+        with open('/app/config.yaml') as f:
+            cfg = yaml.safe_load(f)
+        cfg.setdefault('litellm_settings', {})['success_callback'] = ['langfuse']
+        with open('/tmp/config.yaml', 'w') as f:
+            yaml.dump(cfg, f, default_flow_style=False)
+        "
+          exec litellm --config /tmp/config.yaml --port 4000
+        else
+          exec litellm --config /app/config.yaml --port 4000
+        fi

--- a/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
@@ -53,11 +53,10 @@ fi
 # 4. LiteLLM AMD overlay blanks LITELLM_MASTER_KEY
 # ---------------------------------------------------------------------------
 echo "[contract] LiteLLM auth disabled for AMD"
-if grep -q 'LITELLM_MASTER_KEY=$' extensions/services/litellm/compose.amd.yaml 2>/dev/null || \
-   grep -q 'LITELLM_MASTER_KEY=""' extensions/services/litellm/compose.amd.yaml 2>/dev/null; then
-    pass "litellm compose.amd.yaml: LITELLM_MASTER_KEY blanked"
+if grep -q 'unset LITELLM_MASTER_KEY' extensions/services/litellm/compose.amd.yaml 2>/dev/null; then
+    pass "litellm compose.amd.yaml: LITELLM_MASTER_KEY unset in entrypoint"
 else
-    fail "litellm compose.amd.yaml: must blank LITELLM_MASTER_KEY for local-only installs"
+    fail "litellm compose.amd.yaml: must unset LITELLM_MASTER_KEY (empty string still enables auth)"
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Empty string doesn't disable LiteLLM auth — it checks `is not None`, not truthiness. The only way is to `unset` the env var entirely so `os.environ.get()` returns `None`.

## Fix

Override entrypoint in `compose.amd.yaml` to unset the variable before launching LiteLLM. Langfuse conditional logic replicated from base compose.

## Test plan

- [ ] AMD/Lemonade: LiteLLM starts without auth — OpenClaw connects without 400
- [ ] AMD/Lemonade + Langfuse: callback still injected correctly
- [ ] NVIDIA: compose.amd.yaml not loaded, auth unchanged
- [ ] `make test` passes (contract test updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)