### PR TITLE
fix(models): make GGUF download completion reliable

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -454,6 +454,14 @@ def _write_progress(service_id: str, status: str, phase_label: str = "",
     os.replace(str(tmp_file), str(progress_file))
 
 
+def _model_file_ready(path: Path) -> bool:
+    """Return True only for a final GGUF file that exists and is non-empty."""
+    try:
+        return path.is_file() and path.stat().st_size > 0
+    except OSError:
+        return False
+
+
 def _read_progress_status(service_id: str) -> str | None:
     """Return the ``status`` field of the progress file, or None if absent/unreadable.
 
@@ -2582,11 +2590,25 @@ class AgentHandler(BaseHTTPRequestHandler):
             return
 
         models_dir = INSTALL_DIR / "data" / "models"
+        status_path = INSTALL_DIR / "data" / "model-download-status.json"
         # For split models, check ALL parts exist (not just the first)
-        all_downloaded = all((models_dir / fn).exists() for fn, _ in download_plan)
+        all_downloaded = all(_model_file_ready(models_dir / fn) for fn, _ in download_plan)
         if all_downloaded:
+            # A previous process can leave stale "downloading" status after the
+            # final file is already on disk. Normalize that here so the
+            # dashboard stops showing phantom progress.
+            _write_model_status(status_path, "complete", gguf_file, 0, 0)
             json_response(self, 200, {"status": "already_downloaded"})
             return
+        for fn, _ in download_plan:
+            target = models_dir / fn
+            if target.is_file() and not _model_file_ready(target):
+                target.unlink(missing_ok=True)
+        pending_download_plan = [
+            (idx, fn, url)
+            for idx, (fn, url) in enumerate(download_plan, 1)
+            if not _model_file_ready(models_dir / fn)
+        ]
 
         # Check for concurrent download
         with _model_download_lock:
@@ -2598,13 +2620,12 @@ class AgentHandler(BaseHTTPRequestHandler):
 
             def _download():
                 global _model_download_proc
-                status_path = INSTALL_DIR / "data" / "model-download-status.json"
                 try:
                     models_dir.mkdir(parents=True, exist_ok=True)
                     label = gguf_file if len(download_plan) == 1 else f"{gguf_file} ({len(download_plan)} parts)"
                     _write_model_status(status_path, "downloading", label, 0, 0)
 
-                    for part_idx, (part_file_name, part_url) in enumerate(download_plan, 1):
+                    for part_idx, part_file_name, part_url in pending_download_plan:
                         if _model_download_cancel.is_set():
                             break
                         part_target = models_dir / part_file_name
@@ -2656,6 +2677,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                         # Download with retry. Use Popen (not run) so the process can
                         # be killed from the cancel handler or _poll_progress thread.
                         success = False
+                        last_error = ""
                         for attempt in range(1, 4):
                             if _model_download_cancel.is_set():
                                 break
@@ -2679,11 +2701,26 @@ class AgentHandler(BaseHTTPRequestHandler):
                             if _model_download_cancel.is_set():
                                 break
                             if proc.returncode == 0:
-                                _stop_progress.set()
-                                part_tmp.rename(part_target)
-                                success = True
-                                break
-                            _write_model_status(status_path, "downloading", part_label, 0, part_total, f"Retry {attempt}/3")
+                                try:
+                                    part_tmp.rename(part_target)
+                                except OSError as exc:
+                                    last_error = f"Download finished but final file could not be moved into place: {exc}"
+                                else:
+                                    if _model_file_ready(part_target):
+                                        success = True
+                                        break
+                                    last_error = "Download finished but model file is missing or empty"
+                                    part_target.unlink(missing_ok=True)
+                            else:
+                                last_error = f"curl exited with code {proc.returncode}"
+                            _write_model_status(
+                                status_path,
+                                "downloading",
+                                part_label,
+                                0,
+                                part_total,
+                                f"Retry {attempt}/3: {last_error}",
+                            )
 
                         _stop_progress.set()
                         progress_thread.join(timeout=3)
@@ -2696,7 +2733,14 @@ class AgentHandler(BaseHTTPRequestHandler):
 
                         if not success:
                             part_tmp.unlink(missing_ok=True)
-                            _write_model_status(status_path, "failed", part_label, 0, part_total, "Download failed after 3 attempts")
+                            _write_model_status(
+                                status_path,
+                                "failed",
+                                part_label,
+                                0,
+                                part_total,
+                                last_error or "Download failed after 3 attempts",
+                            )
                             return
 
                     # Verify SHA256 for every downloaded part. Catalog is the
@@ -2711,6 +2755,16 @@ class AgentHandler(BaseHTTPRequestHandler):
                     for part_idx, (part_file_name, _) in enumerate(download_plan, 1):
                         expected = expected_sha_by_file.get(part_file_name, "")
                         final_target = models_dir / part_file_name
+                        if not _model_file_ready(final_target):
+                            _write_model_status(
+                                status_path,
+                                "failed",
+                                part_file_name,
+                                0,
+                                0,
+                                "Download finished but model file is missing or empty",
+                            )
+                            return
                         if not expected:
                             logger.warning(
                                 "SHA256 verification skipped for %s: no checksum in model-library.json",
@@ -2830,12 +2884,15 @@ class AgentHandler(BaseHTTPRequestHandler):
         env_path = INSTALL_DIR / ".env"
         models_ini = INSTALL_DIR / "config" / "llama-server" / "models.ini"
         lemonade_yaml = INSTALL_DIR / "config" / "litellm" / "lemonade.yaml"
+        hermes_live_config = INSTALL_DIR / "data" / "hermes" / "config.yaml"
+        hermes_template_config = INSTALL_DIR / "extensions" / "services" / "hermes" / "cli-config.yaml.template"
 
         # Hoisted so the outer except's rollback can reference them safely.
         # None means the snapshot was not captured, so rollback must skip it.
         env_backup: str | None = None
         ini_backup: str | None = None
         lemonade_backup = None
+        hermes_backups: dict[Path, str] = {}
         committed = False
 
         def restore_backups():
@@ -2845,6 +2902,8 @@ class AgentHandler(BaseHTTPRequestHandler):
                 models_ini.write_text(ini_backup, encoding="utf-8")
             if lemonade_backup is not None:
                 lemonade_yaml.write_text(lemonade_backup, encoding="utf-8")
+            for hermes_path, hermes_text in hermes_backups.items():
+                hermes_path.write_text(hermes_text, encoding="utf-8")
 
         try:
             # Read current env BEFORE modification — needed for gpu_backend guard
@@ -2855,6 +2914,9 @@ class AgentHandler(BaseHTTPRequestHandler):
             env_backup = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
             ini_backup = models_ini.read_text(encoding="utf-8") if models_ini.exists() else ""
             lemonade_backup = lemonade_yaml.read_text(encoding="utf-8") if lemonade_yaml.exists() else None
+            for hermes_path in (hermes_live_config, hermes_template_config):
+                if hermes_path.exists():
+                    hermes_backups[hermes_path] = hermes_path.read_text(encoding="utf-8")
 
             # Update .env
             if env_path.exists():
@@ -2924,6 +2986,11 @@ class AgentHandler(BaseHTTPRequestHandler):
                     encoding="utf-8",
                 )
                 logger.info("Regenerated lemonade.yaml for model: extra.%s", gguf_file)
+
+            hermes_model_name = f"extra.{gguf_file}" if gpu_backend == "amd" else gguf_file
+            hermes_patched = False
+            for path in (hermes_live_config, hermes_template_config):
+                hermes_patched = _patch_hermes_model_config(path, hermes_model_name) or hermes_patched
 
             # Restart llama-server with the new model.
             # Three strategies depending on platform / agent location:
@@ -3052,7 +3119,10 @@ class AgentHandler(BaseHTTPRequestHandler):
                     _write_lemonade_config(INSTALL_DIR, gguf_file)
 
                 # Restart dependent services so they pick up the new model
-                for svc in ["dream-litellm"]:
+                dependent_services = ["dream-litellm"]
+                if hermes_patched:
+                    dependent_services.append("dream-hermes")
+                for svc in dependent_services:
                     subprocess.run(["docker", "restart", svc],
                                    capture_output=True, timeout=60)
                 committed = True  # system state is committed before the response write
@@ -3232,6 +3302,51 @@ def _write_lemonade_config(install_dir: Path, gguf_file: str):
     )
     config_path.write_text(content, encoding="utf-8")
     logger.info("Wrote lemonade.yaml for model: extra.%s", gguf_file)
+
+
+def _patch_hermes_model_config(path: Path, model_name: str) -> bool:
+    """Patch `model.default` in a Hermes config/template YAML file.
+
+    Hermes copies the template once into data/hermes/config.yaml and then uses
+    the persisted copy as source of truth. Patch both when present so current
+    and future Hermes starts request the model that Dream Server just loaded.
+    """
+    if not path.exists():
+        return False
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        logger.warning("Could not read Hermes config for model patch: %s", path)
+        return False
+
+    in_model_block = False
+    changed = False
+    new_lines = []
+    for line in lines:
+        if re.match(r"^model:\s*(?:#.*)?$", line):
+            in_model_block = True
+            new_lines.append(line)
+            continue
+        if in_model_block and line and not line.startswith((" ", "\t", "#")):
+            in_model_block = False
+        if in_model_block and re.match(r"^\s+default:\s*", line):
+            indent = line[:len(line) - len(line.lstrip())]
+            new_line = f'{indent}default: "{model_name}"'
+            new_lines.append(new_line)
+            changed = changed or new_line != line
+            continue
+        new_lines.append(line)
+
+    if not changed:
+        return False
+    try:
+        path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
+        logger.info("Patched Hermes model.default in %s to %s", path, model_name)
+        return True
+    except OSError:
+        logger.warning("Could not write Hermes config model patch: %s", path)
+        return False
+
 
 def _launch_native_llama_server(env_path: Path, llama_bin: Path, llama_log: Path, pid_file: Path):
     """Launch the native (Metal) llama-server process and write its PID file.
@@ -3479,14 +3594,19 @@ def _write_model_status(path: Path, status: str, model: str, downloaded: int, to
     }
     if error:
         data["error"] = error
-    tmp = path.with_suffix(".tmp")
+    tmp = path.with_name(f"{path.name}.{threading.get_ident()}.tmp")
     try:
+        path.parent.mkdir(parents=True, exist_ok=True)
         tmp.write_text(json.dumps(data), encoding="utf-8")
-        tmp.rename(path)
+        os.replace(str(tmp), str(path))
     except OSError as e:
         # Don't crash the activate flow; surface to the journal so operators
         # can diagnose why progress stalled.
         logger.warning("Failed to write model status to %s: %s", path, e)
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2586,3 +2586,168 @@ class TestModelDownloadCatalogUnavailable:
         assert handler.response_code == 403
         body = handler.parse_response()
         assert body["error"] == "Model not in library catalog"
+
+
+class TestModelDownloadFileIntegrity:
+
+    class _NoCancel:
+        def clear(self):
+            pass
+
+        def is_set(self):
+            return False
+
+        def wait(self, timeout=None):
+            return False
+
+    def _setup_env(self, tmp_path, monkeypatch, library_models=None):
+        install_dir = tmp_path / "install"
+        (install_dir / "config").mkdir(parents=True)
+        (install_dir / "data" / "models").mkdir(parents=True)
+        models = library_models or [{
+            "gguf_file": "test-model.gguf",
+            "gguf_url": "https://example.com/test-model.gguf",
+            "gguf_sha256": "",
+        }]
+        (install_dir / "config" / "model-library.json").write_text(
+            json.dumps({"models": models}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+        monkeypatch.setattr(_mod, "_model_download_thread", None)
+        monkeypatch.setattr(_mod, "_model_download_proc", None)
+        monkeypatch.setattr(_mod, "_model_download_cancel", self._NoCancel())
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda cmd, *a, **kw: subprocess.CompletedProcess(
+                args=cmd,
+                returncode=0,
+                stdout="content-length: 123456\n",
+                stderr="",
+            ),
+        )
+        return install_dir
+
+    def _body(self):
+        return json.dumps({
+            "gguf_file": "test-model.gguf",
+            "gguf_url": "https://example.com/test-model.gguf",
+        }).encode("utf-8")
+
+    def _patch_curl_download(self, monkeypatch, payload: bytes):
+        outputs = []
+
+        class FakeProc:
+            def __init__(self, cmd, *args, **kwargs):
+                self.cmd = cmd
+                self.returncode = None
+                self.output = Path(cmd[cmd.index("-o") + 1])
+                outputs.append(self.output.name)
+
+            def wait(self, timeout=None):
+                self.output.parent.mkdir(parents=True, exist_ok=True)
+                self.output.write_bytes(payload)
+                self.returncode = 0
+                return 0
+
+            def kill(self):
+                self.returncode = -9
+
+        monkeypatch.setattr(_mod.subprocess, "Popen", FakeProc)
+        return outputs
+
+    def test_empty_existing_model_is_redownloaded(self, tmp_path, monkeypatch):
+        install_dir = self._setup_env(tmp_path, monkeypatch)
+        self._patch_curl_download(monkeypatch, b"valid gguf bytes")
+        model_path = install_dir / "data" / "models" / "test-model.gguf"
+        model_path.write_bytes(b"")
+
+        handler = _FakeHandler(self._body())
+        _mod.AgentHandler._handle_model_download(handler)
+
+        assert handler.response_code == 200
+        assert handler.parse_response()["status"] == "started"
+        _mod._model_download_thread.join(timeout=2)
+        assert not _mod._model_download_thread.is_alive()
+        assert model_path.read_bytes() == b"valid gguf bytes"
+        status = json.loads((install_dir / "data" / "model-download-status.json").read_text(encoding="utf-8"))
+        assert status["status"] == "complete"
+
+    def test_existing_model_clears_stale_downloading_status(self, tmp_path, monkeypatch):
+        install_dir = self._setup_env(tmp_path, monkeypatch)
+        model_path = install_dir / "data" / "models" / "test-model.gguf"
+        model_path.write_bytes(b"already here")
+        status_path = install_dir / "data" / "model-download-status.json"
+        status_path.write_text(
+            json.dumps({"status": "downloading", "model": "test-model.gguf"}),
+            encoding="utf-8",
+        )
+
+        handler = _FakeHandler(self._body())
+        _mod.AgentHandler._handle_model_download(handler)
+
+        assert handler.response_code == 200
+        assert handler.parse_response()["status"] == "already_downloaded"
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+        assert status["status"] == "complete"
+        assert status["model"] == "test-model.gguf"
+
+    def test_empty_finished_download_is_failed_not_complete(self, tmp_path, monkeypatch):
+        install_dir = self._setup_env(tmp_path, monkeypatch)
+        self._patch_curl_download(monkeypatch, b"")
+
+        handler = _FakeHandler(self._body())
+        _mod.AgentHandler._handle_model_download(handler)
+
+        assert handler.response_code == 200
+        assert handler.parse_response()["status"] == "started"
+        _mod._model_download_thread.join(timeout=2)
+        assert not _mod._model_download_thread.is_alive()
+        status = json.loads((install_dir / "data" / "model-download-status.json").read_text(encoding="utf-8"))
+        assert status["status"] == "failed"
+        assert "missing or empty" in status["error"]
+
+    def test_split_download_skips_existing_non_empty_parts(self, tmp_path, monkeypatch):
+        parts = [
+            {
+                "file": "split-model-00001-of-00002.gguf",
+                "url": "https://example.com/split-model-00001-of-00002.gguf",
+                "sha256": "",
+            },
+            {
+                "file": "split-model-00002-of-00002.gguf",
+                "url": "https://example.com/split-model-00002-of-00002.gguf",
+                "sha256": "",
+            },
+        ]
+        install_dir = self._setup_env(
+            tmp_path,
+            monkeypatch,
+            library_models=[{
+                "gguf_file": "split-model-00001-of-00002.gguf",
+                "gguf_url": "",
+                "gguf_sha256": "",
+                "gguf_parts": parts,
+            }],
+        )
+        calls = self._patch_curl_download(monkeypatch, b"downloaded second part")
+        models_dir = install_dir / "data" / "models"
+        (models_dir / "split-model-00001-of-00002.gguf").write_bytes(b"existing first part")
+
+        handler = _FakeHandler(json.dumps({
+            "gguf_file": "split-model-00001-of-00002.gguf",
+            "gguf_parts": parts,
+        }).encode("utf-8"))
+        _mod.AgentHandler._handle_model_download(handler)
+
+        assert handler.response_code == 200
+        assert handler.parse_response()["status"] == "started"
+        _mod._model_download_thread.join(timeout=2)
+        assert not _mod._model_download_thread.is_alive()
+        assert calls == ["split-model-00002-of-00002.gguf.part"]
+        assert (models_dir / "split-model-00001-of-00002.gguf").read_bytes() == b"existing first part"
+        assert (models_dir / "split-model-00002-of-00002.gguf").read_bytes() == b"downloaded second part"
+        status = json.loads((install_dir / "data" / "model-download-status.json").read_text(encoding="utf-8"))
+        assert status["status"] == "complete"

--- a/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -20,6 +20,7 @@ _spec.loader.exec_module(_mod)
 _check_lemonade_health = _mod._check_lemonade_health
 _send_lemonade_warmup = _mod._send_lemonade_warmup
 _write_lemonade_config = _mod._write_lemonade_config
+_patch_hermes_model_config = _mod._patch_hermes_model_config
 _compose_restart_llama_server = _mod._compose_restart_llama_server
 _launch_native_llama_server = _mod._launch_native_llama_server
 
@@ -158,6 +159,32 @@ class TestWriteLemonadeConfig:
         litellm_dir.mkdir(parents=True)
         _write_lemonade_config(tmp_path, "model.gguf")
         assert (litellm_dir / "lemonade.yaml").exists()
+
+
+class TestPatchHermesModelConfig:
+
+    def test_updates_model_default_only(self, tmp_path):
+        config = tmp_path / "config.yaml"
+        config.write_text(
+            "# example\n"
+            "model:\n"
+            "  default: \"old-model\"\n"
+            "  provider: \"custom\"\n"
+            "  base_url: \"http://llama-server:8080/v1\"\n"
+            "other:\n"
+            "  default: \"leave-me\"\n",
+            encoding="utf-8",
+        )
+
+        assert _patch_hermes_model_config(config, "new-model.gguf") is True
+
+        text = config.read_text(encoding="utf-8")
+        assert '  default: "new-model.gguf"' in text
+        assert '  provider: "custom"' in text
+        assert '  default: "leave-me"' in text
+
+    def test_missing_file_is_noop(self, tmp_path):
+        assert _patch_hermes_model_config(tmp_path / "missing.yaml", "model.gguf") is False
 
 
 class TestComposeRestartLlamaServer:
@@ -371,6 +398,45 @@ class TestModelActivateRollback:
         content = lemonade_yaml.read_text(encoding="utf-8")
         assert "api_key: sk-inline-from-env-file-67890" in content
         assert "api_key: sk-lemonade" not in content
+
+    def test_activation_patches_hermes_configs_and_restarts_hermes(self, tmp_path, monkeypatch):
+        install_dir, _env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        hermes_live = install_dir / "data" / "hermes" / "config.yaml"
+        hermes_template = install_dir / "extensions" / "services" / "hermes" / "cli-config.yaml.template"
+        hermes_live.parent.mkdir(parents=True)
+        hermes_template.parent.mkdir(parents=True)
+        hermes_text = (
+            "model:\n"
+            "  default: \"old-model\"\n"
+            "  provider: \"custom\"\n"
+            "  base_url: \"http://llama-server:8080/v1\"\n"
+        )
+        hermes_live.write_text(hermes_text, encoding="utf-8")
+        hermes_template.write_text(hermes_text, encoding="utf-8")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("DREAM_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
+
+        calls = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            stdout = '{"status": "ok"}' if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "target-model")
+
+        assert handler.response_code == 200
+        assert '  default: "new-model.gguf"' in hermes_live.read_text(encoding="utf-8")
+        assert '  default: "new-model.gguf"' in hermes_template.read_text(encoding="utf-8")
+        assert ["docker", "restart", "dream-hermes"] in calls
 
     def test_unexpected_failure_rolls_back_all_config_backups(self, tmp_path, monkeypatch):
         install_dir, env_path, env_text, models_ini, ini_text, lemonade_yaml, lemonade_text = (

--- a/dream-server/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
@@ -51,7 +51,7 @@ const commonIssues = [
     solutions: [
       {
         title: 'Check model download progress',
-        command: 'ls -lh ~/dream-server/models/',
+        command: 'ls -lh ~/dream-server/data/models/',
         description: 'Verify model files exist and have size > 1GB'
       },
       {

--- a/dream-server/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
@@ -34,7 +34,11 @@ describe('useDownloadProgress', () => {
   test('clears progress when status is complete', async () => {
     fetch.mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ status: 'complete' })
+      json: () => Promise.resolve({
+        status: 'complete',
+        model: 'test-model',
+        updatedAt: '2026-05-16T12:00:00Z'
+      })
     })
 
     const { result } = renderHook(() => useDownloadProgress())
@@ -45,6 +49,11 @@ describe('useDownloadProgress', () => {
     })
     expect(result.current.isDownloading).toBe(false)
     expect(result.current.progress).toBeNull()
+    expect(result.current.completedDownload).toEqual({
+      status: 'complete',
+      model: 'test-model',
+      updatedAt: '2026-05-16T12:00:00Z'
+    })
   })
 
   test('formatBytes formats GB/MB/KB correctly', () => {

--- a/dream-server/extensions/services/dashboard/src/hooks/useDownloadProgress.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useDownloadProgress.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 
 /**
  * Hook to poll download progress during model downloads.
@@ -7,6 +7,8 @@ import { useState, useEffect, useCallback } from 'react'
 export function useDownloadProgress(pollIntervalMs = 1000) {
   const [progress, setProgress] = useState(null)
   const [isDownloading, setIsDownloading] = useState(false)
+  const [completedDownload, setCompletedDownload] = useState(null)
+  const lastCompleteKeyRef = useRef(null)
 
   const fetchProgress = useCallback(async () => {
     try {
@@ -34,6 +36,17 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
       } else if (data.status === 'complete' || data.status === 'idle') {
         setIsDownloading(false)
         setProgress(null)
+        if (data.status === 'complete') {
+          const completeKey = `${data.model || ''}:${data.updatedAt || ''}`
+          if (completeKey && completeKey !== lastCompleteKeyRef.current) {
+            lastCompleteKeyRef.current = completeKey
+            setCompletedDownload({
+              model: data.model,
+              status: data.status,
+              updatedAt: data.updatedAt
+            })
+          }
+        }
       } else if (data.status === 'failed' || data.status === 'error' || data.status === 'cancelled') {
         setIsDownloading(false)
         setProgress({
@@ -41,7 +54,7 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
           model: data.model
         })
       }
-    } catch (err) {
+    } catch {
       // Silently fail - API might not be available
     }
   }, [])
@@ -88,6 +101,7 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
   return {
     isDownloading,
     progress,
+    completedDownload,
     formatBytes,
     formatEta,
     refresh: fetchProgress,

--- a/dream-server/extensions/services/dashboard/src/pages/Models.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Models.jsx
@@ -28,6 +28,13 @@ export default function Models() {
     }
   }, [downloadProgress.isDownloading, error])
 
+  useEffect(() => {
+    if (downloadProgress.completedDownload?.status === 'complete') {
+      setDownloadStarting(null)
+      refresh()
+    }
+  }, [downloadProgress.completedDownload, refresh])
+
   const handleDownload = async (modelId) => {
     setDownloadStarting(modelId)
     await downloadModel(modelId)


### PR DESCRIPTION
﻿## Summary
- Treat empty/missing final GGUF files as incomplete so model downloads retry/fail instead of reporting complete.
- Make model download status writes use per-thread temp files plus `os.replace`, avoiding stale status on Windows/racing progress polls.
- Skip already-valid split GGUF parts during partial split downloads, then verify the full split set before reporting complete.
- Patch Hermes live/template model config during model activation and restart Hermes when its model changes.
- Refresh the Models page immediately when download status reaches complete and fix the troubleshooting path to `~/dream-server/data/models/`.

## Validation
- `python -m py_compile dream-server\bin\dream-host-agent.py`
- `python -m pytest dream-server\extensions\services\dashboard-api\tests\test_host_agent.py -k "ModelDownload"`
- `python -m pytest dream-server\extensions\services\dashboard-api\tests\test_model_activate.py`
- `npm.cmd test -- --run src/hooks/__tests__/useDownloadProgress.test.js src/hooks/__tests__/useModels.test.js`
- `npm.cmd run build`
- `git diff --check`

Note: full `test_host_agent.py` was also run on Windows and still has pre-existing Windows-only symlink/chmod failures unrelated to this change; the targeted ModelDownload tests pass.
