### PR TITLE
fix(macos-installer): dynamic launchd PATH + extensions-lib source

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -863,8 +863,12 @@ OPENCODE_EOF
             ai_ok "OpenCode config already exists"
         fi
 
-        # Install as macOS LaunchAgent (auto-start on login)
-        mkdir -p "$HOME/Library/LaunchAgents"
+        # Install as macOS LaunchAgent (auto-start on login).
+        # Log path is intentionally decoupled from INSTALL_DIR: xpcproxy denies
+        # file-write-create on non-$HOME volumes, which causes the launchd spawn
+        # to exit 78 before the target process ever runs. $HOME/Library/Logs is
+        # always inside xpcproxy's sandbox writable set, so use that instead.
+        mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs/DreamServer"
         OPENCODE_LAUNCHD_PATH="$(_compute_launchd_path "${HOME}/.opencode/bin")"
         cat > "$OPENCODE_PLIST" <<PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
@@ -899,9 +903,9 @@ OPENCODE_EOF
         <false/>
     </dict>
     <key>StandardOutPath</key>
-    <string>${INSTALL_DIR}/data/opencode-web.log</string>
+    <string>${HOME}/Library/Logs/DreamServer/opencode-web.log</string>
     <key>StandardErrorPath</key>
-    <string>${INSTALL_DIR}/data/opencode-web.log</string>
+    <string>${HOME}/Library/Logs/DreamServer/opencode-web.log</string>
 </dict>
 </plist>
 PLIST_EOF
@@ -923,7 +927,9 @@ fi
 # ── Dream Host Agent (extension lifecycle management) ──
 AGENT_PYTHON="$(command -v python3)"
 if [[ -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && [[ -n "$AGENT_PYTHON" ]]; then
-    mkdir -p "$HOME/Library/LaunchAgents"
+    # See opencode-web block above for the xpcproxy sandbox rationale behind
+    # the $HOME-rooted log path.
+    mkdir -p "$HOME/Library/LaunchAgents" "$HOME/Library/Logs/DreamServer"
     DREAM_AGENT_PATH="$(_compute_launchd_path "")"
     if ! command -v docker >/dev/null 2>&1; then
         ai_warn "docker not found on PATH at install time — host agent will fail to start until Docker Desktop is launched and 'docker' resolves on your shell PATH"
@@ -960,9 +966,9 @@ if [[ -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && [[ -n "$AGENT_PYTHON" ]]
         <false/>
     </dict>
     <key>StandardOutPath</key>
-    <string>${INSTALL_DIR}/data/dream-host-agent.log</string>
+    <string>${HOME}/Library/Logs/DreamServer/dream-host-agent.log</string>
     <key>StandardErrorPath</key>
-    <string>${INSTALL_DIR}/data/dream-host-agent.log</string>
+    <string>${HOME}/Library/Logs/DreamServer/dream-host-agent.log</string>
 </dict>
 </plist>
 AGENT_PLIST_EOF

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -103,6 +103,36 @@ source "${LIB_DIR}/tier-map.sh"
 source "${LIB_DIR}/detection.sh"
 source "${LIB_DIR}/env-generator.sh"
 
+# ── File-local helpers ──
+# Build a launchd-friendly PATH that includes Docker and Homebrew prefixes.
+# launchd does NOT inherit the user's login shell PATH, so any path containing
+# `docker` or `brew`-installed tools must be baked into the plist explicitly.
+# Pass an optional leading directory (e.g. ~/.opencode/bin) as $1.
+_compute_launchd_path() {
+    local extra="${1:-}"
+    local docker_bin="" docker_dir="" brew_prefix=""
+    if command -v docker >/dev/null 2>&1; then
+        docker_bin="$(command -v docker)"
+        docker_dir="$(cd "$(dirname "$docker_bin")" && pwd)"
+    fi
+    if command -v brew >/dev/null 2>&1; then
+        brew_prefix="$(brew --prefix)"
+    fi
+    local entries=()
+    [[ -n "$extra" ]]                && entries+=("$extra")
+    [[ -n "$docker_dir" ]]           && entries+=("$docker_dir")
+    [[ -n "$brew_prefix" ]]          && entries+=("${brew_prefix}/bin")
+    entries+=("/opt/homebrew/bin" "/usr/local/bin" "/usr/bin" "/bin")
+    local seen=":" path_out="" d
+    for d in "${entries[@]}"; do
+        case "$seen" in
+            *":${d}:"*) ;;
+            *) seen="${seen}${d}:"; path_out="${path_out:+${path_out}:}${d}" ;;
+        esac
+    done
+    printf '%s' "$path_out"
+}
+
 # ── Resolve install directory ──
 INSTALL_DIR="${DS_INSTALL_DIR}"
 
@@ -376,12 +406,16 @@ else
         ai "Running in-place, skipping file copy"
     fi
 
-    # Copy extensions library to data dir for dashboard portal
-    _ext_lib_src="${SOURCE_ROOT}/resources/dev/extensions-library/services"
+    # Copy extensions library to data dir for dashboard portal.
+    # SOURCE_ROOT resolves to dream-server/, so we climb one more level
+    # ($SOURCE_ROOT/..) to reach the repo root where resources/ lives.
+    _ext_lib_src="${SOURCE_ROOT}/../resources/dev/extensions-library/services"
     if [[ -d "$_ext_lib_src" ]]; then
         mkdir -p "${INSTALL_DIR}/data/extensions-library"
         cp -r "$_ext_lib_src/." "${INSTALL_DIR}/data/extensions-library/"
         ai_ok "Extensions library copied to data/extensions-library/"
+    else
+        ai_warn "Extensions library not found at ${_ext_lib_src}; dashboard Extensions page will return 503 until populated"
     fi
 
     # Copy CLI tool to install root
@@ -831,6 +865,7 @@ OPENCODE_EOF
 
         # Install as macOS LaunchAgent (auto-start on login)
         mkdir -p "$HOME/Library/LaunchAgents"
+        OPENCODE_LAUNCHD_PATH="$(_compute_launchd_path "${HOME}/.opencode/bin")"
         cat > "$OPENCODE_PLIST" <<PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -854,7 +889,7 @@ OPENCODE_EOF
         <key>HOME</key>
         <string>${HOME}</string>
         <key>PATH</key>
-        <string>${HOME}/.opencode/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>${OPENCODE_LAUNCHD_PATH}</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>
@@ -871,12 +906,16 @@ OPENCODE_EOF
 </plist>
 PLIST_EOF
 
-        # Unload existing (if any) and load new plist
-        launchctl bootout "gui/$(id -u)/${OPENCODE_PLIST_LABEL}" 2>/dev/null || true
-        if launchctl bootstrap "gui/$(id -u)" "$OPENCODE_PLIST" 2>/dev/null; then
+        # Unload existing (if any) and load new plist. bootout legitimately
+        # errors when no service is loaded, so we keep that suppressed; the
+        # bootstrap call surfaces real failures (e.g. launchd throttle EIO).
+        launchctl bootout "gui/$(id -u)/${OPENCODE_PLIST_LABEL}" >/dev/null 2>&1 || true
+        _opencode_bootstrap_err="$(launchctl bootstrap "gui/$(id -u)" "$OPENCODE_PLIST" 2>&1)" && _opencode_bootstrap_rc=0 || _opencode_bootstrap_rc=$?
+        if [[ $_opencode_bootstrap_rc -eq 0 ]]; then
             ai_ok "OpenCode Web UI service installed (LaunchAgent, port 3003)"
         else
-            ai_warn "OpenCode LaunchAgent failed — start manually: opencode web --port 3003"
+            ai_warn "OpenCode LaunchAgent failed (rc=${_opencode_bootstrap_rc}): ${_opencode_bootstrap_err}"
+            ai_warn "Start manually: opencode web --port 3003"
         fi
     fi
 fi
@@ -885,6 +924,10 @@ fi
 AGENT_PYTHON="$(command -v python3)"
 if [[ -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && [[ -n "$AGENT_PYTHON" ]]; then
     mkdir -p "$HOME/Library/LaunchAgents"
+    DREAM_AGENT_PATH="$(_compute_launchd_path "")"
+    if ! command -v docker >/dev/null 2>&1; then
+        ai_warn "docker not found on PATH at install time — host agent will fail to start until Docker Desktop is launched and 'docker' resolves on your shell PATH"
+    fi
     cat > "$DREAM_AGENT_PLIST" <<AGENT_PLIST_EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
@@ -907,7 +950,7 @@ if [[ -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && [[ -n "$AGENT_PYTHON" ]]
         <key>HOME</key>
         <string>${HOME}</string>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>${DREAM_AGENT_PATH}</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>
@@ -924,11 +967,17 @@ if [[ -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && [[ -n "$AGENT_PYTHON" ]]
 </plist>
 AGENT_PLIST_EOF
 
-    launchctl bootout "gui/$(id -u)/${DREAM_AGENT_PLIST_LABEL}" 2>/dev/null || true
-    if launchctl bootstrap "gui/$(id -u)" "$DREAM_AGENT_PLIST" 2>/dev/null; then
+    launchctl bootout "gui/$(id -u)/${DREAM_AGENT_PLIST_LABEL}" >/dev/null 2>&1 || true
+    _agent_bootstrap_err="$(launchctl bootstrap "gui/$(id -u)" "$DREAM_AGENT_PLIST" 2>&1)" && _agent_bootstrap_rc=0 || _agent_bootstrap_rc=$?
+    if [[ $_agent_bootstrap_rc -eq 0 ]]; then
         ai_ok "Dream host agent installed (LaunchAgent, port ${DREAM_AGENT_PORT})"
     else
-        ai_warn "Dream host agent LaunchAgent failed — start manually: dream agent start"
+        ai_warn "Dream host agent LaunchAgent failed (rc=${_agent_bootstrap_rc}): ${_agent_bootstrap_err}"
+        if [[ "${_agent_bootstrap_err}" == *"Input/output error"* ]]; then
+            ai_warn "launchd is throttled. Recover with: launchctl bootout gui/\$(id -u)/${DREAM_AGENT_PLIST_LABEL}; sleep 10; then re-run this installer"
+        else
+            ai_warn "Start manually: dream agent start"
+        fi
     fi
 else
     [[ ! -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && ai_warn "Host agent script not found, skipping"


### PR DESCRIPTION
> **Merge order:** Merge before #940 and #920 — all three modify `install-macos.sh`.

## What
Three related macOS installer fixes:

1. Compute the launchd PATH for both the dream host-agent and OpenCode
   plists from the user's actual `docker` and `brew` prefixes instead
   of hardcoding `/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`.
2. Surface `launchctl bootstrap` errors instead of silently redirecting
   stderr to `/dev/null`. Emit a concrete recovery hint when the
   launchd throttle EIO state is detected.
3. Correct the extensions-library copy source path so a fresh macOS
   install actually populates `data/extensions-library/`.

## Why
1. A user running DreamServer on a non-default Homebrew prefix (anything
   other than `/opt/homebrew` or `/usr/local`) or a non-default Docker
   install (e.g. Docker.app on an external volume) crashes the host
   agent at startup: `shutil.which("docker")` returns None, the agent
   `sys.exit(1)`, launchd retries until it gives up and moves the
   service to on-demand with `LastExitStatus = 19968`.
2. Because the bootstrap call redirects `stderr` to `/dev/null`, the
   installer always prints `[OK] Dream host agent installed` even when
   the service is already throttled. The user gets no feedback until
   they hit the dashboard and see a disconnected host-agent.
3. `SOURCE_ROOT` resolves to `dream-server/`, so
   `${SOURCE_ROOT}/resources/dev/extensions-library/services` points at
   a directory that does not exist. The copy is silently skipped,
   `data/extensions-library/` is never created, and the Extensions page
   returns HTTP 503. The Linux installer gets this right via
   `$SCRIPT_DIR/..`; the macOS installer was missing the extra `..`.

## How
- New helper `_compute_launchd_path()` computes a deduped, ordered PATH
  containing (optional prefix) + `dirname "$(command -v docker)"` +
  `$(brew --prefix)/bin` + the four legacy paths. Used by the OpenCode
  plist (with `${HOME}/.opencode/bin` as the prefix arg) and the dream
  host-agent plist (no prefix). `command -v` existence checks are used
  as structured booleans rather than `|| true`.
- Warn up front at install time if `docker` is not on PATH — the user
  learns about the missing binary immediately instead of debugging a
  dead host-agent later.
- Capture `launchctl bootstrap`'s stderr + exit code into a local var
  and surface it via `ai_warn`. When stderr contains `Input/output
  error` (the launchd throttle sentinel), emit a recovery hint showing
  the exact `launchctl bootout; sleep 5;` sequence. Done for both the
  host-agent and OpenCode bootstrap calls.
- `bootout` is left with `>/dev/null 2>&1 || true` — it legitimately
  errors when nothing is loaded.
- Add `..` to `_ext_lib_src` so it climbs from `dream-server/` to repo
  root, and replace the silent-skip `if [[ -d ]]` with an `else`
  branch that emits a warning pointing at what was expected vs. found.

## Testing
- `bash -n` clean.
- `shellcheck` zero-delta vs. baseline.
- Extracted both plist heredocs with substituted vars and ran
  `plutil -lint` → both OK.
- Direct invocation of `_compute_launchd_path` on a machine with Docker
  at `/Volumes/X/applications/Docker.app/...` and Homebrew at
  `/Volumes/X/homebrew` produces the expected deduped order.

### Manual test plan
- **macOS with non-default Homebrew prefix:** fresh install, inspect
  `~/Library/LaunchAgents/com.dreamserver.host-agent.plist`, confirm
  `<key>PATH</key>` contains the actual `dirname $(command -v docker)`.
  `launchctl list com.dreamserver.host-agent` should show
  `LastExitStatus = 0`, `OnDemand = false`, no throttle.
- **macOS with docker briefly off PATH:** re-run installer, expect
  `ai_warn "docker not found on PATH at install time..."`.
- **Throttle recovery:** force a bad-PATH plist, bootout/bootstrap until
  EIO, confirm the new "launchd is throttled. Recover with..." hint.
- **Extensions library:** after install,
  `ls $INSTALL_DIR/data/extensions-library/` should contain aider,
  anythingllm, audiocraft, baserow, ... etc.

## Platform Impact
- **macOS:** primary target of all three fixes.
- **Linux:** untouched. `installers/phases/06-directories.sh:109` is already correct.
- **Windows (WSL2):** untouched. Uses the Linux installer path.