### PR TITLE
fix(extensions-library): remove top-level name: from 7 extension compose files

### DIFF
--- a/resources/dev/extensions-library/services/aider/compose.yaml
+++ b/resources/dev/extensions-library/services/aider/compose.yaml
@@ -1,5 +1,3 @@
-name: aider
-
 services:
   aider:
     image: paulgauthier/aider:v0.86.2

--- a/resources/dev/extensions-library/services/crewai/compose.yaml
+++ b/resources/dev/extensions-library/services/crewai/compose.yaml
@@ -1,5 +1,3 @@
-name: crewai
-
 # CrewAI Studio — no-code multi-agent UI (https://github.com/strnad/CrewAI-Studio)
 # Image: tham0nk/crewai-studio (community build of strnad/CrewAI-Studio)
 # Digest pinned from Docker Hub tag "latest" as of 2024-09-06.

--- a/resources/dev/extensions-library/services/invokeai/compose.yaml
+++ b/resources/dev/extensions-library/services/invokeai/compose.yaml
@@ -1,5 +1,3 @@
-name: invokeai
-
 services:
   invokeai:
     image: ghcr.io/invoke-ai/invokeai:v6.11.1

--- a/resources/dev/extensions-library/services/jupyter/compose.yaml
+++ b/resources/dev/extensions-library/services/jupyter/compose.yaml
@@ -1,5 +1,3 @@
-name: jupyter
-
 services:
   jupyter:
     image: jupyter/scipy-notebook:python-3.11

--- a/resources/dev/extensions-library/services/langflow/compose.yaml
+++ b/resources/dev/extensions-library/services/langflow/compose.yaml
@@ -1,5 +1,3 @@
-name: langflow
-
 services:
   langflow:
     image: langflowai/langflow:1.8.0

--- a/resources/dev/extensions-library/services/open-interpreter/compose.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/compose.yaml
@@ -1,5 +1,3 @@
-name: open-interpreter
-
 services:
   open-interpreter:
     build:

--- a/resources/dev/extensions-library/services/piper-audio/compose.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/compose.yaml
@@ -1,5 +1,3 @@
-name: piper-audio
-
 services:
   piper-audio:
     image: lscr.io/linuxserver/piper:1.6.3


### PR DESCRIPTION
## What
Remove the top-level `name:` field from 7 extension compose files that override the Docker Compose project name.

## Why
When Docker Compose merges multiple `-f` files, the last `name:` wins and overrides the project name for the entire session (e.g., `dream-server` becomes `piper-audio`). This causes orphan container warnings on every compose operation and can break `docker compose down` since the project namespace no longer matches.

## How
Delete the `name:` line (and trailing blank line) from all 7 affected compose files. The project name is now correctly controlled by the DreamServer orchestrator.

**Affected services:** aider, crewai, invokeai, jupyter, langflow, open-interpreter, piper-audio.

## Scope
All changes are within `resources/dev/extensions-library/services/*/compose.yaml`.

## Testing
- All 7 files validated as valid YAML after removal
- `grep -r "^name:" resources/dev/extensions-library/services/*/compose.yaml` returns zero matches
- No other compose semantics affected — only the top-level `name:` key was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>