### PR TITLE
docs: add halo-ai to Wall of Heroes

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Thanks to [kyuz0](https://github.com/kyuz0) for [amd-strix-halo-toolboxes](https
 
 ### Community Builds
 
-*   [halo-ai (bong-water-water-bong)](https://github.com/bong-water-water-bong/halo-ai) — Bare-metal DreamServer rebuild for Strix Halo on Arch Linux. Zero containers, compiled from source, 89 tok/s. Proved Vulkan > ROCm for generation on gfx1151 and contributed kernel tuning research (`amd_iommu=off`, TTM page pool expansion) back to the ecosystem.
+*   [halo-ai (bong-water-water-bong)](https://github.com/bong-water-water-bong/halo-ai) — Bare-metal DreamServer rebuild for Strix Halo on Arch Linux. Zero containers, compiled from source, 89 tok/s. Proved Vulkan > ROCm for generation on gfx1151 and contributed kernel tuning research (`amd_iommu=off`, TTM page pool expansion) back to the ecosystem. Early DreamServer advocate who introduced us to the Lemonade SDK community and AMD developer team.
 
 ### Projects that make Dream Server possible
 

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -393,7 +393,7 @@ Thanks to [kyuz0](https://github.com/kyuz0) for [amd-strix-halo-toolboxes](https
 
 ### Community Builds
 
-*   [halo-ai (bong-water-water-bong)](https://github.com/bong-water-water-bong/halo-ai) — Bare-metal DreamServer rebuild for Strix Halo on Arch Linux. Zero containers, compiled from source, 89 tok/s. Proved Vulkan > ROCm for generation on gfx1151 and contributed kernel tuning research back to the ecosystem.
+*   [halo-ai (bong-water-water-bong)](https://github.com/bong-water-water-bong/halo-ai) — Bare-metal DreamServer rebuild for Strix Halo on Arch Linux. Zero containers, compiled from source, 89 tok/s. Proved Vulkan > ROCm for generation on gfx1151 and contributed kernel tuning research back to the ecosystem. Early DreamServer advocate who introduced us to the Lemonade SDK community and AMD developer team.
 
 ### Projects that make Dream Server possible
 


### PR DESCRIPTION
## Summary

Adds [halo-ai](https://github.com/bong-water-water-bong/halo-ai) to the Wall of Heroes under a new "Community Builds" section in both READMEs. 

halo-ai is a bare-metal DreamServer rebuild for Strix Halo on Arch Linux — zero containers, compiled from source, 89 tok/s. They proved Vulkan > ROCm for generation on gfx1151 and contributed kernel tuning research back to the ecosystem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)