### PR TITLE
refactor(dashboard): tuck Usage + Invites into Settings → Account section

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -596,7 +596,7 @@ function DoneScreen({ invite, onDone }) {
       </div>
 
       <p className="text-xs text-theme-text-muted mt-6 text-center">
-        Need more invites later? They live under <strong>Invites</strong> in the sidebar.
+        Need more invites later? They live under <strong>Settings</strong> / <strong>Account</strong>.
       </p>
     </div>
   )

--- a/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
@@ -6,8 +6,12 @@ import {
   Download,
   Network,
   FileText,
+  UserPlus,
+  CreditCard,
+  ChevronRight,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import EnvEditor from '../components/settings/EnvEditor'
 
 const fetchJson = async (url, ms = 8000, options = {}) => {
@@ -247,6 +251,23 @@ export default function Settings() {
       <div className="max-w-5xl space-y-6 liquid-metal-sequence-grid liquid-metal-sequence-grid--services">
         <SettingsSection title="System Identity" icon={Server}><div className="grid gap-4 sm:grid-cols-2"><InfoRow label="Version" value={version?.version || 'Unknown'} /><InfoRow label="Install Date" value={version?.install_date || 'Unknown'} /><InfoRow label="Tier" value={version?.tier || 'Community'} /><InfoRow label="Uptime" value={version?.uptime || 'Unknown'} /></div></SettingsSection>
 
+        <SettingsSection title="Account" icon={SettingsIcon}>
+          <div className="divide-y divide-theme-border">
+            <SettingsNavRow
+              to="/usage"
+              icon={CreditCard}
+              label="Usage"
+              description="Token and request counts, model-level cost insights, and historical activity."
+            />
+            <SettingsNavRow
+              to="/invites"
+              icon={UserPlus}
+              label="Invites"
+              description="Create, share, and revoke magic-link invites for trusted devices."
+            />
+          </div>
+        </SettingsSection>
+
         {services.length > 0 ? <SettingsSection title="Routing Table" icon={Network}><div className="space-y-3"><div className="flex flex-wrap items-center gap-2"><p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-theme-text-muted/60">route surfaces</p><span className="rounded-full border border-white/10 bg-black/[0.12] px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.16em] text-theme-text">{getDashboardHost()}</span></div><div className="grid gap-3 xl:grid-cols-3">{routingGroups.map(group => <RoutingGroup key={group.key} {...group} />)}</div></div></SettingsSection> : null}
 
         {envEditor ? <SettingsSection title="Environment Editor" icon={FileText}><EnvEditor editor={envEditor} search={envSearch} onSearchChange={setEnvSearch} sections={envSections} activeSection={activeEnvSection} onSectionChange={setEnvActiveSection} fields={envFields} values={envValues} issues={envIssues} issueMap={envIssueMap} revealedSecrets={envRevealSecrets} onToggleReveal={(key) => setEnvRevealSecrets(current => ({ ...current, [key]: !current[key] }))} onFieldChange={(key, value) => setEnvValues(current => ({ ...current, [key]: value }))} onReload={() => fetchEnvEditor({ announce: true })} onSave={handleSaveEnv} onApply={handleApplyEnv} dirty={envDirty} saving={envSaving} applyPlan={envApplyPlan} applying={envApplying} /></SettingsSection> : null}
@@ -289,3 +310,19 @@ function StorageBlock({ storage }) {
 }
 
 function ActionButton({ icon: Icon, label, description, onClick }) { return <button onClick={onClick} className="w-full flex items-center gap-4 p-3 rounded-lg transition-colors hover:bg-theme-surface-hover"><Icon size={20} className="text-theme-text-muted" /><div className="text-left"><p className="text-sm text-theme-text font-medium">{label}</p><p className="text-xs text-theme-text-muted">{description}</p></div></button> }
+
+// Settings → sub-page link row. Mirrors the visual shape of ActionButton
+// but renders a router <Link> so navigation works without an onClick handler
+// and the route gets registered with the SPA's history/scroll restoration.
+function SettingsNavRow({ to, icon: Icon, label, description }) {
+  return (
+    <Link to={to} className="flex items-center gap-4 p-3 rounded-lg transition-colors hover:bg-theme-surface-hover">
+      <Icon size={20} className="text-theme-text-muted" />
+      <div className="flex-1 text-left">
+        <p className="text-sm text-theme-text font-medium">{label}</p>
+        <p className="text-xs text-theme-text-muted">{description}</p>
+      </div>
+      <ChevronRight size={16} className="text-theme-text-muted/60" />
+    </Link>
+  )
+}

--- a/dream-server/extensions/services/dashboard/src/plugins/core.js
+++ b/dream-server/extensions/services/dashboard/src/plugins/core.js
@@ -71,6 +71,11 @@ export const coreRoutes = [
     sidebar: true,
     order: 3,
   },
+  // Usage + Invites are reachable from the Settings page ("Account" section)
+  // rather than the top-level sidebar — the sidebar was getting crowded and
+  // these are settings-adjacent surfaces (one is billing-style insight, the
+  // other is share-link admin). Direct URLs still work for bookmarks and
+  // for the magic-link redemption page which renders inside this dashboard.
   {
     id: 'usage',
     path: '/usage',
@@ -78,7 +83,7 @@ export const coreRoutes = [
     icon: CreditCard,
     component: Usage,
     getProps: ({ status }) => ({ status }),
-    sidebar: true,
+    sidebar: false,
     order: 3.5,
   },
   {
@@ -88,7 +93,7 @@ export const coreRoutes = [
     icon: UserPlus,
     component: Invites,
     getProps: () => ({}),
-    sidebar: true,
+    sidebar: false,
     order: 4,
   },
   {


### PR DESCRIPTION
## Summary

Sidebar had grown to seven top-level items. Usage + Invites are settings-adjacent surfaces (billing-style insight and share-link admin) — neither needs the constant visibility of a top-level slot the way the rest do.

This PR moves both into a new "Account" section inside the Settings page, while keeping their URLs and routes intact (so bookmarks, magic-link redemption redirects, and any deep links still work).

## Before / after

**Sidebar before:** Dashboard, GPU Monitor*, Extensions, Integrations, Models, **Usage**, **Invites**, Settings
**Sidebar after:** Dashboard, GPU Monitor*, Extensions, Integrations, Models, Settings

(*GPU Monitor only on multi-GPU hosts; unchanged.)

The Settings page gets a new "Account" SettingsSection near the top with two `<Link>`-driven nav rows pointing to `/usage` and `/invites`.

## Implementation

Two-file change:

1. **`plugins/core.js`** — flip `sidebar: true` → `sidebar: false` on the usage + invites entries. `getSidebarNavItems()` filters on `route.sidebar !== false`, so this hides the entries from the sidebar without un-registering the routes. Direct URLs and the magic-link redemption flow (which 302s into this SPA at `/usage` or `/invites`) keep working.

2. **`pages/Settings.jsx`** — add an "Account" SettingsSection with two nav rows. New `SettingsNavRow` helper mirrors `ActionButton`'s visual shape but renders a router `<Link>` for proper SPA navigation. Adds three icon imports (`UserPlus`, `CreditCard`, `ChevronRight`) and `Link` from `react-router-dom`.

## Test plan

- [x] `npx eslint src/plugins/core.js src/pages/Settings.jsx` — no errors
- [x] `npx vitest run Sidebar Settings Invites Usage` — 3 test files, 12 tests, all pass
- [ ] Manual: sidebar shows the slimmed list above
- [ ] Manual: Settings page renders an Account section with Usage + Invites links
- [ ] Manual: clicking each link navigates to the existing page
- [ ] Manual: visiting `/usage` and `/invites` directly still renders their pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)