### PR TITLE
fix(installer/health): bump embeddings link-wait 30 -> 150 attempts

### DIFF
--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -156,10 +156,15 @@ if [[ "$ENABLE_COMFYUI" == "true" ]]; then
     dream_progress 93 "health" "Waiting for Image generation"
     _check_health "ComfyUI" "http://127.0.0.1:${SERVICE_PORTS[comfyui]:-8188}${SERVICE_HEALTH[comfyui]:-/}" 150 15 "$(sr_container comfyui)"
 fi
-# Embeddings (TEI): model load on first run can take 1-2 minutes after start_period
+# Embeddings (TEI): 150 attempts * adaptive backoff = up to ~20 minutes.
+# Matches every other service. The 30-attempt cap (~230s total) used to
+# print spurious "embeddings delayed (may still be starting)" warnings on
+# fresh installs because TEI downloads its ONNX model from HuggingFace on
+# first start (BAAI/bge-base-en-v1.5 is ~440 MB), which can take 3-7 min
+# on bufferbloated networks before /health responds.
 if [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]]; then
     dream_progress 94 "health" "Waiting for Embeddings"
-    _check_health "embeddings" "http://127.0.0.1:${SERVICE_PORTS[embeddings]:-7860}${SERVICE_HEALTH[embeddings]:-/health}" 30 10 "$(sr_container embeddings)"
+    _check_health "embeddings" "http://127.0.0.1:${SERVICE_PORTS[embeddings]:-7860}${SERVICE_HEALTH[embeddings]:-/health}" 150 10 "$(sr_container embeddings)"
 fi
 
 # Perplexica auto-config: seed chat model + embedding model on first boot.


### PR DESCRIPTION
## Summary

- Phase 12 (`installers/phases/12-health.sh:162`) capped the embeddings TEI health check at 30 attempts (~230s budget) while every other service uses 150 attempts (~20min budget).
- On a fresh install where the BAAI/bge-base-en-v1.5 ONNX (~440MB) downloads on first start, 230s is exceeded routinely on bufferbloated networks. The installer prints `⚠ embeddings delayed (may still be starting) / ⚠ embeddings not responding yet. I will continue.` even though install is fully functional and embeddings comes healthy a few minutes later.
- Bringing embeddings in line with every other service health check; no behavior change on the cached path.

## Repro / evidence

Observed on tower2 (Linux/NVIDIA, full stack) on 2026-05-19. Bootstrap log:
```
⠹ Linking embeddings           [230s] (starting up)
⚠ embeddings delayed (may still be starting)
⚠ embeddings not responding yet. I will continue.
... [bootstrap continues, install completes rc=0] ...
```
A `docker ps` ~12 min later showed `dream-embeddings  Up 12 min (healthy)`. Same WiFi link historically slow for HF pulls (operator memory `hf_downloads_tower2`).

## Test plan

- [x] `bash -n installers/phases/12-health.sh` — syntax OK
- [ ] CI: shellcheck + smoke tests
- [ ] Manual: fresh install on bufferbloated link should no longer print the embeddings-delayed warning
- [ ] Manual: install with cached embeddings should still complete in single attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)