### PR TITLE
fix(extensions-library): add missing weaviate AUTHENTICATION_APIKEY_USERS

### DIFF
--- a/resources/dev/extensions-library/services/weaviate/compose.yaml
+++ b/resources/dev/extensions-library/services/weaviate/compose.yaml
@@ -10,6 +10,7 @@ services:
       - AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=false
       - AUTHENTICATION_APIKEY_ENABLED=true
       - AUTHENTICATION_APIKEY_ALLOWED_KEYS=${WEAVIATE_API_KEY:?WEAVIATE_API_KEY must be set}
+      - AUTHENTICATION_APIKEY_USERS=admin@dreamserver.local
       - PERSISTENCE_DATA_PATH=/var/lib/weaviate
     volumes:
       - ./data/weaviate:/var/lib/weaviate


### PR DESCRIPTION
## What
Add `AUTHENTICATION_APIKEY_USERS=admin@dreamserver.local` to the weaviate compose environment.

## Why
Weaviate requires both `AUTHENTICATION_APIKEY_ALLOWED_KEYS` and `AUTHENTICATION_APIKEY_USERS` when API key auth is enabled. The setup.sh generates the API key, but no user was configured — causing a fatal startup error: "need at least one user".

## How
Single line addition. The user identifier is hardcoded since it is just a label (not a credential). The API key itself is the security-sensitive part and is already auto-generated by setup.sh.

## Scope
All changes within `resources/dev/extensions-library/services/weaviate/`.

## Testing
- YAML validation: passed
- Critique Guardian: APPROVED
- Manual: start weaviate, verify clean startup (no "need at least one user" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)