### PR TITLE
fix: generate GPU assignment JSON for single-GPU NVIDIA systems

### DIFF
--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -109,9 +109,43 @@ fi
 
 log "All services enabled (core install)"
 
-# Early return if single gpu
+# Single GPU — generate a trivial assignment so the dashboard API can map
+# the GPU UUID to services (without this, /api/gpu/detailed shows empty
+# assigned_services).  Multi-GPU systems fall through to the full TUI below.
 if [[ "$GPU_COUNT" -le 1 ]]; then
-    log "Single GPU detected — skipping multi-GPU configuration."
+    if [[ "${GPU_BACKEND:-}" == "nvidia" ]]; then
+        _single_gpu_uuid=$(nvidia-smi --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | sed -n '1p' || true)
+        if [[ -n "$_single_gpu_uuid" ]]; then
+            GPU_ASSIGNMENT_JSON=$(jq -n \
+                --arg uuid "$_single_gpu_uuid" \
+                '{
+                    gpu_assignment: {
+                        version: "1.0",
+                        strategy: "single",
+                        services: {
+                            llama_server: {
+                                gpus: [$uuid],
+                                parallelism: {
+                                    mode: "none",
+                                    tensor_parallel_size: 1,
+                                    pipeline_parallel_size: 1,
+                                    gpu_memory_utilization: 0.95
+                                }
+                            },
+                            whisper:    { gpus: [$uuid] },
+                            comfyui:    { gpus: [$uuid] },
+                            embeddings: { gpus: [$uuid] }
+                        }
+                    }
+                }')
+            log "Single GPU — assignment generated ($_single_gpu_uuid)"
+        else
+            log "Single GPU detected — no NVIDIA UUID available, skipping assignment."
+        fi
+        unset _single_gpu_uuid
+    else
+        log "Single GPU detected — non-NVIDIA backend, skipping GPU assignment."
+    fi
     return
 fi
 


### PR DESCRIPTION
## What
Generate GPU assignment JSON for single-GPU NVIDIA systems so the dashboard API can attribute GPU usage to services.

## Why
The installer skipped `GPU_ASSIGNMENT_JSON` generation for single-GPU systems (early return in phase 03), causing `/api/gpu/detailed` to always show empty `assigned_services`. Reported as WSL2-specific but actually affects all single-GPU NVIDIA installs.

## How
- Generates trivial assignment JSON mapping all GPU-capable services (llama_server, whisper, comfyui, embeddings) to the single detected UUID
- Guarded by `GPU_BACKEND=nvidia` to prevent crashes on AMD/Intel/CPU-only systems
- `|| true` after nvidia-smi pipe for pipefail safety
- `sed -n '1p'` instead of `head -1` for BSD compatibility
- JSON format verified against `gpu.py` consumer chain (`decode_gpu_assignment()` → `_build_uuid_service_map()`)

## Testing
- `bash -n` PASS, shellcheck PASS (pre-existing only)
- JSON structure matches `gpu.py` expectations end-to-end
- Fallback path (non-NVIDIA) logs and returns cleanly

## Review
Critique Guardian: ✅ APPROVED (after GPU_BACKEND guard fix from initial rejection)

## Platform Impact
- **macOS (Apple Silicon):** Not affected — uses different GPU path
- **Linux (NVIDIA):** Primary target — single-GPU assignment now populated
- **Windows/WSL2 (NVIDIA):** Same fix applies

🤖 Generated with [Claude Code](https://claude.ai/code)