### PR TITLE
fix: remove stray PUA-unicode file from repo root

### DIFF
--- a/ithpipesg
+++ b/ithpipesg
@@ -1,1 +1,0 @@
-  "model": "model",


### PR DESCRIPTION
## What
Removes a 20-byte orphan file named `ith<U+F07C>pipes<U+F07C>g` from the repo root.

## Why
The file was accidentally committed alongside an unrelated Windows CUDA smoke-test tag fix. Its name contains two `U+F07C` Private-Use-Area Unicode codepoints — a signature of a paste accident where a glyph-rendered `|` was interpreted as a filename rather than a pipe. Its content is a stray JSON line fragment (`  "model": "model",\n`).

## How
Single-file deletion of the tracked blob. No code changes.

## Testing
- `git ls-files | grep -a pipes` → empty after the fix
- `ls -la` at repo root → no stray file

## Platform Impact
- **macOS:** Unaffected functionally; file was cosmetic junk in Finder/ls listings. Fresh clones no longer ship it.
- **Linux:** Same as macOS. ext4/btrfs/xfs tolerate the filename, but `pathlib` under UTF-8-strict locales can raise `UnicodeDecodeError` when walking directories — now avoided.
- **Windows/WSL2:** Highest-impact platform. Git-for-Windows and several NTFS-backed archivers/MSI tools reject paths containing Private-Use-Area codepoints. Removing the file removes a latent clone/packaging risk.