### PR TITLE
fix(tailscale): bump pinned image to v1.96.5

### DIFF
--- a/dream-server/extensions/services/tailscale/compose.yaml
+++ b/dream-server/extensions/services/tailscale/compose.yaml
@@ -1,6 +1,6 @@
 services:
   tailscale:
-    image: tailscale/tailscale:v1.78.0
+    image: tailscale/tailscale:v1.96.5
     container_name: dream-tailscale
     restart: unless-stopped
     # network_mode: host puts the Tailscale daemon in the host's network


### PR DESCRIPTION
## Summary

- `extensions/services/tailscale/compose.yaml:3` pinned `tailscale/tailscale:v1.78.0`, which **does not exist** on Docker Hub. Bumped the pin to `tailscale/tailscale:v1.96.5` (current stable, multi-arch).
- Without this fix, every fresh install fails at compose-up with `failed to resolve reference docker.io/tailscale/tailscale:v1.78.0: not found`.

## Evidence

```
$ docker manifest inspect tailscale/tailscale:v1.78.0
no such manifest: docker.io/tailscale/tailscale:v1.78.0
```

`/v2/repositories/tailscale/tailscale/tags` lists the actual stable line as `v1.96` / `v1.96.5` (April 2026), with the `v1.97.x` series in unstable. There is no `v1.78.x` history under this image name.

## How I found it

Discovered while running a fresh-install test across four platforms today (2026-05-12):

| Box | Arch / OS | Outcome |
|---|---|---|
| Tower2 | x86_64 / Ubuntu / 2× NVIDIA Blackwell | fail at compose-up |
| Strix Halo | x86_64 / Ubuntu / AMD Radeon iGPU | fail at compose-up |
| DGX Spark | aarch64 / Ubuntu / NVIDIA GB10 | fail at compose-up |
| Mac Mini | arm64 / macOS 26.2 / Apple M4 | fail at compose-up |

All four bombed identically. Patching the pin to v1.96.5 lets compose-up proceed.

## Follow-up (out of scope here)

A CI check that runs \`docker manifest inspect\` on every pinned image referenced by compose files would catch this class of regression pre-merge. Worth a separate PR; happy to draft if useful.

## Test plan

- [x] \`docker manifest inspect tailscale/tailscale:v1.96.5\` resolves (multi-arch: amd64/arm64/arm/v7)
- [ ] Reviewer: confirm Tailscale extension still starts with the new image (Tailscale's own changelog says \`TS_AUTHKEY\`, \`TS_USERSPACE\`, \`TS_STATE_DIR\` env vars unchanged across the 1.78 → 1.96 line)
- [ ] Reviewer: re-run \`make smoke\` to confirm no other surprises

🤖 Generated with [Claude Code](https://claude.com/claude-code)