### PR TITLE
fix: add load_env to dream stop/start/restart commands

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -523,6 +523,7 @@ cmd_logs() {
 cmd_restart() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
 
     local service="${1:-}"
     local flags_str
@@ -545,6 +546,7 @@ cmd_restart() {
 cmd_stop() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
 
     local service="${1:-}"
     local flags_str
@@ -567,6 +569,7 @@ cmd_stop() {
 cmd_start() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
 
     local service="${1:-}"
     local flags_str


### PR DESCRIPTION
## What
Add `load_env` call to `cmd_stop()`, `cmd_start()`, and `cmd_restart()` in dream-cli before `get_compose_flags()` is called.

## Why
These three commands call `get_compose_flags()` without first loading `.env`. When the `.compose-flags` cache is absent, `GPU_BACKEND` defaults to `nvidia` and `TIER` defaults to `1`, generating wrong compose overlay flags. On AMD/Apple/CPU systems, `docker compose stop` targets the wrong service set and silently "succeeds" without actually stopping anything.

## How
Add `load_env` after `cd "$INSTALL_DIR"` in all three functions, matching the established pattern used by `cmd_chat`, `cmd_benchmark`, and `cmd_agent`.

## Testing
- shellcheck: PASS (no new warnings)
- bash -n: PASS
- test-tier-map.sh: 55/55 PASS
- test-installer-contracts.sh: PASS
- pre-commit hooks: PASS
- Manual: delete `.compose-flags`, run `dream stop/start/restart` on non-NVIDIA system, verify correct compose overlay is used

## Review
Critique Guardian: APPROVED WITH WARNINGS (6 other commands have the same pre-existing bug — tracked separately)

## Platform Impact
- **macOS**: Safe — `load_env` reads `.env` via pure Bash string parsing
- **Linux**: Fixes the bug on AMD/CPU systems
- **Windows/WSL2**: Fixes the bug on AMD/CPU systems