### PR TITLE
fix(07-devtools): preserve trailing comma when rewriting opencode.json

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -153,8 +153,23 @@ OPENCODE_EOF
             ai_ok "OpenCode configured for local llama-server (model: ${LLM_MODEL})"
         else
             # Reinstall: update API key and URL in existing config (key may have changed)
-            _sed_i "s|\"apiKey\":.*|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
-            _sed_i "s|\"baseURL\":.*|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+            if command -v jq >/dev/null 2>&1; then
+                _opencode_tmp="$OPENCODE_CONFIG_DIR/opencode.json.tmp.$$"
+                if jq --arg url "$_opencode_url" --arg key "$_opencode_key" \
+                    '.provider["llama-server"].options.baseURL = $url
+                     | .provider["llama-server"].options.apiKey = $key' \
+                    "$OPENCODE_CONFIG_DIR/opencode.json" > "$_opencode_tmp"; then
+                    mv "$_opencode_tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
+                else
+                    rm -f "$_opencode_tmp"
+                    ai_warn "OpenCode config jq rewrite failed; leaving existing config in place"
+                fi
+            else
+                # Fallback without jq: narrow sed that only matches the quoted value,
+                # preserving any trailing comma on the line
+                _sed_i "s|\"apiKey\": *\"[^\"]*\"|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+                _sed_i "s|\"baseURL\": *\"[^\"]*\"|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+            fi
             ai_ok "OpenCode config updated (API key and URL refreshed)"
         fi
         # OpenCode reads config.json, not opencode.json — always sync

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -160,6 +160,7 @@ OPENCODE_EOF
                      | .provider["llama-server"].options.apiKey = $key' \
                     "$OPENCODE_CONFIG_DIR/opencode.json" > "$_opencode_tmp"; then
                     mv "$_opencode_tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
+                    ai_ok "OpenCode config updated (API key and URL refreshed)"
                 else
                     rm -f "$_opencode_tmp"
                     ai_warn "OpenCode config jq rewrite failed; leaving existing config in place"
@@ -169,8 +170,8 @@ OPENCODE_EOF
                 # preserving any trailing comma on the line
                 _sed_i "s|\"apiKey\": *\"[^\"]*\"|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
                 _sed_i "s|\"baseURL\": *\"[^\"]*\"|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+                ai_ok "OpenCode config updated (API key and URL refreshed)"
             fi
-            ai_ok "OpenCode config updated (API key and URL refreshed)"
         fi
         # OpenCode reads config.json, not opencode.json — always sync
         cp "$OPENCODE_CONFIG_DIR/opencode.json" "$OPENCODE_CONFIG_DIR/config.json"


### PR DESCRIPTION
## What
Replaces the greedy `sed` rewrites of `opencode.json` in the installer's reinstall branch with a `jq`-first implementation and a narrow-sed fallback that preserves the trailing comma on the `baseURL` line. Success/warn logging is gated so the operator sees the success line only when the rewrite actually lands on disk.

## Why
On reinstall, `07-devtools.sh` tried to refresh `apiKey` and `baseURL` in the existing `~/.config/opencode/opencode.json` via:
```bash
_sed_i "s|\"baseURL\":.*|\"baseURL\": \"${_opencode_url}\"|" ...
```
`.*` is greedy to end-of-line. `baseURL` is not the last key in `options`, so its line ends with `,`. The sed pattern consumed the trailing comma and the replacement did not restore it, producing:
```json
"baseURL": "http://127.0.0.1:11434/v1"
"apiKey": "no-key"
```
which is invalid JSON. `opencode-web.service` (user systemd) parsed the file, failed with `CommaExpected at line 11, column 9`, and crash-looped. Reported restart counter reached 1265 on a single reinstall.

## How
1. **jq path (primary):** if `jq` is available, rewrite `.provider["llama-server"].options.baseURL` and `.apiKey` by exact JSON path via `jq --arg`. Writes to a `.tmp.$$` file and atomic `mv` on success. Leaves the existing file untouched if jq fails.
2. **Narrow-sed fallback:** when `jq` is not available, use `_sed_i` patterns `"key": *"[^"]*"` that match only the quoted value. The trailing comma (or closing brace) is outside the match and is preserved.
3. **Logging:** `ai_ok` fires only inside the success branches (jq-success + sed-fallback). `ai_warn` fires on jq-failure. The previous pattern where `ai_ok` fired even after `ai_warn` is closed.

## Testing
- `bash -n` OK
- `shellcheck` shows only pre-existing SC2015/SC2016 on untouched lines; no new errors from the changed block
- Narrow-sed on a fake `opencode.json` with the known-broken key order preserves the trailing comma; `python3 -m json.tool` confirms valid JSON
- jq path on the same fake file preserves both keys and produces valid JSON

## Platform Impact
- **Linux:** Primary fix target. Affects the Linux installer reinstall path.
- **Windows/WSL2:** Inherits the Linux path — same code, same bug, same fix.
- **macOS:** Not affected. The macOS installer (`installers/macos/install-macos.sh`) has its own OpenCode flow that does not run `07-devtools.sh` and does not execute the broken sed. This PR does not touch macOS.