### PR TITLE
fix(helpers): treat bootstrap status failed/cancelled as inactive, reconcile with filesystem

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -397,10 +397,27 @@ def get_bootstrap_status() -> BootstrapStatus:
             data = json.load(f)
 
         status = data.get("status", "")
-        if status == "complete":
+        if status in ("complete", "failed", "cancelled", "error"):
             return BootstrapStatus(active=False)
         if status == "" and not data.get("bytesDownloaded") and not data.get("percent"):
             return BootstrapStatus(active=False)
+
+        # Reconcile with the filesystem: if the target model file is already
+        # present on disk, the download is effectively done regardless of what
+        # the status record says (covers stale "downloading" entries left by a
+        # crash or a parallel download path). Skip during "verifying" because
+        # the file has been renamed into place but SHA256 hasn't finished yet —
+        # returning inactive here would hide a subsequent verification failure.
+        model_name = data.get("model")
+        if model_name and status != "verifying":
+            models_dir = Path(DATA_DIR) / "models"
+            model_path = (models_dir / model_name).resolve()
+            if model_path.is_relative_to(models_dir.resolve()):
+                try:
+                    if model_path.exists() and model_path.stat().st_size > 0:
+                        return BootstrapStatus(active=False)
+                except OSError as e:
+                    logger.debug("bootstrap reconciliation stat failed: %s", e)
 
         eta_str = data.get("eta", "")
         eta_seconds = None

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -142,6 +142,51 @@ class TestGetBootstrapStatus:
         status = get_bootstrap_status()
         assert status.active is False
 
+    def test_inactive_when_failed(self, data_dir):
+        status_file = data_dir / "bootstrap-status.json"
+        status_file.write_text(json.dumps({"status": "failed", "model": "test.gguf"}))
+
+        status = get_bootstrap_status()
+        assert status.active is False
+
+    def test_inactive_when_model_file_on_disk(self, data_dir):
+        models_dir = data_dir / "models"
+        models_dir.mkdir(exist_ok=True)
+        (models_dir / "present.gguf").write_bytes(b"\x00" * 1024)
+
+        status_file = data_dir / "bootstrap-status.json"
+        status_file.write_text(json.dumps({
+            "status": "downloading", "model": "present.gguf",
+            "percent": 50, "bytesDownloaded": 500, "bytesTotal": 1024,
+        }))
+
+        status = get_bootstrap_status()
+        assert status.active is False
+
+    def test_active_during_verifying_even_if_file_exists(self, data_dir):
+        models_dir = data_dir / "models"
+        models_dir.mkdir(exist_ok=True)
+        (models_dir / "verifying.gguf").write_bytes(b"\x00" * 1024)
+
+        status_file = data_dir / "bootstrap-status.json"
+        status_file.write_text(json.dumps({
+            "status": "verifying", "model": "verifying.gguf",
+            "percent": 100, "bytesDownloaded": 1024, "bytesTotal": 1024,
+        }))
+
+        status = get_bootstrap_status()
+        assert status.active is True
+
+    def test_path_traversal_rejected(self, data_dir):
+        status_file = data_dir / "bootstrap-status.json"
+        status_file.write_text(json.dumps({
+            "status": "downloading", "model": "../../etc/passwd",
+            "percent": 50, "bytesDownloaded": 500, "bytesTotal": 1000,
+        }))
+
+        status = get_bootstrap_status()
+        assert status.active is True
+
 
 # --- _update_lifetime_tokens ---
 


### PR DESCRIPTION
> **Merge order:** Merge this PR before #941 — both modify `helpers.py` and `test_helpers.py`.

## What
Fix a permanent stale "Downloading Full Model — 0.0%" banner that appears on the dashboard when a bootstrap model download fails.

## Why
`get_bootstrap_status()` in `helpers.py` checks only for `status == "complete"` to return `active=False`. A failed download leaves `bootstrap-status.json` with `status="failed"`, which falls through to the `active=True` return path. The dashboard's `<BootstrapBanner>` then renders a permanent banner with `0.0% • ETA: calculating... • 0 / 0 GB` that never updates and cannot be dismissed.

## How

### Part 1 — terminal status expansion
Extend the early-return from `if status == "complete"` to `if status in ("complete", "failed", "cancelled", "error")`. Any terminal non-in-progress state returns `active=False`. `"cancelled"` and `"error"` are not currently produced by the download worker but are reserved for forward-compatibility.

### Part 2 — filesystem reconciliation
After the terminal-status check, verify whether the target model file is already present on disk with non-zero size. If it is, return `active=False` regardless of what the status record says. This covers stale `"downloading"` entries left by a crash, a SIGKILL during the atomic `mv`, or a parallel download path (e.g. the dashboard Models page downloading the same model concurrently).

Two guards protect the reconciliation:
- **Skip during `status="verifying"`** — the file has been renamed into place but SHA256 verification is still running. Returning inactive here would suppress the banner one tick too early and hide a subsequent verification failure.
- **Path containment** via `resolve()` + `is_relative_to()` — prevents a corrupted or malicious `model` field in the status file from escaping the models directory.

A narrow `try/except OSError` with `logger.debug` handles the TOCTOU race where the file vanishes between `exists()` and `stat()`.

## Testing

### Automated
- `make lint`: PASS
- `make test`: PASS
- `pytest tests/test_helpers.py::TestGetBootstrapStatus`: **10/10 PASS** (6 existing + 4 new)
- `pytest tests/`: 534 pass + 12 pre-existing failures (unchanged baseline)
- `pre-commit`: PASS

### New unit tests (4 methods in `TestGetBootstrapStatus`)
| Test | Scenario | Asserts |
|---|---|---|
| `test_inactive_when_failed` | `status: "failed"` | `active is False` |
| `test_inactive_when_model_file_on_disk` | `status: "downloading"` + model file exists | `active is False` |
| `test_active_during_verifying_even_if_file_exists` | `status: "verifying"` + model file exists | `active is True` |
| `test_path_traversal_rejected` | `model: "../../etc/passwd"` | `active is True` |

### Runtime (against live macOS install)
Synthesized 5 scenarios by writing `bootstrap-status.json` to the install's data dir:

| Scenario | Expected | Got |
|---|---|---|
| `status: "failed"` | inactive | null ✓ |
| `status: "downloading"` + file IS on disk | inactive (reconciliation) | null ✓ |
| `status: "downloading"` + file NOT on disk | active | `active: True` ✓ |
| `status: "verifying"` + file IS on disk | active (skip reconciliation) | `active: True` ✓ |
| `model: "../../etc/passwd"` (path traversal) | active (traversal rejected) | `active: True` ✓ |

Stale `bootstrap-status.json` cleaned up after testing.

### Manual (per platform for reviewer)
- **All platforms**: write a `{"status":"failed","model":"test.gguf"}` to `data/bootstrap-status.json`, hit `GET /api/status`, confirm `bootstrap` is null/inactive. Then write `{"status":"downloading","model":"<existing-model>.gguf",...}` and confirm reconciliation returns inactive. Clean up the file after.

## Platform Impact
- **macOS**: primary — this is where bootstrap failures most commonly occur (launchd-throttled host agent, network blips during install).
- **Linux**: affected — same code path runs in the dashboard-api container on Linux installs.
- **Windows/WSL2**: affected — same.

## Known Considerations
- `"cancelled"` is a dead status string — no current writer produces it. Kept for forward-compatibility; if a cancellation path is added to the download worker, the reader already handles it.
- The reconciliation check uses `st_size > 0` to avoid false-positive on a zero-byte placeholder. A renamed old version of the same model name could still trip it, but that's acceptable — the model is on disk, so the banner saying "downloading" would be more confusing than helpful.

## Fork issue
Closes yasinBursali/DreamServer#329