### PR TITLE
fix(opencode): use opencode serve in opencode-web.service so headless installs don't trigger browser open

### DIFF
--- a/dream-server/opencode/opencode-web.service
+++ b/dream-server/opencode/opencode-web.service
@@ -6,7 +6,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=__HOME__
-ExecStart=__HOME__/.opencode/bin/opencode web --port 3003 --hostname 127.0.0.1
+ExecStart=__HOME__/.opencode/bin/opencode serve --port 3003 --hostname 127.0.0.1
 Restart=on-failure
 RestartSec=5
 


### PR DESCRIPTION
## What
Single-token edit at `dream-server/opencode/opencode-web.service:9`: `opencode web` → `opencode serve`. Unit filename `opencode-web.service` deliberately preserved.

## Why
`opencode web` invokes `open()` for browser auto-launch; `opencode serve` is the canonical headless variant that calls `Server.listen()` and never `open()`. On a headless Linux host, `--hostname 127.0.0.1` falls through to `open(displayUrl).catch(() => {})` — failure is silently swallowed but the call is semantically wrong.

This is the deferred Linux companion to the prior macOS opencode plist fix.

## How
Change the subcommand token only. Unit filename unchanged because multiple downstream callers reference it (`installers/phases/07-devtools.sh`, `12-health.sh`, `13-summary.sh`, `dream-uninstall.sh`, manifest, completion, docs); renaming would create an upgrade hazard for existing installs with the unit already enabled.

## Testing
- `systemd-analyze verify` clean (after `__HOME__` substitution).
- Manual Linux: `systemctl --user status opencode-web.service` → Active. `ss -ltnp | grep 3003` → listening on 127.0.0.1. `journalctl --user -u opencode-web.service` should NOT show `xdg-open` / display errors.

## Review
Critique Guardian: APPROVED. Mirrors the precedent set by the prior macOS opencode fix.

## Platform Impact
- **Linux**: fixed.
- **macOS**: not applicable. macOS uses a separate launchd plist tracked by a prior PR.
- **Windows / WSL2**: WSL2 inherits this fix via the Linux installer path. Windows native does not install opencode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)