### PR TITLE
fix(installer): correct bash precedence trap in Phase 11 .env bootstrap patch

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -260,10 +260,12 @@ MODELS_INI_EOF
                 for _key_val in "GGUF_FILE=$GGUF_FILE" "LLM_MODEL=$LLM_MODEL" "MAX_CONTEXT=$MAX_CONTEXT"; do
                     _key="${_key_val%%=*}"
                     _val="${_key_val#*=}"
-                    if ! awk -v v="$_val" '{ if (index($0, "'"$_key"'=") == 1) print "'"$_key"'=" v; else print }' \
+                    if awk -v v="$_val" '{ if (index($0, "'"$_key"'=") == 1) print "'"$_key"'=" v; else print }' \
                         "$_env_file" > "${_env_file}.tmp" 2>>"$LOG_FILE" \
                         && cat "${_env_file}.tmp" > "$_env_file" 2>>"$LOG_FILE" \
                         && rm -f "${_env_file}.tmp"; then
+                        : # success
+                    else
                         _env_patch_ok=false
                         warn "Failed to patch $_key in .env"
                     fi


### PR DESCRIPTION
## What
Fix a bash operator-precedence trap in `installers/phases/11-services.sh:263-266`.

## Why
The original `if ! awk && cat && rm; then warn; fi` parses as `if (!awk) && cat && rm`. When awk succeeds (the common case), `!awk = false` short-circuits — cat and rm never run, the `if` body is never entered, the success log fires anyway, but `.env` is unchanged and `.env.tmp` is orphaned. llama-server then crash-loops on the still-configured full-tier model path during the bootstrap fast-start flow (Tier ≥ 1 default).

This is install-blocking on every Linux + WSL2 install with bootstrap mode active (the default).

## How
Invert the conditional: `if awk && cat && rm; then : # success; else _env_patch_ok=false; warn; fi`. KISS — minimal diff, eliminates the `!`-precedence trap, no new helper function or subshell.

## Testing
- `bash -n` / `shellcheck` / `make lint` clean.
- Live bash repro on bash 5.3.9 confirms both paths:
  - Happy path: `.env` updated to bootstrap values, `.env.tmp` removed, `_env_patch_ok=true`.
  - Sabotage (chmod 444): 3 `warn` lines, `_env_patch_ok=false`, `.env` unchanged.
- Manual Linux Tier 1 install: `.env` shows the bootstrap model after Phase 11; llama-server starts.

## Review
Critique Guardian: APPROVED. Bash precedence behavior verified independently. No security implications; pure correctness fix.

## Known Considerations
A pre-existing structural artifact (unchanged by this PR): on the sabotage path, `.env.tmp` survives because the `&&`-chained `rm -f` never runs when `cat` fails. Worth a separate follow-up; `.env` itself is uncorrupted. Adding a BATS regression test for Phase 11 bootstrap `.env` patching is also recommended as a follow-up.

## Platform Impact
- **Linux**: fixed (install-blocking bug).
- **macOS**: not applicable. macOS uses `sed -i ''` at `installers/macos/install-macos.sh:589`, no `&&`-chain.
- **Windows**: not applicable. Windows uses PowerShell regex replace.
- **WSL2**: covered (uses Linux installer path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)