### PR TITLE
fix(healthcheck): use 127.0.0.1 instead of localhost/hostname

### DIFF
--- a/dream-server/extensions/services/dreamforge/Dockerfile.rust
+++ b/dream-server/extensions/services/dreamforge/Dockerfile.rust
@@ -43,6 +43,6 @@ EXPOSE 3010
 VOLUME ["/workspace", "/data/dreamforge"]
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
-    CMD curl -f http://localhost:3010/health || exit 1
+    CMD curl -f http://127.0.0.1:3010/health || exit 1
 
 ENTRYPOINT ["dreamforge-server"]

--- a/dream-server/extensions/services/dreamforge/compose.yaml
+++ b/dream-server/extensions/services/dreamforge/compose.yaml
@@ -47,7 +47,7 @@ services:
       llama-server:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3010/health"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:3010/health"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/dream-server/extensions/services/perplexica/compose.yaml
+++ b/dream-server/extensions/services/perplexica/compose.yaml
@@ -26,7 +26,7 @@ services:
           cpus: '0.25'
           memory: 256M
     healthcheck:
-      test: ["CMD", "node", "-e", "const h=require('http');h.get('http://'+require('os').hostname()+':3000/',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "const h=require('http');h.get('http://127.0.0.1:3000/',r=>{process.exit(r.statusCode===200?0:1)}).on('error',()=>process.exit(1))"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
## What
Replace `localhost` and `os.hostname()` with `127.0.0.1` in DreamForge and Perplexica healthchecks.

## Why
DreamForge used `localhost` which can resolve to `::1` (IPv6) on dual-stack kernels — the server binds to `0.0.0.0` (IPv4 only), so the IPv6 connection fails. Perplexica used `require('os').hostname()` which relies on Docker DNS, adding fragility. Both violated the project convention used by all other 17 services.

## How
Three one-line substitutions:
- `dreamforge/compose.yaml` healthcheck: `localhost` → `127.0.0.1`
- `dreamforge/Dockerfile.rust` HEALTHCHECK: `localhost` → `127.0.0.1`
- `perplexica/compose.yaml` healthcheck: `require('os').hostname()` → `127.0.0.1`

## Testing
- YAML valid, `127.0.0.1` confirmed in all 3 files
- Live test: both containers report `healthy` with new healthchecks
- All 19/19 services now consistently use `127.0.0.1`

## Platform Impact
- **macOS:** Fixed (Docker VM dual-stack)
- **Linux:** Fixed (kernel IPv6 loopback)
- **Windows/WSL2:** Fixed (Docker Desktop)