### PR TITLE
fix(hermes): keep proxy health public

### DIFF
--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -23,7 +23,6 @@
 # This is auth GATING, not user identification. Once past the gate,
 # all users share the same Hermes instance (same memories, skills,
 # persona). See docs/HERMES-SSO.md for the explicit limitation.
-
 {
 	# Disable Caddy's auto-HTTPS — Dream Server's TLS is handled at the
 	# Tailscale layer (PR-12) or by an explicit operator-side reverse
@@ -42,74 +41,79 @@
 # Listen on the proxy's internal port. Compose maps this to the external
 # HERMES_PROXY_PORT via the host port mapping.
 :9120 {
-	# Cheap health endpoint for Docker / dashboard probes. NEVER gates on
-	# the cookie — health checks are anonymous by design.
-	@health path /health
-	handle @health {
-		respond "ok" 200
-	}
-
-	@favicon path /favicon.ico
-	handle @favicon {
-		respond 204
-	}
-
-	# Static "you need an invite" page lives at /auth/required. Always
-	# accessible; this is where unauthenticated requests get bounced.
-	#
-	# `templates` lets index.html substitute `{{env "HERMES_PROXY_AUTH_DOCS_URL"}}`
-	# at response time, so operators can point recipients at a help doc /
-	# admin-contact page via env var without editing the HTML. The page
-	# only renders the "Need help?" row when the var is non-empty.
-	@auth_static path /auth/required* /auth/static/*
-	handle @auth_static {
-		root * /srv/auth-required
-		try_files {path} /index.html
-		templates
-		file_server
-	}
-
-	# Real session verification: delegate to dashboard-api's
-	# /api/auth/verify-session. That endpoint reads the dream-session
-	# cookie, verifies the HMAC signature against DREAM_SESSION_SECRET,
-	# and returns 200 (valid) or 401 (missing/expired/bad-signature).
-	#
-	# Caddy's forward_auth issues a sub-request to the auth upstream
-	# with the original Cookie header copied across, then:
-	#   * 2xx → falls through to reverse_proxy below
-	#   * non-2xx → the handle_response @denied block fires, sending the
-	#               user to the auth-required page (303 — important so a
-	#               no-cookie POST doesn't replay its body to /auth/required)
-	#
-	# DREAM_AUTH_UPSTREAM defaults to the in-network dashboard-api
-	# hostname (which only the compose bridge can resolve); operators
-	# can override via env if dashboard-api lives elsewhere.
-	forward_auth {$DREAM_AUTH_UPSTREAM:dream-dashboard-api:3002} {
-		uri /api/auth/verify-session
-		copy_headers Cookie
-
-		@denied status 401 403
-		handle_response @denied {
-			# The leading `*` is intentional. Without an explicit matcher,
-			# Caddy parses `/auth/required` as a path matcher and `303` as
-			# the redirect target, so unauthenticated `/` requests fall
-			# through to Hermes instead of being bounced to the invite page.
-			redir * /auth/required 303
+	# Caddy's global directive order would otherwise run forward_auth before
+	# these local handle blocks. Keep the literal order so health, favicon,
+	# and invite-help assets remain public, while every other path is gated.
+	route {
+		# Cheap health endpoint for Docker / dashboard probes. NEVER gates on
+		# the cookie — health checks are anonymous by design.
+		@health path /health
+		handle @health {
+			respond "ok" 200
 		}
-	}
 
-	# Forward everything to Hermes. reverse_proxy handles streaming
-	# responses (SSE) and WebSocket upgrades natively — Caddy's
-	# upstream-handling is the reason we picked it over rolling our
-	# own FastAPI proxy.
-	reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
-		# Pass-through with sane defaults. Caddy's defaults are
-		# correct for SSE + WS; we don't need to tweak buffering.
-		header_up X-Forwarded-Proto {scheme}
-		header_up X-Forwarded-Host {host}
-		# Add a marker the operator can grep for in Hermes's logs
-		# if they're debugging a "did this request come via the
-		# proxy or directly?" question.
-		header_up X-Dream-Auth-Proxy "1"
+		@favicon path /favicon.ico
+		handle @favicon {
+			respond 204
+		}
+
+		# Static "you need an invite" page lives at /auth/required. Always
+		# accessible; this is where unauthenticated requests get bounced.
+		#
+		# `templates` lets index.html substitute `{{env "HERMES_PROXY_AUTH_DOCS_URL"}}`
+		# at response time, so operators can point recipients at a help doc /
+		# admin-contact page via env var without editing the HTML. The page
+		# only renders the "Need help?" row when the var is non-empty.
+		@auth_static path /auth/required* /auth/static/*
+		handle @auth_static {
+			root * /srv/auth-required
+			try_files {path} /index.html
+			templates
+			file_server
+		}
+
+		# Real session verification: delegate to dashboard-api's
+		# /api/auth/verify-session. That endpoint reads the dream-session
+		# cookie, verifies the HMAC signature against DREAM_SESSION_SECRET,
+		# and returns 200 (valid) or 401 (missing/expired/bad-signature).
+		#
+		# Caddy's forward_auth issues a sub-request to the auth upstream
+		# with the original Cookie header copied across, then:
+		#   * 2xx → falls through to reverse_proxy below
+		#   * non-2xx → the handle_response @denied block fires, sending the
+		#               user to the auth-required page (303 — important so a
+		#               no-cookie POST doesn't replay its body to /auth/required)
+		#
+		# DREAM_AUTH_UPSTREAM defaults to the in-network dashboard-api
+		# hostname (which only the compose bridge can resolve); operators
+		# can override via env if dashboard-api lives elsewhere.
+		forward_auth {$DREAM_AUTH_UPSTREAM:dream-dashboard-api:3002} {
+			uri /api/auth/verify-session
+			copy_headers Cookie
+
+			@denied status 401 403
+			handle_response @denied {
+				# The leading `*` is intentional. Without an explicit matcher,
+				# Caddy parses `/auth/required` as a path matcher and `303` as
+				# the redirect target, so unauthenticated `/` requests fall
+				# through to Hermes instead of being bounced to the invite page.
+				redir * /auth/required 303
+			}
+		}
+
+		# Forward everything to Hermes. reverse_proxy handles streaming
+		# responses (SSE) and WebSocket upgrades natively — Caddy's
+		# upstream-handling is the reason we picked it over rolling our
+		# own FastAPI proxy.
+		reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119} {
+			# Pass-through with sane defaults. Caddy's defaults are
+			# correct for SSE + WS; we don't need to tweak buffering.
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Forwarded-Host {host}
+			# Add a marker the operator can grep for in Hermes's logs
+			# if they're debugging a "did this request come via the
+			# proxy or directly?" question.
+			header_up X-Dream-Auth-Proxy "1"
+		}
 	}
 }

--- a/dream-server/tests/test-hermes-proxy-caddyfile.sh
+++ b/dream-server/tests/test-hermes-proxy-caddyfile.sh
@@ -12,6 +12,16 @@ fail() {
 
 [[ -f "$CADDYFILE" ]] || fail "Hermes proxy Caddyfile not found"
 
+route_line=$(grep -nE '^[[:space:]]*route[[:space:]]*\{' "$CADDYFILE" | head -n 1 | cut -d: -f1)
+health_line=$(grep -nE '^[[:space:]]*@health[[:space:]]+path[[:space:]]+/health' "$CADDYFILE" | head -n 1 | cut -d: -f1)
+forward_auth_line=$(grep -nE '^[[:space:]]*forward_auth[[:space:]]+' "$CADDYFILE" | head -n 1 | cut -d: -f1)
+
+[[ -n "$route_line" ]] || fail "Hermes proxy Caddyfile must use route to preserve handler order"
+[[ -n "$health_line" ]] || fail "Hermes proxy health matcher not found"
+[[ -n "$forward_auth_line" ]] || fail "Hermes proxy forward_auth not found"
+[[ "$route_line" -lt "$health_line" && "$health_line" -lt "$forward_auth_line" ]] \
+    || fail "Hermes proxy route block must put anonymous health handling before forward_auth"
+
 grep -Eq '^[[:space:]]*redir[[:space:]]+\*[[:space:]]+/auth/required[[:space:]]+303([[:space:]]*#.*)?$' "$CADDYFILE" \
     || fail "Hermes proxy denied auth response must redirect with an explicit wildcard matcher"
 


### PR DESCRIPTION
## Summary

- wrap the Hermes proxy server block in `route` so Caddy preserves the intended order
- keep `/health`, `/favicon.ico`, and `/auth/required*` anonymous before the auth gate runs
- extend the Hermes proxy Caddyfile regression test to require route ordering before `forward_auth`

## Tests

- `bash -n dream-server/tests/test-hermes-proxy-caddyfile.sh`
- `bash dream-server/tests/test-hermes-proxy-caddyfile.sh`
- `bash -n dream-server/tests/test-qrcode-helper.sh`
- `bash dream-server/tests/test-qrcode-helper.sh`
- `docker run --rm -v $PWD/dream-server/extensions/services/hermes-proxy/Caddyfile:/etc/caddy/Caddyfile:ro caddy:2-alpine caddy adapt --config /etc/caddy/Caddyfile --pretty`

## E2E finding

After #1214, anonymous `/` was correctly denied, but Caddy's global directive ordering caused `forward_auth` to run before the local `/health` handler. That made `http://127.0.0.1:9120/health` return the invite redirect and left `dream-hermes-proxy` in `health: starting`. The `route` block preserves literal order so health/static invite routes are public and only application routes are auth-gated.