### PR TITLE
fix(bootstrap): don't block on missing Docker

### DIFF
--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -68,19 +68,11 @@ esac
 # ── Check prerequisites ──────────────────────────────
 log "Checking prerequisites..."
 
-# Docker check (early fail fast)
+# Docker check (informational — the installer auto-installs Docker if missing)
 if command -v docker &> /dev/null; then
     success "Docker found: $(docker --version | head -1)"
-    if docker info &> /dev/null; then
-        success "Docker daemon running"
-    else
-        warn "Docker installed but daemon not running"
-        echo "  Start with: sudo systemctl start docker"
-        echo "  Or on macOS: open Docker Desktop"
-    fi
 else
-    warn "Docker not found — will attempt auto-install"
-    echo "  Note: This requires sudo access and may take several minutes"
+    warn "Docker not found — the installer will attempt to install it"
 fi
 
 # GPU check (early info — real detection happens in the installer)
@@ -149,18 +141,16 @@ else
     success "curl installed"
 fi
 
-# docker
+# docker (the installer auto-installs Docker if missing — don't block here)
 if command -v docker &> /dev/null; then
     success "docker found: $(docker --version | head -1)"
+    if docker compose version &> /dev/null || docker-compose --version &> /dev/null; then
+        success "docker compose found"
+    else
+        warn "Docker Compose not found — the installer will attempt to set it up"
+    fi
 else
-    error "Docker is required but not installed.\n\nInstall Docker:\n  Ubuntu/WSL: https://docs.docker.com/engine/install/ubuntu/\n  Other:      https://docs.docker.com/get-docker/\n\nAfter installing, re-run this script."
-fi
-
-# docker compose (plugin or standalone)
-if docker compose version &> /dev/null || docker-compose --version &> /dev/null; then
-    success "docker compose found"
-else
-    error "Docker Compose is required but not found.\n\nInstall Docker Compose:\n  https://docs.docker.com/compose/install/\n\nAfter installing, re-run this script."
+    warn "Docker not found — the installer will attempt to install it"
 fi
 
 # GPU pre-check already done above — real detection happens in the installer


### PR DESCRIPTION
## Summary

The curl installer exited with an error if Docker wasn't installed, preventing users from reaching the real installer which auto-installs Docker in phase 05.

## Problem

```bash
# Line 156 (old):
error "Docker is required but not installed..."  # ← calls exit 1
```

User runs `curl ... | bash` on a fresh Ubuntu box → bootstrap exits → user never reaches the installer that would have installed Docker for them. The early check (line 82) even said "will attempt auto-install" but the later check contradicted it by exiting.

## Fix

Replace blocking `error` calls with `warn` messages. The bootstrap only needs `git` and `curl` to clone the repo — Docker is the installer's job (phase 05).

Consolidate the two duplicate Docker checks into consistent non-blocking warnings.

## Before vs after

| Scenario | Before | After |
|---|---|---|
| No Docker installed | Script exits with error | Warns, continues to installer (which installs Docker) |
| Docker but no Compose | Script exits with error | Warns, continues to installer |
| Docker + Compose present | "docker found" (twice) | "docker found" + "docker compose found" |

## What still blocks

`git` and `curl` still call `error` if they can't be auto-installed — these are genuinely needed by the bootstrap itself (to clone the repo).