### PR TITLE
fix(installer): avoid SIGPIPE in get-dream-server.sh nvidia-smi GPU pre-check

### DIFF
--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -95,7 +95,12 @@ for _v in /sys/class/drm/card*/device/vendor; do
     case "$(cat "$_v" 2>/dev/null)" in
         0x10de) # NVIDIA
             if command -v nvidia-smi &> /dev/null; then
-                _info=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null | head -1)
+                # Capture all output then take the first line in-shell. Piping
+                # `... | head -1` SIGPIPEs nvidia-smi (~17% on multi-GPU hosts):
+                # head closes the pipe after line 1, nvidia-smi exits 141, and
+                # pipefail propagates the failure → `set -e` aborts the bootstrap.
+                _info=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) || _info=""
+                _info=${_info%%$'\n'*}
                 [[ -n "$_info" ]] && success "NVIDIA GPU detected: $_info" && _gpu_found=true
             else
                 success "NVIDIA GPU detected (driver not yet installed — installer will handle it)"


### PR DESCRIPTION
## What failed

Fresh `--all --non-interactive --force` install on Tower2 (Linux NVIDIA, dual Blackwell, GPU driver freshly restored) exited rc=141 during the very first bootstrap phase, immediately after the prerequisite checks:

```
[dream] Checking prerequisites...
[  ok ] Docker found: Docker version 29.2.1, build a5c7197
===== bootstrap exit: 141 =====
```

No phase tags after preflight, no clone, no `install.sh` invocation — the bootstrap died inside `get-dream-server.sh` before reaching the cloned installer.

## Root cause

`dream-server/get-dream-server.sh:98` runs the NVIDIA pre-check pipeline:

```bash
_info=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null | head -1)
```

On a multi-GPU host, `nvidia-smi --query-gpu=… --format=csv,noheader` prints **one line per GPU**. `head -1` reads the first line and closes the pipe. If `nvidia-smi` is still writing line 2 when the close happens, the kernel signals it with SIGPIPE — its exit status is 141. With `set -euo pipefail` (set at the top of the file), `pipefail` propagates the 141, and `set -e` aborts the script.

Reproduction on Tower2 (2× RTX PRO 6000 Blackwell):

```bash
fail=0; ok=0
for i in $(seq 1 30); do
  bash -c 'set -euo pipefail; x=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null | head -1)' >/dev/null 2>&1
  [[ $? -eq 0 ]] && ok=$((ok+1)) || fail=$((fail+1))
done
echo "ok=$ok fail=$fail"
# → 30 runs: ok=25 fail=5
```

~17% reproduction rate — non-deterministic timing race between `head` closing the pipe and `nvidia-smi` writing the second line.

Why it slipped past previous fleet-test runs:

- **mac-mini, strix-halo**: no `nvidia-smi` available, so line 97's `command -v nvidia-smi` is false and execution falls to the safe `else` branch (lines 100–102). Pipe never runs.
- **spark**: NVIDIA Linux, vulnerable in principle, but apparently got lucky during this fleet run.
- **tower2 earlier today**: NVIDIA driver was broken (modules not loaded), so `command -v nvidia-smi` worked but `nvidia-smi` output was empty / errored — still no second-line pressure → no race. After the driver was restored, the race window opened and the rerun hit it on the first try.

## Fix

Drain `nvidia-smi`'s full output into the variable first, then take the first line with shell parameter expansion — no pipe, no SIGPIPE:

```bash
_info=$(nvidia-smi --query-gpu=name,memory.total --format=csv,noheader 2>/dev/null) || _info=""
_info=${_info%%$'\n'*}
```

A short comment in the source explains the pipe/SIGPIPE interaction so a future contributor doesn't reintroduce the pattern.

## Why it's safe

- **Same observable output.** First line of `nvidia-smi`'s output is captured exactly as before.
- **Both failure modes preserved.** If `nvidia-smi` is missing → unchanged (the `else` branch). If `nvidia-smi` errors → `_info=""` via the explicit `|| _info=""`, the subsequent `[[ -n "$_info" ]]` short-circuits, and the script falls through to the (current) "no GPU detected" warning at line 115.
- **No new dependencies, no `|| true` swallowing of unrelated errors.** Failure tolerance is bounded to this specific informational pre-check.
- **Verified locally:** stress-tested the patched block 50/50 successful runs on the same dual-Blackwell host that previously failed ~17% of runs.

## Scope considered but not taken

Three other `cmd --version | head -1` patterns exist in this file (lines 87, 121, 160). All produce single-line output and have a much smaller SIGPIPE window. They aren't part of the failing path observed in this run, so they're left alone per the project's "fix the bug, not the area" guidance.

## Discovered by

`/dream-fleet-test` rerun `runs/2026-05-19T03-03-43Z` on Tower2 (Linux + dual NVIDIA Blackwell, driver `595.58.03` freshly installed after a `nvidia-driver-595-open` recovery). Install exited rc=141 at bootstrap phase; previous run in the same session passed because the NVIDIA driver was unavailable, masking the race.
