### PR TITLE
fix(extensions-library): use correct PAPERLESS_REDIS env var for Redis connection

### DIFF
--- a/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
@@ -10,8 +10,7 @@ services:
       - PAPERLESS_HOST=${PAPERLESS_HOST:-paperless}
       - PAPERLESS_DBHOST=${PAPERLESS_DBHOST:-paperless-postgres}
       - PAPERLESS_DBPORT=${PAPERLESS_DBPORT:-5432}
-      - PAPERLESS_REDISHOST=${PAPERLESS_REDISHOST:-paperless-redis}
-      - PAPERLESS_REDISPORT=${PAPERLESS_REDISPORT:-6379}
+      - PAPERLESS_REDIS=${PAPERLESS_REDIS:-redis://paperless-redis:6379}
       - "PAPERLESS_SECRET_KEY=${PAPERLESS_SECRET_KEY:?PAPERLESS_SECRET_KEY must be set – generate with: python3 -c \"import secrets; print(secrets.token_urlsafe(50))\"}"
       - PAPERLESS_URL=http://${PAPERLESS_HOST:-paperless}:${PAPERLESS_PORT:-7807}
     volumes:


### PR DESCRIPTION
## What
Fix the Redis connection env var for paperless-ngx so the service can connect to its Redis sidecar.

## Why
paperless-ngx expects `PAPERLESS_REDIS` as a full `redis://` URL. The compose file used `PAPERLESS_REDISHOST` and `PAPERLESS_REDISPORT` which are not recognized by paperless-ngx, causing it to fall back to `localhost:6379`:
```
Waiting for Redis...
Redis ping #0 failed.
Error: Error 111 connecting to localhost:6379. Connection refused.
```

## How
Replaced the two unrecognized env vars with the single correct one:
```yaml
- PAPERLESS_REDIS=${PAPERLESS_REDIS:-redis://paperless-redis:6379}
```
Uses the `${VAR:-default}` override pattern consistent with all other env vars in the file.

## Scope
All changes within `resources/dev/extensions-library/services/paperless-ngx/compose.yaml`.

## Testing
- YAML validation: passed
- Live tested: Redis connects, celery ready, container healthy, web UI returns 200
- `PAPERLESS_DBHOST` verified correct — no change needed

## Review
Critique Guardian: **APPROVED WITH WARNINGS** — warning addressed (added `${VAR:-default}` templating for consistency).

🤖 Generated with [Claude Code](https://claude.com/claude-code)