### PR TITLE
fix(bootstrap): replace docker start with docker rm in fallback path

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -359,8 +359,14 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
             $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" stop llama-server 2>&1 || true
             $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d llama-server 2>&1 || true
         else
+            # No compose flags — use docker rm to force a fresh container that
+            # re-reads GGUF_FILE from the env file. 'docker start' reuses the old
+            # baked environment and would crash-loop if the bootstrap model was
+            # already deleted in Phase 4b.
             $DOCKER_CMD stop dream-llama-server 2>&1 || true
-            $DOCKER_CMD start dream-llama-server 2>&1 || true
+            $DOCKER_CMD rm dream-llama-server 2>&1 || true
+            log "WARNING: .compose-flags not found — container removed. Run 'dream restart' to bring llama-server back up with the correct model."
+            write_status "failed"
         fi
     fi
 


### PR DESCRIPTION
> **Merge order:** Merge after #934 — both modify `bootstrap-upgrade.sh`.

## Summary
- The fallback path in Phase 5 of `bootstrap-upgrade.sh` called `docker start` which reuses the baked container environment (`GGUF_FILE=2B model`)
- If the bootstrap model was already deleted in Phase 4b, this puts the container into a crash loop
- Replaced with `docker rm` + status write so `dream restart` launches a fresh container with the correct model

## Test plan
- [ ] Run bootstrap upgrade on a system with no `.compose-flags` file — should rm the container and write "failed" status
- [ ] Verify `dream restart` afterward creates a fresh container with the upgraded model

🤖 Generated with [Claude Code](https://claude.com/claude-code)