### PR TITLE
fix: bind APE uvicorn to 0.0.0.0 and decouple internal port from APE_PORT

### DIFF
--- a/dream-server/extensions/services/ape/Dockerfile
+++ b/dream-server/extensions/services/ape/Dockerfile
@@ -12,7 +12,7 @@ RUN adduser --system --no-create-home ape
 EXPOSE 7890
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
-    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:7890/health')" || exit 1
+    CMD python3 -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:7890/health')" || exit 1
 
 USER ape
 

--- a/dream-server/extensions/services/ape/compose.yaml
+++ b/dream-server/extensions/services/ape/compose.yaml
@@ -8,7 +8,6 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - APE_PORT=${APE_PORT:-7890}
       - APE_POLICY_FILE=/config/policy.yaml
       - APE_AUDIT_LOG=/data/ape/audit.jsonl
       - APE_RATE_LIMIT_RPM=${APE_RATE_LIMIT_RPM:-60}
@@ -28,7 +27,7 @@ services:
           cpus: '0.1'
           memory: 64M
     healthcheck:
-      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:7890/health')"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:7890/health')"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/dream-server/extensions/services/ape/main.py
+++ b/dream-server/extensions/services/ape/main.py
@@ -377,4 +377,4 @@ async def metrics(api_key: str = Depends(verify_api_key)):
 if __name__ == "__main__":
     import uvicorn
     port = int(os.environ.get("APE_PORT", "7890"))
-    uvicorn.run(app, host="127.0.0.1", port=port)
+    uvicorn.run(app, host="0.0.0.0", port=port)


### PR DESCRIPTION
## What
Fix APE service being completely unreachable from Docker networking and breaking when APE_PORT is customized.

## Why
uvicorn was binding to `127.0.0.1` (container loopback) — unreachable from Docker port forwarding and inter-container traffic. Additionally, `APE_PORT` was passed into the container environment, causing the app to listen on a different port than the hardcoded compose mapping when customized.

## How
- Changed uvicorn host from `127.0.0.1` to `0.0.0.0` in `main.py`
- Removed `APE_PORT` from container environment (internal port always 7890)
- Fixed healthchecks to use `127.0.0.1` instead of `localhost` (IPv6 safety)

## Testing
- Python syntax: PASS
- YAML syntax: PASS
- Manual: verify `curl http://127.0.0.1:7890/health` returns 200

## Review
Critique Guardian: APPROVED (all four pillars clean)

## Platform Impact
All platforms (container-internal changes only)