### PR TITLE
fix: prevent double-inclusion of extension compose files in get_compose_flags

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -286,16 +286,21 @@ get_compose_flags() {
     # Fallback: resolve dynamically
     local base_flags
     if [[ -x "$INSTALL_DIR/scripts/resolve-compose-stack.sh" ]]; then
+        # Resolver handles base + GPU overlay + extension compose files
         base_flags=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
             --script-dir "$INSTALL_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}")
+        echo "$base_flags"
     elif [[ -f "$INSTALL_DIR/docker-compose.base.yml" ]]; then
         base_flags="-f docker-compose.base.yml"
+        local ext_flags
+        ext_flags=$(sr_compose_flags)
+        echo "$base_flags $ext_flags"
     else
         base_flags="-f docker-compose.yml"
+        local ext_flags
+        ext_flags=$(sr_compose_flags)
+        echo "$base_flags $ext_flags"
     fi
-    local ext_flags
-    ext_flags=$(sr_compose_flags)
-    echo "$base_flags $ext_flags"
 }
 
 #=============================================================================


### PR DESCRIPTION
## What
Fix `get_compose_flags()` to not append `sr_compose_flags()` when `resolve-compose-stack.sh` is used, preventing extension compose files from being included twice.

## Why
The resolver already discovers and includes all enabled extension compose files (with GPU backend filtering and `.disabled` checks). The function then unconditionally appended `sr_compose_flags()` which added them again — without any filtering. This caused:
- Disabled services (e.g., ComfyUI on Tier 1) to be re-included
- Docker Compose validation warnings about duplicate array entries (e.g., `security_opt`)
- Commands failing when referenced images don't exist

## How
Restructure `get_compose_flags()` so each code path echoes its result directly:
- **Resolver path:** Output from `resolve-compose-stack.sh` is complete — echo it directly
- **Fallback paths** (bare `docker-compose.base.yml` or `docker-compose.yml`): These don't have the resolver, so `sr_compose_flags()` is appended for extension discovery

## Testing
- **Automated:** shellcheck, `docker compose config` validation
- **Manual:** On a Tier 1 system with ComfyUI disabled, run `dream status` — should succeed without ComfyUI-related errors. Run `docker compose config` with the resolved flags — verify no duplicate entries.

## Review
Critique Guardian: **APPROVED** — resolver confirmed to already include extensions with backend filtering.

## Platform Impact
- **macOS / Linux / WSL2:** `resolve-compose-stack.sh` and `sr_compose_flags()` are pure Bash functions — identical behavior across all platforms.