### PR TITLE
fix(installer/macos): accept any docker daemon, strip stale credsStore

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -198,20 +198,53 @@ info_box "Chip:" "${APPLE_CHIP}"
 info_box "Variant:" "${APPLE_CHIP_VARIANT}"
 ai_ok "Apple Silicon detected"
 
-# Docker Desktop
+# Docker engine (Docker Desktop, Colima, Rancher Desktop, OrbStack, or a
+# forwarded socket are all acceptable — see lib/detection.sh).
 test_docker_desktop
 if ! $DOCKER_INSTALLED; then
-    ai_err "Docker Desktop not found. Install from https://docs.docker.com/desktop/install/mac-install/"
+    ai_err "Docker engine not found (no \`docker\` CLI on PATH)."
+    ai_err "Pick one and install:"
+    ai_err "  - Docker Desktop:  https://docs.docker.com/desktop/install/mac-install/"
+    ai_err "  - Colima (CLI):    brew install colima docker docker-compose && colima start"
+    ai_err "  - Rancher Desktop: https://rancherdesktop.io"
+    ai_err "  - OrbStack:        https://orbstack.dev"
     exit 1
 fi
 ai_ok "Docker CLI found"
 
 if ! $DOCKER_RUNNING; then
-    ai_err "Docker Desktop is not running."
-    ai "Start it from the Applications folder or menu bar, then re-run this installer."
+    ai_err "Docker daemon is not responding."
+    case "${DOCKER_BACKEND:-unknown}" in
+        desktop)  ai "Start Docker Desktop from /Applications or the menu bar, then re-run this installer." ;;
+        colima)   ai "Run \`colima start\` (e.g. \`colima start --cpu 6 --memory 12 --disk 60\`) then re-run this installer." ;;
+        rancher)  ai "Open Rancher Desktop and wait for the daemon to come up, then re-run this installer." ;;
+        orbstack) ai "Open OrbStack and wait for the daemon to come up, then re-run this installer." ;;
+        *)        ai "Start your docker daemon (Docker Desktop, Colima, Rancher Desktop, OrbStack, ...) and re-run this installer." ;;
+    esac
     exit 1
 fi
-ai_ok "Docker Desktop running (v${DOCKER_VERSION})"
+ai_ok "Docker daemon ready (v${DOCKER_VERSION}, backend=${DOCKER_BACKEND:-unknown})"
+
+# Catch a common Colima-after-DockerDesktop config bomb: when a prior
+# Docker Desktop install left `"credsStore": "desktop"` in ~/.docker/config.json
+# and the user has since moved to Colima/Rancher/OrbStack, every `docker
+# compose pull` and `docker compose up` will crash with `error getting
+# credentials - err: exec: "docker-credential-desktop": executable file not
+# found in $PATH`. We strip the stale entry rather than failing the
+# install, because the helper is only meaningful with Docker Desktop.
+if [[ "${DOCKER_BACKEND:-unknown}" != "desktop" ]] && test_stale_docker_creds_store; then
+    ai_warn "Found stale \`credsStore: desktop\` in ~/.docker/config.json — incompatible with backend=${DOCKER_BACKEND:-unknown}."
+    if command -v python3 >/dev/null 2>&1; then
+        python3 -c 'import json,sys,os
+p=os.path.expanduser("~/.docker/config.json")
+d=json.load(open(p))
+d.pop("credsStore",None)
+json.dump(d, open(p,"w"), indent=2)' && ai_ok "Stripped credsStore=desktop from ~/.docker/config.json"
+    else
+        ai_err "python3 not available — please remove the \`credsStore\` line from ~/.docker/config.json manually."
+        exit 1
+    fi
+fi
 
 # Filesystem POSIX-permission check
 # The .env file (chmod 600) lives at INSTALL_DIR; a non-POSIX FS makes that

--- a/dream-server/installers/macos/lib/detection.sh
+++ b/dream-server/installers/macos/lib/detection.sh
@@ -85,12 +85,20 @@ get_macos_version() {
     esac
 }
 
-# ── Docker Desktop ──
+# ── Docker engine detection ──
+#
+# Despite the legacy function name, this only requires a working docker
+# CLI talking to a working daemon — Docker Desktop is one option, but
+# Colima, Rancher Desktop, OrbStack, and a docker socket forwarded from
+# a Linux VM all satisfy the install's actual needs (the install
+# interacts with `docker info`, `docker compose`, image pulls, bind
+# mounts — all of which are daemon-agnostic).
 
 test_docker_desktop() {
     DOCKER_INSTALLED=false
     DOCKER_RUNNING=false
     DOCKER_VERSION=""
+    DOCKER_BACKEND="unknown"  # "desktop" | "colima" | "rancher" | "orbstack" | "other"
 
     # Check if docker CLI is available
     if ! command -v docker >/dev/null 2>&1; then
@@ -102,7 +110,34 @@ test_docker_desktop() {
     if docker version >/dev/null 2>&1; then
         DOCKER_RUNNING=true
         DOCKER_VERSION=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "unknown")
+
+        # Identify the backend so downstream messages can be specific.
+        # `docker context inspect` exposes the active context's endpoint,
+        # which is the most reliable signal across all backends.
+        local _ep
+        _ep=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
+        case "$_ep" in
+            *com.docker.docker*|*docker-desktop*) DOCKER_BACKEND="desktop" ;;
+            *colima*)                              DOCKER_BACKEND="colima" ;;
+            *rancher-desktop*|*rd-sock*)           DOCKER_BACKEND="rancher" ;;
+            *orbstack*)                            DOCKER_BACKEND="orbstack" ;;
+            *)                                     DOCKER_BACKEND="other" ;;
+        esac
     fi
+}
+
+# Detect a stale `credsStore: desktop` config (left by `brew install docker`
+# or by a prior Docker Desktop install). Under any non-Desktop backend, this
+# entry causes `docker compose up` to crash with
+#   error getting credentials - err: exec: "docker-credential-desktop":
+#   executable file not found in $PATH
+# Returns 0 if the config has the bad entry AND the helper binary is missing.
+test_stale_docker_creds_store() {
+    local cfg="$HOME/.docker/config.json"
+    [[ -f "$cfg" ]] || return 1
+    grep -q '"credsStore"[[:space:]]*:[[:space:]]*"desktop"' "$cfg" || return 1
+    command -v docker-credential-desktop >/dev/null 2>&1 && return 1
+    return 0
 }
 
 get_host_logical_cpus() {

--- a/dream-server/installers/macos/lib/detection.sh
+++ b/dream-server/installers/macos/lib/detection.sh
@@ -106,23 +106,28 @@ test_docker_desktop() {
     fi
     DOCKER_INSTALLED=true
 
+    # Identify the backend before probing the daemon so a stopped engine can
+    # still get backend-specific startup guidance.
+    local _ctx _ep _backend_hint
+    _ctx=$(docker context show 2>/dev/null || true)
+    if [[ -n "$_ctx" ]]; then
+        _ep=$(docker context inspect "$_ctx" --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
+    else
+        _ep=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
+    fi
+    _backend_hint="${_ctx} ${_ep}"
+    case "$_backend_hint" in
+        *com.docker.docker*|*docker-desktop*|*desktop-linux*) DOCKER_BACKEND="desktop" ;;
+        *colima*)                                             DOCKER_BACKEND="colima" ;;
+        *rancher-desktop*|*rd-sock*)                          DOCKER_BACKEND="rancher" ;;
+        *orbstack*)                                           DOCKER_BACKEND="orbstack" ;;
+        *)                                                    DOCKER_BACKEND="other" ;;
+    esac
+
     # Check if Docker daemon is responsive
     if docker version >/dev/null 2>&1; then
         DOCKER_RUNNING=true
         DOCKER_VERSION=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "unknown")
-
-        # Identify the backend so downstream messages can be specific.
-        # `docker context inspect` exposes the active context's endpoint,
-        # which is the most reliable signal across all backends.
-        local _ep
-        _ep=$(docker context inspect --format '{{.Endpoints.docker.Host}}' 2>/dev/null || true)
-        case "$_ep" in
-            *com.docker.docker*|*docker-desktop*) DOCKER_BACKEND="desktop" ;;
-            *colima*)                              DOCKER_BACKEND="colima" ;;
-            *rancher-desktop*|*rd-sock*)           DOCKER_BACKEND="rancher" ;;
-            *orbstack*)                            DOCKER_BACKEND="orbstack" ;;
-            *)                                     DOCKER_BACKEND="other" ;;
-        esac
     fi
 }
 


### PR DESCRIPTION
## Summary

Two related fresh-Mac install bugs, fixed together because they share the same root assumption (\"only Docker Desktop is supported\").

### Bug 1: \"Docker Desktop not found\" rejects valid setups

\`installers/macos/install-macos.sh:201-214\` rejects with a Docker-Desktop-only URL hint when the actual preflight check is just \`docker version\` against whatever daemon is up. Colima, Rancher Desktop, OrbStack, and a forwarded socket all pass that check today — but the error message strands users who have a perfectly working CLI-only Colima setup.

### Bug 2: Stale \`credsStore: desktop\` crashes compose-up under Colima

\`brew install docker\` (the CLI formula, not the cask) creates \`~/.docker/config.json\` with \`\"credsStore\": \"desktop\"\` — a Docker-Desktop-flavoured default. If the user is on Colima (which doesn't ship \`docker-credential-desktop\`), \`docker compose up\` immediately bombs:

\`\`\`
error getting credentials - err: exec: \"docker-credential-desktop\":
executable file not found in \$PATH
[XX] docker compose up failed
\`\`\`

### What this PR does

- **Detects the docker backend** (Desktop / Colima / Rancher / OrbStack / other) from \`docker context inspect\` and stashes it in \`\$DOCKER_BACKEND\`.
- **Per-backend daemon-not-running guidance**: \`colima start ...\` for Colima, \"open Applications\" for Desktop, etc.
- **Better \"engine not found\" message**: lists all four common engines with one-line install commands instead of pointing only at Docker Desktop.
- **Auto-strips stale credsStore=desktop** under non-Desktop backends when \`docker-credential-desktop\` is not on PATH. Operators see a single \`ai_warn\` line instead of a cryptic compose-up failure two phases later.

## Repro

Fresh Mac Mini M4 / macOS 26.2 / no prior Docker / no Homebrew:

\`\`\`bash
# bootstrap (out of scope here, but documents the real flow)
/bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"
brew install colima docker docker-compose
colima start

# install
git clone https://github.com/Light-Heart-Labs/DreamServer && cd DreamServer
./install.sh --all --non-interactive
\`\`\`

**Before**:
- Phase 1: \"Docker Desktop not found\" (even though \`docker info\` works fine).
- After hand-installing Docker Desktop: \"Docker Desktop is not running\" (still wrong msg if you opened Colima instead).
- After getting daemon up: \"error getting credentials\" at Phase 5 compose-up.

**After**:
- Phase 1: \`Docker daemon ready (v..., backend=colima)\`.
- Stale credsStore stripped with one \`ai_warn\` line.
- Phase 5 reaches the actual compose-up.

## Out of scope

- Auto-installing a docker backend (was tempted, but \`brew install --cask docker\` triggers macOS GUI flow, and Colima needs its own startup decision — would rather guide than guess).
- Documenting this in installers/macos/README.md (separate doc PR).

## Test plan

- [x] \`bash -n\` on both modified files
- [ ] Reviewer: \`./install.sh --all --non-interactive\` on a Mac with Colima only (no Docker Desktop). Should pass preflight and proceed to compose-up.
- [ ] Reviewer: same on a Mac with Docker Desktop installed but not running. Should print the Desktop-specific guidance.
- [ ] Reviewer: same on a Mac with both engines installed. Active context wins (\`docker context use\` honored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)