### PR TITLE
fix(extensions-library): fix typo in baserow manifest tags

### DIFF
--- a/resources/dev/extensions-library/services/baserow/manifest.yaml
+++ b/resources/dev/extensions-library/services/baserow/manifest.yaml
@@ -23,7 +23,7 @@ service:
     
   tags:
     - database
-    - nocde
+    - nocode
     - airtable
     - spreadsheet
     - collaboration


### PR DESCRIPTION
Fix typo in baserow manifest tags: `nocde` → `nocode`