### PR TITLE
docs(host-agent): accurate platform-specific bind addresses

### DIFF
--- a/dream-server/docs/HOST-AGENT-API.md
+++ b/dream-server/docs/HOST-AGENT-API.md
@@ -4,7 +4,7 @@ The Dream Host Agent (`bin/dream-host-agent.py`) is a lightweight HTTP server th
 
 ## Why It Exists
 
-The Dashboard API runs inside a Docker container and cannot directly run `docker compose` commands on the host. The host agent bridges this gap: it listens on `127.0.0.1:7710`, accepts authenticated requests from the Dashboard API, and executes Docker Compose operations on its behalf. This avoids mounting the Docker socket into the container (a significant security risk).
+The Dashboard API runs inside a Docker container and cannot directly run `docker compose` commands on the host. The host agent bridges this gap: it listens on port `7710` (see "How It Runs" below for the platform-specific bind address), accepts authenticated requests from the Dashboard API, and executes Docker Compose operations on its behalf. This avoids mounting the Docker socket into the container (a significant security risk).
 
 ## How It Runs
 
@@ -12,13 +12,14 @@ The Dashboard API runs inside a Docker container and cannot directly run `docker
 |----------|-----------|
 | Linux | systemd user service (`scripts/systemd/dream-host-agent.service`) |
 | macOS | Started by the installer (`installers/macos/install-macos.sh`) |
+| Windows | Windows Task Scheduler (registered at login by installer phase 07) |
 
 The agent is started during installation (phase 07 on Linux). Its bind address is platform-aware:
 
 - **macOS and Windows:** binds to `127.0.0.1` — Docker Desktop routes `host.docker.internal` to the loopback interface, so containers and the host share that address.
 - **Linux:** binds to the Docker bridge gateway IP (auto-detected via `docker network inspect bridge`, typically `172.17.0.1`) so containers on the default bridge can reach it; if detection fails it falls back to `0.0.0.0` and logs a warning.
 
-Set `DREAM_AGENT_BIND=<ip>` in `.env` to override the default. The agent is never exposed to the LAN — the bridge gateway is a virtual interface reachable only from containers on that bridge.
+Set `DREAM_AGENT_BIND=<ip>` in `.env` to override the default. Under the standard bind addresses the agent is not reachable from other hosts — loopback on macOS/Windows, and the Docker bridge gateway (a virtual interface) on Linux. The Linux `0.0.0.0` fallback (when `docker network inspect bridge` fails) is the exception: it IS reachable from the LAN, which is why the installer logs a warning and why you should set `DREAM_AGENT_BIND=127.0.0.1` to harden when that fallback triggers. The API-key auth below is the primary protection in either case.
 
 ## Configuration
 
@@ -143,7 +144,7 @@ If the container does not exist yet (e.g. image is still pulling), a 200 respons
 The host agent is a **critical security boundary** because it can start and stop Docker containers on the host.
 
 Protections in place:
-- **Localhost only**: Binds to `127.0.0.1`, not `0.0.0.0`
+- **Typically not LAN-exposed**: Binds to loopback (`127.0.0.1`) on macOS/Windows or the Docker bridge gateway (typically `172.17.0.1`) on Linux — not reachable from other devices under those bindings. The Linux `0.0.0.0` fallback (when `docker network inspect bridge` fails) is LAN-reachable; the installer logs a warning when it triggers, and `DREAM_AGENT_BIND=127.0.0.1` in `.env` re-restricts to loopback. API-key auth remains the primary protection in either case.
 - **API key auth**: All mutation endpoints require Bearer token authentication
 - **Core service protection**: Core services (loaded from `config/core-service-ids.json` with hardcoded fallback) cannot be managed
 - **Service ID validation**: Regex-validated, must map to an actual extension directory with a manifest

--- a/dream-server/docs/HOST-AGENT-API.md
+++ b/dream-server/docs/HOST-AGENT-API.md
@@ -13,7 +13,12 @@ The Dashboard API runs inside a Docker container and cannot directly run `docker
 | Linux | systemd user service (`scripts/systemd/dream-host-agent.service`) |
 | macOS | Started by the installer (`installers/macos/install-macos.sh`) |
 
-The agent is started during installation (phase 07 on Linux) and binds to `127.0.0.1` only — it is not accessible from the network.
+The agent is started during installation (phase 07 on Linux). Its bind address is platform-aware:
+
+- **macOS and Windows:** binds to `127.0.0.1` — Docker Desktop routes `host.docker.internal` to the loopback interface, so containers and the host share that address.
+- **Linux:** binds to the Docker bridge gateway IP (auto-detected via `docker network inspect bridge`, typically `172.17.0.1`) so containers on the default bridge can reach it; if detection fails it falls back to `0.0.0.0` and logs a warning.
+
+Set `DREAM_AGENT_BIND=<ip>` in `.env` to override the default. The agent is never exposed to the LAN — the bridge gateway is a virtual interface reachable only from containers on that bridge.
 
 ## Configuration
 


### PR DESCRIPTION
## What

Correct `docs/HOST-AGENT-API.md` to accurately describe the host agent's platform-specific bind behavior, and add the missing Windows row to the "How It Runs" mechanism table.

## Why

The doc said the agent binds to `127.0.0.1` — accurate on macOS and Windows (Docker Desktop routes `host.docker.internal` to the loopback interface) but wrong on Linux, which binds to the Docker bridge gateway IP (auto-detected via `docker network inspect bridge`, typically `172.17.0.1`) so containers on the default bridge can reach it. If detection fails, the Linux path falls back to `0.0.0.0` and logs a warning. Three places in the doc made the "127.0.0.1 only" claim with varying absolutist language that contradicted the same paragraphs' mention of the `0.0.0.0` fallback.

The "How It Runs" mechanism table listed only Linux and macOS rows; Windows wasn't documented at all even though `installers/windows/phases/07-devtools.ps1:244-261` registers a Windows Task Scheduler task with `AtLogOn` trigger.

## How

Two commits:

- `f4c37d3f` — rewrite the bind-address paragraph at line 16 as a platform-aware bulleted list; document the `DREAM_AGENT_BIND` override.
- `6a4072f2` — rewrite the "Why It Exists" intro and "Security Boundaries" bullet so they match the new platform-aware description; add Windows row to the "How It Runs" table.

## Testing

Doc-only change. Verified against:

- `bin/dream-host-agent.py` bind-address resolution logic.
- `installers/windows/phases/07-devtools.ps1:244-261` scheduled-task registration.
- `scripts/systemd/dream-host-agent.service` (Linux systemd user service).
- `installers/macos/install-macos.sh` (macOS LaunchAgent).

## Platform Impact

- **macOS / Windows:** doc now correctly states loopback binding (previously-correct claim preserved, now explicit per-platform).
- **Linux:** doc now correctly states bridge-gateway binding with `0.0.0.0` fallback and `DREAM_AGENT_BIND` override — previously wrong.
