### PR TITLE
fix(extensions-library): replace localhost with 127.0.0.1 in healthcheck URLs

### DIFF
--- a/resources/dev/extensions-library/services/audiocraft/compose.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/compose.yaml
@@ -16,7 +16,7 @@ services:
     ports:
       - "127.0.0.1:${AUDIOCRAFT_PORT:-7863}:7860"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7860/"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:7860/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/bark/compose.yaml
+++ b/resources/dev/extensions-library/services/bark/compose.yaml
@@ -21,7 +21,7 @@ services:
       # Audio output directory
       - ./data/bark/output:/app/output
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:9200/health')"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:9200/health')"]
       interval: 30s
       timeout: 15s
       retries: 5

--- a/resources/dev/extensions-library/services/crewai/compose.yaml
+++ b/resources/dev/extensions-library/services/crewai/compose.yaml
@@ -42,7 +42,7 @@ services:
     ports:
       - "127.0.0.1:${CREWAI_PORT:-8501}:8501"
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8501/')"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8501/')"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/fooocus/compose.yaml
+++ b/resources/dev/extensions-library/services/fooocus/compose.yaml
@@ -13,7 +13,7 @@ services:
     ports:
       - "127.0.0.1:${FOOOCUS_PORT:-7865}:7865"
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7865/"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:7865/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/forge/compose.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.yaml
@@ -15,7 +15,7 @@ services:
     ports:
       - "127.0.0.1:${FORGE_PORT:-7861}:7861"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7861/"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:7861/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/frigate/compose.yaml
+++ b/resources/dev/extensions-library/services/frigate/compose.yaml
@@ -21,7 +21,7 @@ services:
         tmpfs:
           size: 1000000000
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:5000/api/version"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:5000/api/version"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/gitea/compose.yaml
+++ b/resources/dev/extensions-library/services/gitea/compose.yaml
@@ -28,7 +28,7 @@ services:
       - "127.0.0.1:${GITEA_PORT:-7830}:3000"
       - "127.0.0.1:${GITEA_SSH_PORT:-2222}:2222"
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:3000/api/healthz"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:3000/api/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/label-studio/compose.yaml
+++ b/resources/dev/extensions-library/services/label-studio/compose.yaml
@@ -19,7 +19,7 @@ services:
     ports:
       - "127.0.0.1:${LABEL_STUDIO_PORT:-8086}:8080"
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-sf", "http://127.0.0.1:8080/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/langflow/compose.yaml
+++ b/resources/dev/extensions-library/services/langflow/compose.yaml
@@ -14,7 +14,7 @@ services:
     ports:
       - "127.0.0.1:${LANGFLOW_PORT:-7802}:7860"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:7860/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:7860/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/librechat/compose.yaml
+++ b/resources/dev/extensions-library/services/librechat/compose.yaml
@@ -62,7 +62,7 @@ services:
       librechat-meilisearch:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3080/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:3080/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -118,7 +118,7 @@ services:
     volumes:
       - ./data/librechat/meilisearch:/meili_data:rw
     healthcheck:
-      test: ["CMD", "wget", "--spider", "-q", "http://localhost:7700/health"]
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:7700/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/localai/compose.yaml
+++ b/resources/dev/extensions-library/services/localai/compose.yaml
@@ -20,7 +20,7 @@ services:
           cpus: '4'
           memory: 8G
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/healthz || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/healthz || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/milvus/compose.yaml
+++ b/resources/dev/extensions-library/services/milvus/compose.yaml
@@ -20,7 +20,7 @@ services:
           cpus: '2'
           memory: 8G
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9091/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/compose.yaml
@@ -20,7 +20,7 @@ services:
     ports:
       - "127.0.0.1:${PAPERLESS_PORT:-7807}:8000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/accounts/login/"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:8000/accounts/login/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/privacy-shield/compose.yaml
+++ b/resources/dev/extensions-library/services/privacy-shield/compose.yaml
@@ -29,7 +29,7 @@ services:
           cpus: '0.5'
           memory: 512M
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8085/health', timeout=5)"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8085/health', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/weaviate/compose.yaml
+++ b/resources/dev/extensions-library/services/weaviate/compose.yaml
@@ -18,7 +18,7 @@ services:
       - "127.0.0.1:${WEAVIATE_PORT:-7811}:8080"
       - "127.0.0.1:${WEAVIATE_GRPC_PORT:-50051}:50051"
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/v1/.well-known/ready"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8080/v1/.well-known/ready"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/xtts/compose.yaml
+++ b/resources/dev/extensions-library/services/xtts/compose.yaml
@@ -21,7 +21,7 @@ services:
           cpus: '0.5'
           memory: 1G
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:80/health')"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:80/health')"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What
Pure `localhost` → `127.0.0.1` swap in healthcheck `test` lines across 16 extension compose files (17 changes — librechat has two services).

## Why
On hosts where `localhost` resolves to `::1` (IPv6-first), healthchecks fail because the container process only listens on IPv4. Using the explicit IPv4 address `127.0.0.1` avoids this.

## How
Mechanical find-and-replace of `localhost` → `127.0.0.1` **only** in healthcheck `test:` lines. No tool changes, no endpoint changes, no port changes.

## Scope
All changes are within `resources/dev/extensions-library/`.

**Services affected:** audiocraft, bark, crewai, fooocus, forge, frigate, gitea, label-studio, langflow, librechat (+ meilisearch), localai, milvus, paperless-ngx, privacy-shield, weaviate, xtts.

**Deliberately excluded** (handled separately):
- chromadb, baserow, piper-audio → PR #635 (tool changes + IPv4 fix)
- anythingllm, flowise, immich, invokeai, jupyter, ollama, rvc, text-generation-webui → separate PR for tool/endpoint improvements

## Testing
- Each change is a single-token replacement (`localhost` → `127.0.0.1`) — no behavioral change beyond IPv4 enforcement
- YAML validity preserved (no structural changes)

## Context
Split from #641 per reviewer request — this PR contains only the safe, mechanical swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)