### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -74,6 +74,7 @@ LLM_API_URL=http://llama-server:8080
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 TOGETHER_API_KEY=
+MINIMAX_API_KEY=
 
 # ═══════════════════════════════════════════════════════════════════
 # LLM Settings (llama-server)

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -72,6 +72,11 @@
       "description": "Together AI API key (optional)",
       "secret": true
     },
+    "MINIMAX_API_KEY": {
+      "type": "string",
+      "description": "MiniMax API key for MiniMax models (cloud/hybrid modes)",
+      "secret": true
+    },
     "WEBUI_SECRET": {
       "type": "string",
       "description": "Session signing secret for Open WebUI",

--- a/dream-server/config/litellm/cloud.yaml
+++ b/dream-server/config/litellm/cloud.yaml
@@ -14,6 +14,18 @@ model_list:
       model: anthropic/claude-haiku-4-5-20251001
       api_key: os.environ/ANTHROPIC_API_KEY
 
+  - model_name: minimax
+    litellm_params:
+      model: openai/MiniMax-M2.7
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: minimax-fast
+    litellm_params:
+      model: openai/MiniMax-M2.7-highspeed
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
 router_settings:
   routing_strategy: simple-shuffle
 

--- a/dream-server/config/litellm/hybrid.yaml
+++ b/dream-server/config/litellm/hybrid.yaml
@@ -10,6 +10,18 @@ model_list:
       model: anthropic/claude-sonnet-4-5-20250514
       api_key: os.environ/ANTHROPIC_API_KEY
 
+  - model_name: minimax
+    litellm_params:
+      model: openai/MiniMax-M2.7
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: minimax-fast
+    litellm_params:
+      model: openai/MiniMax-M2.7-highspeed
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
   - model_name: default
     litellm_params:
       model: openai/default

--- a/dream-server/docs/MODE-SWITCH.md
+++ b/dream-server/docs/MODE-SWITCH.md
@@ -60,7 +60,7 @@ LLM requests routed through LiteLLM to cloud APIs.
 
 | Aspect | Details |
 |--------|---------|
-| **LLM** | Claude, GPT-4o via LiteLLM |
+| **LLM** | Claude, GPT-4o, MiniMax via LiteLLM |
 | **Cost** | ~$0.003-0.06/1K tokens |
 | **Requires** | Internet, API keys |
 | **GPU** | Not needed |
@@ -114,6 +114,7 @@ For AMD Strix Halo performance tuning (GRUB, kernel module, sysctl settings), se
 | `ANTHROPIC_API_KEY` | *(empty)* | Anthropic API key (cloud/hybrid) |
 | `OPENAI_API_KEY` | *(empty)* | OpenAI API key (cloud/hybrid) |
 | `TOGETHER_API_KEY` | *(empty)* | Together AI API key (optional) |
+| `MINIMAX_API_KEY` | *(empty)* | MiniMax API key (optional, cloud/hybrid) |
 
 ---
 

--- a/dream-server/extensions/services/litellm/README.md
+++ b/dream-server/extensions/services/litellm/README.md
@@ -13,7 +13,7 @@ LiteLLM runs at `http://localhost:4000` and is the recommended integration point
 - **Single endpoint for all modes**: Same `POST /v1/chat/completions` URL regardless of backend
 - **Three operating modes**: Local, cloud, and hybrid with automatic fallback
 - **OpenAI-compatible API**: Works with any OpenAI SDK client
-- **Multi-provider routing**: Anthropic, OpenAI, Together AI, and local llama-server
+- **Multi-provider routing**: Anthropic, OpenAI, Together AI, MiniMax, and local llama-server
 - **Master key auth**: Secure all requests with `LITELLM_KEY`
 - **Drop params**: Unsupported parameters silently ignored across backends
 
@@ -42,6 +42,8 @@ model_list:
   - model_name: default       # → anthropic/claude-sonnet-4-5-20250514
   - model_name: gpt4o         # → openai/gpt-4o
   - model_name: fast          # → anthropic/claude-haiku-4-5-20251001
+  - model_name: minimax       # → MiniMax-M2.7 via minimax API
+  - model_name: minimax-fast  # → MiniMax-M2.7-highspeed
 ```
 
 ### hybrid
@@ -71,6 +73,7 @@ Environment variables (set in `.env`):
 | `ANTHROPIC_API_KEY` | *(empty)* | Required for `cloud` and `hybrid` modes |
 | `OPENAI_API_KEY` | *(empty)* | Required for OpenAI models in `cloud` mode |
 | `TOGETHER_API_KEY` | *(empty)* | Required for Together AI models in `cloud` mode |
+| `MINIMAX_API_KEY` | *(empty)* | Required for MiniMax models in `cloud`/`hybrid` modes |
 
 ## API Endpoints
 

--- a/dream-server/extensions/services/litellm/compose.yaml
+++ b/dream-server/extensions/services/litellm/compose.yaml
@@ -10,6 +10,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
+      - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       - LANGFUSE_ENABLED=${LANGFUSE_ENABLED:-false}
     volumes:
       - ./config/litellm/${DREAM_MODE:-local}.yaml:/app/config.yaml:ro

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -268,6 +268,7 @@ LLM_API_URL=${llm_api_url}
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 TOGETHER_API_KEY=
+MINIMAX_API_KEY=
 
 #=== LLM Settings (llama-server -- native Metal) ===
 MODEL_PROFILE=${MODEL_PROFILE_REQUESTED:-${MODEL_PROFILE:-qwen}}

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -340,6 +340,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     ANTHROPIC_API_KEY=$(_env_get ANTHROPIC_API_KEY "${ANTHROPIC_API_KEY:-}")
     OPENAI_API_KEY=$(_env_get OPENAI_API_KEY "${OPENAI_API_KEY:-}")
     TOGETHER_API_KEY=$(_env_get TOGETHER_API_KEY "${TOGETHER_API_KEY:-}")
+    MINIMAX_API_KEY=$(_env_get MINIMAX_API_KEY "${MINIMAX_API_KEY:-}")
     # Base64-encode GPU assignment JSON for safe .env storage
     if [[ -n "${GPU_ASSIGNMENT_JSON:-}" && "${GPU_ASSIGNMENT_JSON:-}" != "{}" ]]; then
         GPU_ASSIGNMENT_JSON_B64=$(echo "$GPU_ASSIGNMENT_JSON" | jq -c '.' | base64 -w0)
@@ -380,6 +381,7 @@ LLM_API_URL=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local"
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
 OPENAI_API_KEY=${OPENAI_API_KEY:-}
 TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
+MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
 
 #=== Service Auth (LiteLLM proxy) ===
 TARGET_API_KEY=not-needed

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -268,6 +268,7 @@ LLM_API_BASE_PATH=$llmApiBasePath
 ANTHROPIC_API_KEY=$(Get-EnvOrNew "ANTHROPIC_API_KEY" "")
 OPENAI_API_KEY=$(Get-EnvOrNew "OPENAI_API_KEY" "")
 TOGETHER_API_KEY=$(Get-EnvOrNew "TOGETHER_API_KEY" "")
+MINIMAX_API_KEY=$(Get-EnvOrNew "MINIMAX_API_KEY" "")
 
 #=== LLM Settings (llama-server) ===
 MODEL_PROFILE=$(Get-EnvOrNew "MODEL_PROFILE" "$(if ($TierConfig.ModelProfileRequested) { $TierConfig.ModelProfileRequested } else { "qwen" })")


### PR DESCRIPTION
## Summary

Add [MiniMax](https://platform.minimax.io/) as a cloud LLM provider for Dream Server's cloud and hybrid modes, routed through the existing LiteLLM gateway.

**Models added:**
- `minimax` → MiniMax-M2.7 (default, high-performance)
- `minimax-fast` → MiniMax-M2.7-highspeed (same quality, faster)

**Changes across 10 files:**
- LiteLLM configs (`cloud.yaml`, `hybrid.yaml`) — new model entries using OpenAI-compatible API at `api.minimax.io`
- Environment support — `MINIMAX_API_KEY` added to `.env.example`, `.env.schema.json`, and LiteLLM `compose.yaml`
- Installer preservation — key persists across re-installs on Linux, macOS, and Windows
- Documentation — LiteLLM README and MODE-SWITCH docs updated

## Usage

```bash
# Set your API key
MINIMAX_API_KEY=your-key-here

# Switch to cloud or hybrid mode
dream mode cloud

# Use via LiteLLM gateway
curl http://localhost:4000/v1/chat/completions \
  -H "Authorization: Bearer $LITELLM_KEY" \
  -d '{"model": "minimax", "messages": [{"role": "user", "content": "Hello"}]}'
```

## API Documentation

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Verification

- [x] `make lint` passes (shell syntax + Python compile)
- [x] `make test` passes (tier map + installer contracts)
- [x] Dashboard API tests pass (599/600, 1 pre-existing port-conflict flake)
- [x] Docker Compose validation passes
- [x] YAML/JSON schema validation passes
- [x] API integration test — both MiniMax-M2.7 and MiniMax-M2.7-highspeed return valid completions
- [x] Installer bash syntax check passes
- [x] No embedding code added (MiniMax has no embedding models)