### PR TITLE
fix(installer): bundle extensions-library so bootstrap installs don't 503

### DIFF
--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -259,6 +259,22 @@ fi
 
 success "Cloned to $INSTALL_DIR"
 
+# ── Bundle extensions-library templates ──────────────
+# The dashboard's Extensions page reads from data/extensions-library/, which the
+# installer (phase 06 / install-macos.sh) populates from resources/dev/extensions-library/.
+# That source path is in the OUTER repo (one level above dream-server/), which
+# the rsync above does not copy. Without it, dashboard-api returns:
+#   503 {"detail":"Extensions library is unavailable"}
+# on every install. Bundle the templates inside the install dir so the
+# installer can find them deterministically regardless of where it's invoked.
+if [[ -d "$TEMP_DIR/repo/resources/dev/extensions-library" ]]; then
+    cp -r "$TEMP_DIR/repo/resources/dev/extensions-library" "$INSTALL_DIR/extensions-library-bundle" \
+        && success "Bundled extensions-library templates" \
+        || warn "Failed to bundle extensions-library — Extensions page may 503"
+else
+    warn "resources/dev/extensions-library not in clone — Extensions page will 503"
+fi
+
 # ── Make scripts executable ──────────────────────────
 chmod +x "$INSTALL_DIR/install.sh" 2>/dev/null || true
 chmod +x "$INSTALL_DIR/dream-cli" 2>/dev/null || true

--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -215,7 +215,7 @@ _clone_err=$(git clone --depth 1 --filter=blob:none --sparse "$REPO_URL" "$TEMP_
 echo "$_clone_err" | tail -1
 
 cd "$TEMP_DIR/repo"
-git sparse-checkout set dream-server 2>/dev/null || {
+git sparse-checkout set dream-server resources/dev/extensions-library 2>/dev/null || {
     # Fallback: full clone if sparse checkout fails
     cd "$DREAM_BOOTSTRAP_ROOT"
     rm -rf "$TEMP_DIR/repo"
@@ -268,9 +268,13 @@ success "Cloned to $INSTALL_DIR"
 # on every install. Bundle the templates inside the install dir so the
 # installer can find them deterministically regardless of where it's invoked.
 if [[ -d "$TEMP_DIR/repo/resources/dev/extensions-library" ]]; then
-    cp -r "$TEMP_DIR/repo/resources/dev/extensions-library" "$INSTALL_DIR/extensions-library-bundle" \
-        && success "Bundled extensions-library templates" \
-        || warn "Failed to bundle extensions-library — Extensions page may 503"
+    if rm -rf "$INSTALL_DIR/extensions-library-bundle" \
+        && mkdir -p "$INSTALL_DIR/extensions-library-bundle" \
+        && cp -R "$TEMP_DIR/repo/resources/dev/extensions-library/." "$INSTALL_DIR/extensions-library-bundle/"; then
+        success "Bundled extensions-library templates"
+    else
+        warn "Failed to bundle extensions-library — Extensions page may 503"
+    fi
 else
     warn "resources/dev/extensions-library not in clone — Extensions page will 503"
 fi

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -615,15 +615,22 @@ else
     fi
 
     # Copy extensions library to data dir for dashboard portal.
-    # SOURCE_ROOT resolves to dream-server/, so we climb one more level
-    # ($SOURCE_ROOT/..) to reach the repo root where resources/ lives.
-    _ext_lib_src="${SOURCE_ROOT}/../resources/dev/extensions-library/services"
-    if [[ -d "$_ext_lib_src" ]]; then
+    # Source resolution: dev installs find it via SOURCE_ROOT/.. (outer repo).
+    # Bootstrap installs (curl-piped) get the templates bundled inside the
+    # install dir by get-dream-server.sh under extensions-library-bundle/.
+    _ext_lib_src=""
+    for _candidate in \
+        "${SOURCE_ROOT}/../resources/dev/extensions-library/services" \
+        "${INSTALL_DIR}/extensions-library-bundle/services"
+    do
+        if [[ -d "$_candidate" ]]; then _ext_lib_src="$_candidate"; break; fi
+    done
+    if [[ -n "$_ext_lib_src" ]]; then
         mkdir -p "${INSTALL_DIR}/data/extensions-library"
         cp -r "$_ext_lib_src/." "${INSTALL_DIR}/data/extensions-library/"
-        ai_ok "Extensions library copied to data/extensions-library/"
+        ai_ok "Extensions library copied to data/extensions-library/ (from $_ext_lib_src)"
     else
-        ai_warn "Extensions library not found at ${_ext_lib_src}; dashboard Extensions page will return 503 until populated"
+        ai_warn "Extensions library not found; dashboard Extensions page will return 503 until populated"
     fi
 
     # Copy CLI tool to install root

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -111,12 +111,26 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         log "Running in-place (source == install dir), skipping file copy"
     fi
 
-    # Copy extensions library to data dir for dashboard portal
-    _ext_lib_src="$SCRIPT_DIR/../resources/dev/extensions-library/services"
-    if [[ -d "$_ext_lib_src" ]]; then
+    # Copy extensions library to data dir for dashboard portal.
+    # Source resolution: dev installs (running from a checkout) find it via
+    # $SCRIPT_DIR/../resources/. Bootstrap installs (curl-piped) get the
+    # templates bundled inside the install dir by get-dream-server.sh under
+    # extensions-library-bundle/. Without one of these paths, dashboard-api's
+    # /api/extensions/{id}/install endpoint returns 503 "Extensions library is
+    # unavailable" and the dashboard's Extensions page is non-functional.
+    _ext_lib_src=""
+    for _candidate in \
+        "$SCRIPT_DIR/../resources/dev/extensions-library/services" \
+        "$INSTALL_DIR/extensions-library-bundle/services"
+    do
+        if [[ -d "$_candidate" ]]; then _ext_lib_src="$_candidate"; break; fi
+    done
+    if [[ -n "$_ext_lib_src" ]]; then
         mkdir -p "$INSTALL_DIR/data/extensions-library"
         cp -r "$_ext_lib_src/." "$INSTALL_DIR/data/extensions-library/"
-        ai_ok "Extensions library copied to data/extensions-library/"
+        ai_ok "Extensions library copied to data/extensions-library/ (from $_ext_lib_src)"
+    else
+        ai_warn "Extensions library not found; dashboard Extensions page will return 503 until populated"
     fi
 
     # Select tier-appropriate OpenClaw config


### PR DESCRIPTION
## Summary

Fresh installs across all 4 fleet hosts return **503 "Extensions library is unavailable"** from `POST /api/extensions/{id}/install`. The Extensions page in the dashboard is non-functional out of the box.

**Reproduced**: 2026-05-14 fleet test, run `2026-05-14T02-00-32Z` — Tower2, strix-halo, spark, mac-mini (4/4 hosts).

## Root cause

The dashboard's Extensions page reads from `data/extensions-library/`, which the installer (Linux phase 06, macOS `install-macos.sh`) populates by copying from `resources/dev/extensions-library/services/` in the **outer repo** (one level above `dream-server/`).

`get-dream-server.sh` only rsyncs the `dream-server/` subtree into the install location — the `resources/` directory is left behind in `TEMP_DIR/repo/`. So `$SCRIPT_DIR/../resources/dev/extensions-library/services` resolves to a path that doesn't exist (it points to `~/`, not the cloned repo), the installer's `if [[ -d ... ]]` silently skips on Linux (the macOS path at least warns), and dashboard-api comes up with no library to install from.

Only dev installs (running directly from a git checkout) work, because in that layout the outer `resources/` is naturally adjacent.

## Fix

Three small changes:

1. **`get-dream-server.sh`** — after rsyncing `dream-server/`, also copy `resources/dev/extensions-library/` into the install dir at `extensions-library-bundle/`. This puts the templates somewhere the installer can find deterministically regardless of where it's invoked. Warn loudly if the source isn't in the clone (instead of silently failing).

2. **`installers/phases/06-directories.sh`** — try the dev-mode path first, fall back to the bundled `$INSTALL_DIR/extensions-library-bundle/services` path. If neither exists, warn (was previously silent on Linux).

3. **`installers/macos/install-macos.sh`** — same fallback chain.

## Test plan

- [x] `curl -fsSL <bootstrap-url> | bash -s -- --non-interactive --all --force` on Tower2 (Linux, NVIDIA): `data/extensions-library/` populated, `POST /api/extensions/aider/install` returns 200, aider tile appears in dashboard
- [ ] Same on strix-halo (Linux, AMD)
- [ ] Same on spark (Linux, aarch64)
- [ ] Same on mac-mini (macOS, arm64)
- [ ] Dev install from git checkout still uses the outer-repo path (no regression)
