### PR TITLE
fix(extensions-library): resolve open-interpreter starlette dependency conflict

### DIFF
--- a/resources/dev/extensions-library/services/open-interpreter/Dockerfile
+++ b/resources/dev/extensions-library/services/open-interpreter/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.12-slim@sha256:ccc7089399c8bb65dd1fb3ed6d55efa538a3f5e7fca3f5988ac
 # Install dependencies
 RUN pip install --no-cache-dir \
     open-interpreter==0.4.3 \
-    fastapi==0.135.1 \
+    fastapi==0.111.0 \
     uvicorn==0.42.0 \
     pydantic==2.12.5
 


### PR DESCRIPTION
## What
Downgrade fastapi pin from 0.135.1 to 0.111.0 in the open-interpreter Dockerfile.

## Why
The Dockerfile pins two packages with incompatible starlette requirements:
- `open-interpreter==0.4.3` requires `starlette >=0.37.2,<0.38.0`
- `fastapi==0.135.1` requires `starlette >=0.46.0`

These ranges have zero overlap — pip fails with `ResolutionImpossible` and the image cannot be built.

## How
FastAPI 0.111.0 requires `starlette >=0.37.2,<0.38.0` — exactly matching open-interpreter's constraint. All FastAPI features used in `server.py` are basic and available in 0.111.0:
- `FastAPI`, `Depends`, `HTTPException` (core)
- `StreamingResponse` (responses)
- `HTTPBearer`, `HTTPAuthorizationCredentials` (security)
- Pydantic v2 `BaseModel` / `field_validator`

No newer FastAPI features (lifespan, Annotated dependencies, etc.) are used.

## Scope
Single line change in `resources/dev/extensions-library/services/open-interpreter/Dockerfile`.

## Testing
- Verified starlette version ranges overlap with fastapi 0.111.0
- Audited server.py for API compatibility — all features available in 0.111.0
- Note: a separate pre-existing issue (missing `gcc`/`python3-dev` for psutil C extension) also blocks the build — that is out of scope for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>