### PR TITLE
fix: display check IDs in dream doctor and skip non-installed extensions

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1058,7 +1058,7 @@ warnings = []
 if pf_checks:
     print(f"{CYAN}Preflight Checks:{NC}")
     for check in pf_checks:
-        name = check.get('name', 'Unknown')
+        name = check.get('name', check.get('id', 'Unknown'))
         status = check.get('status', 'unknown')
         message = check.get('message', '')
 

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -272,10 +272,14 @@ if runtime["docker_daemon"] and not runtime["webui_http"]:
 # Extension-specific hints
 for ext in ext_diagnostics:
     ext_id = ext.get("id", "unknown")
+    container_state = ext.get("container_state", "unknown")
     issues = ext.get("issues", [])
     for issue in issues:
         if issue == "container_not_running":
-            fix_hints.append(f"Extension {ext_id}: container not running. Run 'dream start {ext_id}'.")
+            if container_state == "not_found":
+                fix_hints.append(f"Extension {ext_id}: not installed (image not built). Skipped by installer or disabled by tier system.")
+            else:
+                fix_hints.append(f"Extension {ext_id}: container not running. Run 'dream start {ext_id}'.")
         elif issue == "health_check_failed":
             fix_hints.append(f"Extension {ext_id}: health check failed. Check logs with 'docker logs dream-{ext_id}'.")
         elif issue == "gpu_backend_incompatible":


### PR DESCRIPTION
## What
Two fixes for `dream doctor` output quality:
1. Preflight checks display their `id` instead of "Unknown"
2. Extensions that were never installed (image not built) get an informational message instead of an actionable "run dream start" hint

## Why
1. The preflight engine (`preflight-engine.sh`) emits checks with `id` field but no `name` field. The Python display code only looked for `name`, so every check showed as "Unknown".
2. When a service is auto-disabled by the tier system (e.g., ComfyUI on Tier 1), its Docker image is never built. Telling users to `dream start comfyui` is misleading — the container cannot start.

## How
1. `dream-cli:1061`: Chain `.get('name', .get('id', 'Unknown'))` — uses `id` as fallback, forward-compatible if `name` is added later.
2. `dream-doctor.sh:275-282`: Check `container_state` field from the diagnostic collector. `not_found` (docker inspect failed) → informational "not installed" message. Otherwise → actionable "dream start" hint.

## Testing
- **Automated:** shellcheck, existing test suites
- **Manual:** Run `dream doctor` on a Tier 1 system — verify check names display correctly and ComfyUI shows "not installed" instead of "Run dream start"

## Review
Critique Guardian: **APPROVED** — full data pipeline trace verified both changes.

## Platform Impact
- **macOS / Linux / WSL2:** Both changes are Python-in-Bash heredocs — platform-agnostic string formatting. No BSD/GNU concerns.