### PR TITLE
[codex] Add optional service status semantics

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -309,17 +309,55 @@ def _serialize_model(model_info) -> Optional[dict]:
     }
 
 
+def _service_semantics(service_id: str, status: str) -> dict:
+    config = SERVICES.get(service_id, {})
+    category = config.get("category", "optional")
+    required = category == "core"
+
+    if status == "healthy":
+        state = "ready"
+        severity = "ok"
+        counts_as_issue = False
+    elif status == "not_deployed":
+        state = "disabled"
+        severity = "disabled"
+        counts_as_issue = False
+    elif status == "unknown" and not required:
+        state = "unknown"
+        severity = "unknown"
+        counts_as_issue = False
+    elif required:
+        state = "blocked"
+        severity = "critical"
+        counts_as_issue = True
+    else:
+        state = "attention"
+        severity = "warning"
+        counts_as_issue = True
+
+    return {
+        "category": category,
+        "required": required,
+        "impact": "core" if required else "optional",
+        "state": state,
+        "severity": severity,
+        "countsAsIssue": counts_as_issue,
+    }
+
+
 def _serialize_services(service_statuses: list[ServiceStatus], uptime: int) -> list[dict]:
-    return [
-        {
+    serialized = []
+    for service in service_statuses:
+        item = {
             "id": service.id,
             "name": service.name,
             "status": service.status,
             "port": service.external_port,
             "uptime": uptime if service.status == "healthy" else None,
         }
-        for service in service_statuses
-    ]
+        item.update(_service_semantics(service.id, service.status))
+        serialized.append(item)
+    return serialized
 
 
 def _fallback_services() -> list[dict]:
@@ -328,13 +366,15 @@ def _fallback_services() -> list[dict]:
         external_port = config.get("external_port", config.get("port", 0))
         if not external_port:
             continue
-        links.append({
+        item = {
             "id": service_id,
             "name": config.get("name", service_id),
             "status": "unknown",
             "port": external_port,
             "uptime": None,
-        })
+        }
+        item.update(_service_semantics(service_id, "unknown"))
+        links.append(item)
     return links
 
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_main.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_main.py
@@ -599,8 +599,11 @@ class TestStatusEndpoint:
 
 class TestApiStatusServiceSerialization:
 
-    def test_serialize_services_includes_service_id(self):
+    def test_serialize_services_includes_service_id_and_semantics(self, monkeypatch):
         from models import ServiceStatus
+        monkeypatch.setattr("main.SERVICES", {
+            "llama-server": {"category": "core"},
+        })
         services = [
             ServiceStatus(
                 id="llama-server",
@@ -619,14 +622,65 @@ class TestApiStatusServiceSerialization:
             "status": "healthy",
             "port": 11434,
             "uptime": 42,
+            "category": "core",
+            "required": True,
+            "impact": "core",
+            "state": "ready",
+            "severity": "ok",
+            "countsAsIssue": False,
         }]
 
-    def test_fallback_services_include_service_ids(self, monkeypatch):
+    def test_serialize_optional_not_deployed_is_disabled(self, monkeypatch):
+        from models import ServiceStatus
+        monkeypatch.setattr("main.SERVICES", {
+            "tailscale": {"category": "optional"},
+        })
+        services = [
+            ServiceStatus(
+                id="tailscale",
+                name="Tailscale",
+                port=0,
+                external_port=0,
+                status="not_deployed",
+            )
+        ]
+
+        serialized = _serialize_services(services, uptime=42)
+
+        assert serialized[0]["required"] is False
+        assert serialized[0]["impact"] == "optional"
+        assert serialized[0]["state"] == "disabled"
+        assert serialized[0]["severity"] == "disabled"
+        assert serialized[0]["countsAsIssue"] is False
+
+    def test_optional_unknown_does_not_count_as_issue(self, monkeypatch):
+        from models import ServiceStatus
+        monkeypatch.setattr("main.SERVICES", {
+            "optional-tool": {"category": "optional"},
+        })
+        services = [
+            ServiceStatus(
+                id="optional-tool",
+                name="Optional Tool",
+                port=8080,
+                external_port=8080,
+                status="unknown",
+            )
+        ]
+
+        serialized = _serialize_services(services, uptime=42)
+
+        assert serialized[0]["state"] == "unknown"
+        assert serialized[0]["severity"] == "unknown"
+        assert serialized[0]["countsAsIssue"] is False
+
+    def test_fallback_services_include_service_ids_and_semantics(self, monkeypatch):
         monkeypatch.setattr("main.SERVICES", {
             "dashboard-api": {
                 "name": "Dashboard API (System Status)",
                 "port": 3002,
                 "external_port": 3002,
+                "category": "core",
             }
         })
 
@@ -638,6 +692,12 @@ class TestApiStatusServiceSerialization:
             "status": "unknown",
             "port": 3002,
             "uptime": None,
+            "category": "core",
+            "required": True,
+            "impact": "core",
+            "state": "blocked",
+            "severity": "critical",
+            "countsAsIssue": True,
         }]
 
 

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -35,8 +35,12 @@ function computeHealth(services) {
   if (!services?.length) return { text: 'Waiting for telemetry...', color: 'text-theme-text-secondary' }
   const deployed = services.filter(s => s.status !== 'not_deployed')
   if (!deployed.length) return { text: 'No services deployed', color: 'text-theme-text-secondary' }
-  const healthy = deployed.filter(s => s.status === 'healthy').length
-  return { text: `${healthy}/${deployed.length} services online.`, color: healthy === deployed.length ? 'text-green-400' : 'text-theme-text-secondary' }
+  const hasRequiredMetadata = deployed.some(s => typeof s.required === 'boolean')
+  const scoped = hasRequiredMetadata ? deployed.filter(s => s.required) : deployed
+  if (!scoped.length) return { text: 'Optional services only.', color: 'text-theme-text-secondary' }
+  const healthy = scoped.filter(s => s.status === 'healthy').length
+  const label = hasRequiredMetadata ? 'core services' : 'services'
+  return { text: `${healthy}/${scoped.length} ${label} online.`, color: healthy === scoped.length ? 'text-green-400' : 'text-theme-text-secondary' }
 }
 
 const FEATURE_ICONS = {
@@ -371,12 +375,20 @@ function buildServiceRows(statusServices, resourceServices) {
     .forEach((service, index) => {
       const resource = resourcesByName.get(normalizeServiceKey(service.name))
       const id = resource?.id || normalizeServiceKey(service.name) || `service-${index}`
+      const hasSemantics = typeof service.required === 'boolean' || service.impact || service.category
       seen.add(id)
       rows.push({
         id,
         name: service.name || resource?.name || id,
         description: getServiceDescription(id, service.name || resource?.name),
         status: service.status || 'unknown',
+        category: service.category || null,
+        required: service.required === true,
+        hasSemantics,
+        impact: service.impact || (hasSemantics ? (service.required ? 'core' : 'optional') : null),
+        state: service.state || null,
+        severity: service.severity || null,
+        countsAsIssue: service.countsAsIssue === true,
         port: service.port,
         uptime: service.uptime,
         cpuPercent: Number.isFinite(resource?.container?.cpu_percent) ? resource.container.cpu_percent : null,
@@ -394,11 +406,19 @@ function buildServiceRows(statusServices, resourceServices) {
   resources.forEach((resource, index) => {
     const id = resource.id || normalizeServiceKey(resource.name) || `resource-${index}`
     if (seen.has(id)) return
+    const hasSemantics = typeof resource.required === 'boolean' || resource.impact || resource.category
     rows.push({
       id,
       name: resource.name || id,
       description: getServiceDescription(id, resource.name),
       status: 'unknown',
+      category: resource.category || null,
+      required: resource.required === true,
+      hasSemantics,
+      impact: resource.impact || (hasSemantics ? (resource.required ? 'core' : 'optional') : null),
+      state: resource.state || null,
+      severity: resource.severity || null,
+      countsAsIssue: resource.countsAsIssue === true,
       port: null,
       uptime: null,
       cpuPercent: Number.isFinite(resource?.container?.cpu_percent) ? resource.container.cpu_percent : null,
@@ -1355,6 +1375,11 @@ const ServiceTableRow = memo(function ServiceTableRow({
         <div className="flex min-w-0 items-center gap-2">
           <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${status.dot}`} />
           <span className="truncate text-xs font-semibold text-theme-text">{service.name}</span>
+          {service.hasSemantics && !service.required && (
+            <span className="shrink-0 rounded border border-white/[0.08] bg-white/[0.035] px-1.5 py-0.5 text-[8px] font-semibold uppercase text-theme-text-muted/70">
+              Optional
+            </span>
+          )}
         </div>
         <div className="mt-1 truncate pl-3.5 text-[10px] text-theme-text-muted/65">
           {service.description}

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -156,6 +156,48 @@ describe('Dashboard system overview', () => {
     expect(screen.queryByText('APE (Agent Policy Engine)')).not.toBeInTheDocument()
   })
 
+  it('uses core service metadata for the headline health summary', async () => {
+    mockResources = { services: [] }
+    const statusWithOptionalIssue = {
+      ...baseStatus,
+      services: [
+        {
+          id: 'llama-server',
+          name: 'llama-server (LLM Inference)',
+          status: 'healthy',
+          required: true,
+          impact: 'core',
+          port: 11434,
+          uptime: 14400,
+        },
+        {
+          id: 'open-webui',
+          name: 'Open WebUI (Chat)',
+          status: 'healthy',
+          required: true,
+          impact: 'core',
+          port: 3000,
+          uptime: 14400,
+        },
+        {
+          id: 'whisper',
+          name: 'Whisper (STT)',
+          status: 'down',
+          required: false,
+          impact: 'optional',
+          category: 'optional',
+          port: 9000,
+          uptime: null,
+        },
+      ],
+    }
+
+    await renderDashboard(statusWithOptionalIssue)
+
+    expect(screen.getByText('2/2 core services online.')).toBeInTheDocument()
+    expect(screen.getByText('Optional')).toBeInTheDocument()
+  })
+
   it('renders real service CPU and RAM metrics from the resources endpoint', async () => {
     mockResources = {
       services: [


### PR DESCRIPTION
## Summary

Formalizes optional-service status semantics through the dashboard status API and Services table.

- enriches serialized services with `category`, `required`, `impact`, `state`, `severity`, and `countsAsIssue`
- treats optional `not_deployed` and optional `unknown` states as non-issues
- keeps core/required services as critical when blocked or unknown
- updates the dashboard headline to count core services when service metadata is present
- adds an Optional badge for optional service rows in the Services table

## Why

Optional services should not make a fresh or intentionally lean install look broken. This gives the UI enough metadata to distinguish core readiness from optional service attention without losing visibility into optional services that are enabled but unhealthy.

## Validation

- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_main.py -q`
- `npm.cmd test -- --run src/pages/Dashboard.test.jsx`
- `python -m compileall -q dream-server/extensions/services/dashboard-api/main.py dream-server/extensions/services/dashboard-api/tests/test_main.py`
- `git diff --check`