### PR TITLE
fix: add missing n8n workflow JSON template files

### DIFF
--- a/dream-server/config/n8n/01-chat-endpoint.json
+++ b/dream-server/config/n8n/01-chat-endpoint.json
@@ -1,0 +1,33 @@
+{
+  "name": "Chat API Endpoint",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Chat API Endpoint\n\nThis is a template workflow for REST API chat completions.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "chat-endpoint"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/03-voice-transcription.json
+++ b/dream-server/config/n8n/03-voice-transcription.json
@@ -1,0 +1,33 @@
+{
+  "name": "Voice Transcription",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Voice Transcription\n\nThis is a template workflow for transcribing audio files to text.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "voice-transcription"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/05-voice-to-voice.json
+++ b/dream-server/config/n8n/05-voice-to-voice.json
@@ -1,0 +1,33 @@
+{
+  "name": "Voice to Voice",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Voice to Voice\n\nThis is a template workflow for speaking and getting AI response as audio.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "voice-to-voice"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/06-rag-demo.json
+++ b/dream-server/config/n8n/06-rag-demo.json
@@ -1,0 +1,33 @@
+{
+  "name": "RAG Demo",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## RAG Demo\n\nThis is a template workflow for retrieval-augmented generation.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "rag-demo"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/07-code-assistant.json
+++ b/dream-server/config/n8n/07-code-assistant.json
@@ -1,0 +1,33 @@
+{
+  "name": "Code Assistant",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Code Assistant\n\nThis is a template workflow for AI-powered coding help via API.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "code-assistant"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/08-m4-deterministic-voice.json
+++ b/dream-server/config/n8n/08-m4-deterministic-voice.json
@@ -1,0 +1,33 @@
+{
+  "name": "M4 Deterministic Voice",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## M4 Deterministic Voice\n\nThis is a template workflow for intent classification with deterministic routing.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "m4-deterministic-voice"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/daily-digest.json
+++ b/dream-server/config/n8n/daily-digest.json
@@ -1,0 +1,33 @@
+{
+  "name": "Daily Digest",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Daily Digest\n\nThis is a template workflow for summarizing your day every morning.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "daily-digest"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/document-qa.json
+++ b/dream-server/config/n8n/document-qa.json
@@ -1,0 +1,33 @@
+{
+  "name": "Document Q&A",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Document Q&A\n\nThis is a template workflow for uploading documents and asking questions about them.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "document-qa"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/email-to-task.json
+++ b/dream-server/config/n8n/email-to-task.json
@@ -1,0 +1,33 @@
+{
+  "name": "Email-to-Task via LiteLLM",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Email-to-Task via LiteLLM\n\nThis is a template workflow for polling an IMAP mailbox, extracting tasks and priority via LiteLLM, and creating cards in your task manager.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "email-to-task"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/image-gen-webhook.json
+++ b/dream-server/config/n8n/image-gen-webhook.json
@@ -1,0 +1,33 @@
+{
+  "name": "Image Generation on Webhook",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Image Generation on Webhook\n\nThis is a template workflow for accepting a prompt via webhook, optionally enhancing with LLM, submitting to ComfyUI, and returning an image URL.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "image-gen-webhook"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/llm-summarizer.json
+++ b/dream-server/config/n8n/llm-summarizer.json
@@ -1,0 +1,33 @@
+{
+  "name": "LLM Summarizer",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## LLM Summarizer\n\nThis is a template workflow for sending text or URLs to a webhook and getting a concise AI-generated summary.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "llm-summarizer"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/openclaw-agent-trigger.json
+++ b/dream-server/config/n8n/openclaw-agent-trigger.json
@@ -1,0 +1,33 @@
+{
+  "name": "OpenClaw Agent Trigger",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## OpenClaw Agent Trigger\n\nThis is a template workflow for dispatching a goal to a named OpenClaw agent via webhook, streaming tool-call events, and storing the final result.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "openclaw-agent-trigger"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/privacy-shield-test.json
+++ b/dream-server/config/n8n/privacy-shield-test.json
@@ -1,0 +1,33 @@
+{
+  "name": "Privacy-Shield Proxy Test",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Privacy-Shield Proxy Test\n\nThis is a template workflow for sending a test payload through Privacy Shield, verifying PII is redacted, and logging a compliance report.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "privacy-shield-test"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/rag-pipeline-trigger.json
+++ b/dream-server/config/n8n/rag-pipeline-trigger.json
@@ -1,0 +1,33 @@
+{
+  "name": "RAG Pipeline Trigger",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## RAG Pipeline Trigger\n\nThis is a template workflow for ingesting documents from a watched folder into Qdrant, then answering questions over the indexed corpus.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "rag-pipeline-trigger"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/scheduled-web-search.json
+++ b/dream-server/config/n8n/scheduled-web-search.json
@@ -1,0 +1,33 @@
+{
+  "name": "Scheduled Web Search",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Scheduled Web Search\n\nThis is a template workflow for running search queries on a cron schedule, summarizing top results with the LLM, and posting a digest.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "scheduled-web-search"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/voice-memo.json
+++ b/dream-server/config/n8n/voice-memo.json
@@ -1,0 +1,33 @@
+{
+  "name": "Voice Memo",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Voice Memo\n\nThis is a template workflow for recording and transcribing voice memos.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "voice-memo"
+  },
+  "tags": []
+}

--- a/dream-server/config/n8n/whisper-to-notes.json
+++ b/dream-server/config/n8n/whisper-to-notes.json
@@ -1,0 +1,33 @@
+{
+  "name": "Whisper Transcription to Notes",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "start",
+      "name": "Start",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [240, 300]
+    },
+    {
+      "parameters": {
+        "content": "## Whisper Transcription to Notes\n\nThis is a template workflow for uploading audio, transcribing with Whisper, extracting action items with LLM, and saving structured markdown notes.\n\nCustomize the nodes below to match your setup.",
+        "height": 200,
+        "width": 400
+      },
+      "id": "note",
+      "name": "Setup Instructions",
+      "type": "n8n-nodes-base.stickyNote",
+      "typeVersion": 1,
+      "position": [440, 140]
+    }
+  ],
+  "connections": {},
+  "settings": {
+    "executionOrder": "v1"
+  },
+  "meta": {
+    "templateId": "whisper-to-notes"
+  },
+  "tags": []
+}


### PR DESCRIPTION
## What
Add 17 n8n workflow JSON template files under `config/n8n/` that match the pre-existing workflow catalog entries.

## Why
`POST /api/workflows/{id}/enable` fails with "Workflow file not found" for every workflow. The catalog (`catalog.json`) lists 17 workflows as available, but the corresponding JSON files were never included in the repository. The installer packages the config directory, but the workflow files simply didn't exist.

## How
Add 17 minimal starter templates, each containing a ManualTrigger node and a StickyNote with setup instructions. Filenames, `meta.templateId`, and `name` fields match the catalog exactly. Templates are intentionally minimal — they provide a working starting point that users can customize, rather than fully-wired workflows that would need per-install configuration.

### Files Added
`01-chat-endpoint.json`, `03-voice-transcription.json`, `05-voice-to-voice.json`, `06-rag-demo.json`, `07-code-assistant.json`, `08-m4-deterministic-voice.json`, `daily-digest.json`, `document-qa.json`, `email-to-task.json`, `image-gen-webhook.json`, `llm-summarizer.json`, `openclaw-agent-trigger.json`, `privacy-shield-test.json`, `rag-pipeline-trigger.json`, `scheduled-web-search.json`, `voice-memo.json`, `whisper-to-notes.json`

## Testing
- **Automated:** All 17 JSON files validated for parse correctness and catalog mapping (17/17 match)
- **Manual:** Call `POST /api/workflows/chat-endpoint/enable` with n8n running — should import successfully instead of returning 404

## Review
Critique Guardian: **APPROVED** — all filenames, templateIds, and names verified against catalog. Volume mount path confirmed correct.

## Platform Impact
- **macOS / Linux / WSL2:** JSON files are platform-independent. Volume mount (`./config:/dream-server/config:ro`) works identically across all platforms.