### PR TITLE
fix(07-devtools): recover from corrupt opencode.json when jq parse fails (#332)

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -123,8 +123,11 @@ else
             _opencode_key="no-key"
         fi
 
-        if [[ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]]; then
-            cat > "$OPENCODE_CONFIG_DIR/opencode.json" <<OPENCODE_EOF
+        # Writes a fresh opencode.json from the template. Used for first-install
+        # and as deterministic recovery when the jq rewrite path finds an
+        # existing malformed file it cannot parse (issue #332).
+        _opencode_write_fresh() {
+            cat > "$1" <<OPENCODE_EOF
 {
   "\$schema": "https://opencode.ai/config.json",
   "model": "llama-server/${LLM_MODEL}",
@@ -150,20 +153,26 @@ else
   }
 }
 OPENCODE_EOF
+        }
+
+        if [[ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]]; then
+            _opencode_write_fresh "$OPENCODE_CONFIG_DIR/opencode.json"
             ai_ok "OpenCode configured for local llama-server (model: ${LLM_MODEL})"
         else
             # Reinstall: update API key and URL in existing config (key may have changed)
+            _opencode_updated=false
             if command -v jq >/dev/null 2>&1; then
                 _opencode_tmp="$OPENCODE_CONFIG_DIR/opencode.json.tmp.$$"
                 if jq --arg url "$_opencode_url" --arg key "$_opencode_key" \
                     '.provider["llama-server"].options.baseURL = $url
                      | .provider["llama-server"].options.apiKey = $key' \
-                    "$OPENCODE_CONFIG_DIR/opencode.json" > "$_opencode_tmp"; then
+                    "$OPENCODE_CONFIG_DIR/opencode.json" > "$_opencode_tmp" 2>/dev/null; then
                     mv "$_opencode_tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
                     ai_ok "OpenCode config updated (API key and URL refreshed)"
+                    _opencode_updated=true
                 else
                     rm -f "$_opencode_tmp"
-                    ai_warn "OpenCode config jq rewrite failed; leaving existing config in place"
+                    ai_warn "OpenCode config jq rewrite failed (existing file unparseable) — regenerating from template"
                 fi
             else
                 # Fallback without jq: narrow sed that only matches the quoted value,
@@ -171,6 +180,14 @@ OPENCODE_EOF
                 _sed_i "s|\"apiKey\": *\"[^\"]*\"|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
                 _sed_i "s|\"baseURL\": *\"[^\"]*\"|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
                 ai_ok "OpenCode config updated (API key and URL refreshed)"
+                _opencode_updated=true
+            fi
+            # Recovery path (issue #332): if the update branch above failed to
+            # produce a valid file (jq parse error on pre-existing corruption),
+            # regenerate deterministically from the template.
+            if [[ "$_opencode_updated" != "true" ]]; then
+                _opencode_write_fresh "$OPENCODE_CONFIG_DIR/opencode.json"
+                ai_ok "OpenCode config regenerated from template (recovered from corruption)"
             fi
         fi
         # OpenCode reads config.json, not opencode.json — always sync

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -153,8 +153,23 @@ OPENCODE_EOF
             ai_ok "OpenCode configured for local llama-server (model: ${LLM_MODEL})"
         else
             # Reinstall: update API key and URL in existing config (key may have changed)
-            _sed_i "s|\"apiKey\":.*|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
-            _sed_i "s|\"baseURL\":.*|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+            if command -v jq >/dev/null 2>&1; then
+                _opencode_tmp="$OPENCODE_CONFIG_DIR/opencode.json.tmp.$$"
+                if jq --arg url "$_opencode_url" --arg key "$_opencode_key" \
+                    '.provider["llama-server"].options.baseURL = $url
+                     | .provider["llama-server"].options.apiKey = $key' \
+                    "$OPENCODE_CONFIG_DIR/opencode.json" > "$_opencode_tmp"; then
+                    mv "$_opencode_tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
+                else
+                    rm -f "$_opencode_tmp"
+                    ai_warn "OpenCode config jq rewrite failed; leaving existing config in place"
+                fi
+            else
+                # Fallback without jq: narrow sed that only matches the quoted value,
+                # preserving any trailing comma on the line
+                _sed_i "s|\"apiKey\": *\"[^\"]*\"|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+                _sed_i "s|\"baseURL\": *\"[^\"]*\"|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+            fi
             ai_ok "OpenCode config updated (API key and URL refreshed)"
         fi
         # OpenCode reads config.json, not opencode.json — always sync

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -160,6 +160,7 @@ OPENCODE_EOF
                      | .provider["llama-server"].options.apiKey = $key' \
                     "$OPENCODE_CONFIG_DIR/opencode.json" > "$_opencode_tmp"; then
                     mv "$_opencode_tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
+                    ai_ok "OpenCode config updated (API key and URL refreshed)"
                 else
                     rm -f "$_opencode_tmp"
                     ai_warn "OpenCode config jq rewrite failed; leaving existing config in place"
@@ -169,8 +170,8 @@ OPENCODE_EOF
                 # preserving any trailing comma on the line
                 _sed_i "s|\"apiKey\": *\"[^\"]*\"|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
                 _sed_i "s|\"baseURL\": *\"[^\"]*\"|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+                ai_ok "OpenCode config updated (API key and URL refreshed)"
             fi
-            ai_ok "OpenCode config updated (API key and URL refreshed)"
         fi
         # OpenCode reads config.json, not opencode.json — always sync
         cp "$OPENCODE_CONFIG_DIR/opencode.json" "$OPENCODE_CONFIG_DIR/config.json"


### PR DESCRIPTION
## Summary

- Adds a deterministic recovery path when `07-devtools.sh`'s jq rewrite finds an existing `opencode.json` it cannot parse (issue #332).
- Extracts the first-install HEREDOC template into a small shell helper `_opencode_write_fresh` and calls it from both the fresh-install branch and the recovery branch.
- When jq parse fails, warns the operator (so the corruption stays visible) and regenerates the file from the template instead of leaving the broken file in place.

## Context

This **stacks on #901** (`fix/opencode-json-sed`). #901 fixes the WRITE path so new installs don't corrupt `opencode.json` by eating the trailing comma. #332 is the RECOVERY gap it leaves behind: users who upgrade from a pre-#901 broken state had no way out of the bad state because the jq path bailed out instead of falling through to any repair logic.

Closes #332. Cross-ref: parent #309 (closed by #901).

## Runtime validation (WSL2 / Ubuntu 24.04 / jq 1.7)

Reproduced against a real pre-existing corrupted file on the running integration install (missing comma between `baseURL` and `apiKey` siblings, the exact #309/#332 symptom):

```
$ jq -e . ~/.config/opencode/opencode.json
jq: parse error: Expected separator between values at line 11, column 16
$ echo $?
5
```

Rsync'd the patched `07-devtools.sh` into the running install and re-ran the phase:

```
⚠ OpenCode config jq rewrite failed (existing file unparseable) — regenerating from template
✓ OpenCode config regenerated from template (recovered from corruption)
```

Post-fix:

```
$ jq -e . ~/.config/opencode/opencode.json >/dev/null && echo "valid"
valid
$ jq -r '.provider["llama-server"].options.baseURL, .provider["llama-server"].options.apiKey' ~/.config/opencode/opencode.json
http://127.0.0.1:11434/v1
no-key
```

Install health unchanged: 17 containers healthy, `dream-host-agent.service` active, dashboard-api `/health` 200.

## Test plan

- [x] Reproduces the #332 symptom on a corrupt pre-existing `opencode.json`
- [x] Recovery path regenerates a valid JSON file
- [x] Fresh-install branch still produces the same file via the shared helper
- [x] jq-absent sed fallback branch is unchanged in behavior
- [x] Warns before regenerating so the operator sees the corruption was detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)