### PR TITLE
fix(installer): launch bootstrap model download regardless of compose_ok

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -349,37 +349,40 @@ MODELS_INI_EOF
         printf "\r  ${BGRN}✓${NC} %-60s\n" "All containers launched"
         echo ""
         ai_ok "Services started (llama-server)"
-
-        # ── Bootstrap: launch background full-model download + auto hot-swap ──
-        if [[ "$_BOOTSTRAP_ACTIVE" == "true" ]]; then
-            ai "Launching background download for $FULL_LLM_MODEL..."
-
-            # Source background task tracking if not already loaded
-            if ! command -v bg_task_start &>/dev/null && [[ -f "$SCRIPT_DIR/installers/lib/background-tasks.sh" ]]; then
-                . "$SCRIPT_DIR/installers/lib/background-tasks.sh"
-            fi
-
-            nohup bash "$SCRIPT_DIR/scripts/bootstrap-upgrade.sh" \
-                "$INSTALL_DIR" "$FULL_GGUF_FILE" "$FULL_GGUF_URL" \
-                "$FULL_GGUF_SHA256" "$FULL_LLM_MODEL" "$FULL_MAX_CONTEXT" \
-                > "$INSTALL_DIR/logs/model-upgrade.log" 2>&1 &
-            _upgrade_pid=$!
-
-            if command -v bg_task_start &>/dev/null; then
-                bg_task_start "full-model-download" "$_upgrade_pid" \
-                    "Full model download: $FULL_LLM_MODEL" \
-                    "$INSTALL_DIR/logs/model-upgrade.log"
-            fi
-
-            log "Background model upgrade started (PID: $_upgrade_pid)"
-            ai "Full model ($FULL_LLM_MODEL) downloading in background."
-            ai "It will auto-swap when ready. Check progress: tail -f $INSTALL_DIR/logs/model-upgrade.log"
-        fi
     else
         printf "\r  ${RED}✗${NC} %-60s\n" "Some containers failed to launch"
         echo ""
         ai_warn "Some services failed. Check: docker compose logs"
         ai_warn "Log file: $LOG_FILE"
+    fi
+
+    # ── Bootstrap: launch background full-model download + auto hot-swap ──
+    # Runs regardless of compose_ok — the download only needs disk + network.
+    # bootstrap-upgrade.sh checks if Docker is running before attempting
+    # hot-swap and handles it gracefully if containers aren't ready yet.
+    if [[ "$_BOOTSTRAP_ACTIVE" == "true" ]]; then
+        ai "Launching background download for $FULL_LLM_MODEL..."
+
+        # Source background task tracking if not already loaded
+        if ! command -v bg_task_start &>/dev/null && [[ -f "$SCRIPT_DIR/installers/lib/background-tasks.sh" ]]; then
+            . "$SCRIPT_DIR/installers/lib/background-tasks.sh"
+        fi
+
+        nohup bash "$SCRIPT_DIR/scripts/bootstrap-upgrade.sh" \
+            "$INSTALL_DIR" "$FULL_GGUF_FILE" "$FULL_GGUF_URL" \
+            "$FULL_GGUF_SHA256" "$FULL_LLM_MODEL" "$FULL_MAX_CONTEXT" \
+            > "$INSTALL_DIR/logs/model-upgrade.log" 2>&1 &
+        _upgrade_pid=$!
+
+        if command -v bg_task_start &>/dev/null; then
+            bg_task_start "full-model-download" "$_upgrade_pid" \
+                "Full model download: $FULL_LLM_MODEL" \
+                "$INSTALL_DIR/logs/model-upgrade.log"
+        fi
+
+        log "Background model upgrade started (PID: $_upgrade_pid)"
+        ai "Full model ($FULL_LLM_MODEL) downloading in background."
+        ai "It will auto-swap when ready. Check progress: tail -f $INSTALL_DIR/logs/model-upgrade.log"
     fi
 
     dream_progress 83 "services" "Running extension setup hooks"


### PR DESCRIPTION
## Summary
Fixes a bug where the background full-model download was silently skipped on NVIDIA systems because it was gated inside `if $compose_ok`.

## Root cause
On NVIDIA, pre-built Docker images start fast but container health checks haven't passed by the time `spin_task` finishes → `compose_ok` stays `false` → the bootstrap download block (lines 354-377) was inside the `if $compose_ok` block → download never launches → `.env` points to a model file that doesn't exist → llama-server crash-loops.

AMD systems were unaffected because building llama-server from source takes long enough that containers are healthy by the time `docker compose up` runs.

## Fix
Moves the bootstrap download block from inside `if $compose_ok; then ... fi` to after it. The download only needs disk + network. `bootstrap-upgrade.sh` already checks if Docker is running before attempting hot-swap and handles it gracefully if containers aren't ready.

## What changed
One file, purely structural — the bootstrap block is cut from inside the conditional and pasted after the `fi`. Zero logic changes to the download code.

## Why this is safe
1. `bootstrap-upgrade.sh` doesn't need containers running — it downloads first, then checks Docker before hot-swap
2. `FULL_*` variables are always defined when `_BOOTSTRAP_ACTIVE=true` (set in the same scope)
3. The safety net (lines 338-346) already ran 3 recovery passes before this point
4. Download failure is non-fatal (retries 3x, writes failed status JSON, exits 1)

## Verification
- [x] `bash -n` syntax check passes
- [x] `_BOOTSTRAP_ACTIVE` block is after `if $compose_ok; then ... else ... fi`
- [x] `compose_ok` not referenced in the moved block (only in a comment)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)