### PR TITLE
[codex] Add model readiness contract

### DIFF
--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -506,6 +506,76 @@ def _serialize_model(model_info) -> Optional[dict]:
     }
 
 
+HERMES_MIN_CONTEXT = 65536
+HERMES_TARGET_CONTEXT = 131072
+
+
+def _build_model_readiness_payload(
+    *,
+    model_info: Optional[ModelInfo],
+    bootstrap_info: BootstrapStatus,
+    loaded_model: Optional[str],
+    runtime_context: Optional[int],
+) -> dict[str, Any]:
+    configured_context = model_info.context_length if model_info else None
+    effective_context = runtime_context or configured_context
+    meets_hermes_minimum = bool(effective_context and effective_context >= HERMES_MIN_CONTEXT)
+    meets_hermes_target = bool(effective_context and effective_context >= HERMES_TARGET_CONTEXT)
+    has_loaded_model = bool(loaded_model)
+    ready = has_loaded_model and meets_hermes_minimum
+
+    issues: list[str] = []
+    if not has_loaded_model:
+        issues.append("No model is currently reported as loaded.")
+    if not meets_hermes_minimum:
+        issues.append(f"Context is below Hermes minimum ({HERMES_MIN_CONTEXT}).")
+    if bootstrap_info.active:
+        issues.append("Full model is still downloading; bootstrap model is serving first-run traffic.")
+
+    if ready and bootstrap_info.active:
+        status = "bootstrap"
+    elif ready:
+        status = "ready"
+    else:
+        status = "blocked"
+
+    return {
+        "ready": ready,
+        "status": status,
+        "activeModel": loaded_model,
+        "configuredModel": {
+            "name": model_info.name,
+            "contextLength": configured_context,
+            "quantization": model_info.quantization,
+            "sizeGb": model_info.size_gb,
+        } if model_info else None,
+        "bootstrap": {
+            "active": bootstrap_info.active,
+            "model": bootstrap_info.model_name,
+            "percent": bootstrap_info.percent,
+            "downloadedGb": bootstrap_info.downloaded_gb,
+            "totalGb": bootstrap_info.total_gb,
+            "etaSeconds": bootstrap_info.eta_seconds,
+        },
+        "context": {
+            "configured": configured_context,
+            "runtime": runtime_context,
+            "effective": effective_context,
+            "hermesMinimum": HERMES_MIN_CONTEXT,
+            "hermesTarget": HERMES_TARGET_CONTEXT,
+            "meetsHermesMinimum": meets_hermes_minimum,
+            "meetsHermesTarget": meets_hermes_target,
+        },
+        "hermes": {
+            "compatible": meets_hermes_minimum,
+            "targetReady": meets_hermes_target,
+            "minimumContext": HERMES_MIN_CONTEXT,
+            "targetContext": HERMES_TARGET_CONTEXT,
+        },
+        "issues": issues,
+    }
+
+
 def _service_semantics(service_id: str, status: str) -> dict:
     config = SERVICES.get(service_id, {})
     category = config.get("category", "optional")
@@ -1088,6 +1158,23 @@ async def model(api_key: str = Depends(verify_api_key)):
 @app.get("/bootstrap", response_model=BootstrapStatus)
 async def bootstrap(api_key: str = Depends(verify_api_key)):
     return await asyncio.to_thread(get_bootstrap_status)
+
+
+@app.get("/api/model-readiness")
+async def api_model_readiness(api_key: str = Depends(verify_api_key)):
+    """Return first-run model/context readiness for Hermes and chat."""
+    model_info, bootstrap_info, loaded_model = await asyncio.gather(
+        asyncio.to_thread(get_model_info),
+        asyncio.to_thread(get_bootstrap_status),
+        get_loaded_model(),
+    )
+    runtime_context = await get_llama_context_size(model_hint=loaded_model)
+    return _build_model_readiness_payload(
+        model_info=model_info,
+        bootstrap_info=bootstrap_info,
+        loaded_model=loaded_model,
+        runtime_context=runtime_context,
+    )
 
 
 @app.get("/status", response_model=FullStatus)

--- a/dream-server/extensions/services/dashboard-api/tests/test_main.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_main.py
@@ -9,6 +9,7 @@ import pytest
 from main import (
     TTLCache,
     _build_api_status,
+    _build_model_readiness_payload,
     _build_readiness_payload,
     _fallback_services,
     _read_installed_version,
@@ -690,6 +691,75 @@ class TestCoreEndpoints:
         resp = test_client.get("/bootstrap", headers=test_client.auth_headers)
         assert resp.status_code == 200
         assert resp.json()["active"] is False
+
+
+# --- model readiness ---
+
+
+class TestModelReadiness:
+
+    def test_ready_when_loaded_context_meets_hermes_minimum(self):
+        from models import BootstrapStatus, ModelInfo
+
+        result = _build_model_readiness_payload(
+            model_info=ModelInfo(name="qwen", size_gb=6.0, context_length=131072, quantization="GGUF"),
+            bootstrap_info=BootstrapStatus(active=False),
+            loaded_model="qwen",
+            runtime_context=131072,
+        )
+
+        assert result["ready"] is True
+        assert result["status"] == "ready"
+        assert result["context"]["meetsHermesMinimum"] is True
+        assert result["context"]["meetsHermesTarget"] is True
+        assert result["hermes"]["compatible"] is True
+
+    def test_bootstrap_can_be_hermes_compatible_before_full_model_ready(self):
+        from models import BootstrapStatus, ModelInfo
+
+        result = _build_model_readiness_payload(
+            model_info=ModelInfo(name="qwen3.5-2b", size_gb=1.5, context_length=65536, quantization="GGUF"),
+            bootstrap_info=BootstrapStatus(active=True, model_name="full-model.gguf", percent=42.0),
+            loaded_model="qwen3.5-2b",
+            runtime_context=65536,
+        )
+
+        assert result["ready"] is True
+        assert result["status"] == "bootstrap"
+        assert result["context"]["meetsHermesMinimum"] is True
+        assert result["context"]["meetsHermesTarget"] is False
+        assert any("Full model is still downloading" in issue for issue in result["issues"])
+
+    def test_context_below_hermes_minimum_blocks_readiness(self):
+        from models import BootstrapStatus, ModelInfo
+
+        result = _build_model_readiness_payload(
+            model_info=ModelInfo(name="small", size_gb=1.0, context_length=8192),
+            bootstrap_info=BootstrapStatus(active=False),
+            loaded_model="small",
+            runtime_context=8192,
+        )
+
+        assert result["ready"] is False
+        assert result["status"] == "blocked"
+        assert result["hermes"]["compatible"] is False
+        assert any("Context is below Hermes minimum" in issue for issue in result["issues"])
+
+    def test_model_readiness_endpoint(self, test_client, monkeypatch):
+        from models import BootstrapStatus, ModelInfo
+
+        monkeypatch.setattr("main.get_model_info", lambda: ModelInfo(name="qwen", size_gb=6.0, context_length=131072))
+        monkeypatch.setattr("main.get_bootstrap_status", lambda: BootstrapStatus(active=False))
+        monkeypatch.setattr("main.get_loaded_model", AsyncMock(return_value="qwen"))
+        monkeypatch.setattr("main.get_llama_context_size", AsyncMock(return_value=131072))
+
+        resp = test_client.get("/api/model-readiness", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["ready"] is True
+        assert data["activeModel"] == "qwen"
+        assert data["hermes"]["targetReady"] is True
 
 
 # --- /status endpoint (FullStatus) ---


### PR DESCRIPTION
## Summary

Adds an explicit first-run model readiness contract to the dashboard API.

- adds authenticated `GET /api/model-readiness`
- reports configured model/context, live loaded model/context, bootstrap progress, and Hermes context suitability
- distinguishes `ready`, `bootstrap`, and `blocked` model readiness states
- treats 64K context as the Hermes minimum and 128K as the Hermes target-ready state
- adds tests for ready, bootstrap-compatible, blocked low-context, and endpoint responses

## Why

Users should not have to infer model/Hermes readiness from installer internals or raw status fields. This endpoint makes the first-run state explicit: whether the bootstrap model is serving traffic, whether the full model is still downloading, and whether the current context window can support Hermes.

## Validation

- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_main.py -q`
- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_routers.py -q`
- `python -m compileall -q dream-server/extensions/services/dashboard-api/main.py dream-server/extensions/services/dashboard-api/tests/test_main.py`
- `git diff --check`