### PR TITLE
Linux portability doc, support-matrix link, reinstall data/ writability check

### DIFF
--- a/dream-server/docs/LINUX-PORTABILITY.md
+++ b/dream-server/docs/LINUX-PORTABILITY.md
@@ -1,0 +1,21 @@
+# Linux portability
+
+How to run Dream Server reliably across different Linux machines (with or without a GPU), recover from a bad reinstall, and work with extensions.
+
+## Installer
+
+- **Entry:** `install.sh` → `install-core.sh` — see [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md).
+- **CPU-only systems:** With a capability profile, set `CAP_LLM_BACKEND=cpu` so the installer keeps CPU inference (see `02-detection.sh`).
+- **Re-running the installer:** If a previous run left directories owned by container users, the installer checks that `config/*` and `data/*` are writable before copying files, uses `rsync` without preserving foreign ownership, and tells you to `chown` if something is still blocked (`06-directories.sh`).
+
+## Extensions and integrations
+
+Services are declared under `extensions/services/<name>/manifest.yaml` for dashboard health and feature metadata. Schema: `extensions/schema/service-manifest.v1.json`. To add or change a service, follow [EXTENSIONS.md](EXTENSIONS.md).
+
+## Checklist on a new Linux machine
+
+1. Docker and Compose v2 work; your user can run containers (e.g. member of the `docker` group).
+2. `./install.sh --dry-run` finishes without errors.
+3. After a real install, run `./dream-preflight.sh` and `scripts/dream-doctor.sh` if you use them.
+
+More context: [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md).

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -74,3 +74,7 @@ Last updated: 2026-03-17
 3. Promote macOS from Tier B to Tier A after broader real-hardware validation.
 4. Validate Intel Arc B580 (Battlemage 12 GB) on the `ARC` tier.
 5. Promote Intel Arc from Tier C to Tier B after A770 + B580 real-hardware validation.
+
+## See also
+
+- [LINUX-PORTABILITY.md](LINUX-PORTABILITY.md) — Linux installer edge cases, `.env` validation, extension manifests.

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -56,14 +56,19 @@ else
         fi
     done
 
-    # Ensure we can write to config (rsync will fail otherwise)
-    if [[ "$SCRIPT_DIR" != "$INSTALL_DIR" ]] && [[ -d "$INSTALL_DIR/config" ]]; then
+    # Ensure we can write to config/data subtrees (rsync will fail otherwise)
+    if [[ "$SCRIPT_DIR" != "$INSTALL_DIR" ]]; then
         _cant_write=""
-        for _d in "$INSTALL_DIR"/config/*/; do
-            [[ -d "$_d" ]] && ! [[ -w "$_d" ]] && _cant_write="$_cant_write ${_d#$INSTALL_DIR/}"
+        for _root in config data; do
+            [[ -d "$INSTALL_DIR/$_root" ]] || continue
+            for _d in "$INSTALL_DIR/$_root"/*/; do
+                [[ -d "$_d" ]] && ! [[ -w "$_d" ]] && _cant_write="$_cant_write ${_d#$INSTALL_DIR/}"
+            done
         done
         if [[ -n "$_cant_write" ]]; then
-            error "Cannot write to config directories (likely container-owned). Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/data — then re-run the installer."
+            error "Cannot write to directories (likely container-owned):$_cant_write
+
+Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/data — then re-run the installer."
         fi
     fi
 


### PR DESCRIPTION
## Changes
- Added `docs/LINUX-PORTABILITY.md`: running on varied Linux hosts (including CPU-only via capability profile), reinstall when config/data were container-owned, where extension manifests live and how to add services (`EXTENSIONS.md`), and a short checklist before/after install.
- Updated `docs/SUPPORT-MATRIX.md`: “See also” link to `LINUX-PORTABILITY.md`.
- Updated `installers/phases/06-directories.sh`: before copying the tree, treat non-writable `data/*/` like `config/*/` and exit with the same `chown` guidance.

## Testing
- `bash -n dream-server/installers/phases/06-directories.sh`