### PR TITLE
fix(dashboard): allow useSystemStatus initial fetch on hidden tab

### DIFF
--- a/dream-server/extensions/services/dashboard/src/hooks/useSystemStatus.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useSystemStatus.js
@@ -54,6 +54,12 @@ export function useSystemStatus() {
   // llama-server under inference load) we skip the next poll rather
   // than stacking concurrent requests that can amplify the problem.
   const fetchInFlight = useRef(false)
+  // Allow the very first fetch to run even on a hidden tab so that
+  // users who open the dashboard in a background window (multi-monitor,
+  // restored session, browser automation) don't see a permanently stuck
+  // loading skeleton. After the initial data lands, the hidden-tab
+  // guard engages for subsequent polls to save CPU/network.
+  const hasInitialData = useRef(false)
 
   useEffect(() => {
     const fetchStatus = async () => {
@@ -62,8 +68,9 @@ export function useSystemStatus() {
         return
       }
 
-      // Pause polling when the tab is hidden to save CPU/network
-      if (document.hidden) return
+      // Pause polling when the tab is hidden — but only after the first
+      // successful fetch so the loading skeleton is never permanent.
+      if (document.hidden && hasInitialData.current) return
 
       // Skip this tick if the previous fetch hasn't returned yet.
       if (fetchInFlight.current) return
@@ -75,6 +82,7 @@ export function useSystemStatus() {
         const data = await response.json()
         setStatus(data)
         setError(null)
+        hasInitialData.current = true
       } catch (err) {
         setError(err.message)
       } finally {


### PR DESCRIPTION
## What
Fix the dashboard loading skeleton being permanently stuck when the tab is opened in a background window.

## Why
`useSystemStatus` guards its polling loop with `if (document.hidden) return` to save CPU/network when the tab is backgrounded. But that guard fires before the very first fetch, so a dashboard opened in a background tab — multi-monitor setup, restored browser session, MCP/Playwright automation, secondary-monitor drag — gets permanently stuck on the loading skeleton ("Linking modules... reading telemetry...", "Services Online: 0/0") until the user happens to focus the tab.

## How
Add a `hasInitialData` ref (alongside the existing `fetchInFlight` ref) that starts `false`. Gate the hidden-tab guard as `if (document.hidden && hasInitialData.current) return` so the very first fetch always runs regardless of tab visibility. After the first successful response, flip `hasInitialData` to `true` — subsequent polls respect the hidden-tab guard as designed.

Edge cases handled:
- **Mock mode:** short-circuits before the guard, unaffected.
- **Error path:** `finally` block sets `loading=false` (prevents permanent skeleton); `hasInitialData` stays false so the next poll also bypasses the guard, retrying until the first success.
- **`visibilitychange` listener:** calls `fetchStatus()` which checks the same guard — first hidden→visible transition on a cold dashboard also bypasses because `hasInitialData` is still false.

## Testing

### Automated
- ESLint: 0 errors, 5 pre-existing warnings (same files as before)
- Vite build: `✓ built in 1.40s`

### Runtime
Dashboard container rebuilt and recreated (healthy). New build hash: `index-CJfOBxGD.js`.

**Chrome MCP hidden-tab verification**: opened a fresh tab navigating to the dashboard. Tab confirmed `document.hidden: true, visibilityState: "hidden"` at load time.

Before fix: "Linking modules... reading telemetry..." stuck forever.

After fix: `isStuck: false`, page shows "17/17 services online" with all feature cards rendered — despite the tab being hidden.

### Manual (per platform for reviewer)
Open the dashboard in a background tab (Cmd+click a link to open in new tab without switching, or restore a minimized browser session). Wait 10+ seconds. The dashboard should show real service data, not the loading skeleton.

## Platform Impact
- **macOS / Linux / Windows**: all affected equally — the bug is in browser-side JavaScript. The fix uses standard React primitives (`useRef`) and the Page Visibility API, both cross-browser.

## Known Considerations
- `useGPUDetailed.js:17` has the same unguarded `if (document.hidden) return` pattern. If the GPU Monitor page is ever loaded in a background tab, it exhibits the same stuck behavior. Flagged for a follow-up.

## Fork issue
Closes yasinBursali/DreamServer#330