### PR TITLE
fix(compose): dial back AMD health check start_period to match observed boot times

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -48,7 +48,7 @@ services:
       interval: 15s
       timeout: 10s
       retries: 10
-      start_period: 300s  # Lemonade first boot builds llama-server binary (~3-5 min)
+      start_period: 180s  # Lemonade ~45s typical, up to ~2min under load on first boot
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary
PR #878 set `start_period: 300s` based on an estimate of 3-5 min for Lemonade's first boot. Actual observed times across multiple test runs on Strix Halo:
- ~45 seconds typical
- Up to ~2 minutes under load (all 18 containers starting simultaneously)

300s was overkill. This dials it back to 180s (3 min) which covers the 2-min worst case with margin. The Phase 11 retry loop (3 attempts with 30s waits from #878) handles the compose-level recovery on top.

## Change
1 line: `start_period: 300s` → `start_period: 180s` with updated comment.

Total Docker health window: 180s + (10 × 15s) = 330s (5.5 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)