### PR TITLE
fix(07-devtools): restart dream-host-agent.service after enable --now (#334)

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -217,6 +217,17 @@ if [[ -f "$INSTALL_DIR/bin/dream-host-agent.py" ]]; then
             systemctl --user enable --now dream-host-agent.service >> "$LOG_FILE" 2>&1 && \
                 ai_ok "Dream host agent installed (systemd --user, port 7710)" || \
                 ai_warn "Dream host agent service failed to start — run: dream agent start"
+            # Force-restart so the running process matches the binary the installer
+            # just rewrote. enable --now is a no-op when the unit was already active,
+            # which would leave an old daemon holding a deleted inode and serving
+            # stale code after a reinstall. See issue #334. Use is-enabled (not
+            # is-active) so a temporarily-down daemon during a fresh install still
+            # triggers the restart rather than skipping it.
+            if systemctl --user is-enabled dream-host-agent.service >/dev/null 2>&1; then
+                systemctl --user restart dream-host-agent.service >> "$LOG_FILE" 2>&1 && \
+                    ai_ok "Dream host agent restarted (loaded new binary)" || \
+                    ai_warn "Dream host agent restart failed (non-fatal) — run: systemctl --user restart dream-host-agent.service"
+            fi
             loginctl enable-linger "$(whoami)" 2>/dev/null || \
                 sudo -n loginctl enable-linger "$(whoami)" 2>/dev/null || true
         else


### PR DESCRIPTION
## Summary

- Adds an explicit `systemctl --user restart dream-host-agent.service` after the existing `enable --now` in `07-devtools.sh`, so the running daemon always matches the binary the installer just rewrote.
- Guards on `is-enabled` (not `is-active`) so a temporarily-down daemon during a fresh install still triggers the restart.
- Failures are non-fatal and surface via `ai_warn` with a manual-recovery hint.

## Why this file (not 11-services.sh)

The issue body suggested `11-services.sh` or a hypothetical `12-finalize.sh`, but the host-agent service lifecycle already lives in `07-devtools.sh` (systemd unit template, `daemon-reload`, `enable --now`, `enable-linger`). Adding the restart right after `enable --now` keeps all host-agent service management in one place. The binary at `$INSTALL_DIR/bin/dream-host-agent.py` is already on disk by phase 06, so phase 07 is a safe point to restart.

## macOS

No change needed on the Mac side. `installers/macos/install-macos.sh` already does `launchctl bootout` + `launchctl bootstrap` against the launchd plist, and none of `installers/phases/` runs on macOS. Confirmed via yasinBursali's comment on #334.

Closes #334.

## Runtime validation (WSL2 / Ubuntu 24.04 / systemd user mode)

Reproduced the exact #334 zombie on the running integration install: the host-agent had been up ~21h from a prior install dir that had been `rm -rf`'d, cwd pointed at `/home/rosenrot/dream-server (deleted)`.

**Before the fix** (PR #893's cancel endpoint returning 404 from the zombie):
```
OLD_PID=353285
cwd -> /home/rosenrot/dream-server (deleted)
POST /api/models/download/cancel → {"detail":"Not found"}   # 404 from old code
```

Rsync'd the patched phase into the running install and re-ran phase 07:

```
✓ Dream host agent installed (systemd --user, port 7710)
✓ Dream host agent restarted (loaded new binary)
```

**After the fix**:
```
NEW_PID=486128                                             # ≠ OLD_PID
cwd -> /home/rosenrot/dream-server                         # no "(deleted)"
POST /api/models/download/cancel → {"status":"no_download"}  # 200 from new code
journalctl: "POST /v1/model/download/cancel HTTP/1.1" 200 -
```

Install health unchanged: 17 containers healthy, `dream-host-agent.service` active, dashboard-api `/health` 200.

## Test plan

- [x] Zombie host-agent holding a deleted inode gets replaced with a fresh process on next install
- [x] New process picks up recently-added routes (PR #893's download/cancel)
- [x] `is-enabled` guard skips cleanly if the unit isn't installed (e.g. first-ever install without systemd)
- [x] Restart failure is non-fatal and doesn't abort the install
- [x] No regression on fresh installs (restart of a just-started service is a harmless quick bounce)

🤖 Generated with [Claude Code](https://claude.com/claude-code)