### PR TITLE
fix(extensions-library): update ollama/text-gen-webui digests, rename ollama port env var

### DIFF
--- a/resources/dev/extensions-library/services/ollama/compose.yaml
+++ b/resources/dev/extensions-library/services/ollama/compose.yaml
@@ -1,12 +1,12 @@
 services:
   ollama:
-    image: ollama/ollama:0.5.7@sha256:8430bdb513d5dbd85294fb70ea7e1f88ee0aaf9756585ca4dbaf080a773dc774
+    image: ollama/ollama:0.5.7@sha256:7e672211886f8bd4448a98ed577e26c816b9e8b052112860564afaa2c105800e
     container_name: dream-ollama
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     ports:
-      - "127.0.0.1:${OLLAMA_PORT:-7804}:11434"
+      - "127.0.0.1:${EXT_OLLAMA_PORT:-7804}:11434"
     volumes:
       - ./data/ollama:/root/.ollama
     environment:

--- a/resources/dev/extensions-library/services/ollama/manifest.yaml
+++ b/resources/dev/extensions-library/services/ollama/manifest.yaml
@@ -8,7 +8,7 @@ service:
   host_env: OLLAMA_HOST
   default_host: ollama
   port: 11434
-  external_port_env: OLLAMA_PORT
+  external_port_env: EXT_OLLAMA_PORT
   external_port_default: 7804
   health: /api/tags
   type: docker

--- a/resources/dev/extensions-library/services/text-generation-webui/compose.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/compose.yaml
@@ -2,7 +2,7 @@ services:
   text-generation-webui:
     # atinoda/text-generation-webui is the most widely-used community image.
     # Supports nvidia, amd, and cpu variants. Pinned to v4.0 nvidia release.
-    image: atinoda/text-generation-webui:default-nvidia-v4.0@sha256:c1faecdc83cd0c5da9c41ec8ddef1bf1cd8ccfeeed0fd4261b977efda187e665
+    image: atinoda/text-generation-webui:default-nvidia-v4.0@sha256:155069f7ed8d4f3354dc7540352064cc354826a2e231d2e673dde63b76c7fac2
     container_name: dream-text-generation-webui
     restart: unless-stopped
     security_opt:


### PR DESCRIPTION
## What
Update stale image digests for ollama and text-generation-webui, and rename the ollama extension port variable to avoid collision with production.

## Why
- **Stale digests**: Both `ollama:0.5.7` and `text-generation-webui:default-nvidia-v4.0` pin to digests that were garbage-collected by their registries. `docker pull` fails on fresh installs.
- **Port collision**: The macOS installer writes `OLLAMA_PORT=8080` to `.env` for the production llama-server proxy. The ollama extension compose uses `${OLLAMA_PORT:-7804}:11434`, which picks up the production value (8080) instead of the intended default (7804), causing a port conflict on macOS.

## How
- Updated both image digests to current registry values via `docker buildx imagetools inspect`
- Renamed the extension port variable from `OLLAMA_PORT` to `EXT_OLLAMA_PORT` in both compose (port binding only) and manifest (`external_port_env`)
- The container-internal `OLLAMA_PORT=11434` environment variable is intentionally left unchanged — it configures the Ollama server inside the container

## Scope
All changes are within `resources/dev/extensions-library/services/`.

## Testing
- `docker buildx imagetools inspect` confirms new digests resolve
- Verified `OLLAMA_PORT=11434` (internal) is not renamed
- `EXT_OLLAMA_PORT` is consistent between compose and manifest
- YAML syntax validated

## Suggested Merge Order
This PR is **4 of 5** in a batch of extensions-library fixes. Suggested order:
1. gitea/localai/rvc digests
2. chromadb v2 API + sillytavern healthcheck
3. piper timeout + baserow port
4. **This PR** — port rename is slightly higher risk
5. frigate + open-interpreter setup hooks