### PR TITLE
fix(dashboard-api): require all parts present for split-file models

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/models.py
+++ b/dream-server/extensions/services/dashboard-api/routers/models.py
@@ -108,14 +108,18 @@ def list_models(api_key: str = Depends(verify_api_key)):
         gguf_file = model.get("gguf_file", "")
         model_id = model.get("id", "")
 
-        # Determine status — for split models, check the first part file
+        # Determine status — for split models, ALL parts must be present
+        # (mirrors host agent's all_downloaded check in dream-host-agent.py).
         parts = model.get("gguf_parts", [])
-        first_part = parts[0]["file"] if parts else gguf_file
+        if parts:
+            is_downloaded = all(p.get("file") in downloaded for p in parts)
+        else:
+            is_downloaded = bool(gguf_file) and gguf_file in downloaded
 
         if gguf_file and gguf_file == active_gguf:
             status = "loaded"
             current_model = model_id
-        elif first_part and first_part in downloaded:
+        elif is_downloaded:
             status = "downloaded"
         else:
             status = "available"

--- a/dream-server/extensions/services/dashboard-api/tests/test_routers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_routers.py
@@ -654,3 +654,83 @@ def test_chat_connection_error(test_client, monkeypatch):
 
     assert resp.status_code == 503
 
+
+# ---------------------------------------------------------------------------
+# Models router — split-file download status (issue #316)
+# ---------------------------------------------------------------------------
+
+
+def _models_get(test_client) -> dict:
+    resp = test_client.get("/api/models", headers=test_client.auth_headers)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _patch_models_env(monkeypatch, library, downloaded):
+    """Patch routers.models helpers used by list_models."""
+    import routers.models as models_router
+    monkeypatch.setattr(models_router, "_load_library", lambda: library)
+    monkeypatch.setattr(models_router, "_scan_downloaded_models", lambda: downloaded)
+    monkeypatch.setattr(models_router, "_read_active_model", lambda: None)
+    monkeypatch.setattr(models_router, "_get_gpu_vram", lambda: None)
+
+
+def test_list_models_split_partial_not_downloaded(test_client, monkeypatch):
+    """A split-file model with only the first part on disk → status 'available'."""
+    library = [{
+        "id": "split-test",
+        "name": "Split Test",
+        "gguf_file": "split-test-00001-of-00002.gguf",
+        "gguf_parts": [
+            {"file": "split-test-00001-of-00002.gguf"},
+            {"file": "split-test-00002-of-00002.gguf"},
+        ],
+        "size_mb": 2048,
+        "vram_required_gb": 8,
+    }]
+    downloaded = {"split-test-00001-of-00002.gguf": 1024}
+    _patch_models_env(monkeypatch, library, downloaded)
+
+    data = _models_get(test_client)
+    assert len(data["models"]) == 1
+    assert data["models"][0]["status"] == "available"
+
+
+def test_list_models_split_all_parts_downloaded(test_client, monkeypatch):
+    """A split-file model with every part on disk → status 'downloaded'."""
+    library = [{
+        "id": "split-test",
+        "name": "Split Test",
+        "gguf_file": "split-test-00001-of-00002.gguf",
+        "gguf_parts": [
+            {"file": "split-test-00001-of-00002.gguf"},
+            {"file": "split-test-00002-of-00002.gguf"},
+        ],
+        "size_mb": 2048,
+        "vram_required_gb": 8,
+    }]
+    downloaded = {
+        "split-test-00001-of-00002.gguf": 1024,
+        "split-test-00002-of-00002.gguf": 1024,
+    }
+    _patch_models_env(monkeypatch, library, downloaded)
+
+    data = _models_get(test_client)
+    assert data["models"][0]["status"] == "downloaded"
+
+
+def test_list_models_single_file_downloaded(test_client, monkeypatch):
+    """Sanity check: single-file model with its gguf_file present → 'downloaded'."""
+    library = [{
+        "id": "single-test",
+        "name": "Single Test",
+        "gguf_file": "single-test.gguf",
+        "size_mb": 1024,
+        "vram_required_gb": 4,
+    }]
+    downloaded = {"single-test.gguf": 1024}
+    _patch_models_env(monkeypatch, library, downloaded)
+
+    data = _models_get(test_client)
+    assert data["models"][0]["status"] == "downloaded"
+


### PR DESCRIPTION
> **Merge order:** Merge before #893 — both modify `models.py`.

## What
Dashboard-api's `list_models` endpoint now requires every part of a
split-file model to be present on disk before reporting the model as
`"downloaded"`. Adds pytest coverage for the new behavior.

## Why
`routers/models.py` checked only the first part of a split-file model's
`gguf_parts` list when deciding whether the model was downloaded. A
user who killed a download mid-way through part 2 would see the model
status flip to `"downloaded"` in the dashboard, click Activate, and hit
a cryptic error later because part 2 never finished. The host agent
computes `all_downloaded = all((models_dir / fn).exists() for fn, _ in
download_plan)` correctly — dashboard-api just failed to mirror it.

## How
Replace the `first_part` check in `list_models` with an inline
`is_downloaded` computation:

- Split-file model (`gguf_parts` non-empty): `all(p.get("file") in
  downloaded for p in parts)`
- Single-file model: `bool(gguf_file) and gguf_file in downloaded`
- Empty `parts` list falls through to the single-file path (defensive
  for malformed catalog entries).

`"loaded"` precedence (active model wins over `"downloaded"`) is
preserved.

## Testing
Three new pytest cases in `tests/test_routers.py`:

- `test_list_models_split_partial_not_downloaded` — only part 1
  present → `"available"` (regression coverage for the exact bug).
- `test_list_models_split_all_parts_downloaded` — all parts present →
  `"downloaded"`.
- `test_list_models_single_file_downloaded` — sanity check, non-split
  case → `"downloaded"`.

Full run: **49 passed**, no regressions in the `test_routers` suite.
`py_compile` and `ruff check` clean.

### Manual test plan
- **Any platform:** pick a split-file model (e.g. Llama-4-Scout 17B).
  Trigger `POST /api/models/<id>/download`, interrupt between part 1
  and part 2. `curl /api/models | jq '.models[] | select(.id==<id>) |
  .status'` should report `"available"`. Finish the download → status
  flips to `"downloaded"`.

## Platform Impact
- **macOS / Linux / Windows:** identical. Pure Python router change, same dashboard-api container on every platform.