### PR TITLE
fix(langfuse): pin minio/mc to existing release tag

### DIFF
--- a/dream-server/extensions/services/langfuse/compose.yaml.disabled
+++ b/dream-server/extensions/services/langfuse/compose.yaml.disabled
@@ -273,7 +273,7 @@ services:
         max-file: "3"
 
   langfuse-minio-init:
-    image: minio/mc:RELEASE.2025-09-07T16-13-09Z
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     container_name: dream-langfuse-minio-init
     restart: "no"
     security_opt:


### PR DESCRIPTION
## Summary
- Pin `minio/mc` init container from non-existent `RELEASE.2025-09-07T16-13-09Z` to `RELEASE.2025-08-13T08-35-41Z` (latest published minio/mc tag)
- The September 2025 release was only published for `minio/minio` (server), not `minio/mc` (client), causing `docker compose up` to fail for the entire stack on fresh installs with `--all` or `--langfuse`

## Test plan
- [ ] Verify `docker pull minio/mc:RELEASE.2025-08-13T08-35-41Z` succeeds
- [ ] Fresh install with `--langfuse` completes compose-up without image pull errors
- [ ] `langfuse-minio-init` container exits 0 after bucket creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)