### PR TITLE
fix: force IPv4 in health checker to prevent WSL2 DNS delays

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import shutil
+import socket
 import time
 from pathlib import Path
 from typing import Optional
@@ -33,7 +34,10 @@ async def _get_aio_session() -> aiohttp.ClientSession:
     """Return (and lazily create) a module-level aiohttp session."""
     global _aio_session
     if _aio_session is None or _aio_session.closed:
-        _aio_session = aiohttp.ClientSession(timeout=_HEALTH_TIMEOUT)
+        _aio_session = aiohttp.ClientSession(
+            timeout=_HEALTH_TIMEOUT,
+            connector=aiohttp.TCPConnector(family=socket.AF_INET),
+        )
     return _aio_session
 
 


### PR DESCRIPTION
## What
Force IPv4 connections in the aiohttp health check session by creating the TCP connector with `family=socket.AF_INET`.

## Why
On WSL2/Docker Desktop, the default aiohttp connector attempts both IPv6 (AAAA) and IPv4 (A) DNS resolution. Docker service name AAAA queries timeout after ~8 seconds before falling back to IPv4, inflating `response_time_ms` to ~8016ms for most services. Docker internal networking is exclusively IPv4 — AAAA queries always fail.

## How
In `_get_aio_session()`, changed the session creation from:
```python
aiohttp.ClientSession(timeout=_HEALTH_TIMEOUT)
```
to:
```python
aiohttp.ClientSession(
    timeout=_HEALTH_TIMEOUT,
    connector=aiohttp.TCPConnector(family=socket.AF_INET),
)
```

## Testing
- `python -m py_compile` passes
- pytest: 374/384 pass (10 pre-existing failures on main, 0 regressions)
- Critique Guardian: APPROVED WITH WARNINGS

## Review
Critique Guardian verdict: ⚠️ APPROVED WITH WARNINGS
- Non-blocking warning: the shared `httpx.AsyncClient` (used for llama-server metrics) does not force IPv4. Single-host with 5s timeout — much smaller impact than the 17-service health poll. Recommended as follow-up.

## Known Considerations
The httpx client for llama-server metrics is not covered by this fix. On WSL2, llama-server requests may still see a one-time ~5s DNS delay. This is a minor follow-up — the critical fix is the health poll (17 services × 8s = 136s delay eliminated).

## Platform Impact
- **macOS:** No impact — Docker Desktop for Mac uses IPv4 internally
- **Linux:** No impact — Docker bridge networking is IPv4
- **Windows/WSL2:** Fixes the ~8016ms response_time_ms inflation