### PR TITLE
fix(extensions): use hyphen in privacy-shield service id

### DIFF
--- a/resources/dev/extensions-library/services/privacy_shield/manifest.yaml
+++ b/resources/dev/extensions-library/services/privacy_shield/manifest.yaml
@@ -1,7 +1,7 @@
 schema_version: dream.services.v1
 
 service:
-  id: privacy_shield
+  id: privacy-shield
   name: Privacy Shield (PII Protection)
   aliases: []
   container_name: dream-privacy-shield


### PR DESCRIPTION
## Summary
Fixes schema validation error for privacy_shield extension.

## Problem
The manifest `id` field used underscore (`privacy_shield`) but schema pattern `^[a-z0-9][a-z0-9-]*$` only allows hyphens.

## Fix
Changed `id: privacy_shield` → `id: privacy-shield`

Folder name unchanged — only the manifest id field affects schema validation.