### PR TITLE
fix(dashboard-api): allow built-in extensions to declare init-time root user

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -303,6 +303,7 @@ def _scan_compose_content(
     trusted: bool = False,
     skip_name_collision: bool = False,
     skip_gpu_passthrough_check: bool = False,
+    skip_root_user_check: bool = False,
 ) -> None:
     """Reject compose files containing dangerous directives."""
     try:
@@ -395,12 +396,13 @@ def _scan_compose_content(
                 status_code=400,
                 detail=f"Service '{svc_name}' uses host user namespace",
             )
-        user = svc_def.get("user")
-        if user is not None and str(user).split(":")[0] in ("root", "0"):
-            raise HTTPException(
-                status_code=400,
-                detail=f"Service '{svc_name}' runs as root",
-            )
+        if not skip_root_user_check:
+            user = svc_def.get("user")
+            if user is not None and str(user).split(":")[0] in ("root", "0"):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Service '{svc_name}' runs as root",
+                )
         if not trusted and "build" in svc_def:
             raise HTTPException(
                 status_code=400,
@@ -1283,14 +1285,18 @@ def _activate_service(service_id: str) -> dict:
     # Re-scan compose content (TOCTOU prevention). Built-in extensions
     # legitimately declare their own service name in their compose file, so
     # skip the CORE_SERVICE_IDS name-collision check for them. User extensions
-    # still get the full anti-shadowing scan. The `trusted` flag is separate
-    # and controls whether `build:` directives are allowed (library installs
-    # need it, built-in activations do not).
+    # still get the full anti-shadowing scan. Some built-ins also legitimately
+    # need `user: "0:0"` to perform init-time chown before dropping privileges
+    # via setpriv (e.g. openclaw), so skip the root-user check for built-ins
+    # only. The `trusted` flag is separate and controls whether `build:`
+    # directives are allowed (library installs need it, built-in activations
+    # do not).
     is_builtin = ext_dir.is_relative_to(EXTENSIONS_DIR.resolve())
     _scan_compose_content(
         disabled_compose,
         skip_name_collision=is_builtin,
         skip_gpu_passthrough_check=is_builtin,
+        skip_root_user_check=is_builtin,
     )
 
     # Reject symlinks
@@ -1344,6 +1350,7 @@ def enable_extension(
                 enabled_compose,
                 skip_name_collision=is_builtin,
                 skip_gpu_passthrough_check=is_builtin,
+                skip_root_user_check=is_builtin,
             )
         # Dependencies were satisfied at install time; compose content is re-scanned above
         _write_initial_progress(service_id)

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -1853,6 +1853,61 @@ class TestScanComposeSkipGpuPassthroughCheck:
         _scan_compose_content(compose)
 
 
+# --- skip_root_user_check flag isolation ---
+
+
+class TestScanComposeSkipRootUserCheck:
+    """Direct unit tests for the skip_root_user_check parameter that permits
+    built-in extensions (e.g. openclaw, which uses `user: "0:0"` to perform
+    init-time chown before dropping privileges via setpriv) to declare a
+    root user, while user/library extensions cannot. Regression guard for
+    the openclaw init-time chown + setpriv pattern."""
+
+    _ROOT_COMPOSE = (
+        'services:\n  svc:\n    image: test\n    user: "0:0"\n'
+    )
+
+    def test_builtin_with_root_user_accepted(self, tmp_path):
+        """A built-in extension with user: 0:0 (init-time chown + setpriv
+        pattern, e.g. openclaw) must be accepted via
+        skip_root_user_check=True. Regression guard: built-ins with
+        `user: '0:0'` must be accepted when skip_root_user_check=True.
+        """
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(self._ROOT_COMPOSE)
+        # Should not raise
+        _scan_compose_content(compose, skip_root_user_check=True)
+
+    def test_user_extension_with_root_user_rejected(self, tmp_path):
+        """User/library extensions (skip_root_user_check defaulting to False)
+        still reject user: "0:0". Regression guard to ensure the
+        new parameter doesn't accidentally weaken security for non-built-ins.
+        """
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(self._ROOT_COMPOSE)
+        with pytest.raises(HTTPException) as exc:
+            _scan_compose_content(compose)
+        assert exc.value.status_code == 400
+        assert "runs as root" in exc.value.detail
+
+    def test_privileged_still_blocked_when_skipped(self, tmp_path):
+        """Other security checks remain active when skip_root_user_check=True;
+        a built-in cannot smuggle in `privileged: true` under the root-user
+        exemption.
+        """
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(
+            'services:\n  svc:\n    image: test\n    user: "0:0"\n'
+            "    privileged: true\n",
+        )
+        with pytest.raises(HTTPException) as exc:
+            _scan_compose_content(compose, skip_root_user_check=True)
+        assert "privileged" in exc.value.detail
+
+
 # --- Size quota enforcement ---
 
 


### PR DESCRIPTION
## What
Adds `skip_root_user_check: bool = False` to `_scan_compose_content` so
built-in extensions can declare `user: "0:0"` for a legitimate init-time
chown + privilege-drop pattern without being rejected by the security scanner.

## Why
`_scan_compose_content` rejects any compose service that declares
`user: "0:0"` or `user: "root"`. The openclaw built-in uses this pattern
legitimately: its entrypoint runs `chown -R 1000:1000 /home/node/.openclaw`
to fix bind-mount ownership, then immediately drops to uid/gid 1000 via
`setpriv --reuid=1000 --regid=1000 --clear-groups`. The container also
declares `security_opt: no-new-privileges: true`, so the chown step cannot
escalate. The existing scanner had no mechanism to permit this pattern for
repo-shipped built-ins while continuing to reject it for user and library
extensions.

## How
Mirrors the existing `skip_name_collision` and `skip_gpu_passthrough_check`
parameter pattern already present on `_scan_compose_content`. The new
`skip_root_user_check: bool = False` parameter is passed as `is_builtin` at
both internal call sites (`_activate_service` and `enable_extension`), where
`is_builtin` is the pre-existing
`ext_dir.is_relative_to(EXTENSIONS_DIR.resolve())` gate. User-installed and
library extensions default to `skip_root_user_check=False` — the root-user
check is unchanged for them.

Files changed:
- `routers/extensions.py` — new parameter + guard + updated docblock on both
  call sites (+16/-9)
- `tests/test_extensions.py` — new `TestScanComposeSkipRootUserCheck` class
  (+53)

## Testing
- Automated: py_compile clean on both files; new test class
  `TestScanComposeSkipRootUserCheck` follows the established skip-class
  pattern (positive: skip=True accepts root user; negative: default rejects;
  regression-guard: skip=True does NOT bypass the `privileged: true` check);
  `test_install_allows_library_build_context` still passes (install path is
  unchanged — `trusted=True` retained at the library install call site).
- Manual: Enable openclaw via the dashboard Extensions page on a clean install;
  confirm the extension activates without a 400 "runs as root" error. On Linux
  (NVIDIA or CPU tier), verify `docker inspect openclaw` shows the container
  running as uid 1000 after startup.

## Review
Critique Guardian: APPROVED. No required-before-merge items. Informational
only: an optional ergonomics follow-up — a one-line comment in
`extensions/services/openclaw/compose.yaml` near `user: "0:0"` documenting
the init-time chown + setpriv handoff and the `skip_root_user_check` trust
boundary would help future readers. Pure documentation; not blocking.

## Known Considerations
This PR is intentionally scoped narrowly to the built-in root-user-check
exemption. A related broader question about tightening the `trusted` parameter
at the library install path was split out and deferred for separate review.
That work is not part of this PR and is not a prerequisite for merge.

`is_builtin` derives from `EXTENSIONS_DIR.resolve()`, which canonicalises
symlinks before comparison. A symlink-into-builtins path substitution would
require pre-existing write access to the install tree — outside the relevant
threat model.

## Platform Impact
- macOS: affected — extension scanning runs on all platforms; the exemption
  applies equally to Apple Silicon installs.
- Linux: affected — primary target platform; openclaw is Linux-deployable.
- Windows (WSL2): affected — same Python code path runs under WSL2.
