### PR TITLE
fix(dashboard): pass agent host env into API container

### DIFF
--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -184,6 +184,7 @@ services:
       - DREAM_INSTALL_DIR=/dream-server
       - DREAM_DATA_DIR=/data
       - DREAM_EXTENSIONS_LIBRARY_DIR=/data/extensions-library
+      - DREAM_AGENT_HOST=${DREAM_AGENT_HOST:-}
       - DREAM_AGENT_PORT=${DREAM_AGENT_PORT:-7710}
       - GPU_BACKEND=${GPU_BACKEND:-nvidia}
       - GPU_COUNT=${GPU_COUNT:-1}

--- a/dream-server/tests/test-desktop-agent-host-env.sh
+++ b/dream-server/tests/test-desktop-agent-host-env.sh
@@ -7,6 +7,8 @@ grep -F 'DREAM_AGENT_HOST=$(Get-EnvOrNew "DREAM_AGENT_HOST" "host.docker.interna
     "$ROOT_DIR/installers/windows/lib/env-generator.ps1" >/dev/null
 grep -F 'DREAM_AGENT_HOST=${DREAM_AGENT_HOST:-host.docker.internal}' \
     "$ROOT_DIR/installers/macos/lib/env-generator.sh" >/dev/null
+grep -F 'DREAM_AGENT_HOST=${DREAM_AGENT_HOST:-}' \
+    "$ROOT_DIR/docker-compose.base.yml" >/dev/null
 grep -F '"DREAM_AGENT_HOST"' "$ROOT_DIR/.env.schema.json" >/dev/null
 grep -F '# DREAM_AGENT_HOST=host.docker.internal' "$ROOT_DIR/.env.example" >/dev/null
 


### PR DESCRIPTION
﻿## Summary
- Pass `DREAM_AGENT_HOST` into the dashboard-api container from `.env`.
- Extend the desktop agent-host regression check to cover the compose mapping.

## Root Cause
PR #1216 generated `DREAM_AGENT_HOST=host.docker.internal` for Docker Desktop installs, but `docker-compose.base.yml` did not include that env var in the dashboard-api service. The container therefore ignored the generated setting and continued auto-resolving the bridge gateway.

## Validation
- `bash -n dream-server/tests/test-desktop-agent-host-env.sh`
- `bash dream-server/tests/test-desktop-agent-host-env.sh`
- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_config.py -q`
- `docker compose --env-file C:\Users\conta\dream-server-ds2-e2e\.env -f dream-server/docker-compose.base.yml config | Select-String -Pattern 'DREAM_AGENT_HOST|DREAM_AGENT_PORT'`
