### PR TITLE
fix(extensions-library): add missing fooocus GPU compose overlay

### DIFF
--- a/resources/dev/extensions-library/services/fooocus/compose.nvidia.yaml
+++ b/resources/dev/extensions-library/services/fooocus/compose.nvidia.yaml
@@ -1,0 +1,9 @@
+services:
+  fooocus:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]


### PR DESCRIPTION
## What
Create compose.nvidia.yaml for fooocus — the only GPU service missing an overlay.

## Why
The resolver at resolve-compose-stack.sh auto-discovers compose.{gpu_backend}.yaml
overlays. Fooocus had no overlay, so it could never access the GPU even when
the resolver ran with nvidia backend.

## How
Single new file following the established nvidia overlay pattern (identical
structure to forge, audiocraft, bark overlays). AMD overlay not created since
manifest declares gpu_backends: [nvidia] only.

## Scope
One new file: `resources/dev/extensions-library/services/fooocus/compose.nvidia.yaml`

## Testing
- docker compose config merge validation passed
- Pattern matches 7 existing nvidia overlays in the codebase


🤖 Generated with [Claude Code](https://claude.com/claude-code)