### PR TITLE
fix(ci): add required keys to schema validation fixture

### DIFF
--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -55,6 +55,10 @@ jobs:
             # Generate minimal .env with all expected keys
             cat > .env << ENVEOF
           # Test .env for tier ${{ matrix.tier }}
+          WEBUI_SECRET=test-secret-changeme
+          N8N_USER=admin
+          N8N_PASS=test-pass-changeme
+          OPENCLAW_TOKEN=sk-test-openclaw-token
           DREAM_VERSION=2.1.0
           DREAM_TIER=${{ matrix.tier }}
           GPU_BACKEND=cpu


### PR DESCRIPTION
The .env test fixture in validate-env.yml was missing WEBUI_SECRET, N8N_USER, N8N_PASS, and OPENCLAW_TOKEN — all marked required in .env.schema.json. This caused all 5 tier validations to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)