### PR TITLE
fix: replace deprecated n8n basic auth vars with v2.x admin setup

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -13,7 +13,7 @@
 WEBUI_SECRET=CHANGEME
 
 # n8n workflow automation credentials
-N8N_USER=admin
+N8N_USER=admin@dreamserver.local
 N8N_PASS=CHANGEME
 
 # LiteLLM API gateway key (generate: echo "sk-dream-$(openssl rand -hex 16)")
@@ -139,7 +139,7 @@ LANGFUSE_ENABLED=false
 # TIMEZONE=UTC
 
 # n8n settings
-# N8N_AUTH=true                # Enable n8n basic auth
+# N8N_AUTH=true                # Deprecated: n8n v2.x has built-in user management
 # N8N_HOST=localhost           # n8n hostname
 # N8N_WEBHOOK_URL=http://localhost:5678  # n8n webhook URL (for external access)
 

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -64,7 +64,7 @@
     },
     "N8N_USER": {
       "type": "string",
-      "description": "n8n admin username"
+      "description": "n8n initial admin email address"
     },
     "N8N_PASS": {
       "type": "string",
@@ -249,7 +249,7 @@
     },
     "N8N_AUTH": {
       "type": "boolean",
-      "description": "Enable n8n basic auth",
+      "description": "Deprecated: n8n v2.x has built-in user management. This variable is ignored.",
       "default": true
     },
     "N8N_HOST": {

--- a/dream-server/extensions/services/n8n/README.md
+++ b/dream-server/extensions/services/n8n/README.md
@@ -22,10 +22,10 @@ Environment variables (set in `.env`):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `N8N_USER` | `admin` | Admin username (required) |
+| `N8N_USER` | `admin@dreamserver.local` | Admin email address (required) |
 | `N8N_PASS` | *(required)* | Admin password — set before first start |
 | `N8N_PORT` | `5678` | External port (maps to internal 5678) |
-| `N8N_AUTH` | `true` | Enable basic authentication |
+| `N8N_AUTH` | `true` | Deprecated: n8n v2.x has built-in user management |
 | `N8N_HOST` | `localhost` | Hostname used in generated URLs |
 | `N8N_WEBHOOK_URL` | `http://localhost:5678` | Public webhook base URL (set to your LAN IP for external access) |
 | `TIMEZONE` | `UTC` | Timezone for scheduled workflows |

--- a/dream-server/extensions/services/n8n/compose.yaml
+++ b/dream-server/extensions/services/n8n/compose.yaml
@@ -7,9 +7,8 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - N8N_BASIC_AUTH_ACTIVE=${N8N_AUTH:-true}
-      - N8N_BASIC_AUTH_USER=${N8N_USER:?N8N_USER must be set in .env}
-      - N8N_BASIC_AUTH_PASSWORD=${N8N_PASS:?N8N_PASS must be set in .env}
+      - N8N_DEFAULT_ADMIN_EMAIL=${N8N_USER:?N8N_USER must be set in .env}
+      - N8N_DEFAULT_ADMIN_PASSWORD=${N8N_PASS:?N8N_PASS must be set in .env}
       - N8N_HOST=${N8N_HOST:-localhost}
       - N8N_PORT=5678
       - N8N_PROTOCOL=http

--- a/dream-server/extensions/services/n8n/manifest.yaml
+++ b/dream-server/extensions/services/n8n/manifest.yaml
@@ -24,7 +24,7 @@ service:
   env_vars:
     - key: N8N_USER
       required: true
-      description: n8n admin username
+      description: n8n initial admin email address
     - key: N8N_PASS
       required: true
       secret: true

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -182,7 +182,7 @@ LANGFUSE_PORT=3006
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=${webui_secret}
 DASHBOARD_API_KEY=${dashboard_api_key}
-N8N_USER=admin
+N8N_USER=admin@dreamserver.local
 N8N_PASS=${n8n_pass}
 LITELLM_KEY=${litellm_key}
 LIVEKIT_API_KEY=${livekit_api_key}
@@ -204,7 +204,6 @@ ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
 
 #=== n8n Settings ===
-N8N_AUTH=true
 N8N_HOST=localhost
 N8N_WEBHOOK_URL=http://localhost:5678
 TIMEZONE=${tz}

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -381,7 +381,7 @@ LANGFUSE_PORT=${LANGFUSE_PORT}
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=${WEBUI_SECRET}
 DASHBOARD_API_KEY=${DASHBOARD_API_KEY}
-N8N_USER=admin
+N8N_USER=admin@dreamserver.local
 N8N_PASS=${N8N_PASS}
 LITELLM_KEY=${LITELLM_KEY}
 LIVEKIT_API_KEY=$(_env_get LIVEKIT_API_KEY "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
@@ -401,7 +401,6 @@ ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
 
 #=== n8n Settings ===
-N8N_AUTH=true
 N8N_HOST=localhost
 N8N_WEBHOOK_URL=http://localhost:5678
 TIMEZONE=${SYSTEM_TZ:-UTC}

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -234,7 +234,7 @@ SEARXNG_PORT=8888
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=$webuiSecret
 DASHBOARD_API_KEY=$dashboardApiKey
-N8N_USER=admin
+N8N_USER=admin@dreamserver.local
 N8N_PASS=$n8nPass
 LITELLM_KEY=$litellmKey
 LIVEKIT_API_KEY=$livekitApiKey
@@ -254,7 +254,6 @@ ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
 
 #=== n8n Settings ===
-N8N_AUTH=true
 N8N_HOST=localhost
 N8N_WEBHOOK_URL=http://localhost:5678
 TIMEZONE=$tz


### PR DESCRIPTION
## What
Replace deprecated `N8N_BASIC_AUTH_*` env vars (removed in n8n v0.229.0) with the v2.x equivalents for initial admin account setup.

## Why
DreamServer uses n8n v2.6.4 which silently ignores `N8N_BASIC_AUTH_ACTIVE`, `N8N_BASIC_AUTH_USER`, and `N8N_BASIC_AUTH_PASSWORD`. Users believe auth is configured when it isn't — n8n presents an open setup wizard on first access.

## How
- Replaced deprecated compose vars with `N8N_DEFAULT_ADMIN_EMAIL` and `N8N_DEFAULT_ADMIN_PASSWORD`
- Changed installer default from `N8N_USER=admin` to `N8N_USER=admin@dreamserver.local` (email required by v2.x)
- Marked `N8N_AUTH` as deprecated in schema (kept for backwards compat with existing `.env` files)
- Updated README and manifest descriptions

## Testing
- JSON schema: PASS
- YAML syntax: PASS
- `docker compose config`: PASS

## Review
Critique Guardian: APPROVED WITH WARNINGS (README + manifest updates applied)

## Known Considerations
- Existing installs with `N8N_USER=admin` in `.env`: only matters if n8n DB is wiped (`N8N_DEFAULT_ADMIN_*` only applies on first startup with empty DB)
- `N8N_AUTH` kept in schema as deprecated to avoid breaking `validate-env.sh` on existing installations

## Platform Impact
All platforms (Linux, macOS, Windows installers updated)