### PR TITLE
fix(extensions-library): increase piper healthcheck timeout and reassign baserow port to 3007

### DIFF
--- a/resources/dev/extensions-library/services/baserow/README.md
+++ b/resources/dev/extensions-library/services/baserow/README.md
@@ -21,15 +21,15 @@ The extension uses the following environment variables:
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `BASEROW_PUBLIC_URL` | Public URL for Baserow | `http://localhost:3006` |
-| `BASEROW_PORT` | External port | `3006` |
+| `BASEROW_PUBLIC_URL` | Public URL for Baserow | `http://localhost:3007` |
+| `BASEROW_PORT` | External port | `3007` |
 | `BASEROW_DATABASE_HOST` | PostgreSQL host | (auto-detected) |
 | `BASEROW_DATABASE_PASSWORD` | Database password | (auto-generated) |
 | `BASEROW_DEBUG` | Enable debug mode | `false` |
 
 ## Ports
 
-- External: `3006` (configurable via `BASEROW_PORT`)
+- External: `3007` (configurable via `BASEROW_PORT`)
 - Internal: `80`
 
 ## Data Persistence
@@ -51,5 +51,5 @@ The extension exposes `/api/_health/` endpoint for monitoring.
 ## Usage
 
 1. Start the extension: `dream enable baserow`
-2. Access the UI at `http://localhost:3006`
+2. Access the UI at `http://localhost:3007`
 3. Create your first database using the spreadsheet interface

--- a/resources/dev/extensions-library/services/baserow/compose.yaml
+++ b/resources/dev/extensions-library/services/baserow/compose.yaml
@@ -6,7 +6,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - BASEROW_PUBLIC_URL=${BASEROW_PUBLIC_URL:-http://localhost:3006}
+      - BASEROW_PUBLIC_URL=${BASEROW_PUBLIC_URL:-http://localhost:3007}
       - BASEROW_CADDY_ADDRESSES=${BASEROW_CADDY_ADDRESSES:-:80}
       - BASEROW_BACKEND_LOG_LEVEL=${BASEROW_LOG_LEVEL:-INFO}
       - BASEROW_FRONTEND_LOG_LEVEL=${BASEROW_LOG_LEVEL:-INFO}
@@ -35,7 +35,7 @@ services:
     volumes:
       - ./data/baserow:/baserow/data:rw
     ports:
-      - "127.0.0.1:${BASEROW_PORT:-3006}:80"
+      - "127.0.0.1:${BASEROW_PORT:-3007}:80"
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost/api/_health/"]
       interval: 30s

--- a/resources/dev/extensions-library/services/baserow/manifest.yaml
+++ b/resources/dev/extensions-library/services/baserow/manifest.yaml
@@ -9,7 +9,7 @@ service:
   default_host: baserow
   port: 80
   external_port_env: BASEROW_PORT
-  external_port_default: 3006
+  external_port_default: 3007
   health: /api/_health/
   type: docker
   gpu_backends: [none]

--- a/resources/dev/extensions-library/services/piper-audio/compose.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/compose.yaml
@@ -33,7 +33,7 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "echo '{\"type\": \"describe\"}' | nc localhost 10200 || exit 1"]
       interval: 30s
-      timeout: 10s
+      timeout: 30s
       retries: 3
       start_period: 60s
     networks:


### PR DESCRIPTION
## What
Fix piper-audio healthcheck timeout and resolve baserow port collision with production langfuse.

## Why
- **piper-audio**: The Wyoming protocol info response includes the full voice list (~81KB JSON). The 10-second healthcheck timeout is insufficient to transfer this data, causing the container to stay permanently `unhealthy` despite the service running correctly.
- **baserow**: Default port 3006 collides with production langfuse (also 3006). Enabling both causes a Docker port bind error.

## How
- piper-audio: Increased healthcheck timeout from `10s` to `30s`
- baserow: Reassigned default port from `3006` to `3007` in manifest, compose, and README. Port 3007 is confirmed unused by any other service in the extensions library.

## Scope
All changes are within `resources/dev/extensions-library/services/`.

## Testing
- Verified port 3007 is not used by any other service manifest
- piper-audio timeout increase is conservative (3x original)
- YAML and Markdown syntax validated

## Suggested Merge Order
This PR is **3 of 5** in a batch of extensions-library fixes. Suggested order:
1. gitea/localai/rvc digests
2. chromadb v2 API + sillytavern healthcheck
3. **This PR** — config changes, low risk
4. ollama digest + port rename + text-gen-webui digest
5. frigate + open-interpreter setup hooks