### PR TITLE
Stabilize host agent and update version paths

### DIFF
--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -639,7 +639,7 @@
     },
     "DREAM_AGENT_BIND": {
       "type": "string",
-      "description": "Bind address for the Dream Host Agent HTTP server. Defaults to 127.0.0.1 on macOS/Windows, Docker bridge gateway IP on Linux (falls back to 127.0.0.1).",
+      "description": "Bind address for the Dream Host Agent HTTP server. Defaults to 127.0.0.1 on macOS/Windows, dream-network gateway IP on Linux, then Docker bridge gateway, then 127.0.0.1.",
       "default": ""
     },
     "DREAM_AGENT_HOST": {

--- a/dream-server/SECURITY.md
+++ b/dream-server/SECURITY.md
@@ -84,7 +84,7 @@ The host agent (`bin/dream-host-agent.py`) has its own bind address, separate fr
 | Platform | Default | Behavior |
 |----------|---------|----------|
 | macOS / Windows | `127.0.0.1` | Docker Desktop routes container traffic via loopback — loopback is sufficient |
-| Linux | auto-detected | Detects the Docker bridge gateway IP (e.g. `172.17.0.1`) so containers can reach the agent; LAN devices cannot. Falls back to `127.0.0.1` if detection fails (since #988 — the prior `0.0.0.0` fallback exposed the agent to LAN unnecessarily). |
+| Linux | auto-detected | Detects the `dream-network` gateway IP (e.g. `172.18.0.1`) so containers can reach the agent; LAN devices cannot. Falls back to the default Docker bridge gateway (e.g. `172.17.0.1`) for partial/older installs, then `127.0.0.1` if detection fails. |
 
 To override the default, set `DREAM_AGENT_BIND` in `.env`:
 
@@ -92,7 +92,7 @@ To override the default, set `DREAM_AGENT_BIND` in `.env`:
 # Restrict to loopback only (e.g. no-Docker Linux or extra hardening)
 DREAM_AGENT_BIND=127.0.0.1
 
-# Bind to Docker bridge only (explicit Linux default)
+# Bind to a Docker network gateway only (explicit Linux default)
 DREAM_AGENT_BIND=172.17.0.1
 
 # Bind to all interfaces — exposes the host agent API on LAN (not recommended)

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -126,17 +126,17 @@ def load_core_service_ids(config_path: Path) -> set:
         return set(_FALLBACK_CORE_IDS)
 
 
-def _detect_docker_bridge_gateway() -> str:
-    """Detect the Docker bridge gateway IP for secure binding on Linux.
+def _detect_docker_network_gateway(network_name: str) -> str:
+    """Detect a Docker network gateway IP for scoped host-agent binding.
 
-    Returns the gateway IP (e.g. '172.17.0.1') or empty string on failure.
-    Containers reach this IP via the host-gateway extra_hosts mapping,
-    while LAN devices cannot (it's on a virtual bridge interface).
+    Returns the gateway IP (for example ``172.18.0.1``) or empty string on
+    failure. Containers on that Docker network can reach this address, while
+    LAN devices cannot route to it directly.
     """
     import ipaddress as _ipaddress
     try:
         result = subprocess.run(
-            ["docker", "network", "inspect", "bridge",
+            ["docker", "network", "inspect", network_name,
              "--format", "{{(index .IPAM.Config 0).Gateway}}"],
             capture_output=True, text=True, timeout=10,
         )
@@ -144,19 +144,48 @@ def _detect_docker_bridge_gateway() -> str:
             addr = result.stdout.strip()
             if addr:
                 _ipaddress.ip_address(addr)  # validate — Docker can return "<no value>"
-                logger.info("Detected Docker bridge gateway: %s", addr)
+                logger.info("Detected Docker network gateway for %s: %s", network_name, addr)
                 return addr
         else:
             logger.warning(
-                "Docker bridge gateway detection failed (exit %d): %s",
+                "Docker network gateway detection failed for %s (exit %d): %s",
+                network_name,
                 result.returncode,
                 result.stderr.strip() or "<no stderr>",
             )
     except ValueError:
-        logger.debug("Docker bridge returned non-IP value, ignoring")
+        logger.debug("Docker network %s returned non-IP gateway value, ignoring", network_name)
     except (subprocess.SubprocessError, OSError) as exc:
-        logger.warning("Docker bridge detection failed: %s", exc)
+        logger.warning("Docker network gateway detection failed for %s: %s", network_name, exc)
     return ""
+
+
+def _detect_docker_bridge_gateway() -> str:
+    """Detect Docker's default bridge gateway as a compatibility fallback."""
+    return _detect_docker_network_gateway("bridge")
+
+
+def _resolve_agent_bind_addr(env: dict, system_name: str | None = None) -> str:
+    """Resolve the host-agent bind address without exposing LAN by default."""
+    explicit = env.get("DREAM_AGENT_BIND", "").strip()
+    if explicit:
+        return explicit
+
+    system_name = system_name or platform.system()
+    if system_name in ("Darwin", "Windows"):
+        return "127.0.0.1"
+
+    if system_name == "Linux":
+        # Prefer Dream's actual compose network. The bridge fallback keeps
+        # older/partial installs reachable without binding the Docker
+        # management API to every LAN interface.
+        return (
+            _detect_docker_network_gateway("dream-network")
+            or _detect_docker_bridge_gateway()
+            or "127.0.0.1"
+        )
+
+    return "127.0.0.1"
 
 
 def invalidate_compose_cache() -> None:
@@ -3713,26 +3742,12 @@ def main():
         pid_path.write_text(str(os.getpid()), encoding="utf-8")
         atexit.register(lambda: pid_path.unlink(missing_ok=True))
 
-    # Determine bind address: env var override, or platform-aware default.
-    # macOS/Windows: 127.0.0.1 (Docker Desktop routes host.docker.internal to loopback)
-    # Linux: 0.0.0.0 — bind to all interfaces. Earlier versions bound to the
-    #   Docker bridge gateway (typically 172.17.0.1) to keep the agent off the
-    #   LAN, but that broke containers on custom networks like dream-network
-    #   (172.18.x.x) which can't route to 172.17.0.1 across Docker's default
-    #   bridge isolation. Reproduced on every fleet-test run as
-    #   `503 Host agent unreachable: <urlopen error timed out>` from
-    #   POST /api/models/{id}/download.
-    #   All endpoints already require Authorization: Bearer DREAM_AGENT_KEY,
-    #   which is the de-facto gate — the bind restriction was defense-in-depth,
-    #   not the primary control. With a 64-char hex key (256 bits of entropy),
-    #   brute-force is infeasible; LAN exposure is bounded by key custody.
-    #   Operators on hostile LANs can restrict via DREAM_AGENT_BIND=<ip> in .env.
-    bind_addr = env.get("DREAM_AGENT_BIND", "").strip()
-    if not bind_addr:
-        if platform.system() in ("Darwin", "Windows"):
-            bind_addr = "127.0.0.1"
-        else:
-            bind_addr = "0.0.0.0"
+    # Determine bind address: explicit env override, or a platform-aware safe
+    # default. Linux prefers the dream-network gateway so dashboard-api
+    # containers can reach the agent without exposing it to the LAN. The bridge
+    # gateway fallback keeps partial/older installs reachable until phase 11 can
+    # restart the service after dream-network exists.
+    bind_addr = _resolve_agent_bind_addr(env)
 
     server = ThreadedHTTPServer((bind_addr, port), AgentHandler)
     signal.signal(signal.SIGTERM, lambda *_: server.shutdown())

--- a/dream-server/docs/HOST-AGENT-API.md
+++ b/dream-server/docs/HOST-AGENT-API.md
@@ -14,7 +14,7 @@ The Dashboard API runs inside a Docker container and cannot directly run `docker
 | macOS | Started by the installer (`installers/macos/install-macos.sh`) |
 | Windows | Started by the installer (`installers/windows/phases/07-devtools.ps1`, managed via `dream.ps1`) |
 
-The agent is started during installation. macOS and Windows bind to `127.0.0.1` by default. Linux auto-detects the Docker bridge gateway so containers can reach the agent, and falls back to `127.0.0.1` if bridge detection fails. It does not bind to `0.0.0.0` unless `DREAM_AGENT_BIND` is explicitly set.
+The agent is started during installation. macOS and Windows bind to `127.0.0.1` by default. Linux auto-detects the `dream-network` gateway so containers can reach the agent, falls back to the default Docker bridge gateway for partial/older installs, and then falls back to `127.0.0.1`. It does not bind to `0.0.0.0` unless `DREAM_AGENT_BIND` is explicitly set.
 
 ## Configuration
 
@@ -23,7 +23,7 @@ The agent reads its configuration from the `.env` file in the DreamServer instal
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `DREAM_AGENT_KEY` | *(none)* | API key for authenticating requests. Falls back to `DASHBOARD_API_KEY` if unset. |
-| `DREAM_AGENT_BIND` | Platform-specific | Bind address. macOS/Windows default to `127.0.0.1`; Linux uses the Docker bridge gateway when detected, otherwise `127.0.0.1`. |
+| `DREAM_AGENT_BIND` | Platform-specific | Bind address. macOS/Windows default to `127.0.0.1`; Linux uses the `dream-network` gateway when detected, then the Docker bridge gateway, otherwise `127.0.0.1`. |
 | `DREAM_AGENT_PORT` | `7710` | Port the agent listens on. |
 | `GPU_BACKEND` | `nvidia` | Passed to `resolve-compose-stack.sh` when building compose flags. |
 | `TIER` | `1` | Hardware tier, passed to compose stack resolution. |
@@ -140,7 +140,7 @@ If the container does not exist yet (e.g. image is still pulling), a 200 respons
 The host agent is a **critical security boundary** because it can start and stop Docker containers on the host.
 
 Protections in place:
-- **Scoped network binding**: macOS/Windows bind to `127.0.0.1`; Linux binds to the Docker bridge gateway when detected so containers can reach the agent. It does not bind to `0.0.0.0` unless explicitly configured.
+- **Scoped network binding**: macOS/Windows bind to `127.0.0.1`; Linux binds to the `dream-network` gateway when detected so containers can reach the agent, with Docker bridge as a compatibility fallback. It does not bind to `0.0.0.0` unless explicitly configured.
 - **API key auth**: All mutation endpoints require Bearer token authentication
 - **Core service protection**: Core services (loaded from `config/core-service-ids.json` with hardcoded fallback) cannot be managed
 - **Service ID validation**: Regex-validated, must map to an actual extension directory with a manifest

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -317,13 +317,12 @@ def _detect_container_default_gateway(route_path: str = "/proc/net/route") -> st
     a little-endian-hex gateway in the 3rd field.
 
     Why this matters: dashboard-api runs on `dream-network` (a custom bridge,
-    e.g. 172.18.0.0/16). The dream-host-agent on the host binds 0.0.0.0 and
-    thus listens on every host-side bridge interface — including
-    dream-network's gateway (172.18.0.1). Targeting that gateway directly is
-    routable from inside the container without depending on
-    `host.docker.internal:host-gateway`, which Docker resolves to the *default*
-    bridge gateway (172.17.0.1) — unreachable from custom networks under
-    Docker's default DOCKER-ISOLATION-STAGE-2 iptables rules.
+    e.g. 172.18.0.0/16). On Linux, the dream-host-agent binds to that network's
+    host-side gateway when it can, so targeting this container's default gateway
+    is routable without depending on `host.docker.internal:host-gateway`, which
+    Docker often resolves to the default bridge gateway (172.17.0.1). That
+    default bridge address is unreachable from custom networks under Docker's
+    default DOCKER-ISOLATION-STAGE-2 iptables rules.
     """
     try:
         with open(route_path, "r", encoding="utf-8") as f:

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -70,20 +70,23 @@ from settings import (
 # TTL Cache — avoids redundant subprocess/IO calls every poll cycle
 # ================================================================
 
+_CACHE_MISS = object()
+
+
 class TTLCache:
     """Simple in-memory cache with per-key TTL (seconds)."""
 
     def __init__(self):
         self._store: dict[str, tuple[float, object]] = {}
 
-    def get(self, key: str) -> object | None:
+    def get(self, key: str, default: object | None = None) -> object | None:
         entry = self._store.get(key)
         if entry is None:
-            return None
+            return default
         expires_at, value = entry
         if time.monotonic() > expires_at:
             del self._store[key]
-            return None
+            return default
         return value
 
     def set(self, key: str, value: object, ttl: float):
@@ -127,8 +130,12 @@ def _read_installed_version() -> str:
         try:
             raw = version_file.read_text().strip()
             if raw:
+                if raw.startswith("{"):
+                    data = json.loads(raw)
+                    if isinstance(data, dict) and data.get("version"):
+                        return str(data["version"])
                 return raw
-        except OSError:
+        except (OSError, json.JSONDecodeError, ValueError):
             pass
 
     manifest_file = install_root / "manifest.json"
@@ -569,7 +576,7 @@ async def _lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Dream Server Dashboard API",
-    version="2.0.0",
+    version="2.4.0",
     description="System status API for Dream Server Dashboard",
     lifespan=_lifespan,
 )
@@ -730,8 +737,8 @@ async def preflight_disk():
 @app.get("/gpu", response_model=Optional[GPUInfo])
 async def gpu(api_key: str = Depends(verify_api_key)):
     """Get GPU metrics (cached for a few seconds to avoid nvidia-smi spam)."""
-    cached = _cache.get("gpu_info")
-    if cached is not None:
+    cached = _cache.get("gpu_info", _CACHE_MISS)
+    if cached is not _CACHE_MISS:
         if not cached:
             raise HTTPException(status_code=503, detail="GPU not available")
         return cached

--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -114,6 +114,20 @@ def _find_usable_bash() -> Optional[str]:
     return None
 
 
+def _to_bash_path(path: Path) -> str:
+    """Convert a Windows path into a form Git Bash can execute."""
+    path_str = str(path)
+    if os.name != "nt":
+        return path_str
+
+    match = re.match(r"^([A-Za-z]):[\\/](.*)$", path_str)
+    if match:
+        drive = match.group(1).lower()
+        rest = match.group(2).replace("\\", "/")
+        return f"/{drive}/{rest}"
+    return path_str.replace("\\", "/")
+
+
 def _update_command(script_path: Path, *args: str) -> list[str]:
     """Build a platform-aware command for dream-update.sh."""
     if os.name != "nt":
@@ -121,7 +135,7 @@ def _update_command(script_path: Path, *args: str) -> list[str]:
 
     bash = _find_usable_bash()
     if bash:
-        return [bash, str(script_path), *args]
+        return [bash, _to_bash_path(script_path), *args]
 
     raise HTTPException(
         status_code=501,

--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -3,7 +3,10 @@
 import asyncio
 import json
 import logging
+import os
 import re
+import shutil
+import subprocess
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,6 +29,12 @@ _GITHUB_HEADERS = {"Accept": "application/vnd.github.v3+json"}
 _VERSION_CACHE_TTL = 300.0
 _version_cache: dict[str, object] = {"expires_at": 0.0, "payload": None}
 _version_refresh_task: Optional[asyncio.Task] = None
+_usable_bash: Optional[str] | bool = None
+
+
+def _read_utf8(path: Path) -> str:
+    """Read repository text files consistently across Windows and Linux."""
+    return path.read_text(encoding="utf-8")
 
 
 def _read_current_version() -> str:
@@ -33,7 +42,7 @@ def _read_current_version() -> str:
     env_file = Path(INSTALL_DIR) / ".env"
     if env_file.exists():
         try:
-            for line in env_file.read_text().splitlines():
+            for line in _read_utf8(env_file).splitlines():
                 if line.startswith("DREAM_VERSION="):
                     return line.split("=", 1)[1].strip().strip("\"'")
         except OSError:
@@ -41,15 +50,19 @@ def _read_current_version() -> str:
     version_file = Path(INSTALL_DIR) / ".version"
     if version_file.exists():
         try:
-            raw = version_file.read_text().strip()
+            raw = _read_utf8(version_file).strip()
             if raw:
+                if raw.startswith("{"):
+                    data = json.loads(raw)
+                    if isinstance(data, dict) and data.get("version"):
+                        return str(data["version"])
                 return raw
-        except OSError:
+        except (OSError, json.JSONDecodeError, ValueError):
             pass
     manifest_file = Path(INSTALL_DIR) / "manifest.json"
     if manifest_file.exists():
         try:
-            data = json.loads(manifest_file.read_text())
+            data = json.loads(_read_utf8(manifest_file))
             version = (
                 data.get("release", {}).get("version")
                 or data.get("dream_version")
@@ -62,12 +75,62 @@ def _read_current_version() -> str:
     main_file = Path(__file__).resolve().parents[1] / "main.py"
     if main_file.exists():
         try:
-            match = re.search(r'version\s*=\s*"([^"]+)"', main_file.read_text())
+            match = re.search(r'version\s*=\s*"([^"]+)"', _read_utf8(main_file))
             if match:
                 return match.group(1)
         except OSError:
             pass
     return "0.0.0"
+
+
+def _find_usable_bash() -> Optional[str]:
+    """Return a Bash executable that can actually run scripts on this host."""
+    global _usable_bash
+    if isinstance(_usable_bash, str):
+        return _usable_bash
+    if _usable_bash is False:
+        return None
+
+    bash = shutil.which("bash")
+    if not bash:
+        _usable_bash = False
+        return None
+
+    try:
+        result = subprocess.run(
+            [bash, "-lc", "printf ok"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _usable_bash = False
+        return None
+
+    if result.returncode == 0 and result.stdout == "ok":
+        _usable_bash = bash
+        return bash
+    _usable_bash = False
+    return None
+
+
+def _update_command(script_path: Path, *args: str) -> list[str]:
+    """Build a platform-aware command for dream-update.sh."""
+    if os.name != "nt":
+        return [str(script_path), *args]
+
+    bash = _find_usable_bash()
+    if bash:
+        return [bash, str(script_path), *args]
+
+    raise HTTPException(
+        status_code=501,
+        detail=(
+            "Update actions require a usable Bash runtime on Windows. "
+            "Run this action inside the Dream Server Linux container/WSL path "
+            "or install Git Bash and retry."
+        ),
+    )
 
 
 def _get_cached_release_payload(allow_stale: bool = False) -> Optional[dict]:
@@ -208,13 +271,13 @@ async def get_update_dry_run():
     version_file = install_path / ".version"
 
     if env_file.exists():
-        for line in env_file.read_text().splitlines():
+        for line in _read_utf8(env_file).splitlines():
             if line.startswith("DREAM_VERSION="):
                 current = line.split("=", 1)[1].strip()
                 break
     if current == "0.0.0" and version_file.exists():
         try:
-            raw = version_file.read_text().strip()
+            raw = _read_utf8(version_file).strip()
             parsed = json.loads(raw) if raw.startswith("{") else None
             current = (parsed or {}).get("version", raw) or raw or "0.0.0"
         except (json.JSONDecodeError, OSError):
@@ -246,7 +309,7 @@ async def get_update_dry_run():
     images: list[str] = []
     for compose_file in sorted(install_path.glob("docker-compose*.yml")):
         try:
-            for line in compose_file.read_text().splitlines():
+            for line in _read_utf8(compose_file).splitlines():
                 stripped = line.strip()
                 if stripped.startswith("image:"):
                     tag = stripped.split(":", 1)[1].strip()
@@ -258,7 +321,7 @@ async def get_update_dry_run():
     # ── .env keys relevant to the update path ────────────────────────────────
     env_snapshot: dict[str, str] = {}
     if env_file.exists():
-        for line in env_file.read_text().splitlines():
+        for line in _read_utf8(env_file).splitlines():
             line = line.strip()
             if not line or line.startswith("#") or "=" not in line:
                 continue
@@ -297,7 +360,7 @@ async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks
     if action.action == "check":
         try:
             proc = await asyncio.create_subprocess_exec(
-                str(script_path), "check",
+                *_update_command(script_path, "check"),
                 stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
@@ -310,7 +373,7 @@ async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks
     elif action.action == "backup":
         try:
             proc = await asyncio.create_subprocess_exec(
-                str(script_path), "backup", f"dashboard-{datetime.now().strftime('%Y%m%d-%H%M%S')}",
+                *_update_command(script_path, "backup", f"dashboard-{datetime.now().strftime('%Y%m%d-%H%M%S')}"),
                 stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
             )
             stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
@@ -321,10 +384,12 @@ async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks
             logger.exception("Backup failed")
             raise HTTPException(status_code=500, detail="Backup failed")
     elif action.action == "update":
+        command = _update_command(script_path, "update")
+
         async def run_update():
             try:
                 proc = await asyncio.create_subprocess_exec(
-                    str(script_path), "update",
+                    *command,
                     stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
                 )
                 await proc.communicate()

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -21,11 +21,44 @@ _spec.loader.exec_module(_mod)
 _parse_mem_value = _mod._parse_mem_value
 _iso_now = _mod._iso_now
 _to_bash_path = _mod._to_bash_path
+_resolve_agent_bind_addr = _mod._resolve_agent_bind_addr
 resolve_compose_flags = _mod.resolve_compose_flags
 validate_core_recreate_ids = _mod.validate_core_recreate_ids
 invalidate_compose_cache = _mod.invalidate_compose_cache
 _post_install_core_recreate = _mod._post_install_core_recreate
 _split_nmcli_terse = _mod._split_nmcli_terse
+
+
+class TestResolveAgentBindAddr:
+
+    def test_explicit_bind_wins(self):
+        assert _resolve_agent_bind_addr({"DREAM_AGENT_BIND": "0.0.0.0"}, "Linux") == "0.0.0.0"
+        assert _resolve_agent_bind_addr({"DREAM_AGENT_BIND": "192.168.1.10"}, "Linux") == "192.168.1.10"
+
+    def test_desktop_platforms_default_loopback(self, monkeypatch):
+        monkeypatch.setattr(_mod, "_detect_docker_network_gateway", lambda network: "172.18.0.1")
+        monkeypatch.setattr(_mod, "_detect_docker_bridge_gateway", lambda: "172.17.0.1")
+
+        assert _resolve_agent_bind_addr({}, "Windows") == "127.0.0.1"
+        assert _resolve_agent_bind_addr({}, "Darwin") == "127.0.0.1"
+
+    def test_linux_prefers_dream_network_gateway(self, monkeypatch):
+        monkeypatch.setattr(_mod, "_detect_docker_network_gateway", lambda network: "172.18.0.1")
+        monkeypatch.setattr(_mod, "_detect_docker_bridge_gateway", lambda: "172.17.0.1")
+
+        assert _resolve_agent_bind_addr({}, "Linux") == "172.18.0.1"
+
+    def test_linux_falls_back_to_bridge_gateway(self, monkeypatch):
+        monkeypatch.setattr(_mod, "_detect_docker_network_gateway", lambda network: "")
+        monkeypatch.setattr(_mod, "_detect_docker_bridge_gateway", lambda: "172.17.0.1")
+
+        assert _resolve_agent_bind_addr({}, "Linux") == "172.17.0.1"
+
+    def test_linux_falls_back_to_loopback(self, monkeypatch):
+        monkeypatch.setattr(_mod, "_detect_docker_network_gateway", lambda network: "")
+        monkeypatch.setattr(_mod, "_detect_docker_bridge_gateway", lambda: "")
+
+        assert _resolve_agent_bind_addr({}, "Linux") == "127.0.0.1"
 
 
 # --- _split_nmcli_terse — parser for nmcli -t (terse) output ---

--- a/dream-server/extensions/services/dashboard-api/tests/test_main.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_main.py
@@ -1,14 +1,30 @@
 """Tests for main.py — core endpoints and helper functions."""
 
+import json
 import time
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from main import get_allowed_origins, _build_api_status, _fallback_services, _serialize_services, TTLCache
+from main import (
+    TTLCache,
+    _build_api_status,
+    _fallback_services,
+    _read_installed_version,
+    _serialize_services,
+    get_allowed_origins,
+)
 
 
 # --- get_allowed_origins ---
+
+
+def test_read_installed_version_parses_json_version_file(tmp_path, monkeypatch):
+    version_file = tmp_path / ".version"
+    version_file.write_text(json.dumps({"version": "3.1.4"}), encoding="utf-8")
+    monkeypatch.setattr("main._resolve_install_root", lambda: tmp_path)
+
+    assert _read_installed_version() == "3.1.4"
 
 
 class TestGetAllowedOrigins:

--- a/dream-server/extensions/services/dashboard-api/tests/test_updates.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_updates.py
@@ -2,6 +2,7 @@
 
 import json
 import sys
+from pathlib import Path
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -142,6 +143,22 @@ def test_update_command_windows_requires_usable_bash(monkeypatch, tmp_path):
 
     assert exc.value.status_code == 501
     assert "usable Bash runtime" in exc.value.detail
+
+
+def test_update_command_windows_uses_bash_path(monkeypatch):
+    """Windows update actions pass Git Bash a POSIX-style script path."""
+    import routers.updates as updates_mod
+
+    monkeypatch.setattr(updates_mod.os, "name", "nt")
+    monkeypatch.setattr(updates_mod, "_find_usable_bash", lambda: "C:\\Program Files\\Git\\bin\\bash.exe")
+
+    command = updates_mod._update_command(Path("C:/DreamServer/dream-server/scripts/dream-update.sh"), "check")
+
+    assert command == [
+        "C:\\Program Files\\Git\\bin\\bash.exe",
+        "/c/DreamServer/dream-server/scripts/dream-update.sh",
+        "check",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/dream-server/extensions/services/dashboard-api/tests/test_updates.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_updates.py
@@ -1,9 +1,12 @@
 """Tests for updates router endpoints."""
 
 import json
+import sys
 from unittest.mock import patch, MagicMock, AsyncMock
 
+import pytest
 import httpx
+from fastapi import HTTPException
 
 
 def test_get_version_requires_auth(test_client):
@@ -124,6 +127,23 @@ def test_trigger_update_no_script(test_client):
     assert resp.status_code == 501
 
 
+def test_update_command_windows_requires_usable_bash(monkeypatch, tmp_path):
+    """Windows update actions fail clearly when no usable Bash runtime exists."""
+    import routers.updates as updates_mod
+
+    script = tmp_path / "dream-update.sh"
+    script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
+
+    monkeypatch.setattr(updates_mod.os, "name", "nt")
+    monkeypatch.setattr(updates_mod, "_find_usable_bash", lambda: None)
+
+    with pytest.raises(HTTPException) as exc:
+        updates_mod._update_command(script, "check")
+
+    assert exc.value.status_code == 501
+    assert "usable Bash runtime" in exc.value.detail
+
+
 # ---------------------------------------------------------------------------
 # /api/releases/manifest — mocked httpx
 # ---------------------------------------------------------------------------
@@ -197,6 +217,30 @@ def test_releases_manifest_github_error_fallback(test_client, tmp_path, monkeypa
     assert len(data["releases"]) == 1
     assert data["releases"][0]["version"] == "1.2.3"
     assert "error" in data
+
+
+def test_releases_manifest_github_error_fallback_reads_json_version(test_client, tmp_path, monkeypatch):
+    """GET /api/releases/manifest reads JSON-formatted .version files."""
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "dream-server"
+    install_dir.mkdir()
+    (install_dir / ".version").write_text(json.dumps({"version": "3.1.4"}))
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    async def mock_get(url, **kwargs):
+        raise httpx.HTTPError("connection failed")
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/releases/manifest", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["releases"][0]["version"] == "3.1.4"
 
 
 # ---------------------------------------------------------------------------
@@ -345,9 +389,14 @@ def test_trigger_update_invalid_action(test_client, tmp_path, monkeypatch):
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir()
     script = scripts_dir / "dream-update.sh"
-    script.write_text("#!/bin/bash\nexit 0")
+    script.write_text("import sys\nsys.exit(0)\n")
     script.chmod(0o755)
     monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+    monkeypatch.setattr(
+        updates_mod,
+        "_update_command",
+        lambda script_path, *args: [sys.executable, str(script_path), *args],
+    )
 
     resp = test_client.post(
         "/api/update",
@@ -372,9 +421,14 @@ def test_trigger_update_action_update(test_client, tmp_path, monkeypatch):
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir()
     script = scripts_dir / "dream-update.sh"
-    script.write_text("#!/bin/bash\nexit 0")
+    script.write_text("import sys\nsys.exit(0)\n")
     script.chmod(0o755)
     monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+    monkeypatch.setattr(
+        updates_mod,
+        "_update_command",
+        lambda script_path, *args: [sys.executable, str(script_path), *args],
+    )
 
     resp = test_client.post(
         "/api/update",
@@ -401,9 +455,14 @@ def test_trigger_update_action_check(test_client, tmp_path, monkeypatch):
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir()
     script = scripts_dir / "dream-update.sh"
-    script.write_text("#!/bin/bash\necho 'no updates'\nexit 0")
+    script.write_text("import sys\nprint('no updates')\nsys.exit(0)\n")
     script.chmod(0o755)
     monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+    monkeypatch.setattr(
+        updates_mod,
+        "_update_command",
+        lambda script_path, *args: [sys.executable, str(script_path), *args],
+    )
 
     resp = test_client.post(
         "/api/update",
@@ -431,9 +490,14 @@ def test_trigger_update_action_backup(test_client, tmp_path, monkeypatch):
     scripts_dir = tmp_path / "scripts"
     scripts_dir.mkdir()
     script = scripts_dir / "dream-update.sh"
-    script.write_text("#!/bin/bash\necho 'backup complete'\nexit 0")
+    script.write_text("import sys\nprint('backup complete')\nsys.exit(0)\n")
     script.chmod(0o755)
     monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+    monkeypatch.setattr(
+        updates_mod,
+        "_update_command",
+        lambda script_path, *args: [sys.executable, str(script_path), *args],
+    )
 
     resp = test_client.post(
         "/api/update",

--- a/dream-server/extensions/services/dashboard-api/tests/test_updates.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_updates.py
@@ -2,7 +2,7 @@
 
 import json
 import sys
-from pathlib import Path
+from pathlib import PureWindowsPath
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
@@ -152,7 +152,10 @@ def test_update_command_windows_uses_bash_path(monkeypatch):
     monkeypatch.setattr(updates_mod.os, "name", "nt")
     monkeypatch.setattr(updates_mod, "_find_usable_bash", lambda: "C:\\Program Files\\Git\\bin\\bash.exe")
 
-    command = updates_mod._update_command(Path("C:/DreamServer/dream-server/scripts/dream-update.sh"), "check")
+    command = updates_mod._update_command(
+        PureWindowsPath("C:/DreamServer/dream-server/scripts/dream-update.sh"),
+        "check",
+    )
 
     assert command == [
         "C:\\Program Files\\Git\\bin\\bash.exe",

--- a/dream-server/installers/phases/01-preflight.sh
+++ b/dream-server/installers/phases/01-preflight.sh
@@ -181,10 +181,10 @@ check_install_dir_filesystem
 check_docker_desktop_sharing
 
 # Firewall check: warn if UFW or firewalld is active. The dashboard host agent
-# binds to the Docker bridge gateway (default 172.17.0.1:7710) and compose
-# containers reach it via the host INPUT chain. Default-DROP firewalls block
-# that traffic and the dashboard reports "Host agent is offline". Warn-only —
-# never abort install.
+# binds to the dream-network gateway by default on Linux, and compose containers
+# reach it via the host INPUT chain. Default-DROP firewalls block that traffic
+# and the dashboard reports "Host agent is offline". Warn-only; never abort
+# install.
 if command -v ufw >/dev/null 2>&1 && systemctl is-active --quiet ufw 2>/dev/null; then
     ai_warn "UFW is active. The dashboard host agent must be reachable from compose subnets."
     ai_warn "The installer will auto-add a scoped rule for the actual dream-network subnet after compose starts."

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -631,6 +631,21 @@ except Exception:
     # Step 3: catch any stragglers from the second pass
     $DOCKER_CMD start $($DOCKER_CMD ps -a --filter status=created -q) 2>/dev/null || true
 
+    # If DREAM_AGENT_BIND is unset, the Linux host-agent binds to the Dream
+    # Docker network gateway once that network exists. Phase 07 may have
+    # started it before compose created dream-network, so restart it here to
+    # let the safer scoped bind take effect.
+    if [[ -z "${DREAM_AGENT_BIND:-}" ]] \
+      && [[ "$(uname -s 2>/dev/null || echo unknown)" == "Linux" ]] \
+      && command -v systemctl >/dev/null 2>&1 \
+      && sudo -n systemctl is-enabled dream-host-agent.service >/dev/null 2>&1; then
+        if sudo -n systemctl restart dream-host-agent.service 2>&1 | tee -a "$LOG_FILE" >/dev/null; then
+            ai_ok "Restarted dream-host-agent after dream-network creation"
+        else
+            ai_warn "dream-host-agent restart after network creation failed (non-fatal)"
+        fi
+    fi
+
     # dashboard-api reaches the host agent from the compose network gateway.
     # With default-DROP UFW/firewalld, the host INPUT chain can block that
     # traffic. Add a scoped rule only after compose has created dream-network,

--- a/dream-server/scripts/check-version-consistency.py
+++ b/dream-server/scripts/check-version-consistency.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Fail the release gate when Dream Server version authorities drift."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SEMVER = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def first_match(path: Path, pattern: str, label: str) -> str:
+    match = re.search(pattern, read_text(path), re.MULTILINE | re.DOTALL)
+    if not match:
+        raise ValueError(f"{label}: could not find version in {path.relative_to(ROOT)}")
+    return match.group(1)
+
+
+def latest_changelog_release() -> tuple[str, str]:
+    changelog = read_text(ROOT / "CHANGELOG.md")
+    for match in re.finditer(r"^## \[([^\]]+)\](?: - ([0-9]{4}-[0-9]{2}-[0-9]{2}))?", changelog, re.MULTILINE):
+        version, date = match.group(1), match.group(2) or ""
+        if version.lower() != "unreleased":
+            return version, date
+    raise ValueError("CHANGELOG.md: could not find a released version heading")
+
+
+def optional_version_file() -> str | None:
+    path = ROOT / ".version"
+    if not path.exists():
+        return None
+    raw = read_text(path).strip()
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return raw
+    if isinstance(data, dict) and data.get("version"):
+        return str(data["version"])
+    return raw
+
+
+def add_regex_check(
+    checks: list[tuple[str, str]],
+    errors: list[str],
+    label: str,
+    path: Path,
+    pattern: str,
+) -> None:
+    try:
+        checks.append((label, first_match(path, pattern, label)))
+    except ValueError as exc:
+        errors.append(str(exc))
+
+
+def main() -> int:
+    errors: list[str] = []
+    manifest_path = ROOT / "manifest.json"
+
+    try:
+        manifest = json.loads(read_text(manifest_path))
+        expected = str(manifest.get("dream_version", "")).strip()
+        release = manifest.get("release") if isinstance(manifest.get("release"), dict) else {}
+        release_version = str(release.get("version", "")).strip()
+        release_date = str(release.get("date", "")).strip()
+    except Exception as exc:  # noqa: BLE001 - gate should report cleanly
+        print(f"[FAIL] version consistency: cannot read manifest.json: {exc}")
+        return 1
+
+    if not expected:
+        errors.append("manifest.json dream_version is empty")
+    elif not SEMVER.match(expected):
+        errors.append(f"manifest.json dream_version must be x.y.z, got {expected!r}")
+
+    checks = [("manifest.json release.version", release_version)]
+    add_regex_check(
+        checks,
+        errors,
+        "extensions/services/dashboard-api/main.py FastAPI version",
+        ROOT / "extensions/services/dashboard-api/main.py",
+        r"app\s*=\s*FastAPI\([^)]*?version\s*=\s*[\"']([^\"']+)[\"']",
+    )
+    add_regex_check(
+        checks,
+        errors,
+        "installers/lib/constants.sh VERSION",
+        ROOT / "installers/lib/constants.sh",
+        r'^VERSION="([^"]+)"',
+    )
+    add_regex_check(
+        checks,
+        errors,
+        "installers/macos/lib/constants.sh DS_VERSION",
+        ROOT / "installers/macos/lib/constants.sh",
+        r'^DS_VERSION="([^"]+)"',
+    )
+
+    version_file = optional_version_file()
+    if version_file is not None:
+        checks.append((".version version", version_file))
+
+    try:
+        changelog_version, changelog_date = latest_changelog_release()
+        checks.append(("CHANGELOG.md latest release", changelog_version))
+        if release_date and changelog_date and release_date != changelog_date:
+            errors.append(
+                f"manifest.json release.date {release_date!r} != CHANGELOG.md latest release date {changelog_date!r}"
+            )
+    except ValueError as exc:
+        errors.append(str(exc))
+
+    for label, value in checks:
+        if value != expected:
+            errors.append(f"{label} {value!r} != manifest.json dream_version {expected!r}")
+
+    if errors:
+        print("[FAIL] version consistency")
+        for error in errors:
+            print(f"  - {error}")
+        return 1
+
+    print(f"[PASS] version consistency ({expected})")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -4,6 +4,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+PYTHON_CMD="python3"
+if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then
+  . "$ROOT_DIR/lib/python-cmd.sh"
+  PYTHON_CMD="$(ds_detect_python_cmd)"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_CMD="python"
+fi
+
 echo "[gate] shell syntax"
 mapfile -t sh_files < <(git ls-files '*.sh')
 for f in "${sh_files[@]}"; do
@@ -12,6 +20,7 @@ done
 
 echo "[gate] compatibility + claims"
 bash scripts/check-compatibility.sh
+"$PYTHON_CMD" scripts/check-version-consistency.py
 bash scripts/check-release-claims.sh
 
 echo "[gate] contracts"
@@ -27,14 +36,6 @@ bash tests/smoke/macos-dispatch.sh
 
 echo "[gate] installer simulation"
 bash scripts/simulate-installers.sh
-PYTHON_CMD="python3"
-if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then
-  . "$ROOT_DIR/lib/python-cmd.sh"
-  PYTHON_CMD="$(ds_detect_python_cmd)"
-elif command -v python >/dev/null 2>&1; then
-  PYTHON_CMD="python"
-fi
-
 "$PYTHON_CMD" scripts/validate-sim-summary.py artifacts/installer-sim/summary.json
 
 echo "[PASS] release gate"


### PR DESCRIPTION
## Summary

Reliability/stability slice focused on making existing host-agent, update, and version behavior more predictable.

- Scope Linux host-agent binding to the dream-network gateway by default, with Docker bridge and loopback fallbacks instead of defaulting to 0.0.0.0.
- Restart the Linux host-agent after compose creates dream-network so the scoped bind can take effect during install.
- Make dashboard update actions platform-aware on Windows: use verified Bash when present, otherwise return an explicit 501.
- Parse JSON-formatted .version files consistently in dashboard version readers.
- Fix GPU TTL cache behavior for cached falsy GPU-unavailable results.
- Add a release gate check for manifest, changelog, installer constants, and dashboard API version metadata.
- Update host-agent docs/security/schema text to match the behavior.

## Verification

- python -m pytest tests\\test_main.py::test_read_installed_version_parses_json_version_file tests\\test_main.py::TestGpuEndpoint tests\\test_updates.py tests\\test_host_agent.py::TestResolveAgentBindAddr -q -> 30 passed
- python -m compileall -q . in dashboard-api
- python -m py_compile dream-server/bin/dream-host-agent.py dream-server/scripts/check-version-consistency.py
- python dream-server/scripts/check-version-consistency.py -> PASS
- git diff --check -> clean except Windows CRLF warnings

Bash syntax/release-gate could not run locally because this Windows environment's bash shim fails with /bin/bash missing.
