### PR TITLE
fix(extensions): compose corrections for baserow, aider, continue

### DIFF
--- a/resources/dev/extensions-library/services/aider/compose.yaml
+++ b/resources/dev/extensions-library/services/aider/compose.yaml
@@ -27,7 +27,8 @@ services:
           memory: 512M
     networks:
       - dream-network
-    command: ["sh", "-c", "echo 'Run: docker compose run --rm aider <files>'"]
+    entrypoint: ["echo"]
+    command: ["Aider is a CLI tool. Run: docker compose run --rm aider <files>"]
 
 # Named volumes removed — using bind mounts only
 

--- a/resources/dev/extensions-library/services/baserow/compose.yaml
+++ b/resources/dev/extensions-library/services/baserow/compose.yaml
@@ -39,7 +39,7 @@ services:
     networks:
       - dream-network
     healthcheck:
-      test: ["CMD", "curl", "-sf", "http://127.0.0.1:80/api/_health/"]
+      test: ["CMD", "curl", "-sf", "-H", "Host: localhost:3007", "http://127.0.0.1:80/api/_health/"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/resources/dev/extensions-library/services/continue/compose.yaml
+++ b/resources/dev/extensions-library/services/continue/compose.yaml
@@ -22,8 +22,8 @@ services:
       - CONTINUE_PORT=${CONTINUE_PORT:-8890}
     volumes:
       - ./data/continue:/usr/share/nginx/html:rw
-      - ./extensions/services/continue/config/continue/nginx.conf:/etc/nginx/conf.d/default.conf:ro
-      - ./extensions/services/continue/config/continue/entrypoint.sh:/docker-entrypoint.d/50-continue-init.sh:ro
+      - ./config/continue/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./config/continue/entrypoint.sh:/docker-entrypoint.d/50-continue-init.sh:ro
     ports:
       - "127.0.0.1:${CONTINUE_PORT:-8890}:8080"
     networks:


### PR DESCRIPTION
## What
Three independent fixes to library extension compose files, bundled into one PR because they all live under `resources/dev/extensions-library/services/` and touch disjoint files.

## 1. baserow — healthcheck Host header (404 → unhealthy regression)
Adds `-H "Host: localhost:3007"` to the healthcheck curl. Baserow embeds Caddy which routes on Host header matching `BASEROW_PUBLIC_URL` (default `http://localhost:3007`). The previous healthcheck sent `Host=127.0.0.1`, failed the named matcher, returned 404 `Site not found`, and the container was marked unhealthy despite the Django/Caddy backend responding correctly. Caddy's `{http.request.host}` placeholder strips the port before the matcher, so the explicit port is safe and forward-defensive if the Caddyfile ever uses `{http.request.hostport}`.

## 2. aider — entrypoint override (crash-on-start)
Overrides the image entrypoint to `["echo"]` so the compose `command:` becomes argv to `echo`. The `paulgauthier/aider` image declares `ENTRYPOINT ["/venv/bin/aider"]`, so the previous `command: ["sh", "-c", "echo ..."]` was appended as argv to aider and crashed with `Unable to open config file: sh` (exit 2). After the fix the container becomes a one-shot helper-message printer that exits 0. Combined with the pre-existing `restart: "no"`, no crash loop.

## 3. continue — bind-mount host paths (OCI mount failure)
Rewrites two bind-mount host paths from `./extensions/services/continue/config/continue/...` to `./config/continue/...`. Library extensions install flat to `data/user-extensions/<id>/`, so compose-relative paths must be relative to that install dir. The previous paths resolved to nonexistent files and Docker failed container init with an OCI mount error. Container mount targets (`/etc/nginx/conf.d/default.conf`, `/docker-entrypoint.d/50-continue-init.sh`) are unchanged; only host paths are corrected.

## Testing
- All three `compose.yaml` files parse with PyYAML.
- baserow healthcheck readback confirms `['CMD', 'curl', '-sf', '-H', 'Host: localhost:3007', 'http://127.0.0.1:80/api/_health/']`.
- aider `entrypoint=['echo']`, `command` starts with "Aider is a CLI tool", `restart: "no"` preserved.
- continue volumes use `./config/continue/nginx.conf` and `./config/continue/entrypoint.sh`; source files exist at `resources/dev/extensions-library/services/continue/config/continue/`.

## Platform Impact
All three fixes are pure Docker Compose YAML edits. They affect container internals and behave identically on macOS Docker Desktop, Linux Docker, and Windows WSL2 Docker Desktop.

## Scope note
Bundled to reduce review overhead — one reviewer familiar with the extensions library can scan all three fixes in one pass. Happy to split into three atomic PRs if that's preferred for bisect/revert clarity.