### PR TITLE
fix: unified APU name fallback in GPU detection

### DIFF
--- a/dream-server/extensions/services/dashboard-api/gpu.py
+++ b/dream-server/extensions/services/dashboard-api/gpu.py
@@ -95,8 +95,13 @@ def get_gpu_info_amd() -> Optional[GPUInfo]:
             if power_str:
                 power_w = round(int(power_str) / 1e6, 1)
 
-        gpu_name = _read_sysfs(f"{base}/product_name") or "AMD Radeon"
+        gpu_name = _read_sysfs(f"{base}/product_name")
         memory_type = "unified" if is_unified else "discrete"
+        if not gpu_name:
+            if is_unified:
+                gpu_name = get_gpu_tier(mem_total / (1024**3), memory_type)
+            else:
+                gpu_name = "AMD Radeon"
 
         mem_used_mb = mem_used // (1024 * 1024)
         mem_total_mb = mem_total // (1024 * 1024)


### PR DESCRIPTION
## Summary

When `product_name` is None on unified APUs, use `get_gpu_tier()` to derive a meaningful name (e.g. "Strix Halo") instead of defaulting to "AMD Radeon".

Fixes `test_parses_unified_apu` test.

## Changes

- `dream-server/extensions/services/dashboard-api/gpu.py`: 6 lines changed in `_amd_gpus()` function

Split from #691 per review feedback on #683 (concern #6: don't mix application code with CI workflow changes).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)