### PR TITLE
chore(compose): route macOS runtime paths to installers/macos/docker-compose.macos.yml

### DIFF
--- a/dream-server/config/hardware-classes.json
+++ b/dream-server/config/hardware-classes.json
@@ -118,7 +118,7 @@
       "recommended": {
         "backend": "apple",
         "tier": "T3",
-        "compose_overlays": ["docker-compose.base.yml", "docker-compose.apple.yml"]
+        "compose_overlays": ["docker-compose.base.yml", "installers/macos/docker-compose.macos.yml"]
       }
     },
     {
@@ -133,7 +133,7 @@
       "recommended": {
         "backend": "apple",
         "tier": "T2",
-        "compose_overlays": ["docker-compose.base.yml", "docker-compose.apple.yml"]
+        "compose_overlays": ["docker-compose.base.yml", "installers/macos/docker-compose.macos.yml"]
       }
     },
     {

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -56,6 +56,7 @@
         "docker-compose.cpu.yml",
         "docker-compose.nvidia.yml",
         "docker-compose.apple.yml",
+        "installers/macos/docker-compose.macos.yml",
         "docker-compose.arc.yml"
       ],
       "legacyFallback": [

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -272,7 +272,20 @@ if command -v docker &>/dev/null && docker ps --filter name=dream-llama-server -
         case "${_gpu_backend}" in
             nvidia) [[ -f "$INSTALL_DIR/docker-compose.nvidia.yml" ]] && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.nvidia.yml") ;;
             amd)    [[ -f "$INSTALL_DIR/docker-compose.amd.yml" ]]    && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.amd.yml") ;;
-            apple)  [[ -f "$INSTALL_DIR/docker-compose.apple.yml" ]]  && COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.apple.yml") ;;
+            apple)
+                # On Darwin hosts the canonical macOS overlay lives at
+                # installers/macos/docker-compose.macos.yml (native Metal llama-server
+                # replicas: 0, llama-server-ready sidecar, host.docker.internal for
+                # dashboard-api). The top-level docker-compose.apple.yml remains
+                # valid for Linux hosts that select --gpu-backend apple (Lemonade).
+                # Mirror the branch in scripts/resolve-compose-stack.sh so that the
+                # .compose-flags fallback selects the same overlay the resolver does.
+                if [[ "$(uname -s)" == "Darwin" && -f "$INSTALL_DIR/installers/macos/docker-compose.macos.yml" ]]; then
+                    COMPOSE_ARGS+=(-f "$INSTALL_DIR/installers/macos/docker-compose.macos.yml")
+                elif [[ -f "$INSTALL_DIR/docker-compose.apple.yml" ]]; then
+                    COMPOSE_ARGS+=(-f "$INSTALL_DIR/docker-compose.apple.yml")
+                fi
+                ;;
             # cpu or unknown: base only, no GPU overlay
         esac
     fi

--- a/dream-server/scripts/classify-hardware.sh
+++ b/dream-server/scripts/classify-hardware.sh
@@ -183,6 +183,12 @@ else:
     memory_source = "vram"
 
 overlays = OVERLAY_MAP.get(backend, ["docker-compose.base.yml"])
+# Darwin hosts running the apple backend use the canonical macOS overlay
+# (installers/macos/docker-compose.macos.yml). The OVERLAY_MAP entry for
+# "apple" still lists docker-compose.apple.yml so Linux hosts selecting
+# --gpu-backend apple (Lemonade) continue to get the top-level overlay.
+if backend == "apple" and platform_id == "macos":
+    overlays = ["docker-compose.base.yml", "installers/macos/docker-compose.macos.yml"]
 gpu_label = selected["specs"].get("label", "") if selected and "specs" in selected else ""
 
 # --- Output ---


### PR DESCRIPTION
## What
Route the four remaining macOS runtime code paths that still hardcode `docker-compose.apple.yml` to the canonical macOS overlay at `installers/macos/docker-compose.macos.yml`. Leave the top-level `docker-compose.apple.yml` in place as a first-class overlay for Linux hosts that select `--gpu-backend apple` (AMD Lemonade).

## Why
`installers/macos/docker-compose.macos.yml` is the macOS overlay the installer actually writes into `.compose-flags` — it sets `replicas: 0` on llama-server (native Metal instead of Docker), adds the `llama-server-ready` sidecar, and routes `dashboard-api` via `host.docker.internal`. The top-level `docker-compose.apple.yml` keeps llama-server as a container and is only valid for Linux-apple installs. Four files in the repo still point at the top-level file on macOS runtime paths, causing silent divergence between the fresh-install path and the recovery / classification / manifest paths.

## How

**1. `scripts/bootstrap-upgrade.sh`** — the `.compose-flags`-missing fallback block (in the `dream update` / model hot-swap path) had a one-liner `apple)` arm that always hardcoded `docker-compose.apple.yml`. Replace it with a Darwin-vs-non-Darwin branch: on Darwin, prefer `installers/macos/docker-compose.macos.yml` if present; otherwise fall through to the existing path. Mirrors the branch pattern in `scripts/resolve-compose-stack.sh` so both source-of-truth paths agree.

**2. `scripts/classify-hardware.sh`** — the embedded-Python OVERLAY_MAP is keyed on `backend` alone, so the `"apple"` entry always emitted the Linux-apple overlay regardless of platform. Add a post-lookup override that replaces overlays with the macOS path when `backend == "apple" and platform_id == "macos"`. The `OVERLAY_MAP` entry itself stays as the Linux-apple default.

**3. `config/hardware-classes.json`** — the `apple_silicon_pro` and `apple_silicon` classes both gate on `platform_id: ["macos"]` exclusively. Their `compose_overlays` arrays can therefore point at the macOS overlay unconditionally; no Linux-apple fallback is reachable through these entries.

**4. `manifest.json`** — add `installers/macos/docker-compose.macos.yml` to `.contracts.compose.canonical` (consumed by `scripts/check-compatibility.sh` to validate every shipped compose file exists). The existing `docker-compose.apple.yml` entry is preserved.

## Testing

### Automated
- `make lint`: PASS
- `make test`: PASS (82/82 tier-map, 17/17 AMD/Lemonade contracts, installer contracts, preflight fixtures)
- `shellcheck bootstrap-upgrade.sh classify-hardware.sh`: clean (no new findings)
- `jq -e` validates both JSON files
- `pre-commit`: PASS
- `check-compatibility.sh` iterates the updated canonical list and verifies all entries exist on disk: PASS

### Runtime (simulated against a live macOS install)

Updated `apple)` case block with `_gpu_backend=apple INSTALL_DIR=<install>`:
\`\`\`
Darwin apple: -f <install>/docker-compose.base.yml -f <install>/installers/macos/docker-compose.macos.yml
\`\`\`

Same block with `_gpu_backend=nvidia` (regression check, unchanged arm):
\`\`\`
Darwin nvidia: -f <install>/docker-compose.base.yml -f <install>/docker-compose.nvidia.yml
\`\`\`

Updated `classify-hardware.sh --platform-id macos --gpu-vendor apple --memory-type unified ...`:
\`\`\`
HW_REC_BACKEND="apple"
HW_REC_COMPOSE_OVERLAYS="docker-compose.base.yml,installers/macos/docker-compose.macos.yml"
\`\`\`

`bootstrap-upgrade.sh` in-place syntax check on a live install: PASS. `dream-macos.sh status` remained healthy throughout.

### Manual (per platform for reviewer)

- **macOS**: on a stale/recovered install, `rm .compose-flags` then exercising the bootstrap-upgrade fallback should pick the `installers/macos/docker-compose.macos.yml` overlay, not the top-level `docker-compose.apple.yml`.
- **Linux**: `classify-hardware.sh --platform-id linux --gpu-vendor amd ...` and bootstrap-upgrade.sh fallback with `_gpu_backend=nvidia` / `amd` should continue to emit the Linux overlays. Linux-apple (Lemonade) users with `--gpu-backend apple` still get `docker-compose.apple.yml` via the `elif` arm and the OVERLAY_MAP default.
- **Windows/WSL2**: no-op — no files sourced by the Windows installer or `dream.ps1`.

## Platform Impact

- **macOS**: bug fix — 4 code paths now emit the canonical macOS overlay.
- **Linux**: not affected — Linux-apple (Lemonade) fallback preserved in all three places (`bootstrap-upgrade.sh` elif, `classify-hardware.sh` OVERLAY_MAP default, `manifest.json` preserved entry).
- **Windows/WSL2**: not affected — files sourced only by the Linux/macOS installer paths.

## Relationship to #897

PR #897 fixes `resolve-compose-stack.sh` to use `APPLE_OVERLAY = IS_DARWIN ? installers/macos/docker-compose.macos.yml : docker-compose.apple.yml`. This PR is a **sibling**, not a dependent: `install-macos.sh` writes `.compose-flags` directly with the correct macOS overlay, so the fresh-install path does not depend on the resolver. Once both PRs merge, every Darwin compose-selection code path agrees on the macOS overlay.

## Known Considerations

- `classify-hardware.sh`'s `OVERLAY_MAP` and `hardware-classes.json`'s `compose_overlays` are two independent sources of truth for overlay paths. This PR keeps them aligned for the macOS case, but the same two-source pattern exists for amd/nvidia/cpu backends and is not enforced by any contract test. Filed as a follow-up hygiene task on the fork.

## Fork issue
Closes yasinBursali/DreamServer#325