### PR TITLE
feat(mdns): publish dream.local on the local network

### DIFF
--- a/dream-server/bin/dream-mdns.py
+++ b/dream-server/bin/dream-mdns.py
@@ -5,8 +5,9 @@ Publishes the device on the local network as `<DREAM_DEVICE_NAME>.local`
 (default `dream.local`) plus per-service `_http._tcp` records so any device
 on the same LAN can find the dashboard and chat UI without knowing the IP.
 
-This makes the "open `dream.local` from any phone" UX work out of the box —
-the device boots, joins WiFi, and starts announcing itself within seconds.
+When paired with dream-proxy on port 80, this makes the "open `dream.local`
+from any phone" UX work: the device boots, joins WiFi, and starts announcing
+itself within seconds.
 
 Reads `DREAM_DEVICE_NAME` and the service ports from `.env`. Re-publishes
 when the file changes (poll-based, 30s cadence) so renaming the device or
@@ -72,7 +73,24 @@ logger = logging.getLogger(__name__)
 
 INSTALL_DIR = Path(os.environ.get("DREAM_INSTALL_DIR", "/opt/dream-server"))
 ENV_FILE = INSTALL_DIR / ".env"
-POLL_INTERVAL = int(os.environ.get("DREAM_MDNS_POLL_INTERVAL", "30"))
+
+
+def _safe_positive_int_env(key: str, default: int) -> int:
+    raw = os.environ.get(key, "")
+    if raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning("Env %s=%r is not a valid integer; using default %d", key, raw, default)
+        return default
+    if value <= 0:
+        logger.warning("Env %s=%r is non-positive; using default %d", key, raw, default)
+        return default
+    return value
+
+
+POLL_INTERVAL = _safe_positive_int_env("DREAM_MDNS_POLL_INTERVAL", 30)
 
 # Hostname-safe pattern matches DREAM_DEVICE_NAME schema in .env.schema.json.
 _HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$")
@@ -128,50 +146,109 @@ def _safe_port(env: dict[str, str], key: str, default: int) -> int:
             "Env %s=%r is not a valid integer; using default %d", key, raw, default,
         )
         return default
-    if value <= 0:
+    if value <= 0 or value > 65535:
         logger.warning(
-            "Env %s=%r is non-positive; using default %d", key, raw, default,
+            "Env %s=%r is outside the valid TCP/UDP port range; using default %d", key, raw, default,
         )
         return default
     return value
 
 
+def _normalized_bind_address(env: dict[str, str]) -> str:
+    return (env.get("BIND_ADDRESS") or "127.0.0.1").strip().lower()
+
+
+def _direct_ports_lan_reachable(env: dict[str, str]) -> bool:
+    """Direct host ports are only truthful when the services bind to the LAN.
+
+    The default Dream posture keeps service ports on 127.0.0.1 and exposes only
+    dream-proxy on the LAN. In that default, advertise the proxy hostnames but
+    do not publish direct-port SRV records that would point LAN clients at
+    unreachable endpoints.
+    """
+    bind = _normalized_bind_address(env)
+    return bind not in {"", "127.0.0.1", "localhost", "::1"}
+
+
 def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[ServiceInfo]:
     """Build the ServiceInfo records to publish.
 
-    Each entry advertises a port on the host (the external port the user
-    actually browses to), not the container-internal port. We only publish
-    services whose port is configured — if the dashboard isn't running on
-    this device, we don't announce it.
+    Two flavors of record:
+
+    1. Direct-port SRV records under `_http._tcp.local.` (the historical
+       shape — backward-compatible with MCP clients and service-discovery
+       tools). These point at the underlying service ports (3000, 3001,
+       3002) for clients that want to bypass the proxy.
+
+    2. Per-subdomain A records (`chat.<device>.local`, `auth.<device>.local`,
+       `dashboard.<device>.local`, `hermes.<device>.local`) all pointing at
+       the device's LAN IP on port 80 — the dream-proxy. The proxy
+       routes by Host header. The A record is a side effect of registering
+       a ServiceInfo whose `server` field is the hostname we want
+       resolvable.
+
+    Each service that isn't configured (port <= 0 or missing) is dropped
+    from publication. Subdomain records are always published as long as
+    DREAM_DEVICE_NAME is valid — the proxy itself decides at routing
+    time whether the upstream is healthy.
     """
     addresses = [socket.inet_aton(ip)]
-    services: list[tuple[str, int, str, dict[str, str]]] = [
-        # (service_type_prefix, port, label, extra_txt)
-        ("dashboard",     _safe_port(env, "DASHBOARD_PORT", 3001),     "Dream Dashboard", {"path": "/"}),
-        ("chat",          _safe_port(env, "WEBUI_PORT", 3000),         "Dream Chat",      {"path": "/"}),
-        ("dashboard-api", _safe_port(env, "DASHBOARD_API_PORT", 3002), "Dream API",       {"path": "/health"}),
-        # Announce unconditionally: the Hermes extension is opt-in via `dream
-        # enable hermes`, but the published mDNS record stays consistent with
-        # the other entries (dashboard/chat/dashboard-api are also announced
-        # whether or not their containers are up). Browser-side failure mode
-        # when Hermes is disabled is "site can't be reached" — same as any
-        # other service-not-running case.
-        ("hermes",        _safe_port(env, "HERMES_PORT", 9119),        "Hermes Agent",    {"path": "/api/health"}),
-    ]
+    proxy_port = _safe_port(env, "DREAM_PROXY_PORT", 80)
+
     infos: list[ServiceInfo] = []
-    for suffix, port, label, txt in services:
-        if port <= 0:
-            continue
-        full_name = f"{device_name}-{suffix}._http._tcp.local."
-        info = ServiceInfo(
+
+    # ----- Direct-port SRV records (back-compat for service discovery) ----
+    if _direct_ports_lan_reachable(env):
+        direct: list[tuple[str, int, str, dict[str, str]]] = [
+            # (suffix, port, label, extra_txt)
+            ("dashboard",     _safe_port(env, "DASHBOARD_PORT", 3001),     "Dream Dashboard", {"path": "/"}),
+            ("chat",          _safe_port(env, "WEBUI_PORT", 3000),         "Dream Chat",      {"path": "/"}),
+            ("dashboard-api", _safe_port(env, "DASHBOARD_API_PORT", 3002), "Dream API",       {"path": "/health"}),
+            # Announce unconditionally when direct ports are LAN-reachable:
+            # the Hermes extension is opt-in via `dream enable hermes`, but
+            # the failure mode when disabled is the same as any optional
+            # service that is not running.
+            ("hermes",        _safe_port(env, "HERMES_PORT", 9119),        "Hermes Agent",    {"path": "/api/health"}),
+        ]
+        for suffix, port, label, txt in direct:
+            infos.append(ServiceInfo(
+                type_="_http._tcp.local.",
+                name=f"{device_name}-{suffix}._http._tcp.local.",
+                addresses=addresses,
+                port=port,
+                properties={**txt, "label": label, "device": device_name, "kind": "direct"},
+                server=f"{device_name}.local.",
+            ))
+    else:
+        logger.info("Skipping direct-port SRV records because BIND_ADDRESS is loopback-only")
+
+    # ----- Per-subdomain A records (proxy-routed) -------------------------
+    # Each entry registers a `<sub>.<device>.local.` A record (or bare
+    # `<device>.local.` for "root") by virtue of being the `server` of the
+    # ServiceInfo. Port is the proxy's listen port; the proxy routes by Host
+    # header to the right backend.
+    subdomain_routes = (
+        ("root",     "Dream Root Redirect (via proxy)"),
+        ("chat",      "Dream Chat (via proxy)"),
+        ("dashboard", "Dream Dashboard (via proxy)"),
+        ("auth",      "Dream Auth (magic-link redemption)"),
+        ("api",       "Dream API (admin)"),
+        # hermes is announced unconditionally; the proxy 502s when the
+        # upstream container isn't running, which is the right failure
+        # mode for an optional extension.
+        ("hermes",    "Hermes Agent (via proxy)"),
+    )
+    for suffix, label in subdomain_routes:
+        server = f"{device_name}.local." if suffix == "root" else f"{suffix}.{device_name}.local."
+        infos.append(ServiceInfo(
             type_="_http._tcp.local.",
-            name=full_name,
+            name=f"{device_name}-proxy-{suffix}._http._tcp.local.",
             addresses=addresses,
-            port=port,
-            properties={**txt, "label": label, "device": device_name},
-            server=f"{device_name}.local.",
-        )
-        infos.append(info)
+            port=proxy_port,
+            properties={"path": "/", "label": label, "device": device_name, "kind": "proxy"},
+            server=server,
+        ))
+
     return infos
 
 
@@ -185,16 +262,24 @@ class Announcer:
     def __init__(self) -> None:
         self.zc: Zeroconf | None = None
         self.registered: list[ServiceInfo] = []
-        self.last_signature: tuple[str, str, int, int, int] | None = None
+        self.last_signature: tuple[str, str, str, int, int, int, int, int] | None = None
 
-    def _config_signature(self, device_name: str, ip: str, env: dict[str, str]) -> tuple[str, str, int, int, int]:
-        """Compact summary of what we'd publish — re-announce on change."""
+    def _config_signature(self, device_name: str, ip: str, env: dict[str, str]) -> tuple[str, str, str, int, int, int, int, int]:
+        """Compact summary of what we'd publish — re-announce on change.
+
+        Includes DREAM_PROXY_PORT so that flipping the proxy to a non-
+        standard port (rare, but supported) triggers re-announcement of
+        the per-subdomain SRV records.
+        """
         return (
             device_name,
             ip,
+            _normalized_bind_address(env),
             _safe_port(env, "DASHBOARD_PORT", 3001),
             _safe_port(env, "WEBUI_PORT", 3000),
             _safe_port(env, "DASHBOARD_API_PORT", 3002),
+            _safe_port(env, "HERMES_PORT", 9119),
+            _safe_port(env, "DREAM_PROXY_PORT", 80),
         )
 
     def refresh(self) -> None:

--- a/dream-server/bin/dream-mdns.py
+++ b/dream-server/bin/dream-mdns.py
@@ -35,17 +35,34 @@ import sys
 import time
 from pathlib import Path
 
-try:
-    from zeroconf import IPVersion, ServiceInfo, Zeroconf
-except ImportError:
-    print(
-        "ERROR: `zeroconf` Python package not installed. "
-        "On Debian/Ubuntu: sudo apt install python3-zeroconf. "
-        "On Fedora: sudo dnf install python3-zeroconf. "
-        "On Arch: sudo pacman -S python-zeroconf.",
-        file=sys.stderr,
-    )
-    sys.exit(1)
+# zeroconf import is deferred past the platform gate in main(). macOS has
+# built-in Bonjour and Windows isn't covered yet — neither should hard-fail
+# at start just because the package isn't installed.
+IPVersion = None  # type: ignore
+ServiceInfo = None  # type: ignore
+Zeroconf = None  # type: ignore
+
+
+def _import_zeroconf_or_die() -> None:
+    """Linux-only path. Imports zeroconf lazily so non-Linux platforms can
+    exit cleanly without the package installed."""
+    global IPVersion, ServiceInfo, Zeroconf
+    try:
+        from zeroconf import IPVersion as _IPVersion  # noqa: PLC0415
+        from zeroconf import ServiceInfo as _ServiceInfo  # noqa: PLC0415
+        from zeroconf import Zeroconf as _Zeroconf  # noqa: PLC0415
+    except ImportError:
+        print(
+            "ERROR: `zeroconf` Python package not installed. "
+            "On Debian/Ubuntu: sudo apt install python3-zeroconf. "
+            "On Fedora: sudo dnf install python3-zeroconf. "
+            "On Arch: sudo pacman -S python-zeroconf.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    IPVersion = _IPVersion
+    ServiceInfo = _ServiceInfo
+    Zeroconf = _Zeroconf
 
 logging.basicConfig(
     level=os.environ.get("DREAM_MDNS_LOG_LEVEL", "INFO"),
@@ -93,6 +110,32 @@ def _get_local_ip() -> str:
     return ip
 
 
+def _safe_port(env: dict[str, str], key: str, default: int) -> int:
+    """Parse a port from .env. Tolerant of blank/non-numeric values.
+
+    The .env file is intentionally user-editable, so a typo in WEBUI_PORT
+    must not crash the announcer (which would then restart on a systemd
+    loop, spamming logs). On bad input we log and fall back to the default;
+    the next refresh picks up the fix once the user corrects .env.
+    """
+    raw = env.get(key, "")
+    if raw == "":
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Env %s=%r is not a valid integer; using default %d", key, raw, default,
+        )
+        return default
+    if value <= 0:
+        logger.warning(
+            "Env %s=%r is non-positive; using default %d", key, raw, default,
+        )
+        return default
+    return value
+
+
 def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[ServiceInfo]:
     """Build the ServiceInfo records to publish.
 
@@ -104,9 +147,9 @@ def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[Serv
     addresses = [socket.inet_aton(ip)]
     services: list[tuple[str, int, str, dict[str, str]]] = [
         # (service_type_prefix, port, label, extra_txt)
-        ("dashboard",   int(env.get("DASHBOARD_PORT", "3001")), "Dream Dashboard", {"path": "/"}),
-        ("chat",        int(env.get("WEBUI_PORT", "3000")),     "Dream Chat",      {"path": "/"}),
-        ("dashboard-api", int(env.get("DASHBOARD_API_PORT", "3002")), "Dream API", {"path": "/health"}),
+        ("dashboard",     _safe_port(env, "DASHBOARD_PORT", 3001),     "Dream Dashboard", {"path": "/"}),
+        ("chat",          _safe_port(env, "WEBUI_PORT", 3000),         "Dream Chat",      {"path": "/"}),
+        ("dashboard-api", _safe_port(env, "DASHBOARD_API_PORT", 3002), "Dream API",       {"path": "/health"}),
     ]
     infos: list[ServiceInfo] = []
     for suffix, port, label, txt in services:
@@ -142,9 +185,9 @@ class Announcer:
         return (
             device_name,
             ip,
-            int(env.get("DASHBOARD_PORT", "3001")),
-            int(env.get("WEBUI_PORT", "3000")),
-            int(env.get("DASHBOARD_API_PORT", "3002")),
+            _safe_port(env, "DASHBOARD_PORT", 3001),
+            _safe_port(env, "WEBUI_PORT", 3000),
+            _safe_port(env, "DASHBOARD_API_PORT", 3002),
         )
 
     def refresh(self) -> None:
@@ -206,6 +249,10 @@ def main() -> int:
             "See docs for follow-up. Exiting cleanly."
         )
         return 0
+    # Linux path: zeroconf is required from here on. Imported lazily so the
+    # no-op exits above don't trip on a missing package.
+    _import_zeroconf_or_die()
+
     if not ENV_FILE.is_file():
         logger.error("Env file not found at %s — cannot determine device config.", ENV_FILE)
         return 1
@@ -224,7 +271,9 @@ def main() -> int:
     while True:
         try:
             announcer.refresh()
-        except (OSError, RuntimeError) as exc:
+        except (OSError, RuntimeError, ValueError) as exc:
+            # ValueError covers any int-conversion failures we missed above —
+            # the alternative is a crashloop that masks the real config bug.
             logger.exception("Refresh failed: %s", exc)
         time.sleep(POLL_INTERVAL)
 

--- a/dream-server/bin/dream-mdns.py
+++ b/dream-server/bin/dream-mdns.py
@@ -150,6 +150,13 @@ def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[Serv
         ("dashboard",     _safe_port(env, "DASHBOARD_PORT", 3001),     "Dream Dashboard", {"path": "/"}),
         ("chat",          _safe_port(env, "WEBUI_PORT", 3000),         "Dream Chat",      {"path": "/"}),
         ("dashboard-api", _safe_port(env, "DASHBOARD_API_PORT", 3002), "Dream API",       {"path": "/health"}),
+        # Announce unconditionally: the Hermes extension is opt-in via `dream
+        # enable hermes`, but the published mDNS record stays consistent with
+        # the other entries (dashboard/chat/dashboard-api are also announced
+        # whether or not their containers are up). Browser-side failure mode
+        # when Hermes is disabled is "site can't be reached" — same as any
+        # other service-not-running case.
+        ("hermes",        _safe_port(env, "HERMES_PORT", 9119),        "Hermes Agent",    {"path": "/api/health"}),
     ]
     infos: list[ServiceInfo] = []
     for suffix, port, label, txt in services:

--- a/dream-server/bin/dream-mdns.py
+++ b/dream-server/bin/dream-mdns.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Dream Server mDNS announcer.
+
+Publishes the device on the local network as `<DREAM_DEVICE_NAME>.local`
+(default `dream.local`) plus per-service `_http._tcp` records so any device
+on the same LAN can find the dashboard and chat UI without knowing the IP.
+
+This makes the "open `dream.local` from any phone" UX work out of the box —
+the device boots, joins WiFi, and starts announcing itself within seconds.
+
+Reads `DREAM_DEVICE_NAME` and the service ports from `.env`. Re-publishes
+when the file changes (poll-based, 30s cadence) so renaming the device or
+changing a port doesn't require a service restart.
+
+Linux-first: relies on `avahi-daemon` being installed and running (already
+standard on Ubuntu / Debian / Fedora / Arch desktop installs). macOS has
+built-in mDNS via mDNSResponder and announces hostname.local automatically;
+this script is a no-op on Darwin (logs and exits 0). Windows mDNS support
+varies — see BRANDING.md / docs/MDNS.md for follow-up.
+
+Run via:
+  python3 /opt/dream-server/bin/dream-mdns.py
+or via the dream-mdns.service systemd unit.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import re
+import signal
+import socket
+import sys
+import time
+from pathlib import Path
+
+try:
+    from zeroconf import IPVersion, ServiceInfo, Zeroconf
+except ImportError:
+    print(
+        "ERROR: `zeroconf` Python package not installed. "
+        "On Debian/Ubuntu: sudo apt install python3-zeroconf. "
+        "On Fedora: sudo dnf install python3-zeroconf. "
+        "On Arch: sudo pacman -S python-zeroconf.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+logging.basicConfig(
+    level=os.environ.get("DREAM_MDNS_LOG_LEVEL", "INFO"),
+    format="%(asctime)s [dream-mdns] %(levelname)s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+INSTALL_DIR = Path(os.environ.get("DREAM_INSTALL_DIR", "/opt/dream-server"))
+ENV_FILE = INSTALL_DIR / ".env"
+POLL_INTERVAL = int(os.environ.get("DREAM_MDNS_POLL_INTERVAL", "30"))
+
+# Hostname-safe pattern matches DREAM_DEVICE_NAME schema in .env.schema.json.
+_HOSTNAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,30}[a-zA-Z0-9])?$")
+
+
+def _read_env() -> dict[str, str]:
+    """Return current .env values, ignoring comments and blank lines."""
+    if not ENV_FILE.is_file():
+        return {}
+    env: dict[str, str] = {}
+    for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        env[key.strip()] = value.strip().strip('"').strip("'")
+    return env
+
+
+def _get_local_ip() -> str:
+    """Best-effort local IPv4 address for the LAN-facing interface.
+
+    Opens a UDP socket to a non-routable address — the kernel picks the
+    interface it would use to reach the public internet, which is the same
+    interface we want to announce on. Never actually sends a packet.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))
+        ip: str = s.getsockname()[0]
+    except OSError:
+        ip = "127.0.0.1"
+    finally:
+        s.close()
+    return ip
+
+
+def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[ServiceInfo]:
+    """Build the ServiceInfo records to publish.
+
+    Each entry advertises a port on the host (the external port the user
+    actually browses to), not the container-internal port. We only publish
+    services whose port is configured — if the dashboard isn't running on
+    this device, we don't announce it.
+    """
+    addresses = [socket.inet_aton(ip)]
+    services: list[tuple[str, int, str, dict[str, str]]] = [
+        # (service_type_prefix, port, label, extra_txt)
+        ("dashboard",   int(env.get("DASHBOARD_PORT", "3001")), "Dream Dashboard", {"path": "/"}),
+        ("chat",        int(env.get("WEBUI_PORT", "3000")),     "Dream Chat",      {"path": "/"}),
+        ("dashboard-api", int(env.get("DASHBOARD_API_PORT", "3002")), "Dream API", {"path": "/health"}),
+    ]
+    infos: list[ServiceInfo] = []
+    for suffix, port, label, txt in services:
+        if port <= 0:
+            continue
+        full_name = f"{device_name}-{suffix}._http._tcp.local."
+        info = ServiceInfo(
+            type_="_http._tcp.local.",
+            name=full_name,
+            addresses=addresses,
+            port=port,
+            properties={**txt, "label": label, "device": device_name},
+            server=f"{device_name}.local.",
+        )
+        infos.append(info)
+    return infos
+
+
+class Announcer:
+    """Manages the lifecycle of mDNS service publications.
+
+    Holds onto the active Zeroconf handle and the currently-registered
+    services so a config change can re-register cleanly.
+    """
+
+    def __init__(self) -> None:
+        self.zc: Zeroconf | None = None
+        self.registered: list[ServiceInfo] = []
+        self.last_signature: tuple[str, str, int, int, int] | None = None
+
+    def _config_signature(self, device_name: str, ip: str, env: dict[str, str]) -> tuple[str, str, int, int, int]:
+        """Compact summary of what we'd publish — re-announce on change."""
+        return (
+            device_name,
+            ip,
+            int(env.get("DASHBOARD_PORT", "3001")),
+            int(env.get("WEBUI_PORT", "3000")),
+            int(env.get("DASHBOARD_API_PORT", "3002")),
+        )
+
+    def refresh(self) -> None:
+        env = _read_env()
+        device_name = env.get("DREAM_DEVICE_NAME", "dream") or "dream"
+        if not _HOSTNAME_RE.match(device_name):
+            logger.warning(
+                "DREAM_DEVICE_NAME %r is not hostname-safe; falling back to 'dream'",
+                device_name,
+            )
+            device_name = "dream"
+        ip = _get_local_ip()
+        signature = self._config_signature(device_name, ip, env)
+        if signature == self.last_signature and self.zc is not None:
+            return
+
+        if self.zc is not None:
+            logger.info("Config changed — re-registering mDNS services")
+            self._teardown()
+
+        self.zc = Zeroconf(ip_version=IPVersion.V4Only)
+        services = _build_services(env, device_name, ip)
+        for info in services:
+            self.zc.register_service(info)
+            self.registered.append(info)
+            logger.info(
+                "Published %s -> %s:%d (server %s)",
+                info.name, ip, info.port, info.server,
+            )
+        self.last_signature = signature
+
+    def _teardown(self) -> None:
+        if self.zc is None:
+            return
+        for info in self.registered:
+            try:
+                self.zc.unregister_service(info)
+            except (OSError, RuntimeError) as exc:
+                logger.warning("Failed to unregister %s: %s", info.name, exc)
+        self.zc.close()
+        self.zc = None
+        self.registered = []
+
+    def shutdown(self) -> None:
+        logger.info("Shutting down mDNS announcer")
+        self._teardown()
+
+
+def main() -> int:
+    if platform.system() == "Darwin":
+        logger.info(
+            "Darwin host detected — macOS mDNSResponder already announces hostname.local; "
+            "this script is a no-op on macOS. Exiting cleanly."
+        )
+        return 0
+    if platform.system() == "Windows":
+        logger.info(
+            "Windows host detected — mDNS support varies; this script is not yet supported on Windows. "
+            "See docs for follow-up. Exiting cleanly."
+        )
+        return 0
+    if not ENV_FILE.is_file():
+        logger.error("Env file not found at %s — cannot determine device config.", ENV_FILE)
+        return 1
+
+    announcer = Announcer()
+
+    def _on_signal(signum: int, _frame: object) -> None:
+        logger.info("Received signal %d", signum)
+        announcer.shutdown()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, _on_signal)
+    signal.signal(signal.SIGTERM, _on_signal)
+
+    logger.info("Starting Dream mDNS announcer (poll every %ds)", POLL_INTERVAL)
+    while True:
+        try:
+            announcer.refresh()
+        except (OSError, RuntimeError) as exc:
+            logger.exception("Refresh failed: %s", exc)
+        time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dream-server/docs/MDNS.md
+++ b/dream-server/docs/MDNS.md
@@ -1,0 +1,63 @@
+# Dream Server mDNS — `dream.local` from any device on your network
+
+Dream Server announces itself on your local network so you can browse to it from any phone, tablet, or laptop without knowing the IP. The URL is `http://dream.local` (or `http://<your-name>.local` if you renamed the device during setup).
+
+## What gets announced
+
+| mDNS name | Points to | What it serves |
+|---|---|---|
+| `<device>.local` | the device's LAN IP | base hostname — works as a bare URL in any browser |
+| `<device>-chat._http._tcp.local` | port 3000 | Open WebUI chat |
+| `<device>-dashboard._http._tcp.local` | port 3001 | Dashboard / settings |
+| `<device>-dashboard-api._http._tcp.local` | port 3002 | Dashboard API (health endpoint) |
+
+The first one is what users actually type. The `_http._tcp` records exist so MCP clients, service-discovery tools, and the eventual Dream Server mobile app can enumerate available services without hard-coded ports.
+
+## Platform support
+
+| Platform | Status | Notes |
+|---|---|---|
+| **Linux** | ✅ supported | Uses `python3-zeroconf` against the system's `avahi-daemon` (already installed on virtually all desktop Linux distros) |
+| **macOS** | ✅ implicit | macOS announces `<hostname>.local` automatically via Bonjour / mDNSResponder. The Dream mDNS script is a no-op on macOS — if you want a name other than your Mac's, change the system hostname. |
+| **Windows** | ⚠️ partial | mDNS support on Windows is fragmented (Bonjour Print Services, Microsoft's own mDNS responder, varying iOS/Android interop). Not yet covered by this script; follow-up planned. |
+
+## Troubleshooting
+
+### "Can't reach `dream.local`"
+
+Some routers and corporate networks block mDNS / Bonjour multicast packets:
+
+1. **Phone can't resolve it but laptop can** — your phone may be on a separate "guest" WiFi or a 5GHz radio that's segregated from the wired network. Try connecting both to the same SSID.
+2. **Nothing on the network can resolve it** — your router has IGMP snooping enabled and isn't forwarding multicast. Either flip that setting off (usually in advanced/multimedia settings) or fall back to using the device's IP address (visible in the dashboard at any time).
+3. **Resolves but slow** — some Android versions cache failed mDNS lookups aggressively. Toggle WiFi off and back on, or wait a few minutes.
+
+### Renaming the device
+
+Edit `.env` and change `DREAM_DEVICE_NAME` to whatever you want (letters, digits, hyphens; max 32 chars). The mDNS service polls `.env` every 30 seconds and re-announces automatically — no restart needed.
+
+If you want to force immediate re-announcement: `sudo systemctl restart dream-mdns`.
+
+### Running multiple Dream Servers on one network
+
+Give each one a unique `DREAM_DEVICE_NAME`. Two devices both calling themselves `dream.local` is undefined behavior — the most recent announcement usually wins but it depends on the OS and the timing. The recommended pattern: `kitchen.local`, `office.local`, `studio.local`.
+
+### Disabling mDNS entirely
+
+```bash
+sudo systemctl stop dream-mdns
+sudo systemctl disable dream-mdns
+```
+
+The device still works — you just have to use the IP address directly. The dashboard always shows the current IP in the top-right.
+
+## What this enables
+
+Once `dream.local` resolves on your network, the Phase 1 onboarding UX works end to end:
+
+1. User installs Dream Server (today: by running `install.sh`)
+2. Device joins WiFi and starts announcing
+3. User opens any browser on any device, types `dream.local`
+4. Chat UI loads
+5. User adds it to their phone's home screen (PWA) — the icon appears next to ChatGPT
+
+No IP-typing, no router-config-page-diving, no DNS setup. The same UX as Sonos / Apple TV / any other consumer device on a home network.

--- a/dream-server/docs/MDNS.md
+++ b/dream-server/docs/MDNS.md
@@ -4,24 +4,42 @@ Dream Server announces itself on your local network so you can browse to it from
 
 ## Prerequisites
 
-The mDNS announcement publishes the device's LAN IP under `<device>.local` (and per-service SRV records on the underlying ports). For `http://dream.local` to actually load chat from a phone, two more things have to be true:
+The mDNS announcement publishes the device's LAN IP under `<device>.local` and the proxy-routed subdomains. For `http://dream.local` to actually load chat from a phone, the `dream-proxy` extension must be enabled and LAN-bound:
 
-1. **`BIND_ADDRESS=0.0.0.0`** in `.env` — without this, all Dream services bind to `127.0.0.1` and only loopback can reach them. The mDNS name still resolves, but the connection is refused.
-2. **The `dream-proxy` extension is enabled** — that's the Caddy service that listens on port 80 and routes `/chat`, `/api/*`, `/auth/*`, etc. to the right backend. Without it, `http://dream.local` hits an empty port 80 and times out; users have to type the per-service port (`dream.local:3000`, `dream.local:3001`, etc.) directly.
+1. **The `dream-proxy` extension is enabled** — that's the Caddy service that listens on port 80 and routes by hostname (`chat.<device>.local`, `dashboard.<device>.local`, `auth.<device>.local`, etc.) to the right backend.
+2. **`DREAM_PROXY_BIND=0.0.0.0`** — this is the proxy default. The other Dream services can remain safely loopback-bound with `BIND_ADDRESS=127.0.0.1`; only the proxy needs to listen on the LAN.
 
-Fresh installs without these two are loopback-only. The installer's first-boot wizard offers to enable both. See [`docs/DREAM-PROXY.md`](DREAM-PROXY.md) for how the proxy routes traffic.
+Fresh installs without the proxy are still loopback-only. The installer's first-boot wizard offers to enable the proxy path. See `docs/DREAM-PROXY.md` for how the proxy routes traffic.
 
 ## What gets announced
 
+Two flavors:
+
+**Per-subdomain A records (the user-facing surface):**
+
 | mDNS name | Points to | What it serves |
 |---|---|---|
-| `<device>.local` | the device's LAN IP | base hostname — `http://<device>.local` hits the dream-proxy on :80 when enabled |
-| `<device>-chat._http._tcp.local` | port 3000 | Open WebUI direct (bypasses proxy) |
-| `<device>-dashboard._http._tcp.local` | port 3001 | Dashboard / settings (bypasses proxy) |
-| `<device>-dashboard-api._http._tcp.local` | port 3002 | Dashboard API health endpoint (bypasses proxy) |
-| `<device>-hermes._http._tcp.local` | port 9119 | Hermes Agent dashboard (when the `hermes` extension is enabled) |
+| `<device>.local` | LAN IP, port 80 | proxy: 302 redirect to `chat.<device>.local` |
+| `chat.<device>.local` | LAN IP, port 80 | proxy → Open WebUI (root-mounted) |
+| `dashboard.<device>.local` | LAN IP, port 80 | proxy → Dream Dashboard (operator UI) |
+| `auth.<device>.local` | LAN IP, port 80 | proxy → dashboard-api (magic-link redemption) |
+| `api.<device>.local` | LAN IP, port 80 | proxy → dashboard-api (admin `/api/*`) |
+| `hermes.<device>.local` | LAN IP, port 80 | proxy → hermes-proxy (when enabled) |
 
-The first row is what users normally type. The `_http._tcp` rows are SRV records primarily for MCP clients, service-discovery tools, and the eventual Dream Server mobile app — they expose the underlying ports so a client can talk directly to a service without going through the proxy (e.g. to scrape `/health`).
+All six names resolve to the same IP — the device's LAN address. Routing happens at the dream-proxy by Host header (see `docs/DREAM-PROXY.md`). The bare `<device>.local` redirects to chat for the friendliest landing.
+
+**Direct-port SRV records (back-compat for service discovery):**
+
+These are published only when `BIND_ADDRESS` is explicitly LAN-facing (for example `0.0.0.0` or a specific LAN IP). In the default safer posture, service ports stay on loopback and mDNS publishes only the proxy-routed names above.
+
+| mDNS name | Underlying port | Use case |
+|---|---|---|
+| `<device>-chat._http._tcp.local` | 3000 | Open WebUI direct (bypasses proxy) |
+| `<device>-dashboard._http._tcp.local` | 3001 | Dashboard direct |
+| `<device>-dashboard-api._http._tcp.local` | 3002 | Dashboard API health endpoint |
+| `<device>-hermes._http._tcp.local` | 9119 | Hermes Agent direct (when the `hermes` extension is enabled) |
+
+These exist for MCP clients, service-discovery tools, and the eventual Dream Server mobile app that want to talk directly to a service. End users should use the subdomain entries above.
 
 ## Platform support
 
@@ -67,7 +85,7 @@ Once `dream.local` resolves on your network **and the dream-proxy is up on port 
 1. User installs Dream Server (today: by running `install.sh`)
 2. Device joins WiFi, starts announcing, and dream-proxy comes up on :80
 3. User opens any browser on any device, types `dream.local`
-4. Caddy on :80 routes `/chat` to Open WebUI, chat UI loads
+4. Caddy on :80 redirects the bare hostname to `chat.<device>.local`, then routes that host to Open WebUI
 5. User adds it to their phone's home screen (PWA) — the icon appears next to ChatGPT
 
 No IP-typing, no router-config-page-diving, no DNS setup. The same UX as Sonos / Apple TV / any other consumer device on a home network.

--- a/dream-server/docs/MDNS.md
+++ b/dream-server/docs/MDNS.md
@@ -2,16 +2,25 @@
 
 Dream Server announces itself on your local network so you can browse to it from any phone, tablet, or laptop without knowing the IP. The URL is `http://dream.local` (or `http://<your-name>.local` if you renamed the device during setup).
 
+## Prerequisites
+
+The mDNS announcement publishes the device's LAN IP under `<device>.local` (and per-service SRV records on the underlying ports). For `http://dream.local` to actually load chat from a phone, two more things have to be true:
+
+1. **`BIND_ADDRESS=0.0.0.0`** in `.env` — without this, all Dream services bind to `127.0.0.1` and only loopback can reach them. The mDNS name still resolves, but the connection is refused.
+2. **The `dream-proxy` extension is enabled** — that's the Caddy service that listens on port 80 and routes `/chat`, `/api/*`, `/auth/*`, etc. to the right backend. Without it, `http://dream.local` hits an empty port 80 and times out; users have to type the per-service port (`dream.local:3000`, `dream.local:3001`, etc.) directly.
+
+Fresh installs without these two are loopback-only. The installer's first-boot wizard offers to enable both. See [`docs/DREAM-PROXY.md`](DREAM-PROXY.md) for how the proxy routes traffic.
+
 ## What gets announced
 
 | mDNS name | Points to | What it serves |
 |---|---|---|
-| `<device>.local` | the device's LAN IP | base hostname — works as a bare URL in any browser |
-| `<device>-chat._http._tcp.local` | port 3000 | Open WebUI chat |
-| `<device>-dashboard._http._tcp.local` | port 3001 | Dashboard / settings |
-| `<device>-dashboard-api._http._tcp.local` | port 3002 | Dashboard API (health endpoint) |
+| `<device>.local` | the device's LAN IP | base hostname — `http://<device>.local` hits the dream-proxy on :80 when enabled |
+| `<device>-chat._http._tcp.local` | port 3000 | Open WebUI direct (bypasses proxy) |
+| `<device>-dashboard._http._tcp.local` | port 3001 | Dashboard / settings (bypasses proxy) |
+| `<device>-dashboard-api._http._tcp.local` | port 3002 | Dashboard API health endpoint (bypasses proxy) |
 
-The first one is what users actually type. The `_http._tcp` records exist so MCP clients, service-discovery tools, and the eventual Dream Server mobile app can enumerate available services without hard-coded ports.
+The first row is what users normally type. The `_http._tcp` rows are SRV records primarily for MCP clients, service-discovery tools, and the eventual Dream Server mobile app — they expose the underlying ports so a client can talk directly to a service without going through the proxy (e.g. to scrape `/health`).
 
 ## Platform support
 
@@ -52,12 +61,12 @@ The device still works — you just have to use the IP address directly. The das
 
 ## What this enables
 
-Once `dream.local` resolves on your network, the Phase 1 onboarding UX works end to end:
+Once `dream.local` resolves on your network **and the dream-proxy is up on port 80** (see [Prerequisites](#prerequisites)), the Phase 1 onboarding UX works end to end:
 
 1. User installs Dream Server (today: by running `install.sh`)
-2. Device joins WiFi and starts announcing
+2. Device joins WiFi, starts announcing, and dream-proxy comes up on :80
 3. User opens any browser on any device, types `dream.local`
-4. Chat UI loads
+4. Caddy on :80 routes `/chat` to Open WebUI, chat UI loads
 5. User adds it to their phone's home screen (PWA) — the icon appears next to ChatGPT
 
 No IP-typing, no router-config-page-diving, no DNS setup. The same UX as Sonos / Apple TV / any other consumer device on a home network.

--- a/dream-server/docs/MDNS.md
+++ b/dream-server/docs/MDNS.md
@@ -19,6 +19,7 @@ Fresh installs without these two are loopback-only. The installer's first-boot w
 | `<device>-chat._http._tcp.local` | port 3000 | Open WebUI direct (bypasses proxy) |
 | `<device>-dashboard._http._tcp.local` | port 3001 | Dashboard / settings (bypasses proxy) |
 | `<device>-dashboard-api._http._tcp.local` | port 3002 | Dashboard API health endpoint (bypasses proxy) |
+| `<device>-hermes._http._tcp.local` | port 9119 | Hermes Agent dashboard (when the `hermes` extension is enabled) |
 
 The first row is what users normally type. The `_http._tcp` rows are SRV records primarily for MCP clients, service-discovery tools, and the eventual Dream Server mobile app — they expose the underlying ports so a client can talk directly to a service without going through the proxy (e.g. to scrape `/health`).
 

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -328,3 +328,72 @@ if [[ -f "$INSTALL_DIR/bin/dream-host-agent.py" ]]; then
         ai_warn "python3 not found — dream host agent not installed"
     fi
 fi
+
+# ── Dream mDNS Announcer (publishes dream.local on the LAN) ──
+# Makes the device discoverable from any phone/laptop on the same network
+# without typing an IP. See docs/MDNS.md for details. Linux-only; macOS
+# announces hostname.local automatically via Bonjour, the script is a no-op
+# there. Windows support TBD.
+if [[ -f "$INSTALL_DIR/bin/dream-mdns.py" ]] && [[ "$(uname -s)" == "Linux" ]]; then
+    # Install python3-zeroconf via the system package manager. Non-fatal —
+    # mDNS is a quality-of-life feature; if zeroconf isn't available the
+    # device is still reachable by IP.
+    if ! python3 -c "import zeroconf" 2>/dev/null; then
+        ai "Installing python3-zeroconf (for mDNS announcer)..."
+        case "$PKG_MANAGER" in
+            apt)    sudo apt-get install -y python3-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
+                        ai_warn "Failed to install python3-zeroconf via apt (non-fatal — mDNS announcer will not start)" ;;
+            dnf)    sudo dnf install -y python3-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
+                        ai_warn "Failed to install python3-zeroconf via dnf (non-fatal — mDNS announcer will not start)" ;;
+            pacman) sudo pacman -S --noconfirm --needed python-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
+                        ai_warn "Failed to install python-zeroconf via pacman (non-fatal — mDNS announcer will not start)" ;;
+            zypper) sudo zypper --non-interactive install python3-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
+                        ai_warn "Failed to install python3-zeroconf via zypper (non-fatal — mDNS announcer will not start)" ;;
+            *)      ai_warn "Unknown package manager — install python3-zeroconf manually for mDNS" ;;
+        esac
+    fi
+
+    # Install the systemd unit alongside dream-host-agent. Reuses the same
+    # __PLACEHOLDER__ substitution pattern, the same user resolution
+    # (INSTALL_USER → SUDO_USER → whoami), and the same sudo discipline.
+    if python3 -c "import zeroconf" 2>/dev/null && \
+       (systemctl status >/dev/null 2>&1 || [[ -d /run/systemd/system ]]) && \
+       [[ -f "$INSTALL_DIR/scripts/systemd/dream-mdns.service" ]]; then
+        MDNS_PYTHON="$(command -v python3)"
+        # Reuse $_agent_user from the host-agent block above if set; otherwise
+        # resolve fresh. Falls back to the same heuristic.
+        if [[ -z "${_agent_user:-}" ]]; then
+            if [[ -n "${INSTALL_USER:-}" ]]; then
+                _agent_user="$INSTALL_USER"
+            elif [[ -n "${SUDO_USER:-}" ]]; then
+                _agent_user="$SUDO_USER"
+            else
+                _agent_user="$(whoami)"
+            fi
+        fi
+        svc_tmp="/tmp/dream-mdns.service.$$"
+        cp "$INSTALL_DIR/scripts/systemd/dream-mdns.service" "$svc_tmp"
+        sed -i "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp" 2>/dev/null || \
+            sed -i '' "s|__INSTALL_DIR__|${INSTALL_DIR}|g" "$svc_tmp"
+        sed -i "s|__HOME__|${HOME}|g" "$svc_tmp" 2>/dev/null || \
+            sed -i '' "s|__HOME__|${HOME}|g" "$svc_tmp"
+        sed -i "s|__PYTHON3__|${MDNS_PYTHON}|g" "$svc_tmp" 2>/dev/null || \
+            sed -i '' "s|__PYTHON3__|${MDNS_PYTHON}|g" "$svc_tmp"
+        sed -i "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp" 2>/dev/null || \
+            sed -i '' "s|__INSTALL_USER__|${_agent_user}|g" "$svc_tmp"
+        if grep -q '__INSTALL_DIR__\|__HOME__\|__PYTHON3__\|__INSTALL_USER__' "$svc_tmp"; then
+            ai_warn "dream-mdns systemd unit has unrendered placeholders — check $svc_tmp"
+        else
+            sudo install -m 644 "$svc_tmp" /etc/systemd/system/dream-mdns.service
+            sudo systemctl daemon-reload 2>/dev/null || true
+            if sudo systemctl enable --now dream-mdns.service 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+                _device_name="$(grep -E '^DREAM_DEVICE_NAME=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || true)"
+                _device_name="${_device_name:-dream}"
+                ai_ok "Dream mDNS announcer installed — browse to http://${_device_name}.local from any device on your network"
+            else
+                ai_warn "Dream mDNS announcer failed to start (non-fatal — device is still reachable by IP)"
+            fi
+        fi
+        rm -f "$svc_tmp"
+    fi
+fi

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -389,7 +389,13 @@ if [[ -f "$INSTALL_DIR/bin/dream-mdns.py" ]] && [[ "$(uname -s)" == "Linux" ]]; 
             if sudo systemctl enable --now dream-mdns.service 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
                 _device_name="$(grep -E '^DREAM_DEVICE_NAME=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || true)"
                 _device_name="${_device_name:-dream}"
-                ai_ok "Dream mDNS announcer installed — browse to http://${_device_name}.local from any device on your network"
+                # Be honest about what mDNS does on its own: it publishes the
+                # name. Whether that name LOADS anything in a browser depends
+                # on dream-proxy being on :80 and DREAM_PROXY_BIND=0.0.0.0. Those
+                # are operator choices made elsewhere (and surfaced in the
+                # first-boot wizard); don't claim the URL works yet.
+                ai_ok "Dream mDNS announcer installed — '${_device_name}.local' now resolves on the LAN"
+                ai "  Enable dream-proxy (DREAM_PROXY_BIND defaults to 0.0.0.0) to make http://${_device_name}.local serve chat. See docs/DREAM-PROXY.md."
             else
                 ai_warn "Dream mDNS announcer failed to start (non-fatal — device is still reachable by IP)"
             fi

--- a/dream-server/scripts/systemd/dream-mdns.service
+++ b/dream-server/scripts/systemd/dream-mdns.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Dream Server mDNS Announcer
+After=network-online.target avahi-daemon.service
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=__INSTALL_USER__
+ExecStart=__PYTHON3__ __INSTALL_DIR__/bin/dream-mdns.py
+WorkingDirectory=__INSTALL_DIR__
+Environment=DREAM_INSTALL_DIR=__INSTALL_DIR__
+Environment=HOME=__HOME__
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# PR-1: mDNS — publish `dream.local` on the local network

**Branch:** `feat/mdns-announcer` (local, not pushed)
**Phase:** 1 of 4 (Network UX)
**Effort:** Medium — 4 files, 382 insertions
**Depends on:** PR-2 (`feat/webui-pwa-branding`) for the `DREAM_DEVICE_NAME` env-schema entry

## Summary

Adds a systemd-managed mDNS announcer that publishes the device on the LAN as `<DREAM_DEVICE_NAME>.local` (default `dream.local`). Once running, any phone/laptop on the same WiFi can browse to the device without knowing the IP.

Same UX as Sonos / Apple TV / any consumer device on a home network. **The foundation for the phone-first onboarding flow.**

## What's published

| mDNS name | Points to | What it serves |
|---|---|---|
| `<device>.local` | LAN IP | base hostname — bare URL in any browser |
| `<device>-chat._http._tcp.local` | port 3000 | Open WebUI chat |
| `<device>-dashboard._http._tcp.local` | port 3001 | Dashboard |
| `<device>-dashboard-api._http._tcp.local` | port 3002 | Dashboard API |

## Files

| File | Lines | What |
|---|---|---|
| `bin/dream-mdns.py` (new) | ~200 | Standalone Python service. Reads `.env` every 30s, calls `zeroconf.Zeroconf.register_service()` for each configured service. Best-effort IP detection via the UDP-to-public-IP trick (kernel chooses the right interface). Graceful SIGTERM shutdown. |
| `scripts/systemd/dream-mdns.service` (new) | 18 | System-mode unit matching `dream-host-agent.service`'s pattern (placeholders for `__INSTALL_DIR__` / `__HOME__` / `__PYTHON3__` / `__INSTALL_USER__`). |
| `docs/MDNS.md` (new) | ~80 | Operator docs: what gets announced, platform support, troubleshooting, how to disable. |
| `installers/phases/07-devtools.sh` (modified) | +60 | Install block after the host-agent install. Installs `python3-zeroconf` via apt/dnf/pacman/zypper, templates the systemd unit, enables --now. Non-fatal failure mode. |

## Platform support

- **Linux** — primary target. Uses `python3-zeroconf` against the system's `avahi-daemon` (already installed on virtually all desktop distros).
- **macOS** — script detects `platform.system() == "Darwin"` and exits cleanly. macOS announces hostname.local natively via mDNSResponder.
- **Windows** — script logs "not yet supported" and exits 0. Deferred to follow-up.

## Non-fatal failure mode

If `python3-zeroconf` install fails or the service fails to start, the install logs a `warn` but doesn't block. The device is still reachable by IP — mDNS is a quality-of-life feature, not a critical path. The dashboard always displays the IP prominently.

## Test plan

I cannot test from this Windows machine — these need a real Linux box on a real LAN:

- [ ] `systemctl status dream-mdns` shows active running after install
- [ ] On a phone on the same WiFi: `http://dream.local` resolves and shows the chat UI
- [ ] On a phone: dns lookup `dig @224.0.0.251 -p 5353 dream.local` returns the device IP
- [ ] On a phone: `avahi-browse -art` (or equivalent) lists the dream services
- [ ] Change `DREAM_DEVICE_NAME` in `.env`, wait 30s — `http://newname.local` resolves
- [ ] Two devices both running Dream — verify they don't collide if named differently

## Known limitations called out in docs

- Some routers / corporate WiFi block mDNS multicast (especially "guest" networks). Documented in `MDNS.md` troubleshooting section.
- Windows mDNS support is fragmented; deferred.
- Two devices both named `dream.local` is undefined behavior — documented as "give each one a unique name."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
