### PR TITLE
Fix/amd strix halo env schema

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -333,6 +333,18 @@
       "type": "integer",
       "description": "AMD ROCm BLAS setting"
     },
+    "HSA_XNACK": {
+      "type": "integer",
+      "description": "AMD ROCm extended memory access for large KV caches"
+    },
+    "AMDGPU_TARGET": {
+      "type": "string",
+      "description": "GPU arch for llama.cpp build (gfx1151, gfx1100, etc.)"
+    },
+    "LLAMA_CPP_REF": {
+      "type": "string",
+      "description": "llama.cpp release tag to build (pin to avoid breakage)"
+    },
     "UID": {
       "type": "integer",
       "description": "Container user ID",

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -30,6 +30,12 @@ echo "[contract] capability profile schema has hardware_class"
 jq -e '.properties.hardware_class and (.required | index("hardware_class"))' config/capability-profile.schema.json >/dev/null \
   || { echo "[FAIL] capability profile schema missing hardware_class"; exit 1; }
 
+echo "[contract] AMD phase-06 env keys exist in schema"
+for key in HSA_XNACK AMDGPU_TARGET LLAMA_CPP_REF; do
+  jq -e --arg key "$key" '.properties[$key]' .env.schema.json >/dev/null \
+    || { echo "[FAIL] .env.schema.json missing AMD installer key: $key"; exit 1; }
+done
+
 echo "[contract] canonical port contract parity"
 test -x tests/contracts/test-port-contracts.sh || { echo "[FAIL] script not executable: tests/contracts/test-port-contracts.sh"; exit 1; }
 bash tests/contracts/test-port-contracts.sh


### PR DESCRIPTION
fix: add missing AMD env vars to .env schema (HSA_XNACK, AMDGPU_TARGET, LLAMA_CPP_REF)

The installer phase 06 generates these three AMD-specific variables for
Strix Halo builds, but they were absent from .env.schema.json. The schema
validator treats unknown keys as errors, causing installation to fail on
AMD Strix Halo hardware.

Fixes #957