### PR TITLE
fix(installer): improve compose startup resilience for slow-starting services

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -47,8 +47,8 @@ services:
       test: ["CMD", "curl", "-sf", "http://127.0.0.1:8080/api/v1/health"]
       interval: 15s
       timeout: 10s
-      retries: 5
-      start_period: 120s
+      retries: 10
+      start_period: 300s  # Lemonade first boot builds llama-server binary (~3-5 min)
     deploy:
       resources:
         limits:

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -327,27 +327,29 @@ MODELS_INI_EOF
             printf "\r  ${BGRN}✓${NC} %-60s\n" "$_svc built"
         fi
     done
-    # Start everything — --no-build skips services whose images failed to build
-    $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" up -d --no-build >> "$LOG_FILE" 2>&1 &
-    compose_pid=$!
-    if spin_task $compose_pid "Launching containers..."; then
-        compose_ok=true
-    else
-        printf "\r  ${AMB}⚠${NC} %-60s\n" "Some services still starting..."
-        echo ""
-        ai_warn "Some containers need more time. Retrying..."
+    # Start everything — --no-build skips services whose images failed to build.
+    # Up to 3 attempts with increasing wait between retries. On AMD/Lemonade,
+    # the first boot builds a cached llama-server binary which can take 3-5 min.
+    for _attempt in 1 2 3; do
         $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" up -d --no-build >> "$LOG_FILE" 2>&1 &
         compose_pid=$!
-        if spin_task $compose_pid "Waiting for remaining services..."; then
+        if spin_task $compose_pid "Launching containers (attempt $_attempt/3)..."; then
             compose_ok=true
+            break
         fi
-    fi
+        if [[ $_attempt -lt 3 ]]; then
+            printf "\r  ${AMB}⚠${NC} %-60s\n" "Some services still starting..."
+            ai_warn "Some containers need more time. Waiting 30s before retry..."
+            sleep 30
+        fi
+    done
     # Safety net: when --no-build hits a missing image, compose aborts before
     # starting other containers. Some end up in "Created", others never got
     # past "Creating" because their dependencies weren't ready yet.
     # Step 1: start any containers already in Created state
     docker start $(docker ps -a --filter status=created -q) 2>/dev/null || true
-    # Step 2: second compose pass picks up services whose deps are now healthy
+    # Step 2: wait for services to stabilize, then compose pass
+    sleep 10
     $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" up -d --no-build >> "$LOG_FILE" 2>&1 || true
     # Step 3: catch any stragglers from the second pass
     docker start $(docker ps -a --filter status=created -q) 2>/dev/null || true


### PR DESCRIPTION
## Summary
Fixes intermittent compose startup failures on AMD machines where Lemonade's first-boot binary build takes longer than the Docker health check timeout. Observed 1/3 install runs on .213 (Strix Halo).

## What was happening
1. Lemonade first boot builds a cached llama-server binary (~3-5 min)
2. Docker health check had `start_period: 120s` + `retries: 5` × `interval: 15s` = 195s total
3. If Lemonade took >195s, Docker marked it unhealthy
4. Dependent services (Open WebUI, Perplexica, etc.) never started
5. `docker compose up -d` exited non-zero
6. Installer had only 1 retry which often wasn't enough

## Fix

### docker-compose.amd.yml
- `start_period: 120s → 300s` (5 min grace for first-boot binary build)
- `retries: 5 → 10`
- Total healthy window: 300s + (10 × 15s) = 450s

### installers/phases/11-services.sh
- Replace single retry with 3-attempt loop
- 30s wait between retries (gives services time to become healthy)
- 10s stabilization wait in safety net before final compose pass

## Not affected
- NVIDIA/Apple: base.yml healthcheck unchanged (120s start_period is sufficient for pre-built images)
- The retry loop uses the same `spin_task` mechanism — no new infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)