### PR TITLE
refactor(dream-cli): enable set -u and add guards for conditional variables

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1547,6 +1547,7 @@ cmd_disable() {
     # Check built-in extensions first, then dashboard-installed user extensions
     local ext_dir="$INSTALL_DIR/extensions/services/$service_id"
     [[ ! -d "$ext_dir" ]] && ext_dir="$INSTALL_DIR/data/user-extensions/$service_id"
+    [[ -d "$ext_dir" ]] || error "Unknown service: $input"
     local cf="$ext_dir/compose.yaml"
 
     # Check it's not a core service
@@ -2488,6 +2489,7 @@ cmd_agent() {
                 tail -f "$log_file"
             else
                 warn "No log file at $log_file"
+                return 1
             fi
             ;;
         *)
@@ -2849,19 +2851,19 @@ _gpu_reassign() {
 
     if ! command -v nvidia-smi &>/dev/null; then
         warn "GPU reassign is only supported for NVIDIA. Use 'dream gpu status' for AMD."
-        return
+        return 1
     fi
 
     if ! command -v jq &>/dev/null; then
         warn "jq not found — required for GPU reassignment"
-        return
+        return 1
     fi
 
     local topo_lib="$SCRIPT_DIR/installers/lib/nvidia-topo.sh"
     local assign_script="$SCRIPT_DIR/scripts/assign_gpus.py"
 
-    [[ -f "$topo_lib" ]] || { warn "Topology library not found: $topo_lib"; return; }
-    [[ -f "$assign_script" ]] || { warn "Assignment script not found: $assign_script"; return; }
+    [[ -f "$topo_lib" ]] || { warn "Topology library not found: $topo_lib"; return 1; }
+    [[ -f "$assign_script" ]] || { warn "Assignment script not found: $assign_script"; return 1; }
 
     # warn and err are already defined; source is safe
     . "$topo_lib"

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -3,7 +3,7 @@
 # Mission: M5 (Clonable Dream Setup Server)
 # Version: 2.0.0 — Registry-driven service resolution
 
-set -e
+set -eo pipefail
 
 # Require Bash 4+ (associative arrays used by service registry and dream-cli)
 if (( BASH_VERSINFO[0] < 4 )); then
@@ -251,7 +251,7 @@ _check_version_compat() {
 
     # 1. Installed version
     _COMPAT_INSTALLED_VER=$(grep '^DREAM_VERSION=' "$INSTALL_DIR/.env" 2>/dev/null \
-        | head -1 | cut -d= -f2 | tr -d '[:space:]')
+        | sed -n '1p' | cut -d= -f2 | tr -d '[:space:]')
     # Fall back to .version file (written by dream-update.sh / PR #349 convention)
     if [[ -z "$_COMPAT_INSTALLED_VER" && -f "$INSTALL_DIR/.version" ]]; then
         _COMPAT_INSTALLED_VER=$(jq -r '.version // empty' "$INSTALL_DIR/.version" 2>/dev/null \
@@ -1892,7 +1892,7 @@ META
 
             # Validate archive structure
             local archive_name
-            archive_name=$(tar tzf "$archive" 2>/dev/null | head -1 | cut -d/ -f1)
+            archive_name=$(tar tzf "$archive" 2>/dev/null | sed -n '1p' | cut -d/ -f1)
             [[ -z "$archive_name" ]] && error "Invalid archive structure"
 
             # Check if preset already exists

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -3,7 +3,7 @@
 # Mission: M5 (Clonable Dream Setup Server)
 # Version: 2.0.0 — Registry-driven service resolution
 
-set -eo pipefail
+set -euo pipefail
 
 # Require Bash 4+ (associative arrays used by service registry and dream-cli)
 if (( BASH_VERSINFO[0] < 4 )); then
@@ -1845,7 +1845,7 @@ cmd_enable() {
     fi
 
     # Check inter-extension dependencies
-    local deps="${SERVICE_DEPENDS[$service_id]}"
+    local deps="${SERVICE_DEPENDS[$service_id]:-}"
     if [[ -n "$deps" ]]; then
         local missing=()
         for dep in $deps; do
@@ -2353,8 +2353,8 @@ META
             ;;
 
         diff|d)
-            local preset1="$2"
-            local preset2="$3"
+            local preset1="${2:-}"
+            local preset2="${3:-}"
 
             # Validate arguments
             if [[ -z "$preset1" ]] || [[ -z "$preset2" ]]; then
@@ -2394,7 +2394,7 @@ META
                 local all_sids=()
                 for sid in "${!ext1[@]}"; do all_sids+=("$sid"); done
                 for sid in "${!ext2[@]}"; do
-                    [[ -z "${ext1[$sid]}" ]] && all_sids+=("$sid")
+                    [[ -z "${ext1[$sid]:-}" ]] && all_sids+=("$sid")
                 done
 
                 # Sort and compare
@@ -2444,14 +2444,14 @@ META
                 local all_keys=()
                 for key in "${!env1[@]}"; do all_keys+=("$key"); done
                 for key in "${!env2[@]}"; do
-                    [[ -z "${env1[$key]}" ]] && all_keys+=("$key")
+                    [[ -z "${env1[$key]:-}" ]] && all_keys+=("$key")
                 done
 
                 # Sort and compare (mask secrets)
                 local has_diff=false
                 for key in $(printf '%s\n' "${all_keys[@]}" | sort); do
-                    local val1="${env1[$key]}"
-                    local val2="${env2[$key]}"
+                    local val1="${env1[$key]:-}"
+                    local val2="${env2[$key]:-}"
 
                     # Check if values differ BEFORE masking
                     if [[ "$val1" != "$val2" ]]; then

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1148,20 +1148,44 @@ cmd_chat() {
     local _llm_port="${SERVICE_PORTS[llama-server]:-11434}"
     _llm_port="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-$_llm_port}}"
 
-    # Get model from llama-server if not specified
+    # Pre-flight reachability check.
+    local _probe
+    _probe=$(curl --silent --show-error --fail --max-time 3 \
+        "http://localhost:${_llm_port}/v1/models" 2>&1) || {
+        error "llama-server not reachable at http://localhost:${_llm_port} — is 'dream status' showing it healthy?"
+    }
+
     if [[ -z "$model" ]]; then
-        model=$(curl -s "http://localhost:${_llm_port}/v1/models" | jq -r '.data[0].id // "local"')
+        model=$(printf '%s' "$_probe" | jq -er '.data[0].id' 2>/dev/null || echo "local")
     fi
 
     log "Sending to $model..."
 
-    # Use jq to safely construct JSON payload (prevents injection)
-    local payload=$(jq -n --arg model "$model" --arg msg "$message" \
+    local payload
+    payload=$(jq -n --arg model "$model" --arg msg "$message" \
         '{model: $model, messages: [{role: "user", content: $msg}], max_tokens: 500}')
 
-    curl -s "http://localhost:${_llm_port}/v1/chat/completions" \
-        -H "Content-Type: application/json" \
-        -d "$payload" | jq -r '.choices[0].message.content // .error.message // "Error: no response"'
+    local _resp
+    # HTTP 4xx/5xx responses are delegated to the jq fallback below, which
+    # extracts .error.message cleanly. Only transport failures (DNS, refused,
+    # timeout) trip curl's non-zero exit here. Avoiding --fail / --fail-with-body
+    # also keeps compat with curl < 7.76 (Ubuntu 20.04, Debian 11, RHEL 8).
+    _resp=$(curl --silent --show-error --max-time 30 \
+        "http://localhost:${_llm_port}/v1/chat/completions" \
+        -H "Content-Type: application/json" -d "$payload" 2>&1) || {
+        error "LLM request failed: $_resp"
+    }
+
+    [[ -z "$_resp" ]] && error "LLM returned empty response"
+
+    local _content
+    _content=$(printf '%s' "$_resp" | jq -er '.choices[0].message.content') || {
+        local _err
+        _err=$(printf '%s' "$_resp" | jq -r '.error.message // "unknown error"' 2>/dev/null)
+        error "LLM error: ${_err:-unparseable response}"
+    }
+
+    printf '%s\n' "$_content"
 }
 
 cmd_benchmark() {
@@ -1171,7 +1195,10 @@ cmd_benchmark() {
     log "Running quick benchmark..."
 
     local start=$(date +%s)
-    local response=$(cmd_chat "Say exactly: Hello World" 2>/dev/null)
+    local response
+    if ! response=$(cmd_chat "Say exactly: Hello World" 2>&1); then
+        error "Benchmark failed: LLM unreachable or error — see 'dream chat' for details"
+    fi
     local end=$(date +%s)
 
     local duration=$(( end - start ))

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -3,7 +3,7 @@
 # Mission: M5 (Clonable Dream Setup Server)
 # Version: 2.0.0 — Registry-driven service resolution
 
-set -eo pipefail
+set -euo pipefail
 
 # Require Bash 4+ (associative arrays used by service registry and dream-cli)
 if (( BASH_VERSINFO[0] < 4 )); then
@@ -1489,7 +1489,7 @@ cmd_enable() {
     fi
 
     # Check inter-extension dependencies
-    local deps="${SERVICE_DEPENDS[$service_id]}"
+    local deps="${SERVICE_DEPENDS[$service_id]:-}"
     if [[ -n "$deps" ]]; then
         local missing=()
         for dep in $deps; do
@@ -1955,8 +1955,8 @@ META
             ;;
 
         diff|d)
-            local preset1="$2"
-            local preset2="$3"
+            local preset1="${2:-}"
+            local preset2="${3:-}"
 
             # Validate arguments
             if [[ -z "$preset1" ]] || [[ -z "$preset2" ]]; then
@@ -1996,7 +1996,7 @@ META
                 local all_sids=()
                 for sid in "${!ext1[@]}"; do all_sids+=("$sid"); done
                 for sid in "${!ext2[@]}"; do
-                    [[ -z "${ext1[$sid]}" ]] && all_sids+=("$sid")
+                    [[ -z "${ext1[$sid]:-}" ]] && all_sids+=("$sid")
                 done
 
                 # Sort and compare
@@ -2041,14 +2041,14 @@ META
                 local all_keys=()
                 for key in "${!env1[@]}"; do all_keys+=("$key"); done
                 for key in "${!env2[@]}"; do
-                    [[ -z "${env1[$key]}" ]] && all_keys+=("$key")
+                    [[ -z "${env1[$key]:-}" ]] && all_keys+=("$key")
                 done
 
                 # Sort and compare (mask secrets)
                 local has_diff=false
                 for key in $(printf '%s\n' "${all_keys[@]}" | sort); do
-                    local val1="${env1[$key]}"
-                    local val2="${env2[$key]}"
+                    local val1="${env1[$key]:-}"
+                    local val2="${env2[$key]:-}"
 
                     # Check if values differ BEFORE masking
                     if [[ "$val1" != "$val2" ]]; then

--- a/dream-server/tests/test-dream-cli-pipefail-tolerance.sh
+++ b/dream-server/tests/test-dream-cli-pipefail-tolerance.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression coverage for dream-cli paths made stricter by set -eo pipefail.
+# Regression coverage for dream-cli paths made stricter by shell strict mode.
 
 set -euo pipefail
 
@@ -62,10 +62,16 @@ SH
 chmod +x "$BIN_DIR/docker" "$BIN_DIR/docker-compose" "$BIN_DIR/curl"
 export PATH="$BIN_DIR:$PATH"
 
-if grep -q '^set -eo pipefail' "$DREAM_CLI"; then
+if grep -Eq '^set -euo pipefail|^set -eo pipefail' "$DREAM_CLI"; then
     pass "dream-cli enables pipefail"
 else
     fail "dream-cli does not enable pipefail"
+fi
+
+if grep -q '^set -euo pipefail' "$DREAM_CLI"; then
+    pass "dream-cli enables nounset"
+else
+    fail "dream-cli does not enable nounset"
 fi
 
 reset_install
@@ -95,6 +101,37 @@ if [[ "$rc" == "0" ]]; then
     pass "model current tolerates missing model/tier keys"
 else
     fail "model current exited $rc with missing model/tier keys"
+fi
+
+mkdir -p "$INSTALL_DIR/presets/left" "$INSTALL_DIR/presets/right"
+cat > "$INSTALL_DIR/presets/left/env" <<'EOF'
+SHARED=value
+ONLY_LEFT=one
+EOF
+cat > "$INSTALL_DIR/presets/right/env" <<'EOF'
+SHARED=value
+ONLY_RIGHT=two
+EOF
+cat > "$INSTALL_DIR/presets/left/extensions.list" <<'EOF'
+enabled:left-only
+EOF
+cat > "$INSTALL_DIR/presets/right/extensions.list" <<'EOF'
+enabled:right-only
+EOF
+result="$(run_dream preset diff left right)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" == "0" ]] && grep -q 'ONLY_LEFT' <<<"$result" && grep -q 'ONLY_RIGHT' <<<"$result" && grep -q 'right-only' <<<"$result"; then
+    pass "preset diff tolerates one-sided env and service keys"
+else
+    fail "preset diff failed for one-sided env/service keys"
+fi
+
+result="$(run_dream preset diff)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" != "0" ]] && grep -q 'Usage:' <<<"$result"; then
+    pass "preset diff validates missing positional arguments"
+else
+    fail "preset diff did not validate missing positional arguments"
 fi
 
 if command -v python3 >/dev/null 2>&1 && python3 -c 'import yaml' >/dev/null 2>&1; then

--- a/dream-server/tests/test-dream-config-secret-mask.sh
+++ b/dream-server/tests/test-dream-config-secret-mask.sh
@@ -100,7 +100,6 @@ build_pathdir_excluding() {
     # build_pathdir_excluding "<exclude1> <exclude2> ..."
     local _excludes="$1"
     local _pdir="$TEMP_DIR/pathdir-$RANDOM"
-    local _extra_paths=""
     mkdir -p "$_pdir"
     local _bin
     # Tools dream-cli (the section we exercise) actually uses.
@@ -113,27 +112,21 @@ build_pathdir_excluding() {
             if [[ "$_real" == *WindowsApps* ]] && type -P python >/dev/null 2>&1; then
                 _real="$(type -P python)"
             fi
-            if [[ -n "$_real" ]]; then
-                _extra_paths="${_extra_paths:+$_extra_paths:}$(dirname "$_real")"
-            fi
         else
             _real="$(type -P "$_bin" 2>/dev/null || true)"
         fi
         [[ -z "$_real" ]] && continue
         # Skip excluded names.
         case " $_excludes " in *" $_bin "*) continue ;; esac
-        if ! ln -s "$_real" "$_pdir/$_bin" 2>/dev/null; then
-            local _escaped="${_real//\\/\\\\}"
-            _escaped="${_escaped//\"/\\\"}"
-            printf '#!/bin/sh\nexec "%s" "$@"\n' "$_escaped" > "$_pdir/$_bin"
-            chmod +x "$_pdir/$_bin"
-        fi
+        # Use wrappers instead of `ln -s`: on Git Bash, symlinking MSYS
+        # binaries into a temp PATH can create executable copies that cannot
+        # find their runtime DLLs once /usr/bin is intentionally absent.
+        local _escaped="${_real//\\/\\\\}"
+        _escaped="${_escaped//\"/\\\"}"
+        printf '#!/bin/sh\nexec "%s" "$@"\n' "$_escaped" > "$_pdir/$_bin"
+        chmod +x "$_pdir/$_bin"
     done
-    if [[ -n "$_extra_paths" ]]; then
-        echo "$_pdir:$_extra_paths"
-    else
-        echo "$_pdir"
-    fi
+    echo "$_pdir"
 }
 
 # --- Case 1: jq + python3 both present (schema-driven path) ---


### PR DESCRIPTION
## What

Enable `set -u` (nounset) in `dream-cli` on top of the existing `set -eo pipefail` foundation. Audit every variable read; add `${VAR:-}` guards to six legitimately-conditional sites (missing positional args for `preset diff`, sparse associative-array lookups when comparing preset ext/env maps, registry lookups for service dirs without valid manifests). All other variables in the file are unconditionally set before use; no guard added elsewhere.

## Why

Nounset catches typos in variable names at runtime instead of silently expanding to empty strings. The audit also surfaced three pre-existing latent bugs that `set -u` would have caught immediately:

- `preset diff`: bare `$2` / `$3` crashed with no args.
- `preset diff`: `ext1[$key]` / `env1[$key]` associative-array reads crashed partway through comparison when a key exists only in the other preset.
- `enable <svc>`: bare `SERVICE_DEPENDS[$service_id]` crashed for service directories that exist on disk but have no valid manifest (edge case: user-extensions with malformed manifest).

## How

Single commit (tip `bea96fe2`; the original `a7bd6cac` was rebased onto this PR's parent branch `fix/dream-cli-pipefail-exit-codes` after that branch's commits were adjusted during review — PR-11's nounset audit content is unchanged, only the base commits it sits on have updated SHAs).

Audited by running every read-only subcommand end-to-end in a fake `INSTALL_DIR` and against a live install: `help`, `version`, `list`, `status`, `status-json`, `config show`, `gpu {status|topology|validate|assignment}`, `model {current|list}`, `mode`, `stt {current|status}`, `preset {list|save|load|delete|export|import|diff}`, `agent status`, `doctor --json`, `template {list|preview}`, `audit`, `chat` (against down backend), `benchmark`, `enable`/`disable`/`purge` (against both valid-service and unknown paths). Also verified with minimal environment (`env -i PATH HOME BASH INSTALL_DIR dream-cli ...`) to catch implicit `TERM`/`USER`/`LANG` assumptions.

## Testing

- End-to-end coverage of ~25 read-only dream-cli subcommands on the operator's integration branch.
- Minimal-environment verification via `env -i`.
- Operator's integration-branch test battery: green.

## Scope Note

Depends on the `set -eo pipefail` foundation from `fix/dream-cli-pipefail-exit-codes` — this branch's base commits are that PR's three commits (rebased onto the review-adjusted tips). Intended to merge after that PR lands.

## Platform Impact

- **macOS / Linux / Windows (WSL2):** identical. Portable Bash 4+ parameter expansion. No platform branching. No variables that are set on one OS but not another were found during the audit — all guarded reads guard against missing registry entries or unprovided positional args, neither of which is platform-specific.


---

## 📋 Chain status (operator's reminder — apr-25)

This PR is the **last link in the `dream-cli` strict-mode chain**:

```
#1008 (READY) ──▶ #998 (DRAFT) ──▶ #1002 (this — DRAFT)
```

**Before this PR can be promoted:**
- #1008 must merge first (.env grep-pipeline guards).
- #998 must merge next (`set -eo pipefail` + exit-code contract — the foundation `-u` builds on).

**This PR currently shares 6+ identical hunks with #998** (line 6 set-line, identical `cmd_chat`/`cmd_benchmark`/`cmd_disable`/`cmd_agent`/`_gpu_reassign` rewrites, `sed -n '1p'` swaps). Merging in parallel = textual conflict.

**After #998 merges, the operator must:**
1. Rebase this branch onto post-#998 main. The shared hunks drop out automatically (already in main).
2. What remains is the unique `-u` work: the extra flag at line 6, plus `:-` empty-string default guards in `cmd_preset`, `cmd_enable`, etc.
3. Promote this PR from DRAFT → ready (`gh pr ready 1002`).

Kept DRAFT until then as a mechanical safeguard — cannot merge before #998.
