### PR TITLE
fix: read CLI version from .env, scan user-extensions, regenerate compose-flags

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -27,7 +27,7 @@ SCRIPT_DIR="$(cd "$(dirname "$_source")" && pwd)"
 INSTALL_DIR="${DREAM_HOME:-$HOME/dream-server}"
 VERSION="2.0.0"
 if [[ -f "$INSTALL_DIR/.env" ]]; then
-    _v=$(awk -F= '/^DREAM_VERSION=/{print $2; exit}' "$INSTALL_DIR/.env" 2>/dev/null) || true
+    _v=$(awk -F= '/^DREAM_VERSION=/{gsub(/^["'"'"']|["'"'"']$/,"",$2); print $2; exit}' "$INSTALL_DIR/.env" 2>/dev/null) || true
     [[ -n "${_v:-}" ]] && VERSION="$_v"
 fi
 

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -98,6 +98,7 @@ user_ext_dir = ext_dir.parent.parent / "data" / "user-extensions"
 if user_ext_dir.exists():
     _all_service_dirs += sorted(user_ext_dir.iterdir())
 
+_seen_ids = set()
 for service_dir in _all_service_dirs:
     if not service_dir.is_dir():
         continue
@@ -125,6 +126,10 @@ for service_dir in _all_service_dirs:
         if not sid:
             print(f'# SKIP: {manifest_path}: missing required "id" field', file=sys.stderr)
             continue
+        if sid in _seen_ids:
+            print(f'# SKIP: {manifest_path}: duplicate service id {sid!r} (built-in takes precedence)', file=sys.stderr)
+            continue
+        _seen_ids.add(sid)
 
         # Validate service ID — must be safe for use as bash associative array key
         if not _re.match(r'^[a-zA-Z0-9_-]+$', sid):


### PR DESCRIPTION
## What
Three `dream-cli` bug fixes bundled to avoid inter-PR merge conflicts (all touch `dream-cli` or its service registry dependency).

## Why
1. **VERSION hardcoded** — `dream-cli` line 22 hardcodes `VERSION="2.0.0"` while `.env` has `DREAM_VERSION=2.4.0`. The help banner and `dream version` show stale version.
2. **CLI ignores user-extensions** — `lib/service-registry.sh` only scans `extensions/services/`, so dashboard-installed extensions in `data/user-extensions/` are invisible to all CLI commands (`dream list`, `dream start`, etc.). The compose resolver already handles both directories.
3. **disable/enable deletes .compose-flags** — `cmd_disable()` and `cmd_enable()` do `rm -f .compose-flags` without regeneration, breaking bootstrap hot-swap and forcing slower dynamic resolution on every subsequent command.

## How
1. Read `DREAM_VERSION` from `.env` via POSIX `awk`, fallback to hardcoded `2.0.0`
2. Extend the Python heredoc in `sr_load()` to also iterate `data/user-extensions/`, mirroring `resolve-compose-stack.sh:210-224`
3. New `_regenerate_compose_flags()` helper calls `resolve-compose-stack.sh` after enable/disable. Added `load_env` to both commands for correct `TIER`/`GPU_BACKEND` resolution.

## Testing
- `bash -n` syntax check on both files — clean
- `shellcheck` on `dream-cli` — no new warnings (30 pre-existing, none on changed lines)
- Python heredoc `ast.parse()` — valid
- No secrets, no unrelated changes

**Manual test steps:**
- `dream version` → shows version from `.env`, not `2.0.0`
- `dream enable/disable <ext>` → `.compose-flags` regenerated, not deleted
- Place manifest in `data/user-extensions/test/manifest.yaml` → `dream list` discovers it
- Remove `DREAM_VERSION` from `.env` → `dream version` falls back to `2.0.0`

## Review
Critique Guardian: **APPROVED**
- Non-blocking note: duplicate service IDs between built-in and user-extensions not deduplicated (low risk)
- Non-blocking note: `cmd_enable` local GPU_BACKEND read now redundant (cleanup candidate)

## Platform Impact
- **macOS**: POSIX `awk` (BSD-safe), Python Path handling (platform-agnostic) — no impact
- **Linux**: Same POSIX `awk` (GNU) — no impact
- **Windows/WSL2**: Same code paths — no impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)