### PR TITLE
fix(detection): validate NVIDIA hardware via sysfs before trusting nvidia-smi

### DIFF
--- a/dream-server/dream-preflight.sh
+++ b/dream-server/dream-preflight.sh
@@ -40,7 +40,13 @@ detect_backend() {
     fi
 
     # 2. Probe NVIDIA first (matches installer's detect_gpu order).
-    if command -v nvidia-smi &> /dev/null; then
+    #    Validate hardware via sysfs vendor ID before trusting nvidia-smi,
+    #    which may be installed without NVIDIA hardware.
+    local _nvidia_hw=false
+    for _v in /sys/class/drm/card*/device/vendor; do
+        [[ "$(cat "$_v" 2>/dev/null)" == "0x10de" ]] && _nvidia_hw=true && break
+    done
+    if $_nvidia_hw && command -v nvidia-smi &> /dev/null; then
         if nvidia-smi --query-gpu=name --format=csv,noheader &> /dev/null; then
             echo "nvidia"
             return

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -93,8 +93,14 @@ detect_gpu() {
     GPU_MEMORY_TYPE="none"
     GPU_DEVICE_ID=""
 
-    # Try NVIDIA first
-    if command -v nvidia-smi &> /dev/null; then
+    # Try NVIDIA first — validate hardware via sysfs vendor ID (0x10de)
+    # before trusting nvidia-smi, which may be installed without NVIDIA hardware
+    # (e.g. nvidia-container-toolkit on AMD-only systems).
+    local _nvidia_hw=false
+    for _v in /sys/class/drm/card*/device/vendor; do
+        [[ "$(cat "$_v" 2>/dev/null)" == "0x10de" ]] && _nvidia_hw=true && break
+    done
+    if $_nvidia_hw && command -v nvidia-smi &> /dev/null; then
         local raw
         if raw=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) && [[ -n "$raw" ]]; then
             GPU_BACKEND="nvidia"

--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -132,6 +132,15 @@ detect_platform() {
 
 # Detect NVIDIA GPU
 detect_nvidia() {
+    # Validate NVIDIA hardware present in sysfs before trusting nvidia-smi,
+    # which may be installed without NVIDIA hardware (e.g. nvidia-container-toolkit
+    # on AMD-only systems).
+    local _has_nvidia=false
+    for _v in /sys/class/drm/card*/device/vendor; do
+        [[ "$(cat "$_v" 2>/dev/null)" == "0x10de" ]] && _has_nvidia=true && break
+    done
+    $_has_nvidia || return 1
+
     # Works on bare metal Linux; on WSL2 it may be present via Docker Desktop GPU integration.
     if command -v nvidia-smi &>/dev/null; then
         nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits 2>/dev/null | first_line


### PR DESCRIPTION
## Summary

Prevents AMD Strix Halo (and other non-NVIDIA systems) from being misdetected as NVIDIA when `nvidia-smi` is installed without NVIDIA hardware.

## Problem

The GPU detection checks `nvidia-smi` first and trusts any output without validating that NVIDIA hardware actually exists. If `nvidia-smi` is installed (e.g., from `nvidia-container-toolkit` or leftover driver packages) but there's no NVIDIA GPU, the detection sets `GPU_BACKEND="nvidia"` and returns early — AMD sysfs detection never runs.

**Reported by:** User on Ubuntu 24.04 LTS (kernel 6.18) with Strix Halo. Installer detected NVIDIA, dashboard showed inference "not responding" because CUDA llama.cpp was deployed on AMD hardware.

Intel Arc and AMD detection both validate PCI vendor IDs from sysfs (`0x8086` and `0x1002`). NVIDIA detection did not.

## Fix

Add a sysfs PCI vendor ID check (`0x10de`) before executing `nvidia-smi`, matching the existing Intel Arc and AMD patterns. If no NVIDIA hardware exists in sysfs, the block is skipped and detection falls through to Intel/AMD/CPU.

Applied to all three detection sites:

| File | Function |
|---|---|
| `installers/lib/detection.sh` | `detect_gpu()` |
| `scripts/detect-hardware.sh` | `detect_nvidia()` |
| `dream-preflight.sh` | `detect_backend()` |

## Impact

| Scenario | Before | After |
|---|---|---|
| NVIDIA GPU + nvidia-smi | Detects NVIDIA | Detects NVIDIA (unchanged) |
| No NVIDIA GPU + nvidia-smi installed | **NVIDIA (bug)** | Falls through to AMD/Intel/CPU |
| AMD Strix Halo + nvidia-smi installed | **NVIDIA (bug)** | Detects AMD |
| Dual GPU (AMD iGPU + NVIDIA dGPU) | Detects NVIDIA | Detects NVIDIA (sysfs finds 0x10de) |
| No GPU + nvidia-smi installed | **NVIDIA (bug)** | Falls through to CPU-only |

## Test plan

- [ ] Strix Halo with nvidia-smi installed: `GPU_BACKEND=amd`
- [ ] NVIDIA system: detection unchanged
- [ ] CPU-only with nvidia-smi: `GPU_BACKEND=cpu`
- [ ] Dual-GPU (AMD iGPU + NVIDIA dGPU): still prefers NVIDIA