### PR TITLE
fix(openclaw): drop broken /v1 upstream from Open WebUI model picker

### DIFF
--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -52,9 +52,20 @@ services:
         max-size: "10m"
         max-file: "3"
 
-  # When OpenClaw is enabled, register it as a second model backend in Open WebUI.
-  # Port 18790 is the OpenAI-compat shim (serves /v1/models + proxies /v1/chat/completions).
-  open-webui:
-    environment:
-      - OPENAI_API_BASE_URLS=${LLM_API_URL:-http://llama-server:8080}/v1;http://openclaw:18790/v1
-      - OPENAI_API_KEYS=;${OPENCLAW_TOKEN:-}
+  # NOTE: OpenClaw's OpenAI-compat shim (port 18790) is conditional on
+  # OPENCLAW_HTTP_API=true, which is not set anywhere in our compose path
+  # — so 18790 isn't listening, and an Open WebUI override that adds
+  # `http://openclaw:18790/v1` to OPENAI_API_BASE_URLS produced
+  # "Connection refused" against the second upstream, breaking the model
+  # dropdown entirely (it would silently swallow llama-server's models
+  # depending on the OWUI version's fan-out failure mode).
+  #
+  # Given OpenClaw is being deprecated in favor of Hermes Agent (see
+  # docs/HERMES.md "OpenClaw migration"), the right move is to stop
+  # routing Open WebUI through the broken shim. Users wanting the
+  # OpenClaw UI directly still reach it on its host port (default 7860,
+  # bound by `ports:` above).
+  #
+  # If we ever want to re-add OpenClaw as a WebUI backend, the fix is:
+  # (a) set OPENCLAW_HTTP_API=true on the openclaw service to enable
+  #     the 18790 shim, and (b) restore the upstream block below.


### PR DESCRIPTION
## Summary

Open WebUI's model dropdown is loading empty (or fails entirely, depending on OWUI version) because its `OPENAI_API_BASE_URLS` contains an OpenClaw upstream that nothing is actually listening on.

- `extensions/services/openclaw/compose.yaml` declares `OPENCLAW_HTTP_API=${OPENCLAW_HTTP_API:-}` (empty default).
- OpenClaw's port 18790 is the OpenAI-compat shim that's only started when `OPENCLAW_HTTP_API=true`.
- The same compose file unconditionally adds `http://openclaw:18790/v1` to Open WebUI's upstream list.
- Result: Open WebUI fans out to two upstreams, one returns "Connection refused", model dropdown fails.

## Repro (tower2, 2026-05-19)

```
$ docker exec dream-webui sh -c \
    'curl -sv --max-time 5 http://openclaw:18790/v1/models 2>&1' | tail -3
* connect to 172.18.0.20 port 18790 failed: Connection refused
```

While the primary upstream works:

```
$ docker exec dream-webui sh -c \
    'curl -s http://llama-server:8080/v1/models | head -c 100'
{"models":[{"name":"qwen3-coder-next-Q4_K_M.gguf",...
```

## Why drop, not fix-by-enabling-shim

Per `docs/HERMES.md` "OpenClaw migration" and the swap PR chain that landed 2026-05-12, OpenClaw is being deprecated in favor of Hermes Agent. Re-enabling the shim by setting `OPENCLAW_HTTP_API=true` would also expose users to OpenClaw's heavy-system-prompt context-bloat — observed today as "context size exceeded on a single user message" against a 128k-ctx llama-server. Not a path worth shoring up during deprecation. Users who want OpenClaw's UI still reach it directly on its host port.

If anyone wants to re-add OpenClaw as a WebUI backend later, the recipe is preserved in a comment in the changed file.

## Test plan

- [x] `docker compose config` validates (with `OPENCLAW_TOKEN` set)
- [ ] Manual: fresh install → Open WebUI dropdown shows llama-server's models (e.g. qwen3-coder-next) on first page load
- [ ] Manual: OpenClaw's own UI still reachable on its host port (default 7860)

🤖 Generated with [Claude Code](https://claude.com/claude-code)