### PR TITLE
fix(installer): retry preflight validation for slow-starting services

### DIFF
--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -160,13 +160,13 @@ if [[ -f "$SCRIPT_DIR/dream-preflight.sh" ]]; then
     # Retry up to 3 times with 10s backoff before reporting failures.
     _preflight_passed=false
     for _pf_attempt in 1 2 3; do
-        sleep 10
         if bash "$SCRIPT_DIR/dream-preflight.sh" 2>>"$LOG_FILE"; then
             _preflight_passed=true
             break
         fi
         if [[ $_pf_attempt -lt 3 ]]; then
             ai_warn "Some services still starting (attempt $_pf_attempt/3). Retrying in 10s..."
+            sleep 10
         fi
     done
     if [[ "$_preflight_passed" != "true" ]]; then


### PR DESCRIPTION
## Summary
On fresh installs, services like APE and Embeddings are still initializing when Phase 13's preflight check runs. The installer exits with error code 1 even though all 17 services are healthy moments later. This is the remaining blocker for clean non-interactive installs.

- **Old behavior**: Single `sleep 2` → one preflight attempt → `|| true` (still triggered ERR trap in some paths) → installer reports failure
- **New behavior**: 3 attempts with 10s backoff → preflight inside `if` (properly consumed by shell, never triggers ERR trap) → warns but doesn't crash

## Test plan
- [ ] ShellCheck passes (CI: `lint-shell.yml`)
- [ ] Fresh install completes with exit code 0 even when APE/Embeddings are slow to start
- [ ] If all services are already healthy, preflight passes on first attempt (10s wait, not 30s)
- [ ] `--non-interactive` install completes without error
- [ ] Dry run is not affected (preflight is skipped in dry run by the preflight script itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)