### PR TITLE
fix(installer): pin desktop agent host for dashboard API

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -163,6 +163,11 @@ WEBUI_PORT=3000            # Open WebUI (external → internal 8080)
 #   detection fails.  Set explicitly to override.
 # DREAM_AGENT_BIND=
 
+# Hostname/IP dashboard-api containers use to reach dream-host-agent.
+# Docker Desktop installs set this to host.docker.internal because the
+# host-agent stays loopback-only on macOS/Windows.
+# DREAM_AGENT_HOST=host.docker.internal
+
 # Dashboard API key (generate: openssl rand -hex 32)
 # DASHBOARD_API_KEY=
 

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -641,6 +641,11 @@
       "description": "Bind address for the Dream Host Agent HTTP server. Defaults to 127.0.0.1 on macOS/Windows, Docker bridge gateway IP on Linux (falls back to 127.0.0.1).",
       "default": ""
     },
+    "DREAM_AGENT_HOST": {
+      "type": "string",
+      "description": "Hostname or IP that dashboard-api containers use to reach the Dream Host Agent. Docker Desktop installs set this to host.docker.internal so loopback-only host-agent binds remain reachable from containers.",
+      "default": ""
+    },
     "DREAM_TIER": {
       "type": "string",
       "description": "Hardware tier classification (0-4, SH_LARGE, SH_COMPACT, NV_ULTRA, CLOUD)"

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -139,6 +139,11 @@ generate_dream_env() {
         if [[ -z "$(read_env_value "$env_path" "DREAM_AGENT_KEY")" ]]; then
             upsert_env_value "$env_path" "DREAM_AGENT_KEY" "$(new_secure_hex 32)"
         fi
+        # Dashboard API runs in Docker; host-agent stays loopback-only on
+        # Docker Desktop and is reachable from containers via this hostname.
+        if [[ -z "$(read_env_value "$env_path" "DREAM_AGENT_HOST")" ]]; then
+            upsert_env_value "$env_path" "DREAM_AGENT_HOST" "host.docker.internal"
+        fi
         # Upsert DREAMFORGE_PULL_POLICY=build on existing Apple Silicon
         # installs so the dreamforge upstream amd64-only image isn't pulled
         # under Rosetta 2 — same logic as the fresh-install branch below.
@@ -258,6 +263,8 @@ generate_dream_env() {
 # macOS has no --lan flag; operators opt in by setting BIND_ADDRESS=0.0.0.0
 # manually. HOST_LAN_IP is only populated when that pre-existed at install time.
 HOST_LAN_IP=${host_lan_ip}
+# Docker Desktop containers reach loopback-only host services through this name.
+DREAM_AGENT_HOST=${DREAM_AGENT_HOST:-host.docker.internal}
 
 #=== LLM Backend Mode ===
 DREAM_MODE=local

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -255,6 +255,8 @@ function New-DreamEnv {
 # 127.0.0.1 = localhost only (secure default)
 # 0.0.0.0   = accessible from LAN (install with -Lan or set manually)
 BIND_ADDRESS=$(Get-EnvOrNew "BIND_ADDRESS" "$(if ($EnableLan) { "0.0.0.0" } else { "127.0.0.1" })")
+# Docker Desktop containers reach loopback-only host services through this name.
+DREAM_AGENT_HOST=$(Get-EnvOrNew "DREAM_AGENT_HOST" "host.docker.internal")
 
 #=== LLM Backend Mode ===
 DREAM_MODE=$DreamMode

--- a/dream-server/tests/test-desktop-agent-host-env.sh
+++ b/dream-server/tests/test-desktop-agent-host-env.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+grep -F 'DREAM_AGENT_HOST=$(Get-EnvOrNew "DREAM_AGENT_HOST" "host.docker.internal")' \
+    "$ROOT_DIR/installers/windows/lib/env-generator.ps1" >/dev/null
+grep -F 'DREAM_AGENT_HOST=${DREAM_AGENT_HOST:-host.docker.internal}' \
+    "$ROOT_DIR/installers/macos/lib/env-generator.sh" >/dev/null
+grep -F '"DREAM_AGENT_HOST"' "$ROOT_DIR/.env.schema.json" >/dev/null
+grep -F '# DREAM_AGENT_HOST=host.docker.internal' "$ROOT_DIR/.env.example" >/dev/null
+
+echo "[PASS] desktop installers pin dashboard-api agent host to host.docker.internal"


### PR DESCRIPTION
﻿## Summary
- Set `DREAM_AGENT_HOST=host.docker.internal` in Windows fresh installs so dashboard-api reaches the loopback-only host agent on Docker Desktop.
- Backfill and emit the same setting for macOS installs.
- Document/schema the env var and add a regression shell check for desktop installer templates.

## Root Cause
During DS2 end-to-end validation on Windows, dashboard-api auto-resolved the Docker bridge gateway (`172.18.0.1`) for host-agent calls. The Windows host agent correctly bound loopback-only, so `/api/setup/network-status` returned 503 even though `host.docker.internal:7710/health` worked from inside the container.

## Validation
- `bash -n dream-server/tests/test-desktop-agent-host-env.sh`
- `bash dream-server/tests/test-desktop-agent-host-env.sh`
- `python -m json.tool dream-server/.env.schema.json`
- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_config.py -q`
