### PR TITLE
fix: add health_port field for services with separate health endpoints

### DIFF
--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -110,6 +110,7 @@ def load_extension_manifests(
                     "name": service.get("name", service_id),
                     "ui_path": service.get("ui_path", "/"),
                     **({"type": service["type"]} if "type" in service else {}),
+                    **({"health_port": int(service["health_port"])} if "health_port" in service else {}),
                 }
 
             manifest_features = manifest.get("features", [])

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -205,7 +205,8 @@ async def check_service_health(service_id: str, config: dict) -> ServiceStatus:
         )
 
     host = config.get('host', 'localhost')
-    url = f"http://{host}:{config['port']}{config['health']}"
+    health_port = config.get('health_port', config['port'])
+    url = f"http://{host}:{health_port}{config['health']}"
     status = "unknown"
     response_time = None
 
@@ -239,7 +240,8 @@ async def _check_host_service_health(service_id: str, config: dict) -> ServiceSt
     """Check health of a host-level service via HTTP."""
     port = config.get("external_port", config["port"])
     host = os.environ.get("HOST_GATEWAY", "host.docker.internal")
-    url = f"http://{host}:{port}{config['health']}"
+    health_port = config.get('health_port', port)
+    url = f"http://{host}:{health_port}{config['health']}"
     status = "down"
     response_time = None
     try:

--- a/resources/dev/extensions-library/services/milvus/manifest.yaml
+++ b/resources/dev/extensions-library/services/milvus/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: MILVUS_PORT
   external_port_default: 19530
   health: /healthz
+  health_port: 9091
   type: docker
   gpu_backends: [all]
   compose_file: compose.yaml


### PR DESCRIPTION
## What
Add an optional `health_port` manifest field so services whose health endpoint lives on a different port than the main service port get correct health checks.

## Why
Milvus exposes gRPC on port 19530 and its HTTP admin/health endpoint (`/healthz`) on port 9091. The dashboard-api was constructing `http://milvus:19530/healthz` — hitting a gRPC port that returns no HTTP response. Result: Milvus permanently shows as unhealthy in the dashboard even when running correctly.

## How
- Added `health_port: 9091` to the Milvus manifest
- `config.py`: loads `health_port` into the service dict (optional, same spread pattern as `type`)
- `helpers.py`: `check_service_health()` and `_check_host_service_health()` use `config.get('health_port', config['port'])` — falls back to `port` when `health_port` is absent

All existing services without `health_port` behave identically (backward compatible).

## Testing
- `python -m py_compile` passes on all modified files
- YAML syntax validated on manifest
- pytest: 374/384 pass (10 pre-existing failures on main, 0 regressions)
- Critique Guardian: APPROVED

## Review
Critique Guardian verdict: ✅ APPROVED — clean, minimal, correct fix with safe fallback.

## Platform Impact
- **macOS:** No impact — pure Python/YAML change
- **Linux:** No impact — Docker bridge networking reaches port 9091 container-to-container
- **Windows/WSL2:** No impact — same Docker networking behavior