### PR TITLE
fix(security): generate dedicated DREAM_AGENT_KEY in installers

### DIFF
--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -132,6 +132,8 @@ generate_dream_env() {
     livekit_api_key=$(new_secure_hex 16)
     local dashboard_api_key
     dashboard_api_key=$(new_secure_hex 32)
+    local dream_agent_key
+    dream_agent_key=$(new_secure_hex 32)
     local openclaw_token
     openclaw_token=$(new_secure_hex 24)
     local qdrant_api_key
@@ -221,6 +223,7 @@ LANGFUSE_PORT=3006
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=${webui_secret}
 DASHBOARD_API_KEY=${dashboard_api_key}
+DREAM_AGENT_KEY=${dream_agent_key}
 N8N_USER=admin@dreamserver.local
 N8N_PASS=${n8n_pass}
 LITELLM_KEY=${litellm_key}

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -199,6 +199,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     LITELLM_KEY=$(_env_get LITELLM_KEY "sk-dream-$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
     LIVEKIT_SECRET=$(_env_get LIVEKIT_API_SECRET "$(openssl rand -base64 32 2>/dev/null || head -c 32 /dev/urandom | base64)")
     DASHBOARD_API_KEY=$(_env_get DASHBOARD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
+    DREAM_AGENT_KEY=$(_env_get DREAM_AGENT_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
     DIFY_SECRET_KEY=$(_env_get DIFY_SECRET_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
     QDRANT_API_KEY=$(_env_get QDRANT_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
     OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
@@ -342,6 +343,7 @@ LANGFUSE_PORT=${LANGFUSE_PORT}
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=${WEBUI_SECRET}
 DASHBOARD_API_KEY=${DASHBOARD_API_KEY}
+DREAM_AGENT_KEY=${DREAM_AGENT_KEY}
 N8N_USER=admin@dreamserver.local
 N8N_PASS=${N8N_PASS}
 LITELLM_KEY=${LITELLM_KEY}


### PR DESCRIPTION
## What
Generate a dedicated `DREAM_AGENT_KEY` in both macOS and Linux installers.

## Why
`DREAM_AGENT_KEY` was registered in `.env.schema.json` and preferred by both the host agent and dashboard-api, but never generated by either installer. All installations fell back to `DASHBOARD_API_KEY`, meaning the browser-facing dashboard key doubled as the privileged host agent credential (container management, `.env` writes, extension hooks).

## How
Added 32-byte hex key generation to both Bash-based installers:
- **macOS** (`env-generator.sh`): `new_secure_hex 32` — matches `dashboard_api_key` pattern
- **Linux** (`06-directories.sh`): `_env_get DREAM_AGENT_KEY` with `openssl rand` — uses re-install merge logic to preserve existing keys

No changes needed to host agent, dashboard-api, compose, or schema — wiring already exists.

## Testing
- shellcheck clean
- Live test: `.env` contains `DREAM_AGENT_KEY=<64-char hex>`
- Schema validation passes (key already registered in `.env.schema.json`)
- Existing installs retain `DASHBOARD_API_KEY` fallback (graceful degradation)

## Known Considerations
- Windows installer (`env-generator.ps1`) not updated — tracked separately. DASHBOARD_API_KEY fallback prevents runtime failure.
- Existing macOS installs without `--force` won't get the key (early-return on existing `.env`). Fallback covers this.

## Platform Impact
- **macOS:** Fixed — new installs get dedicated key
- **Linux:** Fixed — new installs get key, re-installs preserve existing
- **Windows/WSL2:** Fallback covers — follow-up planned