### PR TITLE
fix(installer): prevent bg_task_status from triggering ERR trap

### DIFF
--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -58,8 +58,7 @@ if [[ -f "$SCRIPT_DIR/installers/lib/background-tasks.sh" ]]; then
         bg_task_summary >> "$LOG_FILE" 2>&1
 
         # Check SDXL Lightning download specifically
-        bg_task_status "sdxl-download" &>/dev/null
-        sdxl_status=$?
+        if bg_task_status "sdxl-download" &>/dev/null; then sdxl_status=0; else sdxl_status=$?; fi
         if [[ $sdxl_status -ne 3 ]]; then
             case $sdxl_status in
                 0)  # Still running
@@ -81,8 +80,7 @@ fi
 
 # Check bootstrap model upgrade status
 if [[ "${_BOOTSTRAP_ACTIVE:-false}" == "true" ]]; then
-    bg_task_status "full-model-download" &>/dev/null
-    _upgrade_status=$?
+    if bg_task_status "full-model-download" &>/dev/null; then _upgrade_status=0; else _upgrade_status=$?; fi
     case $_upgrade_status in
         0)  # Still running
             echo ""


### PR DESCRIPTION
## Summary
`bg_task_status` returns exit code 1 for "completed successfully" (status code 1 = completed in the background task system). Under `set -euo pipefail`, this triggers the ERR trap and kills the installer before `$?` can be captured on the next line.

This fires on every fresh install where background tasks (SDXL download, bootstrap model upgrade) completed — which is the common case. It's the root cause of the Phase 13 crash, firing before the preflight check even runs.

Fix: wrap both `bg_task_status` calls in `if/else` so the exit code is consumed by the shell conditional and never triggers ERR.

## Test plan
- [ ] ShellCheck passes
- [ ] Fresh install with SDXL download completing during install — no ERR trap
- [ ] Fresh install with bootstrap model completing during install — no ERR trap  
- [ ] Background tasks still report correct status (running/completed/failed) in the summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)