### PR TITLE
fix(installer): use $DOCKER_CMD instead of bare docker in phases 11-13

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -303,7 +303,7 @@ MODELS_INI_EOF
     [[ "$ENABLE_COMFYUI" == "true" ]] && _build_services+=(comfyui)
     if [[ "${ENABLE_DREAMFORGE:-}" == "true" ]]; then
         _dreamforge_image="${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:latest}"
-        if ! docker image inspect "$_dreamforge_image" &>/dev/null; then
+        if ! $DOCKER_CMD image inspect "$_dreamforge_image" &>/dev/null; then
             _build_services+=(dreamforge)
         else
             log "DreamForge image found locally — skipping source build"
@@ -347,12 +347,12 @@ MODELS_INI_EOF
     # starting other containers. Some end up in "Created", others never got
     # past "Creating" because their dependencies weren't ready yet.
     # Step 1: start any containers already in Created state
-    docker start $(docker ps -a --filter status=created -q) 2>/dev/null || true
+    $DOCKER_CMD start $($DOCKER_CMD ps -a --filter status=created -q) 2>/dev/null || true
     # Step 2: wait for services to stabilize, then compose pass
     sleep 10
     $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" up -d --no-build >> "$LOG_FILE" 2>&1 || true
     # Step 3: catch any stragglers from the second pass
-    docker start $(docker ps -a --filter status=created -q) 2>/dev/null || true
+    $DOCKER_CMD start $($DOCKER_CMD ps -a --filter status=created -q) 2>/dev/null || true
 
     if $compose_ok; then
         printf "\r  ${BGRN}✓${NC} %-60s\n" "All containers launched"

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -86,7 +86,7 @@ fi
 # We use the /api/config HTTP endpoint to set values after the service starts.
 # Retry up to 5 times with 10s delay — Perplexica may still be starting
 # (especially if it was stuck in "Created" state and started late).
-if docker inspect dream-perplexica &>/dev/null; then
+if $DOCKER_CMD inspect dream-perplexica &>/dev/null; then
     PERPLEXICA_URL="http://localhost:${SERVICE_PORTS[perplexica]:-3004}"
     PYTHON_CMD="python3"
     if [[ -f "$SCRIPT_DIR/lib/python-cmd.sh" ]]; then

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -288,7 +288,7 @@ fi
 #=============================================================================
 if ! $DRY_RUN; then
     # Check Perplexica config was seeded (phase 12 may have failed silently)
-    if docker inspect dream-perplexica &>/dev/null; then
+    if $DOCKER_CMD inspect dream-perplexica &>/dev/null; then
         _perplexica_status=$(curl -sf --max-time 5 "http://localhost:${SERVICE_PORTS[perplexica]:-3004}/api/config" 2>>"$LOG_FILE" | \
             "$PYTHON_CMD" -c "import sys,json;d=json.load(sys.stdin);print('ok' if d['values'].get('setupComplete') else 'needed')" 2>>"$LOG_FILE" || echo "skip")
         if [[ "$_perplexica_status" == "needed" ]]; then


### PR DESCRIPTION
## Summary
Fixes #871 — Phase 05 sets `DOCKER_CMD="sudo docker"` when the user is not in the docker group, but 5 locations in phases 11-13 call `docker` directly, causing permission denied on the Docker socket.

Supersedes #874 (which conflicted with #878's Phase 11 retry changes).

## Changes
3 files, 5 lines — bare `docker` → `$DOCKER_CMD`:
- `11-services.sh`: `docker image inspect`, `docker start`, `docker ps` (3 locations)
- `12-health.sh`: `docker inspect` (1 location)
- `13-summary.sh`: `docker inspect` (1 location)

## Verification
- [x] `bash -n` syntax checks pass on all 3 files
- [x] Zero bare `docker` calls remain in phases 11-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)