### PR TITLE
fix(hermes-proxy): include /healthz in anonymous health matcher

### DIFF
--- a/dream-server/extensions/services/hermes-proxy/Caddyfile
+++ b/dream-server/extensions/services/hermes-proxy/Caddyfile
@@ -13,7 +13,9 @@
 #
 # Flow:
 #   1. Request arrives on :9120
-#   2. /health and /favicon.ico — always answered (so health checks work)
+#   2. /health, /healthz, and /favicon.ico — always answered (so health
+#      checks work; /healthz is the k8s-convention path that dream-fleet-test
+#      and other standard health checkers probe)
 #   3. /auth/* — static "you need an invite" assets (always served)
 #   4. Everything else: forward_auth to dashboard-api/api/auth/verify-session
 #      - 2xx → reverse-proxy to dream-hermes:9119
@@ -45,9 +47,13 @@
 	# these local handle blocks. Keep the literal order so health, favicon,
 	# and invite-help assets remain public, while every other path is gated.
 	route {
-		# Cheap health endpoint for Docker / dashboard probes. NEVER gates on
-		# the cookie — health checks are anonymous by design.
-		@health path /health
+		# Cheap health endpoints for Docker / dashboard / k8s probes. NEVER
+		# gate on the cookie — health checks are anonymous by design. Match
+		# both /health (Docker / our dashboard) and /healthz (k8s convention,
+		# what dream-fleet-test verify hits — anything monitoring at the
+		# standard k8s path was getting a 303 to /auth/required and being
+		# marked unhealthy).
+		@health path /health /healthz
 		handle @health {
 			respond "ok" 200
 		}

--- a/dream-server/tests/test-hermes-proxy-caddyfile.sh
+++ b/dream-server/tests/test-hermes-proxy-caddyfile.sh
@@ -29,4 +29,14 @@ if grep -Eq '^[[:space:]]*redir[[:space:]]+/auth/required[[:space:]]+303([[:spac
     fail "Hermes proxy redirect is missing the wildcard matcher; Caddy parses the target as a path matcher"
 fi
 
+# Health matcher must cover BOTH /health and /healthz. The Docker healthcheck
+# uses /health; k8s and dream-fleet-test verify probes use /healthz. Anything
+# left out of the matcher falls through to forward_auth and gets bounced to
+# /auth/required (303) — health monitors then mark the proxy unhealthy.
+grep -Eq '^[[:space:]]*@health[[:space:]]+path([[:space:]]+/[A-Za-z]+)*[[:space:]]+/healthz([[:space:]]|$)' "$CADDYFILE" \
+    || fail "Hermes proxy @health matcher must include /healthz (k8s-convention health path)"
+grep -Eq '^[[:space:]]*@health[[:space:]]+path([[:space:]]+/[A-Za-z]+)*[[:space:]]+/health([[:space:]]|$)' "$CADDYFILE" \
+    || fail "Hermes proxy @health matcher must include /health (Docker healthcheck path)"
+
 echo "[PASS] Hermes proxy auth redirect uses explicit wildcard matcher"
+echo "[PASS] Hermes proxy /health and /healthz both anonymous"


### PR DESCRIPTION
## What failed

`/dream-fleet-test` smoke gate aborted on mac-mini because the core verify probe
`hermes-proxy/healthz` returned **HTTP 303** instead of 2xx:

```
GET http://127.0.0.1:9120/healthz
HTTP/1.1 303 See Other
Location: /auth/required
Server: Caddy
```

Run dir: `/home/michael/dream-fleet-test/runs/2026-05-16T16-56-58Z` (bug record
`bugs/verify-hermes-proxy-healthz.json`). Install on mac-mini completed cleanly
(1m 30s, all 9 services healthy by the installer's own readiness check); the
smoke gate aborted the fleet test before the other three hosts could install.

## Root cause

The hermes-proxy Caddyfile only exempts the literal path `/health` from
`forward_auth`:

```caddy
@health path /health
handle @health { respond "ok" 200 }
```

Any other path — including `/healthz`, which is the k8s-convention health
endpoint that monitoring/orchestration tools probe by default — falls through
to `forward_auth`, fails session validation (no cookie), and gets bounced to
`/auth/required` (303). The dream-fleet-test verify probe hits `/healthz`
because that's what k8s/standard monitors check; the Caddyfile's own comment
already advertises the endpoint as "Cheap health endpoint for Docker /
dashboard probes. NEVER gates on the cookie — health checks are anonymous by
design", so the intent is clearly that any standard health checker should get
a 200 without a cookie.

## Fix

Two-line change in `extensions/services/hermes-proxy/Caddyfile`: extend the
`@health` matcher to cover both paths:

```caddy
@health path /health /healthz
```

Comment + flow doc updated accordingly. Existing `/health` callers (Docker
healthcheck, dashboard) are unaffected.

Test `tests/test-hermes-proxy-caddyfile.sh` tightened to assert both `/health`
and `/healthz` are in the matcher — locks the regression so a future Caddyfile
refactor can't drop `/healthz` silently.

## Why it's safe

- No new behavior for `/health` callers — same handler, same response.
- `/healthz` previously returned a 303 redirect with `Content-Length: 0`; now
  returns `200 ok`. Anything that was treating the 303 as "alive" gets a
  cleaner signal; anything that was treating it as "dead" (the correct read)
  starts seeing the service as up.
- Auth gating semantics for every other path unchanged — `forward_auth` still
  fronts everything that isn't `/health`, `/healthz`, `/favicon.ico`, or
  `/auth/*`.
- Test added in the same PR fails fast if either path is dropped from the
  matcher.
