### PR TITLE
fix(hermes): register agent services in core allowlists

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -50,7 +50,7 @@ logger = logging.getLogger("dream-host-agent")
 # the API key to stop core services like llama-server or dashboard-api.
 _FALLBACK_CORE_IDS = frozenset({
     "dashboard-api", "dashboard", "llama-server", "open-webui",
-    "litellm", "langfuse", "n8n", "openclaw", "opencode",
+    "litellm", "langfuse", "hermes", "hermes-proxy", "n8n", "openclaw", "opencode",
     "perplexica", "searxng", "qdrant", "tts", "whisper",
     "embeddings", "token-spy", "comfyui", "ape", "privacy-shield",
 })
@@ -71,7 +71,7 @@ EXTENSIONS_DIR: Path = Path()
 _service_locks: dict[str, threading.Lock] = collections.defaultdict(threading.Lock)
 _ALLOWED_CORE_RECREATE_IDS = frozenset({
     "llama-server", "open-webui", "litellm", "langfuse", "n8n",
-    "openclaw", "opencode", "perplexica", "searxng", "qdrant",
+    "hermes", "hermes-proxy", "openclaw", "opencode", "perplexica", "searxng", "qdrant",
     "tts", "whisper", "embeddings", "token-spy", "comfyui",
     "ape", "privacy-shield",
 })

--- a/dream-server/config/core-service-ids.json
+++ b/dream-server/config/core-service-ids.json
@@ -5,6 +5,8 @@
   "dashboard-api",
   "embeddings",
   "langfuse",
+  "hermes",
+  "hermes-proxy",
   "litellm",
   "llama-server",
   "n8n",

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -234,6 +234,8 @@ SIDEBAR_ICONS = {
     "open-webui": "MessageSquare",
     "n8n": "Network",
     "openclaw": "Bot",
+    "hermes": "Bot",
+    "hermes-proxy": "Shield",
     "opencode": "Code",
     "perplexica": "Search",
     "comfyui": "Image",
@@ -268,7 +270,7 @@ def _load_core_service_ids() -> frozenset:
     # Fallback to hardcoded list
     return frozenset({
         "dashboard-api", "dashboard", "llama-server", "open-webui",
-        "litellm", "langfuse", "n8n", "openclaw", "opencode",
+        "litellm", "langfuse", "hermes", "hermes-proxy", "n8n", "openclaw", "opencode",
         "perplexica", "searxng", "qdrant", "tts", "whisper",
         "embeddings", "token-spy", "comfyui", "ape", "privacy-shield",
     })

--- a/dream-server/extensions/services/dashboard-api/settings.py
+++ b/dream-server/extensions/services/dashboard-api/settings.py
@@ -28,7 +28,7 @@ _SENSITIVE_ENV_KEY_RE = re.compile(
 
 _SETTINGS_APPLY_ALLOWED_SERVICES = frozenset({
     "llama-server", "open-webui", "litellm", "langfuse", "n8n",
-    "openclaw", "opencode", "perplexica", "searxng", "qdrant",
+    "hermes", "hermes-proxy", "openclaw", "opencode", "perplexica", "searxng", "qdrant",
     "tts", "whisper", "embeddings", "token-spy", "comfyui",
     "ape", "privacy-shield",
 })
@@ -266,6 +266,10 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "langfuse"
     if key.startswith("N8N_"):
         return "n8n"
+    if key == "DREAM_AUTH_UPSTREAM" or key.startswith("HERMES_PROXY_"):
+        return "hermes-proxy"
+    if key.startswith("HERMES_"):
+        return "hermes"
     if key.startswith("COMFYUI_"):
         return "comfyui"
     if key.startswith("WHISPER_"):

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -375,7 +375,7 @@ def _patch_mutation_config(monkeypatch, tmp_path, lib_dir=None, user_dir=None):
     monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR",
                         tmp_path / "builtin")
     monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS",
-                        frozenset({"dashboard-api", "open-webui"}))
+                        frozenset({"dashboard-api", "open-webui", "hermes", "hermes-proxy"}))
 
 
 # --- Install endpoint ---
@@ -1499,6 +1499,23 @@ class TestComposeScanEdgeCases:
             "/api/extensions/bad-ext/install",
             headers=test_client.auth_headers,
         )
+        assert resp.status_code == 400
+        assert "conflicts with core service" in resp.json()["detail"]
+
+    @pytest.mark.parametrize("service_name", ["hermes", "hermes-proxy"])
+    def test_scan_rejects_hermes_core_service_name(
+        self, test_client, monkeypatch, tmp_path, service_name,
+    ):
+        """Hermes built-ins must be protected from user extension shadowing."""
+        compose = f"services:\n  {service_name}:\n    image: test:latest\n"
+        lib_dir = _setup_library_ext(tmp_path, "bad-ext", compose_content=compose)
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
+
+        resp = test_client.post(
+            "/api/extensions/bad-ext/install",
+            headers=test_client.auth_headers,
+        )
+
         assert resp.status_code == 400
         assert "conflicts with core service" in resp.json()["detail"]
 
@@ -3228,7 +3245,7 @@ class TestAssertNotCoreAllowsBuiltins:
     @pytest.mark.parametrize("service_id", [
         "n8n", "tts", "whisper", "comfyui", "litellm", "openclaw",
         "perplexica", "searxng", "privacy-shield", "token-spy", "qdrant",
-        "embeddings", "ape", "langfuse", "opencode",
+        "embeddings", "ape", "langfuse", "opencode", "hermes", "hermes-proxy",
     ])
     def test_assert_not_core_allows_builtin_extension(self, service_id):
         """Built-in extensions are toggleable and must not be blocked."""
@@ -3242,6 +3259,14 @@ class TestAssertNotCoreAllowsBuiltins:
         with pytest.raises(HTTPException) as exc_info:
             _assert_not_core(service_id)
         assert exc_info.value.status_code == 403
+
+
+def test_production_core_service_ids_include_hermes_services():
+    """The production anti-shadowing allowlist must cover Hermes built-ins."""
+    core_ids_path = Path(__file__).resolve().parents[4] / "config" / "core-service-ids.json"
+    core_ids = set(json.loads(core_ids_path.read_text(encoding="utf-8")))
+
+    assert {"hermes", "hermes-proxy"} <= core_ids
 
 
 class TestCallAgentErrorNarrowing:

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -222,6 +222,13 @@ class TestValidateCoreRecreateIds:
         assert ok is True
         assert error == ""
 
+    @pytest.mark.parametrize("service_id", ["hermes", "hermes-proxy"])
+    def test_accepts_hermes_core_recreate_services(self, monkeypatch, service_id):
+        monkeypatch.setattr(_mod, "CORE_SERVICE_IDS", {service_id})
+        ok, error = validate_core_recreate_ids([service_id])
+        assert ok is True
+        assert error == ""
+
     def test_rejects_non_core_service(self, monkeypatch):
         monkeypatch.setattr(_mod, "CORE_SERVICE_IDS", {"dashboard-api"})
         ok, error = validate_core_recreate_ids(["llama-server"])

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -278,6 +278,26 @@ def test_api_settings_env_apply_calls_host_agent(test_client, monkeypatch):
     assert captured["service_ids"] == ["llama-server"]
 
 
+def test_api_settings_env_apply_allows_hermes_services(test_client, monkeypatch):
+    captured = {}
+
+    def fake_call(service_ids):
+        captured["service_ids"] = service_ids
+        return {"status": "ok"}
+
+    monkeypatch.setattr("main._call_agent_core_recreate", fake_call)
+
+    response = test_client.post(
+        "/api/settings/env/apply",
+        headers=test_client.auth_headers,
+        json={"service_ids": ["hermes-proxy", "hermes"]},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert captured["service_ids"] == ["hermes", "hermes-proxy"]
+
+
 def test_api_settings_env_apply_rejects_disallowed_service(test_client):
     response = test_client.post(
         "/api/settings/env/apply",
@@ -287,6 +307,27 @@ def test_api_settings_env_apply_rejects_disallowed_service(test_client):
 
     assert response.status_code == 400
     assert "not eligible" in response.json()["detail"]["message"].lower()
+
+
+def test_settings_apply_plan_maps_hermes_env_keys():
+    from settings import _compute_env_apply_plan
+
+    previous = {
+        "HERMES_LANGUAGE": "en",
+        "HERMES_PROXY_PORT": "9120",
+        "DREAM_AUTH_UPSTREAM": "dream-dashboard-api:3002",
+    }
+    updated = {
+        "HERMES_LANGUAGE": "pt",
+        "HERMES_PROXY_PORT": "9121",
+        "DREAM_AUTH_UPSTREAM": "dashboard-api:3002",
+    }
+
+    plan = _compute_env_apply_plan(previous, updated)
+
+    assert plan["status"] == "ready"
+    assert plan["services"] == ["hermes", "hermes-proxy"]
+    assert plan["manualKeys"] == []
 
 
 # --- Render round-trip fidelity ---


### PR DESCRIPTION
## Summary
Registers `hermes` and `hermes-proxy` across the DreamServer core service allowlists now that Hermes is the native agent system.

## What changed
- Adds `hermes` and `hermes-proxy` to `config/core-service-ids.json`.
- Updates dashboard-api and host-agent fallback core-service lists.
- Allows dashboard-triggered recreate for `hermes` and `hermes-proxy`.
- Maps `HERMES_*` settings to `hermes`.
- Maps `HERMES_PROXY_*` and `DREAM_AUTH_UPSTREAM` settings to `hermes-proxy`.
- Adds sidebar icons for Hermes and Hermes proxy.
- Adds regression tests for:
  - blocking user extension compose services named `hermes` or `hermes-proxy`;
  - production core IDs containing Hermes services;
  - Settings apply-plan routing for Hermes env vars;
  - host-agent core recreate validation for Hermes services.

## Why this matters
Hermes replaced OpenClaw as DreamServer's native agent path, but the service allowlists still treated Hermes like a normal optional extension in a few places. That made the new agent stack less protected than older core services and prevented Settings changes from being applied cleanly.

## Validation
- `pytest dream-server/extensions/services/dashboard-api/tests/test_extensions.py -q`
- `pytest dream-server/extensions/services/dashboard-api/tests/test_settings_env.py -q`
- `pytest dream-server/extensions/services/dashboard-api/tests/test_config.py -q`
- `pytest dream-server/extensions/services/dashboard-api/tests/test_host_agent.py::TestValidateCoreRecreateIds -q`
- `python -m py_compile dream-server/bin/dream-host-agent.py dream-server/extensions/services/dashboard-api/config.py dream-server/extensions/services/dashboard-api/settings.py`
- `git diff --check`

Note: the full `test_host_agent.py` suite has an unrelated Windows-only executable-bit assertion failure in `TestSyncExtensionConfigWire`; the Hermes recreate tests pass.