### PR TITLE
fix(amd): dashboard token metrics via Lemonade inner llama-server

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -21,8 +21,12 @@ services:
       - --no-tray
       - --llamacpp
       - rocm
+      - --llamacpp-args
+      - "--metrics --host 0.0.0.0"
       - --extra-models-dir
       - /models
+    expose:
+      - "8001"
     volumes:
       - ./data/models:/models:ro
       - lemonade-cache:/root/.cache/huggingface
@@ -66,6 +70,7 @@ services:
     environment:
       - GPU_BACKEND=amd
       - LLM_BACKEND=lemonade
+      - LLAMA_METRICS_PORT=8001
     volumes:
       - /sys/class/drm:/sys/class/drm:ro
       - /sys/class/hwmon:/sys/class/hwmon:ro

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -96,8 +96,9 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
     try:
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
+        metrics_port = int(os.environ.get("LLAMA_METRICS_PORT", port))
         model_name = model_hint if model_hint is not None else (await get_loaded_model() or "")
-        url = f"http://{host}:{port}/metrics"
+        url = f"http://{host}:{metrics_port}/metrics"
         params = {"model": model_name} if model_name else {}
         client = await _get_httpx_client()
         resp = await client.get(url, params=params)


### PR DESCRIPTION
## Summary

- Dashboard "Tokens/sec" and "Tokens Generated" always showed `—` and `0` on AMD/Lemonade
- Lemonade wraps llama.cpp but doesn't proxy `/metrics` through its main port (8080)
- Pass `--metrics --host 0.0.0.0` to the inner llama-server via `--llamacpp-args`
- Expose port 8001 (inner llama-server) on the Docker network
- `LLAMA_METRICS_PORT=8001` tells dashboard-api to query the inner process directly

## Changes

- `docker-compose.amd.yml` — added `--llamacpp-args`, `expose: ["8001"]`, `LLAMA_METRICS_PORT`
- `helpers.py` — `metrics_port = int(os.environ.get("LLAMA_METRICS_PORT", port))`

## Backwards compatibility

`LLAMA_METRICS_PORT` defaults to the main service port. NVIDIA/CPU setups don't set it — zero change.

## Test plan

- [ ] AMD: dashboard shows tokens/sec after first inference
- [ ] NVIDIA: dashboard metrics unchanged
- [ ] Verify first-inference delay (Lemonade lazily spawns inner llama-server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)