### PR TITLE
fix(dream-cli): make _template_apply continue past failing extensions

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -3037,7 +3037,7 @@ PYEOF
         fi
 
         log "  Enabling $svc..."
-        cmd_enable "$svc" || warn "  Failed to enable $svc (continuing)"
+        ( cmd_enable "$svc" ) || warn "  Failed to enable $svc (continuing)"
     done
     success "Template applied: $template_id"
 }


### PR DESCRIPTION
## What
One-character fix: wrap `cmd_enable "$svc"` in a subshell inside
`_template_apply` so the existing `|| warn` fallback is actually
reachable.

## Why
`dream template apply` is supposed to enable every service in a
template and `warn` (not abort) when one service fails — typical
scenarios: a library extension that isn't installed yet, a service with
a missing manifest, a typo in the template. The existing code had
`cmd_enable "$svc" || warn "..."` which looks correct but never fired
the `|| warn`: `cmd_enable` eventually calls `error()`, which is
`echo ...; exit 1`, which kills the whole `dream template apply`
process. Any template referencing a missing service aborted on the
first failure and never reached the remaining services.

## How
`( cmd_enable "$svc" ) || warn "  Failed to enable $svc (continuing)"`.
The subshell contains the `exit 1` from `error()`, the parent captures
a non-zero exit code, `|| warn` fires, and the loop continues.

Other call sites of `cmd_enable` were audited:

- Recursive dep-resolution call inside `cmd_enable` itself — intended
  to fail hard when a dep is missing, untouched.
- Top-level dispatcher `enable) shift; cmd_enable "$@"` — intended to
  exit 1, untouched.

Side-effect analysis of the subshell: the only globals `cmd_enable`
mutates are file I/O (persists across subshell, as desired) and the
`_ENABLE_VISITED` circular-dep guard array (used only within a single
invocation of `cmd_enable`, so losing it at the subshell boundary is
fine — each template service starts with a fresh visited set, which
matches existing behavior).

## Testing
- `bash -n` clean.
- `shellcheck` zero-delta vs baseline.
- Subshell-pattern smoke test against a throwaway script with an
  `error()` stub confirms the `|| warn` branch fires and the parent
  loop continues.

### Manual test plan
- **Any platform:** create a template referencing a library extension
  you have NOT installed (e.g. `aider`, `n8n`). Run `dream template
  apply <template>`. Before the fix: script aborts at the first
  missing service. After the fix: each missing service prints a
  `WARN: Failed to enable <svc> (continuing)` line and the loop
  proceeds to the next service; template finishes with whatever
  services were available.

## Platform Impact
- **macOS / Linux / Windows:** identical. Subshell `( ... )` is POSIX/Bash universal.
