### PR TITLE
test(dashboard-api): cover SHIELD_API_KEY early-return in /privacy-shield/stats

### DIFF
--- a/dream-server/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_privacy.py
@@ -275,3 +275,29 @@ def test_privacy_shield_stats_connection_error(test_client):
     data = resp.json()
     assert "error" in data
     assert data["enabled"] is False
+
+
+def test_privacy_shield_stats_missing_shield_key(test_client, monkeypatch):
+    """GET /api/privacy-shield/stats when SHIELD_API_KEY is unset short-circuits before any HTTP call."""
+    monkeypatch.delenv("SHIELD_API_KEY", raising=False)
+    session_factory = MagicMock()
+
+    with patch("routers.privacy.aiohttp.ClientSession", session_factory):
+        resp = test_client.get("/api/privacy-shield/stats", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"error": "SHIELD_API_KEY not configured", "enabled": False}
+    session_factory.assert_not_called()
+
+
+def test_privacy_shield_stats_empty_shield_api_key(test_client, monkeypatch):
+    """GET /api/privacy-shield/stats when SHIELD_API_KEY is empty string short-circuits before any HTTP call."""
+    monkeypatch.setenv("SHIELD_API_KEY", "")
+    session_factory = MagicMock()
+
+    with patch("routers.privacy.aiohttp.ClientSession", session_factory):
+        resp = test_client.get("/api/privacy-shield/stats", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"error": "SHIELD_API_KEY not configured", "enabled": False}
+    session_factory.assert_not_called()

--- a/dream-server/extensions/services/dashboard-api/tests/test_privacy.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_privacy.py
@@ -277,7 +277,7 @@ def test_privacy_shield_stats_connection_error(test_client):
     assert data["enabled"] is False
 
 
-def test_privacy_shield_stats_missing_shield_key(test_client, monkeypatch):
+def test_privacy_shield_stats_missing_shield_key_short_circuits_before_http(test_client, monkeypatch):
     """GET /api/privacy-shield/stats when SHIELD_API_KEY is unset short-circuits before any HTTP call."""
     monkeypatch.delenv("SHIELD_API_KEY", raising=False)
     session_factory = MagicMock()


### PR DESCRIPTION
## What
Add two pytest cases for the early-return guard introduced by Light-Heart-Labs/DreamServer#1069 in `GET /api/privacy-shield/stats`:

1. `test_privacy_shield_stats_missing_shield_key` — `SHIELD_API_KEY` unset
2. `test_privacy_shield_stats_empty_shield_api_key` — `SHIELD_API_KEY=""`

Both assert (a) 200 + `{"error": "SHIELD_API_KEY not configured", "enabled": False}` payload, AND (b) `aiohttp.ClientSession.assert_not_called()` — the stricter security invariant proving no HTTP machinery is constructed when the key is missing or empty.

## Why
Issue requested empty-string parity coverage for the early-return. The `assert_not_called()` invariant is a security regression guard: a future change that re-introduced the network path when the key is unset would slip past payload-only assertions.

## How
26 lines of pure pytest in `tests/test_privacy.py`. Reuses existing test conventions (`test_client` + `monkeypatch` + `MagicMock` + `patch` on `aiohttp.ClientSession`).

## Testing
- `pytest tests/test_privacy.py`: full file passes
- `pytest -k "shield_api_key or shield_key"`: 2 passed

## Review
Critique Guardian: APPROVED (round 2). Round 1 flagged a redundancy with #1069's existing test; round 2 collapsed: one enhanced missing-case test (with `assert_not_called`) + one empty-string case, no duplicates.

## Known Considerations
- These tests target code paths added by Light-Heart-Labs/DreamServer#1069. CI may report failures on this branch until #1069 lands.
- #1069 introduces a similar `_missing_shield_key` test on a payload-only basis. Rebase will resolve to keep this PR's enhanced version with the no-HTTP-call invariant.

## Platform Impact
- macOS / Linux / Windows: identical (pytest, platform-independent).

Must merge after Light-Heart-Labs/DreamServer#1069.