### PR TITLE
fix(tier-map): substitute A3B MoE for coder-next on aarch64 NV_ULTRA

### DIFF
--- a/dream-server/config/model-library.json
+++ b/dream-server/config/model-library.json
@@ -257,6 +257,23 @@
       "llama_server_image": null
     },
     {
+      "id": "qwen3.6-35b-a3b-ud-q4",
+      "name": "Qwen 3.6 35B-A3B",
+      "family": "qwen",
+      "gguf_file": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+      "gguf_sha256": "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61",
+      "size_mb": 21110,
+      "vram_required_gb": 24,
+      "context_length": 131072,
+      "quantization": "UD-Q4_K_M",
+      "specialty": "Quality",
+      "description": "Current A3B MoE successor for Spark-class unified-memory hosts. Verified on DGX Spark with llama.cpp b9014.",
+      "tokens_per_sec_estimate": 59,
+      "llm_model_name": "qwen3.6-35b-a3b",
+      "llama_server_image": null
+    },
+    {
       "id": "deepseek-r1-70b-q4",
       "name": "DeepSeek R1 70B",
       "family": "deepseek",

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -2606,7 +2606,7 @@ cmd_model() {
             echo "  T4         — qwen3-30b-a3b (48GB+)"
             echo "  SH         — qwen3-30b-a3b (Strix Halo unified)"
             echo "  SH_LARGE   — qwen3-coder-next (90GB+ unified)"
-            echo "  NV_ULTRA   — qwen3-coder-next (90GB+ NVIDIA)"
+            echo "  NV_ULTRA   — qwen3-coder-next (amd64) / qwen3.6-35b-a3b (arm64 Spark)"
             echo ""
             echo "Usage: dream model swap <tier>"
             ;;

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -97,25 +97,24 @@ set_qwen_tier_config() {
             GGUF_SHA256="9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090"
             MAX_CONTEXT=131072
             LLM_MODEL_SIZE_MB=48500   # 48.5 GB per HF file listing
-            # NV_ULTRA on aarch64 (DGX Spark / GB10): the qwen3-coder-next MoE
-            # Q4_K_M GGUF produces all-`?` tokens on every chat completion.
-            # SHA256 verifies, llama-server starts cleanly, decode rate is
-            # normal — every output token is just a `?`. Reproducible via raw
-            # curl /v1/chat/completions, so it's a llama.cpp / Blackwell-
-            # aarch64 / MoE-Q4_K_M kernel issue, not a Dream Server bug.
-            # Dense Qwen3.5-2B (bootstrap) was healthy on the same hardware
-            # in the same session, so for now fall back to the dense
-            # Qwen3.5-9B until the upstream fix lands. This wastes ~115GB of
-            # unified memory but gives a working install on Spark; revisit
-            # when the llama.cpp/Blackwell-aarch64 build can run MoE Q4_K_M.
+            # NV_ULTRA on aarch64 (DGX Spark / GB10): qwen3-coder-next MoE
+            # Q4_K_M produces all-`?` tokens on every chat completion against
+            # llama.cpp b9014 on Blackwell-aarch64 (SHA256 verifies, server
+            # starts cleanly, decode rate is normal, but every token is `?`).
+            # Verified bug is coder-next-specific, not a general MoE kernel
+            # bug: Qwen3.5-35B-A3B-Q4_K_M serves cleanly on the same build,
+            # same hardware (~59 tok/s warm decode, coherent output).
+            # Until upstream fixes coder-next on this build, route Spark to
+            # the A3B MoE — same architectural fit (large total / small
+            # active params on unified memory).
             if [[ "${HOST_ARCH:-}" == "arm64" ]]; then
-                TIER_NAME="NVIDIA Ultra (90GB+, aarch64 — MoE workaround)"
-                LLM_MODEL="qwen3.5-9b"
-                GGUF_FILE="Qwen3.5-9B-Q4_K_M.gguf"
-                GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf"
-                GGUF_SHA256="03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8"
-                MAX_CONTEXT=32768
-                LLM_MODEL_SIZE_MB=5760
+                TIER_NAME="NVIDIA Ultra (90GB+, aarch64 — A3B substitution)"
+                LLM_MODEL="qwen3.5-35b-a3b"
+                GGUF_FILE="Qwen3.5-35B-A3B-Q4_K_M.gguf"
+                GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/Qwen3.5-35B-A3B-Q4_K_M.gguf"
+                GGUF_SHA256="3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375"
+                MAX_CONTEXT=131072
+                LLM_MODEL_SIZE_MB=22000
             fi
             ;;
         SH_LARGE)
@@ -352,7 +351,7 @@ tier_to_model() {
                 CLOUD)          model="anthropic/claude-sonnet-4-5-20250514" ;;
                 NV_ULTRA)
                     if [[ "${HOST_ARCH:-}" == "arm64" ]]; then
-                        model="qwen3.5-9b"
+                        model="qwen3.5-35b-a3b"
                     else
                         model="qwen3-coder-next"
                     fi

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -350,7 +350,13 @@ tier_to_model() {
         *)
             case "$t" in
                 CLOUD)          model="anthropic/claude-sonnet-4-5-20250514" ;;
-                NV_ULTRA)       model="qwen3-coder-next" ;;
+                NV_ULTRA)
+                    if [[ "${HOST_ARCH:-}" == "arm64" ]]; then
+                        model="qwen3.5-9b"
+                    else
+                        model="qwen3-coder-next"
+                    fi
+                    ;;
                 SH_LARGE)       model="qwen3-coder-next" ;;
                 SH_COMPACT|SH)  model="qwen3-30b-a3b" ;;
                 ARC)            model="qwen3.5-9b" ;;

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -97,6 +97,26 @@ set_qwen_tier_config() {
             GGUF_SHA256="9e6032d2f3b50a60f17ce8bf5a1d85c71af9b53b89c7978020ae7c660f29b090"
             MAX_CONTEXT=131072
             LLM_MODEL_SIZE_MB=48500   # 48.5 GB per HF file listing
+            # NV_ULTRA on aarch64 (DGX Spark / GB10): the qwen3-coder-next MoE
+            # Q4_K_M GGUF produces all-`?` tokens on every chat completion.
+            # SHA256 verifies, llama-server starts cleanly, decode rate is
+            # normal — every output token is just a `?`. Reproducible via raw
+            # curl /v1/chat/completions, so it's a llama.cpp / Blackwell-
+            # aarch64 / MoE-Q4_K_M kernel issue, not a Dream Server bug.
+            # Dense Qwen3.5-2B (bootstrap) was healthy on the same hardware
+            # in the same session, so for now fall back to the dense
+            # Qwen3.5-9B until the upstream fix lands. This wastes ~115GB of
+            # unified memory but gives a working install on Spark; revisit
+            # when the llama.cpp/Blackwell-aarch64 build can run MoE Q4_K_M.
+            if [[ "${HOST_ARCH:-}" == "arm64" ]]; then
+                TIER_NAME="NVIDIA Ultra (90GB+, aarch64 — MoE workaround)"
+                LLM_MODEL="qwen3.5-9b"
+                GGUF_FILE="Qwen3.5-9B-Q4_K_M.gguf"
+                GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf"
+                GGUF_SHA256="03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8"
+                MAX_CONTEXT=32768
+                LLM_MODEL_SIZE_MB=5760
+            fi
             ;;
         SH_LARGE)
             TIER_NAME="Strix Halo 90+"

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -102,19 +102,18 @@ set_qwen_tier_config() {
             # llama.cpp b9014 on Blackwell-aarch64 (SHA256 verifies, server
             # starts cleanly, decode rate is normal, but every token is `?`).
             # Verified bug is coder-next-specific, not a general MoE kernel
-            # bug: Qwen3.5-35B-A3B-Q4_K_M serves cleanly on the same build,
-            # same hardware (~59 tok/s warm decode, coherent output).
-            # Until upstream fixes coder-next on this build, route Spark to
-            # the A3B MoE — same architectural fit (large total / small
-            # active params on unified memory).
+            # bug: Qwen3.6-35B-A3B (UD-Q4_K_M) serves cleanly on the same
+            # build, same hardware. Until upstream fixes coder-next on this
+            # build, route Spark to the A3B MoE — same architectural fit
+            # (large total / small active params on unified memory).
             if [[ "${HOST_ARCH:-}" == "arm64" ]]; then
                 TIER_NAME="NVIDIA Ultra (90GB+, aarch64 — A3B substitution)"
-                LLM_MODEL="qwen3.5-35b-a3b"
-                GGUF_FILE="Qwen3.5-35B-A3B-Q4_K_M.gguf"
-                GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-35B-A3B-GGUF/resolve/main/Qwen3.5-35B-A3B-Q4_K_M.gguf"
-                GGUF_SHA256="3b46d1066bc91cc2d613e3bc22ce691dd77e6f0d33c9060690d24ce6de494375"
+                LLM_MODEL="qwen3.6-35b-a3b"
+                GGUF_FILE="Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+                GGUF_URL="https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+                GGUF_SHA256="ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61"
                 MAX_CONTEXT=131072
-                LLM_MODEL_SIZE_MB=22000
+                LLM_MODEL_SIZE_MB=21110
             fi
             ;;
         SH_LARGE)
@@ -351,7 +350,7 @@ tier_to_model() {
                 CLOUD)          model="anthropic/claude-sonnet-4-5-20250514" ;;
                 NV_ULTRA)
                     if [[ "${HOST_ARCH:-}" == "arm64" ]]; then
-                        model="qwen3.5-35b-a3b"
+                        model="qwen3.6-35b-a3b"
                     else
                         model="qwen3-coder-next"
                     fi

--- a/dream-server/tests/bats-tests/tier-map.bats
+++ b/dream-server/tests/bats-tests/tier-map.bats
@@ -20,6 +20,7 @@ setup() {
 
 teardown() {
     unset MODEL_PROFILE
+    unset HOST_ARCH
 }
 
 # ── resolve_tier_config ─────────────────────────────────────────────────────
@@ -71,6 +72,17 @@ teardown() {
     assert_equal "$LLM_MODEL" "qwen3-coder-next"
     assert_equal "$GGUF_FILE" "qwen3-coder-next-Q4_K_M.gguf"
     assert_equal "$MAX_CONTEXT" "131072"
+}
+
+@test "resolve_tier_config: arm64 NV_ULTRA falls back to dense Qwen" {
+    TIER=NV_ULTRA
+    HOST_ARCH=arm64
+    resolve_tier_config
+    assert_equal "$TIER_NAME" "NVIDIA Ultra (90GB+, aarch64 — MoE workaround)"
+    assert_equal "$MODEL_PROFILE_EFFECTIVE" "qwen"
+    assert_equal "$LLM_MODEL" "qwen3.5-9b"
+    assert_equal "$GGUF_FILE" "Qwen3.5-9B-Q4_K_M.gguf"
+    assert_equal "$MAX_CONTEXT" "32768"
 }
 
 @test "resolve_tier_config: default profile keeps SH_LARGE on Qwen Coder Next" {
@@ -153,6 +165,12 @@ teardown() {
 
     run tier_to_model SH
     assert_output "qwen3-30b-a3b"
+}
+
+@test "tier_to_model: arm64 NV_ULTRA maps to dense Qwen workaround" {
+    HOST_ARCH=arm64
+    run tier_to_model NV_ULTRA
+    assert_output "qwen3.5-9b"
 }
 
 @test "tier_to_model: invalid tier returns empty string" {
@@ -250,4 +268,8 @@ teardown() {
 
     run tier_to_model NV_ULTRA qwen
     assert_output "qwen3-coder-next"
+
+    HOST_ARCH=arm64
+    run tier_to_model NV_ULTRA qwen
+    assert_output "qwen3.5-9b"
 }

--- a/dream-server/tests/bats-tests/tier-map.bats
+++ b/dream-server/tests/bats-tests/tier-map.bats
@@ -80,8 +80,8 @@ teardown() {
     resolve_tier_config
     assert_equal "$TIER_NAME" "NVIDIA Ultra (90GB+, aarch64 — A3B substitution)"
     assert_equal "$MODEL_PROFILE_EFFECTIVE" "qwen"
-    assert_equal "$LLM_MODEL" "qwen3.5-35b-a3b"
-    assert_equal "$GGUF_FILE" "Qwen3.5-35B-A3B-Q4_K_M.gguf"
+    assert_equal "$LLM_MODEL" "qwen3.6-35b-a3b"
+    assert_equal "$GGUF_FILE" "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
     assert_equal "$MAX_CONTEXT" "131072"
 }
 
@@ -170,7 +170,7 @@ teardown() {
 @test "tier_to_model: arm64 NV_ULTRA maps to A3B MoE substitution" {
     HOST_ARCH=arm64
     run tier_to_model NV_ULTRA
-    assert_output "qwen3.5-35b-a3b"
+    assert_output "qwen3.6-35b-a3b"
 }
 
 @test "tier_to_model: invalid tier returns empty string" {
@@ -271,5 +271,5 @@ teardown() {
 
     HOST_ARCH=arm64
     run tier_to_model NV_ULTRA qwen
-    assert_output "qwen3.5-35b-a3b"
+    assert_output "qwen3.6-35b-a3b"
 }

--- a/dream-server/tests/bats-tests/tier-map.bats
+++ b/dream-server/tests/bats-tests/tier-map.bats
@@ -74,15 +74,15 @@ teardown() {
     assert_equal "$MAX_CONTEXT" "131072"
 }
 
-@test "resolve_tier_config: arm64 NV_ULTRA falls back to dense Qwen" {
+@test "resolve_tier_config: arm64 NV_ULTRA substitutes A3B MoE for coder-next" {
     TIER=NV_ULTRA
     HOST_ARCH=arm64
     resolve_tier_config
-    assert_equal "$TIER_NAME" "NVIDIA Ultra (90GB+, aarch64 — MoE workaround)"
+    assert_equal "$TIER_NAME" "NVIDIA Ultra (90GB+, aarch64 — A3B substitution)"
     assert_equal "$MODEL_PROFILE_EFFECTIVE" "qwen"
-    assert_equal "$LLM_MODEL" "qwen3.5-9b"
-    assert_equal "$GGUF_FILE" "Qwen3.5-9B-Q4_K_M.gguf"
-    assert_equal "$MAX_CONTEXT" "32768"
+    assert_equal "$LLM_MODEL" "qwen3.5-35b-a3b"
+    assert_equal "$GGUF_FILE" "Qwen3.5-35B-A3B-Q4_K_M.gguf"
+    assert_equal "$MAX_CONTEXT" "131072"
 }
 
 @test "resolve_tier_config: default profile keeps SH_LARGE on Qwen Coder Next" {
@@ -167,10 +167,10 @@ teardown() {
     assert_output "qwen3-30b-a3b"
 }
 
-@test "tier_to_model: arm64 NV_ULTRA maps to dense Qwen workaround" {
+@test "tier_to_model: arm64 NV_ULTRA maps to A3B MoE substitution" {
     HOST_ARCH=arm64
     run tier_to_model NV_ULTRA
-    assert_output "qwen3.5-9b"
+    assert_output "qwen3.5-35b-a3b"
 }
 
 @test "tier_to_model: invalid tier returns empty string" {
@@ -271,5 +271,5 @@ teardown() {
 
     HOST_ARCH=arm64
     run tier_to_model NV_ULTRA qwen
-    assert_output "qwen3.5-9b"
+    assert_output "qwen3.5-35b-a3b"
 }

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -107,8 +107,8 @@ HOST_ARCH=arm64
 run_tier NV_ULTRA
 assert_eq "TIER_NAME"   "NVIDIA Ultra (90GB+, aarch64 — A3B substitution)" "$TIER_NAME"
 assert_eq "MODEL_PROFILE_EFFECTIVE" "qwen"                   "$MODEL_PROFILE_EFFECTIVE"
-assert_eq "LLM_MODEL"   "qwen3.5-35b-a3b"                    "$LLM_MODEL"
-assert_eq "GGUF_FILE"   "Qwen3.5-35B-A3B-Q4_K_M.gguf"        "$GGUF_FILE"
+assert_eq "LLM_MODEL"   "qwen3.6-35b-a3b"                    "$LLM_MODEL"
+assert_eq "GGUF_FILE"   "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"     "$GGUF_FILE"
 assert_eq "MAX_CONTEXT"  "131072"                               "$MAX_CONTEXT"
 unset HOST_ARCH
 echo ""

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -93,12 +93,24 @@ echo ""
 
 # --- NV_ULTRA ---
 echo "NV_ULTRA (NVIDIA Ultra 90GB+):"
+unset HOST_ARCH
 run_tier NV_ULTRA
 assert_eq "TIER_NAME"   "NVIDIA Ultra (90GB+)"                 "$TIER_NAME"
 assert_eq "MODEL_PROFILE_EFFECTIVE" "qwen"                   "$MODEL_PROFILE_EFFECTIVE"
 assert_eq "LLM_MODEL"   "qwen3-coder-next"                   "$LLM_MODEL"
 assert_eq "GGUF_FILE"   "qwen3-coder-next-Q4_K_M.gguf"       "$GGUF_FILE"
 assert_eq "MAX_CONTEXT"  "131072"                               "$MAX_CONTEXT"
+echo ""
+
+echo "NV_ULTRA (aarch64 MoE workaround):"
+HOST_ARCH=arm64
+run_tier NV_ULTRA
+assert_eq "TIER_NAME"   "NVIDIA Ultra (90GB+, aarch64 — MoE workaround)" "$TIER_NAME"
+assert_eq "MODEL_PROFILE_EFFECTIVE" "qwen"                   "$MODEL_PROFILE_EFFECTIVE"
+assert_eq "LLM_MODEL"   "qwen3.5-9b"                         "$LLM_MODEL"
+assert_eq "GGUF_FILE"   "Qwen3.5-9B-Q4_K_M.gguf"             "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "32768"                                "$MAX_CONTEXT"
+unset HOST_ARCH
 echo ""
 
 # --- SH_LARGE ---

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -102,14 +102,14 @@ assert_eq "GGUF_FILE"   "qwen3-coder-next-Q4_K_M.gguf"       "$GGUF_FILE"
 assert_eq "MAX_CONTEXT"  "131072"                               "$MAX_CONTEXT"
 echo ""
 
-echo "NV_ULTRA (aarch64 MoE workaround):"
+echo "NV_ULTRA (aarch64 A3B substitution):"
 HOST_ARCH=arm64
 run_tier NV_ULTRA
-assert_eq "TIER_NAME"   "NVIDIA Ultra (90GB+, aarch64 — MoE workaround)" "$TIER_NAME"
+assert_eq "TIER_NAME"   "NVIDIA Ultra (90GB+, aarch64 — A3B substitution)" "$TIER_NAME"
 assert_eq "MODEL_PROFILE_EFFECTIVE" "qwen"                   "$MODEL_PROFILE_EFFECTIVE"
-assert_eq "LLM_MODEL"   "qwen3.5-9b"                         "$LLM_MODEL"
-assert_eq "GGUF_FILE"   "Qwen3.5-9B-Q4_K_M.gguf"             "$GGUF_FILE"
-assert_eq "MAX_CONTEXT"  "32768"                                "$MAX_CONTEXT"
+assert_eq "LLM_MODEL"   "qwen3.5-35b-a3b"                    "$LLM_MODEL"
+assert_eq "GGUF_FILE"   "Qwen3.5-35B-A3B-Q4_K_M.gguf"        "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "131072"                               "$MAX_CONTEXT"
 unset HOST_ARCH
 echo ""
 


### PR DESCRIPTION
## Summary

**Bug #34, reproduced & re-investigated on DGX Spark today (NVIDIA GB10 Grace Blackwell / aarch64 / Ubuntu 24.04):** the `qwen3-coder-next-Q4_K_M` MoE GGUF ? NV_ULTRA's default for `MODEL_PROFILE=qwen` ? produces all-`?` tokens on every chat completion against llama.cpp `b9014-d4b0c22f9` on Blackwell-aarch64.

- SHA256 verifies against upstream
- llama-server starts cleanly, no errors
- Prompt processing and decode timings are normal
- **Every output token is just `?`**

## Why the original dense fallback was wrong

The first revision of this PR routed aarch64 NV_ULTRA to dense Qwen3.5-9B, on the working assumption that the bug was a general llama.cpp / sm_120 / aarch64 / MoE-Q4_K_M kernel issue. Follow-up testing on Spark disproved that:

- Re-confirmed `qwen3-coder-next-Q4_K_M` still emits all-`?` tokens on Spark.
- Served **Qwen3.6-35B-A3B-UD-Q4_K_M** via the same `ghcr.io/ggml-org/llama.cpp:server-cuda-b9014` image and same Spark hardware.
- Output is clean and coherent through both raw `curl /v1/chat/completions` and Hermes dashboard/CLI flows.

So the bug is specific to the **coder-next** GGUF path on this build/hardware, not a category failure of MoE on Spark. Spark / Strix / Apple Silicon are unified-memory hosts whose value proposition is exactly *large total / small active params*, so the correct installer fix is another A3B MoE, not a dense downgrade.

## Fix

`HOST_ARCH == "arm64"` + `TIER == NV_ULTRA` + `MODEL_PROFILE=qwen` ? `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`:

- LLM_MODEL: `qwen3.6-35b-a3b`
- size: 21,110 MB, context: 131,072
- SHA256: `ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61`
- catalog id: `qwen3.6-35b-a3b-ud-q4`

Also adds the Qwen3.6 entry to `config/model-library.json` so dashboard/host-agent model-library flows recognize the Spark default, and updates `dream model list` to show the arm64 Spark-specific NV_ULTRA model.

The `gemma4` NV_ULTRA path (gemma-4-31b-it) is untouched. amd64 NV_ULTRA is unchanged and still uses `qwen3-coder-next`.

The underlying coder-next bug stays open; needs separate upstream llama.cpp investigation.

## Test plan

- [x] Repro re-confirmed on Spark: `qwen3-coder-next-Q4_K_M` + `b9014-d4b0c22f9` ? all-`?` tokens via raw curl.
- [x] A3B counter-test on same Spark: `Qwen3.6-35B-A3B-UD-Q4_K_M` + same b9014 image + same hardware ? coherent output.
- [x] Hermes end-to-end on Spark: dashboard chat, simple factual prompt, Python one-liner, file-tool round trip, and multi-step reasoning all coherent.
- [x] Local: `bash -n dream-server/installers/lib/tier-map.sh dream-server/tests/test-tier-map.sh dream-server/dream-cli`.
- [x] Local: `bash dream-server/tests/test-tier-map.sh` ? 88 passed / 0 failed.
- [x] Local: `config/model-library.json` parses; Qwen3.6 artifact SHA matches Hugging Face LFS metadata.
- [ ] CI after latest catalog/CLI patch.
