### PR TITLE
fix: replace bashisms in whisper entrypoint for POSIX sh compatibility

### DIFF
--- a/dream-server/extensions/services/whisper/docker-entrypoint.sh
+++ b/dream-server/extensions/services/whisper/docker-entrypoint.sh
@@ -10,7 +10,7 @@ apply_vad_patch() {
     local stt_file="$1"
     echo "[dream-whisper] Applying VAD patch to $stt_file"
 
-    if [[ ! -f "$stt_file" ]]; then
+    if [ ! -f "$stt_file" ]; then
         echo "[dream-whisper] Warning: STT file not found: $stt_file"
         return 1
     fi
@@ -143,7 +143,7 @@ fi
 
 STT_FILE=$($PYTHON_CMD -c "import speaches.routers.stt as m; print(m.__file__)" 2>/dev/null || true)
 
-if [[ -n "$STT_FILE" ]]; then
+if [ -n "$STT_FILE" ]; then
     # Apply VAD patch with safe multi-line handling
     apply_vad_patch "$STT_FILE"
 else


### PR DESCRIPTION
## What
Replace `[[` with `[` on lines 13 and 146 of `extensions/services/whisper/docker-entrypoint.sh`.

## Why
The script uses `#!/bin/sh` shebang but contains `[[` (a bash-only construct). The whisper container is Debian-based where `/bin/sh` is `dash`, which doesn't recognize `[[`. The test silently fails (treated as falsy), causing the VAD (Voice Activity Detection) patch to never be applied. Container logs show `[[: not found` on every start.

## How
- Line 13: `if [[ ! -f "$stt_file" ]]` → `if [ ! -f "$stt_file" ]`
- Line 146: `if [[ -n "$STT_FILE" ]]` → `if [ -n "$STT_FILE" ]`

Both substitutions are semantically identical for simple `-f` and `-n` tests with quoted variables.

## Testing
- shellcheck --shell=sh: PASS (SC3010 `[[` warnings eliminated)
- dash -n: PASS
- bash -n: PASS
- No remaining bashisms (grep confirmed)
- Manual: `dream start whisper`, check logs for VAD patch application

## Review
Critique Guardian: APPROVED

## Platform Impact
- **macOS**: No impact — whisper requires `gpu_backends: [amd, nvidia]`, not available on Apple Silicon
- **Linux**: Fixes VAD patch application in whisper container
- **Windows/WSL2**: Same fix, same container image