### PR TITLE
fix(extensions-library): make service.description a required schema field

### DIFF
--- a/resources/dev/extensions-library/schema/service-manifest.v1.json
+++ b/resources/dev/extensions-library/schema/service-manifest.v1.json
@@ -10,7 +10,7 @@
     },
     "service": {
       "type": "object",
-      "required": ["id", "name", "port", "health"],
+      "required": ["id", "name", "port", "health", "description"],
       "properties": {
         "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
         "name": { "type": "string", "minLength": 1 },

--- a/resources/dev/extensions-library/services/aider/manifest.yaml
+++ b/resources/dev/extensions-library/services/aider/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "AI pair programming tool that lets you edit code in your terminal using GPT-4 and Claude."
   env_vars:
     - key: OPENAI_API_KEY
       required: false

--- a/resources/dev/extensions-library/services/chromadb/manifest.yaml
+++ b/resources/dev/extensions-library/services/chromadb/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "AI-native open-source vector database for storing and querying embeddings."
   env_vars: []
 
 features:

--- a/resources/dev/extensions-library/services/continue/manifest.yaml
+++ b/resources/dev/extensions-library/services/continue/manifest.yaml
@@ -17,6 +17,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: [llama-server]
+  description: "Open-source AI coding assistant for VS Code and JetBrains with local LLM support."
 
 features:
   - id: continue-coding

--- a/resources/dev/extensions-library/services/dify/manifest.yaml
+++ b/resources/dev/extensions-library/services/dify/manifest.yaml
@@ -38,6 +38,7 @@ service:
       required: false
       secret: false
       description: Initial admin password (optional, set in .env)
+  description: "LLMOps platform for building AI workflows, RAG pipelines, and autonomous agents."
 
 features:
   - id: agent-platform

--- a/resources/dev/extensions-library/services/fooocus/manifest.yaml
+++ b/resources/dev/extensions-library/services/fooocus/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "Simplified Stable Diffusion interface inspired by Midjourney's ease of use."
   env_vars: []
 
 features:

--- a/resources/dev/extensions-library/services/gitea/manifest.yaml
+++ b/resources/dev/extensions-library/services/gitea/manifest.yaml
@@ -15,6 +15,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "Lightweight self-hosted Git service for managing repositories and CI/CD."
   env_vars:
     - key: GITEA_HOST
       description: "Hostname for Gitea server"

--- a/resources/dev/extensions-library/services/immich/manifest.yaml
+++ b/resources/dev/extensions-library/services/immich/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "Self-hosted Google Photos alternative with AI-powered face and object detection."
   env_vars:
     - key: IMMICH_DB_PASSWORD
       required: true

--- a/resources/dev/extensions-library/services/jupyter/manifest.yaml
+++ b/resources/dev/extensions-library/services/jupyter/manifest.yaml
@@ -17,6 +17,7 @@ service:
   category: optional
   depends_on: []
   setup_hook: setup.sh
+  description: "Interactive notebook environment for data science and machine learning with local LLM kernel support."
   env_vars:
     - key: JUPYTER_TOKEN
       required: true

--- a/resources/dev/extensions-library/services/localai/manifest.yaml
+++ b/resources/dev/extensions-library/services/localai/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: [llama-server]
+  description: "OpenAI-compatible API server for running open-source models locally."
 
 features:
   - id: text-generation

--- a/resources/dev/extensions-library/services/milvus/manifest.yaml
+++ b/resources/dev/extensions-library/services/milvus/manifest.yaml
@@ -15,3 +15,4 @@ service:
   compose_file: compose.yaml
   category: recommended
   depends_on: []
+  description: "Production-grade open-source vector database for scalable similarity search."

--- a/resources/dev/extensions-library/services/ollama/manifest.yaml
+++ b/resources/dev/extensions-library/services/ollama/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "Pull-and-run server for open-source large language models with simple model management."
   env_vars:
     - key: OLLAMA_MODEL
       required: false

--- a/resources/dev/extensions-library/services/piper-audio/manifest.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "Fast and lightweight text-to-speech engine optimized for edge and low-resource devices."
   env_vars:
     - key: PIPER_VOICE
       required: false

--- a/resources/dev/extensions-library/services/privacy-shield/manifest.yaml
+++ b/resources/dev/extensions-library/services/privacy-shield/manifest.yaml
@@ -16,3 +16,4 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: [llama-server]
+  description: "PII detection and redaction proxy that scrubs sensitive data before it reaches LLMs."

--- a/resources/dev/extensions-library/services/rvc/manifest.yaml
+++ b/resources/dev/extensions-library/services/rvc/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "Real-time voice conversion and cloning engine for transforming vocal characteristics."
   env_vars:
     - key: RVC_API_KEY
       description: API key for RVC service authentication (optional; leave empty to disable auth)

--- a/resources/dev/extensions-library/services/sillytavern/manifest.yaml
+++ b/resources/dev/extensions-library/services/sillytavern/manifest.yaml
@@ -16,6 +16,7 @@ service:
   compose_file: compose.yaml
   category: optional
   depends_on: []
+  description: "Advanced character-based roleplay and chat frontend with extensive customization."
   env_vars: []
 
 features:

--- a/resources/dev/extensions-library/services/xtts/manifest.yaml
+++ b/resources/dev/extensions-library/services/xtts/manifest.yaml
@@ -16,3 +16,4 @@ service:
   compose_file: compose.yaml
   category: recommended
   depends_on: []
+  description: "Coqui XTTS voice cloning and multilingual text-to-speech server."

--- a/resources/dev/extensions-library/templates/service-template.yaml
+++ b/resources/dev/extensions-library/templates/service-template.yaml
@@ -89,6 +89,11 @@ service:
   # optional:    User must run "dream enable <id>" to activate
   category: optional
 
+  # ── Description (REQUIRED) ──
+  # One-line human-readable summary of what this service does.
+  # Shown in dashboard and CLI. Keep it under ~100 characters.
+  description: "Short description of what this service does."
+
   # ── Dependencies (optional) ──
   # Other service IDs that must be running for this service to work.
   # "dream enable" will prompt to enable missing dependencies.


### PR DESCRIPTION
## What
Makes `service.description` a required field in the manifest schema and adds descriptions to the 16 services that were missing them. Updates the service template to include the field.

## Why
16 of 33 service manifests had no `service.description`, making it impossible for CLI tools, dashboards, or a future `dream describe` command to show users what a service does. The schema allowed this because `description` was optional.

## How
- Added `"description"` to the `required` array in `schema/service-manifest.v1.json`
- Added concise, accurate `description` strings to 16 manifests: aider, chromadb, continue, dify, fooocus, gitea, immich, jupyter, localai, milvus, ollama, piper-audio, privacy-shield, rvc, sillytavern, xtts
- Added `description` field with guidance comments to `templates/service-template.yaml`

## Scope
All changes are within `resources/dev/extensions-library/`.

## Testing
- All 33 manifests pass `jsonschema.validate()` against the updated schema
- Template verified to produce schema-valid manifests
- No secrets in diff

## Review
Critique Guardian: APPROVED (after rerun with template fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)