### PR TITLE
fix(extensions-portal): increase install timeout and nginx proxy_read_timeout

### DIFF
--- a/dream-server/extensions/services/dashboard/nginx.conf
+++ b/dream-server/extensions/services/dashboard/nginx.conf
@@ -27,6 +27,7 @@ server {
         proxy_set_header Connection "close";
         # B1 fix: Auth header injected by entrypoint.sh after reading key from file/env
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
+        proxy_read_timeout 180s;
     }
 
     # Cache static assets

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -100,7 +100,7 @@ export default function Extensions() {
         : `/api/extensions/${serviceId}/${action}`
       const res = await fetch(url, {
         method: action === 'uninstall' ? 'DELETE' : 'POST',
-        signal: AbortSignal.timeout(15000),
+        signal: AbortSignal.timeout(120000),
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))


### PR DESCRIPTION
## What
Increase the frontend mutation timeout from 15 s to 120 s and add a descriptive "Installing…" hint during extension installs. Also raises the nginx `proxy_read_timeout` from the 60 s default to 180 s so the reverse proxy never cuts the connection before the frontend does.

## Why
The frontend `AbortSignal.timeout(15000)` fired before the backend could complete a Docker image pull. The install would succeed in the background but users saw a false "Failed to install" error. The nginx default of 60 s created a secondary bottleneck in production that the frontend timeout fix alone would not have resolved.

## How
- `Extensions.jsx`: `AbortSignal.timeout(15000)` → `AbortSignal.timeout(120000)`
- `Extensions.jsx`: added `mutatingAction` state; Install button shows "Installing…" while in flight
- `nginx.conf`: added `proxy_read_timeout 180s` to the `/api/` location block

## Scope
All changes are within `dream-server/extensions/services/dashboard/`.

## Testing
- Install an extension with an uncached Docker image (e.g. AnythingLLM) — verify no false error at 15 s, "Installing…" label appears
- Enable/disable an extension — verify spinner only (no "Installing…" label)
- Test in the containerised dashboard (not just `vite dev`) to exercise the nginx timeout

## Review
Critique Guardian: APPROVED (after nginx companion fix added)