### PR TITLE
docs(windows): warn that compose config may expose .env secrets in re…

### DIFF
--- a/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
+++ b/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
@@ -24,7 +24,7 @@ What the diagnostics include (in order):
 
 1. **`docker version`** — confirms the Docker client can talk to the engine.
 2. **`docker info`** (first lines) — daemon state, WSL2, disk, etc.
-3. **`docker compose … config`** (last lines of output) — merged compose after variable substitution (uses `.env` when present). If there is a YAML merge or syntax error, it often appears here.
+3. **`docker compose … config`** (last lines of output) — merged compose after variable substitution (uses `.env` when present). **This output can contain secret values** (API keys, tokens); redact before pasting into public GitHub issues. If there is a YAML merge or syntax error, it often appears here.
 4. **`docker compose … ps -a`** — which containers exist and their state.
 
 **Things to check on your machine before re-running:**
@@ -52,7 +52,10 @@ This creates:
 - `artifacts/windows-report/report.txt` (human-readable summary)
 
 The report includes platform/GPU basics, compose flags, `docker version`, `docker info`, `docker compose ... config`, `docker compose ... ps -a`, and key local health checks.
-Attach `report.json` to GitHub issues or Discord support threads.
+
+**Privacy:** `docker compose config` in the bundle can interpolate values from `.env` (including API keys and other secrets). Open `report.json`, search for sensitive strings, and redact or replace them before attaching to **public** GitHub issues. Discord or private support channels may still need care if you paste large excerpts.
+
+Attach `report.json` to GitHub issues or Discord support threads after review.
 
 ---
 

--- a/dream-server/installers/windows/lib/compose-diagnostics.ps1
+++ b/dream-server/installers/windows/lib/compose-diagnostics.ps1
@@ -81,6 +81,7 @@ function Write-DreamComposeDiagnostics {
         Write-Host ""
 
         $envArgs = Get-DreamComposeEnvFileArgs -InstallDir $InstallDir
+        Write-AIWarn "Output below may include substituted .env values (secrets). Redact before posting publicly."
         Write-Host "  --- docker compose ... config (last 55 lines) ---" -ForegroundColor DarkGray
         $cfgOut = & docker compose @ComposeFlags @envArgs config 2>&1 | ForEach-Object { $_.ToString() }
         if ($cfgOut) {

--- a/dream-server/installers/windows/lib/install-report.ps1
+++ b/dream-server/installers/windows/lib/install-report.ps1
@@ -140,6 +140,9 @@ function Write-DreamInstallReport {
     $lines += "Dream Server Windows Report"
     $lines += "Generated: $($report.generated_at)"
     $lines += ""
+    $lines += "Privacy"
+    $lines += "- docker compose config output (inside report.json) can include interpolated env values from .env — API keys, tokens, or other secrets. Review and redact before sharing publicly."
+    $lines += ""
     $lines += "Platform"
     $lines += "- OS: $($report.platform.os_caption) ($($report.platform.os_version), build $($report.platform.os_build))"
     $lines += "- Machine: $($report.platform.computer_name)"
@@ -173,6 +176,7 @@ function Write-DreamInstallReport {
     Write-AISuccess "Report generated:"
     Write-AI "  JSON: $jsonPath"
     Write-AI "  Text: $txtPath"
+    Write-AIWarn "compose config in report.json may contain secrets from .env — review before sharing."
     Write-AI "Attach report.json when filing Windows install/runtime issues."
 
     return @{


### PR DESCRIPTION
Add clear warnings that `docker compose config` in the Windows install report and compose diagnostics can include substituted `.env` values (including secrets), so users review before sharing publicly.