### PR TITLE
fix(dream-cli): pipefail + surface LLM failures + exit-code contract

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -37,6 +37,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
+	@echo ""
+	@echo "=== dream-cli pipefail tolerance ==="
+	@bash tests/test-dream-cli-pipefail-tolerance.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1547,6 +1547,7 @@ cmd_disable() {
     # Check built-in extensions first, then dashboard-installed user extensions
     local ext_dir="$INSTALL_DIR/extensions/services/$service_id"
     [[ ! -d "$ext_dir" ]] && ext_dir="$INSTALL_DIR/data/user-extensions/$service_id"
+    [[ -d "$ext_dir" ]] || error "Unknown service: $input"
     local cf="$ext_dir/compose.yaml"
 
     # Check it's not a core service
@@ -2488,6 +2489,7 @@ cmd_agent() {
                 tail -f "$log_file"
             else
                 warn "No log file at $log_file"
+                return 1
             fi
             ;;
         *)
@@ -2849,19 +2851,19 @@ _gpu_reassign() {
 
     if ! command -v nvidia-smi &>/dev/null; then
         warn "GPU reassign is only supported for NVIDIA. Use 'dream gpu status' for AMD."
-        return
+        return 1
     fi
 
     if ! command -v jq &>/dev/null; then
         warn "jq not found — required for GPU reassignment"
-        return
+        return 1
     fi
 
     local topo_lib="$SCRIPT_DIR/installers/lib/nvidia-topo.sh"
     local assign_script="$SCRIPT_DIR/scripts/assign_gpus.py"
 
-    [[ -f "$topo_lib" ]] || { warn "Topology library not found: $topo_lib"; return; }
-    [[ -f "$assign_script" ]] || { warn "Assignment script not found: $assign_script"; return; }
+    [[ -f "$topo_lib" ]] || { warn "Topology library not found: $topo_lib"; return 1; }
+    [[ -f "$assign_script" ]] || { warn "Assignment script not found: $assign_script"; return 1; }
 
     # warn and err are already defined; source is safe
     . "$topo_lib"

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -3,7 +3,7 @@
 # Mission: M5 (Clonable Dream Setup Server)
 # Version: 2.0.0 — Registry-driven service resolution
 
-set -e
+set -eo pipefail
 
 # Require Bash 4+ (associative arrays used by service registry and dream-cli)
 if (( BASH_VERSINFO[0] < 4 )); then
@@ -251,7 +251,7 @@ _check_version_compat() {
 
     # 1. Installed version
     _COMPAT_INSTALLED_VER=$(grep '^DREAM_VERSION=' "$INSTALL_DIR/.env" 2>/dev/null \
-        | head -1 | cut -d= -f2 | tr -d '[:space:]')
+        | sed -n '1p' | cut -d= -f2 | tr -d '[:space:]')
     # Fall back to .version file (written by dream-update.sh / PR #349 convention)
     if [[ -z "$_COMPAT_INSTALLED_VER" && -f "$INSTALL_DIR/.version" ]]; then
         _COMPAT_INSTALLED_VER=$(jq -r '.version // empty' "$INSTALL_DIR/.version" 2>/dev/null \
@@ -1892,7 +1892,7 @@ META
 
             # Validate archive structure
             local archive_name
-            archive_name=$(tar tzf "$archive" 2>/dev/null | head -1 | cut -d/ -f1)
+            archive_name=$(tar tzf "$archive" 2>/dev/null | sed -n '1p' | cut -d/ -f1)
             [[ -z "$archive_name" ]] && error "Invalid archive structure"
 
             # Check if preset already exists

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1148,20 +1148,44 @@ cmd_chat() {
     local _llm_port="${SERVICE_PORTS[llama-server]:-11434}"
     _llm_port="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-$_llm_port}}"
 
-    # Get model from llama-server if not specified
+    # Pre-flight reachability check.
+    local _probe
+    _probe=$(curl --silent --show-error --fail --max-time 3 \
+        "http://localhost:${_llm_port}/v1/models" 2>&1) || {
+        error "llama-server not reachable at http://localhost:${_llm_port} — is 'dream status' showing it healthy?"
+    }
+
     if [[ -z "$model" ]]; then
-        model=$(curl -s "http://localhost:${_llm_port}/v1/models" | jq -r '.data[0].id // "local"')
+        model=$(printf '%s' "$_probe" | jq -er '.data[0].id' 2>/dev/null || echo "local")
     fi
 
     log "Sending to $model..."
 
-    # Use jq to safely construct JSON payload (prevents injection)
-    local payload=$(jq -n --arg model "$model" --arg msg "$message" \
+    local payload
+    payload=$(jq -n --arg model "$model" --arg msg "$message" \
         '{model: $model, messages: [{role: "user", content: $msg}], max_tokens: 500}')
 
-    curl -s "http://localhost:${_llm_port}/v1/chat/completions" \
-        -H "Content-Type: application/json" \
-        -d "$payload" | jq -r '.choices[0].message.content // .error.message // "Error: no response"'
+    local _resp
+    # HTTP 4xx/5xx responses are delegated to the jq fallback below, which
+    # extracts .error.message cleanly. Only transport failures (DNS, refused,
+    # timeout) trip curl's non-zero exit here. Avoiding --fail / --fail-with-body
+    # also keeps compat with curl < 7.76 (Ubuntu 20.04, Debian 11, RHEL 8).
+    _resp=$(curl --silent --show-error --max-time 30 \
+        "http://localhost:${_llm_port}/v1/chat/completions" \
+        -H "Content-Type: application/json" -d "$payload" 2>&1) || {
+        error "LLM request failed: $_resp"
+    }
+
+    [[ -z "$_resp" ]] && error "LLM returned empty response"
+
+    local _content
+    _content=$(printf '%s' "$_resp" | jq -er '.choices[0].message.content') || {
+        local _err
+        _err=$(printf '%s' "$_resp" | jq -r '.error.message // "unknown error"' 2>/dev/null)
+        error "LLM error: ${_err:-unparseable response}"
+    }
+
+    printf '%s\n' "$_content"
 }
 
 cmd_benchmark() {
@@ -1171,7 +1195,10 @@ cmd_benchmark() {
     log "Running quick benchmark..."
 
     local start=$(date +%s)
-    local response=$(cmd_chat "Say exactly: Hello World" 2>/dev/null)
+    local response
+    if ! response=$(cmd_chat "Say exactly: Hello World" 2>&1); then
+        error "Benchmark failed: LLM unreachable or error — see 'dream chat' for details"
+    fi
     local end=$(date +%s)
 
     local duration=$(( end - start ))

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -3,7 +3,7 @@
 # Mission: M5 (Clonable Dream Setup Server)
 # Version: 2.0.0 — Registry-driven service resolution
 
-set -e
+set -eo pipefail
 
 # Require Bash 4+ (associative arrays used by service registry and dream-cli)
 if (( BASH_VERSINFO[0] < 4 )); then
@@ -284,6 +284,11 @@ _check_version_compat() {
     local force="${1:-false}"
 
     # 1. Installed version
+    # `|| true` preserves the tolerant fallback semantics required by
+    # the maintainer audit on PR #998: under `set -euo pipefail`,
+    # a fresh install whose .env lacks DREAM_VERSION must fall back
+    # to .version / manifest.json (handled below), not exit out of
+    # the surrounding command. Landed on main via #1008.
     _COMPAT_INSTALLED_VER=$(grep '^DREAM_VERSION=' "$INSTALL_DIR/.env" 2>/dev/null \
         | sed -n '1p' | cut -d= -f2 | tr -d '[:space:]' || true)
     # Fall back to .version file (written by dream-update.sh / PR #349 convention)
@@ -2138,7 +2143,7 @@ META
 
             # Validate archive structure
             local archive_name
-            archive_name=$(tar tzf "$archive" 2>/dev/null | head -1 | cut -d/ -f1)
+            archive_name=$(tar tzf "$archive" 2>/dev/null | sed -n '1p' | cut -d/ -f1)
             [[ -z "$archive_name" ]] && error "Invalid archive structure"
 
             # Check if preset already exists

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -295,7 +295,8 @@ _check_version_compat() {
     if [[ -z "$_COMPAT_INSTALLED_VER" && -f "$INSTALL_DIR/.version" ]]; then
         _COMPAT_INSTALLED_VER=$(jq -r '.version // empty' "$INSTALL_DIR/.version" 2>/dev/null \
             || grep -o '"version"[[:space:]]*:[[:space:]]*"[^"]*"' \
-                "$INSTALL_DIR/.version" 2>/dev/null | cut -d'"' -f4)
+                "$INSTALL_DIR/.version" 2>/dev/null | cut -d'"' -f4 \
+            || true)
     fi
     if [[ -z "$_COMPAT_INSTALLED_VER" && -f "$INSTALL_DIR/manifest.json" ]]; then
         _COMPAT_INSTALLED_VER=$(_manifest_field "$INSTALL_DIR/manifest.json" "dream_version")
@@ -756,18 +757,20 @@ cmd_status() {
     if command -v nvidia-smi &> /dev/null; then
         echo -e "${BLUE}━━━ GPU Status ━━━${NC}"
         nvidia-smi --query-gpu=name,utilization.gpu,memory.used,memory.total,temperature.gpu --format=csv,noheader,nounits | \
-            awk -F', ' '{printf "  %s: %s%% GPU | %sMB/%sMB VRAM | %s°C\n", $1, $2, $3, $4, $5}'
+            awk -F', ' '{printf "  %s: %s%% GPU | %sMB/%sMB VRAM | %s°C\n", $1, $2, $3, $4, $5}' \
+            || warn "nvidia-smi failed"
     fi
 
-    # Bootstrap status
+    # Bootstrap status. This file may be mid-write, so missing fields should
+    # not abort `dream status` under pipefail.
     local bootstrap_file="$INSTALL_DIR/data/bootstrap-status.json"
     if [[ -f "$bootstrap_file" ]]; then
         local bs_status
-        bs_status=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$bootstrap_file" | sed -n '1p' | sed 's/.*"status"[[:space:]]*:[[:space:]]*"//' | sed 's/"//')
+        bs_status=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$bootstrap_file" | sed -n '1p' | sed 's/.*"status"[[:space:]]*:[[:space:]]*"//' | sed 's/"//' || true)
         if [[ "$bs_status" == "downloading" || "$bs_status" == "starting" || "$bs_status" == "verifying" ]]; then
             local bs_model bs_percent
-            bs_model=$(grep -o '"model"[[:space:]]*:[[:space:]]*"[^"]*"' "$bootstrap_file" | sed -n '1p' | sed 's/.*"model"[[:space:]]*:[[:space:]]*"//' | sed 's/"//')
-            bs_percent=$(grep -o '"percent"[[:space:]]*:[[:space:]]*[0-9.]*' "$bootstrap_file" | sed -n '1p' | sed 's/.*:[[:space:]]*//')
+            bs_model=$(grep -o '"model"[[:space:]]*:[[:space:]]*"[^"]*"' "$bootstrap_file" | sed -n '1p' | sed 's/.*"model"[[:space:]]*:[[:space:]]*"//' | sed 's/"//' || true)
+            bs_percent=$(grep -o '"percent"[[:space:]]*:[[:space:]]*[0-9.]*' "$bootstrap_file" | sed -n '1p' | sed 's/.*:[[:space:]]*//' || true)
             log ""
             log "  Model Upgrade: $bs_model (${bs_percent:-?}% downloaded)"
         fi
@@ -1019,7 +1022,7 @@ cmd_dry_run() {
     fi
     if [[ "$cur_ver" == "0.0.0" && -f "$INSTALL_DIR/.version" ]]; then
         local _vf
-        _vf=$(jq -r '.version // empty' "$INSTALL_DIR/.version" 2>/dev/null)
+        _vf=$(jq -r '.version // empty' "$INSTALL_DIR/.version" 2>/dev/null || true)
         [[ -n "$_vf" ]] && cur_ver="$_vf"
     fi
 
@@ -1046,8 +1049,10 @@ cmd_dry_run() {
         local gh_resp
         gh_resp=$(curl -sf --max-time 8 \
             "https://api.github.com/repos/Light-Heart-Labs/DreamServer/releases/latest" 2>/dev/null || true)
-        latest_ver=$(echo "$gh_resp" | jq -r '.tag_name // empty' 2>/dev/null | sed 's/^v//')
-        changelog_url=$(echo "$gh_resp" | jq -r '.html_url // empty' 2>/dev/null)
+        if [[ -n "$gh_resp" ]] && command -v jq >/dev/null 2>&1; then
+            latest_ver=$(echo "$gh_resp" | jq -r '.tag_name // empty' 2>/dev/null | sed 's/^v//' || true)
+            changelog_url=$(echo "$gh_resp" | jq -r '.html_url // empty' 2>/dev/null || true)
+        fi
         if [[ -n "$latest_ver" ]]; then
             if _semver_lt "$cur_ver" "$latest_ver"; then
                 update_status="update available"
@@ -1333,14 +1338,14 @@ cmd_config() {
             echo "Install dir: $INSTALL_DIR"
             echo ""
             echo -e "${CYAN}.env contents:${NC}"
-            grep -v "^#" "$INSTALL_DIR/.env" | grep -v "^$" | while read line; do
+            while IFS= read -r line; do
                 # Hide sensitive values
                 if echo "$line" | grep -qiE "(secret|pass|token|key)="; then
                     echo "  ${line%%=*}=***"
                 else
                     echo "  $line"
                 fi
-            done
+            done < <(grep -v "^#" "$INSTALL_DIR/.env" | grep -v "^$" || true)
             ;;
         edit)
             ${EDITOR:-nano} "$INSTALL_DIR/.env"
@@ -1383,20 +1388,41 @@ cmd_chat() {
     local _llm_port="${SERVICE_PORTS[llama-server]:-11434}"
     _llm_port="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-$_llm_port}}"
 
-    # Get model from llama-server if not specified
+    local _probe
+    _probe=$(curl --silent --show-error --fail --max-time 3 \
+        "http://127.0.0.1:${_llm_port}/v1/models" 2>&1) || {
+        error "llama-server not reachable at http://127.0.0.1:${_llm_port} - is 'dream status' showing it healthy?"
+    }
+
     if [[ -z "$model" ]]; then
-        model=$(curl -s "http://127.0.0.1:${_llm_port}/v1/models" | jq -r '.data[0].id // "local"')
+        model=$(printf '%s' "$_probe" | jq -er '.data[0].id' 2>/dev/null || echo "local")
     fi
 
     log "Sending to $model..."
 
     # Use jq to safely construct JSON payload (prevents injection)
-    local payload=$(jq -n --arg model "$model" --arg msg "$message" \
+    local payload
+    payload=$(jq -n --arg model "$model" --arg msg "$message" \
         '{model: $model, messages: [{role: "user", content: $msg}], max_tokens: 500}')
 
-    curl -s "http://127.0.0.1:${_llm_port}/v1/chat/completions" \
+    local _resp
+    _resp=$(curl --silent --show-error --max-time 30 \
+        "http://127.0.0.1:${_llm_port}/v1/chat/completions" \
         -H "Content-Type: application/json" \
-        -d "$payload" | jq -r '.choices[0].message.content // .error.message // "Error: no response"'
+        -d "$payload" 2>&1) || {
+        error "LLM request failed: $_resp"
+    }
+
+    [[ -z "$_resp" ]] && error "LLM returned empty response"
+
+    local _content
+    _content=$(printf '%s' "$_resp" | jq -er '.choices[0].message.content') || {
+        local _err
+        _err=$(printf '%s' "$_resp" | jq -r '.error.message // "unknown error"' 2>/dev/null || true)
+        error "LLM error: ${_err:-unparseable response}"
+    }
+
+    printf '%s\n' "$_content"
 }
 
 cmd_benchmark() {
@@ -1406,7 +1432,10 @@ cmd_benchmark() {
     log "Running quick benchmark..."
 
     local start=$(date +%s)
-    local response=$(cmd_chat "Say exactly: Hello World" 2>/dev/null)
+    local response
+    if ! response=$(cmd_chat "Say exactly: Hello World" 2>&1); then
+        error "Benchmark failed: LLM unreachable or error - see 'dream chat' for details"
+    fi
     local end=$(date +%s)
 
     local duration=$(( end - start ))
@@ -1766,6 +1795,7 @@ cmd_disable() {
     # Check built-in extensions first, then dashboard-installed user extensions
     local ext_dir="$INSTALL_DIR/extensions/services/$service_id"
     [[ ! -d "$ext_dir" ]] && ext_dir="$INSTALL_DIR/data/user-extensions/$service_id"
+    [[ -d "$ext_dir" ]] || error "Unknown service: $input"
     local cf="$ext_dir/compose.yaml"
 
     # Check it's not a core service
@@ -1804,7 +1834,7 @@ cmd_disable() {
     local _data_dir="$INSTALL_DIR/data/$service_id"
     if [[ -d "$_data_dir" ]]; then
         local _data_size
-        _data_size=$(du -sh "$_data_dir" 2>/dev/null | cut -f1)
+        _data_size=$(du -sh "$_data_dir" 2>/dev/null | cut -f1 || true)
         success "$service_id disabled. Data preserved (${_data_size} in data/$service_id). Use 'dream purge $service_id' to delete."
     else
         success "$service_id disabled."
@@ -1861,7 +1891,7 @@ cmd_purge() {
 
     # Show size and confirm
     local _data_size
-    _data_size=$(du -sh "$_data_dir" 2>/dev/null | cut -f1)
+    _data_size=$(du -sh "$_data_dir" 2>/dev/null | cut -f1 || true)
     warn "This will permanently delete all data for $service_id (${_data_size})."
     warn "Directory: $_data_dir"
     log ""
@@ -2079,8 +2109,10 @@ META
                 pname=$(basename "$dir")
                 local created="" backend=""
                 if [[ -f "$dir/meta.txt" ]]; then
-                    created=$(grep "^created=" "$dir/meta.txt" 2>/dev/null | cut -d= -f2 | cut -dT -f1)
-                    backend=$(grep "^gpu_backend=" "$dir/meta.txt" 2>/dev/null | cut -d= -f2)
+                    # A malformed meta.txt should not abort listing the rest
+                    # of the presets under pipefail.
+                    created=$(grep "^created=" "$dir/meta.txt" 2>/dev/null | cut -d= -f2 | cut -dT -f1 || true)
+                    backend=$(grep "^gpu_backend=" "$dir/meta.txt" 2>/dev/null | cut -d= -f2 || true)
                 fi
                 printf "  %-20s %-22s %-10s\n" "$pname" "${created:-unknown}" "${backend:-unknown}"
             done
@@ -2121,7 +2153,7 @@ META
             cd "$PRESETS_DIR"
             if tar czf "$output" "$name" 2>/dev/null; then
                 local size
-                size=$(du -h "$output" 2>/dev/null | cut -f1)
+                size=$(du -h "$output" 2>/dev/null | cut -f1 || true)
                 success "Preset exported to: $output ($size)"
             else
                 error "Failed to create archive"
@@ -2330,11 +2362,11 @@ cmd_mode() {
 
     if [[ -z "$mode" ]]; then
         # Show current mode
-        local current=$(grep "^DREAM_MODE=" .env 2>/dev/null | cut -d= -f2)
+        local current=$(grep "^DREAM_MODE=" .env 2>/dev/null | cut -d= -f2 || true)
         current="${current:-local}"
-        local api_url=$(grep "^LLM_API_URL=" .env 2>/dev/null | cut -d= -f2)
-        local model=$(grep "^LLM_MODEL=" .env 2>/dev/null | cut -d= -f2)
-        local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2)
+        local api_url=$(grep "^LLM_API_URL=" .env 2>/dev/null | cut -d= -f2 || true)
+        local model=$(grep "^LLM_MODEL=" .env 2>/dev/null | cut -d= -f2 || true)
+        local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2 || true)
         echo -e "${BLUE}━━━ Dream Server Mode ━━━${NC}"
         echo ""
         echo -e "Current mode: ${GREEN}${current}${NC}"
@@ -2411,8 +2443,8 @@ cmd_model() {
 
     case "$subcmd" in
         current)
-            local model=$(grep "^LLM_MODEL=" .env 2>/dev/null | cut -d= -f2)
-            local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2)
+            local model=$(grep "^LLM_MODEL=" .env 2>/dev/null | cut -d= -f2 || true)
+            local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2 || true)
             echo -e "Current model: ${GREEN}${model:-<not set>}${NC}"
             [[ -n "$tier" ]] && echo "Current tier: $tier"
             return 0
@@ -2712,6 +2744,7 @@ cmd_agent() {
                 tail -f "$log_file"
             else
                 warn "No log file at $log_file"
+                return 1
             fi
             ;;
         *)
@@ -3022,7 +3055,8 @@ _gpu_validate() {
     local env_count="${GPU_COUNT:-1}"
     local actual_count=1
     if command -v nvidia-smi &>/dev/null; then
-        actual_count=$(nvidia-smi --list-gpus 2>/dev/null | wc -l | tr -d ' ')
+        actual_count=$(nvidia-smi --list-gpus 2>/dev/null | wc -l | tr -d ' ' || true)
+        actual_count="${actual_count:-0}"
     fi
 
     if [[ -z "${GPU_COUNT:-}" ]]; then
@@ -3046,7 +3080,7 @@ _gpu_validate() {
         if assignment_json=$(echo "$assignment_b64" | base64 -d 2>/dev/null); then
             local live_uuids=""
             if command -v nvidia-smi &>/dev/null; then
-                live_uuids=$(nvidia-smi --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | tr -d ' ')
+                live_uuids=$(nvidia-smi --query-gpu=uuid --format=csv,noheader,nounits 2>/dev/null | tr -d ' ' || true)
             fi
             local missing=0
             while IFS= read -r uuid; do
@@ -3112,19 +3146,19 @@ _gpu_reassign() {
 
     if ! command -v nvidia-smi &>/dev/null; then
         warn "GPU reassign is only supported for NVIDIA. Use 'dream gpu status' for AMD."
-        return
+        return 1
     fi
 
     if ! command -v jq &>/dev/null; then
         warn "jq not found — required for GPU reassignment"
-        return
+        return 1
     fi
 
     local topo_lib="$SCRIPT_DIR/installers/lib/nvidia-topo.sh"
     local assign_script="$SCRIPT_DIR/scripts/assign_gpus.py"
 
-    [[ -f "$topo_lib" ]] || { warn "Topology library not found: $topo_lib"; return; }
-    [[ -f "$assign_script" ]] || { warn "Assignment script not found: $assign_script"; return; }
+    [[ -f "$topo_lib" ]] || { warn "Topology library not found: $topo_lib"; return 1; }
+    [[ -f "$assign_script" ]] || { warn "Assignment script not found: $assign_script"; return 1; }
 
     # warn and err are already defined; source is safe
     . "$topo_lib"
@@ -3209,7 +3243,7 @@ _gpu_reassign() {
 
         # How many llama GPUs?
         local llama_gpu_count
-        llama_gpu_count=$(echo "$_manual_llama" | tr ',' '\n' | grep -c '[0-9]')
+        llama_gpu_count=$(echo "$_manual_llama" | tr ',' '\n' | grep -c '[0-9]' || true)
 
         local split_mode_m="none"
         if [[ "$llama_gpu_count" -gt 1 ]]; then

--- a/dream-server/tests/test-dream-cli-pipefail-tolerance.sh
+++ b/dream-server/tests/test-dream-cli-pipefail-tolerance.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Regression coverage for dream-cli paths made stricter by set -eo pipefail.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DREAM_CLI="$ROOT_DIR/dream-cli"
+TMP_DIR="$(mktemp -d)"
+INSTALL_DIR="$TMP_DIR/install"
+BIN_DIR="$TMP_DIR/bin"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "[SKIP] $1"; SKIP=$((SKIP + 1)); }
+
+run_dream() {
+    local output rc
+    set +e
+    output=$(DREAM_HOME="$INSTALL_DIR" NO_COLOR=1 "$DREAM_CLI" "$@" 2>&1)
+    rc=$?
+    set -e
+    printf '%s\n' "$rc"
+    printf '%s\n' "$output"
+}
+
+reset_install() {
+    rm -rf "$INSTALL_DIR"
+    mkdir -p "$INSTALL_DIR"
+    cp "$ROOT_DIR/docker-compose.base.yml" "$INSTALL_DIR/docker-compose.base.yml"
+}
+
+mkdir -p "$BIN_DIR"
+cat > "$BIN_DIR/docker" <<'SH'
+#!/usr/bin/env bash
+if [[ "$1" == "compose" && "$2" == "ps" ]]; then
+    exit 0
+fi
+if [[ "$1" == "ps" ]]; then
+    exit 0
+fi
+exit 1
+SH
+cat > "$BIN_DIR/docker-compose" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+cat > "$BIN_DIR/curl" <<'SH'
+#!/usr/bin/env bash
+echo "curl: (7) Failed to connect" >&2
+exit 7
+SH
+chmod +x "$BIN_DIR/docker" "$BIN_DIR/docker-compose" "$BIN_DIR/curl"
+export PATH="$BIN_DIR:$PATH"
+
+if grep -q '^set -eo pipefail' "$DREAM_CLI"; then
+    pass "dream-cli enables pipefail"
+else
+    fail "dream-cli does not enable pipefail"
+fi
+
+reset_install
+: > "$INSTALL_DIR/.env"
+result="$(run_dream config show)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" == "0" ]]; then
+    pass "config show tolerates empty .env"
+else
+    fail "config show exited $rc for empty .env"
+fi
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
+DREAM_MODE=local
+EOF
+result="$(run_dream mode)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" == "0" ]]; then
+    pass "mode display tolerates missing optional .env keys"
+else
+    fail "mode display exited $rc with missing optional .env keys"
+fi
+
+result="$(run_dream model current)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" == "0" ]]; then
+    pass "model current tolerates missing model/tier keys"
+else
+    fail "model current exited $rc with missing model/tier keys"
+fi
+
+if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then
+    reset_install
+    cat > "$INSTALL_DIR/.env" <<'EOF'
+DREAM_MODE=local
+TIER=1
+GPU_BACKEND=cpu
+LLM_MODEL=test
+OLLAMA_PORT=65535
+EOF
+    mkdir -p "$INSTALL_DIR/data"
+    printf '{}' > "$INSTALL_DIR/data/bootstrap-status.json"
+    result="$(run_dream status)"
+    rc="$(printf '%s\n' "$result" | sed -n '1p')"
+    if [[ "$rc" == "0" ]]; then
+        pass "status tolerates malformed bootstrap-status.json"
+    else
+        fail "status exited $rc for malformed bootstrap-status.json"
+    fi
+
+    mkdir -p "$INSTALL_DIR/presets/bad"
+    printf 'name=bad\n' > "$INSTALL_DIR/presets/bad/meta.txt"
+    result="$(run_dream preset list)"
+    rc="$(printf '%s\n' "$result" | sed -n '1p')"
+    if [[ "$rc" == "0" ]] && grep -q 'unknown' <<<"$result"; then
+        pass "preset list tolerates missing meta fields"
+    else
+        fail "preset list failed to tolerate missing meta fields"
+    fi
+else
+    skip "PyYAML unavailable; skipped status/preset registry-backed cases"
+fi
+
+reset_install
+cat > "$INSTALL_DIR/.env" <<'EOF'
+DREAM_MODE=local
+TIER=1
+GPU_BACKEND=cpu
+LLM_MODEL=test
+OLLAMA_PORT=65535
+EOF
+result="$(run_dream chat hello)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" != "0" ]] && grep -q 'llama-server not reachable' <<<"$result"; then
+    pass "chat surfaces dead backend as failure"
+else
+    fail "chat did not fail clearly for dead backend"
+fi
+
+result="$(run_dream benchmark)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" != "0" ]] && grep -q 'Benchmark failed' <<<"$result"; then
+    pass "benchmark propagates chat failure"
+else
+    fail "benchmark did not propagate chat failure"
+fi
+
+echo "Result: $PASS passed, $FAIL failed, $SKIP skipped"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## What

Three independent error-discipline improvements to `dream-cli`:

1. Promote shell options from `set -e` to `set -eo pipefail`, aligning with CLAUDE.md's project standard. Audit `| head -1` sites (converted to `| sed -n 1p` for SIGPIPE-safety).
2. `dream chat` and `dream benchmark` now actually detect LLM failures instead of silently reporting "success" against a dead backend. Uses `curl --fail --show-error --max-time` + `jq -er` strict parsing, plus a `/v1/models` preflight probe.
3. Three commands (`dream disable`, `dream agent logs`, `dream gpu reassign`) now exit non-zero on failure/skip conditions, fixing the exit-code contract for scripted callers.

## Why

Before this PR: `dream chat` against a dead backend printed `[dream] Sending to ...`, emitted an empty line, and exited 0. `dream benchmark` propagated that silent failure and happily reported sub-second "Excellent" performance against a non-running LLM. Root cause: curl was invoked with `-s` (silent, no error-show, no fail-on-HTTP-error) and responses were parsed with `jq -r .choices[0].message.content // .error.message // "Error: no response"` — every failure path masked behind a human-friendly string on stdout.

`dream disable bogus-service` used to silently stop a non-existent container (`|| true`) and print a success-shaped message. Several other commands exited 0 after warning about skip conditions, so automation couldn't distinguish "success" from "skipped."

## How

Three commits, each self-contained:

- `dfaa4c8f` — adopt `set -eo pipefail`; convert two `| head -1` sites to `| sed -n 1p`.
- `385372ec` — rewrite chat/benchmark with preflight probe + strict `curl --fail` + `jq -er`. `cmd_benchmark` uses `if ! response=$(cmd_chat ...)` so chat failure aborts the benchmark. On the main chat call, the flag is bare `--show-error` (no `--fail*`) so HTTP 4xx/5xx responses flow through to the existing `jq` fallback which extracts `.error.message` cleanly — also keeps compat with `curl < 7.76` (Ubuntu 20.04, Debian 11, RHEL 8).
- `10588c2a` — exit-code contract for `cmd_disable`, `cmd_agent logs`, `_gpu_reassign`.

## Testing

- `dream chat "hi"` against a stopped llama-server: now exits 1 with "llama-server not reachable..." (previously silent empty output, exit 0).
- `dream benchmark` against a stopped backend: now aborts with "Benchmark failed: LLM unreachable..." (previously false-positive sub-second "Excellent").
- `dream disable bogus-service`: exits 1 with "Unknown service" (previously exit 0 after silent stop).
- Round-1 review: Critique Guardian approved. Round-2 adversarial audit: verified across 5 failure paths including the `--fail` / no-flag asymmetry on the two curl sites.

## Known Considerations

Nounset (`set -u`) is **not** added in this PR — it requires a full bare-variable audit, which lands as the sibling `refactor(dream-cli): enable set -u` PR on top of this one.

## Platform Impact

- **macOS:** chat/benchmark runs locally against llama-server; curl 8.x tested.
- **Linux Ubuntu 20.04 / Debian 11 / RHEL 8:** the `--fail-with-body` flag (curl ≥ 7.76, Mar 2021) was deliberately avoided on the main chat call so these older-curl distros work too.
- **Windows (WSL2):** same behavior as Linux.

## ⚠️ Merge order — must land #1008 first

Adopting `set -eo pipefail` here turns 7 existing `grep "^KEY=" .env | cut | tr` pipelines in `dream-cli` into hard exits when the key is absent. PR **#1008** (`refactor(dream-cli): guard .env grep pipelines against pipefail kill on missing keys`) appends `|| true` to those 7 sites so the surrounding defensive `[[ -n ... ]]` / `${var:-default}` checks keep working.

If this PR merges alone, `dream update`, `dream rollback`, `dream enable`, `dream preset`, and `dream dry-run` can abort mid-flow on installs that predate (or have manually-edited-out) one of those .env keys. **#1008 is preventive on `main` today and load-bearing the moment this PR lands.** Marked as Draft until #1008 is in to make this gate mechanical.



---

## 📋 Chain status (operator's reminder — apr-25)

This PR sits in the middle of a `dream-cli` strict-mode chain:

```
#1008 (READY) ──▶ #998 (this — DRAFT) ──▶ #1002 (DRAFT)
                                     └──▶ #1018 (DRAFT)
```

**Before this PR can be promoted:**
- #1008 must merge first (the .env grep-pipeline guards above are load-bearing the moment `set -eo pipefail` lands here).

**After this PR merges, the next operator step is:**
1. Rebase #1002 onto post-#998 main. The 6+ shared hunks (line 6 set-line, identical sub-hunks in `cmd_chat`/`cmd_benchmark`/`cmd_disable`/`cmd_agent`/`_gpu_reassign`, `| head -1` → `sed -n '1p'` swaps) drop out automatically. What remains is #1002's actual unique work: the `-u` flag and `:-` empty-string default guards.
2. Promote #1002 from DRAFT → ready (`gh pr ready 1002`).
3. Same pattern for #1018 once its other deps (#994, #1003, #1016) have landed.

#1002 and #1018 are kept in DRAFT as a mechanical safeguard so they cannot merge before this one.
