### PR TITLE
fix: handle thinking model responses in /api/chat endpoint

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/setup.py
+++ b/dream-server/extensions/services/dashboard-api/routers/setup.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -170,7 +171,7 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
     payload = {
         "model": model,
         "messages": [{"role": "system", "content": system_prompt}, {"role": "user", "content": request.message}],
-        "max_tokens": 256, "temperature": 0.7
+        "max_tokens": 2048, "temperature": 0.7
     }
 
     try:
@@ -180,6 +181,8 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
                 if resp.status == 200:
                     data = await resp.json()
                     response_text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+                    # Strip thinking model tags — content may contain <think>...</think> blocks
+                    response_text = re.sub(r'<think>[\s\S]*?</think>\s*', '', response_text).strip()
                     return {"response": response_text, "success": True}
                 else:
                     error_text = await resp.text()


### PR DESCRIPTION
## What
Fix `/api/chat` returning empty responses when a thinking model (e.g., Qwen3.5) is loaded.

## Why
Thinking models generate `<think>...</think>` blocks before producing actual content. With `max_tokens: 256`, the model exhausts its token budget on the reasoning phase and never produces visible output — `content` is always empty string.

## How
- Increase `max_tokens` from 256 to 2048 (bounded by existing 30s HTTP timeout)
- Strip `<think>...</think>` tags from response text via regex (safe, no ReDoS risk — fixed delimiters with lazy quantifier)

## Testing
- `python -m py_compile` passes
- Manual: send a message via setup wizard chat, verify thinking tags are stripped and response is non-empty

## Platform Impact
- **macOS / Linux / Windows**: No impact — pure Python string processing on API response

🤖 Generated with [Claude Code](https://claude.ai/claude-code)