### PR TITLE
fix(dreamforge): pin image to v0.1.0 for reproducible deployments

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -256,7 +256,7 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # LLAMA_SERVER_MEMORY_LIMIT=64G
 
 #=== DreamForge (Local Agentic Coding) ===
-# DREAMFORGE_IMAGE=ghcr.io/light-heart-labs/dreamforge:latest
+# DREAMFORGE_IMAGE=ghcr.io/light-heart-labs/dreamforge:v0.1.0
 # DREAMFORGE_PORT=3010
 # DREAMFORGE_PERMISSION_MODE=accept_edits
 # DREAMFORGE_MAX_TURNS=25

--- a/dream-server/extensions/services/dreamforge/compose.yaml
+++ b/dream-server/extensions/services/dreamforge/compose.yaml
@@ -1,6 +1,6 @@
 services:
   dreamforge:
-    image: ${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:latest}
+    image: ${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:v0.1.0}
     build:
       context: ./extensions/services/dreamforge
       dockerfile: Dockerfile.rust

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -47,7 +47,7 @@ fi
 [[ "$ENABLE_RAG" == "true" ]] && PULL_LIST+=("qdrant/qdrant:v1.16.3|QDRANT — memory vault")
 [[ "$ENABLE_OPENCLAW" == "true" ]] && PULL_LIST+=("ghcr.io/openclaw/openclaw:2026.3.8|OPENCLAW — agent framework")
 [[ "$ENABLE_RAG" == "true" ]] && PULL_LIST+=("ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1|TEI — embedding engine")
-[[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && PULL_LIST+=("ghcr.io/light-heart-labs/dreamforge:latest|DREAMFORGE — agent system")
+[[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && PULL_LIST+=("ghcr.io/light-heart-labs/dreamforge:v0.1.0|DREAMFORGE — agent system")
 
 if $DRY_RUN; then
     ai "[DRY RUN] I would download ${#PULL_LIST[@]} modules."

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -313,7 +313,7 @@ MODELS_INI_EOF
     _build_services=(dashboard dashboard-api ape token-spy privacy-shield)
     [[ "$ENABLE_COMFYUI" == "true" ]] && _build_services+=(comfyui)
     if [[ "${ENABLE_DREAMFORGE:-}" == "true" ]]; then
-        _dreamforge_image="${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:latest}"
+        _dreamforge_image="${DREAMFORGE_IMAGE:-ghcr.io/light-heart-labs/dreamforge:v0.1.0}"
         if ! $DOCKER_CMD image inspect "$_dreamforge_image" &>/dev/null; then
             _build_services+=(dreamforge)
         else


### PR DESCRIPTION
## What
Pin DreamForge image from `:latest` to `:v0.1.0` across all 4 reference locations.

## Why
DreamForge was the only service using `:latest`. All other 9+ services use pinned version tags. Installs at different times could pull different DreamForge binaries, making regression bugs impossible to bisect.

## How
Changed `:latest` to `:v0.1.0` (from `Cargo.toml`) in all 4 locations:
- `extensions/services/dreamforge/compose.yaml` — runtime image
- `installers/phases/08-images.sh` — pre-pull list
- `installers/phases/11-services.sh` — build-skip check
- `.env.example` — documented override example

The `DREAMFORGE_IMAGE` env var override remains available for user customization.

## Testing
- YAML valid
- grep confirms zero `:latest` references remain for dreamforge
- Install flow coherent: pre-pull → build-skip → compose all use same tag

## Platform Impact
- **macOS:** Compose tag updated
- **Linux:** Full coverage (installer phases + compose)
- **Windows/WSL2:** Compose tag updated