### PR TITLE
fix(health-check): remove duplicate sr_load call that crashes without registry

### DIFF
--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -41,8 +41,6 @@ LLM_HOST="${LLM_HOST:-localhost}"
 LLM_PORT="${LLM_PORT:-8080}"
 TIMEOUT="${TIMEOUT:-5}"
 
-sr_load
-
 # Safe .env loading for port overrides (no eval; use lib/safe-env.sh)
 [[ -f "$SCRIPT_DIR/lib/safe-env.sh" ]] && . "$SCRIPT_DIR/lib/safe-env.sh"
 load_env_file "${INSTALL_DIR}/.env"


### PR DESCRIPTION
## Problem

`health-check.sh` calls `sr_load` twice:

1. **Line 37** (guarded): inside `if [[ -f "..lib/service-registry.sh" ]]`  correct
2. **Line 44** (bare): no guard  crashes with `sr_load: command not found` under `set -e` if the registry file is absent

This means health checks fail entirely in environments where the service registry is missing (partial installs, standalone runs), which is exactly when you'd want health checks to still work.

## Fix

Remove the redundant unconditional call on line 44. The guarded call on line 37 already handles loading when the registry is available.

## Testing

- Verified `bash -n` passes on modified script
- The duplicate was clearly unintentional (same function, no state change between the two calls)