### PR TITLE
fix(litellm): friendly model name + regenerate config on model swap

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1310,6 +1310,33 @@ class AgentHandler(BaseHTTPRequestHandler):
                 encoding="utf-8",
             )
 
+            # Regenerate LiteLLM lemonade config so it routes to the new model.
+            # Only written on AMD installs where lemonade.yaml exists.
+            litellm_cfg = install_dir / "config" / "litellm" / "lemonade.yaml"
+            if litellm_cfg.exists():
+                litellm_cfg.write_text(
+                    f"model_list:\n"
+                    f"  - model_name: default\n"
+                    f"    litellm_params:\n"
+                    f"      model: openai/extra.{gguf_file}\n"
+                    f"      api_base: http://llama-server:8080/api/v1\n"
+                    f"      api_key: sk-lemonade\n"
+                    f"\n"
+                    f"  - model_name: \"*\"\n"
+                    f"    litellm_params:\n"
+                    f"      model: openai/extra.{gguf_file}\n"
+                    f"      api_base: http://llama-server:8080/api/v1\n"
+                    f"      api_key: sk-lemonade\n"
+                    f"\n"
+                    f"litellm_settings:\n"
+                    f"  drop_params: true\n"
+                    f"  set_verbose: false\n"
+                    f"  request_timeout: 120\n"
+                    f"  stream_timeout: 60\n",
+                    encoding="utf-8",
+                )
+                logger.info("Regenerated lemonade.yaml for model: extra.%s", gguf_file)
+
             # Restart llama-server with the new model.
             # Two strategies depending on where the agent runs:
             # - Host-native (Linux/macOS): docker compose stop+up, same as

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -384,6 +384,12 @@ ENV_EOF
         fi
         cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
 model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/extra.${_active_gguf}
+      api_base: http://llama-server:8080/api/v1
+      api_key: sk-lemonade
+
   - model_name: "*"
     litellm_params:
       model: openai/extra.${_active_gguf}

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -368,6 +368,12 @@ if command -v docker &>/dev/null && docker ps --filter name=dream-llama-server -
             log "Updating LiteLLM config for new model: extra.${FULL_GGUF_FILE}"
             cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_UPGRADE_EOF
 model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/extra.${FULL_GGUF_FILE}
+      api_base: http://llama-server:8080/api/v1
+      api_key: sk-lemonade
+
   - model_name: "*"
     litellm_params:
       model: openai/extra.${FULL_GGUF_FILE}
@@ -382,6 +388,11 @@ litellm_settings:
 LITELLM_UPGRADE_EOF
             log "Restarting LiteLLM to pick up model change..."
             docker restart dream-litellm 2>&1 || log "WARNING: LiteLLM restart failed (non-fatal)"
+        fi
+        # Restart DreamForge so it auto-detects the new model from llama-server
+        if docker ps --filter name=dream-dreamforge --format '{{.Names}}' 2>/dev/null | grep -q dream-dreamforge; then
+            log "Restarting DreamForge to pick up model change..."
+            docker restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
         fi
     else
         log "WARNING: llama-server health check timed out. The model may still be loading."


### PR DESCRIPTION
## Summary

- Open WebUI now shows "default" instead of "*" as the model name on AMD/Lemonade installs
- Model swaps via dashboard no longer leave LiteLLM with a stale GGUF filename
- Bootstrap-to-full model transition now restarts DreamForge (was only restarting LiteLLM)

## Changes (3 files)

### 1. Installer: add `default` model entry to lemonade.yaml
**File:** `installers/phases/06-directories.sh`

Adds a named `default` model entry alongside the wildcard `*`. Matches the pattern already used by `local.yaml` for non-AMD installs.

### 2. Host agent: regenerate lemonade.yaml on model activation
**File:** `bin/dream-host-agent.py`

When a user swaps models via the dashboard (`/v1/model/activate`), regenerates `lemonade.yaml` with the new GGUF filename before restarting LiteLLM. Gated on `lemonade.yaml` existence (AMD only).

### 3. Bootstrap upgrade: add `default` entry + restart DreamForge
**File:** `scripts/bootstrap-upgrade.sh`

The bootstrap-to-full model transition already regenerated lemonade.yaml and restarted LiteLLM, but: (a) used the old `*`-only format, and (b) did not restart DreamForge, leaving it with the stale bootstrap model name. Now includes the `default` entry and restarts DreamForge.

## All three lemonade.yaml generation sites are now consistent

| Location | Generates lemonade.yaml | Has `default` entry | Restarts DreamForge |
|---|---|---|---|
| `06-directories.sh` (installer) | Fresh install | Yes (new) | N/A (first boot) |
| `dream-host-agent.py` (model swap) | On activate | Yes (new) | Already did (line 1369) |
| `bootstrap-upgrade.sh` (bootstrap to full) | On upgrade | Yes (new) | Yes (new) |

## Non-AMD impact: none

All changes are gated on `lemonade.yaml` existence or DreamForge container presence checks.

## Test plan

- [ ] Fresh AMD install: Open WebUI shows "default" as model name
- [ ] Model swap via dashboard: lemonade.yaml updated, LiteLLM + DreamForge restarted
- [ ] Bootstrap to full: lemonade.yaml updated, DreamForge restarted with correct model
- [ ] Non-AMD install: zero change