### PR TITLE
fix: define missing log_warn, log_error, and cmd_repair in dream-cli

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -27,6 +27,8 @@ log() { echo -e "${CYAN}[dream]${NC} $1"; }
 success() { echo -e "${GREEN}✓${NC} $1"; }
 warn() { echo -e "${YELLOW}⚠${NC} $1"; }
 error() { echo -e "${RED}✗${NC} $1"; exit 1; }
+log_warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+log_error() { echo -e "${RED}✗${NC} $1" >&2; }
 
 # Update or add a key=value in .env
 _env_set() {
@@ -2514,6 +2516,11 @@ cmd_gpu() {
     esac
 }
 
+cmd_repair() {
+    warn "The 'repair' command is not yet implemented."
+    log "Run 'dream doctor' to diagnose issues, then check the output for suggested fixes."
+}
+
 cmd_help() {
     sr_load
     cat << EOF
@@ -2549,6 +2556,7 @@ ${CYAN}Commands:${NC}
   chat "<message>"    Quick chat with the LLM
   benchmark           Run a quick performance test
   doctor [report]     Run diagnostics and write JSON report
+  repair|fix          Run basic repairs (currently redirects to doctor)
   audit [extensions]  Audit extension manifests and compose contracts
   help                Show this help
 


### PR DESCRIPTION
## What
Fix `dream update`, `dream rollback`, and `dream repair`/`dream fix` commands crashing due to undefined functions.

## Why
`cmd_update` calls `log_warn`/`log_error` and `cmd_rollback` calls `log_warn`, but neither function was defined in dream-cli. The dispatch table routes `repair|fix` to `cmd_repair` which also doesn't exist. With `set -e`, these crash the CLI immediately.

## How
- Added `log_warn()` and `log_error()` definitions matching sister script convention
- `log_error` writes to stderr and does NOT exit (preserving multi-line error output before explicit exit)
- Added `cmd_repair()` stub redirecting users to `dream doctor`
- Added help text entry for `repair|fix`

## Testing
- `bash -n`: PASS
- `shellcheck -S warning`: zero new warnings (all pre-existing)
- All callsites verified covered by definitions

## Review
Critique Guardian: APPROVED (all four pillars clean)

## Platform Impact
All platforms