### PR TITLE
fix: use platform-aware bind address for host agent HTTP server

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -518,6 +518,11 @@
       "type": "string",
       "description": "OpenClaw configuration profile name"
     },
+    "DREAM_AGENT_BIND": {
+      "type": "string",
+      "description": "Bind address for the Dream Host Agent HTTP server. Defaults to 127.0.0.1 on macOS/Windows, 0.0.0.0 on Linux.",
+      "default": ""
+    },
     "DREAM_TIER": {
       "type": "string",
       "description": "Hardware tier classification (0-4, SH_LARGE, SH_COMPACT, NV_ULTRA, CLOUD)"

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -7,6 +7,7 @@ import collections
 import json
 import logging
 import os
+import platform
 import re
 import secrets
 import shutil
@@ -604,9 +605,20 @@ def main():
         pid_path.write_text(str(os.getpid()), encoding="utf-8")
         atexit.register(lambda: pid_path.unlink(missing_ok=True))
 
-    server = ThreadedHTTPServer(("0.0.0.0", port), AgentHandler)
+    # Determine bind address: env var override, or platform-aware default.
+    # macOS/Windows: 127.0.0.1 (Docker Desktop routes host.docker.internal to loopback)
+    # Linux: 0.0.0.0 (host.docker.internal resolves to Docker bridge gateway, not loopback)
+    bind_addr = env.get("DREAM_AGENT_BIND", "")
+    if not bind_addr:
+        bind_addr = "127.0.0.1" if platform.system() in ("Darwin", "Windows") else "0.0.0.0"
+
+    server = ThreadedHTTPServer((bind_addr, port), AgentHandler)
     signal.signal(signal.SIGTERM, lambda *_: server.shutdown())
-    logger.info("Dream Host Agent v%s listening on 0.0.0.0:%d", VERSION, port)
+    logger.info("Dream Host Agent v%s listening on %s:%d", VERSION, bind_addr, port)
+    if bind_addr == "0.0.0.0":
+        logger.warning(
+            "Agent is listening on all interfaces. Set DREAM_AGENT_BIND=127.0.0.1 in .env to restrict."
+        )
     logger.info("Install dir: %s | GPU: %s | Tier: %s", INSTALL_DIR, GPU_BACKEND, TIER)
     try:
         server.serve_forever()


### PR DESCRIPTION
## What
Change host agent bind address from hardcoded `0.0.0.0` to a platform-aware default with `DREAM_AGENT_BIND` env var override.

## Why
The host agent has a Docker control API (start/stop containers, execute setup hooks, read logs). Binding to `0.0.0.0` exposes it to the entire LAN. On macOS/Windows, Docker Desktop routes `host.docker.internal` through the VM to the host's loopback, so `127.0.0.1` is sufficient. The `/health` endpoint responds without authentication.

## How
- Default: `127.0.0.1` on macOS (Darwin) / Windows, `0.0.0.0` on Linux
- `DREAM_AGENT_BIND` env var overrides the default on any platform
- Warning logged when binding to `0.0.0.0` with guidance to restrict
- Added `DREAM_AGENT_BIND` to `.env.schema.json`

## Testing
- Python syntax verified
- JSON schema validated
- Live tested on WSL2: confirmed `0.0.0.0` is required for Linux (host.docker.internal resolves to Docker bridge gateway 172.17.0.1, not loopback)
- Live tested: `127.0.0.1` bind → container connection refused; `0.0.0.0` → works

## Platform Impact
- **macOS:** Improved — defaults to `127.0.0.1`, no longer LAN-exposed
- **Windows (native):** Improved — defaults to `127.0.0.1`
- **Linux:** No change — defaults to `0.0.0.0` (required for container connectivity via Docker bridge)
- **Windows/WSL2:** No change — `platform.system()` returns "Linux", gets `0.0.0.0` (correct — WSL2 uses Docker bridge like Linux)

## Known Limitations
- Linux remains on `0.0.0.0` — a follow-up could detect the Docker bridge IP for tighter binding
- `DREAM_AGENT_BIND` env var provides escape hatch for all platforms

## Review
- Critique Guardian: APPROVED WITH WARNINGS (doc update for HOST-AGENT-API.md recommended as follow-up)