### PR TITLE
fix(dream-cli): template apply resilience + restart cache invalidation

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -760,12 +760,12 @@ cmd_restart() {
 
     if [[ -z "$service" ]]; then
         log "Restarting all services..."
-        docker compose "${flags[@]}" restart
+        docker compose "${flags[@]}" up -d
         success "All services restarted"
     else
         service=$(resolve_service "$service")
         log "Restarting $service..."
-        docker compose "${flags[@]}" restart "$service"
+        docker compose "${flags[@]}" up -d "$service"
         success "$service restarted"
     fi
 }
@@ -3231,7 +3231,7 @@ PYEOF
         fi
 
         log "  Enabling $svc..."
-        cmd_enable "$svc" || warn "  Failed to enable $svc (continuing)"
+        ( cmd_enable "$svc" ) || warn "  Failed to enable $svc (continuing)"
     done
     success "Template applied: $template_id"
 }

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -1161,6 +1161,9 @@ def enable_extension(
             _scan_compose_content(enabled_compose, skip_name_collision=is_builtin)
         # Dependencies were satisfied at install time; compose content is re-scanned above
         _write_initial_progress(service_id)
+        # Invalidate .compose-flags cache so dream-cli picks up this extension
+        # before the host agent starts the container.
+        _call_agent_invalidate_compose_cache()
         agent_ok = _call_agent("start", service_id)
         logger.info("Started stopped extension: %s", service_id)
         return {

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -852,6 +852,31 @@ class TestComposeCacheInvalidation:
         assert resp.status_code == 200
         assert len(calls) == 1
 
+    def test_enable_stopped_invalidates_cache(self, test_client, monkeypatch, tmp_path):
+        """Stopped-start branch: compose.yaml already exists (library extension
+        enabled flow). Cache must be invalidated BEFORE the host agent start
+        call so it sees the new compose set."""
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+
+        order: list[str] = []
+        monkeypatch.setattr(
+            "routers.extensions._call_agent_invalidate_compose_cache",
+            lambda: order.append("invalidate"),
+        )
+        monkeypatch.setattr(
+            "routers.extensions._call_agent",
+            lambda action, svc: order.append(f"agent:{action}:{svc}") or True,
+        )
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/enable",
+            headers=test_client.auth_headers,
+        )
+        assert resp.status_code == 200
+        assert order.count("invalidate") == 1
+        assert order.index("invalidate") < order.index("agent:start:my-ext")
+
     def test_disable_invalidates_cache(self, test_client, monkeypatch, tmp_path):
         user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
         _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)

--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -112,14 +112,24 @@ get_compose_flags() {
     local flags_file="${INSTALL_DIR}/.compose-flags"
     if [[ -f "$flags_file" ]]; then
         cat "$flags_file"
-    else
-        # Fallback: detect from available files
-        local flags="-f docker-compose.base.yml"
-        if [[ -f "${INSTALL_DIR}/installers/macos/docker-compose.macos.yml" ]]; then
-            flags="$flags -f installers/macos/docker-compose.macos.yml"
-        fi
-        echo "$flags"
+        return
     fi
+    # Fallback: dynamic resolution via resolve-compose-stack.sh so user-installed
+    # extensions in data/user-extensions/ are discovered when the .compose-flags
+    # cache is missing or stale. Mirrors dream-cli's get_compose_flags fallback.
+    if [[ -x "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" ]]; then
+        "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" \
+            --script-dir "$INSTALL_DIR" \
+            --tier "${TIER:-1}" \
+            --gpu-backend "${GPU_BACKEND:-apple}"
+        return
+    fi
+    # Last resort: resolver script missing — emit base + macos overlay
+    local flags="-f docker-compose.base.yml"
+    if [[ -f "${INSTALL_DIR}/installers/macos/docker-compose.macos.yml" ]]; then
+        flags="$flags -f installers/macos/docker-compose.macos.yml"
+    fi
+    echo "$flags"
 }
 
 read_dream_env() {
@@ -443,7 +453,7 @@ cmd_restart() {
     if [[ -n "$service" ]]; then
         ai "Restarting ${service}..."
         # shellcheck disable=SC2086
-        docker compose $flags restart "$service"
+        docker compose $flags up -d "$service"
         ai_ok "${service} restarted"
     else
         # Restart native llama-server
@@ -454,7 +464,7 @@ cmd_restart() {
 
         ai "Restarting all services..."
         # shellcheck disable=SC2086
-        docker compose $flags restart
+        docker compose $flags up -d
         ai_ok "All services restarted"
     fi
 }


### PR DESCRIPTION
> **Merge order:** Merge after #909, #926, and #907 — all modify `extensions.py` and/or `dream-cli`.

Combined PR replacing #903 and #904. See commit message.

Replaces: #903, #904