### PR TITLE
fix(extensions-library): update stale image digests for gitea, localai, and rvc

### DIFF
--- a/resources/dev/extensions-library/services/gitea/compose.yaml
+++ b/resources/dev/extensions-library/services/gitea/compose.yaml
@@ -1,6 +1,6 @@
 services:
   gitea:
-    image: gitea/gitea:1.23.5-rootless@sha256:e4ee234ce0075070337e852e1e0639f1e6061e3e9b43f3e8d145e2a1e0c06f55
+    image: gitea/gitea:1.23.5-rootless@sha256:3a335645ca700660ac6c10d6f3223b6611ed6959441f6d2f7cd5fa607baf1425
     container_name: dream-gitea
     restart: unless-stopped
     security_opt:

--- a/resources/dev/extensions-library/services/localai/compose.yaml
+++ b/resources/dev/extensions-library/services/localai/compose.yaml
@@ -1,6 +1,6 @@
 services:
   localai:
-    image: localai/localai:v3.12.1-aio-cpu@sha256:7b8b2b7765c94c054db1b2e25e4fcab53d6316f5de67bd46041d2cf306fb2356
+    image: localai/localai:v3.12.1-aio-cpu@sha256:4cbc20c59558ed6c1cae9bc3f6ae34d75d390b370aa8ac62a59327089fa56cec
     container_name: dream-localai
     networks:
       - dream-network

--- a/resources/dev/extensions-library/services/rvc/compose.yaml
+++ b/resources/dev/extensions-library/services/rvc/compose.yaml
@@ -1,6 +1,6 @@
 services:
   rvc:
-    image: aladdin1234/rvc-webui:0.1@sha256:0127333111eccb00ee97e12052f2c9efc7739d74841dbdec771d4f469273a0c2
+    image: aladdin1234/rvc-webui:0.1@sha256:7f8b4ca826d31d0ea50c56327d9fbfd1dacead37064a5f9745738b728a6271be
     container_name: dream-rvc
     ports:
       - "127.0.0.1:${RVC_PORT:-7809}:7865"


### PR DESCRIPTION
## What
Update pinned Docker image digests for gitea, localai, and rvc to current registry values.

## Why
Previous digests were garbage-collected after registry rebuilds, causing `docker pull` to fail with `failed to resolve reference` on fresh installs. These 3 services (gitea, localai, rvc) were completely broken — users could not install them at all.

## How
Used `docker buildx imagetools inspect` to obtain the current manifest list digests for each tag:
- `gitea/gitea:1.23.5-rootless` — updated digest
- `localai/localai:v3.12.1-aio-cpu` — updated digest
- `aladdin1234/rvc-webui:0.1` — updated digest

Image tags are unchanged; only the `@sha256:` pin is refreshed.

## Scope
All changes are within `resources/dev/extensions-library/services/`.

## Testing
- `docker buildx imagetools inspect` confirms all 3 new digests resolve
- YAML structure validated

## Suggested Merge Order
This PR is **1 of 5** in a batch of extensions-library fixes. Suggested order:
1. **This PR** — digest-only, zero logic changes
2. chromadb v2 API + sillytavern healthcheck
3. piper timeout + baserow port
4. ollama digest + port rename + text-gen-webui digest
5. frigate + open-interpreter setup hooks