### PR TITLE
chore(proxy): bump Caddy to 2.11.3

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- Updated Dream Proxy and Hermes Proxy to `caddy:2.11.3-alpine`.
+
 ## [2.4.0] - 2026-03-24
 
 ### Added

--- a/dream-server/docs/DREAM-PROXY.md
+++ b/dream-server/docs/DREAM-PROXY.md
@@ -96,3 +96,4 @@ If you want LAN access to a single specific service without the proxy, add a `po
 |---|---|---|
 | 2026-05-12 | `caddy:2.8.4-alpine` | Initial integration. HTTP only; TLS deferred. |
 | 2026-05-12 | `caddy:2.8.4-alpine` | Switched from path-based (`/chat`, `/api/*`) to host-based (`chat.<device>.local`, etc.) routing after audit on subpath issues. Cookie domain via `DREAM_COOKIE_DOMAIN`. |
+| 2026-05-15 | `caddy:2.11.3-alpine` | Updated Dream Proxy image to the current Caddy 2.x stable pin. |

--- a/dream-server/docs/HERMES-SSO.md
+++ b/dream-server/docs/HERMES-SSO.md
@@ -163,3 +163,4 @@ dream disable hermes-proxy
 | Date | Pinned Caddy | Notes |
 |---|---|---|
 | 2026-05-12 | `caddy:2.8.4-alpine` | Initial integration. |
+| 2026-05-15 | `caddy:2.11.3-alpine` | Updated Hermes Proxy image to the current Caddy 2.x stable pin. |

--- a/dream-server/extensions/services/dream-proxy/compose.yaml
+++ b/dream-server/extensions/services/dream-proxy/compose.yaml
@@ -2,7 +2,7 @@ services:
   dream-proxy:
     # Pinned Caddy 2.x. Same image we use for the Hermes auth proxy — single
     # static binary, ~50MB, native WS/SSE support, simple Caddyfile config.
-    image: caddy:2.8.4-alpine
+    image: caddy:2.11.3-alpine
     container_name: dream-proxy
     restart: unless-stopped
     depends_on:

--- a/dream-server/extensions/services/hermes-proxy/compose.yaml
+++ b/dream-server/extensions/services/hermes-proxy/compose.yaml
@@ -3,7 +3,7 @@ services:
     # Pinned Caddy 2.x. Single static binary, ~50MB image, native
     # SSE/WebSocket support — much lighter than a custom FastAPI proxy
     # for what amounts to "check a cookie, forward, or 303 redirect."
-    image: caddy:2.8.4-alpine
+    image: caddy:2.11.3-alpine
     container_name: dream-hermes-proxy
     restart: unless-stopped
     depends_on:

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -51,7 +51,7 @@ if [[ "$ENABLE_HERMES" == "true" ]]; then
     # rationale + "How to bump the pin" in docs/HERMES.md. Hermes-proxy
     # is the auth gate (Caddy) and is pulled alongside Hermes.
     PULL_LIST+=("nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f|HERMES — default agent (Nous Research)")
-    PULL_LIST+=("caddy:2.8.4-alpine|HERMES PROXY — magic-link auth gate (Caddy)")
+    PULL_LIST+=("caddy:2.11.3-alpine|HERMES PROXY — magic-link auth gate (Caddy)")
 fi
 [[ "$ENABLE_OPENCLAW" == "true" ]] && PULL_LIST+=("ghcr.io/openclaw/openclaw:2026.3.8|OPENCLAW — agent framework")
 [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]] && PULL_LIST+=("ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1|TEI — embedding engine")


### PR DESCRIPTION
## Summary
Updates Dream Server's Caddy-based proxy images from `caddy:2.8.4-alpine` to `caddy:2.11.3-alpine`.

## What changed
- Bumped Dream Proxy and Hermes Proxy compose images.
- Updated installer pre-pull image list for Hermes Proxy.
- Updated proxy documentation references.
- Added a changelog entry.

## Why
Caddy `2.11.3` is the current stable release and keeps the LAN proxy / Hermes auth proxy stack on a maintained 2.x image without changing proxy behavior or configuration.

## Validation
- `bash -n dream-server/installers/phases/08-images.sh`
- `docker manifest inspect caddy:2.11.3-alpine`
- `docker compose -f docker-compose.base.yml -f extensions/services/dream-proxy/compose.yaml -f extensions/services/hermes/compose.yaml -f extensions/services/hermes-proxy/compose.yaml config`
- `docker run --rm ... caddy:2.11.3-alpine caddy validate --config /etc/caddy/Caddyfile` for both proxy Caddyfiles