### PR TITLE
feat(hermes): package Hermes Agent as a Dream Server extension

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -340,7 +340,8 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # once mDNS picks it up.
 #
 # HERMES_PORT=9119                       # External dashboard port
-# HERMES_MODEL_NAME=qwen3.5-9b           # Model label passed to Hermes
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
 # HERMES_LANGUAGE=en                     # UI language
+# (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
+#  not in env. Edit the file after first start to switch models.)

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -336,10 +336,15 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # persistent memory, autonomous skill creation, and 70+ tools. Dream
 # Server runs the upstream image pinned by SHA and points it at the
 # local LLM. Browser UI ships in the upstream image (port 9119).
-# Enable: `dream enable hermes`. Reachable at hermes.<device>.local:9119
-# once mDNS picks it up.
+# Enable: `dream enable hermes`. With hermes-proxy enabled, end users
+# reach Hermes at http://hermes.<device>.local (port 80, auth-gated by
+# the proxy); without it, Hermes binds HERMES_PORT directly.
 #
-# HERMES_PORT=9119                       # External dashboard port
+# HERMES_PORT=9119                       # Direct external port (used
+#                                          when hermes-proxy is OFF; with
+#                                          hermes-proxy ON, Hermes is
+#                                          internal-only and this is
+#                                          informational).
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
 # HERMES_LANGUAGE=en                     # UI language

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -329,3 +329,18 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # DREAM_PROXY_PORT=80                    # Host port (standard HTTP)
 # DREAM_PROXY_TLS_PORT=443               # HTTPS port (deferred; HTTP only in v1)
 # DREAM_PROXY_BIND=0.0.0.0               # LAN-exposed by default — that's the point
+
+# Hermes Agent (Remote-capable Chat + Generalist Agent)
+# ═══════════════════════════════════════════════════════════════════
+# Hermes Agent (Nous Research, MIT) — chat-first generalist agent with
+# persistent memory, autonomous skill creation, and 70+ tools. Dream
+# Server runs the upstream image pinned by SHA and points it at the
+# local LLM. Browser UI ships in the upstream image (port 9119).
+# Enable: `dream enable hermes`. Reachable at hermes.<device>.local:9119
+# once mDNS picks it up.
+#
+# HERMES_PORT=9119                       # External dashboard port
+# HERMES_MODEL_NAME=qwen3.5-9b           # Model label passed to Hermes
+# HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
+# HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
+# HERMES_LANGUAGE=en                     # UI language

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -730,6 +730,30 @@
       "type": "string",
       "description": "Bind address for the reverse proxy's host port. Defaults to 0.0.0.0 (LAN-exposed) — that's the whole point of the proxy. Override to 127.0.0.1 to keep it localhost-only.",
       "default": "0.0.0.0"
+    },
+    "HERMES_PORT": {
+      "type": "integer",
+      "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
+      "default": 9119
+    },
+    "HERMES_MODEL_NAME": {
+      "type": "string",
+      "description": "Model name label passed to Hermes Agent. Hermes uses provider=custom against the local llama-server, so this is mostly a display label; what matters is HERMES_LLM_BASE_URL."
+    },
+    "HERMES_LLM_BASE_URL": {
+      "type": "string",
+      "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",
+      "default": "http://llama-server:8080/v1"
+    },
+    "HERMES_LLM_API_KEY": {
+      "type": "string",
+      "description": "Dummy API key for Hermes Agent's OpenAI SDK (llama-server doesn't validate it, but the SDK requires the field to be non-empty).",
+      "secret": true
+    },
+    "HERMES_LANGUAGE": {
+      "type": "string",
+      "description": "UI language for Hermes Agent's web dashboard (defaults to en).",
+      "default": "en"
     }
   }
 }

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -736,10 +736,6 @@
       "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
       "default": 9119
     },
-    "HERMES_MODEL_NAME": {
-      "type": "string",
-      "description": "Model name label passed to Hermes Agent. Hermes uses provider=custom against the local llama-server, so this is mostly a display label; what matters is HERMES_LLM_BASE_URL."
-    },
     "HERMES_LLM_BASE_URL": {
       "type": "string",
       "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -733,7 +733,7 @@
     },
     "HERMES_PORT": {
       "type": "integer",
-      "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
+      "description": "External port for the Hermes Agent dashboard. Used when Hermes is the LAN entry — direct dev access or smoke tests without hermes-proxy. With hermes-proxy enabled, Hermes is internal-only (compose switches to expose:) and this becomes informational; user-facing port is HERMES_PROXY_PORT.",
       "default": 9119
     },
     "HERMES_LLM_BASE_URL": {

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -27,10 +27,12 @@ Hermes ships its own complete web UI — Dream Server is just packaging it. Afte
   ┌─────────────────────────────────────┐
   │  dream-hermes container             │
   │                                     │
-  │   Upstream FastAPI dashboard        │
-  │     - serves React SPA              │
-  │     - exposes /api endpoints        │
-  │     - drives AIAgent class          │
+  │   hermes gateway run                │
+  │     - HERMES_DASHBOARD=1 →          │
+  │         React SPA + /api endpoints  │
+  │     - scheduler tick() every 60s →  │
+  │         fires cron jobs             │
+  │     - no messaging adapters         │
   │                                     │
   │   State: /opt/data (HERMES_HOME)    │
   │     mounted from data/hermes/       │
@@ -82,7 +84,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 ## Defaults Dream Server applies
 
 - **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
-- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — change `HERMES_MODEL_NAME` if you've swapped models)
+- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
 - **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
 - **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
@@ -92,8 +94,8 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 
 Three layers, highest to lowest precedence:
 
-1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting.
-2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_MODEL_NAME`, etc. See `.env.example` for the full list.
+1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting. **The model name lives here**, not in env.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_LLM_API_KEY`, `HERMES_PORT`, `HERMES_LANGUAGE`. These are the only Hermes settings the container actually reads from env. See `.env.example`.
 3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
 
 To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -1,0 +1,188 @@
+# Hermes Agent
+
+Dream Server ships an optional **Hermes Agent** extension — the [Nous Research open-source agent](https://github.com/nousresearch/hermes-agent) packaged as a Dream Server service. Hermes is a self-improving generalist agent with persistent memory, autonomous skill creation, and 70+ tools built in.
+
+When enabled, Hermes runs in a container alongside the rest of the stack, exposes its own browser dashboard at port 9119, and talks to the local LLM (llama-server) via its OpenAI-compatible API.
+
+## What you get
+
+Hermes ships its own complete web UI — Dream Server is just packaging it. After `dream enable hermes`, you can browse to `http://<device>:9119` (or `hermes.<device>.local:9119` once mDNS announcement lands — see "Roadmap" below) and find pages for:
+
+- **Chat** — conversational interface with streaming responses + inline tool calls
+- **Sessions** — list, switch between, prune past conversations
+- **Skills** — view skills Hermes has autonomously created from your interactions; edit or delete
+- **Memories** — persistent facts Hermes has learned about you
+- **Profiles** — per-user agent contexts (a built-in alternative to running multiple Hermes containers)
+- **Cron** — schedule recurring agent tasks
+- **Models** — pick which LLM Hermes uses (defaults to your llama-server)
+- **Config / Env** — Hermes's own settings
+- **Logs / Analytics** — operational visibility
+
+## Architecture
+
+```
+  Browser
+     │  http://<device>:9119
+     ▼
+  ┌─────────────────────────────────────┐
+  │  dream-hermes container             │
+  │                                     │
+  │   Upstream FastAPI dashboard        │
+  │     - serves React SPA              │
+  │     - exposes /api endpoints        │
+  │     - drives AIAgent class          │
+  │                                     │
+  │   State: /opt/data (HERMES_HOME)    │
+  │     mounted from data/hermes/       │
+  │                                     │
+  │   Tool sandbox: local (in-container)│
+  └─────────────────────────────────────┘
+                  │
+                  │  OpenAI-compatible API
+                  ▼
+  ┌─────────────────────────────────────┐
+  │  llama-server (existing)            │
+  │     llama.cpp at :8080/v1           │
+  └─────────────────────────────────────┘
+```
+
+State layout under `data/hermes/`:
+
+```
+data/hermes/
+├── config.yaml      # Bootstrapped from our cli-config.yaml.template on first start
+├── .env             # Bootstrapped from upstream's .env.example
+├── SOUL.md          # Bootstrapped from our SOUL.md.template
+├── sessions/        # Per-session chat history
+├── memories/        # Persistent agent memories
+├── skills/          # Agent-authored skills
+├── cron/            # Scheduled tasks
+├── plans/           # Active multi-step plans
+├── workspace/       # Sandboxed workspace for file ops
+├── hooks/           # Custom lifecycle hooks
+├── home/            # Per-profile $HOME for subprocesses (git, ssh, npm…)
+└── logs/            # Hermes's own logs (separate from Docker logs)
+```
+
+## Setup
+
+```bash
+# 1. (One-time) Verify Dream Server's llama-server is running:
+dream status llama-server
+
+# 2. Pull + start Hermes:
+dream enable hermes
+
+# 3. (Optional) Open the dashboard:
+xdg-open http://localhost:9119
+```
+
+The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.py` bootstrap, and llama-server may cold-load the model on Hermes's first request. Subsequent starts are fast.
+
+## Defaults Dream Server applies
+
+- **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
+- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — change `HERMES_MODEL_NAME` if you've swapped models)
+- **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
+- **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
+- **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
+- **Resource caps:** 4 CPUs / 4GB RAM hard limit, 0.5 CPU / 1GB reservation. Hermes's playwright + ML deps can be hungry; adjust in `extensions/services/hermes/compose.yaml` if needed.
+
+## Configuration
+
+Three layers, highest to lowest precedence:
+
+1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_MODEL_NAME`, etc. See `.env.example` for the full list.
+3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
+
+To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.
+
+## Security posture
+
+- **`--insecure` is enabled.** Hermes's dashboard refuses to bind to non-loopback addresses without it (the dashboard stores API keys, so binding 0.0.0.0 has a clear "you sure?" gate). Dream Server's trusted-LAN posture accepts this trade-off for v1. **Don't expose port 9119 to the public internet.** Use Tailscale (PR-12 from the onboarding plan) if you need remote access.
+- **The container runs as a non-root user** (UID 10000 by default, remappable via `HERMES_UID`). The entrypoint drops privileges via `gosu` before any agent code runs.
+- **The container has full network access** within Dream Server's bridge net — Hermes can make outbound HTTP requests for tools like `web_search`. If you want to restrict this, add an iptables firewall rule on the host or run Hermes behind a forward proxy.
+- **No APE policy enforcement yet.** Hermes's 70+ tools include shell + file write. The base config defaults toward less-risky tools, but Hermes can still execute shell commands inside its sandbox container. APE policy wrapping is a planned follow-up; until then, the trust model is "the user authenticated to Hermes is trusted to use the local container."
+
+## How to bump the SHA pin
+
+Hermes is a young, fast-moving project (~3 months old as of v1 integration). The SHA pin in `compose.yaml` lets us audit upstream changes deliberately rather than auto-tracking `:latest`. Bumping is a 5-minute pass:
+
+```bash
+# 1. Pick the new SHA. Upstream publishes a sha-<full-sha> tag for every
+#    main push, so any commit on NousResearch/hermes-agent's main is fair game.
+gh api repos/NousResearch/hermes-agent/commits/main --jq '{sha,date:.commit.author.date,msg:.commit.message}'
+
+# 2. Read the diff since our current pin. Skim breaking changes,
+#    config-format migrations, removed env vars.
+gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.commits[].commit.message'
+
+# 3. Update extensions/services/hermes/compose.yaml — the only place the
+#    pin appears.
+
+# 4. Smoke test:
+#    dream restart hermes
+#    curl http://localhost:9119/api/health  # should 200
+#    open http://localhost:9119, send a chat, verify tool call
+
+# 5. If it works, commit. If config.yaml format has changed, document the
+#    migration in this file's "Bump history" section below.
+```
+
+## Roadmap (deferred from v1)
+
+These were in the original integration plan but cut once we discovered Hermes ships a complete browser surface:
+
+- **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer (`bin/dream-mdns.py` lands in [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)). One-line follow-up after that PR merges.
+- **APE policy integration** — route Hermes's tool calls through APE for allow/deny + audit. APE is already in the stack; needs a small adapter inside or in front of Hermes.
+- **Magic-link SSO** — hand off magic-link redemptions ([#1155](https://github.com/Light-Heart-Labs/DreamServer/pull/1155)) into a Hermes auth session so family members don't need separate Hermes credentials.
+- **Voice in/out from Dream Server's whisper + kokoro** — Hermes has its own audio pipeline (the image bundles ffmpeg + playwright); verify whether it already proxies to local TTS/STT services or whether we need to wire that ourselves.
+- **Dream-side status panel** — surface Hermes's session count + skill inventory in the Dream dashboard. Lower priority since Hermes has its own `AnalyticsPage`.
+
+## Troubleshooting
+
+### `curl localhost:9119/api/health` returns 502 / connection refused
+
+Hermes hasn't finished bootstrapping. Watch the logs:
+
+```bash
+docker logs -f dream-hermes
+```
+
+First start does a ~30s skills sync; subsequent starts are fast.
+
+### Hermes can't reach the LLM
+
+Inside the container, `llama-server:8080` should resolve to the llama-server container. Test with:
+
+```bash
+docker exec dream-hermes curl -fs http://llama-server:8080/v1/models
+```
+
+If that fails, the most likely cause is that the Hermes container isn't on Dream Server's docker network. Check `docker network inspect dream-server_default`.
+
+### Sessions / memories / skills disappeared after upgrade
+
+The SHA pin protects you from accidental version drift, but if you DID bump and lose data, it's almost certainly because Hermes's config format changed. Check `data/hermes/config.yaml` against upstream's current `cli-config.yaml.example`. The container's first start regenerates `config.yaml` from our template only if it doesn't exist — your old config sticks around.
+
+### "I don't want Hermes anymore"
+
+```bash
+dream disable hermes              # stops the container
+rm -rf data/hermes                # wipes all sessions / memories / skills
+```
+
+The container image stays cached — `docker image prune` removes it.
+
+## Upstream attribution
+
+Hermes Agent is © 2026 Nous Research, MIT-licensed. Dream Server's contribution is the packaging layer (`extensions/services/hermes/`) — no code is forked from upstream. The pinned image is pulled directly from `docker.io/nousresearch/hermes-agent`.
+
+When promoting / talking about this extension, the convention is: "Hermes Agent (from Nous Research) — packaged for Dream Server."
+
+## Bump history
+
+| Date | Pinned SHA | Notes |
+|---|---|---|
+| 2026-05-12 | `dd0923bb89ed2dd56f82cb63656a1323f6f42e6f` | Initial integration. |

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -125,9 +125,9 @@ gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.comm
 
 # 4. Smoke test:
 #    dream restart hermes
-#    curl http://localhost:9119/healthz     # should 200 (unauthenticated)
-#    # NOTE: /api/* is auth-gated (returns 401); use /healthz / /status
-#    # / /ping for unauthenticated probes.
+#    curl http://localhost:9119/api/status  # should 200 (public, read-only)
+#    # NOTE: most /api/* routes are auth-gated; /api/status is the public
+#    # JSON-backed endpoint used by Dream's health metadata and Docker probe.
 #    open http://localhost:9119, send a chat, verify tool call
 
 # 5. If it works, commit. If config.yaml format has changed, document the
@@ -146,7 +146,7 @@ These were in the original integration plan but cut once we discovered Hermes sh
 
 ## Troubleshooting
 
-### `curl localhost:9119/healthz` returns 502 / connection refused
+### `curl localhost:9119/api/status` returns 502 / connection refused
 
 Hermes hasn't finished bootstrapping. Watch the logs:
 

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -125,7 +125,9 @@ gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.comm
 
 # 4. Smoke test:
 #    dream restart hermes
-#    curl http://localhost:9119/api/health  # should 200
+#    curl http://localhost:9119/healthz     # should 200 (unauthenticated)
+#    # NOTE: /api/* is auth-gated (returns 401); use /healthz / /status
+#    # / /ping for unauthenticated probes.
 #    open http://localhost:9119, send a chat, verify tool call
 
 # 5. If it works, commit. If config.yaml format has changed, document the
@@ -144,7 +146,7 @@ These were in the original integration plan but cut once we discovered Hermes sh
 
 ## Troubleshooting
 
-### `curl localhost:9119/api/health` returns 502 / connection refused
+### `curl localhost:9119/healthz` returns 502 / connection refused
 
 Hermes hasn't finished bootstrapping. Watch the logs:
 

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -1,0 +1,56 @@
+# Hermes — Dream Server Default Persona
+
+You are **Hermes**, the resident agent on a Dream Server installation. Dream
+Server is a fully-local AI stack — chat, voice, image generation, agents,
+workflows, RAG, and privacy tooling — that runs on the user's own hardware
+with no data ever leaving their machine.
+
+You are a **generalist agent**. You can chat conversationally, but you can
+also take real action: search the web, read and write files, run shell
+commands (when policy allows), keep notes, set reminders, ingest documents,
+and recall things from past conversations.
+
+## Operating principles
+
+1. **Take the action when it's clear.** If a user says "look up the weather
+   in Tokyo," search the web — don't ask permission first. Save the asking
+   for genuinely destructive or non-reversible operations (file deletion,
+   sending email on their behalf, etc.).
+
+2. **Show your work.** When you use a tool, mention what you did briefly. The
+   user sees tool calls in the UI, so the goal is just to weave them into
+   the conversation, not narrate every step in detail.
+
+3. **Remember what matters.** Hermes has persistent memory — if a user tells
+   you something durable about themselves ("I'm allergic to peanuts," "my
+   partner's name is Alex"), save it. Don't save every passing detail.
+
+4. **Stay local-first.** Dream Server's whole posture is that the user owns
+   their data. Don't suggest cloud services when a local equivalent exists.
+   When you DO need an external resource (a webpage, a Wikipedia article),
+   fetch only what's needed.
+
+5. **Be honest about uncertainty.** If you're not sure whether a recalled
+   fact is current, say so. The local model isn't always up to date; trust
+   web search for current events.
+
+## Tone
+
+Warm, direct, lightly informal. The user is likely on their phone or laptop
+at home, not at a help desk. Match their energy. Avoid hedging language
+("perhaps you might want to consider…"); just answer.
+
+## What you are NOT
+
+- Not a coding agent. DreamForge handles that. If the user wants you to edit
+  their code repo, gently point them at DreamForge.
+- Not a customer-service bot. Don't apologize for things that aren't your
+  fault.
+- Not a moralizer. Don't lecture the user about their choices unless they
+  ask. Respect their autonomy.
+
+## Resetting this persona
+
+The user can edit this file at `/opt/data/SOUL.md` inside the Hermes
+container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply.
+Deleting the file falls back to upstream's default persona.

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -13,9 +13,11 @@
 # Model — points at Dream Server's local LLM by default
 # =============================================================================
 model:
-  # The local model name. Defaults to Dream's LLM_MODEL via the
-  # OPENAI_BASE_URL Hermes inspects. The provider override below makes
-  # the actual model lookup happen against llama-server's /v1/models.
+  # The local model name. Defaults to "qwen3.5-9b" because that's Dream
+  # Server's default; if you've switched llama-server to a different
+  # model, edit this line in /opt/data/config.yaml after first start.
+  # (Hermes does NOT read HERMES_MODEL_NAME from env — the config.yaml
+  # is the source of truth once it's copied out of the example.)
   default: "qwen3.5-9b"
 
   # provider=custom = any OpenAI-compatible local server. Aliases:
@@ -27,6 +29,13 @@ model:
   # value here is the fallback if the env var is unset.
   base_url: "http://llama-server:8080/v1"
 
+  # Match the LLM's context window. Dream Server's default CTX_SIZE is
+  # 16384; bump this in /opt/data/config.yaml if you've raised CTX_SIZE
+  # in .env. Upstream Hermes reads this from model.context_length —
+  # earlier drafts used a top-level context: block which is silently
+  # ignored.
+  context_length: 16384
+
 # =============================================================================
 # Terminal backend — where tool calls execute
 # =============================================================================
@@ -37,30 +46,37 @@ terminal:
   backend: "local"
 
 # =============================================================================
-# Messaging gateways — DISABLED by default in Dream Server
+# Messaging gateways — none enabled by default in Dream Server
 # =============================================================================
 # Hermes ships with Telegram / Discord / Slack / WhatsApp / Signal / email /
-# Teams / Google Chat / Matrix / Mattermost / SMS gateways. Dream Server users
-# reach Hermes via the web dashboard, not platform bots. Leave these off
-# unless you understand the security implications of each.
+# Teams / Google Chat / Matrix / Mattermost / SMS gateway adapters. Dream
+# Server users reach Hermes via the web dashboard, not platform bots — so
+# none of these are configured here.
 #
-# To enable any of them, set the corresponding token in .env (TELEGRAM_TOKEN,
-# DISCORD_TOKEN, etc.) AND remove the disabled: true line from the
-# corresponding adapter config under upstream's gateway docs.
-gateway:
-  # Globally disable the messaging gateway runner. The `dashboard` subcommand
-  # is what compose.yaml starts; this just makes sure that if someone runs
-  # `docker exec dream-hermes hermes gateway run` it stays a no-op until
-  # they explicitly configure a platform.
-  enabled: false
+# IMPORTANT: there is NO top-level `gateway.enabled: false` switch in
+# upstream's config schema. Earlier drafts of this template had one; it
+# was silently ignored. The gateway is "disabled" by simply not
+# configuring any adapter (no TELEGRAM_TOKEN, no DISCORD_TOKEN, etc.),
+# which means `hermes gateway run` starts, ticks cron, hosts the
+# dashboard, and has no platforms to message on.
+#
+# To enable a platform, follow upstream's adapter docs and add the
+# matching block under the platform-specific config keys, then restart
+# the container.
 
 # =============================================================================
 # Compression — keep memory bounded on small devices
 # =============================================================================
-# Hermes auto-compacts long conversations. Lower threshold = more aggressive
-# compaction = lower disk + token costs but more summarization loss.
-context:
-  # Match the LLM's context window. Dream Server's default CTX_SIZE is 16384;
-  # bump this if you've raised CTX_SIZE in .env.
-  context_length: 16384
-  compact_threshold: 10000
+# Hermes auto-compacts long conversations once they cross the threshold.
+# These are the upstream-correct keys (compression.*); an earlier draft
+# used compact_threshold under a context: block which upstream silently
+# ignores.
+compression:
+  # Token count at which Hermes starts compacting the conversation.
+  # Lower = more aggressive = lower disk/token cost but more summary loss.
+  # Keep this comfortably below model.context_length so there's headroom
+  # before hitting the hard window limit.
+  threshold: 10000
+  # Fraction of the conversation to retain after compaction. 0.5 = aim
+  # for half the original token count post-summary.
+  target_ratio: 0.5

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -1,0 +1,66 @@
+# Hermes Agent configuration — Dream Server defaults.
+#
+# This file is mounted into the upstream image at
+# /opt/hermes/cli-config.yaml.example, which Hermes's entrypoint copies into
+# /opt/data/config.yaml on first start IF that file doesn't already exist.
+# Re-running `dream enable hermes` after editing here won't overwrite an
+# existing config — delete /opt/data/config.yaml manually if you want to
+# reset to these defaults.
+#
+# Documentation for every key: https://hermes-agent.nousresearch.com/docs/
+
+# =============================================================================
+# Model — points at Dream Server's local LLM by default
+# =============================================================================
+model:
+  # The local model name. Defaults to Dream's LLM_MODEL via the
+  # OPENAI_BASE_URL Hermes inspects. The provider override below makes
+  # the actual model lookup happen against llama-server's /v1/models.
+  default: "qwen3.5-9b"
+
+  # provider=custom = any OpenAI-compatible local server. Aliases:
+  # ollama, vllm, llamacpp. We pick "custom" for portability.
+  provider: "custom"
+
+  # base_url is overridden at container start by OPENAI_BASE_URL env
+  # (which compose.yaml wires to http://llama-server:8080/v1). The
+  # value here is the fallback if the env var is unset.
+  base_url: "http://llama-server:8080/v1"
+
+# =============================================================================
+# Terminal backend — where tool calls execute
+# =============================================================================
+# Hermes can run tools in a few different sandboxes. For Dream Server we keep
+# it local-to-the-container: no SSH out, no Modal/Daytona, no Docker-in-Docker.
+# The container IS the sandbox.
+terminal:
+  backend: "local"
+
+# =============================================================================
+# Messaging gateways — DISABLED by default in Dream Server
+# =============================================================================
+# Hermes ships with Telegram / Discord / Slack / WhatsApp / Signal / email /
+# Teams / Google Chat / Matrix / Mattermost / SMS gateways. Dream Server users
+# reach Hermes via the web dashboard, not platform bots. Leave these off
+# unless you understand the security implications of each.
+#
+# To enable any of them, set the corresponding token in .env (TELEGRAM_TOKEN,
+# DISCORD_TOKEN, etc.) AND remove the disabled: true line from the
+# corresponding adapter config under upstream's gateway docs.
+gateway:
+  # Globally disable the messaging gateway runner. The `dashboard` subcommand
+  # is what compose.yaml starts; this just makes sure that if someone runs
+  # `docker exec dream-hermes hermes gateway run` it stays a no-op until
+  # they explicitly configure a platform.
+  enabled: false
+
+# =============================================================================
+# Compression — keep memory bounded on small devices
+# =============================================================================
+# Hermes auto-compacts long conversations. Lower threshold = more aggressive
+# compaction = lower disk + token costs but more summarization loss.
+context:
+  # Match the LLM's context window. Dream Server's default CTX_SIZE is 16384;
+  # bump this if you've raised CTX_SIZE in .env.
+  context_length: 16384
+  compact_threshold: 10000

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -28,6 +28,19 @@ services:
       # Locale + timezone match the rest of the stack.
       - TZ=${TIMEZONE:-UTC}
       - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
+      # Embed the dashboard inside the gateway process (see `command` below).
+      # Upstream reads these env vars to configure the dashboard listener
+      # without separate CLI flags.
+      - HERMES_DASHBOARD=1
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=9119
+      # --insecure equivalent: dashboard refuses non-loopback binds without
+      # this since it stores API keys. The trusted-LAN posture is the v1
+      # trade-off (documented in docs/HERMES.md).
+      - HERMES_DASHBOARD_INSECURE=1
+      # --no-open equivalent: stops Hermes from trying to spawn a browser
+      # inside the container.
+      - HERMES_DASHBOARD_NO_OPEN=1
     volumes:
       # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
       # cron jobs, audit logs all live here.
@@ -44,20 +57,23 @@ services:
       # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
       # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
       - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
-    # Run only the dashboard subcommand. Upstream's image entrypoint defaults
-    # to `hermes` (no args) which is for interactive use. We want exactly the
-    # FastAPI + React UI. --insecure is required because the dashboard refuses
-    # non-loopback binds without it (it stores API keys); inside Dream Server's
-    # trusted-LAN posture this is the documented v1 trade-off. --no-open keeps
-    # Hermes from trying to open a browser inside the container.
+    # Run the gateway with the dashboard embedded.
+    #
+    # Why `gateway run` and not just `dashboard`: Hermes's scheduler (the
+    # cron tick that fires recurring tasks) runs INSIDE the gateway process,
+    # not the dashboard. Earlier drafts of this extension ran only
+    # `dashboard`, which let users create cron jobs through the UI but
+    # never actually fired them — `tick()` lives in the gateway's main
+    # loop. `gateway run` with HERMES_DASHBOARD=1 (set above) gives us
+    # both: the gateway's scheduler + the React UI, in one process.
+    #
+    # We don't enable any messaging platforms (Telegram / Discord / etc.)
+    # so the gateway has no adapters to drive — its only job here is to
+    # tick cron and host the dashboard. That's the upstream-supported
+    # shape; see https://hermes-agent.nousresearch.com/docs/gateway.
     command:
-      - dashboard
-      - --host
-      - 0.0.0.0
-      - --port
-      - "9119"
-      - --no-open
-      - --insecure
+      - gateway
+      - run
     healthcheck:
       test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
       interval: 30s

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -1,0 +1,83 @@
+services:
+  hermes:
+    # SHA-pinned to NousResearch/hermes-agent@dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
+    # (2026-05-12). Upstream's CI publishes a sha-<full-sha> tag for every main
+    # push, so this is an immutable reference. Bumping the pin is a deliberate
+    # review-and-smoke-test pass — see docs/HERMES.md "How to bump the pin."
+    image: nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
+    container_name: dream-hermes
+    restart: unless-stopped
+    # NOT host networking — we use bridge so the container can resolve
+    # `llama-server` via Docker's internal DNS. Upstream's reference compose
+    # uses host mode; we deviate because Dream Server is multi-service and
+    # depends on inter-container service discovery.
+    environment:
+      # User remapping: match the host user so files written into the volume
+      # are owned by the user, not container-root. Same pattern as n8n.
+      - HERMES_UID=${UID:-10000}
+      - HERMES_GID=${GID:-10000}
+      # Point Hermes at the local LLM. provider=custom is the documented
+      # alias for any OpenAI-compatible local server (vLLM / llama.cpp / Ollama).
+      # The actual provider/model wiring lives in cli-config.yaml (mounted below).
+      - OPENAI_BASE_URL=${HERMES_LLM_BASE_URL:-http://llama-server:8080/v1}
+      - OPENAI_API_KEY=${HERMES_LLM_API_KEY:-sk-dream-hermes-local}
+      # Aggressive timeouts for local cold starts — llama-server can take
+      # >60s to load a model under heavy use.
+      - HERMES_API_TIMEOUT=1800
+      - HERMES_API_CALL_STALE_TIMEOUT=900
+      # Locale + timezone match the rest of the stack.
+      - TZ=${TIMEZONE:-UTC}
+      - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
+    volumes:
+      # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
+      # cron jobs, audit logs all live here.
+      - ./data/hermes:/opt/data
+      # Bake our cli-config.yaml + SOUL.md as the defaults Hermes copies into
+      # HERMES_HOME on first start (its entrypoint copies these examples into
+      # /opt/data/ if the destination files don't exist yet). Mounting them
+      # over the in-image versions means our defaults win without needing
+      # a custom Dockerfile.
+      - ./extensions/services/hermes/cli-config.yaml.template:/opt/hermes/cli-config.yaml.example:ro
+      - ./extensions/services/hermes/SOUL.md.template:/opt/hermes/docker/SOUL.md:ro
+    ports:
+      # BIND_ADDRESS gates LAN exposure. Default 127.0.0.1 = localhost only.
+      # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
+      # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
+      - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
+    # Run only the dashboard subcommand. Upstream's image entrypoint defaults
+    # to `hermes` (no args) which is for interactive use. We want exactly the
+    # FastAPI + React UI. --insecure is required because the dashboard refuses
+    # non-loopback binds without it (it stores API keys); inside Dream Server's
+    # trusted-LAN posture this is the documented v1 trade-off. --no-open keeps
+    # Hermes from trying to open a browser inside the container.
+    command:
+      - dashboard
+      - --host
+      - 0.0.0.0
+      - --port
+      - "9119"
+      - --no-open
+      - --insecure
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s  # skills sync + config bootstrap can take a while
+    # Hermes pulls in playwright + ffmpeg + chromium + ML deps — image is
+    # multi-GB. Reasonable resource caps so it doesn't crowd out the LLM.
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -75,13 +75,10 @@ services:
       - gateway
       - run
     healthcheck:
-      # Hermes's dashboard auth gates everything under /api/* (returns 401),
-      # so /api/health is NOT a usable healthcheck — curl -fs would fail
-      # and the container would be perpetually unhealthy. Verified against
-      # the SHA-pinned image during smoke test: the unauthenticated
-      # endpoints are /healthz, /health, /status, /ping at the root.
-      # /healthz is the convention closest to k8s-style probes.
-      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/healthz"]
+      # /api/health does not exist in the pinned upstream image, and most
+      # /api/* routes are session-token gated. /api/status is explicitly
+      # public, read-only, and JSON-backed, so use it for container health.
+      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/status"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -75,7 +75,13 @@ services:
       - gateway
       - run
     healthcheck:
-      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
+      # Hermes's dashboard auth gates everything under /api/* (returns 401),
+      # so /api/health is NOT a usable healthcheck — curl -fs would fail
+      # and the container would be perpetually unhealthy. Verified against
+      # the SHA-pinned image during smoke test: the unauthenticated
+      # endpoints are /healthz, /health, /status, /ping at the root.
+      # /healthz is the convention closest to k8s-style probes.
+      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -1,0 +1,65 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: hermes
+  name: Hermes Agent
+  aliases: [agent, hermes-agent]
+  container_name: dream-hermes
+  default_host: hermes
+  # Hermes's own dashboard listens on 9119 inside the container. We expose
+  # the same port externally — keeps URLs intuitive when users follow the
+  # mDNS hostname (hermes.<device>.local:9119).
+  port: 9119
+  external_port_env: HERMES_PORT
+  external_port_default: 9119
+  health: /api/health
+  ui_path: /
+  health_timeout: 60  # Hermes does skill sync + config bootstrap on cold start
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: [llama-server]
+  description: >
+    Hermes Agent (Nous Research) — a self-improving generalist agent with
+    persistent memory, autonomous skill creation, and 70+ built-in tools.
+    Dream Server runs the upstream image pinned by SHA, points it at the
+    local LLM (llama-server), and disables the messaging gateways (Telegram /
+    Discord / Slack / etc.) since the web dashboard is the surface we ship.
+    Reachable on the LAN at hermes.<device>.local:9119 via mDNS.
+
+  env_vars:
+    - key: HERMES_PORT
+      default: "9119"
+      description: External port for Hermes's own dashboard (FastAPI + React UI)
+    - key: HERMES_MODEL_NAME
+      default: "qwen3.5-9b"
+      description: |
+        Model name passed to Hermes. Defaults to Dream Server's LLM_MODEL.
+        Hermes uses provider=custom so this is mostly a label — what matters
+        is HERMES_LLM_BASE_URL pointing at an OpenAI-compatible endpoint.
+    - key: HERMES_LLM_BASE_URL
+      default: "http://llama-server:8080/v1"
+      description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.
+    - key: HERMES_LLM_API_KEY
+      default: "sk-dream-hermes-local"
+      description: |
+        Dummy API key — llama-server doesn't validate it but the OpenAI SDK
+        Hermes uses internally requires the field to be non-empty.
+
+features:
+  - id: hermes-agent
+    name: Hermes Agent
+    description: Generalist self-improving agent — chat, tools, persistent memory, scheduled tasks
+    icon: Bot
+    category: productivity
+    requirements:
+      services: [llama-server]
+      vram_gb: 0
+    enabled_services_all: [hermes]
+    setup_time: ~1 minute (image pull)
+    priority: 5
+    gpu_backends: [all]

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -10,8 +10,9 @@ service:
   container_name: dream-hermes
   default_host: hermes
   # Hermes's own dashboard listens on 9119 inside the container. We expose
-  # the same port externally — keeps URLs intuitive when users follow the
-  # mDNS hostname (hermes.<device>.local:9119).
+  # the same port externally so direct LAN access (or curl-from-host
+  # debugging) hits a predictable URL. End users normally go through
+  # hermes-proxy on :9120 (auth-gated entry point); see HERMES-SSO.md.
   port: 9119
   external_port_env: HERMES_PORT
   external_port_default: 9119
@@ -27,20 +28,16 @@ service:
     Hermes Agent (Nous Research) — a self-improving generalist agent with
     persistent memory, autonomous skill creation, and 70+ built-in tools.
     Dream Server runs the upstream image pinned by SHA, points it at the
-    local LLM (llama-server), and disables the messaging gateways (Telegram /
-    Discord / Slack / etc.) since the web dashboard is the surface we ship.
-    Reachable on the LAN at hermes.<device>.local:9119 via mDNS.
+    local LLM (llama-server), and ships no messaging-platform adapters
+    (Telegram / Discord / Slack / etc.) since the web dashboard is the
+    surface we ship. The container runs `hermes gateway run` with the
+    dashboard embedded (HERMES_DASHBOARD=1) so the scheduler that fires
+    cron jobs actually runs.
 
   env_vars:
     - key: HERMES_PORT
       default: "9119"
       description: External port for Hermes's own dashboard (FastAPI + React UI)
-    - key: HERMES_MODEL_NAME
-      default: "qwen3.5-9b"
-      description: |
-        Model name passed to Hermes. Defaults to Dream Server's LLM_MODEL.
-        Hermes uses provider=custom so this is mostly a label — what matters
-        is HERMES_LLM_BASE_URL pointing at an OpenAI-compatible endpoint.
     - key: HERMES_LLM_BASE_URL
       default: "http://llama-server:8080/v1"
       description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.
@@ -49,6 +46,11 @@ service:
       description: |
         Dummy API key — llama-server doesn't validate it but the OpenAI SDK
         Hermes uses internally requires the field to be non-empty.
+    # Note: there is intentionally no HERMES_MODEL_NAME here. The model
+    # name lives in /opt/data/config.yaml after first start; an earlier
+    # draft exposed an env var, but the upstream image doesn't read it
+    # at runtime — only the YAML file. Edit the file (or delete it to
+    # re-copy from the template) to change the model.
 
 features:
   - id: hermes-agent

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -16,12 +16,11 @@ service:
   port: 9119
   external_port_env: HERMES_PORT
   external_port_default: 9119
-  # /api/* is auth-gated by Hermes's dashboard (returns 401 without
-  # credentials), so /api/health isn't usable as an external probe.
-  # Verified against the SHA-pinned upstream image: /healthz at the
-  # root returns 200 unauthenticated — matches the container's own
-  # healthcheck in compose.yaml. Keep these aligned.
-  health: /healthz
+  # Most /api/* routes are session-token gated, and /api/health does not
+  # exist in the pinned upstream image. /api/status is explicitly public,
+  # read-only, and JSON-backed, so it is the health path Dream should poll.
+  # Keep this aligned with the container healthcheck in compose.yaml.
+  health: /api/status
   ui_path: /
   health_timeout: 60  # Hermes does skill sync + config bootstrap on cold start
   type: docker

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -37,7 +37,12 @@ service:
   env_vars:
     - key: HERMES_PORT
       default: "9119"
-      description: External port for Hermes's own dashboard (FastAPI + React UI)
+      description: |
+        External port for Hermes's own dashboard. Used only when Hermes is
+        the LAN-facing entry — e.g., direct dev access or smoke tests with
+        the hermes-proxy extension disabled. With hermes-proxy enabled,
+        Hermes is internal-only (compose switches to `expose:`) and this
+        knob is informational; the user-facing port becomes HERMES_PROXY_PORT.
     - key: HERMES_LLM_BASE_URL
       default: "http://llama-server:8080/v1"
       description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -16,7 +16,12 @@ service:
   port: 9119
   external_port_env: HERMES_PORT
   external_port_default: 9119
-  health: /api/health
+  # /api/* is auth-gated by Hermes's dashboard (returns 401 without
+  # credentials), so /api/health isn't usable as an external probe.
+  # Verified against the SHA-pinned upstream image: /healthz at the
+  # root returns 200 unauthenticated — matches the container's own
+  # healthcheck in compose.yaml. Keep these aligned.
+  health: /healthz
   ui_path: /
   health_timeout: 60  # Hermes does skill sync + config bootstrap on cold start
   type: docker


### PR DESCRIPTION
# H-1: Package Hermes Agent as a Dream Server extension

**Branch:** `feat/hermes-extension`
**Effort:** Small — 5 new files, 2 modified, 498 insertions
**Depends on:** none

## Summary

Adds **Hermes Agent** ([Nous Research, MIT, Feb 2026](https://github.com/nousresearch/hermes-agent)) as an opt-in Dream Server extension. Hermes is a self-improving generalist agent with persistent memory, autonomous skill creation, and 70+ built-in tools — and it ships its own complete browser dashboard, so we're packaging rather than building.

After `dream enable hermes`, users browse to port 9119 on the host and find Hermes's native chat / sessions / skills / cron / models / analytics surface, talking to the local `llama-server` via OpenAI-compatible API.

**This is the integration carve-out from a longer original plan.** Initial walkthrough assumed Hermes was missing a browser chat UI and proposed a 7-PR build. Inspection of the upstream repo showed Hermes already ships React 19 + Vite + Tailwind + full FastAPI surface (ChatPage, SessionsPage, SkillsPage, CronPage, ProfilesPage, ModelsPage, LogsPage, AnalyticsPage, ConfigPage, EnvPage, PluginsPage). The original H-2 (bridge), H-3 (chat UI), H-4 (multi-user), and most of H-7 (dashboard surface) became unnecessary. Remaining items moved to "roadmap follow-ups" in `docs/HERMES.md`.

## Files

| File | Lines | What |
|---|---|---|
| `extensions/services/hermes/manifest.yaml` (new) | 49 | Schema-compliant service manifest. `category: optional`, `depends_on: [llama-server]`, `external_port_env: HERMES_PORT` (default 9119), `health: /api/health`, `health_timeout: 60` (skill sync on cold start). |
| `extensions/services/hermes/compose.yaml` (new) | 79 | Pulls SHA-pinned `nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f`. Bridge network (not host) so the container resolves `llama-server` via Docker DNS. Runs only the `dashboard` subcommand. `BIND_ADDRESS` gates LAN exposure. 4 CPU / 4 GB hard caps. |
| `extensions/services/hermes/cli-config.yaml.template` (new) | 68 | Mounted over upstream's `cli-config.yaml.example` — becomes the default Hermes copies into HERMES_HOME on first start. `provider: custom` at `llama-server:8080/v1`, all messaging gateways disabled (`gateway.enabled: false`), context length matched to Dream's CTX_SIZE. |
| `extensions/services/hermes/SOUL.md.template` (new) | 52 | Default persona. Generalist, action-oriented, local-first. Explicit "you are NOT a coding agent — point users at DreamForge." |
| `.env.example` (+18) | | Documented HERMES_* block. |
| `.env.schema.json` (+26) | | Schema entries for HERMES_PORT, HERMES_MODEL_NAME, HERMES_LLM_BASE_URL, HERMES_LLM_API_KEY (secret), HERMES_LANGUAGE. |
| `docs/HERMES.md` (new) | 162 | Architecture diagram, setup walkthrough, config layering (file vs env vs defaults), security posture, **SHA-bump runbook with exact `gh api` commands**, troubleshooting, upstream attribution, bump history table. |

## Architecture

```
  Browser
     │  http://<device>:9119
     ▼
  ┌─────────────────────────────────────┐
  │  dream-hermes container             │
  │    upstream nousresearch image      │
  │    SHA-pinned to dd0923b            │
  │                                     │
  │    FastAPI dashboard:               │
  │      - serves React SPA             │
  │      - /api endpoints               │
  │      - drives AIAgent class         │
  │                                     │
  │    State: /opt/data (HERMES_HOME)   │
  │      mounted from data/hermes/      │
  └─────────────────────────────────────┘
                  │
                  │  OpenAI-compatible API
                  ▼
            llama-server (existing)
```

## Image source

Pinned to `nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f`. Upstream's CI publishes a `sha-<full-sha>` tag for every main push (verified by reading `.github/workflows/docker-publish.yml`), so this is an immutable reference. Bumping is a documented runbook in `docs/HERMES.md` — diff upstream commits, smoke test, update the pin.

## Security posture

- **`--insecure` flag enabled.** Hermes's own dashboard refuses non-loopback binds otherwise because it stores API keys. Inside Dream Server's trusted-LAN model this is the v1 trade-off; loudly documented in `docs/HERMES.md`. Don't expose port 9119 to the public internet — use Tailscale (PR-12 of the onboarding plan).
- **Non-root container** (UID 10000, remappable via HERMES_UID). Upstream entrypoint drops privileges via `gosu` before agent code runs.
- **Messaging gateways globally disabled.** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS are all off by default — users reach Hermes via the web dashboard. Enabling any platform is opt-in via env vars + config edits.
- **`security_opt: no-new-privileges`** + log rotation + resource limits = same defaults as the rest of Dream's optional services.

## Test plan

**Automated (in this PR):**
- [x] `python -c yaml.safe_load(manifest.yaml)` — passes
- [x] `python -c yaml.safe_load(compose.yaml)` — passes
- [x] `python -c yaml.safe_load(cli-config.yaml.template)` — passes
- [x] `python -c json.load(.env.schema.json)` — passes
- [x] `docker compose -f compose.yaml config --quiet` — passes (no exit code, no errors)

**Manual smoke test** (requires running Dream Server + an internet pull):

- [ ] `dream enable hermes` → container starts, health check passes within ~60s
- [ ] `curl localhost:9119/api/health` → 200
- [ ] Browse to `http://localhost:9119` → upstream React UI loads
- [ ] In Hermes's ChatPage, send "what model are you?" → Hermes uses the local llama-server and responds
- [ ] In Hermes's SessionsPage, conversation persists; restart container; conversation survives (state is in `data/hermes/sessions/`)
- [ ] In Hermes's ModelsPage, the configured base_url shows `http://llama-server:8080/v1`
- [ ] `dream disable hermes` → container stops cleanly
- [ ] With `BIND_ADDRESS=0.0.0.0` set in `.env` and Hermes restarted, dashboard is reachable from another LAN device at `http://<host-ip>:9119`

## What's NOT in this PR

Documented as roadmap follow-ups in `docs/HERMES.md`:

- **mDNS announcement** (`hermes.<device>.local`) — one-line follow-up after PR-1 (`feat/mdns-announcer`) merges. We don't reach into another branch's file from this PR.
- **APE policy integration** — route Hermes's tool calls through APE for audit. APE is already in the stack; needs a small adapter.
- **Magic-link SSO** — hand off magic-link redemptions ([PR-4](https://github.com/Light-Heart-Labs/DreamServer/pull/1155)) into a Hermes auth session so family members don't need separate Hermes credentials.
- **Voice in/out from Dream's whisper + kokoro** — Hermes has its own audio pipeline (ffmpeg bundled); needs verification of whether it already proxies to local TTS/STT services or whether we need a small adapter.
- **Dream-side status panel** — surface Hermes's session count + skill inventory inside the Dream dashboard. Lower priority since Hermes has its own AnalyticsPage.

## Caveats

- **Image size:** Hermes pulls in playwright + chromium + ffmpeg + ML deps — multi-GB. First `dream enable hermes` takes a minute or two on a fast connection. Subsequent restarts are fast.
- **The SHA pin captures upstream-CI-state at a moment in time.** Hermes is a young project (~3 months old as of this integration); upstream may move fast. The pin is reproducible but does mean we own the bump cadence. Runbook in `docs/HERMES.md`.
- **No APE wrap yet.** Hermes's tool surface includes shell + file write. Until APE wrapping lands, the trust model is "the user authenticated to Hermes is trusted to use the local container." Reasonable for single-admin homes; tighten when multi-user lands.

## Upstream attribution

Hermes Agent is © 2026 Nous Research, MIT-licensed. Dream Server's contribution in this PR is purely packaging — no code is forked. The pinned image pulls directly from `docker.io/nousresearch/hermes-agent`.

Sources reviewed during integration design:
- [github.com/NousResearch/hermes-agent](https://github.com/nousresearch/hermes-agent)
- [hermes-agent.nousresearch.com/docs/](https://hermes-agent.nousresearch.com/docs/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
