### PR TITLE
feat(auth): admin self-issued session — install owner can reach Hermes without a magic-link invite

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/auth.py
+++ b/dream-server/extensions/services/dashboard-api/routers/auth.py
@@ -1,31 +1,65 @@
 """Auth-related dashboard-api endpoints.
 
-Today: a single `/api/auth/verify-session` endpoint that validates the
-HMAC-signed ``dream-session`` cookie. Used by Caddy reverse proxies
-(specifically the Hermes auth-proxy) via ``forward_auth`` to gate
-access on a magic-link-redeemed session without each proxy needing to
-know the signing secret.
+Two endpoints today:
 
-The endpoint is intentionally not gated by the dashboard's API key —
-it's reachable from any reverse proxy on the bridge network. The
-security model: the cookie ITSELF is the credential. Without a valid
-signature, the endpoint returns 401. The endpoint never echoes
-unverifiable data back to the caller.
+  * ``GET /api/auth/verify-session`` — validates the HMAC-signed
+    ``dream-session`` cookie. Used by Caddy reverse proxies (e.g., the
+    Hermes auth-proxy) via ``forward_auth`` to gate access on a valid
+    session without each proxy needing to know the signing secret.
+
+  * ``POST /api/auth/admin-session`` — mints a signed ``dream-session``
+    cookie for the install owner (gated by ``DASHBOARD_API_KEY``). Lets
+    the admin reach cookie-gated services (Hermes, etc.) without
+    redeeming their own magic link. Without this, the install owner
+    would be locked out of their own services until they minted +
+    redeemed an invite to themselves, which is absurd UX.
+
+Security:
+  * ``verify-session`` is intentionally NOT gated by the API key — it's
+    reachable from any reverse proxy on the bridge network. The cookie
+    ITSELF is the credential.
+  * ``admin-session`` IS gated by the API key. Only callers that already
+    hold the admin secret (the dashboard, dream-cli, the host agent)
+    can mint a session. The minted cookie is identical in shape to one
+    issued by magic-link redemption; downstream consumers can't tell
+    them apart.
 """
 
 from __future__ import annotations
 
 import logging
+import os
+from typing import Optional
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
 
 import session_signer
+from security import verify_api_key
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["auth"])
 
 SESSION_COOKIE_NAME = "dream-session"
+# Same TTL the magic-link router uses for redeemed sessions; keeping
+# them aligned means an admin and a guest share the same expiry model
+# and the dashboard's "session expires in N hours" surface is uniform.
+SESSION_TTL_SECONDS = 12 * 3600
+
+
+def _cookie_domain() -> Optional[str]:
+    """Cookie ``Domain`` attribute. Empty/None = host-only cookie.
+
+    DREAM_COOKIE_DOMAIN is set by the installer to ``<DREAM_DEVICE_NAME>.local``
+    when dream-proxy + mDNS are wired so a single redemption authenticates
+    across chat.<name>.local, hermes.<name>.local, and the rest. With it
+    empty, the cookie is host-only — functional for single-host setups
+    but breaks subdomain SSO. Same logic as routers/magic_link.py;
+    duplicated here intentionally so the two cookie-issuing paths stay
+    coupled without one depending on the other.
+    """
+    raw = (os.environ.get("DREAM_COOKIE_DOMAIN") or "").strip()
+    return raw or None
 
 
 @router.get("/api/auth/verify-session")
@@ -71,3 +105,76 @@ def verify_session(request: Request) -> dict:
         expiry = 0
 
     return {"valid": True, "expires_at": expiry}
+
+
+@router.post("/api/auth/admin-session", dependencies=[Depends(verify_api_key)])
+def admin_session(response: Response, request: Request) -> dict:
+    """Mint a signed ``dream-session`` cookie for the install owner.
+
+    The install owner already holds ``DASHBOARD_API_KEY`` (the admin
+    credential). Requiring them to ALSO redeem a magic link to access
+    cookie-gated services (Hermes, future ones) is bad UX — they own
+    the box. This endpoint trades the admin API key in for a signed
+    ``dream-session`` cookie identical to one a magic-link redemption
+    would issue.
+
+    Used by:
+      * The dashboard UI on load — when ``verify-session`` returns 401
+        and the caller has the API key, the dashboard POSTs here to
+        mint a session quietly. From the user's POV, the sidebar
+        "Hermes" link just works.
+      * The first-boot wizard — after Finish, before showing the
+        success screen, so a fresh install lands with a session.
+      * The host agent / dream-cli — when running setup flows that
+        need to leave a cookie in a browser session for follow-up.
+
+    The cookie is identical in shape to a magic-link-issued one:
+    HMAC-SHA256 signed against ``DREAM_SESSION_SECRET``, ``HttpOnly``,
+    ``SameSite=Lax``, ``Secure`` when reached over HTTPS, with the
+    operator's ``DREAM_COOKIE_DOMAIN`` (if set) so it travels across
+    proxy subdomains.
+
+    Returns 503 if ``DREAM_SESSION_SECRET`` is not configured — same
+    behaviour as the redemption path. Issue must fail loudly, not
+    silently mint unverifiable cookies.
+    """
+    if not session_signer.is_configured():
+        logger.error(
+            "admin-session refused: DREAM_SESSION_SECRET is not configured. "
+            "Set it in .env (32+ random bytes) and restart dashboard-api."
+        )
+        raise HTTPException(
+            status_code=503,
+            detail="Session signing is not configured on this server.",
+        )
+
+    session_token = session_signer.issue(ttl_seconds=SESSION_TTL_SECONDS)
+    secure_cookie = request.url.scheme == "https"
+    cookie_domain = _cookie_domain()
+
+    cookie_kwargs: dict = dict(
+        max_age=SESSION_TTL_SECONDS,
+        httponly=True,
+        samesite="lax",
+        secure=secure_cookie,
+        path="/",
+    )
+    if cookie_domain:
+        cookie_kwargs["domain"] = cookie_domain
+
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=session_token,
+        **cookie_kwargs,
+    )
+
+    # Pull the expiry out for the dashboard's "session ends at X" surface.
+    # We know the format because we just minted it; defensive parse anyway.
+    try:
+        _, expiry_str, _ = session_token.split(".")
+        expiry = int(expiry_str)
+    except (ValueError, TypeError):
+        expiry = 0
+
+    logger.info("admin-session minted; expires_at=%d", expiry)
+    return {"ok": True, "expires_at": expiry}

--- a/dream-server/extensions/services/dashboard-api/tests/test_auth_router.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_auth_router.py
@@ -131,3 +131,74 @@ def test_error_response_is_the_same_regardless_of_reason(test_client):
     body_str = str(bodies[0])
     for leak in ("bad-signature", "no-secret", "malformed"):
         assert leak not in body_str, f"reason leaked: {leak!r} in {body_str!r}"
+
+
+# ---------------------------------------------------------------------------
+# admin-session — install owner mints their own cookie via the admin API key.
+# ---------------------------------------------------------------------------
+
+
+class TestAdminSession:
+
+    def test_requires_api_key(self, test_client):
+        """No auth header → 401. The endpoint is admin-only."""
+        resp = test_client.post("/api/auth/admin-session")
+        assert resp.status_code == 401
+
+    def test_with_api_key_returns_200_and_sets_cookie(self, test_client):
+        resp = test_client.post(
+            "/api/auth/admin-session",
+            headers=test_client.auth_headers,
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["expires_at"] > 0
+        set_cookies = [h for h in resp.headers.raw if h[0].lower() == b"set-cookie"]
+        cookie_blob = b" ".join(c[1] for c in set_cookies).lower()
+        assert b"dream-session=" in cookie_blob
+        assert b"httponly" in cookie_blob
+        assert b"samesite=lax" in cookie_blob
+
+    def test_minted_cookie_verifies(self, test_client):
+        """The cookie this endpoint mints must round-trip through
+        verify-session — proving it's the same signed shape that
+        forward_auth consumes from magic-link redemptions."""
+        resp = test_client.post(
+            "/api/auth/admin-session",
+            headers=test_client.auth_headers,
+        )
+        assert resp.status_code == 200
+        cookie = resp.cookies.get("dream-session")
+        assert cookie
+
+        # Roundtrip the cookie through verify-session directly.
+        ok, reason = session_signer.verify(cookie)
+        assert ok is True, f"admin-session cookie did not verify: {reason}"
+
+    def test_503_when_signing_unconfigured(self, test_client):
+        """If DREAM_SESSION_SECRET is empty, the endpoint refuses to mint."""
+        session_signer._set_secret_for_tests("")
+        try:
+            resp = test_client.post(
+                "/api/auth/admin-session",
+                headers=test_client.auth_headers,
+            )
+            assert resp.status_code == 503
+            assert "not configured" in resp.json()["detail"].lower()
+        finally:
+            session_signer._set_secret_for_tests("test-secret-for-verify-endpoint")
+
+    def test_respects_cookie_domain_env(self, test_client, monkeypatch):
+        """DREAM_COOKIE_DOMAIN flows through to the Cookie's Domain attribute
+        so subdomain SSO works the same as for magic-link cookies."""
+        monkeypatch.setenv("DREAM_COOKIE_DOMAIN", "kitchen.local")
+        resp = test_client.post(
+            "/api/auth/admin-session",
+            headers=test_client.auth_headers,
+        )
+        assert resp.status_code == 200
+        cookie_blob = b" ".join(
+            v for k, v in resp.headers.raw if k.lower() == b"set-cookie"
+        ).lower()
+        assert b"domain=kitchen.local" in cookie_blob

--- a/dream-server/extensions/services/dashboard/src/App.jsx
+++ b/dream-server/extensions/services/dashboard/src/App.jsx
@@ -5,6 +5,7 @@ import InstallPromptBanner from './components/InstallPromptBanner'
 import { useSystemStatus } from './hooks/useSystemStatus'
 import { useVersion } from './hooks/useVersion'
 import { useFirstRun } from './hooks/useFirstRun'
+import { useSessionBootstrap } from './hooks/useSessionBootstrap'
 import { getInternalRoutes } from './plugins/registry'
 import SplashScreen from './components/SplashScreen'
 
@@ -30,6 +31,12 @@ function setStorageValue(storage, key, value) {
 }
 
 function App() {
+  // Auto-mint a dream-session cookie on load so the install owner can
+  // reach cookie-gated services (Hermes, future ones) without redeeming
+  // a magic link to themselves. No-ops if a valid cookie already exists.
+  // See hooks/useSessionBootstrap.js for the full rationale.
+  useSessionBootstrap()
+
   // Show splash only once per browser session — not on every F5 / new tab
   const [splashDone, setSplashDone] = useState(
     () => getStorageValue(globalThis.sessionStorage, 'dream-splash-shown') === '1'

--- a/dream-server/extensions/services/dashboard/src/hooks/useSessionBootstrap.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useSessionBootstrap.js
@@ -1,0 +1,85 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Ensure the dashboard user has a valid `dream-session` cookie.
+ *
+ * Why this exists
+ * ---------------
+ * Cookie-gated services (hermes-proxy today, more later) `forward_auth`
+ * against `/api/auth/verify-session` and bounce anyone without a valid
+ * dream-session cookie to a "you need an invite" page. Without this
+ * bootstrap the install owner would have to mint + redeem a magic
+ * link to themselves before they could reach their own services —
+ * absurd UX.
+ *
+ * The dashboard already authenticates to dashboard-api with the admin
+ * API key (nginx injects `Authorization: Bearer ${DASHBOARD_API_KEY}`
+ * via proxy_set_header). On load we:
+ *
+ *   1. GET /api/auth/verify-session
+ *   2. If 200 — already have a session, nothing to do.
+ *   3. If 401 — POST /api/auth/admin-session, which mints a signed
+ *      cookie (same shape magic-link redemption issues) and the
+ *      browser keeps it for 12 hours.
+ *
+ * From the user's POV: open dashboard → sidebar's Hermes link just
+ * works. No invite-to-yourself dance.
+ *
+ * Runs once per mount. Re-runs only if the page is reloaded — which is
+ * fine, the verify-session call is cheap (one signature check, no
+ * DB lookups). If session_signer isn't configured server-side the
+ * admin-session POST 503s; we surface that in console as a hint to
+ * set DREAM_SESSION_SECRET, but don't block the dashboard.
+ */
+export function useSessionBootstrap() {
+  const ran = useRef(false)
+
+  useEffect(() => {
+    if (ran.current) return
+    ran.current = true
+
+    const run = async () => {
+      try {
+        const verify = await fetch('/api/auth/verify-session', {
+          // Include the cookie if the browser has one — that's how
+          // verify-session decides whether to return 200 or 401.
+          credentials: 'same-origin',
+        })
+        if (verify.ok) return  // session already present
+
+        // 401 (or any non-2xx, e.g. 503 if dashboard-api is mid-restart) —
+        // try to mint a fresh session. nginx injects the API-key Authorization
+        // header, so the POST is authenticated automatically.
+        const mint = await fetch('/api/auth/admin-session', {
+          method: 'POST',
+          credentials: 'same-origin',
+        })
+        if (mint.ok) return
+
+        // 503 = DREAM_SESSION_SECRET not configured. The dashboard still
+        // works; cookie-gated services won't. Surface the hint quietly.
+        if (mint.status === 503) {
+          const body = await mint.json().catch(() => ({}))
+          // eslint-disable-next-line no-console
+          console.warn(
+            '[dream-session] could not mint admin session:',
+            body.detail || 'server misconfigured',
+            '— set DREAM_SESSION_SECRET in .env and restart dashboard-api',
+          )
+          return
+        }
+
+        // Other failures (network, 5xx) — log for the operator but don't
+        // crash the dashboard. The user still has the dashboard surface;
+        // just the Hermes / chat tiles will route them to the invite page.
+        // eslint-disable-next-line no-console
+        console.warn('[dream-session] admin-session returned', mint.status)
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[dream-session] bootstrap failed:', err)
+      }
+    }
+
+    run()
+  }, [])
+}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -132,6 +132,28 @@ export default function FirstBoot({ onComplete }) {
         )
       }
 
+      // Mint an admin dream-session cookie for the operator who just
+      // completed the wizard. Without this, after onboarding they'd
+      // be blocked at the Hermes / chat tiles by the same forward_auth
+      // gate that requires magic-link redemption — having to mint and
+      // redeem an invite to themselves is absurd UX. The endpoint is
+      // gated by DASHBOARD_API_KEY (nginx injects the header) so only
+      // someone with admin trust can mint. Non-fatal: if it fails the
+      // wizard still finishes; the user can re-mint by reloading the
+      // dashboard (App.jsx's useSessionBootstrap retries on every load).
+      try {
+        const adminResp = await fetch('/api/auth/admin-session', { method: 'POST' })
+        if (!adminResp.ok && adminResp.status !== 503) {
+          // 503 = signing not configured server-side; surfaced elsewhere.
+          // Other errors are operationally interesting but non-fatal here.
+          // eslint-disable-next-line no-console
+          console.warn('[dream-session] admin-session returned', adminResp.status)
+        }
+      } catch (err) {
+        // eslint-disable-next-line no-console
+        console.warn('[dream-session] admin-session network failure:', err)
+      }
+
       setInvite(inviteData)
       clearProgress()
       // Stay on the success screen until the user taps "Open dashboard".


### PR DESCRIPTION
## Why

After #1214 (hermes proxy gates anonymous requests), the install owner can't reach Hermes from their own dashboard without first minting **and redeeming** a magic-link invite to themselves. New users coming out of onboarding hit the same wall. That's broken UX — the install owner already holds \`DASHBOARD_API_KEY\` (the admin credential); they shouldn't have to invite themselves.

## What

Three coordinated changes, all small:

1. **\`POST /api/auth/admin-session\`** (dashboard-api/routers/auth.py) — gated by \`Depends(verify_api_key)\`. Trades the admin API key in for a signed \`dream-session\` cookie identical in shape to one issued by magic-link redemption. Downstream consumers (Caddy \`forward_auth\`, hermes-proxy) can't tell admin-minted from redeemed — they just check the HMAC.

2. **\`useSessionBootstrap\` hook in App.jsx** — on dashboard mount, GET \`/api/auth/verify-session\`. If 401, POST \`/api/auth/admin-session\` (nginx injects the API key Authorization header). From the user's POV the sidebar's Hermes link just works.

3. **First-boot wizard \`finish()\`** — mints an admin session immediately after \`/api/setup/complete\` flips the sentinel. Fresh installs land with a working cookie.

Returns 503 if \`DREAM_SESSION_SECRET\` is unconfigured (matching the magic-link path's loud-fail posture).

## Security

The admin-session endpoint is gated by the same auth as every other admin route — \`Depends(verify_api_key)\`. Only callers holding \`DASHBOARD_API_KEY\` can mint a session. The minted cookie is the same shape session_signer issues elsewhere; nothing weaker.

## Tests

- 5 new tests on \`admin-session\` cover: auth required, cookie Set-Cookie flags, roundtrip through verify-session (proves it's the same shape forward_auth consumes), 503 on unconfigured secret, \`DREAM_COOKIE_DOMAIN\` propagation.
- 32 of 32 \`auth_router\` + \`session_signer\` tests pass.
- Dashboard \`npm run build\` clean.

## Verified on a live install

End-to-end test on a running stack (Hermes container behind hermes-proxy):

\`\`\`
POST /api/auth/admin-session → 200, Set-Cookie: dream-session=...
GET /api/auth/verify-session (with cookie) → 200
GET hermes-proxy:9120/ (with cookie) → 200 (Hermes HTML)
GET hermes-proxy:9120/ (no cookie)   → 303 → /auth/required
\`\`\`

## Out of scope

- Cookie revocation list (still relies on rotating \`DREAM_SESSION_SECRET\` if a session leaks).
- Per-user identity in the cookie (still opaque; documented in HERMES-SSO.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)