### PR TITLE
feat(windows): compose failure diagnostics and reliable exit codes

### DIFF
--- a/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
+++ b/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
@@ -16,6 +16,28 @@
 
 ---
 
+## Docker Compose failed (during install or `dream.ps1`)
+
+If **`install-windows.ps1`** stops with **docker compose up failed**, or **`.\dream.ps1`** reports a compose error on **start / stop / restart / update**, the installer and CLI print a **COMPOSE FAILURE DIAGNOSTICS** block. Please save that entire block when asking for help (Discord, GitHub, etc.).
+
+What the diagnostics include (in order):
+
+1. **`docker version`** — confirms the Docker client can talk to the engine.
+2. **`docker info`** (first lines) — daemon state, WSL2, disk, etc.
+3. **`docker compose … config`** (last lines of output) — merged compose after variable substitution (uses `.env` when present). If there is a YAML merge or syntax error, it often appears here.
+4. **`docker compose … ps -a`** — which containers exist and their state.
+
+**Things to check on your machine before re-running:**
+
+- Docker Desktop is **running** (whale icon in the tray) and **WSL 2** is enabled for the engine (Settings → General).
+- No other app is blocking the same **ports** as in `.env` (e.g. another stack using 3000, 8080, 11434).
+- Enough **disk space** for images and volumes.
+- If you edited compose files or added overrides, temporarily remove **`docker-compose.override.yml`** and try again.
+
+For GPU and WSL2-specific steps, see **WINDOWS-WSL2-GPU-GUIDE.md** in the same `docs` folder.
+
+---
+
 ## Before You Start
 
 ### What You Need

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -36,6 +36,7 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "constants.ps1")
 . (Join-Path $LibDir "ui.ps1")
+. (Join-Path $LibDir "compose-diagnostics.ps1")
 . (Join-Path $LibDir "detection.ps1")
 
 # ── Resolve install directory ──
@@ -410,11 +411,24 @@ function Invoke-Start {
         $flags = Get-ComposeFlags
         if ($Service) {
             Write-AI "Starting $Service..."
-            & docker compose @flags up -d $Service
+            $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+                -ComposeArgs @("up", "-d", $Service)
+            if ($composeExit -ne 0) {
+                Write-AIError "docker compose up failed (exit code: $composeExit)"
+                Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags `
+                    -Phase "dream.ps1 start ($Service)"
+                exit 1
+            }
             Write-AISuccess "$Service started"
         } else {
             Write-AI "Starting all services..."
-            & docker compose @flags up -d
+            $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+                -ComposeArgs @("up", "-d")
+            if ($composeExit -ne 0) {
+                Write-AIError "docker compose up failed (exit code: $composeExit)"
+                Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "dream.ps1 start (all)"
+                exit 1
+            }
             Write-AISuccess "All services started"
         }
     } finally {
@@ -430,11 +444,24 @@ function Invoke-Stop {
         $flags = Get-ComposeFlags
         if ($Service) {
             Write-AI "Stopping $Service..."
-            & docker compose @flags stop $Service
+            $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+                -ComposeArgs @("stop", $Service)
+            if ($composeExit -ne 0) {
+                Write-AIError "docker compose stop failed (exit code: $composeExit)"
+                Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags `
+                    -Phase "dream.ps1 stop ($Service)"
+                exit 1
+            }
             Write-AISuccess "$Service stopped"
         } else {
             Write-AI "Stopping all services..."
-            & docker compose @flags down
+            $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+                -ComposeArgs @("down")
+            if ($composeExit -ne 0) {
+                Write-AIError "docker compose down failed (exit code: $composeExit)"
+                Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "dream.ps1 stop (all)"
+                exit 1
+            }
 
             # Stop native inference server (AMD path)
             if (Test-Path $script:INFERENCE_PID_FILE) {
@@ -456,7 +483,14 @@ function Invoke-Restart {
         $flags = Get-ComposeFlags
         if ($Service) {
             Write-AI "Restarting $Service..."
-            & docker compose @flags restart $Service
+            $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+                -ComposeArgs @("restart", $Service)
+            if ($composeExit -ne 0) {
+                Write-AIError "docker compose restart failed (exit code: $composeExit)"
+                Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags `
+                    -Phase "dream.ps1 restart ($Service)"
+                exit 1
+            }
             Write-AISuccess "$Service restarted"
         } else {
             # For AMD, also restart native inference server
@@ -465,7 +499,13 @@ function Invoke-Restart {
                 Start-NativeInferenceServer
             }
             Write-AI "Restarting all services..."
-            & docker compose @flags restart
+            $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+                -ComposeArgs @("restart")
+            if ($composeExit -ne 0) {
+                Write-AIError "docker compose restart failed (exit code: $composeExit)"
+                Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "dream.ps1 restart (all)"
+                exit 1
+            }
             Write-AISuccess "All services restarted"
         }
     } finally {
@@ -555,9 +595,20 @@ function Invoke-Update {
     try {
         $flags = Get-ComposeFlags
         Write-AI "Pulling latest images..."
-        & docker compose @flags pull
+        $pullExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags -ComposeArgs @("pull")
+        if ($pullExit -ne 0) {
+            Write-AIError "docker compose pull failed (exit code: $pullExit)"
+            Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "dream.ps1 update (pull)"
+            exit 1
+        }
         Write-AI "Recreating containers..."
-        & docker compose @flags up -d --force-recreate
+        $upExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+            -ComposeArgs @("up", "-d", "--force-recreate")
+        if ($upExit -ne 0) {
+            Write-AIError "docker compose up failed (exit code: $upExit)"
+            Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "dream.ps1 update (up --force-recreate)"
+            exit 1
+        }
         Write-AISuccess "Update complete"
 
         Start-Sleep -Seconds 5

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -62,6 +62,7 @@ $SourceRoot = (Resolve-Path (Join-Path (Join-Path $ScriptDir "..") "..")).Path
 $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "constants.ps1")
 . (Join-Path $LibDir "ui.ps1")
+. (Join-Path $LibDir "compose-diagnostics.ps1")
 . (Join-Path $LibDir "tier-map.ps1")
 . (Join-Path $LibDir "detection.ps1")
 . (Join-Path $LibDir "env-generator.ps1")
@@ -534,21 +535,7 @@ if ($dryRun) {
         }
         if ($composeExit -ne 0) {
             Write-AIError "docker compose up failed (exit code: $composeExit)"
-            # The streaming output above may have scrolled past or PS 5.1 may have
-            # swallowed stderr ErrorRecords. Run config validation to surface the
-            # root cause (missing env vars, invalid YAML, etc.) clearly at the end.
-            $ErrorActionPreference = "SilentlyContinue"
-            $_configOutput = & docker compose @composeFlags config 2>&1
-            $_configExit = $LASTEXITCODE
-            $ErrorActionPreference = $prevEAP
-            if ($_configExit -ne 0) {
-                Write-AI "  Configuration error:"
-                $_configOutput | ForEach-Object { Write-AI "    $_" }
-            }
-            Write-AI "  To debug manually:"
-            Write-AI "    cd $installDir"
-            Write-AI "    docker compose $($composeFlags -join ' ') config"
-            Write-AI "    docker compose $($composeFlags -join ' ') up 2>&1"
+            Write-DreamComposeDiagnostics -InstallDir $installDir -ComposeFlags $composeFlags -Phase "install-windows.ps1 docker compose up -d"
             exit 1
         }
         Write-AISuccess "Docker services started"

--- a/dream-server/installers/windows/lib/compose-diagnostics.ps1
+++ b/dream-server/installers/windows/lib/compose-diagnostics.ps1
@@ -1,0 +1,118 @@
+# ============================================================================
+# Dream Server Windows -- Docker Compose diagnostics
+# ============================================================================
+# Part of: installers/windows/lib/
+# Purpose: When docker compose fails, print actionable context (config, docker
+#          state) so installs on diverse hardware produce useful bug reports.
+# Requires: ui.ps1 (Write-AI, Write-AIWarn, Write-Chapter) sourced first.
+# ============================================================================
+
+function Get-DreamComposeEnvFileArgs {
+    param([string]$InstallDir)
+    $envPath = Join-Path $InstallDir ".env"
+    if (Test-Path $envPath) {
+        return @("--env-file", ".env")
+    }
+    return @()
+}
+
+function Invoke-DreamDockerCompose {
+    <#
+    .SYNOPSIS
+        Run docker compose with PS 5.1-safe stderr handling; return exit code.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InstallDir,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$ComposeFlags,
+        [Parameter(Mandatory = $true)]
+        [string[]]$ComposeArgs
+    )
+    Push-Location $InstallDir
+    try {
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'SilentlyContinue'
+        & docker compose @ComposeFlags @ComposeArgs 2>&1 | ForEach-Object { Write-Host "  $_" }
+        $exitCode = $LASTEXITCODE
+        $ErrorActionPreference = $prevEAP
+        return $exitCode
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Write-DreamComposeDiagnostics {
+    <#
+    .SYNOPSIS
+        Print bounded docker/compose diagnostics after a compose command failed.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InstallDir,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$ComposeFlags,
+        [string]$Phase = "install"
+    )
+
+    Write-Chapter "COMPOSE FAILURE DIAGNOSTICS"
+    Write-AI "Phase: $Phase — save this section if you report an issue."
+    Write-AI "Docs: dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md (section: Docker Compose failed)"
+    Write-Host ""
+
+    Push-Location $InstallDir
+    try {
+        $prevEAP = $ErrorActionPreference
+        $ErrorActionPreference = 'SilentlyContinue'
+
+        Write-Host "  --- docker version ---" -ForegroundColor DarkGray
+        $dv = & docker version 2>&1 | ForEach-Object { $_.ToString() }
+        if ($dv) { $dv | Select-Object -First 25 | ForEach-Object { Write-Host "  $_" } }
+        else { Write-Host "  (docker version produced no output)" -ForegroundColor Yellow }
+        Write-Host ""
+
+        Write-Host "  --- docker info (first 35 lines) ---" -ForegroundColor DarkGray
+        $di = & docker info 2>&1 | ForEach-Object { $_.ToString() }
+        if ($di) { $di | Select-Object -First 35 | ForEach-Object { Write-Host "  $_" } }
+        else { Write-Host "  (docker info failed — is Docker Desktop running?)" -ForegroundColor Yellow }
+        Write-Host ""
+
+        $envArgs = Get-DreamComposeEnvFileArgs -InstallDir $InstallDir
+        Write-Host "  --- docker compose ... config (last 55 lines) ---" -ForegroundColor DarkGray
+        $cfgOut = & docker compose @ComposeFlags @envArgs config 2>&1 | ForEach-Object { $_.ToString() }
+        if ($cfgOut) {
+            $cfgLines = @($cfgOut)
+            $take = [Math]::Min(55, $cfgLines.Count)
+            if ($cfgLines.Count -gt 0) {
+                $start = [Math]::Max(0, $cfgLines.Count - $take)
+                for ($i = $start; $i -lt $cfgLines.Count; $i++) {
+                    Write-Host "  $($cfgLines[$i])"
+                }
+            }
+        }
+        else {
+            Write-AIWarn "docker compose config produced no output (merge/parse error likely above)."
+        }
+        Write-Host ""
+
+        Write-Host "  --- docker compose ... ps -a ---" -ForegroundColor DarkGray
+        $psOut = & docker compose @ComposeFlags @envArgs ps -a 2>&1 | ForEach-Object { $_.ToString() }
+        if ($psOut) {
+            $psOut | Select-Object -First 40 | ForEach-Object { Write-Host "  $_" }
+        }
+        else {
+            Write-Host "  (no ps output)" -ForegroundColor DarkGray
+        }
+
+        $ErrorActionPreference = $prevEAP
+    }
+    finally {
+        Pop-Location
+    }
+
+    Write-Host ""
+    Write-AI "Next: confirm Docker Desktop is running, WSL2 backend is on, and ports in .env are free."
+}


### PR DESCRIPTION
### Summary
Improves support for real-world installs by making Windows failures actionable: when `docker compose` fails during install or via `dream.ps1`, users get a bounded **COMPOSE FAILURE DIAGNOSTICS** block (Docker version/info, merged `docker compose … config` with `.env` when present, `ps -a`) instead of only an exit code. Also ensures **`dream.ps1` respects compose exit codes** on start/stop/restart/update (PowerShell 5.1–safe handling of native command stderr/`$LASTEXITCODE`).

### Changes
- Add `dream-server/installers/windows/lib/compose-diagnostics.ps1` (`Invoke-DreamDockerCompose`, `Write-DreamComposeDiagnostics`).
- `install-windows.ps1`: on failed `docker compose up -d`, run diagnostics before exiting.
- `dream.ps1`: check compose exit codes; run diagnostics on failure for start/stop/restart/update.
- `docs/WINDOWS-TROUBLESHOOTING-GUIDE.md`: section describing the diagnostics output and what to verify.
- 
### Testing
- [ ] Install succeeds when compose succeeds (happy path).
- [ ] Induce compose failure: installer prints diagnostics and exits non-zero.
- [ ] `.\dream.ps1 start|stop|restart|update` with compose error: non-zero exit and diagnostics.
### Notes
Aligns with upstream installer compose logging; diagnostics are additive and shared between installer and `dream.ps1`.