### PR TITLE
fix(bootstrap-upgrade): pre-warm full-model slot + Hermes system prompt

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -571,6 +571,67 @@ LITELLM_UPGRADE_EOF
                 log "WARNING: Could not patch Hermes /opt/data/config.yaml (non-fatal — operator can hand-edit and 'docker restart dream-hermes')"
             log "Restarting Hermes to pick up model change..."
             $DOCKER_CMD restart dream-hermes 2>&1 || log "WARNING: Hermes restart failed (non-fatal — hand-restart with 'docker restart dream-hermes')"
+
+            # Pre-warm the freshly-swapped LLM + Hermes's 14K-token system prompt.
+            #
+            # Two latency hits if we skip this:
+            #   1. llama-server / Lemonade loads the full model into VRAM on first
+            #      request (`--n-gpu-layers 999` is lazy). PR #1192 already warms
+            #      this at install time, but that warm-up was against the
+            #      bootstrap model — after the swap, the slot is cold again.
+            #   2. Hermes's runtime config bakes a 14K-token system prompt
+            #      (skills, soul, tool descriptors). First Hermes prompt has
+            #      to prefill all of it. Empirically 67s on Strix Halo,
+            #      1m25s on macOS, ~5s once cached. We've seen real users
+            #      think Hermes is broken because they alt-tabbed away during
+            #      a fresh install and the first prompt looked stuck.
+            #
+            # Mirrors PR #1192's pattern: best-effort, time-bounded, never fails
+            # the upgrade. If either warm-up times out the swap still succeeds —
+            # the user just eats the slow first call.
+            log "Pre-warming llama-server slot with full model..."
+            _prewarm_api_path="/v1"
+            _prewarm_model="$FULL_GGUF_FILE"
+            if [[ "$_gpu_backend_for_hermes" == "amd" ]]; then
+                _prewarm_api_path="/api/v1"
+                _prewarm_model="extra.$FULL_GGUF_FILE"
+            fi
+            _prewarm_body="{\"model\":\"${_prewarm_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}"
+            if $DOCKER_CMD exec dream-hermes curl -sf --max-time 120 -X POST \
+                "http://llama-server:8080${_prewarm_api_path}/chat/completions" \
+                -H "Content-Type: application/json" \
+                -d "$_prewarm_body" >/dev/null 2>&1; then
+                log "llama-server slot pre-warmed."
+            else
+                log "WARNING: llama-server pre-warm timed out — first Hermes prompt may be slow."
+            fi
+
+            # Wait for Hermes to come back up after the restart, then trigger
+            # one no-op invocation so the 14K system prompt gets into
+            # llama-server's KV cache. We cap at 90s total — long enough for
+            # Hermes's skills sync + config bootstrap (start_period: 60s in
+            # compose.yaml) plus a few decode tokens, short enough that a
+            # broken Hermes doesn't stall the script forever.
+            log "Pre-warming Hermes system prompt (caches 14K-token prefill)..."
+            _hermes_ready=false
+            for _i in $(seq 1 30); do
+                if $DOCKER_CMD exec dream-hermes curl -sf --max-time 3 http://127.0.0.1:9119/api/status >/dev/null 2>&1; then
+                    _hermes_ready=true
+                    break
+                fi
+                sleep 2
+            done
+            if $_hermes_ready; then
+                if $DOCKER_CMD exec dream-hermes timeout 90 \
+                    /opt/hermes/.venv/bin/hermes -z "ping" --yolo \
+                    >/dev/null 2>&1; then
+                    log "Hermes system prompt cached — first user prompt will be fast."
+                else
+                    log "WARNING: Hermes warm-up timed out (>90s). First user prompt will incur the full 14K-token prefill."
+                fi
+            else
+                log "WARNING: Hermes did not respond on /api/status within 60s; skipping system-prompt warm-up."
+            fi
         else
             # If Hermes is stopped, its persisted /opt/data mount may still
             # exist on the host. Patch it when writable; otherwise the template


### PR DESCRIPTION
## Summary

**Stacked on top of #1193 — please merge #1193 first.** After the swap restarts Hermes, two cold caches resurface and the first user-facing Hermes prompt hangs for 1-2 minutes:

1. **llama-server slot is cold.** PR #1192 already pre-warmed it during install — but that was against the *bootstrap* model. After the swap, the full model has to load into VRAM on first request (`--n-gpu-layers 999` is lazy).
2. **Hermes's 14K-token system prompt is uncached.** Skills + SOUL + tool descriptors. First prefill: 67s on Strix Halo, 1m25s on Mac Mini (Apple Silicon). ~5s once llama-server's KV cache has it.

Symptom in the wild: user alt-tabs away during background swap, comes back, types a message, response hangs — assumes Hermes is broken. Reproduced today on Mac + Strix during Wave 2 fresh-clone E2E.

## Fix

After the Hermes restart added by #1193, fire two best-effort warm-ups inside `bootstrap-upgrade.sh`:

- **llama-server**: one `curl -X POST /v1/chat/completions` with `max_tokens=1` to spin up the model slot. Mirrors PR #1192's install-time pattern, including the AMD `/api/v1` + `extra.` prefix branch.
- **Hermes system prompt**: wait up to 60s for `/api/status`, then run `hermes -z "ping" --yolo` (capped at 90s). The single invocation sends Hermes's real system prompt through to llama-server, which caches the 14K-token prefill.

Both are best-effort: if either times out, the swap still completes and the user pays the cold prefill on first prompt. They never fail the upgrade.

## Test plan

- [x] Manual verification on Tower2 (NVIDIA): swap completes, both warm-ups log success, subsequent `curl` round-trips at ~5s vs ~67s pre-fix.
- [x] `make lint` passes.
- [ ] (CI) Linux + macOS smoke tests.
- [ ] Future: revisit Spark cold-start latency once upstream llama.cpp / Blackwell-aarch64 issues are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)