### PR TITLE
fix(extensions): set gpu_backends: [all] for CPU-only features

### DIFF
--- a/resources/dev/extensions-library/services/aider/manifest.yaml
+++ b/resources/dev/extensions-library/services/aider/manifest.yaml
@@ -38,4 +38,4 @@ features:
     enabled_services_all: [aider]
     setup_time: ~1 minute
     priority: 11
-    gpu_backends: []
+    gpu_backends: [all]

--- a/resources/dev/extensions-library/services/chromadb/manifest.yaml
+++ b/resources/dev/extensions-library/services/chromadb/manifest.yaml
@@ -30,4 +30,4 @@ features:
     enabled_services_all: [chromadb]
     setup_time: ~1 minute
     priority: 9
-    gpu_backends: []
+    gpu_backends: [all]

--- a/resources/dev/extensions-library/services/label-studio/manifest.yaml
+++ b/resources/dev/extensions-library/services/label-studio/manifest.yaml
@@ -33,7 +33,7 @@ features:
     enabled_services_all: [label-studio]
     setup_time: ~1 minute
     priority: 15
-    gpu_backends: []
+    gpu_backends: [all]
 
 tags:
   - labeling

--- a/resources/dev/extensions-library/services/piper-audio/manifest.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/manifest.yaml
@@ -33,4 +33,4 @@ features:
     enabled_services_all: [piper-audio]
     setup_time: ~1 minute
     priority: 10
-    gpu_backends: []
+    gpu_backends: [all]

--- a/resources/dev/extensions-library/services/sillytavern/manifest.yaml
+++ b/resources/dev/extensions-library/services/sillytavern/manifest.yaml
@@ -30,4 +30,4 @@ features:
     enabled_services_all: [sillytavern]
     setup_time: ~1 minute
     priority: 6
-    gpu_backends: []
+    gpu_backends: [all]


### PR DESCRIPTION
## Summary

Empty `gpu_backends: []` in feature definitions causes features to be silently skipped during dashboard-api config filtering.

## Problem

In `dashboard-api/config.py` lines 86-88 and 113-115, features are filtered by checking if the current GPU backend is in the feature's `gpu_backends` array. An empty array `[]` means the feature matches NO backends and gets excluded on all platforms.

## Fix

Changed `gpu_backends: []` → `gpu_backends: [all]` for 5 services with CPU-only features that should be available on all platforms:

- **aider** - AI coding assistant (runs via API, no local GPU)
- **chromadb** - Vector database (CPU-based)
- **label-studio** - Data labeling tool (web UI)
- **piper-audio** - TTS engine (CPU inference supported)
- **sillytavern** - Chat UI (no GPU requirement)

## Testing

Verified the change against schema requirements.