### PR TITLE
feat(installer): summarize service readiness

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -66,6 +66,12 @@ jobs:
       - name: Windows Compose Failure Report Tests
         run: bash tests/test-windows-compose-failure-report.sh
 
+      - name: Install Readiness Summary Tests
+        run: bash tests/test-install-readiness-summary.sh
+
+      - name: Windows Install Readiness Summary Tests
+        run: bash tests/test-windows-readiness-summary.sh
+
       - name: Validate Env Tests
         run: bash tests/test-validate-env.sh
 

--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -74,6 +74,7 @@ source "$SCRIPT_DIR/installers/lib/tier-map.sh"
 source "$SCRIPT_DIR/installers/lib/docker-images.sh"
 source "$SCRIPT_DIR/installers/lib/compose-select.sh"
 source "$SCRIPT_DIR/installers/lib/compose-failure-report.sh"
+source "$SCRIPT_DIR/installers/lib/readiness-summary.sh"
 source "$SCRIPT_DIR/installers/lib/packaging.sh"
 source "$SCRIPT_DIR/installers/lib/progress.sh"
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 

--- a/dream-server/installers/lib/readiness-summary.sh
+++ b/dream-server/installers/lib/readiness-summary.sh
@@ -13,18 +13,35 @@
 
 _dream_readiness_http_code() {
     local url="$1" timeout="${2:-3}"
+    local code
     [[ -n "$url" ]] || { printf '000'; return 0; }
-    curl -s -o /dev/null -w "%{http_code}" --max-time "$timeout" "$url" 2>/dev/null || printf '000'
+    code="$(curl -s -o /dev/null -w "%{http_code}" --max-time "$timeout" "$url" 2>/dev/null || true)"
+    [[ "$code" =~ ^[0-9]{3}$ ]] || code="000"
+    printf '%s' "$code"
+}
+
+_dream_readiness_docker_available() {
+    case "${DOCKER_CMD:-docker}" in
+        "sudo docker") command -v sudo >/dev/null 2>&1 && command -v docker >/dev/null 2>&1 ;;
+        *) command -v "${DOCKER_CMD:-docker}" >/dev/null 2>&1 ;;
+    esac
+}
+
+_dream_readiness_docker() {
+    case "${DOCKER_CMD:-docker}" in
+        "sudo docker") sudo docker "$@" ;;
+        *) "${DOCKER_CMD:-docker}" "$@" ;;
+    esac
 }
 
 _dream_readiness_container_state() {
     local container="$1"
     [[ -n "$container" ]] || { printf 'host'; return 0; }
-    if ! command -v docker >/dev/null 2>&1; then
+    if ! _dream_readiness_docker_available; then
         printf 'docker-unavailable'
         return 0
     fi
-    docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container" 2>/dev/null || printf 'missing'
+    _dream_readiness_docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container" 2>/dev/null || printf 'missing'
 }
 
 _dream_readiness_is_ready_code() {

--- a/dream-server/installers/lib/readiness-summary.sh
+++ b/dream-server/installers/lib/readiness-summary.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Installer -- Install Readiness Summary
+# ============================================================================
+# Part of: installers/lib/
+# Purpose: Print a concise post-install summary showing which services are
+#          ready now and which need attention.
+#
+# Input format for dream_readiness_summary:
+#   name|health_url|container_name|open_url
+#   container_name may be empty for host-native services.
+# ============================================================================
+
+_dream_readiness_http_code() {
+    local url="$1" timeout="${2:-3}"
+    [[ -n "$url" ]] || { printf '000'; return 0; }
+    curl -s -o /dev/null -w "%{http_code}" --max-time "$timeout" "$url" 2>/dev/null || printf '000'
+}
+
+_dream_readiness_container_state() {
+    local container="$1"
+    [[ -n "$container" ]] || { printf 'host'; return 0; }
+    if ! command -v docker >/dev/null 2>&1; then
+        printf 'docker-unavailable'
+        return 0
+    fi
+    docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container" 2>/dev/null || printf 'missing'
+}
+
+_dream_readiness_is_ready_code() {
+    local code="$1"
+    [[ "$code" =~ ^(2|3) || "$code" == "401" || "$code" == "403" ]]
+}
+
+dream_readiness_summary() {
+    local status_cmd="${1:-dream status}"
+    local log_file="${2:-}"
+    local dashboard_url="${3:-http://localhost:3001}"
+
+    local ready_lines=()
+    local attention_lines=()
+    local total=0
+
+    while IFS='|' read -r name health_url container open_url; do
+        [[ -n "$name" ]] || continue
+        total=$((total + 1))
+        [[ -n "$open_url" ]] || open_url="$health_url"
+
+        local http_code container_state state detail line
+        http_code="$(_dream_readiness_http_code "$health_url" 3)"
+        container_state="$(_dream_readiness_container_state "$container")"
+
+        if _dream_readiness_is_ready_code "$http_code"; then
+            state="ready"
+            detail="HTTP $http_code"
+        elif [[ "$container_state" == "running" || "$container_state" == "starting" || "$container_state" == "host" ]]; then
+            state="starting"
+            detail="HTTP $http_code"
+        elif [[ "$container_state" == "missing" || "$container_state" == "docker-unavailable" ]]; then
+            state="not detected"
+            detail="$container_state"
+        else
+            state="needs attention"
+            detail="container $container_state, HTTP $http_code"
+        fi
+
+        line=$(printf "%-28s %s (%s)" "$name" "$open_url" "$detail")
+        if [[ "$state" == "ready" ]]; then
+            ready_lines+=("$line")
+        else
+            attention_lines+=("$(printf "%-28s %s - %s" "$name" "$state" "$detail")")
+        fi
+    done
+
+    [[ "$total" -gt 0 ]] || return 0
+
+    echo ""
+    echo -e "${BGRN:-}INSTALL READINESS${NC:-}"
+    echo "Ready now: ${#ready_lines[@]}/${total}"
+    if [[ ${#ready_lines[@]} -gt 0 ]]; then
+        echo "Ready:"
+        for line in "${ready_lines[@]}"; do
+            echo "  [OK] $line"
+        done
+    fi
+
+    if [[ ${#attention_lines[@]} -gt 0 ]]; then
+        echo "Needs attention:"
+        for line in "${attention_lines[@]}"; do
+            echo "  [!!] $line"
+        done
+    fi
+
+    echo "Next:"
+    echo "  - Open dashboard: $dashboard_url"
+    echo "  - Check status: $status_cmd"
+    [[ -n "$log_file" ]] && echo "  - Logs: $log_file"
+    echo ""
+}

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -117,6 +117,7 @@ source "${LIB_DIR}/env-generator.sh"
 if [[ -f "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh" ]]; then
     source "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh"
 fi
+source "${SOURCE_ROOT}/installers/lib/readiness-summary.sh"
 
 # ── File-local helpers ──
 # Build a launchd-friendly PATH that includes Docker and Homebrew prefixes.
@@ -1327,5 +1328,17 @@ if ! $ALL_HEALTHY; then
     echo -e "  ${GRN}./dream-macos.sh status${NC}"
     echo ""
 fi
+
+{
+    printf 'Dashboard|http://127.0.0.1:3001|dream-dashboard|http://localhost:3001\n'
+    printf 'Chat UI (Open WebUI)|http://127.0.0.1:3000|dream-webui|http://localhost:3000\n'
+    printf 'llama-server|http://127.0.0.1:8080/health||http://localhost:8080/v1\n'
+    printf 'Dashboard API|http://127.0.0.1:3002/health|dream-dashboard-api|http://localhost:3002\n'
+    printf 'LiteLLM|http://127.0.0.1:4000/health/readiness|dream-litellm|http://localhost:4000\n'
+    printf 'Perplexica|http://127.0.0.1:3004|dream-perplexica|http://localhost:3004\n'
+    $ENABLE_VOICE && printf 'Whisper (STT)|http://127.0.0.1:9000/health|dream-whisper|http://localhost:9000\n'
+    $ENABLE_WORKFLOWS && printf 'n8n|http://127.0.0.1:5678/healthz|dream-n8n|http://localhost:5678\n'
+    [[ -x "$OPENCODE_BIN" ]] && printf 'OpenCode (IDE)|http://127.0.0.1:%s||http://localhost:%s\n' "$OPENCODE_PORT" "$OPENCODE_PORT"
+} | dream_readiness_summary "./dream-macos.sh status" "$DS_LOG_FILE" "http://localhost:3001"
 
 show_success_card

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1336,7 +1336,7 @@ fi
     printf 'Dashboard API|http://127.0.0.1:3002/health|dream-dashboard-api|http://localhost:3002\n'
     printf 'LiteLLM|http://127.0.0.1:4000/health/readiness|dream-litellm|http://localhost:4000\n'
     printf 'Perplexica|http://127.0.0.1:3004|dream-perplexica|http://localhost:3004\n'
-    $ENABLE_VOICE && printf 'Whisper (STT)|http://127.0.0.1:9000/health|dream-whisper|http://localhost:9000\n'
+    $ENABLE_VOICE && printf 'Whisper (STT)|http://127.0.0.1:%s/health|dream-whisper|http://localhost:%s\n' "${WHISPER_PORT:-9000}" "${WHISPER_PORT:-9000}"
     $ENABLE_WORKFLOWS && printf 'n8n|http://127.0.0.1:5678/healthz|dream-n8n|http://localhost:5678\n'
     [[ -x "$OPENCODE_BIN" ]] && printf 'OpenCode (IDE)|http://127.0.0.1:%s||http://localhost:%s\n' "$OPENCODE_PORT" "$OPENCODE_PORT"
 } | dream_readiness_summary "./dream-macos.sh status" "$DS_LOG_FILE" "http://localhost:3001"

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -336,6 +336,36 @@ if ! $DRY_RUN; then
     fi
 fi
 
+if command -v dream_readiness_summary >/dev/null 2>&1; then
+    _dashboard_url="http://localhost:${SERVICE_PORTS[dashboard]:-3001}"
+    {
+        printf 'Dashboard|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[dashboard]:-3001}" "${SERVICE_HEALTH[dashboard]:-/}" "$(sr_container dashboard)" "$_dashboard_url"
+        printf 'Chat UI (Open WebUI)|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[open-webui]:-3000}" "${SERVICE_HEALTH[open-webui]:-/}" "$(sr_container open-webui)" "http://localhost:${SERVICE_PORTS[open-webui]:-3000}"
+        printf 'llama-server|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[llama-server]:-8080}" "${SERVICE_HEALTH[llama-server]:-/health}" "$(sr_container llama-server)" "http://localhost:${SERVICE_PORTS[llama-server]:-8080}/v1"
+        printf 'Dashboard API|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[dashboard-api]:-3002}" "${SERVICE_HEALTH[dashboard-api]:-/health}" "$(sr_container dashboard-api)" "http://localhost:${SERVICE_PORTS[dashboard-api]:-3002}"
+        printf 'LiteLLM|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[litellm]:-4000}" "${SERVICE_HEALTH[litellm]:-/health/readiness}" "$(sr_container litellm)" "http://localhost:${SERVICE_PORTS[litellm]:-4000}"
+        printf 'Perplexica|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[perplexica]:-3004}" "${SERVICE_HEALTH[perplexica]:-/}" "$(sr_container perplexica)" "http://localhost:${SERVICE_PORTS[perplexica]:-3004}"
+        [[ "$ENABLE_OPENCLAW" == "true" ]] && printf 'OpenClaw|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[openclaw]:-7860}" "${SERVICE_HEALTH[openclaw]:-/}" "$(sr_container openclaw)" "http://localhost:${SERVICE_PORTS[openclaw]:-7860}"
+        [[ "$ENABLE_VOICE" == "true" ]] && printf 'Whisper (STT)|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[whisper]:-9000}" "${SERVICE_HEALTH[whisper]:-/health}" "$(sr_container whisper)" "http://localhost:${SERVICE_PORTS[whisper]:-9000}"
+        [[ "$ENABLE_VOICE" == "true" ]] && printf 'Kokoro (TTS)|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[tts]:-8880}" "${SERVICE_HEALTH[tts]:-/health}" "$(sr_container tts)" "http://localhost:${SERVICE_PORTS[tts]:-8880}"
+        [[ "$ENABLE_WORKFLOWS" == "true" ]] && printf 'n8n|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[n8n]:-5678}" "${SERVICE_HEALTH[n8n]:-/healthz}" "$(sr_container n8n)" "http://localhost:${SERVICE_PORTS[n8n]:-5678}"
+        [[ "$ENABLE_RAG" == "true" ]] && printf 'Qdrant|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[qdrant]:-6333}" "${SERVICE_HEALTH[qdrant]:-/}" "$(sr_container qdrant)" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}"
+        [[ "$ENABLE_COMFYUI" == "true" ]] && printf 'ComfyUI|http://127.0.0.1:%s%s|%s|%s\n' \
+            "${SERVICE_PORTS[comfyui]:-8188}" "${SERVICE_HEALTH[comfyui]:-/}" "$(sr_container comfyui)" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}"
+    } | dream_readiness_summary "dream status" "$LOG_FILE" "$_dashboard_url"
+fi
+
 echo ""
 signal "Broadcast stable. You're free now."
 echo ""

--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -361,7 +361,7 @@ if command -v dream_readiness_summary >/dev/null 2>&1; then
             "${SERVICE_PORTS[n8n]:-5678}" "${SERVICE_HEALTH[n8n]:-/healthz}" "$(sr_container n8n)" "http://localhost:${SERVICE_PORTS[n8n]:-5678}"
         [[ "$ENABLE_RAG" == "true" ]] && printf 'Qdrant|http://127.0.0.1:%s%s|%s|%s\n' \
             "${SERVICE_PORTS[qdrant]:-6333}" "${SERVICE_HEALTH[qdrant]:-/}" "$(sr_container qdrant)" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}"
-        [[ "$ENABLE_COMFYUI" == "true" ]] && printf 'ComfyUI|http://127.0.0.1:%s%s|%s|%s\n' \
+        [[ "${ENABLE_COMFYUI:-}" == "true" ]] && printf 'ComfyUI|http://127.0.0.1:%s%s|%s|%s\n' \
             "${SERVICE_PORTS[comfyui]:-8188}" "${SERVICE_HEALTH[comfyui]:-/}" "$(sr_container comfyui)" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}"
     } | dream_readiness_summary "dream status" "$LOG_FILE" "$_dashboard_url"
 fi

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -71,6 +71,7 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "env-generator.ps1")
 . (Join-Path $LibDir "llm-endpoint.ps1")
 . (Join-Path $LibDir "opencode-config.ps1")
+. (Join-Path $LibDir "readiness-summary.ps1")
 
 # ── Phase context variables ───────────────────────────────────────────────────
 # These are plain (non-$script:) variables set in the orchestrator scope.
@@ -966,6 +967,56 @@ if ($perplexicaOk) {
 } else {
     Write-AIWarn "Perplexica auto-config skipped -- complete setup at http://localhost:3004"
 }
+
+$readinessEnv = Get-WindowsDreamEnvMap -InstallDir $installDir
+function Get-ReadinessPort {
+    param([string]$Name, [string]$Default)
+    if ($readinessEnv.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace($readinessEnv[$Name])) {
+        return $readinessEnv[$Name]
+    }
+    return $Default
+}
+
+$dashboardPort = Get-ReadinessPort -Name "DASHBOARD_PORT" -Default "3001"
+$webuiPort = Get-ReadinessPort -Name "WEBUI_PORT" -Default "3000"
+$dashboardApiPort = Get-ReadinessPort -Name "DASHBOARD_API_PORT" -Default "3002"
+$litellmPort = Get-ReadinessPort -Name "LITELLM_PORT" -Default "4000"
+$perplexicaPort = Get-ReadinessPort -Name "PERPLEXICA_PORT" -Default "3004"
+$llmContainer = if ($useLemonade -or $cloudMode -or $gpuInfo.Backend -eq "amd") { "" } else { "dream-llama-server" }
+$readinessChecks = @(
+    @{ Name = "Dashboard"; Url = "http://localhost:$dashboardPort"; Container = "dream-dashboard"; OpenUrl = "http://localhost:$dashboardPort" }
+    @{ Name = "Chat UI (Open WebUI)"; Url = "http://localhost:$webuiPort"; Container = "dream-webui"; OpenUrl = "http://localhost:$webuiPort" }
+    @{ Name = $llmEndpoint.Name; Url = $llmEndpoint.HealthUrl; Container = $llmContainer; OpenUrl = $llmEndpoint.BaseUrl }
+    @{ Name = "Dashboard API"; Url = "http://localhost:$dashboardApiPort/health"; Container = "dream-dashboard-api"; OpenUrl = "http://localhost:$dashboardApiPort" }
+    @{ Name = "LiteLLM"; Url = "http://localhost:$litellmPort/health/readiness"; Container = "dream-litellm"; OpenUrl = "http://localhost:$litellmPort" }
+    @{ Name = "Perplexica"; Url = "http://localhost:$perplexicaPort"; Container = "dream-perplexica"; OpenUrl = "http://localhost:$perplexicaPort" }
+)
+if ($enableVoice) {
+    $whisperPort = Get-ReadinessPort -Name "WHISPER_PORT" -Default "9000"
+    $ttsPort = Get-ReadinessPort -Name "TTS_PORT" -Default "8880"
+    $readinessChecks += @{ Name = "Whisper (STT)"; Url = "http://localhost:$whisperPort/health"; Container = "dream-whisper"; OpenUrl = "http://localhost:$whisperPort" }
+    $readinessChecks += @{ Name = "Kokoro (TTS)"; Url = "http://localhost:$ttsPort/health"; Container = "dream-tts"; OpenUrl = "http://localhost:$ttsPort" }
+}
+if ($enableWorkflows) {
+    $n8nPort = Get-ReadinessPort -Name "N8N_PORT" -Default "5678"
+    $readinessChecks += @{ Name = "n8n"; Url = "http://localhost:$n8nPort/healthz"; Container = "dream-n8n"; OpenUrl = "http://localhost:$n8nPort" }
+}
+if ($enableRag) {
+    $qdrantPort = Get-ReadinessPort -Name "QDRANT_PORT" -Default "6333"
+    $readinessChecks += @{ Name = "Qdrant"; Url = "http://localhost:$qdrantPort"; Container = "dream-qdrant"; OpenUrl = "http://localhost:$qdrantPort" }
+}
+if ($enableOpenClaw) {
+    $openClawPort = Get-ReadinessPort -Name "OPENCLAW_PORT" -Default "7860"
+    $readinessChecks += @{ Name = "OpenClaw"; Url = "http://localhost:$openClawPort"; Container = "dream-openclaw"; OpenUrl = "http://localhost:$openClawPort" }
+}
+if ($enableComfyui) {
+    $comfyPort = Get-ReadinessPort -Name "COMFYUI_PORT" -Default "8188"
+    $readinessChecks += @{ Name = "ComfyUI"; Url = "http://localhost:$comfyPort"; Container = "dream-comfyui"; OpenUrl = "http://localhost:$comfyPort" }
+}
+Write-DreamInstallReadinessSummary -Checks $readinessChecks `
+    -StatusCommand ".\dream.ps1 status" `
+    -LogPath (Join-Path $installDir "logs\install.log") `
+    -DashboardUrl "http://localhost:$dashboardPort"
 
 # ── Desktop & Start Menu shortcuts ───────────────────────────────────────────
 try {

--- a/dream-server/installers/windows/lib/readiness-summary.ps1
+++ b/dream-server/installers/windows/lib/readiness-summary.ps1
@@ -1,0 +1,102 @@
+# ============================================================================
+# Dream Server Windows -- Install readiness summary
+# ============================================================================
+# Part of: installers/windows/lib/
+# Purpose: Print a concise post-install summary showing which services are
+#          ready now and which need attention.
+# Requires: ui.ps1 (Write-AI, Write-AIWarn, Write-Host colors) sourced first.
+# ============================================================================
+
+function Test-DreamReadinessHttp {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Url,
+        [int]$TimeoutSec = 3
+    )
+
+    try {
+        $req = [System.Net.HttpWebRequest]::Create($Url)
+        $req.Timeout = $TimeoutSec * 1000
+        $req.Method = "GET"
+        $resp = $req.GetResponse()
+        $code = [int]$resp.StatusCode
+        $resp.Close()
+        return @{ Code = $code; Ready = ($code -ge 200 -and $code -lt 400) }
+    }
+    catch [System.Net.WebException] {
+        $webResp = $_.Exception.Response
+        if ($webResp) {
+            $code = [int]$webResp.StatusCode
+            return @{ Code = $code; Ready = ($code -eq 401 -or $code -eq 403) }
+        }
+        return @{ Code = 0; Ready = $false }
+    }
+    catch {
+        return @{ Code = 0; Ready = $false }
+    }
+}
+
+function Get-DreamReadinessContainerState {
+    param([string]$Container)
+
+    if ([string]::IsNullOrWhiteSpace($Container)) { return "host" }
+    try {
+        $state = & docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' $Container 2>$null
+        if ($LASTEXITCODE -eq 0 -and $state) { return $state.ToString().Trim() }
+    }
+    catch { }
+    return "missing"
+}
+
+function Write-DreamInstallReadinessSummary {
+    param(
+        [Parameter(Mandatory = $true)]
+        [object[]]$Checks,
+        [string]$StatusCommand = ".\dream.ps1 status",
+        [string]$LogPath = "",
+        [string]$DashboardUrl = "http://localhost:3001"
+    )
+
+    $ready = New-Object System.Collections.Generic.List[string]
+    $attention = New-Object System.Collections.Generic.List[string]
+
+    foreach ($check in $Checks) {
+        if (-not $check.Name -or -not $check.Url) { continue }
+
+        $http = Test-DreamReadinessHttp -Url $check.Url
+        $containerState = Get-DreamReadinessContainerState -Container $check.Container
+        $openUrl = if ($check.OpenUrl) { $check.OpenUrl } else { $check.Url }
+
+        if ($http.Ready) {
+            [void]$ready.Add(("{0,-28} {1} (HTTP {2})" -f $check.Name, $openUrl, $http.Code))
+        }
+        else {
+            $state = "starting"
+            $detail = "HTTP $($http.Code)"
+            if ($containerState -and $containerState -notin @("running", "starting", "host")) {
+                $state = "needs attention"
+                $detail = "container $containerState, HTTP $($http.Code)"
+            }
+            [void]$attention.Add(("{0,-28} {1} - {2}" -f $check.Name, $state, $detail))
+        }
+    }
+
+    if (($ready.Count + $attention.Count) -eq 0) { return }
+
+    Write-Host ""
+    Write-Host "INSTALL READINESS" -ForegroundColor Green
+    Write-Host "Ready now: $($ready.Count)/$($ready.Count + $attention.Count)"
+    if ($ready.Count -gt 0) {
+        Write-Host "Ready:"
+        foreach ($line in $ready) { Write-Host "  [OK] $line" -ForegroundColor Green }
+    }
+    if ($attention.Count -gt 0) {
+        Write-Host "Needs attention:"
+        foreach ($line in $attention) { Write-Host "  [!!] $line" -ForegroundColor Yellow }
+    }
+    Write-Host "Next:"
+    Write-Host "  - Open dashboard: $DashboardUrl"
+    Write-Host "  - Check status: $StatusCommand"
+    if ($LogPath) { Write-Host "  - Logs: $LogPath" }
+    Write-Host ""
+}

--- a/dream-server/tests/test-install-readiness-summary.sh
+++ b/dream-server/tests/test-install-readiness-summary.sh
@@ -31,6 +31,16 @@ assert_contains() {
     fi
 }
 
+assert_not_contains() {
+    local file="$1" needle="$2" label="$3"
+    if grep -Fq -- "$needle" "$file"; then
+        fail "$label"
+        echo "    unexpected: $needle"
+    else
+        pass "$label"
+    fi
+}
+
 TMP_DIR="$(mktemp -d)"
 cleanup() { rm -rf "$TMP_DIR"; }
 trap cleanup EXIT
@@ -64,7 +74,16 @@ exit 0
 EOF
 chmod +x "$TMP_DIR/bin/docker"
 
+cat > "$TMP_DIR/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+[[ -n "${SUDO_MARKER:-}" ]] && printf 'sudo-called\n' >> "$SUDO_MARKER"
+exec "$@"
+EOF
+chmod +x "$TMP_DIR/bin/sudo"
+
 export PATH="$TMP_DIR/bin:$PATH"
+export DOCKER_CMD="sudo docker"
+export SUDO_MARKER="$TMP_DIR/sudo-marker"
 
 source "$SUMMARY_LIB"
 
@@ -82,8 +101,10 @@ echo ""
 assert_contains "$OUTPUT" "INSTALL READINESS" "summary has heading"
 assert_contains "$OUTPUT" "Ready now: 1/3" "summary counts ready services"
 assert_contains "$OUTPUT" "[OK] Dashboard" "summary lists ready service"
+[[ -s "$SUDO_MARKER" ]] && pass "summary honors DOCKER_CMD wrapper for docker inspect" || fail "summary ignored DOCKER_CMD wrapper"
 assert_contains "$OUTPUT" "[!!] Chat UI (Open WebUI)" "summary lists starting service"
 assert_contains "$OUTPUT" "starting - HTTP 000" "summary explains starting service"
+assert_not_contains "$OUTPUT" "000000" "failed curl probe is normalized to a single 000 code"
 assert_contains "$OUTPUT" "[!!] Qdrant" "summary lists missing service"
 assert_contains "$OUTPUT" "not detected - missing" "summary explains missing container"
 assert_contains "$OUTPUT" "HTTP 000" "summary includes failed HTTP code"

--- a/dream-server/tests/test-install-readiness-summary.sh
+++ b/dream-server/tests/test-install-readiness-summary.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server install readiness summary tests
+# ============================================================================
+# Behavioral tests for installers/lib/readiness-summary.sh with mocked curl
+# and docker commands.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUMMARY_LIB="$ROOT_DIR/installers/lib/readiness-summary.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+assert_contains() {
+    local file="$1" needle="$2" label="$3"
+    if grep -Fq -- "$needle" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+        echo "    missing: $needle"
+    fi
+}
+
+TMP_DIR="$(mktemp -d)"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+mkdir -p "$TMP_DIR/bin"
+
+cat > "$TMP_DIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+url="${@: -1}"
+case "$url" in
+  *3001*) printf "200" ;;
+  *3000*) printf "000"; exit 7 ;;
+  *6333*) printf "000"; exit 7 ;;
+  *) printf "404" ;;
+esac
+EOF
+chmod +x "$TMP_DIR/bin/curl"
+
+cat > "$TMP_DIR/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "$1" == "inspect" ]]; then
+  container="${@: -1}"
+  case "$container" in
+    dream-dashboard) echo "healthy"; exit 0 ;;
+    dream-webui) echo "running"; exit 0 ;;
+    dream-qdrant) exit 1 ;;
+    *) echo "missing"; exit 1 ;;
+  esac
+fi
+exit 0
+EOF
+chmod +x "$TMP_DIR/bin/docker"
+
+export PATH="$TMP_DIR/bin:$PATH"
+
+source "$SUMMARY_LIB"
+
+OUTPUT="$TMP_DIR/readiness.txt"
+{
+    printf 'Dashboard|http://127.0.0.1:3001|dream-dashboard|http://localhost:3001\n'
+    printf 'Chat UI (Open WebUI)|http://127.0.0.1:3000|dream-webui|http://localhost:3000\n'
+    printf 'Qdrant|http://127.0.0.1:6333|dream-qdrant|http://localhost:6333\n'
+} | dream_readiness_summary "dream status" "/tmp/dream-install.log" "http://localhost:3001" > "$OUTPUT"
+
+echo ""
+echo "=== Install readiness summary tests ==="
+echo ""
+
+assert_contains "$OUTPUT" "INSTALL READINESS" "summary has heading"
+assert_contains "$OUTPUT" "Ready now: 1/3" "summary counts ready services"
+assert_contains "$OUTPUT" "[OK] Dashboard" "summary lists ready service"
+assert_contains "$OUTPUT" "[!!] Chat UI (Open WebUI)" "summary lists starting service"
+assert_contains "$OUTPUT" "starting - HTTP 000" "summary explains starting service"
+assert_contains "$OUTPUT" "[!!] Qdrant" "summary lists missing service"
+assert_contains "$OUTPUT" "not detected - missing" "summary explains missing container"
+assert_contains "$OUTPUT" "HTTP 000" "summary includes failed HTTP code"
+assert_contains "$OUTPUT" "Open dashboard: http://localhost:3001" "summary shows dashboard next step"
+assert_contains "$OUTPUT" "Check status: dream status" "summary shows status command"
+assert_contains "$OUTPUT" "Logs: /tmp/dream-install.log" "summary shows log path"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/dream-server/tests/test-windows-readiness-summary.sh
+++ b/dream-server/tests/test-windows-readiness-summary.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Windows install readiness summary tests
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUMMARY_LIB="$ROOT_DIR/installers/windows/lib/readiness-summary.ps1"
+INSTALL_PS1="$ROOT_DIR/installers/windows/install-windows.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+echo ""
+echo "=== Windows install readiness summary tests ==="
+echo ""
+
+[[ -f "$SUMMARY_LIB" ]] && pass "readiness summary library exists" || fail "readiness summary library missing"
+check 'readiness-summary.ps1' "$INSTALL_PS1" "Windows installer sources readiness summary library"
+check 'function Write-DreamInstallReadinessSummary' "$SUMMARY_LIB" "summary writer function exists"
+check 'Test-DreamReadinessHttp' "$SUMMARY_LIB" "summary probes HTTP endpoints"
+check 'Get-DreamReadinessContainerState' "$SUMMARY_LIB" "summary reads Docker container state"
+check 'Write-DreamInstallReadinessSummary -Checks $readinessChecks' "$INSTALL_PS1" "installer prints readiness summary"
+
+if command -v pwsh >/dev/null 2>&1; then
+    OUTPUT="$(SUMMARY_LIB="$SUMMARY_LIB" pwsh -NoProfile -Command '
+        $ErrorActionPreference = "Stop"
+        . $env:SUMMARY_LIB
+        function Test-DreamReadinessHttp {
+            param([string]$Url, [int]$TimeoutSec = 3)
+            if ($Url -like "*3001*") { return @{ Code = 200; Ready = $true } }
+            return @{ Code = 0; Ready = $false }
+        }
+        function Get-DreamReadinessContainerState {
+            param([string]$Container)
+            if ($Container -eq "dream-webui") { return "running" }
+            if ($Container -eq "dream-qdrant") { return "missing" }
+            return "healthy"
+        }
+        $checks = @(
+            @{ Name = "Dashboard"; Url = "http://localhost:3001"; Container = "dream-dashboard"; OpenUrl = "http://localhost:3001" },
+            @{ Name = "Chat UI"; Url = "http://localhost:3000"; Container = "dream-webui"; OpenUrl = "http://localhost:3000" },
+            @{ Name = "Qdrant"; Url = "http://localhost:6333"; Container = "dream-qdrant"; OpenUrl = "http://localhost:6333" }
+        )
+        Write-DreamInstallReadinessSummary -Checks $checks -StatusCommand ".\dream.ps1 status" -LogPath "C:\dream\logs\install.log" -DashboardUrl "http://localhost:3001"
+    ')"
+
+    [[ "$OUTPUT" == *"INSTALL READINESS"* ]] && pass "runtime summary has heading" || fail "runtime summary missing heading"
+    [[ "$OUTPUT" == *"Ready now: 1/3"* ]] && pass "runtime summary counts ready services" || fail "runtime summary count mismatch"
+    [[ "$OUTPUT" == *"[OK] Dashboard"* ]] && pass "runtime summary lists ready service" || fail "runtime summary missing ready service"
+    [[ "$OUTPUT" == *"[!!] Chat UI"* ]] && pass "runtime summary lists starting service" || fail "runtime summary missing starting service"
+    [[ "$OUTPUT" == *"[!!] Qdrant"* ]] && pass "runtime summary lists missing service" || fail "runtime summary missing missing service"
+else
+    pass "PowerShell runtime behavior skipped (pwsh unavailable)"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- adds a post-install readiness summary for Linux/WSL, macOS, and Windows installers
- reports ready services separately from services still starting or needing attention
- includes the dashboard URL, status command, and install log path as the next steps
- adds mocked tests for the Bash readiness summary and Windows PowerShell summary wiring/runtime behavior

## Why
The installer already performs health checks, but the final output primarily lists URLs. This makes the final state clearer for users: they can see what is ready immediately, what is still warming up, and where to look next without digging through logs.

## Validation
- `bash -n dream-server/installers/lib/readiness-summary.sh dream-server/install-core.sh dream-server/installers/phases/13-summary.sh dream-server/installers/macos/install-macos.sh dream-server/tests/test-install-readiness-summary.sh dream-server/tests/test-windows-readiness-summary.sh`
- `bash dream-server/tests/test-install-readiness-summary.sh`
- `bash dream-server/tests/test-windows-readiness-summary.sh`
- PowerShell parser validation for `installers/windows/lib/readiness-summary.ps1`
- PowerShell parser validation for `installers/windows/install-windows.ps1`
- PSScriptAnalyzer for `installers/windows/lib/readiness-summary.ps1`
- PSScriptAnalyzer for `installers/windows/install-windows.ps1`
- Windows PowerShell runtime smoke test for `Write-DreamInstallReadinessSummary`
- `git diff --check`