### PR TITLE
fix(extensions-library): add compatibility blocks to 25 manifests

### DIFF
--- a/resources/dev/extensions-library/services/aider/manifest.yaml
+++ b/resources/dev/extensions-library/services/aider/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: aider
   name: Aider

--- a/resources/dev/extensions-library/services/anythingllm/manifest.yaml
+++ b/resources/dev/extensions-library/services/anythingllm/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: anythingllm
   name: AnythingLLM

--- a/resources/dev/extensions-library/services/audiocraft/manifest.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: audiocraft
   name: AudioCraft

--- a/resources/dev/extensions-library/services/bark/manifest.yaml
+++ b/resources/dev/extensions-library/services/bark/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: bark
   name: Bark TTS

--- a/resources/dev/extensions-library/services/chromadb/manifest.yaml
+++ b/resources/dev/extensions-library/services/chromadb/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: chromadb
   name: ChromaDB

--- a/resources/dev/extensions-library/services/continue/manifest.yaml
+++ b/resources/dev/extensions-library/services/continue/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: continue
   name: Continue (AI Coding Assistant)

--- a/resources/dev/extensions-library/services/dify/manifest.yaml
+++ b/resources/dev/extensions-library/services/dify/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: dify
   name: Dify

--- a/resources/dev/extensions-library/services/flowise/manifest.yaml
+++ b/resources/dev/extensions-library/services/flowise/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: flowise
   name: Flowise

--- a/resources/dev/extensions-library/services/fooocus/manifest.yaml
+++ b/resources/dev/extensions-library/services/fooocus/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: fooocus
   name: Fooocus

--- a/resources/dev/extensions-library/services/forge/manifest.yaml
+++ b/resources/dev/extensions-library/services/forge/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: forge
   name: Forge / A1111

--- a/resources/dev/extensions-library/services/frigate/manifest.yaml
+++ b/resources/dev/extensions-library/services/frigate/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: frigate
   name: Frigate

--- a/resources/dev/extensions-library/services/immich/manifest.yaml
+++ b/resources/dev/extensions-library/services/immich/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: immich
   name: Immich

--- a/resources/dev/extensions-library/services/invokeai/manifest.yaml
+++ b/resources/dev/extensions-library/services/invokeai/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: invokeai
   name: InvokeAI

--- a/resources/dev/extensions-library/services/jan/manifest.yaml
+++ b/resources/dev/extensions-library/services/jan/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: jan
   name: Jan

--- a/resources/dev/extensions-library/services/jupyter/manifest.yaml
+++ b/resources/dev/extensions-library/services/jupyter/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: jupyter
   name: Jupyter

--- a/resources/dev/extensions-library/services/langflow/manifest.yaml
+++ b/resources/dev/extensions-library/services/langflow/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: langflow
   name: Langflow

--- a/resources/dev/extensions-library/services/librechat/manifest.yaml
+++ b/resources/dev/extensions-library/services/librechat/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: librechat
   name: LibreChat

--- a/resources/dev/extensions-library/services/localai/manifest.yaml
+++ b/resources/dev/extensions-library/services/localai/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: localai
   name: LocalAI (OpenAI-compatible API)

--- a/resources/dev/extensions-library/services/ollama/manifest.yaml
+++ b/resources/dev/extensions-library/services/ollama/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: ollama
   name: Ollama

--- a/resources/dev/extensions-library/services/piper-audio/manifest.yaml
+++ b/resources/dev/extensions-library/services/piper-audio/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: piper-audio
   name: Piper TTS

--- a/resources/dev/extensions-library/services/privacy-shield/manifest.yaml
+++ b/resources/dev/extensions-library/services/privacy-shield/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: privacy-shield
   name: Privacy Shield (PII Protection)

--- a/resources/dev/extensions-library/services/rvc/manifest.yaml
+++ b/resources/dev/extensions-library/services/rvc/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: rvc
   name: RVC

--- a/resources/dev/extensions-library/services/sillytavern/manifest.yaml
+++ b/resources/dev/extensions-library/services/sillytavern/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: sillytavern
   name: SillyTavern

--- a/resources/dev/extensions-library/services/text-generation-webui/manifest.yaml
+++ b/resources/dev/extensions-library/services/text-generation-webui/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: text-generation-webui
   name: Text Generation WebUI

--- a/resources/dev/extensions-library/services/xtts/manifest.yaml
+++ b/resources/dev/extensions-library/services/xtts/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: xtts
   name: XTTS (Coqui TTS)


### PR DESCRIPTION
Added `compatibility.dream_min: 2.0.0` to 25 extension manifests that were missing it. Prepares for version gating.

**Services:** aider, anythingllm, audiocraft, bark, chromadb, continue, dify, flowise, fooocus, forge, frigate, immich, invokeai, jan, jupyter, langflow, librechat, localai, ollama, piper-audio, privacy-shield, rvc, sillytavern, text-generation-webui, xtts