### PR TITLE
feat(dashboard): smart PWA install-prompt banner

### DIFF
--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from 'react-router-dom'
 import { useState, useEffect, Suspense, useMemo, useCallback, lazy } from 'react'
 import Sidebar from './components/Sidebar'
+import InstallPromptBanner from './components/InstallPromptBanner'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
 import { useFirstRun } from './hooks/useFirstRun'
@@ -120,6 +121,12 @@ function App() {
           </Routes>
         </Suspense>
       </main>
+
+      {/* Smart PWA install nudge — only renders when the user has shown
+          enough engagement (3+ visits) AND the browser is willing to
+          install. No-op on already-installed PWAs and on browsers that
+          can't install (e.g. Firefox desktop). See usePwaInstallPrompt. */}
+      <InstallPromptBanner />
     </div>
   )
 }

--- a/dream-server/extensions/services/dashboard/src/App.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.test.jsx
@@ -51,6 +51,12 @@ vi.mock('./components/SplashScreen', () => ({
   }
 }))
 
+// InstallPromptBanner depends on browser PWA events we don't simulate
+// in these App-level tests; render nothing so it doesn't interfere.
+vi.mock('./components/InstallPromptBanner', () => ({
+  default: () => null,
+}))
+
 describe('App', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn(() =>

--- a/dream-server/extensions/services/dashboard/src/components/InstallPromptBanner.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/InstallPromptBanner.jsx
@@ -1,0 +1,79 @@
+// Smart PWA install prompt banner.
+//
+// Slides in from the bottom on small screens, sits in the bottom-right
+// on desktop. Only renders when usePwaInstallPrompt says the moment is
+// right (3+ visits, not dismissed, not already installed, browser is
+// installable — or iOS where the install path is manual).
+//
+// Two button states:
+//   * non-iOS: "Add to home screen" -> programmatic prompt
+//   * iOS: copy reads "Tap Share → Add to Home Screen" with the
+//     Share icon called out; no programmatic prompt is possible
+//     (Safari refuses to expose it).
+
+import { Smartphone, X, Share, Plus } from 'lucide-react'
+import { usePwaInstallPrompt } from '../hooks/usePwaInstallPrompt'
+
+export default function InstallPromptBanner() {
+  const { shouldShow, isIos, promptInstall, dismiss } = usePwaInstallPrompt()
+  if (!shouldShow) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Add Dream to your home screen"
+      className="fixed bottom-4 left-4 right-4 md:left-auto md:right-4 md:max-w-sm
+                 bg-theme-card border border-theme-accent/40 rounded-xl shadow-2xl
+                 p-4 z-40 animate-in slide-in-from-bottom-4 fade-in duration-300"
+    >
+      <div className="flex items-start gap-3">
+        <div className="w-10 h-10 rounded-xl bg-theme-accent/15 text-theme-accent flex items-center justify-center flex-shrink-0">
+          <Smartphone size={22} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-theme-text text-sm mb-1">
+            Make Dream feel like an app
+          </h3>
+          {isIos ? (
+            <p className="text-xs text-theme-text-muted leading-relaxed">
+              Tap{' '}
+              <Share size={12} className="inline align-text-bottom mx-0.5 text-theme-accent" />
+              <strong className="text-theme-text">Share</strong>, then{' '}
+              <strong className="text-theme-text">Add to Home Screen</strong>{' '}
+              to put Dream a tap away.
+            </p>
+          ) : (
+            <p className="text-xs text-theme-text-muted leading-relaxed">
+              Install Dream as an app on this device for one-tap access — no browser tabs, no typing the address.
+            </p>
+          )}
+        </div>
+        <button
+          onClick={dismiss}
+          aria-label="Dismiss"
+          className="text-theme-text-muted hover:text-theme-text p-1 -mr-1 -mt-1 flex-shrink-0"
+        >
+          <X size={16} />
+        </button>
+      </div>
+
+      {!isIos && (
+        <div className="flex items-center gap-2 mt-3">
+          <button
+            onClick={promptInstall}
+            className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white text-sm py-2 px-4 rounded-lg hover:opacity-90 transition-opacity"
+          >
+            <Plus size={16} />
+            Add to home screen
+          </button>
+          <button
+            onClick={dismiss}
+            className="text-xs text-theme-text-muted hover:text-theme-text px-3 py-2"
+          >
+            Not now
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/hooks/__tests__/usePwaInstallPrompt.test.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/__tests__/usePwaInstallPrompt.test.js
@@ -1,0 +1,158 @@
+import { renderHook, act } from '@testing-library/react'
+import { usePwaInstallPrompt } from '../usePwaInstallPrompt'
+
+// Helper: fire a synthetic beforeinstallprompt event that the hook listens for.
+function fireBeforeInstall() {
+  const event = new Event('beforeinstallprompt')
+  // The real event has prompt() + userChoice + preventDefault. Stub them.
+  event.preventDefault = vi.fn()
+  event.prompt = vi.fn().mockResolvedValue()
+  event.userChoice = Promise.resolve({ outcome: 'accepted' })
+  window.dispatchEvent(event)
+  return event
+}
+
+function fireAppInstalled() {
+  window.dispatchEvent(new Event('appinstalled'))
+}
+
+describe('usePwaInstallPrompt', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear()
+    globalThis.sessionStorage.clear()
+    // Reset navigator UA detection (jsdom defaults are non-iOS, but be explicit)
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // --------------------------------------------------------------------
+  // Visit-count gating
+  // --------------------------------------------------------------------
+
+  test('does not show on first visit even after beforeinstallprompt fires', () => {
+    const { result } = renderHook(() => usePwaInstallPrompt())
+    act(() => { fireBeforeInstall() })
+    // First mount bumps the visit count to 1; that's below the 3-visit
+    // threshold so the banner stays hidden.
+    expect(result.current.visitCount).toBe(1)
+    expect(result.current.shouldShow).toBe(false)
+  })
+
+  test('shows on the 3rd visit', () => {
+    // Simulate prior visits by pre-setting localStorage.
+    globalThis.localStorage.setItem('dream-pwa-visit-count', '2')
+    const { result } = renderHook(() => usePwaInstallPrompt())
+    act(() => { fireBeforeInstall() })
+    expect(result.current.visitCount).toBe(3)
+    expect(result.current.shouldShow).toBe(true)
+  })
+
+  test('only ticks once per tab session', () => {
+    globalThis.localStorage.setItem('dream-pwa-visit-count', '2')
+    // First mount: increments to 3.
+    const first = renderHook(() => usePwaInstallPrompt())
+    expect(first.result.current.visitCount).toBe(3)
+    // Second mount in the same tab session: sessionStorage guard kicks in.
+    const second = renderHook(() => usePwaInstallPrompt())
+    expect(second.result.current.visitCount).toBe(3)
+  })
+
+  // --------------------------------------------------------------------
+  // Dismissal
+  // --------------------------------------------------------------------
+
+  test('dismiss() persists across reloads', () => {
+    globalThis.localStorage.setItem('dream-pwa-visit-count', '5')
+    const { result, unmount } = renderHook(() => usePwaInstallPrompt())
+    act(() => { fireBeforeInstall() })
+    expect(result.current.shouldShow).toBe(true)
+    act(() => { result.current.dismiss() })
+    expect(result.current.shouldShow).toBe(false)
+    unmount()
+
+    // Simulate a fresh tab: clear session, keep localStorage.
+    globalThis.sessionStorage.clear()
+    const { result: result2 } = renderHook(() => usePwaInstallPrompt())
+    act(() => { fireBeforeInstall() })
+    expect(result2.current.shouldShow).toBe(false)
+  })
+
+  // --------------------------------------------------------------------
+  // Install lifecycle
+  // --------------------------------------------------------------------
+
+  test('promptInstall calls the browser-provided prompt event', async () => {
+    globalThis.localStorage.setItem('dream-pwa-visit-count', '5')
+    const { result } = renderHook(() => usePwaInstallPrompt())
+    let event
+    act(() => { event = fireBeforeInstall() })
+    expect(result.current.shouldShow).toBe(true)
+
+    await act(async () => {
+      await result.current.promptInstall()
+    })
+    expect(event.prompt).toHaveBeenCalled()
+  })
+
+  test('appinstalled event marks the PWA installed and hides the banner', () => {
+    globalThis.localStorage.setItem('dream-pwa-visit-count', '5')
+    const { result } = renderHook(() => usePwaInstallPrompt())
+    act(() => { fireBeforeInstall() })
+    expect(result.current.shouldShow).toBe(true)
+
+    act(() => { fireAppInstalled() })
+    expect(result.current.installed).toBe(true)
+    expect(result.current.shouldShow).toBe(false)
+    expect(globalThis.localStorage.getItem('dream-pwa-installed')).toBe('1')
+  })
+
+  test('does not show when already installed (display-mode: standalone)', () => {
+    // Trick the hook into thinking the PWA is already running standalone.
+    const origMatchMedia = window.matchMedia
+    window.matchMedia = vi.fn().mockReturnValue({ matches: true })
+    try {
+      globalThis.localStorage.setItem('dream-pwa-visit-count', '5')
+      const { result } = renderHook(() => usePwaInstallPrompt())
+      act(() => { fireBeforeInstall() })
+      expect(result.current.installed).toBe(true)
+      expect(result.current.shouldShow).toBe(false)
+    } finally {
+      window.matchMedia = origMatchMedia
+    }
+  })
+
+  // --------------------------------------------------------------------
+  // iOS path (no beforeinstallprompt event)
+  // --------------------------------------------------------------------
+
+  test('iOS shows the banner without beforeinstallprompt firing', () => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      configurable: true,
+    })
+    globalThis.localStorage.setItem('dream-pwa-visit-count', '5')
+    const { result } = renderHook(() => usePwaInstallPrompt())
+    expect(result.current.isIos).toBe(true)
+    expect(result.current.shouldShow).toBe(true)
+  })
+
+  test('iOS promptInstall is a no-op (Safari refuses programmatic install)', async () => {
+    Object.defineProperty(window.navigator, 'userAgent', {
+      value: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
+      configurable: true,
+    })
+    globalThis.localStorage.setItem('dream-pwa-visit-count', '5')
+    const { result } = renderHook(() => usePwaInstallPrompt())
+    let outcome
+    await act(async () => {
+      outcome = await result.current.promptInstall()
+    })
+    expect(outcome.platform).toBe('ios')
+  })
+})

--- a/dream-server/extensions/services/dashboard/src/hooks/usePwaInstallPrompt.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/usePwaInstallPrompt.js
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+// Smart PWA install prompt for the dashboard.
+//
+// What the browser gives us:
+//   * Chrome/Edge/Android Chrome fire `beforeinstallprompt` when the
+//     PWA criteria (manifest + SW + HTTPS / localhost) are met.
+//   * Firefox + iOS Safari do NOT fire this event. iOS users have to
+//     manually use Share → Add to Home Screen. We can't programmatically
+//     trigger that, but we can still show our nudge UI with
+//     iOS-specific copy.
+//   * Once accepted/dismissed, the event can't be reused — the browser
+//     will mint a new one if/when criteria are met again.
+//
+// What we add on top:
+//   * Don't pester on first visit. Wait until the user has come back
+//     N times (default 3) — that's a real signal they value this UI.
+//   * Remember "user said not now" forever (until they clear storage).
+//     A "remind me later" path is implicit in the visit-counter pattern
+//     and doesn't need separate state.
+//   * Detect already-installed PWAs and stay out of their way.
+//
+// Visit counting: we increment on each TAB SESSION (sessionStorage
+// guard), not on each F5. The first session bumps to 1, the third
+// session bumps to 3 — that's when the banner can show.
+
+const VISIT_COUNT_KEY = 'dream-pwa-visit-count'
+const SESSION_TICKED_KEY = 'dream-pwa-session-ticked'
+const DISMISSED_KEY = 'dream-pwa-prompt-dismissed'
+const INSTALLED_KEY = 'dream-pwa-installed'
+const MIN_VISITS_BEFORE_PROMPT = 3
+
+function safeGet(storage, key, fallback = null) {
+  try { return storage?.getItem(key) ?? fallback } catch { return fallback }
+}
+function safeSet(storage, key, value) {
+  try { storage?.setItem(key, value) } catch { /* private mode / quota */ }
+}
+
+function isAlreadyInstalled() {
+  // `display-mode: standalone` is true once the user has launched the
+  // installed PWA. window.matchMedia is the cross-browser way to read it.
+  if (typeof window === 'undefined') return false
+  try {
+    if (window.matchMedia?.('(display-mode: standalone)').matches) return true
+    // iOS exposes this on navigator instead — Safari-only quirk.
+    if (window.navigator?.standalone === true) return true
+  } catch {
+    // matchMedia failures shouldn't crash the hook.
+  }
+  return safeGet(globalThis.localStorage, INSTALLED_KEY) === '1'
+}
+
+function isIos() {
+  if (typeof navigator === 'undefined') return false
+  // Old iPhone / iPad UAs + iPadOS-which-claims-to-be-macOS-but-is-touch.
+  const ua = navigator.userAgent || ''
+  if (/iPad|iPhone|iPod/.test(ua)) return true
+  return /Macintosh/.test(ua) && navigator.maxTouchPoints > 1
+}
+
+export function usePwaInstallPrompt() {
+  const promptEventRef = useRef(null)
+  // installable: browser fired beforeinstallprompt OR we detected iOS
+  // (where the install path is manual but the banner is still useful).
+  const [installable, setInstallable] = useState(false)
+  const [installed, setInstalled] = useState(() => isAlreadyInstalled())
+  const [visitCount, setVisitCount] = useState(() => {
+    const raw = safeGet(globalThis.localStorage, VISIT_COUNT_KEY, '0')
+    return Number.parseInt(raw, 10) || 0
+  })
+  const [dismissed, setDismissed] = useState(
+    () => safeGet(globalThis.localStorage, DISMISSED_KEY) === '1'
+  )
+  const [ios] = useState(() => isIos())
+
+  // Tick the visit counter ONCE per tab session. F5 / hot reload won't
+  // re-tick because sessionStorage persists across reloads within the
+  // same tab.
+  useEffect(() => {
+    if (installed) return
+    if (safeGet(globalThis.sessionStorage, SESSION_TICKED_KEY) === '1') return
+    safeSet(globalThis.sessionStorage, SESSION_TICKED_KEY, '1')
+    setVisitCount(prev => {
+      const next = prev + 1
+      safeSet(globalThis.localStorage, VISIT_COUNT_KEY, String(next))
+      return next
+    })
+  }, [installed])
+
+  // Capture the browser-provided install event for non-iOS browsers.
+  useEffect(() => {
+    if (installed) return
+    const onBeforeInstall = (event) => {
+      event.preventDefault()
+      promptEventRef.current = event
+      setInstallable(true)
+    }
+    const onInstalled = () => {
+      promptEventRef.current = null
+      setInstallable(false)
+      setInstalled(true)
+      safeSet(globalThis.localStorage, INSTALLED_KEY, '1')
+    }
+    window.addEventListener('beforeinstallprompt', onBeforeInstall)
+    window.addEventListener('appinstalled', onInstalled)
+    return () => {
+      window.removeEventListener('beforeinstallprompt', onBeforeInstall)
+      window.removeEventListener('appinstalled', onInstalled)
+    }
+  }, [installed])
+
+  // iOS doesn't fire beforeinstallprompt, but we still want to show a
+  // hint. The banner copy on iOS becomes "Share → Add to Home Screen"
+  // because we can't trigger the install programmatically.
+  useEffect(() => {
+    if (ios && !installed) setInstallable(true)
+  }, [ios, installed])
+
+  // Promptable when the user has shown intent (3+ visits) and we either
+  // have a real event or are on iOS.
+  const shouldShow =
+    !installed &&
+    !dismissed &&
+    installable &&
+    visitCount >= MIN_VISITS_BEFORE_PROMPT
+
+  const promptInstall = useCallback(async () => {
+    const event = promptEventRef.current
+    if (!event) {
+      // iOS path — no programmatic prompt. The banner stays open until
+      // the user taps Dismiss; calling promptInstall is a no-op here
+      // and the banner's iOS-specific copy explains what to do.
+      return { platform: 'ios', outcome: 'manual' }
+    }
+    try {
+      await event.prompt()
+      const choice = await event.userChoice
+      promptEventRef.current = null
+      setInstallable(false)
+      if (choice?.outcome === 'accepted') {
+        setInstalled(true)
+        safeSet(globalThis.localStorage, INSTALLED_KEY, '1')
+      } else {
+        // User chose "not now" in the OS dialog — same as our dismiss.
+        setDismissed(true)
+        safeSet(globalThis.localStorage, DISMISSED_KEY, '1')
+      }
+      return choice
+    } catch {
+      // The browser sometimes throws if prompt() is called twice. Treat
+      // as "not installable any more."
+      promptEventRef.current = null
+      setInstallable(false)
+      return { outcome: 'error' }
+    }
+  }, [])
+
+  const dismiss = useCallback(() => {
+    setDismissed(true)
+    safeSet(globalThis.localStorage, DISMISSED_KEY, '1')
+  }, [])
+
+  return {
+    shouldShow,
+    isIos: ios,
+    installed,
+    visitCount,
+    promptInstall,
+    dismiss,
+  }
+}


### PR DESCRIPTION
# PR-14: Smart PWA install-prompt banner

**Branch:** `feat/pwa-install-prompt`
**Phase:** 4 of 4 (Polish & remote) — **final PR in the onboarding plan**
**Effort:** Small — 5 files (3 new, 2 modified), 422 insertions
**Depends on:** PR-3 (`feat/dashboard-pwa`) for runtime install — not for build

## Summary

The browser's default "install this site" UI is a tiny icon in the address bar that most users never notice. PWAs that ship a custom nudge at a well-timed moment see meaningfully higher install rates.

This PR adds that nudge to the dashboard: a slide-in banner that appears at the bottom of the screen after the user has come back **3+ times**, with copy + button matching the install flow for their browser.

## Behaviour

| Browser | What we show | What the button does |
|---|---|---|
| Chromium / Edge / Android Chrome | "Add to home screen" button | Calls the captured `beforeinstallprompt.prompt()` → OS install dialog |
| iOS Safari (iPhone / iPad) | "Tap Share → Add to Home Screen" with iconography | No button — Safari refuses programmatic install, we walk the user through it |
| Firefox / Safari on macOS | Nothing | `beforeinstallprompt` doesn't fire on these — banner stays hidden |
| Already-installed PWA | Nothing | `display-mode: standalone` is true → hook returns `shouldShow=false` |

Triggers:
- **Don't** show on first visit (would be obnoxious)
- **Do** show after 3+ tab sessions (real signal the user values this UI)
- **Never again** after the user clicks "Not now" / X / accepts → installs

## Files

| File | Lines | What |
|---|---|---|
| `src/hooks/usePwaInstallPrompt.js` (new) | 158 | The brains. Captures `beforeinstallprompt`, counts tab sessions, persists dismissal, detects already-installed, returns `{shouldShow, promptInstall, dismiss, isIos, installed, visitCount}`. |
| `src/components/InstallPromptBanner.jsx` (new) | 84 | The UI. Slide-in card with two flavors (non-iOS button vs. iOS Share-instruction). Pure consumer of the hook. |
| `src/hooks/__tests__/usePwaInstallPrompt.test.js` (new) | 152 | 9 tests covering the full lifecycle. |
| `src/App.jsx` (+8 / 0) | | Top-level mount of the banner. |
| `src/App.test.jsx` (+6 / 0) | | Mock the banner so existing App-level tests stay isolated from PWA event simulation. |

## Hook contract

```js
const {
  shouldShow,    // bool — render the banner?
  isIos,         // bool — show the manual-install copy variant
  installed,     // bool — PWA is already installed
  visitCount,    // int  — debug visibility
  promptInstall, // async () => OS dialog (no-op on iOS)
  dismiss,       // () => persist "not now" forever
} = usePwaInstallPrompt()
```

Visit counting is per **tab session** (sessionStorage guard), not per **navigation** (F5 doesn't double-count). The dismiss state is permanent in localStorage — surfacing a "remind me later" path would need explicit UI; today the visit-count threshold is the gate.

## Test plan

**Automated (9 new, 13 total run together with App.test.jsx — all pass):**
- [x] Does NOT show on first visit even with `beforeinstallprompt` fired
- [x] Shows on the 3rd visit
- [x] Visit counter only ticks once per tab session (F5 doesn't bump)
- [x] `dismiss()` persists across reloads
- [x] `promptInstall()` calls the captured event's `prompt()`
- [x] `appinstalled` event hides the banner and sets the persistent flag
- [x] Already-installed PWAs (display-mode:standalone) never see the banner
- [x] iOS detection shows the banner without `beforeinstallprompt`
- [x] iOS `promptInstall()` is a graceful no-op (returns `{platform: 'ios', outcome: 'manual'}`)

Full suite: 71/71 dashboard tests pass. Build + lint clean (same 5 pre-existing warnings, none in new code).

**Manual smoke** (requires a real browser + PR-3 merged so manifest + SW exist):
- [ ] Chromium localhost: load the dashboard 3 times in 3 tabs → banner appears on the 3rd
- [ ] Click "Add to home screen" → OS install dialog → install → banner stays hidden across reloads
- [ ] Reset localStorage → dismiss the banner → reload → banner stays hidden (dismissal persists)
- [ ] iOS Safari: load 3 times → banner shows Share + Add to Home Screen copy
- [ ] Firefox desktop: load any number of times → banner never appears (no `beforeinstallprompt`)

## What's NOT in this PR

- **Open WebUI install prompt.** The chat surface (port 3000) is where users spend most of their time, and that's where the "install this app" prompt would have the biggest impact. But Open WebUI is a third-party project; injecting our JS would require either forking it or running a reverse proxy that injects a script. Out of scope for this PR. The dashboard is the surface we directly control.
- **"Remind me later" path.** Today dismissal is forever (until localStorage clears). A snooze pattern (re-prompt after N days) is sensible but unnecessary for v1.
- **A/B-testable copy.** The banner text is hardcoded. If install-rate experiments matter, a follow-up could surface copy via a config endpoint.
- **Per-route timing.** The banner mounts at the App root and runs on every page. A future PR could nudge specifically after the user completed setup or generated their first invite — moments of high engagement.

## Caveats

- **The browser controls when `beforeinstallprompt` fires.** Even with manifest + SW + HTTPS, Chrome's heuristics ("user has engaged with the site enough") need to be satisfied. Our 3-visit threshold sits inside Chrome's own engagement gate — so the banner won't appear UNTIL Chrome would normally have its own install ready. We're just intercepting Chrome's mini-infobar with a nicer UI.
- **iOS PWAs have real limitations.** No push notifications, limited storage, no app-store presence. The banner copy is honest: it tells iOS users they can pin Dream to their home screen, not that they're getting a "real app."
- **Already-installed detection is best-effort.** Some browsers (e.g. iOS 16) don't expose a reliable signal. The hook fallback writes `dream-pwa-installed=1` to localStorage on `appinstalled` so subsequent loads on that browser know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
