### PR TITLE
fix: tolerate stale .env on re-install and fix bootstrap GPU overlay fallback

### DIFF
--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -390,10 +390,8 @@ if [[ -n "${COMPOSE_FLAGS:-}" ]] && [[ -f "$INSTALL_DIR/.env" ]]; then
     if "$SCRIPT_DIR/scripts/validate-compose-stack.sh" --compose-flags "$COMPOSE_FLAGS" --env-file "$INSTALL_DIR/.env" --quiet >> "$LOG_FILE" 2>&1; then
         ai_ok "Compose stack validated"
     else
-        ai_bad "Compose stack validation failed"
-        ai "Check log file for details: $LOG_FILE"
-        ai "This usually means a service manifest or compose file has syntax errors."
-        exit 1
+        ai "Compose validation found issues (will validate when services start)"
+        log "Compose validation deferred — .env may be stale from a previous install"
     fi
 fi
 

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -131,8 +131,17 @@ if command -v docker &>/dev/null && docker ps --filter name=dream-llama-server -
         read -ra COMPOSE_ARGS <<< "$(cat "$INSTALL_DIR/.compose-flags")"
     elif [[ -f "$INSTALL_DIR/docker-compose.base.yml" ]]; then
         COMPOSE_ARGS=(-f "$INSTALL_DIR/docker-compose.base.yml")
-        [[ -f "$INSTALL_DIR/docker-compose.nvidia.yml" ]] && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.nvidia.yml")
-        [[ -f "$INSTALL_DIR/docker-compose.amd.yml" ]] && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.amd.yml")
+        # Read GPU backend from .env to select the correct overlay
+        _gpu_backend=""
+        if [[ -f "$ENV_FILE" ]]; then
+            _gpu_backend=$(grep -E '^GPU_BACKEND=' "$ENV_FILE" | cut -d= -f2)
+        fi
+        case "${_gpu_backend}" in
+            nvidia) [[ -f "$INSTALL_DIR/docker-compose.nvidia.yml" ]] && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.nvidia.yml") ;;
+            amd)    [[ -f "$INSTALL_DIR/docker-compose.amd.yml" ]]    && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.amd.yml") ;;
+            apple)  [[ -f "$INSTALL_DIR/docker-compose.apple.yml" ]]  && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.apple.yml") ;;
+            # cpu or unknown: base only, no GPU overlay
+        esac
     fi
 
     cd "$INSTALL_DIR" || fail "Cannot cd to $INSTALL_DIR"


### PR DESCRIPTION
## What
Two fixes for installer robustness on re-install and bootstrap hot-swap.

## Why
1. Re-installing over an existing installation fails at phase 02 compose validation when the old `.env` is missing newly-required variables (e.g. `SEARXNG_SECRET`, `OPENCLAW_TOKEN`) that use `:?` syntax in extension compose files.

2. When `.compose-flags` is absent, `bootstrap-upgrade.sh` blindly includes both nvidia and amd GPU overlays. On NVIDIA systems, the AMD overlay's `/dev/dri` device mapping causes `llama-server` to fail on restart.

## How
1. **Phase 02 (02-detection.sh):** Downgrade compose validation failure from fatal to warning on re-install. The `.env` is regenerated in phase 06, and compose is validated implicitly when services start in phase 11.

2. **Bootstrap (bootstrap-upgrade.sh):** Replace blind dual-overlay fallback with GPU-aware detection that reads `GPU_BACKEND` from `.env` and only includes the matching overlay. Handles all 4 backends: nvidia, amd, apple, cpu/unknown.

## Testing
- `bash -n`: PASS
- `shellcheck`: PASS (no new warnings)
- Secrets scan: PASS
- Critique Guardian: APPROVED WITH WARNINGS (Warning 1 fixed in-PR, Warning 2 tracked in yasinBursali/DreamServer#234)

## Platform Impact
- **macOS (Apple Silicon):** `apple` backend handled correctly in case statement, `grep -E`/`cut` are BSD-safe
- **Linux (NVIDIA/AMD):** Correct overlay selection in bootstrap fallback
- **Windows/WSL2:** Directly fixes the `/dev/dri` failure on NVIDIA WSL2

🤖 Generated with [Claude Code](https://claude.com/claude-code)