### PR TITLE
fix: resolve symlinks in dream-cli SCRIPT_DIR computation

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -17,7 +17,13 @@ fi
 #=============================================================================
 # Configuration
 #=============================================================================
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_source="${BASH_SOURCE[0]}"
+while [[ -L "$_source" ]]; do
+    _dir="$(cd "$(dirname "$_source")" && pwd)"
+    _source="$(readlink "$_source")"
+    [[ "$_source" != /* ]] && _source="$_dir/$_source"
+done
+SCRIPT_DIR="$(cd "$(dirname "$_source")" && pwd)"
 INSTALL_DIR="${DREAM_HOME:-$HOME/dream-server}"
 VERSION="2.0.0"
 


### PR DESCRIPTION
## What
Resolve symlinks before computing `SCRIPT_DIR` in `dream-cli`, so the CLI works when invoked via `/usr/local/bin/dream` symlink.

## Why
`BASH_SOURCE[0]` resolves to the symlink path (`/usr/local/bin/dream`), making `SCRIPT_DIR=/usr/local/bin` instead of `~/dream-server`. Every `dream` command fails because relative path lookups (lib, config, compose files) target the wrong directory.

## How
Replace the single-line `dirname` call with a while loop that follows symlink chains using `readlink` (without `-f`). This is the standard BSD-safe pattern — `readlink -f` is GNU-only and unavailable on macOS.

## Testing
- **Automated:** shellcheck passes (no new warnings)
- **Manual:** Invoke `dream status` via symlink (`/usr/local/bin/dream status`) and directly (`bash ~/dream-server/dream-cli status`) — both should resolve to the correct install directory

## Review
Critique Guardian: **APPROVED** — all five pillars clean.

## Platform Impact
- **macOS:** Uses BSD `readlink` (no `-f`) — explicitly handled
- **Linux:** GNU `readlink` works with this pattern
- **Windows/WSL2:** Same as Linux — GNU userland in WSL2