### PR TITLE
fix(extensions-library): correct gitea env var format, healthcheck, and stale manifest entries

### DIFF
--- a/resources/dev/extensions-library/services/gitea/compose.yaml
+++ b/resources/dev/extensions-library/services/gitea/compose.yaml
@@ -11,28 +11,25 @@ services:
       - GITEA_WORK_DIR=/var/lib/gitea
       - GITEA_CUSTOM=/var/lib/gitea/custom
       - GITEA_TEMP=/tmp/gitea
-      - GITEA_LOG__MODE=console
-      - GITEA_DATABASE__DB_TYPE=sqlite3
-      - GITEA_DATABASE__PATH=/var/lib/gitea/gitea.db
-      - GITEA_REPOSITORY__ROOT=/var/lib/gitea/git/repositories
-      - GITEA_SERVER__DOMAIN=${GITEA_HOST:-localhost}
-      - GITEA_SERVER__ROOT_URL=http://${GITEA_HOST:-localhost}:${GITEA_PORT:-7830}/
-      - GITEA_SERVER__HTTP_PORT=3000
-      - GITEA_SERVER__SSH_PORT=${GITEA_SSH_PORT:-2222}
-      - GITEA_SECURITY__INSTALL_LOCK=true
-      - GITEA_SERVICE__DISABLE_REGISTRATION=true
-      - GITEA_SERVICE__REQUIRE_SIGNIN_VIEW=true
-      - GITEA_SERVICE__DEFAULT_USER_IS_ADMIN=true
-      - GITEA__SECURITY__ADMIN_USER=${GITEA_ADMIN_USER:-}
-      - GITEA__SECURITY__ADMIN_PASSWORD=${GITEA_ADMIN_PASSWORD:-}
-      - GITEA__SECURITY__ADMIN_EMAIL=${GITEA_ADMIN_EMAIL:-admin@localhost}
+      - GITEA__LOG__MODE=console
+      - GITEA__DATABASE__DB_TYPE=sqlite3
+      - GITEA__DATABASE__PATH=/var/lib/gitea/gitea.db
+      - GITEA__REPOSITORY__ROOT=/var/lib/gitea/git/repositories
+      - GITEA__SERVER__DOMAIN=${GITEA_HOST:-localhost}
+      - GITEA__SERVER__ROOT_URL=http://${GITEA_HOST:-localhost}:${GITEA_PORT:-7830}/
+      - GITEA__SERVER__HTTP_PORT=3000
+      - GITEA__SERVER__SSH_PORT=${GITEA_SSH_PORT:-2222}
+      - GITEA__SECURITY__INSTALL_LOCK=true
+      - GITEA__SERVICE__DISABLE_REGISTRATION=true
+      - GITEA__SERVICE__REQUIRE_SIGNIN_VIEW=true
+      - GITEA__SERVICE__DEFAULT_USER_IS_ADMIN=true
     volumes:
       - ./data/gitea:/var/lib/gitea:rw
     ports:
       - "127.0.0.1:${GITEA_PORT:-7830}:3000"
       - "127.0.0.1:${GITEA_SSH_PORT:-2222}:2222"
     healthcheck:
-      test: ["CMD", "/usr/local/bin/gitea", "healthcheck"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:3000/api/healthz || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/gitea/manifest.yaml
+++ b/resources/dev/extensions-library/services/gitea/manifest.yaml
@@ -28,13 +28,3 @@ service:
     - key: GITEA_APP_NAME
       description: "Display name for the Gitea instance"
       default: "Dream Server Git"
-    - key: GITEA_ADMIN_USER
-      description: "Default admin username (created on first run)"
-      default: ""
-    - key: GITEA_ADMIN_PASSWORD
-      description: "Default admin password (created on first run)"
-      secret: true
-      default: ""
-    - key: GITEA_ADMIN_EMAIL
-      description: "Default admin email"
-      default: "admin@localhost"


### PR DESCRIPTION
## What
Fix Gitea environment variable format, replace non-existent healthcheck command, and remove stale admin env vars from compose and manifest.

## Why
Gitea's environment-to-ini mechanism requires `GITEA__SECTION__KEY` (double underscore). All 12 INI-mapped env vars used single underscore and were silently ignored — `INSTALL_LOCK` stayed false (stuck in install wizard), registration stayed open, `ROOT_URL` was empty. The healthcheck used a non-existent `gitea healthcheck` subcommand with a wrong binary path. The admin user env vars mapped to INI keys that don't exist in any Gitea version.

## How
- Fix 12 env vars: `GITEA_SECTION__KEY` → `GITEA__SECTION__KEY`
- Replace healthcheck: `gitea healthcheck` → `curl -sf http://localhost:3000/api/healthz`
- Remove 3 non-functional admin env vars from compose.yaml and manifest.yaml

## Scope
All changes within `resources/dev/extensions-library/services/gitea/`.

## Testing
- YAML validation: passed
- Docker compose config: passed
- Manual: verify Gitea loads directly (no install wizard), registration is disabled, and container becomes healthy

## Known Considerations
No automated admin user creation path exists. This is a pre-existing gap (the old admin env vars were non-functional). Admin can be created via:
```
docker exec -it dream-gitea /app/gitea/gitea admin user create --admin --username admin --password <pass> --email admin@localhost
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)