### PR TITLE
test: add OVERLAY_MAP coherence + plist log path regression guards

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -29,6 +29,10 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
+	@echo ""
+	@echo "=== Overlay/plist contracts ==="
+	@bash tests/contracts/test-overlay-map-coherence.sh
+	@bash tests/contracts/test-plist-log-paths.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/dream-server/tests/contracts/test-overlay-map-coherence.sh
+++ b/dream-server/tests/contracts/test-overlay-map-coherence.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Contract test: OVERLAY_MAP ↔ hardware-classes.json coherence (issue #342)
+#
+# Two independent sources define compose overlay paths:
+#   - scripts/classify-hardware.sh: OVERLAY_MAP dict + apple/macos special case
+#   - config/hardware-classes.json: per-class recommended.compose_overlays
+#
+# This test asserts they agree for every hardware class.
+#
+# Run: bash tests/contracts/test-overlay-map-coherence.sh
+# ============================================================================
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+command -v python3 >/dev/null 2>&1 || { echo "[FAIL] python3 is required"; exit 1; }
+
+echo "[contract] OVERLAY_MAP ↔ hardware-classes.json coherence"
+
+python3 <<'PY'
+import ast, json, re, sys
+
+# --- Read OVERLAY_MAP from the embedded Python in classify-hardware.sh ---
+with open("scripts/classify-hardware.sh", "r") as f:
+    content = f.read()
+
+m = re.search(r'OVERLAY_MAP\s*=\s*(\{[^}]+\})', content)
+if not m:
+    print("[FAIL] OVERLAY_MAP not found in scripts/classify-hardware.sh")
+    sys.exit(1)
+
+overlay_map = ast.literal_eval(m.group(1))
+
+# Verify all four backends are present
+for backend in ("amd", "nvidia", "apple", "cpu"):
+    if backend not in overlay_map:
+        print(f"[FAIL] OVERLAY_MAP missing backend: {backend}")
+        sys.exit(1)
+
+# --- Extract the apple+macos special case ---
+m2 = re.search(
+    r'if\s+backend\s*==\s*"apple"\s+and\s+platform_id\s*==\s*"macos":\s*\n'
+    r'\s*overlays\s*=\s*(\[[^\]]+\])',
+    content,
+)
+if not m2:
+    print("[FAIL] apple+macos overlay override not found in scripts/classify-hardware.sh")
+    sys.exit(1)
+
+macos_overlays = ast.literal_eval(m2.group(1))
+
+# --- Read hardware-classes.json ---
+with open("config/hardware-classes.json", "r") as f:
+    hw = json.load(f)
+
+# --- Check every class ---
+fail = 0
+for cls in hw["classes"]:
+    cid = cls["id"]
+    backend = cls["recommended"]["backend"]
+    actual = cls["recommended"]["compose_overlays"]
+    platforms = cls.get("match", {}).get("platform_id", [])
+
+    # Apple classes on macos use the special macos overlay
+    if backend == "apple" and "macos" in platforms:
+        expected = macos_overlays
+        tag = f"{backend}+macos"
+    else:
+        if backend not in overlay_map:
+            print(f"[FAIL] {cid}: backend '{backend}' not in OVERLAY_MAP")
+            fail += 1
+            continue
+        expected = overlay_map[backend]
+        tag = backend
+
+    if actual != expected:
+        print(f"[FAIL] {cid} ({tag}): expected {expected}, got {actual}")
+        fail += 1
+    else:
+        print(f"  [PASS] {cid} ({tag})")
+
+if fail > 0:
+    sys.exit(1)
+PY
+
+echo "[PASS] OVERLAY_MAP ↔ hardware-classes.json coherence"

--- a/dream-server/tests/contracts/test-plist-log-paths.sh
+++ b/dream-server/tests/contracts/test-plist-log-paths.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================================
+# Contract test: launchd plist log paths (issue #341)
+#
+# PR #899 moved launchd plist log paths from $INSTALL_DIR/data/ to
+# $HOME/Library/Logs/DreamServer/ to avoid xpcproxy sandbox denials.
+# This test validates the two plist heredocs in install-macos.sh.
+#
+# Run: bash tests/contracts/test-plist-log-paths.sh
+# ============================================================================
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+INSTALL_MACOS="installers/macos/install-macos.sh"
+test -f "$INSTALL_MACOS" || { echo "[FAIL] missing $INSTALL_MACOS"; exit 1; }
+
+PASS=0
+FAIL=0
+
+# Extract the plist value (next <string> line) after a given <key>
+extract_plist_value() {
+    local plist="$1" key="$2"
+    echo "$plist" | awk "/<key>${key}<\\/key>/ { getline; print; exit }"
+}
+
+assert_contains() {
+    local label="$1" value="$2" pattern="$3"
+    if echo "$value" | grep -qF "$pattern"; then
+        echo "  [PASS] $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  [FAIL] $label (expected to contain '${pattern}')"
+        echo "         got: $value"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_not_contains() {
+    local label="$1" value="$2" pattern="$3"
+    if echo "$value" | grep -qF "$pattern"; then
+        echo "  [FAIL] $label (should NOT contain '${pattern}')"
+        echo "         got: $value"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  [PASS] $label"
+        PASS=$((PASS + 1))
+    fi
+}
+
+echo "[contract] launchd plist log paths"
+
+# --- Extract plist heredocs ---
+opencode_plist="$(awk '/<<PLIST_EOF$/,/^PLIST_EOF$/' "$INSTALL_MACOS")"
+agent_plist="$(awk '/<<AGENT_PLIST_EOF$/,/^AGENT_PLIST_EOF$/' "$INSTALL_MACOS")"
+
+[[ -n "$opencode_plist" ]] || { echo "[FAIL] could not extract opencode-web plist heredoc"; exit 1; }
+[[ -n "$agent_plist" ]]    || { echo "[FAIL] could not extract dream-host-agent plist heredoc"; exit 1; }
+
+# --- opencode-web plist ---
+echo "  opencode-web plist:"
+stdout_val="$(extract_plist_value "$opencode_plist" "StandardOutPath")"
+stderr_val="$(extract_plist_value "$opencode_plist" "StandardErrorPath")"
+workdir_val="$(extract_plist_value "$opencode_plist" "WorkingDirectory")"
+
+assert_contains     "StandardOutPath uses HOME/Library/Logs/DreamServer"   "$stdout_val"  '${HOME}/Library/Logs/DreamServer/'
+assert_contains     "StandardErrorPath uses HOME/Library/Logs/DreamServer" "$stderr_val"  '${HOME}/Library/Logs/DreamServer/'
+assert_not_contains "StandardOutPath does not use INSTALL_DIR"             "$stdout_val"  'INSTALL_DIR'
+assert_not_contains "StandardErrorPath does not use INSTALL_DIR"           "$stderr_val"  'INSTALL_DIR'
+
+# --- dream-host-agent plist ---
+echo "  dream-host-agent plist:"
+stdout_val="$(extract_plist_value "$agent_plist" "StandardOutPath")"
+stderr_val="$(extract_plist_value "$agent_plist" "StandardErrorPath")"
+workdir_val="$(extract_plist_value "$agent_plist" "WorkingDirectory")"
+
+assert_contains     "StandardOutPath uses HOME/Library/Logs/DreamServer"   "$stdout_val"  '${HOME}/Library/Logs/DreamServer/'
+assert_contains     "StandardErrorPath uses HOME/Library/Logs/DreamServer" "$stderr_val"  '${HOME}/Library/Logs/DreamServer/'
+assert_not_contains "StandardOutPath does not use INSTALL_DIR"             "$stdout_val"  'INSTALL_DIR'
+assert_not_contains "StandardErrorPath does not use INSTALL_DIR"           "$stderr_val"  'INSTALL_DIR'
+assert_contains     "WorkingDirectory uses INSTALL_DIR"                    "$workdir_val" '${INSTALL_DIR}'
+
+echo ""
+echo "==============================="
+echo "Results: $PASS passed, $FAIL failed"
+echo "==============================="
+
+[[ $FAIL -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## What
Two new contract tests to prevent silent drift in compose overlay mapping and macOS launchd plist configuration.

## Why
- **OVERLAY_MAP** (`scripts/classify-hardware.sh`) and `hardware-classes.json` `compose_overlays` are independent sources of truth. Nothing enforced alignment — a future edit could silently drift one without the other.
- **Plist log paths** were recently fixed (PR #899) to use `$HOME/Library/Logs/DreamServer/` instead of `$INSTALL_DIR/data/`. No test validates the generated plists — a regression would only surface at runtime on non-`$HOME` macOS installs.

## How
- `test-overlay-map-coherence.sh`: Extracts OVERLAY_MAP from classify-hardware.sh, reads compose_overlays from hardware-classes.json via jq/Python, asserts string equality for all 10 hardware classes including the apple+macos special case.
- `test-plist-log-paths.sh`: Extracts both plist heredocs from install-macos.sh, asserts StandardOutPath/StandardErrorPath use `$HOME/Library/Logs/DreamServer/` and NOT `$INSTALL_DIR`.
- Both registered in Makefile `test` target.

## Testing
- `test-overlay-map-coherence.sh`: 10/10 PASS (all hardware classes)
- `test-plist-log-paths.sh`: 9/9 PASS (all assertions)
- ShellCheck clean (SC2016 info-level on intentional single-quoted patterns)

## Platform Impact
- **macOS**: Tests run on macOS CI (pure Bash + Python stdlib)
- **Linux**: Tests run on Linux CI (same toolchain)
- **Windows/WSL2**: N/A (Bash tests, not applicable to PowerShell CI)

🤖 Generated with [Claude Code](https://claude.ai/code)