### PR TITLE
fix(openclaw): correct config path env var + modern schema + gateway.mode

### DIFF
--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -199,6 +199,9 @@ try {
     // into ~/.openclaw/openclaw.json but that write may fail (EACCES on
     // Docker volume), so we must also set them here in the merged config.
     if (!primary.gateway) primary.gateway = {};
+    // gateway.mode is required by OpenClaw v2026.3.8+; without it the
+    // gateway refuses to start.
+    if (!primary.gateway.mode) primary.gateway.mode = 'local';
     if (!primary.gateway.controlUi) primary.gateway.controlUi = {};
     primary.gateway.controlUi.allowInsecureAuth = true;
     primary.gateway.controlUi.dangerouslyDisableDeviceAuth = true;

--- a/dream-server/config/openclaw/openclaw-strix-halo.json
+++ b/dream-server/config/openclaw/openclaw-strix-halo.json
@@ -1,51 +1,35 @@
 {
-  "$schema": "https://raw.githubusercontent.com/openclaw/openclaw/main/schemas/openclaw.json",
-  "version": "1.0",
-  "agent": {
-    "name": "Dream Agent (Strix Halo)",
-    "model": "local-llama/__LLM_MODEL__",
-    "systemPrompt": "You are Dream Agent, a powerful local AI assistant running on AMD Strix Halo with unified memory. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning. Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself. Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it."
-  },
-  "providers": {
-    "local-llama": {
-      "type": "openai-compatible",
-      "baseUrl": "http://litellm:4000/v1",
-      "apiKey": "__LITELLM_KEY__",
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "local-llama/__LLM_MODEL__"
+      },
       "models": {
-        "__LLM_MODEL__": {
-          "contextWindow": 131072,
-          "supportsTools": true
-        }
+        "local-llama/__LLM_MODEL__": {}
+      },
+      "subagents": {
+        "model": "local-llama/__LLM_MODEL__",
+        "maxConcurrent": 20
       }
     }
   },
-  "subagent": {
-    "enabled": true,
-    "model": "local-llama/__LLM_MODEL__",
-    "maxConcurrent": 20,
-    "timeoutSeconds": 600
-  },
-  "tools": {
-    "exec": {
-      "enabled": true,
-      "allowedCommands": ["ls", "cat", "grep", "find", "head", "tail", "wc"]
-    },
-    "read": { "enabled": true },
-    "write": { "enabled": true },
-    "web_fetch": { "enabled": true },
-    "web": {
-      "search": {
-        "enabled": true,
-        "provider": "searxng",
-        "maxResults": 5,
-        "searxng": {
-          "baseUrl": "http://searxng:8080"
-        }
+  "models": {
+    "providers": {
+      "local-llama": {
+        "baseUrl": "http://litellm:4000/v1",
+        "apiKey": "__LITELLM_KEY__",
+        "models": [
+          {
+            "id": "__LLM_MODEL__",
+            "name": "__LLM_MODEL__",
+            "contextWindow": 131072
+          }
+        ]
       }
     }
   },
   "gateway": {
-    "port": 7860,
+    "mode": "local",
     "controlUi": {
       "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,

--- a/dream-server/config/openclaw/openclaw.json
+++ b/dream-server/config/openclaw/openclaw.json
@@ -1,52 +1,35 @@
 {
-  "$schema": "https://raw.githubusercontent.com/openclaw/openclaw/main/schemas/openclaw.json",
-  "version": "1.0",
-  "agent": {
-    "name": "Dream Agent (Pro)",
-    "model": "local-llama/__LLM_MODEL__",
-    "systemPrompt": "You are Dream Agent, a powerful local AI assistant running on dedicated GPU with discrete VRAM. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning. Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself. Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it."
-  },
-  "providers": {
-    "local-llama": {
-      "type": "openai-compatible",
-      "baseUrl": "http://llama-server:8080/v1",
-      "apiKey": "none",
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "local-llama/__LLM_MODEL__"
+      },
       "models": {
-        "__LLM_MODEL__": {
-          "contextWindow": 131072,
-          "supportsTools": true
-        }
+        "local-llama/__LLM_MODEL__": {}
+      },
+      "subagents": {
+        "model": "local-llama/__LLM_MODEL__",
+        "maxConcurrent": 20
       }
     }
   },
-  "subagent": {
-    "enabled": true,
-    "model": "local-llama/__LLM_MODEL__",
-    "maxConcurrent": 20,
-    "timeoutSeconds": 600
-  },
-  "tools": {
-    "exec": {
-      "enabled": true,
-      "allowedCommands": ["ls", "cat", "grep", "find", "head", "tail", "wc"]
-    },
-    "read": { "enabled": true },
-    "write": { "enabled": true },
-    "web_fetch": { "enabled": true },
-    "web": {
-      "search": {
-        "enabled": true,
-        "provider": "searxng",
-        "maxResults": 5,
-        "searxng": {
-          "baseUrl": "http://searxng:8080"
-        }
+  "models": {
+    "providers": {
+      "local-llama": {
+        "baseUrl": "http://llama-server:8080/v1",
+        "apiKey": "none",
+        "models": [
+          {
+            "id": "__LLM_MODEL__",
+            "name": "__LLM_MODEL__",
+            "contextWindow": 131072
+          }
+        ]
       }
     }
   },
   "gateway": {
-    "port": 7860,
-    "host": "127.0.0.1",
+    "mode": "local",
     "controlUi": {
       "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,

--- a/dream-server/config/openclaw/pro.json
+++ b/dream-server/config/openclaw/pro.json
@@ -1,52 +1,35 @@
 {
-  "$schema": "https://raw.githubusercontent.com/openclaw/openclaw/main/schemas/openclaw.json",
-  "version": "1.0",
-  "agent": {
-    "name": "Dream Agent (Pro)",
-    "model": "local-llama/__LLM_MODEL__",
-    "systemPrompt": "You are Dream Agent, a powerful local AI assistant running on dedicated GPU with discrete VRAM. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning. Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself. Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it."
-  },
-  "providers": {
-    "local-llama": {
-      "type": "openai-compatible",
-      "baseUrl": "http://llama-server:8080/v1",
-      "apiKey": "none",
+  "agents": {
+    "defaults": {
+      "model": {
+        "primary": "local-llama/__LLM_MODEL__"
+      },
       "models": {
-        "__LLM_MODEL__": {
-          "contextWindow": 131072,
-          "supportsTools": true
-        }
+        "local-llama/__LLM_MODEL__": {}
+      },
+      "subagents": {
+        "model": "local-llama/__LLM_MODEL__",
+        "maxConcurrent": 20
       }
     }
   },
-  "subagent": {
-    "enabled": true,
-    "model": "local-llama/__LLM_MODEL__",
-    "maxConcurrent": 20,
-    "timeoutSeconds": 600
-  },
-  "tools": {
-    "exec": {
-      "enabled": true,
-      "allowedCommands": ["ls", "cat", "grep", "find", "head", "tail", "wc"]
-    },
-    "read": { "enabled": true },
-    "write": { "enabled": true },
-    "web_fetch": { "enabled": true },
-    "web": {
-      "search": {
-        "enabled": true,
-        "provider": "searxng",
-        "maxResults": 5,
-        "searxng": {
-          "baseUrl": "http://searxng:8080"
-        }
+  "models": {
+    "providers": {
+      "local-llama": {
+        "baseUrl": "http://llama-server:8080/v1",
+        "apiKey": "none",
+        "models": [
+          {
+            "id": "__LLM_MODEL__",
+            "name": "__LLM_MODEL__",
+            "contextWindow": 131072
+          }
+        ]
       }
     }
   },
   "gateway": {
-    "port": 7860,
-    "host": "127.0.0.1",
+    "mode": "local",
     "controlUi": {
       "allowInsecureAuth": true,
       "dangerouslyDisableDeviceAuth": true,

--- a/dream-server/config/openclaw/workspace/SYSTEM.md
+++ b/dream-server/config/openclaw/workspace/SYSTEM.md
@@ -1,0 +1,5 @@
+You are Dream Agent, a powerful local AI assistant. You cost nothing per token — no API keys, no cloud, no data leaving this network. Every task you complete is local AI winning.
+
+Be thorough, precise, and leverage your full capabilities. You have access to tools for reading files, writing files, running commands, and spawning sub-agents. Use them aggressively — don't give the user homework you can do yourself.
+
+Build first, polish second. Ship working results. When you can parallelize with sub-agents, do it.

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -19,7 +19,7 @@ services:
       - OPENCLAW_EXTERNAL_PORT=${OPENCLAW_PORT:-7860}
       - HOME=/home/node
     user: "0:0"
-    entrypoint: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.openclaw; exec setpriv --reuid=1000 --regid=1000 --clear-groups /bin/sh -c 'node /config/inject-token.js; export OPENCLAW_CONFIG=/tmp/openclaw-config.json; exec docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured --bind lan'"]
+    entrypoint: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.openclaw; exec setpriv --reuid=1000 --regid=1000 --clear-groups /bin/sh -c 'node /config/inject-token.js; export OPENCLAW_CONFIG_PATH=/tmp/openclaw-config.json; exec docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured --bind lan'"]
     volumes:
       - ./config/openclaw:/config:ro
       - ./data/openclaw:/data


### PR DESCRIPTION
## Summary

Fixes the root cause of OpenClaw defaulting to `anthropic/claude-opus-4-6` on every fresh install. Three interconnected issues:

1. **Wrong env var**: entrypoint set `OPENCLAW_CONFIG` but gateway reads `OPENCLAW_CONFIG_PATH`
2. **Legacy schema**: config templates used deprecated keys rejected by v2026.3.8
3. **Missing `gateway.mode`**: required by v2026.3.8, without it gateway refuses to start

## Root Cause

OpenClaw v2026.3.8 reads `OPENCLAW_CONFIG_PATH` (confirmed in `/app/dist/paths-BJV7vkaX.js` line 132). DreamServer set `OPENCLAW_CONFIG`. The merged config at `/tmp/openclaw-config.json` was created correctly by inject-token.js but the gateway never read it, falling back to `~/.openclaw/openclaw.json` which has no model config.

## Changes (6 files)

| File | Change |
|---|---|
| `compose.yaml` (entrypoint) | `OPENCLAW_CONFIG` -> `OPENCLAW_CONFIG_PATH` |
| `openclaw.json` | Modern schema: `agents.defaults`, `models.providers`, `gateway.mode` |
| `pro.json` | Same modern schema |
| `openclaw-strix-halo.json` | Same modern schema (with LiteLLM routing) |
| `inject-token.js` | Add `gateway.mode: "local"` to Part 3 merged config |
| `workspace/SYSTEM.md` | New — system prompt (no longer a valid JSON config key) |

## Schema changes

| Legacy key (rejected by v2026.3.8) | Modern key |
|---|---|
| `agent.model` | `agents.defaults.model.primary` |
| `agent.systemPrompt` | `workspace/SYSTEM.md` file |
| `providers` | `models.providers` |
| `subagent` | `agents.defaults.subagents` |
| `version` | removed |
| `tools.*` | removed (not configurable via JSON) |
| `tools.web.search.provider: "searxng"` | removed (not a valid provider) |

All templates validated with `openclaw config validate --json` returning `{"valid": true}`.

## Verified

- [x] Fresh volume + container recreate: `agent model: local-llama/qwen3-coder-next`
- [x] No crash loop
- [x] `openclaw config validate` passes
- [x] No manual `openclaw config set` needed
- [ ] Full end-to-end reinstall test

Reverts the config portion of #914 (v1 schema revert was wrong).