### PR TITLE
fix(forge): defense-in-depth — disable bundled cloud-tunnel processes

### DIFF
--- a/resources/dev/extensions-library/services/forge/README.md
+++ b/resources/dev/extensions-library/services/forge/README.md
@@ -2,6 +2,14 @@
 
 The original Stable Diffusion web UI (based on Automatic1111). Features extensive model support, extensions, inpainting, outpainting, and professional-grade image generation capabilities.
 
+## Privacy & Defense-in-depth
+
+The upstream `ai-dock` Forge image bundles `syncthing`, `quicktunnel`, `serviceportal`, and `sshd` for cloud workflows. These are autostarted by the image's bundled supervisord and would otherwise expose the host to remote relays, tunnel endpoints, and inbound SSH on default install.
+
+DreamServer disables them via `SUPERVISOR_NO_AUTOSTART=syncthing,quicktunnel,serviceportal,sshd` in `compose.yaml`. To re-enable any of them, override that env var in your `.env` or a compose override.
+
+`cloudflared` is also bundled but only autostarts when `CF_TUNNEL_TOKEN` is set, so it stays a no-op by default.
+
 ## Requirements
 
 - **GPU:** NVIDIA (min 8 GB VRAM)

--- a/resources/dev/extensions-library/services/forge/README.md
+++ b/resources/dev/extensions-library/services/forge/README.md
@@ -4,9 +4,9 @@ The original Stable Diffusion web UI (based on Automatic1111). Features extensiv
 
 ## Privacy & Defense-in-depth
 
-The upstream `ai-dock` Forge image bundles `syncthing`, `quicktunnel`, `serviceportal`, and `sshd` for cloud workflows. These are autostarted by the image's bundled supervisord and would otherwise expose the host to remote relays, tunnel endpoints, and inbound SSH on default install.
+The upstream `ai-dock` Forge image bundles `syncthing`, `quicktunnel`, `serviceportal`, and `sshd` for cloud workflows, plus a `jupyter` notebook server. These are autostarted by the image's bundled supervisord and would otherwise expose the host to remote relays, tunnel endpoints, inbound SSH, and an unauthenticated notebook on default install.
 
-DreamServer disables them via `SUPERVISOR_NO_AUTOSTART=syncthing,quicktunnel,serviceportal,sshd` in `compose.yaml`. To re-enable any of them, override that env var in your `.env` or a compose override.
+DreamServer disables them via `SUPERVISOR_NO_AUTOSTART=syncthing,quicktunnel,serviceportal,sshd,jupyter` in `compose.yaml`. To re-enable any of them, override that env var in your `.env` or a compose override.
 
 `cloudflared` is also bundled but only autostarts when `CF_TUNNEL_TOKEN` is set, so it stays a no-op by default.
 

--- a/resources/dev/extensions-library/services/forge/compose.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.yaml
@@ -9,7 +9,7 @@ services:
       - FORGE_PORT_HOST=7861
       - FORGE_ARGS=--api --listen
       - AUTO_UPDATE=false
-      - SUPERVISOR_NO_AUTOSTART=syncthing
+      - SUPERVISOR_NO_AUTOSTART=syncthing,quicktunnel,serviceportal,sshd
     volumes:
       - ./data/forge/models:/opt/stable-diffusion-webui-forge/models:rw
       - ./data/forge/outputs:/opt/stable-diffusion-webui-forge/outputs:rw

--- a/resources/dev/extensions-library/services/forge/compose.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.yaml
@@ -9,7 +9,7 @@ services:
       - FORGE_PORT_HOST=7861
       - FORGE_ARGS=--api --listen
       - AUTO_UPDATE=false
-      - SUPERVISOR_NO_AUTOSTART=syncthing,quicktunnel,serviceportal,sshd
+      - SUPERVISOR_NO_AUTOSTART=syncthing,quicktunnel,serviceportal,sshd,jupyter
     volumes:
       - ./data/forge/models:/opt/stable-diffusion-webui-forge/models:rw
       - ./data/forge/outputs:/opt/stable-diffusion-webui-forge/outputs:rw

--- a/resources/dev/extensions-library/services/forge/compose.yaml
+++ b/resources/dev/extensions-library/services/forge/compose.yaml
@@ -9,7 +9,7 @@ services:
       - FORGE_PORT_HOST=7861
       - FORGE_ARGS=--api --listen
       - AUTO_UPDATE=false
-      - SUPERVISOR_NO_AUTOSTART=syncthing,quicktunnel,serviceportal,sshd,jupyter
+      - SUPERVISOR_NO_AUTOSTART=${SUPERVISOR_NO_AUTOSTART:-syncthing,quicktunnel,serviceportal,sshd,jupyter}
     volumes:
       - ./data/forge/models:/opt/stable-diffusion-webui-forge/models:rw
       - ./data/forge/outputs:/opt/stable-diffusion-webui-forge/outputs:rw


### PR DESCRIPTION
## What
Extend `SUPERVISOR_NO_AUTOSTART` in forge `compose.yaml` from `syncthing` to `syncthing,quicktunnel,serviceportal,sshd`. Add a Privacy & Defense-in-depth section to forge's README.

## Why
The upstream `ai-dock` Forge image bundles four processes that autostart by default and would otherwise expose:
- `syncthing` — public-relay outbound + inbound listener (already disabled by Light-Heart-Labs/DreamServer#1077)
- `quicktunnel` — outbound cloudflare tunnel
- `serviceportal` — inbound HTTP UI listing services (port 1111/11111)
- `sshd` — inbound SSH on `${SSH_PORT}`

Light-Heart-Labs/DreamServer#1077 disables only `syncthing`. This PR closes the wider attack surface for default installs.

## How
Single env-var value extension in `compose.yaml`. README gains a 6-line Privacy section that documents the bundled processes, the override path, and the `cloudflared` carve-out.

`cloudflared` is excluded from the disable list — it is gated on `CF_TUNNEL_TOKEN` upstream and is a no-op without the token.

## Testing
- yamllint clean
- `docker compose -f resources/dev/extensions-library/services/forge/compose.yaml config --quiet` exit 0
- Manual: `docker exec dream-forge supervisorctl status` should show `sshd`, `cf_quicktunnel`, `serviceportal`, `syncthing` as STOPPED  
  (Note the supervisorctl output displays `quicktunnel` as `cf_quicktunnel` — that's the program name in `quicktunnel.conf`.)

## Review
Critique Guardian: APPROVED. Mechanism verified against ai-dock `init.sh` (env-var keys off conf filenames; the disabled list is exactly the inbound-listening / cloud-relay subset of ai-dock's own `SERVERLESS=true` defaults).

## Known Considerations
- `caddy` (the in-container reverse proxy serving forge itself) is intentionally NOT disabled.

## Platform Impact
- macOS: Docker-only image; identical behavior on Docker Desktop.
- Linux: GPU-accelerated extension, primary target. NVIDIA only.
- Windows: WSL2 Docker Desktop, identical.

Must merge after Light-Heart-Labs/DreamServer#1077.