### PR TITLE
fix(hermes): gate anonymous proxy requests

### DIFF
--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -90,7 +90,11 @@
 
 		@denied status 401 403
 		handle_response @denied {
-			redir /auth/required 303
+			# The leading `*` is intentional. Without an explicit matcher,
+			# Caddy parses `/auth/required` as a path matcher and `303` as
+			# the redirect target, so unauthenticated `/` requests fall
+			# through to Hermes instead of being bounced to the invite page.
+			redir * /auth/required 303
 		}
 	}
 

--- a/dream-server/tests/test-hermes-proxy-caddyfile.sh
+++ b/dream-server/tests/test-hermes-proxy-caddyfile.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CADDYFILE="$PROJECT_DIR/extensions/services/hermes-proxy/Caddyfile"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+[[ -f "$CADDYFILE" ]] || fail "Hermes proxy Caddyfile not found"
+
+grep -Eq '^[[:space:]]*redir[[:space:]]+\*[[:space:]]+/auth/required[[:space:]]+303([[:space:]]*#.*)?$' "$CADDYFILE" \
+    || fail "Hermes proxy denied auth response must redirect with an explicit wildcard matcher"
+
+if grep -Eq '^[[:space:]]*redir[[:space:]]+/auth/required[[:space:]]+303([[:space:]]*#.*)?$' "$CADDYFILE"; then
+    fail "Hermes proxy redirect is missing the wildcard matcher; Caddy parses the target as a path matcher"
+fi
+
+echo "[PASS] Hermes proxy auth redirect uses explicit wildcard matcher"


### PR DESCRIPTION
## Summary

- fix Hermes proxy denied-auth redirect so anonymous requests are bounced to `/auth/required` instead of falling through to Hermes
- document why Caddy needs the explicit `*` matcher for this redirect
- add a shell regression test for the Caddyfile redirect shape

## Tests

- `bash -n dream-server/tests/test-hermes-proxy-caddyfile.sh`
- `bash dream-server/tests/test-hermes-proxy-caddyfile.sh`
- `bash -n dream-server/tests/test-qrcode-helper.sh`
- `bash dream-server/tests/test-qrcode-helper.sh`
- `docker run --rm -v $PWD/dream-server/extensions/services/hermes-proxy/Caddyfile:/etc/caddy/Caddyfile:ro caddy:2-alpine caddy adapt --config /etc/caddy/Caddyfile --pretty`

## E2E finding

During the fresh DS2 install test, `http://hermes.dream.local/` without a `dream-session` cookie returned Hermes directly. Caddy had parsed `redir /auth/required 303` as a path-matched redirect with `Location: 303`, so normal requests like `/` had no denied-response handler and continued to the upstream. `redir * /auth/required 303` adapts to `Location: /auth/required` and status `303`.