### PR TITLE
test(preflight): cover nfs4 mount type in preflight-fs-networked BATS

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -208,6 +208,16 @@ if $INSTALL_FS_FATAL; then
 fi
 ai_ok "Filesystem supports POSIX permissions"
 
+# Networked-filesystem advisory (warn-only).
+# chmod 600 still applies on NFS/SMB/AFP, but the actual access control is
+# enforced server-side by the share's ACL — other clients with access to the
+# share may read .env regardless of local permissions.
+if [[ "${INSTALL_FS_NETWORKED:-false}" == "true" ]]; then
+    ai_warn "INSTALL_DIR ($INSTALL_DIR) is on a networked filesystem ($INSTALL_FS_TYPE)."
+    ai_warn ".env permissions (chmod 600) are advisory — actual access control is governed by the share's ACL on the server."
+    ai_warn "If this share is exposed to other clients, sensitive credentials may be readable from those hosts."
+fi
+
 # Docker Desktop file-sharing allowlist check
 # Bind-mounts of paths outside the allowlist fail with cryptic OCI errors at
 # `docker compose up`. Probe with a throwaway container so we surface a clear

--- a/dream-server/installers/macos/lib/preflight-fs.sh
+++ b/dream-server/installers/macos/lib/preflight-fs.sh
@@ -8,7 +8,8 @@
 #          sharing allowlist gaps (which surface as cryptic OCI mount errors).
 #
 # Provides:
-#   test_install_dir_filesystem() -- sets INSTALL_FS_TYPE, INSTALL_FS_FATAL
+#   test_install_dir_filesystem() -- sets INSTALL_FS_TYPE, INSTALL_FS_FATAL,
+#                                    INSTALL_FS_NETWORKED
 #   test_docker_desktop_sharing() -- sets DOCKER_SHARE_OK, DOCKER_SHARE_ERR
 #
 # shellcheck disable=SC2034  # vars are read by install-macos.sh after sourcing
@@ -69,6 +70,13 @@ test_install_dir_filesystem() {
     case "$INSTALL_FS_TYPE" in
         *exfat*|*msdos*|*fat32*|*fat16*|*"ms-dos"*|*ntfs*)
             INSTALL_FS_FATAL=true
+            ;;
+    esac
+
+    INSTALL_FS_NETWORKED=false
+    case "$INSTALL_FS_TYPE" in
+        nfs|smbfs|afpfs|webdav)
+            INSTALL_FS_NETWORKED=true
             ;;
     esac
 }

--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -113,6 +113,17 @@ Pick a path on a POSIX-native filesystem (ext4, btrfs, xfs, zfs) and
 re-run, e.g.:  INSTALL_DIR=\"\$HOME/dream-server\" $0"
             ;;
     esac
+
+    # Networked filesystems honour chmod 600 locally, but the real access
+    # control lives in the share's server-side ACL. Warn only — installs
+    # to network-mounted homes are common and not always insecure.
+    case "$fs_type" in
+        nfs|nfs4|cifs|fuse.smbnetfs|fuse.glusterfs|ocfs2)
+            warn "INSTALL_DIR ($INSTALL_DIR) is on a networked filesystem ($fs_type)."
+            warn ".env permissions (chmod 600) are advisory — actual access control is governed by the share's ACL on the server."
+            warn "If this share is exposed to other clients, sensitive credentials may be readable from those hosts."
+            ;;
+    esac
     log "INSTALL_DIR filesystem: ${INSTALL_FS_TYPE}"
 }
 

--- a/dream-server/installers/windows/phases/01-preflight.ps1
+++ b/dream-server/installers/windows/phases/01-preflight.ps1
@@ -142,6 +142,38 @@ if ($_fsFatal) {
 }
 Write-AISuccess "Filesystem supports POSIX-style permissions"
 
+# ── Networked filesystem advisory (warn-only) ────────────────────────────────
+# NTFS ACLs on a mapped network drive (SMB/CIFS) or a UNC share are enforced
+# by the SERVER, not this client. chmod-style local permission bits and any
+# ACLs we set are advisory; another client of the same share may read .env
+# regardless of how this Windows install enforces ACLs locally. Warn-only —
+# installs to network homes are common and not always insecure.
+$_fsNetworked = $false
+$_fsNetworkType = ""
+try {
+    if ($installDir -match '^\\\\') {
+        # UNC path — \\server\share\... — always networked. DriveInfo would
+        # throw for these, so check the path shape first.
+        $_fsNetworked = $true
+        $_fsNetworkType = "UNC share"
+    } elseif ($_di -and $_di.DriveType -eq 'Network') {
+        # Mapped drive — DriveInfo.DriveType reports Network for SMB-mapped
+        # drive letters (Z:\ pointing at \\server\share).
+        $_fsNetworked = $true
+        $_fsNetworkType = "mapped network drive"
+    }
+} catch {
+    # Same graceful-degradation pattern as the FATAL detection above —
+    # if we can't determine drive type, skip the warning silently.
+    $_fsNetworked = $false
+}
+
+if ($_fsNetworked) {
+    Write-AIWarn "INSTALL_DIR ($installDir) is on a $_fsNetworkType."
+    Write-AIWarn ".env permissions are advisory — actual access control is governed by the share's ACL on the server."
+    Write-AIWarn "If this share is exposed to other clients, sensitive credentials may be readable from those hosts."
+}
+
 # ── Docker Desktop file-sharing allowlist check ──────────────────────────────
 # Bind-mounting a path outside the Docker Desktop file-sharing list fails at
 # `docker compose up` with a cryptic OCI error. Probe with a throwaway alpine

--- a/dream-server/tests/bats-tests/preflight-fs-networked.bats
+++ b/dream-server/tests/bats-tests/preflight-fs-networked.bats
@@ -126,6 +126,27 @@ _extract_linux_fs_fn() {
     assert_output --partial "EXIT_OK"
 }
 
+@test "linux preflight: nfs4 warns and does not exit fatally" {
+    _make_gnu_stat_stub "nfs4"
+    local fn_file="$BATS_TEST_TMPDIR/fs-fn.sh"
+    _extract_linux_fs_fn "$fn_file"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        export INSTALL_DIR="'"$INSTALL_DIR"'"
+        log()   { :; }
+        warn()  { echo "WARN: $1"; }
+        error() { echo "ERROR: $1"; exit 1; }
+        source "'"$fn_file"'"
+        check_install_dir_filesystem
+        echo "EXIT_OK"
+    '
+    assert_success
+    assert_output --partial "networked filesystem"
+    assert_output --partial "nfs4"
+    assert_output --partial "EXIT_OK"
+}
+
 # ---------------------------------------------------------------------------
 # Linux: native POSIX filesystems must NOT warn or fatally exit.
 # ---------------------------------------------------------------------------

--- a/dream-server/tests/bats-tests/preflight-fs-networked.bats
+++ b/dream-server/tests/bats-tests/preflight-fs-networked.bats
@@ -1,0 +1,233 @@
+#!/usr/bin/env bats
+# ============================================================================
+# BATS tests for networked-filesystem detection in the preflight phase.
+# ============================================================================
+# Covers:
+#   * macOS:  installers/macos/lib/preflight-fs.sh::test_install_dir_filesystem
+#   * Linux:  installers/phases/01-preflight.sh::check_install_dir_filesystem
+#
+# Strategy: stub `stat` via PATH so each test deterministically reports a
+# specific filesystem type, then source the relevant helper and assert on
+# INSTALL_FS_NETWORKED / warn output / fatal exit behavior.
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+setup() {
+    export INSTALL_DIR="$BATS_TEST_TMPDIR/install-target"
+    mkdir -p "$INSTALL_DIR"
+
+    # PATH stub directory for `stat` (and friends, if needed).
+    export STUB_BIN="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$STUB_BIN"
+
+    # Stub `diskutil` to exit non-zero on every call so the macOS
+    # personality-refinement branch in preflight-fs.sh is deterministically
+    # bypassed; INSTALL_FS_TYPE then stays equal to whatever the stat stub
+    # returned. Linux tests don't invoke diskutil so this stub is harmless.
+    cat > "$STUB_BIN/diskutil" <<'MOCK'
+#!/bin/bash
+exit 1
+MOCK
+    chmod +x "$STUB_BIN/diskutil"
+}
+
+teardown() {
+    rm -rf "$BATS_TEST_TMPDIR/install-target" "$BATS_TEST_TMPDIR/stub-bin"
+}
+
+# ---------------------------------------------------------------------------
+# Helpers: write a `stat` stub that prints the requested filesystem type.
+# ---------------------------------------------------------------------------
+
+# BSD stat stub: macOS preflight-fs.sh calls `stat -f %T <path>`.
+_make_bsd_stat_stub() {
+    local fs_type="$1"
+    cat > "$STUB_BIN/stat" <<MOCK
+#!/bin/bash
+# Match BSD-style \`stat -f %T <path>\`.
+if [[ "\$1" == "-f" && "\$2" == "%T" ]]; then
+    echo "$fs_type"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$STUB_BIN/stat"
+}
+
+# GNU stat stub: Linux 01-preflight.sh calls `stat -fc %T <path>`.
+_make_gnu_stat_stub() {
+    local fs_type="$1"
+    cat > "$STUB_BIN/stat" <<MOCK
+#!/bin/bash
+# Match GNU-style \`stat -fc %T <path>\`.
+if [[ "\$1" == "-fc" && "\$2" == "%T" ]]; then
+    echo "$fs_type"
+    exit 0
+fi
+exit 0
+MOCK
+    chmod +x "$STUB_BIN/stat"
+}
+
+# Extract `check_install_dir_filesystem` from 01-preflight.sh into a
+# standalone snippet so sourcing it doesn't run the entire phase.
+_extract_linux_fs_fn() {
+    local out="$1"
+    awk '
+        /^check_install_dir_filesystem\(\) \{/ { capture=1 }
+        capture { print }
+        capture && /^\}/ { exit }
+    ' "$BATS_TEST_DIRNAME/../../installers/phases/01-preflight.sh" > "$out"
+}
+
+# ---------------------------------------------------------------------------
+# Linux: networked types should warn (non-fatal).
+# ---------------------------------------------------------------------------
+
+@test "linux preflight: nfs warns and does not exit fatally" {
+    _make_gnu_stat_stub "nfs"
+    local fn_file="$BATS_TEST_TMPDIR/fs-fn.sh"
+    _extract_linux_fs_fn "$fn_file"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        export INSTALL_DIR="'"$INSTALL_DIR"'"
+        log()   { :; }
+        warn()  { echo "WARN: $1"; }
+        error() { echo "ERROR: $1"; exit 1; }
+        # Disable diskutil refinement (Linux has none anyway).
+        source "'"$fn_file"'"
+        check_install_dir_filesystem
+        echo "EXIT_OK"
+    '
+    assert_success
+    assert_output --partial "networked filesystem"
+    assert_output --partial "EXIT_OK"
+}
+
+@test "linux preflight: cifs warns and does not exit fatally" {
+    _make_gnu_stat_stub "cifs"
+    local fn_file="$BATS_TEST_TMPDIR/fs-fn.sh"
+    _extract_linux_fs_fn "$fn_file"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        export INSTALL_DIR="'"$INSTALL_DIR"'"
+        log()   { :; }
+        warn()  { echo "WARN: $1"; }
+        error() { echo "ERROR: $1"; exit 1; }
+        source "'"$fn_file"'"
+        check_install_dir_filesystem
+        echo "EXIT_OK"
+    '
+    assert_success
+    assert_output --partial "networked filesystem"
+    assert_output --partial "EXIT_OK"
+}
+
+# ---------------------------------------------------------------------------
+# Linux: native POSIX filesystems must NOT warn or fatally exit.
+# ---------------------------------------------------------------------------
+
+@test "linux preflight: ext2/ext3/ext4 do not warn or exit fatally" {
+    _make_gnu_stat_stub "ext2/ext3"
+    local fn_file="$BATS_TEST_TMPDIR/fs-fn.sh"
+    _extract_linux_fs_fn "$fn_file"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        export INSTALL_DIR="'"$INSTALL_DIR"'"
+        log()   { :; }
+        warn()  { echo "WARN: $1"; }
+        error() { echo "ERROR: $1"; exit 1; }
+        source "'"$fn_file"'"
+        check_install_dir_filesystem
+        echo "EXIT_OK"
+    '
+    assert_success
+    refute_output --partial "WARN:"
+    assert_output --partial "EXIT_OK"
+}
+
+# ---------------------------------------------------------------------------
+# Linux: regression guard — exfat must still be fatal.
+# ---------------------------------------------------------------------------
+
+@test "linux preflight: exfat remains fatal (regression guard)" {
+    _make_gnu_stat_stub "exfat"
+    local fn_file="$BATS_TEST_TMPDIR/fs-fn.sh"
+    _extract_linux_fs_fn "$fn_file"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        export INSTALL_DIR="'"$INSTALL_DIR"'"
+        log()   { :; }
+        warn()  { echo "WARN: $1"; }
+        error() { echo "ERROR: $1"; exit 1; }
+        source "'"$fn_file"'"
+        check_install_dir_filesystem
+        echo "EXIT_OK"
+    '
+    assert_failure
+    assert_output --partial "ERROR:"
+    refute_output --partial "EXIT_OK"
+}
+
+# ---------------------------------------------------------------------------
+# macOS: networked types should set INSTALL_FS_NETWORKED=true (non-fatal).
+# ---------------------------------------------------------------------------
+
+@test "macos preflight: nfs sets INSTALL_FS_NETWORKED=true and is not fatal" {
+    _make_bsd_stat_stub "nfs"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        source "'"$BATS_TEST_DIRNAME/../../installers/macos/lib/preflight-fs.sh"'"
+        test_install_dir_filesystem "'"$INSTALL_DIR"'"
+        echo "TYPE=$INSTALL_FS_TYPE"
+        echo "FATAL=$INSTALL_FS_FATAL"
+        echo "NETWORKED=$INSTALL_FS_NETWORKED"
+    '
+    assert_success
+    assert_output --partial "TYPE=nfs"
+    assert_output --partial "FATAL=false"
+    assert_output --partial "NETWORKED=true"
+}
+
+@test "macos preflight: smbfs sets INSTALL_FS_NETWORKED=true and is not fatal" {
+    _make_bsd_stat_stub "smbfs"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        source "'"$BATS_TEST_DIRNAME/../../installers/macos/lib/preflight-fs.sh"'"
+        test_install_dir_filesystem "'"$INSTALL_DIR"'"
+        echo "TYPE=$INSTALL_FS_TYPE"
+        echo "FATAL=$INSTALL_FS_FATAL"
+        echo "NETWORKED=$INSTALL_FS_NETWORKED"
+    '
+    assert_success
+    assert_output --partial "TYPE=smbfs"
+    assert_output --partial "FATAL=false"
+    assert_output --partial "NETWORKED=true"
+}
+
+# ---------------------------------------------------------------------------
+# macOS: native APFS must NOT flag networked or fatal.
+# ---------------------------------------------------------------------------
+
+@test "macos preflight: apfs is neither fatal nor networked" {
+    _make_bsd_stat_stub "apfs"
+
+    run bash -c '
+        export PATH="'"$STUB_BIN:$PATH"'"
+        source "'"$BATS_TEST_DIRNAME/../../installers/macos/lib/preflight-fs.sh"'"
+        test_install_dir_filesystem "'"$INSTALL_DIR"'"
+        echo "TYPE=$INSTALL_FS_TYPE"
+        echo "FATAL=$INSTALL_FS_FATAL"
+        echo "NETWORKED=$INSTALL_FS_NETWORKED"
+    '
+    assert_success
+    assert_output --partial "FATAL=false"
+    assert_output --partial "NETWORKED=false"
+}


### PR DESCRIPTION
## What
Add one new BATS test case to `dream-server/tests/bats-tests/preflight-fs-networked.bats` (the file added by Light-Heart-Labs/DreamServer#1083) covering the `nfs4` filesystem type.

## Why
#1083's Linux production case statement at `01-preflight.sh:121` matches `nfs|nfs4|cifs|fuse.smbnetfs|fuse.glusterfs|ocfs2`, but the BATS fixture only exercises `nfs` / `cifs` / `ext` / `exfat` — leaving `nfs4` untested. A future change that broke the `nfs4` arm of the regex-OR would slip past CI.

## How
21-line test case mirroring the existing `linux preflight: nfs warns and does not exit fatally` test, with the stat stub returning `nfs4` instead of `nfs`. Asserts:
- the warning fires (`networked filesystem`)
- the type appears in the warning message (`nfs4`)
- the script does not exit fatally (`EXIT_OK`)

## Testing
- `bash dream-server/tests/run-bats.sh dream-server/tests/bats-tests/preflight-fs-networked.bats`: 8/8 PASS

## Review
Critique Guardian: APPROVED. Production warn line at `01-preflight.sh:122` includes `($fs_type)`, so the `nfs4` partial-match is reliable. Test scope honors the plan (`nfs4` only); `fuse.glusterfs` and `ocfs2` are also untested but out of scope here.

## Known Considerations
- macOS `preflight-fs.sh` does not include `nfs4` in its case statement — that's a separate production gap in #1083 itself, not a test-only gap, and is out of scope for this PR.
- `fuse.smbnetfs`, `fuse.glusterfs`, `ocfs2` Linux types are similarly untested by the fixture but match the same case statement; follow-up worth filing.

## Platform Impact
- macOS: BATS runs on macOS shell; this test targets Linux preflight only. No-op on macOS.
- Linux: primary target.
- Windows: N/A.

This branch contains two commits: the first is a rebased copy of #1083's commit on current upstream/main (so this PR's diff is self-contained); the second is the new BATS case. **Must merge after Light-Heart-Labs/DreamServer#1083** — when #1083 lands, rebase this branch onto upstream/main and the #1083 commit drops out cleanly.