### PR TITLE
fix: unbound GPU_ASSIGNMENT_JSON crashes installer on single-GPU

### DIFF
--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -301,7 +301,7 @@ MODELS_EOF
     OPENAI_API_KEY=$(_env_get OPENAI_API_KEY "${OPENAI_API_KEY:-}")
     TOGETHER_API_KEY=$(_env_get TOGETHER_API_KEY "${TOGETHER_API_KEY:-}")
     # Base64-encode GPU assignment JSON for safe .env storage
-    if [[ -n "$GPU_ASSIGNMENT_JSON" && "$GPU_ASSIGNMENT_JSON" != "{}" ]]; then
+    if [[ -n "${GPU_ASSIGNMENT_JSON:-}" && "${GPU_ASSIGNMENT_JSON:-}" != "{}" ]]; then
         GPU_ASSIGNMENT_JSON_B64=$(echo "$GPU_ASSIGNMENT_JSON" | jq -c '.' | base64 -w0)
     else
         GPU_ASSIGNMENT_JSON_B64=""


### PR DESCRIPTION
## Summary

Single-GPU systems crash at Phase 06 line 304 with `GPU_ASSIGNMENT_JSON: unbound variable`. Phase 03 skips multi-GPU config on single-GPU and never sets the variable. `set -euo pipefail` catches it.

One-character fix: `$GPU_ASSIGNMENT_JSON` → `${GPU_ASSIGNMENT_JSON:-}`

Reported from RTX PRO 6000 Blackwell, Ubuntu 24.04, reproduced on 4 consecutive runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)