### PR TITLE
fix: skip disabled extension manifests in dashboard config

### DIFF
--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -69,6 +69,12 @@ def load_extension_manifests(
 
     for path in manifest_files:
         try:
+            # Skip disabled extensions (compose.yaml.disabled convention)
+            ext_dir = path.parent
+            if (ext_dir / "compose.yaml.disabled").exists() or (ext_dir / "compose.yml.disabled").exists():
+                logger.debug("Skipping disabled extension: %s", ext_dir.name)
+                continue
+
             manifest = _read_manifest_file(path)
             if manifest.get("schema_version") != "dream.services.v1":
                 logger.warning("Skipping manifest with unsupported schema_version: %s", path)


### PR DESCRIPTION
## Summary
- `load_extension_manifests()` loaded every `manifest.yaml` found, ignoring the `compose.yaml.disabled` convention used by `resolve-compose-stack.sh`
- Disabled extensions like langfuse appeared as perpetually unhealthy services in the dashboard
- Check for `compose.yaml.disabled` or `compose.yml.disabled` in the extension directory before loading the manifest, matching the resolver's skip logic

## Test plan
- [ ] Verify langfuse (disabled by default) no longer appears in dashboard services
- [ ] Verify enabled extensions still load correctly
- [ ] Verify extensions without `compose.yaml.disabled` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)