### PR TITLE
fix(macos-installer): unload stale LaunchAgents before compose-up

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -742,6 +742,14 @@ else
         fi
     done
 
+    # ── Unload stale LaunchAgents before compose (crash-safe) ──
+    # If a previous install registered these agents and this run fails at
+    # compose-up, the old agents would keep running with stale paths
+    # (DREAM_HOME pointing at the deleted install dir).  Clearing them
+    # here guarantees a clean slate regardless of what happens below.
+    launchctl bootout "gui/$(id -u)/${DREAM_AGENT_PLIST_LABEL}" 2>/dev/null || true
+    launchctl bootout "gui/$(id -u)/${OPENCODE_PLIST_LABEL}" 2>/dev/null || true
+
     # ── Start Docker services ──
     chapter "STARTING SERVICES"
     ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d"


### PR DESCRIPTION
> **Merge order:** Merge after #899, before #920 — all three modify `install-macos.sh`.

## Summary
- Add `launchctl bootout` for both host-agent and opencode-web labels before `docker compose up`
- If compose fails (e.g. bad image tag), the installer exits before reaching the LaunchAgent setup, leaving old plists loaded with stale `DREAM_HOME`/`WorkingDirectory` paths from a previous install
- This causes 403 auth errors on all host agent API calls because the agent reads the wrong `.env`

## Test plan
- [ ] Reinstall to a different path with a compose failure induced — verify old agents are unloaded
- [ ] Fresh install (no previous agents) — verify bootout is a harmless no-op
- [ ] Normal reinstall (compose succeeds) — verify agents are properly re-registered after compose-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)