### PR TITLE
fix(shell): replace find|head with find -print -quit

### DIFF
--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -390,7 +390,7 @@ fix_nvidia_secure_boot() {
         fi
     done
     if [[ -z "$sign_file" ]]; then
-        sign_file=$(find /usr/src /usr/lib -name sign-file -executable 2>/dev/null | head -1)
+        sign_file=$(find /usr/src /usr/lib -name sign-file -executable -print -quit 2>/dev/null)
     fi
     if [[ -z "$sign_file" ]]; then
         ai_bad "Cannot find kernel sign-file tool."

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -609,7 +609,7 @@ else
                 fi
 
                 # Find llama-server binary (may be in a subdirectory)
-                FOUND_BIN=$(find "$TEMP_EXTRACT" -name "llama-server" -type f | head -1)
+                FOUND_BIN=$(find "$TEMP_EXTRACT" -name "llama-server" -type f -print -quit)
                 if [[ -n "$FOUND_BIN" ]]; then
                     cp "$FOUND_BIN" "$LLAMA_SERVER_BIN"
                     chmod +x "$LLAMA_SERVER_BIN"


### PR DESCRIPTION
## What
Replace `find ... | head -1` with `find ... -print -quit` in two installer scripts.

## Why
`find | head -1` under `set -euo pipefail` can produce SIGPIPE (exit 141) when find returns multiple results. `head` closes the pipe after reading one line, sending SIGPIPE to `find`, which `pipefail` propagates as a fatal error.

## How
Two one-line substitutions using `-print -quit` which stops `find` after the first match without any pipe:
- `installers/lib/detection.sh` — Linux secure boot sign-file detection
- `installers/macos/install-macos.sh` — llama-server binary extraction

`-print -quit` is portable across both GNU find (Linux) and BSD find (macOS 10.11+).

## Testing
- shellcheck clean (pre-existing SC2034 warnings only)
- `-print -quit` verified portable across GNU/BSD find

## Platform Impact
- **macOS:** Fixed (install-macos.sh)
- **Linux:** Fixed (detection.sh)
- **Windows/WSL2:** Fixed (shares Linux detection.sh)