### PR TITLE
fix(models): populate SHA256 catalog + verify every download part

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1063,7 +1063,6 @@ class AgentHandler(BaseHTTPRequestHandler):
 
         gguf_file = body.get("gguf_file", "")
         gguf_url = body.get("gguf_url", "")
-        gguf_sha256 = body.get("gguf_sha256", "")
         gguf_parts = body.get("gguf_parts", [])
 
         if not gguf_file or (not gguf_url and not gguf_parts):
@@ -1079,9 +1078,12 @@ class AgentHandler(BaseHTTPRequestHandler):
         else:
             download_plan = [(gguf_file, gguf_url)]
 
-        # Validate against library (prevent arbitrary URL downloads)
+        # Validate against library (prevent arbitrary URL downloads).
+        # Also harvest expected SHA256s keyed by filename so verification can
+        # cover every part of split-file downloads, not just single-file models.
         library_path = INSTALL_DIR / "config" / "model-library.json"
         allowed = False
+        expected_sha_by_file: dict = {}
         if library_path.exists():
             try:
                 lib = json.loads(library_path.read_text(encoding="utf-8"))
@@ -1090,12 +1092,21 @@ class AgentHandler(BaseHTTPRequestHandler):
                         continue
                     if gguf_parts:
                         # Verify every (file, url) in the request matches the library
-                        lib_parts = {(p["file"], p["url"]) for p in m.get("gguf_parts", [])}
+                        lib_parts_meta = {
+                            (p["file"], p["url"]): p.get("sha256", "")
+                            for p in m.get("gguf_parts", [])
+                            if p.get("file") and p.get("url")
+                        }
                         req_parts = set(download_plan)
-                        if req_parts and req_parts <= lib_parts:
+                        if req_parts and req_parts <= set(lib_parts_meta.keys()):
                             allowed = True
+                            expected_sha_by_file = {
+                                file: lib_parts_meta[(file, url)]
+                                for file, url in download_plan
+                            }
                     elif m.get("gguf_url") == gguf_url:
                         allowed = True
+                        expected_sha_by_file = {gguf_file: m.get("gguf_sha256", "")}
                     break
             except (json.JSONDecodeError, OSError):
                 pass
@@ -1188,20 +1199,43 @@ class AgentHandler(BaseHTTPRequestHandler):
                             _write_model_status(status_path, "failed", part_label, 0, part_total, "Download failed after 3 attempts")
                             return
 
-                    # Verify SHA256 if provided (single-file only)
-                    if gguf_sha256 and len(download_plan) == 1:
-                        final_target = models_dir / download_plan[0][0]
+                    # Verify SHA256 for every downloaded part. Catalog is the
+                    # source of truth: split-file models carry per-part sha256
+                    # in expected_sha_by_file, single-file models carry one
+                    # entry. Empty checksum -> warn (do not silently skip), so
+                    # missing catalog entries surface during operator review.
+                    import hashlib
+                    for part_idx, (part_file_name, _) in enumerate(download_plan, 1):
+                        expected = expected_sha_by_file.get(part_file_name, "")
+                        final_target = models_dir / part_file_name
+                        if not expected:
+                            logger.warning(
+                                "SHA256 verification skipped for %s: no checksum in model-library.json",
+                                part_file_name,
+                            )
+                            continue
                         final_size = final_target.stat().st_size
-                        _write_model_status(status_path, "verifying", gguf_file, final_size, final_size)
-                        import hashlib
+                        verify_label = (
+                            part_file_name
+                            if len(download_plan) == 1
+                            else f"{part_file_name} (part {part_idx}/{len(download_plan)})"
+                        )
+                        _write_model_status(status_path, "verifying", verify_label, final_size, final_size)
                         sha = hashlib.sha256()
                         with open(final_target, "rb") as f:
                             for chunk in iter(lambda: f.read(1048576), b""):
                                 sha.update(chunk)
                         actual = sha.hexdigest()
-                        if actual != gguf_sha256:
+                        if actual != expected:
                             final_target.unlink(missing_ok=True)
-                            _write_model_status(status_path, "failed", gguf_file, 0, 0, f"SHA256 mismatch: expected {gguf_sha256[:12]}..., got {actual[:12]}...")
+                            _write_model_status(
+                                status_path,
+                                "failed",
+                                part_file_name,
+                                0,
+                                0,
+                                f"SHA256 mismatch: expected {expected[:12]}..., got {actual[:12]}...",
+                            )
                             return
 
                     _write_model_status(status_path, "complete", gguf_file, 0, 0)

--- a/dream-server/config/model-library.json
+++ b/dream-server/config/model-library.json
@@ -7,7 +7,7 @@
       "family": "qwen",
       "gguf_file": "Qwen3.5-2B-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
       "size_mb": 1500,
       "vram_required_gb": 3,
       "context_length": 8192,
@@ -24,7 +24,7 @@
       "family": "phi",
       "gguf_file": "Phi-4-mini-instruct-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/Phi-4-mini-instruct-GGUF/resolve/main/Phi-4-mini-instruct-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "88c00229914083cd112853aab84ed51b87bdf6b9ce42f532d8c85c7c63b1730a",
       "size_mb": 2490,
       "vram_required_gb": 4,
       "context_length": 128000,
@@ -58,7 +58,7 @@
       "family": "gemma4",
       "gguf_file": "gemma-4-E2B-it-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "ac0069ebccd39925d836f24a88c0f0c858d20578c29b21ab7cedce66ee576845",
       "size_mb": 2810,
       "vram_required_gb": 5,
       "context_length": 16384,
@@ -75,7 +75,7 @@
       "family": "deepseek",
       "gguf_file": "DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-7B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-7B-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "78272d8d32084548bd450394a560eb2d70de8232ab96a725769b1f9171235c1c",
       "size_mb": 4680,
       "vram_required_gb": 7,
       "context_length": 32768,
@@ -92,7 +92,7 @@
       "family": "gemma4",
       "gguf_file": "gemma-4-E4B-it-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "dff0ffba4c90b4082d70214d53ce9504a28d4d8d998276dcb3b8881a656c742a",
       "size_mb": 5340,
       "vram_required_gb": 8,
       "context_length": 32768,
@@ -126,7 +126,7 @@
       "family": "phi",
       "gguf_file": "phi-4-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/bartowski/phi-4-GGUF/resolve/main/phi-4-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "009aba717c09d4a35890c7d35eb59d54e1dba884c7c526e7197d9c13ab5911d9",
       "size_mb": 9050,
       "vram_required_gb": 11,
       "context_length": 16384,
@@ -143,7 +143,7 @@
       "family": "deepseek",
       "gguf_file": "DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-14B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-14B-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "67a7933cf2ad596a393c8e13b30bc4da2d50b283e250b78554aed18817eca31c",
       "size_mb": 8990,
       "vram_required_gb": 12,
       "context_length": 32768,
@@ -177,7 +177,7 @@
       "family": "gemma4",
       "gguf_file": "gemma-4-26B-A4B-it-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/ggml-org/gemma-4-26B-A4B-it-GGUF/resolve/main/gemma-4-26B-A4B-it-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "23c6997912cb7fa36147fe05877de73ddbb2a80ff69b18ff171b354dccf2b5b5",
       "size_mb": 18000,
       "vram_required_gb": 22,
       "context_length": 16384,
@@ -211,7 +211,7 @@
       "family": "gemma4",
       "gguf_file": "gemma-4-31B-it-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/ggml-org/gemma-4-31B-it-GGUF/resolve/main/gemma-4-31B-it-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "a20deaf2f8fc27c501f32fadfd538f8f31a76f10f47d5d3eb895f3d1112d752c",
       "size_mb": 19800,
       "vram_required_gb": 24,
       "context_length": 131072,
@@ -228,7 +228,7 @@
       "family": "deepseek",
       "gguf_file": "DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Qwen-32B-GGUF/resolve/main/DeepSeek-R1-Distill-Qwen-32B-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "ca171ca03554ee20cf67ad6b540610ae7eabb95af00c0abd36bb73542e140fb5",
       "size_mb": 19900,
       "vram_required_gb": 24,
       "context_length": 32768,
@@ -245,7 +245,7 @@
       "family": "qwen",
       "gguf_file": "Qwen3.5-35B-A3B-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/Qwen3.5-35B-A3B-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375",
       "size_mb": 22000,
       "vram_required_gb": 24,
       "context_length": 131072,
@@ -262,7 +262,7 @@
       "family": "deepseek",
       "gguf_file": "DeepSeek-R1-Distill-Llama-70B-Q4_K_M.gguf",
       "gguf_url": "https://huggingface.co/unsloth/DeepSeek-R1-Distill-Llama-70B-GGUF/resolve/main/DeepSeek-R1-Distill-Llama-70B-Q4_K_M.gguf",
-      "gguf_sha256": "",
+      "gguf_sha256": "952ff479c48ac3ece81fb6d9a5a03bfeac215e6caac780fbe91ff8cb0e05bcf3",
       "size_mb": 42500,
       "vram_required_gb": 48,
       "context_length": 32768,
@@ -300,11 +300,13 @@
       "gguf_parts": [
         {
           "file": "Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf",
-          "url": "https://huggingface.co/unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF/resolve/main/Q4_K_M/Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf"
+          "url": "https://huggingface.co/unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF/resolve/main/Q4_K_M/Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00001-of-00002.gguf",
+          "sha256": "fbe956902467171ed7c0c326e5d868771a84d46468d407abecd0f289297313f9"
         },
         {
           "file": "Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00002-of-00002.gguf",
-          "url": "https://huggingface.co/unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF/resolve/main/Q4_K_M/Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00002-of-00002.gguf"
+          "url": "https://huggingface.co/unsloth/Llama-4-Scout-17B-16E-Instruct-GGUF/resolve/main/Q4_K_M/Llama-4-Scout-17B-16E-Instruct-Q4_K_M-00002-of-00002.gguf",
+          "sha256": "e7330ae14527f08e8a44a6a573b45084052b8822c4b8a5179c5cad9cd6f6f795"
         }
       ],
       "size_mb": 65300,
@@ -327,15 +329,18 @@
       "gguf_parts": [
         {
           "file": "Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf",
-          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf"
+          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00001-of-00003.gguf",
+          "sha256": "467c9bd92ea518539cf75bf5a5fbfbd35e9a0b40d766ccaa67bf120e12041df3"
         },
         {
           "file": "Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf",
-          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf"
+          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00002-of-00003.gguf",
+          "sha256": "90db14846413aebdac365b57206441437cac5f7e5037d94b325f0167f902e6e7"
         },
         {
           "file": "Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf",
-          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf"
+          "url": "https://huggingface.co/unsloth/Qwen3.5-122B-A10B-GGUF/resolve/main/Q4_K_M/Qwen3.5-122B-A10B-Q4_K_M-00003-of-00003.gguf",
+          "sha256": "e3c24b8ebec070bb4f69ea0aca25a16531da7440cd515529953e046882901f97"
         }
       ],
       "size_mb": 76500,


### PR DESCRIPTION
> **Merge order:** Merge after #906 and #905 — touches `dream-host-agent.py` and `model-library.json`.

## What
Populate missing SHA256 checksums in the model catalog and harden the
host-agent download verifier to check every part of every model.

## Why
`config/model-library.json` shipped with `gguf_sha256` populated for
only 5 of 19 entries. For the other 14 single-file models, the host-
agent's verifier hit `if gguf_sha256 and len(download_plan) == 1:` and
silently skipped the check. Split-file models (two of them) also hit
that gate unconditionally because `len(download_plan) > 1`, so every
multi-part download was never verified. Result: a corrupted or
tampered GGUF could slip through and only surface as a runtime crash
in llama-server, with no signal to the user or operator.

The host-agent also read `gguf_sha256` from the client request body
and used the client-supplied value as ground truth. That added an
unnecessary trust boundary — a caller supplying their own matching-but-
bogus hash could fake a "verified" download.

## How
- Populate `gguf_sha256` for all 12 single-file models that shipped
  with an empty string. For the 2 split-file models, add a `sha256`
  field to each entry in `gguf_parts`. Top-level `gguf_sha256` on
  split-file models is intentionally left empty — for those, the
  per-part sha is authoritative. All SHAs were fetched from
  HuggingFace LFS `x-linked-etag` response headers, cross-validated
  against the 5 pre-existing catalog SHAs as a sanity check.
- In `dream-host-agent.py`, drop the `len(download_plan) == 1` gate.
  Build an `expected_sha_by_file: dict[str, str]` map inside the
  existing library-validation block (keyed by filename, single-file
  and split-file both supported) and iterate over every entry in
  `download_plan`. For each part:
  - Empty catalog sha → `logger.warning(...)` and continue (no silent
    skip; the warning drives the operator to populate the catalog).
  - Non-empty sha → stream-hash in 1 MiB chunks and compare. On
    mismatch, `unlink` the bad part, write `failed` status, return.
- Drop the client-supplied `gguf_sha256` body field. The catalog is
  the sole trust root. Dashboard-api continues to accept the field in
  the request body for backwards compatibility but the host-agent
  ignores it.
- Verifier status label distinguishes `"foo.gguf (part 2/3)"` so the
  dashboard can show meaningful per-part progress during multi-part
  verification.

## Testing
- `python3 -m py_compile dream-host-agent.py`, `ruff check` clean
  (the body-field drop also fixed a pre-existing F841 dead-variable).
- `python3 -c "import json; json.load(...)"` confirms the catalog
  stays well-formed; 19 models preserved; key order and 4-space
  indentation untouched.
- Existing dashboard-api test suite green (22 host_agent tests, 13
  models tests).
- Chunked-hash path validated against a 2.3 MB synthetic file with a
  known SHA, plus a deliberate mismatch confirming the failure path.

### Manual test plan
- **Any platform:** trigger a single-file model download, watch
  host-agent log for `verifying` status, expect `complete` with no
  warning.
- **Split-file:** trigger llama4-scout-q4 or qwen3.5-122b-a10b-q4,
  status should pass through `verifying ... (part N/M)` for each
  part.
- **Tamper test:** temporarily edit the catalog to a bogus sha for one
  entry, retry, expect the download to land in `failed` with a clear
  mismatch message in the status file.
- **Empty-sha warning:** blank one entry's sha, retry, expect a
  `WARNING: SHA256 verification skipped for ...` in stderr but still
  `complete`.

## Platform Impact
- **macOS / Linux / Windows:** identical. Pure Python stdlib (`hashlib`, `pathlib`, `json`), no platform-specific behavior.