### PR TITLE
fix(whisper): bug fixes + recovery tooling (dream stt, doctor check, offline warn)

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -2207,6 +2207,81 @@ cmd_model() {
     esac
 }
 
+cmd_stt() {
+    check_install; cd "$INSTALL_DIR"
+    local subcmd="${1:-status}"
+
+    # Resolve model and port from .env (with fallback for older installs).
+    local model port model_encoded url
+    model=$(_env_get_raw AUDIO_STT_MODEL)
+    [[ -z "$model" ]] && model="Systran/faster-whisper-base"
+    port=$(_env_get_raw WHISPER_PORT)
+    [[ -z "$port" ]] && port="9000"
+    model_encoded="${model//\//%2F}"
+    url="http://localhost:${port}"
+
+    case "$subcmd" in
+        current)
+            echo "STT model: ${model}"
+            echo "Whisper URL: ${url}"
+            return 0
+            ;;
+        status)
+            if ! curl -sf --max-time 3 "${url}/v1/models" >/dev/null 2>&1; then
+                warn "Whisper service not reachable at ${url}"
+                echo "  Is voice enabled and the stack running?"
+                return 1
+            fi
+            local target_encoded="$model_encoded"
+            local target_model="$model"
+            if [[ -n "${2:-}" ]]; then
+                target_model="$2"
+                target_encoded="${target_model//\//%2F}"
+            fi
+            if curl -sf --max-time 5 "${url}/v1/models/${target_encoded}" >/dev/null 2>&1; then
+                success "Cached: ${target_model}"
+            else
+                warn "Not cached: ${target_model}"
+                echo "  Run: dream stt download${2:+ $2}"
+            fi
+            ;;
+        download)
+            local target_model="${2:-$model}"
+            local target_encoded="${target_model//\//%2F}"
+            # Wait briefly for the models API to be ready (max 15s).
+            local ready=false
+            for _i in $(seq 1 15); do
+                if curl -sf --max-time 2 "${url}/v1/models" >/dev/null 2>&1; then
+                    ready=true
+                    break
+                fi
+                sleep 1
+            done
+            if ! $ready; then
+                error "Whisper models API not reachable at ${url}. Is voice enabled and the stack running?"
+            fi
+            # Skip if already cached.
+            if curl -sf --max-time 5 "${url}/v1/models/${target_encoded}" >/dev/null 2>&1; then
+                success "Already cached: ${target_model}"
+                return 0
+            fi
+            echo "Downloading ${target_model}..."
+            if ! curl -s --max-time 3600 -X POST "${url}/v1/models/${target_encoded}"; then
+                error "Download request failed. Check Whisper logs: dream logs whisper"
+            fi
+            # Verify the download actually cached.
+            if curl -sf --max-time 10 "${url}/v1/models/${target_encoded}" >/dev/null 2>&1; then
+                success "Downloaded and cached: ${target_model}"
+            else
+                error "Download returned but model is not cached. Check Whisper logs: dream logs whisper"
+            fi
+            ;;
+        *)
+            error "Usage: dream stt <current|status|download> [MODEL]"
+            ;;
+    esac
+}
+
 cmd_backup() {
     check_install
     cd "$INSTALL_DIR"
@@ -3196,6 +3271,8 @@ ${CYAN}Commands:${NC}
                       Switch between local/cloud/hybrid modes
   model [current|list|swap]
                       View or change the local LLM model tier
+  stt [current|status|download] [MODEL]
+                      View Whisper STT model, check cache, or trigger download
   backup [options]    Create a backup of user data and config
   backup verify <id>   Verify checksum integrity for a backup
   restore [backup_id] Restore from a backup
@@ -3317,6 +3394,7 @@ case "${1:-help}" in
     preset|p)    shift; cmd_preset "$@" ;;
     mode|m)      shift; cmd_mode "$@" ;;
     model)       shift; cmd_model "$@" ;;
+    stt)         shift; cmd_stt "$@" ;;
     backup)      shift; cmd_backup "$@" ;;
     restore)     shift; cmd_restore "$@" ;;
     rollback)    cmd_rollback ;;

--- a/dream-server/installers/phases/09-offline.sh
+++ b/dream-server/installers/phases/09-offline.sh
@@ -87,6 +87,21 @@ M1_EOF
         fi
     fi
 
+    # Whisper STT model: Phase 12 pre-downloads it by POSTing to the running
+    # Speaches API, but offline-mode users often disconnect BEFORE Phase 12
+    # completes, or they run 'dream stop' before network becomes unavailable.
+    # We can't pre-download from HuggingFace directly in Phase 9 without a
+    # huggingface_hub Python dep, so surface the requirement loudly here and
+    # point users at the 'dream stt download' CLI (added in the same PR).
+    if [[ "$ENABLE_VOICE" == "true" ]]; then
+        ai_warn "Offline mode + voice enabled: Whisper STT model is NOT pre-downloaded by Phase 9"
+        log "  The installer's Phase 12 will still attempt the download while online,"
+        log "  but if you go offline before it completes, STT will 404 on first use."
+        log "  To ensure the model is cached before disconnecting, run after install:"
+        log "    dream stt download"
+        log "  Or use 'scripts/pre-download.sh --with-voice' to pre-cache before install."
+    fi
+
     # Offline docs already copied by rsync/cp block above
     ai_ok "Offline mode configured"
     log "After installation, disconnect from internet for fully air-gapped operation"

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -179,7 +179,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
     WHISPER_PORT_RESOLVED="${SERVICE_PORTS[whisper]:-9000}"
     WHISPER_URL="http://localhost:${WHISPER_PORT_RESOLVED}"
-    STT_RECOVERY_CMD="curl -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
+    STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
 
     # Step 1: wait briefly for the models API to be ready. Whisper's /health
     # endpoint can pass before the models endpoint responds, so we probe

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -662,17 +662,35 @@ foreach ($check in $healthChecks) {
 # Trigger the download explicitly, verify it completed, surface recovery
 # instructions on failure. Mirrors Linux Phase 12 and macOS install-macos.sh.
 if ($enableVoice) {
-    # Read AUDIO_STT_MODEL from .env (written by env-generator.ps1).
+    # Read AUDIO_STT_MODEL and WHISPER_PORT from .env (written by env-generator.ps1).
+    # Use ReadAllText with explicit UTF8NoBom encoding so legacy BOM-prefixed
+    # .env files (written by old Set-Content -Encoding UTF8) don't break the
+    # regex on the first line.
     $sttModel = "Systran/faster-whisper-base"  # safe fallback
+    $whisperPort = "9000"  # safe fallback
     $envPath = Join-Path $installDir ".env"
     if (Test-Path $envPath) {
-        $envLine = Get-Content $envPath -ErrorAction SilentlyContinue | Where-Object { $_ -match "^AUDIO_STT_MODEL=(.+)$" } | Select-Object -First 1
-        if ($envLine -match "^AUDIO_STT_MODEL=(.+)$") {
-            $sttModel = $Matches[1].Trim('"').Trim()
+        try {
+            $envText = [System.IO.File]::ReadAllText($envPath, (New-Object System.Text.UTF8Encoding($false)))
+            # Strip any leading BOM defensively in case the file was written
+            # with a different encoding.
+            if ($envText.Length -gt 0 -and [int]$envText[0] -eq 0xFEFF) {
+                $envText = $envText.Substring(1)
+            }
+            foreach ($line in ($envText -split "`r?`n")) {
+                if ($line -match "^AUDIO_STT_MODEL=(.*)$") {
+                    $val = $Matches[1].Trim('"').Trim()
+                    if ($val) { $sttModel = $val }
+                } elseif ($line -match "^WHISPER_PORT=(.*)$") {
+                    $val = $Matches[1].Trim('"').Trim()
+                    if ($val) { $whisperPort = $val }
+                }
+            }
+        } catch {
+            # Fall through to defaults on any read failure.
         }
     }
     $sttModelEncoded = $sttModel -replace "/", "%2F"
-    $whisperPort = 9000  # Windows doesn't reassign this port
     $whisperUrl = "http://localhost:$whisperPort"
     $sttRecoveryCmd = "Invoke-WebRequest -Method POST -Uri '$whisperUrl/v1/models/$sttModelEncoded' -TimeoutSec 3600"
 

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -115,6 +115,31 @@ if command -v curl >/dev/null 2>&1; then
     fi
 fi
 
+# STT model cache check: a common silent-failure mode is the installer's
+# pre-download failing, so Whisper's /health passes (service up) but the
+# model isn't cached. Transcription then returns 404. This check catches
+# that case and surfaces the exact recovery command.
+STT_MODEL_CACHED="unknown"
+STT_MODEL_NAME=""
+STT_RECOVERY_HINT=""
+if [[ "${ENABLE_VOICE:-false}" == "true" ]] && command -v curl >/dev/null 2>&1; then
+    STT_MODEL_NAME="${AUDIO_STT_MODEL:-Systran/faster-whisper-base}"
+    _stt_whisper_port="${SERVICE_PORTS[whisper]:-9000}"
+    _stt_model_encoded="${STT_MODEL_NAME//\//%2F}"
+    _stt_whisper_url="http://127.0.0.1:${_stt_whisper_port}"
+    if curl -sf --max-time 5 "${_stt_whisper_url}/v1/models/${_stt_model_encoded}" >/dev/null 2>&1; then
+        STT_MODEL_CACHED="true"
+    else
+        # Distinguish "service down" from "model missing" for the hint.
+        if curl -sf --max-time 5 "${_stt_whisper_url}/health" >/dev/null 2>&1; then
+            STT_MODEL_CACHED="false"
+            STT_RECOVERY_HINT="curl --max-time 3600 -X POST ${_stt_whisper_url}/v1/models/${_stt_model_encoded}"
+        else
+            STT_MODEL_CACHED="service_down"
+        fi
+    fi
+fi
+
 # Collect extension diagnostics (wrapped in function to allow local variables)
 collect_extension_diagnostics() {
     # Use outer GPU_BACKEND or default to nvidia (don't make local to avoid set -u issues)
@@ -214,13 +239,13 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" <<'PY'
+"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" <<'PY'
 import json
 import pathlib
 import sys
 from datetime import datetime, timezone
 
-cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json = sys.argv[1:]
+cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery = sys.argv[1:]
 
 cap = json.load(open(cap_file, "r", encoding="utf-8"))
 pre = json.load(open(preflight_file, "r", encoding="utf-8"))
@@ -238,6 +263,8 @@ report = {
         "compose_cli": compose_cli == "true",
         "dashboard_http": dashboard_http == "true",
         "webui_http": webui_http == "true",
+        "stt_model_cached": stt_cached,
+        "stt_model_name": stt_model_name,
     },
     "extensions": ext_diagnostics,
     "summary": {
@@ -268,6 +295,13 @@ if runtime["docker_daemon"] and not runtime["dashboard_http"]:
     fix_hints.append(f"Run installer/start command, then verify dashboard on http://127.0.0.1:{dashboard_port}.")
 if runtime["docker_daemon"] and not runtime["webui_http"]:
     fix_hints.append(f"Verify Open WebUI container and port {webui_port} mapping.")
+
+# STT model cache: service up but model missing is a common silent failure
+if stt_cached == "false" and stt_recovery:
+    fix_hints.append(
+        f"Whisper STT model '{stt_model_name}' not cached — transcription will 404. "
+        f"Run: {stt_recovery}"
+    )
 
 # Extension-specific hints
 for ext in ext_diagnostics:

--- a/dream-server/tests/bats-tests/stt-download.bats
+++ b/dream-server/tests/bats-tests/stt-download.bats
@@ -1,0 +1,204 @@
+#!/usr/bin/env bats
+# ============================================================================
+# BATS tests for the STT pre-download logic in installers/phases/12-health.sh
+# ============================================================================
+# Guards against re-breakage of:
+#   - PR #984: silent-failure message ("will download on first use" lie)
+#   - PR #985: AUDIO_STT_MODEL env var wiring + backward-compat fallback
+#   - Post-#985 bug fix: recovery command must include --max-time 3600
+#
+# We execute only the STT pre-download block (lines ~165-215 of 12-health.sh)
+# with curl stubbed, then assert on the commands it would have run and on the
+# strings it prints.
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+setup() {
+    export TMPDIR_TEST="$BATS_TEST_TMPDIR"
+    mkdir -p "$TMPDIR_TEST/bin"
+
+    # Capture curl invocations to a file instead of actually hitting the network.
+    # The stub also lets tests toggle "cache hit" vs "cache miss" via an env var.
+    cat > "$TMPDIR_TEST/bin/curl" << 'CURL_STUB'
+#!/usr/bin/env bash
+# Record every invocation (for assertion), then return the scripted exit code.
+echo "CURL: $*" >> "$TMPDIR_TEST/curl.log"
+# STT_STUB_MODE controls behavior:
+#   cache-hit:      GET /v1/models/{id} returns 0 (cached), all other calls return 0
+#   cache-miss:     GET /v1/models returns 0, GET /v1/models/{id} returns 1, POST returns 0, verify GET returns 0
+#   download-fail:  everything returns 0 except the verify GET after POST
+#   api-not-ready:  all curls return 1
+case "${STT_STUB_MODE:-cache-hit}" in
+    cache-hit)       exit 0 ;;
+    api-not-ready)   exit 1 ;;
+    cache-miss)
+        # Distinguish GET /v1/models (ready probe) from GET /v1/models/{id} (cache) from POST.
+        if [[ "$*" == *"-X POST"* ]]; then exit 0
+        elif [[ "$*" == */v1/models ]] || [[ "$*" == *"/v1/models " ]] || [[ "$*" == *"/v1/models" ]]; then exit 0
+        else exit 0  # verify GET after POST succeeds
+        fi
+        ;;
+    download-fail)
+        if [[ "$*" == */v1/models ]] || [[ "$*" == *"/v1/models" ]]; then exit 0
+        elif [[ "$*" == *"-X POST"* ]]; then exit 0
+        else exit 1  # cache GET + verify GET both fail
+        fi
+        ;;
+    *) exit 0 ;;
+esac
+CURL_STUB
+    chmod +x "$TMPDIR_TEST/bin/curl"
+    export PATH="$TMPDIR_TEST/bin:$PATH"
+
+    # Reset log on each test.
+    : > "$TMPDIR_TEST/curl.log"
+
+    # Environment that Phase 12's STT block expects. The block starts after the
+    # health checks; we provide the same variables the rest of Phase 12 would have set.
+    export SERVICE_PORTS_whisper="9000"
+    export BGRN='' AMB='' NC='' DIM=''
+    export LOG_FILE="$TMPDIR_TEST/install.log"
+    : > "$LOG_FILE"
+}
+
+teardown() {
+    rm -rf "$TMPDIR_TEST/bin" "$TMPDIR_TEST/curl.log" "$TMPDIR_TEST/install.log"
+}
+
+# The STT block extracted from 12-health.sh for testing in isolation. Pulling
+# this out of the phase means we don't need to stub every other phase concern
+# (service registry, docker health loops, etc.) — just the STT logic.
+# If 12-health.sh drifts, update this block to match.
+_run_stt_block() {
+    bash -c '
+        set -u
+        declare -A SERVICE_PORTS
+        SERVICE_PORTS[whisper]="9000"
+
+        if [[ "$ENABLE_VOICE" == "true" ]]; then
+            if [[ -n "${AUDIO_STT_MODEL:-}" ]]; then
+                STT_MODEL="$AUDIO_STT_MODEL"
+            elif [[ "$GPU_BACKEND" == "nvidia" ]]; then
+                STT_MODEL="deepdml/faster-whisper-large-v3-turbo-ct2"
+            else
+                STT_MODEL="Systran/faster-whisper-base"
+            fi
+            STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
+            WHISPER_PORT_RESOLVED="${SERVICE_PORTS[whisper]:-9000}"
+            WHISPER_URL="http://localhost:${WHISPER_PORT_RESOLVED}"
+            STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
+
+            _stt_api_ready=false
+            for _i in $(seq 1 3); do
+                if curl -sf --max-time 2 "${WHISPER_URL}/v1/models" >/dev/null 2>&1; then
+                    _stt_api_ready=true
+                    break
+                fi
+                sleep 0
+            done
+
+            if ! $_stt_api_ready; then
+                echo "API_NOT_READY: $STT_RECOVERY_CMD"
+            elif curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >/dev/null 2>&1; then
+                echo "ALREADY_CACHED: ${STT_MODEL}"
+            else
+                echo "DOWNLOADING: ${STT_MODEL}"
+                curl -s --max-time 3600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >> "$LOG_FILE" 2>&1 || true
+                if curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >/dev/null 2>&1; then
+                    echo "CACHED: ${STT_MODEL}"
+                else
+                    echo "DOWNLOAD_FAILED: $STT_RECOVERY_CMD"
+                fi
+            fi
+        fi
+    '
+}
+
+# ── Tests ──────────────────────────────────────────────────────────────────
+
+@test "stt: reads AUDIO_STT_MODEL from env when set" {
+    export ENABLE_VOICE=true
+    export GPU_BACKEND=nvidia
+    export AUDIO_STT_MODEL="custom-org/custom-model"
+    export STT_STUB_MODE=cache-hit
+
+    run _run_stt_block
+    assert_success
+    assert_output --partial "custom-org/custom-model"
+}
+
+@test "stt: falls back to NVIDIA turbo when AUDIO_STT_MODEL unset and GPU_BACKEND=nvidia" {
+    export ENABLE_VOICE=true
+    export GPU_BACKEND=nvidia
+    unset AUDIO_STT_MODEL
+    export STT_STUB_MODE=cache-hit
+
+    run _run_stt_block
+    assert_success
+    assert_output --partial "deepdml/faster-whisper-large-v3-turbo-ct2"
+}
+
+@test "stt: falls back to base model when AUDIO_STT_MODEL unset and GPU_BACKEND != nvidia" {
+    export ENABLE_VOICE=true
+    export GPU_BACKEND=amd
+    unset AUDIO_STT_MODEL
+    export STT_STUB_MODE=cache-hit
+
+    run _run_stt_block
+    assert_success
+    assert_output --partial "Systran/faster-whisper-base"
+}
+
+@test "stt: skips entirely when ENABLE_VOICE=false" {
+    export ENABLE_VOICE=false
+    export GPU_BACKEND=nvidia
+    export STT_STUB_MODE=cache-hit
+
+    run _run_stt_block
+    assert_success
+    # No output and no curl invocations logged.
+    [[ -z "$output" ]]
+    [[ ! -s "$TMPDIR_TEST/curl.log" ]]
+}
+
+@test "stt: recovery command includes --max-time 3600" {
+    export ENABLE_VOICE=true
+    export GPU_BACKEND=amd
+    export AUDIO_STT_MODEL="Systran/faster-whisper-base"
+    export STT_STUB_MODE=download-fail
+
+    run _run_stt_block
+    assert_success
+    # Must not say "will download on first use" (the old lie from pre-PR #984).
+    refute_output --partial "will download on first use"
+    # Must include the recovery command with --max-time.
+    assert_output --partial "curl --max-time 3600 -X POST"
+}
+
+@test "stt: already-cached short-circuits without POST" {
+    export ENABLE_VOICE=true
+    export GPU_BACKEND=amd
+    export AUDIO_STT_MODEL="Systran/faster-whisper-base"
+    export STT_STUB_MODE=cache-hit
+
+    run _run_stt_block
+    assert_success
+    assert_output --partial "ALREADY_CACHED"
+    # Should NOT have issued a POST.
+    run grep -F "-X POST" "$TMPDIR_TEST/curl.log"
+    assert_failure
+}
+
+@test "stt: URL-encodes slash in model name" {
+    export ENABLE_VOICE=true
+    export GPU_BACKEND=amd
+    export AUDIO_STT_MODEL="org/name-with-slash"
+    export STT_STUB_MODE=cache-miss
+
+    run _run_stt_block
+    assert_success
+    # The curl log should contain the encoded form in at least one URL.
+    run grep -F "org%2Fname-with-slash" "$TMPDIR_TEST/curl.log"
+    assert_success
+}


### PR DESCRIPTION
## Summary

**Base:** `feat/stt-env-var-and-platform-parity` (PR #985). Merge #984 → #985 → this.

Addresses the real issues found during PR #985's self-audit: three Windows/Linux bugs, plus four gaps from the earlier audit trail that are now in scope.

## Stages (one commit each)

### Stage 1 — Bug fixes (PR #985 audit findings)
- **Windows port hardcoded to 9000** → now resolved from `.env` dynamically (matches Linux/macOS behavior)
- **Windows BOM blind spot** → switch from `Get-Content` to `[System.IO.File]::ReadAllText` with explicit UTF8NoBom encoding, plus defensive BOM strip for legacy files
- **Linux recovery command missing `--max-time 3600`** → added, matching macOS/Windows

### Stage 2 — `dream doctor` STT cache check
Detects the silent-failure mode where Whisper `/health` passes but the model isn't cached. Reports cache state in the JSON report and adds a ready-to-run recovery curl to `autofix_hints` when the model is missing.

### Stage 3 — `dream stt` CLI command
Three subcommands (mirror of `dream model`):
- `dream stt current` — show AUDIO_STT_MODEL from `.env`
- `dream stt status [MODEL]` — report cache state via Speaches API
- `dream stt download [MODEL]` — trigger download + verify

Post-install recovery without raw curl.

### Stage 4 — Phase 9 offline mode warning
Phase 9 runs before services start, so it can't use the Speaches API. Rather than introduce a complex direct-HuggingFace download path, we warn loudly when `OFFLINE_MODE=true` + `ENABLE_VOICE=true` and point users at `dream stt download` (which they can run online before disconnecting) or `scripts/pre-download.sh --with-voice`.

### Stage 5 — BATS regression tests
Seven tests in `tests/bats-tests/stt-download.bats` covering:
- AUDIO_STT_MODEL env respected (PR #985)
- Fallback to GPU_BACKEND switch when unset (PR #985)
- ENABLE_VOICE=false skip
- Recovery command has `--max-time 3600` (this PR)
- No "will download on first use" lie (PR #984)
- Already-cached short-circuit
- URL encoding

## Why this is safe

- **Stage 1** bug fixes are narrow — only touch the STT block added in #985 and one string in Phase 12
- **Stage 2** is additive — doctor check reports only, never modifies state, never fails doctor
- **Stage 3** is a new command — doesn't touch any existing dispatch entry
- **Stage 4** is a warning inside an existing `OFFLINE_MODE==true` block — no behavior change for online installs
- **Stage 5** tests don't change production code

Every stage is an independent commit so any one can be reverted.

## Test plan

- [x] `bash -n` passes on all modified shell files (except `.bats`, which isn't valid bash syntactically — expected)
- [x] PowerShell `PSParser::Tokenize` passes on `install-windows.ps1`
- [x] 5 clean commits, each in one stage
- [ ] BATS: `bats tests/bats-tests/stt-download.bats` (requires CI/make bats; repo auto-installs BATS on first run)
- [ ] End-to-end: fresh AMD install, STT works without manual recovery
- [ ] Reinstall with `WHISPER_PORT=9100` in .env, verify Windows block uses port 9100
- [ ] `dream stt current` / `status` / `download` on running install
- [ ] `dream doctor` shows `stt_model_cached` field in JSON output

## Deferred follow-ups

Still in the "deferred" bucket from earlier audits:
- Dashboard-api `/api/voice/stt-models` endpoint (frontend work)
- AUDIO_STT_MODEL exposure in Settings UI (frontend work)
- TTS Kokoro hardening (different pattern, separate PR)
- Phase 9 actual offline download (requires huggingface_hub Python dep or direct HF CDN curl with cache-layout reconstruction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)