### PR TITLE
ci(validate-compose): cover installer overlays via base+overlay merge

### DIFF
--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -5,12 +5,12 @@ on:
     branches: [main]
     paths:
       - "dream-server/docker-compose*.yml"
-      - "dream-server/compose/**"
+      - "dream-server/installers/**/*compose*.yml"
   pull_request:
     branches: [main]
     paths:
       - "dream-server/docker-compose*.yml"
-      - "dream-server/compose/**"
+      - "dream-server/installers/**/*compose*.yml"
 
 permissions:
   contents: read
@@ -29,25 +29,25 @@ jobs:
           echo "Validating dream-server/docker-compose.base.yml"
           docker compose -f dream-server/docker-compose.base.yml config --quiet
 
-      - name: Validate compose files in dream-server/compose/
+      - name: Validate installer compose overlays (base + overlay)
         env:
           WEBUI_SECRET: ci-placeholder
         run: |
-          compose_files=$(find dream-server/compose/ -name '*.yml' -type f 2>/dev/null || true)
+          compose_files=$(find dream-server/installers -name '*compose*.yml' -type f 2>/dev/null || true)
 
           if [ -z "$compose_files" ]; then
-            echo "No compose files found in dream-server/compose/"
+            echo "No installer compose files found under dream-server/installers/"
             exit 0
           fi
 
-          echo "Found compose files:"
+          echo "Found installer compose overlays:"
           echo "$compose_files"
           echo ""
 
           failed=0
           for f in $compose_files; do
-            echo "Validating $f ..."
-            if docker compose -f "$f" config --quiet 2>&1; then
+            echo "Validating $f (merged with docker-compose.base.yml) ..."
+            if docker compose -f dream-server/docker-compose.base.yml -f "$f" config --quiet 2>&1; then
               echo "  OK"
             else
               echo "  FAILED"
@@ -57,9 +57,9 @@ jobs:
 
           if [ "$failed" -ne 0 ]; then
             echo ""
-            echo "One or more compose files failed validation."
+            echo "One or more installer compose overlays failed validation."
             exit 1
           fi
 
           echo ""
-          echo "All compose files validated successfully."
+          echo "All installer compose overlays validated successfully."

--- a/dream-server/extensions/services/litellm/compose.apple.yaml
+++ b/dream-server/extensions/services/litellm/compose.apple.yaml
@@ -1,0 +1,8 @@
+# LiteLLM macOS Apple Silicon overlay — adds host-gateway resolution so the
+# litellm container can reach the natively-running llama-server on the macOS
+# host via the hostname `llama-server` (not in Docker on macOS, so DNS would
+# otherwise fail).
+services:
+  litellm:
+    extra_hosts:
+      - "llama-server:host-gateway"

--- a/dream-server/installers/macos/docker-compose.macos.yml
+++ b/dream-server/installers/macos/docker-compose.macos.yml
@@ -61,7 +61,3 @@ services:
         condition: service_healthy
     environment:
       OPENAI_API_BASE_URL: "http://host.docker.internal:8080/v1"
-
-  litellm:
-    extra_hosts:
-      - "llama-server:host-gateway"

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -830,6 +830,17 @@ else
 
             REL_PATH="${COMPOSE_PATH#"${INSTALL_DIR}/"}"
             COMPOSE_FLAGS+=("-f" "$REL_PATH")
+
+            # GPU-backend overlay (mirrors resolve-compose-stack.sh discovery).
+            # E.g. extensions/services/litellm/compose.apple.yaml on macOS.
+            # Skipped in cloud mode (CURRENT_BACKEND=none) since no native
+            # GPU/host-gateway patches apply when llama-server runs remotely.
+            if [[ "$CURRENT_BACKEND" != "none" ]]; then
+                GPU_OVERLAY_PATH="${SVC_DIR}compose.${CURRENT_BACKEND}.yaml"
+                if [[ -f "$GPU_OVERLAY_PATH" ]]; then
+                    COMPOSE_FLAGS+=("-f" "${GPU_OVERLAY_PATH#"${INSTALL_DIR}/"}")
+                fi
+            fi
         done
     fi
 


### PR DESCRIPTION
## What
Three coordinated changes that together close a CI gap on installer compose overlays:
- **CI**: extend `validate-compose.yml` paths filter and validation step to cover `dream-server/installers/**/*compose*.yml` (mac + windows-amd overlays).
- **Architecture**: move the cross-extension `litellm.extra_hosts` patch out of the macOS platform overlay into `extensions/services/litellm/compose.apple.yaml`, matching the existing per-extension overlay convention.
- **Installer**: `install-macos.sh` now scans `compose.{backend}.yaml` overlays during manifest discovery (latent gap that would silently miss any apple-specific extension overlay on first install).

## Why
The previous paths filter pointed at `dream-server/compose/**` — a directory that does not exist. The workflow was never triggering on installer compose changes, and its compose-validation step has been a no-op since it was added (`find` on a missing directory returns empty, step exits 0).

Naively adding installer overlays to the filter exposes a deeper issue: the macOS overlay patches `litellm.extra_hosts`, but `litellm` is defined in `extensions/services/litellm/`, not base. Standalone `docker compose -f base -f overlay config` fails with `service "litellm" has neither an image nor a build context specified`. The patch belonged with the extension all along — every other GPU/mode-specific extension patch (`compose.amd.yaml`, `compose.nvidia.yaml`, `compose.local.yaml`) follows that convention.

Moving the patch then exposed a third issue: `install-macos.sh:746-833` builds `COMPOSE_FLAGS` by hand and never scanned `compose.{backend}.yaml` per extension. The resolver in `scripts/resolve-compose-stack.sh:189-191` does, and `dream-cli` / `dream-macos.sh` fall back to the resolver — but `install-macos.sh` writes `.compose-flags` from the hand-built array on first install. Without the installer fix, the new `compose.apple.yaml` (and any future apple-specific extension fragment) would silently miss on macOS first install.

## How
- `.github/workflows/validate-compose.yml`: paths filter swap (`compose/**` → `installers/**/*compose*.yml`), and replace the dead "Validate compose files in dream-server/compose/" step with "Validate installer compose overlays (base + overlay)" using `docker compose -f base -f overlay config --quiet`.
- `dream-server/installers/macos/docker-compose.macos.yml`: remove the 4-line `litellm:` block.
- `dream-server/extensions/services/litellm/compose.apple.yaml`: new 8-line fragment carrying the `extra_hosts: ["llama-server:host-gateway"]` patch.
- `dream-server/installers/macos/install-macos.sh`: append a GPU-backend overlay scan inside the manifest discovery loop, mirroring `resolve-compose-stack.sh:189-191`. Gated by `CURRENT_BACKEND != "none"` so cloud mode is unaffected.

## Testing
**Automated (run locally; will run in CI on this branch via the new path filter):**
- [x] `docker compose -f base -f installers/macos/docker-compose.macos.yml config --quiet` — exit 0 (was failing pre-PR).
- [x] `docker compose -f base -f installers/windows/docker-compose.windows-amd.yml config --quiet` — exit 0.
- [x] `docker compose -f base -f extensions/services/litellm/compose.yaml -f extensions/services/litellm/compose.apple.yaml config --quiet` — exit 0; resulting `litellm.extra_hosts` resolves to `llama-server=host-gateway`.
- [x] `bash scripts/resolve-compose-stack.sh --gpu-backend apple` — includes `extensions/services/litellm/compose.apple.yaml`.
- [x] `bash scripts/resolve-compose-stack.sh --gpu-backend nvidia` — does NOT include `compose.apple.yaml` (no leakage to non-apple backends).
- [x] `make lint`, `bash tests/test-tier-map.sh`, `bash tests/contracts/test-installer-contracts.sh` — all PASS.
- [x] `bash -n install-macos.sh`, `shellcheck -S warning install-macos.sh` — clean (zero new warnings; pre-change baseline also clean).

**Manual (requires Apple Silicon hardware):**
- [ ] Re-run macOS installer on Apple Silicon; confirm `docker exec dream-litellm cat /etc/hosts | grep llama-server` shows the host-gateway mapping.
- [ ] `bash -x install-macos.sh 2>&1 | grep 'compose.apple.yaml'` shows the new fragment being appended to `COMPOSE_FLAGS`.

## Review
- **Verifier**: ✅ CONFIRMED. Original "base + overlay" prescription was incomplete because the macOS overlay patches an extension-defined service (`litellm`) — required architectural refactor to validate clean.
- **Tester**: PASS WITH NOTES. All 14 mechanical checks pass. Two non-blocking observations: (1) the new CI step's `find` glob does not cover `extensions/services/**/compose.*.yaml` — same pre-existing gap as for sibling fragments, (2) `*compose*.yml` glob excludes `.yaml` extensions used by extension fragments. Both out of scope for this PR.
- **Critique Guardian**: APPROVED, no required-before-merge. Specifically validated:
  - macOS dashboard-driven enable/disable: not affected — host-agent's `/v1/compose/invalidate-cache` clears the cache on every enable/disable; `dream-macos.sh:111-133` falls back to the resolver, which picks up `compose.apple.yaml`.
  - `CURRENT_BACKEND="apple"` hardcode in `install-macos.sh:759`: safe — macOS Intel is not a supported install path.
  - Cloud mode: gated correctly via `CURRENT_BACKEND != "none"`; no overlay applied when llama-server is remote.

## Known Considerations
1. **Extension overlay CI gap**: `extensions/services/**/compose.*.yaml` (including this PR's new fragment, and pre-existing siblings like `litellm/compose.amd.yaml`) still get no direct compose-validation in CI. Out of scope here — the new fragment follows the same pattern as its siblings. Worth a follow-up to extend the new step.
2. **Windows installer parallel gap**: `installers/windows/install-windows.ps1:556-562` only scans `compose.nvidia.yaml`, never `compose.amd.yaml` / `compose.cpu.yaml`. Same class of latent bug this PR fixes for macOS, on the PowerShell side. Out of scope.
3. **Windows-AMD litellm host-gateway**: `installers/windows/docker-compose.windows-amd.yml` does not patch litellm at all. If a Windows-AMD user runs litellm with native llama-server on host, the same DNS-resolution failure this PR fixes for macOS will reproduce. Cleanest fix is `extensions/services/litellm/compose.local.yaml` (the resolver already includes that fragment for `local` / `hybrid` / `lemonade` modes on non-Apple). Out of scope.

## Platform Impact
- **macOS Apple Silicon**: ✅ improved. The litellm host-gateway patch now travels with the extension; first-install scan picks up `compose.apple.yaml`; CI now actually validates the macOS overlay merge. No behavior change for end users — the runtime stack resolves to the same compose graph.
- **Linux (NVIDIA / AMD)**: untouched. `install-macos.sh` is mac-only; `compose.apple.yaml` only loads when `gpu_backend == "apple"` in the resolver. New CI step also validates that no Linux compose path was broken.
- **Windows WSL2 / AMD**: ✅ improved. The Windows AMD overlay was not validated by CI before; now it is (`installers/windows/docker-compose.windows-amd.yml` merges clean with base, verified locally). No installer changes — the `install-windows.ps1` parallel gap is acknowledged for follow-up.