### PR TITLE
feat(hermes): magic-link SSO gating via Caddy auth-proxy sidecar

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -336,15 +336,11 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # persistent memory, autonomous skill creation, and 70+ tools. Dream
 # Server runs the upstream image pinned by SHA and points it at the
 # local LLM. Browser UI ships in the upstream image (port 9119).
-# Enable: `dream enable hermes`. With hermes-proxy enabled, end users
-# reach Hermes at http://hermes.<device>.local (port 80, auth-gated by
-# the proxy); without it, Hermes binds HERMES_PORT directly.
+# Enable: `dream enable hermes`. With hermes-proxy enabled (the default
+# pairing), end users reach Hermes at http://hermes.<device>.local
+# (port 80, auth-gated by the proxy). Hermes itself is internal-only —
+# there's no HERMES_PORT knob in this stack.
 #
-# HERMES_PORT=9119                       # Direct external port (used
-#                                          when hermes-proxy is OFF; with
-#                                          hermes-proxy ON, Hermes is
-#                                          internal-only and this is
-#                                          informational).
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
 # HERMES_LANGUAGE=en                     # UI language

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -352,7 +352,9 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 #  not in env. Edit the file after first start to switch models.)
 #
 # Hermes is reached on the LAN via dream-hermes-proxy (Caddy sidecar) which
-# gates access on the dream-session cookie set by magic-link redemption.
+# verifies the dream-session cookie against dashboard-api's verify endpoint
+# (forward_auth → HMAC signature check via DREAM_SESSION_SECRET).
 # Direct Hermes port is NOT bound to the host — only the proxy is LAN-facing.
 # HERMES_PROXY_PORT=9120                 # LAN entry — what users actually browse to
 # HERMES_PROXY_UPSTREAM=dream-hermes:9119  # Where the proxy forwards (internal DNS)
+# DREAM_AUTH_UPSTREAM=dream-dashboard-api:3002  # Where forward_auth verifies sessions

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -350,3 +350,9 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # HERMES_LANGUAGE=en                     # UI language
 # (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
 #  not in env. Edit the file after first start to switch models.)
+#
+# Hermes is reached on the LAN via dream-hermes-proxy (Caddy sidecar) which
+# gates access on the dream-session cookie set by magic-link redemption.
+# Direct Hermes port is NOT bound to the host — only the proxy is LAN-facing.
+# HERMES_PROXY_PORT=9120                 # LAN entry — what users actually browse to
+# HERMES_PROXY_UPSTREAM=dream-hermes:9119  # Where the proxy forwards (internal DNS)

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -750,6 +750,16 @@
       "type": "string",
       "description": "UI language for Hermes Agent's web dashboard (defaults to en).",
       "default": "en"
+    },
+    "HERMES_PROXY_PORT": {
+      "type": "integer",
+      "description": "External port for the Hermes auth-proxy (Caddy sidecar that gates LAN access on the dream-session cookie set by magic-link redemption).",
+      "default": 9120
+    },
+    "HERMES_PROXY_UPSTREAM": {
+      "type": "string",
+      "description": "Internal upstream the Hermes auth-proxy forwards to. Defaults to dream-hermes:9119.",
+      "default": "dream-hermes:9119"
     }
   }
 }

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -731,11 +731,6 @@
       "description": "Bind address for the reverse proxy's host port. Defaults to 0.0.0.0 (LAN-exposed) — that's the whole point of the proxy. Override to 127.0.0.1 to keep it localhost-only.",
       "default": "0.0.0.0"
     },
-    "HERMES_PORT": {
-      "type": "integer",
-      "description": "External port for the Hermes Agent dashboard. Used when Hermes is the LAN entry — direct dev access or smoke tests without hermes-proxy. With hermes-proxy enabled, Hermes is internal-only (compose switches to expose:) and this becomes informational; user-facing port is HERMES_PROXY_PORT.",
-      "default": 9119
-    },
     "HERMES_LLM_BASE_URL": {
       "type": "string",
       "description": "OpenAI-compatible endpoint Hermes Agent talks to. Defaults to Dream Server's llama-server.",

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -753,13 +753,18 @@
     },
     "HERMES_PROXY_PORT": {
       "type": "integer",
-      "description": "External port for the Hermes auth-proxy (Caddy sidecar that gates LAN access on the dream-session cookie set by magic-link redemption).",
+      "description": "External port for the Hermes auth-proxy (Caddy sidecar that gates LAN access by verifying the dream-session cookie via dashboard-api's /api/auth/verify-session endpoint).",
       "default": 9120
     },
     "HERMES_PROXY_UPSTREAM": {
       "type": "string",
       "description": "Internal upstream the Hermes auth-proxy forwards to. Defaults to dream-hermes:9119.",
       "default": "dream-hermes:9119"
+    },
+    "DREAM_AUTH_UPSTREAM": {
+      "type": "string",
+      "description": "Where Caddy forward_auth sends its session-verify sub-request. Defaults to the in-network dashboard-api container; override if dashboard-api lives elsewhere.",
+      "default": "dream-dashboard-api:3002"
     }
   }
 }

--- a/dream-server/docs/HERMES-SSO.md
+++ b/dream-server/docs/HERMES-SSO.md
@@ -6,9 +6,9 @@ When this extension is enabled:
 
 - Hermes itself binds **internal-only** (no host port).
 - The proxy binds the LAN-facing port (default `9120`) — that's what users browse to.
-- Every request to the proxy is inspected for the `dream-session` cookie that magic-link redemption (PR-4) sets in the user's browser.
-- No cookie → 303 redirect to a static "you need an invite" page.
-- Cookie present → traffic is forwarded to `dream-hermes:9119`. Hermes's own [per-process session token model](HERMES.md#security-posture) then handles per-request `/api/` auth.
+- Every request to the proxy is verified via `forward_auth` against dashboard-api's `/api/auth/verify-session` endpoint — which HMAC-validates the `dream-session` cookie's signature against `DREAM_SESSION_SECRET`.
+- Verified (HTTP 200 from the verify endpoint) → traffic is forwarded to `dream-hermes:9119`. Hermes's own [per-process session token model](HERMES.md#security-posture) then handles per-request `/api/` auth.
+- Not verified (HTTP 401 — missing cookie, bad signature, or expired) → 303 redirect to a static "you need an invite" page.
 
 ## Why this design
 
@@ -43,13 +43,16 @@ dream enable hermes-proxy
 #    → Save the QR / URL
 
 # 4. Recipient scans the QR on their phone
-#    → Lands on dashboard-api's /auth/magic-link/<token>
-#    → Redemption sets the dream-session cookie
-#    → 302 redirect to chat (or wherever the scope says)
-#    → They now have a valid cookie for any Hermes proxy access too
+#    → Lands on the dream-proxy at <device>.local/auth/magic-link/<token>
+#    → Redemption sets the HMAC-signed dream-session cookie on <device>.local
+#    → 302 redirect to /chat (same origin → cookie travels along)
+#    → They now have a valid cookie for any same-host port too (cookies
+#      are scoped by host, not port — so <device>.local:9120 will receive
+#      it as well)
 
-# 5. Recipient browses to http://hermes.<device>.local:9120
-#    → Proxy sees the dream-session cookie → forward
+# 5. Recipient browses to http://<device>.local:9120
+#    → Proxy forward_auths to dashboard-api/api/auth/verify-session
+#    → Signature check passes → forward to Hermes
 #    → Hermes serves the SPA → they chat
 ```
 
@@ -60,19 +63,20 @@ If the recipient hasn't yet redeemed an invite, step 5 lands them on the "you ne
 ```
 Phone / laptop
    │
-   ▼  http://hermes.<device>.local:9120
+   ▼  http://<device>.local:9120
 ┌──────────────────────────────────────────┐
 │  dream-hermes-proxy  (Caddy, ~50MB)      │
 │                                          │
 │  Caddyfile match rules:                  │
 │    /health, /favicon.ico → respond       │
 │    /auth/required*       → static files  │
-│    cookie has dream-session → reverse_   │
-│                                 proxy    │
-│    everything else        → 303 redirect │
+│    everything else        → forward_auth │
 │                                          │
-│  Listens on :9120, forwards to           │
-│  dream-hermes:9119                       │
+│  forward_auth sub-request:               │
+│    GET /api/auth/verify-session →        │
+│      dashboard-api:3002                  │
+│        2xx → reverse_proxy dream-hermes  │
+│        401 → 303 to /auth/required       │
 └──────────┬───────────────────────────────┘
            │
            ▼  internal Docker bridge network only
@@ -89,39 +93,48 @@ Phone / laptop
        llama-server (existing)
 ```
 
-## What "cookie present" actually means
+## What gets verified
 
-The `dream-session` cookie is set by the dashboard-api's magic-link redemption (`routers/magic_link.py`). The cookie:
+The `dream-session` cookie is set by the dashboard-api's magic-link redemption (`routers/magic_link.py`) and signed with HMAC-SHA256 against `DREAM_SESSION_SECRET` (see `session_signer.py`). The cookie:
 
 - Is `HttpOnly` (JS can't read it)
 - Has `SameSite=Lax` (sent on top-level navigation cross-origin GETs, blocked on background cross-site POSTs)
-- Is `Secure` when the dashboard-api was reached over HTTPS
+- Is `Secure` when the redemption host was reached over HTTPS
 - Has `Max-Age = 12h` from redemption
-- Contains a random `secrets.token_urlsafe(24)` value (NOT the magic-link token itself)
+- Carries `<random-id>.<expiry-epoch>.<hmac-signature>` — the signature is what gates validity, not presence
 
-The proxy checks **presence and non-emptiness**. It does NOT:
+On every request the proxy issues a sub-request to `dashboard-api/api/auth/verify-session`, which:
 
-- Cross-check the cookie value against any server-side store (PR-4 doesn't keep one — see [Limitations](#known-limitations))
-- Validate the user identity carried by the cookie (there is none)
-- Verify the cookie's signature (it's not signed today)
+1. Splits the cookie value on `.`
+2. Recomputes the HMAC over `<random-id>.<expiry-epoch>` and constant-time-compares it (`hmac.compare_digest`) against the claimed signature
+3. Checks the embedded expiry hasn't passed
 
-In effect: anyone who can read another user's `dream-session` cookie value can pass the proxy gate. The cookie's `HttpOnly` and same-origin properties make casual sharing hard but not impossible (a malicious browser extension on the redeemed user's device could exfiltrate it; a screenshot of devtools could leak it).
+Any failure (missing cookie, tampered signature, expired timestamp, missing server-side secret) returns a single byte-identical 401 response so an attacker can't probe which step failed.
 
-For the Dream Server trust model (single home, trusted LAN, family-scale users), this is the v1 trade-off. The proxy explicitly says "**gating**, not identification."
+What this catches:
+- Forged cookies (any value not signed with the secret fails the HMAC check)
+- Expired cookies (server-side expiry, independent of the browser's `Max-Age`)
+- Tampered cookies (changing the `<random-id>` or extending `<expiry-epoch>` invalidates the signature)
+
+What this does NOT do:
+- Identify which user is behind a request — the cookie is opaque (the random-id is not a username)
+- Track per-cookie revocation. Today's only revocation mechanism is rotating `DREAM_SESSION_SECRET`, which invalidates every issued cookie. A future PR could add a revocation list keyed on the random-id; the cookie format reserves space for it.
+
+For the Dream Server trust model (single home, trusted LAN, family-scale users), this gives real signature-based gating without a session store. The proxy explicitly says "**gating**, not identification."
 
 ## Known limitations
 
 1. **No real multi-user.** All authed users share one Hermes — same memories, skills, persona, sessions. Mom can see Dad's chats and vice-versa. Treat Hermes as "the family's agent."
 
-2. **No server-side cookie validation.** Today's PR-4 redemption sets the cookie but doesn't store the issued session in a server-side store. Anyone with the raw cookie value can use it. A future PR could add a sessions table that the proxy validates against, but that's not this extension.
+2. **Stolen cookies are valid until expiry or secret rotation.** The cookie is signed, but if it's exfiltrated (malicious browser extension, leaked screenshot, etc.) the attacker can use it until the 12h expiry passes or the operator rotates `DREAM_SESSION_SECRET`. There's no per-cookie revocation today. The signed format reserves the random-id field for a future revocation list.
 
-3. **No per-request user identification.** The proxy doesn't add an `X-Dream-User` header to forwarded requests. Hermes can't know "this request is from Alice" — only "this request is from someone with a valid invite."
+3. **No per-request user identification.** The proxy doesn't add an `X-Dream-User` header to forwarded requests. Hermes can't know "this request is from Alice" — only "this request is from someone with a valid signed cookie."
 
 4. **The cookie's `dream-target-user` field is ignored by the proxy.** Magic-link redemption sets a second cookie naming the target username, but the proxy doesn't surface it to Hermes (there's no Hermes-side hook to consume it).
 
 5. **Direct access to Hermes is now blocked.** Anyone who was reaching Hermes at `:9119` before this extension lands needs to switch to `:9120` (the proxy port). If they want raw direct access for testing, they can `docker exec dream-hermes` or temporarily re-add a `ports:` binding to the Hermes compose.
 
-6. **Caddy's auth check is `header_regexp` on the `Cookie` header.** That's text-based — it doesn't parse cookie semantics. The match anchor `(?:^|;\s*)dream-session=[^;]+` covers the common cases but a deliberately-malformed `Cookie` header could in theory slip past. In practice browsers never send malformed Cookie headers, and an attacker who can set arbitrary HTTP headers already has bigger leverage.
+6. **`DREAM_SESSION_SECRET` must be configured.** With no secret set, `verify-session` returns 401 for every request (and `issue()` raises during magic-link redemption) — the proxy gate effectively becomes "nobody passes." Set a 32+-byte random value in `.env` before enabling `hermes-proxy`.
 
 ## Future: Option B — per-user Hermes
 

--- a/dream-server/docs/HERMES-SSO.md
+++ b/dream-server/docs/HERMES-SSO.md
@@ -1,0 +1,152 @@
+# Hermes SSO — magic-link gating in front of the Hermes Agent
+
+Dream Server's `hermes-proxy` extension is a Caddy reverse proxy that fronts the [Hermes Agent container](HERMES.md) and gates access on Dream Server's magic-link auth.
+
+When this extension is enabled:
+
+- Hermes itself binds **internal-only** (no host port).
+- The proxy binds the LAN-facing port (default `9120`) — that's what users browse to.
+- Every request to the proxy is inspected for the `dream-session` cookie that magic-link redemption (PR-4) sets in the user's browser.
+- No cookie → 303 redirect to a static "you need an invite" page.
+- Cookie present → traffic is forwarded to `dream-hermes:9119`. Hermes's own [per-process session token model](HERMES.md#security-posture) then handles per-request `/api/` auth.
+
+## Why this design
+
+After reading [upstream's web_server.py at our pinned SHA](https://github.com/NousResearch/hermes-agent/blob/dd0923bb89ed2dd56f82cb63656a1323f6f42e6f/hermes_cli/web_server.py), Hermes's auth is **per-PROCESS, not per-user**. The session token is `secrets.token_urlsafe(32)` generated at server start and baked into the SPA HTML — no env-var to pre-seed, no login flow, no user concept.
+
+Hermes **does** support per-user isolation via [profiles](https://github.com/NousResearch/hermes-agent/blob/dd0923bb89ed2dd56f82cb63656a1323f6f42e6f/hermes_cli/profiles.py) (separate `HERMES_HOME/profiles/<name>/`), but a profile is bound at process launch — one Hermes process = one profile. There's no in-process profile switching.
+
+This extension does NOT try to give you real multi-user. It gives you:
+
+| Property | Achieved? |
+|---|---|
+| Magic-link-authed gateway | ✅ |
+| Anyone with a valid invite can reach Hermes | ✅ |
+| Anyone without a valid invite gets bounced | ✅ |
+| Mom's memories / skills / sessions isolated from Dad's | ❌ — shared |
+| The proxy knows WHO is logged in | ❌ — only that *someone* has a valid invite |
+
+If you need per-user isolation, the path is to run **one Hermes container per user** (each with its own profile), and have the proxy route based on the redeemed user's identity. That's [Option B](#future-option-b--per-user-hermes) below — out of scope for v1.
+
+## Setup
+
+```bash
+# 1. Enable Hermes (the agent itself)
+dream enable hermes
+
+# 2. Enable the auth proxy (this extension)
+dream enable hermes-proxy
+
+# 3. Generate an invite from the dashboard
+#    → Browse to http://<device>:3001/invites
+#    → "New invite" → scope: chat or all → Generate
+#    → Save the QR / URL
+
+# 4. Recipient scans the QR on their phone
+#    → Lands on dashboard-api's /auth/magic-link/<token>
+#    → Redemption sets the dream-session cookie
+#    → 302 redirect to chat (or wherever the scope says)
+#    → They now have a valid cookie for any Hermes proxy access too
+
+# 5. Recipient browses to http://hermes.<device>.local:9120
+#    → Proxy sees the dream-session cookie → forward
+#    → Hermes serves the SPA → they chat
+```
+
+If the recipient hasn't yet redeemed an invite, step 5 lands them on the "you need an invite" page with instructions.
+
+## Architecture
+
+```
+Phone / laptop
+   │
+   ▼  http://hermes.<device>.local:9120
+┌──────────────────────────────────────────┐
+│  dream-hermes-proxy  (Caddy, ~50MB)      │
+│                                          │
+│  Caddyfile match rules:                  │
+│    /health, /favicon.ico → respond       │
+│    /auth/required*       → static files  │
+│    cookie has dream-session → reverse_   │
+│                                 proxy    │
+│    everything else        → 303 redirect │
+│                                          │
+│  Listens on :9120, forwards to           │
+│  dream-hermes:9119                       │
+└──────────┬───────────────────────────────┘
+           │
+           ▼  internal Docker bridge network only
+┌──────────────────────────────────────────┐
+│  dream-hermes  (NousResearch image)      │
+│  - exposes :9119 internally              │
+│  - DOES NOT bind a host port             │
+│  - serves its React SPA + /api/*         │
+│  - its own X-Hermes-Session-Token gates  │
+│    /api/* requests per-request           │
+└──────────────────────────────────────────┘
+           │
+           ▼  OpenAI-compatible API
+       llama-server (existing)
+```
+
+## What "cookie present" actually means
+
+The `dream-session` cookie is set by the dashboard-api's magic-link redemption (`routers/magic_link.py`). The cookie:
+
+- Is `HttpOnly` (JS can't read it)
+- Has `SameSite=Lax` (sent on top-level navigation cross-origin GETs, blocked on background cross-site POSTs)
+- Is `Secure` when the dashboard-api was reached over HTTPS
+- Has `Max-Age = 12h` from redemption
+- Contains a random `secrets.token_urlsafe(24)` value (NOT the magic-link token itself)
+
+The proxy checks **presence and non-emptiness**. It does NOT:
+
+- Cross-check the cookie value against any server-side store (PR-4 doesn't keep one — see [Limitations](#known-limitations))
+- Validate the user identity carried by the cookie (there is none)
+- Verify the cookie's signature (it's not signed today)
+
+In effect: anyone who can read another user's `dream-session` cookie value can pass the proxy gate. The cookie's `HttpOnly` and same-origin properties make casual sharing hard but not impossible (a malicious browser extension on the redeemed user's device could exfiltrate it; a screenshot of devtools could leak it).
+
+For the Dream Server trust model (single home, trusted LAN, family-scale users), this is the v1 trade-off. The proxy explicitly says "**gating**, not identification."
+
+## Known limitations
+
+1. **No real multi-user.** All authed users share one Hermes — same memories, skills, persona, sessions. Mom can see Dad's chats and vice-versa. Treat Hermes as "the family's agent."
+
+2. **No server-side cookie validation.** Today's PR-4 redemption sets the cookie but doesn't store the issued session in a server-side store. Anyone with the raw cookie value can use it. A future PR could add a sessions table that the proxy validates against, but that's not this extension.
+
+3. **No per-request user identification.** The proxy doesn't add an `X-Dream-User` header to forwarded requests. Hermes can't know "this request is from Alice" — only "this request is from someone with a valid invite."
+
+4. **The cookie's `dream-target-user` field is ignored by the proxy.** Magic-link redemption sets a second cookie naming the target username, but the proxy doesn't surface it to Hermes (there's no Hermes-side hook to consume it).
+
+5. **Direct access to Hermes is now blocked.** Anyone who was reaching Hermes at `:9119` before this extension lands needs to switch to `:9120` (the proxy port). If they want raw direct access for testing, they can `docker exec dream-hermes` or temporarily re-add a `ports:` binding to the Hermes compose.
+
+6. **Caddy's auth check is `header_regexp` on the `Cookie` header.** That's text-based — it doesn't parse cookie semantics. The match anchor `(?:^|;\s*)dream-session=[^;]+` covers the common cases but a deliberately-malformed `Cookie` header could in theory slip past. In practice browsers never send malformed Cookie headers, and an attacker who can set arbitrary HTTP headers already has bigger leverage.
+
+## Future: Option B — per-user Hermes
+
+If/when real multi-user becomes a felt need, the path is:
+
+1. dashboard-api dynamically spawns a Hermes container per magic-link `target_username` (each with `HERMES_HOME=/opt/data/profiles/<username>`)
+2. The Hermes auth proxy gains a routing layer — reads the `dream-target-user` cookie set during redemption, maps it to the per-user container's address, forwards there.
+3. Lifecycle management: idle-timeout to stop unused containers; cold-start when a user returns.
+
+Roughly 2-3 PRs of work and meaningful resource cost (each Hermes container is ~3GB image + ~1GB idle RAM with chromium / playwright loaded). Not worth it until a family member specifically asks for "my own Hermes."
+
+## Disabling the proxy
+
+```bash
+dream disable hermes-proxy
+
+# To restore direct Hermes access, re-add a ports binding to
+# extensions/services/hermes/compose.yaml:
+#   ports:
+#     - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
+# (then `dream restart hermes`)
+```
+
+## Bump history
+
+| Date | Pinned Caddy | Notes |
+|---|---|---|
+| 2026-05-12 | `caddy:2.8.4-alpine` | Initial integration. |

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -6,7 +6,7 @@ When enabled, Hermes runs in a container alongside the rest of the stack, expose
 
 ## What you get
 
-Hermes ships its own complete web UI — Dream Server is just packaging it. After `dream enable hermes`, you can browse to `http://<device>:9119` (or `hermes.<device>.local:9119` once mDNS announcement lands — see "Roadmap" below) and find pages for:
+Hermes ships its own complete web UI — Dream Server is just packaging it. After `dream enable hermes` + `dream enable hermes-proxy`, you can browse to `http://<device>:9120` (or `hermes.<device>.local:9120` once mDNS announcement lands — see "Roadmap" below). The proxy is the LAN-facing entry; it gates access on Dream Server's magic-link cookie before forwarding to Hermes's internal port 9119. See [docs/HERMES-SSO.md](HERMES-SSO.md) for the full auth flow. Once past the proxy you find pages for:
 
 - **Chat** — conversational interface with streaming responses + inline tool calls
 - **Sessions** — list, switch between, prune past conversations
@@ -87,7 +87,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 - **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
 - **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
-- **Network exposure:** controlled by Dream Server's `BIND_ADDRESS` (default `127.0.0.1` = localhost only). Set `BIND_ADDRESS=0.0.0.0` to make Hermes reachable on the LAN at port 9119.
+- **Network exposure:** Hermes is **not directly LAN-reachable**. Once the `hermes-proxy` extension is enabled (see [docs/HERMES-SSO.md](HERMES-SSO.md)), the proxy at port 9120 fronts Hermes and gates access on Dream Server's magic-link cookie. Hermes's own port 9119 is internal-only. To restore direct access (e.g. for testing without auth), re-add a `ports:` binding to `extensions/services/hermes/compose.yaml`.
 - **Resource caps:** 4 CPUs / 4GB RAM hard limit, 0.5 CPU / 1GB reservation. Hermes's playwright + ML deps can be hungry; adjust in `extensions/services/hermes/compose.yaml` if needed.
 
 ## Configuration
@@ -138,11 +138,12 @@ gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.comm
 
 These were in the original integration plan but cut once we discovered Hermes ships a complete browser surface:
 
-- **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer (`bin/dream-mdns.py` lands in [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)). One-line follow-up after that PR merges.
+- **mDNS announcement** — register `hermes.<device>.local` in the Dream Server mDNS announcer. ✅ shipped as [#1167](https://github.com/Light-Heart-Labs/DreamServer/pull/1167) (stacked on [#1152](https://github.com/Light-Heart-Labs/DreamServer/pull/1152)).
+- **Magic-link SSO** — magic-link cookie gates access to Hermes via the new `hermes-proxy` Caddy sidecar. ✅ shipped — see [docs/HERMES-SSO.md](HERMES-SSO.md). Known limitation: single shared Hermes for all users; real per-user isolation would require per-user containers.
 - **APE policy integration** — route Hermes's tool calls through APE for allow/deny + audit. APE is already in the stack; needs a small adapter inside or in front of Hermes.
-- **Magic-link SSO** — hand off magic-link redemptions ([#1155](https://github.com/Light-Heart-Labs/DreamServer/pull/1155)) into a Hermes auth session so family members don't need separate Hermes credentials.
 - **Voice in/out from Dream Server's whisper + kokoro** — Hermes has its own audio pipeline (the image bundles ffmpeg + playwright); verify whether it already proxies to local TTS/STT services or whether we need to wire that ourselves.
 - **Dream-side status panel** — surface Hermes's session count + skill inventory in the Dream dashboard. Lower priority since Hermes has its own `AnalyticsPage`.
+- **Per-user Hermes containers** — if true multi-user becomes a felt need, spawn one Hermes per magic-link target_username and have the proxy route based on the redeemed identity. See [docs/HERMES-SSO.md](HERMES-SSO.md#future-option-b--per-user-hermes).
 
 ## Troubleshooting
 

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -95,7 +95,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 Three layers, highest to lowest precedence:
 
 1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting. **The model name lives here**, not in env.
-2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_LLM_API_KEY`, `HERMES_PORT`, `HERMES_LANGUAGE`. These are the only Hermes settings the container actually reads from env. See `.env.example`.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_LLM_API_KEY`, `HERMES_LANGUAGE`, and the `HERMES_PROXY_*` proxy settings. Hermes itself has no host-port env knob in the auth-gated stack; the LAN-facing port is `HERMES_PROXY_PORT`.
 3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
 
 To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.

--- a/dream-server/extensions/services/dashboard-api/tests/test_config.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_config.py
@@ -66,6 +66,24 @@ class TestLoadExtensionManifests:
         assert len(features) == 1
         assert features[0]["id"] == "test-feature"
 
+    def test_external_port_default_zero_disables_external_port_fallback(self, tmp_path):
+        svc_dir = tmp_path / "internal-service"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n"
+            "  id: internal-service\n"
+            "  name: Internal Service\n"
+            "  port: 9119\n"
+            "  external_port_default: 0\n"
+            "  health: /api/status\n"
+        )
+
+        services, _, _ = load_extension_manifests(tmp_path, "nvidia")
+
+        assert services["internal-service"]["port"] == 9119
+        assert services["internal-service"]["external_port"] == 0
+
     def test_skips_wrong_schema_version(self, tmp_path):
         svc_dir = tmp_path / "old-service"
         svc_dir.mkdir()

--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -48,10 +48,16 @@
 
 	# Static "you need an invite" page lives at /auth/required. Always
 	# accessible; this is where unauthenticated requests get bounced.
+	#
+	# `templates` lets index.html substitute `{{env "HERMES_PROXY_AUTH_DOCS_URL"}}`
+	# at response time, so operators can point recipients at a help doc /
+	# admin-contact page via env var without editing the HTML. The page
+	# only renders the "Need help?" row when the var is non-empty.
 	@auth_static path /auth/required* /auth/static/*
 	handle @auth_static {
 		root * /srv/auth-required
 		try_files {path} /index.html
+		templates
 		file_server
 	}
 

--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -1,16 +1,24 @@
 # Hermes Auth Proxy — Caddy config
 #
-# Sits in front of the dream-hermes container. Gates LAN access on the
-# presence of a `dream-session` cookie set by the dashboard-api's
-# magic-link redemption flow.
+# Sits in front of the dream-hermes container. Gates LAN access by
+# verifying the `dream-session` cookie against dashboard-api's
+# /api/auth/verify-session endpoint — which validates the cookie's
+# HMAC signature against DREAM_SESSION_SECRET (see session_signer.py).
+#
+# An earlier draft of this file only checked that the cookie HEADER
+# was present (`header_regexp Cookie dream-session=[^;]+`). That's
+# trivially bypassed — any LAN user can set `Cookie: dream-session=foo`
+# in curl or devtools and slip past the gate. We now do real signature
+# verification by delegating to dashboard-api via forward_auth.
 #
 # Flow:
 #   1. Request arrives on :9120
 #   2. /health and /favicon.ico — always answered (so health checks work)
 #   3. /auth/* — static "you need an invite" assets (always served)
-#   4. Has dream-session cookie? → reverse-proxy to dream-hermes:9119
-#      (Hermes's own X-Hermes-Session-Token check then runs per-request)
-#   5. Otherwise → 302 to /auth/required (the "ask the admin" page)
+#   4. Everything else: forward_auth to dashboard-api/api/auth/verify-session
+#      - 2xx → reverse-proxy to dream-hermes:9119
+#               (Hermes's own X-Hermes-Session-Token check still runs)
+#      - 401 → 303 redirect to /auth/required (the "ask the admin" page)
 #
 # This is auth GATING, not user identification. Once past the gate,
 # all users share the same Hermes instance (same memories, skills,
@@ -61,32 +69,43 @@
 		file_server
 	}
 
-	# Cookie matcher: presence of a non-empty `dream-session=<value>` in
-	# the Cookie header. Caddy's `header_regexp` matches the raw Cookie
-	# header as one string, so we anchor on `(?:^|;\s*)` so we match
-	# even when there are other cookies before ours.
-	@authenticated header_regexp Cookie (?:^|;\s*)dream-session=[^;]+
-	handle @authenticated {
-		# Forward everything to Hermes. reverse_proxy handles streaming
-		# responses (SSE) and WebSocket upgrades natively — Caddy's
-		# upstream-handling is the reason we picked it over rolling our
-		# own FastAPI proxy.
-		reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
-			# Pass-through with sane defaults. Caddy's defaults are
-			# correct for SSE + WS; we don't need to tweak buffering.
-			header_up X-Forwarded-Proto {scheme}
-			header_up X-Forwarded-Host {host}
-			# Add a marker the operator can grep for in Hermes's logs
-			# if they're debugging a "did this request come via the
-			# proxy or directly?" question.
-			header_up X-Dream-Auth-Proxy "1"
+	# Real session verification: delegate to dashboard-api's
+	# /api/auth/verify-session. That endpoint reads the dream-session
+	# cookie, verifies the HMAC signature against DREAM_SESSION_SECRET,
+	# and returns 200 (valid) or 401 (missing/expired/bad-signature).
+	#
+	# Caddy's forward_auth issues a sub-request to the auth upstream
+	# with the original Cookie header copied across, then:
+	#   * 2xx → falls through to reverse_proxy below
+	#   * non-2xx → the handle_response @denied block fires, sending the
+	#               user to the auth-required page (303 — important so a
+	#               no-cookie POST doesn't replay its body to /auth/required)
+	#
+	# DREAM_AUTH_UPSTREAM defaults to the in-network dashboard-api
+	# hostname (which only the compose bridge can resolve); operators
+	# can override via env if dashboard-api lives elsewhere.
+	forward_auth {$DREAM_AUTH_UPSTREAM:dream-dashboard-api:3002} {
+		uri /api/auth/verify-session
+		copy_headers Cookie
+
+		@denied status 401 403
+		handle_response @denied {
+			redir /auth/required 303
 		}
 	}
 
-	# No cookie → bounce to the auth-required page. 303 (See Other) is
-	# the correct status for "this method is done, go GET that URL" —
-	# important so a no-cookie POST doesn't replay the body to /auth/required.
-	handle {
-		redir /auth/required 303
+	# Forward everything to Hermes. reverse_proxy handles streaming
+	# responses (SSE) and WebSocket upgrades natively — Caddy's
+	# upstream-handling is the reason we picked it over rolling our
+	# own FastAPI proxy.
+	reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
+		# Pass-through with sane defaults. Caddy's defaults are
+		# correct for SSE + WS; we don't need to tweak buffering.
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+		# Add a marker the operator can grep for in Hermes's logs
+		# if they're debugging a "did this request come via the
+		# proxy or directly?" question.
+		header_up X-Dream-Auth-Proxy "1"
 	}
 }

--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -1,0 +1,86 @@
+# Hermes Auth Proxy — Caddy config
+#
+# Sits in front of the dream-hermes container. Gates LAN access on the
+# presence of a `dream-session` cookie set by the dashboard-api's
+# magic-link redemption flow.
+#
+# Flow:
+#   1. Request arrives on :9120
+#   2. /health and /favicon.ico — always answered (so health checks work)
+#   3. /auth/* — static "you need an invite" assets (always served)
+#   4. Has dream-session cookie? → reverse-proxy to dream-hermes:9119
+#      (Hermes's own X-Hermes-Session-Token check then runs per-request)
+#   5. Otherwise → 302 to /auth/required (the "ask the admin" page)
+#
+# This is auth GATING, not user identification. Once past the gate,
+# all users share the same Hermes instance (same memories, skills,
+# persona). See docs/HERMES-SSO.md for the explicit limitation.
+
+{
+	# Disable Caddy's auto-HTTPS — Dream Server's TLS is handled at the
+	# Tailscale layer (PR-12) or by an explicit operator-side reverse
+	# proxy. Inside the bridge network we serve plain HTTP.
+	auto_https off
+	# Don't expose Caddy's admin API. It's an attack surface we don't need.
+	admin off
+	# Log to stdout for `docker logs dream-hermes-proxy`.
+	log {
+		output stdout
+		format console
+		level INFO
+	}
+}
+
+# Listen on the proxy's internal port. Compose maps this to the external
+# HERMES_PROXY_PORT via the host port mapping.
+:9120 {
+	# Cheap health endpoint for Docker / dashboard probes. NEVER gates on
+	# the cookie — health checks are anonymous by design.
+	@health path /health
+	handle @health {
+		respond "ok" 200
+	}
+
+	@favicon path /favicon.ico
+	handle @favicon {
+		respond 204
+	}
+
+	# Static "you need an invite" page lives at /auth/required. Always
+	# accessible; this is where unauthenticated requests get bounced.
+	@auth_static path /auth/required* /auth/static/*
+	handle @auth_static {
+		root * /srv/auth-required
+		try_files {path} /index.html
+		file_server
+	}
+
+	# Cookie matcher: presence of a non-empty `dream-session=<value>` in
+	# the Cookie header. Caddy's `header_regexp` matches the raw Cookie
+	# header as one string, so we anchor on `(?:^|;\s*)` so we match
+	# even when there are other cookies before ours.
+	@authenticated header_regexp Cookie (?:^|;\s*)dream-session=[^;]+
+	handle @authenticated {
+		# Forward everything to Hermes. reverse_proxy handles streaming
+		# responses (SSE) and WebSocket upgrades natively — Caddy's
+		# upstream-handling is the reason we picked it over rolling our
+		# own FastAPI proxy.
+		reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
+			# Pass-through with sane defaults. Caddy's defaults are
+			# correct for SSE + WS; we don't need to tweak buffering.
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Forwarded-Host {host}
+			# Add a marker the operator can grep for in Hermes's logs
+			# if they're debugging a "did this request come via the
+			# proxy or directly?" question.
+			header_up X-Dream-Auth-Proxy "1"
+		}
+	}
+
+	# No cookie → bounce to the auth-required page. 303 (See Other) is
+	# the correct status for "this method is done, go GET that URL" —
+	# important so a no-cookie POST doesn't replay the body to /auth/required.
+	handle {
+		redir /auth/required 303
+	}
+}

--- a/dream-server/extensions/services/hermes-proxy/auth-required/index.html
+++ b/dream-server/extensions/services/hermes-proxy/auth-required/index.html
@@ -1,0 +1,136 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="theme-color" content="#0f0f13" />
+  <title>Hermes — Invite required</title>
+  <style>
+    :root {
+      --bg: #0f0f13;
+      --card: #1a1a22;
+      --text: #e4e4e7;
+      --muted: #8c8c96;
+      --accent: #a78bfa;
+      --border: #2a2a34;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, system-ui, sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      line-height: 1.5;
+    }
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 1rem;
+      padding: 2rem;
+      max-width: 28rem;
+      width: 100%;
+    }
+    .badge {
+      display: inline-block;
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 0.75rem;
+      font-weight: 700;
+      letter-spacing: 0.15em;
+      color: var(--accent);
+      margin-bottom: 1rem;
+    }
+    h1 {
+      margin: 0 0 0.5rem;
+      font-size: 1.5rem;
+      font-weight: 700;
+    }
+    p {
+      color: var(--muted);
+      margin: 0 0 1rem;
+    }
+    .icon {
+      width: 3rem;
+      height: 3rem;
+      border-radius: 0.75rem;
+      background: rgba(167, 139, 250, 0.15);
+      color: var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin-bottom: 1.25rem;
+    }
+    .steps {
+      list-style: none;
+      padding: 0;
+      margin: 1.5rem 0 0;
+      counter-reset: step;
+    }
+    .steps li {
+      counter-increment: step;
+      padding: 0.5rem 0 0.5rem 2.5rem;
+      position: relative;
+      color: var(--text);
+    }
+    .steps li::before {
+      content: counter(step);
+      position: absolute;
+      left: 0;
+      top: 0.4rem;
+      width: 1.5rem;
+      height: 1.5rem;
+      border-radius: 50%;
+      background: rgba(167, 139, 250, 0.15);
+      color: var(--accent);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 0.75rem;
+      font-weight: 700;
+    }
+    code {
+      background: rgba(255, 255, 255, 0.04);
+      padding: 0.1rem 0.4rem;
+      border-radius: 0.25rem;
+      font-family: ui-monospace, "SF Mono", Menlo, monospace;
+      font-size: 0.85em;
+      color: var(--accent);
+    }
+    .footer {
+      margin-top: 1.5rem;
+      padding-top: 1.25rem;
+      border-top: 1px solid var(--border);
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon" aria-hidden="true">
+      <!-- Shield icon, inline SVG so we don't depend on a network fetch -->
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" />
+      </svg>
+    </div>
+    <div class="badge">HERMES AGENT</div>
+    <h1>You need an invite.</h1>
+    <p>This Hermes Agent is gated behind Dream Server's magic-link auth. To reach the chat surface, an admin needs to send you an invite link from their dashboard.</p>
+
+    <ol class="steps">
+      <li>Ask the admin to open their dashboard's <strong>Invites</strong> page.</li>
+      <li>They generate a magic-link with scope <code>chat</code> or <code>all</code>.</li>
+      <li>They share the QR or URL with you — scan or tap once and you're in.</li>
+    </ol>
+
+    <p class="footer">
+      Already have a link? Open it directly — redemption sets the session cookie
+      this page is waiting for, and you'll be redirected straight to Hermes.
+    </p>
+  </div>
+</body>
+</html>

--- a/dream-server/extensions/services/hermes-proxy/auth-required/index.html
+++ b/dream-server/extensions/services/hermes-proxy/auth-required/index.html
@@ -127,6 +127,12 @@
       <li>They share the QR or URL with you — scan or tap once and you're in.</li>
     </ol>
 
+    {{ $docsUrl := env "HERMES_PROXY_AUTH_DOCS_URL" }}{{ if $docsUrl }}
+    <p style="margin-top: 1rem; font-size: 0.875rem; color: var(--text);">
+      Need help? <a href="{{ $docsUrl }}" style="color: var(--accent); text-decoration: underline;">See the operator's notes</a>.
+    </p>
+    {{ end }}
+
     <p class="footer">
       Already have a link? Open it directly — redemption sets the session cookie
       this page is waiting for, and you'll be redirected straight to Hermes.

--- a/dream-server/extensions/services/hermes-proxy/compose.yaml
+++ b/dream-server/extensions/services/hermes-proxy/compose.yaml
@@ -8,9 +8,19 @@ services:
     restart: unless-stopped
     depends_on:
       - hermes
+      # forward_auth needs dashboard-api up to verify sessions. Compose
+      # depends_on only sequences start-up, not health — Caddy will get
+      # 502s for verify-session until dashboard-api is responding, at
+      # which point users get bounced to /auth/required (correct behaviour
+      # for the brief window).
+      - dashboard-api
     environment:
       # Override the upstream from .env if the operator's wiring differs.
       - HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}
+      # Where forward_auth sends its session-verify sub-request. Defaults
+      # to the in-network dashboard-api container; override if dashboard-api
+      # lives on a different host or non-standard port.
+      - DREAM_AUTH_UPSTREAM=${DREAM_AUTH_UPSTREAM:-dream-dashboard-api:3002}
       # Optional help URL surfaced on the "you need an invite" page via
       # Caddy `templates` substitution. Empty hides the row entirely.
       - HERMES_PROXY_AUTH_DOCS_URL=${HERMES_PROXY_AUTH_DOCS_URL:-}

--- a/dream-server/extensions/services/hermes-proxy/compose.yaml
+++ b/dream-server/extensions/services/hermes-proxy/compose.yaml
@@ -1,0 +1,50 @@
+services:
+  hermes-proxy:
+    # Pinned Caddy 2.x. Single static binary, ~50MB image, native
+    # SSE/WebSocket support — much lighter than a custom FastAPI proxy
+    # for what amounts to "check a cookie, forward, or 303 redirect."
+    image: caddy:2.8.4-alpine
+    container_name: dream-hermes-proxy
+    restart: unless-stopped
+    depends_on:
+      - hermes
+    environment:
+      # Override the upstream from .env if the operator's wiring differs.
+      - HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}
+    volumes:
+      # Caddyfile is read-only; mounting :ro reduces the blast radius if
+      # the container were ever compromised.
+      - ./extensions/services/hermes-proxy/Caddyfile:/etc/caddy/Caddyfile:ro
+      # Static "you need an invite" page served when no cookie is present.
+      - ./extensions/services/hermes-proxy/auth-required:/srv/auth-required:ro
+      # Caddy persists its own state (certs, etc.) — empty for us since
+      # auto_https is off, but keeping the volume avoids first-start chatter.
+      - ./data/hermes-proxy/caddy-data:/data
+      - ./data/hermes-proxy/caddy-config:/config
+    ports:
+      # BIND_ADDRESS gates LAN exposure (Dream Server convention). Default
+      # 127.0.0.1 = localhost only. Set BIND_ADDRESS=0.0.0.0 in .env to
+      # expose on the LAN at hermes.<device>.local:9120.
+      - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PROXY_PORT:-9120}:9120"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:9120/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    # Caddy is very light; small caps reflect that.
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 256M
+        reservations:
+          cpus: '0.05'
+          memory: 32M
+    security_opt:
+      - no-new-privileges:true
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/hermes-proxy/compose.yaml
+++ b/dream-server/extensions/services/hermes-proxy/compose.yaml
@@ -11,6 +11,9 @@ services:
     environment:
       # Override the upstream from .env if the operator's wiring differs.
       - HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}
+      # Optional help URL surfaced on the "you need an invite" page via
+      # Caddy `templates` substitution. Empty hides the row entirely.
+      - HERMES_PROXY_AUTH_DOCS_URL=${HERMES_PROXY_AUTH_DOCS_URL:-}
     volumes:
       # Caddyfile is read-only; mounting :ro reduces the blast radius if
       # the container were ever compromised.

--- a/dream-server/extensions/services/hermes-proxy/manifest.yaml
+++ b/dream-server/extensions/services/hermes-proxy/manifest.yaml
@@ -1,0 +1,57 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: hermes-proxy
+  name: Hermes Auth Proxy
+  aliases: [hermes-gate]
+  container_name: dream-hermes-proxy
+  default_host: hermes-proxy
+  port: 9120
+  external_port_env: HERMES_PROXY_PORT
+  external_port_default: 9120
+  health: /health
+  ui_path: /
+  health_timeout: 10
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: [hermes, dashboard-api]
+  description: >
+    Caddy-based reverse proxy that fronts the Hermes Agent extension.
+    Gates access on the presence of a `dream-session` cookie (set by
+    the magic-link redemption flow in dashboard-api). Without the
+    cookie, requests are answered with a static "you need an invite"
+    page. With it, traffic is forwarded to dream-hermes:9119 and
+    Hermes's own session-token model handles per-request auth.
+    Native streaming + WebSocket support via Caddy's `reverse_proxy`.
+
+  env_vars:
+    - key: HERMES_PROXY_PORT
+      default: "9120"
+      description: External port for the Hermes auth-proxy (LAN-facing entry)
+    - key: HERMES_PROXY_UPSTREAM
+      default: "dream-hermes:9119"
+      description: Internal address of the Hermes container we forward to
+    - key: HERMES_PROXY_AUTH_DOCS_URL
+      default: ""
+      description: |
+        Optional URL shown on the "you need an invite" page if the operator
+        has a help doc / contact info. Empty hides the row.
+
+features:
+  - id: hermes-sso
+    name: Hermes Single Sign-On
+    description: Magic-link SSO gating in front of Hermes Agent
+    icon: Shield
+    category: privacy
+    requirements:
+      services: [hermes, dashboard-api]
+      vram_gb: 0
+    enabled_services_all: [hermes-proxy]
+    setup_time: Ready
+    priority: 5
+    gpu_backends: [all]

--- a/dream-server/extensions/services/hermes-proxy/manifest.yaml
+++ b/dream-server/extensions/services/hermes-proxy/manifest.yaml
@@ -22,11 +22,12 @@ service:
   depends_on: [hermes, dashboard-api]
   description: >
     Caddy-based reverse proxy that fronts the Hermes Agent extension.
-    Gates access on the presence of a `dream-session` cookie (set by
-    the magic-link redemption flow in dashboard-api). Without the
-    cookie, requests are answered with a static "you need an invite"
-    page. With it, traffic is forwarded to dream-hermes:9119 and
-    Hermes's own session-token model handles per-request auth.
+    Verifies the `dream-session` cookie against dashboard-api's
+    /api/auth/verify-session endpoint (Caddy forward_auth) — which
+    HMAC-validates the cookie's signature against DREAM_SESSION_SECRET.
+    Without a valid cookie, requests are bounced to a static "you need
+    an invite" page. With one, traffic is forwarded to dream-hermes:9119
+    and Hermes's own session-token model handles per-request auth.
     Native streaming + WebSocket support via Caddy's `reverse_proxy`.
 
   env_vars:
@@ -36,6 +37,12 @@ service:
     - key: HERMES_PROXY_UPSTREAM
       default: "dream-hermes:9119"
       description: Internal address of the Hermes container we forward to
+    - key: DREAM_AUTH_UPSTREAM
+      default: "dream-dashboard-api:3002"
+      description: |
+        Where forward_auth sends its session-verify sub-request. Defaults
+        to the in-network dashboard-api container; override if dashboard-api
+        lives on a different host or non-standard port.
     - key: HERMES_PROXY_AUTH_DOCS_URL
       default: ""
       description: |

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -52,11 +52,17 @@ services:
       # a custom Dockerfile.
       - ./extensions/services/hermes/cli-config.yaml.template:/opt/hermes/cli-config.yaml.example:ro
       - ./extensions/services/hermes/SOUL.md.template:/opt/hermes/docker/SOUL.md:ro
-    ports:
-      # BIND_ADDRESS gates LAN exposure. Default 127.0.0.1 = localhost only.
-      # Set BIND_ADDRESS=0.0.0.0 in .env to make Hermes reachable on the LAN
-      # at hermes.<device>.local:9119 (mDNS) or via Tailscale.
-      - "${BIND_ADDRESS:-127.0.0.1}:${HERMES_PORT:-9119}:9119"
+    # Hermes is exposed to the LAN via dream-hermes-proxy on port 9120 — that
+    # Caddy sidecar forward_auths to dashboard-api's verify-session and only
+    # then forwards traffic here. By NOT binding a host port on the Hermes
+    # container itself, we close the door on direct LAN access that would
+    # bypass the magic-link gate. If you disable the proxy, you'll need to
+    # re-add a `ports:` binding here OR `docker exec dream-hermes` to interact.
+    #
+    # Internal port 9119 stays reachable from other containers (the proxy
+    # forwards to dream-hermes:9119 via the Docker network).
+    expose:
+      - "9119"
     # Run the gateway with the dashboard embedded.
     #
     # Why `gateway run` and not just `dashboard`: Hermes's scheduler (the

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -16,11 +16,11 @@ service:
   # under `expose:` so other containers on the bridge network (notably
   # hermes-proxy) can talk to dream-hermes:9119.
   port: 9119
-  # external_port_env / external_port_default are deliberately omitted —
-  # with hermes-proxy enabled Hermes is internal-only (compose declares
-  # the port under `expose:` not `ports:`). Surfacing a "browse to this
-  # port" URL in /api/external-links would mislead users into bypassing
-  # the magic-link gate.
+  # This explicit zero prevents dashboard-api from falling back
+  # external_port to service.port and advertising a non-existent direct
+  # :9119 host URL. Hermes is internal-only (compose declares the port
+  # under `expose:` not `ports:`); hermes-proxy is the LAN entry.
+  external_port_default: 0
   #
   # Most /api/* routes are session-token gated, and /api/health does not
   # exist in the pinned upstream image. /api/status is explicitly public,

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -9,13 +9,19 @@ service:
   aliases: [agent, hermes-agent]
   container_name: dream-hermes
   default_host: hermes
-  # Hermes's own dashboard listens on 9119 inside the container. We expose
-  # the same port externally so direct LAN access (or curl-from-host
-  # debugging) hits a predictable URL. End users normally go through
-  # hermes-proxy on :9120 (auth-gated entry point); see HERMES-SSO.md.
+  # Hermes's own dashboard listens on 9119 inside the container.
+  # Internal-only — there is intentionally no host-port binding here.
+  # End users reach Hermes via hermes-proxy on :9120 (auth-gated entry
+  # point); see HERMES-SSO.md. The compose file declares this port
+  # under `expose:` so other containers on the bridge network (notably
+  # hermes-proxy) can talk to dream-hermes:9119.
   port: 9119
-  external_port_env: HERMES_PORT
-  external_port_default: 9119
+  # external_port_env / external_port_default are deliberately omitted —
+  # with hermes-proxy enabled Hermes is internal-only (compose declares
+  # the port under `expose:` not `ports:`). Surfacing a "browse to this
+  # port" URL in /api/external-links would mislead users into bypassing
+  # the magic-link gate.
+  #
   # Most /api/* routes are session-token gated, and /api/health does not
   # exist in the pinned upstream image. /api/status is explicitly public,
   # read-only, and JSON-backed, so it is the health path Dream should poll.
@@ -39,14 +45,10 @@ service:
     cron jobs actually runs.
 
   env_vars:
-    - key: HERMES_PORT
-      default: "9119"
-      description: |
-        External port for Hermes's own dashboard. Used only when Hermes is
-        the LAN-facing entry — e.g., direct dev access or smoke tests with
-        the hermes-proxy extension disabled. With hermes-proxy enabled,
-        Hermes is internal-only (compose switches to `expose:`) and this
-        knob is informational; the user-facing port becomes HERMES_PROXY_PORT.
+    # HERMES_PORT is intentionally NOT exposed here. With this PR's
+    # internal-only compose (`expose: 9119`), there's no host binding to
+    # control — the variable would be a no-op knob. The user-facing port
+    # is HERMES_PROXY_PORT (declared by the hermes-proxy manifest).
     - key: HERMES_LLM_BASE_URL
       default: "http://llama-server:8080/v1"
       description: OpenAI-compatible endpoint Hermes talks to. Defaults to Dream's llama-server.

--- a/dream-server/scripts/audit-extensions.py
+++ b/dream-server/scripts/audit-extensions.py
@@ -277,6 +277,18 @@ def parse_positive_int(value: Any) -> int | None:
     return integer if integer > 0 else None
 
 
+def parse_non_negative_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        integer = int(value)
+    except (TypeError, ValueError):
+        return None
+    return integer if integer >= 0 else None
+
+
 def collect_service_references(feature: dict[str, Any]) -> list[str]:
     refs: list[str] = []
     for path in FEATURE_SERVICE_KEYS:
@@ -490,11 +502,11 @@ def validate_records(
             )
 
         ext_port_default = service.get("external_port_default")
-        if ext_port_default not in (None, "") and parse_positive_int(ext_port_default) is None:
+        if ext_port_default not in (None, "") and parse_non_negative_int(ext_port_default) is None:
             record.add_issue(
                 "error",
                 "service-external-port-invalid",
-                "service.external_port_default must be a positive integer when set",
+                "service.external_port_default must be a non-negative integer when set",
                 path=record.manifest_path,
             )
 

--- a/dream-server/scripts/audit-extensions.py
+++ b/dream-server/scripts/audit-extensions.py
@@ -325,6 +325,15 @@ def load_compose_definitions(record: ServiceRecord) -> tuple[dict[str, Any], dic
 
 
 def extract_target_ports(service_def: Any) -> list[int]:
+    """Return every container-internal port a service makes available.
+
+    Looks at BOTH `ports:` (host-bound) and `expose:` (internal-only)
+    declarations so internal-only services like dream-hermes (fronted by
+    hermes-proxy) still register their port. Without this, a service
+    that switches from `ports:` to `expose:` would fail
+    compose-port-mismatch even though its container is fully reachable
+    by other containers on the bridge network.
+    """
     if not isinstance(service_def, dict):
         return []
 
@@ -349,6 +358,20 @@ def extract_target_ports(service_def: Any) -> list[int]:
             target_int = parse_positive_int(target)
             if target_int:
                 results.append(target_int)
+
+    # `expose:` is a list of "<port>" or "<port>/<proto>" strings/ints —
+    # internal-network-only, never bound to the host.
+    for entry in as_list(service_def.get("expose")):
+        if isinstance(entry, int):
+            if entry > 0:
+                results.append(entry)
+            continue
+        if isinstance(entry, str):
+            head = entry.split("/", 1)[0]
+            try:
+                results.append(int(head))
+            except ValueError:
+                continue
     return results
 
 

--- a/dream-server/tests/test-extension-audit.sh
+++ b/dream-server/tests/test-extension-audit.sh
@@ -37,7 +37,7 @@ fail() {
 
 header() {
     echo ""
-    echo -e "${BOLD}${CYAN}[$1/6]${NC} ${BOLD}$2${NC}"
+    echo -e "${BOLD}${CYAN}[$1/7]${NC} ${BOLD}$2${NC}"
     echo -e "${CYAN}$(printf '%.0s─' {1..60})${NC}"
 }
 
@@ -215,7 +215,7 @@ PY
 
 header "1" "Valid Project Passes Cleanly"
 root=$(make_fixture_root)
-trap 'rm -rf "$root" "${root2:-}" "${root3:-}" "${root4:-}" "${root5:-}" "${root6:-}"' EXIT
+trap 'rm -rf "$root" "${root2:-}" "${root3:-}" "${root4:-}" "${root5:-}" "${root6:-}" "${root7:-}"' EXIT
 create_valid_project "$root"
 report=$(mktemp)
 if run_audit "$root" --json > "$report"; then
@@ -342,6 +342,26 @@ if run_audit "$root6" --strict >/dev/null 2>&1; then
     fail "strict mode should fail on warnings"
 else
     pass "strict mode converts warnings into failure"
+fi
+
+header "7" "External Port Zero Is Accepted"
+root7=$(make_fixture_root)
+create_valid_project "$root7"
+python3 - "$root7/extensions/services/search/manifest.yaml" <<'PY'
+import yaml
+import sys
+path = sys.argv[1]
+doc = yaml.safe_load(open(path, encoding="utf-8"))
+doc["service"].pop("external_port_env", None)
+doc["service"]["external_port_default"] = 0
+with open(path, "w", encoding="utf-8") as handle:
+    yaml.safe_dump(doc, handle, sort_keys=False)
+PY
+report7=$(mktemp)
+if run_audit "$root7" --json > "$report7" 2>/dev/null; then
+    pass "external_port_default=0 fixture audits successfully"
+else
+    fail "external_port_default=0 should be allowed for internal-only services"
 fi
 
 echo ""

--- a/dream-server/tests/test-service-registry.sh
+++ b/dream-server/tests/test-service-registry.sh
@@ -162,6 +162,55 @@ else:
     fi
 fi
 
+declare -A SERVICE_INTERNAL_PORTS=()
+if "$PYTHON_CMD" -c "import yaml" 2>/dev/null; then
+    while IFS=$'\t' read -r sid internal_port; do
+        [[ -z "$sid" ]] && continue
+        SERVICE_INTERNAL_PORTS["$sid"]="$internal_port"
+    done < <("$PYTHON_CMD" - "$EXTENSIONS_DIR" <<'PY'
+import sys
+import yaml
+from pathlib import Path
+
+ext_dir = Path(sys.argv[1])
+if not ext_dir.exists():
+    raise SystemExit(0)
+
+service_dirs = sorted(ext_dir.iterdir())
+user_ext_dir = ext_dir.parent.parent / "data" / "user-extensions"
+if user_ext_dir.exists():
+    service_dirs += sorted(user_ext_dir.iterdir())
+
+seen = set()
+for service_dir in service_dirs:
+    if not service_dir.is_dir():
+        continue
+    manifest_path = None
+    for name in ("manifest.yaml", "manifest.yml", "manifest.json"):
+        candidate = service_dir / name
+        if candidate.exists():
+            manifest_path = candidate
+            break
+    if manifest_path is None:
+        continue
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except Exception:
+        continue
+    if not isinstance(manifest, dict) or manifest.get("schema_version") != "dream.services.v1":
+        continue
+    service = manifest.get("service")
+    if not isinstance(service, dict):
+        continue
+    sid = service.get("id")
+    if not sid or sid in seen:
+        continue
+    seen.add(sid)
+    print(f"{sid}\t{service.get('port', 0) or 0}")
+PY
+    )
+fi
+
 # ============================================
 # TEST 3: Core Service Manifests
 # ============================================
@@ -263,10 +312,14 @@ for sid in "${SERVICE_IDS[@]}"; do
         fail "Missing health endpoint: $sid"
     fi
 
-    # Every service should have a port
+    # Every service should have a runtime port. SERVICE_PORTS is the
+    # user-facing external port; internal-only services may intentionally set
+    # it to 0 when a proxy owns the LAN entry point.
     port="${SERVICE_PORTS[$sid]:-0}"
     if [[ "$port" != "0" ]]; then
-        pass "Has port: $sid → $port"
+        pass "Has external port: $sid → $port"
+    elif [[ "${SERVICE_INTERNAL_PORTS[$sid]:-0}" != "0" ]]; then
+        pass "Internal-only service has container port: $sid → ${SERVICE_INTERNAL_PORTS[$sid]}"
     else
         fail "Missing/zero port: $sid"
     fi


### PR DESCRIPTION
Replacement for closed #1168 after #1166's stacked base branch was merged/deleted.

This PR adds the Hermes auth-proxy sidecar:
- Adds `hermes-proxy`, a Caddy service that gates Hermes access with `forward_auth` to dashboard-api `/api/auth/verify-session`.
- Makes `dream-hermes` internal-only via `expose: 9119` so direct host/LAN `:9119` access is not advertised or bound.
- Adds the static `/auth/required` invite-needed page.
- Documents the SSO flow and its known limitation: access gating, not per-user Hermes isolation.
- Teaches the extension audit to understand internal-only `expose:` ports and explicit `external_port_default: 0`.

Fixes included during audit:
- Preserved the merged Hermes `/api/status` health contract instead of the old `/healthz` draft.
- Added `external_port_default: 0` for Hermes so dashboard-api does not fall back to advertising `:9119` as an external URL.
- Added regression coverage for `external_port_default: 0`.

Local checks already run on this head:
- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_config.py dream-server/extensions/services/dashboard-api/tests/test_auth_router.py dream-server/extensions/services/dashboard-api/tests/test_magic_link.py -q` -> 63 passed
- `python dream-server/scripts/audit-extensions.py --project-dir dream-server` -> pass, 24 services, 0 warnings/errors
- `dream-server/tests/test-extension-audit.sh` via Git Bash with the dependency-bearing Python shim -> 15 passed, 0 failed
- `docker compose -f dream-server/docker-compose.base.yml -f dream-server/extensions/services/hermes/compose.yaml -f dream-server/extensions/services/hermes-proxy/compose.yaml config --quiet` -> pass
- `dream-server/tests/test-doc-links.sh` via Git Bash -> pass
- JSON/YAML parse checks -> pass
- `git diff --check origin/main...HEAD` -> pass

Could not run local `caddy validate` because Docker Engine is unavailable on this machine (`dockerDesktopLinuxEngine` pipe missing). Compose syntax validation passed; GitHub CI should cover the repo-level checks.