### PR TITLE
fix(dashboard): use theme token for info tooltip background

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -515,7 +515,7 @@ const FeatureCard = memo(function FeatureCard({ icon: Icon, title, description, 
           <CircleHelp size={13} />
         </div>
 
-        <div className="pointer-events-none absolute bottom-[calc(100%+0.45rem)] right-0 z-20 w-52 rounded-lg border border-white/10 bg-[#0d0b12]/95 px-3 py-2 text-[11px] leading-4 text-theme-text-muted opacity-0 shadow-2xl transition-all duration-150 group-hover/info:translate-y-0 group-hover/info:opacity-100 translate-y-1">
+        <div className="pointer-events-none absolute bottom-[calc(100%+0.45rem)] right-0 z-20 w-52 rounded-lg border border-white/10 bg-theme-card/95 px-3 py-2 text-[11px] leading-4 text-theme-text-muted opacity-0 shadow-2xl transition-all duration-150 group-hover/info:translate-y-0 group-hover/info:opacity-100 translate-y-1">
           {description}
           {status === 'disabled' && hint && (
             <p className="mt-2 font-mono text-[10px] text-theme-text-secondary">{hint}</p>


### PR DESCRIPTION
## What
`Dashboard.jsx:518` swaps a hardcoded `bg-[#0d0b12]/95` literal on the FeatureCard info tooltip for the `bg-theme-card/95` theme token.

## Why
A prior commit migrated `Extensions.jsx` to theme tokens but was scoped exclusively to that file. `Dashboard.jsx` retained one residual hardcoded literal — the info tooltip — which rendered as a near-black rectangle against the page background on every non-dark theme (`light`, `lemonade`, `arctic`).

## How
One-line substitution. Matches the migration pattern applied earlier to the equivalent `Extensions.jsx` tooltip.

## Testing
- `grep '#0d0b12' dream-server/extensions/services/dashboard/src/` → empty (no residuals)
- `grep 'bg-theme-card/95' Dashboard.jsx` → single match at L518

## Platform Impact
- **macOS / Linux / Windows:** Identical. Static JSX class string. Users on `light`, `lemonade`, or `arctic` themes now see the info tooltip blend with the page surface instead of rendering as a dark rectangle.