### PR TITLE
fix(installer/macos): skip port 0 in preflight conflict check

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -293,7 +293,12 @@ _conflict_ports=(8080 11434)  # llama-server (native) + Ollama default (host con
 for _manifest in "${SOURCE_ROOT}/extensions/services/"*/manifest.yaml; do
     [[ -f "$_manifest" ]] || continue
     _port=$(grep 'external_port_default:' "$_manifest" 2>/dev/null | awk '{print $2}' | tr -d '"') || true
-    if [[ -n "$_port" && "$_port" =~ ^[0-9]+$ && "$_port" -ne 8080 ]]; then
+    # Skip port 0 — used by internal-only services (e.g. hermes is gated
+    # behind hermes-proxy and exposes nothing) as a "no external port"
+    # sentinel. Passing 0 to check_port_conflict trips lsof rows where the
+    # local-port column reads 0 (identityservicesd does this on macOS) and
+    # produces a confusing "Port 0 is in use" warning.
+    if [[ -n "$_port" && "$_port" =~ ^[0-9]+$ && "$_port" -gt 0 && "$_port" -ne 8080 ]]; then
         _conflict_ports+=("$_port")
     fi
 done


### PR DESCRIPTION
## Summary

`installers/macos/install-macos.sh:291-298` builds its port-conflict check list dynamically from every extension's \`external_port_default:\` field. Internal-only services set this to 0 as a sentinel — most prominently \`extensions/services/hermes/manifest.yaml\` (hermes is gated behind hermes-proxy and exposes nothing on the host). The current guard accepts 0 because the regex \`^[0-9]+$\` matches it, so \`check_port_conflict 0\` runs, lsof returns rows where the local-port column reads 0 (\`identityservicesd\` does this for some Mach sockets), and the user sees:

\`\`\`
[!!] Port 0 is in use by /System/Library/PrivateFrameworks/IDS.framework/identityservicesd.app/Contents/MacOS/identityservicesd (PID 910)
\`\`\`

Install continues — it's a warning — but it shows up on every fresh macOS install and looks like a real conflict the user has to chase. This PR adds \`-gt 0\` to the guard so internal-only ports are skipped.

## Repro

Mac Mini M4 / macOS 26.2 / fresh clone + \`./install.sh --all --non-interactive\` (2026-05-12). Preflight emitted the line above for every install attempt.

## Test plan

- [x] \`bash -n install-macos.sh\` syntactic
- [ ] Reviewer: install on a Mac and confirm preflight no longer warns about port 0
- [ ] Reviewer: confirm real conflicts (e.g. an external_port_default like 5678 already in use by another process) still warn as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)