### PR TITLE
fix(windows): resolve PS 5.1 parse errors by replacing Unicode em dashes

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -258,7 +258,7 @@ if ($dryRun) {
                 # --extra-models-dir: Lemonade auto-discovers GGUF files in this directory
                 # --no-tray: headless mode (no GUI system tray icon)
                 # --llamacpp vulkan: AMD Vulkan GPU acceleration
-                # Model loads automatically on first chat request — no /api/v1/load needed
+                # Model loads automatically on first chat request -- no /api/v1/load needed
                 Write-AI "Starting Lemonade server..."
                 $modelsDir = Join-Path (Join-Path $installDir "data") "models"
                 $lemonadeArgs = @(
@@ -413,7 +413,7 @@ if ($dryRun) {
         } elseif ($gpuInfo.Backend -eq "amd") {
             $composeFlags += @("-f", "installers/windows/docker-compose.windows-amd.yml")
         } else {
-            # No supported GPU detected (Intel integrated, etc.) — use CPU-only overlay
+            # No supported GPU detected (Intel integrated, etc.) -- use CPU-only overlay
             Write-AIWarn "No supported GPU detected. Using CPU-only inference (slower)."
             $composeFlags += @("-f", "docker-compose.cpu.yml")
         }
@@ -560,7 +560,7 @@ if ($dryRun) {
 
                 # Write a temp wrapper script to avoid Windows/PowerShell quoting
                 # issues. Empty arguments (e.g., SHA256 for some tiers) get lost
-                # during command-line parsing — embedding them in a script file
+                # during command-line parsing -- embedding them in a script file
                 # with bash double-quotes preserves them correctly.
                 $wrapperScript = Join-Path $logDir "bootstrap-run.sh"
                 $wrapperContent = @"

--- a/dream-server/installers/windows/lib/compose-diagnostics.ps1
+++ b/dream-server/installers/windows/lib/compose-diagnostics.ps1
@@ -59,7 +59,7 @@ function Write-DreamComposeDiagnostics {
     )
 
     Write-Chapter "COMPOSE FAILURE DIAGNOSTICS"
-    Write-AI "Phase: $Phase — save this section if you report an issue."
+    Write-AI "Phase: $Phase -- save this section if you report an issue."
     Write-AI "Docs: dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md (section: Docker Compose failed)"
     Write-Host ""
 
@@ -77,7 +77,7 @@ function Write-DreamComposeDiagnostics {
         Write-Host "  --- docker info (first 35 lines) ---" -ForegroundColor DarkGray
         $di = & docker info 2>&1 | ForEach-Object { $_.ToString() }
         if ($di) { $di | Select-Object -First 35 | ForEach-Object { Write-Host "  $_" } }
-        else { Write-Host "  (docker info failed — is Docker Desktop running?)" -ForegroundColor Yellow }
+        else { Write-Host "  (docker info failed -- is Docker Desktop running?)" -ForegroundColor Yellow }
         Write-Host ""
 
         $envArgs = Get-DreamComposeEnvFileArgs -InstallDir $InstallDir

--- a/dream-server/installers/windows/lib/install-report.ps1
+++ b/dream-server/installers/windows/lib/install-report.ps1
@@ -141,7 +141,7 @@ function Write-DreamInstallReport {
     $lines += "Generated: $($report.generated_at)"
     $lines += ""
     $lines += "Privacy"
-    $lines += "- docker compose config output (inside report.json) can include interpolated env values from .env — API keys, tokens, or other secrets. Review and redact before sharing publicly."
+    $lines += "- docker compose config output (inside report.json) can include interpolated env values from .env -- API keys, tokens, or other secrets. Review and redact before sharing publicly."
     $lines += ""
     $lines += "Platform"
     $lines += "- OS: $($report.platform.os_caption) ($($report.platform.os_version), build $($report.platform.os_build))"
@@ -176,7 +176,7 @@ function Write-DreamInstallReport {
     Write-AISuccess "Report generated:"
     Write-AI "  JSON: $jsonPath"
     Write-AI "  Text: $txtPath"
-    Write-AIWarn "compose config in report.json may contain secrets from .env — review before sharing."
+    Write-AIWarn "compose config in report.json may contain secrets from .env -- review before sharing."
     Write-AI "Attach report.json when filing Windows install/runtime issues."
 
     return @{

--- a/dream-server/installers/windows/phases/03-features.ps1
+++ b/dream-server/installers/windows/phases/03-features.ps1
@@ -87,7 +87,7 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
 }
 
 # Tier safety net: disable ComfyUI on Tier 0/1 or CLOUD in non-interactive mode.
-# Interactive mode has its own tier checks in the menu — this catches -NonInteractive.
+# Interactive mode has its own tier checks in the menu -- this catches -NonInteractive.
 if ($nonInteractive -and $enableComfyui -and ($selectedTier -eq "0" -or $selectedTier -eq "1")) {
     $enableComfyui = $false
     Write-AI "ComfyUI auto-disabled for Tier $selectedTier (insufficient RAM for shm_size 8GB)"


### PR DESCRIPTION
## Problem

When running the Windows installer on standard systems (which use PowerShell 5.1 and an ANSI codepage like Windows-1252), it crashes with a parsing error:

`
C:\Users\...\dream-server\installers\windows\lib\compose-diagnostics.ps1:80 character:106
+ ... nfo failed  is Docker Desktop running?)" -ForegroundColor Yellow }
+                                                                        ~
Missing closing ')' in expression.
`

## Cause

The script contained Unicode em dashes (``, U+2014) inside string literals and comments. Because PowerShell 5.1 does not default to UTF-8 without BOM, it reads these as multibyte garbage characters, which breaks its ability to parse the rest of the line (hence the "Missing closing ')'" error).

## Fix

Replaced all instances of the Unicode em dash (``) with the ASCII double-hyphen (`--`) across all `.ps1` files in the Windows installer directory. This ensures the files are syntactically valid regardless of the system's active ANSI codepage.