### PR TITLE
docs: add extensions API, host agent, and runtime lifecycle documentation

### DIFF
--- a/dream-server/docs/EXTENSIONS.md
+++ b/dream-server/docs/EXTENSIONS.md
@@ -360,6 +360,101 @@ npm run lint
 npm run build
 ```
 
+## Runtime Lifecycle
+
+This section describes the end-to-end flow of how extensions are discovered, installed, enabled, and managed at runtime. Each step references the source file that implements it.
+
+### 1. Catalog Generation
+
+At startup, the Dashboard API (`config.py:load_extension_catalog()`) loads `config/extensions-catalog.json` — a static JSON file listing all available extensions. This catalog is served via `GET /api/extensions/catalog` and enriched at request time with live status (enabled, disabled, not_installed, incompatible) by checking the filesystem and service health (`routers/extensions.py:_compute_extension_status()`).
+
+### 2. Manifest Loading
+
+The Dashboard API loads manifests from `extensions/services/*/manifest.yaml` at startup (`config.py:load_extension_manifests()`). This populates the `SERVICES` dict (used for health checks) and `FEATURES` list (used by the features endpoint). Disabled extensions (those with `compose.yaml.disabled` instead of `compose.yaml`) are skipped during manifest loading — they do not appear in service health checks or feature recommendations.
+
+### 3. Install (Library to User Extensions)
+
+When a user installs an extension via the dashboard (`POST /api/extensions/{service_id}/install`), the extensions router:
+
+1. Validates the service ID and confirms it is not a core service
+2. Locates the extension in the **extensions library** (`$DREAM_DATA_DIR/extensions-library/<id>/`)
+3. Performs a size check (max 50 MB) and security scan of the compose file (rejects privileged mode, Docker socket mounts, host network, dangerous capabilities, non-localhost port bindings, and other unsafe directives)
+4. Copies the extension to `$DREAM_DATA_DIR/user-extensions/<id>/` atomically via a temp directory on the same filesystem
+5. Calls the host agent to start the container (`POST /v1/extension/start`)
+
+The install uses file locking (`fcntl.flock`) to prevent double-install races.
+
+### 4. Enable / Disable
+
+Extensions are enabled or disabled by renaming their compose file:
+
+- **Enable** (`POST /api/extensions/{service_id}/enable`): Renames `compose.yaml.disabled` to `compose.yaml`, then calls the host agent to start the container. Before enabling, the router checks that all dependencies declared in the manifest's `service.depends_on` are present and enabled.
+- **Disable** (`POST /api/extensions/{service_id}/disable`): Calls the host agent to stop the container first (prevents zombie containers), then renames `compose.yaml` to `compose.yaml.disabled`. Warns if other enabled extensions depend on this one.
+
+Both operations validate that the compose file is not a symlink (TOCTOU prevention under lock) and re-scan compose contents before enabling.
+
+### 5. Host Agent Container Management
+
+The [host agent](HOST-AGENT-API.md) (`bin/dream-host-agent.py`) runs on the host machine and exposes `/v1/extension/start`, `/v1/extension/stop`, and `/v1/extension/logs`. When the Dashboard API calls start/stop, the host agent:
+
+1. Resolves the full compose stack by calling `scripts/resolve-compose-stack.sh`
+2. Runs `docker compose <flags> up -d <service_id>` (start) or `docker compose <flags> stop <service_id>` (stop)
+3. For start operations, pre-creates any `./data/` volume directories with correct ownership
+
+If the host agent is unreachable, file-level operations (install, enable, disable) still succeed, but `restart_required: true` is returned to signal that `dream restart` is needed.
+
+### 6. Compose Stack Discovery
+
+`scripts/resolve-compose-stack.sh` dynamically builds the list of `-f` flags for `docker compose`. It:
+
+1. Selects the base compose files based on GPU backend and tier (e.g., `docker-compose.base.yml` + `docker-compose.nvidia.yml`)
+2. Walks `extensions/services/*/` and includes each extension's `compose.yaml` if it exists (not `.disabled`), skipping extensions incompatible with the current GPU backend
+3. Picks up GPU-specific overlays (`compose.<backend>.yaml`) and mode-specific overlays (`compose.local.yaml`) per extension
+4. Walks `data/user-extensions/*/` and includes compose files from user-installed extensions
+5. Appends `docker-compose.override.yml` if it exists (user customizations)
+
+### 7. Uninstall
+
+Uninstalling (`DELETE /api/extensions/{service_id}`) requires the extension to be disabled first (compose file must be renamed to `.disabled`). It then removes the extension directory from `user-extensions/` under file lock.
+
+### 8. Dashboard UI Status Polling
+
+The dashboard frontend polls `GET /api/extensions/catalog` to display extension status. Each extension's status is computed by checking:
+
+- For core/built-in services: whether the service health check reports "healthy"
+- For user-installed extensions: whether `compose.yaml` (enabled) or `compose.yaml.disabled` (disabled) exists in the user-extensions directory
+- For extensions not yet installed: whether the current GPU backend is compatible
+
+The catalog response also includes `agent_available` (whether the host agent is reachable) and `library_available` (whether the extensions library directory exists and is non-empty).
+
+### Lifecycle Summary
+
+```
+  Extensions Library                User Extensions Dir
+  ($DATA_DIR/extensions-library/)   ($DATA_DIR/user-extensions/)
+         │                                   │
+         │  POST .../install                 │
+         │  (copy + security scan)           │
+         └──────────────────────────────────►│
+                                             │
+                     compose.yaml ◄──────────┤ (enabled)
+                     compose.yaml.disabled ◄─┤ (disabled)
+                                             │
+                     Host Agent              │
+                     (127.0.0.1:7710)        │
+                         │                   │
+                         ▼                   │
+                     docker compose up -d    │
+                     docker compose stop     │
+                                             │
+                     resolve-compose-stack.sh │
+                         │                   │
+                         ▼                   │
+                     Merges base + GPU +     │
+                     extensions + user-ext   │
+                     into one compose stack  │
+```
+
 ## Notes
 
 - Manifest loading is additive with safe fallback defaults.

--- a/dream-server/docs/HOST-AGENT-API.md
+++ b/dream-server/docs/HOST-AGENT-API.md
@@ -1,0 +1,153 @@
+# Dream Host Agent API
+
+The Dream Host Agent (`bin/dream-host-agent.py`) is a lightweight HTTP server that runs **on the host machine** (outside Docker). It allows the Dashboard API (running inside a container) to manage extension containers — starting, stopping, and fetching logs — without giving the container direct access to the Docker socket.
+
+## Why It Exists
+
+The Dashboard API runs inside a Docker container and cannot directly run `docker compose` commands on the host. The host agent bridges this gap: it listens on `127.0.0.1:7710`, accepts authenticated requests from the Dashboard API, and executes Docker Compose operations on its behalf. This avoids mounting the Docker socket into the container (a significant security risk).
+
+## How It Runs
+
+| Platform | Mechanism |
+|----------|-----------|
+| Linux | systemd user service (`scripts/systemd/dream-host-agent.service`) |
+| macOS | Started by the installer (`installers/macos/install-macos.sh`) |
+
+The agent is started during installation (phase 07 on Linux) and binds to `127.0.0.1` only — it is not accessible from the network.
+
+## Configuration
+
+The agent reads its configuration from the `.env` file in the DreamServer install directory.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DREAM_AGENT_KEY` | *(none)* | API key for authenticating requests. Falls back to `DASHBOARD_API_KEY` if unset. |
+| `DREAM_AGENT_PORT` | `7710` | Port the agent listens on. |
+| `GPU_BACKEND` | `nvidia` | Passed to `resolve-compose-stack.sh` when building compose flags. |
+| `TIER` | `1` | Hardware tier, passed to compose stack resolution. |
+| `DREAM_DATA_DIR` | `~/.dream-server` | Data directory root. |
+| `DREAM_USER_EXTENSIONS_DIR` | `$DREAM_DATA_DIR/user-extensions` | Where user-installed extensions live. |
+
+The agent also loads `config/core-service-ids.json` to determine which services are protected from management operations. If this file is missing, a hardcoded fallback list is used.
+
+## Authentication
+
+All mutation endpoints (`/v1/extension/*`) require a Bearer token:
+
+```
+Authorization: Bearer <DREAM_AGENT_KEY>
+```
+
+The agent uses constant-time comparison (`secrets.compare_digest`) to prevent timing attacks.
+
+## Endpoints
+
+### `GET /health`
+
+Health check. No authentication required.
+
+**Response (200):**
+```json
+{
+  "status": "ok",
+  "version": "1.0.0"
+}
+```
+
+### `POST /v1/extension/start`
+
+Start an extension container. Runs `docker compose up -d <service_id>` using the full compose stack (resolved via `scripts/resolve-compose-stack.sh`). Before starting, the agent pre-creates any `./data/` volume directories declared in the extension's `compose.yaml`, with correct ownership based on the `user:` field.
+
+**Authentication:** Required
+
+**Request body:**
+```json
+{
+  "service_id": "my-extension"
+}
+```
+
+**Validation rules:**
+- `service_id` must match `^[a-z0-9][a-z0-9_-]*$`
+- Core services are rejected (403)
+- Extension directory must exist in `user-extensions/` with a valid manifest
+
+**Response (200):**
+```json
+{
+  "status": "ok",
+  "service_id": "my-extension",
+  "action": "start"
+}
+```
+
+**Error responses:**
+| Code | Condition |
+|------|-----------|
+| 400 | Invalid `service_id` format or missing request body |
+| 401 | Missing Authorization header |
+| 403 | Invalid API key or core service |
+| 404 | Extension not found (no directory or no manifest) |
+| 409 | Operation already in progress for this service |
+| 500 | Docker Compose operation failed |
+| 503 | Docker Compose operation timed out (120s) |
+
+### `POST /v1/extension/stop`
+
+Stop an extension container. Runs `docker compose stop <service_id>`.
+
+**Authentication:** Required
+
+**Request/response format:** Same as `/v1/extension/start` with `"action": "stop"`.
+
+### `POST /v1/extension/logs`
+
+Fetch recent container logs. Uses `docker logs --tail N dream-<service_id>` directly (bypasses compose for speed).
+
+**Authentication:** Required
+
+**Request body:**
+```json
+{
+  "service_id": "my-extension",
+  "tail": 100
+}
+```
+
+The `tail` parameter is clamped to 1-500 (defaults to 100).
+
+**Response (200):**
+```json
+{
+  "service_id": "my-extension",
+  "logs": "...log output...",
+  "lines": 100
+}
+```
+
+If the container does not exist yet (e.g. image is still pulling), a 200 response is returned with a message instead of logs.
+
+**Error responses:**
+| Code | Condition |
+|------|-----------|
+| 503 | Log fetch timed out (5s) |
+| 500 | Failed to fetch logs |
+
+## Security Boundaries
+
+The host agent is a **critical security boundary** because it can start and stop Docker containers on the host.
+
+Protections in place:
+- **Localhost only**: Binds to `127.0.0.1`, not `0.0.0.0`
+- **API key auth**: All mutation endpoints require Bearer token authentication
+- **Core service protection**: Core services (loaded from `config/core-service-ids.json` with hardcoded fallback) cannot be managed
+- **Service ID validation**: Regex-validated, must map to an actual extension directory with a manifest
+- **Per-service locking**: Prevents concurrent start+stop races on the same service via `threading.Lock`
+- **Request size limit**: Request bodies capped at 4 KB
+- **Subprocess timeout**: Docker operations time out after 120 seconds
+
+## How the Dashboard API Calls It
+
+The Dashboard API (`extensions/services/dashboard-api/routers/extensions.py`) communicates with the host agent via the `AGENT_URL` environment variable (constructed from `DREAM_AGENT_HOST` and `DREAM_AGENT_PORT` in `config.py`). It uses `DREAM_AGENT_KEY` for authentication. The connection flows through Docker's `host.docker.internal` DNS name by default, allowing the containerized API to reach the host-bound agent.
+
+If the host agent is unreachable, mutation operations (install, enable, disable) still succeed at the file level but return `"restart_required": true` to signal that `dream restart` is needed.

--- a/dream-server/extensions/README.md
+++ b/dream-server/extensions/README.md
@@ -1,0 +1,41 @@
+# Dream Server Extensions
+
+This directory contains all service extensions that ship with Dream Server. Each subdirectory under `services/` is a self-contained extension with a manifest and optional compose files.
+
+## Documentation Map
+
+| Document | What it covers |
+|----------|----------------|
+| [Extension Authoring Guide](../docs/EXTENSIONS.md) | How to create a new extension: directory structure, manifest contract, compose patterns, GPU overlays, enable/disable mechanism, validation, and runtime lifecycle |
+| [Extension Catalog](CATALOG.md) | List of all bundled extensions with ports, categories, and GPU compatibility |
+| [Manifest Schema Reference](schema/README.md) | JSON Schema specification for `manifest.yaml` — all fields, types, and validation rules |
+| [Host Agent API](../docs/HOST-AGENT-API.md) | API contract for the host agent that starts/stops extension containers from outside Docker |
+| [Dashboard API Extensions Endpoints](services/dashboard-api/README.md#extensions) | REST API for browsing, installing, enabling, disabling, and uninstalling extensions |
+
+## Directory Layout
+
+```
+extensions/
+  CATALOG.md              # Bundled extension catalog
+  README.md               # This file
+  schema/
+    service-manifest.v1.json  # JSON Schema for manifest validation
+    README.md                 # Schema documentation
+  services/
+    <service-id>/
+      manifest.yaml           # Service metadata (required)
+      compose.yaml            # Docker Compose fragment (extension services)
+      compose.amd.yaml        # AMD GPU overlay (optional)
+      compose.nvidia.yaml     # NVIDIA GPU overlay (optional)
+      compose.local.yaml      # Mode-specific overlay (optional)
+      README.md               # Per-service documentation (optional)
+```
+
+Core services (llama-server, open-webui, dashboard, dashboard-api) only have a `manifest.yaml` here — their compose definitions live in `docker-compose.base.yml` at the repository root.
+
+## Quick Links
+
+- **Add an extension**: [30-Minute Path](../docs/EXTENSIONS.md#30-minute-path-add-a-service)
+- **Validate manifests**: `bash scripts/validate-manifests.sh` or `dream config validate`
+- **Audit extensions**: `python3 scripts/audit-extensions.py --project-dir .`
+- **Enable/disable from CLI**: `dream enable <id>` / `dream disable <id>`

--- a/dream-server/extensions/services/dashboard-api/README.md
+++ b/dream-server/extensions/services/dashboard-api/README.md
@@ -123,6 +123,20 @@ Environment variables (set in `.env`):
 | `GET` | `/api/releases/manifest` | No | Recent release history from GitHub |
 | `POST` | `/api/update` | Yes | Trigger update actions (`check`, `backup`, `update`) |
 
+### Extensions
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/api/extensions/catalog` | Yes | Browse extension catalog with status, filterable by `category` and `gpu_compatible` query params |
+| `GET` | `/api/extensions/{service_id}` | Yes | Detailed info for a single extension (manifest, features, env vars, setup instructions) |
+| `POST` | `/api/extensions/{service_id}/install` | Yes | Install an extension from the extensions library into user-extensions |
+| `POST` | `/api/extensions/{service_id}/enable` | Yes | Enable a disabled extension (renames `compose.yaml.disabled` to `compose.yaml`, starts container via host agent) |
+| `POST` | `/api/extensions/{service_id}/disable` | Yes | Disable an enabled extension (stops container via host agent, renames `compose.yaml` to `compose.yaml.disabled`) |
+| `DELETE` | `/api/extensions/{service_id}` | Yes | Uninstall a disabled extension (removes its directory from user-extensions) |
+| `POST` | `/api/extensions/{service_id}/logs` | Yes | Fetch container logs via the host agent (last 100 lines) |
+
+Core services cannot be installed, enabled, disabled, or uninstalled via these endpoints (returns 403). The catalog endpoint also reports whether the [host agent](../../docs/HOST-AGENT-API.md) is available (`agent_available` field).
+
 ## Authentication
 
 When `DASHBOARD_API_KEY` is set in `.env`, all authenticated endpoints require the key:
@@ -150,7 +164,8 @@ Dashboard API (:3002)
        ├── setup.py ─────────── Setup wizard + persona system
        ├── updates.py ──────── GitHub releases + dream-update.sh
        ├── agents.py ───────── Agent session + throughput metrics
-       └── privacy.py ──────── Privacy Shield container control
+       ├── privacy.py ──────── Privacy Shield container control
+       └── extensions.py ───── Extension catalog, install, enable/disable, logs
 ```
 
 ## Files
@@ -162,7 +177,7 @@ Dashboard API (:3002)
 - `gpu.py` — GPU detection for NVIDIA and AMD
 - `helpers.py` — Service health checks, LLM metrics, system metrics
 - `agent_monitor.py` — Background agent metrics collection
-- `routers/` — Endpoint modules (workflows, features, setup, updates, agents, privacy)
+- `routers/` — Endpoint modules (workflows, features, setup, updates, agents, privacy, extensions)
 - `Dockerfile` — Container definition
 - `requirements.txt` — Python dependencies
 


### PR DESCRIPTION
## Summary
- Add 7 extensions router endpoints to dashboard-api README (catalog, detail, install, enable, disable, uninstall, logs)
- Create `docs/HOST-AGENT-API.md` documenting the host agent contract (endpoints, authentication, security boundaries, configuration)
- Create `extensions/README.md` as a documentation entry-point linking all extensions-related docs
- Add "Runtime Lifecycle" section to `docs/EXTENSIONS.md` covering the end-to-end flow: catalog generation, manifest loading, install, enable/disable, host agent interaction, compose stack discovery, uninstall, and dashboard UI polling

## Test plan
- [ ] Verify all internal markdown cross-references resolve correctly
- [ ] Confirm documented endpoints match `routers/extensions.py` source
- [ ] Confirm documented host agent behavior matches `bin/dream-host-agent.py` source
- [ ] Confirm documented compose resolution flow matches `scripts/resolve-compose-stack.sh` source

🤖 Generated with [Claude Code](https://claude.com/claude-code)