### PR TITLE
fix(extensions): clean up stale progress files on disable/uninstall

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -1165,6 +1165,9 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
 
         os.rename(str(enabled_compose), str(disabled_compose))
 
+        progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"
+        progress_file.unlink(missing_ok=True)
+
     logger.info("Disabled extension: %s", service_id)
 
     message = (
@@ -1223,6 +1226,9 @@ def uninstall_extension(service_id: str, include_data_info: bool = Query(True), 
         except OSError as e:
             logger.error("Failed to remove extension %s: %s", service_id, e)
             raise HTTPException(status_code=500, detail=f"Failed to remove extension files: {e}")
+
+        progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"
+        progress_file.unlink(missing_ok=True)
 
     logger.info("Uninstalled extension: %s", service_id)
     return {

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -632,6 +632,22 @@ class TestDisableExtension:
         assert (user_dir / "my-ext" / "compose.yaml.disabled").exists()
         assert not (user_dir / "my-ext" / "compose.yaml").exists()
 
+    def test_disable_unlinks_progress_file(self, test_client, monkeypatch, tmp_path):
+        """Disable removes the stale progress file so status reflects reality."""
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+        progress_file = tmp_path / "extension-progress" / "my-ext.json"
+        progress_file.parent.mkdir(parents=True, exist_ok=True)
+        progress_file.write_text('{"status": "started", "updated_at": "2026-04-10T00:00:00"}')
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/disable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert not progress_file.exists()
+
     def test_disable_already_disabled_409(self, test_client, monkeypatch, tmp_path):
         """409 when extension is already disabled."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
@@ -716,6 +732,22 @@ class TestUninstallExtension:
         data = resp.json()
         assert data["action"] == "uninstalled"
         assert not (user_dir / "my-ext").exists()
+
+    def test_uninstall_unlinks_progress_file(self, test_client, monkeypatch, tmp_path):
+        """Uninstall removes the stale progress file so status reflects reality."""
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=False)
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+        progress_file = tmp_path / "extension-progress" / "my-ext.json"
+        progress_file.parent.mkdir(parents=True, exist_ok=True)
+        progress_file.write_text('{"status": "started", "updated_at": "2026-04-10T00:00:00"}')
+
+        resp = test_client.delete(
+            "/api/extensions/my-ext",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert not progress_file.exists()
 
     def test_uninstall_rejects_enabled_400(self, test_client, monkeypatch, tmp_path):
         """400 when extension is still enabled."""


### PR DESCRIPTION
## What

Progress files in `data/extension-progress/{service_id}.json` persisted through `disable_extension` and `uninstall_extension`. Because `_compute_extension_status` reads the progress file **before** inspecting the actual compose-file state, a stale `"status": "started"` entry would override the real "disabled" or "uninstalled" state — the dashboard UI would show "installing" for an extension the user had just removed, for up to 5 minutes.

## Why

The stale window is a direct UX regression: the user clicks "disable" or "remove", sees a success toast, then the same extension's card flips back to a spinner labeled "installing". The only self-heal path is `_cleanup_stale_progress()` which removes `"started"` entries after 900s (15 minutes) — too long for an operation the user considers finished immediately.

## How

Two small edits in `routers/extensions.py`, both **inside** `_extensions_lock()`, immediately after the main mutation succeeds:

```python
progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"
progress_file.unlink(missing_ok=True)
```

Placed in:
- `disable_extension` — after the `os.rename(compose.yaml → compose.yaml.disabled)` call
- `uninstall_extension` — after the `shutil.rmtree(ext_dir)` call (uninstall already stops the container pre-lock, then removes state under the lock)

Path construction is byte-identical to the existing helpers `_read_progress`, `_write_initial_progress`, `_cleanup_stale_progress` — no normalization drift.

Let-it-crash: `missing_ok=True` handles the common "no progress file exists" case. A real `OSError` (permission denied, disk error) propagates naturally as a 500 — the project's error-handling philosophy rejects silent swallowing.

`service_id` is validated at the router entry point by `_validate_service_id()` against `^[a-z0-9][a-z0-9_-]*$`, so the path-interpolation is safe from traversal by construction.

## Testing

Two new tests in `tests/test_extensions.py`:

- `TestDisableExtension::test_disable_unlinks_progress_file` — pre-creates a fake `{"status": "started"}` entry at `tmp_path/extension-progress/my-ext.json`, POSTs `/api/extensions/my-ext/disable`, asserts HTTP 200 AND `progress_file.exists()` is false.
- `TestUninstallExtension::test_uninstall_unlinks_progress_file` — same pattern, DELETEs `/api/extensions/my-ext`.

Both tests would fail if the unlink is removed — they actively guard against future regression.

**End-to-end verification on a live macOS install**: seeded a real stale progress file for `chromadb` with `"status": "started"`, called `GET /api/extensions/chromadb/progress` and confirmed the stale "started" entry came back, then `POST /api/extensions/chromadb/enable` and `POST /api/extensions/chromadb/disable`, confirmed the progress file was unlinked on disk, and `GET /api/extensions/chromadb/progress` now returns `{"status": "idle"}` instead of the stale entry. `GET /api/extensions/catalog` shows the chromadb entry as `disabled` rather than `installing`.

Full test suite: `pytest tests/test_extensions.py -k "disable or uninstall"` → 14 passed (2 new + 12 pre-existing). Full file: 99 passed, 0 failed.

## Platform Impact

Pure Python + pathlib. Identical behavior on macOS, Linux Docker, Windows WSL2. `./data:/data` is mounted rw into the dashboard-api container, so the unlink inside the container reaches the host filesystem directly — no host-agent indirection needed (unlike the `.compose-flags` case).