### PR TITLE
fix(P0): correct NVIDIA CUDA smoke test image tag — fixes GPU falling back to CPU on all Windows installs

### DIFF
--- a/dream-server/docs/DOCKER-DESKTOP-OPTIMIZATION.md
+++ b/dream-server/docs/DOCKER-DESKTOP-OPTIMIZATION.md
@@ -185,7 +185,7 @@ By following these guidelines, you can optimize Docker Desktop for running local
 1. Verify WSL2 backend is enabled
 2. Verify WSL2 integration for Ubuntu is on
 3. Restart Docker Desktop
-4. Test: `docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi`
+4. Test: `docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi`
 
 ### Issue: WSL2 distro won't start
 

--- a/dream-server/docs/WINDOWS-INSTALL-WALKTHROUGH.md
+++ b/dream-server/docs/WINDOWS-INSTALL-WALKTHROUGH.md
@@ -62,7 +62,7 @@ wsl --status
 
 **Verify GPU in Docker:**
 ```powershell
-docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
 ```
 
 ---

--- a/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
+++ b/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
@@ -261,7 +261,7 @@ wsl nvidia-smi
 
 **Symptoms:**
 - `wsl nvidia-smi` works (shows GPU)
-- `docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi` fails
+- `docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi` fails
 
 **Solution:**
 1. Open Docker Desktop
@@ -492,7 +492,7 @@ wsl nvidia-smi
 
 ### 5. Check GPU in Docker
 ```powershell
-docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
 ```
 ✅ Should show the same GPU information
 

--- a/dream-server/docs/WINDOWS-WSL2-GPU-GUIDE.md
+++ b/dream-server/docs/WINDOWS-WSL2-GPU-GUIDE.md
@@ -15,7 +15,7 @@ wsl
 nvidia-smi
 
 # In Docker container
-docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
 ```
 
 All three should show your GPU. If any fail, see troubleshooting below.
@@ -103,7 +103,7 @@ wsl cat /proc/driver/nvidia/version
 
 **Symptoms:**
 - `wsl nvidia-smi` shows GPU ✓
-- `docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi` fails ✗
+- `docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi` fails ✗
 
 **Cause:** Docker Desktop not using WSL2 backend.
 
@@ -242,7 +242,7 @@ Before reporting issues, verify:
 - [ ] Docker Desktop is running
 - [ ] Docker Desktop uses WSL2 backend (Settings → General)
 - [ ] WSL integration enabled for Ubuntu (Settings → Resources → WSL Integration)
-- [ ] `docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi` shows GPU
+- [ ] `docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi` shows GPU
 
 ---
 

--- a/dream-server/docs/WSL2-GPU-TROUBLESHOOTING.md
+++ b/dream-server/docs/WSL2-GPU-TROUBLESHOOTING.md
@@ -40,7 +40,7 @@ nvidia-smi
 
 ### 5. Check GPU in Docker
 ```powershell
-docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
 # Should show GPU info inside container
 ```
 
@@ -244,7 +244,7 @@ nvidia-smi
 wsl -e nvidia-smi
 
 # 3. Docker GPU access
-docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
 
 # 4. llama-server health (after Dream Server starts)
 curl http://localhost:8080/health

--- a/dream-server/extensions/services/comfyui/README.md
+++ b/dream-server/extensions/services/comfyui/README.md
@@ -117,7 +117,7 @@ docker compose logs dream-comfyui --follow
 For NVIDIA:
 ```bash
 # Verify NVIDIA Container Toolkit is installed
-docker run --rm --gpus all nvidia/cuda:12.0-base nvidia-smi
+docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
 ```
 
 For AMD:

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -405,7 +405,7 @@ if ($dryRun) {
                 Write-AIWarn "NVIDIA GPU passthrough unavailable -- falling back to CPU-only inference."
                 Write-AI "  Inference will be slower but functional. To fix GPU passthrough:"
                 Write-AI "  1. Restart Docker Desktop and WSL: wsl --shutdown"
-                Write-AI "  2. Verify: docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi"
+                Write-AI "  2. Verify: docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi"
                 $composeFlags += @("-f", "docker-compose.cpu.yml")
             } else {
                 $composeFlags += @("-f", "docker-compose.nvidia.yml")

--- a/dream-server/installers/windows/phases/05-docker.ps1
+++ b/dream-server/installers/windows/phases/05-docker.ps1
@@ -106,7 +106,7 @@ if ($dryRun) {
         Write-AI "Testing NVIDIA GPU passthrough in Docker (non-fatal)..."
         $prevEAP = $ErrorActionPreference
         $ErrorActionPreference = "SilentlyContinue"
-        $gpuTestOutput = & docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi 2>&1
+        $gpuTestOutput = & docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi 2>&1
         $gpuTestExit = $LASTEXITCODE
         $ErrorActionPreference = $prevEAP
 
@@ -123,7 +123,7 @@ if ($dryRun) {
             Start-Sleep -Seconds 5
 
             $ErrorActionPreference = "SilentlyContinue"
-            $retryOutput = & docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi 2>&1
+            $retryOutput = & docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi 2>&1
             $retryExit = $LASTEXITCODE
             $ErrorActionPreference = $prevEAP
 
@@ -162,7 +162,7 @@ sudo nvidia-ctk runtime configure --runtime=docker
 
                 # Step 3: Final retry
                 $ErrorActionPreference = "SilentlyContinue"
-                $finalOutput = & docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi 2>&1
+                $finalOutput = & docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi 2>&1
                 $finalExit = $LASTEXITCODE
                 $ErrorActionPreference = $prevEAP
 

--- a/ithpipesg
+++ b/ithpipesg
@@ -1,0 +1,1 @@
+  "model": "model",


### PR DESCRIPTION
## Summary
**Every Windows NVIDIA install has been falling back to CPU-only inference because the GPU smoke test uses a Docker image tag that doesn't exist.**

The smoke test runs `docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi`. The tag `12.0-base-ubuntu22.04` does not exist on Docker Hub. The correct tag is `12.0.0-base-ubuntu22.04`.

This means a machine with a working RTX 5090 (24GB VRAM), with the NVIDIA driver, toolkit, and runtime all correctly configured, silently falls back to CPU mode with a 2B model. The GPU sits idle.

## Root cause
A typo in the Docker image tag. `12.0` vs `12.0.0`. The `nvidia/cuda` images on Docker Hub use three-part version numbers.

## Verified
```
$ docker run --rm --gpus all nvidia/cuda:12.0-base-ubuntu22.04 nvidia-smi
Error: not found

$ docker run --rm --gpus all nvidia/cuda:12.0.0-base-ubuntu22.04 nvidia-smi
NVIDIA-SMI 590.62  Driver Version: 592.01  CUDA Version: 13.1
NVIDIA GeForce RTX 5090 Laptop GPU  24463MiB
```

## Fix
Changed `12.0-base-ubuntu22.04` to `12.0.0-base-ubuntu22.04` in:
- Smoke test (`05-docker.ps1` — 3 occurrences: initial test + 2 retries)
- Fallback message (`install-windows.ps1`)
- 6 documentation files

## Test plan
- [ ] Windows NVIDIA install → smoke test passes, uses `docker-compose.nvidia.yml`, gets full GPU inference