### PR TITLE
fix(extensions): set gpu_backends: [all] for gitea service

### DIFF
--- a/resources/dev/extensions-library/services/gitea/manifest.yaml
+++ b/resources/dev/extensions-library/services/gitea/manifest.yaml
@@ -12,7 +12,7 @@ service:
   external_port_default: 7830
   health: /api/healthz
   type: docker
-  gpu_backends: []
+  gpu_backends: [all]
   compose_file: compose.yaml
   category: optional
   depends_on: []


### PR DESCRIPTION
## Summary

Gitea manifest has empty `gpu_backends: []` which violates schema constraint `minItems: 1`.

## Problem

- Schema requires `gpu_backends` array to have at least 1 item
- Empty array causes validation failure
- Could affect service filtering in runtime

## Fix

Changed `gpu_backends: []` → `gpu_backends: [all]`

Gitea is a Git hosting server (pure CPU workload) that should be available on all platforms regardless of GPU backend.