### PR TITLE
fix(extensions-library): add RAFT single-node config for weaviate

### DIFF
--- a/resources/dev/extensions-library/services/weaviate/compose.yaml
+++ b/resources/dev/extensions-library/services/weaviate/compose.yaml
@@ -12,6 +12,9 @@ services:
       - AUTHENTICATION_APIKEY_ALLOWED_KEYS=${WEAVIATE_API_KEY:?WEAVIATE_API_KEY must be set}
       - AUTHENTICATION_APIKEY_USERS=admin@dreamserver.local
       - PERSISTENCE_DATA_PATH=/var/lib/weaviate
+      - CLUSTER_HOSTNAME=dream-weaviate
+      - RAFT_JOIN=dream-weaviate
+      - RAFT_BOOTSTRAP_EXPECT=1
     volumes:
       - ./data/weaviate:/var/lib/weaviate
     ports:


### PR DESCRIPTION
## Summary
- Weaviate 1.25+ uses RAFT consensus and defaults to the container hostname as node ID
- On container recreation, hostname changes → node can't rejoin its own persisted RAFT state → infinite join loop → 503 on `/v1/.well-known/ready`
- Adds `CLUSTER_HOSTNAME`, `RAFT_JOIN`, and `RAFT_BOOTSTRAP_EXPECT` for stable single-node identity

## Test plan
- [x] Verified weaviate was stuck in RAFT join loop before fix (503, "attempting to join" every second)
- [x] Applied fix, cleared stale RAFT data, started fresh → healthy in ~10s
- [x] Recreated container WITHOUT clearing RAFT data → re-elected leader → healthy
- [x] Tested on M4 Mac Mini with Docker Desktop (Apple Silicon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)