### PR TITLE
fix: filter disabled services and resolve external ports in preflight endpoint

### DIFF
--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -24,6 +24,19 @@ EXTENSIONS_DIR = Path(
 DEFAULT_SERVICE_HOST = os.environ.get("SERVICE_HOST", "host.docker.internal")
 GPU_BACKEND = os.environ.get("GPU_BACKEND", "nvidia")
 
+
+def _read_env_from_file(key: str) -> str:
+    """Read a variable from the .env file when not available in process environment."""
+    env_path = Path(INSTALL_DIR) / ".env"
+    try:
+        for line in env_path.read_text().splitlines():
+            if line.startswith(f"{key}="):
+                return line.split("=", 1)[1].strip().strip("\"'")
+    except OSError:
+        pass
+    return ""
+
+
 # --- Manifest Loading ---
 
 
@@ -100,7 +113,11 @@ def load_extension_manifests(
 
                 ext_port_env = service.get("external_port_env")
                 ext_port_default = service.get("external_port_default", service.get("port", 0))
-                external_port = int(os.environ.get(ext_port_env, str(ext_port_default))) if ext_port_env else int(ext_port_default)
+                if ext_port_env:
+                    val = os.environ.get(ext_port_env) or _read_env_from_file(ext_port_env)
+                    external_port = int(val) if val else int(ext_port_default)
+                else:
+                    external_port = int(ext_port_default)
 
                 services[service_id] = {
                     "host": host,

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -187,8 +187,14 @@ async def preflight_gpu():
 @app.get("/api/preflight/required-ports")
 async def preflight_required_ports():
     """Return the list of service ports for preflight checking (no auth required)."""
+    # When health cache exists, filter out services not in the compose stack
+    cached = get_cached_services()
+    deployed = {s.id for s in cached if s.status != "not_deployed"} if cached else None
+
     ports = []
     for sid, cfg in SERVICES.items():
+        if deployed is not None and sid not in deployed:
+            continue
         ext_port = cfg.get("external_port", cfg.get("port", 0))
         if ext_port:
             ports.append({"port": ext_port, "service": cfg.get("name", sid)})


### PR DESCRIPTION
## What
Filter `/api/preflight/required-ports` to exclude services not in the active compose stack and resolve external port env vars from the mounted `.env` file.

## Why
The preflight endpoint returned ports for disabled services (e.g., ComfyUI on Tier 1) and showed internal container ports (e.g., 8080) instead of external host-mapped ports (e.g., 11434) because port env vars like `OLLAMA_PORT` aren't passed in the compose `environment:` block.

## How
- Added `_read_env_from_file()` helper in `config.py` to resolve port env vars from the mounted `.env` file when not available in process environment (three-tier fallback: process env → .env file → manifest default)
- Filter `preflight_required_ports()` using the service health cache — services with `not_deployed` status are excluded when the cache is available; pre-cache state returns all services (safe fallback)

## Testing
- `python -m py_compile` passes for both files
- Existing `TestPreflightRequiredPorts` tests pass (pre-cache path unchanged)

## Platform Impact
- **macOS**: No impact — Python-only changes, runs inside Docker
- **Linux**: No impact — same container behavior
- **Windows/WSL2**: No impact — same container behavior

🤖 Generated with [Claude Code](https://claude.ai/claude-code)