### PR TITLE
fix: log errors instead of silently swallowing exceptions in token-spy and updates

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -227,6 +227,7 @@ async def get_update_dry_run():
     latest: Optional[str] = None
     changelog_url: Optional[str] = None
     update_available = False
+    version_check_error: Optional[str] = None
 
     try:
         req = urllib.request.Request(
@@ -241,8 +242,8 @@ async def get_update_dry_run():
                 def _parts(v: str) -> list[int]:
                     return ([int(x) for x in v.split(".") if x.isdigit()][:3] + [0, 0, 0])[:3]
                 update_available = _parts(latest) > _parts(current)
-    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError, ValueError):
-        pass
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError, json.JSONDecodeError, ValueError) as e:
+        version_check_error = f"Could not reach GitHub: {e}"
 
     # ── configured image tags from compose files ──────────────────────────────
     images: list[str] = []
@@ -276,6 +277,7 @@ async def get_update_dry_run():
         "changelog_url": changelog_url,
         "images": images,
         "env_keys": env_snapshot,
+        "version_check_error": version_check_error,
     }
 
 

--- a/dream-server/extensions/services/token-spy/main.py
+++ b/dream-server/extensions/services/token-spy/main.py
@@ -712,6 +712,7 @@ async def _handle_non_streaming(client, raw_body, headers, model, sys_analysis,
     try:
         data = resp.json()
     except Exception:
+        log.warning("Failed to parse Anthropic response JSON — token usage will be recorded as zero")
         data = {}
 
     resp_usage = data.get("usage", {})
@@ -942,6 +943,7 @@ async def _handle_openai_non_streaming(client, raw_body, headers, model, sys_ana
     try:
         data = resp.json()
     except Exception:
+        log.warning("Failed to parse OpenAI response JSON — token usage will be recorded as zero")
         data = {}
 
     resp_usage = data.get("usage", {})
@@ -1184,7 +1186,8 @@ def _get_remote_session_status(agent: str) -> dict:
         "                    history_chars += sum(len(str(x)) for x in c)\n"
         "                elif isinstance(c, str):\n"
         "                    history_chars += len(c)\n"
-        "        except: pass\n"
+        "        except Exception:\n"
+        "            pass  # skip corrupt JSONL lines\n"
         "    print(json.dumps({'turns': turns, 'chars': history_chars, 'tool_results': tool_results,"
         " 'file_bytes': os.path.getsize(largest), 'total_lines': len(lines), 'files': len(files)}))"
     )
@@ -1266,7 +1269,8 @@ def _kill_remote_session(agent: str, reason: str = "dashboard") -> dict:
         "        for k in list(data.keys()):\n"
         "            if isinstance(data[k], dict) and data[k].get('sessionId') == sid: del data[k]\n"
         "        with open(sj, 'w') as fh: json.dump(data, fh, indent=2)\n"
-        "    except: pass\n"
+        "    except Exception as e:\n"
+        "        print(json.dumps({'warn': 'sessions.json update failed', 'error': str(e)}))\n"
         "    print(json.dumps({'action': 'killed', 'session_id': sid, 'size_bytes': size}))"
     )
     try:


### PR DESCRIPTION
## Summary

- **token-spy**: add warning logs when response JSON parsing fails (Anthropic and OpenAI paths) so zeroed-out token usage is diagnosable instead of silently returning empty data
- **token-spy**: replace bare `except: pass` in SSH-scoped Python scripts with `except Exception` + comments; sessions.json cleanup now prints structured warnings
- **updates**: include `version_check_error` field in dry-run response when GitHub API is unreachable, instead of silently returning `latest: null`

## Test plan

- [ ] Trigger a token-spy request with malformed upstream response — warning should appear in logs
- [ ] Run dry-run update with GitHub unreachable — response should include `version_check_error` field
- [ ] Verify existing token-spy and updates tests still pass
