### PR TITLE
fix(localai): switch to non-AIO image to stop silent model download

### DIFF
--- a/resources/dev/extensions-library/services/localai/README.md
+++ b/resources/dev/extensions-library/services/localai/README.md
@@ -18,22 +18,34 @@ Your data is preserved when disabling. To re-enable later: `dream enable localai
 
 ## Access
 
-- **URL:** `http://localhost:7803`
+- **URL:** `http://127.0.0.1:7803`
 
 ## First-Time Setup
 
 1. Enable the service: `dream enable localai`
-2. Open `http://localhost:7803` to access the web interface
-3. Use the OpenAI-compatible API for integration with existing applications
+2. Configure your first model — see below. LocalAI ships with no models pre-configured.
+3. Open `http://127.0.0.1:7803` to access the web interface
+4. Use the OpenAI-compatible API for integration with existing applications
+
+### Configure your first model
+
+LocalAI ships with **no models pre-configured**. This is intentional — DreamServer favors explicit consent over silently downloading multi-gigabyte weights on first boot. Until you add at least one model, the API will report an empty model list and chat/image/audio endpoints will return errors.
+
+You have two ways to add a model:
+
+- **Use the built-in gallery browser.** Open `http://127.0.0.1:7803` and browse the model gallery from the web UI. Pick a model and LocalAI will download and register it for you.
+- **Drop a YAML model config into `data/localai/builds/`.** This directory is mounted at `/builds` inside the container and is where LocalAI loads model definitions from. See LocalAI's model-config docs for the YAML schema: <https://localai.io/docs/getting-started/customize-model/>.
+
+You can browse the upstream LocalAI model gallery at <https://localai.io/gallery/> for ready-made model entries you can copy into `data/localai/builds/`.
 
 ### API Usage
 
 ```bash
 # Chat completion (OpenAI-compatible)
-curl -X POST http://localhost:7803/v1/chat/completions \
+curl -X POST http://127.0.0.1:7803/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "gpt-4", "messages": [{"role": "user", "content": "Hello!"}]}'
 
 # List available models
-curl http://localhost:7803/v1/models
+curl http://127.0.0.1:7803/v1/models
 ```

--- a/resources/dev/extensions-library/services/localai/compose.yaml
+++ b/resources/dev/extensions-library/services/localai/compose.yaml
@@ -1,6 +1,6 @@
 services:
   localai:
-    image: localai/localai:v3.12.1-aio-cpu@sha256:4cbc20c59558ed6c1cae9bc3f6ae34d75d390b370aa8ac62a59327089fa56cec
+    image: localai/localai:v3.12.1@sha256:558efc7610e2ce43e702eaed4fcf456102a416471929d99819ef251fdbbf8b51
     container_name: dream-localai
     depends_on:
       llama-server:


### PR DESCRIPTION
## What
Switch the LocalAI extension from the AIO-CPU image variant to the standard CPU image, and document the resulting "configure your first model" step.

- Image: `localai/localai:v3.12.1-aio-cpu@sha256:4cbc...` → `localai/localai:v3.12.1@sha256:558efc7610e2ce43e702eaed4fcf456102a416471929d99819ef251fdbbf8b51`
- README: add a "Configure your first model" subsection guiding users to either the in-UI gallery browser or dropping a YAML model config into `data/localai/builds/`. Also sweeps `localhost` → `127.0.0.1` per project healthcheck convention.

## Why
The AIO-CPU image ships pre-configured `models.yaml` entries that auto-pull ~3.7 GB of HuggingFace weights on first container boot (Stable Diffusion v1.5, Hermes-3-Llama-3.2-3B, embedding + reranker models — and the AIO bundle's full set is ~10 GB+). Users got no UI prompt, no progress reflection in the dashboard, and one of the auto-pulled models (stable-diffusion) is in a different category than the manifest's "OpenAI-compatible API" description.

This violates DreamServer's opt-in install ergonomics: clicking install on a non-metered description should not silently saturate a user's connection or fill their disk.

## How
- The non-AIO base image (`v3.12.1`) is the standard LocalAI build. It includes the full Python deps for all backends (text generation, image generation, audio, video, voice cloning) — no functional regression. It simply ships **without preconfigured models**, so the user explicitly enables what they want.
- `/healthz` endpoint is identical in both variants (registered in `core/http/app.go` before auth middleware). Compose healthcheck unchanged.
- Image is digest-pinned to the **multi-arch manifest list** (`sha256:558efc...`); Docker selects amd64 on Linux/WSL2 and arm64 on Apple Silicon Docker Desktop automatically.

## Testing
- `python3 -c "import yaml; yaml.safe_load(...)"` — compose parses.
- Tag verified published on Docker Hub. Multi-arch manifest digest confirmed for `linux/amd64` and `linux/arm64`.
- `/healthz` endpoint cross-verified against upstream LocalAI source.

## Review
Critique Guardian: APPROVED. Variant-change implications and README placement both adjudicated as intentional and acceptable.

## Platform Impact
- **macOS (Apple Silicon)**: Docker Desktop pulls arm64 layer automatically — no `platform:` directive needed. No regression.
- **Linux (NVIDIA / AMD / CPU)**: amd64 layer pulled. No regression.
- **Windows WSL2**: same as Linux. No regression.

## Known Considerations
- Manifest declares `gpu_backends: [amd, nvidia]` while the image is CPU-only — pre-existing inconsistency, intentionally out of scope here per Verifier scope.
- Behavior change: existing LocalAI users who upgrade will lose the auto-loaded AIO models on next pull. README's new section walks them through re-adding models.
