### PR TITLE
fix(extensions-library): correct RVC README ports and volume paths

### DIFF
--- a/resources/dev/extensions-library/services/rvc/README.md
+++ b/resources/dev/extensions-library/services/rvc/README.md
@@ -9,7 +9,7 @@ RVC (Retrieval-Based Voice Conversion) is an open-source voice conversion framew
 ## Features
 
 - **Voice Conversion**: Transform voices while preserving speaker characteristics
-- **Web UI**: Easy-to-use interface on port 7860
+- **Web UI**: Easy-to-use interface on port 7809
 - **Local Processing**: All processing happens locally
 - **Multiple Models**: Support for various RVC models
 
@@ -17,19 +17,19 @@ RVC (Retrieval-Based Voice Conversion) is an open-source voice conversion framew
 
 ### Environment Variables
 
-- `RVC_PORT` - Port for web interface (default: 7860)
+- `RVC_PORT` - Port for web interface (default: 7809)
 - `RVC_API_KEY` - API key for RVC service authentication (optional; leave empty to disable auth)
 
 ### Volumes
 
-- `./data/rvc/models` - RVC models storage
-- `./data/rvc/voices` - Input/output voices
-- `./data/rvc/index` - Index files for voice conversion
+- `./data/rvc/weights` - Model weights storage
+- `./data/rvc/opt` - Optimization files
+- `./data/rvc/dataset` - Training datasets
 - `./data/rvc/logs` - Processing logs
 
 ### Ports
 
-- `7860` - Web interface
+- `7865` (internal), `7809` (external default) - Web interface
 
 ## Quick Start
 
@@ -49,7 +49,7 @@ docker-compose -f extensions/services/rvc/compose.yaml up -d
 
 ### Web Interface
 
-Access the web interface at `http://localhost:7860`.
+Access the web interface at `http://localhost:7809`.
 
 ### Voice Conversion Workflow
 


### PR DESCRIPTION
## What
Fix incorrect port numbers and volume paths in RVC README.md.

## Why
README listed port 7860 and volumes models/voices/index/ which don't match
the actual compose.yaml (ports 7809/7865, volumes weights/opt/dataset/logs/).

## How
Updated all port references and volume paths to match compose.yaml and manifest.yaml.

## Scope
All changes within `resources/dev/extensions-library/services/rvc/`.
Documentation only — no code or compose changes.

## Testing
- Cross-referenced all values against compose.yaml and manifest.yaml
- No runtime testing needed (documentation fix)


🤖 Generated with [Claude Code](https://claude.com/claude-code)