### PR TITLE
[codex] document headless setup and AMD brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | | |
 |---|---|
 | [Quickstart](dream-server/QUICKSTART.md) | Step-by-step install guide with troubleshooting |
+| [Headless Setup](dream-server/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Hardware Guide](dream-server/docs/HARDWARE-GUIDE.md) | What to buy, tier recommendations |
 | [FAQ](dream-server/FAQ.md) | Common questions and configuration |
 | [Extensions](dream-server/docs/EXTENSIONS.md) | How to add custom services |

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -409,6 +409,7 @@ dream mode status                        # Show current mode
 
 - [docs/README.md](docs/README.md) — **Full documentation index** (start here)
 - [QUICKSTART.md](QUICKSTART.md) — Detailed setup guide
+- [HEADLESS-SETUP.md](docs/HEADLESS-SETUP.md) — QR onboarding, first-boot setup, AP mode, mDNS, and local agent access
 - [HARDWARE-GUIDE.md](docs/HARDWARE-GUIDE.md) — What to buy
 - [EXTENSIONS.md](docs/EXTENSIONS.md) — Add services, manifests, dashboard plugins
 - [INSTALLER-ARCHITECTURE.md](docs/INSTALLER-ARCHITECTURE.md) — Modding the installer

--- a/dream-server/docs/AMD-STRIX-HALO-GAMMA-BRIEF.md
+++ b/dream-server/docs/AMD-STRIX-HALO-GAMMA-BRIEF.md
@@ -1,0 +1,163 @@
+# Dream Server H2 on AMD Strix Halo
+
+Gamma.ai source outline for an AMD-facing partnership deck.
+
+This brief keeps the public product story hardware-neutral while using AMD
+Strix Halo as the concrete example platform. The feature is deployed in the
+Dream Server codebase and tested in pieces, but it still needs complete
+end-to-end validation on packaged target hardware before it should be described
+as production-ready appliance onboarding.
+
+## Slide 1: Dream Server H2
+
+**Headless Helper for local AI hardware**
+
+Dream Server H2 turns a local AI machine into an approachable appliance: power
+it on, scan a QR code, finish setup from a phone or laptop, and start using a
+local agent without needing a monitor.
+
+## Slide 2: The Problem
+
+Local AI hardware is powerful, but setup still feels like a developer workflow.
+
+- Many small AI appliances ship without a permanent monitor or keyboard.
+- Users may not know the device IP address, host name, or service ports.
+- Wi-Fi setup, local discovery, authentication, and chat access are usually
+  separate chores.
+- The strongest hardware story can be weakened if the first-run experience
+  starts with SSH, logs, and network debugging.
+
+## Slide 3: The Opportunity
+
+Make local AI hardware feel more like opening a useful device than configuring a
+server.
+
+- A vendor, reseller, lab, or friend can preinstall Dream Server.
+- The recipient can set up the device from a phone, laptop, tablet, or TV.
+- Power users still get the full dashboard, diagnostics, model controls, and
+  service visibility.
+- Everyday users can land directly in a local chat and voice-capable agent
+  surface.
+
+## Slide 4: Why Strix Halo Is A Strong Example
+
+Strix Halo is an ideal demo platform for this workflow because it combines
+local-AI-class memory bandwidth, APU simplicity, and living-room-friendly form
+factors.
+
+- One compact machine can run useful local models.
+- Unified memory helps make larger local models more approachable.
+- The same setup flow also applies to other capable hardware.
+- AMD can show a complete user journey, not only benchmark numbers.
+
+## Slide 5: The Solution
+
+Dream Server H2 connects the first-run pieces into one appliance flow.
+
+- Printed setup card with Wi-Fi and setup URL QR codes.
+- Optional first-boot access point for machines not already on a network.
+- Mobile-friendly setup wizard.
+- Host-side Wi-Fi scan and connect actions.
+- Local mDNS names such as `dashboard.dream.local` and `chat.dream.local`.
+- Magic-link invite QR that gives the first user an authenticated session.
+- Hermes agent surface behind Dream Server session auth.
+
+## Slide 6: User Journey
+
+1. Power on the preinstalled device.
+2. Scan the setup card QR code.
+3. Join the setup AP or open the local setup URL.
+4. Pick a Wi-Fi network from the first-boot wizard.
+5. Scan the invite QR.
+6. Land in a local agent chat experience.
+7. Open the dashboard later for models, services, telemetry, and diagnostics.
+
+## Slide 7: Architecture
+
+```mermaid
+flowchart LR
+    Card["Setup card QR codes"] --> Wizard["First-boot wizard"]
+    Wizard --> API["Dashboard API"]
+    API --> HostAgent["Host agent"]
+    HostAgent --> WiFi["Wi-Fi / NetworkManager"]
+    API --> Magic["Magic-link auth"]
+    Magic --> Session["Signed local session"]
+    Session --> Hermes["Hermes agent"]
+    Proxy["dream-proxy + mDNS"] --> Wizard
+    Proxy --> Hermes
+    Proxy --> Dashboard["Power-user dashboard"]
+```
+
+## Slide 8: Code Proof Points
+
+- Setup card QR generation:
+  [generate-setup-card.py](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/scripts/generate-setup-card.py#L51)
+- First-boot wizard:
+  [FirstBoot.jsx](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx#L80)
+- Setup and Wi-Fi API:
+  [setup.py](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/extensions/services/dashboard-api/routers/setup.py#L315)
+- Host-side Wi-Fi control:
+  [dream-host-agent.py](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/bin/dream-host-agent.py#L1216)
+- Magic-link QR and redemption:
+  [magic_link.py](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/extensions/services/dashboard-api/routers/magic_link.py#L382)
+- First-boot AP mode:
+  [ap-mode.sh](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/scripts/ap-mode.sh#L2)
+- LAN discovery:
+  [dream-mdns.py](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/bin/dream-mdns.py#L4)
+- Local reverse proxy:
+  [dream-proxy Caddyfile](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/extensions/services/dream-proxy/Caddyfile#L65)
+- Hermes authenticated entry path:
+  [hermes-proxy Caddyfile](https://github.com/Light-Heart-Labs/DreamServer/blob/62a7391d0b9d8c69ff0a48824d727950916e1f2a/dream-server/extensions/services/hermes-proxy/Caddyfile#L1)
+
+## Slide 9: Demo Plan
+
+Show the complete flow on a Strix Halo device while describing it as a
+hardware-neutral Dream Server capability.
+
+- Start with the device powered on and no monitor attached.
+- Scan the setup card from a phone.
+- Open the first-boot wizard.
+- Join Wi-Fi or confirm existing LAN connectivity.
+- Scan the magic-link invite QR.
+- Chat with Hermes from the phone or laptop.
+- Open the dashboard to show local services, model status, and controls.
+
+## Slide 10: What Still Needs Validation
+
+The code is present, but the appliance story needs hardware image validation.
+
+- End-to-end setup on the exact Strix Halo image.
+- Wi-Fi adapter AP-mode compatibility.
+- NetworkManager behavior across target Linux distributions.
+- mDNS behavior across common phone, laptop, router, and VPN environments.
+- Hermes auth handoff through the proxy on the packaged image.
+- Recovery path when the user changes networks or loses the setup card.
+
+## Slide 11: Partnership Ask
+
+Work together to turn the implemented feature into a polished hardware demo and
+marketplace-ready user journey.
+
+- Access to representative Strix Halo hardware and target OS images.
+- AMD guidance on Lemonade, ROCm, Vulkan, and model packaging best practices.
+- Co-validation of the headless first-run flow.
+- A Dream Server listing in the Lemonade Marketplace once the user journey is
+  validated.
+- Optional co-marketing around local AI appliance experiences on Strix Halo.
+
+## Appendix: Repo Reference
+
+- Hardware-neutral repo doc:
+  [HEADLESS-SETUP.md](HEADLESS-SETUP.md)
+- Setup card operator doc:
+  [SETUP-CARD.md](SETUP-CARD.md)
+- Hermes integration:
+  [HERMES.md](HERMES.md)
+- Hermes SSO:
+  [HERMES-SSO.md](HERMES-SSO.md)
+- AP mode:
+  [AP-MODE.md](AP-MODE.md)
+- Local proxy:
+  [DREAM-PROXY.md](DREAM-PROXY.md)
+- mDNS:
+  [MDNS.md](MDNS.md)

--- a/dream-server/docs/HEADLESS-SETUP.md
+++ b/dream-server/docs/HEADLESS-SETUP.md
@@ -1,0 +1,97 @@
+# Headless Setup and QR Onboarding
+
+Dream Server can be prepared as a local AI appliance: install it on hardware,
+ship or hand over the machine without a monitor, and let the recipient finish
+setup from a phone, laptop, tablet, or TV browser.
+
+This page is the hardware-neutral map of the code that makes that possible.
+Strix Halo, DGX Spark, NUC-style mini PCs, repurposed desktops, and home lab
+servers should all follow the same high-level flow once their platform-specific
+installer path is working.
+
+## Current Status
+
+The headless setup stack is implemented on `main` across the setup-card script,
+dashboard, dashboard API, host agent, mDNS announcer, AP-mode script, and Caddy
+proxy extensions.
+
+Status is **deployed in code, tested in pieces, and awaiting full end-to-end
+hardware validation** for a packaged appliance flow. In particular:
+
+- Magic-link generation, QR rendering, first-run state, and dashboard flows have
+  unit/integration coverage.
+- Wi-Fi management is implemented for Linux hosts with NetworkManager / `nmcli`.
+- AP mode is available but intentionally disabled by default because it takes
+  over a wireless interface.
+- mDNS plus `dream-proxy` provide the friendly LAN URLs, but local network
+  behavior should be validated on each hardware image and router environment.
+
+## User Journey
+
+1. The device is pre-installed with Dream Server and given a friendly
+   `DREAM_DEVICE_NAME` such as `dream`, `studio`, or `kitchen-ai`.
+2. The operator prints or ships a setup card with:
+   - a Wi-Fi QR code for the device setup AP, if AP mode is used;
+   - a setup URL QR code, usually `http://192.168.7.1/setup` during AP mode or
+     `http://dashboard.<device>.local/setup` on an existing LAN.
+3. The recipient scans the setup QR, opens the first-boot wizard, and joins the
+   device to their home network when needed.
+4. Dream Server generates a magic-link invite and QR code for the first user.
+5. After redemption, the user lands in the chat or agent surface. Power users can
+   still open the dashboard for model, service, and diagnostics controls.
+
+## Main Components
+
+| Component | Code | Tests / Docs | Purpose |
+|---|---|---|---|
+| Setup card generator | [`scripts/generate-setup-card.py`](../scripts/generate-setup-card.py) | [`tests/test_setup_card.py`](../tests/test_setup_card.py), [`SETUP-CARD.md`](SETUP-CARD.md) | Produces a printable card with Wi-Fi and setup URL QR codes. |
+| First-run state | [`extensions/services/dashboard-api/routers/setup.py`](../extensions/services/dashboard-api/routers/setup.py), [`extensions/services/dashboard/src/hooks/useFirstRun.js`](../extensions/services/dashboard/src/hooks/useFirstRun.js) | [`tests/test_setup.py`](../extensions/services/dashboard-api/tests/test_setup.py), [`App.test.jsx`](../extensions/services/dashboard/src/App.test.jsx) | Server-side setup sentinel that decides whether the wizard should appear. |
+| Phone-first wizard | [`extensions/services/dashboard/src/pages/FirstBoot.jsx`](../extensions/services/dashboard/src/pages/FirstBoot.jsx) | [`FirstBoot.test.jsx`](../extensions/services/dashboard/src/pages/FirstBoot.test.jsx) | Guides first setup and shows the first invite QR. |
+| Magic-link auth and QR | [`extensions/services/dashboard-api/routers/magic_link.py`](../extensions/services/dashboard-api/routers/magic_link.py), [`extensions/services/dashboard/src/pages/Invites.jsx`](../extensions/services/dashboard/src/pages/Invites.jsx) | [`test_magic_link.py`](../extensions/services/dashboard-api/tests/test_magic_link.py), [`Invites.test.jsx`](../extensions/services/dashboard/src/pages/Invites.test.jsx), [`HERMES-SSO.md`](HERMES-SSO.md) | Creates invite links, renders QR codes, redeems tokens, and issues signed session cookies. |
+| Wi-Fi setup API | [`extensions/services/dashboard-api/routers/setup.py`](../extensions/services/dashboard-api/routers/setup.py), [`bin/dream-host-agent.py`](../bin/dream-host-agent.py) | [`test_network_config.py`](../extensions/services/dashboard-api/tests/test_network_config.py), [`test_host_agent.py`](../extensions/services/dashboard-api/tests/test_host_agent.py) | Lets the dashboard ask the host agent to scan, connect, check status, and forget Wi-Fi profiles. |
+| First-boot AP mode | [`scripts/ap-mode.sh`](../scripts/ap-mode.sh), [`scripts/systemd/dream-ap-mode.service`](../scripts/systemd/dream-ap-mode.service), [`scripts/ap-mode.conf.example`](../scripts/ap-mode.conf.example) | [`test-ap-mode.sh`](../tests/test-ap-mode.sh), [`AP-MODE.md`](AP-MODE.md) | Optional setup access point for devices that are not yet on the user's network. |
+| LAN discovery | [`bin/dream-mdns.py`](../bin/dream-mdns.py), [`scripts/systemd/dream-mdns.service`](../scripts/systemd/dream-mdns.service) | [`MDNS.md`](MDNS.md) | Publishes `<device>.local` and service subdomains on the local network. |
+| LAN reverse proxy | [`extensions/services/dream-proxy/Caddyfile`](../extensions/services/dream-proxy/Caddyfile), [`extensions/services/dream-proxy/compose.yaml`](../extensions/services/dream-proxy/compose.yaml) | [`DREAM-PROXY.md`](DREAM-PROXY.md) | Routes `chat.<device>.local`, `dashboard.<device>.local`, `auth.<device>.local`, `api.<device>.local`, and `hermes.<device>.local`. |
+| Agent surface | [`extensions/services/hermes-proxy/Caddyfile`](../extensions/services/hermes-proxy/Caddyfile) | [`HERMES.md`](HERMES.md), [`HERMES-SSO.md`](HERMES-SSO.md) | Gates Hermes behind Dream Server magic-link session auth. |
+
+## Operator Prep Checklist
+
+For a hardware image or pre-installed unit:
+
+1. Install Dream Server normally for the target platform.
+2. Set a unique `DREAM_DEVICE_NAME` in `.env`.
+3. Set `DREAM_SESSION_SECRET` so magic-link redemption can issue signed
+   `dream-session` cookies.
+4. Enable the LAN entry path:
+   - `dream-proxy` for friendly HTTP routing;
+   - `dream-mdns` for local `.local` discovery where supported;
+   - `hermes-proxy` if the Hermes Agent should be LAN-reachable behind auth.
+5. For AP-based out-of-box setup, write `/etc/dream/ap-mode.conf`, install the
+   `dream-ap-mode.service` unit, and generate a setup card.
+6. Validate the exact QR flow on the target image before shipping.
+
+## Validation Checklist
+
+Use this checklist for each target hardware profile:
+
+- Fresh install completes without a monitor attached.
+- Setup card Wi-Fi QR joins the setup AP.
+- Setup URL QR opens the first-boot wizard.
+- Wi-Fi scan returns nearby networks on Linux NetworkManager hosts.
+- Wi-Fi connect succeeds and the device remains reachable after network handoff.
+- `dream-proxy` answers on port 80 from another device on the LAN.
+- `<device>.local`, `chat.<device>.local`, `dashboard.<device>.local`, and
+  `auth.<device>.local` resolve on at least one phone and one laptop.
+- First magic-link invite redeems, sets the signed cookie, and redirects to chat.
+- Hermes is reachable through `hermes.<device>.local` when enabled.
+- Dashboard remains available for power users after first-run completion.
+
+## Known Limits
+
+- AP mode is Linux-only and assumes NetworkManager, `hostapd`, `dnsmasq`,
+  `iptables`, and a Wi-Fi interface capable of AP mode.
+- AP mode is disabled by default because it is intentionally disruptive to a
+  wireless interface.
+- mDNS behavior varies by client OS, router, VPN, and enterprise network policy.
+- The complete appliance flow still needs repeated end-to-end testing on target
+  packaged hardware.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -9,6 +9,7 @@ Links from this directory use `../` for the repo root (e.g. `../README.md`, `../
 | [HOW-DREAM-SERVER-WORKS.md](HOW-DREAM-SERVER-WORKS.md) | **Everyone** | **The friendly guide — what Dream Server is, why it exists, how every piece fits together, and how to make it your own. No technical background required.** |
 | [../README.md](../README.md) | Everyone | Project overview, quickstart, architecture |
 | [../QUICKSTART.md](../QUICKSTART.md) | Operators | Step-by-step first install |
+| [HEADLESS-SETUP.md](HEADLESS-SETUP.md) | Operators / hardware builders | Hardware-neutral QR onboarding, first-boot setup, AP mode, mDNS, and local-agent access map |
 | [../EDGE-QUICKSTART.md](../EDGE-QUICKSTART.md) | Operators | Edge devices (planned — do not follow yet; use cloud mode for CPU-only today) |
 | [../.env.example](../.env.example) | Operators | All environment variables with defaults |
 
@@ -69,6 +70,7 @@ Links from this directory use `../` for the repo root (e.g. `../README.md`, `../
 | Doc | Audience | Description |
 |-----|----------|-------------|
 | [M1-OFFLINE-MODE.md](M1-OFFLINE-MODE.md) | Operators | Air-gapped operation guide |
+| [SETUP-CARD.md](SETUP-CARD.md) | Operators / hardware builders | Generate printable QR setup cards for headless devices |
 | [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) | Operators | Post-install verification |
 | [KNOWN-GOOD-VERSIONS.md](KNOWN-GOOD-VERSIONS.md) | Operators | Tested image/version combos |
 | [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) | Developers | Platform feature matrix |


### PR DESCRIPTION
﻿## Summary

- Add a hardware-neutral headless setup and QR onboarding reference for repo users and hardware builders.
- Add a Gamma.ai-ready AMD Strix Halo partnership brief that keeps Strix Halo as the example platform while preserving the repo's neutral positioning.
- Link the headless setup guide from the root README, dream-server README, and docs index.

## Validation

- Ran `git diff --check HEAD~1..HEAD`.
- Ran a local Markdown link sanity check across the touched docs.

## Notes

The headless setup doc explicitly says the feature is deployed in code and tested in pieces, but still awaiting full end-to-end hardware validation.
