### PR TITLE
fix: remove GNU-only xargs -r flag for macOS compatibility

### DIFF
--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -97,14 +97,14 @@ if command -v docker &>/dev/null; then
     dream_containers=$(docker ps -a --filter "name=dream-" --format "{{.Names}}" 2>/dev/null || true)
     if [[ -n "$dream_containers" ]]; then
         log_info "Removing Dream Server containers..."
-        echo "$dream_containers" | xargs -r docker rm -f 2>/dev/null || true
+        echo "$dream_containers" | xargs docker rm -f 2>/dev/null || true
     fi
 
     # Remove dream-specific Docker volumes
     dream_volumes=$(docker volume ls --filter "name=dream" --format "{{.Name}}" 2>/dev/null || true)
     if [[ -n "$dream_volumes" ]]; then
         log_info "Removing Docker volumes..."
-        echo "$dream_volumes" | xargs -r docker volume rm 2>/dev/null || true
+        echo "$dream_volumes" | xargs docker volume rm 2>/dev/null || true
     fi
 
     log_ok "Docker cleanup complete"


### PR DESCRIPTION
## What
Remove `-r` flag from two `xargs` calls in `dream-uninstall.sh`.

## Why
macOS BSD xargs doesn't support `-r` (GNU extension). The flag causes "illegal option -- r" error, masked by `|| true`, silently skipping container and volume cleanup during uninstall.

## How
Simply removed `-r` from lines 100 and 107. Both calls are already guarded by `[[ -n "$var" ]]` checks, so xargs never receives empty input. BSD xargs also defaults to not running on empty input, making `-r` redundant.

## Testing
- shellcheck clean
- No other `xargs -r` in codebase

## Platform Impact
- **macOS:** Fixed — uninstall now cleans containers and volumes
- **Linux/WSL2:** No change — GNU xargs works with or without `-r`