### PR TITLE
fix: add pipe to sed escape character class in phase 06 _sed_escape function

### DIFF
--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -124,7 +124,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
 
         # Replace model and provider placeholders to match what the inference backend actually serves
         # Escape sed special chars in variable values to prevent injection
-        _sed_escape() { printf '%s\n' "$1" | sed 's/[&/\]/\\&/g'; }
+        _sed_escape() { printf '%s\n' "$1" | sed 's/[&/\|]/\\&/g'; }
         _oc_model_esc=$(_sed_escape "$OPENCLAW_MODEL")
         _oc_prov_esc=$(_sed_escape "$OPENCLAW_PROVIDER_NAME")
         _sed_i "s|__LLM_MODEL__|${_oc_model_esc}|g" "$INSTALL_DIR/config/openclaw/openclaw.json"


### PR DESCRIPTION
## Problem
The `_sed_escape` helper in phase 06 did not escape the pipe (|) character, which is used as the sed delimiter by all four callers. Paths or values containing pipes would cause sed substitution to fail silently.

## Solution
Added `|` to the escape character class in `_sed_escape`: `[&/\]` → `[&/\|]`. This ensures pipes in variable values are properly escaped before being used in sed replacements.

## Testing
Verified with shellcheck, tested with pipe-containing values, and regression-tested that existing escapes (`&`, `/`, `\`) still work correctly. Cross-platform compatible (POSIX sed on both BSD and GNU).