### PR TITLE
[codex] fix DS2 magic-link device URL env

### DIFF
--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -207,6 +207,11 @@ services:
       # phase 06; an unconfigured dev box without the secret will fail
       # magic-link redemption loudly rather than mint unsignable cookies.
       - DREAM_SESSION_SECRET=${DREAM_SESSION_SECRET:-}
+      # Device/public URL inputs used by magic-link generation. Keep these
+      # aligned with dream-proxy and dream-mdns so invite QR codes point at
+      # the actual LAN-facing auth/chat hosts for the unit.
+      - DREAM_DEVICE_NAME=${DREAM_DEVICE_NAME:-dream}
+      - DREAM_PUBLIC_URL=${DREAM_PUBLIC_URL:-}
       # Cookie Domain scope. Set to <device>.local (no leading dot) so
       # cookies are shared across chat / auth / hermes / dashboard
       # subdomains routed by the dream-proxy. Empty = host-only (only


### PR DESCRIPTION
﻿## Summary

- Pass `DREAM_DEVICE_NAME` into `dashboard-api` so DS2 magic links use the same device hostname as `dream-proxy` and mDNS.
- Pass `DREAM_PUBLIC_URL` into `dashboard-api` so tunnel/custom-domain deployments can generate correct invite and redirect URLs.

## Why

During local DS2 end-to-end testing, the proxy was configured for `ds2test.local`, but generated invite links still pointed at `auth.dream.local`. `magic_link.py` reads `DREAM_DEVICE_NAME` / `DREAM_PUBLIC_URL` from the process environment, but compose did not provide those values to `dashboard-api`.

## Verification

- Built and ran a disposable current-main DS2 stack on alternate ports.
- Verified setup card generation.
- Verified `/setup` served through `dream-proxy`.
- Generated a magic-link invite through the dashboard/proxy route.
- Verified QR data URL generation.
- Marked setup complete and confirmed first-run became false.
- Redeemed the invite through `auth.ds2test.local` via the proxy: `302 Found` to `chat.ds2test.local`.
- Verified signed session cookie with `/api/auth/verify-session`: `200`.
- Verified chat and dashboard routes through proxy: `200`.
- Python DS2-focused tests: 112 passed, 2 deselected.
- Dashboard tests: 3 files / 8 tests passed.
