### PR TITLE
fix: add tiered auth to Privacy Shield /health and /stats endpoints

### DIFF
--- a/dream-server/extensions/services/privacy-shield/proxy.py
+++ b/dream-server/extensions/services/privacy-shield/proxy.py
@@ -9,6 +9,7 @@ import time
 import httpx
 import secrets
 import hashlib
+from typing import Optional
 from fastapi import FastAPI, Request, Response, Depends, HTTPException, Security
 from fastapi.responses import JSONResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -92,31 +93,39 @@ def get_session(request: Request) -> CachedPrivacyShield:
 
 
 @app.get("/health")
-async def health():
-    """Health check endpoint."""
-    return {
+async def health(credentials: Optional[HTTPAuthorizationCredentials] = Security(security_scheme, auto_error=False)):
+    """Health check endpoint. Sensitive fields require authentication."""
+    base = {
         "status": "ok",
         "service": "api-privacy-shield",
         "version": "0.2.0",
-        "target_api": TARGET_API_BASE,
-        "cache_enabled": CACHE_ENABLED,
-        "active_sessions": len(sessions)
     }
+    if credentials and secrets.compare_digest(credentials.credentials, SHIELD_API_KEY):
+        base.update({
+            "target_api": TARGET_API_BASE,
+            "cache_enabled": CACHE_ENABLED,
+            "active_sessions": len(sessions),
+        })
+    return base
 
 
 @app.get("/stats")
-async def stats():
-    """Session statistics."""
-    total_pii = sum(
-        s.detector.get_stats()['unique_pii_count']
-        for s in sessions.values()
-    )
-    return {
-        "active_sessions": len(sessions),
-        "total_pii_scrubbed": total_pii,
+async def stats(credentials: Optional[HTTPAuthorizationCredentials] = Security(security_scheme, auto_error=False)):
+    """Session statistics. Sensitive metrics require authentication."""
+    base = {
         "cache_enabled": CACHE_ENABLED,
-        "cache_size": CACHE_SIZE
+        "cache_size": CACHE_SIZE,
     }
+    if credentials and secrets.compare_digest(credentials.credentials, SHIELD_API_KEY):
+        total_pii = sum(
+            s.detector.get_stats()['unique_pii_count']
+            for s in sessions.values()
+        )
+        base.update({
+            "active_sessions": len(sessions),
+            "total_pii_scrubbed": total_pii,
+        })
+    return base
 
 
 @app.post("/{path:path}", dependencies=[Depends(verify_api_key)])


### PR DESCRIPTION
## Summary
- `/health` and `/stats` had no authentication while catch-all proxy routes did
- `/health` leaked the target LLM API URL and session count; `/stats` leaked PII scrubbing volume metrics
- Both endpoints now use tiered responses: unauthenticated callers get non-sensitive base fields only (preserving Docker healthcheck and dashboard-api compatibility), authenticated callers get full operational details
- Uses `Security(security_scheme, auto_error=False)` with `secrets.compare_digest` for timing-safe optional auth

## Test plan
- [ ] `curl http://localhost:8085/health` returns only `{status, service, version}` — no `target_api`
- [ ] `curl -H "Authorization: Bearer $KEY" http://localhost:8085/health` returns all fields
- [ ] `curl http://localhost:8085/stats` returns only `{cache_enabled, cache_size}` — no PII counts
- [ ] `curl -H "Authorization: Bearer $KEY" http://localhost:8085/stats` returns all fields
- [ ] Docker healthcheck still passes (200 OK without auth)
- [ ] Dashboard privacy stats page still loads (dashboard-api calls /stats without auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)