### PR TITLE
fix(extensions-library): use Draft7Validator for jsonschema 3.x compat

### DIFF
--- a/resources/dev/extensions-library/validate-manifests.py
+++ b/resources/dev/extensions-library/validate-manifests.py
@@ -62,7 +62,7 @@ def main():
             failed += 1
             continue
 
-        errors = list(jsonschema.Draft202012Validator(schema).iter_errors(data))
+        errors = list(jsonschema.Draft7Validator(schema).iter_errors(data))
         if errors:
             failed += 1
             print(f"FAIL  {service_name}:")


### PR DESCRIPTION
Draft202012Validator requires jsonschema 4.0+, but many systems (including Ubuntu 22.04/24.04) ship jsonschema 3.x by default.

Draft7Validator is available in both versions and validates the same manifest structure correctly.