### PR TITLE
fix(scripts): use 127.0.0.1 instead of localhost in bootstrap-upgrade and repair-perplexica

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -402,9 +402,9 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
     # Pick health endpoint based on GPU backend — Lemonade (AMD) serves
     # /api/v1/health, llama.cpp (NVIDIA/Apple/CPU) serves /health.
     if [[ "$_gpu_backend" == "amd" ]]; then
-        _health_url="http://localhost:${OLLAMA_PORT:-8080}/api/v1/health"
+        _health_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/api/v1/health"
     else
-        _health_url="http://localhost:${OLLAMA_PORT:-8080}/health"
+        _health_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/health"
     fi
 
     # Wait for health (up to 5 minutes for the larger model to load)
@@ -439,7 +439,7 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
                     _model_id="extra.${FULL_GGUF_FILE//\"/\\\"}"
                     log "Sending warm-up request to trigger model loading: $_model_id (attempt $_i/60)"
                     if curl -sf --max-time 30 -X POST \
-                        "http://localhost:${OLLAMA_PORT:-8080}/api/v1/chat/completions" \
+                        "http://127.0.0.1:${OLLAMA_PORT:-8080}/api/v1/chat/completions" \
                         -H "Content-Type: application/json" \
                         -d "{\"model\":\"${_model_id}\",\"messages\":[{\"role\":\"user\",\"content\":\"hello\"}],\"max_tokens\":1}" \
                         &>/dev/null; then

--- a/dream-server/scripts/repair/repair-perplexica.sh
+++ b/dream-server/scripts/repair/repair-perplexica.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Called by: dream repair perplexica
 # Requires: Perplexica container running, python3 available
 
-PERPLEXICA_URL="${1:-http://localhost:3004}"
+PERPLEXICA_URL="${1:-http://127.0.0.1:3004}"
 LLM_MODEL="${2:-qwen3-30b-a3b}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"


### PR DESCRIPTION
## What
Four mechanical `localhost` → `127.0.0.1` substitutions across two files:
- `scripts/bootstrap-upgrade.sh` lines 405, 407, 442 (3 host-process curl/URL sites in the 60-iteration model-load wait loop)
- `scripts/repair/repair-perplexica.sh` line 7 (default URL fallback)

## Why
On dual-stack hosts, `http://localhost:` adds an IPv6 `::1` retry penalty when the target only binds IPv4. The earlier installer/CLI sweep migrated the bulk of sites; this PR covers the residual host-process curl/URL strings.

## How
Pure string substitution. No control-flow or env-var changes. The `repair-perplexica.sh:7` default propagates to L21 + L30 consumers automatically.

## Testing
- `bash -n` / `shellcheck` / `make lint` clean.
- Pre-existing 127.0.0.1 sites in the same files (L568, L587 of bootstrap-upgrade.sh) untouched.
- Manual Linux: trigger a model swap; observe wait-loop curls now point at `127.0.0.1` and the `::1` retry latency disappears on dual-stack hosts (intrinsically hard to automate).

## Review
Critique Guardian: APPROVED. Tiny security improvement — eliminates DNS / `/etc/hosts` substitution surface.

## Platform Impact
- **Linux**: fixed.
- **macOS**: not applicable. macOS sites tracked separately.
- **Windows / WSL2**: WSL2 inherits this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)