### PR TITLE
fix(installer): re-resolve compose flags after Phase 3 feature selection

### DIFF
--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -91,6 +91,18 @@ else
 fi
 unset _comfyui_compose
 
+# Re-resolve compose flags now that feature selection may have disabled services.
+# Without this, Phases 4-11 use stale flags from Phase 2 that reference files
+# which were just renamed to .disabled.
+if [[ -x "$SCRIPT_DIR/scripts/resolve-compose-stack.sh" ]]; then
+    _refreshed_flags=$("$SCRIPT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" 2>/dev/null) || true
+    if [[ -n "$_refreshed_flags" ]]; then
+        COMPOSE_FLAGS="$_refreshed_flags"
+        log "Compose flags refreshed after feature selection"
+    fi
+fi
+
 # All services are core — no profiles needed (compose profiles removed)
 
 # Select tier-appropriate OpenClaw config


### PR DESCRIPTION
## Summary
Completes the compose flags race condition fix from PR #793. Phase 8 (image pulls) still used stale flags from Phase 2, causing unnecessary image pulls for disabled services (e.g., ComfyUI on Tier 0). This added wasted time on .213 installs.

## Fix
Re-resolve `COMPOSE_FLAGS` at the end of Phase 3, right after ComfyUI compose files are renamed based on feature selection. Uses `$SCRIPT_DIR` (not `$INSTALL_DIR`) because Phase 6 hasn't copied files yet. The Phase 11 re-resolve from #793 stays as a safety net.

## Test plan
- [ ] Tier 0 install: Phase 8 does NOT pull ComfyUI images
- [ ] Normal install with ComfyUI: Phase 8 pulls ComfyUI images correctly
- [ ] `bash -n` passes

Closes #798