### PR TITLE
fix(installer): pre-warm llama-server slot after health check (Hermes-first-call fix)

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -932,7 +932,8 @@ else
             # "this may take a minute" install context. Bounded by curl
             # --max-time so a stalled llama-server can't hang the install.
             _prewarm_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1/chat/completions"
-            _prewarm_body='{"messages":[{"role":"user","content":"hi"}],"max_tokens":1,"temperature":0,"stream":false}'
+            _prewarm_model="${GGUF_FILE:-default}"
+            _prewarm_body="{\"model\":\"${_prewarm_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}"
             if curl -sf --max-time 120 -X POST "$_prewarm_url" \
                 -H "Content-Type: application/json" \
                 -d "$_prewarm_body" >/dev/null 2>&1; then

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -921,6 +921,25 @@ else
 
         if $HEALTHY; then
             ai_ok "Native llama-server healthy (PID ${LLAMA_PID})"
+
+            # ── Pre-warm the LLM slot ──
+            # /health returning 200 only means the model is mmap'd. The
+            # FIRST chat completion still has to materialize KV cache and
+            # JIT compile fused kernels — during that, llama-server 503s
+            # concurrent requests. Hermes Agent's default 3-retry / 120s
+            # budget burns out on this on slower hardware, so we force
+            # the slot through cold path here while we're already in the
+            # "this may take a minute" install context. Bounded by curl
+            # --max-time so a stalled llama-server can't hang the install.
+            _prewarm_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1/chat/completions"
+            _prewarm_body='{"messages":[{"role":"user","content":"hi"}],"max_tokens":1,"temperature":0,"stream":false}'
+            if curl -sf --max-time 120 -X POST "$_prewarm_url" \
+                -H "Content-Type: application/json" \
+                -d "$_prewarm_body" >/dev/null 2>&1; then
+                ai_ok "LLM slot pre-warmed (first real chat will be fast)"
+            else
+                ai_warn "LLM pre-warm timed out — first Hermes prompt may need a retry while the slot warms."
+            fi
         else
             ai_warn "llama-server did not become healthy within ${MAX_WAIT}s. It may still be loading."
         fi

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -129,8 +129,14 @@ _check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-80
 # lands on an already-hot slot. Bounded by curl --max-time so a stalled
 # llama-server doesn't hang phase 12.
 dream_progress 87 "health" "Pre-warming LLM slot"
-_prewarm_url="http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}/v1/chat/completions"
-_prewarm_body='{"messages":[{"role":"user","content":"hi"}],"max_tokens":1,"temperature":0,"stream":false}'
+_prewarm_api_path="/v1"
+_prewarm_model="${GGUF_FILE:-${LLM_MODEL:-default}}"
+if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
+    _prewarm_api_path="/api/v1"
+    [[ -n "${GGUF_FILE:-}" ]] && _prewarm_model="extra.${GGUF_FILE}"
+fi
+_prewarm_url="http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${_prewarm_api_path}/chat/completions"
+_prewarm_body="{\"model\":\"${_prewarm_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}"
 if curl -sf --max-time 120 -X POST "$_prewarm_url" \
     -H "Content-Type: application/json" \
     -d "$_prewarm_body" >/dev/null 2>&1; then

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -110,6 +110,35 @@ _check_container_health() {
 # llama-server: 150 attempts * adaptive backoff (2s->8s) = up to ~20 minutes (model loading can be slow)
 dream_progress 86 "health" "Waiting for LLM engine"
 _check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15 "$(sr_container llama-server)"
+
+# ── Pre-warm the LLM slot so the first real chat doesn't 503 ──
+#
+# /health goes green once the model is mmap'd, but the FIRST chat
+# completion still materializes the KV cache, JIT-compiles fused kernels,
+# and processes any system prompt the caller injects. While that's in
+# flight, llama-server returns `HTTP 503: Loading model` to concurrent
+# requests — including from Hermes Agent, which sends a ~14k-token system
+# prompt and only retries 3 times within 120s. On big-model + single-GPU
+# boxes (DGX Spark with the 45 GB qwen3-coder-next, tested 2026-05-12),
+# that 14k prefill alone takes ~54s — fitting inside Hermes's first-call
+# window only by luck. Roll the dice the wrong way and Hermes 503s every
+# prompt for the rest of the install run.
+#
+# Pre-warming with a tiny dummy completion forces the slot through its
+# cold path inside the installer (where time isn't surprising) so Hermes
+# lands on an already-hot slot. Bounded by curl --max-time so a stalled
+# llama-server doesn't hang phase 12.
+dream_progress 87 "health" "Pre-warming LLM slot"
+_prewarm_url="http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}/v1/chat/completions"
+_prewarm_body='{"messages":[{"role":"user","content":"hi"}],"max_tokens":1,"temperature":0,"stream":false}'
+if curl -sf --max-time 120 -X POST "$_prewarm_url" \
+    -H "Content-Type: application/json" \
+    -d "$_prewarm_body" >/dev/null 2>&1; then
+    ai_ok "LLM slot pre-warmed (first real chat will be fast)"
+else
+    ai_warn "LLM pre-warm timed out — first Hermes prompt may need a retry or two while the slot finishes warming."
+fi
+
 # Open WebUI: 150 attempts * adaptive backoff = up to ~20 minutes
 dream_progress 89 "health" "Waiting for Chat UI"
 _check_health "Open WebUI" "http://127.0.0.1:${SERVICE_PORTS[open-webui]:-3000}${SERVICE_HEALTH[open-webui]:-/}" 150 10 "$(sr_container open-webui)"


### PR DESCRIPTION
## Summary

llama-server's \`/health\` returning 200 doesn't mean the slot can serve a chat completion — only that the model is mmap'd. The FIRST chat completion still has to materialize the KV cache, JIT compile fused kernels, and process whatever system prompt the caller sends. While that's in flight, llama-server returns \`HTTP 503: Loading model\` to concurrent requests.

Hermes Agent retries 3 times within 120s. That's fine on:
- Tower2 (2× Blackwell, small bootstrap model — slot warms in seconds)
- Strix Halo (Lemonade + 4B Q4 — slot warms in seconds)

It is **not** fine on:
- DGX Spark (single GB10, 45 GB qwen3-coder-next, 128K context — Hermes's 14,862-token system prompt prefill alone takes ~54s; first call 503s, retry collides with the same prefill that's now mid-flight, third retry too, give up).
- Apple Silicon with a 9B-class model on Metal first run.

Verified today: direct \`curl\` to llama-server after one warm-up call runs at 60 tok/s on Spark; Hermes's first \`-z\` invocation under the same conditions 503s and gives up.

## What this PR does

After llama-server's healthcheck goes green in phase 12 (Linux) or the launchctl wait loop (macOS), send one throwaway chat completion (\`max_tokens=1, temperature=0, prompt=\"hi\"\`) before returning to phase 13. Bounded by \`curl --max-time 120\` so a stalled llama-server can't hang the installer.

\`\`\`
  ✓ llama-server online
  ⠋ Pre-warming LLM slot ...
  ✓ LLM slot pre-warmed (first real chat will be fast)
\`\`\`

If the pre-warm itself times out, fail-warn (not -err) — the install still ships, the user just has to retry their first Hermes prompt.

## Cost

3-30s of installer wall time on most hardware, depending on model size + context. Net win on Spark is ~enormous: Hermes goes from "every prompt 503s" to "every prompt works on first try".

## Test plan

- [x] \`bash -n\` on both modified files
- [ ] Reviewer: fresh install on Spark (or any slow-cold-start LLM box). Confirm the pre-warm line fires post-health-check, and that \`hermes -z 'reply ALIVE' --yolo\` succeeds on first run.
- [ ] Reviewer: standard install on Tower2 (Linux NVIDIA). Confirm <5s overhead and no functional change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)