### PR TITLE
fix(extensions): use 'key' instead of 'name' in env_vars per schema

### DIFF
--- a/resources/dev/extensions-library/services/bark/manifest.yaml
+++ b/resources/dev/extensions-library/services/bark/manifest.yaml
@@ -17,13 +17,13 @@ service:
   category: optional
   depends_on: []
   env_vars:
-    - name: BARK_USE_SMALL_MODELS
+    - key: BARK_USE_SMALL_MODELS
       description: Use smaller/faster Bark models (less VRAM, slightly lower quality)
       default: "false"
-    - name: BARK_OFFLOAD_CPU
+    - key: BARK_OFFLOAD_CPU
       description: Offload Bark models to CPU between requests (reduces VRAM usage)
       default: "false"
-    - name: BARK_API_KEY
+    - key: BARK_API_KEY
       description: API key for Bark TTS service authentication (optional; leave empty to disable auth)
       default: ""
   description: |

--- a/resources/dev/extensions-library/services/rvc/manifest.yaml
+++ b/resources/dev/extensions-library/services/rvc/manifest.yaml
@@ -17,7 +17,7 @@ service:
   category: optional
   depends_on: []
   env_vars:
-    - name: RVC_API_KEY
+    - key: RVC_API_KEY
       description: API key for RVC service authentication (optional; leave empty to disable auth)
       default: ""
 


### PR DESCRIPTION
## Summary
Fixes schema violation in `bark` and `rvc` extension manifests.

## Problem
The `service-manifest.v1.json` schema requires `env_vars` items to use `key`:
```json
"required": ["key"]
```
But `bark` and `rvc` were using `name:`, failing validation.

## Changes
- `bark/manifest.yaml`: 3 env_vars fixed (`name:` → `key:`)
- `rvc/manifest.yaml`: 1 env_var fixed

## Validation
Both manifests pass `jsonschema` validation after this fix:
```bash
python3 -c "
import json, yaml
from jsonschema import validate
schema = json.load(open('resources/dev/extensions-library/schema/service-manifest.v1.json'))
for svc in ['bark', 'rvc']:
    validate(yaml.safe_load(open(f'resources/dev/extensions-library/services/{svc}/manifest.yaml')), schema)
    print(f'{svc}: Valid!')
"
```