### PR TITLE
fix(extensions-portal): add tooltip explanations to core and incompatible badges

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -259,6 +259,7 @@ export default function Extensions() {
             <ExtensionCard
               key={ext.id}
               ext={ext}
+              gpuBackend={catalog?.gpu_backend}
               onDetails={() => setExpanded(ext.id)}
               onConsole={() => setConsoleExt(ext)}
               onAction={requestAction}
@@ -270,7 +271,7 @@ export default function Extensions() {
 
       {/* Detail modal */}
       {expanded && (
-        <DetailModal ext={extensions.find(e => e.id === expanded)} onClose={() => setExpanded(null)} />
+        <DetailModal ext={extensions.find(e => e.id === expanded)} gpuBackend={catalog?.gpu_backend} onClose={() => setExpanded(null)} />
       )}
 
       {/* Console modal */}
@@ -329,7 +330,7 @@ function SummaryItem({ label, value, color }) {
   )
 }
 
-function ExtensionCard({ ext, onDetails, onConsole, onAction, mutating }) {
+function ExtensionCard({ ext, gpuBackend, onDetails, onConsole, onAction, mutating }) {
   const iconName = ext.features?.[0]?.icon
   const Icon = (iconName && ICON_MAP[iconName]) || Package
   const status = ext.status || 'not_installed'
@@ -371,11 +372,17 @@ function ExtensionCard({ ext, onDetails, onConsole, onAction, mutating }) {
           </div>
           <div className="flex items-center gap-2">
             {isCore ? (
-              <span className="text-[10px] px-2 py-0.5 rounded-full bg-blue-500/10 text-blue-400 border border-blue-500/15 uppercase tracking-wider">
+              <span
+                className="text-[10px] px-2 py-0.5 rounded-full bg-blue-500/10 text-blue-400 border border-blue-500/15 uppercase tracking-wider cursor-help"
+                title="Built-in service — managed by DreamServer"
+              >
                 core
               </span>
             ) : (
-              <span className={`text-[10px] px-2 py-0.5 rounded-full uppercase tracking-wider ${statusStyle}`}>
+              <span
+                className={`text-[10px] px-2 py-0.5 rounded-full uppercase tracking-wider ${statusStyle} ${status === 'incompatible' ? 'cursor-help' : ''}`}
+                title={status === 'incompatible' ? `Requires ${ext.gpu_backends?.join(' or ') || 'specific GPU'} — your system: ${gpuBackend || 'unknown'}` : undefined}
+              >
                 {status.replace('_', ' ')}
               </span>
             )}
@@ -423,7 +430,8 @@ function ExtensionCard({ ext, onDetails, onConsole, onAction, mutating }) {
             </button>
           )}
           {!showInstall && !showRemove && !isToggleable && (
-            <div className="flex gap-1">
+            <div className="flex items-center gap-1" title={status === 'incompatible' && gpuBackend ? `Your system: ${gpuBackend}` : undefined}>
+              {status === 'incompatible' && <span className="text-[10px] text-zinc-600 mr-0.5">Requires:</span>}
               {ext.gpu_backends?.slice(0, 3).map(gpu => (
                 <span key={gpu} className="text-[10px] px-1.5 py-0.5 rounded bg-zinc-800/80 text-zinc-600">{gpu}</span>
               ))}
@@ -465,7 +473,7 @@ function ExtensionCard({ ext, onDetails, onConsole, onAction, mutating }) {
   )
 }
 
-function DetailModal({ ext, onClose }) {
+function DetailModal({ ext, gpuBackend, onClose }) {
   if (!ext) return null
 
   const iconName = ext.features?.[0]?.icon
@@ -474,6 +482,7 @@ function DetailModal({ ext, onClose }) {
   const deps = ext.depends_on || []
   const features = ext.features || []
   const statusStyle = STATUS_STYLES[ext.status] || STATUS_STYLES.not_installed
+  const isIncompatible = ext.status === 'incompatible'
 
   return (
     <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50" onClick={onClose}>
@@ -487,7 +496,10 @@ function DetailModal({ ext, onClose }) {
             <Icon size={22} className="text-zinc-400" />
             <div>
               <h3 className="text-lg font-semibold text-white">{ext.name}</h3>
-              <span className={`text-xs px-2 py-0.5 rounded-full ${statusStyle}`}>
+              <span
+                className={`text-xs px-2 py-0.5 rounded-full ${statusStyle}`}
+                title={isIncompatible ? `Requires ${ext.gpu_backends?.join(' or ') || 'specific GPU'} — your system: ${gpuBackend || 'unknown'}` : ext.source === 'core' ? 'Built-in service — managed by DreamServer' : undefined}
+              >
                 {(ext.status || 'not_installed').replace('_', ' ')}
               </span>
             </div>
@@ -510,6 +522,9 @@ function DetailModal({ ext, onClose }) {
             <div className="bg-zinc-800/50 rounded-lg p-3">
               <span className="text-zinc-500 text-xs block mb-1">GPU</span>
               <span className="text-white">{ext.gpu_backends?.join(', ') || 'none'}</span>
+              {isIncompatible && gpuBackend && (
+                <span className="text-orange-400 text-[10px] block mt-1">Your system: {gpuBackend}</span>
+              )}
             </div>
             <div className="bg-zinc-800/50 rounded-lg p-3">
               <span className="text-zinc-500 text-xs block mb-1">Category</span>


### PR DESCRIPTION
## What
Add contextual explanations to "incompatible" and "core" status badges in the Extensions portal so users understand what they mean and why.

## Why
Users — especially non-technical ones — see orange "incompatible" and blue "core" badges with no explanation:
- "Incompatible" gives no indication of WHY (e.g., requires NVIDIA GPU on an Apple Silicon Mac)
- "Core" doesn't explain what it means or why the extension can't be installed/removed through the portal
- The detail modal shows GPU backends as a list ("nvidia, amd") but doesn't compare to the user's system

## How
- Thread `catalog.gpu_backend` (the user's system GPU type) down to `ExtensionCard` and `DetailModal` via a new `gpuBackend` prop
- **Core badge**: add `title="Built-in service — managed by DreamServer"` + `cursor-help`
- **Incompatible badge**: add `title="Requires {gpu_backends} — your system: {gpuBackend}"` + `cursor-help`
- **Card footer GPU chips**: prefix with "Requires:" label for incompatible extensions; container div gets title showing user's system
- **Detail modal GPU cell**: add orange `"Your system: {gpuBackend}"` subtitle when incompatible
- **Detail modal header badge**: same tooltip treatment as card badge

## Scope
All changes within `dream-server/extensions/services/dashboard/src/pages/Extensions.jsx` — `Extensions()` prop threading, `ExtensionCard`, and `DetailModal` components.

## Testing
- Incompatible extension card: hover orange badge → tooltip shows GPU requirement vs user's system
- Core extension card: hover blue badge → tooltip shows "Built-in service — managed by DreamServer"
- Incompatible card footer: "Requires:" label appears before GPU chips
- Detail modal incompatible: GPU cell shows orange "Your system: apple" subtitle
- Detail modal core: header badge has tooltip
- Compatible/enabled/disabled extensions: no tooltip regression
- Missing `gpu_backend` in response: tooltips show "unknown" gracefully

## Review
Critique Guardian: **APPROVED** — badge changes clean on all four pillars.