### PR TITLE
fix(dashboard-api): unified-memory fallback for GB10/GB200

### DIFF
--- a/dream-server/extensions/services/dashboard-api/gpu.py
+++ b/dream-server/extensions/services/dashboard-api/gpu.py
@@ -34,6 +34,31 @@ def _read_sysfs(path: str) -> Optional[str]:
         return None
 
 
+def _read_meminfo_mb() -> Optional[tuple[int, int]]:
+    """Return (used_mb, total_mb) from /proc/meminfo, or None on failure.
+
+    Used as a fallback for unified-memory NVIDIA GPUs (GB10, GB200) where
+    nvidia-smi reports [N/A] for memory.total/memory.used. Mirrors the
+    installer's detection.sh fallback.
+    """
+    try:
+        with open("/proc/meminfo") as f:
+            info = {}
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 2:
+                    info[parts[0].rstrip(":")] = int(parts[1])
+    except OSError:
+        return None
+    total_kb = info.get("MemTotal", 0)
+    avail_kb = info.get("MemAvailable", 0)
+    if total_kb <= 0:
+        return None
+    used_mb = max(0, (total_kb - avail_kb)) // 1024
+    total_mb = total_kb // 1024
+    return used_mb, total_mb
+
+
 def _find_amd_gpu_sysfs() -> Optional[str]:
     """Find the sysfs base path for an AMD GPU device."""
     import glob
@@ -143,6 +168,7 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
 
     try:
         gpus = []
+        any_unified = False
         for line in lines:
             parts = [p.strip() for p in line.split(",")]
             if len(parts) < 5:
@@ -153,12 +179,19 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
                     power_w = round(float(parts[5]), 1)
                 except (ValueError, TypeError):
                     pass
-            # Guard against [N/A] / [Not Supported] — skip row if memory is unavailable
             na_values = ("[N/A]", "[Not Supported]", "N/A", "Not Supported", "")
-            if parts[1] in na_values or parts[2] in na_values:
-                continue
-            mem_used = int(parts[1])
-            mem_total = int(parts[2])
+            # GB10/GB200 unified memory: nvidia-smi reports [N/A] for memory
+            # fields; fall back to /proc/meminfo (mirrors detection.sh).
+            unified = parts[1] in na_values or parts[2] in na_values
+            if unified:
+                fallback = _read_meminfo_mb()
+                if not fallback:
+                    continue
+                mem_used, mem_total = fallback
+                any_unified = True
+            else:
+                mem_used = int(parts[1])
+                mem_total = int(parts[2])
             util = int(parts[3]) if parts[3] not in na_values else 0
             temp = int(parts[4]) if parts[4] not in na_values else 0
             gpus.append({
@@ -173,6 +206,8 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
         if not gpus:
             return None
 
+        memory_type = "unified" if any_unified else "discrete"
+
         if len(gpus) == 1:
             g = gpus[0]
             mem_used, mem_total = g["mem_used"], g["mem_total"]
@@ -184,6 +219,7 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
                 utilization_percent=g["util"],
                 temperature_c=g["temp"],
                 power_w=g["power_w"],
+                memory_type=memory_type,
                 gpu_backend="nvidia",
             )
 
@@ -214,6 +250,7 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
             utilization_percent=avg_util,
             temperature_c=max_temp,
             power_w=total_power,
+            memory_type=memory_type,
             gpu_backend="nvidia",
         )
     except (ValueError, IndexError):
@@ -476,19 +513,27 @@ def get_gpu_info_nvidia_detailed() -> Optional[list[IndividualGPU]]:
         uuid_service_map = _infer_gpu_services_from_processes()
 
     gpus: list[IndividualGPU] = []
+    na_values = ("[N/A]", "[Not Supported]", "N/A", "Not Supported", "")
     for line in lines:
         try:
             parts = [p.strip() for p in line.split(",")]
             if len(parts) < 7:
                 continue
             power_w = None
-            if len(parts) >= 8 and parts[7] not in ("[N/A]", "[Not Supported]", "N/A", "Not Supported", ""):
+            if len(parts) >= 8 and parts[7] not in na_values:
                 try:
                     power_w = round(float(parts[7]), 1)
                 except (ValueError, TypeError):
                     pass
-            mem_used = int(parts[3])
-            mem_total = int(parts[4])
+            # GB10/GB200 unified memory fallback (see _read_meminfo_mb).
+            if parts[3] in na_values or parts[4] in na_values:
+                fallback = _read_meminfo_mb()
+                if not fallback:
+                    continue
+                mem_used, mem_total = fallback
+            else:
+                mem_used = int(parts[3])
+                mem_total = int(parts[4])
             uuid = parts[1]
             gpus.append(IndividualGPU(
                 index=int(parts[0]),

--- a/dream-server/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_gpu.py
@@ -102,6 +102,29 @@ class TestGetGpuInfoNvidia:
         assert info.memory_used_mb == 2048 + 4096
         assert info.memory_total_mb == 24564 * 2
 
+    def test_unified_memory_fallback_for_na_memory(self, monkeypatch):
+        # GB10 / GB200 unified-memory: nvidia-smi reports [N/A] for memory.
+        csv = "NVIDIA GB10, [N/A], [N/A], 6, 43, 8.2"
+        monkeypatch.setattr("gpu.run_command", lambda cmd, **kw: (True, csv))
+        monkeypatch.setattr("gpu._read_meminfo_mb", lambda: (12000, 124000))
+
+        info = get_gpu_info_nvidia()
+        assert info is not None
+        assert info.name == "NVIDIA GB10"
+        assert info.memory_used_mb == 12000
+        assert info.memory_total_mb == 124000
+        assert info.memory_type == "unified"
+        assert info.utilization_percent == 6
+        assert info.temperature_c == 43
+        assert info.power_w == 8.2
+
+    def test_unified_memory_fallback_skips_when_meminfo_unavailable(self, monkeypatch):
+        csv = "NVIDIA GB10, [N/A], [N/A], 6, 43, 8.2"
+        monkeypatch.setattr("gpu.run_command", lambda cmd, **kw: (True, csv))
+        monkeypatch.setattr("gpu._read_meminfo_mb", lambda: None)
+
+        assert get_gpu_info_nvidia() is None
+
 
 # --- get_gpu_info_apple (mock subprocess) ---
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -185,6 +185,23 @@ class TestGetGpuInfoNvidiaDetailed:
         monkeypatch.setattr("gpu.run_command", lambda cmd, **kw: (True, ""))
         assert get_gpu_info_nvidia_detailed() is None
 
+    def test_unified_memory_fallback_for_na_memory(self, monkeypatch):
+        # GB10 / GB200 unified-memory: nvidia-smi reports [N/A] for memory.
+        csv = "0, GPU-gb10-uuid, NVIDIA GB10, [N/A], [N/A], 6, 43, 8.2"
+        monkeypatch.setattr("gpu.run_command", lambda cmd, **kw: (True, csv))
+        monkeypatch.setattr("gpu._read_meminfo_mb", lambda: (12000, 124000))
+        monkeypatch.delenv("GPU_ASSIGNMENT_JSON_B64", raising=False)
+
+        result = get_gpu_info_nvidia_detailed()
+        assert result is not None and len(result) == 1
+        g = result[0]
+        assert g.name == "NVIDIA GB10"
+        assert g.memory_used_mb == 12000
+        assert g.memory_total_mb == 124000
+        assert g.utilization_percent == 6
+        assert g.temperature_c == 43
+        assert g.power_w == 8.2
+
 
 # ============================================================================
 # get_gpu_info_amd_detailed


### PR DESCRIPTION
## Summary

On NVIDIA Grace Blackwell hardware (GB10, GB200), `nvidia-smi` reports `[N/A]` for `memory.total` / `memory.used` because the GPU shares system RAM. The dashboard-api was skipping any row with `[N/A]` values, so `get_gpu_info_nvidia()` and `get_gpu_info_nvidia_detailed()` returned `None` and the dashboard rendered **"no GPU detected"** on a working GB10.

This mirrors the fallback already in `installers/lib/detection.sh` (added in #875): when memory fields are `[N/A]`, read `MemTotal` / `MemAvailable` from `/proc/meminfo` and tag the GPU as `memory_type="unified"`. Utilization, temperature, and power keep coming from `nvidia-smi` — those fields work on GB10.

After this change on a DGX Spark:

```
$ curl -sH "Authorization: Bearer …" http://127.0.0.1:3001/api/status | jq .gpu
{
  "name": "NVIDIA GB10",
  "vramUsed": 12.3,
  "vramTotal": 121.7,
  "utilization": 8,
  "temperature": 45,
  "memoryType": "unified",
  "backend": "nvidia",
  "gpu_count": 1,
  "powerDraw": 9.3,
  "memoryLabel": "VRAM Partition"
}
```

Follow-on to #1130 (now merged); the runtime metrics path needed the same treatment as the installer detection path.

## Changes

- `extensions/services/dashboard-api/gpu.py`
  - New `_read_meminfo_mb()` helper (reads `MemTotal` / `MemAvailable`).
  - `get_gpu_info_nvidia()` falls back to `_read_meminfo_mb()` when memory is `[N/A]`; sets `memory_type="unified"` on the resulting `GPUInfo`.
  - `get_gpu_info_nvidia_detailed()` does the same per-GPU.
- `tests/test_gpu.py`, `tests/test_gpu_detailed.py`
  - Three new tests covering the fallback path and the case where `/proc/meminfo` is unavailable.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `pytest tests/test_gpu.py tests/test_gpu_detailed.py` — 65 passed (was 62)
- [x] On DGX Spark (GB10): rebuilt `dashboard-api` image, `localhost:3001` shows the GB10 with correct util / temp / VRAM, `memoryType` reads `unified`.
- [ ] Regression check on a discrete-VRAM NVIDIA host (need a reviewer with an RTX-class card).

## Notes

- No model change; `IndividualGPU` does not gain `memory_type`. The aggregate built by `routers/gpu.py::_build_aggregate` still defaults to `"discrete"`. Propagating `memory_type` into per-GPU records and through the aggregate would be a follow-up — left out here to keep the diff focused on the "no GPU detected" symptom.
- `_read_meminfo_mb` returns `None` on `OSError` (missing/unreadable `/proc/meminfo`); callers fall through to skipping the row, matching the existing behavior on hosts with no meminfo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)