### PR TITLE
fix(extensions-library): replace immich postgres image with pgvecto-rs

### DIFF
--- a/resources/dev/extensions-library/services/immich/compose.yaml
+++ b/resources/dev/extensions-library/services/immich/compose.yaml
@@ -38,7 +38,7 @@ services:
       - dream-network
 
   immich-postgres:
-    image: postgres:16-alpine
+    image: docker.io/tensorchord/pgvecto-rs:pg16-v0.2.0
     container_name: immich-postgres
     volumes:
       - ./data/immich/postgres:/var/lib/postgresql/data


### PR DESCRIPTION
## What
Replace `postgres:16-alpine` with `docker.io/tensorchord/pgvecto-rs:pg16-v0.2.0` for the immich-postgres service.

## Why
Immich requires the pgvecto.rs (vectors) PostgreSQL extension for ML-based smart search on photos. The vanilla postgres:16-alpine image lacks this extension, causing Immich to crash at database migration with "extension vector does not exist".

## How
Single line image swap. The tensorchord/pgvecto-rs image is a PostgreSQL image that bundles the required vectors extension. This is the image recommended by Immich's official documentation. Both images are PG16-based, so existing data directories are compatible.

## Scope
All changes within `resources/dev/extensions-library/services/immich/`.

## Testing
- YAML validation: passed
- Critique Guardian: APPROVED
- Manual: start immich stack, verify migrations complete, test photo upload + smart search

🤖 Generated with [Claude Code](https://claude.com/claude-code)