### PR TITLE
feat(tailscale): opt-in remote access via Tailscale mesh VPN

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -354,3 +354,17 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # HERMES_PROXY_PORT=9120                 # LAN entry — what users actually browse to
 # HERMES_PROXY_UPSTREAM=dream-hermes:9119  # Where the proxy forwards (internal DNS)
 # DREAM_AUTH_UPSTREAM=dream-dashboard-api:3002  # Where forward_auth verifies sessions
+
+# Tailscale (Remote Access)
+# ═══════════════════════════════════════════════════════════════════
+# Optional remote-access via Tailscale's mesh VPN. Generate an auth
+# key at https://login.tailscale.com/admin/settings/keys and paste
+# below. Once joined the device is reachable as <hostname>.<tailnet>.ts.net
+# from any other tailnet member, anywhere on the internet.
+#
+# TS_AUTHKEY is consumed exactly once on first join. After that the
+# tailscale daemon caches the node key in data/tailscale/, so you can
+# rotate or delete the auth key in the Tailscale admin.
+#
+# TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
+# TS_HOSTNAME=                         # Defaults to DREAM_DEVICE_NAME

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -360,7 +360,16 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # Optional remote-access via Tailscale's mesh VPN. Generate an auth
 # key at https://login.tailscale.com/admin/settings/keys and paste
 # below. Once joined the device is reachable as <hostname>.<tailnet>.ts.net
-# from any other tailnet member, anywhere on the internet.
+# from any other tailnet member.
+#
+# IMPORTANT: joining the tailnet alone isn't enough. For the device to
+# actually answer HTTP at <hostname>.tail-xxxxx.ts.net, the host has to
+# be listening for non-loopback traffic. That means:
+#   1. dream-proxy is enabled (Caddy fielding port 80 + routing /chat,
+#      /api/*, /auth/* to backends)
+#   2. BIND_ADDRESS=0.0.0.0 in this .env (loopback-only services don't
+#      accept tailnet packets even with network_mode: host)
+# See docs/TAILSCALE.md for the full prerequisites and architecture.
 #
 # TS_AUTHKEY is consumed exactly once on first join. After that the
 # tailscale daemon caches the node key in data/tailscale/, so you can

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -377,3 +377,4 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 #
 # TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
 # TS_HOSTNAME=                         # Defaults to DREAM_DEVICE_NAME
+# TS_EXTRA_ARGS=                       # Optional, e.g. --advertise-tags=tag:dream

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -760,6 +760,16 @@
       "type": "string",
       "description": "Where Caddy forward_auth sends its session-verify sub-request. Defaults to the in-network dashboard-api container; override if dashboard-api lives elsewhere.",
       "default": "dream-dashboard-api:3002"
+    },
+    "TS_AUTHKEY": {
+      "type": "string",
+      "description": "Tailscale auth key (tskey-auth-...). Generate at https://login.tailscale.com/admin/settings/keys. Consumed once on first join; the daemon caches the node key in data/tailscale/.",
+      "secret": true
+    },
+    "TS_HOSTNAME": {
+      "type": "string",
+      "description": "Hostname this device registers as on the Tailscale net. Defaults to DREAM_DEVICE_NAME. Reachable as <hostname>.<tailnet>.ts.net once joined.",
+      "pattern": "^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$"
     }
   }
 }

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -770,6 +770,10 @@
       "type": "string",
       "description": "Hostname this device registers as on the Tailscale net. Defaults to DREAM_DEVICE_NAME. Reachable as <hostname>.<tailnet>.ts.net once joined.",
       "pattern": "^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$"
+    },
+    "TS_EXTRA_ARGS": {
+      "type": "string",
+      "description": "Optional extra flags passed to `tailscale up`, such as --advertise-tags=tag:dream after your tailnet ACL defines and authorizes that tag."
     }
   }
 }

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -962,8 +962,93 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_network_wifi_scan()
         elif self.path == "/v1/network/status":
             self._handle_network_status()
+        elif self.path == "/v1/tailscale/status":
+            self._handle_tailscale_status()
         else:
             json_response(self, 404, {"error": "Not found"})
+
+    def _handle_tailscale_status(self):
+        """Return Tailscale daemon status by docker-exec'ing into the
+        dream-tailscale container.
+
+        Three outcome shapes:
+          1. Container running AND authenticated:
+             {running:true, authenticated:true, self:{...},
+              magic_dns_suffix:"tail-xxxxx.ts.net", ...}
+          2. Container running but not authenticated (auth key absent
+             or rejected):
+             {running:true, authenticated:false, reason:"..."}
+          3. Container not running:
+             {running:false}
+
+        We never return 5xx for "container not running" — that's a normal
+        state. 5xx is reserved for "the docker daemon itself broke."
+        """
+        if not check_auth(self):
+            return
+        try:
+            result = subprocess.run(
+                ["docker", "exec", "dream-tailscale",
+                 "tailscale", "status", "--json"],
+                capture_output=True, text=True, timeout=10,
+            )
+        except subprocess.TimeoutExpired:
+            json_response(self, 504, {"error": "docker exec timed out"})
+            return
+        except OSError as exc:
+            json_response(self, 500, {"error": f"docker exec failed: {exc}"})
+            return
+
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            lowered = stderr.lower()
+            # Container not running -> normal "not enabled yet" state.
+            if "no such container" in lowered or "is not running" in lowered:
+                json_response(self, 200, {"running": False})
+                return
+            # Container up but daemon not yet authed.
+            if "logged out" in lowered or "needs login" in lowered:
+                json_response(self, 200, {
+                    "running": True,
+                    "authenticated": False,
+                    "reason": "Tailscale is running but not yet authenticated. Set TS_AUTHKEY and restart.",
+                })
+                return
+            json_response(self, 200, {
+                "running": True,
+                "authenticated": False,
+                "error": stderr[:300] or "tailscale status returned non-zero",
+            })
+            return
+
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            json_response(self, 500, {"error": f"could not parse tailscale status: {exc}"})
+            return
+
+        # Distill the chunky `tailscale status --json` blob to what the
+        # dashboard actually needs.
+        self_node = payload.get("Self", {}) or {}
+        magic_dns = payload.get("MagicDNSSuffix") or ""
+        dns_name = self_node.get("DNSName", "").rstrip(".") or None
+        tailnet = payload.get("CurrentTailnet")
+        tailnet_name = (
+            tailnet.get("Name") if isinstance(tailnet, dict) else None
+        )
+        json_response(self, 200, {
+            "running": True,
+            "authenticated": payload.get("BackendState") == "Running",
+            "backend_state": payload.get("BackendState"),
+            "self": {
+                "hostname": self_node.get("HostName"),
+                "dns_name": dns_name,
+                "ips": self_node.get("TailscaleIPs", []),
+                "online": self_node.get("Online", False),
+            },
+            "magic_dns_suffix": magic_dns,
+            "tailnet_name": tailnet_name,
+        })
 
     def _handle_service_stats(self):
         """Return CPU/memory stats for all Dream-managed containers."""

--- a/dream-server/docs/TAILSCALE.md
+++ b/dream-server/docs/TAILSCALE.md
@@ -18,7 +18,7 @@ Tradeoff: every device that needs to reach Dream Server has to install the Tails
 ```
         ┌────────── Your phone (away from home) ──────────┐
         │  Tailscale client running                       │
-        │  browser opens https://dream.tail-xxxxx.ts.net  │
+        │  browser opens http://dream.tail-xxxxx.ts.net   │
         └──────────────────────┬──────────────────────────┘
                                │
                                │  encrypted WireGuard
@@ -33,14 +33,25 @@ Tradeoff: every device that needs to reach Dream Server has to install the Tails
         │     dream-tailscale container in host-net mode)│
         │                                                │
         │  Container's tailscaled exposes the HOST'S     │
-        │  network namespace to the tailnet — so the     │
-        │  dashboard on :3001 and chat on :3000 are      │
-        │  reachable on dream.tail-xxxxx.ts.net:3001     │
-        │  and :3000 with zero extra config.             │
+        │  network namespace to the tailnet. The         │
+        │  reachable surface is whatever the host        │
+        │  itself is listening on. With dream-proxy on   │
+        │  port 80 and BIND_ADDRESS=0.0.0.0, that's the  │
+        │  same /chat, /api/*, /auth/* paths users see   │
+        │  on the LAN.                                   │
         └────────────────────────────────────────────────┘
 ```
 
-The container uses `network_mode: host` so the Tailscale daemon and the dashboard share the same network namespace. That's what makes the dashboard's normal ports (`3000`, `3001`, `3002`) automatically reachable over the tailnet.
+The container uses `network_mode: host` so the Tailscale daemon and the dashboard share the same network namespace. **What that buys you depends entirely on what the host is binding to** (see Prerequisites below).
+
+## Prerequisites for tailnet reachability
+
+Joining the tailnet only gets the device a `100.x.y.z` IP and a `dream.tail-xxxxx.ts.net` DNS name. For an HTTP request from another tailnet member to actually load chat, the host has to be listening on the right port and address:
+
+1. **`dream-proxy` is enabled.** It listens on port 80 and routes `/chat`, `/api/*`, `/auth/*` to the right backend. With it, tailnet clients browse to `http://dream.tail-xxxxx.ts.net` (no port). Without it, only the per-service ports work (`:3000`, `:3001`, `:3002`) and only if those are LAN-bound.
+2. **`BIND_ADDRESS=0.0.0.0` in `.env`.** The default `127.0.0.1` means the proxy / dashboard / chat only accept loopback connections — even though tailscaled is in the same namespace, an incoming tailnet packet looks like any other LAN packet, not loopback. Set `BIND_ADDRESS=0.0.0.0` so the host's listen sockets accept those connections.
+
+If you ship a fresh install with Tailscale enabled but neither of the above, `tailscale status` will show the device authed but `http://dream.tail-xxxxx.ts.net` will hang or refuse. The dashboard's Tailscale page surfaces both conditions when they're missing.
 
 ## Setup
 
@@ -97,9 +108,14 @@ curl -H "Authorization: Bearer ${DASHBOARD_API_KEY}" \
 From any other device on your tailnet:
 
 ```bash
-# After installing the Tailscale client and signing into the same tailnet:
-curl http://dream.tail-abcde.ts.net:3001
-# Or from a browser: http://dream.tail-abcde.ts.net:3001
+# After installing the Tailscale client and signing into the same tailnet,
+# AND with dream-proxy enabled + BIND_ADDRESS=0.0.0.0 on the device:
+curl http://dream.tail-abcde.ts.net/api/status
+# Or from a browser: http://dream.tail-abcde.ts.net (lands at /chat via the proxy)
+
+# To bypass the proxy and hit a specific service directly, use its port
+# (only works when BIND_ADDRESS=0.0.0.0):
+curl http://dream.tail-abcde.ts.net:3001  # dashboard direct
 ```
 
 ## After the auth key has done its job

--- a/dream-server/docs/TAILSCALE.md
+++ b/dream-server/docs/TAILSCALE.md
@@ -1,6 +1,6 @@
 # Tailscale (remote access)
 
-Dream Server includes an optional Tailscale extension that puts the device on your Tailscale net (the mesh VPN at `tailscale.com`). Once joined, the dashboard and chat are reachable from any other tailnet member — your laptop, your phone, a friend's machine — anywhere with internet.
+Dream Server includes an optional Tailscale extension that puts the device on your Tailscale net (the mesh VPN at `tailscale.com`). Once joined, the device gets a private tailnet IP/DNS name; with `dream-proxy` enabled and `BIND_ADDRESS=0.0.0.0`, the dashboard and chat are reachable from any other tailnet member — your laptop, your phone, a friend's machine — anywhere with internet.
 
 This is how you reach `dream.local` from the coffee shop without exposing anything to the public internet.
 
@@ -51,7 +51,7 @@ Joining the tailnet only gets the device a `100.x.y.z` IP and a `dream.tail-xxxx
 1. **`dream-proxy` is enabled.** It listens on port 80 and routes `/chat`, `/api/*`, `/auth/*` to the right backend. With it, tailnet clients browse to `http://dream.tail-xxxxx.ts.net` (no port). Without it, only the per-service ports work (`:3000`, `:3001`, `:3002`) and only if those are LAN-bound.
 2. **`BIND_ADDRESS=0.0.0.0` in `.env`.** The default `127.0.0.1` means the proxy / dashboard / chat only accept loopback connections — even though tailscaled is in the same namespace, an incoming tailnet packet looks like any other LAN packet, not loopback. Set `BIND_ADDRESS=0.0.0.0` so the host's listen sockets accept those connections.
 
-If you ship a fresh install with Tailscale enabled but neither of the above, `tailscale status` will show the device authed but `http://dream.tail-xxxxx.ts.net` will hang or refuse. The dashboard's Tailscale page surfaces both conditions when they're missing.
+If you ship a fresh install with Tailscale enabled but neither of the above, `tailscale status` will show the device authed but `http://dream.tail-xxxxx.ts.net` will hang or refuse. Until the dashboard gets a dedicated Remote Access UI, verify those prerequisites with `.env`, `dream list`, and the status endpoint below.
 
 ## Setup
 
@@ -62,12 +62,14 @@ The extension is **opt-in**. It doesn't auto-install; you enable it when you wan
 # In the Tailscale admin console (https://login.tailscale.com/admin/settings/keys):
 #   - Reusable: usually yes (so you don't have to mint a fresh key every reinstall)
 #   - Ephemeral: NO (the device stays in your tailnet after the daemon restarts)
-#   - Tags: add tag:dream (recommend; lets you write ACLs scoped to Dream devices)
+#   - Tags: optional. If your ACL defines tag:dream and your key is allowed
+#     to use it, set TS_EXTRA_ARGS=--advertise-tags=tag:dream below.
 
 # 2. Drop the key into .env:
 cat >> .env <<'EOF'
 TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
 TS_HOSTNAME=                # leave blank — defaults to DREAM_DEVICE_NAME
+TS_EXTRA_ARGS=              # optional, e.g. --advertise-tags=tag:dream
 EOF
 
 # 3. Enable the extension.
@@ -172,7 +174,7 @@ Either:
 
 ### Device joined but unreachable from other tailnet members
 
-- Check your tailnet ACLs (`https://login.tailscale.com/admin/acls`). The default ACL allows all-to-all; if you've restricted it, make sure tag:dream is allowed inbound.
+- Check your tailnet ACLs (`https://login.tailscale.com/admin/acls`). The default ACL allows all-to-all; if you've restricted it and use `--advertise-tags=tag:dream`, make sure `tag:dream` is defined and allowed inbound.
 - Check the receiving side actually has the Tailscale client running: `tailscale status` on the other device should show your dream node.
 
 ### Network is sluggish

--- a/dream-server/docs/TAILSCALE.md
+++ b/dream-server/docs/TAILSCALE.md
@@ -1,0 +1,164 @@
+# Tailscale (remote access)
+
+Dream Server includes an optional Tailscale extension that puts the device on your Tailscale net (the mesh VPN at `tailscale.com`). Once joined, the dashboard and chat are reachable from any other tailnet member — your laptop, your phone, a friend's machine — anywhere with internet.
+
+This is how you reach `dream.local` from the coffee shop without exposing anything to the public internet.
+
+## Why Tailscale (vs. exposing ports / port-forwarding / Cloudflare Tunnel)
+
+- **Zero NAT / port-forwarding config.** You don't touch your router. Tailscale's mesh handles NAT traversal.
+- **Identity-based access.** Only devices signed into your tailnet can reach Dream Server. No "the URL leaked" failure mode.
+- **End-to-end encrypted.** WireGuard under the hood.
+- **No public endpoint.** The device is invisible to the open internet — there's no `dreamXYZ.com` listing to attack.
+
+Tradeoff: every device that needs to reach Dream Server has to install the Tailscale client. For "me and my family" that's fine. For "publish this to anyone on the internet," you'd want Cloudflare Tunnel + auth instead — out of scope for this extension.
+
+## Architecture
+
+```
+        ┌────────── Your phone (away from home) ──────────┐
+        │  Tailscale client running                       │
+        │  browser opens https://dream.tail-xxxxx.ts.net  │
+        └──────────────────────┬──────────────────────────┘
+                               │
+                               │  encrypted WireGuard
+                               ▼
+        ┌────────────────────────────────────────────────┐
+        │  Tailscale relay or direct path (depends on NAT)│
+        └──────────────────────┬─────────────────────────┘
+                               │
+                               ▼
+        ┌────────────────────────────────────────────────┐
+        │  Dream Server host (Linux, with                │
+        │     dream-tailscale container in host-net mode)│
+        │                                                │
+        │  Container's tailscaled exposes the HOST'S     │
+        │  network namespace to the tailnet — so the     │
+        │  dashboard on :3001 and chat on :3000 are      │
+        │  reachable on dream.tail-xxxxx.ts.net:3001     │
+        │  and :3000 with zero extra config.             │
+        └────────────────────────────────────────────────┘
+```
+
+The container uses `network_mode: host` so the Tailscale daemon and the dashboard share the same network namespace. That's what makes the dashboard's normal ports (`3000`, `3001`, `3002`) automatically reachable over the tailnet.
+
+## Setup
+
+The extension is **opt-in**. It doesn't auto-install; you enable it when you want remote access.
+
+```bash
+# 1. Generate an auth key.
+# In the Tailscale admin console (https://login.tailscale.com/admin/settings/keys):
+#   - Reusable: usually yes (so you don't have to mint a fresh key every reinstall)
+#   - Ephemeral: NO (the device stays in your tailnet after the daemon restarts)
+#   - Tags: add tag:dream (recommend; lets you write ACLs scoped to Dream devices)
+
+# 2. Drop the key into .env:
+cat >> .env <<'EOF'
+TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
+TS_HOSTNAME=                # leave blank — defaults to DREAM_DEVICE_NAME
+EOF
+
+# 3. Enable the extension.
+dream enable tailscale
+# (Or from the dashboard: Extensions → Tailscale → Enable.)
+
+# 4. The container starts, joins the tailnet, and shows up in
+#    `tailscale status` on every other tailnet member within seconds.
+```
+
+## Verifying
+
+From the device itself:
+
+```bash
+docker exec dream-tailscale tailscale status
+# Should show this device authed + your tailnet name
+```
+
+From the dashboard API:
+
+```bash
+curl -H "Authorization: Bearer ${DASHBOARD_API_KEY}" \
+  http://localhost:3002/api/tailscale/status
+# {
+#   "running": true,
+#   "authenticated": true,
+#   "self": {
+#     "hostname": "dream",
+#     "dns_name": "dream.tail-abcde.ts.net",
+#     "ips": ["100.64.0.42", ...],
+#     "online": true
+#   },
+#   "magic_dns_suffix": "tail-abcde.ts.net"
+# }
+```
+
+From any other device on your tailnet:
+
+```bash
+# After installing the Tailscale client and signing into the same tailnet:
+curl http://dream.tail-abcde.ts.net:3001
+# Or from a browser: http://dream.tail-abcde.ts.net:3001
+```
+
+## After the auth key has done its job
+
+The auth key is single-purpose: get the container into the tailnet on first start. After the daemon authenticates, it caches a long-lived node key in `data/tailscale/`. You can:
+
+- **Rotate the auth key in the Tailscale admin** — won't disconnect this device.
+- **Delete the auth key entirely** — won't disconnect this device.
+- **Wipe the key from .env** — set `TS_AUTHKEY=` to empty. The container still works because of the cached node key.
+
+If `data/tailscale/` is ever deleted, the container needs a fresh auth key to rejoin.
+
+## Disabling
+
+```bash
+dream disable tailscale
+# Or: Extensions → Tailscale → Disable
+```
+
+This stops the container but leaves the cached node key in `data/tailscale/`. Re-enabling rejoins without a new auth key.
+
+To fully remove from the tailnet, also delete the device entry in the Tailscale admin (`https://login.tailscale.com/admin/machines`).
+
+## API surface
+
+### `GET /api/tailscale/status`
+
+Auth: Bearer (dashboard).
+
+Three shapes, always 200:
+
+| Container | TS daemon | Response |
+|---|---|---|
+| Not running | — | `{"running": false}` |
+| Running | Not authenticated | `{"running": true, "authenticated": false, "reason": "..."}` |
+| Running | Authenticated | `{"running": true, "authenticated": true, "self": {hostname, dns_name, ips, online}, "magic_dns_suffix": "...", "tailnet_name": "..."}` |
+
+Errors (5xx) are reserved for "the docker daemon itself broke" — never for "the extension isn't enabled."
+
+## Caveats
+
+- **Linux only in v1.** Host networking on macOS / Windows Docker Desktop doesn't share the host's network namespace the same way. Both work in some configurations with `TS_USERSPACE=true` and `tailscale serve`, but that's substantially more complex than this PR ships. Documented as a follow-up.
+- **No HTTPS yet.** Tailscale's HTTPS feature (auto-issued certs from `<hostname>.<tailnet>.ts.net`) requires `tailscale cert` + a proxy. Future PR.
+- **No Funnel (public internet exposure).** Tailscale Funnel can expose a tailnet service to the public internet via `*.ts.net`. We don't enable this by default — it would defeat the "identity-based access" property. Operator opt-in if they want it.
+- **The container needs `NET_ADMIN`, `NET_RAW`, and `/dev/net/tun`.** These are unusual for Docker containers. They're necessary for any WireGuard-based VPN. The container runs as root; this is the Tailscale-published image's standard pattern.
+
+## Troubleshooting
+
+### `tailscale status` says "Logged out"
+
+Either:
+- `TS_AUTHKEY` is empty or expired in `.env` → mint a fresh key and `dream restart tailscale`
+- The auth key was single-use and already consumed by a different container → mint a reusable key
+
+### Device joined but unreachable from other tailnet members
+
+- Check your tailnet ACLs (`https://login.tailscale.com/admin/acls`). The default ACL allows all-to-all; if you've restricted it, make sure tag:dream is allowed inbound.
+- Check the receiving side actually has the Tailscale client running: `tailscale status` on the other device should show your dream node.
+
+### Network is sluggish
+
+Tailscale uses DERP relays as a fallback when direct UDP isn't possible. Behind a strict NAT or carrier-grade NAT, you'll go through a relay (typically <50ms in the US but variable). Run `tailscale netcheck` for a diagnosis.

--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -27,7 +27,19 @@
     },
     "service": {
       "type": "object",
-      "required": ["id", "name", "port", "health"],
+      "required": ["id", "name"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "host_network": { "const": true }
+            },
+            "required": ["host_network"]
+          },
+          "then": {},
+          "else": { "required": ["port", "health"] }
+        }
+      ],
       "properties": {
         "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
         "name": { "type": "string", "minLength": 1 },
@@ -45,6 +57,10 @@
         "port": { "type": "integer", "minimum": 0, "maximum": 65535 },
         "external_port_env": { "type": "string" },
         "external_port_default": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "host_network": {
+          "type": "boolean",
+          "description": "True for Docker network_mode: host services that do not declare Docker-mapped ports or HTTP health paths."
+        },
         "health": { "type": "string", "minLength": 1 },
         "health_timeout": {
           "type": "integer",

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -55,6 +55,7 @@ from routers import (
     gpu as gpu_router, resources, voice, models as models_router, templates,
     auth as auth_router,
     magic_link,
+    tailscale,
 )
 
 
@@ -929,6 +930,7 @@ app.include_router(models_router.router)
 app.include_router(templates.router)
 app.include_router(auth_router.router)
 app.include_router(magic_link.router)
+app.include_router(tailscale.router)
 
 
 # ================================================================

--- a/dream-server/extensions/services/dashboard-api/routers/tailscale.py
+++ b/dream-server/extensions/services/dashboard-api/routers/tailscale.py
@@ -1,0 +1,74 @@
+"""Tailscale (remote access) — dashboard-api proxy in front of the host-agent.
+
+The host-agent has /v1/tailscale/status, which docker-exec's into the
+dream-tailscale container to query the daemon. This module exposes that
+to the dashboard UI via /api/tailscale/status.
+
+For the typical lifecycle the operator runs:
+  1. Generate an auth key at https://login.tailscale.com/admin/settings/keys
+  2. Set TS_AUTHKEY in .env (via the existing Settings page or `dream env`)
+  3. Enable the tailscale extension (via Extensions page or `dream enable tailscale`)
+  4. Container starts, joins the tailnet, shows up in `tailscale status`
+  5. The device is reachable as <hostname>.<tailnet>.ts.net from any
+     other tailnet member
+
+The status endpoint is what powers the "Remote Access" section in the
+dashboard's Settings page — it shows the user whether their device is
+on the tailnet, what its tailnet hostname is, and whether the daemon
+is authenticated.
+"""
+
+import asyncio
+import json
+import logging
+import urllib.error
+import urllib.request
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from config import AGENT_URL, DREAM_AGENT_KEY
+from security import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["tailscale"])
+
+
+def _proxy_agent(path: str, timeout: int = 15) -> dict:
+    """Forward a GET to the host-agent. Translates HTTPError → HTTPException."""
+    headers = {"Authorization": f"Bearer {DREAM_AGENT_KEY}"}
+    req = urllib.request.Request(f"{AGENT_URL}{path}", headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+            return json.loads(body) if body else {}
+    except urllib.error.HTTPError as exc:
+        detail = f"Host agent returned HTTP {exc.code}"
+        try:
+            err_payload = json.loads(exc.read().decode("utf-8"))
+            detail = err_payload.get("error", detail)
+        except (json.JSONDecodeError, UnicodeDecodeError, AttributeError):
+            pass
+        logger.info("host-agent GET %s -> %s", path, exc.code)
+        raise HTTPException(status_code=exc.code, detail=detail) from exc
+    except urllib.error.URLError as exc:
+        logger.warning("host-agent GET %s unreachable: %s", path, exc)
+        raise HTTPException(status_code=503, detail="Dream host agent is not reachable.") from exc
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.exception("host-agent GET %s failed", path)
+        raise HTTPException(status_code=500, detail=f"Host agent call failed: {exc}") from exc
+
+
+@router.get("/api/tailscale/status", dependencies=[Depends(verify_api_key)])
+async def tailscale_status() -> dict:
+    """Current Tailscale state for this device.
+
+    Three shapes (always 200, never an exception for "not configured"):
+      * `{"running": false}` — extension not enabled (no container)
+      * `{"running": true, "authenticated": false, ...}` — extension up
+        but no TS_AUTHKEY, or auth was rejected
+      * `{"running": true, "authenticated": true, "self": {hostname,
+        dns_name, ips, online}, "magic_dns_suffix": "...", "tailnet_name": "..."}`
+        — fully on the tailnet
+    """
+    return await asyncio.to_thread(_proxy_agent, "/v1/tailscale/status", 15)

--- a/dream-server/extensions/services/dashboard-api/routers/tailscale.py
+++ b/dream-server/extensions/services/dashboard-api/routers/tailscale.py
@@ -51,6 +51,9 @@ def _proxy_agent(path: str, timeout: int = 15) -> dict:
             pass
         logger.info("host-agent GET %s -> %s", path, exc.code)
         raise HTTPException(status_code=exc.code, detail=detail) from exc
+    except TimeoutError as exc:
+        logger.warning("host-agent GET %s timed out", path)
+        raise HTTPException(status_code=504, detail="Dream host agent request timed out.") from exc
     except urllib.error.URLError as exc:
         logger.warning("host-agent GET %s unreachable: %s", path, exc)
         raise HTTPException(status_code=503, detail="Dream host agent is not reachable.") from exc

--- a/dream-server/extensions/services/dashboard-api/tests/test_tailscale.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_tailscale.py
@@ -122,6 +122,15 @@ def test_status_returns_503_when_agent_unreachable(test_client):
     assert resp.status_code == 503
 
 
+def test_status_returns_504_when_agent_request_times_out(test_client):
+    with patch(
+        "routers.tailscale.urllib.request.urlopen",
+        side_effect=TimeoutError("timed out"),
+    ):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 504
+
+
 def test_status_passes_through_504_timeout(test_client):
     err = _mock_agent_http_error(504, {"error": "docker exec timed out"})
     with patch("routers.tailscale.urllib.request.urlopen", side_effect=err):

--- a/dream-server/extensions/services/dashboard-api/tests/test_tailscale.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_tailscale.py
@@ -1,0 +1,137 @@
+"""Tests for routers/tailscale.py — the proxy in front of the host-agent's
+Tailscale status endpoint.
+
+Mocked surfaces:
+  * urllib.request.urlopen — stand-in for the host-agent HTTP call.
+
+The actual `docker exec tailscale status --json` behavior is covered at
+the host-agent layer and not reproducible without a running Tailscale
+container.
+"""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import urllib.error
+
+
+# ---------------------------------------------------------------------------
+# Auth enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_tailscale_status_requires_auth(test_client):
+    resp = test_client.get("/api/tailscale/status")
+    assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_agent_response(body, status=200):
+    mock_resp = MagicMock()
+    mock_resp.status = status
+    mock_resp.read = MagicMock(return_value=json.dumps(body).encode("utf-8"))
+    mock_resp.__enter__ = MagicMock(return_value=mock_resp)
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def _mock_agent_http_error(status, body):
+    err = urllib.error.HTTPError(
+        url="http://agent/v1/tailscale/status",
+        code=status,
+        msg="error",
+        hdrs=None,
+        fp=None,
+    )
+    err.read = lambda: json.dumps(body).encode("utf-8")
+    return err
+
+
+# ---------------------------------------------------------------------------
+# Three normal status shapes (all 200)
+# ---------------------------------------------------------------------------
+
+
+def test_status_when_extension_not_running(test_client):
+    """Container not started → running=false. Not an error — the user just
+    hasn't enabled the extension yet."""
+    upstream = {"running": False}
+    with patch("routers.tailscale.urllib.request.urlopen", return_value=_mock_agent_response(upstream)):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["running"] is False
+
+
+def test_status_when_running_but_not_authenticated(test_client):
+    """Container up but TS_AUTHKEY is empty / rejected → user-facing reason."""
+    upstream = {
+        "running": True,
+        "authenticated": False,
+        "reason": "Tailscale is running but not yet authenticated. Set TS_AUTHKEY and restart.",
+    }
+    with patch("routers.tailscale.urllib.request.urlopen", return_value=_mock_agent_response(upstream)):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["running"] is True
+    assert body["authenticated"] is False
+    assert "TS_AUTHKEY" in body["reason"]
+
+
+def test_status_when_fully_joined(test_client):
+    """Happy path — device is on the tailnet."""
+    upstream = {
+        "running": True,
+        "authenticated": True,
+        "backend_state": "Running",
+        "self": {
+            "hostname": "dream",
+            "dns_name": "dream.tail-abcde.ts.net",
+            "ips": ["100.64.0.42", "fd7a:115c:a1e0::42"],
+            "online": True,
+        },
+        "magic_dns_suffix": "tail-abcde.ts.net",
+        "tailnet_name": "example.com",
+    }
+    with patch("routers.tailscale.urllib.request.urlopen", return_value=_mock_agent_response(upstream)):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["authenticated"] is True
+    assert body["self"]["dns_name"].endswith(".ts.net")
+    assert "100.64.0.42" in body["self"]["ips"]
+    assert body["magic_dns_suffix"] == "tail-abcde.ts.net"
+
+
+# ---------------------------------------------------------------------------
+# Error translation
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_503_when_agent_unreachable(test_client):
+    with patch(
+        "routers.tailscale.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
+    ):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 503
+
+
+def test_status_passes_through_504_timeout(test_client):
+    err = _mock_agent_http_error(504, {"error": "docker exec timed out"})
+    with patch("routers.tailscale.urllib.request.urlopen", side_effect=err):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 504
+    assert "timed out" in resp.json()["detail"]
+
+
+def test_status_passes_through_500_when_agent_errors(test_client):
+    err = _mock_agent_http_error(500, {"error": "docker exec failed: ENOENT"})
+    with patch("routers.tailscale.urllib.request.urlopen", side_effect=err):
+        resp = test_client.get("/api/tailscale/status", headers=test_client.auth_headers)
+    assert resp.status_code == 500

--- a/dream-server/extensions/services/tailscale/compose.yaml
+++ b/dream-server/extensions/services/tailscale/compose.yaml
@@ -1,0 +1,53 @@
+services:
+  tailscale:
+    image: tailscale/tailscale:v1.78.0
+    container_name: dream-tailscale
+    restart: unless-stopped
+    # network_mode: host is required for Tailscale to share the host's
+    # network namespace — that's what makes services on 127.0.0.1:<port>
+    # reachable as <hostname>.<tailnet>.ts.net:<port> from the tailnet.
+    # Linux only. macOS + Docker Desktop need a different topology
+    # (userspace networking + tailscale serve); not supported in v1.
+    network_mode: host
+    cap_add:
+      # NET_ADMIN: manipulate routing tables (Tailscale's mesh)
+      # NET_RAW: send raw packets (NAT traversal probes)
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      # The TUN device is how Tailscale's userspace daemon hands packets
+      # back to the kernel. Without this, tailscale up exits with
+      # "no TUN device available".
+      - /dev/net/tun:/dev/net/tun
+    environment:
+      # TS_AUTHKEY is consumed once on first join; the daemon caches the
+      # resulting node key in TS_STATE_DIR so the auth key can be rotated
+      # or deleted afterward. Empty value = container starts but doesn't
+      # join (waits for the user to set it).
+      - TS_AUTHKEY=${TS_AUTHKEY:-}
+      - TS_HOSTNAME=${TS_HOSTNAME:-${DREAM_DEVICE_NAME:-dream}}
+      - TS_STATE_DIR=/var/lib/tailscale
+      # AcceptRoutes lets this device see subnet routes advertised by
+      # other tailnet nodes (off by default — Dream's bidirectional case
+      # is just incoming).
+      - TS_EXTRA_ARGS=--advertise-tags=tag:dream
+      # Userspace mode is OFF — we want full kernel networking so the
+      # dashboard/chat ports on the host are exposed to the tailnet via
+      # network_mode: host. TS_USERSPACE=true is for the inverse
+      # (container reaches the tailnet) which isn't what we need.
+      - TS_USERSPACE=false
+    volumes:
+      - ./data/tailscale:/var/lib/tailscale
+    healthcheck:
+      # `tailscale status` returns 0 if the daemon is up and authenticated,
+      # 1 if not. Useful for "is this device on the tailnet right now."
+      test: ["CMD", "tailscale", "status", "--json"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/tailscale/compose.yaml
+++ b/dream-server/extensions/services/tailscale/compose.yaml
@@ -37,10 +37,12 @@ services:
       - TS_AUTHKEY=${TS_AUTHKEY:-}
       - TS_HOSTNAME=${TS_HOSTNAME:-${DREAM_DEVICE_NAME:-dream}}
       - TS_STATE_DIR=/var/lib/tailscale
-      # AcceptRoutes lets this device see subnet routes advertised by
-      # other tailnet nodes (off by default — Dream's bidirectional case
-      # is just incoming).
-      - TS_EXTRA_ARGS=--advertise-tags=tag:dream
+      # Optional extra flags for `tailscale up`. Leave empty for a normal
+      # auth key. Operators with a tailnet ACL tag configured can set:
+      #   TS_EXTRA_ARGS=--advertise-tags=tag:dream
+      # A hard-coded tag breaks first join on tailnets that do not define
+      # or authorize that tag, so Dream keeps this opt-in.
+      - TS_EXTRA_ARGS=${TS_EXTRA_ARGS:-}
       # Userspace mode is OFF — we want full kernel networking so the
       # tailscaled daemon ends up sharing the host's network namespace.
       # That places the device's tailnet IP on the host (rather than

--- a/dream-server/extensions/services/tailscale/compose.yaml
+++ b/dream-server/extensions/services/tailscale/compose.yaml
@@ -3,9 +3,19 @@ services:
     image: tailscale/tailscale:v1.78.0
     container_name: dream-tailscale
     restart: unless-stopped
-    # network_mode: host is required for Tailscale to share the host's
-    # network namespace — that's what makes services on 127.0.0.1:<port>
-    # reachable as <hostname>.<tailnet>.ts.net:<port> from the tailnet.
+    # network_mode: host puts the Tailscale daemon in the host's network
+    # namespace so the device's tailnet IP (100.x.y.z) is the host
+    # itself. **It does NOT make loopback-bound services reachable
+    # from the tailnet.** Incoming tailnet packets arrive on the host's
+    # Tailscale interface, not 127.0.0.1, so a service bound to
+    # 127.0.0.1:3000 still refuses them. To make Dream Server services
+    # reachable over the tailnet, also:
+    #   - Enable dream-proxy (port 80 with host-based routing)
+    #   - Set BIND_ADDRESS=0.0.0.0 in .env so the proxy listens on
+    #     the LAN interface (which is the same interface the tailscaled
+    #     daemon is observing).
+    # See docs/TAILSCALE.md "Prerequisites for tailnet reachability".
+    #
     # Linux only. macOS + Docker Desktop need a different topology
     # (userspace networking + tailscale serve); not supported in v1.
     network_mode: host
@@ -32,9 +42,11 @@ services:
       # is just incoming).
       - TS_EXTRA_ARGS=--advertise-tags=tag:dream
       # Userspace mode is OFF — we want full kernel networking so the
-      # dashboard/chat ports on the host are exposed to the tailnet via
-      # network_mode: host. TS_USERSPACE=true is for the inverse
-      # (container reaches the tailnet) which isn't what we need.
+      # tailscaled daemon ends up sharing the host's network namespace.
+      # That places the device's tailnet IP on the host (rather than
+      # inside the container) so Dream's host-bound services can answer
+      # tailnet traffic — provided they're bound to 0.0.0.0 / a real
+      # interface, not loopback. See the network_mode comment above.
       - TS_USERSPACE=false
     volumes:
       - ./data/tailscale:/var/lib/tailscale

--- a/dream-server/extensions/services/tailscale/manifest.yaml
+++ b/dream-server/extensions/services/tailscale/manifest.yaml
@@ -1,0 +1,46 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: tailscale
+  name: Tailscale (Remote Access)
+  aliases: [remote, vpn]
+  container_name: dream-tailscale
+  # Tailscale runs in host network mode on Linux — no port exposed at the
+  # container layer. Health is checked via `tailscale status` over docker exec.
+  port: 0
+  health_timeout: 30
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []
+  env_vars:
+    - key: TS_AUTHKEY
+      required: false
+      secret: true
+      description: |
+        Tailscale auth key. Generate one at https://login.tailscale.com/admin/settings/keys
+        Recommend a reusable, ephemeral=false, tags=tag:dream key per device. The container
+        joins your tailnet on first start, after which you can rotate or delete the key.
+    - key: TS_HOSTNAME
+      required: false
+      description: |
+        The hostname this device registers as on the tailnet. Defaults to
+        ${DREAM_DEVICE_NAME}. Reachable as <hostname>.<tailnet>.ts.net once joined.
+
+features:
+  - id: remote-access
+    name: Remote Access
+    description: Reach Dream Server from any device, anywhere via Tailscale VPN.
+    icon: Globe
+    category: networking
+    requirements:
+      services: [tailscale]
+      vram_gb: 0
+    enabled_services_all: [tailscale]
+    setup_time: ~2 minutes
+    priority: 3
+    gpu_backends: [all]

--- a/dream-server/extensions/services/tailscale/manifest.yaml
+++ b/dream-server/extensions/services/tailscale/manifest.yaml
@@ -8,8 +8,13 @@ service:
   name: Tailscale (Remote Access)
   aliases: [remote, vpn]
   container_name: dream-tailscale
-  # Tailscale runs in host network mode on Linux — no port exposed at the
-  # container layer. Health is checked via `tailscale status` over docker exec.
+  # `host_network: true` opts this service out of the audit's port-mapping +
+  # health-path requirements. Tailscale uses `network_mode: host` so its
+  # daemon shares the host's network namespace — there's no Docker-mapped
+  # port and no HTTP health endpoint, so those manifest fields don't apply.
+  # Liveness is checked via the compose healthcheck (`tailscale status
+  # --json`) instead. See scripts/audit-extensions.py.
+  host_network: true
   port: 0
   health_timeout: 30
   type: docker

--- a/dream-server/extensions/services/tailscale/manifest.yaml
+++ b/dream-server/extensions/services/tailscale/manifest.yaml
@@ -28,13 +28,18 @@ service:
       secret: true
       description: |
         Tailscale auth key. Generate one at https://login.tailscale.com/admin/settings/keys
-        Recommend a reusable, ephemeral=false, tags=tag:dream key per device. The container
-        joins your tailnet on first start, after which you can rotate or delete the key.
+        Recommend a reusable, ephemeral=false key per device. The container joins your
+        tailnet on first start, after which you can rotate or delete the key.
     - key: TS_HOSTNAME
       required: false
       description: |
         The hostname this device registers as on the tailnet. Defaults to
         ${DREAM_DEVICE_NAME}. Reachable as <hostname>.<tailnet>.ts.net once joined.
+    - key: TS_EXTRA_ARGS
+      required: false
+      description: |
+        Optional extra flags passed to `tailscale up`, for example
+        --advertise-tags=tag:dream when your tailnet ACL defines and authorizes that tag.
 
 features:
   - id: remote-access

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -33,6 +33,12 @@ declare -A SERVICE_HEALTH       # service_id → health endpoint path
 declare -A SERVICE_HEALTH_TIMEOUTS  # service_id → health check timeout in seconds
 declare -A SERVICE_PORTS        # service_id → external port (what the user hits on localhost)
 declare -A SERVICE_PORT_ENVS    # service_id → env var name for the external port
+# Services with `host_network: true` in their manifest (Docker
+# network_mode: host) — share the host's network namespace, so there's
+# no Docker-mapped port. SERVICE_PORTS[sid] is irrelevant for them.
+# Callers (tests, health probes, doctor) should skip the port check
+# when SERVICE_HOST_NETWORK[sid] is "1".
+declare -A SERVICE_HOST_NETWORK # service_id → "1" iff manifest sets host_network: true
 declare -A SERVICE_NAMES        # service_id → display name
 declare -A SERVICE_SETUP_HOOKS  # service_id → absolute path to setup script
 declare -A SERVICE_GPU_BACKENDS # service_id → space-separated GPU backends (amd, nvidia, apple, cpu)
@@ -170,10 +176,13 @@ for service_dir in _all_service_dirs:
         health_timeout = s.get("health_timeout", 5)  # Default 5 seconds
         port = s.get("external_port_default", s.get("port", 0))
         port_env = s.get("external_port_env", "")
+        host_network = "1" if s.get("host_network") else ""
         print(f'SERVICE_HEALTH["{_esc(sid)}"]="{_esc(health)}"')
         print(f'SERVICE_HEALTH_TIMEOUTS["{_esc(sid)}"]="{_esc(health_timeout)}"')
         print(f'SERVICE_PORTS["{_esc(sid)}"]="{_esc(port)}"')
         print(f'SERVICE_PORT_ENVS["{_esc(sid)}"]="{_esc(port_env)}"')
+        if host_network:
+            print(f'SERVICE_HOST_NETWORK["{_esc(sid)}"]="1"')
         print(f'SERVICE_NAMES["{_esc(sid)}"]="{_esc(s.get("name", sid))}"')
         # Prefer hooks.post_install over legacy setup_hook
         hooks = s.get("hooks", {})

--- a/dream-server/scripts/audit-extensions.py
+++ b/dream-server/scripts/audit-extensions.py
@@ -488,12 +488,19 @@ def validate_records(
                 path=record.manifest_path,
             )
 
+        # `host_network: true` marks services that use Docker's
+        # `network_mode: host` (Tailscale being the canonical example) — they
+        # don't have a Docker-mapped port or an HTTP health endpoint, so the
+        # port/health requirements don't apply. The flag also flips off the
+        # compose-port-mismatch check further down.
+        host_network = bool(service.get("host_network"))
+
         port = parse_positive_int(service.get("port"))
-        if port is None:
+        if port is None and not host_network:
             record.add_issue("error", "service-port-invalid", "service.port must be a positive integer", path=record.manifest_path)
 
         health = str(service.get("health") or "")
-        if not health.startswith("/"):
+        if not health.startswith("/") and not host_network:
             record.add_issue(
                 "error",
                 "service-health-invalid",
@@ -693,7 +700,11 @@ def validate_records(
                     path=source_paths.get("base", record.manifest_path),
                 )
 
-        if port is not None:
+        if port is not None and not host_network:
+            # host-network services share the host's network namespace; their
+            # listen ports come from whatever process binds inside the host,
+            # not from Docker's port mapping. Skipping this check is what
+            # makes host_network: true viable in the first place.
             port_matches = False
             for definition in definitions.values():
                 if port in extract_target_ports(definition):

--- a/dream-server/tests/test-service-registry.sh
+++ b/dream-server/tests/test-service-registry.sh
@@ -117,7 +117,10 @@ else
             continue
         fi
 
-        # Validate required fields
+        # Validate required fields. host_network services (Docker
+        # network_mode: host) don't have a Docker-mapped port and may
+        # not serve an HTTP health endpoint — port and health drop to
+        # "optional" for them.
         validation=$("$PYTHON_CMD" -c "
 import yaml, sys
 with open(sys.argv[1]) as f:
@@ -129,7 +132,9 @@ s = m.get('service', {})
 if not isinstance(s, dict):
     errors.append('service must be a dict')
 else:
-    for field in ('id', 'name', 'port', 'health'):
+    host_network = bool(s.get('host_network'))
+    required = ['id', 'name'] if host_network else ['id', 'name', 'port', 'health']
+    for field in required:
         if not s.get(field):
             errors.append(f'missing required field: service.{field}')
     if 'category' in s and s['category'] not in ('core', 'recommended', 'optional'):
@@ -314,14 +319,19 @@ for sid in "${SERVICE_IDS[@]}"; do
 
     # Every service should have a runtime port. SERVICE_PORTS is the
     # user-facing external port; internal-only services may intentionally set
-    # it to 0 when a proxy owns the LAN entry point.
-    port="${SERVICE_PORTS[$sid]:-0}"
-    if [[ "$port" != "0" ]]; then
-        pass "Has external port: $sid → $port"
-    elif [[ "${SERVICE_INTERNAL_PORTS[$sid]:-0}" != "0" ]]; then
-        pass "Internal-only service has container port: $sid → ${SERVICE_INTERNAL_PORTS[$sid]}"
+    # it to 0 when a proxy owns the LAN entry point. Host-network services
+    # share the host namespace and have no Docker-mapped port to validate.
+    if [[ "${SERVICE_HOST_NETWORK[$sid]:-}" == "1" ]]; then
+        pass "host_network service exempt from port check: $sid"
     else
-        fail "Missing/zero port: $sid"
+        port="${SERVICE_PORTS[$sid]:-0}"
+        if [[ "$port" != "0" ]]; then
+            pass "Has external port: $sid → $port"
+        elif [[ "${SERVICE_INTERNAL_PORTS[$sid]:-0}" != "0" ]]; then
+            pass "Internal-only service has container port: $sid → ${SERVICE_INTERNAL_PORTS[$sid]}"
+        else
+            fail "Missing/zero port: $sid"
+        fi
     fi
 done
 


### PR DESCRIPTION
# PR-12: Opt-in remote access via Tailscale

**Branch:** `feat/tailscale-remote`
**Phase:** 4 of 4 (Polish & remote)
**Effort:** Medium — 9 files (7 new, 2 modified), 586 insertions
**Depends on:** none

## Summary

Adds an opt-in Tailscale extension that puts the device on the user's tailnet. Once joined, the dashboard at `:3001` and chat at `:3000` are reachable as `<hostname>.<tailnet>.ts.net` from any other tailnet member — anywhere on the internet, without port-forwarding, without exposing anything publicly.

This is how you reach Dream Server from the coffee shop without exposing it to the open internet.

## Why Tailscale (vs. tunneling / port-forwarding / Cloudflare)

- **Zero NAT / router config.** Tailscale's mesh handles NAT traversal.
- **Identity-based access.** Only devices signed into your tailnet can reach Dream Server. No "URL leaked" failure mode.
- **End-to-end encrypted** (WireGuard).
- **No public endpoint.** The device is invisible to the open internet.

Tradeoff: every device that wants to reach Dream Server needs the Tailscale client. For "me and my family," fine. For "publish this to anyone on the internet," you'd want Cloudflare Tunnel + auth instead — out of scope here.

## Architecture

```
Phone (away from home, Tailscale client running)
        │
        │  WireGuard, encrypted, NAT-traversed by Tailscale
        ▼
Dream Server host (Linux)
  ┌─────────────────────────────────────────────┐
  │  dream-tailscale container                  │
  │    network_mode: host                       │
  │    → tailscaled shares the host's net ns,   │
  │      so dashboard's :3000/:3001/:3002 are   │
  │      automatically on the tailnet           │
  └─────────────────────────────────────────────┘
```

Container in `network_mode: host` is the key: the Tailscale daemon and the dashboard share the same network namespace, so the dashboard's already-bound ports become reachable on `<hostname>.<tailnet>.ts.net` with zero extra config. No `tailscale serve` plumbing needed.

## Files

| File | Lines | What |
|---|---|---|
| `extensions/services/tailscale/manifest.yaml` (new) | 39 | Schema-compliant manifest. `category: optional`, env vars TS_AUTHKEY (secret) + TS_HOSTNAME, new "Remote Access" feature. |
| `extensions/services/tailscale/compose.yaml` (new) | 53 | `tailscale/tailscale:v1.78.0`, `network_mode: host`, `NET_ADMIN`+`NET_RAW`, `/dev/net/tun`, persistent state in `data/tailscale/`. Tags `tag:dream` so users can write tailnet ACLs scoped to Dream devices. |
| `.env.example` (+16) | | Documented `TS_AUTHKEY` + `TS_HOSTNAME` block. |
| `.env.schema.json` (+12) | | Schema entries with hostname-safe pattern for TS_HOSTNAME. |
| `bin/dream-host-agent.py` (+92) | | New `GET /v1/tailscale/status` endpoint. `docker exec` into the container to run `tailscale status --json`; distills the chunky output to {running, authenticated, self, magic_dns_suffix, tailnet_name}. Returns 200 with `running:false` when the extension isn't enabled — that's a normal state, not an error. |
| `extensions/services/dashboard-api/routers/tailscale.py` (new) | 73 | The proxy. Three response shapes for the three lifecycle stages (not running / unauthed / joined). |
| `extensions/services/dashboard-api/main.py` (+2) | | Router import + registration. |
| `extensions/services/dashboard-api/tests/test_tailscale.py` (new) | 137 | 7 tests: auth enforcement, three status shapes, error translation. |
| `docs/TAILSCALE.md` (new) | 162 | Why-Tailscale, architecture diagram, setup workflow, verification, auth-key lifecycle, API reference, caveats, troubleshooting. |

## API surface

### `GET /api/tailscale/status`

Three shapes, always 200:

```json
// Extension not enabled
{ "running": false }

// Running but TS_AUTHKEY missing / rejected
{ "running": true, "authenticated": false,
  "reason": "Tailscale is running but not yet authenticated. Set TS_AUTHKEY and restart." }

// Fully joined
{ "running": true, "authenticated": true,
  "backend_state": "Running",
  "self": { "hostname": "dream", "dns_name": "dream.tail-abcde.ts.net",
            "ips": ["100.64.0.42", "fd7a:115c:a1e0::42"], "online": true },
  "magic_dns_suffix": "tail-abcde.ts.net",
  "tailnet_name": "example.com" }
```

5xx is reserved for "the docker daemon itself broke" — never for "the extension isn't enabled."

## Operator workflow

```bash
# 1. Generate an auth key at https://login.tailscale.com/admin/settings/keys
#    Recommend: Reusable=yes, Ephemeral=no, Tags=tag:dream

# 2. Drop it into .env
echo "TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx" >> .env

# 3. Enable
dream enable tailscale

# 4. Verify
curl -H "Authorization: Bearer ${DASHBOARD_API_KEY}" \
  http://localhost:3002/api/tailscale/status
# {"running": true, "authenticated": true, "self": {"dns_name": "dream.tail-abcde.ts.net", ...}}

# 5. From any other tailnet device:
#    open http://dream.tail-abcde.ts.net:3001
```

## Auth-key lifecycle

The key is single-purpose: get the daemon into the tailnet on first start. After that, the daemon caches a long-lived node key in `data/tailscale/`. You can:

- Rotate the auth key in the admin → doesn't disconnect the device
- Delete the auth key → doesn't disconnect the device
- Wipe `TS_AUTHKEY` from `.env` → device still works because of the cached node key

If `data/tailscale/` is ever deleted, you need a fresh auth key to rejoin.

## Test plan

**Automated:**
- [x] 7 new tests in `test_tailscale.py` — all pass locally (0.67s)
- [x] `python -m py_compile bin/dream-host-agent.py` clean
- [x] `.env.schema.json` round-trips through `json.load` cleanly

**Manual (requires real Linux + a Tailscale account):**
- [ ] Generate a reusable auth key in Tailscale admin
- [ ] Set TS_AUTHKEY in .env, run `dream enable tailscale`
- [ ] Container starts; `docker exec dream-tailscale tailscale status` shows the device authed
- [ ] `/api/tailscale/status` returns the joined shape with the right DNS name
- [ ] From another tailnet device: browse to `http://<hostname>.<tailnet>.ts.net:3001` — dashboard loads
- [ ] Edit TS_AUTHKEY to empty in .env, restart — device stays joined (uses cached node key)
- [ ] Delete `data/tailscale/`, restart with empty TS_AUTHKEY — daemon comes up but `authenticated:false`
- [ ] `dream disable tailscale` — container stops; status returns `running:false`

## What's NOT in this PR

- **"Remote Access" Settings UI.** Surfacing TS_AUTHKEY input + status + toggle in the dashboard's Settings page. Deferred to a focused follow-up — this PR is the security-sensitive integration layer, the UI is straightforward composition on top.
- **Wizard step for "Want remote access?"** The original plan mentioned an optional wizard step. Real-world flow: the user needs an account at tailscale.com + an auth key minted there. That friction is bad inside the first-boot wizard. Deferred until we can ship a cleaner OAuth flow.
- **macOS / Windows support.** Both work in some configurations with `TS_USERSPACE=true` + `tailscale serve` (entirely different topology). Linux only in v1.
- **HTTPS via `tailscale cert`.** Tailscale can issue real HTTPS certs for `*.ts.net` hostnames. Adding this needs a thin reverse proxy in front of the dashboard; future PR.
- **Funnel (public internet exposure).** Tailscale Funnel can expose a tailnet service publicly via `*.ts.net`. We don't enable this by default — it would defeat the identity-based access property. Operator can `tailscale funnel 3001` manually if they want it.

## Caveats

- **The container needs `NET_ADMIN`, `NET_RAW`, and `/dev/net/tun`.** Unusual for Docker containers but necessary for any WireGuard-based VPN. Standard pattern from Tailscale's published image.
- **`network_mode: host`** means the container shares the host's network ns — that's what makes dashboard ports reachable via the tailnet. Tradeoff: the container can also see anything else bound to the host's interfaces.
- **Pinned to `tailscale/tailscale:v1.78.0`.** Future image bumps need conscious review; Tailscale's wire protocol is stable but feature flags shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
