### PR TITLE
fix(hermes): enable in-browser chat (HERMES_DASHBOARD_TUI=1)

### DIFF
--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -90,6 +90,22 @@
 		forward_auth {$DREAM_AUTH_UPSTREAM:dream-dashboard-api:3002} {
 			uri /api/auth/verify-session
 			copy_headers Cookie
+			# Strip WebSocket upgrade headers from the auth sub-request.
+			# Hermes's in-browser chat opens WebSockets to /api/ws +
+			# /api/pty + /api/events. Without these strips, Caddy
+			# propagates the Upgrade/Connection/Sec-WebSocket-* headers
+			# to the verify-session sub-request, dashboard-api's FastAPI
+			# treats it as a malformed WS handshake (no WS handler at
+			# that path), returns 403, and forward_auth bounces the user
+			# to /auth/required even though their cookie is valid. The
+			# auth sub-request is plain HTTP regardless of what protocol
+			# the original request is; force that here.
+			header_up -Connection
+			header_up -Upgrade
+			header_up -Sec-Websocket-Key
+			header_up -Sec-Websocket-Version
+			header_up -Sec-Websocket-Protocol
+			header_up -Sec-Websocket-Extensions
 
 			@denied status 401 403
 			handle_response @denied {

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -41,6 +41,21 @@ services:
       # --no-open equivalent: stops Hermes from trying to spawn a browser
       # inside the container.
       - HERMES_DASHBOARD_NO_OPEN=1
+      # Enable the in-browser chat tab. Hermes's chat surface is PTY-
+      # backed (it runs a real REPL inside the container and pipes it
+      # to the browser via WebSocket on /api/pty + /api/ws + /api/events).
+      # Without HERMES_DASHBOARD_TUI=1 those endpoints stay off and
+      # the React UI renders Sessions / Analytics / Models / Cron /
+      # Skills / etc. but has no way to actually start a conversation.
+      # Upstream defaults this off because PTY = shell access; we flip
+      # it on because (a) Hermes is the agent we ship — chat is the
+      # point — and (b) the surface is gated end-to-end:
+      #   * hermes container is internal-only (compose `expose:`)
+      #   * hermes-proxy in front does forward_auth against
+      #     dashboard-api/api/auth/verify-session
+      #   * a magic-link session OR admin-session bootstrap (#1222) is
+      #     required before Caddy lets the request through
+      - HERMES_DASHBOARD_TUI=1
     volumes:
       # Persistent state: Hermes's HERMES_HOME. Sessions, skills, memories,
       # cron jobs, audit logs all live here.


### PR DESCRIPTION
## Why

The Hermes Agent dashboard renders Sessions / Analytics / Models / Skills / Cron / Plugins / etc. — but the actual chat surface is missing. Empty Sessions page says "Start a conversation to see it here" with no way to do so. Verified on a live install: \`window.__HERMES_DASHBOARD_EMBEDDED_CHAT__=false\` in the served HTML.

Upstream Hermes Agent gates the in-browser chat behind \`HERMES_DASHBOARD_TUI=1\` because it's PTY-backed (a real REPL inside the container piped to the browser via WebSocket on \`/api/pty\`, \`/api/ws\`, \`/api/events\`). Off by default for safety.

## Why turn it on for us

The PTY trust model is fine in our stack:

- \`dream-hermes\` is internal-only (compose \`expose:\`, no host port binding)
- \`hermes-proxy\` fronts it with Caddy \`forward_auth\` against \`dashboard-api/api/auth/verify-session\`
- A magic-link redemption OR admin-session bootstrap (#1222) is required before Caddy lets a request through

So PTY isn't a new attack surface — it's reachable only after the same auth gate as everything else in the Hermes stack. And without PTY, the agent is non-functional, which defeats the point of shipping Hermes as Dream Server's native agent (per #1221).

## Verified

After \`HERMES_DASHBOARD_TUI=1\`:

\`\`\`
curl http://localhost:9120/ → \`window.__HERMES_DASHBOARD_EMBEDDED_CHAT__=true\`
curl http://localhost:9120/chat → 200
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)