### PR TITLE
fix(scripts): NUL-delimited compose-flags contract for path-with-spaces safety

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -33,6 +33,9 @@ test: ## Run unit and contract tests
 	@echo "=== Overlay/plist contracts ==="
 	@bash tests/contracts/test-overlay-map-coherence.sh
 	@bash tests/contracts/test-plist-log-paths.sh
+	@echo ""
+	@echo "=== resolve-compose-stack --null contract ==="
+	@bash tests/test-resolve-compose-null.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/dream-server/scripts/dream-preflight.sh
+++ b/dream-server/scripts/dream-preflight.sh
@@ -22,6 +22,8 @@ if [[ -x "$SCRIPT_DIR/scripts/resolve-compose-stack.sh" ]]; then
     COMPOSE_FLAGS=$("$SCRIPT_DIR/scripts/resolve-compose-stack.sh" \
         --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}")
 fi
+# Split COMPOSE_FLAGS into an array so paths with spaces survive expansion
+read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
 
 # Colors
 RED='\033[0;31m'
@@ -53,7 +55,7 @@ fi
 
 # Check containers are up
 echo -n "Core containers... "
-if docker compose $COMPOSE_FLAGS ps | grep -q "$LLM_CONTAINER"; then
+if docker compose "${COMPOSE_FLAGS_ARR[@]}" ps | grep -q "$LLM_CONTAINER"; then
     echo -e "${GREEN}✓ running${NC}"
 else
     echo -e "${RED}✗ not running${NC}"
@@ -94,7 +96,7 @@ fi
 for sid in "${SERVICE_IDS[@]}"; do
     [[ "${SERVICE_CATEGORIES[$sid]}" == "core" ]] && continue
     container="${SERVICE_CONTAINERS[$sid]}"
-    docker compose $COMPOSE_FLAGS ps 2>/dev/null | grep -q "$container" || continue
+    docker compose "${COMPOSE_FLAGS_ARR[@]}" ps 2>/dev/null | grep -q "$container" || continue
 
     port="${SERVICE_PORTS[$sid]:-0}"
     health="${SERVICE_HEALTH[$sid]:-/}"

--- a/dream-server/scripts/dream-preflight.sh
+++ b/dream-server/scripts/dream-preflight.sh
@@ -16,14 +16,17 @@ sr_load
 load_env_file "$SCRIPT_DIR/.env"
 sr_resolve_ports
 
-# Resolve compose flags for accurate status checks
-COMPOSE_FLAGS=""
+# Resolve compose flags for accurate status checks. The resolver's
+# --null mode emits each argv token NUL-separated so paths containing
+# whitespace round-trip through this consumer safely.
+COMPOSE_FLAGS_ARR=()
 if [[ -x "$SCRIPT_DIR/scripts/resolve-compose-stack.sh" ]]; then
-    COMPOSE_FLAGS=$("$SCRIPT_DIR/scripts/resolve-compose-stack.sh" \
-        --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}")
+    while IFS= read -r -d '' _arg; do
+        COMPOSE_FLAGS_ARR+=("$_arg")
+    done < <("$SCRIPT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" \
+        --null)
 fi
-# Split COMPOSE_FLAGS into an array so paths with spaces survive expansion
-read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
 
 # Colors
 RED='\033[0;31m'

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -8,6 +8,7 @@ PROFILE_OVERLAYS=""
 ENV_MODE="false"
 SKIP_BROKEN="false"
 GPU_COUNT="1"
+NULL_MODE="false"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -39,6 +40,13 @@ while [[ $# -gt 0 ]]; do
             GPU_COUNT="${2:-$GPU_COUNT}"
             shift 2
             ;;
+        --null|-0)
+            # NUL-delimited output: emit args separated by \0 with a
+            # trailing \0 so consumers can use `read -d ''` to round-trip
+            # paths containing whitespace safely.
+            NULL_MODE="true"
+            shift
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
@@ -55,7 +63,7 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" <<'PY'
+"$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" "$NULL_MODE" <<'PY'
 import os
 import pathlib
 import platform
@@ -70,6 +78,7 @@ env_mode = (sys.argv[5] or "false").lower() == "true"
 skip_broken = (sys.argv[6] or "false").lower() == "true"
 dream_mode = os.environ.get("DREAM_MODE", "local").lower()
 gpu_count = int(sys.argv[7] or "1")
+null_mode = (sys.argv[8] or "false").lower() == "true"
 
 IS_DARWIN = platform.system() == "Darwin"
 APPLE_OVERLAY = "installers/macos/docker-compose.macos.yml" if IS_DARWIN else "docker-compose.apple.yml"
@@ -252,7 +261,19 @@ def to_flags(files):
 
 resolved_flags = to_flags(resolved)
 
-if env_mode:
+if null_mode:
+    # NUL-delimited stream of individual argv tokens. Trailing NUL lets
+    # consumers terminate `while IFS= read -r -d ''` loops cleanly even
+    # when the resolved set is empty.
+    parts = []
+    for f in resolved:
+        parts.append("-f")
+        parts.append(str(f))
+    payload = b"\0".join(p.encode("utf-8") for p in parts)
+    if payload:
+        payload += b"\0"
+    sys.stdout.buffer.write(payload)
+elif env_mode:
     def out(key, value):
         safe = str(value).replace("\\", "\\\\").replace('"', '\\"')
         print(f'{key}="{safe}"')

--- a/dream-server/scripts/validate-compose-stack.sh
+++ b/dream-server/scripts/validate-compose-stack.sh
@@ -39,10 +39,13 @@ if [[ -z "$COMPOSE_FLAGS" ]]; then
 fi
 
 # Build env-file flag if provided (allows compose to resolve required variable references)
-ENV_FILE_FLAG=""
+ENV_FILE_FLAG_ARR=()
 if [[ -n "$ENV_FILE" && -f "$ENV_FILE" ]]; then
-    ENV_FILE_FLAG="--env-file $ENV_FILE"
+    ENV_FILE_FLAG_ARR=(--env-file "$ENV_FILE")
 fi
+
+# Split COMPOSE_FLAGS into an array so paths with spaces survive expansion
+read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
 
 # Check if docker/docker compose is available
 if command -v docker &>/dev/null && docker compose version &>/dev/null; then
@@ -67,7 +70,7 @@ fi
 # - Circular dependencies
 # - Invalid environment variable references
 validation_output=$(mktemp)
-if $DOCKER_COMPOSE_CMD $ENV_FILE_FLAG $COMPOSE_FLAGS config > "$validation_output" 2>&1; then
+if $DOCKER_COMPOSE_CMD "${ENV_FILE_FLAG_ARR[@]}" "${COMPOSE_FLAGS_ARR[@]}" config > "$validation_output" 2>&1; then
     if ! $QUIET; then
         echo "Compose stack validation passed"
         # Show summary of services

--- a/dream-server/scripts/validate-compose-stack.sh
+++ b/dream-server/scripts/validate-compose-stack.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 # Validate resolved Docker Compose stack for syntax errors
-# Usage: validate-compose-stack.sh --compose-flags "-f file1.yml -f file2.yml" [--env-file /path/to/.env]
+#
+# Usage:
+#   validate-compose-stack.sh --compose-flags "-f file1.yml -f file2.yml" [--env-file /path/to/.env]
+#   validate-compose-stack.sh --compose-flag -f --compose-flag file1.yml --compose-flag -f --compose-flag file2.yml [...]
+#
+# `--compose-flag` (singular, repeatable) is the path-with-spaces-safe
+# input form. `--compose-flags` (plural string) is whitespace-split and
+# kept for legacy callers (e.g. installers/phases/02-detection.sh).
 #
 # Returns:
 #   0 - Valid compose stack
@@ -8,14 +15,25 @@
 
 set -euo pipefail
 
-COMPOSE_FLAGS=""
+COMPOSE_FLAGS_ARR=()
 ENV_FILE=""
 QUIET=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --compose-flags)
-            COMPOSE_FLAGS="${2:-}"
+            # Legacy whitespace-split string form. Splits on any
+            # whitespace, so paths containing spaces are unsafe via
+            # this flag — use --compose-flag (singular) instead.
+            read -ra _legacy_arr <<< "${2:-}"
+            COMPOSE_FLAGS_ARR+=("${_legacy_arr[@]}")
+            shift 2
+            ;;
+        --compose-flag)
+            # Repeatable singular form. Each invocation appends one
+            # already-tokenised argv element, preserving any embedded
+            # whitespace in paths.
+            COMPOSE_FLAGS_ARR+=("${2:-}")
             shift 2
             ;;
         --env-file)
@@ -33,8 +51,8 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ -z "$COMPOSE_FLAGS" ]]; then
-    echo "ERROR: --compose-flags required" >&2
+if [[ ${#COMPOSE_FLAGS_ARR[@]} -eq 0 ]]; then
+    echo "ERROR: --compose-flag (repeatable) or --compose-flags (string) required" >&2
     exit 1
 fi
 
@@ -44,8 +62,9 @@ if [[ -n "$ENV_FILE" && -f "$ENV_FILE" ]]; then
     ENV_FILE_FLAG_ARR=(--env-file "$ENV_FILE")
 fi
 
-# Split COMPOSE_FLAGS into an array so paths with spaces survive expansion
-read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
+# Diagnostic-only string for log/error output; the array is what gets
+# executed.
+COMPOSE_FLAGS_DISPLAY="${COMPOSE_FLAGS_ARR[*]}"
 
 # Check if docker/docker compose is available
 if command -v docker &>/dev/null && docker compose version &>/dev/null; then
@@ -59,7 +78,7 @@ fi
 
 # Validate compose stack syntax
 if ! $QUIET; then
-    echo "Validating compose stack: $COMPOSE_FLAGS"
+    echo "Validating compose stack: $COMPOSE_FLAGS_DISPLAY"
 fi
 
 # Use docker compose config to validate syntax and merge
@@ -85,7 +104,7 @@ else
     echo "Errors:" >&2
     cat "$validation_output" >&2
     echo "" >&2
-    echo "Compose flags: $COMPOSE_FLAGS" >&2
+    echo "Compose flags: $COMPOSE_FLAGS_DISPLAY" >&2
     rm -f "$validation_output"
     exit 1
 fi

--- a/dream-server/scripts/validate.sh
+++ b/dream-server/scripts/validate.sh
@@ -35,6 +35,8 @@ if [[ -x "$PROJECT_DIR/scripts/resolve-compose-stack.sh" ]]; then
     COMPOSE_FLAGS=$("$PROJECT_DIR/scripts/resolve-compose-stack.sh" \
         --script-dir "$PROJECT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}")
 fi
+# Split COMPOSE_FLAGS into an array so paths with spaces survive expansion
+read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
 
 echo ""
 echo "╔═══════════════════════════════════════════╗"
@@ -61,8 +63,24 @@ check() {
 
 echo "1. Container Status"
 echo "───────────────────"
-check "llama-server running" "docker compose $COMPOSE_FLAGS ps llama-server 2>/dev/null | grep -qE 'Up|running'"
-check "Open WebUI running" "docker compose $COMPOSE_FLAGS ps open-webui 2>/dev/null | grep -qE 'Up|running'"
+# Compose-flag checks use array expansion directly (check() runs via bash -c
+# which can't preserve array boundaries across string handoff)
+printf "  %-30s " "llama-server running..."
+if docker compose "${COMPOSE_FLAGS_ARR[@]}" ps llama-server 2>/dev/null | grep -qE 'Up|running'; then
+    echo -e "${GREEN}✓ PASS${NC}"
+    ((PASSED++))
+else
+    echo -e "${RED}✗ FAIL${NC}"
+    ((FAILED++))
+fi
+printf "  %-30s " "Open WebUI running..."
+if docker compose "${COMPOSE_FLAGS_ARR[@]}" ps open-webui 2>/dev/null | grep -qE 'Up|running'; then
+    echo -e "${GREEN}✓ PASS${NC}"
+    ((PASSED++))
+else
+    echo -e "${RED}✗ FAIL${NC}"
+    ((FAILED++))
+fi
 
 echo ""
 echo "2. Health Endpoints"
@@ -118,7 +136,7 @@ for sid in "${SERVICE_IDS[@]}"; do
     [[ -z "$_health" || "$_port" == "0" ]] && continue
 
     # Check if container is running
-    if docker compose $COMPOSE_FLAGS ps "$sid" 2>/dev/null | grep -qE "Up|running"; then
+    if docker compose "${COMPOSE_FLAGS_ARR[@]}" ps "$sid" 2>/dev/null | grep -qE "Up|running"; then
         check "$_name" "curl -sf --max-time 10 http://localhost:${_port}${_health}"
     else
         printf "  %-30s ${YELLOW}○ SKIP (not enabled)${NC}\n" "$_name..."

--- a/dream-server/scripts/validate.sh
+++ b/dream-server/scripts/validate.sh
@@ -29,14 +29,17 @@ LLM_HEALTH="${SERVICE_HEALTH[llama-server]:-/health}"
 WEBUI_PORT="${WEBUI_PORT:-${SERVICE_PORTS[open-webui]:-3000}}"
 WEBUI_HEALTH="${WEBUI_HEALTH:-${SERVICE_HEALTH[open-webui]:-/}}"
 
-# Resolve compose flags to match actual stack
-COMPOSE_FLAGS=""
+# Resolve compose flags to match actual stack. The resolver's --null
+# mode emits each argv token NUL-separated so paths containing
+# whitespace round-trip through this consumer safely.
+COMPOSE_FLAGS_ARR=()
 if [[ -x "$PROJECT_DIR/scripts/resolve-compose-stack.sh" ]]; then
-    COMPOSE_FLAGS=$("$PROJECT_DIR/scripts/resolve-compose-stack.sh" \
-        --script-dir "$PROJECT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}")
+    while IFS= read -r -d '' _arg; do
+        COMPOSE_FLAGS_ARR+=("$_arg")
+    done < <("$PROJECT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$PROJECT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" \
+        --null)
 fi
-# Split COMPOSE_FLAGS into an array so paths with spaces survive expansion
-read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"
 
 echo ""
 echo "╔═══════════════════════════════════════════╗"

--- a/dream-server/tests/test-resolve-compose-null.sh
+++ b/dream-server/tests/test-resolve-compose-null.sh
@@ -125,6 +125,43 @@ else
     fail "default mode output changed: '$default_text'"
 fi
 
+# 5. End-to-end: an extension whose own directory name contains a
+#    space produces a relative compose path with a literal space, and
+#    that path survives the NUL round-trip as a single token.
+EXT_NAME="space ext"
+mkdir -p "$SCRIPT_DIR_WITH_SPACE/extensions/services/$EXT_NAME"
+cat > "$SCRIPT_DIR_WITH_SPACE/extensions/services/$EXT_NAME/manifest.json" <<EOF
+{
+  "schema_version": "dream.services.v1",
+  "service": {
+    "id": "space-ext",
+    "compose_file": "compose.yaml",
+    "gpu_backends": ["all"]
+  }
+}
+EOF
+touch "$SCRIPT_DIR_WITH_SPACE/extensions/services/$EXT_NAME/compose.yaml"
+
+ext_arr=()
+while IFS= read -r -d '' tok; do
+    ext_arr+=("$tok")
+done < <("$RESOLVER" --script-dir "$SCRIPT_DIR_WITH_SPACE" \
+    --tier 1 --gpu-backend nvidia --null)
+
+# Find the token that points at the space-ext compose file. It should
+# be exactly one element with the literal space preserved.
+expected_path="extensions/services/$EXT_NAME/compose.yaml"
+match_count=0
+for t in "${ext_arr[@]}"; do
+    [[ "$t" == "$expected_path" ]] && match_count=$((match_count + 1))
+done
+
+if [[ "$match_count" -eq 1 ]]; then
+    pass "extension dir with space round-trips as a single token: '$expected_path'"
+else
+    fail "expected exactly one token '$expected_path', got $match_count matches in [${ext_arr[*]}]"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]

--- a/dream-server/tests/test-resolve-compose-null.sh
+++ b/dream-server/tests/test-resolve-compose-null.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# ============================================================================
+# resolve-compose-stack.sh --null contract test
+# ============================================================================
+# Verifies that:
+#   1. --null emits each argv token NUL-separated.
+#   2. The standard consumer pattern (`while IFS= read -r -d ''`) reads
+#      back the array correctly, including paths containing whitespace.
+#   3. Default (string) mode is unchanged when --null is not passed.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOLVER="$ROOT_DIR/scripts/resolve-compose-stack.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   resolve-compose-stack.sh --null contract    ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+if [[ ! -x "$RESOLVER" ]]; then
+    fail "resolver not found at $RESOLVER"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+pass "resolver is executable"
+
+# Build a temp script-dir with a parent path containing a space, plus
+# the minimum scaffolding the resolver expects.
+TEMP_DIR=$(mktemp -d "/tmp/ds null test.XXXXXX")
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+mkdir -p "$TEMP_DIR/space dir/dream-server"
+SCRIPT_DIR_WITH_SPACE="$TEMP_DIR/space dir/dream-server"
+touch "$SCRIPT_DIR_WITH_SPACE/docker-compose.base.yml"
+touch "$SCRIPT_DIR_WITH_SPACE/docker-compose.nvidia.yml"
+mkdir -p "$SCRIPT_DIR_WITH_SPACE/extensions/services"
+
+# 1. --null mode emits NUL-separated tokens. Bash's `$()` strips NUL
+#    bytes silently, so we use a tempfile to inspect the raw bytes.
+nul_file="$TEMP_DIR/null-output.bin"
+"$RESOLVER" --script-dir "$SCRIPT_DIR_WITH_SPACE" \
+    --tier 1 --gpu-backend nvidia --null > "$nul_file"
+
+nul_count=$(tr -cd '\0' < "$nul_file" | wc -c | tr -d ' ')
+if [[ "$nul_count" -ge 4 ]]; then
+    pass "--null output contains $nul_count NUL bytes"
+else
+    fail "--null output should have >= 4 NUL bytes, got $nul_count"
+fi
+
+# 2. Round-trip via `read -d ''` produces an array with the expected
+#    tokens.
+arr=()
+while IFS= read -r -d '' tok; do
+    arr+=("$tok")
+done < <("$RESOLVER" --script-dir "$SCRIPT_DIR_WITH_SPACE" \
+    --tier 1 --gpu-backend nvidia --null)
+
+if [[ ${#arr[@]} -eq 4 ]]; then
+    pass "round-trip array has 4 tokens"
+else
+    fail "expected 4 tokens, got ${#arr[@]}: ${arr[*]}"
+fi
+
+if [[ "${arr[0]:-}" == "-f" && "${arr[1]:-}" == "docker-compose.base.yml" ]]; then
+    pass "first token pair is -f docker-compose.base.yml"
+else
+    fail "expected '-f docker-compose.base.yml' first, got '${arr[0]:-<unset>} ${arr[1]:-<unset>}'"
+fi
+
+if [[ "${arr[2]:-}" == "-f" && "${arr[3]:-}" == "docker-compose.nvidia.yml" ]]; then
+    pass "second token pair is -f docker-compose.nvidia.yml"
+else
+    fail "expected '-f docker-compose.nvidia.yml' second, got '${arr[2]:-<unset>} ${arr[3]:-<unset>}'"
+fi
+
+# 3. Synthetic NUL stream containing a path with whitespace round-trips
+#    through the consumer pattern intact. Bash's `$()` strips NUL bytes,
+#    so we feed the read loop directly from process substitution.
+recv=()
+while IFS= read -r -d '' tok; do
+    recv+=("$tok")
+done < <(printf '%s\0%s\0%s\0' "-f" "/tmp/path with spaces/compose.yml" "-f")
+
+if [[ ${#recv[@]} -eq 3 ]] \
+    && [[ "${recv[0]}" == "-f" ]] \
+    && [[ "${recv[1]}" == "/tmp/path with spaces/compose.yml" ]] \
+    && [[ "${recv[2]}" == "-f" ]]; then
+    pass "consumer pattern preserves whitespace inside tokens"
+else
+    fail "round-trip mangled whitespace token: count=${#recv[@]} [${recv[*]}]"
+fi
+
+# 4. Default mode (no --null) still emits the legacy space-delimited
+#    string. Inspect the raw bytes via tempfile because `$()` would
+#    discard any NUL anyway and we want to detect a regression.
+default_file="$TEMP_DIR/default-output.txt"
+"$RESOLVER" --script-dir "$SCRIPT_DIR_WITH_SPACE" \
+    --tier 1 --gpu-backend nvidia > "$default_file"
+
+default_nul_count=$(tr -cd '\0' < "$default_file" | wc -c | tr -d ' ')
+if [[ "$default_nul_count" -eq 0 ]]; then
+    pass "default mode contains no NUL bytes (legacy string preserved)"
+else
+    fail "default mode unexpectedly contains $default_nul_count NUL bytes"
+fi
+
+default_text=$(cat "$default_file")
+if [[ "$default_text" == "-f docker-compose.base.yml -f docker-compose.nvidia.yml" ]]; then
+    pass "default mode output is the expected legacy string"
+else
+    fail "default mode output changed: '$default_text'"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## What
Replace the broken `read -ra COMPOSE_FLAGS_ARR <<< "$COMPOSE_FLAGS"` whitespace-split with an end-to-end NUL-delimited contract between `resolve-compose-stack.sh` and its consumers, addressing the maintainer's audit follow-up that `read -ra` still mangles paths containing spaces.

Also adds a path-safe singular `--compose-flag` interface to `validate-compose-stack.sh` (legacy `--compose-flags` plural string preserved for the existing installer caller).

## Why
The original PR's scope-clarification admitted: "install directories containing spaces do not appear in COMPOSE_FLAGS as absolute path components in the current code. This PR does not change that behaviour; it is shellcheck hardening and convention alignment only." The maintainer didn't accept that boundary and asked for a delimiter-safe contract.

Empirically reproduced the underlying bug: legacy `--compose-flags "-f /tmp/ds path test.XXX/c.yml"` fails with "open /tmp/ds: file does not exist" because `read -ra` splits on whitespace inside the path. The same input via the new `--compose-flag -f --compose-flag "/tmp/ds path test.XXX/c.yml"` succeeds.

## How

### Producer side: `dream-server/scripts/resolve-compose-stack.sh`
- New `--null` (alias `-0`) flag.
- The Python heredoc receives `NULL_MODE` as an 8th positional argv. When set, it emits each argv token (`-f`, file-path, `-f`, file-path, …) as raw bytes via `sys.stdout.buffer.write`, NUL-separated, with a trailing NUL (suppressed when the resolved set is empty so consumer `read -d ''` loops terminate cleanly with zero tokens).
- Default and `--env` modes are unchanged.

### Consumer side: `dream-server/scripts/validate.sh`, `dream-server/scripts/dream-preflight.sh`
- Replaced the broken `read -ra <<< "$str"` pattern with the standard NUL-safe consumer loop:
  ```bash
  while IFS= read -r -d '' _arg; do
      COMPOSE_FLAGS_ARR+=("$_arg")
  done < <(./scripts/resolve-compose-stack.sh ... --null)
  ```
- The `COMPOSE_FLAGS_ARR` array is then passed via `"${COMPOSE_FLAGS_ARR[@]}"` to `docker compose`, preserving every embedded character including whitespace.

### Validator side: `dream-server/scripts/validate-compose-stack.sh`
- Added `--compose-flag` (singular, repeatable) for path-safe input. Each invocation appends one already-tokenised argv element.
- Kept `--compose-flags` (plural string) for legacy callers (the installer's `installers/phases/02-detection.sh:405` passes the resolver's string output via this flag; updating that caller is a separate scope).
- Internal: both interfaces feed into the same `COMPOSE_FLAGS_ARR`. Empty-check is now `${#COMPOSE_FLAGS_ARR[@]} -eq 0`. Diagnostic-only display string is built from the array with `[*]` join.

## Testing

New `dream-server/tests/test-resolve-compose-null.sh` (9 cases, wired into `make test`):
1. Resolver is executable.
2. `--null` output contains NUL bytes (inspected via tempfile because bash `$()` strips NUL silently).
3. Round-trip via `read -d ''` produces the expected token array.
4. First token pair is `-f docker-compose.base.yml`.
5. Second token pair is `-f docker-compose.nvidia.yml`.
6. Synthetic NUL stream containing a path with whitespace round-trips through the consumer pattern intact.
7. Default mode contains no NUL bytes (legacy contract preserved).
8. Default mode output is the expected legacy string.
9. **End-to-end**: an extension whose own directory name contains a space (`extensions/services/space ext/compose.yaml`) is enumerated by the resolver, emitted as a single NUL-terminated token with the literal space preserved, and read back correctly by the consumer pattern.

Empirical verification on macOS:
- `xxd` inspection: `--null` output is `-f\0docker-compose.base.yml\0-f\0docker-compose.nvidia.yml\0...`
- End-to-end: legacy `--compose-flags "-f /tmp/ds path test.XXX/c.yml" --quiet` exits 1 with "open /tmp/ds: file does not exist"; new `--compose-flag -f --compose-flag "/tmp/ds path test.XXX/c.yml" --quiet` exits 0.
- All 50 tokens (the live repo's full extension set) round-trip correctly.

`make lint`, `make test`, `shellcheck` all green. The 12 pre-existing Python 3.14 asyncio shim failures in dashboard-api tests are unrelated.

## Review
Local CG **APPROVED WITH WARNINGS**:
- Required-before-push: none.
- Worth fixing now (addressed in commit `cd89f028`): the original test's `SCRIPT_DIR_WITH_SPACE` scaffold was misleading because the resolver emits paths relative to `--script-dir`, so the literal space never appeared in the NUL stream. The 9th case scaffolds an extension at `extensions/services/space ext/` so the relative path `extensions/services/space ext/compose.yaml` itself contains a literal space — exercising the producer→consumer round-trip end-to-end.

## Out of scope (deferred follow-ups)
- **`installers/lib/compose-select.sh`** builds `COMPOSE_FLAGS` as a space-delimited string for the installer's own use. Migrating that producer to NUL would expand scope into the installer chain. The new `--compose-flag` singular interface is available when phase 02 wants to migrate independently.
- **`installers/phases/02-detection.sh:405`** still uses legacy `--compose-flags "$COMPOSE_FLAGS"`. The resolver currently emits relative paths and the script `cd "$INSTALL_DIR"`s before invoking compose, so this path is mostly theoretical — but a path-safe migration is a clean follow-up.
- **`((FAILED++))` under `set -e`** in `validate.sh` and `dream-preflight.sh`: pre-existing across upstream/main, NOT introduced by this PR. Recommend separate cleanup PR using `((FAILED++)) || true` or `FAILED=$((FAILED + 1))`.
- **`"${arr[@]}"` empty-array expansion under bash 3.2 + `set -u`**: would crash, but repo posture is bash 4+ (enforced via `service-registry.sh:18`). Not a regression introduced by this PR; the legacy code paths used string variables that didn't have this trap.

## Platform Impact
- **macOS** (Homebrew bash 5+): all changes active and verified.
- **Linux** (NVIDIA + AMD): all changes active. The `--null` Python branch uses `sys.stdout.buffer.write` which emits raw bytes correctly under all Python 3 versions.
- **Windows/WSL2**: not affected — these scripts are not executed by the PowerShell installer.
