### PR TITLE
[codex] Add voice doctor repair commands

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1668,6 +1668,36 @@ elif dgx_status == 'warn':
 
 print()
 
+# Voice checks
+stt_cached = runtime.get('stt_model_cached', 'unknown')
+stt_model = runtime.get('stt_model_name') or '<not configured>'
+tts_http = runtime.get('tts_http', 'unknown')
+if stt_cached != 'unknown' or tts_http != 'unknown':
+    print(f"{CYAN}Voice Readiness:{NC}")
+    if stt_cached == 'true':
+        print(f"  {GREEN}✓{NC} Whisper STT model cached: {stt_model}")
+    elif stt_cached == 'false':
+        print(f"  {YELLOW}⚠{NC} Whisper STT model missing: {stt_model}")
+        has_failures = True
+    elif stt_cached == 'service_down':
+        print(f"  {RED}✗{NC} Whisper STT service not responding")
+        has_failures = True
+    elif stt_cached == 'disabled':
+        print(f"  {YELLOW}?{NC} Whisper STT disabled")
+    else:
+        print(f"  {YELLOW}?{NC} Whisper STT model cache unknown")
+
+    if tts_http == 'true':
+        print(f"  {GREEN}✓{NC} Kokoro TTS responding")
+    elif tts_http == 'false':
+        print(f"  {RED}✗{NC} Kokoro TTS not responding")
+        has_failures = True
+    elif tts_http == 'disabled':
+        print(f"  {YELLOW}?{NC} Kokoro TTS disabled")
+    else:
+        print(f"  {YELLOW}?{NC} Kokoro TTS status unknown")
+    print()
+
 # Preflight checks
 preflight = report.get('preflight', {})
 pf_checks = preflight.get('checks', [])
@@ -3543,8 +3573,78 @@ cmd_gpu() {
 }
 
 cmd_repair() {
-    warn "The 'repair' command is not yet implemented."
-    log "Run 'dream doctor' to diagnose issues, then check the output for suggested fixes."
+    check_install
+    cd "$INSTALL_DIR"
+    load_env
+    sr_load
+
+    local target="${1:-voice}"
+    case "$target" in
+        voice|stt|tts)
+            local flags_str
+            flags_str=$(get_compose_flags)
+            local -a flags
+            read -ra flags <<< "$flags_str"
+
+            local services
+            services=$(docker compose "${flags[@]}" config --services 2>/dev/null || true)
+            local missing=()
+            grep -qx "whisper" <<< "$services" || missing+=("whisper")
+            grep -qx "tts" <<< "$services" || missing+=("tts")
+            if (( ${#missing[@]} > 0 )); then
+                log_error "Voice services are not in this compose stack: ${missing[*]}"
+                echo "  Enable voice, or add the whisper/tts extension compose files, then retry."
+                return 1
+            fi
+
+            _compose_run_with_summary "Starting voice services" "${flags[@]}" up -d whisper tts
+
+            local model port url tts_port tts_url
+            model=$(_env_get_raw AUDIO_STT_MODEL)
+            [[ -z "$model" ]] && model="Systran/faster-whisper-base"
+            port=$(_env_get_raw WHISPER_PORT)
+            [[ -z "$port" ]] && port="9000"
+            url="http://127.0.0.1:${port}"
+            tts_port=$(_env_get_raw TTS_PORT)
+            [[ -z "$tts_port" ]] && tts_port="8880"
+            tts_url="http://127.0.0.1:${tts_port}"
+
+            local ready=false
+            for _i in $(seq 1 45); do
+                if curl -sf --max-time 2 "${url}/health" >/dev/null 2>&1; then
+                    ready=true
+                    break
+                fi
+                sleep 2
+            done
+            if ! $ready; then
+                log_error "Whisper STT is still not responding. Check: dream logs whisper"
+                return 1
+            fi
+
+            cmd_stt download "$model"
+
+            local tts_ready=false
+            for _i in $(seq 1 45); do
+                if curl -sf --max-time 2 "${tts_url}/health" >/dev/null 2>&1; then
+                    tts_ready=true
+                    break
+                fi
+                sleep 2
+            done
+            if ! $tts_ready; then
+                log_error "Kokoro TTS is still not responding. Check: dream logs tts"
+                return 1
+            fi
+
+            success "Voice repair complete"
+            ;;
+        *)
+            log "Usage: dream repair voice"
+            log_error "Unknown repair target: $target"
+            return 1
+            ;;
+    esac
 }
 
 #=============================================================================
@@ -3777,7 +3877,7 @@ ${CYAN}Commands:${NC}
   chat "<message>"    Quick chat with the LLM
   benchmark           Run a quick performance test
   doctor [report|--json]   Run diagnostics (--json writes JSON to stdout)
-  repair|fix          Run basic repairs (currently redirects to doctor)
+  repair|fix [voice]  Repair voice services and cache the STT model
   template [action]   Apply pre-built service templates (list|preview|apply)
   audit [extensions]  Audit extension manifests and compose contracts
   agent [action]      Manage dream host agent (status|start|stop|restart|logs)
@@ -3862,6 +3962,7 @@ ${CYAN}Examples:${NC}
   dream audit --json whisper      # Audit one service as JSON
   dream agent status              # Check host agent health
   dream agent restart             # Restart host agent
+  dream repair voice              # Start voice services and cache STT model
 
 ${CYAN}Environment:${NC}
   DREAM_HOME          Installation directory (default: ~/dream-server)

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -14,6 +14,8 @@
 #   .\dream.ps1 config edit         # Open .env in notepad
 #   .\dream.ps1 chat "message"      # Quick chat via API
 #   .\dream.ps1 update              # Pull latest images and restart
+#   .\dream.ps1 doctor              # Diagnose runtime readiness
+#   .\dream.ps1 repair voice        # Repair voice/STT/TTS readiness
 #   .\dream.ps1 report              # Generate Windows diagnostics bundle
 #   .\dream.ps1 version             # Show version
 #   .\dream.ps1 help                # Show help
@@ -142,31 +144,110 @@ function Get-DreamEnvValue {
     return $Default
 }
 
-function Test-DreamSttModelCache {
+function Get-DreamVoiceDiagnosis {
     $whisperPort = Get-DreamEnvValue -Name "WHISPER_PORT" -Default "9000"
     $whisperUrl = "http://localhost:$whisperPort"
-
-    try {
-        Invoke-WebRequest -Uri "$whisperUrl/health" -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop | Out-Null
-    } catch {
-        return
-    }
-
     $sttModel = Get-DreamEnvValue -Name "AUDIO_STT_MODEL" -Default "Systran/faster-whisper-base"
     $sttModelEncoded = $sttModel -replace "/", "%2F"
     $modelUrl = "$whisperUrl/v1/models/$sttModelEncoded"
-    $recoveryCmd = "Invoke-WebRequest -Method POST -Uri '$modelUrl' -TimeoutSec 3600"
+    $ttsPort = Get-DreamEnvValue -Name "TTS_PORT" -Default "8880"
+    $ttsUrl = "http://localhost:$ttsPort"
+
+    $result = [ordered]@{
+        WhisperPort      = $whisperPort
+        WhisperUrl       = $whisperUrl
+        WhisperHealthy   = $false
+        ModelsApiReady   = $false
+        SttModel         = $sttModel
+        SttModelCached   = $false
+        SttModelUrl      = $modelUrl
+        RecoveryCommand  = "Invoke-WebRequest -Method POST -Uri '$modelUrl' -TimeoutSec 3600"
+        TtsPort          = $ttsPort
+        TtsUrl           = $ttsUrl
+        TtsHealthy       = $false
+    }
+
+    try {
+        Invoke-WebRequest -Uri "$whisperUrl/health" -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop | Out-Null
+        $result.WhisperHealthy = $true
+    } catch { }
+
+    try {
+        $resp = Invoke-WebRequest -Uri "$whisperUrl/v1/models" -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
+        if ($resp.StatusCode -eq 200) {
+            $result.ModelsApiReady = $true
+        }
+    } catch { }
 
     try {
         $resp = Invoke-WebRequest -Uri $modelUrl -TimeoutSec 5 -UseBasicParsing -ErrorAction Stop
         if ($resp.StatusCode -eq 200) {
-            Write-AISuccess "Whisper STT model: cached ($sttModel)"
+            $result.SttModelCached = $true
+        }
+    } catch { }
+
+    try {
+        Invoke-WebRequest -Uri "$ttsUrl/health" -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop | Out-Null
+        $result.TtsHealthy = $true
+    } catch { }
+
+    return $result
+}
+
+function Test-DreamSttModelCache {
+    try {
+        $flags = Get-ComposeFlags
+        if (-not (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "whisper")) {
             return
         }
     } catch { }
 
-    Write-AIWarn "Whisper STT model missing ($sttModel) -- transcription will 404"
-    Write-Host "  Run: $recoveryCmd" -ForegroundColor DarkGray
+    $diag = Get-DreamVoiceDiagnosis
+    if (-not $diag.WhisperHealthy) {
+        Write-AIWarn "Whisper STT: not responding (port $($diag.WhisperPort))"
+        return
+    }
+    if ($diag.SttModelCached) {
+        Write-AISuccess "Whisper STT model: cached ($($diag.SttModel))"
+        return
+    }
+
+    $apiState = if ($diag.ModelsApiReady) { "models API ready" } else { "models API not ready" }
+    Write-AIWarn "Whisper STT model missing ($($diag.SttModel)) -- transcription will 404 ($apiState)"
+    Write-Host "  Run: $($diag.RecoveryCommand)" -ForegroundColor DarkGray
+}
+
+function Wait-DreamHttpOk {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [int]$TimeoutSeconds = 60
+    )
+
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    while ((Get-Date) -lt $deadline) {
+        try {
+            $resp = Invoke-WebRequest -Uri $Url -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop
+            if ($resp.StatusCode -ge 200 -and $resp.StatusCode -lt 400) {
+                return $true
+            }
+        } catch { }
+        Start-Sleep -Seconds 2
+    }
+    return $false
+}
+
+function Test-DreamComposeServiceAvailable {
+    param(
+        [string[]]$ComposeFlags,
+        [Parameter(Mandatory = $true)][string]$Service
+    )
+
+    try {
+        $services = & docker compose @ComposeFlags config --services 2>$null
+        return ($services -contains $Service)
+    } catch {
+        return $false
+    }
 }
 
 function Set-DreamEnvValue {
@@ -794,6 +875,162 @@ function Invoke-Report {
     }
 }
 
+function Invoke-Doctor {
+    Test-Install
+    Push-Location $InstallDir
+    try {
+        $flags = Get-ComposeFlags
+        $voiceInStack = (
+            (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "whisper") -and
+            (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "tts")
+        )
+
+        Write-Host ""
+        Write-Host "  Dream Doctor" -ForegroundColor Cyan
+        Write-Host ("  " + ("-" * 40)) -ForegroundColor DarkGray
+
+        $hasIssue = $false
+
+        Write-Host ""
+        Write-Host "  Voice Readiness" -ForegroundColor Cyan
+        if (-not $voiceInStack) {
+            Write-AI "Voice services: not enabled in this compose stack"
+            Write-Host ""
+            Write-AISuccess "Doctor found no voice readiness issues."
+            return
+        }
+
+        $voice = Get-DreamVoiceDiagnosis
+        if ($voice.WhisperHealthy) {
+            Write-AISuccess "Whisper STT: healthy ($($voice.WhisperUrl))"
+        } else {
+            Write-AIWarn "Whisper STT: not responding ($($voice.WhisperUrl))"
+            $hasIssue = $true
+        }
+
+        if ($voice.SttModelCached) {
+            Write-AISuccess "Whisper STT model: cached ($($voice.SttModel))"
+        } elseif ($voice.WhisperHealthy) {
+            Write-AIWarn "Whisper STT model: missing ($($voice.SttModel))"
+            Write-Host "  Repair: .\dream.ps1 repair voice" -ForegroundColor DarkGray
+            Write-Host "  Manual: $($voice.RecoveryCommand)" -ForegroundColor DarkGray
+            $hasIssue = $true
+        }
+
+        if ($voice.TtsHealthy) {
+            Write-AISuccess "Kokoro TTS: healthy ($($voice.TtsUrl))"
+        } else {
+            Write-AIWarn "Kokoro TTS: not responding ($($voice.TtsUrl))"
+            Write-Host "  Repair: .\dream.ps1 repair voice" -ForegroundColor DarkGray
+            $hasIssue = $true
+        }
+
+        Write-Host ""
+        if ($hasIssue) {
+            Write-AIWarn "Doctor found repairable voice issues."
+            exit 1
+        }
+        Write-AISuccess "Doctor found no voice readiness issues."
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-RepairVoice {
+    Test-Install
+    Push-Location $InstallDir
+    try {
+        $flags = Get-ComposeFlags
+
+        Write-Host ""
+        Write-Host "  Repair Voice" -ForegroundColor Cyan
+        Write-Host ("  " + ("-" * 40)) -ForegroundColor DarkGray
+
+        $missingServices = @()
+        foreach ($svc in @("whisper", "tts")) {
+            if (-not (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service $svc)) {
+                $missingServices += $svc
+            }
+        }
+        if ($missingServices.Count -gt 0) {
+            Write-AIError "Voice services are not in this compose stack: $($missingServices -join ', ')"
+            Write-AI "Enable voice in the installer or add the whisper/tts extension compose files, then retry."
+            exit 1
+        }
+
+        Write-AI "Starting Whisper and Kokoro TTS..."
+        $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
+            -ComposeArgs @("up", "-d", "whisper", "tts")
+        if ($composeExit -ne 0) {
+            Write-AIError "docker compose up failed (exit code: $composeExit)"
+            Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "dream.ps1 repair voice"
+            exit 1
+        }
+
+        $voice = Get-DreamVoiceDiagnosis
+        if (-not $voice.WhisperHealthy) {
+            Write-AI "Waiting for Whisper STT..."
+            Wait-DreamHttpOk -Url "$($voice.WhisperUrl)/health" -TimeoutSeconds 90 | Out-Null
+        }
+        if (-not $voice.TtsHealthy) {
+            Write-AI "Waiting for Kokoro TTS..."
+            Wait-DreamHttpOk -Url "$($voice.TtsUrl)/health" -TimeoutSeconds 90 | Out-Null
+        }
+
+        $voice = Get-DreamVoiceDiagnosis
+        if (-not $voice.WhisperHealthy) {
+            Write-AIError "Whisper STT is still not responding. Check: .\dream.ps1 logs whisper 100"
+            exit 1
+        }
+        if (-not $voice.SttModelCached) {
+            Write-AI "Downloading STT model ($($voice.SttModel))..."
+            try {
+                Invoke-WebRequest -Method POST -Uri $voice.SttModelUrl -TimeoutSec 3600 -UseBasicParsing -ErrorAction Stop | Out-Null
+            } catch {
+                Write-AIWarn "STT model download request failed; verifying cache before failing."
+            }
+        }
+
+        $voice = Get-DreamVoiceDiagnosis
+        if ($voice.SttModelCached) {
+            Write-AISuccess "Whisper STT model cached ($($voice.SttModel))"
+        } else {
+            Write-AIError "STT model is still missing. Run manually: $($voice.RecoveryCommand)"
+            exit 1
+        }
+
+        if ($voice.TtsHealthy) {
+            Write-AISuccess "Kokoro TTS healthy"
+        } else {
+            Write-AIError "Kokoro TTS is still not responding. Check: .\dream.ps1 logs tts 100"
+            exit 1
+        }
+
+        Write-AISuccess "Voice repair complete."
+    } finally {
+        Pop-Location
+    }
+}
+
+function Invoke-Repair {
+    param([string]$Target)
+
+    if ([string]::IsNullOrWhiteSpace($Target)) {
+        $Target = "voice"
+    }
+
+    switch ($Target.ToLower()) {
+        "voice" { Invoke-RepairVoice }
+        "stt"   { Invoke-RepairVoice }
+        "tts"   { Invoke-RepairVoice }
+        default {
+            Write-AI "Usage: .\dream.ps1 repair voice"
+            Write-AIWarn "Unknown repair target: $Target"
+            exit 1
+        }
+    }
+}
+
 function Invoke-Agent {
     param([string]$Action = "status")
 
@@ -951,6 +1188,10 @@ function Show-Help {
     Write-Host "Quick chat via API" -ForegroundColor DarkGray
     Write-Host "    update              " -ForegroundColor Cyan -NoNewline
     Write-Host "Pull latest images and restart" -ForegroundColor DarkGray
+    Write-Host "    doctor              " -ForegroundColor Cyan -NoNewline
+    Write-Host "Diagnose runtime readiness" -ForegroundColor DarkGray
+    Write-Host "    repair voice        " -ForegroundColor Cyan -NoNewline
+    Write-Host "Start voice services and cache STT model" -ForegroundColor DarkGray
     Write-Host "    agent [action]      " -ForegroundColor Cyan -NoNewline
     Write-Host "Host agent: status|start|stop|restart|logs" -ForegroundColor DarkGray
     Write-Host "    report              " -ForegroundColor Cyan -NoNewline
@@ -964,6 +1205,7 @@ function Show-Help {
     Write-Host "    .\dream.ps1 status" -ForegroundColor DarkGray
     Write-Host "    .\dream.ps1 logs llama-server 50" -ForegroundColor DarkGray
     Write-Host "    .\dream.ps1 restart open-webui" -ForegroundColor DarkGray
+    Write-Host "    .\dream.ps1 repair voice" -ForegroundColor DarkGray
     Write-Host "    .\dream.ps1 chat `"What is quantum computing?`"" -ForegroundColor DarkGray
     Write-Host ""
 }
@@ -993,6 +1235,8 @@ switch ($Command.ToLower()) {
     }
     "chat"    { Invoke-Chat -Message ($Arguments -join " ") }
     "update"  { Invoke-Update }
+    "doctor"  { Invoke-Doctor }
+    "repair"  { Invoke-Repair -Target ($Arguments | Select-Object -First 1) }
     "report"  { Invoke-Report }
     "agent"   {
         $action = ($Arguments | Select-Object -First 1)

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -135,6 +135,8 @@ fi
 STT_MODEL_CACHED="unknown"
 STT_MODEL_NAME=""
 STT_RECOVERY_HINT=""
+TTS_HTTP="unknown"
+TTS_PORT=""
 if [[ "${ENABLE_VOICE:-false}" == "true" ]] && command -v curl >/dev/null 2>&1; then
     STT_MODEL_NAME="${AUDIO_STT_MODEL:-Systran/faster-whisper-base}"
     _stt_whisper_port="${SERVICE_PORTS[whisper]:-9000}"
@@ -151,6 +153,16 @@ if [[ "${ENABLE_VOICE:-false}" == "true" ]] && command -v curl >/dev/null 2>&1; 
             STT_MODEL_CACHED="service_down"
         fi
     fi
+
+    TTS_PORT="${SERVICE_PORTS[tts]:-8880}"
+    if curl -sf --max-time 5 "http://127.0.0.1:${TTS_PORT}/health" >/dev/null 2>&1; then
+        TTS_HTTP="true"
+    else
+        TTS_HTTP="false"
+    fi
+elif [[ "${ENABLE_VOICE:-false}" != "true" ]]; then
+    STT_MODEL_CACHED="disabled"
+    TTS_HTTP="disabled"
 fi
 
 # DGX Spark / GB10 CUDA arch check. Generic llama.cpp CUDA images can run on
@@ -298,13 +310,13 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" "$DGX_SPARK_GPU" "$DGX_SPARK_GPU_NAME" "$DGX_SPARK_COMPUTE_CAP" "$LLAMA_CUDA_ARCHS" "$DGX_SPARK_CUDA_ARCH_STATUS" "$DGX_SPARK_CUDA_ARCH_MESSAGE" <<'PY'
+"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" "$TTS_HTTP" "$TTS_PORT" "$DGX_SPARK_GPU" "$DGX_SPARK_GPU_NAME" "$DGX_SPARK_COMPUTE_CAP" "$LLAMA_CUDA_ARCHS" "$DGX_SPARK_CUDA_ARCH_STATUS" "$DGX_SPARK_CUDA_ARCH_MESSAGE" <<'PY'
 import json
 import pathlib
 import sys
 from datetime import datetime, timezone
 
-cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message = sys.argv[1:]
+cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, tts_http, tts_port, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message = sys.argv[1:]
 
 cap = json.load(open(cap_file, "r", encoding="utf-8"))
 pre = json.load(open(preflight_file, "r", encoding="utf-8"))
@@ -324,6 +336,8 @@ report = {
         "webui_http": webui_http == "true",
         "stt_model_cached": stt_cached,
         "stt_model_name": stt_model_name,
+        "tts_http": tts_http,
+        "tts_port": tts_port,
         "dgx_spark_gpu": dgx_spark_gpu == "true",
         "dgx_spark_gpu_name": dgx_spark_gpu_name,
         "dgx_spark_compute_cap": dgx_spark_compute_cap,
@@ -337,7 +351,11 @@ report = {
     "summary": {
         "preflight_blockers": pre.get("summary", {}).get("blockers", 0),
         "preflight_warnings": pre.get("summary", {}).get("warnings", 0),
-        "runtime_warnings": 1 if dgx_spark_arch_status == "warn" else 0,
+        "runtime_warnings": (
+            (1 if dgx_spark_arch_status == "warn" else 0)
+            + (1 if stt_cached in {"false", "service_down"} else 0)
+            + (1 if tts_http == "false" else 0)
+        ),
         "runtime_ready": (docker_daemon == "true" and compose_cli == "true"),
         "extensions_total": len(ext_diagnostics),
         "extensions_healthy": sum(1 for e in ext_diagnostics if e.get("health_status") == "healthy"),
@@ -370,6 +388,11 @@ if stt_cached == "false" and stt_recovery:
         f"Whisper STT model '{stt_model_name}' not cached — transcription will 404. "
         f"Run: {stt_recovery}"
     )
+elif stt_cached == "service_down":
+    fix_hints.append("Whisper STT is not responding. Run: dream repair voice")
+
+if tts_http == "false":
+    fix_hints.append("Kokoro TTS is not responding. Run: dream repair voice")
 
 if dgx_spark_arch_status == "warn":
     fix_hints.append(

--- a/dream-server/tests/test-voice-repair-command.sh
+++ b/dream-server/tests/test-voice-repair-command.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Static checks for voice doctor/repair command wiring.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DREAM_CLI="$ROOT_DIR/dream-cli"
+DREAM_DOCTOR="$ROOT_DIR/scripts/dream-doctor.sh"
+WINDOWS_CLI="$ROOT_DIR/installers/windows/dream.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+echo ""
+echo "=== Voice repair command tests ==="
+echo ""
+
+[[ -f "$DREAM_CLI" ]] && pass "dream-cli exists" || fail "dream-cli missing"
+[[ -f "$DREAM_DOCTOR" ]] && pass "dream-doctor.sh exists" || fail "dream-doctor.sh missing"
+[[ -f "$WINDOWS_CLI" ]] && pass "Windows dream.ps1 exists" || fail "Windows dream.ps1 missing"
+
+grep -q '^cmd_repair()' "$DREAM_CLI" && pass "dream-cli defines cmd_repair" || fail "cmd_repair missing"
+grep -q 'cmd_stt download' "$DREAM_CLI" && pass "repair reuses STT download command" || fail "repair does not cache STT model"
+grep -q 'Starting voice services' "$DREAM_CLI" && pass "repair starts voice services" || fail "repair does not start voice services"
+grep -q 'Voice Readiness' "$DREAM_CLI" && pass "doctor displays voice readiness" || fail "doctor voice readiness missing"
+grep -q 'repair|fix \[voice\]' "$DREAM_CLI" && pass "help documents repair voice" || fail "help missing repair voice"
+
+grep -q '"tts_http"' "$DREAM_DOCTOR" && pass "doctor report includes TTS status" || fail "doctor missing TTS status"
+grep -q 'dream repair voice' "$DREAM_DOCTOR" && pass "doctor suggests repair voice" || fail "doctor missing repair hint"
+
+grep -q 'function Invoke-Doctor' "$WINDOWS_CLI" && pass "Windows CLI defines doctor" || fail "Windows doctor missing"
+grep -q 'function Invoke-RepairVoice' "$WINDOWS_CLI" && pass "Windows CLI defines repair voice" || fail "Windows repair voice missing"
+grep -q '".*doctor".*Invoke-Doctor' "$WINDOWS_CLI" && pass "Windows dispatch includes doctor" || fail "Windows doctor dispatch missing"
+grep -q '".*repair".*Invoke-Repair' "$WINDOWS_CLI" && pass "Windows dispatch includes repair" || fail "Windows repair dispatch missing"
+grep -q 'repair voice' "$WINDOWS_CLI" && pass "Windows help documents repair voice" || fail "Windows help missing repair voice"
+
+if bash -n "$DREAM_CLI" 2>/dev/null; then
+    pass "dream-cli syntax valid"
+else
+    fail "dream-cli syntax invalid"
+fi
+
+if bash -n "$DREAM_DOCTOR" 2>/dev/null; then
+    pass "dream-doctor syntax valid"
+else
+    fail "dream-doctor syntax invalid"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds repair-first voice diagnostics for the Whisper/STT and Kokoro/TTS path.

- adds `dream repair voice` on Linux/macOS CLI to start voice services, wait for Whisper, cache the configured STT model, and verify TTS
- adds Windows `./dream.ps1 doctor` and `./dream.ps1 repair voice` with the same STT model cache and TTS readiness checks
- extends `dream doctor` JSON and rendered output with voice readiness, including STT cache state and TTS health
- adds static coverage for the new command wiring

## Why

Issue #1247 showed a common failure mode where Whisper/Speaches was healthy but the configured STT model was not cached, so transcription returned 404. Users need a direct repair path instead of a recovery command buried in diagnostics.

## Validation

- `bash dream-server/tests/test-voice-repair-command.sh` via Git Bash
- `bash dream-server/tests/test-doctor-command.sh` via Git Bash
- `bash dream-server/tests/test-dream-doctor.sh` via Git Bash
- `bash dream-server/tests/test-windows-report-command.sh` via Git Bash
- PowerShell parser check for `dream-server/installers/windows/dream.ps1`
- `git diff --check`
- doctor JSON smoke check for `runtime.stt_model_cached`, `runtime.tts_http`, and numeric `summary.runtime_warnings`