### PR TITLE
feat(cli): add dream purge command and data-aware disable messages

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1392,7 +1392,7 @@ cmd_purge() {
         error "$service_id is still enabled. Run 'dream disable $service_id' first."
     fi
 
-    # Check if container is still running
+    # Check if container is still running (disable may have failed to stop it)
     local _container="${SERVICE_CONTAINERS[$service_id]:-dream-$service_id}"
     if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${_container}$"; then
         error "$service_id container is still running. Run 'dream stop $service_id' first."

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1347,7 +1347,94 @@ cmd_disable() {
     docker compose "${flags[@]}" stop "$service_id" 2>/dev/null || true
     [[ -f "$cf" ]] && mv "$cf" "${cf}.disabled"
     _regenerate_compose_flags
-    success "$service_id disabled."
+    local _data_dir="$INSTALL_DIR/data/$service_id"
+    if [[ -d "$_data_dir" ]]; then
+        local _data_size
+        _data_size=$(du -sh "$_data_dir" 2>/dev/null | cut -f1)
+        success "$service_id disabled. Data preserved (${_data_size} in data/$service_id). Use 'dream purge $service_id' to delete."
+    else
+        success "$service_id disabled."
+    fi
+}
+
+cmd_purge() {
+    check_install
+    sr_load
+
+    if [[ $# -lt 1 ]]; then
+        error "Usage: dream purge <service>"
+    fi
+
+    local service_id
+    service_id=$(sr_resolve "$1")
+
+    # Validate against known service IDs
+    local _found=false
+    for _sid in "${SERVICE_IDS[@]}"; do
+        if [[ "$_sid" == "$service_id" ]]; then
+            _found=true
+            break
+        fi
+    done
+    if ! $_found; then
+        error "Unknown service: $service_id"
+    fi
+
+    # Block core services
+    local _cat="${SERVICE_CATEGORIES[$service_id]:-optional}"
+    if [[ "$_cat" == "core" ]]; then
+        error "Cannot purge core service data: $service_id"
+    fi
+
+    # Check if service is still enabled (compose.yaml exists = enabled)
+    local _cf="$INSTALL_DIR/extensions/services/$service_id/compose.yaml"
+    if [[ -f "$_cf" ]]; then
+        error "$service_id is still enabled. Run 'dream disable $service_id' first."
+    fi
+
+    # Check if container is still running
+    local _container="${SERVICE_CONTAINERS[$service_id]:-dream-$service_id}"
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${_container}$"; then
+        error "$service_id container is still running. Run 'dream stop $service_id' first."
+    fi
+
+    # Check data directory exists
+    local _data_dir="$INSTALL_DIR/data/$service_id"
+    if [[ ! -d "$_data_dir" ]]; then
+        log "No data directory found for $service_id."
+        return 0
+    fi
+
+    # Show size and confirm
+    local _data_size
+    _data_size=$(du -sh "$_data_dir" 2>/dev/null | cut -f1)
+    warn "This will permanently delete all data for $service_id (${_data_size})."
+    warn "Directory: $_data_dir"
+    log ""
+
+    local _confirm
+    read -p "  Type '$service_id' to confirm deletion: " -r _confirm
+    if [[ "$_confirm" != "$service_id" ]]; then
+        log "Purge cancelled."
+        return 0
+    fi
+
+    # Delete data — try direct rm first, fall back to docker for root-owned files
+    rm -rf "$_data_dir" 2>/dev/null || true
+    if [[ -d "$_data_dir" ]]; then
+        log "Some files are owned by root (created by Docker). Removing via container..."
+        if command -v docker &>/dev/null; then
+            docker run --rm -v "$_data_dir:/purge-target" alpine \
+                sh -c 'rm -rf /purge-target/* /purge-target/.[!.]* 2>/dev/null; true' 2>/dev/null \
+                || warn "Docker cleanup failed (non-fatal)"
+            rm -rf "$_data_dir" 2>/dev/null || true
+        fi
+        if [[ -d "$_data_dir" ]]; then
+            error "Could not fully remove $_data_dir. Try: sudo rm -rf $_data_dir"
+        fi
+    fi
+
+    success "Purged $service_id data (${_data_size} freed)."
 }
 
 cmd_list() {
@@ -2720,6 +2807,7 @@ ${CYAN}Commands:${NC}
   list                List all services and their status
   enable <service>    Enable an extension service
   disable <service>   Disable an extension service
+  purge <service>     Permanently delete service data
   preset <action>     Save/load/list/delete/export/import presets
   mode [local|cloud|hybrid]
                       Switch between local/cloud/hybrid modes
@@ -2836,6 +2924,7 @@ case "${1:-help}" in
     list|ls)     cmd_list ;;
     enable)      shift; cmd_enable "$@" ;;
     disable)     shift; cmd_disable "$@" ;;
+    purge)       shift; cmd_purge "$@" ;;
     preset|p)    shift; cmd_preset "$@" ;;
     mode|m)      shift; cmd_mode "$@" ;;
     model)       shift; cmd_model "$@" ;;


### PR DESCRIPTION
## What
- Add `dream purge <service>` command to permanently delete extension data with type-to-confirm safety
- Update `dream disable` to show preserved data size and hint about purge
- Register purge in command dispatch and help text

## Why
- Users have no way to reclaim disk space from disabled extensions without manual `rm -rf`
- Root-owned files from Docker containers make manual cleanup fail without `sudo`
- `dream disable` gives no indication of data persistence or how to clean up
- Explicit data lifecycle: disable (preserves data) → purge (deletes data)

## How
- **`cmd_purge()`:** Validates service_id against registry (prevents path traversal), blocks core services, requires disabled state, shows size via `du -sh`, requires typing service name to confirm
- **Root-owned files:** Tries `rm -rf` first, falls back to `docker run --rm alpine sh -c 'rm -rf contents'` for Docker-created root-owned files, suggests `sudo` as last resort
- **`cmd_disable()` update:** Checks for `data/$service_id` directory, shows size if present, hints about `dream purge`

## Three Pillars Impact
- **Install Reliability:** No impact — purge is a post-install user action
- **Broad Compatibility:** Uses only POSIX tools (`du -sh`, `read -p`, `rm -rf`). Docker fallback works on Linux and WSL2. All three platforms supported
- **Extension Coherence:** Strengthens data lifecycle by making purge an explicit, confirmed operation that integrates with the existing enable/disable workflow

## New Files
None.

## Modified Files
- `dream-server/dream-cli` — `cmd_purge()`, `cmd_disable()` message, dispatch entry, help text

## Testing
### Automated
- ShellCheck: PASS (exit 0 on extracted function)
- Existing tests: 55 passed, 0 failed (no regression)
- Security review: SERVICE_IDS validation prevents path traversal

### Manual — All Platforms
- [ ] `dream purge` (no args) → usage error
- [ ] `dream purge nonexistent` → "Unknown service"
- [ ] `dream purge dashboard` → "Cannot purge core service data"
- [ ] `dream purge n8n` (enabled) → "still enabled"
- [ ] `dream disable n8n` → shows data size hint
- [ ] `dream purge n8n` → shows size, prompts, type name → success
- [ ] Wrong confirmation text → cancelled
- [ ] `dream purge n8n` (already purged) → "No data directory found"
- [ ] `dream help` → lists purge command

### Manual — Linux-specific
- [ ] Root-owned files in data dir → Docker fallback succeeds
- [ ] Docker not running → suggests `sudo rm -rf`

## Review
- CG: ✅ APPROVED (after Docker fallback fix — rm-rf logic corrected, EBUSY warning resolved)
- Compatibility: PASS (all tools portable across BSD/GNU)
- Security: PASS (registry validation, no confirmation bypass, core service guard)

## Platform Impact
- **macOS (Apple Silicon):** Fully supported
- **Linux:** Fully supported — Docker fallback for root-owned files
- **Windows (WSL2):** Fully supported — Docker Desktop fallback