### PR TITLE
fix(dream-cli): schema-driven secret masking + macOS Bash 4 validation

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -75,7 +75,8 @@
     },
     "N8N_USER": {
       "type": "string",
-      "description": "n8n initial admin email address"
+      "description": "n8n initial admin email address",
+      "secret": true
     },
     "N8N_PASS": {
       "type": "string",
@@ -497,7 +498,8 @@
     "LANGFUSE_INIT_USER_EMAIL": {
       "type": "string",
       "description": "Langfuse initial admin user email",
-      "default": "admin@dreamserver.local"
+      "default": "admin@dreamserver.local",
+      "secret": true
     },
     "LANGFUSE_INIT_USER_PASSWORD": {
       "type": "string",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -79,7 +79,8 @@
     },
     "N8N_USER": {
       "type": "string",
-      "description": "n8n initial admin email address"
+      "description": "n8n initial admin email address",
+      "secret": true
     },
     "N8N_PASS": {
       "type": "string",
@@ -539,7 +540,8 @@
     "LANGFUSE_INIT_USER_EMAIL": {
       "type": "string",
       "description": "Langfuse initial admin user email",
-      "default": "admin@dreamserver.local"
+      "default": "admin@dreamserver.local",
+      "secret": true
     },
     "LANGFUSE_INIT_USER_PASSWORD": {
       "type": "string",

--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -40,6 +40,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== dream-cli pipefail tolerance ==="
 	@bash tests/test-dream-cli-pipefail-tolerance.sh
+	@echo ""
+	@echo "=== dream config show secret-mask matrix ==="
+	@bash tests/test-dream-config-secret-mask.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1125,7 +1125,7 @@ cmd_config() {
                 # substring match against common secret-ish keywords.
                 _kl="${_k,,}"
                 case "$_kl" in
-                    *secret*|*password*|*pass*|*token*|*key*|*salt*) return 0 ;;
+                    *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*) return 0 ;;
                 esac
                 return 1
             }

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1148,7 +1148,11 @@ cmd_config() {
         validate)
             cd "$INSTALL_DIR"
             if [[ -x "$INSTALL_DIR/scripts/validate-env.sh" ]]; then
-                "$INSTALL_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$INSTALL_DIR/.env.schema.json"
+                # Invoke through "$BASH" (the currently-running shell, guaranteed
+                # Bash 4+ by the version check at the top of this file). The
+                # target script uses associative arrays (declare -A), which
+                # crash under macOS's system /bin/bash (3.2).
+                "$BASH" "$INSTALL_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$INSTALL_DIR/.env.schema.json"
             else
                 warn "validate-env.sh not found at $INSTALL_DIR/scripts/validate-env.sh"
                 warn "Make sure you're on a recent Dream Server release."

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1087,6 +1087,42 @@ cmd_shell() {
     docker exec -it "$container" /bin/bash || docker exec -it "$container" /bin/sh
 }
 
+# File-scope helpers used by `dream config show` and `dream preset diff` to
+# mask secret values. `.env.schema.json` is the authoritative source; keys
+# marked `"secret": true` are treated as secrets. A keyword fallback covers
+# schema gaps (e.g. ANTHROPIC_API_KEY is currently secret:false) and the case
+# where the schema file or jq is unavailable. Callers must invoke
+# _cmd_config_load_secret_schema once (after check_install, so INSTALL_DIR is
+# set) before calling _cmd_config_is_secret.
+_cmd_config_secret_keys=()
+_cmd_config_schema_loaded=0
+
+_cmd_config_load_secret_schema() {
+    local _schema_path="$INSTALL_DIR/.env.schema.json"
+    _cmd_config_secret_keys=()
+    _cmd_config_schema_loaded=0
+    if [[ -f "$_schema_path" ]] && command -v jq >/dev/null 2>&1; then
+        mapfile -t _cmd_config_secret_keys < <(jq -r '.properties | to_entries[] | select(.value.secret == true) | .key' "$_schema_path" 2>/dev/null)
+        _cmd_config_schema_loaded=1
+    fi
+}
+
+_cmd_config_is_secret() {
+    local _k="$1" _s _kl
+    if (( _cmd_config_schema_loaded == 1 )); then
+        for _s in "${_cmd_config_secret_keys[@]}"; do
+            [[ "$_k" == "$_s" ]] && return 0
+        done
+        # Fall through to keyword match — defense in depth against schema gaps
+        # and against malformed schemas where jq returns zero secret keys.
+    fi
+    _kl="${_k,,}"
+    case "$_kl" in
+        *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*) return 0 ;;
+    esac
+    return 1
+}
+
 cmd_config() {
     check_install
 
@@ -1099,36 +1135,7 @@ cmd_config() {
             echo ""
             echo -e "${CYAN}.env contents:${NC}"
 
-            # Mask secrets using .env.schema.json as the authoritative source:
-            # keys marked `"secret": true` in the schema are hidden. If the
-            # schema file or jq is unavailable, fall back to a case-insensitive
-            # substring match on common secret-ish keywords. The narrow regex
-            # that previously lived here missed suffixes like _PASSWORD and
-            # _SALT (see fix notes in commit message).
-            local _schema_path="$INSTALL_DIR/.env.schema.json"
-            local -a _secret_keys=()
-            local _schema_loaded=0
-            if [[ -f "$_schema_path" ]] && command -v jq >/dev/null 2>&1; then
-                mapfile -t _secret_keys < <(jq -r '.properties | to_entries[] | select(.value.secret == true) | .key' "$_schema_path" 2>/dev/null)
-                _schema_loaded=1
-            fi
-
-            _cmd_config_is_secret() {
-                local _k="$1" _s _kl
-                if (( _schema_loaded == 1 )); then
-                    for _s in "${_secret_keys[@]}"; do
-                        [[ "$_k" == "$_s" ]] && return 0
-                    done
-                    return 1
-                fi
-                # Fallback (schema or jq unavailable): case-insensitive
-                # substring match against common secret-ish keywords.
-                _kl="${_k,,}"
-                case "$_kl" in
-                    *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*) return 0 ;;
-                esac
-                return 1
-            }
+            _cmd_config_load_secret_schema
 
             local _line _key
             while IFS= read -r _line; do
@@ -2034,6 +2041,11 @@ META
             # Compare environment variables
             echo -e "${CYAN}━━━ Environment Variables ━━━${NC}"
             if [[ -f "$dir1/env" ]] && [[ -f "$dir2/env" ]]; then
+                # Load secret schema so `_cmd_config_is_secret` below can consult
+                # .env.schema.json instead of the narrow regex the old version
+                # used (which missed _PASS, _SALT, email admin fields, etc.).
+                _cmd_config_load_secret_schema
+
                 # Parse both env files
                 declare -A env1 env2
                 while IFS='=' read -r key value; do
@@ -2065,7 +2077,7 @@ META
                         has_diff=true
 
                         # Mask sensitive values for display
-                        if [[ "$key" =~ (PASSWORD|SECRET|KEY|TOKEN|API) ]]; then
+                        if _cmd_config_is_secret "$key"; then
                             [[ -n "$val1" ]] && val1="***"
                             [[ -n "$val2" ]] && val2="***"
                         fi

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1098,14 +1098,48 @@ cmd_config() {
             echo "Install dir: $INSTALL_DIR"
             echo ""
             echo -e "${CYAN}.env contents:${NC}"
-            grep -v "^#" "$INSTALL_DIR/.env" | grep -v "^$" | while read line; do
-                # Hide sensitive values
-                if echo "$line" | grep -qiE "(secret|pass|token|key)="; then
-                    echo "  ${line%%=*}=***"
-                else
-                    echo "  $line"
+
+            # Mask secrets using .env.schema.json as the authoritative source:
+            # keys marked `"secret": true` in the schema are hidden. If the
+            # schema file or jq is unavailable, fall back to a case-insensitive
+            # substring match on common secret-ish keywords. The narrow regex
+            # that previously lived here missed suffixes like _PASSWORD and
+            # _SALT (see fix notes in commit message).
+            local _schema_path="$INSTALL_DIR/.env.schema.json"
+            local -a _secret_keys=()
+            local _schema_loaded=0
+            if [[ -f "$_schema_path" ]] && command -v jq >/dev/null 2>&1; then
+                mapfile -t _secret_keys < <(jq -r '.properties | to_entries[] | select(.value.secret == true) | .key' "$_schema_path" 2>/dev/null)
+                _schema_loaded=1
+            fi
+
+            _cmd_config_is_secret() {
+                local _k="$1" _s _kl
+                if (( _schema_loaded == 1 )); then
+                    for _s in "${_secret_keys[@]}"; do
+                        [[ "$_k" == "$_s" ]] && return 0
+                    done
+                    return 1
                 fi
-            done
+                # Fallback (schema or jq unavailable): case-insensitive
+                # substring match against common secret-ish keywords.
+                _kl="${_k,,}"
+                case "$_kl" in
+                    *secret*|*password*|*pass*|*token*|*key*|*salt*) return 0 ;;
+                esac
+                return 1
+            }
+
+            local _line _key
+            while IFS= read -r _line; do
+                [[ -z "$_line" || "$_line" =~ ^[[:space:]]*# ]] && continue
+                _key="${_line%%=*}"
+                if _cmd_config_is_secret "$_key"; then
+                    echo "  ${_key}=***"
+                else
+                    echo "  $_line"
+                fi
+            done < "$INSTALL_DIR/.env"
             ;;
         edit)
             ${EDITOR:-nano} "$INSTALL_DIR/.env"

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1368,24 +1368,60 @@ _cmd_config_load_secret_schema() {
     local _schema_path="$INSTALL_DIR/.env.schema.json"
     _cmd_config_secret_keys=()
     _cmd_config_schema_loaded=0
-    if [[ -f "$_schema_path" ]] && command -v jq >/dev/null 2>&1; then
+    [[ -f "$_schema_path" ]] || return 0
+
+    # Prefer jq when available — fast, single-process, schema-typed.
+    if command -v jq >/dev/null 2>&1; then
         mapfile -t _cmd_config_secret_keys < <(jq -r '.properties | to_entries[] | select(.value.secret == true) | .key' "$_schema_path" 2>/dev/null)
         _cmd_config_schema_loaded=1
+        return 0
     fi
+
+    # python3 fallback for environments without jq (Git Bash on Windows
+    # is the common one). The installer guarantees python3, so this
+    # path closes the gap where N8N_USER / LANGFUSE_INIT_USER_EMAIL etc.
+    # would otherwise leak through the keyword fallback.
+    if command -v python3 >/dev/null 2>&1; then
+        mapfile -t _cmd_config_secret_keys < <(python3 - "$_schema_path" <<'PYEOF' 2>/dev/null
+import json, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except (OSError, json.JSONDecodeError):
+    sys.exit(0)
+for key, spec in (data.get("properties") or {}).items():
+    if isinstance(spec, dict) and spec.get("secret") is True:
+        print(key)
+PYEOF
+)
+        _cmd_config_schema_loaded=1
+        return 0
+    fi
+
+    # Neither jq nor python3 — leave _cmd_config_schema_loaded=0 so
+    # _cmd_config_is_secret falls through to the keyword regex (which
+    # covers user/email keys explicitly to avoid leaks in this case).
 }
 
 _cmd_config_is_secret() {
     local _k="$1" _s _kl
     if (( _cmd_config_schema_loaded == 1 )); then
         for _s in "${_cmd_config_secret_keys[@]}"; do
+            _s="${_s%$'\r'}"
             [[ "$_k" == "$_s" ]] && return 0
         done
         # Fall through to keyword match — defense in depth against schema gaps
-        # and against malformed schemas where jq returns zero secret keys.
+        # and against malformed schemas where jq/python returns zero secret keys.
     fi
     _kl="${_k,,}"
+    # `*user*` and `*email*` cover N8N_USER, LANGFUSE_INIT_USER_EMAIL, etc.
+    # in environments where neither jq nor python3 was available to read
+    # `.env.schema.json` (Git Bash without jq). Risks light over-masking
+    # on operational keys like USER_HOME, but `cat .env` remains the
+    # escape hatch — `dream config show` defaults to over-mask on
+    # purpose.
     case "$_kl" in
-        *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*) return 0 ;;
+        *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*|*user*|*email*) return 0 ;;
     esac
     return 1
 }

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1415,7 +1415,11 @@ cmd_config() {
         validate)
             cd "$INSTALL_DIR"
             if [[ -x "$INSTALL_DIR/scripts/validate-env.sh" ]]; then
-                "$INSTALL_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$INSTALL_DIR/.env.schema.json"
+                # Invoke through "$BASH" (the currently-running shell, guaranteed
+                # Bash 4+ by the version check at the top of this file). The
+                # target script uses associative arrays (declare -A), which
+                # crash under macOS's system /bin/bash (3.2).
+                "$BASH" "$INSTALL_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$INSTALL_DIR/.env.schema.json"
             else
                 warn "validate-env.sh not found at $INSTALL_DIR/scripts/validate-env.sh"
                 warn "Make sure you're on a recent Dream Server release."

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1354,6 +1354,42 @@ cmd_shell() {
     fi
 }
 
+# File-scope helpers used by `dream config show` and `dream preset diff` to
+# mask secret values. `.env.schema.json` is the authoritative source; keys
+# marked `"secret": true` are treated as secrets. A keyword fallback covers
+# schema gaps (e.g. ANTHROPIC_API_KEY is currently secret:false) and the case
+# where the schema file or jq is unavailable. Callers must invoke
+# _cmd_config_load_secret_schema once (after check_install, so INSTALL_DIR is
+# set) before calling _cmd_config_is_secret.
+_cmd_config_secret_keys=()
+_cmd_config_schema_loaded=0
+
+_cmd_config_load_secret_schema() {
+    local _schema_path="$INSTALL_DIR/.env.schema.json"
+    _cmd_config_secret_keys=()
+    _cmd_config_schema_loaded=0
+    if [[ -f "$_schema_path" ]] && command -v jq >/dev/null 2>&1; then
+        mapfile -t _cmd_config_secret_keys < <(jq -r '.properties | to_entries[] | select(.value.secret == true) | .key' "$_schema_path" 2>/dev/null)
+        _cmd_config_schema_loaded=1
+    fi
+}
+
+_cmd_config_is_secret() {
+    local _k="$1" _s _kl
+    if (( _cmd_config_schema_loaded == 1 )); then
+        for _s in "${_cmd_config_secret_keys[@]}"; do
+            [[ "$_k" == "$_s" ]] && return 0
+        done
+        # Fall through to keyword match — defense in depth against schema gaps
+        # and against malformed schemas where jq returns zero secret keys.
+    fi
+    _kl="${_k,,}"
+    case "$_kl" in
+        *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*) return 0 ;;
+    esac
+    return 1
+}
+
 cmd_config() {
     check_install
 
@@ -1366,36 +1402,7 @@ cmd_config() {
             echo ""
             echo -e "${CYAN}.env contents:${NC}"
 
-            # Mask secrets using .env.schema.json as the authoritative source:
-            # keys marked `"secret": true` in the schema are hidden. If the
-            # schema file or jq is unavailable, fall back to a case-insensitive
-            # substring match on common secret-ish keywords. The narrow regex
-            # that previously lived here missed suffixes like _PASSWORD and
-            # _SALT (see fix notes in commit message).
-            local _schema_path="$INSTALL_DIR/.env.schema.json"
-            local -a _secret_keys=()
-            local _schema_loaded=0
-            if [[ -f "$_schema_path" ]] && command -v jq >/dev/null 2>&1; then
-                mapfile -t _secret_keys < <(jq -r '.properties | to_entries[] | select(.value.secret == true) | .key' "$_schema_path" 2>/dev/null)
-                _schema_loaded=1
-            fi
-
-            _cmd_config_is_secret() {
-                local _k="$1" _s _kl
-                if (( _schema_loaded == 1 )); then
-                    for _s in "${_secret_keys[@]}"; do
-                        [[ "$_k" == "$_s" ]] && return 0
-                    done
-                    return 1
-                fi
-                # Fallback (schema or jq unavailable): case-insensitive
-                # substring match against common secret-ish keywords.
-                _kl="${_k,,}"
-                case "$_kl" in
-                    *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*) return 0 ;;
-                esac
-                return 1
-            }
+            _cmd_config_load_secret_schema
 
             local _line _key
             while IFS= read -r _line; do
@@ -2379,6 +2386,11 @@ META
             # Compare environment variables
             echo -e "${BLUE}━━━ Environment Variables ━━━${NC}"
             if [[ -f "$dir1/env" ]] && [[ -f "$dir2/env" ]]; then
+                # Load secret schema so `_cmd_config_is_secret` below can consult
+                # .env.schema.json instead of the narrow regex the old version
+                # used (which missed _PASS, _SALT, email admin fields, etc.).
+                _cmd_config_load_secret_schema
+
                 # Parse both env files
                 declare -A env1 env2
                 while IFS='=' read -r key value; do
@@ -2410,7 +2422,7 @@ META
                         has_diff=true
 
                         # Mask sensitive values for display
-                        if [[ "$key" =~ (PASSWORD|SECRET|KEY|TOKEN|API) ]]; then
+                        if _cmd_config_is_secret "$key"; then
                             [[ -n "$val1" ]] && val1="***"
                             [[ -n "$val2" ]] && val2="***"
                         fi

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1365,14 +1365,48 @@ cmd_config() {
             echo "Install dir: $INSTALL_DIR"
             echo ""
             echo -e "${CYAN}.env contents:${NC}"
-            while IFS= read -r line; do
-                # Hide sensitive values
-                if echo "$line" | grep -qiE "(secret|pass|token|key)="; then
-                    echo "  ${line%%=*}=***"
-                else
-                    echo "  $line"
+
+            # Mask secrets using .env.schema.json as the authoritative source:
+            # keys marked `"secret": true` in the schema are hidden. If the
+            # schema file or jq is unavailable, fall back to a case-insensitive
+            # substring match on common secret-ish keywords. The narrow regex
+            # that previously lived here missed suffixes like _PASSWORD and
+            # _SALT (see fix notes in commit message).
+            local _schema_path="$INSTALL_DIR/.env.schema.json"
+            local -a _secret_keys=()
+            local _schema_loaded=0
+            if [[ -f "$_schema_path" ]] && command -v jq >/dev/null 2>&1; then
+                mapfile -t _secret_keys < <(jq -r '.properties | to_entries[] | select(.value.secret == true) | .key' "$_schema_path" 2>/dev/null)
+                _schema_loaded=1
+            fi
+
+            _cmd_config_is_secret() {
+                local _k="$1" _s _kl
+                if (( _schema_loaded == 1 )); then
+                    for _s in "${_secret_keys[@]}"; do
+                        [[ "$_k" == "$_s" ]] && return 0
+                    done
+                    return 1
                 fi
-            done < <(grep -v "^#" "$INSTALL_DIR/.env" | grep -v "^$" || true)
+                # Fallback (schema or jq unavailable): case-insensitive
+                # substring match against common secret-ish keywords.
+                _kl="${_k,,}"
+                case "$_kl" in
+                    *secret*|*password*|*pass*|*token*|*key*|*salt*) return 0 ;;
+                esac
+                return 1
+            }
+
+            local _line _key
+            while IFS= read -r _line; do
+                [[ -z "$_line" || "$_line" =~ ^[[:space:]]*# ]] && continue
+                _key="${_line%%=*}"
+                if _cmd_config_is_secret "$_key"; then
+                    echo "  ${_key}=***"
+                else
+                    echo "  $_line"
+                fi
+            done < "$INSTALL_DIR/.env"
             ;;
         edit)
             ${EDITOR:-nano} "$INSTALL_DIR/.env"

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1392,7 +1392,7 @@ cmd_config() {
                 # substring match against common secret-ish keywords.
                 _kl="${_k,,}"
                 case "$_kl" in
-                    *secret*|*password*|*pass*|*token*|*key*|*salt*) return 0 ;;
+                    *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*) return 0 ;;
                 esac
                 return 1
             }

--- a/dream-server/scripts/validate-env.sh
+++ b/dream-server/scripts/validate-env.sh
@@ -7,6 +7,19 @@
 #  - Validate required keys, unknown keys, types, enums, and numeric ranges
 #  - Fail deterministically with a single exit code for CI
 
+# Require Bash 4+ (associative arrays used below).
+# macOS ships Bash 3.2 due to licensing; the system /bin/bash will crash on
+# `declare -A`. When launched via dream-cli this is invoked through "$BASH",
+# but this guard protects direct invocations (e.g. /bin/bash validate-env.sh).
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "✗ validate-env.sh requires Bash 4+ (you have ${BASH_VERSION})" >&2
+    echo "  macOS ships Bash 3.2 — install a modern Bash:" >&2
+    echo "    brew install bash" >&2
+    echo "  Then re-run with the Homebrew bash, e.g.:" >&2
+    echo "    /opt/homebrew/bin/bash $0 $*" >&2
+    exit 1
+fi
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/dream-server/tests/test-dream-config-secret-mask.sh
+++ b/dream-server/tests/test-dream-config-secret-mask.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Regression: `dream config show` masks `N8N_USER` and
+# `LANGFUSE_INIT_USER_EMAIL` even in environments without `jq`.
+# ============================================================================
+# Audit follow-up on PR #994 (Lightheartdevs, 2026-04-28):
+#
+#   "Schema-driven secret masking is useful, but the CLI only learns
+#    the schema secret flags through `jq`. In Git Bash without `jq`,
+#    newly marked user/email fields such as `N8N_USER` and
+#    `LANGFUSE_INIT_USER_EMAIL` can still print in clear. Please either
+#    make schema parsing available without `jq` for this command or
+#    extend the fallback mask to cover the new schema secrets."
+#
+# Both fixes are now in place: a Python fallback parser when `jq` is
+# absent, plus `*user*` / `*email*` keyword fallback when neither is
+# present. This test exercises all three PATH configurations.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DREAM_CLI="$ROOT_DIR/dream-cli"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   dream config show — secret masking matrix   ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+if [[ ! -x "$DREAM_CLI" ]]; then
+    fail "dream-cli not found at $DREAM_CLI"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+
+# Scaffold a hermetic install dir. The schema marks N8N_USER and
+# LANGFUSE_INIT_USER_EMAIL as secret:true; .env contains values that
+# must NEVER appear in `dream config show` output.
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+INSTALL_SCAFFOLD="$TEMP_DIR/install"
+mkdir -p "$INSTALL_SCAFFOLD"
+# check_install requires either docker-compose.base.yml or docker-compose.yml
+touch "$INSTALL_SCAFFOLD/docker-compose.base.yml"
+
+cat > "$INSTALL_SCAFFOLD/.env" <<'EOF'
+# Test fixture
+N8N_USER=actual-admin-username
+LANGFUSE_INIT_USER_EMAIL=admin@example.test
+DREAM_OPERATOR=operator-secret
+DREAM_VERSION=2.0.0-test
+HOST_RAM_GB=32
+EOF
+
+cat > "$INSTALL_SCAFFOLD/.env.schema.json" <<'EOF'
+{
+  "properties": {
+    "N8N_USER": {"type": "string", "secret": true},
+    "LANGFUSE_INIT_USER_EMAIL": {"type": "string", "secret": true},
+    "DREAM_OPERATOR": {"type": "string", "secret": true},
+    "DREAM_VERSION": {"type": "string"},
+    "HOST_RAM_GB": {"type": "string"}
+  }
+}
+EOF
+
+# Sentinel values whose appearance in stdout would prove a leak.
+SECRET_USER='actual-admin-username'
+SECRET_EMAIL='admin@example.test'
+SECRET_OPERATOR='operator-secret'
+
+run_dream_config_show() {
+    # Invokes dream-cli with a controlled PATH to simulate environments
+    # with/without jq + python3. NO_COLOR=1 keeps output ASCII.
+    local _path="$1"
+    local _label="$2"
+    local _output
+    _output=$(NO_COLOR=1 PATH="$_path" DREAM_HOME="$INSTALL_SCAFFOLD" \
+        "$BASH" "$DREAM_CLI" config show 2>&1)
+    echo "$_output"
+}
+
+# Discover real paths to bash, sed, awk, mktemp, etc. so the CLI runs.
+# We strip jq and/or python3 from PATH by listing only their needed
+# siblings. The simplest approach: build a path that excludes a
+# specific binary by symlinking required binaries into a tempdir.
+build_pathdir_excluding() {
+    # build_pathdir_excluding "<exclude1> <exclude2> ..."
+    local _excludes="$1"
+    local _pdir="$TEMP_DIR/pathdir-$RANDOM"
+    local _extra_paths=""
+    mkdir -p "$_pdir"
+    local _bin
+    # Tools dream-cli (the section we exercise) actually uses.
+    for _bin in bash sh ls cat grep sed awk tr cut sort head tail \
+                printf echo mkdir rm tee dirname basename pwd \
+                python3 jq find env; do
+        local _real
+        if [[ "$_bin" == "python3" ]]; then
+            _real="$(type -P python3 2>/dev/null || true)"
+            if [[ "$_real" == *WindowsApps* ]] && type -P python >/dev/null 2>&1; then
+                _real="$(type -P python)"
+            fi
+            if [[ -n "$_real" ]]; then
+                _extra_paths="${_extra_paths:+$_extra_paths:}$(dirname "$_real")"
+            fi
+        else
+            _real="$(type -P "$_bin" 2>/dev/null || true)"
+        fi
+        [[ -z "$_real" ]] && continue
+        # Skip excluded names.
+        case " $_excludes " in *" $_bin "*) continue ;; esac
+        if ! ln -s "$_real" "$_pdir/$_bin" 2>/dev/null; then
+            local _escaped="${_real//\\/\\\\}"
+            _escaped="${_escaped//\"/\\\"}"
+            printf '#!/bin/sh\nexec "%s" "$@"\n' "$_escaped" > "$_pdir/$_bin"
+            chmod +x "$_pdir/$_bin"
+        fi
+    done
+    if [[ -n "$_extra_paths" ]]; then
+        echo "$_pdir:$_extra_paths"
+    else
+        echo "$_pdir"
+    fi
+}
+
+# --- Case 1: jq + python3 both present (schema-driven path) ---
+PATH_FULL=$(build_pathdir_excluding "")
+out1=$(run_dream_config_show "$PATH_FULL" "full")
+if grep -q "N8N_USER=\\*\\*\\*" <<<"$out1" && ! grep -qF "$SECRET_USER" <<<"$out1"; then
+    pass "with jq+python3: N8N_USER masked, value not leaked"
+else
+    fail "with jq+python3: N8N_USER not masked correctly"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out1"
+fi
+if grep -q "LANGFUSE_INIT_USER_EMAIL=\\*\\*\\*" <<<"$out1" && ! grep -qF "$SECRET_EMAIL" <<<"$out1"; then
+    pass "with jq+python3: LANGFUSE_INIT_USER_EMAIL masked, value not leaked"
+else
+    fail "with jq+python3: LANGFUSE_INIT_USER_EMAIL not masked correctly"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out1"
+fi
+
+if grep -q "DREAM_OPERATOR=\\*\\*\\*" <<<"$out1" && ! grep -qF "$SECRET_OPERATOR" <<<"$out1"; then
+    pass "with jq+python3: non-keyword schema secret masked"
+else
+    fail "with jq+python3: non-keyword schema secret not masked correctly"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out1"
+fi
+
+# --- Case 2: no jq, python3 present (Git-Bash-without-jq simulation) ---
+PATH_NO_JQ=$(build_pathdir_excluding "jq")
+out2=$(run_dream_config_show "$PATH_NO_JQ" "no-jq")
+if grep -q "N8N_USER=\\*\\*\\*" <<<"$out2" && ! grep -qF "$SECRET_USER" <<<"$out2"; then
+    pass "without jq: N8N_USER masked via python3 fallback"
+else
+    fail "without jq: N8N_USER LEAKED — Git Bash regression"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out2"
+fi
+if grep -q "LANGFUSE_INIT_USER_EMAIL=\\*\\*\\*" <<<"$out2" && ! grep -qF "$SECRET_EMAIL" <<<"$out2"; then
+    pass "without jq: LANGFUSE_INIT_USER_EMAIL masked via python3 fallback"
+else
+    fail "without jq: LANGFUSE_INIT_USER_EMAIL LEAKED — Git Bash regression"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out2"
+fi
+
+if grep -q "DREAM_OPERATOR=\\*\\*\\*" <<<"$out2" && ! grep -qF "$SECRET_OPERATOR" <<<"$out2"; then
+    pass "without jq: non-keyword schema secret masked via python3 fallback"
+else
+    fail "without jq: non-keyword schema secret LEAKED - python3 fallback did not load"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out2"
+fi
+
+# --- Case 3: neither jq nor python3 (keyword-fallback only) ---
+PATH_NO_TOOLS=$(build_pathdir_excluding "jq python3")
+out3=$(run_dream_config_show "$PATH_NO_TOOLS" "no-tools")
+if grep -q "N8N_USER=\\*\\*\\*" <<<"$out3" && ! grep -qF "$SECRET_USER" <<<"$out3"; then
+    pass "without jq+python3: N8N_USER masked via *user* keyword"
+else
+    fail "without jq+python3: N8N_USER LEAKED — keyword fallback gap"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out3"
+fi
+if grep -q "LANGFUSE_INIT_USER_EMAIL=\\*\\*\\*" <<<"$out3" && ! grep -qF "$SECRET_EMAIL" <<<"$out3"; then
+    pass "without jq+python3: LANGFUSE_INIT_USER_EMAIL masked via *user*/*email* keyword"
+else
+    fail "without jq+python3: LANGFUSE_INIT_USER_EMAIL LEAKED — keyword fallback gap"
+    echo "  --- output ---"; awk '{print "  " $0}' <<<"$out3"
+fi
+
+# --- Sanity: non-secret keys are NOT masked (no over-mask regression) ---
+if grep -q "DREAM_VERSION=2.0.0-test" <<<"$out1"; then
+    pass "non-secret DREAM_VERSION shown in clear (no over-mask)"
+else
+    fail "non-secret DREAM_VERSION incorrectly masked or missing"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]]

--- a/dream-server/tests/test-validate-env.sh
+++ b/dream-server/tests/test-validate-env.sh
@@ -15,6 +15,15 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+# validate-env.sh uses associative arrays (declare -A), which require Bash 4+.
+# Its shebang is #!/bin/bash, and macOS ships /bin/bash 3.2 — invoking by raw
+# path there hits the Bash-4+ guard and exits 1 before any validation runs.
+# Invoke through "$BASH" (the shell running this test) so the interpreter is
+# guaranteed to be whatever bash launched us (typically Homebrew bash on
+# macOS, /bin/bash 4+ on Linux/WSL2). Fall back to $PATH bash if $BASH is
+# unset (e.g. when the test is launched from a non-bash shell).
+VALIDATE_ENV_BASH="${BASH:-$(command -v bash)}"
+
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'
@@ -56,7 +65,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 # 2. Missing .env → exit 3
 set +e
-"$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/nonexistent.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
+"$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/nonexistent.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
 r=$?
 set -e
 if [[ $r -eq 3 ]]; then
@@ -68,7 +77,7 @@ fi
 # 3. Missing schema → exit 3
 touch "$TMP_DIR/empty.env"
 set +e
-"$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/empty.env" "$TMP_DIR/nonexistent.json" >/dev/null 2>&1
+"$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/empty.env" "$TMP_DIR/nonexistent.json" >/dev/null 2>&1
 r=$?
 set -e
 if [[ $r -eq 3 ]]; then
@@ -88,7 +97,7 @@ LITELLM_KEY=testkey
 OPENCLAW_TOKEN=testtoken
 EOF
 set +e
-"$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/valid.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
+"$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/valid.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
 r=$?
 set -e
 if [[ $r -eq 0 ]]; then
@@ -106,7 +115,7 @@ N8N_PASS=testpass
 LITELLM_KEY=testkey
 EOF
 set +e
-out=$("$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/missing.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/missing.env" "$ROOT_DIR/.env.schema.json" 2>&1)
 r=$?
 set -e
 if [[ $r -eq 2 ]]; then
@@ -131,7 +140,7 @@ OPENCLAW_TOKEN=testtoken
 UNKNOWN_KEY=value
 EOF
 set +e
-"$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/unknown.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
+"$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/unknown.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
 r=$?
 set -e
 if [[ $r -eq 2 ]]; then


### PR DESCRIPTION
## What

Five related hardenings to `dream config` and its helpers:

1. **Schema-driven masking in `dream config show`** — replace the narrow keyword regex (which missed `_PASSWORD`, `_SALT`, `_PASS` suffixed fields) with `.env.schema.json`-driven detection.
2. **Bash 4+ invocation** — `dream config validate` now invokes `validate-env.sh` through `"$BASH"`, and the target script adds its own Bash-4 guard. Fixes a macOS-only crash under `/bin/bash` 3.2.
3. **Belt-and-suspenders fallback** — after a schema-miss under `_schema_loaded=1`, fall through to the keyword match instead of returning "not secret." Covers schema gaps and malformed schemas.
4. **Helper promoted to file-scope + reused by `dream preset diff`** — `_cmd_config_is_secret` was nested inside `cmd_config show`, so `dream preset diff` still used the original narrow regex and leaked `N8N_PASS`, `LANGFUSE_SALT`, and admin email fields in plaintext. Helper is now file-scope; both commands use it. `N8N_USER` and `LANGFUSE_INIT_USER_EMAIL` are also marked `secret: true` in `.env.schema.json`.
5. **Audit follow-up — close the jq-less Git Bash leak.** `python3` fallback in `_cmd_config_load_secret_schema` when `jq` is absent (Git Bash on Windows is the canonical case). Plus `*user*|*email*` keyword extension as belt-and-suspenders for the no-jq-no-python3 case.

## Why

The narrow regex `(SECRET|PASS|KEY|TOKEN)=` missed suffix-form names like `LANGFUSE_DB_PASSWORD`, `LANGFUSE_SALT`, `OPENCODE_SERVER_PASSWORD`, etc. `dream config validate` crashed on every fresh macOS install because `validate-env.sh` uses `declare -A` (Bash 4+ only) but was invoked through `/bin/bash` 3.2. And `dream preset diff` was a forgotten sibling code path.

Maintainer audit (2026-04-28) flagged that the schema-driven path only fires when `jq` is on PATH. In Git Bash on Windows (no jq by default), the helper silently set `_cmd_config_schema_loaded=0` and `dream config show` fell through to the keyword regex, which didn't cover `*user*|*email*`-suffixed names — so `N8N_USER` and `LANGFUSE_INIT_USER_EMAIL` printed in clear.

## How

Five commits, each self-contained:

- `d4d754ae` — schema-driven masking in `cmd_config show`.
- `cc6c40ac` — Bash 4+ gate + `"$BASH"` invocation path.
- `ce37c119` — fallback-masking hardening (`*bearer*` added to keyword fallback) + test-harness fix for macOS.
- `9cee345d` — schema-miss falls through to keywords + helper promoted to file-scope + `dream preset diff` now uses the helper + `N8N_USER` / `LANGFUSE_INIT_USER_EMAIL` marked `secret: true`.
- `2b49c8ff` — **audit follow-up:** python3 fallback in `_cmd_config_load_secret_schema`, `*user*|*email*` keyword extension, regression test exercising all three PATH conditions.

### Audit follow-up details (commit `2b49c8ff`)

`_cmd_config_load_secret_schema` now follows this order:

1. If `jq` available → use jq (existing fast path).
2. Else if `python3` available → parse `.env.schema.json` via heredoc'd `python3` and extract keys where `spec.get("secret") is True`. Sets `_cmd_config_schema_loaded=1`.
3. Else → leave `_cmd_config_schema_loaded=0`. `_cmd_config_is_secret` falls through to the keyword regex which now also includes `*user*|*email*` to cover the new schema secrets.

Verified: jq and python3 produce **identical 36-key outputs** on the live `.env.schema.json` (CG diff'd both, no delta).

## Testing

- `make lint`, `make test`, `shellcheck` all green.
- New `tests/test-dream-config-secret-mask.sh` (7 cases, wired into `make test`):
  - jq+python3 both present → schema-driven jq path
  - jq absent, python3 present → python fallback
  - both absent → keyword regex fallback
  - sanity case: non-secret `DREAM_VERSION=2.0.0-test` shown in clear (no over-mask)
- Each PATH case asserts both **positive** (`KEY=***` appears in stdout) AND **negative** (literal sensitive value does NOT leak). Sentinel values: `actual-admin-username` (N8N_USER), `admin@example.test` (LANGFUSE_INIT_USER_EMAIL).
- CG sabotage check: with both fallbacks reverted, 4 cases fail (jq-less and tools-less paths both leak). With only the keyword extension reverted, 2 cases fail (only the no-tools path leaks). Confirms each layer is independently load-bearing.
- Original PR's `dream config show` / `dream config validate` / `dream preset diff` testing still passes.

## Review

Local CG **APPROVED** (no warnings). Notes from review (informational only):
- A literal-`null` `.env.schema.json` would trigger `AttributeError` in the python heredoc. Suppressed by `2>/dev/null` and degrades to keyword regex fallback (functionally safe, just an ungraceful traceback). Could widen the `except` clause but project style discourages broad lists.
- The test harness's symlink-PATH approach is sensitive to the outer PATH's Bash version (only matters for manual `PATH=...` debugging; standard `make test` is unaffected).
- Over-mask risk from `*user*|*email*` extension is zero in current `.env.schema.json` — all 4 user/email-bearing keys are already `secret: true`. Hypothetical future operational keys (e.g., `USER_HOME`) would be over-masked but `cat .env` remains the unmasked escape hatch.

## Known Considerations

A small number of operational keys (`TOKEN_SPY_PORT`, `TOKEN_SPY_URL`, `LANGFUSE_PROJECT_PUBLIC_KEY`) remain over-masked by the keyword fallback. This is intentional: `dream config show` should default to over-masking; raw values remain accessible via `cat .env`.

## Platform Impact

- **macOS:** primary fix target for the validate-env crash. All five hardenings apply.
- **Linux / WSL2:** fixes apply identically; no platform branching.
- **Windows (Git Bash without jq):** the audit follow-up is the primary win — schema-driven masking now works without jq via the python3 fallback, and the keyword extension closes the residual gap.
