### PR TITLE
feat(dashboard): PWA manifest + service worker + Apple home-screen support

### DIFF
--- a/dream-server/extensions/services/dashboard/index.html
+++ b/dream-server/extensions/services/dashboard/index.html
@@ -2,10 +2,21 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="description" content="Dream Server Dashboard - Control your local AI" />
-    <title>Dream Server 2026</title>
+    <title>Dream</title>
     <link rel="icon" type="image/svg+xml" href="/dream.svg" />
+
+    <!-- PWA manifest — makes the dashboard installable as "Dream" on phone home screens -->
+    <link rel="manifest" href="/manifest.webmanifest" />
+    <meta name="theme-color" content="#0f0f13" />
+
+    <!-- iOS PWA support: "Add to Home Screen" → standalone mode with custom icon and title -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Dream" />
+    <link rel="apple-touch-icon" href="/dream.svg" />
     <script>
       // Prevent flash of wrong theme — runs before React
       (function() {
@@ -54,5 +65,20 @@
       </div>
     </div>
     <script type="module" src="/src/main.jsx"></script>
+    <script>
+      // Register the PWA service worker after the page loads so it doesn't
+      // delay first paint. Only registers over secure contexts (HTTPS or
+      // localhost) — browsers refuse to register SWs from plain HTTP on a
+      // LAN IP, which is fine because the PWA-install affordance is also
+      // gated on a secure context.
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', function () {
+          navigator.serviceWorker.register('/sw.js').catch(function () {
+            // Silent: SW registration failure just means no PWA install
+            // prompt — the dashboard works the same either way.
+          });
+        });
+      }
+    </script>
   </body>
 </html>

--- a/dream-server/extensions/services/dashboard/public/manifest.webmanifest
+++ b/dream-server/extensions/services/dashboard/public/manifest.webmanifest
@@ -1,0 +1,26 @@
+{
+  "name": "Dream Server",
+  "short_name": "Dream",
+  "description": "Control center for your local Dream Server — chat, agents, models, settings.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "any",
+  "theme_color": "#0f0f13",
+  "background_color": "#0f0f13",
+  "categories": ["productivity", "utilities"],
+  "icons": [
+    {
+      "src": "/dream.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/dream.svg",
+      "sizes": "any",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/dream-server/extensions/services/dashboard/public/sw.js
+++ b/dream-server/extensions/services/dashboard/public/sw.js
@@ -1,0 +1,40 @@
+// Dream Server dashboard service worker.
+//
+// Minimal shell — registers the dashboard as a PWA so users can install it
+// to their phone's home screen. We deliberately do NOT cache API responses
+// or vendored chunks — the dashboard is a live system-status surface, and a
+// stale cache would mask the actual state of the running stack.
+//
+// What this gets us:
+//   - "Add to Home Screen" prompt fires on iOS / Android
+//   - Standalone display mode (no browser chrome) when launched from icon
+//   - Splash screen using theme_color + name from manifest.webmanifest
+//
+// What's intentionally NOT done here:
+//   - No precache. The shell is fast enough fresh.
+//   - No runtime caching of /api/* — that would silently mask down services.
+//   - No background sync. The dashboard polls when open; idle = no work.
+//
+// If we later want offline support for the chat surface, that lives in
+// Open WebUI's own service worker, not here.
+
+const VERSION = 'dream-dashboard-sw-v1';
+
+self.addEventListener('install', (event) => {
+  // Skip the waiting-for-existing-pages dance — install immediately.
+  // The dashboard is fine if the worker swaps mid-session; nothing is cached.
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener('activate', (event) => {
+  // Claim all open tabs so the new worker controls them right away,
+  // and clear any caches a previous version may have created.
+  event.waitUntil(Promise.all([
+    self.clients.claim(),
+    caches.keys().then((keys) => Promise.all(keys.map((k) => caches.delete(k)))),
+  ]));
+});
+
+// No fetch handler — let the network handle everything. Adding a no-op
+// handler would still serialize requests through the worker; omitting it
+// keeps the dashboard at native speed.


### PR DESCRIPTION
# PR-3: Dashboard PWA support

**Branch:** `feat/dashboard-pwa` (local, not pushed)
**Phase:** 1 of 4 (Network UX)
**Effort:** Small — 3 files, 94 insertions / 2 deletions

## Summary

Makes the dashboard at `:3001` installable as a PWA on any device. After this PR, a user can:

- Add the dashboard to their phone's home screen via the standard browser "Add to Home Screen" flow
- Tap the resulting "Dream" icon to launch the dashboard in standalone mode (no browser chrome)
- See the same dark theme color in the OS status bar

Pairs with PR-2 (which does the same for the chat surface). The two together produce a phone home screen with **two Dream tiles next to ChatGPT**: chat for daily-use, dashboard for admin.

## Files

| File | Change |
|---|---|
| `public/manifest.webmanifest` (new) | PWA manifest — name "Dream Server", short_name "Dream", standalone display, dark `theme_color` matching the dashboard's actual theme background. Icons point at the existing `dream.svg`. |
| `public/sw.js` (new) | Minimal service worker. Deliberately caches **nothing** — the dashboard is a live system-status surface and stale cache would mask running-service state. Just enough SW registration to satisfy PWA-install criteria. |
| `index.html` (modified) | Added `<link rel="manifest">`, `theme-color` meta, Apple PWA meta tags (capable / title / status-bar-style / apple-touch-icon), SW registration script. Title shortened to "Dream" since it's now the PWA install label. |

## What's NOT in this PR

- **Real PNG icons** at 192/512/maskable sizes. Currently using the existing SVG for all slots. Modern browsers handle SVG icons fine; iOS prefers PNG for apple-touch-icon at 180x180. Needs design input (Dream logo, brand palette).
- **`vite-plugin-pwa`** integration. Going static keeps the PR small and dependency-free. Can migrate later if we want auto-generated manifest or runtime caching.
- **iOS splash screens** — separate `<link rel="apple-touch-startup-image">` entries per device size. Skipping for v1.

## Test plan

- [ ] On iOS Safari at `http://dream.local:3001`: Share → Add to Home Screen → tile reads "Dream" with dream.svg icon
- [ ] On Android Chrome: install prompt fires → home-screen icon launches in standalone mode
- [ ] Desktop Chrome: install icon appears in address bar
- [ ] `npm run build` succeeds — `manifest.webmanifest` and `sw.js` end up in `dist/`
- [ ] Open WebUI's PWA install (PR-2) still works independently — different scope
- [ ] DevTools → Application → Service Workers → `/sw.js` registered with no errors

## Caveats

- **HTTPS required for full PWA features.** Browsers gate "Add to Home Screen" prompts on secure context. Works on `http://localhost` (special-cased) but not on `http://dream.local` without a cert. Users will need either:
  - Tailscale Funnel / Cloudflare Tunnel for legit HTTPS (PR-12 territory)
  - Self-signed cert + manual trust (advanced)
  - Or just use the dashboard from `localhost` on the device itself
- The chat PWA from PR-2 has the same constraint — they're addressed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
