### PR TITLE
refactor(dashboard): consolidate failure-counter into createRecoveryTracker

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useRef } from 'react'
 import { DependencyBadges, DependencyConfirmDialog, DisableDependentWarning } from '../components/DependencyBadges'
 import { TemplatePicker } from '../components/TemplatePicker'
 import { getTemplateStatus } from '../lib/templates'
+import { createRecoveryTracker } from '../utils/recoveryTracker'
 
 // Re-export so existing importers of getTemplateStatus from this module keep working.
 export { getTemplateStatus }
@@ -99,21 +100,29 @@ export default function Extensions() {
   const [pollingLost, setPollingLost] = useState(false)
   const installProgressRef = useRef(null)
   const activePollers = useRef({})
-  // Per-service consecutive fetch-failure counter. Mirrors the log-streaming
-  // pattern in ExtensionDetailsModal (see function-local `fails` near L1009).
-  // We key by serviceId because multiple installs can be polling concurrently.
-  const consecutiveFailuresRef = useRef({})
+  // Per-service recovery tracker: counts consecutive fetch failures and
+  // fires onThresholdReached/onRecovered to drive the polling-lost banner.
+  // Keyed by serviceId because multiple installs can be polling concurrently.
+  const recoveryTrackers = useRef({})
 
   const pollProgress = (serviceId) => {
     if (activePollers.current[serviceId]) return
-    consecutiveFailuresRef.current[serviceId] = 0
+    recoveryTrackers.current[serviceId] = createRecoveryTracker({
+      threshold: 3,
+      onThresholdReached: () => {
+        setPollingLost(true)
+        // Attempt to recover catalog state — if the backend is back,
+        // the next successful poll will clear the banner.
+        fetchCatalog()
+      },
+      onRecovered: () => setPollingLost(prev => (prev ? false : prev)),
+    })
     activePollers.current[serviceId] = setInterval(async () => {
       try {
         const res = await fetchJson(`/api/extensions/${serviceId}/progress`)
         // Successful fetch (regardless of HTTP status) means the dashboard
         // is reachable again — reset the failure counter and clear the banner.
-        consecutiveFailuresRef.current[serviceId] = 0
-        setPollingLost(prev => (prev ? false : prev))
+        recoveryTrackers.current[serviceId]?.recordSuccess()
         if (!res.ok) return
         const data = await res.json()
         if (data.status === 'idle') return
@@ -121,7 +130,7 @@ export default function Extensions() {
         if (data.status === 'error') {
           clearInterval(activePollers.current[serviceId])
           delete activePollers.current[serviceId]
-          delete consecutiveFailuresRef.current[serviceId]
+          delete recoveryTrackers.current[serviceId]
           setToast({ type: 'error', text: data.error || 'Installation failed' })
           setProgressMap(prev => { const next = { ...prev }; delete next[serviceId]; return next })
           fetchCatalog()
@@ -136,7 +145,7 @@ export default function Extensions() {
           if (ext && ext.status === 'enabled') {
             clearInterval(activePollers.current[serviceId])
             delete activePollers.current[serviceId]
-            delete consecutiveFailuresRef.current[serviceId]
+            delete recoveryTrackers.current[serviceId]
             setToast({ type: 'success', text: `Extension installed and started.` })
             setProgressMap(prev => { const next = { ...prev }; delete next[serviceId]; return next })
           }
@@ -144,17 +153,11 @@ export default function Extensions() {
         }
       } catch (err) {
         // Dashboard-api may be mid-restart, or the browser briefly lost
-        // network. Count consecutive failures; surface a banner after 3
-        // so the user isn't left staring at a silent spinner forever.
-        const fails = (consecutiveFailuresRef.current[serviceId] || 0) + 1
-        consecutiveFailuresRef.current[serviceId] = fails
+        // network. Tracker counts consecutive failures; surfaces a banner
+        // after 3 via onThresholdReached so the user isn't left staring
+        // at a silent spinner forever.
         console.warn('poll fetch failed:', err)
-        if (fails >= 3) {
-          setPollingLost(true)
-          // Attempt to recover catalog state — if the backend is back,
-          // the next successful poll will clear the banner.
-          fetchCatalog()
-        }
+        recoveryTrackers.current[serviceId]?.recordFailure()
       }
     }, 3000)
   }
@@ -168,7 +171,7 @@ export default function Extensions() {
     return () => {
       Object.values(activePollers.current).forEach(clearInterval)
       activePollers.current = {}
-      consecutiveFailuresRef.current = {}
+      recoveryTrackers.current = {}
     }
   }, [])
 
@@ -1046,7 +1049,16 @@ function ConsoleModal({ ext, onClose }) {
 
   useEffect(() => {
     let active = true
-    let fails = 0
+    // Tracker drives the disconnected banner after 3 consecutive failures.
+    // We also keep the raw failure count locally for the exponential
+    // backoff calculation (trackers don't expose internal state on success).
+    let failCount = 0
+    const tracker = createRecoveryTracker({
+      threshold: 3,
+      onThresholdReached: () => setDisconnected(true),
+      // setDisconnected(false) is already done in the success branch below,
+      // so no onRecovered callback is needed here.
+    })
 
     const poll = async () => {
       if (!active) return
@@ -1063,16 +1075,16 @@ function ConsoleModal({ ext, onClose }) {
         setLogs(data.logs || 'No logs available.')
         setError(null)
         setDisconnected(false)
-        fails = 0
+        tracker.recordSuccess()
+        failCount = 0
       } catch (err) {
-        fails++
+        failCount = tracker.recordFailure()
         setError(err.message)
-        if (fails >= 3) setDisconnected(true)
       } finally {
         setLoading(false)
       }
       if (active) {
-        const delay = fails > 0 ? Math.min(2000 * Math.pow(2, fails - 1), 30000) : 2000
+        const delay = failCount > 0 ? Math.min(2000 * Math.pow(2, failCount - 1), 30000) : 2000
         setTimeout(poll, delay)
       }
     }

--- a/dream-server/extensions/services/dashboard/src/utils/__tests__/recoveryTracker.test.js
+++ b/dream-server/extensions/services/dashboard/src/utils/__tests__/recoveryTracker.test.js
@@ -1,0 +1,81 @@
+import { describe, test, expect, vi } from 'vitest'
+import { createRecoveryTracker } from '../recoveryTracker'
+
+describe('createRecoveryTracker', () => {
+  test('recordFailure increments counter and returns the new count', () => {
+    const tracker = createRecoveryTracker()
+    expect(tracker.recordFailure()).toBe(1)
+    expect(tracker.recordFailure()).toBe(2)
+    expect(tracker.recordFailure()).toBe(3)
+  })
+
+  test('calls onThresholdReached exactly once at the default threshold (3)', () => {
+    const onThresholdReached = vi.fn()
+    const tracker = createRecoveryTracker({ onThresholdReached })
+
+    tracker.recordFailure()
+    tracker.recordFailure()
+    expect(onThresholdReached).not.toHaveBeenCalled()
+
+    tracker.recordFailure() // crosses threshold
+    expect(onThresholdReached).toHaveBeenCalledTimes(1)
+
+    // Subsequent failures do NOT re-fire the callback
+    tracker.recordFailure()
+    tracker.recordFailure()
+    expect(onThresholdReached).toHaveBeenCalledTimes(1)
+  })
+
+  test('recordSuccess resets the counter and calls onRecovered when previously past threshold', () => {
+    const onThresholdReached = vi.fn()
+    const onRecovered = vi.fn()
+    const tracker = createRecoveryTracker({ onThresholdReached, onRecovered })
+
+    tracker.recordFailure()
+    tracker.recordFailure()
+    tracker.recordFailure() // past threshold
+    expect(onThresholdReached).toHaveBeenCalledTimes(1)
+
+    tracker.recordSuccess()
+    expect(onRecovered).toHaveBeenCalledTimes(1)
+
+    // Counter has reset — failures must accumulate again before threshold re-fires
+    expect(tracker.recordFailure()).toBe(1)
+    expect(onThresholdReached).toHaveBeenCalledTimes(1)
+
+    tracker.recordFailure()
+    tracker.recordFailure() // crosses threshold again
+    expect(onThresholdReached).toHaveBeenCalledTimes(2)
+  })
+
+  test('recordSuccess does NOT call onRecovered when never past threshold', () => {
+    const onRecovered = vi.fn()
+    const tracker = createRecoveryTracker({ onRecovered })
+
+    tracker.recordFailure()
+    tracker.recordFailure() // counter=2, below threshold=3
+    tracker.recordSuccess()
+
+    expect(onRecovered).not.toHaveBeenCalled()
+  })
+
+  test('honors a custom threshold', () => {
+    const onThresholdReached = vi.fn()
+    const tracker = createRecoveryTracker({ threshold: 2, onThresholdReached })
+
+    tracker.recordFailure()
+    expect(onThresholdReached).not.toHaveBeenCalled()
+    tracker.recordFailure()
+    expect(onThresholdReached).toHaveBeenCalledTimes(1)
+  })
+
+  test('works without any callbacks (no throw)', () => {
+    const tracker = createRecoveryTracker()
+    expect(() => {
+      tracker.recordFailure()
+      tracker.recordFailure()
+      tracker.recordFailure()
+      tracker.recordSuccess()
+    }).not.toThrow()
+  })
+})

--- a/dream-server/extensions/services/dashboard/src/utils/recoveryTracker.js
+++ b/dream-server/extensions/services/dashboard/src/utils/recoveryTracker.js
@@ -1,0 +1,46 @@
+/**
+ * createRecoveryTracker — closure-based failure counter for poll loops.
+ *
+ * Returns { recordFailure, recordSuccess }.
+ * - recordFailure() → increments counter; calls onThresholdReached() once
+ *   when the counter first crosses `threshold`. Returns the new count so
+ *   callers can use it for backoff calculations.
+ * - recordSuccess() → resets counter; calls onRecovered() if the tracker
+ *   was previously past threshold (i.e. recovery from a degraded state).
+ *
+ * Used to unify two near-identical "consecutive-failure → banner" patterns
+ * in dashboard polling code (Extensions.jsx pollProgress + ConsoleModal
+ * log poll). Plain factory + closure (not a React hook) so it can be used
+ * inside non-component scopes like `setInterval` callbacks.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.threshold=3] - failures required to trip the banner
+ * @param {Function} [opts.onThresholdReached] - called once when counter >= threshold
+ * @param {Function} [opts.onRecovered] - called on first success after threshold
+ * @returns {{ recordFailure: () => number, recordSuccess: () => void }}
+ */
+export function createRecoveryTracker({
+  threshold = 3,
+  onThresholdReached,
+  onRecovered,
+} = {}) {
+  let counter = 0
+  let pastThreshold = false
+
+  return {
+    recordFailure() {
+      counter += 1
+      if (counter >= threshold && !pastThreshold) {
+        pastThreshold = true
+        onThresholdReached?.()
+      }
+      return counter
+    },
+    recordSuccess() {
+      const wasPastThreshold = pastThreshold
+      counter = 0
+      pastThreshold = false
+      if (wasPastThreshold) onRecovered?.()
+    },
+  }
+}


### PR DESCRIPTION
## What
Consolidates the "count consecutive failures, fire callback at threshold, reset on success" primitive that was duplicated between two pollers in `Extensions.jsx`:
- `pollProgress` (per-service interval-based progress poller)
- `ConsoleModal.poll` (singleton recursive-with-backoff log poller)

Both inline implementations used threshold=3, reset-on-success, with slightly different recovery callbacks. Extracted into a small factory utility so future pollers can re-use the same primitive without copy-paste.

## Why
Threshold + counter logic that's right twice and wrong twice if anyone mis-edits one site. The primitive is small but the duplication makes it footgun-shaped — change the threshold (3) on one side and the other silently drifts.

## How
New file `dream-server/extensions/services/dashboard/src/utils/recoveryTracker.js`:

```javascript
export function createRecoveryTracker({ threshold = 3, onThresholdReached, onRecovered } = {}) {
  let counter = 0;
  let pastThreshold = false;
  return {
    recordFailure() {
      counter += 1;
      if (counter >= threshold && !pastThreshold) {
        pastThreshold = true;
        onThresholdReached?.();
      }
      return counter;
    },
    recordSuccess() {
      const wasPastThreshold = pastThreshold;
      counter = 0;
      pastThreshold = false;
      if (wasPastThreshold) onRecovered?.();
    },
  };
}
```

**Closure-based on purpose, NOT a React hook.** The two callers want fundamentally different storage shapes:
- `pollProgress` wants per-serviceId trackers in a `useRef` Map (lazy-created on first poll per service).
- `ConsoleModal.poll` wants a singleton tracker per modal instance.

A single hook signature can't cover both shapes cleanly; a factory utility does. Each caller wraps the factory in their own state-management mechanism (Map ref vs local closure).

**`pollProgress` refactor** (Extensions.jsx L107-160): replaces `consecutiveFailuresRef` with `recoveryTrackers.current` (Map keyed by serviceId). Lazy-created on first poll per service. Cleanup at every clear-poll site (error path, success path, unmount) deletes the tracker entry alongside the existing `setInterval` cleanup. Threshold callback retains the original `setPollingLost(true) + fetchCatalog()`. `onRecovered` uses functional setter `setPollingLost(prev => prev ? false : prev)` to avoid extra renders.

**`ConsoleModal.poll` refactor** (Extensions.jsx L1047-1081): singleton tracker created when the effect runs. `recordFailure()` returns the new count which feeds the existing exponential-backoff math `Math.min(2000 * Math.pow(2, failCount-1), 30000)`. Threshold callback sets `disconnected`. Success path retains `setDisconnected(false)` + error clear directly (no `onRecovered` callback needed).

## Intentionally NOT changed
- `setInterval(3000)` cadence in `pollProgress`.
- Recursive `setTimeout` + exponential backoff in `ConsoleModal.poll`.
- `AbortSignal.timeout(8000)` only on `ConsoleModal.poll` (the log endpoint is slow; the progress endpoint is fast — adding it to `pollProgress` would be over-engineering).
- Threshold value (3) on either side.
- `pollingLost` banner UI.

## Testing
- New file `src/utils/__tests__/recoveryTracker.test.js` — 6 cases covering:
  - Counter increments on failure.
  - `onThresholdReached` fires once at threshold (not multiple times on subsequent failures).
  - `recordSuccess` resets counter.
  - `onRecovered` fires when crossing back from past-threshold.
  - `onRecovered` does NOT fire if never past threshold.
  - Default threshold = 3.
- `npx vitest run` previously verified at 54/54 pass with these exact files (was 48/48 before this PR's tests + the in-flight Extensions UI test PR).
- `npm run lint` clean.

## Review
The backend half of this refactor (extraction of the host-agent's `_run_post_install_hook` helper that DRYs the install + enable-retry hook paths) was consolidated into PR Light-Heart-Labs/DreamServer#1039 since it depends on `_enable_retry_work` which that PR introduces. This frontend half is independent — works against current upstream/main.

## Platform Impact
- **macOS**: no impact — pure JS / closure factory + React component refactor; Vitest runs identically.
- **Linux**: no impact — same.
- **Windows-WSL2**: no impact — same.
