### PR TITLE
fix(hermes): default web-search backend to bundled SearXNG

### DIFF
--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -41,6 +41,16 @@ services:
       # --no-open equivalent: stops Hermes from trying to spawn a browser
       # inside the container.
       - HERMES_DASHBOARD_NO_OPEN=1
+      # Point Hermes's web tools at the bundled SearXNG. Without this,
+      # tools/web_tools.py:_get_backend() falls through paid backends
+      # (Firecrawl / Parallel / Tavily / Exa) — all of which require API
+      # keys we don't ship — and ultimately defaults to "firecrawl",
+      # raising a backend-configuration error on every web_search /
+      # web_extract call. SearXNG is the only backend bundled with the
+      # stack and is always reachable on the dream-network, so it's the
+      # right default. Users wanting Firecrawl/Tavily/etc. still set the
+      # paid backend's API key and it takes priority over SEARXNG_URL.
+      - SEARXNG_URL=${SEARXNG_URL:-http://searxng:8080}
       # Enable the in-browser chat tab. Hermes's chat surface is PTY-
       # backed (it runs a real REPL inside the container and pipes it
       # to the browser via WebSocket on /api/pty + /api/ws + /api/events).

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -33,7 +33,7 @@ service:
   gpu_backends: [all]
   compose_file: compose.yaml
   category: recommended
-  depends_on: [llama-server]
+  depends_on: [llama-server, searxng]
   description: >
     Hermes Agent (Nous Research) — a self-improving generalist agent with
     persistent memory, autonomous skill creation, and 70+ built-in tools.
@@ -57,6 +57,9 @@ service:
       description: |
         Dummy API key — llama-server doesn't validate it but the OpenAI SDK
         Hermes uses internally requires the field to be non-empty.
+    - key: SEARXNG_URL
+      default: "http://searxng:8080"
+      description: Hermes web-search backend. Defaults to Dream's bundled SearXNG service.
     # Note: there is intentionally no HERMES_MODEL_NAME here. The model
     # name lives in /opt/data/config.yaml after first start; an earlier
     # draft exposed an env var, but the upstream image doesn't read it


### PR DESCRIPTION
## Summary

The Hermes container ships with no web-search backend wired up. Its backend-selection fallback in `tools/web_tools.py:_get_backend()` checks env vars in priority order (Firecrawl > Parallel > Tavily > Exa > SearXNG > Brave-free > DDGS) and ultimately defaults to `"firecrawl"` when nothing is set — at which point every `web_search` / `web_extract` call raises a backend-configuration error.

The stack already deploys a healthy SearXNG container reachable as `http://searxng:8080` on the dream-network. Plumbing `SEARXNG_URL` into the Hermes container picks it up via the existing fallback without any new code paths.

## Repro

On 2026-05-19, a user reported the Hermes agent on the strix-halo install couldn't use web search. Verified across the fleet:

```bash
$ ssh strix-halo 'docker exec dream-hermes env | grep -iE "SEARXNG|FIRECRAWL|TAVILY|EXA_|PARALLEL_API|BRAVE_SEARCH"'
(empty)
```

Same on tower2, spark, mac-mini, m5-mbp. Meanwhile:

```bash
$ ssh strix-halo 'docker exec dream-hermes curl -s "http://searxng:8080/search?q=anthropic&format=json"' | head -c 100
{"query": "anthropic", "number_of_results": 0, "results": [{"url": "https://www.anthropic.com/", ...
```

So the backend is fully functional, just not pointed at.

## Why this change is safe

- Picks up via the existing `_get_backend()` env-var fallback ladder. No new code paths.
- Paid backends still win — if a user sets `FIRECRAWL_API_KEY` / `PARALLEL_API_KEY` / `TAVILY_API_KEY` / `EXA_API_KEY`, the existing priority order means SearXNG is overridden. (Order preserved.)
- `SEARXNG_URL=${SEARXNG_URL:-http://searxng:8080}` honors a user override in `.env`.

## Test plan

- [x] `docker compose config` validates
- [x] Confirmed dream-hermes can reach `http://searxng:8080` from inside the container
- [ ] Manual smoke: ask Hermes a current-events question, observe SearXNG tool call instead of Firecrawl-missing-key error
- [ ] Paid backend regression: set `FIRECRAWL_API_KEY` and confirm `_get_backend()` returns `firecrawl`, not `searxng`

🤖 Generated with [Claude Code](https://claude.com/claude-code)