### PR TITLE
fix(compose): move depends_on to mode-conditional overlays

### DIFF
--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -67,9 +67,6 @@ services:
     image: ghcr.io/open-webui/open-webui:v0.7.2
     container_name: dream-webui
     restart: unless-stopped
-    depends_on:
-      llama-server:
-        condition: service_healthy
     logging: *default-logging
     security_opt:
       - no-new-privileges:true

--- a/dream-server/docker-compose.local.yml
+++ b/dream-server/docker-compose.local.yml
@@ -1,8 +1,0 @@
-# Mode-specific overlay: included by resolve-compose-stack.sh for local and hybrid modes only.
-# Do NOT add this file to docker-compose directly — it is conditionally included based on DREAM_MODE.
-
-services:
-  open-webui:
-    depends_on:
-      llama-server:
-        condition: service_healthy

--- a/dream-server/extensions/services/dreamforge/compose.local.yaml
+++ b/dream-server/extensions/services/dreamforge/compose.local.yaml
@@ -1,0 +1,5 @@
+services:
+  dreamforge:
+    depends_on:
+      llama-server:
+        condition: service_healthy

--- a/dream-server/extensions/services/dreamforge/compose.yaml
+++ b/dream-server/extensions/services/dreamforge/compose.yaml
@@ -43,9 +43,6 @@ services:
         reservations:
           cpus: '0.5'
           memory: 256M
-    depends_on:
-      llama-server:
-        condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:3010/health"]
       interval: 30s


### PR DESCRIPTION
## What
Move llama-server `depends_on` from unconditional base compose to mode-conditional `compose.local.yaml` overlays.

## Why
`open-webui` and `DreamForge` had unconditional `depends_on: llama-server: condition: service_healthy` in base compose files. In cloud mode (`DREAM_MODE=cloud`), llama-server has no local model, crash-loops, and blocks both services from ever starting. Cloud mode was completely non-functional.

## How
1. Removed `depends_on` from `docker-compose.base.yml` (open-webui section)
2. Removed `depends_on` from `dreamforge/compose.yaml`
3. Created `dreamforge/compose.local.yaml` with the `depends_on` (included only for local/hybrid/lemonade modes by `resolve-compose-stack.sh`)
4. Deleted `docker-compose.local.yml` (dead code — never referenced by resolver)

Follows the pattern already used by 6 other services (open-webui, litellm, openclaw, perplexica, privacy-shield, dashboard).

## Testing
- YAML validation passed
- Resolver logic verified: `compose.local.yaml` discovered for local/hybrid/lemonade, excluded for cloud
- New file format matches existing 6 `compose.local.yaml` files exactly

## Platform Impact
- **macOS:** Latent fix (removes additive depends_on conflict)
- **Linux:** Fixed — cloud mode now starts open-webui and DreamForge
- **Windows/WSL2:** Fixed — same as Linux