### PR TITLE
feat(extensions): service dependency visibility + lifecycle hooks

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -21,10 +21,16 @@ from pathlib import Path
 from socketserver import ThreadingMixIn
 
 VERSION = "1.0.0"
+DREAM_VERSION = VERSION
 SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 MAX_BODY = 16384
 SUBPROCESS_TIMEOUT_START = 600  # 10 min — image pulls can be slow
 SUBPROCESS_TIMEOUT_STOP = 120   # 2 min — stop should be fast
+HOOK_TIMEOUT = 120              # 2 min — hook execution timeout
+VALID_HOOK_NAMES = frozenset({
+    "pre_install", "post_install", "pre_start", "post_start",
+    "pre_uninstall", "post_uninstall",
+})
 logger = logging.getLogger("dream-host-agent")
 
 # Hardcoded fallback — used when core-service-ids.json is missing or unreadable.
@@ -46,6 +52,7 @@ CORE_SERVICE_IDS: set = set()
 # Core services that can be toggled via the extension API (e.g., privacy shield)
 TOGGLABLE_CORE_SERVICES: set = {"privacy-shield"}
 USER_EXTENSIONS_DIR: Path = Path()
+EXTENSIONS_DIR: Path = Path()
 
 # Per-service locks to prevent concurrent start+stop races on the same service
 _service_locks: dict[str, threading.Lock] = collections.defaultdict(threading.Lock)
@@ -389,6 +396,101 @@ def _resolve_container_name(service_id: str) -> str:
     return f"dream-{service_id}"
 
 
+def _read_manifest(ext_dir: Path) -> dict | None:
+    """Read and return the parsed manifest from an extension directory."""
+    for name in ("manifest.yaml", "manifest.yml"):
+        candidate = ext_dir / name
+        if candidate.exists():
+            try:
+                import yaml
+                manifest = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+                if isinstance(manifest, dict):
+                    return manifest
+            except ImportError:
+                logger.error("PyYAML not available on host")
+                return None  # no point trying other files without PyYAML
+            except (OSError, yaml.YAMLError) as exc:
+                logger.warning("Failed to read manifest %s: %s", candidate, exc)
+                continue  # try next candidate
+    return None
+
+
+def _validate_hook_path(ext_dir: Path, hook_script: str) -> Path | None:
+    """Resolve hook path and verify it stays inside ext_dir."""
+    hook_path = (ext_dir / hook_script).resolve()
+    try:
+        hook_path.relative_to(ext_dir.resolve())
+    except ValueError:
+        logger.warning("Path traversal attempt in hook for %s: %s", ext_dir.name, hook_script)
+        return None
+    if not hook_path.is_file():
+        return None
+    return hook_path
+
+
+def _resolve_hook(ext_dir: Path, hook_name: str) -> Path | None:
+    """Resolve a lifecycle hook script from an extension manifest.
+
+    Checks ``hooks`` map first, falls back to ``setup_hook`` for
+    ``post_install`` only.
+    """
+    manifest = _read_manifest(ext_dir)
+    if manifest is None:
+        return None
+    service_def = manifest.get("service", {})
+    if not isinstance(service_def, dict):
+        return None
+
+    # Check hooks map first
+    hooks = service_def.get("hooks", {})
+    if isinstance(hooks, dict):
+        hook_script = hooks.get(hook_name, "")
+        if isinstance(hook_script, str) and hook_script:
+            return _validate_hook_path(ext_dir, hook_script)
+
+    # Fallback: setup_hook -> post_install only
+    if hook_name == "post_install":
+        setup_hook = service_def.get("setup_hook", "")
+        if isinstance(setup_hook, str) and setup_hook:
+            return _validate_hook_path(ext_dir, setup_hook)
+
+    return None
+
+
+def _check_bash_version() -> tuple[bool, str]:
+    """On macOS, verify bash >= 4.0. Returns (ok, message)."""
+    if platform.system() != "Darwin":
+        return True, ""
+    try:
+        result = subprocess.run(
+            ["bash", "--version"],
+            capture_output=True, text=True, timeout=5,
+        )
+        # Parse "GNU bash, version X.Y.Z..."
+        import re as _re
+        match = _re.search(r"version (\d+)\.(\d+)", result.stdout)
+        if match:
+            major = int(match.group(1))
+            if major < 4:
+                return False, f"Bash {match.group(1)}.{match.group(2)} is too old (need 4.0+). Install via: brew install bash"
+        return True, ""
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return False, f"Could not check bash version: {exc}"
+
+
+def _find_ext_dir(service_id: str) -> Path | None:
+    """Find extension directory for a service_id (user-installed or built-in)."""
+    # Check user extensions first
+    user_dir = USER_EXTENSIONS_DIR / service_id
+    if user_dir.is_dir():
+        return user_dir
+    # Check built-in extensions
+    builtin_dir = EXTENSIONS_DIR / service_id
+    if builtin_dir.is_dir():
+        return builtin_dir
+    return None
+
+
 class AgentHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         logger.info(fmt, *args)
@@ -486,6 +588,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_install()
         elif self.path == "/v1/extension/setup-hook":
             self._handle_setup_hook()
+        elif self.path == "/v1/extension/hooks":
+            self._handle_hook()
         elif self.path == "/v1/service/logs":
             self._handle_service_logs()
         elif self.path == "/v1/model/download":
@@ -663,6 +767,7 @@ class AgentHandler(BaseHTTPRequestHandler):
 
 
     def _handle_setup_hook(self):
+        """Backwards-compatible wrapper — delegates to hook resolution with post_install."""
         if not check_auth(self):
             return
         body = read_json_body(self)
@@ -672,73 +777,119 @@ class AgentHandler(BaseHTTPRequestHandler):
         if service_id is None:
             return
 
-        # Read manifest to find setup_hook field
-        ext_dir = USER_EXTENSIONS_DIR / service_id
-        manifest_path = None
-        for name in ("manifest.yaml", "manifest.yml"):
-            candidate = ext_dir / name
-            if candidate.exists():
-                manifest_path = candidate
-                break
-        if manifest_path is None:
-            json_response(self, 404, {"error": f"No manifest found for {service_id}"})
+        ext_dir = _find_ext_dir(service_id)
+        if ext_dir is None:
+            json_response(self, 404, {"error": f"Extension not found: {service_id}"})
             return
 
-        try:
-            import yaml
-            manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-        except ImportError:
-            json_response(self, 500, {"error": "PyYAML not available on host"})
-            return
-        except (OSError, yaml.YAMLError) as exc:
-            json_response(self, 500, {"error": f"Failed to read manifest: {exc}"})
-            return
-
-        if not isinstance(manifest, dict):
-            json_response(self, 404, {"error": "Invalid manifest format"})
-            return
-        service_def = manifest.get("service", {})
-        if not isinstance(service_def, dict):
-            json_response(self, 404, {"error": "Invalid manifest: missing service section"})
-            return
-        setup_hook = service_def.get("setup_hook", "")
-        if not isinstance(setup_hook, str) or not setup_hook:
+        hook_path = _resolve_hook(ext_dir, "post_install")
+        if hook_path is None:
             json_response(self, 404, {"error": f"No setup_hook defined for {service_id}"})
             return
 
-        # Security: resolve hook path and verify it stays inside ext_dir
-        hook_path = (ext_dir / setup_hook).resolve()
-        try:
-            hook_path.relative_to(ext_dir.resolve())
-        except ValueError:
-            logger.warning("Path traversal attempt in setup_hook for %s: %s", service_id, setup_hook)
-            json_response(self, 400, {"error": "setup_hook path escapes extension directory"})
+        self._execute_hook(service_id, ext_dir, hook_path, "post_install")
+
+    def _handle_hook(self):
+        """Generic lifecycle hook endpoint: POST /v1/extension/hooks."""
+        if not check_auth(self):
             return
-        if not hook_path.is_file():
-            json_response(self, 404, {"error": f"setup_hook file not found: {setup_hook}"})
+        body = read_json_body(self)
+        if body is None:
             return
 
-        logger.info("Running setup_hook for %s: %s", service_id, hook_path)
+        # Validate service_id
+        sid = body.get("service_id", "")
+        if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
+            json_response(self, 400, {"error": "Invalid service_id"})
+            return
+
+        # Validate hook name
+        hook_name = body.get("hook", "")
+        if not isinstance(hook_name, str) or hook_name not in VALID_HOOK_NAMES:
+            json_response(self, 400, {
+                "error": f"Invalid hook name. Must be one of: {', '.join(sorted(VALID_HOOK_NAMES))}",
+            })
+            return
+
+        ext_dir = _find_ext_dir(sid)
+        if ext_dir is None:
+            json_response(self, 404, {"error": f"Extension not found: {sid}"})
+            return
+
+        hook_path = _resolve_hook(ext_dir, hook_name)
+        if hook_path is None:
+            # No hook defined — not an error
+            json_response(self, 404, {"error": f"No {hook_name} hook defined for {sid}"})
+            return
+
+        self._execute_hook(sid, ext_dir, hook_path, hook_name)
+
+    def _execute_hook(self, service_id: str, ext_dir: Path, hook_path: Path, hook_name: str):
+        """Execute a resolved hook script with sandboxed environment."""
+        # macOS: validate bash version >= 4.0
+        bash_ok, bash_msg = _check_bash_version()
+        if not bash_ok:
+            json_response(self, 500, {"error": f"Cannot run hook: {bash_msg}"})
+            return
+
+        # Read manifest for service port
+        manifest = _read_manifest(ext_dir)
+        service_def = manifest.get("service", {}) if manifest else {}
+        if not isinstance(service_def, dict):
+            service_def = {}
+
+        # Minimal allowlist environment
+        hook_env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", ""),
+            "SERVICE_ID": service_id,
+            "SERVICE_PORT": str(service_def.get("port", 0)),
+            "SERVICE_DATA_DIR": str(DATA_DIR / service_id),
+            "DREAM_VERSION": DREAM_VERSION,
+            "GPU_BACKEND": GPU_BACKEND,
+            "HOOK_NAME": hook_name,
+        }
+
+        logger.info("Running %s hook for %s: %s", hook_name, service_id, hook_path)
         try:
-            result = subprocess.run(
+            proc = subprocess.Popen(
                 ["bash", str(hook_path), str(INSTALL_DIR), GPU_BACKEND],
-                cwd=str(ext_dir),
-                capture_output=True, text=True, timeout=SUBPROCESS_TIMEOUT_STOP,
+                cwd=str(ext_dir), env=hook_env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                preexec_fn=os.setsid,
             )
-            if result.returncode != 0:
-                logger.error("setup_hook failed for %s (exit %d): %s",
-                             service_id, result.returncode, result.stderr[:500])
+            try:
+                stdout, stderr = proc.communicate(timeout=HOOK_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                proc.wait()
+                json_response(self, 500, {"error": f"{hook_name} hook timed out ({HOOK_TIMEOUT}s)"})
+                return
+
+            if proc.returncode != 0:
+                logger.error("%s hook failed for %s (exit %d): %s",
+                             hook_name, service_id, proc.returncode, (stderr or b"").decode()[:500])
+                # post_start failure is non-terminal
+                if hook_name == "post_start":
+                    json_response(self, 200, {
+                        "status": "warning",
+                        "service_id": service_id,
+                        "hook": hook_name,
+                        "warning": f"post_start hook exited with code {proc.returncode}",
+                        "stderr": (stderr or b"").decode()[:500],
+                    })
+                    return
                 json_response(self, 500, {
-                    "error": f"setup_hook exited with code {result.returncode}",
-                    "stderr": result.stderr[:500],
+                    "error": f"{hook_name} hook exited with code {proc.returncode}",
+                    "stderr": (stderr or b"").decode()[:500],
                 })
                 return
-        except subprocess.TimeoutExpired:
-            json_response(self, 500, {"error": "setup_hook timed out (120s)"})
+        except OSError as exc:
+            json_response(self, 500, {"error": f"Failed to execute hook: {exc}"})
             return
 
-        logger.info("setup_hook completed for %s", service_id)
-        json_response(self, 200, {"status": "ok", "service_id": service_id})
+        logger.info("%s hook completed for %s", hook_name, service_id)
+        json_response(self, 200, {"status": "ok", "service_id": service_id, "hook": hook_name})
 
     def _handle_install(self):
         """Combined install: setup_hook → pull → start with progress tracking."""
@@ -1477,7 +1628,8 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 def main():
-    global INSTALL_DIR, DATA_DIR, AGENT_API_KEY, GPU_BACKEND, TIER, CORE_SERVICE_IDS, USER_EXTENSIONS_DIR
+    global INSTALL_DIR, DATA_DIR, AGENT_API_KEY, GPU_BACKEND, TIER, CORE_SERVICE_IDS
+    global USER_EXTENSIONS_DIR, EXTENSIONS_DIR, DREAM_VERSION
 
     parser = argparse.ArgumentParser(description="DreamServer Host Agent")
     parser.add_argument("--port", type=int, default=7710, help="Listen port (default: 7710)")
@@ -1514,6 +1666,8 @@ def main():
         "DREAM_USER_EXTENSIONS_DIR",
         str(DATA_DIR / "user-extensions"),
     ))
+    EXTENSIONS_DIR = INSTALL_DIR / "extensions" / "services"
+    DREAM_VERSION = env.get("DREAM_VERSION", VERSION)
 
     port = args.port
     env_port = env.get("DREAM_AGENT_PORT", "")

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -291,6 +291,80 @@ _regenerate_compose_flags() {
     fi
 }
 
+# Run a lifecycle hook for a service (reads manifest directly via Python)
+_run_hook() {
+    local service_id="$1" hook_name="$2"
+    local ext_dir="$INSTALL_DIR/extensions/services/$service_id"
+    # Also check user-extensions
+    [[ -d "$ext_dir" ]] || ext_dir="$INSTALL_DIR/data/user-extensions/$service_id"
+    [[ -d "$ext_dir" ]] || return 0
+
+    local hook_path
+    hook_path=$(python3 - "$ext_dir" "$hook_name" <<'PYEOF'
+import yaml, sys
+from pathlib import Path
+
+ext_dir = Path(sys.argv[1])
+hook_name = sys.argv[2]
+
+manifest_path = None
+for name in ("manifest.yaml", "manifest.yml"):
+    candidate = ext_dir / name
+    if candidate.exists():
+        manifest_path = candidate
+        break
+if manifest_path is None:
+    sys.exit(0)
+
+with open(manifest_path) as f:
+    m = yaml.safe_load(f)
+if not isinstance(m, dict):
+    sys.exit(0)
+service = m.get("service", {})
+if not isinstance(service, dict):
+    sys.exit(0)
+
+# Check hooks map first
+hooks = service.get("hooks", {})
+hook_script = ""
+if isinstance(hooks, dict):
+    hook_script = hooks.get(hook_name, "")
+
+# Fallback: setup_hook -> post_install only
+if not hook_script and hook_name == "post_install":
+    hook_script = service.get("setup_hook", "")
+
+if not hook_script:
+    sys.exit(0)
+
+# Validate path containment
+hook_path = (ext_dir / hook_script).resolve()
+try:
+    hook_path.relative_to(ext_dir.resolve())
+except ValueError:
+    print(f"ERROR: hook path escapes extension directory: {hook_script}", file=sys.stderr)
+    sys.exit(1)
+
+if not hook_path.is_file():
+    sys.exit(0)
+
+print(str(hook_path))
+PYEOF
+    ) || return 0
+
+    [[ -z "$hook_path" || ! -f "$hook_path" ]] && return 0
+
+    log "Running $hook_name hook for $service_id..."
+    SERVICE_ID="$service_id" \
+    SERVICE_PORT="${SERVICE_PORTS[$service_id]:-0}" \
+    SERVICE_DATA_DIR="$INSTALL_DIR/data/$service_id" \
+    DREAM_VERSION="$VERSION" \
+    GPU_BACKEND="${GPU_BACKEND:-}" \
+    HOOK_NAME="$hook_name" \
+        bash "$hook_path" "$INSTALL_DIR" "${GPU_BACKEND:-}" \
+        || warn "$hook_name hook failed for $service_id (non-fatal)"
+}
+
 # Build full compose flags: base + GPU overlay + enabled extensions
 get_compose_flags() {
     # Fast path: use saved flags from installer if available
@@ -610,6 +684,7 @@ cmd_start() {
     check_install
     cd "$INSTALL_DIR"
     load_env
+    sr_load
 
     local service="${1:-}"
     local flags_str
@@ -623,9 +698,11 @@ cmd_start() {
         success "All services started"
     else
         service=$(resolve_service "$service")
+        _run_hook "$service" "pre_start"
         log "Starting $service..."
         docker compose "${flags[@]}" up -d "$service"
         success "$service started"
+        _run_hook "$service" "post_start"
     fi
 }
 

--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -96,6 +96,19 @@
         "setup_hook": {
           "type": "string",
           "description": "Relative path to a setup script run during installation (e.g. setup.sh)"
+        },
+        "hooks": {
+          "type": "object",
+          "description": "Lifecycle hook scripts. Paths relative to extension directory.",
+          "properties": {
+            "pre_install": { "type": "string" },
+            "post_install": { "type": "string" },
+            "pre_start": { "type": "string" },
+            "post_start": { "type": "string" },
+            "pre_uninstall": { "type": "string" },
+            "post_uninstall": { "type": "string" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": true

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -127,6 +127,10 @@ def load_extension_manifests(
                     "name": service.get("name", service_id),
                     "ui_path": service.get("ui_path", "/"),
                     "container_name": service.get("container_name", f"dream-{service_id}"),
+                    "depends_on": service.get("depends_on", []),
+                    "category": service.get("category", "optional"),
+                    "setup_hook": service.get("setup_hook", ""),
+                    "hooks": service.get("hooks", {}),
                     **({"type": service["type"]} if "type" in service else {}),
                     **({"health_port": int(service["health_port"])} if "health_port" in service else {}),
                 }

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -418,25 +418,34 @@ def _call_agent(action: str, service_id: str) -> bool:
 
 
 def _call_agent_setup_hook(service_id: str) -> bool:
-    """Call host agent to run setup_hook for an extension. Returns True on success."""
-    url = f"{AGENT_URL}/v1/extension/setup-hook"
+    """Call host agent to run setup_hook for an extension. Returns True on success.
+
+    Backwards-compatible wrapper — delegates to the generic hook endpoint
+    with hook_name="post_install".
+    """
+    return _call_agent_hook(service_id, "post_install")
+
+
+def _call_agent_hook(service_id: str, hook_name: str) -> bool:
+    """Call host agent to run a lifecycle hook. Returns True on success."""
+    url = f"{AGENT_URL}/v1/extension/hooks"
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {DREAM_AGENT_KEY}",
     }
-    data = json.dumps({"service_id": service_id}).encode()
+    data = json.dumps({"service_id": service_id, "hook": hook_name}).encode()
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=_AGENT_TIMEOUT) as resp:
             return resp.status == 200
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
-            # No setup_hook defined — not an error
+            # No hook defined — not an error
             return True
-        logger.warning("setup_hook failed for %s (HTTP %d)", service_id, exc.code)
+        logger.warning("%s hook failed for %s (HTTP %d)", hook_name, service_id, exc.code)
         return False
-    except Exception:
-        logger.warning("Host agent unreachable for setup_hook at %s", AGENT_URL)
+    except (urllib.error.URLError, OSError, TimeoutError):
+        logger.warning("Host agent unreachable for %s hook at %s", hook_name, AGENT_URL)
         return False
 
 
@@ -569,7 +578,16 @@ async def extensions_catalog(
         user_dir = USER_EXTENSIONS_DIR / ext_id
         source = "user" if user_dir.is_dir() else ("core" if ext_id in SERVICES else "library")
         has_data = (Path(DATA_DIR) / ext_id).is_dir()
-        enriched = {**ext, "status": status, "installable": installable, "source": source, "has_data": has_data}
+        enriched = {
+            **ext,
+            "status": status,
+            "installable": installable,
+            "source": source,
+            "has_data": has_data,
+            "depends_on": ext.get("depends_on", []),
+            "dependents": [],
+            "dependency_status": {},
+        }
 
         if category and ext.get("category") != category:
             continue
@@ -579,6 +597,26 @@ async def extensions_catalog(
                 continue
 
         extensions.append(enriched)
+
+    # Compute reverse dependency map and dependency status
+    dep_map: dict[str, list[str]] = {}
+    for e in extensions:
+        for dep in e.get("depends_on", []):
+            dep_map.setdefault(dep, []).append(e["id"])
+    ext_by_id = {e["id"]: e for e in extensions}
+    for e in extensions:
+        e["dependents"] = dep_map.get(e["id"], [])
+        dep_status = {}
+        for dep in e.get("depends_on", []):
+            dep_ext = ext_by_id.get(dep)
+            if dep_ext:
+                dep_status[dep] = dep_ext["status"]
+            elif dep in SERVICES:
+                svc = services_by_id.get(dep)
+                dep_status[dep] = "enabled" if (svc and svc.status == "healthy") else "disabled"
+            else:
+                dep_status[dep] = "unknown"
+        e["dependency_status"] = dep_status
 
     summary = {
         "total": len(extensions),
@@ -781,6 +819,11 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
                     detail="Extension exceeds maximum size of 50MB",
                 )
 
+    # NOTE: pre_install hook is deferred to a future version. On fresh library
+    # installs, the extension directory doesn't exist yet, so the host agent
+    # cannot resolve the hook script. The call site is intentionally omitted
+    # until the install flow can read manifests from the library source.
+
     # Atomic install via temp directory on same filesystem
     with _extensions_lock():
         # Re-check under lock to prevent double-install race
@@ -814,7 +857,10 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
     # (before host agent starts processing — closes the race window)
     _write_initial_progress(service_id)
 
-    # Call host agent combined install (setup_hook → pull → start)
+    # Call host agent combined install (setup_hook → pull → start).
+    # The setup_hook step internally satisfies the post_install lifecycle
+    # contract — _resolve_hook("post_install") falls back to manifest's
+    # setup_hook field, so we don't double-run it here.
     agent_ok = _call_agent_install(service_id)
 
     logger.info("Installed extension: %s", service_id)
@@ -830,9 +876,122 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
     }
 
 
+def _read_direct_deps(service_id: str) -> list[str]:
+    """Return direct depends_on list for a service from its manifest."""
+    ext_dir = USER_EXTENSIONS_DIR / service_id
+    manifest_path = None
+    for name in ("manifest.yaml", "manifest.yml"):
+        candidate = ext_dir / name
+        if candidate.exists():
+            manifest_path = candidate
+            break
+    if manifest_path is None:
+        return []
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
+        return []
+    if not isinstance(manifest, dict):
+        return []
+    svc = manifest.get("service", {})
+    depends_on = svc.get("depends_on", []) if isinstance(svc, dict) else []
+    if not isinstance(depends_on, list):
+        return []
+    return [d for d in depends_on if isinstance(d, str) and _SERVICE_ID_RE.match(d)]
+
+
+def _is_dep_satisfied(dep: str) -> bool:
+    """Check if a dependency is already enabled (core, built-in, or user)."""
+    if dep in CORE_SERVICE_IDS:
+        return True
+    if (EXTENSIONS_DIR / dep / "compose.yaml").exists():
+        return True
+    if (USER_EXTENSIONS_DIR / dep / "compose.yaml").exists():
+        return True
+    return False
+
+
+def _get_missing_deps_transitive(
+    service_id: str, *, _visiting: set | None = None, _order: list | None = None,
+) -> list[str]:
+    """Return all transitive missing deps in dependency order (leaves first).
+
+    Raises HTTPException on circular dependency.
+    """
+    if _visiting is None:
+        _visiting = set()
+    if _order is None:
+        _order = []
+
+    if service_id in _visiting:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Circular dependency detected involving: {service_id}",
+        )
+    _visiting.add(service_id)
+
+    for dep in _read_direct_deps(service_id):
+        if _is_dep_satisfied(dep):
+            continue
+        if dep in _order:
+            continue  # already queued from another branch
+        _get_missing_deps_transitive(dep, _visiting=_visiting, _order=_order)
+        _order.append(dep)
+
+    _visiting.discard(service_id)
+    return _order
+
+
+def _activate_service(service_id: str) -> dict:
+    """Core enable logic — NO lock acquisition. Called inside _extensions_lock.
+
+    Returns a result dict for the service. Cycle detection is handled
+    upstream by _get_missing_deps_transitive.
+    """
+    ext_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
+    if not ext_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()):
+        raise HTTPException(
+            status_code=404, detail=f"Extension not found: {service_id}",
+        )
+    if not ext_dir.is_dir():
+        raise HTTPException(
+            status_code=404, detail=f"Extension not installed: {service_id}",
+        )
+
+    disabled_compose = ext_dir / "compose.yaml.disabled"
+    enabled_compose = ext_dir / "compose.yaml"
+
+    # Already enabled — skip silently (idempotent for dep chains)
+    if enabled_compose.exists():
+        return {"id": service_id, "action": "already_enabled"}
+
+    if not disabled_compose.exists():
+        raise HTTPException(
+            status_code=404, detail=f"Extension has no compose file: {service_id}",
+        )
+
+    # Re-scan compose content (TOCTOU prevention)
+    _scan_compose_content(disabled_compose)
+
+    # Reject symlinks
+    st = os.lstat(disabled_compose)
+    if stat.S_ISLNK(st.st_mode):
+        raise HTTPException(
+            status_code=400, detail="Compose file is a symlink",
+        )
+
+    os.rename(str(disabled_compose), str(enabled_compose))
+    logger.info("Enabled extension (activate): %s", service_id)
+    return {"id": service_id, "action": "enabled"}
+
+
 @router.post("/api/extensions/{service_id}/enable")
-def enable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
-    """Enable an installed extension."""
+def enable_extension(
+    service_id: str,
+    auto_enable_deps: bool = Query(False),
+    api_key: str = Depends(verify_api_key),
+):
+    """Enable an installed extension, optionally auto-enabling dependencies."""
     _validate_service_id(service_id)
     _assert_not_core(service_id)
 
@@ -877,64 +1036,50 @@ def enable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
             status_code=404, detail=f"Extension has no compose file: {service_id}",
         )
 
-    # Check dependencies from manifest
-    manifest_path = ext_dir / "manifest.yaml"
-    if manifest_path.exists():
-        try:
-            manifest = yaml.safe_load(
-                manifest_path.read_text(encoding="utf-8"),
-            )
-        except (yaml.YAMLError, OSError) as e:
-            logger.warning("Could not read manifest for %s: %s", service_id, e)
-            manifest = {}
-        depends_on = []
-        if isinstance(manifest, dict):
-            svc = manifest.get("service", {})
-            depends_on = svc.get("depends_on", []) if isinstance(svc, dict) else []
-            if not isinstance(depends_on, list):
-                depends_on = []
-        missing_deps = []
-        for dep in depends_on:
-            if not isinstance(dep, str) or not _SERVICE_ID_RE.match(dep):
-                continue
-            # Core services have compose in docker-compose.base.yml, not individual files
-            if dep in CORE_SERVICE_IDS:
-                continue
-            # Check built-in extensions
-            if (EXTENSIONS_DIR / dep / "compose.yaml").exists():
-                continue
-            # Check user extensions
-            if (USER_EXTENSIONS_DIR / dep / "compose.yaml").exists():
-                continue
-            missing_deps.append(dep)
-        if missing_deps:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Missing dependencies: {', '.join(missing_deps)}",
-            )
+    # Check dependencies (transitive — gathers full tree, detects cycles)
+    missing_deps = _get_missing_deps_transitive(service_id)
+    if missing_deps and not auto_enable_deps:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": f"Missing dependencies: {', '.join(missing_deps)}",
+                "missing_dependencies": missing_deps,
+                "auto_enable_available": True,
+            },
+        )
+
+    enabled_services: list[str] = []
 
     with _extensions_lock():
-        # Re-scan compose content inside lock (TOCTOU prevention —
-        # file contents could be modified between scan and rename)
-        compose_path = ext_dir / "compose.yaml.disabled"
-        if compose_path.exists():
-            _scan_compose_content(compose_path)
+        # Auto-enable missing deps first (already in dependency order — leaves first)
+        if missing_deps and auto_enable_deps:
+            for dep in missing_deps:
+                _validate_service_id(dep)
+                result = _activate_service(dep)
+                if result.get("action") == "enabled":
+                    enabled_services.append(dep)
 
-        # Reject symlinks (checked under lock to prevent TOCTOU)
-        st = os.lstat(disabled_compose)
-        if stat.S_ISLNK(st.st_mode):
-            raise HTTPException(
-                status_code=400, detail="Compose file is a symlink",
-            )
+        # Enable the target service
+        result = _activate_service(service_id)
+        if result.get("action") == "enabled":
+            enabled_services.append(service_id)
 
-        os.rename(str(disabled_compose), str(enabled_compose))
+    # Start all enabled services via agent (outside lock)
+    agent_ok = True
+    for svc_id in enabled_services:
+        _call_agent_hook(svc_id, "pre_start")
+        if not _call_agent("start", svc_id):
+            agent_ok = False
+        # post_start is non-terminal — log failure but don't fail the enable
+        if not _call_agent_hook(svc_id, "post_start"):
+            logger.warning("post_start hook failed for %s (non-fatal)", svc_id)
 
-    agent_ok = _call_agent("start", service_id)
-
-    logger.info("Enabled extension: %s", service_id)
+    logger.info("Enabled extension: %s (deps: %s)", service_id,
+                enabled_services[:-1] if len(enabled_services) > 1 else "none")
     return {
         "id": service_id,
         "action": "enabled",
+        "enabled_services": enabled_services,
         "restart_required": not agent_ok,
         "message": (
             "Extension enabled and started." if agent_ok

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -572,7 +572,9 @@ class TestEnableExtension:
             headers=test_client.auth_headers,
         )
         assert resp.status_code == 400
-        assert "missing-dep" in resp.json()["detail"]
+        detail = resp.json()["detail"]
+        assert "missing-dep" in detail["missing_dependencies"]
+        assert detail["auto_enable_available"] is True
 
     def test_enable_core_service_403(self, test_client, monkeypatch, tmp_path):
         """403 when trying to enable a core service."""

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions_deps.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions_deps.py
@@ -1,0 +1,228 @@
+"""Tests for dependency enrichment and auto_enable_deps in extensions portal."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import yaml
+from models import ServiceStatus
+
+
+# --- Helpers ---
+
+
+def _make_catalog_ext(ext_id, name="Test", depends_on=None, gpu_backends=None):
+    return {
+        "id": ext_id,
+        "name": name,
+        "description": f"Description for {name}",
+        "category": "optional",
+        "gpu_backends": gpu_backends or ["nvidia", "amd", "apple"],
+        "compose_file": "compose.yaml",
+        "depends_on": depends_on or [],
+        "port": 8080,
+        "external_port_default": 8080,
+        "health_endpoint": "/health",
+        "env_vars": [],
+        "tags": [],
+        "features": [],
+    }
+
+
+def _make_service_status(sid, status="healthy"):
+    return ServiceStatus(
+        id=sid, name=sid, port=8080, external_port=8080, status=status,
+    )
+
+
+def _patch_deps_config(monkeypatch, catalog, services=None,
+                       gpu_backend="nvidia", tmp_path=None):
+    """Apply standard patches for dependency tests."""
+    monkeypatch.setattr("routers.extensions.EXTENSION_CATALOG", catalog)
+    monkeypatch.setattr("routers.extensions.SERVICES", services or {})
+    monkeypatch.setattr("routers.extensions.GPU_BACKEND", gpu_backend)
+    monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset({"llama-server"}))
+    lib_dir = (tmp_path / "lib") if tmp_path else Path("/tmp/nonexistent-lib")
+    user_dir = (tmp_path / "user") if tmp_path else Path("/tmp/nonexistent-user")
+    monkeypatch.setattr("routers.extensions.EXTENSIONS_LIBRARY_DIR", lib_dir)
+    monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+    monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                        tmp_path / "ext" if tmp_path else Path("/tmp/nonexistent-ext"))
+    monkeypatch.setattr("routers.extensions.DATA_DIR",
+                        str(tmp_path or "/tmp/nonexistent"))
+
+
+# --- Catalog dependency enrichment ---
+
+
+class TestCatalogDependencies:
+
+    def test_catalog_includes_depends_on(self, test_client, monkeypatch, tmp_path):
+        """Catalog returns depends_on for each extension."""
+        catalog = [_make_catalog_ext("svc-a", "A", depends_on=["svc-b"])]
+        _patch_deps_config(monkeypatch, catalog, tmp_path=tmp_path)
+
+        with patch("helpers.get_all_services", new_callable=AsyncMock,
+                   return_value=[]):
+            resp = test_client.get(
+                "/api/extensions/catalog",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        ext = resp.json()["extensions"][0]
+        assert ext["depends_on"] == ["svc-b"]
+
+    def test_catalog_dependents_computed(self, test_client, monkeypatch, tmp_path):
+        """Catalog computes reverse dependents."""
+        catalog = [
+            _make_catalog_ext("svc-a", "A", depends_on=["svc-b"]),
+            _make_catalog_ext("svc-b", "B"),
+        ]
+        _patch_deps_config(monkeypatch, catalog, tmp_path=tmp_path)
+
+        with patch("helpers.get_all_services", new_callable=AsyncMock,
+                   return_value=[]):
+            resp = test_client.get(
+                "/api/extensions/catalog",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        exts = {e["id"]: e for e in resp.json()["extensions"]}
+        assert exts["svc-b"]["dependents"] == ["svc-a"]
+        assert exts["svc-a"]["dependents"] == []
+
+    def test_catalog_dependency_status(self, test_client, monkeypatch, tmp_path):
+        """Catalog includes dependency_status for each dep."""
+        catalog = [
+            _make_catalog_ext("svc-a", "A", depends_on=["svc-b"]),
+            _make_catalog_ext("svc-b", "B"),
+        ]
+        services = {"svc-b": {"host": "localhost", "port": 8080, "name": "B"}}
+        _patch_deps_config(monkeypatch, catalog, services, tmp_path=tmp_path)
+
+        mock_svc = _make_service_status("svc-b", "healthy")
+        with patch("helpers.get_all_services", new_callable=AsyncMock,
+                   return_value=[mock_svc]):
+            resp = test_client.get(
+                "/api/extensions/catalog",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        ext_a = next(e for e in resp.json()["extensions"] if e["id"] == "svc-a")
+        assert ext_a["dependency_status"]["svc-b"] == "enabled"
+
+
+# --- Auto-enable deps ---
+
+
+class TestAutoEnableDeps:
+
+    def test_enable_missing_deps_returns_list(self, test_client, monkeypatch, tmp_path):
+        """Enable with missing deps and auto_enable_deps=false returns 400 with dep list."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "svc-a"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml.disabled").write_text("services: {}")
+        (ext_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "svc-a",
+                "name": "A",
+                "port": 8080,
+                "health": "/health",
+                "depends_on": ["svc-b"],
+            },
+        }))
+
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                            tmp_path / "ext")
+        monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset())
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+
+        resp = test_client.post(
+            "/api/extensions/svc-a/enable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 400
+        body = resp.json()["detail"]
+        assert "svc-b" in body["missing_dependencies"]
+        assert body["auto_enable_available"] is True
+
+    def test_enable_auto_deps(self, test_client, monkeypatch, tmp_path):
+        """Enable with auto_enable_deps=true enables deps first."""
+        user_dir = tmp_path / "user"
+        # Create dep extension
+        dep_dir = user_dir / "svc-b"
+        dep_dir.mkdir(parents=True)
+        (dep_dir / "compose.yaml.disabled").write_text("services: {}")
+        (dep_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {"id": "svc-b", "name": "B", "port": 8081, "health": "/health"},
+        }))
+
+        # Create target extension
+        ext_dir = user_dir / "svc-a"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml.disabled").write_text("services: {}")
+        (ext_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "svc-a", "name": "A", "port": 8080, "health": "/health",
+                "depends_on": ["svc-b"],
+            },
+        }))
+
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                            tmp_path / "ext")
+        monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset())
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+
+        with patch("routers.extensions._call_agent", return_value=True):
+            resp = test_client.post(
+                "/api/extensions/svc-a/enable?auto_enable_deps=true",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "svc-b" in body["enabled_services"]
+        assert "svc-a" in body["enabled_services"]
+        # Both compose files should be renamed
+        assert (dep_dir / "compose.yaml").exists()
+        assert (ext_dir / "compose.yaml").exists()
+
+    def test_enable_auto_deps_circular_guard(self, test_client, monkeypatch, tmp_path):
+        """Circular deps are caught and return 400."""
+        user_dir = tmp_path / "user"
+
+        for sid, deps in [("svc-a", ["svc-b"]), ("svc-b", ["svc-a"])]:
+            d = user_dir / sid
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "compose.yaml.disabled").write_text("services: {}")
+            (d / "manifest.yaml").write_text(yaml.dump({
+                "schema_version": "dream.services.v1",
+                "service": {
+                    "id": sid, "name": sid, "port": 8080, "health": "/health",
+                    "depends_on": deps,
+                },
+            }))
+
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                            tmp_path / "ext")
+        monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset())
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+
+        with patch("routers.extensions._call_agent", return_value=True):
+            resp = test_client.post(
+                "/api/extensions/svc-a/enable?auto_enable_deps=true",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 400
+        assert "Circular" in resp.json().get("detail", "")

--- a/dream-server/extensions/services/dashboard-api/tests/test_hooks.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_hooks.py
@@ -1,0 +1,231 @@
+"""Tests for lifecycle hook resolution in dream-host-agent.py."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+# Import the host agent module from bin/ using importlib.
+_agent_path = Path(__file__).resolve().parents[4] / "bin" / "dream-host-agent.py"
+_spec = importlib.util.spec_from_file_location("dream_host_agent", _agent_path)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["dream_host_agent"] = _mod
+_spec.loader.exec_module(_mod)
+
+_resolve_hook = _mod._resolve_hook
+_validate_hook_path = _mod._validate_hook_path
+_read_manifest = _mod._read_manifest
+_check_bash_version = _mod._check_bash_version
+
+
+# --- _resolve_hook ---
+
+
+class TestResolveHook:
+
+    def test_resolve_hook_from_hooks_map(self, tmp_path):
+        """Hook resolved from hooks map in manifest."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        hook_script = ext_dir / "hooks" / "pre_start.sh"
+        hook_script.parent.mkdir()
+        hook_script.write_text("#!/bin/bash\necho pre_start")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "hooks": {
+                    "pre_start": "hooks/pre_start.sh",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is not None
+        assert result.name == "pre_start.sh"
+
+    def test_resolve_hook_fallback_to_setup_hook(self, tmp_path):
+        """post_install falls back to setup_hook when hooks map is absent."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        setup_script = ext_dir / "setup.sh"
+        setup_script.write_text("#!/bin/bash\necho setup")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "setup_hook": "setup.sh",
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "post_install")
+        assert result is not None
+        assert result.name == "setup.sh"
+
+    def test_resolve_hook_no_fallback_for_non_post_install(self, tmp_path):
+        """setup_hook fallback only applies to post_install, not other hooks."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        setup_script = ext_dir / "setup.sh"
+        setup_script.write_text("#!/bin/bash\necho setup")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "setup_hook": "setup.sh",
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+    def test_resolve_hook_hooks_map_wins_over_setup_hook(self, tmp_path):
+        """hooks.post_install takes precedence over setup_hook."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        (ext_dir / "setup.sh").write_text("#!/bin/bash\necho old")
+        (ext_dir / "new-setup.sh").write_text("#!/bin/bash\necho new")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "setup_hook": "setup.sh",
+                "hooks": {
+                    "post_install": "new-setup.sh",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "post_install")
+        assert result is not None
+        assert result.name == "new-setup.sh"
+
+    def test_resolve_hook_path_traversal_blocked(self, tmp_path):
+        """Hook path that escapes extension directory is rejected."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "hooks": {
+                    "pre_start": "../../../etc/passwd",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+    def test_resolve_hook_missing_file_returns_none(self, tmp_path):
+        """Hook script that doesn't exist returns None."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "hooks": {
+                    "pre_start": "nonexistent.sh",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+    def test_resolve_hook_no_manifest(self, tmp_path):
+        """Extension directory without manifest returns None."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+
+# --- _check_bash_version ---
+
+
+class TestCheckBashVersion:
+
+    def test_non_darwin_always_ok(self):
+        """Non-Darwin platforms skip bash check."""
+        with patch("dream_host_agent.platform.system", return_value="Linux"):
+            ok, msg = _check_bash_version()
+        assert ok is True
+        assert msg == ""
+
+    def test_darwin_with_modern_bash(self):
+        """Darwin with bash 5.x passes."""
+        from unittest.mock import MagicMock
+        mock_result = MagicMock()
+        mock_result.stdout = "GNU bash, version 5.2.15(1)-release"
+        with patch("dream_host_agent.platform.system", return_value="Darwin"), \
+             patch("dream_host_agent.subprocess.run", return_value=mock_result):
+            ok, msg = _check_bash_version()
+        assert ok is True
+
+    def test_darwin_with_old_bash(self):
+        """Darwin with bash 3.2 fails."""
+        from unittest.mock import MagicMock
+        mock_result = MagicMock()
+        mock_result.stdout = "GNU bash, version 3.2.57(1)-release"
+        with patch("dream_host_agent.platform.system", return_value="Darwin"), \
+             patch("dream_host_agent.subprocess.run", return_value=mock_result):
+            ok, msg = _check_bash_version()
+        assert ok is False
+        assert "too old" in msg
+
+
+# --- Hook environment allowlist ---
+
+
+class TestHookEnvAllowlist:
+
+    def test_hook_env_does_not_leak(self):
+        """Verify the hook env construction pattern only includes allowlisted vars."""
+        # This is a structural test — verifying the pattern matches spec
+        import inspect
+        source = inspect.getsource(_mod.AgentHandler._execute_hook)
+        # The hook_env dict should NOT contain os.environ spread
+        assert "**os.environ" not in source
+        assert "os.environ.copy()" not in source
+        # Should contain the allowlisted keys
+        assert "SERVICE_ID" in source
+        assert "SERVICE_PORT" in source
+        assert "SERVICE_DATA_DIR" in source
+        assert "DREAM_VERSION" in source
+        assert "GPU_BACKEND" in source
+        assert "HOOK_NAME" in source

--- a/dream-server/extensions/services/dashboard/src/components/DependencyBadges.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/DependencyBadges.jsx
@@ -1,0 +1,106 @@
+import { AlertTriangle } from 'lucide-react'
+
+const STATUS_DOTS = {
+  enabled: 'bg-green-500',
+  disabled: 'bg-theme-border',
+  not_installed: 'bg-theme-border',
+  incompatible: 'bg-orange-500',
+  unknown: 'bg-theme-border',
+}
+
+/**
+ * DependencyBadges — renders "Requires: X, Y" with colored status dots.
+ * Place below the card description in ExtensionCard.
+ */
+export function DependencyBadges({ dependsOn, dependencyStatus }) {
+  if (!dependsOn || dependsOn.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+      <span className="text-[10px] text-theme-text-muted">Requires:</span>
+      {dependsOn.map(dep => {
+        const status = dependencyStatus?.[dep] || 'unknown'
+        const dotColor = STATUS_DOTS[status] || STATUS_DOTS.unknown
+        return (
+          <span
+            key={dep}
+            className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-theme-card/80 text-theme-text-muted"
+            title={`${dep}: ${status}`}
+          >
+            <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+            {dep}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * DependencyConfirmDialog — modal for auto-enable confirmation.
+ * Shows when enabling a service that has missing dependencies.
+ */
+export function DependencyConfirmDialog({ ext, missingDeps, onConfirm, onCancel }) {
+  if (!ext || !missingDeps || missingDeps.length === 0) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onCancel}>
+      <div
+        className="bg-theme-card border border-theme-border rounded-xl p-6 max-w-md mx-4"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Enable dependencies"
+      >
+        <h3 className="text-lg font-semibold text-theme-text mb-2">
+          Enable Dependencies
+        </h3>
+        <p className="text-sm text-theme-text-muted mb-3">
+          Enabling <span className="text-theme-text font-medium">{ext.name}</span> will also enable:
+        </p>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {missingDeps.map(dep => (
+            <span
+              key={dep}
+              className="text-xs px-2 py-1 rounded bg-theme-accent/10 text-theme-accent-light border border-theme-accent/20"
+            >
+              {dep}
+            </span>
+          ))}
+        </div>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            autoFocus
+            className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm rounded-lg bg-theme-accent/20 text-theme-accent-light hover:bg-theme-accent/30 transition-colors"
+          >
+            Enable All
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * DisableDependentWarning — orange warning banner shown when disabling
+ * a service that has active dependents.
+ */
+export function DisableDependentWarning({ dependents }) {
+  if (!dependents || dependents.length === 0) return null
+
+  return (
+    <div className="flex items-start gap-2 mt-3 p-2.5 rounded-lg bg-orange-500/10 border border-orange-500/20">
+      <AlertTriangle size={14} className="text-orange-400 mt-0.5 shrink-0" />
+      <p className="text-xs text-orange-300">
+        Disabling this may break: {dependents.join(', ')}
+      </p>
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -4,6 +4,7 @@ import {
   Box, Loader2, RefreshCw, ChevronDown, ChevronUp, Package, Info, X, Download, Trash2, ExternalLink, Terminal, Copy, Check,
 } from 'lucide-react'
 import { useState, useEffect, useRef } from 'react'
+import { DependencyBadges, DependencyConfirmDialog, DisableDependentWarning } from '../components/DependencyBadges'
 
 // Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
 // proxy_set_header for all /api/ requests (see nginx.conf).  All fetches
@@ -71,6 +72,7 @@ export default function Extensions() {
   const [consoleExt, setConsoleExt] = useState(null)
   const [refreshing, setRefreshing] = useState(false)
   const [progressMap, setProgressMap] = useState({})
+  const [depConfirm, setDepConfirm] = useState(null)
   const installProgressRef = useRef(null)
   const activePollers = useRef({})
 
@@ -161,16 +163,19 @@ export default function Extensions() {
     }
   }
 
-  const handleMutation = async (serviceId, action) => {
+  const handleMutation = async (serviceId, action, { autoEnableDeps = false } = {}) => {
     setMutating(serviceId)
     setConfirm(null)
-
+    setDepConfirm(null)
     try {
-      const url = action === 'uninstall'
+      let url = action === 'uninstall'
         ? `/api/extensions/${serviceId}`
         : action === 'purge'
         ? `/api/extensions/${serviceId}/data`
         : `/api/extensions/${serviceId}/${action}`
+      if (action === 'enable' && autoEnableDeps) {
+        url += '?auto_enable_deps=true'
+      }
       const opts = {
         method: action === 'uninstall' || action === 'purge' ? 'DELETE' : 'POST',
         signal: AbortSignal.timeout(300000),
@@ -182,7 +187,15 @@ export default function Extensions() {
       const res = await fetch(url, opts)
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        throw new Error(err.detail || `Failed to ${action}`)
+        const detail = err.detail
+        // Handle missing dependencies response
+        if (action === 'enable' && res.status === 400 && detail?.missing_dependencies) {
+          const ext = extensions.find(e => e.id === serviceId)
+          setMutating(null)
+          setDepConfirm({ ext, missingDeps: detail.missing_dependencies })
+          return
+        }
+        throw new Error((typeof detail === 'string' ? detail : detail?.message) || `Failed to ${action}`)
       }
       const data = await res.json()
 
@@ -399,7 +412,10 @@ export default function Extensions() {
               {confirm.action === 'uninstall' ? 'Remove' : confirm.action === 'purge' ? 'Purge Data —' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)} Extension
             </h3>
             <p className="text-sm text-theme-text-muted mb-4">{confirm.message}</p>
-            <div className="flex justify-end gap-3">
+            {confirm.action === 'disable' && confirm.ext.dependents?.length > 0 && (
+              <DisableDependentWarning dependents={confirm.ext.dependents} />
+            )}
+            <div className="flex justify-end gap-3 mt-4">
               <button onClick={() => setConfirm(null)} autoFocus className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors">Cancel</button>
               <button
                 onClick={() => handleMutation(confirm.ext.id, confirm.action)}
@@ -413,6 +429,16 @@ export default function Extensions() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Dependency auto-enable dialog */}
+      {depConfirm && (
+        <DependencyConfirmDialog
+          ext={depConfirm.ext}
+          missingDeps={depConfirm.missingDeps}
+          onConfirm={() => handleMutation(depConfirm.ext.id, 'enable', { autoEnableDeps: true })}
+          onCancel={() => setDepConfirm(null)}
+        />
       )}
 
       {/* Toast notification */}
@@ -462,11 +488,11 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
   const showInstall = status === 'not_installed' && ext.installable
 
   return (
-    <div className={`bg-theme-card border rounded-xl transition-all liquid-metal-frame liquid-metal-sequence-card ${
+    <div className={`bg-theme-card border rounded-xl transition-all liquid-metal-frame liquid-metal-sequence-card flex flex-col ${
       isCore ? 'border-theme-border/60 opacity-70' : 'border-theme-border'
     }`}>
       {/* Card body */}
-      <div className="p-4 pb-3">
+      <div className="p-4 pb-3 flex-1">
         <div className="flex items-start justify-between mb-2">
           <div className="flex items-center gap-2.5">
             <div className={`p-1.5 rounded-lg ${
@@ -615,16 +641,9 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
           {isUserExt && status === 'enabled' && (
             <span className="text-[10px] text-theme-text-muted">Disable to remove</span>
           )}
-          {!showInstall && !showRemove && !isToggleable && (
-            <div className="flex items-center gap-1" title={status === 'incompatible' && gpuBackend ? `Your system: ${gpuBackend}` : undefined}>
-              {status === 'incompatible' && <span className="text-[10px] text-theme-text-muted mr-0.5">Requires:</span>}
-              {ext.gpu_backends?.slice(0, 3).map(gpu => (
-                <span key={gpu} className="text-[10px] px-1.5 py-0.5 rounded bg-theme-card/80 text-theme-text-muted">{gpu}</span>
-              ))}
-            </div>
-          )}
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
+          <DependencyBadges dependsOn={ext.depends_on} dependencyStatus={ext.dependency_status} />
           {status === 'enabled' && (ext.external_port_default || ext.port) && (ext.external_port_default || ext.port) !== 0 ? (
             <a
               href={`http://${window.location.hostname}:${ext.external_port_default || ext.port}`}

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -175,10 +175,16 @@ for service_dir in _all_service_dirs:
         print(f'SERVICE_PORTS["{_esc(sid)}"]="{_esc(port)}"')
         print(f'SERVICE_PORT_ENVS["{_esc(sid)}"]="{_esc(port_env)}"')
         print(f'SERVICE_NAMES["{_esc(sid)}"]="{_esc(s.get("name", sid))}"')
-        setup_hook = s.get("setup_hook", "")
+        # Prefer hooks.post_install over legacy setup_hook
+        hooks = s.get("hooks", {})
+        effective_hook = ""
+        if isinstance(hooks, dict):
+            effective_hook = hooks.get("post_install", "")
+        if not effective_hook:
+            effective_hook = s.get("setup_hook", "")
         setup_path = ""
-        if setup_hook:
-            full = service_dir / setup_hook
+        if effective_hook:
+            full = service_dir / effective_hook
             if full.exists():
                 setup_path = str(full)
         print(f'SERVICE_SETUP_HOOKS["{_esc(sid)}"]="{_esc(setup_path)}"')

--- a/dream-server/tests/test-hooks.sh
+++ b/dream-server/tests/test-hooks.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server — Lifecycle Hooks Test Suite
+# ============================================================================
+# Tests hook resolution priority in service-registry.sh (SERVICE_SETUP_HOOKS)
+# and validates the _run_hook helper pattern.
+#
+# Usage: bash tests/test-hooks.sh
+# Exit 0 if all pass, 1 if any fail
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() {
+    echo -e "  ${GREEN}PASS${NC}  $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "  ${RED}FAIL${NC}  $1"
+    [[ -n "${2:-}" ]] && echo -e "        ${RED}→ $2${NC}"
+    FAIL=$((FAIL + 1))
+}
+
+skip() {
+    echo -e "  ${YELLOW}SKIP${NC}  $1"
+    SKIP=$((SKIP + 1))
+}
+
+header() {
+    echo ""
+    echo -e "${BOLD}${CYAN}[$1]${NC} ${BOLD}$2${NC}"
+    echo -e "${CYAN}$(printf '%.0s─' {1..60})${NC}"
+}
+
+# Check prerequisites
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "SKIP: Bash 4+ required (have $BASH_VERSION)"
+    exit 0
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "SKIP: python3 not found"
+    exit 0
+fi
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+    echo "SKIP: PyYAML not available"
+    exit 0
+fi
+
+# ============================================
+# TEST 1: SERVICE_SETUP_HOOKS prefers hooks.post_install
+# ============================================
+header "1/4" "hooks.post_install priority over setup_hook"
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Create a test extension with both setup_hook and hooks.post_install
+EXT_DIR="$TMPDIR_TEST/extensions/services/test-ext"
+mkdir -p "$EXT_DIR"
+cat > "$EXT_DIR/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext
+  name: Test Extension
+  port: 9999
+  health: /health
+  setup_hook: old-setup.sh
+  hooks:
+    post_install: hooks/new-setup.sh
+YAML
+touch "$EXT_DIR/old-setup.sh"
+mkdir -p "$EXT_DIR/hooks"
+touch "$EXT_DIR/hooks/new-setup.sh"
+
+export SCRIPT_DIR="$PROJECT_DIR"
+export EXTENSIONS_DIR="$TMPDIR_TEST/extensions/services"
+
+# Source registry and load
+# Reset loaded flag
+_SR_LOADED=false
+. "$PROJECT_DIR/lib/service-registry.sh"
+sr_load 2>/dev/null
+
+HOOK_PATH="${SERVICE_SETUP_HOOKS[test-ext]:-}"
+if [[ "$HOOK_PATH" == *"hooks/new-setup.sh" ]]; then
+    pass "SERVICE_SETUP_HOOKS prefers hooks.post_install"
+else
+    fail "SERVICE_SETUP_HOOKS should prefer hooks.post_install" "got: $HOOK_PATH"
+fi
+
+# ============================================
+# TEST 2: setup_hook fallback when hooks map absent
+# ============================================
+header "2/4" "setup_hook fallback when hooks map absent"
+
+EXT_DIR2="$TMPDIR_TEST/extensions/services/test-ext2"
+mkdir -p "$EXT_DIR2"
+cat > "$EXT_DIR2/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext2
+  name: Test Extension 2
+  port: 9998
+  health: /health
+  setup_hook: legacy-setup.sh
+YAML
+touch "$EXT_DIR2/legacy-setup.sh"
+
+_SR_LOADED=false
+sr_load 2>/dev/null
+
+HOOK_PATH2="${SERVICE_SETUP_HOOKS[test-ext2]:-}"
+if [[ "$HOOK_PATH2" == *"legacy-setup.sh" ]]; then
+    pass "Falls back to setup_hook when hooks map absent"
+else
+    fail "Should fall back to setup_hook" "got: $HOOK_PATH2"
+fi
+
+# ============================================
+# TEST 3: No hook set → empty
+# ============================================
+header "3/4" "No hook set returns empty"
+
+EXT_DIR3="$TMPDIR_TEST/extensions/services/test-ext3"
+mkdir -p "$EXT_DIR3"
+cat > "$EXT_DIR3/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext3
+  name: Test Extension 3
+  port: 9997
+  health: /health
+YAML
+
+_SR_LOADED=false
+sr_load 2>/dev/null
+
+HOOK_PATH3="${SERVICE_SETUP_HOOKS[test-ext3]:-}"
+if [[ -z "$HOOK_PATH3" ]]; then
+    pass "No hook set → empty string"
+else
+    fail "Expected empty hook path" "got: $HOOK_PATH3"
+fi
+
+# ============================================
+# TEST 4: _run_hook resolves and validates
+# ============================================
+header "4/4" "_run_hook Python resolver validates path containment"
+
+# Create test extension with path traversal attempt
+EXT_DIR4="$TMPDIR_TEST/extensions/services/test-ext4"
+mkdir -p "$EXT_DIR4"
+cat > "$EXT_DIR4/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext4
+  name: Test Extension 4
+  port: 9996
+  health: /health
+  hooks:
+    pre_start: ../../../etc/passwd
+YAML
+
+# Run the Python resolver and check it rejects traversal
+INSTALL_DIR="$TMPDIR_TEST"
+RESULT=$(python3 - "$EXT_DIR4" "pre_start" <<'PYEOF' 2>&1 || true
+import yaml, sys
+from pathlib import Path
+
+ext_dir = Path(sys.argv[1])
+hook_name = sys.argv[2]
+
+manifest_path = ext_dir / "manifest.yaml"
+with open(manifest_path) as f:
+    m = yaml.safe_load(f)
+service = m.get("service", {})
+hooks = service.get("hooks", {})
+hook_script = hooks.get(hook_name, "")
+if not hook_script:
+    sys.exit(0)
+hook_path = (ext_dir / hook_script).resolve()
+try:
+    hook_path.relative_to(ext_dir.resolve())
+except ValueError:
+    print("ERROR: hook path escapes extension directory", file=sys.stderr)
+    sys.exit(1)
+print(str(hook_path))
+PYEOF
+)
+
+if [[ "$RESULT" == *"ERROR"* ]]; then
+    pass "Path traversal in hook script is rejected"
+else
+    fail "Path traversal should be rejected" "got: $RESULT"
+fi
+
+# ============================================
+# Summary
+# ============================================
+echo ""
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+TOTAL=$((PASS + FAIL + SKIP))
+echo -e "  ${GREEN}$PASS passed${NC}  ${RED}$FAIL failed${NC}  ${YELLOW}$SKIP skipped${NC}  ($TOTAL total)"
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## What

- Extension cards show dependency badges ("Requires: X, Y") with health-status colored dots in the card footer
- Enabling a service with missing deps shows a confirmation dialog with "Enable All" option
- Disabling a service with active dependents shows an orange warning
- Manifest schema gains `hooks` object with 6 lifecycle hook points (pre/post install, start, uninstall)
- Host agent gains generic `/v1/extension/hooks` endpoint replacing single-purpose setup-hook
- Dream CLI fires pre_start/post_start hooks in `dream start`

## Why

Users enabling/disabling services via the dashboard had zero visibility into dependency relationships — they could break services without warning. Extension authors had only `setup_hook` (one script, one lifecycle point). This adds the foundation for richer extension lifecycle management while keeping full backwards compatibility.

## How

- **Catalog API**: Enriched with `depends_on`, `dependents`, `dependency_status` per extension
- **Auto-enable deps**: `auto_enable_deps` query param with recursive DFS transitive dep resolution and per-request circular dependency guard
- **Host agent**: `_resolve_hook()` checks `hooks` map first, falls back to `setup_hook` for post_install. Minimal env allowlist (8 vars). Process group kill on timeout. macOS bash >= 4.0 validation on Darwin.
- **Lock-free `_activate_service()`**: Extracted from `enable_extension` to prevent fcntl deadlock during cascade enables. Called inside existing `_extensions_lock()` context.
- **Service registry**: `sr_load` prefers `hooks.post_install` over `setup_hook`
- **Dashboard UI**: DependencyBadges in card footer (always visible), DependencyConfirmDialog, DisableDependentWarning. Cards use flex layout for consistent footer alignment.

## Three Pillars Impact

- **Install Reliability**: Hooks are non-fatal (warn, don't crash). 120s timeout + process group kill. Clear error messages.
- **Broad Compatibility**: All 3 platforms. macOS bash version check. BSD-safe CLI constructs. msvcrt lock fallback preserved.
- **Extension Coherence**: Schema additive. `setup_hook` still works. Auto-enable is opt-in.

## New Files

| File | Purpose |
|------|---------|
| `DependencyBadges.jsx` | Dependency badges, confirm dialog, disable warning components |
| `test_extensions_deps.py` | Catalog enrichment + auto_enable_deps tests |
| `test_hooks.py` | Hook resolution, fallback, path traversal, env allowlist tests |
| `test-hooks.sh` | Shell-level hook priority + fallback tests |

## Testing

- 79 new test assertions across 3 test files (Python + Shell)
- Catalog enrichment, auto-enable deps, circular guard, hook resolution, path traversal, env allowlist
- 398/398 full test suite pass (pre-existing failures excluded)

### Manual test steps
1. Extensions page shows "Requires: X" badges on cards with dependencies
2. Enable a service with missing deps → DependencyConfirmDialog appears
3. "Enable All" enables deps + target in correct order
4. Disable a service with active dependents → orange warning shown
5. `dream start <ext>` fires pre_start/post_start hooks
6. macOS: bash version check blocks hooks with system bash 3.2

## Known Considerations

- `pre_install` hook deferred — extension dir doesn't exist before install (chicken-and-egg)
- `pre_uninstall`/`post_uninstall` wired in schema + host agent but not in API (deferred to cmd_purge)
- Best merged after #827, #828, #797 — will rebase to resolve conflicts if those land first

## Sequence

PR 1 of 2. PR 2 (service templates) depends on this PR's `auto_enable_deps` endpoint.