### PR TITLE
feat(dashboard): add Invites page consuming magic-link API

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Invites.jsx
@@ -1,0 +1,545 @@
+import { useState, useEffect, useCallback } from 'react'
+import {
+  UserPlus, Copy, Check, Trash2, RefreshCw, QrCode, Share2, X,
+  Loader2, AlertCircle, Clock, Users,
+} from 'lucide-react'
+
+// Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
+// proxy_set_header for all /api/ requests (see nginx.conf). All fetches
+// use relative URLs so the proxy adds the header before forwarding to
+// dashboard-api. No explicit auth in JS.
+
+const fetchJson = async (url, init = {}, ms = 8000) => {
+  const c = new AbortController()
+  const t = setTimeout(() => c.abort(), ms)
+  try {
+    return await fetch(url, { ...init, signal: c.signal })
+  } finally {
+    clearTimeout(t)
+  }
+}
+
+const SCOPES = [
+  { value: 'chat', label: 'Chat only', help: 'Recipient can use the chat surface.' },
+  { value: 'dashboard', label: 'Dashboard + chat', help: 'Recipient also sees the admin dashboard. Use sparingly.' },
+  { value: 'all', label: 'Full access', help: 'Everything. Treat like a co-admin invite.' },
+]
+
+const EXPIRY_PRESETS = [
+  { value: 900, label: '15 minutes' },
+  { value: 3600, label: '1 hour' },
+  { value: 86400, label: '24 hours' },
+]
+
+function formatRelative(iso) {
+  if (!iso) return null
+  const t = new Date(iso).getTime()
+  if (Number.isNaN(t)) return null
+  const diff = t - Date.now()
+  const abs = Math.abs(diff)
+  const minutes = Math.round(abs / 60_000)
+  const hours = Math.round(abs / 3_600_000)
+  const future = diff > 0
+  if (minutes < 1) return future ? 'in seconds' : 'just now'
+  if (minutes < 60) return future ? `in ${minutes}m` : `${minutes}m ago`
+  if (hours < 24) return future ? `in ${hours}h` : `${hours}h ago`
+  const days = Math.round(abs / 86_400_000)
+  return future ? `in ${days}d` : `${days}d ago`
+}
+
+function tokenStatus(token) {
+  if (token.revoked_at) return { label: 'revoked', tone: 'bg-theme-border text-theme-text-muted' }
+  if (new Date(token.expires_at).getTime() < Date.now()) {
+    return { label: 'expired', tone: 'bg-theme-border text-theme-text-muted' }
+  }
+  if (token.redemption_count > 0 && !token.reusable) {
+    return { label: 'used', tone: 'bg-theme-border text-theme-text-muted' }
+  }
+  if (token.redemption_count > 0) {
+    return { label: `reused × ${token.redemption_count}`, tone: 'bg-blue-500/20 text-blue-400' }
+  }
+  return { label: 'active', tone: 'bg-green-500/20 text-green-400' }
+}
+
+export default function Invites() {
+  const [tokens, setTokens] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [showCreate, setShowCreate] = useState(false)
+  const [generated, setGenerated] = useState(null)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      const resp = await fetchJson('/api/auth/magic-link/list')
+      if (!resp.ok) throw new Error(`list failed: ${resp.status}`)
+      const data = await resp.json()
+      setTokens(data.tokens || [])
+      setError(null)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  const handleRevoke = async (prefix) => {
+    try {
+      const resp = await fetchJson(`/api/auth/magic-link/${prefix}`, { method: 'DELETE' })
+      if (!resp.ok && resp.status !== 404) {
+        const body = await resp.json().catch(() => ({}))
+        throw new Error(body.detail || `revoke failed: ${resp.status}`)
+      }
+      await refresh()
+    } catch (err) {
+      setError(err.message)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="p-8">
+        <div className="animate-pulse">
+          <div className="h-8 bg-theme-card rounded w-1/3 mb-8" />
+          <div className="h-24 bg-theme-card rounded-xl mb-4" />
+          <div className="space-y-3">
+            {[...Array(3)].map((_, i) => <div key={i} className="h-20 bg-theme-card rounded-xl" />)}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-8">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-theme-text">Invites</h1>
+          <p className="text-theme-text-muted mt-1">
+            Share single-use magic links so other people can reach Dream Server without an account flow.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={refresh}
+            disabled={refreshing}
+            className="p-2 text-theme-text-muted hover:text-theme-text hover:bg-theme-surface-hover rounded-lg transition-colors disabled:opacity-50"
+            title="Refresh"
+            aria-label="Refresh invites"
+          >
+            <RefreshCw size={20} className={refreshing ? 'animate-spin' : ''} />
+          </button>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex items-center gap-2 bg-theme-accent text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity"
+          >
+            <UserPlus size={18} />
+            New invite
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm flex items-start gap-2">
+          <AlertCircle size={18} className="flex-shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {tokens.length === 0 ? (
+        <EmptyState onCreate={() => setShowCreate(true)} />
+      ) : (
+        <div className="space-y-3">
+          {tokens.map(t => (
+            <InviteRow key={t.token_hash_prefix} token={t} onRevoke={() => handleRevoke(t.token_hash_prefix)} />
+          ))}
+        </div>
+      )}
+
+      {showCreate && (
+        <CreateInviteModal
+          onClose={() => setShowCreate(false)}
+          onCreated={(record) => {
+            setShowCreate(false)
+            setGenerated(record)
+            refresh()
+          }}
+        />
+      )}
+
+      {generated && (
+        <GeneratedInviteModal
+          record={generated}
+          onClose={() => setGenerated(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function EmptyState({ onCreate }) {
+  return (
+    <div className="bg-theme-card border border-theme-border rounded-xl p-12 text-center">
+      <Users size={40} className="mx-auto mb-4 text-theme-text-muted" />
+      <h3 className="text-lg font-semibold text-theme-text mb-2">No invites yet</h3>
+      <p className="text-sm text-theme-text-muted mb-6 max-w-md mx-auto">
+        Generate a magic link to let someone reach the chat surface from their phone.
+        They scan a QR or tap a link — no account, no password, no app store.
+      </p>
+      <button
+        onClick={onCreate}
+        className="inline-flex items-center gap-2 bg-theme-accent text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity"
+      >
+        <UserPlus size={18} />
+        Create your first invite
+      </button>
+    </div>
+  )
+}
+
+function InviteRow({ token, onRevoke }) {
+  const status = tokenStatus(token)
+  const expires = formatRelative(token.expires_at)
+  const lastRedeemed = formatRelative(token.last_redeemed_at)
+  const isActive = status.label === 'active' || status.label.startsWith('reused')
+
+  return (
+    <div className="bg-theme-card border border-theme-border rounded-xl p-4 flex items-center justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <span className="font-medium text-theme-text">{token.target_username}</span>
+          <span className={`text-xs px-2 py-0.5 rounded ${status.tone}`}>{status.label}</span>
+          {token.reusable && (
+            <span className="text-xs px-2 py-0.5 rounded bg-purple-500/20 text-purple-300">reusable</span>
+          )}
+          <span className="text-xs text-theme-text-muted">scope: {token.scope}</span>
+        </div>
+        {token.note && (
+          <p className="text-xs text-theme-text-muted mb-1 truncate">{token.note}</p>
+        )}
+        <div className="flex items-center gap-3 text-xs text-theme-text-muted">
+          <span className="inline-flex items-center gap-1">
+            <Clock size={12} />
+            expires {expires}
+          </span>
+          {lastRedeemed && (
+            <span>last used {lastRedeemed}</span>
+          )}
+          <span className="font-mono opacity-70">{token.token_hash_prefix}…</span>
+        </div>
+      </div>
+      {isActive && (
+        <button
+          onClick={onRevoke}
+          className="p-2 text-theme-text-muted hover:text-red-400 hover:bg-red-500/10 rounded-lg transition-colors"
+          title="Revoke"
+          aria-label={`Revoke invite for ${token.target_username}`}
+        >
+          <Trash2 size={18} />
+        </button>
+      )}
+    </div>
+  )
+}
+
+function CreateInviteModal({ onClose, onCreated }) {
+  const [username, setUsername] = useState('')
+  const [scope, setScope] = useState('chat')
+  const [expiresIn, setExpiresIn] = useState(3600)
+  const [reusable, setReusable] = useState(false)
+  const [note, setNote] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [formError, setFormError] = useState(null)
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setFormError(null)
+    const trimmed = username.trim()
+    if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+      setFormError('Username may only contain letters, numbers, dot, dash, and underscore.')
+      return
+    }
+    setSubmitting(true)
+    try {
+      const resp = await fetchJson('/api/auth/magic-link/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_username: trimmed,
+          scope,
+          expires_in: expiresIn,
+          reusable,
+          note: note.trim() || null,
+        }),
+      })
+      if (!resp.ok) {
+        const body = await resp.json().catch(() => ({}))
+        const detail = Array.isArray(body.detail) ? body.detail[0]?.msg : body.detail
+        throw new Error(detail || `generate failed: ${resp.status}`)
+      }
+      const data = await resp.json()
+      onCreated(data)
+    } catch (err) {
+      setFormError(err.message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <form
+        onSubmit={handleSubmit}
+        className="bg-theme-card border border-theme-border rounded-xl p-6 w-full max-w-md"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Create invite"
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-theme-text">Create invite</h2>
+          <button type="button" onClick={onClose} className="text-theme-text-muted hover:text-theme-text" aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        <label className="block mb-3">
+          <span className="text-sm text-theme-text-muted">Username</span>
+          <input
+            type="text"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            required
+            autoFocus
+            placeholder="alice"
+            className="mt-1 w-full bg-theme-bg border border-theme-border rounded-lg px-3 py-2 text-theme-text focus:outline-none focus:border-theme-accent"
+            maxLength={64}
+          />
+          <span className="text-xs text-theme-text-muted">
+            Open WebUI will use this as the display name when the recipient lands on chat.
+          </span>
+        </label>
+
+        <label className="block mb-3">
+          <span className="text-sm text-theme-text-muted">Access scope</span>
+          <select
+            value={scope}
+            onChange={e => setScope(e.target.value)}
+            className="mt-1 w-full bg-theme-bg border border-theme-border rounded-lg px-3 py-2 text-theme-text focus:outline-none focus:border-theme-accent"
+          >
+            {SCOPES.map(s => (
+              <option key={s.value} value={s.value}>{s.label}</option>
+            ))}
+          </select>
+          <span className="text-xs text-theme-text-muted">
+            {SCOPES.find(s => s.value === scope)?.help}
+          </span>
+        </label>
+
+        <label className="block mb-3">
+          <span className="text-sm text-theme-text-muted">Expires in</span>
+          <select
+            value={expiresIn}
+            onChange={e => setExpiresIn(parseInt(e.target.value, 10))}
+            className="mt-1 w-full bg-theme-bg border border-theme-border rounded-lg px-3 py-2 text-theme-text focus:outline-none focus:border-theme-accent"
+          >
+            {EXPIRY_PRESETS.map(p => (
+              <option key={p.value} value={p.value}>{p.label}</option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex items-start gap-2 mb-3 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={reusable}
+            onChange={e => setReusable(e.target.checked)}
+            className="mt-1"
+          />
+          <span className="text-sm">
+            <span className="text-theme-text">Reusable</span>
+            <span className="block text-xs text-theme-text-muted">
+              Multiple people can redeem this link until it expires (e.g. a family share poster).
+              Each redemption is logged.
+            </span>
+          </span>
+        </label>
+
+        <label className="block mb-4">
+          <span className="text-sm text-theme-text-muted">Note (optional)</span>
+          <input
+            type="text"
+            value={note}
+            onChange={e => setNote(e.target.value)}
+            placeholder="for mom's iPad"
+            maxLength={200}
+            className="mt-1 w-full bg-theme-bg border border-theme-border rounded-lg px-3 py-2 text-theme-text focus:outline-none focus:border-theme-accent"
+          />
+        </label>
+
+        {formError && (
+          <div className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded-lg text-red-400 text-sm flex items-start gap-2">
+            <AlertCircle size={16} className="flex-shrink-0 mt-0.5" />
+            <span>{formError}</span>
+          </div>
+        )}
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-theme-text-muted hover:text-theme-text"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting || !username.trim()}
+            className="flex items-center gap-2 bg-theme-accent text-white px-4 py-2 rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
+          >
+            {submitting && <Loader2 size={16} className="animate-spin" />}
+            Generate
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function GeneratedInviteModal({ record, onClose }) {
+  const [copied, setCopied] = useState(false)
+  const [qrDataUrl, setQrDataUrl] = useState(null)
+  const [qrError, setQrError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const loadQr = async () => {
+      try {
+        const resp = await fetchJson(
+          `/api/auth/magic-link/qr?url=${encodeURIComponent(record.url)}`,
+        )
+        if (!resp.ok) {
+          // 503 means the qrcode python lib isn't installed — fall back gracefully.
+          setQrError('QR generation unavailable on the server.')
+          return
+        }
+        const data = await resp.json()
+        if (!cancelled) setQrDataUrl(data.data_url)
+      } catch (err) {
+        if (!cancelled) setQrError(err.message)
+      }
+    }
+    loadQr()
+    return () => { cancelled = true }
+  }, [record.url])
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(record.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback: select the input so the user can ctrl-c manually.
+    }
+  }
+
+  const share = async () => {
+    if (!navigator.share) {
+      copy()
+      return
+    }
+    try {
+      await navigator.share({
+        title: `Dream Server invite for ${record.target_username}`,
+        text: 'Tap to open Dream Server',
+        url: record.url,
+      })
+    } catch {
+      // User cancelled the share sheet — no-op.
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onClose}>
+      <div
+        className="bg-theme-card border border-theme-border rounded-xl p-6 w-full max-w-lg"
+        onClick={e => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Invite created"
+      >
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-semibold text-theme-text">Invite ready for {record.target_username}</h2>
+          <button onClick={onClose} className="text-theme-text-muted hover:text-theme-text" aria-label="Close">
+            <X size={20} />
+          </button>
+        </div>
+
+        <p className="text-sm text-theme-text-muted mb-4">
+          Share this link <strong className="text-theme-text">once</strong> — the recipient&apos;s first tap consumes it.
+          {record.reusable && ' This is a reusable invite; every redemption is logged.'}
+        </p>
+
+        {qrDataUrl ? (
+          <div className="bg-white p-4 rounded-xl flex justify-center mb-4">
+            <img src={qrDataUrl} alt="QR code for invite link" className="w-56 h-56" />
+          </div>
+        ) : (
+          <div className="bg-theme-bg border border-theme-border rounded-xl p-6 flex flex-col items-center justify-center mb-4 min-h-56">
+            <QrCode size={48} className="text-theme-text-muted mb-2" />
+            <p className="text-xs text-theme-text-muted text-center">
+              {qrError || 'Generating QR code…'}
+            </p>
+          </div>
+        )}
+
+        <label className="block mb-4">
+          <span className="text-xs text-theme-text-muted">Invite URL</span>
+          <div className="mt-1 flex gap-2">
+            <input
+              type="text"
+              readOnly
+              value={record.url}
+              onFocus={e => e.target.select()}
+              className="flex-1 bg-theme-bg border border-theme-border rounded-lg px-3 py-2 text-theme-text font-mono text-xs"
+            />
+            <button
+              onClick={copy}
+              className="flex items-center gap-1 px-3 py-2 bg-theme-bg border border-theme-border rounded-lg text-theme-text hover:bg-theme-surface-hover text-sm"
+              title="Copy link"
+            >
+              {copied ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}
+              {copied ? 'Copied' : 'Copy'}
+            </button>
+          </div>
+        </label>
+
+        <div className="flex justify-between items-center">
+          <p className="text-xs text-theme-text-muted">
+            Expires {formatRelative(record.expires_at)}
+          </p>
+          <div className="flex gap-2">
+            {typeof navigator !== 'undefined' && navigator.share && (
+              <button
+                onClick={share}
+                className="flex items-center gap-2 px-4 py-2 bg-theme-bg border border-theme-border rounded-lg text-theme-text hover:bg-theme-surface-hover text-sm"
+              >
+                <Share2 size={16} />
+                Share
+              </button>
+            )}
+            <button
+              onClick={onClose}
+              className="px-4 py-2 bg-theme-accent text-white rounded-lg hover:opacity-90 text-sm"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Invites.jsx
@@ -19,10 +19,10 @@ const fetchJson = async (url, init = {}, ms = 8000) => {
   }
 }
 
+// NOTE: only `chat` is wired through end-to-end right now. Wider scopes need
+// backend enforcement before they are safe to show as operator-facing choices.
 const SCOPES = [
-  { value: 'chat', label: 'Chat only', help: 'Recipient can use the chat surface.' },
-  { value: 'dashboard', label: 'Dashboard + chat', help: 'Recipient also sees the admin dashboard. Use sparingly.' },
-  { value: 'all', label: 'Full access', help: 'Everything. Treat like a co-admin invite.' },
+  { value: 'chat', label: 'Chat only', help: 'Recipient can reach the chat surface (Open WebUI). Other surfaces still require their own login.' },
 ]
 
 const EXPIRY_PRESETS = [
@@ -56,7 +56,7 @@ function tokenStatus(token) {
     return { label: 'used', tone: 'bg-theme-border text-theme-text-muted' }
   }
   if (token.redemption_count > 0) {
-    return { label: `reused × ${token.redemption_count}`, tone: 'bg-blue-500/20 text-blue-400' }
+    return { label: `reused x ${token.redemption_count}`, tone: 'bg-blue-500/20 text-blue-400' }
   }
   return { label: 'active', tone: 'bg-green-500/20 text-green-400' }
 }
@@ -120,7 +120,7 @@ export default function Invites() {
         <div>
           <h1 className="text-2xl font-bold text-theme-text">Invites</h1>
           <p className="text-theme-text-muted mt-1">
-            Share single-use magic links so other people can reach Dream Server without an account flow.
+            Share magic links so other people can get to the Dream Server chat surface quickly.
           </p>
         </div>
         <div className="flex items-center gap-2">
@@ -187,8 +187,9 @@ function EmptyState({ onCreate }) {
       <Users size={40} className="mx-auto mb-4 text-theme-text-muted" />
       <h3 className="text-lg font-semibold text-theme-text mb-2">No invites yet</h3>
       <p className="text-sm text-theme-text-muted mb-6 max-w-md mx-auto">
-        Generate a magic link to let someone reach the chat surface from their phone.
-        They scan a QR or tap a link — no account, no password, no app store.
+        Generate a magic link so someone can reach the chat surface from their phone.
+        The link itself is the credential; anyone who opens it gets in, so share it the
+        way you would share a password.
       </p>
       <button
         onClick={onCreate}
@@ -229,7 +230,7 @@ function InviteRow({ token, onRevoke }) {
           {lastRedeemed && (
             <span>last used {lastRedeemed}</span>
           )}
-          <span className="font-mono opacity-70">{token.token_hash_prefix}…</span>
+          <span className="font-mono opacity-70">{token.token_hash_prefix}...</span>
         </div>
       </div>
       {isActive && (
@@ -319,7 +320,8 @@ function CreateInviteModal({ onClose, onCreated }) {
             maxLength={64}
           />
           <span className="text-xs text-theme-text-muted">
-            Open WebUI will use this as the display name when the recipient lands on chat.
+            Recorded with the invite for the audit trail. Open WebUI may still ask the
+            recipient to sign in or pick a profile name on first arrival.
           </span>
         </label>
 
@@ -422,7 +424,7 @@ function GeneratedInviteModal({ record, onClose }) {
           `/api/auth/magic-link/qr?url=${encodeURIComponent(record.url)}`,
         )
         if (!resp.ok) {
-          // 503 means the qrcode python lib isn't installed — fall back gracefully.
+          // 503 means the qrcode python lib isn't installed; fall back gracefully.
           setQrError('QR generation unavailable on the server.')
           return
         }
@@ -458,9 +460,13 @@ function GeneratedInviteModal({ record, onClose }) {
         url: record.url,
       })
     } catch {
-      // User cancelled the share sheet — no-op.
+      // User cancelled the share sheet; no-op.
     }
   }
+
+  const inviteCopy = record.reusable
+    ? 'Share this reusable link with the intended group. Each redemption is logged. Open WebUI may still prompt for a sign-in until SSO is wired up.'
+    : 'Share this link once. The recipient\'s first tap consumes it and drops them at the chat surface. Open WebUI may still prompt for a sign-in until SSO is wired up.'
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onClose}>
@@ -478,10 +484,7 @@ function GeneratedInviteModal({ record, onClose }) {
           </button>
         </div>
 
-        <p className="text-sm text-theme-text-muted mb-4">
-          Share this link <strong className="text-theme-text">once</strong> — the recipient&apos;s first tap consumes it.
-          {record.reusable && ' This is a reusable invite; every redemption is logged.'}
-        </p>
+        <p className="text-sm text-theme-text-muted mb-4">{inviteCopy}</p>
 
         {qrDataUrl ? (
           <div className="bg-white p-4 rounded-xl flex justify-center mb-4">

--- a/dream-server/extensions/services/dashboard/src/pages/Invites.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Invites.test.jsx
@@ -1,0 +1,100 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import Invites from './Invites' // eslint-disable-line no-unused-vars
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+const future = new Date(Date.now() + 3_600_000).toISOString()
+
+describe('Invites', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('lists and revokes active invites', async () => {
+    let listCount = 0
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/list') {
+        listCount += 1
+        return response({
+          tokens: listCount === 1 ? [{
+            token_hash_prefix: 'abc12345',
+            target_username: 'alice',
+            scope: 'chat',
+            reusable: false,
+            created_at: new Date().toISOString(),
+            expires_at: future,
+            redemption_count: 0,
+            last_redeemed_at: null,
+            revoked_at: null,
+            note: 'family phone',
+          }] : [],
+        })
+      }
+      if (url === '/api/auth/magic-link/abc12345' && options.method === 'DELETE') {
+        return response({ revoked: true })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Invites />)
+
+    expect(await screen.findByText('alice')).toBeInTheDocument()
+    expect(screen.getByText('family phone')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /revoke invite for alice/i }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/auth/magic-link/abc12345',
+        expect.objectContaining({ method: 'DELETE' }),
+      )
+    })
+    expect(await screen.findByText('No invites yet')).toBeInTheDocument()
+  })
+
+  test('generates chat-scoped invite from the backend URL and loads QR', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/list') {
+        return response({ tokens: [] })
+      }
+      if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
+        return response({
+          token: 'plain-secret-token',
+          url: 'http://auth.dream.local/magic-link/plain-secret-token',
+          expires_at: future,
+          target_username: 'bob',
+          scope: 'chat',
+          reusable: false,
+        })
+      }
+      if (String(url).startsWith('/api/auth/magic-link/qr?url=')) {
+        return response({ data_url: 'data:image/png;base64,abc123' })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Invites />)
+
+    await screen.findByText('No invites yet')
+    fireEvent.click(screen.getByRole('button', { name: 'New invite' }))
+    fireEvent.change(screen.getByPlaceholderText('alice'), { target: { value: 'bob' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Generate' }))
+
+    await screen.findByRole('dialog', { name: 'Invite created' })
+    const generateCall = fetchMock.mock.calls.find(([url]) => url === '/api/auth/magic-link/generate')
+    expect(JSON.parse(generateCall[1].body)).toMatchObject({
+      target_username: 'bob',
+      scope: 'chat',
+      reusable: false,
+    })
+    expect(screen.getByDisplayValue('http://auth.dream.local/magic-link/plain-secret-token')).toBeInTheDocument()
+    expect(await screen.findByAltText('QR code for invite link')).toHaveAttribute('src', 'data:image/png;base64,abc123')
+  })
+})

--- a/dream-server/extensions/services/dashboard/src/plugins/core.js
+++ b/dream-server/extensions/services/dashboard/src/plugins/core.js
@@ -6,6 +6,7 @@ import {
   Activity,
   Box,
   Network,
+  UserPlus,
 } from 'lucide-react'
 
 const Dashboard = lazy(() => import('../pages/Dashboard'))
@@ -14,6 +15,7 @@ const Extensions = lazy(() => import('../pages/Extensions'))
 const GPUMonitor = lazy(() => import('../pages/GPUMonitor'))
 const Models = lazy(() => import('../pages/Models'))
 const ServiceMap = lazy(() => import('../pages/ServiceMap'))
+const Invites = lazy(() => import('../pages/Invites'))
 
 export const coreRoutes = [
   {
@@ -66,6 +68,16 @@ export const coreRoutes = [
     getProps: () => ({}),
     sidebar: true,
     order: 3,
+  },
+  {
+    id: 'invites',
+    path: '/invites',
+    label: 'Invites',
+    icon: UserPlus,
+    component: Invites,
+    getProps: () => ({}),
+    sidebar: true,
+    order: 4,
   },
   {
     id: 'settings',


### PR DESCRIPTION
# PR-5: Invite flow — dashboard UI for magic links

**Branch:** `feat/invite-flow` (local, not pushed)
**Phase:** 1 of 4 (Network UX)
**Effort:** Medium — 2 files (1 new, 1 modified), 557 insertions
**Depends on:** PR-4 (`feat/magic-link-auth`) — consumes the endpoints it exposes

## Summary

Surfaces the magic-link backend from PR-4 in the dashboard UI. The admin clicks **Invites** in the sidebar, hits **New invite**, fills three fields, and gets back a modal with a QR code + URL + share/copy/done.

This is the missing half of the phone-first onboarding loop. Today: admin SSHs into the box and curls a JSON payload. After this PR: admin opens the dashboard, fills the form, hands their phone to the recipient.

## Surface

| Element | Behaviour |
|---|---|
| **Sidebar entry** | `UserPlus` icon, label "Invites", route `/invites`, order 4 (between Models and Settings). |
| **List view** | One row per token. Shows target username, status pill (active / reused × N / used / expired / revoked / reusable), optional note, expiry countdown, hash prefix. Revoke button for active rows. |
| **Empty state** | `Users` icon + one-line pitch + "Create your first invite" CTA. Removes the "where do I start" friction. |
| **Create modal** | Username (validated `^[A-Za-z0-9._-]+$` client-side, matching the server's pattern), scope dropdown with inline help, expiry preset (15m / 1h / 24h), reusable checkbox, optional note. |
| **Generated modal** | Server-rendered QR (fetched from `GET /api/auth/magic-link/qr`), invite URL with click-to-copy, native `navigator.share()` button on browsers that support it (mobile Safari/Chrome), Done. |

## Files

| File | Change |
|---|---|
| `src/pages/Invites.jsx` (new, ~525 lines) | The whole page — list, create modal, generated modal, helpers. Self-contained; no new hooks or contexts. |
| `src/plugins/core.js` (+13 lines) | Lazy-import `Invites`, add the route entry (sidebar order 4). |

## Design choices

- **No new hook abstraction.** The page makes three `fetch` calls (`list`, `generate`, `revoke`, plus on-demand `qr`); wrapping that in a `useInvites()` hook would add code without paying for itself. If a second page ever needs the same data we extract then.
- **No client-side caching of generated tokens.** The plaintext token is sensitive — it never lives in localStorage or sessionStorage. The "Generated" modal holds it in component state only; closing the modal drops it. The admin re-shares via the URL displayed once; if they lose it they generate a new invite.
- **QR endpoint is fetched on demand, not pre-rendered.** The list view shows hash prefixes; rendering 30 QR codes preemptively wastes bytes. Generation is fast (~50ms server-side) and the modal shows a skeleton while it loads.
- **`navigator.share()` is feature-detected, not assumed.** Desktop Chrome doesn't ship the Web Share API; we render a Share button only when it's available. Falls back to Copy on desktop.
- **Status pill semantics match server pruning rules.** Server keeps revoked + redeemed records for audit; UI labels them clearly so the admin doesn't think a "used" token is still valid.

## What's NOT in this PR

- **Bulk operations** — no "revoke all expired" sweep. The server prunes expired-never-redeemed tokens automatically; the rest is intentional retention for audit.
- **Search / filter** — list is unfiltered. Comes if/when token volume justifies it.
- **Per-token detail view** — list rows show everything that matters (status, expiry, redemption count, note). No drilldown today.
- **Audit log surface** — the server records `at`, `ip`, `user_agent` per redemption. Surfacing that is a separate PR (privacy implications + UI design).
- **Tests** — the page is exercised via the existing build/lint pipeline, and the backend it talks to has 25 tests in PR-4. The component logic is thin enough that integration testing would be more useful than unit testing; deferring until the page stabilizes.

## Test plan

- [x] `npm run build` succeeds; `Invites-*.js` shows up as a lazy chunk (~14 KB / 4 KB gzipped)
- [x] `npm run lint` — zero new warnings, zero errors
- [ ] Smoke test on a running dashboard:
  - [ ] Sidebar shows Invites entry with UserPlus icon
  - [ ] Empty state renders when no tokens exist
  - [ ] Create modal validates username (rejects `bad name with spaces`)
  - [ ] Submitting opens Generated modal with QR + URL
  - [ ] Copy button copies the URL; Share button opens the native sheet (mobile)
  - [ ] Closing the modal returns to the list with the new row visible
  - [ ] Revoke button on an active row marks it revoked + greys the badge
  - [ ] Refresh button re-fetches without flicker

## Caveats

- **Plaintext token is shown exactly once.** The admin must copy/share before closing the Generated modal. This is deliberate (the token is the credential — if it shows up in a recovered closed-tab session we have a leak). The list view shows only the hash prefix.
- **QR generation requires the `qrcode` python lib on the backend.** PR-4 adds it to `requirements.txt`. If a deployment has stale dependencies, the QR panel shows a "QR generation unavailable" hint and Copy/Share still work.
- **Web Share API requires HTTPS.** On `http://dream.local` the Share button is hidden. Same constraint that gates the PWA install prompts; will be resolved by the Tailscale/cert PR in Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
