### PR TITLE
fix: guard nvidia-smi fields against [N/A] values in gpu.py

### DIFF
--- a/dream-server/extensions/services/dashboard-api/gpu.py
+++ b/dream-server/extensions/services/dashboard-api/gpu.py
@@ -148,12 +148,20 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
                     power_w = round(float(parts[5]), 1)
                 except (ValueError, TypeError):
                     pass
+            # Guard against [N/A] / [Not Supported] — skip row if memory is unavailable
+            na_values = ("[N/A]", "[Not Supported]", "N/A", "Not Supported", "")
+            if parts[1] in na_values or parts[2] in na_values:
+                continue
+            mem_used = int(parts[1])
+            mem_total = int(parts[2])
+            util = int(parts[3]) if parts[3] not in na_values else 0
+            temp = int(parts[4]) if parts[4] not in na_values else 0
             gpus.append({
                 "name": parts[0],
-                "mem_used": int(parts[1]),
-                "mem_total": int(parts[2]),
-                "util": int(parts[3]),
-                "temp": int(parts[4]),
+                "mem_used": mem_used,
+                "mem_total": mem_total,
+                "util": util,
+                "temp": temp,
                 "power_w": power_w,
             })
 


### PR DESCRIPTION
## Summary
- nvidia-smi returns `[N/A]` or `[Not Supported]` for memory, utilization, and temperature fields on MIG/vGPU/TCC configurations
- The `power_w` field already had this guard, but the other four fields did not, causing `ValueError` that silently discarded all GPU data via the outer `except (ValueError, IndexError)`
- Skip the GPU row if memory fields are N/A (metrics are meaningless without memory data); default utilization and temperature to 0 when N/A

## Test plan
- [ ] Verify normal single-GPU system still reports correctly (regression check)
- [ ] Verify multi-GPU aggregation still works when all fields are valid
- [ ] Verify GPU row with N/A memory is skipped (MIG/vGPU config)
- [ ] Verify GPU row with N/A utilization reports `util=0`
- [ ] Verify multi-GPU where one GPU has N/A memory — only valid GPUs aggregated

🤖 Generated with [Claude Code](https://claude.com/claude-code)