### PR TITLE
fix(dashboard-api/extensions): surface install error_message in catalog

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -882,6 +882,14 @@ async def extensions_catalog(
             "dependents": [],
             "dependency_status": {},
         }
+        # Surface install-failure reason inline. The progress file already
+        # records `error` (set by _write_error_progress) but it lives behind
+        # a separate /progress endpoint, so a caller seeing `status: "error"`
+        # in the catalog has no idea why without a second round-trip.
+        if status == "error":
+            _progress = _read_progress(ext_id)
+            if _progress and _progress.get("error"):
+                enriched["error_message"] = _progress["error"]
 
         if category and ext.get("category") != category:
             continue
@@ -1012,11 +1020,19 @@ async def extension_detail(
     user_dir = USER_EXTENSIONS_DIR / service_id
     source = "user" if user_dir.is_dir() else ("core" if service_id in SERVICES else "library")
 
+    # See extensions_catalog: same rationale for inlining the install error.
+    error_message: Optional[str] = None
+    if status == "error":
+        _progress = _read_progress(service_id)
+        if _progress and _progress.get("error"):
+            error_message = _progress["error"]
+
     return {
         "id": ext["id"],
         "name": ext["name"],
         "description": ext.get("description", ""),
         "status": status,
+        "error_message": error_message,
         "source": source,
         "installable": installable,
         "manifest": ext,


### PR DESCRIPTION
## Summary

- When extension install fails, `_write_error_progress()` records the reason in `DATA_DIR/extension-progress/<id>.json` under the `error` key.
- But that data only flows through `GET /api/extensions/<id>/progress`. The catalog (`GET /api/extensions/catalog`) and detail (`GET /api/extensions/<id>`) endpoints only expose `status: "error"` — callers can see the failure but not the cause.
- Inline the recorded error message as `error_message` in both endpoints when `status == "error"`. Omitted/null otherwise.

## Repro

On 2026-05-19 fleet-test, m5-mbp's aider install hung on `docker compose pull paulgauthier/aider:v0.86.2` over WiFi. Eventually ended up in error state. Catalog response:

```json
{ "id": "aider", "status": "error", /* no clue why */ }
```

With this change:

```json
{ "id": "aider", "status": "error",
  "error_message": "docker compose pull failed: ...", ... }
```

The fleet-test harness and dashboard UI can now display the actual failure without a separate /progress round-trip.

## Test plan

- [x] `python3 -m py_compile` — OK
- [ ] CI: pytest tests/test_extensions.py
- [ ] Manual: trigger a failing install, check catalog response includes `error_message`
- [ ] Manual: GET `/api/extensions/<id>` for a healthy ext, see `error_message: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)