### PR TITLE
fix: use host agent API for privacy-shield toggle and guard unbound variable

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/privacy.py
+++ b/dream-server/extensions/services/dashboard-api/routers/privacy.py
@@ -1,13 +1,16 @@
 """Privacy Shield management endpoints."""
 
 import asyncio
+import json
 import logging
 import os
+import urllib.error
+import urllib.request
 
 import aiohttp
 from fastapi import APIRouter, Depends
 
-from config import SERVICES, INSTALL_DIR
+from config import AGENT_URL, DREAM_AGENT_KEY, SERVICES
 from models import PrivacyShieldStatus, PrivacyShieldToggle
 from security import verify_api_key
 
@@ -23,25 +26,16 @@ async def get_privacy_shield_status(api_key: str = Depends(verify_api_key)):
     shield_port = int(os.environ.get("SHIELD_PORT", str(_ps.get("port", 0))))
     shield_url = f"http://{_ps.get('host', 'privacy-shield')}:{shield_port}"
 
-    container_running = False
-    try:
-        proc = await asyncio.create_subprocess_exec(
-            "docker", "ps", "--filter", "name=dream-privacy-shield", "--format", "{{.Names}}",
-            stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
-        )
-        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
-        container_running = "dream-privacy-shield" in stdout.decode()
-    except (FileNotFoundError, asyncio.TimeoutError, OSError):
-        logger.warning("Failed to check privacy-shield container status")
-
+    # Check health directly — no Docker socket needed
     service_healthy = False
-    if container_running:
-        try:
-            async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=2)) as session:
-                async with session.get(f"{shield_url}/health") as resp:
-                    service_healthy = resp.status == 200
-        except (asyncio.TimeoutError, aiohttp.ClientError):
-            logger.warning("Failed to reach privacy-shield health endpoint")
+    try:
+        async with aiohttp.ClientSession(timeout=aiohttp.ClientTimeout(total=3)) as session:
+            async with session.get(f"{shield_url}/health") as resp:
+                service_healthy = resp.status == 200
+    except (asyncio.TimeoutError, aiohttp.ClientError, OSError):
+        logger.debug("Privacy-shield health check failed")
+
+    container_running = service_healthy
 
     return PrivacyShieldStatus(
         enabled=container_running and service_healthy,
@@ -55,30 +49,28 @@ async def get_privacy_shield_status(api_key: str = Depends(verify_api_key)):
 
 @router.post("/api/privacy-shield/toggle")
 async def toggle_privacy_shield(request: PrivacyShieldToggle, api_key: str = Depends(verify_api_key)):
-    """Enable or disable Privacy Shield."""
+    """Enable or disable Privacy Shield via host agent."""
+    action = "start" if request.enable else "stop"
+
+    def _call_agent():
+        url = f"{AGENT_URL}/v1/extension/{action}"
+        headers = {
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {DREAM_AGENT_KEY}",
+        }
+        data = json.dumps({"service_id": "privacy-shield"}).encode()
+        req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status == 200
+
     try:
-        if request.enable:
-            proc = await asyncio.create_subprocess_exec(
-                "docker", "compose", "up", "-d", "privacy-shield",
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=INSTALL_DIR
-            )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-            if proc.returncode == 0:
-                return {"success": True, "message": "Privacy Shield started. PII scrubbing is now active."}
-            else:
-                return {"success": False, "message": f"Failed to start: {stderr.decode()}"}
-        else:
-            proc = await asyncio.create_subprocess_exec(
-                "docker", "compose", "stop", "privacy-shield",
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE, cwd=INSTALL_DIR
-            )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-            if proc.returncode == 0:
-                return {"success": True, "message": "Privacy Shield stopped."}
-            else:
-                return {"success": False, "message": f"Failed to stop: {stderr.decode()}"}
-    except FileNotFoundError:
-        return {"success": False, "message": "Docker not available", "note": "Running in development mode without Docker"}
+        ok = await asyncio.to_thread(_call_agent)
+        if ok:
+            msg = "Privacy Shield started. PII scrubbing is now active." if request.enable else "Privacy Shield stopped."
+            return {"success": True, "message": msg}
+        return {"success": False, "message": f"Host agent returned failure for {action}"}
+    except urllib.error.URLError:
+        return {"success": False, "message": "Host agent not reachable", "note": "Ensure the dream host agent is running"}
     except asyncio.TimeoutError:
         return {"success": False, "message": "Operation timed out"}
     except OSError:

--- a/dream-server/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_privacy.py
@@ -1,6 +1,7 @@
 """Tests for privacy router endpoints."""
 
 import asyncio
+import urllib.error
 
 import aiohttp
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -34,18 +35,12 @@ def test_privacy_shield_stats_authenticated(test_client):
 
 
 # ---------------------------------------------------------------------------
-# /api/privacy-shield/status — container running + service healthy
+# /api/privacy-shield/status — health-based detection
 # ---------------------------------------------------------------------------
 
 
-def test_privacy_shield_status_container_running_healthy(test_client, monkeypatch):
-    """GET /api/privacy-shield/status with container running and healthy service."""
-    async def _fake_subprocess(*args, **kwargs):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"dream-privacy-shield\n", b""))
-        proc.returncode = 0
-        return proc
-
+def test_privacy_shield_status_healthy(test_client):
+    """GET /api/privacy-shield/status when health endpoint responds 200."""
     resp_mock = AsyncMock()
     resp_mock.status = 200
 
@@ -59,8 +54,7 @@ def test_privacy_shield_status_container_running_healthy(test_client, monkeypatc
     session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
     session_ctx.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess), \
-         patch("routers.privacy.aiohttp.ClientSession", return_value=session_ctx):
+    with patch("routers.privacy.aiohttp.ClientSession", return_value=session_ctx):
         resp = test_client.get("/api/privacy-shield/status", headers=test_client.auth_headers)
 
     assert resp.status_code == 200
@@ -69,15 +63,15 @@ def test_privacy_shield_status_container_running_healthy(test_client, monkeypatc
     assert data["container_running"] is True
 
 
-def test_privacy_shield_status_container_not_running(test_client):
-    """GET /api/privacy-shield/status with no container."""
-    async def _fake_subprocess(*args, **kwargs):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"", b""))
-        proc.returncode = 0
-        return proc
+def test_privacy_shield_status_not_running(test_client):
+    """GET /api/privacy-shield/status when health endpoint fails."""
+    session_mock = MagicMock()
+    session_mock.get = MagicMock(side_effect=aiohttp.ClientError("refused"))
+    session_ctx = AsyncMock()
+    session_ctx.__aenter__ = AsyncMock(return_value=session_mock)
+    session_ctx.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
+    with patch("routers.privacy.aiohttp.ClientSession", return_value=session_ctx):
         resp = test_client.get("/api/privacy-shield/status", headers=test_client.auth_headers)
 
     assert resp.status_code == 200
@@ -87,19 +81,18 @@ def test_privacy_shield_status_container_not_running(test_client):
 
 
 # ---------------------------------------------------------------------------
-# /api/privacy-shield/toggle — enable/disable
+# /api/privacy-shield/toggle — host agent API
 # ---------------------------------------------------------------------------
 
 
-def test_privacy_shield_toggle_enable_success(test_client, monkeypatch):
-    """POST /api/privacy-shield/toggle enable=True → success."""
-    async def _fake_subprocess(*args, **kwargs):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"started\n", b""))
-        proc.returncode = 0
-        return proc
+def test_privacy_shield_toggle_enable_success(test_client):
+    """POST /api/privacy-shield/toggle enable=True → success via host agent."""
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
 
-    with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
+    with patch("routers.privacy.urllib.request.urlopen", return_value=mock_resp):
         resp = test_client.post(
             "/api/privacy-shield/toggle",
             json={"enable": True},
@@ -112,15 +105,14 @@ def test_privacy_shield_toggle_enable_success(test_client, monkeypatch):
     assert "started" in data["message"].lower() or "active" in data["message"].lower()
 
 
-def test_privacy_shield_toggle_disable_success(test_client, monkeypatch):
-    """POST /api/privacy-shield/toggle enable=False → success."""
-    async def _fake_subprocess(*args, **kwargs):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"stopped\n", b""))
-        proc.returncode = 0
-        return proc
+def test_privacy_shield_toggle_disable_success(test_client):
+    """POST /api/privacy-shield/toggle enable=False → success via host agent."""
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
 
-    with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
+    with patch("routers.privacy.urllib.request.urlopen", return_value=mock_resp):
         resp = test_client.post(
             "/api/privacy-shield/toggle",
             json={"enable": False},
@@ -133,15 +125,14 @@ def test_privacy_shield_toggle_disable_success(test_client, monkeypatch):
     assert "stopped" in data["message"].lower()
 
 
-def test_privacy_shield_toggle_enable_failure(test_client, monkeypatch):
-    """POST /api/privacy-shield/toggle enable=True when docker compose fails."""
-    async def _fake_subprocess(*args, **kwargs):
-        proc = MagicMock()
-        proc.communicate = AsyncMock(return_value=(b"", b"compose error"))
-        proc.returncode = 1
-        return proc
+def test_privacy_shield_toggle_agent_failure(test_client):
+    """POST /api/privacy-shield/toggle when host agent returns failure."""
+    mock_resp = MagicMock()
+    mock_resp.status = 500
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
 
-    with patch("asyncio.create_subprocess_exec", side_effect=_fake_subprocess):
+    with patch("routers.privacy.urllib.request.urlopen", return_value=mock_resp):
         resp = test_client.post(
             "/api/privacy-shield/toggle",
             json={"enable": True},
@@ -153,9 +144,10 @@ def test_privacy_shield_toggle_enable_failure(test_client, monkeypatch):
     assert data["success"] is False
 
 
-def test_privacy_shield_toggle_docker_not_found(test_client):
-    """POST /api/privacy-shield/toggle when docker is not installed."""
-    with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError("docker")):
+def test_privacy_shield_toggle_agent_unreachable(test_client):
+    """POST /api/privacy-shield/toggle when host agent is not reachable."""
+    with patch("routers.privacy.urllib.request.urlopen",
+               side_effect=urllib.error.URLError("Connection refused")):
         resp = test_client.post(
             "/api/privacy-shield/toggle",
             json={"enable": True},
@@ -165,12 +157,13 @@ def test_privacy_shield_toggle_docker_not_found(test_client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["success"] is False
-    assert "Docker not available" in data["message"]
+    assert "host agent" in data["message"].lower()
 
 
 def test_privacy_shield_toggle_timeout(test_client):
     """POST /api/privacy-shield/toggle when operation times out."""
-    with patch("asyncio.create_subprocess_exec", side_effect=asyncio.TimeoutError()):
+    with patch("routers.privacy.urllib.request.urlopen",
+               side_effect=asyncio.TimeoutError()):
         resp = test_client.post(
             "/api/privacy-shield/toggle",
             json={"enable": True},
@@ -185,7 +178,8 @@ def test_privacy_shield_toggle_timeout(test_client):
 
 def test_privacy_shield_toggle_os_error(test_client):
     """POST /api/privacy-shield/toggle when OS error occurs."""
-    with patch("asyncio.create_subprocess_exec", side_effect=OSError("broken")):
+    with patch("routers.privacy.urllib.request.urlopen",
+               side_effect=OSError("broken")):
         resp = test_client.post(
             "/api/privacy-shield/toggle",
             json={"enable": True},

--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -30,6 +30,9 @@ if [[ -f "$_FT_DIR/lib/service-registry.sh" ]]; then
     sr_resolve_ports
 fi
 
+# Ensure SERVICE_PORTS is declared even if service-registry.sh was not sourced
+declare -A SERVICE_PORTS 2>/dev/null || true
+
 # Service endpoints — resolved from registry
 LLM_URL="${LLM_URL:-http://localhost:${SERVICE_PORTS[llama-server]:-11434}}"
 WHISPER_URL="${WHISPER_URL:-http://localhost:${SERVICE_PORTS[whisper]:-9000}}"


### PR DESCRIPTION
## What
Replace direct Docker CLI calls in privacy-shield toggle with host agent API and fix unbound variable in functional test script.

## Why
- The privacy-shield toggle used `docker compose up/stop` directly, which requires Docker socket access from inside the container. The dashboard-api container correctly does NOT have Docker socket mounted — container management should go through the host agent API.
- `dream-test-functional.sh` crashed with unbound variable error when `SERVICE_PORTS` associative array was not declared (happens inside the container where `lib/service-registry.sh` is not mounted).

## How
- **Privacy toggle**: Replaced `asyncio.create_subprocess_exec("docker", "compose", ...)` with host agent API calls (`POST {AGENT_URL}/v1/extension/{start|stop}`), matching the existing pattern in `routers/extensions.py:_call_agent()`
- **Privacy status**: Replaced `docker ps` container check with direct health endpoint probe — if the health endpoint responds, the service is running
- **Test script**: Added `declare -A SERVICE_PORTS 2>/dev/null || true` guard before first array access
- Updated all privacy tests to mock the new host agent API path (`urllib.request.urlopen`) instead of the old subprocess path

## Testing
- `python -m py_compile` passes for privacy.py and test_privacy.py
- `shellcheck` passes for dream-test-functional.sh
- `bash -n` syntax check passes

## Platform Impact
- **macOS**: No impact — host agent API is platform-agnostic HTTP
- **Linux**: No impact — same host agent API
- **Windows/WSL2**: No impact — same host agent API

🤖 Generated with [Claude Code](https://claude.ai/claude-code)