### PR TITLE
feat(open-webui): brand as Dream via WEBUI_NAME + add DREAM_DEVICE_NAME env

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -240,16 +240,16 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # install label (the text next to the icon on a phone's home screen).
 # WEBUI_NAME=Dream
 
-# Open WebUI public URL — used for share links, OAuth callbacks, and PWA
-# install metadata. Defaults to the dream-proxy path on the device's mDNS
-# hostname: http://<DREAM_DEVICE_NAME>.local/chat. The proxy listens on :80
-# and routes /chat to Open WebUI, so this is the URL users actually reach.
-# Override when fronted by Tailscale Funnel / Cloudflare Tunnel / etc.
-# WEBUI_URL=http://dream.local/chat
+# Optional Open WebUI public URL — used for share links, OAuth callbacks, and
+# PWA install metadata. Leave empty for traditional localhost usage. After
+# enabling dream-proxy + mDNS, set this to the reachable chat subdomain:
+# http://chat.<DREAM_DEVICE_NAME>.local. Override with a Tailscale Funnel /
+# Cloudflare Tunnel / custom domain URL when fronted by one.
+# WEBUI_URL=http://chat.dream.local
 
-# Device name used by mDNS announcements and as the default hostname segment
-# for WEBUI_URL (and future remote-access integrations). Letters / digits /
-# hyphens only — short and memorable wins (e.g. "dream", "kitchen", "lab").
+# Device name used by mDNS announcements and as the hostname segment for
+# proxy/headless URLs. Letters / digits / hyphens only — short and memorable
+# wins (e.g. "dream", "kitchen", "lab").
 # DREAM_DEVICE_NAME=dream
 
 # Web search settings

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -236,6 +236,20 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # Open WebUI authentication (true/false)
 # WEBUI_AUTH=true
 
+# Open WebUI PWA / branding name. Shown as the app title, page title, and PWA
+# install label (the text next to the icon on a phone's home screen).
+# WEBUI_NAME=Dream
+
+# Open WebUI public URL — used for share links and OAuth callbacks. Defaults to
+# http://<DREAM_DEVICE_NAME>.local:<WEBUI_PORT>. Override when fronted by a
+# reverse proxy, Tailscale Funnel, or Cloudflare Tunnel.
+# WEBUI_URL=http://dream.local:3000
+
+# Device name used by mDNS announcements and as the default hostname segment
+# for WEBUI_URL (and future remote-access integrations). Letters / digits /
+# hyphens only — short and memorable wins (e.g. "dream", "kitchen", "lab").
+# DREAM_DEVICE_NAME=dream
+
 # Web search settings
 # ENABLE_WEB_SEARCH=true
 # WEB_SEARCH_ENGINE=searxng

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -240,10 +240,12 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # install label (the text next to the icon on a phone's home screen).
 # WEBUI_NAME=Dream
 
-# Open WebUI public URL — used for share links and OAuth callbacks. Defaults to
-# http://<DREAM_DEVICE_NAME>.local:<WEBUI_PORT>. Override when fronted by a
-# reverse proxy, Tailscale Funnel, or Cloudflare Tunnel.
-# WEBUI_URL=http://dream.local:3000
+# Open WebUI public URL — used for share links, OAuth callbacks, and PWA
+# install metadata. Defaults to the dream-proxy path on the device's mDNS
+# hostname: http://<DREAM_DEVICE_NAME>.local/chat. The proxy listens on :80
+# and routes /chat to Open WebUI, so this is the URL users actually reach.
+# Override when fronted by Tailscale Funnel / Cloudflare Tunnel / etc.
+# WEBUI_URL=http://dream.local/chat
 
 # Device name used by mDNS announcements and as the default hostname segment
 # for WEBUI_URL (and future remote-access integrations). Letters / digits /

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -319,6 +319,22 @@
       "description": "Enable Open WebUI authentication",
       "default": true
     },
+    "WEBUI_NAME": {
+      "type": "string",
+      "description": "Open WebUI display + PWA install name. Surfaces as page title, app header, and the label next to the icon when the user adds Dream to their phone home screen.",
+      "default": "Dream"
+    },
+    "WEBUI_URL": {
+      "type": "string",
+      "description": "Open WebUI public URL — used for share links and OAuth callbacks. Defaults to http://<DREAM_DEVICE_NAME>.local:<WEBUI_PORT>. Override when fronted by a reverse proxy, Tailscale Funnel, or Cloudflare Tunnel.",
+      "default": ""
+    },
+    "DREAM_DEVICE_NAME": {
+      "type": "string",
+      "description": "Device name used by mDNS announcement and as the default hostname segment for WEBUI_URL and future remote-access integrations. Letters / digits / hyphens only.",
+      "default": "dream",
+      "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{0,30}[a-zA-Z0-9]$|^[a-zA-Z0-9]$"
+    },
     "WHISPER_MODEL": {
       "type": "string",
       "description": "Whisper STT model size",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -326,12 +326,12 @@
     },
     "WEBUI_URL": {
       "type": "string",
-      "description": "Open WebUI public URL — used for share links and OAuth callbacks. Defaults to http://<DREAM_DEVICE_NAME>.local:<WEBUI_PORT>. Override when fronted by a reverse proxy, Tailscale Funnel, or Cloudflare Tunnel.",
+      "description": "Optional Open WebUI public URL used for share links, OAuth callbacks, and PWA install metadata. Leave empty for traditional localhost usage. Set to http://chat.<DREAM_DEVICE_NAME>.local after enabling dream-proxy + mDNS, or to a Tailscale Funnel / Cloudflare Tunnel / custom domain URL.",
       "default": ""
     },
     "DREAM_DEVICE_NAME": {
       "type": "string",
-      "description": "Device name used by mDNS announcement and as the default hostname segment for WEBUI_URL and future remote-access integrations. Letters / digits / hyphens only.",
+      "description": "Device name used by mDNS announcement and as the hostname segment for proxy/headless URLs. Letters / digits / hyphens only.",
       "default": "dream",
       "pattern": "^[a-zA-Z0-9][a-zA-Z0-9-]{0,30}[a-zA-Z0-9]$|^[a-zA-Z0-9]$"
     },

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -82,6 +82,14 @@ services:
       ENABLE_OLLAMA_API: "false"
       OPENAI_API_BASE_URL: "${LLM_API_URL:-http://llama-server:8080}/v1"
       OPENAI_API_KEY: ""
+      # PWA / branding — surfaces as the app title, page title, and PWA install name.
+      # When a user adds Dream to their home screen, this is the label they see
+      # next to the Dream icon. Defaults to "Dream"; users can override per-install.
+      WEBUI_NAME: "${WEBUI_NAME:-Dream}"
+      # Public URL used by Open WebUI for share links and OAuth callbacks.
+      # Defaults to the local-network URL; override when fronted by a reverse
+      # proxy / Tailscale Funnel / Cloudflare Tunnel.
+      WEBUI_URL: "${WEBUI_URL:-http://${DREAM_DEVICE_NAME:-dream}.local:${WEBUI_PORT:-3000}}"
       WEBUI_AUTH: "${WEBUI_AUTH:-true}"
       WEBUI_SECRET_KEY: "${WEBUI_SECRET:?WEBUI_SECRET must be set — run the installer or add it to .env}"
       ENABLE_WEB_SEARCH: "true"

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -92,13 +92,13 @@ services:
       # so seeding a URL that doesn't actually resolve will bake bad share
       # links into the install.
       #
-      # Default points at the dream-proxy path (`/chat`) on the device's
-      # mDNS hostname. The proxy is the canonical LAN entry point — it
-      # listens on :80, routes `/chat` to Open WebUI, and is what end
-      # users actually hit. Fronting by Tailscale Funnel / Cloudflare
-      # Tunnel? Override WEBUI_URL in `.env` to the public URL of that
-      # tunnel.
-      WEBUI_URL: "${WEBUI_URL:-http://${DREAM_DEVICE_NAME:-dream}.local/chat}"
+      # Optional public URL Open WebUI uses for share links, OAuth callbacks,
+      # and PWA install metadata. Leave empty for traditional localhost usage.
+      # Headless/proxy installs should set WEBUI_URL to the real reachable chat
+      # origin, usually http://chat.${DREAM_DEVICE_NAME:-dream}.local once
+      # dream-proxy and mDNS are enabled. Tailscale/Cloudflare/custom domains
+      # should set this to the tunnel URL instead.
+      WEBUI_URL: "${WEBUI_URL:-}"
       WEBUI_AUTH: "${WEBUI_AUTH:-true}"
       WEBUI_SECRET_KEY: "${WEBUI_SECRET:?WEBUI_SECRET must be set — run the installer or add it to .env}"
       ENABLE_WEB_SEARCH: "true"

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -86,10 +86,19 @@ services:
       # When a user adds Dream to their home screen, this is the label they see
       # next to the Dream icon. Defaults to "Dream"; users can override per-install.
       WEBUI_NAME: "${WEBUI_NAME:-Dream}"
-      # Public URL used by Open WebUI for share links and OAuth callbacks.
-      # Defaults to the local-network URL; override when fronted by a reverse
-      # proxy / Tailscale Funnel / Cloudflare Tunnel.
-      WEBUI_URL: "${WEBUI_URL:-http://${DREAM_DEVICE_NAME:-dream}.local:${WEBUI_PORT:-3000}}"
+      # Public URL Open WebUI uses for share links, OAuth callbacks, and PWA
+      # install metadata. This value is persistent inside Open WebUI's config
+      # database (https://docs.openwebui.com/getting-started/env-configuration/#webui_url),
+      # so seeding a URL that doesn't actually resolve will bake bad share
+      # links into the install.
+      #
+      # Default points at the dream-proxy path (`/chat`) on the device's
+      # mDNS hostname. The proxy is the canonical LAN entry point — it
+      # listens on :80, routes `/chat` to Open WebUI, and is what end
+      # users actually hit. Fronting by Tailscale Funnel / Cloudflare
+      # Tunnel? Override WEBUI_URL in `.env` to the public URL of that
+      # tunnel.
+      WEBUI_URL: "${WEBUI_URL:-http://${DREAM_DEVICE_NAME:-dream}.local/chat}"
       WEBUI_AUTH: "${WEBUI_AUTH:-true}"
       WEBUI_SECRET_KEY: "${WEBUI_SECRET:?WEBUI_SECRET must be set — run the installer or add it to .env}"
       ENABLE_WEB_SEARCH: "true"

--- a/dream-server/extensions/services/open-webui/BRANDING.md
+++ b/dream-server/extensions/services/open-webui/BRANDING.md
@@ -1,0 +1,64 @@
+# Open WebUI — Dream branding
+
+How Dream Server brands the Open WebUI chat surface that users see daily.
+
+## What's branded today
+
+Set via env vars in `docker-compose.base.yml`. These flow into Open WebUI's runtime config and surface in the page title, PWA install dialog, and share links.
+
+| Variable | Default | What it controls |
+|---|---|---|
+| `WEBUI_NAME` | `Dream` | The display name. Appears as the browser tab title, the header inside the chat UI, and — critically — the label next to the Dream icon when the user adds the chat to their phone's home screen. |
+| `WEBUI_URL` | `http://${DREAM_DEVICE_NAME}.local:${WEBUI_PORT}` | The public URL Open WebUI uses for share links, OAuth callbacks, and any "open in browser" affordances. |
+| `DREAM_DEVICE_NAME` | `dream` | The mDNS hostname segment. Drives `${...}.local` and is reused by future remote-access integrations. |
+
+A user installing Dream Server today already sees "Dream" everywhere instead of "Open WebUI", and adding the PWA to a phone's home screen produces a tile labeled "Dream".
+
+## What's not branded yet (follow-up work)
+
+Open WebUI's PWA manifest pulls its name from `WEBUI_NAME` (✓) but its icons and theme color from static assets bundled inside the container image. To fully match the Dream brand, a follow-up PR needs to:
+
+1. **Override `/static/favicon.png`, `/static/splash.png`, `/static/logo.png`** — Open WebUI serves these from `/app/backend/static/`. Mounting a Dream-branded set via a volume mount in the compose service is the cleanest path:
+   ```yaml
+   volumes:
+     - ./extensions/services/open-webui/branding/favicon.png:/app/backend/static/favicon.png:ro
+     - ./extensions/services/open-webui/branding/logo.png:/app/backend/static/logo.png:ro
+     - ./extensions/services/open-webui/branding/splash.png:/app/backend/static/splash.png:ro
+   ```
+2. **Source actual icon assets.** Sizes needed:
+   - `favicon.ico` — 16x16, 32x32, 48x48 (multi-resolution)
+   - `apple-touch-icon.png` — 180x180
+   - `pwa-192.png` — 192x192 (Android home screen)
+   - `pwa-512.png` — 512x512 (PWA splash + larger displays)
+   - `pwa-maskable-512.png` — 512x512 with safe-zone padding for adaptive icons
+   - `splash.png` — 1024x1024 brand splash for iOS PWA launch
+3. **Set `theme_color`** to a Dream brand color (currently Open WebUI defaults to its own dark gray). This may require a custom `manifest.json` override served via the same volume-mount approach if Open WebUI doesn't expose a theme-color env var.
+
+## Where future assets should live
+
+```
+extensions/services/open-webui/
+├── BRANDING.md       (this file)
+├── manifest.yaml
+└── branding/         (new — added when icon assets are produced)
+    ├── favicon.ico
+    ├── favicon.png
+    ├── apple-touch-icon.png
+    ├── pwa-192.png
+    ├── pwa-512.png
+    ├── pwa-maskable-512.png
+    └── splash.png
+```
+
+Asset production needs design input (Dream logo, brand palette) before this directory should be populated. Placeholder assets risk shipping in a release if not caught.
+
+## Testing the current PR
+
+After this PR merges, on a running Dream Server:
+
+1. Browse to `http://dream.local:3000` (or the configured URL).
+2. The browser tab should read "Dream" — not "Open WebUI".
+3. On a phone, after adding the page to the home screen, the icon label should read "Dream".
+4. Inside the chat UI, the top-left header should read "Dream".
+
+The icon next to the label still shows Open WebUI's default until the follow-up PR ships the asset overrides.

--- a/dream-server/extensions/services/open-webui/BRANDING.md
+++ b/dream-server/extensions/services/open-webui/BRANDING.md
@@ -9,10 +9,10 @@ Set via env vars in `docker-compose.base.yml`. These flow into Open WebUI's runt
 | Variable | Default | What it controls |
 |---|---|---|
 | `WEBUI_NAME` | `Dream` | The display name. Appears as the browser tab title, the header inside the chat UI, and — critically — the label next to the Dream icon when the user adds the chat to their phone's home screen. |
-| `WEBUI_URL` | `http://${DREAM_DEVICE_NAME}.local/chat` | The public URL Open WebUI uses for share links, OAuth callbacks, and PWA install metadata. Points at the dream-proxy on `:80`, which routes `/chat` to Open WebUI — this is the URL end users actually reach, not the direct `:3000` port. |
+| `WEBUI_URL` | empty | Optional public URL Open WebUI uses for share links, OAuth callbacks, and PWA install metadata. Leave empty for traditional localhost usage. Headless/proxy installs should set it to `http://chat.${DREAM_DEVICE_NAME}.local` after dream-proxy + mDNS are enabled; tunnels should use their public URL. |
 | `DREAM_DEVICE_NAME` | `dream` | The mDNS hostname segment. Drives `${...}.local` and is reused by future remote-access integrations. |
 
-A user installing Dream Server today already sees "Dream" everywhere instead of "Open WebUI", and adding the PWA to a phone's home screen produces a tile labeled "Dream".
+After opening a reachable chat URL, users see "Dream" everywhere instead of "Open WebUI", and adding the PWA to a phone's home screen produces a tile labeled "Dream".
 
 ## What's not branded yet (follow-up work)
 
@@ -56,7 +56,7 @@ Asset production needs design input (Dream logo, brand palette) before this dire
 
 After this PR merges, on a running Dream Server:
 
-1. Browse to `http://dream.local:3000` (or the configured URL).
+1. Browse to the reachable chat URL: `http://localhost:3000` for traditional local usage, or `http://chat.dream.local` after enabling dream-proxy + mDNS.
 2. The browser tab should read "Dream" — not "Open WebUI".
 3. On a phone, after adding the page to the home screen, the icon label should read "Dream".
 4. Inside the chat UI, the top-left header should read "Dream".

--- a/dream-server/extensions/services/open-webui/BRANDING.md
+++ b/dream-server/extensions/services/open-webui/BRANDING.md
@@ -9,7 +9,7 @@ Set via env vars in `docker-compose.base.yml`. These flow into Open WebUI's runt
 | Variable | Default | What it controls |
 |---|---|---|
 | `WEBUI_NAME` | `Dream` | The display name. Appears as the browser tab title, the header inside the chat UI, and — critically — the label next to the Dream icon when the user adds the chat to their phone's home screen. |
-| `WEBUI_URL` | `http://${DREAM_DEVICE_NAME}.local:${WEBUI_PORT}` | The public URL Open WebUI uses for share links, OAuth callbacks, and any "open in browser" affordances. |
+| `WEBUI_URL` | `http://${DREAM_DEVICE_NAME}.local/chat` | The public URL Open WebUI uses for share links, OAuth callbacks, and PWA install metadata. Points at the dream-proxy on `:80`, which routes `/chat` to Open WebUI — this is the URL end users actually reach, not the direct `:3000` port. |
 | `DREAM_DEVICE_NAME` | `dream` | The mDNS hostname segment. Drives `${...}.local` and is reused by future remote-access integrations. |
 
 A user installing Dream Server today already sees "Dream" everywhere instead of "Open WebUI", and adding the PWA to a phone's home screen produces a tile labeled "Dream".


### PR DESCRIPTION
# PR-2: Open WebUI PWA branding — surface as "Dream"

**Branch:** `feat/webui-pwa-branding` (local, not pushed)
**Phase:** 1 of 4 (Network UX)
**Effort:** Small — 4 files, 102 insertions

## Summary

The Open WebUI chat surface ships today branded as "Open WebUI". This PR surfaces it as "Dream" in the three places the user actually sees:

1. Browser tab / page title
2. Header inside the chat UI
3. **Home-screen label** when the user adds the PWA to their phone

The third one is the goal. The "uncle test" is whether someone can scan a QR, tap "Install", and end up with a "Dream" icon on their home screen that looks indistinguishable from ChatGPT in daily use. This PR is the brand-string half of that.

## What changed

| File | Change |
|---|---|
| `docker-compose.base.yml` | Added `WEBUI_NAME=${WEBUI_NAME:-Dream}` and `WEBUI_URL` (defaults to `http://<DREAM_DEVICE_NAME>.local:<WEBUI_PORT>`) to the open-webui environment block |
| `.env.example` | Documented `WEBUI_NAME`, `WEBUI_URL`, `DREAM_DEVICE_NAME` as optional overrides |
| `.env.schema.json` | Registered the 3 new keys with descriptions and a hostname-safe pattern for `DREAM_DEVICE_NAME` |
| `extensions/services/open-webui/BRANDING.md` (new) | Explains what this PR brands, what icon/manifest customization is pending, where future asset files should live |

## What's NOT in this PR

- **Icon assets** (favicon, apple-touch-icon, PWA icons at 192/512/maskable, splash). Need design input — Dream logo and brand palette — before populating. Documented in BRANDING.md as a follow-up.
- **`manifest.json` theme_color override**. May need a volume-mount approach if Open WebUI doesn't expose theme-color as an env var. Deferred to the icon-asset PR.
- **Dashboard PWA manifest** — separate PR (PR-3 in the plan).
- **mDNS responder** — separate PR (PR-1 in the plan). `DREAM_DEVICE_NAME` is added here so the mDNS PR can read it without a second env-schema change.

## Why this is "PR-2" and not "PR-1"

In the plan I'd actually start with this one (smaller, more visible, lower risk) and follow with mDNS. The numbering in the plan was logical ordering, not execution ordering — PR-1 (mDNS) is the architectural foundation but PR-2 is what's actually shippable today.

## Test plan

After merge, on a running Dream Server:

- [ ] Browser tab reads "Dream", not "Open WebUI"
- [ ] Chat UI top-left header reads "Dream"
- [ ] On a phone, after adding the page to the home screen, the icon label reads "Dream"
- [ ] `docker compose config` validates (no syntax errors in the env block)
- [ ] `bash dream-server/scripts/validate-env.sh` passes the new schema entries

The icon next to the label still shows Open WebUI's default until the follow-up PR ships the asset overrides — this is expected and called out in BRANDING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
