### PR TITLE
fix(bootstrap): restart host agent after model hot-swap

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -381,4 +381,17 @@ else
     log "Docker services not running. Config updated — full model will load on next start."
 fi
 
+# ── Phase 6: Restart host agent (if running) ──
+# The host agent may cache stale state — restart it so it picks up the new
+# model config and any updated endpoints.
+if command -v systemctl &>/dev/null && systemctl --user is-active dream-host-agent.service &>/dev/null; then
+    log "Restarting dream-host-agent (systemd)..."
+    systemctl --user restart dream-host-agent.service 2>&1 || \
+        log "WARNING: Could not restart host agent (non-fatal)"
+elif [[ -f "$HOME/Library/LaunchAgents/com.dreamserver.host-agent.plist" ]]; then
+    log "Restarting dream-host-agent (launchctl)..."
+    launchctl kickstart -k "gui/$(id -u)/com.dreamserver.host-agent" 2>&1 || \
+        log "WARNING: Could not restart host agent (non-fatal)"
+fi
+
 log "Bootstrap upgrade complete."


### PR DESCRIPTION
## What
Add a host agent restart at the end of `bootstrap-upgrade.sh` after the model hot-swap completes.

## Why
After `bootstrap-upgrade.sh` swaps to the full model, the host agent keeps running old code. New endpoints (container stats, service logs) are unreachable — the dashboard shows null for container metrics.

## How
Detect the host agent platform and restart non-fatally:
- **Linux/WSL2:** `systemctl --user restart dream-host-agent.service`
- **macOS:** `launchctl kickstart -k gui/$(id -u)/com.dreamserver.host-agent`

Restart failure is logged as a warning — it does not block the upgrade.

## Testing
- `shellcheck` passes cleanly
- `bash -n` syntax check passes
- Manual: run bootstrap-upgrade on Linux, verify host agent PID changes
- Manual: run bootstrap-upgrade on macOS, verify agent restarts

## Review
Critique Guardian: APPROVED (clean across all five pillars)

## Platform Impact
- **macOS:** Uses `launchctl kickstart -k` (macOS 10.10+, all Apple Silicon Macs)
- **Linux:** Uses `systemctl --user restart` (all systemd distros)
- **Windows/WSL2:** Same systemd path as Linux (WSL2 Ubuntu 22.04+)