### PR TITLE
fix(bootstrap): use $DOCKER_CMD for DreamForge restart

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -43,6 +43,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== dream config show secret-mask matrix ==="
 	@bash tests/test-dream-config-secret-mask.sh
+	@echo ""
+	@echo "=== bootstrap OpenClaw compose-guard regression ==="
+	@bash tests/test-bootstrap-openclaw-compose-guard.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -461,7 +461,7 @@ LITELLM_UPGRADE_EOF
         # Restart DreamForge so it auto-detects the new model from llama-server
         if $DOCKER_CMD ps --filter name=dream-dreamforge --format '{{.Names}}' 2>/dev/null | grep -q dream-dreamforge; then
             log "Restarting DreamForge to pick up model change..."
-            docker restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
+            $DOCKER_CMD restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
         fi
         # Recreate OpenClaw so inject-token.js picks up the new GGUF_FILE/LLM_MODEL
         # from .env. A restart alone won't work — env vars are baked in at container

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -466,10 +466,10 @@ LITELLM_UPGRADE_EOF
         # Recreate OpenClaw so inject-token.js picks up the new GGUF_FILE/LLM_MODEL
         # from .env. A restart alone won't work — env vars are baked in at container
         # creation time, and inject-token.js builds the Lemonade model name from them.
-        if docker ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
+        if $DOCKER_CMD ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
             log "Recreating OpenClaw to pick up model change..."
             if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then
-                docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
+                $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
                     log "WARNING: OpenClaw recreate failed (non-fatal)"
             else
                 log "WARNING: No compose args — cannot recreate OpenClaw. Restart manually."

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -495,7 +495,7 @@ LITELLM_UPGRADE_EOF
         # Restart DreamForge so it auto-detects the new model from llama-server
         if $DOCKER_CMD ps --filter name=dream-dreamforge --format '{{.Names}}' 2>/dev/null | grep -q dream-dreamforge; then
             log "Restarting DreamForge to pick up model change..."
-            docker restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
+            $DOCKER_CMD restart dream-dreamforge 2>&1 || log "WARNING: DreamForge restart failed (non-fatal)"
         fi
         # Recreate OpenClaw so inject-token.js picks up the new GGUF_FILE/LLM_MODEL
         # from .env. A restart alone won't work — env vars are baked in at container

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -500,10 +500,10 @@ LITELLM_UPGRADE_EOF
         # Recreate OpenClaw so inject-token.js picks up the new GGUF_FILE/LLM_MODEL
         # from .env. A restart alone won't work — env vars are baked in at container
         # creation time, and inject-token.js builds the Lemonade model name from them.
-        if docker ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
+        if $DOCKER_CMD ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
             log "Recreating OpenClaw to pick up model change..."
             if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then
-                docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
+                $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
                     log "WARNING: OpenClaw recreate failed (non-fatal)"
             else
                 log "WARNING: No compose args — cannot recreate OpenClaw. Restart manually."

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -502,11 +502,19 @@ LITELLM_UPGRADE_EOF
         # creation time, and inject-token.js builds the Lemonade model name from them.
         if $DOCKER_CMD ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
             log "Recreating OpenClaw to pick up model change..."
-            if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then
+            # Guard on BOTH compose args AND a non-empty $DOCKER_COMPOSE_CMD —
+            # mirrors the llama-server hot-swap contract above (the
+            # `${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD"` checks).
+            # If $DOCKER_COMPOSE_CMD is empty (no compose v2 plugin AND no
+            # docker-compose v1 binary), expanding it as the command word
+            # would turn the line into `"${COMPOSE_ARGS[@]}" up -d ...`,
+            # which executes the first compose-arg (e.g. `-f`) as a binary.
+            # Skip the recreate and surface a clear warning instead.
+            if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
                 $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
                     log "WARNING: OpenClaw recreate failed (non-fatal)"
             else
-                log "WARNING: No compose args — cannot recreate OpenClaw. Restart manually."
+                log "WARNING: No compose binary available (DOCKER_COMPOSE_CMD empty or compose args missing) — OpenClaw was NOT recreated. The new model will not take effect until OpenClaw is recreated manually with: docker compose up -d --force-recreate openclaw"
             fi
         fi
         sync_windows_opencode_config

--- a/dream-server/tests/test-bootstrap-openclaw-compose-guard.sh
+++ b/dream-server/tests/test-bootstrap-openclaw-compose-guard.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Regression: bootstrap-upgrade.sh's OpenClaw recreate path must guard on
+# both ${#COMPOSE_ARGS[@]} > 0 AND -n "$DOCKER_COMPOSE_CMD" before
+# expanding $DOCKER_COMPOSE_CMD as the command word.
+# ============================================================================
+# Audit follow-up on PR #974 (Lightheartdevs, 2026-04-28):
+#
+#   "The direction of using $DOCKER_CMD instead of bare docker is right,
+#    but the OpenClaw recreation path can still invoke an empty compose
+#    command when no compose binary is available. Please make that path
+#    use the same compose detection/failure handling contract as the rest
+#    of the installer before merge."
+#
+# Without the second guard, when DOCKER_COMPOSE_CMD is empty (no compose
+# v2 plugin AND no docker-compose v1 binary) but COMPOSE_ARGS is populated,
+# the line `$DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d ...` expands to
+# `"${COMPOSE_ARGS[@]}" up -d ...` and tries to execute the first
+# compose-arg (typically `-f`) as a binary. This test locks in the fix.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   bootstrap-upgrade — OpenClaw compose guard  ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+if [[ ! -f "$TARGET" ]]; then
+    fail "bootstrap-upgrade.sh not found at $TARGET"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+pass "bootstrap-upgrade.sh exists"
+
+# 1. Source-pattern check: the OpenClaw recreate block must contain the
+#    canonical guard pattern. Extract the block via awk between the
+#    "Recreating OpenClaw" log line and the closing fi for that block.
+openclaw_block=$(awk '
+    /Recreating OpenClaw to pick up model change/ { in_block=1 }
+    in_block { print }
+    in_block && /^[[:space:]]+fi[[:space:]]*$/ { fi_count++; if (fi_count == 2) exit }
+' "$TARGET")
+
+if [[ -z "$openclaw_block" ]]; then
+    fail "could not extract OpenClaw recreate block from $TARGET"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+
+# Guard literal — matches the canonical pattern used by the
+# llama-server hot-swap blocks earlier in the file. Single-quoted on
+# purpose: we want the literal $-bearing string for grep, not an
+# expansion.
+# shellcheck disable=SC2016
+canonical='${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD"'
+if grep -qF "$canonical" <<<"$openclaw_block"; then
+    pass "OpenClaw recreate guards on BOTH \${#COMPOSE_ARGS[@]} > 0 AND -n \"\$DOCKER_COMPOSE_CMD\""
+else
+    fail "OpenClaw recreate missing canonical guard"
+    echo "  --- block extracted ---"
+    awk '{print "  " $0}' <<<"$openclaw_block"
+fi
+
+# 2. Source-pattern check: the block must NOT use the single-condition
+#    guard `${#COMPOSE_ARGS[@]} -gt 0` immediately followed by an
+#    unguarded $DOCKER_COMPOSE_CMD invocation. This catches a regression
+#    where someone re-introduces the half-guard.
+single_guard_only='if \[\[ \$\{#COMPOSE_ARGS\[@\]\} -gt 0 \]\]; then$'
+if grep -qE "$single_guard_only" <<<"$openclaw_block"; then
+    fail "OpenClaw recreate uses single-condition guard (regression)"
+else
+    pass "OpenClaw recreate does not use the half-guard form"
+fi
+
+# 3. Behavioural simulation of the guard logic: with DOCKER_COMPOSE_CMD
+#    empty but COMPOSE_ARGS populated, the OLD guard would have tried to
+#    execute the first compose-arg as a command. The NEW guard must
+#    short-circuit to the warning branch.
+old_branch=""; new_branch=""
+COMPOSE_ARGS=(-f /tmp/example-base.yml -f /tmp/example-nvidia.yml)
+DOCKER_COMPOSE_CMD=""
+
+# Old (buggy) form
+if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then
+    old_branch="execute"
+else
+    old_branch="warn"
+fi
+
+# New (fixed) form
+if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
+    new_branch="execute"
+else
+    new_branch="warn"
+fi
+
+if [[ "$old_branch" == "execute" && "$new_branch" == "warn" ]]; then
+    pass "guard logic: old form would execute, new form correctly warns"
+else
+    fail "guard logic: old=$old_branch new=$new_branch (expected old=execute new=warn)"
+fi
+
+# 4. Behavioural simulation of the happy path: with both COMPOSE_ARGS
+#    populated AND DOCKER_COMPOSE_CMD set, the new guard must let
+#    execution through (no false-negative).
+COMPOSE_ARGS=(-f /tmp/example-base.yml)
+DOCKER_COMPOSE_CMD="docker compose"
+
+happy_branch=""
+if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
+    happy_branch="execute"
+else
+    happy_branch="warn"
+fi
+
+if [[ "$happy_branch" == "execute" ]]; then
+    pass "guard logic: happy path correctly proceeds to execute"
+else
+    fail "guard logic: happy path incorrectly warned (false negative)"
+fi
+
+# 5. Behavioural simulation of zero-args: COMPOSE_ARGS empty must also warn.
+COMPOSE_ARGS=()
+DOCKER_COMPOSE_CMD="docker compose"
+
+empty_branch=""
+if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
+    empty_branch="execute"
+else
+    empty_branch="warn"
+fi
+
+if [[ "$empty_branch" == "warn" ]]; then
+    pass "guard logic: empty COMPOSE_ARGS correctly warns"
+else
+    fail "guard logic: empty COMPOSE_ARGS incorrectly executed"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]]

--- a/dream-server/tests/test-bootstrap-openclaw-compose-guard.sh
+++ b/dream-server/tests/test-bootstrap-openclaw-compose-guard.sh
@@ -61,18 +61,26 @@ if [[ -z "$openclaw_block" ]]; then
     echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
 fi
 
+# Strip comment lines before grepping so the canonical-pattern check
+# matches the actual `if [[ ... ]]` statement, not a literal mention
+# of the guard inside the rationale comment block. Without this, a
+# future PR that rewrites the comment but breaks the code would
+# silently pass case #2.
+openclaw_code=$(grep -v '^[[:space:]]*#' <<<"$openclaw_block")
+
 # Guard literal — matches the canonical pattern used by the
 # llama-server hot-swap blocks earlier in the file. Single-quoted on
 # purpose: we want the literal $-bearing string for grep, not an
-# expansion.
+# expansion. Anchored to the `if [[ ... ]];` structural form so a
+# pasted-into-comment occurrence cannot satisfy this check.
 # shellcheck disable=SC2016
-canonical='${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD"'
-if grep -qF "$canonical" <<<"$openclaw_block"; then
+canonical_if='if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]];'
+if grep -qF "$canonical_if" <<<"$openclaw_code"; then
     pass "OpenClaw recreate guards on BOTH \${#COMPOSE_ARGS[@]} > 0 AND -n \"\$DOCKER_COMPOSE_CMD\""
 else
-    fail "OpenClaw recreate missing canonical guard"
-    echo "  --- block extracted ---"
-    awk '{print "  " $0}' <<<"$openclaw_block"
+    fail "OpenClaw recreate missing canonical guard (in active code, not just comments)"
+    echo "  --- code (comments stripped) ---"
+    awk '{print "  " $0}' <<<"$openclaw_code"
 fi
 
 # 2. Source-pattern check: the block must NOT use the single-condition


### PR DESCRIPTION
## What

Three related hardenings to `scripts/bootstrap-upgrade.sh` so the post-download model hot-swap path works on Linux systems where the user isn't in the `docker` group:

1. **Use `$DOCKER_CMD` for DreamForge restart** (commit `66ebc4da`) — replace bare `docker restart dream-dreamforge` with `$DOCKER_CMD restart dream-dreamforge`. The rest of the file already uses `$DOCKER_CMD`.
2. **Same fix for the OpenClaw recreate block** (commit `7e7aaf48`) — both `docker ps` and `docker compose` calls in the OpenClaw block now route through `$DOCKER_CMD` and `$DOCKER_COMPOSE_CMD`.
3. **Audit follow-up — guard `$DOCKER_COMPOSE_CMD` against empty expansion** (commits `af9cd5f7` + `1843db49`) — extend the OpenClaw recreate guard to mirror the canonical pattern at lines 380 and 387.

## Why

On Linux systems where the user isn't in the `docker` group, the bootstrap script needs `sudo docker` to talk to the daemon. The detection block at lines 134-172 sets `DOCKER_CMD="sudo docker"` accordingly. But several invocations were still using bare `docker`, silently failing under the `|| log` fallback.

Maintainer audit (2026-04-28) flagged a deeper issue: even after #2 above, the OpenClaw recreate path's guard was incomplete — it only checked `[[ ${#COMPOSE_ARGS[@]} -gt 0 ]]`. When `DOCKER_COMPOSE_CMD` is empty (no compose v2 plugin AND no docker-compose v1 binary) but `COMPOSE_ARGS` is populated, expanding `$DOCKER_COMPOSE_CMD` as the command word turns the line into `"${COMPOSE_ARGS[@]}" up -d ...`, which tries to execute the first compose-arg (typically `-f`) as a binary.

## How

- `scripts/bootstrap-upgrade.sh:464` — `docker restart dream-dreamforge` → `$DOCKER_CMD restart dream-dreamforge`.
- `scripts/bootstrap-upgrade.sh:469, 472` — `docker ps` / `docker compose` for OpenClaw → `$DOCKER_CMD ps` / `$DOCKER_COMPOSE_CMD`.
- `scripts/bootstrap-upgrade.sh:508` — guard extended to `[[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]`, matching the canonical pattern used by the llama-server hot-swap blocks at lines 380 and 387 byte-for-byte. The else branch now provides a clear warning naming both possible failure modes plus the manual recovery command.

## Testing

- `make lint`, `make test`, `shellcheck` all green.
- New `tests/test-bootstrap-openclaw-compose-guard.sh` (6 cases, wired into `make test`):
  - Source-pattern (active code only — comments stripped before grep): canonical guard literal `if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]];` is present in the OpenClaw recreate block.
  - Anti-regression: the half-guard form `if [[ ${#COMPOSE_ARGS[@]} -gt 0 ]]; then` is NOT present.
  - Behavioural: with `COMPOSE_ARGS=(-f /tmp/...)` and `DOCKER_COMPOSE_CMD=""`, the OLD guard branched to `execute` while the NEW guard correctly branches to `warn`. Plus happy-path (both populated → execute) and empty-args (`COMPOSE_ARGS=()` → warn) cases.
- Live verification on macOS Docker Desktop (carried over from earlier review rounds): with real `.compose-flags` (46 args), `dream-openclaw` container ID changed as expected, returned to healthy in ~10s, no other services touched.

## Review

Local CG **APPROVED WITH WARNINGS** on the audit follow-up. The substantive warning was about test honesty — case #2 (canonical-pattern present) was originally matching the literal pattern inside the rationale comment block as well as the active `if` statement, so a future PR that broke the code but left the comments would have silently passed. Addressed in commit `1843db49`: the test now strips comment lines before the canonical-pattern grep AND anchors on the structural `if [[ ... ]];` form. Case #3 (anti-half-guard) was already load-bearing; this hardens case #2 to actually verify the active code.

## Platform Impact

- **macOS:** Not affected (native llama-server, no docker-based hot-swap path).
- **Linux:** Primary fix target. DreamForge / OpenClaw recreate now work on docker-group-less installs (sudo path) AND fail safely when no compose binary is available.
- **Windows/WSL2:** Not affected (Docker Desktop ships compose v2 plugin; WSL2 inherits).
