### PR TITLE
fix(installer): skip amd64-only extensions on aarch64 hosts

### DIFF
--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -7,12 +7,13 @@
 #
 # Expects: INTERACTIVE, DRY_RUN, TIER, ENABLE_VOICE, ENABLE_WORKFLOWS,
 #           ENABLE_RAG, ENABLE_HERMES, ENABLE_OPENCLAW, GPU_COUNT, GPU_BACKEND,
+#           HOST_ARCH,
 #           GPU_TOPOLOGY_JSON, LLM_MODEL_SIZE_MB, SCRIPT_DIR, VERBOSE, DEBUG,
 #           GPU_INDICES, GPU_UUIDS (arrays from topology),
 #           show_phase(), show_install_menu(), chapter(), bootline(),
 #           success(), log(), warn(), error(), signal()
-# Provides: ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG, ENABLE_HERMES,
-#           ENABLE_OPENCLAW, OPENCLAW_CONFIG, GPU_ASSIGNMENT_JSON,
+# Provides: ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG, ENABLE_EMBEDDINGS,
+#           ENABLE_HERMES, ENABLE_OPENCLAW, OPENCLAW_CONFIG, GPU_ASSIGNMENT_JSON,
 #           LLAMA_SERVER_GPU_UUIDS, WHISPER_GPU_UUID, COMFYUI_GPU_UUID,
 #           EMBEDDINGS_GPU_UUID, LLAMA_ARG_SPLIT_MODE, LLAMA_ARG_TENSOR_SPLIT
 #
@@ -127,12 +128,14 @@ _sync_extension_compose() {
 }
 
 if ! $DRY_RUN; then
+    ENABLE_EMBEDDINGS="${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}"
     _sync_extension_compose "${ENABLE_VOICE:-}"      whisper    "Whisper (STT)" "voice not enabled"
     _sync_extension_compose "${ENABLE_VOICE:-}"      tts        "Kokoro (TTS)"  "voice not enabled"
     _sync_extension_compose "${ENABLE_WORKFLOWS:-}"  n8n        "n8n"           "workflows not enabled"
     # RAG = qdrant (vector store) + embeddings (TEI). Both must follow
     # ENABLE_RAG, otherwise opting out leaves the embeddings container
-    # being pulled and started even though nothing queries it.
+    # being pulled and started even though nothing queries it. aarch64 Linux
+    # has a temporary TEI-only exception below while Qdrant remains enabled.
     _sync_extension_compose "${ENABLE_RAG:-}"        qdrant     "Qdrant"        "RAG not enabled"
     _sync_extension_compose "${ENABLE_RAG:-}"        embeddings "Embeddings (TEI)" "RAG not enabled"
     # Hermes is the default agent as of 2026-05-12. hermes-proxy is the
@@ -165,17 +168,20 @@ if ! $DRY_RUN; then
     # compose stack on aarch64 hosts. The other 25 services run cleanly on
     # arm64 and the operator gets a clear "not available on aarch64" line
     # rather than hours of crash-loop forensics.
-    if [[ "$(uname -m)" == "aarch64" ]]; then
+    _host_arch="${HOST_ARCH:-$(uname -m 2>/dev/null || echo unknown)}"
+    if [[ "$_host_arch" == "arm64" || "$_host_arch" == "aarch64" ]]; then
         if [[ "${ENABLE_DREAMFORGE:-true}" == "true" ]]; then
             ai_warn "DreamForge: upstream image is amd64-only — disabled on aarch64. Re-enable with: dream enable dreamforge (after upstream ships arm64 multi-arch)."
             _sync_extension_compose "false" dreamforge "DreamForge"        "amd64-only image, no arm64 multi-arch yet"
             ENABLE_DREAMFORGE=false
         fi
-        if [[ "${ENABLE_RAG:-true}" == "true" ]]; then
-            ai_warn "Embeddings (TEI): upstream image is amd64-only — disabled on aarch64. RAG search still works via Qdrant; only the embeddings router is skipped."
+        if [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]]; then
+            ai_warn "Embeddings (TEI): upstream image is amd64-only — disabled on aarch64. Qdrant remains enabled; only the embeddings router is skipped."
             _sync_extension_compose "false" embeddings "Embeddings (TEI)"  "amd64-only image, no arm64 multi-arch yet"
+            ENABLE_EMBEDDINGS=false
         fi
     fi
+    unset _host_arch
 fi
 
 # Re-resolve compose flags now that feature selection may have disabled services.

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -146,6 +146,36 @@ if ! $DRY_RUN; then
     _sync_extension_compose "${ENABLE_DREAMFORGE:-}" dreamforge "DreamForge"    "agent system not enabled"
     _sync_extension_compose "${ENABLE_LANGFUSE:-}"   langfuse   "Langfuse"      "LLM observability not enabled"
     _sync_extension_compose "${ENABLE_BRAVE_SEARCH:-false}" brave-search "Brave Search" "Brave Search API not enabled"
+
+    # ── arm64 / aarch64 platform guard ──
+    # Two extensions in the current --all bundle ship amd64-only binaries
+    # inside their images and crash-loop on aarch64 (DGX Spark, ARM SBCs,
+    # etc.) with `exec /usr/local/bin/...: exec format error`:
+    #
+    #   - dreamforge — upstream image has no arm64 variant. installers/lib
+    #     does set DREAMFORGE_PULL_POLICY=build to force a local Rust build,
+    #     but docker compose can still resolve to the registry image when
+    #     compose+buildkit version skew lets `pull_policy` be ignored.
+    #   - embeddings (HF text-embeddings-inference) — upstream tag
+    #     `cpu-1.9.1` is amd64-only. The compose file pins
+    #     `platform: linux/amd64`, which works under Rosetta 2 on Apple
+    #     Silicon but produces ENOEXEC on aarch64 Linux without QEMU.
+    #
+    # Until both upstreams ship multi-arch images, exclude these from the
+    # compose stack on aarch64 hosts. The other 25 services run cleanly on
+    # arm64 and the operator gets a clear "not available on aarch64" line
+    # rather than hours of crash-loop forensics.
+    if [[ "$(uname -m)" == "aarch64" ]]; then
+        if [[ "${ENABLE_DREAMFORGE:-true}" == "true" ]]; then
+            ai_warn "DreamForge: upstream image is amd64-only — disabled on aarch64. Re-enable with: dream enable dreamforge (after upstream ships arm64 multi-arch)."
+            _sync_extension_compose "false" dreamforge "DreamForge"        "amd64-only image, no arm64 multi-arch yet"
+            ENABLE_DREAMFORGE=false
+        fi
+        if [[ "${ENABLE_RAG:-true}" == "true" ]]; then
+            ai_warn "Embeddings (TEI): upstream image is amd64-only — disabled on aarch64. RAG search still works via Qdrant; only the embeddings router is skipped."
+            _sync_extension_compose "false" embeddings "Embeddings (TEI)"  "amd64-only image, no arm64 multi-arch yet"
+        fi
+    fi
 fi
 
 # Re-resolve compose flags now that feature selection may have disabled services.

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -6,7 +6,8 @@
 # Purpose: Build image pull list and download all Docker images
 #
 # Expects: DRY_RUN, GPU_BACKEND, ENABLE_VOICE, ENABLE_WORKFLOWS,
-#           ENABLE_RAG, ENABLE_HERMES, ENABLE_OPENCLAW, DOCKER_CMD, LOG_FILE, BGRN, AMB, NC,
+#           ENABLE_RAG, ENABLE_EMBEDDINGS, ENABLE_HERMES, ENABLE_OPENCLAW,
+#           DOCKER_CMD, LOG_FILE, BGRN, AMB, NC,
 #           show_phase(), bootline(), signal(), ai(), ai_ok(), ai_warn(),
 #           pull_with_progress()
 # Provides: (Docker images pulled locally)
@@ -53,7 +54,7 @@ if [[ "$ENABLE_HERMES" == "true" ]]; then
     PULL_LIST+=("caddy:2.8.4-alpine|HERMES PROXY — magic-link auth gate (Caddy)")
 fi
 [[ "$ENABLE_OPENCLAW" == "true" ]] && PULL_LIST+=("ghcr.io/openclaw/openclaw:2026.3.8|OPENCLAW — agent framework")
-[[ "$ENABLE_RAG" == "true" ]] && PULL_LIST+=("ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1|TEI — embedding engine")
+[[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]] && PULL_LIST+=("ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1|TEI — embedding engine")
 [[ "${ENABLE_DREAMFORGE:-}" == "true" ]] && PULL_LIST+=("ghcr.io/light-heart-labs/dreamforge:v0.1.0|DREAMFORGE — agent system")
 
 if $DRY_RUN; then

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -7,7 +7,8 @@
 #          pre-download STT model
 #
 # Expects: DRY_RUN, GPU_BACKEND, ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG,
-#           ENABLE_HERMES, ENABLE_OPENCLAW, LLM_MODEL, LOG_FILE, BGRN, AMB, NC,
+#           ENABLE_EMBEDDINGS, ENABLE_HERMES, ENABLE_OPENCLAW, LLM_MODEL,
+#           LOG_FILE, BGRN, AMB, NC,
 #           WHISPER_PORT, TTS_PORT, OPENCLAW_PORT,
 #           PERPLEXICA_PORT (:-3004), COMFYUI_PORT (:-8188),
 #           show_phase(), check_service(), ai(), ai_ok(), ai_warn(), signal()
@@ -41,6 +42,7 @@ if $DRY_RUN; then
     [[ "$ENABLE_VOICE" == "true" ]] && log "[DRY RUN]   - Whisper (STT), Kokoro (TTS), pre-download STT model"
     [[ "$ENABLE_WORKFLOWS" == "true" ]] && log "[DRY RUN]   - n8n"
     [[ "$ENABLE_RAG" == "true" ]] && log "[DRY RUN]   - Qdrant"
+    [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]] && log "[DRY RUN]   - Embeddings (TEI)"
     echo ""
     signal "All systems nominal. (dry run)"
     ai_ok "Sovereign intelligence is online. (dry run)"
@@ -120,7 +122,7 @@ if [[ "$ENABLE_COMFYUI" == "true" ]]; then
     _check_health "ComfyUI" "http://127.0.0.1:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 150 15 "$(sr_container comfyui)"
 fi
 # Embeddings (TEI): model load on first run can take 1-2 minutes after start_period
-if [[ "$ENABLE_RAG" == "true" ]]; then
+if [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]]; then
     dream_progress 94 "health" "Waiting for Embeddings"
     _check_health "embeddings" "http://127.0.0.1:${SERVICE_PORTS[embeddings]:-7860}${SERVICE_HEALTH[embeddings]:-/health}" 30 10 "$(sr_container embeddings)"
 fi


### PR DESCRIPTION
## Summary

DGX Spark (aarch64 / NVIDIA GB10) install today brought up 27 containers, of which two were in permanent restart loops:

\`\`\`
dream-dreamforge   Restarting (255) — exec /usr/local/bin/dreamforge-server: exec format error
dream-embeddings   Restarting (255) — exec /usr/local/bin/text-embeddings-router: exec format error
\`\`\`

Both upstream images are amd64-only:

- \`ghcr.io/light-heart-labs/dreamforge:v0.1.0\` — no arm64 in the registry manifest. \`installers/phases/02-detection.sh\` already sets \`DREAMFORGE_PULL_POLICY=build\` to force a local Rust build, but docker compose pulled the registry image on Spark anyway (compose+buildkit version skew making \`pull_policy\` ineffective, or local build silently falling back to the registry tag).
- \`ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1\` — no arm64 variant for this tag. The compose pins \`platform: linux/amd64\` (Rosetta 2 emulates fine on Apple Silicon), but Linux aarch64 without QEMU just gets ENOEXEC.

## What this PR does

In \`installers/phases/03-features.sh\`, after the existing \`_sync_extension_compose\` block, add an aarch64 guard that disables both services with a clear \`ai_warn\` explaining the upstream gap and how to re-enable (\`dream enable <svc>\`).

Result on aarch64:
- Stack comes up with 25 healthy services instead of 27-with-2-restart-loops.
- Operator sees the warning at install time rather than hours later in \`docker ps\`.
- amd64 / Apple Silicon paths are unchanged.

## Out of scope / follow-up

- Real fix needs upstream multi-arch images, or QEMU-as-a-prereq on aarch64 — filing separately.
- A \`docker manifest inspect\` preflight (same shape as #1177's CI suggestion) would catch this class for any future pinned image.

## Test plan

- [x] \`bash -n\` syntactic
- [ ] Reviewer: install on an aarch64 box. Confirm \`dream-dreamforge\` and \`dream-embeddings\` aren't in the running stack and the two \`ai_warn\` lines fire during phase 03.
- [ ] Reviewer: install on amd64 / Apple Silicon. Confirm no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)