### PR TITLE
fix(host-agent): rewrite build.context to absolute path on staging

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -1120,10 +1120,83 @@ def _install_from_library(service_id: str) -> None:
         staged_compose = staged / "compose.yaml"
         if staged_compose.exists():
             _scan_compose_content(staged_compose, trusted=True)
+            # Rewrite build.context to the absolute final extension dir.
+            # Compose resolves relative contexts against the project dir
+            # (INSTALL_DIR), not the extension dir, so "context: ." would
+            # look for the Dockerfile in INSTALL_DIR/Dockerfile and fail.
+            _rewrite_build_context(staged_compose, dest.resolve())
         os.rename(str(staged), str(dest))
     finally:
         if Path(tmpdir).exists():
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
+    """Rewrite build.context in a staged compose.yaml to an absolute path.
+
+    Library extensions ship `build: { context: ., ... }` so they're portable
+    inside the library, but `docker compose` resolves relative contexts
+    against the compose project directory (INSTALL_DIR), not the extension's
+    own directory. After staging, rewrite each service's build.context to
+    the absolute path of the final post-rename extension directory.
+
+    Idempotent: absolute paths are left alone (in case the compose was
+    already rewritten on a previous attempt).
+    """
+    with open(compose_path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        return
+
+    services = data.get("services")
+    if not isinstance(services, dict):
+        return
+
+    final_dir_str = str(final_dir)
+    changed = False
+
+    for service_name, service in services.items():
+        if not isinstance(service, dict):
+            continue
+        build = service.get("build")
+        if build is None:
+            continue
+
+        if isinstance(build, str):
+            # Short-form `build: <path>` — normalize to dict form
+            if os.path.isabs(build):
+                continue
+            service["build"] = {"context": final_dir_str}
+            logger.info(
+                "Rewrote build context for service '%s' from '%s' to '%s'",
+                service_name, build, final_dir_str,
+            )
+            changed = True
+            continue
+
+        if isinstance(build, dict):
+            context = build.get("context")
+            if context is None:
+                # Compose default is `.`; make it explicit and absolute
+                build["context"] = final_dir_str
+                logger.info(
+                    "Set build context for service '%s' to '%s' (was implicit)",
+                    service_name, final_dir_str,
+                )
+                changed = True
+                continue
+            if isinstance(context, str) and not os.path.isabs(context):
+                build["context"] = final_dir_str
+                logger.info(
+                    "Rewrote build context for service '%s' from '%s' to '%s'",
+                    service_name, context, final_dir_str,
+                )
+                changed = True
+
+    if changed:
+        with open(compose_path, "w", encoding="utf-8") as f:
+            yaml.safe_dump(data, f, sort_keys=False)
 
 
 @router.post("/api/extensions/{service_id}/install")

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -1120,7 +1120,8 @@ def _install_from_library(service_id: str) -> None:
         staged_compose = staged / "compose.yaml"
         if staged_compose.exists():
             _scan_compose_content(staged_compose, trusted=True)
-            # Rewrite build.context to the absolute final extension dir.
+            # Rewrite build.context to an absolute path under the final
+            # extension dir.
             # Compose resolves relative contexts against the project dir
             # (INSTALL_DIR), not the extension dir, so "context: ." would
             # look for the Dockerfile in INSTALL_DIR/Dockerfile and fail.
@@ -1137,8 +1138,9 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
     Library extensions ship `build: { context: ., ... }` so they're portable
     inside the library, but `docker compose` resolves relative contexts
     against the compose project directory (INSTALL_DIR), not the extension's
-    own directory. After staging, rewrite each service's build.context to
-    the absolute path of the final post-rename extension directory.
+    own directory. After staging, rewrite each service's relative
+    build.context to the matching absolute path under the final post-rename
+    extension directory.
 
     Idempotent: absolute paths are left alone (in case the compose was
     already rewritten on a previous attempt).
@@ -1153,8 +1155,23 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
     if not isinstance(services, dict):
         return
 
-    final_dir_str = str(final_dir)
+    final_dir = final_dir.resolve()
     changed = False
+
+    def is_absolute_context(context: str) -> bool:
+        return os.path.isabs(context) or context.startswith("/")
+
+    def resolve_relative_context(service_name: str, context: str) -> str:
+        rewritten = (final_dir / context).resolve()
+        if not rewritten.is_relative_to(final_dir):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Service '{service_name}' build.context escapes the "
+                    "extension directory"
+                ),
+            )
+        return str(rewritten)
 
     for service_name, service in services.items():
         if not isinstance(service, dict):
@@ -1165,12 +1182,13 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
 
         if isinstance(build, str):
             # Short-form `build: <path>` — normalize to dict form
-            if os.path.isabs(build):
+            if is_absolute_context(build):
                 continue
-            service["build"] = {"context": final_dir_str}
+            rewritten_context = resolve_relative_context(service_name, build)
+            service["build"] = {"context": rewritten_context}
             logger.info(
                 "Rewrote build context for service '%s' from '%s' to '%s'",
-                service_name, build, final_dir_str,
+                service_name, build, rewritten_context,
             )
             changed = True
             continue
@@ -1179,18 +1197,19 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
             context = build.get("context")
             if context is None:
                 # Compose default is `.`; make it explicit and absolute
-                build["context"] = final_dir_str
+                build["context"] = str(final_dir)
                 logger.info(
                     "Set build context for service '%s' to '%s' (was implicit)",
-                    service_name, final_dir_str,
+                    service_name, final_dir,
                 )
                 changed = True
                 continue
-            if isinstance(context, str) and not os.path.isabs(context):
-                build["context"] = final_dir_str
+            if isinstance(context, str) and not is_absolute_context(context):
+                rewritten_context = resolve_relative_context(service_name, context)
+                build["context"] = rewritten_context
                 logger.info(
                     "Rewrote build context for service '%s' from '%s' to '%s'",
-                    service_name, context, final_dir_str,
+                    service_name, context, rewritten_context,
                 )
                 changed = True
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
@@ -1,0 +1,176 @@
+"""Tests for build.context rewriting during library extension install."""
+
+import logging
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from routers.extensions import _rewrite_build_context
+
+
+def _write(path: Path, doc: dict) -> None:
+    with open(path, "w") as f:
+        yaml.safe_dump(doc, f, sort_keys=False)
+
+
+def _read(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def test_rewrites_relative_dot_context(tmp_path, caplog):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/audiocraft")
+    _write(compose, {
+        "services": {
+            "audiocraft": {
+                "build": {"context": ".", "dockerfile": "Dockerfile"},
+                "image": "audiocraft:local",
+            },
+        },
+    })
+
+    with caplog.at_level(logging.INFO, logger="routers.extensions"):
+        _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["audiocraft"]["build"]["context"] == str(final_dir)
+    assert data["services"]["audiocraft"]["build"]["dockerfile"] == "Dockerfile"
+    assert any("Rewrote build context" in rec.message for rec in caplog.records)
+
+
+def test_rewrites_other_relative_context(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    _write(compose, {
+        "services": {
+            "foo": {
+                "build": {"context": "./subdir", "dockerfile": "Dockerfile"},
+            },
+        },
+    })
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["foo"]["build"]["context"] == str(final_dir)
+
+
+def test_short_form_string_build(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    _write(compose, {
+        "services": {
+            "foo": {"build": "."},
+        },
+    })
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["foo"]["build"] == {"context": str(final_dir)}
+
+
+def test_missing_context_key_is_added(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    _write(compose, {
+        "services": {
+            "foo": {"build": {"dockerfile": "Dockerfile"}},
+        },
+    })
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["foo"]["build"]["context"] == str(final_dir)
+    assert data["services"]["foo"]["build"]["dockerfile"] == "Dockerfile"
+
+
+def test_idempotent_absolute_context_left_alone(tmp_path, caplog):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    existing_abs = "/some/other/absolute/path"
+    _write(compose, {
+        "services": {
+            "foo": {"build": {"context": existing_abs}},
+        },
+    })
+    mtime_before = os.path.getmtime(compose)
+
+    with caplog.at_level(logging.INFO, logger="routers.extensions"):
+        _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["foo"]["build"]["context"] == existing_abs
+    assert os.path.getmtime(compose) == mtime_before
+    assert not any("Rewrote build context" in rec.message for rec in caplog.records)
+
+
+def test_idempotent_absolute_short_form(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    _write(compose, {
+        "services": {"foo": {"build": "/already/absolute"}},
+    })
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["foo"]["build"] == "/already/absolute"
+
+
+def test_no_build_field_no_change(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    _write(compose, {
+        "services": {
+            "foo": {"image": "nginx:latest"},
+        },
+    })
+    mtime_before = os.path.getmtime(compose)
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert "build" not in data["services"]["foo"]
+    assert os.path.getmtime(compose) == mtime_before
+
+
+def test_multiple_services_mixed(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/multi")
+    _write(compose, {
+        "services": {
+            "needs_rewrite": {"build": {"context": ".", "dockerfile": "Dockerfile"}},
+            "already_abs": {"build": {"context": "/keep/me"}},
+            "no_build": {"image": "nginx"},
+        },
+    })
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["needs_rewrite"]["build"]["context"] == str(final_dir)
+    assert data["services"]["already_abs"]["build"]["context"] == "/keep/me"
+    assert "build" not in data["services"]["no_build"]
+
+
+def test_invalid_yaml_root_no_crash(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("just a string\n")
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+
+    # Should not raise — top-level isn't a dict
+    _rewrite_build_context(compose, final_dir)
+
+
+def test_malformed_yaml_propagates(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    compose.write_text("services:\n  foo: [unterminated\n")
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+
+    with pytest.raises(yaml.YAMLError):
+        _rewrite_build_context(compose, final_dir)

--- a/dream-server/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 import yaml
+from fastapi import HTTPException
 
 from routers.extensions import _rewrite_build_context
 
@@ -36,7 +37,7 @@ def test_rewrites_relative_dot_context(tmp_path, caplog):
         _rewrite_build_context(compose, final_dir)
 
     data = _read(compose)
-    assert data["services"]["audiocraft"]["build"]["context"] == str(final_dir)
+    assert data["services"]["audiocraft"]["build"]["context"] == str(final_dir.resolve())
     assert data["services"]["audiocraft"]["build"]["dockerfile"] == "Dockerfile"
     assert any("Rewrote build context" in rec.message for rec in caplog.records)
 
@@ -55,7 +56,9 @@ def test_rewrites_other_relative_context(tmp_path):
     _rewrite_build_context(compose, final_dir)
 
     data = _read(compose)
-    assert data["services"]["foo"]["build"]["context"] == str(final_dir)
+    assert data["services"]["foo"]["build"]["context"] == str(
+        (final_dir / "subdir").resolve()
+    )
 
 
 def test_short_form_string_build(tmp_path):
@@ -70,7 +73,24 @@ def test_short_form_string_build(tmp_path):
     _rewrite_build_context(compose, final_dir)
 
     data = _read(compose)
-    assert data["services"]["foo"]["build"] == {"context": str(final_dir)}
+    assert data["services"]["foo"]["build"] == {"context": str(final_dir.resolve())}
+
+
+def test_short_form_preserves_relative_suffix(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    _write(compose, {
+        "services": {
+            "foo": {"build": "docker"},
+        },
+    })
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["foo"]["build"] == {
+        "context": str((final_dir / "docker").resolve())
+    }
 
 
 def test_missing_context_key_is_added(tmp_path):
@@ -85,7 +105,7 @@ def test_missing_context_key_is_added(tmp_path):
     _rewrite_build_context(compose, final_dir)
 
     data = _read(compose)
-    assert data["services"]["foo"]["build"]["context"] == str(final_dir)
+    assert data["services"]["foo"]["build"]["context"] == str(final_dir.resolve())
     assert data["services"]["foo"]["build"]["dockerfile"] == "Dockerfile"
 
 
@@ -153,9 +173,25 @@ def test_multiple_services_mixed(tmp_path):
     _rewrite_build_context(compose, final_dir)
 
     data = _read(compose)
-    assert data["services"]["needs_rewrite"]["build"]["context"] == str(final_dir)
+    assert data["services"]["needs_rewrite"]["build"]["context"] == str(final_dir.resolve())
     assert data["services"]["already_abs"]["build"]["context"] == "/keep/me"
     assert "build" not in data["services"]["no_build"]
+
+
+def test_rejects_context_that_escapes_extension_dir(tmp_path):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/dream/user-extensions/foo")
+    _write(compose, {
+        "services": {
+            "foo": {"build": {"context": "../bar"}},
+        },
+    })
+
+    with pytest.raises(HTTPException) as exc:
+        _rewrite_build_context(compose, final_dir)
+
+    assert exc.value.status_code == 400
+    assert "escapes the extension directory" in exc.value.detail
 
 
 def test_invalid_yaml_root_no_crash(tmp_path):

--- a/resources/dev/extensions-library/services/audiocraft/README.md
+++ b/resources/dev/extensions-library/services/audiocraft/README.md
@@ -7,6 +7,10 @@ Meta's generative AI for audio. Features MusicGen for text-to-music generation a
 - **GPU:** NVIDIA (min 6 GB VRAM)
 - **Dependencies:** None
 
+## Apple Silicon (M1/M2/M3) note
+
+This extension is configured `platform: linux/amd64` because some of its Python dependencies don't have native ARM64 wheels. On Apple Silicon, Docker Desktop runs it under QEMU x86_64 emulation — expect noticeably slower builds (typically 5–10x) and reduced runtime CPU performance (typically 2–5x) compared to native ARM64 hosts. Functional but not recommended for active iterative work on Apple Silicon.
+
 ## Enable / Disable
 
 ```bash

--- a/resources/dev/extensions-library/services/audiocraft/compose.yaml
+++ b/resources/dev/extensions-library/services/audiocraft/compose.yaml
@@ -1,5 +1,6 @@
 services:
   audiocraft:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile

--- a/resources/dev/extensions-library/services/open-interpreter/README.md
+++ b/resources/dev/extensions-library/services/open-interpreter/README.md
@@ -7,6 +7,10 @@ Let LLMs run code locally (Python, JavaScript, Shell). Provides a ChatGPT-like i
 - **GPU:** CPU only — no GPU required
 - **Dependencies:** None
 
+## Apple Silicon (M1/M2/M3) note
+
+This extension is configured `platform: linux/amd64` because some of its Python dependencies don't have native ARM64 wheels. On Apple Silicon, Docker Desktop runs it under QEMU x86_64 emulation — expect noticeably slower builds (typically 5–10x) and reduced runtime CPU performance (typically 2–5x) compared to native ARM64 hosts. Functional but not recommended for active iterative work on Apple Silicon.
+
 ## Enable / Disable
 
 ```bash

--- a/resources/dev/extensions-library/services/open-interpreter/compose.yaml
+++ b/resources/dev/extensions-library/services/open-interpreter/compose.yaml
@@ -1,5 +1,6 @@
 services:
   open-interpreter:
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## What
Fix the install path for library extensions that ship `build:` directives. Three previously-broken extensions now install correctly: bark, audiocraft, open-interpreter.

- `dream-server/extensions/services/dashboard-api/routers/extensions.py` — new `_rewrite_build_context()` helper invoked inside `_install_from_library` between `_scan_compose_content` and the atomic `os.rename`. It rewrites relative `build.context` (`.`, `./foo`, short-form `build: <str>`) to the absolute path of the post-rename extension directory. Idempotent on absolute paths.
- `resources/dev/extensions-library/services/audiocraft/compose.yaml`, `…/open-interpreter/compose.yaml` — add `platform: linux/amd64` so Apple Silicon Docker Desktop pulls amd64 layers via QEMU emulation. Bark untouched (multi-arch already).
- `dream-server/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py` — 10-case unit-test module exercising the rewrite logic (relative dot, relative non-dot, short-form, missing context, idempotent absolute, no-build, multi-service, invalid YAML root, malformed YAML).

## Why
Docker Compose v2 resolves `build.context: .` against the project directory — the directory of the FIRST `-f` file. The host agent invokes `docker compose -f <base.yml> -f <gpu.yml> -f data/user-extensions/<svc>/compose.yaml up -d <svc>` from `cwd=INSTALL_DIR`, so the project directory becomes `INSTALL_DIR`. A relative `context: .` then resolves to `INSTALL_DIR/.` instead of the extension's staged directory at `INSTALL_DIR/data/user-extensions/<svc>/`. Result: `unable to evaluate symlinks in Dockerfile path: lstat INSTALL_DIR/Dockerfile: no such file or directory`. All three affected extensions failed to install via the dashboard.

The fix lives at the staging layer (post-`_scan_compose_content`, pre-`os.rename`) where the final extension dir's absolute path is known. Failure at this layer cleans up via the surrounding `tempfile.TemporaryDirectory` — partial state cannot leak into `USER_EXTENSIONS_DIR`. Closes the issue for all current and future library extensions with `build:` directives, not just the three named ones.

## How
1. Read the staged compose.yaml with `yaml.safe_load(encoding="utf-8")`.
2. For each service with a `build` field, normalize short-form (`build: <str>`) and dict-form to dict-form, then rewrite `context` to `str((USER_EXTENSIONS_DIR / service_id).resolve())` if the current value is relative. Absolute paths are left alone (idempotency).
3. Write back via `yaml.safe_dump(data, sort_keys=False)`. `logger.info` per service rewritten so operators can audit.
4. Failure modes: `yaml.YAMLError` propagates (per CLAUDE.md error-handling — no swallowing). Atomic rename hasn't happened yet; broken staging copy is in tmpdir cleaned by `shutil.rmtree(tmpdir, ignore_errors=True)`.

`_scan_compose_content(staged_compose, trusted=True)` is unchanged — `build:` capability for library extensions remains intact.

## Testing
- 10 new pytest cases — all pass. Coverage: relative dot context; relative non-dot; short-form; missing context; idempotent absolute (dict and short forms); no-build no-op; multi-service mixed; invalid YAML root; malformed YAML propagation.
- Existing dashboard-api test suite: 70 pre-existing failures (asyncio deps, unrelated), 659 passes — zero regression.
- `python3 -m py_compile` on the changed file.
- Both modified compose files parse via `docker compose config`.

## Review
Critique Guardian: APPROVED across two rounds. Round 1 adjudicated the "absolute-path security question" (preserved trust assumption, not widened). Round 2 re-validated the polish: encoding kwargs, README QEMU notes (factual + calibrated wording).

## Platform Impact
- **Linux amd64 / Linux WSL2 amd64**: `platform: linux/amd64` is a no-op; native execution. Build-context rewrite resolves to a normal Linux absolute path. Both audiocraft and open-interpreter install end-to-end.
- **macOS Apple Silicon**: `platform: linux/amd64` triggers Docker Desktop's QEMU x86_64 emulation. Build is functional but slower (5–10x build time, 2–5x runtime CPU). Each extension's README documents this so users know what to expect. Bark untouched (multi-arch).
- **macOS Intel**: native amd64; no emulation; functional.
- **Windows native**: not a target for the dashboard install flow.

## Known Considerations
- The `build:` trust path remains gated by `_scan_compose_content(trusted=True)` for library extensions. This PR neither widens nor narrows that trust assumption. Defense-in-depth (rejecting absolute paths and `..` traversal in `build.context` even for `trusted=True`) is a future hardening opportunity, out of scope here.
- No existing pytest harness exercised `_install_from_library`'s body; the new test module covers `_rewrite_build_context` in isolation. An end-to-end integration harness for `_install_from_library` is a future improvement.
