### PR TITLE
fix(installer): rebuild locally-built images on macOS, Windows, and via dream-cli

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -607,6 +607,25 @@ _compose_run_with_summary() {
 }
 
 #=============================================================================
+# Warn (don't exit) when the current user can't reach the Docker daemon on
+# Linux. Phase 05 of the installer sets DOCKER_CMD="sudo docker" for users
+# not in the docker group, but dream-cli calls bare `docker compose` and
+# can't see that. Without this check, --rebuild-images fails with an opaque
+# "permission denied while trying to connect to the Docker daemon socket"
+# and users have no idea what to do next. macOS Docker Desktop grants
+# socket access to the logged-in user, so the check is Linux-only.
+#=============================================================================
+_check_docker_access() {
+    [[ "$(uname -s)" == "Darwin" ]] && return 0
+    if id -nG 2>/dev/null | grep -qw docker && docker ps >/dev/null 2>&1; then
+        return 0
+    fi
+    warn "Current user cannot reach the Docker daemon (not in 'docker' group, or daemon unreachable)."
+    warn "If the next step fails with 'permission denied', run:  newgrp docker  (current shell)"
+    warn "or log out and back in (all shells), then re-run your dream command."
+}
+
+#=============================================================================
 # Rebuild local-built images (opt-in via --rebuild-images on restart/start/update).
 # Always rebuilds: dashboard, dashboard-api, ape, token-spy, privacy-shield.
 # Conditionally rebuilds based on .env state:
@@ -627,6 +646,7 @@ _dream_cli_rebuild_images() {
     [[ "${ENABLE_COMFYUI:-}" == "true" ]] && svcs+=(comfyui)
     [[ "${GPU_BACKEND:-}" == "amd" ]] && svcs+=(llama-server)
     [[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && svcs+=(dreamforge)
+    _check_docker_access
     log "Rebuilding local-built images (--rebuild-images)..."
     if ! docker compose "${flags[@]}" build --no-cache "${svcs[@]}"; then
         warn "One or more images failed to rebuild (continuing — see compose output above)"

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -607,6 +607,33 @@ _compose_run_with_summary() {
 }
 
 #=============================================================================
+# Rebuild local-built images (opt-in via --rebuild-images on restart/start/update).
+# Always rebuilds: dashboard, dashboard-api, ape, token-spy, privacy-shield.
+# Conditionally rebuilds based on .env state:
+#   - comfyui     (ENABLE_COMFYUI=true)
+#   - llama-server (GPU_BACKEND=amd, e.g. AMD Lemonade)
+#   - dreamforge   (ENABLE_DREAMFORGE=true)
+# Mirrors the conditional logic in installers/phases/11-services.sh. Unlike that
+# phase's image-inspect fast-path, --rebuild-images is an explicit opt-in so we
+# always rebuild every applicable service from source.
+#=============================================================================
+_dream_cli_rebuild_images() {
+    local flags=("$@")
+    local svcs=(dashboard dashboard-api ape token-spy privacy-shield)
+    # Mirror phases/11-services.sh conditional builds: ComfyUI when enabled,
+    # llama-server on AMD (Lemonade builds the binary in the container), and
+    # dreamforge when enabled (Rust source build). Other GPU backends pull
+    # pre-built images.
+    [[ "${ENABLE_COMFYUI:-}" == "true" ]] && svcs+=(comfyui)
+    [[ "${GPU_BACKEND:-}" == "amd" ]] && svcs+=(llama-server)
+    [[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && svcs+=(dreamforge)
+    log "Rebuilding local-built images (--rebuild-images)..."
+    if ! docker compose "${flags[@]}" build --no-cache "${svcs[@]}"; then
+        warn "One or more images failed to rebuild (continuing — see compose output above)"
+    fi
+}
+
+#=============================================================================
 # Commands
 #=============================================================================
 
@@ -867,11 +894,24 @@ cmd_restart() {
     load_env
     ensure_llama_cpu_budget
 
-    local service="${1:-}"
+    # Parse flags vs positional service name
+    local rebuild_images="false"
+    local service=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --rebuild-images) rebuild_images="true"; shift ;;
+            --) shift; break ;;
+            -*) error "Unknown option: $1" ;;
+            *) service="$1"; shift ;;
+        esac
+    done
+
     local flags_str
     flags_str=$(get_compose_flags)
     local -a flags
     read -ra flags <<< "$flags_str"
+
+    [[ "$rebuild_images" == "true" ]] && _dream_cli_rebuild_images "${flags[@]}"
 
     if [[ -z "$service" ]]; then
         _compose_run_with_summary "Restarting all services" "${flags[@]}" up -d
@@ -907,11 +947,24 @@ cmd_start() {
     ensure_llama_cpu_budget
     sr_load
 
-    local service="${1:-}"
+    # Parse flags vs positional service name
+    local rebuild_images="false"
+    local service=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --rebuild-images) rebuild_images="true"; shift ;;
+            --) shift; break ;;
+            -*) error "Unknown option: $1" ;;
+            *) service="$1"; shift ;;
+        esac
+    done
+
     local flags_str
     flags_str=$(get_compose_flags)
     local -a flags
     read -ra flags <<< "$flags_str"
+
+    [[ "$rebuild_images" == "true" ]] && _dream_cli_rebuild_images "${flags[@]}"
 
     if [[ -z "$service" ]]; then
         _compose_run_with_summary "Starting all services" "${flags[@]}" up -d
@@ -1073,10 +1126,12 @@ cmd_update() {
     # Parse flags
     local dry_run="false"
     local force_flag="false"
+    local rebuild_images="false"
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --dry-run|-n) dry_run="true"; shift ;;
             --force|-f) force_flag="true"; shift ;;
+            --rebuild-images) rebuild_images="true"; shift ;;
             --*) error "Unknown option: $1" ;;
             -*) error "Unknown option: $1" ;;
             *) error "Unexpected argument: $1" ;;
@@ -1127,6 +1182,8 @@ cmd_update() {
     if ! _compose_run_with_summary "Pulling latest images" "${flags[@]}" pull; then
         error "Failed to pull latest images"
     fi
+
+    [[ "$rebuild_images" == "true" ]] && _dream_cli_rebuild_images "${flags[@]}"
 
     if ! _compose_run_with_summary "Recreating containers with new images" "${flags[@]}" up -d --force-recreate; then
         error "Failed to recreate containers. Run 'dream rollback' to restore previous state."
@@ -3483,10 +3540,14 @@ ${CYAN}Commands:${NC}
   restore [backup_id] Restore from a backup
   rollback            Rollback to pre-update state (after failed update)
   logs <service>      Tail logs for a service
-  restart [service]   Restart services (all if no service specified)
-  start [service]     Start services
+  restart [service] [--rebuild-images]
+                      Restart services (all if no service specified)
+  start [service] [--rebuild-images]
+                      Start services
   stop [service]      Stop services
-  update [--force]    Pull latest images and restart (--force skips version-compat confirmation)
+  update [--force] [--rebuild-images]
+                      Pull latest images and restart (--force skips version-compat confirmation;
+                      --rebuild-images rebuilds locally-built images so contributor edits deploy)
   shell <service>     Open shell in container
   config [show|edit|validate]
                       View, edit, or validate configuration

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -616,7 +616,7 @@ _compose_run_with_summary() {
 # socket access to the logged-in user, so the check is Linux-only.
 #=============================================================================
 _check_docker_access() {
-    [[ "$(uname -s)" == "Darwin" ]] && return 0
+    [[ "$(uname -s)" == Linux* ]] || return 0
     if id -nG 2>/dev/null | grep -qw docker && docker ps >/dev/null 2>&1; then
         return 0
     fi

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -880,9 +880,29 @@ else
 
     # ── Start Docker services ──
     chapter "STARTING SERVICES"
-    ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d"
+
+    # ── Rebuild local-built images ─────────────────────────────────────
+    # Mirrors phases/11-services.sh on Linux: local Dockerfiles (dashboard,
+    # dashboard-api, ape, token-spy, privacy-shield) can drift from the
+    # baked images, so we always rebuild without cache before `up -d`.
+    # ComfyUI has no Apple-Silicon variant (only amd/nvidia/multigpu); the
+    # llama-server runs natively on macOS via Metal — neither is built here.
+    ai "Rebuilding local-built images (no-cache)..."
+    _macos_build_services=(dashboard dashboard-api ape token-spy privacy-shield)
+    declare -a _macos_build_pids _macos_build_names
+    for _svc in "${_macos_build_services[@]}"; do
+        docker compose "${COMPOSE_FLAGS[@]}" build --no-cache "$_svc" >> "$DS_LOG_FILE" 2>&1 &
+        _macos_build_pids+=($!)
+        _macos_build_names+=("$_svc")
+    done
+    for _i in "${!_macos_build_pids[@]}"; do
+        wait "${_macos_build_pids[$_i]}" || ai_warn "Build failed for ${_macos_build_names[$_i]} (see $DS_LOG_FILE)"
+    done
+    ai_ok "Local images rebuilt"
+
+    ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d --no-build"
     set +o pipefail  # pipefail would abort on compose exit before PIPESTATUS is read; capture it first
-    docker compose "${COMPOSE_FLAGS[@]}" up -d 2>&1 | while IFS= read -r line; do
+    docker compose "${COMPOSE_FLAGS[@]}" up -d --no-build 2>&1 | while IFS= read -r line; do
         echo "  $line"
     done
     compose_exit="${PIPESTATUS[0]}"

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -883,12 +883,15 @@ else
 
     # ── Rebuild local-built images ─────────────────────────────────────
     # Mirrors phases/11-services.sh on Linux: local Dockerfiles (dashboard,
-    # dashboard-api, ape, token-spy, privacy-shield) can drift from the
-    # baked images, so we always rebuild without cache before `up -d`.
+    # dashboard-api, ape, token-spy, privacy-shield, and Apple-Silicon
+    # DreamForge builds) can drift from the baked images, so we always
+    # rebuild without cache before `up -d`.
     # ComfyUI has no Apple-Silicon variant (only amd/nvidia/multigpu); the
     # llama-server runs natively on macOS via Metal — neither is built here.
     ai "Rebuilding local-built images (no-cache)..."
     _macos_build_services=(dashboard dashboard-api ape token-spy privacy-shield)
+    _dreamforge_pull_policy="$(grep -m1 '^DREAMFORGE_PULL_POLICY=' "${INSTALL_DIR}/.env" 2>/dev/null | cut -d= -f2- | tr -d '"'\''[:space:]' || true)"
+    [[ "$_dreamforge_pull_policy" == "build" ]] && _macos_build_services+=(dreamforge)
     declare -a _macos_build_pids _macos_build_names
     for _svc in "${_macos_build_services[@]}"; do
         docker compose "${COMPOSE_FLAGS[@]}" build --no-cache "$_svc" >> "$DS_LOG_FILE" 2>&1 &

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -606,8 +606,29 @@ if ($dryRun) {
         $_composeLogDir = Join-Path $installDir "logs"
         if (-not (Test-Path $_composeLogDir)) { New-Item -ItemType Directory -Path $_composeLogDir -Force | Out-Null }
         $_composeLog = Join-Path $_composeLogDir "compose-up.log"
+
+        # ── Rebuild local-built images ─────────────────────────────────────
+        # Mirrors phases/11-services.sh on Linux: local Dockerfiles can drift
+        # from the baked images, so we always rebuild without cache before
+        # `up -d`. llama-server runs natively on Windows (Lemonade or Vulkan
+        # binary) so it is not built here. ComfyUI is included only if
+        # explicitly enabled.
+        $_buildServices = @("dashboard", "dashboard-api", "ape", "token-spy", "privacy-shield")
+        if ($enableComfyui) { $_buildServices += "comfyui" }
+        Write-AI "Rebuilding local-built images (no-cache)..."
+        $_buildLog = Join-Path $_composeLogDir "compose-build.log"
+        "" | Out-File -FilePath $_buildLog -Encoding ascii
+        foreach ($_svc in $_buildServices) {
+            Write-AI "  building $_svc ..."
+            & docker compose @composeFlags build --no-cache $_svc *>> $_buildLog
+            if ($LASTEXITCODE -ne 0) {
+                Write-AIWarn "$_svc build failed (non-fatal — see $_buildLog)"
+            }
+        }
+        Write-AISuccess "Local images rebuilt"
+
         Write-AI "Starting services... this may take several minutes."
-        & docker compose @composeFlags up -d *> $_composeLog
+        & docker compose @composeFlags up -d --no-build *> $_composeLog
         $composeExit = $LASTEXITCODE
         $ErrorActionPreference = $prevEAP
         # Show tail of compose output for immediate feedback

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -622,7 +622,7 @@ if ($dryRun) {
             Write-AI "  building $_svc ..."
             & docker compose @composeFlags build --no-cache $_svc *>> $_buildLog
             if ($LASTEXITCODE -ne 0) {
-                Write-AIWarn "$_svc build failed (non-fatal — see $_buildLog)"
+                Write-AIWarn "$_svc build failed (non-fatal - see $_buildLog)"
             }
         }
         Write-AISuccess "Local images rebuilt"

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -597,7 +597,7 @@ if ($dryRun) {
             exit 1
         }
 
-        Write-AI "Running: docker compose $($composeFlags -join ' ') up -d"
+        Write-AI "Running: docker compose $($composeFlags -join ' ') up -d --no-build"
         # PS 5.1 treats ANY stderr output from native commands as NativeCommandError.
         # Silence stderr-as-error so $LASTEXITCODE reflects the real compose exit code.
         # Write output to log file to avoid ForEach-Object pipeline hang on failure.


### PR DESCRIPTION
## What
Brings macOS and Windows installers + `dream-cli` to feature parity with Linux phase-11's image-rebuild step:
- `installers/macos/install-macos.sh` — parallel build loop with PID-array per-build error checking via `ai_warn`; switches to `up -d --no-build`.
- `installers/windows/install-windows.ps1` — sequential build loop with `\$LASTEXITCODE` per-service `Write-AIWarn`; switches to `up -d --no-build`.
- `dream-cli` — opt-in `--rebuild-images` flag for `restart`, `start`, and `update`, backed by `_dream_cli_rebuild_images` helper.

## Why
On Linux, `installers/phases/11-services.sh:311–340` rebuilds the 5 locally-built services (dashboard, dashboard-api, ape, token-spy, privacy-shield, plus conditional comfyui/llama-server-amd/dreamforge) before `up -d --no-build`. macOS and Windows installers were running `up -d` with no preceding build — contributor edits to bake-in services silently no-op'd on reinstall. Same trap PR #1055's dev-workflow doc warns about, addressed from the installer side.

## How
- **macOS**: parallel `&` with explicit PID-array tracking + per-PID `wait \$pid || ai_warn \"Build failed for \$svc\"`. Bare `wait` returns 0 even on child failure under `set -e`, so per-PID checks are required to surface failures by service name.
- **Windows**: sequential `docker compose ... build --no-cache <svc>`, each followed by `\$LASTEXITCODE` check + non-fatal `Write-AIWarn`. CRLF preserved.
- **dream-cli**: helper appends conditional services based on `.env` state (mirroring phase-11 logic). Documented in `cmd_help`. Default behavior unchanged — `--rebuild-images` is opt-in. Argparse handles flag-first / flag-last / `--` / unknown-flag cases without breaking existing positional usage.

## Testing
- `bash -n` clean on `dream-cli` and `install-macos.sh`
- `shellcheck` no new warnings on edited regions
- PowerShell visual review (no pwsh on dev host); CRLF preserved

## Manual test plan (per platform)
- **Linux** (regression-only — phase-11 unchanged): full `install.sh` should still rebuild as before.
- **macOS**: edit `routers/extensions.py`, run `install-macos.sh`, confirm \"Rebuilding local-built images\" log + `docker exec dream-dashboard-api` reflects the change.
- **macOS failure path**: break a Dockerfile, run installer, confirm `[!!] Build failed for <name>` warning fires + `up -d --no-build` produces a clean missing-image error.
- **Windows**: run `install-windows.ps1` in a Windows VM, confirm sequential build output to `compose-build.log`.
- **dream-cli flag** (any platform): `dream restart --rebuild-images`, `dream start <svc> --rebuild-images`, `dream update --rebuild-images`, `dream restart` (default — no rebuild).

## Known Considerations
- The `up -d --no-build` switch on macOS and Windows means a failed build now surfaces as a missing-image error at compose-up time rather than silently rebuilding from cached layers — matches Linux's deliberate semantics.
- File overlap with #1079 (macos installer orphan + opencode serve): both touch `install-macos.sh` at different sections. Whichever lands second will rebase cleanly.

## Platform Impact
- **Linux**: NOT affected (regression-only).
- **macOS**: build loop newly added before `up -d --no-build`.
- **Windows**: build loop newly added before `up -d --no-build`.
- **dream-cli `--rebuild-images`**: opt-in across all platforms; ComfyUI/llama-server/dreamforge conditionally included based on `.env` state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)