### PR TITLE
fix(host-agent): start install worker thread before sending 202

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1518,8 +1518,8 @@ class AgentHandler(BaseHTTPRequestHandler):
                 lock.release()
 
         try:
-            json_response(self, 202, {"status": "accepted", "service_id": service_id, "action": "install"})
             threading.Thread(target=_run_install, daemon=True).start()
+            json_response(self, 202, {"status": "accepted", "service_id": service_id, "action": "install"})
         except Exception:
             lock.release()
             raise


### PR DESCRIPTION
## What
Invert the two lines in `_handle_install` so `threading.Thread(...).start()` runs before `json_response(self, 202, ...)`.

## Why
Under the old ordering, if `Thread.start()` raised (OS thread-resource exhaustion, process thread-limit hit), the 202 had already been written to the socket. The bare `raise` then propagated into `BaseHTTPRequestHandler`, which logged the exception and dropped the connection mid-wire. The caller received a 202 with an abrupt close and no JSON body — indistinguishable from a successful accept, causing the dashboard install-poll loop and the dream CLI to spin indefinitely waiting for a completion event that would never arrive.

## How
Single-line swap in `dream-server/bin/dream-host-agent.py` inside `_handle_install`'s outer try block: `Thread(...).start()` is now called first, `json_response(self, 202, ...)` second. The existing `except` clause already handles launch failure correctly (releases the lock and re-raises); no changes needed there. Lock mechanics are entirely unchanged.

This brings `_handle_install` into alignment with the sibling pattern already used at `_handle_model_download` (lines 1819–1822), where `Thread.start()` precedes `json_response`. `_handle_install` was the lone outlier.

## Testing
- Automated: `python3 -m py_compile dream-server/bin/dream-host-agent.py` — clean. No dedicated unit test exists for host-agent (it is a stdlib HTTPServer process, outside the dashboard-api pytest scaffolding).
- Manual: trigger an extension install via dashboard or `curl -X POST http://127.0.0.1:7710/v1/extension/install`; confirm the 202 response arrives only after the worker-thread launch log line appears in the host-agent log; confirm a forced thread-start failure surfaces a 500 rather than a 202+silent-stall.

## Review
Critique Guardian: APPROVED. No required-before-merge items. Informational notes: (1) thread-spawn-failure now surfaces a 500 instead of 202+silent-stall — this is an operator-actionable signal improvement, not a regression; (2) new ordering matches the established sibling pattern at `_handle_model_download` lines 1819–1822.

## Known Considerations
Thread.start() failures are rare in practice (require OS-level thread exhaustion). The behavior change — 500 on launch failure instead of 202+stall — is strictly better for callers: the error is immediately observable rather than silent. No downstream code assumes that `_handle_install` always returns 202 on the happy path; the worker-started 202 contract is preserved.

## Platform Impact
- macOS: affected — host agent runs as a launchd-managed background process on macOS Apple Silicon; fix applies equally.
- Linux: affected — host agent runs as a systemd service; primary deployment target; fix applies equally.
- Windows (WSL2): affected — host agent runs inside the WSL2 environment; fix applies equally.
