### PR TITLE
fix(macos-installer): guard Bash 4+ and auto-install via Homebrew

### DIFF
--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -20,6 +20,43 @@
 #
 # ============================================================================
 
+# Guard: macOS ships Bash 3.2 (GPL). dream-cli and our libs need Bash 4+.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+  # Default candidate paths cover standard Apple Silicon and Intel Homebrew
+  # prefixes. If brew is already on PATH we also ask it for its actual prefix,
+  # which handles custom installs (e.g. /Volumes/X/homebrew).
+  candidates=(/opt/homebrew/bin/bash /usr/local/bin/bash)
+  if command -v brew >/dev/null 2>&1; then
+    brew_prefix="$(brew --prefix 2>/dev/null)"
+    [ -n "$brew_prefix" ] && candidates=("$brew_prefix/bin/bash" "${candidates[@]}")
+  fi
+  for candidate in "${candidates[@]}"; do
+    if [ -x "$candidate" ]; then
+      exec "$candidate" "$0" "$@"
+    fi
+  done
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "DreamServer requires Bash 4+ (you have ${BASH_VERSION})." >&2
+    echo "Install Homebrew first:" >&2
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"" >&2
+    echo "Then re-run this installer." >&2
+    exit 1
+  fi
+  echo "Installing Bash 4+ via Homebrew (one-time setup)..."
+  brew install bash || { echo "brew install bash failed" >&2; exit 1; }
+  brew_prefix="$(brew --prefix 2>/dev/null)"
+  if [ -n "$brew_prefix" ] && [ -x "$brew_prefix/bin/bash" ]; then
+    exec "$brew_prefix/bin/bash" "$0" "$@"
+  fi
+  for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [ -x "$candidate" ]; then
+      exec "$candidate" "$0" "$@"
+    fi
+  done
+  echo "Homebrew bash installed but not found in expected paths." >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # ── Locate libraries ──

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -17,6 +17,43 @@
 #
 # ============================================================================
 
+# Guard: macOS ships Bash 3.2 (GPL). dream-cli and our libs need Bash 4+.
+if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
+  # Default candidate paths cover standard Apple Silicon and Intel Homebrew
+  # prefixes. If brew is already on PATH we also ask it for its actual prefix,
+  # which handles custom installs (e.g. /Volumes/X/homebrew).
+  candidates=(/opt/homebrew/bin/bash /usr/local/bin/bash)
+  if command -v brew >/dev/null 2>&1; then
+    brew_prefix="$(brew --prefix 2>/dev/null)"
+    [ -n "$brew_prefix" ] && candidates=("$brew_prefix/bin/bash" "${candidates[@]}")
+  fi
+  for candidate in "${candidates[@]}"; do
+    if [ -x "$candidate" ]; then
+      exec "$candidate" "$0" "$@"
+    fi
+  done
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "DreamServer requires Bash 4+ (you have ${BASH_VERSION})." >&2
+    echo "Install Homebrew first:" >&2
+    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"" >&2
+    echo "Then re-run this installer." >&2
+    exit 1
+  fi
+  echo "Installing Bash 4+ via Homebrew (one-time setup)..."
+  brew install bash || { echo "brew install bash failed" >&2; exit 1; }
+  brew_prefix="$(brew --prefix 2>/dev/null)"
+  if [ -n "$brew_prefix" ] && [ -x "$brew_prefix/bin/bash" ]; then
+    exec "$brew_prefix/bin/bash" "$0" "$@"
+  fi
+  for candidate in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+    if [ -x "$candidate" ]; then
+      exec "$candidate" "$0" "$@"
+    fi
+  done
+  echo "Homebrew bash installed but not found in expected paths." >&2
+  exit 1
+fi
+
 set -euo pipefail
 
 # ── Parse arguments ──


### PR DESCRIPTION
## What

`install-macos.sh` and `dream-macos.sh` run under macOS's system `/bin/bash` (3.2.57 — unchanged since 2007 for GPL licensing reasons). Both files then `source` libs under `installers/macos/lib/` that use Bash-4+ syntax (`declare -A`, etc.). On a fresh macOS machine without a modern Bash installed, the installer crashes with a cryptic parser error before any user-facing output, leaving the user wondering why the installer "did nothing".

## Why

macOS will never ship Bash ≥ 4 out of the box. The only path forward for any Bash-4-dependent tool is to either vendor its own bash, re-exec under Homebrew's bash, or refuse to run on stock systems. This project already decided at the `dream-cli` level to require Bash 4+, so the installer needs to solve the same problem as the first thing it does.

## How

A top-of-file guard in both `install-macos.sh` and `dream-macos.sh`, placed **before** `set -euo pipefail` and **before** any `source` statement. The guard uses only Bash-3.2-safe constructs: `[ -x ... ]`, `${BASH_VERSINFO[0]:-0}`, POSIX `command -v`, plain indexed arrays, `exec`.

Algorithm:
1. If `BASH_VERSINFO[0] >= 4`, continue (no-op).
2. Else, build a candidate list of known Homebrew bash paths. If `brew` is already on `PATH`, query `brew --prefix` and prepend `$brew_prefix/bin/bash` — this handles non-standard Homebrew prefixes (e.g. external-drive installs) that the two hardcoded paths would miss.
3. Try each candidate in order. First executable one wins; `exec` replaces the process.
4. If no candidate resolves and `brew` is missing, print actionable Homebrew install instructions and exit 1. No auto-install of Homebrew itself — too invasive to do silently.
5. If `brew` is present but no bash found, `brew install bash`, then re-query `brew --prefix` and re-try the candidate list.
6. If all else fails, exit 1 with a clear "Homebrew bash installed but not found in expected paths" message.

## Testing

- `bash -n` on both files under stock macOS `/bin/bash` 3.2.57 — no syntax errors. (Important: the guard itself must parse on 3.2, because it's responsible for escaping to a newer Bash.)

- `shellcheck` — clean on the new code in both files. Only pre-existing `SC2153` on `OLLAMA_PID` (line 166 of `install-macos.sh`) remains, unchanged.

- **Manual validation on macOS Apple Silicon with a custom Homebrew prefix** (`/Volumes/X/homebrew` on an external drive): the initial guard version that probed only `/opt/homebrew/bin/bash` and `/usr/local/bin/bash` FAILED on this environment with "Homebrew bash installed but not found in expected paths." That bug was fixed during manual testing by adding the `brew --prefix` lookup — the current code handles this case correctly. Installer subsequently completed all 6 phases in 2m 37s on the same machine.

## Platform Impact

- **macOS** (both Apple Silicon and Intel, both standard and custom Homebrew prefixes): this is the only platform affected and the only platform the guard runs on. ✓
- **Linux**: not touched. `install.sh` and the Linux phases under `installers/phases/` are not modified. ✓
- **Windows / WSL2**: not touched. The Windows installer is a separate PowerShell script. ✓