### PR TITLE
[codex] add model management guide

### DIFF
--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -63,9 +63,11 @@ By default, Dream Server uses **bootstrap mode** for instant gratification:
 1. Starts immediately with a tiny 1.5B model (downloads in <1 minute)
 2. You can start chatting within **2 minutes** of running the installer
 3. The full model downloads in the background
-4. When ready, run `./scripts/upgrade-model.sh` to hot-swap to the full model
+4. Use the Dashboard **Models** page to download and load larger catalog models
 
 No more staring at download bars. Start playing immediately.
+
+Model download, switching, and manual GGUF notes: [docs/MODEL-MANAGEMENT.md](docs/MODEL-MANAGEMENT.md)
 
 To skip bootstrap and wait for the full model: `./install.sh --no-bootstrap`
 
@@ -314,6 +316,7 @@ dream preset load <name>  # Restore a saved preset
 ```
 
 Full mode-switching documentation: [docs/MODE-SWITCH.md](docs/MODE-SWITCH.md)
+Model download and manual GGUF documentation: [docs/MODEL-MANAGEMENT.md](docs/MODEL-MANAGEMENT.md)
 
 ## Showcase & Demos
 
@@ -409,6 +412,7 @@ dream mode status                        # Show current mode
 - [docs/README.md](docs/README.md) — **Full documentation index** (start here)
 - [QUICKSTART.md](QUICKSTART.md) — Detailed setup guide
 - [HEADLESS-SETUP.md](docs/HEADLESS-SETUP.md) — QR onboarding, first-boot setup, AP mode, mDNS, and local agent access
+- [MODEL-MANAGEMENT.md](docs/MODEL-MANAGEMENT.md) — Dashboard model downloads, switching, and manual GGUF use
 - [HARDWARE-GUIDE.md](docs/HARDWARE-GUIDE.md) — What to buy
 - [EXTENSIONS.md](docs/EXTENSIONS.md) — Add services, manifests, dashboard plugins
 - [INSTALLER-ARCHITECTURE.md](docs/INSTALLER-ARCHITECTURE.md) — Modding the installer

--- a/dream-server/docs/MODE-SWITCH.md
+++ b/dream-server/docs/MODE-SWITCH.md
@@ -142,6 +142,9 @@ dream model list
 dream model swap T3
 ```
 
+For Dashboard downloads, loading catalog models, and manual GGUF swaps, see
+[MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md).
+
 ---
 
 ## Architecture

--- a/dream-server/docs/MODEL-MANAGEMENT.md
+++ b/dream-server/docs/MODEL-MANAGEMENT.md
@@ -1,0 +1,239 @@
+# Model Management
+
+Dream Server runs local language models as GGUF files from `data/models/`.
+The recommended path is the Dashboard Models page; manual model swaps are
+possible, but they are an operator workflow today.
+
+## Recommended: Dashboard Models Page
+
+Open the Dashboard and go to **Models**.
+
+From there you can:
+
+- See the curated Dream Server model catalog.
+- Check approximate model size, VRAM requirement, context length, and specialty.
+- Download a catalog model into `data/models/`.
+- Load a downloaded model.
+- Delete a downloaded catalog model.
+
+When a catalog model is loaded, Dream Server updates the active GGUF settings
+and restarts the local inference service so OpenAI-compatible clients use the
+new model. After the switch settles, verify it from the host:
+
+```bash
+dream model current
+curl http://localhost:11434/v1/models
+```
+
+On macOS native Metal and Windows native/Lemonade installs, use
+`http://localhost:8080/v1/models` unless you changed the port.
+
+Downstream apps that talk to `llama-server` or LiteLLM pick up the active model
+through those services. Examples include Open WebUI, Perplexica, Token Spy, and
+OpenAI-compatible SDK clients configured against Dream Server.
+
+Hermes Agent keeps its own model name in `data/hermes/config.yaml`. If Hermes is
+enabled after a model switch, verify the `model.default` line:
+
+```bash
+grep -n "default:" data/hermes/config.yaml
+docker restart dream-hermes
+```
+
+For Lemonade/AMD backends, Hermes and LiteLLM may need the model name in the
+form `extra.<GGUF_FILE>`.
+
+## Where Models Live
+
+Default model directory:
+
+```bash
+~/dream-server/data/models/
+```
+
+On Windows installs:
+
+```powershell
+%LOCALAPPDATA%\DreamServer\data\models\
+```
+
+Each model is normally a single `.gguf` file:
+
+```bash
+ls -lh ~/dream-server/data/models/*.gguf
+```
+
+The active model is recorded in `.env`:
+
+```bash
+grep -E "^(LLM_MODEL|GGUF_FILE|CTX_SIZE|MAX_CONTEXT)=" ~/dream-server/.env
+```
+
+`GGUF_FILE` is the filename Dream Server should load from `data/models/`.
+`LLM_MODEL` is the friendly logical model name used by scripts and config.
+`CTX_SIZE` and `MAX_CONTEXT` control context length.
+
+## Manual: Download a Catalog Model
+
+For most users, use the Dashboard. If you are debugging a failed download or
+preloading a machine, download the exact catalog GGUF URL from
+`config/model-library.json` into `data/models/`.
+
+Example:
+
+```bash
+cd ~/dream-server
+mkdir -p data/models
+
+curl -L \
+  -o data/models/Qwen3.5-9B-Q4_K_M.gguf \
+  https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf
+```
+
+Then open Dashboard -> Models. If the filename matches a catalog entry, the
+model should appear as downloaded and you can load it from the Dashboard.
+
+## Manual: Bring Your Own GGUF
+
+Custom GGUFs are supported by the underlying stack, but not yet as a polished
+Dashboard import flow. Treat this as an operator procedure.
+
+1. Download the GGUF into `data/models/`.
+
+```bash
+cd ~/dream-server
+mkdir -p data/models
+cp /path/to/MyModel-Q4_K_M.gguf data/models/
+```
+
+2. Update `.env`.
+
+```bash
+dream config edit
+```
+
+Set:
+
+```dotenv
+LLM_MODEL=my-model
+GGUF_FILE=MyModel-Q4_K_M.gguf
+CTX_SIZE=8192
+MAX_CONTEXT=8192
+```
+
+3. Update `config/llama-server/models.ini`.
+
+```ini
+[my-model]
+filename = MyModel-Q4_K_M.gguf
+load-on-startup = true
+n-ctx = 8192
+```
+
+4. If Hermes is enabled, update `data/hermes/config.yaml`.
+
+```yaml
+model:
+  default: "MyModel-Q4_K_M.gguf"
+```
+
+For Lemonade/AMD backends, use:
+
+```yaml
+model:
+  default: "extra.MyModel-Q4_K_M.gguf"
+```
+
+5. Restart the affected services.
+
+```bash
+dream restart llama-server
+dream restart litellm
+docker restart dream-hermes 2>/dev/null || true
+```
+
+If your install uses direct Docker Compose commands instead of the `dream` CLI,
+recreate `llama-server` so it rereads `.env`.
+
+## Verify a Switch
+
+Use these checks after Dashboard or manual model changes:
+
+```bash
+dream model current
+curl http://localhost:11434/v1/models
+```
+
+For LiteLLM installs that require an API key, use the key from `.env`:
+
+```bash
+LITELLM_KEY=$(grep '^LITELLM_KEY=' .env | cut -d= -f2-)
+curl -H "Authorization: Bearer $LITELLM_KEY" http://localhost:4000/v1/models
+```
+
+From inside a Docker container, the inference endpoint is:
+
+```text
+http://llama-server:8080/v1
+```
+
+## Troubleshooting
+
+### The download finished, but the model is not visible
+
+Check the file is present and non-empty:
+
+```bash
+ls -lh data/models/*.gguf
+```
+
+If it is a catalog model, confirm the filename exactly matches
+`config/model-library.json`. The Dashboard only marks catalog models as
+downloaded when the on-disk filename matches the catalog entry.
+
+### The model file exists, but loading fails
+
+Check service logs:
+
+```bash
+dream logs llm
+```
+
+Common causes:
+
+- The model needs more VRAM or unified memory than the machine has.
+- Context length is too high; lower `CTX_SIZE` / `MAX_CONTEXT`.
+- The GGUF is not compatible with the active backend.
+- On AMD/Lemonade, a service is still asking for the raw filename instead of
+  `extra.<GGUF_FILE>`.
+
+### Open WebUI or another app still shows the old model
+
+Verify the server first:
+
+```bash
+curl http://localhost:11434/v1/models
+```
+
+If the server is correct, refresh the app. If the server is wrong, restart
+`llama-server` and verify `.env` / `models.ini`.
+
+### Hermes still asks for the old model
+
+Hermes has its own config:
+
+```bash
+grep -n "default:" data/hermes/config.yaml
+docker restart dream-hermes
+```
+
+For AMD/Lemonade, use `extra.<GGUF_FILE>`.
+
+## Current Limitations
+
+- Dashboard model download and load are catalog-based.
+- Custom GGUF import from a local file or arbitrary URL is not yet a first-class
+  Dashboard workflow.
+- `dream model swap` switches Dream Server tiers, not arbitrary GGUF files.
+- `scripts/upgrade-model.sh` is a legacy helper for model-directory layouts and
+  should not be used as the primary GGUF switch path on current installs.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -30,6 +30,7 @@ Links from this directory use `../` for the repo root (e.g. `../README.md`, `../
 | [HARDWARE-GUIDE.md](HARDWARE-GUIDE.md) | Buyers | GPU buying advice, tier recommendations |
 | [HARDWARE-CLASSES.md](HARDWARE-CLASSES.md) | Developers | GPU-to-tier classification logic |
 | [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md) | Operators | Platform/GPU support status |
+| [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | Operators | Dashboard model downloads, switching, and manual GGUF workflows |
 | [CAPABILITY-PROFILE.md](CAPABILITY-PROFILE.md) | Developers | Machine capability profiling schema |
 | [MULTI-USER-SETUP.md](MULTI-USER-SETUP.md) | Operators | Expose and tune one install for multiple users |
 | [PROFILES.md](PROFILES.md) | Reference | Docker Compose profiles (historical reference) |

--- a/dream-server/docs/WINDOWS-QUICKSTART.md
+++ b/dream-server/docs/WINDOWS-QUICKSTART.md
@@ -121,7 +121,7 @@ GPU access: Windows driver → WSL2 → Docker Container Toolkit → llama-serve
 |------|-------|
 | Install directory | `%LOCALAPPDATA%\DreamServer` |
 | Config | `.env` file in install directory |
-| Models | Docker volume `dream-server_model-cache` |
+| Models | `%LOCALAPPDATA%\DreamServer\data\models\` |
 | Logs | `docker compose logs` |
 | Data | Docker volumes (auto-managed) |
 

--- a/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
+++ b/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
@@ -406,7 +406,9 @@ docker compose down
 ```
 
 **4. Manual download (advanced):**
-If automatic download keeps failing, you can download the model manually using huggingface-cli.
+If automatic download keeps failing, see
+[`MODEL-MANAGEMENT.md`](MODEL-MANAGEMENT.md) for the supported model directory,
+catalog filename matching, and manual GGUF swap checklist.
 
 ### Problem: "Web UI loads but AI doesn't respond"
 

--- a/dream-server/scripts/README.md
+++ b/dream-server/scripts/README.md
@@ -32,7 +32,7 @@ Utility scripts for diagnostics, testing, validation, and operations.
 | Script | Description | Requires Stack? |
 |--------|-------------|-----------------|
 | `mode-switch.sh` | Switch deployment modes | Yes |
-| `upgrade-model.sh` | Upgrade to a different model | Yes |
+| `upgrade-model.sh` | Legacy model-directory swap helper; use [`../docs/MODEL-MANAGEMENT.md`](../docs/MODEL-MANAGEMENT.md) for current GGUF workflows | Yes |
 | `migrate-config.sh` | Migrate config between versions | No |
 | `session-cleanup.sh` | OpenClaw session lifecycle | Yes |
 | `pre-download.sh` | Pre-download models for offline use | No |

--- a/dream-server/scripts/upgrade-model.sh
+++ b/dream-server/scripts/upgrade-model.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 #=============================================================================
-# upgrade-model.sh — Atomic Model Upgrade with Rollback
+# upgrade-model.sh — Legacy Model Directory Upgrade with Rollback
 #
 # Part of Dream Server — Phase 0 Foundation
 #
-# Gracefully swaps models in llama-server with automatic rollback on failure.
-# Ensures zero downtime when possible, minimal downtime otherwise.
+# Legacy helper for older model-directory layouts. Current Dream Server GGUF
+# installs should prefer the Dashboard Models page and docs/MODEL-MANAGEMENT.md.
 #
 # Usage:
 #   ./upgrade-model.sh <new-model>           # Upgrade to new model
@@ -292,7 +292,7 @@ cmd_list() {
     fi
     
     echo ""
-    echo "Download more models with: model-bootstrap.sh"
+    echo "For current GGUF downloads and swaps, see: docs/MODEL-MANAGEMENT.md"
 }
 
 cmd_current() {
@@ -441,6 +441,11 @@ Usage:
   $0 --current           Show current model
   $0 --rollback          Rollback to previous model
   $0 --help              Show this help
+
+Note:
+  This is a legacy helper for model directories containing config.json.
+  Current GGUF installs should use the Dashboard Models page or
+  docs/MODEL-MANAGEMENT.md.
 
 Examples:
   $0 Qwen2.5-32B-Instruct-AWQ


### PR DESCRIPTION
﻿## Summary

Adds a canonical model-management guide for Dream Server users and operators.

- Documents Dashboard-based catalog model download/loading as the recommended path.
- Documents where GGUF files live on Linux/macOS and Windows.
- Adds a manual catalog download and BYO GGUF checklist covering `.env`, `models.ini`, Hermes, Lemonade/AMD `extra.<GGUF_FILE>` naming, restarts, and verification.
- Links the guide from README, docs index, mode-switch docs, Windows troubleshooting, and scripts README.
- Corrects the Windows quickstart model path from the old Docker volume reference to `%LOCALAPPDATA%\DreamServer\data\models\`.
- Marks `scripts/upgrade-model.sh` as a legacy model-directory helper so current GGUF users are not sent down the wrong path.

## Why

The Dashboard model path is usable for catalog models, but manual downloads and custom GGUF swaps were scattered across docs and stale script hints. This gives users a clear answer when a model download appears missing or when they want to bring their own GGUF.

## Validation

- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe -n scripts/upgrade-model.sh`
- Checked changed Markdown relative links resolve with a PowerShell link check.
