### PR TITLE
fix(installer): derive DREAM_DEVICE_NAME from hostname for LAN uniqueness

### DIFF
--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -82,6 +82,34 @@ detect_host_lan_ip() {
     printf '%s\n' "$ip"
 }
 
+sanitize_device_name() {
+    local raw="${1:-}"
+    local name
+    name="$(printf '%s' "$raw" \
+        | tr '[:upper:]' '[:lower:]' \
+        | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//' \
+        | cut -c1-32 \
+        | sed -E 's/-+$//')"
+    if [[ -n "$name" && "$name" =~ ^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$ ]]; then
+        printf '%s\n' "$name"
+    else
+        printf 'dream\n'
+    fi
+}
+
+detect_device_name() {
+    local raw=""
+    # macOS users often set LocalHostName for Bonjour sharing; prefer it
+    # because it already represents the host's LAN identity.
+    if command -v scutil >/dev/null 2>&1; then
+        raw="$(scutil --get LocalHostName 2>/dev/null || true)"
+    fi
+    if [[ -z "$raw" ]] && command -v hostname >/dev/null 2>&1; then
+        raw="$(hostname -s 2>/dev/null || hostname 2>/dev/null || true)"
+    fi
+    sanitize_device_name "$raw"
+}
+
 # Detect system timezone (macOS-specific)
 detect_timezone() {
     local tz=""
@@ -154,6 +182,12 @@ generate_dream_env() {
         # gate effectively breaks). Rotating invalidates every issued cookie.
         if [[ -z "$(read_env_value "$env_path" "DREAM_SESSION_SECRET")" ]]; then
             upsert_env_value "$env_path" "DREAM_SESSION_SECRET" "$(new_secure_hex 32)"
+        fi
+        # DREAM_DEVICE_NAME backfill: older macOS installs omitted this key,
+        # so magic links defaulted to auth.dream.local/chat.dream.local and
+        # collided with every other default install on the LAN.
+        if [[ -z "$(read_env_value "$env_path" "DREAM_DEVICE_NAME")" ]]; then
+            upsert_env_value "$env_path" "DREAM_DEVICE_NAME" "$(detect_device_name)"
         fi
 
         # HOST_LAN_IP backfill: the fresh-install heredoc below populates
@@ -241,6 +275,8 @@ generate_dream_env() {
     if [[ "${BIND_ADDRESS:-127.0.0.1}" == "0.0.0.0" ]]; then
         host_lan_ip=$(detect_host_lan_ip)
     fi
+    local device_name
+    device_name=$(detect_device_name)
 
     local tz
     tz=$(detect_timezone)
@@ -257,6 +293,10 @@ generate_dream_env() {
 # macOS has no --lan flag; operators opt in by setting BIND_ADDRESS=0.0.0.0
 # manually. HOST_LAN_IP is only populated when that pre-existed at install time.
 HOST_LAN_IP=${host_lan_ip}
+# Device name used by dream-mdns/dream-proxy hostnames and magic-link URLs.
+# Derived from the macOS LocalHostName/hostname so multiple installs on one LAN
+# do not all collide on auth.dream.local/chat.dream.local.
+DREAM_DEVICE_NAME=${device_name}
 # Docker Desktop containers reach loopback-only host services through this name.
 DREAM_AGENT_HOST=${DREAM_AGENT_HOST:-host.docker.internal}
 

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -327,6 +327,34 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     # used for every other persistent value in this phase).
     HOST_LAN_IP=$(_env_get HOST_LAN_IP "$HOST_LAN_IP")
 
+    # Device name — used by dream-mdns (publishes <name>.local + per-service
+    # subdomains: auth.<name>.local, chat.<name>.local, etc.) and by magic-
+    # link URL generation in dashboard-api. The previous default literal
+    # "dream" causes mDNS NonUniqueNameException collisions when more than
+    # one Dream Server install is on the same LAN: the first one wins and
+    # every subsequent host's mDNS service crash-loops, so phones following
+    # invite QR codes from the losing hosts land on the winning host (or
+    # nothing at all). Auto-derive from the system hostname for per-host
+    # uniqueness, sanitized to match .env.schema.json's pattern
+    # (^[a-zA-Z0-9][a-zA-Z0-9-]{0,30}[a-zA-Z0-9]$|^[a-zA-Z0-9]$). Fall back
+    # to "dream" only when the hostname can't be sanitized into the schema.
+    _device_default="dream"
+    if command -v hostname >/dev/null 2>&1; then
+        _raw_hn="$(hostname -s 2>/dev/null || hostname 2>/dev/null || true)"
+        # Lowercase; collapse any non-[a-z0-9-] to a single '-'; trim
+        # leading/trailing '-'; cap at 32 chars.
+        _hn="$(printf '%s' "$_raw_hn" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed -E 's/[^a-z0-9-]+/-/g; s/^-+//; s/-+$//' \
+            | cut -c1-32 \
+            | sed -E 's/-+$//')"
+        # Schema requires first + last char alphanumeric.
+        if [[ -n "$_hn" && "$_hn" =~ ^[a-z0-9]([a-z0-9-]{0,30}[a-z0-9])?$ ]]; then
+            _device_default="$_hn"
+        fi
+    fi
+    DREAM_DEVICE_NAME=$(_env_get DREAM_DEVICE_NAME "$_device_default")
+
     # Whisper STT model — NVIDIA picks the larger turbo model, everyone else
     # uses base. Phase 12 reads this to pre-download the right file, and
     # Open WebUI reads it to request the same model for transcription.
@@ -538,6 +566,15 @@ WHISPER_MODEL=base
 # Auto-selected based on GPU backend; edit to override.
 AUDIO_STT_MODEL=${AUDIO_STT_MODEL}
 TTS_VOICE=en_US-lessac-medium
+
+#=== Device Name / mDNS / Proxy hostnames ===
+# Used by dream-mdns to publish <name>.local on the LAN, by dream-proxy
+# to route auth/chat/dashboard subdomains, and by dashboard-api when
+# generating magic-link invite URLs. Auto-derived from the system
+# hostname at install time so multiple Dream Server installs on the
+# same LAN don't collide on a shared default name. Override by editing
+# this line and restarting dream-mdns + dream-proxy.
+DREAM_DEVICE_NAME=${DREAM_DEVICE_NAME}
 
 #=== Web UI Settings ===
 WEBUI_AUTH=true


### PR DESCRIPTION
## Summary

The previous default literal `"dream"` causes mDNS `NonUniqueNameException` collisions when more than one Dream Server install is on the same LAN. The first install wins `auth.dream.local` / `chat.dream.local` / `dashboard.dream.local`; every subsequent host's `dream-mdns.service` crashes on register, gets put in a systemd auto-restart loop, and never publishes its records.

Phones following invite-link QR codes from the losing hosts either:
- resolve to the winning host (wrong install's UI), or
- get NXDOMAIN with no error surfaced to the user.

## Repro (fleet, 2026-05-19)

```
$ ssh strix-halo 'systemctl status dream-mdns --no-pager'
Active: activating (auto-restart) (Result: exit-code) since ...
  zeroconf._exceptions.NonUniqueNameException
```

Meanwhile Tower2 had already won the race:

```
Published dream-proxy-auth._http._tcp.local. -> 192.168.0.175:80 (server auth.dream.local.)
```

Both hosts had defaulted to `DREAM_DEVICE_NAME=dream`. Strix's invite links pointed at `auth.dream.local` which routes to Tower2 (the winner), so the user's phone landed on the wrong machine's chat surface.

## Fix

`installers/phases/06-directories.sh`: derive `DREAM_DEVICE_NAME` from `hostname -s` at install time. Sanitize to match `.env.schema.json`'s pattern (lowercase, `[a-z0-9-]`, first+last char alphanumeric, ≤32 chars). Fall back to `"dream"` only if hostname is missing or sanitizes to empty. `_env_get` preserves operator overrides across re-runs.

Sanitizer behavior:

| raw hostname | sanitized | result |
|---|---|---|
| `Tower2` | `tower2` | use |
| `dream-server` | `dream-server` | use |
| `michaels-Mini.localdomain` | `michaels-mini-localdomain` | use |
| `very-long-hostname-...-32-chars+` | (truncated) | use |
| `""` / `---` | `""` | fall back to "dream" |

## Test plan

- [x] `bash -n installers/phases/06-directories.sh` — syntax OK
- [x] Sanitizer smoke against all the above hostnames — all map correctly
- [ ] Fresh install on 2+ hosts on the same LAN → each gets a unique `DREAM_DEVICE_NAME` in its `.env` → `dream-mdns` publishes without `NonUniqueNameException` → magic-link URLs resolve on all hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)