### PR TITLE
feat(dreamforge): publish pre-built image to GHCR, pull instead of build

### DIFF
--- a/.github/workflows/build-dreamforge.yml
+++ b/.github/workflows/build-dreamforge.yml
@@ -1,0 +1,47 @@
+name: Build DreamForge Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dream-server/extensions/services/dreamforge/**'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: light-heart-labs/dreamforge
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(grep -oP 'version\s*=\s*"\K[^"]+' dream-server/extensions/services/dreamforge/rust/Cargo.toml | head -1)
+          echo "version=${VERSION:-0.1.0}" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: dream-server/extensions/services/dreamforge
+          file: dream-server/extensions/services/dreamforge/Dockerfile.rust
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:v${{ steps.version.outputs.version }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.sha_short }}

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -184,6 +184,7 @@ LANGFUSE_ENABLED=false
 # ENABLE_IMAGE_GENERATION=true
 
 #=== DreamForge (Local Agentic Coding) ===
+# DREAMFORGE_IMAGE=ghcr.io/light-heart-labs/dreamforge:latest
 # DREAMFORGE_PORT=3010
 # DREAMFORGE_PERMISSION_MODE=accept_edits
 # DREAMFORGE_MAX_TURNS=25

--- a/dream-server/extensions/services/dreamforge/compose.yaml.disabled
+++ b/dream-server/extensions/services/dreamforge/compose.yaml.disabled
@@ -1,5 +1,6 @@
 services:
   dreamforge:
+    image: ${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:latest}
     build:
       context: ./extensions/services/dreamforge
       dockerfile: Dockerfile.rust

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -47,6 +47,7 @@ fi
 [[ "$ENABLE_RAG" == "true" ]] && PULL_LIST+=("qdrant/qdrant:v1.16.3|QDRANT — memory vault")
 [[ "$ENABLE_OPENCLAW" == "true" ]] && PULL_LIST+=("ghcr.io/openclaw/openclaw:2026.3.8|OPENCLAW — agent framework")
 [[ "$ENABLE_RAG" == "true" ]] && PULL_LIST+=("ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1|TEI — embedding engine")
+[[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && PULL_LIST+=("ghcr.io/light-heart-labs/dreamforge:latest|DREAMFORGE — agentic coding engine")
 
 if $DRY_RUN; then
     ai "[DRY RUN] I would download ${#PULL_LIST[@]} modules."

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -301,7 +301,14 @@ MODELS_INI_EOF
     _build_count=0
     _build_services=(dashboard dashboard-api ape token-spy privacy-shield)
     [[ "$ENABLE_COMFYUI" == "true" ]] && _build_services+=(comfyui)
-    [[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && _build_services+=(dreamforge)
+    if [[ "${ENABLE_DREAMFORGE:-}" == "true" ]]; then
+        _dreamforge_image="${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:latest}"
+        if ! docker image inspect "$_dreamforge_image" &>/dev/null; then
+            _build_services+=(dreamforge)
+        else
+            log "DreamForge image found locally — skipping source build"
+        fi
+    fi
     [[ "$GPU_BACKEND" == "amd" ]] && _build_services+=(llama-server)
     if [[ "$GPU_BACKEND" == "nvidia" && " ${_build_services[*]} " == *" comfyui "* ]]; then
         ai "ComfyUI is compiling from source for NVIDIA — this takes 25-40 minutes on first run."


### PR DESCRIPTION
## Summary
Publishes DreamForge as a pre-built Docker image to GitHub Container Registry. Install goes from 15-25 minutes of Rust compilation to a ~25MB image pull in seconds.

## How it works

**Dual `image:` + `build:` pattern** (same as AMD llama-server in `docker-compose.amd.yml`):
- `docker compose pull` → pulls from GHCR
- `docker compose up -d` → uses local image if present, builds from Dockerfile if not
- `docker compose build` → always builds from source (for development)

**Install flow:**
1. Phase 08: pulls `ghcr.io/light-heart-labs/dreamforge:latest` (~25MB, seconds)
2. Phase 11: checks if image exists locally → skips Rust build if found
3. Fallback: if pull fails (GHCR down, image not published), Phase 11 builds from source

**CI workflow:** Builds and pushes on changes to `dreamforge/**` or manual dispatch. Tags: `latest`, semver from Cargo.toml, short SHA.

## Files changed

| File | Change |
|------|--------|
| `.github/workflows/build-dreamforge.yml` | NEW — CI build + push to GHCR |
| `compose.yaml.disabled` | Added `image:` with `${DREAMFORGE_IMAGE:-...}` fallback |
| `08-images.sh` | Added DreamForge to conditional PULL_LIST |
| `11-services.sh` | Build now conditional on `docker image inspect` (respects DREAMFORGE_IMAGE env var) |
| `.env.example` | Documented DREAMFORGE_IMAGE override |

## What stays the same
- `Dockerfile.rust` — unchanged, still works for local dev
- Feature flag, health checks, port checks, URL display — all from #841, unchanged
- Manifest, core-service-ids, dream-cli — unchanged

## After merge
Manually trigger the `Build DreamForge Image` workflow (workflow_dispatch) to publish the first image to GHCR. Future changes to dreamforge files auto-trigger.

## Test plan
- [x] `bash -n` syntax checks pass on all modified files
- [x] Compose has both `image:` and `build:` (verified dual pattern)
- [x] Phase 08 has DreamForge in PULL_LIST
- [x] Phase 11 skips build when image exists
- [ ] CI workflow builds and pushes successfully (verify after merge)
- [ ] `docker pull ghcr.io/light-heart-labs/dreamforge:latest` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)