### PR TITLE
fix(uninstall): chown INSTALL_DIR before rm so container-UID files clear

### DIFF
--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -152,6 +152,7 @@ fi
 
 # 5. Remove install directory (with optional data/model preservation)
 log_info "Removing installation directory..."
+INSTALL_DIR_CLEANED=true
 if $KEEP_MODELS && [[ -d "$INSTALL_DIR/data/models" ]]; then
     MODELS_BACKUP="$HOME/.dream-server-models-backup"
     mkdir -p "$MODELS_BACKUP"
@@ -179,13 +180,21 @@ else
     if command -v sudo >/dev/null 2>&1; then
         sudo chown -R "$(id -u):$(id -g)" "$INSTALL_DIR" 2>/dev/null || \
             log_warn "Could not chown $INSTALL_DIR (container-UID files may remain)"
+    else
+        log_warn "sudo not available; attempting non-privileged removal of $INSTALL_DIR"
     fi
-    rm -rf "$INSTALL_DIR"
+    rm -rf "$INSTALL_DIR" || \
+        log_warn "Could not fully remove $INSTALL_DIR"
     if [[ -d "$INSTALL_DIR" ]]; then
-        log_warn "Install dir still present at $INSTALL_DIR — likely container-UID files that need: sudo rm -rf $INSTALL_DIR"
+        INSTALL_DIR_CLEANED=false
+        log_warn "Install dir still present at $INSTALL_DIR - likely container-UID files that need: sudo rm -rf \"$INSTALL_DIR\""
     fi
 fi
-log_ok "Installation directory cleaned"
+if $INSTALL_DIR_CLEANED; then
+    log_ok "Installation directory cleaned"
+else
+    log_warn "Installation directory cleanup incomplete"
+fi
 
 # 6. Remove backup directory
 if [[ -d "$HOME/.dream-server" ]]; then

--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -160,11 +160,30 @@ if $KEEP_MODELS && [[ -d "$INSTALL_DIR/data/models" ]]; then
 fi
 
 if $KEEP_DATA; then
-    # Remove everything except data/
+    # Remove everything except data/. Container-UID files under data/ stay
+    # untouched (--keep-data implies preserving them anyway).
     find "$INSTALL_DIR" -mindepth 1 -maxdepth 1 ! -name 'data' -exec rm -rf {} + 2>/dev/null || true
     log_info "User data preserved at: $INSTALL_DIR/data/"
 else
+    # Containers (open-webui, qdrant, baserow, searxng, ...) write into
+    # $INSTALL_DIR/data/ as their own UIDs, not the host user's. Plain
+    # `rm -rf` then fails on every file with Permission denied and exits
+    # with $INSTALL_DIR still present — which silently turns "uninstall"
+    # into "uninstall everything but the install directory."
+    #
+    # Reclaim ownership before the rm. The installer itself does the same
+    # dance at `installers/phases/06-directories.sh` after picking up
+    # container-owned dirs from a prior run, so the pattern is already
+    # blessed for this codebase. If sudo is unavailable, fall back to a
+    # best-effort rm and let the operator see the failures explicitly.
+    if command -v sudo >/dev/null 2>&1; then
+        sudo chown -R "$(id -u):$(id -g)" "$INSTALL_DIR" 2>/dev/null || \
+            log_warn "Could not chown $INSTALL_DIR (container-UID files may remain)"
+    fi
     rm -rf "$INSTALL_DIR"
+    if [[ -d "$INSTALL_DIR" ]]; then
+        log_warn "Install dir still present at $INSTALL_DIR — likely container-UID files that need: sudo rm -rf $INSTALL_DIR"
+    fi
 fi
 log_ok "Installation directory cleaned"
 


### PR DESCRIPTION
## Summary

- `dream-uninstall.sh` ends with `rm -rf "$INSTALL_DIR"`. That fails on every file containerized services wrote as a non-host UID: open-webui's HuggingFace cache (huggingface user inside the image), qdrant's `aliases/data.json`, baserow's media + jwt signing key, searxng's `settings.yml`, etc.
- The current rm has no error gate, so the script exits success while `$INSTALL_DIR` is still on disk. A subsequent fresh install then hits Permission-denied at the first `rsync` and the user is stuck.
- Fix: `sudo chown -R \$(id -u):\$(id -g) "$INSTALL_DIR"` before the rm. If sudo isn't available or fails, fall through to the rm and `log_warn` the exact recovery command (`sudo rm -rf …`) so the operator isn't left guessing.

The chown pattern is already used by `installers/phases/06-directories.sh:48-56` at install time when picking up container-owned dirs from a prior run — this PR just mirrors it on the uninstall side so the round-trip is symmetric.

## Repro

Reproduced today on three different boxes during a fresh-install test (2026-05-12):

| Box | OS / arch | Leftover after uninstall |
|---|---|---|
| Tower2 | Ubuntu / x86_64 | open-webui HF cache + qdrant aliases |
| Strix Halo | Ubuntu / x86_64 (AMD) | open-webui HF cache + qdrant aliases |
| DGX Spark | Ubuntu / aarch64 | baserow media thumbnails + searxng config |

Each emitted hundreds of \`rm: cannot remove '...': Permission denied\` lines, then exited 0. The Permission-denied output spam itself is also confusing because the script claims \"Installation directory cleaned\" at the end.

## Test plan

- [x] Syntax: \`bash -n dream-uninstall.sh\`
- [ ] Reviewer: install via \`install.sh --all --non-interactive\` on a box with passwordless sudo, then \`./dream-uninstall.sh --force\`. \`$INSTALL_DIR\` should be gone with no Permission-denied output.
- [ ] Reviewer: same on a box WITHOUT passwordless sudo. Expected: chown step prints \`log_warn\`, rm runs anyway, final \`log_warn\` lists the recovery command.

## Out of scope

The same chown-then-rm pattern probably wants to apply to \`\$HOME/.dream-server\` backup cleanup further down (line 174), but that dir is created by the host user and shouldn't have UID-mismatched files in practice. Holding off until/unless we see it bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)