### PR TITLE
[codex] fix Windows OpenClaw profile self-copy

### DIFF
--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -185,8 +185,14 @@ if ($enableOpenClaw) {
         $_ocSrcProfile = Join-Path (Join-Path $installDir "config\openclaw") $openClawConfig
         $_ocDstProfile = Join-Path (Join-Path $installDir "config\openclaw") "openclaw.json"
         if (Test-Path $_ocSrcProfile) {
-            Copy-Item -Path $_ocSrcProfile -Destination $_ocDstProfile -Force
-            Write-AISuccess "Installed OpenClaw profile: $openClawConfig -> openclaw.json"
+            $_ocSrcResolved = (Resolve-Path $_ocSrcProfile).Path
+            $_ocDstResolved = [System.IO.Path]::GetFullPath($_ocDstProfile)
+            if ($_ocSrcResolved -ieq $_ocDstResolved) {
+                Write-AISuccess "OpenClaw profile already installed: $openClawConfig"
+            } else {
+                Copy-Item -Path $_ocSrcProfile -Destination $_ocDstProfile -Force
+                Write-AISuccess "Installed OpenClaw profile: $openClawConfig -> openclaw.json"
+            }
         } else {
             Write-AIError "Missing OpenClaw config $openClawConfig and no fallback present in repo. This is a packaging bug; please re-clone or report."
             exit 1


### PR DESCRIPTION
﻿## Summary

- Avoid copying `config/openclaw/openclaw.json` onto itself in the Windows installer.
- Keep the existing profile copy behavior for tier-specific profiles such as `pro.json` or `openclaw-strix-halo.json`.

## Why

A fresh non-interactive Windows install with `-OpenClaw` on Tier 1 selects `openclaw.json` as the active profile. Because the installed profile source and destination are the same path, PowerShell raises `Cannot overwrite the item ... with itself` and aborts phase 06 before Docker services launch.

## Verification

- Parsed `installers/windows/phases/06-directories.ps1` with PowerShell's AST parser.
- Ran a focused PowerShell self-copy simulation confirming the `openclaw.json` case is skipped cleanly.
- Reproduced the original failure during a fresh Windows install before applying the fix.
