### PR TITLE
feat(dashboard): add data lifecycle feedback and purge capability

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -37,10 +37,9 @@ from security import verify_api_key
 from gpu import get_gpu_info
 from helpers import (
     get_all_services, get_cached_services, set_services_cache,
-    get_disk_usage, get_model_info, get_bootstrap_status,
+    get_disk_usage, dir_size_gb, get_model_info, get_bootstrap_status,
     get_uptime, get_cpu_metrics, get_ram_metrics,
     get_llama_metrics, get_loaded_model, get_llama_context_size,
-    dir_size_gb,
 )
 from agent_monitor import collect_metrics
 

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from config import (
@@ -709,7 +709,7 @@ def enable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
 
 
 @router.post("/api/extensions/{service_id}/disable")
-def disable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
+def disable_extension(service_id: str, include_data_info: bool = Query(True), api_key: str = Depends(verify_api_key)):
     """Disable an enabled extension."""
     _validate_service_id(service_id)
     _assert_not_core(service_id)
@@ -788,13 +788,13 @@ def disable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
         "action": "disabled",
         "restart_required": not agent_ok,
         "dependents_warning": dependents_warning,
-        "data_info": _get_service_data_info(service_id),
+        "data_info": _get_service_data_info(service_id) if include_data_info else None,
         "message": message,
     }
 
 
 @router.delete("/api/extensions/{service_id}")
-def uninstall_extension(service_id: str, api_key: str = Depends(verify_api_key)):
+def uninstall_extension(service_id: str, include_data_info: bool = Query(True), api_key: str = Depends(verify_api_key)):
     """Uninstall a disabled extension."""
     _validate_service_id(service_id)
     _assert_not_core(service_id)
@@ -834,7 +834,7 @@ def uninstall_extension(service_id: str, api_key: str = Depends(verify_api_key))
     return {
         "id": service_id,
         "action": "uninstalled",
-        "data_info": _get_service_data_info(service_id),
+        "data_info": _get_service_data_info(service_id) if include_data_info else None,
         "message": "Extension uninstalled. Docker volumes may remain — run 'docker volume ls' to check.",
         "cleanup_hint": f"To remove orphaned volumes: docker volume ls --filter 'name={service_id}' -q | xargs docker volume rm",
     }

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -282,7 +282,9 @@ def _copytree_safe(src: Path, dst: Path) -> None:
 def _get_service_data_info(service_id: str) -> dict | None:
     """Return data directory info for a service, or None if no data dir exists."""
     from helpers import dir_size_gb  # noqa: PLC0415 — deferred to avoid circular import at module level
-    data_path = Path(DATA_DIR) / service_id
+    data_path = (Path(DATA_DIR) / service_id).resolve()
+    if not data_path.is_relative_to(Path(DATA_DIR).resolve()):
+        return None
     if not data_path.is_dir():
         return None
     size_gb = dir_size_gb(data_path)
@@ -843,7 +845,7 @@ class PurgeRequest(BaseModel):
 
 
 @router.delete("/api/extensions/{service_id}/data")
-async def purge_extension_data(
+def purge_extension_data(
     service_id: str,
     body: PurgeRequest,
     api_key: str = Depends(verify_api_key),
@@ -855,34 +857,35 @@ async def purge_extension_data(
     if service_id in CORE_SERVICE_IDS:
         raise HTTPException(status_code=403, detail="Cannot purge core service data")
 
-    # Check if service is still enabled (built-in or user extension)
-    for check_dir in [Path(EXTENSIONS_DIR) / service_id, USER_EXTENSIONS_DIR / service_id]:
-        if (check_dir / "compose.yaml").exists():
-            raise HTTPException(status_code=400, detail=f"{service_id} is still enabled. Disable it first.")
+    with _extensions_lock():
+        # Check if service is still enabled (built-in or user extension)
+        for check_dir in [Path(EXTENSIONS_DIR) / service_id, USER_EXTENSIONS_DIR / service_id]:
+            if (check_dir / "compose.yaml").exists():
+                raise HTTPException(status_code=400, detail=f"{service_id} is still enabled. Disable it first.")
 
-    data_path = (Path(DATA_DIR) / service_id).resolve()
-    if not data_path.is_relative_to(Path(DATA_DIR).resolve()):
-        raise HTTPException(status_code=400, detail="Invalid data path")
+        data_path = (Path(DATA_DIR) / service_id).resolve()
+        if not data_path.is_relative_to(Path(DATA_DIR).resolve()):
+            raise HTTPException(status_code=400, detail="Invalid data path")
 
-    if not data_path.is_dir():
-        raise HTTPException(status_code=404, detail=f"No data directory found for {service_id}")
+        if not data_path.is_dir():
+            raise HTTPException(status_code=404, detail=f"No data directory found for {service_id}")
 
-    if not body.confirm:
-        raise HTTPException(status_code=400, detail="Confirmation required: set confirm=true")
+        if not body.confirm:
+            raise HTTPException(status_code=400, detail="Confirmation required: set confirm=true")
 
-    from helpers import dir_size_gb  # noqa: PLC0415
-    size_gb = dir_size_gb(data_path)
+        from helpers import dir_size_gb  # noqa: PLC0415
+        size_gb = dir_size_gb(data_path)
 
-    shutil.rmtree(data_path, ignore_errors=True)
+        shutil.rmtree(data_path, ignore_errors=True)
 
-    if data_path.exists():
-        raise HTTPException(status_code=500, detail=f"Could not fully remove {data_path}. Some files may be owned by root.")
+        if data_path.exists():
+            raise HTTPException(status_code=500, detail=f"Could not fully remove data/{service_id}. Some files may be owned by root.")
 
-    return {"id": service_id, "action": "purged", "size_gb_freed": size_gb}
+        return {"id": service_id, "action": "purged", "size_gb_freed": size_gb}
 
 
 @router.get("/api/storage/orphaned")
-async def orphaned_storage(api_key: str = Depends(verify_api_key)):
+def orphaned_storage(api_key: str = Depends(verify_api_key)):
     """Find data directories not belonging to any known service."""
     from helpers import dir_size_gb  # noqa: PLC0415
 

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -18,6 +18,7 @@ from typing import Optional
 
 import yaml
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 
 from config import (
     AGENT_URL, CORE_SERVICE_IDS, DATA_DIR,
@@ -276,6 +277,21 @@ def _ignore_special(directory: str, files: list[str]) -> list[str]:
 def _copytree_safe(src: Path, dst: Path) -> None:
     """Copy directory tree, skipping symlinks and special files."""
     shutil.copytree(src, dst, ignore=_ignore_special)
+
+
+def _get_service_data_info(service_id: str) -> dict | None:
+    """Return data directory info for a service, or None if no data dir exists."""
+    from helpers import dir_size_gb  # noqa: PLC0415 — deferred to avoid circular import at module level
+    data_path = Path(DATA_DIR) / service_id
+    if not data_path.is_dir():
+        return None
+    size_gb = dir_size_gb(data_path)
+    return {
+        "path": f"data/{service_id}",
+        "size_gb": size_gb,
+        "preserved": True,
+        "purge_command": f"dream purge {service_id}",
+    }
 
 
 # --- Host Agent Helpers ---
@@ -770,6 +786,7 @@ def disable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
         "action": "disabled",
         "restart_required": not agent_ok,
         "dependents_warning": dependents_warning,
+        "data_info": _get_service_data_info(service_id),
         "message": message,
     }
 
@@ -815,6 +832,77 @@ def uninstall_extension(service_id: str, api_key: str = Depends(verify_api_key))
     return {
         "id": service_id,
         "action": "uninstalled",
+        "data_info": _get_service_data_info(service_id),
         "message": "Extension uninstalled. Docker volumes may remain — run 'docker volume ls' to check.",
         "cleanup_hint": f"To remove orphaned volumes: docker volume ls --filter 'name={service_id}' -q | xargs docker volume rm",
     }
+
+
+class PurgeRequest(BaseModel):
+    confirm: bool = False
+
+
+@router.delete("/api/extensions/{service_id}/data")
+async def purge_extension_data(
+    service_id: str,
+    body: PurgeRequest,
+    api_key: str = Depends(verify_api_key),
+):
+    """Permanently delete service data directory."""
+    if not _SERVICE_ID_RE.match(service_id):
+        raise HTTPException(status_code=404, detail=f"Invalid service_id: {service_id}")
+
+    if service_id in CORE_SERVICE_IDS:
+        raise HTTPException(status_code=403, detail="Cannot purge core service data")
+
+    # Check if service is still enabled (built-in or user extension)
+    for check_dir in [Path(EXTENSIONS_DIR) / service_id, USER_EXTENSIONS_DIR / service_id]:
+        if (check_dir / "compose.yaml").exists():
+            raise HTTPException(status_code=400, detail=f"{service_id} is still enabled. Disable it first.")
+
+    data_path = (Path(DATA_DIR) / service_id).resolve()
+    if not data_path.is_relative_to(Path(DATA_DIR).resolve()):
+        raise HTTPException(status_code=400, detail="Invalid data path")
+
+    if not data_path.is_dir():
+        raise HTTPException(status_code=404, detail=f"No data directory found for {service_id}")
+
+    if not body.confirm:
+        raise HTTPException(status_code=400, detail="Confirmation required: set confirm=true")
+
+    from helpers import dir_size_gb  # noqa: PLC0415
+    size_gb = dir_size_gb(data_path)
+
+    shutil.rmtree(data_path, ignore_errors=True)
+
+    if data_path.exists():
+        raise HTTPException(status_code=500, detail=f"Could not fully remove {data_path}. Some files may be owned by root.")
+
+    return {"id": service_id, "action": "purged", "size_gb_freed": size_gb}
+
+
+@router.get("/api/storage/orphaned")
+async def orphaned_storage(api_key: str = Depends(verify_api_key)):
+    """Find data directories not belonging to any known service."""
+    from helpers import dir_size_gb  # noqa: PLC0415
+
+    data_path = Path(DATA_DIR)
+    if not data_path.is_dir():
+        return {"orphaned": [], "total_gb": 0}
+
+    # Known system directories that are not service data
+    system_dirs = {"models", "config", "user-extensions", "extensions-library"}
+    known_ids = set(SERVICES.keys()) | system_dirs
+
+    orphaned = []
+    total = 0.0
+    for child in sorted(data_path.iterdir()):
+        if not child.is_dir():
+            continue
+        if child.name in known_ids:
+            continue
+        size = dir_size_gb(child)
+        orphaned.append({"name": child.name, "size_gb": size, "path": f"data/{child.name}"})
+        total += size
+
+    return {"orphaned": orphaned, "total_gb": round(total, 2)}

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -675,6 +675,18 @@ class TestDisableExtension:
         resp = test_client.post("/api/extensions/my-ext/disable")
         assert resp.status_code == 401
 
+    def test_disable_skips_data_info(self, test_client, monkeypatch, tmp_path):
+        """include_data_info=false → data_info is None (skips expensive dir scan)."""
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/disable?include_data_info=false",
+            headers=test_client.auth_headers,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["data_info"] is None
+
 
 # --- Uninstall endpoint ---
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -1,5 +1,6 @@
 """Tests for extensions portal endpoints."""
 
+import contextlib
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -1132,3 +1133,273 @@ class TestSymlinkHandling:
         )
         assert resp.status_code == 400
         assert "symlink" in resp.json()["detail"]
+
+
+# --- Purge extension data ---
+
+
+class TestPurgeExtensionData:
+
+    def test_purge_happy_path(self, test_client, monkeypatch, tmp_path):
+        """Purge succeeds for disabled extension with existing data dir."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+        data_dir = tmp_path / "my-ext"
+        data_dir.mkdir()
+        (data_dir / "some-file.db").write_text("data")
+
+        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()), \
+             patch("helpers.dir_size_gb", return_value=1.5):
+            resp = test_client.request(
+                "DELETE", "/api/extensions/my-ext/data",
+                headers=test_client.auth_headers,
+                json={"confirm": True},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == "my-ext"
+        assert data["action"] == "purged"
+        assert data["size_gb_freed"] == 1.5
+        assert not data_dir.exists()
+
+    def test_purge_400_when_enabled_builtin(self, test_client, monkeypatch, tmp_path):
+        """400 when extension is still enabled (compose.yaml in built-in dir)."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+        # Create compose.yaml in the built-in extensions dir
+        builtin_dir = tmp_path / "builtin" / "my-ext"
+        builtin_dir.mkdir(parents=True)
+        (builtin_dir / "compose.yaml").write_text("version: '3'")
+        # Also need a data dir to get past later checks
+        data_dir = tmp_path / "my-ext"
+        data_dir.mkdir()
+
+        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+            resp = test_client.request(
+                "DELETE", "/api/extensions/my-ext/data",
+                headers=test_client.auth_headers,
+                json={"confirm": True},
+            )
+
+        assert resp.status_code == 400
+        assert "still enabled" in resp.json()["detail"]
+
+    def test_purge_400_when_enabled_user(self, test_client, monkeypatch, tmp_path):
+        """400 when extension is still enabled (compose.yaml in user dir)."""
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+
+        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+            resp = test_client.request(
+                "DELETE", "/api/extensions/my-ext/data",
+                headers=test_client.auth_headers,
+                json={"confirm": True},
+            )
+
+        assert resp.status_code == 400
+        assert "still enabled" in resp.json()["detail"]
+
+    def test_purge_403_core_service(self, test_client, monkeypatch, tmp_path):
+        """403 when trying to purge a core service."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+
+        resp = test_client.request(
+            "DELETE", "/api/extensions/open-webui/data",
+            headers=test_client.auth_headers,
+            json={"confirm": True},
+        )
+
+        assert resp.status_code == 403
+        assert "core service" in resp.json()["detail"].lower()
+
+    def test_purge_404_invalid_id(self, test_client, monkeypatch, tmp_path):
+        """404 for service_id that fails regex validation."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+
+        for bad_id in ["..etc", ".hidden", "UPPERCASE", "-starts-dash"]:
+            resp = test_client.request(
+                "DELETE", f"/api/extensions/{bad_id}/data",
+                headers=test_client.auth_headers,
+                json={"confirm": True},
+            )
+            assert resp.status_code == 404, f"Expected 404 for: {bad_id}"
+
+    def test_purge_404_no_data_dir(self, test_client, monkeypatch, tmp_path):
+        """404 when valid ID but no data directory exists."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+
+        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+            resp = test_client.request(
+                "DELETE", "/api/extensions/my-ext/data",
+                headers=test_client.auth_headers,
+                json={"confirm": True},
+            )
+
+        assert resp.status_code == 404
+        assert "No data directory" in resp.json()["detail"]
+
+    def test_purge_400_confirm_false(self, test_client, monkeypatch, tmp_path):
+        """400 when data exists but confirm is false."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+        data_dir = tmp_path / "my-ext"
+        data_dir.mkdir()
+
+        with patch("routers.extensions._extensions_lock", return_value=contextlib.nullcontext()):
+            resp = test_client.request(
+                "DELETE", "/api/extensions/my-ext/data",
+                headers=test_client.auth_headers,
+                json={"confirm": False},
+            )
+
+        assert resp.status_code == 400
+        assert "Confirmation required" in resp.json()["detail"]
+        # Data dir should still exist
+        assert data_dir.exists()
+
+    def test_purge_path_traversal(self, test_client, monkeypatch, tmp_path):
+        """Path traversal attempts are blocked by regex or path check."""
+        _patch_mutation_config(monkeypatch, tmp_path)
+
+        resp = test_client.request(
+            "DELETE", "/api/extensions/..%2fetc/data",
+            headers=test_client.auth_headers,
+            json={"confirm": True},
+        )
+        # Should fail at regex or Starlette routing level
+        assert resp.status_code in (404, 422)
+
+    def test_purge_requires_auth(self, test_client):
+        """DELETE /api/extensions/{id}/data without auth → 401."""
+        resp = test_client.request(
+            "DELETE", "/api/extensions/my-ext/data",
+            json={"confirm": True},
+        )
+        assert resp.status_code == 401
+
+
+# --- Orphaned storage ---
+
+
+class TestOrphanedStorage:
+
+    def test_orphaned_requires_auth(self, test_client):
+        """GET /api/storage/orphaned without auth → 401."""
+        resp = test_client.get("/api/storage/orphaned")
+        assert resp.status_code == 401
+
+    def test_orphaned_empty_data_dir(self, test_client, monkeypatch, tmp_path):
+        """Empty data dir returns empty orphaned list."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(data_dir))
+        monkeypatch.setattr("routers.extensions.SERVICES", {})
+
+        resp = test_client.get(
+            "/api/storage/orphaned",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["orphaned"] == []
+        assert data["total_gb"] == 0
+
+    def test_orphaned_nonexistent_data_dir(self, test_client, monkeypatch, tmp_path):
+        """Non-existent data dir returns empty orphaned list."""
+        monkeypatch.setattr("routers.extensions.DATA_DIR",
+                            str(tmp_path / "nonexistent"))
+        monkeypatch.setattr("routers.extensions.SERVICES", {})
+
+        resp = test_client.get(
+            "/api/storage/orphaned",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["orphaned"] == []
+        assert data["total_gb"] == 0
+
+    def test_orphaned_excludes_known_services(self, test_client, monkeypatch, tmp_path):
+        """Dirs matching SERVICES keys are not listed as orphaned."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "known-svc").mkdir()
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(data_dir))
+        monkeypatch.setattr("routers.extensions.SERVICES",
+                            {"known-svc": {"host": "localhost", "port": 8080}})
+
+        with patch("helpers.dir_size_gb", return_value=2.0):
+            resp = test_client.get(
+                "/api/storage/orphaned",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["orphaned"] == []
+        assert data["total_gb"] == 0
+
+    def test_orphaned_excludes_system_dirs(self, test_client, monkeypatch, tmp_path):
+        """System dirs (models, config, etc.) are not listed as orphaned."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        for name in ("models", "config", "user-extensions", "extensions-library"):
+            (data_dir / name).mkdir()
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(data_dir))
+        monkeypatch.setattr("routers.extensions.SERVICES", {})
+
+        with patch("helpers.dir_size_gb", return_value=1.0):
+            resp = test_client.get(
+                "/api/storage/orphaned",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["orphaned"] == []
+        assert data["total_gb"] == 0
+
+    def test_orphaned_includes_unknown_dirs(self, test_client, monkeypatch, tmp_path):
+        """Dirs not in SERVICES or system_dirs are listed as orphaned."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "mystery-data").mkdir()
+        (data_dir / "leftover-ext").mkdir()
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(data_dir))
+        monkeypatch.setattr("routers.extensions.SERVICES", {})
+
+        with patch("helpers.dir_size_gb", return_value=3.0):
+            resp = test_client.get(
+                "/api/storage/orphaned",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["orphaned"]) == 2
+        names = [o["name"] for o in data["orphaned"]]
+        assert "mystery-data" in names
+        assert "leftover-ext" in names
+        assert data["orphaned"][0]["size_gb"] == 3.0
+        assert data["total_gb"] == 6.0
+
+    def test_orphaned_skips_files(self, test_client, monkeypatch, tmp_path):
+        """Regular files in data dir are not listed."""
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "some-file.txt").write_text("not a directory")
+        (data_dir / "orphan-dir").mkdir()
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(data_dir))
+        monkeypatch.setattr("routers.extensions.SERVICES", {})
+
+        with patch("helpers.dir_size_gb", return_value=0.5):
+            resp = test_client.get(
+                "/api/storage/orphaned",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["orphaned"]) == 1
+        assert data["orphaned"][0]["name"] == "orphan-dir"
+        assert data["total_gb"] == 0.5

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -738,6 +738,7 @@ class TestMutationPathTraversal:
             ("POST", "/api/extensions/{}/enable"),
             ("POST", "/api/extensions/{}/disable"),
             ("DELETE", "/api/extensions/{}"),
+            ("DELETE", "/api/extensions/{}/data"),
         ]
 
         for bad_id in bad_ids:

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -748,6 +748,12 @@ class TestMutationPathTraversal:
                     resp = test_client.post(
                         url, headers=test_client.auth_headers,
                     )
+                elif "/data" in pattern:
+                    # Purge endpoint requires a JSON body (PurgeRequest)
+                    resp = test_client.request(
+                        "DELETE", url, headers=test_client.auth_headers,
+                        json={"confirm": False},
+                    )
                 else:
                     resp = test_client.delete(
                         url, headers=test_client.auth_headers,

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -37,6 +37,10 @@ const friendlyError = (detail) => {
     return 'This extension is already disabled.'
   if (detail.includes('Disable extension before'))
     return 'Please disable this extension before removing it.'
+  if (detail.includes('still enabled'))
+    return 'Please disable this extension before purging its data.'
+  if (detail.includes('No data directory'))
+    return 'No data directory found for this extension.'
   if (detail.includes('Missing dependencies'))
     return detail
   return detail
@@ -104,17 +108,31 @@ export default function Extensions() {
     try {
       const url = action === 'uninstall'
         ? `/api/extensions/${serviceId}`
+        : action === 'purge'
+        ? `/api/extensions/${serviceId}/data`
         : `/api/extensions/${serviceId}/${action}`
-      const res = await fetch(url, {
-        method: action === 'uninstall' ? 'DELETE' : 'POST',
+      const opts = {
+        method: action === 'uninstall' || action === 'purge' ? 'DELETE' : 'POST',
         signal: AbortSignal.timeout(120000),
-      })
+      }
+      if (action === 'purge') {
+        opts.headers = { 'Content-Type': 'application/json' }
+        opts.body = JSON.stringify({ confirm: true })
+      }
+      const res = await fetch(url, opts)
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
         throw new Error(err.detail || `Failed to ${action}`)
       }
       const data = await res.json()
-      const successText = data.message || (action === 'uninstall' ? 'Extension removed' : `Extension ${action}d`)
+      let successText = data.message || (
+        action === 'uninstall' ? 'Extension removed' :
+        action === 'purge' ? `Data purged — ${data.size_gb_freed ?? 0} GB freed` :
+        `Extension ${action}d`
+      )
+      if (data.data_info) {
+        successText += ` Data preserved (${data.data_info.size_gb} GB) — purge to remove.`
+      }
       if (data.restart_required) {
         setToast({ type: 'info', text: `${successText} — restart needed to apply.` })
       } else {
@@ -134,6 +152,7 @@ export default function Extensions() {
       enable: `Enable ${ext.name}? The service will be started.`,
       disable: `Disable ${ext.name}? The service will be stopped.`,
       uninstall: `Remove ${ext.name}? You can reinstall it from the library.`,
+      purge: `Permanently delete all data for ${ext.name}? This cannot be undone.`,
     }
     setConfirm({ action, ext, message: messages[action] })
   }
@@ -304,7 +323,7 @@ export default function Extensions() {
         <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setConfirm(null)}>
           <div className="bg-theme-card border border-theme-border rounded-xl p-6 max-w-md mx-4" onClick={e => e.stopPropagation()} role="dialog" aria-modal="true" aria-label="Confirm action">
             <h3 className="text-lg font-semibold text-theme-text mb-2">
-              {confirm.action === 'uninstall' ? 'Remove' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)} Extension
+              {confirm.action === 'uninstall' ? 'Remove' : confirm.action === 'purge' ? 'Purge Data —' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)} Extension
             </h3>
             <p className="text-sm text-theme-text-muted mb-4">{confirm.message}</p>
             <div className="flex justify-end gap-3">
@@ -312,11 +331,11 @@ export default function Extensions() {
               <button
                 onClick={() => handleMutation(confirm.ext.id, confirm.action)}
                 className={`px-4 py-2 text-sm rounded-lg transition-colors ${
-                  confirm.action === 'uninstall' ? 'bg-red-500/20 text-red-300 hover:bg-red-500/30' :
+                  confirm.action === 'uninstall' || confirm.action === 'purge' ? 'bg-red-500/20 text-red-300 hover:bg-red-500/30' :
                   'bg-theme-accent/20 text-theme-accent-light hover:bg-theme-accent/30'
                 }`}
               >
-                {confirm.action === 'uninstall' ? 'Remove' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)}
+                {confirm.action === 'uninstall' ? 'Remove' : confirm.action === 'purge' ? 'Purge' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)}
               </button>
             </div>
           </div>
@@ -453,6 +472,16 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
               className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-theme-card text-red-400 hover:bg-red-500/20 hover:text-red-300 transition-colors disabled:opacity-50"
             >
               {isMutating ? <Loader2 size={12} className="animate-spin" /> : <><Trash2 size={12} /> Remove</>}
+            </button>
+          )}
+          {showRemove && (
+            <button
+              disabled={actionDisabled}
+              title={disabledTitle || 'Permanently delete service data'}
+              onClick={() => onAction(ext, 'purge')}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg bg-theme-card text-amber-400 hover:bg-amber-500/20 hover:text-amber-300 transition-colors disabled:opacity-50"
+            >
+              {isMutating ? <Loader2 size={12} className="animate-spin" /> : <><Database size={12} /> Purge Data</>}
             </button>
           )}
           {isUserExt && status === 'enabled' && (


### PR DESCRIPTION
## What
- Add `data_info` to disable/uninstall API responses showing preserved data size and purge command
- Add `DELETE /api/extensions/{id}/data` purge endpoint with confirm gate
- Add `GET /api/storage/orphaned` for detecting abandoned data directories
- Add Purge Data button to dashboard with data-aware confirmation dialogs

## Why
- Users get no feedback about preserved data when disabling extensions
- No way to reclaim disk space through the dashboard
- Orphaned data from removed extensions wastes disk invisibly
- Mirrors the CLI `dream purge` command (PR 2) in the web UI

## How
- **data_info:** `_get_service_data_info()` scans `data/{service_id}` via `dir_size_gb()`, returns size/path/purge_command or null
- **Purge endpoint:** Validates service_id (regex), blocks core services (403), requires disabled state (400), path traversal prevention (`resolve()` + `is_relative_to()`), requires `{"confirm": true}` in body, measures size before `shutil.rmtree`, verifies removal
- **Orphaned scan:** Iterates `data/` directories, excludes SERVICES keys + system dirs (models, config, user-extensions, extensions-library)
- **UI:** Amber "Purge Data" button for disabled user extensions, red destructive confirmation dialog, data size display after disable/uninstall

## Three Pillars Impact
- **Install Reliability:** No installer changes
- **Broad Compatibility:** Standard Python pathlib + shutil, all platforms
- **Extension Coherence:** Strengthens data lifecycle — disable (preserve) → purge (delete) is now explicit in both CLI and dashboard

## Modified Files
- `dashboard-api/routers/extensions.py` — `_get_service_data_info()`, data_info in responses, purge + orphaned endpoints
- `dashboard/src/pages/Extensions.jsx` — purge button, confirmation dialog, data_info display

## Testing
### Automated
- Python compile: PASS
- Dashboard build: PASS (977ms)
- Existing tests: 173 pass

### Manual
- [ ] Disable extension → response includes `data_info` with size
- [ ] `DELETE /api/extensions/n8n/data` without `confirm: true` → 400
- [ ] `DELETE /api/extensions/dashboard/data` → 403 (core service)
- [ ] `DELETE /api/extensions/n8n/data` (enabled) → 400
- [ ] `DELETE /api/extensions/n8n/data` with `{"confirm": true}` → success + size freed
- [ ] `GET /api/storage/orphaned` → lists dirs not in SERVICES
- [ ] UI: Purge button only visible for disabled user extensions
- [ ] UI: Confirmation dialog shows data size

## Review
- CG: ⚠️ APPROVED WITH WARNINGS (dir scan latency on large dirs — non-blocking)
- Security: PASS (regex + resolve/is_relative_to, confirm gate, core service block)

## Platform Impact
- All platforms supported

## Sequence
PR 7 of 7 (Phase 3). Depends on PR 3 (#804 — dir_size_gb extraction)