### PR TITLE
fix: add dream_min version bounds to 15 extension manifests

### DIFF
--- a/dream-server/extensions/services/ape/manifest.yaml
+++ b/dream-server/extensions/services/ape/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: ape
   name: APE (Agent Policy Engine)

--- a/dream-server/extensions/services/comfyui/manifest.yaml
+++ b/dream-server/extensions/services/comfyui/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: comfyui
   name: ComfyUI (Image Generation)

--- a/dream-server/extensions/services/dashboard-api/manifest.yaml
+++ b/dream-server/extensions/services/dashboard-api/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: dashboard-api
   name: Dashboard API (System Status)

--- a/dream-server/extensions/services/dashboard/manifest.yaml
+++ b/dream-server/extensions/services/dashboard/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: dashboard
   name: Dashboard (Control Center)

--- a/dream-server/extensions/services/embeddings/manifest.yaml
+++ b/dream-server/extensions/services/embeddings/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: embeddings
   name: TEI (Embeddings)

--- a/dream-server/extensions/services/langfuse/manifest.yaml
+++ b/dream-server/extensions/services/langfuse/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: langfuse
   name: Langfuse (LLM Observability)

--- a/dream-server/extensions/services/litellm/manifest.yaml
+++ b/dream-server/extensions/services/litellm/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: litellm
   name: LiteLLM (API Gateway)

--- a/dream-server/extensions/services/openclaw/manifest.yaml
+++ b/dream-server/extensions/services/openclaw/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: openclaw
   name: OpenClaw (Agents)

--- a/dream-server/extensions/services/opencode/manifest.yaml
+++ b/dream-server/extensions/services/opencode/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: opencode
   name: OpenCode (IDE)

--- a/dream-server/extensions/services/perplexica/manifest.yaml
+++ b/dream-server/extensions/services/perplexica/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: perplexica
   name: Perplexica (Deep Research)

--- a/dream-server/extensions/services/privacy-shield/manifest.yaml
+++ b/dream-server/extensions/services/privacy-shield/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: privacy-shield
   name: Privacy Shield (PII Protection)

--- a/dream-server/extensions/services/searxng/manifest.yaml
+++ b/dream-server/extensions/services/searxng/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: searxng
   name: SearXNG (Web Search)

--- a/dream-server/extensions/services/token-spy/manifest.yaml
+++ b/dream-server/extensions/services/token-spy/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: token-spy
   name: Token Spy (Usage Monitor)

--- a/dream-server/extensions/services/tts/manifest.yaml
+++ b/dream-server/extensions/services/tts/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: tts
   name: Kokoro (TTS)

--- a/dream-server/extensions/services/whisper/manifest.yaml
+++ b/dream-server/extensions/services/whisper/manifest.yaml
@@ -1,5 +1,8 @@
 schema_version: dream.services.v1
 
+compatibility:
+  dream_min: "2.0.0"
+
 service:
   id: whisper
   name: Whisper (STT)


### PR DESCRIPTION
## What
Add `compatibility.dream_min` version bounds to 15 extension manifests that were missing them.

## Why
15 of 19 manifests lacked `dream_min`, causing `validate-manifests.sh` to report `ok-no-metadata` instead of definitive compatibility status. Project documentation claimed all extensions had this field — now they do.

## How
- Added `compatibility: dream_min: "2.0.0"` to 15 manifests matching the format of the 4 existing ones (llama-server, n8n, open-webui, qdrant)
- Block placed between `schema_version` and `service` — consistent with existing manifests

## Testing
- All 19/19 YAML valid, `validate-manifests.sh` passes with 19 compatible / 0 errors
- Format consistency verified across all files

## Review
Critique Guardian: ✅ APPROVED

## Platform Impact
- **macOS / Linux / WSL2:** YAML metadata only, no runtime impact

🤖 Generated with [Claude Code](https://claude.ai/code)