### PR TITLE
chore(bash32): guard declare -A callers + route dream-cli validate through $BASH

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -41,6 +41,9 @@ test: ## Run unit and contract tests
 	@echo "=== dream-cli pipefail tolerance ==="
 	@bash tests/test-dream-cli-pipefail-tolerance.sh
 	@echo ""
+	@echo "=== Bash 3.2 guard contracts ==="
+	@bash tests/test-bash32-guards.sh
+	@echo ""
 	@echo "=== dream config show secret-mask matrix ==="
 	@bash tests/test-dream-config-secret-mask.sh
 	@echo ""

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1114,7 +1114,7 @@ cmd_config() {
         validate)
             cd "$INSTALL_DIR"
             if [[ -x "$INSTALL_DIR/scripts/validate-env.sh" ]]; then
-                "$INSTALL_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$INSTALL_DIR/.env.schema.json"
+                "$BASH" "$INSTALL_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$INSTALL_DIR/.env.schema.json"
             else
                 warn "validate-env.sh not found at $INSTALL_DIR/scripts/validate-env.sh"
                 warn "Make sure you're on a recent Dream Server release."
@@ -1122,7 +1122,7 @@ cmd_config() {
             echo ""
             if [[ -x "$INSTALL_DIR/scripts/validate-manifests.sh" ]]; then
                 log "Validating extension manifests and compatibility..."
-                if "$INSTALL_DIR/scripts/validate-manifests.sh"; then
+                if "$BASH" "$INSTALL_DIR/scripts/validate-manifests.sh"; then
                     success "Extension manifests validated"
                 else
                     warn "Extension manifest validation reported issues. See output above."

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1470,7 +1470,7 @@ cmd_config() {
             echo ""
             if [[ -x "$INSTALL_DIR/scripts/validate-manifests.sh" ]]; then
                 log "Validating extension manifests and compatibility..."
-                if "$INSTALL_DIR/scripts/validate-manifests.sh"; then
+                if "$BASH" "$INSTALL_DIR/scripts/validate-manifests.sh"; then
                     success "Extension manifests validated"
                 else
                     warn "Extension manifest validation reported issues. See output above."

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -20,6 +20,14 @@
 #   Add new optional features to the Custom menu here.
 # ============================================================================
 
+# Require Bash 4+ (associative arrays used for GPU topology/link maps)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: $(basename "${BASH_SOURCE[0]}") requires Bash 4.0+ (current: $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 dream_progress 18 "features" "Selecting features"
 if $INTERACTIVE && ! $DRY_RUN; then
     show_phase 2 6 "Feature Selection" "~1 minute"

--- a/dream-server/lib/progress.sh
+++ b/dream-server/lib/progress.sh
@@ -2,6 +2,14 @@
 # Dream Server — Progress Bar Utilities
 # Sourced by install-core.sh for download/install progress display
 
+# Require Bash 4+ (associative array PHASE_ESTIMATES used for phase timing)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: $(basename "${BASH_SOURCE[0]}") requires Bash 4.0+ (current: $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    return 1 2>/dev/null || exit 1
+fi
+
 # ═══════════════════════════════════════════════════════════════
 # PROGRESS BAR
 # ═══════════════════════════════════════════════════════════════

--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -11,6 +11,14 @@
 # This complements dream-test.sh which checks service health.
 #=============================================================================
 
+# Require Bash 4+ (associative arrays used for service-port lookup)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: $(basename "$0") requires Bash 4.0+ (you have $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    exit 1
+fi
+
 set -euo pipefail
 
 # Colors
@@ -31,7 +39,7 @@ if [[ -f "$_FT_DIR/lib/service-registry.sh" ]]; then
 fi
 
 # Ensure SERVICE_PORTS is declared even if service-registry.sh was not sourced
-declare -A SERVICE_PORTS 2>/dev/null || true
+declare -A SERVICE_PORTS
 
 # Service endpoints — resolved from registry
 LLM_URL="${LLM_URL:-http://localhost:${SERVICE_PORTS[llama-server]:-11434}}"

--- a/dream-server/scripts/pre-download.sh
+++ b/dream-server/scripts/pre-download.sh
@@ -17,6 +17,14 @@
 # Cache location: ~/.cache/huggingface/hub/
 #=============================================================================
 
+# Require Bash 4+ (associative arrays used for tier → model mapping)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: $(basename "$0") requires Bash 4.0+ (you have $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    exit 1
+fi
+
 set -euo pipefail
 
 # Colors

--- a/dream-server/scripts/validate-env.sh
+++ b/dream-server/scripts/validate-env.sh
@@ -7,6 +7,14 @@
 #  - Validate required keys, unknown keys, types, enums, and numeric ranges
 #  - Fail deterministically with a single exit code for CI
 
+# Require Bash 4+ (associative arrays used for env key/value/line tracking)
+if (( BASH_VERSINFO[0] < 4 )); then
+    echo "ERROR: $(basename "$0") requires Bash 4.0+ (you have $BASH_VERSION)" >&2
+    echo "  macOS ships Bash 3.2 due to licensing. Install a modern version:" >&2
+    echo "    brew install bash" >&2
+    exit 1
+fi
+
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/dream-server/tests/test-bash32-guards.sh
+++ b/dream-server/tests/test-bash32-guards.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Regression coverage for scripts that use Bash 4 associative arrays.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+first_line() {
+    local pattern="$1"
+    local file="$2"
+    grep -n "$pattern" "$file" | head -n 1 | cut -d: -f1
+}
+
+assert_guard_before_declare() {
+    local file="$1"
+    local mode="$2"
+    local label="$3"
+    local guard_line declare_line
+
+    guard_line="$(first_line 'BASH_VERSINFO\[0\] < 4' "$file")"
+    declare_line="$(first_line 'declare -A' "$file")"
+
+    if [[ -n "$guard_line" && -n "$declare_line" && "$guard_line" -lt "$declare_line" ]]; then
+        pass "$label guard appears before declare -A"
+    else
+        fail "$label guard must appear before first declare -A"
+    fi
+
+    if [[ "$mode" == "sourced" ]]; then
+        if grep -q 'return 1 2>/dev/null || exit 1' "$file"; then
+            pass "$label guard is safe when sourced"
+        else
+            fail "$label guard should return when sourced"
+        fi
+    else
+        if awk '/BASH_VERSINFO\[0\] < 4/{in_guard=1} in_guard && /exit 1/{found=1} /^fi$/{if(in_guard) exit} END{exit found ? 0 : 1}' "$file"; then
+            pass "$label guard exits for direct execution"
+        else
+            fail "$label guard should exit for direct execution"
+        fi
+    fi
+}
+
+assert_guard_before_declare "$ROOT_DIR/lib/progress.sh" sourced "lib/progress.sh"
+assert_guard_before_declare "$ROOT_DIR/installers/phases/03-features.sh" sourced "03-features.sh"
+assert_guard_before_declare "$ROOT_DIR/scripts/pre-download.sh" direct "pre-download.sh"
+assert_guard_before_declare "$ROOT_DIR/scripts/dream-test-functional.sh" direct "dream-test-functional.sh"
+
+if grep -q '"$BASH" "$INSTALL_DIR/scripts/validate-env.sh"' "$ROOT_DIR/dream-cli"; then
+    pass "dream-cli config validate runs validate-env.sh through active Bash"
+else
+    fail "dream-cli config validate should run validate-env.sh through active Bash"
+fi
+
+if grep -q '"$BASH" "$INSTALL_DIR/scripts/validate-manifests.sh"' "$ROOT_DIR/dream-cli"; then
+    pass "dream-cli config validate runs validate-manifests.sh through active Bash"
+else
+    fail "dream-cli config validate should run validate-manifests.sh through active Bash"
+fi
+
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
> **Merge after: #994.** This branch overlaps with #994 on `dream-server/dream-cli` and `scripts/validate-env.sh` (the schema-driven secret masking + Bash 4 `validate-env.sh` invocation). Merging this first would conflict with #994 / re-add reverted hunks. Once #994 lands, rebasing this drops the duplicated `dream-cli` / `validate-env.sh` hunks and the unique `installers/phases/03-features.sh`, `lib/progress.sh`, `scripts/pre-download.sh`, `scripts/dream-test-functional.sh` Bash-3.2 guards remain.

## What
Adds Bash 4+ guards to five scripts that use `declare -A` without one, and routes two `dream config validate` subprocesses through `"$BASH"` so they inherit dream-cli's modern bash interpreter.

Files touched (6):
- `dream-server/scripts/pre-download.sh` — Pattern A guard (bare `exit 1`)
- `dream-server/scripts/dream-test-functional.sh` — Pattern A guard + drop dead `2>/dev/null || true` fallback on `declare -A SERVICE_PORTS`
- `dream-server/scripts/validate-env.sh` — Pattern A guard
- `dream-server/lib/progress.sh` — Pattern B guard (`return 1 2>/dev/null || exit 1`)
- `dream-server/installers/phases/03-features.sh` — Pattern B guard
- `dream-server/dream-cli` — prefix validate-env.sh and validate-manifests.sh subprocess execs with `"$BASH"`

Guard style mirrors `dream-cli:8-14` (Pattern A, standalone scripts) and `lib/service-registry.sh:18-24` (Pattern B, sourced libraries).

## Why
On macOS, system `/bin/bash` is 3.2.57, which does not support associative arrays. Two user-facing problems:

1. Invoking any of these scripts directly under system bash (e.g. `./scripts/pre-download.sh --tier 3` from FAQ.md) produced a cryptic `declare -A: invalid option` crash with no actionable hint.
2. Even when dream-cli itself was launched under a modern Homebrew bash (its own Bash 4+ guard passes), it invoked `scripts/validate-env.sh` via shebang — which re-resolves to `/bin/bash` 3.2 regardless of the parent interpreter. `dream config validate` was silently non-functional on macOS for users without bash in PATH.

Guards turn (1) into a friendly error with a `brew install bash` hint. The `"$BASH"` prefix makes (2) work by inheriting the parent interpreter.

## How
- Guard block placed after the file header/purpose comments but before `set -euo pipefail` and before the first `declare -A`. Pattern B uses `return 1 2>/dev/null || exit 1` so sourced-vs-exec'd-direct both behave correctly.
- `dream-cli:1117` and `:1125`: `"$INSTALL_DIR/scripts/<script>.sh" ...` → `"$BASH" "$INSTALL_DIR/scripts/<script>.sh" ...`. `$BASH` is bash's own path to its interpreter; since dream-cli guards at line 9 require Bash 4+, `$BASH` is guaranteed to point at a modern bash when this code runs.

## Testing
- [x] `bash -n` syntax check — all 6 files pass
- [x] `shellcheck` — per-file warning counts identical between upstream/main and PR (no new diagnostics). SC2317 on Pattern B `exit 1` is accepted baseline, identical to `service-registry.sh:23`.
- [x] `make lint` — clean
- [x] Pre-commit (gitleaks / private-key / large-file) — clean
- [x] **Live macOS test on Bash 3.2.57**: each script exits with "ERROR: ... requires Bash 4.0+ (you have 3.2.57)" when run under `/bin/bash`. Pattern B sourced-path correctly propagates non-zero `$?` to the caller without aborting the parent shell.
- [x] Pattern B error-text wording aligned to `lib/service-registry.sh:20` ("Install a modern version") for consistency.

## Platform Impact
- **macOS** (primary target): `dream config validate` now works without requiring the user to manually invoke via `/opt/homebrew/bin/bash`. Direct invocations of the 5 scripts under system bash produce a clean error message instead of a cryptic crash.
- **Linux**: no impact (Bash 5+ everywhere; guards never fire).
- **Windows WSL2**: no impact (Bash 5+ in WSL2; guards never fire).
