### PR TITLE
fix(updates): resolve dream-update.sh path so dashboard updates actually work

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -283,13 +283,11 @@ async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks
     if action.action not in _VALID_ACTIONS:
         raise HTTPException(status_code=400, detail=f"Unknown action: {action.action}")
 
-    script_path = Path(INSTALL_DIR).parent / "scripts" / "dream-update.sh"
+    script_path = Path(INSTALL_DIR) / "dream-update.sh"
     if not script_path.exists():
-        install_script = Path(INSTALL_DIR) / "install.sh"
-        if install_script.exists():
-            script_path = Path(INSTALL_DIR).parent / "scripts" / "dream-update.sh"
-        else:
-            script_path = Path(INSTALL_DIR) / "scripts" / "dream-update.sh"
+        script_path = Path(INSTALL_DIR).parent / "scripts" / "dream-update.sh"
+    if not script_path.exists():
+        script_path = Path(INSTALL_DIR) / "scripts" / "dream-update.sh"
 
     if not script_path.exists():
         logger.error("dream-update.sh not found at %s", script_path)


### PR DESCRIPTION
## Summary

- The `/api/update` endpoint in the dashboard API tried the same wrong path twice (`INSTALL_DIR.parent/scripts/dream-update.sh`) and never checked the actual script location at `INSTALL_DIR/dream-update.sh`
- This meant the dashboard update, check, and backup actions would always fail with "Update system not installed" on a standard deployment
- Fixed the resolution order to check the correct path first, then fall back to legacy locations

## Test plan

- [ ] Verify `dream-update.sh` exists at `INSTALL_DIR/dream-update.sh` on a standard install
- [ ] Trigger a version check from the dashboard — should no longer return 501
- [ ] Confirm the fallback paths still work for non-standard installations
