### PR TITLE
fix: prevent code injection in session-cleanup.sh Python invocation

### DIFF
--- a/dream-server/scripts/session-cleanup.sh
+++ b/dream-server/scripts/session-cleanup.sh
@@ -143,15 +143,17 @@ if [ -n "$WIPE_IDS" ]; then
 
         "$PYTHON_CMD" -c "
 import json, sys
-with open('$SESSIONS_JSON', 'r') as f:
+sessions_file = sys.argv[1]
+target_id = sys.argv[2]
+with open(sessions_file, 'r') as f:
     data = json.load(f)
-to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get('sessionId') == '$ID']
+to_remove = [k for k, v in data.items() if isinstance(v, dict) and v.get('sessionId') == target_id]
 for k in to_remove:
     del data[k]
     print(f'  Removed session key: {k}', file=sys.stderr)
-with open('$SESSIONS_JSON', 'w') as f:
+with open(sessions_file, 'w') as f:
     json.dump(data, f, indent=2)
-" 2>&1
+" "$SESSIONS_JSON" "$ID" 2>&1
     done
 
     # Clean up the backup


### PR DESCRIPTION
## What
Pass `$SESSIONS_JSON` and `$ID` as `sys.argv` arguments to `python3 -c` instead of interpolating them into the code string.

## Why
`session-cleanup.sh` interpolated shell variables directly into single-quoted Python string literals inside a `python3 -c` invocation. A file path containing a single quote (e.g., macOS username `O'Brien`) breaks the Python syntax. A crafted session filename could execute arbitrary Python code.

## How
- Replaced `'$SESSIONS_JSON'` → `sys.argv[1]`
- Replaced `'$ID'` → `sys.argv[2]`
- Arguments passed as `"$SESSIONS_JSON" "$ID"` after the `-c` string

## Testing
- shellcheck: clean (pre-existing warnings only)
- Tested with normal session cleanup operation
- Tested with injection payload — treated as harmless literal string via sys.argv
- Python syntax verified

## Platform Impact
- **macOS:** Fixed — paths with apostrophes (O'Brien, O'Connor) no longer break cleanup
- **Linux:** Fixed — same code path
- **Windows/WSL2:** Fixed — same code path

## Review
- Critique Guardian: APPROVED