### PR TITLE
fix: disable ComfyUI compose when image generation is off

### DIFF
--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -72,17 +72,24 @@ if ! $INTERACTIVE && [[ "$ENABLE_COMFYUI" == "true" ]]; then
     esac
 fi
 
-# Disable ComfyUI compose if image generation is off — prevents
-# resolve-compose-stack.sh from including a compose file whose image
-# was never built/pulled, which would block ALL containers on start.
-if [[ "${ENABLE_COMFYUI:-}" != "true" ]]; then
-    _comfyui_compose="$SCRIPT_DIR/extensions/services/comfyui/compose.yaml"
+# Sync ComfyUI compose state with ENABLE_COMFYUI — the resolver uses the
+# .disabled convention to exclude services from the compose stack.
+_comfyui_compose="$SCRIPT_DIR/extensions/services/comfyui/compose.yaml"
+if [[ "${ENABLE_COMFYUI:-}" == "true" ]]; then
+    # Re-enable if previously disabled (re-install with different options)
+    if [[ ! -f "$_comfyui_compose" && -f "${_comfyui_compose}.disabled" ]]; then
+        mv "${_comfyui_compose}.disabled" "$_comfyui_compose"
+        log "ComfyUI compose re-enabled"
+    fi
+else
+    # Disable — prevents resolve-compose-stack.sh from including a compose
+    # file whose image was never built/pulled, blocking ALL containers.
     if [[ -f "$_comfyui_compose" ]]; then
         mv "$_comfyui_compose" "${_comfyui_compose}.disabled"
         log "ComfyUI compose disabled (image generation not enabled)"
     fi
-    unset _comfyui_compose
 fi
+unset _comfyui_compose
 
 # All services are core — no profiles needed (compose profiles removed)
 


### PR DESCRIPTION
## What
Exclude ComfyUI compose files from the Docker Compose stack when image generation is disabled.

## Why
When `ENABLE_COMFYUI=false` (non-interactive without `--all`, or Tier 0/1 safety net), the installer skips building the ComfyUI image but `resolve-compose-stack.sh` still includes its compose files. `docker compose up` then fails with "No such image: dream-server-comfyui:latest", blocking ALL containers from starting — not just ComfyUI.

## How
Added a block at the end of Phase 03 that syncs ComfyUI compose state with the `ENABLE_COMFYUI` flag:
- When disabled: renames `compose.yaml` → `compose.yaml.disabled` (resolver already skips `.disabled`)
- When enabled: renames back if previously disabled (handles re-install edge case)

Uses the existing `.disabled` convention that `resolve-compose-stack.sh` and `dream-cli enable/disable` already respect.

## Testing
- `bash -n` syntax check passes
- Verified resolver handles `.disabled` at line 169
- Verified `dream enable comfyui` uses same rename convention

## Review
Critique Guardian: APPROVED (after adding companion re-enable block for re-install edge case)

## Platform Impact
- **macOS:** N/A — Phase 03 only runs on Linux installer. ComfyUI's manifest declares `gpu_backends: [amd, nvidia]`, no Apple support.
- **Linux:** Direct fix for the reported bug
- **Windows/WSL2:** Direct fix — originally reported on WSL2/NVIDIA

🤖 Generated with [Claude Code](https://claude.ai/code)