### PR TITLE
fix: change opencode manifest requirements.services_all to requirements.services

### DIFF
--- a/dream-server/extensions/services/opencode/manifest.yaml
+++ b/dream-server/extensions/services/opencode/manifest.yaml
@@ -23,7 +23,7 @@ features:
     icon: Code
     category: development
     requirements:
-      services_all: [opencode]
+      services: [opencode]
       vram_gb: 8
     enabled_services_all: [opencode]
     setup_time: Ready


### PR DESCRIPTION
## Problem
The opencode manifest used a non-standard field `requirements.services_all` instead of `requirements.services`. The feature gating code only recognizes `services`, so opencode's service requirement was silently ignored.

## Solution
Changed the field name to `requirements.services` per the extension manifest spec. This field is now correctly read by feature gating to mark the coding feature as requiring the opencode service.

## Testing
Verified the manifest YAML parses correctly and matches the schema spec. Manual test: hit `GET /api/features` with opencode running and not running to confirm the coding feature shows the correct `status` value.