### PR TITLE
feat(host-agent): add read-only service logs endpoint for all services

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -219,6 +219,7 @@ def _resolve_container_name(service_id: str) -> str:
         result = subprocess.run(
             ["docker", "ps", "--filter",
              f"label=com.docker.compose.service={service_id}",
+             "--filter", "label=com.docker.compose.project=dream-server",
              "--format", "{{.Names}}"],
             capture_output=True, text=True, timeout=5,
         )
@@ -361,6 +362,9 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "lines": 0,
                 })
                 return
+            if result.returncode != 0:
+                json_response(self, 500, {"error": f"docker logs failed: {(result.stderr or '')[:500]}"})
+                return
             output = result.stdout or result.stderr or ""
             json_response(self, 200, {
                 "service_id": sid,
@@ -370,6 +374,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             })
         except subprocess.TimeoutExpired:
             json_response(self, 503, {"error": "Log fetch timed out"})
+        except Exception as exc:
+            json_response(self, 500, {"error": f"Failed to fetch logs: {exc}"})
 
 
     def _handle_setup_hook(self):


### PR DESCRIPTION
## What
- Add `POST /v1/service/logs` to the host agent for read-only log access to ALL services (core + extensions)
- Add `_resolve_container_name()` using Docker Compose label lookup for accurate name resolution
- Existing `/v1/extension/logs` endpoint is unchanged (backwards compatible)

## Why
- The existing `/v1/extension/logs` returns 403 for core services (llama-server, open-webui, etc.) because `validate_service_id()` blocks them
- Users cannot view core service logs through the dashboard — the Terminal button opens but the fetch fails
- Container name hardcoding (`dream-{service_id}`) fails for `open-webui` whose container is `dream-webui`

## How
- **New endpoint:** `POST /v1/service/logs` with `{"service_id": "...", "tail": N}` — validates format only via `SERVICE_ID_RE`, no core service restriction
- **Container resolution:** `docker ps --filter label=com.docker.compose.service={service_id}` returns actual container name. Falls back to `dream-{service_id}` if lookup fails
- **Safety:** Auth required, tail clamped to 1-500, output truncated to 50KB, read-only (no mutations)

## Three Pillars Impact
- **Install Reliability:** No installer code touched
- **Broad Compatibility:** Standard Docker CLI commands, Compose V1+V2 label format identical
- **Extension Coherence:** Existing `/v1/extension/logs` untouched — additive only

## Modified Files
- `dream-server/bin/dream-host-agent.py` — `_resolve_container_name()`, `_handle_service_logs()`, route in `do_POST`

## Testing
### Automated
- Python compile: PASS

### Manual
- [ ] `curl -X POST -H "Auth..." -d '{"service_id":"open-webui","tail":50}' .../v1/service/logs` — verify logs returned
- [ ] Core service (llama-server) → 200 with logs (NOT 403)
- [ ] Non-existent container → 200 + "Container is not running."
- [ ] `tail: 0` → treated as 1; `tail: 999` → treated as 500
- [ ] No auth → 401
- [ ] Invalid service_id (`../etc`) → 400
- [ ] Existing `/v1/extension/logs` still works for user extensions

## Review
- CG: ✅ APPROVED (clean — no warnings)
- Compatibility: PASS (Docker label lookup, standard CLI)
- Security: PASS (SERVICE_ID_RE prevents injection, auth enforced, read-only)

## Platform Impact
- **macOS:** Supported (host agent present)
- **Linux:** Supported (host agent present)
- **Windows (WSL2):** No host agent — dashboard-api fallback message (handled in follow-up PR)

## Sequence
PR 4 of 7 (Phase 2 — shared infrastructure)