### PR TITLE
fix: skip gpu overlay if base compose_file is missing in resolve-compose-stack.sh

### DIFF
--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -168,6 +168,9 @@ if ext_dir.exists():
                     resolved.append(str(compose_path.relative_to(script_dir)))
                 elif (service_dir / f"{compose_rel}.disabled").exists():
                     continue  # Service disabled — skip all overlays
+                else:
+                    print(f"WARNING: {service_dir.name}: compose_file '{compose_rel}' not found, skipping overlays", file=sys.stderr)
+                    continue  # Base compose missing — skip GPU/mode overlays
             # GPU-specific overlay (filesystem discovery — not in manifest)
             gpu_overlay = service_dir / f"compose.{gpu_backend}.yaml"
             if gpu_overlay.exists():


### PR DESCRIPTION
## Problem
`resolve-compose-stack.sh` included GPU overlays (nvidia.yaml, amd.yaml) even when the manifest declared a `compose_file` that doesn't exist on disk, causing silent Docker Compose merge failures.

## Solution
Added an `else` branch to check for missing base `compose_file`. If missing and no `.disabled` variant exists, the script now prints a WARNING to stderr and skips all overlays (GPU, mode, multi-GPU) for that service.

## Testing
Tested with shellcheck, verified normal operation (no change when files exist), and confirmed the bug scenario works correctly (WARNING printed, overlays skipped).