### PR TITLE
ci: regression guard for curl http://localhost: in shell scripts

### DIFF
--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -60,3 +60,22 @@ jobs:
           echo "$shfiles" | xargs shellcheck \
             --exclude=SC1091,SC2034 \
             --severity=error
+
+      - name: Regression guard - no http://localhost in shell scripts
+        run: |
+          # IPv6 ::1 resolution can hang on macOS — always use 127.0.0.1 in
+          # shell scripts. Excludes: demo-offline.sh (echo'd documentation,
+          # never executed) and test-extension-audit.sh (heredoc compose YAML
+          # fixtures with container-internal localhost).
+          # Note: extensionless scripts (e.g. dream-cli) are not scanned by
+          # this glob; coverage is limited to *.sh / *.bash. dream-cli's
+          # localhost sites are swept by PR #1074.
+          matches=$(find dream-server -type f \( -name '*.sh' -o -name '*.bash' \) \
+            ! -path 'dream-server/scripts/demo-offline.sh' \
+            ! -path 'dream-server/tests/test-extension-audit.sh' \
+            -exec grep -nE 'curl[^|]*http://localhost:' {} + || true)
+          if [ -n "$matches" ]; then
+            echo "::error::curl http://localhost: detected — use 127.0.0.1 (IPv6 ::1 resolution can hang on macOS):"
+            echo "$matches"
+            exit 1
+          fi

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -63,19 +63,19 @@ jobs:
 
       - name: Regression guard - no http://localhost in shell scripts
         run: |
-          # IPv6 ::1 resolution can hang on macOS — always use 127.0.0.1 in
+          # IPv6 ::1 resolution can hang on macOS; always use 127.0.0.1 in
           # shell scripts. Excludes: demo-offline.sh (echo'd documentation,
           # never executed) and test-extension-audit.sh (heredoc compose YAML
           # fixtures with container-internal localhost).
           # Note: extensionless scripts (e.g. dream-cli) are not scanned by
           # this glob; coverage is limited to *.sh / *.bash. dream-cli's
-          # localhost sites are swept by PR #1074.
+          # localhost sites were handled by the earlier localhost-to-127.0.0.1 sweep.
           matches=$(find dream-server -type f \( -name '*.sh' -o -name '*.bash' \) \
             ! -path 'dream-server/scripts/demo-offline.sh' \
             ! -path 'dream-server/tests/test-extension-audit.sh' \
             -exec grep -nE 'curl[^|]*http://localhost:' {} + || true)
           if [ -n "$matches" ]; then
-            echo "::error::curl http://localhost: detected — use 127.0.0.1 (IPv6 ::1 resolution can hang on macOS):"
+            echo "::error::curl http://localhost: detected; use 127.0.0.1 (IPv6 ::1 resolution can hang on macOS):"
             echo "$matches"
             exit 1
           fi

--- a/dream-server/test-stack.sh
+++ b/dream-server/test-stack.sh
@@ -135,12 +135,12 @@ if $VOICE || $STRESS; then
     echo ""
     
     # Quick voice health
-    if curl -s http://localhost:3002/api/voice/status | grep -q '"available":true'; then
+    if curl -s http://127.0.0.1:3002/api/voice/status | grep -q '"available":true'; then
         echo -e "${GREEN}✓ Voice services available${NC}"
         
         # Check individual services
         for svc in stt tts livekit; do
-            if curl -s http://localhost:3002/api/voice/status | jq -e ".services.$svc.status == \"healthy\"" >/dev/null 2>&1; then
+            if curl -s http://127.0.0.1:3002/api/voice/status | jq -e ".services.$svc.status == \"healthy\"" >/dev/null 2>&1; then
                 echo -e "  ${GREEN}✓${NC} $svc healthy"
             else
                 echo -e "  ${RED}✗${NC} $svc unhealthy"

--- a/dream-server/tests/benchmark-status-performance.sh
+++ b/dream-server/tests/benchmark-status-performance.sh
@@ -65,7 +65,7 @@ benchmark_sequential() {
 
     # Simulate 13 sequential curl calls with 1 second timeout each
     for i in {1..13}; do
-        curl -sf --max-time 1 http://localhost:8080/health > /dev/null 2>&1 || true
+        curl -sf --max-time 1 http://127.0.0.1:8080/health > /dev/null 2>&1 || true
     done
 
     local end duration
@@ -83,7 +83,7 @@ benchmark_parallel() {
 
     # Launch 13 parallel curl calls
     for i in {1..13}; do
-        (curl -sf --max-time 1 http://localhost:8080/health > /dev/null 2>&1 && echo "ok" > "$tmpdir/$i") &
+        (curl -sf --max-time 1 http://127.0.0.1:8080/health > /dev/null 2>&1 && echo "ok" > "$tmpdir/$i") &
         pids+=($!)
     done
 


### PR DESCRIPTION
## What
Add a CI step to `.github/workflows/lint-shell.yml` that fails the build if any shell script under `dream-server/` introduces `curl ... http://localhost:`. Also fixes 4 currently-broken sites that Light-Heart-Labs/DreamServer#1074 does not sweep.

## Why
IPv6 `::1` resolution can hang on macOS — the IPv4 form `127.0.0.1` is the safe pattern across all platforms. PR #1074 sweeps ~46 existing localhost sites; this PR adds the regression guard so the pattern can't be reintroduced, plus catches 4 sites #1074 misses.

## How
1. New step in the existing shellcheck job — `find` + `grep -nE 'curl[^|]*http://localhost:'` with explicit excludes:
   - `dream-server/scripts/demo-offline.sh` (literal text inside `echo -e`, never executed)
   - `dream-server/tests/test-extension-audit.sh` (heredoc compose YAML fixtures with container-internal localhost)
   Comment notes that extensionless scripts (e.g. `dream-cli`) are not scanned by the `*.sh` / `*.bash` glob — their localhost sites are swept by #1074.
2. Fix 4 sites NOT covered by #1074:
   - `dream-server/test-stack.sh:138,143`
   - `dream-server/tests/benchmark-status-performance.sh:68,86`

## Testing
- yamllint clean
- shellcheck on touched .sh files: no NEW findings (only pre-existing on untouched lines)
- Local guard simulation: REMAINING grep is empty after the 4-site fix (modulo the 18 sites #1074 sweeps)

## Review
Critique Guardian: APPROVED (round 2). Round 1 flagged a misleading dream-cli comment; round 2 rewrote it to clarify the glob-coverage limit and #1074 as the sweeper.

## Known Considerations
- Regex does not match `wget` or case variants (`Localhost`/`LOCALHOST`). Future hardening if needed.
- Until #1074 lands, this PR's CI job will fire on the 18 sites #1074 sweeps. That's expected and is why this PR is DRAFT.

## Platform Impact
- macOS: runtime fix in test-stack.sh + benchmark-status-performance.sh helps macOS dev machines (IPv6 hang).
- Linux: CI runs on ubuntu-latest. Same runtime benefit as macOS for any operator running these scripts locally.
- Windows: N/A for the CI step; shell scripts unaffected on Windows side.

Must merge after Light-Heart-Labs/DreamServer#1074.