### PR TITLE
[codex] Fix LXD AMD fallback when device nodes are missing

### DIFF
--- a/dream-server/docs/TROUBLESHOOTING.md
+++ b/dream-server/docs/TROUBLESHOOTING.md
@@ -38,6 +38,28 @@ sudo nvidia-ctk runtime configure --runtime=docker
 sudo systemctl restart docker
 ```
 
+### AMD GPU Devices Missing in LXD/LXC
+
+**Error:** installer reports missing `/dev/kfd`, `/dev/dri`, or `/dev/dri/renderD*`, or AMD services never become healthy inside an LXD container.
+
+**Cause:** LXD/LXC containers can expose enough host CPU/sysfs information for Dream Server to recognize AMD/Strix Halo hardware while still hiding the actual GPU device nodes that Docker must mount into ROCm containers.
+
+**Fix for GPU acceleration:** pass the GPU devices from the LXD host into the container, then re-run the installer.
+
+```bash
+lxc config set <container> security.nesting=true
+lxc config device add <container> gpu gpu
+lxc config device add <container> kfd unix-char path=/dev/kfd
+```
+
+**CPU fallback:** if you do not need GPU acceleration inside the container, run:
+
+```bash
+GPU_BACKEND=cpu ./install.sh
+```
+
+Fresh installs now fall back to CPU mode automatically when AMD is auto-detected but the required device nodes are unavailable inside a container. If you explicitly force `GPU_BACKEND=amd`, the installer fails fast with passthrough guidance instead.
+
 ---
 
 ## Startup Issues

--- a/dream-server/installers/lib/compose-select.sh
+++ b/dream-server/installers/lib/compose-select.sh
@@ -51,6 +51,11 @@ resolve_compose_config() {
                 COMPOSE_FLAGS="-f docker-compose.base.yml"
                 COMPOSE_FILE="docker-compose.base.yml"
             fi
+        elif [[ "$GPU_BACKEND" == "cpu" ]]; then
+            if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.cpu.yml" ]]; then
+                COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.cpu.yml"
+                COMPOSE_FILE="docker-compose.cpu.yml"
+            fi
         elif [[ "$TIER" == "SH_LARGE" || "$TIER" == "SH_COMPACT" ]]; then
             if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.amd.yml" ]]; then
                 COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.amd.yml"
@@ -65,11 +70,6 @@ resolve_compose_config() {
             elif [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.intel.yml" ]]; then
                 COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.intel.yml"
                 COMPOSE_FILE="docker-compose.intel.yml"
-            fi
-        elif [[ "$GPU_BACKEND" == "cpu" ]]; then
-            if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.cpu.yml" ]]; then
-                COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.cpu.yml"
-                COMPOSE_FILE="docker-compose.cpu.yml"
             fi
         else
             if [[ -f "$SCRIPT_DIR/docker-compose.base.yml" && -f "$SCRIPT_DIR/docker-compose.nvidia.yml" ]]; then

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -146,6 +146,132 @@ calculate_llama_cpu_budget() {
     echo "$limit $reservation $available"
 }
 
+ds_in_container() {
+    [[ -f /.dockerenv ]] && return 0
+    [[ -f /run/.containerenv ]] && return 0
+    if command -v systemd-detect-virt >/dev/null 2>&1; then
+        systemd-detect-virt --container --quiet 2>/dev/null && return 0
+    fi
+    if [[ -f /proc/1/cgroup ]] && grep -qiE '(docker|containerd|kubepods|lxc|libpod)' /proc/1/cgroup 2>/dev/null; then
+        return 0
+    fi
+    if [[ -f /proc/1/environ ]] && awk -v RS='\0' -F= '$1 == "container" { found = 1 } END { exit !found }' /proc/1/environ 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+ds_container_label() {
+    if command -v systemd-detect-virt >/dev/null 2>&1; then
+        local virt
+        virt=$(systemd-detect-virt --container 2>/dev/null || true)
+        [[ -n "$virt" && "$virt" != "none" ]] && { echo "$virt"; return 0; }
+    fi
+    if [[ -f /proc/1/environ ]]; then
+        local env_container
+        env_container=$(awk -v RS='\0' -F= '$1 == "container" { print $2; exit }' /proc/1/environ 2>/dev/null || true)
+        [[ -n "$env_container" ]] && { echo "$env_container"; return 0; }
+    fi
+    if [[ -f /.dockerenv ]]; then
+        echo "docker"
+    elif [[ -f /run/.containerenv ]]; then
+        echo "container"
+    elif [[ -f /proc/1/cgroup ]] && grep -qiE 'lxc|lxd' /proc/1/cgroup 2>/dev/null; then
+        echo "lxc"
+    else
+        echo "container"
+    fi
+}
+
+amd_gpu_missing_runtime_devices() {
+    local root="${DREAM_AMD_DEVICE_ROOT:-/dev}"
+    local kfd="$root/kfd"
+    local dri="$root/dri"
+    local missing=()
+
+    if [[ -n "${DREAM_AMD_DEVICE_ROOT:-}" ]]; then
+        [[ -e "$kfd" ]] || missing+=("$kfd")
+    else
+        [[ -c "$kfd" ]] || missing+=("$kfd")
+    fi
+
+    if [[ ! -d "$dri" ]]; then
+        missing+=("$dri")
+    elif ! compgen -G "$dri/renderD*" >/dev/null; then
+        missing+=("$dri/renderD*")
+    fi
+
+    printf '%s\n' "${missing[@]}"
+}
+
+amd_gpu_runtime_devices_available() {
+    [[ -z "$(amd_gpu_missing_runtime_devices)" ]]
+}
+
+amd_gpu_missing_devices_csv() {
+    local missing
+    missing="$(amd_gpu_missing_runtime_devices | xargs || true)"
+    printf '%s' "${missing// /, }"
+}
+
+show_amd_gpu_device_guidance() {
+    local missing="${1:-$(amd_gpu_missing_devices_csv)}"
+    ai_warn "AMD GPU device nodes unavailable: ${missing:-unknown}"
+    if ds_in_container; then
+        local container_label
+        container_label="$(ds_container_label)"
+        ai "Container environment detected (${container_label}). LXD/LXC containers can see CPU/sysfs clues while GPU device nodes stay hidden."
+        ai "For LXD GPU acceleration, pass the devices from the host, for example:"
+        ai "  lxc config device add <container> gpu gpu"
+        ai "  lxc config device add <container> kfd unix-char path=/dev/kfd"
+    else
+        ai "On native Linux, make sure the amdgpu/amdkfd modules are loaded and /dev/dri/renderD* exists."
+        ai "  sudo modprobe amdgpu"
+        ai "  sudo modprobe amdkfd"
+    fi
+}
+
+apply_cpu_gpu_fallback() {
+    local reason="${1:-AMD GPU runtime devices are unavailable.}"
+    ai_warn "$reason"
+    ai "Using CPU mode so installation can complete without GPU passthrough."
+
+    GPU_BACKEND="cpu"
+    GPU_NAME="None (CPU fallback)"
+    GPU_VRAM=0
+    GPU_COUNT=0
+    GPU_MEMORY_TYPE="none"
+    GPU_DEVICE_ID=""
+    HAS_NPU=false
+    [[ "${DREAM_MODE:-local}" == "lemonade" ]] && DREAM_MODE="local"
+    BACKEND_ID="cpu"
+    CAP_LLM_BACKEND="cpu"
+    CAP_GPU_VENDOR="cpu"
+    CAP_GPU_NAME="$GPU_NAME"
+    CAP_GPU_VRAM_MB=0
+    CAP_GPU_COUNT=0
+    CAP_GPU_MEMORY_TYPE="none"
+    CAP_RECOMMENDED_TIER=""
+    CAP_COMPOSE_OVERLAYS=""
+}
+
+select_cpu_fallback_tier() {
+    local ram_gb="${1:-0}"
+    if ! [[ "$ram_gb" =~ ^[0-9]+$ ]]; then
+        ram_gb=0
+    fi
+
+    if [[ "$ram_gb" -ge 96 ]]; then
+        echo "3"
+    elif [[ "$ram_gb" -ge 48 ]]; then
+        echo "2"
+    elif [[ "$ram_gb" -lt 12 ]]; then
+        echo "0"
+    else
+        echo "1"
+    fi
+}
+
 detect_gpu() {
     GPU_BACKEND="cpu"  # default to CPU-only fallback
     GPU_MEMORY_TYPE="none"

--- a/dream-server/installers/lib/ui.sh
+++ b/dream-server/installers/lib/ui.sh
@@ -265,6 +265,7 @@ check_service() {
   local url=$2
   local max_attempts=${3:-30}
   local timeout=${4:-10}  # Timeout per request (default 10s)
+  local container_name=${5:-}
   local spin='⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏'
   local i=0
   local lore_idx=$(( RANDOM % ${#LORE_MESSAGES[@]} ))
@@ -293,6 +294,24 @@ check_service() {
 
     local curl_exit=$?
     elapsed=$((elapsed + backoff))
+
+    if [[ -n "$container_name" ]]; then
+      local docker_cmd="${DOCKER_CMD:-docker}"
+      local -a docker_cmd_arr=()
+      read -r -a docker_cmd_arr <<< "$docker_cmd"
+      [[ ${#docker_cmd_arr[@]} -gt 0 ]] || docker_cmd_arr=(docker)
+      local container_state=""
+      if command -v "${docker_cmd_arr[0]}" >/dev/null 2>&1; then
+        container_state=$("${docker_cmd_arr[@]}" inspect --format '{{.State.Status}}' "$container_name" 2>/dev/null || echo "missing")
+        case "$container_state" in
+          exited|dead|missing)
+            printf "\r  ${RED}✗${NC} %-55s\n" "$name container $container_state"
+            ai_warn "$name container is $container_state; not retrying health probe."
+            return 1
+            ;;
+        esac
+      fi
+    fi
 
     # Distinguish between timeout (124), connection refused (7),
     # and transient startup errors (56 = recv error, 52 = empty reply)

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -27,6 +27,15 @@
 dream_progress 12 "detection" "Detecting GPU hardware"
 chapter "SYSTEM DETECTION"
 
+GPU_BACKEND_REQUESTED="${GPU_BACKEND:-}"
+GPU_BACKEND_FORCED=false
+[[ "${GPU_BACKEND_REQUESTED,,}" == "amd" ]] && GPU_BACKEND_FORCED=true
+GPU_BACKEND_FORCED_CPU=false
+[[ "${GPU_BACKEND_REQUESTED,,}" == "cpu" ]] && GPU_BACKEND_FORCED_CPU=true
+TIER_REQUESTED="${TIER:-}"
+TIER_FORCED=false
+[[ -n "$TIER_REQUESTED" ]] && TIER_FORCED=true
+
 # Cloud mode: skip GPU detection entirely
 if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
     ai "Cloud mode — skipping GPU detection"
@@ -108,22 +117,43 @@ DISK_AVAIL=$(df -BG "$HOME" | tail -1 | awk '{print $4}' | tr -d 'G')
 log "Available disk: ${DISK_AVAIL}GB"
 
 # GPU Detection
-ai "Detecting GPU..."
-detect_gpu || true
+if [[ "$GPU_BACKEND_FORCED_CPU" == "true" ]]; then
+    ai "GPU_BACKEND=cpu requested - skipping GPU detection"
+    apply_cpu_gpu_fallback "GPU_BACKEND=cpu was requested."
+else
+    ai "Detecting GPU..."
+    detect_gpu || true
 
-if [[ "${CAP_PROFILE_LOADED:-false}" == "true" ]]; then
-    case "${CAP_LLM_BACKEND:-}" in
-        amd)   GPU_BACKEND="amd" ;;
-        intel) GPU_BACKEND="intel" ;;
-        cpu)   GPU_BACKEND="cpu" ;;
-        apple) GPU_BACKEND="apple" ;;
-        *) GPU_BACKEND="nvidia" ;;
-    esac
-    [[ -n "${CAP_GPU_MEMORY_TYPE:-}" ]] && GPU_MEMORY_TYPE="${CAP_GPU_MEMORY_TYPE}"
-    [[ -n "${CAP_GPU_NAME:-}" ]] && GPU_NAME="${CAP_GPU_NAME}"
-    [[ -n "${CAP_GPU_VRAM_MB:-}" ]] && GPU_VRAM="${CAP_GPU_VRAM_MB}"
-    [[ -n "${CAP_GPU_COUNT:-}" ]] && GPU_COUNT="${CAP_GPU_COUNT}"
-    log "Capabilities override detection: backend=${GPU_BACKEND}, memory=${GPU_MEMORY_TYPE}, tier=${CAP_RECOMMENDED_TIER:-unknown}"
+    if [[ "${CAP_PROFILE_LOADED:-false}" == "true" ]]; then
+        case "${CAP_LLM_BACKEND:-}" in
+            amd)   GPU_BACKEND="amd" ;;
+            intel) GPU_BACKEND="intel" ;;
+            cpu)   GPU_BACKEND="cpu" ;;
+            apple) GPU_BACKEND="apple" ;;
+            *) GPU_BACKEND="nvidia" ;;
+        esac
+        [[ -n "${CAP_GPU_MEMORY_TYPE:-}" ]] && GPU_MEMORY_TYPE="${CAP_GPU_MEMORY_TYPE}"
+        [[ -n "${CAP_GPU_NAME:-}" ]] && GPU_NAME="${CAP_GPU_NAME}"
+        [[ -n "${CAP_GPU_VRAM_MB:-}" ]] && GPU_VRAM="${CAP_GPU_VRAM_MB}"
+        [[ -n "${CAP_GPU_COUNT:-}" ]] && GPU_COUNT="${CAP_GPU_COUNT}"
+        log "Capabilities override detection: backend=${GPU_BACKEND}, memory=${GPU_MEMORY_TYPE}, tier=${CAP_RECOMMENDED_TIER:-unknown}"
+    fi
+
+    if [[ "$GPU_BACKEND" == "amd" ]] && ! amd_gpu_runtime_devices_available; then
+        _amd_missing_devices="$(amd_gpu_missing_devices_csv)"
+        if [[ "${GPU_BACKEND_FORCED:-false}" == "true" ]]; then
+            ai_bad "GPU_BACKEND=amd was explicitly requested, but required AMD device nodes are missing."
+            show_amd_gpu_device_guidance "$_amd_missing_devices"
+            error "Cannot continue with AMD GPU mode until device passthrough is available."
+        elif ds_in_container; then
+            ai_warn "AMD hardware was detected, but this container cannot access the AMD GPU devices."
+            show_amd_gpu_device_guidance "$_amd_missing_devices"
+            apply_cpu_gpu_fallback "Falling back to CPU mode because AMD GPU passthrough is unavailable in this container."
+        else
+            ai_warn "AMD GPU runtime devices not ready yet: ${_amd_missing_devices:-unknown}"
+            ai "Continuing for now; AMD tuning will try to load kernel modules before services start."
+        fi
+    fi
 fi
 
 BACKEND_ID="$GPU_BACKEND"
@@ -155,7 +185,7 @@ fi
 #-----------------------------------------------------------------------------
 # If detect_gpu found no working GPU, check if it's a fixable driver/Secure Boot issue
 # (Only for NVIDIA — AMD APU is handled above)
-if [[ $GPU_COUNT -eq 0 && "$GPU_BACKEND" != "amd" ]] && ! $DRY_RUN; then
+if [[ "${GPU_BACKEND_FORCED_CPU:-false}" != "true" && $GPU_COUNT -eq 0 && "$GPU_BACKEND" != "amd" ]] && ! $DRY_RUN; then
     fix_nvidia_secure_boot || true
 fi
 

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -25,6 +25,58 @@ if $DRY_RUN; then
 else
     cd "$INSTALL_DIR" || exit 1
 
+    _phase11_env_set() {
+        local key="$1" value="$2" env_file="$INSTALL_DIR/.env" tmp_file
+        [[ -f "$env_file" ]] || return 0
+        tmp_file="${env_file}.tmp.$$"
+        awk -v k="$key" -v v="$value" '
+            BEGIN { found = 0 }
+            index($0, k "=") == 1 { print k "=" v; found = 1; next }
+            { print }
+            END { if (!found) print k "=" v }
+        ' "$env_file" > "$tmp_file" && cat "$tmp_file" > "$env_file" && rm -f "$tmp_file"
+    }
+
+    _phase11_apply_cpu_fallback() {
+        local missing="$1"
+        show_amd_gpu_device_guidance "$missing"
+        apply_cpu_gpu_fallback "Falling back to CPU mode before launching services."
+
+        if [[ "${TIER_FORCED:-false}" != "true" ]]; then
+            TIER="$(select_cpu_fallback_tier "${RAM_GB:-0}")"
+            log "CPU fallback tier selected: $TIER"
+        fi
+
+        load_backend_contract "cpu" || true
+        LLM_HEALTHCHECK_URL="${BACKEND_PUBLIC_HEALTH_URL:-http://localhost:8080/health}"
+        LLM_PUBLIC_API_PORT="${BACKEND_PUBLIC_API_PORT:-8080}"
+        OPENCLAW_PROVIDER_NAME_DEFAULT="${BACKEND_PROVIDER_NAME:-local-llama}"
+        OPENCLAW_PROVIDER_URL_DEFAULT="${BACKEND_PROVIDER_URL:-http://llama-server:8080/v1}"
+        resolve_tier_config
+        GPU_BACKEND="cpu"
+
+        _phase11_env_set GPU_BACKEND "$GPU_BACKEND"
+        _phase11_env_set DREAM_MODE "local"
+        _phase11_env_set LLM_API_URL "http://llama-server:8080"
+        _phase11_env_set LLM_MODEL "$LLM_MODEL"
+        _phase11_env_set GGUF_FILE "$GGUF_FILE"
+        _phase11_env_set MAX_CONTEXT "$MAX_CONTEXT"
+        _phase11_env_set CTX_SIZE "$MAX_CONTEXT"
+        _phase11_env_set AUDIO_STT_MODEL "Systran/faster-whisper-base"
+        _phase11_env_set LLAMA_SERVER_IMAGE "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}"
+        ai_ok "Rewrote .env for CPU fallback"
+    }
+
+    if [[ "${GPU_BACKEND:-}" == "amd" ]] && ! amd_gpu_runtime_devices_available; then
+        _amd_missing_devices="$(amd_gpu_missing_devices_csv)"
+        if [[ "${GPU_BACKEND_FORCED:-false}" == "true" ]]; then
+            ai_bad "GPU_BACKEND=amd was explicitly requested, but required AMD device nodes are missing."
+            show_amd_gpu_device_guidance "$_amd_missing_devices"
+            exit 1
+        fi
+        _phase11_apply_cpu_fallback "$_amd_missing_devices"
+    fi
+
     # Re-resolve compose flags against the actual install directory.
     # Phase 03 may have disabled services (e.g., ComfyUI on Tier 0) after
     # COMPOSE_FLAGS was first set in Phase 02, making the cached value stale.

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -63,22 +63,22 @@ _check_health() {
 # Format: _check_health "name" "url" max_attempts timeout_per_request
 # llama-server: 150 attempts * adaptive backoff (2s->8s) = up to ~20 minutes (model loading can be slow)
 dream_progress 86 "health" "Waiting for LLM engine"
-_check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15
+_check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15 "$(sr_container llama-server)"
 # Open WebUI: 150 attempts * adaptive backoff = up to ~20 minutes
 dream_progress 89 "health" "Waiting for Chat UI"
-_check_health "Open WebUI" "http://127.0.0.1:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 150 10
+_check_health "Open WebUI" "http://127.0.0.1:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 150 10 "$(sr_container open-webui)"
 # Perplexica: 150 attempts * adaptive backoff = up to ~20 minutes
 dream_progress 91 "health" "Waiting for Research engine"
-_check_health "Perplexica" "http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}${SERVICE_HEALTH[perplexica]:-/}" 150 10
+_check_health "Perplexica" "http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}${SERVICE_HEALTH[perplexica]:-/}" 150 10 "$(sr_container perplexica)"
 # ComfyUI: 150 attempts * adaptive backoff = up to ~20 minutes (FLUX model loading is slow)
 if [[ "$ENABLE_COMFYUI" == "true" ]]; then
     dream_progress 93 "health" "Waiting for Image generation"
-    _check_health "ComfyUI" "http://127.0.0.1:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 150 15
+    _check_health "ComfyUI" "http://127.0.0.1:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 150 15 "$(sr_container comfyui)"
 fi
 # Embeddings (TEI): model load on first run can take 1-2 minutes after start_period
 if [[ "$ENABLE_RAG" == "true" ]]; then
     dream_progress 94 "health" "Waiting for Embeddings"
-    _check_health "embeddings" "http://127.0.0.1:${SERVICE_PORTS[embeddings]:-7860}${SERVICE_HEALTH[embeddings]:-/health}" 30 10
+    _check_health "embeddings" "http://127.0.0.1:${SERVICE_PORTS[embeddings]:-7860}${SERVICE_HEALTH[embeddings]:-/health}" 30 10 "$(sr_container embeddings)"
 fi
 
 # Perplexica auto-config: seed chat model + embedding model on first boot.
@@ -155,12 +155,12 @@ fi
 
 # Extension service health checks with adaptive timeouts
 dream_progress 94 "health" "Checking extension services"
-[[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://127.0.0.1:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 150 10
+[[ "$ENABLE_OPENCLAW" == "true" ]] && _check_health "OpenClaw" "http://127.0.0.1:${SERVICE_PORTS[openclaw]:-7860}${SERVICE_HEALTH[openclaw]:-/}" 150 10 "$(sr_container openclaw)"
 systemctl --user is-active opencode-web &>/dev/null && _check_health "OpenCode Web" "http://127.0.0.1:3003/" 10 5
 # Whisper: 150 attempts * adaptive backoff = up to ~20 minutes (model download on first start)
 dream_progress 95 "health" "Checking voice services"
-[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://127.0.0.1:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 150 10
-[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Kokoro (TTS)" "http://127.0.0.1:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 150 10
+[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Whisper (STT)" "http://127.0.0.1:${SERVICE_PORTS[whisper]:-9000}${SERVICE_HEALTH[whisper]:-/health}" 150 10 "$(sr_container whisper)"
+[[ "$ENABLE_VOICE" == "true" ]] && _check_health "Kokoro (TTS)" "http://127.0.0.1:${SERVICE_PORTS[tts]:-8880}${SERVICE_HEALTH[tts]:-/health}" 150 10 "$(sr_container tts)"
 
 # Pre-download the Whisper STT model so first transcription is instant.
 # Speaches does NOT auto-download on transcription requests — it returns 404.
@@ -218,9 +218,9 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
 fi
 
 dream_progress 96 "health" "Checking workflow and RAG services"
-[[ "$ENABLE_WORKFLOWS" == "true" ]] && _check_health "n8n" "http://127.0.0.1:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 150 10
-[[ "$ENABLE_RAG" == "true" ]] && _check_health "Qdrant" "http://127.0.0.1:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 150 10
-[[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && _check_health "DreamForge" "http://127.0.0.1:${SERVICE_PORTS[dreamforge]:-3010}${SERVICE_HEALTH[dreamforge]:-/health}" 150 10
+[[ "$ENABLE_WORKFLOWS" == "true" ]] && _check_health "n8n" "http://127.0.0.1:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 150 10 "$(sr_container n8n)"
+[[ "$ENABLE_RAG" == "true" ]] && _check_health "Qdrant" "http://127.0.0.1:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 150 10 "$(sr_container qdrant)"
+[[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && _check_health "DreamForge" "http://127.0.0.1:${SERVICE_PORTS[dreamforge]:-3010}${SERVICE_HEALTH[dreamforge]:-/health}" 150 10 "$(sr_container dreamforge)"
 
 dream_progress 97 "health" "Health checks complete"
 echo ""

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -90,6 +90,13 @@ elif tier in {"AP_ULTRA", "AP_PRO", "AP_BASE"}:
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"
+elif gpu_backend == "cpu":
+    if existing(["docker-compose.base.yml", "docker-compose.cpu.yml"]):
+        resolved = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
+        primary = "docker-compose.cpu.yml"
+    elif existing(["docker-compose.base.yml"]):
+        resolved = ["docker-compose.base.yml"]
+        primary = "docker-compose.base.yml"
 elif tier in {"SH_LARGE", "SH_COMPACT"}:
     if existing(["docker-compose.base.yml", "docker-compose.amd.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
@@ -105,13 +112,6 @@ elif gpu_backend == "amd":
     if existing(["docker-compose.base.yml", "docker-compose.amd.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
         primary = "docker-compose.amd.yml"
-elif gpu_backend == "cpu":
-    if existing(["docker-compose.base.yml", "docker-compose.cpu.yml"]):
-        resolved = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
-        primary = "docker-compose.cpu.yml"
-    elif existing(["docker-compose.base.yml"]):
-        resolved = ["docker-compose.base.yml"]
-        primary = "docker-compose.base.yml"
 elif gpu_backend in ("intel", "sycl") or tier in ("ARC", "ARC_LITE"):
     if existing(["docker-compose.base.yml", "docker-compose.arc.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.arc.yml"]

--- a/dream-server/tests/bats-tests/compose-select.bats
+++ b/dream-server/tests/bats-tests/compose-select.bats
@@ -95,6 +95,14 @@ STUB
 
 # ── Numeric tiers (default NVIDIA path) ────────────────────────────────────
 
+@test "resolve_compose_config: CPU backend overrides Strix Halo tier" {
+    TIER=SH_LARGE
+    GPU_BACKEND=cpu
+    resolve_compose_config
+    assert_equal "$COMPOSE_FLAGS" "-f docker-compose.base.yml -f docker-compose.cpu.yml"
+    assert_equal "$COMPOSE_FILE" "docker-compose.cpu.yml"
+}
+
 @test "resolve_compose_config: numeric tier selects base + nvidia" {
     TIER=3
     GPU_BACKEND=nvidia

--- a/dream-server/tests/bats-tests/detection.bats
+++ b/dream-server/tests/bats-tests/detection.bats
@@ -244,6 +244,50 @@ _setup_amd_sysfs() {
     assert_equal "$GPU_MEMORY_TYPE" "unified"
 }
 
+@test "amd_gpu_runtime_devices_available: accepts mocked AMD device nodes" {
+    export DREAM_AMD_DEVICE_ROOT="$BATS_TEST_TMPDIR/dev"
+    mkdir -p "$DREAM_AMD_DEVICE_ROOT/dri"
+    touch "$DREAM_AMD_DEVICE_ROOT/kfd"
+    touch "$DREAM_AMD_DEVICE_ROOT/dri/renderD128"
+
+    run amd_gpu_runtime_devices_available
+    assert_success
+}
+
+@test "amd_gpu_runtime_devices_available: reports missing AMD device nodes" {
+    export DREAM_AMD_DEVICE_ROOT="$BATS_TEST_TMPDIR/dev"
+    mkdir -p "$DREAM_AMD_DEVICE_ROOT/dri"
+
+    run amd_gpu_runtime_devices_available
+    assert_failure
+
+    run amd_gpu_missing_devices_csv
+    assert_success
+    assert_output --partial "$DREAM_AMD_DEVICE_ROOT/kfd"
+    assert_output --partial "$DREAM_AMD_DEVICE_ROOT/dri/renderD*"
+}
+
+@test "apply_cpu_gpu_fallback: resets AMD capability state to CPU" {
+    GPU_BACKEND="amd"
+    GPU_NAME="AMD APU"
+    GPU_VRAM=98304
+    GPU_COUNT=1
+    GPU_MEMORY_TYPE="unified"
+    CAP_LLM_BACKEND="amd"
+    CAP_RECOMMENDED_TIER="SH_LARGE"
+    CAP_COMPOSE_OVERLAYS="docker-compose.base.yml,docker-compose.amd.yml"
+
+    apply_cpu_gpu_fallback "test fallback"
+
+    assert_equal "$GPU_BACKEND" "cpu"
+    assert_equal "$GPU_COUNT" "0"
+    assert_equal "$GPU_VRAM" "0"
+    assert_equal "$GPU_MEMORY_TYPE" "none"
+    assert_equal "$CAP_LLM_BACKEND" "cpu"
+    assert_equal "$CAP_RECOMMENDED_TIER" ""
+    assert_equal "$CAP_COMPOSE_OVERLAYS" ""
+}
+
 @test "detect_gpu: does not misidentify discrete AMD GPU as APU" {
     # Future discrete card: 32 GB VRAM, 16 GB GTT — should NOT be an APU
     _setup_amd_sysfs $(( 32 * 1073741824 )) $(( 16 * 1073741824 ))

--- a/dream-server/tests/bats-tests/ui.bats
+++ b/dream-server/tests/bats-tests/ui.bats
@@ -226,6 +226,56 @@ setup() {
 
 # ── LORE_MESSAGES ───────────────────────────────────────────────────────────
 
+@test "check_service: exits early when managed container has exited" {
+    export DRY_RUN="false"
+    export DOCKER_CMD="docker"
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/timeout" <<'MOCK'
+#!/bin/bash
+exit 7
+MOCK
+    cat > "$BATS_TEST_TMPDIR/bin/docker" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "inspect" ]]; then
+    echo "exited"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/timeout" "$BATS_TEST_TMPDIR/bin/docker"
+    export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+
+    run check_service "llama-server" "http://127.0.0.1:8080/health" 3 1 "dream-llama-server"
+    assert_failure
+    assert_output --partial "container exited"
+    assert_output --partial "not retrying"
+}
+
+@test "check_service: supports sudo docker command for container state" {
+    export DRY_RUN="false"
+    export DOCKER_CMD="sudo docker"
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/timeout" <<'MOCK'
+#!/bin/bash
+exit 7
+MOCK
+    cat > "$BATS_TEST_TMPDIR/bin/sudo" <<'MOCK'
+#!/bin/bash
+if [[ "$1" == "docker" && "$2" == "inspect" ]]; then
+    echo "dead"
+    exit 0
+fi
+exit 1
+MOCK
+    chmod +x "$BATS_TEST_TMPDIR/bin/timeout" "$BATS_TEST_TMPDIR/bin/sudo"
+    export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+
+    run check_service "llama-server" "http://127.0.0.1:8080/health" 3 1 "dream-llama-server"
+    assert_failure
+    assert_output --partial "container dead"
+    assert_output --partial "not retrying"
+}
+
 @test "LORE_MESSAGES: array is non-empty" {
     [[ ${#LORE_MESSAGES[@]} -gt 0 ]]
 }

--- a/dream-server/tests/test-cpu-only-path.sh
+++ b/dream-server/tests/test-cpu-only-path.sh
@@ -90,6 +90,16 @@ if [[ -x "$RESOLVER" ]]; then
     else
         pass "CPU path includes base compose"
     fi
+
+    set +e
+    strix_cpu_out=$(cd "$ROOT_DIR" && bash "$RESOLVER" --script-dir "$ROOT_DIR" --tier SH_LARGE --gpu-backend cpu 2>&1)
+    strix_cpu_rc=$?
+    set -e
+    if [[ $strix_cpu_rc -eq 0 ]] && echo "$strix_cpu_out" | grep -q "docker-compose.cpu.yml" && ! echo "$strix_cpu_out" | grep -q "docker-compose.amd.yml"; then
+        pass "CPU backend overrides Strix Halo tier compose overlay"
+    else
+        fail "CPU backend should not select AMD overlay for Strix Halo tier"
+    fi
 fi
 
 # 4. Tier map or detection: tier 1 works without GPU


### PR DESCRIPTION
## Summary

Closes #1131.

This changes the installer so an LXD/LXC container that auto-detects AMD/Strix Halo hardware but cannot see `/dev/kfd` or `/dev/dri/renderD*` no longer waits through doomed service health checks.

## What changed

- Adds AMD runtime device validation for `/dev/kfd` and `/dev/dri/renderD*`, plus container-aware guidance for LXD/LXC GPU passthrough.
- Falls back to CPU mode when AMD is auto-detected inside a container without GPU device nodes.
- Fails fast when `GPU_BACKEND=amd` was explicitly requested and required AMD devices are unavailable.
- Revalidates AMD devices before service launch, rewrites `.env` for CPU fallback, and re-resolves compose flags so Strix Halo tiers do not keep the AMD overlay after fallback.
- Makes Docker-managed service health checks stop early when the container is `exited`, `dead`, or missing.
- Documents LXD AMD passthrough commands and CPU fallback behavior.

## Validation

- `bash -n install-core.sh installers/lib/detection.sh installers/lib/compose-select.sh installers/lib/ui.sh installers/phases/02-detection.sh installers/phases/11-services.sh installers/phases/12-health.sh scripts/resolve-compose-stack.sh tests/test-cpu-only-path.sh`
- `git diff --check`
- Targeted BATS: `tests/bats-tests/detection.bats tests/bats-tests/compose-select.bats tests/bats-tests/ui.bats`
- `tests/test-cpu-only-path.sh`