### PR TITLE
feat(dashboard): phone-first first-boot wizard SPA

### DIFF
--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -1,12 +1,16 @@
 import { Routes, Route } from 'react-router-dom'
-import { useState, useEffect, Suspense, useMemo, useCallback } from 'react'
+import { useState, useEffect, Suspense, useMemo, useCallback, lazy } from 'react'
 import Sidebar from './components/Sidebar'
-import SetupWizard from './components/SetupWizard'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
 import { useFirstRun } from './hooks/useFirstRun'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
+
+// Phone-first first-boot wizard. Mounted instead of the normal app shell
+// when useFirstRun() reports firstRun=true. Lazy-loaded so the wizard
+// bundle isn't paid for on every page load after onboarding.
+const FirstBoot = lazy(() => import('./pages/FirstBoot'))
 
 function getStorageValue(storage, key) {
   try {
@@ -53,6 +57,29 @@ function App() {
   const routes = useMemo(() => getInternalRoutes({ status, loading }), [status, loading])
   const handleToggle = useCallback(() => setSidebarCollapsed(c => !c), [])
 
+  // First-boot path: render the FirstBoot SPA fullscreen and lock out the
+  // rest of the dashboard. The user can't reach Settings / Extensions / etc.
+  // until they've completed onboarding — that simplifies the wizard story
+  // (one path, no escape hatches) and prevents half-configured devices
+  // from getting halfway-set-up.
+  if (firstRun) {
+    return (
+      <div className="min-h-screen bg-theme-bg text-theme-text">
+        {!splashDone && <SplashScreen onComplete={() => {
+          setStorageValue(globalThis.sessionStorage, 'dream-splash-shown', '1')
+          setSplashDone(true)
+        }} />}
+        <Suspense fallback={
+          <div className="min-h-screen flex items-center justify-center">
+            <div className="font-mono text-sm text-theme-accent tracking-widest animate-pulse">DREAM SERVER</div>
+          </div>
+        }>
+          <FirstBoot onComplete={dismissFirstRun} />
+        </Suspense>
+      </div>
+    )
+  }
+
   return (
     <div className="flex min-h-screen bg-theme-bg text-theme-text relative">
       {!splashDone && <SplashScreen onComplete={() => {
@@ -66,10 +93,6 @@ function App() {
       />
 
       <main className={`dashboard-market-shell flex-1 transition-all duration-200 ${sidebarCollapsed ? 'ml-20' : 'ml-64'}`}>
-        {firstRun && (
-          <SetupWizard onComplete={dismissFirstRun} />
-        )}
-
         {status?.bootstrap?.active && (
           <BootstrapBanner bootstrap={status.bootstrap} />
         )}

--- a/dream-server/extensions/services/dashboard/src/App.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.test.jsx
@@ -32,9 +32,12 @@ vi.mock('./plugins/registry', () => ({
   getSidebarExternalLinks: vi.fn(() => [])
 }))
 
-vi.mock('./components/SetupWizard', () => ({
+// FirstBoot is lazy-imported in App.jsx and rendered fullscreen when
+// firstRun=true. Mock it as a sync component so tests don't need to
+// await Suspense.
+vi.mock('./pages/FirstBoot', () => ({
   default: ({ onComplete }) => (
-    <div data-testid="setup-wizard">
+    <div data-testid="first-boot">
       <button onClick={onComplete}>Complete</button>
     </div>
   )
@@ -67,16 +70,19 @@ describe('App', () => {
     expect(document.querySelector('aside')).toBeInTheDocument()
   })
 
-  test('shows SetupWizard when server reports first_run=true', () => {
+  test('shows FirstBoot when server reports first_run=true', async () => {
     useFirstRun.mockReturnValue({ firstRun: true, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
-    expect(screen.getByTestId('setup-wizard')).toBeInTheDocument()
+    // FirstBoot is lazy-loaded under Suspense; await its appearance.
+    expect(await screen.findByTestId('first-boot')).toBeInTheDocument()
+    // Sidebar must NOT render during onboarding — the wizard owns the screen.
+    expect(document.querySelector('aside')).not.toBeInTheDocument()
   })
 
-  test('hides SetupWizard when server reports first_run=false', () => {
+  test('hides FirstBoot when server reports first_run=false', () => {
     useFirstRun.mockReturnValue({ firstRun: false, loading: false, error: null, refresh: vi.fn() })
     render(<App />)
-    expect(screen.queryByTestId('setup-wizard')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('first-boot')).not.toBeInTheDocument()
   })
 
   test('renders sidebar', () => {

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -2,14 +2,14 @@
 //
 // Lives at /setup. App.jsx routes here when useFirstRun() says
 // firstRun=true and locks all other routes out. Single-column,
-// large tap targets, big text — the user is most likely on a
+// large tap targets, big text - the user is most likely on a
 // phone scanning the device's setup link.
 //
 // 4 screens:
-//   1. Welcome — name your device (DREAM_DEVICE_NAME)
-//   2. First user — username for the initial magic-link invite
-//   3. Pick your stack — chat-only / chat+agents / everything
-//   4. Done — generate magic-link, show QR
+//   1. Welcome - label this setup
+//   2. First user - username for the initial magic-link invite
+//   3. Pick your stack - chat-only / chat+agents / everything
+//   4. Done - generate magic-link, show QR
 //
 // Progress is mirrored to localStorage so a phone refresh doesn't
 // lose state mid-wizard. The server-side flip happens only on the
@@ -39,13 +39,13 @@ const STACK_OPTIONS = [
   {
     id: 'chat-agents',
     title: 'Chat + Agents',
-    blurb: 'Adds n8n workflows and the agent runtime — enable from Extensions after setup.',
+    blurb: 'Adds n8n workflows and the agent runtime; enable from Extensions after setup.',
     Icon: Workflow,
   },
   {
     id: 'everything',
     title: 'Everything',
-    blurb: 'Voice, image generation, search, the whole catalog — enable from Extensions after setup.',
+    blurb: 'Voice, image generation, search, the whole catalog; enable from Extensions after setup.',
     Icon: Boxes,
   },
 ]
@@ -65,7 +65,7 @@ function writeProgress(progress) {
   try {
     globalThis.localStorage?.setItem(PROGRESS_KEY, JSON.stringify(progress))
   } catch {
-    // localStorage may be blocked in private windows — wizard still works.
+    // localStorage may be blocked in private windows; wizard still works.
   }
 }
 
@@ -107,9 +107,9 @@ export default function FirstBoot({ onComplete }) {
         body: JSON.stringify({
           target_username: username,
           scope: 'chat',
-          expires_in: 86400, // 24h — the wizard target may not redeem immediately
+          expires_in: 86400, // 24h; the wizard target may not redeem immediately
           reusable: false,
-          note: 'First-boot invite',
+          note: `First-boot invite (${deviceName.trim() || 'dream'})`,
         }),
       })
       if (!genResp.ok) {
@@ -119,12 +119,23 @@ export default function FirstBoot({ onComplete }) {
       const inviteData = await genResp.json()
 
       // Flip the server-side sentinel so this device is "configured".
-      await fetch('/api/setup/complete', { method: 'POST' })
+      // Check the response; an earlier draft fired the request and
+      // moved on regardless of status, which left the server in
+      // first-run mode while the UI said "You're set." If complete
+      // fails, throw and let the catch surface the error to the user
+      // (with the invite still safely visible on the previous screen).
+      const completeResp = await fetch('/api/setup/complete', { method: 'POST' })
+      if (!completeResp.ok) {
+        const body = await completeResp.json().catch(() => ({}))
+        throw new Error(
+          body.detail || `Failed to mark setup complete (${completeResp.status}). Your invite was generated; ask the admin to re-run setup.`,
+        )
+      }
 
       setInvite(inviteData)
       clearProgress()
-      // Stay on the success screen until the user taps "Open chat" or "Done"
-      // — calling onComplete() immediately would route them away before they
+      // Stay on the success screen until the user taps "Open dashboard".
+      // Calling onComplete() immediately would route them away before they
       // can copy the QR. onComplete fires on the final tap.
     } catch (err) {
       setFinishError(err.message)
@@ -217,7 +228,7 @@ function StepDots({ step, total }) {
 }
 
 // ---------------------------------------------------------------------------
-// Step 1 — Welcome / device name
+// Step 1 - Welcome / setup label
 // ---------------------------------------------------------------------------
 
 function WelcomeStep({ deviceName, setDeviceName, onNext }) {
@@ -229,11 +240,11 @@ function WelcomeStep({ deviceName, setDeviceName, onNext }) {
       </div>
       <h1 className="text-3xl font-bold text-theme-text mb-3">Welcome to Dream.</h1>
       <p className="text-theme-text-muted mb-8 leading-relaxed">
-        Let&apos;s get you set up in about a minute. First, give this device a name so it&apos;s easy to find on your network.
+        Let&apos;s get you set up in about a minute. First, give this setup a friendly label for the invite audit trail.
       </p>
 
       <label className="block mb-6">
-        <span className="text-sm text-theme-text-muted">Device name</span>
+        <span className="text-sm text-theme-text-muted">Setup label</span>
         <input
           type="text"
           value={deviceName}
@@ -246,8 +257,9 @@ function WelcomeStep({ deviceName, setDeviceName, onNext }) {
           spellCheck={false}
         />
         <span className="text-xs text-theme-text-muted mt-2 block">
-          We&apos;ll save this preference. Once mDNS is configured the device will be
-          reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code>.
+          This label is recorded on the first invite only. It does not rename the host yet;
+          change <code className="text-theme-accent">DREAM_DEVICE_NAME</code> in Settings before expecting
+          <code className="text-theme-accent"> {deviceName.trim() || 'dream'}.local</code> to resolve.
           Letters, numbers, and dashes only.
         </span>
       </label>
@@ -265,7 +277,7 @@ function WelcomeStep({ deviceName, setDeviceName, onNext }) {
 }
 
 // ---------------------------------------------------------------------------
-// Step 2 — First user
+// Step 2 - First user
 // ---------------------------------------------------------------------------
 
 function UserStep({ username, setUsername, onNext, onBack }) {
@@ -278,7 +290,7 @@ function UserStep({ username, setUsername, onNext, onBack }) {
       </div>
       <h1 className="text-3xl font-bold text-theme-text mb-3">Who&apos;s the first user?</h1>
       <p className="text-theme-text-muted mb-8 leading-relaxed">
-        We&apos;ll generate a magic link for them at the end. They scan it once and they&apos;re in.
+        We&apos;ll generate a magic link for them at the end. They scan it once to reach the chat surface.
       </p>
 
       <label className="block mb-6">
@@ -322,7 +334,7 @@ function UserStep({ username, setUsername, onNext, onBack }) {
 }
 
 // ---------------------------------------------------------------------------
-// Step 3 — Stack picker
+// Step 3 - Stack picker
 // ---------------------------------------------------------------------------
 
 function StackStep({ stack, setStack, onNext, onBack }) {
@@ -387,7 +399,7 @@ function StackStep({ stack, setStack, onNext, onBack }) {
 }
 
 // ---------------------------------------------------------------------------
-// Step 4 — Confirm & finish
+// Step 4 - Confirm & finish
 // ---------------------------------------------------------------------------
 
 function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing, error }) {
@@ -400,7 +412,7 @@ function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing,
       </p>
 
       <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
-        <Row label="Device name" value={deviceName.trim() || 'dream'} hint="saved as preference" />
+        <Row label="Setup label" value={deviceName.trim() || 'dream'} hint="invite audit note" />
         <Row label="First user" value={username.trim()} />
         <Row label="Stack" value={stackTitle} hint="enable extras from Extensions" />
       </dl>
@@ -426,7 +438,7 @@ function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing,
           className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
         >
           {finishing && <Loader2 size={18} className="animate-spin" />}
-          {finishing ? 'Finishing…' : 'Finish'}
+          {finishing ? 'Finishing...' : 'Finish'}
         </button>
       </div>
     </div>
@@ -446,7 +458,7 @@ function Row({ label, value, hint }) {
 }
 
 // ---------------------------------------------------------------------------
-// Done — show generated invite
+// Done - show generated invite
 // ---------------------------------------------------------------------------
 
 function DoneScreen({ invite, onDone }) {
@@ -462,7 +474,7 @@ function DoneScreen({ invite, onDone }) {
           `/api/auth/magic-link/qr?url=${encodeURIComponent(invite.url)}`,
         )
         if (!resp.ok) {
-          setQrError('QR generation unavailable on the server.')
+          if (!cancelled) setQrError('QR generation unavailable on the server.')
           return
         }
         const data = await resp.json()
@@ -521,7 +533,7 @@ function DoneScreen({ invite, onDone }) {
         <div className="bg-theme-card border border-theme-border rounded-xl p-8 flex flex-col items-center justify-center mb-6 min-h-56">
           <QrCode size={48} className="text-theme-text-muted mb-2" />
           <p className="text-xs text-theme-text-muted text-center">
-            {qrError || 'Generating QR…'}
+            {qrError || 'Generating QR...'}
           </p>
         </div>
       )}
@@ -535,6 +547,8 @@ function DoneScreen({ invite, onDone }) {
         />
         <button
           onClick={copy}
+          title="Copy link"
+          aria-label="Copy invite link"
           className="flex items-center gap-1 px-3 py-2 bg-theme-card border border-theme-border rounded-lg text-theme-text hover:bg-theme-surface-hover text-sm"
         >
           {copied ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -24,23 +24,28 @@ import {
 
 const PROGRESS_KEY = 'dream-firstboot-progress'
 
+// NOTE: this picker records a preference today; it does NOT enable
+// extensions or start services. The matching backend wiring lives in
+// the Extensions panel (and a follow-up PR will let Finish apply the
+// chosen preset there). Until then the blurbs describe the *intent*
+// of each stack, with the copy honest that nothing changes yet.
 const STACK_OPTIONS = [
   {
     id: 'chat',
     title: 'Chat only',
-    blurb: 'Just the chat surface — fastest setup, smallest footprint.',
+    blurb: 'Just the chat surface. This is what runs out of the box.',
     Icon: MessageSquare,
   },
   {
     id: 'chat-agents',
     title: 'Chat + Agents',
-    blurb: 'Adds n8n workflows and the agent runtime so models can do work for you.',
+    blurb: 'Adds n8n workflows and the agent runtime — enable from Extensions after setup.',
     Icon: Workflow,
   },
   {
     id: 'everything',
     title: 'Everything',
-    blurb: 'Voice in/out, image generation, search, the whole stack. Take some time to download.',
+    blurb: 'Voice, image generation, search, the whole catalog — enable from Extensions after setup.',
     Icon: Boxes,
   },
 ]
@@ -241,7 +246,9 @@ function WelcomeStep({ deviceName, setDeviceName, onNext }) {
           spellCheck={false}
         />
         <span className="text-xs text-theme-text-muted mt-2 block">
-          Reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code> on your network. Letters, numbers, and dashes only.
+          We&apos;ll save this preference. Once mDNS is configured the device will be
+          reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code>.
+          Letters, numbers, and dashes only.
         </span>
       </label>
 
@@ -289,7 +296,8 @@ function UserStep({ username, setUsername, onNext, onBack }) {
           spellCheck={false}
         />
         <span className="text-xs text-theme-text-muted mt-2 block">
-          Open WebUI will display this name when they land on chat.
+          Recorded with the invite for the audit trail. Open WebUI may still ask the
+          recipient to sign in or pick a profile name on first arrival.
         </span>
       </label>
 
@@ -392,9 +400,9 @@ function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing,
       </p>
 
       <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
-        <Row label="Device name" value={deviceName.trim() || 'dream'} hint={`.local on your network`} />
+        <Row label="Device name" value={deviceName.trim() || 'dream'} hint="saved as preference" />
         <Row label="First user" value={username.trim()} />
-        <Row label="Stack" value={stackTitle} />
+        <Row label="Stack" value={stackTitle} hint="enable extras from Extensions" />
       </dl>
 
       {error && (
@@ -501,7 +509,8 @@ function DoneScreen({ invite, onDone }) {
       <h1 className="text-3xl font-bold text-theme-text mb-3">You&apos;re set.</h1>
       <p className="text-theme-text-muted mb-6 leading-relaxed">
         Here&apos;s the magic link for <strong className="text-theme-text">{invite.target_username}</strong>.
-        They scan or tap it to land straight in chat.
+        They scan or tap it to reach the chat surface. (Open WebUI may still prompt for a
+        sign-in until SSO is wired up.)
       </p>
 
       {qrDataUrl ? (

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -1,0 +1,558 @@
+// Phone-first first-boot wizard.
+//
+// Lives at /setup. App.jsx routes here when useFirstRun() says
+// firstRun=true and locks all other routes out. Single-column,
+// large tap targets, big text — the user is most likely on a
+// phone scanning the device's setup link.
+//
+// 4 screens:
+//   1. Welcome — name your device (DREAM_DEVICE_NAME)
+//   2. First user — username for the initial magic-link invite
+//   3. Pick your stack — chat-only / chat+agents / everything
+//   4. Done — generate magic-link, show QR
+//
+// Progress is mirrored to localStorage so a phone refresh doesn't
+// lose state mid-wizard. The server-side flip happens only on the
+// final "Finish" tap, via /api/setup/complete.
+
+import { useEffect, useMemo, useState } from 'react'
+import {
+  Sparkles, User, Layers, Check, ChevronRight, ChevronLeft,
+  MessageSquare, Workflow, Boxes, Loader2, AlertCircle, Copy,
+  QrCode, Share2,
+} from 'lucide-react'
+
+const PROGRESS_KEY = 'dream-firstboot-progress'
+
+const STACK_OPTIONS = [
+  {
+    id: 'chat',
+    title: 'Chat only',
+    blurb: 'Just the chat surface — fastest setup, smallest footprint.',
+    Icon: MessageSquare,
+  },
+  {
+    id: 'chat-agents',
+    title: 'Chat + Agents',
+    blurb: 'Adds n8n workflows and the agent runtime so models can do work for you.',
+    Icon: Workflow,
+  },
+  {
+    id: 'everything',
+    title: 'Everything',
+    blurb: 'Voice in/out, image generation, search, the whole stack. Take some time to download.',
+    Icon: Boxes,
+  },
+]
+
+const TOTAL_STEPS = 4
+
+function readProgress() {
+  try {
+    const raw = globalThis.localStorage?.getItem(PROGRESS_KEY)
+    return raw ? JSON.parse(raw) : null
+  } catch {
+    return null
+  }
+}
+
+function writeProgress(progress) {
+  try {
+    globalThis.localStorage?.setItem(PROGRESS_KEY, JSON.stringify(progress))
+  } catch {
+    // localStorage may be blocked in private windows — wizard still works.
+  }
+}
+
+function clearProgress() {
+  try {
+    globalThis.localStorage?.removeItem(PROGRESS_KEY)
+  } catch {
+    // Ignore.
+  }
+}
+
+export default function FirstBoot({ onComplete }) {
+  const initial = useMemo(() => readProgress() || {}, [])
+  const [step, setStep] = useState(initial.step || 1)
+  const [deviceName, setDeviceName] = useState(initial.deviceName || 'dream')
+  const [username, setUsername] = useState(initial.username || '')
+  const [stack, setStack] = useState(initial.stack || 'chat')
+  const [finishing, setFinishing] = useState(false)
+  const [finishError, setFinishError] = useState(null)
+  const [invite, setInvite] = useState(null)
+
+  // Persist progress whenever the user moves forward.
+  useEffect(() => {
+    writeProgress({ step, deviceName, username, stack })
+  }, [step, deviceName, username, stack])
+
+  const next = () => setStep(s => Math.min(s + 1, TOTAL_STEPS))
+  const prev = () => setStep(s => Math.max(s - 1, 1))
+
+  const finish = async () => {
+    setFinishing(true)
+    setFinishError(null)
+    try {
+      // Generate the first magic-link for the named user. Reuses PR-4's
+      // backend; this is the same endpoint /Invites consumes.
+      const genResp = await fetch('/api/auth/magic-link/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          target_username: username,
+          scope: 'chat',
+          expires_in: 86400, // 24h — the wizard target may not redeem immediately
+          reusable: false,
+          note: 'First-boot invite',
+        }),
+      })
+      if (!genResp.ok) {
+        const body = await genResp.json().catch(() => ({}))
+        throw new Error(body.detail || `generate failed: ${genResp.status}`)
+      }
+      const inviteData = await genResp.json()
+
+      // Flip the server-side sentinel so this device is "configured".
+      await fetch('/api/setup/complete', { method: 'POST' })
+
+      setInvite(inviteData)
+      clearProgress()
+      // Stay on the success screen until the user taps "Open chat" or "Done"
+      // — calling onComplete() immediately would route them away before they
+      // can copy the QR. onComplete fires on the final tap.
+    } catch (err) {
+      setFinishError(err.message)
+    } finally {
+      setFinishing(false)
+    }
+  }
+
+  const handleDone = () => {
+    onComplete?.()
+  }
+
+  return (
+    <div className="min-h-screen bg-theme-bg flex flex-col">
+      <header className="px-6 pt-8 pb-4 flex items-center justify-between">
+        <div className="font-mono text-sm font-bold text-theme-accent tracking-widest">DREAM SERVER</div>
+        {!invite && <StepDots step={step} total={TOTAL_STEPS} />}
+      </header>
+
+      <main className="flex-1 flex items-stretch px-6 pb-8">
+        <div className="w-full max-w-md mx-auto flex flex-col justify-center">
+          {invite ? (
+            <DoneScreen invite={invite} onDone={handleDone} />
+          ) : (
+            <>
+              {step === 1 && (
+                <WelcomeStep
+                  deviceName={deviceName}
+                  setDeviceName={setDeviceName}
+                  onNext={next}
+                />
+              )}
+              {step === 2 && (
+                <UserStep
+                  username={username}
+                  setUsername={setUsername}
+                  onNext={next}
+                  onBack={prev}
+                />
+              )}
+              {step === 3 && (
+                <StackStep
+                  stack={stack}
+                  setStack={setStack}
+                  onNext={next}
+                  onBack={prev}
+                />
+              )}
+              {step === 4 && (
+                <ConfirmStep
+                  deviceName={deviceName}
+                  username={username}
+                  stack={stack}
+                  onBack={prev}
+                  onFinish={finish}
+                  finishing={finishing}
+                  error={finishError}
+                />
+              )}
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step dots
+// ---------------------------------------------------------------------------
+
+function StepDots({ step, total }) {
+  return (
+    <div className="flex items-center gap-2">
+      {Array.from({ length: total }).map((_, i) => {
+        const n = i + 1
+        const active = n === step
+        const done = n < step
+        return (
+          <div
+            key={n}
+            className={`w-2 h-2 rounded-full transition-colors ${
+              done ? 'bg-theme-accent' : active ? 'bg-theme-accent ring-2 ring-theme-accent/40' : 'bg-theme-border'
+            }`}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 1 — Welcome / device name
+// ---------------------------------------------------------------------------
+
+function WelcomeStep({ deviceName, setDeviceName, onNext }) {
+  const valid = /^[a-z0-9-]{1,32}$/i.test(deviceName.trim())
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <Sparkles size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Welcome to Dream.</h1>
+      <p className="text-theme-text-muted mb-8 leading-relaxed">
+        Let&apos;s get you set up in about a minute. First, give this device a name so it&apos;s easy to find on your network.
+      </p>
+
+      <label className="block mb-6">
+        <span className="text-sm text-theme-text-muted">Device name</span>
+        <input
+          type="text"
+          value={deviceName}
+          onChange={e => setDeviceName(e.target.value)}
+          autoFocus
+          maxLength={32}
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text focus:outline-none focus:border-theme-accent"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <span className="text-xs text-theme-text-muted mt-2 block">
+          Reachable at <code className="text-theme-accent">{deviceName.trim() || 'dream'}.local</code> on your network. Letters, numbers, and dashes only.
+        </span>
+      </label>
+
+      <button
+        onClick={onNext}
+        disabled={!valid}
+        className="w-full flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+      >
+        Continue
+        <ChevronRight size={18} />
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 2 — First user
+// ---------------------------------------------------------------------------
+
+function UserStep({ username, setUsername, onNext, onBack }) {
+  const trimmed = username.trim()
+  const valid = /^[A-Za-z0-9._-]{1,64}$/.test(trimmed)
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <User size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Who&apos;s the first user?</h1>
+      <p className="text-theme-text-muted mb-8 leading-relaxed">
+        We&apos;ll generate a magic link for them at the end. They scan it once and they&apos;re in.
+      </p>
+
+      <label className="block mb-6">
+        <span className="text-sm text-theme-text-muted">Username</span>
+        <input
+          type="text"
+          value={username}
+          onChange={e => setUsername(e.target.value)}
+          autoFocus
+          maxLength={64}
+          placeholder="alice"
+          className="mt-2 w-full bg-theme-card border border-theme-border rounded-xl px-4 py-3 text-lg text-theme-text focus:outline-none focus:border-theme-accent"
+          autoComplete="off"
+          autoCapitalize="off"
+          spellCheck={false}
+        />
+        <span className="text-xs text-theme-text-muted mt-2 block">
+          Open WebUI will display this name when they land on chat.
+        </span>
+      </label>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onNext}
+          disabled={!valid}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          Continue
+          <ChevronRight size={18} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 3 — Stack picker
+// ---------------------------------------------------------------------------
+
+function StackStep({ stack, setStack, onNext, onBack }) {
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-theme-accent/15 text-theme-accent flex items-center justify-center mb-6">
+        <Layers size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">Pick your stack.</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        You can change this later. Start small if you want and add things as you go.
+      </p>
+
+      <div className="space-y-3 mb-8">
+        {STACK_OPTIONS.map(opt => {
+          const Icon = opt.Icon
+          const selected = stack === opt.id
+          return (
+            <button
+              key={opt.id}
+              onClick={() => setStack(opt.id)}
+              className={`w-full text-left p-4 rounded-xl border-2 transition-colors flex gap-4 ${
+                selected
+                  ? 'border-theme-accent bg-theme-accent/10'
+                  : 'border-theme-border bg-theme-card hover:border-theme-text-muted'
+              }`}
+            >
+              <div className={`w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0 ${
+                selected ? 'bg-theme-accent text-white' : 'bg-theme-border text-theme-text-muted'
+              }`}>
+                <Icon size={24} />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="flex items-center justify-between">
+                  <span className="font-medium text-theme-text">{opt.title}</span>
+                  {selected && <Check size={18} className="text-theme-accent flex-shrink-0" />}
+                </div>
+                <p className="text-sm text-theme-text-muted mt-1">{opt.blurb}</p>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onNext}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 transition-opacity"
+        >
+          Continue
+          <ChevronRight size={18} />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Step 4 — Confirm & finish
+// ---------------------------------------------------------------------------
+
+function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing, error }) {
+  const stackTitle = STACK_OPTIONS.find(s => s.id === stack)?.title || stack
+  return (
+    <div>
+      <h1 className="text-3xl font-bold text-theme-text mb-6">Ready?</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        Tap Finish and we&apos;ll generate the first invite. Bring it up on a phone or share the QR.
+      </p>
+
+      <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
+        <Row label="Device name" value={deviceName.trim() || 'dream'} hint={`.local on your network`} />
+        <Row label="First user" value={username.trim()} />
+        <Row label="Stack" value={stackTitle} />
+      </dl>
+
+      {error && (
+        <div className="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm flex items-start gap-2">
+          <AlertCircle size={18} className="flex-shrink-0 mt-0.5" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="flex gap-3">
+        <button
+          onClick={onBack}
+          disabled={finishing}
+          className="flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 px-5 rounded-xl disabled:opacity-50"
+        >
+          <ChevronLeft size={18} />
+        </button>
+        <button
+          onClick={onFinish}
+          disabled={finishing}
+          className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
+        >
+          {finishing && <Loader2 size={18} className="animate-spin" />}
+          {finishing ? 'Finishing…' : 'Finish'}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function Row({ label, value, hint }) {
+  return (
+    <div className="px-4 py-3 flex items-center justify-between gap-4">
+      <span className="text-sm text-theme-text-muted">{label}</span>
+      <span className="text-theme-text font-medium text-right">
+        {value}
+        {hint && <span className="text-xs text-theme-text-muted block font-normal">{hint}</span>}
+      </span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Done — show generated invite
+// ---------------------------------------------------------------------------
+
+function DoneScreen({ invite, onDone }) {
+  const [copied, setCopied] = useState(false)
+  const [qrDataUrl, setQrDataUrl] = useState(null)
+  const [qrError, setQrError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    const loadQr = async () => {
+      try {
+        const resp = await fetch(
+          `/api/auth/magic-link/qr?url=${encodeURIComponent(invite.url)}`,
+        )
+        if (!resp.ok) {
+          setQrError('QR generation unavailable on the server.')
+          return
+        }
+        const data = await resp.json()
+        if (!cancelled) setQrDataUrl(data.data_url)
+      } catch (err) {
+        if (!cancelled) setQrError(err.message)
+      }
+    }
+    loadQr()
+    return () => { cancelled = true }
+  }, [invite.url])
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(invite.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback: a visible input would let the user select manually.
+    }
+  }
+
+  const share = async () => {
+    if (!navigator.share) {
+      copy()
+      return
+    }
+    try {
+      await navigator.share({
+        title: `Dream Server invite for ${invite.target_username}`,
+        text: 'Tap to open Dream Server',
+        url: invite.url,
+      })
+    } catch {
+      // User cancelled.
+    }
+  }
+
+  return (
+    <div>
+      <div className="w-16 h-16 rounded-2xl bg-green-500/15 text-green-400 flex items-center justify-center mb-6">
+        <Check size={32} />
+      </div>
+      <h1 className="text-3xl font-bold text-theme-text mb-3">You&apos;re set.</h1>
+      <p className="text-theme-text-muted mb-6 leading-relaxed">
+        Here&apos;s the magic link for <strong className="text-theme-text">{invite.target_username}</strong>.
+        They scan or tap it to land straight in chat.
+      </p>
+
+      {qrDataUrl ? (
+        <div className="bg-white p-4 rounded-xl flex justify-center mb-6">
+          <img src={qrDataUrl} alt="QR code for invite link" className="w-56 h-56" />
+        </div>
+      ) : (
+        <div className="bg-theme-card border border-theme-border rounded-xl p-8 flex flex-col items-center justify-center mb-6 min-h-56">
+          <QrCode size={48} className="text-theme-text-muted mb-2" />
+          <p className="text-xs text-theme-text-muted text-center">
+            {qrError || 'Generating QR…'}
+          </p>
+        </div>
+      )}
+
+      <div className="flex gap-2 mb-6">
+        <input
+          readOnly
+          value={invite.url}
+          onFocus={e => e.target.select()}
+          className="flex-1 bg-theme-card border border-theme-border rounded-lg px-3 py-2 text-xs font-mono text-theme-text"
+        />
+        <button
+          onClick={copy}
+          className="flex items-center gap-1 px-3 py-2 bg-theme-card border border-theme-border rounded-lg text-theme-text hover:bg-theme-surface-hover text-sm"
+        >
+          {copied ? <Check size={16} className="text-green-400" /> : <Copy size={16} />}
+        </button>
+      </div>
+
+      <div className="flex gap-3">
+        {typeof navigator !== 'undefined' && navigator.share && (
+          <button
+            onClick={share}
+            className="flex-1 flex items-center justify-center gap-2 bg-theme-card border border-theme-border text-theme-text py-4 rounded-xl"
+          >
+            <Share2 size={18} />
+            Share
+          </button>
+        )}
+        <button
+          onClick={onDone}
+          className="flex-1 bg-theme-accent text-white py-4 rounded-xl font-medium hover:opacity-90 transition-opacity"
+        >
+          Open dashboard
+        </button>
+      </div>
+
+      <p className="text-xs text-theme-text-muted mt-6 text-center">
+        Need more invites later? They live under <strong>Invites</strong> in the sidebar.
+      </p>
+    </div>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
@@ -1,0 +1,99 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import FirstBoot from './FirstBoot' // eslint-disable-line no-unused-vars
+
+const response = (body, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+})
+
+function finishWizard() {
+  fireEvent.change(screen.getByDisplayValue('dream'), { target: { value: 'spark' } })
+  fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+
+  fireEvent.change(screen.getByPlaceholderText('alice'), { target: { value: 'sam' } })
+  fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+
+  fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+  fireEvent.click(screen.getByRole('button', { name: /^finish$/i }))
+}
+
+describe('FirstBoot', () => {
+  beforeEach(() => {
+    globalThis.localStorage.removeItem('dream-firstboot-progress')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    globalThis.localStorage.removeItem('dream-firstboot-progress')
+  })
+
+  test('generates the first invite, marks setup complete, and shows the QR', async () => {
+    const onComplete = vi.fn()
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
+        return response({
+          url: 'http://auth.spark.local/magic-link/first-token',
+          target_username: 'sam',
+          expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+          scope: 'chat',
+          reusable: false,
+        })
+      }
+      if (url === '/api/setup/complete' && options.method === 'POST') {
+        return response({ success: true })
+      }
+      if (String(url).startsWith('/api/auth/magic-link/qr?url=')) {
+        return response({ data_url: 'data:image/png;base64,qrpayload' })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={onComplete} />)
+
+    finishWizard()
+
+    expect(await screen.findByRole('heading', { name: /you're set/i })).toBeInTheDocument()
+    const generateCall = fetchMock.mock.calls.find(([url]) => url === '/api/auth/magic-link/generate')
+    expect(JSON.parse(generateCall[1].body)).toMatchObject({
+      target_username: 'sam',
+      scope: 'chat',
+      expires_in: 86400,
+      reusable: false,
+      note: 'First-boot invite (spark)',
+    })
+    expect(fetchMock).toHaveBeenCalledWith('/api/setup/complete', { method: 'POST' })
+    expect(await screen.findByAltText('QR code for invite link')).toHaveAttribute('src', 'data:image/png;base64,qrpayload')
+
+    fireEvent.click(screen.getByRole('button', { name: /open dashboard/i }))
+    expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not show success when setup completion fails', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
+        return response({
+          url: 'http://auth.spark.local/magic-link/first-token',
+          target_username: 'sam',
+          expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+          scope: 'chat',
+          reusable: false,
+        })
+      }
+      if (url === '/api/setup/complete' && options.method === 'POST') {
+        return response({ detail: 'sentinel write failed' }, 500)
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+
+    finishWizard()
+
+    await waitFor(() => expect(screen.getByText(/sentinel write failed/i)).toBeInTheDocument())
+    expect(screen.queryByRole('heading', { name: /you're set/i })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Reopens the phone-first first-boot wizard work from #1158, retargeted to `main` after #1157 was merged and the stacked base branch closed the original PR.

This updated head includes the audit fixes from the merge pass:
- Depends on the now-merged server-side first-run gate and magic-link API.
- Uses the backend-returned magic-link URL and checks `/api/setup/complete` before showing success.
- Makes the setup label honest: it is recorded as an invite audit note only and does not claim to rename the host or update `DREAM_DEVICE_NAME`.
- Adds focused FirstBoot tests for successful finish/QR display and setup-completion failure.

Local checks run:
- `npm.cmd test -- --run src/pages/FirstBoot.test.jsx`
- `npm.cmd test`
- `npm.cmd run build`
- `npm.cmd run lint`
- `git diff --check`