### PR TITLE
fix: preserve installer VERSION across /etc/os-release sourcing

### DIFF
--- a/dream-server/installers/lib/packaging.sh
+++ b/dream-server/installers/lib/packaging.sh
@@ -26,8 +26,10 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then _SUDO="sudo"; fi
 # Sets: PKG_MANAGER, DISTRO_ID, DISTRO_ID_LIKE
 detect_pkg_manager() {
     if [[ -f /etc/os-release ]]; then
+        local _saved_version="${VERSION:-}"
         # shellcheck source=/dev/null
         source /etc/os-release
+        VERSION="$_saved_version"
         DISTRO_ID="${ID:-unknown}"
         DISTRO_ID_LIKE="${ID_LIKE:-}"
     else

--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -28,7 +28,9 @@ if [[ ! -f /etc/os-release ]]; then
     error "Unsupported OS. This installer requires Linux."
 fi
 
+_installer_version="$VERSION"
 source /etc/os-release
+VERSION="$_installer_version"
 log "Detected OS: $PRETTY_NAME"
 
 # Check for required tools


### PR DESCRIPTION
## What
Save and restore the installer's `VERSION` variable around both `source /etc/os-release` calls that overwrite it.

## Why
`constants.sh` sets `VERSION="2.4.0"`. Two locations source `/etc/os-release` which defines its own `VERSION` (e.g., `"24.04.4 LTS (Noble Numbat)"`), overwriting the installer's value. Phase 06 then writes `DREAM_VERSION=${VERSION}` to `.env` with the OS version. The `/api/update/dry-run` endpoint reads this and reports the OS version instead of the DreamServer version, making version comparison meaningless.

## How
- `installers/lib/packaging.sh`: save/restore `VERSION` inside `detect_pkg_manager()` around `source /etc/os-release`
- `installers/phases/01-preflight.sh`: save/restore `VERSION` around `source /etc/os-release`

Both locations independently source `/etc/os-release` — both need protection. Exhaustive grep confirmed no other unprotected `source /etc/os-release` calls exist (phase 05 uses subshells).

## Testing
- shellcheck: PASS
- bash -n: PASS
- test-installer-contracts.sh: PASS
- test-preflight-fixtures.sh: PASS
- pre-commit hooks: PASS
- Manual: run installer on Linux, verify `grep DREAM_VERSION .env` shows `2.4.0`

## Review
Critique Guardian: APPROVED (confirmed exhaustive search found no other clobber sites)

## Platform Impact
- **macOS**: No impact — macOS doesn't have `/etc/os-release` (guarded at line 27), uses separate installer
- **Linux**: Fixes the bug
- **Windows/WSL2**: Fixes the bug (same Linux installer path)