### PR TITLE
fix(extensions): trust built-in composes in _scan_compose_content name-collision check

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -229,7 +229,12 @@ def _assert_not_core(service_id: str) -> None:
         )
 
 
-def _scan_compose_content(compose_path: Path, *, trusted: bool = False) -> None:
+def _scan_compose_content(
+    compose_path: Path,
+    *,
+    trusted: bool = False,
+    skip_name_collision: bool = False,
+) -> None:
     """Reject compose files containing dangerous directives."""
     try:
         data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
@@ -246,7 +251,7 @@ def _scan_compose_content(compose_path: Path, *, trusted: bool = False) -> None:
         return
 
     for svc_name in services:
-        if svc_name in CORE_SERVICE_IDS:
+        if not skip_name_collision and svc_name in CORE_SERVICE_IDS:
             raise HTTPException(
                 status_code=400,
                 detail=f"Extension rejected: service name '{svc_name}' conflicts with core service",
@@ -1073,8 +1078,14 @@ def _activate_service(service_id: str) -> dict:
             status_code=404, detail=f"Extension has no compose file: {service_id}",
         )
 
-    # Re-scan compose content (TOCTOU prevention)
-    _scan_compose_content(disabled_compose)
+    # Re-scan compose content (TOCTOU prevention). Built-in extensions
+    # legitimately declare their own service name in their compose file, so
+    # skip the CORE_SERVICE_IDS name-collision check for them. User extensions
+    # still get the full anti-shadowing scan. The `trusted` flag is separate
+    # and controls whether `build:` directives are allowed (library installs
+    # need it, built-in activations do not).
+    is_builtin = ext_dir.is_relative_to(EXTENSIONS_DIR.resolve())
+    _scan_compose_content(disabled_compose, skip_name_collision=is_builtin)
 
     # Reject symlinks
     st = os.lstat(disabled_compose)

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -5,7 +5,9 @@ import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
+import pytest
 import yaml
+from fastapi import HTTPException
 from models import ServiceStatus
 
 
@@ -1185,6 +1187,45 @@ class TestComposeScanEdgeCases:
         )
         assert resp.status_code == 400
         assert "dangerous security_opt" in resp.json()["detail"]
+
+
+# --- skip_name_collision flag isolation ---
+
+
+class TestScanComposeSkipNameCollision:
+    """Direct unit tests for the skip_name_collision parameter added for
+    built-in activation (fork issue #338)."""
+
+    def test_rejects_core_name_by_default(self, tmp_path):
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  open-webui:\n    image: test\n")
+        with pytest.raises(HTTPException) as exc:
+            _scan_compose_content(compose, skip_name_collision=False)
+        assert exc.value.status_code == 400
+        assert "conflicts with core service" in exc.value.detail
+
+    def test_allows_core_name_when_skipped(self, tmp_path):
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  open-webui:\n    image: test\n")
+        _scan_compose_content(compose, skip_name_collision=True)
+
+    def test_privileged_still_blocked_when_skipped(self, tmp_path):
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  svc:\n    image: test\n    privileged: true\n")
+        with pytest.raises(HTTPException) as exc:
+            _scan_compose_content(compose, skip_name_collision=True)
+        assert "privileged" in exc.value.detail
+
+    def test_docker_socket_still_blocked_when_skipped(self, tmp_path):
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text("services:\n  svc:\n    image: test\n    volumes:\n      - /var/run/docker.sock:/var/run/docker.sock\n")
+        with pytest.raises(HTTPException) as exc:
+            _scan_compose_content(compose, skip_name_collision=True)
+        assert "Docker socket" in exc.value.detail
 
 
 # --- Size quota enforcement ---


### PR DESCRIPTION
> **Merge order:** Merge after #909, before #907 and #935 — all modify `extensions.py`.

## What
Allow built-in extensions (n8n, tts, whisper, langfuse, token-spy, etc.) to be activated via templates and the enable API without being rejected by the CORE_SERVICE_IDS name-collision check.

## Why
`_scan_compose_content` blocks any compose file whose `services:` map declares a name found in `CORE_SERVICE_IDS`. This is a legitimate anti-shadowing defense for user extensions — it prevents a user extension from defining `services: {n8n: ...}` and hijacking the built-in n8n container. But every built-in extension naturally declares its own service name in its compose file. The same check therefore blocks `_activate_service` from re-enabling any built-in except comfyui (which happens to have an empty `services: {}` stub because its real definitions live in GPU-specific overlays).

Templates that call `_activate_service` for built-ins — e.g. the `llm-platform` template enabling n8n, tts, whisper — all fail silently with `"Extension rejected: service name 'X' conflicts with core service"` and never reach the compose rename.

## How

### 1. New `skip_name_collision` parameter on `_scan_compose_content`
A keyword-only `skip_name_collision: bool = False` parameter, separate from the existing `trusted` (which controls the `build:` directive check). When `True`, only the `CORE_SERVICE_IDS` loop is skipped. All other security checks remain active:
- Privileged mode
- Docker socket mounts
- Absolute host path mounts
- Dangerous capabilities (SYS_ADMIN, NET_ADMIN, etc.)
- Docker Compose label spoofing
- Host PID/network/IPC/userns namespaces
- Root user
- Security option relaxation

The separation from `trusted` is important: library installs (`_install_from_library`) pass `trusted=True` to allow `build:` directives but MUST still check core-service names. An initial implementation that overloaded `trusted` for both broke the existing `test_scan_rejects_core_service_name` test — a library extension shadowing `open-webui` was silently allowed.

### 2. Dual-directory lookup in `_activate_service`
`_activate_service` now checks both `USER_EXTENSIONS_DIR` (user-installed) and `EXTENSIONS_DIR` (built-in), user-dir first. Path containment is verified via `resolve()` + `is_relative_to()` so a user extension cannot be misclassified as built-in. Then: `is_builtin = ext_dir.is_relative_to(EXTENSIONS_DIR.resolve())` → `_scan_compose_content(disabled_compose, skip_name_collision=is_builtin)`.

## Testing

### Automated
- `pytest tests/test_extensions.py`: **108/108 PASS** (104 existing + 4 new)
- `make lint`: PASS
- `make test`: PASS
- `pre-commit`: PASS

### New unit tests (`TestScanComposeSkipNameCollision`)
| Test | Scenario | Asserts |
|---|---|---|
| `test_rejects_core_name_by_default` | `skip_name_collision=False` + core service name | HTTPException 400, "conflicts with core service" |
| `test_allows_core_name_when_skipped` | `skip_name_collision=True` + core service name | No exception |
| `test_privileged_still_blocked_when_skipped` | `skip_name_collision=True` + `privileged: true` | HTTPException 400, "privileged" |
| `test_docker_socket_still_blocked_when_skipped` | `skip_name_collision=True` + docker socket mount | HTTPException 400, "Docker socket" |

### Runtime (against live macOS install)
- Template apply for `llm-platform` reached `os.rename` for built-in langfuse (which then hit EROFS from the `:ro` bind-mount — a separate known issue). The error is "Read-only file system", NOT "conflicts with core service" — proving the scan gate was passed.
- Security verification inside the container via `docker exec`:
  - Untrusted user extension shadowing core name → correctly REJECTED
  - Trusted built-in with its own name → correctly ALLOWED
  - Trusted but privileged → correctly REJECTED

### Manual (per platform for reviewer)
- **All platforms**: disable a built-in extension's compose (`mv compose.yaml compose.yaml.disabled`), apply a template that includes it, verify it passes the scan gate (reaches either `os.rename` success or the `:ro` mount error, but NOT "conflicts with core service"). Then verify a user extension with a core service name is still blocked via the install endpoint.

## Platform Impact
- **macOS**: affected — built-in activation is the primary use case for templates on Mac installs.
- **Linux**: affected — same code path runs in the dashboard-api container.
- **Windows/WSL2**: affected — same.

## Known Considerations
- **Relationship to PRs #907 and #909.** PR #907 relaxes `_assert_not_core` from `CORE_SERVICE_IDS` to `ALWAYS_ON_SERVICES`. PR #909 adds the dual-dir lookup to `_activate_service`. This PR adds the `skip_name_collision` parameter to `_scan_compose_content` and reproduces #909's dual-dir lookup so the fix is standalone against upstream/main. Once all three merge, the full "make built-ins manageable" surface is covered.
- **The `:ro` mount issue (#331).** Even with this fix, `os.rename` still fails on `:ro` bind-mounts. That's a separate orthogonal fix (delegate rename to host-agent). Both fixes are needed for full built-in activation support.

## Fork issue
Closes yasinBursali/DreamServer#338