### PR TITLE
fix: add load_env to 6 dream-cli commands and use 127.0.0.1 in doctor hint

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -316,6 +316,7 @@ get_compose_flags() {
 cmd_status() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
     sr_load
 
     local flags_str
@@ -333,8 +334,6 @@ cmd_status() {
 
     # Registry-driven health checks (parallel)
     echo -e "${BLUE}━━━ Health Checks ━━━${NC}"
-
-    load_env
 
     # Create temp directory for health check results
     local tmpdir
@@ -513,6 +512,7 @@ cmd_status_json() {
 cmd_logs() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
 
     local service="${1:-}"
     local lines="${2:-100}"
@@ -603,6 +603,7 @@ cmd_start() {
 cmd_dry_run() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
 
     echo -e "${BLUE}━━━ Dream Update — Dry Run ━━━${NC}"
     echo -e "${CYAN}Preview only. No changes will be applied.${NC}"
@@ -744,6 +745,7 @@ cmd_dry_run() {
 cmd_update() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
 
     # Parse flags
     local dry_run="false"
@@ -1269,6 +1271,8 @@ cmd_enable() {
 
 cmd_disable() {
     check_install
+    cd "$INSTALL_DIR"
+    load_env
     sr_load
 
     local input="${1:-}"
@@ -1912,6 +1916,7 @@ cmd_restore() {
 cmd_rollback() {
     check_install
     cd "$INSTALL_DIR"
+    load_env
 
     if [[ ! -f "$INSTALL_DIR/.last-backup-id" ]]; then
         error "No rollback point found. Rollback is only available after a failed update."

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -265,7 +265,7 @@ if runtime["docker_cli"] and not runtime["docker_daemon"]:
 if not runtime["compose_cli"]:
     fix_hints.append("Install Docker Compose v2 plugin (or docker-compose).")
 if runtime["docker_daemon"] and not runtime["dashboard_http"]:
-    fix_hints.append(f"Run installer/start command, then verify dashboard on http://localhost:{dashboard_port}.")
+    fix_hints.append(f"Run installer/start command, then verify dashboard on http://127.0.0.1:{dashboard_port}.")
 if runtime["docker_daemon"] and not runtime["webui_http"]:
     fix_hints.append(f"Verify Open WebUI container and port {webui_port} mapping.")
 


### PR DESCRIPTION
## What
- Add `load_env` before `get_compose_flags` in 6 dream-cli commands: `cmd_status`, `cmd_logs`, `cmd_dry_run`, `cmd_update`, `cmd_disable`, `cmd_rollback`
- Fix last remaining `localhost` reference in dream-doctor.sh Python fix hint (line 268)

## Why
`get_compose_flags()` falls back to `${GPU_BACKEND:-nvidia}` and `${TIER:-1}` when `.compose-flags` cache is absent. Without `load_env` first, AMD/Apple/CPU systems get wrong compose overlays — potentially loading nvidia configs on Apple Silicon or amd configs on NVIDIA.

The `localhost` fix aligns with the project convention (PR #736) to use `127.0.0.1` to avoid IPv6 dual-stack ambiguity.

## How
Follows the exact pattern established in PR #773 (`cmd_stop`/`cmd_start`/`cmd_restart`) and the canonical `cmd_status_json`. Also adds missing `cd "$INSTALL_DIR"` to `cmd_disable` which was the only command lacking it.

## Testing
- `bash -n`: PASS
- `shellcheck`: PASS (no new warnings)
- Secrets scan: PASS
- Critique Guardian: APPROVED

## Platform Impact
- **macOS (Apple Silicon):** Directly benefits — no longer defaults to nvidia overlay
- **Linux (NVIDIA/AMD):** Correct overlay selection when `.compose-flags` absent
- **Windows/WSL2:** Same benefit as Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)