### PR TITLE
installer: curl retries, longer llama-server healthcheck grace, phase-state markers

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -110,6 +110,7 @@ LLM_MODEL=qwen3.5-9b
 # LLAMA_PARALLEL=1           # Concurrent request slots (increase for multi-user)
 # LLAMA_CPU_LIMIT=12.0       # Auto-generated: capped to CPUs actually exposed by Docker
 # LLAMA_CPU_RESERVATION=2.0  # Auto-generated: reservation capped to the same ceiling
+# LLAMA_START_PERIOD=240s    # Healthcheck grace window for cold model load (bump for 70B-class on slow NVMe)
 
 # ═══════════════════════════════════════════════════════════════════
 # Ports — all overridable, defaults shown

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -149,6 +149,10 @@
       "description": "Auto-capped Docker CPU reservation for llama-server",
       "minimum": 0.01
     },
+    "LLAMA_START_PERIOD": {
+      "type": "string",
+      "description": "Healthcheck grace window for llama-server cold model load (Docker duration, e.g. 240s, 5m). Bump for 70B-class GGUFs on slow NVMe."
+    },
     "TIER": {
       "type": "string",
       "description": "Hardware tier (1, 2, 3, 4, CLOUD, SH_COMPACT, SH_LARGE, NV_ULTRA)"

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -58,7 +58,9 @@ services:
       interval: 15s
       timeout: 10s
       retries: 5
-      start_period: 120s
+      # 70B-class GGUFs cold-load in 60-120s; thermal throttling and first-touch
+      # page faults push Tier 4 past 180s. Override via LLAMA_START_PERIOD in .env.
+      start_period: ${LLAMA_START_PERIOD:-240s}
 
   # ============================================
   # Chat UI

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -127,7 +127,9 @@ else
             _dl_success=false
             for _attempt in 1 2 3; do
                 [[ $_attempt -gt 1 ]] && ai "Retry attempt $_attempt of 3..."
-                curl -fSL -C - --connect-timeout 30 --max-time 3600 -o "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_URL" \
+                curl -fSL -C - --connect-timeout 30 --max-time 3600 \
+                    --retry 3 --retry-delay 5 --retry-all-errors \
+                    -o "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_URL" \
                     >> "$INSTALL_DIR/logs/model-download.log" 2>&1 &
                 dl_pid=$!
 
@@ -217,7 +219,9 @@ else
                     echo "[SDXL] Starting SDXL Lightning model download..."
                     if [[ ! -f "$SDXL_CHECKPOINT_DIR/$SDXL_MODEL" ]]; then
                         echo "[SDXL] Downloading $SDXL_MODEL (~6.5GB)..."
-                        curl -fSL -C - --connect-timeout 30 --max-time 3600 -o "$SDXL_CHECKPOINT_DIR/$SDXL_MODEL.part" \
+                        curl -fSL -C - --connect-timeout 30 --max-time 3600 \
+                            --retry 5 --retry-delay 10 --retry-all-errors \
+                            -o "$SDXL_CHECKPOINT_DIR/$SDXL_MODEL.part" \
                             "$SDXL_URL" 2>&1 && \
                             mv "$SDXL_CHECKPOINT_DIR/$SDXL_MODEL.part" "$SDXL_CHECKPOINT_DIR/$SDXL_MODEL" && \
                             echo "[SDXL] $SDXL_MODEL complete" || \


### PR DESCRIPTION
# Three low-risk installer reliability improvements
Three small, independent changes to the Linux installer and the llama-server compose stack that together cut spurious install failures and let repeat installs skip already-completed work. no architectural changes.

## What's in here

1. **Curl-level retries on model downloads.** GGUF and SDXL Lightning downloads now absorb transient network blips before failing the outer attempt loop, instead of bailing on the first dropped packet.
2. **Larger, env-overridable healthcheck grace window for `llama-server`.** The hardcoded 120s `start_period` was tight for 70B-class GGUFs cold-loading from NVMe; bumped to 240s with a `LLAMA_START_PERIOD` env override for slower disks.
3. **Phase-state idempotency markers.** New `installers/lib/phase-state.sh` lets phases mark themselves complete; install-core wipes markers on `--force` (or `DREAM_REPHASE=1`). Phase 07 (devtools) is the first opt-in.

## Change 1 — curl retries on model downloads

The GGUF download is wrapped in a 3-attempt outer bash retry loop today, but each `curl` invocation has no `--retry`, so a single TCP RST or DNS hiccup mid-stream consumes a whole outer attempt. The SDXL download isn't wrapped at all — it's a single backgrounded `curl` that fails outright on the first transient error.

- GGUF curl: `+ --retry 3 --retry-delay 5 --retry-all-errors`. Combined with the existing outer loop this gives up to ~9 fetch attempts before the user sees a manual-recovery message.
- SDXL curl: `+ --retry 5 --retry-delay 10 --retry-all-errors`. Single-shot path, so retries live inside the curl invocation.

`-C -` (resume) was already there, so retries pick up where the previous attempt stopped.

Impact: fewer phantom failures on hotel wifi, mobile hotspots, VPN reconnects.

## Change 2 — healthcheck `start_period` for `llama-server`

`start_period: 120s` was hardcoded. A 70B Q4_K_M GGUF mmap+upload to VRAM regularly takes 60–120s on Tier 3 hardware and can exceed 180s on Tier 4 with thermal throttling or first-touch page faults — at which point Docker marks the container unhealthy and downstream services restart prematurely. The AMD overlay already bumped Lemonade to `300s` for the same reason ([`docker-compose.amd.yml:56`](dream-server/docker-compose.amd.yml#L56)); llama-server didn't get the same treatment.

Now: `start_period: ${LLAMA_START_PERIOD:-240s}`. Documented in `.env.example` and `.env.schema.json`. Default covers Tier 0–4 single-model loads with margin; tuning users with extra-slow NVMe can raise it via `.env` without touching compose.

No behaviour change for healthy small-model loads — `start_period` only delays the unhealthy-mark, it doesn't slow the actual ready signal.

## Change 3 — phase-state idempotency markers

New library exposing four helpers:

```bash
phase_state_init      # called once from install-core, clears markers under --force
phase_should_skip <n> # 0 if marker present, 1 otherwise
phase_mark_done <n>   # writes marker (no-op under --dry-run)
phase_clear_all       # exposed for tooling/tests
```

Markers live at `$INSTALL_DIR/.phase-state/<phase>.complete`. The existing `--force` flag now wipes them in addition to its existing semantics; `DREAM_REPHASE=1` is a CI-friendly alternative that doesn't imply the rest of `--force`.

A phase opts in by adding two lines:

```bash
phase_should_skip "$INSTALL_PHASE" && return 0
# ... existing phase work ...
phase_mark_done "$INSTALL_PHASE"
```

Phase 07 (`07-devtools.sh`, npm/pkg-manager driven, no exported variables, no `ENABLE_*` flag dependencies) is wrapped as the first user. Re-running the installer skips it after first completion, saving ~30–60s per repeat install.

### Why only one phase

The infrastructure is reusable, but expanding to phases 04/05/08 needs more things:

- **04-requirements** *exports* `REQUIREMENTS_MET` and `TIER_RANK`, consumed downstream. Skipping it would leave those unset.
- **05-docker** *exports* `DOCKER_CMD` and `DOCKER_COMPOSE_CMD`. Same problem.
- **08-images** builds its `PULL_LIST` conditionally on `ENABLE_VOICE`/`ENABLE_RAG`/`ENABLE_COMFYUI`/etc. A naive marker would skip pulls for newly enabled services on re-run.

Each of those needs either (a) a "detect-only" subset that always runs and exports vars, or (b) a fingerprint of relevant inputs hashed into the marker name. Both are potential follow-ups.

## Migration notes

- No env-var defaults changed. `LLAMA_START_PERIOD` is only read when set — existing `.env` files keep working.
- Phase markers live under `$INSTALL_DIR/.phase-state/`. Removing the install dir wipes them automatically.
- After kernel/driver updates, users should re-run with `--force` to refresh phase 07 (and any future opt-in phases). Documented in the `--force` help text.