### PR TITLE
fix(get-dream-server): anchor CWD + clearer clone error message

### DIFF
--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -11,8 +11,10 @@ set -euo pipefail
 # same terminal will land here with a deleted working directory — `git
 # clone` then fails with `fatal: Unable to read current working directory`
 # and the user sees a misleading "check your internet connection" message.
-if ! cd "${HOME:-/tmp}" 2>/dev/null; then
-    cd /tmp 2>/dev/null || {
+DREAM_BOOTSTRAP_ROOT="${HOME:-/tmp}"
+if ! cd "$DREAM_BOOTSTRAP_ROOT" 2>/dev/null; then
+    DREAM_BOOTSTRAP_ROOT="/tmp"
+    cd "$DREAM_BOOTSTRAP_ROOT" 2>/dev/null || {
         echo "[error] Cannot find a usable working directory (\$HOME and /tmp both inaccessible)." >&2
         exit 1
     }
@@ -28,7 +30,7 @@ BOLD='\033[1m'
 NC='\033[0m'
 
 REPO_URL="https://github.com/Light-Heart-Labs/DreamServer.git"
-INSTALL_DIR="$HOME/dream-server"
+INSTALL_DIR="$DREAM_BOOTSTRAP_ROOT/dream-server"
 
 log()     { echo -e "${CYAN}[dream]${NC} $1"; }
 success() { echo -e "${GREEN}[  ok ]${NC} $1"; }
@@ -215,7 +217,7 @@ echo "$_clone_err" | tail -1
 cd "$TEMP_DIR/repo"
 git sparse-checkout set dream-server 2>/dev/null || {
     # Fallback: full clone if sparse checkout fails
-    cd "${HOME:-/tmp}"
+    cd "$DREAM_BOOTSTRAP_ROOT"
     rm -rf "$TEMP_DIR/repo"
     git clone --depth 1 "$REPO_URL" "$TEMP_DIR/repo" 2>&1 | tail -1 || \
         error "Failed to clone repository (fallback full clone also failed)."

--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -6,6 +6,18 @@
 
 set -euo pipefail
 
+# Anchor CWD to a known-good directory. Without this, a user who just
+# uninstalled Dream Server and immediately re-runs the bootstrap from the
+# same terminal will land here with a deleted working directory — `git
+# clone` then fails with `fatal: Unable to read current working directory`
+# and the user sees a misleading "check your internet connection" message.
+if ! cd "${HOME:-/tmp}" 2>/dev/null; then
+    cd /tmp 2>/dev/null || {
+        echo "[error] Cannot find a usable working directory (\$HOME and /tmp both inaccessible)." >&2
+        exit 1
+    }
+fi
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -186,16 +198,27 @@ log "Cloning Dream Server..."
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
-git clone --depth 1 --filter=blob:none --sparse "$REPO_URL" "$TEMP_DIR/repo" 2>&1 | tail -1 || \
-    error "Failed to clone repository. Check your internet connection."
+_clone_err=$(git clone --depth 1 --filter=blob:none --sparse "$REPO_URL" "$TEMP_DIR/repo" 2>&1) || {
+    case "$_clone_err" in
+        *"Unable to read current working directory"*|*"getcwd"*)
+            error "git could not read the current working directory. This usually means the directory you launched from has been deleted (e.g. you uninstalled Dream Server and re-ran the bootstrap from the same shell). Run \`cd ~\` and re-run the bootstrap." ;;
+        *"Could not resolve host"*|*"Failed to connect"*|*"Connection refused"*|*"Network is unreachable"*)
+            error "Failed to reach github.com. Check your internet connection or proxy settings.\n  git said: $_clone_err" ;;
+        *"Permission denied"*|*"could not create"*)
+            error "git failed to write to $TEMP_DIR (permissions). Check that /tmp is writable.\n  git said: $_clone_err" ;;
+        *)
+            error "Failed to clone repository.\n  git said: $_clone_err" ;;
+    esac
+}
+echo "$_clone_err" | tail -1
 
 cd "$TEMP_DIR/repo"
 git sparse-checkout set dream-server 2>/dev/null || {
     # Fallback: full clone if sparse checkout fails
-    cd /
+    cd "${HOME:-/tmp}"
     rm -rf "$TEMP_DIR/repo"
     git clone --depth 1 "$REPO_URL" "$TEMP_DIR/repo" 2>&1 | tail -1 || \
-        error "Failed to clone repository."
+        error "Failed to clone repository (fallback full clone also failed)."
     cd "$TEMP_DIR/repo"
 }
 


### PR DESCRIPTION
## Summary

The curl-piped bootstrap fails confusingly if you run it from a directory that no longer exists. The most common way to hit this:

```bash
$ cd ~/dream-server
$ ./dream-uninstall.sh          # removes ~/dream-server
$ curl ... | bash                # ← still in the deleted dir; getcwd() fails
[error] Failed to clone repository. Check your internet connection.
```

The user is now hunting a network bug that doesn't exist. Reproduced today during a fresh-install pass on Tower2.

## Fix

Two changes in `get-dream-server.sh`:

1. **Anchor CWD at the top of the script.** `cd "${HOME:-/tmp}"` (falling back to `/tmp` if `$HOME` is missing/unreadable). Bootstraps now work regardless of where the user invoked from.

2. **Classify the clone error.** Capture `git`'s stderr and emit an appropriate message instead of always blaming the network:
   - `getcwd` / "Unable to read current working directory" → tells the user to `cd ~`
   - "Could not resolve host" / "Failed to connect" / "Network is unreachable" → keeps the network message and includes git's actual output
   - "Permission denied" / "could not create" → points at `/tmp` writability
   - anything else → falls through with git's stderr included

3. **Fallback full-clone branch:** changed `cd /` to `cd "${HOME:-/tmp}"`, which is what the rest of the script targets. Mostly cosmetic.

## Test plan

- [x] `bash -n get-dream-server.sh` syntax OK.
- [x] Verified the CWD-anchor path against the original failure (Tower2, 2026-05-13).
- [ ] CI smoke (Linux/macOS bootstrap simulation).