### PR TITLE
feat(extensions): service templates — curated multi-extension presets

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -21,10 +21,16 @@ from pathlib import Path
 from socketserver import ThreadingMixIn
 
 VERSION = "1.0.0"
+DREAM_VERSION = VERSION
 SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 MAX_BODY = 16384
 SUBPROCESS_TIMEOUT_START = 600  # 10 min — image pulls can be slow
 SUBPROCESS_TIMEOUT_STOP = 120   # 2 min — stop should be fast
+HOOK_TIMEOUT = 120              # 2 min — hook execution timeout
+VALID_HOOK_NAMES = frozenset({
+    "pre_install", "post_install", "pre_start", "post_start",
+    "pre_uninstall", "post_uninstall",
+})
 logger = logging.getLogger("dream-host-agent")
 
 # Hardcoded fallback — used when core-service-ids.json is missing or unreadable.
@@ -46,6 +52,7 @@ CORE_SERVICE_IDS: set = set()
 # Core services that can be toggled via the extension API (e.g., privacy shield)
 TOGGLABLE_CORE_SERVICES: set = {"privacy-shield"}
 USER_EXTENSIONS_DIR: Path = Path()
+EXTENSIONS_DIR: Path = Path()
 
 # Per-service locks to prevent concurrent start+stop races on the same service
 _service_locks: dict[str, threading.Lock] = collections.defaultdict(threading.Lock)
@@ -389,6 +396,101 @@ def _resolve_container_name(service_id: str) -> str:
     return f"dream-{service_id}"
 
 
+def _read_manifest(ext_dir: Path) -> dict | None:
+    """Read and return the parsed manifest from an extension directory."""
+    for name in ("manifest.yaml", "manifest.yml"):
+        candidate = ext_dir / name
+        if candidate.exists():
+            try:
+                import yaml
+                manifest = yaml.safe_load(candidate.read_text(encoding="utf-8"))
+                if isinstance(manifest, dict):
+                    return manifest
+            except ImportError:
+                logger.error("PyYAML not available on host")
+                return None  # no point trying other files without PyYAML
+            except (OSError, yaml.YAMLError) as exc:
+                logger.warning("Failed to read manifest %s: %s", candidate, exc)
+                continue  # try next candidate
+    return None
+
+
+def _validate_hook_path(ext_dir: Path, hook_script: str) -> Path | None:
+    """Resolve hook path and verify it stays inside ext_dir."""
+    hook_path = (ext_dir / hook_script).resolve()
+    try:
+        hook_path.relative_to(ext_dir.resolve())
+    except ValueError:
+        logger.warning("Path traversal attempt in hook for %s: %s", ext_dir.name, hook_script)
+        return None
+    if not hook_path.is_file():
+        return None
+    return hook_path
+
+
+def _resolve_hook(ext_dir: Path, hook_name: str) -> Path | None:
+    """Resolve a lifecycle hook script from an extension manifest.
+
+    Checks ``hooks`` map first, falls back to ``setup_hook`` for
+    ``post_install`` only.
+    """
+    manifest = _read_manifest(ext_dir)
+    if manifest is None:
+        return None
+    service_def = manifest.get("service", {})
+    if not isinstance(service_def, dict):
+        return None
+
+    # Check hooks map first
+    hooks = service_def.get("hooks", {})
+    if isinstance(hooks, dict):
+        hook_script = hooks.get(hook_name, "")
+        if isinstance(hook_script, str) and hook_script:
+            return _validate_hook_path(ext_dir, hook_script)
+
+    # Fallback: setup_hook -> post_install only
+    if hook_name == "post_install":
+        setup_hook = service_def.get("setup_hook", "")
+        if isinstance(setup_hook, str) and setup_hook:
+            return _validate_hook_path(ext_dir, setup_hook)
+
+    return None
+
+
+def _check_bash_version() -> tuple[bool, str]:
+    """On macOS, verify bash >= 4.0. Returns (ok, message)."""
+    if platform.system() != "Darwin":
+        return True, ""
+    try:
+        result = subprocess.run(
+            ["bash", "--version"],
+            capture_output=True, text=True, timeout=5,
+        )
+        # Parse "GNU bash, version X.Y.Z..."
+        import re as _re
+        match = _re.search(r"version (\d+)\.(\d+)", result.stdout)
+        if match:
+            major = int(match.group(1))
+            if major < 4:
+                return False, f"Bash {match.group(1)}.{match.group(2)} is too old (need 4.0+). Install via: brew install bash"
+        return True, ""
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return False, f"Could not check bash version: {exc}"
+
+
+def _find_ext_dir(service_id: str) -> Path | None:
+    """Find extension directory for a service_id (user-installed or built-in)."""
+    # Check user extensions first
+    user_dir = USER_EXTENSIONS_DIR / service_id
+    if user_dir.is_dir():
+        return user_dir
+    # Check built-in extensions
+    builtin_dir = EXTENSIONS_DIR / service_id
+    if builtin_dir.is_dir():
+        return builtin_dir
+    return None
+
+
 class AgentHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         logger.info(fmt, *args)
@@ -486,6 +588,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_install()
         elif self.path == "/v1/extension/setup-hook":
             self._handle_setup_hook()
+        elif self.path == "/v1/extension/hooks":
+            self._handle_hook()
         elif self.path == "/v1/service/logs":
             self._handle_service_logs()
         elif self.path == "/v1/model/download":
@@ -663,6 +767,7 @@ class AgentHandler(BaseHTTPRequestHandler):
 
 
     def _handle_setup_hook(self):
+        """Backwards-compatible wrapper — delegates to hook resolution with post_install."""
         if not check_auth(self):
             return
         body = read_json_body(self)
@@ -672,73 +777,119 @@ class AgentHandler(BaseHTTPRequestHandler):
         if service_id is None:
             return
 
-        # Read manifest to find setup_hook field
-        ext_dir = USER_EXTENSIONS_DIR / service_id
-        manifest_path = None
-        for name in ("manifest.yaml", "manifest.yml"):
-            candidate = ext_dir / name
-            if candidate.exists():
-                manifest_path = candidate
-                break
-        if manifest_path is None:
-            json_response(self, 404, {"error": f"No manifest found for {service_id}"})
+        ext_dir = _find_ext_dir(service_id)
+        if ext_dir is None:
+            json_response(self, 404, {"error": f"Extension not found: {service_id}"})
             return
 
-        try:
-            import yaml
-            manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-        except ImportError:
-            json_response(self, 500, {"error": "PyYAML not available on host"})
-            return
-        except (OSError, yaml.YAMLError) as exc:
-            json_response(self, 500, {"error": f"Failed to read manifest: {exc}"})
-            return
-
-        if not isinstance(manifest, dict):
-            json_response(self, 404, {"error": "Invalid manifest format"})
-            return
-        service_def = manifest.get("service", {})
-        if not isinstance(service_def, dict):
-            json_response(self, 404, {"error": "Invalid manifest: missing service section"})
-            return
-        setup_hook = service_def.get("setup_hook", "")
-        if not isinstance(setup_hook, str) or not setup_hook:
+        hook_path = _resolve_hook(ext_dir, "post_install")
+        if hook_path is None:
             json_response(self, 404, {"error": f"No setup_hook defined for {service_id}"})
             return
 
-        # Security: resolve hook path and verify it stays inside ext_dir
-        hook_path = (ext_dir / setup_hook).resolve()
-        try:
-            hook_path.relative_to(ext_dir.resolve())
-        except ValueError:
-            logger.warning("Path traversal attempt in setup_hook for %s: %s", service_id, setup_hook)
-            json_response(self, 400, {"error": "setup_hook path escapes extension directory"})
+        self._execute_hook(service_id, ext_dir, hook_path, "post_install")
+
+    def _handle_hook(self):
+        """Generic lifecycle hook endpoint: POST /v1/extension/hooks."""
+        if not check_auth(self):
             return
-        if not hook_path.is_file():
-            json_response(self, 404, {"error": f"setup_hook file not found: {setup_hook}"})
+        body = read_json_body(self)
+        if body is None:
             return
 
-        logger.info("Running setup_hook for %s: %s", service_id, hook_path)
+        # Validate service_id
+        sid = body.get("service_id", "")
+        if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
+            json_response(self, 400, {"error": "Invalid service_id"})
+            return
+
+        # Validate hook name
+        hook_name = body.get("hook", "")
+        if not isinstance(hook_name, str) or hook_name not in VALID_HOOK_NAMES:
+            json_response(self, 400, {
+                "error": f"Invalid hook name. Must be one of: {', '.join(sorted(VALID_HOOK_NAMES))}",
+            })
+            return
+
+        ext_dir = _find_ext_dir(sid)
+        if ext_dir is None:
+            json_response(self, 404, {"error": f"Extension not found: {sid}"})
+            return
+
+        hook_path = _resolve_hook(ext_dir, hook_name)
+        if hook_path is None:
+            # No hook defined — not an error
+            json_response(self, 404, {"error": f"No {hook_name} hook defined for {sid}"})
+            return
+
+        self._execute_hook(sid, ext_dir, hook_path, hook_name)
+
+    def _execute_hook(self, service_id: str, ext_dir: Path, hook_path: Path, hook_name: str):
+        """Execute a resolved hook script with sandboxed environment."""
+        # macOS: validate bash version >= 4.0
+        bash_ok, bash_msg = _check_bash_version()
+        if not bash_ok:
+            json_response(self, 500, {"error": f"Cannot run hook: {bash_msg}"})
+            return
+
+        # Read manifest for service port
+        manifest = _read_manifest(ext_dir)
+        service_def = manifest.get("service", {}) if manifest else {}
+        if not isinstance(service_def, dict):
+            service_def = {}
+
+        # Minimal allowlist environment
+        hook_env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": os.environ.get("HOME", ""),
+            "SERVICE_ID": service_id,
+            "SERVICE_PORT": str(service_def.get("port", 0)),
+            "SERVICE_DATA_DIR": str(DATA_DIR / service_id),
+            "DREAM_VERSION": DREAM_VERSION,
+            "GPU_BACKEND": GPU_BACKEND,
+            "HOOK_NAME": hook_name,
+        }
+
+        logger.info("Running %s hook for %s: %s", hook_name, service_id, hook_path)
         try:
-            result = subprocess.run(
+            proc = subprocess.Popen(
                 ["bash", str(hook_path), str(INSTALL_DIR), GPU_BACKEND],
-                cwd=str(ext_dir),
-                capture_output=True, text=True, timeout=SUBPROCESS_TIMEOUT_STOP,
+                cwd=str(ext_dir), env=hook_env,
+                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                preexec_fn=os.setsid,
             )
-            if result.returncode != 0:
-                logger.error("setup_hook failed for %s (exit %d): %s",
-                             service_id, result.returncode, result.stderr[:500])
+            try:
+                stdout, stderr = proc.communicate(timeout=HOOK_TIMEOUT)
+            except subprocess.TimeoutExpired:
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                proc.wait()
+                json_response(self, 500, {"error": f"{hook_name} hook timed out ({HOOK_TIMEOUT}s)"})
+                return
+
+            if proc.returncode != 0:
+                logger.error("%s hook failed for %s (exit %d): %s",
+                             hook_name, service_id, proc.returncode, (stderr or b"").decode()[:500])
+                # post_start failure is non-terminal
+                if hook_name == "post_start":
+                    json_response(self, 200, {
+                        "status": "warning",
+                        "service_id": service_id,
+                        "hook": hook_name,
+                        "warning": f"post_start hook exited with code {proc.returncode}",
+                        "stderr": (stderr or b"").decode()[:500],
+                    })
+                    return
                 json_response(self, 500, {
-                    "error": f"setup_hook exited with code {result.returncode}",
-                    "stderr": result.stderr[:500],
+                    "error": f"{hook_name} hook exited with code {proc.returncode}",
+                    "stderr": (stderr or b"").decode()[:500],
                 })
                 return
-        except subprocess.TimeoutExpired:
-            json_response(self, 500, {"error": "setup_hook timed out (120s)"})
+        except OSError as exc:
+            json_response(self, 500, {"error": f"Failed to execute hook: {exc}"})
             return
 
-        logger.info("setup_hook completed for %s", service_id)
-        json_response(self, 200, {"status": "ok", "service_id": service_id})
+        logger.info("%s hook completed for %s", hook_name, service_id)
+        json_response(self, 200, {"status": "ok", "service_id": service_id, "hook": hook_name})
 
     def _handle_install(self):
         """Combined install: setup_hook → pull → start with progress tracking."""
@@ -1477,7 +1628,8 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 def main():
-    global INSTALL_DIR, DATA_DIR, AGENT_API_KEY, GPU_BACKEND, TIER, CORE_SERVICE_IDS, USER_EXTENSIONS_DIR
+    global INSTALL_DIR, DATA_DIR, AGENT_API_KEY, GPU_BACKEND, TIER, CORE_SERVICE_IDS
+    global USER_EXTENSIONS_DIR, EXTENSIONS_DIR, DREAM_VERSION
 
     parser = argparse.ArgumentParser(description="DreamServer Host Agent")
     parser.add_argument("--port", type=int, default=7710, help="Listen port (default: 7710)")
@@ -1514,6 +1666,8 @@ def main():
         "DREAM_USER_EXTENSIONS_DIR",
         str(DATA_DIR / "user-extensions"),
     ))
+    EXTENSIONS_DIR = INSTALL_DIR / "extensions" / "services"
+    DREAM_VERSION = env.get("DREAM_VERSION", VERSION)
 
     port = args.port
     env_port = env.get("DREAM_AGENT_PORT", "")

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -182,6 +182,7 @@ services:
       - ./.env.example:/dream-server/.env.example:ro
       - ./.env.schema.json:/dream-server/.env.schema.json:ro
       - ./data:/data
+      - ./templates:/dream-server/templates:ro
     deploy:
       resources:
         limits:

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -291,6 +291,80 @@ _regenerate_compose_flags() {
     fi
 }
 
+# Run a lifecycle hook for a service (reads manifest directly via Python)
+_run_hook() {
+    local service_id="$1" hook_name="$2"
+    local ext_dir="$INSTALL_DIR/extensions/services/$service_id"
+    # Also check user-extensions
+    [[ -d "$ext_dir" ]] || ext_dir="$INSTALL_DIR/data/user-extensions/$service_id"
+    [[ -d "$ext_dir" ]] || return 0
+
+    local hook_path
+    hook_path=$(python3 - "$ext_dir" "$hook_name" <<'PYEOF'
+import yaml, sys
+from pathlib import Path
+
+ext_dir = Path(sys.argv[1])
+hook_name = sys.argv[2]
+
+manifest_path = None
+for name in ("manifest.yaml", "manifest.yml"):
+    candidate = ext_dir / name
+    if candidate.exists():
+        manifest_path = candidate
+        break
+if manifest_path is None:
+    sys.exit(0)
+
+with open(manifest_path) as f:
+    m = yaml.safe_load(f)
+if not isinstance(m, dict):
+    sys.exit(0)
+service = m.get("service", {})
+if not isinstance(service, dict):
+    sys.exit(0)
+
+# Check hooks map first
+hooks = service.get("hooks", {})
+hook_script = ""
+if isinstance(hooks, dict):
+    hook_script = hooks.get(hook_name, "")
+
+# Fallback: setup_hook -> post_install only
+if not hook_script and hook_name == "post_install":
+    hook_script = service.get("setup_hook", "")
+
+if not hook_script:
+    sys.exit(0)
+
+# Validate path containment
+hook_path = (ext_dir / hook_script).resolve()
+try:
+    hook_path.relative_to(ext_dir.resolve())
+except ValueError:
+    print(f"ERROR: hook path escapes extension directory: {hook_script}", file=sys.stderr)
+    sys.exit(1)
+
+if not hook_path.is_file():
+    sys.exit(0)
+
+print(str(hook_path))
+PYEOF
+    ) || return 0
+
+    [[ -z "$hook_path" || ! -f "$hook_path" ]] && return 0
+
+    log "Running $hook_name hook for $service_id..."
+    SERVICE_ID="$service_id" \
+    SERVICE_PORT="${SERVICE_PORTS[$service_id]:-0}" \
+    SERVICE_DATA_DIR="$INSTALL_DIR/data/$service_id" \
+    DREAM_VERSION="$VERSION" \
+    GPU_BACKEND="${GPU_BACKEND:-}" \
+    HOOK_NAME="$hook_name" \
+        bash "$hook_path" "$INSTALL_DIR" "${GPU_BACKEND:-}" \
+        || warn "$hook_name hook failed for $service_id (non-fatal)"
+}
+
 # Build full compose flags: base + GPU overlay + enabled extensions
 get_compose_flags() {
     # Fast path: use saved flags from installer if available
@@ -610,6 +684,7 @@ cmd_start() {
     check_install
     cd "$INSTALL_DIR"
     load_env
+    sr_load
 
     local service="${1:-}"
     local flags_str
@@ -623,9 +698,11 @@ cmd_start() {
         success "All services started"
     else
         service=$(resolve_service "$service")
+        _run_hook "$service" "pre_start"
         log "Starting $service..."
         docker compose "${flags[@]}" up -d "$service"
         success "$service started"
+        _run_hook "$service" "post_start"
     fi
 }
 

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -2884,6 +2884,178 @@ cmd_repair() {
     log "Run 'dream doctor' to diagnose issues, then check the output for suggested fixes."
 }
 
+#=============================================================================
+# Templates
+#=============================================================================
+_template_list() {
+    local templates_dir="$INSTALL_DIR/templates"
+    if [[ ! -d "$templates_dir" ]]; then
+        warn "No templates directory found at $templates_dir"
+        return 0
+    fi
+
+    local found=0
+    printf "${CYAN}%-20s %-30s %-6s %s${NC}\n" "ID" "NAME" "TIER" "SERVICES"
+    printf "%-20s %-30s %-6s %s\n" "----" "----" "----" "--------"
+
+    for f in "$templates_dir"/*.yaml "$templates_dir"/*.yml; do
+        [[ -f "$f" ]] || continue
+        local info
+        info=$(python3 - "$f" <<'PYEOF'
+import yaml, sys
+with open(sys.argv[1]) as fh:
+    d = yaml.safe_load(fh)
+if not isinstance(d, dict) or d.get("schema_version") != "dream.templates.v1":
+    sys.exit(0)
+t = d.get("template", {})
+tid = t.get("id", "")
+name = t.get("name", "")
+tier = t.get("tier_minimum", "-")
+svcs = ", ".join(t.get("services", []))
+if tid:
+    print(f"{tid}\t{name}\t{tier}\t{svcs}")
+PYEOF
+        ) || continue
+        [[ -z "$info" ]] && continue
+        IFS=$'\t' read -r tid tname ttier tsvcs <<< "$info"
+        printf "%-20s %-30s %-6s %s\n" "$tid" "$tname" "$ttier" "$tsvcs"
+        found=1
+    done
+
+    if [[ "$found" -eq 0 ]]; then
+        log "No templates found."
+    fi
+}
+
+_template_preview() {
+    local template_id="${1:-}"
+    [[ -z "$template_id" ]] && { log "Usage: dream template preview <template-id>"; exit 1; }
+
+    local templates_dir="$INSTALL_DIR/templates"
+    local tmpl_file=""
+    for f in "$templates_dir"/*.yaml "$templates_dir"/*.yml; do
+        [[ -f "$f" ]] || continue
+        local tid
+        tid=$(python3 - "$f" <<'PYEOF'
+import yaml, sys
+with open(sys.argv[1]) as fh:
+    d = yaml.safe_load(fh)
+if not isinstance(d, dict) or d.get("schema_version") != "dream.templates.v1":
+    sys.exit(0)
+t = d.get("template", {})
+print(t.get("id", ""))
+PYEOF
+        ) || continue
+        if [[ "$tid" == "$template_id" ]]; then
+            tmpl_file="$f"
+            break
+        fi
+    done
+
+    [[ -z "$tmpl_file" ]] && error "Template not found: $template_id"
+
+    python3 - "$tmpl_file" "$INSTALL_DIR" <<'PYEOF'
+import yaml, sys
+from pathlib import Path
+
+with open(sys.argv[1]) as fh:
+    d = yaml.safe_load(fh)
+t = d.get("template", {})
+install_dir = Path(sys.argv[2])
+
+print(f"Template: {t.get('name', t.get('id', ''))}")
+print(f"Description: {t.get('description', '-')}")
+if t.get("estimated_disk_gb"):
+    print(f"Estimated disk: ~{t['estimated_disk_gb']}GB")
+print()
+
+services = t.get("services", [])
+ext_dir = install_dir / "extensions" / "services"
+user_ext_dir = install_dir / "data" / "user-extensions"
+
+to_enable = []
+already = []
+for svc in services:
+    cf = ext_dir / svc / "compose.yaml"
+    ucf = user_ext_dir / svc / "compose.yaml"
+    if cf.exists() or ucf.exists():
+        already.append(svc)
+    else:
+        to_enable.append(svc)
+
+if already:
+    print(f"Already enabled: {', '.join(already)}")
+if to_enable:
+    print(f"Will enable:     {', '.join(to_enable)}")
+if not to_enable:
+    print("Nothing to change — all services already enabled.")
+PYEOF
+}
+
+_template_apply() {
+    local template_id="${1:-}"
+    [[ -z "$template_id" ]] && { log "Usage: dream template apply <template-id>"; exit 1; }
+
+    local templates_dir="$INSTALL_DIR/templates"
+    local services
+    services=$(python3 - "$templates_dir" "$template_id" <<'PYEOF'
+import yaml, sys
+from pathlib import Path
+
+templates_dir = Path(sys.argv[1])
+target_id = sys.argv[2]
+
+for f in sorted(templates_dir.glob("*.yaml")) + sorted(templates_dir.glob("*.yml")):
+    with open(f) as fh:
+        d = yaml.safe_load(fh)
+    if not isinstance(d, dict) or d.get("schema_version") != "dream.templates.v1":
+        continue
+    t = d.get("template", {})
+    if t.get("id") == target_id:
+        print(" ".join(t.get("services", [])))
+        sys.exit(0)
+
+print("", file=sys.stderr)
+sys.exit(1)
+PYEOF
+    ) || error "Template not found: $template_id"
+
+    [[ -z "$services" ]] && { warn "Template has no services."; return 0; }
+
+    log "Applying template: $template_id"
+    local svc
+    for svc in $services; do
+        # Skip core services (no compose toggle needed)
+        local cat="${SERVICE_CATEGORIES[$svc]:-optional}"
+        [[ "$cat" == "core" ]] && continue
+
+        local cf="$INSTALL_DIR/extensions/services/$svc/compose.yaml"
+        local ucf="$INSTALL_DIR/data/user-extensions/$svc/compose.yaml"
+        if [[ -f "$cf" || -f "$ucf" ]]; then
+            log "  $svc — already enabled"
+            continue
+        fi
+
+        log "  Enabling $svc..."
+        cmd_enable "$svc" || warn "  Failed to enable $svc (continuing)"
+    done
+    success "Template applied: $template_id"
+}
+
+cmd_template() {
+    check_install
+    sr_load
+    load_env 2>/dev/null || true
+    local subcmd="${1:-list}"
+    shift || true
+    case "$subcmd" in
+        list)    _template_list ;;
+        preview) _template_preview "$@" ;;
+        apply)   _template_apply "$@" ;;
+        *)       log "Usage: dream template [list|preview|apply] [template-id]"; exit 1 ;;
+    esac
+}
+
 cmd_help() {
     sr_load
     cat << EOF
@@ -2921,6 +3093,7 @@ ${CYAN}Commands:${NC}
   benchmark           Run a quick performance test
   doctor [report]     Run diagnostics and write JSON report
   repair|fix          Run basic repairs (currently redirects to doctor)
+  template [action]   Apply pre-built service templates (list|preview|apply)
   audit [extensions]  Audit extension manifests and compose contracts
   agent [action]      Manage dream host agent (status|start|stop|restart|logs)
   help                Show this help
@@ -2995,6 +3168,11 @@ ${CYAN}Examples:${NC}
   dream restart stt               # Restart Whisper (via alias)
   dream chat "What is 2+2?"      # Quick LLM test
   dream config edit               # Edit .env file
+  dream template list              # List available templates
+  dream template preview creative-studio
+                                  # Preview what a template will change
+  dream template apply chat-playground
+                                  # Apply a template (enables services)
   dream audit                     # Audit every extension contract
   dream audit --json whisper      # Audit one service as JSON
   dream agent status              # Check host agent health
@@ -3035,6 +3213,7 @@ case "${1:-help}" in
     benchmark|bench|b) cmd_benchmark ;;
     doctor|diag|d) shift; cmd_doctor "$@" ;;
     audit)        shift; cmd_audit "$@" ;;
+    template|tmpl) shift; cmd_template "$@" ;;
     agent)        shift; cmd_agent "$@" ;;
     help|h|--help|-h) cmd_help ;;
     version|v|--version|-v) echo "dream-cli v${VERSION}" ;;

--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -96,6 +96,19 @@
         "setup_hook": {
           "type": "string",
           "description": "Relative path to a setup script run during installation (e.g. setup.sh)"
+        },
+        "hooks": {
+          "type": "object",
+          "description": "Lifecycle hook scripts. Paths relative to extension directory.",
+          "properties": {
+            "pre_install": { "type": "string" },
+            "post_install": { "type": "string" },
+            "pre_start": { "type": "string" },
+            "post_start": { "type": "string" },
+            "pre_uninstall": { "type": "string" },
+            "post_uninstall": { "type": "string" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": true

--- a/dream-server/extensions/schema/service-template.v1.json
+++ b/dream-server/extensions/schema/service-template.v1.json
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://dreamserver.ai/schemas/service-template.v1.json",
+  "title": "Dream Server Service Template v1",
+  "type": "object",
+  "required": ["schema_version", "template"],
+  "properties": {
+    "schema_version": {
+      "const": "dream.templates.v1"
+    },
+    "template": {
+      "type": "object",
+      "required": ["id", "name", "services"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "Unique template identifier"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Human-readable template name"
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of what this template provides"
+        },
+        "icon": {
+          "type": "string",
+          "description": "Lucide icon name for UI display"
+        },
+        "tags": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Searchable tags for template discovery"
+        },
+        "services": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+          "minItems": 1,
+          "description": "Service IDs to enable when this template is applied"
+        },
+        "tier_minimum": {
+          "type": "string",
+          "pattern": "^T[0-9]+$",
+          "description": "Minimum hardware tier required (e.g. T1, T2)"
+        },
+        "estimated_disk_gb": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Estimated disk space in GB"
+        },
+        "service_notes": {
+          "type": "object",
+          "additionalProperties": { "type": "string" },
+          "description": "Per-service notes shown in the UI"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -127,6 +127,10 @@ def load_extension_manifests(
                     "name": service.get("name", service_id),
                     "ui_path": service.get("ui_path", "/"),
                     "container_name": service.get("container_name", f"dream-{service_id}"),
+                    "depends_on": service.get("depends_on", []),
+                    "category": service.get("category", "optional"),
+                    "setup_hook": service.get("setup_hook", ""),
+                    "hooks": service.get("hooks", {}),
                     **({"type": service["type"]} if "type" in service else {}),
                     **({"health_port": int(service["health_port"])} if "health_port" in service else {}),
                 }

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -131,6 +131,7 @@ def load_extension_manifests(
                     "category": service.get("category", "optional"),
                     "setup_hook": service.get("setup_hook", ""),
                     "hooks": service.get("hooks", {}),
+                    "gpu_backends": service.get("gpu_backends", []),
                     **({"type": service["type"]} if "type" in service else {}),
                     **({"health_port": int(service["health_port"])} if "health_port" in service else {}),
                 }
@@ -300,3 +301,62 @@ DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY", "")
 # Prefer dedicated DREAM_AGENT_KEY; fall back to DASHBOARD_API_KEY for
 # existing installs that haven't generated a separate key yet.
 DREAM_AGENT_KEY = os.environ.get("DREAM_AGENT_KEY", "") or DASHBOARD_API_KEY
+
+
+# --- Templates ---
+
+TEMPLATES_DIR = Path(
+    os.environ.get(
+        "DREAM_TEMPLATES_DIR",
+        str(Path(INSTALL_DIR) / "templates")
+    )
+)
+
+_TEMPLATE_SCHEMA = None
+try:
+    import jsonschema as _jsonschema_mod
+    _schema_path = Path(__file__).parent.parent.parent / "schema" / "service-template.v1.json"
+    if _schema_path.exists():
+        _TEMPLATE_SCHEMA = json.loads(_schema_path.read_text(encoding="utf-8"))
+except ImportError:
+    _jsonschema_mod = None
+
+
+def load_templates() -> list[dict]:
+    """Load service templates from YAML files. Returns empty list on failure."""
+    if not TEMPLATES_DIR.exists():
+        logger.info("Templates directory not found at %s", TEMPLATES_DIR)
+        return []
+
+    templates = []
+    for path in sorted(TEMPLATES_DIR.iterdir()):
+        if path.suffix.lower() not in (".yaml", ".yml"):
+            continue
+        try:
+            data = yaml.safe_load(path.read_text(encoding="utf-8"))
+            if not isinstance(data, dict):
+                logger.warning("Skipping template %s: root is not a mapping", path.name)
+                continue
+            if data.get("schema_version") != "dream.templates.v1":
+                logger.warning("Skipping template %s: unsupported schema_version", path.name)
+                continue
+            # Validate against JSON Schema if available
+            if _TEMPLATE_SCHEMA is not None and _jsonschema_mod is not None:
+                try:
+                    _jsonschema_mod.validate(data, _TEMPLATE_SCHEMA)
+                except _jsonschema_mod.ValidationError as ve:
+                    logger.warning("Template validation failed for %s: %s", path.name, ve.message)
+                    continue
+            template = data.get("template")
+            if not isinstance(template, dict) or not template.get("id") or not template.get("services"):
+                logger.warning("Skipping template %s: missing required fields", path.name)
+                continue
+            templates.append(template)
+        except (yaml.YAMLError, OSError, ValueError) as e:
+            logger.warning("Failed loading template %s: %s", path.name, e)
+
+    logger.info("Loaded %d service templates", len(templates))
+    return templates
+
+
+TEMPLATES = load_templates()

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -122,7 +122,7 @@ _MANUAL_RESTART_KEYS = {
 }
 
 # --- Router imports ---
-from routers import workflows, features, setup, updates, agents, privacy, extensions, gpu as gpu_router, resources, voice, models as models_router
+from routers import workflows, features, setup, updates, agents, privacy, extensions, gpu as gpu_router, resources, voice, models as models_router, templates
 
 logger = logging.getLogger(__name__)
 
@@ -928,6 +928,7 @@ app.include_router(gpu_router.router)
 app.include_router(resources.router)
 app.include_router(voice.router)
 app.include_router(models_router.router)
+app.include_router(templates.router)
 
 
 # ================================================================

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -418,25 +418,34 @@ def _call_agent(action: str, service_id: str) -> bool:
 
 
 def _call_agent_setup_hook(service_id: str) -> bool:
-    """Call host agent to run setup_hook for an extension. Returns True on success."""
-    url = f"{AGENT_URL}/v1/extension/setup-hook"
+    """Call host agent to run setup_hook for an extension. Returns True on success.
+
+    Backwards-compatible wrapper — delegates to the generic hook endpoint
+    with hook_name="post_install".
+    """
+    return _call_agent_hook(service_id, "post_install")
+
+
+def _call_agent_hook(service_id: str, hook_name: str) -> bool:
+    """Call host agent to run a lifecycle hook. Returns True on success."""
+    url = f"{AGENT_URL}/v1/extension/hooks"
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {DREAM_AGENT_KEY}",
     }
-    data = json.dumps({"service_id": service_id}).encode()
+    data = json.dumps({"service_id": service_id, "hook": hook_name}).encode()
     req = urllib.request.Request(url, data=data, headers=headers, method="POST")
     try:
         with urllib.request.urlopen(req, timeout=_AGENT_TIMEOUT) as resp:
             return resp.status == 200
     except urllib.error.HTTPError as exc:
         if exc.code == 404:
-            # No setup_hook defined — not an error
+            # No hook defined — not an error
             return True
-        logger.warning("setup_hook failed for %s (HTTP %d)", service_id, exc.code)
+        logger.warning("%s hook failed for %s (HTTP %d)", hook_name, service_id, exc.code)
         return False
-    except Exception:
-        logger.warning("Host agent unreachable for setup_hook at %s", AGENT_URL)
+    except (urllib.error.URLError, OSError, TimeoutError):
+        logger.warning("Host agent unreachable for %s hook at %s", hook_name, AGENT_URL)
         return False
 
 
@@ -569,7 +578,16 @@ async def extensions_catalog(
         user_dir = USER_EXTENSIONS_DIR / ext_id
         source = "user" if user_dir.is_dir() else ("core" if ext_id in SERVICES else "library")
         has_data = (Path(DATA_DIR) / ext_id).is_dir()
-        enriched = {**ext, "status": status, "installable": installable, "source": source, "has_data": has_data}
+        enriched = {
+            **ext,
+            "status": status,
+            "installable": installable,
+            "source": source,
+            "has_data": has_data,
+            "depends_on": ext.get("depends_on", []),
+            "dependents": [],
+            "dependency_status": {},
+        }
 
         if category and ext.get("category") != category:
             continue
@@ -579,6 +597,26 @@ async def extensions_catalog(
                 continue
 
         extensions.append(enriched)
+
+    # Compute reverse dependency map and dependency status
+    dep_map: dict[str, list[str]] = {}
+    for e in extensions:
+        for dep in e.get("depends_on", []):
+            dep_map.setdefault(dep, []).append(e["id"])
+    ext_by_id = {e["id"]: e for e in extensions}
+    for e in extensions:
+        e["dependents"] = dep_map.get(e["id"], [])
+        dep_status = {}
+        for dep in e.get("depends_on", []):
+            dep_ext = ext_by_id.get(dep)
+            if dep_ext:
+                dep_status[dep] = dep_ext["status"]
+            elif dep in SERVICES:
+                svc = services_by_id.get(dep)
+                dep_status[dep] = "enabled" if (svc and svc.status == "healthy") else "disabled"
+            else:
+                dep_status[dep] = "unknown"
+        e["dependency_status"] = dep_status
 
     summary = {
         "total": len(extensions),
@@ -781,6 +819,11 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
                     detail="Extension exceeds maximum size of 50MB",
                 )
 
+    # NOTE: pre_install hook is deferred to a future version. On fresh library
+    # installs, the extension directory doesn't exist yet, so the host agent
+    # cannot resolve the hook script. The call site is intentionally omitted
+    # until the install flow can read manifests from the library source.
+
     # Atomic install via temp directory on same filesystem
     with _extensions_lock():
         # Re-check under lock to prevent double-install race
@@ -814,7 +857,10 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
     # (before host agent starts processing — closes the race window)
     _write_initial_progress(service_id)
 
-    # Call host agent combined install (setup_hook → pull → start)
+    # Call host agent combined install (setup_hook → pull → start).
+    # The setup_hook step internally satisfies the post_install lifecycle
+    # contract — _resolve_hook("post_install") falls back to manifest's
+    # setup_hook field, so we don't double-run it here.
     agent_ok = _call_agent_install(service_id)
 
     logger.info("Installed extension: %s", service_id)
@@ -830,9 +876,122 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
     }
 
 
+def _read_direct_deps(service_id: str) -> list[str]:
+    """Return direct depends_on list for a service from its manifest."""
+    ext_dir = USER_EXTENSIONS_DIR / service_id
+    manifest_path = None
+    for name in ("manifest.yaml", "manifest.yml"):
+        candidate = ext_dir / name
+        if candidate.exists():
+            manifest_path = candidate
+            break
+    if manifest_path is None:
+        return []
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError):
+        return []
+    if not isinstance(manifest, dict):
+        return []
+    svc = manifest.get("service", {})
+    depends_on = svc.get("depends_on", []) if isinstance(svc, dict) else []
+    if not isinstance(depends_on, list):
+        return []
+    return [d for d in depends_on if isinstance(d, str) and _SERVICE_ID_RE.match(d)]
+
+
+def _is_dep_satisfied(dep: str) -> bool:
+    """Check if a dependency is already enabled (core, built-in, or user)."""
+    if dep in CORE_SERVICE_IDS:
+        return True
+    if (EXTENSIONS_DIR / dep / "compose.yaml").exists():
+        return True
+    if (USER_EXTENSIONS_DIR / dep / "compose.yaml").exists():
+        return True
+    return False
+
+
+def _get_missing_deps_transitive(
+    service_id: str, *, _visiting: set | None = None, _order: list | None = None,
+) -> list[str]:
+    """Return all transitive missing deps in dependency order (leaves first).
+
+    Raises HTTPException on circular dependency.
+    """
+    if _visiting is None:
+        _visiting = set()
+    if _order is None:
+        _order = []
+
+    if service_id in _visiting:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Circular dependency detected involving: {service_id}",
+        )
+    _visiting.add(service_id)
+
+    for dep in _read_direct_deps(service_id):
+        if _is_dep_satisfied(dep):
+            continue
+        if dep in _order:
+            continue  # already queued from another branch
+        _get_missing_deps_transitive(dep, _visiting=_visiting, _order=_order)
+        _order.append(dep)
+
+    _visiting.discard(service_id)
+    return _order
+
+
+def _activate_service(service_id: str) -> dict:
+    """Core enable logic — NO lock acquisition. Called inside _extensions_lock.
+
+    Returns a result dict for the service. Cycle detection is handled
+    upstream by _get_missing_deps_transitive.
+    """
+    ext_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
+    if not ext_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()):
+        raise HTTPException(
+            status_code=404, detail=f"Extension not found: {service_id}",
+        )
+    if not ext_dir.is_dir():
+        raise HTTPException(
+            status_code=404, detail=f"Extension not installed: {service_id}",
+        )
+
+    disabled_compose = ext_dir / "compose.yaml.disabled"
+    enabled_compose = ext_dir / "compose.yaml"
+
+    # Already enabled — skip silently (idempotent for dep chains)
+    if enabled_compose.exists():
+        return {"id": service_id, "action": "already_enabled"}
+
+    if not disabled_compose.exists():
+        raise HTTPException(
+            status_code=404, detail=f"Extension has no compose file: {service_id}",
+        )
+
+    # Re-scan compose content (TOCTOU prevention)
+    _scan_compose_content(disabled_compose)
+
+    # Reject symlinks
+    st = os.lstat(disabled_compose)
+    if stat.S_ISLNK(st.st_mode):
+        raise HTTPException(
+            status_code=400, detail="Compose file is a symlink",
+        )
+
+    os.rename(str(disabled_compose), str(enabled_compose))
+    logger.info("Enabled extension (activate): %s", service_id)
+    return {"id": service_id, "action": "enabled"}
+
+
 @router.post("/api/extensions/{service_id}/enable")
-def enable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
-    """Enable an installed extension."""
+def enable_extension(
+    service_id: str,
+    auto_enable_deps: bool = Query(False),
+    api_key: str = Depends(verify_api_key),
+):
+    """Enable an installed extension, optionally auto-enabling dependencies."""
     _validate_service_id(service_id)
     _assert_not_core(service_id)
 
@@ -877,64 +1036,50 @@ def enable_extension(service_id: str, api_key: str = Depends(verify_api_key)):
             status_code=404, detail=f"Extension has no compose file: {service_id}",
         )
 
-    # Check dependencies from manifest
-    manifest_path = ext_dir / "manifest.yaml"
-    if manifest_path.exists():
-        try:
-            manifest = yaml.safe_load(
-                manifest_path.read_text(encoding="utf-8"),
-            )
-        except (yaml.YAMLError, OSError) as e:
-            logger.warning("Could not read manifest for %s: %s", service_id, e)
-            manifest = {}
-        depends_on = []
-        if isinstance(manifest, dict):
-            svc = manifest.get("service", {})
-            depends_on = svc.get("depends_on", []) if isinstance(svc, dict) else []
-            if not isinstance(depends_on, list):
-                depends_on = []
-        missing_deps = []
-        for dep in depends_on:
-            if not isinstance(dep, str) or not _SERVICE_ID_RE.match(dep):
-                continue
-            # Core services have compose in docker-compose.base.yml, not individual files
-            if dep in CORE_SERVICE_IDS:
-                continue
-            # Check built-in extensions
-            if (EXTENSIONS_DIR / dep / "compose.yaml").exists():
-                continue
-            # Check user extensions
-            if (USER_EXTENSIONS_DIR / dep / "compose.yaml").exists():
-                continue
-            missing_deps.append(dep)
-        if missing_deps:
-            raise HTTPException(
-                status_code=400,
-                detail=f"Missing dependencies: {', '.join(missing_deps)}",
-            )
+    # Check dependencies (transitive — gathers full tree, detects cycles)
+    missing_deps = _get_missing_deps_transitive(service_id)
+    if missing_deps and not auto_enable_deps:
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "message": f"Missing dependencies: {', '.join(missing_deps)}",
+                "missing_dependencies": missing_deps,
+                "auto_enable_available": True,
+            },
+        )
+
+    enabled_services: list[str] = []
 
     with _extensions_lock():
-        # Re-scan compose content inside lock (TOCTOU prevention —
-        # file contents could be modified between scan and rename)
-        compose_path = ext_dir / "compose.yaml.disabled"
-        if compose_path.exists():
-            _scan_compose_content(compose_path)
+        # Auto-enable missing deps first (already in dependency order — leaves first)
+        if missing_deps and auto_enable_deps:
+            for dep in missing_deps:
+                _validate_service_id(dep)
+                result = _activate_service(dep)
+                if result.get("action") == "enabled":
+                    enabled_services.append(dep)
 
-        # Reject symlinks (checked under lock to prevent TOCTOU)
-        st = os.lstat(disabled_compose)
-        if stat.S_ISLNK(st.st_mode):
-            raise HTTPException(
-                status_code=400, detail="Compose file is a symlink",
-            )
+        # Enable the target service
+        result = _activate_service(service_id)
+        if result.get("action") == "enabled":
+            enabled_services.append(service_id)
 
-        os.rename(str(disabled_compose), str(enabled_compose))
+    # Start all enabled services via agent (outside lock)
+    agent_ok = True
+    for svc_id in enabled_services:
+        _call_agent_hook(svc_id, "pre_start")
+        if not _call_agent("start", svc_id):
+            agent_ok = False
+        # post_start is non-terminal — log failure but don't fail the enable
+        if not _call_agent_hook(svc_id, "post_start"):
+            logger.warning("post_start hook failed for %s (non-fatal)", svc_id)
 
-    agent_ok = _call_agent("start", service_id)
-
-    logger.info("Enabled extension: %s", service_id)
+    logger.info("Enabled extension: %s (deps: %s)", service_id,
+                enabled_services[:-1] if len(enabled_services) > 1 else "none")
     return {
         "id": service_id,
         "action": "enabled",
+        "enabled_services": enabled_services,
         "restart_required": not agent_ok,
         "message": (
             "Extension enabled and started." if agent_ok

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -768,12 +768,15 @@ async def extension_logs(
         )
 
 
-@router.post("/api/extensions/{service_id}/install")
-def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
-    """Install an extension from the library."""
-    _validate_service_id(service_id)
-    _assert_not_core(service_id)
+def _install_from_library(service_id: str) -> None:
+    """Copy an extension from the library to USER_EXTENSIONS_DIR atomically.
 
+    Must be called inside _extensions_lock() by the caller. Performs the
+    library path check, size check, and atomic stage+rename. Does NOT call
+    hooks or start the container — that's the caller's responsibility.
+
+    Raises HTTPException on failure.
+    """
     # Verify library is accessible
     try:
         lib_available = EXTENSIONS_LIBRARY_DIR.is_dir()
@@ -796,16 +799,17 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
 
     dest = USER_EXTENSIONS_DIR / service_id
 
-    # Early check (non-authoritative, rechecked under lock)
+    # Re-check under lock to prevent double-install race
     if dest.exists():
         has_compose = (dest / "compose.yaml").exists()
         has_disabled = (dest / "compose.yaml.disabled").exists()
         if has_compose or has_disabled:
             raise HTTPException(
-                status_code=409, detail=f"Extension already installed: {service_id}",
+                status_code=409,
+                detail=f"Extension already installed: {service_id}",
             )
         # Broken directory (no compose file) — clean up before reinstall
-        logger.warning("Cleaning up broken extension directory: %s", dest)
+        logger.warning("Cleaning up broken extension directory under lock: %s", dest)
         shutil.rmtree(dest)
 
     # Size check
@@ -819,39 +823,49 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
                     detail="Extension exceeds maximum size of 50MB",
                 )
 
+    USER_EXTENSIONS_DIR.mkdir(parents=True, exist_ok=True)
+    tmpdir = tempfile.mkdtemp(dir=str(USER_EXTENSIONS_DIR.parent))
+    try:
+        staged = Path(tmpdir) / service_id
+        _copytree_safe(source, staged)
+        # Security scan the staged copy (prevents TOCTOU)
+        staged_compose = staged / "compose.yaml"
+        if staged_compose.exists():
+            _scan_compose_content(staged_compose, trusted=True)
+        os.rename(str(staged), str(dest))
+    finally:
+        if Path(tmpdir).exists():
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@router.post("/api/extensions/{service_id}/install")
+def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
+    """Install an extension from the library."""
+    _validate_service_id(service_id)
+    _assert_not_core(service_id)
+
+    dest = USER_EXTENSIONS_DIR / service_id
+
+    # Early check (non-authoritative, rechecked under lock in _install_from_library)
+    if dest.exists():
+        has_compose = (dest / "compose.yaml").exists()
+        has_disabled = (dest / "compose.yaml.disabled").exists()
+        if has_compose or has_disabled:
+            raise HTTPException(
+                status_code=409, detail=f"Extension already installed: {service_id}",
+            )
+        # Broken directory (no compose file) — clean up before reinstall
+        logger.warning("Cleaning up broken extension directory: %s", dest)
+        shutil.rmtree(dest)
+
     # NOTE: pre_install hook is deferred to a future version. On fresh library
     # installs, the extension directory doesn't exist yet, so the host agent
     # cannot resolve the hook script. The call site is intentionally omitted
     # until the install flow can read manifests from the library source.
 
-    # Atomic install via temp directory on same filesystem
+    # Atomic install via shared helper (used by templates too)
     with _extensions_lock():
-        # Re-check under lock to prevent double-install race
-        if dest.exists():
-            has_compose = (dest / "compose.yaml").exists()
-            has_disabled = (dest / "compose.yaml.disabled").exists()
-            if has_compose or has_disabled:
-                raise HTTPException(
-                    status_code=409,
-                    detail=f"Extension already installed: {service_id}",
-                )
-            # Broken directory (no compose file) — clean up before reinstall
-            logger.warning("Cleaning up broken extension directory under lock: %s", dest)
-            shutil.rmtree(dest)
-
-        USER_EXTENSIONS_DIR.mkdir(parents=True, exist_ok=True)
-        tmpdir = tempfile.mkdtemp(dir=str(USER_EXTENSIONS_DIR.parent))
-        try:
-            staged = Path(tmpdir) / service_id
-            _copytree_safe(source, staged)
-            # Security scan the staged copy (prevents TOCTOU)
-            staged_compose = staged / "compose.yaml"
-            if staged_compose.exists():
-                _scan_compose_content(staged_compose, trusted=True)
-            os.rename(str(staged), str(dest))
-        finally:
-            if Path(tmpdir).exists():
-                shutil.rmtree(tmpdir, ignore_errors=True)
+        _install_from_library(service_id)
 
     # Write initial progress file so status shows "installing" immediately
     # (before host agent starts processing — closes the race window)

--- a/dream-server/extensions/services/dashboard-api/routers/templates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/templates.py
@@ -1,0 +1,220 @@
+"""Service template endpoints."""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from config import EXTENSION_CATALOG, GPU_BACKEND, SERVICES, TEMPLATES, USER_EXTENSIONS_DIR
+from security import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+# Services defined in docker-compose.base.yml — always running, no compose toggle
+_BASE_COMPOSE_SERVICES = frozenset({"llama-server", "open-webui", "dashboard", "dashboard-api"})
+
+router = APIRouter(tags=["templates"])
+
+
+@router.get("/api/templates")
+async def list_templates(api_key: str = Depends(verify_api_key)):
+    """List all available service templates."""
+    return {"templates": TEMPLATES}
+
+
+@router.post("/api/templates/{template_id}/preview")
+async def preview_template(template_id: str, api_key: str = Depends(verify_api_key)):
+    """Preview what applying a template would change."""
+    template = next((t for t in TEMPLATES if t["id"] == template_id), None)
+    if not template:
+        raise HTTPException(status_code=404, detail=f"Template not found: {template_id}")
+
+    from helpers import get_cached_services, get_all_services
+    from routers.extensions import _compute_extension_status
+
+    service_list = get_cached_services()
+    if service_list is None:
+        service_list = await get_all_services()
+    services_by_id = {s.id: s for s in service_list}
+    catalog_by_id = {e["id"]: e for e in EXTENSION_CATALOG}
+
+    to_enable = []
+    already_enabled = []
+    incompatible = []
+    in_progress = []
+    has_errors = []
+    warnings = []
+
+    for svc_id in template.get("services", []):
+        svc_config = SERVICES.get(svc_id)
+        svc_status = services_by_id.get(svc_id)
+
+        # Core services are always running — treat as already enabled
+        if svc_id in _BASE_COMPOSE_SERVICES:
+            already_enabled.append(svc_id)
+            continue
+
+        # Compute rich extension status (installing / setting_up / error / enabled / …)
+        # by reusing the same logic the catalog endpoint uses, so template state
+        # stays consistent with what the UI shows on individual extension cards.
+        ext = catalog_by_id.get(svc_id)
+        ext_status = (
+            _compute_extension_status(ext, services_by_id) if ext else None
+        )
+
+        if ext_status == "error":
+            has_errors.append(svc_id)
+            continue
+        if ext_status in ("installing", "setting_up"):
+            in_progress.append(svc_id)
+            continue
+        if ext_status == "enabled" or (svc_status and svc_status.status == "healthy"):
+            already_enabled.append(svc_id)
+            continue
+
+        # Check GPU compatibility (from manifest data in SERVICES)
+        if svc_config:
+            gpu_backends = svc_config.get("gpu_backends", ["amd", "nvidia", "apple"])
+            if GPU_BACKEND != "apple" and GPU_BACKEND not in gpu_backends and "all" not in gpu_backends:
+                incompatible.append(svc_id)
+                warnings.append(f"{svc_id} gpu_backends {gpu_backends} - your system: {GPU_BACKEND}")
+                continue
+
+        to_enable.append(svc_id)
+
+    return {
+        "template": {"id": template["id"], "name": template["name"]},
+        "changes": {
+            "to_enable": to_enable,
+            "already_enabled": already_enabled,
+            "incompatible": incompatible,
+            "in_progress": in_progress,
+            "has_errors": has_errors,
+        },
+        "warnings": warnings,
+    }
+
+
+@router.post("/api/templates/{template_id}/apply")
+async def apply_template(template_id: str, api_key: str = Depends(verify_api_key)):
+    """Apply a template by enabling its listed services (additive only).
+
+    Uses the same dep-aware enable flow as enable_extension with
+    auto_enable_deps=True — transitive deps are resolved and activated
+    before each service.
+    """
+    template = next((t for t in TEMPLATES if t["id"] == template_id), None)
+    if not template:
+        raise HTTPException(status_code=404, detail=f"Template not found: {template_id}")
+
+    from helpers import get_cached_services, get_all_services
+    from routers.extensions import (
+        _activate_service, _extensions_lock, _call_agent, _call_agent_hook,
+        _get_missing_deps_transitive, _validate_service_id,
+        _install_from_library, _is_installable,
+    )
+
+    service_list = get_cached_services()
+    if service_list is None:
+        service_list = await get_all_services()
+    services_by_id = {s.id: s for s in service_list}
+
+    results = {}
+    enabled_services = []
+    library_installed: list[str] = []
+
+    for svc_id in template.get("services", []):
+        # Skip services already healthy
+        svc_status = services_by_id.get(svc_id)
+        if svc_status and svc_status.status == "healthy":
+            results[svc_id] = "already_enabled"
+            continue
+
+        # Skip core services (defined in docker-compose.base.yml, always running)
+        # These have no individual compose.yaml to toggle — they're always on.
+        if svc_id in _BASE_COMPOSE_SERVICES:
+            results[svc_id] = "core_service"
+            continue
+
+        try:
+            _validate_service_id(svc_id)
+
+            # Library extension not yet installed → copy from library first.
+            # _install_from_library produces a directory with compose.yaml
+            # already in place (not compose.yaml.disabled), so _activate_service
+            # will report "already_enabled" afterwards — we still want to start it.
+            if _is_installable(svc_id) and not (USER_EXTENSIONS_DIR / svc_id).is_dir():
+                try:
+                    with _extensions_lock():
+                        _install_from_library(svc_id)
+                    _call_agent_hook(svc_id, "post_install")
+                    library_installed.append(svc_id)
+                except HTTPException as exc:
+                    detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+                    logger.warning(
+                        "Template apply failed to install library extension %s: %s",
+                        svc_id, detail,
+                    )
+                    results[svc_id] = f"skipped: install failed: {detail}"
+                    continue
+
+            # Dep-aware enable: resolve transitive deps, activate leaves first.
+            # _activate_service checks both user-installed and built-in extension dirs.
+            missing_deps = _get_missing_deps_transitive(svc_id)
+
+            with _extensions_lock():
+                for dep in missing_deps:
+                    if dep in results:
+                        continue
+                    dep_result = _activate_service(dep)
+                    if dep_result.get("action") == "enabled":
+                        enabled_services.append(dep)
+                        results[dep] = "enabled_as_dependency"
+                result = _activate_service(svc_id)
+
+            action = result.get("action", "skipped")
+            if svc_id in library_installed:
+                results[svc_id] = "library_installed"
+            else:
+                results[svc_id] = action
+            # Always start via host agent unless already healthy
+            # "already_enabled" means compose file exists but container may not be running
+            if action in ("enabled", "already_enabled"):
+                enabled_services.append(svc_id)
+        except HTTPException as exc:
+            detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
+            logger.warning("Template apply skipped %s: %s", svc_id, detail)
+            results[svc_id] = f"skipped: {detail}"
+
+    # Start enabled services via agent (outside locks)
+    for svc_id in enabled_services:
+        # Host agent can only start user-installed extensions
+        user_ext_dir = USER_EXTENSIONS_DIR / svc_id
+        if user_ext_dir.is_dir():
+            _call_agent_hook(svc_id, "pre_start")
+            start_ok = _call_agent("start", svc_id)
+            if not start_ok:
+                # Preserve library_installed label — user-visible install succeeded,
+                # only the start call failed (e.g., stale .compose-flags cache).
+                if results.get(svc_id) != "library_installed":
+                    results[svc_id] = "enabled_but_start_failed"
+                else:
+                    logger.warning("Library-installed extension %s failed to start via agent", svc_id)
+            _call_agent_hook(svc_id, "post_start")
+        elif svc_id not in library_installed:
+            # Built-in extension: compose file toggled, needs stack restart
+            results[svc_id] = "enabled"
+
+    any_builtin = any(
+        not (USER_EXTENSIONS_DIR / svc_id).is_dir()
+        for svc_id in enabled_services
+    )
+    # Library installs add new services to the compose stack → restart needed
+    restart_required = any_builtin or bool(library_installed)
+
+    return {
+        "template_id": template_id,
+        "results": results,
+        "enabled_count": len(enabled_services),
+        "library_installed": library_installed,
+        "restart_required": restart_required,
+    }

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -572,7 +572,9 @@ class TestEnableExtension:
             headers=test_client.auth_headers,
         )
         assert resp.status_code == 400
-        assert "missing-dep" in resp.json()["detail"]
+        detail = resp.json()["detail"]
+        assert "missing-dep" in detail["missing_dependencies"]
+        assert detail["auto_enable_available"] is True
 
     def test_enable_core_service_403(self, test_client, monkeypatch, tmp_path):
         """403 when trying to enable a core service."""

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions_deps.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions_deps.py
@@ -1,0 +1,228 @@
+"""Tests for dependency enrichment and auto_enable_deps in extensions portal."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import yaml
+from models import ServiceStatus
+
+
+# --- Helpers ---
+
+
+def _make_catalog_ext(ext_id, name="Test", depends_on=None, gpu_backends=None):
+    return {
+        "id": ext_id,
+        "name": name,
+        "description": f"Description for {name}",
+        "category": "optional",
+        "gpu_backends": gpu_backends or ["nvidia", "amd", "apple"],
+        "compose_file": "compose.yaml",
+        "depends_on": depends_on or [],
+        "port": 8080,
+        "external_port_default": 8080,
+        "health_endpoint": "/health",
+        "env_vars": [],
+        "tags": [],
+        "features": [],
+    }
+
+
+def _make_service_status(sid, status="healthy"):
+    return ServiceStatus(
+        id=sid, name=sid, port=8080, external_port=8080, status=status,
+    )
+
+
+def _patch_deps_config(monkeypatch, catalog, services=None,
+                       gpu_backend="nvidia", tmp_path=None):
+    """Apply standard patches for dependency tests."""
+    monkeypatch.setattr("routers.extensions.EXTENSION_CATALOG", catalog)
+    monkeypatch.setattr("routers.extensions.SERVICES", services or {})
+    monkeypatch.setattr("routers.extensions.GPU_BACKEND", gpu_backend)
+    monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset({"llama-server"}))
+    lib_dir = (tmp_path / "lib") if tmp_path else Path("/tmp/nonexistent-lib")
+    user_dir = (tmp_path / "user") if tmp_path else Path("/tmp/nonexistent-user")
+    monkeypatch.setattr("routers.extensions.EXTENSIONS_LIBRARY_DIR", lib_dir)
+    monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+    monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                        tmp_path / "ext" if tmp_path else Path("/tmp/nonexistent-ext"))
+    monkeypatch.setattr("routers.extensions.DATA_DIR",
+                        str(tmp_path or "/tmp/nonexistent"))
+
+
+# --- Catalog dependency enrichment ---
+
+
+class TestCatalogDependencies:
+
+    def test_catalog_includes_depends_on(self, test_client, monkeypatch, tmp_path):
+        """Catalog returns depends_on for each extension."""
+        catalog = [_make_catalog_ext("svc-a", "A", depends_on=["svc-b"])]
+        _patch_deps_config(monkeypatch, catalog, tmp_path=tmp_path)
+
+        with patch("helpers.get_all_services", new_callable=AsyncMock,
+                   return_value=[]):
+            resp = test_client.get(
+                "/api/extensions/catalog",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        ext = resp.json()["extensions"][0]
+        assert ext["depends_on"] == ["svc-b"]
+
+    def test_catalog_dependents_computed(self, test_client, monkeypatch, tmp_path):
+        """Catalog computes reverse dependents."""
+        catalog = [
+            _make_catalog_ext("svc-a", "A", depends_on=["svc-b"]),
+            _make_catalog_ext("svc-b", "B"),
+        ]
+        _patch_deps_config(monkeypatch, catalog, tmp_path=tmp_path)
+
+        with patch("helpers.get_all_services", new_callable=AsyncMock,
+                   return_value=[]):
+            resp = test_client.get(
+                "/api/extensions/catalog",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        exts = {e["id"]: e for e in resp.json()["extensions"]}
+        assert exts["svc-b"]["dependents"] == ["svc-a"]
+        assert exts["svc-a"]["dependents"] == []
+
+    def test_catalog_dependency_status(self, test_client, monkeypatch, tmp_path):
+        """Catalog includes dependency_status for each dep."""
+        catalog = [
+            _make_catalog_ext("svc-a", "A", depends_on=["svc-b"]),
+            _make_catalog_ext("svc-b", "B"),
+        ]
+        services = {"svc-b": {"host": "localhost", "port": 8080, "name": "B"}}
+        _patch_deps_config(monkeypatch, catalog, services, tmp_path=tmp_path)
+
+        mock_svc = _make_service_status("svc-b", "healthy")
+        with patch("helpers.get_all_services", new_callable=AsyncMock,
+                   return_value=[mock_svc]):
+            resp = test_client.get(
+                "/api/extensions/catalog",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        ext_a = next(e for e in resp.json()["extensions"] if e["id"] == "svc-a")
+        assert ext_a["dependency_status"]["svc-b"] == "enabled"
+
+
+# --- Auto-enable deps ---
+
+
+class TestAutoEnableDeps:
+
+    def test_enable_missing_deps_returns_list(self, test_client, monkeypatch, tmp_path):
+        """Enable with missing deps and auto_enable_deps=false returns 400 with dep list."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "svc-a"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml.disabled").write_text("services: {}")
+        (ext_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "svc-a",
+                "name": "A",
+                "port": 8080,
+                "health": "/health",
+                "depends_on": ["svc-b"],
+            },
+        }))
+
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                            tmp_path / "ext")
+        monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset())
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+
+        resp = test_client.post(
+            "/api/extensions/svc-a/enable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 400
+        body = resp.json()["detail"]
+        assert "svc-b" in body["missing_dependencies"]
+        assert body["auto_enable_available"] is True
+
+    def test_enable_auto_deps(self, test_client, monkeypatch, tmp_path):
+        """Enable with auto_enable_deps=true enables deps first."""
+        user_dir = tmp_path / "user"
+        # Create dep extension
+        dep_dir = user_dir / "svc-b"
+        dep_dir.mkdir(parents=True)
+        (dep_dir / "compose.yaml.disabled").write_text("services: {}")
+        (dep_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {"id": "svc-b", "name": "B", "port": 8081, "health": "/health"},
+        }))
+
+        # Create target extension
+        ext_dir = user_dir / "svc-a"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml.disabled").write_text("services: {}")
+        (ext_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "svc-a", "name": "A", "port": 8080, "health": "/health",
+                "depends_on": ["svc-b"],
+            },
+        }))
+
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                            tmp_path / "ext")
+        monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset())
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+
+        with patch("routers.extensions._call_agent", return_value=True):
+            resp = test_client.post(
+                "/api/extensions/svc-a/enable?auto_enable_deps=true",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert "svc-b" in body["enabled_services"]
+        assert "svc-a" in body["enabled_services"]
+        # Both compose files should be renamed
+        assert (dep_dir / "compose.yaml").exists()
+        assert (ext_dir / "compose.yaml").exists()
+
+    def test_enable_auto_deps_circular_guard(self, test_client, monkeypatch, tmp_path):
+        """Circular deps are caught and return 400."""
+        user_dir = tmp_path / "user"
+
+        for sid, deps in [("svc-a", ["svc-b"]), ("svc-b", ["svc-a"])]:
+            d = user_dir / sid
+            d.mkdir(parents=True, exist_ok=True)
+            (d / "compose.yaml.disabled").write_text("services: {}")
+            (d / "manifest.yaml").write_text(yaml.dump({
+                "schema_version": "dream.services.v1",
+                "service": {
+                    "id": sid, "name": sid, "port": 8080, "health": "/health",
+                    "depends_on": deps,
+                },
+            }))
+
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
+                            tmp_path / "ext")
+        monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset())
+        monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+
+        with patch("routers.extensions._call_agent", return_value=True):
+            resp = test_client.post(
+                "/api/extensions/svc-a/enable?auto_enable_deps=true",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 400
+        assert "Circular" in resp.json().get("detail", "")

--- a/dream-server/extensions/services/dashboard-api/tests/test_hooks.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_hooks.py
@@ -1,0 +1,231 @@
+"""Tests for lifecycle hook resolution in dream-host-agent.py."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+# Import the host agent module from bin/ using importlib.
+_agent_path = Path(__file__).resolve().parents[4] / "bin" / "dream-host-agent.py"
+_spec = importlib.util.spec_from_file_location("dream_host_agent", _agent_path)
+_mod = importlib.util.module_from_spec(_spec)
+sys.modules["dream_host_agent"] = _mod
+_spec.loader.exec_module(_mod)
+
+_resolve_hook = _mod._resolve_hook
+_validate_hook_path = _mod._validate_hook_path
+_read_manifest = _mod._read_manifest
+_check_bash_version = _mod._check_bash_version
+
+
+# --- _resolve_hook ---
+
+
+class TestResolveHook:
+
+    def test_resolve_hook_from_hooks_map(self, tmp_path):
+        """Hook resolved from hooks map in manifest."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        hook_script = ext_dir / "hooks" / "pre_start.sh"
+        hook_script.parent.mkdir()
+        hook_script.write_text("#!/bin/bash\necho pre_start")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "hooks": {
+                    "pre_start": "hooks/pre_start.sh",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is not None
+        assert result.name == "pre_start.sh"
+
+    def test_resolve_hook_fallback_to_setup_hook(self, tmp_path):
+        """post_install falls back to setup_hook when hooks map is absent."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        setup_script = ext_dir / "setup.sh"
+        setup_script.write_text("#!/bin/bash\necho setup")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "setup_hook": "setup.sh",
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "post_install")
+        assert result is not None
+        assert result.name == "setup.sh"
+
+    def test_resolve_hook_no_fallback_for_non_post_install(self, tmp_path):
+        """setup_hook fallback only applies to post_install, not other hooks."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        setup_script = ext_dir / "setup.sh"
+        setup_script.write_text("#!/bin/bash\necho setup")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "setup_hook": "setup.sh",
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+    def test_resolve_hook_hooks_map_wins_over_setup_hook(self, tmp_path):
+        """hooks.post_install takes precedence over setup_hook."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+        (ext_dir / "setup.sh").write_text("#!/bin/bash\necho old")
+        (ext_dir / "new-setup.sh").write_text("#!/bin/bash\necho new")
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "setup_hook": "setup.sh",
+                "hooks": {
+                    "post_install": "new-setup.sh",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "post_install")
+        assert result is not None
+        assert result.name == "new-setup.sh"
+
+    def test_resolve_hook_path_traversal_blocked(self, tmp_path):
+        """Hook path that escapes extension directory is rejected."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "hooks": {
+                    "pre_start": "../../../etc/passwd",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+    def test_resolve_hook_missing_file_returns_none(self, tmp_path):
+        """Hook script that doesn't exist returns None."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+
+        manifest = {
+            "schema_version": "dream.services.v1",
+            "service": {
+                "id": "my-ext",
+                "name": "My Extension",
+                "port": 8080,
+                "health": "/health",
+                "hooks": {
+                    "pre_start": "nonexistent.sh",
+                },
+            },
+        }
+        (ext_dir / "manifest.yaml").write_text(yaml.dump(manifest))
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+    def test_resolve_hook_no_manifest(self, tmp_path):
+        """Extension directory without manifest returns None."""
+        ext_dir = tmp_path / "my-ext"
+        ext_dir.mkdir()
+
+        result = _resolve_hook(ext_dir, "pre_start")
+        assert result is None
+
+
+# --- _check_bash_version ---
+
+
+class TestCheckBashVersion:
+
+    def test_non_darwin_always_ok(self):
+        """Non-Darwin platforms skip bash check."""
+        with patch("dream_host_agent.platform.system", return_value="Linux"):
+            ok, msg = _check_bash_version()
+        assert ok is True
+        assert msg == ""
+
+    def test_darwin_with_modern_bash(self):
+        """Darwin with bash 5.x passes."""
+        from unittest.mock import MagicMock
+        mock_result = MagicMock()
+        mock_result.stdout = "GNU bash, version 5.2.15(1)-release"
+        with patch("dream_host_agent.platform.system", return_value="Darwin"), \
+             patch("dream_host_agent.subprocess.run", return_value=mock_result):
+            ok, msg = _check_bash_version()
+        assert ok is True
+
+    def test_darwin_with_old_bash(self):
+        """Darwin with bash 3.2 fails."""
+        from unittest.mock import MagicMock
+        mock_result = MagicMock()
+        mock_result.stdout = "GNU bash, version 3.2.57(1)-release"
+        with patch("dream_host_agent.platform.system", return_value="Darwin"), \
+             patch("dream_host_agent.subprocess.run", return_value=mock_result):
+            ok, msg = _check_bash_version()
+        assert ok is False
+        assert "too old" in msg
+
+
+# --- Hook environment allowlist ---
+
+
+class TestHookEnvAllowlist:
+
+    def test_hook_env_does_not_leak(self):
+        """Verify the hook env construction pattern only includes allowlisted vars."""
+        # This is a structural test — verifying the pattern matches spec
+        import inspect
+        source = inspect.getsource(_mod.AgentHandler._execute_hook)
+        # The hook_env dict should NOT contain os.environ spread
+        assert "**os.environ" not in source
+        assert "os.environ.copy()" not in source
+        # Should contain the allowlisted keys
+        assert "SERVICE_ID" in source
+        assert "SERVICE_PORT" in source
+        assert "SERVICE_DATA_DIR" in source
+        assert "DREAM_VERSION" in source
+        assert "GPU_BACKEND" in source
+        assert "HOOK_NAME" in source

--- a/dream-server/extensions/services/dashboard-api/tests/test_templates.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_templates.py
@@ -1,0 +1,643 @@
+"""Tests for service template loading, preview, and apply."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+
+# --- Template loading tests ---
+
+
+def test_load_templates_valid(tmp_path):
+    """Valid template YAML files are loaded correctly."""
+    (tmp_path / "test.yaml").write_text(yaml.dump({
+        "schema_version": "dream.templates.v1",
+        "template": {
+            "id": "test-tmpl",
+            "name": "Test Template",
+            "services": ["llama-server", "open-webui"],
+        },
+    }))
+
+    with patch("config.TEMPLATES_DIR", tmp_path):
+        # Re-import to trigger load
+        from config import load_templates
+        templates = load_templates()
+
+    assert len(templates) == 1
+    assert templates[0]["id"] == "test-tmpl"
+    assert templates[0]["services"] == ["llama-server", "open-webui"]
+
+
+def test_load_templates_invalid_schema(tmp_path):
+    """Template with wrong schema_version is skipped."""
+    (tmp_path / "bad.yaml").write_text(yaml.dump({
+        "schema_version": "wrong.version",
+        "template": {
+            "id": "bad-tmpl",
+            "name": "Bad",
+            "services": ["foo"],
+        },
+    }))
+    (tmp_path / "good.yaml").write_text(yaml.dump({
+        "schema_version": "dream.templates.v1",
+        "template": {
+            "id": "good-tmpl",
+            "name": "Good",
+            "services": ["llama-server"],
+        },
+    }))
+
+    with patch("config.TEMPLATES_DIR", tmp_path):
+        from config import load_templates
+        templates = load_templates()
+
+    assert len(templates) == 1
+    assert templates[0]["id"] == "good-tmpl"
+
+
+def test_load_templates_missing_dir(tmp_path):
+    """Missing templates directory returns empty list."""
+    missing = tmp_path / "nonexistent"
+
+    with patch("config.TEMPLATES_DIR", missing):
+        from config import load_templates
+        templates = load_templates()
+
+    assert templates == []
+
+
+def test_load_templates_malformed_yaml(tmp_path):
+    """Malformed YAML is skipped with warning."""
+    (tmp_path / "broken.yaml").write_text(":::invalid yaml{{{}}")
+
+    with patch("config.TEMPLATES_DIR", tmp_path):
+        from config import load_templates
+        templates = load_templates()
+
+    assert templates == []
+
+
+# --- Preview tests ---
+
+
+@pytest.mark.asyncio
+async def test_template_preview_diff():
+    """Preview shows correct to_enable, already_enabled, incompatible."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["llama-server", "open-webui", "comfyui"],
+    }]
+
+    mock_services_config = {
+        "llama-server": {"port": 8080, "gpu_backends": ["amd", "nvidia", "apple"]},
+        "open-webui": {"port": 3000, "gpu_backends": ["amd", "nvidia", "apple"]},
+        "comfyui": {"port": 8188, "gpu_backends": ["nvidia", "amd"]},
+    }
+
+    class MockSvc:
+        def __init__(self, id_, status):
+            self.id = id_
+            self.status = status
+
+    mock_svc_list = [
+        MockSvc("llama-server", "healthy"),
+        MockSvc("open-webui", "unhealthy"),
+    ]
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates.SERVICES", mock_services_config),
+        patch("routers.templates.GPU_BACKEND", "apple"),
+        patch("helpers.get_cached_services", return_value=mock_svc_list),
+    ):
+        from routers.templates import preview_template
+        result = await preview_template("test-tmpl", api_key="test")
+
+    assert result["template"]["id"] == "test-tmpl"
+    # Both are base compose services → always already_enabled
+    assert "llama-server" in result["changes"]["already_enabled"]
+    assert "open-webui" in result["changes"]["already_enabled"]
+    # Apple backend — all Docker services compatible, so comfyui should be in to_enable
+    assert "comfyui" in result["changes"]["to_enable"]
+
+
+@pytest.mark.asyncio
+async def test_template_preview_in_progress_bucket():
+    """Services in installing/setting_up state land in `in_progress`, not `to_enable`."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["svc-installing", "svc-setting-up", "svc-fresh"],
+    }]
+    mock_catalog = [
+        {"id": "svc-installing", "gpu_backends": ["all"]},
+        {"id": "svc-setting-up", "gpu_backends": ["all"]},
+        {"id": "svc-fresh", "gpu_backends": ["all"]},
+    ]
+    mock_services_config = {
+        "svc-installing": {"gpu_backends": ["all"]},
+        "svc-setting-up": {"gpu_backends": ["all"]},
+        "svc-fresh": {"gpu_backends": ["all"]},
+    }
+
+    def fake_compute_status(ext, _services_by_id):
+        return {
+            "svc-installing": "installing",
+            "svc-setting-up": "setting_up",
+            "svc-fresh": "not_installed",
+        }[ext["id"]]
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates.EXTENSION_CATALOG", mock_catalog),
+        patch("routers.templates.SERVICES", mock_services_config),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.GPU_BACKEND", "apple"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._compute_extension_status", side_effect=fake_compute_status),
+    ):
+        from routers.templates import preview_template
+        result = await preview_template("test-tmpl", api_key="test")
+
+    changes = result["changes"]
+    assert "svc-installing" in changes["in_progress"]
+    assert "svc-setting-up" in changes["in_progress"]
+    assert "svc-fresh" in changes["to_enable"]
+    assert "svc-installing" not in changes["to_enable"]
+    assert changes["has_errors"] == []
+
+
+@pytest.mark.asyncio
+async def test_template_preview_has_errors_bucket():
+    """Services in error state land in `has_errors`, blocking to_enable classification."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["svc-error", "svc-ok"],
+    }]
+    mock_catalog = [
+        {"id": "svc-error", "gpu_backends": ["all"]},
+        {"id": "svc-ok", "gpu_backends": ["all"]},
+    ]
+    mock_services_config = {
+        "svc-error": {"gpu_backends": ["all"]},
+        "svc-ok": {"gpu_backends": ["all"]},
+    }
+
+    def fake_compute_status(ext, _services_by_id):
+        return {"svc-error": "error", "svc-ok": "not_installed"}[ext["id"]]
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates.EXTENSION_CATALOG", mock_catalog),
+        patch("routers.templates.SERVICES", mock_services_config),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.GPU_BACKEND", "apple"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._compute_extension_status", side_effect=fake_compute_status),
+    ):
+        from routers.templates import preview_template
+        result = await preview_template("test-tmpl", api_key="test")
+
+    changes = result["changes"]
+    assert "svc-error" in changes["has_errors"]
+    assert "svc-ok" in changes["to_enable"]
+    assert changes["in_progress"] == []
+
+
+@pytest.mark.asyncio
+async def test_template_preview_not_found():
+    """Preview returns 404 for unknown template."""
+    with patch("routers.templates.TEMPLATES", []):
+        from fastapi import HTTPException
+        from routers.templates import preview_template
+        with pytest.raises(HTTPException) as exc_info:
+            await preview_template("nonexistent", api_key="test")
+        assert exc_info.value.status_code == 404
+
+
+# --- Apply tests ---
+
+
+@pytest.mark.asyncio
+async def test_template_apply_additive(tmp_path):
+    """Apply enables services that aren't already running."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["svc-a", "svc-b"],
+    }]
+
+    class MockSvc:
+        def __init__(self, id_, status):
+            self.id = id_
+            self.status = status
+
+    mock_svc_list = [
+        MockSvc("svc-a", "healthy"),
+    ]
+
+    mock_activate = MagicMock(return_value={"id": "svc-b", "action": "enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=mock_svc_list),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        # Create user ext dir so host agent path resolves for svc-b
+        user_ext = tmp_path / "user-ext" / "svc-b"
+        user_ext.mkdir(parents=True)
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert result["template_id"] == "test-tmpl"
+    assert result["results"]["svc-a"] == "already_enabled"
+    assert result["results"]["svc-b"] == "enabled"
+    assert result["enabled_count"] == 1
+    assert "restart_required" in result
+
+
+@pytest.mark.asyncio
+async def test_template_apply_activates_deps(tmp_path):
+    """Apply activates transitive deps before the target service."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["svc-b"],
+    }]
+
+    class MockSvc:
+        def __init__(self, id_, status):
+            self.id = id_
+            self.status = status
+
+    mock_activate = MagicMock(side_effect=lambda svc_id: {"id": svc_id, "action": "enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    # Create user ext dirs so host agent path resolves
+    user_ext = tmp_path / "user-ext"
+    (user_ext / "dep-svc").mkdir(parents=True)
+    (user_ext / "svc-b").mkdir(parents=True)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=["dep-svc"]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    # _activate_service must be called for dep-svc AND svc-b
+    activated_ids = [call.args[0] for call in mock_activate.call_args_list]
+    assert "dep-svc" in activated_ids
+    assert "svc-b" in activated_ids
+    assert result["results"]["dep-svc"] == "enabled_as_dependency"
+    assert result["results"]["svc-b"] == "enabled"
+    assert result["enabled_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_template_apply_incompatible_skipped():
+    """Apply skips services that fail activation (e.g., not installed)."""
+    from fastapi import HTTPException
+
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["missing-svc"],
+    }]
+
+    class MockSvc:
+        def __init__(self, id_, status):
+            self.id = id_
+            self.status = status
+
+    def mock_activate(svc_id):
+        raise HTTPException(status_code=404, detail=f"Extension not installed: {svc_id}")
+
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert result["enabled_count"] == 0
+    assert "skipped" in result["results"]["missing-svc"]
+
+
+@pytest.mark.asyncio
+async def test_template_apply_builtin_extension(tmp_path):
+    """Apply with a built-in extension skips host agent start and sets restart_required."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["builtin-svc"],
+    }]
+
+    class MockSvc:
+        def __init__(self, id_, status):
+            self.id = id_
+            self.status = status
+
+    mock_activate = MagicMock(return_value={"id": "builtin-svc", "action": "enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    # user-ext dir exists but does NOT contain builtin-svc → built-in path
+    user_ext = tmp_path / "user-ext"
+    user_ext.mkdir()
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert result["results"]["builtin-svc"] == "enabled"
+    assert result["restart_required"] is True
+    assert result["enabled_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_template_apply_auto_installs_library_extension(tmp_path):
+    """Apply copies a library extension into USER_EXTENSIONS_DIR before activating it."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["lib-svc"],
+    }]
+
+    user_ext = tmp_path / "user-ext"
+    user_ext.mkdir()
+
+    install_calls: list[str] = []
+
+    def mock_install(svc_id):
+        # Simulate the library install: create the dir so the host-agent start branch runs
+        (user_ext / svc_id).mkdir(parents=True, exist_ok=True)
+        install_calls.append(svc_id)
+
+    # After install, _activate_service sees compose.yaml is already in place
+    mock_activate = MagicMock(return_value={"id": "lib-svc", "action": "already_enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+        patch("routers.extensions._is_installable", return_value=True),
+        patch("routers.extensions._install_from_library", side_effect=mock_install),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert install_calls == ["lib-svc"]
+    assert result["results"]["lib-svc"] == "library_installed"
+    assert result["library_installed"] == ["lib-svc"]
+    # Library install → compose stack grew → restart required
+    assert result["restart_required"] is True
+    assert result["enabled_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_template_apply_library_install_failure_skips_gracefully(tmp_path):
+    """When _install_from_library raises, the service is skipped with a clear reason."""
+    from fastapi import HTTPException
+
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["lib-svc"],
+    }]
+
+    user_ext = tmp_path / "user-ext"
+    user_ext.mkdir()
+
+    def mock_install(svc_id):
+        raise HTTPException(status_code=503, detail="Extensions library is unavailable")
+
+    mock_activate = MagicMock(return_value={"id": "lib-svc", "action": "enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+        patch("routers.extensions._is_installable", return_value=True),
+        patch("routers.extensions._install_from_library", side_effect=mock_install),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert "skipped" in result["results"]["lib-svc"]
+    assert "install failed" in result["results"]["lib-svc"]
+    assert result["library_installed"] == []
+    assert result["enabled_count"] == 0
+    # _activate_service must NOT have been called after the install failed
+    mock_activate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_template_apply_library_already_installed_skips_reinstall(tmp_path):
+    """If the library extension is already in USER_EXTENSIONS_DIR, _install_from_library is NOT called."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["lib-svc"],
+    }]
+
+    user_ext = tmp_path / "user-ext"
+    (user_ext / "lib-svc").mkdir(parents=True)  # Already installed
+
+    mock_install = MagicMock()
+    mock_activate = MagicMock(return_value={"id": "lib-svc", "action": "enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+        patch("routers.extensions._is_installable", return_value=True),
+        patch("routers.extensions._install_from_library", mock_install),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_install.assert_not_called()
+    assert result["library_installed"] == []
+    assert result["results"]["lib-svc"] == "enabled"
+    assert result["enabled_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_template_apply_mixed_builtin_and_library(tmp_path):
+    """Template with both built-in and library extensions handles both correctly."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["builtin-svc", "lib-svc"],
+    }]
+
+    user_ext = tmp_path / "user-ext"
+    user_ext.mkdir()
+
+    installed: list[str] = []
+
+    def mock_install(svc_id):
+        (user_ext / svc_id).mkdir(parents=True, exist_ok=True)
+        installed.append(svc_id)
+
+    def mock_is_installable(svc_id):
+        return svc_id == "lib-svc"
+
+    def mock_activate(svc_id):
+        if svc_id == "lib-svc":
+            return {"id": svc_id, "action": "already_enabled"}
+        return {"id": svc_id, "action": "enabled"}
+
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", side_effect=mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+        patch("routers.extensions._is_installable", side_effect=mock_is_installable),
+        patch("routers.extensions._install_from_library", side_effect=mock_install),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    # lib-svc was installed, builtin-svc was not
+    assert installed == ["lib-svc"]
+    assert result["library_installed"] == ["lib-svc"]
+    # Built-in extension: compose file toggled → message set to "enabled" in post loop
+    assert result["results"]["builtin-svc"] == "enabled"
+    # Library extension: marked as library_installed
+    assert result["results"]["lib-svc"] == "library_installed"
+    # Both count as enabled
+    assert result["enabled_count"] == 2
+    # Either the built-in toggle or the library install forces a restart
+    assert result["restart_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_template_apply_already_enabled_still_starts(tmp_path):
+    """Service with action 'already_enabled' from _activate_service still gets started."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["svc-a"],
+    }]
+
+    class MockSvc:
+        def __init__(self, id_, status):
+            self.id = id_
+            self.status = status
+
+    # _activate_service returns already_enabled (compose.yaml exists but container not running)
+    mock_activate = MagicMock(return_value={"id": "svc-a", "action": "already_enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+    mock_agent = MagicMock(return_value=True)
+
+    user_ext = tmp_path / "user-ext"
+    (user_ext / "svc-a").mkdir(parents=True)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        # svc-a is NOT healthy — so it won't be skipped by the healthy check
+        patch("helpers.get_cached_services", return_value=[MockSvc("svc-a", "unhealthy")]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", mock_agent),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    # _call_agent should have been called for svc-a (start attempt)
+    mock_agent.assert_called()
+    assert result["enabled_count"] == 1

--- a/dream-server/extensions/services/dashboard/src/components/DependencyBadges.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/DependencyBadges.jsx
@@ -1,0 +1,106 @@
+import { AlertTriangle } from 'lucide-react'
+
+const STATUS_DOTS = {
+  enabled: 'bg-green-500',
+  disabled: 'bg-theme-border',
+  not_installed: 'bg-theme-border',
+  incompatible: 'bg-orange-500',
+  unknown: 'bg-theme-border',
+}
+
+/**
+ * DependencyBadges — renders "Requires: X, Y" with colored status dots.
+ * Place below the card description in ExtensionCard.
+ */
+export function DependencyBadges({ dependsOn, dependencyStatus }) {
+  if (!dependsOn || dependsOn.length === 0) return null
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+      <span className="text-[10px] text-theme-text-muted">Requires:</span>
+      {dependsOn.map(dep => {
+        const status = dependencyStatus?.[dep] || 'unknown'
+        const dotColor = STATUS_DOTS[status] || STATUS_DOTS.unknown
+        return (
+          <span
+            key={dep}
+            className="flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-theme-card/80 text-theme-text-muted"
+            title={`${dep}: ${status}`}
+          >
+            <span className={`w-1.5 h-1.5 rounded-full ${dotColor}`} />
+            {dep}
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * DependencyConfirmDialog — modal for auto-enable confirmation.
+ * Shows when enabling a service that has missing dependencies.
+ */
+export function DependencyConfirmDialog({ ext, missingDeps, onConfirm, onCancel }) {
+  if (!ext || !missingDeps || missingDeps.length === 0) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onCancel}>
+      <div
+        className="bg-theme-card border border-theme-border rounded-xl p-6 max-w-md mx-4"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Enable dependencies"
+      >
+        <h3 className="text-lg font-semibold text-theme-text mb-2">
+          Enable Dependencies
+        </h3>
+        <p className="text-sm text-theme-text-muted mb-3">
+          Enabling <span className="text-theme-text font-medium">{ext.name}</span> will also enable:
+        </p>
+        <div className="flex flex-wrap gap-2 mb-4">
+          {missingDeps.map(dep => (
+            <span
+              key={dep}
+              className="text-xs px-2 py-1 rounded bg-theme-accent/10 text-theme-accent-light border border-theme-accent/20"
+            >
+              {dep}
+            </span>
+          ))}
+        </div>
+        <div className="flex justify-end gap-3">
+          <button
+            onClick={onCancel}
+            autoFocus
+            className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-4 py-2 text-sm rounded-lg bg-theme-accent/20 text-theme-accent-light hover:bg-theme-accent/30 transition-colors"
+          >
+            Enable All
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * DisableDependentWarning — orange warning banner shown when disabling
+ * a service that has active dependents.
+ */
+export function DisableDependentWarning({ dependents }) {
+  if (!dependents || dependents.length === 0) return null
+
+  return (
+    <div className="flex items-start gap-2 mt-3 p-2.5 rounded-lg bg-orange-500/10 border border-orange-500/20">
+      <AlertTriangle size={14} className="text-orange-400 mt-0.5 shrink-0" />
+      <p className="text-xs text-orange-300">
+        Disabling this may break: {dependents.join(', ')}
+      </p>
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
-import { CheckCircle, Circle, ChevronRight, ChevronLeft, Mic, User, Settings, Play, Shield } from 'lucide-react'
+import { CheckCircle, Circle, ChevronRight, ChevronLeft, Mic, User, Settings, Play, Shield, Layers } from 'lucide-react'
 import { PreFlightChecks } from './PreFlightChecks'
+import { TemplatePicker } from './TemplatePicker'
 
 export default function SetupWizard({ onComplete }) {
   const [step, setStep] = useState(1)
@@ -12,7 +13,15 @@ export default function SetupWizard({ onComplete }) {
   })
   const [testStatus, setTestStatus] = useState({ running: false, output: [], done: false, success: false })
   const [preflightIssues, setPreflightIssues] = useState([])
-  const totalSteps = 5
+  const [templates, setTemplates] = useState([])
+  const totalSteps = 6
+
+  useEffect(() => {
+    fetch('/api/templates')
+      .then(res => res.ok ? res.json() : { templates: [] })
+      .then(data => setTemplates(data.templates || []))
+      .catch(() => {})
+  }, [])
 
   const voices = [
     { id: 'af_heart', name: 'Heart', desc: 'Warm, friendly female' },
@@ -66,7 +75,7 @@ export default function SetupWizard({ onComplete }) {
         <div className="flex-1 flex flex-col justify-center p-8">
           {/* Step Indicator */}
           <div className="flex items-center justify-center gap-2 mb-8">
-            {[1, 2, 3, 4, 5].map(i => (
+            {[1, 2, 3, 4, 5, 6].map(i => (
               <div key={i} className="flex items-center">
                 {i < step ? (
                   <CheckCircle className="w-6 h-6 text-green-500" />
@@ -75,7 +84,7 @@ export default function SetupWizard({ onComplete }) {
                 ) : (
                   <Circle className="w-6 h-6 text-theme-text-muted" />
                 )}
-                {i < 5 && <div className={`w-8 h-0.5 mx-1 ${i < step ? 'bg-green-500' : 'bg-theme-border'}`} />}
+                {i < 6 && <div className={`w-8 h-0.5 mx-1 ${i < step ? 'bg-green-500' : 'bg-theme-border'}`} />}
               </div>
             ))}
           </div>
@@ -97,8 +106,26 @@ export default function SetupWizard({ onComplete }) {
             </div>
           )}
 
-          {/* Step 2: Welcome */}
+          {/* Step 2: Templates (optional) */}
           {step === 2 && (
+            <div className="text-center max-w-2xl mx-auto">
+              <div className="w-20 h-20 bg-theme-accent/20 rounded-2xl flex items-center justify-center mx-auto mb-6">
+                <Layers className="w-10 h-10 text-theme-accent" />
+              </div>
+              <h2 className="text-3xl font-bold text-theme-text mb-4">Choose a Template</h2>
+              <p className="text-theme-text-secondary mb-8">
+                Pick a pre-configured set of services to get started quickly, or skip to customize later.
+              </p>
+              {templates.length > 0 ? (
+                <TemplatePicker templates={templates} compact />
+              ) : (
+                <p className="text-sm text-theme-text-muted">No templates available.</p>
+              )}
+            </div>
+          )}
+
+          {/* Step 3: Welcome */}
+          {step === 3 && (
             <div className="text-center max-w-lg mx-auto">
               <div className="w-20 h-20 bg-theme-accent/20 rounded-2xl flex items-center justify-center mx-auto mb-6">
                 <Settings className="w-10 h-10 text-theme-accent" />
@@ -125,8 +152,8 @@ export default function SetupWizard({ onComplete }) {
             </div>
           )}
 
-          {/* Step 3: Name */}
-          {step === 3 && (
+          {/* Step 4: Name */}
+          {step === 4 && (
             <div className="text-center max-w-md mx-auto">
               <div className="w-20 h-20 bg-purple-500/20 rounded-2xl flex items-center justify-center mx-auto mb-6">
                 <User className="w-10 h-10 text-purple-400" />
@@ -146,8 +173,8 @@ export default function SetupWizard({ onComplete }) {
             </div>
           )}
 
-          {/* Step 4: Voice */}
-          {step === 4 && (
+          {/* Step 5: Voice */}
+          {step === 5 && (
             <div className="text-center max-w-lg mx-auto">
               <div className="w-20 h-20 bg-pink-500/20 rounded-2xl flex items-center justify-center mx-auto mb-6">
                 <Mic className="w-10 h-10 text-pink-400" />
@@ -182,8 +209,8 @@ export default function SetupWizard({ onComplete }) {
             </div>
           )}
 
-          {/* Step 5: Diagnostics */}
-          {step === 5 && (
+          {/* Step 6: Diagnostics */}
+          {step === 6 && (
             <div className="text-center max-w-2xl mx-auto">
               <div className="w-20 h-20 bg-green-500/20 rounded-2xl flex items-center justify-center mx-auto mb-6">
                 <Play className="w-10 h-10 text-green-400" />
@@ -238,7 +265,7 @@ export default function SetupWizard({ onComplete }) {
             {step < totalSteps ? (
               <button
                 onClick={() => setStep(s => s + 1)}
-                disabled={step === 3 && !config.userName.trim()}
+                disabled={step === 4 && !config.userName.trim()}
                 className="flex items-center gap-2 px-6 py-2 bg-theme-accent hover:bg-theme-accent-hover disabled:bg-zinc-700 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
               >
                 Next

--- a/dream-server/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -1,0 +1,304 @@
+import { useState } from 'react'
+import {
+  MessageSquare, Image, Code, Shield, Layers, Package,
+  Loader2, X, Check, AlertTriangle, HardDrive,
+} from 'lucide-react'
+
+const ICON_MAP = { MessageSquare, Image, Code, Shield, Layers, Package }
+
+const fetchJson = async (url, options = {}) => {
+  const c = new AbortController()
+  const t = setTimeout(() => c.abort(), options.timeout || 30000)
+  try {
+    return await fetch(url, { ...options, signal: c.signal })
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+/**
+ * TemplatePicker — card grid of templates. Click shows preview.
+ *
+ * Templates carry a `_status` field set by the parent: 'available',
+ * 'in_progress', or 'has_errors'. ('applied' is filtered upstream.) The
+ * card renders differently per state and is only clickable in 'available'.
+ */
+export function TemplatePicker({ templates, onApplied, compact = false }) {
+  const [preview, setPreview] = useState(null)
+
+  if (!templates || templates.length === 0) return null
+
+  return (
+    <>
+      <div className={`grid gap-3 ${compact ? 'grid-cols-1 sm:grid-cols-2' : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'}`}>
+        {templates.map(tmpl => {
+          const Icon = ICON_MAP[tmpl.icon] || Package
+          const status = tmpl._status || 'available'
+          const inProgress = status === 'in_progress'
+          const hasErrors = status === 'has_errors'
+          const disabled = inProgress || hasErrors
+
+          const cardBase = 'text-left rounded-xl p-4 transition-all group border'
+          const cardByStatus = inProgress
+            ? 'bg-theme-card border-blue-500/30 cursor-not-allowed opacity-80'
+            : hasErrors
+            ? 'bg-red-500/5 border-red-500/30 cursor-not-allowed'
+            : 'bg-theme-card border-theme-border hover:border-theme-accent/40 hover:bg-theme-surface-hover'
+
+          return (
+            <button
+              key={tmpl.id}
+              onClick={() => !disabled && setPreview(tmpl)}
+              disabled={disabled}
+              aria-disabled={disabled}
+              className={`${cardBase} ${cardByStatus}`}
+            >
+              <div className="flex items-center gap-3 mb-2">
+                <div className={`p-2 rounded-lg ${hasErrors ? 'bg-red-500/10' : 'bg-theme-accent/10 group-hover:bg-theme-accent/20'} transition-colors`}>
+                  {inProgress
+                    ? <Loader2 size={18} className="animate-spin text-blue-400" />
+                    : hasErrors
+                    ? <AlertTriangle size={18} className="text-red-400" />
+                    : <Icon size={18} className="text-theme-accent-light" />}
+                </div>
+                <div>
+                  <h4 className="text-sm font-semibold text-theme-text">{tmpl.name}</h4>
+                  {inProgress && (
+                    <span className="text-[10px] text-blue-400 uppercase tracking-wider">Installing…</span>
+                  )}
+                  {hasErrors && (
+                    <span className="text-[10px] text-red-400 uppercase tracking-wider">Has errors</span>
+                  )}
+                  {!inProgress && !hasErrors && tmpl.tier_minimum && (
+                    <span className="text-[10px] text-theme-text-muted uppercase tracking-wider">
+                      {tmpl.tier_minimum}+
+                    </span>
+                  )}
+                </div>
+              </div>
+              <p className="text-xs text-theme-text-muted line-clamp-2">{tmpl.description}</p>
+              <div className="flex items-center gap-3 mt-2 text-[10px] text-theme-text-muted">
+                <span>{tmpl.services?.length || 0} services</span>
+                {tmpl.estimated_disk_gb && (
+                  <span className="flex items-center gap-1">
+                    <HardDrive size={10} />
+                    ~{tmpl.estimated_disk_gb}GB
+                  </span>
+                )}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      {preview && (
+        <TemplatePreview
+          template={preview}
+          onClose={() => setPreview(null)}
+          onApplied={onApplied}
+        />
+      )}
+    </>
+  )
+}
+
+/**
+ * TemplatePreview — modal showing what will be enabled/already enabled/incompatible.
+ */
+export function TemplatePreview({ template, onClose, onApplied }) {
+  const [previewData, setPreviewData] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const [error, setError] = useState(null)
+  const [applied, setApplied] = useState(false)
+
+  const Icon = ICON_MAP[template.icon] || Package
+
+  const loadPreview = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetchJson(`/api/templates/${template.id}/preview`, { method: 'POST' })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      setPreviewData(await res.json())
+    } catch (err) {
+      setError(err.name === 'AbortError' ? 'Request timed out' : 'Failed to load preview')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleApply = async () => {
+    setApplying(true)
+    setError(null)
+    try {
+      const res = await fetchJson(`/api/templates/${template.id}/apply`, {
+        method: 'POST',
+        timeout: 120000,
+      })
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json().catch(() => ({}))
+      if (data.enabled_count > 0) {
+        setApplied(data.restart_required ? 'restart_required' : 'enabled')
+      } else {
+        setApplied('already_active')
+      }
+      onApplied?.()
+    } catch (err) {
+      setError(err.name === 'AbortError' ? 'Request timed out' : 'Failed to apply template')
+    } finally {
+      setApplying(false)
+    }
+  }
+
+  // Load preview on mount
+  if (!previewData && !loading && !error) {
+    loadPreview()
+  }
+
+  const changes = previewData?.changes || {}
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={onClose}>
+      <div
+        className="bg-theme-card border border-theme-border rounded-xl p-6 max-w-lg mx-4 w-full"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={`${template.name} template preview`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-lg bg-theme-accent/10">
+              <Icon size={20} className="text-theme-accent-light" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-theme-text">{template.name}</h3>
+              <p className="text-xs text-theme-text-muted">{template.description}</p>
+            </div>
+          </div>
+          <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text transition-colors">
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Loading */}
+        {loading && (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="animate-spin text-theme-accent" size={24} />
+          </div>
+        )}
+
+        {/* Preview content */}
+        {previewData && !applied && (
+          <div className="space-y-3">
+            {changes.to_enable?.length > 0 && (
+              <div>
+                <h4 className="text-xs font-medium text-theme-text-muted uppercase tracking-wider mb-1.5">Will be enabled</h4>
+                <div className="flex flex-wrap gap-1.5">
+                  {changes.to_enable.map(svc => (
+                    <span key={svc} className="text-xs px-2 py-1 rounded bg-theme-accent/10 text-theme-accent-light border border-theme-accent/20">
+                      {svc}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {changes.already_enabled?.length > 0 && (
+              <div>
+                <h4 className="text-xs font-medium text-theme-text-muted uppercase tracking-wider mb-1.5">Already running</h4>
+                <div className="flex flex-wrap gap-1.5">
+                  {changes.already_enabled.map(svc => (
+                    <span key={svc} className="text-xs px-2 py-1 rounded bg-green-500/10 text-green-400 border border-green-500/20">
+                      <Check size={10} className="inline mr-1" />{svc}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {changes.incompatible?.length > 0 && (
+              <div>
+                <h4 className="text-xs font-medium text-theme-text-muted uppercase tracking-wider mb-1.5">Incompatible</h4>
+                <div className="flex flex-wrap gap-1.5">
+                  {changes.incompatible.map(svc => (
+                    <span key={svc} className="text-xs px-2 py-1 rounded bg-orange-500/10 text-orange-400 border border-orange-500/20">
+                      <AlertTriangle size={10} className="inline mr-1" />{svc}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {previewData.warnings?.length > 0 && (
+              <div className="p-2.5 rounded-lg bg-orange-500/10 border border-orange-500/20">
+                {previewData.warnings.map((w, i) => (
+                  <p key={i} className="text-xs text-orange-300">{w}</p>
+                ))}
+              </div>
+            )}
+
+            {template.service_notes && Object.keys(template.service_notes).length > 0 && (
+              <div className="text-xs text-theme-text-muted space-y-1 pt-1">
+                {Object.entries(template.service_notes).map(([svc, note]) => (
+                  <p key={svc}><span className="text-theme-text">{svc}:</span> {note}</p>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Applied success */}
+        {applied && (
+          <div className="py-6 text-center">
+            <Check size={32} className="text-green-400 mx-auto mb-2" />
+            {applied === 'enabled' && (
+              <p className="text-sm text-green-400">Template applied — check extension cards for installation progress</p>
+            )}
+            {applied === 'already_active' && (
+              <p className="text-sm text-green-400">All services in this template are already active</p>
+            )}
+            {applied === 'restart_required' && (
+              <>
+                <p className="text-sm text-green-400 mb-3">Template applied successfully</p>
+                <div className="p-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-left">
+                  <p className="text-sm text-orange-300 font-medium mb-1">Restart required</p>
+                  <p className="text-xs text-orange-200/80">Run <code className="px-1.5 py-0.5 rounded bg-theme-card text-orange-100">dream restart</code> in your terminal to start the newly enabled services.</p>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-sm text-red-300 mb-3">
+            {error}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex justify-end gap-3 mt-4">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors"
+          >
+            {applied ? 'Close' : 'Cancel'}
+          </button>
+          {!applied && previewData && (
+            <button
+              onClick={handleApply}
+              disabled={applying || (changes.to_enable?.length === 0)}
+              className="px-4 py-2 text-sm rounded-lg bg-theme-accent/20 text-theme-accent-light hover:bg-theme-accent/30 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            >
+              {applying ? <Loader2 size={14} className="animate-spin" /> : null}
+              Apply Template
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -4,6 +4,7 @@ import {
   Box, Loader2, RefreshCw, ChevronDown, ChevronUp, Package, Info, X, Download, Trash2, ExternalLink, Terminal, Copy, Check,
 } from 'lucide-react'
 import { useState, useEffect, useRef } from 'react'
+import { DependencyBadges, DependencyConfirmDialog, DisableDependentWarning } from '../components/DependencyBadges'
 
 // Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
 // proxy_set_header for all /api/ requests (see nginx.conf).  All fetches
@@ -71,6 +72,7 @@ export default function Extensions() {
   const [consoleExt, setConsoleExt] = useState(null)
   const [refreshing, setRefreshing] = useState(false)
   const [progressMap, setProgressMap] = useState({})
+  const [depConfirm, setDepConfirm] = useState(null)
   const installProgressRef = useRef(null)
   const activePollers = useRef({})
 
@@ -161,16 +163,19 @@ export default function Extensions() {
     }
   }
 
-  const handleMutation = async (serviceId, action) => {
+  const handleMutation = async (serviceId, action, { autoEnableDeps = false } = {}) => {
     setMutating(serviceId)
     setConfirm(null)
-
+    setDepConfirm(null)
     try {
-      const url = action === 'uninstall'
+      let url = action === 'uninstall'
         ? `/api/extensions/${serviceId}`
         : action === 'purge'
         ? `/api/extensions/${serviceId}/data`
         : `/api/extensions/${serviceId}/${action}`
+      if (action === 'enable' && autoEnableDeps) {
+        url += '?auto_enable_deps=true'
+      }
       const opts = {
         method: action === 'uninstall' || action === 'purge' ? 'DELETE' : 'POST',
         signal: AbortSignal.timeout(300000),
@@ -182,7 +187,15 @@ export default function Extensions() {
       const res = await fetch(url, opts)
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        throw new Error(err.detail || `Failed to ${action}`)
+        const detail = err.detail
+        // Handle missing dependencies response
+        if (action === 'enable' && res.status === 400 && detail?.missing_dependencies) {
+          const ext = extensions.find(e => e.id === serviceId)
+          setMutating(null)
+          setDepConfirm({ ext, missingDeps: detail.missing_dependencies })
+          return
+        }
+        throw new Error((typeof detail === 'string' ? detail : detail?.message) || `Failed to ${action}`)
       }
       const data = await res.json()
 
@@ -399,7 +412,10 @@ export default function Extensions() {
               {confirm.action === 'uninstall' ? 'Remove' : confirm.action === 'purge' ? 'Purge Data —' : confirm.action.charAt(0).toUpperCase() + confirm.action.slice(1)} Extension
             </h3>
             <p className="text-sm text-theme-text-muted mb-4">{confirm.message}</p>
-            <div className="flex justify-end gap-3">
+            {confirm.action === 'disable' && confirm.ext.dependents?.length > 0 && (
+              <DisableDependentWarning dependents={confirm.ext.dependents} />
+            )}
+            <div className="flex justify-end gap-3 mt-4">
               <button onClick={() => setConfirm(null)} autoFocus className="px-4 py-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors">Cancel</button>
               <button
                 onClick={() => handleMutation(confirm.ext.id, confirm.action)}
@@ -413,6 +429,16 @@ export default function Extensions() {
             </div>
           </div>
         </div>
+      )}
+
+      {/* Dependency auto-enable dialog */}
+      {depConfirm && (
+        <DependencyConfirmDialog
+          ext={depConfirm.ext}
+          missingDeps={depConfirm.missingDeps}
+          onConfirm={() => handleMutation(depConfirm.ext.id, 'enable', { autoEnableDeps: true })}
+          onCancel={() => setDepConfirm(null)}
+        />
       )}
 
       {/* Toast notification */}
@@ -462,11 +488,11 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
   const showInstall = status === 'not_installed' && ext.installable
 
   return (
-    <div className={`bg-theme-card border rounded-xl transition-all liquid-metal-frame liquid-metal-sequence-card ${
+    <div className={`bg-theme-card border rounded-xl transition-all liquid-metal-frame liquid-metal-sequence-card flex flex-col ${
       isCore ? 'border-theme-border/60 opacity-70' : 'border-theme-border'
     }`}>
       {/* Card body */}
-      <div className="p-4 pb-3">
+      <div className="p-4 pb-3 flex-1">
         <div className="flex items-start justify-between mb-2">
           <div className="flex items-center gap-2.5">
             <div className={`p-1.5 rounded-lg ${
@@ -615,16 +641,9 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
           {isUserExt && status === 'enabled' && (
             <span className="text-[10px] text-theme-text-muted">Disable to remove</span>
           )}
-          {!showInstall && !showRemove && !isToggleable && (
-            <div className="flex items-center gap-1" title={status === 'incompatible' && gpuBackend ? `Your system: ${gpuBackend}` : undefined}>
-              {status === 'incompatible' && <span className="text-[10px] text-theme-text-muted mr-0.5">Requires:</span>}
-              {ext.gpu_backends?.slice(0, 3).map(gpu => (
-                <span key={gpu} className="text-[10px] px-1.5 py-0.5 rounded bg-theme-card/80 text-theme-text-muted">{gpu}</span>
-              ))}
-            </div>
-          )}
         </div>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-2">
+          <DependencyBadges dependsOn={ext.depends_on} dependencyStatus={ext.dependency_status} />
           {status === 'enabled' && (ext.external_port_default || ext.port) && (ext.external_port_default || ext.port) !== 0 ? (
             <a
               href={`http://${window.location.hostname}:${ext.external_port_default || ext.port}`}

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -5,6 +5,32 @@ import {
 } from 'lucide-react'
 import { useState, useEffect, useRef } from 'react'
 import { DependencyBadges, DependencyConfirmDialog, DisableDependentWarning } from '../components/DependencyBadges'
+import { TemplatePicker } from '../components/TemplatePicker'
+
+// Services defined in docker-compose.base.yml — always running, not togglable via templates
+const BASE_COMPOSE_SERVICES = new Set(['llama-server', 'open-webui', 'dashboard', 'dashboard-api'])
+
+// Compute template status from catalog extensions data.
+// Returns one of: 'available', 'in_progress', 'applied', 'has_errors'
+// Precedence: has_errors > in_progress > applied > available
+export function getTemplateStatus(template, extensions) {
+  const services = template.services || []
+  const serviceStatus = {}
+  for (const svcId of services) {
+    if (BASE_COMPOSE_SERVICES.has(svcId)) {
+      serviceStatus[svcId] = 'enabled'
+      continue
+    }
+    const ext = extensions.find(e => e.id === svcId)
+    serviceStatus[svcId] = ext ? ext.status : undefined
+  }
+  const statuses = Object.values(serviceStatus)
+  if (statuses.some(s => s === 'error')) return 'has_errors'
+  if (statuses.some(s => s === 'installing' || s === 'setting_up')) return 'in_progress'
+  const allEnabled = statuses.every(s => s === 'enabled')
+  if (allEnabled) return 'applied'
+  return 'available'
+}
 
 // Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
 // proxy_set_header for all /api/ requests (see nginx.conf).  All fetches
@@ -73,6 +99,8 @@ export default function Extensions() {
   const [refreshing, setRefreshing] = useState(false)
   const [progressMap, setProgressMap] = useState({})
   const [depConfirm, setDepConfirm] = useState(null)
+  const [templates, setTemplates] = useState([])
+  const [templatesOpen, setTemplatesOpen] = useState(false)
   const installProgressRef = useRef(null)
   const activePollers = useRef({})
 
@@ -113,6 +141,10 @@ export default function Extensions() {
 
   useEffect(() => {
     fetchCatalog()
+    fetch('/api/templates')
+      .then(r => r.ok ? r.json() : { templates: [] })
+      .then(d => setTemplates(d.templates || []))
+      .catch(() => {})
     return () => { Object.values(activePollers.current).forEach(clearInterval); activePollers.current = {} }
   }, [])
 
@@ -370,6 +402,22 @@ export default function Extensions() {
       )}
 
       {/* Card grid */}
+      {(() => {
+        const enrichedTemplates = templates
+          .map(t => ({ ...t, _status: getTemplateStatus(t, extensions) }))
+          .filter(t => t._status !== 'applied')
+        if (enrichedTemplates.length === 0) return null
+        return (
+          <div className="mb-4">
+            <button onClick={() => setTemplatesOpen(!templatesOpen)} className="flex items-center gap-2 text-sm text-theme-text-muted hover:text-theme-text transition-colors mb-2">
+              {templatesOpen ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+              Quick Start Templates ({enrichedTemplates.length})
+            </button>
+            {templatesOpen && <TemplatePicker templates={enrichedTemplates} onApplied={fetchCatalog} />}
+          </div>
+        )
+      })()}
+
       {filtered.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-theme-text-muted">
           <Package size={48} className="mb-4 opacity-40" />

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -175,10 +175,16 @@ for service_dir in _all_service_dirs:
         print(f'SERVICE_PORTS["{_esc(sid)}"]="{_esc(port)}"')
         print(f'SERVICE_PORT_ENVS["{_esc(sid)}"]="{_esc(port_env)}"')
         print(f'SERVICE_NAMES["{_esc(sid)}"]="{_esc(s.get("name", sid))}"')
-        setup_hook = s.get("setup_hook", "")
+        # Prefer hooks.post_install over legacy setup_hook
+        hooks = s.get("hooks", {})
+        effective_hook = ""
+        if isinstance(hooks, dict):
+            effective_hook = hooks.get("post_install", "")
+        if not effective_hook:
+            effective_hook = s.get("setup_hook", "")
         setup_path = ""
-        if setup_hook:
-            full = service_dir / setup_hook
+        if effective_hook:
+            full = service_dir / effective_hook
             if full.exists():
                 setup_path = str(full)
         print(f'SERVICE_SETUP_HOOKS["{_esc(sid)}"]="{_esc(setup_path)}"')

--- a/dream-server/templates/ai-coding-workspace.yaml
+++ b/dream-server/templates/ai-coding-workspace.yaml
@@ -1,0 +1,14 @@
+schema_version: dream.templates.v1
+template:
+  id: ai-coding-workspace
+  name: AI Coding Workspace
+  description: "Local AI-assisted coding with version control and project memory — code stays on your machine."
+  icon: Code2
+  tags: [development, ai-assistant, self-hosted]
+  services: [aider, gitea, chromadb, n8n, openclaw]
+  tier_minimum: T2
+  estimated_disk_gb: 15
+  service_notes:
+    aider: "CLI tool — run with 'docker compose run --rm aider' in your project directory. Not a background service."
+    gitea: "Self-hosted Git — access at port 7830, SSH at 2222"
+    chromadb: "Vector database for codebase memory and RAG"

--- a/dream-server/templates/chat-playground.yaml
+++ b/dream-server/templates/chat-playground.yaml
@@ -1,0 +1,14 @@
+schema_version: dream.templates.v1
+template:
+  id: chat-playground
+  name: Chat Playground
+  description: "Multiple chat UIs and voice synthesis — perfect for writers, roleplayers, and chat enthusiasts."
+  icon: MessagesSquare
+  tags: [chat, voice, creative-writing]
+  services: [librechat, sillytavern, piper-audio, tts, whisper]
+  tier_minimum: T2
+  estimated_disk_gb: 14
+  service_notes:
+    librechat: "Multi-provider chat UI — set OPENAI_REVERSE_PROXY to use local LLM. 3 containers (+MongoDB, Meilisearch)."
+    sillytavern: "Character chat and roleplay interface"
+    piper-audio: "Neural TTS (alternative to Kokoro)"

--- a/dream-server/templates/creative-studio.yaml
+++ b/dream-server/templates/creative-studio.yaml
@@ -1,0 +1,13 @@
+schema_version: dream.templates.v1
+template:
+  id: creative-studio
+  name: Creative Studio
+  description: "Image generation, voice synthesis, and chat — a full creative toolkit. Requires NVIDIA or AMD GPU."
+  icon: Image
+  tags: [creative, gpu-intensive]
+  services: [llama-server, open-webui, comfyui, tts, whisper]
+  tier_minimum: T3
+  estimated_disk_gb: 25
+  service_notes:
+    comfyui: "Stable Diffusion image generation — requires 8GB+ VRAM"
+    tts: "Kokoro text-to-speech — runs on CPU"

--- a/dream-server/templates/developer-homelab.yaml
+++ b/dream-server/templates/developer-homelab.yaml
@@ -1,0 +1,14 @@
+schema_version: dream.templates.v1
+template:
+  id: developer-homelab
+  name: Developer Homelab
+  description: "Complete self-hosted toolkit for indie developers — Git, database, automation, and AI assistant."
+  icon: Server
+  tags: [self-hosted, homelab, indie]
+  services: [gitea, aider, baserow, n8n, token-spy]
+  tier_minimum: T2
+  estimated_disk_gb: 12
+  service_notes:
+    aider: "CLI tool — run with 'docker compose run --rm aider'. Not a background service."
+    gitea: "Self-hosted Git (port 7830, SSH 2222)"
+    baserow: "No-code database"

--- a/dream-server/templates/llm-platform.yaml
+++ b/dream-server/templates/llm-platform.yaml
@@ -1,0 +1,15 @@
+schema_version: dream.templates.v1
+template:
+  id: llm-platform
+  name: LLM Platform
+  description: "Run your local LLM as a service for multiple apps and users with gateway, observability, and a chat UI."
+  icon: Network
+  tags: [platform, observability, teams]
+  services: [litellm, langfuse, token-spy, librechat, n8n]
+  tier_minimum: T2
+  estimated_disk_gb: 15
+  service_notes:
+    litellm: "LLM gateway — routes between models"
+    langfuse: "LLM observability — 7 containers, ~6GB"
+    librechat: "Chat UI — set OPENAI_REVERSE_PROXY=http://litellm:4000/v1 to use the gateway"
+    n8n: "Automation consumer for the LLM gateway"

--- a/dream-server/templates/ml-data-workshop.yaml
+++ b/dream-server/templates/ml-data-workshop.yaml
@@ -1,0 +1,14 @@
+schema_version: dream.templates.v1
+template:
+  id: ml-data-workshop
+  name: ML Data Workshop
+  description: "Label data, evaluate LLM pipelines, and track metrics — a local alternative to W&B and Scale AI."
+  icon: Microscope
+  tags: [ml-ops, labeling, evaluation]
+  services: [label-studio, chromadb, litellm, langfuse, n8n]
+  tier_minimum: T3
+  estimated_disk_gb: 20
+  service_notes:
+    label-studio: "Data labeling interface"
+    langfuse: "LLM evaluation and tracing — 7 containers, ~6GB"
+    litellm: "LLM gateway for routing between models"

--- a/dream-server/templates/multi-agent-laboratory.yaml
+++ b/dream-server/templates/multi-agent-laboratory.yaml
@@ -1,0 +1,14 @@
+schema_version: dream.templates.v1
+template:
+  id: multi-agent-laboratory
+  name: Multi-Agent Laboratory
+  description: "Build and observe autonomous multi-agent systems with full tracing and vector memory."
+  icon: Bot
+  tags: [agents, experimental, gpu-recommended]
+  services: [crewai, langflow, openclaw, chromadb, langfuse, n8n]
+  tier_minimum: T3
+  estimated_disk_gb: 20
+  service_notes:
+    crewai: "Code-first multi-agent framework"
+    langfuse: "LLM observability — 7 containers, ~6GB. Essential for debugging agent loops."
+    n8n: "Workflow automation — wire agents into external systems"

--- a/dream-server/templates/no-code-ai-builder.yaml
+++ b/dream-server/templates/no-code-ai-builder.yaml
@@ -1,0 +1,14 @@
+schema_version: dream.templates.v1
+template:
+  id: no-code-ai-builder
+  name: No-Code AI Builder
+  description: "Visual LLM workflow builders, vector memory, and a local database — build AI apps without writing code."
+  icon: Blocks
+  tags: [no-code, workflows, visual]
+  services: [flowise, langflow, n8n, chromadb, baserow]
+  tier_minimum: T2
+  estimated_disk_gb: 12
+  service_notes:
+    flowise: "Polished LLM app builder"
+    langflow: "Experimental visual agent composer"
+    baserow: "Airtable alternative for data storage"

--- a/dream-server/templates/personal-knowledge-base.yaml
+++ b/dream-server/templates/personal-knowledge-base.yaml
@@ -1,0 +1,13 @@
+schema_version: dream.templates.v1
+template:
+  id: personal-knowledge-base
+  name: Personal Knowledge Base
+  description: "Turn your documents and notes into a searchable, chat-ready knowledge base."
+  icon: Library
+  tags: [rag, documents, research]
+  services: [paperless-ngx, chromadb, perplexica, searxng, whisper]
+  tier_minimum: T2
+  estimated_disk_gb: 12
+  service_notes:
+    paperless-ngx: "Document management with OCR and full-text search"
+    whisper: "Transcribe voice memos into your knowledge base"

--- a/dream-server/templates/private-research-hub.yaml
+++ b/dream-server/templates/private-research-hub.yaml
@@ -1,0 +1,10 @@
+schema_version: dream.templates.v1
+template:
+  id: private-research-hub
+  name: Private Research Hub
+  description: "Search, collect, and analyze sensitive information privately — no data leaves your machine."
+  icon: ShieldCheck
+  tags: [privacy, research, documents]
+  services: [searxng, perplexica, privacy-shield, paperless-ngx, chromadb]
+  tier_minimum: T2
+  estimated_disk_gb: 11

--- a/dream-server/templates/voice-assistant.yaml
+++ b/dream-server/templates/voice-assistant.yaml
@@ -1,0 +1,14 @@
+schema_version: dream.templates.v1
+template:
+  id: voice-assistant
+  name: Voice Assistant
+  description: "Voice-first AI assistant with local speech recognition, synthesis, and workflow automation."
+  icon: Mic
+  tags: [voice, automation, cpu-friendly]
+  services: [whisper, tts, piper-audio, open-interpreter, n8n]
+  tier_minimum: T2
+  estimated_disk_gb: 10
+  service_notes:
+    open-interpreter: "Requires OPEN_INTERPRETER_API_KEY to be set in .env before first start. Edit dream-server/.env to add your API key."
+    piper-audio: "Neural TTS — pairs with Kokoro (tts) for voice variety"
+    n8n: "Wire voice intents to external systems"

--- a/dream-server/tests/test-hooks.sh
+++ b/dream-server/tests/test-hooks.sh
@@ -1,0 +1,225 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server — Lifecycle Hooks Test Suite
+# ============================================================================
+# Tests hook resolution priority in service-registry.sh (SERVICE_SETUP_HOOKS)
+# and validates the _run_hook helper pattern.
+#
+# Usage: bash tests/test-hooks.sh
+# Exit 0 if all pass, 1 if any fail
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() {
+    echo -e "  ${GREEN}PASS${NC}  $1"
+    PASS=$((PASS + 1))
+}
+
+fail() {
+    echo -e "  ${RED}FAIL${NC}  $1"
+    [[ -n "${2:-}" ]] && echo -e "        ${RED}→ $2${NC}"
+    FAIL=$((FAIL + 1))
+}
+
+skip() {
+    echo -e "  ${YELLOW}SKIP${NC}  $1"
+    SKIP=$((SKIP + 1))
+}
+
+header() {
+    echo ""
+    echo -e "${BOLD}${CYAN}[$1]${NC} ${BOLD}$2${NC}"
+    echo -e "${CYAN}$(printf '%.0s─' {1..60})${NC}"
+}
+
+# Check prerequisites
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "SKIP: Bash 4+ required (have $BASH_VERSION)"
+    exit 0
+fi
+
+if ! command -v python3 &>/dev/null; then
+    echo "SKIP: python3 not found"
+    exit 0
+fi
+
+if ! python3 -c "import yaml" 2>/dev/null; then
+    echo "SKIP: PyYAML not available"
+    exit 0
+fi
+
+# ============================================
+# TEST 1: SERVICE_SETUP_HOOKS prefers hooks.post_install
+# ============================================
+header "1/4" "hooks.post_install priority over setup_hook"
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Create a test extension with both setup_hook and hooks.post_install
+EXT_DIR="$TMPDIR_TEST/extensions/services/test-ext"
+mkdir -p "$EXT_DIR"
+cat > "$EXT_DIR/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext
+  name: Test Extension
+  port: 9999
+  health: /health
+  setup_hook: old-setup.sh
+  hooks:
+    post_install: hooks/new-setup.sh
+YAML
+touch "$EXT_DIR/old-setup.sh"
+mkdir -p "$EXT_DIR/hooks"
+touch "$EXT_DIR/hooks/new-setup.sh"
+
+export SCRIPT_DIR="$PROJECT_DIR"
+export EXTENSIONS_DIR="$TMPDIR_TEST/extensions/services"
+
+# Source registry and load
+# Reset loaded flag
+_SR_LOADED=false
+. "$PROJECT_DIR/lib/service-registry.sh"
+sr_load 2>/dev/null
+
+HOOK_PATH="${SERVICE_SETUP_HOOKS[test-ext]:-}"
+if [[ "$HOOK_PATH" == *"hooks/new-setup.sh" ]]; then
+    pass "SERVICE_SETUP_HOOKS prefers hooks.post_install"
+else
+    fail "SERVICE_SETUP_HOOKS should prefer hooks.post_install" "got: $HOOK_PATH"
+fi
+
+# ============================================
+# TEST 2: setup_hook fallback when hooks map absent
+# ============================================
+header "2/4" "setup_hook fallback when hooks map absent"
+
+EXT_DIR2="$TMPDIR_TEST/extensions/services/test-ext2"
+mkdir -p "$EXT_DIR2"
+cat > "$EXT_DIR2/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext2
+  name: Test Extension 2
+  port: 9998
+  health: /health
+  setup_hook: legacy-setup.sh
+YAML
+touch "$EXT_DIR2/legacy-setup.sh"
+
+_SR_LOADED=false
+sr_load 2>/dev/null
+
+HOOK_PATH2="${SERVICE_SETUP_HOOKS[test-ext2]:-}"
+if [[ "$HOOK_PATH2" == *"legacy-setup.sh" ]]; then
+    pass "Falls back to setup_hook when hooks map absent"
+else
+    fail "Should fall back to setup_hook" "got: $HOOK_PATH2"
+fi
+
+# ============================================
+# TEST 3: No hook set → empty
+# ============================================
+header "3/4" "No hook set returns empty"
+
+EXT_DIR3="$TMPDIR_TEST/extensions/services/test-ext3"
+mkdir -p "$EXT_DIR3"
+cat > "$EXT_DIR3/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext3
+  name: Test Extension 3
+  port: 9997
+  health: /health
+YAML
+
+_SR_LOADED=false
+sr_load 2>/dev/null
+
+HOOK_PATH3="${SERVICE_SETUP_HOOKS[test-ext3]:-}"
+if [[ -z "$HOOK_PATH3" ]]; then
+    pass "No hook set → empty string"
+else
+    fail "Expected empty hook path" "got: $HOOK_PATH3"
+fi
+
+# ============================================
+# TEST 4: _run_hook resolves and validates
+# ============================================
+header "4/4" "_run_hook Python resolver validates path containment"
+
+# Create test extension with path traversal attempt
+EXT_DIR4="$TMPDIR_TEST/extensions/services/test-ext4"
+mkdir -p "$EXT_DIR4"
+cat > "$EXT_DIR4/manifest.yaml" <<'YAML'
+schema_version: dream.services.v1
+service:
+  id: test-ext4
+  name: Test Extension 4
+  port: 9996
+  health: /health
+  hooks:
+    pre_start: ../../../etc/passwd
+YAML
+
+# Run the Python resolver and check it rejects traversal
+INSTALL_DIR="$TMPDIR_TEST"
+RESULT=$(python3 - "$EXT_DIR4" "pre_start" <<'PYEOF' 2>&1 || true
+import yaml, sys
+from pathlib import Path
+
+ext_dir = Path(sys.argv[1])
+hook_name = sys.argv[2]
+
+manifest_path = ext_dir / "manifest.yaml"
+with open(manifest_path) as f:
+    m = yaml.safe_load(f)
+service = m.get("service", {})
+hooks = service.get("hooks", {})
+hook_script = hooks.get(hook_name, "")
+if not hook_script:
+    sys.exit(0)
+hook_path = (ext_dir / hook_script).resolve()
+try:
+    hook_path.relative_to(ext_dir.resolve())
+except ValueError:
+    print("ERROR: hook path escapes extension directory", file=sys.stderr)
+    sys.exit(1)
+print(str(hook_path))
+PYEOF
+)
+
+if [[ "$RESULT" == *"ERROR"* ]]; then
+    pass "Path traversal in hook script is rejected"
+else
+    fail "Path traversal should be rejected" "got: $RESULT"
+fi
+
+# ============================================
+# Summary
+# ============================================
+echo ""
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+TOTAL=$((PASS + FAIL + SKIP))
+echo -e "  ${GREEN}$PASS passed${NC}  ${RED}$FAIL failed${NC}  ${YELLOW}$SKIP skipped${NC}  ($TOTAL total)"
+echo -e "${BOLD}════════════════════════════════════════${NC}"
+
+[[ $FAIL -eq 0 ]]

--- a/dream-server/tests/test-templates.sh
+++ b/dream-server/tests/test-templates.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Test suite: Service templates validation
+# Verifies template YAML files parse correctly, reference valid service IDs,
+# and have unique template IDs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATES_DIR="$PROJECT_DIR/templates"
+EXTENSIONS_DIR="$PROJECT_DIR/extensions/services"
+# Library extension source (pre-install). Runtime path after install is
+# data/extensions-library/ but the source tree ships them under resources/dev/.
+EXTENSIONS_LIBRARY_DIR="${EXTENSIONS_LIBRARY_DIR:-$PROJECT_DIR/../resources/dev/extensions-library/services}"
+
+PASS=0
+FAIL=0
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1" >&2; }
+
+echo "=== Template Validation Tests ==="
+
+# --- Test 1: All template YAML files parse correctly ---
+echo ""
+echo "--- Test: Template YAML parsing ---"
+if [[ ! -d "$TEMPLATES_DIR" ]]; then
+    fail "Templates directory not found: $TEMPLATES_DIR"
+else
+    for f in "$TEMPLATES_DIR"/*.yaml "$TEMPLATES_DIR"/*.yml; do
+        [[ -f "$f" ]] || continue
+        basename="$(basename "$f")"
+        if python3 -c "
+import yaml, sys
+with open(sys.argv[1]) as fh:
+    d = yaml.safe_load(fh)
+assert isinstance(d, dict), 'root must be a mapping'
+assert d.get('schema_version') == 'dream.templates.v1', 'wrong schema_version'
+t = d.get('template', {})
+assert t.get('id'), 'missing template.id'
+assert t.get('name'), 'missing template.name'
+assert isinstance(t.get('services', []), list) and len(t['services']) > 0, 'services must be non-empty list'
+" "$f" 2>/dev/null; then
+            pass "$basename parses correctly"
+        else
+            fail "$basename failed to parse"
+        fi
+    done
+fi
+
+# --- Test 2: All template service IDs exist in manifest registry ---
+echo ""
+echo "--- Test: Template service IDs exist in manifests ---"
+
+# Build set of known service IDs from built-in manifests AND the library.
+# Library extensions are installable on demand by the template apply flow,
+# so they are valid template service IDs even though they're not under
+# extensions/services/.
+known_ids=$(python3 - "$EXTENSIONS_DIR" "$EXTENSIONS_LIBRARY_DIR" <<'PYEOF'
+import yaml, sys
+from pathlib import Path
+ids = set()
+for root in sys.argv[1:]:
+    rp = Path(root)
+    if not rp.is_dir():
+        continue
+    for d in sorted(rp.iterdir()):
+        if not d.is_dir():
+            continue
+        for name in ("manifest.yaml", "manifest.yml"):
+            mp = d / name
+            if mp.exists():
+                try:
+                    with open(mp) as f:
+                        m = yaml.safe_load(f)
+                except Exception:
+                    break
+                if isinstance(m, dict) and m.get("schema_version") == "dream.services.v1":
+                    s = m.get("service", {})
+                    if s.get("id"):
+                        ids.add(s["id"])
+                break
+for sid in sorted(ids):
+    print(sid)
+PYEOF
+)
+
+for f in "$TEMPLATES_DIR"/*.yaml "$TEMPLATES_DIR"/*.yml; do
+    [[ -f "$f" ]] || continue
+    basename="$(basename "$f")"
+    services=$(python3 -c "
+import yaml, sys
+with open(sys.argv[1]) as fh:
+    d = yaml.safe_load(fh)
+for s in d.get('template', {}).get('services', []):
+    print(s)
+" "$f" 2>/dev/null) || continue
+
+    all_found=true
+    while IFS= read -r svc; do
+        [[ -z "$svc" ]] && continue
+        if ! echo "$known_ids" | grep -q "^${svc}$"; then
+            fail "$basename: service '$svc' not found in manifests"
+            all_found=false
+        fi
+    done <<< "$services"
+
+    if $all_found; then
+        pass "$basename: all service IDs exist"
+    fi
+done
+
+# --- Test 3: Template IDs are unique ---
+echo ""
+echo "--- Test: Template IDs are unique ---"
+
+all_ids=$(python3 - "$TEMPLATES_DIR" <<'PYEOF'
+import yaml, sys
+from pathlib import Path
+d = Path(sys.argv[1])
+for f in sorted(list(d.glob("*.yaml")) + list(d.glob("*.yml"))):
+    with open(f) as fh:
+        data = yaml.safe_load(fh)
+    if isinstance(data, dict) and data.get("schema_version") == "dream.templates.v1":
+        tid = data.get("template", {}).get("id", "")
+        if tid:
+            print(tid)
+PYEOF
+)
+
+total=$(echo "$all_ids" | wc -l | tr -d ' ')
+unique=$(echo "$all_ids" | sort -u | wc -l | tr -d ' ')
+
+if [[ "$total" == "$unique" ]]; then
+    pass "All $total template IDs are unique"
+else
+    fail "Duplicate template IDs found ($total total, $unique unique)"
+fi
+
+# --- Summary ---
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[[ "$FAIL" -eq 0 ]] || exit 1


### PR DESCRIPTION
## What

Adds a template system for DreamServer: curated multi-extension presets that let users set up groups of services with one click. Templates are YAML files describing a set of services that work together for a specific use case.

**11 built-in templates**, 10 focused on library extensions + `creative-studio` kept as a GPU-only preset:

| Template | Services | Use Case |
|----------|----------|----------|
| `ai-coding-workspace` | aider, gitea, chromadb, n8n, openclaw | Local AI-assisted coding with Git + vector memory |
| `no-code-ai-builder` | flowise, langflow, n8n, chromadb, baserow | Visual LLM workflow builders + no-code database |
| `personal-knowledge-base` | paperless-ngx, chromadb, perplexica, searxng, whisper | Document RAG + voice memo transcription |
| `multi-agent-laboratory` | crewai, langflow, openclaw, chromadb, langfuse, n8n | Multi-agent systems with observability |
| `chat-playground` | librechat, sillytavern, piper-audio, tts, whisper | Multi-provider chat + character roleplay + voice |
| `voice-assistant` | whisper, tts, piper-audio, open-interpreter, n8n | Voice-first AI with terminal control (CPU-friendly) |
| `private-research-hub` | searxng, perplexica, privacy-shield, paperless-ngx, chromadb | Privacy-focused research with document archive |
| `developer-homelab` | gitea, aider, baserow, n8n, token-spy | Self-hosted indie dev toolkit |
| `ml-data-workshop` | label-studio, chromadb, litellm, langfuse, n8n | Local alternative to W&B + Scale AI |
| `llm-platform` | litellm, langfuse, token-spy, librechat, n8n | Local LLM as a service for multiple apps |
| `creative-studio` | llama-server, open-webui, comfyui, tts, whisper | Image generation + voice (GPU-required) |

## Why

Users faced 30+ extension cards with no guidance on which to enable. Non-technical users don't know what `flowise` does or that it pairs well with `chromadb`. Templates give curated starting points for common use cases without making the user research every extension.

The feature focuses on **library extensions** (the optional services users install from the extension portal), not core services. Core services are always running — including them in templates adds noise.

## How

### Backend

- **Template YAML format** (`extensions/schema/service-template.v1.json`): `schema_version: dream.templates.v1`, template metadata (id, name, description, icon, tags), services list, optional tier_minimum + estimated_disk_gb + service_notes
- **Loader** (`config.py::load_templates`): scans `templates/*.yaml`, validates schema_version, optional JSON Schema validation via jsonschema if installed, graceful fallback on missing dir / malformed YAML
- **Router** (`routers/templates.py`): 3 endpoints all auth-gated (`verify_api_key`)
  - `GET /api/templates` — list all templates
  - `POST /api/templates/{id}/preview` — diff `to_enable`/`already_enabled`/`incompatible`/`in_progress`/`has_errors`
  - `POST /api/templates/{id}/apply` — auto-install + activate services (additive only)
- **Library auto-install**: extracted `_install_from_library()` helper from `install_extension` in extensions.py. Template apply calls it for library extensions not yet in `USER_EXTENSIONS_DIR`, then uses `_activate_service` from PR #877 for built-in extensions.

### Frontend

- **TemplatePicker.jsx**: card grid with status-aware rendering (available/in_progress/has_errors)
- **Extensions.jsx**: collapsible "Quick Start Templates" section above the card grid, `getTemplateStatus()` helper computes template state client-side from catalog data (live-updates with catalog polling)
- **SetupWizard.jsx**: new step 2 template picker (skippable), `totalSteps` 5 → 6

### CLI

- `dream template list` — table of available templates
- `dream template preview <id>` — diff of what will change
- `dream template apply <id>` — calls `cmd_enable` per service

## Dependency + Merge Ordering

This is **PR 2 of 2** from the extension-system-v2 feature.

### Hard dependency

- **#877** — `feat(extensions): service dependency visibility + lifecycle hooks`
  Uses `_activate_service`, `_get_missing_deps_transitive`, `_is_installable` from that PR. This PR will not compile without #877.

### Works better after

Template apply still works without these, but features are degraded:

- **#827** — `feat(extensions): install progress tracking with host agent orchestration`
  Adds `_call_agent_install`, `_write_initial_progress`, and the host agent `/v1/extension/install` endpoint. Without it, library extensions installed via template apply will start without progress UI (template cards won't show "Installing..." state during the install).
- **#828** — `feat(extensions): progress UI + error display during install`
  Without it, the template card state-aware rendering still works for `has_errors` and `applied`, but `in_progress` state won't light up because `_compute_extension_status` doesn't return `installing`/`setting_up` without #827's progress tracking.
- **Cache invalidation fix** (not yet submitted)
  When a template installs a library extension, `.compose-flags` becomes stale. Without cache invalidation, users need to `dream restart` once after template apply for newly installed services to appear in the stack (same limitation as manually copying a new extension into `data/user-extensions/`).

### Recommended merge order

1. #877 first (hard dep)
2. This PR (service templates)
3. #827, #828 can merge in either order before or after

I'll rebase after each dependency lands.

## Three Pillars Impact

| Pillar | Impact | Notes |
|--------|--------|-------|
| Install Reliability | ✅ Positive | `_install_from_library` reuses existing atomic stage+rename, size cap, TOCTOU-safe compose scan. Failed services skipped, not fatal. |
| Broad Compatibility | ✅ Neutral/Positive | All 10 new templates work on Apple Silicon. `creative-studio` marked GPU-only. No new platform-specific code. |
| Extension Coherence | ✅ Positive | Templates reuse the existing install flow via a shared helper, not a parallel path. Schema additive, loader graceful. |

## Testing

- **pytest** `tests/test_templates.py` — 15 tests (load, preview buckets, apply with mixed built-in + library, deps, auto-install failure path)
- **pytest** full dashboard-api suite — 96 passing
- **Shell** `tests/test-templates.sh` — 23 tests (YAML parse, service IDs resolve across `extensions/services/` + `resources/dev/extensions-library/services/`, unique template IDs)
- **Live end-to-end** on clean Apple Silicon install: templates list, preview, apply, library extensions installed and started, status tooltips

## Known Limitations (documented for reviewers)

1. **`aider` and `open-interpreter` are not daemons** — aider is a CLI tool (`restart: "no"`, `stdin_open: true`). open-interpreter needs `OPEN_INTERPRETER_API_KEY` set manually. Both have prominent `service_notes` warnings. Users see them install but the containers exit — that's correct for CLI tools. Filed as yasinBursali/DreamServer#303.
2. **`baserow` healthcheck incorrectly fails** — the container runs fine but the dashboard reports it as `stopped` because the baserow compose healthcheck doesn't send a proper `Host:` header to Caddy. Filed as yasinBursali/DreamServer#304.
3. **`continue` extension has broken volume paths** — removed from templates until fixed. Filed as yasinBursali/DreamServer#301.
4. **Cache invalidation on macOS** — after template apply, `.compose-flags` becomes stale. On a fresh install, users need to `dream restart` once. A separate fix tracked at yasinBursali/DreamServer#298.
5. **macOS installer uses installer-specific compose overlay** — runtime `resolve-compose-stack.sh` doesn't match. Tracked at yasinBursali/DreamServer#302.

None of these are regressions. All are pre-existing bugs surfaced by end-to-end template testing.

## Files Changed

**Modified (7):**
- `config.py` — `load_templates()`, `TEMPLATES` constant, `gpu_backends` in service dict
- `main.py` — register templates router
- `routers/extensions.py` — extract `_install_from_library()` helper
- `dream-cli` — `cmd_template` with list/preview/apply subcommands
- `docker-compose.base.yml` — `./templates:/dream-server/templates:ro` bind mount
- `Extensions.jsx` — Quick Start section + `getTemplateStatus()` helper
- `SetupWizard.jsx` — step 2 template picker + totalSteps 5→6

**New (15):**
- 11 template YAML files (`templates/*.yaml`)
- `extensions/schema/service-template.v1.json` — JSON Schema
- `routers/templates.py` — FastAPI router
- `tests/test_templates.py` — 15 pytest tests
- `tests/test-templates.sh` — 23 shell tests
- `TemplatePicker.jsx` — card grid + preview modal component