### PR TITLE
fix(installer): Docker 29.3 AMD downgrade on pacman + start-limit-hit recovery

### DIFF
--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -142,7 +142,7 @@ if command -v docker &>/dev/null && ! $DRY_RUN; then
             # Warn the user with clear manual instructions.
             ai_warn "Automatic Docker downgrade is not supported on pacman-based distros."
             ai_warn "GPU containers may fail with device passthrough errors."
-            ai "  Manual fix: downgrade Docker using your distro's package cache:"
+            ai "  Manual fix: downgrade Docker from the Arch Linux Archive:"
             ai "    sudo pacman -U https://archive.archlinux.org/packages/d/docker/docker-1%3A29.2.1-1-x86_64.pkg.tar.zst"
             ai "  Or wait for Docker to fix the bug in a future release."
         else


### PR DESCRIPTION
## Summary
Fixes 2 bugs reported from a CachyOS install on Strix Halo (Ryzen AI MAX+ 395):

- **Docker 29.3 AMD downgrade missing pacman handler** — The downgrade logic only had `apt` and `dnf` cases. On Arch/CachyOS/Manjaro, the installer printed "Downgrading..." but silently did nothing. Now emits a clear warning with manual instructions, plus a catch-all `else` so no distro silently skips.

- **Docker start-limit-hit causes infinite hang** — Multiple Docker restarts during install trigger systemd's `StartLimitBurst` rate limiter. Docker enters a `failed` state and all subsequent phases hang forever. Now detects the failed state via `systemctl is-failed`, runs `reset-failed` to clear the limiter, and retries.

## Test plan
- [ ] ShellCheck passes (CI: `lint-shell.yml`)
- [ ] On pacman-based distro with Docker 29.3 + AMD GPU: warning message appears with manual downgrade instructions
- [ ] On any distro: simulate start-limit-hit (`sudo systemctl stop docker && for i in 1 2 3 4 5; do sudo systemctl start docker; sudo systemctl stop docker; done`) — installer should recover
- [ ] Dry run is not affected by either change
- [ ] Existing apt/dnf downgrade paths unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)