### PR TITLE
fix(token-spy): bundle dashboard charts for offline installs

### DIFF
--- a/dream-server/extensions/services/token-spy/dashboard_charts.js
+++ b/dream-server/extensions/services/token-spy/dashboard_charts.js
@@ -1,0 +1,318 @@
+(function () {
+  const COLORS = {
+    text: '#e6edf3',
+    muted: '#8b949e',
+    grid: '#21262d',
+  };
+
+  function getContext(canvas) {
+    const dpr = window.devicePixelRatio || 1;
+    const width = Math.max(canvas.clientWidth || 320, 320);
+    const height = Math.max(parseInt(canvas.dataset.height || '', 10) || canvas.clientHeight || 280, 220);
+    canvas.width = Math.floor(width * dpr);
+    canvas.height = Math.floor(height * dpr);
+    canvas.style.width = width + 'px';
+    canvas.style.height = height + 'px';
+    const ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, width, height);
+    return { ctx, width, height };
+  }
+
+  function legend(target, items) {
+    if (!target) return;
+    target.innerHTML = items.map(item =>
+      '<span class="chart-legend-item"><span class="chart-legend-swatch" style="background:' + item.color +
+      '"></span><span>' + item.label + '</span></span>'
+    ).join('');
+  }
+
+  function noData(ctx, width, height) {
+    ctx.fillStyle = COLORS.muted;
+    ctx.font = '13px system-ui, sans-serif';
+    ctx.textAlign = 'center';
+    ctx.textBaseline = 'middle';
+    ctx.fillText('No chart data for this time range', width / 2, height / 2);
+  }
+
+  function linePath(ctx, points, xFor, yFor, baselineY, fillColor) {
+    if (!points.length) return;
+    ctx.beginPath();
+    ctx.moveTo(xFor(points[0].x), yFor(points[0].y));
+    for (let i = 1; i < points.length; i += 1) {
+      ctx.lineTo(xFor(points[i].x), yFor(points[i].y));
+    }
+    if (fillColor) {
+      const last = points[points.length - 1];
+      const first = points[0];
+      ctx.lineTo(xFor(last.x), baselineY);
+      ctx.lineTo(xFor(first.x), baselineY);
+      ctx.closePath();
+      ctx.fillStyle = fillColor;
+      ctx.fill();
+    }
+  }
+
+  function tickXRange(min, max, count) {
+    const ticks = [];
+    if (!Number.isFinite(min) || !Number.isFinite(max)) return ticks;
+    if (min === max) return [min];
+    for (let i = 0; i < count; i += 1) {
+      ticks.push(min + ((max - min) * i) / (count - 1));
+    }
+    return ticks;
+  }
+
+  function line(canvas, options) {
+    const series = options.series || [];
+    const legendEl = options.legendEl;
+
+    function draw() {
+      const { ctx, width, height } = getContext(canvas);
+      const allPoints = series.flatMap(s => s.points || []);
+      if (!allPoints.length) {
+        legend(legendEl, []);
+        noData(ctx, width, height);
+        return;
+      }
+
+      const margin = { top: 16, right: 14, bottom: 30, left: 56 };
+      const plotW = width - margin.left - margin.right;
+      const plotH = height - margin.top - margin.bottom;
+      const xs = allPoints.map(p => +new Date(p.x));
+      const thresholdLines = options.thresholdLines || [];
+      const ys = allPoints.map(p => Number(p.y) || 0).concat(thresholdLines.map(t => Number(t.value) || 0));
+      let xMin = Math.min(...xs);
+      let xMax = Math.max(...xs);
+      if (xMin === xMax) xMax = xMin + 1;
+      const yMin = options.minY != null ? options.minY : 0;
+      let yMax = Math.max(...ys, yMin + 1);
+      yMax *= 1.08;
+
+      const xFor = value => margin.left + (((+new Date(value)) - xMin) / (xMax - xMin)) * plotW;
+      const yFor = value => margin.top + plotH - (((value - yMin) / (yMax - yMin)) * plotH);
+
+      ctx.strokeStyle = COLORS.grid;
+      ctx.fillStyle = COLORS.muted;
+      ctx.lineWidth = 1;
+      ctx.font = '12px system-ui, sans-serif';
+
+      for (let i = 0; i < 5; i += 1) {
+        const value = yMin + ((yMax - yMin) * i) / 4;
+        const y = yFor(value);
+        ctx.beginPath();
+        ctx.moveTo(margin.left, y);
+        ctx.lineTo(width - margin.right, y);
+        ctx.stroke();
+        const label = options.yFormatter ? options.yFormatter(value) : String(Math.round(value));
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(label, margin.left - 8, y);
+      }
+
+      tickXRange(xMin, xMax, 5).forEach(value => {
+        const x = xFor(value);
+        ctx.beginPath();
+        ctx.moveTo(x, margin.top);
+        ctx.lineTo(x, height - margin.bottom);
+        ctx.stroke();
+        const label = options.xFormatter ? options.xFormatter(new Date(value)) : new Date(value).toLocaleTimeString();
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'top';
+        ctx.fillText(label, x, height - margin.bottom + 8);
+      });
+
+      thresholdLines.forEach((lineDef, index) => {
+        const y = yFor(lineDef.value);
+        ctx.save();
+        ctx.setLineDash(index === 0 ? [6, 4] : [4, 4]);
+        ctx.strokeStyle = lineDef.color;
+        ctx.beginPath();
+        ctx.moveTo(margin.left, y);
+        ctx.lineTo(width - margin.right, y);
+        ctx.stroke();
+        ctx.restore();
+        ctx.fillStyle = lineDef.color;
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'bottom';
+        ctx.fillText(lineDef.label, margin.left + 6, y - 4);
+        ctx.fillStyle = COLORS.muted;
+      });
+
+      series.forEach(s => {
+        const points = (s.points || []).filter(p => Number.isFinite(+new Date(p.x)));
+        if (!points.length) return;
+        if (s.fillColor) {
+          linePath(ctx, points, xFor, yFor, margin.top + plotH, s.fillColor);
+        }
+        ctx.beginPath();
+        ctx.moveTo(xFor(points[0].x), yFor(points[0].y));
+        for (let i = 1; i < points.length; i += 1) {
+          ctx.lineTo(xFor(points[i].x), yFor(points[i].y));
+        }
+        ctx.strokeStyle = s.color;
+        ctx.lineWidth = s.lineWidth || 2;
+        ctx.stroke();
+        const pointRadius = s.pointRadius == null ? 2 : s.pointRadius;
+        if (pointRadius > 0) {
+          ctx.fillStyle = s.color;
+          points.forEach(point => {
+            ctx.beginPath();
+            ctx.arc(xFor(point.x), yFor(point.y), pointRadius, 0, Math.PI * 2);
+            ctx.fill();
+          });
+        }
+      });
+
+      legend(legendEl, series.map(s => ({ label: s.label, color: s.color })));
+    }
+
+    const onResize = () => draw();
+    window.addEventListener('resize', onResize);
+    draw();
+    return {
+      destroy() {
+        window.removeEventListener('resize', onResize);
+        const { ctx, width, height } = getContext(canvas);
+        ctx.clearRect(0, 0, width, height);
+      },
+    };
+  }
+
+  function stackedBar(canvas, options) {
+    const labels = options.labels || [];
+    const datasets = options.datasets || [];
+    const legendEl = options.legendEl;
+
+    function draw() {
+      const { ctx, width, height } = getContext(canvas);
+      if (!labels.length || !datasets.length) {
+        legend(legendEl, []);
+        noData(ctx, width, height);
+        return;
+      }
+
+      const margin = { top: 16, right: 14, bottom: 30, left: 56 };
+      const plotW = width - margin.left - margin.right;
+      const plotH = height - margin.top - margin.bottom;
+      const totals = labels.map((_, i) => datasets.reduce((sum, ds) => sum + (Number(ds.data[i]) || 0), 0));
+      const yMax = Math.max(...totals, 1) * 1.08;
+
+      ctx.strokeStyle = COLORS.grid;
+      ctx.fillStyle = COLORS.muted;
+      ctx.lineWidth = 1;
+      ctx.font = '12px system-ui, sans-serif';
+
+      for (let i = 0; i < 5; i += 1) {
+        const value = (yMax * i) / 4;
+        const y = margin.top + plotH - (value / yMax) * plotH;
+        ctx.beginPath();
+        ctx.moveTo(margin.left, y);
+        ctx.lineTo(width - margin.right, y);
+        ctx.stroke();
+        ctx.textAlign = 'right';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(Math.round(value).toLocaleString(), margin.left - 8, y);
+      }
+
+      const slot = plotW / labels.length;
+      const barWidth = Math.max(Math.min(slot * 0.7, 28), 8);
+      const labelEvery = Math.max(Math.ceil(labels.length / 6), 1);
+
+      labels.forEach((labelValue, index) => {
+        const x = margin.left + (slot * index) + (slot / 2);
+        let stackBase = 0;
+        datasets.forEach(ds => {
+          const raw = Number(ds.data[index]) || 0;
+          if (raw <= 0) return;
+          const y = margin.top + plotH - ((stackBase + raw) / yMax) * plotH;
+          const barHeight = (raw / yMax) * plotH;
+          ctx.fillStyle = ds.color;
+          ctx.fillRect(x - (barWidth / 2), y, barWidth, barHeight);
+          stackBase += raw;
+        });
+        if (index % labelEvery === 0 || index === labels.length - 1) {
+          const text = options.labelFormatter ? options.labelFormatter(labelValue) : String(labelValue);
+          ctx.fillStyle = COLORS.muted;
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'top';
+          ctx.fillText(text, x, height - margin.bottom + 8);
+        }
+      });
+
+      legend(legendEl, datasets.map(ds => ({ label: ds.label, color: ds.color })));
+    }
+
+    const onResize = () => draw();
+    window.addEventListener('resize', onResize);
+    draw();
+    return {
+      destroy() {
+        window.removeEventListener('resize', onResize);
+        const { ctx, width, height } = getContext(canvas);
+        ctx.clearRect(0, 0, width, height);
+      },
+    };
+  }
+
+  function donut(canvas, options) {
+    const labels = options.labels || [];
+    const values = options.values || [];
+    const colors = options.colors || [];
+    const legendEl = options.legendEl;
+
+    function draw() {
+      const { ctx, width, height } = getContext(canvas);
+      const total = values.reduce((sum, value) => sum + (Number(value) || 0), 0);
+      if (!labels.length || total <= 0) {
+        legend(legendEl, []);
+        noData(ctx, width, height);
+        return;
+      }
+
+      const centerX = width / 2;
+      const centerY = height / 2;
+      const radius = Math.min(width, height) * 0.32;
+      const innerRadius = radius * 0.58;
+      let start = -Math.PI / 2;
+
+      values.forEach((value, index) => {
+        const sweep = ((Number(value) || 0) / total) * Math.PI * 2;
+        ctx.beginPath();
+        ctx.moveTo(centerX, centerY);
+        ctx.arc(centerX, centerY, radius, start, start + sweep);
+        ctx.closePath();
+        ctx.fillStyle = colors[index] || '#58a6ff';
+        ctx.fill();
+        start += sweep;
+      });
+
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.beginPath();
+      ctx.arc(centerX, centerY, innerRadius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.globalCompositeOperation = 'source-over';
+
+      ctx.fillStyle = COLORS.text;
+      ctx.font = '600 14px system-ui, sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(options.centerText || '', centerX, centerY);
+
+      legend(legendEl, labels.map((label, index) => ({ label, color: colors[index] || '#58a6ff' })));
+    }
+
+    const onResize = () => draw();
+    window.addEventListener('resize', onResize);
+    draw();
+    return {
+      destroy() {
+        window.removeEventListener('resize', onResize);
+        const { ctx, width, height } = getContext(canvas);
+        ctx.clearRect(0, 0, width, height);
+      },
+    };
+  }
+
+  window.TokenSpyCharts = { line, stackedBar, donut };
+}());

--- a/dream-server/extensions/services/token-spy/main.py
+++ b/dream-server/extensions/services/token-spy/main.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import httpx
 from fastapi import Depends, FastAPI, HTTPException, Request, Response, Security
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from filters import apply_filters
 from providers import ProviderRegistry
@@ -1668,7 +1668,6 @@ DASHBOARD_HTML = """<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Token Spy — API Monitor</title>
-<script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
   body { font-family: -apple-system, system-ui, sans-serif; background: #0d1117; color: #e6edf3; padding: 20px; }
@@ -1682,7 +1681,10 @@ DASHBOARD_HTML = """<!DOCTYPE html>
   .chart-container { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 16px; margin-bottom: 20px; }
   .chart-container h3 { font-size: 0.95em; margin-bottom: 12px; }
   .chart-row { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 20px; }
-  canvas { max-height: 300px; }
+  canvas { width: 100%; height: 280px; max-height: 300px; display: block; }
+  .chart-legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 12px; color: #8b949e; font-size: 0.8em; }
+  .chart-legend-item { display: inline-flex; align-items: center; gap: 6px; }
+  .chart-legend-swatch { width: 10px; height: 10px; border-radius: 999px; display: inline-block; }
   table { width: 100%; border-collapse: collapse; font-size: 0.85em; }
   th, td { padding: 8px 12px; text-align: left; border-bottom: 1px solid #21262d; }
   th { color: #8b949e; font-weight: 600; }
@@ -1787,28 +1789,33 @@ DASHBOARD_HTML = """<!DOCTYPE html>
 <div class="chart-row">
   <div class="chart-container">
     <h3>Cost Per Turn (Session Timeline)</h3>
-    <canvas id="cost-chart"></canvas>
+    <canvas id="cost-chart" data-height="280"></canvas>
+    <div class="chart-legend" id="cost-legend"></div>
   </div>
   <div class="chart-container">
     <h3>History Growth (chars)</h3>
-    <canvas id="history-chart"></canvas>
+    <canvas id="history-chart" data-height="280"></canvas>
+    <div class="chart-legend" id="history-legend"></div>
   </div>
 </div>
 
 <div class="chart-row">
   <div class="chart-container">
     <h3>Token Usage Over Time</h3>
-    <canvas id="tokens-chart"></canvas>
+    <canvas id="tokens-chart" data-height="280"></canvas>
+    <div class="chart-legend" id="tokens-legend"></div>
   </div>
   <div class="chart-container">
     <h3>Cost Breakdown by Type</h3>
-    <canvas id="breakdown-chart"></canvas>
+    <canvas id="breakdown-chart" data-height="280"></canvas>
+    <div class="chart-legend" id="breakdown-legend"></div>
   </div>
 </div>
 
 <div class="chart-container">
   <h3>Cumulative Cost Over Time</h3>
-  <canvas id="cumulative-chart" style="max-height:260px;"></canvas>
+  <canvas id="cumulative-chart" data-height="260" style="height:260px;max-height:260px;"></canvas>
+  <div class="chart-legend" id="cumulative-legend"></div>
 </div>
 
 <div class="chart-container">
@@ -1833,6 +1840,7 @@ DASHBOARD_HTML = """<!DOCTYPE html>
   </table>
 </div>
 
+<script src="/dashboard-assets/charts.js"></script>
 <script>
 function _getApiKey(){return sessionStorage.getItem('token_spy_api_key')||''}
 function _authHeaders(){return {Authorization:'Bearer '+_getApiKey()}}
@@ -1875,6 +1883,14 @@ async function loadAll() {
 function parseTs(ts) {
   if (!ts) return new Date(NaN);
   return new Date(ts);
+}
+
+function formatTimeTick(ts) {
+  if (!(ts instanceof Date) || Number.isNaN(ts.getTime())) return '\\u2014';
+  if (getHours() >= 168) {
+    return ts.toLocaleDateString([], { month: 'short', day: 'numeric' });
+  }
+  return ts.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
 function fmt(n) {
@@ -1982,103 +1998,77 @@ function renderSummary(data) {
 }
 
 function renderCostChart(usage) {
-  const ctx = document.getElementById('cost-chart').getContext('2d');
+  const canvas = document.getElementById('cost-chart');
   if (costChart) costChart.destroy();
   const sorted = [...usage].reverse();
   const colors = ['#58a6ff', '#f0883e', '#3fb950', '#a371f7', '#da3633', '#e6edf3'];
   const agents = [...new Set(usage.map(u => u.agent))];
-  const datasets = agents.map((agent, i) => {
+  const series = agents.map((agent, i) => {
     const agentData = sorted.filter(u => u.agent === agent);
     return {
       label: agent,
-      data: agentData.map(u => ({x: parseTs(u.timestamp), y: u.estimated_cost_usd})),
-      borderColor: colors[i % colors.length],
+      points: agentData.map(u => ({x: parseTs(u.timestamp), y: u.estimated_cost_usd || 0})),
+      color: colors[i % colors.length],
       pointRadius: 2,
-      tension: 0.1
     };
   });
-  costChart = new Chart(ctx, {
-    type: 'line',
-    data: { datasets },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      scales: {
-        x: { type: 'time', time: { tooltipFormat: 'HH:mm:ss' }, ticks: { color: '#8b949e', maxTicksLimit: 10 }, grid: { color: '#21262d' } },
-        y: { title: { display: true, text: 'USD', color: '#8b949e' }, ticks: { color: '#8b949e', callback: v => '$' + v.toFixed(2) }, grid: { color: '#21262d' } }
-      },
-      plugins: { legend: { labels: { color: '#e6edf3' } } }
-    }
+  costChart = TokenSpyCharts.line(canvas, {
+    legendEl: document.getElementById('cost-legend'),
+    series,
+    yFormatter: v => '$' + v.toFixed(2),
+    xFormatter: formatTimeTick,
   });
 }
 
 function renderHistoryChart(usage) {
-  const ctx = document.getElementById('history-chart').getContext('2d');
+  const canvas = document.getElementById('history-chart');
   if (historyChart) historyChart.destroy();
   const sorted = [...usage].reverse();
   const colors = ['#58a6ff', '#f0883e', '#3fb950', '#a371f7', '#da3633', '#e6edf3'];
   const bgColors = ['rgba(88,166,255,0.08)', 'rgba(240,136,62,0.08)', 'rgba(63,185,80,0.08)', 'rgba(163,113,247,0.08)', 'rgba(218,54,51,0.08)', 'rgba(230,237,243,0.08)'];
   const agents = [...new Set(usage.map(u => u.agent))];
-  const datasets = agents.map((agent, i) => {
+  const series = agents.map((agent, i) => {
     const agentData = sorted.filter(u => u.agent === agent);
     return {
       label: agent,
-      data: agentData.map(u => ({x: parseTs(u.timestamp), y: u.conversation_history_chars})),
-      borderColor: colors[i % colors.length],
+      points: agentData.map(u => ({x: parseTs(u.timestamp), y: u.conversation_history_chars || 0})),
+      color: colors[i % colors.length],
+      fillColor: bgColors[i % bgColors.length],
       pointRadius: 1,
-      tension: 0.1,
-      fill: true,
-      backgroundColor: bgColors[i % bgColors.length]
     };
   });
-  historyChart = new Chart(ctx, {
-    type: 'line',
-    data: { datasets },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      scales: {
-        x: { type: 'time', time: { tooltipFormat: 'HH:mm:ss' }, ticks: { color: '#8b949e', maxTicksLimit: 10 }, grid: { color: '#21262d' } },
-        y: { title: { display: true, text: 'chars', color: '#8b949e' }, ticks: { color: '#8b949e', callback: v => v >= 1000 ? (v/1000).toFixed(0) + 'K' : v }, grid: { color: '#21262d' } }
-      },
-      plugins: {
-        legend: { labels: { color: '#e6edf3' } },
-        annotation: { annotations: {
-          autoReset: { type: 'line', yMin: window._scl || 200000, yMax: window._scl || 200000, borderColor: '#f0883e', borderWidth: 2, borderDash: [6,3], label: { display: true, content: fmt(window._scl || 200000) + ' (~' + fmt(Math.round((window._scl || 200000)/4)) + ' tok) auto-reset', color: '#f0883e', position: 'start' } },
-          danger: { type: 'line', yMin: (window._scl || 200000) * 2.5, yMax: (window._scl || 200000) * 2.5, borderColor: '#da3633', borderWidth: 1, borderDash: [6,3], label: { display: true, content: fmt((window._scl || 200000) * 2.5) + ' (~' + fmt(Math.round((window._scl || 200000)*2.5/4)) + ' tok) danger', color: '#da3633', position: 'start' } }
-        } }
-      }
-    }
+  historyChart = TokenSpyCharts.line(canvas, {
+    legendEl: document.getElementById('history-legend'),
+    series,
+    yFormatter: v => v >= 1000 ? (v/1000).toFixed(0) + 'K' : String(Math.round(v)),
+    xFormatter: formatTimeTick,
+    thresholdLines: [
+      { value: window._scl || 200000, color: '#f0883e', label: fmt(window._scl || 200000) + ' (~' + fmt(Math.round((window._scl || 200000)/4)) + ' tok) auto-reset' },
+      { value: (window._scl || 200000) * 2.5, color: '#da3633', label: fmt((window._scl || 200000) * 2.5) + ' (~' + fmt(Math.round((window._scl || 200000)*2.5/4)) + ' tok) danger' },
+    ],
   });
 }
 
 function renderTokensChart(usage) {
-  const ctx = document.getElementById('tokens-chart').getContext('2d');
+  const canvas = document.getElementById('tokens-chart');
   if (tokensChart) tokensChart.destroy();
   const sorted = [...usage].reverse();
-  const labels = sorted.map(u => parseTs(u.timestamp).toLocaleTimeString());
-  tokensChart = new Chart(ctx, {
-    type: 'bar',
-    data: {
-      labels,
-      datasets: [
-        { label: 'Input', data: sorted.map(u => u.input_tokens), backgroundColor: '#58a6ff', stack: 'tokens' },
-        { label: 'Output', data: sorted.map(u => u.output_tokens), backgroundColor: '#f0883e', stack: 'tokens' },
-        { label: 'Cache Read', data: sorted.map(u => u.cache_read_tokens), backgroundColor: '#3fb950', stack: 'cache' },
-        { label: 'Cache Write', data: sorted.map(u => u.cache_write_tokens), backgroundColor: '#da3633', stack: 'cache' },
-      ]
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      scales: {
-        x: { display: true, ticks: { maxTicksLimit: 12, color: '#8b949e' }, grid: { color: '#21262d' } },
-        y: { ticks: { color: '#8b949e' }, grid: { color: '#21262d' } },
-      },
-      plugins: { legend: { labels: { color: '#e6edf3' } } },
-    }
+  const labels = sorted.map(u => parseTs(u.timestamp));
+  tokensChart = TokenSpyCharts.stackedBar(canvas, {
+    legendEl: document.getElementById('tokens-legend'),
+    labels,
+    labelFormatter: formatTimeTick,
+    datasets: [
+      { label: 'Input', data: sorted.map(u => u.input_tokens || 0), color: '#58a6ff' },
+      { label: 'Output', data: sorted.map(u => u.output_tokens || 0), color: '#f0883e' },
+      { label: 'Cache Read', data: sorted.map(u => u.cache_read_tokens || 0), color: '#3fb950' },
+      { label: 'Cache Write', data: sorted.map(u => u.cache_write_tokens || 0), color: '#da3633' },
+    ],
   });
 }
 
 function renderBreakdownChart(usage) {
-  const ctx = document.getElementById('breakdown-chart').getContext('2d');
+  const canvas = document.getElementById('breakdown-chart');
   if (breakdownChart) breakdownChart.destroy();
   let cacheRead = 0, cacheWrite = 0, input = 0, output = 0;
   usage.forEach(u => {
@@ -2089,29 +2079,22 @@ function renderBreakdownChart(usage) {
   });
   const total = cacheRead + cacheWrite + input + output || 1;
   const pct = v => (v / total * 100).toFixed(1) + '%';
-  breakdownChart = new Chart(ctx, {
-    type: 'doughnut',
-    data: {
-      labels: [
-        'Cache Read ' + pct(cacheRead),
-        'Cache Write ' + pct(cacheWrite),
-        'Input ' + pct(input),
-        'Output ' + pct(output),
-      ],
-      datasets: [{ data: [cacheRead, cacheWrite, input, output], backgroundColor: ['#3fb950', '#da3633', '#58a6ff', '#f0883e'], borderColor: '#161b22', borderWidth: 2 }]
-    },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      plugins: {
-        legend: { position: 'right', labels: { color: '#e6edf3', padding: 12, font: { size: 12 } } },
-        tooltip: { callbacks: { label: (c) => { const v = c.raw; const p = (v / total * 100).toFixed(1); return c.label.split(' ')[0] + ' ' + c.label.split(' ')[1] + ': ' + fmt(v) + ' tokens (' + p + '%)'; } } },
-      },
-    }
+  breakdownChart = TokenSpyCharts.donut(canvas, {
+    legendEl: document.getElementById('breakdown-legend'),
+    labels: [
+      'Cache Read ' + pct(cacheRead),
+      'Cache Write ' + pct(cacheWrite),
+      'Input ' + pct(input),
+      'Output ' + pct(output),
+    ],
+    values: [cacheRead, cacheWrite, input, output],
+    colors: ['#3fb950', '#da3633', '#58a6ff', '#f0883e'],
+    centerText: fmt(total) + ' total',
   });
 }
 
 function renderCumulativeChart(usage) {
-  const ctx = document.getElementById('cumulative-chart').getContext('2d');
+  const canvas = document.getElementById('cumulative-chart');
   if (cumulativeChart) cumulativeChart.destroy();
   const sorted = [...usage].reverse();
   const colors = ['#58a6ff', '#f0883e', '#3fb950', '#a371f7', '#da3633'];
@@ -2134,27 +2117,20 @@ function renderCumulativeChart(usage) {
     }
   });
   const datasets = [
-    { label: 'Total', data: totalData, borderColor: '#e6edf3', borderWidth: 2, pointRadius: 0, tension: 0.1, fill: true, backgroundColor: 'rgba(230,237,243,0.05)' },
+    { label: 'Total', points: totalData, color: '#e6edf3', lineWidth: 2, pointRadius: 0, fillColor: 'rgba(230,237,243,0.05)' },
     ...agents.map((agent, i) => ({
       label: agent,
-      data: agentData[agent],
-      borderColor: colors[i % colors.length],
-      borderWidth: 1.5,
+      points: agentData[agent],
+      color: colors[i % colors.length],
+      lineWidth: 1.5,
       pointRadius: 0,
-      tension: 0.1
     }))
   ];
-  cumulativeChart = new Chart(ctx, {
-    type: 'line',
-    data: { datasets },
-    options: {
-      responsive: true, maintainAspectRatio: false,
-      scales: {
-        x: { type: 'time', time: { tooltipFormat: 'MMM d, HH:mm' }, ticks: { color: '#8b949e', maxTicksLimit: 10 }, grid: { color: '#21262d' } },
-        y: { title: { display: true, text: 'USD', color: '#8b949e' }, ticks: { color: '#8b949e', callback: v => '$' + v.toFixed(2) }, grid: { color: '#21262d' } }
-      },
-      plugins: { legend: { labels: { color: '#e6edf3' } } }
-    }
+  cumulativeChart = TokenSpyCharts.line(canvas, {
+    legendEl: document.getElementById('cumulative-legend'),
+    series: datasets,
+    yFormatter: v => '$' + v.toFixed(2),
+    xFormatter: formatTimeTick,
   });
 }
 
@@ -2305,7 +2281,6 @@ document.getElementById('hours-select').addEventListener('change', loadAll);
 if(_getApiKey()){loadAll()}
 setInterval(function(){if(_getApiKey())loadAll()}, 30000);
 </script>
-<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
 </body>
 </html>"""
 
@@ -2313,6 +2288,11 @@ setInterval(function(){if(_getApiKey())loadAll()}, 30000);
 @app.get("/dashboard", response_class=HTMLResponse)
 def dashboard():
     return DASHBOARD_HTML
+
+
+@app.get("/dashboard-assets/charts.js")
+def dashboard_charts_asset():
+    return FileResponse(Path(__file__).with_name("dashboard_charts.js"), media_type="application/javascript")
 
 
 # ── SSE Token Events Stream ─────────────────────────────────────────────────

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -52,4 +52,13 @@ grep -q 'MINIO_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml.
   grep -q 'MINIO_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml 2>/dev/null || \
   { echo "[FAIL] MinIO telemetry not disabled"; exit 1; }
 
+echo "[contract] Token Spy dashboard ships offline chart assets"
+test -f extensions/services/token-spy/dashboard_charts.js || { echo "[FAIL] missing extensions/services/token-spy/dashboard_charts.js"; exit 1; }
+grep -q '/dashboard-assets/charts.js' extensions/services/token-spy/main.py || \
+  { echo "[FAIL] Token Spy dashboard missing local chart asset reference"; exit 1; }
+if grep -q 'cdn.jsdelivr.net/npm/chart.js\|cdn.jsdelivr.net/npm/chartjs-adapter-date-fns' extensions/services/token-spy/main.py; then
+  echo "[FAIL] Token Spy dashboard still depends on CDN chart assets"
+  exit 1
+fi
+
 echo "[PASS] installer contracts"


### PR DESCRIPTION
## Summary

This removes the shipped Token Spy dashboard's dependency on jsDelivr so the dashboard keeps working in DreamServer offline installs.

Before this change, the dashboard loaded Chart.js and the date adapter from `cdn.jsdelivr.net`. In offline or air-gapped environments, the page would still load but all chart visualizations would fail.

## What changed

- remove external Chart.js and date-adapter script tags from the shipped dashboard HTML
- add a bundled local chart helper at `extensions/services/token-spy/dashboard_charts.js`
- serve that asset from Token Spy at `/dashboard-assets/charts.js`
- replace the Chart.js-based render calls with local canvas rendering for line, stacked bar, and doughnut charts
- add a contract check to prevent jsDelivr chart dependencies from returning to the shipped Token Spy dashboard

## Validation

- `python3 -m py_compile dream-server/extensions/services/token-spy/main.py`
- `node --check dream-server/extensions/services/token-spy/dashboard_charts.js`
- `bash -n dream-server/tests/contracts/test-installer-contracts.sh`
- targeted offline asset check:
  - local `dashboard_charts.js` exists
  - `main.py` references `/dashboard-assets/charts.js`
  - `main.py` no longer references jsDelivr Chart.js assets

## Notes

- this PR is intentionally scoped to the shipped Token Spy dashboard only
- it does not change the separate dashboard service, which still has its own external asset usage
- full `tests/contracts/test-installer-contracts.sh` could not be run locally because `jq` is not installed in this environment
