### PR TITLE
fix: populate null fields in /api/status and fix n8n health detection

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -305,6 +305,8 @@ async def api_status(api_key: str = Depends(verify_api_key)):
             "version": app.version, "tier": "Unknown",
             "cpu": {"percent": 0, "temp_c": None},
             "ram": {"used_gb": 0, "total_gb": 0, "percent": 0},
+            "disk": {"used_gb": 0, "total_gb": 0, "percent": 0},
+            "system": {"uptime": 0, "hostname": os.environ.get("HOSTNAME", "dream-server")},
             "inference": {"tokensPerSecond": 0, "lifetimeTokens": 0,
                           "loadedModel": None, "contextSize": None},
             "manifest_errors": MANIFEST_ERRORS,
@@ -321,7 +323,7 @@ async def _build_api_status() -> dict:
     # Fan out: sync helpers in threads + async health checks simultaneously
     (
         gpu_info, model_info, bootstrap_info, uptime,
-        cpu_metrics, ram_metrics,
+        cpu_metrics, ram_metrics, disk_info,
         service_statuses, loaded_model,
     ) = await asyncio.gather(
         asyncio.to_thread(get_gpu_info),
@@ -330,6 +332,7 @@ async def _build_api_status() -> dict:
         asyncio.to_thread(get_uptime),
         asyncio.to_thread(get_cpu_metrics),
         asyncio.to_thread(get_ram_metrics),
+        asyncio.to_thread(get_disk_usage),
         _get_services(),
         get_loaded_model(),
     )
@@ -369,11 +372,11 @@ async def _build_api_status() -> dict:
             gpu_data["powerDraw"] = gpu_info.power_w
         gpu_data["memoryLabel"] = "VRAM Partition" if gpu_info.memory_type == "unified" else "VRAM"
 
-    services_data = [{"name": s.name, "status": s.status, "port": s.external_port, "uptime": None} for s in service_statuses]
+    services_data = [{"name": s.name, "status": s.status, "port": s.external_port, "uptime": uptime if s.status == "healthy" else None} for s in service_statuses]
 
     model_data = None
     if model_info:
-        model_data = {"name": model_info.name, "tokensPerSecond": None, "contextLength": model_info.context_length}
+        model_data = {"name": model_info.name, "tokensPerSecond": llama_metrics_data.get("tokens_per_second") or None, "contextLength": context_size or model_info.context_length}
 
     bootstrap_data = None
     if bootstrap_info.active:
@@ -401,6 +404,8 @@ async def _build_api_status() -> dict:
         "bootstrap": bootstrap_data, "uptime": uptime,
         "version": app.version, "tier": tier,
         "cpu": cpu_metrics, "ram": ram_metrics,
+        "disk": {"used_gb": disk_info.used_gb, "total_gb": disk_info.total_gb, "percent": disk_info.percent},
+        "system": {"uptime": uptime, "hostname": os.environ.get("HOSTNAME", "dream-server")},
         "inference": {
             "tokensPerSecond": llama_metrics_data.get("tokens_per_second", 0),
             "lifetimeTokens": llama_metrics_data.get("lifetime_tokens", 0),

--- a/dream-server/extensions/services/dashboard-api/routers/workflows.py
+++ b/dream-server/extensions/services/dashboard-api/routers/workflows.py
@@ -1,5 +1,6 @@
 """Workflow management endpoints — n8n integration."""
 
+import asyncio
 import json
 import logging
 import re
@@ -82,10 +83,11 @@ async def check_workflow_dependencies(deps: list[str], health_cache: dict[str, b
 async def check_n8n_available() -> bool:
     """Check if n8n is responding."""
     try:
-        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
-            async with session.get(f"{N8N_URL}/healthz") as resp:
-                return resp.status < 500
-    except (aiohttp.ClientError, OSError):
+        from helpers import _get_aio_session
+        session = await _get_aio_session()
+        async with session.get(f"{N8N_URL}/healthz") as resp:
+            return resp.status < 500
+    except (aiohttp.ClientError, asyncio.TimeoutError, OSError):
         return False
 
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
@@ -306,10 +306,11 @@ def test_check_n8n_available_success(test_client):
 
     session_mock = AsyncMock()
     session_mock.get = MagicMock(return_value=ctx)
-    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
-    session_mock.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+    async def fake_get_session():
+        return session_mock
+
+    with patch("helpers._get_aio_session", side_effect=fake_get_session):
         import asyncio
         result = asyncio.get_event_loop().run_until_complete(wf_mod.check_n8n_available())
 
@@ -322,10 +323,11 @@ def test_check_n8n_available_failure(test_client):
 
     session_mock = AsyncMock()
     session_mock.get = MagicMock(side_effect=aiohttp.ClientError("refused"))
-    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
-    session_mock.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+    async def fake_get_session():
+        return session_mock
+
+    with patch("helpers._get_aio_session", side_effect=fake_get_session):
         import asyncio
         result = asyncio.get_event_loop().run_until_complete(wf_mod.check_n8n_available())
 
@@ -384,10 +386,11 @@ def test_n8n_status_available(test_client):
 
     session_mock = AsyncMock()
     session_mock.get = MagicMock(return_value=ctx)
-    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
-    session_mock.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+    async def fake_get_session():
+        return session_mock
+
+    with patch("helpers._get_aio_session", side_effect=fake_get_session):
         resp = test_client.get("/api/workflows/n8n/status", headers=test_client.auth_headers)
 
     assert resp.status_code == 200
@@ -400,10 +403,11 @@ def test_n8n_status_unavailable(test_client):
     """GET /api/workflows/n8n/status → 200, returns available=False when n8n is down."""
     session_mock = AsyncMock()
     session_mock.get = MagicMock(side_effect=aiohttp.ClientError("refused"))
-    session_mock.__aenter__ = AsyncMock(return_value=session_mock)
-    session_mock.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
+    async def fake_get_session():
+        return session_mock
+
+    with patch("helpers._get_aio_session", side_effect=fake_get_session):
         resp = test_client.get("/api/workflows/n8n/status", headers=test_client.auth_headers)
 
     assert resp.status_code == 200


### PR DESCRIPTION
## What
Populate previously-null fields in `/api/status` response and fix n8n health check returning false negatives.

## Why
- `model.tokensPerSecond` was hardcoded to `null` despite llama metrics being fetched in the same request
- All service `uptime` values were `null`
- `disk` and `system` keys were missing from the response
- `check_n8n_available()` created a new HTTP session with 3s timeout per call, causing false negatives when n8n was slow to respond

## How
- Populate `model.tokensPerSecond` from already-fetched llama metrics data
- Use `context_size` from llama-server `/props` when available for `contextLength`
- Set service `uptime` to system uptime for healthy services (pragmatic approximation)
- Add `disk` (from `get_disk_usage`) and `system` (hostname + uptime) to response and error fallback
- Refactor `check_n8n_available()` to reuse the shared HTTP session (30s timeout) from `helpers._get_aio_session()`
- Update all 4 n8n-related tests to mock `helpers._get_aio_session` instead of `aiohttp.ClientSession`

## Testing
- `python -m py_compile` passes for all modified files
- All existing tests pass with updated mocks

## Platform Impact
- **macOS / Linux / Windows**: No impact — cross-platform Python primitives only

🤖 Generated with [Claude Code](https://claude.ai/claude-code)