### PR TITLE
fix(dream-cli): add Bash 4+ version gate for macOS compatibility

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1,9 +1,18 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # dream-cli - Command line interface for Dream Server
 # Mission: M5 (Clonable Dream Setup Server)
 # Version: 2.0.0 — Registry-driven service resolution
 
 set -e
+
+# Require Bash 4+ (associative arrays used by service registry and dream-cli)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo -e "\033[0;31m✗\033[0m dream-cli requires Bash 4.0+ (you have $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    echo "  Then re-run with:  /opt/homebrew/bin/bash $0 $*" >&2
+    exit 1
+fi
 
 #=============================================================================
 # Configuration

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -12,6 +12,16 @@ _SR_COMPOSE_FLAGS_CACHED=false
 _SR_CACHE_HITS=0
 _SR_CACHE_MISSES=0
 
+# Bash 4+ required for associative arrays used throughout the service registry.
+# macOS ships Bash 3.2 — users must install a modern shell (e.g. via Homebrew).
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: service-registry.sh requires Bash 4.0+ (current: $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    echo "  Then re-run with:  /opt/homebrew/bin/bash $0 \$*" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 # Associative arrays (bash 4+)
 declare -A SERVICE_ALIASES      # alias → service_id
 declare -A SERVICE_CONTAINERS   # service_id → container_name


### PR DESCRIPTION
## What
Adds an early Bash 4+ version check to `dream-cli` and `service-registry.sh`,
and changes the `dream-cli` shebang to `#!/usr/bin/env bash`.

## Why
macOS ships Bash 3.2, which lacks associative arrays (`declare -A`). Every
`dream-cli` command that loads the service registry crashes with a cryptic
`declare: -A: invalid option` on stock macOS. Users have no indication of
what went wrong or how to fix it.

## How
- **`service-registry.sh`**: A `BASH_VERSINFO[0] < 4` guard fires before
  any `declare -A`, printing an actionable error with Homebrew install
  instructions. Uses `return 1 2>/dev/null || exit 1` to handle both
  sourced and direct-execution contexts.
- **`dream-cli`**: Shebang changed to `#!/usr/bin/env bash` so Homebrew
  bash (5.x) is resolved automatically via PATH. A matching version guard
  is added after `set -e` as a safety net.

## Design Decision
A full rewrite of all associative arrays to Bash 3.2–compatible patterns
(parallel indexed arrays, indirect variable expansion) was evaluated and
rejected. The codebase has ~130 direct associative-array accesses across
16 consumer scripts — rewriting all of them in a single PR would produce
a 600+ line diff with high regression risk touching the entire CLI
surface. The version gate is the clearer fix: it makes the Bash 4+
requirement explicit, turns a cryptic crash into an actionable error,
and the shebang change resolves it automatically for Homebrew users.

## Scope
- `dream-server/lib/service-registry.sh` — version guard (8 lines)
- `dream-server/dream-cli` — shebang + version guard (8 lines)

## Testing
- **Automated**: shellcheck passes (only pre-existing warnings)
- **Manual**:
  - Run `/bin/bash ./dream-cli list` → should print version error with
    Homebrew instructions, exit 1
  - Run `/opt/homebrew/bin/bash ./dream-cli list` → should work normally
  - Run `./dream-cli list` with Homebrew bash in PATH → should work
    (shebang resolves via env)