### PR TITLE
fix: lemonade model routing, dreamforge permissions, openclaw config

### DIFF
--- a/dream-server/config/litellm/lemonade.yaml
+++ b/dream-server/config/litellm/lemonade.yaml
@@ -1,14 +1,14 @@
 model_list:
-  # Wildcard — pass any model name through to Lemonade's OpenAI-compatible API.
-  # Lemonade auto-discovers models from --extra-models-dir and serves them
-  # at /api/v1. Uses the same wildcard approach as local.yaml (NVIDIA/CPU).
+  # Lemonade exposes models as "extra.<GGUF_FILENAME>" — the wildcard
+  # passthrough (openai/*) does NOT work because it forwards the friendly
+  # model name verbatim and lemonade returns 404.
   #
-  # The previous config tried to map os.environ/LLM_MODEL to a specific
-  # Lemonade model ID, but the env vars were never passed to the container
-  # and the model name changed after bootstrap upgrade.
+  # This file is a template. The installer (06-directories.sh) generates
+  # the actual config with the correct model ID at install time, and
+  # bootstrap-upgrade.sh regenerates it when the model swaps.
   - model_name: "*"
     litellm_params:
-      model: openai/*
+      model: openai/extra.GGUF_FILENAME_HERE
       api_base: http://llama-server:8080/api/v1
       api_key: sk-lemonade
 

--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -213,7 +213,7 @@ try {
     // Fix provider baseUrl to match the actual LLM endpoint (OLLAMA_URL env)
     const ollamaUrl = process.env.OLLAMA_URL || '';
     if (ollamaUrl) {
-      const provs = primary.providers || {};
+      const provs = primary.models?.providers || primary.providers || {};
       for (const [name, prov] of Object.entries(provs)) {
         if (prov.baseUrl) {
           const oldUrl = prov.baseUrl;

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -6,7 +6,7 @@ services:
     security_opt:
       - no-new-privileges:true
     environment:
-      - OPENCLAW_CONFIG=/config/openclaw-strix-halo.json
+      - OPENCLAW_CONFIG=/config/openclaw.json
       - OPENCLAW_DATA=/data
       - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_TOKEN:?Set OPENCLAW_TOKEN in .env}
       - LLM_MODEL=${LLM_MODEL:-qwen3:30b-a3b}

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -39,7 +39,7 @@ else
     # Create directories
     dream_progress 38 "directories" "Creating directory structure"
     mkdir -p "$INSTALL_DIR"/{config,data,models}
-    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield,dreamforge}
+    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield,dreamforge,ape}
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
@@ -373,7 +373,15 @@ ENV_EOF
     # bootstrap-upgrade.sh regenerates this config when the model swaps.
     if [[ "$GPU_BACKEND" == "amd" ]]; then
         mkdir -p "$INSTALL_DIR/config/litellm"
-        _active_gguf="${BOOTSTRAP_GGUF_FILE:-$GGUF_FILE}"
+        # Source bootstrap-model.sh for BOOTSTRAP_GGUF_FILE and bootstrap_needed().
+        # Pure library (zero side effects), all deps available by phase 06.
+        # Phase 11 re-sources it harmlessly (idempotent).
+        [[ -f "$SCRIPT_DIR/installers/lib/bootstrap-model.sh" ]] && . "$SCRIPT_DIR/installers/lib/bootstrap-model.sh"
+        if type bootstrap_needed &>/dev/null && bootstrap_needed; then
+            _active_gguf="$BOOTSTRAP_GGUF_FILE"
+        else
+            _active_gguf="$GGUF_FILE"
+        fi
         cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
 model_list:
   - model_name: "*"

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -39,7 +39,7 @@ else
     # Create directories
     dream_progress 38 "directories" "Creating directory structure"
     mkdir -p "$INSTALL_DIR"/{config,data,models}
-    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield}
+    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield,dreamforge}
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
@@ -365,18 +365,20 @@ ENV_EOF
     ai_ok "Created $INSTALL_DIR"
     ai_ok "Generated secure secrets in .env (permissions: 600)"
 
-    # Generate LiteLLM config for Lemonade — wildcard-only.
-    # Lemonade auto-discovers models from --extra-models-dir and resolves
-    # model names internally. No hardcoded model aliases needed — the wildcard
-    # passes any model name through to Lemonade's OpenAI-compatible API.
-    # This avoids stale model references after bootstrap-upgrade swaps models.
+    # Generate LiteLLM config for Lemonade.
+    # Lemonade exposes models as "extra.<GGUF_FILENAME>" — the wildcard
+    # passthrough (openai/*) does NOT work because it forwards the friendly
+    # model name verbatim and lemonade returns 404.  Instead, map all
+    # requests to the concrete model ID that lemonade actually serves.
+    # bootstrap-upgrade.sh regenerates this config when the model swaps.
     if [[ "$GPU_BACKEND" == "amd" ]]; then
         mkdir -p "$INSTALL_DIR/config/litellm"
+        _active_gguf="${BOOTSTRAP_GGUF_FILE:-$GGUF_FILE}"
         cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
 model_list:
   - model_name: "*"
     litellm_params:
-      model: openai/*
+      model: openai/extra.${_active_gguf}
       api_base: http://llama-server:8080/api/v1
       api_key: sk-lemonade
 
@@ -386,7 +388,7 @@ litellm_settings:
   request_timeout: 120
   stream_timeout: 60
 LITELLM_EOF
-        ai_ok "Generated LiteLLM config for Lemonade (wildcard routing)"
+        ai_ok "Generated LiteLLM config for Lemonade (model: extra.${_active_gguf})"
     fi
 
     # Validate generated .env against schema (fails fast on missing/unknown keys).

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -64,7 +64,8 @@ $_dirs = @(
     (Join-Path $_dataDir "qdrant"),
     (Join-Path $_dataDir "models"),
     (Join-Path $_dataDir "comfyui"),
-    (Join-Path $_dataDir "perplexica")
+    (Join-Path $_dataDir "perplexica"),
+    (Join-Path $_dataDir "dreamforge")
 )
 foreach ($_d in $_dirs) {
     New-Item -ItemType Directory -Path $_d -Force | Out-Null

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -361,10 +361,25 @@ if command -v docker &>/dev/null && docker ps --filter name=dream-llama-server -
 
     if $_healthy; then
         log "SUCCESS: llama-server is running with $FULL_LLM_MODEL"
-        # Restart LiteLLM so it picks up the new model context.
-        # The lemonade.yaml wildcard config passes any model name through,
-        # but LiteLLM caches routing state and may hold stale model references.
+        # Regenerate lemonade.yaml with the new model ID and restart LiteLLM.
+        # Lemonade exposes models as "extra.<GGUF_FILE>" — the config must
+        # reference the exact ID, not a wildcard passthrough.
         if docker ps --filter name=dream-litellm --format '{{.Names}}' 2>/dev/null | grep -q dream-litellm; then
+            log "Updating LiteLLM config for new model: extra.${FULL_GGUF_FILE}"
+            cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_UPGRADE_EOF
+model_list:
+  - model_name: "*"
+    litellm_params:
+      model: openai/extra.${FULL_GGUF_FILE}
+      api_base: http://llama-server:8080/api/v1
+      api_key: sk-lemonade
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 120
+  stream_timeout: 60
+LITELLM_UPGRADE_EOF
             log "Restarting LiteLLM to pick up model change..."
             docker restart dream-litellm 2>&1 || log "WARNING: LiteLLM restart failed (non-fatal)"
         fi


### PR DESCRIPTION
## Summary

Three bugs that break fresh installs on AMD (lemonade) systems:

- **LiteLLM lemonade.yaml**: wildcard passthrough (`openai/*`) forwards friendly model names (e.g. `qwen3.5-2b`) verbatim to lemonade-server, which exposes models as `extra.<GGUF_FILE>` — causing 404 on every chat request from Open WebUI, Perplexica, and DreamForge. Fix: generate config with the concrete `extra.` model ID at install time; regenerate in `bootstrap-upgrade.sh` when the model swaps.

- **DreamForge sessions dir**: `data/dreamforge` was missing from the `mkdir` list in `06-directories.sh`. Docker auto-creates the mount as root, so the `forger` user (uid 1000) gets "Permission denied" when creating the sessions subdirectory.

- **OpenClaw compose config**: `OPENCLAW_CONFIG` env var was hardcoded to the raw template (`openclaw-strix-halo.json`) which contains unresolved `__LITELLM_KEY__` and `__LLM_MODEL__` placeholders. The installer resolves these into `openclaw.json`, so the env var should point there. Also fixes `inject-token.js` Part 3 provider iteration to check `models.providers` (where strix-halo config nests them), not just top-level `providers`.

## Test plan

- [ ] Fresh install on AMD (lemonade) system — verify Open WebUI, Perplexica, DreamForge all get chat responses
- [ ] Verify bootstrap model works immediately, then full model auto-swaps and LiteLLM config regenerates
- [ ] Verify DreamForge can create sessions without permission errors
- [ ] Verify OpenClaw uses local LLM via LiteLLM, not Anthropic API
- [ ] Run `make test` — installer contracts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)