### PR TITLE
fix: add log rotation to all extension compose files

### DIFF
--- a/dream-server/extensions/services/ape/compose.yaml
+++ b/dream-server/extensions/services/ape/compose.yaml
@@ -32,3 +32,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/comfyui/compose.amd.yaml
+++ b/dream-server/extensions/services/comfyui/compose.amd.yaml
@@ -37,3 +37,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 120s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/comfyui/compose.multigpu.yaml
+++ b/dream-server/extensions/services/comfyui/compose.multigpu.yaml
@@ -7,3 +7,8 @@ services:
             - driver: nvidia
               device_ids: ["${COMFYUI_GPU_UUID}"]
               capabilities: [gpu]
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/comfyui/compose.nvidia.yaml
+++ b/dream-server/extensions/services/comfyui/compose.nvidia.yaml
@@ -31,3 +31,8 @@ services:
       timeout: 10s
       start_period: 120s
       retries: 3
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/dreamforge/compose.yaml
+++ b/dream-server/extensions/services/dreamforge/compose.yaml
@@ -52,6 +52,11 @@ services:
       timeout: 5s
       retries: 3
       start_period: 15s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - dream-network
 

--- a/dream-server/extensions/services/embeddings/compose.multigpu.yaml
+++ b/dream-server/extensions/services/embeddings/compose.multigpu.yaml
@@ -7,3 +7,8 @@ services:
             - driver: nvidia
               device_ids: ["${EMBEDDINGS_GPU_UUID}"]
               capabilities: [gpu]
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/embeddings/compose.yaml
+++ b/dream-server/extensions/services/embeddings/compose.yaml
@@ -26,3 +26,8 @@ services:
       timeout: 10s
       retries: 5
       start_period: 120s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/langfuse/compose.yaml.disabled
+++ b/dream-server/extensions/services/langfuse/compose.yaml.disabled
@@ -67,6 +67,11 @@ services:
         reservations:
           cpus: '0.25'
           memory: 256m
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   langfuse-worker:
     image: langfuse/langfuse-worker:3.159.0
@@ -122,6 +127,11 @@ services:
         reservations:
           cpus: '0.25'
           memory: 256m
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   langfuse-postgres:
     image: postgres:17.9-alpine
@@ -151,6 +161,11 @@ services:
         reservations:
           cpus: '0.1'
           memory: 128m
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   langfuse-clickhouse:
     image: clickhouse/clickhouse-server:26.2.4.23
@@ -183,6 +198,11 @@ services:
         reservations:
           cpus: '0.5'
           memory: 256m
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   langfuse-redis:
     image: redis:7.4.8-alpine
@@ -211,6 +231,11 @@ services:
         reservations:
           cpus: '0.1'
           memory: 64m
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   langfuse-minio:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
@@ -241,6 +266,11 @@ services:
         reservations:
           cpus: '0.1'
           memory: 128m
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   langfuse-minio-init:
     image: minio/mc:RELEASE.2025-09-07T16-13-09Z
@@ -271,6 +301,11 @@ services:
         limits:
           cpus: '0.25'
           memory: 128m
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # Inject Langfuse credentials into LiteLLM when this extension is active.
   # The callback itself is conditionally enabled by litellm's own entrypoint
@@ -281,6 +316,11 @@ services:
       - LANGFUSE_SECRET_KEY=${LANGFUSE_PROJECT_SECRET_KEY:-}
       - LANGFUSE_HOST=http://langfuse:3000
       - LANGFUSE_TRACING_ENABLED=${LANGFUSE_ENABLED:-false}
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 networks:
   langfuse-internal:

--- a/dream-server/extensions/services/litellm/compose.amd.yaml
+++ b/dream-server/extensions/services/litellm/compose.amd.yaml
@@ -22,3 +22,8 @@ services:
         else
           exec litellm --config /app/config.yaml --port 4000
         fi
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/litellm/compose.yaml
+++ b/dream-server/extensions/services/litellm/compose.yaml
@@ -45,3 +45,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 20s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/n8n/compose.yaml
+++ b/dream-server/extensions/services/n8n/compose.yaml
@@ -33,3 +33,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -44,6 +44,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
   # When OpenClaw is enabled, register it as a second model backend in Open WebUI.
   # Port 18790 is the OpenAI-compat shim (serves /v1/models + proxies /v1/chat/completions).

--- a/dream-server/extensions/services/perplexica/compose.yaml
+++ b/dream-server/extensions/services/perplexica/compose.yaml
@@ -31,6 +31,11 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
 
 volumes:
   perplexica-data:

--- a/dream-server/extensions/services/privacy-shield/compose.yaml
+++ b/dream-server/extensions/services/privacy-shield/compose.yaml
@@ -35,3 +35,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/qdrant/compose.yaml
+++ b/dream-server/extensions/services/qdrant/compose.yaml
@@ -23,3 +23,8 @@ services:
       resources:
         limits:
           memory: 1G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/searxng/compose.yaml
+++ b/dream-server/extensions/services/searxng/compose.yaml
@@ -26,3 +26,8 @@ services:
         reservations:
           cpus: '0.1'
           memory: 64M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/token-spy/compose.yaml
+++ b/dream-server/extensions/services/token-spy/compose.yaml
@@ -28,3 +28,8 @@ services:
       timeout: 5s
       retries: 3
       start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/tts/compose.yaml
+++ b/dream-server/extensions/services/tts/compose.yaml
@@ -25,3 +25,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/whisper/compose.multigpu.yaml
+++ b/dream-server/extensions/services/whisper/compose.multigpu.yaml
@@ -7,3 +7,8 @@ services:
             - driver: nvidia
               device_ids: ["${WHISPER_GPU_UUID}"]
               capabilities: [gpu]
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/whisper/compose.nvidia.yaml
+++ b/dream-server/extensions/services/whisper/compose.nvidia.yaml
@@ -11,3 +11,8 @@ services:
         limits:
           cpus: '4.0'
           memory: 8G
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/whisper/compose.yaml
+++ b/dream-server/extensions/services/whisper/compose.yaml
@@ -30,3 +30,8 @@ services:
       timeout: 10s
       retries: 3
       start_period: 60s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## What
Add explicit `logging:` sections (json-file driver, max-size 10m, max-file 3) to all extension service definitions across 21 compose files.

## Why
Core services in `docker-compose.base.yml` use the `x-logging` YAML anchor for log rotation. Extension compose files are separate YAML documents and cannot reference base anchors. All extension containers ran with Docker's default unlimited logging, risking disk exhaustion on long-running installs.

## How
Added identical logging block to every service definition in 21 files:
- 19 extension compose files (ape, comfyui GPU overlays, embeddings, litellm, n8n, openclaw, perplexica, privacy-shield, qdrant, searxng, token-spy, tts, whisper + GPU overlays)
- langfuse disabled file (8 sub-services)
- dreamforge disabled file

Skipped: `comfyui/compose.yaml` (stub), `.local.yaml` dev files, core services (already in base.yml)

## Testing
- All 21 YAML files validated
- Live verified: all 12 running containers confirmed with `{json-file map[max-file:3 max-size:10m]}`

## Platform Impact
- **All platforms:** Fixed — 30MB max log per service (10m × 3 files)