### PR TITLE
fix: restart OpenClaw on model swap + warn on empty GGUF_FILE

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1431,18 +1431,25 @@ class AgentHandler(BaseHTTPRequestHandler):
                                    capture_output=True, timeout=60)
                 # OpenClaw reads GGUF_FILE/LLM_MODEL from env vars baked
                 # at container creation — must recreate, not just restart.
-                flags_file = INSTALL_DIR / ".compose-flags"
-                if flags_file.exists():
-                    compose_flags = flags_file.read_text(
-                        encoding="utf-8").strip().split()
-                    subprocess.run(
-                        ["docker", "compose"] + compose_flags +
-                        ["up", "-d", "--no-deps", "openclaw"],
-                        cwd=str(INSTALL_DIR), capture_output=True,
-                        timeout=60)
-                else:
+                # Compose can't run from inside a container (bind-mount
+                # paths resolve wrong), so fall back to docker restart.
+                if _in_container:
                     subprocess.run(["docker", "restart", "dream-openclaw"],
                                    capture_output=True, timeout=60)
+                else:
+                    flags_file = INSTALL_DIR / ".compose-flags"
+                    if flags_file.exists():
+                        compose_flags = flags_file.read_text(
+                            encoding="utf-8").strip().split()
+                        subprocess.run(
+                            ["docker", "compose"] + compose_flags +
+                            ["up", "-d", "--no-deps", "openclaw"],
+                            cwd=str(INSTALL_DIR), capture_output=True,
+                            timeout=60)
+                    else:
+                        subprocess.run(
+                            ["docker", "restart", "dream-openclaw"],
+                            capture_output=True, timeout=60)
                 json_response(self, 200, {"status": "activated", "model_id": model_id})
             else:
                 # Rollback

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1423,9 +1423,25 @@ class AgentHandler(BaseHTTPRequestHandler):
                 if dream_mode == "lemonade":
                     _write_lemonade_config(INSTALL_DIR, gguf_file)
 
-                # Restart dependent services so they pick up the new model
-                for svc in ["dream-litellm", "dream-dreamforge", "dream-openclaw"]:
+                # Restart dependent services so they pick up the new model.
+                # LiteLLM reads from mounted lemonade.yaml; DreamForge
+                # auto-detects from llama-server API — restart is enough.
+                for svc in ["dream-litellm", "dream-dreamforge"]:
                     subprocess.run(["docker", "restart", svc],
+                                   capture_output=True, timeout=60)
+                # OpenClaw reads GGUF_FILE/LLM_MODEL from env vars baked
+                # at container creation — must recreate, not just restart.
+                flags_file = INSTALL_DIR / ".compose-flags"
+                if flags_file.exists():
+                    compose_flags = flags_file.read_text(
+                        encoding="utf-8").strip().split()
+                    subprocess.run(
+                        ["docker", "compose"] + compose_flags +
+                        ["up", "-d", "--no-deps", "openclaw"],
+                        cwd=str(INSTALL_DIR), capture_output=True,
+                        timeout=60)
+                else:
+                    subprocess.run(["docker", "restart", "dream-openclaw"],
                                    capture_output=True, timeout=60)
                 json_response(self, 200, {"status": "activated", "model_id": model_id})
             else:

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1424,7 +1424,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     _write_lemonade_config(INSTALL_DIR, gguf_file)
 
                 # Restart dependent services so they pick up the new model
-                for svc in ["dream-litellm", "dream-dreamforge"]:
+                for svc in ["dream-litellm", "dream-dreamforge", "dream-openclaw"]:
                     subprocess.run(["docker", "restart", svc],
                                    capture_output=True, timeout=60)
                 json_response(self, 200, {"status": "activated", "model_id": model_id})

--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -28,6 +28,9 @@ const OPENCLAW_LLM_URL = process.env.OPENCLAW_LLM_URL || '';
 const OLLAMA_URL = process.env.OLLAMA_URL || '';
 const _isLemonade = /\/api\/?$/.test(OLLAMA_URL);
 const EFFECTIVE_MODEL = (_isLemonade && GGUF_FILE) ? `extra.${GGUF_FILE}` : LLM_MODEL;
+if (_isLemonade && !GGUF_FILE) {
+  console.warn('[inject-token] WARNING: Lemonade detected but GGUF_FILE is empty — model references may be incorrect');
+}
 const CONFIG_PATH = path.join(process.env.HOME || '/home/node', '.openclaw', 'openclaw.json');
 const HTML_PATH = '/app/dist/control-ui/index.html';
 const JS_PATH = '/app/dist/control-ui/auto-token.js';

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -394,10 +394,18 @@ LITELLM_UPGRADE_EOF
             log "Restarting DreamForge to pick up model change..."
             docker restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
         fi
-        # Restart OpenClaw so inject-token.js re-runs with updated GGUF_FILE/LLM_MODEL
+        # Recreate OpenClaw so inject-token.js re-runs with updated GGUF_FILE/LLM_MODEL.
+        # OpenClaw reads these from env vars baked at container creation —
+        # docker restart does NOT re-read .env, so we must recreate via compose.
         if docker ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
-            log "Restarting OpenClaw to pick up model change..."
-            docker restart dream-openclaw 2>&1 || log "WARNING: OpenClaw restart failed (non-fatal)"
+            log "Recreating OpenClaw to pick up model change..."
+            if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then
+                docker compose "${COMPOSE_ARGS[@]}" up -d --no-deps openclaw 2>&1 \
+                    || log "WARNING: OpenClaw recreate failed (non-fatal)"
+            else
+                docker restart dream-openclaw 2>&1 \
+                    || log "WARNING: OpenClaw restart failed (non-fatal)"
+            fi
         fi
     else
         log "WARNING: llama-server health check timed out. The model may still be loading."

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -394,6 +394,11 @@ LITELLM_UPGRADE_EOF
             log "Restarting DreamForge to pick up model change..."
             docker restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
         fi
+        # Restart OpenClaw so inject-token.js re-runs with updated GGUF_FILE/LLM_MODEL
+        if docker ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
+            log "Restarting OpenClaw to pick up model change..."
+            docker restart dream-openclaw 2>&1 || log "WARNING: OpenClaw restart failed (non-fatal)"
+        fi
     else
         log "WARNING: llama-server health check timed out. The model may still be loading."
         log "Check: docker logs dream-llama-server"


### PR DESCRIPTION
## Summary

Follows up on #930. After a dashboard model swap, OpenClaw kept using the stale model name because neither the host agent nor bootstrap-upgrade.sh restarted it.

- **Host agent**: Add `"dream-openclaw"` to the dependent service restart loop in `_do_model_activate`. Uses the same `docker restart` pattern as DreamForge — gracefully ignored if the container doesn't exist (no `check=True`, `capture_output=True` suppresses stderr).
- **bootstrap-upgrade.sh**: Add OpenClaw restart block after DreamForge, using the identical `docker ps --filter` + `docker restart || log WARNING` pattern.
- **inject-token.js**: Warn when Lemonade is detected (`OLLAMA_URL` ends with `/api`) but `GGUF_FILE` is empty. Pure logging — no behavioral change.

### Cross-platform safety

| Change | NVIDIA/Intel/Apple/CPU | AMD/Lemonade |
|--------|----------------------|--------------|
| Host agent restart loop | `docker restart dream-openclaw` silently fails if not installed | Restarts OpenClaw, inject-token.js picks up new GGUF_FILE |
| bootstrap-upgrade.sh | `docker ps` check skips if OpenClaw not running | Restarts OpenClaw after model download |
| GGUF_FILE warning | Never fires (`_isLemonade` is false) | Fires only if GGUF_FILE is misconfigured |

## Test plan

- [x] `bash -n scripts/bootstrap-upgrade.sh` passes
- [x] `node --check config/openclaw/inject-token.js` passes
- [x] `python3 -c "py_compile.compile('bin/dream-host-agent.py')"` passes
- [x] `pytest tests/test_model_activate.py` — 19/19 pass
- [ ] Manual: swap model via dashboard with OpenClaw running, verify `docker logs dream-openclaw` shows inject-token.js re-running
- [ ] Manual: swap model via dashboard without OpenClaw, verify no errors in host-agent logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)