### PR TITLE
fix(installer): handle stale empty keyring on re-install (apt --yes)

### DIFF
--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -355,7 +355,7 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
         ai "Installing NVIDIA Container Toolkit..."
         if ! $DRY_RUN; then
             # Add NVIDIA GPG key (used by apt and as trust anchor)
-            curl -fsSL --max-time 60 https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg 2>/dev/null || true
+            curl -fsSL --max-time 60 https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor --yes -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg 2>/dev/null || true
 
             # Distro-aware repo setup + install
             case "$PKG_MANAGER" in


### PR DESCRIPTION
## What
Add `--yes` flag to `gpg --dearmor` in Phase 05 NVIDIA Container Toolkit installation so re-installs over a stale 0-byte keyring file overwrite cleanly instead of failing.

## Why
`gpg --dearmor -o <existing-file>` prompts to overwrite; with stdin piped (`curl | gpg`), the prompt declines and gpg exits non-zero. Today this is silently masked by `2>/dev/null || true`. Once the masking goes away (Light-Heart-Labs/DreamServer#1071), this becomes fail-loud on re-install over a stale empty keyring.

## How
Single-token addition: `gpg --dearmor` → `gpg --dearmor --yes`.

## Testing
- `bash -n` clean
- `shellcheck` clean on touched line (only pre-existing warnings on untouched lines)
- Manual repro: pre-create empty keyring at `/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg`, run Phase 05, observe success vs prior failure

## Review
Critique Guardian: APPROVED. `--yes` only suppresses the file-overwrite prompt — it does NOT bypass signature verification or change the apt trust model.

## Known Considerations
- WSL2 Ubuntu hits this code path and benefits from the fix identically.

## Platform Impact
- macOS: N/A — Phase 05 is Linux-only.
- Linux: apt branch only — affects Debian/Ubuntu/Mint/Kali. pacman/dnf/zypper untouched.
- Windows: WSL2 Ubuntu hits this path; benefits identically.

Must merge after Light-Heart-Labs/DreamServer#1071.