### PR TITLE
Add dashboard host agent diagnostics

### DIFF
--- a/dream-server/extensions/services/dashboard-api/README.md
+++ b/dream-server/extensions/services/dashboard-api/README.md
@@ -51,6 +51,7 @@ Environment variables (set in `.env`):
 | `GET` | `/bootstrap` | Yes | Model bootstrap/download status |
 | `GET` | `/status` | Yes | Full system status (all above combined) |
 | `GET` | `/api/status` | Yes | Dashboard-formatted status with inference metrics |
+| `GET` | `/api/host-agent/diagnostics` | Yes | Host-agent URL, gateway, auth, and live probe diagnostics |
 
 ### Preflight
 

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -35,7 +35,8 @@ from fastapi.middleware.cors import CORSMiddleware
 # --- Local modules ---
 from config import (
     SERVICES, DATA_DIR, INSTALL_DIR, SIDEBAR_ICONS, MANIFEST_ERRORS,
-    AGENT_URL, DREAM_AGENT_KEY,
+    AGENT_HOST, AGENT_PORT, AGENT_URL, DREAM_AGENT_KEY,
+    _detect_container_default_gateway, _running_inside_container,
 )
 from models import (
     GPUInfo, ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus,
@@ -103,6 +104,10 @@ _SETTINGS_SUMMARY_CACHE_TTL = 5.0
 _SETTINGS_CONFIG_CACHE_TTL = 15.0
 _SETTINGS_ENV_CACHE_TTL = 5.0
 _SERVICE_POLL_INTERVAL = 10.0  # background health check interval
+_host_agent_probe_state: dict[str, Optional[str]] = {
+    "last_success_at": None,
+    "last_error": None,
+}
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +158,54 @@ def _read_installed_version() -> str:
             pass
 
     return app.version
+
+
+def _probe_host_agent_health() -> dict[str, Any]:
+    """Probe the host-agent health endpoint and update diagnostic state."""
+    started = time.monotonic()
+    url = f"{AGENT_URL}/health"
+    headers = {}
+    if DREAM_AGENT_KEY:
+        headers["Authorization"] = f"Bearer {DREAM_AGENT_KEY}"
+    request = urllib.request.Request(url, headers=headers)
+
+    try:
+        with urllib.request.urlopen(request, timeout=3) as response:
+            status_code = int(getattr(response, "status", response.getcode()))
+            raw = response.read(2048).decode("utf-8", errors="replace")
+            try:
+                body: Any = json.loads(raw) if raw else None
+            except json.JSONDecodeError:
+                body = raw[:500]
+
+        latency_ms = round((time.monotonic() - started) * 1000)
+        success_at = datetime.now(timezone.utc).isoformat()
+        _host_agent_probe_state["last_success_at"] = success_at
+        _host_agent_probe_state["last_error"] = None
+        return {
+            "available": status_code == 200,
+            "status_code": status_code,
+            "latency_ms": latency_ms,
+            "response": body,
+            "error": None,
+        }
+    except urllib.error.HTTPError as exc:
+        latency_ms = round((time.monotonic() - started) * 1000)
+        status_code = exc.code
+        detail = f"HTTP {exc.code}: {exc.reason}"
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        latency_ms = round((time.monotonic() - started) * 1000)
+        status_code = None
+        detail = str(getattr(exc, "reason", exc))
+
+    _host_agent_probe_state["last_error"] = detail
+    return {
+        "available": False,
+        "status_code": status_code,
+        "latency_ms": latency_ms,
+        "response": None,
+        "error": detail,
+    }
 
 
 def _normalize_timestamp_precision(timestamp: str) -> str:
@@ -637,6 +690,31 @@ app.include_router(tailscale.router)
 async def health():
     """API health check."""
     return {"status": "ok", "timestamp": datetime.now(timezone.utc).isoformat()}
+
+
+@app.get("/api/host-agent/diagnostics", dependencies=[Depends(verify_api_key)])
+async def host_agent_diagnostics():
+    """Report how dashboard-api resolves and reaches the host agent."""
+    inside_container = await asyncio.to_thread(_running_inside_container)
+    default_gateway = await asyncio.to_thread(_detect_container_default_gateway)
+    probe = await asyncio.to_thread(_probe_host_agent_health)
+    probe["last_success_at"] = _host_agent_probe_state["last_success_at"]
+    probe["last_error"] = _host_agent_probe_state["last_error"]
+
+    return {
+        "configured": {
+            "url": AGENT_URL,
+            "host": AGENT_HOST,
+            "port": AGENT_PORT,
+            "dream_agent_key_configured": bool(DREAM_AGENT_KEY),
+            "dream_agent_host_explicit": bool(os.environ.get("DREAM_AGENT_HOST", "").strip()),
+        },
+        "container": {
+            "inside_container": inside_container,
+            "default_gateway": default_gateway or None,
+        },
+        "probe": probe,
+    }
 
 
 # --- Preflight ---

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -696,7 +696,9 @@ async def health():
 async def host_agent_diagnostics():
     """Report how dashboard-api resolves and reaches the host agent."""
     inside_container = await asyncio.to_thread(_running_inside_container)
-    default_gateway = await asyncio.to_thread(_detect_container_default_gateway)
+    default_gateway = None
+    if inside_container:
+        default_gateway = await asyncio.to_thread(_detect_container_default_gateway)
     probe = await asyncio.to_thread(_probe_host_agent_health)
     probe["last_success_at"] = _host_agent_probe_state["last_success_at"]
     probe["last_error"] = _host_agent_probe_state["last_error"]

--- a/dream-server/extensions/services/dashboard-api/tests/test_routers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_routers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import urllib.error
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -18,6 +19,100 @@ def test_health_returns_ok(test_client):
     data = resp.json()
     assert data["status"] == "ok"
     assert "timestamp" in data
+
+
+def test_host_agent_diagnostics_requires_auth(test_client):
+    """GET /api/host-agent/diagnostics without auth returns 401."""
+    resp = test_client.get("/api/host-agent/diagnostics")
+    assert resp.status_code == 401
+
+
+def test_host_agent_diagnostics_success(test_client, monkeypatch):
+    """Host-agent diagnostics reports URL, gateway, auth, and probe state."""
+    import main as main_mod
+
+    captured = {}
+
+    class Response:
+        status = 200
+
+        def getcode(self):
+            return self.status
+
+        def read(self, limit=-1):
+            return b'{"status":"ok","version":"1.0.0"}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(request, timeout):
+        captured["url"] = request.full_url
+        captured["authorization"] = request.get_header("Authorization")
+        captured["timeout"] = timeout
+        return Response()
+
+    monkeypatch.setattr(main_mod, "AGENT_URL", "http://172.18.0.1:7710")
+    monkeypatch.setattr(main_mod, "AGENT_HOST", "172.18.0.1")
+    monkeypatch.setattr(main_mod, "AGENT_PORT", 7710)
+    monkeypatch.setattr(main_mod, "DREAM_AGENT_KEY", "secret")
+    monkeypatch.setattr(main_mod, "_running_inside_container", lambda: True)
+    monkeypatch.setattr(main_mod, "_detect_container_default_gateway", lambda: "172.18.0.1")
+    monkeypatch.setattr(main_mod, "_host_agent_probe_state", {"last_success_at": None, "last_error": None})
+    monkeypatch.setattr(main_mod.urllib.request, "urlopen", fake_urlopen)
+
+    resp = test_client.get("/api/host-agent/diagnostics", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["configured"]["url"] == "http://172.18.0.1:7710"
+    assert data["configured"]["dream_agent_key_configured"] is True
+    assert data["container"]["inside_container"] is True
+    assert data["container"]["default_gateway"] == "172.18.0.1"
+    assert data["probe"]["available"] is True
+    assert data["probe"]["status_code"] == 200
+    assert data["probe"]["response"]["status"] == "ok"
+    assert data["probe"]["last_success_at"]
+    assert data["probe"]["last_error"] is None
+    assert captured == {
+        "url": "http://172.18.0.1:7710/health",
+        "authorization": "Bearer secret",
+        "timeout": 3,
+    }
+
+
+def test_host_agent_diagnostics_failure_keeps_last_success(test_client, monkeypatch):
+    """A failed probe reports the error without discarding last success."""
+    import main as main_mod
+
+    monkeypatch.setattr(main_mod, "AGENT_URL", "http://172.18.0.1:7710")
+    monkeypatch.setattr(main_mod, "AGENT_HOST", "172.18.0.1")
+    monkeypatch.setattr(main_mod, "AGENT_PORT", 7710)
+    monkeypatch.setattr(main_mod, "DREAM_AGENT_KEY", "")
+    monkeypatch.setattr(main_mod, "_running_inside_container", lambda: True)
+    monkeypatch.setattr(main_mod, "_detect_container_default_gateway", lambda: "172.18.0.1")
+    monkeypatch.setattr(
+        main_mod,
+        "_host_agent_probe_state",
+        {"last_success_at": "2026-01-01T00:00:00+00:00", "last_error": None},
+    )
+
+    def fake_urlopen(request, timeout):
+        raise urllib.error.URLError("timed out")
+
+    monkeypatch.setattr(main_mod.urllib.request, "urlopen", fake_urlopen)
+
+    resp = test_client.get("/api/host-agent/diagnostics", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    probe = resp.json()["probe"]
+    assert probe["available"] is False
+    assert probe["status_code"] is None
+    assert "timed out" in probe["error"]
+    assert probe["last_success_at"] == "2026-01-01T00:00:00+00:00"
+    assert "timed out" in probe["last_error"]
 
 
 # ---------------------------------------------------------------------------

--- a/dream-server/extensions/services/dashboard-api/tests/test_routers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_routers.py
@@ -83,6 +83,41 @@ def test_host_agent_diagnostics_success(test_client, monkeypatch):
     }
 
 
+def test_host_agent_diagnostics_omits_gateway_outside_container(test_client, monkeypatch):
+    """Host-side diagnostics should not report a host route as a container gateway."""
+    import main as main_mod
+
+    monkeypatch.setattr(main_mod, "AGENT_URL", "http://127.0.0.1:7710")
+    monkeypatch.setattr(main_mod, "AGENT_HOST", "127.0.0.1")
+    monkeypatch.setattr(main_mod, "AGENT_PORT", 7710)
+    monkeypatch.setattr(main_mod, "DREAM_AGENT_KEY", "")
+    monkeypatch.setattr(main_mod, "_running_inside_container", lambda: False)
+    monkeypatch.setattr(
+        main_mod,
+        "_detect_container_default_gateway",
+        lambda: (_ for _ in ()).throw(AssertionError("gateway detection should not run")),
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "_probe_host_agent_health",
+        lambda: {
+            "available": False,
+            "status_code": None,
+            "response": None,
+            "error": "not checked",
+            "checked_at": "2026-01-01T00:00:00+00:00",
+        },
+    )
+    monkeypatch.setattr(main_mod, "_host_agent_probe_state", {"last_success_at": None, "last_error": None})
+
+    resp = test_client.get("/api/host-agent/diagnostics", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["container"]["inside_container"] is False
+    assert data["container"]["default_gateway"] is None
+
+
 def test_host_agent_diagnostics_failure_keeps_last_success(test_client, monkeypatch):
     """A failed probe reports the error without discarding last success."""
     import main as main_mod


### PR DESCRIPTION
## Summary

Stacked on #1243. Adds an authenticated dashboard API diagnostic endpoint for the host agent so operators can see what the dashboard is trying to reach before digging through logs.

- Add GET /api/host-agent/diagnostics.
- Report configured host-agent URL, host, port, whether DREAM_AGENT_KEY is configured, and whether DREAM_AGENT_HOST was explicit.
- Report container context and detected default gateway.
- Perform a live /health probe, including status code, latency, parsed response, last success timestamp, and last error.
- Document the endpoint in the dashboard API README.

## Verification

- python -m pytest tests\\test_routers.py::test_host_agent_diagnostics_requires_auth tests\\test_routers.py::test_host_agent_diagnostics_success tests\\test_routers.py::test_host_agent_diagnostics_failure_keeps_last_success -q -> 3 passed
- python -m pytest tests\\test_routers.py tests\\test_main.py::test_read_installed_version_parses_json_version_file tests\\test_main.py::TestGpuEndpoint tests\\test_updates.py tests\\test_host_agent.py::TestResolveAgentBindAddr -q -> 82 passed
- python -m compileall -q . in dashboard-api
- git diff --check -> clean except Windows CRLF warnings
