### PR TITLE
fix(litellm): use wildcard config for Lemonade + restart after model swap

### DIFF
--- a/dream-server/config/litellm/lemonade.yaml
+++ b/dream-server/config/litellm/lemonade.yaml
@@ -1,13 +1,11 @@
 model_list:
-  # Map friendly model alias (e.g. qwen3.5-2b) to Lemonade's internal ID
-  # (e.g. extra.Qwen3.5-2B-Q4_K_M.gguf). Both are set in .env by the installer.
-  - model_name: "os.environ/LLM_MODEL"
-    litellm_params:
-      model: "openai/os.environ/LEMONADE_MODEL_ID"
-      api_base: http://llama-server:8080/api/v1
-      api_key: sk-lemonade
-
-  # Wildcard fallback — pass through any other model name to Lemonade
+  # Wildcard — pass any model name through to Lemonade's OpenAI-compatible API.
+  # Lemonade auto-discovers models from --extra-models-dir and serves them
+  # at /api/v1. Uses the same wildcard approach as local.yaml (NVIDIA/CPU).
+  #
+  # The previous config tried to map os.environ/LLM_MODEL to a specific
+  # Lemonade model ID, but the env vars were never passed to the container
+  # and the model name changed after bootstrap upgrade.
   - model_name: "*"
     litellm_params:
       model: openai/*

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -340,6 +340,13 @@ if command -v docker &>/dev/null && docker ps --filter name=dream-llama-server -
 
     if $_healthy; then
         log "SUCCESS: llama-server is running with $FULL_LLM_MODEL"
+        # Restart LiteLLM so it picks up the new model context.
+        # The lemonade.yaml wildcard config passes any model name through,
+        # but LiteLLM caches routing state and may hold stale model references.
+        if docker ps --filter name=dream-litellm --format '{{.Names}}' 2>/dev/null | grep -q dream-litellm; then
+            log "Restarting LiteLLM to pick up model change..."
+            docker restart dream-litellm 2>&1 || log "WARNING: LiteLLM restart failed (non-fatal)"
+        fi
     else
         log "WARNING: llama-server health check timed out. The model may still be loading."
         log "Check: docker logs dream-llama-server"


### PR DESCRIPTION
## Summary
After bootstrap-upgrade.sh swaps from the bootstrap model to the full model on AMD, LiteLLM still routes to the deleted bootstrap model name → 404 errors. All requests through LiteLLM fail.

## Root cause
`config/litellm/lemonade.yaml` had `os.environ/LLM_MODEL` and `os.environ/LEMONADE_MODEL_ID` references, but:
1. `LEMONADE_MODEL_ID` is never set anywhere (not in .env, not in the container environment)
2. `LLM_MODEL` is not passed to the LiteLLM container
3. After bootstrap-upgrade.sh deletes the bootstrap model and restarts llama-server, LiteLLM is never restarted

NVIDIA was unaffected because `local.yaml` uses a wildcard `*` config.

## Fix

**lemonade.yaml:** Replace broken env var references with wildcard config:
```yaml
# Before (broken)
- model_name: "os.environ/LLM_MODEL"
  litellm_params:
    model: "openai/os.environ/LEMONADE_MODEL_ID"

# After (wildcard, same as NVIDIA)
- model_name: "*"
  litellm_params:
    model: openai/*
```

**bootstrap-upgrade.sh:** Restart LiteLLM after successful model swap:
```bash
if docker ps --filter name=dream-litellm ... | grep -q dream-litellm; then
    docker restart dream-litellm
fi
```

## Evidence from .199
- Lemonade loaded `extra.qwen3-coder-next-Q4_K_M.gguf` (correct model)
- LiteLLM tried to request `extra.Qwen3.5-2B-Q4_K_M.gguf` (deleted bootstrap model) → 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)