### PR TITLE
fix(dashboard-api): reject newlines and null bytes in env editor values

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -520,6 +520,12 @@ def _serialize_form_values(
 
     for key, field in fields.items():
         value = raw_values.get(key, current_values.get(key, ""))
+        # Reject newlines and null bytes to prevent .env injection
+        if value is not None and any(c in str(value) for c in ("\n", "\r", "\0")):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Value for '{key}' contains invalid characters (newlines or null bytes are not allowed)",
+            )
         if value is None:
             serialized[key] = current_values.get(key, "") if field.get("secret") else ""
             continue

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -185,3 +185,35 @@ def test_api_settings_env_allows_existing_local_override(test_client, settings_e
     assert response.status_code == 200
     updated_env = env_path.read_text(encoding="utf-8")
     assert "LOCAL_OVERRIDE=updated" in updated_env
+
+
+def test_api_settings_env_rejects_newline_in_value(test_client, settings_env_fixture):
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {
+                "LLM_BACKEND": "local\nINJECTED_KEY=malicious",
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    assert "invalid characters" in response.json()["detail"]
+
+
+def test_api_settings_env_rejects_null_byte_in_value(test_client, settings_env_fixture):
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {
+                "LLM_BACKEND": "local\x00injected",
+            },
+        },
+    )
+
+    assert response.status_code == 400
+    assert "invalid characters" in response.json()["detail"]


### PR DESCRIPTION
## Summary
Closes a defense-in-depth gap in the env editor (#854). Rejects values containing `\n`, `\r`, or `\0` to prevent .env injection.

## What was the gap
A submitted value like `3010\nINJECTED_KEY=malicious` would write two lines to .env. Not exploitable in the current architecture (Docker Compose and Python dotenv treat it as a literal string), but a defense-in-depth gap.

## Fix
4 lines added to `_serialize_form_values` in `main.py`:
```python
if value is not None and any(c in str(value) for c in ("\n", "\r", "\0")):
    raise HTTPException(status_code=400, detail=f"Value for '{key}' contains invalid characters")
```

## Tests
- `test_api_settings_env_rejects_newline_in_value` — submits `3010\nINJECTED_KEY=malicious`, asserts 400
- `test_api_settings_env_rejects_null_byte_in_value` — submits `3010\x00injected`, asserts 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)