### PR TITLE
fix(openclaw): revert strix-halo config to v1 schema

### DIFF
--- a/dream-server/config/openclaw/openclaw-strix-halo.json
+++ b/dream-server/config/openclaw/openclaw-strix-halo.json
@@ -1,37 +1,29 @@
 {
   "$schema": "https://raw.githubusercontent.com/openclaw/openclaw/main/schemas/openclaw.json",
-  "models": {
-    "providers": {
-      "local-llama": {
-        "type": "openai-compatible",
-        "baseUrl": "http://litellm:4000/v1",
-        "apiKey": "__LITELLM_KEY__",
-        "models": [
-          {
-            "id": "__LLM_MODEL__",
-            "contextWindow": 131072,
-            "supportsTools": true
-          }
-        ]
+  "version": "1.0",
+  "agent": {
+    "name": "Dream Agent (Strix Halo)",
+    "model": "local-llama/__LLM_MODEL__",
+    "systemPrompt": "You are Dream Agent, a powerful local AI assistant running on AMD Strix Halo with unified memory. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning. Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself. Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it."
+  },
+  "providers": {
+    "local-llama": {
+      "type": "openai-compatible",
+      "baseUrl": "http://litellm:4000/v1",
+      "apiKey": "__LITELLM_KEY__",
+      "models": {
+        "__LLM_MODEL__": {
+          "contextWindow": 131072,
+          "supportsTools": true
+        }
       }
     }
   },
-  "agents": {
-    "defaults": {
-      "name": "Dream Agent (Strix Halo)",
-      "model": {
-        "primary": "local-llama/__LLM_MODEL__"
-      },
-      "models": {
-        "local-llama/__LLM_MODEL__": {}
-      },
-      "systemPrompt": "You are Dream Agent, a powerful local AI assistant running on AMD Strix Halo with unified memory. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning. Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself. Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it.",
-      "subagents": {
-        "model": "local-llama/__LLM_MODEL__",
-        "maxConcurrent": 20,
-        "timeoutSeconds": 600
-      }
-    }
+  "subagent": {
+    "enabled": true,
+    "model": "local-llama/__LLM_MODEL__",
+    "maxConcurrent": 20,
+    "timeoutSeconds": 600
   },
   "tools": {
     "exec": {


### PR DESCRIPTION
## Summary

- Reverts `openclaw-strix-halo.json` from the non-working schema introduced in #591 back to the v1 schema that OpenClaw v2026.3.8 actually reads
- Fixes Strix Halo installs defaulting to `anthropic/claude-opus-4-6` and failing with "No API key found for provider anthropic"
- Preserves LiteLLM routing (`baseUrl: http://litellm:4000/v1`) and `__LITELLM_KEY__` placeholder from #591

## Root Cause

PR #591 changed the config schema from v1 keys (`agent.model`, top-level `providers`, `subagent`) to different keys (`agents.defaults.model.primary`, `models.providers`, `agents.defaults.subagents`), claiming the old keys were "deprecated in OpenClaw 2026.3.8."

This was incorrect. OpenClaw v2026.3.8 reads `agent.model` for its gateway default model. With the new keys, the gateway can't find the model config and falls back to `anthropic/claude-opus-4-6`.

Every other config template in the repo (`openclaw.json`, `pro.json`) still uses the working v1 schema. Only `openclaw-strix-halo.json` was broken.

## What changed vs what's preserved from #591

| PR #591 change | This PR |
|---|---|
| `agent` -> `agents.defaults` | Reverted |
| `providers` -> `models.providers` | Reverted |
| `subagent` -> `agents.defaults.subagents` | Reverted |
| `version: "1.0"` removed | Restored |
| `gateway.host` removed | Kept removed (inject-token.js handles binding) |
| `baseUrl` -> `http://litellm:4000/v1` | Kept |
| `apiKey` -> `__LITELLM_KEY__` | Kept |
| `models` object -> array format | Reverted to object |

## Test plan

- [x] Strix Halo: fresh volume, gateway shows `local-llama/<model>` (not `anthropic/claude-opus-4-6`)
- [x] Strix Halo: OpenClaw sends messages without "No API key" error
- [ ] Non-Strix-Halo installs: unaffected (file only used for SH_LARGE/SH_COMPACT tiers)

Reverts the config portion of #591.