### PR TITLE
fix(installer): bound STT preload curl timeout (3600s → 600s)

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1485,7 +1485,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     # macOS reassigns Whisper to 9100 if port 9000 is in use (AirPlay Receiver).
     WHISPER_PORT_RESOLVED="${WHISPER_PORT:-9000}"
     WHISPER_URL="http://127.0.0.1:${WHISPER_PORT_RESOLVED}"
-    STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
+    STT_RECOVERY_CMD="curl --max-time 1800 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
 
     # Step 1: wait briefly for the models API to be ready (max 15s).
     _stt_api_ready=false
@@ -1505,8 +1505,13 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
         ai_ok "STT model already cached (${STT_MODEL})"
     else
         # Step 3: POST to trigger download.
+        # max-time 600s (10 min): bounded retry budget so a stuck
+        # huggingface_hub.snapshot_download (well-known on slow links and
+        # under bufferbloat) can't consume the entire install timeout. The
+        # next step verifies cache state via GET and prints the recovery
+        # command if the timeout was hit before completion.
         ai "Downloading STT model (${STT_MODEL})..."
-        curl -s --max-time 3600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" \
+        curl -s --max-time 600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" \
             >> "$DS_LOG_FILE" 2>&1 || true
 
         # Step 4: verify the model is actually cached.

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -299,7 +299,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
         # command if the timeout was hit before completion.
         ai "Downloading STT model (${STT_MODEL})..."
         curl -s --max-time 600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" \
-            >> "$LOG_FILE" 2>&1
+            >> "$LOG_FILE" 2>&1 || true
 
         # Step 4: verify the model is actually cached. POST can return 200
         # even if the download partially fails, so this GET is the real test.

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -270,7 +270,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
     WHISPER_PORT_RESOLVED="${SERVICE_PORTS[whisper]:-9000}"
     WHISPER_URL="http://127.0.0.1:${WHISPER_PORT_RESOLVED}"
-    STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
+    STT_RECOVERY_CMD="curl --max-time 1800 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
 
     # Step 1: wait briefly for the models API to be ready. Whisper's /health
     # endpoint can pass before the models endpoint responds, so we probe
@@ -292,8 +292,13 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
         printf "\r  ${BGRN}✓${NC} %-60s\n" "STT model already cached (${STT_MODEL})"
     else
         # Step 3: POST to trigger download. Log stdout/stderr to install log.
+        # max-time 600s (10 min): bounded retry budget so a stuck
+        # huggingface_hub.snapshot_download (well-known on slow links and
+        # under bufferbloat) can't consume the entire install timeout. The
+        # next step verifies cache state via GET and prints the recovery
+        # command if the timeout was hit before completion.
         ai "Downloading STT model (${STT_MODEL})..."
-        curl -s --max-time 3600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" \
+        curl -s --max-time 600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" \
             >> "$LOG_FILE" 2>&1
 
         # Step 4: verify the model is actually cached. POST can return 200

--- a/dream-server/tests/bats-tests/stt-download.bats
+++ b/dream-server/tests/bats-tests/stt-download.bats
@@ -5,7 +5,8 @@
 # Guards against re-breakage of:
 #   - PR #984: silent-failure message ("will download on first use" lie)
 #   - PR #985: AUDIO_STT_MODEL env var wiring + backward-compat fallback
-#   - Post-#985 bug fix: recovery command must include --max-time 3600
+#   - Post-#985 bug fix: recovery command must include --max-time
+#   - PR #1229: bounded preload timeout must stay non-fatal under set -e
 #
 # We execute only the STT pre-download block (lines ~165-215 of 12-health.sh)
 # with curl stubbed, then assert on the commands it would have run and on the
@@ -28,6 +29,7 @@ echo "CURL: $*" >> "$TMPDIR_TEST/curl.log"
 #   cache-hit:      GET /v1/models/{id} returns 0 (cached), all other calls return 0
 #   cache-miss:     GET /v1/models returns 0, GET /v1/models/{id} returns 1, POST returns 0, verify GET returns 0
 #   download-fail:  everything returns 0 except the verify GET after POST
+#   post-timeout:   POST returns 28, verify GET fails, recovery path still runs
 #   api-not-ready:  all curls return 1
 case "${STT_STUB_MODE:-cache-hit}" in
     cache-hit)       exit 0 ;;
@@ -42,6 +44,12 @@ case "${STT_STUB_MODE:-cache-hit}" in
     download-fail)
         if [[ "$*" == */v1/models ]] || [[ "$*" == *"/v1/models" ]]; then exit 0
         elif [[ "$*" == *"-X POST"* ]]; then exit 0
+        else exit 1  # cache GET + verify GET both fail
+        fi
+        ;;
+    post-timeout)
+        if [[ "$*" == */v1/models ]] || [[ "$*" == *"/v1/models" ]]; then exit 0
+        elif [[ "$*" == *"-X POST"* ]]; then exit 28
         else exit 1  # cache GET + verify GET both fail
         fi
         ;;
@@ -72,7 +80,7 @@ teardown() {
 # If 12-health.sh drifts, update this block to match.
 _run_stt_block() {
     bash -c '
-        set -u
+        set -euo pipefail
         declare -A SERVICE_PORTS
         SERVICE_PORTS[whisper]="9000"
 
@@ -87,7 +95,7 @@ _run_stt_block() {
             STT_MODEL_ENCODED="${STT_MODEL//\//%2F}"
             WHISPER_PORT_RESOLVED="${SERVICE_PORTS[whisper]:-9000}"
             WHISPER_URL="http://localhost:${WHISPER_PORT_RESOLVED}"
-            STT_RECOVERY_CMD="curl --max-time 3600 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
+            STT_RECOVERY_CMD="curl --max-time 1800 -X POST ${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}"
 
             _stt_api_ready=false
             for _i in $(seq 1 3); do
@@ -104,7 +112,7 @@ _run_stt_block() {
                 echo "ALREADY_CACHED: ${STT_MODEL}"
             else
                 echo "DOWNLOADING: ${STT_MODEL}"
-                curl -s --max-time 3600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >> "$LOG_FILE" 2>&1 || true
+                curl -s --max-time 600 -X POST "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >> "$LOG_FILE" 2>&1 || true
                 if curl -sf --max-time 10 "${WHISPER_URL}/v1/models/${STT_MODEL_ENCODED}" >/dev/null 2>&1; then
                     echo "CACHED: ${STT_MODEL}"
                 else
@@ -162,7 +170,7 @@ _run_stt_block() {
     [[ ! -s "$TMPDIR_TEST/curl.log" ]]
 }
 
-@test "stt: recovery command includes --max-time 3600" {
+@test "stt: recovery command includes bounded manual retry timeout" {
     export ENABLE_VOICE=true
     export GPU_BACKEND=amd
     export AUDIO_STT_MODEL="Systran/faster-whisper-base"
@@ -173,7 +181,21 @@ _run_stt_block() {
     # Must not say "will download on first use" (the old lie from pre-PR #984).
     refute_output --partial "will download on first use"
     # Must include the recovery command with --max-time.
-    assert_output --partial "curl --max-time 3600 -X POST"
+    assert_output --partial "curl --max-time 1800 -X POST"
+}
+
+@test "stt: preload POST timeout is non-fatal under set -e" {
+    export ENABLE_VOICE=true
+    export GPU_BACKEND=amd
+    export AUDIO_STT_MODEL="Systran/faster-whisper-base"
+    export STT_STUB_MODE=post-timeout
+
+    run _run_stt_block
+    assert_success
+    assert_output --partial "DOWNLOAD_FAILED"
+    assert_output --partial "curl --max-time 1800 -X POST"
+    run grep -F -- "--max-time 600 -X POST" "$TMPDIR_TEST/curl.log"
+    assert_success
 }
 
 @test "stt: already-cached short-circuits without POST" {
@@ -186,7 +208,7 @@ _run_stt_block() {
     assert_success
     assert_output --partial "ALREADY_CACHED"
     # Should NOT have issued a POST.
-    run grep -F "-X POST" "$TMPDIR_TEST/curl.log"
+    run grep -F -- "-X POST" "$TMPDIR_TEST/curl.log"
     assert_failure
 }
 


### PR DESCRIPTION
## What failed

`/dream-fleet-test` install phase on **spark** timed out while preloading the STT model. The installer was stuck in the blocking POST to `whisper:9000/v1/models/...`; the HuggingFace download had partially filled a `.incomplete` blob and then stopped making progress.

## Fix

Bound the automatic STT preload POST to 10 minutes:

- Linux phase 12: `curl --max-time 600 ... || true`
- macOS installer: `curl --max-time 600 ... || true`
- recovery command remains a more generous `curl --max-time 1800 ...` for an operator-initiated retry.

During audit, the Linux path was corrected to keep the POST non-fatal under the top-level installer `set -euo pipefail`. If the bounded POST times out, the installer now continues to the verification GET, prints the recovery command, and proceeds to the summary instead of aborting.

## Why it is safe

- Healthy downloads still complete normally.
- A stalled HuggingFace download no longer consumes the whole install timeout.
- Voice preload failure remains recoverable and clearly reported.
- Regression coverage now runs the STT block under `set -euo pipefail` with a simulated POST timeout.

## Validation

- `bash -n installers/phases/12-health.sh installers/macos/install-macos.sh tests/bats-tests/stt-download.bats`
- `tests/bats/bats-core/bin/bats tests/bats-tests/stt-download.bats`