### PR TITLE
fix(installer): save compose failure reports

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -60,6 +60,12 @@ jobs:
       - name: Windows Report Command Tests
         run: bash tests/test-windows-report-command.sh
 
+      - name: Compose Failure Report Tests
+        run: bash tests/test-compose-failure-report.sh
+
+      - name: Windows Compose Failure Report Tests
+        run: bash tests/test-windows-compose-failure-report.sh
+
       - name: Validate Env Tests
         run: bash tests/test-validate-env.sh
 

--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -72,6 +72,7 @@ source "$SCRIPT_DIR/installers/lib/detection.sh"
 source "$SCRIPT_DIR/installers/lib/host-arch.sh"
 source "$SCRIPT_DIR/installers/lib/tier-map.sh"
 source "$SCRIPT_DIR/installers/lib/compose-select.sh"
+source "$SCRIPT_DIR/installers/lib/compose-failure-report.sh"
 source "$SCRIPT_DIR/installers/lib/packaging.sh"
 source "$SCRIPT_DIR/installers/lib/progress.sh"
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 

--- a/dream-server/installers/lib/compose-failure-report.sh
+++ b/dream-server/installers/lib/compose-failure-report.sh
@@ -48,6 +48,47 @@ _dream_report_failed_images() {
         | head -n 20 || true
 }
 
+_dream_report_redact_stream() {
+    local env_file="${1:-}"
+    awk -v env_file="$env_file" '
+        BEGIN {
+            secret_re = "(key|token|secret|password|pass|salt|auth|credential)"
+            if (env_file != "") {
+                while ((getline line < env_file) > 0) {
+                    sub(/\r$/, "", line)
+                    if (line !~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+                        continue
+                    }
+                    split(line, parts, "=")
+                    key = parts[1]
+                    value = substr(line, length(key) + 2)
+                    gsub(/^["\047]|["\047]$/, "", value)
+                    if (length(value) >= 4 && tolower(key) ~ secret_re) {
+                        sensitive_values[++sensitive_count] = value
+                    }
+                }
+                close(env_file)
+            }
+        }
+        {
+            out = $0
+            lowered = tolower(out)
+            if (lowered ~ secret_re && match(out, /[:=][[:space:]]*/)) {
+                out = substr(out, 1, RSTART + RLENGTH - 1) "[REDACTED]"
+            }
+            for (i = 1; i <= sensitive_count; i++) {
+                value = sensitive_values[i]
+                pos = index(out, value)
+                while (pos > 0) {
+                    out = substr(out, 1, pos - 1) "[REDACTED]" substr(out, pos + length(value))
+                    pos = index(out, value)
+                }
+            }
+            print out
+        }
+    '
+}
+
 write_compose_failure_report() {
     local install_dir="$1"
     local phase="$2"
@@ -71,7 +112,8 @@ write_compose_failure_report() {
         echo "Phase: $phase"
         echo ""
         echo "Privacy note"
-        echo "- This report avoids dumping the full .env, but docker compose config can still include interpolated values."
+        echo "- This report avoids dumping the full .env."
+        echo "- Compose config output is redacted for common secret fields and known sensitive .env values."
         echo "- Review before posting publicly."
         echo ""
         echo "Summary"
@@ -112,10 +154,10 @@ write_compose_failure_report() {
         echo "Docker info"
         docker info 2>&1 | sed -n '1,80p' || true
         echo ""
-        echo "Compose config tail"
+        echo "Compose config tail (redacted)"
         if command -v docker >/dev/null 2>&1; then
             # shellcheck disable=SC2086
-            docker compose $report_compose_flags config 2>&1 | tail -n 80 || true
+            docker compose $report_compose_flags config 2>&1 | _dream_report_redact_stream "$env_file" | tail -n 80 || true
         else
             echo "docker command not found"
         fi

--- a/dream-server/installers/lib/compose-failure-report.sh
+++ b/dream-server/installers/lib/compose-failure-report.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Installer -- Compose Failure Report
+# ============================================================================
+# Part of: installers/lib/
+# Purpose: Persist a bounded, shareable report when Docker Compose startup fails.
+#
+# Provides: write_compose_failure_report()
+# ============================================================================
+
+_dream_report_env_value() {
+    local env_file="${1:-}" key="${2:-}" default="${3:-}"
+    [[ -f "$env_file" ]] || { printf '%s' "$default"; return 0; }
+    local value
+    value="$(grep -m1 "^${key}=" "$env_file" 2>/dev/null | cut -d= -f2- | tr -d '\r' || true)"
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+    printf '%s' "${value:-$default}"
+}
+
+_dream_report_port_line() {
+    local label="$1" port="$2"
+    [[ -n "$port" && "$port" != "0" ]] || return 0
+
+    local status="free"
+    local detail=""
+    if command -v lsof >/dev/null 2>&1; then
+        detail="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN 2>/dev/null | tail -n +2 | head -n 3 || true)"
+    elif command -v ss >/dev/null 2>&1; then
+        detail="$(ss -ltnp 2>/dev/null | awk -v p=":$port" '$4 ~ p {print}' | head -n 3 || true)"
+    elif command -v netstat >/dev/null 2>&1; then
+        detail="$(netstat -an 2>/dev/null | awk -v p=":$port" '$0 ~ p && $0 ~ /LISTEN/ {print}' | head -n 3 || true)"
+    fi
+    [[ -n "$detail" ]] && status="occupied"
+
+    printf -- "- %s:%s %s\n" "$label" "$port" "$status"
+    [[ -n "$detail" ]] && printf '%s\n' "$detail" | sed 's/^/  /'
+}
+
+_dream_report_failed_images() {
+    local log_file="$1"
+    [[ -f "$log_file" ]] || return 0
+    grep -Eio '([a-z0-9._-]+([.:][0-9]+)?/)?[a-z0-9._/-]+:[A-Za-z0-9._-]+' "$log_file" 2>/dev/null \
+        | grep -E 'ghcr\.io|docker\.io|quay\.io|nvidia|llama|dream|open-webui|qdrant|speaches|comfy|litellm|perplexica' \
+        | sort -u \
+        | head -n 20 || true
+}
+
+write_compose_failure_report() {
+    local install_dir="$1"
+    local phase="$2"
+    local compose_command="$3"
+    local log_file="${4:-}"
+    local gpu_backend="${5:-unknown}"
+    local next_step="${6:-Review the failed image, Docker daemon, ports, and compose config sections below; then re-run the installer.}"
+
+    mkdir -p "$install_dir" "$install_dir/logs" 2>/dev/null || true
+
+    local stamp report env_file compose_flags_file
+    stamp="$(date '+%Y-%m-%d-%H%M%S')"
+    report="$install_dir/install-report-${stamp}.txt"
+    env_file="$install_dir/.env"
+    compose_flags_file="$install_dir/.compose-flags"
+    local report_compose_flags="${COMPOSE_FLAGS_REPORT:-${COMPOSE_FLAGS:-}}"
+
+    {
+        echo "Dream Server install failure report"
+        echo "Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+        echo "Phase: $phase"
+        echo ""
+        echo "Privacy note"
+        echo "- This report avoids dumping the full .env, but docker compose config can still include interpolated values."
+        echo "- Review before posting publicly."
+        echo ""
+        echo "Summary"
+        echo "- Install dir: $install_dir"
+        echo "- GPU backend: $gpu_backend"
+        echo "- Compose command: $compose_command"
+        [[ -n "$log_file" ]] && echo "- Installer log: $log_file"
+        [[ -f "$compose_flags_file" ]] && echo "- Cached compose flags: $(cat "$compose_flags_file" 2>/dev/null)"
+        echo "- Next step: $next_step"
+        echo ""
+        echo "Configured model/runtime"
+        echo "- DREAM_MODE=$(_dream_report_env_value "$env_file" DREAM_MODE "unknown")"
+        echo "- LLM_MODEL=$(_dream_report_env_value "$env_file" LLM_MODEL "unknown")"
+        echo "- GGUF_FILE=$(_dream_report_env_value "$env_file" GGUF_FILE "unknown")"
+        echo "- LLAMA_SERVER_IMAGE=$(_dream_report_env_value "$env_file" LLAMA_SERVER_IMAGE "default")"
+        echo "- CTX_SIZE=$(_dream_report_env_value "$env_file" CTX_SIZE "unknown")"
+        echo ""
+        echo "Likely failed image(s)"
+        local failed_images
+        failed_images="$(_dream_report_failed_images "$log_file")"
+        if [[ -n "$failed_images" ]]; then
+            printf '%s\n' "$failed_images" | sed 's/^/- /'
+        else
+            echo "- none detected from installer log"
+        fi
+        echo ""
+        echo "Port checks"
+        _dream_report_port_line "llama-server" "$(_dream_report_env_value "$env_file" OLLAMA_PORT "11434")"
+        _dream_report_port_line "open-webui" "$(_dream_report_env_value "$env_file" WEBUI_PORT "3000")"
+        _dream_report_port_line "dashboard" "$(_dream_report_env_value "$env_file" DASHBOARD_PORT "3001")"
+        _dream_report_port_line "dashboard-api" "$(_dream_report_env_value "$env_file" DASHBOARD_API_PORT "3002")"
+        _dream_report_port_line "litellm" "$(_dream_report_env_value "$env_file" LITELLM_PORT "4000")"
+        _dream_report_port_line "searxng" "$(_dream_report_env_value "$env_file" SEARXNG_PORT "8888")"
+        echo ""
+        echo "Docker version"
+        docker version 2>&1 | sed -n '1,60p' || true
+        echo ""
+        echo "Docker info"
+        docker info 2>&1 | sed -n '1,80p' || true
+        echo ""
+        echo "Compose config tail"
+        if command -v docker >/dev/null 2>&1; then
+            # shellcheck disable=SC2086
+            docker compose $report_compose_flags config 2>&1 | tail -n 80 || true
+        else
+            echo "docker command not found"
+        fi
+        echo ""
+        echo "Compose ps"
+        if command -v docker >/dev/null 2>&1; then
+            # shellcheck disable=SC2086
+            docker compose $report_compose_flags ps -a 2>&1 | sed -n '1,80p' || true
+        else
+            echo "docker command not found"
+        fi
+        echo ""
+        echo "Installer log tail"
+        if [[ -f "$log_file" ]]; then
+            tail -n 160 "$log_file"
+        else
+            echo "installer log unavailable"
+        fi
+    } > "$report" 2>&1
+
+    if command -v ai_warn >/dev/null 2>&1; then
+        ai_warn "Compose failure report saved: $report"
+    else
+        echo "Compose failure report saved: $report"
+    fi
+    printf '%s\n' "$report"
+}

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -114,6 +114,9 @@ source "${LIB_DIR}/tier-map.sh"
 source "${LIB_DIR}/detection.sh"
 source "${LIB_DIR}/preflight-fs.sh"
 source "${LIB_DIR}/env-generator.sh"
+if [[ -f "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh" ]]; then
+    source "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh"
+fi
 
 # ── File-local helpers ──
 # Build a launchd-friendly PATH that includes Docker and Homebrew prefixes.
@@ -947,14 +950,28 @@ else
     ai_ok "Local images rebuilt"
 
     ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build"
+    _compose_up_log="${INSTALL_DIR}/logs/compose-up.log"
+    mkdir -p "${INSTALL_DIR}/logs"
+    : > "$_compose_up_log"
     set +o pipefail  # pipefail would abort on compose exit before PIPESTATUS is read; capture it first
-    docker compose "${COMPOSE_FLAGS[@]}" up -d --remove-orphans --no-build 2>&1 | while IFS= read -r line; do
+    docker compose "${COMPOSE_FLAGS[@]}" up -d --remove-orphans --no-build 2>&1 | tee -a "$_compose_up_log" | while IFS= read -r line; do
         echo "  $line"
     done
     compose_exit="${PIPESTATUS[0]}"
     set -o pipefail
 
     if [[ "$compose_exit" -ne 0 ]]; then
+        if command -v write_compose_failure_report >/dev/null 2>&1; then
+            _compose_report_path="$(COMPOSE_FLAGS_REPORT="${COMPOSE_FLAGS[*]}" write_compose_failure_report \
+                "$INSTALL_DIR" \
+                "install-macos docker compose up" \
+                "docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build" \
+                "$_compose_up_log" \
+                "apple" \
+                "Open the saved report, fix the failed image/port/compose error it identifies, then re-run ./installers/macos.sh." |
+                tail -n 1)" || true
+            [[ -n "${_compose_report_path:-}" ]] && ai_warn "Compose failure report saved: $_compose_report_path"
+        fi
         ai_err "docker compose up failed"
         exit 1
     fi

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -432,6 +432,17 @@ MODELS_INI_EOF
         echo ""
         ai_warn "Some services failed. Check: docker compose logs"
         ai_warn "Log file: $LOG_FILE"
+        if command -v write_compose_failure_report >/dev/null 2>&1; then
+            _compose_report_path="$(write_compose_failure_report \
+                "$INSTALL_DIR" \
+                "install-core phase 11 docker compose up" \
+                "$DOCKER_COMPOSE_CMD $COMPOSE_FLAGS up -d --remove-orphans --no-build" \
+                "$LOG_FILE" \
+                "${GPU_BACKEND:-unknown}" \
+                "Open the saved report, fix the failed image/port/compose error it identifies, then re-run ./install.sh." |
+                tail -n 1)" || true
+            [[ -n "${_compose_report_path:-}" ]] && ai_warn "Compose failure report saved: $_compose_report_path"
+        fi
     fi
 
     # ── Bootstrap: launch background full-model download + auto hot-swap ──

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -655,7 +655,11 @@ if ($dryRun) {
         }
         if ($composeExit -ne 0) {
             Write-AIError "docker compose up failed (exit code: $composeExit)"
-            Write-DreamComposeDiagnostics -InstallDir $installDir -ComposeFlags $composeFlags -Phase "install-windows.ps1 docker compose up -d"
+            Write-DreamComposeDiagnostics -InstallDir $installDir -ComposeFlags $composeFlags `
+                -ComposeArgs @("up", "-d", "--remove-orphans", "--no-build") `
+                -ComposeLogPath $_composeLog `
+                -Phase "install-windows.ps1 docker compose up -d" `
+                -SaveReport
             exit 1
         }
         Write-AISuccess "Docker services started"

--- a/dream-server/installers/windows/lib/compose-diagnostics.ps1
+++ b/dream-server/installers/windows/lib/compose-diagnostics.ps1
@@ -79,9 +79,9 @@ function Get-DreamComposeFailedImages {
     }
 
     $pattern = '([a-z0-9._-]+([.:][0-9]+)?/)?[a-z0-9._/-]+:[A-Za-z0-9._-]+'
-    $matches = @()
+    $imageMatches = @()
     try {
-        $matches = Select-String -Path $ComposeLogPath -Pattern $pattern -AllMatches -ErrorAction Stop |
+        $imageMatches = Select-String -Path $ComposeLogPath -Pattern $pattern -AllMatches -ErrorAction Stop |
             ForEach-Object { $_.Matches.Value } |
             Where-Object {
                 $_ -match 'ghcr\.io|docker\.io|quay\.io|nvidia|llama|dream|open-webui|qdrant|speaches|comfy|litellm|perplexica'
@@ -93,7 +93,7 @@ function Get-DreamComposeFailedImages {
         return @()
     }
 
-    return @($matches)
+    return @($imageMatches)
 }
 
 function Add-DreamComposePortReport {

--- a/dream-server/installers/windows/lib/compose-diagnostics.ps1
+++ b/dream-server/installers/windows/lib/compose-diagnostics.ps1
@@ -129,7 +129,10 @@ function ConvertTo-DreamComposeRedactedLine {
 
     $redacted = $Line
     if ($redacted -match '(?i)(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)' -and $redacted -match '[:=]') {
-        $redacted = $redacted -replace '([:=]\s*)[^\s,}]+', '${1}[REDACTED]'
+        $separatorMatch = [regex]::Match($redacted, '[:=]\s*')
+        if ($separatorMatch.Success) {
+            $redacted = $redacted.Substring(0, $separatorMatch.Index + $separatorMatch.Length) + "[REDACTED]"
+        }
     }
 
     foreach ($value in $SensitiveValues) {

--- a/dream-server/installers/windows/lib/compose-diagnostics.ps1
+++ b/dream-server/installers/windows/lib/compose-diagnostics.ps1
@@ -44,6 +44,226 @@ function Invoke-DreamDockerCompose {
     }
 }
 
+function Get-DreamComposeEnvValue {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InstallDir,
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [string]$Default = "unknown"
+    )
+
+    $envPath = Join-Path $InstallDir ".env"
+    if (-not (Test-Path $envPath)) { return $Default }
+
+    try {
+        $line = Get-Content $envPath -ErrorAction Stop |
+            Where-Object { $_ -match "^$([regex]::Escape($Name))=" } |
+            Select-Object -First 1
+        if (-not $line) { return $Default }
+        $value = ($line -split "=", 2)[1].Trim()
+        $value = $value.Trim('"').Trim("'")
+        if ([string]::IsNullOrWhiteSpace($value)) { return $Default }
+        return $value
+    }
+    catch {
+        return $Default
+    }
+}
+
+function Get-DreamComposeFailedImages {
+    param([string]$ComposeLogPath)
+
+    if ([string]::IsNullOrWhiteSpace($ComposeLogPath) -or -not (Test-Path $ComposeLogPath)) {
+        return @()
+    }
+
+    $pattern = '([a-z0-9._-]+([.:][0-9]+)?/)?[a-z0-9._/-]+:[A-Za-z0-9._-]+'
+    $matches = @()
+    try {
+        $matches = Select-String -Path $ComposeLogPath -Pattern $pattern -AllMatches -ErrorAction Stop |
+            ForEach-Object { $_.Matches.Value } |
+            Where-Object {
+                $_ -match 'ghcr\.io|docker\.io|quay\.io|nvidia|llama|dream|open-webui|qdrant|speaches|comfy|litellm|perplexica'
+            } |
+            Sort-Object -Unique |
+            Select-Object -First 20
+    }
+    catch {
+        return @()
+    }
+
+    return @($matches)
+}
+
+function Add-DreamComposePortReport {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReportPath,
+        [Parameter(Mandatory = $true)]
+        [string]$Label,
+        [Parameter(Mandatory = $true)]
+        [string]$Port
+    )
+
+    if ([string]::IsNullOrWhiteSpace($Port) -or $Port -eq "0") { return }
+
+    $connections = @()
+    try {
+        $connections = Get-NetTCPConnection -LocalPort ([int]$Port) -State Listen -ErrorAction SilentlyContinue |
+            Select-Object -First 3
+    }
+    catch {
+        $connections = @()
+    }
+
+    if ($connections -and $connections.Count -gt 0) {
+        "- ${Label}:${Port} occupied" | Add-Content -Path $ReportPath -Encoding UTF8
+        foreach ($conn in $connections) {
+            $pidText = if ($conn.OwningProcess) { " pid=$($conn.OwningProcess)" } else { "" }
+            "  $($conn.LocalAddress):$($conn.LocalPort)$pidText" | Add-Content -Path $ReportPath -Encoding UTF8
+        }
+    }
+    else {
+        "- ${Label}:${Port} free" | Add-Content -Path $ReportPath -Encoding UTF8
+    }
+}
+
+function Add-DreamComposeCommandSection {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ReportPath,
+        [Parameter(Mandatory = $true)]
+        [string]$Title,
+        [Parameter(Mandatory = $true)]
+        [scriptblock]$Command,
+        [int]$First = 0,
+        [int]$Last = 0
+    )
+
+    "" | Add-Content -Path $ReportPath -Encoding UTF8
+    $Title | Add-Content -Path $ReportPath -Encoding UTF8
+    try {
+        $output = & $Command 2>&1 | ForEach-Object { $_.ToString() }
+        if ($output) {
+            $lines = @($output)
+            if ($First -gt 0) {
+                $lines | Select-Object -First $First | Add-Content -Path $ReportPath -Encoding UTF8
+            }
+            elseif ($Last -gt 0) {
+                $take = [Math]::Min($Last, $lines.Count)
+                $start = [Math]::Max(0, $lines.Count - $take)
+                for ($i = $start; $i -lt $lines.Count; $i++) {
+                    $lines[$i] | Add-Content -Path $ReportPath -Encoding UTF8
+                }
+            }
+            else {
+                $lines | Add-Content -Path $ReportPath -Encoding UTF8
+            }
+        }
+        else {
+            "(no output)" | Add-Content -Path $ReportPath -Encoding UTF8
+        }
+    }
+    catch {
+        "command failed: $_" | Add-Content -Path $ReportPath -Encoding UTF8
+    }
+}
+
+function Write-DreamComposeFailureReport {
+    <#
+    .SYNOPSIS
+        Save a bounded, shareable report after install-time docker compose failure.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$InstallDir,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyCollection()]
+        [string[]]$ComposeFlags,
+        [string[]]$ComposeArgs = @(),
+        [string]$Phase = "install",
+        [string]$ComposeLogPath = "",
+        [string]$NextStep = "Open the saved report, fix the failed image/port/compose error it identifies, then re-run .\install.ps1."
+    )
+
+    $logsDir = Join-Path $InstallDir "logs"
+    if (-not (Test-Path $logsDir)) { New-Item -ItemType Directory -Path $logsDir -Force | Out-Null }
+
+    $stamp = Get-Date -Format "yyyy-MM-dd-HHmmss"
+    $reportPath = Join-Path $InstallDir "install-report-$stamp.txt"
+    $composeCommand = ("docker compose " + (($ComposeFlags + $ComposeArgs) -join " ")).Trim()
+    $flagsFile = Join-Path $InstallDir ".compose-flags"
+    $gpuBackend = Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "GPU_BACKEND" -Default "unknown"
+
+    @(
+        "Dream Server install failure report",
+        "Generated: $((Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ"))",
+        "Phase: $Phase",
+        "",
+        "Privacy note",
+        "- This report avoids dumping the full .env, but docker compose config can still include interpolated values.",
+        "- Review before posting publicly.",
+        "",
+        "Summary",
+        "- Install dir: $InstallDir",
+        "- GPU backend: $gpuBackend",
+        "- Compose command: $composeCommand",
+        "- Installer log: $(if ($ComposeLogPath) { $ComposeLogPath } else { "unavailable" })",
+        "- Cached compose flags: $(if (Test-Path $flagsFile) { Get-Content $flagsFile -Raw } else { "unavailable" })",
+        "- Next step: $NextStep",
+        "",
+        "Configured model/runtime",
+        "- DREAM_MODE=$(Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "DREAM_MODE" -Default "unknown")",
+        "- LLM_MODEL=$(Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "LLM_MODEL" -Default "unknown")",
+        "- GGUF_FILE=$(Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "GGUF_FILE" -Default "unknown")",
+        "- LLAMA_SERVER_IMAGE=$(Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "LLAMA_SERVER_IMAGE" -Default "default")",
+        "- CTX_SIZE=$(Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "CTX_SIZE" -Default "unknown")",
+        "",
+        "Likely failed image(s)"
+    ) | Set-Content -Path $reportPath -Encoding UTF8
+
+    $failedImages = @(Get-DreamComposeFailedImages -ComposeLogPath $ComposeLogPath)
+    if ($failedImages.Count -gt 0) {
+        $failedImages | ForEach-Object { "- $_" } | Add-Content -Path $reportPath -Encoding UTF8
+    }
+    else {
+        "- none detected from installer log" | Add-Content -Path $reportPath -Encoding UTF8
+    }
+
+    "" | Add-Content -Path $reportPath -Encoding UTF8
+    "Port checks" | Add-Content -Path $reportPath -Encoding UTF8
+    Add-DreamComposePortReport -ReportPath $reportPath -Label "llama-server" -Port (Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "OLLAMA_PORT" -Default "11434")
+    Add-DreamComposePortReport -ReportPath $reportPath -Label "open-webui" -Port (Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "WEBUI_PORT" -Default "3000")
+    Add-DreamComposePortReport -ReportPath $reportPath -Label "dashboard" -Port (Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "DASHBOARD_PORT" -Default "3001")
+    Add-DreamComposePortReport -ReportPath $reportPath -Label "dashboard-api" -Port (Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "DASHBOARD_API_PORT" -Default "3002")
+    Add-DreamComposePortReport -ReportPath $reportPath -Label "litellm" -Port (Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "LITELLM_PORT" -Default "4000")
+    Add-DreamComposePortReport -ReportPath $reportPath -Label "searxng" -Port (Get-DreamComposeEnvValue -InstallDir $InstallDir -Name "SEARXNG_PORT" -Default "8888")
+
+    Push-Location $InstallDir
+    try {
+        $envArgs = Get-DreamComposeEnvFileArgs -InstallDir $InstallDir
+        Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Docker version" -First 60 -Command { & docker version }
+        Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Docker info" -First 80 -Command { & docker info }
+        Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Compose config tail" -Last 80 -Command { & docker compose @ComposeFlags @envArgs config }
+        Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Compose ps" -First 80 -Command { & docker compose @ComposeFlags @envArgs ps -a }
+    }
+    finally {
+        Pop-Location
+    }
+
+    "" | Add-Content -Path $reportPath -Encoding UTF8
+    "Installer log tail" | Add-Content -Path $reportPath -Encoding UTF8
+    if ($ComposeLogPath -and (Test-Path $ComposeLogPath)) {
+        Get-Content $ComposeLogPath -Tail 160 | Add-Content -Path $reportPath -Encoding UTF8
+    }
+    else {
+        "installer log unavailable" | Add-Content -Path $reportPath -Encoding UTF8
+    }
+
+    return $reportPath
+}
+
 function Write-DreamComposeDiagnostics {
     <#
     .SYNOPSIS
@@ -55,7 +275,11 @@ function Write-DreamComposeDiagnostics {
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
         [string[]]$ComposeFlags,
-        [string]$Phase = "install"
+        [string]$Phase = "install",
+        [string[]]$ComposeArgs = @(),
+        [string]$ComposeLogPath = "",
+        [string]$NextStep = "Open the saved report, fix the failed image/port/compose error it identifies, then re-run .\install.ps1.",
+        [switch]$SaveReport
     )
 
     Write-Chapter "COMPOSE FAILURE DIAGNOSTICS"
@@ -116,4 +340,10 @@ function Write-DreamComposeDiagnostics {
 
     Write-Host ""
     Write-AI "Next: confirm Docker Desktop is running, WSL2 backend is on, and ports in .env are free."
+
+    if ($SaveReport) {
+        $reportPath = Write-DreamComposeFailureReport -InstallDir $InstallDir -ComposeFlags $ComposeFlags `
+            -ComposeArgs $ComposeArgs -Phase $Phase -ComposeLogPath $ComposeLogPath -NextStep $NextStep
+        Write-AIWarn "Compose failure report saved: $reportPath"
+    }
 }

--- a/dream-server/installers/windows/lib/compose-diagnostics.ps1
+++ b/dream-server/installers/windows/lib/compose-diagnostics.ps1
@@ -96,6 +96,50 @@ function Get-DreamComposeFailedImages {
     return @($imageMatches)
 }
 
+function Get-DreamComposeSensitiveEnvValues {
+    param([string]$InstallDir)
+
+    $envPath = Join-Path $InstallDir ".env"
+    if (-not (Test-Path $envPath)) { return @() }
+
+    $values = @()
+    try {
+        foreach ($line in (Get-Content $envPath -ErrorAction Stop)) {
+            if ($line -notmatch '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') { continue }
+            $key = $Matches[1]
+            $value = $Matches[2].Trim().Trim('"').Trim("'")
+            if ($value.Length -ge 4 -and $key -match '(?i)(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)') {
+                $values += $value
+            }
+        }
+    }
+    catch {
+        return @()
+    }
+
+    return @($values | Sort-Object -Unique)
+}
+
+function ConvertTo-DreamComposeRedactedLine {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Line,
+        [string[]]$SensitiveValues = @()
+    )
+
+    $redacted = $Line
+    if ($redacted -match '(?i)(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)' -and $redacted -match '[:=]') {
+        $redacted = $redacted -replace '([:=]\s*)[^\s,}]+', '${1}[REDACTED]'
+    }
+
+    foreach ($value in $SensitiveValues) {
+        if ([string]::IsNullOrWhiteSpace($value)) { continue }
+        $redacted = $redacted.Replace($value, "[REDACTED]")
+    }
+
+    return $redacted
+}
+
 function Add-DreamComposePortReport {
     param(
         [Parameter(Mandatory = $true)]
@@ -138,7 +182,9 @@ function Add-DreamComposeCommandSection {
         [Parameter(Mandatory = $true)]
         [scriptblock]$Command,
         [int]$First = 0,
-        [int]$Last = 0
+        [int]$Last = 0,
+        [switch]$RedactSecrets,
+        [string[]]$SensitiveValues = @()
     )
 
     "" | Add-Content -Path $ReportPath -Encoding UTF8
@@ -147,6 +193,11 @@ function Add-DreamComposeCommandSection {
         $output = & $Command 2>&1 | ForEach-Object { $_.ToString() }
         if ($output) {
             $lines = @($output)
+            if ($RedactSecrets) {
+                $lines = $lines | ForEach-Object {
+                    ConvertTo-DreamComposeRedactedLine -Line $_ -SensitiveValues $SensitiveValues
+                }
+            }
             if ($First -gt 0) {
                 $lines | Select-Object -First $First | Add-Content -Path $ReportPath -Encoding UTF8
             }
@@ -202,7 +253,8 @@ function Write-DreamComposeFailureReport {
         "Phase: $Phase",
         "",
         "Privacy note",
-        "- This report avoids dumping the full .env, but docker compose config can still include interpolated values.",
+        "- This report avoids dumping the full .env.",
+        "- Compose config output is redacted for common secret fields and known sensitive .env values.",
         "- Review before posting publicly.",
         "",
         "Summary",
@@ -243,9 +295,10 @@ function Write-DreamComposeFailureReport {
     Push-Location $InstallDir
     try {
         $envArgs = Get-DreamComposeEnvFileArgs -InstallDir $InstallDir
+        $sensitiveValues = @(Get-DreamComposeSensitiveEnvValues -InstallDir $InstallDir)
         Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Docker version" -First 60 -Command { & docker version }
         Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Docker info" -First 80 -Command { & docker info }
-        Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Compose config tail" -Last 80 -Command { & docker compose @ComposeFlags @envArgs config }
+        Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Compose config tail (redacted)" -Last 80 -RedactSecrets -SensitiveValues $sensitiveValues -Command { & docker compose @ComposeFlags @envArgs config }
         Add-DreamComposeCommandSection -ReportPath $reportPath -Title "Compose ps" -First 80 -Command { & docker compose @ComposeFlags @envArgs ps -a }
     }
     finally {

--- a/dream-server/tests/test-compose-failure-report.sh
+++ b/dream-server/tests/test-compose-failure-report.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server compose failure report tests
+# ============================================================================
+# Behavioral test for the install-time report writer using a mocked docker CLI.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPORT_LIB="$ROOT_DIR/installers/lib/compose-failure-report.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+assert_contains() {
+    local file="$1" needle="$2" label="$3"
+    if grep -Fq -- "$needle" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+        echo "    missing: $needle"
+    fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+INSTALL_DIR="$TMP_DIR/dream-server"
+mkdir -p "$INSTALL_DIR/logs" "$TMP_DIR/bin"
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
+DREAM_MODE=core
+GPU_BACKEND=nvidia
+LLM_MODEL=gemma-4-e2b-it
+GGUF_FILE=gemma-4-E2B-it-Q4_K_M.gguf
+LLAMA_SERVER_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-b8648
+CTX_SIZE=32768
+OLLAMA_PORT=39134
+WEBUI_PORT=39000
+DASHBOARD_PORT=39001
+DASHBOARD_API_PORT=39002
+LITELLM_PORT=39040
+SEARXNG_PORT=39888
+EOF
+
+cat > "$INSTALL_DIR/.compose-flags" <<'EOF'
+--env-file .env -f docker-compose.base.yml -f docker-compose.nvidia.yml
+EOF
+
+COMPOSE_LOG="$INSTALL_DIR/logs/compose-up.log"
+cat > "$COMPOSE_LOG" <<'EOF'
+Image ghcr.io/ggml-org/llama.cpp:server-cuda-b8648 Pulling
+Error response from daemon: failed to resolve reference "ghcr.io/ggml-org/llama.cpp:server-cuda-b8648": not found
+EOF
+
+cat > "$TMP_DIR/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "version" ]]; then
+  echo "Client: Docker Engine"
+  echo " Version: 29.2.1"
+  exit 0
+fi
+if [[ "$1" == "info" ]]; then
+  echo "Server Version: 29.2.1"
+  echo "Operating System: Docker Desktop"
+  exit 0
+fi
+if [[ "$1" == "compose" ]]; then
+  if [[ "$*" == *" config"* ]]; then
+    echo "services:"
+    echo "  llama-server:"
+    echo "    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b8648"
+    exit 0
+  fi
+  if [[ "$*" == *" ps -a"* ]]; then
+    echo "NAME IMAGE COMMAND SERVICE CREATED STATUS PORTS"
+    exit 0
+  fi
+fi
+exit 0
+EOF
+chmod +x "$TMP_DIR/bin/docker"
+
+export PATH="$TMP_DIR/bin:$PATH"
+
+source "$REPORT_LIB"
+
+echo ""
+echo "=== Compose failure report tests ==="
+echo ""
+
+COMPOSE_FLAGS_REPORT="--env-file .env -f docker-compose.base.yml -f docker-compose.nvidia.yml"
+report_path="$(
+    COMPOSE_FLAGS_REPORT="$COMPOSE_FLAGS_REPORT" write_compose_failure_report \
+        "$INSTALL_DIR" \
+        "install-core phase 11 docker compose up" \
+        "docker compose $COMPOSE_FLAGS_REPORT up -d --remove-orphans --no-build" \
+        "$COMPOSE_LOG" \
+        "nvidia" \
+        "Fix the missing image tag, then re-run ./install.sh." |
+        tail -n 1
+)"
+
+if [[ -f "$report_path" ]]; then
+    pass "report file is created"
+else
+    fail "report file is missing"
+fi
+
+assert_contains "$report_path" "Dream Server install failure report" "report has title"
+assert_contains "$report_path" "Phase: install-core phase 11 docker compose up" "report records phase"
+assert_contains "$report_path" "GPU backend: nvidia" "report records GPU backend"
+assert_contains "$report_path" "Compose command: docker compose --env-file .env -f docker-compose.base.yml -f docker-compose.nvidia.yml up -d --remove-orphans --no-build" "report records compose command"
+assert_contains "$report_path" "LLAMA_SERVER_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-b8648" "report records configured image"
+assert_contains "$report_path" "- ghcr.io/ggml-org/llama.cpp:server-cuda-b8648" "report extracts failed image"
+assert_contains "$report_path" "- dashboard:39001" "report includes port checks"
+assert_contains "$report_path" "Docker version" "report includes docker version section"
+assert_contains "$report_path" "Compose config tail" "report includes compose config section"
+assert_contains "$report_path" "Fix the missing image tag, then re-run ./install.sh." "report records next step"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/dream-server/tests/test-compose-failure-report.sh
+++ b/dream-server/tests/test-compose-failure-report.sh
@@ -51,6 +51,8 @@ DASHBOARD_PORT=39001
 DASHBOARD_API_PORT=39002
 LITELLM_PORT=39040
 SEARXNG_PORT=39888
+DASHBOARD_API_KEY=super-secret-dashboard-key
+OPENCLAW_TOKEN=super-secret-openclaw-token
 EOF
 
 cat > "$INSTALL_DIR/.compose-flags" <<'EOF'
@@ -80,6 +82,10 @@ if [[ "$1" == "compose" ]]; then
     echo "services:"
     echo "  llama-server:"
     echo "    image: ghcr.io/ggml-org/llama.cpp:server-cuda-b8648"
+    echo "  dashboard-api:"
+    echo "    environment:"
+    echo "      DASHBOARD_API_KEY: super-secret-dashboard-key"
+    echo "      OPENCLAW_TOKEN: super-secret-openclaw-token"
     exit 0
   fi
   if [[ "$*" == *" ps -a"* ]]; then
@@ -125,7 +131,13 @@ assert_contains "$report_path" "LLAMA_SERVER_IMAGE=ghcr.io/ggml-org/llama.cpp:se
 assert_contains "$report_path" "- ghcr.io/ggml-org/llama.cpp:server-cuda-b8648" "report extracts failed image"
 assert_contains "$report_path" "- dashboard:39001" "report includes port checks"
 assert_contains "$report_path" "Docker version" "report includes docker version section"
-assert_contains "$report_path" "Compose config tail" "report includes compose config section"
+assert_contains "$report_path" "Compose config tail (redacted)" "report includes redacted compose config section"
+assert_contains "$report_path" "DASHBOARD_API_KEY: [REDACTED]" "report redacts compose config secret fields"
+if grep -Fq "super-secret-dashboard-key" "$report_path" || grep -Fq "super-secret-openclaw-token" "$report_path"; then
+    fail "report leaks sensitive compose config values"
+else
+    pass "report does not leak sensitive compose config values"
+fi
 assert_contains "$report_path" "Fix the missing image tag, then re-run ./install.sh." "report records next step"
 
 echo ""

--- a/dream-server/tests/test-windows-compose-failure-report.sh
+++ b/dream-server/tests/test-windows-compose-failure-report.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Windows compose failure report tests
+# ============================================================================
+# Static checks for install-time automatic report wiring on Windows.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DIAG_LIB="$ROOT_DIR/installers/windows/lib/compose-diagnostics.ps1"
+INSTALL_PS1="$ROOT_DIR/installers/windows/install-windows.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+echo ""
+echo "=== Windows compose failure report tests ==="
+echo ""
+
+[[ -f "$DIAG_LIB" ]] && pass "compose diagnostics library exists" || fail "compose diagnostics library missing"
+[[ -f "$INSTALL_PS1" ]] && pass "Windows installer exists" || fail "Windows installer missing"
+
+check 'function Write-DreamComposeFailureReport' "$DIAG_LIB" "report writer function exists"
+check 'install-report-$stamp.txt' "$DIAG_LIB" "report uses install-report timestamp path"
+check 'Get-DreamComposeFailedImages' "$DIAG_LIB" "report extracts failed images from compose log"
+check 'Get-NetTCPConnection' "$DIAG_LIB" "report includes Windows port checks"
+check 'docker compose @ComposeFlags @envArgs config' "$DIAG_LIB" "report captures compose config"
+check '[switch]$SaveReport' "$DIAG_LIB" "diagnostics only save report when requested"
+check '-ComposeLogPath $_composeLog' "$INSTALL_PS1" "installer passes compose log to diagnostics"
+check '-ComposeArgs @("up", "-d", "--remove-orphans", "--no-build")' "$INSTALL_PS1" "installer passes exact compose up args"
+check '-SaveReport' "$INSTALL_PS1" "installer enables saved report on compose failure"
+
+if grep -q "Write-DreamComposeDiagnostics .*SaveReport" "$ROOT_DIR/installers/windows/dream.ps1"; then
+    fail "dream.ps1 command failures should not create install reports by default"
+else
+    pass "dream.ps1 diagnostics remain console-only by default"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/dream-server/tests/test-windows-compose-failure-report.sh
+++ b/dream-server/tests/test-windows-compose-failure-report.sh
@@ -40,8 +40,9 @@ echo ""
 check 'function Write-DreamComposeFailureReport' "$DIAG_LIB" "report writer function exists"
 check 'install-report-$stamp.txt' "$DIAG_LIB" "report uses install-report timestamp path"
 check 'Get-DreamComposeFailedImages' "$DIAG_LIB" "report extracts failed images from compose log"
+check 'ConvertTo-DreamComposeRedactedLine' "$DIAG_LIB" "report has compose config redaction helper"
 check 'Get-NetTCPConnection' "$DIAG_LIB" "report includes Windows port checks"
-check 'docker compose @ComposeFlags @envArgs config' "$DIAG_LIB" "report captures compose config"
+check 'Compose config tail (redacted)' "$DIAG_LIB" "report captures redacted compose config"
 check '[switch]$SaveReport' "$DIAG_LIB" "diagnostics only save report when requested"
 check '-ComposeLogPath $_composeLog' "$INSTALL_PS1" "installer passes compose log to diagnostics"
 check '-ComposeArgs @("up", "-d", "--remove-orphans", "--no-build")' "$INSTALL_PS1" "installer passes exact compose up args"
@@ -51,6 +52,87 @@ if grep -q "Write-DreamComposeDiagnostics .*SaveReport" "$ROOT_DIR/installers/wi
     fail "dream.ps1 command failures should not create install reports by default"
 else
     pass "dream.ps1 diagnostics remain console-only by default"
+fi
+
+if command -v pwsh >/dev/null 2>&1; then
+    TMP_DIR="$(mktemp -d)"
+    cleanup() { rm -rf "$TMP_DIR"; }
+    trap cleanup EXIT
+
+    INSTALL_DIR="$TMP_DIR/dream-server"
+    mkdir -p "$TMP_DIR/bin" "$INSTALL_DIR/logs"
+
+    cat > "$TMP_DIR/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "version" ]]; then
+  echo "Docker version 29.2.1"
+  exit 0
+fi
+if [[ "$1" == "info" ]]; then
+  echo "Server Version: 29.2.1"
+  exit 0
+fi
+if [[ "$1" == "compose" ]]; then
+  if [[ "$*" == *" config"* ]]; then
+    echo "services:"
+    echo "  dashboard-api:"
+    echo "    environment:"
+    echo "      DASHBOARD_API_KEY: super-secret-dashboard-key"
+    echo "      OPENCLAW_TOKEN: super-secret-openclaw-token"
+    exit 0
+  fi
+  if [[ "$*" == *" ps -a"* ]]; then
+    echo "NAME IMAGE COMMAND SERVICE CREATED STATUS PORTS"
+    exit 0
+  fi
+fi
+exit 0
+EOF
+    chmod +x "$TMP_DIR/bin/docker"
+
+    cat > "$INSTALL_DIR/.env" <<'EOF'
+GPU_BACKEND=nvidia
+LLAMA_SERVER_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-b8648
+DASHBOARD_API_KEY=super-secret-dashboard-key
+OPENCLAW_TOKEN=super-secret-openclaw-token
+OLLAMA_PORT=39134
+EOF
+
+    cat > "$INSTALL_DIR/logs/compose-up.log" <<'EOF'
+Error response from daemon: failed to resolve reference "ghcr.io/ggml-org/llama.cpp:server-cuda-b8648": not found
+EOF
+
+    if PATH="$TMP_DIR/bin:$PATH" DIAG_LIB="$DIAG_LIB" INSTALL_DIR="$INSTALL_DIR" pwsh -NoProfile -Command '
+        $ErrorActionPreference = "Stop"
+        . $env:DIAG_LIB
+        $report = Write-DreamComposeFailureReport `
+            -InstallDir $env:INSTALL_DIR `
+            -ComposeFlags @("-f", "docker-compose.base.yml") `
+            -ComposeArgs @("up", "-d") `
+            -Phase "test phase" `
+            -ComposeLogPath (Join-Path $env:INSTALL_DIR "logs/compose-up.log")
+        if (-not (Test-Path $report)) { throw "report not created" }
+        $text = Get-Content $report -Raw
+        foreach ($needle in @(
+            "Dream Server install failure report",
+            "GPU backend: nvidia",
+            "ghcr.io/ggml-org/llama.cpp:server-cuda-b8648",
+            "Compose config tail (redacted)",
+            "DASHBOARD_API_KEY: [REDACTED]",
+            "OPENCLAW_TOKEN: [REDACTED]"
+        )) {
+            if ($text -notlike "*$needle*") { throw "missing $needle" }
+        }
+        if ($text -like "*super-secret-dashboard-key*" -or $text -like "*super-secret-openclaw-token*") {
+            throw "sensitive compose config value leaked"
+        }
+    '; then
+        pass "PowerShell report writer creates redacted report with mocked docker"
+    else
+        fail "PowerShell report writer runtime behavior failed"
+    fi
+else
+    pass "PowerShell runtime behavior skipped (pwsh unavailable)"
 fi
 
 echo ""

--- a/dream-server/tests/test-windows-compose-failure-report.sh
+++ b/dream-server/tests/test-windows-compose-failure-report.sh
@@ -121,9 +121,9 @@ EOF
             "DASHBOARD_API_KEY: [REDACTED]",
             "OPENCLAW_TOKEN: [REDACTED]"
         )) {
-            if ($text -notlike "*$needle*") { throw "missing $needle" }
+            if (-not $text.Contains($needle)) { throw "missing $needle" }
         }
-        if ($text -like "*super-secret-dashboard-key*" -or $text -like "*super-secret-openclaw-token*") {
+        if ($text.Contains("super-secret-dashboard-key") -or $text.Contains("super-secret-openclaw-token")) {
             throw "sensitive compose config value leaked"
         }
     '; then


### PR DESCRIPTION
## Summary
- adds an install-time compose failure report writer for Linux/WSL and macOS installs
- extends Windows install compose diagnostics to optionally save the same bounded report on install failure
- records the compose command, failed image references from the compose log, selected runtime/model values, port checks, Docker/compose state, and installer log tail
- keeps existing console diagnostics and normal `dream.ps1` start/stop/update behavior unchanged

## Why
When `docker compose up` fails during install, users currently have to copy a large console dump manually. This saves a focused `install-report-YYYY-MM-DD-HHMMSS.txt` under the install directory so the next support step is clear and shareable.

## Validation
- `bash -n dream-server/installers/lib/compose-failure-report.sh dream-server/install-core.sh dream-server/installers/phases/11-services.sh dream-server/installers/macos/install-macos.sh dream-server/tests/test-compose-failure-report.sh dream-server/tests/test-windows-compose-failure-report.sh`
- `bash dream-server/tests/test-compose-failure-report.sh`
- `bash dream-server/tests/test-windows-compose-failure-report.sh`
- `bash dream-server/tests/test-windows-report-command.sh`
- PowerShell parser validation for `installers/windows/lib/compose-diagnostics.ps1`
- PowerShell parser validation for `installers/windows/install-windows.ps1`
- Windows runtime smoke test for `Write-DreamComposeFailureReport` with mocked `docker.cmd`
- `git diff --cached --check`