### PR TITLE
fix(extensions-library): fix open-interpreter healthcheck and add gcc build deps

### DIFF
--- a/resources/dev/extensions-library/services/open-interpreter/Dockerfile
+++ b/resources/dev/extensions-library/services/open-interpreter/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.12-slim@sha256:ccc7089399c8bb65dd1fb3ed6d55efa538a3f5e7fca3f5988ac3b5b87e593bf0
 
+# Install build dependencies for C extensions (psutil)
+RUN apt-get update && apt-get install -y --no-install-recommends gcc python3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
 # Install dependencies
 RUN pip install --no-cache-dir \
     open-interpreter==0.4.3 \

--- a/resources/dev/extensions-library/services/open-interpreter/compose.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/compose.yaml
@@ -21,7 +21,7 @@ services:
     working_dir: /app
     command: ["python", "server.py"]
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:8080/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8080/health')"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What
Replace wget healthcheck with python3 urllib. Add gcc and python3-dev to Dockerfile
for psutil C extension compilation.

## Why
The python:3.12-slim base image has neither wget nor curl, causing permanent
healthcheck failure. It also lacks gcc/python3-dev, causing pip install to fail
when building psutil (a dependency of open-interpreter).

## How
- compose.yaml: healthcheck uses python3 stdlib urllib with 127.0.0.1 (avoids IPv6 resolution issues)
- Dockerfile: apt-get install gcc python3-dev before pip install, with cache cleanup

## Scope
All changes within `resources/dev/extensions-library/services/open-interpreter/`.

## Testing
- YAML validation: `docker compose config` passes
- Manual: `docker compose build dream-open-interpreter` (verify gcc resolves psutil build),
  then `docker compose up` and verify healthcheck passes


🤖 Generated with [Claude Code](https://claude.com/claude-code)