### PR TITLE
fix(setup): inject docker-network service URLs into dashboard-api for diagnostics

### DIFF
--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -213,6 +213,14 @@ services:
       # the redemption host sees the cookie); functional for single-host
       # setups but breaks subdomain SSO.
       - DREAM_COOKIE_DOMAIN=${DREAM_COOKIE_DOMAIN:-}
+      # URLs consumed by scripts/dream-test-functional.sh (executed inside this
+      # container by /api/setup/test). The script's own `localhost:<port>`
+      # defaults are correct for host-side runs but unreachable from inside
+      # the container; explicitly point at docker network names here.
+      - LLM_URL=${LLM_URL:-${LLM_API_URL:-http://llama-server:8080}}
+      - TTS_URL=${TTS_URL:-http://tts:8880}
+      - EMBEDDING_URL=${EMBEDDING_URL:-http://embeddings:80}
+      - WHISPER_URL=${WHISPER_URL:-http://whisper:8000}
     volumes:
       - ./scripts:/dream-server/scripts:ro
       - ./config:/dream-server/config:ro

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -43,6 +43,29 @@ bash tests/contracts/test-port-contracts.sh
 echo "[contract] Windows AMD local compose readiness"
 bash tests/contracts/test-windows-amd-local-compose.sh
 
+echo "[contract] dashboard diagnostics route through docker network URLs"
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  tmp_env="$(mktemp)"
+  trap 'rm -f "$tmp_env"' EXIT
+  cat > "$tmp_env" <<'ENV_EOF'
+WEBUI_SECRET=ci-placeholder
+LLM_API_URL=http://litellm:4000
+ENV_EOF
+  rendered="$(docker compose --env-file "$tmp_env" -f docker-compose.base.yml config dashboard-api)"
+  grep -q 'LLM_URL: http://litellm:4000' <<<"$rendered" \
+    || { echo "[FAIL] dashboard-api diagnostics LLM_URL must follow LLM_API_URL when LLM_URL is unset"; exit 1; }
+  grep -q 'OLLAMA_URL: http://litellm:4000' <<<"$rendered" \
+    || { echo "[FAIL] dashboard-api OLLAMA_URL lost LLM_API_URL routing"; exit 1; }
+  grep -q 'TTS_URL: http://tts:8880' <<<"$rendered" \
+    || { echo "[FAIL] dashboard-api diagnostics TTS_URL must use docker network hostname"; exit 1; }
+  grep -q 'EMBEDDING_URL: http://embeddings:80' <<<"$rendered" \
+    || { echo "[FAIL] dashboard-api diagnostics EMBEDDING_URL must use docker network hostname"; exit 1; }
+  grep -q 'WHISPER_URL: http://whisper:8000' <<<"$rendered" \
+    || { echo "[FAIL] dashboard-api diagnostics WHISPER_URL must use docker network hostname"; exit 1; }
+else
+  echo "[SKIP] docker compose unavailable"
+fi
+
 echo "[contract] resolver scripts executable"
 for s in scripts/build-capability-profile.sh scripts/classify-hardware.sh scripts/load-backend-contract.sh scripts/resolve-compose-stack.sh scripts/preflight-engine.sh scripts/dream-doctor.sh scripts/simulate-installers.sh; do
   test -x "$s" || { echo "[FAIL] script not executable: $s"; exit 1; }


### PR DESCRIPTION
## Summary

`scripts/dream-test-functional.sh` is run by `POST /api/setup/test` from the setup wizard's "Run Diagnostics" step. The script is **executed inside the dashboard-api container**, but its `LLM_URL` / `TTS_URL` / `EMBEDDING_URL` / `WHISPER_URL` defaults all point at `http://localhost:<port>`. Those defaults are correct for someone running the script on the host (where each service is published on `127.0.0.1:<port>`), but inside the container `localhost` is the container's own loopback, so every test connect-refuses regardless of service health.

Symptom: setup wizard reports `0/3 passed, Some tests failed.` even when LLM / TTS / Whisper are all healthy → "Complete Setup" stays disabled (`disabled={!config.tested}` in `SetupWizard.jsx`) and the user is stuck on the diagnostics screen.

## Fix

Set the URLs explicitly on `dashboard-api` in `docker-compose.base.yml`, using docker network hostnames:

```yaml
- LLM_URL=${LLM_URL:-http://llama-server:8080}
- TTS_URL=${TTS_URL:-http://tts:8880}
- EMBEDDING_URL=${EMBEDDING_URL:-http://embeddings:80}
- WHISPER_URL=${WHISPER_URL:-http://whisper:8000}
```

The script's existing `${VAR:-default}` pattern picks these up. Host-side invocations of the script (e.g. for debugging) keep working as before via the unchanged `localhost:<port>` defaults.

## Before / after on a live install (DGX Spark, GB10)

Before:
```
> Testing LLM Functional Generation
✗ LLM returned no response
> Testing TTS Audio Generation
✗ TTS returned HTTP 000
> Testing Embeddings Vector Generation
✗ Embeddings returned no response
Results: 0 passed, 3 failed
__DREAM_RESULT__:FAIL:1
```

After:
```
> Testing LLM Functional Generation
✓ LLM generates text (answer may vary)
> Testing TTS Audio Generation
✓ TTS generates audio file (72248 bytes)
> Testing Embeddings Vector Generation
✗ Embeddings returned no response          ← TEI amd64-only image, OOS
> Testing Whisper Transcription
✗ Whisper returned empty transcription     ← missing model, OOS
Results: 2 passed, 2 failed
```

LLM and TTS now correctly reflect actual health. The remaining two failures are real, separate bugs out of scope here:

- **Embeddings**: `text-embeddings-inference` does not publish an arm64 manifest, so `dream-embeddings` can't start on aarch64 hosts (already tracked as a follow-up to #1130).
- **Whisper**: `dream-whisper` returns `{"detail":"Model 'Systran/faster-whisper-large-v3' is not installed locally."}` on this install — a model-provisioning issue separate from the diagnostic plumbing.

## Test plan

- [x] `make lint`
- [x] `docker compose ... config dashboard-api` shows the four URLs on the merged config.
- [x] Recreated `dashboard-api` on live install; `POST /api/setup/test` now produces the after-output above (LLM + TTS PASS).
- [ ] Reviewer with a healthy embeddings/whisper install confirms all four PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)