### PR TITLE
fix: rename langfuse compose service to match manifest ID convention

### DIFF
--- a/dream-server/extensions/services/langfuse/compose.yaml.disabled
+++ b/dream-server/extensions/services/langfuse/compose.yaml.disabled
@@ -1,5 +1,5 @@
 services:
-  langfuse-web:
+  langfuse:
     image: langfuse/langfuse:3.159.0
     container_name: dream-langfuse-web
     restart: unless-stopped
@@ -279,7 +279,7 @@ services:
     environment:
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PROJECT_PUBLIC_KEY:-}
       - LANGFUSE_SECRET_KEY=${LANGFUSE_PROJECT_SECRET_KEY:-}
-      - LANGFUSE_HOST=http://langfuse-web:3000
+      - LANGFUSE_HOST=http://langfuse:3000
       - LANGFUSE_TRACING_ENABLED=${LANGFUSE_ENABLED:-false}
 
 networks:

--- a/dream-server/extensions/services/langfuse/manifest.yaml
+++ b/dream-server/extensions/services/langfuse/manifest.yaml
@@ -5,7 +5,7 @@ service:
   name: Langfuse (LLM Observability)
   aliases: [observability, traces]
   container_name: dream-langfuse-web
-  default_host: langfuse-web
+  default_host: langfuse
   port: 3000
   external_port_env: LANGFUSE_PORT
   external_port_default: 3006


### PR DESCRIPTION
## What
Rename langfuse compose service from `langfuse-web` to `langfuse` to match the manifest ID convention used by all other extensions.

## Why
`dream start langfuse` failed with "no such service" because the CLI resolves manifest ID → compose service name, and langfuse was the only extension where these didn't match.

## How
- Renamed compose service key `langfuse-web` → `langfuse` in `compose.yaml.disabled`
- Updated `LANGFUSE_HOST` hostname in litellm overlay from `langfuse-web:3000` → `langfuse:3000`
- Updated manifest `default_host` to match
- Container name `dream-langfuse-web` preserved (independent from compose service name)

## Testing
- YAML syntax valid for both files
- Codebase-wide grep confirmed no stale `langfuse-web` references (except intentional `container_name`)

## Review
Critique Guardian: ✅ APPROVED

## Platform Impact
- **macOS / Linux / WSL2:** YAML-only changes, no platform-specific concerns

🤖 Generated with [Claude Code](https://claude.ai/code)