### PR TITLE
fix(extensions-portal): add keyboard accessibility and aria roles to modals

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -74,6 +74,13 @@ export default function Extensions() {
     }
   }, [toast])
 
+  useEffect(() => {
+    if (!confirm) return
+    const handler = (e) => { if (e.key === 'Escape') setConfirm(null) }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [confirm])
+
   const fetchCatalog = async () => {
     try {
       if (!catalog) setLoading(true)
@@ -285,14 +292,14 @@ export default function Extensions() {
 
       {/* Confirmation dialog */}
       {confirm && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
-          <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-6 max-w-md mx-4">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setConfirm(null)}>
+          <div className="bg-zinc-900 border border-zinc-700 rounded-xl p-6 max-w-md mx-4" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Confirm action">
             <h3 className="text-lg font-semibold text-white mb-2">
               {confirm.action === 'uninstall' ? 'Remove' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)} Extension
             </h3>
             <p className="text-sm text-zinc-400 mb-4">{confirm.message}</p>
             <div className="flex justify-end gap-3">
-              <button onClick={() => setConfirm(null)} className="px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors">Cancel</button>
+              <button onClick={() => setConfirm(null)} autoFocus className="px-4 py-2 text-sm text-zinc-400 hover:text-white transition-colors">Cancel</button>
               <button
                 onClick={() => handleMutation(confirm.ext.id, confirm.action)}
                 className={`px-4 py-2 text-sm rounded-lg transition-colors ${
@@ -478,6 +485,13 @@ function ExtensionCard({ ext, gpuBackend, onDetails, onConsole, onAction, mutati
 }
 
 function DetailModal({ ext, gpuBackend, onClose }) {
+  useEffect(() => {
+    if (!ext) return
+    const handler = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [ext, onClose])
+
   if (!ext) return null
 
   const iconName = ext.features?.[0]?.icon
@@ -493,6 +507,7 @@ function DetailModal({ ext, gpuBackend, onClose }) {
       <div
         className="bg-zinc-900 border border-zinc-700 rounded-xl w-full max-w-lg max-h-[80vh] overflow-y-auto mx-4"
         onClick={e => e.stopPropagation()}
+        role="dialog" aria-modal="true" aria-label={ext.name}
       >
         {/* Header */}
         <div className="sticky top-0 bg-zinc-900 border-b border-zinc-800 p-4 flex items-center justify-between rounded-t-xl">
@@ -508,7 +523,7 @@ function DetailModal({ ext, gpuBackend, onClose }) {
               </span>
             </div>
           </div>
-          <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300 transition-colors p-1">
+          <button onClick={onClose} autoFocus className="text-zinc-500 hover:text-zinc-300 transition-colors p-1">
             <X size={18} />
           </button>
         </div>
@@ -632,6 +647,12 @@ function ConsoleModal({ ext, onClose }) {
   const isNearBottom = useRef(true)
 
   useEffect(() => {
+    const handler = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  useEffect(() => {
     let active = true
     let fails = 0
 
@@ -714,6 +735,7 @@ function ConsoleModal({ ext, onClose }) {
       <div
         className="bg-[#0d0d11] border border-zinc-700 rounded-xl w-full max-w-3xl h-[70vh] flex flex-col mx-4"
         onClick={e => e.stopPropagation()}
+        role="dialog" aria-modal="true" aria-label={`${ext.name} logs`}
       >
         <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-800">
           <div className="flex items-center gap-2">
@@ -726,7 +748,7 @@ function ConsoleModal({ ext, onClose }) {
               <span className="w-1.5 h-1.5 rounded-full bg-green-500 animate-pulse" title="Live" />
             )}
           </div>
-          <button onClick={onClose} className="text-zinc-500 hover:text-zinc-300 transition-colors p-1">
+          <button onClick={onClose} autoFocus className="text-zinc-500 hover:text-zinc-300 transition-colors p-1">
             <X size={16} />
           </button>
         </div>


### PR DESCRIPTION
## What
Add Escape-key-to-close, `role="dialog"`, `aria-modal="true"`, `aria-label`, and `autoFocus` to all three modal/dialog components in the Extensions page.

## Why
Pressing Escape did not close any modal. Tab focus could escape to elements behind the overlay. Screen readers received no semantic indication that a dialog was open. This constitutes a WCAG 2.1 Level A violation (2.1.1 Keyboard, 2.1.2 No Keyboard Trap).

## How
All three modals (DetailModal, ConsoleModal, confirmation dialog) now have:
- `useEffect` keydown listener for Escape with cleanup on unmount
- `role="dialog" aria-modal="true"` on the inner content div
- `aria-label` for screen reader identification
- `autoFocus` on the primary close/cancel button so focus lands inside the dialog on open
- Confirmation dialog backdrop now closes on click (was missing `onClick` handler)
- `useEffect` moved before `if (!ext) return null` in DetailModal to comply with React Rules of Hooks

## Scope
All changes are within `dream-server/extensions/services/dashboard/src/pages/Extensions.jsx`.

## Testing
- Open Detail modal → press Escape → verifies it closes
- Open Console modal → press Escape → verifies it closes
- Open confirmation dialog → press Escape → verifies it closes
- Open confirmation dialog → click backdrop → verifies it closes
- Open Detail/Console modal → verify focus lands on X close button automatically
- VoiceOver/screen reader: verify each modal announces as "dialog" with its label
- Open DetailModal with a catalog entry → trigger catalog refresh while modal is open → verify no React hooks crash

## Review
Critique Guardian: APPROVED (after 3 rounds of required fixes: aria-label, autoFocus, hooks ordering)