### PR TITLE
fix(qr): honor dashboard URL in terminal helper

### DIFF
--- a/dream-server/lib/qrcode.sh
+++ b/dream-server/lib/qrcode.sh
@@ -6,27 +6,34 @@
 # QR CODE DISPLAY
 # ═══════════════════════════════════════════════════════════════
 
+# Best-effort LAN IP detection for remote access URLs.
+_dream_lan_ip() {
+    local lan_ip=""
+    if command -v ip >/dev/null 2>&1; then
+        lan_ip=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
+    fi
+
+    if [[ -z "$lan_ip" ]] && command -v ifconfig >/dev/null 2>&1; then
+        lan_ip=$(ifconfig 2>/dev/null | awk '/inet / && $2 != "127.0.0.1" {print $2; exit}')
+    fi
+
+    printf '%s' "$lan_ip"
+}
+
 # Print a QR code for the dashboard URL
 # Falls back to plain text if qrencode not available
 print_dashboard_qr() {
-    local url=${1:-"http://localhost:3001"}
-    local hostname
-    hostname=$(hostname 2>/dev/null || echo "localhost")
-    
-    # Try to get LAN IP for remote access
-    local lan_ip=""
-    if command -v ip &>/dev/null; then
-        lan_ip=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
-    elif command -v ifconfig &>/dev/null; then
-        lan_ip=$(ifconfig 2>/dev/null | grep 'inet ' | grep -v '127.0.0.1' | head -1 | awk '{print $2}')
+    local display_url="${1:-}"
+    if [[ -z "$display_url" ]]; then
+        local lan_ip
+        lan_ip=$(_dream_lan_ip)
+        display_url="http://${lan_ip:-localhost}:3001"
     fi
-    
-    local display_url="http://${lan_ip:-localhost}:3001"
     
     echo ""
     
     # Try qrencode if available
-    if command -v qrencode &>/dev/null; then
+    if command -v qrencode >/dev/null 2>&1; then
         echo -e "  ${BOLD}Scan to open Dashboard:${NC}"
         echo ""
         qrencode -t ANSIUTF8 -m 2 "$display_url" | sed 's/^/    /'
@@ -65,10 +72,8 @@ print_success_card() {
     local api_url=${4:-"http://localhost:8000/v1"}
     
     # Get LAN IP for remote access URLs
-    local lan_ip=""
-    if command -v ip &>/dev/null; then
-        lan_ip=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
-    fi
+    local lan_ip
+    lan_ip=$(_dream_lan_ip)
     
     local remote_dash="http://${lan_ip:-localhost}:3001"
     local remote_api="http://${lan_ip:-localhost}:8000/v1"

--- a/dream-server/tests/test-qrcode-helper.sh
+++ b/dream-server/tests/test-qrcode-helper.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+BOLD=""
+NC=""
+CYAN=""
+GREEN=""
+
+source "$PROJECT_DIR/lib/qrcode.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+requested_url="http://example.test:1234/custom"
+output=$(print_dashboard_qr "$requested_url")
+
+grep -Fq "$requested_url" <<< "$output" \
+    || fail "print_dashboard_qr did not include the explicit URL"
+
+if grep -Eq 'http://[^[:space:]]+:3001' <<< "$output"; then
+    fail "print_dashboard_qr replaced the explicit URL with a generated dashboard URL"
+fi
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+cat > "$tmpdir/ip" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+
+cat > "$tmpdir/ifconfig" <<'SH'
+#!/usr/bin/env bash
+cat <<'OUT'
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+    inet 127.0.0.1 netmask 0xff000000
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+    inet 10.42.0.99 netmask 0xffffff00 broadcast 10.42.0.255
+OUT
+SH
+
+chmod +x "$tmpdir/ip" "$tmpdir/ifconfig"
+
+lan_ip=$(PATH="$tmpdir:$PATH" _dream_lan_ip)
+[[ "$lan_ip" == "10.42.0.99" ]] \
+    || fail "_dream_lan_ip did not parse the macOS ifconfig fallback"
+
+default_output=$(PATH="$tmpdir:$PATH" print_dashboard_qr)
+grep -Fq "http://10.42.0.99:3001" <<< "$default_output" \
+    || fail "print_dashboard_qr did not use the discovered LAN IP by default"
+
+echo "[PASS] qrcode helper honors explicit URLs and macOS LAN detection"


### PR DESCRIPTION
## Summary

- honor the URL passed to `print_dashboard_qr` instead of replacing it with a generated `:3001` dashboard URL
- share LAN IP detection between dashboard QR and success card output
- add a shell regression test for explicit URLs and the macOS `ifconfig` fallback path

## Tests

- `bash -n dream-server/lib/qrcode.sh`
- `bash -n dream-server/tests/test-qrcode-helper.sh`
- `bash dream-server/tests/test-qrcode-helper.sh`
