### PR TITLE
fix(mdns): pip --user fallback when distro python3-zeroconf install fails

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -369,8 +369,10 @@ if [[ -f "$INSTALL_DIR/bin/dream-mdns.py" ]] && [[ "$(uname -s)" == "Linux" ]]; 
     }
     if ! python3 -c "import zeroconf" 2>/dev/null; then
         ai "Installing python3-zeroconf (for mDNS announcer)..."
-        if ! _install_zeroconf_via_pkg && python3 -c "import zeroconf" 2>/dev/null; then
-            : # pkg manager succeeded
+        if _install_zeroconf_via_pkg && python3 -c "import zeroconf" 2>/dev/null; then
+            ai_ok "Installed python3-zeroconf via $PKG_MANAGER"
+        elif python3 -c "import zeroconf" 2>/dev/null; then
+            : # Package manager returned non-zero, but the module is importable.
         elif _install_zeroconf_via_pip && python3 -c "import zeroconf" 2>/dev/null; then
             ai_ok "Installed zeroconf via pip --user (system package manager unavailable / failed)"
         else

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -338,19 +338,44 @@ if [[ -f "$INSTALL_DIR/bin/dream-mdns.py" ]] && [[ "$(uname -s)" == "Linux" ]]; 
     # Install python3-zeroconf via the system package manager. Non-fatal —
     # mDNS is a quality-of-life feature; if zeroconf isn't available the
     # device is still reachable by IP.
+    #
+    # Two-tier strategy:
+    #   1. Try the distro package manager first (best: integrates with apt
+    #      upgrades, doesn't require pip / network in offline mode).
+    #   2. Fall back to `pip install --user zeroconf` if the package isn't
+    #      in the distro's repos (e.g. minimal images, stale apt cache,
+    #      Ubuntu universe disabled) — without this, the install logs a
+    #      warning and the mDNS announcer never starts even though the
+    #      Python module is one pip away.
+    _install_zeroconf_via_pkg() {
+        case "$PKG_MANAGER" in
+            apt)    sudo apt-get install -y python3-zeroconf 2>&1 | tee -a "$LOG_FILE" ;;
+            dnf)    sudo dnf install -y python3-zeroconf 2>&1 | tee -a "$LOG_FILE" ;;
+            pacman) sudo pacman -S --noconfirm --needed python-zeroconf 2>&1 | tee -a "$LOG_FILE" ;;
+            zypper) sudo zypper --non-interactive install python3-zeroconf 2>&1 | tee -a "$LOG_FILE" ;;
+            *)      return 99 ;;
+        esac
+    }
+    _install_zeroconf_via_pip() {
+        # `--user` writes into ~/.local/lib/python3.x/site-packages so we
+        # don't need sudo and don't fight PEP 668 (Debian/Ubuntu mark the
+        # system site-packages as externally-managed). The mDNS announcer
+        # runs as $USER, not root, so --user is the right install scope.
+        if command -v pip3 >/dev/null 2>&1; then
+            pip3 install --user --quiet --no-warn-script-location zeroconf 2>&1 | tee -a "$LOG_FILE"
+        else
+            return 99
+        fi
+    }
     if ! python3 -c "import zeroconf" 2>/dev/null; then
         ai "Installing python3-zeroconf (for mDNS announcer)..."
-        case "$PKG_MANAGER" in
-            apt)    sudo apt-get install -y python3-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
-                        ai_warn "Failed to install python3-zeroconf via apt (non-fatal — mDNS announcer will not start)" ;;
-            dnf)    sudo dnf install -y python3-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
-                        ai_warn "Failed to install python3-zeroconf via dnf (non-fatal — mDNS announcer will not start)" ;;
-            pacman) sudo pacman -S --noconfirm --needed python-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
-                        ai_warn "Failed to install python-zeroconf via pacman (non-fatal — mDNS announcer will not start)" ;;
-            zypper) sudo zypper --non-interactive install python3-zeroconf 2>&1 | tee -a "$LOG_FILE" || \
-                        ai_warn "Failed to install python3-zeroconf via zypper (non-fatal — mDNS announcer will not start)" ;;
-            *)      ai_warn "Unknown package manager — install python3-zeroconf manually for mDNS" ;;
-        esac
+        if ! _install_zeroconf_via_pkg && python3 -c "import zeroconf" 2>/dev/null; then
+            : # pkg manager succeeded
+        elif _install_zeroconf_via_pip && python3 -c "import zeroconf" 2>/dev/null; then
+            ai_ok "Installed zeroconf via pip --user (system package manager unavailable / failed)"
+        else
+            ai_warn "Failed to install zeroconf via $PKG_MANAGER AND pip --user — mDNS announcer will not start (non-fatal; device still reachable by IP)"
+        fi
     fi
 
     # Install the systemd unit alongside dream-host-agent. Reuses the same


### PR DESCRIPTION
## Summary

\`installers/phases/07-devtools.sh:344-353\` tries to install \`python3-zeroconf\` via the system package manager and gives up if it fails. Hit this on Tower2 today (Ubuntu 24.04 with a stale apt cache from a fresh install):

\`\`\`
⚠ Failed to install python3-zeroconf via apt (non-fatal — mDNS announcer will not start)
\`\`\`

The package IS installable via pip though (\`pip3 install --user zeroconf\` works on the same box), and Python is already on the system. Today's logic gives up too early.

## Fix

Two-tier fallback:
1. Try the distro package manager first (preferred — integrates with system upgrades, works offline).
2. If that fails AND \`import zeroconf\` still doesn't work, try \`pip3 install --user zeroconf\`.

\`--user\` writes to \`~/.local/lib/python3.x/site-packages\` so we don't need sudo and don't trip PEP 668 (Debian/Ubuntu \`externally-managed-environment\`). The mDNS announcer runs as the host user (not root), so \`--user\` is the right scope.

The \"mDNS announcer will not start\" warning still fires when BOTH strategies fail — e.g. truly offline installs with no apt cache + no network.

## Repro

Tower2 (Ubuntu 24.04, fresh install today) emitted the warning on first run. After this PR's logic: pip fallback would have succeeded silently.

## Test plan

- [x] \`bash -n\` on the modified phase
- [ ] Reviewer: simulate apt failure (\`sudo mv /etc/apt/sources.list.d/* /tmp/ && sudo apt update\`) then run phase 07 — should fall through to pip and announce success
- [ ] Reviewer: confirm mDNS announcer systemd unit starts cleanly using the pip-installed module

🤖 Generated with [Claude Code](https://claude.com/claude-code)