### PR TITLE
fix(schema): register HOST_RAM_GB key used by macOS env-generator

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -72,6 +72,10 @@ CTX_SIZE=16384
 # GPU backend: nvidia or amd
 GPU_BACKEND=nvidia
 
+# Unified system RAM in GB (macOS Apple Silicon only — written by env-generator.sh).
+# Passed to llama.cpp for the Metal backend to size the unified-memory pool.
+# HOST_RAM_GB=24
+
 # Model name override (installer normally rewrites this from tier + MODEL_PROFILE)
 LLM_MODEL=qwen3.5-9b
 

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -115,6 +115,12 @@
       "description": "Number of model layers to offload to GPU",
       "default": 99
     },
+    "HOST_RAM_GB": {
+      "type": "integer",
+      "description": "Unified system RAM in GB. macOS Apple Silicon only; the macOS env-generator writes it from sysctl hw.memsize and it is passed to llama.cpp for the Metal backend so it can size the unified-memory pool. Not written on Linux or Windows .env files. Not sensitive.",
+      "minimum": 1,
+      "maximum": 1024
+    },
     "LLM_MODEL": {
       "type": "string",
       "description": "Model name used by OpenClaw and dashboard"


### PR DESCRIPTION
> **Merge order:** Merge this PR before #936 — both modify `.env.schema.json` and `.env.example`.

## What
Register `HOST_RAM_GB` in `.env.schema.json` so the dashboard Settings panel on macOS can save again.

## Why
`installers/macos/lib/env-generator.sh:170` unconditionally writes `HOST_RAM_GB=<unified memory GB>` to the `.env` of every Apple Silicon install. `.env.schema.json` had no `HOST_RAM_GB` entry. The schema-aware validator in `dashboard-api/main.py::_handle_env_update` (and its `api_settings_env_save` proxy) walks every key in the incoming payload through the schema and rejects the first unknown one with `503 Unknown key: HOST_RAM_GB`.

On a fresh Apple Silicon install, `HOST_RAM_GB` is always present in `.env`, so every `PUT /api/settings/env` — both the raw-text round-trip and the dashboard UI's form-mode save — fails before reaching any other key. The dashboard Settings panel is effectively broken on Mac.

The value is actively consumed in production code:
- `docker-compose.base.yml:167` and `installers/macos/docker-compose.macos.yml:56` pass `HOST_RAM_GB=${HOST_RAM_GB:-0}` into the `llama-server` container environment
- `extensions/services/dashboard-api/routers/features.py:29,142` reads it as the Apple Silicon VRAM fallback for tier gating

The schema registration was the only missing link.

## How
Add `HOST_RAM_GB` as an optional integer property in `.env.schema.json` (between `N_GPU_LAYERS` and `LLM_MODEL`, grouped with the other llama.cpp runtime tunables):
\`\`\`json
"HOST_RAM_GB": {
  "type": "integer",
  "description": "...macOS Apple Silicon only...",
  "minimum": 1,
  "maximum": 1024
}
\`\`\`
Not in the `required` array — Linux / Windows installs don't write it, and absence is fine.

Add a commented-out example in `.env.example` next to the hardware section so `_render_env_from_values` walks it in the natural position on rebuild.

## Testing

### Audit
Cross-referenced every `^KEY=` write in `installers/macos/lib/env-generator.sh` against schema `properties`. 54 keys written, **only `HOST_RAM_GB` was missing**. `HOST_GPU_CORES` and `HOST_CHIP` are not written by the generator (confirming the existing convention) and stay out of the schema.

### Automated
- `make lint`: PASS
- `make test`: PASS (tier-map 82/82, installer contracts, preflight fixtures, AMD/Lemonade contracts 17/17)
- `jq -e '.properties.HOST_RAM_GB'`: valid
- `pre-commit` (gitleaks, private-key, large-files): PASS
- Schema property count: 125 → 126 (delta +1)
- `pytest dashboard-api/tests/`: 534 pass + 12 pre-existing failures (unchanged from baseline)

### Runtime (against a live macOS install)
Reproduced the bug against an 84-line baseline `.env` containing `HOST_RAM_GB=24`:

**Before fix** (raw_text PUT): `HTTP 503: {"detail":{"message":"Unknown key: HOST_RAM_GB"}}`

**After fix** (schema deployed, dashboard-api restarted): `status: 200`

Inside the container after deploy: `docker exec` confirms `HOST_RAM_GB` is in `schema.properties` with the correct spec.

**Chrome UI**: fresh tab navigated to `http://localhost:3001/settings`. Settings page rendered cleanly, 8 section headings, Save `.env` button present, zero "Unknown key" errors in DOM.

Live `.env` restored to pre-test MD5 after testing. LibreChat containers unaffected.

### Manual (per platform for reviewer)
- **macOS**: reproduce the 503 by removing `HOST_RAM_GB` from a local `.env.schema.json`, restart dashboard-api, hit `PUT /api/settings/env` — expect 503. Re-add the entry, restart, same PUT — expect 200.
- **Linux / WSL2**: `HOST_RAM_GB` is not written to `.env` on these platforms. Schema addition is inert. GET/PUT flows unaffected.
- **Windows**: same as Linux.

## Platform Impact
- **macOS**: bug fix — Settings panel save unblocked on fresh installs.
- **Linux**: not affected — schema addition is inert.
- **Windows/WSL2**: not affected — same as Linux.

## Known Considerations

**A second schema-coverage bug exists on installs with extension install hooks.** Testing revealed that after the HOST_RAM_GB fix unblocks the first unknown key, the validator then rejects extension-installed keys (e.g. 6 LibreChat-specific keys). Filed as a separate fork issue with proposed fix directions. This PR fixes the exact key reported; the extension-env-key issue warrants its own architectural discussion.

**`.env.example` ordering.** The new commented-out entry sits between `GPU_BACKEND` and `LLM_MODEL`. `_render_env_from_values` preserves `.env.example` ordering on rebuild, so rebuilt `.env` files see a one-line cosmetic shift. Non-functional.

**`minimum`/`maximum` bounds.** These are the first use of min/max in the schema. `_validate_env_values` currently only honors `type` and `enum` — the bounds are inert today but document the valid range for future validator extensions.

## Fork issue
Closes yasinBursali/DreamServer#337