### PR TITLE
fix(detection): WSL2 GPU detection fallback via nvidia-smi

### DIFF
--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -100,6 +100,11 @@ detect_gpu() {
     for _v in /sys/class/drm/card*/device/vendor; do
         [[ "$(cat "$_v" 2>/dev/null)" == "0x10de" ]] && _nvidia_hw=true && break
     done
+    # WSL2: /sys/class/drm/ only contains a 'version' file — no card* entries exist.
+    # Fall back to nvidia-smi as the sole hardware witness on WSL2.
+    if ! $_nvidia_hw && grep -qiE "microsoft|wsl" /proc/sys/kernel/osrelease 2>/dev/null; then
+        command -v nvidia-smi &>/dev/null && _nvidia_hw=true
+    fi
     if $_nvidia_hw && command -v nvidia-smi &> /dev/null; then
         local raw
         if raw=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) && [[ -n "$raw" ]]; then


### PR DESCRIPTION
## Summary
- On WSL2, `/sys/class/drm/` contains only a `version` file (no `card*` entries), so the sysfs vendor-ID loop never sets `_nvidia_hw=true` even with a working NVIDIA GPU
- Added WSL2 fallback: checks `/proc/sys/kernel/osrelease` for `microsoft|wsl` and uses `nvidia-smi` availability as the sole hardware witness when sysfs fails

## Test plan
- [ ] Run installer on WSL2 with NVIDIA GPU — should detect GPU correctly
- [ ] Run installer on native Linux with NVIDIA — existing sysfs path still works
- [ ] Run installer on macOS — WSL fallback path not triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)