### PR TITLE
fix: correct host agent default data directory to match Docker mount path

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -335,7 +335,7 @@ def main():
     GPU_BACKEND = env.get("GPU_BACKEND", "nvidia")
     TIER = env.get("TIER", "1")
 
-    data_dir = Path(env.get("DREAM_DATA_DIR", str(Path.home() / ".dream-server")))
+    data_dir = Path(env.get("DREAM_DATA_DIR", str(INSTALL_DIR / "data")))
     USER_EXTENSIONS_DIR = Path(env.get(
         "DREAM_USER_EXTENSIONS_DIR",
         str(data_dir / "user-extensions"),


### PR DESCRIPTION
## What
Default `DREAM_DATA_DIR` to `INSTALL_DIR/data` instead of `~/.dream-server` in the host agent.

## Why
The host agent reads `.env` directly, but `DREAM_DATA_DIR` is only injected inside Docker containers (not written to `.env`). The agent defaulted to `~/.dream-server/user-extensions/` while the dashboard-api container used `INSTALL_DIR/data/user-extensions/`, causing all extension operations to return 404.

## How
Change the fallback from `Path.home() / ".dream-server"` to `INSTALL_DIR / "data"` — aligning with the Docker volume mount path.

## Testing
- Python syntax validation ✅
- `INSTALL_DIR` is resolved and guard-checked before use (line 323-326)

## Platform Impact
All platforms (host agent Python)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)