### PR TITLE
fix(dream-macos): auto-detect install dir from script location when DREAM_HOME unset

### DIFF
--- a/dream-server/installers/lib/path-utils.sh
+++ b/dream-server/installers/lib/path-utils.sh
@@ -47,16 +47,24 @@ normalize_path() {
 # Resolve installation directory with precedence:
 # 1. INSTALL_DIR env var (if set)
 # 2. DREAM_HOME env var (if set) - legacy macOS
-# 3. DS_INSTALL_DIR env var (if set) - legacy macOS
-# 4. Default: $HOME/dream-server
+# 3. DREAM_SCRIPT_HINT env var, only when it points at a populated install
+#    (detected by presence of a .env sentinel at that root). Callers set this
+#    when they know the script lives inside the install dir (e.g. dream-macos.sh
+#    exports SCRIPT_DIR before sourcing constants.sh). The sentinel guard
+#    prevents false positives from /usr/local/bin PATH symlinks or scratch
+#    copies that lack an installer-generated .env.
+# 4. DS_INSTALL_DIR env var (if set) - legacy macOS
+# 5. Default: $HOME/dream-server
 resolve_install_dir() {
     local resolved=""
-    
+
     # Check precedence order
     if [[ -n "${INSTALL_DIR:-}" ]]; then
         resolved="$INSTALL_DIR"
     elif [[ -n "${DREAM_HOME:-}" ]]; then
         resolved="$DREAM_HOME"
+    elif [[ -n "${DREAM_SCRIPT_HINT:-}" ]] && [[ -f "${DREAM_SCRIPT_HINT}/.env" ]]; then
+        resolved="$DREAM_SCRIPT_HINT"
     elif [[ -n "${DS_INSTALL_DIR:-}" ]]; then
         resolved="$DS_INSTALL_DIR"
     else

--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -63,10 +63,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="${SCRIPT_DIR}/lib"
 
+# Hint resolve_install_dir() that the script lives inside a populated install.
+# Lets `bash /path/to/install/dream-macos.sh status` work without DREAM_HOME
+# when /path/to/install contains an installer-generated .env sentinel. Unset
+# after the sourced chain so the hint does not leak into child processes we
+# spawn later (docker compose, curl, etc.).
+export DREAM_SCRIPT_HINT="$SCRIPT_DIR"
+
 # Source only what we need for CLI
 source "${LIB_DIR}/constants.sh"
 source "${LIB_DIR}/ui.sh"
 source "${LIB_DIR}/detection.sh"
+
+unset DREAM_SCRIPT_HINT
 
 # ── Resolve install directory ──
 INSTALL_DIR="${DS_INSTALL_DIR}"
@@ -86,7 +95,8 @@ test_docker_running() {
 
 test_install() {
     if [[ ! -d "$INSTALL_DIR" ]]; then
-        ai_err "Dream Server not found at ${INSTALL_DIR}. Set DREAM_HOME or run installer first."
+        ai_err "Dream Server not found at ${INSTALL_DIR}."
+        ai "Invoke from inside the install dir (bash <install>/dream-macos.sh status), export DREAM_HOME=<install>, or run the installer."
         exit 1
     fi
     local base_compose="${INSTALL_DIR}/docker-compose.base.yml"

--- a/dream-server/installers/macos/lib/constants.sh
+++ b/dream-server/installers/macos/lib/constants.sh
@@ -13,15 +13,29 @@
 
 DS_VERSION="2.4.0"
 
-# Install location - use shared path resolution if available
-MACOS_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
-if [[ -f "$MACOS_SCRIPT_DIR/installers/lib/path-utils.sh" ]]; then
-    . "$MACOS_SCRIPT_DIR/installers/lib/path-utils.sh"
+# Install location - use shared path resolution if available.
+# constants.sh lives at two different depths depending on layout:
+#   source tree: dream-server/installers/macos/lib/constants.sh
+#   installed  : <install>/lib/constants.sh
+# so try both relative locations for path-utils.sh and pick whichever exists.
+_constants_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_path_utils=""
+for _candidate in \
+    "${_constants_dir}/../../lib/path-utils.sh" \
+    "${_constants_dir}/../installers/lib/path-utils.sh"; do
+    if [[ -f "$_candidate" ]]; then
+        _path_utils="$_candidate"
+        break
+    fi
+done
+if [[ -n "$_path_utils" ]]; then
+    . "$_path_utils"
     DS_INSTALL_DIR="$(resolve_install_dir)"
 else
     # Fallback to legacy behavior
     DS_INSTALL_DIR="${DREAM_HOME:-$HOME/dream-server}"
 fi
+unset _constants_dir _path_utils _candidate
 
 # Logging
 DS_LOG_FILE="/tmp/dream-server-install-macos.log"

--- a/dream-server/tests/bats-tests/path-utils.bats
+++ b/dream-server/tests/bats-tests/path-utils.bats
@@ -11,6 +11,12 @@ load '../bats/bats-assert/load'
 setup() {
     # Source the library under test
     source "$BATS_TEST_DIRNAME/../../installers/lib/path-utils.sh"
+    # Ensure resolve_install_dir sees a clean env; each test sets its own.
+    unset INSTALL_DIR DREAM_HOME DS_INSTALL_DIR DREAM_SCRIPT_HINT
+}
+
+teardown() {
+    unset INSTALL_DIR DREAM_HOME DS_INSTALL_DIR DREAM_SCRIPT_HINT
 }
 
 # ── normalize_path ──────────────────────────────────────────────────────────
@@ -85,6 +91,24 @@ setup() {
     unset INSTALL_DIR
     unset DREAM_HOME
     unset DS_INSTALL_DIR
+    run resolve_install_dir
+    assert_success
+    assert_output "$HOME/dream-server"
+}
+
+@test "resolve_install_dir: DREAM_SCRIPT_HINT used when sentinel .env present" {
+    export DREAM_SCRIPT_HINT="$BATS_TEST_TMPDIR/dream-install-hint"
+    mkdir -p "$DREAM_SCRIPT_HINT"
+    touch "$DREAM_SCRIPT_HINT/.env"
+    run resolve_install_dir
+    assert_success
+    assert_output "$DREAM_SCRIPT_HINT"
+}
+
+@test "resolve_install_dir: DREAM_SCRIPT_HINT falls through when sentinel .env absent" {
+    export DREAM_SCRIPT_HINT="$BATS_TEST_TMPDIR/dream-install-no-sentinel"
+    mkdir -p "$DREAM_SCRIPT_HINT"
+    # No .env file created — hint must be rejected and fall through to default.
     run resolve_install_dir
     assert_success
     assert_output "$HOME/dream-server"


### PR DESCRIPTION
> **Merge order:** Merge before #935 — both modify `dream-macos.sh`.

## What
`bash /path/to/install/dream-macos.sh status` now works from any non-default install without requiring `DREAM_HOME` to be exported, by auto-detecting the install from the script's own location. Also fixes a latent off-by-one in `installers/macos/lib/constants.sh`'s `path-utils.sh` lookup that rendered the original `resolve_install_dir()` dead code in both source-tree and installed layouts.

## Why
External-drive installs, custom Homebrew prefixes, CI automation, cron jobs, and any launchd plist that invokes the CLI by absolute path without inheriting the user shell's env all hit "Dream Server not found at \$HOME/dream-server" even when the script itself lives in a populated install. The workaround (always `export DREAM_HOME=<install>` in `.zshrc`) is not discoverable from the error message.

Second-order: while verifying the fix, tracing showed `MACOS_SCRIPT_DIR` in `installers/macos/lib/constants.sh` resolved to the wrong depth in both layouts. The `if [[ -f $MACOS_SCRIPT_DIR/installers/lib/path-utils.sh ]]; then . $MACOS_SCRIPT_DIR/installers/lib/path-utils.sh; fi` block was dead in both source-tree (`dream-server/installers/installers/lib/path-utils.sh`, extra `installers/`) and installed (`/Volumes/X/installers/lib/path-utils.sh`, one too many dirs up) layouts. `resolve_install_dir()` was never actually called from `dream-macos.sh`; the ELSE fallback was the only live code path. Without fixing this, the new `DREAM_SCRIPT_HINT` tier would be dead on both layouts too.

## How
1. **`installers/lib/path-utils.sh`** — new resolution tier in `resolve_install_dir()` between `DREAM_HOME` and `DS_INSTALL_DIR`. Fires only when `DREAM_SCRIPT_HINT` is set AND `${DREAM_SCRIPT_HINT}/.env` exists. Sentinel prevents false positives from PATH symlinks or scratch copies.

2. **`installers/macos/dream-macos.sh`** — exports `DREAM_SCRIPT_HINT="$SCRIPT_DIR"` before sourcing `constants.sh`, unsets after. Updated `test_install()` error message to point users at the new behavior.

3. **`installers/macos/lib/constants.sh`** — replaces the broken single-path `path-utils.sh` lookup with a two-candidate for-loop: `../../lib/path-utils.sh` matches the source tree, `../installers/lib/path-utils.sh` matches the installed layout. Each candidate matches exactly one layout; both verified with `realpath`. Drops the unused `MACOS_SCRIPT_DIR` variable.

4. **`tests/bats-tests/path-utils.bats`** — two new tests for the `DREAM_SCRIPT_HINT` tier (sentinel present / sentinel absent) plus `setup`/`teardown` that clears all four env vars for test isolation.

## Testing

### Automated
- `bash -n` all modified shell files: PASS
- `make lint`: PASS
- `make test`: PASS (82/82 tier-map, 17/17 AMD/Lemonade contracts, all installer contracts, all preflight fixtures)
- `shellcheck` on the 3 modified shell files: PASS (only preexisting SC2034 info findings on `constants.sh`, identical set present on `main`)
- `pre-commit` (gitleaks, private-key, large-files): PASS
- Two-candidate path loop in `constants.sh` verified empirically with `realpath` against both layouts — each candidate matches exactly one.

### Runtime (against a macOS install at a non-\$HOME volume)
Before fix:
\`\`\`
\$ env -u DREAM_HOME -u INSTALL_DIR -u DS_INSTALL_DIR bash /Volumes/X/dream-server-test/dream-macos.sh status
[XX] Dream Server not found at /Users/<user>/dream-server.
\`\`\`
After fix:
\`\`\`
\$ env -u DREAM_HOME -u INSTALL_DIR -u DS_INSTALL_DIR bash /Volumes/X/dream-server-test/dream-macos.sh status

  Dream Server Status (macOS)
  ----------------------------------------
  Chip: Apple M4
  RAM:  24 GB (unified memory)
  [OK] llama-server (native Metal): running PID 13757 (healthy)

  Health Checks
  ----------------------------------------
  [OK] LLM API: healthy
  [OK] Chat UI: healthy
  [OK] Dashboard: healthy
  [OK] OpenCode (IDE): healthy
\`\`\`

Happy-path regression check — \`DREAM_HOME\` still takes precedence when set:
\`\`\`
\$ DREAM_HOME=/Volumes/X/dream-server-test bash /Volumes/X/dream-server-test/dream-macos.sh status
# identical full status output — no regression
\`\`\`

Sentinel guard sanity — hint pointing at a dir without \`.env\` falls through to default:
\`\`\`
\$ DREAM_SCRIPT_HINT=/tmp resolve_install_dir
# returns \$HOME/dream-server (correctly falls through)
\`\`\`

### Manual (per platform for reviewer)
- **macOS**: `unset DREAM_HOME INSTALL_DIR DS_INSTALL_DIR; bash /path/to/install/dream-macos.sh status` from any install path should produce status output, not "not found".
- **Linux**: no-op. `installers/macos/lib/constants.sh` is macOS-only. `installers/lib/path-utils.sh` is shared, but the new tier is guarded by `DREAM_SCRIPT_HINT` which only `dream-macos.sh` sets; Linux's `dream-cli` and `install-core.sh` never set it, so the new branch is structurally dead there. Verified via `make test` passing unchanged.
- **Windows/WSL2**: no-op. None of the 4 files are sourced by the Windows installer or `dream.ps1`.

## Platform Impact
- **macOS**: affected — bug fix + latent dead-code path resolved. Runtime-verified.
- **Linux**: not affected — new code path is dead on Linux (env var never set). `make test` unchanged.
- **Windows**: not affected — no sourced files.

## Known Considerations
- The new BATS tests assert exact-string match on `\$BATS_TEST_TMPDIR/dream-install-hint`. On macOS developer machines with Homebrew `coreutils` installed, `grealpath` canonicalizes `/var/folders/...` → `/private/var/folders/...`, which would break the assertion locally. CI runs BATS on Linux (`/tmp/...` has no symlink layer) so it stays green. Flagged non-blocking for any reviewer attempting local Mac runs.
- `DREAM_SCRIPT_HINT` is an ephemeral shell var (`export` → source chain → `unset`), never written to `.env` or `.env.schema.json`. No schema entry needed.

## Fork issue
Closes yasinBursali/DreamServer#339