### PR TITLE
fix(installer): re-resolve compose flags in Phase 11 — fixes Tier 0 total failure

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -24,6 +24,19 @@ if $DRY_RUN; then
     log "[DRY RUN] Would start services: $DOCKER_COMPOSE_CMD $COMPOSE_FLAGS up -d"
 else
     cd "$INSTALL_DIR" || exit 1
+
+    # Re-resolve compose flags against the actual install directory.
+    # Phase 03 may have disabled services (e.g., ComfyUI on Tier 0) after
+    # COMPOSE_FLAGS was first set in Phase 02, making the cached value stale.
+    if [[ -x "$INSTALL_DIR/scripts/resolve-compose-stack.sh" ]]; then
+        _refreshed_flags=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
+            --script-dir "$INSTALL_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" 2>/dev/null) || true
+        if [[ -n "$_refreshed_flags" ]]; then
+            COMPOSE_FLAGS="$_refreshed_flags"
+            log "Compose flags refreshed from install directory"
+        fi
+    fi
+
     # Convert COMPOSE_FLAGS string to array for safe word-splitting
     read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
     mkdir -p "$INSTALL_DIR/logs"


### PR DESCRIPTION
## Summary
Fixes the P0 bug where **every Tier 0 install is completely broken** — zero containers start.

## Root cause
`COMPOSE_FLAGS` is resolved once in Phase 02. Phase 03 then disables ComfyUI for Tier 0 (renames `compose.yaml` → `compose.yaml.disabled`). Phase 06 copies the modified tree to INSTALL_DIR. Phase 11 uses the stale flags pointing to a file that no longer exists:

```
open /home/michael/dream-server/extensions/services/comfyui/compose.yaml: no such file or directory
```

## Fix
Re-resolve `COMPOSE_FLAGS` at the start of Phase 11 by re-running `resolve-compose-stack.sh` against the actual INSTALL_DIR filesystem. The resolver already handles `.disabled` files (skips them). Falls back to the cached value if the resolver isn't available.

This also fixes the false "build failed" warnings — those were caused by the same stale compose reference.

## Test plan
- [ ] `--tier 0` install: containers start (ComfyUI excluded)
- [ ] Normal install with ComfyUI enabled: ComfyUI builds and starts
- [ ] `.compose-flags` in INSTALL_DIR does not reference `.disabled` files
- [ ] `bash -n` passes

Closes #792