### PR TITLE
fix(resolve-compose-stack): select macOS overlay on Darwin hosts

### DIFF
--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -58,6 +58,7 @@ fi
 "$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" <<'PY'
 import os
 import pathlib
+import platform
 import sys
 import json
 
@@ -70,6 +71,9 @@ skip_broken = (sys.argv[6] or "false").lower() == "true"
 dream_mode = os.environ.get("DREAM_MODE", "local").lower()
 gpu_count = int(sys.argv[7] or "1")
 
+IS_DARWIN = platform.system() == "Darwin"
+APPLE_OVERLAY = "installers/macos/docker-compose.macos.yml" if IS_DARWIN else "docker-compose.apple.yml"
+
 def existing(overlays):
     return all((script_dir / f).exists() for f in overlays)
 
@@ -80,9 +84,9 @@ if profile_overlays and existing(profile_overlays):
     resolved = profile_overlays
     primary = profile_overlays[-1]
 elif tier in {"AP_ULTRA", "AP_PRO", "AP_BASE"}:
-    if existing(["docker-compose.base.yml", "docker-compose.apple.yml"]):
-        resolved = ["docker-compose.base.yml", "docker-compose.apple.yml"]
-        primary = "docker-compose.apple.yml"
+    if existing(["docker-compose.base.yml", APPLE_OVERLAY]):
+        resolved = ["docker-compose.base.yml", APPLE_OVERLAY]
+        primary = APPLE_OVERLAY
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"
@@ -91,9 +95,9 @@ elif tier in {"SH_LARGE", "SH_COMPACT"}:
         resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
         primary = "docker-compose.amd.yml"
 elif gpu_backend == "apple":
-    if existing(["docker-compose.base.yml", "docker-compose.apple.yml"]):
-        resolved = ["docker-compose.base.yml", "docker-compose.apple.yml"]
-        primary = "docker-compose.apple.yml"
+    if existing(["docker-compose.base.yml", APPLE_OVERLAY]):
+        resolved = ["docker-compose.base.yml", APPLE_OVERLAY]
+        primary = APPLE_OVERLAY
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"


### PR DESCRIPTION
## What
`resolve-compose-stack.sh` now selects `installers/macos/docker-compose.macos.yml` on Darwin hosts instead of `docker-compose.apple.yml`. Linux and Windows (WSL2) hosts are unchanged — they continue to select `docker-compose.apple.yml` for `--gpu-backend apple`.

## Why
The macOS installer writes `.compose-flags` using `installers/macos/docker-compose.macos.yml`. That overlay:
- Sets `llama-server` to `replicas: 0` with a busybox placeholder (llama-server runs natively on macOS via Metal, not in Docker)
- Adds the `llama-server-ready` sidecar that polls `host.docker.internal:${OLLAMA_PORT}` so `open-webui.depends_on` can bridge the native host process
- Overrides `dashboard-api` env (`OLLAMA_URL=http://host.docker.internal:8080`, `GPU_BACKEND=apple`, `HOST_RAM_GB`)

The runtime cache-regeneration path, however, went through `resolve-compose-stack.sh` which hardcoded `docker-compose.apple.yml`. That file tries to run llama-server as a real Docker container using an image tag with no usable `linux/arm64` variant, drops the dashboard-api env overrides, and breaks `open-webui` startup ordering. Any cache invalidation on macOS (`dream enable/disable`, template apply, manual `.compose-flags` deletion) silently produced the wrong stack.

## How
Introduces a module-level constant in the Python heredoc:
```python
IS_DARWIN = platform.system() == "Darwin"
APPLE_OVERLAY = "installers/macos/docker-compose.macos.yml" if IS_DARWIN else "docker-compose.apple.yml"
```
Substituted in both branches that previously hardcoded the apple overlay (the `AP_*` tier branch and the `gpu_backend == "apple"` branch). The gate is `platform.system() == "Darwin"`, so Linux and Windows continue to see `docker-compose.apple.yml` unchanged.

## Testing
- `bash -n` clean
- Python heredoc extracted and `compile()`-validated
- **Darwin smoke test:** `bash scripts/resolve-compose-stack.sh --script-dir "$(pwd)" --tier AP_BASE --gpu-backend apple` → output begins `-f docker-compose.base.yml -f installers/macos/docker-compose.macos.yml ...` ✓
- **Linux regression test:** `--tier SH_LARGE --gpu-backend amd` → output begins `-f docker-compose.base.yml -f docker-compose.amd.yml ...` (unchanged)
- `shellcheck` clean

## Platform Impact
- **macOS:** Cache regeneration now produces the overlay the installer wrote. `llama-server` stays native. Any cache-invalidating action is safe.
- **Linux (NVIDIA/AMD/CPU/Apple CI):** No change. `platform.system() != "Darwin"` preserves previous resolver output byte-for-byte.
- **Windows (WSL2):** Inherits Linux behavior.

## Known Considerations
Four other call sites still hardcode `docker-compose.apple.yml` — `scripts/bootstrap-upgrade.sh:275`, `scripts/classify-hardware.sh:80`, `manifest.json:58`, `config/hardware-classes.json:121,136`. These are pre-existing, not regressions from this PR. Deferred to a follow-up to avoid colliding with an in-flight PR that also touches `bootstrap-upgrade.sh`.