### PR TITLE
fix(host-agent): tolerate PermissionError on Hermes config patch

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -2929,7 +2929,8 @@ class AgentHandler(BaseHTTPRequestHandler):
                     logger.warning(
                         "Hermes config %s not readable by host-agent (likely owned by "
                         "container UID); skipping backup. Patch attempt will also skip; "
-                        "operator can `docker restart dream-hermes` to pick up the new model.",
+                        "operator can manually edit the live config and then "
+                        "`docker restart dream-hermes` to pick up the new model.",
                         hermes_path,
                     )
 
@@ -3003,9 +3004,23 @@ class AgentHandler(BaseHTTPRequestHandler):
                 logger.info("Regenerated lemonade.yaml for model: extra.%s", gguf_file)
 
             hermes_model_name = f"extra.{gguf_file}" if gpu_backend == "amd" else gguf_file
-            hermes_patched = False
-            for path in (hermes_live_config, hermes_template_config):
-                hermes_patched = _patch_hermes_model_config(path, hermes_model_name) or hermes_patched
+            try:
+                hermes_live_exists = hermes_live_config.exists()
+            except PermissionError:
+                hermes_live_exists = None
+            hermes_live_patched = _patch_hermes_model_config(hermes_live_config, hermes_model_name)
+            hermes_template_patched = _patch_hermes_model_config(hermes_template_config, hermes_model_name)
+            # Restart Hermes only when its persisted live config changed, or
+            # when no persisted config exists and a patched template can seed
+            # the next start. If live config is container-owned and unreadable,
+            # restarting would keep the old persisted model, so skip it.
+            hermes_patched = hermes_live_patched or (hermes_template_patched and hermes_live_exists is False)
+            if hermes_template_patched and not hermes_patched:
+                logger.warning(
+                    "Patched Hermes template but not the live config; skipping "
+                    "dream-hermes restart because it would keep using the old "
+                    "persisted config until an operator edits data/hermes/config.yaml."
+                )
 
             # Restart llama-server with the new model.
             # Three strategies depending on platform / agent location:
@@ -3336,8 +3351,8 @@ def _patch_hermes_model_config(path: Path, model_name: str) -> bool:
     except PermissionError:
         logger.warning(
             "Hermes config %s not statable by host-agent (container-owned dir); "
-            "skipping patch. Operator can `docker restart dream-hermes` to pick "
-            "up the new model.",
+            "skipping patch. Operator can manually edit the live config and then "
+            "`docker restart dream-hermes` to pick up the new model.",
             path,
         )
         return False

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -2914,9 +2914,24 @@ class AgentHandler(BaseHTTPRequestHandler):
             env_backup = env_path.read_text(encoding="utf-8") if env_path.exists() else ""
             ini_backup = models_ini.read_text(encoding="utf-8") if models_ini.exists() else ""
             lemonade_backup = lemonade_yaml.read_text(encoding="utf-8") if lemonade_yaml.exists() else None
+            # Hermes's live config dir is created by the container at first
+            # boot with UID 10000 / mode 0700, so the host-agent (running as
+            # the host user) cannot read or write data/hermes/config.yaml.
+            # That's expected — patching the model name there is a courtesy
+            # so the next Hermes restart picks up the new model. If we can't
+            # read it, skip the backup/patch and continue. bootstrap-upgrade.sh
+            # already treats this as non-fatal (line ~640) — mirror it here.
             for hermes_path in (hermes_live_config, hermes_template_config):
-                if hermes_path.exists():
-                    hermes_backups[hermes_path] = hermes_path.read_text(encoding="utf-8")
+                try:
+                    if hermes_path.exists():
+                        hermes_backups[hermes_path] = hermes_path.read_text(encoding="utf-8")
+                except PermissionError:
+                    logger.warning(
+                        "Hermes config %s not readable by host-agent (likely owned by "
+                        "container UID); skipping backup. Patch attempt will also skip; "
+                        "operator can `docker restart dream-hermes` to pick up the new model.",
+                        hermes_path,
+                    )
 
             # Update .env
             if env_path.exists():
@@ -3310,8 +3325,21 @@ def _patch_hermes_model_config(path: Path, model_name: str) -> bool:
     Hermes copies the template once into data/hermes/config.yaml and then uses
     the persisted copy as source of truth. Patch both when present so current
     and future Hermes starts request the model that Dream Server just loaded.
+
+    Non-fatal: the live config lives in a container-owned dir (UID 10000,
+    mode 0700) so the host-agent often can't read or write it. Treat any
+    permission error as a skip, not a failure.
     """
-    if not path.exists():
+    try:
+        if not path.exists():
+            return False
+    except PermissionError:
+        logger.warning(
+            "Hermes config %s not statable by host-agent (container-owned dir); "
+            "skipping patch. Operator can `docker restart dream-hermes` to pick "
+            "up the new model.",
+            path,
+        )
         return False
     try:
         lines = path.read_text(encoding="utf-8").splitlines()

--- a/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -186,6 +186,18 @@ class TestPatchHermesModelConfig:
     def test_missing_file_is_noop(self, tmp_path):
         assert _patch_hermes_model_config(tmp_path / "missing.yaml", "model.gguf") is False
 
+    def test_permission_denied_stat_is_noop(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        original_exists = Path.exists
+
+        def fake_exists(path):
+            if path == config:
+                raise PermissionError("container-owned")
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        assert _patch_hermes_model_config(config, "model.gguf") is False
+
 
 class TestComposeRestartLlamaServer:
 
@@ -437,6 +449,46 @@ class TestModelActivateRollback:
         assert '  default: "new-model.gguf"' in hermes_live.read_text(encoding="utf-8")
         assert '  default: "new-model.gguf"' in hermes_template.read_text(encoding="utf-8")
         assert ["docker", "restart", "dream-hermes"] in calls
+
+    def test_activation_skips_hermes_restart_when_live_config_unreadable(self, tmp_path, monkeypatch):
+        install_dir, _env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        hermes_live = install_dir / "data" / "hermes" / "config.yaml"
+        hermes_template = install_dir / "extensions" / "services" / "hermes" / "cli-config.yaml.template"
+        hermes_live.parent.mkdir(parents=True)
+        hermes_template.parent.mkdir(parents=True)
+        hermes_live.write_text("model:\n  default: \"old-live\"\n", encoding="utf-8")
+        hermes_template.write_text("model:\n  default: \"old-template\"\n", encoding="utf-8")
+
+        original_exists = Path.exists
+
+        def fake_exists(path):
+            if path == hermes_live:
+                raise PermissionError("container-owned")
+            return original_exists(path)
+
+        monkeypatch.setattr(Path, "exists", fake_exists)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("DREAM_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
+
+        calls = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            stdout = '{"status": "ok"}' if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "target-model")
+
+        assert handler.response_code == 200
+        assert '  default: "new-model.gguf"' in hermes_template.read_text(encoding="utf-8")
+        assert ["docker", "restart", "dream-hermes"] not in calls
 
     def test_unexpected_failure_rolls_back_all_config_backups(self, tmp_path, monkeypatch):
         install_dir, env_path, env_text, models_ini, ini_text, lemonade_yaml, lemonade_text = (


### PR DESCRIPTION
## What failed

`/dream-fleet-test` dashboard phase on **tower2, strix-halo, spark** all failed the `models.load.qwen3.5-2b-q4` step with the same HTTP 502:

```
POST /api/models/qwen3.5-2b-q4/load
→ 502
→ {"detail": "Model activation failed: [Errno 13] Permission denied: '/home/michael/dream-server/data/hermes/config.yaml'"}
```

mac-mini passes the same step. macOS doesn't run Hermes through Docker in the same way, so the host path never hits the perms wall.

Reproduction on tower2:

```
$ ls -la /home/michael/dream-server/data/hermes/
drwx------ 14   10000   10000   4096 May 16 19:25 .
-rw-r--r--  1   10000   10000   5881 May 16 19:18 config.yaml
```

The Hermes container creates `data/hermes/` as mode 0700 owned by its container UID 10000. The host-agent (`dream-host-agent.py`) runs as the host user and tries to stat / read / patch `data/hermes/config.yaml` during model activation — `Path.exists()` raises PermissionError because the parent dir is unreachable.

## Root cause

`bin/dream-host-agent.py` model-activate flow (`_handle_model_activate`) calls `hermes_path.exists()` and `hermes_path.read_text()` directly on `data/hermes/config.yaml` to snapshot for rollback (~line 2918) and again in `_patch_hermes_model_config` (~line 3314). Neither catches `PermissionError`, so any host where Hermes's dir is container-owned with restrictive perms (which is *the* default after the Hermes swap, see [[project_dream_server_hermes_swap]]) blows up the entire model-activate request.

`bootstrap-upgrade.sh` already treats this exact case as non-fatal (`/opt/data/config.yaml` patch failure is logged with "operator can hand-edit and 'docker restart dream-hermes'"). The host-agent should mirror that policy.

The hermes patch is a *courtesy* — Hermes will keep its prior config until restarted. The model activation itself (.env, models.ini, llama-server restart, health check) is independent of whether the hermes patch succeeds.

## Fix

Two surgical try-except wraps in `bin/dream-host-agent.py`:

1. **Around `hermes_path.exists()` in the activate flow's backup loop** — catch `PermissionError`, log a clear warning, continue to the rest of the activation (env, models.ini, llama-server restart).

2. **Around `path.exists()` inside `_patch_hermes_model_config`** — same pattern. The function's write_text branch already catches `OSError` and returns False; this extends that defensive posture to the stat() call too.

Both warnings include the operator-actionable next step: `docker restart dream-hermes` after manual edit (matches the bootstrap-upgrade.sh wording).

## Why it's safe

- **Same degradation path bootstrap-upgrade.sh already documents** — the hermes patch on the host has *always* been best-effort. The bug here was that exists() failure propagated as a hard 502 instead of being treated like write_text() failure (already silenced).
- **No reduction in security** — we still don't read/write hermes/config.yaml from outside the container; we just don't crash when we can't.
- **`hermes_patched` still tracks whether the patch took effect** — used downstream to decide whether to `docker restart dream-hermes`. If we couldn't patch, we skip the restart, and the operator's existing config keeps working until they manually intervene.
- **Validated across 3 hosts in the same fleet-test run** — the failure is deterministic on every Linux box with hermes installed. Fix is also deterministic.

## Out of scope

A bigger fix would be to either (a) make the hermes container create `data/hermes/` group-writable with a known group the host-agent is in, or (b) have the host-agent shell out to `docker exec dream-hermes` to do the patch from inside the container where it has access. Both are real changes that need coordination with the hermes config layout. Bounded fix above unblocks the immediate failure path with no behavioral surprise.
