### PR TITLE
fix(whisper): verify STT model download + stop lying in failure message

### DIFF
--- a/dream-server/extensions/services/whisper/README.md
+++ b/dream-server/extensions/services/whisper/README.md
@@ -61,7 +61,24 @@ VAD parameters injected:
 
 ## Data Persistence
 
-Downloaded models are cached in `data/whisper/` (mounted at `/home/ubuntu/.cache/huggingface/hub` inside the container). Models are downloaded automatically on first use.
+Downloaded models are cached in `data/whisper/` (mounted at `/home/ubuntu/.cache/huggingface/hub` inside the container).
+
+## Model Downloads
+
+**Important:** Speaches does NOT auto-download models on transcription requests — it returns `404 Model ... is not installed locally` if the model isn't already cached. The installer's Phase 12 (`installers/phases/12-health.sh`) pre-downloads the default STT model by triggering `POST /v1/models/{id}` against the service.
+
+If the pre-download fails (network issue, models API not ready in time), run the recovery command manually:
+
+```bash
+# For AMD / CPU / Intel (default: base model, ~130MB):
+curl -X POST http://localhost:9000/v1/models/Systran%2Ffaster-whisper-base
+
+# For NVIDIA (default: large-v3 turbo, ~1.5GB):
+curl -X POST http://localhost:9000/v1/models/deepdml%2Ffaster-whisper-large-v3-turbo-ct2
+
+# Wait 2-5 minutes (depending on model size + network). Verify it cached:
+curl http://localhost:9000/v1/models
+```
 
 ## Files
 
@@ -85,8 +102,9 @@ docker compose logs whisper
 - The patch targets a specific line in the speaches source; if the upstream image changes, the patch may be skipped silently
 - Check logs for `[dream-whisper] WARNING: Target pattern not found`
 
-**Model download hanging:**
-- Whisper downloads models from HuggingFace on first use; allow a few minutes
+**Model download failed during install / STT returns 404:**
+- Speaches does not auto-download on transcription — run the recovery `curl -X POST ...` command from the **Model Downloads** section above
+- Downloads come from HuggingFace; allow 2-5 minutes for the ~130MB base model (or ~1.5GB for NVIDIA turbo)
 - Check container logs: `docker compose logs -f whisper`
 
 **Open WebUI not using Whisper:**

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -163,8 +163,9 @@ dream_progress 95 "health" "Checking voice services"
 [[ "$ENABLE_VOICE" == "true" ]] && _check_health "Kokoro (TTS)" "http://localhost:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 150 10
 
 # Pre-download the Whisper STT model so first transcription is instant.
-# Speaches lazy-downloads on first request, but that causes a long delay +
-# a 404 if the model isn't cached yet. Trigger the download now.
+# Speaches does NOT auto-download on transcription requests — it returns 404.
+# We must trigger the download explicitly here, verify it completed, and
+# surface a clear recovery command if anything fails.
 if [[ "$ENABLE_VOICE" == "true" ]]; then
     if [[ "$GPU_BACKEND" == "nvidia" ]]; then
         STT_MODEL="deepdml/faster-whisper-large-v3-turbo-ct2"
@@ -172,15 +173,43 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
         STT_MODEL="Systran/faster-whisper-base"
     fi
     STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
-    WHISPER_URL="http://localhost:${SERVICE_PORTS[whisper]:-9000}"
-    # Only download if model isn't already loaded
-    if ! curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" &>/dev/null; then
-        ai "Downloading STT model (${STT_MODEL})..."
-        curl -sf --max-time 3600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >> "$LOG_FILE" 2>&1 && \
-            printf "\r  ${BGRN}✓${NC} %-60s\n" "STT model cached (${STT_MODEL})" || \
-            printf "\r  ${AMB}⚠${NC} %-60s\n" "STT model will download on first use"
-    else
+    WHISPER_PORT_RESOLVED="${SERVICE_PORTS[whisper]:-9000}"
+    WHISPER_URL="http://localhost:${WHISPER_PORT_RESOLVED}"
+    STT_RECOVERY_CMD="curl -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
+
+    # Step 1: wait briefly for the models API to be ready. Whisper's /health
+    # endpoint can pass before the models endpoint responds, so we probe
+    # GET /v1/models with a short retry loop (max 15s total).
+    _stt_api_ready=false
+    for _i in $(seq 1 15); do
+        if curl -sf --max-time 2 "${WHISPER_URL}/v1/models" &>/dev/null; then
+            _stt_api_ready=true
+            break
+        fi
+        sleep 1
+    done
+
+    if ! $_stt_api_ready; then
+        printf "\r  ${AMB}⚠${NC} %-60s\n" "STT models API not ready — download manually:"
+        printf "      %s\n" "$STT_RECOVERY_CMD"
+    # Step 2: skip download if already cached.
+    elif curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" &>/dev/null; then
         printf "\r  ${BGRN}✓${NC} %-60s\n" "STT model already cached (${STT_MODEL})"
+    else
+        # Step 3: POST to trigger download. Log stdout/stderr to install log.
+        ai "Downloading STT model (${STT_MODEL})..."
+        curl -s --max-time 3600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" \
+            >> "$LOG_FILE" 2>&1
+
+        # Step 4: verify the model is actually cached. POST can return 200
+        # even if the download partially fails, so this GET is the real test.
+        if curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" &>/dev/null; then
+            printf "\r  ${BGRN}✓${NC} %-60s\n" "STT model cached (${STT_MODEL})"
+        else
+            printf "\r  ${AMB}⚠${NC} %-60s\n" "STT model download failed — run manually:"
+            printf "      %s\n" "$STT_RECOVERY_CMD"
+            printf "      %s\n" "See $LOG_FILE for details."
+        fi
     fi
 fi
 


### PR DESCRIPTION
## Summary

Fixes #982 — Users installing DreamServer on AMD (and other non-NVIDIA) hardware report getting `HTTP 404: Model 'Systran/faster-whisper-base' is not installed locally` when trying to use STT. The README and installer both claimed the model would download automatically — it doesn't.

## Root cause (three compounding bugs)

1. **Phase 12 lied in the failure branch.** `installers/phases/12-health.sh:179-181` used `curl -sf ... && ... || "STT model will download on first use"`. Speaches does **not** auto-download on transcription — it returns 404. So when the pre-download POST failed silently (timing, network, models API not ready), the installer assured the user it would work later. It didn't.

2. **Phase 12 didn't verify the download succeeded.** A successful POST doesn't guarantee the model cached correctly. Some speaches versions return 200 on "download started" but fail mid-transfer.

3. **`whisper/README.md` made false claims.** Lines 64 and 89 both stated "Models are downloaded automatically on first use" — this contradicts actual speaches behavior.

## Changes

### `installers/phases/12-health.sh`
- **Step 1 (new):** 15s readiness probe for `GET /v1/models` before the POST. Whisper's `/health` can pass before the models API is ready, causing the POST to fail.
- **Step 2:** Skip if already cached (unchanged behavior).
- **Step 3:** POST to trigger download with the existing 3600s timeout.
- **Step 4 (new):** Verify the model is actually cached via GET after POST.
- **Failure message:** Replaced the misleading "will download on first use" with a copy-paste recovery curl command and a pointer to the install log.

### `extensions/services/whisper/README.md`
- Removed the false "automatic download on first use" claim.
- Added a **Model Downloads** section that correctly explains speaches' behavior and provides recovery curl commands for both AMD/CPU (base model, ~130MB) and NVIDIA (large-v3 turbo, ~1.5GB) paths.
- Updated the troubleshooting entry to match.

## What's NOT changed

- No compose, schema, or env changes
- No change to model selection logic (NVIDIA → turbo-v3, else → base)
- No change to speaches image or Whisper service config
- Install still completes on STT download failure — we warn loudly but don't abort, so users behind flaky HuggingFace connections aren't blocked

## Test plan

- [x] Shell syntax check: `bash -n 12-health.sh`
- [x] Review README renders correctly
- [ ] Fresh install on AMD — verify "STT model cached (Systran/faster-whisper-base)" appears
- [ ] Fresh install on NVIDIA — verify turbo-v3 downloads
- [ ] Simulate failure (stop whisper container after health check) — verify the recovery curl command appears
- [ ] Existing-cache case: reinstall — verify "STT model already cached" appears
- [ ] ENABLE_VOICE=false install — verify STT block is skipped entirely

## Follow-up (not in this PR)

- Add `dream stt download` CLI wrapper for the recovery curl
- Add STT model presence to `dream doctor` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)