### PR TITLE
fix(host-agent): bind 0.0.0.0 + detect container gateway for cross-bridge reach

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -3554,8 +3554,7 @@ def main():
     #   not the primary control. With a 64-char hex key (256 bits of entropy),
     #   brute-force is infeasible; LAN exposure is bounded by key custody.
     #   Operators on hostile LANs can restrict via DREAM_AGENT_BIND=<ip> in .env.
-    bind_addr = env.get("DREAM_AGENT_BIND", "")
-    bind_from_env = bool(bind_addr)
+    bind_addr = env.get("DREAM_AGENT_BIND", "").strip()
     if not bind_addr:
         if platform.system() in ("Darwin", "Windows"):
             bind_addr = "127.0.0.1"

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -3542,24 +3542,35 @@ def main():
 
     # Determine bind address: env var override, or platform-aware default.
     # macOS/Windows: 127.0.0.1 (Docker Desktop routes host.docker.internal to loopback)
-    # Linux: Docker bridge gateway IP (containers reach via host-gateway,
-    #   LAN devices cannot — the bridge is a virtual interface).
-    #   Falls back to 127.0.0.1 if detection fails.
+    # Linux: 0.0.0.0 — bind to all interfaces. Earlier versions bound to the
+    #   Docker bridge gateway (typically 172.17.0.1) to keep the agent off the
+    #   LAN, but that broke containers on custom networks like dream-network
+    #   (172.18.x.x) which can't route to 172.17.0.1 across Docker's default
+    #   bridge isolation. Reproduced on every fleet-test run as
+    #   `503 Host agent unreachable: <urlopen error timed out>` from
+    #   POST /api/models/{id}/download.
+    #   All endpoints already require Authorization: Bearer DREAM_AGENT_KEY,
+    #   which is the de-facto gate — the bind restriction was defense-in-depth,
+    #   not the primary control. With a 64-char hex key (256 bits of entropy),
+    #   brute-force is infeasible; LAN exposure is bounded by key custody.
+    #   Operators on hostile LANs can restrict via DREAM_AGENT_BIND=<ip> in .env.
     bind_addr = env.get("DREAM_AGENT_BIND", "")
     bind_from_env = bool(bind_addr)
     if not bind_addr:
         if platform.system() in ("Darwin", "Windows"):
             bind_addr = "127.0.0.1"
         else:
-            bind_addr = _detect_docker_bridge_gateway() or "127.0.0.1"
+            bind_addr = "0.0.0.0"
 
     server = ThreadedHTTPServer((bind_addr, port), AgentHandler)
     signal.signal(signal.SIGTERM, lambda *_: server.shutdown())
     logger.info("Dream Host Agent v%s listening on %s:%d", VERSION, bind_addr, port)
-    if bind_addr == "127.0.0.1" and not bind_from_env and platform.system() not in ("Darwin", "Windows"):
-        logger.warning(
-            "Docker bridge detection failed, using loopback (127.0.0.1). "
-            "Containers may not reach the agent. Set DREAM_AGENT_BIND=<bridge-ip> in .env."
+    if bind_addr == "0.0.0.0":
+        logger.info(
+            "Bound to all interfaces. Bearer-auth (DREAM_AGENT_KEY) is enforced "
+            "on every endpoint. To restrict to a specific interface, set "
+            "DREAM_AGENT_BIND=<ip> in %s/.env.",
+            INSTALL_DIR,
         )
     logger.info("Install dir: %s | GPU: %s | Tier: %s", INSTALL_DIR, GPU_BACKEND, TIER)
     try:

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -298,7 +298,18 @@ EXTENSION_CATALOG = load_extension_catalog()
 
 # --- Host Agent ---
 
-def _detect_container_default_gateway() -> str:
+def _running_inside_container() -> bool:
+    """Best-effort check for Docker/Podman/containerd runtime context."""
+    if Path("/.dockerenv").exists():
+        return True
+    try:
+        cgroup = Path("/proc/1/cgroup").read_text(encoding="utf-8").lower()
+    except OSError:
+        return False
+    return any(marker in cgroup for marker in ("docker", "containerd", "kubepods", "podman"))
+
+
+def _detect_container_default_gateway(route_path: str = "/proc/net/route") -> str:
     """Return this container's default-gateway IP, or empty on failure.
 
     Reads /proc/net/route directly so the container image doesn't need
@@ -315,17 +326,25 @@ def _detect_container_default_gateway() -> str:
     Docker's default DOCKER-ISOLATION-STAGE-2 iptables rules.
     """
     try:
-        with open("/proc/net/route", "r", encoding="utf-8") as f:
+        with open(route_path, "r", encoding="utf-8") as f:
             for line in f.readlines()[1:]:
                 fields = line.strip().split()
                 # destination == 0.0.0.0 AND flags has RTF_GATEWAY (0x2)
-                if len(fields) >= 4 and fields[1] == "00000000":
-                    gw_hex = fields[2]
-                    # Little-endian: 0100A8C0 → 192.168.0.1
-                    return ".".join(
-                        str(int(gw_hex[i:i+2], 16)) for i in (6, 4, 2, 0)
-                    )
-    except (OSError, ValueError):
+                if len(fields) < 4 or fields[1] != "00000000":
+                    continue
+                gw_hex = fields[2]
+                try:
+                    flags = int(fields[3], 16)
+                    gateway_raw = int(gw_hex, 16)
+                except ValueError:
+                    continue
+                if not (flags & 0x2) or gateway_raw == 0 or len(gw_hex) != 8:
+                    continue
+                # Little-endian: 0100A8C0 -> 192.168.0.1
+                return ".".join(
+                    str(int(gw_hex[i:i + 2], 16)) for i in (6, 4, 2, 0)
+                )
+    except OSError:
         pass
     return ""
 
@@ -344,10 +363,11 @@ def _resolve_agent_host() -> str:
     explicit = os.environ.get("DREAM_AGENT_HOST", "").strip()
     if explicit:
         return explicit
-    gw = _detect_container_default_gateway()
-    if gw:
-        logger.info("Resolved DREAM_AGENT_HOST=%s via /proc/net/route", gw)
-        return gw
+    if _running_inside_container():
+        gw = _detect_container_default_gateway()
+        if gw:
+            logger.info("Resolved DREAM_AGENT_HOST=%s via /proc/net/route", gw)
+            return gw
     logger.warning(
         "Could not detect container default gateway; falling back to "
         "host.docker.internal. If host-agent calls time out, set "

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -298,7 +298,65 @@ EXTENSION_CATALOG = load_extension_catalog()
 
 # --- Host Agent ---
 
-AGENT_HOST = os.environ.get("DREAM_AGENT_HOST", "host.docker.internal")
+def _detect_container_default_gateway() -> str:
+    """Return this container's default-gateway IP, or empty on failure.
+
+    Reads /proc/net/route directly so the container image doesn't need
+    iproute2 installed. The default route line has destination 00000000 and
+    a little-endian-hex gateway in the 3rd field.
+
+    Why this matters: dashboard-api runs on `dream-network` (a custom bridge,
+    e.g. 172.18.0.0/16). The dream-host-agent on the host binds 0.0.0.0 and
+    thus listens on every host-side bridge interface — including
+    dream-network's gateway (172.18.0.1). Targeting that gateway directly is
+    routable from inside the container without depending on
+    `host.docker.internal:host-gateway`, which Docker resolves to the *default*
+    bridge gateway (172.17.0.1) — unreachable from custom networks under
+    Docker's default DOCKER-ISOLATION-STAGE-2 iptables rules.
+    """
+    try:
+        with open("/proc/net/route", "r", encoding="utf-8") as f:
+            for line in f.readlines()[1:]:
+                fields = line.strip().split()
+                # destination == 0.0.0.0 AND flags has RTF_GATEWAY (0x2)
+                if len(fields) >= 4 and fields[1] == "00000000":
+                    gw_hex = fields[2]
+                    # Little-endian: 0100A8C0 → 192.168.0.1
+                    return ".".join(
+                        str(int(gw_hex[i:i+2], 16)) for i in (6, 4, 2, 0)
+                    )
+    except (OSError, ValueError):
+        pass
+    return ""
+
+
+def _resolve_agent_host() -> str:
+    """Pick the host name/IP to use for the dream-host-agent.
+
+    Priority:
+      1. DREAM_AGENT_HOST env (explicit operator override)
+      2. The container's own default-gateway IP (works regardless of which
+         Docker network the container is on)
+      3. host.docker.internal (legacy fallback — broken on custom networks
+         under default Docker iptables, but kept so explicit operator setups
+         relying on it don't silently change)
+    """
+    explicit = os.environ.get("DREAM_AGENT_HOST", "").strip()
+    if explicit:
+        return explicit
+    gw = _detect_container_default_gateway()
+    if gw:
+        logger.info("Resolved DREAM_AGENT_HOST=%s via /proc/net/route", gw)
+        return gw
+    logger.warning(
+        "Could not detect container default gateway; falling back to "
+        "host.docker.internal. If host-agent calls time out, set "
+        "DREAM_AGENT_HOST=<host-ip> in dashboard-api's environment."
+    )
+    return "host.docker.internal"
+
+
+AGENT_HOST = _resolve_agent_host()
 AGENT_PORT = int(os.environ.get("DREAM_AGENT_PORT", "7710"))
 AGENT_URL = f"http://{AGENT_HOST}:{AGENT_PORT}"
 DASHBOARD_API_KEY = os.environ.get("DASHBOARD_API_KEY", "")

--- a/dream-server/extensions/services/dashboard-api/tests/test_config.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_config.py
@@ -4,7 +4,8 @@ import logging
 
 import pytest
 
-from config import load_extension_manifests, _read_manifest_file
+import config
+from config import _detect_container_default_gateway, load_extension_manifests, _read_manifest_file
 
 
 VALID_MANIFEST = """\
@@ -49,6 +50,50 @@ class TestReadManifestFile:
         f.write_text("- just\n- a\n- list\n")
         with pytest.raises(ValueError, match="object"):
             _read_manifest_file(f)
+
+
+class TestHostAgentResolution:
+
+    def test_detect_container_default_gateway_reads_little_endian_route(self, tmp_path):
+        route = tmp_path / "route"
+        route.write_text(
+            "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n"
+            "eth0\t00000000\t010012AC\t0003\t0\t0\t0\t00000000\t0\t0\t0\n",
+            encoding="utf-8",
+        )
+
+        assert _detect_container_default_gateway(str(route)) == "172.18.0.1"
+
+    def test_detect_container_default_gateway_requires_gateway_flag(self, tmp_path):
+        route = tmp_path / "route"
+        route.write_text(
+            "Iface\tDestination\tGateway\tFlags\tRefCnt\tUse\tMetric\tMask\tMTU\tWindow\tIRTT\n"
+            "eth0\t00000000\t010012AC\t0001\t0\t0\t0\t00000000\t0\t0\t0\n",
+            encoding="utf-8",
+        )
+
+        assert _detect_container_default_gateway(str(route)) == ""
+
+    def test_resolve_agent_host_honors_explicit_env(self, monkeypatch):
+        monkeypatch.setenv("DREAM_AGENT_HOST", "  10.9.8.7  ")
+        monkeypatch.setattr(config, "_running_inside_container", lambda: True)
+        monkeypatch.setattr(config, "_detect_container_default_gateway", lambda: "172.18.0.1")
+
+        assert config._resolve_agent_host() == "10.9.8.7"
+
+    def test_resolve_agent_host_uses_gateway_inside_container(self, monkeypatch):
+        monkeypatch.delenv("DREAM_AGENT_HOST", raising=False)
+        monkeypatch.setattr(config, "_running_inside_container", lambda: True)
+        monkeypatch.setattr(config, "_detect_container_default_gateway", lambda: "172.18.0.1")
+
+        assert config._resolve_agent_host() == "172.18.0.1"
+
+    def test_resolve_agent_host_falls_back_outside_container(self, monkeypatch):
+        monkeypatch.delenv("DREAM_AGENT_HOST", raising=False)
+        monkeypatch.setattr(config, "_running_inside_container", lambda: False)
+        monkeypatch.setattr(config, "_detect_container_default_gateway", lambda: "192.168.1.1")
+
+        assert config._resolve_agent_host() == "host.docker.internal"
 
 
 class TestLoadExtensionManifests:


### PR DESCRIPTION
## Summary

`POST /api/models/{id}/download` returns `503 {"detail":"Host agent unreachable: <urlopen error timed out>"}` on every fresh install. Reproduced 2026-05-14 on the fleet test (Tower2, mac-mini); strix-halo and spark only avoid the symptom by accident of their Docker version + absent host firewall.

## Root cause

Two coupled issues:

1. **Host-agent bind address**. `bin/dream-host-agent.py` binds to the **default Docker bridge gateway** (typically `172.17.0.1`), discovered via `docker network inspect bridge`. The intent was to keep the agent off the LAN. But `dashboard-api` runs on the **custom `dream-network`** (172.18.x.x). Under Docker's default `DOCKER-ISOLATION-STAGE-2` iptables rules, traffic from a container on one bridge can't reach a host listener bound on a *different* bridge's gateway. The `host.docker.internal:host-gateway` keyword always resolves to the default bridge gateway, so there's no resolution path that works.

2. **Dashboard-api target host**. `dashboard-api/config.py` defaults `DREAM_AGENT_HOST=host.docker.internal`. Per the above, that's a dead end for containers on custom networks.

## Fix

**Approach B chosen** (vs. detect-dream-network-gateway and write to .env, vs. attach dashboard-api to both networks — see PR discussion):

1. **`bin/dream-host-agent.py`** — bind to `0.0.0.0` on Linux. macOS/Windows still bind to `127.0.0.1` (Docker Desktop handles host.docker.internal mapping there). Operators wanting the old "virtual-bridge-only" posture can still set `DREAM_AGENT_BIND=<ip>` in `.env`.

2. **`extensions/services/dashboard-api/config.py`** — add `_detect_container_default_gateway()` that reads `/proc/net/route` directly (no iproute2 needed). `DREAM_AGENT_HOST` resolution priority:
   - explicit `DREAM_AGENT_HOST` env (operator override)
   - container's own default-gateway IP (works for *any* Docker network the container is on, including custom bridges, without depending on `host.docker.internal`)
   - `host.docker.internal` as legacy fallback

## Security trade-off (the "B" in "Approach B")

Pre-PR, the agent was bound to a virtual bridge interface that LAN devices can't reach. Post-PR, it's reachable from the LAN. All endpoints still require `Authorization: Bearer DREAM_AGENT_KEY` (64-char hex, 256 bits of entropy — brute-force is geologic-time infeasible). The bind-restriction was defense-in-depth, not the primary control. Operators on hostile LANs can set `DREAM_AGENT_BIND=<ip>` to restore the old behavior.

## Caveat: host firewalls

Hosts with **UFW or firewalld active** will additionally block container→host traffic to port 7710 at the kernel level, regardless of what address the agent binds to (reproduced on Tower2 — UFW configured to allow port 22 only). Such hosts need a one-time:

```bash
sudo ufw allow from 172.17.0.0/12 to any port 7710 proto tcp
```

…or equivalent firewalld zone rule. Not handled in this PR — proposing as a follow-up that the installer detects UFW/firewalld and prompts the operator to allow the rule.

## Test plan

- [x] Verified `_detect_container_default_gateway()` returns `172.18.0.1` from inside `dream-dashboard-api` on Tower2 (`/proc/net/route` parsing).
- [x] Verified host-agent binds to `0.0.0.0:7710` after restart with new code.
- [ ] Full fleet rerun after merge (Tower2 needs UFW rule first; strix-halo, spark, mac-mini should pass cleanly).
- [ ] Verify operator override path: set `DREAM_AGENT_BIND=127.0.0.1` and confirm the agent no longer accepts LAN traffic.
