### PR TITLE
fix: recreate OpenClaw after bootstrap model upgrade

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -394,6 +394,18 @@ LITELLM_UPGRADE_EOF
             log "Restarting DreamForge to pick up model change..."
             docker restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
         fi
+        # Recreate OpenClaw so inject-token.js picks up the new GGUF_FILE/LLM_MODEL
+        # from .env. A restart alone won't work — env vars are baked in at container
+        # creation time, and inject-token.js builds the Lemonade model name from them.
+        if docker ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
+            log "Recreating OpenClaw to pick up model change..."
+            if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then
+                docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
+                    log "WARNING: OpenClaw recreate failed (non-fatal)"
+            else
+                log "WARNING: No compose args — cannot recreate OpenClaw. Restart manually."
+            fi
+        fi
     else
         log "WARNING: llama-server health check timed out. The model may still be loading."
         log "Check: docker logs dream-llama-server"


### PR DESCRIPTION
## Summary
- `bootstrap-upgrade.sh` updates `.env` with the new model name after downloading the full model, then restarts LiteLLM and DreamForge — but never recreates OpenClaw
- OpenClaw's `inject-token.js` reads `GGUF_FILE` from env vars that are baked in at container creation time, so a restart still uses the stale bootstrap value (`extra.Qwen3.5-2B-Q4_K_M.gguf`), causing HTTP 404 on every request
- Adds `docker compose up -d --force-recreate openclaw` after the DreamForge restart so the container picks up the updated env vars

## Test plan
- [ ] Run bootstrap-upgrade with a model change and verify OpenClaw uses the new model name
- [ ] Verify `docker compose exec openclaw env | grep GGUF_FILE` matches `.env` after upgrade
- [ ] Confirm OpenClaw can successfully send chat completions after the upgrade completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)