### PR TITLE
fix(tests): export WEBUI_SECRET stub for compose validation

### DIFF
--- a/dream-server/tests/integration-test.sh
+++ b/dream-server/tests/integration-test.sh
@@ -126,6 +126,9 @@ fi
 # ============================================
 header "2/6" "Docker Compose Validation"
 
+# Provide required compose variables so validation doesn't fail on :? guards
+export WEBUI_SECRET="${WEBUI_SECRET:-test}"
+
 if [[ -z "$COMPOSE_FILE" ]]; then
     fail "No compose file found (expected base+overlay or docker-compose.yml)"
 else


### PR DESCRIPTION
The integration-smoke test fails on current main after #964 added `${WEBUI_SECRET:?...}` to `docker-compose.base.yml`.

The `docker compose config` validation in `integration-test.sh` runs without a `.env`, so the `:?` guard triggers. The `.env.example` fallback also fails because `--env-file` alone doesn't satisfy compose interpolation in all Docker Compose versions.

Fix: export `WEBUI_SECRET` with a dummy value before the compose validation block, matching the existing pattern in `installer-env-smoke.sh:219`.