### PR TITLE
fix: pre-create privacy-shield data directory in installer

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -290,6 +290,7 @@ else
     mkdir -p "${INSTALL_DIR}/data/n8n"
     mkdir -p "${INSTALL_DIR}/data/qdrant"
     mkdir -p "${INSTALL_DIR}/data/models"
+    mkdir -p "${INSTALL_DIR}/data/privacy-shield"
     mkdir -p "${INSTALL_DIR}/data/langfuse/postgres"
     mkdir -p "${INSTALL_DIR}/data/langfuse/clickhouse"
     mkdir -p "${INSTALL_DIR}/data/langfuse/redis"

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -39,7 +39,7 @@ else
     # Create directories
     dream_progress 38 "directories" "Creating directory structure"
     mkdir -p "$INSTALL_DIR"/{config,data,models}
-    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models}
+    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield}
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 


### PR DESCRIPTION
## What
Pre-create privacy-shield data directory in both Linux and macOS installers.

## Why
Docker auto-creates bind-mount directories as root when they don't exist, causing `PermissionError` when the privacy-shield container (running as UID 1000) tries to persist `SHIELD_API_KEY` to `/data/shield_api_key`. Without persistence, the API key regenerates on every container restart.

## How
- Added `privacy-shield` to existing `mkdir -p` brace expansion in `06-directories.sh`
- Added `mkdir -p` in macOS `install-macos.sh` matching existing pattern
- Same fix pattern already used for openclaw (which had the same issue)

## Testing
- `bash -n` PASS for both files, shellcheck PASS (pre-existing only)
- Volume mount path verified against `compose.yaml`

## Review
Critique Guardian: ✅ APPROVED

## Platform Impact
- **macOS:** `install-macos.sh` change covers it
- **Linux:** `06-directories.sh` change covers it
- **Windows/WSL2:** Uses Linux installer path (`06-directories.sh`)

🤖 Generated with [Claude Code](https://claude.ai/code)