### PR TITLE
docs: restructure resources README — elevate agent blueprint, add reading order

### DIFF
--- a/resources/README.md
+++ b/resources/README.md
@@ -2,7 +2,7 @@
 
 Production-tested tools, frameworks, research, and recipes from building a local AI stack. Everything here was built by the Light Heart Labs team (4 AI agents + humans) while developing DreamServer.
 
-**459 files. Zero fluff.**
+**~500 files. Zero fluff.**
 
 ---
 
@@ -11,6 +11,57 @@ Production-tested tools, frameworks, research, and recipes from building a local
 ### [`multi-agent/`](multi-agent/) — How We Ran a Self-Organizing AI Team
 
 **Start here if you're interested in multi-agent systems.** Complete documentation of the OpenClaw Collective — 4 AI agents that self-organized on consumer GPUs, producing 3,464 commits in 8 days with 10 human commits. Covers architecture, six transferable patterns (deterministic supervision, workspace-as-brain, mission governance, session lifecycle, memory stratification, self-healing infrastructure), the governance files loaded into every agent session, operational lessons from 24/7 production, swarm playbooks with reliability math, and design decisions with full rationale. Framework-agnostic — the patterns apply to any multi-agent setup.
+
+---
+
+### Agent Systems Blueprint — 32 Documents, 14,384 Lines
+
+**A complete, vendor-neutral blueprint for building a production agentic coding tool from scratch.** Extracted as open-source best practices from exhaustive analysis of production agentic systems. Zero proprietary code. Zero vendor-specific terms. Every pattern described in original writing.
+
+> **Start here:** [`AGENT-ARCHITECTURE-OVERVIEW.md`](research/AGENT-ARCHITECTURE-OVERVIEW.md) — the master map with dependency graphs, error boundaries, and end-to-end walkthroughs.
+>
+> **For local AI:** [`AGENT-LOCAL-LLM-ADAPTATION.md`](research/AGENT-LOCAL-LLM-ADAPTATION.md) — bridges all cloud patterns to DreamServer's local stack (llama-server, LiteLLM, GPU VRAM budgeting, tool calling tiers).
+
+#### Reading Order by Layer
+
+Build from the bottom up. Each layer depends on layers below it.
+
+| Layer | # | Document | What It Covers |
+|-------|---|----------|---------------|
+| **1. Security** | 1 | [`AGENT-SECURITY-COMMAND-EXECUTION.md`](research/AGENT-SECURITY-COMMAND-EXECUTION.md) | Multi-layer shell injection prevention, AST parsing, path validation |
+| | 2 | [`AGENT-SECURITY-NETWORK-AND-INJECTION.md`](research/AGENT-SECURITY-NETWORK-AND-INJECTION.md) | SSRF protection, DNS rebinding, Unicode injection defense |
+| **2. Architecture** | 3 | [`AGENT-PERMISSION-SYSTEM-DESIGN.md`](research/AGENT-PERMISSION-SYSTEM-DESIGN.md) | Declarative rule-based permissions, modes, denial tracking |
+| | 4 | [`AGENT-TOOL-ARCHITECTURE.md`](research/AGENT-TOOL-ARCHITECTURE.md) | Unified tool interface, MCP protocol, plugins, skills system |
+| | 5 | [`AGENT-COORDINATION-PATTERNS.md`](research/AGENT-COORDINATION-PATTERNS.md) | Coordinator/worker orchestration, teammates, parallelism |
+| | 6 | [`AGENT-ERROR-HANDLING-AND-HOOKS.md`](research/AGENT-ERROR-HANDLING-AND-HOOKS.md) | Error classification, event-driven hooks, HTTP hook security |
+| **3. Core** | 7 | [`AGENT-SYSTEM-PROMPT-ENGINEERING.md`](research/AGENT-SYSTEM-PROMPT-ENGINEERING.md) | Section-based prompts, caching, injection defense, versioning |
+| | 8 | [`AGENT-CONTEXT-AND-CONVERSATION.md`](research/AGENT-CONTEXT-AND-CONVERSATION.md) | Token budgeting, history management, compaction triggers |
+| | 9 | [`AGENT-LLM-API-INTEGRATION.md`](research/AGENT-LLM-API-INTEGRATION.md) | Streaming, retry, model selection, rate limits, cost tracking |
+| | 10 | [`AGENT-BOOTSTRAP-AND-CONFIGURATION.md`](research/AGENT-BOOTSTRAP-AND-CONFIGURATION.md) | Startup sequence, multi-source config, enterprise polling, migrations |
+| | 11 | [`AGENT-AUTH-AND-SESSION-MANAGEMENT.md`](research/AGENT-AUTH-AND-SESSION-MANAGEMENT.md) | OAuth/PKCE, token refresh, keychain, session persistence, crash recovery |
+| | 12 | [`AGENT-SPECULATION-AND-CACHING.md`](research/AGENT-SPECULATION-AND-CACHING.md) | Optimistic execution, file state overlays, stale-while-refresh |
+| **4. Rendering** | 13 | [`AGENT-TERMINAL-UI-ARCHITECTURE.md`](research/AGENT-TERMINAL-UI-ARCHITECTURE.md) | React reconciler for terminals, double buffering, keyboard, mouse |
+| | 14 | [`AGENT-DIFF-AND-FILE-EDITING.md`](research/AGENT-DIFF-AND-FILE-EDITING.md) | Patch generation, encoding, notebooks, change attribution |
+| | 15 | [`AGENT-IDE-AND-LSP-INTEGRATION.md`](research/AGENT-IDE-AND-LSP-INTEGRATION.md) | Language Server Protocol, passive diagnostics, crash recovery |
+| **5. Operations** | 16 | [`AGENT-WORKTREE-AND-ISOLATION.md`](research/AGENT-WORKTREE-AND-ISOLATION.md) | Git worktrees for parallel agents, symlinks, sparse checkout |
+| | 17 | [`AGENT-FEATURE-DELIVERY.md`](research/AGENT-FEATURE-DELIVERY.md) | Auto-update, kill switch, subscription tiers, contributor safety |
+| **6. Product** | 18 | [`AGENT-MEMORY-AND-CONSOLIDATION.md`](research/AGENT-MEMORY-AND-CONSOLIDATION.md) | Persistent memory, 4 types, auto-dream consolidation, team sync |
+| | 19 | [`AGENT-CONTEXT-COMPACTION-ADVANCED.md`](research/AGENT-CONTEXT-COMPACTION-ADVANCED.md) | Microcompact, session compact, full compact, reactive recovery |
+| | 20 | [`AGENT-TASK-AND-BACKGROUND-EXECUTION.md`](research/AGENT-TASK-AND-BACKGROUND-EXECUTION.md) | Forked agent pattern, 7 task types, cache-safe params |
+| | 21 | [`AGENT-REMOTE-AND-TEAM-COLLABORATION.md`](research/AGENT-REMOTE-AND-TEAM-COLLABORATION.md) | WebSocket sessions, permission routing, teammates, teleportation |
+| | 22 | [`AGENT-ENTERPRISE-AND-POLICY.md`](research/AGENT-ENTERPRISE-AND-POLICY.md) | Managed settings, policy limits, fail-open/closed, settings sync |
+| | 23 | [`AGENT-MESSAGE-PIPELINE.md`](research/AGENT-MESSAGE-PIPELINE.md) | Message types, command queue, priority scheduling, collapsing |
+| | 24 | [`AGENT-MEDIA-AND-ATTACHMENTS.md`](research/AGENT-MEDIA-AND-ATTACHMENTS.md) | Images, PDFs, clipboard, notebooks, ANSI rendering |
+| | 25 | [`AGENT-LIFECYCLE-AND-PROCESS.md`](research/AGENT-LIFECYCLE-AND-PROCESS.md) | Graceful shutdown, cleanup, crash recovery, concurrent sessions |
+| **7. Engine** | 26 | [`AGENT-QUERY-LOOP-AND-STATE-MACHINE.md`](research/AGENT-QUERY-LOOP-AND-STATE-MACHINE.md) | The main loop — 11 recovery transitions, 9 terminal conditions |
+| | 27 | [`AGENT-STREAMING-TOOL-EXECUTION.md`](research/AGENT-STREAMING-TOOL-EXECUTION.md) | Concurrent tool execution, batching, size management |
+| | 28 | [`AGENT-SDK-BRIDGE.md`](research/AGENT-SDK-BRIDGE.md) | Message translation, NDJSON protocol, permission routing |
+| | 29 | [`AGENT-INITIALIZATION-AND-WIRING.md`](research/AGENT-INITIALIZATION-AND-WIRING.md) | 6-stage bootstrap, preflight, fast mode, prefetch ordering |
+| **Meta** | 30 | [`AGENT-ARCHITECTURE-OVERVIEW.md`](research/AGENT-ARCHITECTURE-OVERVIEW.md) | **Master map** — dependency graph, error boundaries, walkthroughs |
+| | 31 | [`AGENT-BUILD-AND-DEPENDENCIES.md`](research/AGENT-BUILD-AND-DEPENDENCIES.md) | Technology stack, project structure, packaging, test pyramid |
+| **Mission** | 32 | [`AGENT-LOCAL-LLM-ADAPTATION.md`](research/AGENT-LOCAL-LLM-ADAPTATION.md) | **DreamServer bridge** — GPU budgeting, tool calling tiers, small models |
+
+---
 
 ### [`products/`](products/) — Deployable Tools (97 files)
 
@@ -30,9 +81,9 @@ Ready-to-run software you can drop into your stack today.
 |-----------|------------------|
 | [`voice-agent/`](frameworks/voice-agent/) | **Complete multi-agent voice system** built on LiveKit. 8 specialist agents with shared state, intent-based routing, TTS filtering, transcript capture. Built for HVAC customer service but domain-agnostic. Includes 9 research docs on handoff architecture and 15 LiveKit SDK guides. |
 
-### [`research/`](research/) — 88 Deep Dives
+### [`research/`](research/) — 56 Deep Dives
 
-Technical analysis from real deployments, not theory.
+Technical analysis from real deployments, not theory. *(The 32 agent architecture documents listed above are also in this directory but are covered in their own section.)*
 
 **Hardware & Capacity** — GPU buying guide, VRAM multi-service limits, consumer GPU benchmarks, single-GPU full-stack configs, Mac Mini and Raspberry Pi 5 guides, cluster benchmarks.
 
@@ -41,8 +92,6 @@ Technical analysis from real deployments, not theory.
 **Voice & Agents** — Voice latency optimization (<2s round-trip), scaling architecture, agent swarm patterns and operational playbook, LiveKit self-hosting deep dive, deterministic vs LLM call handling.
 
 **Security & Privacy** — Ship-readiness audit (217 findings, 42 critical), security audit methodology, PII detection library comparison, privacy strategies analysis.
-
-**Agent Systems** — 12 deep dives forming a complete blueprint for building production-grade agentic AI systems. **Security:** Command execution (multi-layer validation, AST parsing, injection prevention), network protection (SSRF guards, DNS rebinding, Unicode injection defense). **Architecture:** Permission system design (declarative rules, modes, denial tracking), tool architecture (unified interfaces, MCP integration, plugin loading), multi-agent coordination (coordinator/worker patterns, parallelism, state isolation), error handling with hook frameworks (error classification, async hooks, HTTP hook security). **Core Infrastructure:** System prompt engineering (section-based architecture, caching, injection defense, versioning), context and conversation management (token budgeting, history truncation, compaction), LLM API integration (streaming, retry, model selection, rate limits, cost tracking), bootstrap and configuration (startup sequencing, multi-source config merging, enterprise policy, feature flags, migrations), authentication and session management (OAuth/PKCE, token refresh, keychain integration, crash recovery, team sync), and speculation and caching (optimistic execution, file state overlays, stale-while-refresh, cache storm prevention). **32 documents total forming a complete, reproducible blueprint** for building a production agentic coding tool from scratch. Covers every subsystem: security (command execution, SSRF, injection), architecture (permissions, tools, coordination, errors/hooks), core infrastructure (system prompts, context management, LLM API, bootstrap/config, auth/sessions, speculation/caching), rendering and editing (terminal UI, diff/patch, LSP/IDE), operations (worktrees, feature delivery), and the full product layer (persistent memory with auto-dream consolidation and team sync, advanced multi-stage context compaction, background task execution with forked agent pattern, remote sessions and teammate collaboration, enterprise policy enforcement with fail-open/fail-closed patterns, the complete message pipeline, multimodal media handling, graceful process lifecycle management), and the execution engine itself (the async generator query loop with 11 recovery transitions and 9 terminal conditions, streaming tool execution with concurrency partitioning and sibling abort cascade, the SDK bridge layer for message translation and cross-process permission routing, and the complete initialization wiring from parallel prefetch to query loop activation). Vendor-neutral best practices derived from exhaustive analysis of production agentic systems — every stone turned, every pattern captured, every subsystem documented. Crowned by a master architecture overview mapping all 30 systems with dependency graphs, error boundaries, and complete end-to-end walkthroughs, a full build and dependencies guide with technology stack, project structure, and packaging strategy, and a capstone local LLM adaptation guide bridging all cloud-native patterns to DreamServer's local AI stack — covering API compatibility layers, GPU VRAM budgeting, small context window strategies, tool calling reliability tiers with prompt-based fallbacks, system prompt tuning for 7B-70B models, and direct DreamServer integration.
 
 **Architecture & Market** — Edge AI market trends, competitive landscape, unsolved local AI problems, model hot-swapping, Windows-specific challenges.
 
@@ -93,6 +142,8 @@ Old compose files, systemd units, and configs from earlier DreamServer iteration
 
 ## Quick Start
 
+**Building an agentic coding tool?** → Start with [`AGENT-ARCHITECTURE-OVERVIEW.md`](research/AGENT-ARCHITECTURE-OVERVIEW.md), then follow the layer-by-layer reading order above. For local LLM deployment, finish with [`AGENT-LOCAL-LLM-ADAPTATION.md`](research/AGENT-LOCAL-LLM-ADAPTATION.md).
+
 **Want to strip PII from your API calls?** → [`products/privacy-shield/`](products/privacy-shield/)
 
 **Building a voice agent?** → [`frameworks/voice-agent/`](frameworks/voice-agent/) + [`cookbooks/07-grace-voice-agent.md`](cookbooks/07-grace-voice-agent.md)
@@ -114,5 +165,6 @@ This content was extracted from three Light Heart Labs repositories:
 - **[GLO](https://github.com/Light-Heart-Labs/GLO)** — Multi-voice agent framework (→ `frameworks/voice-agent/`)
 - **[Android Labs](https://github.com/Light-Heart-Labs/Android-Labs)** — AI agent collective workspace (→ `multi-agent/`, `products/`, `research/`, `cookbooks/`, `tools/`, `blog/`)
 - **DreamServer development** — Infrastructure and operational tools (→ `docs/`, `legacy/`)
+- **Production agentic systems analysis** — Vendor-neutral architecture extraction (→ 32 `AGENT-*.md` documents)
 
 All content was produced by local AI agents running on consumer GPU hardware as part of DreamServer development.


### PR DESCRIPTION
## Summary

- Elevates the 32 agent architecture documents from a buried paragraph into a **first-class section** with a layered reading order table
- Adds clear entry points: **start with** Architecture Overview, **finish with** Local LLM Adaptation
- Separates the agent blueprint (32 coherent docs) from general research (56 independent papers)
- Updates file count from 459 to ~500
- Adds agent blueprint to Quick Start navigation
- Adds production agentic systems analysis to Origin section

## Before

The 32 agent docs were described in a single unreadable paragraph inside the "88 Deep Dives" research section. No reading order, no entry point, no way to understand the layered architecture.

## After

The agent blueprint gets its own section with:
- 2-sentence description of what it is
- Clear "Start here" and "For local AI" entry points
- Full 7-layer reading order table showing all 32 documents with descriptions
- Proper separation from the 56 independent research papers

## Test plan

- [ ] All 32 AGENT doc links resolve correctly
- [ ] Research section accurately describes the remaining 56 docs
- [ ] Quick Start includes agent blueprint navigation
- [ ] Reading order matches the architectural layer system from AGENT-ARCHITECTURE-OVERVIEW.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)