### PR TITLE
fix(dashboard-api): send Host header in health check requests

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -227,7 +227,10 @@ async def check_service_health(service_id: str, config: dict) -> ServiceStatus:
     try:
         session = await _get_aio_session()
         start = asyncio.get_event_loop().time()
-        async with session.get(url) as resp:
+        # Send Host header so reverse-proxy services (e.g. Caddy in Baserow)
+        # route the request correctly instead of returning 404.
+        headers = {"Host": "localhost"}
+        async with session.get(url, headers=headers) as resp:
             response_time = (asyncio.get_event_loop().time() - start) * 1000
             status = "healthy" if resp.status < 400 else "unhealthy"
     except asyncio.TimeoutError:
@@ -261,7 +264,9 @@ async def _check_host_service_health(service_id: str, config: dict) -> ServiceSt
     try:
         session = await _get_aio_session()
         start = asyncio.get_event_loop().time()
-        async with session.get(url) as resp:
+        # Host header for reverse-proxy routing (see check_service_health)
+        headers = {"Host": "localhost"}
+        async with session.get(url, headers=headers) as resp:
             response_time = (asyncio.get_event_loop().time() - start) * 1000
             status = "healthy" if resp.status < 400 else "unhealthy"
     except asyncio.TimeoutError:

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -248,6 +248,16 @@ class TestCheckServiceHealth:
         assert result.port == 8080
 
     @pytest.mark.asyncio
+    async def test_sends_host_localhost_header(self, mock_aiohttp_session, monkeypatch):
+        session = mock_aiohttp_session(status=200)
+        monkeypatch.setattr("helpers._get_aio_session", AsyncMock(return_value=session))
+
+        await check_service_health("test-svc", self._CONFIG)
+        session.get.assert_called_once()
+        _, kwargs = session.get.call_args
+        assert kwargs.get("headers", {}).get("Host") == "localhost"
+
+    @pytest.mark.asyncio
     async def test_unhealthy_on_500(self, mock_aiohttp_session, monkeypatch):
         session = mock_aiohttp_session(status=500)
         monkeypatch.setattr("helpers._get_aio_session", AsyncMock(return_value=session))
@@ -631,6 +641,15 @@ class TestCheckHostServiceHealth:
         monkeypatch.setattr("helpers._get_aio_session", AsyncMock(return_value=session))
         result = await _check_host_service_health("test-host-svc", self._CONFIG)
         assert result.status == "healthy"
+
+    @pytest.mark.asyncio
+    async def test_sends_host_localhost_header(self, mock_aiohttp_session, monkeypatch):
+        session = mock_aiohttp_session(status=200)
+        monkeypatch.setattr("helpers._get_aio_session", AsyncMock(return_value=session))
+        await _check_host_service_health("test-host-svc", self._CONFIG)
+        session.get.assert_called_once()
+        _, kwargs = session.get.call_args
+        assert kwargs.get("headers", {}).get("Host") == "localhost"
 
     @pytest.mark.asyncio
     async def test_down_on_timeout(self, monkeypatch):


### PR DESCRIPTION
> **Merge order:** Merge after #924 — both modify `helpers.py` and `test_helpers.py`.

## Summary
- Add `Host: localhost` header to both `check_service_health()` and `_check_host_service_health()` in helpers.py
- Reverse-proxy services like Baserow (Caddy) return 404 without a Host header, causing false "STOPPED" status in the dashboard despite the container being healthy
- Docker's own compose healthcheck already sends this header; the dashboard-api poller did not

## Test plan
- [ ] Install Baserow extension and verify it shows as "healthy" in the dashboard
- [ ] Verify all existing services still show correct health status
- [ ] Run `pytest tests/test_helpers.py` — 66 tests pass (2 new regression tests for Host header)

🤖 Generated with [Claude Code](https://claude.com/claude-code)