### PR TITLE
fix(host-agent,dashboard-api): allow API management of built-in extensions

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -49,8 +49,9 @@ AGENT_API_KEY: str = ""
 GPU_BACKEND: str = "nvidia"
 TIER: str = "1"
 CORE_SERVICE_IDS: set = set()
-# Core services that can be toggled via the extension API (e.g., privacy shield)
-TOGGLABLE_CORE_SERVICES: set = {"privacy-shield"}
+# Always-on services defined in docker-compose.base.yml — never stoppable via API.
+# Distinct from CORE_SERVICE_IDS (which is the allowlist of known service IDs).
+ALWAYS_ON_SERVICES: frozenset = frozenset({"llama-server", "open-webui", "dashboard", "dashboard-api"})
 USER_EXTENSIONS_DIR: Path = Path()
 EXTENSIONS_DIR: Path = Path()
 
@@ -358,14 +359,14 @@ def validate_service_id(handler, body: dict) -> str | None:
     if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
         json_response(handler, 400, {"error": "Invalid service_id"})
         return None
-    if sid in CORE_SERVICE_IDS and sid not in TOGGLABLE_CORE_SERVICES:
-        json_response(handler, 403, {"error": f"Cannot manage core service: {sid}"})
+    if sid in ALWAYS_ON_SERVICES:
+        json_response(handler, 403, {"error": f"Cannot manage always-on service: {sid}"})
         return None
     # Verify the service_id maps to an actual installed extension.
-    # Check user-extensions first, then core extensions for togglable services.
+    # Check user-extensions first, then built-in extensions.
     ext_dir = USER_EXTENSIONS_DIR / sid
-    if not ext_dir.is_dir() and sid in TOGGLABLE_CORE_SERVICES:
-        ext_dir = INSTALL_DIR / "extensions" / "services" / sid
+    if not ext_dir.is_dir():
+        ext_dir = EXTENSIONS_DIR / sid
     manifest_exists = any((ext_dir / n).exists() for n in ("manifest.yaml", "manifest.yml", "manifest.json"))
     if not ext_dir.is_dir() or not manifest_exists:
         json_response(handler, 404, {"error": f"Extension not found: {sid}"})

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -589,6 +589,10 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_setup_hook()
         elif self.path == "/v1/extension/hooks":
             self._handle_hook()
+        elif self.path == "/v1/extension/activate":
+            self._handle_extension_compose_toggle(activate=True)
+        elif self.path == "/v1/extension/deactivate":
+            self._handle_extension_compose_toggle(activate=False)
         elif self.path == "/v1/service/logs":
             self._handle_service_logs()
         elif self.path == "/v1/model/download":
@@ -797,6 +801,60 @@ class AgentHandler(BaseHTTPRequestHandler):
         else:
             json_response(self, 503 if "timed out" in err else 500, {"error": err})
 
+    def _handle_extension_compose_toggle(self, activate: bool):
+        """Rename compose.yaml.disabled <-> compose.yaml for an extension.
+
+        Used by dashboard-api when the extensions mount is read-only (:ro).
+        The host agent runs on the host filesystem where the files are writable.
+        """
+        if not check_auth(self):
+            return
+        body = read_json_body(self)
+        if body is None:
+            return
+
+        # Validate service_id format and existence
+        sid = body.get("service_id", "")
+        if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
+            json_response(self, 400, {"error": "Invalid service_id"})
+            return
+
+        ext_dir = _find_ext_dir(sid)
+        if ext_dir is None:
+            json_response(self, 404, {"error": f"Extension not found: {sid}"})
+            return
+
+        if sid in ALWAYS_ON_SERVICES:
+            json_response(self, 403, {"error": f"Cannot modify always-on service: {sid}"})
+            return
+
+        action = "activate" if activate else "deactivate"
+        if activate:
+            src = ext_dir / "compose.yaml.disabled"
+            dst = ext_dir / "compose.yaml"
+        else:
+            src = ext_dir / "compose.yaml"
+            dst = ext_dir / "compose.yaml.disabled"
+
+        lock = _service_locks[sid]
+        if not lock.acquire(blocking=False):
+            json_response(self, 409, {"error": f"Operation already in progress for {sid}"})
+            return
+        try:
+            # Check existence inside the lock to prevent TOCTOU races
+            if not src.exists():
+                state = "enabled" if activate else "disabled"
+                json_response(self, 409, {"error": f"Extension already {state}: {sid}"})
+                return
+            os.rename(str(src), str(dst))
+        except OSError as exc:
+            json_response(self, 500, {"error": f"Failed to {action} extension: {exc}"})
+            return
+        finally:
+            lock.release()
+
+        logger.info("%sd extension compose: %s", action, sid)
+        json_response(self, 200, {"status": "ok", "service_id": sid, "action": action})
 
     def _handle_logs(self):
         if not check_auth(self):

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -276,6 +276,10 @@ def _load_core_service_ids() -> frozenset:
 
 CORE_SERVICE_IDS = _load_core_service_ids()
 
+# Always-on services defined in docker-compose.base.yml — never manageable via API.
+# Distinct from CORE_SERVICE_IDS (the full built-in service allowlist).
+ALWAYS_ON_SERVICES: frozenset = frozenset({"llama-server", "open-webui", "dashboard", "dashboard-api"})
+
 
 def load_extension_catalog() -> list[dict]:
     """Load the static extensions catalog JSON. Returns empty list on failure."""

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -22,7 +22,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 
 from config import (
-    AGENT_URL, CORE_SERVICE_IDS, DATA_DIR,
+    AGENT_URL, ALWAYS_ON_SERVICES, CORE_SERVICE_IDS, DATA_DIR,
     DREAM_AGENT_KEY, EXTENSION_CATALOG, EXTENSIONS_DIR,
     EXTENSIONS_LIBRARY_DIR, GPU_BACKEND, INSTALL_DIR, SERVICES,
     USER_EXTENSIONS_DIR,
@@ -222,10 +222,15 @@ def _validate_service_id(service_id: str) -> None:
 
 
 def _assert_not_core(service_id: str) -> None:
-    """Raise 403 if the service_id belongs to a core service."""
-    if service_id in CORE_SERVICE_IDS:
+    """Raise 403 if the service_id is an always-on base-compose service.
+
+    Only blocks the 4 services from docker-compose.base.yml (llama-server,
+    open-webui, dashboard, dashboard-api). Built-in extensions (n8n, tts, etc.)
+    are allowed through because they're managed via compose.yaml toggle.
+    """
+    if service_id in ALWAYS_ON_SERVICES:
         raise HTTPException(
-            status_code=403, detail=f"Cannot modify core service: {service_id}",
+            status_code=403, detail=f"Cannot modify always-on service: {service_id}",
         )
 
 
@@ -997,8 +1002,8 @@ def _read_direct_deps(service_id: str) -> list[str]:
 
 
 def _is_dep_satisfied(dep: str) -> bool:
-    """Check if a dependency is already enabled (core, built-in, or user)."""
-    if dep in CORE_SERVICE_IDS:
+    """Check if a dependency is already enabled (always-on, built-in, or user)."""
+    if dep in ALWAYS_ON_SERVICES:
         return True
     if (EXTENSIONS_DIR / dep / "compose.yaml").exists():
         return True
@@ -1360,8 +1365,8 @@ def purge_extension_data(
     if not _SERVICE_ID_RE.match(service_id):
         raise HTTPException(status_code=404, detail=f"Invalid service_id: {service_id}")
 
-    if service_id in CORE_SERVICE_IDS:
-        raise HTTPException(status_code=403, detail="Cannot purge core service data")
+    if service_id in ALWAYS_ON_SERVICES:
+        raise HTTPException(status_code=403, detail="Cannot purge always-on service data")
 
     with _extensions_lock():
         # Check if service is still enabled (built-in or user extension)

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -233,7 +233,22 @@ def _assert_not_core(service_id: str) -> None:
             status_code=403, detail=f"Cannot modify always-on service: {service_id}",
         )
 
+def _resolve_extension_dir(service_id: str) -> Path:
+    """Resolve an extension's directory, checking user-extensions first, then built-in.
 
+    Raises HTTPException(404) if not found or path traversal is detected.
+    """
+    user_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
+    if user_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()) and user_dir.is_dir():
+        return user_dir
+
+    builtin_dir = (EXTENSIONS_DIR / service_id).resolve()
+    if builtin_dir.is_relative_to(EXTENSIONS_DIR.resolve()) and builtin_dir.is_dir():
+        return builtin_dir
+
+    raise HTTPException(
+        status_code=404, detail=f"Extension not found: {service_id}",
+    )
 def _scan_compose_content(
     compose_path: Path,
     *,
@@ -549,6 +564,27 @@ def _call_agent_install(service_id: str) -> bool:
         return False
     except OSError as exc:
         logger.warning("Host agent install error for %s: %s", service_id, exc)
+        return False
+
+
+def _call_agent_compose_rename(action: str, service_id: str) -> bool:
+    """Ask host agent to rename compose.yaml <-> compose.yaml.disabled.
+
+    Used for built-in extensions where the extensions mount is read-only.
+    action must be 'activate' or 'deactivate'.
+    """
+    url = f"{AGENT_URL}/v1/extension/{action}"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {DREAM_AGENT_KEY}",
+    }
+    data = json.dumps({"service_id": service_id}).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=_AGENT_LOG_TIMEOUT) as resp:
+            return resp.status == 200
+    except Exception:
+        logger.warning("Host agent unreachable for compose rename at %s", AGENT_URL)
         return False
 
 
@@ -1052,24 +1088,7 @@ def _activate_service(service_id: str) -> dict:
     Returns a result dict for the service. Cycle detection is handled
     upstream by _get_missing_deps_transitive.
     """
-    user_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
-    builtin_dir = (EXTENSIONS_DIR / service_id).resolve()
-
-    in_user = user_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve())
-    in_builtin = builtin_dir.is_relative_to(EXTENSIONS_DIR.resolve())
-    if not in_user and not in_builtin:
-        raise HTTPException(
-            status_code=404, detail=f"Extension not found: {service_id}",
-        )
-
-    if in_user and user_dir.is_dir():
-        ext_dir = user_dir
-    elif in_builtin and builtin_dir.is_dir():
-        ext_dir = builtin_dir
-    else:
-        raise HTTPException(
-            status_code=404, detail=f"Extension not installed: {service_id}",
-        )
+    ext_dir = _resolve_extension_dir(service_id)
 
     disabled_compose = ext_dir / "compose.yaml.disabled"
     enabled_compose = ext_dir / "compose.yaml"
@@ -1099,7 +1118,15 @@ def _activate_service(service_id: str) -> dict:
             status_code=400, detail="Compose file is a symlink",
         )
 
-    os.rename(str(disabled_compose), str(enabled_compose))
+    # Built-in extensions live on a :ro mount — delegate rename to host agent
+    if is_builtin:
+        if not _call_agent_compose_rename("activate", service_id):
+            raise HTTPException(
+                status_code=502,
+                detail=f"Host agent failed to activate extension: {service_id}",
+            )
+    else:
+        os.rename(str(disabled_compose), str(enabled_compose))
     logger.info("Enabled extension (activate): %s", service_id)
     return {"id": service_id, "action": "enabled"}
 
@@ -1114,15 +1141,7 @@ def enable_extension(
     _validate_service_id(service_id)
     _assert_not_core(service_id)
 
-    ext_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
-    if not ext_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()):
-        raise HTTPException(
-            status_code=404, detail=f"Extension not found: {service_id}",
-        )
-    if not ext_dir.is_dir():
-        raise HTTPException(
-            status_code=404, detail=f"Extension not installed: {service_id}",
-        )
+    ext_dir = _resolve_extension_dir(service_id)
 
     disabled_compose = ext_dir / "compose.yaml.disabled"
     enabled_compose = ext_dir / "compose.yaml"
@@ -1135,7 +1154,11 @@ def enable_extension(
                 raise HTTPException(
                     status_code=400, detail="Compose file is a symlink",
                 )
-            _scan_compose_content(enabled_compose)
+            # Built-in extensions legitimately use their own service name which
+            # appears in CORE_SERVICE_IDS — skip the name-collision check for
+            # them, mirroring _activate_service's logic.
+            is_builtin = ext_dir.is_relative_to(EXTENSIONS_DIR.resolve())
+            _scan_compose_content(enabled_compose, skip_name_collision=is_builtin)
         # Dependencies were satisfied at install time; compose content is re-scanned above
         _write_initial_progress(service_id)
         agent_ok = _call_agent("start", service_id)
@@ -1217,15 +1240,7 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
     _validate_service_id(service_id)
     _assert_not_core(service_id)
 
-    ext_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
-    if not ext_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()):
-        raise HTTPException(
-            status_code=404, detail=f"Extension not found: {service_id}",
-        )
-    if not ext_dir.is_dir():
-        raise HTTPException(
-            status_code=404, detail=f"Extension not installed: {service_id}",
-        )
+    ext_dir = _resolve_extension_dir(service_id)
 
     enabled_compose = ext_dir / "compose.yaml"
     disabled_compose = ext_dir / "compose.yaml.disabled"
@@ -1272,7 +1287,16 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
                 status_code=400, detail="Compose file is a symlink",
             )
 
-        os.rename(str(enabled_compose), str(disabled_compose))
+        # Built-in extensions live on a :ro mount — delegate rename to host agent
+        is_builtin = ext_dir.is_relative_to(EXTENSIONS_DIR.resolve())
+        if is_builtin:
+            if not _call_agent_compose_rename("deactivate", service_id):
+                raise HTTPException(
+                    status_code=502,
+                    detail=f"Host agent failed to deactivate extension: {service_id}",
+                )
+        else:
+            os.rename(str(enabled_compose), str(disabled_compose))
         _call_agent_invalidate_compose_cache()
 
         progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 from fastapi import HTTPException
 from models import ServiceStatus
+from routers.extensions import _assert_not_core
 
 
 # --- Helpers ---
@@ -1589,7 +1590,7 @@ class TestPurgeExtensionData:
         )
 
         assert resp.status_code == 403
-        assert "core service" in resp.json()["detail"].lower()
+        assert "always-on service" in resp.json()["detail"].lower()
 
     def test_purge_404_invalid_id(self, test_client, monkeypatch, tmp_path):
         """404 for service_id that fails regex validation."""
@@ -2184,3 +2185,25 @@ class TestActivateServiceBuiltinBranch:
         assert not (user_ext / "compose.yaml.disabled").exists()
         # Built-in untouched
         assert builtin_compose.exists()
+
+
+class TestAssertNotCoreAllowsBuiltins:
+    """_assert_not_core blocks only the 4 always-on base-compose services."""
+
+    @pytest.mark.parametrize("service_id", [
+        "n8n", "tts", "whisper", "comfyui", "litellm", "openclaw",
+        "perplexica", "searxng", "privacy-shield", "token-spy", "qdrant",
+        "embeddings", "ape", "dreamforge", "langfuse", "opencode",
+    ])
+    def test_assert_not_core_allows_builtin_extension(self, service_id):
+        """Built-in extensions are toggleable and must not be blocked."""
+        _assert_not_core(service_id)
+
+    @pytest.mark.parametrize("service_id", [
+        "llama-server", "open-webui", "dashboard", "dashboard-api",
+    ])
+    def test_assert_not_core_blocks_always_on(self, service_id):
+        """Always-on base-compose services must raise 403."""
+        with pytest.raises(HTTPException) as exc_info:
+            _assert_not_core(service_id)
+        assert exc_info.value.status_code == 403

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -635,6 +635,40 @@ class TestDisableExtension:
         assert (user_dir / "my-ext" / "compose.yaml.disabled").exists()
         assert not (user_dir / "my-ext" / "compose.yaml").exists()
 
+    def test_disable_builtin_delegates_to_host_agent(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        builtin_root = tmp_path / "builtin"
+        ext_dir = builtin_root / "my-ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
+        _patch_mutation_config(monkeypatch, tmp_path)
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr("routers.extensions._call_agent", lambda action, sid: True)
+
+        calls = []
+
+        def _mock_compose_rename(action, service_id):
+            calls.append((action, service_id))
+            (ext_dir / "compose.yaml").rename(ext_dir / "compose.yaml.disabled")
+            return True
+
+        monkeypatch.setattr(
+            "routers.extensions._call_agent_compose_rename",
+            _mock_compose_rename,
+        )
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/disable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["action"] == "disabled"
+        assert calls == [("deactivate", "my-ext")]
+        assert (ext_dir / "compose.yaml.disabled").exists()
+        assert not (ext_dir / "compose.yaml").exists()
+
     def test_disable_unlinks_progress_file(self, test_client, monkeypatch, tmp_path):
         """Disable removes the stale progress file so status reflects reality."""
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
@@ -2122,10 +2156,22 @@ class TestActivateServiceBuiltinBranch:
 
         monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR", builtin_root)
         monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_root)
+        calls = []
+
+        def _mock_compose_rename(action, service_id):
+            calls.append((action, service_id))
+            (ext_dir / "compose.yaml.disabled").rename(ext_dir / "compose.yaml")
+            return True
+
+        monkeypatch.setattr(
+            "routers.extensions._call_agent_compose_rename",
+            _mock_compose_rename,
+        )
 
         result = _activate_service("fakesvc")
 
         assert result == {"id": "fakesvc", "action": "enabled"}
+        assert calls == [("activate", "fakesvc")]
         assert (ext_dir / "compose.yaml").exists()
         assert not (ext_dir / "compose.yaml.disabled").exists()
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -165,6 +165,57 @@ class TestComposeCacheInvalidationWire:
             thread.join(timeout=2)
 
 
+class TestComposeToggleWire:
+    """End-to-end HTTP test for built-in compose toggles via the host agent."""
+
+    def test_client_posts_to_host_agent_and_renames_builtin_compose(
+        self, tmp_path, monkeypatch,
+    ):
+        import threading
+        from http.server import HTTPServer
+
+        from routers import extensions as ext_router
+
+        builtin_root = tmp_path / "builtin"
+        user_root = tmp_path / "user"
+        builtin_root.mkdir()
+        user_root.mkdir()
+        ext_dir = builtin_root / "fakesvc"
+        ext_dir.mkdir()
+        (ext_dir / "compose.yaml.disabled").write_text(
+            "services:\n  svc:\n    image: test:latest\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            monkeypatch.setattr(ext_router, "AGENT_URL", f"http://127.0.0.1:{port}")
+            monkeypatch.setattr(ext_router, "DREAM_AGENT_KEY", "wire-test-secret")
+
+            assert ext_router._call_agent_compose_rename("activate", "fakesvc") is True
+            assert (ext_dir / "compose.yaml").exists()
+            assert not (ext_dir / "compose.yaml.disabled").exists()
+
+            assert ext_router._call_agent_compose_rename("deactivate", "fakesvc") is True
+            assert (ext_dir / "compose.yaml.disabled").exists()
+            assert not (ext_dir / "compose.yaml").exists()
+
+            monkeypatch.setattr(ext_router, "DREAM_AGENT_KEY", "wrong-secret")
+            assert ext_router._call_agent_compose_rename("activate", "fakesvc") is False
+            assert (ext_dir / "compose.yaml.disabled").exists()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+
 class TestInvalidateComposeCache:
 
     def test_unlinks_existing_cache_file(self, tmp_path, monkeypatch):


### PR DESCRIPTION
> **Merge order:** Merge after #909 and #926, before #935 — all modify `extensions.py`.

## What
The host agent and dashboard-api blocklist now correctly identifies the 4 always-on base-compose services (llama-server, open-webui, dashboard, dashboard-api) as the only services that cannot be managed via API. The 16 other built-in extensions (n8n, tts, whisper, comfyui, litellm, langfuse, openclaw, perplexica, searxng, token-spy, qdrant, embeddings, ape, dreamforge, opencode, privacy-shield) are now first-class manageable extensions.

## Why
`CORE_SERVICE_IDS` contains all 20 known service IDs. `validate_service_id` (host agent) and `_assert_not_core` (dashboard-api) were using it as a blocklist, rejecting all 20 with 403 "Cannot manage core service" — except for `privacy-shield` which was whitelisted via `TOGGLABLE_CORE_SERVICES`. This broke every dashboard UI action (start/stop/restart/purge) for 15 optional extensions that users are supposed to be able to toggle, blocked multiple in-flight features (template apply, deps+hooks, UI extension cards), and made the dashboard API lie about what it could actually manage.

Root cause: `core-service-ids.json` was originally a whitelist of known service IDs (for input validation), but got repurposed as a blocklist of "services the API is not allowed to touch" — those are two different concepts and the file contents only match the whitelist meaning.

## How
- Introduce `ALWAYS_ON_SERVICES = frozenset({"llama-server", "open-webui", "dashboard", "dashboard-api"})` in `dream-host-agent.py` and `dashboard-api/config.py` — the real 4-service blocklist.
- Update `validate_service_id` to check `ALWAYS_ON_SERVICES` instead of the `CORE_SERVICE_IDS`-minus-`TOGGLABLE_CORE_SERVICES` pattern, and make the extension-dir fallback (`EXTENSIONS_DIR / sid`) unconditional so all built-ins resolve.
- Update `_assert_not_core`, `_is_dep_satisfied`, and the purge handler in `dashboard-api/routers/extensions.py` to check `ALWAYS_ON_SERVICES`.
- **Keep** `CORE_SERVICE_IDS` and `_scan_compose_content`'s use of it — that's a legitimate name-collision check preventing user extensions from shadowing built-in service names.
- **Delete** the now-unused `TOGGLABLE_CORE_SERVICES` constant from the host agent.
- Add `TestAssertNotCoreAllowsBuiltins` — 20 parametrized test cases covering all 16 built-ins as "allow" and all 4 always-on as "block with 403".
- Update `test_purge_403_core_service` assertion substring to match the renamed error message ("always-on service" instead of "core service").

## Testing
- `pytest dashboard-api/tests/test_extensions.py -k assert_not_core` → 20 passed
- Full `test_extensions.py` → 124 passed, 0 failed (104 pre-existing + 20 new)
- `python3 -m py_compile` on both modified .py files → clean
- Pre-existing 12 pytest failures (test_workflows, test_gpu_detailed, test_main GPU cached) are unrelated — verified by reverting this diff and re-running.
- **Manual test needed:** install fresh, disable tts via CLI (`dream disable tts`), open dashboard → click Enable on tts card → expect success (was 403 before this fix). Also verify that `dream stop llama-server` via API still 403s.

## Platform Impact
- **macOS:** affected — Python-only change, identical behavior on all three platforms.
- **Linux:** affected — same.
- **Windows/WSL2:** affected — same.

## Merge order
**This PR should merge AFTER PR #909 (`fix/apply-template-sync-builtin-extensions`).**

Reason: this PR's change to `_is_dep_satisfied` makes disabled built-in extensions fall through to `_activate_service`, which on upstream/main still only checks `USER_EXTENSIONS_DIR` and would return 404 for built-ins. PR #909 fixes `_activate_service` to check both dirs. If this lands first, there's a brief window where a user extension declaring a disabled built-in as a dep would fail to auto-resolve.

The two PRs touch `dashboard-api/routers/extensions.py` in disjoint functions (`_assert_not_core`/`_is_dep_satisfied`/purge handler here vs `_activate_service` in #909), so the merge is a trivial fast-forward in either order.

## Known considerations
- Follow-up issue filed at https://github.com/yasinBursali/DreamServer/issues/327 for the architecture ambiguity between "core / built-in / user" extension lanes. Not a blocker for this fix.
- `core-service-ids.json` is NOT renamed — intentional, avoids config migration churn. A cleaner name like `known-service-ids.json` is a follow-up.