### PR TITLE
fix(openclaw): stop leaking gateway token via stdout and unauthenticated static asset

### DIFF
--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -145,11 +145,13 @@ try {
   fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2), 'utf8');
   console.log('[inject-token] patched runtime config:', CONFIG_PATH);
 
-  // Log the browser-accessible URL with token for Docker users
+  // Confirm token was injected without leaking it to stdout.
+  // Anyone with `docker logs dream-openclaw` access could otherwise harvest
+  // the gateway token from a URL printed here.
   if (token) {
     console.log(`[inject-token] ┌─────────────────────────────────────────────┐`);
-    console.log(`[inject-token] │ OpenClaw Control UI:                        │`);
-    console.log(`[inject-token] │ http://localhost:${EXTERNAL_PORT}/#token=${token}`);
+    console.log(`[inject-token] │ OpenClaw Control UI ready on port ${EXTERNAL_PORT}.`);
+    console.log(`[inject-token] │ Token redacted; paste from .env to sign in. │`);
     console.log(`[inject-token] └─────────────────────────────────────────────┘`);
   }
 } catch (err) {
@@ -160,18 +162,26 @@ try {
 
 if (token && fs.existsSync(HTML_PATH)) {
   try {
-    // 1. Create external JS file with token-setting code
-    const jsCode = [
-      '(function() {',
-      '  var k = "openclaw.control.settings.v1";',
-      '  var s = {};',
-      '  try { s = JSON.parse(localStorage.getItem(k) || "{}"); } catch(e) {}',
-      '  s.token = ' + JSON.stringify(token) + ';',
-      '  s.gatewayUrl = (location.protocol === "https:" ? "wss://" : "ws://") + location.host;',
-      '  localStorage.setItem(k, JSON.stringify(s));',
-      '})();',
+    // 1. Auto-token injection is DISABLED.
+    //
+    // Previously this wrote the raw gateway token into /app/dist/control-ui/auto-token.js,
+    // which the OpenClaw gateway serves UNAUTHENTICATED at HTTP root. With
+    // BIND_ADDRESS=0.0.0.0 (LAN mode) anyone on the LAN could fetch
+    // http://<host>:<port>/auto-token.js and harvest the token. See fork issue #548.
+    //
+    // We still write a placeholder file (and keep the <script src="./auto-token.js">
+    // injection below) so the gateway's CSP `script-src 'self'` policy is satisfied
+    // and existing HTML references do not 404. The placeholder contains no secrets.
+    //
+    // UX impact: Control UI no longer auto-signs-in. Users must paste the token
+    // manually from the install summary or the OPENCLAW_TOKEN value in .env.
+    const placeholder = [
+      '// Auto-token injection disabled to prevent gateway-token disclosure via',
+      '// this unauthenticated static asset (fork issue #548).',
+      '// Paste the token manually from .env (OPENCLAW_TOKEN) into the Control UI.',
+      '(function(){ /* no-op */ })();',
     ].join('\n');
-    fs.writeFileSync(JS_PATH, jsCode);
+    fs.writeFileSync(JS_PATH, placeholder);
 
     // 2. Inject <script src> tag as first element in <head> (satisfies CSP 'self')
     let html = fs.readFileSync(HTML_PATH, 'utf8');
@@ -182,7 +192,7 @@ if (token && fs.existsSync(HTML_PATH)) {
     html = html.replace('<head>', '<head><script src="./auto-token.js"></script>');
     fs.writeFileSync(HTML_PATH, html);
 
-    console.log('[inject-token] created auto-token.js and injected <script src> into Control UI');
+    console.log('[inject-token] wrote placeholder auto-token.js (token disclosure mitigated; manual sign-in required)');
   } catch (err) {
     console.error('[inject-token] UI injection warning:', err.message);
   }


### PR DESCRIPTION
## What
Close two token-leak vectors in `dream-server/config/openclaw/inject-token.js`:
1. **Stdout / `docker logs` URL leak** — every container start logged `[inject-token] │ http://localhost:${EXTERNAL_PORT}/#token=${token}` to stdout. Anyone with `docker logs dream-openclaw` access could harvest the gateway token.
2. **Unauthenticated static-asset disclosure** — `inject-token.js` wrote a static file `/app/dist/control-ui/auto-token.js` containing `s.token = <raw token>;`, served UNAUTHENTICATED at HTTP root. With `BIND_ADDRESS=0.0.0.0` (LAN mode), any LAN host could `curl http://<host>:<port>/auto-token.js` and harvest the token.

## Why
Token disclosure on default LAN-mode installs is a high-severity issue. The gateway token is the only credential gating the openclaw `/v1/chat/completions` endpoint and WebSocket; harvesting it grants full LLM/automation access.

## How
1. **Stdout redaction**: replace the `console.log` URL+token line with a redacted line that confirms inject ran but contains no secret.
2. **Static-asset placeholder**: replace the token-bearing JS with a no-op IIFE plus an inline comment documenting the security rationale. The file still exists at `JS_PATH` so the gateway's CSP `script-src 'self'` policy is satisfied; the placeholder contains no secret.

## Testing
- `node --check` clean
- Manual:
  - `docker logs dream-openclaw 2>&1 | grep -E '#token=|token=[a-f0-9]{40,}'` returns zero hits
  - With `BIND_ADDRESS=0.0.0.0`, from another LAN host: `curl http://<host>:<port>/auto-token.js` returns only the placeholder, no hex-secret content
  - **Operator smoke-test required before flipping ready-for-review**: paste `OPENCLAW_TOKEN` from `.env` into the Control UI sign-in form → confirm it connects → submit a task end-to-end

## Review
Critique Guardian: APPROVED WITH WARNINGS — both vectors closed; CSP path preserved (placeholder file still exists at `JS_PATH`). Operator must smoke-test the manual sign-in path before merge.

## Known Considerations
- **UX regression (intentional)**: Manual token paste replaces auto-injection. The Control UI's localStorage settings store (`openclaw.control.settings.v1`) is the upstream OpenClaw mechanism — operators paste the token into the sign-in form, which writes to localStorage normally.
- **Token rotation advisory**: Operators who previously deployed openclaw with `BIND_ADDRESS=0.0.0.0` should rotate `OPENCLAW_TOKEN`. Once a token has been served via `/auto-token.js` to a LAN observer, overwriting the file does not invalidate the harvested token.
- File overwrite is idempotent — every container restart re-writes the placeholder, so existing exposed installs are remediated on next restart (after rotation).

## Platform Impact
- macOS: Docker-only — identical behavior on Docker Desktop.
- Linux: identical.
- Windows: WSL2 Docker Desktop, identical.

Independent — no must-merge-after dependency.