### PR TITLE
feat(dashboard): add Models page to sidebar navigation

### DIFF
--- a/dream-server/extensions/services/dashboard/src/plugins/core.js
+++ b/dream-server/extensions/services/dashboard/src/plugins/core.js
@@ -4,12 +4,14 @@ import {
   Settings,
   Puzzle,
   Activity,
+  Box,
 } from 'lucide-react'
 
 const Dashboard = lazy(() => import('../pages/Dashboard'))
 const SettingsPage = lazy(() => import('../pages/Settings'))
 const Extensions = lazy(() => import('../pages/Extensions'))
 const GPUMonitor = lazy(() => import('../pages/GPUMonitor'))
+const Models = lazy(() => import('../pages/Models'))
 
 export const coreRoutes = [
   {
@@ -41,6 +43,16 @@ export const coreRoutes = [
     component: Extensions,
     getProps: () => ({}),
     sidebar: true,
+  },
+  {
+    id: 'models',
+    path: '/models',
+    label: 'Models',
+    icon: Box,
+    component: Models,
+    getProps: () => ({}),
+    sidebar: true,
+    order: 3,
   },
   {
     id: 'settings',


### PR DESCRIPTION
## Summary
The Models page and API were merged in #864 and #870, but the page was never registered as a route. Users couldn't see or navigate to it.

## Fix
Adds Models to the core routes in `plugins/core.js`:
- Lazy-loads `pages/Models.jsx`
- Uses `Box` icon from lucide-react
- `order: 3` — appears between Extensions and Settings in the sidebar
- Always visible in sidebar (`sidebar: true`)

## Verification
- [x] `npm run build` passes
- [x] 35/35 tests pass
- [x] Models appears in sidebar navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)