### PR TITLE
fix(installer): pipefail-safe hostname fallback in phase 13

### DIFF
--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -323,7 +323,7 @@ echo ""
 DASHBOARD_PORT="${SERVICE_PORTS[dashboard]:-3001}"
 WEBUI_PORT="${SERVICE_PORTS[open-webui]:-3000}"
 OPENCLAW_PORT="${SERVICE_PORTS[openclaw]:-7860}"
-LOCAL_IP=$(hostname -I 2>/dev/null | awk '{print $1}')
+LOCAL_IP=$(hostname -I 2>/dev/null | awk '{print $1}' || echo "")
 echo -e "${GRN}──────────────────────────────────────────────────────────────────────────────${NC}"
 echo -e "${BGRN}  YOUR DREAM SERVER IS LIVE${NC}"
 echo -e "${GRN}──────────────────────────────────────────────────────────────────────────────${NC}"


### PR DESCRIPTION
## Summary
- Adds `|| echo ""` fallback to `hostname -I` on line 326 of phase 13-summary
- On Manjaro/Arch (inetutils hostname), `hostname -I` exits with code 64. With `set -euo pipefail`, this kills the installer during the final summary even though installation completed successfully
- Line 38 already had this safe pattern; line 326 did not

## Test plan
- [ ] `bash -n dream-server/installers/phases/13-summary.sh` passes
- [ ] Run installer on Manjaro — phase 13 no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)