### PR TITLE
Fix Windows voice diagnostics and Tailscale status

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -1155,18 +1155,92 @@ class AgentHandler(BaseHTTPRequestHandler):
         else:
             json_response(self, 404, {"error": "Not found"})
 
+    def _write_tailscale_status_payload(self, payload: dict, source: str):
+        """Distill `tailscale status --json` into the dashboard response."""
+        self_node = payload.get("Self", {}) or {}
+        magic_dns = payload.get("MagicDNSSuffix") or ""
+        dns_name = self_node.get("DNSName", "").rstrip(".") or None
+        tailnet = payload.get("CurrentTailnet")
+        tailnet_name = (
+            tailnet.get("Name") if isinstance(tailnet, dict) else None
+        )
+        json_response(self, 200, {
+            "running": True,
+            "authenticated": payload.get("BackendState") == "Running",
+            "backend_state": payload.get("BackendState"),
+            "source": source,
+            "self": {
+                "hostname": self_node.get("HostName"),
+                "dns_name": dns_name,
+                "ips": self_node.get("TailscaleIPs", []),
+                "online": self_node.get("Online", False),
+            },
+            "magic_dns_suffix": magic_dns,
+            "tailnet_name": tailnet_name,
+        })
+
+    def _find_native_tailscale_cli(self) -> str | None:
+        """Return a host-native tailscale CLI path if one is installed."""
+        tailscale = shutil.which("tailscale")
+        if tailscale:
+            return tailscale
+        if platform.system() == "Windows":
+            for base in (
+                os.environ.get("ProgramFiles"),
+                os.environ.get("ProgramFiles(x86)"),
+            ):
+                if not base:
+                    continue
+                candidate = Path(base) / "Tailscale" / "tailscale.exe"
+                if candidate.exists():
+                    return str(candidate)
+        return None
+
+    def _try_native_tailscale_status(self) -> bool:
+        """Return True after writing a response from host-native Tailscale."""
+        tailscale = self._find_native_tailscale_cli()
+        if not tailscale:
+            return False
+        try:
+            result = subprocess.run(
+                [tailscale, "status", "--json"],
+                capture_output=True, text=True, timeout=10,
+            )
+        except (subprocess.TimeoutExpired, OSError):
+            return False
+
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            lowered = stderr.lower()
+            if "logged out" in lowered or "needs login" in lowered:
+                json_response(self, 200, {
+                    "running": True,
+                    "authenticated": False,
+                    "source": "native",
+                    "reason": "Native Tailscale is installed but not authenticated.",
+                })
+                return True
+            return False
+
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return False
+
+        self._write_tailscale_status_payload(payload, "native")
+        return True
+
     def _handle_tailscale_status(self):
-        """Return Tailscale daemon status by docker-exec'ing into the
-        dream-tailscale container.
+        """Return Tailscale daemon status from Dream's container or the host.
 
         Three outcome shapes:
-          1. Container running AND authenticated:
+          1. Tailscale running AND authenticated:
              {running:true, authenticated:true, self:{...},
-              magic_dns_suffix:"tail-xxxxx.ts.net", ...}
-          2. Container running but not authenticated (auth key absent
-             or rejected):
+              magic_dns_suffix:"tail-xxxxx.ts.net", source:"..."}
+          2. Tailscale running but not authenticated (auth key absent,
+             rejected, or host app logged out):
              {running:true, authenticated:false, reason:"..."}
-          3. Container not running:
+          3. Dream container and host-native Tailscale are not running:
              {running:false}
 
         We never return 5xx for "container not running" — that's a normal
@@ -1190,8 +1264,13 @@ class AgentHandler(BaseHTTPRequestHandler):
         if result.returncode != 0:
             stderr = (result.stderr or "").strip()
             lowered = stderr.lower()
-            # Container not running -> normal "not enabled yet" state.
+            # Container not running -> try host-native Tailscale first. This
+            # covers Windows/macOS installs where users already run Tailscale
+            # outside Docker; absent both, it remains a normal "not enabled
+            # yet" state.
             if "no such container" in lowered or "is not running" in lowered:
+                if self._try_native_tailscale_status():
+                    return
                 json_response(self, 200, {"running": False})
                 return
             # Container up but daemon not yet authed.
@@ -1215,28 +1294,7 @@ class AgentHandler(BaseHTTPRequestHandler):
             json_response(self, 500, {"error": f"could not parse tailscale status: {exc}"})
             return
 
-        # Distill the chunky `tailscale status --json` blob to what the
-        # dashboard actually needs.
-        self_node = payload.get("Self", {}) or {}
-        magic_dns = payload.get("MagicDNSSuffix") or ""
-        dns_name = self_node.get("DNSName", "").rstrip(".") or None
-        tailnet = payload.get("CurrentTailnet")
-        tailnet_name = (
-            tailnet.get("Name") if isinstance(tailnet, dict) else None
-        )
-        json_response(self, 200, {
-            "running": True,
-            "authenticated": payload.get("BackendState") == "Running",
-            "backend_state": payload.get("BackendState"),
-            "self": {
-                "hostname": self_node.get("HostName"),
-                "dns_name": dns_name,
-                "ips": self_node.get("TailscaleIPs", []),
-                "online": self_node.get("Online", False),
-            },
-            "magic_dns_suffix": magic_dns,
-            "tailnet_name": tailnet_name,
-        })
+        self._write_tailscale_status_payload(payload, "container")
 
     def _handle_ap_mode_status(self):
         """Read-only AP-mode status snapshot.

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -129,6 +129,7 @@ def load_extension_manifests(
                     "container_name": service.get("container_name", f"dream-{service_id}"),
                     "depends_on": service.get("depends_on", []),
                     "category": service.get("category", "optional"),
+                    "host_network": bool(service.get("host_network", False)),
                     "setup_hook": service.get("setup_hook", ""),
                     "hooks": service.get("hooks", {}),
                     "gpu_backends": service.get("gpu_backends", []),

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -14,7 +14,7 @@ from typing import Optional
 import aiohttp
 import httpx
 
-from config import SERVICES, INSTALL_DIR, DATA_DIR, LLM_BACKEND
+from config import SERVICES, INSTALL_DIR, DATA_DIR, LLM_BACKEND, AGENT_URL, DREAM_AGENT_KEY
 from models import ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus
 
 
@@ -79,6 +79,38 @@ async def _get_httpx_client() -> httpx.AsyncClient:
     if _httpx_client is None or _httpx_client.is_closed:
         _httpx_client = httpx.AsyncClient(timeout=5.0)
     return _httpx_client
+
+
+def _service_status_from_config(service_id: str, config: dict, status: str) -> ServiceStatus:
+    return ServiceStatus(
+        id=service_id, name=config["name"], port=config["port"],
+        external_port=config.get("external_port", config["port"]),
+        status=status, response_time_ms=None,
+    )
+
+
+async def _check_tailscale_health(service_id: str, config: dict) -> ServiceStatus:
+    """Map the host-agent Tailscale snapshot into a service health status.
+
+    Tailscale has no HTTP port to poll. Treat an absent container as
+    not_deployed so the optional Remote Access feature does not make a fresh
+    local install look degraded.
+    """
+    try:
+        client = await _get_httpx_client()
+        headers = {"Authorization": f"Bearer {DREAM_AGENT_KEY}"} if DREAM_AGENT_KEY else {}
+        resp = await client.get(f"{AGENT_URL}/v1/tailscale/status", headers=headers)
+        if resp.status_code >= 500:
+            return _service_status_from_config(service_id, config, "not_deployed")
+        payload = resp.json()
+    except (httpx.HTTPError, httpx.TimeoutException, ValueError, OSError):
+        return _service_status_from_config(service_id, config, "not_deployed")
+
+    if not payload.get("running"):
+        return _service_status_from_config(service_id, config, "not_deployed")
+    if payload.get("authenticated"):
+        return _service_status_from_config(service_id, config, "healthy")
+    return _service_status_from_config(service_id, config, "unhealthy")
 
 
 # --- Token Tracking ---
@@ -250,11 +282,12 @@ async def check_service_health(
         # Host-systemd services bind to 127.0.0.1 and are unreachable from
         # inside Docker.  The installer manages them via systemd (auto-restart
         # on failure), so treat them as healthy when configured.
-        return ServiceStatus(
-            id=service_id, name=config["name"], port=config["port"],
-            external_port=config.get("external_port", config["port"]),
-            status="healthy", response_time_ms=None,
-        )
+        return _service_status_from_config(service_id, config, "healthy")
+
+    if config.get("host_network") and int(config.get("port") or 0) <= 0:
+        if service_id == "tailscale":
+            return await _check_tailscale_health(service_id, config)
+        return _service_status_from_config(service_id, config, "not_deployed")
 
     host = config.get('host', 'localhost')
     health_port = config.get('health_port', config['port'])

--- a/dream-server/extensions/services/dashboard-api/routers/tailscale.py
+++ b/dream-server/extensions/services/dashboard-api/routers/tailscale.py
@@ -1,8 +1,9 @@
 """Tailscale (remote access) — dashboard-api proxy in front of the host-agent.
 
-The host-agent has /v1/tailscale/status, which docker-exec's into the
-dream-tailscale container to query the daemon. This module exposes that
-to the dashboard UI via /api/tailscale/status.
+The host-agent has /v1/tailscale/status, which queries the dream-tailscale
+container or falls back to host-native Tailscale when the container is not
+running. This module exposes that to the dashboard UI via
+/api/tailscale/status.
 
 For the typical lifecycle the operator runs:
   1. Generate an auth key at https://login.tailscale.com/admin/settings/keys

--- a/dream-server/extensions/services/dashboard-api/tests/test_config.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_config.py
@@ -129,6 +129,22 @@ class TestLoadExtensionManifests:
         assert services["internal-service"]["port"] == 9119
         assert services["internal-service"]["external_port"] == 0
 
+    def test_preserves_host_network_flag(self, tmp_path):
+        svc_dir = tmp_path / "host-network-service"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n"
+            "  id: host-network-service\n"
+            "  name: Host Network Service\n"
+            "  host_network: true\n"
+            "  port: 0\n"
+        )
+
+        services, _, _ = load_extension_manifests(tmp_path, "nvidia")
+
+        assert services["host-network-service"]["host_network"] is True
+
     def test_skips_wrong_schema_version(self, tmp_path):
         svc_dir = tmp_path / "old-service"
         svc_dir.mkdir()

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -355,6 +355,60 @@ class TestCheckServiceHealth:
         result = await check_service_health("test-svc", self._CONFIG)
         assert result.status == "down"
 
+    @pytest.mark.asyncio
+    async def test_host_network_portless_service_is_not_deployed(self):
+        config = {
+            "name": "Portless",
+            "port": 0,
+            "external_port": 0,
+            "health": "/health",
+            "host": "localhost",
+            "host_network": True,
+        }
+
+        result = await check_service_health("portless", config)
+        assert result.status == "not_deployed"
+
+    @pytest.mark.asyncio
+    async def test_tailscale_not_running_is_not_deployed(self, monkeypatch):
+        config = {
+            "name": "Tailscale",
+            "port": 0,
+            "external_port": 0,
+            "health": "/health",
+            "host": "localhost",
+            "host_network": True,
+        }
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"running": False}
+        client = MagicMock()
+        client.get = AsyncMock(return_value=response)
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=client))
+
+        result = await check_service_health("tailscale", config)
+        assert result.status == "not_deployed"
+
+    @pytest.mark.asyncio
+    async def test_tailscale_authenticated_is_healthy(self, monkeypatch):
+        config = {
+            "name": "Tailscale",
+            "port": 0,
+            "external_port": 0,
+            "health": "/health",
+            "host": "localhost",
+            "host_network": True,
+        }
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"running": True, "authenticated": True}
+        client = MagicMock()
+        client.get = AsyncMock(return_value=response)
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=client))
+
+        result = await check_service_health("tailscale", config)
+        assert result.status == "healthy"
+
 
 # --- get_all_services ---
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1221,6 +1221,74 @@ class _FakeHandler:
         return json.loads(self.wfile.getvalue().decode("utf-8"))
 
 
+class TestTailscaleStatus:
+    """Direct host-agent tests for /v1/tailscale/status behavior."""
+
+    @pytest.fixture(autouse=True)
+    def _auth(self, monkeypatch):
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+
+    def _handler(self):
+        handler = _FakeHandler(b"")
+        handler._write_tailscale_status_payload = types.MethodType(
+            _mod.AgentHandler._write_tailscale_status_payload, handler
+        )
+        handler._find_native_tailscale_cli = types.MethodType(
+            _mod.AgentHandler._find_native_tailscale_cli, handler
+        )
+        handler._try_native_tailscale_status = types.MethodType(
+            _mod.AgentHandler._try_native_tailscale_status, handler
+        )
+        return handler
+
+    def test_falls_back_to_native_tailscale_when_container_absent(self, monkeypatch):
+        payload = {
+            "BackendState": "Running",
+            "Self": {
+                "HostName": "dream-win",
+                "DNSName": "dream-win.tail-example.ts.net.",
+                "TailscaleIPs": ["100.64.0.42"],
+                "Online": True,
+            },
+            "MagicDNSSuffix": "tail-example.ts.net",
+            "CurrentTailnet": {"Name": "example.com"},
+        }
+
+        def fake_run(cmd, *args, **kwargs):
+            if cmd[:2] == ["docker", "exec"]:
+                return subprocess.CompletedProcess(cmd, 1, "", "No such container: dream-tailscale")
+            if cmd[:3] == ["tailscale", "status", "--json"]:
+                return subprocess.CompletedProcess(cmd, 0, json.dumps(payload), "")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        monkeypatch.setattr(_mod.shutil, "which", lambda name: "tailscale" if name == "tailscale" else None)
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        handler = self._handler()
+        _mod.AgentHandler._handle_tailscale_status(handler)
+        body = handler.parse_response()
+
+        assert handler.response_code == 200
+        assert body["running"] is True
+        assert body["authenticated"] is True
+        assert body["source"] == "native"
+        assert body["self"]["dns_name"] == "dream-win.tail-example.ts.net"
+
+    def test_absent_container_without_native_tailscale_is_not_running(self, monkeypatch):
+        def fake_run(cmd, *args, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, "", "No such container: dream-tailscale")
+
+        monkeypatch.setattr(_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        handler = self._handler()
+        _mod.AgentHandler._handle_tailscale_status(handler)
+        body = handler.parse_response()
+
+        assert handler.response_code == 200
+        assert body == {"running": False}
+
+
 class TestServiceRestart:
     """Direct host-agent tests for POST /v1/service/restart behavior."""
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_tailscale.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_tailscale.py
@@ -4,9 +4,8 @@ Tailscale status endpoint.
 Mocked surfaces:
   * urllib.request.urlopen — stand-in for the host-agent HTTP call.
 
-The actual `docker exec tailscale status --json` behavior is covered at
-the host-agent layer and not reproducible without a running Tailscale
-container.
+The actual container/native `tailscale status --json` behavior lives at the
+host-agent layer and is not reproducible here.
 """
 
 import json

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -128,6 +128,47 @@ function Read-DreamEnv {
     return Get-WindowsDreamEnvMap -InstallDir $InstallDir
 }
 
+function Get-DreamEnvValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ""
+    )
+    try {
+        $envMap = Read-DreamEnv
+        if ($envMap.ContainsKey($Name) -and -not [string]::IsNullOrWhiteSpace($envMap[$Name])) {
+            return $envMap[$Name]
+        }
+    } catch { }
+    return $Default
+}
+
+function Test-DreamSttModelCache {
+    $whisperPort = Get-DreamEnvValue -Name "WHISPER_PORT" -Default "9000"
+    $whisperUrl = "http://localhost:$whisperPort"
+
+    try {
+        Invoke-WebRequest -Uri "$whisperUrl/health" -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop | Out-Null
+    } catch {
+        return
+    }
+
+    $sttModel = Get-DreamEnvValue -Name "AUDIO_STT_MODEL" -Default "Systran/faster-whisper-base"
+    $sttModelEncoded = $sttModel -replace "/", "%2F"
+    $modelUrl = "$whisperUrl/v1/models/$sttModelEncoded"
+    $recoveryCmd = "Invoke-WebRequest -Method POST -Uri '$modelUrl' -TimeoutSec 3600"
+
+    try {
+        $resp = Invoke-WebRequest -Uri $modelUrl -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+        if ($resp.StatusCode -eq 200) {
+            Write-AISuccess "Whisper STT model: cached ($sttModel)"
+            return
+        }
+    } catch { }
+
+    Write-AIWarn "Whisper STT model missing ($sttModel) -- transcription will 404"
+    Write-Host "  Run: $recoveryCmd" -ForegroundColor DarkGray
+}
+
 function Set-DreamEnvValue {
     <#
     .SYNOPSIS
@@ -480,6 +521,7 @@ function Invoke-Status {
                 Write-AIWarn "$($ep.Name): not responding"
             }
         }
+        Test-DreamSttModelCache
 
         # GPU status
         Write-Host ""

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -911,6 +911,10 @@ foreach ($check in $healthChecks) {
 # Speaches does NOT auto-download on transcription requests — it returns 404.
 # Trigger the download explicitly, verify it completed, surface recovery
 # instructions on failure. Mirrors Linux Phase 12 and macOS install-macos.sh.
+$sttModelReady = (-not $enableVoice)
+$sttModelNameForReadiness = ""
+$sttModelCacheUrl = ""
+$sttRecoveryCmd = ""
 if ($enableVoice) {
     # Read AUDIO_STT_MODEL and WHISPER_PORT from .env (written by env-generator.ps1).
     # Use ReadAllText with explicit UTF8NoBom encoding so legacy BOM-prefixed
@@ -943,6 +947,8 @@ if ($enableVoice) {
     $sttModelEncoded = $sttModel -replace "/", "%2F"
     $whisperUrl = "http://localhost:$whisperPort"
     $sttRecoveryCmd = "Invoke-WebRequest -Method POST -Uri '$whisperUrl/v1/models/$sttModelEncoded' -TimeoutSec 3600"
+    $sttModelNameForReadiness = $sttModel
+    $sttModelCacheUrl = "$whisperUrl/v1/models/$sttModelEncoded"
 
     # Step 1: wait briefly for the models API to be ready (max 15s).
     $sttApiReady = $false
@@ -955,6 +961,8 @@ if ($enableVoice) {
     }
 
     if (-not $sttApiReady) {
+        $sttModelReady = $false
+        $allHealthy = $false
         Write-AIWarn "STT models API not ready -- download manually:"
         Write-Host "    $sttRecoveryCmd" -ForegroundColor DarkGray
     } else {
@@ -966,12 +974,13 @@ if ($enableVoice) {
         } catch { }
 
         if ($alreadyCached) {
+            $sttModelReady = $true
             Write-AISuccess "STT model already cached ($sttModel)"
         } else {
             # Step 3: POST to trigger download.
             Write-AI "Downloading STT model ($sttModel)..."
             try {
-                Invoke-WebRequest -Method POST -Uri "$whisperUrl/v1/models/$sttModelEncoded" -TimeoutSec 3600 -UseBasicParsing -ErrorAction Stop | Out-Null
+                Invoke-WebRequest -Method POST -Uri "$whisperUrl/v1/models/$sttModelEncoded" -TimeoutSec 600 -UseBasicParsing -ErrorAction Stop | Out-Null
             } catch {
                 # Fall through to verification step regardless — POST can succeed or partial-fail.
             }
@@ -984,8 +993,11 @@ if ($enableVoice) {
             } catch { }
 
             if ($verified) {
+                $sttModelReady = $true
                 Write-AISuccess "STT model cached ($sttModel)"
             } else {
+                $sttModelReady = $false
+                $allHealthy = $false
                 Write-AIWarn "STT model download failed -- run manually:"
                 Write-Host "    $sttRecoveryCmd" -ForegroundColor DarkGray
             }
@@ -1029,6 +1041,9 @@ if ($enableVoice) {
     $whisperPort = Get-ReadinessPort -Name "WHISPER_PORT" -Default "9000"
     $ttsPort = Get-ReadinessPort -Name "TTS_PORT" -Default "8880"
     $readinessChecks += @{ Name = "Whisper (STT)"; Url = "http://localhost:$whisperPort/health"; Container = "dream-whisper"; OpenUrl = "http://localhost:$whisperPort" }
+    if ($sttModelCacheUrl) {
+        $readinessChecks += @{ Name = "Whisper STT model cache"; Url = $sttModelCacheUrl; Container = "dream-whisper"; OpenUrl = $sttModelNameForReadiness; Hint = "Run: $sttRecoveryCmd" }
+    }
     $readinessChecks += @{ Name = "Kokoro (TTS)"; Url = "http://localhost:$ttsPort/health"; Container = "dream-tts"; OpenUrl = "http://localhost:$ttsPort" }
 }
 if ($enableWorkflows) {
@@ -1118,6 +1133,7 @@ if ($SummaryJsonPath) {
         gpuBackend = $gpuInfo.Backend
         gpuName    = $gpuInfo.Name
         installDir = $installDir
+        sttModelCached = $sttModelReady
         features   = @{
             voice     = $enableVoice
             workflows = $enableWorkflows

--- a/dream-server/installers/windows/lib/install-report.ps1
+++ b/dream-server/installers/windows/lib/install-report.ps1
@@ -81,10 +81,19 @@ function New-DreamInstallReport {
     if (Get-Command Get-NativeInferenceBackend -ErrorAction SilentlyContinue) {
         $nativeBackend = Get-NativeInferenceBackend
     }
+    $envMap = Get-WindowsDreamEnvMap -InstallDir $InstallDir
     $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $InstallDir -GpuBackend $gpu.Backend -NativeBackend $nativeBackend
 
     $composeConfigArgs = @("compose") + $ComposeFlags + @("config")
     $composePsArgs = @("compose") + $ComposeFlags + @("ps", "-a")
+
+    $whisperPort = if ($envMap.ContainsKey("WHISPER_PORT") -and $envMap["WHISPER_PORT"]) { $envMap["WHISPER_PORT"] } else { "9000" }
+    $sttModel = if ($envMap.ContainsKey("AUDIO_STT_MODEL") -and $envMap["AUDIO_STT_MODEL"]) { $envMap["AUDIO_STT_MODEL"] } else { "Systran/faster-whisper-base" }
+    $sttModelEncoded = $sttModel -replace "/", "%2F"
+    $sttModelUrl = "http://localhost:$whisperPort/v1/models/$sttModelEncoded"
+    $whisperStatus = Test-HttpEndpoint -Url "http://localhost:$whisperPort/health"
+    $sttModelStatus = Test-HttpEndpoint -Url $sttModelUrl -TimeoutSec 5
+    $sttModelCached = if ($whisperStatus.ok) { $sttModelStatus.ok } else { $null }
 
     $report = [ordered]@{
         generated_at = (Get-Date).ToString("o")
@@ -114,6 +123,14 @@ function New-DreamInstallReport {
             open_webui = Test-HttpEndpoint -Url "http://localhost:3000"
             dashboard = Test-HttpEndpoint -Url "http://localhost:3001"
             dashboard_api = Test-HttpEndpoint -Url "http://localhost:3002/health"
+            whisper = $whisperStatus
+            stt_model = [ordered]@{
+                name = $sttModel
+                cached = $sttModelCached
+                status_code = $sttModelStatus.status_code
+                url = $sttModelUrl
+                recovery_command = "Invoke-WebRequest -Method POST -Uri '$sttModelUrl' -TimeoutSec 3600"
+            }
         }
     }
 
@@ -168,6 +185,15 @@ function Write-DreamInstallReport {
     $lines += "- Open WebUI: $($report.health.open_webui.ok) (status $($report.health.open_webui.status_code))"
     $lines += "- Dashboard: $($report.health.dashboard.ok) (status $($report.health.dashboard.status_code))"
     $lines += "- Dashboard API: $($report.health.dashboard_api.ok) (status $($report.health.dashboard_api.status_code))"
+    $lines += "- Whisper: $($report.health.whisper.ok) (status $($report.health.whisper.status_code))"
+    if ($report.health.whisper.ok) {
+        $lines += "- Whisper STT model cached: $($report.health.stt_model.cached) ($($report.health.stt_model.name), status $($report.health.stt_model.status_code))"
+        if (-not $report.health.stt_model.cached) {
+            $lines += "  Recovery: $($report.health.stt_model.recovery_command)"
+        }
+    } else {
+        $lines += "- Whisper STT model cached: skipped (Whisper unavailable)"
+    }
     $lines += ""
     $lines += "Raw command snippets are available in report.json."
 

--- a/dream-server/installers/windows/lib/readiness-summary.ps1
+++ b/dream-server/installers/windows/lib/readiness-summary.ps1
@@ -77,6 +77,9 @@ function Write-DreamInstallReadinessSummary {
                 $state = "needs attention"
                 $detail = "container $containerState, HTTP $($http.Code)"
             }
+            if ($check.Hint) {
+                $detail = "$detail; $($check.Hint)"
+            }
             [void]$attention.Add(("{0,-28} {1} - {2}" -f $check.Name, $state, $detail))
         }
     }


### PR DESCRIPTION
## Summary
- make Windows install/readiness/status/report surface missing Whisper STT model cache with a recovery command
- keep STT preload bounded and mark installs as needing attention when the model is unavailable
- map portless Tailscale health through the host agent, including host-native Tailscale fallback, so optional remote access does not make fresh installs look degraded

## Tests
- python -m pytest extensions/services/dashboard-api/tests/test_config.py extensions/services/dashboard-api/tests/test_helpers.py -q -k "not symlinks_are_skipped"
- python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py::TestTailscaleStatus extensions/services/dashboard-api/tests/test_tailscale.py extensions/services/dashboard-api/tests/test_config.py::TestLoadExtensionManifests::test_preserves_host_network_flag extensions/services/dashboard-api/tests/test_helpers.py::TestCheckServiceHealth::test_host_network_portless_service_is_not_deployed extensions/services/dashboard-api/tests/test_helpers.py::TestCheckServiceHealth::test_tailscale_not_running_is_not_deployed extensions/services/dashboard-api/tests/test_helpers.py::TestCheckServiceHealth::test_tailscale_authenticated_is_healthy -q
- python -m py_compile bin/dream-host-agent.py
- PowerShell parser check for install-windows.ps1, dream.ps1, and install-report.ps1

Note: the unfiltered test_helpers.py file has an existing Windows symlink privilege failure on TestDirSizeGb::test_symlinks_are_skipped, so I ran the same file with that one test deselected.
