### PR TITLE
fix: resolve relative output path in preset export

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1493,6 +1493,11 @@ META
 
             log "Exporting preset '${name}'..."
 
+            # Resolve relative output path before cd changes the working directory
+            if [[ "$output" != /* ]]; then
+                output="$(pwd)/$output"
+            fi
+
             # Create archive (relative to presets dir to avoid absolute paths)
             cd "$PRESETS_DIR"
             if tar czf "$output" "$name" 2>/dev/null; then


### PR DESCRIPTION
## What
Fix `dream preset export` creating archive in wrong directory when given relative path.

## Why
The command does `cd "$PRESETS_DIR"` before `tar czf "$output"`, so relative output paths resolve against PRESETS_DIR instead of the user's working directory.

## How
Resolve relative paths to absolute before the `cd`:
```bash
if [[ "$output" != /* ]]; then
    output="$(pwd)/$output"
fi
```

## Testing
- `bash -n` syntax check passes
- POSIX/BSD compatible (no `realpath`, just `pwd` + string check)
- Manual: `dream preset export mypreset ./backup.tar.gz` now creates file in CWD

## Review
Critique Guardian: APPROVED
- Noted pre-existing identical bug in `dream preset import` — separate issue.

## Platform Impact
- **macOS:** `pwd` is POSIX builtin, works identically
- **Linux:** Same
- **Windows/WSL2:** Same

> **Note:** This PR touches `dream-cli` which is also modified by #734. Rebase needed after #734 merges.

🤖 Generated with [Claude Code](https://claude.ai/code)