### PR TITLE
[codex] harden Linux installer runtime checks

### DIFF
--- a/dream-server/docs/INSTALL-TROUBLESHOOTING.md
+++ b/dream-server/docs/INSTALL-TROUBLESHOOTING.md
@@ -4,6 +4,33 @@ This guide provides solutions for common issues encountered during the installat
 
 For **Linux**, run `./scripts/linux-install-preflight.sh` (or `./dream-preflight.sh --install-env`) for a structured report with stable check IDs; see [LINUX-TROUBLESHOOTING-GUIDE.md](LINUX-TROUBLESHOOTING-GUIDE.md) for ID-by-ID fixes.
 
+## Linux Installer Startup
+
+### Problem: Installer Stops Near System Detection With `No module named 'yaml'`
+**Solution:** Deactivate Conda/venv before installing, or install PyYAML into the active Python.
+
+Dream Server prefers the system Python during Linux install because distro packages such as `python3-yaml` are installed for `/usr/bin/python3`. If a Conda or venv Python is first in `PATH`, it may not see those modules.
+
+```bash
+conda deactivate
+./install.sh
+```
+
+Or:
+
+```bash
+python3 -m pip install pyyaml
+./install.sh
+```
+
+### Problem: `--non-interactive` Appears Hung During Docker Or NVIDIA Setup
+**Solution:** Cache sudo credentials before starting, or run interactively.
+
+```bash
+sudo -v
+./install.sh --non-interactive
+```
+
 ## Docker Issues
 
 ### Problem: Docker Not Installed
@@ -48,6 +75,23 @@ sudo systemctl restart docker
 Verify GPU detection:
 ```bash
 docker run --rm --gpus all nvidia/cuda:11.0-base nvidia-smi
+```
+
+### Problem: Blackwell GPU Shows Driver But No Devices
+**Solution:** Install NVIDIA open kernel modules.
+
+Blackwell GPUs, including RTX PRO 6000 Blackwell and Grace Blackwell systems, require the NVIDIA open kernel module driver stack. On Ubuntu 22.04/24.04:
+
+```bash
+sudo apt install nvidia-open
+sudo reboot
+```
+
+If your distro uses branch-specific package names, install the matching open package, for example:
+
+```bash
+sudo apt install nvidia-driver-580-open
+sudo reboot
 ```
 
 ## Port Conflicts

--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -64,10 +64,14 @@ trap '' TSTP
 # Load libraries (pure functions, no side effects)
 #=============================================================================
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$(uname -s 2>/dev/null || true)" == "Linux" ]]; then
+    export DREAM_PYTHON_PREFER_SYSTEM="${DREAM_PYTHON_PREFER_SYSTEM:-1}"
+fi
 
 source "$SCRIPT_DIR/installers/lib/constants.sh"
 source "$SCRIPT_DIR/installers/lib/logging.sh"
 source "$SCRIPT_DIR/installers/lib/ui.sh"
+source "$SCRIPT_DIR/installers/lib/sudo.sh"
 source "$SCRIPT_DIR/installers/lib/detection.sh"
 source "$SCRIPT_DIR/installers/lib/host-arch.sh"
 source "$SCRIPT_DIR/installers/lib/tier-map.sh"
@@ -76,6 +80,7 @@ source "$SCRIPT_DIR/installers/lib/compose-select.sh"
 source "$SCRIPT_DIR/installers/lib/compose-failure-report.sh"
 source "$SCRIPT_DIR/installers/lib/readiness-summary.sh"
 source "$SCRIPT_DIR/installers/lib/packaging.sh"
+source "$SCRIPT_DIR/installers/lib/python-runtime.sh"
 source "$SCRIPT_DIR/installers/lib/progress.sh"
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
     source "$SCRIPT_DIR/lib/service-registry.sh" 
@@ -223,6 +228,10 @@ fi
 # Detect distro + package manager (after arg parsing so --help still shows
 # the correct VERSION before /etc/os-release overwrites it)
 detect_pkg_manager
+log "Installer run started: pid=$$, script=$0"
+ds_prepare_sudo "Dream Server installer setup"
+export DREAM_SR_AUTO_INSTALL_PYYAML=1
+ds_ensure_python_module yaml python3-pyyaml pyyaml PyYAML
 
 #=============================================================================
 # Splash

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -429,6 +429,91 @@ detect_gpu() {
 
 MIN_DRIVER_VERSION=570
 
+nvidia_name_is_blackwell() {
+    local name="$1"
+    echo "$name" | grep -Eiq 'Blackwell|Grace Blackwell|GB10|GB200|RTX PRO 6000|RTX 50[0-9][0-9]|RTX 5090|RTX 5080|RTX 5070|RTX 5060|B100|B200'
+}
+
+nvidia_blackwell_hardware_detected() {
+    local raw line name compute_cap cc_major
+    if command -v nvidia-smi >/dev/null 2>&1; then
+        raw=$(nvidia-smi --query-gpu=name,compute_cap --format=csv,noheader,nounits 2>/dev/null || true)
+        if [[ -n "$raw" ]]; then
+            while IFS=',' read -r name compute_cap; do
+                name="$(echo "${name:-}" | xargs)"
+                compute_cap="$(echo "${compute_cap:-}" | xargs)"
+                cc_major="${compute_cap%%.*}"
+                [[ "$cc_major" =~ ^[0-9]+$ && "$cc_major" -ge 12 ]] && return 0
+                nvidia_name_is_blackwell "$name" && return 0
+            done <<< "$raw"
+        fi
+    fi
+
+    if command -v lspci >/dev/null 2>&1; then
+        while IFS= read -r line; do
+            nvidia_name_is_blackwell "$line" && return 0
+        done < <(lspci 2>/dev/null | grep -i nvidia || true)
+    fi
+
+    [[ -n "${GPU_NAME:-}" ]] && nvidia_name_is_blackwell "$GPU_NAME" && return 0
+    return 1
+}
+
+nvidia_kernel_module_flavor() {
+    local license version
+    if command -v modinfo >/dev/null 2>&1; then
+        license=$(modinfo -F license nvidia 2>/dev/null | head -1 || true)
+        if echo "$license" | grep -Eiq 'MIT|GPL'; then
+            echo "open"
+            return 0
+        fi
+        if [[ -n "$license" ]]; then
+            echo "proprietary"
+            return 0
+        fi
+    fi
+
+    if [[ -r /proc/driver/nvidia/version ]]; then
+        version="$(cat /proc/driver/nvidia/version 2>/dev/null || true)"
+        if echo "$version" | grep -Eiq 'Open Kernel Module|open kernel'; then
+            echo "open"
+            return 0
+        fi
+        if echo "$version" | grep -qi 'NVIDIA'; then
+            echo "proprietary"
+            return 0
+        fi
+    fi
+
+    echo "unknown"
+}
+
+validate_nvidia_blackwell_open_modules() {
+    nvidia_blackwell_hardware_detected || return 0
+
+    local flavor
+    flavor="$(nvidia_kernel_module_flavor)"
+    case "$flavor" in
+        open)
+            ai_ok "NVIDIA Blackwell GPU detected with open kernel modules"
+            ;;
+        proprietary)
+            ai_bad "NVIDIA Blackwell GPU detected, but proprietary NVIDIA kernel modules appear to be loaded."
+            ai_bad "Blackwell GPUs require NVIDIA open kernel modules."
+            ai "On Ubuntu 22.04/24.04, install the open driver stack, for example:"
+            ai "  sudo apt install nvidia-open"
+            ai "or the distro package matching your driver branch, e.g.:"
+            ai "  sudo apt install nvidia-driver-${MIN_DRIVER_VERSION}-open"
+            ai "Then reboot and re-run the Dream Server installer."
+            error "Blackwell requires NVIDIA open kernel modules."
+            ;;
+        *)
+            ai_warn "NVIDIA Blackwell GPU detected, but kernel module flavor could not be verified."
+            ai_warn "Blackwell requires NVIDIA open kernel modules. If GPU containers fail, install nvidia-open / nvidia-driver-*-open and reboot."
+            ;;
+    esac
+}
+
 fix_nvidia_secure_boot() {
     # Step 1: Is there even NVIDIA hardware on this machine?
     if ! lspci 2>/dev/null | grep -qi 'nvidia'; then
@@ -442,13 +527,21 @@ fix_nvidia_secure_boot() {
     installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>/dev/null \
                        | sed -n 's/.*nvidia-driver-\([0-9][0-9]*\).*/\1/p' | sort -n | tail -1 || true)
 
+    if nvidia_blackwell_hardware_detected; then
+        ai_warn "Blackwell NVIDIA hardware needs the open kernel module driver stack."
+        ai "Install the open driver, reboot, and re-run:"
+        ai "  sudo apt install nvidia-open"
+        ai "  # or: sudo apt install nvidia-driver-${MIN_DRIVER_VERSION}-open"
+        return 1
+    fi
+
     if [[ -z "$installed_driver" ]]; then
         ai "No NVIDIA driver package found. Installing recommended driver..."
         if command -v ubuntu-drivers &>/dev/null; then
-            sudo ubuntu-drivers install 2>>"$LOG_FILE" || \
-            sudo apt-get install -y "nvidia-driver-${MIN_DRIVER_VERSION}" 2>>"$LOG_FILE" || true
+            ds_sudo ubuntu-drivers install 2>>"$LOG_FILE" || \
+            ds_sudo apt-get install -y "nvidia-driver-${MIN_DRIVER_VERSION}" 2>>"$LOG_FILE" || true
         else
-            sudo apt-get install -y "nvidia-driver-${MIN_DRIVER_VERSION}" 2>>"$LOG_FILE" || true
+            ds_sudo apt-get install -y "nvidia-driver-${MIN_DRIVER_VERSION}" 2>>"$LOG_FILE" || true
         fi
         installed_driver=$(dpkg-query -W -f='${Package}\n' 'nvidia-driver-*' 2>/dev/null \
                            | sed -n 's/.*nvidia-driver-\([0-9][0-9]*\).*/\1/p' | sort -n | tail -1 || true)
@@ -463,13 +556,13 @@ fix_nvidia_secure_boot() {
 
     # Step 3: Try loading the module — see why it fails
     local modprobe_err
-    modprobe_err=$(sudo modprobe nvidia 2>&1) || true
+    modprobe_err=$(ds_sudo modprobe nvidia 2>&1) || true
 
     if nvidia-smi &>/dev/null; then
         ai_ok "NVIDIA driver loaded successfully"
         # Regenerate CDI spec so Docker sees the correct driver libraries
         if command -v nvidia-ctk &>/dev/null; then
-            sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
+            ds_sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
         fi
         detect_gpu || true
         return 0
@@ -488,22 +581,22 @@ fix_nvidia_secure_boot() {
     local kver mok_dir sign_file
     kver=$(uname -r)
     mok_dir="/var/lib/shim-signed/mok"
-    sudo mkdir -p "$mok_dir"
+    ds_sudo mkdir -p "$mok_dir"
 
     # Ensure linux-headers are present (needed for sign-file)
     if [[ ! -d "/usr/src/linux-headers-${kver}" ]]; then
         ai "Installing kernel headers for ${kver}..."
-        sudo apt-get install -y "linux-headers-${kver}" 2>>"$LOG_FILE" || true
+        ds_sudo apt-get install -y "linux-headers-${kver}" 2>>"$LOG_FILE" || true
     fi
 
     # Generate MOK keypair if not already present
     if [[ ! -f "$mok_dir/MOK.priv" ]] || [[ ! -f "$mok_dir/MOK.der" ]]; then
-        sudo openssl req -new -x509 -newkey rsa:2048 \
+        ds_sudo openssl req -new -x509 -newkey rsa:2048 \
             -keyout "$mok_dir/MOK.priv" \
             -outform DER -out "$mok_dir/MOK.der" \
             -nodes -days 36500 \
             -subj "/CN=Dream Server Module Signing/" 2>>"$LOG_FILE"
-        sudo chmod 600 "$mok_dir/MOK.priv"
+        ds_sudo chmod 600 "$mok_dir/MOK.priv"
         ai_ok "Generated MOK signing key"
     else
         ai_ok "Using existing MOK signing key"
@@ -534,31 +627,31 @@ fix_nvidia_secure_boot() {
         [[ -f "$mod_path" ]] || continue
         case "$mod_path" in
             *.zst)
-                sudo zstd -d -f "$mod_path" -o "${mod_path%.zst}" 2>>"$LOG_FILE"
-                sudo "$sign_file" sha256 "$mok_dir/MOK.priv" "$mok_dir/MOK.der" "${mod_path%.zst}" 2>>"$LOG_FILE"
-                sudo zstd -f --rm "${mod_path%.zst}" -o "$mod_path" 2>>"$LOG_FILE"
+                ds_sudo zstd -d -f "$mod_path" -o "${mod_path%.zst}" 2>>"$LOG_FILE"
+                ds_sudo "$sign_file" sha256 "$mok_dir/MOK.priv" "$mok_dir/MOK.der" "${mod_path%.zst}" 2>>"$LOG_FILE"
+                ds_sudo zstd -f --rm "${mod_path%.zst}" -o "$mod_path" 2>>"$LOG_FILE"
                 ;;
             *.xz)
-                sudo xz -d -f -k "$mod_path" 2>>"$LOG_FILE"
-                sudo "$sign_file" sha256 "$mok_dir/MOK.priv" "$mok_dir/MOK.der" "${mod_path%.xz}" 2>>"$LOG_FILE"
-                sudo xz -f "${mod_path%.xz}" 2>>"$LOG_FILE"
-                sudo mv "${mod_path%.xz}.xz" "$mod_path" 2>>"$LOG_FILE"
+                ds_sudo xz -d -f -k "$mod_path" 2>>"$LOG_FILE"
+                ds_sudo "$sign_file" sha256 "$mok_dir/MOK.priv" "$mok_dir/MOK.der" "${mod_path%.xz}" 2>>"$LOG_FILE"
+                ds_sudo xz -f "${mod_path%.xz}" 2>>"$LOG_FILE"
+                ds_sudo mv "${mod_path%.xz}.xz" "$mod_path" 2>>"$LOG_FILE"
                 ;;
             *)
-                sudo "$sign_file" sha256 "$mok_dir/MOK.priv" "$mok_dir/MOK.der" "$mod_path" 2>>"$LOG_FILE"
+                ds_sudo "$sign_file" sha256 "$mok_dir/MOK.priv" "$mok_dir/MOK.der" "$mod_path" 2>>"$LOG_FILE"
                 ;;
         esac
         signed_count=$((signed_count + 1))
     done
-    sudo depmod -a 2>>"$LOG_FILE"
+    ds_sudo depmod -a 2>>"$LOG_FILE"
     ai_ok "Signed $signed_count NVIDIA module(s)"
 
     # Step 6: Try loading — if MOK key is already enrolled, this works immediately
-    if sudo modprobe nvidia 2>>"$LOG_FILE" && nvidia-smi &>/dev/null; then
+    if ds_sudo modprobe nvidia 2>>"$LOG_FILE" && nvidia-smi &>/dev/null; then
         ai_ok "NVIDIA driver loaded — GPU is online"
         # Regenerate CDI spec so Docker sees the correct driver libraries
         if command -v nvidia-ctk &>/dev/null; then
-            sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
+            ds_sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
         fi
         detect_gpu || true
         return 0
@@ -570,7 +663,7 @@ fix_nvidia_secure_boot() {
 
     local mok_pass
     mok_pass=$(openssl rand -hex 4)
-    printf '%s\n%s\n' "$mok_pass" "$mok_pass" | sudo mokutil --import "$mok_dir/MOK.der" 2>>"$LOG_FILE"
+    printf '%s\n%s\n' "$mok_pass" "$mok_pass" | ds_sudo mokutil --import "$mok_dir/MOK.der" 2>>"$LOG_FILE"
 
     # --- Auto-resume: create a systemd oneshot so the install continues
     #     automatically after reboot (user doesn't have to re-run manually)
@@ -584,7 +677,7 @@ fix_nvidia_secure_boot() {
     [[ -n "$TIER" ]] && resume_args="$resume_args --tier $TIER"
     [[ "$OFFLINE_MODE" == "true" ]] && resume_args="$resume_args --offline"
 
-    sudo tee /etc/systemd/system/${svc_name}.service > /dev/null << SVCEOF
+    ds_sudo tee /etc/systemd/system/${svc_name}.service > /dev/null << SVCEOF
 [Unit]
 Description=Dream Server Install (auto-resume after Secure Boot enrollment)
 After=network-online.target docker.service
@@ -604,8 +697,8 @@ StandardError=journal+console
 [Install]
 WantedBy=multi-user.target
 SVCEOF
-    sudo systemctl daemon-reload
-    sudo systemctl enable "${svc_name}.service" 2>>"$LOG_FILE"
+    ds_sudo systemctl daemon-reload
+    ds_sudo systemctl enable "${svc_name}.service" 2>>"$LOG_FILE"
     log "Auto-resume service installed: ${svc_name}.service"
 
     # --- Show a clean, friendly reboot screen ---
@@ -634,7 +727,7 @@ SVCEOF
 
     if $INTERACTIVE; then
         read -p "  Press Enter to reboot (or Ctrl+C to do it later)... " -r < /dev/tty
-        sudo reboot
+        ds_sudo reboot
     fi
 
     # Non-interactive mode: exit cleanly (not an error — reboot is a normal install phase)

--- a/dream-server/installers/lib/packaging.sh
+++ b/dream-server/installers/lib/packaging.sh
@@ -20,7 +20,13 @@ DISTRO_ID_LIKE=""
 
 # Use sudo only when not already root (e.g. Docker containers run as root)
 _SUDO=""
-if [[ ${EUID:-$(id -u)} -ne 0 ]]; then _SUDO="sudo"; fi
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+    if declare -f ds_sudo >/dev/null 2>&1; then
+        _SUDO="ds_sudo"
+    else
+        _SUDO="sudo"
+    fi
+fi
 
 # Detect the system's package manager from /etc/os-release
 # Sets: PKG_MANAGER, DISTRO_ID, DISTRO_ID_LIKE

--- a/dream-server/installers/lib/python-runtime.sh
+++ b/dream-server/installers/lib/python-runtime.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Installer — Python runtime guards
+# ============================================================================
+# Part of: installers/lib/
+# Purpose: Ensure installer Python helpers use an interpreter that can import
+#          the modules they need. This especially protects Linux users with
+#          Conda/venv Python ahead of /usr/bin/python3 in PATH.
+#
+# Expects: SCRIPT_DIR, LOG_FILE, PKG_MANAGER, INTERACTIVE, DRY_RUN,
+#          pkg_install(), pkg_resolve(), ds_sudo(), ai(), ai_ok(), ai_warn(),
+#          error()
+# Provides: ds_python_cmd_path(), ds_python_has_module(),
+#           ds_ensure_python_module()
+# ============================================================================
+
+[[ -f "${SCRIPT_DIR:-$(pwd)}/lib/python-cmd.sh" ]] && . "${SCRIPT_DIR:-$(pwd)}/lib/python-cmd.sh"
+
+ds_python_cmd_path() {
+    local cmd="${1:-$(ds_detect_python_cmd 2>/dev/null || true)}"
+    [[ -z "$cmd" ]] && return 1
+    command -v "$cmd" 2>/dev/null || printf '%s\n' "$cmd"
+}
+
+ds_python_has_module() {
+    local module="$1"
+    local pycmd="${2:-$(ds_detect_python_cmd)}"
+    "$pycmd" -c "import ${module}" >/dev/null 2>&1
+}
+
+ds_python_is_env_managed() {
+    local py_path="${1:-$(ds_python_cmd_path 2>/dev/null || true)}"
+
+    [[ -n "${CONDA_PREFIX:-}" || -n "${VIRTUAL_ENV:-}" ]] && return 0
+    [[ "$py_path" == *"/conda/"* || "$py_path" == *"/miniconda"* || "$py_path" == *"/anaconda"* ]] && return 0
+    [[ "$py_path" == *"/.venv/"* || "$py_path" == *"/venv/"* ]] && return 0
+    return 1
+}
+
+ds_ensure_python_module() {
+    local module="$1"
+    local canonical_pkg="$2"
+    local pip_pkg="$3"
+    local display="${4:-$module}"
+
+    local pycmd
+    pycmd="$(ds_detect_python_cmd)" || error "Python is required but no runnable python3/python was found."
+
+    if ds_python_has_module "$module" "$pycmd"; then
+        ai_ok "$display available for $pycmd"
+        return 0
+    fi
+
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        ai_warn "$display is not importable by $pycmd (dry-run: would install ${canonical_pkg})."
+        return 0
+    fi
+
+    if declare -f pkg_install >/dev/null 2>&1 && declare -f pkg_resolve >/dev/null 2>&1; then
+        ai "Installing $display for the installer Python runtime..."
+        # shellcheck disable=SC2046
+        pkg_install $(pkg_resolve "$canonical_pkg") 2>>"${LOG_FILE:-/dev/null}" || true
+    fi
+
+    if ds_python_has_module "$module" "$pycmd"; then
+        ai_ok "$display available for $pycmd"
+        return 0
+    fi
+
+    local py_path
+    py_path="$(ds_python_cmd_path "$pycmd" 2>/dev/null || printf '%s' "$pycmd")"
+    if ds_python_is_env_managed "$py_path"; then
+        ai_bad "$display is not importable by the active Python: $py_path"
+        ai_bad "A Conda/venv Python appears to be ahead of the system Python."
+        ai "Run: conda deactivate"
+        ai "Then re-run the installer, or install the module into that environment:"
+        ai "  $pycmd -m pip install $pip_pkg"
+    else
+        ai_bad "$display is not importable by $pycmd."
+        ai "Install it manually and re-run:"
+        ai "  $pycmd -m pip install $pip_pkg"
+    fi
+    error "$display is required by the Dream Server compose and service registry helpers."
+}

--- a/dream-server/installers/lib/sudo.sh
+++ b/dream-server/installers/lib/sudo.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Installer — sudo helpers
+# ============================================================================
+# Part of: installers/lib/
+# Purpose: Keep privileged installer commands from hanging invisibly in
+#          --non-interactive mode, while still allowing normal interactive sudo.
+#
+# Expects: INTERACTIVE, DRY_RUN, ai(), ai_bad(), ai_warn(), error()
+# Provides: ds_sudo(), ds_prepare_sudo()
+# ============================================================================
+
+ds_sudo() {
+    if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+        "$@"
+        return $?
+    fi
+
+    if [[ "${INTERACTIVE:-true}" != "true" ]]; then
+        sudo -n "$@"
+    else
+        sudo "$@"
+    fi
+}
+
+ds_prepare_sudo() {
+    local reason="${1:-installer setup}"
+
+    [[ "${DRY_RUN:-false}" == "true" ]] && return 0
+    [[ ${EUID:-$(id -u)} -eq 0 ]] && return 0
+    command -v sudo >/dev/null 2>&1 || error "sudo is required for ${reason}."
+
+    if [[ "${INTERACTIVE:-true}" != "true" ]]; then
+        if ! sudo -n true 2>/dev/null; then
+            ai_bad "sudo requires a password, but this run is --non-interactive."
+            ai_bad "The installer would otherwise appear to hang at the first hidden sudo prompt."
+            ai "Run one of:"
+            ai "  sudo -v && ./install.sh --non-interactive ..."
+            ai "  ./install.sh ..."
+            ai "  configure NOPASSWD sudo for this install user"
+            error "Cannot continue non-interactively without cached or passwordless sudo."
+        fi
+    else
+        ai "Checking sudo access up front so later setup steps do not stall..."
+        sudo -v || error "sudo authentication failed."
+    fi
+}

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -181,6 +181,8 @@ if [[ "${GPU_BACKEND_FORCED_CPU:-false}" != "true" && $GPU_COUNT -eq 0 && "$GPU_
     fix_nvidia_secure_boot || true
 fi
 
+validate_nvidia_blackwell_open_modules
+
 # NVIDIA Driver Compatibility Check
 # llama-server (CUDA) requires driver >= 570
 if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
@@ -192,6 +194,12 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
         log "NVIDIA driver: $DRIVER_VERSION"
         if [[ "$DRIVER_VERSION" -lt "$MIN_DRIVER_VERSION" ]]; then
             ai_bad "NVIDIA driver $DRIVER_VERSION is too old. llama-server (CUDA) requires driver >= $MIN_DRIVER_VERSION."
+            if nvidia_blackwell_hardware_detected; then
+                ai_bad "This is a Blackwell GPU, so install an NVIDIA open kernel module driver."
+                ai "  sudo apt install nvidia-open"
+                ai "  # or: sudo apt install nvidia-driver-${MIN_DRIVER_VERSION}-open"
+                error "Blackwell requires driver >= ${MIN_DRIVER_VERSION} with open kernel modules."
+            fi
             ai "Attempting to install a compatible driver..."
             if ! $DRY_RUN; then
                 if command -v ubuntu-drivers &> /dev/null; then

--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -80,18 +80,18 @@ else
             pacman)
                 # Arch/Manjaro/CachyOS/EndeavourOS -- Docker is in the official repos
                 pkg_install docker
-                sudo systemctl enable --now docker.service 2>>"$LOG_FILE" || true
+                ds_sudo systemctl enable --now docker.service 2>>"$LOG_FILE" || true
                 ;;
             xbps)
                 # Void Linux -- runit service management
                 pkg_install docker
-                sudo ln -s /etc/sv/docker /var/service/ 2>/dev/null || true
+                ds_sudo ln -s /etc/sv/docker /var/service/ 2>/dev/null || true
                 ;;
             apk)
                 # Alpine -- OpenRC service management
                 pkg_install docker
-                sudo rc-update add docker boot 2>>"$LOG_FILE" || true
-                sudo service docker start 2>>"$LOG_FILE" || true
+                ds_sudo rc-update add docker boot 2>>"$LOG_FILE" || true
+                ds_sudo service docker start 2>>"$LOG_FILE" || true
                 ;;
             *)
                 # Unknown distro -- try get.docker.com as best-effort fallback
@@ -106,7 +106,7 @@ else
 
         # Add the invoking user (not root) to the docker group
         target_user="${SUDO_USER:-$USER}"
-        sudo usermod -aG docker "$target_user"
+        ds_sudo usermod -aG docker "$target_user"
 
         # In most cases group membership won't take effect until a new login shell.
         if ! id -nG "$target_user" 2>/dev/null | tr ' ' '\n' | grep -qx docker; then
@@ -127,14 +127,14 @@ if command -v docker &>/dev/null && ! $DRY_RUN; then
         # Detect package format
         if command -v apt-get &>/dev/null; then
             _distro_codename=$(. /etc/os-release 2>/dev/null && echo "$VERSION_CODENAME" || echo "noble")
-            sudo apt-get install -y --allow-downgrades \
+            ds_sudo apt-get install -y --allow-downgrades \
                 docker-ce=5:29.2.1-1~ubuntu."$(. /etc/os-release && echo "$VERSION_ID")"~"$_distro_codename" \
                 docker-ce-cli=5:29.2.1-1~ubuntu."$(. /etc/os-release && echo "$VERSION_ID")"~"$_distro_codename" \
                 >> "$LOG_FILE" 2>&1 && \
                 ai_ok "Docker downgraded to 29.2.1 (AMD GPU fix)" || \
                 ai_warn "Could not downgrade Docker. GPU containers may fail. Manual fix: sudo apt install docker-ce=5:29.2.1-1~ubuntu.24.04~noble"
         elif command -v dnf &>/dev/null; then
-            sudo dnf downgrade -y docker-ce-29.2.1 docker-ce-cli-29.2.1 >> "$LOG_FILE" 2>&1 && \
+            ds_sudo dnf downgrade -y docker-ce-29.2.1 docker-ce-cli-29.2.1 >> "$LOG_FILE" 2>&1 && \
                 ai_ok "Docker downgraded to 29.2.1 (AMD GPU fix)" || \
                 ai_warn "Could not downgrade Docker. GPU containers may fail."
         elif command -v pacman &>/dev/null; then
@@ -148,7 +148,7 @@ if command -v docker &>/dev/null && ! $DRY_RUN; then
         else
             ai_warn "Could not downgrade Docker on this system. GPU containers may fail."
         fi
-        sudo systemctl restart docker 2>/dev/null || true
+        ds_sudo systemctl restart docker 2>/dev/null || true
     fi
 fi
 
@@ -248,9 +248,9 @@ _docker_ensure_daemon() {
             # Clear start-limit-hit if docker has been restarted too many times
             if systemctl is-failed docker &>/dev/null; then
                 ai_warn "Docker is in failed state (possible start-limit-hit). Resetting..."
-                sudo systemctl reset-failed docker 2>>"$LOG_FILE" || true
+                ds_sudo systemctl reset-failed docker 2>>"$LOG_FILE" || true
             fi
-            sudo systemctl start docker 2>>"$LOG_FILE" || true
+            ds_sudo systemctl start docker 2>>"$LOG_FILE" || true
             # Give the daemon a moment to initialize
             sleep 2
         fi
@@ -349,7 +349,7 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
         ai_ok "NVIDIA Container Toolkit installed"
         # Always regenerate CDI spec — driver version may have changed since last run
         if command -v nvidia-ctk &>/dev/null && ! $DRY_RUN; then
-            sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
+            ds_sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
         fi
     else
         ai "Installing NVIDIA Container Toolkit..."
@@ -359,7 +359,7 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
                 apt)
                     # Add NVIDIA GPG key (apt's signed-by trust anchor for the toolkit repo)
                     curl -fsSL --max-time 60 https://nvidia.github.io/libnvidia-container/gpgkey | \
-                        sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+                        ds_sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
                     if [[ ! -s /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg ]]; then
                         error "NVIDIA Container Toolkit keyring download failed (empty or missing /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg). Check network connectivity to nvidia.github.io."
                     fi
@@ -394,22 +394,22 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
                     unset _nvidia_expected_fp _nvidia_actual_fp
                     curl -s -L --max-time 60 https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
                         sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-                        sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
+                        ds_sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
                     # Verify we got a valid repo file, not an HTML 404
                     if grep -q '<html' /etc/apt/sources.list.d/nvidia-container-toolkit.list 2>/dev/null; then
                         warn "Failed to download NVIDIA Container Toolkit repo list. Trying fallback..."
                         echo "deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://nvidia.github.io/libnvidia-container/stable/deb/\$(ARCH) /" | \
-                            sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
+                            ds_sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list > /dev/null
                     fi
-                    sudo apt-get update
-                    if ! sudo apt-get install -y nvidia-container-toolkit; then
+                    ds_sudo apt-get update
+                    if ! ds_sudo apt-get install -y nvidia-container-toolkit; then
                         error "Failed to install NVIDIA Container Toolkit. Check network connectivity and GPU drivers."
                     fi
                     ;;
                 dnf)
                     curl -s -L --max-time 60 https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo | \
-                        sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo > /dev/null
-                    if ! sudo dnf install -y nvidia-container-toolkit 2>>"$LOG_FILE"; then
+                        ds_sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo > /dev/null
+                    if ! ds_sudo dnf install -y nvidia-container-toolkit 2>>"$LOG_FILE"; then
                         error "Failed to install NVIDIA Container Toolkit. Check network connectivity and NVIDIA repo configuration."
                     fi
                     ;;
@@ -428,9 +428,9 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
                     fi
                     ;;
                 zypper)
-                    sudo zypper addrepo https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo 2>/dev/null || true
-                    sudo zypper --non-interactive --gpg-auto-import-keys refresh 2>>"$LOG_FILE"
-                    if ! sudo zypper --non-interactive install nvidia-container-toolkit 2>>"$LOG_FILE"; then
+                    ds_sudo zypper addrepo https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo 2>/dev/null || true
+                    ds_sudo zypper --non-interactive --gpg-auto-import-keys refresh 2>>"$LOG_FILE"
+                    if ! ds_sudo zypper --non-interactive install nvidia-container-toolkit 2>>"$LOG_FILE"; then
                         error "Failed to install NVIDIA Container Toolkit."
                     fi
                     ;;
@@ -439,9 +439,9 @@ if [[ $GPU_COUNT -gt 0 && "$GPU_BACKEND" == "nvidia" ]]; then
                     ;;
             esac
 
-            sudo nvidia-ctk runtime configure --runtime=docker
-            sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
-            sudo systemctl restart docker
+            ds_sudo nvidia-ctk runtime configure --runtime=docker
+            ds_sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml 2>>"$LOG_FILE" || true
+            ds_sudo systemctl restart docker
         fi
         if command -v nvidia-container-cli &> /dev/null 2>&1; then
             ai_ok "NVIDIA Container Toolkit installed"

--- a/dream-server/lib/python-cmd.sh
+++ b/dream-server/lib/python-cmd.sh
@@ -6,6 +6,13 @@
 
 _ds_python_cmd_cached=""
 
+_ds_python_runnable() {
+    local candidate="$1"
+    [[ -n "$candidate" ]] || return 1
+    command -v "$candidate" >/dev/null 2>&1 || [[ -x "$candidate" ]] || return 1
+    "$candidate" -c 'import sys; sys.exit(0)' >/dev/null 2>&1
+}
+
 # Prints the python command name to stdout.
 # Order:
 #  1) python3 (must be runnable)
@@ -17,20 +24,33 @@ ds_detect_python_cmd() {
         return 0
     fi
 
-    if command -v python3 >/dev/null 2>&1; then
-        if python3 -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
-            _ds_python_cmd_cached="python3"
+    if [[ -n "${DREAM_PYTHON_CMD:-}" ]] && _ds_python_runnable "$DREAM_PYTHON_CMD"; then
+        _ds_python_cmd_cached="$DREAM_PYTHON_CMD"
+        printf '%s' "${_ds_python_cmd_cached}"
+        return 0
+    fi
+
+    # Linux installer paths install Python modules through the system package
+    # manager. Prefer /usr/bin/python3 when requested so a Conda/venv python3
+    # ahead of PATH does not miss apt/dnf-installed modules like PyYAML.
+    if [[ "${DREAM_PYTHON_PREFER_SYSTEM:-}" == "1" && -x /usr/bin/python3 ]]; then
+        if _ds_python_runnable /usr/bin/python3; then
+            _ds_python_cmd_cached="/usr/bin/python3"
             printf '%s' "${_ds_python_cmd_cached}"
             return 0
         fi
     fi
 
-    if command -v python >/dev/null 2>&1; then
-        if python -c 'import sys; sys.exit(0)' >/dev/null 2>&1; then
-            _ds_python_cmd_cached="python"
-            printf '%s' "${_ds_python_cmd_cached}"
-            return 0
-        fi
+    if _ds_python_runnable python3; then
+        _ds_python_cmd_cached="python3"
+        printf '%s' "${_ds_python_cmd_cached}"
+        return 0
+    fi
+
+    if _ds_python_runnable python; then
+        _ds_python_cmd_cached="python"
+        printf '%s' "${_ds_python_cmd_cached}"
+        return 0
     fi
 
     echo "ERROR: Neither python3 nor python is available/runnable." >&2

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -60,9 +60,12 @@ sr_load() {
         PYTHON_CMD="python"
     fi
 
-    # Ensure PyYAML is available (Arch, Void, Alpine don't ship it by default)
+    # Ensure PyYAML is available (Arch, Void, Alpine don't ship it by default).
+    # install-core.sh initially loads the registry before CLI flags are parsed,
+    # so avoid surprise sudo prompts until the installer has prepared sudo and
+    # explicitly enabled DREAM_SR_AUTO_INSTALL_PYYAML.
     if ! "$PYTHON_CMD" -c "import yaml" 2>/dev/null; then
-        if declare -f pkg_install &>/dev/null && declare -f pkg_resolve &>/dev/null; then
+        if [[ "${DREAM_SR_AUTO_INSTALL_PYYAML:-}" == "1" ]] && declare -f pkg_install &>/dev/null && declare -f pkg_resolve &>/dev/null; then
             [[ -z "${PKG_MANAGER:-}" ]] && declare -f detect_pkg_manager &>/dev/null && detect_pkg_manager
             declare -f log &>/dev/null && log "PyYAML not found; installing system package..."
             # shellcheck disable=SC2046

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -17,6 +17,7 @@ bash scripts/check-release-claims.sh
 echo "[gate] contracts"
 bash tests/contracts/test-installer-contracts.sh
 bash tests/contracts/test-preflight-fixtures.sh
+bash tests/contracts/test-installer-hardening.sh
 
 echo "[gate] smoke"
 bash tests/smoke/linux-amd.sh

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -55,6 +55,14 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
+if ! "$PYTHON_CMD" -c 'import yaml' >/dev/null 2>&1; then
+    echo "ERROR: PyYAML is required by resolve-compose-stack.sh for compose validation." >&2
+    echo "       Active Python: $PYTHON_CMD ($(command -v "$PYTHON_CMD" 2>/dev/null || echo "$PYTHON_CMD"))" >&2
+    echo "       If Conda/venv is active, run 'conda deactivate' before installing Dream Server." >&2
+    echo "       Or install manually: $PYTHON_CMD -m pip install pyyaml" >&2
+    exit 2
+fi
+
 "$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" <<'PY'
 import os
 import pathlib

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+assert_contains() {
+  local file="$1"
+  local pattern="$2"
+  local msg="$3"
+  if ! grep -qE "$pattern" "$file"; then
+    echo "[FAIL] $msg"
+    echo "---- output ----"
+    cat "$file"
+    echo "----------------"
+    exit 1
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+echo "[contract] resolve-compose-stack fails loud when PyYAML is missing"
+fake_py="$tmpdir/python3"
+cat > "$fake_py" <<'PYEOF'
+#!/usr/bin/env bash
+code=""
+if [[ "${1:-}" == "-c" ]]; then
+  code="${2:-}"
+fi
+case "$code" in
+  *"import sys"*) exit 0 ;;
+  *"import yaml"*) echo "ModuleNotFoundError: No module named 'yaml'" >&2; exit 1 ;;
+esac
+echo "unexpected fake python invocation: $*" >&2
+exit 99
+PYEOF
+chmod +x "$fake_py"
+
+missing_yaml_err="$tmpdir/missing-yaml.err"
+if DREAM_PYTHON_CMD="$fake_py" scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" >"$tmpdir/missing-yaml.out" 2>"$missing_yaml_err"; then
+  echo "[FAIL] resolver should fail when selected Python cannot import yaml"
+  exit 1
+fi
+assert_contains "$missing_yaml_err" 'PyYAML is required' "resolver did not explain PyYAML requirement"
+assert_contains "$missing_yaml_err" 'conda deactivate' "resolver did not include Conda/venv recovery hint"
+
+echo "[contract] ds_sudo uses sudo -n in non-interactive mode"
+fakebin="$tmpdir/fakebin"
+mkdir -p "$fakebin"
+cat > "$fakebin/sudo" <<'SUDOEOT'
+#!/usr/bin/env bash
+printf '%s\n' "$*" > "$DREAM_TEST_SUDO_ARGS"
+exit 0
+SUDOEOT
+chmod +x "$fakebin/sudo"
+sudo_args="$tmpdir/sudo.args"
+PATH="$fakebin:$PATH" DREAM_TEST_SUDO_ARGS="$sudo_args" bash -c '
+  set -euo pipefail
+  INTERACTIVE=false
+  DRY_RUN=false
+  source installers/lib/sudo.sh
+  ds_sudo nvidia-ctk cdi generate --output=/etc/cdi/nvidia.yaml
+'
+assert_contains "$sudo_args" '^-n nvidia-ctk cdi generate' "ds_sudo did not use sudo -n for non-interactive runs"
+
+echo "[contract] Blackwell proprietary module is blocked"
+blackwell_bin="$tmpdir/blackwell-proprietary"
+mkdir -p "$blackwell_bin"
+cat > "$blackwell_bin/nvidia-smi" <<'NVSMI'
+#!/usr/bin/env bash
+if [[ "$*" == *"--query-gpu=name,compute_cap"* ]]; then
+  echo "NVIDIA RTX PRO 6000 Blackwell Workstation Edition, 12.0"
+  exit 0
+fi
+exit 0
+NVSMI
+cat > "$blackwell_bin/modinfo" <<'MODINFO'
+#!/usr/bin/env bash
+if [[ "$*" == "-F license nvidia" ]]; then
+  echo "NVIDIA"
+  exit 0
+fi
+exit 1
+MODINFO
+cat > "$blackwell_bin/lspci" <<'LSPCI'
+#!/usr/bin/env bash
+echo "01:00.0 VGA compatible controller: NVIDIA Corporation Blackwell"
+LSPCI
+chmod +x "$blackwell_bin/nvidia-smi" "$blackwell_bin/modinfo" "$blackwell_bin/lspci"
+
+if PATH="$blackwell_bin:$PATH" bash -c '
+  set -euo pipefail
+  LOG_FILE=/dev/null
+  ai() { :; }
+  ai_ok() { :; }
+  ai_warn() { :; }
+  ai_bad() { :; }
+  error() { echo "$1"; return 42; }
+  source installers/lib/detection.sh
+  validate_nvidia_blackwell_open_modules
+' >"$tmpdir/blackwell-proprietary.out" 2>"$tmpdir/blackwell-proprietary.err"; then
+  echo "[FAIL] proprietary Blackwell module should block install"
+  exit 1
+fi
+assert_contains "$tmpdir/blackwell-proprietary.out" 'Blackwell requires NVIDIA open kernel modules' "Blackwell proprietary failure did not explain open-module requirement"
+
+echo "[contract] Blackwell open module is accepted"
+open_bin="$tmpdir/blackwell-open"
+mkdir -p "$open_bin"
+cp "$blackwell_bin/nvidia-smi" "$open_bin/nvidia-smi"
+cp "$blackwell_bin/lspci" "$open_bin/lspci"
+cat > "$open_bin/modinfo" <<'OPENMOD'
+#!/usr/bin/env bash
+if [[ "$*" == "-F license nvidia" ]]; then
+  echo "Dual MIT/GPL"
+  exit 0
+fi
+exit 1
+OPENMOD
+chmod +x "$open_bin/nvidia-smi" "$open_bin/lspci" "$open_bin/modinfo"
+
+PATH="$open_bin:$PATH" bash -c '
+  set -euo pipefail
+  LOG_FILE=/dev/null
+  ai() { :; }
+  ai_ok() { :; }
+  ai_warn() { :; }
+  ai_bad() { :; }
+  error() { echo "$1"; return 42; }
+  source installers/lib/detection.sh
+  validate_nvidia_blackwell_open_modules
+'
+
+echo "[PASS] installer hardening contracts"


### PR DESCRIPTION
## Summary

Hardens the Linux installer around the install report failure modes we investigated:

- Prefer system Python during Linux install and fail loudly when PyYAML is missing, with Conda/venv recovery guidance.
- Add sudo helpers so non-interactive runs use `sudo -n` and fail clearly instead of hanging at hidden password prompts.
- Validate NVIDIA Blackwell systems against the open-kernel-module requirement and give explicit `nvidia-open` / `nvidia-driver-*-open` guidance.
- Route NVIDIA Docker/CDI and Secure Boot helper sudo calls through the safer wrapper.
- Add installer troubleshooting docs and a targeted contract test for PyYAML, sudo, and Blackwell module behavior.

## Root Cause

Miniconda can put a Python ahead of `/usr/bin/python3`, while the installer installs distro Python packages such as `python3-yaml` into the system interpreter. The compose resolver then imports `yaml` under `set -e`, creating a hard-to-read failure. Separately, late `sudo nvidia-ctk` calls could prompt invisibly during non-interactive installs, and Blackwell NVIDIA GPUs were only checked by driver version rather than kernel module flavor.

## Validation

- `bash -n install-core.sh installers/lib/sudo.sh installers/lib/python-runtime.sh installers/lib/detection.sh installers/phases/02-detection.sh installers/phases/05-docker.sh lib/python-cmd.sh lib/service-registry.sh scripts/resolve-compose-stack.sh tests/contracts/test-installer-hardening.sh scripts/release-gate.sh`
- `bash tests/contracts/test-installer-hardening.sh`
- `bash tests/contracts/test-preflight-fixtures.sh`
- `bash scripts/simulate-installers.sh artifacts/installer-sim-pr-hardening`
- `git diff --check`

Not run locally: `tests/contracts/test-installer-contracts.sh` because this Windows Git Bash environment does not have `jq` installed.