### PR TITLE
fix(extensions-library): add missing milvus standalone command

### DIFF
--- a/resources/dev/extensions-library/services/milvus/compose.yaml
+++ b/resources/dev/extensions-library/services/milvus/compose.yaml
@@ -8,6 +8,7 @@ services:
       - ./data/milvus:/var/lib/milvus
     environment:
       - MODE=standalone
+    command: ["milvus", "run", "standalone"]
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## What
Add `command: ["milvus", "run", "standalone"]` to the milvus compose service.

## Why
The milvus compose had no `command:` field. The image entrypoint is `tini` which requires an explicit command — without it, tini prints its help text and exits, causing indefinite crash-loops.

## How
Single line addition. Aligns with the existing `MODE=standalone` environment variable.

## Scope
All changes within `resources/dev/extensions-library/services/milvus/`.

## Testing
- YAML validation: passed
- Critique Guardian: APPROVED
- Manual: start milvus container, verify healthcheck (`curl localhost:9091/healthz`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)