### PR TITLE
fix(dashboard): allow setup wizard to be completed when diagnostics fail

### DIFF
--- a/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -9,7 +9,6 @@ export default function SetupWizard({ onComplete }) {
   const [config, setConfig] = useState({
     userName: '',
     voice: 'af_heart',
-    tested: false,
     preflightPassed: false
   })
   const [testStatus, setTestStatus] = useState({ running: false, output: [], done: false, success: false })
@@ -133,9 +132,6 @@ export default function SetupWizard({ onComplete }) {
         : collected.some(l => l.includes('All tests passed!'))
 
       setTestStatus(prev => ({ ...prev, running: false, done: true, success }))
-      if (success) {
-        setConfig(c => ({ ...c, tested: true }))
-      }
     } catch (err) {
       // Aborted fetches throw AbortError. That's the user cancelling or the
       // component unmounting — don't surface it as a user-visible error.
@@ -330,9 +326,21 @@ export default function SetupWizard({ onComplete }) {
               )}
 
               {testStatus.done && (
-                <div className={`mt-4 p-4 rounded-lg ${testStatus.success ? 'bg-green-500/20 text-green-400' : 'bg-red-500/20 text-red-400'}`}>
-                  {testStatus.success ? '✓ All systems operational' : '✗ Some tests failed — check logs'}
+                <div className={`mt-4 p-4 rounded-lg ${testStatus.success ? 'bg-green-500/20 text-green-400' : 'bg-amber-500/20 text-amber-400'}`}>
+                  {testStatus.success
+                    ? '✓ All systems operational'
+                    : '⚠ Some tests failed — review the log above. You can re-run, or continue anyway and revisit from the Diagnostics tab later.'}
                 </div>
+              )}
+
+              {testStatus.done && !testStatus.success && (
+                <button
+                  onClick={runDiagnostics}
+                  disabled={testStatus.running}
+                  className="mt-4 px-4 py-2 text-sm bg-theme-card hover:bg-theme-surface-hover text-theme-text rounded-lg transition-colors disabled:opacity-50"
+                >
+                  Re-run Diagnostics
+                </button>
               )}
             </div>
           )}
@@ -365,11 +373,15 @@ export default function SetupWizard({ onComplete }) {
             ) : (
               <button
                 onClick={saveConfig}
-                disabled={!config.tested}
-                className="flex items-center gap-2 px-6 py-2 bg-green-600 hover:bg-green-700 disabled:bg-zinc-700 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+                disabled={!testStatus.done}
+                className={`flex items-center gap-2 px-6 py-2 ${
+                  testStatus.success
+                    ? 'bg-green-600 hover:bg-green-700'
+                    : 'bg-amber-600 hover:bg-amber-700'
+                } disabled:bg-zinc-700 disabled:cursor-not-allowed text-white rounded-lg transition-colors`}
               >
                 <CheckCircle className="w-5 h-5" />
-                Complete Setup
+                {testStatus.success ? 'Complete Setup' : 'Continue Anyway'}
               </button>
             )}
           </div>

--- a/dream-server/extensions/services/dashboard/src/components/__tests__/SetupWizard.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/__tests__/SetupWizard.test.jsx
@@ -156,8 +156,30 @@ describe('SetupWizard diagnostics sentinel parser', () => {
       expect(screen.getByText(/Some tests failed/i)).toBeInTheDocument()
     })
     expect(screen.queryByText(/__DREAM_RESULT__/)).not.toBeInTheDocument()
-    // Complete Setup remains disabled because tested=false.
-    expect(screen.getByRole('button', { name: /Complete Setup/i })).toBeDisabled()
+    // After failure the bottom button flips from "Complete Setup" to
+    // "Continue Anyway" and is enabled — so a transient diagnostic failure
+    // doesn't lock the user out of the wizard. A "Re-run Diagnostics" button
+    // also appears next to the failure banner.
+    expect(screen.queryByRole('button', { name: /^Complete Setup$/i })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Continue Anyway/i })).toBeEnabled()
+    expect(screen.getByRole('button', { name: /Re-run Diagnostics/i })).toBeEnabled()
+  })
+
+  test('clicking Continue Anyway after a failed diagnostic completes the wizard', async () => {
+    stubFetchWithSetupStream([
+      'bar\n',
+      '__DREAM_RESULT__:FAIL:3\n'
+    ])
+
+    const onComplete = vi.fn()
+    render(<SetupWizard onComplete={onComplete} />)
+    await navigateToStep6()
+
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: /Start Diagnostics/i })))
+    await waitFor(() => expect(screen.getByText(/Some tests failed/i)).toBeInTheDocument())
+
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: /Continue Anyway/i })))
+    expect(onComplete).toHaveBeenCalledTimes(1)
   })
 
   test('falls back to "All tests passed!" trailer when sentinel missing (older backend)', async () => {


### PR DESCRIPTION
## Summary

The setup wizard's Step 6 "Complete Setup" button was gated on `config.tested`, set true only when *every* functional test PASSed. A single genuinely-failing-but-optional service (embeddings on a host with no arm64 TEI image, whisper missing its model, a transient TTS hiccup, etc.) was enough to permanently lock a user out of the wizard. The only failure UI was a red "✗ Some tests failed — check logs" banner and a disabled green button — no skip path, no re-run affordance, no way to acknowledge the failure and proceed.

This was severe enough that on a fresh GB10 install the only way to escape the wizard was to open DevTools and `localStorage.setItem('dream-dashboard-visited','true')`.

## Fix

Loosen the gate: the bottom button is now disabled only while diagnostics haven't completed (`!testStatus.done`). Once the run finishes — pass or fail — the button is always clickable. Its label and color flip based on outcome:

| Outcome | Color | Label             |
| ------- | ----- | ----------------- |
| PASS    | green | Complete Setup    |
| FAIL    | amber | Continue Anyway   |

The failure banner copy is updated accordingly:

> ⚠ Some tests failed — review the log above. You can re-run, or continue anyway and revisit from the Diagnostics tab later.

A "Re-run Diagnostics" button is added next to that banner so the user can retry without leaving the step. The dead `config.tested` field is removed (it had no other readers).

## What this isn't

This isn't lying to the user — failures are still surfaced clearly with amber styling and explanatory copy. It isn't auto-skipping either: the user has to read the "Continue Anyway" label and click it deliberately. It just stops *blocking* progress on something that's almost always going to be a partial-fail in practice.

## Test plan

- [x] Unit tests updated. The previous `expect(...Complete Setup...).toBeDisabled()` assertion is replaced with three: button label flips to "Continue Anyway", that button is enabled, "Re-run Diagnostics" appears.
- [x] New test: clicking "Continue Anyway" after a FAIL sentinel calls `onComplete` once.
- [x] Full dashboard test suite — `vitest run` — 12 files, 61 tests, all green (was 59).
- [x] Rebuilt `dream-server-dashboard` image on a live install (DGX Spark / GB10) — `Continue Anyway`, `Re-run Diagnostics`, and `Complete Setup` strings all present in the deployed JS bundle.
- [ ] Manual click-through in the browser by a reviewer to confirm UX feel.

## Diff stat

```
SetupWizard.jsx           | 30 +++++++++++++++-------
SetupWizard.test.jsx      | 26 +++++++++++++++++--
2 files changed, 45 insertions(+), 11 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)