### PR TITLE
refactor(dream-cli): unify logging helpers and section-banner style

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -61,9 +61,19 @@ fi
 log() { echo -e "${CYAN}[dream]${NC} $1" >&2; }
 success() { echo -e "${GREEN}✓${NC} $1"; }
 warn() { echo -e "${YELLOW}⚠${NC} $1" >&2; }
-error() { echo -e "${RED}✗${NC} $1"; exit 1; }
-log_warn() { echo -e "${YELLOW}⚠${NC} $1"; }
+error() { echo -e "${RED}✗${NC} $1" >&2; exit 1; }
 log_error() { echo -e "${RED}✗${NC} $1" >&2; }
+
+# Map cmd_list status string to a colour. Returns an empty string for unknown
+# statuses so future state names don't break formatting.
+_status_color() {
+    case "$1" in
+        enabled|always-on) echo "$GREEN" ;;
+        disabled|stopped)  echo "$YELLOW" ;;
+        unhealthy|error)   echo "$RED" ;;
+        *)                 echo "" ;;
+    esac
+}
 
 # Print a separator of repeated characters filling the given width.
 # Usage: hr <width> [<char=─>]
@@ -919,7 +929,7 @@ cmd_dry_run() {
     load_env
 
     echo -e "${BLUE}━━━ Dream Update — Dry Run ━━━${NC}"
-    echo -e "${CYAN}Preview only. No changes will be applied.${NC}"
+    echo "Preview only. No changes will be applied."
     echo ""
 
     # ── version ──────────────────────────────────────────────────────────────
@@ -969,7 +979,7 @@ cmd_dry_run() {
         fi
     fi
 
-    echo -e "${CYAN}Version:${NC}"
+    echo -e "${BLUE}━━━ Version ━━━${NC}"
     echo "  Installed : v${cur_ver}"
     if [[ -n "$latest_ver" ]]; then
         echo "  Available : v${latest_ver}"
@@ -985,7 +995,7 @@ cmd_dry_run() {
     echo ""
 
     # ── image tags ────────────────────────────────────────────────────────────
-    echo -e "${CYAN}Configured image tags (would be pulled):${NC}"
+    echo -e "${BLUE}━━━ Image tags (would be pulled) ━━━${NC}"
     local flags_str
     flags_str=$(get_compose_flags)
     local -a flags
@@ -1016,14 +1026,14 @@ cmd_dry_run() {
     [[ "$images_shown" == "false" ]] && echo "  (could not resolve compose config)"
 
     echo ""
-    echo -e "${CYAN}Currently running image digests:${NC}"
+    echo -e "${BLUE}━━━ Running image digests ━━━${NC}"
     docker compose "${flags[@]}" images 2>/dev/null \
         | awk 'NR>1 {printf "  %-30s %s\n", $1, $4}' \
         || echo "  (services not running)"
     echo ""
 
     # ── model / GGUF ─────────────────────────────────────────────────────────
-    echo -e "${CYAN}Model configuration (.env):${NC}"
+    echo -e "${BLUE}━━━ Model configuration (.env) ━━━${NC}"
     local -a model_keys=(TIER LLM_MODEL GGUF_FILE CTX_SIZE GPU_BACKEND N_GPU_LAYERS)
     local key
     for key in "${model_keys[@]}"; do
@@ -1034,7 +1044,7 @@ cmd_dry_run() {
     echo ""
 
     # ── .env keys the update path reads/writes ────────────────────────────────
-    echo -e "${CYAN}.env keys the update path will read or write:${NC}"
+    echo -e "${BLUE}━━━ .env keys (read/write) ━━━${NC}"
     local -a update_keys=(DREAM_VERSION TIER LLM_MODEL GGUF_FILE CTX_SIZE GPU_BACKEND N_GPU_LAYERS)
 
     if [[ -n "$api_json" ]] && echo "$api_json" | jq -e '.env_keys' >/dev/null 2>&1; then
@@ -1050,9 +1060,9 @@ cmd_dry_run() {
     echo ""
 
     # ── summary ───────────────────────────────────────────────────────────────
-    echo -e "${CYAN}To apply this update:${NC}  dream update"
+    echo "To apply this update:  dream update"
     echo ""
-    echo -e "${YELLOW}Dry run complete. Nothing was changed.${NC}"
+    warn "Dry run complete. Nothing was changed."
 }
 
 cmd_update() {
@@ -1139,7 +1149,7 @@ cmd_update() {
         container=$(sr_container "$service" 2>/dev/null || echo "")
         if [[ -n "$container" ]]; then
             if ! docker ps --filter "name=$container" --filter "status=running" --format "{{.Names}}" | grep -q "^$container$"; then
-                log_warn "Service $service ($container) is not running"
+                warn "Service $service ($container) is not running"
                 ((failed_services++))
             fi
         fi
@@ -1799,7 +1809,12 @@ cmd_list() {
         else
             status="disabled"
         fi
-        printf "%-20s %-12s %-10s\n" "$sid" "$cat" "$status"
+        # Colour vars are blanked to "" off-TTY (lines 42-56), so no extra
+        # `[[ -t 1 ]]` guard is needed; padding stays consistent because ANSI
+        # escapes have zero display width.
+        local color
+        color=$(_status_color "$status")
+        printf "%-20s %-12s %s%-10s%s\n" "$sid" "$cat" "$color" "$status" "$NC"
     done
 }
 
@@ -2081,14 +2096,14 @@ META
             echo ""
 
             # Compare metadata
-            echo -e "${CYAN}━━━ Metadata ━━━${NC}"
+            echo -e "${BLUE}━━━ Metadata ━━━${NC}"
             if [[ -f "$dir1/meta.txt" ]] && [[ -f "$dir2/meta.txt" ]]; then
                 diff -u "$dir1/meta.txt" "$dir2/meta.txt" | tail -n +4 | sed "s/^-/$(printf "${RED}-${NC}")/" | sed "s/^+/$(printf "${GREEN}+${NC}")/" || true
             fi
             echo ""
 
             # Compare extensions
-            echo -e "${CYAN}━━━ Service State ━━━${NC}"
+            echo -e "${BLUE}━━━ Service State ━━━${NC}"
             if [[ -f "$dir1/extensions.list" ]] && [[ -f "$dir2/extensions.list" ]]; then
                 # Parse both files into associative arrays
                 declare -A ext1 ext2
@@ -2129,7 +2144,7 @@ META
             echo ""
 
             # Compare environment variables
-            echo -e "${CYAN}━━━ Environment Variables ━━━${NC}"
+            echo -e "${BLUE}━━━ Environment Variables ━━━${NC}"
             if [[ -f "$dir1/env" ]] && [[ -f "$dir2/env" ]]; then
                 # Parse both env files
                 declare -A env1 env2
@@ -2297,7 +2312,7 @@ cmd_model() {
         current)
             local model=$(grep "^LLM_MODEL=" .env 2>/dev/null | cut -d= -f2)
             local tier=$(grep "^TIER=" .env 2>/dev/null | cut -d= -f2)
-            echo "Current model: ${model:-<not set>}"
+            echo -e "Current model: ${GREEN}${model:-<not set>}${NC}"
             [[ -n "$tier" ]] && echo "Current tier: $tier"
             return 0
             ;;
@@ -2468,7 +2483,7 @@ cmd_rollback() {
 
     log "Rolling back to pre-update state (backup: $backup_id)..."
     echo ""
-    log_warn "This will restore configuration from before the last update."
+    warn "This will restore configuration from before the last update."
     read -p "Continue with rollback? [y/N] " -n 1 -r
     echo ""
 


### PR DESCRIPTION
## What
Sweeps the dream-cli logging style for consistency: `error()` writes to stderr (was stdout), `log_warn()` is dropped in favor of `warn()` (the two were duplicates with diverging streams), three CYAN section banners in `cmd_preset diff` are flipped to BLUE to match the other 19 banner sites, the `cmd_list` status column and `cmd_model current` model name are now color-coded, and `cmd_update --dry-run` sub-section headers use the standard BLUE banner pattern.

## Why
- `error()` writing to stdout was a behavioral bug — anything piping `dream <cmd>` to capture errors had to read the stdout stream, breaking the conventional stdout-data / stderr-diagnostics split.
- `log_warn()` (stdout) and `warn()` (stderr) emitted identical visuals to different streams. Two callsites used `log_warn()` and silently lost stderr-routing.
- Three of the 22 `━━━ Heading ━━━` section banners used CYAN instead of the established BLUE — the visual inconsistency made `dream preset diff` look like a different command's output.
- `cmd_list` status column was uncolored even though state semantics map cleanly to colors (enabled→green, disabled→yellow, error→red).
- `cmd_model current` printed the model name in plain text while sibling `cmd_mode` already colored its primary value green.
- `cmd_update --dry-run` had ~5 raw inline `${CYAN}heading:${NC}` patterns instead of using the helper system.

## How
1. `error() { echo -e "${RED}✗${NC} $1" >&2; exit 1; }` — added stderr redirect.
2. Deleted `log_warn()`; migrated the 2 actual callsites to `warn()`. (Verifier had cited 5 callsites; only 2 were real on `upstream/main`.)
3. Three CYAN→BLUE flips at `cmd_preset diff` sub-table headers.
4. Added `_status_color()` helper covering 6 known states; `cmd_list` wraps the status column in the resolved color via `printf "%-20s %-12s %s%-10s%s\n"` (zero display width when off-TTY thanks to the existing `[[ -t 1 ]]` guard, so column alignment is preserved both on- and off-TTY).
5. `cmd_model current` wraps the model name in `${GREEN}…${NC}` matching `cmd_mode`'s primary-value style.
6. `cmd_update --dry-run` 5 sub-sections converted to `${BLUE}━━━ … ━━━${NC}` banner pattern; final "Dry run complete." routed through `warn()` (stderr).

49 lines net (32 ins / 17 del). Single file: `dream-server/dream-cli`.

## Testing
- `bash -n dream-server/dream-cli` — clean.
- `shellcheck dream-server/dream-cli` — went from 38 to 33 warning lines (net −5; no new warnings introduced).
- Smoke on macOS Apple Silicon (live install at `/Volumes/X/dreamserver`):
  - `dream list` — BLUE banner, status column color-coded (verified ANSI bytes via `script -q /dev/null | cat -v`).
  - `dream model current` — model name green, secondary fields plain (matches `cmd_mode` style).
  - `dream update --dry-run` — top + sub-section banners all BLUE; "Dry run complete." appears as `⚠` on stderr.
  - `dream nonexistent-cmd 2>/dev/null` — empty stdout, exit 1 (proves `error()` is on stderr).
  - `dream nonexistent-cmd >/dev/null` — `✗ Unknown command:` still visible on stderr (proves not silently dropped).

## Review
Critique Guardian: **APPROVED WITH WARNINGS** (one description note, no code blockers — see Known Considerations).

## Known Considerations
- The in-flight dream-cli BATS coverage branch (`test-compose-summary-wrapper.bats`) asserts on the current `log()` / `log_error()` / `warn()` output strings. After this PR lands, those expectations need updating to (a) drop any `log_warn` references, (b) capture stderr (not stdout) for `error()` output and the `cmd_dry_run` final line. That coordination happens on the test branch, not in this PR.
- `_check_version_compat` (lines 1842-1847) calls `log "⚠️ ..."` which double-warns since `log()` already prefixes `[dream]`. Out of scope for this sweep — recommend a separate cleanup.
- `cmd_doctor`'s Python heredoc redefines its own ANSI vars internally — left alone, independent ANSI scope from the Bash helper system.

## Platform Impact
- **macOS** (native, brew bash 5+): no BSD/GNU divergence; `printf %-Ns` is POSIX-standard, identical to GNU. ANSI guard `[[ -t 1 ]]` works as before.
- **Linux** (Docker, system bash 5+): same — pure refactor of color/stream helpers.
- **Windows-WSL2** (Linux bash inside WSL): same — runs in the WSL Linux environment, no native Windows path.
