### PR TITLE
fix(restart,extensions): use compose up -d and invalidate cache on enable

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -647,12 +647,12 @@ cmd_restart() {
 
     if [[ -z "$service" ]]; then
         log "Restarting all services..."
-        docker compose "${flags[@]}" restart
+        docker compose "${flags[@]}" up -d
         success "All services restarted"
     else
         service=$(resolve_service "$service")
         log "Restarting $service..."
-        docker compose "${flags[@]}" restart "$service"
+        docker compose "${flags[@]}" up -d "$service"
         success "$service restarted"
     fi
 }

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -1051,6 +1051,9 @@ def enable_extension(
             _scan_compose_content(enabled_compose)
         # Dependencies were satisfied at install time; compose content is re-scanned above
         _write_initial_progress(service_id)
+        # Invalidate .compose-flags cache so dream-cli picks up this extension
+        # before the host agent starts the container.
+        _call_agent_invalidate_compose_cache()
         agent_ok = _call_agent("start", service_id)
         logger.info("Started stopped extension: %s", service_id)
         return {

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -815,6 +815,31 @@ class TestComposeCacheInvalidation:
         assert resp.status_code == 200
         assert len(calls) == 1
 
+    def test_enable_stopped_invalidates_cache(self, test_client, monkeypatch, tmp_path):
+        """Stopped-start branch: compose.yaml already exists (library extension
+        enabled flow). Cache must be invalidated BEFORE the host agent start
+        call so it sees the new compose set."""
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+
+        order: list[str] = []
+        monkeypatch.setattr(
+            "routers.extensions._call_agent_invalidate_compose_cache",
+            lambda: order.append("invalidate"),
+        )
+        monkeypatch.setattr(
+            "routers.extensions._call_agent",
+            lambda action, svc: order.append(f"agent:{action}:{svc}") or True,
+        )
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/enable",
+            headers=test_client.auth_headers,
+        )
+        assert resp.status_code == 200
+        assert order.count("invalidate") == 1
+        assert order.index("invalidate") < order.index("agent:start:my-ext")
+
     def test_disable_invalidates_cache(self, test_client, monkeypatch, tmp_path):
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)

--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -102,14 +102,24 @@ get_compose_flags() {
     local flags_file="${INSTALL_DIR}/.compose-flags"
     if [[ -f "$flags_file" ]]; then
         cat "$flags_file"
-    else
-        # Fallback: detect from available files
-        local flags="-f docker-compose.base.yml"
-        if [[ -f "${INSTALL_DIR}/installers/macos/docker-compose.macos.yml" ]]; then
-            flags="$flags -f installers/macos/docker-compose.macos.yml"
-        fi
-        echo "$flags"
+        return
     fi
+    # Fallback: dynamic resolution via resolve-compose-stack.sh so user-installed
+    # extensions in data/user-extensions/ are discovered when the .compose-flags
+    # cache is missing or stale. Mirrors dream-cli's get_compose_flags fallback.
+    if [[ -x "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" ]]; then
+        "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" \
+            --script-dir "$INSTALL_DIR" \
+            --tier "${TIER:-1}" \
+            --gpu-backend "${GPU_BACKEND:-apple}"
+        return
+    fi
+    # Last resort: resolver script missing — emit base + macos overlay
+    local flags="-f docker-compose.base.yml"
+    if [[ -f "${INSTALL_DIR}/installers/macos/docker-compose.macos.yml" ]]; then
+        flags="$flags -f installers/macos/docker-compose.macos.yml"
+    fi
+    echo "$flags"
 }
 
 read_dream_env() {
@@ -364,7 +374,7 @@ cmd_restart() {
     if [[ -n "$service" ]]; then
         ai "Restarting ${service}..."
         # shellcheck disable=SC2086
-        docker compose $flags restart "$service"
+        docker compose $flags up -d "$service"
         ai_ok "${service} restarted"
     else
         # Restart native llama-server
@@ -375,7 +385,7 @@ cmd_restart() {
 
         ai "Restarting all services..."
         # shellcheck disable=SC2086
-        docker compose $flags restart
+        docker compose $flags up -d
         ai_ok "All services restarted"
     fi
 }


### PR DESCRIPTION
## What
Three coordinated fixes across the CLIs and dashboard-api:

1. `dream-cli` and `dream-macos.sh` `cmd_restart` now use `docker
   compose up -d` instead of `docker compose restart` so newly-enabled
   services are actually created on restart.
2. `dream-macos.sh get_compose_flags` falls back to
   `scripts/resolve-compose-stack.sh` (matching `dream-cli`) so
   user-installed extensions are visible to `cmd_stop` when the
   `.compose-flags` cache is missing or stale.
3. Dashboard-api's `enable_extension` stopped-start branch now calls
   `_call_agent_invalidate_compose_cache()` before `_call_agent(
   "start", ...)`, closing a gap left by the prior partial fix.

## Why
1. `docker compose restart` only touches containers it already has in
   its internal state. When a user runs `dream enable <ext> && dream
   restart`, the new extension's container has never been created —
   compose silently skips it, the user sees the restart succeed, and
   the extension never starts. Reproduced against a live install:
   `dream-langfuse` absent from `docker ps` after `dream enable
   langfuse && dream restart`. `docker compose up -d` is the verb
   compose's own docs recommend for "ensure running with current
   config".

2. `dream-macos.sh get_compose_flags` fast-path reads `.compose-flags`
   — fine when the cache is fresh. Its fallback only adds base +
   macos overlay (no resolver call). So when the cache is stale (e.g.
   after a compose overlay change) or missing (fresh install edge
   case), `cmd_stop` never sees user-installed extensions and leaks
   containers behind. `dream-cli` already calls the resolver in its
   fallback; this PR pulls `dream-macos.sh` into line.

3. Dashboard-api's `enable_extension` has two branches: an "activate"
   branch that renames `compose.yaml.disabled` → `compose.yaml`, and a
   "stopped-start" branch that fires when `compose.yaml` is already on
   disk (the typical case for library extensions like `jupyter` that
   ship with an active compose file). A prior fix added
   `_call_agent_invalidate_compose_cache()` to the activate branch but
   missed the stopped-start branch entirely. A user installing jupyter
   from the library and then enabling it through the dashboard ended
   up with a stale `.compose-flags` cache, and the CLI's subsequent
   `dream start/stop/restart` passed the wrong flag set.

## How
- `dream-cli:647-655`: `docker compose "${flags[@]}" restart [svc]` →
  `docker compose "${flags[@]}" up -d [svc]`. Matches `cmd_start`'s
  existing pattern.
- `dream-macos.sh:367, 378`: same `restart` → `up -d` substitution.
- `dream-macos.sh get_compose_flags`: rewritten fallback. When
  `.compose-flags` is missing, now invokes `scripts/resolve-compose-
  stack.sh --script-dir ... --tier "${TIER:-1}" --gpu-backend
  "${GPU_BACKEND:-apple}"`. The hard-coded base + macos overlay is
  kept only as a last resort if the resolver script itself is
  missing. Fast-path (cache hit) is unchanged.
- `extensions.py enable_extension` stopped-start branch: add
  `_call_agent_invalidate_compose_cache()` after
  `_write_initial_progress(service_id)` and before `_call_agent(
  "start", service_id)`. Placed outside `_extensions_lock()` to match
  the activate branch's existing placement. The activate branch is
  NOT touched.

## Testing
- `bash -n` + `shellcheck` clean on both shell files (zero new
  warnings vs baseline).
- `py_compile` + `ruff check` clean on the Python changes.
- New pytest `test_enable_stopped_invalidates_cache` added adjacent
  to the existing `test_enable_invalidates_cache`. Uses
  `_setup_user_ext(enabled=True)` (the existing test uses
  `enabled=False`, covering only the activate branch). Asserts the
  invalidate spy is called exactly once AND that ordering is
  invalidate → start. Full test suite: **105 passed** in
  `test_extensions.py`, all 5 `TestComposeCacheInvalidation` cases
  green.
- Verified the new test would fail on upstream/main without the
  extensions.py edit (the stopped-start path never invokes the spy
  there).

### Manual test plan
- **Linux (`dream-cli`):** `docker ps -a --filter name=dream-langfuse`
  → empty; `dream enable langfuse && dream restart`; `docker ps
  --filter name=dream-langfuse` → present. Before the fix,
  `dream-langfuse` never appeared.
- **macOS (`dream-macos.sh` restart):** same pattern with any user
  extension.
- **macOS (`dream-macos.sh` get_compose_flags fallback):** `mv
  .compose-flags .compose-flags.bak; ./dream-macos.sh stop;
  mv .compose-flags.bak .compose-flags`. All user-installed
  extensions should stop (was: only base + macos overlay services).
- **Dashboard-api stopped-start (jupyter reproducer):** install
  jupyter, plant a known `.compose-flags`, `POST
  /api/extensions/jupyter/enable`, confirm `.compose-flags` was
  deleted by the host agent.

## Platform Impact
| File | Linux | macOS | Windows (WSL2) |
|---|---|---|---|
| `dream-cli` | ✅ primary | ✅ | ✅ |
| `installers/macos/dream-macos.sh` | — | ✅ only | — |
| `dashboard-api/routers/extensions.py` | ✅ | ✅ | ✅ |
