### PR TITLE
fix(windows): auto-install NVIDIA Container Toolkit when GPU passthrough fails

### DIFF
--- a/dream-server/installers/windows/phases/05-docker.ps1
+++ b/dream-server/installers/windows/phases/05-docker.ps1
@@ -114,11 +114,63 @@ if ($dryRun) {
             Write-AISuccess "NVIDIA GPU passthrough confirmed in Docker"
             $script:gpuPassthroughFailed = $false
         } else {
-            Write-AIWarn "NVIDIA GPU passthrough smoke test failed (exit: $gpuTestExit)."
-            Write-AI "  Installer will fall back to CPU-only inference."
-            Write-AI "  To fix GPU passthrough later, restart Docker Desktop and WSL:"
-            Write-AI "  wsl --shutdown && docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi"
-            $script:gpuPassthroughFailed = $true
+            # Attempt automatic recovery before falling back to CPU
+            Write-AIWarn "GPU passthrough test failed. Attempting automatic fix..."
+
+            # Step 1: WSL kernel refresh (fixes post-driver-update staleness)
+            Write-AI "  Restarting WSL2 kernel..."
+            & wsl --shutdown 2>$null
+            Start-Sleep -Seconds 5
+
+            $ErrorActionPreference = "SilentlyContinue"
+            $retryOutput = & docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi 2>&1
+            $retryExit = $LASTEXITCODE
+            $ErrorActionPreference = $prevEAP
+
+            if ($retryExit -eq 0) {
+                Write-AISuccess "GPU passthrough recovered after WSL restart"
+                $script:gpuPassthroughFailed = $false
+            } else {
+                # Step 2: Install NVIDIA Container Toolkit in WSL2
+                Write-AI "  Installing NVIDIA Container Toolkit in WSL2..."
+                $toolkitScript = @'
+set -e
+if command -v nvidia-ctk &>/dev/null; then
+    echo "NVIDIA Container Toolkit already installed"
+    exit 0
+fi
+distribution=$(. /etc/os-release; echo ${ID}${VERSION_ID})
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | \
+    sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg 2>/dev/null
+curl -s -L "https://nvidia.github.io/libnvidia-container/${distribution}/libnvidia-container.list" | \
+    sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list >/dev/null
+sudo apt-get update -qq
+sudo apt-get install -y -qq nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+'@
+                $toolkitScript | & wsl bash 2>&1 | ForEach-Object { Write-Host "    $_" }
+
+                # Restart WSL to pick up the new runtime config
+                & wsl --shutdown 2>$null
+                Start-Sleep -Seconds 5
+
+                # Step 3: Final retry
+                $ErrorActionPreference = "SilentlyContinue"
+                $finalOutput = & docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi 2>&1
+                $finalExit = $LASTEXITCODE
+                $ErrorActionPreference = $prevEAP
+
+                if ($finalExit -eq 0) {
+                    Write-AISuccess "GPU passthrough working after toolkit installation"
+                    $script:gpuPassthroughFailed = $false
+                } else {
+                    Write-AIWarn "GPU passthrough still failing after auto-fix attempts."
+                    Write-AI "  Continuing with CPU-only inference (slower)."
+                    Write-AI "  Manual fix: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html"
+                    $script:gpuPassthroughFailed = $true
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
An RTX 5090 with 24GB VRAM silently fell back to CPU mode because the NVIDIA Container Toolkit wasn't installed in WSL2. The Linux installer auto-installs the toolkit (Phase 5, lines 345-420) but the Windows installer just warned and continued with CPU-only inference.

## Root cause
Docker Desktop uses WSL2 under the hood. The NVIDIA Container Toolkit needs to be installed *inside* the WSL2 distro for `docker run --gpus all` to work. The Windows installer detected the GPU via `nvidia-smi` and detected the smoke test failure, but didn't attempt to fix it.

## Fix
Three-step automatic recovery when the Docker GPU smoke test fails:

1. **WSL kernel refresh** — `wsl --shutdown` + retry (fixes stale kernel after driver updates, the cheapest fix)
2. **NVIDIA Container Toolkit install** — installs the toolkit inside WSL2 via `wsl bash` using the same approach as the Linux installer (add NVIDIA repo, `apt-get install nvidia-container-toolkit`, `nvidia-ctk runtime configure`)
3. **Final retry** — if the toolkit install succeeded, restarts WSL2 and retries the smoke test

Only falls back to CPU if all three steps fail. No user prompt — the user has a GPU and wants GPU mode.

## Design decisions
- No interactive prompts. Just fix it.
- Uses `apt-get` — works on Ubuntu/Debian WSL distros (95%+ of Docker Desktop installs). Non-Ubuntu distros fail gracefully and fall back to CPU.
- `wsl --shutdown` is safe — Docker Desktop restarts WSL automatically.
- Matches the Linux installer's toolkit installation pattern.

## Test plan
- [ ] Fresh Windows + NVIDIA GPU + no toolkit in WSL → auto-installs and passes
- [ ] Windows + toolkit already present → smoke test passes first try, auto-fix never runs
- [ ] Windows + no NVIDIA GPU → entire block is skipped (line 105 guard)
- [ ] PowerShell syntax validates cleanly