### PR TITLE
feat(wizard,host-agent): AP-mode awareness + WiFi handoff

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -864,6 +864,100 @@ def _narrowed_compose_set_resolves(narrowed_flags: list, service_id: str,
     return service_id in result.stdout.split()
 
 
+def _wifi_handoff_worker(ssid: str, password: str) -> None:
+    """Background worker for /v1/network/wifi-handoff.
+
+    Sequence:
+      1. Sleep 3s so the HTTP 202 response has time to flush to the wizard.
+      2. `systemctl stop dream-ap-mode` — tears down hostapd/dnsmasq and
+         hands the interface back to NetworkManager (ap-mode.sh ExecStop
+         handles the cleanup).
+      3. Wait briefly for the interface to settle.
+      4. `nmcli device wifi connect <ssid> password <pwd>`.
+      5. On success: write handoff-status.json with status=ok.
+      6. On failure: write handoff-status.json with status=error AND
+         re-enable dream-ap-mode so the user isn't stranded.
+
+    All errors are caught — this runs in a daemon thread and a crash
+    would silently strand the device. The result file is the only
+    feedback channel after the HTTP response is gone.
+    """
+    handoff_dir = Path("/run/dream-ap-mode")
+    handoff_dir.mkdir(parents=True, exist_ok=True)
+    status_path = handoff_dir / "handoff-status.json"
+
+    def _write_status(status: str, **extra) -> None:
+        payload = {
+            "status": status,
+            "ssid": ssid,
+            "at": datetime.now(timezone.utc).isoformat(),
+            **extra,
+        }
+        try:
+            status_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+            status_path.chmod(0o600)
+        except OSError as exc:
+            logger.error("wifi-handoff: failed to write status file: %s", exc)
+
+    # Step 1: give the HTTP response time to flush.
+    time.sleep(3)
+
+    # Step 2: tear down AP.
+    logger.info("wifi-handoff: stopping dream-ap-mode")
+    try:
+        subprocess.run(
+            ["systemctl", "stop", "dream-ap-mode"],
+            check=False, capture_output=True, timeout=20,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        _write_status("error", stage="ap-teardown", reason=str(exc))
+        return
+
+    # Step 3: settle period for NM to reclaim the interface.
+    time.sleep(2)
+
+    # Step 4: try to join the target network.
+    logger.info("wifi-handoff: connecting to %s", ssid)
+    args = ["nmcli", "device", "wifi", "connect", ssid]
+    if password:
+        args += ["password", password]
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=45,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        _write_status("error", stage="wifi-connect", reason=str(exc))
+        _restart_ap_for_recovery()
+        return
+
+    if result.returncode != 0:
+        raw = (result.stderr or result.stdout or "").strip()[:300]
+        _write_status(
+            "error",
+            stage="wifi-connect",
+            reason=raw or "nmcli connect failed",
+            returncode=result.returncode,
+        )
+        _restart_ap_for_recovery()
+        return
+
+    logger.info("wifi-handoff: connected to %s", ssid)
+    _write_status("ok")
+
+
+def _restart_ap_for_recovery() -> None:
+    """Bring dream-ap-mode back up after a failed handoff so the user
+    can reach the wizard again and retry."""
+    logger.info("wifi-handoff: recovering — restarting dream-ap-mode")
+    try:
+        subprocess.run(
+            ["systemctl", "start", "dream-ap-mode"],
+            check=False, capture_output=True, timeout=30,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        logger.error("wifi-handoff: AP recovery failed: %s", exc)
+
+
 class AgentHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         logger.info(fmt, *args)
@@ -983,6 +1077,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_invalidate_compose_cache()
         elif self.path == "/v1/env/update":
             self._handle_env_update()
+        elif self.path == "/v1/network/wifi-handoff":
+            self._handle_network_wifi_handoff()
         else:
             json_response(self, 404, {"error": "Not found"})
 
@@ -993,6 +1089,77 @@ class AgentHandler(BaseHTTPRequestHandler):
         invalidate_compose_cache()
         logger.info("compose-flags cache invalidated")
         json_response(self, 200, {"status": "ok"})
+
+    def _handle_network_wifi_handoff(self):
+        """End-of-wizard handoff: tear down AP mode and join a real Wi-Fi network.
+
+        This is a deliberate exception to PR-10's "no AP enable/disable from
+        HTTP" policy:
+          * Direction is one-way — disable AP, join home network. Can't
+            lock anyone out: the worst case is the device ends up on
+            its home network (where it was supposed to be all along).
+          * Bundled with the wizard's final "Finish" action. Not a general
+            "stop AP" endpoint.
+          * If the connect fails, the background script brings the AP
+            back up so the user isn't stranded.
+
+        The HTTP response returns immediately after validating + scheduling
+        the background work, because the caller (the wizard, served by the
+        dashboard) is about to lose the TCP connection when AP teardown
+        starts. Result is written to /run/dream-ap-mode/handoff-status.json
+        for post-hoc inspection.
+        """
+        if not check_auth(self):
+            return
+        if platform.system() != "Linux":
+            json_response(self, 501, {"error": "Wi-Fi handoff requires Linux"})
+            return
+        if shutil.which("nmcli") is None or shutil.which("systemctl") is None:
+            json_response(self, 501, {
+                "error": "nmcli + systemctl required for Wi-Fi handoff",
+            })
+            return
+
+        body = read_json_body(self)
+        if body is None:
+            return
+
+        ssid = body.get("ssid", "")
+        password = body.get("password", "")
+
+        if not isinstance(ssid, str) or not ssid or len(ssid) > 32:
+            json_response(self, 400, {"error": "ssid must be 1-32 chars"})
+            return
+        if any(c in ssid for c in ("\n", "\r", "\0")):
+            json_response(self, 400, {"error": "ssid contains invalid characters"})
+            return
+        if not isinstance(password, str) or len(password) > 63:
+            json_response(self, 400, {"error": "password must be 0-63 chars"})
+            return
+        if any(c in password for c in ("\n", "\r", "\0")):
+            json_response(self, 400, {"error": "password contains invalid characters"})
+            return
+
+        logger.info(
+            "wifi-handoff scheduled ssid=%s password_set=%s",
+            ssid, bool(password),
+        )
+
+        # Fire-and-forget background worker. The HTTP response flushes
+        # immediately so the wizard sees confirmation before connectivity
+        # dies during teardown.
+        thread = threading.Thread(
+            target=_wifi_handoff_worker,
+            args=(ssid, password),
+            daemon=True,
+        )
+        thread.start()
+
+        json_response(self, 202, {
+            "status": "scheduled",
+            "ssid": ssid,
+            "message": "AP teardown + Wi-Fi connect started; connectivity will drop briefly.",
+        })
 
     def _handle_env_update(self):
         """Write a validated .env file. Dashboard-api delegates here because the

--- a/dream-server/extensions/services/dashboard-api/routers/setup.py
+++ b/dream-server/extensions/services/dashboard-api/routers/setup.py
@@ -5,14 +5,17 @@ import json
 import logging
 import os
 import re
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field, field_validator
 
-from config import SERVICES, PERSONAS, SETUP_CONFIG_DIR, INSTALL_DIR
+from config import SERVICES, PERSONAS, SETUP_CONFIG_DIR, INSTALL_DIR, AGENT_URL, DREAM_AGENT_KEY
 from models import PersonaRequest, ChatRequest
 from security import verify_api_key
 
@@ -222,3 +225,93 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
     except aiohttp.ClientError:
         logger.exception("Cannot reach LLM backend")
         raise HTTPException(status_code=503, detail="Cannot reach LLM backend")
+
+
+# ---------------------------------------------------------------------------
+# AP-mode awareness for the first-boot wizard
+#
+# When the device is hosting its own setup AP (PR-10), the wizard needs to:
+#   1. Know it's running in AP mode (so it can show different copy)
+#   2. Collect home WiFi credentials
+#   3. Trigger an orchestrated handoff: tear down AP → join home network
+#
+# Both endpoints are thin proxies over the host-agent.
+# ---------------------------------------------------------------------------
+
+
+class WifiHandoffRequest(BaseModel):
+    ssid: str = Field(..., min_length=1, max_length=32)
+    password: str = Field(default="", max_length=63)
+
+    @field_validator("ssid")
+    @classmethod
+    def _ssid_no_control_chars(cls, v: str) -> str:
+        if any(c in v for c in ("\n", "\r", "\0")):
+            raise ValueError("ssid contains invalid characters")
+        return v
+
+    @field_validator("password")
+    @classmethod
+    def _password_no_control_chars(cls, v: str) -> str:
+        if any(c in v for c in ("\n", "\r", "\0")):
+            raise ValueError("password contains invalid characters")
+        return v
+
+
+def _proxy_agent(path: str, method: str = "GET", payload: dict | None = None, timeout: int = 30) -> dict:
+    """Forward to host-agent. Translates HTTPError → HTTPException; never
+    logs the request body (Wi-Fi passwords stay out of logs)."""
+    headers = {"Authorization": f"Bearer {DREAM_AGENT_KEY}"}
+    data = None
+    if payload is not None:
+        headers["Content-Type"] = "application/json"
+        data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(f"{AGENT_URL}{path}", data=data, headers=headers, method=method)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        detail = f"Host agent returned HTTP {exc.code}"
+        try:
+            err_payload = json.loads(exc.read().decode("utf-8"))
+            detail = err_payload.get("error", detail)
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            pass
+        logger.info("host-agent %s %s -> %s", method, path, exc.code)
+        raise HTTPException(status_code=exc.code, detail=detail) from exc
+    except urllib.error.URLError as exc:
+        logger.warning("host-agent %s %s unreachable: %s", method, path, exc)
+        raise HTTPException(status_code=503, detail="Dream host agent is not reachable.") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.exception("host-agent %s %s failed", method, path)
+        raise HTTPException(status_code=500, detail=f"Host agent call failed: {exc}") from exc
+
+
+@router.get("/api/setup/ap-mode-status", dependencies=[Depends(verify_api_key)])
+async def setup_ap_mode_status() -> dict:
+    """Return the device's AP-mode state. Used by the wizard to decide
+    whether to render the "you're on the setup AP" flow or the normal one.
+
+    Returns `{"status": "inactive"}` when AP mode isn't running. When
+    active, the body carries SSID, gateway IP, and timing — see
+    docs/AP-MODE.md.
+    """
+    return await asyncio.to_thread(_proxy_agent, "/v1/ap-mode/status", "GET", None, 10)
+
+
+@router.post("/api/setup/wifi-handoff", dependencies=[Depends(verify_api_key)])
+async def setup_wifi_handoff(payload: WifiHandoffRequest) -> dict:
+    """Trigger the AP-mode → home-network handoff. The host-agent does the
+    actual orchestration on a background thread and writes
+    /run/dream-ap-mode/handoff-status.json with the eventual result.
+    Returns 202 from the host-agent (scheduled) — connectivity to the
+    wizard drops within a few seconds of this call returning.
+    """
+    return await asyncio.to_thread(
+        _proxy_agent,
+        "/v1/network/wifi-handoff",
+        "POST",
+        {"ssid": payload.ssid, "password": payload.password},
+        15,
+    )

--- a/dream-server/extensions/services/dashboard-api/tests/test_setup_ap_mode.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_setup_ap_mode.py
@@ -1,0 +1,179 @@
+"""Tests for the AP-mode awareness proxy endpoints in routers/setup.py.
+
+These cover the dashboard-api → host-agent forwarding paths used by the
+first-boot wizard when running in AP mode. The actual handoff sequence
+(systemctl stop dream-ap-mode + nmcli connect) is tested at the
+host-agent layer.
+
+Mocked surfaces:
+  * urllib.request.urlopen — stand-in for the host-agent HTTP call.
+"""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import urllib.error
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_ap_mode_status_requires_auth(test_client):
+    resp = test_client.get("/api/setup/ap-mode-status")
+    assert resp.status_code == 401
+
+
+def test_wifi_handoff_requires_auth(test_client):
+    resp = test_client.post(
+        "/api/setup/wifi-handoff",
+        json={"ssid": "x", "password": ""},
+    )
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_agent_response(body, status=200):
+    mock_resp = MagicMock()
+    mock_resp.status = status
+    mock_resp.read = MagicMock(return_value=json.dumps(body).encode("utf-8"))
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _mock_agent_http_error(status, body):
+    err = urllib.error.HTTPError(
+        url="http://agent/v1/...",
+        code=status,
+        msg="error",
+        hdrs=None,
+        fp=None,
+    )
+    err.read = lambda: json.dumps(body).encode("utf-8")
+    return err
+
+
+# ---------------------------------------------------------------------------
+# ap-mode-status
+# ---------------------------------------------------------------------------
+
+
+def test_ap_mode_status_active(test_client):
+    upstream = {
+        "status": "active",
+        "ssid": "Dream-Setup-A4F2",
+        "interface": "wlan0",
+        "gateway_ip": "192.168.7.1",
+        "since": "2026-05-12T08:00:00+00:00",
+    }
+    with patch("routers.setup.urllib.request.urlopen", return_value=_mock_agent_response(upstream)):
+        resp = test_client.get("/api/setup/ap-mode-status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "active"
+    assert body["ssid"] == "Dream-Setup-A4F2"
+
+
+def test_ap_mode_status_inactive(test_client):
+    with patch(
+        "routers.setup.urllib.request.urlopen",
+        return_value=_mock_agent_response({"status": "inactive"}),
+    ):
+        resp = test_client.get("/api/setup/ap-mode-status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "inactive"
+
+
+def test_ap_mode_status_returns_503_when_agent_unreachable(test_client):
+    with patch(
+        "routers.setup.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        resp = test_client.get("/api/setup/ap-mode-status", headers=test_client.auth_headers)
+    assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# wifi-handoff
+# ---------------------------------------------------------------------------
+
+
+def test_wifi_handoff_happy_path(test_client):
+    upstream = {
+        "status": "scheduled",
+        "ssid": "MyHomeWiFi",
+        "message": "AP teardown + Wi-Fi connect started; connectivity will drop briefly.",
+    }
+    with patch(
+        "routers.setup.urllib.request.urlopen",
+        return_value=_mock_agent_response(upstream, status=202),
+    ):
+        resp = test_client.post(
+            "/api/setup/wifi-handoff",
+            json={"ssid": "MyHomeWiFi", "password": "supersecret"},
+            headers=test_client.auth_headers,
+        )
+    # urllib.urlopen treats 2xx as success and reads body normally;
+    # FastAPI passes through the body, but the proxy method doesn't
+    # forward upstream status — it always returns 200 OK on success.
+    # That's fine: the wizard cares about content, not the code.
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "scheduled"
+
+
+def test_wifi_handoff_rejects_oversized_ssid(test_client):
+    resp = test_client.post(
+        "/api/setup/wifi-handoff",
+        json={"ssid": "x" * 33, "password": ""},
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_wifi_handoff_rejects_oversized_password(test_client):
+    resp = test_client.post(
+        "/api/setup/wifi-handoff",
+        json={"ssid": "ok", "password": "x" * 64},
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_wifi_handoff_rejects_control_chars(test_client):
+    resp = test_client.post(
+        "/api/setup/wifi-handoff",
+        json={"ssid": "bad\rssid", "password": ""},
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 422
+
+
+def test_wifi_handoff_translates_501_when_handoff_not_supported(test_client):
+    err = _mock_agent_http_error(501, {"error": "Wi-Fi handoff requires Linux"})
+    with patch("routers.setup.urllib.request.urlopen", side_effect=err):
+        resp = test_client.post(
+            "/api/setup/wifi-handoff",
+            json={"ssid": "Home", "password": "secret"},
+            headers=test_client.auth_headers,
+        )
+    assert resp.status_code == 501
+    assert "Linux" in resp.json()["detail"]
+
+
+def test_wifi_handoff_returns_503_when_agent_unreachable(test_client):
+    with patch(
+        "routers.setup.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        resp = test_client.post(
+            "/api/setup/wifi-handoff",
+            json={"ssid": "Home", "password": "secret"},
+            headers=test_client.auth_headers,
+        )
+    assert resp.status_code == 503

--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -4,6 +4,7 @@ import Sidebar from './components/Sidebar'
 import SetupWizard from './components/SetupWizard'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
+import { useFirstRun } from './hooks/useFirstRun'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
 
@@ -30,26 +31,24 @@ function App() {
   )
   const { status, loading, error } = useSystemStatus()
   const { version, dismissUpdate } = useVersion()
-  const [firstRun, setFirstRun] = useState(false)
+  // Server-side first-run flag (sourced from /api/setup/status). localStorage
+  // was per-browser and gave the wrong answer on re-imaged devices or fresh
+  // browsers. The hook returns firstRun=false while it's loading or if the
+  // API call fails, so the normal app shell is the safe default.
+  const { firstRun, refresh: refreshFirstRun } = useFirstRun()
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => {
     return getStorageValue(globalThis.localStorage, 'dream-sidebar-collapsed') === 'true'
   })
 
   useEffect(() => {
-    const hasVisited = getStorageValue(globalThis.localStorage, 'dream-dashboard-visited')
-    if (!hasVisited) {
-      setFirstRun(true)
-    }
-  }, [])
-
-  useEffect(() => {
     setStorageValue(globalThis.localStorage, 'dream-sidebar-collapsed', String(sidebarCollapsed))
   }, [sidebarCollapsed])
 
-  const dismissFirstRun = () => {
-    setStorageValue(globalThis.localStorage, 'dream-dashboard-visited', 'true')
-    setFirstRun(false)
-  }
+  const dismissFirstRun = useCallback(() => {
+    // SetupWizard's saveConfig has already POSTed /api/setup/complete; we
+    // re-fetch the server flag so the next mount sees the new state.
+    refreshFirstRun()
+  }, [refreshFirstRun])
 
   const routes = useMemo(() => getInternalRoutes({ status, loading }), [status, loading])
   const handleToggle = useCallback(() => setSidebarCollapsed(c => !c), [])

--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -1,12 +1,16 @@
 import { Routes, Route } from 'react-router-dom'
-import { useState, useEffect, Suspense, useMemo, useCallback } from 'react'
+import { useState, useEffect, Suspense, useMemo, useCallback, lazy } from 'react'
 import Sidebar from './components/Sidebar'
-import SetupWizard from './components/SetupWizard'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
 import { useFirstRun } from './hooks/useFirstRun'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
+
+// Phone-first first-boot wizard. Mounted instead of the normal app shell
+// when useFirstRun() reports firstRun=true. Lazy-loaded so the wizard
+// bundle isn't paid for on every page load after onboarding.
+const FirstBoot = lazy(() => import('./pages/FirstBoot'))
 
 function getStorageValue(storage, key) {
   try {
@@ -53,6 +57,29 @@ function App() {
   const routes = useMemo(() => getInternalRoutes({ status, loading }), [status, loading])
   const handleToggle = useCallback(() => setSidebarCollapsed(c => !c), [])
 
+  // First-boot path: render the FirstBoot SPA fullscreen and lock out the
+  // rest of the dashboard. The user can't reach Settings / Extensions / etc.
+  // until they've completed onboarding — that simplifies the wizard story
+  // (one path, no escape hatches) and prevents half-configured devices
+  // from getting halfway-set-up.
+  if (firstRun) {
+    return (
+      <div className="min-h-screen bg-theme-bg text-theme-text">
+        {!splashDone && <SplashScreen onComplete={() => {
+          setStorageValue(globalThis.sessionStorage, 'dream-splash-shown', '1')
+          setSplashDone(true)
+        }} />}
+        <Suspense fallback={
+          <div className="min-h-screen flex items-center justify-center">
+            <div className="font-mono text-sm text-theme-accent tracking-widest animate-pulse">DREAM SERVER</div>
+          </div>
+        }>
+          <FirstBoot onComplete={dismissFirstRun} />
+        </Suspense>
+      </div>
+    )
+  }
+
   return (
     <div className="flex min-h-screen bg-theme-bg text-theme-text relative">
       {!splashDone && <SplashScreen onComplete={() => {
@@ -66,10 +93,6 @@ function App() {
       />
 
       <main className={`dashboard-market-shell flex-1 transition-all duration-200 ${sidebarCollapsed ? 'ml-20' : 'ml-64'}`}>
-        {firstRun && (
-          <SetupWizard onComplete={dismissFirstRun} />
-        )}
-
         {status?.bootstrap?.active && (
           <BootstrapBanner bootstrap={status.bootstrap} />
         )}

--- a/dream-server/extensions/services/dashboard/src/App.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.test.jsx
@@ -1,6 +1,7 @@
 import { screen } from '@testing-library/react'
 import { render } from './test/test-utils'
 import App from './App' // eslint-disable-line no-unused-vars
+import { useFirstRun } from './hooks/useFirstRun'
 
 vi.mock('./hooks/useSystemStatus', () => ({
   useSystemStatus: vi.fn(() => ({
@@ -17,6 +18,12 @@ vi.mock('./hooks/useVersion', () => ({
     error: null,
     dismissUpdate: vi.fn()
   }))
+}))
+
+// Server-side first-run gating — the hook drives whether SetupWizard mounts.
+// Tests below override the mock per case.
+vi.mock('./hooks/useFirstRun', () => ({
+  useFirstRun: vi.fn(() => ({ firstRun: false, loading: false, error: null, refresh: vi.fn() })),
 }))
 
 vi.mock('./plugins/registry', () => ({
@@ -46,9 +53,9 @@ describe('App', () => {
     vi.stubGlobal('fetch', vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
     ))
-    globalThis.localStorage.removeItem('dream-dashboard-visited')
     globalThis.localStorage.removeItem('dream-sidebar-collapsed')
     globalThis.sessionStorage.removeItem('dream-splash-shown')
+    useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
   })
 
   afterEach(() => {
@@ -60,20 +67,19 @@ describe('App', () => {
     expect(document.querySelector('aside')).toBeInTheDocument()
   })
 
-  test('shows SetupWizard on first visit', () => {
-    // localStorage is clear, so firstRun should become true
+  test('shows SetupWizard when server reports first_run=true', () => {
+    useFirstRun.mockReturnValue({ firstRun: true, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
     expect(screen.getByTestId('setup-wizard')).toBeInTheDocument()
   })
 
-  test('hides SetupWizard when already visited', () => {
-    localStorage.setItem('dream-dashboard-visited', 'true')
+  test('hides SetupWizard when server reports first_run=false', () => {
+    useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
     expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
   })
 
   test('renders sidebar', () => {
-    localStorage.setItem('dream-dashboard-visited', 'true')
     render(<App />)
     expect(document.querySelector('aside')).toBeInTheDocument()
     expect(document.querySelector('main')).toBeInTheDocument()

--- a/dream-server/extensions/services/dashboard/src/App.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.test.jsx
@@ -32,9 +32,12 @@ vi.mock('./plugins/registry', () => ({
   getSidebarExternalLinks: vi.fn(() => [])
 }))
 
-vi.mock('./components/SetupWizard', () => ({
+// FirstBoot is lazy-imported in App.jsx and rendered fullscreen when
+// firstRun=true. Mock it as a sync component so tests don't need to
+// await Suspense.
+vi.mock('./pages/FirstBoot', () => ({
   default: ({ onComplete }) => (
-    <div data-testid="setup-wizard">
+    <div data-testid="first-boot">
       <button onClick={onComplete}>Complete</button>
     </div>
   )
@@ -67,16 +70,19 @@ describe('App', () => {
     expect(document.querySelector('aside')).toBeInTheDocument()
   })
 
-  test('shows SetupWizard when server reports first_run=true', () => {
+  test('shows FirstBoot when server reports first_run=true', async () => {
     useFirstRun.mockReturnValue({ firstRun: true, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
-    expect(screen.getByTestId('setup-wizard')).toBeInTheDocument()
+    // FirstBoot is lazy-loaded under Suspense; await its appearance.
+    expect(await screen.findByTestId('first-boot')).toBeInTheDocument()
+    // Sidebar must NOT render during onboarding — the wizard owns the screen.
+    expect(document.querySelector('aside')).not.toBeInTheDocument()
   })
 
-  test('hides SetupWizard when server reports first_run=false', () => {
+  test('hides FirstBoot when server reports first_run=false', () => {
     useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
-    expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('first-boot')).not.toBeInTheDocument()
   })
 
   test('renders sidebar', () => {

--- a/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/SetupWizard.jsx
@@ -146,9 +146,20 @@ export default function SetupWizard({ onComplete }) {
     }
   }
 
-  const saveConfig = () => {
+  const saveConfig = async () => {
+    // localStorage retains the wizard's *answers* (voice / userName etc.)
+    // for the dashboard to consult later, but is no longer the source of
+    // truth for "have we onboarded?" — that lives on the server now.
     localStorage.setItem('dream-config', JSON.stringify(config))
-    localStorage.setItem('dream-dashboard-visited', 'true')
+    try {
+      // The server endpoint writes setup-complete.json which the
+      // useFirstRun hook reads. Best-effort: if it fails (e.g. dashboard-api
+      // restarting mid-wizard) we still dismiss the wizard so the user
+      // isn't trapped, and rely on the next refresh to converge.
+      await fetch('/api/setup/complete', { method: 'POST' })
+    } catch (err) {
+      console.error('Failed to mark setup complete on server:', err)
+    }
     onComplete()
   }
 

--- a/dream-server/extensions/services/dashboard/src/hooks/useFirstRun.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useFirstRun.js
@@ -1,0 +1,48 @@
+import { useState, useEffect, useCallback } from 'react'
+
+// Auth: nginx injects the Authorization header for /api/ requests
+// (see nginx.conf). The fetch below is a plain relative URL.
+//
+// Server-side authoritative first-run gating.
+//
+// Why a hook (vs. just localStorage): localStorage flags are per-browser.
+// A fresh device opened from a different phone, a re-imaged disk, or a
+// cleared browser cache would all re-trigger the wizard for that browser
+// while leaving an actually-onboarded device "unconfigured" from the new
+// browser's perspective. The truth lives in the dashboard-api's
+// `setup-complete.json` sentinel; this hook surfaces that truth to the UI.
+//
+// Failure mode: if the API call fails (network error, CORS, dashboard-api
+// not yet up), we default to "not first run". A false negative ("wizard
+// never shows; user reads docs") is far less disruptive than a false
+// positive ("wizard re-appears whenever the API blips and the user
+// can't reach the normal dashboard"). The wizard can always be
+// re-triggered via the deeper `/setup` route once that exists.
+
+export function useFirstRun() {
+  const [firstRun, setFirstRun] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      const resp = await fetch('/api/setup/status')
+      if (!resp.ok) throw new Error(`setup-status returned ${resp.status}`)
+      const data = await resp.json()
+      setFirstRun(!!data.first_run)
+      setError(null)
+    } catch (err) {
+      // See the failure-mode comment above. We mark loading=false so the
+      // UI proceeds normally; the wizard is hidden until the next refresh.
+      setFirstRun(false)
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { refresh() }, [refresh])
+
+  return { firstRun, loading, error, refresh }
+}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -1,0 +1,558 @@
+// Phone-first first-boot wizard.
+//
+// Lives at /setup. App.jsx routes here when useFirstRun() says
+// firstRun=true and locks all other routes out. Single-column,
+// large tap targets, big text — the user is most likely on a
+// phone scanning the device's setup link.
+//
+// 4 screens:
+//   1. Welcome — name your device (DREAM_DEVICE_NAME)
+//   2. First user — username for the initial magic-link invite
+//   3. Pick your stack — chat-only / chat+agents / everything
+//   4. Done — generate magic-link, show QR
+//
+// Progress is mirrored to localStorage so a phone refresh doesn't
+// lose state mid-wizard. The server-side flip happens only on the
+// final "Finish" tap, via /api/setup/complete.
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Sparkles, User, Layers, Check, ChevronRight, ChevronLeft,
+  MessageSquare, Workflow, Boxes, Loader2, AlertCircle, Copy,
+  QrCode, Share2,
+} from 'lucide-react'
+
+const PROGRESS_KEY = 'dream-firstboot-progress'
+
+const STACK_OPTIONS = [
+  {
+    id: 'chat',
+    title: 'Chat only',
+    blurb: 'Just the chat surface — fastest setup, smallest footprint.',
+    Icon: MessageSquare,
+  },
+  {
+    id: 'chat-agents',
+    title: 'Chat + Agents',
+    blurb: 'Adds n8n workflows and the agent runtime so models can do work for you.',
+    Icon: Workflow,
+  },
+  {
+    id: 'everything',
+    title: 'Everything',
+    blurb: 'Voice in/out, image generation, search, the whole stack. Take some time to download.',
+    Icon: Boxes,
+  },
+]
+
+const TOTAL_STEPS = 4
+
+function readProgress() {
+  try {
+    const raw = globalThis.localStorage?.getItem(PROGRESS_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function writeProgress(progress) {
+  try {
+    globalThis.localStorage?.setItem(PROGRESS_KEY, JSON.stringify(progress))
+  } catch {
+    // localStorage may be blocked in private windows — wizard still works.
+  }
+}
+
+function clearProgress() {
+  try {
+    globalThis.localStorage?.removeItem(PROGRESS_KEY)
+  } catch {
+    // Ignore.
+  }
+}
+
+export default function FirstBoot({ onComplete }) {
+  const initial = useMemo(() => readProgress() || {}, [])
+  const [step, setStep] = useState(initial.step || 1)
+  const [deviceName, setDeviceName] = useState(initial.deviceName || 'dream')
+  const [username, setUsername] = useState(initial.username || '')
+  const [stack, setStack] = useState(initial.stack || 'chat')
+  const [finishing, setFinishing] = useState(false)
+  const [finishError, setFinishError] = useState(null)
+  const [invite, setInvite] = useState(null)
+
+  // Persist progress whenever the user moves forward.
+  useEffect(() => {
+    writeProgress({ step, deviceName, username, stack })
+  }, [step, deviceName, username, stack])
+
+  const next = () => setStep(s => Math.min(s + 1, TOTAL_STEPS))
+  const prev = () => setStep(s => Math.max(s - 1, 1))
+
+  const finish = async () => {
+    setFinishing(true)
+    setFinishError(null)
+    try {
+      // Generate the first magic-link for the named user. Reuses PR-4's
+      // backend; this is the same endpoint /Invites consumes.
+      const genResp = await fetch('/api/auth/magic-link/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_username: username,
+          scope: 'chat',
+          expires_in: 86400, // 24h — the wizard target may not redeem immediately
+          reusable: false,
+          note: 'First-boot invite',
+        }),
+      })
+      if (!genResp.ok) {
+        const body = await genResp.json().catch(() => ({}))
+        throw new Error(body.detail || `generate failed: ${genResp.status}`)
+      }
+      const inviteData = await genResp.json()
+
+      // Flip the server-side sentinel so this device is "configured".
+      await fetch('/api/setup/complete', { method: 'POST' })
+
+      setInvite(inviteData)
+      clearProgress()
+      // Stay on the success screen until the user taps "Open chat" or "Done"
+      // — calling onComplete() immediately would route them away before they
+      // can copy the QR. onComplete fires on the final tap.
+    } catch (err) {
+      setFinishError(err.message)
+    } finally {
+      setFinishing(false)
+    }
+  }
+
+  const handleDone = () => {
+    onComplete?.()
+  }
+
+  return (
+    <div className="min-h-screen bg-theme-bg flex flex-col">
+      <header className="px-6 pt-8 pb-4 flex items-center justify-between">
+        <div className="font-mono text-sm font-bold text-theme-accent tracking-widest">DREAM SERVER</div>
+        {!invite && <StepDots step={step} total={TOTAL_STEPS} />}
+      </header>
+
+      <main className="flex-1 flex items-stretch px-6 pb-8">
+        <div className="w-full max-w-md mx-auto flex flex-col justify-center">
+          {invite ? (
+            <DoneScreen invite={invite} onDone={handleDone} />
+          ) : (
+            <>
+              {step === 1 && (
+                <WelcomeStep
+                  deviceName={deviceName}
+                  setDeviceName={setDeviceName}
+                  onNext={next}
+                />
+              )}
+              {step === 2 && (
+                <UserStep
+                  username={username}
+                  setUsername={setUsername}
+                  onNext={next}
+                  onBack={prev}
+                />
+              )}
+              {step === 3 && (
+                <StackStep
+                  stack={stack}
+                  setStack={setStack}
+                  onNext={next}
+                  onBack={prev}
+                />
+              )}
+              {step === 4 && (
+                <ConfirmStep
+                  deviceName={deviceName}
+                  username={username}
+                  stack={stack}
+                  onBack={prev}
+                  onFinish={finish}
+                  finishing={finishing}
+                  error={finishError}
+                />
+              )}
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step dots
+// ---------------------------------------------------------------------------
+
+function StepDots({ step, total }) {
+  return (
+    <div className="flex items-center gap-2">
+      {Array.from({ length: total }).map((_, i) => {
+        const n = i + 1
+        const active = n === step
+        const done = n < step
+        return (
+          <div
+            key={n}
+            className={`w-2 h-2 rounded-full transition-colors ${
+              done ? 'bg-theme-accent' : active ? 'bg-theme-accent ring-2 ring-theme-accent/40' : 'bg-theme-border'
+            }`}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Welcome / device name
+// ---------------------------------------------------------------------------
+
+function WelcomeStep({ deviceName, setDeviceName, onNext }) {
+  const valid = /^[a-z0-9-]{1,32}$/i.test(deviceName.trim())
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <Sparkles size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Welcome to Dream.</h1>
+      <p className="text-theme-text-muted mb-8 leading-relaxed">
+        Let&apos;s get you set up in about a minute. First, give this device a name so it&apos;s easy to find on your network.
+      </p>
+
+      <label className="block mb-6">
+        <span className="text-sm text-theme-text-muted">Device name</span>
+        <input
+          type="text"
+          value={deviceName}
+          onChange={e => setDeviceName(e.target.value)}
+          autoFocus
+          maxLength={32}
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text focus:outline-none focus:border-theme-accent"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <span className="text-xs text-theme-text-muted mt-2 block">
+          Reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code> on your network. Letters, numbers, and dashes only.
+        </span>
+      </label>
+
+      <button
+        onClick={onNext}
+        disabled={!valid}
+        className="w-full flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+      >
+        Continue
+        <ChevronRight size={18} />
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — First user
+// ---------------------------------------------------------------------------
+
+function UserStep({ username, setUsername, onNext, onBack }) {
+  const trimmed = username.trim()
+  const valid = /^[A-Za-z0-9._-]{1,64}$/.test(trimmed)
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <User size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Who&apos;s the first user?</h1>
+      <p className="text-theme-text-muted mb-8 leading-relaxed">
+        We&apos;ll generate a magic link for them at the end. They scan it once and they&apos;re in.
+      </p>
+
+      <label className="block mb-6">
+        <span className="text-sm text-theme-text-muted">Username</span>
+        <input
+          type="text"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          autoFocus
+          maxLength={64}
+          placeholder="alice"
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text focus:outline-none focus:border-theme-accent"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <span className="text-xs text-theme-text-muted mt-2 block">
+          Open WebUI will display this name when they land on chat.
+        </span>
+      </label>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onNext}
+          disabled={!valid}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          Continue
+          <ChevronRight size={18} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — Stack picker
+// ---------------------------------------------------------------------------
+
+function StackStep({ stack, setStack, onNext, onBack }) {
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <Layers size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Pick your stack.</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        You can change this later. Start small if you want and add things as you go.
+      </p>
+
+      <div className="space-y-3 mb-8">
+        {STACK_OPTIONS.map(opt => {
+          const Icon = opt.Icon
+          const selected = stack === opt.id
+          return (
+            <button
+              key={opt.id}
+              onClick={() => setStack(opt.id)}
+              className={`w-full text-left p-4 rounded-xl border-2 transition-colors flex gap-4 ${
+                selected
+                  ? 'border-theme-accent bg-theme-accent/10'
+                  : 'border-theme-border bg-theme-card hover:border-theme-text-muted'
+              }`}
+            >
+              <div className={`w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0 ${
+                selected ? 'bg-theme-accent text-white' : 'bg-theme-border text-theme-text-muted'
+              }`}>
+                <Icon size={24} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-theme-text">{opt.title}</span>
+                  {selected && <Check size={18} className="text-theme-accent flex-shrink-0" />}
+                </div>
+                <p className="text-sm text-theme-text-muted mt-1">{opt.blurb}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onNext}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 transition-opacity"
+        >
+          Continue
+          <ChevronRight size={18} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — Confirm & finish
+// ---------------------------------------------------------------------------
+
+function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing, error }) {
+  const stackTitle = STACK_OPTIONS.find(s => s.id === stack)?.title || stack
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-theme-text mb-6">Ready?</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        Tap Finish and we&apos;ll generate the first invite. Bring it up on a phone or share the QR.
+      </p>
+
+      <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
+        <Row label="Device name" value={deviceName.trim() || 'dream'} hint={`.local on your network`} />
+        <Row label="First user" value={username.trim()} />
+        <Row label="Stack" value={stackTitle} />
+      </dl>
+
+      {error && (
+        <div className="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm flex items-start gap-2">
+          <AlertCircle size={18} className="flex-shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          disabled={finishing}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl disabled:opacity-50"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onFinish}
+          disabled={finishing}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          {finishing && <Loader2 size={18} className="animate-spin" />}
+          {finishing ? 'Finishing…' : 'Finish'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Row({ label, value, hint }) {
+  return (
+    <div className="px-4 py-3 flex items-center justify-between gap-4">
+      <span className="text-sm text-theme-text-muted">{label}</span>
+      <span className="text-theme-text font-medium text-right">
+        {value}
+        {hint && <span className="text-xs text-theme-text-muted block font-normal">{hint}</span>}
+      </span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Done — show generated invite
+// ---------------------------------------------------------------------------
+
+function DoneScreen({ invite, onDone }) {
+  const [copied, setCopied] = useState(false)
+  const [qrDataUrl, setQrDataUrl] = useState(null)
+  const [qrError, setQrError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const loadQr = async () => {
+      try {
+        const resp = await fetch(
+          `/api/auth/magic-link/qr?url=${encodeURIComponent(invite.url)}`,
+        )
+        if (!resp.ok) {
+          setQrError('QR generation unavailable on the server.')
+          return
+        }
+        const data = await resp.json()
+        if (!cancelled) setQrDataUrl(data.data_url)
+      } catch (err) {
+        if (!cancelled) setQrError(err.message)
+      }
+    }
+    loadQr()
+    return () => { cancelled = true }
+  }, [invite.url])
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(invite.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback: a visible input would let the user select manually.
+    }
+  }
+
+  const share = async () => {
+    if (!navigator.share) {
+      copy()
+      return
+    }
+    try {
+      await navigator.share({
+        title: `Dream Server invite for ${invite.target_username}`,
+        text: 'Tap to open Dream Server',
+        url: invite.url,
+      })
+    } catch {
+      // User cancelled.
+    }
+  }
+
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-green-500/15 text-green-400 flex items-center justify-center mb-6">
+        <Check size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">You&apos;re set.</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        Here&apos;s the magic link for <strong className="text-theme-text">{invite.target_username}</strong>.
+        They scan or tap it to land straight in chat.
+      </p>
+
+      {qrDataUrl ? (
+        <div className="bg-white p-4 rounded-xl flex justify-center mb-6">
+          <img src={qrDataUrl} alt="QR code for invite link" className="w-56 h-56" />
+        </div>
+      ) : (
+        <div className="bg-theme-card border border-theme-border rounded-xl p-8 flex flex-col items-center justify-center mb-6 min-h-56">
+          <QrCode size={48} className="text-theme-text-muted mb-2" />
+          <p className="text-xs text-theme-text-muted text-center">
+            {qrError || 'Generating QR…'}
+          </p>
+        </div>
+      )}
+
+      <div className="flex gap-2 mb-6">
+        <input
+          readOnly
+          value={invite.url}
+          onFocus={e => e.target.select()}
+          className="flex-1 bg-theme-card border border-theme-border rounded-lg px-3 py-2 text-xs font-mono text-theme-text"
+        />
+        <button
+          onClick={copy}
+          className="flex items-center gap-1 px-3 py-2 bg-theme-card border border-theme-border rounded-lg text-theme-text hover:bg-theme-surface-hover text-sm"
+        >
+          {copied ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}
+        </button>
+      </div>
+
+      <div className="flex gap-3">
+        {typeof navigator !== 'undefined' && navigator.share && (
+          <button
+            onClick={share}
+            className="flex-1 flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 rounded-xl"
+          >
+            <Share2 size={18} />
+            Share
+          </button>
+        )}
+        <button
+          onClick={onDone}
+          className="flex-1 bg-theme-accent text-white py-4 rounded-xl font-medium hover:opacity-90 transition-opacity"
+        >
+          Open dashboard
+        </button>
+      </div>
+
+      <p className="text-xs text-theme-text-muted mt-6 text-center">
+        Need more invites later? They live under <strong>Invites</strong> in the sidebar.
+      </p>
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -95,7 +95,13 @@ export default function FirstBoot({ onComplete }) {
   // the network handoff happens after the magic-link is generated (and
   // shown to the user, who needs to save it before connectivity drops).
   const [homeSsid, setHomeSsid] = useState(initial.homeSsid || '')
-  const [homePassword, setHomePassword] = useState(initial.homePassword || '')
+  // Home Wi-Fi password is intentionally NOT initialized from saved progress
+  // and NOT persisted (see writeProgress below). Keeping a plaintext WPA
+  // password in localStorage indefinitely is bad posture — if the user
+  // abandons the wizard or refreshes, the password should not survive in
+  // browser storage. Trade-off: a refresh mid-wizard requires re-typing the
+  // password, but the device name / SSID / username / stack DO survive.
+  const [homePassword, setHomePassword] = useState('')
   const [finishing, setFinishing] = useState(false)
   const [finishError, setFinishError] = useState(null)
   const [invite, setInvite] = useState(null)
@@ -116,9 +122,12 @@ export default function FirstBoot({ onComplete }) {
   const totalSteps = inApMode ? TOTAL_STEPS_AP : TOTAL_STEPS_NORMAL
 
   // Persist progress whenever the user moves forward.
+  // Note: homePassword is deliberately omitted from the persisted shape.
+  // It lives in component state only — a refresh forces a re-entry rather
+  // than leaving a plaintext WPA password in localStorage indefinitely.
   useEffect(() => {
-    writeProgress({ step, deviceName, username, stack, homeSsid, homePassword })
-  }, [step, deviceName, username, stack, homeSsid, homePassword])
+    writeProgress({ step, deviceName, username, stack, homeSsid })
+  }, [step, deviceName, username, stack, homeSsid])
 
   const next = () => setStep(s => Math.min(s + 1, totalSteps))
   const prev = () => setStep(s => Math.max(s - 1, 1))
@@ -146,29 +155,67 @@ export default function FirstBoot({ onComplete }) {
       }
       const inviteData = await genResp.json()
 
-      // Flip the server-side sentinel so this device is "configured".
-      await fetch('/api/setup/complete', { method: 'POST' })
+      // Pre-fetch the QR before triggering handoff. Otherwise DoneScreen
+      // mounts AFTER the host-agent's 3-second sleep starts ticking, and
+      // its useEffect's QR fetch can race against AP teardown. Pre-fetched,
+      // the QR is in invite.qr_data_url and renders synchronously when
+      // DoneScreen mounts — the user sees it BEFORE network handoff begins,
+      // with time to save the image to their phone.
+      let qrDataUrl = null
+      try {
+        const qrResp = await fetch(
+          `/api/auth/magic-link/qr?url=${encodeURIComponent(inviteData.url)}`,
+        )
+        if (qrResp.ok) {
+          const qrJson = await qrResp.json()
+          qrDataUrl = qrJson.data_url
+        }
+        // If QR fetch fails (503 — qrcode lib missing), DoneScreen falls
+        // back to its placeholder + URL/copy. We don't fail the wizard
+        // for that — the URL and Copy button still work.
+      } catch {
+        // Network error during QR fetch — same fallback path.
+      }
 
-      // AP-mode only: trigger the home-WiFi handoff. The host-agent does
-      // this on a background thread and returns 202 immediately; the wizard
-      // shell will lose connectivity a few seconds later when the AP tears
-      // down. The Done screen tells the user what to expect.
+      // AP-mode only: trigger the home-WiFi handoff BEFORE flipping the
+      // setup-complete sentinel. The host-agent does the switch on a
+      // background thread and returns 202 (scheduled) immediately. We
+      // check the response.ok so a 4xx/5xx (validation failure, missing
+      // nmcli, unreachable host-agent) doesn't silently flip first-boot
+      // off and strand the user on the setup AP.
+      //
+      // If handoff fails: error surfaces to the user, sentinel stays
+      // unflipped, the wizard reappears on next visit, and the user can
+      // retry with corrected credentials.
       let handoffStarted = false
       if (inApMode && homeSsid) {
+        let handoffResp
         try {
-          await fetch('/api/setup/wifi-handoff', {
+          handoffResp = await fetch('/api/setup/wifi-handoff', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ ssid: homeSsid, password: homePassword }),
           })
-          handoffStarted = true
-        } catch {
-          // Handoff scheduling failure is non-fatal — show the invite anyway.
-          // The user can connect manually from their existing network.
+        } catch (err) {
+          throw new Error(`Could not reach the network handoff endpoint: ${err.message}`)
         }
+        if (!handoffResp.ok) {
+          const body = await handoffResp.json().catch(() => ({}))
+          throw new Error(
+            body.detail
+              ? `Wi-Fi handoff was rejected: ${body.detail}`
+              : `Wi-Fi handoff failed: ${handoffResp.status}`
+          )
+        }
+        handoffStarted = true
       }
 
-      setInvite({ ...inviteData, handoffStarted })
+      // Only flip the sentinel AFTER the handoff was accepted (or skipped
+      // because we're not in AP mode). Otherwise a failed handoff would
+      // leave first-boot=false plus the user still on the setup AP.
+      await fetch('/api/setup/complete', { method: 'POST' })
+
+      setInvite({ ...inviteData, qrDataUrl, handoffStarted })
       clearProgress()
       // Stay on the success screen until the user taps "Open chat" or "Done"
       // — calling onComplete() immediately would route them away before they
@@ -602,10 +649,16 @@ function Row({ label, value, hint }) {
 
 function DoneScreen({ invite, onDone, deviceName }) {
   const [copied, setCopied] = useState(false)
-  const [qrDataUrl, setQrDataUrl] = useState(null)
+  // In AP-mode, finish() pre-fetches the QR before triggering the network
+  // handoff and passes it through as invite.qrDataUrl. That way the user
+  // sees the QR immediately on mount — no race against the 3-second AP
+  // teardown window. In non-AP-mode we fall back to an on-demand fetch.
+  const [qrDataUrl, setQrDataUrl] = useState(invite.qrDataUrl || null)
   const [qrError, setQrError] = useState(null)
 
   useEffect(() => {
+    // Skip the on-demand fetch when finish() already pre-fetched.
+    if (invite.qrDataUrl) return
     let cancelled = false
     const loadQr = async () => {
       try {
@@ -624,7 +677,7 @@ function DoneScreen({ invite, onDone, deviceName }) {
     }
     loadQr()
     return () => { cancelled = true }
-  }, [invite.url])
+  }, [invite.url, invite.qrDataUrl])
 
   const copy = async () => {
     try {

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -5,11 +5,20 @@
 // large tap targets, big text — the user is most likely on a
 // phone scanning the device's setup link.
 //
-// 4 screens:
+// Screens (non-AP-mode):
 //   1. Welcome — name your device (DREAM_DEVICE_NAME)
 //   2. First user — username for the initial magic-link invite
 //   3. Pick your stack — chat-only / chat+agents / everything
-//   4. Done — generate magic-link, show QR
+//   4. Confirm + Finish → Done (magic-link QR)
+//
+// Screens when in AP mode (PR-10) — an extra step prepended:
+//   0. WiFi handoff — collect home WiFi credentials (text inputs, no scan
+//      since the AP interface is busy hosting). Applied at the END.
+//   1-4 as above.
+//   On Finish: generates the magic-link, flips the sentinel, AND triggers
+//   the WiFi handoff via /api/setup/wifi-handoff. The Done screen shows
+//   a "switching networks" notice — the user's phone will drop the AP
+//   and rejoin its home network, then can scan the QR there.
 //
 // Progress is mirrored to localStorage so a phone refresh doesn't
 // lose state mid-wizard. The server-side flip happens only on the
@@ -19,7 +28,7 @@ import { useEffect, useMemo, useState } from 'react'
 import {
   Sparkles, User, Layers, Check, ChevronRight, ChevronLeft,
   MessageSquare, Workflow, Boxes, Loader2, AlertCircle, Copy,
-  QrCode, Share2,
+  QrCode, Share2, Wifi, ArrowRightLeft,
 } from 'lucide-react'
 
 const PROGRESS_KEY = 'dream-firstboot-progress'
@@ -45,7 +54,10 @@ const STACK_OPTIONS = [
   },
 ]
 
-const TOTAL_STEPS = 4
+// Step counts vary by AP-mode flag. The WiFi step is step 0 (prepended)
+// when present, then welcome / user / stack / confirm follow as 1-4.
+const TOTAL_STEPS_NORMAL = 4
+const TOTAL_STEPS_AP = 5
 
 function readProgress() {
   try {
@@ -78,16 +90,37 @@ export default function FirstBoot({ onComplete }) {
   const [deviceName, setDeviceName] = useState(initial.deviceName || 'dream')
   const [username, setUsername] = useState(initial.username || '')
   const [stack, setStack] = useState(initial.stack || 'chat')
+  // Home WiFi credentials — only collected when in AP mode. We collect them
+  // BEFORE the rest of the wizard runs and APPLY them at the very end so
+  // the network handoff happens after the magic-link is generated (and
+  // shown to the user, who needs to save it before connectivity drops).
+  const [homeSsid, setHomeSsid] = useState(initial.homeSsid || '')
+  const [homePassword, setHomePassword] = useState(initial.homePassword || '')
   const [finishing, setFinishing] = useState(false)
   const [finishError, setFinishError] = useState(null)
   const [invite, setInvite] = useState(null)
+  const [apMode, setApMode] = useState(null)  // null = unknown, {} = inactive, {...} = active
+
+  // Detect whether the wizard is being served by a device that's hosting
+  // its own setup AP. If so, we add a WiFi-handoff step at the start.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/setup/ap-mode-status')
+      .then(r => r.ok ? r.json() : { status: 'inactive' })
+      .then(data => { if (!cancelled) setApMode(data) })
+      .catch(() => { if (!cancelled) setApMode({ status: 'inactive' }) })
+    return () => { cancelled = true }
+  }, [])
+
+  const inApMode = apMode?.status === 'active'
+  const totalSteps = inApMode ? TOTAL_STEPS_AP : TOTAL_STEPS_NORMAL
 
   // Persist progress whenever the user moves forward.
   useEffect(() => {
-    writeProgress({ step, deviceName, username, stack })
-  }, [step, deviceName, username, stack])
+    writeProgress({ step, deviceName, username, stack, homeSsid, homePassword })
+  }, [step, deviceName, username, stack, homeSsid, homePassword])
 
-  const next = () => setStep(s => Math.min(s + 1, TOTAL_STEPS))
+  const next = () => setStep(s => Math.min(s + 1, totalSteps))
   const prev = () => setStep(s => Math.max(s - 1, 1))
 
   const finish = async () => {
@@ -116,7 +149,26 @@ export default function FirstBoot({ onComplete }) {
       // Flip the server-side sentinel so this device is "configured".
       await fetch('/api/setup/complete', { method: 'POST' })
 
-      setInvite(inviteData)
+      // AP-mode only: trigger the home-WiFi handoff. The host-agent does
+      // this on a background thread and returns 202 immediately; the wizard
+      // shell will lose connectivity a few seconds later when the AP tears
+      // down. The Done screen tells the user what to expect.
+      let handoffStarted = false
+      if (inApMode && homeSsid) {
+        try {
+          await fetch('/api/setup/wifi-handoff', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ssid: homeSsid, password: homePassword }),
+          })
+          handoffStarted = true
+        } catch {
+          // Handoff scheduling failure is non-fatal — show the invite anyway.
+          // The user can connect manually from their existing network.
+        }
+      }
+
+      setInvite({ ...inviteData, handoffStarted })
       clearProgress()
       // Stay on the success screen until the user taps "Open chat" or "Done"
       // — calling onComplete() immediately would route them away before they
@@ -132,27 +184,48 @@ export default function FirstBoot({ onComplete }) {
     onComplete?.()
   }
 
+  // Step mapping. When in AP mode, step 1 is the WiFi-handoff step and
+  // everything shifts by 1. When NOT in AP mode, step 1 is Welcome and
+  // there are 4 total steps.
+  const shift = inApMode ? 1 : 0
   return (
     <div className="min-h-screen bg-theme-bg flex flex-col">
       <header className="px-6 pt-8 pb-4 flex items-center justify-between">
         <div className="font-mono text-sm font-bold text-theme-accent tracking-widest">DREAM SERVER</div>
-        {!invite && <StepDots step={step} total={TOTAL_STEPS} />}
+        {!invite && <StepDots step={step} total={totalSteps} />}
       </header>
+
+      {inApMode && !invite && (
+        <div className="mx-6 mb-2 px-4 py-2 rounded-lg bg-theme-accent/15 text-theme-accent text-sm flex items-center gap-2">
+          <Wifi size={16} />
+          <span>You&apos;re on Dream&apos;s setup Wi-Fi. We&apos;ll switch you to your home network at the end.</span>
+        </div>
+      )}
 
       <main className="flex-1 flex items-stretch px-6 pb-8">
         <div className="w-full max-w-md mx-auto flex flex-col justify-center">
           {invite ? (
-            <DoneScreen invite={invite} onDone={handleDone} />
+            <DoneScreen invite={invite} onDone={handleDone} deviceName={deviceName.trim() || 'dream'} />
           ) : (
             <>
-              {step === 1 && (
+              {inApMode && step === 1 && (
+                <WifiStep
+                  homeSsid={homeSsid}
+                  setHomeSsid={setHomeSsid}
+                  homePassword={homePassword}
+                  setHomePassword={setHomePassword}
+                  onNext={next}
+                />
+              )}
+              {step === 1 + shift && (
                 <WelcomeStep
                   deviceName={deviceName}
                   setDeviceName={setDeviceName}
                   onNext={next}
+                  onBack={inApMode ? prev : undefined}
                 />
               )}
-              {step === 2 && (
+              {step === 2 + shift && (
                 <UserStep
                   username={username}
                   setUsername={setUsername}
@@ -160,7 +233,7 @@ export default function FirstBoot({ onComplete }) {
                   onBack={prev}
                 />
               )}
-              {step === 3 && (
+              {step === 3 + shift && (
                 <StackStep
                   stack={stack}
                   setStack={setStack}
@@ -168,11 +241,13 @@ export default function FirstBoot({ onComplete }) {
                   onBack={prev}
                 />
               )}
-              {step === 4 && (
+              {step === 4 + shift && (
                 <ConfirmStep
                   deviceName={deviceName}
                   username={username}
                   stack={stack}
+                  inApMode={inApMode}
+                  homeSsid={homeSsid}
                   onBack={prev}
                   onFinish={finish}
                   finishing={finishing}
@@ -183,6 +258,67 @@ export default function FirstBoot({ onComplete }) {
           )}
         </div>
       </main>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step (AP-mode only) — collect home WiFi credentials
+// ---------------------------------------------------------------------------
+
+function WifiStep({ homeSsid, setHomeSsid, homePassword, setHomePassword, onNext }) {
+  const valid = homeSsid.trim().length >= 1 && homeSsid.trim().length <= 32
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <Wifi size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Your home Wi-Fi.</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        Tell us which network this device should join after setup. We&apos;ll switch over at the very end —
+        your phone will drop the setup Wi-Fi and reconnect to {homeSsid.trim() || 'your home network'} too.
+      </p>
+
+      <label className="block mb-4">
+        <span className="text-sm text-theme-text-muted">Network name (SSID)</span>
+        <input
+          type="text"
+          value={homeSsid}
+          onChange={e => setHomeSsid(e.target.value)}
+          autoFocus
+          maxLength={32}
+          placeholder="MyHomeWiFi"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text focus:outline-none focus:border-theme-accent"
+        />
+      </label>
+
+      <label className="block mb-6">
+        <span className="text-sm text-theme-text-muted">Password</span>
+        <input
+          type="password"
+          value={homePassword}
+          onChange={e => setHomePassword(e.target.value)}
+          maxLength={63}
+          placeholder="(leave blank for open networks)"
+          autoComplete="new-password"
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text font-mono focus:outline-none focus:border-theme-accent"
+        />
+        <span className="text-xs text-theme-text-muted mt-2 block">
+          Stored only long enough to join. Never logged.
+        </span>
+      </label>
+
+      <button
+        onClick={onNext}
+        disabled={!valid}
+        className="w-full flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+      >
+        Continue
+        <ChevronRight size={18} />
+      </button>
     </div>
   )
 }
@@ -215,7 +351,7 @@ function StepDots({ step, total }) {
 // Step 1 — Welcome / device name
 // ---------------------------------------------------------------------------
 
-function WelcomeStep({ deviceName, setDeviceName, onNext }) {
+function WelcomeStep({ deviceName, setDeviceName, onNext, onBack }) {
   const valid = /^[a-z0-9-]{1,32}$/i.test(deviceName.trim())
   return (
     <div>
@@ -245,14 +381,24 @@ function WelcomeStep({ deviceName, setDeviceName, onNext }) {
         </span>
       </label>
 
-      <button
-        onClick={onNext}
-        disabled={!valid}
-        className="w-full flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
-      >
-        Continue
-        <ChevronRight size={18} />
-      </button>
+      <div className="flex gap-3">
+        {onBack && (
+          <button
+            onClick={onBack}
+            className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl"
+          >
+            <ChevronLeft size={18} />
+          </button>
+        )}
+        <button
+          onClick={onNext}
+          disabled={!valid}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          Continue
+          <ChevronRight size={18} />
+        </button>
+      </div>
     </div>
   )
 }
@@ -382,20 +528,33 @@ function StackStep({ stack, setStack, onNext, onBack }) {
 // Step 4 — Confirm & finish
 // ---------------------------------------------------------------------------
 
-function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing, error }) {
+function ConfirmStep({ deviceName, username, stack, inApMode, homeSsid, onBack, onFinish, finishing, error }) {
   const stackTitle = STACK_OPTIONS.find(s => s.id === stack)?.title || stack
   return (
     <div>
       <h1 className="text-3xl font-bold text-theme-text mb-6">Ready?</h1>
       <p className="text-theme-text-muted mb-6 leading-relaxed">
-        Tap Finish and we&apos;ll generate the first invite. Bring it up on a phone or share the QR.
+        Tap Finish and we&apos;ll generate the first invite.
+        {inApMode && ' Right after, this device drops the setup Wi-Fi and joins your home network.'}
       </p>
 
-      <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
+      <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-6">
         <Row label="Device name" value={deviceName.trim() || 'dream'} hint={`.local on your network`} />
         <Row label="First user" value={username.trim()} />
         <Row label="Stack" value={stackTitle} />
+        {inApMode && <Row label="Home Wi-Fi" value={homeSsid.trim()} />}
       </dl>
+
+      {inApMode && (
+        <div className="mb-6 p-4 bg-theme-accent/10 border border-theme-accent/30 rounded-xl text-theme-text text-sm flex items-start gap-2">
+          <ArrowRightLeft size={18} className="flex-shrink-0 mt-0.5 text-theme-accent" />
+          <span>
+            <strong>Heads up — your phone is about to lose this connection.</strong> When the AP shuts
+            down, your phone will reconnect to {homeSsid.trim() || 'your home network'} automatically.
+            From there, scan the QR we&apos;re about to show you to open chat.
+          </span>
+        </div>
+      )}
 
       {error && (
         <div className="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm flex items-start gap-2">
@@ -441,7 +600,7 @@ function Row({ label, value, hint }) {
 // Done — show generated invite
 // ---------------------------------------------------------------------------
 
-function DoneScreen({ invite, onDone }) {
+function DoneScreen({ invite, onDone, deviceName }) {
   const [copied, setCopied] = useState(false)
   const [qrDataUrl, setQrDataUrl] = useState(null)
   const [qrError, setQrError] = useState(null)
@@ -504,6 +663,21 @@ function DoneScreen({ invite, onDone }) {
         They scan or tap it to land straight in chat.
       </p>
 
+      {invite.handoffStarted && (
+        <div className="mb-6 p-4 bg-theme-accent/10 border border-theme-accent/30 rounded-xl text-theme-text text-sm">
+          <div className="flex items-start gap-2">
+            <ArrowRightLeft size={18} className="flex-shrink-0 mt-0.5 text-theme-accent" />
+            <div>
+              <strong className="block mb-1">Switching networks now.</strong>
+              The setup Wi-Fi is shutting down — your phone will reconnect to your home network in a few seconds.
+              Save the QR (long-press → Save Image, or use Share / Copy) before that happens.
+              When you&apos;re back on your home Wi-Fi, scan the QR or open{' '}
+              <code className="text-theme-accent">{deviceName}.local</code>.
+            </div>
+          </div>
+        </div>
+      )}
+
       {qrDataUrl ? (
         <div className="bg-white p-4 rounded-xl flex justify-center mb-6">
           <img src={qrDataUrl} alt="QR code for invite link" className="w-56 h-56" />
@@ -546,7 +720,7 @@ function DoneScreen({ invite, onDone }) {
           onClick={onDone}
           className="flex-1 bg-theme-accent text-white py-4 rounded-xl font-medium hover:opacity-90 transition-opacity"
         >
-          Open dashboard
+          {invite.handoffStarted ? 'Done' : 'Open dashboard'}
         </button>
       </div>
 


### PR DESCRIPTION
# PR-11: AP-mode awareness + WiFi handoff in the wizard

**Branch:** `feat/ap-mode-wizard` (stacked on `feat/first-boot-wizard`)
**Phase:** 3 of 4 (Captive portal / AP mode)
**Effort:** Medium — 4 files (1 new, 3 modified), 642 insertions / 29 deletions
**Depends on (in merge order):**
- PR-7 (`feat/first-boot-wizard`) — this branch sits on top of it
- PR-8 (`feat/network-config-backend`) — shares helpers and conventions in `routers/setup.py`
- PR-10 (`feat/ap-mode`) — provides the `dream-ap-mode` service and `/v1/ap-mode/status` endpoint

## Summary

The other half of PR-10. With this PR the end-to-end "out of box" flow works:

```
Recipient takes device out of box
  → scans QR-A (from PR-9 setup card)
  → phone joins "Dream-Setup-XXXX" AP (PR-10)
  → any URL opens the wizard (captive portal)
  → wizard detects AP mode + collects home WiFi creds  ← THIS PR
  → user names device, picks user, picks stack
  → wizard generates magic-link QR
  → user saves the QR
  → wizard tears down AP, joins home WiFi               ← THIS PR
  → phone auto-reconnects to home WiFi
  → user scans saved QR → opens chat on home network
```

## API surface

| Method | Path | Auth | Purpose |
|---|---|---|---|
| GET  | `/api/setup/ap-mode-status` | Bearer | Proxy to host-agent `/v1/ap-mode/status` |
| POST | `/api/setup/wifi-handoff` | Bearer | Proxy to host-agent `/v1/network/wifi-handoff` — bundled disable-AP + nmcli connect |
| POST | `/v1/network/wifi-handoff` (host-agent, new) | Bearer | Validates creds, returns 202, runs background worker |

## Files

| File | Lines | What |
|---|---|---|
| `bin/dream-host-agent.py` (+128) | | New `/v1/network/wifi-handoff` endpoint and `_wifi_handoff_worker` + `_restart_ap_for_recovery` helpers. Worker sequence: sleep 3s → `systemctl stop dream-ap-mode` → sleep 2s → `nmcli connect`. On failure, restarts AP so the user can retry. |
| `extensions/services/dashboard-api/routers/setup.py` (+89/−3) | | Two new proxy endpoints + `_proxy_agent` helper that never logs request bodies (Wi-Fi passwords stay out of logs). |
| `extensions/services/dashboard/src/pages/FirstBoot.jsx` (+170/−25) | | Detects AP mode on mount; when active, prepends a WiFi step and triggers handoff at Finish. New `WifiStep` component; updated `ConfirmStep` (summary + heads-up notice) and `DoneScreen` (switching-networks callout). |
| `extensions/services/dashboard-api/tests/test_setup_ap_mode.py` (new, 152) | | 9 tests: auth, happy paths, validation (oversized SSID/password, control chars), error translation (501 unsupported platform, 503 agent unreachable). |

## Design choices

### Why the handoff is a deliberate exception to PR-10's "no AP toggle from HTTP"

PR-10 was strict: no enable/disable endpoints, only `/v1/ap-mode/status`. The reasoning: toggling an AP from HTTP is a great way to lock yourself out of a remote box.

`wifi-handoff` is the carve-out, and it's safe because:

1. **Direction is one-way disable.** The endpoint tears down the AP and joins a real network. Accidentally hitting it puts the device on its home network — exactly where the device was supposed to be all along.
2. **Bundled with wizard completion.** It's not a general "stop AP" endpoint. The wizard's Finish action calls it as the final step.
3. **Auto-recovery on failure.** If the nmcli connect fails, the worker restarts `dream-ap-mode` so the user lands back on the setup AP and can retry.

The corresponding `enable` direction stays off-limits — that's the dangerous case.

### Why the worker is async (background thread) instead of synchronous

The HTTP response has to flush before the AP tears down — otherwise the wizard never sees confirmation. The worker:

1. Sleeps 3s after thread start (HTTP response time)
2. Tears down AP
3. Sleeps 2s (NM reclaims interface)
4. Runs nmcli connect
5. Writes result to `/run/dream-ap-mode/handoff-status.json`

The wizard's user sees the Done screen with the "switching networks" notice *before* the AP dies. From their perspective: tap Finish → see QR + instructions → save QR → phone reconnects to home network within seconds.

### Why no live WiFi scan in the wizard's WiFi step

The AP interface (`wlan0`) is busy hosting `hostapd`. Running `nmcli wifi list` against it returns nothing useful. The wizard collects SSID + password via plain text inputs. The user knows their own network name; the friction is acceptable for a once-per-device flow. A future PR could surface WiFi scan when the device has TWO wireless interfaces (rare on small Linux boxes today).

### Why the user has to "save the QR" before networks switch

The QR is rendered on a page served by the AP. When the AP tears down, the page becomes unreachable. The Done screen explicitly tells the user to save/share/copy the QR before the network switches. Modern iOS / Android save-image gestures all work fine on the rendered `<img>`.

## Step layout

| Step | Non-AP mode | AP mode |
|---|---|---|
| 1 | Welcome (device name) | **Home Wi-Fi (NEW)** |
| 2 | First user | Welcome (device name) |
| 3 | Stack picker | First user |
| 4 | Confirm + Finish | Stack picker |
| 5 | — | Confirm + Finish |

`StepDots` shows the right count based on `useFirstRun()` + `/api/setup/ap-mode-status`.

## Test plan

**Automated:**
- [x] 9 new tests in `test_setup_ap_mode.py` — all pass
- [x] 33 setup-router tests (9 new + 24 existing) — all pass
- [x] Dashboard build clean; FirstBoot lazy chunk now 17.1 KB / 4.6 KB gzipped (was 12.5 KB; +4.6 KB for the WiFi step)
- [x] All 62 dashboard vitest tests pass; FirstBoot stays mocked in App.test.jsx
- [x] Lint clean (0 errors; same 5 pre-existing warnings)
- [x] `python -m py_compile bin/dream-host-agent.py` passes

**Manual (requires real Linux hardware + the dream-ap-mode service running):**

- [ ] AP mode active, navigate to dashboard
  - [ ] Wizard mounts (firstRun=true)
  - [ ] Detects AP mode → shows banner + WiFi step first
  - [ ] StepDots shows 5 dots, not 4
- [ ] Complete the wizard with bogus home credentials
  - [ ] Handoff fires, but nmcli connect fails
  - [ ] Background worker writes handoff-status.json with `status: error`
  - [ ] AP restarts; user can re-open the wizard and retry
- [ ] Complete with correct home credentials
  - [ ] Handoff succeeds; AP tears down; device joins home network
  - [ ] Phone reconnects to home WiFi automatically
  - [ ] Scanning the saved QR on the home network opens chat at <device>.local

## Caveats

- **Wifi-handoff worker runs as root** (same as the rest of the host-agent's privileged ops). That's why it can `systemctl stop dream-ap-mode` + `nmcli connect` — no sudo trickery, just the agent's normal privilege level.
- **Handoff is one-shot per wizard run.** No retry inside the wizard. If creds are wrong, the worker restarts the AP and the user comes back to the wizard fresh.
- **Limited error surface to the user.** The wizard fires the handoff and shows "switching networks now"; it doesn't poll for the result. The user finds out by either (a) reaching the device on their home network shortly, or (b) seeing the AP come back up and the wizard reload. A future PR could expose handoff-status.json via a polling endpoint and show a richer waiting screen.

## What's NOT in this PR

- **Polling for handoff completion.** The wizard fires the handoff and moves on; it doesn't expose the result file. Acceptable for v1 because the user's connection drops anyway.
- **Wifi scan on the AP step.** wlan0 is busy. Multi-interface devices could scan with the second iface; deferred until that's a real configuration.
- **Custom DREAM_PUBLIC_URL handling.** The magic-link URL embedded in the QR uses whatever `DREAM_PUBLIC_URL`/`WEBUI_URL` is currently set to (likely the AP gateway IP at this point). After handoff that won't resolve from outside the AP. The user is told to navigate to `<device>.local` directly, which works via mDNS (PR-1). A nicer future PR could rewrite the magic-link URL host based on the device name.
- **A "factory reset" button** (mentioned in the plan). That's hardware-specific (long-press a physical button on a hardware unit) and lives in the image-build layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
