### PR TITLE
fix(installer): make phase 13-summary exit 0 when ComfyUI/other optio…

### DIFF
--- a/dream-server/installers/phases/13-summary.sh
+++ b/dream-server/installers/phases/13-summary.sh
@@ -363,6 +363,10 @@ if command -v dream_readiness_summary >/dev/null 2>&1; then
             "${SERVICE_PORTS[qdrant]:-6333}" "${SERVICE_HEALTH[qdrant]:-/}" "$(sr_container qdrant)" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}"
         [[ "${ENABLE_COMFYUI:-}" == "true" ]] && printf 'ComfyUI|http://127.0.0.1:%s%s|%s|%s\n' \
             "${SERVICE_PORTS[comfyui]:-8188}" "${SERVICE_HEALTH[comfyui]:-/}" "$(sr_container comfyui)" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}"
+        # Ensure the block exits 0 regardless of the trailing optional conditionals:
+        # under set -e + pipefail, a false `[[ ENABLE_x ]] && printf` makes the block
+        # return 1, which propagates through the pipe and trips the ERR trap.
+        :
     } | dream_readiness_summary "dream status" "$LOG_FILE" "$_dashboard_url"
 fi
 


### PR DESCRIPTION
…nal services disabled

The brace group that pipes service rows into `dream_readiness_summary` ends with `[[ "${ENABLE_COMFYUI:-}" == "true" ]] && printf ...`. With `set -euo pipefail`, when ENABLE_COMFYUI is not "true", the conditional returns 1, the brace group exits 1, pipefail propagates it, and the ERR trap installed in `install-core.sh` aborts the install — even though every service started healthy.

Add a trailing `:` so the group always exits 0, with a short comment explaining the set -e + pipefail interaction so a future contributor doesn't reintroduce the bug.

Hit during `/dream-fleet-test` runs/2026-05-18T16-36-19Z on Tower2 (Linux + dual NVIDIA Blackwell, ComfyUI compose disabled).