### PR TITLE
fix(security): route .env writes through host agent, restore :ro mount

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -676,10 +676,17 @@ class AgentHandler(BaseHTTPRequestHandler):
                 return
             key, _, value = stripped.partition("=")
             key = key.strip()
-            if key not in allowed_keys:
-                logger.warning("env_update rejected: unknown key %r from %s", key, client_ip)
-                json_response(self, 400, {"error": f"Unknown key: {key}"})
+            if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', key):
+                logger.warning("env_update rejected: invalid key name %r from %s", key[:40], client_ip)
+                json_response(self, 400, {"error": f"Invalid key name: {key[:40]}"})
                 return
+            if key not in allowed_keys:
+                # Warn but accept — extension install hooks and GPU pinning write
+                # keys that are not in the core schema (e.g. JWT_SECRET from
+                # LibreChat, COMFYUI_GPU_UUID from the installer).  Rejecting
+                # them breaks the dashboard Settings save for any install that
+                # has ever enabled an extension.
+                logger.info("env_update: non-schema key %r from %s (accepted)", key, client_ip)
             # Defense in depth: reject values containing control chars (null bytes,
             # escape sequences, etc.). splitlines() already consumed \n/\r/\u2028/\u2029;
             # this catches the residual edge cases flagged by security review.

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -598,6 +598,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_model_delete()
         elif self.path == "/v1/compose/invalidate-cache":
             self._handle_invalidate_compose_cache()
+        elif self.path == "/v1/env/update":
+            self._handle_env_update()
         else:
             json_response(self, 404, {"error": "Not found"})
 
@@ -608,6 +610,114 @@ class AgentHandler(BaseHTTPRequestHandler):
         invalidate_compose_cache()
         logger.info("compose-flags cache invalidated")
         json_response(self, 200, {"status": "ok"})
+
+    def _handle_env_update(self):
+        """Write a validated .env file. Dashboard-api delegates here because the
+        container mount is :ro — only the host agent may write secrets to disk.
+
+        Bypasses read_json_body() because the default 16 KB body limit truncates
+        real .env files (.env.example alone is ~11 KB)."""
+        if not check_auth(self):
+            return
+
+        client_ip = self.client_address[0] if hasattr(self, "client_address") else "?"
+        MAX_ENV_BODY = 65536  # env files routinely exceed the default 16 KB cap
+
+        try:
+            length = int(self.headers.get("Content-Length", "0"))
+        except (TypeError, ValueError):
+            logger.warning("env_update rejected: invalid Content-Length from %s", client_ip)
+            json_response(self, 400, {"error": "Invalid Content-Length"})
+            return
+        if length <= 0:
+            logger.warning("env_update rejected: empty body from %s", client_ip)
+            json_response(self, 400, {"error": "Empty body"})
+            return
+        if length > MAX_ENV_BODY:
+            logger.warning("env_update rejected: body too large (%d bytes) from %s", length, client_ip)
+            json_response(self, 413, {"error": f"Body too large: {length} > {MAX_ENV_BODY}"})
+            return
+        try:
+            raw = self.rfile.read(length)
+            body = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError, json.JSONDecodeError) as exc:
+            logger.warning("env_update rejected: invalid JSON from %s: %s", client_ip, exc)
+            json_response(self, 400, {"error": f"Invalid JSON: {exc}"})
+            return
+
+        raw_text = body.get("raw_text")
+        if not isinstance(raw_text, str) or not raw_text.strip():
+            logger.warning("env_update rejected: raw_text missing/empty from %s", client_ip)
+            json_response(self, 400, {"error": "raw_text required"})
+            return
+        backup = body.get("backup", True)
+
+        schema_path = INSTALL_DIR / ".env.schema.json"
+        if not schema_path.exists():
+            logger.warning("env_update rejected: schema missing at %s (request from %s)", schema_path, client_ip)
+            json_response(self, 500, {"error": f".env.schema.json not found at {schema_path}"})
+            return
+        try:
+            with open(schema_path, encoding="utf-8") as f:
+                schema = json.load(f)
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("env_update rejected: failed to read schema (request from %s): %s", client_ip, exc)
+            json_response(self, 500, {"error": f"Failed to read .env.schema.json: {exc}"})
+            return
+        allowed_keys = set(schema.get("properties", {}).keys())
+
+        for line in raw_text.splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if "=" not in stripped:
+                logger.warning("env_update rejected: malformed line %r from %s", stripped[:80], client_ip)
+                json_response(self, 400, {"error": f"Malformed line: {stripped[:80]}"})
+                return
+            key, _, value = stripped.partition("=")
+            key = key.strip()
+            if key not in allowed_keys:
+                logger.warning("env_update rejected: unknown key %r from %s", key, client_ip)
+                json_response(self, 400, {"error": f"Unknown key: {key}"})
+                return
+            # Defense in depth: reject values containing control chars (null bytes,
+            # escape sequences, etc.). splitlines() already consumed \n/\r/\u2028/\u2029;
+            # this catches the residual edge cases flagged by security review.
+            if any(ord(c) < 32 and c != "\t" for c in value):
+                logger.warning("env_update rejected: control char in value for key %r from %s", key, client_ip)
+                json_response(self, 400, {"error": f"Value contains control characters for key: {key}"})
+                return
+
+        # Coordinate with model activation, which also writes .env under this lock.
+        if not _model_activate_lock.acquire(blocking=False):
+            logger.warning("env_update rejected: lock contention from %s", client_ip)
+            json_response(self, 409, {"error": "Model activation or another env update in progress; try again shortly"})
+            return
+
+        env_path = INSTALL_DIR / ".env"
+        backup_relative_path = None
+        try:
+            if backup and env_path.exists():
+                backup_dir = DATA_DIR / "config-backups"
+                backup_dir.mkdir(parents=True, exist_ok=True)
+                timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+                backup_path = backup_dir / f".env.backup.{timestamp}"
+                shutil.copy2(env_path, backup_path)
+                backup_relative_path = f"data/{backup_path.relative_to(DATA_DIR).as_posix()}"
+
+            payload_text = raw_text if raw_text.endswith("\n") else raw_text + "\n"
+            tmp_path = env_path.with_name(".env.tmp")
+            tmp_path.write_text(payload_text, encoding="utf-8")
+            os.replace(str(tmp_path), str(env_path))
+        except OSError as exc:
+            logger.warning("env_update OSError from %s: %s", client_ip, exc)
+            json_response(self, 500, {"error": str(exc)})
+            return
+        finally:
+            _model_activate_lock.release()
+
+        logger.info(".env updated via host agent from %s (backup=%s)", client_ip, backup_relative_path or "none")
+        json_response(self, 200, {"status": "ok", "backup_path": backup_relative_path})
 
     def _handle_core_recreate(self):
         if not check_auth(self):

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -175,7 +175,7 @@ services:
       - ./scripts:/dream-server/scripts:ro
       - ./config:/dream-server/config:ro
       - ./extensions:/dream-server/extensions:ro
-      - ./.env:/dream-server/.env
+      - ./.env:/dream-server/.env:ro
       - ./.env.example:/dream-server/.env.example:ro
       - ./.env.schema.json:/dream-server/.env.schema.json:ro
       - ./data:/data

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -709,7 +709,7 @@ def _render_env_from_values(values: dict[str, str]) -> str:
 
         output_lines.append(line)
 
-    extras = [(key, value) for key, value in values.items() if key not in seen and value != ""]
+    extras = [(key, value) for key, value in values.items() if key not in seen]
     if extras:
         if output_lines and output_lines[-1] != "":
             output_lines.append("")

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -744,6 +744,23 @@ def _call_agent_core_recreate(service_ids: list[str]) -> dict[str, Any]:
         return json.loads(response.read().decode("utf-8"))
 
 
+def _call_agent_env_update(raw_text: str) -> dict[str, Any]:
+    """Route .env writes through the host agent (filesystem is :ro in container)."""
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {DREAM_AGENT_KEY}",
+    }
+    data = json.dumps({"raw_text": raw_text, "backup": True}).encode("utf-8")
+    request = urllib.request.Request(
+        f"{AGENT_URL}/v1/env/update",
+        data=data,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
 def _check_host_agent_available() -> bool:
     try:
         with urllib.request.urlopen(f"{AGENT_URL}/health", timeout=3) as response:
@@ -802,45 +819,6 @@ def _relative_install_path(path: Path) -> str:
         return str(path.relative_to(_resolve_install_root())).replace("\\", "/")
     except ValueError:
         return str(path).replace("\\", "/")
-
-
-def _resolve_env_backup_root() -> Path:
-    backup_root = Path(DATA_DIR) / "config-backups"
-    backup_root.mkdir(parents=True, exist_ok=True)
-    return backup_root
-
-
-def _display_backup_path(path: Path) -> str:
-    data_root = Path(DATA_DIR)
-    try:
-        return f"data/{path.relative_to(data_root).as_posix()}"
-    except ValueError:
-        return str(path).replace("\\", "/")
-
-
-def _write_text_atomic(path: Path, raw_text: str):
-    temp_path = path.with_name(f"{path.name}.tmp-{os.getpid()}-{int(time.time() * 1000)}")
-    try:
-        try:
-            temp_path.write_text(raw_text, encoding="utf-8")
-            if path.exists():
-                try:
-                    shutil.copymode(path, temp_path)
-                except OSError:
-                    pass
-            os.replace(temp_path, path)
-            return
-        except PermissionError:
-            if not path.exists():
-                raise
-            path.write_text(raw_text, encoding="utf-8")
-            return
-    finally:
-        try:
-            if temp_path.exists():
-                temp_path.unlink()
-        except OSError:
-            pass
 
 
 def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]], dict[str, Any]]:
@@ -1365,7 +1343,6 @@ async def api_settings_env_save(
     payload: dict[str, Any] = Body(...),
     api_key: str = Depends(verify_api_key),
 ):
-    env_path = _resolve_runtime_env_path()
     raw_text, issues, apply_plan = await asyncio.to_thread(_prepare_env_save, payload)
     if issues:
         raise HTTPException(
@@ -1376,35 +1353,27 @@ async def api_settings_env_save(
             },
         )
 
-    env_path.parent.mkdir(parents=True, exist_ok=True)
-    timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
-    backup_root = await asyncio.to_thread(_resolve_env_backup_root)
-    backup_path = backup_root / f".env.backup.{timestamp}"
-    backup_relative = None
-
-    if env_path.exists():
-        try:
-            shutil.copy2(env_path, backup_path)
-            backup_relative = _display_backup_path(backup_path)
-        except OSError as exc:
-            raise HTTPException(
-                status_code=500,
-                detail={
-                    "message": "Could not create a configuration backup before saving.",
-                    "reason": str(exc),
-                },
-            ) from exc
-
     try:
-        await asyncio.to_thread(_write_text_atomic, env_path, raw_text)
+        agent_resp = await asyncio.to_thread(_call_agent_env_update, raw_text)
+    except urllib.error.HTTPError as exc:
+        detail = f"Host agent returned HTTP {exc.code}."
+        try:
+            err_payload = json.loads(exc.read().decode("utf-8"))
+            detail = err_payload.get("error", detail)
+        except Exception:
+            pass
+        raise HTTPException(status_code=503, detail={"message": detail}) from exc
+    except urllib.error.URLError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Dream host agent is not reachable. Start the host agent, then try again."},
+        ) from exc
     except OSError as exc:
         raise HTTPException(
             status_code=500,
-            detail={
-                "message": "Could not write the updated environment file.",
-                "reason": str(exc),
-            },
+            detail={"message": "Could not contact host agent to write environment file.", "reason": str(exc)},
         ) from exc
+    backup_relative = agent_resp.get("backup_path")
 
     _clear_settings_caches()
     result = await asyncio.to_thread(

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -325,14 +325,19 @@ class TestHandleEnvUpdate:
         assert handler.response_code == 413
         assert "too large" in handler.parse_response()["error"].lower()
 
-    def test_400_unknown_key(self, env_update_env):
-        body = _make_body("NOT_IN_SCHEMA=foo\n")
+    def test_accepts_unknown_key_with_warning(self, env_update_env):
+        """Non-schema keys are accepted (warn, not reject) so extension-added
+        keys (e.g. JWT_SECRET from LibreChat) don't break Settings save."""
+        install_dir, data_dir = env_update_env
+        (install_dir / ".env").write_text("DREAM_AGENT_KEY=old\n", encoding="utf-8")
+        body = _make_body("DREAM_AGENT_KEY=old\nNOT_IN_SCHEMA=foo\n")
         handler = _FakeHandler(body)
 
         _mod.AgentHandler._handle_env_update(handler)
 
-        assert handler.response_code == 400
-        assert "Unknown key" in handler.parse_response()["error"]
+        assert handler.response_code == 200
+        env_text = (install_dir / ".env").read_text(encoding="utf-8")
+        assert "NOT_IN_SCHEMA=foo" in env_text
 
     def test_400_malformed_line(self, env_update_env):
         body = _make_body("THIS_LINE_HAS_NO_EQUALS\n")

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1,8 +1,12 @@
 """Tests for dream-host-agent.py — _parse_mem_value and _iso_now."""
 
 import importlib.util
+import io
+import json
 import sys
 from pathlib import Path, PurePosixPath
+
+import pytest
 
 # Import the host agent module from bin/ using importlib.
 # The module has an ``if __name__ == "__main__":`` guard so no server starts.
@@ -227,3 +231,165 @@ class TestInstallHookEnvAllowlist:
             "setup_hook must use _resolve_hook(..., 'post_install'); "
             "the legacy _resolve_setup_hook has been removed"
         )
+
+
+# --- _handle_env_update ---
+
+
+class _FakeHandler:
+    """Minimal stand-in for BaseHTTPRequestHandler used by _handle_env_update."""
+
+    def __init__(self, body: bytes, headers=None):
+        merged = {
+            "Authorization": "Bearer test-key",
+            "Content-Length": str(len(body)),
+        }
+        if headers:
+            merged.update(headers)
+        self.headers = merged
+        self.rfile = io.BytesIO(body)
+        self.wfile = io.BytesIO()
+        self.client_address = ("127.0.0.1", 12345)
+        self.response_code = None
+        self.response_headers = []
+
+    def send_response(self, code):
+        self.response_code = code
+
+    def send_header(self, name, value):
+        self.response_headers.append((name, value))
+
+    def end_headers(self):
+        pass
+
+    def parse_response(self):
+        # json_response writes the JSON body via wfile.write()
+        return json.loads(self.wfile.getvalue().decode("utf-8"))
+
+
+@pytest.fixture
+def env_update_env(tmp_path, monkeypatch):
+    """Wire up INSTALL_DIR/DATA_DIR/AGENT_API_KEY for _handle_env_update tests."""
+    install_dir = tmp_path / "install"
+    install_dir.mkdir()
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    schema = {
+        "properties": {
+            "DREAM_AGENT_KEY": {"type": "string"},
+            "GGUF_FILE": {"type": "string"},
+        }
+    }
+    (install_dir / ".env.schema.json").write_text(json.dumps(schema), encoding="utf-8")
+    (install_dir / ".env").write_text("DREAM_AGENT_KEY=existing\n", encoding="utf-8")
+
+    monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+    monkeypatch.setattr(_mod, "DATA_DIR", data_dir)
+    monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+    return install_dir, data_dir
+
+
+def _make_body(raw_text: str, backup: bool = True) -> bytes:
+    return json.dumps({"raw_text": raw_text, "backup": backup}).encode("utf-8")
+
+
+class TestHandleEnvUpdate:
+
+    def test_happy_path_writes_file_and_returns_backup(self, env_update_env):
+        install_dir, data_dir = env_update_env
+        body = _make_body("DREAM_AGENT_KEY=newvalue\nGGUF_FILE=/models/foo.gguf\n")
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 200
+        resp = handler.parse_response()
+        assert resp["status"] == "ok"
+        assert resp["backup_path"].startswith("data/config-backups/.env.backup.")
+        env_text = (install_dir / ".env").read_text(encoding="utf-8")
+        assert "DREAM_AGENT_KEY=newvalue" in env_text
+        assert "GGUF_FILE=/models/foo.gguf" in env_text
+        # backup file actually exists where the response says it does
+        backup_files = list((data_dir / "config-backups").glob(".env.backup.*"))
+        assert len(backup_files) == 1
+
+    def test_413_oversize_body(self, env_update_env):
+        # Construct headers claiming body is too large; rfile content is irrelevant.
+        handler = _FakeHandler(b"x", headers={"Content-Length": str(_mod.MAX_BODY + 999999) if hasattr(_mod, "MAX_BODY") else "100000"})
+        # MAX_ENV_BODY is hard-coded to 65536 inside the handler.
+        handler.headers["Content-Length"] = "70000"
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 413
+        assert "too large" in handler.parse_response()["error"].lower()
+
+    def test_400_unknown_key(self, env_update_env):
+        body = _make_body("NOT_IN_SCHEMA=foo\n")
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 400
+        assert "Unknown key" in handler.parse_response()["error"]
+
+    def test_400_malformed_line(self, env_update_env):
+        body = _make_body("THIS_LINE_HAS_NO_EQUALS\n")
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 400
+        assert "Malformed line" in handler.parse_response()["error"]
+
+    def test_400_control_char_in_value(self, env_update_env):
+        body = _make_body("DREAM_AGENT_KEY=foo\x00bar\n")
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 400
+        assert "control characters" in handler.parse_response()["error"]
+
+    def test_400_control_char_escape_sequence(self, env_update_env):
+        # ESC (0x1b) — common in injected ANSI sequences
+        body = _make_body("DREAM_AGENT_KEY=foo\x1b[31mbar\n")
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 400
+
+    def test_tab_in_value_is_allowed(self, env_update_env):
+        # Tab is the only sub-32 char that should pass through.
+        body = _make_body("DREAM_AGENT_KEY=foo\tbar\n")
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 200
+
+    def test_409_lock_contention(self, env_update_env):
+        body = _make_body("DREAM_AGENT_KEY=newvalue\n")
+        handler = _FakeHandler(body)
+
+        assert _mod._model_activate_lock.acquire(blocking=False)
+        try:
+            _mod.AgentHandler._handle_env_update(handler)
+        finally:
+            _mod._model_activate_lock.release()
+
+        assert handler.response_code == 409
+        assert "in progress" in handler.parse_response()["error"]
+
+    def test_500_missing_schema(self, env_update_env):
+        install_dir, _ = env_update_env
+        (install_dir / ".env.schema.json").unlink()
+        body = _make_body("DREAM_AGENT_KEY=newvalue\n")
+        handler = _FakeHandler(body)
+
+        _mod.AgentHandler._handle_env_update(handler)
+
+        assert handler.response_code == 500
+        assert ".env.schema.json not found" in handler.parse_response()["error"]

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -287,3 +287,25 @@ def test_api_settings_env_apply_rejects_disallowed_service(test_client):
 
     assert response.status_code == 400
     assert "not eligible" in response.json()["detail"]["message"].lower()
+
+
+# --- Render round-trip fidelity ---
+
+
+def test_render_env_preserves_extras_with_empty_values():
+    """Keys with empty values must survive _render_env_from_values round-trip.
+
+    Regression guard for fork issue #335: the old filter
+    ``value != ""`` silently dropped keys like LLAMA_ARG_TENSOR_SPLIT=""
+    on every save.
+    """
+    from main import _render_env_from_values
+
+    values = {
+        "LLM_BACKEND": "local",
+        "TENSOR_SPLIT": "",       # intentionally empty
+        "GPU_UUID": "GPU-abc123",
+    }
+    rendered = _render_env_from_values(values)
+    assert "TENSOR_SPLIT=" in rendered
+    assert "GPU_UUID=GPU-abc123" in rendered

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -64,6 +64,18 @@ def settings_env_fixture(tmp_path, monkeypatch):
     monkeypatch.setattr("main._resolve_runtime_env_path", lambda: env_path)
     monkeypatch.setattr("main.DATA_DIR", str(data_root))
 
+    def fake_env_update(raw_text):
+        backup_dir = data_root / "config-backups"
+        backup_dir.mkdir(parents=True, exist_ok=True)
+        backup_path = backup_dir / ".env.backup.test"
+        if env_path.exists():
+            backup_path.write_bytes(env_path.read_bytes())
+        payload = raw_text if raw_text.endswith("\n") else raw_text + "\n"
+        env_path.write_text(payload, encoding="utf-8")
+        return {"backup_path": "data/config-backups/.env.backup.test"}
+
+    monkeypatch.setattr("main._call_agent_env_update", fake_env_update)
+
     def fake_resolve_template(name: str):
         if name == ".env.example":
             return example_path


### PR DESCRIPTION
> **Merge order:** Merge after #906, #905, and #900 — touches `dream-host-agent.py` and `docker-compose.base.yml`.

## What
Restores the `.env` mount for the `dashboard-api` container to `:ro` and routes env-editor writes through a new host-agent endpoint `POST /v1/env/update`, mirroring the existing host-agent-owned write path used by model activation.

## Why (security regression)
Commit `c7ffea39` (settings environment editor) changed the dashboard-api `.env` mount from `:ro` to writable so the new `PUT /api/settings/env` endpoint could write `.env` with `_write_text_atomic(env_path, raw_text)` from inside the container.

The endpoint itself is API-key-gated, but the filesystem-level `:rw` mount is a container escape risk: any RCE in the dashboard-api container (dependency CVE, SSRF chain, malicious extension manifest during install) now has write access to `.env` at the filesystem level, bypassing the API key check entirely.

Before this regression, container RCE meant **credential read**. After the regression, it meant **credential overwrite** — an attacker could plant a known `DREAM_AGENT_KEY`, reset `DASHBOARD_API_KEY`, overwrite cloud API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`), then reach the host agent on port 7710 for full container lifecycle control.

## How
1. **docker-compose.base.yml** — restore `- ./.env:/dream-server/.env:ro`.
2. **dream-host-agent.py** — new `POST /v1/env/update` endpoint + `_handle_env_update` method that:
   - authenticates via `check_auth`
   - enforces its own `MAX_ENV_BODY = 65536` (default `MAX_BODY = 16384` truncates real `.env` files which routinely exceed 16KB)
   - validates the raw body parses as JSON with a `raw_text` string
   - loads `.env.schema.json` from `INSTALL_DIR`, uses `properties` keys as the allowlist
   - validates every line: unknown keys → 400, malformed lines → 400, values containing ASCII control characters (other than tab) → 400
   - acquires `_model_activate_lock` non-blocking (409 on contention) to avoid racing concurrent `_do_model_activate` calls, which also read-modify-write `.env`
   - backs up the current `.env` under `DATA_DIR/config-backups/.env.backup.<timestamp>`
   - writes atomically via tempfile + `os.replace`
   - returns the relative backup path in the response
   - logs every reject path with client IP for audit trail
3. **dashboard-api/main.py** — new `_call_agent_env_update(raw_text)` helper mirroring `_call_agent_core_recreate`. `api_settings_env_save` still runs the existing `_prepare_env_save` validation for UX, then delegates the write to the host agent via the helper, handling `HTTPError`/`URLError`/`OSError` into 503/500.
4. Delete three now-orphaned helpers from `main.py`: `_write_text_atomic`, `_resolve_env_backup_root`, `_display_backup_path`.
5. Update `test_settings_env.py` fixture `settings_env_fixture` with a monkeypatch for `_call_agent_env_update` that fakes the agent response (fake also writes the target file so existing read-back tests pass).
6. Add `TestHandleEnvUpdate` to `test_host_agent.py` — 9 tests covering happy path, 413 oversize, 400 unknown key / malformed line / control char (`\x00` and `\x1b`), tab allowed, 409 lock contention, 500 missing schema.

## Testing
- \`pytest dashboard-api/tests/test_host_agent.py dashboard-api/tests/test_settings_env.py\` → 41 passed (10 settings env + 31 host agent)
- \`python3 -m py_compile\` on both modified .py files → clean
- YAML valid: \`python3 -c "import yaml; yaml.safe_load(open('docker-compose.base.yml'))"\`
- **Manual test needed:**
  1. Install cleanly, open dashboard Settings → Environment editor.
  2. Change a field (e.g. \`OLLAMA_PORT\`), click Save. Expected: 200 + backup path returned.
  3. Verify \`data/config-backups/.env.backup.*\` file exists with previous contents.
  4. Verify new \`.env\` on host has the new value.
  5. Inspect the running dashboard-api container: \`docker exec dream-dashboard-api mount | grep .env\` — should show \`ro\`.
  6. From inside the container: \`docker exec dream-dashboard-api sh -c 'echo test > /dream-server/.env'\` — must fail with "Read-only file system".
  7. Try an oversize body: oversized curl POST to \`/v1/env/update\` → expect 413.
  8. Try an unknown key: curl with \`{"raw_text": "NOT_IN_SCHEMA=foo"}\` → expect 400.

## Platform Impact
- **macOS:** affected — the host agent runs natively via launchd. \`.env\` lives under \`INSTALL_DIR\` on the host filesystem, backups go under \`DATA_DIR/config-backups/\`. \`:ro\` mount works identically on Docker Desktop.
- **Linux:** affected — host agent runs natively via systemd. Same behavior.
- **Windows/WSL2:** affected — host agent runs inside the WSL2 distro. \`.env\` lives on the WSL2 filesystem. \`:ro\` mount works identically on Docker Desktop for Windows.

## Known residual risk
An attacker with a valid \`DREAM_AGENT_KEY\` can still set any schema-allowed key — this is the intended threat model for the endpoint. The raw-text-blob API (versus structured key-value JSON) is an architectural tradeoff that is worth revisiting in a future hardening pass, but is out of scope for this security regression fix.

Multi-line value injection via JSON-embedded \`\n\`: \`splitlines()\` will decompose the attacker's raw_text into multiple lines and each line re-enters full key + control-char validation. A smuggled line whose key is ALSO in \`.env.schema.json\` would be written — but such a write requires an already-authenticated caller, so the attacker has already passed the API-key gate and could use the legitimate API to set the same keys. This is the accepted tradeoff of the raw-text API.

## Follow-up items (deferred, not blocking)
- Consider migrating the endpoint to structured \`{"values": {"KEY": "value", ...}}\` body shape in a future PR — eliminates the multi-line parsing ambiguity at the API layer.