### PR TITLE
fix: use 127.0.0.1 in doctor health curls and check compose flags in dream list

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1303,6 +1303,9 @@ cmd_disable() {
 
 cmd_list() {
     sr_load
+    load_env 2>/dev/null || true
+    local active_flags
+    active_flags=$(get_compose_flags)
     echo -e "${BLUE}━━━ Available Services ━━━${NC}"
     printf "%-20s %-12s %-10s\n" "SERVICE" "CATEGORY" "STATUS"
     printf "%-20s %-12s %-10s\n" "───────" "────────" "──────"
@@ -1312,7 +1315,7 @@ cmd_list() {
         local status
         if [[ "$cat" == "core" ]]; then
             status="always-on"
-        elif [[ -n "$cf" && -f "$cf" ]]; then
+        elif [[ -n "$cf" && -f "$cf" && "$active_flags" == *"${cf#"$INSTALL_DIR/"}"* ]]; then
             status="enabled"
         else
             status="disabled"

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -107,10 +107,10 @@ if command -v docker >/dev/null 2>&1; then
 fi
 
 if command -v curl >/dev/null 2>&1; then
-    if curl -sf --max-time 10 "http://localhost:${_DASHBOARD_PORT}" >/dev/null 2>&1; then
+    if curl -sf --max-time 10 "http://127.0.0.1:${_DASHBOARD_PORT}" >/dev/null 2>&1; then
         DASHBOARD_HTTP="true"
     fi
-    if curl -sf --max-time 10 "http://localhost:${_WEBUI_PORT}" >/dev/null 2>&1; then
+    if curl -sf --max-time 10 "http://127.0.0.1:${_WEBUI_PORT}" >/dev/null 2>&1; then
         WEBUI_HTTP="true"
     fi
 fi
@@ -150,7 +150,7 @@ collect_extension_diagnostics() {
                 local port="${SERVICE_PORTS[$sid]:-0}"
                 local health="${SERVICE_HEALTH[$sid]:-}"
                 if [[ "$port" != "0" && -n "$health" ]]; then
-                    if curl -sf --max-time 5 "http://localhost:${port}${health}" >/dev/null 2>&1; then
+                    if curl -sf --max-time 5 "http://127.0.0.1:${port}${health}" >/dev/null 2>&1; then
                         health_status="healthy"
                     else
                         health_status="unhealthy"


### PR DESCRIPTION
## What
Two fixes in one PR (both relate to accurate service state reporting):

1. **dream-doctor.sh**: Replace `localhost` with `127.0.0.1` in 3 health check curls (lines 110, 113, 153)
2. **dream-cli cmd_list()**: Check compose flags to determine enabled/disabled status instead of just file existence

## Why
1. On systems where `localhost` resolves to `::1` (IPv6), services bound to `127.0.0.1` appear unreachable, causing false negatives in `dream doctor`. This was missed during PR #736 which updated Docker healthcheck definitions but not the doctor script.

2. `cmd_list()` checks if `compose.yaml` exists on disk to determine enabled/disabled. Services excluded by tier/GPU backend still have their `compose.yaml` on disk, so they incorrectly show as "enabled" even though they're not in the active compose stack.

## How
1. Literal string replacement: `localhost` → `127.0.0.1` in curl commands
2. Add `load_env` + `get_compose_flags()` to `cmd_list()`, then check if the service's compose file (normalized to relative path) appears in the active compose flags string

## Testing
- shellcheck: PASS on both files
- bash -n: PASS
- make lint: PASS
- test-doctor-command.sh: 14/14 PASS
- pre-commit hooks: PASS
- Manual: `dream doctor` on IPv6 system; `dream list` with tier-excluded services

## Review
Critique Guardian: APPROVED WITH WARNINGS (doctor hint message at line 268 still uses localhost — tracked separately)

## Platform Impact
- **macOS**: IPv4 fix applies; list fix applies to all platforms
- **Linux**: Both fixes apply
- **Windows/WSL2**: Both fixes apply