### PR TITLE
fix(dashboard-api): prevent timeout when fetching extension catalog

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -353,9 +353,11 @@ async def extensions_catalog(
     api_key: str = Depends(verify_api_key),
 ):
     """Get the extensions catalog with computed status."""
-    from helpers import get_all_services
+    from helpers import get_cached_services, get_all_services
 
-    service_list = await get_all_services()
+    service_list = get_cached_services()
+    if service_list is None:
+        service_list = await get_all_services()
     services_by_id = {s.id: s for s in service_list}
 
     extensions = []


### PR DESCRIPTION
The extensions_catalog endpoint previously bypassed the health cache and performed a live ping (get_all_services) of all container endpoints sequentially in the same event loop block. If an optional container was down (e.g., ComfyUI or Whisper), Docker Desktop's virtiofs DNS resolution combined with a request timeout would block the API router for up to 30 seconds.

This caused the dashboard UI to hit a 10s AbortError when switching to the Extensions tab. Fixed by pulling from the low-latency background get_cached_services poller.