### PR TITLE
fix(windows): cpu fallback for no-GPU systems, 8GB RAM floor, compose hang fix

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -524,6 +524,7 @@ if ($dryRun) {
         $_composeLogDir = Join-Path $installDir "logs"
         if (-not (Test-Path $_composeLogDir)) { New-Item -ItemType Directory -Path $_composeLogDir -Force | Out-Null }
         $_composeLog = Join-Path $_composeLogDir "compose-up.log"
+        Write-AI "Starting services... this may take several minutes."
         & docker compose @composeFlags up -d *> $_composeLog
         $composeExit = $LASTEXITCODE
         $ErrorActionPreference = $prevEAP

--- a/dream-server/installers/windows/phases/04-requirements.ps1
+++ b/dream-server/installers/windows/phases/04-requirements.ps1
@@ -85,8 +85,8 @@ $_minRamGB = switch ($selectedTier) {
 
 # Hard floor: Docker Desktop + WSL2 + containers need at least 8 GB to function
 if ($systemRamGB -lt 8) {
-    Write-AIBad "RAM: ${systemRamGB} GB detected. Dream Server requires at least 8 GB."
-    Write-AIBad "Docker Desktop + WSL2 + services need more memory than is available."
+    Write-AIError "RAM: ${systemRamGB} GB detected. Dream Server requires at least 8 GB."
+    Write-AIError "Docker Desktop + WSL2 + services need more memory than is available."
     Write-AI "  With ${systemRamGB} GB, Docker alone consumes most available RAM."
     $requirementsMet = $false
 } elseif ($systemRamGB -lt $_minRamGB) {


### PR DESCRIPTION
## Summary
Three fixes from Windows install test reports (Sessions 7-9 on low-spec hardware):

- **backend "none" → cpu fallback** — When no discrete GPU is detected (Intel integrated), `GPU_BACKEND` is set to `"none"` and no compose overlay was added. Compose failed with "Configuration error" and zero containers created. Now includes `docker-compose.cpu.yml` as fallback, matching Linux behavior.

- **8GB hard RAM floor** — A 4GB machine has ~400MB free after Docker Desktop + WSL2 start. The installer previously warned but continued, spending 30+ minutes building containers that could never start. Now blocks at Phase 4 with a clear message. Per-tier soft warnings above 8GB are unchanged.

- **Compose pipeline hang fix** — After compose failure, the `ForEach-Object` pipeline on compose output hung indefinitely (the `@` loop bug). Replaced with log file redirect (`logs/compose-up.log`) + `Get-Content -Tail 20` for immediate feedback. No more unbreakable loops.

## Test plan
- [ ] PowerShell lint passes (CI: `lint-powershell.yml`)
- [ ] Windows with no discrete GPU: includes `docker-compose.cpu.yml`, shows "CPU-only inference" warning
- [ ] Windows with NVIDIA GPU: unchanged path (nvidia overlay or cpu fallback on passthrough failure)
- [ ] Windows with <8GB RAM: hard stops at Phase 4 with clear message
- [ ] Windows with 8GB+ RAM: existing tier-specific warnings unchanged
- [ ] Compose failure: exits cleanly, no hanging loop, log file created at `logs/compose-up.log`
- [ ] Successful compose: shows last 20 lines of output, continues normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)