### PR TITLE
[codex] configure Hermes contexts for installers

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ The installer detects your GPU and picks the optimal model automatically. No man
 
 The current model map supports `MODEL_PROFILE=qwen` by default, plus `MODEL_PROFILE=gemma4` and `MODEL_PROFILE=auto` for Gemma 4 tiers where supported. Override tier selection with `./install.sh --tier 3`; override the model family with `MODEL_PROFILE=gemma4 ./install.sh` or `MODEL_PROFILE=auto ./install.sh`.
 
+When Hermes is enabled, which is the default agent path, installers keep the first-run bootstrap model at a 64K context floor and promote the full local model context to 128K. That avoids Hermes's hard 64K minimum while preserving the under-2-minute first chat experience. Core-only or `--no-hermes` installs keep the smaller tier contexts shown below.
+
 ### NVIDIA
 
 | Tier | VRAM | Qwen profile | Gemma 4 profile | Context | Example GPUs |
@@ -231,6 +233,8 @@ No waiting for large downloads. Dream Server uses bootstrap mode by default:
 *The installer pulls all services in parallel. Downloads are resume-capable — interrupted downloads pick up where they left off.*
 
 </div>
+
+The bootstrap model starts with a 64K context window so Hermes can work during the first session. After the background download finishes, Dream Server swaps to the full model and restores the Hermes/full-model context target.
 
 Skip bootstrap: `./install.sh --no-bootstrap`
 

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -67,6 +67,8 @@ By default, Dream Server uses **bootstrap mode** for instant gratification:
 
 No more staring at download bars. Start playing immediately.
 
+Hermes-enabled installs keep this fast-start path: the bootstrap model runs at a 64K context floor so Hermes can start cleanly, then the background full-model swap promotes the local context target to 128K.
+
 Model download, switching, and manual GGUF notes: [docs/MODEL-MANAGEMENT.md](docs/MODEL-MANAGEMENT.md)
 
 To skip bootstrap and wait for the full model: `./install.sh --no-bootstrap`
@@ -123,6 +125,8 @@ See [`docs/WINDOWS-QUICKSTART.md`](docs/WINDOWS-QUICKSTART.md) for details.
 ## Hardware Tiers
 
 The installer **automatically detects your GPU** and selects the right configuration. `MODEL_PROFILE=qwen` is the default; `MODEL_PROFILE=gemma4` and `MODEL_PROFILE=auto` are also supported by the tier map where those GGUFs are available.
+
+When Hermes is enabled, installers keep the bootstrap model at 64K context and promote the full local model context to 128K. The table contexts below are the base tier choices used for core-only or `--no-hermes` installs.
 
 ### AMD Strix Halo (Unified Memory)
 

--- a/dream-server/docs/FAQ.md
+++ b/dream-server/docs/FAQ.md
@@ -286,7 +286,7 @@ Applying a template only enables services — it doesn't disable anything you've
 
 ### Can I chat while models are downloading?
 
-Yes. During install, a small bootstrap model (~1.5GB, Qwen 3.5 2B) downloads first so you can start chatting within a couple of minutes. The full tier-appropriate model downloads in the background.
+Yes. During install, a small bootstrap model (~1.5GB, Qwen 3.5 2B) downloads first so you can start chatting within a couple of minutes. The bootstrap context is 64K so Hermes can work during the first session. The full tier-appropriate model downloads in the background.
 
 When the full model finishes, the system swaps it in automatically — you don't need to do anything. `dream status` shows the current bootstrap state if a swap is still in progress.
 

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -93,6 +93,8 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 ## Defaults Dream Server applies
 
 - **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
+- **Context:** Hermes requires at least 64K tokens. Local installers run the bootstrap model at 64K so Hermes works immediately, then move the full model and Hermes config to 128K after the background model upgrade completes.
+- **Compression:** enabled at `compression.threshold: 0.50` with `target_ratio: 0.20` so long sessions compact before the backend hard-rejects an over-window request.
 - **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
 - **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server users reach Hermes via the web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
@@ -108,6 +110,8 @@ Three layers, highest to lowest precedence:
 3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
 
 To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.
+
+For local backends, keep `model.context_length` and `auxiliary.compression.context_length` aligned with `.env`'s `CTX_SIZE` / `MAX_CONTEXT`. Values below 64000 will make Hermes reject prompts; values above the server's real context can produce `context length exceeded` / `max compression attempts reached` loops.
 
 ## Security posture
 
@@ -176,6 +180,17 @@ docker exec dream-hermes curl -fs http://llama-server:8080/v1/models
 ```
 
 If that fails, the most likely cause is that the Hermes container isn't on Dream Server's docker network. Check `docker network inspect dream-server_default`.
+
+### Hermes says context length exceeded or max compression attempts reached
+
+Check that the running backend and Hermes agree on context:
+
+```bash
+grep -E "^(CTX_SIZE|MAX_CONTEXT)=" .env
+grep -n "context_length\|threshold\|target_ratio" data/hermes/config.yaml
+```
+
+For Hermes, `CTX_SIZE` / `MAX_CONTEXT`, `model.context_length`, and `auxiliary.compression.context_length` should be at least `65536`. Fresh local installs use `65536` during bootstrap and `131072` after the full model swap.
 
 ### Sessions / memories / skills disappeared after upgrade
 

--- a/dream-server/docs/MACOS-QUICKSTART.md
+++ b/dream-server/docs/MACOS-QUICKSTART.md
@@ -94,6 +94,8 @@ The installer auto-selects the best model for your unified memory:
 | 48 GB | 3 | Qwen3 30B-A3B (MoE, Q4_K_M) | 32768 |
 | 64+ GB | 4 | Qwen3 30B-A3B (MoE, Q4_K_M) | 131072 |
 
+When Hermes is enabled, the macOS installer promotes the active local context to 128K for the full model. If bootstrap mode is used, the first-run bootstrap model starts at 64K so Hermes is usable while the full model downloads.
+
 Override: `./install.sh --tier 3`
 
 ---

--- a/dream-server/docs/MIGRATION-OPENCLAW-TO-HERMES.md
+++ b/dream-server/docs/MIGRATION-OPENCLAW-TO-HERMES.md
@@ -12,7 +12,7 @@ This document covers the migration path for existing Dream Server installs that 
 
 ## Platform support in this release
 
-The default-agent swap is wired through the **Linux and macOS** installers in this release. The Windows installer (`installers/windows/`) continues to ship OpenClaw enabled by default through the deprecation window; Windows users who want Hermes can run `dream enable hermes` and `dream enable hermes-proxy` post-install. Windows installer parity (default-Hermes, `--hermes` / `--no-hermes` flags, data-dir creation) lands in a follow-up PR before the removal release.
+The default-agent swap is wired through the **Linux, macOS, and Windows** installers in this release. Windows now has installer parity with `-Hermes` / `-NoHermes` flags, Hermes data-dir creation, and the same context handling used on the other platforms.
 
 ## Why the swap
 

--- a/dream-server/docs/MODEL-MANAGEMENT.md
+++ b/dream-server/docs/MODEL-MANAGEMENT.md
@@ -73,6 +73,11 @@ grep -E "^(LLM_MODEL|GGUF_FILE|CTX_SIZE|MAX_CONTEXT)=" ~/dream-server/.env
 `LLM_MODEL` is the friendly logical model name used by scripts and config.
 `CTX_SIZE` and `MAX_CONTEXT` control context length.
 
+Hermes requires at least a 64K context window. Installer bootstrap mode uses
+`65536` for the fast-start model, then switches `.env`, llama-server, and
+Hermes config to the full model context, usually `131072`, when the background
+download completes.
+
 ## Manual: Download a Catalog Model
 
 For most users, use the Dashboard. If you are debugging a failed download or
@@ -135,6 +140,7 @@ n-ctx = 8192
 ```yaml
 model:
   default: "MyModel-Q4_K_M.gguf"
+  context_length: 65536
 ```
 
 For Lemonade/AMD backends, use:
@@ -142,7 +148,12 @@ For Lemonade/AMD backends, use:
 ```yaml
 model:
   default: "extra.MyModel-Q4_K_M.gguf"
+  context_length: 65536
 ```
+
+Also keep `auxiliary.compression.context_length` at the same value and use
+`compression.threshold: 0.50`; older absolute-token thresholds can leave Hermes
+waiting too long to compact.
 
 5. Restart the affected services.
 
@@ -223,7 +234,7 @@ If the server is correct, refresh the app. If the server is wrong, restart
 Hermes has its own config:
 
 ```bash
-grep -n "default:" data/hermes/config.yaml
+grep -n "default:\|context_length:" data/hermes/config.yaml
 docker restart dream-hermes
 ```
 

--- a/dream-server/docs/WINDOWS-QUICKSTART.md
+++ b/dream-server/docs/WINDOWS-QUICKSTART.md
@@ -53,7 +53,7 @@ First user becomes admin. Start chatting immediately.
 
 ## Bootstrap Mode (Faster Start)
 
-The installer automatically uses bootstrap mode when applicable — a small model (~1.5 GB) downloads first so you can start chatting within 2 minutes, while the full model downloads in the background. No extra flags needed.
+The installer automatically uses bootstrap mode when applicable — a small model (~1.5 GB) downloads first so you can start chatting within 2 minutes, while the full model downloads in the background. Hermes-enabled installs run that bootstrap model at a 64K context floor, then promote the full local model context to 128K after the swap. No extra flags needed.
 
 ---
 
@@ -65,10 +65,12 @@ The installer automatically uses bootstrap mode when applicable — a small mode
 | `-Voice` | Enable Whisper + TTS |
 | `-Workflows` | Enable n8n automation |
 | `-Rag` | Enable Qdrant vector DB |
-| `-OpenClaw` | Enable OpenClaw agent framework |
+| `-Hermes` | Enable Hermes Agent explicitly |
+| `-NoHermes` | Disable Hermes Agent |
+| `-OpenClaw` | Enable deprecated OpenClaw agent framework |
 | `-Comfyui` | Enable ComfyUI image generation |
 | `-Langfuse` | Enable Langfuse LLM observability |
-| `-All` | Everything enabled |
+| `-All` | Recommended full stack enabled (OpenClaw remains opt-in) |
 | `-Cloud` | Use cloud LLM provider instead of local |
 | `-DryRun` | Simulate install without making changes |
 

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -41,12 +41,11 @@ model:
   # or rely on a future installer-side substitution.
   base_url: "http://llama-server:8080/v1"
 
-  # Hermes Agent v0.13.0+ enforces a 64K minimum context window — anything
-  # smaller and *every* prompt 500s with "context window of N tokens is
-  # below the minimum 64,000 required by Hermes Agent". 131072 (128K) gives
-  # plenty of headroom for long agentic conversations while staying well
-  # within qwen3-coder-next's native 128K context. Bump higher in
-  # /opt/data/config.yaml if you've loaded a model with a larger context.
+  # Hermes needs a large working window for tool-calling workflows. Dream's
+  # installers keep this value aligned with CTX_SIZE: 64K for the fast-start
+  # bootstrap model, then 128K after the full model swap. Advertising a larger
+  # window than llama-server actually allocates causes "context length
+  # exceeded / max compression attempts reached" loops.
   context_length: 131072
 
 # =============================================================================
@@ -95,15 +94,16 @@ terminal:
 # Compression — keep memory bounded on small devices
 # =============================================================================
 # Hermes auto-compacts long conversations once they cross the threshold.
-# These are the upstream-correct keys (compression.*); an earlier draft
-# used compact_threshold under a context: block which upstream silently
-# ignores.
+# Current upstream reads threshold as a fraction of model.context_length
+# (0.50 = 50%), not an absolute token count. A stale value like 10000
+# effectively disables proactive compression until the backend rejects the
+# request, which is how sessions fall into max-compression-attempt loops.
 compression:
-  # Token count at which Hermes starts compacting the conversation.
-  # Lower = more aggressive = lower disk/token cost but more summary loss.
-  # Keep this comfortably below model.context_length so there's headroom
-  # before hitting the hard window limit.
-  threshold: 10000
-  # Fraction of the conversation to retain after compaction. 0.5 = aim
-  # for half the original token count post-summary.
-  target_ratio: 0.5
+  # Enable automatic context compression.
+  enabled: true
+  # Trigger compression at this fraction of the context window.
+  threshold: 0.50
+  # Preserve this fraction of the threshold-sized window as recent tail.
+  target_ratio: 0.20
+  # Keep roughly the last ten full turns intact during compression.
+  protect_last_n: 20

--- a/dream-server/installers/lib/bootstrap-model.sh
+++ b/dream-server/installers/lib/bootstrap-model.sh
@@ -12,11 +12,13 @@
 # Provides: BOOTSTRAP_* constants, bootstrap_needed()
 # ============================================================================
 
-# Bootstrap model: Tier 0 (Qwen 3.5 2B, Q4_K_M quantization, ~1.5GB)
+# Bootstrap model: Tier 0 (Qwen 3.5 2B, Q4_K_M quantization, ~1.5GB).
+# Hermes requires at least a 64K context window, so fast-start installs keep
+# the bootstrap server at that floor instead of the older 8K default.
 BOOTSTRAP_GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
 BOOTSTRAP_GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
 BOOTSTRAP_LLM_MODEL="qwen3.5-2b"
-BOOTSTRAP_MAX_CONTEXT=8192
+BOOTSTRAP_MAX_CONTEXT=65536
 
 # bootstrap_needed — Should we use the fast-start bootstrap pattern?
 #

--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -262,7 +262,7 @@ start_native_llama() {
 
     read_dream_env
     local gguf_file="${ENV_GGUF_FILE:-Qwen3.5-9B-Q4_K_M.gguf}"
-    local ctx_size="${ENV_CTX_SIZE:-16384}"
+    local ctx_size="${ENV_CTX_SIZE:-131072}"
     local model_path="${INSTALL_DIR}/data/models/${gguf_file}"
 
     if [[ ! -f "$model_path" ]]; then

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -14,6 +14,7 @@
 #   ./install-macos.sh --dry-run        # Validate without installing
 #   ./install-macos.sh --all            # Enable all optional services
 #   ./install-macos.sh --non-interactive # Headless install (defaults)
+#   ./install-macos.sh --no-bootstrap   # Wait for the full model before launch
 #
 # ============================================================================
 
@@ -89,6 +90,8 @@ NO_LANGFUSE_EXPLICIT=false
 OPENCLAW_EXPLICIT=false
 ALL_FEATURES=false
 CLOUD_MODE=false
+NO_BOOTSTRAP=false
+HERMES_CONTEXT_SIZE=131072
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -107,6 +110,7 @@ while [[ $# -gt 0 ]]; do
         --no-langfuse)   ENABLE_LANGFUSE=false; NO_LANGFUSE_EXPLICIT=true; shift ;;
         --all)           ALL_FEATURES=true; shift ;;
         --cloud)         CLOUD_MODE=true; shift ;;
+        --no-bootstrap)  NO_BOOTSTRAP=true; shift ;;
         *)               echo "Unknown option: $1"; exit 1 ;;
     esac
 done
@@ -558,6 +562,13 @@ if ! $NON_INTERACTIVE && ! $ALL_FEATURES && ! $DRY_RUN; then
     esac
 fi
 
+if $ENABLE_HERMES && ! $CLOUD_MODE; then
+    if [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
+        ai_warn "Hermes enabled: increasing macOS llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (128K)."
+        MAX_CONTEXT="$HERMES_CONTEXT_SIZE"
+    fi
+fi
+
 ai "Features:"
 info_box "  Voice:" "$(if $ENABLE_VOICE; then echo enabled; else echo disabled; fi)"
 info_box "  Workflows:" "$(if $ENABLE_WORKFLOWS; then echo enabled; else echo disabled; fi)"
@@ -684,6 +695,11 @@ else
         ai_ok "Preserved existing .env (use --force to regenerate secrets)"
     else
         ai_ok "Generated .env with secure secrets"
+    fi
+    if $ENABLE_HERMES && ! $CLOUD_MODE; then
+        upsert_env_value "${INSTALL_DIR}/.env" "MAX_CONTEXT" "$MAX_CONTEXT"
+        upsert_env_value "${INSTALL_DIR}/.env" "CTX_SIZE" "$MAX_CONTEXT"
+        ai_ok "Set macOS llama context to ${MAX_CONTEXT} for Hermes"
     fi
 
     # Generate SearXNG config
@@ -813,13 +829,34 @@ else
     if ! $CLOUD_MODE; then
         _hermes_tpl="${INSTALL_DIR}/extensions/services/hermes/cli-config.yaml.template"
         if [[ -f "$_hermes_tpl" ]]; then
-            sed -i '' \
-                -e "s|^  default: \"qwen3.5-9b\"|  default: \"${GGUF_FILE}\"|" \
-                -e "s|^  base_url: \"http://llama-server:8080/v1\"|  base_url: \"http://host.docker.internal:${OLLAMA_PORT:-8080}/v1\"|" \
-                "$_hermes_tpl"
+            _hermes_base_url="http://host.docker.internal:${OLLAMA_PORT:-8080}/v1"
+            _hermes_patcher="${INSTALL_DIR}/scripts/patch-hermes-config.py"
+            if [[ -f "$_hermes_patcher" ]]; then
+                python3 "$_hermes_patcher" "$_hermes_tpl" \
+                    --model "$GGUF_FILE" \
+                    --base-url "$_hermes_base_url" \
+                    --context-length "$MAX_CONTEXT" >>"$LOG_FILE" 2>&1 || \
+                    ai_warn "Hermes template patch failed — hand-edit ${_hermes_tpl} if prompts hang."
+                _hermes_live="${INSTALL_DIR}/data/hermes/config.yaml"
+                if [[ -f "$_hermes_live" ]]; then
+                    python3 "$_hermes_patcher" "$_hermes_live" \
+                        --model "$GGUF_FILE" \
+                        --base-url "$_hermes_base_url" \
+                        --context-length "$MAX_CONTEXT" >>"$LOG_FILE" 2>&1 || \
+                        ai_warn "Hermes live config patch failed — hand-edit ${_hermes_live} and restart Hermes if prompts hang."
+                fi
+            else
+                sed -i '' \
+                    -e "s|^  default: \"qwen3.5-9b\"|  default: \"${GGUF_FILE}\"|" \
+                    -e "s|^  base_url: \"http://llama-server:8080/v1\"|  base_url: \"${_hermes_base_url}\"|" \
+                    -e "s|^  context_length: .*|  context_length: ${MAX_CONTEXT}|" \
+                    -e "s|^    context_length: .*|    context_length: ${MAX_CONTEXT}|" \
+                    "$_hermes_tpl"
+            fi
             if grep -q "host.docker.internal" "$_hermes_tpl" && \
-               grep -q "^  default: \"${GGUF_FILE}\"$" "$_hermes_tpl"; then
-                ai_ok "Patched Hermes template for macOS (model=${GGUF_FILE}, base_url=host.docker.internal)"
+               grep -q "^  default: \"${GGUF_FILE}\"$" "$_hermes_tpl" && \
+               grep -q "^  context_length: ${MAX_CONTEXT}$" "$_hermes_tpl"; then
+                ai_ok "Patched Hermes config for macOS (model=${GGUF_FILE}, context=${MAX_CONTEXT}, base_url=host.docker.internal)"
             else
                 ai_warn "Hermes template patch incomplete — Hermes may fail to reach llama-server. Hand-edit ${_hermes_tpl} if prompts hang."
             fi

--- a/dream-server/installers/macos/lib/tier-map.sh
+++ b/dream-server/installers/macos/lib/tier-map.sh
@@ -222,7 +222,9 @@ auto_select_tier() {
 BOOTSTRAP_GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
 BOOTSTRAP_GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
 BOOTSTRAP_LLM_MODEL="qwen3.5-2b"
-BOOTSTRAP_MAX_CONTEXT=8192
+# Hermes requires at least a 64K context window. Keep the fast-start model at
+# that floor so Hermes works during the first-run bootstrap experience too.
+BOOTSTRAP_MAX_CONTEXT=65536
 
 macos_tier_rank() {
     case "$1" in

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -94,6 +94,14 @@ if ! $INTERACTIVE && [[ "$ENABLE_COMFYUI" == "true" ]]; then
     esac
 fi
 
+if [[ "${ENABLE_HERMES:-false}" == "true" && "${DREAM_MODE:-local}" != "cloud" ]]; then
+    HERMES_CONTEXT_SIZE="${HERMES_CONTEXT_SIZE:-131072}"
+    if [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
+        ai_warn "Hermes enabled: increasing llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (128K)."
+        MAX_CONTEXT="$HERMES_CONTEXT_SIZE"
+    fi
+fi
+
 # Sync optional-extension compose state with the ENABLE_* flags — the
 # resolver uses the .disabled convention to exclude services from the compose
 # stack. These mv calls are skipped during --dry-run so the source tree is

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -382,7 +382,7 @@ MODELS_INI_EOF
             _env_file="$INSTALL_DIR/.env"
             if [[ -f "$_env_file" ]]; then
                 _env_patch_ok=true
-                for _key_val in "GGUF_FILE=$GGUF_FILE" "LLM_MODEL=$LLM_MODEL" "MAX_CONTEXT=$MAX_CONTEXT"; do
+                for _key_val in "GGUF_FILE=$GGUF_FILE" "LLM_MODEL=$LLM_MODEL" "MAX_CONTEXT=$MAX_CONTEXT" "CTX_SIZE=$MAX_CONTEXT"; do
                     _key="${_key_val%%=*}"
                     _val="${_key_val#*=}"
                     if awk -v v="$_val" '{ if (index($0, "'"$_key"'=") == 1) print "'"$_key"'=" v; else print }' \
@@ -460,11 +460,24 @@ MODELS_INI_EOF
             # base_url stays at the compose-bridge name for Linux installs.
             # On Linux there's a sibling llama-server container; on macOS
             # the install-macos.sh path handles the host.docker.internal swap.
-            sed -i.bak \
-                -e "s|^  default: \"qwen3.5-9b\"|  default: \"$_hermes_model\"|" \
-                "$_hermes_tpl" 2>>"$LOG_FILE" && rm -f "${_hermes_tpl}.bak"
-            if grep -q "^  default: \"$_hermes_model\"$" "$_hermes_tpl"; then
-                ai_ok "Patched Hermes template: model.default=$_hermes_model"
+            _hermes_context="${MAX_CONTEXT:-131072}"
+            _hermes_patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"
+            _python_cmd="$(ds_detect_python_cmd 2>/dev/null || command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+            if [[ -n "$_python_cmd" && -f "$_hermes_patcher" ]]; then
+                "$_python_cmd" "$_hermes_patcher" "$_hermes_tpl" \
+                    --model "$_hermes_model" \
+                    --context-length "$_hermes_context" >>"$LOG_FILE" 2>&1 || \
+                    warn "Hermes config patcher failed for $_hermes_tpl"
+            else
+                sed -i.bak \
+                    -e "s|^  default: \"qwen3.5-9b\"|  default: \"$_hermes_model\"|" \
+                    -e "s|^  context_length: .*|  context_length: ${_hermes_context}|" \
+                    -e "s|^    context_length: .*|    context_length: ${_hermes_context}|" \
+                    "$_hermes_tpl" 2>>"$LOG_FILE" && rm -f "${_hermes_tpl}.bak"
+            fi
+            if grep -q "^  default: \"$_hermes_model\"$" "$_hermes_tpl" && \
+               grep -q "^  context_length: ${_hermes_context}$" "$_hermes_tpl"; then
+                ai_ok "Patched Hermes template: model.default=$_hermes_model, context=$_hermes_context"
             else
                 warn "Hermes template substitution didn't take effect — Hermes may 404 every chat completion. Hand-edit $_hermes_tpl after install if Hermes prompts hang."
             fi

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -30,6 +30,7 @@
 #   .\install-windows.ps1 --Cloud          # Cloud-only (no local GPU)
 #   .\install-windows.ps1 --DryRun         # Validate without installing
 #   .\install-windows.ps1 --All            # Enable all optional services
+#   .\install-windows.ps1 -NoHermes        # Disable Hermes Agent
 #   .\install-windows.ps1 --NonInteractive # Headless install (defaults)
 #
 # ============================================================================
@@ -43,6 +44,8 @@ param(
     [switch]$Voice,
     [switch]$Workflows,
     [switch]$Rag,
+    [switch]$Hermes,
+    [switch]$NoHermes,
     [switch]$OpenClaw,
     [switch]$All,
     [switch]$Cloud,
@@ -85,6 +88,8 @@ $tierOverride   = $Tier
 $voiceFlag      = $Voice.IsPresent
 $workflowsFlag  = $Workflows.IsPresent
 $ragFlag        = $Rag.IsPresent
+$hermesFlag     = $Hermes.IsPresent
+$noHermesFlag   = $NoHermes.IsPresent
 $openClawFlag   = $OpenClaw.IsPresent
 $allFlag        = $All.IsPresent
 $comfyuiFlag    = $Comfyui.IsPresent
@@ -272,6 +277,26 @@ if ($dryRun) {
                 $envContent = $envContent -replace "(?m)^CTX_SIZE=.*$", "CTX_SIZE=$($tierConfig.MaxContext)"
                 [System.IO.File]::WriteAllText($envPath, $envContent, (New-Object System.Text.UTF8Encoding($false)))
                 Write-AISuccess "Patched .env for bootstrap model ($($tierConfig.GgufFile))"
+            }
+
+            if ($enableHermes) {
+                $hermesModel = $(if ($tierConfig.GgufFile) {
+                    if ($gpuInfo.Backend -eq "amd") { "extra.$($tierConfig.GgufFile)" } else { $tierConfig.GgufFile }
+                } else {
+                    $tierConfig.LlmModel
+                })
+                $hermesBaseUrl = $(if ($gpuInfo.Backend -eq "amd") {
+                    "http://host.docker.internal:8080/api/v1"
+                } elseif ($cloudMode) {
+                    "http://litellm:4000/v1"
+                } else {
+                    "http://llama-server:8080/v1"
+                })
+                $hermesTemplate = Join-Path (Join-Path (Join-Path $installDir "extensions") "services\hermes") "cli-config.yaml.template"
+                $hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
+                Update-HermesConfigFile -Path $hermesTemplate -Model $hermesModel -BaseUrl $hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+                Update-HermesConfigFile -Path $hermesLive -Model $hermesModel -BaseUrl $hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+                Write-AISuccess "Patched Hermes config for bootstrap model (model=$hermesModel, context=$($tierConfig.MaxContext))"
             }
         }
 
@@ -562,6 +587,8 @@ if ($dryRun) {
                     "n8n"        { if (-not $enableWorkflows) { $skip = $true } }
                     "qdrant"     { if (-not $enableRag)       { $skip = $true } }
                     "embeddings" { if (-not $enableRag)       { $skip = $true } }
+                    "hermes"     { if (-not $enableHermes)    { $skip = $true } }
+                    "hermes-proxy" { if (-not $enableHermes)  { $skip = $true } }
                     "openclaw"   { if (-not $enableOpenClaw)  { $skip = $true } }
                     "comfyui"    { if (-not $enableComfyui)   { $skip = $true } }
                     # Paid API extension; users enable it post-install after adding a key.

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -300,6 +300,14 @@ LITELLM_PORT=4000
 OPENCLAW_PORT=7860
 SEARXNG_PORT=8888
 
+#=== Hermes Agent ===
+HERMES_LLM_BASE_URL=$llmApiUrl$llmApiBasePath
+HERMES_LLM_API_KEY=sk-dream-hermes-local
+HERMES_LANGUAGE=en
+HERMES_PROXY_PORT=9120
+HERMES_PROXY_UPSTREAM=dream-hermes:9119
+DREAM_AUTH_UPSTREAM=dream-dashboard-api:3002
+
 #=== Security (auto-generated, keep secret!) ===
 WEBUI_SECRET=$webuiSecret
 DASHBOARD_API_KEY=$dashboardApiKey

--- a/dream-server/installers/windows/lib/tier-map.ps1
+++ b/dream-server/installers/windows/lib/tier-map.ps1
@@ -417,7 +417,9 @@ function ConvertTo-ModelFromTier {
 $script:BOOTSTRAP_GGUF_FILE    = "Qwen3.5-2B-Q4_K_M.gguf"
 $script:BOOTSTRAP_GGUF_URL     = "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
 $script:BOOTSTRAP_LLM_MODEL    = "qwen3.5-2b"
-$script:BOOTSTRAP_MAX_CONTEXT   = 8192
+# Hermes requires at least a 64K context window. Keep the fast-start model at
+# that floor so Hermes works during the first-run bootstrap experience too.
+$script:BOOTSTRAP_MAX_CONTEXT   = 65536
 
 function Get-TierRank {
     param([string]$Tier)

--- a/dream-server/installers/windows/phases/03-features.ps1
+++ b/dream-server/installers/windows/phases/03-features.ps1
@@ -7,7 +7,7 @@
 #
 # Reads:
 #   $voiceFlag, $workflowsFlag, $ragFlag, $openClawFlag, $allFlag
-#   $comfyuiFlag, $noComfyuiFlag
+#   $hermesFlag, $noHermesFlag, $comfyuiFlag, $noComfyuiFlag
 #   $nonInteractive  -- suppress menus (use flag defaults)
 #   $dryRun          -- skip prompts, log only
 #   $selectedTier    -- from phase 02, for tier-appropriate OpenClaw config
@@ -16,6 +16,7 @@
 #   $enableVoice      -- bool: enable Whisper + Kokoro TTS
 #   $enableWorkflows  -- bool: enable n8n workflow automation
 #   $enableRag        -- bool: enable Qdrant + embeddings (RAG)
+#   $enableHermes     -- bool: enable Hermes Agent
 #   $enableOpenClaw   -- bool: enable OpenClaw agent framework
 #   $enableComfyui    -- bool: enable ComfyUI image generation
 #   $openClawConfig   -- string: tier-appropriate OpenClaw config filename
@@ -32,7 +33,9 @@ Write-Phase -Phase 3 -Total 13 -Name "FEATURE SELECTION" -Estimate "interactive"
 $enableVoice      = $voiceFlag -or $allFlag
 $enableWorkflows  = $workflowsFlag -or $allFlag
 $enableRag        = $ragFlag -or $allFlag
-$enableOpenClaw   = $openClawFlag -or $allFlag
+$enableHermes     = (-not $noHermesFlag) -and ($hermesFlag -or $allFlag -or (-not $nonInteractive))
+if ($nonInteractive -and -not $noHermesFlag) { $enableHermes = $true }
+$enableOpenClaw   = $openClawFlag
 $enableComfyui    = -not $noComfyuiFlag
 # Langfuse defaults OFF on all tiers because its clickhouse + postgres + minio
 # stack adds ~500MB baseline memory. Opt in via -Langfuse, -All, the Custom
@@ -45,7 +48,7 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
     Write-Host ""
     Write-Host "  Choose your Dream Server configuration:" -ForegroundColor White
     Write-Host ""
-    Write-Host "  [1] Full Stack   -- Voice + Workflows + RAG + Agents (everything)" -ForegroundColor Green
+    Write-Host "  [1] Full Stack   -- Hermes + Voice + Workflows + RAG + image generation" -ForegroundColor Green
     Write-Host "  [2] Core Only    -- Chat + LLM inference (lean, fastest startup)" -ForegroundColor White
     Write-Host "  [3] Custom       -- Choose each feature individually" -ForegroundColor White
     Write-Host ""
@@ -56,6 +59,7 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
             $enableVoice     = $false
             $enableWorkflows = $false
             $enableRag       = $false
+            $enableHermes    = $false
             $enableOpenClaw  = $false
             $enableComfyui   = $false
             $enableLangfuse  = $false
@@ -65,7 +69,8 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
             $enableVoice     = (Read-Host "  Enable Voice (Whisper STT + Kokoro TTS)?  [y/N]") -match "^[yY]"
             $enableWorkflows = (Read-Host "  Enable Workflows (n8n, 400+ integrations)? [y/N]") -match "^[yY]"
             $enableRag       = (Read-Host "  Enable RAG (Qdrant vector DB + embeddings)? [y/N]") -match "^[yY]"
-            $enableOpenClaw  = (Read-Host "  Enable OpenClaw (autonomous AI agents)?    [y/N]") -match "^[yY]"
+            $enableHermes    = (Read-Host "  Enable Hermes Agent (default AI agent)? [Y/n]") -notmatch "^[nN]"
+            $enableOpenClaw  = (Read-Host "  Enable OpenClaw (DEPRECATED; Hermes replaces it)? [y/N]") -match "^[yY]"
             $enableComfyui   = (Read-Host "  Enable image generation (ComfyUI + SDXL Lightning, ~6.5GB)? [y/N]") -match "^[yY]"
             $enableLangfuse  = (Read-Host "  Enable Langfuse (LLM observability, ~500MB)? [y/N]") -match "^[yY]"
 
@@ -80,7 +85,8 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
             $enableVoice     = $true
             $enableWorkflows = $true
             $enableRag       = $true
-            $enableOpenClaw  = $true
+            $enableHermes    = $true
+            $enableOpenClaw  = $false
             $enableComfyui   = $true
             $enableLangfuse  = $true
 
@@ -92,6 +98,10 @@ if (-not $nonInteractive -and -not $allFlag -and -not $dryRun) {
             }
         }
     }
+}
+
+if ($noHermesFlag) {
+    $enableHermes = $false
 }
 
 # Tier safety net: disable ComfyUI on Tier 0/1 or CLOUD in non-interactive mode.
@@ -107,12 +117,21 @@ if ($enableComfyui -and $selectedTier -eq "CLOUD") {
     Write-AIWarn "ComfyUI disabled for CLOUD tier (requires local GPU for image generation)"
 }
 
+if ($enableHermes -and -not $cloudMode) {
+    $hermesContextSize = 131072
+    if ([int]$tierConfig.MaxContext -lt $hermesContextSize) {
+        Write-AIWarn "Hermes enabled: increasing llama context from $($tierConfig.MaxContext) to $hermesContextSize (128K)."
+        $tierConfig.MaxContext = $hermesContextSize
+    }
+}
+
 # ── Feature summary ───────────────────────────────────────────────────────────
 Write-Host ""
 Write-AI "Feature configuration:"
 Write-InfoBox "  Voice (Whisper + Kokoro):" $(if ($enableVoice)     { "enabled" } else { "disabled" })
 Write-InfoBox "  Workflows (n8n):"          $(if ($enableWorkflows) { "enabled" } else { "disabled" })
 Write-InfoBox "  RAG (Qdrant + embeddings):" $(if ($enableRag)      { "enabled" } else { "disabled" })
+Write-InfoBox "  Hermes Agent:"              $(if ($enableHermes)   { "enabled" } else { "disabled" })
 Write-InfoBox "  Agents (OpenClaw):"         $(if ($enableOpenClaw) { "enabled" } else { "disabled" })
 Write-InfoBox "  Image gen (ComfyUI):"        $(if ($enableComfyui)  { "enabled" } else { "disabled" })
 Write-InfoBox "  Langfuse (observability):"   $(if ($enableLangfuse) { "enabled" } else { "disabled" })

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -62,7 +62,10 @@ $_dirs = @(
     (Join-Path $_dataDir "qdrant"),
     (Join-Path $_dataDir "models"),
     (Join-Path $_dataDir "comfyui"),
-    (Join-Path $_dataDir "perplexica")
+    (Join-Path $_dataDir "perplexica"),
+    (Join-Path $_dataDir "hermes"),
+    (Join-Path $_dataDir "hermes-proxy\caddy-data"),
+    (Join-Path $_dataDir "hermes-proxy\caddy-config")
 )
 foreach ($_d in $_dirs) {
     New-Item -ItemType Directory -Path $_d -Force | Out-Null
@@ -163,6 +166,76 @@ if ($_missingKeys.Count -gt 0) {
     exit 1
 }
 Write-AISuccess "Verified .env contains all required secrets"
+
+function Update-HermesConfigFile {
+    param(
+        [string]$Path,
+        [string]$Model,
+        [string]$BaseUrl,
+        [int]$ContextLength
+    )
+
+    if (-not (Test-Path $Path)) { return }
+
+    $content = Get-Content $Path -Raw
+    $content = $content -replace '(?m)^  default: ".*"$', "  default: `"$Model`""
+    $content = $content -replace '(?m)^  base_url: ".*"$', "  base_url: `"$BaseUrl`""
+    $content = $content -replace '(?m)^  context_length: .+$', "  context_length: $ContextLength"
+    $content = $content -replace '(?m)^    context_length: .+$', "    context_length: $ContextLength"
+
+    if ($content -notmatch '(?m)^auxiliary:\s*$') {
+        if ($content -match '(?m)^terminal:\s*$') {
+            $content = $content -replace '(?m)^terminal:\s*$', "auxiliary:`n  compression:`n    context_length: $ContextLength`n`nterminal:"
+        } else {
+            $content += "`nauxiliary:`n  compression:`n    context_length: $ContextLength`n"
+        }
+    } elseif ($content -notmatch '(?m)^  compression:\s*$') {
+        $content = $content -replace '(?m)^auxiliary:\s*$', "auxiliary:`n  compression:`n    context_length: $ContextLength"
+    }
+
+    if ($content -notmatch '(?m)^compression:\s*$') {
+        $content += "`ncompression:`n  enabled: true`n  threshold: 0.50`n  target_ratio: 0.20`n  protect_last_n: 20`n"
+    } else {
+        if ($content -notmatch '(?m)^  enabled:') {
+            $content = $content -replace '(?m)^compression:\s*$', "compression:`n  enabled: true"
+        }
+        if ($content -match '(?m)^  threshold:') {
+            $content = $content -replace '(?m)^  threshold: .+$', "  threshold: 0.50"
+        } else {
+            $content = $content -replace '(?m)^compression:\s*$', "compression:`n  threshold: 0.50"
+        }
+        if ($content -match '(?m)^  target_ratio:') {
+            $content = $content -replace '(?m)^  target_ratio: .+$', "  target_ratio: 0.20"
+        } else {
+            $content = $content -replace '(?m)^compression:\s*$', "compression:`n  target_ratio: 0.20"
+        }
+        if ($content -notmatch '(?m)^  protect_last_n:') {
+            $content = $content -replace '(?m)^compression:\s*$', "compression:`n  protect_last_n: 20"
+        }
+    }
+
+    Write-Utf8NoBom -Path $Path -Content $content
+}
+
+if ($enableHermes) {
+    $_hermesModel = $(if ($tierConfig.GgufFile) {
+        if ($gpuInfo.Backend -eq "amd") { "extra.$($tierConfig.GgufFile)" } else { $tierConfig.GgufFile }
+    } else {
+        $tierConfig.LlmModel
+    })
+    $_hermesBaseUrl = $(if ($gpuInfo.Backend -eq "amd") {
+        "http://host.docker.internal:8080/api/v1"
+    } elseif ($cloudMode) {
+        "http://litellm:4000/v1"
+    } else {
+        "http://llama-server:8080/v1"
+    })
+    $_hermesTemplate = Join-Path (Join-Path (Join-Path $installDir "extensions") "services\hermes") "cli-config.yaml.template"
+    $_hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
+    Update-HermesConfigFile -Path $_hermesTemplate -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+    Update-HermesConfigFile -Path $_hermesLive -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+    Write-AISuccess "Patched Hermes config (model=$_hermesModel, context=$($tierConfig.MaxContext))"
+}
 
 # ── Generate SearXNG config ───────────────────────────────────────────────────
 $_searxngPath = New-SearxngConfig -InstallDir $installDir -SecretKey $envResult.SearxngSecret

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -550,8 +550,18 @@ LITELLM_UPGRADE_EOF
         # bootstrap model id.
         _hermes_tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
         if [[ -f "$_hermes_tpl" ]]; then
-            if sed -i.bak \
+            _hermes_patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"
+            _python_cmd="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+            if [[ -n "$_python_cmd" && -f "$_hermes_patcher" ]]; then
+                if ! "$_python_cmd" "$_hermes_patcher" "$_hermes_tpl" \
+                    --model "$_hermes_new_model" \
+                    --context-length "$FULL_MAX_CONTEXT" 2>&1; then
+                    log "WARNING: Could not patch ${_hermes_tpl} with patch-hermes-config.py (non-fatal — operator can hand-edit before restarting Hermes)"
+                fi
+            elif sed -i.bak \
                 -e "s|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|" \
+                -e "s|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|" \
+                -e "s|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|" \
                 "$_hermes_tpl" 2>&1; then
                 rm -f "${_hermes_tpl}.bak"
             else
@@ -562,7 +572,7 @@ LITELLM_UPGRADE_EOF
         if $DOCKER_CMD ps --filter name=dream-hermes --format '{{.Names}}' 2>/dev/null | grep -q dream-hermes; then
             # Live config inside the running container (owned by container UID).
             $DOCKER_CMD exec dream-hermes sh -c \
-                "sed -i 's|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|' /opt/data/config.yaml" 2>&1 || \
+                "sed -i -e 's|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|' -e 's|^  threshold: .*|  threshold: 0.50|' -e 's|^  target_ratio: .*|  target_ratio: 0.20|' /opt/data/config.yaml" 2>&1 || \
                 log "WARNING: Could not patch Hermes /opt/data/config.yaml (non-fatal — operator can hand-edit and 'docker restart dream-hermes')"
             log "Restarting Hermes to pick up model change..."
             $DOCKER_CMD restart dream-hermes 2>&1 || log "WARNING: Hermes restart failed (non-fatal — hand-restart with 'docker restart dream-hermes')"
@@ -633,8 +643,16 @@ LITELLM_UPGRADE_EOF
             # update above still protects first-time/fresh data starts.
             _hermes_live="$INSTALL_DIR/data/hermes/config.yaml"
             if [[ -f "$_hermes_live" ]]; then
-                if sed -i.bak \
+                if [[ -n "${_python_cmd:-}" && -f "${_hermes_patcher:-}" ]]; then
+                    if ! "$_python_cmd" "$_hermes_patcher" "$_hermes_live" \
+                        --model "$_hermes_new_model" \
+                        --context-length "$FULL_MAX_CONTEXT" 2>&1; then
+                        log "WARNING: Could not patch ${_hermes_live} with patch-hermes-config.py (non-fatal — operator can hand-edit and restart Hermes)"
+                    fi
+                elif sed -i.bak \
                     -e "s|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|" \
+                    -e "s|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|" \
+                    -e "s|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|" \
                     "$_hermes_live" 2>&1; then
                     rm -f "${_hermes_live}.bak"
                 else

--- a/dream-server/scripts/patch-hermes-config.py
+++ b/dream-server/scripts/patch-hermes-config.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Patch Dream Server's Hermes config without clobbering user sections.
+
+Hermes copies extensions/services/hermes/cli-config.yaml.template to
+data/hermes/config.yaml only on first start. Installer migrations need to
+repair the small set of Dream-managed defaults in both files while preserving
+the rest of the user's config.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+
+def _top_level_block(lines: list[str], name: str) -> tuple[int, int] | None:
+    start = None
+    pattern = re.compile(rf"^{re.escape(name)}:\s*(?:#.*)?$")
+    for idx, line in enumerate(lines):
+        if start is None:
+            if pattern.match(line):
+                start = idx
+            continue
+        if line and not line.startswith((" ", "\t")) and not line.lstrip().startswith("#"):
+            return start, idx
+    if start is None:
+        return None
+    return start, len(lines)
+
+
+def _child_block(lines: list[str], parent: tuple[int, int], name: str, indent: int) -> tuple[int, int] | None:
+    start = None
+    prefix = " " * indent
+    pattern = re.compile(rf"^{prefix}{re.escape(name)}:\s*(?:#.*)?$")
+    for idx in range(parent[0] + 1, parent[1]):
+        line = lines[idx]
+        if start is None:
+            if pattern.match(line):
+                start = idx
+            continue
+        if line.startswith(prefix) and line.strip() and not line.startswith(prefix + " ") and not line.lstrip().startswith("#"):
+            return start, idx
+    if start is None:
+        return None
+    return start, parent[1]
+
+
+def _set_key(lines: list[str], block: tuple[int, int], key: str, value: str, indent: int) -> tuple[int, int]:
+    prefix = " " * indent
+    pattern = re.compile(rf"^{prefix}{re.escape(key)}:\s*.*$")
+    for idx in range(block[0] + 1, block[1]):
+        if pattern.match(lines[idx]):
+            lines[idx] = f"{prefix}{key}: {value}"
+            return block
+
+    insert_at = block[1]
+    lines.insert(insert_at, f"{prefix}{key}: {value}")
+    return block[0], block[1] + 1
+
+
+def _ensure_model(lines: list[str], model: str | None, base_url: str | None, context_length: int | None) -> None:
+    block = _top_level_block(lines, "model")
+    if block is None:
+        insert = ["model:"]
+        if model:
+            insert.append(f'  default: "{model}"')
+        if base_url:
+            insert.append('  provider: "custom"')
+            insert.append(f'  base_url: "{base_url}"')
+        if context_length:
+            insert.append(f"  context_length: {context_length}")
+        lines[:0] = insert + [""]
+        return
+
+    if model:
+        block = _set_key(lines, block, "default", f'"{model}"', 2)
+    if base_url:
+        block = _set_key(lines, block, "base_url", f'"{base_url}"', 2)
+    if context_length:
+        _set_key(lines, block, "context_length", str(context_length), 2)
+
+
+def _ensure_auxiliary(lines: list[str], context_length: int | None) -> None:
+    if not context_length:
+        return
+
+    block = _top_level_block(lines, "auxiliary")
+    if block is None:
+        terminal = _top_level_block(lines, "terminal")
+        insert_at = terminal[0] if terminal else len(lines)
+        payload = [
+            "auxiliary:",
+            "  compression:",
+            f"    context_length: {context_length}",
+            "",
+        ]
+        lines[insert_at:insert_at] = payload
+        return
+
+    compression = _child_block(lines, block, "compression", 2)
+    if compression is None:
+        insert_at = block[1]
+        lines[insert_at:insert_at] = [
+            "  compression:",
+            f"    context_length: {context_length}",
+        ]
+        return
+
+    _set_key(lines, compression, "context_length", str(context_length), 4)
+
+
+def _ensure_compression(lines: list[str]) -> None:
+    block = _top_level_block(lines, "compression")
+    if block is None:
+        lines.extend(
+            [
+                "",
+                "compression:",
+                "  enabled: true",
+                "  threshold: 0.50",
+                "  target_ratio: 0.20",
+                "  protect_last_n: 20",
+            ]
+        )
+        return
+
+    block = _set_key(lines, block, "enabled", "true", 2)
+    block = _set_key(lines, block, "threshold", "0.50", 2)
+    block = _set_key(lines, block, "target_ratio", "0.20", 2)
+    _set_key(lines, block, "protect_last_n", "20", 2)
+
+
+def patch_config(path: Path, model: str | None, base_url: str | None, context_length: int | None) -> bool:
+    original = path.read_text(encoding="utf-8")
+    trailing_newline = original.endswith("\n")
+    lines = original.splitlines()
+
+    _ensure_model(lines, model, base_url, context_length)
+    _ensure_auxiliary(lines, context_length)
+    _ensure_compression(lines)
+
+    updated = "\n".join(lines)
+    if trailing_newline:
+        updated += "\n"
+    if updated == original:
+        return False
+    path.write_text(updated, encoding="utf-8")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Patch Dream Server Hermes config defaults.")
+    parser.add_argument("path", type=Path)
+    parser.add_argument("--model")
+    parser.add_argument("--base-url")
+    parser.add_argument("--context-length", type=int)
+    args = parser.parse_args()
+
+    if not args.path.exists():
+        return 0
+    changed = patch_config(args.path, args.model, args.base_url, args.context_length)
+    print("changed" if changed else "unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dream-server/tests/bats-tests/bootstrap-model.bats
+++ b/dream-server/tests/bats-tests/bootstrap-model.bats
@@ -108,7 +108,7 @@ setup() {
     [[ -n "$BOOTSTRAP_LLM_MODEL" ]]
 }
 
-@test "BOOTSTRAP_MAX_CONTEXT: is a positive integer" {
+@test "BOOTSTRAP_MAX_CONTEXT: meets Hermes 64K floor" {
     [[ "$BOOTSTRAP_MAX_CONTEXT" =~ ^[0-9]+$ ]]
-    [[ "$BOOTSTRAP_MAX_CONTEXT" -gt 0 ]]
+    [[ "$BOOTSTRAP_MAX_CONTEXT" -ge 64000 ]]
 }

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -124,4 +124,54 @@ grep -q "python3 -c 'import yaml'" installers/macos/install-macos.sh \
 grep -q 'python3 -m pip install --user .*pyyaml' installers/macos/install-macos.sh \
   || { echo "[FAIL] macOS installer must install PyYAML via python3 -m pip, not a possibly unrelated pip3"; exit 1; }
 
+echo "[contract] Hermes context defaults are installer-wide"
+grep -q '^BOOTSTRAP_MAX_CONTEXT=65536$' installers/lib/bootstrap-model.sh \
+  || { echo "[FAIL] Linux bootstrap context must meet Hermes 64K floor"; exit 1; }
+grep -q '^BOOTSTRAP_MAX_CONTEXT=65536$' installers/macos/lib/tier-map.sh \
+  || { echo "[FAIL] macOS bootstrap context must meet Hermes 64K floor"; exit 1; }
+grep -q 'BOOTSTRAP_MAX_CONTEXT.*65536' installers/windows/lib/tier-map.ps1 \
+  || { echo "[FAIL] Windows bootstrap context must meet Hermes 64K floor"; exit 1; }
+grep -q '"CTX_SIZE=$MAX_CONTEXT"' installers/phases/11-services.sh \
+  || { echo "[FAIL] Linux bootstrap .env patch must update CTX_SIZE as well as MAX_CONTEXT"; exit 1; }
+grep -q 'Patched Hermes config for bootstrap model' installers/windows/install-windows.ps1 \
+  || { echo "[FAIL] Windows bootstrap path must re-patch Hermes config after switching to bootstrap model"; exit 1; }
+grep -q 'threshold: 0.50' extensions/services/hermes/cli-config.yaml.template \
+  || { echo "[FAIL] Hermes compression threshold must use upstream fractional semantics"; exit 1; }
+
+python_cmd="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+test -n "$python_cmd" || { echo "[FAIL] python is required to test Hermes config patcher"; exit 1; }
+tmp_hermes="$(mktemp)"
+cat > "$tmp_hermes" <<'HERMES_EOF'
+model:
+  default: "old-model"
+  provider: "custom"
+  base_url: "http://old.example/v1"
+  context_length: 8192
+
+compression:
+  threshold: 10000
+  target_ratio: 0.5
+terminal:
+  backend: "local"
+HERMES_EOF
+"$python_cmd" scripts/patch-hermes-config.py "$tmp_hermes" \
+  --model "Qwen3.5-2B-Q4_K_M.gguf" \
+  --base-url "http://llama-server:8080/v1" \
+  --context-length 65536 >/dev/null
+grep -q 'default: "Qwen3.5-2B-Q4_K_M.gguf"' "$tmp_hermes" \
+  || { echo "[FAIL] Hermes patcher did not update model.default"; rm -f "$tmp_hermes"; exit 1; }
+grep -q 'base_url: "http://llama-server:8080/v1"' "$tmp_hermes" \
+  || { echo "[FAIL] Hermes patcher did not update base_url"; rm -f "$tmp_hermes"; exit 1; }
+grep -q '^  context_length: 65536$' "$tmp_hermes" \
+  || { echo "[FAIL] Hermes patcher did not update model.context_length"; rm -f "$tmp_hermes"; exit 1; }
+grep -q '^    context_length: 65536$' "$tmp_hermes" \
+  || { echo "[FAIL] Hermes patcher did not add auxiliary compression context"; rm -f "$tmp_hermes"; exit 1; }
+grep -q '^  threshold: 0.50$' "$tmp_hermes" \
+  || { echo "[FAIL] Hermes patcher did not normalize compression threshold"; rm -f "$tmp_hermes"; exit 1; }
+grep -q '^  target_ratio: 0.20$' "$tmp_hermes" \
+  || { echo "[FAIL] Hermes patcher did not normalize compression target_ratio"; rm -f "$tmp_hermes"; exit 1; }
+grep -q '^  protect_last_n: 20$' "$tmp_hermes" \
+  || { echo "[FAIL] Hermes patcher did not add protect_last_n"; rm -f "$tmp_hermes"; exit 1; }
+rm -f "$tmp_hermes"
+
 echo "[PASS] installer contracts"


### PR DESCRIPTION
## Summary

- Raise Hermes-enabled local installs to a 128K full-model context on Linux, macOS, and Windows.
- Keep bootstrap mode enabled by moving the bootstrap model context floor to 64K so Hermes works during the first-run experience.
- Patch Hermes template/live configs for model name, base URL, context length, and current upstream compression settings.
- Add Windows Hermes installer parity (`-Hermes` / `-NoHermes`), data dirs, env keys, and bootstrap re-patching.
- Document the 64K bootstrap / 128K full-context behavior and add installer contract coverage.

## Validation

- `python -m py_compile dream-server/scripts/patch-hermes-config.py`
- PowerShell parse checks for modified Windows installer files
- Git Bash `bash -n` on modified shell scripts and installer contract script
- `git diff --check`
- Hermes-specific contract checks run directly

## Not run

- Full `dream-server/tests/contracts/test-installer-contracts.sh` because this Windows workspace is missing `jq`.
- BATS suite because `bats` is not installed in this workspace.