### PR TITLE
fix: update stale model tier names in dream-cli and fix model current exit code

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1834,13 +1834,14 @@ cmd_model() {
             local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2)
             echo "Current model: ${model:-<not set>}"
             [[ -n "$tier" ]] && echo "Current tier: $tier"
+            return 0
             ;;
         list)
             echo -e "${BLUE}━━━ Available Tiers ━━━${NC}"
             echo "  T0         — qwen3.5-2b (< 8GB RAM, any GPU)"
-            echo "  T1         — qwen3-8b (<12GB VRAM)"
-            echo "  T2         — qwen3-8b (12-19GB, larger context)"
-            echo "  T3         — qwen3-14b (20-47GB)"
+            echo "  T1         — qwen3.5-9b (<12GB VRAM)"
+            echo "  T2         — qwen3.5-9b (12-19GB, larger context)"
+            echo "  T3         — qwen3-30b-a3b (20-47GB)"
             echo "  T4         — qwen3-30b-a3b (48GB+)"
             echo "  SH         — qwen3-30b-a3b (Strix Halo unified)"
             echo "  SH_LARGE   — qwen3-coder-next (90GB+ unified)"


### PR DESCRIPTION
## What
Update stale model tier display strings in `dream model list` and fix exit code 1 in `dream model current`.

## Why
T1/T2/T3 display strings were never updated after the Qwen3 → Qwen3.5 model change in tier-map.sh. `dream model current` returned exit code 1 when TIER is unset in .env because `[[ -n "$tier" ]] &&` was the last command under `set -e`.

## How
- Updated T1/T2 from `qwen3-8b` → `qwen3.5-9b`, T3 from `qwen3-14b` → `qwen3-30b-a3b`
- Added `return 0` after conditional tier echo

## Testing
- `bash -n` PASS, shellcheck PASS (pre-existing only)
- Tier strings verified against `installers/lib/tier-map.sh`

## Review
Critique Guardian: ✅ APPROVED

## Platform Impact
- **macOS / Linux / WSL2:** No platform-specific concerns — same `dream-cli` on all platforms

🤖 Generated with [Claude Code](https://claude.ai/code)