### PR TITLE
fix(extensions-library): correct open-interpreter build context path

### DIFF
--- a/resources/dev/extensions-library/services/open-interpreter/compose.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/compose.yaml
@@ -3,7 +3,7 @@ name: open-interpreter
 services:
   open-interpreter:
     build:
-      context: .
+      context: ./extensions/services/open-interpreter
       dockerfile: Dockerfile
     container_name: dream-open-interpreter
     restart: unless-stopped


### PR DESCRIPTION
## What
Fix the Docker build context for open-interpreter so `docker compose build` can find the Dockerfile.

## Why
The build context was set to `.` which resolves to `$INSTALL_DIR` (the directory of the first `-f` compose file) when Docker Compose processes multi-file stacks. The Dockerfile lives at `extensions/services/open-interpreter/Dockerfile`, not at `$INSTALL_DIR/Dockerfile`, causing build failure:
```
failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

## How
Changed `context: .` → `context: ./extensions/services/open-interpreter` so the build context resolves to the correct extension directory. `dockerfile: Dockerfile` remains relative to the context and now finds the file.

## Scope
All changes within `resources/dev/extensions-library/services/open-interpreter/compose.yaml`.

## Testing
- YAML validation: passed
- Manual: `docker compose config` resolves correct path
- Note: the actual build fails due to a separate pre-existing starlette dependency conflict (unrelated to this fix)

## Review
Critique Guardian: **APPROVED** — single-line, logically correct fix confirmed by tracing `resolve-compose-stack.sh` path resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)