### PR TITLE
fix(extensions-library): align rvc and bark env vars between compose and manifest

### DIFF
--- a/resources/dev/extensions-library/services/bark/README.md
+++ b/resources/dev/extensions-library/services/bark/README.md
@@ -70,6 +70,7 @@ Bark understands non-verbal cues in brackets:
 | `BARK_USE_SMALL_MODELS` | `false` | Use smaller/faster models |
 | `BARK_OFFLOAD_CPU` | `false` | Offload to CPU between requests |
 | `BARK_PORT` | `9200` | External port |
+| `BARK_API_KEY` | `` | API key for authentication (optional) |
 
 ## Data Persistence
 

--- a/resources/dev/extensions-library/services/bark/compose.yaml
+++ b/resources/dev/extensions-library/services/bark/compose.yaml
@@ -14,6 +14,7 @@ services:
       - SUNO_USE_SMALL_MODELS=${BARK_USE_SMALL_MODELS:-false}
       # Offload to CPU between calls — reduces VRAM at the cost of speed
       - SUNO_OFFLOAD_CPU=${BARK_OFFLOAD_CPU:-false}
+      - BARK_API_KEY=${BARK_API_KEY:-}
     volumes:
       # Bark model cache — persists ~5GB of downloaded models
       - ./data/bark/models:/root/.cache/suno

--- a/resources/dev/extensions-library/services/rvc/README.md
+++ b/resources/dev/extensions-library/services/rvc/README.md
@@ -18,7 +18,7 @@ RVC (Retrieval-Based Voice Conversion) is an open-source voice conversion framew
 ### Environment Variables
 
 - `RVC_PORT` - Port for web interface (default: 7860)
-- `LLM_API_URL` - URL for your LLM API (from .env)
+- `RVC_API_KEY` - API key for RVC service authentication (optional; leave empty to disable auth)
 
 ### Volumes
 

--- a/resources/dev/extensions-library/services/rvc/compose.yaml
+++ b/resources/dev/extensions-library/services/rvc/compose.yaml
@@ -10,7 +10,7 @@ services:
       - ./data/rvc/dataset:/app/dataset
       - ./data/rvc/logs:/app/logs
     environment:
-      - LLM_API_URL=${LLM_API_URL:-http://localhost:8000}
+      - RVC_API_KEY=${RVC_API_KEY:-}
     shm_size: "1gb"
     restart: unless-stopped
     security_opt:


### PR DESCRIPTION
## What
Fix env var mismatches between compose and manifest for rvc and bark extensions.

## Why
**RVC:** The manifest declares `RVC_API_KEY` for optional authentication, but the compose file never passes it to the container — instead it passes a bogus `LLM_API_URL=http://localhost:8000` (RVC is a voice conversion tool with no LLM dependency; this was a copy-paste artifact). Users cannot enable API key auth even though the manifest documents it.

**Bark:** The manifest declares `BARK_API_KEY` for optional authentication, but the compose file never passes it to the container. Same pattern as RVC.

## How
- **rvc/compose.yaml:** Replace `LLM_API_URL=${LLM_API_URL:-http://localhost:8000}` with `RVC_API_KEY=${RVC_API_KEY:-}`
- **rvc/README.md:** Replace `LLM_API_URL` documentation with `RVC_API_KEY`
- **bark/compose.yaml:** Add `BARK_API_KEY=${BARK_API_KEY:-}` to environment
- **bark/README.md:** Add `BARK_API_KEY` row to environment variables table

Both use `${VAR:-}` (empty default = auth disabled), matching the convention used by other extensions (librechat, crewai, aider, privacy-shield).

## Scope
All changes are within `resources/dev/extensions-library/services/{rvc,bark}/`.

## Testing
- Compose env vars now match manifest declarations for both services
- Empty default is backward-compatible — no auth required unless user sets a key
- Workflow JSON files for both services already reference these API keys for `X-API-Key` header auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>