### PR TITLE
fix: kill orphaned curl subprocess on cluster status timeout

### DIFF
--- a/dream-server/extensions/services/dashboard-api/agent_monitor.py
+++ b/dream-server/extensions/services/dashboard-api/agent_monitor.py
@@ -52,7 +52,7 @@ class ClusterStatus:
         logger.debug("Refreshing cluster status from proxy")
         try:
             proc = await asyncio.create_subprocess_exec(
-                "curl", "-s", f"http://localhost:{os.environ.get('CLUSTER_PROXY_PORT', '9199')}/status",
+                "curl", "-s", "--max-time", "4", f"http://localhost:{os.environ.get('CLUSTER_PROXY_PORT', '9199')}/status",
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE
             )
@@ -69,6 +69,8 @@ class ClusterStatus:
         except FileNotFoundError:
             logger.debug("Cluster proxy not available: curl command not found")
         except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
             logger.debug("Cluster proxy health check timed out after 5s")
         except OSError as e:
             logger.debug("Cluster proxy connection failed: %s", e)

--- a/dream-server/extensions/services/dashboard-api/tests/test_agent_monitor.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_agent_monitor.py
@@ -254,12 +254,17 @@ class TestClusterStatusRefresh:
         async def _fake_subprocess(*args, **kwargs):
             proc = MagicMock()
             proc.communicate = AsyncMock(side_effect=_asyncio.TimeoutError())
+            proc.kill = MagicMock()
+            proc.wait = AsyncMock()
+            _fake_subprocess.proc = proc
             return proc
 
         with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
             await cs.refresh()
 
         assert cs.total_gpus == 0
+        _fake_subprocess.proc.kill.assert_called_once()
+        _fake_subprocess.proc.wait.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_refresh_os_error(self):


### PR DESCRIPTION
## Summary
- `asyncio.wait_for` cancels the Python coroutine on timeout but does not kill the underlying curl process
- On systems without cluster proxy (most single-GPU installs), orphaned curl processes accumulated every 5 seconds
- Add `proc.kill()` + `await proc.wait()` in the `TimeoutError` handler and `--max-time 4` to curl as defense-in-depth
- Update `test_refresh_timeout` mock to support the new cleanup calls and assert they execute

## Test plan
- [ ] Run existing `test_agent_monitor.py` test suite — all tests pass
- [ ] Verify `test_refresh_timeout` asserts `kill()` and `wait()` are called
- [ ] On a system without cluster proxy, confirm no orphaned curl processes after 2+ minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)