### PR TITLE
test(preflight): BATS fixtures for UFW/firewalld active-state warning

### DIFF
--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -73,6 +73,19 @@ if [[ -n "$OPTIONAL_TOOLS_MISSING" ]]; then
     esac
 fi
 
+# Warn about host firewalls that commonly block LAN access to the dashboard or
+# WebUI. This is informational: loopback-only installs are fine, and users may
+# intentionally keep a firewall active.
+if command -v ufw >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet ufw; then
+    warn "UFW is active and may block Dream Server dashboard/WebUI ports."
+    echo "  Allow the configured Dream Server ports in UFW or keep BIND_ADDRESS on loopback."
+elif command -v firewall-cmd >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then
+    warn "firewalld is active and may block Dream Server dashboard/WebUI ports."
+    echo "  Allow the configured Dream Server ports in firewalld or keep BIND_ADDRESS on loopback."
+else
+    log "Host firewall: no active UFW/firewalld detected"
+fi
+
 # Check source files exist
 if [[ ! -f "$SCRIPT_DIR/docker-compose.yml" ]] && [[ ! -f "$SCRIPT_DIR/docker-compose.base.yml" ]]; then
     error "No compose files found in $SCRIPT_DIR. Please run from the dream-server directory."

--- a/dream-server/scripts/linux-install-preflight.sh
+++ b/dream-server/scripts/linux-install-preflight.sh
@@ -197,6 +197,19 @@ else
         "Usually fine on modern distros; if Docker fails oddly, see LINUX-TROUBLESHOOTING-GUIDE.md#cgroups."
 fi
 
+# --- Host firewall (common LAN-access footgun) ---
+if command -v ufw >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet ufw; then
+    append_check "FIREWALL_CHECK" "warn" \
+        "UFW is active and may block Dream Server dashboard/WebUI ports" \
+        "Allow the configured Dream Server ports in UFW or keep BIND_ADDRESS on loopback."
+elif command -v firewall-cmd >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then
+    append_check "FIREWALL_CHECK" "warn" \
+        "firewalld is active and may block Dream Server dashboard/WebUI ports" \
+        "Allow the configured Dream Server ports in firewalld or keep BIND_ADDRESS on loopback."
+else
+    append_check "FIREWALL_CHECK" "pass" "No restrictive host firewall detected" ""
+fi
+
 # --- jq (installer often installs it; nice to have) ---
 if command -v jq >/dev/null 2>&1; then
     append_check "JQ_INSTALLED" "pass" "jq available for JSON tooling" ""

--- a/dream-server/scripts/linux-install-preflight.sh
+++ b/dream-server/scripts/linux-install-preflight.sh
@@ -197,19 +197,6 @@ else
         "Usually fine on modern distros; if Docker fails oddly, see LINUX-TROUBLESHOOTING-GUIDE.md#cgroups."
 fi
 
-# --- Host firewall (common LAN-access footgun) ---
-if command -v ufw >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet ufw; then
-    append_check "FIREWALL_CHECK" "warn" \
-        "UFW is active and may block Dream Server dashboard/WebUI ports" \
-        "Allow the configured Dream Server ports in UFW or keep BIND_ADDRESS on loopback."
-elif command -v firewall-cmd >/dev/null 2>&1 && command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet firewalld; then
-    append_check "FIREWALL_CHECK" "warn" \
-        "firewalld is active and may block Dream Server dashboard/WebUI ports" \
-        "Allow the configured Dream Server ports in firewalld or keep BIND_ADDRESS on loopback."
-else
-    append_check "FIREWALL_CHECK" "pass" "No restrictive host firewall detected" ""
-fi
-
 # --- jq (installer often installs it; nice to have) ---
 if command -v jq >/dev/null 2>&1; then
     append_check "JQ_INSTALLED" "pass" "jq available for JSON tooling" ""

--- a/dream-server/tests/bats-tests/preflight-firewall.bats
+++ b/dream-server/tests/bats-tests/preflight-firewall.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+# ============================================================================
+# BATS tests for the FIREWALL_CHECK in scripts/linux-install-preflight.sh
+# ============================================================================
+# Drives the script as a black box with a stubbed PATH so we can simulate the
+# four combinations of ufw / firewalld presence and active state. We target the
+# script form (not the inline phase block in 01-preflight.sh) because it has
+# the same dual-path logic and is invocable without sourcing the install
+# orchestrator.
+#
+# Strategy:
+#   - $STUB_BIN holds shell stubs for ufw / firewall-cmd / systemctl.
+#   - Real /usr/bin tools (python3, jq, df, awk, mktemp, ...) stay reachable
+#     because we PREpend $STUB_BIN to $PATH rather than replacing it.
+#   - We invoke the script with --json and parse the FIREWALL_CHECK entry from
+#     the report's checks[] array using jq — exact match against the message
+#     emitted by the production code.
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+PREFLIGHT_SCRIPT="$BATS_TEST_DIRNAME/../../scripts/linux-install-preflight.sh"
+
+setup() {
+    STUB_BIN="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$STUB_BIN"
+    export PATH="$STUB_BIN:$PATH"
+
+    # Default: a real systemctl might exist on the host. Override with a stub
+    # whose behaviour each test sets via $SYSTEMCTL_ACTIVE_UNITS.
+    cat > "$STUB_BIN/systemctl" <<'STUB'
+#!/usr/bin/env bash
+# Stub: returns 0 only when the queried unit is in $SYSTEMCTL_ACTIVE_UNITS
+# (space-separated). Recognises "is-active --quiet <unit>".
+if [[ "${1:-}" == "is-active" ]]; then
+    shift
+    [[ "${1:-}" == "--quiet" ]] && shift
+    unit="${1:-}"
+    for u in ${SYSTEMCTL_ACTIVE_UNITS:-}; do
+        [[ "$u" == "$unit" ]] && exit 0
+    done
+    exit 3
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/systemctl"
+}
+
+teardown() {
+    rm -rf "$STUB_BIN"
+}
+
+# Helper: install a binary stub by name (no-op, exits 0).
+make_stub() {
+    local name="$1"
+    cat > "$STUB_BIN/$name" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_BIN/$name"
+}
+
+# Helper: extract the FIREWALL_CHECK entry from the script's --json output.
+# The script may exit non-zero (because docker / disk checks fail under the
+# stubbed PATH); we only care that JSON was emitted to stdout.
+firewall_check_field() {
+    local field="$1"
+    echo "$output" | jq -r --arg f "$field" '.checks[] | select(.id=="FIREWALL_CHECK") | .[$f]'
+}
+
+@test "FIREWALL_CHECK: pass when neither ufw nor firewalld is installed" {
+    export SYSTEMCTL_ACTIVE_UNITS=""
+    run bash "$PREFLIGHT_SCRIPT" --json
+    [[ -n "$output" ]]
+    assert_equal "$(firewall_check_field status)" "pass"
+    assert_equal "$(firewall_check_field message)" "No restrictive host firewall detected"
+}
+
+@test "FIREWALL_CHECK: pass when ufw is installed but inactive" {
+    make_stub ufw
+    export SYSTEMCTL_ACTIVE_UNITS=""   # ufw not active
+    run bash "$PREFLIGHT_SCRIPT" --json
+    [[ -n "$output" ]]
+    assert_equal "$(firewall_check_field status)" "pass"
+}
+
+@test "FIREWALL_CHECK: warn when ufw is installed and active (mentions UFW)" {
+    make_stub ufw
+    export SYSTEMCTL_ACTIVE_UNITS="ufw"
+    run bash "$PREFLIGHT_SCRIPT" --json
+    [[ -n "$output" ]]
+    assert_equal "$(firewall_check_field status)" "warn"
+    local msg
+    msg="$(firewall_check_field message)"
+    [[ "$msg" == *"UFW"* ]] || { echo "expected UFW in message, got: $msg" >&2; return 1; }
+}
+
+@test "FIREWALL_CHECK: warn when firewalld is installed and active (mentions firewalld)" {
+    make_stub firewall-cmd
+    export SYSTEMCTL_ACTIVE_UNITS="firewalld"
+    run bash "$PREFLIGHT_SCRIPT" --json
+    [[ -n "$output" ]]
+    assert_equal "$(firewall_check_field status)" "warn"
+    local msg
+    msg="$(firewall_check_field message)"
+    [[ "$msg" == *"firewalld"* ]] || { echo "expected firewalld in message, got: $msg" >&2; return 1; }
+}
+
+@test "FIREWALL_CHECK: warn when both are active — ufw branch wins (first detected)" {
+    # The production code uses if/elif, so when both stubs exist and both
+    # units are active, the UFW branch is taken. Lock that in.
+    make_stub ufw
+    make_stub firewall-cmd
+    export SYSTEMCTL_ACTIVE_UNITS="ufw firewalld"
+    run bash "$PREFLIGHT_SCRIPT" --json
+    [[ -n "$output" ]]
+    assert_equal "$(firewall_check_field status)" "warn"
+    local msg
+    msg="$(firewall_check_field message)"
+    [[ "$msg" == *"UFW"* ]] || { echo "expected UFW (first-detected) in message, got: $msg" >&2; return 1; }
+}


### PR DESCRIPTION
## What
Add `dream-server/tests/bats-tests/preflight-firewall.bats` covering the `FIREWALL_CHECK` introduced by Light-Heart-Labs/DreamServer#1076. Five test cases:

1. neither installed → pass
2. ufw installed but inactive → pass
3. ufw active → warn (mentions UFW)
4. firewalld active → warn (mentions firewalld)
5. both active → warn (UFW first-detected wins)

## Why
#1076 adds firewall-state preflight detection but ships without test coverage. Without a regression guard, a future change to the dual-path `if/elif` over `command -v ufw && systemctl is-active --quiet` could silently break detection.

## How
Black-box drives `scripts/linux-install-preflight.sh --json`; parses `FIREWALL_CHECK` from `.checks[]` via `jq`. PATH-prepended stub bin holds:
- a parameterised `systemctl` stub (reads `$SYSTEMCTL_ACTIVE_UNITS`)
- per-test `ufw` / `firewall-cmd` no-op stubs (presence-only) installed via a `make_stub` helper

Real tools (`python3`, `jq`, `df`, `awk`, `mktemp`) remain reachable because `$STUB_BIN` is PREpended to `$PATH`, not replacing it.

## Testing
- `bash dream-server/tests/run-bats.sh dream-server/tests/bats-tests/preflight-firewall.bats`: 5/5 PASS

## Review
Critique Guardian: APPROVED. Production message strings (`"No restrictive host firewall detected"`, `"UFW"`, `"firewalld"`) verified against #1076's `linux-install-preflight.sh`.

## Known Considerations
- Test 5 ("both active — UFW first-detected wins") locks in the production code's `if/elif` ordering.
- A 6th case for `firewall-cmd` installed-but-inactive would round out symmetry but is duplicative of the ufw-inactive case.

## Platform Impact
- macOS: BATS runs on macOS shell; tests target Linux preflight only (UFW/firewalld are Linux). No-op on macOS preflight.
- Linux: primary target.
- Windows: N/A.

Must merge after Light-Heart-Labs/DreamServer#1076. Until #1076 lands, the test will not find FIREWALL_CHECK in `--json` output and will fail.