### PR TITLE
fix: detect DGX Spark llama.cpp arch mismatch

### DIFF
--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -18,6 +18,8 @@ const EXTERNAL_PORT = process.env.OPENCLAW_EXTERNAL_PORT || '7860';
 const LLM_MODEL = process.env.LLM_MODEL || '';
 const GGUF_FILE = process.env.GGUF_FILE || '';
 const OPENCLAW_LLM_URL = process.env.OPENCLAW_LLM_URL || '';
+const BIND_ADDRESS = (process.env.BIND_ADDRESS || '127.0.0.1').trim();
+const AUTO_TOKEN_ALLOWED = ['127.0.0.1', 'localhost', '::1'].includes(BIND_ADDRESS);
 
 // On AMD/Lemonade, compose.amd.yaml sets OLLAMA_URL to
 // "http://llama-server:8080/api" (Lemonade's Ollama-compat endpoint).
@@ -29,8 +31,8 @@ const OLLAMA_URL = process.env.OLLAMA_URL || '';
 const _isLemonade = /\/api\/?$/.test(OLLAMA_URL);
 const EFFECTIVE_MODEL = (_isLemonade && GGUF_FILE) ? `extra.${GGUF_FILE}` : LLM_MODEL;
 const CONFIG_PATH = path.join(process.env.HOME || '/home/node', '.openclaw', 'openclaw.json');
-const HTML_PATH = '/app/dist/control-ui/index.html';
-const JS_PATH = '/app/dist/control-ui/auto-token.js';
+const HTML_PATH = process.env.OPENCLAW_CONTROL_UI_HTML || '/app/dist/control-ui/index.html';
+const JS_PATH = process.env.OPENCLAW_AUTO_TOKEN_JS || '/app/dist/control-ui/auto-token.js';
 
 // ── Part 1: Patch runtime config ──────────────────────────────────────────────
 
@@ -162,26 +164,36 @@ try {
 
 if (token && fs.existsSync(HTML_PATH)) {
   try {
-    // 1. Auto-token injection is DISABLED.
+    // 1. Create external JS file for token bootstrap.
     //
-    // Previously this wrote the raw gateway token into /app/dist/control-ui/auto-token.js,
-    // which the OpenClaw gateway serves UNAUTHENTICATED at HTTP root. With
-    // BIND_ADDRESS=0.0.0.0 (LAN mode) anyone on the LAN could fetch
-    // http://<host>:<port>/auto-token.js and harvest the token. See fork issue #548.
+    // Do not write the gateway token to the unauthenticated static asset when
+    // Dream Server is LAN-bound. With BIND_ADDRESS=0.0.0.0, anyone on the LAN
+    // could fetch http://<host>:<port>/auto-token.js and harvest the token.
     //
-    // We still write a placeholder file (and keep the <script src="./auto-token.js">
-    // injection below) so the gateway's CSP `script-src 'self'` policy is satisfied
-    // and existing HTML references do not 404. The placeholder contains no secrets.
-    //
-    // UX impact: Control UI no longer auto-signs-in. Users must paste the token
-    // manually from the install summary or the OPENCLAW_TOKEN value in .env.
-    const placeholder = [
-      '// Auto-token injection disabled to prevent gateway-token disclosure via',
-      '// this unauthenticated static asset (fork issue #548).',
-      '// Paste the token manually from .env (OPENCLAW_TOKEN) into the Control UI.',
-      '(function(){ /* no-op */ })();',
-    ].join('\n');
-    fs.writeFileSync(JS_PATH, placeholder);
+    // For the default localhost-only bind, the asset is only reachable from the
+    // same machine, so restore auto-connect UX by placing the token into the
+    // Control UI settings store.
+    let jsCode;
+    if (AUTO_TOKEN_ALLOWED) {
+      jsCode = [
+        '(function() {',
+        '  var k = "openclaw.control.settings.v1";',
+        '  var s = {};',
+        '  try { s = JSON.parse(localStorage.getItem(k) || "{}"); } catch(e) {}',
+        '  s.token = ' + JSON.stringify(token) + ';',
+        '  s.gatewayUrl = (location.protocol === "https:" ? "wss://" : "ws://") + location.host;',
+        '  localStorage.setItem(k, JSON.stringify(s));',
+        '})();',
+      ].join('\n');
+    } else {
+      jsCode = [
+        '// Auto-token injection disabled to prevent gateway-token disclosure via',
+        '// this unauthenticated static asset when Dream Server is LAN-bound.',
+        '// Paste the token manually from .env (OPENCLAW_TOKEN) into the Control UI.',
+        '(function(){ /* no-op */ })();',
+      ].join('\n');
+    }
+    fs.writeFileSync(JS_PATH, jsCode);
 
     // 2. Inject <script src> tag as first element in <head> (satisfies CSP 'self')
     let html = fs.readFileSync(HTML_PATH, 'utf8');
@@ -192,7 +204,11 @@ if (token && fs.existsSync(HTML_PATH)) {
     html = html.replace('<head>', '<head><script src="./auto-token.js"></script>');
     fs.writeFileSync(HTML_PATH, html);
 
-    console.log('[inject-token] wrote placeholder auto-token.js (token disclosure mitigated; manual sign-in required)');
+    if (AUTO_TOKEN_ALLOWED) {
+      console.log('[inject-token] wrote localhost-only auto-token.js');
+    } else {
+      console.log('[inject-token] wrote placeholder auto-token.js (LAN token disclosure mitigated; manual sign-in required)');
+    }
   } catch (err) {
     console.error('[inject-token] UI injection warning:', err.message);
   }

--- a/dream-server/docs/DGX-SPARK-GB10-LLAMA-CPP-NOTES.md
+++ b/dream-server/docs/DGX-SPARK-GB10-LLAMA-CPP-NOTES.md
@@ -1,0 +1,157 @@
+# DGX Spark GB10 llama.cpp Notes
+
+Date: 2026-05-07
+
+This note tracks a field investigation on an NVIDIA DGX Spark / GB10 machine where
+Qwen3-Coder-Next returned only question marks through Open WebUI.
+
+## Machine
+
+- Host: DGX Spark field machine
+- OS: Ubuntu 24.04.4 LTS, aarch64
+- Kernel: `6.17.0-1014-nvidia`
+- GPU: NVIDIA GB10, compute capability 12.1
+- CUDA toolkit: 13.0.88
+- Driver: 580.142
+
+## Symptom
+
+Open WebUI displayed responses like:
+
+```text
+????????????????????????????????
+```
+
+The issue reproduced outside Open WebUI by calling llama.cpp directly:
+
+```bash
+curl -sS http://127.0.0.1:11434/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"qwen3-coder-next","messages":[{"role":"user","content":"What is 2+2? Answer in one short sentence."}],"max_tokens":32,"temperature":0}'
+```
+
+With `ghcr.io/ggml-org/llama.cpp:server-cuda-b9014`, the response content was
+question marks. Raw `/completion` and `/v1/completions` requests showed the same
+behavior, so this was not an Open WebUI rendering issue.
+
+## Isolation
+
+- Same GGUF on CPU-only llama.cpp generated normal text.
+- GPU offload with the generic llama.cpp CUDA image generated question marks.
+- Disabling flash attention did not fix the output.
+- `--no-op-offload` improved a trivial echo prompt but still failed a basic
+  `2+2` prompt.
+- The model file itself was viable:
+  - Path: `$HOME/dream-server/data/models/qwen3-coder-next-Q4_K_M.gguf`
+  - SHA256: `9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090`
+
+## Bad Runtime Evidence
+
+The failing container reported GB10 as compute 12.1, but the compiled CUDA archs
+did not include the Spark target:
+
+```text
+Device 0: NVIDIA GB10, compute capability 12.1
+system_info: ... CUDA : ARCHS = 500,610,700,750,800,860,890,1200 ...
+```
+
+NVIDIA's DGX Spark llama.cpp playbook instructs Spark users to build llama.cpp
+with:
+
+```bash
+-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="121"
+```
+
+The DGX Spark porting guide similarly recommends compiling for `121-real`.
+
+Relevant upstream references:
+
+- https://build.nvidia.com/spark/llama-cpp/instructions
+- https://build.nvidia.com/spark/llama-cpp/troubleshooting
+- https://docs.nvidia.com/dgx/dgx-spark-porting-guide/porting/compilation.html
+- https://github.com/ggml-org/llama.cpp/issues/19305
+
+## Working Runtime
+
+Built llama.cpp natively on the Spark:
+
+```bash
+git clone --depth=1 https://github.com/ggml-org/llama.cpp $HOME/code/llama.cpp-gb10
+cd $HOME/code/llama.cpp-gb10
+cmake -S . -B build-gb10 \
+  -DGGML_CUDA=ON \
+  -DCMAKE_CUDA_ARCHITECTURES=121 \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DLLAMA_CURL=OFF \
+  -DCMAKE_CUDA_COMPILER=/usr/local/cuda/bin/nvcc
+cmake --build build-gb10 --target llama-server -j 12
+```
+
+CMake rewrote the Spark target as expected:
+
+```text
+Replacing 121 in CMAKE_CUDA_ARCHITECTURES with 121a
+Using CMAKE_CUDA_ARCHITECTURES=121a
+```
+
+The working binary reports:
+
+```text
+build_info: b1-2496f9c
+system_info: ... CUDA : ARCHS = 1210 ... BLACKWELL_NATIVE_FP4 = 1 ...
+```
+
+Native and containerized tests both produced normal text:
+
+```text
+2 + 2 = 4.
+Hello from Qwen.
+```
+
+## Local Dream Server Fix Applied
+
+Created a local image:
+
+```text
+dream-llama-cpp-gb10:sm121-2496f9c
+```
+
+The image uses:
+
+- Base: `nvidia/cuda:13.0.0-runtime-ubuntu24.04`
+- Runtime deps: `ca-certificates`, `curl`, `libgomp1`, `libssl3`
+- Payload: `build-gb10/bin/` copied to `/app`
+- Entry point: `/app/llama-server`
+
+Updated the live install at `$HOME/dream-server/.env`:
+
+```env
+LLAMA_SERVER_IMAGE=dream-llama-cpp-gb10:sm121-2496f9c
+```
+
+Validation after `./dream-cli start llm`:
+
+- `dream-llama-server` is healthy.
+- Host API `http://127.0.0.1:11434/v1/chat/completions` returns normal text.
+- Open WebUI container path `http://llama-server:8080/v1/chat/completions`
+  returns normal text.
+
+## Upstream Changes And Follow-ups
+
+- Added a `dream doctor` runtime check that detects DGX Spark / GB10
+  (`compute_cap=12.1` or `nvidia-smi` name contains `GB10`) and compares
+  llama-server's reported CUDA archs against the required `sm_121` target.
+- Warn when GB10 is served by a llama.cpp CUDA binary that reports archs without
+  `1210` / `121` / `121a`.
+- Surface a remediation hint to build llama.cpp with
+  `-DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=121` or use a GB10-specific
+  llama-server image.
+
+Follow-up ideas:
+
+- Avoid selecting generic llama.cpp CUDA images for GB10 unless the image is
+  known to include `sm_121` / `121a` support.
+- Add a GB10-specific local build path or documented override for
+  `LLAMA_SERVER_IMAGE`.
+- Add troubleshooting text for the specific question-mark output pattern:
+  direct API repro, CPU-only isolation, and `sm_121` rebuild guidance.

--- a/dream-server/docs/DREAM-DOCTOR.md
+++ b/dream-server/docs/DREAM-DOCTOR.md
@@ -43,6 +43,7 @@ Runtime Environment:
   ✓ Docker Compose
   ✗ Dashboard HTTP
   ✗ WebUI HTTP
+  ⚠ DGX Spark llama-server CUDA arch: DGX Spark detected, but llama-server reports CUDA archs '500,610,700,750,800,860,890,1200' without sm_121.
 
 Preflight Checks:
   ✓ RAM: 16GB available
@@ -68,6 +69,9 @@ dream doctor --json > report.json
 - **capability_profile**: Hardware detection snapshot
 - **preflight**: Blocker/warning analysis
 - **runtime**: Docker/Compose/UI reachability checks
+- **runtime.dgx_spark_cuda_arch_check**: Warns when a DGX Spark / GB10
+  machine is running a llama.cpp CUDA binary that does not report `sm_121`
+  support in `llama-server` logs.
 - **summary**: Aggregate status (blockers, warnings, runtime_ready)
 - **autofix_hints**: Prioritized remediation actions
 
@@ -95,4 +99,3 @@ The doctor command integrates with:
 ## Default Report Path
 
 `/tmp/dream-doctor-report.json`
-

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1434,6 +1434,14 @@ for name, status in checks:
         print(f"  {RED}✗{NC} {name}")
         has_failures = True
 
+dgx_check = runtime.get('dgx_spark_cuda_arch_check', {})
+dgx_status = dgx_check.get('status')
+dgx_message = dgx_check.get('message', '')
+if dgx_status == 'pass':
+    print(f"  {GREEN}✓{NC} DGX Spark llama-server CUDA arch")
+elif dgx_status == 'warn':
+    print(f"  {YELLOW}⚠{NC} DGX Spark llama-server CUDA arch: {dgx_message}")
+
 print()
 
 # Preflight checks
@@ -1466,6 +1474,7 @@ if pf_checks:
 summary = report.get('summary', {})
 blocker_count = summary.get('preflight_blockers', 0)
 warning_count = summary.get('preflight_warnings', 0)
+runtime_warning_count = summary.get('runtime_warnings', 0)
 runtime_ready = summary.get('runtime_ready', False)
 
 print(f"{CYAN}Summary:{NC}")
@@ -1473,7 +1482,9 @@ if blocker_count > 0:
     print(f"  {RED}✗{NC} {blocker_count} blocker(s) found")
 if warning_count > 0:
     print(f"  {YELLOW}⚠{NC} {warning_count} warning(s) found")
-if blocker_count == 0 and warning_count == 0 and runtime_ready:
+if runtime_warning_count > 0:
+    print(f"  {YELLOW}⚠{NC} {runtime_warning_count} runtime warning(s) found")
+if blocker_count == 0 and warning_count == 0 and runtime_warning_count == 0 and runtime_ready:
     print(f"  {GREEN}✓{NC} All checks passed")
 
 print()

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -18,6 +18,7 @@ services:
       - LITELLM_KEY=${LITELLM_KEY:-}
       - SEARXNG_BASE_URL=http://searxng:8080
       - OPENCLAW_EXTERNAL_PORT=${OPENCLAW_PORT:-7860}
+      - BIND_ADDRESS=${BIND_ADDRESS:-127.0.0.1}
       - HOME=/home/node
     user: "0:0"
     entrypoint: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.openclaw; exec setpriv --reuid=1000 --regid=1000 --clear-groups /bin/sh -c 'node /config/inject-token.js; export OPENCLAW_CONFIG_PATH=/tmp/openclaw-config.json; exec docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured --bind lan'"]

--- a/dream-server/opencode/opencode-web.service
+++ b/dream-server/opencode/opencode-web.service
@@ -13,7 +13,10 @@ RestartSec=5
 # Environment
 Environment=HOME=__HOME__
 Environment=PATH=__HOME__/.opencode/bin:/usr/local/bin:/usr/bin:/bin
-EnvironmentFile=-__HOME__/dream-server/.env
+# Do not import Dream Server's full .env here. OpenCode treats
+# OPENCODE_SERVER_PASSWORD as a Basic Auth password when present, but this
+# localhost-only web UI should be reachable without a login prompt.
+UnsetEnvironment=OPENCODE_SERVER_PASSWORD
 
 # Hardening
 NoNewPrivileges=true

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -153,6 +153,45 @@ if [[ "${ENABLE_VOICE:-false}" == "true" ]] && command -v curl >/dev/null 2>&1; 
     fi
 fi
 
+# DGX Spark / GB10 CUDA arch check. Generic llama.cpp CUDA images can run on
+# GB10 while missing sm_121 support, which has been observed to produce
+# syntactically valid but unusable model output. Surface that mismatch in
+# doctor so operators do not have to infer it from llama-server logs.
+DGX_SPARK_GPU="false"
+DGX_SPARK_GPU_NAME=""
+DGX_SPARK_COMPUTE_CAP=""
+LLAMA_CUDA_ARCHS=""
+DGX_SPARK_CUDA_ARCH_STATUS="unknown"
+DGX_SPARK_CUDA_ARCH_MESSAGE=""
+_doctor_gpu_backend="${GPU_BACKEND:-${CAP_LLM_BACKEND:-}}"
+if [[ "$_doctor_gpu_backend" == "nvidia" ]] && command -v nvidia-smi >/dev/null 2>&1; then
+    _dgx_gpu_raw="$(nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader,nounits 2>/dev/null | head -1 || true)"
+    if [[ -n "$_dgx_gpu_raw" ]]; then
+        DGX_SPARK_GPU_NAME="$(echo "$_dgx_gpu_raw" | cut -d',' -f1 | xargs)"
+        DGX_SPARK_COMPUTE_CAP="$(echo "$_dgx_gpu_raw" | cut -d',' -f2 | xargs)"
+        if [[ "$DGX_SPARK_GPU_NAME" == *"GB10"* || "$DGX_SPARK_COMPUTE_CAP" == "12.1" ]]; then
+            DGX_SPARK_GPU="true"
+            if [[ "$DOCKER_DAEMON" == "true" ]] && docker ps -a --format '{{.Names}}' 2>/dev/null | grep -qx 'dream-llama-server'; then
+                _llama_arch_line="$(docker logs dream-llama-server 2>&1 | grep 'CUDA : ARCHS =' | tail -1 || true)"
+                LLAMA_CUDA_ARCHS="$(echo "$_llama_arch_line" | sed -n 's/.*CUDA : ARCHS = \([^|]*\).*/\1/p' | xargs)"
+                if [[ -z "$LLAMA_CUDA_ARCHS" ]]; then
+                    DGX_SPARK_CUDA_ARCH_STATUS="unknown"
+                    DGX_SPARK_CUDA_ARCH_MESSAGE="DGX Spark detected, but llama-server CUDA archs were not found in logs."
+                elif [[ ",${LLAMA_CUDA_ARCHS}," == *",1210,"* || ",${LLAMA_CUDA_ARCHS}," == *",121,"* || ",${LLAMA_CUDA_ARCHS}," == *",121a,"* ]]; then
+                    DGX_SPARK_CUDA_ARCH_STATUS="pass"
+                    DGX_SPARK_CUDA_ARCH_MESSAGE="DGX Spark llama-server binary includes sm_121 support."
+                else
+                    DGX_SPARK_CUDA_ARCH_STATUS="warn"
+                    DGX_SPARK_CUDA_ARCH_MESSAGE="DGX Spark detected, but llama-server reports CUDA archs '${LLAMA_CUDA_ARCHS}' without sm_121."
+                fi
+            else
+                DGX_SPARK_CUDA_ARCH_STATUS="unknown"
+                DGX_SPARK_CUDA_ARCH_MESSAGE="DGX Spark detected, but dream-llama-server is not available for CUDA arch inspection."
+            fi
+        fi
+    fi
+fi
+
 # Collect extension diagnostics (wrapped in function to allow local variables)
 collect_extension_diagnostics() {
     # Use outer GPU_BACKEND or default to nvidia (don't make local to avoid set -u issues)
@@ -259,13 +298,13 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" <<'PY'
+"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" "$DGX_SPARK_GPU" "$DGX_SPARK_GPU_NAME" "$DGX_SPARK_COMPUTE_CAP" "$LLAMA_CUDA_ARCHS" "$DGX_SPARK_CUDA_ARCH_STATUS" "$DGX_SPARK_CUDA_ARCH_MESSAGE" <<'PY'
 import json
 import pathlib
 import sys
 from datetime import datetime, timezone
 
-cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery = sys.argv[1:]
+cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message = sys.argv[1:]
 
 cap = json.load(open(cap_file, "r", encoding="utf-8"))
 pre = json.load(open(preflight_file, "r", encoding="utf-8"))
@@ -285,11 +324,20 @@ report = {
         "webui_http": webui_http == "true",
         "stt_model_cached": stt_cached,
         "stt_model_name": stt_model_name,
+        "dgx_spark_gpu": dgx_spark_gpu == "true",
+        "dgx_spark_gpu_name": dgx_spark_gpu_name,
+        "dgx_spark_compute_cap": dgx_spark_compute_cap,
+        "llama_cuda_archs": llama_cuda_archs,
+        "dgx_spark_cuda_arch_check": {
+            "status": dgx_spark_arch_status,
+            "message": dgx_spark_arch_message,
+        },
     },
     "extensions": ext_diagnostics,
     "summary": {
         "preflight_blockers": pre.get("summary", {}).get("blockers", 0),
         "preflight_warnings": pre.get("summary", {}).get("warnings", 0),
+        "runtime_warnings": 1 if dgx_spark_arch_status == "warn" else 0,
         "runtime_ready": (docker_daemon == "true" and compose_cli == "true"),
         "extensions_total": len(ext_diagnostics),
         "extensions_healthy": sum(1 for e in ext_diagnostics if e.get("health_status") == "healthy"),
@@ -321,6 +369,12 @@ if stt_cached == "false" and stt_recovery:
     fix_hints.append(
         f"Whisper STT model '{stt_model_name}' not cached — transcription will 404. "
         f"Run: {stt_recovery}"
+    )
+
+if dgx_spark_arch_status == "warn":
+    fix_hints.append(
+        "DGX Spark / GB10 detected, but llama-server was not built with sm_121 support. "
+        "Build llama.cpp with -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=121 or use a GB10-specific llama-server image."
     )
 
 # Extension-specific hints
@@ -382,6 +436,12 @@ ext_issues = summary.get("extensions_issues", 0)
 
 if ext_total > 0:
     print(f"  Extensions:    {ext_healthy}/{ext_total} healthy, {ext_issues} with issues")
+
+dgx_check = data.get("runtime", {}).get("dgx_spark_cuda_arch_check", {})
+if dgx_check.get("status") == "warn":
+    print(f"  DGX Spark:     warning - {dgx_check.get('message')}")
+elif dgx_check.get("status") == "pass":
+    print("  DGX Spark:     llama-server includes sm_121 support")
 
 hints = data.get("autofix_hints") or []
 if hints:

--- a/dream-server/tests/test-openclaw-inject-token.sh
+++ b/dream-server/tests/test-openclaw-inject-token.sh
@@ -74,6 +74,10 @@ fi
 TEST_HOME="$(mktemp -d -t dream-openclaw-XXXXXXXX)"
 mkdir -p "$TEST_HOME/.openclaw"
 MERGED_PATH="/tmp/openclaw-config.json"
+TEST_UI_DIR="$TEST_HOME/control-ui"
+TEST_HTML="$TEST_UI_DIR/index.html"
+TEST_JS="$TEST_UI_DIR/auto-token.js"
+mkdir -p "$TEST_UI_DIR"
 
 cleanup() {
     rm -rf "$TEST_HOME"
@@ -82,10 +86,14 @@ cleanup() {
 trap cleanup EXIT
 
 run_inject() {
+    local bind_address="${1:-127.0.0.1}"
     HOME="$TEST_HOME" \
     OPENCLAW_GATEWAY_TOKEN="test-token-abc123" \
     OPENCLAW_EXTERNAL_PORT="7860" \
     OPENCLAW_CONFIG="$SOURCE_CONFIG" \
+    OPENCLAW_CONTROL_UI_HTML="$TEST_HTML" \
+    OPENCLAW_AUTO_TOKEN_JS="$TEST_JS" \
+    BIND_ADDRESS="$bind_address" \
     LLM_MODEL="test-model" \
     GGUF_FILE="" \
     OLLAMA_URL="" \
@@ -94,6 +102,12 @@ run_inject() {
         node "$INJECT_SCRIPT" >/dev/null 2>&1
 }
 
+write_test_html() {
+    printf '%s\n' '<!doctype html><html><head></head><body></body></html>' >"$TEST_HTML"
+    rm -f "$TEST_JS"
+}
+
+write_test_html
 if ! run_inject; then
     fail "inject-token.js exited non-zero"
     exit 1
@@ -175,6 +189,39 @@ if [[ -f "$HOME_CONFIG" ]]; then
     fi
 else
     fail "Part 1 output ~/.openclaw/openclaw.json not written"
+fi
+
+# ── Assertion 6: localhost-only installs auto-bootstrap the Control UI token ─
+if [[ -f "$TEST_JS" ]]; then
+    if grep -Fq 'test-token-abc123' "$TEST_JS" \
+        && grep -Fq 'openclaw.control.settings.v1' "$TEST_JS" \
+        && grep -Fq 'localStorage.setItem' "$TEST_JS"; then
+        pass "localhost auto-token.js writes token into Control UI settings"
+    else
+        fail "localhost auto-token.js should bootstrap token and gateway URL"
+    fi
+else
+    fail "localhost auto-token.js was not written"
+fi
+
+if grep -Fq '<script src="./auto-token.js"></script>' "$TEST_HTML"; then
+    pass "Control UI HTML includes external auto-token script"
+else
+    fail "Control UI HTML missing external auto-token script"
+fi
+
+# ── Assertion 7: LAN-bound installs keep token out of unauthenticated asset ──
+write_test_html
+if ! run_inject "0.0.0.0"; then
+    fail "LAN-bound inject-token.js exited non-zero"
+else
+    if [[ -f "$TEST_JS" ]] \
+        && ! grep -Fq 'test-token-abc123' "$TEST_JS" \
+        && grep -Fq 'LAN-bound' "$TEST_JS"; then
+        pass "LAN-bound auto-token.js remains a token-free placeholder"
+    else
+        fail "LAN-bound auto-token.js must not contain the gateway token"
+    fi
 fi
 
 # ── Upgrade scenario: pre-seed bad flag, confirm Part 1 strips it ───────────


### PR DESCRIPTION
## Summary

- add a `dream doctor` runtime diagnostic for DGX Spark / GB10 systems that compares detected compute capability 12.1 against llama-server's reported CUDA arch list
- surface a remediation hint when GB10 is served by a llama.cpp CUDA binary without `sm_121` / `121a` support
- stop the OpenCode user service from importing Dream Server's full `.env`, which unintentionally enabled Basic Auth through `OPENCODE_SERVER_PASSWORD`
- restore OpenClaw Control UI auto-connect for localhost-only installs while keeping the token-free placeholder behavior for LAN-bound installs
- pass `BIND_ADDRESS` into OpenClaw so the token bootstrap can distinguish localhost from LAN exposure
- add a DGX Spark field note documenting the Qwen3-Coder-Next question-mark output, CPU/GPU isolation, and the working `CMAKE_CUDA_ARCHITECTURES=121` build path

## Validation

- `bash -n dream-server/scripts/dream-doctor.sh`
- `bash -n dream-server/dream-cli`
- `node --check dream-server/config/openclaw/inject-token.js`
- `git diff --check`
- `./tests/test-openclaw-inject-token.sh` (18 passed)
- `./tests/test-bind-address-sweep.sh`
- ran source-tree `dream-server/scripts/dream-doctor.sh /tmp/dream-doctor-pr-check.json` on DGX Spark; report shows `dgx_spark_gpu: true`, `llama_cuda_archs: "1210"`, `dgx_spark_cuda_arch_check.status: "pass"`
- verified local OpenCode service on `http://127.0.0.1:3003/` returns `200 text/html` without Basic Auth
- recreated live `dream-openclaw`; container is healthy on `127.0.0.1:7860`, serves localhost-only `auto-token.js`, and logs `agent model: local-llama/qwen3-coder-next`