### PR TITLE
fix(installer): prevent Phase 10 from clobbering rendered host agent service file

### DIFF
--- a/dream-server/installers/phases/10-amd-tuning.sh
+++ b/dream-server/installers/phases/10-amd-tuning.sh
@@ -73,10 +73,14 @@ elif [[ "$GPU_BACKEND" == "amd" ]] && ! $DRY_RUN; then
     chmod +x "$INSTALL_DIR/scripts/session-cleanup.sh" \
              "$INSTALL_DIR/memory-shepherd/memory-shepherd.sh" 2>/dev/null || true
 
-    # Copy all systemd unit files
+    # Copy systemd unit files — skip dream-host-agent.service which was already
+    # rendered with path substitutions (__INSTALL_DIR__ etc.) by phase 07.
     if [[ -d "$INSTALL_DIR/scripts/systemd" ]]; then
-        cp "$INSTALL_DIR/scripts/systemd"/*.service "$INSTALL_DIR/scripts/systemd"/*.timer \
-            "$SYSTEMD_USER_DIR/" 2>/dev/null || true
+        for _unit in "$INSTALL_DIR/scripts/systemd"/*.service "$INSTALL_DIR/scripts/systemd"/*.timer; do
+            [[ -f "$_unit" ]] || continue
+            [[ "$(basename "$_unit")" == "dream-host-agent.service" ]] && continue
+            cp "$_unit" "$SYSTEMD_USER_DIR/" 2>/dev/null || true
+        done
     fi
 
     # Create archive directories for memory shepherd


### PR DESCRIPTION
## Summary
On AMD machines, Phase 10 (AMD tuning) overwrites the host agent systemd service file that Phase 07 already rendered with real paths. The raw template with `__INSTALL_DIR__`, `__PYTHON3__`, `__HOME__` placeholders gets deployed, breaking the host agent.

NVIDIA machines are unaffected because Phase 10 only runs on AMD.

## Root cause
Phase 10 line 78: `cp "$INSTALL_DIR/scripts/systemd"/*.service ... "$SYSTEMD_USER_DIR/"` — wildcard copy grabs the raw template and overwrites Phase 07's rendered version.

## Fix
Replace the wildcard `cp` with a loop that skips `dream-host-agent.service`:
```bash
for _unit in "$INSTALL_DIR/scripts/systemd"/*.service "$INSTALL_DIR/scripts/systemd"/*.timer; do
    [[ "$(basename "$_unit")" == "dream-host-agent.service" ]] && continue
    cp "$_unit" "$SYSTEMD_USER_DIR/" 2>/dev/null || true
done
```

All other systemd units (session-cleanup, memory-shepherd timers) are still copied.

## Verification
- [x] `bash -n` syntax check passes
- [x] Skip logic verified in code

🤖 Generated with [Claude Code](https://claude.com/claude-code)