### PR TITLE
feat(whisper): macOS/Windows STT parity + AUDIO_STT_MODEL env var

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -188,6 +188,14 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # Whisper model (tiny, base, small, medium, large-v3-turbo)
 # WHISPER_MODEL=base
 
+# Whisper STT model (HuggingFace repo ID). Installer auto-selects by GPU:
+#   NVIDIA  → deepdml/faster-whisper-large-v3-turbo-ct2 (faster, ~1.5GB)
+#   AMD/CPU → Systran/faster-whisper-base (~130MB)
+# Override to use a different model — must then run `dream restart` and
+# manually download the new model via:
+#   curl -X POST --max-time 3600 http://localhost:9000/v1/models/<url-encoded-model-id>
+# AUDIO_STT_MODEL=Systran/faster-whisper-base
+
 # Kokoro TTS voice name
 # TTS_VOICE=en_US-lessac-medium
 

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -299,6 +299,11 @@
       "description": "Whisper STT model size",
       "default": "base"
     },
+    "AUDIO_STT_MODEL": {
+      "type": "string",
+      "description": "Whisper STT model (HuggingFace repo ID). Auto-set by installer based on GPU backend: NVIDIA picks large-v3-turbo (faster, ~1.5GB), others pick base (~130MB). Edit in .env to override, then run `dream restart` (or reinstall).",
+      "default": "Systran/faster-whisper-base"
+    },
     "TIMEZONE": {
       "type": "string",
       "description": "System timezone",

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -111,7 +111,7 @@ services:
       AUDIO_STT_ENGINE: "openai"
       AUDIO_STT_OPENAI_API_BASE_URL: "http://whisper:8000/v1"
       AUDIO_STT_OPENAI_API_KEY: ""
-      AUDIO_STT_MODEL: "Systran/faster-whisper-base"
+      AUDIO_STT_MODEL: "${AUDIO_STT_MODEL:-Systran/faster-whisper-base}"
       # ── Text-to-Speech (Kokoro) ──
       AUDIO_TTS_ENGINE: "openai"
       AUDIO_TTS_OPENAI_API_BASE_URL: "http://tts:8880/v1"

--- a/dream-server/extensions/services/whisper/README.md
+++ b/dream-server/extensions/services/whisper/README.md
@@ -65,16 +65,32 @@ Downloaded models are cached in `data/whisper/` (mounted at `/home/ubuntu/.cache
 
 ## Model Downloads
 
-**Important:** Speaches does NOT auto-download models on transcription requests — it returns `404 Model ... is not installed locally` if the model isn't already cached. The installer's Phase 12 (`installers/phases/12-health.sh`) pre-downloads the default STT model by triggering `POST /v1/models/{id}` against the service.
+**Important:** Speaches does NOT auto-download models on transcription requests — it returns `404 Model ... is not installed locally` if the model isn't already cached.
+
+The installer pre-downloads the STT model on all platforms:
+- **Linux:** Phase 12 (`installers/phases/12-health.sh`)
+- **macOS:** `installers/macos/install-macos.sh` (post-health check)
+- **Windows:** `installers/windows/install-windows.ps1` (post-health check)
+
+The model to download is controlled by the `AUDIO_STT_MODEL` variable in `.env`:
+- **NVIDIA default:** `deepdml/faster-whisper-large-v3-turbo-ct2` (~1.5GB)
+- **macOS / AMD / CPU default:** `Systran/faster-whisper-base` (~130MB)
+
+Edit `AUDIO_STT_MODEL` in `.env` to use a different model, then reinstall or manually run the recovery command below. Open WebUI automatically picks up the same `AUDIO_STT_MODEL` value so transcription requests always match the cached model.
+
+### Recovery
 
 If the pre-download fails (network issue, models API not ready in time), run the recovery command manually:
 
 ```bash
-# For AMD / CPU / Intel (default: base model, ~130MB):
-curl -X POST http://localhost:9000/v1/models/Systran%2Ffaster-whisper-base
+# Linux / macOS — the model ID from your .env:
+curl --max-time 3600 -X POST http://localhost:9000/v1/models/Systran%2Ffaster-whisper-base
 
-# For NVIDIA (default: large-v3 turbo, ~1.5GB):
-curl -X POST http://localhost:9000/v1/models/deepdml%2Ffaster-whisper-large-v3-turbo-ct2
+# For NVIDIA turbo:
+curl --max-time 3600 -X POST http://localhost:9000/v1/models/deepdml%2Ffaster-whisper-large-v3-turbo-ct2
+
+# Windows (PowerShell):
+Invoke-WebRequest -Method POST -Uri 'http://localhost:9000/v1/models/Systran%2Ffaster-whisper-base' -TimeoutSec 3600
 
 # Wait 2-5 minutes (depending on model size + network). Verify it cached:
 curl http://localhost:9000/v1/models

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1093,6 +1093,55 @@ for ((idx=0; idx<${#HEALTH_NAMES[@]}; idx++)); do
     fi
 done
 
+# ── Pre-download the Whisper STT model ──
+# Speaches does NOT auto-download on transcription requests — it returns 404.
+# We must trigger the download explicitly here, verify it completed, and
+# surface a clear recovery command if anything fails.
+if [[ "$ENABLE_VOICE" == "true" ]]; then
+    # Read AUDIO_STT_MODEL from .env (written by env-generator). On macOS the
+    # default is base; user can override by editing .env before reinstalling.
+    STT_MODEL=$(grep -m1 '^AUDIO_STT_MODEL=' "${INSTALL_DIR}/.env" 2>/dev/null \
+                | cut -d= -f2- | tr -d '"' | tr -d '\r' || true)
+    [[ -z "$STT_MODEL" ]] && STT_MODEL="Systran/faster-whisper-base"
+    STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
+    # macOS reassigns Whisper to 9100 if port 9000 is in use (AirPlay Receiver).
+    WHISPER_PORT_RESOLVED="${WHISPER_PORT:-9000}"
+    WHISPER_URL="http://localhost:${WHISPER_PORT_RESOLVED}"
+    STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
+
+    # Step 1: wait briefly for the models API to be ready (max 15s).
+    _stt_api_ready=false
+    for _i in $(seq 1 15); do
+        if curl -sf --max-time 2 "${WHISPER_URL}/v1/models" &>/dev/null; then
+            _stt_api_ready=true
+            break
+        fi
+        sleep 1
+    done
+
+    if ! $_stt_api_ready; then
+        ai_warn "STT models API not ready -- download manually:"
+        echo "    $STT_RECOVERY_CMD"
+    # Step 2: skip if already cached.
+    elif curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" &>/dev/null; then
+        ai_ok "STT model already cached (${STT_MODEL})"
+    else
+        # Step 3: POST to trigger download.
+        ai "Downloading STT model (${STT_MODEL})..."
+        curl -s --max-time 3600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" \
+            >> "$DS_LOG_FILE" 2>&1 || true
+
+        # Step 4: verify the model is actually cached.
+        if curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" &>/dev/null; then
+            ai_ok "STT model cached (${STT_MODEL})"
+        else
+            ai_warn "STT model download failed -- run manually:"
+            echo "    $STT_RECOVERY_CMD"
+            echo "    See $DS_LOG_FILE for details."
+        fi
+    fi
+fi
+
 # ── Auto-configure Perplexica ──
 ai "Configuring Perplexica..."
 if configure_perplexica 3004 "$LLM_MODEL"; then

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -236,6 +236,10 @@ OPENCODE_SERVER_PASSWORD=${opencode_password}
 
 #=== Voice Settings ===
 WHISPER_MODEL=base
+# Whisper STT model. macOS (Apple Silicon, Metal) uses base by default —
+# Metal performance is good enough for most transcription needs. Override
+# here and run 'dream-macos.sh restart' to use a different model.
+AUDIO_STT_MODEL=Systran/faster-whisper-base
 TTS_VOICE=en_US-lessac-medium
 
 #=== Web UI Settings ===

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -249,6 +249,16 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     # Network binding (--lan sets 0.0.0.0; default is localhost-only)
     BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
 
+    # Whisper STT model — NVIDIA picks the larger turbo model, everyone else
+    # uses base. Phase 12 reads this to pre-download the right file, and
+    # Open WebUI reads it to request the same model for transcription.
+    if [[ "$GPU_BACKEND" == "nvidia" ]]; then
+        _default_stt_model="deepdml/faster-whisper-large-v3-turbo-ct2"
+    else
+        _default_stt_model="Systran/faster-whisper-base"
+    fi
+    AUDIO_STT_MODEL=$(_env_get AUDIO_STT_MODEL "${AUDIO_STT_MODEL:-$_default_stt_model}")
+
     # Preserve user-supplied cloud API keys
     ANTHROPIC_API_KEY=$(_env_get ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}")
     OPENAI_API_KEY=$(_env_get OPENAI_API_KEY "${OPENAI_API_KEY:-}")
@@ -355,6 +365,9 @@ DIFY_SECRET_KEY=${DIFY_SECRET_KEY}
 
 #=== Voice Settings ===
 WHISPER_MODEL=base
+# Whisper STT model passed to Open WebUI and pre-downloaded by Phase 12.
+# Auto-selected based on GPU backend; edit to override.
+AUDIO_STT_MODEL=${AUDIO_STT_MODEL}
 TTS_VOICE=en_US-lessac-medium
 
 #=== Web UI Settings ===

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -167,7 +167,11 @@ dream_progress 95 "health" "Checking voice services"
 # We must trigger the download explicitly here, verify it completed, and
 # surface a clear recovery command if anything fails.
 if [[ "$ENABLE_VOICE" == "true" ]]; then
-    if [[ "$GPU_BACKEND" == "nvidia" ]]; then
+    # Prefer AUDIO_STT_MODEL from .env (written by Phase 06). Fall back to the
+    # GPU_BACKEND switch for backward compat with older .env files missing it.
+    if [[ -n "${AUDIO_STT_MODEL:-}" ]]; then
+        STT_MODEL="$AUDIO_STT_MODEL"
+    elif [[ "$GPU_BACKEND" == "nvidia" ]]; then
         STT_MODEL="deepdml/faster-whisper-large-v3-turbo-ct2"
     else
         STT_MODEL="Systran/faster-whisper-base"

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -657,6 +657,74 @@ foreach ($check in $healthChecks) {
     }
 }
 
+# ── Pre-download the Whisper STT model ───────────────────────────────────────
+# Speaches does NOT auto-download on transcription requests — it returns 404.
+# Trigger the download explicitly, verify it completed, surface recovery
+# instructions on failure. Mirrors Linux Phase 12 and macOS install-macos.sh.
+if ($enableVoice) {
+    # Read AUDIO_STT_MODEL from .env (written by env-generator.ps1).
+    $sttModel = "Systran/faster-whisper-base"  # safe fallback
+    $envPath = Join-Path $installDir ".env"
+    if (Test-Path $envPath) {
+        $envLine = Get-Content $envPath -ErrorAction SilentlyContinue | Where-Object { $_ -match "^AUDIO_STT_MODEL=(.+)$" } | Select-Object -First 1
+        if ($envLine -match "^AUDIO_STT_MODEL=(.+)$") {
+            $sttModel = $Matches[1].Trim('"').Trim()
+        }
+    }
+    $sttModelEncoded = $sttModel -replace "/", "%2F"
+    $whisperPort = 9000  # Windows doesn't reassign this port
+    $whisperUrl = "http://localhost:$whisperPort"
+    $sttRecoveryCmd = "Invoke-WebRequest -Method POST -Uri '$whisperUrl/v1/models/$sttModelEncoded' -TimeoutSec 3600"
+
+    # Step 1: wait briefly for the models API to be ready (max 15s).
+    $sttApiReady = $false
+    for ($i = 1; $i -le 15; $i++) {
+        try {
+            $probe = Invoke-WebRequest -Uri "$whisperUrl/v1/models" -TimeoutSec 2 -UseBasicParsing -ErrorAction Stop
+            if ($probe.StatusCode -eq 200) { $sttApiReady = $true; break }
+        } catch { }
+        Start-Sleep -Seconds 1
+    }
+
+    if (-not $sttApiReady) {
+        Write-AIWarn "STT models API not ready -- download manually:"
+        Write-Host "    $sttRecoveryCmd" -ForegroundColor DarkGray
+    } else {
+        # Step 2: skip if already cached.
+        $alreadyCached = $false
+        try {
+            $check = Invoke-WebRequest -Uri "$whisperUrl/v1/models/$sttModelEncoded" -TimeoutSec 10 -UseBasicParsing -ErrorAction Stop
+            if ($check.StatusCode -eq 200) { $alreadyCached = $true }
+        } catch { }
+
+        if ($alreadyCached) {
+            Write-AISuccess "STT model already cached ($sttModel)"
+        } else {
+            # Step 3: POST to trigger download.
+            Write-AI "Downloading STT model ($sttModel)..."
+            try {
+                Invoke-WebRequest -Method POST -Uri "$whisperUrl/v1/models/$sttModelEncoded" -TimeoutSec 3600 -UseBasicParsing -ErrorAction Stop | Out-Null
+            } catch {
+                # Fall through to verification step regardless — POST can succeed or partial-fail.
+            }
+
+            # Step 4: verify the model is actually cached.
+            $verified = $false
+            try {
+                $verify = Invoke-WebRequest -Uri "$whisperUrl/v1/models/$sttModelEncoded" -TimeoutSec 10 -UseBasicParsing -ErrorAction Stop
+                if ($verify.StatusCode -eq 200) { $verified = $true }
+            } catch { }
+
+            if ($verified) {
+                Write-AISuccess "STT model cached ($sttModel)"
+            } else {
+                Write-AIWarn "STT model download failed -- run manually:"
+                Write-Host "    $sttRecoveryCmd" -ForegroundColor DarkGray
+            }
+        }
+    }
+}
+
 # ── Auto-configure Perplexica ─────────────────────────────────────────────────
 Write-AI "Configuring Perplexica..."
 $perplexicaOk = Set-PerplexicaConfig -PerplexicaPort 3004 -LlmModel $tierConfig.LlmModel

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -298,6 +298,10 @@ DIFY_SECRET_KEY=$difySecretKey
 
 #=== Voice Settings ===
 WHISPER_MODEL=base
+# Whisper STT model — NVIDIA uses the larger turbo model, others use base.
+# Open WebUI reads this to request transcription; installer pre-downloads
+# the same model so the first transcription works.
+AUDIO_STT_MODEL=$(Get-EnvOrNew "AUDIO_STT_MODEL" $(if ($GpuBackend -eq "nvidia") { "deepdml/faster-whisper-large-v3-turbo-ct2" } else { "Systran/faster-whisper-base" }))
 TTS_VOICE=en_US-lessac-medium
 
 #=== Web UI Settings ===


### PR DESCRIPTION
## Summary

**Base branch:** `fix/stt-model-download-verification` (PR #984). Merge that one first, then this.

This PR builds on #984 to close three gaps identified during its self-audit:

1. **macOS has no STT pre-download.** macOS users hit the same 404 bug Linux users had before #984. Fixed by porting the Phase 12 logic inline.
2. **Windows has no STT pre-download.** Same bug. Fixed via PowerShell port using `Invoke-WebRequest`.
3. **NVIDIA users silently broken.** Phase 12 downloaded the turbo model but Open WebUI's compose hardcoded `AUDIO_STT_MODEL=Systran/faster-whisper-base`. Every NVIDIA transcription 404'd. Fixed by making `AUDIO_STT_MODEL` a real env var with per-platform defaults.

## Changes

### Area 1 — `AUDIO_STT_MODEL` becomes a proper env var (5 files)
- `docker-compose.base.yml`: `AUDIO_STT_MODEL: "${AUDIO_STT_MODEL:-Systran/faster-whisper-base}"`
- `.env.schema.json` + `.env.example`: documented
- Linux/macOS/Windows env-generators write the variable based on GPU backend

### Area 2 — Phase 12 reads from env
- Falls back to the `GPU_BACKEND` switch for backward compat with older `.env` files

### Area 3 — macOS installer STT pre-download
- Inserted after the health-check loop, before Perplexica config
- 4-step logic: API readiness probe → cache check → POST → verify
- Respects macOS's WHISPER_PORT reassignment (AirPlay port 9000 conflict)
- Uses existing `ai`/`ai_ok`/`ai_warn` helpers

### Area 4 — Windows installer STT pre-download
- PowerShell port using `Invoke-WebRequest -UseBasicParsing`
- Same 4 steps, platform-appropriate recovery command
- Uses existing `Write-AI*` helpers

### Area 5 — whisper README updated
- Per-platform recovery commands
- `AUDIO_STT_MODEL` override documented
- Curl commands now include `--max-time 3600`

## Why this is safe

- **Default behavior unchanged for existing installs** — `AUDIO_STT_MODEL` falls back everywhere
- **Fixes a real broken path** — NVIDIA users currently 404 on every transcription
- **macOS/Windows gain what Linux got** in #984
- **No CLI, doctor, or API changes** — those gaps belong in separate focused PRs
- **URL encoding identical across platforms** (bash `//\//%2F` == PowerShell `-replace '/', '%2F'`)

## Test plan

- [x] `bash -n` on all modified shell files
- [x] PowerShell parse check on both modified `.ps1` files
- [x] `docker compose config` with `AUDIO_STT_MODEL=deepdml/...` → resolves correctly
- [x] `docker compose config` with no env var → falls back to base
- [ ] Fresh Linux NVIDIA install — verify turbo downloaded, Open WebUI requests turbo, transcription works
- [ ] Fresh macOS install — verify base downloaded, STT works
- [ ] Fresh Windows install — verify base downloaded, STT works
- [ ] User override: set `AUDIO_STT_MODEL=Systran/faster-whisper-small` in .env, reinstall, verify
- [ ] ENABLE_VOICE=false on all three platforms — STT block skipped

## Deferred to follow-up PRs

- `dream stt download` CLI command
- `dream doctor` STT cache validation
- Phase 9 offline mode STT handling
- dashboard-api voice model management endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)