### PR TITLE
fix: portable ANSI stripping and narrowed GPU exception

### DIFF
--- a/dream-server/dream-preflight.sh
+++ b/dream-server/dream-preflight.sh
@@ -80,7 +80,7 @@ WARN=0
 
 log() {
     echo -e "$1"
-    echo -e "$1" | sed 's/\x1b\[[0-9;]*m//g' >> "$LOG_FILE"
+    echo -e "$1" | sed $'s/\033\\[[0-9;]*m//g' >> "$LOG_FILE"
 }
 pass() { log "${GREEN}✓${NC} $1"; PASS=$((PASS+1)); }
 fail() { log "${RED}✗${NC} $1"; FAIL=$((FAIL+1)); }

--- a/dream-server/extensions/services/dashboard-api/routers/models.py
+++ b/dream-server/extensions/services/dashboard-api/routers/models.py
@@ -79,7 +79,8 @@ def _get_gpu_vram() -> Optional[ModelLibraryGpu]:
             vramUsed=round(used_gb, 1),
             vramFree=round(total_gb - used_gb, 1),
         )
-    except Exception:
+    except (ImportError, FileNotFoundError, OSError, KeyError, AttributeError) as exc:
+        logger.warning("GPU VRAM detection failed: %s", exc)
         return None
 
 

--- a/dream-server/extensions/services/dashboard-api/routers/models.py
+++ b/dream-server/extensions/services/dashboard-api/routers/models.py
@@ -20,6 +20,20 @@ router = APIRouter(tags=["models"])
 _LIBRARY_PATH = Path(INSTALL_DIR) / "config" / "model-library.json"
 _MODELS_DIR = Path(DATA_DIR) / "models"
 _ENV_PATH = Path(INSTALL_DIR) / ".env"
+_GPU_VRAM_EXCEPTIONS = (
+    ImportError,
+    FileNotFoundError,
+    OSError,
+    KeyError,
+    AttributeError,
+)
+
+try:
+    import pynvml
+except ImportError:
+    pynvml = None
+else:
+    _GPU_VRAM_EXCEPTIONS = _GPU_VRAM_EXCEPTIONS + (pynvml.NVMLError,)
 
 
 def _load_library() -> list[dict]:
@@ -79,7 +93,7 @@ def _get_gpu_vram() -> Optional[ModelLibraryGpu]:
             vramUsed=round(used_gb, 1),
             vramFree=round(total_gb - used_gb, 1),
         )
-    except (ImportError, FileNotFoundError, OSError, KeyError, AttributeError) as exc:
+    except _GPU_VRAM_EXCEPTIONS as exc:
         logger.warning("GPU VRAM detection failed: %s", exc)
         return None
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_models.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_models.py
@@ -1,0 +1,40 @@
+"""Focused tests for the models router helpers."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def test_get_gpu_vram_returns_none_on_nvml_error(monkeypatch):
+    """Operational NVML failures should degrade to unknown GPU rather than 500."""
+
+    class FakeNVMLError(Exception):
+        pass
+
+    def _raise_nvml_error():
+        raise FakeNVMLError("driver not loaded")
+
+    real_gpu = sys.modules.get("gpu")
+    real_pynvml = sys.modules.get("pynvml")
+
+    monkeypatch.setitem(sys.modules, "gpu", types.SimpleNamespace(get_gpu_info=_raise_nvml_error))
+    monkeypatch.setitem(sys.modules, "pynvml", types.SimpleNamespace(NVMLError=FakeNVMLError))
+
+    import routers.models as models_router
+
+    importlib.reload(models_router)
+    assert models_router._get_gpu_vram() is None
+
+    if real_gpu is None:
+        monkeypatch.delitem(sys.modules, "gpu", raising=False)
+    else:
+        monkeypatch.setitem(sys.modules, "gpu", real_gpu)
+
+    if real_pynvml is None:
+        monkeypatch.delitem(sys.modules, "pynvml", raising=False)
+    else:
+        monkeypatch.setitem(sys.modules, "pynvml", real_pynvml)
+
+    importlib.reload(models_router)


### PR DESCRIPTION
## What
Two targeted error handling fixes: portable sed ANSI stripping and narrowed GPU detection exception.

## Why
1. `dream-preflight.sh` used `\x1b` hex escape in sed regex — older BSD sed (macOS) treats this literally, leaving raw ANSI codes in log files.
2. `routers/models.py` caught bare `Exception` in GPU VRAM detection, silently hiding all errors (including programming bugs) per a blanket `return None`.

## How
1. **sed fix:** Changed `\x1b` to `$'\033'` (Bash ANSI-C quoting). The shell resolves the escape before sed sees it — works on all platforms.
2. **Python fix:** Narrowed `except Exception` to `(ImportError, FileNotFoundError, OSError, KeyError, AttributeError)` with `logger.warning()`. Covers I/O-boundary failures while letting programming errors propagate visibly.

The `fitsVram=True` fallback when GPU is unknown is deliberately unchanged — it's the optimistic path that lets users browse and download models even when GPU detection fails.

## Testing
- shellcheck clean, Python compile OK
- pytest: 172/173 pass (1 pre-existing failure in unrelated test)
- `logger` already defined in models.py (line 16)

## Platform Impact
- **macOS:** Fixed (BSD sed portability for older versions)
- **Linux:** Fixed (narrowed exception + logging visibility)
- **Windows/WSL2:** Fixed (same Python code)