### PR TITLE
fix: use $DOCKER_CMD instead of bare docker in installer phases 11-13

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -303,7 +303,7 @@ MODELS_INI_EOF
     [[ "$ENABLE_COMFYUI" == "true" ]] && _build_services+=(comfyui)
     if [[ "${ENABLE_DREAMFORGE:-}" == "true" ]]; then
         _dreamforge_image="${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:latest}"
-        if ! docker image inspect "$_dreamforge_image" &>/dev/null; then
+        if ! $DOCKER_CMD image inspect "$_dreamforge_image" &>/dev/null; then
             _build_services+=(dreamforge)
         else
             log "DreamForge image found locally — skipping source build"
@@ -346,11 +346,11 @@ MODELS_INI_EOF
     # starting other containers. Some end up in "Created", others never got
     # past "Creating" because their dependencies weren't ready yet.
     # Step 1: start any containers already in Created state
-    docker start $(docker ps -a --filter status=created -q) 2>/dev/null || true
+    $DOCKER_CMD start $($DOCKER_CMD ps -a --filter status=created -q 2>/dev/null) 2>/dev/null || true
     # Step 2: second compose pass picks up services whose deps are now healthy
     $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" up -d --no-build >> "$LOG_FILE" 2>&1 || true
     # Step 3: catch any stragglers from the second pass
-    docker start $(docker ps -a --filter status=created -q) 2>/dev/null || true
+    $DOCKER_CMD start $($DOCKER_CMD ps -a --filter status=created -q 2>/dev/null) 2>/dev/null || true
 
     if $compose_ok; then
         printf "\r  ${BGRN}✓${NC} %-60s\n" "All containers launched"

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -86,7 +86,7 @@ fi
 # We use the /api/config HTTP endpoint to set values after the service starts.
 # Retry up to 5 times with 10s delay — Perplexica may still be starting
 # (especially if it was stuck in "Created" state and started late).
-if docker inspect dream-perplexica &>/dev/null; then
+if $DOCKER_CMD inspect dream-perplexica &>/dev/null; then
     PERPLEXICA_URL="http://localhost:${SERVICE_PORTS[perplexica]:-3004}"
     PYTHON_CMD="python3"
     if [[ -f "$SCRIPT_DIR/lib/python-cmd.sh" ]]; then

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -288,7 +288,7 @@ fi
 #=============================================================================
 if ! $DRY_RUN; then
     # Check Perplexica config was seeded (phase 12 may have failed silently)
-    if docker inspect dream-perplexica &>/dev/null; then
+    if $DOCKER_CMD inspect dream-perplexica &>/dev/null; then
         _perplexica_status=$(curl -sf --max-time 5 "http://localhost:${SERVICE_PORTS[perplexica]:-3004}/api/config" 2>>"$LOG_FILE" | \
             "$PYTHON_CMD" -c "import sys,json;d=json.load(sys.stdin);print('ok' if d['values'].get('setupComplete') else 'needed')" 2>>"$LOG_FILE" || echo "skip")
         if [[ "$_perplexica_status" == "needed" ]]; then


### PR DESCRIPTION
## What
Replace 5 bare `docker` calls with `$DOCKER_CMD` in installer phases 11–13.

## Why
Phase 05 sets `DOCKER_CMD="sudo docker"` when the user is not in the docker group. Five locations in later phases bypass this by calling `docker` directly, causing "permission denied" on the Docker socket during container recovery (phase 11) and health checks (phases 12/13).

Reported by a user on a fresh Ubuntu 24.04 install (Dell Pro Max GB10) where the installer correctly detected `sudo docker` was needed but later phases ignored it.

## How
Substitute `docker` → `$DOCKER_CMD` in all 5 call sites:

- `11-services.sh:306` — `docker image inspect` (DreamForge image check)
- `11-services.sh:349` — `docker start $(docker ps -a ...)` (container recovery step 1)
- `11-services.sh:353` — `docker start $(docker ps -a ...)` (container recovery step 3)
- `12-health.sh:89` — `docker inspect` (Perplexica auto-config gate)
- `13-summary.sh:291` — `docker inspect` (Perplexica post-install validation)

The inner `$()` subshells on lines 349/353 also get `2>/dev/null` to suppress stderr from the subshell when permissions fail.

## Testing
- `bash -n`: all 3 modified files pass syntax check
- `shellcheck`: no new warnings introduced
- `$DOCKER_CMD` scope verified: Phase 05 defines it before Phases 11/12/13
- Manual: requires Linux VM where user is NOT in docker group

## Review
Critique Guardian: ✅ APPROVED (all five pillars clean)

## Platform Impact
- **Linux:** Fix applies — resolves permission denied for non-docker-group users
- **WSL2:** Fix applies — same code path as Linux
- **macOS:** Not affected — uses separate installer (`installers/macos/`)

Closes #871