### PR TITLE
fix: report vramFits=true for features already consuming VRAM

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/features.py
+++ b/dream-server/extensions/services/dashboard-api/routers/features.py
@@ -62,6 +62,11 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
     )
     is_enabled = enabled_all_ok and enabled_any_ok
 
+    # A running feature already occupies VRAM — report it as fitting
+    # when total VRAM meets the requirement, not just free VRAM.
+    if is_enabled:
+        vram_fits = vram_ok
+
     if is_enabled:
         status = "enabled"
     elif not vram_ok:


### PR DESCRIPTION
## What
Override `vramFits` to use total VRAM (not free VRAM) when a feature is already enabled and running.

## Why
The `/api/features` endpoint computes `vramFits` from free VRAM. When a feature is running, its services consume VRAM, reducing free VRAM below the feature's requirement. This produces `vramFits=false` alongside `enabled=true` — a contradictory signal that confuses users into thinking their hardware is insufficient for features already running successfully.

## How
In `calculate_feature_status()`, after determining `is_enabled`, if the feature is enabled, override `vram_fits = vram_ok` (total VRAM >= requirement). A running feature has already "fit" — its own VRAM usage shouldn't count against it.

The `vramFits` field is informational only — it is not used in status determination logic (`enabled`, `available`, `insufficient_vram`, `services_needed`).

## Testing
- `python -m py_compile` passes
- pytest: 374/384 pass (10 pre-existing failures on main, 0 regressions)
- Critique Guardian: APPROVED

## Review
Critique Guardian verdict: ✅ APPROVED — correct logic, minimal diff, clear commentary.

## Platform Impact
- **macOS:** No impact — pure Python logic
- **Linux:** No impact
- **Windows/WSL2:** No impact — this was reported on WSL2, fix resolves the confusing signal