### PR TITLE
fix: OpenClaw model ID on AMD + OpenCode config and service

### DIFF
--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -16,7 +16,18 @@ const path = require('path');
 const token = process.env.OPENCLAW_GATEWAY_TOKEN || '';
 const EXTERNAL_PORT = process.env.OPENCLAW_EXTERNAL_PORT || '7860';
 const LLM_MODEL = process.env.LLM_MODEL || '';
+const GGUF_FILE = process.env.GGUF_FILE || '';
 const OPENCLAW_LLM_URL = process.env.OPENCLAW_LLM_URL || '';
+
+// On AMD/Lemonade, compose.amd.yaml sets OLLAMA_URL to
+// "http://llama-server:8080/api" (Lemonade's Ollama-compat endpoint).
+// Models there are exposed as "extra.<GGUF_FILE>".  When going through
+// LiteLLM, LLM_MODEL is fine because the wildcard route rewrites it.
+// Detect Lemonade by the trailing "/api" path (NVIDIA's llama.cpp URL
+// never has it — its default is "http://llama-server:8080" or via LiteLLM).
+const OLLAMA_URL = process.env.OLLAMA_URL || '';
+const _isLemonade = /\/api\/?$/.test(OLLAMA_URL);
+const EFFECTIVE_MODEL = (_isLemonade && GGUF_FILE) ? `extra.${GGUF_FILE}` : LLM_MODEL;
 const CONFIG_PATH = path.join(process.env.HOME || '/home/node', '.openclaw', 'openclaw.json');
 const HTML_PATH = '/app/dist/control-ui/index.html';
 const JS_PATH = '/app/dist/control-ui/auto-token.js';
@@ -58,7 +69,7 @@ try {
   }
 
   // Fix model references to match what llama-server actually serves
-  if (LLM_MODEL) {
+  if (EFFECTIVE_MODEL) {
     // Find the provider name (first key under models.providers)
     const providerName = config.models?.providers
       ? Object.keys(config.models.providers)[0]
@@ -82,12 +93,13 @@ try {
         }
       }
 
-      // Update model list — replace the first model's id
+      // Update model list — replace the first model's id and name
       if (Array.isArray(provider.models) && provider.models.length > 0) {
         const oldId = provider.models[0].id;
-        if (oldId !== LLM_MODEL) {
-          provider.models[0].id = LLM_MODEL;
-          console.log(`[inject-token] updated provider model: ${oldId} -> ${LLM_MODEL}`);
+        if (oldId !== EFFECTIVE_MODEL) {
+          provider.models[0].id = EFFECTIVE_MODEL;
+          provider.models[0].name = EFFECTIVE_MODEL;
+          console.log(`[inject-token] updated provider model: ${oldId} -> ${EFFECTIVE_MODEL}`);
         }
       }
     }
@@ -97,7 +109,7 @@ try {
       const d = config.agents.defaults;
       const fullOld = d.model?.primary || '';
       if (fullOld && providerName) {
-        const fullNew = `${providerName}/${LLM_MODEL}`;
+        const fullNew = `${providerName}/${EFFECTIVE_MODEL}`;
         if (fullOld !== fullNew) {
           d.model = { primary: fullNew };
           // Rebuild models map
@@ -213,7 +225,7 @@ try {
     }
     primary.gateway.controlUi.allowedOrigins = origins;
 
-    // Fix provider baseUrl to match the actual LLM endpoint (OLLAMA_URL env)
+    // Fix provider baseUrl and model IDs to match the actual LLM endpoint
     const ollamaUrl = process.env.OLLAMA_URL || '';
     if (ollamaUrl) {
       const provs = primary.models?.providers || primary.providers || {};
@@ -224,6 +236,32 @@ try {
           if (oldUrl !== prov.baseUrl) {
             console.log(`[inject-token] merged config: provider ${name} baseUrl: ${oldUrl} -> ${prov.baseUrl}`);
           }
+        }
+        // Patch model IDs to match what the backend actually serves
+        if (EFFECTIVE_MODEL && Array.isArray(prov.models) && prov.models.length > 0) {
+          const oldId = prov.models[0].id;
+          if (oldId !== EFFECTIVE_MODEL) {
+            prov.models[0].id = EFFECTIVE_MODEL;
+            prov.models[0].name = EFFECTIVE_MODEL;
+            console.log(`[inject-token] merged config: provider ${name} model: ${oldId} -> ${EFFECTIVE_MODEL}`);
+          }
+        }
+      }
+    }
+
+    // Patch agent model references in merged config
+    if (EFFECTIVE_MODEL && primary.agents?.defaults) {
+      const provs = primary.models?.providers || {};
+      const providerName = Object.keys(provs)[0];
+      if (providerName) {
+        const d = primary.agents.defaults;
+        const fullNew = `${providerName}/${EFFECTIVE_MODEL}`;
+        const fullOld = d.model?.primary || '';
+        if (fullOld && fullOld !== fullNew) {
+          d.model = { primary: fullNew };
+          d.models = { [fullNew]: {} };
+          if (d.subagents) d.subagents.model = fullNew;
+          console.log(`[inject-token] merged config: agent model: ${fullOld} -> ${fullNew}`);
         }
       }
     }

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -11,6 +11,7 @@ services:
       - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_TOKEN:?Set OPENCLAW_TOKEN in .env}
       - LLM_MODEL=${LLM_MODEL:-qwen3:30b-a3b}
       - BOOTSTRAP_MODEL=${BOOTSTRAP_MODEL:-qwen3:8b-q4_K_M}
+      - GGUF_FILE=${GGUF_FILE:-}
       - OLLAMA_URL=${LLM_API_URL:-http://llama-server:8080}
       - OPENCLAW_LLM_URL=${OPENCLAW_LLM_URL:-}
       - OPENCLAW_HTTP_API=${OPENCLAW_HTTP_API:-}

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -154,7 +154,7 @@ OPENCODE_EOF
         else
             # Reinstall: update API key and URL in existing config (key may have changed)
             _sed_i "s|\"apiKey\":.*|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
-            _sed_i "s|\"baseURL\":.*|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
+            _sed_i "s|\"baseURL\":.*|\"baseURL\": \"${_opencode_url}\",|" "$OPENCODE_CONFIG_DIR/opencode.json"
             ai_ok "OpenCode config updated (API key and URL refreshed)"
         fi
         # OpenCode reads config.json, not opencode.json — always sync

--- a/dream-server/opencode/opencode-web.service
+++ b/dream-server/opencode/opencode-web.service
@@ -13,6 +13,7 @@ RestartSec=5
 # Environment
 Environment=HOME=__HOME__
 Environment=PATH=__HOME__/.opencode/bin:/usr/local/bin:/usr/bin:/bin
+EnvironmentFile=-__HOME__/dream-server/.env
 
 # Hardening
 NoNewPrivileges=true


### PR DESCRIPTION
## Summary

- **OpenClaw 404 on AMD**: `inject-token.js` Part 3 patched `baseUrl` to point directly to Lemonade but never patched model IDs. Lemonade exposes models as `extra.<GGUF_FILE>` — not the human-readable `LLM_MODEL` name — so every agent request returned `HTTP 404: Model 'qwen3-coder-next' was not found`. Now computes `EFFECTIVE_MODEL` from `GGUF_FILE` when `OLLAMA_URL` ends with `/api` (Lemonade detection), and patches model IDs in both Part 1 and Part 3 of the merged config.
- **OpenCode crash loop**: The installer's reinstall sed path (`07-devtools.sh:157`) used `s|"baseURL":.*|...|` which ate the trailing comma, producing invalid JSON. OpenCode's JSONC parser rejected it (`CommaExpected at line 11`), causing 3300+ restart cycles. Fixed the sed to preserve the comma.
- **OpenCode unsecured**: The systemd unit template lacked `EnvironmentFile` for `.env`, so `OPENCODE_SERVER_PASSWORD` was never set. Added `EnvironmentFile=-__HOME__/dream-server/.env`.
- **GGUF_FILE passthrough**: Added `GGUF_FILE` env var to OpenClaw's `compose.yaml` so the container can compute the correct Lemonade model ID.

### Cross-platform safety

| Path | NVIDIA/Intel/Apple/CPU | AMD/Lemonade |
|------|----------------------|--------------|
| `EFFECTIVE_MODEL` | Falls back to `LLM_MODEL` (OLLAMA_URL doesn't end with `/api`) | Uses `extra.{GGUF_FILE}` |
| `GGUF_FILE` env var | Empty string, ignored | Set from `.env`, used for model ID |
| sed comma fix | Adds trailing comma on reinstall (already present in fresh template) | Same |
| `EnvironmentFile` | `-` prefix = optional, no-op if `.env` missing | Loads `OPENCODE_SERVER_PASSWORD` etc. |

## Test plan

- [x] OpenClaw merged config has `extra.qwen3-coder-next-Q4_K_M.gguf` as model ID on AMD
- [x] OpenClaw gateway log shows `agent model: local-llama/extra.qwen3-coder-next-Q4_K_M.gguf`
- [x] OpenCode starts without JSON parse errors (systemd status: `active (running)`)
- [x] OpenCode web UI responds on port 3003 (HTTP 200)
- [x] `OPENCODE_SERVER_PASSWORD` warning gone after EnvironmentFile fix
- [x] `node --check inject-token.js` passes
- [x] `bash -n 07-devtools.sh` passes
- [ ] Verify NVIDIA install: EFFECTIVE_MODEL = LLM_MODEL (no `extra.` prefix)
- [ ] Verify OpenClaw can complete an agent request on AMD

🤖 Generated with [Claude Code](https://claude.com/claude-code)