### PR TITLE
fix(openclaw): bypass LiteLLM for Responses API to fix streaming 500s

### DIFF
--- a/dream-server/extensions/services/openclaw/compose.amd.yaml
+++ b/dream-server/extensions/services/openclaw/compose.amd.yaml
@@ -1,0 +1,11 @@
+# AMD/Lemonade overlay — bypass LiteLLM for Responses API.
+#
+# LiteLLM v1.81.3 has a streaming bug: Lemonade omits optional fields
+# (created_at, output) in SSE response.created events and LiteLLM's
+# Pydantic validation rejects them, causing HTTP 500 errors.
+# Lemonade handles the Responses API correctly on its own — both
+# streaming and non-streaming — so bypassing LiteLLM avoids the issue.
+services:
+  openclaw:
+    environment:
+      - OLLAMA_URL=http://llama-server:8080/api


### PR DESCRIPTION
## Summary

- Routes OpenClaw directly to Lemonade `/api/v1` endpoint on **AMD deployments only**, bypassing LiteLLM
- Fixes HTTP 500 errors when OpenClaw uses the streaming Responses API through LiteLLM v1.81.3
- Uses the existing `compose.{gpu_backend}.yaml` overlay mechanism — no changes to non-AMD installs

## Root Cause

LiteLLM v1.81.3 streaming transform for the Responses API requires `created_at` and `output` fields in every SSE event, but Lemonade omits them in `response.created` events. Pydantic validation rejects them, returning HTTP 500.

Lemonade handles the Responses API correctly on its own (both streaming and non-streaming), so bypassing LiteLLM avoids the issue.

## Changes

- **`dream-server/extensions/services/openclaw/compose.amd.yaml`** (new): AMD-specific overlay setting `OLLAMA_URL=http://llama-server:8080/api`
- **`dream-server/extensions/services/openclaw/compose.local.yaml`**: No changes (remains depends_on only)

## Why compose.amd.yaml instead of compose.local.yaml

`compose.local.yaml` applies to ALL local backends (NVIDIA, CPU, Intel, Apple, AMD). Standard llama.cpp does not serve `/api/v1` and does not support the Responses API — only Lemonade does. `compose.amd.yaml` ensures it only activates on AMD hardware, via `resolve-compose-stack.sh` GPU overlay discovery.

## Impact by backend

| Backend | Change | Result |
|---|---|---|
| AMD (Lemonade) | compose.amd.yaml loaded | OpenClaw direct to Lemonade /api/v1 |
| NVIDIA | No overlay loaded | Unchanged (routes through LiteLLM) |
| CPU | No overlay loaded | Unchanged |
| Intel/Arc | No overlay loaded | Unchanged |
| Apple | No overlay loaded | Unchanged |
| Cloud | No local overlays | Unchanged |

## Test plan

- [x] AMD/Lemonade: OpenClaw sends messages without 500 errors
- [x] AMD/Lemonade: Streaming responses work end-to-end
- [ ] NVIDIA: Verify OpenClaw still works through LiteLLM
- [ ] CPU: Verify no regression
- [ ] Cloud mode: Verify compose.amd.yaml is not loaded