### PR TITLE
fix: add missing gpu_backends to 8 extension manifests

### DIFF
--- a/resources/dev/extensions-library/services/baserow/manifest.yaml
+++ b/resources/dev/extensions-library/services/baserow/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 3007
   health: /api/_health/
   type: docker
+  gpu_backends: [all]
   category: optional
   compose_file: compose.yaml
   depends_on: []

--- a/resources/dev/extensions-library/services/crewai/manifest.yaml
+++ b/resources/dev/extensions-library/services/crewai/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 8501
   health: /
   type: docker
+  gpu_backends: [all]
   category: optional
   depends_on: []
   env_vars: []

--- a/resources/dev/extensions-library/services/gitea/manifest.yaml
+++ b/resources/dev/extensions-library/services/gitea/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 7830
   health: /api/healthz
   type: docker
+  gpu_backends: [all]
   compose_file: compose.yaml
   category: optional
   depends_on: []

--- a/resources/dev/extensions-library/services/label-studio/manifest.yaml
+++ b/resources/dev/extensions-library/services/label-studio/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 8086
   health: /health
   type: docker
+  gpu_backends: [all]
   compose_file: compose.yaml
   category: optional
   depends_on: []

--- a/resources/dev/extensions-library/services/milvus/manifest.yaml
+++ b/resources/dev/extensions-library/services/milvus/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 19530
   health: /healthz
   type: docker
+  gpu_backends: [all]
   compose_file: compose.yaml
   category: recommended
   depends_on: []

--- a/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 7805
   health: /health
   type: docker
+  gpu_backends: [all]
   category: optional
   depends_on: []
   compose_file: compose.yaml

--- a/resources/dev/extensions-library/services/paperless-ngx/manifest.yaml
+++ b/resources/dev/extensions-library/services/paperless-ngx/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 7807
   health: /accounts/login/
   type: docker
+  gpu_backends: [all]
   compose_file: compose.yaml
   category: optional
   depends_on: []

--- a/resources/dev/extensions-library/services/weaviate/manifest.yaml
+++ b/resources/dev/extensions-library/services/weaviate/manifest.yaml
@@ -12,6 +12,7 @@ service:
   external_port_default: 7811
   health: /v1/.well-known/ready
   type: docker
+  gpu_backends: [all]
   compose_file: compose.yaml
   category: optional
   depends_on: []


### PR DESCRIPTION
Adds the missing `gpu_backends` field to 8 services in the extensions library.

All 8 services use `gpu_backends: [all]` — CPU-only tools that work on any backend.

| Service | Value | Description |
|---------|-------|-------------|
| baserow | `[all]` | No-code database tool |
| crewai | `[all]` | Agent framework |
| gitea | `[all]` | Git server |
| label-studio | `[all]` | Data labeling tool |
| milvus | `[all]` | Vector database |
| open-interpreter | `[all]` | Code interpreter |
| paperless-ngx | `[all]` | Document management |
| weaviate | `[all]` | Vector database |

Using `[all]` ensures compatibility with dashboard-api, dream-cli, and dream-doctor across all GPU backends.