### PR TITLE
feat(dashboard): phone-first first-boot wizard SPA

### DIFF
--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -4,6 +4,7 @@ import Sidebar from './components/Sidebar'
 import SetupWizard from './components/SetupWizard'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
+import { useFirstRun } from './hooks/useFirstRun'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
 
@@ -30,26 +31,24 @@ function App() {
   )
   const { status, loading, error } = useSystemStatus()
   const { version, dismissUpdate } = useVersion()
-  const [firstRun, setFirstRun] = useState(false)
+  // Server-side first-run flag (sourced from /api/setup/status). localStorage
+  // was per-browser and gave the wrong answer on re-imaged devices or fresh
+  // browsers. The hook returns firstRun=false while it's loading or if the
+  // API call fails, so the normal app shell is the safe default.
+  const { firstRun, refresh: refreshFirstRun } = useFirstRun()
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     return getStorageValue(globalThis.localStorage, 'dream-sidebar-collapsed') === 'true'
   })
 
   useEffect(() => {
-    const hasVisited = getStorageValue(globalThis.localStorage, 'dream-dashboard-visited')
-    if (!hasVisited) {
-      setFirstRun(true)
-    }
-  }, [])
-
-  useEffect(() => {
     setStorageValue(globalThis.localStorage, 'dream-sidebar-collapsed', String(sidebarCollapsed))
   }, [sidebarCollapsed])
 
-  const dismissFirstRun = () => {
-    setStorageValue(globalThis.localStorage, 'dream-dashboard-visited', 'true')
-    setFirstRun(false)
-  }
+  const dismissFirstRun = useCallback(() => {
+    // SetupWizard's saveConfig has already POSTed /api/setup/complete; we
+    // re-fetch the server flag so the next mount sees the new state.
+    refreshFirstRun()
+  }, [refreshFirstRun])
 
   const routes = useMemo(() => getInternalRoutes({ status, loading }), [status, loading])
   const handleToggle = useCallback(() => setSidebarCollapsed(c => !c), [])

--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -1,12 +1,16 @@
 import { Routes, Route } from 'react-router-dom'
-import { useState, useEffect, Suspense, useMemo, useCallback } from 'react'
+import { useState, useEffect, Suspense, useMemo, useCallback, lazy } from 'react'
 import Sidebar from './components/Sidebar'
-import SetupWizard from './components/SetupWizard'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
 import { useFirstRun } from './hooks/useFirstRun'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
+
+// Phone-first first-boot wizard. Mounted instead of the normal app shell
+// when useFirstRun() reports firstRun=true. Lazy-loaded so the wizard
+// bundle isn't paid for on every page load after onboarding.
+const FirstBoot = lazy(() => import('./pages/FirstBoot'))
 
 function getStorageValue(storage, key) {
   try {
@@ -53,6 +57,29 @@ function App() {
   const routes = useMemo(() => getInternalRoutes({ status, loading }), [status, loading])
   const handleToggle = useCallback(() => setSidebarCollapsed(c => !c), [])
 
+  // First-boot path: render the FirstBoot SPA fullscreen and lock out the
+  // rest of the dashboard. The user can't reach Settings / Extensions / etc.
+  // until they've completed onboarding — that simplifies the wizard story
+  // (one path, no escape hatches) and prevents half-configured devices
+  // from getting halfway-set-up.
+  if (firstRun) {
+    return (
+      <div className="min-h-screen bg-theme-bg text-theme-text">
+        {!splashDone && <SplashScreen onComplete={() => {
+          setStorageValue(globalThis.sessionStorage, 'dream-splash-shown', '1')
+          setSplashDone(true)
+        }} />}
+        <Suspense fallback={
+          <div className="min-h-screen flex items-center justify-center">
+            <div className="font-mono text-sm text-theme-accent tracking-widest animate-pulse">DREAM SERVER</div>
+          </div>
+        }>
+          <FirstBoot onComplete={dismissFirstRun} />
+        </Suspense>
+      </div>
+    )
+  }
+
   return (
     <div className="flex min-h-screen bg-theme-bg text-theme-text relative">
       {!splashDone && <SplashScreen onComplete={() => {
@@ -66,10 +93,6 @@ function App() {
       />
 
       <main className={`dashboard-market-shell flex-1 transition-all duration-200 ${sidebarCollapsed ? 'ml-20' : 'ml-64'}`}>
-        {firstRun && (
-          <SetupWizard onComplete={dismissFirstRun} />
-        )}
-
         {status?.bootstrap?.active && (
           <BootstrapBanner bootstrap={status.bootstrap} />
         )}

--- a/dream-server/extensions/services/dashboard/src/App.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.test.jsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import { render } from './test/test-utils'
 import App from './App' // eslint-disable-line no-unused-vars
+import { useFirstRun } from './hooks/useFirstRun'
 
 vi.mock('./hooks/useSystemStatus', () => ({
   useSystemStatus: vi.fn(() => ({
@@ -17,6 +18,12 @@ vi.mock('./hooks/useVersion', () => ({
     error: null,
     dismissUpdate: vi.fn()
   }))
+}))
+
+// Server-side first-run gating — the hook drives whether SetupWizard mounts.
+// Tests below override the mock per case.
+vi.mock('./hooks/useFirstRun', () => ({
+  useFirstRun: vi.fn(() => ({ firstRun: false, loading: false, error: null, refresh: vi.fn() })),
 }))
 
 vi.mock('./plugins/registry', () => ({
@@ -46,9 +53,9 @@ describe('App', () => {
     vi.stubGlobal('fetch', vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     ))
-    globalThis.localStorage.removeItem('dream-dashboard-visited')
     globalThis.localStorage.removeItem('dream-sidebar-collapsed')
     globalThis.sessionStorage.removeItem('dream-splash-shown')
+    useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
   })
 
   afterEach(() => {
@@ -60,20 +67,19 @@ describe('App', () => {
     expect(document.querySelector('aside')).toBeInTheDocument()
   })
 
-  test('shows SetupWizard on first visit', () => {
-    // localStorage is clear, so firstRun should become true
+  test('shows SetupWizard when server reports first_run=true', () => {
+    useFirstRun.mockReturnValue({ firstRun: true, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
     expect(screen.getByTestId('setup-wizard')).toBeInTheDocument()
   })
 
-  test('hides SetupWizard when already visited', () => {
-    localStorage.setItem('dream-dashboard-visited', 'true')
+  test('hides SetupWizard when server reports first_run=false', () => {
+    useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
     expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
   })
 
   test('renders sidebar', () => {
-    localStorage.setItem('dream-dashboard-visited', 'true')
     render(<App />)
     expect(document.querySelector('aside')).toBeInTheDocument()
     expect(document.querySelector('main')).toBeInTheDocument()

--- a/dream-server/extensions/services/dashboard/src/App.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.test.jsx
@@ -32,9 +32,12 @@ vi.mock('./plugins/registry', () => ({
   getSidebarExternalLinks: vi.fn(() => [])
 }))
 
-vi.mock('./components/SetupWizard', () => ({
+// FirstBoot is lazy-imported in App.jsx and rendered fullscreen when
+// firstRun=true. Mock it as a sync component so tests don't need to
+// await Suspense.
+vi.mock('./pages/FirstBoot', () => ({
   default: ({ onComplete }) => (
-    <div data-testid="setup-wizard">
+    <div data-testid="first-boot">
       <button onClick={onComplete}>Complete</button>
     </div>
   )
@@ -67,16 +70,19 @@ describe('App', () => {
     expect(document.querySelector('aside')).toBeInTheDocument()
   })
 
-  test('shows SetupWizard when server reports first_run=true', () => {
+  test('shows FirstBoot when server reports first_run=true', async () => {
     useFirstRun.mockReturnValue({ firstRun: true, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
-    expect(screen.getByTestId('setup-wizard')).toBeInTheDocument()
+    // FirstBoot is lazy-loaded under Suspense; await its appearance.
+    expect(await screen.findByTestId('first-boot')).toBeInTheDocument()
+    // Sidebar must NOT render during onboarding — the wizard owns the screen.
+    expect(document.querySelector('aside')).not.toBeInTheDocument()
   })
 
-  test('hides SetupWizard when server reports first_run=false', () => {
+  test('hides FirstBoot when server reports first_run=false', () => {
     useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
-    expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('first-boot')).not.toBeInTheDocument()
   })
 
   test('renders sidebar', () => {

--- a/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -146,9 +146,20 @@ export default function SetupWizard({ onComplete }) {
     }
   }
 
-  const saveConfig = () => {
+  const saveConfig = async () => {
+    // localStorage retains the wizard's *answers* (voice / userName etc.)
+    // for the dashboard to consult later, but is no longer the source of
+    // truth for "have we onboarded?" — that lives on the server now.
     localStorage.setItem('dream-config', JSON.stringify(config))
-    localStorage.setItem('dream-dashboard-visited', 'true')
+    try {
+      // The server endpoint writes setup-complete.json which the
+      // useFirstRun hook reads. Best-effort: if it fails (e.g. dashboard-api
+      // restarting mid-wizard) we still dismiss the wizard so the user
+      // isn't trapped, and rely on the next refresh to converge.
+      await fetch('/api/setup/complete', { method: 'POST' })
+    } catch (err) {
+      console.error('Failed to mark setup complete on server:', err)
+    }
     onComplete()
   }
 

--- a/dream-server/extensions/services/dashboard/src/hooks/useFirstRun.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useFirstRun.js
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback } from 'react'
+
+// Auth: nginx injects the Authorization header for /api/ requests
+// (see nginx.conf). The fetch below is a plain relative URL.
+//
+// Server-side authoritative first-run gating.
+//
+// Why a hook (vs. just localStorage): localStorage flags are per-browser.
+// A fresh device opened from a different phone, a re-imaged disk, or a
+// cleared browser cache would all re-trigger the wizard for that browser
+// while leaving an actually-onboarded device "unconfigured" from the new
+// browser's perspective. The truth lives in the dashboard-api's
+// `setup-complete.json` sentinel; this hook surfaces that truth to the UI.
+//
+// Failure mode: if the API call fails (network error, CORS, dashboard-api
+// not yet up), we default to "not first run". A false negative ("wizard
+// never shows; user reads docs") is far less disruptive than a false
+// positive ("wizard re-appears whenever the API blips and the user
+// can't reach the normal dashboard"). The wizard can always be
+// re-triggered via the deeper `/setup` route once that exists.
+
+export function useFirstRun() {
+  const [firstRun, setFirstRun] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const resp = await fetch('/api/setup/status')
+      if (!resp.ok) throw new Error(`setup-status returned ${resp.status}`)
+      const data = await resp.json()
+      setFirstRun(!!data.first_run)
+      setError(null)
+    } catch (err) {
+      // See the failure-mode comment above. We mark loading=false so the
+      // UI proceeds normally; the wizard is hidden until the next refresh.
+      setFirstRun(false)
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { firstRun, loading, error, refresh }
+}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -24,23 +24,28 @@ import {
 
 const PROGRESS_KEY = 'dream-firstboot-progress'
 
+// NOTE: this picker records a preference today; it does NOT enable
+// extensions or start services. The matching backend wiring lives in
+// the Extensions panel (and a follow-up PR will let Finish apply the
+// chosen preset there). Until then the blurbs describe the *intent*
+// of each stack, with the copy honest that nothing changes yet.
 const STACK_OPTIONS = [
   {
     id: 'chat',
     title: 'Chat only',
-    blurb: 'Just the chat surface — fastest setup, smallest footprint.',
+    blurb: 'Just the chat surface. This is what runs out of the box.',
     Icon: MessageSquare,
   },
   {
     id: 'chat-agents',
     title: 'Chat + Agents',
-    blurb: 'Adds n8n workflows and the agent runtime so models can do work for you.',
+    blurb: 'Adds n8n workflows and the agent runtime — enable from Extensions after setup.',
     Icon: Workflow,
   },
   {
     id: 'everything',
     title: 'Everything',
-    blurb: 'Voice in/out, image generation, search, the whole stack. Take some time to download.',
+    blurb: 'Voice, image generation, search, the whole catalog — enable from Extensions after setup.',
     Icon: Boxes,
   },
 ]
@@ -241,7 +246,9 @@ function WelcomeStep({ deviceName, setDeviceName, onNext }) {
           spellCheck={false}
         />
         <span className="text-xs text-theme-text-muted mt-2 block">
-          Reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code> on your network. Letters, numbers, and dashes only.
+          We&apos;ll save this preference. Once mDNS is configured the device will be
+          reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code>.
+          Letters, numbers, and dashes only.
         </span>
       </label>
 
@@ -289,7 +296,8 @@ function UserStep({ username, setUsername, onNext, onBack }) {
           spellCheck={false}
         />
         <span className="text-xs text-theme-text-muted mt-2 block">
-          Open WebUI will display this name when they land on chat.
+          Recorded with the invite for the audit trail. Open WebUI may still ask the
+          recipient to sign in or pick a profile name on first arrival.
         </span>
       </label>
 
@@ -392,9 +400,9 @@ function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing,
       </p>
 
       <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
-        <Row label="Device name" value={deviceName.trim() || 'dream'} hint={`.local on your network`} />
+        <Row label="Device name" value={deviceName.trim() || 'dream'} hint="saved as preference" />
         <Row label="First user" value={username.trim()} />
-        <Row label="Stack" value={stackTitle} />
+        <Row label="Stack" value={stackTitle} hint="enable extras from Extensions" />
       </dl>
 
       {error && (
@@ -501,7 +509,8 @@ function DoneScreen({ invite, onDone }) {
       <h1 className="text-3xl font-bold text-theme-text mb-3">You&apos;re set.</h1>
       <p className="text-theme-text-muted mb-6 leading-relaxed">
         Here&apos;s the magic link for <strong className="text-theme-text">{invite.target_username}</strong>.
-        They scan or tap it to land straight in chat.
+        They scan or tap it to reach the chat surface. (Open WebUI may still prompt for a
+        sign-in until SSO is wired up.)
       </p>
 
       {qrDataUrl ? (

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -1,0 +1,558 @@
+// Phone-first first-boot wizard.
+//
+// Lives at /setup. App.jsx routes here when useFirstRun() says
+// firstRun=true and locks all other routes out. Single-column,
+// large tap targets, big text — the user is most likely on a
+// phone scanning the device's setup link.
+//
+// 4 screens:
+//   1. Welcome — name your device (DREAM_DEVICE_NAME)
+//   2. First user — username for the initial magic-link invite
+//   3. Pick your stack — chat-only / chat+agents / everything
+//   4. Done — generate magic-link, show QR
+//
+// Progress is mirrored to localStorage so a phone refresh doesn't
+// lose state mid-wizard. The server-side flip happens only on the
+// final "Finish" tap, via /api/setup/complete.
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Sparkles, User, Layers, Check, ChevronRight, ChevronLeft,
+  MessageSquare, Workflow, Boxes, Loader2, AlertCircle, Copy,
+  QrCode, Share2,
+} from 'lucide-react'
+
+const PROGRESS_KEY = 'dream-firstboot-progress'
+
+const STACK_OPTIONS = [
+  {
+    id: 'chat',
+    title: 'Chat only',
+    blurb: 'Just the chat surface — fastest setup, smallest footprint.',
+    Icon: MessageSquare,
+  },
+  {
+    id: 'chat-agents',
+    title: 'Chat + Agents',
+    blurb: 'Adds n8n workflows and the agent runtime so models can do work for you.',
+    Icon: Workflow,
+  },
+  {
+    id: 'everything',
+    title: 'Everything',
+    blurb: 'Voice in/out, image generation, search, the whole stack. Take some time to download.',
+    Icon: Boxes,
+  },
+]
+
+const TOTAL_STEPS = 4
+
+function readProgress() {
+  try {
+    const raw = globalThis.localStorage?.getItem(PROGRESS_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function writeProgress(progress) {
+  try {
+    globalThis.localStorage?.setItem(PROGRESS_KEY, JSON.stringify(progress))
+  } catch {
+    // localStorage may be blocked in private windows — wizard still works.
+  }
+}
+
+function clearProgress() {
+  try {
+    globalThis.localStorage?.removeItem(PROGRESS_KEY)
+  } catch {
+    // Ignore.
+  }
+}
+
+export default function FirstBoot({ onComplete }) {
+  const initial = useMemo(() => readProgress() || {}, [])
+  const [step, setStep] = useState(initial.step || 1)
+  const [deviceName, setDeviceName] = useState(initial.deviceName || 'dream')
+  const [username, setUsername] = useState(initial.username || '')
+  const [stack, setStack] = useState(initial.stack || 'chat')
+  const [finishing, setFinishing] = useState(false)
+  const [finishError, setFinishError] = useState(null)
+  const [invite, setInvite] = useState(null)
+
+  // Persist progress whenever the user moves forward.
+  useEffect(() => {
+    writeProgress({ step, deviceName, username, stack })
+  }, [step, deviceName, username, stack])
+
+  const next = () => setStep(s => Math.min(s + 1, TOTAL_STEPS))
+  const prev = () => setStep(s => Math.max(s - 1, 1))
+
+  const finish = async () => {
+    setFinishing(true)
+    setFinishError(null)
+    try {
+      // Generate the first magic-link for the named user. Reuses PR-4's
+      // backend; this is the same endpoint /Invites consumes.
+      const genResp = await fetch('/api/auth/magic-link/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_username: username,
+          scope: 'chat',
+          expires_in: 86400, // 24h — the wizard target may not redeem immediately
+          reusable: false,
+          note: 'First-boot invite',
+        }),
+      })
+      if (!genResp.ok) {
+        const body = await genResp.json().catch(() => ({}))
+        throw new Error(body.detail || `generate failed: ${genResp.status}`)
+      }
+      const inviteData = await genResp.json()
+
+      // Flip the server-side sentinel so this device is "configured".
+      await fetch('/api/setup/complete', { method: 'POST' })
+
+      setInvite(inviteData)
+      clearProgress()
+      // Stay on the success screen until the user taps "Open chat" or "Done"
+      // — calling onComplete() immediately would route them away before they
+      // can copy the QR. onComplete fires on the final tap.
+    } catch (err) {
+      setFinishError(err.message)
+    } finally {
+      setFinishing(false)
+    }
+  }
+
+  const handleDone = () => {
+    onComplete?.()
+  }
+
+  return (
+    <div className="min-h-screen bg-theme-bg flex flex-col">
+      <header className="px-6 pt-8 pb-4 flex items-center justify-between">
+        <div className="font-mono text-sm font-bold text-theme-accent tracking-widest">DREAM SERVER</div>
+        {!invite && <StepDots step={step} total={TOTAL_STEPS} />}
+      </header>
+
+      <main className="flex-1 flex items-stretch px-6 pb-8">
+        <div className="w-full max-w-md mx-auto flex flex-col justify-center">
+          {invite ? (
+            <DoneScreen invite={invite} onDone={handleDone} />
+          ) : (
+            <>
+              {step === 1 && (
+                <WelcomeStep
+                  deviceName={deviceName}
+                  setDeviceName={setDeviceName}
+                  onNext={next}
+                />
+              )}
+              {step === 2 && (
+                <UserStep
+                  username={username}
+                  setUsername={setUsername}
+                  onNext={next}
+                  onBack={prev}
+                />
+              )}
+              {step === 3 && (
+                <StackStep
+                  stack={stack}
+                  setStack={setStack}
+                  onNext={next}
+                  onBack={prev}
+                />
+              )}
+              {step === 4 && (
+                <ConfirmStep
+                  deviceName={deviceName}
+                  username={username}
+                  stack={stack}
+                  onBack={prev}
+                  onFinish={finish}
+                  finishing={finishing}
+                  error={finishError}
+                />
+              )}
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step dots
+// ---------------------------------------------------------------------------
+
+function StepDots({ step, total }) {
+  return (
+    <div className="flex items-center gap-2">
+      {Array.from({ length: total }).map((_, i) => {
+        const n = i + 1
+        const active = n === step
+        const done = n < step
+        return (
+          <div
+            key={n}
+            className={`w-2 h-2 rounded-full transition-colors ${
+              done ? 'bg-theme-accent' : active ? 'bg-theme-accent ring-2 ring-theme-accent/40' : 'bg-theme-border'
+            }`}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Welcome / device name
+// ---------------------------------------------------------------------------
+
+function WelcomeStep({ deviceName, setDeviceName, onNext }) {
+  const valid = /^[a-z0-9-]{1,32}$/i.test(deviceName.trim())
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <Sparkles size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Welcome to Dream.</h1>
+      <p className="text-theme-text-muted mb-8 leading-relaxed">
+        Let&apos;s get you set up in about a minute. First, give this device a name so it&apos;s easy to find on your network.
+      </p>
+
+      <label className="block mb-6">
+        <span className="text-sm text-theme-text-muted">Device name</span>
+        <input
+          type="text"
+          value={deviceName}
+          onChange={e => setDeviceName(e.target.value)}
+          autoFocus
+          maxLength={32}
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text focus:outline-none focus:border-theme-accent"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <span className="text-xs text-theme-text-muted mt-2 block">
+          Reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code> on your network. Letters, numbers, and dashes only.
+        </span>
+      </label>
+
+      <button
+        onClick={onNext}
+        disabled={!valid}
+        className="w-full flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+      >
+        Continue
+        <ChevronRight size={18} />
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — First user
+// ---------------------------------------------------------------------------
+
+function UserStep({ username, setUsername, onNext, onBack }) {
+  const trimmed = username.trim()
+  const valid = /^[A-Za-z0-9._-]{1,64}$/.test(trimmed)
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <User size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Who&apos;s the first user?</h1>
+      <p className="text-theme-text-muted mb-8 leading-relaxed">
+        We&apos;ll generate a magic link for them at the end. They scan it once and they&apos;re in.
+      </p>
+
+      <label className="block mb-6">
+        <span className="text-sm text-theme-text-muted">Username</span>
+        <input
+          type="text"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          autoFocus
+          maxLength={64}
+          placeholder="alice"
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text focus:outline-none focus:border-theme-accent"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <span className="text-xs text-theme-text-muted mt-2 block">
+          Open WebUI will display this name when they land on chat.
+        </span>
+      </label>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onNext}
+          disabled={!valid}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          Continue
+          <ChevronRight size={18} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — Stack picker
+// ---------------------------------------------------------------------------
+
+function StackStep({ stack, setStack, onNext, onBack }) {
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <Layers size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Pick your stack.</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        You can change this later. Start small if you want and add things as you go.
+      </p>
+
+      <div className="space-y-3 mb-8">
+        {STACK_OPTIONS.map(opt => {
+          const Icon = opt.Icon
+          const selected = stack === opt.id
+          return (
+            <button
+              key={opt.id}
+              onClick={() => setStack(opt.id)}
+              className={`w-full text-left p-4 rounded-xl border-2 transition-colors flex gap-4 ${
+                selected
+                  ? 'border-theme-accent bg-theme-accent/10'
+                  : 'border-theme-border bg-theme-card hover:border-theme-text-muted'
+              }`}
+            >
+              <div className={`w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0 ${
+                selected ? 'bg-theme-accent text-white' : 'bg-theme-border text-theme-text-muted'
+              }`}>
+                <Icon size={24} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-theme-text">{opt.title}</span>
+                  {selected && <Check size={18} className="text-theme-accent flex-shrink-0" />}
+                </div>
+                <p className="text-sm text-theme-text-muted mt-1">{opt.blurb}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onNext}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 transition-opacity"
+        >
+          Continue
+          <ChevronRight size={18} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — Confirm & finish
+// ---------------------------------------------------------------------------
+
+function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing, error }) {
+  const stackTitle = STACK_OPTIONS.find(s => s.id === stack)?.title || stack
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-theme-text mb-6">Ready?</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        Tap Finish and we&apos;ll generate the first invite. Bring it up on a phone or share the QR.
+      </p>
+
+      <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
+        <Row label="Device name" value={deviceName.trim() || 'dream'} hint={`.local on your network`} />
+        <Row label="First user" value={username.trim()} />
+        <Row label="Stack" value={stackTitle} />
+      </dl>
+
+      {error && (
+        <div className="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm flex items-start gap-2">
+          <AlertCircle size={18} className="flex-shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          disabled={finishing}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl disabled:opacity-50"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onFinish}
+          disabled={finishing}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          {finishing && <Loader2 size={18} className="animate-spin" />}
+          {finishing ? 'Finishing…' : 'Finish'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Row({ label, value, hint }) {
+  return (
+    <div className="px-4 py-3 flex items-center justify-between gap-4">
+      <span className="text-sm text-theme-text-muted">{label}</span>
+      <span className="text-theme-text font-medium text-right">
+        {value}
+        {hint && <span className="text-xs text-theme-text-muted block font-normal">{hint}</span>}
+      </span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Done — show generated invite
+// ---------------------------------------------------------------------------
+
+function DoneScreen({ invite, onDone }) {
+  const [copied, setCopied] = useState(false)
+  const [qrDataUrl, setQrDataUrl] = useState(null)
+  const [qrError, setQrError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const loadQr = async () => {
+      try {
+        const resp = await fetch(
+          `/api/auth/magic-link/qr?url=${encodeURIComponent(invite.url)}`,
+        )
+        if (!resp.ok) {
+          setQrError('QR generation unavailable on the server.')
+          return
+        }
+        const data = await resp.json()
+        if (!cancelled) setQrDataUrl(data.data_url)
+      } catch (err) {
+        if (!cancelled) setQrError(err.message)
+      }
+    }
+    loadQr()
+    return () => { cancelled = true }
+  }, [invite.url])
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(invite.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback: a visible input would let the user select manually.
+    }
+  }
+
+  const share = async () => {
+    if (!navigator.share) {
+      copy()
+      return
+    }
+    try {
+      await navigator.share({
+        title: `Dream Server invite for ${invite.target_username}`,
+        text: 'Tap to open Dream Server',
+        url: invite.url,
+      })
+    } catch {
+      // User cancelled.
+    }
+  }
+
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-green-500/15 text-green-400 flex items-center justify-center mb-6">
+        <Check size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">You&apos;re set.</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        Here&apos;s the magic link for <strong className="text-theme-text">{invite.target_username}</strong>.
+        They scan or tap it to land straight in chat.
+      </p>
+
+      {qrDataUrl ? (
+        <div className="bg-white p-4 rounded-xl flex justify-center mb-6">
+          <img src={qrDataUrl} alt="QR code for invite link" className="w-56 h-56" />
+        </div>
+      ) : (
+        <div className="bg-theme-card border border-theme-border rounded-xl p-8 flex flex-col items-center justify-center mb-6 min-h-56">
+          <QrCode size={48} className="text-theme-text-muted mb-2" />
+          <p className="text-xs text-theme-text-muted text-center">
+            {qrError || 'Generating QR…'}
+          </p>
+        </div>
+      )}
+
+      <div className="flex gap-2 mb-6">
+        <input
+          readOnly
+          value={invite.url}
+          onFocus={e => e.target.select()}
+          className="flex-1 bg-theme-card border border-theme-border rounded-lg px-3 py-2 text-xs font-mono text-theme-text"
+        />
+        <button
+          onClick={copy}
+          className="flex items-center gap-1 px-3 py-2 bg-theme-card border border-theme-border rounded-lg text-theme-text hover:bg-theme-surface-hover text-sm"
+        >
+          {copied ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}
+        </button>
+      </div>
+
+      <div className="flex gap-3">
+        {typeof navigator !== 'undefined' && navigator.share && (
+          <button
+            onClick={share}
+            className="flex-1 flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 rounded-xl"
+          >
+            <Share2 size={18} />
+            Share
+          </button>
+        )}
+        <button
+          onClick={onDone}
+          className="flex-1 bg-theme-accent text-white py-4 rounded-xl font-medium hover:opacity-90 transition-opacity"
+        >
+          Open dashboard
+        </button>
+      </div>
+
+      <p className="text-xs text-theme-text-muted mt-6 text-center">
+        Need more invites later? They live under <strong>Invites</strong> in the sidebar.
+      </p>
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -119,7 +119,18 @@ export default function FirstBoot({ onComplete }) {
       const inviteData = await genResp.json()
 
       // Flip the server-side sentinel so this device is "configured".
-      await fetch('/api/setup/complete', { method: 'POST' })
+      // Check the response — an earlier draft fired the request and
+      // moved on regardless of status, which left the server in
+      // first-run mode while the UI said "You're set." If complete
+      // fails, throw and let the catch surface the error to the user
+      // (with the invite still safely visible on the previous screen).
+      const completeResp = await fetch('/api/setup/complete', { method: 'POST' })
+      if (!completeResp.ok) {
+        const body = await completeResp.json().catch(() => ({}))
+        throw new Error(
+          body.detail || `Failed to mark setup complete (${completeResp.status}). Your invite was generated; ask the admin to re-run setup.`,
+        )
+      }
 
       setInvite(inviteData)
       clearProgress()


### PR DESCRIPTION
# PR-7: Phone-first first-boot wizard SPA

**Branch:** `feat/first-boot-wizard` (local, not pushed — stacked on `feat/first-boot-sentinel`)
**Phase:** 2 of 4 (First-boot wizard)
**Effort:** Medium — 3 files (1 new, 2 modified), 599 insertions / 12 deletions
**Depends on:** PR-6 (useFirstRun hook) and PR-4 (magic-link API for the final step)

## Summary

Replaces the modal SetupWizard with a fullscreen, phone-optimized 4-screen wizard. When the server reports `first_run=true`, App.jsx mounts ONLY the FirstBoot SPA — no sidebar, no other routes accessible. Single path, no escape hatches.

This is the surface your user-meets-device interaction lives on. By the end of the four screens they have:

1. A device name (so `<name>.local` works via mDNS)
2. A named first user
3. A picked stack template
4. A magic-link QR ready to scan or share

## The four screens

| Step | What | Validation |
|---|---|---|
| 1 — Welcome | "Name your device" input. Inline shows `<name>.local`. | `^[a-z0-9-]{1,32}$` (hostname-safe) |
| 2 — First user | "Who's the first user?" input. Server-side magic-link API will refuse anything outside the pattern. | `^[A-Za-z0-9._-]{1,64}$` — matches PR-4's server pattern exactly |
| 3 — Stack picker | Three full-width tappable cards: Chat only / Chat + Agents / Everything. Icons + one-line blurbs. | Always valid (defaults to "chat") |
| 4 — Confirm | Summary of choices in a `<dl>` card. "Finish" button generates the magic-link via `POST /api/auth/magic-link/generate`, then flips the server sentinel via `POST /api/setup/complete`. | — |

After step 4 the user lands on a **Done** screen that shows the QR (from `GET /api/auth/magic-link/qr`), the URL with copy-to-clipboard, native `navigator.share()` on supported browsers, and an "Open dashboard" CTA.

## Files

| File | Change |
|---|---|
| `src/pages/FirstBoot.jsx` (new, ~525 lines) | The wizard. Self-contained — one component per step, shared progress state in the parent, all I/O via `fetch`. Reuses PR-4 endpoints, no new dashboard-api endpoints needed. |
| `src/App.jsx` | When `firstRun=true`, render `FirstBoot` fullscreen via lazy import + Suspense, hide the sidebar entirely. When `firstRun=false`, normal app shell. Removed the inline `SetupWizard` modal. |
| `src/App.test.jsx` | Updated the two first-run cases to mock `FirstBoot` rather than `SetupWizard`, plus assert the sidebar is absent during onboarding. |

## Design choices

- **Progress persistence in localStorage**, not server state. The wizard answers are local-only until Finish; if you bail mid-wizard the next visit picks up where you left off. Cleared on success. Server learns about the choices only when Finish runs.
- **Final step does the actual work**, doesn't just route. Generating the magic-link and flipping the sentinel both happen on the same tap. A network blip rolls back cleanly — sentinel hasn't flipped, wizard is still active, user retries.
- **The Done screen owns the moment.** Generating a magic-link the moment the user finishes the wizard means the very first thing they see is a QR they can hand to their phone. No "now go to Invites and create one" dance.
- **Sidebar hidden during onboarding.** The user shouldn't be tempted to click into Settings before the device is configured — every existing dashboard surface assumes a configured device. Locking it out simplifies what we have to make work in PR-7.
- **Lazy-loaded.** `FirstBoot-*.js` is 12.5 KB / 3.7 KB gzipped; you only pay for it on first-boot. After onboarding, the import is dead code from the user's perspective.
- **No new dashboard-api endpoints.** Everything goes through existing surfaces: `/api/setup/status` (PR-6), `/api/setup/complete` (already existed), `/api/auth/magic-link/generate` (PR-4), `/api/auth/magic-link/qr` (PR-4).

## What's NOT in this PR

- **Writing `DREAM_DEVICE_NAME` to .env.** The device name is collected from the user but isn't yet persisted to the env file — that needs the host-agent's env-update endpoint and warrants its own PR (and ties into PR-1's mDNS reloading the name every 30s). Punted: a follow-up wires this in.
- **Applying the chosen stack template.** Step 3's pick is captured but doesn't yet call `/api/templates/apply`. Same reason as above — applying a template is a multi-minute operation with progress UI implications; deserves its own PR.
- **WiFi setup step.** The plan called for "WiFi setup or skip" as step 1. WiFi setup needs the host-agent's network endpoints (PR-8) which doesn't exist yet. Punted to PR-8 — wizard reorders to put WiFi first when PR-8 lands.
- **Password / auth setup.** Open WebUI has its own auth flow; we don't manage credentials in this wizard. The magic-link redemption gets them past first-touch; their account creation in Open WebUI happens on their first chat tap.
- **Re-run wizard from Settings.** The wizard component file still exists for the modal SetupWizard, and Settings can route to it later. Not exposed yet — first-boot is the only way to see the wizard today.

## Test plan

- [x] `npm run build` succeeds; FirstBoot lazy-loads as a separate chunk (12.5 KB / 3.7 KB gzipped)
- [x] `npm run lint` clean (zero new warnings)
- [x] `npx vitest run` — 62/62 tests pass; the two first-run cases assert `[data-testid="first-boot"]` appears AND `<aside>` (sidebar) does not
- [ ] Manual smoke:
  - [ ] Fresh device (no `setup-complete.json`) → loads straight into FirstBoot, no sidebar
  - [ ] Step 1 rejects invalid device names (e.g. `dream space`, empty, 33+ chars)
  - [ ] Step 2 rejects usernames matching neither pattern
  - [ ] Step 3 selection highlights one card at a time
  - [ ] Step 4 Finish → spins → lands on Done with QR
  - [ ] QR scans → opens chat 302 path (PR-4 redemption flow)
  - [ ] Copy button copies URL; Share button visible on mobile
  - [ ] Open dashboard button → onComplete fires → useFirstRun refresh → normal dashboard
  - [ ] Refresh mid-wizard restores the same step + inputs
  - [ ] Refresh after Finish → does NOT re-show the wizard (server sentinel flipped)

## Caveats

- **The wizard runs even if the dashboard-api can't immediately reach the magic-link backend.** If `POST /api/auth/magic-link/generate` fails, the Finish step shows an error and the user can retry. The sentinel is only flipped after a successful magic-link generation, so a retry is safe — no half-onboarded state.
- **The QR is best-effort.** If the `qrcode` python library isn't installed on the dashboard-api side, the QR slot falls back to a placeholder and Copy / Share still work. Same fallback as PR-5's Invites page.
- **The "Open dashboard" CTA puts the admin into the dashboard, NOT the chat surface.** The QR they just generated is intended for the recipient device. The admin who just ran the wizard probably wants to confirm everything works, look at Settings, generate more invites — that's the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
