### PR TITLE
fix: fail-closed on missing WEBUI_SECRET and add open-webui memory limits

### DIFF
--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -23,11 +23,15 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Validate main docker-compose.base.yml
+        env:
+          WEBUI_SECRET: ci-placeholder
         run: |
           echo "Validating dream-server/docker-compose.base.yml"
           docker compose -f dream-server/docker-compose.base.yml config --quiet
 
       - name: Validate compose files in dream-server/compose/
+        env:
+          WEBUI_SECRET: ci-placeholder
         run: |
           compose_files=$(find dream-server/compose/ -name '*.yml' -type f 2>/dev/null || true)
 

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -75,7 +75,7 @@ services:
       OPENAI_API_BASE_URL: "${LLM_API_URL:-http://llama-server:8080}/v1"
       OPENAI_API_KEY: ""
       WEBUI_AUTH: "${WEBUI_AUTH:-true}"
-      WEBUI_SECRET_KEY: "${WEBUI_SECRET:-changeme}"
+      WEBUI_SECRET_KEY: "${WEBUI_SECRET:?WEBUI_SECRET must be set — run the installer or add it to .env}"
       ENABLE_WEB_SEARCH: "true"
       WEB_SEARCH_ENGINE: "searxng"
       SEARXNG_QUERY_URL: "http://searxng:8080/search?q=<query>&format=json"
@@ -120,6 +120,14 @@ services:
       - ./data/open-webui:/app/backend/data
     ports:
       - "127.0.0.1:${WEBUI_PORT:-3000}:8080"
+    deploy:
+      resources:
+        limits:
+          cpus: '2.0'
+          memory: 4G
+        reservations:
+          cpus: '0.25'
+          memory: 512M
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s


### PR DESCRIPTION
## What
Eliminate hardcoded `changeme` fallback for JWT signing key and add missing memory limits to open-webui.

## Why
`WEBUI_SECRET_KEY` defaulted to `changeme` if `.env` was missing — a publicly known value enabling JWT forgery. open-webui was the only major service without `deploy.resources` limits, risking host OOM under heavy load.

## How
- Changed `${WEBUI_SECRET:-changeme}` to `${WEBUI_SECRET:?error message}` so the container fails loudly instead of starting insecure
- Added `deploy.resources` block: 4G memory limit, 512M reservation, matching the pattern of other user-facing services

## Testing
- YAML syntax: PASS
- `docker compose config`: PASS (all overlays)
- Missing `WEBUI_SECRET` correctly aborts with clear error message

## Review
Critique Guardian: APPROVED (all four pillars clean)

## Platform Impact
All platforms