### PR TITLE
feat(installer): add --langfuse flag and Custom menu prompt for langfuse

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -96,6 +96,11 @@ ENABLE_RAG=true
 ENABLE_OPENCLAW=true
 ENABLE_COMFYUI=true
 ENABLE_DREAMFORGE=true
+# Langfuse (LLM observability) defaults OFF on all tiers because its
+# clickhouse + postgres + minio stack adds ~500MB baseline memory that is
+# nontrivial even on Tier 3+ systems. Users opt in via --langfuse, --all,
+# the Custom menu, or post-install `dream enable langfuse`.
+ENABLE_LANGFUSE=false
 INTERACTIVE=true
 DREAM_MODE="${DREAM_MODE:-local}"
 OFFLINE_MODE=false   # M1 integration: fully air-gapped operation
@@ -122,7 +127,9 @@ Options:
     --no-comfyui      Disable ComfyUI image generation (saves ~34GB)
     --dreamforge      Enable DreamForge agent system (default)
     --no-dreamforge   Disable DreamForge
-    --all             Enable all optional services
+    --langfuse        Enable Langfuse LLM observability (off by default)
+    --no-langfuse     Explicitly disable Langfuse (for --all overrides)
+    --all             Enable all optional services (including Langfuse)
     --non-interactive Run without prompts (use defaults or flags)
     --offline         M1 mode: Configure for fully offline/air-gapped operation
     --no-bootstrap    Skip bootstrap fast-start (download full model in foreground)
@@ -166,7 +173,11 @@ while [[ $# -gt 0 ]]; do
         --no-comfyui) ENABLE_COMFYUI=false; shift ;;
         --dreamforge) ENABLE_DREAMFORGE=true; shift ;;
         --no-dreamforge) ENABLE_DREAMFORGE=false; shift ;;
-        --all) ENABLE_VOICE=true; ENABLE_WORKFLOWS=true; ENABLE_RAG=true; ENABLE_OPENCLAW=true; ENABLE_COMFYUI=true; ENABLE_DREAMFORGE=true; shift ;;
+        --langfuse) ENABLE_LANGFUSE=true; shift ;;
+        # NOTE: with --all, --no-langfuse must appear AFTER --all on the command
+        # line (flag processing is case-loop ordered, matching comfyui/dreamforge).
+        --no-langfuse) ENABLE_LANGFUSE=false; shift ;;
+        --all) ENABLE_VOICE=true; ENABLE_WORKFLOWS=true; ENABLE_RAG=true; ENABLE_OPENCLAW=true; ENABLE_COMFYUI=true; ENABLE_DREAMFORGE=true; ENABLE_LANGFUSE=true; shift ;;
         --non-interactive) INTERACTIVE=false; shift ;;
         --offline) OFFLINE_MODE=true; shift ;;
         --no-bootstrap) NO_BOOTSTRAP=true; shift ;;

--- a/dream-server/installers/lib/ui.sh
+++ b/dream-server/installers/lib/ui.sh
@@ -392,6 +392,7 @@ show_install_menu() {
             ENABLE_RAG=true
             ENABLE_OPENCLAW=true
             ENABLE_COMFYUI=true
+            ENABLE_LANGFUSE=true
 
             # Disable image generation on low-tier systems (insufficient RAM/VRAM)
             # ComfyUI requires shm_size 8GB + 24GB memory limit
@@ -412,6 +413,7 @@ show_install_menu() {
             ENABLE_RAG=false
             ENABLE_OPENCLAW=false
             ENABLE_COMFYUI=false
+            ENABLE_LANGFUSE=false
             ;;
         3)
             signal "Acknowledged."
@@ -424,6 +426,7 @@ show_install_menu() {
             ENABLE_RAG=true
             ENABLE_OPENCLAW=true
             ENABLE_COMFYUI=true
+            ENABLE_LANGFUSE=true
 
             # Disable image generation on low-tier systems (insufficient RAM/VRAM)
             # ComfyUI requires shm_size 8GB + 24GB memory limit

--- a/dream-server/installers/lib/ui.sh
+++ b/dream-server/installers/lib/ui.sh
@@ -413,6 +413,7 @@ show_install_menu() {
             ENABLE_RAG=false
             ENABLE_OPENCLAW=false
             ENABLE_COMFYUI=false
+            ENABLE_DREAMFORGE=false
             ENABLE_LANGFUSE=false
             ;;
         3)

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -65,6 +65,12 @@ ENABLE_VOICE=false
 ENABLE_WORKFLOWS=false
 ENABLE_RAG=false
 ENABLE_OPENCLAW=false
+# Langfuse defaults OFF because its clickhouse + postgres + minio stack adds
+# ~500MB baseline memory. Enable via --langfuse, --all, or post-install
+# `dream enable langfuse`. --no-langfuse honored as explicit override so a
+# --all run can still suppress Langfuse.
+ENABLE_LANGFUSE=false
+NO_LANGFUSE_EXPLICIT=false
 ALL_FEATURES=false
 CLOUD_MODE=false
 
@@ -78,6 +84,8 @@ while [[ $# -gt 0 ]]; do
         --workflows)     ENABLE_WORKFLOWS=true; shift ;;
         --rag)           ENABLE_RAG=true; shift ;;
         --openclaw)      ENABLE_OPENCLAW=true; shift ;;
+        --langfuse)      ENABLE_LANGFUSE=true; shift ;;
+        --no-langfuse)   ENABLE_LANGFUSE=false; NO_LANGFUSE_EXPLICIT=true; shift ;;
         --all)           ALL_FEATURES=true; shift ;;
         --cloud)         CLOUD_MODE=true; shift ;;
         *)               echo "Unknown option: $1"; exit 1 ;;
@@ -89,6 +97,8 @@ if $ALL_FEATURES; then
     ENABLE_WORKFLOWS=true
     ENABLE_RAG=true
     ENABLE_OPENCLAW=true
+    # --all enables Langfuse unless the user explicitly passed --no-langfuse.
+    $NO_LANGFUSE_EXPLICIT || ENABLE_LANGFUSE=true
 fi
 
 # ── Locate script directory and source tree root ──
@@ -293,10 +303,12 @@ if ! $NON_INTERACTIVE && ! $ALL_FEATURES && ! $DRY_RUN; then
         1)
             ENABLE_VOICE=true; ENABLE_WORKFLOWS=true
             ENABLE_RAG=true; ENABLE_OPENCLAW=true
+            ENABLE_LANGFUSE=true
             ;;
         2)
             ENABLE_VOICE=false; ENABLE_WORKFLOWS=false
             ENABLE_RAG=false; ENABLE_OPENCLAW=false
+            ENABLE_LANGFUSE=false
             ;;
         3)
             read -r -p "  Enable Voice (Whisper + Kokoro)? [y/N] " yn < /dev/tty
@@ -307,10 +319,13 @@ if ! $NON_INTERACTIVE && ! $ALL_FEATURES && ! $DRY_RUN; then
             [[ "$yn" =~ ^[yY] ]] && ENABLE_RAG=true
             read -r -p "  Enable OpenClaw (AI agents)?      [y/N] " yn < /dev/tty
             [[ "$yn" =~ ^[yY] ]] && ENABLE_OPENCLAW=true
+            read -r -p "  Enable Langfuse (LLM observability, ~500MB)? [y/N] " yn < /dev/tty
+            [[ "$yn" =~ ^[yY] ]] && ENABLE_LANGFUSE=true
             ;;
         *)
             ENABLE_VOICE=true; ENABLE_WORKFLOWS=true
             ENABLE_RAG=true; ENABLE_OPENCLAW=true
+            ENABLE_LANGFUSE=true
             ;;
     esac
 fi
@@ -320,6 +335,7 @@ info_box "  Voice:" "$(if $ENABLE_VOICE; then echo enabled; else echo disabled; 
 info_box "  Workflows:" "$(if $ENABLE_WORKFLOWS; then echo enabled; else echo disabled; fi)"
 info_box "  RAG:" "$(if $ENABLE_RAG; then echo enabled; else echo disabled; fi)"
 info_box "  OpenClaw:" "$(if $ENABLE_OPENCLAW; then echo enabled; else echo disabled; fi)"
+info_box "  Langfuse:" "$(if $ENABLE_LANGFUSE; then echo enabled; else echo disabled; fi)"
 
 # ============================================================================
 # PHASE 4 -- SETUP (directories, copy source, generate .env)
@@ -332,6 +348,7 @@ if $DRY_RUN; then
     ai "[DRY RUN] Would generate .env with secrets"
     ai "[DRY RUN] Would generate SearXNG config"
     $ENABLE_OPENCLAW && ai "[DRY RUN] Would configure OpenClaw"
+    $ENABLE_LANGFUSE && ai "[DRY RUN] Would enable Langfuse (LLM observability)"
 else
     # Create directory structure
     mkdir -p "${INSTALL_DIR}/config/searxng"
@@ -668,6 +685,28 @@ else
     CURRENT_BACKEND="apple"
     $CLOUD_MODE && CURRENT_BACKEND="none"
 
+    # Sync Langfuse compose state with ENABLE_LANGFUSE before manifest discovery.
+    # Langfuse ships as compose.yaml.disabled; enable it here when the user opted
+    # in so the manifest loop below picks it up on the first pass. Disable
+    # (rename back) when the user did not opt in so a re-install correctly drops it.
+    _langfuse_svc_dir="${EXT_DIR}/langfuse"
+    if [[ -d "$_langfuse_svc_dir" ]]; then
+        _langfuse_compose="${_langfuse_svc_dir}/compose.yaml"
+        if $ENABLE_LANGFUSE; then
+            if [[ ! -f "$_langfuse_compose" && -f "${_langfuse_compose}.disabled" ]]; then
+                mv "${_langfuse_compose}.disabled" "$_langfuse_compose"
+                ai_ok "Langfuse compose re-enabled"
+            fi
+        else
+            if [[ -f "$_langfuse_compose" ]]; then
+                mv "$_langfuse_compose" "${_langfuse_compose}.disabled"
+                log "Langfuse compose disabled (LLM observability not enabled)"
+            fi
+        fi
+        unset _langfuse_compose
+    fi
+    unset _langfuse_svc_dir
+
     if [[ -d "$EXT_DIR" ]]; then
         for SVC_DIR in "$EXT_DIR"/*/; do
             [[ ! -d "$SVC_DIR" ]] && continue
@@ -711,6 +750,7 @@ else
                 n8n)           $ENABLE_WORKFLOWS || SKIP=true ;;
                 qdrant|embeddings) $ENABLE_RAG || SKIP=true ;;
                 openclaw)      $ENABLE_OPENCLAW || SKIP=true ;;
+                langfuse)      $ENABLE_LANGFUSE || SKIP=true ;;
             esac
             $SKIP && continue
 

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -216,7 +216,11 @@ N8N_WEBHOOK_URL=http://localhost:5678
 TIMEZONE=${tz}
 
 #=== Langfuse (LLM Observability) ===
-LANGFUSE_ENABLED=false
+# NOTE: this value is only written on first install or --force (the macOS
+# env-generator early-returns when .env already exists). Users who re-run
+# ./install-macos.sh --langfuse on an existing install should instead use
+# post-install: `dream enable langfuse`.
+LANGFUSE_ENABLED=${ENABLE_LANGFUSE:-false}
 LANGFUSE_NEXTAUTH_SECRET=${langfuse_nextauth_secret}
 LANGFUSE_SALT=${langfuse_salt}
 LANGFUSE_ENCRYPTION_KEY=${langfuse_encryption_key}

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -51,6 +51,10 @@ if $INTERACTIVE && ! $DRY_RUN; then
         echo
         [[ $REPLY =~ ^[Nn]$ ]] || ENABLE_DREAMFORGE=true
 
+        read -p "  Enable Langfuse (LLM observability + telemetry, ~500MB)? [y/N] " -r < /dev/tty
+        echo
+        [[ $REPLY =~ ^[Yy]$ ]] && ENABLE_LANGFUSE=true
+
         # Warn if ComfyUI enabled on low-tier hardware
         if [[ "$ENABLE_COMFYUI" == "true" ]]; then
             case "${TIER:-}" in
@@ -76,39 +80,58 @@ if ! $INTERACTIVE && [[ "$ENABLE_COMFYUI" == "true" ]]; then
     esac
 fi
 
-# Sync ComfyUI compose state with ENABLE_COMFYUI — the resolver uses the
-# .disabled convention to exclude services from the compose stack.
-_comfyui_compose="$SCRIPT_DIR/extensions/services/comfyui/compose.yaml"
-if [[ "${ENABLE_COMFYUI:-}" == "true" ]]; then
-    # Re-enable if previously disabled (re-install with different options)
-    if [[ ! -f "$_comfyui_compose" && -f "${_comfyui_compose}.disabled" ]]; then
-        mv "${_comfyui_compose}.disabled" "$_comfyui_compose"
-        log "ComfyUI compose re-enabled"
+# Sync optional-extension compose state with the ENABLE_* flags — the
+# resolver uses the .disabled convention to exclude services from the compose
+# stack. These mv calls are skipped during --dry-run so the source tree is
+# never mutated by a preview invocation.
+if ! $DRY_RUN; then
+    _comfyui_compose="$SCRIPT_DIR/extensions/services/comfyui/compose.yaml"
+    if [[ "${ENABLE_COMFYUI:-}" == "true" ]]; then
+        # Re-enable if previously disabled (re-install with different options)
+        if [[ ! -f "$_comfyui_compose" && -f "${_comfyui_compose}.disabled" ]]; then
+            mv "${_comfyui_compose}.disabled" "$_comfyui_compose"
+            log "ComfyUI compose re-enabled"
+        fi
+    else
+        # Disable — prevents resolve-compose-stack.sh from including a compose
+        # file whose image was never built/pulled, blocking ALL containers.
+        if [[ -f "$_comfyui_compose" ]]; then
+            mv "$_comfyui_compose" "${_comfyui_compose}.disabled"
+            log "ComfyUI compose disabled (image generation not enabled)"
+        fi
     fi
-else
-    # Disable — prevents resolve-compose-stack.sh from including a compose
-    # file whose image was never built/pulled, blocking ALL containers.
-    if [[ -f "$_comfyui_compose" ]]; then
-        mv "$_comfyui_compose" "${_comfyui_compose}.disabled"
-        log "ComfyUI compose disabled (image generation not enabled)"
-    fi
-fi
-unset _comfyui_compose
+    unset _comfyui_compose
 
-# Sync DreamForge compose state with ENABLE_DREAMFORGE — same .disabled convention.
-_dreamforge_compose="$SCRIPT_DIR/extensions/services/dreamforge/compose.yaml"
-if [[ "${ENABLE_DREAMFORGE:-}" == "true" ]]; then
-    if [[ ! -f "$_dreamforge_compose" && -f "${_dreamforge_compose}.disabled" ]]; then
-        mv "${_dreamforge_compose}.disabled" "$_dreamforge_compose"
-        log "DreamForge compose re-enabled"
+    # Sync DreamForge compose state with ENABLE_DREAMFORGE — same .disabled convention.
+    _dreamforge_compose="$SCRIPT_DIR/extensions/services/dreamforge/compose.yaml"
+    if [[ "${ENABLE_DREAMFORGE:-}" == "true" ]]; then
+        if [[ ! -f "$_dreamforge_compose" && -f "${_dreamforge_compose}.disabled" ]]; then
+            mv "${_dreamforge_compose}.disabled" "$_dreamforge_compose"
+            log "DreamForge compose re-enabled"
+        fi
+    else
+        if [[ -f "$_dreamforge_compose" ]]; then
+            mv "$_dreamforge_compose" "${_dreamforge_compose}.disabled"
+            log "DreamForge compose disabled (agent system not enabled)"
+        fi
     fi
-else
-    if [[ -f "$_dreamforge_compose" ]]; then
-        mv "$_dreamforge_compose" "${_dreamforge_compose}.disabled"
-        log "DreamForge compose disabled (agent system not enabled)"
+    unset _dreamforge_compose
+
+    # Sync Langfuse compose state with ENABLE_LANGFUSE — same .disabled convention.
+    _langfuse_compose="$SCRIPT_DIR/extensions/services/langfuse/compose.yaml"
+    if [[ "${ENABLE_LANGFUSE:-}" == "true" ]]; then
+        if [[ ! -f "$_langfuse_compose" && -f "${_langfuse_compose}.disabled" ]]; then
+            mv "${_langfuse_compose}.disabled" "$_langfuse_compose"
+            log "Langfuse compose re-enabled"
+        fi
+    else
+        if [[ -f "$_langfuse_compose" ]]; then
+            mv "$_langfuse_compose" "${_langfuse_compose}.disabled"
+            log "Langfuse compose disabled (LLM observability not enabled)"
+        fi
     fi
+    unset _langfuse_compose
 fi
-unset _dreamforge_compose
 
 # Re-resolve compose flags now that feature selection may have disabled services.
 # Without this, Phases 4-11 use stale flags from Phase 2 that reference files

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -204,9 +204,11 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
     SEARXNG_SECRET=$(_env_get SEARXNG_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
 
-    # Langfuse (LLM Observability)
+    # Langfuse (LLM Observability). LANGFUSE_ENABLED mirrors the install-time
+    # ENABLE_LANGFUSE toggle, falling back to whatever the user had in .env on
+    # re-install so manual post-install `dream enable langfuse` edits survive.
     LANGFUSE_PORT=$(_env_get LANGFUSE_PORT "3006")
-    LANGFUSE_ENABLED=$(_env_get LANGFUSE_ENABLED "false")
+    LANGFUSE_ENABLED=$(_env_get LANGFUSE_ENABLED "${ENABLE_LANGFUSE:-false}")
     LANGFUSE_NEXTAUTH_SECRET=$(_env_get LANGFUSE_NEXTAUTH_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
     LANGFUSE_SALT=$(_env_get LANGFUSE_SALT "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
     LANGFUSE_ENCRYPTION_KEY=$(_env_get LANGFUSE_ENCRYPTION_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -48,6 +48,8 @@ param(
     [switch]$Cloud,
     [switch]$Comfyui,
     [switch]$NoComfyui,
+    [switch]$Langfuse,
+    [switch]$NoLangfuse,
     [string]$SummaryJsonPath = ""
 )
 
@@ -83,6 +85,8 @@ $openClawFlag   = $OpenClaw.IsPresent
 $allFlag        = $All.IsPresent
 $comfyuiFlag    = $Comfyui.IsPresent
 $noComfyuiFlag  = $NoComfyui.IsPresent
+$langfuseFlag   = $Langfuse.IsPresent
+$noLangfuseFlag = $NoLangfuse.IsPresent
 $installDir     = $script:DS_INSTALL_DIR
 $sourceRoot     = $SourceRoot
 

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -75,7 +75,12 @@ function New-DreamEnv {
         [string]$Tier,
         [string]$GpuBackend = "nvidia",
         [string]$DreamMode = "local",
-        [string]$LlamaServerImage = ""
+        [string]$LlamaServerImage = "",
+        # Mirror the install-time ENABLE_LANGFUSE toggle from phase 03 into
+        # .env's LANGFUSE_ENABLED default. Re-install preserves whatever the
+        # user already had in .env (via Get-EnvOrNew), so manual
+        # `dream enable langfuse` edits survive.
+        [bool]$EnableLangfuse = $false
     )
 
     # Preserve existing secrets on re-install (mirrors Linux _env_get logic)
@@ -112,7 +117,8 @@ function New-DreamEnv {
 
     # Langfuse observability secrets
     $langfusePort              = Get-EnvOrNew "LANGFUSE_PORT"              "3006"
-    $langfuseEnabled           = Get-EnvOrNew "LANGFUSE_ENABLED"           "false"
+    $langfuseDefault           = if ($EnableLangfuse) { "true" } else { "false" }
+    $langfuseEnabled           = Get-EnvOrNew "LANGFUSE_ENABLED"           $langfuseDefault
     $langfuseNextauthSecret    = Get-EnvOrNew "LANGFUSE_NEXTAUTH_SECRET"   (New-SecureHex -Bytes 32)
     $langfuseSalt              = Get-EnvOrNew "LANGFUSE_SALT"              (New-SecureHex -Bytes 32)
     $langfuseEncryptionKey     = Get-EnvOrNew "LANGFUSE_ENCRYPTION_KEY"    (New-SecureHex -Bytes 32)

--- a/dream-server/installers/windows/phases/03-features.ps1
+++ b/dream-server/installers/windows/phases/03-features.ps1
@@ -34,6 +34,11 @@ $enableWorkflows  = $workflowsFlag -or $allFlag
 $enableRag        = $ragFlag -or $allFlag
 $enableOpenClaw   = $openClawFlag -or $allFlag
 $enableComfyui    = -not $noComfyuiFlag
+# Langfuse defaults OFF on all tiers because its clickhouse + postgres + minio
+# stack adds ~500MB baseline memory. Opt in via -Langfuse, -All, the Custom
+# menu, or post-install `dream enable langfuse`. -NoLangfuse is honored as an
+# explicit override so a -All run can still suppress Langfuse.
+$enableLangfuse   = ($langfuseFlag -or $allFlag) -and (-not $noLangfuseFlag)
 
 # ── Interactive menu (skipped in non-interactive / dry-run / --All mode) ──────
 if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
@@ -53,6 +58,7 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
             $enableRag       = $false
             $enableOpenClaw  = $false
             $enableComfyui   = $false
+            $enableLangfuse  = $false
         }
         "3" {
             Write-Host ""
@@ -61,6 +67,7 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
             $enableRag       = (Read-Host "  Enable RAG (Qdrant vector DB + embeddings)? [y/N]") -match "^[yY]"
             $enableOpenClaw  = (Read-Host "  Enable OpenClaw (autonomous AI agents)?    [y/N]") -match "^[yY]"
             $enableComfyui   = (Read-Host "  Enable image generation (ComfyUI + SDXL Lightning, ~6.5GB)? [y/N]") -match "^[yY]"
+            $enableLangfuse  = (Read-Host "  Enable Langfuse (LLM observability, ~500MB)? [y/N]") -match "^[yY]"
 
             # Warn on low-tier
             if ($enableComfyui -and ($selectedTier -eq "0" -or $selectedTier -eq "1")) {
@@ -75,6 +82,7 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
             $enableRag       = $true
             $enableOpenClaw  = $true
             $enableComfyui   = $true
+            $enableLangfuse  = $true
 
             # Disable image generation on low-tier systems (insufficient RAM/VRAM)
             if ($selectedTier -eq "0" -or $selectedTier -eq "1") {
@@ -107,6 +115,7 @@ Write-InfoBox "  Workflows (n8n):"          $(if ($enableWorkflows) { "enabled" 
 Write-InfoBox "  RAG (Qdrant + embeddings):" $(if ($enableRag)      { "enabled" } else { "disabled" })
 Write-InfoBox "  Agents (OpenClaw):"         $(if ($enableOpenClaw) { "enabled" } else { "disabled" })
 Write-InfoBox "  Image gen (ComfyUI):"        $(if ($enableComfyui)  { "enabled" } else { "disabled" })
+Write-InfoBox "  Langfuse (observability):"   $(if ($enableLangfuse) { "enabled" } else { "disabled" })
 
 # ── Tier-appropriate OpenClaw config selection ────────────────────────────────
 # Mirrors bash phase 03 logic (config/openclaw/<profile>.json).

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -124,7 +124,8 @@ $envResult = New-DreamEnv `
     -Tier           $selectedTier `
     -GpuBackend     $gpuInfo.Backend `
     -DreamMode      $_dreamMode `
-    -LlamaServerImage $llamaServerImage
+    -LlamaServerImage $llamaServerImage `
+    -EnableLangfuse $enableLangfuse
 Write-AISuccess "Generated .env with secure secrets"
 
 # ── Post-generation validation: verify all required keys are present with values ──


### PR DESCRIPTION
> **Merge order:** Merge after #899 and #940 — all three modify `install-macos.sh`.

## What
Add Langfuse to the install-time feature menu across all three installers (Linux / macOS / Windows). Before this PR, Langfuse was the only optional built-in extension users couldn't opt into at install time — they had to run `dream enable langfuse` post-install, which is inconsistent with every other optional extension.

## Why
- `installers/phases/06-directories.sh` already generates all `LANGFUSE_*` secrets unconditionally.
- `.env.schema.json` already registers every `LANGFUSE_*` key.
- The extension ships as `compose.yaml.disabled` (default off).
- But there was no CLI flag, no Custom menu prompt, and `LANGFUSE_ENABLED` was hardcoded to `false` in all three env-writers (Linux `phases/06-directories.sh`, macOS `lib/env-generator.sh`, Windows `lib/env-generator.ps1`). The infrastructure was in place, but the user-visible plumbing was missing.

## How

### Flag surface (all three installers)
- **Linux** (`install-core.sh`): `--langfuse` / `--no-langfuse`. Langfuse added to the `--all` expansion. Order-sensitive (matches existing `--comfyui` / `--no-comfyui` pattern): `--all --no-langfuse` resolves to off.
- **macOS** (`installers/macos/install-macos.sh`): `--langfuse` / `--no-langfuse`. Because macOS post-processes `--all` outside the case loop, the override uses an explicit `NO_LANGFUSE_EXPLICIT` tracking flag so order-insensitivity holds.
- **Windows** (`installers/windows/install-windows.ps1`): `-Langfuse` / `-NoLangfuse` switches. Uses boolean AND: `\$enableLangfuse = (\$langfuseFlag -or \$allFlag) -and (-not \$noLangfuseFlag)` — order-insensitive.

### Menu surface (all three)
- **Full Stack**: Langfuse ON (matches the "all features enabled" label).
- **Core Only**: Langfuse explicitly OFF.
- **Custom**: `[y/N]` opt-in prompt matching the existing OpenClaw pattern.

### Env-generator propagation (all three)
- **Linux** (`phases/06-directories.sh:209`): `LANGFUSE_ENABLED=\$(_env_get LANGFUSE_ENABLED \"\${ENABLE_LANGFUSE:-false}\")`. Preserves explicit user overrides on re-install via `_env_get`, defaults to install-time flag on fresh install.
- **macOS** (`lib/env-generator.sh:219`): `LANGFUSE_ENABLED=\${ENABLE_LANGFUSE:-false}` in the unquoted heredoc. Note: macOS env-generator early-returns on re-install, so this value is only written on first install or `--force`. Users re-running `install-macos.sh --langfuse` on an existing install should instead use `dream enable langfuse`.
- **Windows** (`lib/env-generator.ps1:115`): new `[bool]\$EnableLangfuse` parameter on `New-DreamEnv`. Computed default flows through `Get-EnvOrNew` so manual post-install edits survive.

### Compose rename blocks (shared `03-features.sh` + macOS installer)
- **Linux** `phases/03-features.sh`: new Langfuse rename block mirroring the existing comfyui/dreamforge pattern (`mv compose.yaml.disabled → compose.yaml` when enabled, reverse when disabled).
- **macOS** `install-macos.sh`: pre-loop rename block in PHASE 4 (non-dry-run branch), plus a new `langfuse) \$ENABLE_LANGFUSE || SKIP=true ;;` entry in the COMPOSE_FLAGS assembly loop's feature-gating case.

### Bonus fix — dry-run source-tree mutation
The pre-existing comfyui and dreamforge rename blocks in `03-features.sh` were not gated on `\$DRY_RUN`, so dry-run invocations would mutate the source tree (renaming compose files). Since the new Langfuse rename block would have inherited the same bug, I wrapped all three blocks in a single `if ! \$DRY_RUN; then ... fi` gate. Dry-run now leaves the source tree untouched.

## Testing

### Automated
- `make lint` PASS
- `make test` PASS (82/82 tier-map, 17/17 AMD/Lemonade contracts, installer contracts, preflight fixtures)
- `shellcheck` — NET -4 improvement (cleared 5 pre-existing SC1091 sourced-file-not-found warnings; introduced 2 SC2034 on `ENABLE_LANGFUSE` that are structurally identical to the 9 existing SC2034s on other `ENABLE_*` flags — not regressions)
- `pre-commit` (gitleaks, private-key, large-files) PASS on all 10 files
- `bash -n` PASS on all 6 bash files
- `pwsh` was not available on the dev machine; PowerShell files will be validated by `lint-powershell.yml` in CI

### Runtime (macOS dry-run scenarios)
\`\`\`
\$ install-macos.sh --dry-run --non-interactive --langfuse
Features:
  Langfuse: enabled
> [DRY RUN] Would enable Langfuse (LLM observability)

\$ install-macos.sh --dry-run --non-interactive --all
Features:
  Langfuse: enabled

\$ install-macos.sh --dry-run --non-interactive
Features:
  Langfuse: disabled

\$ install-macos.sh --dry-run --non-interactive --all --no-langfuse
Features:
  Langfuse: disabled
\`\`\`

### Source-tree integrity
After running the dry-run scenarios, `git status --short` showed exactly the 10 modified files — no stray `compose.yaml` ↔ `compose.yaml.disabled` renames. The dry-run gate is working.

### Manual (per platform for reviewer)
- **Linux**: `bash install-core.sh --help | grep -i langfuse` (3 lines), `bash install-core.sh --dry-run --langfuse --non-interactive` (exit 0, Langfuse mentioned, `.env` writes `LANGFUSE_ENABLED=true` on fresh install).
- **macOS**: the 4 scenarios above + interactive Custom menu prompt visible when running without `--non-interactive`.
- **Windows**: `pwsh .\install.ps1 -DryRun -NonInteractive -Langfuse` (and `-All`, `-All -NoLangfuse`, default) — verify each combination lands the right `LANGFUSE_ENABLED` in `.env`.

## Platform Impact
- **macOS**: affected — new flag, menu entry, env propagation, compose rename. Runtime-verified via dry-run.
- **Linux**: affected — new flag, menu entry, env propagation, compose rename. Static-verified; runtime testing pending on a Linux host (not available in this dev environment).
- **Windows**: affected — new switch, menu entry, env propagation. Static-verified only; PowerShell AST + runtime testing happens in CI.

## Known Considerations

- **Full Stack default.** The issue author suggested defaulting Langfuse off even for Full Stack because its clickhouse + postgres + minio stack adds ~500MB baseline memory. The implementation enables it in Full Stack because the UI label promises "all features enabled". Non-interactive CLI default remains conservative (off unless `--langfuse` or `--all`), and `--no-langfuse` is honored as an override. If stricter default is preferred, flip the two `ENABLE_LANGFUSE=true` lines in `installers/lib/ui.sh` Full Stack / default cases (and the equivalents in the macOS and Windows phase files).
- **macOS re-install gotcha.** `macos/lib/env-generator.sh::generate_dream_env` early-returns when `.env` already exists without `--force`, so running `install-macos.sh --langfuse` on an already-installed system will NOT update `LANGFUSE_ENABLED` in `.env`. Users should use `dream enable langfuse` post-install instead. Inline comment added at the heredoc call site.
- **Linux `--no-langfuse --all` order-sensitivity.** Matches existing comfyui/dreamforge behavior — a known installer quirk, not introduced by this PR. `--all --no-langfuse` (the intuitive ordering) works correctly. Inline comment added near `--no-langfuse)` arm.
- **Core Only + DreamForge (pre-existing).** The shell auditor discovered `installers/lib/ui.sh` Core Only case doesn't set `ENABLE_DREAMFORGE=false` — DreamForge defaults to true, so "Core Only" silently leaves DreamForge enabled. Filed as a separate fork hygiene task rather than bundled here.
- **PowerShell static validation.** `pwsh` is not installed on the dev machine. The 4 modified `.ps1` files will be validated by CI's `lint-powershell.yml` workflow.

## Fork issue
Closes yasinBursali/DreamServer#327