### PR TITLE
fix: harden extension templates and APE API key verification

### DIFF
--- a/dream-server/extensions/services/ape/main.py
+++ b/dream-server/extensions/services/ape/main.py
@@ -246,7 +246,7 @@ app.add_middleware(
 
 
 async def verify_api_key(x_api_key: Optional[str] = Header(None)):
-    if API_KEY and x_api_key != API_KEY:
+    if API_KEY and not secrets.compare_digest(x_api_key or "", API_KEY):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
 

--- a/dream-server/extensions/templates/compose-gpu-only.yaml
+++ b/dream-server/extensions/templates/compose-gpu-only.yaml
@@ -61,7 +61,7 @@ services:
     restart: unless-stopped
 
     ports:
-      - "${MY_SERVICE_PORT:-8080}:8080"
+      - "127.0.0.1:${MY_SERVICE_PORT:-8080}:8080"
 
     volumes:
       - ./data/my-service/models:/models

--- a/dream-server/extensions/templates/compose-template.yaml
+++ b/dream-server/extensions/templates/compose-template.yaml
@@ -58,7 +58,7 @@ services:
 
     ports:
       # External port (user-facing) : Internal port (container)
-      - "${MY_SERVICE_PORT:-1234}:1234"
+      - "127.0.0.1:${MY_SERVICE_PORT:-1234}:1234"
 
     deploy:
       resources:


### PR DESCRIPTION
## What
- Add `127.0.0.1:` prefix to port bindings in extension compose templates
- Replace non-constant-time API key comparison in APE with `secrets.compare_digest`

## Why
- Extension templates used bare port bindings (`"${PORT}:1234"`), teaching community extension authors the wrong pattern — LAN-exposed by default. All deployed services already bind to `127.0.0.1`.
- APE was the only service using `!=` for API key comparison. All other services (dashboard-api, host-agent, token-spy, privacy-shield) use `secrets.compare_digest()`.

## How
- `compose-template.yaml:61` and `compose-gpu-only.yaml:64`: prefixed with `127.0.0.1:`
- `ape/main.py:249`: `x_api_key != API_KEY` → `not secrets.compare_digest(x_api_key or "", API_KEY)` (`secrets` already imported)

## Testing
- YAML validated, Python syntax checked
- Live tested: wrong key → 401, correct key → processes request

## Platform Impact
- **All platforms:** Identical — templates and Python auth are platform-agnostic