### PR TITLE
fix: replace grep -oP with POSIX-compatible alternatives for macOS

### DIFF
--- a/dream-server/extensions/services/token-spy/session-manager.sh
+++ b/dream-server/extensions/services/token-spy/session-manager.sh
@@ -73,7 +73,7 @@ clean_inactive() {
   [ -f "$sessions_json" ] || return 0
 
   local active_ids
-  active_ids=$(grep -oP '"sessionId":\s*"\K[^"]+' "$sessions_json" 2>/dev/null || true)
+  active_ids=$(sed -n 's/.*"sessionId":[[:space:]]*"\([^"]*\)".*/\1/p' "$sessions_json" 2>/dev/null || true)
 
   for f in "$sessions_dir"/*.jsonl; do
     [ -f "$f" ] || continue
@@ -192,7 +192,7 @@ manage_remote_agent() {
     echo "SESSION_LIST_END"
     if [ -f "\$SESSIONS_DIR/sessions.json" ]; then
       echo "ACTIVE_IDS_START"
-      grep -oP '"sessionId":\s*"\K[^"]+' "\$SESSIONS_DIR/sessions.json" 2>/dev/null || true
+      sed -n 's/.*"sessionId":[[:space:]]*"\([^"]*\)".*/\1/p' "\$SESSIONS_DIR/sessions.json" 2>/dev/null || true
       echo "ACTIVE_IDS_END"
     fi
     echo "TOTAL_SIZE=\$(du -sb "\$SESSIONS_DIR" 2>/dev/null | cut -f1)"

--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -157,7 +157,8 @@ if [[ "$OS" == "linux" || "$OS" == "wsl" ]]; then
         if [[ -n "$GPU_INFO" ]]; then
             success "NVIDIA GPU detected: $GPU_INFO"
             # Extract VRAM in MB and check minimum
-            VRAM_MB=$(echo "$GPU_INFO" | grep -oP '\d+(?= MiB)' || echo "0")
+            VRAM_MB=$(echo "$GPU_INFO" | sed -n 's/.*[^0-9]\([0-9][0-9]*\) MiB.*/\1/p')
+            VRAM_MB=${VRAM_MB:-0}
             if [[ "$VRAM_MB" -lt 8192 ]]; then
                 warn "GPU has less than 8GB VRAM. Some models may not fit."
                 echo "  Consider using a smaller model (7B) or cloud fallback."

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -103,7 +103,7 @@ detect_gpu() {
             GPU_NAME=$(echo "$GPU_INFO" | head -1 | cut -d',' -f1 | xargs)
             GPU_COUNT=$(echo "$GPU_INFO" | wc -l)
             # Sum VRAM across all GPUs (each line = one GPU)
-            GPU_VRAM=$(echo "$GPU_INFO" | cut -d',' -f2 | grep -oP '\d+' | awk '{s+=$1} END {print s+0}')
+            GPU_VRAM=$(echo "$GPU_INFO" | cut -d',' -f2 | grep -oE '[0-9]+' | awk '{s+=$1} END {print s+0}')
             # Extract PCI device ID from first GPU
             local pci_id
             pci_id=$(nvidia-smi --query-gpu=pci.device_id --format=csv,noheader 2>/dev/null | head -1 | xargs)
@@ -221,7 +221,7 @@ fix_nvidia_secure_boot() {
     # Step 2: Ensure a driver package is installed
     local installed_driver
     installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>/dev/null \
-                       | grep -oP 'nvidia-driver-\K\d+' | sort -n | tail -1 || true)
+                       | sed -n 's/.*nvidia-driver-\([0-9][0-9]*\).*/\1/p' | sort -n | tail -1 || true)
 
     if [[ -z "$installed_driver" ]]; then
         ai "No NVIDIA driver package found. Installing recommended driver..."
@@ -232,7 +232,7 @@ fix_nvidia_secure_boot() {
             sudo apt-get install -y "nvidia-driver-${MIN_DRIVER_VERSION}" 2>>"$LOG_FILE" || true
         fi
         installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>/dev/null \
-                           | grep -oP 'nvidia-driver-\K\d+' | sort -n | tail -1 || true)
+                           | sed -n 's/.*nvidia-driver-\([0-9][0-9]*\).*/\1/p' | sort -n | tail -1 || true)
         if [[ -z "$installed_driver" ]]; then
             ai_bad "Failed to install NVIDIA driver."
             return 1

--- a/dream-server/installers/phases/10-amd-tuning.sh
+++ b/dream-server/installers/phases/10-amd-tuning.sh
@@ -187,7 +187,7 @@ GTT_EOF
                 ai "  sudo systemctl enable --now tuned && sudo tuned-adm profile accelerator-performance"
             fi
         else
-            active_profile=$(tuned-adm active 2>/dev/null | grep -oP 'Current active profile: \K.*' || true)
+            active_profile=$(tuned-adm active 2>/dev/null | sed -n 's/^Current active profile: \(.*\)/\1/p' || true)
             if [[ "$active_profile" != "accelerator-performance" ]]; then
                 sudo -n tuned-adm profile accelerator-performance 2>/dev/null && \
                     ai_ok "tuned profile changed to accelerator-performance" || \

--- a/dream-server/lib/validate-dependencies.sh
+++ b/dream-server/lib/validate-dependencies.sh
@@ -28,7 +28,7 @@ validate_service_dependencies() {
         local _svc
         while IFS= read -r _svc; do
             enabled_services[$_svc]=1
-        done < <(grep -oP '^  \K[a-z][a-z0-9_-]+(?=:)' "$_base_compose" 2>/dev/null)
+        done < <(sed -n 's/^  \([a-z][a-z0-9_-]*\):.*/\1/p' "$_base_compose" 2>/dev/null)
     fi
 
     # Check each enabled service's dependencies
@@ -78,7 +78,7 @@ validate_dependencies_verbose() {
         local _svc
         while IFS= read -r _svc; do
             enabled_services[$_svc]=1
-        done < <(grep -oP '^  \K[a-z][a-z0-9_-]+(?=:)' "$_base_compose" 2>/dev/null)
+        done < <(sed -n 's/^  \([a-z][a-z0-9_-]*\):.*/\1/p' "$_base_compose" 2>/dev/null)
     fi
 
     local total_enabled=${#enabled_services[@]}

--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -81,7 +81,7 @@ test_llm_functional() {
     fi
 
     local content
-    content=$(echo "$response" | grep -oP '"content":\s*"[^"]+"' | head -1 | cut -d'"' -f4)
+    content=$(echo "$response" | grep -oE '"content":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4)
 
     if [[ -z "$content" ]]; then
         fail "LLM returned empty content"
@@ -227,7 +227,7 @@ test_whisper_functional() {
     fi
     
     local transcription
-    transcription=$(echo "$response" | grep -oP '"text":\s*"[^"]+"' | head -1 | cut -d'"' -f4)
+    transcription=$(echo "$response" | grep -oE '"text":[[:space:]]*"[^"]+"' | head -1 | cut -d'"' -f4)
     
     if [[ -z "$transcription" ]]; then
         fail "Whisper returned empty transcription"

--- a/dream-server/tests/test-bootstrap-mode.sh
+++ b/dream-server/tests/test-bootstrap-mode.sh
@@ -54,7 +54,7 @@ pass "Upgrade script ready"
 
 # ===== Test 5: Healthcheck timing =====
 info "Test 5: Checking healthcheck configuration..."
-MAIN_START_PERIOD=$(grep -A10 "llama-server:" docker-compose.yml | grep -A5 "healthcheck:" | grep "start_period" | grep -oP '\d+' | head -1 || echo "0")
+MAIN_START_PERIOD=$(grep -A10 "llama-server:" docker-compose.yml | grep -A5 "healthcheck:" | grep "start_period" | grep -oE '[0-9]+' | head -1 || echo "0")
 if [[ "$MAIN_START_PERIOD" -gt 0 ]]; then
     pass "llama-server healthcheck start_period configured ($MAIN_START_PERIOD)"
 else

--- a/dream-server/tests/test-docker-image-pull-retry.sh
+++ b/dream-server/tests/test-docker-image-pull-retry.sh
@@ -190,7 +190,7 @@ echo "3. Retry Strategy Tests (source-level sanity checks)"
 echo "────────────────────────────────────────────────────"
 
 printf "  %-60s " "max_attempts is 3..."
-retry_count=$(grep -A 15 "^pull_with_progress()" "$ROOT_DIR/installers/lib/ui.sh" | grep -m1 "max_attempts=" | grep -oP '\d+' || true)
+retry_count=$(grep -A 15 "^pull_with_progress()" "$ROOT_DIR/installers/lib/ui.sh" | grep -m1 "max_attempts=" | grep -oE '[0-9]+' || true)
 retry_count=${retry_count:-0}
 if [[ "$retry_count" == "3" ]]; then
   print_pass


### PR DESCRIPTION
## What
Replace all `grep -oP` (Perl regex, GNU-only) with POSIX-compatible `sed -n` or `grep -oE` alternatives across 8 files.

## Why
macOS ships BSD grep which does not support the `-P` flag. Scripts using `grep -oP` fail silently on macOS, breaking VRAM detection, driver version parsing, session management, and service dependency validation.

## How
Each replacement chosen based on the pattern complexity:
- Simple `\d+` → `grep -oE '[0-9]+'` (4 instances)
- `\K` reset / lookaheads → `sed -n 's/.../\1/p'` (8 instances)
- `\s` → `[[:space:]]` POSIX character class

Files changed: `get-dream-server.sh`, `detection.sh`, `session-manager.sh`, `validate-dependencies.sh`, `10-amd-tuning.sh`, `dream-test-functional.sh`, `test-bootstrap-mode.sh`, `test-docker-image-pull-retry.sh`

## Testing
- shellcheck: all warnings pre-existing
- Each replacement verified to produce identical output on GNU systems
- VRAM extraction tested against real nvidia-smi output (RTX 3070: "8192 MiB" → "8192")
- Zero remaining `grep -oP` in modified files

## Platform Impact
- **macOS:** Fixed — all grep patterns now work with BSD grep
- **Linux:** No change — GNU grep handles both old and new patterns
- **Windows/WSL2:** No change — uses GNU grep

## Review
- Critique Guardian: APPROVED (re-review after fixing sed fallback + missed file)