### PR TITLE
fix(installer/host-agent): scope firewall rule to dream-network subnet

### DIFF
--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -187,13 +187,10 @@ check_docker_desktop_sharing
 # never abort install.
 if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
     ai_warn "UFW is active. The dashboard host agent must be reachable from compose subnets."
-    ai_warn "After install, run:"
-    ai_warn "  sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent'"
+    ai_warn "The installer will auto-add a scoped rule for the actual dream-network subnet after compose starts."
 elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
     ai_warn "firewalld is active. The dashboard host agent must be reachable from compose subnets."
-    ai_warn "After install, run:"
-    ai_warn "  sudo firewall-cmd --permanent --add-rich-rule='rule family=\"ipv4\" source address=\"172.16.0.0/12\" port protocol=\"tcp\" port=\"7710\" accept'"
-    ai_warn "  sudo firewall-cmd --reload"
+    ai_warn "The installer will auto-add a scoped rule for the actual dream-network subnet after compose starts."
 fi
 
 ai_ok "Pre-flight checks passed."

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -320,6 +320,38 @@ if [[ -f "$INSTALL_DIR/bin/dream-host-agent.py" ]]; then
                 fi
             fi
             # loginctl enable-linger no longer needed for host agent (system-mode unit)
+
+            # Open the firewall to dashboard-api → host-agent traffic.
+            # dashboard-api runs inside a compose container and reaches the
+            # host-agent at the Docker bridge gateway:7710. With UFW or
+            # firewalld in default-DROP, the INPUT chain blocks that flow
+            # and the dashboard reports "Host agent is offline" even though
+            # the agent itself is up. The preflight phase warns about this,
+            # but the warning is easy to miss in a long, successful install
+            # log; the rule is mechanical, scoped to RFC-1918 docker subnets
+            # only, and idempotent — apply it directly when we have sudo.
+            if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
+                if sudo ufw status 2>/dev/null | grep -qE '7710/tcp.*ALLOW.*172\.16\.0\.0/12'; then
+                    ai_ok "UFW already allows dream-host-agent (port 7710) from compose subnets"
+                elif sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent' 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+                    ai_ok "UFW: allowed dream-host-agent (port 7710) from 172.16.0.0/12 (docker bridge subnets)"
+                else
+                    ai_warn "UFW: failed to auto-add host-agent rule — run manually:"
+                    ai_warn "  sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent'"
+                fi
+            elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+                fw_rule='rule family="ipv4" source address="172.16.0.0/12" port protocol="tcp" port="7710" accept'
+                if sudo firewall-cmd --query-rich-rule="$fw_rule" >/dev/null 2>&1; then
+                    ai_ok "firewalld already allows dream-host-agent (port 7710) from compose subnets"
+                elif sudo firewall-cmd --permanent --add-rich-rule="$fw_rule" 2>&1 | tee -a "$LOG_FILE" >/dev/null \
+                  && sudo firewall-cmd --reload 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+                    ai_ok "firewalld: allowed dream-host-agent (port 7710) from 172.16.0.0/12"
+                else
+                    ai_warn "firewalld: failed to auto-add host-agent rule — run manually:"
+                    ai_warn "  sudo firewall-cmd --permanent --add-rich-rule='$fw_rule'"
+                    ai_warn "  sudo firewall-cmd --reload"
+                fi
+            fi
         else
             ai_warn "No systemd detected — dream host agent not auto-installed."
             ai_warn "  Start manually: dream agent start"

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -321,37 +321,6 @@ if [[ -f "$INSTALL_DIR/bin/dream-host-agent.py" ]]; then
             fi
             # loginctl enable-linger no longer needed for host agent (system-mode unit)
 
-            # Open the firewall to dashboard-api → host-agent traffic.
-            # dashboard-api runs inside a compose container and reaches the
-            # host-agent at the Docker bridge gateway:7710. With UFW or
-            # firewalld in default-DROP, the INPUT chain blocks that flow
-            # and the dashboard reports "Host agent is offline" even though
-            # the agent itself is up. The preflight phase warns about this,
-            # but the warning is easy to miss in a long, successful install
-            # log; the rule is mechanical, scoped to RFC-1918 docker subnets
-            # only, and idempotent — apply it directly when we have sudo.
-            if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
-                if sudo ufw status 2>/dev/null | grep -qE '7710/tcp.*ALLOW.*172\.16\.0\.0/12'; then
-                    ai_ok "UFW already allows dream-host-agent (port 7710) from compose subnets"
-                elif sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent' 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
-                    ai_ok "UFW: allowed dream-host-agent (port 7710) from 172.16.0.0/12 (docker bridge subnets)"
-                else
-                    ai_warn "UFW: failed to auto-add host-agent rule — run manually:"
-                    ai_warn "  sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent'"
-                fi
-            elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
-                fw_rule='rule family="ipv4" source address="172.16.0.0/12" port protocol="tcp" port="7710" accept'
-                if sudo firewall-cmd --query-rich-rule="$fw_rule" >/dev/null 2>&1; then
-                    ai_ok "firewalld already allows dream-host-agent (port 7710) from compose subnets"
-                elif sudo firewall-cmd --permanent --add-rich-rule="$fw_rule" 2>&1 | tee -a "$LOG_FILE" >/dev/null \
-                  && sudo firewall-cmd --reload 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
-                    ai_ok "firewalld: allowed dream-host-agent (port 7710) from 172.16.0.0/12"
-                else
-                    ai_warn "firewalld: failed to auto-add host-agent rule — run manually:"
-                    ai_warn "  sudo firewall-cmd --permanent --add-rich-rule='$fw_rule'"
-                    ai_warn "  sudo firewall-cmd --reload"
-                fi
-            fi
         else
             ai_warn "No systemd detected — dream host agent not auto-installed."
             ai_warn "  Start manually: dream agent start"

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -67,6 +67,64 @@ else
         ai_ok "Rewrote .env for CPU fallback"
     }
 
+    _phase11_allow_host_agent_firewall() {
+        local network_name="${1:-dream-network}"
+        local port="${DREAM_AGENT_PORT:-7710}"
+        local bind_addr="${DREAM_AGENT_BIND:-}"
+        local subnet fw_rule
+        local -a subnets=()
+
+        [[ "$(uname -s 2>/dev/null || echo unknown)" == "Linux" ]] || return 0
+        command -v systemctl >/dev/null 2>&1 || return 0
+        command -v sudo >/dev/null 2>&1 || return 0
+
+        if [[ -n "$bind_addr" && "$bind_addr" != "0.0.0.0" ]]; then
+            ai_warn "DREAM_AGENT_BIND=$bind_addr; skipping automatic host-agent firewall rule."
+            return 0
+        fi
+
+        while IFS= read -r subnet; do
+            [[ -n "$subnet" && "$subnet" != *:* ]] && subnets+=("$subnet")
+        done < <($DOCKER_CMD network inspect "$network_name" \
+            --format '{{range .IPAM.Config}}{{println .Subnet}}{{end}}' 2>/dev/null || true)
+
+        if [[ ${#subnets[@]} -eq 0 ]]; then
+            if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
+                ai_warn "UFW is active, but I could not detect the $network_name subnet for host-agent access."
+                ai_warn "If dashboard says host-agent is offline, inspect: docker network inspect $network_name"
+            elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+                ai_warn "firewalld is active, but I could not detect the $network_name subnet for host-agent access."
+                ai_warn "If dashboard says host-agent is offline, inspect: docker network inspect $network_name"
+            fi
+            return 0
+        fi
+
+        for subnet in "${subnets[@]}"; do
+            if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
+                if sudo ufw status 2>/dev/null | grep -F "${port}/tcp" | grep -F "$subnet" >/dev/null; then
+                    ai_ok "UFW already allows dream-host-agent (port $port) from $network_name subnet $subnet"
+                elif sudo ufw allow from "$subnet" to any port "$port" proto tcp comment 'dream-host-agent' 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+                    ai_ok "UFW: allowed dream-host-agent (port $port) from $network_name subnet $subnet"
+                else
+                    ai_warn "UFW: failed to auto-add host-agent rule - run manually:"
+                    ai_warn "  sudo ufw allow from $subnet to any port $port proto tcp comment 'dream-host-agent'"
+                fi
+            elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
+                fw_rule="rule family=\"ipv4\" source address=\"$subnet\" port protocol=\"tcp\" port=\"$port\" accept"
+                if sudo firewall-cmd --query-rich-rule="$fw_rule" >/dev/null 2>&1; then
+                    ai_ok "firewalld already allows dream-host-agent (port $port) from $network_name subnet $subnet"
+                elif sudo firewall-cmd --permanent --add-rich-rule="$fw_rule" 2>&1 | tee -a "$LOG_FILE" >/dev/null \
+                  && sudo firewall-cmd --reload 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+                    ai_ok "firewalld: allowed dream-host-agent (port $port) from $network_name subnet $subnet"
+                else
+                    ai_warn "firewalld: failed to auto-add host-agent rule - run manually:"
+                    ai_warn "  sudo firewall-cmd --permanent --add-rich-rule='$fw_rule'"
+                    ai_warn "  sudo firewall-cmd --reload"
+                fi
+            fi
+        done
+    }
+
     if [[ "${GPU_BACKEND:-}" == "amd" ]] && ! amd_gpu_runtime_devices_available; then
         _amd_missing_devices="$(amd_gpu_missing_devices_csv)"
         if [[ "${GPU_BACKEND_FORCED:-false}" == "true" ]]; then
@@ -572,6 +630,12 @@ except Exception:
     $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" up -d --remove-orphans --no-build >> "$LOG_FILE" 2>&1 || true
     # Step 3: catch any stragglers from the second pass
     $DOCKER_CMD start $($DOCKER_CMD ps -a --filter status=created -q) 2>/dev/null || true
+
+    # dashboard-api reaches the host agent from the compose network gateway.
+    # With default-DROP UFW/firewalld, the host INPUT chain can block that
+    # traffic. Add a scoped rule only after compose has created dream-network,
+    # so we allow the actual Docker subnet instead of a broad RFC1918 range.
+    _phase11_allow_host_agent_firewall dream-network
 
     if $compose_ok; then
         printf "\r  ${BGRN}✓${NC} %-60s\n" "All containers launched"

--- a/dream-server/scripts/linux-install-preflight.sh
+++ b/dream-server/scripts/linux-install-preflight.sh
@@ -213,11 +213,11 @@ fi
 if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
     append_check "FIREWALL_CHECK" "warn" \
         "UFW active — may block container→host:7710 traffic" \
-        "sudo ufw allow from 172.16.0.0/12 to any port 7710 proto tcp comment 'dream-host-agent'"
+        "Installer will auto-add a scoped rule for the actual dream-network subnet after compose starts."
 elif command -v firewall-cmd >/dev/null 2>&1 && systemctl is-active --quiet firewalld 2>/dev/null; then
     append_check "FIREWALL_CHECK" "warn" \
         "firewalld active — may block container→host:7710 traffic" \
-        "sudo firewall-cmd --permanent --add-rich-rule='rule family=\"ipv4\" source address=\"172.16.0.0/12\" port protocol=\"tcp\" port=\"7710\" accept' && sudo firewall-cmd --reload"
+        "Installer will auto-add a scoped rule for the actual dream-network subnet after compose starts."
 else
     append_check "FIREWALL_CHECK" "pass" \
         "No restrictive host firewall detected" ""

--- a/dream-server/tests/bats-tests/services-firewall.bats
+++ b/dream-server/tests/bats-tests/services-firewall.bats
@@ -1,0 +1,161 @@
+#!/usr/bin/env bats
+# ============================================================================
+# BATS tests for installers/phases/11-services.sh host-agent firewall helper.
+# ============================================================================
+# The full phase has top-level installer side effects, so these tests extract
+# only _phase11_allow_host_agent_firewall and exercise it with stubbed commands.
+
+load '../bats/bats-support/load'
+load '../bats/bats-assert/load'
+
+PHASE11="$BATS_TEST_DIRNAME/../../installers/phases/11-services.sh"
+
+setup() {
+    STUB_BIN="$BATS_TEST_TMPDIR/stub-bin"
+    COMMAND_LOG="$BATS_TEST_TMPDIR/commands.log"
+    mkdir -p "$STUB_BIN"
+    touch "$COMMAND_LOG"
+    export STUB_BIN COMMAND_LOG
+    export PATH="$STUB_BIN:$PATH"
+    export DOCKER_CMD="docker"
+    export DREAM_AGENT_PORT=7710
+    export LOG_FILE="$BATS_TEST_TMPDIR/install.log"
+
+    cat > "$STUB_BIN/uname" <<'STUB'
+#!/usr/bin/env bash
+echo Linux
+STUB
+    chmod +x "$STUB_BIN/uname"
+
+    cat > "$STUB_BIN/docker" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "network" && "${2:-}" == "inspect" ]]; then
+    printf '%s\n' "${DOCKER_NETWORK_SUBNETS:-10.89.0.0/24}"
+    exit 0
+fi
+exit 1
+STUB
+    chmod +x "$STUB_BIN/docker"
+
+    cat > "$STUB_BIN/systemctl" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "is-active" ]]; then
+    shift
+    [[ "${1:-}" == "--quiet" ]] && shift
+    unit="${1:-}"
+    for active in ${SYSTEMCTL_ACTIVE_UNITS:-}; do
+        [[ "$unit" == "$active" ]] && exit 0
+    done
+    exit 3
+fi
+exit 0
+STUB
+    chmod +x "$STUB_BIN/systemctl"
+
+    cat > "$STUB_BIN/ufw" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_BIN/ufw"
+
+    cat > "$STUB_BIN/firewall-cmd" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUB_BIN/firewall-cmd"
+
+    cat > "$STUB_BIN/sudo" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$COMMAND_LOG"
+case "${1:-}" in
+    ufw)
+        if [[ "${2:-}" == "status" ]]; then
+            exit 0
+        fi
+        echo "Rule added"
+        exit 0
+        ;;
+    firewall-cmd)
+        if [[ "${2:-}" == "--query-rich-rule="* ]]; then
+            exit 1
+        fi
+        echo "success"
+        exit 0
+        ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUB_BIN/sudo"
+}
+
+extract_firewall_helper() {
+    local out="$1"
+    awk '
+        /^    _phase11_allow_host_agent_firewall\(\) \{/ { capture=1 }
+        capture { print }
+        capture && /^    \}/ { exit }
+    ' "$PHASE11" > "$out"
+}
+
+@test "services firewall: UFW rule is scoped to detected dream-network subnet" {
+    helper="$BATS_TEST_TMPDIR/helper.sh"
+    extract_firewall_helper "$helper"
+
+    run bash -c '
+        source "'"$helper"'"
+        ai_ok() { echo "OK: $1"; }
+        ai_warn() { echo "WARN: $1"; }
+        export SYSTEMCTL_ACTIVE_UNITS="ufw"
+        export DOCKER_NETWORK_SUBNETS="10.89.0.0/24"
+        _phase11_allow_host_agent_firewall dream-network
+        cat "$COMMAND_LOG"
+    '
+
+    assert_success
+    assert_output --partial "ufw allow from 10.89.0.0/24 to any port 7710 proto tcp comment dream-host-agent"
+    refute_output --partial "172.16.0.0/12"
+}
+
+@test "services firewall: firewalld rich rule is scoped to detected dream-network subnet" {
+    helper="$BATS_TEST_TMPDIR/helper.sh"
+    extract_firewall_helper "$helper"
+
+    run bash -c '
+        source "'"$helper"'"
+        ai_ok() { echo "OK: $1"; }
+        ai_warn() { echo "WARN: $1"; }
+        export SYSTEMCTL_ACTIVE_UNITS="firewalld"
+        export DOCKER_NETWORK_SUBNETS="10.90.0.0/24"
+        _phase11_allow_host_agent_firewall dream-network
+        cat "$COMMAND_LOG"
+    '
+
+    assert_success
+    assert_output --partial "source address=\"10.90.0.0/24\""
+    assert_output --partial "port=\"7710\" accept"
+    refute_output --partial "172.16.0.0/12"
+}
+
+@test "services firewall: explicit non-wildcard DREAM_AGENT_BIND skips auto rule" {
+    helper="$BATS_TEST_TMPDIR/helper.sh"
+    extract_firewall_helper "$helper"
+
+    run bash -c '
+        source "'"$helper"'"
+        ai_ok() { echo "OK: $1"; }
+        ai_warn() { echo "WARN: $1"; }
+        export SYSTEMCTL_ACTIVE_UNITS="ufw"
+        export DREAM_AGENT_BIND="127.0.0.1"
+        _phase11_allow_host_agent_firewall dream-network
+        cat "$COMMAND_LOG"
+    '
+
+    assert_success
+    assert_output --partial "skipping automatic host-agent firewall rule"
+    refute_output --partial "ufw allow"
+}
+
+@test "services firewall: installer no longer contains broad docker CIDR allow rule" {
+    run grep -R "172\\.16\\.0\\.0/12" "$BATS_TEST_DIRNAME/../../installers" "$BATS_TEST_DIRNAME/../../scripts"
+    assert_failure
+}


### PR DESCRIPTION
## What failed

`/dream-fleet-test` dashboard phase on **tower2** failed with `models.load.qwen3-coder-next-q4: status=0` / connection timeout. Direct reproduction with auth returned `503 Service Unavailable` and `Host agent unreachable` from the dashboard API.

The dashboard-api container reaches the Linux host agent through the `dream-network` gateway on port `7710`. On tower2, UFW was active in default-DROP mode, so the host INPUT chain blocked container-to-host traffic even though `dream-host-agent` itself was running.

## Fix

This PR now avoids the original broad `172.16.0.0/12` rule. Instead it:

- leaves host-agent service installation in `07-devtools.sh` alone;
- updates preflight warnings to say the installer will add a scoped rule after compose starts;
- adds a Phase 11 helper that runs after compose has created `dream-network`;
- inspects the actual Docker network subnet with `docker network inspect dream-network`;
- adds an idempotent UFW/firewalld allow rule for port `7710` only from that detected IPv4 subnet;
- skips automation when `DREAM_AGENT_BIND` is explicitly set to a non-wildcard address;
- warns, without failing install, if the subnet cannot be detected.

## Why it is safer

- The firewall rule is scoped to the actual `dream-network` subnet, not a broad RFC1918 range.
- Hosts without active UFW/firewalld still no-op.
- Explicit host-agent bind overrides are respected.
- If firewall mutation fails, the installer prints the exact manual command for the detected subnet.
- A new BATS regression test guards UFW, firewalld, explicit bind override, and the absence of the old broad CIDR rule.

## Validation

- `git diff --check`
- `bash -n installers/phases/01-preflight.sh installers/phases/07-devtools.sh installers/phases/11-services.sh scripts/linux-install-preflight.sh tests/bats-tests/services-firewall.bats`
- `tests/bats/bats-core/bin/bats tests/bats-tests/services-firewall.bats` locally via Git Bash
- Linux container: `bash -n ...` plus `bash tests/test-linux-install-preflight.sh`