### PR TITLE
fix(extensions-library): add milvus standalone env vars for embedded etcd and local storage

### DIFF
--- a/resources/dev/extensions-library/services/milvus/compose.yaml
+++ b/resources/dev/extensions-library/services/milvus/compose.yaml
@@ -8,6 +8,8 @@ services:
       - ./data/milvus:/var/lib/milvus
     environment:
       - MODE=standalone
+      - ETCD_USE_EMBED=true
+      - COMMON_STORAGETYPE=local
     command: ["milvus", "run", "standalone"]
     restart: unless-stopped
     security_opt:


### PR DESCRIPTION
## What
Add ETCD_USE_EMBED=true and COMMON_STORAGETYPE=local to milvus compose environment.

## Why
Milvus standalone mode tries to connect to external etcd (:2379) and MinIO (:9000)
by default. Neither exists in this single-container deployment, causing crash-loops
after the command fix in PR #633.

## How
Two environment variables added to the existing environment block in compose.yaml.

## Scope
All changes within `resources/dev/extensions-library/services/milvus/`.

## Testing
- YAML validation: `docker compose config` passes
- Live-tested: container starts healthy, REST API works, vector operations succeed
- Manual: `docker compose up dream-milvus`, verify healthcheck passes, test `/v1/vector/collections`


🤖 Generated with [Claude Code](https://claude.com/claude-code)