### PR TITLE
docs: refresh main README accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A handful of companies control the vast majority of global AI traffic — and wi
 
 If AI is becoming critical infrastructure, it shouldn’t be rented. Self-hosting local AI should be a sovereign human right, not a career choice.
 
-**Dream Server is the exit.** A fully local AI stack — LLM inference, chat, voice, agents, workflows, RAG, image generation, and privacy tools — deployed on your hardware with a single command. No cloud. No subscriptions. No one watching.
+**Dream Server is the exit.** A local-first AI stack — LLM inference, chat, voice, agents, workflows, RAG, image generation, and privacy tools — deployed on your hardware with a single command. No cloud required. No subscriptions required. No one watching. Cloud and hybrid API modes are optional when you choose them.
 
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 [![GitHub Stars](https://img.shields.io/github/stars/Light-Heart-Labs/DreamServer)](https://github.com/Light-Heart-Labs/DreamServer/stargazers)
@@ -24,17 +24,17 @@ If AI is becoming critical infrastructure, it shouldn’t be rented. Self-hostin
 
 ---
 
-> **Platform Support — March 2026**
+> **Current Platform Support**
 >
 > | Platform | Status |
 > |----------|--------|
-> | **Linux** (NVIDIA + AMD) | **Supported** — install and run today |
+> | **Linux** (NVIDIA + AMD + Intel Arc) | **Supported** — install and run today |
 > | **Windows** (NVIDIA + AMD) | **Supported** — install and run today |
 > | **macOS** (Apple Silicon) | **Supported** — install and run today |
 >
 > **Tested Linux distros:** Ubuntu 24.04/22.04, Debian 12, Fedora 41+, Arch Linux, CachyOS, openSUSE Tumbleweed. Other distros using apt, dnf, pacman, or zypper should also work — [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues) if yours doesn't.
 >
-> **Windows:** Requires Docker Desktop with WSL2 backend. NVIDIA GPUs use Docker GPU passthrough; AMD Strix Halo runs natively with Lemonade (NPU + ROCm + Vulkan acceleration).
+> **Windows:** Requires Docker Desktop with WSL2 backend. NVIDIA GPUs use Docker GPU passthrough; AMD Strix Halo runs through the platform-specific accelerated path documented in the Windows installer and support matrix.
 >
 > **macOS:** Requires Apple Silicon (M1+) and Docker Desktop. llama-server runs natively with Metal GPU acceleration; all other services run in Docker.
 >
@@ -50,14 +50,16 @@ We built Dream Server so you don't have to.
 
 - **One command** — detects your GPU, picks the right model, generates credentials, launches everything
 - **Chatting in under 2 minutes** — bootstrap mode gives you a working model instantly while your full model downloads in the background
-- **13 services, pre-wired** — chat, agents, voice, workflows, search, RAG, image generation, privacy tools. All talking to each other out of the box
+- **Full service stack, pre-wired** — chat, agents, voice, workflows, search, RAG, image generation, privacy tools, observability, and developer tools. All talking to each other out of the box
 - **Fully moddable** — every service is an extension. Drop in a folder, run `dream enable`, done
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.3.2/dream-server/get-dream-server.sh | bash
+curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/dream-server/get-dream-server.sh | bash
 ```
 
 Open **http://localhost:3000** and start chatting.
+
+> **API endpoint:** llama-server is exposed on **http://localhost:11434** by default (`OLLAMA_PORT`) and runs on port `8080` inside Docker. Open WebUI stays on **http://localhost:3000**.
 
 > **No GPU?** Dream Server also runs in cloud mode — same full stack, powered by OpenAI/Anthropic/Together APIs instead of local inference:
 > ```bash
@@ -94,7 +96,7 @@ cd DreamServer/dream-server
 Requires [Docker Desktop](https://www.docker.com/products/docker-desktop/) with WSL2 backend enabled.
 **Install Docker Desktop first and make sure it is running before you start.**
 
-Open **PowerShell as Administrator** and run:
+Open a normal **PowerShell** session and run:
 
 ```powershell
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
@@ -104,6 +106,7 @@ cd DreamServer
 ```
 
 > The `Set-ExecutionPolicy` command allows the installer script to run in the current session. It does not change your system-wide policy.
+> Running as Administrator is not recommended for the installer because user-level paths such as `.opencode`, `data/`, and `.env` can be created with admin-owned permissions.
 
 The installer detects your GPU, picks the right model, generates credentials, starts all services, and creates a Desktop shortcut to the Dashboard. Manage with `.\dream-server\installers\windows\dream.ps1 status`.
 
@@ -133,8 +136,9 @@ See the [macOS Quickstart](dream-server/docs/MACOS-QUICKSTART.md) for details.
 
 ### Chat & Inference
 - **Open WebUI** — full-featured chat interface with conversation history, web search, document upload, and [30+ languages](https://docs.openwebui.com)
-- **llama-server** — high-performance LLM inference with continuous batching, auto-selected for your GPU
+- **llama-server** — high-performance LLM inference with continuous batching, auto-selected for your GPU; host API defaults to `localhost:11434`, container API runs on `8080`
 - **LiteLLM** — API gateway supporting local/cloud/hybrid modes
+- **TEI Embeddings** — text embedding service for RAG and search workflows
 
 ### Voice
 - **Whisper** — speech-to-text
@@ -143,11 +147,16 @@ See the [macOS Quickstart](dream-server/docs/MACOS-QUICKSTART.md) for details.
 ### Agents & Automation
 - **OpenClaw** — autonomous AI agent framework
 - **n8n** — workflow automation with 400+ integrations (Slack, email, databases, APIs)
+- **APE** — Agent Policy Engine for auditing and governing autonomous tool calls
+- **OpenCode** — browser-based AI coding assistant wired to the local stack
+- **DreamForge** — developer/build service extension for Dream Server workflows
+- **Memory Shepherd** — host/systemd helper for agent memory lifecycle management
 
 ### Knowledge & Search
 - **Qdrant** — vector database for retrieval-augmented generation (RAG)
 - **SearXNG** — self-hosted web search (no tracking)
 - **Perplexica** — deep research engine
+- **Brave Search** — optional paid Brave Search API integration
 
 ### Creative
 - **ComfyUI** — node-based image generation
@@ -155,40 +164,52 @@ See the [macOS Quickstart](dream-server/docs/MACOS-QUICKSTART.md) for details.
 ### Privacy & Ops
 - **Privacy Shield** — PII scrubbing proxy for API calls
 - **Dashboard** — real-time GPU metrics, service health, model management
+- **Dashboard API** — service health, setup, status, metrics, and management API behind the dashboard
+- **Token Spy** — token usage monitor for local and proxied LLM traffic
+- **Langfuse** — optional LLM observability and tracing
 
 ---
 
 ## Hardware Auto-Detection
 
-The installer detects your GPU and picks the optimal model automatically. No manual configuration.
+The installer detects your GPU and picks the optimal model automatically. No manual configuration is required for the default path.
+
+The current model map supports `MODEL_PROFILE=qwen` by default, plus `MODEL_PROFILE=gemma4` and `MODEL_PROFILE=auto` for Gemma 4 tiers where supported. Override tier selection with `./install.sh --tier 3`; override the model family with `MODEL_PROFILE=gemma4 ./install.sh` or `MODEL_PROFILE=auto ./install.sh`.
 
 ### NVIDIA
 
-| VRAM | Model | Example GPUs |
-|------|-------|--------------|
-| < 8 GB | Qwen3.5 2B (Q4_K_M) | Any GPU or CPU-only |
-| 8–11 GB | Qwen3.5 9B (Q4_K_M) | RTX 4060 Ti, RTX 3060 12GB |
-| 12–20 GB | Qwen3.5 9B (Q4_K_M) | RTX 3090, RTX 4080 |
-| 20–40 GB | Qwen3 30B-A3B MoE (Q4_K_M) | RTX 4090, A6000 |
-| 40+ GB | Qwen3 30B-A3B (MoE, Q4_K_M) | A100, multi-GPU |
-| 90+ GB | Qwen3 Coder Next (80B MoE, Q4_K_M) | Multi-GPU A100/H100 |
+| Tier | VRAM | Qwen profile | Gemma 4 profile | Context | Example GPUs |
+|------|------|--------------|-----------------|---------|--------------|
+| 0 | < 8 GB or CPU-only fallback | Qwen3.5 2B (Q4_K_M) | Qwen3.5 2B (bootstrap-friendly minimum) | 8K | Any GPU or CPU-only |
+| 1 | 8–11 GB | Qwen3.5 9B (Q4_K_M) | Gemma 4 E2B IT (Q4_K_M) | 16K | RTX 4060, RTX 3060 12GB |
+| 2 | 12–20 GB | Qwen3.5 9B (Q4_K_M) | Gemma 4 E4B IT (Q4_K_M) | 32K | RTX 3090, RTX 4080 |
+| 3 | 20–40 GB | Qwen3 30B-A3B MoE (Q4_K_M) | Gemma 4 26B-A4B IT (Q4_K_M) | 32K Qwen / 16K Gemma | RTX 4090, A6000 |
+| 4 | 40+ GB | Qwen3 30B-A3B MoE (Q4_K_M) | Gemma 4 31B IT (Q4_K_M) | 128K Qwen / 64K Gemma | A100, H100, multi-GPU |
+| NV_ULTRA | 90+ GB | Qwen3 Coder Next (Q4_K_M) | Gemma 4 31B IT (Q4_K_M) | 128K | Multi-GPU A100/H100 |
 
 ### AMD Strix Halo (Unified Memory)
 
-| Unified RAM | Model | Hardware |
-|-------------|-------|----------|
-| 64–89 GB | Qwen3 30B-A3B (30B MoE) | Ryzen AI MAX+ 395 (64GB) |
-| 90+ GB | Qwen3 Coder Next (80B MoE) | Ryzen AI MAX+ 395 (96GB) |
+| Tier | Unified RAM | Qwen profile | Gemma 4 profile | Context | Hardware |
+|------|-------------|--------------|-----------------|---------|----------|
+| SH_COMPACT | 64–89 GB | Qwen3 30B-A3B MoE (Q4_K_M) | Gemma 4 26B-A4B IT (Q4_K_M) | 128K Qwen / 64K Gemma | Ryzen AI MAX+ 395 (64GB) |
+| SH_LARGE | 90+ GB | Qwen3 Coder Next (Q4_K_M) | Gemma 4 31B IT (Q4_K_M) | 128K | Ryzen AI MAX+ 395 (96GB) |
 
 ### Apple Silicon (Unified Memory, Metal)
 
-| Unified RAM | Model | Example Hardware |
-|-------------|-------|-----------------|
-| < 16 GB | Qwen3.5 2B (Q4_K_M) | M1/M2 base (8GB) |
-| 16–24 GB | Qwen3.5 9B (Q4_K_M) | M4 Mac Mini (16GB) |
-| 32 GB | Qwen3.5 9B (Q4_K_M) | M4 Pro Mac Mini, M3 Max MacBook Pro |
-| 48 GB | Qwen3 30B-A3B (MoE, Q4_K_M) | M4 Pro (48GB), M2 Max (48GB) |
-| 64+ GB | Qwen3 30B-A3B (MoE, Q4_K_M) | M2 Ultra Mac Studio, M4 Max (64GB+) |
+| Tier | Unified RAM | Qwen profile | Gemma 4 profile | Context | Example Hardware |
+|------|-------------|--------------|-----------------|---------|-----------------|
+| 0 | < 16 GB | Qwen3.5 2B (Q4_K_M) | Qwen3.5 2B (bootstrap-friendly minimum) | 8K | M1/M2 base (8GB) |
+| 1 | 16–24 GB | Qwen3.5 9B (Q4_K_M) | Gemma 4 E2B IT (Q4_K_M) | 16K | M4 Mac Mini (16GB) |
+| 2 | 32 GB | Qwen3.5 9B (Q4_K_M) | Gemma 4 E4B IT (Q4_K_M) | 32K | M4 Pro Mac Mini, M3 Max MacBook Pro |
+| 3 | 48 GB | Qwen3 30B-A3B MoE (Q4_K_M) | Gemma 4 26B-A4B IT (Q4_K_M) | 32K Qwen / 16K Gemma | M4 Pro (48GB), M2 Max (48GB) |
+| 4 | 64+ GB | Qwen3 30B-A3B MoE (Q4_K_M) | Gemma 4 31B IT (Q4_K_M) | 128K Qwen / 64K Gemma | M2 Ultra Mac Studio, M4 Max (64GB+) |
+
+### Intel Arc (Linux, SYCL)
+
+| Tier | VRAM | Qwen profile | Gemma 4 profile | Context | Example Hardware |
+|------|------|--------------|-----------------|---------|------------------|
+| ARC_LITE | 6–11 GB | Qwen3.5 4B (Q4_K_M) | Gemma 4 E2B IT (Q4_K_M) | 16K | Arc A380, Arc A750 |
+| ARC | 12+ GB | Qwen3.5 9B (Q4_K_M) | Gemma 4 E4B IT (Q4_K_M) | 32K | Arc A770 16GB, newer Arc GPUs |
 
 Override tier selection: `./install.sh --tier 3`
 
@@ -232,7 +253,13 @@ If the new model isn't downloaded yet, pre-fetch it first:
 dream model swap T3                    # Then swap (restarts llama-server)
 ```
 
-Already have a GGUF you want to use? Drop it in `data/models/`, update `GGUF_FILE` and `LLM_MODEL` in `.env`, and restart:
+Already have a GGUF you want to use? Drop it in `data/models/`, update `GGUF_FILE` and `LLM_MODEL` in `.env`, and restart with the CLI:
+
+```bash
+dream restart llm
+```
+
+Or restart the container directly from the installed `dream-server` directory:
 
 ```bash
 docker compose restart llama-server
@@ -299,8 +326,8 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 |---|:---:|:---:|:---:|
 | **Scope** | Full AI stack — inference to agents to workflows | LLM + chat | LLM only |
 | One-command install | Everything, auto-configured | LLM + chat only | LLM only |
-| Hardware auto-detect + model selection | NVIDIA + AMD Strix Halo | No | No |
-| AMD APU unified memory support | ROCm + llama-server | Partial (Vulkan) | No |
+| Hardware auto-detect + model selection | NVIDIA + AMD Strix Halo + Apple Silicon + Intel Arc + CPU/cloud fallback | No | No |
+| AMD APU unified memory support | Platform-specific accelerated backend, selected by installer | Partial (Vulkan) | No |
 | Autonomous AI agents | OpenClaw | No | No |
 | Workflow automation | n8n (400+ integrations) | No | No |
 | Voice (STT + TTS) | Whisper + Kokoro | No | No |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/d
 
 Open **http://localhost:3000** and start chatting.
 
-> **API endpoint:** llama-server is exposed on **http://localhost:11434** by default (`OLLAMA_PORT`) and runs on port `8080` inside Docker. Open WebUI stays on **http://localhost:3000**.
+> **API endpoint:** Linux Docker installs expose llama-server on **http://localhost:11434** by default (`OLLAMA_PORT`) while containers use `llama-server:8080`. macOS native Metal and Windows native/Lemonade paths use **http://localhost:8080** unless overridden. Open WebUI stays on **http://localhost:3000**.
 
 > **No GPU?** Dream Server also runs in cloud mode — same full stack, powered by OpenAI/Anthropic/Together APIs instead of local inference:
 > ```bash
@@ -136,7 +136,7 @@ See the [macOS Quickstart](dream-server/docs/MACOS-QUICKSTART.md) for details.
 
 ### Chat & Inference
 - **Open WebUI** — full-featured chat interface with conversation history, web search, document upload, and [30+ languages](https://docs.openwebui.com)
-- **llama-server** — high-performance LLM inference with continuous batching, auto-selected for your GPU; host API defaults to `localhost:11434`, container API runs on `8080`
+- **llama-server** — high-performance LLM inference with continuous batching, auto-selected for your GPU; Linux Docker host API defaults to `localhost:11434`, native macOS/Windows paths use `localhost:8080`, and container API runs on `8080`
 - **LiteLLM** — API gateway supporting local/cloud/hybrid modes
 - **TEI Embeddings** — text embedding service for RAG and search workflows
 
@@ -145,7 +145,8 @@ See the [macOS Quickstart](dream-server/docs/MACOS-QUICKSTART.md) for details.
 - **Kokoro** — text-to-speech
 
 ### Agents & Automation
-- **OpenClaw** — autonomous AI agent framework
+- **Hermes Agent** — optional local-first autonomous/browser agent with memory, skills, and a magic-link-gated proxy
+- **OpenClaw** — optional autonomous AI agent framework
 - **n8n** — workflow automation with 400+ integrations (Slack, email, databases, APIs)
 - **APE** — Agent Policy Engine for auditing and governing autonomous tool calls
 - **OpenCode** — browser-based AI coding assistant wired to the local stack
@@ -328,7 +329,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | One-command install | Everything, auto-configured | LLM + chat only | LLM only |
 | Hardware auto-detect + model selection | NVIDIA + AMD Strix Halo + Apple Silicon + Intel Arc + CPU/cloud fallback | No | No |
 | AMD APU unified memory support | Platform-specific accelerated backend, selected by installer | Partial (Vulkan) | No |
-| Autonomous AI agents | OpenClaw | No | No |
+| Autonomous AI agents | Hermes Agent / OpenClaw | No | No |
 | Workflow automation | n8n (400+ integrations) | No | No |
 | Voice (STT + TTS) | Whisper + Kokoro | No | No |
 | Image generation | ComfyUI | No | No |

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -14,7 +14,7 @@
 
 > | Platform | Status |
 > |----------|--------|
-> | **Linux** (NVIDIA + AMD) | **Supported** — install and run today |
+> | **Linux** (NVIDIA + AMD + Intel Arc) | **Supported** — install and run today |
 > | **macOS** (Apple Silicon) | **Supported** — install and run today |
 > | **Windows** (NVIDIA + AMD) | **Supported** — install and run today |
 >
@@ -40,8 +40,8 @@ Known-good version baselines: [`docs/KNOWN-GOOD-VERSIONS.md`](docs/KNOWN-GOOD-VE
 > **Prerequisites:** `curl` and `jq` must be installed. The installer will auto-install `jq` if missing, but `curl` is required to fetch the installer itself.
 
 ```bash
-# One-line install (Linux — NVIDIA or AMD)
-curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.4.0/get-dream-server.sh | bash
+# One-line install (Linux — NVIDIA, AMD, Intel Arc, or CPU/cloud fallback)
+curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/dream-server/get-dream-server.sh | bash
 ```
 
 Or manually:
@@ -53,6 +53,8 @@ cd DreamServer
 ```
 
 The installer auto-detects your GPU, picks the right model, generates secure passwords, and starts everything. Open **http://localhost:3000** and start chatting.
+
+By default, llama-server is exposed to the host on **http://localhost:11434** (`OLLAMA_PORT`) and runs on `8080` inside Docker. Use `llama-server:8080` only from other containers on the Dream Server network.
 
 ### Instant Start (Bootstrap Mode)
 
@@ -93,56 +95,71 @@ See [`docs/WINDOWS-QUICKSTART.md`](docs/WINDOWS-QUICKSTART.md) for details.
 
 | Component | Purpose | Port | Backend |
 |-----------|---------|------|---------|
-| **llama-server** | LLM inference engine | 8080 | Both |
-| **Open WebUI** | Beautiful chat interface | 3000 | Both |
-| **Dashboard** | System status, GPU metrics, service health | 3001 | Both |
-| **Dashboard API** | Backend API for dashboard | 3002 | Both |
-| **LiteLLM** | Multi-model API gateway | 4000 | Both |
-| **OpenClaw** | Autonomous AI agent framework | 7860 | Both |
-| **SearXNG** | Self-hosted web search | 8888 | Both |
-| **Perplexica** | Deep research engine | 3004 | Both |
-| **n8n** | Workflow automation | 5678 | Both |
-| **Qdrant** | Vector database for RAG | 6333 | Both |
-| **Embeddings** | Text embeddings for RAG | 8090 | Both |
-| **Whisper** | Speech-to-text | 9000 | Both |
-| **Kokoro** | Text-to-speech | 8880 | Both |
-| **Privacy Shield** | PII protection for API calls | 8085 | Both |
-| **Memory Shepherd** | Agent memory lifecycle management | — | AMD |
-| **ComfyUI** | Image generation | 8188 | Both |
+| **llama-server** | LLM inference engine | 11434 host / 8080 container | Core GPU backend |
+| **Open WebUI** | Beautiful chat interface | 3000 | Core |
+| **Dashboard** | System status, GPU metrics, service health | 3001 | Core |
+| **Dashboard API** | Backend API for dashboard | 3002 | Core |
+| **LiteLLM** | Multi-model API gateway | 4000 | Recommended |
+| **Token Spy** | Token usage monitor | 3005 | Recommended |
+| **SearXNG** | Self-hosted web search | 8888 | Recommended |
+| **OpenClaw** | Autonomous AI agent framework | 7860 | Optional |
+| **APE** | Agent Policy Engine for policy/audit controls | 7890 | Optional |
+| **OpenCode** | Browser IDE / coding assistant | 3003 | Optional host service |
+| **DreamForge** | Developer/build service extension | 3010 | Optional |
+| **Perplexica** | Deep research engine | 3004 | Optional |
+| **Brave Search** | Paid Brave Search API bridge | 8585 | Optional |
+| **n8n** | Workflow automation | 5678 | Optional |
+| **Qdrant** | Vector database for RAG | 6333 / 6334 gRPC | Optional |
+| **TEI Embeddings** | Text embeddings for RAG | 8090 | Optional |
+| **Whisper** | Speech-to-text | 9000 | Optional |
+| **Kokoro** | Text-to-speech | 8880 | Optional |
+| **Privacy Shield** | PII protection for API calls | 8085 | Optional |
+| **Langfuse** | LLM observability and tracing | 3006 | Optional |
+| **ComfyUI** | Image generation | 8188 | Optional GPU service |
+| **Memory Shepherd** | Agent memory lifecycle management | — | Host/systemd helper |
 
 ## Hardware Tiers
 
-The installer **automatically detects your GPU** and selects the right configuration:
+The installer **automatically detects your GPU** and selects the right configuration. `MODEL_PROFILE=qwen` is the default; `MODEL_PROFILE=gemma4` and `MODEL_PROFILE=auto` are also supported by the tier map where those GGUFs are available.
 
 ### AMD Strix Halo (Unified Memory)
 
-| Tier | Unified VRAM | Model | Context | Example Hardware |
-|------|-------------|-------|---------|-----------------|
-| SH_LARGE | 90GB+ | qwen3-coder-next (80B MoE, 3B active) | 128K | Ryzen AI MAX+ 395 (96GB VRAM config) |
-| SH_COMPACT | 64-89GB | qwen3-30b-a3b (30B MoE, 3B active) | 128K | Ryzen AI MAX+ 395 (64GB VRAM config) |
+| Tier | Unified VRAM | Qwen profile | Gemma 4 profile | Context | Example Hardware |
+|------|-------------|--------------|-----------------|---------|-----------------|
+| SH_LARGE | 90GB+ | qwen3-coder-next (80B MoE, 3B active) | gemma-4-31b-it | 128K | Ryzen AI MAX+ 395 (96GB VRAM config) |
+| SH_COMPACT | 64-89GB | qwen3-30b-a3b (30B MoE, 3B active) | gemma-4-26b-a4b-it | 128K Qwen / 64K Gemma | Ryzen AI MAX+ 395 (64GB VRAM config) |
 
 Both tiers use `qwen2.5:7b` as a bootstrap model for instant startup. The full model downloads in the background via GGUF from HuggingFace.
 
-**Inference backend:** Lemonade Server via ROCm (Docker image: `ghcr.io/lemonade-sdk/lemonade-server:v10.0.0`)
+**Inference backend:** selected by the platform installer and support matrix. Linux AMD paths use ROCm-capable containers; Windows Strix Halo uses the Windows-specific accelerated path.
 
 ### NVIDIA (Discrete GPU)
 
-| Tier | VRAM | Model | Quant | Context | Example GPUs |
-|------|------|-------|-------|---------|--------------|
-| NV_ULTRA | 90GB+ | qwen3-coder-next | GGUF Q4_K_M | 128K | Multi-GPU A100/H100 |
-| 1 (Entry) | <12GB | qwen3.5-9b | GGUF Q4_K_M | 16K | RTX 3080, RTX 4070 |
-| 2 (Prosumer) | 12-20GB | qwen3.5-9b | GGUF Q4_K_M | 32K | RTX 3090, RTX 4080 |
-| 3 (Pro) | 20-40GB | qwen3-30b-a3b | GGUF Q4_K_M | 32K | RTX 4090, A6000 |
-| 4 (Enterprise) | 40GB+ | qwen3-30b-a3b | GGUF Q4_K_M | 128K | A100, H100, multi-GPU |
+| Tier | VRAM | Qwen profile | Gemma 4 profile | Context | Example GPUs |
+|------|------|--------------|-----------------|---------|--------------|
+| NV_ULTRA | 90GB+ | qwen3-coder-next | gemma-4-31b-it | 128K | Multi-GPU A100/H100 |
+| 0 (Lightweight) | <8GB or CPU fallback | qwen3.5-2b | qwen3.5-2b | 8K | Any GPU or CPU-only |
+| 1 (Entry) | 8-11GB | qwen3.5-9b | gemma-4-e2b-it | 16K | RTX 4060, RTX 3060 12GB |
+| 2 (Prosumer) | 12-20GB | qwen3.5-9b | gemma-4-e4b-it | 32K | RTX 3090, RTX 4080 |
+| 3 (Pro) | 20-40GB | qwen3-30b-a3b | gemma-4-26b-a4b-it | 32K Qwen / 16K Gemma | RTX 4090, A6000 |
+| 4 (Enterprise) | 40GB+ | qwen3-30b-a3b | gemma-4-31b-it | 128K Qwen / 64K Gemma | A100, H100, multi-GPU |
 
 ### Apple Silicon (Unified Memory, Metal)
 
-| Tier | Unified RAM | Model | Quant | Context | Example Hardware |
-|------|-------------|-------|-------|---------|-----------------|
-| 1 (Entry) | 8–24GB | qwen3.5-9b | GGUF Q4_K_M | 16K | M1/M2 base, M4 Mac Mini (16GB) |
-| 2 (Prosumer) | 32GB | qwen3.5-9b | GGUF Q4_K_M | 32K | M4 Pro Mac Mini, M3 Max MacBook Pro |
-| 3 (Pro) | 48GB | qwen3-30b-a3b | GGUF Q4_K_M | 32K | M4 Pro (48GB), M2 Max (48GB) |
-| 4 (Enterprise) | 64GB+ | qwen3-30b-a3b (30B MoE) | GGUF Q4_K_M | 128K | M2 Ultra Mac Studio, M4 Max (64GB+) |
+| Tier | Unified RAM | Qwen profile | Gemma 4 profile | Context | Example Hardware |
+|------|-------------|--------------|-----------------|---------|-----------------|
+| 0 (Lightweight) | <16GB | qwen3.5-2b | qwen3.5-2b | 8K | M1/M2 base (8GB) |
+| 1 (Entry) | 16-24GB | qwen3.5-9b | gemma-4-e2b-it | 16K | M4 Mac Mini (16GB) |
+| 2 (Prosumer) | 32GB | qwen3.5-9b | gemma-4-e4b-it | 32K | M4 Pro Mac Mini, M3 Max MacBook Pro |
+| 3 (Pro) | 48GB | qwen3-30b-a3b | gemma-4-26b-a4b-it | 32K Qwen / 16K Gemma | M4 Pro (48GB), M2 Max (48GB) |
+| 4 (Enterprise) | 64GB+ | qwen3-30b-a3b | gemma-4-31b-it | 128K Qwen / 64K Gemma | M2 Ultra Mac Studio, M4 Max (64GB+) |
+
+### Intel Arc (Linux, SYCL)
+
+| Tier | VRAM | Qwen profile | Gemma 4 profile | Context | Example Hardware |
+|------|------|--------------|-----------------|---------|------------------|
+| ARC_LITE | 6-11GB | qwen3.5-4b | gemma-4-e2b-it | 16K | Arc A380, Arc A750 |
+| ARC | 12GB+ | qwen3.5-9b | gemma-4-e4b-it | 32K | Arc A770 16GB, newer Arc GPUs |
 
 Override with: `./install.sh --tier 3`
 
@@ -152,7 +169,7 @@ See [docs/HARDWARE-GUIDE.md](docs/HARDWARE-GUIDE.md) for buying recommendations.
 
 ## Architecture
 
-### AMD Strix Halo (llama-server + ROCm)
+### AMD Strix Halo (platform-selected accelerated backend)
 
 ```
 ┌─────────────────────────────────────────────────┐
@@ -161,8 +178,8 @@ See [docs/HARDWARE-GUIDE.md](docs/HARDWARE-GUIDE.md) for buying recommendations.
 └─────────────────────┬───────────────────────────┘
                       │
 ┌─────────────────────▼───────────────────────────┐
-│               llama-server (ROCm 7.2)           │
-│            (localhost:8080/v1/...)               │
+│               llama-server backend              │
+│     host localhost:11434 / Docker :8080/v1       │
 │        qwen3-coder-next / qwen3-30b-a3b         │
 └─────────────────────────────────────────────────┘
          │                              │
@@ -187,7 +204,7 @@ See [docs/HARDWARE-GUIDE.md](docs/HARDWARE-GUIDE.md) for buying recommendations.
                       │
 ┌─────────────────────▼───────────────────────────┐
 │               llama-server (CUDA)               │
-│            (localhost:8080/v1/...)               │
+│     host localhost:11434 / Docker :8080/v1       │
 │            qwen3-30b-a3b                        │
 └─────────────────────────────────────────────────┘
          │                              │
@@ -246,11 +263,19 @@ The installer generates `.env` automatically. Key settings:
 # NVIDIA
 LLM_MODEL=qwen3-30b-a3b                   # Model (auto-set by installer)
 CTX_SIZE=32768                             # Context window
+MODEL_PROFILE=qwen                         # qwen, gemma4, or auto
+OLLAMA_PORT=11434                          # Host API port for llama-server
 
 # AMD Strix Halo
 LLM_MODEL=qwen3-coder-next                # or qwen3-30b-a3b for compact tier
 CTX_SIZE=131072                            # Context window
 GPU_BACKEND=amd                            # Set automatically by installer
+
+# Advanced llama-server tuning
+LLAMA_ARG_FLASH_ATTN=auto                  # auto, on, or off
+LLAMA_ARG_CACHE_TYPE_K=f16                 # f16 or q8_0
+LLAMA_ARG_CACHE_TYPE_V=f16                 # f16 or q8_0
+# LLAMA_ARG_N_CPU_MOE=25                   # Optional MoE-only CPU expert offload
 ```
 
 ## dream-cli
@@ -327,8 +352,8 @@ dream mode status                        # Show current mode
 | Feature | Dream Server | Ollama + WebUI | LocalAI |
 |---------|:---:|:---:|:---:|
 | Full-stack one-command install | **LLM + agent + workflows + RAG** | LLM + chat only | LLM only |
-| Hardware auto-detect + model selection | **NVIDIA + AMD Strix Halo** | No | No |
-| AMD APU / unified memory support | **ROCm + llama-server** | Partial (Vulkan) | No |
+| Hardware auto-detect + model selection | **NVIDIA + AMD Strix Halo + Apple Silicon + Intel Arc + CPU/cloud fallback** | No | No |
+| AMD APU / unified memory support | **Platform-specific accelerated backend selected by installer** | Partial (Vulkan) | No |
 | Inference engine | **llama-server** (all GPUs) | llama.cpp | llama.cpp |
 | Autonomous AI agent | **OpenClaw** | No | No |
 | Workflow automation | **n8n (400+ integrations)** | No | No |
@@ -348,7 +373,8 @@ dream mode status                        # Show current mode
 - Watch progress: `dream logs llm`
 
 **Open WebUI shows "Connection error"**
-- llama-server is still loading. Wait for health check to pass: `curl localhost:8080/health`
+- llama-server is still loading. Wait for the host health check to pass: `curl localhost:11434/health`
+- From another container on the Dream Server network, use `http://llama-server:8080/health`
 
 **Port already in use**
 - Change ports in `.env` (e.g., `WEBUI_PORT=3001`)
@@ -418,7 +444,7 @@ Thanks to [kyuz0](https://github.com/kyuz0) for [amd-strix-halo-toolboxes](https
 
 ### Community Contributors
 
-For the full contributor list with detailed credits, see the [Wall of Heroes](../../README.md#wall-of-heroes) in the root README.
+For the full contributor list with detailed credits, see the [Wall of Heroes](../README.md#wall-of-heroes) in the root README.
 
 If we missed anyone, [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues). We want to get this right.
 

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -54,7 +54,7 @@ cd DreamServer
 
 The installer auto-detects your GPU, picks the right model, generates secure passwords, and starts everything. Open **http://localhost:3000** and start chatting.
 
-By default, llama-server is exposed to the host on **http://localhost:11434** (`OLLAMA_PORT`) and runs on `8080` inside Docker. Use `llama-server:8080` only from other containers on the Dream Server network.
+On Linux Docker installs, llama-server is exposed to the host on **http://localhost:11434** (`OLLAMA_PORT`) and runs on `8080` inside Docker. Use `llama-server:8080` only from other containers on the Dream Server network. macOS native Metal and Windows native/Lemonade paths use **http://localhost:8080** unless overridden.
 
 ### Instant Start (Bootstrap Mode)
 
@@ -95,13 +95,14 @@ See [`docs/WINDOWS-QUICKSTART.md`](docs/WINDOWS-QUICKSTART.md) for details.
 
 | Component | Purpose | Port | Backend |
 |-----------|---------|------|---------|
-| **llama-server** | LLM inference engine | 11434 host / 8080 container | Core GPU backend |
+| **llama-server** | LLM inference engine | Linux Docker: 11434 host / 8080 container; native macOS/Windows: 8080 host | Core GPU backend |
 | **Open WebUI** | Beautiful chat interface | 3000 | Core |
 | **Dashboard** | System status, GPU metrics, service health | 3001 | Core |
 | **Dashboard API** | Backend API for dashboard | 3002 | Core |
 | **LiteLLM** | Multi-model API gateway | 4000 | Recommended |
 | **Token Spy** | Token usage monitor | 3005 | Recommended |
 | **SearXNG** | Self-hosted web search | 8888 | Recommended |
+| **Hermes Agent** | Local-first autonomous/browser agent | 9120 via auth proxy; 9119 internal | Optional |
 | **OpenClaw** | Autonomous AI agent framework | 7860 | Optional |
 | **APE** | Agent Policy Engine for policy/audit controls | 7890 | Optional |
 | **OpenCode** | Browser IDE / coding assistant | 3003 | Optional host service |
@@ -179,13 +180,14 @@ See [docs/HARDWARE-GUIDE.md](docs/HARDWARE-GUIDE.md) for buying recommendations.
                       │
 ┌─────────────────────▼───────────────────────────┐
 │               llama-server backend              │
-│     host localhost:11434 / Docker :8080/v1       │
+│     Linux host :11434 / Docker :8080/v1       │
+│     native macOS/Windows host :8080/v1        │
 │        qwen3-coder-next / qwen3-30b-a3b         │
 └─────────────────────────────────────────────────┘
          │                              │
 ┌────────▼────────┐            ┌───────▼────────┐
-│   OpenClaw      │            │    Dashboard    │
-│ (Agent :7860)   │            │ (Status :3001)  │
+│ Hermes/OpenClaw │            │    Dashboard    │
+│ (Agents)        │            │ (Status :3001)  │
 └─────────────────┘            └────────────────┘
 
 ┌─────────────┐  ┌─────────────┐  ┌─────────────┐
@@ -204,7 +206,7 @@ See [docs/HARDWARE-GUIDE.md](docs/HARDWARE-GUIDE.md) for buying recommendations.
                       │
 ┌─────────────────────▼───────────────────────────┐
 │               llama-server (CUDA)               │
-│     host localhost:11434 / Docker :8080/v1       │
+│     Linux host :11434 / Docker :8080/v1          │
 │            qwen3-30b-a3b                        │
 └─────────────────────────────────────────────────┘
          │                              │
@@ -355,7 +357,7 @@ dream mode status                        # Show current mode
 | Hardware auto-detect + model selection | **NVIDIA + AMD Strix Halo + Apple Silicon + Intel Arc + CPU/cloud fallback** | No | No |
 | AMD APU / unified memory support | **Platform-specific accelerated backend selected by installer** | Partial (Vulkan) | No |
 | Inference engine | **llama-server** (all GPUs) | llama.cpp | llama.cpp |
-| Autonomous AI agent | **OpenClaw** | No | No |
+| Autonomous AI agent | **Hermes Agent / OpenClaw** | No | No |
 | Workflow automation | **n8n (400+ integrations)** | No | No |
 | LLM usage monitoring | **Open WebUI built-in** | No | No |
 | Multi-GPU | **Yes** (NVIDIA) | Partial | Partial |
@@ -373,7 +375,8 @@ dream mode status                        # Show current mode
 - Watch progress: `dream logs llm`
 
 **Open WebUI shows "Connection error"**
-- llama-server is still loading. Wait for the host health check to pass: `curl localhost:11434/health`
+- llama-server is still loading. On Linux Docker installs, wait for the host health check to pass: `curl localhost:11434/health`
+- On macOS native Metal and Windows native/Lemonade paths, use `curl localhost:8080/health`
 - From another container on the Dream Server network, use `http://llama-server:8080/health`
 
 **Port already in use**

--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Dream Server Bootstrap Installer
-# curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/v2.4.0/get-dream-server.sh | bash
+# curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/dream-server/get-dream-server.sh | bash
 #
 # Detects OS, clones repo, runs installer.
 


### PR DESCRIPTION
## Summary

This is a focused documentation accuracy pass for the root README, the nested `dream-server/README.md`, and the bootstrap installer comment.

It updates the docs to match the current project shape without removing the existing sections or contributor credits:

- replaces stale/broken one-line installer references with the current raw path under `main/dream-server/get-dream-server.sh`
- documents the host/container llama-server port split (`localhost:11434` on the host, `8080` inside Docker)
- updates Windows install guidance to avoid recommending Administrator by default, matching the installer warning
- expands the service list to include currently documented/manifests-backed services such as Dashboard API, Token Spy, APE, OpenCode, DreamForge, Brave Search, TEI embeddings, Langfuse, and Memory Shepherd
- updates hardware/model documentation for Qwen, Gemma 4, Apple Silicon, Intel Arc, AMD Strix Halo, CPU fallback, and cloud fallback
- fixes the nested README Wall of Heroes link target

## Why

The main page currently mixes older release docs with newer installer/runtime behavior. In particular:

- the root README still points at `v2.3.2`
- the nested README points at `v2.4.0/get-dream-server.sh`, but that raw URL is currently broken because the path is missing `dream-server/` and the tag is not present in the visible tag list
- service counts and hardware support no longer match the current manifests/tier maps
- Windows docs recommend Administrator, while the installer warns against it

I used the `main` raw installer path here because it is the only currently valid path for the current main-branch docs. If the preferred release policy is to pin README install commands to tags only, this can be switched once a matching tag exists.

## Validation

- `git diff --check`
- local README relative-link check for `README.md` and `dream-server/README.md`
- local Markdown table pipe-count check for both READMEs
- verified the new raw installer URL returns HTTP 200
- grep check confirmed the stale references were removed from the touched docs/scripts:
  - `v2.3.2`
  - `v2.4.0/get-dream-server`
  - `13 services`
  - `PowerShell as Administrator`
  - `localhost:8080/health`
  - `localhost:8080/v1`

## Maintainer note

This PR intentionally does not remove the existing Wall of Heroes or other narrative sections. It only updates claims, commands, support tables, and links that had drifted from the current repository behavior.
