### PR TITLE
fix(token-spy): standalone product binds 127.0.0.1, auth on by default

### DIFF
--- a/resources/products/token-spy/config/.env.example
+++ b/resources/products/token-spy/config/.env.example
@@ -13,6 +13,7 @@
 
 # PostgreSQL password — REQUIRED
 # Generate one: openssl rand -base64 24
+# WARNING: must be changed before starting — do not deploy with the literal value 'CHANGE_ME'.
 POSTGRES_PASSWORD=CHANGE_ME
 
 # Provider key encryption secret — REQUIRED
@@ -41,7 +42,7 @@ DEFAULT_API_KEY=
 # ============================================
 
 # Enable basic auth for the dashboard (recommended for public deployments)
-DASHBOARD_AUTH_ENABLED=false
+DASHBOARD_AUTH_ENABLED=true
 DASHBOARD_USERNAME=admin
 DASHBOARD_PASSWORD=
 

--- a/resources/products/token-spy/docker-compose.yml
+++ b/resources/products/token-spy/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       - REQUEST_TIMEOUT=300
       - TOKEN_SPY_API_PATH=/app/sidecar/api.py
     ports:
-      - "${TOKEN_SPY_PROXY_PORT:-8080}:8080"
+      - "${BIND_ADDRESS:-127.0.0.1}:${TOKEN_SPY_PROXY_PORT:-8080}:8080"
     volumes:
       - token-spy-data:/data
     depends_on:
@@ -66,13 +66,13 @@ services:
       - DATABASE_URL=postgresql://token_spy:${POSTGRES_PASSWORD}@token-spy-db:5432/token_spy
       - DASHBOARD_PORT=3001
       - DASHBOARD_HOST=0.0.0.0
-      - DASHBOARD_AUTH_ENABLED=${DASHBOARD_AUTH_ENABLED:-false}
+      - DASHBOARD_AUTH_ENABLED=${DASHBOARD_AUTH_ENABLED:-true}
       - DASHBOARD_USERNAME=${DASHBOARD_USERNAME:-admin}
       - DASHBOARD_PASSWORD=${DASHBOARD_PASSWORD:-}
       - ENABLE_SSE=${ENABLE_SSE:-true}
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
     ports:
-      - "${TOKEN_SPY_DASHBOARD_PORT:-3001}:3001"
+      - "${BIND_ADDRESS:-127.0.0.1}:${TOKEN_SPY_DASHBOARD_PORT:-3001}:3001"
     volumes:
       - token-spy-dashboard-cache:/app/cache
     depends_on:
@@ -101,7 +101,7 @@ services:
       - PGDATA=/var/lib/postgresql/data/pgdata
       - TIMESCALEDB_TELEMETRY=off
     ports:
-      - "${TOKEN_SPY_DB_PORT:-5432}:5432"
+      - "${BIND_ADDRESS:-127.0.0.1}:${TOKEN_SPY_DB_PORT:-5432}:5432"
     volumes:
       - token-spy-postgres:/var/lib/postgresql/data
       - ./schema:/docker-entrypoint-initdb.d:ro


### PR DESCRIPTION
## What
Apply the project's `${BIND_ADDRESS:-127.0.0.1}:` port-binding pattern to the **standalone** token-spy product (`resources/products/token-spy/docker-compose.yml`) and flip the dashboard auth default to enabled.

## Why
The standalone product (separate from the integrated `extensions/services/token-spy/` extension, which is already correctly bound) was binding three services to all interfaces by default:

- proxy on port 8080 (logs all proxied LLM requests/responses including PII)
- analytics dashboard on port 3001 (`DASHBOARD_AUTH_ENABLED:-false` default — auth off)
- PostgreSQL on port 5432 (token usage history, weak default password)

A user running `make start` on a laptop on a coffee-shop / hotel / shared LAN exposed all three to any host on the network, with the dashboard fully unauthenticated by default.

## How
- `docker-compose.yml:37,75,104` — apply `${BIND_ADDRESS:-127.0.0.1}:` prefix to all three host-exposed ports. Default-secure to localhost; `BIND_ADDRESS=0.0.0.0` opts in to LAN exposure.
- `docker-compose.yml:69` — flip `DASHBOARD_AUTH_ENABLED:-true` so a fresh deploy has auth enabled.
- `config/.env.example:44` — flip the example to `DASHBOARD_AUTH_ENABLED=true` (otherwise `cp .env.example .env` re-disables auth).
- `config/.env.example:16` — add a louder warning above `POSTGRES_PASSWORD=CHANGE_ME` to make the literal placeholder more obvious.

PostgreSQL host port mapping is **kept** (with the BIND_ADDRESS prefix) — the Makefile's `make test-local` fallback path uses `127.0.0.1:5432`, and removing the mapping outright would break local tooling. Localhost-only is sufficient.

## Testing
- `python3 -c "import yaml; yaml.safe_load(open(...))"` — both files parse.
- `docker compose -f docker-compose.yml --env-file config/.env.example config` — exits 0 with all three host ports rendered as `127.0.0.1:<port>` (no `0.0.0.0`).
- Default-value rendering with `BIND_ADDRESS` unset: all three ports bind to `127.0.0.1` only.
- Auth path verified in `dashboard/main.py:70-91`: when `DASHBOARD_AUTH_ENABLED=true` and `DASHBOARD_PASSWORD` is empty, the API returns HTTP 500 — fail-closed, not silent accept.

## Review
Critique Guardian: APPROVED. All five pillars clean. No blockers.

## Platform Impact
- **macOS**: `${BIND_ADDRESS:-127.0.0.1}:` is Compose v2 universal — no platform-specific concern. `lsof -iTCP -sTCP:LISTEN | grep -E ':8080|:3001|:5432'` should show 127.0.0.1 only.
- **Linux**: same. `ss -tlnp | grep -E ':8080|:3001|:5432'` shows 127.0.0.1 only.
- **Windows WSL2**: same Compose v2 inside WSL2. `netstat -an | findstr "8080 3001 5432"` from a Windows shell shows 127.0.0.1 in LISTENING state.

## Known Considerations
- The supplementary `resources/products/token-spy/docker-compose.timescaledb.yml` (alternate workflow) still uses bare port mappings without the BIND_ADDRESS prefix. Same class of issue, out of scope here. Worth a separate sweep PR.
- The standalone product is on the "prototype/incubator" track per its own README — not part of normal DreamServer install. Severity is lower than a standard extension would imply.
