### PR TITLE
fix(installer): handle missing PyYAML in resolve-compose-stack.sh

### DIFF
--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -130,7 +130,6 @@ if ext_dir.exists():
         import yaml
         yaml_available = True
     except ImportError:
-        import json as yaml  # fallback if yaml not available
         yaml_available = False
 
     for service_dir in sorted(ext_dir.iterdir()):
@@ -149,8 +148,10 @@ if ext_dir.exists():
             with open(manifest_path) as f:
                 if manifest_path.suffix == ".json":
                     manifest = json.load(f)
-                else:
+                elif yaml_available:
                     manifest = yaml.safe_load(f)
+                else:
+                    continue  # skip YAML manifests when PyYAML unavailable
             if manifest.get("schema_version") != "dream.services.v1":
                 continue
             service = manifest.get("service", {})


### PR DESCRIPTION
## Summary
Fixes a crash in `resolve-compose-stack.sh` when PyYAML is not installed for the active Python version. The script aliased `import json as yaml` then called `yaml.safe_load()` — which doesn't exist on the json module. This blocks installation entirely.

Common on rolling-release distros (Manjaro, Arch) where `python-yaml` is installed for Python 3.14 but `python3` points to 3.13.

**Before:** `AttributeError: module 'json' has no attribute 'safe_load'` → silent install failure
**After:** YAML manifests are skipped gracefully when PyYAML is unavailable. JSON manifests still work.

## Test plan
- [ ] ShellCheck passes
- [ ] Install on a system without PyYAML — extensions with YAML manifests are skipped, install completes
- [ ] Install on a system with PyYAML — all manifests loaded normally (no behavior change)
- [ ] Extensions with JSON manifests work regardless of PyYAML availability

🤖 Generated with [Claude Code](https://claude.com/claude-code)