### PR TITLE
[codex] fix Windows Whisper CUDA driver fallback

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -575,8 +575,15 @@ if ($dryRun) {
                 if ($currentBackend -eq "nvidia" -and -not $script:gpuPassthroughFailed) {
                     $gpuOverlay = Join-Path $svcDir.FullName "compose.nvidia.yaml"
                     if (Test-Path $gpuOverlay) {
-                        $relOverlay = $gpuOverlay.Substring($installDir.Length + 1) -replace "\\", "/"
-                        $composeFlags += @("-f", $relOverlay)
+                        $useGpuOverlay = $true
+                        if ($svcName -eq "whisper" -and $gpuInfo.DriverMajor -lt 575) {
+                            $useGpuOverlay = $false
+                            Write-AIWarn "Whisper CUDA image requires a newer NVIDIA driver than $($gpuInfo.DriverVersion); using CPU Whisper."
+                        }
+                        if ($useGpuOverlay) {
+                            $relOverlay = $gpuOverlay.Substring($installDir.Length + 1) -replace "\\", "/"
+                            $composeFlags += @("-f", $relOverlay)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
﻿## Summary

- Skip the Whisper NVIDIA compose overlay on Windows when the detected NVIDIA driver is older than branch 575.
- Keep the CPU Whisper service enabled so voice installs remain functional instead of failing the whole compose launch.

## Why

During a fresh Windows DS2 demo install on an RTX 5070 Laptop GPU with driver 573.22, the stack reached Docker launch but the CUDA Whisper image failed during container init:

`nvidia-container-cli: requirement error: unsatisfied condition: cuda>=12.9`

The base Whisper compose file already uses the CPU image. For this driver range, that is the safer default: slower STT, but the installer completes and voice endpoints are still live.

## Verification

- Parsed `installers/windows/install-windows.ps1` with PowerShell's AST parser.
- Ran Windows installer dry-run with `-Voice -OpenClaw -Workflows -Rag -Lan` on this machine.
- Manually started the fresh demo stack with CPU Whisper; `dream-whisper` is healthy.
