### PR TITLE
fix(dashboard-api): error-progress parity, restart guidance, unhealthy status

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -198,6 +198,13 @@ def _compute_extension_status(ext: dict, services_by_id: dict) -> str:
             svc = services_by_id.get(ext_id)
             if svc and svc.status == "healthy":
                 return "enabled"
+            # HTTP 4xx/5xx from the health endpoint is the clearest "container
+            # is up but broken" signal — surface it as "unhealthy" so the UI
+            # can prompt a log check. Timeouts / connection refused / DNS
+            # failures stay "stopped" because they don't distinguish a crashed
+            # container from an intentionally-stopped one.
+            if svc and svc.status == "unhealthy":
+                return "unhealthy"
             return "stopped"
         if (user_dir / "compose.yaml.disabled").exists():
             return "disabled"
@@ -733,10 +740,11 @@ async def extensions_catalog(
 
     summary = {
         "total": len(extensions),
-        "installed": sum(1 for e in extensions if e["status"] in ("enabled", "disabled", "stopped")),
+        "installed": sum(1 for e in extensions if e["status"] in ("enabled", "disabled", "stopped", "unhealthy")),
         "enabled": sum(1 for e in extensions if e["status"] == "enabled"),
         "disabled": sum(1 for e in extensions if e["status"] == "disabled"),
         "stopped": sum(1 for e in extensions if e["status"] == "stopped"),
+        "unhealthy": sum(1 for e in extensions if e["status"] == "unhealthy"),
         "installing": sum(1 for e in extensions if e["status"] == "installing"),
         "setting_up": sum(1 for e in extensions if e["status"] == "setting_up"),
         "error": sum(1 for e in extensions if e["status"] == "error"),
@@ -998,7 +1006,10 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
     agent_ok = _call_agent_install(service_id)
 
     if not agent_ok:
-        _write_error_progress(service_id, "Host agent failed to start extension")
+        _write_error_progress(
+            service_id,
+            "Host agent failed to start extension. Run 'dream restart' to recover.",
+        )
 
     logger.info("Installed extension: %s", service_id)
     return {
@@ -1165,6 +1176,11 @@ def enable_extension(
         # before the host agent starts the container.
         _call_agent_invalidate_compose_cache()
         agent_ok = _call_agent("start", service_id)
+        if not agent_ok:
+            _write_error_progress(
+                service_id,
+                "Host agent failed to start extension. Run 'dream restart' to recover.",
+            )
         logger.info("Started stopped extension: %s", service_id)
         return {
             "id": service_id,

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -1382,6 +1382,44 @@ class TestExtensionLifecycleStatus:
         ext = resp.json()["extensions"][0]
         assert ext["status"] == "stopped"
 
+    def test_user_extension_http_unhealthy_returns_unhealthy(self, test_client, monkeypatch, tmp_path):
+        """User extension with compose.yaml + HTTP 4xx/5xx health → unhealthy."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "my-ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
+        (ext_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {"id": "my-ext", "name": "My Ext", "port": 8080,
+                         "health": "/health"},
+        }))
+
+        catalog = [_make_catalog_ext("my-ext", "My Extension")]
+        _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+
+        mock_svc = _make_service_status("my-ext", "unhealthy")
+        with patch("user_extensions.get_user_services_cached",
+                   return_value={"my-ext": {"host": "my-ext", "port": 8080,
+                                             "health": "/health", "name": "My Ext"}}):
+            with patch("helpers.get_all_services", new_callable=AsyncMock,
+                       return_value=[]):
+                with patch("helpers.check_service_health", new_callable=AsyncMock,
+                           return_value=mock_svc):
+                    resp = test_client.get(
+                        "/api/extensions/catalog",
+                        headers=test_client.auth_headers,
+                    )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        ext = data["extensions"][0]
+        assert ext["status"] == "unhealthy"
+        # Unhealthy counts toward "installed" and has its own summary bucket
+        assert data["summary"]["unhealthy"] == 1
+        assert data["summary"]["installed"] == 1
+        assert data["summary"]["stopped"] == 0
+
     def test_user_extension_disabled_unchanged(self, test_client, monkeypatch, tmp_path):
         """User extension with compose.yaml.disabled → disabled (unchanged)."""
         user_dir = tmp_path / "user"
@@ -1467,6 +1505,50 @@ class TestExtensionLifecycleStatus:
         assert data["action"] == "enabled"
         # compose.yaml should still exist (not renamed)
         assert (user_dir / "my-ext" / "compose.yaml").exists()
+
+    def test_enable_stopped_writes_error_progress_on_agent_failure(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Enable-stopped path writes error progress with restart guidance on agent failure."""
+        user_dir = _setup_user_ext(tmp_path, "my-ext", enabled=True)
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+        monkeypatch.setattr("routers.extensions._call_agent",
+                            lambda action, sid: False)
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/enable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["restart_required"] is True
+
+        progress_file = Path(tmp_path) / "extension-progress" / "my-ext.json"
+        assert progress_file.exists(), "enable-stopped path must write progress on agent failure"
+        data = json.loads(progress_file.read_text())
+        assert data["status"] == "error"
+        assert "dream restart" in data["error"]
+
+    def test_install_error_progress_includes_restart_guidance(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Install failure-path error message contains 'dream restart' actionable guidance."""
+        lib_dir = _setup_library_ext(tmp_path, "my-ext")
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
+        monkeypatch.setattr("routers.extensions._call_agent_install",
+                            lambda sid: False)
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        progress_file = Path(tmp_path) / "extension-progress" / "my-ext.json"
+        assert progress_file.exists()
+        data = json.loads(progress_file.read_text())
+        assert data["status"] == "error"
+        assert "dream restart" in data["error"]
 
     def test_enable_stopped_rejects_malicious_compose(self, test_client, monkeypatch, tmp_path):
         """Enable stopped ext with malicious compose.yaml → 400."""

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -79,6 +79,7 @@ const friendlyError = (detail) => {
 const STATUS_STYLES = {
   enabled:       'bg-green-500/20 text-green-400',
   stopped:       'bg-red-500/20 text-red-400',
+  unhealthy:     'bg-amber-500/20 text-amber-400',
   disabled:      'bg-theme-border text-theme-text-muted',
   not_installed: 'border border-theme-border text-theme-text-muted',
   incompatible:  'bg-orange-500/20 text-orange-400',
@@ -90,7 +91,8 @@ const STATUS_STYLES = {
 const STATUS_DESCRIPTIONS = {
   enabled:       'Service is running and healthy',
   disabled:      'Installed but turned off \u2014 won\u2019t start on restart',
-  stopped:       'Enabled but container is not running or unhealthy',
+  stopped:       'Enabled but container is not running',
+  unhealthy:     'Container is running but health check is failing \u2014 check logs',
   not_installed: 'Available to install from the extension library',
   incompatible:  'Requires a GPU backend not available on this system',
   installing:    'Being downloaded and set up',
@@ -303,8 +305,8 @@ export default function Extensions() {
       .filter(Boolean)
   )]
 
-  const STATUS_FILTERS = ['all', 'enabled', 'stopped', 'disabled', 'installing', 'setting_up', 'error', 'not_installed', 'incompatible']
-  const STATUS_LABELS = { all: 'All', enabled: 'Enabled', stopped: 'Stopped', disabled: 'Disabled', installing: 'Installing', setting_up: 'Setting Up', error: 'Error', not_installed: 'Not Installed', incompatible: 'Incompatible' }
+  const STATUS_FILTERS = ['all', 'enabled', 'stopped', 'unhealthy', 'disabled', 'installing', 'setting_up', 'error', 'not_installed', 'incompatible']
+  const STATUS_LABELS = { all: 'All', enabled: 'Enabled', stopped: 'Stopped', unhealthy: 'Unhealthy', disabled: 'Disabled', installing: 'Installing', setting_up: 'Setting Up', error: 'Error', not_installed: 'Not Installed', incompatible: 'Incompatible' }
 
   // Filter extensions
   const query = search.toLowerCase()
@@ -357,6 +359,7 @@ export default function Extensions() {
           <SummaryItem label="Total" value={summary.total || extensions.length} color="bg-theme-text-muted" />
           <SummaryItem label="Installed" value={summary.installed ?? 0} color="bg-green-500" />
           <SummaryItem label="Stopped" value={summary.stopped ?? 0} color="bg-red-500" />
+          <SummaryItem label="Unhealthy" value={summary.unhealthy ?? 0} color="bg-amber-500" />
           <SummaryItem label="Available" value={summary.not_installed ?? 0} color="bg-theme-accent" />
           <SummaryItem label="Installing" value={summary.installing ?? 0} color="bg-blue-500" />
           <SummaryItem label="Error" value={summary.error ?? 0} color="bg-red-500" />
@@ -601,7 +604,8 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
   const isUserExt = ext.source === 'user'
   const isError = status === 'error'
   const isStopped = status === 'stopped'
-  const isToggleable = isUserExt && (status === 'enabled' || status === 'disabled' || status === 'error' || status === 'stopped')
+  const isUnhealthy = status === 'unhealthy'
+  const isToggleable = isUserExt && (status === 'enabled' || status === 'disabled' || status === 'error' || status === 'stopped' || status === 'unhealthy')
   const showRemove = isUserExt && (status === 'disabled' || isError)
   const showInstall = status === 'not_installed' && ext.installable
 
@@ -616,6 +620,7 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
             <div className={`p-1.5 rounded-lg ${
               status === 'enabled' ? 'bg-green-500/10' :
               status === 'stopped' ? 'bg-red-500/10' :
+              status === 'unhealthy' ? 'bg-amber-500/10' :
               status === 'incompatible' ? 'bg-orange-500/10' :
               (status === 'installing' || status === 'setting_up') ? 'bg-blue-500/10' :
               status === 'error' ? 'bg-red-500/10' :
@@ -624,6 +629,7 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
               <Icon size={16} className={
                 status === 'enabled' ? 'text-green-400' :
                 status === 'stopped' ? 'text-red-400' :
+                status === 'unhealthy' ? 'text-amber-400' :
                 status === 'incompatible' ? 'text-orange-400' :
                 (status === 'installing' || status === 'setting_up') ? 'text-blue-400' :
                 status === 'error' ? 'text-red-400' :
@@ -656,6 +662,7 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
                 className={`relative inline-flex h-[18px] w-[32px] shrink-0 rounded-full transition-colors disabled:opacity-50 ${
                   status === 'error' ? 'bg-red-500' :
                   status === 'stopped' ? 'bg-amber-500' :
+                  status === 'unhealthy' ? 'bg-amber-500' :
                   status === 'enabled' ? 'bg-green-500' : 'bg-theme-border'
                 }`}
               >
@@ -708,6 +715,16 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
               className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg bg-green-500/15 text-green-400 hover:bg-green-500/25 transition-colors disabled:opacity-50"
             >
               {isMutating ? <Loader2 size={12} className="animate-spin" /> : 'Start'}
+            </button>
+          )}
+          {isUserExt && isUnhealthy && (
+            <button
+              onClick={onConsole}
+              disabled={agentOffline}
+              title={agentOffline ? 'Host agent is offline' : 'View container logs'}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg bg-amber-500/15 text-amber-400 hover:bg-amber-500/25 transition-colors disabled:opacity-50"
+            >
+              <Terminal size={12} /> Check Logs
             </button>
           )}
           {isError && (
@@ -780,7 +797,7 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
               className={`flex items-center gap-1.5 px-2 py-1.5 text-[10px] rounded-lg transition-colors ${
                 agentOffline ? 'text-theme-text-muted/40 cursor-not-allowed' :
                 isError ? 'text-red-400 hover:text-red-300 hover:bg-red-500/10' :
-                (status === 'installing' || isStopped) ? 'text-amber-400/80 hover:text-amber-300 hover:bg-amber-500/10' :
+                (status === 'installing' || isStopped || isUnhealthy) ? 'text-amber-400/80 hover:text-amber-300 hover:bg-amber-500/10' :
                 'text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover/40'
               }`}
               title={agentOffline ? 'Agent offline' : 'View logs'}


### PR DESCRIPTION
## What
Three defect fixes across the dashboard-api extension lifecycle and the Extensions.jsx UI.

## Why
1. `enable_extension` never wrote `_write_error_progress` on host-agent failure, so the UI card hung at "installing" for 2 minutes before silently reverting to "stopped". `install_extension` already handled this correctly — parity gap only.
2. `install_extension` did return actionable restart guidance in the HTTP response body (`data.message = "Run 'dream restart' to recover"`) but the frontend's `handleInstall` fired `fetchCatalog() + pollProgress(serviceId)` and ignored `data.message`. The poller surfaced only the shorter `_write_error_progress` text, so operators never saw the "run dream restart" hint.
3. `_compute_extension_status` conflated two very different failure modes into "stopped" — a container that was intentionally off and a container that was crash-looping or health-probe-failing both showed the same Start button. Clicking it on the crashed case just replayed the failure.

## How
1. `enable_extension`'s stopped-path now mirrors `install_extension`: writes `_write_error_progress(service_id, <msg>)` on agent failure.
2. Both failure paths now write a single richer error message — `"Host agent failed to start extension. Run 'dream restart' to recover."` — so the progress poller surfaces the guidance. No frontend change needed.
3. `_compute_extension_status` now returns a new `"unhealthy"` status when the service-health poller reports `status="unhealthy"` (HTTP 4xx/5xx). Other failure modes (`down`, `degraded`, `not_deployed`) continue to return `"stopped"` — `"unhealthy"` is reserved for the clearest crash signal. `Extensions.jsx` adds `"unhealthy"` to STATUS_STYLES / DESCRIPTIONS / FILTERS / LABELS (all amber, reusing the existing toggle-stopped theme token), keeps `isStopped` as `=== 'stopped'` so the Start button isn't shown for crashed containers, adds a "Check Logs" CTA wired to the existing `onConsole` handler, and includes `unhealthy` in the summary bucket.

## Testing
- `pytest tests/test_extensions.py` — 140/140 pass (3 new tests).
- `pytest tests/` — full suite green (one pre-existing asyncio/Py3.14 failure in `test_gpu_detailed.py`, confirmed unrelated).
- `make lint` + `ruff` + `py_compile` — all clean.
- `pre-commit` — gitleaks / private-key / large-file pass.
- JSX grep audit: every status-branching location in `Extensions.jsx` symmetrically handles `"unhealthy"` (badge, filters, labels, summary, toggle, Check Logs, logs icon color). Zero inconsistencies found.

## Review
Critique Guardian: APPROVED WITH WARNINGS. No required changes.

## Known Considerations
- **Services without a health probe never reach `"unhealthy"`** — they get auto-`healthy` in `extensions_catalog`. Detecting "container crashed but no health endpoint" would require the host agent to expose `docker ps`/`docker inspect` state, which is out of scope.
- **Stale-window quirk:** during the first 5 minutes after enable-stopped, a 4xx-throwing container still reads as "installing" (existing grace window). After 5 minutes it correctly flips to `"unhealthy"`.

## Platform Impact
- **macOS / Linux / Windows (WSL2):** identical. Dashboard-api runs in a container on all three; `Extensions.jsx` runs in the browser. Amber Tailwind tokens render identically across engines.
