### PR TITLE
fix(schema): add 'cpu' and 'none' to gpu_backends enum

### DIFF
--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -60,7 +60,7 @@
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
         "gpu_backends": {
           "type": "array",
-          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all"] },
+          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
           "minItems": 1
         },
         "compose_file": {
@@ -127,7 +127,7 @@
           "priority": { "type": "integer", "minimum": 1 },
           "gpu_backends": {
             "type": "array",
-            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all"] },
+            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
             "minItems": 1
           }
         },

--- a/resources/dev/extensions-library/schema/service-manifest.v1.json
+++ b/resources/dev/extensions-library/schema/service-manifest.v1.json
@@ -32,7 +32,7 @@
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
         "gpu_backends": {
           "type": "array",
-          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all"] },
+          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
           "minItems": 1
         },
         "compose_file": {
@@ -99,7 +99,7 @@
           "priority": { "type": "integer", "minimum": 1 },
           "gpu_backends": {
             "type": "array",
-            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all"] },
+            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
             "minItems": 1
           }
         },


### PR DESCRIPTION
## Summary
Adds `cpu` and `none` to the allowed `gpu_backends` values in both schema files.

## Problem
The manifest schema only allowed `[amd, nvidia, apple, all]` for `gpu_backends`, but:
- CPU-only services in extensions-library use `[none]`
- Runtime code (`resolve-compose-stack.sh`, `audit-extensions.py`) already accepts `none`
- `validate-manifest-schema.sh` already accepts `cpu`

This caused schema validation to fail for 14+ CPU-only extensions.

## Changes
- `dream-server/extensions/schema/service-manifest.v1.json`: Added `cpu` and `none`
- `resources/dev/extensions-library/schema/service-manifest.v1.json`: Added `cpu` and `none`

Both service-level and features-level `gpu_backends` updated.

## Safety
- No manifest changes required (existing `[none]` values now validate)
- Aligns schema with existing runtime behavior
- Forward-compatible for new `[cpu]` usage