### PR TITLE
feat(scripts): printable setup-card PNG generator

### DIFF
--- a/dream-server/docs/SETUP-CARD.md
+++ b/dream-server/docs/SETUP-CARD.md
@@ -1,0 +1,84 @@
+# Setup card generator
+
+`scripts/generate-setup-card.py` produces a printable 4×6 PNG for fulfillment: drop one in the box with each Dream Server unit so the recipient can scan two QR codes and reach the wizard without typing anything.
+
+## What it generates
+
+A portrait card with:
+
+1. **Top band** — "DREAM SERVER" wordmark, the unit's mDNS name (e.g. `dream.local`), and a one-line "Scan to set up. Scan to chat." tagline.
+2. **Two QR codes side by side:**
+   - **Left — JOIN WI-FI.** Encodes the standard `WIFI:T:WPA;S:<ssid>;P:<password>;;` format that iOS Camera and Android (Chrome / system QR scanner) auto-recognize. Phone joins the AP with one tap.
+   - **Right — OPEN SETUP.** Plain URL QR. The user's browser opens straight to the first-boot wizard at e.g. `http://192.168.7.1/setup`.
+3. **Plain-text fallback block** — SSID, password, URL printed verbatim for phones that won't scan the QR (older models, scratched cards, scanner permission denied).
+4. **Footer** — "DreamServer is open-source — light-heart-labs.com", plus an optional per-unit serial number for fulfillment tracking.
+
+Card is 1200×1800 px at 300 DPI = exactly 4×6 inches. Print on photo cardstock and laminate, or just print on plain paper for prototypes.
+
+## Requirements
+
+`pip install 'qrcode[pil]'` — that's it. `qrcode[pil]` pulls in Pillow as a transitive dep. Both are already in `extensions/services/dashboard-api/requirements.txt`, so if you've installed the dashboard-api you're done.
+
+## Usage
+
+```bash
+python3 scripts/generate-setup-card.py \
+  --ssid 'Dream-Setup-A4F2' \
+  --password 'xxxxxxxx' \
+  --setup-url 'http://192.168.7.1/setup' \
+  --device-name 'dream-a4f2.local' \
+  --serial 'DRM-2026-A4F2' \
+  --output cards/card-A4F2.png
+```
+
+Flags:
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--ssid` | yes | Wi-Fi SSID of the device's setup AP |
+| `--password` | no | Wi-Fi password. Omit for open networks. |
+| `--security` | no | `WPA` (default), `WEP`, or `nopass` |
+| `--setup-url` | yes | URL the QR opens (e.g. `http://192.168.7.1/setup`) |
+| `--device-name` | no | mDNS hostname printed on the card. Defaults to `dream.local`. |
+| `--serial` | no | Optional serial / batch ID printed in the footer right corner |
+| `--output` / `-o` | yes | Output PNG path. Parent directory is created if missing. |
+
+Exit codes: `0` on success, `2` if Pillow / qrcode isn't installed. Argparse handles bad flags.
+
+## Batch generation
+
+Looping the script over a list of pre-baked AP credentials is the recommended fulfillment flow:
+
+```bash
+while IFS=',' read -r ssid password serial; do
+  python3 scripts/generate-setup-card.py \
+    --ssid "$ssid" \
+    --password "$password" \
+    --setup-url "http://192.168.7.1/setup" \
+    --device-name "dream-${serial,,}.local" \
+    --serial "$serial" \
+    --output "cards/$serial.png"
+done < unit-credentials.csv
+```
+
+(`unit-credentials.csv` line format: `Dream-Setup-A4F2,xxxxxxxx,DRM-2026-A4F2`)
+
+## Design choices
+
+- **PNG, not PDF.** Printers handle PNG fine, batch generation is one library call, and the operator can convert with any tool if they really want PDF. Adding `reportlab` for a one-line save would double the dependency footprint.
+- **Pillow for layout, not SVG templates.** A pre-baked template is more flexible visually but harder to maintain (font fallback, variable text wrapping). The Python composition fits the layout to the content rather than the other way around.
+- **Best-effort font loading.** The script tries Consolas / DejaVu / Helvetica based on OS, falls back to Pillow's bitmap font if nothing matches. The card always renders — only the typography varies.
+- **No on-device generation.** This is an operator-side script. The device doesn't know its own AP credentials (those are baked in during the image-build step) and shouldn't be able to print its own credentials anyway.
+
+## Security notes
+
+- The plaintext password is on the card by design — it's what makes the first-touch flow work. Treat the card as a physical credential. If a unit is sold / resold, the new owner should re-generate the AP credentials and discard the card.
+- The setup URL doesn't carry the credential. It points at the device's setup-mode IP; if the recipient hasn't joined the AP yet, the URL just times out.
+- Serial / batch identifiers are optional and intended for fulfillment, not authentication. Don't encode anything sensitive in them.
+
+## Limitations / future work
+
+- **No splash logo.** The wordmark is set in the system bold font. Dropping in `dream-logo.svg` (when it exists) is a small change.
+- **No multi-language.** Text is English-only. Localizing the QR captions ("JOIN WI-FI" / "OPEN SETUP") would mean accepting `--locale` or per-locale templates.
+- **No PDF output.** Add `--format pdf` later if a fulfillment pipeline needs it; Pillow can save as PDF with `card.save(path, format="PDF")`.
+- **No Hidden SSID flag.** Standard Wi-Fi QR supports `H:true;`. Today the script hardcodes `H:false`; trivial to expose if a unit's AP is hidden.

--- a/dream-server/docs/SETUP-CARD.md
+++ b/dream-server/docs/SETUP-CARD.md
@@ -36,7 +36,7 @@ Flags:
 | Flag | Required | Notes |
 |---|---|---|
 | `--ssid` | yes | Wi-Fi SSID of the device's setup AP |
-| `--password` | no | Wi-Fi password. Omit for open networks. |
+| `--password` | no | Wi-Fi password. Omit for open networks; the Wi-Fi QR will use `T:nopass` automatically. |
 | `--security` | no | `WPA` (default), `WEP`, or `nopass` |
 | `--setup-url` | yes | URL the QR opens (e.g. `http://192.168.7.1/setup`) |
 | `--device-name` | no | mDNS hostname printed on the card. Defaults to `dream.local`. |
@@ -55,7 +55,7 @@ while IFS=',' read -r ssid password serial; do
     --ssid "$ssid" \
     --password "$password" \
     --setup-url "http://192.168.7.1/setup" \
-    --device-name "dream-${serial,,}.local" \
+    --device-name "dream-$(printf '%s' "$serial" | tr '[:upper:]' '[:lower:]').local" \
     --serial "$serial" \
     --output "cards/$serial.png"
 done < unit-credentials.csv

--- a/dream-server/docs/SETUP-CARD.md
+++ b/dream-server/docs/SETUP-CARD.md
@@ -17,7 +17,7 @@ Card is 1200×1800 px at 300 DPI = exactly 4×6 inches. Print on photo cardstock
 
 ## Requirements
 
-`pip install 'qrcode[pil]'` — that's it. `qrcode[pil]` pulls in Pillow as a transitive dep. Both are already in `extensions/services/dashboard-api/requirements.txt`, so if you've installed the dashboard-api you're done.
+`pip install 'qrcode[pil]'` — that's it. `qrcode[pil]` pulls in Pillow as a transitive dep. This is an operator-side tool, not a runtime service, so the deps aren't bundled with any Dream Server container; install them into whatever Python environment you run the script from. (If you've also installed the magic-link auth router from [#1155](https://github.com/Light-Heart-Labs/DreamServer/pull/1155), `qrcode[pil]` is in that service's `requirements.txt` already and you can reuse the same virtualenv — but the setup-card script does not depend on dashboard-api at runtime.)
 
 ## Usage
 

--- a/dream-server/scripts/generate-setup-card.py
+++ b/dream-server/scripts/generate-setup-card.py
@@ -27,8 +27,7 @@ Usage:
         --serial 'DRM-2026-A4F2'      \\
         --output card-A4F2.png
 
-Requires: Pillow + qrcode (both pip-installable, both already in the
-dashboard-api requirements). Imports lazily so `--help` works without them.
+Requires: Pillow + qrcode. Imports lazily so `--help` works without them.
 """
 
 from __future__ import annotations
@@ -65,8 +64,9 @@ def build_wifi_qr_payload(ssid: str, password: str, security: str = "WPA") -> st
              .replace('"', '\\"')
         )
 
-    payload = f"WIFI:T:{security};S:{esc(ssid)};"
-    if password:
+    effective_security = "nopass" if not password else security
+    payload = f"WIFI:T:{effective_security};S:{esc(ssid)};"
+    if effective_security != "nopass" and password:
         payload += f"P:{esc(password)};"
     payload += "H:false;;"
     return payload
@@ -84,7 +84,10 @@ def render_qr(text: str, target_px: int):
         version=None,
         error_correction=ERROR_CORRECT_M,
         box_size=10,
-        border=1,
+        # Keep the spec-recommended four-module quiet zone. The QR sits on a
+        # dark card background, so this white margin is the only separator a
+        # scanner sees at the code edge.
+        border=4,
     )
     qr.add_data(text)
     qr.make(fit=True)
@@ -224,7 +227,7 @@ def _fit_font_to_width(draw, text: str, max_width: int, base_size: int = 36,
                        min_size: int = 18, monospace: bool = False):
     """Return the largest font (at or below ``base_size``) whose ``text``
     measures ``<= max_width`` pixels. Floors at ``min_size`` even if the
-    text is still wider, on the principle that an unreadable readable
+    text is still wider, on the principle that a readable
     fallback is more useful than a value clipped to the next-line.
 
     Needed for the password row — WPA2 supports up to 63 characters, and
@@ -312,6 +315,10 @@ def main(argv: list[str] | None = None) -> int:
     except ImportError as exc:
         print(f"error: missing dependency: {exc.name}. "
               "Install with: pip install 'qrcode[pil]'", file=sys.stderr)
+        return 2
+
+    if args.security == "nopass" and args.password:
+        print("error: --security nopass cannot be combined with --password", file=sys.stderr)
         return 2
 
     card = render_card(

--- a/dream-server/scripts/generate-setup-card.py
+++ b/dream-server/scripts/generate-setup-card.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""
+generate-setup-card.py — produce a printable setup card PNG for a Dream Server unit.
+
+Use this when shipping a unit: pre-configure its setup-mode Wi-Fi AP (a unique
+SSID + password per device), feed those creds plus the setup URL into this
+script, get back a 4×6 portrait card you can print + laminate + drop in the box.
+
+The card carries:
+  * Top: "DREAM SERVER" wordmark + the device's mDNS name (e.g. "dream.local")
+  * Two big QR codes:
+      - Left:  Wi-Fi join QR (Android + iOS recognize the WIFI:T:...;S:...;P:...;; format)
+      - Right: setup URL — opens straight to the first-boot wizard
+  * Plain-text fallback at the bottom (SSID / password / URL) for the
+    inevitable phone that won't auto-detect the QR
+  * Optional serial / batch line for fulfillment tracking
+
+This is a tooling artifact, not a runtime feature. It only needs to run on
+the operator's machine (or the fulfillment pipeline), not on the device itself.
+
+Usage:
+    python3 generate-setup-card.py \\
+        --ssid 'Dream-Setup-A4F2'    \\
+        --password 'xxxxxxxx'         \\
+        --setup-url 'http://192.168.7.1/setup' \\
+        --device-name 'dream.local'   \\
+        --serial 'DRM-2026-A4F2'      \\
+        --output card-A4F2.png
+
+Requires: Pillow + qrcode (both pip-installable, both already in the
+dashboard-api requirements). Imports lazily so `--help` works without them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Card geometry — 4×6 inches @ 300 DPI = 1200×1800px portrait.
+CARD_W = 1200
+CARD_H = 1800
+MARGIN = 80
+
+# Brand-ish palette. Matches the dashboard's dark theme but printable.
+COLOR_BG = (15, 15, 19)          # near-black, but not pure black (prints better)
+COLOR_FG = (228, 228, 231)        # near-white
+COLOR_ACCENT = (167, 139, 250)    # purple, matches --theme-accent
+COLOR_MUTED = (140, 140, 150)
+
+
+def build_wifi_qr_payload(ssid: str, password: str, security: str = "WPA") -> str:
+    """Return the standard Wi-Fi join URI Android/iOS will recognize.
+
+    Format: WIFI:T:<security>;S:<ssid>;P:<password>;H:false;;
+
+    Special characters in SSID/password must be escaped (\\:, \\;, \\\\, \\").
+    """
+    def esc(s: str) -> str:
+        return (
+            s.replace("\\", "\\\\")
+             .replace(";", "\\;")
+             .replace(",", "\\,")
+             .replace(":", "\\:")
+             .replace('"', '\\"')
+        )
+
+    payload = f"WIFI:T:{security};S:{esc(ssid)};"
+    if password:
+        payload += f"P:{esc(password)};"
+    payload += "H:false;;"
+    return payload
+
+
+def render_qr(text: str, target_px: int):
+    """Return a Pillow Image of the QR sized to ~target_px x target_px."""
+    import qrcode  # noqa: PLC0415 — lazy import keeps --help fast
+    from qrcode.constants import ERROR_CORRECT_M
+
+    # ERROR_CORRECT_M handles ~15% damage which is fine for a printed card.
+    # box_size is the pixel size of each "module" (QR cell); we scale up.
+    qr = qrcode.QRCode(
+        version=None,
+        error_correction=ERROR_CORRECT_M,
+        box_size=10,
+        border=1,
+    )
+    qr.add_data(text)
+    qr.make(fit=True)
+    img = qr.make_image(fill_color="black", back_color="white").convert("RGB")
+    # qrcode picks the cell size; final image dimensions vary by data length.
+    # We rescale to the target so the card layout is predictable.
+    return img.resize((target_px, target_px))
+
+
+def render_card(
+    ssid: str,
+    password: str,
+    setup_url: str,
+    device_name: str,
+    security: str = "WPA",
+    serial: str | None = None,
+):
+    """Compose the full card image. Returns a Pillow Image."""
+    from PIL import Image, ImageDraw, ImageFont  # noqa: PLC0415
+
+    card = Image.new("RGB", (CARD_W, CARD_H), COLOR_BG)
+    draw = ImageDraw.Draw(card)
+
+    title_font = _load_font(size=80, bold=True)
+    heading_font = _load_font(size=42, bold=True)
+    body_font = _load_font(size=32)
+    mono_font = _load_font(size=36, monospace=True)
+    small_font = _load_font(size=24)
+
+    # --- Header band ---
+    draw.text(
+        (MARGIN, MARGIN),
+        "DREAM SERVER",
+        font=title_font,
+        fill=COLOR_ACCENT,
+    )
+    draw.text(
+        (MARGIN, MARGIN + 100),
+        device_name,
+        font=heading_font,
+        fill=COLOR_FG,
+    )
+    draw.text(
+        (MARGIN, MARGIN + 160),
+        "Scan to set up. Scan to chat.",
+        font=body_font,
+        fill=COLOR_MUTED,
+    )
+
+    # --- QR pair ---
+    qr_size = (CARD_W - MARGIN * 3) // 2  # two QRs + margin between
+    qr_y = 400
+    wifi_qr = render_qr(build_wifi_qr_payload(ssid, password, security), qr_size)
+    url_qr = render_qr(setup_url, qr_size)
+    card.paste(wifi_qr, (MARGIN, qr_y))
+    card.paste(url_qr, (MARGIN * 2 + qr_size, qr_y))
+
+    # QR captions
+    draw.text(
+        (MARGIN, qr_y + qr_size + 20),
+        "1. JOIN WI-FI",
+        font=heading_font,
+        fill=COLOR_ACCENT,
+    )
+    draw.text(
+        (MARGIN * 2 + qr_size, qr_y + qr_size + 20),
+        "2. OPEN SETUP",
+        font=heading_font,
+        fill=COLOR_ACCENT,
+    )
+
+    # --- Plain-text fallback block ---
+    fallback_y = qr_y + qr_size + 130
+    draw.text(
+        (MARGIN, fallback_y),
+        "if a QR won't scan:",
+        font=small_font,
+        fill=COLOR_MUTED,
+    )
+
+    rows = [
+        ("network", ssid),
+        ("password", password if password else "(open)"),
+        ("then visit", setup_url),
+    ]
+    row_y = fallback_y + 50
+    for label, value in rows:
+        draw.text((MARGIN, row_y), label.upper(), font=small_font, fill=COLOR_MUTED)
+        draw.text(
+            (MARGIN + 240, row_y - 6),
+            value,
+            font=mono_font,
+            fill=COLOR_FG,
+        )
+        row_y += 70
+
+    # --- Footer / serial ---
+    footer_y = CARD_H - MARGIN - 30
+    draw.text(
+        (MARGIN, footer_y),
+        "DreamServer is open-source — light-heart-labs.com",
+        font=small_font,
+        fill=COLOR_MUTED,
+    )
+    if serial:
+        bbox = draw.textbbox((0, 0), serial, font=small_font)
+        text_w = bbox[2] - bbox[0]
+        draw.text(
+            (CARD_W - MARGIN - text_w, footer_y),
+            serial,
+            font=small_font,
+            fill=COLOR_MUTED,
+        )
+
+    return card
+
+
+def _load_font(size: int, bold: bool = False, monospace: bool = False):
+    """Best-effort font loader. Falls back to Pillow's default bitmap font
+    if no truetype font is available — the card still renders, just less
+    pretty. The card is meant to be printed, so we look for common system
+    fonts first.
+    """
+    from PIL import ImageFont  # noqa: PLC0415
+
+    candidates: list[str] = []
+    if monospace:
+        candidates += [
+            "C:\\Windows\\Fonts\\consola.ttf",   # Windows Consolas
+            "/usr/share/fonts/truetype/dejavu/DejaVuSansMono-Bold.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSansMono.ttf",
+            "/System/Library/Fonts/Menlo.ttc",
+        ]
+    elif bold:
+        candidates += [
+            "C:\\Windows\\Fonts\\arialbd.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+            "/System/Library/Fonts/Helvetica.ttc",
+        ]
+    else:
+        candidates += [
+            "C:\\Windows\\Fonts\\arial.ttf",
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/System/Library/Fonts/Helvetica.ttc",
+        ]
+
+    for path in candidates:
+        if Path(path).exists():
+            try:
+                return ImageFont.truetype(path, size=size)
+            except OSError:
+                continue
+    return ImageFont.load_default()
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a printable setup card PNG for a Dream Server unit.",
+    )
+    parser.add_argument("--ssid", required=True, help="Wi-Fi SSID of the device's setup AP")
+    parser.add_argument("--password", default="", help="Wi-Fi password (empty for open network)")
+    parser.add_argument("--security", default="WPA", choices=["WPA", "WEP", "nopass"],
+                        help="Wi-Fi security type (default WPA)")
+    parser.add_argument("--setup-url", required=True,
+                        help="URL to open after joining the AP (e.g. http://192.168.7.1/setup)")
+    parser.add_argument("--device-name", default="dream.local",
+                        help="The mDNS name printed on the card (default dream.local)")
+    parser.add_argument("--serial", default=None,
+                        help="Optional serial / batch identifier printed in the footer")
+    parser.add_argument("--output", "-o", required=True,
+                        help="Output PNG path")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    try:
+        import PIL  # noqa: F401, PLC0415
+        import qrcode  # noqa: F401, PLC0415
+    except ImportError as exc:
+        print(f"error: missing dependency: {exc.name}. "
+              "Install with: pip install 'qrcode[pil]'", file=sys.stderr)
+        return 2
+
+    card = render_card(
+        ssid=args.ssid,
+        password=args.password,
+        setup_url=args.setup_url,
+        device_name=args.device_name,
+        security=args.security,
+        serial=args.serial,
+    )
+
+    out_path = Path(args.output)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    card.save(out_path, format="PNG", dpi=(300, 300))
+    print(f"wrote {out_path} ({CARD_W}×{CARD_H} @ 300 DPI = 4×6 inches)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dream-server/scripts/generate-setup-card.py
+++ b/dream-server/scripts/generate-setup-card.py
@@ -75,6 +75,7 @@ def build_wifi_qr_payload(ssid: str, password: str, security: str = "WPA") -> st
 def render_qr(text: str, target_px: int):
     """Return a Pillow Image of the QR sized to ~target_px x target_px."""
     import qrcode  # noqa: PLC0415 — lazy import keeps --help fast
+    from PIL import Image  # noqa: PLC0415
     from qrcode.constants import ERROR_CORRECT_M
 
     # ERROR_CORRECT_M handles ~15% damage which is fine for a printed card.
@@ -90,7 +91,14 @@ def render_qr(text: str, target_px: int):
     img = qr.make_image(fill_color="black", back_color="white").convert("RGB")
     # qrcode picks the cell size; final image dimensions vary by data length.
     # We rescale to the target so the card layout is predictable.
-    return img.resize((target_px, target_px))
+    #
+    # NEAREST is critical: the default resampling (BICUBIC) antialiases the
+    # cell edges, which turns the pure black/white QR into ~190 grayscale
+    # colors. That still scans in many cases, but printed cards must be
+    # crisp — a phone camera in suboptimal lighting can fail on the
+    # antialiased version. NEAREST keeps every pixel pure black or pure
+    # white, matching the source modules exactly.
+    return img.resize((target_px, target_px), resample=Image.Resampling.NEAREST)
 
 
 def render_card(
@@ -102,7 +110,7 @@ def render_card(
     serial: str | None = None,
 ):
     """Compose the full card image. Returns a Pillow Image."""
-    from PIL import Image, ImageDraw, ImageFont  # noqa: PLC0415
+    from PIL import Image, ImageDraw  # noqa: PLC0415
 
     card = Image.new("RGB", (CARD_W, CARD_H), COLOR_BG)
     draw = ImageDraw.Draw(card)
@@ -110,8 +118,10 @@ def render_card(
     title_font = _load_font(size=80, bold=True)
     heading_font = _load_font(size=42, bold=True)
     body_font = _load_font(size=32)
-    mono_font = _load_font(size=36, monospace=True)
     small_font = _load_font(size=24)
+    # Note: the monospace value font is no longer eagerly loaded — the
+    # password-overflow fix (auto-shrinking via _fit_font_to_width) picks
+    # a size per-row instead of using a single fixed mono_font.
 
     # --- Header band ---
     draw.text(
@@ -169,13 +179,22 @@ def render_card(
         ("password", password if password else "(open)"),
         ("then visit", setup_url),
     ]
+    # The value column starts at x=MARGIN+240 and must fit within the right
+    # margin (CARD_W - MARGIN). Anything wider gets shrunk to fit OR wrapped
+    # across lines. Max-length WPA2 passwords (63 chars) and long mDNS URLs
+    # both blow past the default mono font width otherwise — and a setup
+    # card where the password runs off the right edge defeats the point of
+    # having a fallback block.
+    value_x = MARGIN + 240
+    value_max_width = CARD_W - MARGIN - value_x  # pixels available
     row_y = fallback_y + 50
     for label, value in rows:
         draw.text((MARGIN, row_y), label.upper(), font=small_font, fill=COLOR_MUTED)
+        value_font = _fit_font_to_width(draw, value, value_max_width, base_size=36, min_size=18, monospace=True)
         draw.text(
-            (MARGIN + 240, row_y - 6),
+            (value_x, row_y - 6),
             value,
-            font=mono_font,
+            font=value_font,
             fill=COLOR_FG,
         )
         row_y += 70
@@ -199,6 +218,32 @@ def render_card(
         )
 
     return card
+
+
+def _fit_font_to_width(draw, text: str, max_width: int, base_size: int = 36,
+                       min_size: int = 18, monospace: bool = False):
+    """Return the largest font (at or below ``base_size``) whose ``text``
+    measures ``<= max_width`` pixels. Floors at ``min_size`` even if the
+    text is still wider, on the principle that an unreadable readable
+    fallback is more useful than a value clipped to the next-line.
+
+    Needed for the password row — WPA2 supports up to 63 characters, and
+    a 36-pt monospace render of that is wider than the available column.
+    Without auto-shrink, the value runs off the right edge of the card.
+    """
+    for size in range(base_size, min_size - 1, -2):
+        font = _load_font(size=size, monospace=monospace)
+        try:
+            bbox = draw.textbbox((0, 0), text, font=font)
+            width = bbox[2] - bbox[0]
+        except (AttributeError, OSError):
+            # Pillow's fallback bitmap font doesn't honor textbbox cleanly
+            # on every platform — assume it fits and return base size.
+            return font
+        if width <= max_width:
+            return font
+    # Floor: return the smallest size and accept the overflow as a last resort.
+    return _load_font(size=min_size, monospace=monospace)
 
 
 def _load_font(size: int, bold: bool = False, monospace: bool = False):

--- a/dream-server/tests/test_setup_card.py
+++ b/dream-server/tests/test_setup_card.py
@@ -1,0 +1,170 @@
+"""Tests for scripts/generate-setup-card.py.
+
+These exercise the CLI end-to-end: invoke the script, verify it writes
+a valid PNG, and sanity-check the WiFi-QR payload encoding. Visual
+correctness is not asserted — that's eyeball-test territory.
+
+Run with: pytest tests/test_setup_card.py
+"""
+
+import importlib.util
+import os
+import subprocess
+import sys
+import struct
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "generate-setup-card.py"
+
+
+def _import_module():
+    """Import the script as a module so we can unit-test its helpers."""
+    spec = importlib.util.spec_from_file_location("generate_setup_card", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Helper: build_wifi_qr_payload
+# ---------------------------------------------------------------------------
+
+
+def test_wifi_qr_payload_basic():
+    mod = _import_module()
+    p = mod.build_wifi_qr_payload("MyNet", "secret123", "WPA")
+    # Order is T;S;P;H — standard.
+    assert p == "WIFI:T:WPA;S:MyNet;P:secret123;H:false;;"
+
+
+def test_wifi_qr_payload_open_network():
+    mod = _import_module()
+    p = mod.build_wifi_qr_payload("Open", "", "nopass")
+    # Password segment omitted entirely when password is empty.
+    assert "P:" not in p
+    assert p.startswith("WIFI:T:nopass;S:Open;")
+
+
+def test_wifi_qr_payload_escapes_special_chars():
+    mod = _import_module()
+    p = mod.build_wifi_qr_payload("My;Net,wifi", 'pass":word\\', "WPA")
+    # Per the WIFI: URI escape rules, all of \, ;, ,, :, " must be
+    # backslash-escaped in the value (not just the obvious separators).
+    assert "S:My\\;Net\\,wifi" in p
+    assert "P:pass\\\"\\:word\\\\" in p
+
+
+# ---------------------------------------------------------------------------
+# CLI invocation
+# ---------------------------------------------------------------------------
+
+
+def _have_pillow_and_qrcode():
+    try:
+        import PIL  # noqa: F401
+        import qrcode  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+pillow_required = pytest.mark.skipif(
+    not _have_pillow_and_qrcode(),
+    reason="Pillow + qrcode not installed; setup-card requires them",
+)
+
+
+@pillow_required
+def test_cli_writes_valid_png(tmp_path):
+    out = tmp_path / "card.png"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--ssid", "Dream-Setup-TEST",
+            "--password", "supersecret",
+            "--setup-url", "http://192.168.7.1/setup",
+            "--device-name", "dream-test.local",
+            "--serial", "TEST-001",
+            "--output", str(out),
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert out.exists()
+    assert out.stat().st_size > 1000  # nontrivial PNG
+
+    # PNG magic number — first 8 bytes must be 89 50 4E 47 0D 0A 1A 0A
+    with open(out, "rb") as f:
+        header = f.read(8)
+    assert header == b"\x89PNG\r\n\x1a\n", "output is not a valid PNG"
+
+
+@pillow_required
+def test_cli_creates_parent_directory(tmp_path):
+    nested = tmp_path / "deep" / "subdir" / "card.png"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--ssid", "Open",
+            "--security", "nopass",
+            "--setup-url", "http://192.168.7.1/setup",
+            "--output", str(nested),
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert nested.exists()
+
+
+@pillow_required
+def test_cli_dimensions_match_4x6_at_300dpi(tmp_path):
+    """The script promises 1200×1800 px at 300 DPI = 4×6 inches."""
+    out = tmp_path / "card.png"
+    subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--ssid", "x", "--password", "y",
+            "--setup-url", "http://192.168.7.1/setup",
+            "--output", str(out),
+        ],
+        check=True, capture_output=True, timeout=30,
+    )
+    # Parse PNG IHDR to read width/height without importing Pillow here.
+    with open(out, "rb") as f:
+        f.seek(16)
+        width, height = struct.unpack(">II", f.read(8))
+    assert (width, height) == (1200, 1800)
+
+
+def test_cli_requires_ssid():
+    """Argparse error when --ssid is missing."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--setup-url", "http://x/", "--output", "/tmp/x.png"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode != 0
+    assert "ssid" in result.stderr.lower()
+
+
+def test_cli_requires_setup_url():
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--ssid", "x", "--output", "/tmp/x.png"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode != 0
+    assert "setup-url" in result.stderr.lower() or "setup_url" in result.stderr.lower()
+
+
+def test_cli_help_works_without_pillow():
+    """Argparse help shouldn't require Pillow; helpful when an operator is
+    checking flags before installing deps."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--help"],
+        capture_output=True, text=True, timeout=10,
+    )
+    assert result.returncode == 0
+    assert "ssid" in result.stdout.lower()
+    assert "setup-url" in result.stdout.lower()

--- a/dream-server/tests/test_setup_card.py
+++ b/dream-server/tests/test_setup_card.py
@@ -8,7 +8,6 @@ Run with: pytest tests/test_setup_card.py
 """
 
 import importlib.util
-import os
 import subprocess
 import sys
 import struct
@@ -168,3 +167,49 @@ def test_cli_help_works_without_pillow():
     assert result.returncode == 0
     assert "ssid" in result.stdout.lower()
     assert "setup-url" in result.stdout.lower()
+
+
+# ---------------------------------------------------------------------------
+# Regression: 63-char WPA2 password must fit in the fallback column
+# ---------------------------------------------------------------------------
+
+
+@pillow_required
+def test_max_length_wpa_password_fits_in_fallback(tmp_path):
+    """Reviewer flagged the plaintext fallback overflowing for max-length
+    WPA2 passwords (63 chars). The fix auto-shrinks the mono font to fit
+    within the value column; this test renders such a password and inspects
+    the output pixels along the right margin to make sure the text didn't
+    bleed off the card edge.
+    """
+    from PIL import Image  # imported only when Pillow is available
+
+    # WPA2 PSK upper bound = 63 chars. Pick a worst-case glyph (wide M's).
+    password = "M" * 63
+    out = tmp_path / "card-max-password.png"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--ssid", "DreamCard",
+            "--password", password,
+            "--setup-url", "http://192.168.7.1/setup",
+            "--output", str(out),
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+
+    # Inspect the right-edge column of the password row. Generator puts the
+    # password block roughly in the lower-middle of the card; the right
+    # margin should be pure background (no glyph pixels). Check a vertical
+    # strip 4 px wide along the very right edge in the password band.
+    img = Image.open(out).convert("RGB")
+    card_w, card_h = img.size
+    # Password row sits between ~y=1100 and y=1300 in the layout.
+    bg = (15, 15, 19)  # COLOR_BG
+    for x in range(card_w - 4, card_w):
+        for y in range(1100, 1300):
+            assert img.getpixel((x, y)) == bg, (
+                f"Pixel at ({x},{y}) is {img.getpixel((x, y))}, "
+                "expected card background — password text overflowed the column."
+            )

--- a/dream-server/tests/test_setup_card.py
+++ b/dream-server/tests/test_setup_card.py
@@ -41,10 +41,16 @@ def test_wifi_qr_payload_basic():
 
 def test_wifi_qr_payload_open_network():
     mod = _import_module()
-    p = mod.build_wifi_qr_payload("Open", "", "nopass")
+    p = mod.build_wifi_qr_payload("Open", "", "WPA")
     # Password segment omitted entirely when password is empty.
     assert "P:" not in p
     assert p.startswith("WIFI:T:nopass;S:Open;")
+
+
+def test_wifi_qr_payload_nopass_ignores_empty_password_only():
+    mod = _import_module()
+    p = mod.build_wifi_qr_payload("Open", "", "nopass")
+    assert p == "WIFI:T:nopass;S:Open;H:false;;"
 
 
 def test_wifi_qr_payload_escapes_special_chars():
@@ -167,6 +173,37 @@ def test_cli_help_works_without_pillow():
     assert result.returncode == 0
     assert "ssid" in result.stdout.lower()
     assert "setup-url" in result.stdout.lower()
+
+
+@pillow_required
+def test_cli_rejects_nopass_with_password(tmp_path):
+    out = tmp_path / "card.png"
+    result = subprocess.run(
+        [
+            sys.executable, str(SCRIPT),
+            "--ssid", "Open",
+            "--password", "should-not-be-used",
+            "--security", "nopass",
+            "--setup-url", "http://192.168.7.1/setup",
+            "--output", str(out),
+        ],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 2
+    assert "nopass" in result.stderr
+    assert not out.exists()
+
+
+@pillow_required
+def test_qr_has_four_module_quiet_zone():
+    mod = _import_module()
+    img = mod.render_qr("hello", 240)
+    white = (255, 255, 255)
+    # With border=4 on a version-1 QR, the top quiet zone is ~33 px after
+    # scaling to 240 px. A one-module border is only ~10 px and fails here.
+    for x in range(0, 240):
+        for y in range(0, 24):
+            assert img.getpixel((x, y)) == white
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# PR-9: Printable setup-card generator

**Branch:** `feat/setup-card-generator`
**Phase:** 2 of 4 (First-boot wizard)
**Effort:** Small — 3 files (all new), 543 insertions
**Depends on:** none (independent operator-side tool)

## Summary

A CLI utility for fulfillment. Feed it a per-device Wi-Fi AP SSID + password + setup URL, get back a 4×6 portrait PNG ready to print, laminate, and drop in the box. The recipient scans two QRs — first joins the setup AP, second opens the first-boot wizard — and they're in.

This is a tooling artifact, not a runtime feature. The device never prints its own credentials; this runs on the operator's machine or in the fulfillment pipeline.

## Sample output

A 1200×1800 px (4×6 inches @ 300 DPI) portrait card with:

1. **Top band** — "DREAM SERVER" wordmark in brand purple, the unit's mDNS name (e.g. `dream-a4f2.local`), "Scan to set up. Scan to chat." tagline.
2. **Two QR codes side by side:**
   - **Left — JOIN WI-FI:** Encodes the standard `WIFI:T:WPA;S:<ssid>;P:<password>;;` URI that iOS Camera and Android system scanner auto-recognize. One tap joins the AP.
   - **Right — OPEN SETUP:** Plain URL QR. Opens straight to `/setup` on the device's setup-mode IP.
3. **Plain-text fallback block** — `NETWORK / PASSWORD / THEN VISIT` for phones whose camera won't scan a QR.
4. **Footer** — "DreamServer is open-source — light-heart-labs.com", plus optional per-unit serial in the right corner.

Verified visually with a sample card (`Dream-Setup-A4F2` / `dream-a4f2.local` / `DRM-2026-A4F2`).

## Files

| File | Lines | What |
|---|---|---|
| `scripts/generate-setup-card.py` | 248 | The CLI. Pillow + qrcode for layout/QR; both imported lazily so `--help` works without them. Best-effort font loader walks Consolas / DejaVu / Helvetica based on OS. |
| `docs/SETUP-CARD.md` | 100 | Operator docs: usage, batch-generation example, design choices, security notes, called-out limitations. |
| `tests/test_setup_card.py` | 195 | 9 tests: WiFi URI escape rules, CLI happy path, PNG validity, dimensions, parent-dir creation, missing-flag handling, `--help`-without-Pillow. |

## CLI

```bash
python3 scripts/generate-setup-card.py \
  --ssid 'Dream-Setup-A4F2' \
  --password 'xxxxxxxx' \
  --setup-url 'http://192.168.7.1/setup' \
  --device-name 'dream-a4f2.local' \
  --serial 'DRM-2026-A4F2' \
  --output cards/card-A4F2.png
```

| Flag | Required | Notes |
|---|---|---|
| `--ssid` | yes | Wi-Fi SSID of the device's setup AP |
| `--password` | no | Wi-Fi password. Omit for open networks. |
| `--security` | no | `WPA` (default), `WEP`, `nopass` |
| `--setup-url` | yes | URL embedded in the second QR |
| `--device-name` | no | mDNS hostname printed on the card (default `dream.local`) |
| `--serial` | no | Optional fulfillment / batch ID |
| `--output` / `-o` | yes | Output PNG path. Parent dirs created if missing. |

Exit codes: `0` success; `2` if Pillow / qrcode aren't installed (with install hint).

## Design choices

- **PNG, not PDF.** Printers handle PNG fine. PDF would require adding `reportlab` (a heavy dep) for what amounts to a wrapper around the same image.
- **Pillow composition, not SVG template.** A pre-baked template would be more "designed" but harder to maintain across font fallback and variable-length text. Procedural layout fits text to content cleanly.
- **Lazy imports.** `--help` works without Pillow installed so operators can check flags before installing deps.
- **No on-device generation.** The device never knows its AP credentials at runtime — those are baked in during the image-build step. Printing the credentials from the device would also be a self-leak vector.

## What's NOT in this PR

- **PDF output.** Trivial follow-up if a fulfillment pipeline needs it (`card.save(path, format="PDF")`). PNG is the canonical format here.
- **Multi-language.** "JOIN WI-FI" / "OPEN SETUP" / fallback labels are English-only. Localizable as `--locale` later if it matters.
- **A Dream logo SVG.** The wordmark is set in the system bold font today. When a real `dream-logo.svg` exists, dropping it in is a small change.
- **Hidden-SSID flag.** WIFI URI supports `H:true;`; today we hardcode `H:false`. Trivial to expose later.
- **Setup-card output endpoint on the dashboard.** The wizard from PR-7 could in principle expose a "regenerate my setup card" button. Out of scope here — this is a CLI tool.

## Test plan

```bash
cd dream-server
pytest tests/test_setup_card.py -v
```

**9 tests, all passing locally:**

- [x] WiFi URI builds the spec-correct format
- [x] Open network (no password) omits the `P:` segment
- [x] WIFI URI escape rules (\\, ;, ,, :, ") apply in values
- [x] CLI writes a valid PNG (magic-number check)
- [x] CLI creates the output's parent directory
- [x] CLI output is exactly 1200×1800 (the documented 4×6 @ 300 DPI)
- [x] Missing `--ssid` errors out
- [x] Missing `--setup-url` errors out
- [x] `--help` works even without Pillow / qrcode installed

**Manual sample**: ran with `Dream-Setup-A4F2 / dream-a4f2.local / DRM-2026-A4F2`; output renders cleanly with both QR codes scannable on a phone camera and the fallback block readable.

## Caveats

- **The plaintext password is on the card by design.** Without it the QR fallback doesn't work. Treat the card as a physical credential — if the unit is resold, regenerate the AP creds and discard the card.
- **The setup URL doesn't carry the credential.** It points at the setup-mode IP (`192.168.7.1` by convention); if the recipient hasn't joined the AP yet, the URL just times out. The QRs depend on being scanned in order.
- **Font selection varies by OS.** The card always renders, but typography on a stripped-down container (e.g. Alpine with no system fonts) falls back to Pillow's bitmap font, which is functional but ugly. The fulfillment machine should have DejaVu / Helvetica / Consolas, which all modern OSs ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
