### PR TITLE
fix: preserve .env inode during model swap and env updates

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -46,7 +46,7 @@ _env_set() {
         # Use awk to avoid sed delimiter collisions with values containing | / or =
         awk -v k="$key" -v v="$val" '{
             if (index($0, k "=") == 1) print k "=" v; else print
-        }' "$file" > "${file}.tmp" && mv "${file}.tmp" "$file"
+        }' "$file" > "${file}.tmp" && cat "${file}.tmp" > "$file" && rm -f "${file}.tmp"
     else
         echo "${key}=${val}" >> "$file"
     fi

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -243,9 +243,9 @@ MODELS_INI_EOF
         if [[ "$_BOOTSTRAP_ACTIVE" == "true" ]]; then
             _env_file="$INSTALL_DIR/.env"
             if [[ -f "$_env_file" ]]; then
-                awk -v v="$GGUF_FILE" '{ if (index($0, "GGUF_FILE=") == 1) print "GGUF_FILE=" v; else print }'                     "$_env_file" > "${_env_file}.tmp" && mv "${_env_file}.tmp" "$_env_file"
-                awk -v v="$LLM_MODEL" '{ if (index($0, "LLM_MODEL=") == 1) print "LLM_MODEL=" v; else print }'                     "$_env_file" > "${_env_file}.tmp" && mv "${_env_file}.tmp" "$_env_file"
-                awk -v v="$MAX_CONTEXT" '{ if (index($0, "MAX_CONTEXT=") == 1) print "MAX_CONTEXT=" v; else print }'                     "$_env_file" > "${_env_file}.tmp" && mv "${_env_file}.tmp" "$_env_file"
+                awk -v v="$GGUF_FILE" '{ if (index($0, "GGUF_FILE=") == 1) print "GGUF_FILE=" v; else print }'                     "$_env_file" > "${_env_file}.tmp" && cat "${_env_file}.tmp" > "$_env_file" && rm -f "${_env_file}.tmp"
+                awk -v v="$LLM_MODEL" '{ if (index($0, "LLM_MODEL=") == 1) print "LLM_MODEL=" v; else print }'                     "$_env_file" > "${_env_file}.tmp" && cat "${_env_file}.tmp" > "$_env_file" && rm -f "${_env_file}.tmp"
+                awk -v v="$MAX_CONTEXT" '{ if (index($0, "MAX_CONTEXT=") == 1) print "MAX_CONTEXT=" v; else print }'                     "$_env_file" > "${_env_file}.tmp" && cat "${_env_file}.tmp" > "$_env_file" && rm -f "${_env_file}.tmp"
                 ai_ok "Patched .env for bootstrap model ($GGUF_FILE)"
             fi
         fi

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -84,21 +84,21 @@ if [[ -f "$ENV_FILE" ]]; then
     # Update GGUF_FILE
     if grep -q '^GGUF_FILE=' "$ENV_FILE"; then
         awk -v v="$FULL_GGUF_FILE" '{ if (index($0, "GGUF_FILE=") == 1) print "GGUF_FILE=" v; else print }' \
-            "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+            "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
     fi
     # Update LLM_MODEL
     if grep -q '^LLM_MODEL=' "$ENV_FILE"; then
         awk -v v="$FULL_LLM_MODEL" '{ if (index($0, "LLM_MODEL=") == 1) print "LLM_MODEL=" v; else print }' \
-            "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+            "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
     fi
     # Update MAX_CONTEXT / CTX_SIZE
     if grep -q '^MAX_CONTEXT=' "$ENV_FILE"; then
         awk -v v="$FULL_MAX_CONTEXT" '{ if (index($0, "MAX_CONTEXT=") == 1) print "MAX_CONTEXT=" v; else print }' \
-            "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+            "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
     fi
     if grep -q '^CTX_SIZE=' "$ENV_FILE"; then
         awk -v v="$FULL_MAX_CONTEXT" '{ if (index($0, "CTX_SIZE=") == 1) print "CTX_SIZE=" v; else print }' \
-            "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+            "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
     fi
     log ".env updated"
 else

--- a/dream-server/scripts/mode-switch.sh
+++ b/dream-server/scripts/mode-switch.sh
@@ -32,7 +32,7 @@ env_set() {
     if grep -q "^${key}=" "$ENV_FILE" 2>/dev/null; then
         awk -v k="$key" -v v="$val" '{
             if (index($0, k "=") == 1) print k "=" v; else print
-        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && mv "${ENV_FILE}.tmp" "$ENV_FILE"
+        }' "$ENV_FILE" > "${ENV_FILE}.tmp" && cat "${ENV_FILE}.tmp" > "$ENV_FILE" && rm -f "${ENV_FILE}.tmp"
     else
         echo "${key}=${val}" >> "$ENV_FILE"
     fi

--- a/dream-server/scripts/upgrade-model.sh
+++ b/dream-server/scripts/upgrade-model.sh
@@ -243,7 +243,7 @@ start_llm() {
             # Use awk index() instead of sed to avoid delimiter collisions
             awk -v k="$MODEL_ENV_KEY" -v v="$model" '{
                 if (index($0, k "=") == 1) print k "=" v; else print
-            }' "$env_file" > "${env_file}.tmp" && mv "${env_file}.tmp" "$env_file"
+            }' "$env_file" > "${env_file}.tmp" && cat "${env_file}.tmp" > "$env_file" && rm -f "${env_file}.tmp"
         else
             echo "${MODEL_ENV_KEY}=$model" >> "$env_file"
         fi


### PR DESCRIPTION
## What
Replace `mv tmp .env` with `cat tmp > .env && rm tmp` across all 10 instances in 5 files that modify `.env` at runtime.

## Why
Scripts that update `.env` (model hot-swap, bootstrap upgrade, mode switch, CLI env updates) use `awk > tmp && mv tmp .env`. The `mv` replaces the file with a new inode. Docker bind mounts track the original inode, so `dashboard-api` (which bind-mounts `.env`) continues reading stale bootstrap values after hot-swap — reporting the wrong model, context size, and mode.

## How
`cat tmp > file` overwrites content while preserving the original inode, keeping Docker bind mounts valid. Applied to:
- `scripts/upgrade-model.sh` (1 instance)
- `installers/phases/11-services.sh` (3 instances)
- `scripts/bootstrap-upgrade.sh` (4 instances)
- `scripts/mode-switch.sh` (1 instance)
- `dream-cli` `_env_set()` (1 instance, ~20 call sites)

## Testing
- shellcheck: PASS on all 5 files
- bash -n: PASS on all 5 files
- test-tier-map.sh: 55/55 PASS
- pre-commit hooks: PASS
- Manual: verify inode unchanged after `dream model swap`, `dream mode cloud`, and bootstrap-upgrade completion

## Review
Critique Guardian: APPROVED (re-reviewed after expanding from 4 to 10 instances)

## Platform Impact
- **macOS**: Safe — `cat` redirect is POSIX, works on BSD
- **Linux**: Fixes stale bind mount on Docker
- **Windows/WSL2**: Fixes stale bind mount on Docker Desktop