### PR TITLE
feat(dashboard): server-side first-boot gating

### DIFF
--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -4,6 +4,7 @@ import Sidebar from './components/Sidebar'
 import SetupWizard from './components/SetupWizard'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
+import { useFirstRun } from './hooks/useFirstRun'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
 
@@ -30,26 +31,24 @@ function App() {
   )
   const { status, loading, error } = useSystemStatus()
   const { version, dismissUpdate } = useVersion()
-  const [firstRun, setFirstRun] = useState(false)
+  // Server-side first-run flag (sourced from /api/setup/status). localStorage
+  // was per-browser and gave the wrong answer on re-imaged devices or fresh
+  // browsers. The hook returns firstRun=false while it's loading or if the
+  // API call fails, so the normal app shell is the safe default.
+  const { firstRun, refresh: refreshFirstRun } = useFirstRun()
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     return getStorageValue(globalThis.localStorage, 'dream-sidebar-collapsed') === 'true'
   })
 
   useEffect(() => {
-    const hasVisited = getStorageValue(globalThis.localStorage, 'dream-dashboard-visited')
-    if (!hasVisited) {
-      setFirstRun(true)
-    }
-  }, [])
-
-  useEffect(() => {
     setStorageValue(globalThis.localStorage, 'dream-sidebar-collapsed', String(sidebarCollapsed))
   }, [sidebarCollapsed])
 
-  const dismissFirstRun = () => {
-    setStorageValue(globalThis.localStorage, 'dream-dashboard-visited', 'true')
-    setFirstRun(false)
-  }
+  const dismissFirstRun = useCallback(() => {
+    // SetupWizard's saveConfig has already POSTed /api/setup/complete; we
+    // re-fetch the server flag so the next mount sees the new state.
+    refreshFirstRun()
+  }, [refreshFirstRun])
 
   const routes = useMemo(() => getInternalRoutes({ status, loading }), [status, loading])
   const handleToggle = useCallback(() => setSidebarCollapsed(c => !c), [])

--- a/dream-server/extensions/services/dashboard/src/App.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.test.jsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import { render } from './test/test-utils'
 import App from './App' // eslint-disable-line no-unused-vars
+import { useFirstRun } from './hooks/useFirstRun'
 
 vi.mock('./hooks/useSystemStatus', () => ({
   useSystemStatus: vi.fn(() => ({
@@ -17,6 +18,12 @@ vi.mock('./hooks/useVersion', () => ({
     error: null,
     dismissUpdate: vi.fn()
   }))
+}))
+
+// Server-side first-run gating — the hook drives whether SetupWizard mounts.
+// Tests below override the mock per case.
+vi.mock('./hooks/useFirstRun', () => ({
+  useFirstRun: vi.fn(() => ({ firstRun: false, loading: false, error: null, refresh: vi.fn() })),
 }))
 
 vi.mock('./plugins/registry', () => ({
@@ -46,9 +53,9 @@ describe('App', () => {
     vi.stubGlobal('fetch', vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     ))
-    globalThis.localStorage.removeItem('dream-dashboard-visited')
     globalThis.localStorage.removeItem('dream-sidebar-collapsed')
     globalThis.sessionStorage.removeItem('dream-splash-shown')
+    useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
   })
 
   afterEach(() => {
@@ -60,20 +67,19 @@ describe('App', () => {
     expect(document.querySelector('aside')).toBeInTheDocument()
   })
 
-  test('shows SetupWizard on first visit', () => {
-    // localStorage is clear, so firstRun should become true
+  test('shows SetupWizard when server reports first_run=true', () => {
+    useFirstRun.mockReturnValue({ firstRun: true, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
     expect(screen.getByTestId('setup-wizard')).toBeInTheDocument()
   })
 
-  test('hides SetupWizard when already visited', () => {
-    localStorage.setItem('dream-dashboard-visited', 'true')
+  test('hides SetupWizard when server reports first_run=false', () => {
+    useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
     expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
   })
 
   test('renders sidebar', () => {
-    localStorage.setItem('dream-dashboard-visited', 'true')
     render(<App />)
     expect(document.querySelector('aside')).toBeInTheDocument()
     expect(document.querySelector('main')).toBeInTheDocument()

--- a/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -146,9 +146,20 @@ export default function SetupWizard({ onComplete }) {
     }
   }
 
-  const saveConfig = () => {
+  const saveConfig = async () => {
+    // localStorage retains the wizard's *answers* (voice / userName etc.)
+    // for the dashboard to consult later, but is no longer the source of
+    // truth for "have we onboarded?" — that lives on the server now.
     localStorage.setItem('dream-config', JSON.stringify(config))
-    localStorage.setItem('dream-dashboard-visited', 'true')
+    try {
+      // The server endpoint writes setup-complete.json which the
+      // useFirstRun hook reads. Best-effort: if it fails (e.g. dashboard-api
+      // restarting mid-wizard) we still dismiss the wizard so the user
+      // isn't trapped, and rely on the next refresh to converge.
+      await fetch('/api/setup/complete', { method: 'POST' })
+    } catch (err) {
+      console.error('Failed to mark setup complete on server:', err)
+    }
     onComplete()
   }
 

--- a/dream-server/extensions/services/dashboard/src/hooks/useFirstRun.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useFirstRun.js
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback } from 'react'
+
+// Auth: nginx injects the Authorization header for /api/ requests
+// (see nginx.conf). The fetch below is a plain relative URL.
+//
+// Server-side authoritative first-run gating.
+//
+// Why a hook (vs. just localStorage): localStorage flags are per-browser.
+// A fresh device opened from a different phone, a re-imaged disk, or a
+// cleared browser cache would all re-trigger the wizard for that browser
+// while leaving an actually-onboarded device "unconfigured" from the new
+// browser's perspective. The truth lives in the dashboard-api's
+// `setup-complete.json` sentinel; this hook surfaces that truth to the UI.
+//
+// Failure mode: if the API call fails (network error, CORS, dashboard-api
+// not yet up), we default to "not first run". A false negative ("wizard
+// never shows; user reads docs") is far less disruptive than a false
+// positive ("wizard re-appears whenever the API blips and the user
+// can't reach the normal dashboard"). The wizard can always be
+// re-triggered via the deeper `/setup` route once that exists.
+
+export function useFirstRun() {
+  const [firstRun, setFirstRun] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const resp = await fetch('/api/setup/status')
+      if (!resp.ok) throw new Error(`setup-status returned ${resp.status}`)
+      const data = await resp.json()
+      setFirstRun(!!data.first_run)
+      setError(null)
+    } catch (err) {
+      // See the failure-mode comment above. We mark loading=false so the
+      // UI proceeds normally; the wizard is hidden until the next refresh.
+      setFirstRun(false)
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { firstRun, loading, error, refresh }
+}


### PR DESCRIPTION
# PR-6: Server-side first-boot gating

**Branch:** `feat/first-boot-sentinel` (local, not pushed)
**Phase:** 2 of 4 (First-boot wizard)
**Effort:** Small — 4 files (1 new, 3 modified), 84 insertions / 20 deletions
**Depends on:** none (the dashboard-api already exposes `/api/setup/status`)

## Summary

Fixes the wrong gate on the first-boot wizard. Today the dashboard reads `localStorage.getItem('dream-dashboard-visited')` to decide whether to show the wizard — a flag that's per-browser. A re-imaged device, a different phone, or a cleared cache all re-trigger the wizard for that browser while an actually-onboarded device still looks unconfigured to a fresh visitor.

After this PR, "is this device onboarded?" is a server-side answer sourced from the existing `setup-complete.json` sentinel via `/api/setup/status`. Every browser sees the same truth.

This is the prerequisite for PR-7 (first-boot wizard SPA), which adds the standalone `/setup` route and locks down other routes until completion. PR-6 ships the smaller, focused gate change first so the SPA change is reviewable on its own.

## Files

| File | Change |
|---|---|
| `src/hooks/useFirstRun.js` (new, 45 lines) | Fetches `/api/setup/status`, returns `{firstRun, loading, error, refresh}`. Defaults `firstRun=false` on API failure (wizard re-appearing on every network blip is worse than occasionally not appearing). |
| `src/App.jsx` | Uses `useFirstRun()` instead of `localStorage`. `dismissFirstRun` re-fetches rather than flipping a local boolean. |
| `src/components/SetupWizard.jsx` | `saveConfig` now POSTs `/api/setup/complete` before calling `onComplete`. localStorage retains wizard *answers* (voice, userName) for in-app consumption but no longer gates the wizard. |
| `src/App.test.jsx` | Mocks `useFirstRun` directly rather than driving the wizard through localStorage. |

## Behaviour matrix

| Scenario | Before this PR | After this PR |
|---|---|---|
| Fresh device, first open from phone A | Wizard shows | Wizard shows |
| Same device, open from phone B after A completed wizard | **Wizard shows again (wrong)** | Wizard hidden ✓ |
| Same device, phone A clears browser cache | **Wizard shows again (wrong)** | Wizard hidden ✓ |
| Re-imaged device (data wiped), open from phone A | Wizard hidden if `dream-dashboard-visited` is still set | Wizard shows ✓ |
| dashboard-api unreachable | Wizard never shows (localStorage default) | Wizard never shows (safe default) |
| dashboard-api returns `first_run: true` | n/a (no API used) | Wizard shows ✓ |

## What's NOT in this PR

- **`/setup` standalone route + route-restriction.** The plan called for "all routes redirect to `/setup` until sentinel writes." That's PR-7 (wizard SPA) — bigger change, deserves its own review. Today the wizard remains an overlay modal on the dashboard, just driven by the server flag.
- **Phone-optimized wizard layout.** Existing SetupWizard.jsx is already 6 steps with PreFlight + TemplatePicker; rewriting for phone-first is also PR-7.
- **A wizard-progress server endpoint.** The progress step is still in `setup-progress.json` on the server — useful but not required for gating. Untouched by this PR.

## Test plan

- [x] `npm run build` succeeds
- [x] `npm run lint` clean (zero new warnings)
- [x] `npx vitest run` — 12/12 files, 62/62 tests pass including 4 in App.test.jsx
- [ ] Manual smoke on running dashboard:
  - [ ] Fresh install (`setup-complete.json` absent) → wizard appears on first load
  - [ ] Complete wizard → POST hits server → reload → wizard does NOT reappear
  - [ ] Clear browser cache → reload → wizard still does NOT appear (server is the gate)
  - [ ] Delete `setup-complete.json` on the server → reload → wizard reappears
  - [ ] Stop dashboard-api → reload → app renders normally without wizard (safe fallback)

## Caveats

- **Failure mode is "hide the wizard"**, not "show it". Rationale in the hook's source: an admin who hits a working app and then types `/setup` to re-trigger the wizard is fine; an admin who can't reach the app because the wizard re-appears every time the API blips is a regression. PR-7 adds the deeper `/setup` route for explicit re-entry.
- **localStorage is no longer cleared on wizard completion**, but its key (`dream-dashboard-visited`) is also no longer read. Stale keys will remain in browsers that previously visited; harmless. A cleanup pass on the storage layout could happen but feels over-engineered for this PR.
- **No new admin endpoints.** This PR consumes only the existing `/api/setup/status` and `/api/setup/complete` — both already auth-gated by the standard `verify_api_key` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
