### PR TITLE
fix: resolve API_BASE ReferenceError and category filter in Extensions page

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -152,7 +152,7 @@ export default function Extensions() {
   // Derive unique categories from features
   const categories = ['all', ...new Set(
     extensions
-      .map(ext => ext.features?.[0]?.category)
+      .flatMap(ext => ext.features?.map(f => f.category) || [])
       .filter(Boolean)
   )]
 
@@ -680,7 +680,7 @@ function ConsoleModal({ ext, onClose }) {
     const poll = async () => {
       if (!active) return
       try {
-        const res = await fetch(`${API_BASE}/api/extensions/${ext.id}/logs`, {
+        const res = await fetch(`/api/extensions/${ext.id}/logs`, {
           method: 'POST',
           signal: AbortSignal.timeout(8000),
         })


### PR DESCRIPTION
## What
- Fix `ReferenceError: API_BASE is not defined` in ConsoleModal log polling
- Fix category filter dropdown missing categories from secondary features

## Why
- `API_BASE` was never declared in Extensions.jsx — the poll() function crashed on every call, preventing auto-refresh of extension logs
- Category derivation only read `features[0].category`, ignoring categories from features[1+]

## How
- Replace `${API_BASE}/api/extensions/...` with relative URL `/api/extensions/...` (matching fetchLogsOnce)
- Replace `.map(ext => ext.features?.[0]?.category)` with `.flatMap(ext => ext.features?.map(f => f.category) || [])`

## Testing
- `npm run build` ✅
- `npm run lint` ✅ (0 errors)

## Platform Impact
All platforms (browser-side fix)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)