### PR TITLE
fix(host-agent): elevate bridge-detection failure log to WARNING

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -139,7 +139,7 @@ def _detect_docker_bridge_gateway() -> str:
     except ValueError:
         logger.debug("Docker bridge returned non-IP value, ignoring")
     except (subprocess.SubprocessError, OSError) as exc:
-        logger.debug("Docker bridge detection failed: %s", exc)
+        logger.warning("Docker bridge detection failed: %s", exc)
     return ""
 
 


### PR DESCRIPTION
## What
Promote the log level inside `_detect_docker_bridge_gateway()`'s sibling `(subprocess.SubprocessError, OSError)` handler from `debug` to `warning`. One-line change.

## Why
Bridge detection runs at host-agent startup on Linux and WSL2. When `docker` is missing from PATH, or the docker socket is permission-denied, `subprocess.run` raises one of those exceptions. Previously the failure was logged at DEBUG — hidden under default journalctl, leaving operators with a silent fallback to `127.0.0.1` and no clue why their container-network setup wasn't being detected.

PR #1075 (also open) fixed the sibling `else: returncode != 0` branch to log at WARNING. This is the companion fix for the exception path. The two changes are non-overlapping (different exception clauses inside the same function).

## How
One-token swap at `bin/dream-host-agent.py:142` — `logger.debug` → `logger.warning`. The narrow named-exception catch at the I/O boundary remains permitted by CLAUDE.md error-handling rule 2 — only the operational visibility changes.

## Testing
- `python3 -m py_compile dream-server/bin/dream-host-agent.py` — clean.
- Diff is exactly `+1 / -1`.
- `grep -rn "Docker bridge detection failed" dream-server/` — only the source line; no test asserts the log level.

## Review
Critique Guardian: APPROVED. Five pillars clean. No log-injection vector (`exc` is exception object; `%s` invokes controlled `__str__`).

## Platform Impact
- **macOS native**: function never called (gated at L2587 to non-Darwin/non-Windows). Zero noise.
- **Windows native**: same gate. Zero noise.
- **Linux**: WARNING is the desired operator-actionable behavior. Surfaces a previously-invisible failure mode.
- **Windows WSL2**: `platform.system() == "Linux"` inside WSL2; function executes, WARNING fires when applicable.
