### PR TITLE
fix(token-spy): stop forwarding proxy auth upstream and align shipped docs

### DIFF
--- a/dream-server/extensions/services/token-spy/README.md
+++ b/dream-server/extensions/services/token-spy/README.md
@@ -1,6 +1,6 @@
 # Token Spy
 
-Transparent LLM API proxy that captures per-turn token usage, cost, latency, and session health. Sits between your application and upstream providers (Anthropic, OpenAI, Moonshot, local models), logging everything while forwarding requests and responses untouched -- including SSE streams.
+Authenticated LLM API proxy that captures per-turn token usage, cost, latency, and session health. It sits between your application and upstream providers (Anthropic, OpenAI, Moonshot, local models), logs every turn, and streams responses through without buffering.
 
 ## How It Works
 
@@ -14,7 +14,7 @@ Your agent -> Token Spy proxy -> Upstream API (Anthropic, OpenAI, etc.)
            Session Manager (polls every N minutes, enforces limits)
 ```
 
-Point your agent's API base URL at Token Spy instead of the upstream provider. Token Spy forwards everything transparently -- your agent won't know it's there.
+Point your agent's API base URL at Token Spy instead of the upstream provider. Clients authenticate to Token Spy with `TOKEN_SPY_API_KEY`. For external providers, Token Spy uses server-side `UPSTREAM_API_KEY` and never forwards its own Bearer token upstream. Local OpenAI-compatible backends such as llama-server or Ollama can still run without an upstream key.
 
 ## Features
 
@@ -31,11 +31,21 @@ Point your agent's API base URL at Token Spy instead of the upstream provider. T
 cd token-spy
 pip install -r requirements.txt
 cp .env.example .env
-# Edit .env -- at minimum set AGENT_NAME
+# Edit .env -- at minimum set AGENT_NAME and TOKEN_SPY_API_KEY
+TOKEN_SPY_API_KEY=dev-token \
+UPSTREAM_API_KEY=provider-secret \
 AGENT_NAME=my-agent python -m uvicorn main:app --host 0.0.0.0 --port 9110
 ```
 
 Open `http://localhost:9110/dashboard` to see the monitoring UI.
+
+All `/api/*`, `/token_events`, and `/v1/*` endpoints require:
+
+```bash
+Authorization: Bearer <TOKEN_SPY_API_KEY>
+```
+
+Use `UPSTREAM_API_KEY` for external Anthropic/OpenAI/Moonshot providers. For local no-auth OpenAI-compatible upstreams, `UPSTREAM_API_KEY` is optional.
 
 ## Configuration
 

--- a/dream-server/extensions/services/token-spy/TOKEN-SPY-GUIDE.md
+++ b/dream-server/extensions/services/token-spy/TOKEN-SPY-GUIDE.md
@@ -6,9 +6,9 @@
 
 ## What Is Token Spy?
 
-Token Spy is a **transparent API proxy** that sits between your AI agents and upstream LLM providers. Every API call passes through Token Spy, which logs token usage, cost, latency, and session health — then forwards the request and response untouched.
+Token Spy is an **authenticated API proxy** that sits between your AI agents and upstream LLM providers. Every API call passes through Token Spy, which logs token usage, cost, latency, and session health before forwarding the request upstream.
 
-You don't need to change anything about how you make API calls. Token Spy is invisible to your application layer. It just watches, logs, and — when configured — enforces session limits to keep your context from growing out of control.
+You do need one proxy-specific change: point your base URL at Token Spy and send `Authorization: Bearer <TOKEN_SPY_API_KEY>` on protected routes. For external providers, Token Spy uses `UPSTREAM_API_KEY` on the server side and does not forward its own Bearer token upstream.
 
 ### Architecture
 
@@ -29,6 +29,14 @@ You (agent) -> Token Spy proxy -> Upstream API (Anthropic, OpenAI, etc.)
 | my-agent   | `:9110`    | `http://localhost:9110/dashboard`   |
 
 Each agent instance shares the same database, so any dashboard shows data for all agents.
+
+### Authentication Model
+
+- Clients authenticate to Token Spy with `Authorization: Bearer <TOKEN_SPY_API_KEY>`
+- Dashboard/API routes and proxy routes both use the same Token Spy API key
+- External Anthropic/OpenAI/Moonshot upstreams should be configured with `UPSTREAM_API_KEY`
+- Local OpenAI-compatible upstreams can run without `UPSTREAM_API_KEY`
+- Token Spy strips its own Bearer token before forwarding requests upstream
 
 ---
 
@@ -70,12 +78,14 @@ All endpoints are available on the proxy port. Multiple instances share the same
 
 **Read current settings:**
 ```bash
-curl http://localhost:9110/api/settings
+curl http://localhost:9110/api/settings \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY"
 ```
 
 **Update global session limit (takes effect immediately):**
 ```bash
 curl -X POST http://localhost:9110/api/settings \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"session_char_limit": 150000}'
 ```
@@ -83,6 +93,7 @@ curl -X POST http://localhost:9110/api/settings \
 **Set a per-agent override:**
 ```bash
 curl -X POST http://localhost:9110/api/settings \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"agents": {"my-agent": {"session_char_limit": 80000}}}'
 ```
@@ -90,6 +101,7 @@ curl -X POST http://localhost:9110/api/settings \
 **Clear a per-agent override (back to inheriting global):**
 ```bash
 curl -X POST http://localhost:9110/api/settings \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"agents": {"my-agent": {"session_char_limit": null}}}'
 ```
@@ -97,6 +109,7 @@ curl -X POST http://localhost:9110/api/settings \
 **Change poll frequency (also updates the systemd timer if configured):**
 ```bash
 curl -X POST http://localhost:9110/api/settings \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"poll_interval_minutes": 1}'
 ```
@@ -111,7 +124,8 @@ curl http://localhost:9110/health
 
 **Session status (current session health):**
 ```bash
-curl http://localhost:9110/api/session-status?agent=my-agent
+curl "http://localhost:9110/api/session-status?agent=my-agent" \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY"
 # -> {
 #     "current_session_turns": 27,
 #     "current_history_chars": 170829,
@@ -130,17 +144,38 @@ Recommendation levels scale with your configured limit:
 
 **Usage data (raw turns):**
 ```bash
-curl "http://localhost:9110/api/usage?hours=24&limit=100"
+curl "http://localhost:9110/api/usage?hours=24&limit=100" \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY"
 ```
 
 **Summary (aggregated by agent):**
 ```bash
-curl "http://localhost:9110/api/summary?hours=24"
+curl "http://localhost:9110/api/summary?hours=24" \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY"
 ```
 
 **Manual session reset (emergency):**
 ```bash
-curl -X POST "http://localhost:9110/api/reset-session?agent=my-agent"
+curl -X POST "http://localhost:9110/api/reset-session?agent=my-agent" \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY"
+```
+
+### Proxy Requests
+
+**Anthropic Messages API via Token Spy:**
+```bash
+curl -X POST http://localhost:9110/v1/messages \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"claude-sonnet-4","max_tokens":128,"messages":[{"role":"user","content":"Hello"}]}'
+```
+
+**OpenAI-compatible Chat Completions via Token Spy:**
+```bash
+curl -X POST http://localhost:9110/v1/chat/completions \
+  -H "Authorization: Bearer $TOKEN_SPY_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model":"qwen3-coder-next","messages":[{"role":"user","content":"Hello"}]}'
 ```
 
 ### Dashboard

--- a/dream-server/extensions/services/token-spy/main.py
+++ b/dream-server/extensions/services/token-spy/main.py
@@ -1,5 +1,5 @@
 """
-Token Spy — API Monitor — Transparent LLM API Proxy.
+Token Spy — API Monitor — Authenticated LLM API Proxy.
 
 Captures per-turn token usage and system prompt breakdown, streams SSE through
 without buffering. Single or multi-instance deployment, sharing SQLite database.
@@ -306,6 +306,63 @@ def get_moonshot_client() -> httpx.AsyncClient:
     return _openai_client
 
 
+def _build_anthropic_upstream_headers(request: Request) -> dict[str, str]:
+    """Build upstream headers for Anthropic-style requests.
+
+    Token Spy auth stays on the proxy boundary. The Bearer token used to
+    authenticate to Token Spy is never forwarded upstream.
+    """
+    headers: dict[str, str] = {}
+    for key in (
+        "x-api-key",
+        "anthropic-version",
+        "content-type",
+        "anthropic-beta",
+        "anthropic-dangerous-direct-browser-access",
+        "user-agent",
+        "x-app",
+        "accept",
+    ):
+        val = request.headers.get(key)
+        if val:
+            headers[key] = val
+
+    if "x-api-key" not in headers:
+        if UPSTREAM_API_KEY:
+            headers["x-api-key"] = UPSTREAM_API_KEY
+        elif API_PROVIDER == "anthropic":
+            raise HTTPException(
+                status_code=500,
+                detail="Token Spy is missing UPSTREAM_API_KEY for Anthropic upstream requests.",
+            )
+
+    return headers
+
+
+def _build_openai_upstream_headers(request: Request) -> dict[str, str]:
+    """Build upstream headers for OpenAI-compatible requests."""
+    headers: dict[str, str] = {}
+    for key in ("content-type", "accept", "user-agent", "openai-organization", "openai-project"):
+        val = request.headers.get(key)
+        if val:
+            headers[key] = val
+
+    if UPSTREAM_API_KEY:
+        headers["authorization"] = f"Bearer {UPSTREAM_API_KEY}"
+    elif API_PROVIDER in ("openai", "moonshot"):
+        raise HTTPException(
+            status_code=500,
+            detail=f"Token Spy is missing UPSTREAM_API_KEY for {API_PROVIDER} upstream requests.",
+        )
+
+    return headers
+
+
+def _uses_openai_upstream() -> bool:
+    """Return True when the configured provider speaks OpenAI-style APIs."""
+    return API_PROVIDER in ("openai", "moonshot", "local", "ollama", "vllm", "llama-server")
+
+
 _db_available = True
 
 @app.on_event("startup")
@@ -547,7 +604,7 @@ def estimate_cost(model: str, input_tokens: int, output_tokens: int,
 
 @app.post("/v1/messages", dependencies=[Depends(verify_api_key)])
 async def proxy_messages(request: Request):
-    """Transparent proxy for Anthropic /v1/messages with metrics capture."""
+    """Authenticated proxy for Anthropic /v1/messages with metrics capture."""
     start = time.time()
 
     # Read and parse request body
@@ -576,21 +633,7 @@ async def proxy_messages(request: Request):
         f"body={len(raw_body)}B"
     )
 
-    # Build upstream headers — forward everything relevant
-    forward_headers = {}
-    for key in ("x-api-key", "anthropic-version", "content-type", "anthropic-beta",
-                "anthropic-dangerous-direct-browser-access", "user-agent", "x-app",
-                "accept", "authorization"):
-        val = request.headers.get(key)
-        if val:
-            forward_headers[key] = val
-
-    # Inject environment API key if not provided in request (for external deployments)
-    if UPSTREAM_API_KEY and "x-api-key" not in forward_headers and "authorization" not in forward_headers:
-        if API_PROVIDER == "anthropic":
-            forward_headers["x-api-key"] = UPSTREAM_API_KEY
-        else:
-            forward_headers["authorization"] = f"Bearer {UPSTREAM_API_KEY}"
+    forward_headers = _build_anthropic_upstream_headers(request)
 
     client = get_http_client()
 
@@ -769,7 +812,7 @@ def _analyze_openai_messages(messages: list) -> dict:
 
 @app.post("/v1/chat/completions", dependencies=[Depends(verify_api_key)])
 async def proxy_chat_completions(request: Request):
-    """Transparent proxy for OpenAI-compatible /v1/chat/completions (Moonshot/Kimi)."""
+    """Authenticated proxy for OpenAI-compatible /v1/chat/completions."""
     start = time.time()
 
     raw_body = await request.body()
@@ -818,15 +861,7 @@ async def proxy_chat_completions(request: Request):
         f"body={len(raw_body)}B | roles={roles}"
     )
 
-    forward_headers = {}
-    for key in ("authorization", "content-type", "accept", "user-agent"):
-        val = request.headers.get(key)
-        if val:
-            forward_headers[key] = val
-
-    # Inject environment API key if not provided in request (for external deployments)
-    if UPSTREAM_API_KEY and "authorization" not in forward_headers:
-        forward_headers["authorization"] = f"Bearer {UPSTREAM_API_KEY}"
+    forward_headers = _build_openai_upstream_headers(request)
 
     client = get_moonshot_client()
 
@@ -2369,27 +2404,16 @@ async def token_events(request: Request):
 
 # ── Catch-all for other endpoints ────────────────────────────────────────────
 
-@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"])
+@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"], dependencies=[Depends(verify_api_key)])
 async def proxy_other(request: Request, path: str):
-    """Forward any other requests to upstream transparently."""
+    """Forward any other authenticated requests to upstream."""
     # Use the correct upstream client based on provider
-    if API_PROVIDER in ("openai", "moonshot"):
+    if _uses_openai_upstream():
         client = get_moonshot_client()
+        headers = _build_openai_upstream_headers(request)
     else:
         client = get_http_client()
-    headers = {}
-    for key in ("x-api-key", "anthropic-version", "content-type", "anthropic-beta",
-                "authorization", "accept", "user-agent"):
-        val = request.headers.get(key)
-        if val:
-            headers[key] = val
-
-    # Inject environment API key if not provided in request
-    if UPSTREAM_API_KEY and "x-api-key" not in headers and "authorization" not in headers:
-        if API_PROVIDER == "anthropic":
-            headers["x-api-key"] = UPSTREAM_API_KEY
-        else:
-            headers["authorization"] = f"Bearer {UPSTREAM_API_KEY}"
+        headers = _build_anthropic_upstream_headers(request)
 
     body = await request.body()
     try:

--- a/dream-server/extensions/services/token-spy/start.sh
+++ b/dream-server/extensions/services/token-spy/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Token Spy — API Monitor — launcher
 # Starts proxy instances sharing a single database.
-# Pure telemetry — no request modification.
+# Authenticated proxy — strips Token Spy auth before forwarding upstream.
 #
 # Dual upstream routing:
 #   Anthropic Messages API (/v1/messages) → ANTHROPIC_UPSTREAM

--- a/dream-server/tests/test-secret-security.sh
+++ b/dream-server/tests/test-secret-security.sh
@@ -320,6 +320,28 @@ else
     skip "Token-spy db.py not found"
 fi
 
+token_spy_main="extensions/services/token-spy/main.py"
+if [[ -f "$token_spy_main" ]]; then
+    if grep -Fq '@app.post("/v1/messages", dependencies=[Depends(verify_api_key)])' "$token_spy_main" && \
+       grep -Fq '@app.post("/v1/chat/completions", dependencies=[Depends(verify_api_key)])' "$token_spy_main" && \
+       grep -Fq '@app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE", "PATCH"], dependencies=[Depends(verify_api_key)])' "$token_spy_main"; then
+        pass "Token-spy proxy routes require API key auth"
+    else
+        fail "Token-spy proxy routes missing API key protection" "Expected verify_api_key on /v1/* and catch-all proxy routes"
+    fi
+
+    if grep -Fq 'for key in (' "$token_spy_main" && \
+       grep -Fq '"anthropic-dangerous-direct-browser-access"' "$token_spy_main" && \
+       grep -Fq 'for key in ("content-type", "accept", "user-agent", "openai-organization", "openai-project"):' "$token_spy_main" && \
+       ! grep -Fq 'for key in ("authorization", "content-type", "accept", "user-agent"):' "$token_spy_main"; then
+        pass "Token-spy upstream headers exclude proxy Authorization"
+    else
+        fail "Token-spy upstream headers may leak proxy Authorization" "Proxy auth should stop at Token Spy and not be forwarded upstream"
+    fi
+else
+    skip "Token-spy main.py not found"
+fi
+
 # Check for password hashing
 password_hashing=0
 while IFS= read -r -d '' pyfile; do


### PR DESCRIPTION
## Summary

This updates the shipped Token Spy service to use an authenticated-proxy model consistently.

Before this change, Token Spy required `TOKEN_SPY_API_KEY` on proxy routes, but could still forward the caller's `Authorization` header upstream. At the same time, the shipped docs still described Token Spy as a transparent / invisible proxy.

## What changed

- stop forwarding Token Spy Bearer auth upstream
- use dedicated upstream header builders for Anthropic and OpenAI-compatible requests
- require auth on the catch-all proxy route too
- inject `UPSTREAM_API_KEY` for external upstreams instead of reusing proxy auth
- keep local OpenAI-compatible upstreams working without `UPSTREAM_API_KEY`
- update shipped Token Spy docs and examples to describe the real auth model
- add a regression check in `tests/test-secret-security.sh`

## Validation

- `python3 -m py_compile dream-server/extensions/services/token-spy/main.py`
- `bash dream-server/tests/test-secret-security.sh`
- `git diff --check`

## Notes

- this change keeps the current Token Spy proxy protection on `/v1/*`
- local no-auth OpenAI-compatible backends still work
- external `openai` / `moonshot` upstreams now fail clearly if `UPSTREAM_API_KEY` is missing
