### PR TITLE
feat:Add apply-changes flow for Settings env editor

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -46,6 +46,25 @@ USER_EXTENSIONS_DIR: Path = Path()
 
 # Per-service locks to prevent concurrent start+stop races on the same service
 _service_locks: dict[str, threading.Lock] = collections.defaultdict(threading.Lock)
+_ALLOWED_CORE_RECREATE_IDS = frozenset({
+    "llama-server", "open-webui", "litellm", "langfuse", "n8n",
+    "openclaw", "opencode", "perplexica", "searxng", "qdrant",
+    "tts", "whisper", "embeddings", "token-spy", "comfyui",
+    "ape", "privacy-shield", "dreamforge",
+})
+
+
+def _to_bash_path(path: Path) -> str:
+    """Convert a Windows path into a Git-Bash-friendly POSIX path when needed."""
+    resolved = str(path)
+    if platform.system() != "Windows":
+        return resolved
+    normalized = resolved.replace("\\", "/")
+    match = re.match(r"^([A-Za-z]):/(.*)$", normalized)
+    if match:
+        drive, tail = match.groups()
+        return f"/{drive.lower()}/{tail}"
+    return normalized
 
 
 def load_env(env_path: Path) -> dict:
@@ -77,11 +96,17 @@ def load_core_service_ids(config_path: Path) -> set:
 
 
 def resolve_compose_flags() -> list:
+    flags_file = INSTALL_DIR / ".compose-flags"
+    if flags_file.exists():
+        raw = flags_file.read_text(encoding="utf-8").strip()
+        if raw:
+            return raw.split()
+
     script = INSTALL_DIR / "scripts" / "resolve-compose-stack.sh"
     if not script.exists():
         raise RuntimeError(f"resolve-compose-stack.sh not found at {script}")
     result = subprocess.run(
-        ["bash", str(script), "--script-dir", str(INSTALL_DIR),
+        ["bash", _to_bash_path(script), "--script-dir", _to_bash_path(INSTALL_DIR),
          "--tier", TIER, "--gpu-backend", GPU_BACKEND],
         capture_output=True, text=True, check=True,
         cwd=str(INSTALL_DIR), timeout=30,
@@ -157,6 +182,40 @@ def docker_compose_action(service_id: str, action: str) -> tuple:
         return (True, "") if result.returncode == 0 else (False, result.stderr[:500])
     except subprocess.TimeoutExpired:
         return False, f"Docker compose operation timed out ({timeout}s)"
+
+
+def validate_core_recreate_ids(service_ids: list[str]) -> tuple[bool, str]:
+    """Validate a requested set of core services for safe recreation."""
+    if not isinstance(service_ids, list) or not service_ids:
+        return False, "service_ids must be a non-empty list"
+
+    for service_id in service_ids:
+        if not isinstance(service_id, str) or not SERVICE_ID_RE.match(service_id):
+            return False, f"Invalid service_id: {service_id!r}"
+        if service_id not in CORE_SERVICE_IDS:
+            return False, f"Service is not a core DreamServer service: {service_id}"
+        if service_id not in _ALLOWED_CORE_RECREATE_IDS:
+            return False, f"Service is not eligible for dashboard-triggered recreation: {service_id}"
+
+    return True, ""
+
+
+def docker_compose_recreate(service_ids: list[str]) -> tuple:
+    """Force-recreate a set of allowed core services using the current compose stack."""
+    ok, error = validate_core_recreate_ids(service_ids)
+    if not ok:
+        return False, error
+
+    flags = resolve_compose_flags()
+    cmd = ["docker", "compose"] + flags + ["up", "-d", "--no-deps", "--force-recreate"] + service_ids
+    try:
+        result = subprocess.run(
+            cmd, cwd=str(INSTALL_DIR),
+            capture_output=True, text=True, timeout=SUBPROCESS_TIMEOUT_START,
+        )
+        return (True, "") if result.returncode == 0 else (False, result.stderr[:500] or result.stdout[:500])
+    except subprocess.TimeoutExpired:
+        return False, f"Docker compose operation timed out ({SUBPROCESS_TIMEOUT_START}s)"
 
 
 def _parse_mem_value(s: str) -> float:
@@ -335,6 +394,8 @@ class AgentHandler(BaseHTTPRequestHandler):
         if self.path in ("/v1/extension/start", "/v1/extension/stop"):
             action = "start" if self.path.endswith("/start") else "stop"
             self._handle_extension(action)
+        elif self.path == "/v1/core/recreate":
+            self._handle_core_recreate()
         elif self.path == "/v1/extension/logs":
             self._handle_logs()
         elif self.path == "/v1/extension/setup-hook":
@@ -343,6 +404,47 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_service_logs()
         else:
             json_response(self, 404, {"error": "Not found"})
+
+    def _handle_core_recreate(self):
+        if not check_auth(self):
+            return
+        body = read_json_body(self)
+        if body is None:
+            return
+
+        requested = body.get("service_ids", [])
+        unique_service_ids = sorted(set(requested)) if isinstance(requested, list) else requested
+        ok, error = validate_core_recreate_ids(unique_service_ids)
+        if not ok:
+            json_response(self, 400, {"error": error})
+            return
+
+        locks = []
+        try:
+            for service_id in unique_service_ids:
+                lock = _service_locks[service_id]
+                if not lock.acquire(blocking=False):
+                    json_response(self, 409, {"error": f"Operation already in progress for {service_id}"})
+                    return
+                locks.append(lock)
+
+            logger.info("Recreating core services: %s", ", ".join(unique_service_ids))
+            ok, err = docker_compose_recreate(unique_service_ids)
+            if ok:
+                json_response(self, 200, {
+                    "status": "ok",
+                    "action": "recreate",
+                    "service_ids": unique_service_ids,
+                })
+            else:
+                json_response(self, 503 if "timed out" in err else 500, {"error": err})
+        except RuntimeError as exc:
+            json_response(self, 500, {"error": str(exc)})
+        except subprocess.CalledProcessError as exc:
+            json_response(self, 500, {"error": f"Compose resolution failed: {exc.stderr[:300]}"})
+        finally:
+            for lock in reversed(locks):
+                lock.release()
 
     def _handle_extension(self, action: str):
         if not check_auth(self):

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -22,6 +22,8 @@ import re
 import socket
 import shutil
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -30,7 +32,10 @@ from fastapi import FastAPI, Depends, HTTPException, Body
 from fastapi.middleware.cors import CORSMiddleware
 
 # --- Local modules ---
-from config import SERVICES, DATA_DIR, INSTALL_DIR, SIDEBAR_ICONS, MANIFEST_ERRORS
+from config import (
+    SERVICES, DATA_DIR, INSTALL_DIR, SIDEBAR_ICONS, MANIFEST_ERRORS,
+    AGENT_URL, DREAM_AGENT_KEY,
+)
 from models import (
     GPUInfo, ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus,
     FullStatus, PortCheckRequest,
@@ -87,6 +92,35 @@ _ENV_COMMENTED_ASSIGNMENT_RE = re.compile(r"^\s*#\s*([A-Za-z_][A-Za-z0-9_]*)=(.*
 _SENSITIVE_ENV_KEY_RE = re.compile(
     r"(SECRET|TOKEN|PASSWORD|(?:^|_)PASS(?:$|_)|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|(?:^|_)SALT(?:$|_))"
 )
+_SETTINGS_APPLY_ALLOWED_SERVICES = frozenset({
+    "llama-server", "open-webui", "litellm", "langfuse", "n8n",
+    "openclaw", "opencode", "perplexica", "searxng", "qdrant",
+    "tts", "whisper", "embeddings", "token-spy", "comfyui",
+    "ape", "privacy-shield", "dreamforge",
+})
+_LLAMA_APPLY_KEYS = {
+    "CTX_SIZE", "MAX_CONTEXT", "GGUF_FILE", "GGUF_URL", "GGUF_SHA256",
+    "LLM_MODEL", "LLM_MODEL_SIZE_MB", "LLM_BACKEND", "N_GPU_LAYERS", "GPU_BACKEND",
+    "OLLAMA_PORT", "OLLAMA_URL", "LLM_API_URL", "MODEL_PROFILE",
+}
+_OPEN_WEBUI_APPLY_KEYS = {
+    "ENABLE_IMAGE_GENERATION", "IMAGE_GENERATION_ENGINE", "IMAGE_SIZE",
+    "IMAGE_STEPS", "IMAGE_GENERATION_MODEL", "COMFYUI_BASE_URL",
+    "COMFYUI_WORKFLOW", "COMFYUI_WORKFLOW_NODES", "AUDIO_STT_ENGINE",
+    "AUDIO_STT_OPENAI_API_BASE_URL", "AUDIO_STT_OPENAI_API_KEY",
+    "AUDIO_STT_MODEL", "AUDIO_TTS_ENGINE", "AUDIO_TTS_OPENAI_API_BASE_URL",
+    "AUDIO_TTS_OPENAI_API_KEY", "AUDIO_TTS_MODEL", "AUDIO_TTS_VOICE",
+}
+_TOKEN_SPY_APPLY_KEYS = {
+    "TOKEN_SPY_URL", "TOKEN_SPY_API_KEY",
+}
+_PRIVACY_SHIELD_APPLY_KEYS = {
+    "TARGET_API_URL", "PII_CACHE_ENABLED", "SHIELD_PORT",
+}
+_MANUAL_RESTART_KEYS = {
+    "DASHBOARD_API_KEY", "DREAM_AGENT_KEY", "DASHBOARD_PORT",
+    "DASHBOARD_API_PORT", "DREAM_AGENT_PORT", "DREAM_AGENT_HOST",
+}
 
 # --- Router imports ---
 from routers import workflows, features, setup, updates, agents, privacy, extensions, gpu as gpu_router, resources, voice
@@ -545,6 +579,100 @@ def _serialize_form_values(
     return serialized
 
 
+def _match_apply_service(key: str) -> Optional[str]:
+    if key in _LLAMA_APPLY_KEYS or key.startswith(("LLAMA_", "GGUF_")):
+        return "llama-server"
+    if (
+        key in _OPEN_WEBUI_APPLY_KEYS
+        or key.startswith("WEBUI_")
+        or key.startswith("OPENAI_API_")
+        or key.startswith("SEARXNG_")
+    ):
+        return "open-webui"
+    if key in _TOKEN_SPY_APPLY_KEYS or key.startswith("TOKEN_SPY_"):
+        return "token-spy"
+    if key in _PRIVACY_SHIELD_APPLY_KEYS or key.startswith("SHIELD_"):
+        return "privacy-shield"
+    if key.startswith("LITELLM_"):
+        return "litellm"
+    if key.startswith("LANGFUSE_"):
+        return "langfuse"
+    if key.startswith("N8N_"):
+        return "n8n"
+    if key.startswith("COMFYUI_"):
+        return "comfyui"
+    if key.startswith("WHISPER_"):
+        return "whisper"
+    if key.startswith("QDRANT_"):
+        return "qdrant"
+    if key.startswith("TTS_") or key.startswith("KOKORO_"):
+        return "tts"
+    if key.startswith("EMBEDDINGS_"):
+        return "embeddings"
+    if key.startswith("PERPLEXICA_"):
+        return "perplexica"
+    if key.startswith("APE_"):
+        return "ape"
+    return None
+
+
+def _build_apply_summary(services: list[str], manual_keys: list[str]) -> str:
+    if services and manual_keys:
+        return (
+            f"Saved changes can be applied now to {', '.join(services)}. "
+            f"Other keys still need a broader manual restart: {', '.join(manual_keys)}."
+        )
+    if services:
+        return f"Saved changes are ready to apply to {', '.join(services)}."
+    if manual_keys:
+        return (
+            "Saved changes were written to .env, but these keys still need a manual stack restart: "
+            + ", ".join(manual_keys)
+            + "."
+        )
+    return "No service recreation is required for the saved keys."
+
+
+def _compute_env_apply_plan(previous_values: dict[str, str], next_values: dict[str, str]) -> dict[str, Any]:
+    changed_keys = sorted(
+        key for key in set(previous_values) | set(next_values)
+        if previous_values.get(key, "") != next_values.get(key, "")
+    )
+    services: set[str] = set()
+    manual_keys: list[str] = []
+
+    for key in changed_keys:
+        service = _match_apply_service(key)
+        if service and service in _SETTINGS_APPLY_ALLOWED_SERVICES:
+            services.add(service)
+            continue
+        if key in _MANUAL_RESTART_KEYS or key.startswith("DREAM_AGENT_"):
+            manual_keys.append(key)
+            continue
+        if key not in {"TZ", "TIMEZONE"}:
+            manual_keys.append(key)
+
+    services_list = sorted(services)
+    manual_list = sorted(set(manual_keys))
+    if not changed_keys:
+        status = "none"
+    elif services_list and manual_list:
+        status = "partial"
+    elif services_list:
+        status = "ready"
+    else:
+        status = "manual"
+
+    return {
+        "status": status,
+        "changedKeys": changed_keys,
+        "services": services_list,
+        "manualKeys": manual_list,
+        "supported": bool(services_list),
+        "summary": _build_apply_summary(services_list, manual_list),
+    }
+
+
 def _render_env_from_values(values: dict[str, str]) -> str:
     example_path = _resolve_template_path(".env.example")
     seen: set[str] = set()
@@ -599,7 +727,36 @@ def _clear_settings_caches():
         _cache._store.pop(key, None)
 
 
-def _build_settings_env_payload(*, raw_text: Optional[str] = None, backup_path: Optional[str] = None) -> dict:
+def _call_agent_core_recreate(service_ids: list[str]) -> dict[str, Any]:
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {DREAM_AGENT_KEY}",
+    }
+    data = json.dumps({"service_ids": service_ids}).encode("utf-8")
+    request = urllib.request.Request(
+        f"{AGENT_URL}/v1/core/recreate",
+        data=data,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=180) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _check_host_agent_available() -> bool:
+    try:
+        with urllib.request.urlopen(f"{AGENT_URL}/health", timeout=3) as response:
+            return response.status == 200
+    except Exception:
+        return False
+
+
+def _build_settings_env_payload(
+    *,
+    raw_text: Optional[str] = None,
+    backup_path: Optional[str] = None,
+    apply_plan: Optional[dict[str, Any]] = None,
+) -> dict:
     env_path = _resolve_runtime_env_path()
     if raw_text is None:
         try:
@@ -632,8 +789,10 @@ def _build_settings_env_payload(*, raw_text: Optional[str] = None, backup_path: 
         "sections": sections,
         "issues": issues,
         "saveHint": "Saving writes the .env file directly, keeps existing secret values when left blank, never sends stored secrets back to the browser, and stores a timestamped backup under data/config-backups first.",
-        "restartHint": "Most DreamServer services need a rebuild or restart before changed values fully take effect.",
+        "restartHint": "Some DreamServer services need a container recreate before changed values fully take effect. Use Apply changes when it becomes available after saving.",
         "backupPath": backup_path,
+        "applyPlan": apply_plan,
+        "agentAvailable": _check_host_agent_available(),
     }
 
 
@@ -683,7 +842,7 @@ def _write_text_atomic(path: Path, raw_text: str):
             pass
 
 
-def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]]]:
+def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]], dict[str, Any]]:
     mode = payload.get("mode", "form")
     env_path = _resolve_runtime_env_path()
     current_values, _ = _read_env_map_from_path(env_path)
@@ -711,13 +870,14 @@ def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]
                 "message": "Field is not editable from the dashboard. Only schema-backed fields and existing local overrides can be changed here.",
             }
             for key in invalid_keys
-        ]
+        ], _compute_env_apply_plan(current_values, current_values)
 
     normalized_values = _serialize_form_values(submitted_values, base_fields, current_values)
     merged_values = {**current_values, **normalized_values}
     merged_fields = _build_env_fields(schema_properties, required_keys, merged_values)
     issues = _validate_env_values(merged_values, merged_fields)
-    return _render_env_from_values(merged_values), issues
+    apply_plan = _compute_env_apply_plan(current_values, merged_values)
+    return _render_env_from_values(merged_values), issues, apply_plan
 
 # --- App ---
 
@@ -1198,7 +1358,7 @@ async def api_settings_env_save(
     api_key: str = Depends(verify_api_key),
 ):
     env_path = _resolve_runtime_env_path()
-    raw_text, issues = await asyncio.to_thread(_prepare_env_save, payload)
+    raw_text, issues, apply_plan = await asyncio.to_thread(_prepare_env_save, payload)
     if issues:
         raise HTTPException(
             status_code=400,
@@ -1239,9 +1399,64 @@ async def api_settings_env_save(
         ) from exc
 
     _clear_settings_caches()
-    result = await asyncio.to_thread(_build_settings_env_payload, raw_text=raw_text, backup_path=backup_relative)
+    result = await asyncio.to_thread(
+        _build_settings_env_payload,
+        raw_text=raw_text,
+        backup_path=backup_relative,
+        apply_plan=apply_plan,
+    )
     _cache.set("settings_env", result, _SETTINGS_ENV_CACHE_TTL)
     return result
+
+
+@app.post("/api/settings/env/apply")
+async def api_settings_env_apply(
+    payload: dict[str, Any] = Body(...),
+    api_key: str = Depends(verify_api_key),
+):
+    service_ids = payload.get("service_ids", [])
+    if not isinstance(service_ids, list) or not service_ids:
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "service_ids must be a non-empty list."},
+        )
+
+    normalized: list[str] = []
+    for service_id in sorted(set(service_ids)):
+        if not isinstance(service_id, str) or service_id not in _SETTINGS_APPLY_ALLOWED_SERVICES:
+            raise HTTPException(
+                status_code=400,
+                detail={"message": f"Service is not eligible for dashboard-triggered apply: {service_id}"},
+            )
+        normalized.append(service_id)
+
+    try:
+        await asyncio.to_thread(_call_agent_core_recreate, normalized)
+        _clear_settings_caches()
+        return {
+            "success": True,
+            "services": normalized,
+            "message": f"Applied runtime changes to {', '.join(normalized)}.",
+        }
+    except urllib.error.HTTPError as exc:
+        detail = f"Host agent returned HTTP {exc.code}."
+        try:
+            payload = json.loads(exc.read().decode("utf-8"))
+            detail = payload.get("error", detail)
+        except Exception:
+            pass
+        raise HTTPException(status_code=503, detail={"message": detail}) from exc
+    except urllib.error.URLError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Dream host agent is not reachable. Start the host agent, then try Apply changes again."},
+        ) from exc
+    except OSError as exc:
+        logger.exception("Settings apply failed")
+        raise HTTPException(
+            status_code=500,
+            detail={"message": f"Could not apply runtime changes: {exc}"},
+        ) from exc
 
 
 # --- Service Health Polling ---

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2,7 +2,7 @@
 
 import importlib.util
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 # Import the host agent module from bin/ using importlib.
 # The module has an ``if __name__ == "__main__":`` guard so no server starts.
@@ -14,6 +14,9 @@ _spec.loader.exec_module(_mod)
 
 _parse_mem_value = _mod._parse_mem_value
 _iso_now = _mod._iso_now
+_to_bash_path = _mod._to_bash_path
+resolve_compose_flags = _mod.resolve_compose_flags
+validate_core_recreate_ids = _mod.validate_core_recreate_ids
 
 
 # --- _parse_mem_value ---
@@ -70,3 +73,47 @@ class TestIsoNow:
     def test_contains_t_separator(self):
         result = _iso_now()
         assert "T" in result
+
+
+class TestToBashPath:
+
+    def test_leaves_posix_paths_unchanged(self, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Linux")
+        assert _to_bash_path(PurePosixPath("/opt/dream-server")) == "/opt/dream-server"
+
+    def test_converts_windows_drive_path(self, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        assert _to_bash_path(Path(r"C:\Users\Gabriel\dream-server")) == "/c/Users/Gabriel/dream-server"
+
+
+class TestValidateCoreRecreateIds:
+
+    def test_accepts_allowed_core_service(self, monkeypatch):
+        monkeypatch.setattr(_mod, "CORE_SERVICE_IDS", {"llama-server", "dashboard-api"})
+        ok, error = validate_core_recreate_ids(["llama-server"])
+        assert ok is True
+        assert error == ""
+
+    def test_rejects_non_core_service(self, monkeypatch):
+        monkeypatch.setattr(_mod, "CORE_SERVICE_IDS", {"dashboard-api"})
+        ok, error = validate_core_recreate_ids(["llama-server"])
+        assert ok is False
+        assert "not a core" in error.lower()
+
+    def test_rejects_disallowed_core_service(self, monkeypatch):
+        monkeypatch.setattr(_mod, "CORE_SERVICE_IDS", {"dashboard-api"})
+        ok, error = validate_core_recreate_ids(["dashboard-api"])
+        assert ok is False
+        assert "not eligible" in error.lower()
+
+
+class TestResolveComposeFlags:
+
+    def test_prefers_saved_compose_flags_file(self, tmp_path, monkeypatch):
+        install_dir = tmp_path / "dream-server"
+        install_dir.mkdir()
+        (install_dir / ".compose-flags").write_text("--env-file .env -f docker-compose.base.yml", encoding="utf-8")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        assert resolve_compose_flags() == ["--env-file", ".env", "-f", "docker-compose.base.yml"]

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -126,6 +126,8 @@ def test_api_settings_env_preserves_existing_secret_when_blank(test_client, sett
     assert payload["values"]["OPENAI_API_KEY"] == ""
     assert payload["fields"]["OPENAI_API_KEY"]["hasValue"] is True
     assert payload["backupPath"].startswith("data/config-backups/.env.backup.")
+    assert payload["applyPlan"]["status"] == "ready"
+    assert payload["applyPlan"]["services"] == ["llama-server", "open-webui"]
 
 
 def test_api_settings_env_rejects_raw_mode(test_client, settings_env_fixture):
@@ -217,3 +219,59 @@ def test_api_settings_env_rejects_null_byte_in_value(test_client, settings_env_f
 
     assert response.status_code == 400
     assert "invalid characters" in response.json()["detail"]
+
+
+def test_api_settings_env_save_returns_llama_apply_plan(test_client, settings_env_fixture):
+    env_path = settings_env_fixture["env_path"]
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8") + "CTX_SIZE=8192\n",
+        encoding="utf-8",
+    )
+
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {
+                "CTX_SIZE": "16384",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["applyPlan"]["status"] == "ready"
+    assert payload["applyPlan"]["services"] == ["llama-server"]
+    assert "llama-server" in payload["applyPlan"]["summary"]
+
+
+def test_api_settings_env_apply_calls_host_agent(test_client, monkeypatch):
+    captured = {}
+
+    def fake_call(service_ids):
+        captured["service_ids"] = service_ids
+        return {"status": "ok"}
+
+    monkeypatch.setattr("main._call_agent_core_recreate", fake_call)
+
+    response = test_client.post(
+        "/api/settings/env/apply",
+        headers=test_client.auth_headers,
+        json={"service_ids": ["llama-server"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert captured["service_ids"] == ["llama-server"]
+
+
+def test_api_settings_env_apply_rejects_disallowed_service(test_client):
+    response = test_client.post(
+        "/api/settings/env/apply",
+        headers=test_client.auth_headers,
+        json={"service_ids": ["dashboard-api"]},
+    )
+
+    assert response.status_code == 400
+    assert "not eligible" in response.json()["detail"]["message"].lower()

--- a/dream-server/extensions/services/dashboard/src/components/__tests__/EnvEditor.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/__tests__/EnvEditor.test.jsx
@@ -78,4 +78,19 @@ describe('EnvEditor', () => {
     expect(screen.getByPlaceholderText('Not set')).toBeInTheDocument()
     expect(screen.getByText(/Enter a value to store this secret/i)).toBeInTheDocument()
   })
+
+  test('enables apply button when a saved runtime change can be applied', () => {
+    renderEditor({
+      applyPlan: {
+        status: 'ready',
+        supported: true,
+        services: ['llama-server'],
+        summary: 'Saved changes are ready to apply to llama-server.',
+      },
+    })
+
+    expect(screen.getByRole('button', { name: /apply changes/i })).toBeEnabled()
+    expect(screen.getByText(/Pending runtime changes/i)).toBeInTheDocument()
+    expect(screen.getAllByText(/llama-server/i).length).toBeGreaterThan(0)
+  })
 })

--- a/dream-server/extensions/services/dashboard/src/components/settings/EnvEditor.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/settings/EnvEditor.jsx
@@ -16,10 +16,14 @@ export default function EnvEditor({
   onFieldChange,
   onReload,
   onSave,
+  onApply = () => {},
   dirty,
   saving,
+  applyPlan = null,
+  applying = false,
 }) {
   const activeKeys = activeSection?.keys || []
+  const canApply = Boolean(applyPlan?.supported && applyPlan?.services?.length > 0 && editor?.agentAvailable !== false)
 
   return (
     <div className="space-y-4">
@@ -40,6 +44,12 @@ export default function EnvEditor({
           <div className="flex flex-wrap items-center gap-2">
             <ToolbarButton icon={RefreshCw} label="Reload" onClick={onReload} />
             <ToolbarButton icon={Save} label={saving ? 'Saving...' : 'Save .env'} onClick={onSave} primary disabled={!dirty || saving} />
+            <ToolbarButton
+              icon={RefreshCw}
+              label={applying ? 'Applying...' : 'Apply changes'}
+              onClick={onApply}
+              disabled={!canApply || applying || saving}
+            />
           </div>
         </div>
 
@@ -47,12 +57,30 @@ export default function EnvEditor({
           <Chip>{Object.keys(fields || {}).length} fields</Chip>
           <Chip>{issues.length} validation issue{issues.length === 1 ? '' : 's'}</Chip>
           {editor.backupPath ? <Chip accent>last backup {editor.backupPath}</Chip> : null}
+          {applyPlan?.status && applyPlan.status !== 'none' ? <Chip accent>{applyPlan.status}</Chip> : null}
         </div>
       </div>
 
-      <div className="grid gap-3 sm:grid-cols-2">
+      {applyPlan?.status && applyPlan.status !== 'none' ? (
+        <div className="rounded-xl border border-theme-accent/20 bg-theme-accent/10 px-4 py-3">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-theme-accent-light">Pending runtime changes</p>
+          <p className="mt-1 text-sm text-theme-text">{applyPlan.summary}</p>
+        </div>
+      ) : null}
+
+      <div className="grid gap-3 sm:grid-cols-3">
         <Hint title="Save behavior" text={editor.saveHint} />
         <Hint title="Restart behavior" text={editor.restartHint} />
+        <Hint
+          title="Apply behavior"
+          text={
+            editor?.agentAvailable === false
+              ? 'Dream host agent is offline. Start it first, then use Apply changes to recreate affected services.'
+              : canApply
+                ? `Apply changes will recreate: ${applyPlan.services.join(', ')}.`
+                : 'Apply changes becomes available after saving keys that affect running services.'
+          }
+        />
       </div>
 
       {issues.length > 0 ? (

--- a/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
@@ -80,8 +80,10 @@ export default function Settings() {
   const [envSearch, setEnvSearch] = useState('')
   const [envActiveSection, setEnvActiveSection] = useState(null)
   const [envSaving, setEnvSaving] = useState(false)
+  const [envApplying, setEnvApplying] = useState(false)
   const [envIssues, setEnvIssues] = useState([])
   const [envRevealSecrets, setEnvRevealSecrets] = useState({})
+  const [envApplyPlan, setEnvApplyPlan] = useState(null)
   const [statusCache, setStatusCache] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -95,6 +97,7 @@ export default function Settings() {
     setEnvValuesOriginal(payload?.values || {})
     setEnvIssues(payload?.issues || [])
     setEnvRevealSecrets({})
+    setEnvApplyPlan(payload?.applyPlan || null)
     setEnvActiveSection(current => (current && payload?.sections?.some(section => section.id === current)) ? current : (payload?.sections?.[0]?.id || null))
   }
 
@@ -168,12 +171,30 @@ export default function Settings() {
         body: JSON.stringify({ mode: 'form', values: envValues }),
       })
       applyEnvEditorPayload(payload)
-      setNotice({ type: 'info', text: `.env saved.${payload?.backupPath ? ` Backup: ${payload.backupPath}.` : ''} Restart or rebuild the stack to apply service-level changes.` })
+      setNotice({ type: 'info', text: `.env saved.${payload?.backupPath ? ` Backup: ${payload.backupPath}.` : ''} ${payload?.applyPlan?.summary || 'Restart or rebuild the stack to apply service-level changes.'}` })
     } catch (err) {
       if (err?.details?.issues?.length) setEnvIssues(err.details.issues)
       setNotice({ type: 'danger', text: getErrorText(err) })
     } finally {
       setEnvSaving(false)
+    }
+  }
+
+  const handleApplyEnv = async () => {
+    if (!envApplyPlan?.supported || !envApplyPlan?.services?.length) return
+    setEnvApplying(true)
+    try {
+      const payload = await fetchPayload('/api/settings/env/apply', 180000, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ service_ids: envApplyPlan.services }),
+      })
+      setEnvApplyPlan(null)
+      setNotice({ type: 'info', text: payload?.message || 'Runtime changes applied successfully.' })
+    } catch (err) {
+      setNotice({ type: 'danger', text: getErrorText(err) })
+    } finally {
+      setEnvApplying(false)
     }
   }
 
@@ -228,7 +249,7 @@ export default function Settings() {
 
         {services.length > 0 ? <SettingsSection title="Routing Table" icon={Network}><div className="space-y-3"><div className="flex flex-wrap items-center gap-2"><p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-theme-text-muted/60">route surfaces</p><span className="rounded-full border border-white/10 bg-black/[0.12] px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.16em] text-theme-text">{getDashboardHost()}</span></div><div className="grid gap-3 xl:grid-cols-3">{routingGroups.map(group => <RoutingGroup key={group.key} {...group} />)}</div></div></SettingsSection> : null}
 
-        {envEditor ? <SettingsSection title="Environment Editor" icon={FileText}><EnvEditor editor={envEditor} search={envSearch} onSearchChange={setEnvSearch} sections={envSections} activeSection={activeEnvSection} onSectionChange={setEnvActiveSection} fields={envFields} values={envValues} issues={envIssues} issueMap={envIssueMap} revealedSecrets={envRevealSecrets} onToggleReveal={(key) => setEnvRevealSecrets(current => ({ ...current, [key]: !current[key] }))} onFieldChange={(key, value) => setEnvValues(current => ({ ...current, [key]: value }))} onReload={() => fetchEnvEditor({ announce: true })} onSave={handleSaveEnv} dirty={envDirty} saving={envSaving} /></SettingsSection> : null}
+        {envEditor ? <SettingsSection title="Environment Editor" icon={FileText}><EnvEditor editor={envEditor} search={envSearch} onSearchChange={setEnvSearch} sections={envSections} activeSection={activeEnvSection} onSectionChange={setEnvActiveSection} fields={envFields} values={envValues} issues={envIssues} issueMap={envIssueMap} revealedSecrets={envRevealSecrets} onToggleReveal={(key) => setEnvRevealSecrets(current => ({ ...current, [key]: !current[key] }))} onFieldChange={(key, value) => setEnvValues(current => ({ ...current, [key]: value }))} onReload={() => fetchEnvEditor({ announce: true })} onSave={handleSaveEnv} onApply={handleApplyEnv} dirty={envDirty} saving={envSaving} applyPlan={envApplyPlan} applying={envApplying} /></SettingsSection> : null}
 
         <SettingsSection title="Storage" icon={HardDrive}><StorageBlock storage={storage} /></SettingsSection>
         <SettingsSection title="Updates" icon={RefreshCw}><div className="flex items-center justify-between gap-4"><div><p className="text-theme-text">{version?.update_available && version?.latest ? `Update available: v${version.latest}` : `Installed version: v${version?.version || 'Unknown'}`}</p><p className="text-sm text-theme-text-muted">{version?.checked_at ? `Last checked: ${new Date(version.checked_at).toLocaleString()}` : 'Checks GitHub in the background to avoid blocking the page.'}</p></div><button onClick={() => { setNotice({ type: 'info', text: 'Checking for updates...' }); void fetchVersionInfo({ announce: true }) }} className="liquid-metal-button px-4 py-2 text-white rounded-lg text-sm flex items-center gap-2"><RefreshCw size={16} />Check for Updates</button></div></SettingsSection>


### PR DESCRIPTION
This PR addresses a real Settings UX/runtime gap: saving `.env` changes was not enough for compose-substituted runtime values like `CTX_SIZE`, because affected services still needed container recreation before the new values actually took effect.

What this adds:
- an explicit `Apply changes` flow in the Settings env editor
- service-level apply planning after save, instead of asking users to guess when a manual restart is needed
- host-agent-driven recreation of allowed runtime services, rather than arbitrary shell execution
- graceful fallback when the host agent is offline
- Windows compatibility improvements in the host agent by reusing saved `.compose-flags`

I validated this locally on Windows with the current Docker stack by changing `CTX_SIZE` from `16384 -> 12288 -> 16384`, applying through the new flow, and confirming that `llama-server` actually reloaded with the updated `--ctx-size` each time.

Validation:
- `pytest tests/test_settings_env.py tests/test_host_agent.py`
- `vitest run src/components/__tests__/EnvEditor.test.jsx`
- local Docker rebuild and live end-to-end test on `localhost:3001` and `localhost:11434`
- linux/macOs/windows ✅