### PR TITLE
fix(installer/macos): reap orphan llama-server + advertise ComfyUI gap

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -226,26 +226,6 @@ mkdir -p "$(dirname "$DS_LOG_FILE")"
 show_dream_banner
 show_phase 1 6 "PREFLIGHT CHECKS" "30 seconds"
 
-# Reap orphan native llama-server processes from prior install runs.
-#
-# The Metal-backed `bin/llama-server` is spawned via launchctl in Phase 5.
-# Re-running the installer (debugging, version bump, switching models)
-# leaves the prior PID alive and listening on the same port — `lsof` then
-# shows multiple instances, only the first wins the bind, and the
-# debugging operator wastes time wondering why their config change didn't
-# take effect. Kill any process whose argv references THIS install dir's
-# `bin/llama-server`. Other native llama-server installs (e.g. a personal
-# one outside INSTALL_DIR) are left alone.
-_reaped=0
-if command -v pgrep >/dev/null 2>&1 && [[ -n "${INSTALL_DIR:-}" ]]; then
-    while read -r _pid; do
-        [[ -z "$_pid" ]] && continue
-        kill "$_pid" 2>/dev/null && _reaped=$((_reaped + 1))
-    done < <(pgrep -f "${INSTALL_DIR}/bin/llama-server" 2>/dev/null)
-    [[ "$_reaped" -gt 0 ]] && ai "Reaped $_reaped orphan llama-server process(es) from prior install run(s)."
-fi
-unset _reaped
-
 # macOS version
 get_macos_version
 info_box "macOS:" "${MACOS_NAME} ${MACOS_VERSION} (${MACOS_BUILD})"
@@ -861,6 +841,22 @@ else
                 sleep 2
             fi
         fi
+        # Reap orphan native llama-server processes from prior install runs.
+        # The PID file only tracks the most recent process, so model switches
+        # or interrupted installs can leave older copies shadowing the new
+        # config. Scope to this install dir so personal llama-server installs
+        # elsewhere are left alone, and do this only when we are about to start
+        # the replacement server so failed preflights do not take a working
+        # server down.
+        _reaped=0
+        if command -v pgrep >/dev/null 2>&1 && [[ -x "${LLAMA_SERVER_BIN:-}" ]]; then
+            while read -r _pid; do
+                [[ -z "$_pid" ]] && continue
+                kill "$_pid" 2>/dev/null && _reaped=$((_reaped + 1))
+            done < <(pgrep -f "$LLAMA_SERVER_BIN" 2>/dev/null)
+            [[ "$_reaped" -gt 0 ]] && ai "Reaped $_reaped orphan llama-server process(es) from prior install run(s)."
+        fi
+        unset _reaped
 
         # Read reasoning mode from .env (default off to prevent thinking models
         # from consuming the entire token budget on internal reasoning)

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -226,6 +226,26 @@ mkdir -p "$(dirname "$DS_LOG_FILE")"
 show_dream_banner
 show_phase 1 6 "PREFLIGHT CHECKS" "30 seconds"
 
+# Reap orphan native llama-server processes from prior install runs.
+#
+# The Metal-backed `bin/llama-server` is spawned via launchctl in Phase 5.
+# Re-running the installer (debugging, version bump, switching models)
+# leaves the prior PID alive and listening on the same port — `lsof` then
+# shows multiple instances, only the first wins the bind, and the
+# debugging operator wastes time wondering why their config change didn't
+# take effect. Kill any process whose argv references THIS install dir's
+# `bin/llama-server`. Other native llama-server installs (e.g. a personal
+# one outside INSTALL_DIR) are left alone.
+_reaped=0
+if command -v pgrep >/dev/null 2>&1 && [[ -n "${INSTALL_DIR:-}" ]]; then
+    while read -r _pid; do
+        [[ -z "$_pid" ]] && continue
+        kill "$_pid" 2>/dev/null && _reaped=$((_reaped + 1))
+    done < <(pgrep -f "${INSTALL_DIR}/bin/llama-server" 2>/dev/null)
+    [[ "$_reaped" -gt 0 ]] && ai "Reaped $_reaped orphan llama-server process(es) from prior install run(s)."
+fi
+unset _reaped
+
 # macOS version
 get_macos_version
 info_box "macOS:" "${MACOS_NAME} ${MACOS_VERSION} (${MACOS_BUILD})"
@@ -540,6 +560,12 @@ info_box "  RAG:" "$(if $ENABLE_RAG; then echo enabled; else echo disabled; fi)"
 info_box "  Hermes:" "$(if $ENABLE_HERMES; then echo enabled; else echo disabled; fi)"
 info_box "  OpenClaw:" "$(if $ENABLE_OPENCLAW; then echo "enabled (DEPRECATED)"; else echo disabled; fi)"
 info_box "  Langfuse:" "$(if $ENABLE_LANGFUSE; then echo enabled; else echo disabled; fi)"
+# The macOS installer doesn't currently ship a ComfyUI container — none of
+# the published ComfyUI images target Apple Silicon Metal, and the upstream
+# Python build under MPS is non-trivial to package as a Docker service.
+# Surface this to operators who passed --all so they aren't left wondering
+# why the dashboard shows no image-gen tile after install.
+info_box "  ComfyUI:" "not available on macOS (no MPS Docker image upstream)"
 
 if $ENABLE_VOICE && [[ -z "$_docker_cpu_override" ]] && [[ "${_docker_cpu_preflight_min:-0}" -lt 10 ]]; then
     _require_docker_cpu_budget 10 8 "voice-enabled compose stack"


### PR DESCRIPTION
## Summary

Two small UX wins for the macOS install path, both surfaced during today's fresh-install test on Mac Mini M4.

### 1. Reap orphan \`bin/llama-server\` processes (was Bug #15)

Native Metal llama-server is spawned via launchctl in Phase 5. Re-running the installer (debugging, model switch) leaves the prior PID alive on the same port. Today's box had three stacked PIDs from three earlier install runs:

\`\`\`
PID 1200  /Users/.../dream-server/bin/llama-server --port 8080 --model Qwen3.5-2B...
PID 15183 /Users/.../dream-server/bin/llama-server --port 8080 --model Qwen3.5-2B...
PID 32242 /Users/.../dream-server/bin/llama-server --port 8080 --model Qwen3.5-9B...
\`\`\`

Only the first wins the bind; the other two are zombies shadowing the operator's new configuration. Added a \`pgrep + kill\` pass in Phase 1 scoped to \`\${INSTALL_DIR}/bin/llama-server\` so unrelated personal llama-server installs are untouched.

### 2. Tell operators ComfyUI isn't available on macOS (was Bug #16)

\`grep -rn comfyui dream-server/installers/macos/\` returns zero hits — the macOS install codepath has no ComfyUI handling at all. Every other platform's \`--all\` ships image-gen; macOS silently doesn't, so operators wonder why their dashboard has no ComfyUI tile after the install banner says \"THE GATEWAY IS OPEN\".

Added an \`info_box\` line in the feature summary that surfaces the gap up front:

\`\`\`
ComfyUI: not available on macOS (no MPS Docker image upstream)
\`\`\`

Longer-term fix: package an MPS-backed ComfyUI as a service (or native install via brew). Out of scope for this PR — this just makes the gap visible.

## Test plan

- [x] \`bash -n\` syntactic
- [ ] Reviewer: \`./install.sh --all --non-interactive\` on a Mac with a stray native llama-server running under \$INSTALL_DIR — observe \"Reaped 1 orphan llama-server process(es) from prior install run(s).\" in Phase 1
- [ ] Reviewer: same install — observe ComfyUI gap line in the feature summary, no hidden behaviour

🤖 Generated with [Claude Code](https://claude.com/claude-code)