### PR TITLE
fix(extensions-library): fix broken healthchecks in crewai, continue, label-studio

### DIFF
--- a/resources/dev/extensions-library/services/continue/compose.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.yaml
@@ -29,7 +29,7 @@ services:
     networks:
       - dream-network
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/crewai/compose.yaml
+++ b/resources/dev/extensions-library/services/crewai/compose.yaml
@@ -44,7 +44,7 @@ services:
     ports:
       - "127.0.0.1:${CREWAI_PORT:-8501}:8501"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8501/"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8501/')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/label-studio/compose.yaml
+++ b/resources/dev/extensions-library/services/label-studio/compose.yaml
@@ -19,7 +19,7 @@ services:
     ports:
       - "127.0.0.1:${LABEL_STUDIO_PORT:-8086}:8080"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What
Fix healthcheck commands in three extensions that report permanently unhealthy despite working correctly.

## Why
- **crewai**: uses `wget` but image (Python-based) has no wget — only Python available
- **continue**: `localhost` resolves to IPv6 on Alpine, but nginx only listens IPv4
- **label-studio**: uses `wget` but image has no wget — curl is available

## How
- **crewai**: replace wget with `python3 urllib` (matches project pattern)
- **continue**: change `localhost` to `127.0.0.1` to force IPv4 resolution
- **label-studio**: replace wget with `curl -sf`

## Scope
All changes within `resources/dev/extensions-library/services/{crewai,continue,label-studio}/`.

## Testing
- YAML validation: passed
- Critique Guardian: APPROVED
- Manual: start each service, verify container reaches `healthy` status

🤖 Generated with [Claude Code](https://claude.com/claude-code)