### PR TITLE
[codex] Add Windows installer flag parity

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Windows Install Readiness Summary Tests
         run: bash tests/test-windows-readiness-summary.sh
 
+      - name: Windows Installer Flag Tests
+        run: bash tests/test-windows-installer-flags.sh
+
       - name: Validate Env Tests
         run: bash tests/test-validate-env.sh
 

--- a/dream-server/docs/WINDOWS-QUICKSTART.md
+++ b/dream-server/docs/WINDOWS-QUICKSTART.md
@@ -67,6 +67,7 @@ The installer automatically uses bootstrap mode when applicable — a small mode
 | `-Rag` | Enable Qdrant vector DB |
 | `-Hermes` | Enable Hermes Agent explicitly |
 | `-NoHermes` | Disable Hermes Agent |
+| `-NoBootstrap` | Wait for the full model before launching |
 | `-OpenClaw` | Enable deprecated OpenClaw agent framework |
 | `-Comfyui` | Enable ComfyUI image generation |
 | `-Langfuse` | Enable Langfuse LLM observability |

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -31,6 +31,7 @@
 #   .\install-windows.ps1 --DryRun         # Validate without installing
 #   .\install-windows.ps1 --All            # Enable all optional services
 #   .\install-windows.ps1 -NoHermes        # Disable Hermes Agent
+#   .\install-windows.ps1 -NoBootstrap     # Wait for full model before launch
 #   .\install-windows.ps1 --NonInteractive # Headless install (defaults)
 #
 # ============================================================================
@@ -54,6 +55,7 @@ param(
     [switch]$Lan,
     [switch]$Langfuse,
     [switch]$NoLangfuse,
+    [switch]$NoBootstrap,
     [string]$SummaryJsonPath = ""
 )
 
@@ -97,6 +99,7 @@ $noComfyuiFlag  = $NoComfyui.IsPresent
 $lanFlag        = $Lan.IsPresent
 $langfuseFlag   = $Langfuse.IsPresent
 $noLangfuseFlag = $NoLangfuse.IsPresent
+$noBootstrapFlag = $NoBootstrap.IsPresent
 $installDir     = $script:DS_INSTALL_DIR
 $sourceRoot     = $SourceRoot
 
@@ -210,7 +213,8 @@ if ($dryRun) {
         $fullTierConfig = $null
 
         if (Should-UseBootstrap -Tier $selectedTier -InstallDir $installDir `
-                -GgufFile $tierConfig.GgufFile -CloudMode $cloudMode) {
+                -GgufFile $tierConfig.GgufFile -CloudMode $cloudMode `
+                -NoBootstrap $noBootstrapFlag) {
             $bootstrapActive = $true
             $fullTierConfig = @{}
             foreach ($k in $tierConfig.Keys) { $fullTierConfig[$k] = $tierConfig[$k] }

--- a/dream-server/tests/test-windows-installer-flags.sh
+++ b/dream-server/tests/test-windows-installer-flags.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Dream Server Windows installer flag parity tests
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$ROOT_DIR/.." && pwd)"
+ROOT_INSTALLER="$REPO_ROOT/install.ps1"
+WINDOWS_INSTALLER="$ROOT_DIR/installers/windows/install-windows.ps1"
+WINDOWS_QUICKSTART="$ROOT_DIR/docs/WINDOWS-QUICKSTART.md"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+echo ""
+echo "=== Windows installer flag parity tests ==="
+echo ""
+
+[[ -f "$ROOT_INSTALLER" ]] && pass "root Windows installer wrapper exists" || fail "root Windows installer wrapper missing"
+[[ -f "$WINDOWS_INSTALLER" ]] && pass "Windows installer orchestrator exists" || fail "Windows installer orchestrator missing"
+
+for flag in Hermes NoHermes Langfuse NoLangfuse NoBootstrap; do
+    check "[switch]\$$flag" "$ROOT_INSTALLER" "root wrapper forwards -$flag"
+done
+
+check "[switch]\$NoBootstrap" "$WINDOWS_INSTALLER" "Windows installer exposes -NoBootstrap"
+check '$noBootstrapFlag = $NoBootstrap.IsPresent' "$WINDOWS_INSTALLER" "Windows installer captures -NoBootstrap"
+check '-NoBootstrap $noBootstrapFlag' "$WINDOWS_INSTALLER" "Windows bootstrap decision receives -NoBootstrap"
+
+check '| `-NoHermes` | Disable Hermes Agent |' "$WINDOWS_QUICKSTART" "Windows quickstart documents -NoHermes"
+check '| `-NoBootstrap` | Wait for the full model before launching |' "$WINDOWS_QUICKSTART" "Windows quickstart documents -NoBootstrap"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/install.ps1
+++ b/install.ps1
@@ -9,11 +9,16 @@ param(
     [switch]$Voice,
     [switch]$Workflows,
     [switch]$Rag,
+    [switch]$Hermes,
+    [switch]$NoHermes,
     [switch]$OpenClaw,
     [switch]$All,
     [switch]$Cloud,
     [switch]$Comfyui,
     [switch]$NoComfyui,
+    [switch]$Langfuse,
+    [switch]$NoLangfuse,
+    [switch]$NoBootstrap,
     [switch]$Lan,
     [string]$SummaryJsonPath = ""
 )


### PR DESCRIPTION
## Summary
- Forward missing Windows root installer flags for Hermes and Langfuse controls
- Expose `-NoBootstrap` in the Windows installer and pass it into the existing bootstrap decision helper
- Document `-NoBootstrap` and add a CI-wired static parity test for Windows installer flags

## Why
The Windows root wrapper and orchestrator had drifted from the installer behavior: `-NoHermes` existed in the real installer but not the root wrapper, and `Should-UseBootstrap` already supported `NoBootstrap` without a user-facing switch. This makes the first-run install surface more predictable.

## Validation
- `bash dream-server/tests/test-windows-installer-flags.sh` -> 12 passed
- `bash -n dream-server/tests/test-windows-installer-flags.sh`
- PowerShell parser checks for `install.ps1` and `dream-server/installers/windows/install-windows.ps1`
- `bash dream-server/tests/test-windows-readiness-summary.sh` -> 7 passed
- `git diff --check`