### PR TITLE
fix(dashboard-api): non-blocking apply_template + resolve built-in extensions

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -1036,15 +1036,27 @@ def _get_missing_deps_transitive(
 def _activate_service(service_id: str) -> dict:
     """Core enable logic — NO lock acquisition. Called inside _extensions_lock.
 
+    Checks both USER_EXTENSIONS_DIR (user-installed) and EXTENSIONS_DIR
+    (built-in) so templates can enable built-in extensions like n8n, tts, etc.
+
     Returns a result dict for the service. Cycle detection is handled
     upstream by _get_missing_deps_transitive.
     """
-    ext_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
-    if not ext_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()):
+    user_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
+    builtin_dir = (EXTENSIONS_DIR / service_id).resolve()
+
+    in_user = user_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve())
+    in_builtin = builtin_dir.is_relative_to(EXTENSIONS_DIR.resolve())
+    if not in_user and not in_builtin:
         raise HTTPException(
             status_code=404, detail=f"Extension not found: {service_id}",
         )
-    if not ext_dir.is_dir():
+
+    if in_user and user_dir.is_dir():
+        ext_dir = user_dir
+    elif in_builtin and builtin_dir.is_dir():
+        ext_dir = builtin_dir
+    else:
         raise HTTPException(
             status_code=404, detail=f"Extension not installed: {service_id}",
         )

--- a/dream-server/extensions/services/dashboard-api/routers/templates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/templates.py
@@ -1,5 +1,6 @@
 """Service template endpoints."""
 
+import asyncio
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -114,6 +115,29 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
         _call_agent_invalidate_compose_cache,
     )
 
+    # Blocking sections run in the thread pool so the event loop stays
+    # responsive: urllib install fetches use 300s timeouts, and host-agent
+    # calls block on the network. _extensions_lock cannot cross thread
+    # boundaries, so each lock acquisition runs inside a single off-loop call.
+    def _install_with_lock(sid: str) -> None:
+        with _extensions_lock():
+            _install_from_library(sid)
+            _call_agent_invalidate_compose_cache()
+
+    def _activate_with_lock(sid: str, missing_deps, prior_results):
+        deps_enabled: list[str] = []
+        with _extensions_lock():
+            for dep in missing_deps:
+                if dep in prior_results:
+                    continue
+                dep_result = _activate_service(dep)
+                if dep_result.get("action") == "enabled":
+                    deps_enabled.append(dep)
+            main_result = _activate_service(sid)
+            if deps_enabled or main_result.get("action") == "enabled":
+                _call_agent_invalidate_compose_cache()
+        return deps_enabled, main_result
+
     service_list = get_cached_services()
     if service_list is None:
         service_list = await get_all_services()
@@ -145,10 +169,8 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
             # will report "already_enabled" afterwards — we still want to start it.
             if _is_installable(svc_id) and not (USER_EXTENSIONS_DIR / svc_id).is_dir():
                 try:
-                    with _extensions_lock():
-                        _install_from_library(svc_id)
-                        _call_agent_invalidate_compose_cache()
-                    _call_agent_hook(svc_id, "post_install")
+                    await asyncio.to_thread(_install_with_lock, svc_id)
+                    await asyncio.to_thread(_call_agent_hook, svc_id, "post_install")
                     library_installed.append(svc_id)
                 except HTTPException as exc:
                     detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
@@ -161,21 +183,14 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
 
             # Dep-aware enable: resolve transitive deps, activate leaves first.
             # _activate_service checks both user-installed and built-in extension dirs.
-            missing_deps = _get_missing_deps_transitive(svc_id)
+            missing_deps = await asyncio.to_thread(_get_missing_deps_transitive, svc_id)
 
-            with _extensions_lock():
-                activated_any = False
-                for dep in missing_deps:
-                    if dep in results:
-                        continue
-                    dep_result = _activate_service(dep)
-                    if dep_result.get("action") == "enabled":
-                        enabled_services.append(dep)
-                        results[dep] = "enabled_as_dependency"
-                        activated_any = True
-                result = _activate_service(svc_id)
-                if activated_any or result.get("action") == "enabled":
-                    _call_agent_invalidate_compose_cache()
+            deps_enabled, result = await asyncio.to_thread(
+                _activate_with_lock, svc_id, missing_deps, results,
+            )
+            for dep in deps_enabled:
+                enabled_services.append(dep)
+                results[dep] = "enabled_as_dependency"
 
             action = result.get("action", "skipped")
             if svc_id in library_installed:
@@ -196,8 +211,8 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
         # Host agent can only start user-installed extensions
         user_ext_dir = USER_EXTENSIONS_DIR / svc_id
         if user_ext_dir.is_dir():
-            _call_agent_hook(svc_id, "pre_start")
-            start_ok = _call_agent("start", svc_id)
+            await asyncio.to_thread(_call_agent_hook, svc_id, "pre_start")
+            start_ok = await asyncio.to_thread(_call_agent, "start", svc_id)
             if not start_ok:
                 # Preserve library_installed label — user-visible install succeeded,
                 # only the start call failed.
@@ -205,7 +220,7 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
                     results[svc_id] = "enabled_but_start_failed"
                 else:
                     logger.warning("Library-installed extension %s failed to start via agent", svc_id)
-            _call_agent_hook(svc_id, "post_start")
+            await asyncio.to_thread(_call_agent_hook, svc_id, "post_start")
         elif svc_id not in library_installed:
             # Built-in extension: compose file toggled, needs stack restart
             results[svc_id] = "enabled"

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -2055,3 +2055,91 @@ class TestWriteErrorProgress:
         assert data["status"] == "error"
         assert data["error"] == "Agent unreachable"
         assert "phase_label" in data
+
+# --- _activate_service: built-in (EXTENSIONS_DIR) branch ---
+
+
+class TestActivateServiceBuiltinBranch:
+    """_activate_service must resolve services from EXTENSIONS_DIR (built-in)
+    when not present under USER_EXTENSIONS_DIR — required so templates can
+    enable built-in extensions like n8n, tts, etc."""
+
+    def test_activate_service_resolves_builtin_with_disabled_compose(
+        self, monkeypatch, tmp_path,
+    ):
+        """Built-in extension with compose.yaml.disabled is renamed to compose.yaml."""
+        from routers.extensions import _activate_service
+
+        builtin_root = tmp_path / "builtin"
+        user_root = tmp_path / "user"
+        builtin_root.mkdir()
+        user_root.mkdir()
+        ext_dir = builtin_root / "fakesvc"
+        ext_dir.mkdir()
+        (ext_dir / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
+
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_root)
+
+        result = _activate_service("fakesvc")
+
+        assert result == {"id": "fakesvc", "action": "enabled"}
+        assert (ext_dir / "compose.yaml").exists()
+        assert not (ext_dir / "compose.yaml.disabled").exists()
+
+    def test_activate_service_resolves_builtin_already_enabled(
+        self, monkeypatch, tmp_path,
+    ):
+        """Built-in extension already enabled returns idempotent action without mutation."""
+        from routers.extensions import _activate_service
+
+        builtin_root = tmp_path / "builtin"
+        user_root = tmp_path / "user"
+        builtin_root.mkdir()
+        user_root.mkdir()
+        ext_dir = builtin_root / "fakesvc"
+        ext_dir.mkdir()
+        enabled_compose = ext_dir / "compose.yaml"
+        enabled_compose.write_text(_SAFE_COMPOSE)
+
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_root)
+
+        result = _activate_service("fakesvc")
+
+        assert result == {"id": "fakesvc", "action": "already_enabled"}
+        assert enabled_compose.exists()
+        assert not (ext_dir / "compose.yaml.disabled").exists()
+
+    def test_activate_service_user_dir_takes_precedence_over_builtin(
+        self, monkeypatch, tmp_path,
+    ):
+        """When the same id exists in both, the user-installed copy wins."""
+        from routers.extensions import _activate_service
+
+        builtin_root = tmp_path / "builtin"
+        user_root = tmp_path / "user"
+        builtin_root.mkdir()
+        user_root.mkdir()
+
+        # User dir: disabled, expected to be activated
+        user_ext = user_root / "fakesvc"
+        user_ext.mkdir()
+        (user_ext / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
+
+        # Built-in: already enabled, must remain untouched
+        builtin_ext = builtin_root / "fakesvc"
+        builtin_ext.mkdir()
+        builtin_compose = builtin_ext / "compose.yaml"
+        builtin_compose.write_text(_SAFE_COMPOSE)
+
+        monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_root)
+
+        result = _activate_service("fakesvc")
+
+        assert result == {"id": "fakesvc", "action": "enabled"}
+        assert (user_ext / "compose.yaml").exists()
+        assert not (user_ext / "compose.yaml.disabled").exists()
+        # Built-in untouched
+        assert builtin_compose.exists()

--- a/dream-server/extensions/services/dashboard-api/tests/test_templates.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_templates.py
@@ -686,3 +686,103 @@ async def test_template_apply_invalidates_compose_flags_cache(tmp_path):
 
     # Cache invalidation must fire at least once for the activation path.
     assert mock_invalidate.called, "apply_template must invalidate .compose-flags cache"
+
+
+# --- Event-loop non-blocking guarantee (structural / AST proof) ---
+
+
+def test_apply_template_blocking_calls_run_in_to_thread():
+    """Every blocking helper inside apply_template must be wrapped in
+    asyncio.to_thread so the event loop is not stalled while waiting on
+    network or filesystem locks.
+
+    This is a structural proof: we walk the AST of apply_template and
+    confirm that any Call to a known blocking helper appears as the first
+    argument of an asyncio.to_thread(...) call inside an Await.
+    Replaces a flaky concurrent-request timing test with a deterministic
+    one.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from routers.templates import apply_template
+
+    blocking_callees = {
+        "_call_agent_hook",
+        "_call_agent",
+        "_call_agent_invalidate_compose_cache",
+        "_get_missing_deps_transitive",
+        "_install_from_library",
+        "_install_with_lock",
+        "_activate_with_lock",
+    }
+
+    src = textwrap.dedent(inspect.getsource(apply_template))
+    tree = ast.parse(src)
+
+    # Collect every Call to a blocking helper
+    found_blocking_calls: list[tuple[str, bool]] = []
+
+    class _Walker(ast.NodeVisitor):
+        def __init__(self):
+            self.in_to_thread_first_arg = False
+
+        def visit_Call(self, node: ast.Call) -> None:
+            func_name = None
+            if isinstance(node.func, ast.Attribute):
+                func_name = node.func.attr
+            elif isinstance(node.func, ast.Name):
+                func_name = node.func.id
+
+            # Check whether this is asyncio.to_thread(<callee>, ...) and mark
+            # its first positional arg as "wrapped".
+            is_to_thread = (
+                isinstance(node.func, ast.Attribute)
+                and node.func.attr == "to_thread"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "asyncio"
+            )
+            if is_to_thread and node.args:
+                first = node.args[0]
+                # The first argument should be a Name referencing a callable
+                if isinstance(first, ast.Name) and first.id in blocking_callees:
+                    found_blocking_calls.append((first.id, True))
+
+            # Detect direct (non-wrapped) calls to blocking helpers — these
+            # would be the regression we want to prevent.
+            if func_name in blocking_callees and not is_to_thread:
+                found_blocking_calls.append((func_name, False))
+
+            self.generic_visit(node)
+
+    _Walker().visit(tree)
+
+    # Build a map: callee -> set of (wrapped) booleans seen
+    seen: dict[str, set[bool]] = {}
+    for name, wrapped in found_blocking_calls:
+        seen.setdefault(name, set()).add(wrapped)
+
+    # The blocking helpers we expect apply_template to invoke
+    must_be_wrapped = {
+        "_call_agent_hook",
+        "_call_agent",
+        "_get_missing_deps_transitive",
+        "_install_with_lock",
+        "_activate_with_lock",
+    }
+
+    for callee in must_be_wrapped:
+        assert callee in seen, (
+            f"Expected apply_template to call {callee}() — not found in AST. "
+            f"Either the helper was renamed or the to_thread wrapping was removed."
+        )
+        assert True in seen[callee], (
+            f"{callee}() is called but never wrapped in asyncio.to_thread(...). "
+            f"This would block the event loop and is a regression of the "
+            f"apply_template async fix."
+        )
+        assert False not in seen[callee], (
+            f"{callee}() is called directly (without asyncio.to_thread). "
+            f"All blocking helpers must run in the thread pool."
+        )


### PR DESCRIPTION
> **Merge order:** Merge before #926, #907, and #935 — all modify `extensions.py`.

## What
Two related dashboard-api bugs:

1. `apply_template` was `async def` but called blocking urllib-based helpers with 300s timeouts, stalling the FastAPI event loop and freezing every other request for potentially minutes at a time.
2. `_activate_service` only resolved extension directories under `USER_EXTENSIONS_DIR`, silently 404'ing on the 11 built-in extensions that live in `EXTENSIONS_DIR`. All 11 shipped templates (chat-playground, voice-assistant, creative-studio, llm-platform, ...) reference at least one built-in, so template apply silently "succeeded" with `enabled_count: 0` and the UI showed "Template applied" but nothing actually started.

## Why
**Event-loop stall (async handler + blocking I/O):** `apply_template` at `templates.py:98` is `async def`, so FastAPI runs it directly on the asyncio event loop. Inside, it calls `_call_agent_hook`, `_call_agent`, `_call_agent_invalidate_compose_cache`, and `_install_from_library` — all of which use `urllib.request.urlopen` with blocking 300s timeouts. A template with 5 services could freeze the entire dashboard-api for several minutes while health checks, log streams, and GPU metric polls all time out.

**Silent skip of built-ins:** `_activate_service` at `extensions.py:977` resolves `ext_dir = (USER_EXTENSIONS_DIR / service_id).resolve()`. Built-in extensions are installed by the product at `EXTENSIONS_DIR / <name>/`, not `USER_EXTENSIONS_DIR`. `ext_dir.is_dir()` returned False → `HTTPException(404, "Extension not installed: n8n")`. `apply_template` caught the HTTPException and recorded `"skipped: Extension not installed: n8n"` — no user-visible error. The in-code comment at `templates.py:163` said "_activate_service checks both user-installed and built-in extension dirs", which was false.

## How
### Event-loop stall fix
Keep `apply_template` as `async def` and wrap every blocking helper call in `await asyncio.to_thread(...)` — same pattern `main.py:api_settings_env_save` already uses. Introduce two nested helpers (`_install_with_lock`, `_activate_with_lock`) to keep `_extensions_lock` acquisition inside a single off-loop call, because `fcntl` file locks cannot cross thread boundaries in Python.

### Built-in resolution fix
Rewrite `_activate_service` to check both `USER_EXTENSIONS_DIR` and `EXTENSIONS_DIR`, with `is_relative_to` path-traversal validation on each. User dir takes precedence when both exist (matches existing precedence in `_is_dep_satisfied`). The rest of the function (`compose.yaml.disabled` → `compose.yaml` rename logic) operates on the resolved `ext_dir` unchanged.

### Tests
- `TestActivateServiceBuiltinBranch` — 3 tests covering the disabled-compose rename path, the already-enabled idempotent path, and the user-dir-takes-precedence path (all via `tmp_path` + `monkeypatch`).
- `test_templates.py` — structural AST regression test that walks `apply_template`'s source and asserts every blocking helper (`_call_agent_hook`, `_call_agent`, `_get_missing_deps_transitive`, `_install_with_lock`, `_activate_with_lock`) is invoked as the first positional arg of an `await asyncio.to_thread(...)` Call. Any revert to a direct blocking call fails the test with a clear regression message.

## Testing
- \`pytest dashboard-api/tests/test_extensions.py tests/test_templates.py\` → 126 passed (123 pre-existing + 3 new + structural template tests)
- \`python3 -m py_compile\` on both modified .py files → clean
- **Manual test needed:**
  1. Install cleanly, disable a built-in (\`dream disable n8n\`).
  2. In dashboard, apply a template that references n8n (e.g. \`no-code-ai-builder\`). Expected: template apply succeeds, n8n container shows up in \`docker ps\`, UI shows n8n as healthy. Before fix: "Template applied" but n8n never started.
  3. During a template apply, open the dashboard in another tab and hit \`/health\`. Expected: immediate response. Before fix: hung until the apply finished.

## Platform Impact
- **macOS:** affected — Python-only change, identical behavior on all three platforms.
- **Linux:** affected — same.
- **Windows/WSL2:** affected — same.

## Merge order
**This PR should merge BEFORE PR #907 (\`fix/validate-service-id-always-on\`).**

Reason: PR #907's change to \`_is_dep_satisfied\` makes disabled built-ins fall through to \`_activate_service\`. If #907 lands first, \`_activate_service\` still only checks \`USER_EXTENSIONS_DIR\` on upstream/main and would 404 for built-ins. This PR fixes \`_activate_service\` to check both dirs. Same file, disjoint functions — merge is clean in either order but the sequence affects behavior during the brief window between the two landings.

## Known considerations
- **Langfuse edge case:** of the 15 built-in extensions, 14 ship with \`compose.yaml\` and only \`langfuse\` ships with \`compose.yaml.disabled\`. Enabling langfuse via a template renames the disabled compose inside the shipped extensions tree (same pattern the installer's feature-selection already uses at install time — see \`installers/phases/03-features.sh:78-96\`). The installer's \`dream update\` flow preserves file-level state, so this is behavior-consistent with how comfyui/dreamforge are already handled. A follow-up issue at https://github.com/yasinBursali/DreamServer/issues/327 proposes adding langfuse to the install-time feature menu for full parity with the other optional extensions.
- **\`_is_dep_satisfied\` correctness:** the pre-existing function treats any \`CORE_SERVICE_IDS\` member as "always satisfied", which is wrong for built-in extensions that haven't actually been enabled yet. This is fixed in the companion PR #907 (which should merge after this one).