### PR TITLE
fix(extensions): add missing required fields to localai features

### DIFF
--- a/resources/dev/extensions-library/services/localai/manifest.yaml
+++ b/resources/dev/extensions-library/services/localai/manifest.yaml
@@ -20,20 +20,50 @@ features:
   - id: text-generation
     name: Text Generation
     description: Generate text with local LLMs via OpenAI-compatible API
-    vram_mb: 4096
+    icon: MessageSquare
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 4
+    priority: 5
+    gpu_backends: [amd, nvidia]
   - id: image-generation
     name: Image Generation
     description: Generate images with local diffusion models
-    vram_mb: 8192
+    icon: Image
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 8
+    priority: 6
+    gpu_backends: [amd, nvidia]
   - id: audio-generation
     name: Audio Generation
     description: Generate audio with local models
-    vram_mb: 4096
+    icon: Music
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 4
+    priority: 7
+    gpu_backends: [amd, nvidia]
   - id: video-generation
     name: Video Generation
     description: Generate video with local models
-    vram_mb: 16384
+    icon: Video
+    category: ai
+    requirements:
+      services: [localai]
+      vram_gb: 16
+    priority: 8
+    gpu_backends: [amd, nvidia]
   - id: voice-cloning
     name: Voice Cloning
     description: Clone voices for TTS with local models
-    vram_mb: 4096
+    icon: Mic
+    category: voice
+    requirements:
+      services: [localai]
+      vram_gb: 4
+    priority: 9
+    gpu_backends: [amd, nvidia]


### PR DESCRIPTION
## Summary
Fixes schema validation for localai extension by adding all required feature fields.

## Problem
All 5 features were missing required fields per schema:
- `icon` - feature icon name
- `category` - feature category
- `requirements` - service dependencies and vram
- `priority` - feature priority order
- `gpu_backends` - supported GPU backends

Also used invalid `vram_mb` instead of `requirements.vram_gb`.

## Changes
Added all required fields to 5 features:
- text-generation
- image-generation  
- audio-generation
- video-generation
- voice-cloning

## Validation
Manifest now passes jsonschema validation.