### PR TITLE
fix(extensions-portal): inline refresh indicator and persist restart-required toast

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -61,13 +61,14 @@ export default function Extensions() {
   const [confirm, setConfirm] = useState(null)
   const [toast, setToast] = useState(null)
   const [consoleExt, setConsoleExt] = useState(null)
+  const [refreshing, setRefreshing] = useState(false)
 
   useEffect(() => {
     fetchCatalog()
   }, [])
 
   useEffect(() => {
-    if (toast) {
+    if (toast && toast.type !== 'info') {
       const t = setTimeout(() => setToast(null), 5000)
       return () => clearTimeout(t)
     }
@@ -75,7 +76,8 @@ export default function Extensions() {
 
   const fetchCatalog = async () => {
     try {
-      setLoading(true)
+      if (!catalog) setLoading(true)
+      setRefreshing(true)
       setError(null)
       const res = await fetchJson(`/api/extensions/catalog`)
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
@@ -85,6 +87,7 @@ export default function Extensions() {
       console.error('Extensions fetch error:', err)
     } finally {
       setLoading(false)
+      setRefreshing(false)
     }
   }
 
@@ -128,7 +131,7 @@ export default function Extensions() {
     setConfirm({ action, ext, message: messages[action] })
   }
 
-  if (loading) {
+  if (loading && !catalog) {
     return (
       <div className="p-8 flex items-center justify-center h-64">
         <Loader2 className="animate-spin text-indigo-500" size={32} />
@@ -178,9 +181,10 @@ export default function Extensions() {
           )}
           <button
             onClick={fetchCatalog}
-            className="text-sm text-indigo-300 hover:text-indigo-200 flex items-center gap-1.5 transition-colors"
+            disabled={refreshing}
+            className="text-sm text-indigo-300 hover:text-indigo-200 flex items-center gap-1.5 transition-colors disabled:opacity-50"
           >
-            <RefreshCw size={14} />
+            <RefreshCw size={14} className={refreshing ? 'animate-spin' : ''} />
             Refresh
           </button>
         </div>


### PR DESCRIPTION
## What
Replace full-page spinner on catalog refresh with an inline spinning icon. Make restart-required toasts persist until manually dismissed.

## Why
Two UX timing bugs in the Extensions portal:
1. Clicking Refresh replaced the entire page with a centered spinner, losing visual context (filters, scroll position, card layout) — even though catalog data was already loaded
2. The "restart required" info toast (which contains the `dream restart` CLI command users need to run) auto-dismissed after 5 seconds — too fast to act on

## How
- Added `refreshing` state separate from `loading`
- `fetchCatalog` only sets `loading=true` when `catalog === null` (initial load); otherwise sets `refreshing=true`
- Loading early-return guard changed from `if (loading)` → `if (loading && !catalog)` so the page stays visible during refresh
- Refresh button shows spinning RefreshCw icon and disables during fetch via `refreshing`
- Toast auto-dismiss effect now exempts `type === 'info'` toasts — they persist until the user clicks ×

## Scope
All changes within `dream-server/extensions/services/dashboard/src/pages/Extensions.jsx` — `Extensions()` component only.

## Testing
- Initial load: full-page spinner still appears (catalog is null)
- Refresh with data: page stays visible, RefreshCw spins, button disables
- Error on refresh: error banner appears over existing page content
- `restart_required` action: info toast stays until manually closed
- Success/error toasts: still auto-dismiss after 5s

## Review
Critique Guardian: **APPROVED** — clean pass all four pillars, no regressions.