### PR TITLE
fix(extensions-portal): smart auto-scroll and disconnect recovery in console modal

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -607,9 +607,71 @@ function ConsoleModal({ ext, onClose }) {
   const [logs, setLogs] = useState('')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
+  const [disconnected, setDisconnected] = useState(false)
+  const [atBottom, setAtBottom] = useState(true)
   const logRef = useRef(null)
+  const isNearBottom = useRef(true)
 
-  const fetchLogs = async () => {
+  useEffect(() => {
+    let active = true
+    let fails = 0
+
+    const poll = async () => {
+      if (!active) return
+      try {
+        const res = await fetch(`${API_BASE}/api/extensions/${ext.id}/logs`, {
+          method: 'POST',
+          signal: AbortSignal.timeout(8000),
+        })
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}))
+          throw new Error(err.detail || 'Failed to fetch logs')
+        }
+        const data = await res.json()
+        setLogs(data.logs || 'No logs available.')
+        setError(null)
+        setDisconnected(false)
+        fails = 0
+      } catch (err) {
+        fails++
+        setError(err.message)
+        if (fails >= 3) setDisconnected(true)
+      } finally {
+        setLoading(false)
+      }
+      if (active) {
+        const delay = fails > 0 ? Math.min(2000 * Math.pow(2, fails - 1), 30000) : 2000
+        setTimeout(poll, delay)
+      }
+    }
+    poll()
+    return () => { active = false }
+  }, [ext.id])
+
+  useEffect(() => {
+    if (logRef.current && isNearBottom.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight
+    }
+  }, [logs])
+
+  const handleScroll = () => {
+    if (logRef.current) {
+      const { scrollTop, scrollHeight, clientHeight } = logRef.current
+      const near = scrollHeight - scrollTop - clientHeight < 50
+      isNearBottom.current = near
+      setAtBottom(near)
+    }
+  }
+
+  const scrollToBottom = () => {
+    if (logRef.current) {
+      logRef.current.scrollTop = logRef.current.scrollHeight
+      isNearBottom.current = true
+      setAtBottom(true)
+    }
+  }
+
+  const fetchLogsOnce = async () => {
     try {
       const res = await fetch(`/api/extensions/${ext.id}/logs`, {
         method: 'POST',
@@ -622,24 +684,11 @@ function ConsoleModal({ ext, onClose }) {
       const data = await res.json()
       setLogs(data.logs || 'No logs available.')
       setError(null)
+      setDisconnected(false)
     } catch (err) {
       setError(err.message)
-    } finally {
-      setLoading(false)
     }
   }
-
-  useEffect(() => {
-    fetchLogs()
-    const interval = setInterval(fetchLogs, 2000)
-    return () => clearInterval(interval)
-  }, [ext.id])
-
-  useEffect(() => {
-    if (logRef.current) {
-      logRef.current.scrollTop = logRef.current.scrollHeight
-    }
-  }, [logs])
 
   return (
     <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50" onClick={onClose}>
@@ -649,32 +698,57 @@ function ConsoleModal({ ext, onClose }) {
       >
         <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
           <div className="flex items-center gap-2">
-            <Terminal size={16} className="text-green-400" />
+            <Terminal size={16} className={disconnected ? 'text-red-400' : 'text-green-400'} />
             <span className="text-sm font-medium text-white">{ext.name}</span>
             <span className="text-xs text-zinc-600">logs</span>
-            <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" title="Live" />
+            {disconnected ? (
+              <span className="w-1.5 h-1.5 rounded-full bg-red-500" title="Disconnected" />
+            ) : (
+              <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" title="Live" />
+            )}
           </div>
           <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300 transition-colors p-1">
             <X size={16} />
           </button>
         </div>
-        <div
-          ref={el => { logRef.current = el }}
-          className="flex-1 overflow-y-auto p-4 font-mono text-xs leading-relaxed text-zinc-300 whitespace-pre-wrap break-all"
-        >
-          {loading && !logs ? (
-            <div className="flex items-center gap-2 text-zinc-500">
-              <Loader2 size={14} className="animate-spin" /> Loading logs...
-            </div>
-          ) : error && !logs ? (
-            <div className="text-red-400">{error}</div>
-          ) : (
-            logs
+        <div className="relative flex-1">
+          <div
+            ref={el => { logRef.current = el }}
+            onScroll={handleScroll}
+            className="absolute inset-0 overflow-y-auto p-4 font-mono text-xs leading-relaxed text-zinc-300 whitespace-pre-wrap break-all"
+          >
+            {loading && !logs ? (
+              <div className="flex items-center gap-2 text-zinc-500">
+                <Loader2 size={14} className="animate-spin" /> Loading logs...
+              </div>
+            ) : (
+              <>
+                {logs}
+                {error && logs && (
+                  <div className="mt-2 text-red-400 border-t border-red-500/20 pt-2">
+                    {disconnected ? 'Connection lost' : 'Fetch error'}: {error}
+                  </div>
+                )}
+              </>
+            )}
+            {error && !logs && (
+              <div className="text-red-400">{error}</div>
+            )}
+          </div>
+          {!atBottom && (
+            <button
+              onClick={scrollToBottom}
+              className="absolute bottom-2 right-4 bg-zinc-800 border border-zinc-700 text-zinc-400 hover:text-white rounded-full px-3 py-1 text-xs shadow-lg transition-colors"
+            >
+              ↓ Jump to bottom
+            </button>
           )}
         </div>
         <div className="border-t border-zinc-800 px-4 py-2 flex items-center justify-between">
-          <span className="text-[10px] text-zinc-600">Auto-refreshing every 2s</span>
-          <button onClick={fetchLogs} className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors">
+          <span className={`text-[10px] ${disconnected ? 'text-red-400' : 'text-zinc-600'}`}>
+            {disconnected ? 'Reconnecting...' : 'Auto-refreshing every 2s'}
+          </span>
+          <button onClick={fetchLogsOnce} className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors" title="Refresh now">
             <RefreshCw size={12} />
           </button>
         </div>


### PR DESCRIPTION
## What
Fix two UX bugs in the Extensions portal log viewer (ConsoleModal): force-scrolling while reading, and no recovery when the host agent disconnects.

## Why
1. Every 2 seconds when new logs arrived, the modal force-scrolled to the bottom — impossible to read earlier log lines (the primary reason to open logs is to diagnose problems, which requires reading backwards)
2. If the host agent went down, the `setInterval` kept firing failed requests every 2 seconds indefinitely with no backoff, and the UI kept showing a green "Live" pulse dot while displaying stale data

## How
**Auto-scroll**: Track user scroll position with `isNearBottom` ref (avoids re-renders). Only auto-scroll when within 50px of the bottom. Show a floating "↓ Jump to bottom" button (driven by `atBottom` state) when user has scrolled up.

**Disconnect recovery**: Replace `setInterval(fetchLogs, 2000)` with a recursive `setTimeout` chain inside the effect. Track consecutive failures with a local `fails` counter. Exponential backoff: `Math.min(2000 * 2^(fails-1), 30000)`. After 3 failures → `disconnected=true` → terminal icon turns red, live dot goes static red, footer shows "Reconnecting...". Auto-recovers when polling succeeds again.

**Error display**: Show fetch errors inline even when previous logs exist (error appends below logs with red border separator).

**Cleanup**: `active` flag prevents state updates after component unmount.

**Manual refresh**: Footer RefreshCw button calls standalone `fetchLogsOnce` (separate from polling loop) — matches original semantics.

## Scope
All changes within `dream-server/extensions/services/dashboard/src/pages/Extensions.jsx` — `ConsoleModal` function only.

## Testing
- Open console for running extension: auto-scrolls to bottom on new logs
- Scroll up: auto-scroll stops, "Jump to bottom" button appears
- Click "Jump to bottom": scrolls down, button disappears
- Stop host agent: after ~6s (3×2s failures), indicators turn red, "Reconnecting..." shown
- Restart host agent: indicators return to green automatically
- Footer RefreshCw: triggers immediate one-shot fetch
- Close modal quickly: no console errors about unmounted state updates

## Review
Critique Guardian: **APPROVED** (v2, after fixing RefreshCw button semantics)