### PR TITLE
fix(host-agent): from __future__ import annotations for Python 3.9 compat

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python3
 """DreamServer Host Agent — manages extension containers from the host."""
 
+# PEP 604 union syntax (e.g. `threading.Thread | None`) is evaluated at runtime
+# in non-stringified annotations, which crashes on Python 3.9 — the version
+# Apple ships as /usr/bin/python3 on macOS 14.x. The LaunchAgent fails at
+# import with `TypeError: unsupported operand type(s) for |: 'type' and
+# 'NoneType'`, leaving Dream Server's macOS install with no host agent.
+# `from __future__ import annotations` makes ALL annotations lazy strings,
+# so PEP 604 syntax parses on Python 3.7+. The host-agent doesn't use
+# typing.get_type_hints() at runtime, so lazy annotations are safe here.
+from __future__ import annotations
+
 import argparse
 import atexit
 import collections


### PR DESCRIPTION
## Summary

`bin/dream-host-agent.py` uses PEP 604 union syntax (`X | None`) in non-stringified annotations, which fails to parse on Python 3.9 — the version Apple ships as `/usr/bin/python3` on macOS 14.x. The LaunchAgent fails at import with `TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'` and respawns indefinitely, leaving Dream Server's macOS install with no host agent → `/api/models/*/download` and `/api/extensions/*/install` return 503 "Host agent unreachable".

Reproduced on mac-mini (`/usr/bin/python3 --version` → `Python 3.9.6`) in fleet-test run `2026-05-14T12-43-56Z`, on a fresh install on top of PRs #1201 + #1203.

## Evidence

`launchctl list | grep dream`:
```
-       1       com.dreamserver.host-agent
```
(exit code 1, no PID — LaunchAgent failed to stay running.)

`~/Library/Logs/DreamServer/dream-host-agent.log`:
```
Traceback (most recent call last):
  File "/Users/michaelbradley/dream-server/bin/dream-host-agent.py", line 84, in <module>
    _model_download_thread: threading.Thread | None = None
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```
…repeated indefinitely (LaunchAgent KeepAlive restarts it).

16 occurrences of PEP 604 unions in the file, including module-level assignments evaluated at import time.

## Fix

Add `from __future__ import annotations` at the top of the module. This makes all annotations lazy strings (PEP 563), so PEP 604 syntax parses cleanly on Python 3.7+. The host-agent doesn't use `typing.get_type_hints()` at runtime, so lazy annotations are safe.

One-line change. `bin/dream-mdns.py` already has this import; I confirmed `bin/` has no other host-side Python scripts that need it.

## Test plan

- [x] `python3 -c "import ast; ast.parse(open('bin/dream-host-agent.py').read())"` succeeds.
- [ ] After merge: `launchctl unload && launchctl load ~/Library/LaunchAgents/com.dreamserver.host-agent.plist` on mac-mini; `launchctl list | grep dream-server` shows status 0 with a PID; `lsof -nP -iTCP:7710 -sTCP:LISTEN` shows the python3 listener; `curl http://127.0.0.1:7710/health` returns 200.
- [ ] Linux installs unaffected (host-agent already ran fine there; this is a parse-time fix, not a runtime semantics change).

## Why this didn't surface before PR #1203

PR #1203 is what made `dashboard-api → host-agent` calls actually attempt to reach the agent on dream-network containers. Before that, the calls timed out earlier in the network path on every install, masking the LaunchAgent-failed-to-start condition on macOS specifically. Once #1203 cleared the network blocker, the macOS install path surfaced as `503 "Host agent unreachable: Connection refused"` (TCP RST, nothing listening) — the LaunchAgent's actual cause was visible.
