### PR TITLE
fix(installer): include dream-proxy in --all so magic-link invites resolve

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -220,7 +220,13 @@ while [[ $# -gt 0 ]]; do
         # --all enables Hermes (the new default agent) but NOT OpenClaw —
         # the deprecated agent is opt-in via --openclaw for the deprecation
         # release. Will be dropped entirely in the removal release.
-        --all) ENABLE_VOICE=true; ENABLE_WORKFLOWS=true; ENABLE_RAG=true; ENABLE_RECOMMENDED=true; ENABLE_HERMES=true; ENABLE_OPENCLAW=false; ENABLE_COMFYUI=true; ENABLE_APE=true; ENABLE_PERPLEXICA=true; ENABLE_PRIVACY_SHIELD=true; ENABLE_LANGFUSE=true; shift ;;
+        # ENABLE_DREAM_PROXY is included so magic-link invite URLs
+        # (http://auth.<device>.local/magic-link/<token>) actually resolve.
+        # Without dream-proxy on host :80, mDNS publishes the hostname but
+        # nothing serves it, and a phone clicking the invite gets
+        # "site can't be reached." Operators who don't want the LAN-facing
+        # surface can set ENABLE_DREAM_PROXY=false in .env after install.
+        --all) ENABLE_VOICE=true; ENABLE_WORKFLOWS=true; ENABLE_RAG=true; ENABLE_RECOMMENDED=true; ENABLE_HERMES=true; ENABLE_OPENCLAW=false; ENABLE_COMFYUI=true; ENABLE_APE=true; ENABLE_PERPLEXICA=true; ENABLE_PRIVACY_SHIELD=true; ENABLE_LANGFUSE=true; ENABLE_DREAM_PROXY=true; shift ;;
         --non-interactive) INTERACTIVE=false; shift ;;
         --offline) OFFLINE_MODE=true; shift ;;
         --lan) BIND_ADDRESS="0.0.0.0"; shift ;;

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -136,6 +136,7 @@ if $ALL_FEATURES; then
     ENABLE_APE=true
     ENABLE_PERPLEXICA=true
     ENABLE_PRIVACY_SHIELD=true
+    ENABLE_DREAM_PROXY=true
     # --all enables Langfuse unless the user explicitly passed --no-langfuse.
     $NO_LANGFUSE_EXPLICIT || ENABLE_LANGFUSE=true
 fi


### PR DESCRIPTION
## Summary

`--all` doesn't include `dream-proxy`, but magic-link invite URLs assume `dream-proxy` is running. Result: every fresh `--all` install ships a magic-link page that generates dead URLs.

- Magic-link generates `http://auth.<DREAM_DEVICE_NAME>.local/magic-link/<token>`.
- `dream-mdns` (phase 07-devtools) publishes `<device>.local` on the LAN — the phone resolves the hostname fine.
- But nothing listens on host port 80, because `dream-proxy` is opt-in (`ENABLE_DREAM_PROXY=false` default at `install-core.sh:118`) and the `--all` flag handler at `install-core.sh:223` doesn't flip it.
- Phone clicking the invite gets "site can't be reached."

## Repro (strix-halo, 2026-05-19)

```
$ ssh strix-halo 'docker ps --format "{{.Names}}" | grep -i proxy'
dream-hermes-proxy        # only

$ ssh strix-halo 'sudo lsof -nP -iTCP:80 -sTCP:LISTEN'
# empty — nothing serves auth.dream.local

$ ssh strix-halo 'curl -X POST .../api/auth/magic-link/generate ...'
{ "url": "http://auth.dream.local/magic-link/i96uHR-...", ... }
```

User report: "When I use an invite link on my phone from the strix, it doesn't take me anywhere — there's no place to chat with an agent."

## Why include in --all (not flip the global default)

`dream-proxy` is the LAN-facing surface — everything else stays loopback-bound, and the proxy is what makes the device's services reachable from a phone on the same network. `--all` already enables every other LAN-shareable surface (chat, dashboard, voice, research, etc.). Including `dream-proxy` in `--all` keeps the global default (`false`) so operators who don't pass `--all` are unaffected.

Opt-out is preserved: `--all` + `ENABLE_DREAM_PROXY=false` in `.env` still disables it.

## Test plan

- [x] `bash -n install-core.sh` syntax-checks clean
- [ ] CI: matrix-smoke + installer-contract tests pick up the addition under `--all`
- [ ] Manual: fresh `--all` install → `docker ps` includes `dream-proxy` → magic-link URL opens chat on the phone
- [ ] Manual: `--all` + `ENABLE_DREAM_PROXY=false` in `.env` still disables it (opt-out preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)