### PR TITLE
fix(installer/macos): install PyYAML for compose resolver

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -374,12 +374,12 @@ if command -v python3 >/dev/null 2>&1; then
         ai_ok "PyYAML available"
     else
         ai "Installing PyYAML (required by compose resolver)..."
-        if pip3 install --user --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$LOG_FILE" >/dev/null \
+        if python3 -m pip install --user --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$LOG_FILE" >/dev/null \
            && python3 -c 'import yaml' >/dev/null 2>&1; then
-            ai_ok "PyYAML installed (pip3 --user)"
+            ai_ok "PyYAML installed (python3 -m pip --user)"
         else
             ai_err "Failed to install PyYAML for $(command -v python3)."
-            ai_err "Run manually: pip3 install --user pyyaml"
+            ai_err "Run manually: python3 -m pip install --user pyyaml"
             exit 1
         fi
     fi

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -363,6 +363,31 @@ if ! $DISK_SUFFICIENT; then
 fi
 ai_ok "Disk space OK"
 
+# PyYAML — required by scripts/resolve-compose-stack.sh for the compose
+# security scan (it parses every extension/overlay manifest before letting
+# user composes through). Linux distros generally bundle python3-yaml with
+# the system python; macOS does not. Without PyYAML, every extension install
+# fails at compose resolution with a cryptic "ModuleNotFoundError: No module
+# named 'yaml'" returned through the dashboard-api as state=error.
+if command -v python3 >/dev/null 2>&1; then
+    if python3 -c 'import yaml' >/dev/null 2>&1; then
+        ai_ok "PyYAML available"
+    else
+        ai "Installing PyYAML (required by compose resolver)..."
+        if pip3 install --user --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$LOG_FILE" >/dev/null \
+           && python3 -c 'import yaml' >/dev/null 2>&1; then
+            ai_ok "PyYAML installed (pip3 --user)"
+        else
+            ai_err "Failed to install PyYAML for $(command -v python3)."
+            ai_err "Run manually: pip3 install --user pyyaml"
+            exit 1
+        fi
+    fi
+else
+    ai_err "python3 not available — required for compose resolver"
+    exit 1
+fi
+
 # Ollama conflict detection
 check_ollama_conflict
 if $OLLAMA_RUNNING; then

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -118,4 +118,10 @@ grep -q 'data/config/setup-complete.json' installers/macos/install-macos.sh \
 grep -q 'data\\\\config\\\\setup-complete.json\|setup-complete.json' installers/windows/install-windows.ps1 \
   || { echo "[FAIL] Windows installer does not write setup-complete.json"; exit 1; }
 
+echo "[contract] macOS compose resolver installs PyYAML into checked python3"
+grep -q "python3 -c 'import yaml'" installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer does not verify PyYAML with python3"; exit 1; }
+grep -q 'python3 -m pip install --user .*pyyaml' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must install PyYAML via python3 -m pip, not a possibly unrelated pip3"; exit 1; }
+
 echo "[PASS] installer contracts"


### PR DESCRIPTION
## What failed

`/dream-fleet-test` dashboard phase on **mac-mini** reported `aider_installed=false` after `POST /api/extensions/aider/install`. The dashboard API stored an extension-progress error showing `scripts/resolve-compose-stack.sh` exited non-zero.

Direct reproduction on mac-mini showed:

```text
ModuleNotFoundError: No module named 'yaml'
```

`resolve-compose-stack.sh` now treats PyYAML as a hard requirement because extension and overlay compose files must be parsed before user-provided compose files are allowed through.

## Fix

Add a macOS installer preflight after disk-space checks and before compose/extension work:

- verify `python3 -c 'import yaml'`;
- if missing, run `python3 -m pip install --user --quiet --no-warn-script-location pyyaml`;
- verify the same `python3` can import `yaml` afterward;
- fail fast with a clear manual command if installation fails.

The branch was adjusted during audit to use `python3 -m pip` instead of bare `pip3`, so PyYAML is installed into the same interpreter the compose resolver later uses.

## Why it is safe

- macOS-only path; Linux/Windows installers are untouched.
- No sudo; installs to the user's Python site packages.
- Idempotent when PyYAML already exists.
- Adds an installer contract guard so future changes do not reintroduce a mismatched `pip3` install.

## Validation

- `bash -n installers/macos/install-macos.sh tests/contracts/test-installer-contracts.sh`
- Linux container: `bash tests/contracts/test-installer-contracts.sh`