### PR TITLE
fix: update llama.cpp from b4601 to b8248 for Intel Arc builds

### DIFF
--- a/dream-server/docker-compose.arc.yml
+++ b/dream-server/docker-compose.arc.yml
@@ -8,10 +8,10 @@
 #   ARC_LITE tier — Arc A750 8 GB, A380 6 GB
 #
 # Build arguments (customise via .env or shell export):
-#   LLAMA_TAG       llama.cpp git tag (default: b4601)
+#   LLAMA_TAG       llama.cpp git tag (default: b8248)
 #   ONEAPI_VERSION  oneAPI Base Toolkit image tag (default: 2025.0.0-0-devel-ubuntu22.04)
 #   LLAMA_ARC_IMAGE Override to a pre-built image and skip the local build entirely
-#                   e.g. LLAMA_ARC_IMAGE=ghcr.io/ggml-org/llama.cpp:server-intel-b4601
+#                   e.g. LLAMA_ARC_IMAGE=ghcr.io/ggml-org/llama.cpp:server-intel-b8248
 #
 # First-run note:
 #   The SYCL build compiles llama.cpp with Intel icx/icpx. Allow 10–20 min
@@ -28,7 +28,7 @@ services:
       context: ./images/llama-sycl
       dockerfile: Dockerfile
       args:
-        LLAMA_TAG: ${LLAMA_TAG:-b4601}
+        LLAMA_TAG: ${LLAMA_TAG:-b8248}
         ONEAPI_VERSION: ${ONEAPI_VERSION:-2025.0.0-0-devel-ubuntu22.04}
     # Set LLAMA_ARC_IMAGE in .env to skip the local build and pull a pre-built image.
     image: ${LLAMA_ARC_IMAGE:-dream-llama-sycl:local}

--- a/dream-server/docs/INTEL-ARC-GUIDE.md
+++ b/dream-server/docs/INTEL-ARC-GUIDE.md
@@ -143,7 +143,7 @@ docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d --buil
 docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d
 
 # Skip local build — use a pre-built image
-LLAMA_ARC_IMAGE=ghcr.io/ggml-org/llama.cpp:server-intel-b4601 \
+LLAMA_ARC_IMAGE=ghcr.io/ggml-org/llama.cpp:server-intel-b8248 \
   docker compose -f docker-compose.base.yml -f docker-compose.arc.yml up -d
 ```
 

--- a/dream-server/images/llama-sycl/Dockerfile
+++ b/dream-server/images/llama-sycl/Dockerfile
@@ -11,7 +11,7 @@
 #
 # Build args:
 #   ONEAPI_VERSION  oneAPI Base Toolkit image tag (default: 2025.0.0-0-devel-ubuntu22.04)
-#   LLAMA_TAG       llama.cpp git tag to build (default: b4601)
+#   LLAMA_TAG       llama.cpp git tag to build (default: b8248)
 #
 # Layers ordered for optimal Docker cache re-use:
 #   1. System build deps       — rarely changes; rebuilds only on ONEAPI_VERSION bump
@@ -29,7 +29,7 @@ ARG ONEAPI_VERSION=2025.0.0-0-devel-ubuntu22.04
 # ---------------------------------------------------------------------------
 FROM intel/oneapi-basekit:${ONEAPI_VERSION} AS builder
 
-ARG LLAMA_TAG=b4601
+ARG LLAMA_TAG=b8248
 ENV DEBIAN_FRONTEND=noninteractive
 
 # cmake + ninja for fast parallel builds; libcurl for model URL loading


### PR DESCRIPTION
## What
Update all `b4601` references to `b8248` in Intel Arc build-from-source files.

## Why
`docker-compose.arc.yml` defaulted `LLAMA_TAG` to `b4601` while all other overlays (base, nvidia, intel, cpu, apple) use `b8248`. Intel Arc build-from-source users got a significantly older llama.cpp version.

## How
3 files updated:
- `docker-compose.arc.yml`: build arg default + 2 comments
- `images/llama-sycl/Dockerfile`: ARG default + comment
- `docs/INTEL-ARC-GUIDE.md`: example command

Zero remaining `b4601` references in the codebase.

## Testing
- YAML validated
- Grep confirms zero b4601 remaining

## Platform Impact
- **Linux (Intel Arc):** Fixed — builds use b8248
- **All other platforms:** No change