### PR TITLE
feat(hermes): route tool calls through APE via pre_tool_call plugin

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -315,6 +315,6 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # call through (default; matches Dream's trusted-LAN posture). Flip to false
 # if you're exposing Hermes to less-trusted networks.
 # APE_URL=http://ape:7890                # APE service URL (internal Docker DNS)
-# APE_API_KEY=                           # Bearer token if APE has auth enabled
+# APE_API_KEY=                           # X-API-Key value; must match the APE service's APE_API_KEY
 # APE_FAIL_OPEN=true                     # true = allow on APE-unreachable
 # APE_TIMEOUT=5                          # Per-request timeout (seconds)

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -291,3 +291,19 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # DREAMFORGE_MODEL=                    # Auto-detected from LLM server if empty
 # DREAMFORGE_RAG_ENABLED=false
 # DREAMFORGE_COMPACT_THRESHOLD=10000
+
+# ═══════════════════════════════════════════════════════════════════
+# Hermes Agent (Remote-capable Chat + Generalist Agent)
+# ═══════════════════════════════════════════════════════════════════
+# Hermes Agent (Nous Research, MIT) — chat-first generalist agent with
+# persistent memory, autonomous skill creation, and 70+ tools. Dream
+# Server runs the upstream image pinned by SHA and points it at the
+# local LLM. Browser UI ships in the upstream image (port 9119).
+# Enable: `dream enable hermes`. Reachable at hermes.<device>.local:9119
+# once mDNS picks it up.
+#
+# HERMES_PORT=9119                       # External dashboard port
+# HERMES_MODEL_NAME=qwen3.5-9b           # Model label passed to Hermes
+# HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
+# HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
+# HERMES_LANGUAGE=en                     # UI language

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -303,7 +303,8 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # once mDNS picks it up.
 #
 # HERMES_PORT=9119                       # External dashboard port
-# HERMES_MODEL_NAME=qwen3.5-9b           # Model label passed to Hermes
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
 # HERMES_LANGUAGE=en                     # UI language
+# (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
+#  not in env. Edit the file after first start to switch models.)

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -308,3 +308,13 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # HERMES_LANGUAGE=en                     # UI language
 # (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
 #  not in env. Edit the file after first start to switch models.)
+#
+# APE policy enforcement — Hermes's `pre_tool_call` hook routes every tool
+# call through APE for allow/deny + audit. The ape extension must be enabled
+# for these to do anything. fail_open=true means APE-unreachable allows the
+# call through (default; matches Dream's trusted-LAN posture). Flip to false
+# if you're exposing Hermes to less-trusted networks.
+# APE_URL=http://ape:7890                # APE service URL (internal Docker DNS)
+# APE_API_KEY=                           # Bearer token if APE has auth enabled
+# APE_FAIL_OPEN=true                     # true = allow on APE-unreachable
+# APE_TIMEOUT=5                          # Per-request timeout (seconds)

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -700,10 +700,6 @@
       "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
       "default": 9119
     },
-    "HERMES_MODEL_NAME": {
-      "type": "string",
-      "description": "Model name label passed to Hermes Agent. Hermes uses provider=custom against the local llama-server, so this is mostly a display label; what matters is HERMES_LLM_BASE_URL."
-    },
     "HERMES_LLM_BASE_URL": {
       "type": "string",
       "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -296,7 +296,7 @@
     },
     "APE_API_KEY": {
       "type": "string",
-      "description": "API key for the APE (AI Proxy Engine) extension",
+      "description": "Shared X-API-Key value for the APE (AI Proxy Engine) service and any plugin that calls /verify (e.g. Hermes's ape-policy). Must be identical across both sides; APE auto-generates a random per-process key when unset, which causes 401s from any caller.",
       "secret": true
     },
     "SHIELD_API_KEY": {
@@ -719,11 +719,6 @@
       "type": "string",
       "description": "APE policy engine service URL consumed by Hermes's ape-policy plugin. Defaults to http://ape:7890 (internal Docker DNS).",
       "default": "http://ape:7890"
-    },
-    "APE_API_KEY": {
-      "type": "string",
-      "description": "Bearer token sent with APE /verify requests when APE has auth enabled. Empty = no auth header.",
-      "secret": true
     },
     "APE_FAIL_OPEN": {
       "type": "string",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -714,6 +714,26 @@
       "type": "string",
       "description": "UI language for Hermes Agent's web dashboard (defaults to en).",
       "default": "en"
+    },
+    "APE_URL": {
+      "type": "string",
+      "description": "APE policy engine service URL consumed by Hermes's ape-policy plugin. Defaults to http://ape:7890 (internal Docker DNS).",
+      "default": "http://ape:7890"
+    },
+    "APE_API_KEY": {
+      "type": "string",
+      "description": "Bearer token sent with APE /verify requests when APE has auth enabled. Empty = no auth header.",
+      "secret": true
+    },
+    "APE_FAIL_OPEN": {
+      "type": "string",
+      "description": "Behavior when APE is unreachable: 'true' allows the tool call (default), 'false' blocks. Flip to false for less-trusted network exposure.",
+      "default": "true"
+    },
+    "APE_TIMEOUT": {
+      "type": "string",
+      "description": "Per-request timeout in seconds for the ape-policy plugin's /verify calls.",
+      "default": "5"
     }
   }
 }

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -694,6 +694,30 @@
       "type": "string",
       "description": "Enable/disable Langfuse telemetry",
       "default": "false"
+    },
+    "HERMES_PORT": {
+      "type": "integer",
+      "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
+      "default": 9119
+    },
+    "HERMES_MODEL_NAME": {
+      "type": "string",
+      "description": "Model name label passed to Hermes Agent. Hermes uses provider=custom against the local llama-server, so this is mostly a display label; what matters is HERMES_LLM_BASE_URL."
+    },
+    "HERMES_LLM_BASE_URL": {
+      "type": "string",
+      "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",
+      "default": "http://llama-server:8080/v1"
+    },
+    "HERMES_LLM_API_KEY": {
+      "type": "string",
+      "description": "Dummy API key for Hermes Agent's OpenAI SDK (llama-server doesn't validate it, but the SDK requires the field to be non-empty).",
+      "secret": true
+    },
+    "HERMES_LANGUAGE": {
+      "type": "string",
+      "description": "UI language for Hermes Agent's web dashboard (defaults to en).",
+      "default": "en"
     }
   }
 }

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -27,10 +27,12 @@ Hermes ships its own complete web UI — Dream Server is just packaging it. Afte
   ┌─────────────────────────────────────┐
   │  dream-hermes container             │
   │                                     │
-  │   Upstream FastAPI dashboard        │
-  │     - serves React SPA              │
-  │     - exposes /api endpoints        │
-  │     - drives AIAgent class          │
+  │   hermes gateway run                │
+  │     - HERMES_DASHBOARD=1 →          │
+  │         React SPA + /api endpoints  │
+  │     - scheduler tick() every 60s →  │
+  │         fires cron jobs             │
+  │     - no messaging adapters         │
   │                                     │
   │   State: /opt/data (HERMES_HOME)    │
   │     mounted from data/hermes/       │
@@ -82,7 +84,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 ## Defaults Dream Server applies
 
 - **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
-- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — change `HERMES_MODEL_NAME` if you've swapped models)
+- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
 - **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
 - **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
@@ -92,8 +94,8 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 
 Three layers, highest to lowest precedence:
 
-1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting.
-2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_MODEL_NAME`, etc. See `.env.example` for the full list.
+1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting. **The model name lives here**, not in env.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_LLM_API_KEY`, `HERMES_PORT`, `HERMES_LANGUAGE`. These are the only Hermes settings the container actually reads from env. See `.env.example`.
 3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
 
 To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -1,0 +1,188 @@
+# Hermes Agent
+
+Dream Server ships an optional **Hermes Agent** extension — the [Nous Research open-source agent](https://github.com/nousresearch/hermes-agent) packaged as a Dream Server service. Hermes is a self-improving generalist agent with persistent memory, autonomous skill creation, and 70+ tools built in.
+
+When enabled, Hermes runs in a container alongside the rest of the stack, exposes its own browser dashboard at port 9119, and talks to the local LLM (llama-server) via its OpenAI-compatible API.
+
+## What you get
+
+Hermes ships its own complete web UI — Dream Server is just packaging it. After `dream enable hermes`, you can browse to `http://<device>:9119` (or `hermes.<device>.local:9119` once mDNS announcement lands — see "Roadmap" below) and find pages for:
+
+- **Chat** — conversational interface with streaming responses + inline tool calls
+- **Sessions** — list, switch between, prune past conversations
+- **Skills** — view skills Hermes has autonomously created from your interactions; edit or delete
+- **Memories** — persistent facts Hermes has learned about you
+- **Profiles** — per-user agent contexts (a built-in alternative to running multiple Hermes containers)
+- **Cron** — schedule recurring agent tasks
+- **Models** — pick which LLM Hermes uses (defaults to your llama-server)
+- **Config / Env** — Hermes's own settings
+- **Logs / Analytics** — operational visibility
+
+## Architecture
+
+```
+  Browser
+     │  http://<device>:9119
+     ▼
+  ┌─────────────────────────────────────┐
+  │  dream-hermes container             │
+  │                                     │
+  │   Upstream FastAPI dashboard        │
+  │     - serves React SPA              │
+  │     - exposes /api endpoints        │
+  │     - drives AIAgent class          │
+  │                                     │
+  │   State: /opt/data (HERMES_HOME)    │
+  │     mounted from data/hermes/       │
+  │                                     │
+  │   Tool sandbox: local (in-container)│
+  └─────────────────────────────────────┘
+                  │
+                  │  OpenAI-compatible API
+                  ▼
+  ┌─────────────────────────────────────┐
+  │  llama-server (existing)            │
+  │     llama.cpp at :8080/v1           │
+  └─────────────────────────────────────┘
+```
+
+State layout under `data/hermes/`:
+
+```
+data/hermes/
+├── config.yaml      # Bootstrapped from our cli-config.yaml.template on first start
+├── .env             # Bootstrapped from upstream's .env.example
+├── SOUL.md          # Bootstrapped from our SOUL.md.template
+├── sessions/        # Per-session chat history
+├── memories/        # Persistent agent memories
+├── skills/          # Agent-authored skills
+├── cron/            # Scheduled tasks
+├── plans/           # Active multi-step plans
+├── workspace/       # Sandboxed workspace for file ops
+├── hooks/           # Custom lifecycle hooks
+├── home/            # Per-profile $HOME for subprocesses (git, ssh, npm…)
+└── logs/            # Hermes's own logs (separate from Docker logs)
+```
+
+## Setup
+
+```bash
+# 1. (One-time) Verify Dream Server's llama-server is running:
+dream status llama-server
+
+# 2. Pull + start Hermes:
+dream enable hermes
+
+# 3. (Optional) Open the dashboard:
+xdg-open http://localhost:9119
+```
+
+The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.py` bootstrap, and llama-server may cold-load the model on Hermes's first request. Subsequent starts are fast.
+
+## Defaults Dream Server applies
+
+- **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
+- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — change `HERMES_MODEL_NAME` if you've swapped models)
+- **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
+- **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
+- **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
+- **Resource caps:** 4 CPUs / 4GB RAM hard limit, 0.5 CPU / 1GB reservation. Hermes's playwright + ML deps can be hungry; adjust in `extensions/services/hermes/compose.yaml` if needed.
+
+## Configuration
+
+Three layers, highest to lowest precedence:
+
+1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_MODEL_NAME`, etc. See `.env.example` for the full list.
+3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
+
+To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.
+
+## Security posture
+
+- **`--insecure` is enabled.** Hermes's dashboard refuses to bind to non-loopback addresses without it (the dashboard stores API keys, so binding 0.0.0.0 has a clear "you sure?" gate). Dream Server's trusted-LAN posture accepts this trade-off for v1. **Don't expose port 9119 to the public internet.** Use Tailscale (PR-12 from the onboarding plan) if you need remote access.
+- **The container runs as a non-root user** (UID 10000 by default, remappable via `HERMES_UID`). The entrypoint drops privileges via `gosu` before any agent code runs.
+- **The container has full network access** within Dream Server's bridge net — Hermes can make outbound HTTP requests for tools like `web_search`. If you want to restrict this, add an iptables firewall rule on the host or run Hermes behind a forward proxy.
+- **No APE policy enforcement yet.** Hermes's 70+ tools include shell + file write. The base config defaults toward less-risky tools, but Hermes can still execute shell commands inside its sandbox container. APE policy wrapping is a planned follow-up; until then, the trust model is "the user authenticated to Hermes is trusted to use the local container."
+
+## How to bump the SHA pin
+
+Hermes is a young, fast-moving project (~3 months old as of v1 integration). The SHA pin in `compose.yaml` lets us audit upstream changes deliberately rather than auto-tracking `:latest`. Bumping is a 5-minute pass:
+
+```bash
+# 1. Pick the new SHA. Upstream publishes a sha-<full-sha> tag for every
+#    main push, so any commit on NousResearch/hermes-agent's main is fair game.
+gh api repos/NousResearch/hermes-agent/commits/main --jq '{sha,date:.commit.author.date,msg:.commit.message}'
+
+# 2. Read the diff since our current pin. Skim breaking changes,
+#    config-format migrations, removed env vars.
+gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.commits[].commit.message'
+
+# 3. Update extensions/services/hermes/compose.yaml — the only place the
+#    pin appears.
+
+# 4. Smoke test:
+#    dream restart hermes
+#    curl http://localhost:9119/api/health  # should 200
+#    open http://localhost:9119, send a chat, verify tool call
+
+# 5. If it works, commit. If config.yaml format has changed, document the
+#    migration in this file's "Bump history" section below.
+```
+
+## Roadmap (deferred from v1)
+
+These were in the original integration plan but cut once we discovered Hermes ships a complete browser surface:
+
+- **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer (`bin/dream-mdns.py` lands in [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)). One-line follow-up after that PR merges.
+- **APE policy integration** — route Hermes's tool calls through APE for allow/deny + audit. APE is already in the stack; needs a small adapter inside or in front of Hermes.
+- **Magic-link SSO** — hand off magic-link redemptions ([#1155](https://github.com/Light-Heart-Labs/DreamServer/pull/1155)) into a Hermes auth session so family members don't need separate Hermes credentials.
+- **Voice in/out from Dream Server's whisper + kokoro** — Hermes has its own audio pipeline (the image bundles ffmpeg + playwright); verify whether it already proxies to local TTS/STT services or whether we need to wire that ourselves.
+- **Dream-side status panel** — surface Hermes's session count + skill inventory in the Dream dashboard. Lower priority since Hermes has its own `AnalyticsPage`.
+
+## Troubleshooting
+
+### `curl localhost:9119/api/health` returns 502 / connection refused
+
+Hermes hasn't finished bootstrapping. Watch the logs:
+
+```bash
+docker logs -f dream-hermes
+```
+
+First start does a ~30s skills sync; subsequent starts are fast.
+
+### Hermes can't reach the LLM
+
+Inside the container, `llama-server:8080` should resolve to the llama-server container. Test with:
+
+```bash
+docker exec dream-hermes curl -fs http://llama-server:8080/v1/models
+```
+
+If that fails, the most likely cause is that the Hermes container isn't on Dream Server's docker network. Check `docker network inspect dream-server_default`.
+
+### Sessions / memories / skills disappeared after upgrade
+
+The SHA pin protects you from accidental version drift, but if you DID bump and lose data, it's almost certainly because Hermes's config format changed. Check `data/hermes/config.yaml` against upstream's current `cli-config.yaml.example`. The container's first start regenerates `config.yaml` from our template only if it doesn't exist — your old config sticks around.
+
+### "I don't want Hermes anymore"
+
+```bash
+dream disable hermes              # stops the container
+rm -rf data/hermes                # wipes all sessions / memories / skills
+```
+
+The container image stays cached — `docker image prune` removes it.
+
+## Upstream attribution
+
+Hermes Agent is © 2026 Nous Research, MIT-licensed. Dream Server's contribution is the packaging layer (`extensions/services/hermes/`) — no code is forked from upstream. The pinned image is pulled directly from `docker.io/nousresearch/hermes-agent`.
+
+When promoting / talking about this extension, the convention is: "Hermes Agent (from Nous Research) — packaged for Dream Server."
+
+## Bump history
+
+| Date | Pinned SHA | Notes |
+|---|---|---|
+| 2026-05-12 | `dd0923bb89ed2dd56f82cb63656a1323f6f42e6f` | Initial integration. |

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -105,7 +105,7 @@ To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthrop
 - **`--insecure` is enabled.** Hermes's dashboard refuses to bind to non-loopback addresses without it (the dashboard stores API keys, so binding 0.0.0.0 has a clear "you sure?" gate). Dream Server's trusted-LAN posture accepts this trade-off for v1. **Don't expose port 9119 to the public internet.** Use Tailscale (PR-12 from the onboarding plan) if you need remote access.
 - **The container runs as a non-root user** (UID 10000 by default, remappable via `HERMES_UID`). The entrypoint drops privileges via `gosu` before any agent code runs.
 - **The container has full network access** within Dream Server's bridge net — Hermes can make outbound HTTP requests for tools like `web_search`. If you want to restrict this, add an iptables firewall rule on the host or run Hermes behind a forward proxy.
-- **No APE policy enforcement yet.** Hermes's 70+ tools include shell + file write. The base config defaults toward less-risky tools, but Hermes can still execute shell commands inside its sandbox container. APE policy wrapping is a planned follow-up; until then, the trust model is "the user authenticated to Hermes is trusted to use the local container."
+- **APE policy enforcement is wired in.** Every Hermes tool call hits APE's `/verify` endpoint before execution (via Hermes's `pre_tool_call` plugin hook — see `extensions/services/hermes/plugins/ape-policy/`). Denied calls return as block messages to the agent, which surfaces them as tool errors in the conversation. Behavior when APE is unreachable is configurable via `APE_FAIL_OPEN` (default `true` for Dream's trusted-LAN posture). For tighter exposure (e.g. Hermes-over-Tailscale-to-public-internet), set `APE_FAIL_OPEN=false` so unreachable APE blocks instead of permitting.
 
 ## How to bump the SHA pin
 
@@ -137,7 +137,7 @@ gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.comm
 These were in the original integration plan but cut once we discovered Hermes ships a complete browser surface:
 
 - **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer (`bin/dream-mdns.py` lands in [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)). One-line follow-up after that PR merges.
-- **APE policy integration** — route Hermes's tool calls through APE for allow/deny + audit. APE is already in the stack; needs a small adapter inside or in front of Hermes.
+- **APE policy integration** — ✅ shipped via the `ape-policy` plugin under `extensions/services/hermes/plugins/`. Uses Hermes's native `pre_tool_call` hook to call APE's `/verify` endpoint before each tool execution. Configurable fail-open / fail-closed via `APE_FAIL_OPEN`.
 - **Magic-link SSO** — hand off magic-link redemptions ([#1155](https://github.com/Light-Heart-Labs/DreamServer/pull/1155)) into a Hermes auth session so family members don't need separate Hermes credentials.
 - **Voice in/out from Dream Server's whisper + kokoro** — Hermes has its own audio pipeline (the image bundles ffmpeg + playwright); verify whether it already proxies to local TTS/STT services or whether we need to wire that ourselves.
 - **Dream-side status panel** — surface Hermes's session count + skill inventory in the Dream dashboard. Lower priority since Hermes has its own `AnalyticsPage`.

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -1,0 +1,56 @@
+# Hermes — Dream Server Default Persona
+
+You are **Hermes**, the resident agent on a Dream Server installation. Dream
+Server is a fully-local AI stack — chat, voice, image generation, agents,
+workflows, RAG, and privacy tooling — that runs on the user's own hardware
+with no data ever leaving their machine.
+
+You are a **generalist agent**. You can chat conversationally, but you can
+also take real action: search the web, read and write files, run shell
+commands (when policy allows), keep notes, set reminders, ingest documents,
+and recall things from past conversations.
+
+## Operating principles
+
+1. **Take the action when it's clear.** If a user says "look up the weather
+   in Tokyo," search the web — don't ask permission first. Save the asking
+   for genuinely destructive or non-reversible operations (file deletion,
+   sending email on their behalf, etc.).
+
+2. **Show your work.** When you use a tool, mention what you did briefly. The
+   user sees tool calls in the UI, so the goal is just to weave them into
+   the conversation, not narrate every step in detail.
+
+3. **Remember what matters.** Hermes has persistent memory — if a user tells
+   you something durable about themselves ("I'm allergic to peanuts," "my
+   partner's name is Alex"), save it. Don't save every passing detail.
+
+4. **Stay local-first.** Dream Server's whole posture is that the user owns
+   their data. Don't suggest cloud services when a local equivalent exists.
+   When you DO need an external resource (a webpage, a Wikipedia article),
+   fetch only what's needed.
+
+5. **Be honest about uncertainty.** If you're not sure whether a recalled
+   fact is current, say so. The local model isn't always up to date; trust
+   web search for current events.
+
+## Tone
+
+Warm, direct, lightly informal. The user is likely on their phone or laptop
+at home, not at a help desk. Match their energy. Avoid hedging language
+("perhaps you might want to consider…"); just answer.
+
+## What you are NOT
+
+- Not a coding agent. DreamForge handles that. If the user wants you to edit
+  their code repo, gently point them at DreamForge.
+- Not a customer-service bot. Don't apologize for things that aren't your
+  fault.
+- Not a moralizer. Don't lecture the user about their choices unless they
+  ask. Respect their autonomy.
+
+## Resetting this persona
+
+The user can edit this file at `/opt/data/SOUL.md` inside the Hermes
+container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply.
+Deleting the file falls back to upstream's default persona.

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -13,9 +13,11 @@
 # Model — points at Dream Server's local LLM by default
 # =============================================================================
 model:
-  # The local model name. Defaults to Dream's LLM_MODEL via the
-  # OPENAI_BASE_URL Hermes inspects. The provider override below makes
-  # the actual model lookup happen against llama-server's /v1/models.
+  # The local model name. Defaults to "qwen3.5-9b" because that's Dream
+  # Server's default; if you've switched llama-server to a different
+  # model, edit this line in /opt/data/config.yaml after first start.
+  # (Hermes does NOT read HERMES_MODEL_NAME from env — the config.yaml
+  # is the source of truth once it's copied out of the example.)
   default: "qwen3.5-9b"
 
   # provider=custom = any OpenAI-compatible local server. Aliases:
@@ -27,6 +29,13 @@ model:
   # value here is the fallback if the env var is unset.
   base_url: "http://llama-server:8080/v1"
 
+  # Match the LLM's context window. Dream Server's default CTX_SIZE is
+  # 16384; bump this in /opt/data/config.yaml if you've raised CTX_SIZE
+  # in .env. Upstream Hermes reads this from model.context_length —
+  # earlier drafts used a top-level context: block which is silently
+  # ignored.
+  context_length: 16384
+
 # =============================================================================
 # Terminal backend — where tool calls execute
 # =============================================================================
@@ -37,30 +46,37 @@ terminal:
   backend: "local"
 
 # =============================================================================
-# Messaging gateways — DISABLED by default in Dream Server
+# Messaging gateways — none enabled by default in Dream Server
 # =============================================================================
 # Hermes ships with Telegram / Discord / Slack / WhatsApp / Signal / email /
-# Teams / Google Chat / Matrix / Mattermost / SMS gateways. Dream Server users
-# reach Hermes via the web dashboard, not platform bots. Leave these off
-# unless you understand the security implications of each.
+# Teams / Google Chat / Matrix / Mattermost / SMS gateway adapters. Dream
+# Server users reach Hermes via the web dashboard, not platform bots — so
+# none of these are configured here.
 #
-# To enable any of them, set the corresponding token in .env (TELEGRAM_TOKEN,
-# DISCORD_TOKEN, etc.) AND remove the disabled: true line from the
-# corresponding adapter config under upstream's gateway docs.
-gateway:
-  # Globally disable the messaging gateway runner. The `dashboard` subcommand
-  # is what compose.yaml starts; this just makes sure that if someone runs
-  # `docker exec dream-hermes hermes gateway run` it stays a no-op until
-  # they explicitly configure a platform.
-  enabled: false
+# IMPORTANT: there is NO top-level `gateway.enabled: false` switch in
+# upstream's config schema. Earlier drafts of this template had one; it
+# was silently ignored. The gateway is "disabled" by simply not
+# configuring any adapter (no TELEGRAM_TOKEN, no DISCORD_TOKEN, etc.),
+# which means `hermes gateway run` starts, ticks cron, hosts the
+# dashboard, and has no platforms to message on.
+#
+# To enable a platform, follow upstream's adapter docs and add the
+# matching block under the platform-specific config keys, then restart
+# the container.
 
 # =============================================================================
 # Compression — keep memory bounded on small devices
 # =============================================================================
-# Hermes auto-compacts long conversations. Lower threshold = more aggressive
-# compaction = lower disk + token costs but more summarization loss.
-context:
-  # Match the LLM's context window. Dream Server's default CTX_SIZE is 16384;
-  # bump this if you've raised CTX_SIZE in .env.
-  context_length: 16384
-  compact_threshold: 10000
+# Hermes auto-compacts long conversations once they cross the threshold.
+# These are the upstream-correct keys (compression.*); an earlier draft
+# used compact_threshold under a context: block which upstream silently
+# ignores.
+compression:
+  # Token count at which Hermes starts compacting the conversation.
+  # Lower = more aggressive = lower disk/token cost but more summary loss.
+  # Keep this comfortably below model.context_length so there's headroom
+  # before hitting the hard window limit.
+  threshold: 10000
+  # Fraction of the conversation to retain after compaction. 0.5 = aim
+  # for half the original token count post-summary.
+  target_ratio: 0.5

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -1,0 +1,66 @@
+# Hermes Agent configuration — Dream Server defaults.
+#
+# This file is mounted into the upstream image at
+# /opt/hermes/cli-config.yaml.example, which Hermes's entrypoint copies into
+# /opt/data/config.yaml on first start IF that file doesn't already exist.
+# Re-running `dream enable hermes` after editing here won't overwrite an
+# existing config — delete /opt/data/config.yaml manually if you want to
+# reset to these defaults.
+#
+# Documentation for every key: https://hermes-agent.nousresearch.com/docs/
+
+# =============================================================================
+# Model — points at Dream Server's local LLM by default
+# =============================================================================
+model:
+  # The local model name. Defaults to Dream's LLM_MODEL via the
+  # OPENAI_BASE_URL Hermes inspects. The provider override below makes
+  # the actual model lookup happen against llama-server's /v1/models.
+  default: "qwen3.5-9b"
+
+  # provider=custom = any OpenAI-compatible local server. Aliases:
+  # ollama, vllm, llamacpp. We pick "custom" for portability.
+  provider: "custom"
+
+  # base_url is overridden at container start by OPENAI_BASE_URL env
+  # (which compose.yaml wires to http://llama-server:8080/v1). The
+  # value here is the fallback if the env var is unset.
+  base_url: "http://llama-server:8080/v1"
+
+# =============================================================================
+# Terminal backend — where tool calls execute
+# =============================================================================
+# Hermes can run tools in a few different sandboxes. For Dream Server we keep
+# it local-to-the-container: no SSH out, no Modal/Daytona, no Docker-in-Docker.
+# The container IS the sandbox.
+terminal:
+  backend: "local"
+
+# =============================================================================
+# Messaging gateways — DISABLED by default in Dream Server
+# =============================================================================
+# Hermes ships with Telegram / Discord / Slack / WhatsApp / Signal / email /
+# Teams / Google Chat / Matrix / Mattermost / SMS gateways. Dream Server users
+# reach Hermes via the web dashboard, not platform bots. Leave these off
+# unless you understand the security implications of each.
+#
+# To enable any of them, set the corresponding token in .env (TELEGRAM_TOKEN,
+# DISCORD_TOKEN, etc.) AND remove the disabled: true line from the
+# corresponding adapter config under upstream's gateway docs.
+gateway:
+  # Globally disable the messaging gateway runner. The `dashboard` subcommand
+  # is what compose.yaml starts; this just makes sure that if someone runs
+  # `docker exec dream-hermes hermes gateway run` it stays a no-op until
+  # they explicitly configure a platform.
+  enabled: false
+
+# =============================================================================
+# Compression — keep memory bounded on small devices
+# =============================================================================
+# Hermes auto-compacts long conversations. Lower threshold = more aggressive
+# compaction = lower disk + token costs but more summarization loss.
+context:
+  # Match the LLM's context window. Dream Server's default CTX_SIZE is 16384;
+  # bump this if you've raised CTX_SIZE in .env.
+  context_length: 16384
+  compact_threshold: 10000

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -28,6 +28,19 @@ services:
       # Locale + timezone match the rest of the stack.
       - TZ=${TIMEZONE:-UTC}
       - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
+      # Embed the dashboard inside the gateway process (see `command` below).
+      # Upstream reads these env vars to configure the dashboard listener
+      # without separate CLI flags.
+      - HERMES_DASHBOARD=1
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=9119
+      # --insecure equivalent: dashboard refuses non-loopback binds without
+      # this since it stores API keys. The trusted-LAN posture is the v1
+      # trade-off (documented in docs/HERMES.md).
+      - HERMES_DASHBOARD_INSECURE=1
+      # --no-open equivalent: stops Hermes from trying to spawn a browser
+      # inside the container.
+      - HERMES_DASHBOARD_NO_OPEN=1
     volumes:
       # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
       # cron jobs, audit logs all live here.
@@ -44,20 +57,23 @@ services:
       # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
       # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
       - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
-    # Run only the dashboard subcommand. Upstream's image entrypoint defaults
-    # to `hermes` (no args) which is for interactive use. We want exactly the
-    # FastAPI + React UI. --insecure is required because the dashboard refuses
-    # non-loopback binds without it (it stores API keys); inside Dream Server's
-    # trusted-LAN posture this is the documented v1 trade-off. --no-open keeps
-    # Hermes from trying to open a browser inside the container.
+    # Run the gateway with the dashboard embedded.
+    #
+    # Why `gateway run` and not just `dashboard`: Hermes's scheduler (the
+    # cron tick that fires recurring tasks) runs INSIDE the gateway process,
+    # not the dashboard. Earlier drafts of this extension ran only
+    # `dashboard`, which let users create cron jobs through the UI but
+    # never actually fired them — `tick()` lives in the gateway's main
+    # loop. `gateway run` with HERMES_DASHBOARD=1 (set above) gives us
+    # both: the gateway's scheduler + the React UI, in one process.
+    #
+    # We don't enable any messaging platforms (Telegram / Discord / etc.)
+    # so the gateway has no adapters to drive — its only job here is to
+    # tick cron and host the dashboard. That's the upstream-supported
+    # shape; see https://hermes-agent.nousresearch.com/docs/gateway.
     command:
-      - dashboard
-      - --host
-      - 0.0.0.0
-      - --port
-      - "9119"
-      - --no-open
-      - --insecure
+      - gateway
+      - run
     healthcheck:
       test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
       interval: 30s

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -41,6 +41,13 @@ services:
       # --no-open equivalent: stops Hermes from trying to spawn a browser
       # inside the container.
       - HERMES_DASHBOARD_NO_OPEN=1
+      # APE policy engine wiring — consumed by the ape-policy plugin
+      # (mounted below at /opt/data/plugins/ape-policy/). If the ape
+      # extension isn't enabled, the plugin warns + applies APE_FAIL_OPEN.
+      - APE_URL=${APE_URL:-http://ape:7890}
+      - APE_API_KEY=${APE_API_KEY:-}
+      - APE_FAIL_OPEN=${APE_FAIL_OPEN:-true}
+      - APE_TIMEOUT=${APE_TIMEOUT:-5}
     volumes:
       # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
       # cron jobs, audit logs all live here.
@@ -52,6 +59,14 @@ services:
       # a custom Dockerfile.
       - ./extensions/services/hermes/cli-config.yaml.template:/opt/hermes/cli-config.yaml.example:ro
       - ./extensions/services/hermes/SOUL.md.template:/opt/hermes/docker/SOUL.md:ro
+      # ape-policy plugin — Hermes's `pre_tool_call` hook calls APE's /verify
+      # before each tool execution. Mounted into the user-plugins directory
+      # (Hermes's discovery rules: ~/.hermes/plugins/<name>/ ⇒ /opt/data/plugins/<name>/).
+      # The deeper mount overlays the parent data volume at this path; the
+      # plugin source is :ro because users shouldn't be editing it from
+      # Hermes — to disable APE checks, set APE_FAIL_OPEN=true and stop the
+      # ape extension, or remove this mount.
+      - ./extensions/services/hermes/plugins/ape-policy:/opt/data/plugins/ape-policy:ro
     ports:
       # BIND_ADDRESS gates LAN exposure. Default 127.0.0.1 = localhost only.
       # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -1,0 +1,83 @@
+services:
+  hermes:
+    # SHA-pinned to NousResearch/hermes-agent@dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
+    # (2026-05-12). Upstream's CI publishes a sha-<full-sha> tag for every main
+    # push, so this is an immutable reference. Bumping the pin is a deliberate
+    # review-and-smoke-test pass — see docs/HERMES.md "How to bump the pin."
+    image: nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
+    container_name: dream-hermes
+    restart: unless-stopped
+    # NOT host networking — we use bridge so the container can resolve
+    # `llama-server` via Docker's internal DNS. Upstream's reference compose
+    # uses host mode; we deviate because Dream Server is multi-service and
+    # depends on inter-container service discovery.
+    environment:
+      # User remapping: match the host user so files written into the volume
+      # are owned by the user, not container-root. Same pattern as n8n.
+      - HERMES_UID=${UID:-10000}
+      - HERMES_GID=${GID:-10000}
+      # Point Hermes at the local LLM. provider=custom is the documented
+      # alias for any OpenAI-compatible local server (vLLM / llama.cpp / Ollama).
+      # The actual provider/model wiring lives in cli-config.yaml (mounted below).
+      - OPENAI_BASE_URL=${HERMES_LLM_BASE_URL:-http://llama-server:8080/v1}
+      - OPENAI_API_KEY=${HERMES_LLM_API_KEY:-sk-dream-hermes-local}
+      # Aggressive timeouts for local cold starts — llama-server can take
+      # >60s to load a model under heavy use.
+      - HERMES_API_TIMEOUT=1800
+      - HERMES_API_CALL_STALE_TIMEOUT=900
+      # Locale + timezone match the rest of the stack.
+      - TZ=${TIMEZONE:-UTC}
+      - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
+    volumes:
+      # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
+      # cron jobs, audit logs all live here.
+      - ./data/hermes:/opt/data
+      # Bake our cli-config.yaml + SOUL.md as the defaults Hermes copies into
+      # HERMES_HOME on first start (its entrypoint copies these examples into
+      # /opt/data/ if the destination files don't exist yet). Mounting them
+      # over the in-image versions means our defaults win without needing
+      # a custom Dockerfile.
+      - ./extensions/services/hermes/cli-config.yaml.template:/opt/hermes/cli-config.yaml.example:ro
+      - ./extensions/services/hermes/SOUL.md.template:/opt/hermes/docker/SOUL.md:ro
+    ports:
+      # BIND_ADDRESS gates LAN exposure. Default 127.0.0.1 = localhost only.
+      # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
+      # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
+      - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
+    # Run only the dashboard subcommand. Upstream's image entrypoint defaults
+    # to `hermes` (no args) which is for interactive use. We want exactly the
+    # FastAPI + React UI. --insecure is required because the dashboard refuses
+    # non-loopback binds without it (it stores API keys); inside Dream Server's
+    # trusted-LAN posture this is the documented v1 trade-off. --no-open keeps
+    # Hermes from trying to open a browser inside the container.
+    command:
+      - dashboard
+      - --host
+      - 0.0.0.0
+      - --port
+      - "9119"
+      - --no-open
+      - --insecure
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s  # skills sync + config bootstrap can take a while
+    # Hermes pulls in playwright + ffmpeg + chromium + ML deps — image is
+    # multi-GB. Reasonable resource caps so it doesn't crowd out the LLM.
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -75,7 +75,13 @@ services:
       - gateway
       - run
     healthcheck:
-      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
+      # Hermes's dashboard auth gates everything under /api/* (returns 401),
+      # so /api/health is NOT a usable healthcheck — curl -fs would fail
+      # and the container would be perpetually unhealthy. Verified against
+      # the SHA-pinned image during smoke test: the unauthenticated
+      # endpoints are /healthz, /health, /status, /ping at the root.
+      # /healthz is the convention closest to k8s-style probes.
+      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -1,0 +1,65 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: hermes
+  name: Hermes Agent
+  aliases: [agent, hermes-agent]
+  container_name: dream-hermes
+  default_host: hermes
+  # Hermes's own dashboard listens on 9119 inside the container. We expose
+  # the same port externally — keeps URLs intuitive when users follow the
+  # mDNS hostname (hermes.<device>.local:9119).
+  port: 9119
+  external_port_env: HERMES_PORT
+  external_port_default: 9119
+  health: /api/health
+  ui_path: /
+  health_timeout: 60  # Hermes does skill sync + config bootstrap on cold start
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: [llama-server]
+  description: >
+    Hermes Agent (Nous Research) — a self-improving generalist agent with
+    persistent memory, autonomous skill creation, and 70+ built-in tools.
+    Dream Server runs the upstream image pinned by SHA, points it at the
+    local LLM (llama-server), and disables the messaging gateways (Telegram /
+    Discord / Slack / etc.) since the web dashboard is the surface we ship.
+    Reachable on the LAN at hermes.<device>.local:9119 via mDNS.
+
+  env_vars:
+    - key: HERMES_PORT
+      default: "9119"
+      description: External port for Hermes's own dashboard (FastAPI + React UI)
+    - key: HERMES_MODEL_NAME
+      default: "qwen3.5-9b"
+      description: |
+        Model name passed to Hermes. Defaults to Dream Server's LLM_MODEL.
+        Hermes uses provider=custom so this is mostly a label — what matters
+        is HERMES_LLM_BASE_URL pointing at an OpenAI-compatible endpoint.
+    - key: HERMES_LLM_BASE_URL
+      default: "http://llama-server:8080/v1"
+      description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.
+    - key: HERMES_LLM_API_KEY
+      default: "sk-dream-hermes-local"
+      description: |
+        Dummy API key — llama-server doesn't validate it but the OpenAI SDK
+        Hermes uses internally requires the field to be non-empty.
+
+features:
+  - id: hermes-agent
+    name: Hermes Agent
+    description: Generalist self-improving agent — chat, tools, persistent memory, scheduled tasks
+    icon: Bot
+    category: productivity
+    requirements:
+      services: [llama-server]
+      vram_gb: 0
+    enabled_services_all: [hermes]
+    setup_time: ~1 minute (image pull)
+    priority: 5
+    gpu_backends: [all]

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -10,8 +10,9 @@ service:
   container_name: dream-hermes
   default_host: hermes
   # Hermes's own dashboard listens on 9119 inside the container. We expose
-  # the same port externally — keeps URLs intuitive when users follow the
-  # mDNS hostname (hermes.<device>.local:9119).
+  # the same port externally so direct LAN access (or curl-from-host
+  # debugging) hits a predictable URL. End users normally go through
+  # hermes-proxy on :9120 (auth-gated entry point); see HERMES-SSO.md.
   port: 9119
   external_port_env: HERMES_PORT
   external_port_default: 9119
@@ -27,20 +28,16 @@ service:
     Hermes Agent (Nous Research) — a self-improving generalist agent with
     persistent memory, autonomous skill creation, and 70+ built-in tools.
     Dream Server runs the upstream image pinned by SHA, points it at the
-    local LLM (llama-server), and disables the messaging gateways (Telegram /
-    Discord / Slack / etc.) since the web dashboard is the surface we ship.
-    Reachable on the LAN at hermes.<device>.local:9119 via mDNS.
+    local LLM (llama-server), and ships no messaging-platform adapters
+    (Telegram / Discord / Slack / etc.) since the web dashboard is the
+    surface we ship. The container runs `hermes gateway run` with the
+    dashboard embedded (HERMES_DASHBOARD=1) so the scheduler that fires
+    cron jobs actually runs.
 
   env_vars:
     - key: HERMES_PORT
       default: "9119"
       description: External port for Hermes's own dashboard (FastAPI + React UI)
-    - key: HERMES_MODEL_NAME
-      default: "qwen3.5-9b"
-      description: |
-        Model name passed to Hermes. Defaults to Dream Server's LLM_MODEL.
-        Hermes uses provider=custom so this is mostly a label — what matters
-        is HERMES_LLM_BASE_URL pointing at an OpenAI-compatible endpoint.
     - key: HERMES_LLM_BASE_URL
       default: "http://llama-server:8080/v1"
       description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.
@@ -49,6 +46,11 @@ service:
       description: |
         Dummy API key — llama-server doesn't validate it but the OpenAI SDK
         Hermes uses internally requires the field to be non-empty.
+    # Note: there is intentionally no HERMES_MODEL_NAME here. The model
+    # name lives in /opt/data/config.yaml after first start; an earlier
+    # draft exposed an env var, but the upstream image doesn't read it
+    # at runtime — only the YAML file. Edit the file (or delete it to
+    # re-copy from the template) to change the model.
 
 features:
   - id: hermes-agent

--- a/dream-server/extensions/services/hermes/plugins/ape-policy/__init__.py
+++ b/dream-server/extensions/services/hermes/plugins/ape-policy/__init__.py
@@ -21,9 +21,14 @@ internet should flip this to fail_closed.
 
 Env vars consumed:
   * APE_URL          — APE service URL (default http://ape:7890)
-  * APE_API_KEY      — APE Bearer token (default empty = no auth)
+  * APE_API_KEY      — APE API key sent as X-API-Key header (default
+                       empty; APE auto-generates a per-process key when
+                       unset, so callers MUST set this on both services
+                       for /verify to succeed)
   * APE_TIMEOUT      — per-request timeout in seconds (default 5)
-  * APE_FAIL_OPEN    — true/false (default true)
+  * APE_FAIL_OPEN    — true/false (default true). Applies to network
+                       outages only; 401 (auth misconfigured) always
+                       fails closed.
 
 Discovery: mounted by extensions/services/hermes/compose.yaml at
 /opt/data/plugins/ape-policy/, which is the user-plugins path
@@ -67,7 +72,7 @@ def _ape_verify(
     }).encode("utf-8")
     headers = {"Content-Type": "application/json"}
     if APE_API_KEY:
-        headers["Authorization"] = f"Bearer {APE_API_KEY}"
+        headers["X-API-Key"] = APE_API_KEY
 
     request = urllib.request.Request(
         f"{APE_URL}/verify",
@@ -88,6 +93,19 @@ def _ape_verify(
                 return False, str(err.get("detail", "denied by APE policy"))
             except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
                 return False, "denied by APE policy"
+        if exc.code == 401:
+            # Auth misconfigured: APE requires X-API-Key but the plugin
+            # either sent nothing (APE_API_KEY unset on hermes) or the
+            # value doesn't match APE's. This is a deployment bug, not
+            # a network outage — always fail closed regardless of
+            # APE_FAIL_OPEN so it surfaces loudly instead of silently
+            # whitelisting every tool call.
+            logger.error(
+                "APE returned 401 for tool=%s — set APE_API_KEY on both "
+                "the 'ape' and 'hermes' services to the same value",
+                tool_name,
+            )
+            return False, "ape-auth-misconfigured"
         logger.warning("APE returned HTTP %d for tool=%s", exc.code, tool_name)
         return _fail()
     except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:

--- a/dream-server/extensions/services/hermes/plugins/ape-policy/__init__.py
+++ b/dream-server/extensions/services/hermes/plugins/ape-policy/__init__.py
@@ -1,0 +1,140 @@
+"""ape-policy — Dream Server's APE policy engine integration.
+
+Plugs into Hermes's `pre_tool_call` hook so every tool call (file_ops,
+shell, web_fetch, MCP, etc.) hits APE's /verify endpoint before
+execution. APE evaluates the call against configured policy (tool
+allowlists, command guards, rate limits) and returns allowed / denied
+with a reason.
+
+Denied → the plugin returns a block directive in Hermes's documented
+shape (``{"action": "block", "message": "..."}``). Hermes skips the
+tool, surfaces the denial back to the LLM, and the agent learns from
+it like any other tool error.
+
+Allowed → the plugin returns None, Hermes proceeds normally.
+
+Failure handling: if APE is unreachable, default to `fail_open`
+(allow + warn). For stricter deployments set APE_FAIL_OPEN=false to
+fail closed instead. Dream Server's default trusts the local-LAN
+posture; operators who run Hermes-exposed-via-Tailscale to the public
+internet should flip this to fail_closed.
+
+Env vars consumed:
+  * APE_URL          — APE service URL (default http://ape:7890)
+  * APE_API_KEY      — APE Bearer token (default empty = no auth)
+  * APE_TIMEOUT      — per-request timeout in seconds (default 5)
+  * APE_FAIL_OPEN    — true/false (default true)
+
+Discovery: mounted by extensions/services/hermes/compose.yaml at
+/opt/data/plugins/ape-policy/, which is the user-plugins path
+(~/.hermes/plugins/<name>/) per Hermes's discovery rules. Read-only
+mount — the plugin code lives in this repo, not in user state.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import urllib.error
+import urllib.request
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+APE_URL = os.environ.get("APE_URL", "http://ape:7890").rstrip("/")
+APE_API_KEY = os.environ.get("APE_API_KEY", "")
+APE_TIMEOUT = float(os.environ.get("APE_TIMEOUT", "5"))
+APE_FAIL_OPEN = os.environ.get("APE_FAIL_OPEN", "true").lower() in ("1", "true", "yes")
+
+
+def _ape_verify(
+    tool_name: str,
+    args: Optional[Dict[str, Any]],
+    session_id: str,
+    agent_id: str,
+) -> tuple[bool, str]:
+    """POST APE /verify. Returns (allowed, reason).
+
+    On unreachable APE: returns (APE_FAIL_OPEN, "ape-unreachable-fail-open|closed").
+    On 403 from APE in STRICT_MODE: returns (False, <reason-from-body>).
+    """
+    payload = json.dumps({
+        "tool_name": tool_name,
+        "args": args or {},
+        "session_id": session_id,
+        "agent_id": agent_id or "hermes",
+    }).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if APE_API_KEY:
+        headers["Authorization"] = f"Bearer {APE_API_KEY}"
+
+    request = urllib.request.Request(
+        f"{APE_URL}/verify",
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=APE_TIMEOUT) as response:
+            data = json.loads(response.read().decode("utf-8"))
+            return bool(data.get("allowed", False)), str(data.get("reason", "no reason"))
+    except urllib.error.HTTPError as exc:
+        # APE in STRICT_MODE returns 403 for denials. Parse the body to
+        # surface the reason; if parsing fails, use a generic message.
+        if exc.code == 403:
+            try:
+                err = json.loads(exc.read().decode("utf-8"))
+                return False, str(err.get("detail", "denied by APE policy"))
+            except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+                return False, "denied by APE policy"
+        logger.warning("APE returned HTTP %d for tool=%s", exc.code, tool_name)
+        return _fail()
+    except (urllib.error.URLError, OSError, json.JSONDecodeError) as exc:
+        logger.warning("APE unreachable for tool=%s: %s", tool_name, exc)
+        return _fail()
+
+
+def _fail() -> tuple[bool, str]:
+    """Apply the fail-open / fail-closed policy when APE itself is broken."""
+    if APE_FAIL_OPEN:
+        return True, "ape-unreachable-fail-open"
+    return False, "ape-unreachable-fail-closed"
+
+
+def _on_pre_tool_call(
+    tool_name: str = "",
+    args: Optional[Dict[str, Any]] = None,
+    session_id: str = "",
+    task_id: str = "",
+    tool_call_id: str = "",
+    **kwargs: Any,
+) -> Optional[Dict[str, str]]:
+    """Hermes `pre_tool_call` hook.
+
+    Return ``None`` to allow the tool call. Return
+    ``{"action": "block", "message": "..."}`` to deny.
+    """
+    agent_id = str(kwargs.get("agent_id", "")) or "hermes"
+    allowed, reason = _ape_verify(tool_name, args, session_id, agent_id)
+    if not allowed:
+        logger.info(
+            "APE blocked tool=%s reason=%s session=%s tool_call_id=%s",
+            tool_name, reason, session_id, tool_call_id,
+        )
+        return {
+            "action": "block",
+            "message": (
+                f"Tool '{tool_name}' was blocked by APE policy: {reason}"
+            ),
+        }
+    return None
+
+
+def register(ctx) -> None:
+    """Plugin entry point. Wires the pre_tool_call hook."""
+    ctx.register_hook("pre_tool_call", _on_pre_tool_call)
+    logger.info(
+        "ape-policy plugin registered (APE_URL=%s, fail_open=%s, timeout=%.1fs)",
+        APE_URL, APE_FAIL_OPEN, APE_TIMEOUT,
+    )

--- a/dream-server/extensions/services/hermes/plugins/ape-policy/plugin.yaml
+++ b/dream-server/extensions/services/hermes/plugins/ape-policy/plugin.yaml
@@ -1,0 +1,6 @@
+name: ape-policy
+version: 1.0.0
+description: "Route Hermes tool calls through Dream Server's APE policy engine for allow/deny + audit. Every tool call hits APE's /verify endpoint before execution; denials surface as block messages back to the agent."
+author: "Light Heart Labs"
+hooks:
+  - pre_tool_call


### PR DESCRIPTION
## Summary

Closes the "APE policy enforcement" item on the Hermes roadmap. Every Hermes tool call (file_ops, shell, web_fetch, MCP, etc.) now hits Dream Server's APE policy engine \`/verify\` endpoint before execution. Denied calls return a block directive to Hermes; the agent surfaces the denial like any other tool error and the conversation continues.

**This is NOT a fork of Hermes.** Hermes ships a first-class plugin system with \`pre_tool_call\` hook documented as supporting \`{action: block, message: ...}\` return values to block tool execution. Our plugin is just a consumer of that contract — no upstream code modified.

## How it works

1. Hermes's agent loop is about to call a tool
2. \`hermes_cli/plugins.py:get_pre_tool_call_block_message()\` invokes all registered \`pre_tool_call\` hooks
3. Our plugin POSTs to APE \`/verify\` with \`{tool_name, args, session_id, agent_id}\`
4. APE returns \`{allowed, reason}\` (or 403 in STRICT_MODE with detail)
5. If denied → plugin returns \`{action: "block", message: "Tool '...' was blocked by APE policy: ..."}\`
6. Hermes skips the tool, surfaces the denial back to the agent, conversation continues

## Files

| File | Lines | What |
|---|---|---|
| \`extensions/services/hermes/plugins/ape-policy/plugin.yaml\` (new) | 7 | Plugin manifest: name, version, hooks: [pre_tool_call] |
| \`extensions/services/hermes/plugins/ape-policy/__init__.py\` (new) | 140 | Pure-stdlib \`urllib.request\` call to APE /verify, error-translation, fail-open/closed policy. No external deps. |
| \`extensions/services/hermes/compose.yaml\` (+18 / 0) | | New \`APE_*\` env vars and a bind mount that places our plugin into Hermes's user-plugin directory (\`/opt/data/plugins/ape-policy/\`, read-only) |
| \`.env.example\` (+10) | | Documented \`APE_URL\`, \`APE_API_KEY\`, \`APE_FAIL_OPEN\`, \`APE_TIMEOUT\` block |
| \`.env.schema.json\` (+19) | | Schema entries |
| \`docs/HERMES.md\` | | Security posture section updated; Roadmap marks APE shipped |

## Fail behavior

| APE response | Outcome |
|---|---|
| 200 \`allowed: true\` | Tool runs |
| 200 \`allowed: false\` | Block message returned to agent with the reason |
| 403 (STRICT_MODE in APE) | Block with body's \`detail\` |
| Unreachable + \`APE_FAIL_OPEN=true\` (default) | Tool runs (warning logged) |
| Unreachable + \`APE_FAIL_OPEN=false\` | Block with reason \`ape-unreachable-fail-closed\` |

Default \`APE_FAIL_OPEN=true\` matches Dream Server's trusted-LAN posture. Operators exposing Hermes to less-trusted networks should flip to \`false\` so an APE outage doesn't open the gate.

## How the plugin gets discovered

Hermes's [\`plugins.py\` discovery rules](https://github.com/NousResearch/hermes-agent/blob/dd0923bb89ed2dd56f82cb63656a1323f6f42e6f/hermes_cli/plugins.py#L1):

> 1. Bundled plugins  – \`<repo>/plugins/<name>/\`
> 2. User plugins    – \`~/.hermes/plugins/<name>/\`
> 3. Project plugins – \`./.hermes/plugins/<name>/\`
> 4. Pip plugins     – \`hermes_agent.plugins\` entry-point group

We mount into the user-plugins path (\`/opt/data/plugins/ape-policy/\` inside the container, since \`HERMES_HOME=/opt/data\`). The deeper bind mount overlays the broader data volume at that exact subpath — standard Docker compose pattern.

The plugin source is \`:ro\` because it lives in this repo, not in user state. To disable APE checks, either:
- Stop the \`ape\` extension (plugin falls through to fail-open by default)
- Or remove the mount from \`compose.yaml\`
- Or set \`APE_FAIL_OPEN=false\` AND stop \`ape\` (deliberately fail-closed)

## Test plan

- [x] \`python -c yaml.safe_load(plugin.yaml)\` passes
- [x] \`python -c yaml.safe_load(compose.yaml)\` passes
- [x] \`python -c json.load(.env.schema.json)\` passes
- [x] \`python -m py_compile plugins/ape-policy/__init__.py\` passes
- [ ] Manual smoke (requires running stack):
  - [ ] \`dream enable ape hermes\` → both come up healthy
  - [ ] Hermes logs show \`ape-policy plugin registered\` on start
  - [ ] In Hermes chat, ask it to read a file → plugin logs the \`/verify\` call; APE audit log shows the decision
  - [ ] Configure an APE deny rule for \`terminal\` (or whichever shell tool Hermes uses) → ask Hermes to run a command → it returns a block message in chat
  - [ ] Stop the ape container with \`APE_FAIL_OPEN=true\` → tools still run (warning log); flip to \`false\` → tools fail

## Caveats

- **Plugin runs on every tool call** — adds an HTTP round-trip per call. APE is on the bridge network so latency is sub-millisecond locally; not a concern at home scale.
- **APE's classify_intent + policy.yaml is what actually decides.** This PR is just the wire-up; tuning the deny rules is operator work in \`config/ape/policy.yaml\`.
- **No \`post_tool_call\` hook here.** APE's \`/verify\` writes its own audit entry at decision time; surfacing tool RESULTS to APE for richer auditing (was the file write actually successful, did the shell return non-zero) is a follow-up worth considering once the policy story is mature.

Stacked on \`feat/hermes-extension\` (#1166).

🤖 Generated with [Claude Code](https://claude.com/claude-code)