### PR TITLE
[codex] Fix Windows local LLM endpoint resolution

### DIFF
--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -39,6 +39,7 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "ui.ps1")
 . (Join-Path $LibDir "compose-diagnostics.ps1")
 . (Join-Path $LibDir "detection.ps1")
+. (Join-Path $LibDir "llm-endpoint.ps1")
 . (Join-Path $LibDir "install-report.ps1")
 
 # ── Resolve install directory ──
@@ -124,20 +125,7 @@ function Read-DreamEnv {
     .SYNOPSIS
         Safely load .env file into a hashtable (no eval, no injection).
     #>
-    $envFile = Join-Path $InstallDir ".env"
-    $result = @{}
-    if (-not (Test-Path $envFile)) { return $result }
-
-    Get-Content $envFile | ForEach-Object {
-        $line = $_.Trim()
-        if ($line -match "^#" -or $line -eq "") { return }
-        if ($line -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
-            $key = $Matches[1]
-            $val = $Matches[2].Trim('"').Trim("'")
-            $result[$key] = $val
-        }
-    }
-    return $result
+    return Get-WindowsDreamEnvMap -InstallDir $InstallDir
 }
 
 function Set-DreamEnvValue {
@@ -464,13 +452,9 @@ function Invoke-Status {
         Write-Host "  Health Checks" -ForegroundColor Cyan
         Write-Host ("  " + ("-" * 40)) -ForegroundColor DarkGray
 
-        $llmHealthUrl = $(if ((Get-NativeInferenceBackend) -eq "lemonade") {
-            $script:LEMONADE_HEALTH_URL
-        } else {
-            "http://localhost:8080/health"
-        })
+        $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $InstallDir -NativeBackend (Get-NativeInferenceBackend)
         $endpoints = @(
-            @{ Name = "LLM API";    Url = $llmHealthUrl }
+            @{ Name = "LLM API";    Url = $llmEndpoint.HealthUrl }
             @{ Name = "Chat UI";    Url = "http://localhost:3000" }
             @{ Name = "Dashboard";  Url = "http://localhost:3001" }
         )
@@ -702,9 +686,9 @@ function Invoke-Chat {
         )
     } | ConvertTo-Json -Depth 3
 
-    $chatBasePath = $(if ((Get-NativeInferenceBackend) -eq "lemonade") { "/api/v1" } else { "/v1" })
+    $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $InstallDir -NativeBackend (Get-NativeInferenceBackend)
     try {
-        $resp = Invoke-RestMethod -Uri "http://localhost:8080${chatBasePath}/chat/completions" `
+        $resp = Invoke-RestMethod -Uri $llmEndpoint.ChatCompletionsUrl `
             -Method POST -Body $body -ContentType "application/json" -TimeoutSec 120
 
         if ($resp.choices -and $resp.choices[0].message) {

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -69,6 +69,7 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "tier-map.ps1")
 . (Join-Path $LibDir "detection.ps1")
 . (Join-Path $LibDir "env-generator.ps1")
+. (Join-Path $LibDir "llm-endpoint.ps1")
 
 # ── Phase context variables ───────────────────────────────────────────────────
 # These are plain (non-$script:) variables set in the orchestrator scope.
@@ -93,6 +94,65 @@ $installDir     = $script:DS_INSTALL_DIR
 $sourceRoot     = $SourceRoot
 
 # ── Phase dispatcher ──────────────────────────────────────────────────────────
+function Get-UsableWindowsBash {
+    <#
+    .SYNOPSIS
+        Prefer a Git Bash-style shell for bootstrap-upgrade.sh on Windows.
+    #>
+    param(
+        [string]$InstallPath = $installDir
+    )
+
+    $probeCommand = "command -v bash >/dev/null 2>&1"
+    if ($InstallPath -match "^([A-Za-z]):") {
+        $probeCommand += " && test -d /$($Matches[1].ToLower())"
+    }
+
+    $candidates = New-Object 'System.Collections.Generic.List[string]'
+
+    $gitCmd = Get-Command git -ErrorAction SilentlyContinue
+    if ($gitCmd -and $gitCmd.Source) {
+        $gitRoot = Split-Path (Split-Path $gitCmd.Source -Parent) -Parent
+        $gitBash = Join-Path $gitRoot "bin\bash.exe"
+        if (Test-Path $gitBash) {
+            [void]$candidates.Add($gitBash)
+        }
+    }
+
+    $programFilesBash = Join-Path $env:ProgramFiles "Git\bin\bash.exe"
+    if (Test-Path $programFilesBash) {
+        [void]$candidates.Add($programFilesBash)
+    }
+
+    if (${env:ProgramFiles(x86)} -and $env:ProgramFiles -ne ${env:ProgramFiles(x86)}) {
+        $programFilesX86Bash = Join-Path ${env:ProgramFiles(x86)} "Git\bin\bash.exe"
+        if (Test-Path $programFilesX86Bash) {
+            [void]$candidates.Add($programFilesX86Bash)
+        }
+    }
+
+    $bashCmd = Get-Command bash -ErrorAction SilentlyContinue
+    if ($bashCmd -and $bashCmd.Source) {
+        [void]$candidates.Add($bashCmd.Source)
+    }
+
+    $seen = @{}
+    foreach ($candidate in $candidates) {
+        if ([string]::IsNullOrWhiteSpace($candidate)) { continue }
+        if ($seen.ContainsKey($candidate)) { continue }
+        $seen[$candidate] = $true
+
+        try {
+            & $candidate -lc $probeCommand *> $null
+            if ($LASTEXITCODE -eq 0) {
+                return $candidate
+            }
+        } catch { }
+    }
+
+    return $null
+}
+
 $PhasesDir = Join-Path $ScriptDir "phases"
 
 Write-DreamBanner
@@ -575,13 +635,29 @@ exec bash "$bashScript" "$bashInstallDir" "$($fullTierConfig.GgufFile)" "$($full
 "@
                 [System.IO.File]::WriteAllText($wrapperScript, $wrapperContent.Replace("`r`n", "`n"), (New-Object System.Text.UTF8Encoding($false)))
 
-                Start-Process -FilePath "bash" -ArgumentList $wrapperScript `
-                    -WindowStyle Hidden `
-                    -RedirectStandardOutput $upgradeLog `
-                    -RedirectStandardError $upgradeErrLog
+                $bashPath = Get-UsableWindowsBash -InstallPath $installDir
+                if ($bashPath) {
+                    $upgradeProc = Start-Process -FilePath $bashPath -ArgumentList $wrapperScript `
+                        -WindowStyle Hidden `
+                        -RedirectStandardOutput $upgradeLog `
+                        -RedirectStandardError $upgradeErrLog `
+                        -PassThru
 
-                Write-AI "Full model ($($fullTierConfig.LlmModel)) downloading in background."
-                Write-AI "Check progress: Get-Content '$upgradeLog' -Tail 10"
+                    Start-Sleep -Seconds 2
+                    $upgradeProc.Refresh()
+
+                    if ($upgradeProc.HasExited) {
+                        Write-AIWarn "Background full-model download exited immediately (exit code: $($upgradeProc.ExitCode))."
+                        Write-AI "  Retry manually with: & '$bashPath' '$wrapperScript'"
+                        Write-AI "  Error log: $upgradeErrLog"
+                    } else {
+                        Write-AI "Full model ($($fullTierConfig.LlmModel)) downloading in background."
+                        Write-AI "Check progress: Get-Content '$upgradeLog' -Tail 10"
+                    }
+                } else {
+                    Write-AIWarn "No Git Bash-compatible shell was found for bootstrap-upgrade.sh."
+                    Write-AI "  Install Git for Windows or run the upgrade script manually after adding bash.exe to PATH."
+                }
             } else {
                 Write-AIWarn "bootstrap-upgrade.sh not found at $upgradeScript"
                 Write-AIWarn "Download the full model manually or re-run the installer."
@@ -608,22 +684,15 @@ if ($dryRun) {
 }
 
 # ── Service health checks ─────────────────────────────────────────────────────
-# Use Lemonade health endpoint when AMD + Lemonade is active, llama-server otherwise
-$llmHealthUrl = $(if ($useLemonade) {
-    $script:LEMONADE_HEALTH_URL
-} else {
-    "http://localhost:8080/health"
-})
-$llmHealthName = $(if ($useLemonade) { "LLM (Lemonade)" } else { "LLM (llama-server)" })
+$llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $installDir `
+    -EnvMap (Get-WindowsDreamEnvMap -InstallDir $installDir) `
+    -UseLemonade:$useLemonade -GpuBackend $gpuInfo.Backend -CloudMode:$cloudMode
 $healthChecks = @(
-    @{ Name = $llmHealthName; Url = $llmHealthUrl }
+    @{ Name = $llmEndpoint.Name; Url = $llmEndpoint.HealthUrl }
     @{ Name = "Chat UI (Open WebUI)"; Url = "http://localhost:3000" }
 )
 if ($enableVoice)     { $healthChecks += @{ Name = "Whisper (STT)";    Url = "http://localhost:9000/health" } }
 if ($enableWorkflows) { $healthChecks += @{ Name = "n8n (Workflows)";   Url = "http://localhost:5678/healthz" } }
-if (Test-Path $script:OPENCODE_EXE) {
-    $healthChecks += @{ Name = "OpenCode (IDE)"; Url = "http://localhost:$($script:OPENCODE_PORT)/" }
-}
 
 Write-AI "Running health checks..."
 $maxAttempts = 60; $allHealthy = $true

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -70,6 +70,7 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "detection.ps1")
 . (Join-Path $LibDir "env-generator.ps1")
 . (Join-Path $LibDir "llm-endpoint.ps1")
+. (Join-Path $LibDir "opencode-config.ps1")
 
 # ── Phase context variables ───────────────────────────────────────────────────
 # These are plain (non-$script:) variables set in the orchestrator scope.
@@ -684,6 +685,22 @@ if ($dryRun) {
 }
 
 # ── Service health checks ─────────────────────────────────────────────────────
+$opencodeSync = Sync-WindowsOpenCodeConfigFromEnv -InstallDir $installDir `
+    -GpuBackend $gpuInfo.Backend -UseLemonade:$useLemonade -CloudMode:$cloudMode `
+    -DefaultModelId $tierConfig.GgufFile -DefaultModelName $tierConfig.LlmModel `
+    -DefaultContextLimit ([int]$tierConfig.MaxContext) -SkipIfUnavailable
+switch ($opencodeSync.Status) {
+    "created" {
+        Write-AISuccess "OpenCode config synced to active model (model: $($opencodeSync.ModelName))"
+    }
+    "updated" {
+        Write-AISuccess "OpenCode config synced to active model (model: $($opencodeSync.ModelName))"
+    }
+    "regenerated" {
+        Write-AISuccess "OpenCode config regenerated for active model (model: $($opencodeSync.ModelName))"
+    }
+}
+
 $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $installDir `
     -EnvMap (Get-WindowsDreamEnvMap -InstallDir $installDir) `
     -UseLemonade:$useLemonade -GpuBackend $gpuInfo.Backend -CloudMode:$cloudMode

--- a/dream-server/installers/windows/lib/install-report.ps1
+++ b/dream-server/installers/windows/lib/install-report.ps1
@@ -3,7 +3,7 @@
 # ============================================================================
 # Part of: installers/windows/lib/
 # Purpose: Build a shareable support bundle with compose + system diagnostics.
-# Requires: ui.ps1 and detection.ps1 sourced first.
+# Requires: ui.ps1, detection.ps1, and llm-endpoint.ps1 sourced first.
 # ============================================================================
 
 function Invoke-OptionalCommand {
@@ -66,6 +66,7 @@ function Test-HttpEndpoint {
 
 function New-DreamInstallReport {
     param(
+        [string]$InstallDir = $script:DS_INSTALL_DIR,
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
         [string[]]$ComposeFlags
@@ -80,6 +81,7 @@ function New-DreamInstallReport {
     if (Get-Command Get-NativeInferenceBackend -ErrorAction SilentlyContinue) {
         $nativeBackend = Get-NativeInferenceBackend
     }
+    $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $InstallDir -GpuBackend $gpu.Backend -NativeBackend $nativeBackend
 
     $composeConfigArgs = @("compose") + $ComposeFlags + @("config")
     $composePsArgs = @("compose") + $ComposeFlags + @("ps", "-a")
@@ -108,7 +110,7 @@ function New-DreamInstallReport {
             compose_ps = Invoke-OptionalCommand -Command "docker" -CommandArgs $composePsArgs -MaxLines 80
         }
         health = [ordered]@{
-            llm_api = Test-HttpEndpoint -Url "http://localhost:8080/health"
+            llm_api = Test-HttpEndpoint -Url $llmEndpoint.HealthUrl
             open_webui = Test-HttpEndpoint -Url "http://localhost:3000"
             dashboard = Test-HttpEndpoint -Url "http://localhost:3001"
             dashboard_api = Test-HttpEndpoint -Url "http://localhost:3002/health"
@@ -133,7 +135,7 @@ function Write-DreamInstallReport {
     $jsonPath = Join-Path $artifactsDir "report.json"
     $txtPath = Join-Path $artifactsDir "report.txt"
 
-    $report = New-DreamInstallReport -ComposeFlags $ComposeFlags
+    $report = New-DreamInstallReport -InstallDir $InstallDir -ComposeFlags $ComposeFlags
     ($report | ConvertTo-Json -Depth 8) | Set-Content -Path $jsonPath -Encoding UTF8
 
     $lines = @()

--- a/dream-server/installers/windows/lib/llm-endpoint.ps1
+++ b/dream-server/installers/windows/lib/llm-endpoint.ps1
@@ -1,0 +1,144 @@
+# ============================================================================
+# Dream Server Windows -- local LLM endpoint helpers
+# ============================================================================
+# Part of: installers/windows/lib/
+# Purpose: Parse .env safely and resolve the active local LLM endpoint across
+#          Docker-backed NVIDIA/CPU installs and native AMD backends.
+# ============================================================================
+
+function Get-WindowsDreamEnvMap {
+    <#
+    .SYNOPSIS
+        Parse the generated .env file without executing it.
+    #>
+    param(
+        [string]$InstallDir = $script:DS_INSTALL_DIR,
+        [string]$Path = ""
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Path)) {
+        if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+            return @{}
+        }
+        $Path = Join-Path $InstallDir ".env"
+    }
+
+    $result = @{}
+    if (-not (Test-Path $Path)) { return $result }
+
+    Get-Content $Path | ForEach-Object {
+        $line = $_.Trim()
+        if ($line -match "^#" -or $line -eq "") { return }
+        if ($line -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
+            $key = $Matches[1]
+            $val = $Matches[2].Trim('"').Trim("'")
+            $result[$key] = $val
+        }
+    }
+
+    return $result
+}
+
+function Get-WindowsDreamEnvValue {
+    <#
+    .SYNOPSIS
+        Read the first populated value from a parsed .env hashtable.
+    #>
+    param(
+        [hashtable]$EnvMap,
+        [string[]]$Keys,
+        [string]$Default = ""
+    )
+
+    foreach ($key in $Keys) {
+        if ($EnvMap.ContainsKey($key)) {
+            $value = [string]$EnvMap[$key]
+            if (-not [string]::IsNullOrWhiteSpace($value)) {
+                return $value
+            }
+        }
+    }
+
+    return $Default
+}
+
+function Get-WindowsLocalLlmEndpoint {
+    <#
+    .SYNOPSIS
+        Resolve the active local LLM endpoint for native AMD and Docker installs.
+    .OUTPUTS
+        @{ Name; Backend; Port; ApiBasePath; HealthUrl; BaseUrl; ChatCompletionsUrl }
+    #>
+    param(
+        [string]$InstallDir = $script:DS_INSTALL_DIR,
+        [hashtable]$EnvMap = $null,
+        [string]$GpuBackend = "",
+        [string]$NativeBackend = "",
+        [switch]$UseLemonade,
+        [switch]$CloudMode
+    )
+
+    if ($null -eq $EnvMap) {
+        $EnvMap = Get-WindowsDreamEnvMap -InstallDir $InstallDir
+    }
+
+    $resolvedNativeBackend = $NativeBackend
+    if ([string]::IsNullOrWhiteSpace($resolvedNativeBackend)) {
+        $resolvedNativeBackend = ""
+    } else {
+        $resolvedNativeBackend = $resolvedNativeBackend.ToLowerInvariant()
+    }
+
+    $resolvedGpuBackend = $GpuBackend
+    if ([string]::IsNullOrWhiteSpace($resolvedGpuBackend)) {
+        $resolvedGpuBackend = Get-WindowsDreamEnvValue -EnvMap $EnvMap -Keys @("GPU_BACKEND") -Default ""
+    }
+    if (-not [string]::IsNullOrWhiteSpace($resolvedGpuBackend)) {
+        $resolvedGpuBackend = $resolvedGpuBackend.ToLowerInvariant()
+    }
+
+    $llmBackend = Get-WindowsDreamEnvValue -EnvMap $EnvMap -Keys @("LLM_BACKEND") -Default "llama-server"
+    if (-not [string]::IsNullOrWhiteSpace($llmBackend)) {
+        $llmBackend = $llmBackend.ToLowerInvariant()
+    }
+
+    if ($UseLemonade -or $resolvedNativeBackend -eq "lemonade" -or $llmBackend -eq "lemonade") {
+        return @{
+            Name = "LLM (Lemonade)"
+            Backend = "lemonade"
+            Port = "$($script:LEMONADE_PORT)"
+            ApiBasePath = "/api/v1"
+            HealthUrl = $script:LEMONADE_HEALTH_URL
+            BaseUrl = "http://localhost:$($script:LEMONADE_PORT)/api/v1"
+            ChatCompletionsUrl = "http://localhost:$($script:LEMONADE_PORT)/api/v1/chat/completions"
+        }
+    }
+
+    if ($resolvedNativeBackend -eq "llama-server" -or (-not $CloudMode -and $resolvedGpuBackend -eq "amd")) {
+        return @{
+            Name = "LLM (llama-server)"
+            Backend = "native-llama-server"
+            Port = "8080"
+            ApiBasePath = "/v1"
+            HealthUrl = "http://localhost:8080/health"
+            BaseUrl = "http://localhost:8080/v1"
+            ChatCompletionsUrl = "http://localhost:8080/v1/chat/completions"
+        }
+    }
+
+    $port = Get-WindowsDreamEnvValue -EnvMap $EnvMap -Keys @("OLLAMA_PORT", "LLAMA_SERVER_PORT") -Default "11434"
+    $apiBasePath = Get-WindowsDreamEnvValue -EnvMap $EnvMap -Keys @("LLM_API_BASE_PATH") -Default "/v1"
+    if ($apiBasePath -notmatch "^/") {
+        $apiBasePath = "/$apiBasePath"
+    }
+
+    return @{
+        Name = "LLM (llama-server)"
+        Backend = "docker-llama-server"
+        Port = $port
+        ApiBasePath = $apiBasePath
+        HealthUrl = "http://localhost:${port}/health"
+        BaseUrl = "http://localhost:${port}${apiBasePath}"
+        ChatCompletionsUrl = "http://localhost:${port}${apiBasePath}/chat/completions"
+    }
+}

--- a/dream-server/installers/windows/lib/opencode-config.ps1
+++ b/dream-server/installers/windows/lib/opencode-config.ps1
@@ -1,0 +1,216 @@
+# ============================================================================
+# Dream Server Windows -- OpenCode config helpers
+# ============================================================================
+# Part of: installers/windows/lib/
+# Purpose: Create or update OpenCode config from the active local LLM settings.
+# Requires: constants.ps1 and llm-endpoint.ps1 sourced first.
+# ============================================================================
+
+function Set-OpenCodeObjectProperty {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Target,
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        $Value
+    )
+
+    $property = $Target.PSObject.Properties[$Name]
+    if ($property) {
+        $property.Value = $Value
+    } else {
+        $Target | Add-Member -NotePropertyName $Name -NotePropertyValue $Value
+    }
+}
+
+function New-WindowsOpenCodeConfigObject {
+    param(
+        [hashtable]$LlmEndpoint,
+        [string]$ModelId,
+        [string]$ModelName,
+        [int]$ContextLimit
+    )
+
+    return [pscustomobject]@{
+        '$schema' = "https://opencode.ai/config.json"
+        model = "llama-server/$ModelId"
+        small_model = "llama-server/$ModelId"
+        provider = [pscustomobject]@{
+            'llama-server' = [pscustomobject]@{
+                npm = "@ai-sdk/openai-compatible"
+                name = "llama-server (local)"
+                options = [pscustomobject]@{
+                    baseURL = $LlmEndpoint.BaseUrl
+                    apiKey = "no-key"
+                }
+                models = [pscustomobject]@{
+                    $ModelId = [pscustomobject]@{
+                        name = $ModelName
+                        limit = [pscustomobject]@{
+                            context = $ContextLimit
+                            output = 32768
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+function Update-WindowsOpenCodeConfigObject {
+    param(
+        [object]$Config,
+        [hashtable]$LlmEndpoint,
+        [string]$ModelId,
+        [string]$ModelName,
+        [int]$ContextLimit
+    )
+
+    if ($null -eq $Config) {
+        return New-WindowsOpenCodeConfigObject -LlmEndpoint $LlmEndpoint -ModelId $ModelId -ModelName $ModelName -ContextLimit $ContextLimit
+    }
+
+    Set-OpenCodeObjectProperty -Target $Config -Name '$schema' -Value "https://opencode.ai/config.json"
+    Set-OpenCodeObjectProperty -Target $Config -Name 'model' -Value "llama-server/$ModelId"
+    Set-OpenCodeObjectProperty -Target $Config -Name 'small_model' -Value "llama-server/$ModelId"
+
+    if (-not $Config.PSObject.Properties['provider'] -or $null -eq $Config.provider) {
+        Set-OpenCodeObjectProperty -Target $Config -Name 'provider' -Value ([pscustomobject]@{})
+    }
+    $provider = $Config.provider
+
+    if (-not $provider.PSObject.Properties['llama-server'] -or $null -eq $provider.'llama-server') {
+        Set-OpenCodeObjectProperty -Target $provider -Name 'llama-server' -Value ([pscustomobject]@{})
+    }
+    $llamaProvider = $provider.'llama-server'
+
+    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'npm' -Value "@ai-sdk/openai-compatible"
+    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'name' -Value "llama-server (local)"
+
+    if (-not $llamaProvider.PSObject.Properties['options'] -or $null -eq $llamaProvider.options) {
+        Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'options' -Value ([pscustomobject]@{})
+    }
+    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'baseURL' -Value $LlmEndpoint.BaseUrl
+    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'apiKey' -Value "no-key"
+
+    if (-not $llamaProvider.PSObject.Properties['models'] -or $null -eq $llamaProvider.models) {
+        Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'models' -Value ([pscustomobject]@{})
+    }
+    $models = $llamaProvider.models
+
+    if (-not $models.PSObject.Properties[$ModelId] -or $null -eq $models.PSObject.Properties[$ModelId].Value) {
+        Set-OpenCodeObjectProperty -Target $models -Name $ModelId -Value ([pscustomobject]@{})
+    }
+    $modelEntry = $models.PSObject.Properties[$ModelId].Value
+    Set-OpenCodeObjectProperty -Target $modelEntry -Name 'name' -Value $ModelName
+
+    if (-not $modelEntry.PSObject.Properties['limit'] -or $null -eq $modelEntry.limit) {
+        Set-OpenCodeObjectProperty -Target $modelEntry -Name 'limit' -Value ([pscustomobject]@{})
+    }
+    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'context' -Value $ContextLimit
+    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'output' -Value 32768
+
+    return $Config
+}
+
+function Sync-WindowsOpenCodeConfig {
+    param(
+        [hashtable]$LlmEndpoint,
+        [string]$ModelId,
+        [string]$ModelName,
+        [int]$ContextLimit,
+        [string]$ConfigDir = $script:OPENCODE_CONFIG_DIR,
+        [switch]$SkipIfUnavailable
+    )
+
+    $_ocConfigFile = Join-Path $ConfigDir "opencode.json"
+    $_ocCompatConfigFile = Join-Path $ConfigDir "config.json"
+
+    if ($SkipIfUnavailable -and `
+        -not (Test-Path $script:OPENCODE_EXE) -and `
+        -not (Test-Path $_ocConfigFile) -and `
+        -not (Test-Path $_ocCompatConfigFile)) {
+        return @{
+            Status = "skipped"
+            ConfigPath = $_ocConfigFile
+            CompatConfigPath = $_ocCompatConfigFile
+            ModelId = $ModelId
+            ModelName = $ModelName
+            BaseUrl = $LlmEndpoint.BaseUrl
+        }
+    }
+
+    New-Item -ItemType Directory -Path $ConfigDir -Force | Out-Null
+
+    $_existingConfigFile = @($_ocConfigFile, $_ocCompatConfigFile) |
+        Where-Object { Test-Path $_ } |
+        Select-Object -First 1
+
+    $_configObject = $null
+    $_configStatus = "created"
+
+    if ($_existingConfigFile) {
+        try {
+            $_configObject = Get-Content $_existingConfigFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            $_configStatus = "updated"
+        } catch {
+            $_configStatus = "regenerated"
+        }
+    }
+
+    $_configObject = Update-WindowsOpenCodeConfigObject `
+        -Config $_configObject `
+        -LlmEndpoint $LlmEndpoint `
+        -ModelId $ModelId `
+        -ModelName $ModelName `
+        -ContextLimit $ContextLimit
+
+    $_configJson = $_configObject | ConvertTo-Json -Depth 12
+    $_utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($_ocConfigFile, $_configJson, $_utf8NoBom)
+    [System.IO.File]::WriteAllText($_ocCompatConfigFile, $_configJson, $_utf8NoBom)
+
+    return @{
+        Status = $_configStatus
+        ConfigPath = $_ocConfigFile
+        CompatConfigPath = $_ocCompatConfigFile
+        ModelId = $ModelId
+        ModelName = $ModelName
+        BaseUrl = $LlmEndpoint.BaseUrl
+    }
+}
+
+function Sync-WindowsOpenCodeConfigFromEnv {
+    param(
+        [string]$InstallDir = $script:DS_INSTALL_DIR,
+        [string]$ConfigDir = $script:OPENCODE_CONFIG_DIR,
+        [string]$GpuBackend = "",
+        [string]$NativeBackend = "",
+        [switch]$UseLemonade,
+        [switch]$CloudMode,
+        [string]$DefaultModelId = "",
+        [string]$DefaultModelName = "",
+        [int]$DefaultContextLimit = 16384,
+        [switch]$SkipIfUnavailable
+    )
+
+    $_envMap = Get-WindowsDreamEnvMap -InstallDir $InstallDir
+    $_llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $InstallDir -EnvMap $_envMap `
+        -GpuBackend $GpuBackend -NativeBackend $NativeBackend `
+        -UseLemonade:$UseLemonade -CloudMode:$CloudMode
+    $_modelId = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("GGUF_FILE") -Default $DefaultModelId
+    $_modelName = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("LLM_MODEL") -Default $DefaultModelName
+    $_contextRaw = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("MAX_CONTEXT", "CTX_SIZE") -Default "$DefaultContextLimit"
+    $_contextLimit = 0
+    if (-not [int]::TryParse($_contextRaw, [ref]$_contextLimit)) {
+        $_contextLimit = $DefaultContextLimit
+    }
+
+    return Sync-WindowsOpenCodeConfig `
+        -LlmEndpoint $_llmEndpoint `
+        -ModelId $_modelId `
+        -ModelName $_modelName `
+        -ContextLimit $_contextLimit `
+        -ConfigDir $ConfigDir `
+        -SkipIfUnavailable:$SkipIfUnavailable
+}

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -3,8 +3,8 @@
 # ============================================================================
 # Part of: installers/windows/phases/
 # Purpose: Install OpenCode (AI coding IDE), Claude Code CLI, and Codex CLI.
-#          Configures OpenCode to point at the local llama-server. Adds
-#          OpenCode to Windows Startup so it persists across reboots.
+#          Configures OpenCode to point at the local llama-server and creates
+#          a manual launcher instead of auto-starting it at login.
 #
 # Reads:
 #   $dryRun, $cloudMode         -- from orchestrator context
@@ -27,7 +27,7 @@ Write-Phase -Phase 7 -Total 13 -Name "DEVELOPER TOOLS" -Estimate "~2-5 minutes"
 if ($dryRun) {
     Write-AI "[DRY RUN] Would install OpenCode v$($script:OPENCODE_VERSION) to $($script:OPENCODE_EXE)"
     Write-AI "[DRY RUN] Would configure OpenCode for local llama-server (model: $($tierConfig.LlmModel))"
-    Write-AI "[DRY RUN] Would add OpenCode to Windows Startup folder"
+    Write-AI "[DRY RUN] Would create a manual OpenCode launcher"
     if (-not $cloudMode) {
         Write-AI "[DRY RUN] Would check for Node.js and install Claude Code + Codex CLI via npm"
     }
@@ -37,6 +37,158 @@ if ($dryRun) {
 }
 
 # ── OpenCode ──────────────────────────────────────────────────────────────────
+function Set-OpenCodeObjectProperty {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object]$Target,
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        $Value
+    )
+
+    $property = $Target.PSObject.Properties[$Name]
+    if ($property) {
+        $property.Value = $Value
+    } else {
+        $Target | Add-Member -NotePropertyName $Name -NotePropertyValue $Value
+    }
+}
+
+function New-WindowsOpenCodeConfigObject {
+    param(
+        [hashtable]$LlmEndpoint,
+        [string]$ModelId,
+        [string]$ModelName,
+        [int]$ContextLimit
+    )
+
+    return [pscustomobject]@{
+        '$schema' = "https://opencode.ai/config.json"
+        model = "llama-server/$ModelId"
+        small_model = "llama-server/$ModelId"
+        provider = [pscustomobject]@{
+            'llama-server' = [pscustomobject]@{
+                npm = "@ai-sdk/openai-compatible"
+                name = "llama-server (local)"
+                options = [pscustomobject]@{
+                    baseURL = $LlmEndpoint.BaseUrl
+                    apiKey = "no-key"
+                }
+                models = [pscustomobject]@{
+                    $ModelId = [pscustomobject]@{
+                        name = $ModelName
+                        limit = [pscustomobject]@{
+                            context = $ContextLimit
+                            output = 32768
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+function Update-WindowsOpenCodeConfigObject {
+    param(
+        [object]$Config,
+        [hashtable]$LlmEndpoint,
+        [string]$ModelId,
+        [string]$ModelName,
+        [int]$ContextLimit
+    )
+
+    if ($null -eq $Config) {
+        return New-WindowsOpenCodeConfigObject -LlmEndpoint $LlmEndpoint -ModelId $ModelId -ModelName $ModelName -ContextLimit $ContextLimit
+    }
+
+    Set-OpenCodeObjectProperty -Target $Config -Name '$schema' -Value "https://opencode.ai/config.json"
+    Set-OpenCodeObjectProperty -Target $Config -Name 'model' -Value "llama-server/$ModelId"
+    Set-OpenCodeObjectProperty -Target $Config -Name 'small_model' -Value "llama-server/$ModelId"
+
+    if (-not $Config.PSObject.Properties['provider'] -or $null -eq $Config.provider) {
+        Set-OpenCodeObjectProperty -Target $Config -Name 'provider' -Value ([pscustomobject]@{})
+    }
+    $provider = $Config.provider
+
+    if (-not $provider.PSObject.Properties['llama-server'] -or $null -eq $provider.'llama-server') {
+        Set-OpenCodeObjectProperty -Target $provider -Name 'llama-server' -Value ([pscustomobject]@{})
+    }
+    $llamaProvider = $provider.'llama-server'
+
+    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'npm' -Value "@ai-sdk/openai-compatible"
+    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'name' -Value "llama-server (local)"
+
+    if (-not $llamaProvider.PSObject.Properties['options'] -or $null -eq $llamaProvider.options) {
+        Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'options' -Value ([pscustomobject]@{})
+    }
+    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'baseURL' -Value $LlmEndpoint.BaseUrl
+    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'apiKey' -Value "no-key"
+
+    if (-not $llamaProvider.PSObject.Properties['models'] -or $null -eq $llamaProvider.models) {
+        Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'models' -Value ([pscustomobject]@{})
+    }
+    $models = $llamaProvider.models
+
+    if (-not $models.PSObject.Properties[$ModelId] -or $null -eq $models.PSObject.Properties[$ModelId].Value) {
+        Set-OpenCodeObjectProperty -Target $models -Name $ModelId -Value ([pscustomobject]@{})
+    }
+    $modelEntry = $models.PSObject.Properties[$ModelId].Value
+    Set-OpenCodeObjectProperty -Target $modelEntry -Name 'name' -Value $ModelName
+
+    if (-not $modelEntry.PSObject.Properties['limit'] -or $null -eq $modelEntry.limit) {
+        Set-OpenCodeObjectProperty -Target $modelEntry -Name 'limit' -Value ([pscustomobject]@{})
+    }
+    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'context' -Value $ContextLimit
+    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'output' -Value 32768
+
+    return $Config
+}
+
+function Sync-WindowsOpenCodeConfig {
+    param(
+        [hashtable]$LlmEndpoint,
+        [string]$ModelId,
+        [string]$ModelName,
+        [int]$ContextLimit
+    )
+
+    $_ocConfigFile = Join-Path $script:OPENCODE_CONFIG_DIR "opencode.json"
+    $_ocCompatConfigFile = Join-Path $script:OPENCODE_CONFIG_DIR "config.json"
+    $_existingConfigFile = @($_ocConfigFile, $_ocCompatConfigFile) |
+        Where-Object { Test-Path $_ } |
+        Select-Object -First 1
+
+    $_configObject = $null
+    $_configStatus = "created"
+
+    if ($_existingConfigFile) {
+        try {
+            $_configObject = Get-Content $_existingConfigFile -Raw | ConvertFrom-Json -ErrorAction Stop
+            $_configStatus = "updated"
+        } catch {
+            Write-AIWarn "OpenCode config is invalid -- regenerating from template"
+            $_configStatus = "regenerated"
+        }
+    }
+
+    $_configObject = Update-WindowsOpenCodeConfigObject `
+        -Config $_configObject `
+        -LlmEndpoint $LlmEndpoint `
+        -ModelId $ModelId `
+        -ModelName $ModelName `
+        -ContextLimit $ContextLimit
+
+    $_configJson = $_configObject | ConvertTo-Json -Depth 12
+    Write-Utf8NoBom -Path $_ocConfigFile -Content $_configJson
+    Write-Utf8NoBom -Path $_ocCompatConfigFile -Content $_configJson
+
+    return @{
+        ConfigPath = $_ocConfigFile
+        CompatConfigPath = $_ocCompatConfigFile
+        Status = $_configStatus
+    }
+}
+
 Write-AI "Setting up OpenCode AI coding assistant..."
 
 if (-not (Test-Path $script:OPENCODE_EXE)) {
@@ -89,56 +241,34 @@ if (-not (Test-Path $script:OPENCODE_EXE)) {
 # ── OpenCode configuration ────────────────────────────────────────────────────
 if (Test-Path $script:OPENCODE_EXE) {
     New-Item -ItemType Directory -Path $script:OPENCODE_CONFIG_DIR -Force | Out-Null
-    $_ocConfigFile = Join-Path $script:OPENCODE_CONFIG_DIR "opencode.json"
-
-    if (-not (Test-Path $_ocConfigFile)) {
-        # llama-server is always on port 8080 (OLLAMA_PORT in .env)
-        # AMD native + NVIDIA Docker both expose on 127.0.0.1:8080
-        $_llamaPort = "8080"
-
-        # Read OLLAMA_PORT from generated .env in case it was overridden
-        $_envPath = Join-Path $installDir ".env"
-        if (Test-Path $_envPath) {
-            $_portLine = Get-Content $_envPath |
-                Where-Object { $_ -match "^OLLAMA_PORT=" } |
-                Select-Object -First 1
-            if ($_portLine) {
-                $_llamaPort = ($_portLine -split "=", 2)[1].Trim()
-            }
-        }
-
-        # NOTE: llama-server exposes models by GGUF filename (not the LlmModel alias)
-        $_ocModelId = $tierConfig.GgufFile
-
-        $ocConfig = @"
-{
-  "`$schema": "https://opencode.ai/config.json",
-  "model": "llama-server/$_ocModelId",
-  "provider": {
-    "llama-server": {
-      "npm": "@ai-sdk/openai-compatible",
-      "name": "llama-server (local)",
-      "options": {
-        "baseURL": "http://127.0.0.1:${_llamaPort}/v1",
-        "apiKey": "no-key"
-      },
-      "models": {
-        "$_ocModelId": {
-          "name": "$($tierConfig.LlmModel)",
-          "limit": {
-            "context": $($tierConfig.MaxContext),
-            "output": 32768
-          }
-        }
-      }
+    $_envMap = Get-WindowsDreamEnvMap -InstallDir $installDir
+    $_llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $installDir -EnvMap $_envMap `
+        -GpuBackend $gpuInfo.Backend -CloudMode:$cloudMode
+    # NOTE: Windows llama-server/OpenCode integration uses the GGUF filename as the model ID.
+    $_ocModelId = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("GGUF_FILE") -Default $tierConfig.GgufFile
+    $_ocModelName = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("LLM_MODEL") -Default $tierConfig.LlmModel
+    $_ocContextRaw = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("MAX_CONTEXT", "CTX_SIZE") -Default "$($tierConfig.MaxContext)"
+    $_ocContext = 0
+    if (-not [int]::TryParse($_ocContextRaw, [ref]$_ocContext)) {
+        $_ocContext = [int]$tierConfig.MaxContext
     }
-  }
-}
-"@
-        Write-Utf8NoBom -Path $_ocConfigFile -Content $ocConfig
-        Write-AISuccess "OpenCode configured for local llama-server (model: $($tierConfig.LlmModel))"
-    } else {
-        Write-AISuccess "OpenCode config already exists -- preserving existing configuration"
+
+    $_ocSync = Sync-WindowsOpenCodeConfig `
+        -LlmEndpoint $_llmEndpoint `
+        -ModelId $_ocModelId `
+        -ModelName $_ocModelName `
+        -ContextLimit $_ocContext
+
+    switch ($_ocSync.Status) {
+        "created" {
+            Write-AISuccess "OpenCode configured for local llama-server (model: $_ocModelName)"
+        }
+        "updated" {
+            Write-AISuccess "OpenCode config updated for local llama-server (model: $_ocModelName)"
+        }
+        default {
+            Write-AISuccess "OpenCode config regenerated for local llama-server (model: $_ocModelName)"
+        }
     }
 
     # ── VBS launcher (available for manual startup) ──────────────────────────
@@ -284,15 +414,19 @@ if (Test-Path $_agentScript) {
             -AllowStartIfOnBatteries -DontStopIfGoingOnBatteries `
             -StartWhenAvailable -ExecutionTimeLimit ([TimeSpan]::Zero)
 
-        Register-ScheduledTask -TaskName $script:DREAM_AGENT_TASK_NAME `
-            -Action $taskAction -Trigger $taskTrigger -Settings $taskSettings `
-            -Description "DreamServer Host Agent -- manages extensions and bridges dashboard to host" `
-            -ErrorAction SilentlyContinue | Out-Null
-
-        if ($?) {
+        $taskError = $null
+        try {
+            Register-ScheduledTask -TaskName $script:DREAM_AGENT_TASK_NAME `
+                -Action $taskAction -Trigger $taskTrigger -Settings $taskSettings `
+                -Description "DreamServer Host Agent -- manages extensions and bridges dashboard to host" `
+                -ErrorAction Stop | Out-Null
             Write-AISuccess "Host agent registered to start at login (Task: $($script:DREAM_AGENT_TASK_NAME))"
-        } else {
+        } catch {
+            $taskError = $_
             Write-AIWarn "Could not register login task -- start manually: .\dream.ps1 agent start"
+            if ($taskError -and $taskError.Exception) {
+                Write-AI "  Scheduled Tasks error: $($taskError.Exception.Message)"
+            }
         }
     } else {
         Write-AIWarn "Python not found -- Dream host agent not started"

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -37,158 +37,7 @@ if ($dryRun) {
 }
 
 # ── OpenCode ──────────────────────────────────────────────────────────────────
-function Set-OpenCodeObjectProperty {
-    param(
-        [Parameter(Mandatory = $true)]
-        [object]$Target,
-        [Parameter(Mandatory = $true)]
-        [string]$Name,
-        $Value
-    )
-
-    $property = $Target.PSObject.Properties[$Name]
-    if ($property) {
-        $property.Value = $Value
-    } else {
-        $Target | Add-Member -NotePropertyName $Name -NotePropertyValue $Value
-    }
-}
-
-function New-WindowsOpenCodeConfigObject {
-    param(
-        [hashtable]$LlmEndpoint,
-        [string]$ModelId,
-        [string]$ModelName,
-        [int]$ContextLimit
-    )
-
-    return [pscustomobject]@{
-        '$schema' = "https://opencode.ai/config.json"
-        model = "llama-server/$ModelId"
-        small_model = "llama-server/$ModelId"
-        provider = [pscustomobject]@{
-            'llama-server' = [pscustomobject]@{
-                npm = "@ai-sdk/openai-compatible"
-                name = "llama-server (local)"
-                options = [pscustomobject]@{
-                    baseURL = $LlmEndpoint.BaseUrl
-                    apiKey = "no-key"
-                }
-                models = [pscustomobject]@{
-                    $ModelId = [pscustomobject]@{
-                        name = $ModelName
-                        limit = [pscustomobject]@{
-                            context = $ContextLimit
-                            output = 32768
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-function Update-WindowsOpenCodeConfigObject {
-    param(
-        [object]$Config,
-        [hashtable]$LlmEndpoint,
-        [string]$ModelId,
-        [string]$ModelName,
-        [int]$ContextLimit
-    )
-
-    if ($null -eq $Config) {
-        return New-WindowsOpenCodeConfigObject -LlmEndpoint $LlmEndpoint -ModelId $ModelId -ModelName $ModelName -ContextLimit $ContextLimit
-    }
-
-    Set-OpenCodeObjectProperty -Target $Config -Name '$schema' -Value "https://opencode.ai/config.json"
-    Set-OpenCodeObjectProperty -Target $Config -Name 'model' -Value "llama-server/$ModelId"
-    Set-OpenCodeObjectProperty -Target $Config -Name 'small_model' -Value "llama-server/$ModelId"
-
-    if (-not $Config.PSObject.Properties['provider'] -or $null -eq $Config.provider) {
-        Set-OpenCodeObjectProperty -Target $Config -Name 'provider' -Value ([pscustomobject]@{})
-    }
-    $provider = $Config.provider
-
-    if (-not $provider.PSObject.Properties['llama-server'] -or $null -eq $provider.'llama-server') {
-        Set-OpenCodeObjectProperty -Target $provider -Name 'llama-server' -Value ([pscustomobject]@{})
-    }
-    $llamaProvider = $provider.'llama-server'
-
-    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'npm' -Value "@ai-sdk/openai-compatible"
-    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'name' -Value "llama-server (local)"
-
-    if (-not $llamaProvider.PSObject.Properties['options'] -or $null -eq $llamaProvider.options) {
-        Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'options' -Value ([pscustomobject]@{})
-    }
-    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'baseURL' -Value $LlmEndpoint.BaseUrl
-    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'apiKey' -Value "no-key"
-
-    if (-not $llamaProvider.PSObject.Properties['models'] -or $null -eq $llamaProvider.models) {
-        Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'models' -Value ([pscustomobject]@{})
-    }
-    $models = $llamaProvider.models
-
-    if (-not $models.PSObject.Properties[$ModelId] -or $null -eq $models.PSObject.Properties[$ModelId].Value) {
-        Set-OpenCodeObjectProperty -Target $models -Name $ModelId -Value ([pscustomobject]@{})
-    }
-    $modelEntry = $models.PSObject.Properties[$ModelId].Value
-    Set-OpenCodeObjectProperty -Target $modelEntry -Name 'name' -Value $ModelName
-
-    if (-not $modelEntry.PSObject.Properties['limit'] -or $null -eq $modelEntry.limit) {
-        Set-OpenCodeObjectProperty -Target $modelEntry -Name 'limit' -Value ([pscustomobject]@{})
-    }
-    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'context' -Value $ContextLimit
-    Set-OpenCodeObjectProperty -Target $modelEntry.limit -Name 'output' -Value 32768
-
-    return $Config
-}
-
-function Sync-WindowsOpenCodeConfig {
-    param(
-        [hashtable]$LlmEndpoint,
-        [string]$ModelId,
-        [string]$ModelName,
-        [int]$ContextLimit
-    )
-
-    $_ocConfigFile = Join-Path $script:OPENCODE_CONFIG_DIR "opencode.json"
-    $_ocCompatConfigFile = Join-Path $script:OPENCODE_CONFIG_DIR "config.json"
-    $_existingConfigFile = @($_ocConfigFile, $_ocCompatConfigFile) |
-        Where-Object { Test-Path $_ } |
-        Select-Object -First 1
-
-    $_configObject = $null
-    $_configStatus = "created"
-
-    if ($_existingConfigFile) {
-        try {
-            $_configObject = Get-Content $_existingConfigFile -Raw | ConvertFrom-Json -ErrorAction Stop
-            $_configStatus = "updated"
-        } catch {
-            Write-AIWarn "OpenCode config is invalid -- regenerating from template"
-            $_configStatus = "regenerated"
-        }
-    }
-
-    $_configObject = Update-WindowsOpenCodeConfigObject `
-        -Config $_configObject `
-        -LlmEndpoint $LlmEndpoint `
-        -ModelId $ModelId `
-        -ModelName $ModelName `
-        -ContextLimit $ContextLimit
-
-    $_configJson = $_configObject | ConvertTo-Json -Depth 12
-    Write-Utf8NoBom -Path $_ocConfigFile -Content $_configJson
-    Write-Utf8NoBom -Path $_ocCompatConfigFile -Content $_configJson
-
-    return @{
-        ConfigPath = $_ocConfigFile
-        CompatConfigPath = $_ocCompatConfigFile
-        Status = $_configStatus
-    }
-}
-
+# Config helpers are sourced from installers/windows/lib/opencode-config.ps1.
 Write-AI "Setting up OpenCode AI coding assistant..."
 
 if (-not (Test-Path $script:OPENCODE_EXE)) {
@@ -240,34 +89,23 @@ if (-not (Test-Path $script:OPENCODE_EXE)) {
 
 # ── OpenCode configuration ────────────────────────────────────────────────────
 if (Test-Path $script:OPENCODE_EXE) {
-    New-Item -ItemType Directory -Path $script:OPENCODE_CONFIG_DIR -Force | Out-Null
-    $_envMap = Get-WindowsDreamEnvMap -InstallDir $installDir
-    $_llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $installDir -EnvMap $_envMap `
-        -GpuBackend $gpuInfo.Backend -CloudMode:$cloudMode
-    # NOTE: Windows llama-server/OpenCode integration uses the GGUF filename as the model ID.
-    $_ocModelId = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("GGUF_FILE") -Default $tierConfig.GgufFile
-    $_ocModelName = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("LLM_MODEL") -Default $tierConfig.LlmModel
-    $_ocContextRaw = Get-WindowsDreamEnvValue -EnvMap $_envMap -Keys @("MAX_CONTEXT", "CTX_SIZE") -Default "$($tierConfig.MaxContext)"
-    $_ocContext = 0
-    if (-not [int]::TryParse($_ocContextRaw, [ref]$_ocContext)) {
-        $_ocContext = [int]$tierConfig.MaxContext
-    }
-
-    $_ocSync = Sync-WindowsOpenCodeConfig `
-        -LlmEndpoint $_llmEndpoint `
-        -ModelId $_ocModelId `
-        -ModelName $_ocModelName `
-        -ContextLimit $_ocContext
+    $_ocSync = Sync-WindowsOpenCodeConfigFromEnv `
+        -InstallDir $installDir `
+        -GpuBackend $gpuInfo.Backend `
+        -CloudMode:$cloudMode `
+        -DefaultModelId $tierConfig.GgufFile `
+        -DefaultModelName $tierConfig.LlmModel `
+        -DefaultContextLimit ([int]$tierConfig.MaxContext)
 
     switch ($_ocSync.Status) {
         "created" {
-            Write-AISuccess "OpenCode configured for local llama-server (model: $_ocModelName)"
+            Write-AISuccess "OpenCode configured for local llama-server (model: $($_ocSync.ModelName))"
         }
         "updated" {
-            Write-AISuccess "OpenCode config updated for local llama-server (model: $_ocModelName)"
+            Write-AISuccess "OpenCode config updated for local llama-server (model: $($_ocSync.ModelName))"
         }
         default {
-            Write-AISuccess "OpenCode config regenerated for local llama-server (model: $_ocModelName)"
+            Write-AISuccess "OpenCode config regenerated for local llama-server (model: $($_ocSync.ModelName))"
         }
     }
 

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -80,6 +80,35 @@ STATUSEOF
     mv "$STATUS_FILE.tmp" "$STATUS_FILE"
 }
 
+sync_windows_opencode_config() {
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) ;;
+        *) return 0 ;;
+    esac
+
+    local sync_script="$INSTALL_DIR/scripts/update-windows-opencode-config.ps1"
+    [[ -f "$sync_script" ]] || return 0
+
+    local ps_cmd=""
+    if command -v powershell.exe >/dev/null 2>&1; then
+        ps_cmd="powershell.exe"
+    elif command -v pwsh.exe >/dev/null 2>&1; then
+        ps_cmd="pwsh.exe"
+    fi
+    [[ -n "$ps_cmd" ]] || return 0
+
+    local install_dir_arg="$INSTALL_DIR"
+    local sync_script_arg="$sync_script"
+    if command -v cygpath >/dev/null 2>&1; then
+        install_dir_arg=$(cygpath -w "$INSTALL_DIR")
+        sync_script_arg=$(cygpath -w "$sync_script")
+    fi
+
+    log "Refreshing Windows OpenCode config for model: $FULL_GGUF_FILE"
+    "$ps_cmd" -NoProfile -ExecutionPolicy Bypass -File "$sync_script_arg" -InstallDir "$install_dir_arg" \
+        >/dev/null 2>&1 || log "WARNING: OpenCode config refresh failed (non-fatal)"
+}
+
 # Background monitor: polls .part file size every 2s
 monitor_download() {
     local part_file="$1" total_bytes="$2"
@@ -475,6 +504,7 @@ LITELLM_UPGRADE_EOF
                 log "WARNING: No compose args — cannot recreate OpenClaw. Restart manually."
             fi
         fi
+        sync_windows_opencode_config
     else
         log "WARNING: llama-server health check timed out. The model may still be loading."
         log "Check: docker logs dream-llama-server"

--- a/dream-server/scripts/update-windows-opencode-config.ps1
+++ b/dream-server/scripts/update-windows-opencode-config.ps1
@@ -1,0 +1,25 @@
+[CmdletBinding()]
+param(
+    [string]$InstallDir = ""
+)
+
+$ErrorActionPreference = "Stop"
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$RepoRoot = Split-Path $ScriptDir -Parent
+$WindowsInstallerDir = Join-Path (Join-Path $RepoRoot "installers") "windows"
+$LibDir = Join-Path $WindowsInstallerDir "lib"
+
+. (Join-Path $LibDir "constants.ps1")
+. (Join-Path $LibDir "ui.ps1")
+. (Join-Path $LibDir "llm-endpoint.ps1")
+. (Join-Path $LibDir "opencode-config.ps1")
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = $script:DS_INSTALL_DIR
+}
+
+$sync = Sync-WindowsOpenCodeConfigFromEnv -InstallDir $InstallDir -SkipIfUnavailable
+if ($sync.Status -ne "skipped") {
+    Write-Host "OpenCode config $($sync.Status) for model $($sync.ModelName)"
+}

--- a/dream-server/tests/test-windows-opencode-config.sh
+++ b/dream-server/tests/test-windows-opencode-config.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Windows OpenCode config tests
+# ============================================================================
+# Static checks for the Windows OpenCode config migration/update path.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEVTOOLS_PS1="$ROOT_DIR/installers/windows/phases/07-devtools.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== Windows OpenCode config tests ==="
+echo ""
+
+[[ -f "$DEVTOOLS_PS1" ]] && pass "07-devtools.ps1 exists" || fail "07-devtools.ps1 missing"
+grep -q "function Sync-WindowsOpenCodeConfig" "$DEVTOOLS_PS1" && pass "sync helper exists" || fail "sync helper missing"
+grep -q 'config.json' "$DEVTOOLS_PS1" && pass "config.json sync exists" || fail "config.json sync missing"
+grep -q 'Get-WindowsDreamEnvMap' "$DEVTOOLS_PS1" && pass "OpenCode config reads shared env helper" || fail "shared env helper missing from OpenCode config path"
+grep -q 'OpenCode config updated' "$DEVTOOLS_PS1" && pass "existing config update message exists" || fail "existing config update message missing"
+
+if grep -q 'preserving existing configuration' "$DEVTOOLS_PS1"; then
+    fail "existing configs are still preserved without migration"
+else
+    pass "existing configs are no longer preserved without migration"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/dream-server/tests/test-windows-opencode-config.sh
+++ b/dream-server/tests/test-windows-opencode-config.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEVTOOLS_PS1="$ROOT_DIR/installers/windows/phases/07-devtools.ps1"
+OPENCODE_LIB="$ROOT_DIR/installers/windows/lib/opencode-config.ps1"
+INSTALLER_PS1="$ROOT_DIR/installers/windows/install-windows.ps1"
+BOOTSTRAP_UPGRADE="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+UPDATE_SCRIPT="$ROOT_DIR/scripts/update-windows-opencode-config.ps1"
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -25,9 +29,14 @@ echo "=== Windows OpenCode config tests ==="
 echo ""
 
 [[ -f "$DEVTOOLS_PS1" ]] && pass "07-devtools.ps1 exists" || fail "07-devtools.ps1 missing"
-grep -q "function Sync-WindowsOpenCodeConfig" "$DEVTOOLS_PS1" && pass "sync helper exists" || fail "sync helper missing"
-grep -q 'config.json' "$DEVTOOLS_PS1" && pass "config.json sync exists" || fail "config.json sync missing"
-grep -q 'Get-WindowsDreamEnvMap' "$DEVTOOLS_PS1" && pass "OpenCode config reads shared env helper" || fail "shared env helper missing from OpenCode config path"
+[[ -f "$OPENCODE_LIB" ]] && pass "opencode-config.ps1 exists" || fail "opencode-config.ps1 missing"
+[[ -f "$UPDATE_SCRIPT" ]] && pass "update-windows-opencode-config.ps1 exists" || fail "update-windows-opencode-config.ps1 missing"
+grep -q "function Sync-WindowsOpenCodeConfigFromEnv" "$OPENCODE_LIB" && pass "env sync helper exists" || fail "env sync helper missing"
+grep -q 'config.json' "$OPENCODE_LIB" && pass "config.json sync exists" || fail "config.json sync missing"
+grep -q 'Sync-WindowsOpenCodeConfigFromEnv' "$DEVTOOLS_PS1" && pass "phase 07 uses shared OpenCode sync helper" || fail "phase 07 missing shared OpenCode sync helper"
+grep -q 'opencode-config.ps1' "$INSTALLER_PS1" && pass "installer sources OpenCode helper library" || fail "installer missing OpenCode helper library"
+grep -q 'OpenCode config synced to active model' "$INSTALLER_PS1" && pass "installer resyncs OpenCode after launch" || fail "installer missing active-model OpenCode resync"
+grep -q 'update-windows-opencode-config.ps1' "$BOOTSTRAP_UPGRADE" && pass "bootstrap upgrade refreshes Windows OpenCode config" || fail "bootstrap upgrade missing Windows OpenCode refresh"
 grep -q 'OpenCode config updated' "$DEVTOOLS_PS1" && pass "existing config update message exists" || fail "existing config update message missing"
 
 if grep -q 'preserving existing configuration' "$DEVTOOLS_PS1"; then

--- a/dream-server/tests/test-windows-report-command.sh
+++ b/dream-server/tests/test-windows-report-command.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DREAM_PS1="$ROOT_DIR/installers/windows/dream.ps1"
 REPORT_LIB="$ROOT_DIR/installers/windows/lib/install-report.ps1"
+LLM_HELPER_LIB="$ROOT_DIR/installers/windows/lib/llm-endpoint.ps1"
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -27,14 +28,22 @@ echo ""
 
 [[ -f "$DREAM_PS1" ]] && pass "dream.ps1 exists" || fail "dream.ps1 missing"
 [[ -f "$REPORT_LIB" ]] && pass "install-report.ps1 exists" || fail "install-report.ps1 missing"
+[[ -f "$LLM_HELPER_LIB" ]] && pass "llm-endpoint.ps1 exists" || fail "llm-endpoint.ps1 missing"
 
 grep -q "install-report.ps1" "$DREAM_PS1" && pass "dream.ps1 sources report library" || fail "dream.ps1 missing report library source"
+grep -q "llm-endpoint.ps1" "$DREAM_PS1" && pass "dream.ps1 sources llm endpoint helper" || fail "dream.ps1 missing llm endpoint helper source"
 grep -q "function Invoke-Report" "$DREAM_PS1" && pass "Invoke-Report function exists" || fail "Invoke-Report function missing"
 grep -q '"report"  { Invoke-Report }' "$DREAM_PS1" && pass "report command dispatch exists" || fail "report command dispatch missing"
 grep -q "Generate Windows diagnostics bundle" "$DREAM_PS1" && pass "help text includes report command" || fail "help text missing report command"
 
 grep -q "function Write-DreamInstallReport" "$REPORT_LIB" && pass "report writer function exists" || fail "report writer function missing"
 grep -q "windows-report" "$REPORT_LIB" && pass "report output path is defined" || fail "report output path missing"
+grep -q "Get-WindowsLocalLlmEndpoint" "$REPORT_LIB" && pass "report uses shared llm endpoint helper" || fail "report missing shared llm endpoint helper"
+if grep -q 'http://localhost:8080/health' "$REPORT_LIB"; then
+    fail "report lib still hardcodes localhost:8080/health"
+else
+    pass "report lib does not hardcode localhost:8080/health"
+fi
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"


### PR DESCRIPTION
## Summary

- centralize Windows local LLM endpoint resolution in a shared helper and reuse it in the CLI, installer verification, and support report flows
- fix the Windows report command so it no longer hardcodes `http://localhost:8080/health` on Docker-backed installs
- migrate existing Windows OpenCode configs instead of preserving stale `8080` settings forever, and sync both `opencode.json` and `config.json`
- add regression coverage for the report path and OpenCode config migration

## Root cause

Several Windows entry points had drifted and were each inferring the local LLM endpoint independently. That left `dream.ps1 status` and `chat`, installer verification, and `dream.ps1 report` out of sync, especially on Docker-backed NVIDIA/CPU installs that expose llama-server through `OLLAMA_PORT` rather than `8080`.

OpenCode had a similar split-brain problem: the Windows installer only wrote config for first-time installs, so reinstalls and upgrades preserved stale `baseURL` values and never repaired existing configs.

## What changed

- added `installers/windows/lib/llm-endpoint.ps1` to parse `.env` and resolve local LLM base/health URLs for Docker-backed, native AMD, and Lemonade cases
- updated `installers/windows/dream.ps1`, `installers/windows/install-windows.ps1`, and `installers/windows/lib/install-report.ps1` to use that shared resolver
- refactored `installers/windows/phases/07-devtools.ps1` to create or update OpenCode config deterministically, including `config.json` sync
- added static regression tests for the Windows report and OpenCode config paths

## Validation

- parsed all touched PowerShell files successfully
- `tests/test-windows-report-command.sh`
- `tests/test-windows-opencode-config.sh`
- live `dream.ps1 chat "Reply with the single word OK."`
- live `dream.ps1 report`, verified `LLM API: True (status 200)` in the generated report
- live reinstall after seeding a stale OpenCode config, verified both `opencode.json` and `config.json` were repaired to `http://localhost:11434/v1`

## Follow-up

This PR does not yet address the separate bootstrap-upgrade timing issue where OpenCode can drift after the bootstrap model is later replaced by the full model.