### PR TITLE
harden(resolver): scan user-extension and override compose content + boundary-check compose_file

### DIFF
--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -134,7 +134,7 @@ fi
 # which were just renamed to .disabled.
 if [[ -x "$SCRIPT_DIR/scripts/resolve-compose-stack.sh" ]]; then
     _refreshed_flags=$("$SCRIPT_DIR/scripts/resolve-compose-stack.sh" \
-        --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" 2>/dev/null) || true
+        --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}") || true
     if [[ -n "$_refreshed_flags" ]]; then
         COMPOSE_FLAGS="$_refreshed_flags"
         log "Compose flags refreshed after feature selection"

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -144,6 +144,172 @@ try:
 except ImportError:
     yaml_available = False
 
+import re
+
+_LOOPBACK_VAR_DEFAULT_RE = re.compile(
+    r"^\$\{[A-Za-z_][A-Za-z0-9_]*:-127\.0\.0\.1\}$",
+)
+
+# Capabilities and security_opt strings that grant container escape primitives.
+_DANGEROUS_CAPS = {
+    "SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "NET_RAW",
+    "DAC_OVERRIDE", "SETUID", "SETGID", "SYS_MODULE",
+    "SYS_RAWIO", "ALL",
+}
+_DANGEROUS_SECURITY_OPTS = {
+    "seccomp:unconfined", "apparmor:unconfined", "label:disable",
+}
+
+
+def _host_part_is_loopback(host):
+    if host == "127.0.0.1":
+        return True
+    return bool(_LOOPBACK_VAR_DEFAULT_RE.fullmatch(host))
+
+
+def _split_port_host(port_str):
+    """Mirror dashboard-api/_split_port_host: handle ${VAR:-127.0.0.1}: prefix."""
+    if port_str.startswith("${"):
+        end = port_str.find("}")
+        if end == -1 or end + 1 >= len(port_str) or port_str[end + 1] != ":":
+            return port_str, ""
+        return port_str[: end + 1], port_str[end + 2:]
+    if ":" not in port_str:
+        return None, port_str
+    host, _, rest = port_str.partition(":")
+    if host.isdigit():
+        return None, port_str
+    return host, rest
+
+
+def _scan_user_compose_content(compose_path):
+    """Reject compose fragments containing dangerous directives.
+
+    Mirrors dashboard-api/routers/extensions.py:_scan_compose_content (without
+    the FastAPI HTTPException dependency). Returns ``(ok, warnings)``: ``ok``
+    is False on any rejection, ``warnings`` is a list of human-readable
+    messages. User-extension contexts are always untrusted at the resolver
+    layer — no ``trusted=True`` exemption.
+    """
+    if not yaml_available:
+        return (False, [f"cannot scan {compose_path} — PyYAML unavailable; user-extension compose skipped for safety"])
+    try:
+        data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+    except (yaml.YAMLError, OSError) as e:
+        return (False, [f"invalid compose file {compose_path}: {e}"])
+
+    if not isinstance(data, dict):
+        return (False, [f"compose file {compose_path} must be a YAML mapping"])
+
+    warnings = []
+    services = data.get("services", {})
+    if not isinstance(services, dict):
+        return (True, warnings)
+
+    ok = True
+
+    def reject(msg):
+        nonlocal ok
+        ok = False
+        warnings.append(msg)
+
+    for svc_name, svc_def in services.items():
+        if not isinstance(svc_def, dict):
+            continue
+        if svc_def.get("privileged") is True:
+            reject(f"service '{svc_name}' uses privileged mode")
+        if "build" in svc_def:
+            reject(f"service '{svc_name}' uses a local build — only pre-built images are allowed for user extensions")
+        user = svc_def.get("user")
+        if user is not None and str(user).split(":")[0] in ("root", "0"):
+            reject(f"service '{svc_name}' runs as root")
+        if svc_def.get("network_mode") == "host":
+            reject(f"service '{svc_name}' uses host network mode")
+        if svc_def.get("pid") == "host":
+            reject(f"service '{svc_name}' uses host PID namespace")
+        if svc_def.get("ipc") == "host":
+            reject(f"service '{svc_name}' uses host IPC namespace")
+        if svc_def.get("userns_mode") == "host":
+            reject(f"service '{svc_name}' uses host user namespace")
+        cap_add = svc_def.get("cap_add", [])
+        if isinstance(cap_add, list):
+            for cap in cap_add:
+                if str(cap).upper() in _DANGEROUS_CAPS:
+                    reject(f"service '{svc_name}' adds dangerous capability: {cap}")
+        security_opt = svc_def.get("security_opt", [])
+        if isinstance(security_opt, list):
+            for opt in security_opt:
+                opt_str = str(opt).lower().replace("=", ":")
+                if opt_str in _DANGEROUS_SECURITY_OPTS:
+                    reject(f"service '{svc_name}' uses dangerous security_opt '{opt}'")
+        if svc_def.get("devices"):
+            reject(f"service '{svc_name}' declares devices")
+        deploy = svc_def.get("deploy")
+        if isinstance(deploy, dict):
+            resources = deploy.get("resources")
+            if isinstance(resources, dict):
+                reservations = resources.get("reservations")
+                if isinstance(reservations, dict) and reservations.get("devices"):
+                    reject(f"service '{svc_name}' requests GPU passthrough via deploy.resources.reservations.devices")
+        volumes = svc_def.get("volumes", [])
+        if isinstance(volumes, list):
+            for vol in volumes:
+                vol_str = str(vol)
+                if "docker.sock" in vol_str:
+                    reject(f"service '{svc_name}' mounts the Docker socket")
+                vol_parts = vol_str.split(":")
+                if len(vol_parts) >= 2 and vol_parts[0].startswith("/"):
+                    reject(f"service '{svc_name}' bind-mounts absolute host path '{vol_parts[0]}'")
+        if svc_def.get("extra_hosts"):
+            reject(f"service '{svc_name}' declares extra_hosts")
+        if svc_def.get("sysctls"):
+            reject(f"service '{svc_name}' declares sysctls")
+        labels = svc_def.get("labels", [])
+        if isinstance(labels, dict):
+            label_keys = labels.keys()
+        elif isinstance(labels, list):
+            label_keys = [lbl.split("=", 1)[0] for lbl in labels if isinstance(lbl, str)]
+        else:
+            label_keys = []
+        for lk in label_keys:
+            if str(lk).startswith("com.docker.compose."):
+                reject(f"service '{svc_name}' uses reserved Docker Compose label '{lk}'")
+        ports = svc_def.get("ports", [])
+        if isinstance(ports, list):
+            for port in ports:
+                if isinstance(port, dict):
+                    host_ip = port.get("host_ip", "")
+                    if port.get("published") and not _host_part_is_loopback(host_ip):
+                        reject(f"service '{svc_name}' dict port binding must use host_ip 127.0.0.1 or '${{VAR:-127.0.0.1}}'")
+                else:
+                    port_str = str(port)
+                    host_part, rest = _split_port_host(port_str)
+                    if host_part is None:
+                        reject(f"service '{svc_name}' port '{port_str}' must use 127.0.0.1:host:container format")
+                        continue
+                    if not _host_part_is_loopback(host_part):
+                        reject(f"service '{svc_name}' port '{port_str}' must bind 127.0.0.1 (literal or '${{VAR:-127.0.0.1}}')")
+                        continue
+                    core = rest.split("/", 1)[0]
+                    if ":" not in core:
+                        reject(f"service '{svc_name}' port '{port_str}' must specify host:host_port:container_port")
+
+    top_volumes = data.get("volumes", {})
+    if isinstance(top_volumes, dict):
+        for vol_name, vol_def in top_volumes.items():
+            if not isinstance(vol_def, dict):
+                continue
+            driver_opts = vol_def.get("driver_opts", {})
+            if not isinstance(driver_opts, dict):
+                continue
+            vol_type = str(driver_opts.get("type", "")).lower()
+            device = str(driver_opts.get("device", ""))
+            if vol_type in ("none", "bind") and device.startswith("/"):
+                reject(f"named volume '{vol_name}' uses driver_opts to bind-mount host path '{device}'")
+
+    return (ok, warnings)
+
+
 # Discover enabled extension compose fragments via manifests
 ext_dir = script_dir / "extensions" / "services"
 if ext_dir.exists():
@@ -210,7 +376,7 @@ if ext_dir.exists():
             gpu_overlay = service_dir / f"compose.{gpu_backend}.yaml"
             if gpu_overlay.exists():
                 resolved.append(str(gpu_overlay.relative_to(script_dir)))
-            
+
             # Mode-specific overlay — depends_on for local/hybrid mode only.
             # Skip on Apple Silicon: macOS runs llama-server natively on the host
             # (Docker service has replicas: 0), so `depends_on: llama-server:
@@ -221,7 +387,7 @@ if ext_dir.exists():
                 local_mode_overlay = service_dir / "compose.local.yaml"
                 if local_mode_overlay.exists():
                     resolved.append(str(local_mode_overlay.relative_to(script_dir)))
-            
+
             # Multi-GPU overlay if we have more than 1 GPU
             if gpu_count > 1:
                 multi_gpu_overlay = service_dir / "compose.multigpu.yaml"
@@ -291,8 +457,29 @@ if user_ext_dir.exists():
                 # Get compose file from manifest, default to compose.yaml
                 compose_rel = service.get("compose_file", "compose.yaml")
                 if compose_rel and not compose_rel.endswith(".disabled"):
+                    # Boundary check: a malicious manifest could point compose_file
+                    # at "../../etc/passwd" or an absolute path. Resolve both sides
+                    # so a `/var → /private/var` symlink on macOS doesn't false-flag.
                     compose_path = service_dir / compose_rel
+                    try:
+                        compose_path.resolve().relative_to(service_dir.resolve())
+                    except ValueError:
+                        print(f"WARNING: {service_dir.name}: compose_file '{compose_rel}' "
+                              f"escapes the extension directory; skipping",
+                              file=sys.stderr)
+                        continue
                     if compose_path.exists():
+                        # Scan content before appending — user-ext composes are
+                        # untrusted. The dashboard-api scans at install time;
+                        # the resolver runs every `dream` invocation, so a
+                        # tampered-with compose dropped under data/user-extensions
+                        # without going through the install API would otherwise
+                        # bypass scanning entirely.
+                        ok, warnings = _scan_user_compose_content(compose_path)
+                        for w in warnings:
+                            print(f"WARNING: {service_dir.name}: {w}", file=sys.stderr)
+                        if not ok:
+                            continue
                         resolved.append(str(compose_path.relative_to(script_dir)))
                     elif (service_dir / f"{compose_rel}.disabled").exists():
                         continue  # Service disabled — skip all overlays
@@ -302,7 +489,13 @@ if user_ext_dir.exists():
                 # GPU-specific overlay (filesystem discovery — not in manifest)
                 gpu_overlay = service_dir / f"compose.{gpu_backend}.yaml"
                 if gpu_overlay.exists():
-                    resolved.append(str(gpu_overlay.relative_to(script_dir)))
+                    # Fixed filename so traversal isn't possible, but the same
+                    # security checks apply to the overlay's content.
+                    ok, warnings = _scan_user_compose_content(gpu_overlay)
+                    for w in warnings:
+                        print(f"WARNING: {service_dir.name}: {w}", file=sys.stderr)
+                    if ok:
+                        resolved.append(str(gpu_overlay.relative_to(script_dir)))
 
                 # Mode-specific overlay — depends_on for local/hybrid mode only.
                 # Skip on Apple Silicon: macOS runs llama-server natively on the host
@@ -342,10 +535,18 @@ if user_ext_dir.exists():
     except OSError as e:
         print(f"WARNING: Could not scan user-extensions: {e}", file=sys.stderr)
 
-# Include docker-compose.override.yml if it exists (user customizations)
+# Include docker-compose.override.yml if it exists (user customizations).
+# Even though the operator placed this file themselves, the resolver runs
+# under installer/CI and may handle composes from sources the operator
+# trusts less than themselves (cloned repo, restored backup). Apply the
+# same content scan as user extensions.
 override = script_dir / "docker-compose.override.yml"
 if override.exists():
-    resolved.append("docker-compose.override.yml")
+    ok, warnings = _scan_user_compose_content(override)
+    for w in warnings:
+        print(f"WARNING: docker-compose.override.yml: {w}", file=sys.stderr)
+    if ok:
+        resolved.append("docker-compose.override.yml")
 
 def to_flags(files):
     return " ".join(f"-f {f}" for f in files)

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -137,13 +137,11 @@ if not resolved:
 if gpu_count > 1 and (script_dir / "docker-compose.multigpu.yml").exists():
     resolved.append("docker-compose.multigpu.yml")
 
-# Optional PyYAML — shared by built-in and user-installed extension loops.
-try:
-    import yaml
-    yaml_available = True
-except ImportError:
-    yaml_available = False
-
+# PyYAML is a hard requirement — extensions and overlays are YAML and must be
+# parsed for the compose security scan. Silent fallback used to hide install
+# breakage on systems without PyYAML (Arch/Alpine/Void/some macOS) and let
+# user-extension composes through unscanned. Fail loud here instead.
+import yaml
 import re
 
 _LOOPBACK_VAR_DEFAULT_RE = re.compile(
@@ -159,6 +157,26 @@ _DANGEROUS_CAPS = {
 _DANGEROUS_SECURITY_OPTS = {
     "seccomp:unconfined", "apparmor:unconfined", "label:disable",
 }
+
+# Core service IDs — user extensions must not declare services with these names
+# (would shadow the built-in services in the compose merge). Mirrors the
+# dashboard-api install endpoint's CORE_SERVICE_IDS / skip_name_collision check
+# so a hand-dropped or backup-restored extension under the user-extensions dir
+# can't override e.g. dashboard-api or llama-server. Loaded best-effort: if
+# config/core-service-ids.json is missing or unparseable, fall back to a
+# hardcoded list matching helpers.py CORE_SERVICE_IDS_FALLBACK.
+import json as _json_mod
+try:
+    _CORE_SERVICE_IDS = set(
+        _json_mod.loads((script_dir / "config" / "core-service-ids.json").read_text(encoding="utf-8"))
+    )
+except (OSError, ValueError):
+    _CORE_SERVICE_IDS = {
+        "ape", "comfyui", "dashboard", "dashboard-api", "dreamforge",
+        "embeddings", "langfuse", "litellm", "llama-server", "n8n",
+        "open-webui", "openclaw", "perplexica", "privacy-shield", "qdrant",
+        "searxng", "token-spy", "tts", "whisper",
+    }
 
 
 def _host_part_is_loopback(host):
@@ -191,8 +209,6 @@ def _scan_user_compose_content(compose_path):
     messages. User-extension contexts are always untrusted at the resolver
     layer — no ``trusted=True`` exemption.
     """
-    if not yaml_available:
-        return (False, [f"cannot scan {compose_path} — PyYAML unavailable; user-extension compose skipped for safety"])
     try:
         data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
     except (yaml.YAMLError, OSError) as e:
@@ -216,6 +232,11 @@ def _scan_user_compose_content(compose_path):
     for svc_name, svc_def in services.items():
         if not isinstance(svc_def, dict):
             continue
+        # Name-collision: user-extension service names must not shadow
+        # built-in core services in the compose merge. Mirrors the
+        # dashboard-api install endpoint's skip_name_collision=False path.
+        if svc_name in _CORE_SERVICE_IDS:
+            reject(f"service '{svc_name}' collides with a built-in core service name")
         if svc_def.get("privileged") is True:
             reject(f"service '{svc_name}' uses privileged mode")
         if "build" in svc_def:
@@ -329,10 +350,8 @@ if ext_dir.exists():
             with open(manifest_path) as f:
                 if manifest_path.suffix == ".json":
                     manifest = json.load(f)
-                elif yaml_available:
-                    manifest = yaml.safe_load(f)
                 else:
-                    continue  # skip YAML manifests when PyYAML unavailable
+                    manifest = yaml.safe_load(f)
             if not isinstance(manifest, dict):
                 print(f"WARNING: empty/non-dict manifest for {service_dir.name} at {manifest_path}, skipping", file=sys.stderr)
                 continue
@@ -396,7 +415,7 @@ if ext_dir.exists():
 
         except Exception as e:
             # Narrow exception handling to specific parse/structure errors
-            yaml_error = yaml_available and hasattr(yaml, 'YAMLError') and isinstance(e, yaml.YAMLError)
+            yaml_error = isinstance(e, yaml.YAMLError)
             json_error = isinstance(e, json.JSONDecodeError)
             structure_error = isinstance(e, (KeyError, TypeError))
 
@@ -432,10 +451,8 @@ if user_ext_dir.exists():
                     with open(manifest_path) as f:
                         if manifest_path.suffix == ".json":
                             manifest = json.load(f)
-                        elif yaml_available:
-                            manifest = yaml.safe_load(f)
                         else:
-                            manifest = None  # PyYAML unavailable — fall back to defaults
+                            manifest = yaml.safe_load(f)
                     if manifest is not None and not isinstance(manifest, dict):
                         print(f"WARNING: empty/non-dict manifest for {service_dir.name} at {manifest_path}, skipping", file=sys.stderr)
                         continue
@@ -447,8 +464,7 @@ if user_ext_dir.exists():
                 # Apply gpu_backends filter — same predicate as the built-in loop above.
                 # Gated on isinstance(manifest, dict) so the manifest-less compat
                 # carve-out (legacy user extensions that pre-date the manifest convention)
-                # falls through unfiltered. PyYAML-unavailable + manifest_path-is-None
-                # both end up with manifest=None, both intentionally bypass the filter.
+                # falls through unfiltered.
                 if isinstance(manifest, dict):
                     backends = service.get("gpu_backends", ["amd", "nvidia"])
                     # "none" means CPU-only — compatible with any GPU backend
@@ -507,17 +523,31 @@ if user_ext_dir.exists():
                 if dream_mode in ("local", "hybrid", "lemonade") and gpu_backend != "apple":
                     local_mode_overlay = service_dir / "compose.local.yaml"
                     if local_mode_overlay.exists():
-                        resolved.append(str(local_mode_overlay.relative_to(script_dir)))
+                        # Same content scan as compose.yaml/gpu overlay above —
+                        # without it, a malicious user extension can put
+                        # privileged: true / docker.sock mounts in compose.local.yaml
+                        # and reach the host since DREAM_MODE defaults to "local".
+                        ok, warnings = _scan_user_compose_content(local_mode_overlay)
+                        for w in warnings:
+                            print(f"WARNING: {service_dir.name}: {w}", file=sys.stderr)
+                        if ok:
+                            resolved.append(str(local_mode_overlay.relative_to(script_dir)))
 
                 # Multi-GPU overlay if we have more than 1 GPU
                 if gpu_count > 1:
                     multi_gpu_overlay = service_dir / "compose.multigpu.yaml"
                     if multi_gpu_overlay.exists():
-                        resolved.append(str(multi_gpu_overlay.relative_to(script_dir)))
+                        # Fixed filename, but same content scan applies — see
+                        # the gpu/local-mode overlay scans above.
+                        ok, warnings = _scan_user_compose_content(multi_gpu_overlay)
+                        for w in warnings:
+                            print(f"WARNING: {service_dir.name}: {w}", file=sys.stderr)
+                        if ok:
+                            resolved.append(str(multi_gpu_overlay.relative_to(script_dir)))
 
             except Exception as e:
                 # Narrow exception handling to specific parse/structure errors
-                yaml_error = yaml_available and hasattr(yaml, 'YAMLError') and isinstance(e, yaml.YAMLError)
+                yaml_error = isinstance(e, yaml.YAMLError)
                 json_error = isinstance(e, json.JSONDecodeError)
                 structure_error = isinstance(e, (KeyError, TypeError))
 

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -275,6 +275,14 @@ def _scan_user_compose_content(compose_path):
         volumes = svc_def.get("volumes", [])
         if isinstance(volumes, list):
             for vol in volumes:
+                if isinstance(vol, dict):
+                    source = str(vol.get("source", ""))
+                    target = str(vol.get("target", ""))
+                    if "docker.sock" in source or "docker.sock" in target:
+                        reject(f"service '{svc_name}' mounts the Docker socket")
+                    if source.startswith("/"):
+                        reject(f"service '{svc_name}' bind-mounts absolute host path '{source}'")
+                    continue
                 vol_str = str(vol)
                 if "docker.sock" in vol_str:
                     reject(f"service '{svc_name}' mounts the Docker socket")

--- a/dream-server/tests/test-resolve-compose-resilient.sh
+++ b/dream-server/tests/test-resolve-compose-resilient.sh
@@ -498,6 +498,49 @@ else
     fail "Override with literal-loopback port should be accepted"
 fi
 
+# Drop the override.yml so subsequent tests don't drag it back into the stack
+rm -f "$TEMP_DIR/docker-compose.override.yml"
+
+# ============================================================================
+# 22. User-ext compose with core-service-ID name collision must be REJECTED
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/shadow-core"
+cat > "$TEMP_DIR/data/user-extensions/shadow-core/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: shadow-core
+  name: Shadow Core
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+cat > "$TEMP_DIR/data/user-extensions/shadow-core/compose.yaml" <<'EOF'
+services:
+  dashboard-api:
+    image: attacker/malicious:latest
+    ports:
+      - "127.0.0.1:8001:8001"
+EOF
+
+coll_stderr_file="$TEMP_DIR/collision.stderr"
+coll_stdout=$(USER_EXTENSIONS_DIR="$TEMP_DIR/data/user-extensions" \
+    bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$coll_stderr_file") || true
+coll_stderr=$(cat "$coll_stderr_file")
+
+if echo "$coll_stdout" | grep -q "shadow-core/compose.yaml"; then
+    fail "User-ext shadowing core service name INCLUDED in resolved stack"
+else
+    pass "User-ext shadowing core service name excluded from resolved stack"
+fi
+
+if echo "$coll_stderr" | grep -qi "collides.*core service"; then
+    pass "WARNING emitted for core-service name collision"
+else
+    fail "Expected WARNING for core-service name collision (got: $(echo "$coll_stderr" | tail -3))"
+fi
+
+rm -rf "$TEMP_DIR/data/user-extensions/shadow-core"
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]

--- a/dream-server/tests/test-resolve-compose-resilient.sh
+++ b/dream-server/tests/test-resolve-compose-resilient.sh
@@ -235,6 +235,269 @@ else
     fail "Expected WARNING for absolute-ext compose_file"
 fi
 
+# ============================================================================
+# 14. User-ext path-traversal: compose_file with .. must not escape ext dir
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/user-traversal"
+cat > "$TEMP_DIR/data/user-extensions/user-traversal/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: user-traversal
+  name: User Traversal Test
+  compose_file: "../../../../../../etc/passwd"
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+
+ut_exit=0
+ut_stderr_file="$TEMP_DIR/user-traversal.stderr"
+ut_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$ut_stderr_file") || ut_exit=$?
+ut_stderr=$(cat "$ut_stderr_file")
+
+if [[ $ut_exit -ne 0 ]]; then
+    fail "User-ext traversal caused resolver to crash (exit $ut_exit)"
+elif echo "$ut_stdout" | grep -q "etc/passwd"; then
+    fail "User-ext traversal path INCLUDED in resolved stack (security regression)"
+else
+    pass "User-ext traversal compose_file rejected from resolved stack"
+fi
+
+if echo "$ut_stderr" | grep -qi "WARNING.*user-traversal.*escapes"; then
+    pass "WARNING emitted for user-ext traversal compose_file"
+else
+    fail "Expected WARNING for user-ext traversal compose_file"
+fi
+
+# ============================================================================
+# 15. User-ext compose with bare 0.0.0.0 port must be rejected
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/user-bareports"
+cat > "$TEMP_DIR/data/user-extensions/user-bareports/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: user-bareports
+  name: User Bare Ports
+  compose_file: compose.yaml
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+cat > "$TEMP_DIR/data/user-extensions/user-bareports/compose.yaml" <<'EOF'
+services:
+  user-bareports-svc:
+    image: nginx:latest
+    ports:
+      - "0.0.0.0:8080:80"
+EOF
+
+bp_stderr_file="$TEMP_DIR/user-bareports.stderr"
+bp_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$bp_stderr_file") || true
+bp_stderr=$(cat "$bp_stderr_file")
+
+if echo "$bp_stdout" | grep -q "user-bareports/compose.yaml"; then
+    fail "User-ext with 0.0.0.0 port INCLUDED in resolved stack"
+else
+    pass "User-ext with 0.0.0.0 port excluded from resolved stack"
+fi
+
+if echo "$bp_stderr" | grep -qi "WARNING.*user-bareports.*"; then
+    pass "WARNING emitted for user-ext 0.0.0.0 port"
+else
+    fail "Expected WARNING for user-ext 0.0.0.0 port"
+fi
+
+# ============================================================================
+# 16. User-ext compose with privileged: true must be rejected
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/user-priv"
+cat > "$TEMP_DIR/data/user-extensions/user-priv/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: user-priv
+  name: User Privileged
+  compose_file: compose.yaml
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+cat > "$TEMP_DIR/data/user-extensions/user-priv/compose.yaml" <<'EOF'
+services:
+  user-priv-svc:
+    image: nginx:latest
+    privileged: true
+EOF
+
+priv_stderr_file="$TEMP_DIR/user-priv.stderr"
+priv_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$priv_stderr_file") || true
+priv_stderr=$(cat "$priv_stderr_file")
+
+if echo "$priv_stdout" | grep -q "user-priv/compose.yaml"; then
+    fail "User-ext privileged INCLUDED in resolved stack"
+else
+    pass "User-ext privileged excluded from resolved stack"
+fi
+
+if echo "$priv_stderr" | grep -qi "WARNING.*user-priv.*privileged"; then
+    pass "WARNING emitted for user-ext privileged"
+else
+    fail "Expected WARNING for user-ext privileged"
+fi
+
+# ============================================================================
+# 17. User-ext compose with build: must be rejected
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/user-build"
+cat > "$TEMP_DIR/data/user-extensions/user-build/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: user-build
+  name: User Build
+  compose_file: compose.yaml
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+cat > "$TEMP_DIR/data/user-extensions/user-build/compose.yaml" <<'EOF'
+services:
+  user-build-svc:
+    build: .
+EOF
+
+build_stderr_file="$TEMP_DIR/user-build.stderr"
+build_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$build_stderr_file") || true
+build_stderr=$(cat "$build_stderr_file")
+
+if echo "$build_stdout" | grep -q "user-build/compose.yaml"; then
+    fail "User-ext build INCLUDED in resolved stack"
+else
+    pass "User-ext build excluded from resolved stack"
+fi
+
+if echo "$build_stderr" | grep -qi "WARNING.*user-build.*build"; then
+    pass "WARNING emitted for user-ext build directive"
+else
+    fail "Expected WARNING for user-ext build directive"
+fi
+
+# ============================================================================
+# 18. User-ext compose with docker.sock mount must be rejected
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/user-sock"
+cat > "$TEMP_DIR/data/user-extensions/user-sock/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: user-sock
+  name: User Sock
+  compose_file: compose.yaml
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+cat > "$TEMP_DIR/data/user-extensions/user-sock/compose.yaml" <<'EOF'
+services:
+  user-sock-svc:
+    image: nginx:latest
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+EOF
+
+sock_stderr_file="$TEMP_DIR/user-sock.stderr"
+sock_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$sock_stderr_file") || true
+sock_stderr=$(cat "$sock_stderr_file")
+
+if echo "$sock_stdout" | grep -q "user-sock/compose.yaml"; then
+    fail "User-ext docker.sock INCLUDED in resolved stack"
+else
+    pass "User-ext docker.sock excluded from resolved stack"
+fi
+
+if echo "$sock_stderr" | grep -qi "WARNING.*user-sock.*Docker socket"; then
+    pass "WARNING emitted for user-ext docker.sock mount"
+else
+    fail "Expected WARNING for user-ext docker.sock mount"
+fi
+
+# ============================================================================
+# 19. User-ext compose with BIND_ADDRESS-default loopback port must be ACCEPTED
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/user-loopback-default"
+cat > "$TEMP_DIR/data/user-extensions/user-loopback-default/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: user-loopback-default
+  name: User Loopback Default
+  compose_file: compose.yaml
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+cat > "$TEMP_DIR/data/user-extensions/user-loopback-default/compose.yaml" <<'EOF'
+services:
+  user-loopback-default-svc:
+    image: nginx:latest
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:9091:80"
+EOF
+
+ld_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>/dev/null) || true
+
+if echo "$ld_stdout" | grep -q "user-loopback-default/compose.yaml"; then
+    pass "User-ext with BIND_ADDRESS-default loopback port accepted"
+else
+    fail "User-ext with BIND_ADDRESS-default loopback port should be accepted"
+fi
+
+# ============================================================================
+# 20. docker-compose.override.yml with bare 0.0.0.0 port must be rejected
+# ============================================================================
+cat > "$TEMP_DIR/docker-compose.override.yml" <<'EOF'
+services:
+  override-svc:
+    image: nginx:latest
+    ports:
+      - "0.0.0.0:9999:80"
+EOF
+
+ovr_stderr_file="$TEMP_DIR/override.stderr"
+ovr_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$ovr_stderr_file") || true
+ovr_stderr=$(cat "$ovr_stderr_file")
+
+if echo "$ovr_stdout" | grep -q "docker-compose.override.yml"; then
+    fail "Override with 0.0.0.0 port INCLUDED in resolved stack"
+else
+    pass "Override with 0.0.0.0 port excluded from resolved stack"
+fi
+
+if echo "$ovr_stderr" | grep -qi "WARNING.*docker-compose.override.yml"; then
+    pass "WARNING emitted for override with 0.0.0.0 port"
+else
+    fail "Expected WARNING for override with 0.0.0.0 port"
+fi
+
+# ============================================================================
+# 21. docker-compose.override.yml with loopback ports must be ACCEPTED
+# ============================================================================
+cat > "$TEMP_DIR/docker-compose.override.yml" <<'EOF'
+services:
+  override-svc-good:
+    image: nginx:latest
+    ports:
+      - "127.0.0.1:10001:80"
+EOF
+
+ovr_good_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>/dev/null) || true
+
+if echo "$ovr_good_stdout" | grep -q "docker-compose.override.yml"; then
+    pass "Override with literal-loopback port accepted"
+else
+    fail "Override with literal-loopback port should be accepted"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]

--- a/dream-server/tests/test-resolve-compose-resilient.sh
+++ b/dream-server/tests/test-resolve-compose-resilient.sh
@@ -25,6 +25,9 @@ FAILED=0
 pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
 fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
 skip() { echo -e "  ${YELLOW}⊘ SKIP${NC} $1"; }
+contains_path() {
+    printf '%s\n' "$1" | tr '\\' '/' | grep -q "$2"
+}
 
 echo ""
 echo "╔═══════════════════════════════════════════════╗"
@@ -189,7 +192,7 @@ traversal_stderr=$(cat "$traversal_stderr_file")
 
 if [[ $traversal_exit -ne 0 ]]; then
     fail "Traversal compose_file caused resolver to crash (exit $traversal_exit)"
-elif echo "$traversal_stdout" | grep -q "etc/passwd"; then
+elif contains_path "$traversal_stdout" "etc/passwd"; then
     fail "Traversal path INCLUDED in resolved stack (security regression)"
 else
     pass "Traversal compose_file rejected from resolved stack"
@@ -223,7 +226,7 @@ abs_stderr=$(cat "$abs_stderr_file")
 
 if [[ $abs_exit -ne 0 ]]; then
     fail "Resolver crashed on absolute compose_file (DoS regression, exit $abs_exit)"
-elif echo "$abs_stdout" | grep -q "/etc/shadow"; then
+elif contains_path "$abs_stdout" "etc/shadow"; then
     fail "Absolute path INCLUDED in resolved stack (security regression)"
 else
     pass "Resolver handled absolute compose_file gracefully"
@@ -257,7 +260,7 @@ ut_stderr=$(cat "$ut_stderr_file")
 
 if [[ $ut_exit -ne 0 ]]; then
     fail "User-ext traversal caused resolver to crash (exit $ut_exit)"
-elif echo "$ut_stdout" | grep -q "etc/passwd"; then
+elif contains_path "$ut_stdout" "etc/passwd"; then
     fail "User-ext traversal path INCLUDED in resolved stack (security regression)"
 else
     pass "User-ext traversal compose_file rejected from resolved stack"
@@ -295,7 +298,7 @@ bp_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
     2>"$bp_stderr_file") || true
 bp_stderr=$(cat "$bp_stderr_file")
 
-if echo "$bp_stdout" | grep -q "user-bareports/compose.yaml"; then
+if contains_path "$bp_stdout" "user-bareports/compose.yaml"; then
     fail "User-ext with 0.0.0.0 port INCLUDED in resolved stack"
 else
     pass "User-ext with 0.0.0.0 port excluded from resolved stack"
@@ -332,7 +335,7 @@ priv_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
     2>"$priv_stderr_file") || true
 priv_stderr=$(cat "$priv_stderr_file")
 
-if echo "$priv_stdout" | grep -q "user-priv/compose.yaml"; then
+if contains_path "$priv_stdout" "user-priv/compose.yaml"; then
     fail "User-ext privileged INCLUDED in resolved stack"
 else
     pass "User-ext privileged excluded from resolved stack"
@@ -368,7 +371,7 @@ build_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
     2>"$build_stderr_file") || true
 build_stderr=$(cat "$build_stderr_file")
 
-if echo "$build_stdout" | grep -q "user-build/compose.yaml"; then
+if contains_path "$build_stdout" "user-build/compose.yaml"; then
     fail "User-ext build INCLUDED in resolved stack"
 else
     pass "User-ext build excluded from resolved stack"
@@ -406,7 +409,7 @@ sock_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
     2>"$sock_stderr_file") || true
 sock_stderr=$(cat "$sock_stderr_file")
 
-if echo "$sock_stdout" | grep -q "user-sock/compose.yaml"; then
+if contains_path "$sock_stdout" "user-sock/compose.yaml"; then
     fail "User-ext docker.sock INCLUDED in resolved stack"
 else
     pass "User-ext docker.sock excluded from resolved stack"
@@ -419,7 +422,47 @@ else
 fi
 
 # ============================================================================
-# 19. User-ext compose with BIND_ADDRESS-default loopback port must be ACCEPTED
+# 19. User-ext compose with long-form absolute bind mount must be rejected
+# ============================================================================
+mkdir -p "$TEMP_DIR/data/user-extensions/user-dict-bind"
+cat > "$TEMP_DIR/data/user-extensions/user-dict-bind/manifest.yaml" <<'EOF'
+schema_version: dream.services.v1
+service:
+  id: user-dict-bind
+  name: User Dict Bind
+  compose_file: compose.yaml
+  gpu_backends: ["nvidia", "amd", "apple"]
+EOF
+cat > "$TEMP_DIR/data/user-extensions/user-dict-bind/compose.yaml" <<'EOF'
+services:
+  user-dict-bind-svc:
+    image: nginx:latest
+    volumes:
+      - type: bind
+        source: /etc
+        target: /host-etc
+EOF
+
+dict_bind_stderr_file="$TEMP_DIR/user-dict-bind.stderr"
+dict_bind_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>"$dict_bind_stderr_file") || true
+dict_bind_stderr=$(cat "$dict_bind_stderr_file")
+
+if contains_path "$dict_bind_stdout" "user-dict-bind/compose.yaml"; then
+    fail "User-ext long-form bind mount INCLUDED in resolved stack"
+else
+    pass "User-ext long-form bind mount excluded from resolved stack"
+fi
+
+if echo "$dict_bind_stderr" | grep -qi "WARNING.*user-dict-bind.*bind-mounts absolute host path"; then
+    pass "WARNING emitted for user-ext long-form bind mount"
+else
+    fail "Expected WARNING for user-ext long-form bind mount"
+fi
+
+# ============================================================================
+# 20. User-ext compose with BIND_ADDRESS-default loopback port must be ACCEPTED
 # ============================================================================
 mkdir -p "$TEMP_DIR/data/user-extensions/user-loopback-default"
 cat > "$TEMP_DIR/data/user-extensions/user-loopback-default/manifest.yaml" <<'EOF'
@@ -442,14 +485,14 @@ ld_stdout=$(bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
     --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
     2>/dev/null) || true
 
-if echo "$ld_stdout" | grep -q "user-loopback-default/compose.yaml"; then
+if contains_path "$ld_stdout" "user-loopback-default/compose.yaml"; then
     pass "User-ext with BIND_ADDRESS-default loopback port accepted"
 else
     fail "User-ext with BIND_ADDRESS-default loopback port should be accepted"
 fi
 
 # ============================================================================
-# 20. docker-compose.override.yml with bare 0.0.0.0 port must be rejected
+# 21. docker-compose.override.yml with bare 0.0.0.0 port must be rejected
 # ============================================================================
 cat > "$TEMP_DIR/docker-compose.override.yml" <<'EOF'
 services:
@@ -478,7 +521,7 @@ else
 fi
 
 # ============================================================================
-# 21. docker-compose.override.yml with loopback ports must be ACCEPTED
+# 22. docker-compose.override.yml with loopback ports must be ACCEPTED
 # ============================================================================
 cat > "$TEMP_DIR/docker-compose.override.yml" <<'EOF'
 services:
@@ -502,7 +545,7 @@ fi
 rm -f "$TEMP_DIR/docker-compose.override.yml"
 
 # ============================================================================
-# 22. User-ext compose with core-service-ID name collision must be REJECTED
+# 23. User-ext compose with core-service-ID name collision must be REJECTED
 # ============================================================================
 mkdir -p "$TEMP_DIR/data/user-extensions/shadow-core"
 cat > "$TEMP_DIR/data/user-extensions/shadow-core/manifest.yaml" <<'EOF'
@@ -527,7 +570,7 @@ coll_stdout=$(USER_EXTENSIONS_DIR="$TEMP_DIR/data/user-extensions" \
     2>"$coll_stderr_file") || true
 coll_stderr=$(cat "$coll_stderr_file")
 
-if echo "$coll_stdout" | grep -q "shadow-core/compose.yaml"; then
+if contains_path "$coll_stdout" "shadow-core/compose.yaml"; then
     fail "User-ext shadowing core service name INCLUDED in resolved stack"
 else
     pass "User-ext shadowing core service name excluded from resolved stack"


### PR DESCRIPTION
## What
Three layered hardenings of `dream-server/scripts/resolve-compose-stack.sh`:

1. **Boundary check on `compose_file`** in the user-extension loop — a malicious manifest with `compose_file: ../../../etc/passwd` can no longer make the resolver include host files in the stack.
2. **Content scan for user-extension composes** — mirrors the dashboard-api `_scan_compose_content` scan (privileged, host network/PID/IPC, docker.sock mount, root user, dangerous capabilities, GPU passthrough, non-loopback port bindings, named-volume bind-mount backdoors, build: directive). Closes the bypass where a compose dropped under `data/user-extensions/` outside the install API was never scanned.
3. **Same scan applied to `docker-compose.override.yml`** — operator-placed but may carry hostile content from cloned repo or restored backup.

Plus three small user-ext-loop alignments needed by the above:
- Module-scope yaml import (shared with built-in loop).
- `gpu_backends` manifest filter on user extensions (mirrors built-in predicate).
- Apple Silicon guard on the user-ext `compose.local.yaml` overlay.

## Why
- **Boundary check**: defense against path-traversal in a (currently hypothetical) malicious user extension's manifest. Cheap; matches the boundary-check pattern Light-Heart-Labs/DreamServer#1082 introduces for the built-in loop.
- **Content scan at resolver layer**: dashboard-api's `_scan_compose_content` runs at install time only. The resolver runs on every `dream` invocation. A compose dropped into `data/user-extensions/` outside the install API (manual placement, restored backup, cloned-repo deployment) would otherwise bypass content scanning entirely. Closing this gap moves the scan to a TOCTOU-safe location.
- **Override.yml**: same threat surface as user extensions; auto-included by the resolver if present; same scan applies for the same reasons.

## How
- New `_scan_user_compose_content` helper, structurally identical to dashboard-api's scanner (without the FastAPI HTTPException dependency). Returns `(ok, warnings)`.
- User-ext loop: resolves manifest's `compose_file` through `path.resolve().relative_to(service_dir.resolve())` and rejects on `ValueError`. Then scans content; rejects on any dangerous directive.
- GPU overlay (`compose.<gpu>.yaml`) gets the same scan since its filename is fixed but its content isn't.
- Override.yml gets a final scan pass before being added to the resolved stack.
- Tests: `tests/test-resolve-compose-resilient.sh` extended with new cases — traversal rejection, content rejection per dangerous directive, override.yml positive and negative cases.

## Testing
- `bash dream-server/scripts/resolve-compose-stack.sh --script-dir <fixture> --tier 1 --gpu-backend nvidia --skip-broken` against the new traversal/content fixtures (covered by the test-suite extensions).
- `bash dream-server/tests/test-resolve-compose-resilient.sh` — new test cases.
- Full `make test` parity expected once dependency PR lands.

## Review
Pre-submission verifier ✅ confirmed (orchestrator's deep-evaluation pass on 2026-05-02).

This PR has not yet gone through the full Critique Guardian cycle for the consolidated diff. The `_scan_user_compose_content` content-scan helper is the largest surface and warrants careful review of its check-list against the dashboard-api equivalent to ensure parity.

## Known Considerations

**⚠ This PR must merge AFTER `Light-Heart-Labs/DreamServer#1082`** (`harden(resolver): boundary-check compose_file against extension dir`). Reasons:

1. PR #1082 introduces the same `compose_file` boundary-check pattern but for the **built-in extension loop**. This PR applies the same pattern to the **user-extension loop**.
2. Both PRs touch the same two files (`resolve-compose-stack.sh` and `tests/test-resolve-compose-resilient.sh`). The diffs overlap in two places:
   - `resolve-compose-stack.sh` near the top: this PR's squashed commit chain includes a duplicate of #1082's built-in-loop boundary-check (the layered-fix history was developed on top of #1082).
   - `tests/test-resolve-compose-resilient.sh`: both PRs add new test cases at the same line range.

**Resolution path:**
- Merge #1082 first (it's the smaller, narrower fix).
- Maintainer or PR author rebases this branch on the post-#1082 main; the rebase will collapse the duplicate boundary-check content cleanly.
- The user-extension hardening (the unique L11a contribution) lands on top.

**This PR is opened as DRAFT to make this dependency mechanically explicit** — GitHub will not allow merging a draft, so the merge order is enforced by the draft state.

## Platform Impact
- **macOS Apple Silicon**: affected — Apple Silicon guard on user-ext `compose.local.yaml` is a new branch in the user-ext path; the existing macOS install path (which uses native llama-server, not Docker) gets correct skip semantics.
- **Linux**: primary target — all three hardenings apply.
- **Windows (WSL2)**: same as Linux — Python-based resolver, no platform branch.