### PR TITLE
refactor(host-agent): migrate systemd unit from user-mode to system-mode

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -2521,7 +2521,7 @@ cmd_agent() {
     case "$(uname -s)" in
         Darwin) daemon_type="launchd" ;;
         Linux)
-            if systemctl --user status >/dev/null 2>&1; then
+            if systemctl status >/dev/null 2>&1 || [[ -d /run/systemd/system ]]; then
                 daemon_type="systemd"
             fi
             ;;
@@ -2546,7 +2546,7 @@ cmd_agent() {
                         success "Agent started (LaunchAgent)" || warn "Agent start failed"
                     ;;
                 systemd)
-                    systemctl --user start dream-host-agent.service 2>/dev/null && \
+                    sudo systemctl start dream-host-agent.service 2>/dev/null && \
                         success "Agent started (systemd)" || warn "Agent start failed"
                     ;;
                 *)
@@ -2572,7 +2572,7 @@ cmd_agent() {
                         success "Agent stopped" || warn "Agent not running"
                     ;;
                 systemd)
-                    systemctl --user stop dream-host-agent.service 2>/dev/null && \
+                    sudo systemctl stop dream-host-agent.service 2>/dev/null && \
                         success "Agent stopped" || warn "Agent not running"
                     ;;
                 *)

--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -126,6 +126,14 @@ for unit in opencode-web.service openclaw-session-cleanup.timer \
     fi
 done
 systemctl --user daemon-reload 2>/dev/null || true
+
+# Remove system-mode dream-host-agent unit (migrated from --user mode).
+# Idempotent — no-op if the unit was never installed (e.g. older user-mode installs).
+if systemctl is-enabled dream-host-agent.service >/dev/null 2>&1; then
+    sudo systemctl disable --now dream-host-agent.service 2>/dev/null || true
+fi
+sudo rm -f /etc/systemd/system/dream-host-agent.service 2>/dev/null || true
+sudo systemctl daemon-reload 2>/dev/null || true
 log_ok "Systemd services removed"
 
 # 3. Remove CLI symlink

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -220,49 +220,99 @@ OPENCODE_EOF
 fi
 
 # ── Dream Host Agent (extension lifecycle management) ──
+# System-mode systemd unit (was --user mode pre-#573). Installs to
+# /etc/systemd/system, runs as the installing user with SupplementaryGroups=docker
+# so the agent can manage Docker without socket-mounting into a container.
 if [[ -f "$INSTALL_DIR/bin/dream-host-agent.py" ]]; then
     AGENT_PYTHON="$(command -v python3)"
     if [[ -n "$AGENT_PYTHON" ]]; then
-        if systemctl --user status >/dev/null 2>&1; then
-            # systemd path
-            SYSTEMD_USER_DIR="$HOME/.config/systemd/user"
-            mkdir -p "$SYSTEMD_USER_DIR"
+        if systemctl status >/dev/null 2>&1 || [[ -d /run/systemd/system ]]; then
+            # Migrate any pre-existing user-mode unit (idempotent — no-op if absent).
+            if [[ -f "$HOME/.config/systemd/user/dream-host-agent.service" ]]; then
+                systemctl --user stop dream-host-agent.service 2>/dev/null || true
+                systemctl --user disable dream-host-agent.service 2>/dev/null || true
+                rm -f "$HOME/.config/systemd/user/dream-host-agent.service"
+                systemctl --user daemon-reload 2>/dev/null || true
+                ai_ok "Migrated host agent from --user mode to system mode"
+            fi
+
+            # System-mode install requires sudo. Fail fast in non-interactive
+            # mode if passwordless sudo isn't available (mirrors phase 05).
+            if [[ "${INTERACTIVE:-true}" != "true" ]] && ! sudo -n true 2>/dev/null; then
+                ai_bad "Host agent install requires sudo and sudo requires a password."
+                ai_bad "In non-interactive mode, either:"
+                ai "  1. Run with passwordless sudo (NOPASSWD in sudoers)"
+                ai "  2. Run the installer interactively (without --non-interactive)"
+                error "Cannot install host agent system unit without sudo in non-interactive mode."
+            fi
+
+            # Determine the user that should own the running agent. Under
+            # `sudo bash install.sh`, $(whoami) returns root — wrong; we want
+            # the original invoking user. SUDO_USER is set by sudo and is
+            # empty otherwise. INSTALL_USER override wins if explicitly set.
+            if [[ -n "${INSTALL_USER:-}" ]]; then
+                _agent_user="$INSTALL_USER"
+            elif [[ -n "${SUDO_USER:-}" ]]; then
+                _agent_user="$SUDO_USER"
+            else
+                _agent_user="$(whoami)"
+            fi
+
+            # Surface (don't block) the case where the agent will run as root.
+            # Happens under `sudo su` → `bash install.sh` (SUDO_USER unset, whoami=root).
+            # Some appliance/single-user installs may want this; warn so the operator
+            # can override with INSTALL_USER if it's unintentional.
+            if [[ "$_agent_user" == "root" ]]; then
+                ai_warn "Resolved install user is 'root' — host agent will run as root."
+                ai_warn "  Set INSTALL_USER=<non-root user> before re-running install if this is unintentional."
+            fi
+
             if [[ -f "$INSTALL_DIR/scripts/systemd/dream-host-agent.service" ]]; then
                 svc_tmp="/tmp/dream-host-agent.service.$$"
                 cp "$INSTALL_DIR/scripts/systemd/dream-host-agent.service" "$svc_tmp"
                 # Substitute placeholders — use sed directly with | delimiter
-                # (paths contain / but never |, so | is a safe delimiter)
+                # (paths contain / but never |, so | is a safe delimiter).
+                # Dual-form for BSD/GNU sed compatibility.
                 sed -i "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp" 2>/dev/null || \
                     sed -i '' "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp"
                 sed -i "s|__HOME__|${HOME}|g" "$svc_tmp" 2>/dev/null || \
                     sed -i '' "s|__HOME__|${HOME}|g" "$svc_tmp"
                 sed -i "s|__PYTHON3__|${AGENT_PYTHON}|g" "$svc_tmp" 2>/dev/null || \
                     sed -i '' "s|__PYTHON3__|${AGENT_PYTHON}|g" "$svc_tmp"
+                sed -i "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp" 2>/dev/null || \
+                    sed -i '' "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp"
                 # Verify placeholders were actually rendered
-                if grep -q '__INSTALL_DIR__\|__HOME__\|__PYTHON3__' "$svc_tmp"; then
+                if grep -q '__INSTALL_DIR__\|__HOME__\|__PYTHON3__\|__INSTALL_USER__' "$svc_tmp"; then
                     ai_warn "Host agent systemd unit has unrendered placeholders — check $svc_tmp"
                 else
-                    cp "$svc_tmp" "$SYSTEMD_USER_DIR/dream-host-agent.service"
+                    sudo install -m 644 "$svc_tmp" /etc/systemd/system/dream-host-agent.service
                 fi
                 rm -f "$svc_tmp"
             fi
-            systemctl --user daemon-reload 2>/dev/null || true
-            systemctl --user enable --now dream-host-agent.service >> "$LOG_FILE" 2>&1 && \
-                ai_ok "Dream host agent installed (systemd --user, port 7710)" || \
+            sudo systemctl daemon-reload 2>/dev/null || true
+            # Pipe through tee (matching the file's existing sudo+log idiom at L31-45)
+            # so the redirect runs in the user's shell rather than under sudo (avoids
+            # SC2024). pipefail is set in install-core.sh, so the if branches on the
+            # actual systemctl exit status, not tee's.
+            if sudo systemctl enable --now dream-host-agent.service 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+                ai_ok "Dream host agent installed (systemd system-mode, user=${_agent_user}, port 7710)"
+            else
                 ai_warn "Dream host agent service failed to start — run: dream agent start"
+            fi
             # Force-restart so the running process matches the binary the installer
             # just rewrote. enable --now is a no-op when the unit was already active,
             # which would leave an old daemon holding a deleted inode and serving
             # stale code after a reinstall. See issue #334. Use is-enabled (not
             # is-active) so a temporarily-down daemon during a fresh install still
             # triggers the restart rather than skipping it.
-            if systemctl --user is-enabled dream-host-agent.service >/dev/null 2>&1; then
-                systemctl --user restart dream-host-agent.service >> "$LOG_FILE" 2>&1 && \
-                    ai_ok "Dream host agent restarted (loaded new binary)" || \
-                    ai_warn "Dream host agent restart failed (non-fatal) — run: systemctl --user restart dream-host-agent.service"
+            if sudo systemctl is-enabled dream-host-agent.service >/dev/null 2>&1; then
+                if sudo systemctl restart dream-host-agent.service 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+                    ai_ok "Dream host agent restarted (loaded new binary)"
+                else
+                    ai_warn "Dream host agent restart failed (non-fatal) — run: sudo systemctl restart dream-host-agent.service"
+                fi
             fi
-            loginctl enable-linger "$(whoami)" 2>/dev/null || \
-                sudo -n loginctl enable-linger "$(whoami)" 2>/dev/null || true
+            # loginctl enable-linger no longer needed for host agent (system-mode unit)
         else
             ai_warn "No systemd detected — dream host agent not auto-installed."
             ai_warn "  Start manually: dream agent start"

--- a/dream-server/scripts/systemd/dream-host-agent.service
+++ b/dream-server/scripts/systemd/dream-host-agent.service
@@ -4,6 +4,8 @@ After=docker.service
 
 [Service]
 Type=simple
+User=__INSTALL_USER__
+SupplementaryGroups=docker
 ExecStart=__PYTHON3__ __INSTALL_DIR__/bin/dream-host-agent.py
 WorkingDirectory=__INSTALL_DIR__
 Environment=DREAM_HOME=__INSTALL_DIR__
@@ -12,4 +14,4 @@ Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target


### PR DESCRIPTION
## What
Migrate the dream-host-agent systemd unit from user-mode (`systemctl --user`) to system-mode (`/etc/systemd/system/`) with `User=<installer-user>` and `SupplementaryGroups=docker`.

## Why
User-mode systemd (PID 1 per-user manager) spawns at login with a frozen supplementary group set. When Phase 05 runs `usermod -aG docker $USER`, the change takes effect for future login sessions but the user manager is never re-exec'd — so the host-agent process inherits a stale group set and lacks docker socket access at runtime. `loginctl enable-linger` keeps the unit alive past logout but does not solve the group-inheritance race; the group set is still frozen at the moment the user manager first started.

A system-mode unit with `User=<installer-user>` and `SupplementaryGroups=docker` makes docker group membership explicit at unit-load time, completely bypassing the group-inheritance race.

## How
**`dream-server/scripts/systemd/dream-host-agent.service`** — added `User=__INSTALL_USER__` and `SupplementaryGroups=docker` to `[Service]`; flipped `WantedBy` from `default.target` to `multi-user.target` (system-mode target).

**`dream-server/installers/phases/07-devtools.sh`** — replaced the `--user`-mode install block with a system-mode block. Key decisions:
- Detection guard: `systemctl status >/dev/null 2>&1 || [[ -d /run/systemd/system ]]` (covers WSL2-with-systemd and standard Linux).
- Idempotent migration: stops, disables, and removes any pre-existing `~/.config/systemd/user/dream-host-agent.service`, emitting `✓ Migrated host agent from --user mode to system mode`.
- Hard-fail sudo guard in non-interactive mode (mirrors Phase 05 pattern).
- User resolution: `${INSTALL_USER:-${SUDO_USER:-$(whoami)}}` — INSTALL_USER wins (test harnesses), then SUDO_USER (the documented `sudo bash install.sh` path), then `whoami` as final fallback.
- Root-user guard: emits `ai_warn` (not `error`) so appliance installs are flagged but not blocked.
- `__INSTALL_USER__` placeholder substituted alongside existing placeholders in the same sed loop.
- `sudo install -m 644` to `/etc/systemd/system/`.
- All `systemctl` invocations use the `if sudo X 2>&1 | tee -a "$LOG_FILE" >/dev/null; then ... else ... fi` form (pipefail-aware; shellcheck SC2024-clean — avoids sudo redirection antipattern).
- `loginctl enable-linger` removed for the host-agent block; preserved for opencode-web and memory-shepherd which remain user-mode.

**`dream-server/dream-cli`** — `cmd_agent` start/stop/status-detection: `systemctl --user X` → `sudo systemctl X` (3 lines). Detection condition updated to match the installer guard (`systemctl status || [[ -d /run/systemd/system ]]`).

**`dream-server/dream-uninstall.sh`** — existing user-mode cleanup block preserved (handles migration-leftover case). Appended idempotent system-unit cleanup: `is-enabled`-gated `disable --now`, `rm -f /etc/systemd/system/dream-host-agent.service`, `daemon-reload`.

## Testing
- Automated: shellcheck clean (warning-parity with baseline); `make lint` passes; no SC2024 warnings introduced.
- Manual (live install on CachyOS sandbox, `--all --non-interactive` via `sudo bash install.sh`):
  - System-mode unit installed at `/etc/systemd/system/dream-host-agent.service`
  - Unit active and running (`Active: active (running)`)
  - `User=yasin` confirmed in unit status (resolved via SUDO_USER — correct for the `sudo bash install.sh` path)
  - `SupplementaryGroups=docker` present in unit file
  - `WantedBy=multi-user.target` confirmed; cgroup under `/system.slice/dream-host-agent.service`
  - Migration block ran cleanly with `✓ Migrated host agent from --user mode to system mode` log line (pre-existing user-mode unit was removed)
  - Port 7710 listening on 172.17.0.1 (docker bridge)
  - `/health` returns `{"status":"ok","version":"1.0.0"}`
  - `dream agent stop` and `dream agent start` work via cached sudo
  - Full stack came up (19+ containers healthy)
  - Dashboard HTTP 200 on :3001

## Review
Critique Guardian: APPROVED WITH WARNINGS (informational only). No required-before-merge items.

## Known Considerations

**Behavior change:** Non-interactive Linux installs without passwordless sudo now hard-fail at Phase 07. This mirrors the existing Phase 05 pattern — any CI flow that already passes Phase 05 will pass Phase 07.

**Pre-existing SIGTERM-handler issue surfaced (not introduced by this PR):** `dream agent stop` may end in `Active: failed (Result: timeout)` instead of a clean `inactive` state. The host-agent SIGTERM handler at `bin/dream-host-agent.py` blocks on `server.shutdown()` (a `ThreadingHTTPServer` that waits for in-flight requests); CachyOS systemd `DefaultTimeoutStopUSec=10s` escalates to SIGKILL after 10s. The identical handler exists on `upstream/main` — this is a pre-existing issue, not introduced by this change. The service still stops; just not cleanly. Filed as a separate follow-up for tracking.

**Follow-up issues to file post-merge:**
- Pre-start port-7710 collision check (prevent silent bind failure on reinstall).
- `dream-cli` non-tty sudo UX improvement: `sudo -n` probe + clear error message when cached credentials have expired.
- BATS coverage for the migration path (coordinate with PR #1102's test framework).
- Optional `unset _agent_user` at end of the install block for shell hygiene.

## Platform Impact
- **macOS Apple Silicon:** NOT AFFECTED — `installers/macos/install-macos.sh` is untouched; macOS uses launchd for the host agent separately.
- **Linux:** PRIMARY TARGET. All Linux installs migrate to the system-mode unit on next install. Any pre-existing `--user` unit is cleaned by the migration block.
- **Windows (WSL2):** AFFECTED (compatible). The `systemctl status || [[ -d /run/systemd/system ]]` guard covers WSL2-with-systemd. WSL2 without systemd falls through to `ai_warn "No systemd detected"` — same graceful behavior as before this change.
