### PR TITLE
fix(installer): verify bootstrap model file + .env patch actually took effect

### DIFF
--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -186,7 +186,6 @@ else
                 dl_pid=$!
 
                 if spin_task $dl_pid "Downloading $GGUF_FILE"; then
-                    mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE"
                     # Verify the file actually landed before claiming success.
                     # Today's chain (spin_task → mv → printf) trusts each step's
                     # exit code separately and can race: mv can silently fail if
@@ -194,11 +193,12 @@ else
                     # another process can remove the file before the printf
                     # fires. A spurious "Model downloaded" line then misleads
                     # later phases that depend on the file existing.
-                    if [[ -s "$GGUF_DIR/$GGUF_FILE" ]]; then
+                    if mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE" && [[ -s "$GGUF_DIR/$GGUF_FILE" ]]; then
                         printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
                         _dl_success=true
                         break
                     else
+                        rm -f "$GGUF_DIR/$GGUF_FILE" 2>/dev/null || true
                         printf "\r  ${AMB}⚠${NC} %-60s\n" "Download claimed to succeed but $GGUF_FILE is missing/empty"
                     fi
                 fi
@@ -337,7 +337,7 @@ MODELS_INI_EOF
                         # contains awk-meta characters or the original
                         # line had trailing whitespace the regex didn't
                         # match). Re-read the file and assert.
-                        if grep -q "^${_key}=${_val}$" "$_env_file"; then
+                        if grep -Fqx "${_key}=${_val}" "$_env_file"; then
                             : # confirmed
                         else
                             _env_patch_ok=false

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -187,9 +187,20 @@ else
 
                 if spin_task $dl_pid "Downloading $GGUF_FILE"; then
                     mv "$GGUF_DIR/$GGUF_FILE.part" "$GGUF_DIR/$GGUF_FILE"
-                    printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
-                    _dl_success=true
-                    break
+                    # Verify the file actually landed before claiming success.
+                    # Today's chain (spin_task → mv → printf) trusts each step's
+                    # exit code separately and can race: mv can silently fail if
+                    # the target dir is read-only or .part was truncated, or
+                    # another process can remove the file before the printf
+                    # fires. A spurious "Model downloaded" line then misleads
+                    # later phases that depend on the file existing.
+                    if [[ -s "$GGUF_DIR/$GGUF_FILE" ]]; then
+                        printf "\r  ${BGRN}✓${NC} %-60s\n" "Model downloaded: $GGUF_FILE"
+                        _dl_success=true
+                        break
+                    else
+                        printf "\r  ${AMB}⚠${NC} %-60s\n" "Download claimed to succeed but $GGUF_FILE is missing/empty"
+                    fi
                 fi
                 printf "\r  ${AMB}⚠${NC} %-60s\n" "Download attempt $_attempt failed"
                 sleep 3
@@ -320,7 +331,18 @@ MODELS_INI_EOF
                         "$_env_file" > "${_env_file}.tmp" 2>>"$LOG_FILE" \
                         && cat "${_env_file}.tmp" > "$_env_file" 2>>"$LOG_FILE" \
                         && rm -f "${_env_file}.tmp"; then
-                        : # success
+                        # Verify the patch took effect — the awk-then-cat
+                        # chain can succeed bytewise while landing a line
+                        # that isn't what we asked for (e.g. when $_val
+                        # contains awk-meta characters or the original
+                        # line had trailing whitespace the regex didn't
+                        # match). Re-read the file and assert.
+                        if grep -q "^${_key}=${_val}$" "$_env_file"; then
+                            : # confirmed
+                        else
+                            _env_patch_ok=false
+                            warn "Patched $_key in .env, but verification re-read shows a different value (expected '$_val')"
+                        fi
                     else
                         _env_patch_ok=false
                         warn "Failed to patch $_key in .env"
@@ -328,6 +350,19 @@ MODELS_INI_EOF
                 done
                 if [[ "$_env_patch_ok" == "true" ]]; then
                     ai_ok "Patched .env for bootstrap model ($GGUF_FILE)"
+                fi
+            fi
+
+            # End-of-bootstrap-block sanity: refuse to leave Phase 11 with
+            # $LLM_MODEL pointing at a file that isn't on disk. Without this
+            # guard, compose-up brings up llama-server, which immediately
+            # crash-loops trying to open a missing GGUF, and the operator
+            # spends the next ~20 minutes watching the linker retry. Better
+            # to surface the missing file here, while there's still a clean
+            # recovery path (re-run the download, fix .env, then resume).
+            if [[ -n "${GGUF_DIR:-}" && -n "${GGUF_FILE:-}" ]]; then
+                if [[ ! -s "$GGUF_DIR/$GGUF_FILE" ]]; then
+                    warn "Bootstrap sanity: $GGUF_DIR/$GGUF_FILE missing or empty after Phase 11 — llama-server will crash-loop on compose-up. Investigate before proceeding."
                 fi
             fi
         fi


### PR DESCRIPTION
## Summary

Today's fresh-install test on DGX Spark (NV_ULTRA tier, aarch64) surfaced a silent corruption in the bootstrap fast-start path. Both success markers fired:

\`\`\`
✓ Model downloaded: Qwen3.5-2B-Q4_K_M.gguf
✓ Patched .env for bootstrap model (Qwen3.5-2B-Q4_K_M.gguf)
\`\`\`

…but by compose-up the bootstrap GGUF was gone from \`data/models/\` and \`.env\` had the FULL model values (\`qwen3-coder-next\`, still mid-download as \`.part\`). llama-server then crash-looped trying to load a non-existent file, Phase-6 linker burned its full ~8 min retry budget, and the install limped to completion with llama-server permanently broken.

Root cause is unclear (foreground download log shows 100%, the awk patch's pipeline exits 0). What's clear is that the install has zero state verification — both the download "✓" and the patch "✓" trust the intermediate exit codes and assume the filesystem reflects them.

## What this PR adds

Three cheap defensive checks. None change the success path; they catch silent corruption at phase boundaries.

1. **After \`mv "$GGUF_FILE.part" "$GGUF_FILE"\`** (line ~189), \`-s\` the destination before printing "Model downloaded". If the file isn't there, the loop falls into the retry path instead of pretending success.

2. **After each awk patch line** (line ~333), re-read \`.env\` and \`grep -q "^KEY=VALUE$"\`. If the re-read doesn't match, flag \`_env_patch_ok=false\` and warn. Catches the case where awk succeeded bytewise but landed something other than what we asked for (whitespace, awk-meta in value, etc.).

3. **End-of-Phase-11 sanity** (new): if the bootstrap block ran but \`$GGUF_DIR/$GGUF_FILE\` isn't on disk, emit a \`warn\` so the operator can investigate before Phase 12 health checks.

## Workaround on Spark today

\`\`\`bash
curl -fSL -o data/models/Qwen3.5-2B-Q4_K_M.gguf \\
  https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf
sed -i 's|^GGUF_FILE=.*|GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf|; s|^LLM_MODEL=.*|LLM_MODEL=qwen3.5-2b|' .env
docker compose up -d --force-recreate llama-server
# came up (healthy) in 25s
\`\`\`

## Test plan

- [x] \`bash -n\` syntactic
- [ ] Reviewer: dry-run an install where \`mv\` to data/models/ would fail (e.g. \`chmod -w data/models\` between phases) — should now retry rather than print "✓ Model downloaded".
- [ ] Reviewer: confirm the .env patch verification re-reads — temporarily corrupt the awk command to write a sentinel value, run install, confirm warn fires.

Out of scope: actually finding WHY the file disappears on Spark. The defensive checks here make it visible; the root-cause fix is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)