### PR TITLE
fix(dashboard): add loading indicator on model download click

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Models.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Models.jsx
@@ -1,21 +1,39 @@
+import { useState, useEffect } from 'react'
 import { Box, Download, Trash2, Check, AlertCircle, Loader2, Play, RefreshCw, HardDrive } from 'lucide-react'
 import { useModels } from '../hooks/useModels'
 import { useDownloadProgress } from '../hooks/useDownloadProgress'
 
 export default function Models() {
   const downloadProgress = useDownloadProgress()
-  const { 
-    models, 
-    gpu, 
-    currentModel, 
-    loading, 
-    error, 
+  const {
+    models,
+    gpu,
+    currentModel,
+    loading,
+    error,
     actionLoading,
     downloadModel,
     loadModel,
     deleteModel,
     refresh
   } = useModels()
+
+  // Optimistic state: tracks which model had Download clicked before
+  // the progress poller picks up real data (up to 10s gap otherwise).
+  const [downloadStarting, setDownloadStarting] = useState(null)
+
+  useEffect(() => {
+    if (downloadProgress.isDownloading || error) {
+      setDownloadStarting(null)
+    }
+  }, [downloadProgress.isDownloading, error])
+
+  const handleDownload = async (modelId) => {
+    setDownloadStarting(modelId)
+    await downloadModel(modelId)
+    // Kick the progress poller immediately instead of waiting up to 10s
+    downloadProgress.refresh()
+  }
 
   if (loading) {
     return (
@@ -104,8 +122,9 @@ export default function Models() {
             model={model}
             isLoading={actionLoading === model.id}
             loadBusy={!!actionLoading}
-            downloadBusy={downloadProgress.isDownloading}
-            onDownload={() => downloadModel(model.id)}
+            downloadBusy={downloadProgress.isDownloading || !!downloadStarting}
+            downloadStarting={downloadStarting === model.id}
+            onDownload={() => handleDownload(model.id)}
             onLoad={() => loadModel(model.id)}
             onDelete={() => deleteModel(model.id)}
           />
@@ -121,7 +140,7 @@ export default function Models() {
   )
 }
 
-function ModelCard({ model, isLoading, loadBusy, downloadBusy, onDownload, onLoad, onDelete }) {
+function ModelCard({ model, isLoading, loadBusy, downloadBusy, downloadStarting, onDownload, onLoad, onDelete }) {
   const isLoaded = model.status === 'loaded'
   const isDownloaded = model.status === 'downloaded'
   const isAvailable = model.status === 'available'
@@ -233,6 +252,14 @@ function ModelCard({ model, isLoading, loadBusy, downloadBusy, onDownload, onLoa
                 <Trash2 size={16} />
               </button>
             </>
+          ) : downloadStarting ? (
+            <button
+              disabled
+              className="px-4 py-2 bg-theme-accent/20 text-theme-accent rounded-lg text-sm font-medium flex items-center gap-2 cursor-not-allowed"
+            >
+              <Loader2 size={16} className="animate-spin" />
+              Starting...
+            </button>
           ) : downloadBusy ? (
             <button
               disabled


### PR DESCRIPTION
## Summary
- Add optimistic "Starting..." spinner on the Download button immediately when clicked
- Bridges the gap (up to 10s) between the API call completing and the download progress poller detecting the active download
- Trigger immediate progress poll after download API succeeds instead of waiting for next 10s cycle
- Other models show "Waiting" during the starting phase

## Test plan
- [ ] Click Download on an available model — verify "Starting..." appears immediately
- [ ] Wait for progress bar to appear — verify "Starting..." is replaced cleanly
- [ ] Click Download with API error (e.g. agent down) — verify "Starting..." clears and error shows
- [ ] Verify other model cards show "Waiting" during the starting phase
- [ ] `npm run build` succeeds, `npm run lint` shows only pre-existing warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)