### PR TITLE
fix(installer/macos): tell users the full bash 4+ bootstrap, not half

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -34,9 +34,20 @@ if [ "${BASH_VERSINFO[0]:-0}" -lt 4 ]; then
   done
   if ! command -v brew >/dev/null 2>&1; then
     echo "DreamServer requires Bash 4+ (you have ${BASH_VERSION})." >&2
-    echo "Install Homebrew first:" >&2
-    echo "  /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"" >&2
-    echo "Then re-run this installer." >&2
+    echo "macOS ships only Bash 3.2 — the last GPLv2 release Apple was willing to bundle." >&2
+    echo >&2
+    echo "Two-step bootstrap (one-time):" >&2
+    echo >&2
+    echo "  1. Install Homebrew. Requires an admin password and ~3 min:" >&2
+    echo "       /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"" >&2
+    echo >&2
+    echo "  2. Re-run this installer. It will detect Homebrew, run \`brew install bash\` for you, and proceed." >&2
+    echo >&2
+    echo "If \`brew install\` later complains \"Need sudo access on macOS\" under --non-interactive," >&2
+    echo "Homebrew is asking for passwordless sudo. Workaround:" >&2
+    echo "  echo \"\$USER ALL=(ALL) NOPASSWD: ALL\" | sudo tee /etc/sudoers.d/99-dream-install >/dev/null" >&2
+    echo "  sudo chmod 440 /etc/sudoers.d/99-dream-install" >&2
+    echo "(remove the file after install if you'd rather not keep passwordless sudo.)" >&2
     exit 1
   fi
   echo "Installing Bash 4+ via Homebrew (one-time setup)..."


### PR DESCRIPTION
## Summary

Today's bash-4+ guard message stops at \"Install Homebrew first... Then re-run this installer.\" It's literally correct — the installer's re-run auto-runs \`brew install bash\` — but a first-time user has no way to know that. They install Homebrew, re-run, and have no idea why it's now grinding through brew operations they didn't ask for.

Worse, they often hit a **second wall**: Homebrew's \`NONINTERACTIVE=1\` mode requires passwordless sudo. \`sudo -n -v\` is the check; it returns exit 1 even when the user is in the admin group, so the operator sees:

\`\`\`
==> Checking for \`sudo\` access (which may request your password)...
Need sudo access on macOS (e.g. the user michaelbradley needs to be an Administrator)!
\`\`\`

…which is misleading (the user *is* an Administrator). Today's installer says nothing about this.

## What this PR changes

Pure message change in the bash-version guard. New text:

\`\`\`
DreamServer requires Bash 4+ (you have 3.2.57(1)-release).
macOS ships only Bash 3.2 — the last GPLv2 release Apple was willing to bundle.

Two-step bootstrap (one-time):

  1. Install Homebrew. Requires an admin password and ~3 min:
       /bin/bash -c \"\$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"

  2. Re-run this installer. It will detect Homebrew, run \`brew install bash\` for you, and proceed.

If \`brew install\` later complains \"Need sudo access on macOS\" under --non-interactive,
Homebrew is asking for passwordless sudo. Workaround:
  echo \"\$USER ALL=(ALL) NOPASSWD: ALL\" | sudo tee /etc/sudoers.d/99-dream-install >/dev/null
  sudo chmod 440 /etc/sudoers.d/99-dream-install
(remove the file after install if you'd rather not keep passwordless sudo.)
\`\`\`

No code-flow changes; the existing two-pass logic (homebrew install on first run, brew install bash auto-handled on re-run) is unchanged.

## Repro

Fresh Mac Mini M4 / macOS 26.2 today. Hit wall 1 (\"install homebrew first\"), installed Homebrew, hit wall 2 (NONINTERACTIVE sudo). Operator with this message would have both fixes inline.

## Test plan

- [x] \`bash -n\` syntactic
- [ ] Reviewer: run on a stock macOS box without bash 4+. Read the message and verify the bootstrap path can be followed start-to-finish without external guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)