### PR TITLE
feat(hermes): one sidebar tile after the proxy split

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -313,3 +313,9 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # HERMES_LANGUAGE=en                     # UI language
 # (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
 #  not in env. Edit the file after first start to switch models.)
+#
+# Hermes is reached on the LAN via dream-hermes-proxy (Caddy sidecar) which
+# gates access on the dream-session cookie set by magic-link redemption.
+# Direct Hermes port is NOT bound to the host — only the proxy is LAN-facing.
+# HERMES_PROXY_PORT=9120                 # LAN entry — what users actually browse to
+# HERMES_PROXY_UPSTREAM=dream-hermes:9119  # Where the proxy forwards (internal DNS)

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -291,3 +291,19 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # DREAMFORGE_MODEL=                    # Auto-detected from LLM server if empty
 # DREAMFORGE_RAG_ENABLED=false
 # DREAMFORGE_COMPACT_THRESHOLD=10000
+
+# ═══════════════════════════════════════════════════════════════════
+# Hermes Agent (Remote-capable Chat + Generalist Agent)
+# ═══════════════════════════════════════════════════════════════════
+# Hermes Agent (Nous Research, MIT) — chat-first generalist agent with
+# persistent memory, autonomous skill creation, and 70+ tools. Dream
+# Server runs the upstream image pinned by SHA and points it at the
+# local LLM. Browser UI ships in the upstream image (port 9119).
+# Enable: `dream enable hermes`. Reachable at hermes.<device>.local:9119
+# once mDNS picks it up.
+#
+# HERMES_PORT=9119                       # External dashboard port
+# HERMES_MODEL_NAME=qwen3.5-9b           # Model label passed to Hermes
+# HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
+# HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
+# HERMES_LANGUAGE=en                     # UI language

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -299,15 +299,11 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # persistent memory, autonomous skill creation, and 70+ tools. Dream
 # Server runs the upstream image pinned by SHA and points it at the
 # local LLM. Browser UI ships in the upstream image (port 9119).
-# Enable: `dream enable hermes`. With hermes-proxy enabled, end users
-# reach Hermes at http://hermes.<device>.local (port 80, auth-gated by
-# the proxy); without it, Hermes binds HERMES_PORT directly.
+# Enable: `dream enable hermes`. With hermes-proxy enabled (the default
+# pairing), end users reach Hermes at http://hermes.<device>.local
+# (port 80, auth-gated by the proxy). Hermes itself is internal-only —
+# there's no HERMES_PORT knob in this stack.
 #
-# HERMES_PORT=9119                       # Direct external port (used
-#                                          when hermes-proxy is OFF; with
-#                                          hermes-proxy ON, Hermes is
-#                                          internal-only and this is
-#                                          informational).
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
 # HERMES_LANGUAGE=en                     # UI language

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -303,7 +303,8 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # once mDNS picks it up.
 #
 # HERMES_PORT=9119                       # External dashboard port
-# HERMES_MODEL_NAME=qwen3.5-9b           # Model label passed to Hermes
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
 # HERMES_LANGUAGE=en                     # UI language
+# (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
+#  not in env. Edit the file after first start to switch models.)

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -299,10 +299,15 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # persistent memory, autonomous skill creation, and 70+ tools. Dream
 # Server runs the upstream image pinned by SHA and points it at the
 # local LLM. Browser UI ships in the upstream image (port 9119).
-# Enable: `dream enable hermes`. Reachable at hermes.<device>.local:9119
-# once mDNS picks it up.
+# Enable: `dream enable hermes`. With hermes-proxy enabled, end users
+# reach Hermes at http://hermes.<device>.local (port 80, auth-gated by
+# the proxy); without it, Hermes binds HERMES_PORT directly.
 #
-# HERMES_PORT=9119                       # External dashboard port
+# HERMES_PORT=9119                       # Direct external port (used
+#                                          when hermes-proxy is OFF; with
+#                                          hermes-proxy ON, Hermes is
+#                                          internal-only and this is
+#                                          informational).
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
 # HERMES_LANGUAGE=en                     # UI language

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -315,7 +315,9 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 #  not in env. Edit the file after first start to switch models.)
 #
 # Hermes is reached on the LAN via dream-hermes-proxy (Caddy sidecar) which
-# gates access on the dream-session cookie set by magic-link redemption.
+# verifies the dream-session cookie against dashboard-api's verify endpoint
+# (forward_auth → HMAC signature check via DREAM_SESSION_SECRET).
 # Direct Hermes port is NOT bound to the host — only the proxy is LAN-facing.
 # HERMES_PROXY_PORT=9120                 # LAN entry — what users actually browse to
 # HERMES_PROXY_UPSTREAM=dream-hermes:9119  # Where the proxy forwards (internal DNS)
+# DREAM_AUTH_UPSTREAM=dream-dashboard-api:3002  # Where forward_auth verifies sessions

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -700,10 +700,6 @@
       "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
       "default": 9119
     },
-    "HERMES_MODEL_NAME": {
-      "type": "string",
-      "description": "Model name label passed to Hermes Agent. Hermes uses provider=custom against the local llama-server, so this is mostly a display label; what matters is HERMES_LLM_BASE_URL."
-    },
     "HERMES_LLM_BASE_URL": {
       "type": "string",
       "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -717,13 +717,18 @@
     },
     "HERMES_PROXY_PORT": {
       "type": "integer",
-      "description": "External port for the Hermes auth-proxy (Caddy sidecar that gates LAN access on the dream-session cookie set by magic-link redemption).",
+      "description": "External port for the Hermes auth-proxy (Caddy sidecar that gates LAN access by verifying the dream-session cookie via dashboard-api's /api/auth/verify-session endpoint).",
       "default": 9120
     },
     "HERMES_PROXY_UPSTREAM": {
       "type": "string",
       "description": "Internal upstream the Hermes auth-proxy forwards to. Defaults to dream-hermes:9119.",
       "default": "dream-hermes:9119"
+    },
+    "DREAM_AUTH_UPSTREAM": {
+      "type": "string",
+      "description": "Where Caddy forward_auth sends its session-verify sub-request. Defaults to the in-network dashboard-api container; override if dashboard-api lives elsewhere.",
+      "default": "dream-dashboard-api:3002"
     }
   }
 }

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -695,11 +695,6 @@
       "description": "Enable/disable Langfuse telemetry",
       "default": "false"
     },
-    "HERMES_PORT": {
-      "type": "integer",
-      "description": "External port for the Hermes Agent dashboard. Used when Hermes is the LAN entry — direct dev access or smoke tests without hermes-proxy. With hermes-proxy enabled, Hermes is internal-only (compose switches to expose:) and this becomes informational; user-facing port is HERMES_PROXY_PORT.",
-      "default": 9119
-    },
     "HERMES_LLM_BASE_URL": {
       "type": "string",
       "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -697,7 +697,7 @@
     },
     "HERMES_PORT": {
       "type": "integer",
-      "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
+      "description": "External port for the Hermes Agent dashboard. Used when Hermes is the LAN entry — direct dev access or smoke tests without hermes-proxy. With hermes-proxy enabled, Hermes is internal-only (compose switches to expose:) and this becomes informational; user-facing port is HERMES_PROXY_PORT.",
       "default": 9119
     },
     "HERMES_LLM_BASE_URL": {

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -714,6 +714,16 @@
       "type": "string",
       "description": "UI language for Hermes Agent's web dashboard (defaults to en).",
       "default": "en"
+    },
+    "HERMES_PROXY_PORT": {
+      "type": "integer",
+      "description": "External port for the Hermes auth-proxy (Caddy sidecar that gates LAN access on the dream-session cookie set by magic-link redemption).",
+      "default": 9120
+    },
+    "HERMES_PROXY_UPSTREAM": {
+      "type": "string",
+      "description": "Internal upstream the Hermes auth-proxy forwards to. Defaults to dream-hermes:9119.",
+      "default": "dream-hermes:9119"
     }
   }
 }

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -694,6 +694,30 @@
       "type": "string",
       "description": "Enable/disable Langfuse telemetry",
       "default": "false"
+    },
+    "HERMES_PORT": {
+      "type": "integer",
+      "description": "External port for the Hermes Agent dashboard (FastAPI + React UI from upstream).",
+      "default": 9119
+    },
+    "HERMES_MODEL_NAME": {
+      "type": "string",
+      "description": "Model name label passed to Hermes Agent. Hermes uses provider=custom against the local llama-server, so this is mostly a display label; what matters is HERMES_LLM_BASE_URL."
+    },
+    "HERMES_LLM_BASE_URL": {
+      "type": "string",
+      "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",
+      "default": "http://llama-server:8080/v1"
+    },
+    "HERMES_LLM_API_KEY": {
+      "type": "string",
+      "description": "Dummy API key for Hermes Agent's OpenAI SDK (llama-server doesn't validate it, but the SDK requires the field to be non-empty).",
+      "secret": true
+    },
+    "HERMES_LANGUAGE": {
+      "type": "string",
+      "description": "UI language for Hermes Agent's web dashboard (defaults to en).",
+      "default": "en"
     }
   }
 }

--- a/dream-server/docs/HERMES-SSO.md
+++ b/dream-server/docs/HERMES-SSO.md
@@ -6,9 +6,9 @@ When this extension is enabled:
 
 - Hermes itself binds **internal-only** (no host port).
 - The proxy binds the LAN-facing port (default `9120`) — that's what users browse to.
-- Every request to the proxy is inspected for the `dream-session` cookie that magic-link redemption (PR-4) sets in the user's browser.
-- No cookie → 303 redirect to a static "you need an invite" page.
-- Cookie present → traffic is forwarded to `dream-hermes:9119`. Hermes's own [per-process session token model](HERMES.md#security-posture) then handles per-request `/api/` auth.
+- Every request to the proxy is verified via `forward_auth` against dashboard-api's `/api/auth/verify-session` endpoint — which HMAC-validates the `dream-session` cookie's signature against `DREAM_SESSION_SECRET`.
+- Verified (HTTP 200 from the verify endpoint) → traffic is forwarded to `dream-hermes:9119`. Hermes's own [per-process session token model](HERMES.md#security-posture) then handles per-request `/api/` auth.
+- Not verified (HTTP 401 — missing cookie, bad signature, or expired) → 303 redirect to a static "you need an invite" page.
 
 ## Why this design
 
@@ -43,13 +43,16 @@ dream enable hermes-proxy
 #    → Save the QR / URL
 
 # 4. Recipient scans the QR on their phone
-#    → Lands on dashboard-api's /auth/magic-link/<token>
-#    → Redemption sets the dream-session cookie
-#    → 302 redirect to chat (or wherever the scope says)
-#    → They now have a valid cookie for any Hermes proxy access too
+#    → Lands on the dream-proxy at <device>.local/auth/magic-link/<token>
+#    → Redemption sets the HMAC-signed dream-session cookie on <device>.local
+#    → 302 redirect to /chat (same origin → cookie travels along)
+#    → They now have a valid cookie for any same-host port too (cookies
+#      are scoped by host, not port — so <device>.local:9120 will receive
+#      it as well)
 
-# 5. Recipient browses to http://hermes.<device>.local:9120
-#    → Proxy sees the dream-session cookie → forward
+# 5. Recipient browses to http://<device>.local:9120
+#    → Proxy forward_auths to dashboard-api/api/auth/verify-session
+#    → Signature check passes → forward to Hermes
 #    → Hermes serves the SPA → they chat
 ```
 
@@ -60,19 +63,20 @@ If the recipient hasn't yet redeemed an invite, step 5 lands them on the "you ne
 ```
 Phone / laptop
    │
-   ▼  http://hermes.<device>.local:9120
+   ▼  http://<device>.local:9120
 ┌──────────────────────────────────────────┐
 │  dream-hermes-proxy  (Caddy, ~50MB)      │
 │                                          │
 │  Caddyfile match rules:                  │
 │    /health, /favicon.ico → respond       │
 │    /auth/required*       → static files  │
-│    cookie has dream-session → reverse_   │
-│                                 proxy    │
-│    everything else        → 303 redirect │
+│    everything else        → forward_auth │
 │                                          │
-│  Listens on :9120, forwards to           │
-│  dream-hermes:9119                       │
+│  forward_auth sub-request:               │
+│    GET /api/auth/verify-session →        │
+│      dashboard-api:3002                  │
+│        2xx → reverse_proxy dream-hermes  │
+│        401 → 303 to /auth/required       │
 └──────────┬───────────────────────────────┘
            │
            ▼  internal Docker bridge network only
@@ -89,39 +93,48 @@ Phone / laptop
        llama-server (existing)
 ```
 
-## What "cookie present" actually means
+## What gets verified
 
-The `dream-session` cookie is set by the dashboard-api's magic-link redemption (`routers/magic_link.py`). The cookie:
+The `dream-session` cookie is set by the dashboard-api's magic-link redemption (`routers/magic_link.py`) and signed with HMAC-SHA256 against `DREAM_SESSION_SECRET` (see `session_signer.py`). The cookie:
 
 - Is `HttpOnly` (JS can't read it)
 - Has `SameSite=Lax` (sent on top-level navigation cross-origin GETs, blocked on background cross-site POSTs)
-- Is `Secure` when the dashboard-api was reached over HTTPS
+- Is `Secure` when the redemption host was reached over HTTPS
 - Has `Max-Age = 12h` from redemption
-- Contains a random `secrets.token_urlsafe(24)` value (NOT the magic-link token itself)
+- Carries `<random-id>.<expiry-epoch>.<hmac-signature>` — the signature is what gates validity, not presence
 
-The proxy checks **presence and non-emptiness**. It does NOT:
+On every request the proxy issues a sub-request to `dashboard-api/api/auth/verify-session`, which:
 
-- Cross-check the cookie value against any server-side store (PR-4 doesn't keep one — see [Limitations](#known-limitations))
-- Validate the user identity carried by the cookie (there is none)
-- Verify the cookie's signature (it's not signed today)
+1. Splits the cookie value on `.`
+2. Recomputes the HMAC over `<random-id>.<expiry-epoch>` and constant-time-compares it (`hmac.compare_digest`) against the claimed signature
+3. Checks the embedded expiry hasn't passed
 
-In effect: anyone who can read another user's `dream-session` cookie value can pass the proxy gate. The cookie's `HttpOnly` and same-origin properties make casual sharing hard but not impossible (a malicious browser extension on the redeemed user's device could exfiltrate it; a screenshot of devtools could leak it).
+Any failure (missing cookie, tampered signature, expired timestamp, missing server-side secret) returns a single byte-identical 401 response so an attacker can't probe which step failed.
 
-For the Dream Server trust model (single home, trusted LAN, family-scale users), this is the v1 trade-off. The proxy explicitly says "**gating**, not identification."
+What this catches:
+- Forged cookies (any value not signed with the secret fails the HMAC check)
+- Expired cookies (server-side expiry, independent of the browser's `Max-Age`)
+- Tampered cookies (changing the `<random-id>` or extending `<expiry-epoch>` invalidates the signature)
+
+What this does NOT do:
+- Identify which user is behind a request — the cookie is opaque (the random-id is not a username)
+- Track per-cookie revocation. Today's only revocation mechanism is rotating `DREAM_SESSION_SECRET`, which invalidates every issued cookie. A future PR could add a revocation list keyed on the random-id; the cookie format reserves space for it.
+
+For the Dream Server trust model (single home, trusted LAN, family-scale users), this gives real signature-based gating without a session store. The proxy explicitly says "**gating**, not identification."
 
 ## Known limitations
 
 1. **No real multi-user.** All authed users share one Hermes — same memories, skills, persona, sessions. Mom can see Dad's chats and vice-versa. Treat Hermes as "the family's agent."
 
-2. **No server-side cookie validation.** Today's PR-4 redemption sets the cookie but doesn't store the issued session in a server-side store. Anyone with the raw cookie value can use it. A future PR could add a sessions table that the proxy validates against, but that's not this extension.
+2. **Stolen cookies are valid until expiry or secret rotation.** The cookie is signed, but if it's exfiltrated (malicious browser extension, leaked screenshot, etc.) the attacker can use it until the 12h expiry passes or the operator rotates `DREAM_SESSION_SECRET`. There's no per-cookie revocation today. The signed format reserves the random-id field for a future revocation list.
 
-3. **No per-request user identification.** The proxy doesn't add an `X-Dream-User` header to forwarded requests. Hermes can't know "this request is from Alice" — only "this request is from someone with a valid invite."
+3. **No per-request user identification.** The proxy doesn't add an `X-Dream-User` header to forwarded requests. Hermes can't know "this request is from Alice" — only "this request is from someone with a valid signed cookie."
 
 4. **The cookie's `dream-target-user` field is ignored by the proxy.** Magic-link redemption sets a second cookie naming the target username, but the proxy doesn't surface it to Hermes (there's no Hermes-side hook to consume it).
 
 5. **Direct access to Hermes is now blocked.** Anyone who was reaching Hermes at `:9119` before this extension lands needs to switch to `:9120` (the proxy port). If they want raw direct access for testing, they can `docker exec dream-hermes` or temporarily re-add a `ports:` binding to the Hermes compose.
 
-6. **Caddy's auth check is `header_regexp` on the `Cookie` header.** That's text-based — it doesn't parse cookie semantics. The match anchor `(?:^|;\s*)dream-session=[^;]+` covers the common cases but a deliberately-malformed `Cookie` header could in theory slip past. In practice browsers never send malformed Cookie headers, and an attacker who can set arbitrary HTTP headers already has bigger leverage.
+6. **`DREAM_SESSION_SECRET` must be configured.** With no secret set, `verify-session` returns 401 for every request (and `issue()` raises during magic-link redemption) — the proxy gate effectively becomes "nobody passes." Set a 32+-byte random value in `.env` before enabling `hermes-proxy`.
 
 ## Future: Option B — per-user Hermes
 

--- a/dream-server/docs/HERMES-SSO.md
+++ b/dream-server/docs/HERMES-SSO.md
@@ -1,0 +1,152 @@
+# Hermes SSO — magic-link gating in front of the Hermes Agent
+
+Dream Server's `hermes-proxy` extension is a Caddy reverse proxy that fronts the [Hermes Agent container](HERMES.md) and gates access on Dream Server's magic-link auth.
+
+When this extension is enabled:
+
+- Hermes itself binds **internal-only** (no host port).
+- The proxy binds the LAN-facing port (default `9120`) — that's what users browse to.
+- Every request to the proxy is inspected for the `dream-session` cookie that magic-link redemption (PR-4) sets in the user's browser.
+- No cookie → 303 redirect to a static "you need an invite" page.
+- Cookie present → traffic is forwarded to `dream-hermes:9119`. Hermes's own [per-process session token model](HERMES.md#security-posture) then handles per-request `/api/` auth.
+
+## Why this design
+
+After reading [upstream's web_server.py at our pinned SHA](https://github.com/NousResearch/hermes-agent/blob/dd0923bb89ed2dd56f82cb63656a1323f6f42e6f/hermes_cli/web_server.py), Hermes's auth is **per-PROCESS, not per-user**. The session token is `secrets.token_urlsafe(32)` generated at server start and baked into the SPA HTML — no env-var to pre-seed, no login flow, no user concept.
+
+Hermes **does** support per-user isolation via [profiles](https://github.com/NousResearch/hermes-agent/blob/dd0923bb89ed2dd56f82cb63656a1323f6f42e6f/hermes_cli/profiles.py) (separate `HERMES_HOME/profiles/<name>/`), but a profile is bound at process launch — one Hermes process = one profile. There's no in-process profile switching.
+
+This extension does NOT try to give you real multi-user. It gives you:
+
+| Property | Achieved? |
+|---|---|
+| Magic-link-authed gateway | ✅ |
+| Anyone with a valid invite can reach Hermes | ✅ |
+| Anyone without a valid invite gets bounced | ✅ |
+| Mom's memories / skills / sessions isolated from Dad's | ❌ — shared |
+| The proxy knows WHO is logged in | ❌ — only that *someone* has a valid invite |
+
+If you need per-user isolation, the path is to run **one Hermes container per user** (each with its own profile), and have the proxy route based on the redeemed user's identity. That's [Option B](#future-option-b--per-user-hermes) below — out of scope for v1.
+
+## Setup
+
+```bash
+# 1. Enable Hermes (the agent itself)
+dream enable hermes
+
+# 2. Enable the auth proxy (this extension)
+dream enable hermes-proxy
+
+# 3. Generate an invite from the dashboard
+#    → Browse to http://<device>:3001/invites
+#    → "New invite" → scope: chat or all → Generate
+#    → Save the QR / URL
+
+# 4. Recipient scans the QR on their phone
+#    → Lands on dashboard-api's /auth/magic-link/<token>
+#    → Redemption sets the dream-session cookie
+#    → 302 redirect to chat (or wherever the scope says)
+#    → They now have a valid cookie for any Hermes proxy access too
+
+# 5. Recipient browses to http://hermes.<device>.local:9120
+#    → Proxy sees the dream-session cookie → forward
+#    → Hermes serves the SPA → they chat
+```
+
+If the recipient hasn't yet redeemed an invite, step 5 lands them on the "you need an invite" page with instructions.
+
+## Architecture
+
+```
+Phone / laptop
+   │
+   ▼  http://hermes.<device>.local:9120
+┌──────────────────────────────────────────┐
+│  dream-hermes-proxy  (Caddy, ~50MB)      │
+│                                          │
+│  Caddyfile match rules:                  │
+│    /health, /favicon.ico → respond       │
+│    /auth/required*       → static files  │
+│    cookie has dream-session → reverse_   │
+│                                 proxy    │
+│    everything else        → 303 redirect │
+│                                          │
+│  Listens on :9120, forwards to           │
+│  dream-hermes:9119                       │
+└──────────┬───────────────────────────────┘
+           │
+           ▼  internal Docker bridge network only
+┌──────────────────────────────────────────┐
+│  dream-hermes  (NousResearch image)      │
+│  - exposes :9119 internally              │
+│  - DOES NOT bind a host port             │
+│  - serves its React SPA + /api/*         │
+│  - its own X-Hermes-Session-Token gates  │
+│    /api/* requests per-request           │
+└──────────────────────────────────────────┘
+           │
+           ▼  OpenAI-compatible API
+       llama-server (existing)
+```
+
+## What "cookie present" actually means
+
+The `dream-session` cookie is set by the dashboard-api's magic-link redemption (`routers/magic_link.py`). The cookie:
+
+- Is `HttpOnly` (JS can't read it)
+- Has `SameSite=Lax` (sent on top-level navigation cross-origin GETs, blocked on background cross-site POSTs)
+- Is `Secure` when the dashboard-api was reached over HTTPS
+- Has `Max-Age = 12h` from redemption
+- Contains a random `secrets.token_urlsafe(24)` value (NOT the magic-link token itself)
+
+The proxy checks **presence and non-emptiness**. It does NOT:
+
+- Cross-check the cookie value against any server-side store (PR-4 doesn't keep one — see [Limitations](#known-limitations))
+- Validate the user identity carried by the cookie (there is none)
+- Verify the cookie's signature (it's not signed today)
+
+In effect: anyone who can read another user's `dream-session` cookie value can pass the proxy gate. The cookie's `HttpOnly` and same-origin properties make casual sharing hard but not impossible (a malicious browser extension on the redeemed user's device could exfiltrate it; a screenshot of devtools could leak it).
+
+For the Dream Server trust model (single home, trusted LAN, family-scale users), this is the v1 trade-off. The proxy explicitly says "**gating**, not identification."
+
+## Known limitations
+
+1. **No real multi-user.** All authed users share one Hermes — same memories, skills, persona, sessions. Mom can see Dad's chats and vice-versa. Treat Hermes as "the family's agent."
+
+2. **No server-side cookie validation.** Today's PR-4 redemption sets the cookie but doesn't store the issued session in a server-side store. Anyone with the raw cookie value can use it. A future PR could add a sessions table that the proxy validates against, but that's not this extension.
+
+3. **No per-request user identification.** The proxy doesn't add an `X-Dream-User` header to forwarded requests. Hermes can't know "this request is from Alice" — only "this request is from someone with a valid invite."
+
+4. **The cookie's `dream-target-user` field is ignored by the proxy.** Magic-link redemption sets a second cookie naming the target username, but the proxy doesn't surface it to Hermes (there's no Hermes-side hook to consume it).
+
+5. **Direct access to Hermes is now blocked.** Anyone who was reaching Hermes at `:9119` before this extension lands needs to switch to `:9120` (the proxy port). If they want raw direct access for testing, they can `docker exec dream-hermes` or temporarily re-add a `ports:` binding to the Hermes compose.
+
+6. **Caddy's auth check is `header_regexp` on the `Cookie` header.** That's text-based — it doesn't parse cookie semantics. The match anchor `(?:^|;\s*)dream-session=[^;]+` covers the common cases but a deliberately-malformed `Cookie` header could in theory slip past. In practice browsers never send malformed Cookie headers, and an attacker who can set arbitrary HTTP headers already has bigger leverage.
+
+## Future: Option B — per-user Hermes
+
+If/when real multi-user becomes a felt need, the path is:
+
+1. dashboard-api dynamically spawns a Hermes container per magic-link `target_username` (each with `HERMES_HOME=/opt/data/profiles/<username>`)
+2. The Hermes auth proxy gains a routing layer — reads the `dream-target-user` cookie set during redemption, maps it to the per-user container's address, forwards there.
+3. Lifecycle management: idle-timeout to stop unused containers; cold-start when a user returns.
+
+Roughly 2-3 PRs of work and meaningful resource cost (each Hermes container is ~3GB image + ~1GB idle RAM with chromium / playwright loaded). Not worth it until a family member specifically asks for "my own Hermes."
+
+## Disabling the proxy
+
+```bash
+dream disable hermes-proxy
+
+# To restore direct Hermes access, re-add a ports binding to
+# extensions/services/hermes/compose.yaml:
+#   ports:
+#     - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
+# (then `dream restart hermes`)
+```
+
+## Bump history
+
+| Date | Pinned Caddy | Notes |
+|---|---|---|
+| 2026-05-12 | `caddy:2.8.4-alpine` | Initial integration. |

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -27,10 +27,12 @@ Hermes ships its own complete web UI — Dream Server is just packaging it. Afte
   ┌─────────────────────────────────────┐
   │  dream-hermes container             │
   │                                     │
-  │   Upstream FastAPI dashboard        │
-  │     - serves React SPA              │
-  │     - exposes /api endpoints        │
-  │     - drives AIAgent class          │
+  │   hermes gateway run                │
+  │     - HERMES_DASHBOARD=1 →          │
+  │         React SPA + /api endpoints  │
+  │     - scheduler tick() every 60s →  │
+  │         fires cron jobs             │
+  │     - no messaging adapters         │
   │                                     │
   │   State: /opt/data (HERMES_HOME)    │
   │     mounted from data/hermes/       │
@@ -82,7 +84,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 ## Defaults Dream Server applies
 
 - **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
-- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — change `HERMES_MODEL_NAME` if you've swapped models)
+- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
 - **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
 - **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
@@ -92,8 +94,8 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 
 Three layers, highest to lowest precedence:
 
-1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting.
-2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_MODEL_NAME`, etc. See `.env.example` for the full list.
+1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting. **The model name lives here**, not in env.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_LLM_API_KEY`, `HERMES_PORT`, `HERMES_LANGUAGE`. These are the only Hermes settings the container actually reads from env. See `.env.example`.
 3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
 
 To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -1,0 +1,188 @@
+# Hermes Agent
+
+Dream Server ships an optional **Hermes Agent** extension — the [Nous Research open-source agent](https://github.com/nousresearch/hermes-agent) packaged as a Dream Server service. Hermes is a self-improving generalist agent with persistent memory, autonomous skill creation, and 70+ tools built in.
+
+When enabled, Hermes runs in a container alongside the rest of the stack, exposes its own browser dashboard at port 9119, and talks to the local LLM (llama-server) via its OpenAI-compatible API.
+
+## What you get
+
+Hermes ships its own complete web UI — Dream Server is just packaging it. After `dream enable hermes`, you can browse to `http://<device>:9119` (or `hermes.<device>.local:9119` once mDNS announcement lands — see "Roadmap" below) and find pages for:
+
+- **Chat** — conversational interface with streaming responses + inline tool calls
+- **Sessions** — list, switch between, prune past conversations
+- **Skills** — view skills Hermes has autonomously created from your interactions; edit or delete
+- **Memories** — persistent facts Hermes has learned about you
+- **Profiles** — per-user agent contexts (a built-in alternative to running multiple Hermes containers)
+- **Cron** — schedule recurring agent tasks
+- **Models** — pick which LLM Hermes uses (defaults to your llama-server)
+- **Config / Env** — Hermes's own settings
+- **Logs / Analytics** — operational visibility
+
+## Architecture
+
+```
+  Browser
+     │  http://<device>:9119
+     ▼
+  ┌─────────────────────────────────────┐
+  │  dream-hermes container             │
+  │                                     │
+  │   Upstream FastAPI dashboard        │
+  │     - serves React SPA              │
+  │     - exposes /api endpoints        │
+  │     - drives AIAgent class          │
+  │                                     │
+  │   State: /opt/data (HERMES_HOME)    │
+  │     mounted from data/hermes/       │
+  │                                     │
+  │   Tool sandbox: local (in-container)│
+  └─────────────────────────────────────┘
+                  │
+                  │  OpenAI-compatible API
+                  ▼
+  ┌─────────────────────────────────────┐
+  │  llama-server (existing)            │
+  │     llama.cpp at :8080/v1           │
+  └─────────────────────────────────────┘
+```
+
+State layout under `data/hermes/`:
+
+```
+data/hermes/
+├── config.yaml      # Bootstrapped from our cli-config.yaml.template on first start
+├── .env             # Bootstrapped from upstream's .env.example
+├── SOUL.md          # Bootstrapped from our SOUL.md.template
+├── sessions/        # Per-session chat history
+├── memories/        # Persistent agent memories
+├── skills/          # Agent-authored skills
+├── cron/            # Scheduled tasks
+├── plans/           # Active multi-step plans
+├── workspace/       # Sandboxed workspace for file ops
+├── hooks/           # Custom lifecycle hooks
+├── home/            # Per-profile $HOME for subprocesses (git, ssh, npm…)
+└── logs/            # Hermes's own logs (separate from Docker logs)
+```
+
+## Setup
+
+```bash
+# 1. (One-time) Verify Dream Server's llama-server is running:
+dream status llama-server
+
+# 2. Pull + start Hermes:
+dream enable hermes
+
+# 3. (Optional) Open the dashboard:
+xdg-open http://localhost:9119
+```
+
+The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.py` bootstrap, and llama-server may cold-load the model on Hermes's first request. Subsequent starts are fast.
+
+## Defaults Dream Server applies
+
+- **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
+- **Model name:** `qwen3.5-9b` (Dream Server's default LLM — change `HERMES_MODEL_NAME` if you've swapped models)
+- **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
+- **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
+- **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
+- **Resource caps:** 4 CPUs / 4GB RAM hard limit, 0.5 CPU / 1GB reservation. Hermes's playwright + ML deps can be hungry; adjust in `extensions/services/hermes/compose.yaml` if needed.
+
+## Configuration
+
+Three layers, highest to lowest precedence:
+
+1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_MODEL_NAME`, etc. See `.env.example` for the full list.
+3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
+
+To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.
+
+## Security posture
+
+- **`--insecure` is enabled.** Hermes's dashboard refuses to bind to non-loopback addresses without it (the dashboard stores API keys, so binding 0.0.0.0 has a clear "you sure?" gate). Dream Server's trusted-LAN posture accepts this trade-off for v1. **Don't expose port 9119 to the public internet.** Use Tailscale (PR-12 from the onboarding plan) if you need remote access.
+- **The container runs as a non-root user** (UID 10000 by default, remappable via `HERMES_UID`). The entrypoint drops privileges via `gosu` before any agent code runs.
+- **The container has full network access** within Dream Server's bridge net — Hermes can make outbound HTTP requests for tools like `web_search`. If you want to restrict this, add an iptables firewall rule on the host or run Hermes behind a forward proxy.
+- **No APE policy enforcement yet.** Hermes's 70+ tools include shell + file write. The base config defaults toward less-risky tools, but Hermes can still execute shell commands inside its sandbox container. APE policy wrapping is a planned follow-up; until then, the trust model is "the user authenticated to Hermes is trusted to use the local container."
+
+## How to bump the SHA pin
+
+Hermes is a young, fast-moving project (~3 months old as of v1 integration). The SHA pin in `compose.yaml` lets us audit upstream changes deliberately rather than auto-tracking `:latest`. Bumping is a 5-minute pass:
+
+```bash
+# 1. Pick the new SHA. Upstream publishes a sha-<full-sha> tag for every
+#    main push, so any commit on NousResearch/hermes-agent's main is fair game.
+gh api repos/NousResearch/hermes-agent/commits/main --jq '{sha,date:.commit.author.date,msg:.commit.message}'
+
+# 2. Read the diff since our current pin. Skim breaking changes,
+#    config-format migrations, removed env vars.
+gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.commits[].commit.message'
+
+# 3. Update extensions/services/hermes/compose.yaml — the only place the
+#    pin appears.
+
+# 4. Smoke test:
+#    dream restart hermes
+#    curl http://localhost:9119/api/health  # should 200
+#    open http://localhost:9119, send a chat, verify tool call
+
+# 5. If it works, commit. If config.yaml format has changed, document the
+#    migration in this file's "Bump history" section below.
+```
+
+## Roadmap (deferred from v1)
+
+These were in the original integration plan but cut once we discovered Hermes ships a complete browser surface:
+
+- **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer (`bin/dream-mdns.py` lands in [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)). One-line follow-up after that PR merges.
+- **APE policy integration** — route Hermes's tool calls through APE for allow/deny + audit. APE is already in the stack; needs a small adapter inside or in front of Hermes.
+- **Magic-link SSO** — hand off magic-link redemptions ([#1155](https://github.com/Light-Heart-Labs/DreamServer/pull/1155)) into a Hermes auth session so family members don't need separate Hermes credentials.
+- **Voice in/out from Dream Server's whisper + kokoro** — Hermes has its own audio pipeline (the image bundles ffmpeg + playwright); verify whether it already proxies to local TTS/STT services or whether we need to wire that ourselves.
+- **Dream-side status panel** — surface Hermes's session count + skill inventory in the Dream dashboard. Lower priority since Hermes has its own `AnalyticsPage`.
+
+## Troubleshooting
+
+### `curl localhost:9119/api/health` returns 502 / connection refused
+
+Hermes hasn't finished bootstrapping. Watch the logs:
+
+```bash
+docker logs -f dream-hermes
+```
+
+First start does a ~30s skills sync; subsequent starts are fast.
+
+### Hermes can't reach the LLM
+
+Inside the container, `llama-server:8080` should resolve to the llama-server container. Test with:
+
+```bash
+docker exec dream-hermes curl -fs http://llama-server:8080/v1/models
+```
+
+If that fails, the most likely cause is that the Hermes container isn't on Dream Server's docker network. Check `docker network inspect dream-server_default`.
+
+### Sessions / memories / skills disappeared after upgrade
+
+The SHA pin protects you from accidental version drift, but if you DID bump and lose data, it's almost certainly because Hermes's config format changed. Check `data/hermes/config.yaml` against upstream's current `cli-config.yaml.example`. The container's first start regenerates `config.yaml` from our template only if it doesn't exist — your old config sticks around.
+
+### "I don't want Hermes anymore"
+
+```bash
+dream disable hermes              # stops the container
+rm -rf data/hermes                # wipes all sessions / memories / skills
+```
+
+The container image stays cached — `docker image prune` removes it.
+
+## Upstream attribution
+
+Hermes Agent is © 2026 Nous Research, MIT-licensed. Dream Server's contribution is the packaging layer (`extensions/services/hermes/`) — no code is forked from upstream. The pinned image is pulled directly from `docker.io/nousresearch/hermes-agent`.
+
+When promoting / talking about this extension, the convention is: "Hermes Agent (from Nous Research) — packaged for Dream Server."
+
+## Bump history
+
+| Date | Pinned SHA | Notes |
+|---|---|---|
+| 2026-05-12 | `dd0923bb89ed2dd56f82cb63656a1323f6f42e6f` | Initial integration. |

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -6,7 +6,7 @@ When enabled, Hermes runs in a container alongside the rest of the stack, expose
 
 ## What you get
 
-Hermes ships its own complete web UI — Dream Server is just packaging it. After `dream enable hermes`, you can browse to `http://<device>:9119` (or `hermes.<device>.local:9119` once mDNS announcement lands — see "Roadmap" below) and find pages for:
+Hermes ships its own complete web UI — Dream Server is just packaging it. After `dream enable hermes` + `dream enable hermes-proxy`, you can browse to `http://<device>:9120` (or `hermes.<device>.local:9120` once mDNS announcement lands — see "Roadmap" below). The proxy is the LAN-facing entry; it gates access on Dream Server's magic-link cookie before forwarding to Hermes's internal port 9119. See [docs/HERMES-SSO.md](HERMES-SSO.md) for the full auth flow. Once past the proxy you find pages for:
 
 - **Chat** — conversational interface with streaming responses + inline tool calls
 - **Sessions** — list, switch between, prune past conversations
@@ -87,7 +87,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 - **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
 - **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
-- **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
+- **Network exposure:** Hermes is **not directly LAN-reachable**. Once the `hermes-proxy` extension is enabled (see [docs/HERMES-SSO.md](HERMES-SSO.md)), the proxy at port 9120 fronts Hermes and gates access on Dream Server's magic-link cookie. Hermes's own port 9119 is internal-only. To restore direct access (e.g. for testing without auth), re-add a `ports:` binding to `extensions/services/hermes/compose.yaml`.
 - **Resource caps:** 4 CPUs / 4GB RAM hard limit, 0.5 CPU / 1GB reservation. Hermes's playwright + ML deps can be hungry; adjust in `extensions/services/hermes/compose.yaml` if needed.
 
 ## Configuration
@@ -138,11 +138,12 @@ gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.comm
 
 These were in the original integration plan but cut once we discovered Hermes ships a complete browser surface:
 
-- **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer (`bin/dream-mdns.py` lands in [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)). One-line follow-up after that PR merges.
+- **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer. ✅ shipped as [#1167](https://github.com/Light-Heart-Labs/DreamServer/pull/1167) (stacked on [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)).
+- **Magic-link SSO** — magic-link cookie gates access to Hermes via the new `hermes-proxy` Caddy sidecar. ✅ shipped — see [docs/HERMES-SSO.md](HERMES-SSO.md). Known limitation: single shared Hermes for all users; real per-user isolation would require per-user containers.
 - **APE policy integration** — route Hermes's tool calls through APE for allow/deny + audit. APE is already in the stack; needs a small adapter inside or in front of Hermes.
-- **Magic-link SSO** — hand off magic-link redemptions ([#1155](https://github.com/Light-Heart-Labs/DreamServer/pull/1155)) into a Hermes auth session so family members don't need separate Hermes credentials.
 - **Voice in/out from Dream Server's whisper + kokoro** — Hermes has its own audio pipeline (the image bundles ffmpeg + playwright); verify whether it already proxies to local TTS/STT services or whether we need to wire that ourselves.
 - **Dream-side status panel** — surface Hermes's session count + skill inventory in the Dream dashboard. Lower priority since Hermes has its own `AnalyticsPage`.
+- **Per-user Hermes containers** — if true multi-user becomes a felt need, spawn one Hermes per magic-link target_username and have the proxy route based on the redeemed identity. See [docs/HERMES-SSO.md](HERMES-SSO.md#future-option-b--per-user-hermes).
 
 ## Troubleshooting
 

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -142,7 +142,7 @@ These were in the original integration plan but cut once we discovered Hermes sh
 - **Magic-link SSO** — magic-link cookie gates access to Hermes via the new `hermes-proxy` Caddy sidecar. ✅ shipped — see [docs/HERMES-SSO.md](HERMES-SSO.md). Known limitation: single shared Hermes for all users; real per-user isolation would require per-user containers.
 - **APE policy integration** — route Hermes's tool calls through APE for allow/deny + audit. APE is already in the stack; needs a small adapter inside or in front of Hermes.
 - **Voice in/out from Dream Server's whisper + kokoro** — Hermes has its own audio pipeline (the image bundles ffmpeg + playwright); verify whether it already proxies to local TTS/STT services or whether we need to wire that ourselves.
-- **Dream-side status panel** — surface Hermes's session count + skill inventory in the Dream dashboard. Lower priority since Hermes has its own `AnalyticsPage`.
+- **Dream-side status panel** — ✅ partially shipped via manifest cleanup. Sidebar now surfaces "Hermes Agent" as a single tile pointing at the proxy (port 9120), instead of double-listing raw Hermes + proxy. The deeper "session count / skill inventory inside the Dream dashboard" is intentionally deferred — Hermes ships its own `AnalyticsPage` that's strictly richer than anything we'd surface, and cross-surface scraping would require bypassing Hermes's own auth.
 - **Per-user Hermes containers** — if true multi-user becomes a felt need, spawn one Hermes per magic-link target_username and have the proxy route based on the redeemed identity. See [docs/HERMES-SSO.md](HERMES-SSO.md#future-option-b--per-user-hermes).
 
 ## Troubleshooting

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -125,7 +125,9 @@ gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.comm
 
 # 4. Smoke test:
 #    dream restart hermes
-#    curl http://localhost:9119/api/health  # should 200
+#    curl http://localhost:9119/healthz     # should 200 (unauthenticated)
+#    # NOTE: /api/* is auth-gated (returns 401); use /healthz / /status
+#    # / /ping for unauthenticated probes.
 #    open http://localhost:9119, send a chat, verify tool call
 
 # 5. If it works, commit. If config.yaml format has changed, document the
@@ -144,7 +146,7 @@ These were in the original integration plan but cut once we discovered Hermes sh
 
 ## Troubleshooting
 
-### `curl localhost:9119/api/health` returns 502 / connection refused
+### `curl localhost:9119/healthz` returns 502 / connection refused
 
 Hermes hasn't finished bootstrapping. Watch the logs:
 

--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -48,10 +48,16 @@
 
 	# Static "you need an invite" page lives at /auth/required. Always
 	# accessible; this is where unauthenticated requests get bounced.
+	#
+	# `templates` lets index.html substitute `{{env "HERMES_PROXY_AUTH_DOCS_URL"}}`
+	# at response time, so operators can point recipients at a help doc /
+	# admin-contact page via env var without editing the HTML. The page
+	# only renders the "Need help?" row when the var is non-empty.
 	@auth_static path /auth/required* /auth/static/*
 	handle @auth_static {
 		root * /srv/auth-required
 		try_files {path} /index.html
+		templates
 		file_server
 	}
 

--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -1,16 +1,24 @@
 # Hermes Auth Proxy — Caddy config
 #
-# Sits in front of the dream-hermes container. Gates LAN access on the
-# presence of a `dream-session` cookie set by the dashboard-api's
-# magic-link redemption flow.
+# Sits in front of the dream-hermes container. Gates LAN access by
+# verifying the `dream-session` cookie against dashboard-api's
+# /api/auth/verify-session endpoint — which validates the cookie's
+# HMAC signature against DREAM_SESSION_SECRET (see session_signer.py).
+#
+# An earlier draft of this file only checked that the cookie HEADER
+# was present (`header_regexp Cookie dream-session=[^;]+`). That's
+# trivially bypassed — any LAN user can set `Cookie: dream-session=foo`
+# in curl or devtools and slip past the gate. We now do real signature
+# verification by delegating to dashboard-api via forward_auth.
 #
 # Flow:
 #   1. Request arrives on :9120
 #   2. /health and /favicon.ico — always answered (so health checks work)
 #   3. /auth/* — static "you need an invite" assets (always served)
-#   4. Has dream-session cookie? → reverse-proxy to dream-hermes:9119
-#      (Hermes's own X-Hermes-Session-Token check then runs per-request)
-#   5. Otherwise → 302 to /auth/required (the "ask the admin" page)
+#   4. Everything else: forward_auth to dashboard-api/api/auth/verify-session
+#      - 2xx → reverse-proxy to dream-hermes:9119
+#               (Hermes's own X-Hermes-Session-Token check still runs)
+#      - 401 → 303 redirect to /auth/required (the "ask the admin" page)
 #
 # This is auth GATING, not user identification. Once past the gate,
 # all users share the same Hermes instance (same memories, skills,
@@ -61,32 +69,43 @@
 		file_server
 	}
 
-	# Cookie matcher: presence of a non-empty `dream-session=<value>` in
-	# the Cookie header. Caddy's `header_regexp` matches the raw Cookie
-	# header as one string, so we anchor on `(?:^|;\s*)` so we match
-	# even when there are other cookies before ours.
-	@authenticated header_regexp Cookie (?:^|;\s*)dream-session=[^;]+
-	handle @authenticated {
-		# Forward everything to Hermes. reverse_proxy handles streaming
-		# responses (SSE) and WebSocket upgrades natively — Caddy's
-		# upstream-handling is the reason we picked it over rolling our
-		# own FastAPI proxy.
-		reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
-			# Pass-through with sane defaults. Caddy's defaults are
-			# correct for SSE + WS; we don't need to tweak buffering.
-			header_up X-Forwarded-Proto {scheme}
-			header_up X-Forwarded-Host {host}
-			# Add a marker the operator can grep for in Hermes's logs
-			# if they're debugging a "did this request come via the
-			# proxy or directly?" question.
-			header_up X-Dream-Auth-Proxy "1"
+	# Real session verification: delegate to dashboard-api's
+	# /api/auth/verify-session. That endpoint reads the dream-session
+	# cookie, verifies the HMAC signature against DREAM_SESSION_SECRET,
+	# and returns 200 (valid) or 401 (missing/expired/bad-signature).
+	#
+	# Caddy's forward_auth issues a sub-request to the auth upstream
+	# with the original Cookie header copied across, then:
+	#   * 2xx → falls through to reverse_proxy below
+	#   * non-2xx → the handle_response @denied block fires, sending the
+	#               user to the auth-required page (303 — important so a
+	#               no-cookie POST doesn't replay its body to /auth/required)
+	#
+	# DREAM_AUTH_UPSTREAM defaults to the in-network dashboard-api
+	# hostname (which only the compose bridge can resolve); operators
+	# can override via env if dashboard-api lives elsewhere.
+	forward_auth {$DREAM_AUTH_UPSTREAM:dream-dashboard-api:3002} {
+		uri /api/auth/verify-session
+		copy_headers Cookie
+
+		@denied status 401 403
+		handle_response @denied {
+			redir /auth/required 303
 		}
 	}
 
-	# No cookie → bounce to the auth-required page. 303 (See Other) is
-	# the correct status for "this method is done, go GET that URL" —
-	# important so a no-cookie POST doesn't replay the body to /auth/required.
-	handle {
-		redir /auth/required 303
+	# Forward everything to Hermes. reverse_proxy handles streaming
+	# responses (SSE) and WebSocket upgrades natively — Caddy's
+	# upstream-handling is the reason we picked it over rolling our
+	# own FastAPI proxy.
+	reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
+		# Pass-through with sane defaults. Caddy's defaults are
+		# correct for SSE + WS; we don't need to tweak buffering.
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+		# Add a marker the operator can grep for in Hermes's logs
+		# if they're debugging a "did this request come via the
+		# proxy or directly?" question.
+		header_up X-Dream-Auth-Proxy "1"
 	}
 }

--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -1,0 +1,86 @@
+# Hermes Auth Proxy — Caddy config
+#
+# Sits in front of the dream-hermes container. Gates LAN access on the
+# presence of a `dream-session` cookie set by the dashboard-api's
+# magic-link redemption flow.
+#
+# Flow:
+#   1. Request arrives on :9120
+#   2. /health and /favicon.ico — always answered (so health checks work)
+#   3. /auth/* — static "you need an invite" assets (always served)
+#   4. Has dream-session cookie? → reverse-proxy to dream-hermes:9119
+#      (Hermes's own X-Hermes-Session-Token check then runs per-request)
+#   5. Otherwise → 302 to /auth/required (the "ask the admin" page)
+#
+# This is auth GATING, not user identification. Once past the gate,
+# all users share the same Hermes instance (same memories, skills,
+# persona). See docs/HERMES-SSO.md for the explicit limitation.
+
+{
+	# Disable Caddy's auto-HTTPS — Dream Server's TLS is handled at the
+	# Tailscale layer (PR-12) or by an explicit operator-side reverse
+	# proxy. Inside the bridge network we serve plain HTTP.
+	auto_https off
+	# Don't expose Caddy's admin API. It's an attack surface we don't need.
+	admin off
+	# Log to stdout for `docker logs dream-hermes-proxy`.
+	log {
+		output stdout
+		format console
+		level INFO
+	}
+}
+
+# Listen on the proxy's internal port. Compose maps this to the external
+# HERMES_PROXY_PORT via the host port mapping.
+:9120 {
+	# Cheap health endpoint for Docker / dashboard probes. NEVER gates on
+	# the cookie — health checks are anonymous by design.
+	@health path /health
+	handle @health {
+		respond "ok" 200
+	}
+
+	@favicon path /favicon.ico
+	handle @favicon {
+		respond 204
+	}
+
+	# Static "you need an invite" page lives at /auth/required. Always
+	# accessible; this is where unauthenticated requests get bounced.
+	@auth_static path /auth/required* /auth/static/*
+	handle @auth_static {
+		root * /srv/auth-required
+		try_files {path} /index.html
+		file_server
+	}
+
+	# Cookie matcher: presence of a non-empty `dream-session=<value>` in
+	# the Cookie header. Caddy's `header_regexp` matches the raw Cookie
+	# header as one string, so we anchor on `(?:^|;\s*)` so we match
+	# even when there are other cookies before ours.
+	@authenticated header_regexp Cookie (?:^|;\s*)dream-session=[^;]+
+	handle @authenticated {
+		# Forward everything to Hermes. reverse_proxy handles streaming
+		# responses (SSE) and WebSocket upgrades natively — Caddy's
+		# upstream-handling is the reason we picked it over rolling our
+		# own FastAPI proxy.
+		reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
+			# Pass-through with sane defaults. Caddy's defaults are
+			# correct for SSE + WS; we don't need to tweak buffering.
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Forwarded-Host {host}
+			# Add a marker the operator can grep for in Hermes's logs
+			# if they're debugging a "did this request come via the
+			# proxy or directly?" question.
+			header_up X-Dream-Auth-Proxy "1"
+		}
+	}
+
+	# No cookie → bounce to the auth-required page. 303 (See Other) is
+	# the correct status for "this method is done, go GET that URL" —
+	# important so a no-cookie POST doesn't replay the body to /auth/required.
+	handle {
+		redir /auth/required 303
+	}
+}

--- a/dream-server/extensions/services/hermes-proxy/auth-required/index.html
+++ b/dream-server/extensions/services/hermes-proxy/auth-required/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#0f0f13" />
+  <title>Hermes — Invite required</title>
+  <style>
+    :root {
+      --bg: #0f0f13;
+      --card: #1a1a22;
+      --text: #e4e4e7;
+      --muted: #8c8c96;
+      --accent: #a78bfa;
+      --border: #2a2a34;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      line-height: 1.5;
+    }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 1rem;
+      padding: 2rem;
+      max-width: 28rem;
+      width: 100%;
+    }
+    .badge {
+      display: inline-block;
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.15em;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+    h1 {
+      margin: 0 0 0.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    p {
+      color: var(--muted);
+      margin: 0 0 1rem;
+    }
+    .icon {
+      width: 3rem;
+      height: 3rem;
+      border-radius: 0.75rem;
+      background: rgba(167, 139, 250, 0.15);
+      color: var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 1.25rem;
+    }
+    .steps {
+      list-style: none;
+      padding: 0;
+      margin: 1.5rem 0 0;
+      counter-reset: step;
+    }
+    .steps li {
+      counter-increment: step;
+      padding: 0.5rem 0 0.5rem 2.5rem;
+      position: relative;
+      color: var(--text);
+    }
+    .steps li::before {
+      content: counter(step);
+      position: absolute;
+      left: 0;
+      top: 0.4rem;
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 50%;
+      background: rgba(167, 139, 250, 0.15);
+      color: var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 700;
+    }
+    code {
+      background: rgba(255, 255, 255, 0.04);
+      padding: 0.1rem 0.4rem;
+      border-radius: 0.25rem;
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 0.85em;
+      color: var(--accent);
+    }
+    .footer {
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon" aria-hidden="true">
+      <!-- Shield icon, inline SVG so we don't depend on a network fetch -->
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      </svg>
+    </div>
+    <div class="badge">HERMES AGENT</div>
+    <h1>You need an invite.</h1>
+    <p>This Hermes Agent is gated behind Dream Server's magic-link auth. To reach the chat surface, an admin needs to send you an invite link from their dashboard.</p>
+
+    <ol class="steps">
+      <li>Ask the admin to open their dashboard's <strong>Invites</strong> page.</li>
+      <li>They generate a magic-link with scope <code>chat</code> or <code>all</code>.</li>
+      <li>They share the QR or URL with you — scan or tap once and you're in.</li>
+    </ol>
+
+    <p class="footer">
+      Already have a link? Open it directly — redemption sets the session cookie
+      this page is waiting for, and you'll be redirected straight to Hermes.
+    </p>
+  </div>
+</body>
+</html>

--- a/dream-server/extensions/services/hermes-proxy/auth-required/index.html
+++ b/dream-server/extensions/services/hermes-proxy/auth-required/index.html
@@ -127,6 +127,12 @@
       <li>They share the QR or URL with you — scan or tap once and you're in.</li>
     </ol>
 
+    {{ $docsUrl := env "HERMES_PROXY_AUTH_DOCS_URL" }}{{ if $docsUrl }}
+    <p style="margin-top: 1rem; font-size: 0.875rem; color: var(--text);">
+      Need help? <a href="{{ $docsUrl }}" style="color: var(--accent); text-decoration: underline;">See the operator's notes</a>.
+    </p>
+    {{ end }}
+
     <p class="footer">
       Already have a link? Open it directly — redemption sets the session cookie
       this page is waiting for, and you'll be redirected straight to Hermes.

--- a/dream-server/extensions/services/hermes-proxy/compose.yaml
+++ b/dream-server/extensions/services/hermes-proxy/compose.yaml
@@ -8,9 +8,19 @@ services:
     restart: unless-stopped
     depends_on:
       - hermes
+      # forward_auth needs dashboard-api up to verify sessions. Compose
+      # depends_on only sequences start-up, not health — Caddy will get
+      # 502s for verify-session until dashboard-api is responding, at
+      # which point users get bounced to /auth/required (correct behaviour
+      # for the brief window).
+      - dashboard-api
     environment:
       # Override the upstream from .env if the operator's wiring differs.
       - HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}
+      # Where forward_auth sends its session-verify sub-request. Defaults
+      # to the in-network dashboard-api container; override if dashboard-api
+      # lives on a different host or non-standard port.
+      - DREAM_AUTH_UPSTREAM=${DREAM_AUTH_UPSTREAM:-dream-dashboard-api:3002}
       # Optional help URL surfaced on the "you need an invite" page via
       # Caddy `templates` substitution. Empty hides the row entirely.
       - HERMES_PROXY_AUTH_DOCS_URL=${HERMES_PROXY_AUTH_DOCS_URL:-}

--- a/dream-server/extensions/services/hermes-proxy/compose.yaml
+++ b/dream-server/extensions/services/hermes-proxy/compose.yaml
@@ -1,0 +1,50 @@
+services:
+  hermes-proxy:
+    # Pinned Caddy 2.x. Single static binary, ~50MB image, native
+    # SSE/WebSocket support — much lighter than a custom FastAPI proxy
+    # for what amounts to "check a cookie, forward, or 303 redirect."
+    image: caddy:2.8.4-alpine
+    container_name: dream-hermes-proxy
+    restart: unless-stopped
+    depends_on:
+      - hermes
+    environment:
+      # Override the upstream from .env if the operator's wiring differs.
+      - HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}
+    volumes:
+      # Caddyfile is read-only; mounting :ro reduces the blast radius if
+      # the container were ever compromised.
+      - ./extensions/services/hermes-proxy/Caddyfile:/etc/caddy/Caddyfile:ro
+      # Static "you need an invite" page served when no cookie is present.
+      - ./extensions/services/hermes-proxy/auth-required:/srv/auth-required:ro
+      # Caddy persists its own state (certs, etc.) — empty for us since
+      # auto_https is off, but keeping the volume avoids first-start chatter.
+      - ./data/hermes-proxy/caddy-data:/data
+      - ./data/hermes-proxy/caddy-config:/config
+    ports:
+      # BIND_ADDRESS gates LAN exposure (Dream Server convention). Default
+      # 127.0.0.1 = localhost only. Set BIND_ADDRESS=0.0.0.0 in .env to
+      # expose on the LAN at hermes.<device>.local:9120.
+      - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PROXY_PORT:-9120}:9120"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:9120/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    # Caddy is very light; small caps reflect that.
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.05'
+          memory: 32M
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/hermes-proxy/compose.yaml
+++ b/dream-server/extensions/services/hermes-proxy/compose.yaml
@@ -11,6 +11,9 @@ services:
     environment:
       # Override the upstream from .env if the operator's wiring differs.
       - HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}
+      # Optional help URL surfaced on the "you need an invite" page via
+      # Caddy `templates` substitution. Empty hides the row entirely.
+      - HERMES_PROXY_AUTH_DOCS_URL=${HERMES_PROXY_AUTH_DOCS_URL:-}
     volumes:
       # Caddyfile is read-only; mounting :ro reduces the blast radius if
       # the container were ever compromised.

--- a/dream-server/extensions/services/hermes-proxy/manifest.yaml
+++ b/dream-server/extensions/services/hermes-proxy/manifest.yaml
@@ -1,0 +1,57 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: hermes-proxy
+  name: Hermes Auth Proxy
+  aliases: [hermes-gate]
+  container_name: dream-hermes-proxy
+  default_host: hermes-proxy
+  port: 9120
+  external_port_env: HERMES_PROXY_PORT
+  external_port_default: 9120
+  health: /health
+  ui_path: /
+  health_timeout: 10
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: [hermes, dashboard-api]
+  description: >
+    Caddy-based reverse proxy that fronts the Hermes Agent extension.
+    Gates access on the presence of a `dream-session` cookie (set by
+    the magic-link redemption flow in dashboard-api). Without the
+    cookie, requests are answered with a static "you need an invite"
+    page. With it, traffic is forwarded to dream-hermes:9119 and
+    Hermes's own session-token model handles per-request auth.
+    Native streaming + WebSocket support via Caddy's `reverse_proxy`.
+
+  env_vars:
+    - key: HERMES_PROXY_PORT
+      default: "9120"
+      description: External port for the Hermes auth-proxy (LAN-facing entry)
+    - key: HERMES_PROXY_UPSTREAM
+      default: "dream-hermes:9119"
+      description: Internal address of the Hermes container we forward to
+    - key: HERMES_PROXY_AUTH_DOCS_URL
+      default: ""
+      description: |
+        Optional URL shown on the "you need an invite" page if the operator
+        has a help doc / contact info. Empty hides the row.
+
+features:
+  - id: hermes-sso
+    name: Hermes Single Sign-On
+    description: Magic-link SSO gating in front of Hermes Agent
+    icon: Shield
+    category: privacy
+    requirements:
+      services: [hermes, dashboard-api]
+      vram_gb: 0
+    enabled_services_all: [hermes-proxy]
+    setup_time: Ready
+    priority: 5
+    gpu_backends: [all]

--- a/dream-server/extensions/services/hermes-proxy/manifest.yaml
+++ b/dream-server/extensions/services/hermes-proxy/manifest.yaml
@@ -5,8 +5,11 @@ compatibility:
 
 service:
   id: hermes-proxy
-  name: Hermes Auth Proxy
-  aliases: [hermes-gate]
+  # This is the user-facing sidebar tile for "Hermes Agent." The raw
+  # Hermes container (id: hermes) is internal-only; this proxy is the
+  # only entry point reachable from the LAN / Tailscale.
+  name: Hermes Agent
+  aliases: [hermes, agent, hermes-gate, hermes-auth-proxy]
   container_name: dream-hermes-proxy
   default_host: hermes-proxy
   port: 9120
@@ -21,8 +24,8 @@ service:
   category: optional
   depends_on: [hermes, dashboard-api]
   description: >
-    Caddy-based reverse proxy that fronts the Hermes Agent extension.
-    Verifies the `dream-session` cookie against dashboard-api's
+    User-facing entry point for the Hermes Agent. A Caddy reverse proxy
+    that verifies the `dream-session` cookie against dashboard-api's
     /api/auth/verify-session endpoint (Caddy forward_auth) — which
     HMAC-validates the cookie's signature against DREAM_SESSION_SECRET.
     Without a valid cookie, requests are bounced to a static "you need

--- a/dream-server/extensions/services/hermes-proxy/manifest.yaml
+++ b/dream-server/extensions/services/hermes-proxy/manifest.yaml
@@ -22,11 +22,12 @@ service:
   depends_on: [hermes, dashboard-api]
   description: >
     Caddy-based reverse proxy that fronts the Hermes Agent extension.
-    Gates access on the presence of a `dream-session` cookie (set by
-    the magic-link redemption flow in dashboard-api). Without the
-    cookie, requests are answered with a static "you need an invite"
-    page. With it, traffic is forwarded to dream-hermes:9119 and
-    Hermes's own session-token model handles per-request auth.
+    Verifies the `dream-session` cookie against dashboard-api's
+    /api/auth/verify-session endpoint (Caddy forward_auth) — which
+    HMAC-validates the cookie's signature against DREAM_SESSION_SECRET.
+    Without a valid cookie, requests are bounced to a static "you need
+    an invite" page. With one, traffic is forwarded to dream-hermes:9119
+    and Hermes's own session-token model handles per-request auth.
     Native streaming + WebSocket support via Caddy's `reverse_proxy`.
 
   env_vars:
@@ -36,6 +37,12 @@ service:
     - key: HERMES_PROXY_UPSTREAM
       default: "dream-hermes:9119"
       description: Internal address of the Hermes container we forward to
+    - key: DREAM_AUTH_UPSTREAM
+      default: "dream-dashboard-api:3002"
+      description: |
+        Where forward_auth sends its session-verify sub-request. Defaults
+        to the in-network dashboard-api container; override if dashboard-api
+        lives on a different host or non-standard port.
     - key: HERMES_PROXY_AUTH_DOCS_URL
       default: ""
       description: |

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -1,0 +1,56 @@
+# Hermes — Dream Server Default Persona
+
+You are **Hermes**, the resident agent on a Dream Server installation. Dream
+Server is a fully-local AI stack — chat, voice, image generation, agents,
+workflows, RAG, and privacy tooling — that runs on the user's own hardware
+with no data ever leaving their machine.
+
+You are a **generalist agent**. You can chat conversationally, but you can
+also take real action: search the web, read and write files, run shell
+commands (when policy allows), keep notes, set reminders, ingest documents,
+and recall things from past conversations.
+
+## Operating principles
+
+1. **Take the action when it's clear.** If a user says "look up the weather
+   in Tokyo," search the web — don't ask permission first. Save the asking
+   for genuinely destructive or non-reversible operations (file deletion,
+   sending email on their behalf, etc.).
+
+2. **Show your work.** When you use a tool, mention what you did briefly. The
+   user sees tool calls in the UI, so the goal is just to weave them into
+   the conversation, not narrate every step in detail.
+
+3. **Remember what matters.** Hermes has persistent memory — if a user tells
+   you something durable about themselves ("I'm allergic to peanuts," "my
+   partner's name is Alex"), save it. Don't save every passing detail.
+
+4. **Stay local-first.** Dream Server's whole posture is that the user owns
+   their data. Don't suggest cloud services when a local equivalent exists.
+   When you DO need an external resource (a webpage, a Wikipedia article),
+   fetch only what's needed.
+
+5. **Be honest about uncertainty.** If you're not sure whether a recalled
+   fact is current, say so. The local model isn't always up to date; trust
+   web search for current events.
+
+## Tone
+
+Warm, direct, lightly informal. The user is likely on their phone or laptop
+at home, not at a help desk. Match their energy. Avoid hedging language
+("perhaps you might want to consider…"); just answer.
+
+## What you are NOT
+
+- Not a coding agent. DreamForge handles that. If the user wants you to edit
+  their code repo, gently point them at DreamForge.
+- Not a customer-service bot. Don't apologize for things that aren't your
+  fault.
+- Not a moralizer. Don't lecture the user about their choices unless they
+  ask. Respect their autonomy.
+
+## Resetting this persona
+
+The user can edit this file at `/opt/data/SOUL.md` inside the Hermes
+container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply.
+Deleting the file falls back to upstream's default persona.

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -13,9 +13,11 @@
 # Model — points at Dream Server's local LLM by default
 # =============================================================================
 model:
-  # The local model name. Defaults to Dream's LLM_MODEL via the
-  # OPENAI_BASE_URL Hermes inspects. The provider override below makes
-  # the actual model lookup happen against llama-server's /v1/models.
+  # The local model name. Defaults to "qwen3.5-9b" because that's Dream
+  # Server's default; if you've switched llama-server to a different
+  # model, edit this line in /opt/data/config.yaml after first start.
+  # (Hermes does NOT read HERMES_MODEL_NAME from env — the config.yaml
+  # is the source of truth once it's copied out of the example.)
   default: "qwen3.5-9b"
 
   # provider=custom = any OpenAI-compatible local server. Aliases:
@@ -27,6 +29,13 @@ model:
   # value here is the fallback if the env var is unset.
   base_url: "http://llama-server:8080/v1"
 
+  # Match the LLM's context window. Dream Server's default CTX_SIZE is
+  # 16384; bump this in /opt/data/config.yaml if you've raised CTX_SIZE
+  # in .env. Upstream Hermes reads this from model.context_length —
+  # earlier drafts used a top-level context: block which is silently
+  # ignored.
+  context_length: 16384
+
 # =============================================================================
 # Terminal backend — where tool calls execute
 # =============================================================================
@@ -37,30 +46,37 @@ terminal:
   backend: "local"
 
 # =============================================================================
-# Messaging gateways — DISABLED by default in Dream Server
+# Messaging gateways — none enabled by default in Dream Server
 # =============================================================================
 # Hermes ships with Telegram / Discord / Slack / WhatsApp / Signal / email /
-# Teams / Google Chat / Matrix / Mattermost / SMS gateways. Dream Server users
-# reach Hermes via the web dashboard, not platform bots. Leave these off
-# unless you understand the security implications of each.
+# Teams / Google Chat / Matrix / Mattermost / SMS gateway adapters. Dream
+# Server users reach Hermes via the web dashboard, not platform bots — so
+# none of these are configured here.
 #
-# To enable any of them, set the corresponding token in .env (TELEGRAM_TOKEN,
-# DISCORD_TOKEN, etc.) AND remove the disabled: true line from the
-# corresponding adapter config under upstream's gateway docs.
-gateway:
-  # Globally disable the messaging gateway runner. The `dashboard` subcommand
-  # is what compose.yaml starts; this just makes sure that if someone runs
-  # `docker exec dream-hermes hermes gateway run` it stays a no-op until
-  # they explicitly configure a platform.
-  enabled: false
+# IMPORTANT: there is NO top-level `gateway.enabled: false` switch in
+# upstream's config schema. Earlier drafts of this template had one; it
+# was silently ignored. The gateway is "disabled" by simply not
+# configuring any adapter (no TELEGRAM_TOKEN, no DISCORD_TOKEN, etc.),
+# which means `hermes gateway run` starts, ticks cron, hosts the
+# dashboard, and has no platforms to message on.
+#
+# To enable a platform, follow upstream's adapter docs and add the
+# matching block under the platform-specific config keys, then restart
+# the container.
 
 # =============================================================================
 # Compression — keep memory bounded on small devices
 # =============================================================================
-# Hermes auto-compacts long conversations. Lower threshold = more aggressive
-# compaction = lower disk + token costs but more summarization loss.
-context:
-  # Match the LLM's context window. Dream Server's default CTX_SIZE is 16384;
-  # bump this if you've raised CTX_SIZE in .env.
-  context_length: 16384
-  compact_threshold: 10000
+# Hermes auto-compacts long conversations once they cross the threshold.
+# These are the upstream-correct keys (compression.*); an earlier draft
+# used compact_threshold under a context: block which upstream silently
+# ignores.
+compression:
+  # Token count at which Hermes starts compacting the conversation.
+  # Lower = more aggressive = lower disk/token cost but more summary loss.
+  # Keep this comfortably below model.context_length so there's headroom
+  # before hitting the hard window limit.
+  threshold: 10000
+  # Fraction of the conversation to retain after compaction. 0.5 = aim
+  # for half the original token count post-summary.
+  target_ratio: 0.5

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -1,0 +1,66 @@
+# Hermes Agent configuration — Dream Server defaults.
+#
+# This file is mounted into the upstream image at
+# /opt/hermes/cli-config.yaml.example, which Hermes's entrypoint copies into
+# /opt/data/config.yaml on first start IF that file doesn't already exist.
+# Re-running `dream enable hermes` after editing here won't overwrite an
+# existing config — delete /opt/data/config.yaml manually if you want to
+# reset to these defaults.
+#
+# Documentation for every key: https://hermes-agent.nousresearch.com/docs/
+
+# =============================================================================
+# Model — points at Dream Server's local LLM by default
+# =============================================================================
+model:
+  # The local model name. Defaults to Dream's LLM_MODEL via the
+  # OPENAI_BASE_URL Hermes inspects. The provider override below makes
+  # the actual model lookup happen against llama-server's /v1/models.
+  default: "qwen3.5-9b"
+
+  # provider=custom = any OpenAI-compatible local server. Aliases:
+  # ollama, vllm, llamacpp. We pick "custom" for portability.
+  provider: "custom"
+
+  # base_url is overridden at container start by OPENAI_BASE_URL env
+  # (which compose.yaml wires to http://llama-server:8080/v1). The
+  # value here is the fallback if the env var is unset.
+  base_url: "http://llama-server:8080/v1"
+
+# =============================================================================
+# Terminal backend — where tool calls execute
+# =============================================================================
+# Hermes can run tools in a few different sandboxes. For Dream Server we keep
+# it local-to-the-container: no SSH out, no Modal/Daytona, no Docker-in-Docker.
+# The container IS the sandbox.
+terminal:
+  backend: "local"
+
+# =============================================================================
+# Messaging gateways — DISABLED by default in Dream Server
+# =============================================================================
+# Hermes ships with Telegram / Discord / Slack / WhatsApp / Signal / email /
+# Teams / Google Chat / Matrix / Mattermost / SMS gateways. Dream Server users
+# reach Hermes via the web dashboard, not platform bots. Leave these off
+# unless you understand the security implications of each.
+#
+# To enable any of them, set the corresponding token in .env (TELEGRAM_TOKEN,
+# DISCORD_TOKEN, etc.) AND remove the disabled: true line from the
+# corresponding adapter config under upstream's gateway docs.
+gateway:
+  # Globally disable the messaging gateway runner. The `dashboard` subcommand
+  # is what compose.yaml starts; this just makes sure that if someone runs
+  # `docker exec dream-hermes hermes gateway run` it stays a no-op until
+  # they explicitly configure a platform.
+  enabled: false
+
+# =============================================================================
+# Compression — keep memory bounded on small devices
+# =============================================================================
+# Hermes auto-compacts long conversations. Lower threshold = more aggressive
+# compaction = lower disk + token costs but more summarization loss.
+context:
+  # Match the LLM's context window. Dream Server's default CTX_SIZE is 16384;
+  # bump this if you've raised CTX_SIZE in .env.
+  context_length: 16384
+  compact_threshold: 10000

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -28,6 +28,19 @@ services:
       # Locale + timezone match the rest of the stack.
       - TZ=${TIMEZONE:-UTC}
       - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
+      # Embed the dashboard inside the gateway process (see `command` below).
+      # Upstream reads these env vars to configure the dashboard listener
+      # without separate CLI flags.
+      - HERMES_DASHBOARD=1
+      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_PORT=9119
+      # --insecure equivalent: dashboard refuses non-loopback binds without
+      # this since it stores API keys. The trusted-LAN posture is the v1
+      # trade-off (documented in docs/HERMES.md).
+      - HERMES_DASHBOARD_INSECURE=1
+      # --no-open equivalent: stops Hermes from trying to spawn a browser
+      # inside the container.
+      - HERMES_DASHBOARD_NO_OPEN=1
     volumes:
       # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
       # cron jobs, audit logs all live here.
@@ -44,20 +57,23 @@ services:
       # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
       # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
       - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
-    # Run only the dashboard subcommand. Upstream's image entrypoint defaults
-    # to `hermes` (no args) which is for interactive use. We want exactly the
-    # FastAPI + React UI. --insecure is required because the dashboard refuses
-    # non-loopback binds without it (it stores API keys); inside Dream Server's
-    # trusted-LAN posture this is the documented v1 trade-off. --no-open keeps
-    # Hermes from trying to open a browser inside the container.
+    # Run the gateway with the dashboard embedded.
+    #
+    # Why `gateway run` and not just `dashboard`: Hermes's scheduler (the
+    # cron tick that fires recurring tasks) runs INSIDE the gateway process,
+    # not the dashboard. Earlier drafts of this extension ran only
+    # `dashboard`, which let users create cron jobs through the UI but
+    # never actually fired them — `tick()` lives in the gateway's main
+    # loop. `gateway run` with HERMES_DASHBOARD=1 (set above) gives us
+    # both: the gateway's scheduler + the React UI, in one process.
+    #
+    # We don't enable any messaging platforms (Telegram / Discord / etc.)
+    # so the gateway has no adapters to drive — its only job here is to
+    # tick cron and host the dashboard. That's the upstream-supported
+    # shape; see https://hermes-agent.nousresearch.com/docs/gateway.
     command:
-      - dashboard
-      - --host
-      - 0.0.0.0
-      - --port
-      - "9119"
-      - --no-open
-      - --insecure
+      - gateway
+      - run
     healthcheck:
       test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
       interval: 30s

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -52,11 +52,17 @@ services:
       # a custom Dockerfile.
       - ./extensions/services/hermes/cli-config.yaml.template:/opt/hermes/cli-config.yaml.example:ro
       - ./extensions/services/hermes/SOUL.md.template:/opt/hermes/docker/SOUL.md:ro
-    ports:
-      # BIND_ADDRESS gates LAN exposure. Default 127.0.0.1 = localhost only.
-      # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
-      # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
-      - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
+    # Hermes is exposed to the LAN via dream-hermes-proxy on port 9120 — that
+    # Caddy sidecar forward_auths to dashboard-api's verify-session and only
+    # then forwards traffic here. By NOT binding a host port on the Hermes
+    # container itself, we close the door on direct LAN access that would
+    # bypass the magic-link gate. If you disable the proxy, you'll need to
+    # re-add a `ports:` binding here OR `docker exec dream-hermes` to interact.
+    #
+    # Internal port 9119 stays reachable from other containers (the proxy
+    # forwards to dream-hermes:9119 via the Docker network).
+    expose:
+      - "9119"
     # Run the gateway with the dashboard embedded.
     #
     # Why `gateway run` and not just `dashboard`: Hermes's scheduler (the

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -1,0 +1,83 @@
+services:
+  hermes:
+    # SHA-pinned to NousResearch/hermes-agent@dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
+    # (2026-05-12). Upstream's CI publishes a sha-<full-sha> tag for every main
+    # push, so this is an immutable reference. Bumping the pin is a deliberate
+    # review-and-smoke-test pass — see docs/HERMES.md "How to bump the pin."
+    image: nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
+    container_name: dream-hermes
+    restart: unless-stopped
+    # NOT host networking — we use bridge so the container can resolve
+    # `llama-server` via Docker's internal DNS. Upstream's reference compose
+    # uses host mode; we deviate because Dream Server is multi-service and
+    # depends on inter-container service discovery.
+    environment:
+      # User remapping: match the host user so files written into the volume
+      # are owned by the user, not container-root. Same pattern as n8n.
+      - HERMES_UID=${UID:-10000}
+      - HERMES_GID=${GID:-10000}
+      # Point Hermes at the local LLM. provider=custom is the documented
+      # alias for any OpenAI-compatible local server (vLLM / llama.cpp / Ollama).
+      # The actual provider/model wiring lives in cli-config.yaml (mounted below).
+      - OPENAI_BASE_URL=${HERMES_LLM_BASE_URL:-http://llama-server:8080/v1}
+      - OPENAI_API_KEY=${HERMES_LLM_API_KEY:-sk-dream-hermes-local}
+      # Aggressive timeouts for local cold starts — llama-server can take
+      # >60s to load a model under heavy use.
+      - HERMES_API_TIMEOUT=1800
+      - HERMES_API_CALL_STALE_TIMEOUT=900
+      # Locale + timezone match the rest of the stack.
+      - TZ=${TIMEZONE:-UTC}
+      - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
+    volumes:
+      # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
+      # cron jobs, audit logs all live here.
+      - ./data/hermes:/opt/data
+      # Bake our cli-config.yaml + SOUL.md as the defaults Hermes copies into
+      # HERMES_HOME on first start (its entrypoint copies these examples into
+      # /opt/data/ if the destination files don't exist yet). Mounting them
+      # over the in-image versions means our defaults win without needing
+      # a custom Dockerfile.
+      - ./extensions/services/hermes/cli-config.yaml.template:/opt/hermes/cli-config.yaml.example:ro
+      - ./extensions/services/hermes/SOUL.md.template:/opt/hermes/docker/SOUL.md:ro
+    ports:
+      # BIND_ADDRESS gates LAN exposure. Default 127.0.0.1 = localhost only.
+      # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
+      # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
+      - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
+    # Run only the dashboard subcommand. Upstream's image entrypoint defaults
+    # to `hermes` (no args) which is for interactive use. We want exactly the
+    # FastAPI + React UI. --insecure is required because the dashboard refuses
+    # non-loopback binds without it (it stores API keys); inside Dream Server's
+    # trusted-LAN posture this is the documented v1 trade-off. --no-open keeps
+    # Hermes from trying to open a browser inside the container.
+    command:
+      - dashboard
+      - --host
+      - 0.0.0.0
+      - --port
+      - "9119"
+      - --no-open
+      - --insecure
+    healthcheck:
+      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s  # skills sync + config bootstrap can take a while
+    # Hermes pulls in playwright + ffmpeg + chromium + ML deps — image is
+    # multi-GB. Reasonable resource caps so it doesn't crowd out the LLM.
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 4G
+        reservations:
+          cpus: '0.5'
+          memory: 1G
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -75,7 +75,13 @@ services:
       - gateway
       - run
     healthcheck:
-      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/api/health"]
+      # Hermes's dashboard auth gates everything under /api/* (returns 401),
+      # so /api/health is NOT a usable healthcheck — curl -fs would fail
+      # and the container would be perpetually unhealthy. Verified against
+      # the SHA-pinned image during smoke test: the unauthenticated
+      # endpoints are /healthz, /health, /status, /ping at the root.
+      # /healthz is the convention closest to k8s-style probes.
+      test: ["CMD", "curl", "-fs", "http://127.0.0.1:9119/healthz"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -1,0 +1,65 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: hermes
+  name: Hermes Agent
+  aliases: [agent, hermes-agent]
+  container_name: dream-hermes
+  default_host: hermes
+  # Hermes's own dashboard listens on 9119 inside the container. We expose
+  # the same port externally — keeps URLs intuitive when users follow the
+  # mDNS hostname (hermes.<device>.local:9119).
+  port: 9119
+  external_port_env: HERMES_PORT
+  external_port_default: 9119
+  health: /api/health
+  ui_path: /
+  health_timeout: 60  # Hermes does skill sync + config bootstrap on cold start
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: [llama-server]
+  description: >
+    Hermes Agent (Nous Research) — a self-improving generalist agent with
+    persistent memory, autonomous skill creation, and 70+ built-in tools.
+    Dream Server runs the upstream image pinned by SHA, points it at the
+    local LLM (llama-server), and disables the messaging gateways (Telegram /
+    Discord / Slack / etc.) since the web dashboard is the surface we ship.
+    Reachable on the LAN at hermes.<device>.local:9119 via mDNS.
+
+  env_vars:
+    - key: HERMES_PORT
+      default: "9119"
+      description: External port for Hermes's own dashboard (FastAPI + React UI)
+    - key: HERMES_MODEL_NAME
+      default: "qwen3.5-9b"
+      description: |
+        Model name passed to Hermes. Defaults to Dream Server's LLM_MODEL.
+        Hermes uses provider=custom so this is mostly a label — what matters
+        is HERMES_LLM_BASE_URL pointing at an OpenAI-compatible endpoint.
+    - key: HERMES_LLM_BASE_URL
+      default: "http://llama-server:8080/v1"
+      description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.
+    - key: HERMES_LLM_API_KEY
+      default: "sk-dream-hermes-local"
+      description: |
+        Dummy API key — llama-server doesn't validate it but the OpenAI SDK
+        Hermes uses internally requires the field to be non-empty.
+
+features:
+  - id: hermes-agent
+    name: Hermes Agent
+    description: Generalist self-improving agent — chat, tools, persistent memory, scheduled tasks
+    icon: Bot
+    category: productivity
+    requirements:
+      services: [llama-server]
+      vram_gb: 0
+    enabled_services_all: [hermes]
+    setup_time: ~1 minute (image pull)
+    priority: 5
+    gpu_backends: [all]

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -10,8 +10,9 @@ service:
   container_name: dream-hermes
   default_host: hermes
   # Hermes's own dashboard listens on 9119 inside the container. We expose
-  # the same port externally — keeps URLs intuitive when users follow the
-  # mDNS hostname (hermes.<device>.local:9119).
+  # the same port externally so direct LAN access (or curl-from-host
+  # debugging) hits a predictable URL. End users normally go through
+  # hermes-proxy on :9120 (auth-gated entry point); see HERMES-SSO.md.
   port: 9119
   external_port_env: HERMES_PORT
   external_port_default: 9119
@@ -27,20 +28,16 @@ service:
     Hermes Agent (Nous Research) — a self-improving generalist agent with
     persistent memory, autonomous skill creation, and 70+ built-in tools.
     Dream Server runs the upstream image pinned by SHA, points it at the
-    local LLM (llama-server), and disables the messaging gateways (Telegram /
-    Discord / Slack / etc.) since the web dashboard is the surface we ship.
-    Reachable on the LAN at hermes.<device>.local:9119 via mDNS.
+    local LLM (llama-server), and ships no messaging-platform adapters
+    (Telegram / Discord / Slack / etc.) since the web dashboard is the
+    surface we ship. The container runs `hermes gateway run` with the
+    dashboard embedded (HERMES_DASHBOARD=1) so the scheduler that fires
+    cron jobs actually runs.
 
   env_vars:
     - key: HERMES_PORT
       default: "9119"
       description: External port for Hermes's own dashboard (FastAPI + React UI)
-    - key: HERMES_MODEL_NAME
-      default: "qwen3.5-9b"
-      description: |
-        Model name passed to Hermes. Defaults to Dream Server's LLM_MODEL.
-        Hermes uses provider=custom so this is mostly a label — what matters
-        is HERMES_LLM_BASE_URL pointing at an OpenAI-compatible endpoint.
     - key: HERMES_LLM_BASE_URL
       default: "http://llama-server:8080/v1"
       description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.
@@ -49,6 +46,11 @@ service:
       description: |
         Dummy API key — llama-server doesn't validate it but the OpenAI SDK
         Hermes uses internally requires the field to be non-empty.
+    # Note: there is intentionally no HERMES_MODEL_NAME here. The model
+    # name lives in /opt/data/config.yaml after first start; an earlier
+    # draft exposed an env var, but the upstream image doesn't read it
+    # at runtime — only the YAML file. Edit the file (or delete it to
+    # re-copy from the template) to change the model.
 
 features:
   - id: hermes-agent

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -37,7 +37,12 @@ service:
   env_vars:
     - key: HERMES_PORT
       default: "9119"
-      description: External port for Hermes's own dashboard (FastAPI + React UI)
+      description: |
+        External port for Hermes's own dashboard. Used only when Hermes is
+        the LAN-facing entry — e.g., direct dev access or smoke tests with
+        the hermes-proxy extension disabled. With hermes-proxy enabled,
+        Hermes is internal-only (compose switches to `expose:`) and this
+        knob is informational; the user-facing port becomes HERMES_PROXY_PORT.
     - key: HERMES_LLM_BASE_URL
       default: "http://llama-server:8080/v1"
       description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -9,13 +9,19 @@ service:
   aliases: [agent, hermes-agent]
   container_name: dream-hermes
   default_host: hermes
-  # Hermes's own dashboard listens on 9119 inside the container. We expose
-  # the same port externally so direct LAN access (or curl-from-host
-  # debugging) hits a predictable URL. End users normally go through
-  # hermes-proxy on :9120 (auth-gated entry point); see HERMES-SSO.md.
+  # Hermes's own dashboard listens on 9119 inside the container.
+  # Internal-only — there is intentionally no host-port binding here.
+  # End users reach Hermes via hermes-proxy on :9120 (auth-gated entry
+  # point); see HERMES-SSO.md. The compose file declares this port
+  # under `expose:` so other containers on the bridge network (notably
+  # hermes-proxy) can talk to dream-hermes:9119.
   port: 9119
-  external_port_env: HERMES_PORT
-  external_port_default: 9119
+  # external_port_env / external_port_default are deliberately omitted —
+  # with hermes-proxy enabled Hermes is internal-only (compose declares
+  # the port under `expose:` not `ports:`). Surfacing a "browse to this
+  # port" URL in /api/external-links would mislead users into bypassing
+  # the magic-link gate.
+  #
   # /api/* is auth-gated by Hermes's dashboard (returns 401 without
   # credentials), so /api/health isn't usable as an external probe.
   # Verified against the SHA-pinned upstream image: /healthz at the
@@ -40,14 +46,10 @@ service:
     cron jobs actually runs.
 
   env_vars:
-    - key: HERMES_PORT
-      default: "9119"
-      description: |
-        External port for Hermes's own dashboard. Used only when Hermes is
-        the LAN-facing entry — e.g., direct dev access or smoke tests with
-        the hermes-proxy extension disabled. With hermes-proxy enabled,
-        Hermes is internal-only (compose switches to `expose:`) and this
-        knob is informational; the user-facing port becomes HERMES_PROXY_PORT.
+    # HERMES_PORT is intentionally NOT exposed here. With this PR's
+    # internal-only compose (`expose: 9119`), there's no host binding to
+    # control — the variable would be a no-op knob. The user-facing port
+    # is HERMES_PROXY_PORT (declared by the hermes-proxy manifest).
     - key: HERMES_LLM_BASE_URL
       default: "http://llama-server:8080/v1"
       description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -5,8 +5,17 @@ compatibility:
 
 service:
   id: hermes
-  name: Hermes Agent
-  aliases: [agent, hermes-agent]
+  # Internal-only after the hermes-proxy extension landed. The user-facing
+  # "Hermes Agent" sidebar tile is published by hermes-proxy (port 9120),
+  # which gates access on Dream Server's magic-link cookie and forwards
+  # here. Hermes itself is reachable only on the Docker bridge network.
+  name: Hermes Agent (internal)
+  # `agent` was previously claimed here, but #1171 hands the user-facing
+  # "Hermes Agent" tile (and its aliases) to hermes-proxy — keeping the
+  # bare `agent` alias on both sides triggers an extension-audit collision.
+  # The internal-only tile is for tooling/debug, so a narrower alias list
+  # is fine here.
+  aliases: [hermes-agent, hermes-internal]
   container_name: dream-hermes
   default_host: hermes
   # Hermes's own dashboard listens on 9119 inside the container.
@@ -16,11 +25,11 @@ service:
   # under `expose:` so other containers on the bridge network (notably
   # hermes-proxy) can talk to dream-hermes:9119.
   port: 9119
-  # external_port_env / external_port_default are deliberately omitted —
   # with hermes-proxy enabled Hermes is internal-only (compose declares
   # the port under `expose:` not `ports:`). Surfacing a "browse to this
   # port" URL in /api/external-links would mislead users into bypassing
-  # the magic-link gate.
+  # the magic-link gate. Operators who want raw direct access can re-add
+  # a `ports:` binding in compose.yaml.
   #
   # /api/* is auth-gated by Hermes's dashboard (returns 401 without
   # credentials), so /api/health isn't usable as an external probe.
@@ -43,7 +52,8 @@ service:
     (Telegram / Discord / Slack / etc.) since the web dashboard is the
     surface we ship. The container runs `hermes gateway run` with the
     dashboard embedded (HERMES_DASHBOARD=1) so the scheduler that fires
-    cron jobs actually runs.
+    cron jobs actually runs. Reached through the hermes-proxy extension
+    (port 9120), not directly.
 
   env_vars:
     # HERMES_PORT is intentionally NOT exposed here. With this PR's

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -16,7 +16,12 @@ service:
   port: 9119
   external_port_env: HERMES_PORT
   external_port_default: 9119
-  health: /api/health
+  # /api/* is auth-gated by Hermes's dashboard (returns 401 without
+  # credentials), so /api/health isn't usable as an external probe.
+  # Verified against the SHA-pinned upstream image: /healthz at the
+  # root returns 200 unauthenticated — matches the container's own
+  # healthcheck in compose.yaml. Keep these aligned.
+  health: /healthz
   ui_path: /
   health_timeout: 60  # Hermes does skill sync + config bootstrap on cold start
   type: docker

--- a/dream-server/scripts/audit-extensions.py
+++ b/dream-server/scripts/audit-extensions.py
@@ -325,6 +325,15 @@ def load_compose_definitions(record: ServiceRecord) -> tuple[dict[str, Any], dic
 
 
 def extract_target_ports(service_def: Any) -> list[int]:
+    """Return every container-internal port a service makes available.
+
+    Looks at BOTH `ports:` (host-bound) and `expose:` (internal-only)
+    declarations so internal-only services like dream-hermes (fronted by
+    hermes-proxy) still register their port. Without this, a service
+    that switches from `ports:` to `expose:` would fail
+    compose-port-mismatch even though its container is fully reachable
+    by other containers on the bridge network.
+    """
     if not isinstance(service_def, dict):
         return []
 
@@ -349,6 +358,20 @@ def extract_target_ports(service_def: Any) -> list[int]:
             target_int = parse_positive_int(target)
             if target_int:
                 results.append(target_int)
+
+    # `expose:` is a list of "<port>" or "<port>/<proto>" strings/ints —
+    # internal-network-only, never bound to the host.
+    for entry in as_list(service_def.get("expose")):
+        if isinstance(entry, int):
+            if entry > 0:
+                results.append(entry)
+            continue
+        if isinstance(entry, str):
+            head = entry.split("/", 1)[0]
+            try:
+                results.append(int(head))
+            except ValueError:
+                continue
     return results
 
 


### PR DESCRIPTION
## Summary

Tiny cleanup pass for the post-H-2 dashboard surface. After [PR #1168](https://github.com/Light-Heart-Labs/DreamServer/pull/1168) made Hermes internal-only, its manifest **still** declared \`external_port_env: HERMES_PORT\` — which the dashboard's \`/api/external-links\` reads to publish sidebar tiles. The user would have seen TWO \"Hermes\" tiles in the sidebar: one unreachable (raw hermes at 9119, no host port bound) and one real (hermes-proxy at 9120).

This PR fixes that to one tile labeled \"Hermes Agent\" pointing at the proxy.

## Changes

| File | Change |
|---|---|
| \`extensions/services/hermes/manifest.yaml\` | Dropped \`external_port_env\` + \`external_port_default\`. Hermes is internal-only on the Docker bridge after H-2; it must not advertise an external port. Renamed \`name: Hermes Agent\` → \`name: Hermes Agent (internal)\` so anyone on the Extensions page sees what's running where. |
| \`extensions/services/hermes-proxy/manifest.yaml\` | Renamed \`name: Hermes Auth Proxy\` → \`name: Hermes Agent\`. The proxy IS the user-facing Hermes — internal machinery shouldn't be in the sidebar tile label. Added aliases \`[hermes, agent, hermes-gate, hermes-auth-proxy]\` so \`dream enable hermes-auth-proxy\` etc. still resolve. |
| \`docs/HERMES.md\` | Roadmap \"Dream-side status panel\" item marked partially shipped (this naming / single-tile cleanup IS the practical chunk of it). |

## What's still deferred

The deeper \"session count / skill inventory inside the Dream dashboard\" piece of the original roadmap item is intentionally NOT in this PR. Two reasons:

1. **Hermes already has \`AnalyticsPage\`** built in — strictly richer than anything we'd surface.
2. **Cross-surface scraping requires bypassing Hermes's own auth** (the per-process X-Hermes-Session-Token), which we explicitly avoided in PR #1168.

The natural follow-up (if real demand exists) is to put a small \"Hermes\" widget on the dashboard home that shows just container-level health (\"running / healthy / x sessions today\") via Docker stats, without trying to introspect into Hermes's app state. Not built here.

## Test plan

- [x] \`python -c yaml.safe_load(<both manifests>)\` passes
- [ ] Manual smoke (post-merge):
  - [ ] Dashboard sidebar shows one \"Hermes Agent\" tile, links to port 9120
  - [ ] Extensions page shows both \"Hermes Agent (internal)\" and \"Hermes Agent\" with distinct \`id\` / \`container\` so admins can see the architecture
  - [ ] \`dream enable hermes-auth-proxy\` still resolves (via alias)

Stacked on \`feat/hermes-magic-link-sso\` (#1168) because that's the PR that flipped Hermes to internal-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)