### PR TITLE
Route dashboard updates through host agent

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1047,6 +1047,26 @@ def _read_update_status() -> dict:
     return data if isinstance(data, dict) else {"status": "unknown"}
 
 
+def _fail_stale_update_status(data: dict) -> dict:
+    """Convert a non-live queued/running update record into a terminal failure."""
+    if data.get("status") not in {"queued", "running"}:
+        return data
+
+    action = data.get("action")
+    if not isinstance(action, str) or not action:
+        action = "update"
+
+    fields = {
+        key: value
+        for key, value in data.items()
+        if key not in {"status", "action", "updated_at", "error", "finished_at"}
+    }
+    fields["error"] = data.get("error") or "Update process exited before reporting completion."
+    fields["finished_at"] = _iso_now()
+    _write_update_status("failed", action, **fields)
+    return _read_update_status()
+
+
 def _find_update_script() -> Path | None:
     for candidate in (
         INSTALL_DIR / "dream-update.sh",
@@ -1375,6 +1395,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             running = _update_thread is not None and _update_thread.is_alive()
         if running:
             data = {**data, "status": "running"}
+        else:
+            data = _fail_stale_update_status(data)
         json_response(self, 200, data)
 
     def _handle_update_action(self):
@@ -1485,6 +1507,13 @@ class AgentHandler(BaseHTTPRequestHandler):
                     _write_update_status(
                         "failed", "update",
                         error=f"Update failed: {exc}",
+                        finished_at=_iso_now(),
+                    )
+                except Exception as exc:
+                    logger.exception("Unhandled update failure")
+                    _write_update_status(
+                        "failed", "update",
+                        error=f"Update failed unexpectedly: {exc}",
                         finished_at=_iso_now(),
                     )
 

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -96,6 +96,11 @@ _model_download_proc: subprocess.Popen | None = None
 _model_download_cancel = threading.Event()
 # Model activation lock — prevent concurrent .env writes and Docker restarts
 _model_activate_lock = threading.Lock()
+# Update lock/state: only one background dream-update run at a time.
+_update_lock = threading.Lock()
+_update_status_lock = threading.Lock()
+_update_thread: threading.Thread | None = None
+_update_usable_bash: str | bool | None = None
 
 
 def load_env(env_path: Path) -> dict:
@@ -769,6 +774,25 @@ def read_json_body(handler) -> dict | None:
         return None
 
 
+def read_optional_json_body(handler) -> dict | None:
+    try:
+        length = int(handler.headers.get("Content-Length", 0))
+    except (ValueError, TypeError):
+        json_response(handler, 400, {"error": "Invalid Content-Length"})
+        return None
+    if length <= 0:
+        return {}
+    try:
+        data = json.loads(handler.rfile.read(min(length, MAX_BODY)))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        json_response(handler, 400, {"error": "Invalid JSON"})
+        return None
+    if not isinstance(data, dict):
+        json_response(handler, 400, {"error": "JSON body must be an object"})
+        return None
+    return data
+
+
 def validate_service_id(handler, body: dict) -> str | None:
     sid = body.get("service_id", "")
     if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
@@ -992,6 +1016,99 @@ def _narrowed_compose_set_resolves(narrowed_flags: list, service_id: str,
     return service_id in result.stdout.split()
 
 
+def _update_status_path() -> Path:
+    return INSTALL_DIR / "data" / "update-status.json"
+
+
+def _write_update_status(status: str, action: str, **fields) -> None:
+    with _update_status_lock:
+        path = _update_status_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "status": status,
+            "action": action,
+            "updated_at": _iso_now(),
+            **fields,
+        }
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        tmp.replace(path)
+
+
+def _read_update_status() -> dict:
+    with _update_status_lock:
+        path = _update_status_path()
+        if not path.exists():
+            return {"status": "idle"}
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {"status": "unknown", "error": "could not read update status"}
+    return data if isinstance(data, dict) else {"status": "unknown"}
+
+
+def _find_update_script() -> Path | None:
+    for candidate in (
+        INSTALL_DIR / "dream-update.sh",
+        INSTALL_DIR / "scripts" / "dream-update.sh",
+        INSTALL_DIR.parent / "scripts" / "dream-update.sh",
+    ):
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _find_update_bash() -> str | None:
+    global _update_usable_bash
+    if isinstance(_update_usable_bash, str):
+        return _update_usable_bash
+    if _update_usable_bash is False:
+        return None
+
+    bash = shutil.which("bash")
+    if not bash:
+        _update_usable_bash = False
+        return None
+    try:
+        result = subprocess.run(
+            [bash, "-lc", "printf ok"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        _update_usable_bash = False
+        return None
+    if result.returncode == 0 and result.stdout == "ok":
+        _update_usable_bash = bash
+        return bash
+    _update_usable_bash = False
+    return None
+
+
+def _update_command(script_path: Path, *args: str) -> list[str]:
+    if platform.system() != "Windows":
+        return [str(script_path), *args]
+    bash = _find_update_bash()
+    if not bash:
+        raise RuntimeError(
+            "Update actions require a usable Bash runtime on Windows. "
+            "Install Git Bash or run Dream Server through WSL/Linux."
+        )
+    return [bash, _to_bash_path(script_path), *args]
+
+
+def _run_update_script(action: str, *args: str, timeout: int | None) -> subprocess.CompletedProcess:
+    script = _find_update_script()
+    if script is None:
+        raise FileNotFoundError("dream-update.sh not found")
+    return subprocess.run(
+        _update_command(script, action, *args),
+        cwd=str(INSTALL_DIR),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
 class AgentHandler(BaseHTTPRequestHandler):
     def log_message(self, fmt, *args):
         logger.info(fmt, *args)
@@ -1013,6 +1130,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_tailscale_status()
         elif self.path == "/v1/ap-mode/status":
             self._handle_ap_mode_status()
+        elif self.path == "/v1/update/status":
+            self._handle_update_status()
         else:
             json_response(self, 404, {"error": "Not found"})
 
@@ -1230,6 +1349,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             self._handle_invalidate_compose_cache()
         elif self.path == "/v1/env/update":
             self._handle_env_update()
+        elif self.path in ("/v1/update/check", "/v1/update/backup", "/v1/update/start"):
+            self._handle_update_action()
         elif self.path == "/v1/network/wifi-connect":
             self._handle_network_wifi_connect()
         elif self.path == "/v1/network/wifi-forget":
@@ -1244,6 +1365,137 @@ class AgentHandler(BaseHTTPRequestHandler):
         invalidate_compose_cache()
         logger.info("compose-flags cache invalidated")
         json_response(self, 200, {"status": "ok"})
+
+    def _handle_update_status(self):
+        """Return the last host-agent managed update run status."""
+        if not check_auth(self):
+            return
+        data = _read_update_status()
+        with _update_lock:
+            running = _update_thread is not None and _update_thread.is_alive()
+        if running:
+            data = {**data, "status": "running"}
+        json_response(self, 200, data)
+
+    def _handle_update_action(self):
+        """Run dream-update.sh from the host-agent trust boundary."""
+        if not check_auth(self):
+            return
+        body = read_optional_json_body(self)
+        if body is None:
+            return
+
+        endpoint_action = self.path.rsplit("/", 1)[-1]
+        if endpoint_action == "check":
+            self._handle_update_check()
+        elif endpoint_action == "backup":
+            backup_id = body.get("backup_id")
+            if not isinstance(backup_id, str) or not backup_id.strip():
+                backup_id = f"dashboard-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+            self._handle_update_backup(backup_id.strip())
+        elif endpoint_action == "start":
+            self._handle_update_start()
+        else:
+            json_response(self, 404, {"error": "Not found"})
+
+    def _handle_update_check(self):
+        try:
+            result = _run_update_script("check", timeout=30)
+        except FileNotFoundError:
+            json_response(self, 501, {"error": "Update system not installed."})
+            return
+        except RuntimeError as exc:
+            json_response(self, 501, {"error": str(exc)})
+            return
+        except subprocess.TimeoutExpired:
+            json_response(self, 504, {"error": "Update check timed out"})
+            return
+        except OSError as exc:
+            json_response(self, 500, {"error": f"Update check failed: {exc}"})
+            return
+
+        output = (result.stdout or "") + (result.stderr or "")
+        json_response(self, 200, {
+            "success": result.returncode in (0, 2),
+            "update_available": result.returncode == 2,
+            "returncode": result.returncode,
+            "output": output,
+        })
+
+    def _handle_update_backup(self, backup_id: str):
+        try:
+            result = _run_update_script("backup", backup_id, timeout=60)
+        except FileNotFoundError:
+            json_response(self, 501, {"error": "Update system not installed."})
+            return
+        except RuntimeError as exc:
+            json_response(self, 501, {"error": str(exc)})
+            return
+        except subprocess.TimeoutExpired:
+            json_response(self, 504, {"error": "Backup timed out"})
+            return
+        except OSError as exc:
+            json_response(self, 500, {"error": f"Backup failed: {exc}"})
+            return
+
+        output = (result.stdout or "") + (result.stderr or "")
+        json_response(self, 200, {
+            "success": result.returncode == 0,
+            "returncode": result.returncode,
+            "output": output,
+        })
+
+    def _handle_update_start(self):
+        global _update_thread
+
+        with _update_lock:
+            if _update_thread is not None and _update_thread.is_alive():
+                json_response(self, 409, {
+                    "success": False,
+                    "status": "running",
+                    "message": "Update already running",
+                })
+                return
+
+            _write_update_status("queued", "update", started_at=_iso_now())
+
+            def _run_background_update():
+                try:
+                    _write_update_status("running", "update", started_at=_iso_now())
+                    result = _run_update_script("update", timeout=3600)
+                    output = ((result.stdout or "") + (result.stderr or ""))[-8000:]
+                    _write_update_status(
+                        "succeeded" if result.returncode == 0 else "failed",
+                        "update",
+                        returncode=result.returncode,
+                        output_tail=output,
+                        finished_at=_iso_now(),
+                    )
+                except FileNotFoundError:
+                    _write_update_status(
+                        "failed", "update",
+                        error="Update system not installed.",
+                        finished_at=_iso_now(),
+                    )
+                except RuntimeError as exc:
+                    _write_update_status("failed", "update", error=str(exc), finished_at=_iso_now())
+                except subprocess.TimeoutExpired:
+                    _write_update_status("failed", "update", error="Update timed out", finished_at=_iso_now())
+                except OSError as exc:
+                    _write_update_status(
+                        "failed", "update",
+                        error=f"Update failed: {exc}",
+                        finished_at=_iso_now(),
+                    )
+
+            _update_thread = threading.Thread(target=_run_background_update, daemon=True)
+            _update_thread.start()
+
+        json_response(self, 202, {
+            "success": True,
+            "status": "started",
+            "message": "Update started in background. Check update status for progress.",
+        })
 
     # ------------------------------------------------------------------
     # Wi-Fi / network management (Linux + NetworkManager only)

--- a/dream-server/docs/HOST-AGENT-API.md
+++ b/dream-server/docs/HOST-AGENT-API.md
@@ -56,6 +56,41 @@ Health check. No authentication required.
 }
 ```
 
+### `GET /v1/update/status`
+
+Return the last host-agent managed update run status.
+
+**Authentication:** Required
+
+**Response (200):**
+```json
+{
+  "status": "succeeded",
+  "action": "update",
+  "returncode": 0,
+  "updated_at": "2026-05-18T18:00:00Z"
+}
+```
+
+If no update has run, the response is `{ "status": "idle" }`.
+
+### `POST /v1/update/check`, `POST /v1/update/backup`, `POST /v1/update/start`
+
+Run `dream-update.sh` from the host-agent boundary. `check` and `backup` run synchronously and return script output. `start` launches the update in a background thread and writes `data/update-status.json` for polling.
+
+**Authentication:** Required
+
+**Request body:** optional JSON object. `backup` accepts an optional `backup_id`; otherwise the host agent generates one.
+
+**Error responses:**
+| Code | Condition |
+|------|-----------|
+| 401 | Missing Authorization header |
+| 403 | Invalid API key |
+| 409 | Update already running |
+| 501 | Update system or usable Bash runtime not available |
+| 504 | Update check/backup timed out |
+
 ### `POST /v1/extension/start`
 
 Start an extension container. Runs `docker compose up -d <service_id>` using the full compose stack (resolved via `scripts/resolve-compose-stack.sh`). Before starting, the agent pre-creates any `./data/` volume directories declared in the extension's `compose.yaml`, with correct ownership based on the `user:` field.

--- a/dream-server/extensions/services/dashboard-api/README.md
+++ b/dream-server/extensions/services/dashboard-api/README.md
@@ -121,7 +121,8 @@ Environment variables (set in `.env`):
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/api/version` | Yes | Current version + GitHub update check |
-| `GET` | `/api/releases/manifest` | No | Recent release history from GitHub |
+| `GET` | `/api/releases/manifest` | Yes | Recent release history from GitHub |
+| `GET` | `/api/update/status` | Yes | Host-agent managed update status |
 | `POST` | `/api/update` | Yes | Trigger update actions (`check`, `backup`, `update`) |
 
 ### Extensions

--- a/dream-server/extensions/services/dashboard-api/routers/updates.py
+++ b/dream-server/extensions/services/dashboard-api/routers/updates.py
@@ -3,19 +3,18 @@
 import asyncio
 import json
 import logging
-import os
 import re
-import shutil
-import subprocess
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
 import httpx
-from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
-from config import INSTALL_DIR
+from config import AGENT_URL, DREAM_AGENT_KEY, INSTALL_DIR
 from models import VersionInfo, UpdateAction
 from security import verify_api_key
 
@@ -29,7 +28,6 @@ _GITHUB_HEADERS = {"Accept": "application/vnd.github.v3+json"}
 _VERSION_CACHE_TTL = 300.0
 _version_cache: dict[str, object] = {"expires_at": 0.0, "payload": None}
 _version_refresh_task: Optional[asyncio.Task] = None
-_usable_bash: Optional[str] | bool = None
 
 
 def _read_utf8(path: Path) -> str:
@@ -83,68 +81,59 @@ def _read_current_version() -> str:
     return "0.0.0"
 
 
-def _find_usable_bash() -> Optional[str]:
-    """Return a Bash executable that can actually run scripts on this host."""
-    global _usable_bash
-    if isinstance(_usable_bash, str):
-        return _usable_bash
-    if _usable_bash is False:
-        return None
-
-    bash = shutil.which("bash")
-    if not bash:
-        _usable_bash = False
-        return None
+def _call_update_agent(endpoint_action: str, payload: dict, timeout: int) -> dict:
+    """Call the host agent for update execution."""
+    url = f"{AGENT_URL}/v1/update/{endpoint_action}"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {DREAM_AGENT_KEY}",
+    }
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.loads(exc.read().decode("utf-8") or "{}")
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            body = {}
+        detail = body.get("error") or body.get("detail") or exc.reason
+        raise HTTPException(status_code=exc.code, detail=detail)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        detail = str(getattr(exc, "reason", exc))
+        raise HTTPException(status_code=503, detail=f"Host agent unreachable: {detail}")
 
     try:
-        result = subprocess.run(
-            [bash, "-lc", "printf ok"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
-        _usable_bash = False
-        return None
-
-    if result.returncode == 0 and result.stdout == "ok":
-        _usable_bash = bash
-        return bash
-    _usable_bash = False
-    return None
+        parsed = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        parsed = {"success": False, "output": raw}
+    return parsed if isinstance(parsed, dict) else {"success": False, "output": raw}
 
 
-def _to_bash_path(path: Path) -> str:
-    """Convert a Windows path into a form Git Bash can execute."""
-    path_str = str(path)
-    if os.name != "nt":
-        return path_str
+def _get_update_agent_status(timeout: int = 5) -> dict:
+    url = f"{AGENT_URL}/v1/update/status"
+    headers = {"Authorization": f"Bearer {DREAM_AGENT_KEY}"}
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        try:
+            body = json.loads(exc.read().decode("utf-8") or "{}")
+        except (json.JSONDecodeError, OSError, UnicodeDecodeError):
+            body = {}
+        detail = body.get("error") or body.get("detail") or exc.reason
+        raise HTTPException(status_code=exc.code, detail=detail)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        detail = str(getattr(exc, "reason", exc))
+        raise HTTPException(status_code=503, detail=f"Host agent unreachable: {detail}")
 
-    match = re.match(r"^([A-Za-z]):[\\/](.*)$", path_str)
-    if match:
-        drive = match.group(1).lower()
-        rest = match.group(2).replace("\\", "/")
-        return f"/{drive}/{rest}"
-    return path_str.replace("\\", "/")
-
-
-def _update_command(script_path: Path, *args: str) -> list[str]:
-    """Build a platform-aware command for dream-update.sh."""
-    if os.name != "nt":
-        return [str(script_path), *args]
-
-    bash = _find_usable_bash()
-    if bash:
-        return [bash, _to_bash_path(script_path), *args]
-
-    raise HTTPException(
-        status_code=501,
-        detail=(
-            "Update actions require a usable Bash runtime on Windows. "
-            "Run this action inside the Dream Server Linux container/WSL path "
-            "or install Git Bash and retry."
-        ),
-    )
+    try:
+        parsed = json.loads(raw or "{}")
+    except json.JSONDecodeError:
+        parsed = {"status": "unknown", "output": raw}
+    return parsed if isinstance(parsed, dict) else {"status": "unknown", "output": raw}
 
 
 def _get_cached_release_payload(allow_stale: bool = False) -> Optional[dict]:
@@ -355,59 +344,22 @@ async def get_update_dry_run():
     }
 
 
+@router.get("/api/update/status", dependencies=[Depends(verify_api_key)])
+async def get_update_status():
+    """Return host-agent managed update status."""
+    return await asyncio.to_thread(_get_update_agent_status)
+
+
 @router.post("/api/update")
-async def trigger_update(action: UpdateAction, background_tasks: BackgroundTasks, api_key: str = Depends(verify_api_key)):
+async def trigger_update(action: UpdateAction, api_key: str = Depends(verify_api_key)):
     """Trigger update actions via dashboard."""
     if action.action not in _VALID_ACTIONS:
         raise HTTPException(status_code=400, detail=f"Unknown action: {action.action}")
 
-    script_path = Path(INSTALL_DIR) / "dream-update.sh"
-    if not script_path.exists():
-        script_path = Path(INSTALL_DIR).parent / "scripts" / "dream-update.sh"
-    if not script_path.exists():
-        script_path = Path(INSTALL_DIR) / "scripts" / "dream-update.sh"
-
-    if not script_path.exists():
-        logger.error("dream-update.sh not found at %s", script_path)
-        raise HTTPException(status_code=501, detail="Update system not installed.")
-
     if action.action == "check":
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *_update_command(script_path, "check"),
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
-            return {"success": True, "update_available": proc.returncode == 2, "output": stdout.decode() + stderr.decode()}
-        except asyncio.TimeoutError:
-            raise HTTPException(status_code=504, detail="Update check timed out")
-        except OSError:
-            logger.exception("Update check failed")
-            raise HTTPException(status_code=500, detail="Check failed")
-    elif action.action == "backup":
-        try:
-            proc = await asyncio.create_subprocess_exec(
-                *_update_command(script_path, "backup", f"dashboard-{datetime.now().strftime('%Y%m%d-%H%M%S')}"),
-                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-            )
-            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=60)
-            return {"success": proc.returncode == 0, "output": stdout.decode() + stderr.decode()}
-        except asyncio.TimeoutError:
-            raise HTTPException(status_code=504, detail="Backup timed out")
-        except OSError:
-            logger.exception("Backup failed")
-            raise HTTPException(status_code=500, detail="Backup failed")
-    elif action.action == "update":
-        command = _update_command(script_path, "update")
+        return await asyncio.to_thread(_call_update_agent, "check", {}, 35)
+    if action.action == "backup":
+        payload = {"backup_id": f"dashboard-{datetime.now().strftime('%Y%m%d-%H%M%S')}"}
+        return await asyncio.to_thread(_call_update_agent, "backup", payload, 65)
 
-        async def run_update():
-            try:
-                proc = await asyncio.create_subprocess_exec(
-                    *command,
-                    stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
-                )
-                await proc.communicate()
-            except OSError:
-                logger.exception("update task failed")
-        background_tasks.add_task(run_update)
-        return {"success": True, "message": "Update started in background. Check logs for progress."}
+    return await asyncio.to_thread(_call_update_agent, "start", {}, 10)

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -435,6 +435,98 @@ class TestUpdateWire:
             server.server_close()
             thread.join(timeout=2)
 
+    def test_status_marks_stale_running_update_failed(self, tmp_path, monkeypatch):
+        import threading
+        import urllib.request
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "dream-server"
+        install_dir.mkdir()
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+        monkeypatch.setattr(_mod, "_update_thread", None)
+        _mod._write_update_status("running", "update", started_at="2026-01-01T00:00:00+00:00")
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/update/status",
+                headers={"Authorization": "Bearer wire-test-secret"},
+            )
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                status = json.loads(resp.read().decode("utf-8"))
+
+            assert resp.status == 200
+            assert status["status"] == "failed"
+            assert status["action"] == "update"
+            assert "before reporting completion" in status["error"]
+            assert _mod._read_update_status()["status"] == "failed"
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_start_records_unexpected_background_failure(self, tmp_path, monkeypatch):
+        import threading
+        import urllib.request
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "dream-server"
+        install_dir.mkdir()
+
+        def fail_update(action, *args, timeout):
+            raise ValueError("boom")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+        monkeypatch.setattr(_mod, "_update_thread", None)
+        monkeypatch.setattr(_mod, "_run_update_script", fail_update)
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/update/start",
+                data=b"{}",
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer wire-test-secret",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                accepted = json.loads(resp.read().decode("utf-8"))
+
+            assert resp.status == 202
+            assert accepted["status"] == "started"
+
+            deadline = time.time() + 2
+            status = {}
+            while time.time() < deadline:
+                req = urllib.request.Request(
+                    f"http://127.0.0.1:{port}/v1/update/status",
+                    headers={"Authorization": "Bearer wire-test-secret"},
+                )
+                with urllib.request.urlopen(req, timeout=2) as resp:
+                    status = json.loads(resp.read().decode("utf-8"))
+                if status.get("status") == "failed":
+                    break
+                time.sleep(0.05)
+
+            assert status["status"] == "failed"
+            assert "unexpectedly" in status["error"]
+            assert "boom" in status["error"]
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
 
 class TestComposeToggleWire:
     """End-to-end HTTP test for built-in compose toggles via the host agent."""

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5,6 +5,7 @@ import io
 import json
 import subprocess
 import sys
+import time
 import types
 from pathlib import Path, PurePosixPath
 
@@ -315,6 +316,120 @@ class TestComposeCacheInvalidationWire:
             monkeypatch.setattr(ext_router, "DREAM_AGENT_KEY", "wrong-secret")
             ext_router._call_agent_invalidate_compose_cache()
             assert cache_file.exists()
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+
+class TestUpdateWire:
+    """End-to-end HTTP tests for host-agent managed update actions."""
+
+    def test_check_runs_update_script_on_host_agent(self, tmp_path, monkeypatch):
+        import threading
+        import urllib.request
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "dream-server"
+        install_dir.mkdir()
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+        monkeypatch.setattr(
+            _mod,
+            "_run_update_script",
+            lambda action, *args, timeout: subprocess.CompletedProcess(
+                ["dream-update", action, *args],
+                2,
+                "update available\n",
+                "",
+            ),
+        )
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/update/check",
+                data=b"{}",
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer wire-test-secret",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+
+            assert resp.status == 200
+            assert data["success"] is True
+            assert data["update_available"] is True
+            assert data["returncode"] == 2
+            assert "update available" in data["output"]
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_start_records_background_update_status(self, tmp_path, monkeypatch):
+        import threading
+        import urllib.request
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "dream-server"
+        install_dir.mkdir()
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+        monkeypatch.setattr(
+            _mod,
+            "_run_update_script",
+            lambda action, *args, timeout: subprocess.CompletedProcess(
+                ["dream-update", action, *args],
+                0,
+                "updated\n",
+                "",
+            ),
+        )
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/update/start",
+                data=b"{}",
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer wire-test-secret",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                accepted = json.loads(resp.read().decode("utf-8"))
+
+            assert resp.status == 202
+            assert accepted["status"] == "started"
+
+            deadline = time.time() + 2
+            status = {}
+            while time.time() < deadline:
+                req = urllib.request.Request(
+                    f"http://127.0.0.1:{port}/v1/update/status",
+                    headers={"Authorization": "Bearer wire-test-secret"},
+                )
+                with urllib.request.urlopen(req, timeout=2) as resp:
+                    status = json.loads(resp.read().decode("utf-8"))
+                if status.get("status") == "succeeded":
+                    break
+                time.sleep(0.05)
+
+            assert status["status"] == "succeeded"
+            assert status["returncode"] == 0
+            assert "updated" in status["output_tail"]
         finally:
             server.shutdown()
             server.server_close()

--- a/dream-server/extensions/services/dashboard-api/tests/test_updates.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_updates.py
@@ -1,11 +1,8 @@
 """Tests for updates router endpoints."""
 
 import json
-import sys
-from pathlib import PureWindowsPath
 from unittest.mock import patch, MagicMock, AsyncMock
 
-import pytest
 import httpx
 from fastapi import HTTPException
 
@@ -118,50 +115,22 @@ def test_trigger_update_requires_auth(test_client):
     assert resp.status_code == 401
 
 
-def test_trigger_update_no_script(test_client):
-    """POST /api/update when update script is missing → 501."""
+def test_trigger_update_host_agent_unreachable(test_client, monkeypatch):
+    """POST /api/update surfaces host-agent reachability failures."""
+    import routers.updates as updates_mod
+
+    def fail(action, payload, timeout):
+        raise HTTPException(status_code=503, detail="Host agent unreachable: timed out")
+
+    monkeypatch.setattr(updates_mod, "_call_update_agent", fail)
+
     resp = test_client.post(
         "/api/update",
         json={"action": "check"},
-        headers=test_client.auth_headers
+        headers=test_client.auth_headers,
     )
-    assert resp.status_code == 501
-
-
-def test_update_command_windows_requires_usable_bash(monkeypatch, tmp_path):
-    """Windows update actions fail clearly when no usable Bash runtime exists."""
-    import routers.updates as updates_mod
-
-    script = tmp_path / "dream-update.sh"
-    script.write_text("#!/usr/bin/env bash\n", encoding="utf-8")
-
-    monkeypatch.setattr(updates_mod.os, "name", "nt")
-    monkeypatch.setattr(updates_mod, "_find_usable_bash", lambda: None)
-
-    with pytest.raises(HTTPException) as exc:
-        updates_mod._update_command(script, "check")
-
-    assert exc.value.status_code == 501
-    assert "usable Bash runtime" in exc.value.detail
-
-
-def test_update_command_windows_uses_bash_path(monkeypatch):
-    """Windows update actions pass Git Bash a POSIX-style script path."""
-    import routers.updates as updates_mod
-
-    monkeypatch.setattr(updates_mod.os, "name", "nt")
-    monkeypatch.setattr(updates_mod, "_find_usable_bash", lambda: "C:\\Program Files\\Git\\bin\\bash.exe")
-
-    command = updates_mod._update_command(
-        PureWindowsPath("C:/DreamServer/dream-server/scripts/dream-update.sh"),
-        "check",
-    )
-
-    assert command == [
-        "C:\\Program Files\\Git\\bin\\bash.exe",
-        "/c/DreamServer/dream-server/scripts/dream-update.sh",
-        "check",
-    ]
+    assert resp.status_code == 503
+    assert "Host agent unreachable" in resp.json()["detail"]
 
 
 # ---------------------------------------------------------------------------
@@ -395,29 +364,29 @@ def test_update_dry_run_no_files(test_client, tmp_path, monkeypatch):
     assert data["images"] == []
 
 
+def test_get_update_status_proxies_host_agent(test_client, monkeypatch):
+    """GET /api/update/status returns host-agent update status."""
+    import routers.updates as updates_mod
+
+    monkeypatch.setattr(
+        updates_mod,
+        "_get_update_agent_status",
+        lambda: {"status": "succeeded", "returncode": 0},
+    )
+
+    resp = test_client.get("/api/update/status", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "succeeded", "returncode": 0}
+
+
 # ---------------------------------------------------------------------------
 # POST /api/update — invalid action
 # ---------------------------------------------------------------------------
 
 
-def test_trigger_update_invalid_action(test_client, tmp_path, monkeypatch):
+def test_trigger_update_invalid_action(test_client):
     """POST /api/update with unknown action → 400."""
-    import routers.updates as updates_mod
-
-    # Create a fake script so we get past the 501 check
-    install_dir = tmp_path / "dream-server"
-    scripts_dir = tmp_path / "scripts"
-    scripts_dir.mkdir()
-    script = scripts_dir / "dream-update.sh"
-    script.write_text("import sys\nsys.exit(0)\n")
-    script.chmod(0o755)
-    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
-    monkeypatch.setattr(
-        updates_mod,
-        "_update_command",
-        lambda script_path, *args: [sys.executable, str(script_path), *args],
-    )
-
     resp = test_client.post(
         "/api/update",
         json={"action": "destroy"},
@@ -432,23 +401,17 @@ def test_trigger_update_invalid_action(test_client, tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_trigger_update_action_update(test_client, tmp_path, monkeypatch):
+def test_trigger_update_action_update(test_client, monkeypatch):
     """POST /api/update with action=update → 200, starts background task."""
     import routers.updates as updates_mod
 
-    install_dir = tmp_path / "dream-server"
-    install_dir.mkdir()
-    scripts_dir = tmp_path / "scripts"
-    scripts_dir.mkdir()
-    script = scripts_dir / "dream-update.sh"
-    script.write_text("import sys\nsys.exit(0)\n")
-    script.chmod(0o755)
-    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
-    monkeypatch.setattr(
-        updates_mod,
-        "_update_command",
-        lambda script_path, *args: [sys.executable, str(script_path), *args],
-    )
+    calls = []
+
+    def fake_call(action, payload, timeout):
+        calls.append((action, payload, timeout))
+        return {"success": True, "message": "Update started in background."}
+
+    monkeypatch.setattr(updates_mod, "_call_update_agent", fake_call)
 
     resp = test_client.post(
         "/api/update",
@@ -459,6 +422,7 @@ def test_trigger_update_action_update(test_client, tmp_path, monkeypatch):
     data = resp.json()
     assert data["success"] is True
     assert "background" in data["message"].lower()
+    assert calls == [("start", {}, 10)]
 
 
 # ---------------------------------------------------------------------------
@@ -466,23 +430,17 @@ def test_trigger_update_action_update(test_client, tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_trigger_update_action_check(test_client, tmp_path, monkeypatch):
+def test_trigger_update_action_check(test_client, monkeypatch):
     """POST /api/update with action=check → 200, runs script and returns output."""
     import routers.updates as updates_mod
 
-    install_dir = tmp_path / "dream-server"
-    install_dir.mkdir()
-    scripts_dir = tmp_path / "scripts"
-    scripts_dir.mkdir()
-    script = scripts_dir / "dream-update.sh"
-    script.write_text("import sys\nprint('no updates')\nsys.exit(0)\n")
-    script.chmod(0o755)
-    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
-    monkeypatch.setattr(
-        updates_mod,
-        "_update_command",
-        lambda script_path, *args: [sys.executable, str(script_path), *args],
-    )
+    calls = []
+
+    def fake_call(action, payload, timeout):
+        calls.append((action, payload, timeout))
+        return {"success": True, "update_available": False, "output": "no updates"}
+
+    monkeypatch.setattr(updates_mod, "_call_update_agent", fake_call)
 
     resp = test_client.post(
         "/api/update",
@@ -494,6 +452,7 @@ def test_trigger_update_action_check(test_client, tmp_path, monkeypatch):
     assert data["success"] is True
     assert data["update_available"] is False
     assert "no updates" in data["output"]
+    assert calls == [("check", {}, 35)]
 
 
 # ---------------------------------------------------------------------------
@@ -501,23 +460,17 @@ def test_trigger_update_action_check(test_client, tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_trigger_update_action_backup(test_client, tmp_path, monkeypatch):
+def test_trigger_update_action_backup(test_client, monkeypatch):
     """POST /api/update with action=backup → 200, runs backup script."""
     import routers.updates as updates_mod
 
-    install_dir = tmp_path / "dream-server"
-    install_dir.mkdir()
-    scripts_dir = tmp_path / "scripts"
-    scripts_dir.mkdir()
-    script = scripts_dir / "dream-update.sh"
-    script.write_text("import sys\nprint('backup complete')\nsys.exit(0)\n")
-    script.chmod(0o755)
-    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
-    monkeypatch.setattr(
-        updates_mod,
-        "_update_command",
-        lambda script_path, *args: [sys.executable, str(script_path), *args],
-    )
+    calls = []
+
+    def fake_call(action, payload, timeout):
+        calls.append((action, payload, timeout))
+        return {"success": True, "output": "backup complete"}
+
+    monkeypatch.setattr(updates_mod, "_call_update_agent", fake_call)
 
     resp = test_client.post(
         "/api/update",
@@ -528,3 +481,6 @@ def test_trigger_update_action_backup(test_client, tmp_path, monkeypatch):
     data = resp.json()
     assert data["success"] is True
     assert "backup" in data["output"].lower()
+    assert calls[0][0] == "backup"
+    assert calls[0][1]["backup_id"].startswith("dashboard-")
+    assert calls[0][2] == 65


### PR DESCRIPTION
## Summary

Stacked on #1243. Moves dashboard-triggered update execution to the host-agent boundary instead of spawning `dream-update.sh` from the containerized dashboard API.

- Add host-agent endpoints:
  - `POST /v1/update/check`
  - `POST /v1/update/backup`
  - `POST /v1/update/start`
  - `GET /v1/update/status`
- Keep `check` and `backup` synchronous, returning script output and return codes.
- Run `update` in a host-agent background thread and persist status to `data/update-status.json`.
- Add a status read/write lock so polling is safe on Windows too.
- Change dashboard `POST /api/update` to proxy to the host agent.
- Add dashboard `GET /api/update/status` for polling host-agent update state.
- Document the new host-agent and dashboard API endpoints.

## Verification

- `python -m pytest tests\\test_updates.py tests\\test_host_agent.py::TestUpdateWire -q` -> `23 passed`
- `python -m pytest tests\\test_main.py::test_read_installed_version_parses_json_version_file tests\\test_main.py::TestGpuEndpoint tests\\test_updates.py tests\\test_host_agent.py::TestResolveAgentBindAddr tests\\test_host_agent.py::TestUpdateWire -q` -> `32 passed`
- `python -m ruff check main.py routers\\updates.py tests\\test_updates.py tests\\test_host_agent.py` -> passed
- `python -m py_compile dream-server/bin/dream-host-agent.py`
- `python -m compileall -q dream-server/extensions/services/dashboard-api`
- `git diff --check` -> clean except Windows CRLF warnings
