### PR TITLE
fix(bootstrap-upgrade): also patch Hermes config + restart Hermes

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -538,31 +538,53 @@ LITELLM_UPGRADE_EOF
         #   2. extensions/services/hermes/cli-config.yaml.template — the
         #      source Hermes copies into /opt/data on first start. Updating
         #      it keeps subsequent down-and-up cycles correct.
-        if $DOCKER_CMD ps --filter name=dream-hermes --format '{{.Names}}' 2>/dev/null | grep -q dream-hermes; then
-            # Lemonade prefixes the served model id with "extra."; llama.cpp
-            # serves under the bare file name. Mirror the same branch PR #1191
-            # added in installers/phases/11-services.sh.
-            _hermes_old_model="$BOOTSTRAP_GGUF_FILE"
-            _hermes_new_model="$FULL_GGUF_FILE"
-            _gpu_backend_for_hermes=$(grep -E '^GPU_BACKEND=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"\047\r' || echo "")
-            if [[ "$_gpu_backend_for_hermes" == "amd" ]]; then
-                _hermes_old_model="extra.$BOOTSTRAP_GGUF_FILE"
-                _hermes_new_model="extra.$FULL_GGUF_FILE"
+        # Lemonade prefixes the served model id with "extra."; llama.cpp
+        # serves under the bare file name. Mirror the same branch PR #1191
+        # added in installers/phases/11-services.sh.
+        _hermes_old_model="$BOOTSTRAP_GGUF_FILE"
+        _hermes_new_model="$FULL_GGUF_FILE"
+        _gpu_backend_for_hermes=$(grep -E '^GPU_BACKEND=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"\047\r' || echo "")
+        if [[ "$_gpu_backend_for_hermes" == "amd" ]]; then
+            _hermes_old_model="extra.$BOOTSTRAP_GGUF_FILE"
+            _hermes_new_model="extra.$FULL_GGUF_FILE"
+        fi
+        log "Patching Hermes config: model.default $_hermes_old_model -> $_hermes_new_model"
+
+        # Template on host (user-owned, no sudo needed). Patch this even when
+        # Hermes is stopped so future container creates do not copy the stale
+        # bootstrap model id.
+        _hermes_tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
+        if [[ -f "$_hermes_tpl" ]]; then
+            if sed -i.bak \
+                -e "s|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|" \
+                "$_hermes_tpl" 2>&1; then
+                rm -f "${_hermes_tpl}.bak"
+            else
+                log "WARNING: Could not patch ${_hermes_tpl} (non-fatal — operator can hand-edit before restarting Hermes)"
             fi
-            log "Patching Hermes config: model.default $_hermes_old_model -> $_hermes_new_model"
-            # Live config inside the container (owned by container UID).
+        fi
+
+        if $DOCKER_CMD ps --filter name=dream-hermes --format '{{.Names}}' 2>/dev/null | grep -q dream-hermes; then
+            # Live config inside the running container (owned by container UID).
             $DOCKER_CMD exec dream-hermes sh -c \
                 "sed -i 's|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|' /opt/data/config.yaml" 2>&1 || \
                 log "WARNING: Could not patch Hermes /opt/data/config.yaml (non-fatal — operator can hand-edit and 'docker restart dream-hermes')"
-            # Template on host (user-owned, no sudo needed).
-            _hermes_tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
-            if [[ -f "$_hermes_tpl" ]]; then
-                sed -i.bak \
-                    -e "s|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|" \
-                    "$_hermes_tpl" 2>&1 && rm -f "${_hermes_tpl}.bak"
-            fi
             log "Restarting Hermes to pick up model change..."
             $DOCKER_CMD restart dream-hermes 2>&1 || log "WARNING: Hermes restart failed (non-fatal — hand-restart with 'docker restart dream-hermes')"
+        else
+            # If Hermes is stopped, its persisted /opt/data mount may still
+            # exist on the host. Patch it when writable; otherwise the template
+            # update above still protects first-time/fresh data starts.
+            _hermes_live="$INSTALL_DIR/data/hermes/config.yaml"
+            if [[ -f "$_hermes_live" ]]; then
+                if sed -i.bak \
+                    -e "s|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|" \
+                    "$_hermes_live" 2>&1; then
+                    rm -f "${_hermes_live}.bak"
+                else
+                    log "WARNING: Could not patch ${_hermes_live} (non-fatal — operator can hand-edit and restart Hermes)"
+                fi
+            fi
         fi
         sync_windows_opencode_config
     else

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -517,6 +517,53 @@ LITELLM_UPGRADE_EOF
                 log "WARNING: No compose binary available (DOCKER_COMPOSE_CMD empty or compose args missing) — OpenClaw was NOT recreated. The new model will not take effect until OpenClaw is recreated manually with: docker compose up -d --force-recreate openclaw"
             fi
         fi
+        # Patch Hermes Agent's config so it stops asking the LLM server for the
+        # bootstrap model id. PR #1191 substitutes model.default in the template
+        # at install time, but at install time we've only loaded the bootstrap
+        # model (Qwen3.5-2B) — Hermes's /opt/data/config.yaml is therefore
+        # pinned to that name. Once this script swaps Lemonade/llama-server
+        # to the full model, Hermes keeps sending the stale bootstrap id and
+        # every chat completion 404s.
+        #
+        # This is hard-broken on AMD/Lemonade (which strictly validates the
+        # `model` field) and silently masked on NVIDIA/Apple (llama.cpp
+        # ignores the field and serves whatever's loaded), so the bug
+        # surfaces as "Hermes works on Tower2/Mac but every prompt 404s on
+        # Strix Halo" after a bootstrap-to-full swap.
+        #
+        # Two files to keep in sync:
+        #   1. /opt/data/config.yaml inside the container — the live config
+        #      Hermes reads at startup. Owned by container UID; patch via
+        #      `docker exec` so we don't need host sudo.
+        #   2. extensions/services/hermes/cli-config.yaml.template — the
+        #      source Hermes copies into /opt/data on first start. Updating
+        #      it keeps subsequent down-and-up cycles correct.
+        if $DOCKER_CMD ps --filter name=dream-hermes --format '{{.Names}}' 2>/dev/null | grep -q dream-hermes; then
+            # Lemonade prefixes the served model id with "extra."; llama.cpp
+            # serves under the bare file name. Mirror the same branch PR #1191
+            # added in installers/phases/11-services.sh.
+            _hermes_old_model="$BOOTSTRAP_GGUF_FILE"
+            _hermes_new_model="$FULL_GGUF_FILE"
+            _gpu_backend_for_hermes=$(grep -E '^GPU_BACKEND=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"\047\r' || echo "")
+            if [[ "$_gpu_backend_for_hermes" == "amd" ]]; then
+                _hermes_old_model="extra.$BOOTSTRAP_GGUF_FILE"
+                _hermes_new_model="extra.$FULL_GGUF_FILE"
+            fi
+            log "Patching Hermes config: model.default $_hermes_old_model -> $_hermes_new_model"
+            # Live config inside the container (owned by container UID).
+            $DOCKER_CMD exec dream-hermes sh -c \
+                "sed -i 's|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|' /opt/data/config.yaml" 2>&1 || \
+                log "WARNING: Could not patch Hermes /opt/data/config.yaml (non-fatal — operator can hand-edit and 'docker restart dream-hermes')"
+            # Template on host (user-owned, no sudo needed).
+            _hermes_tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
+            if [[ -f "$_hermes_tpl" ]]; then
+                sed -i.bak \
+                    -e "s|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|" \
+                    "$_hermes_tpl" 2>&1 && rm -f "${_hermes_tpl}.bak"
+            fi
+            log "Restarting Hermes to pick up model change..."
+            $DOCKER_CMD restart dream-hermes 2>&1 || log "WARNING: Hermes restart failed (non-fatal — hand-restart with 'docker restart dream-hermes')"
+        fi
         sync_windows_opencode_config
     else
         log "WARNING: llama-server health check timed out. The model may still be loading."


### PR DESCRIPTION
## Summary

After PR #1191, the install-time substitution writes the **bootstrap** model id (`Qwen3.5-2B-Q4_K_M.gguf`) into Hermes's `/opt/data/config.yaml` — that's what's loaded when phase 11 runs. When `scripts/bootstrap-upgrade.sh` later swaps the LLM server from bootstrap to the full model, Hermes is left pointing at a name the server no longer serves.

- **AMD/Lemonade**: strictly validates the `model` field → every Hermes chat completion 404s with `model_not_found`.
- **NVIDIA/Apple**: llama.cpp ignores the field and serves whatever's loaded → bug silently masked.

Symptom: a fresh Strix Halo install completes successfully, the LLM works end-to-end via curl with the right model name, but every prompt in the Hermes UI hangs or fails. Reproduced on Wave 2 fresh-clone install today.

## Fix

After the OpenClaw recreate (already in the swap path), patch the live config and template, then restart Hermes:

1. **Live config** — `/opt/data/config.yaml` inside `dream-hermes` is owned by the container UID. Patch via `docker exec sh -c 'sed -i …'` so we don't need host sudo.
2. **Host template** — `extensions/services/hermes/cli-config.yaml.template` (user-owned), so the template stays in sync for any future down/up cycle.
3. **Restart** — `docker restart dream-hermes` to pick up the new value.

Mirrors the `extra.` prefix branch PR #1191 already added in `installers/phases/11-services.sh`.

## Test plan

- [x] Reproduced on Strix Halo (AMD/Lemonade): bootstrap install → swap completes → `curl /v1/chat/completions` with stale Hermes model name returns `model_not_found`.
- [x] Manually patched `/opt/data/config.yaml` + restarted Hermes → `/api/model/info` shows new id, Hermes-shaped chat request returns `ALIVE`.
- [x] `make lint` passes.
- [ ] (CI) Linux + macOS smoke tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)