### PR TITLE
fix(openclaw): enable device auth by default, gate disable behind explicit opt-in

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -42,6 +42,23 @@ OPENCODE_SERVER_PASSWORD=CHANGEME
 OPENCLAW_TOKEN=CHANGEME
 
 # ═══════════════════════════════════════════════════════════════════
+# OpenClaw Security
+# ═══════════════════════════════════════════════════════════════════
+#
+# OpenClaw device authentication (device pairing) defaults to ON. Token auth
+# and device auth are separate gates: a valid OPENCLAW_TOKEN still auto-
+# connects the local Control UI with device auth enabled, so you normally do
+# NOT need to change this.
+#
+# Setting this to "true" DISABLES device pairing entirely. Anyone who can
+# reach the gateway then gets an UNAUTHENTICATED agent with exec / read /
+# write tools — especially dangerous with a widened BIND_ADDRESS
+# (LAN / Tailscale / 0.0.0.0). Only enable as a deliberate, understood
+# escape hatch; a loud warning banner is logged at startup when set.
+# Leave unset (the secure default) unless you fully accept the risk.
+# OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=
+
+# ═══════════════════════════════════════════════════════════════════
 # Network Binding
 # ═══════════════════════════════════════════════════════════════════
 

--- a/dream-server/config/openclaw/inject-token.js
+++ b/dream-server/config/openclaw/inject-token.js
@@ -34,6 +34,52 @@ const CONFIG_PATH = path.join(process.env.HOME || '/home/node', '.openclaw', 'op
 const HTML_PATH = process.env.OPENCLAW_CONTROL_UI_HTML || '/app/dist/control-ui/index.html';
 const JS_PATH = process.env.OPENCLAW_AUTO_TOKEN_JS || '/app/dist/control-ui/auto-token.js';
 
+// ── Device auth policy (#1270) ────────────────────────────────────────────────
+//
+// Device auth (pairing) is a SEPARATE gate from token auth. Token auth + a
+// valid injected gateway token still auto-connect on loopback with device auth
+// ON, so device auth defaults to ON regardless of bind mode. Disabling it is an
+// explicit, deliberate opt-in via OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH.
+//
+// Behaviour:
+//   - unset / anything but "true"  -> device auth ON (delete the disable key so
+//                                     the gateway default of device auth ON
+//                                     takes effect)
+//   - exactly "true"               -> device auth DISABLED + loud startup banner
+//
+// allowInsecureAuth is a distinct transport concern and is intentionally NOT
+// touched here.
+const DISABLE_DEVICE_AUTH =
+  (process.env.OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH || '').trim().toLowerCase() === 'true';
+let _deviceAuthWarned = false;
+
+// Apply the device-auth decision to a controlUi object in place. When disabled,
+// emit the warning banner exactly once per process (Part 1 and Part 3 share
+// this helper). Logging is redaction-safe: no token or secret is ever printed.
+function applyDeviceAuthPolicy(controlUi) {
+  if (DISABLE_DEVICE_AUTH) {
+    controlUi.dangerouslyDisableDeviceAuth = true;
+    if (!_deviceAuthWarned) {
+      _deviceAuthWarned = true;
+      console.warn('[inject-token] ┌──────────────────────────────────────────────────────────┐');
+      console.warn('[inject-token] │  *** SECURITY WARNING: DEVICE AUTH DISABLED ***          │');
+      console.warn('[inject-token] │                                                          │');
+      console.warn('[inject-token] │  OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=true is set.   │');
+      console.warn('[inject-token] │  The OpenClaw gateway will NOT require device pairing.   │');
+      console.warn('[inject-token] │  Anyone who can reach the gateway (LAN/Tailscale/0.0.0.0 │');
+      console.warn('[inject-token] │  binds) gets an UNAUTHENTICATED agent with exec / read / │');
+      console.warn('[inject-token] │  write tools. Unset this variable to restore the secure  │');
+      console.warn('[inject-token] │  default (device auth ON).                               │');
+      console.warn('[inject-token] └──────────────────────────────────────────────────────────┘');
+    }
+  } else {
+    // Remove the key entirely so the gateway falls back to its secure default
+    // (device auth ON). Deleting is more robust than setting false against
+    // pre-PR configs persisted on the named Docker volume.
+    delete controlUi.dangerouslyDisableDeviceAuth;
+  }
+}
+
 // ── Part 1: Patch runtime config ──────────────────────────────────────────────
 
 try {
@@ -71,7 +117,8 @@ try {
 
   // Ensure controlUi flags are set for local use
   config.gateway.controlUi.allowInsecureAuth = true;
-  config.gateway.controlUi.dangerouslyDisableDeviceAuth = true;
+  // Device auth defaults ON; disable only via explicit opt-in env (#1270).
+  applyDeviceAuthPolicy(config.gateway.controlUi);
   delete config.gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback;  // defang upgrades from pre-PR installs that wrote this flag to the persistent volume
 
   // Keep token auth (required for LAN bind) with token from env
@@ -251,7 +298,8 @@ try {
     if (!primary.gateway.mode) primary.gateway.mode = 'local';
     if (!primary.gateway.controlUi) primary.gateway.controlUi = {};
     primary.gateway.controlUi.allowInsecureAuth = true;
-    primary.gateway.controlUi.dangerouslyDisableDeviceAuth = true;
+    // Device auth defaults ON; disable only via explicit opt-in env (#1270).
+    applyDeviceAuthPolicy(primary.gateway.controlUi);
     delete primary.gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback;  // defang carry-over (mirrors Part 1)
     const extPort = process.env.OPENCLAW_EXTERNAL_PORT || '7860';
     const origins = primary.gateway.controlUi.allowedOrigins || [];

--- a/dream-server/config/openclaw/openclaw-strix-halo.json
+++ b/dream-server/config/openclaw/openclaw-strix-halo.json
@@ -32,7 +32,7 @@
     "mode": "local",
     "controlUi": {
       "allowInsecureAuth": true,
-      "dangerouslyDisableDeviceAuth": true
+      "dangerouslyDisableDeviceAuth": false
     }
   }
 }

--- a/dream-server/config/openclaw/openclaw.json
+++ b/dream-server/config/openclaw/openclaw.json
@@ -32,7 +32,7 @@
     "mode": "local",
     "controlUi": {
       "allowInsecureAuth": true,
-      "dangerouslyDisableDeviceAuth": true
+      "dangerouslyDisableDeviceAuth": false
     }
   }
 }

--- a/dream-server/config/openclaw/pro.json
+++ b/dream-server/config/openclaw/pro.json
@@ -32,7 +32,7 @@
     "mode": "local",
     "controlUi": {
       "allowInsecureAuth": true,
-      "dangerouslyDisableDeviceAuth": true
+      "dangerouslyDisableDeviceAuth": false
     }
   }
 }

--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -20,9 +20,16 @@ services:
       - OPENCLAW_EXTERNAL_PORT=${OPENCLAW_PORT:-7860}
       - HOST_LAN_IP=${HOST_LAN_IP:-}
       - BIND_ADDRESS=${BIND_ADDRESS:-127.0.0.1}
+      - OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=${OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH:-}
       - HOME=/home/node
     user: "0:0"
-    entrypoint: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.openclaw; exec setpriv --reuid=1000 --regid=1000 --clear-groups /bin/sh -c 'node /config/inject-token.js; export OPENCLAW_CONFIG_PATH=/tmp/openclaw-config.json; exec docker-entrypoint.sh node openclaw.mjs gateway --allow-unconfigured --bind lan'"]
+    # Gateway bind mode tracks BIND_ADDRESS: a loopback bind (127.0.0.1 /
+    # localhost / ::1) binds the gateway to localhost so the process-level
+    # binding matches the localhost intent; any widened bind exposes it on the
+    # LAN interface. The unconfigured-gateway flag is dropped: inject-token.js
+    # always writes the merged config to /tmp/openclaw-config.json
+    # (OPENCLAW_CONFIG_PATH), so the gateway is always configured at start.
+    entrypoint: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.openclaw; exec setpriv --reuid=1000 --regid=1000 --clear-groups /bin/sh -c 'node /config/inject-token.js; export OPENCLAW_CONFIG_PATH=/tmp/openclaw-config.json; case \"$${BIND_ADDRESS:-127.0.0.1}\" in 127.0.0.1|localhost|::1) BIND_MODE=localhost ;; *) BIND_MODE=lan ;; esac; exec docker-entrypoint.sh node openclaw.mjs gateway --bind \"$$BIND_MODE\"'"]
     volumes:
       - ./config/openclaw:/config:ro
       - ./data/openclaw:/data

--- a/dream-server/tests/test-openclaw-device-auth-default.sh
+++ b/dream-server/tests/test-openclaw-device-auth-default.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+# ============================================================================
+# Test: OpenClaw device auth is ENABLED by default  (#1270)
+# ============================================================================
+# SECURITY REGRESSION TEST (swarm task #10, owns #1270 verification).
+#
+# config/openclaw/openclaw.json shipped with
+#   "gateway.controlUi.dangerouslyDisableDeviceAuth": true
+# AND config/openclaw/inject-token.js UNCONDITIONALLY re-forces that flag at
+# every container start (lines ~74 and ~254). So a fix that edits only the
+# static JSON is COSMETIC — the runtime-effective config is whatever
+# inject-token.js writes. The compose entrypoint also ran
+# `gateway --allow-unconfigured --bind lan`, so the only thing protecting an
+# unauthenticated agent gateway was the default BIND_ADDRESS (#1270).
+#
+# Post-fix contract verified here:
+#   A. STATIC source of truth (config/openclaw/openclaw.json): device auth
+#      NOT disabled by default (key absent or false).
+#   B. RUNTIME-EFFECTIVE path (inject-token.js output): with NO opt-in env,
+#      the patched config must NOT disable device auth. With the explicit
+#      opt-in env set, disabling is allowed (gated, deliberate).
+#   C. compose entrypoint no longer combines --allow-unconfigured + --bind lan.
+#   D. Localhost path unaffected: BIND_ADDRESS default 127.0.0.1, port map
+#      unchanged.
+#
+# Run: bash tests/test-openclaw-device-auth-default.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+SKIP=0
+
+pass() { echo "  PASS: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); }
+skip() { echo "  SKIP: $1"; ((SKIP++)); }
+
+CONF="$SCRIPT_DIR/config/openclaw/openclaw.json"
+INJECT="$SCRIPT_DIR/config/openclaw/inject-token.js"
+COMPOSE="$SCRIPT_DIR/extensions/services/openclaw/compose.yaml"
+OPTIN_ENV="OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH"
+
+have_node=0; command -v node >/dev/null 2>&1 && have_node=1
+have_jq=0;   command -v jq   >/dev/null 2>&1 && have_jq=1
+have_py=0;   command -v python3 >/dev/null 2>&1 && have_py=1
+
+json_get() { # file pyexpr
+    python3 - "$1" "$2" <<'PY' 2>/dev/null
+import json,sys
+d=json.load(open(sys.argv[1]))
+try: print(eval(sys.argv[2]))
+except Exception: print("__MISSING__")
+PY
+}
+
+echo "== #1270: OpenClaw device auth enabled by default =="
+
+# ── A. Static source of truth ──────────────────────────────────────────────
+if [[ ! -f "$CONF" ]]; then
+    fail "config/openclaw/openclaw.json missing"
+elif (( have_py )); then
+    v="$(json_get "$CONF" "d.get('gateway',{}).get('controlUi',{}).get('dangerouslyDisableDeviceAuth','__MISSING__')")"
+    case "$v" in
+        True)       fail "static config still disables device auth (dangerouslyDisableDeviceAuth:true)";;
+        False)      pass "static config: dangerouslyDisableDeviceAuth explicitly false";;
+        __MISSING__) pass "static config: dangerouslyDisableDeviceAuth absent (auth on by default)";;
+        *)          fail "static config: unexpected value '$v'";;
+    esac
+else
+    if grep -Eq '"dangerouslyDisableDeviceAuth"[[:space:]]*:[[:space:]]*true' "$CONF"; then
+        fail "static config still disables device auth"
+    else
+        pass "static config does not hardcode device-auth disable"
+    fi
+fi
+
+# ── B. Runtime-effective path: inject-token.js output ──────────────────────
+# This is the security-critical assertion: inject-token.js is what the
+# container actually runs, and it currently re-forces the insecure default.
+if [[ ! -f "$INJECT" ]]; then
+    fail "config/openclaw/inject-token.js missing"
+elif (( ! have_node )); then
+    skip "node unavailable — cannot exercise inject-token.js runtime path"
+else
+    run_inject() { # $1 = optin value ("" = unset)  -> echoes patched flag
+        local optin="$1"
+        local td; td="$(mktemp -d)"
+        mkdir -p "$td/.openclaw"
+        # Seed with a SECURE source config (post-fix static default).
+        cat > "$td/.openclaw/openclaw.json" <<'JSON'
+{ "gateway": { "mode": "local", "controlUi": {} } }
+JSON
+        (
+            cd "$td" || exit 3
+            export HOME="$td"
+            export OPENCLAW_GATEWAY_TOKEN="tkn"
+            export OPENCLAW_CONTROL_UI_HTML="$td/index.html"
+            export OPENCLAW_AUTO_TOKEN_JS="$td/auto-token.js"
+            : > "$td/index.html"
+            if [[ -n "$optin" ]]; then export "$OPTIN_ENV=$optin"; else unset "$OPTIN_ENV"; fi
+            node "$INJECT" >/dev/null 2>&1 || true
+        )
+        if (( have_jq )); then
+            jq -r '.gateway.controlUi.dangerouslyDisableDeviceAuth // "ABSENT"' \
+                "$td/.openclaw/openclaw.json" 2>/dev/null
+        else
+            json_get "$td/.openclaw/openclaw.json" \
+              "d.get('gateway',{}).get('controlUi',{}).get('dangerouslyDisableDeviceAuth','ABSENT')"
+        fi
+        rm -rf "$td"
+    }
+
+    default_flag="$(run_inject "")"
+    case "$default_flag" in
+        true|True)
+            fail "RUNTIME: inject-token.js still forces dangerouslyDisableDeviceAuth=true with NO opt-in (gateway unauthenticated by default)";;
+        false|False|ABSENT|null|"")
+            pass "RUNTIME: inject-token.js leaves device auth ENABLED when opt-in unset (flag=$default_flag)";;
+        *)
+            fail "RUNTIME: unexpected inject-token.js flag value '$default_flag'";;
+    esac
+
+    optin_flag="$(run_inject "true")"
+    case "$optin_flag" in
+        true|True)
+            pass "RUNTIME: explicit opt-in ($OPTIN_ENV=true) deliberately disables device auth";;
+        *)
+            # Not fatal to the security goal, but the opt-in escape hatch
+            # should still work; flag as a soft failure.
+            fail "RUNTIME: opt-in $OPTIN_ENV=true did not disable device auth (flag=$optin_flag) — escape hatch broken";;
+    esac
+fi
+
+# ── C. compose entrypoint ──────────────────────────────────────────────────
+if [[ ! -f "$COMPOSE" ]]; then
+    fail "extensions/services/openclaw/compose.yaml missing"
+else
+    if grep -Eq -- '--allow-unconfigured' "$COMPOSE" \
+       && grep -Eq -- '--bind[[:space:]]+lan' "$COMPOSE"; then
+        fail "entrypoint still runs --allow-unconfigured --bind lan (unauth LAN gateway)"
+    else
+        pass "entrypoint no longer combines --allow-unconfigured with --bind lan"
+    fi
+fi
+
+# ── D. Localhost path unaffected ───────────────────────────────────────────
+if [[ -f "$COMPOSE" ]]; then
+    if grep -Eq 'BIND_ADDRESS:-127\.0\.0\.1' "$COMPOSE"; then
+        pass "BIND_ADDRESS still defaults to 127.0.0.1 (localhost unaffected)"
+    else
+        fail "BIND_ADDRESS default changed away from 127.0.0.1"
+    fi
+    if grep -Eq '\$\{BIND_ADDRESS:-127\.0\.0\.1\}:\$\{OPENCLAW_PORT:-7860\}:18789' "$COMPOSE"; then
+        pass "port mapping 127.0.0.1:7860->18789 unchanged"
+    else
+        fail "openclaw port mapping changed"
+    fi
+fi
+
+echo
+echo "== #1270 results: $PASS passed, $FAIL failed, $SKIP skipped =="
+[[ $FAIL -eq 0 ]] || exit 1

--- a/dream-server/tests/test-openclaw-inject-token.sh
+++ b/dream-server/tests/test-openclaw-inject-token.sh
@@ -11,8 +11,11 @@
 #     container start, so any cosmetic edit to openclaw.json/pro.json/
 #     openclaw-strix-halo.json is overridden by this script. The test must
 #     guard the *runtime* output, not just the static JSON files.
-#   - dangerouslyDisableDeviceAuth=true MUST stay (Docker auto-connect breaks
-#     without it; the auth pairing flow is incompatible with inject-token.js).
+#   - Device auth defaults ON (#1270): with the opt-in env unset,
+#     dangerouslyDisableDeviceAuth must be false/absent in BOTH the merged
+#     config and the ~/.openclaw home config. Setting
+#     OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=true deliberately disables it
+#     and must emit a loud startup warning.
 #   - allowedOrigins must be populated so the gateway no longer needs the
 #     Host-header fallback to accept cross-origin requests from the Control UI.
 #
@@ -127,12 +130,72 @@ else
     pass "dangerouslyAllowHostHeaderOriginFallback absent from merged config"
 fi
 
-# ── Assertion 2: dangerouslyDisableDeviceAuth still TRUE (Docker regression guard) ─
-if [[ "$(jq -r '.gateway.controlUi.dangerouslyDisableDeviceAuth' "$MERGED_PATH")" == "true" ]]; then
-    pass "dangerouslyDisableDeviceAuth=true preserved (Docker auto-connect intact)"
+# ── Assertion 2: device auth ENABLED by default (#1270 security guard) ──────
+# With OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH unset, inject-token.js must NOT
+# disable device auth. The flag must be false or absent in BOTH the merged
+# config (Part 3) and the ~/.openclaw home config (Part 1).
+HOME_CONFIG="$TEST_HOME/.openclaw/openclaw.json"
+merged_da="$(jq -r '.gateway.controlUi.dangerouslyDisableDeviceAuth // "ABSENT"' "$MERGED_PATH")"
+if [[ "$merged_da" == "false" || "$merged_da" == "ABSENT" ]]; then
+    pass "merged config: device auth enabled by default (dangerouslyDisableDeviceAuth=$merged_da)"
 else
-    fail "dangerouslyDisableDeviceAuth must remain true — Docker auto-connect would break"
+    fail "merged config: device auth must default ON — dangerouslyDisableDeviceAuth=$merged_da (expected false/absent)"
 fi
+if [[ -f "$HOME_CONFIG" ]]; then
+    home_da="$(jq -r '.gateway.controlUi.dangerouslyDisableDeviceAuth // "ABSENT"' "$HOME_CONFIG")"
+    if [[ "$home_da" == "false" || "$home_da" == "ABSENT" ]]; then
+        pass "home config: device auth enabled by default (dangerouslyDisableDeviceAuth=$home_da)"
+    else
+        fail "home config: device auth must default ON — dangerouslyDisableDeviceAuth=$home_da (expected false/absent)"
+    fi
+else
+    fail "home config ~/.openclaw/openclaw.json not written (Part 1)"
+fi
+
+# ── Assertion 2b: explicit opt-in disables device auth AND warns ───────────
+# OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=true must (a) set the flag true in
+# both configs and (b) emit a loud startup warning on stderr.
+OPTIN_HOME="$(mktemp -d -t dream-openclaw-optin-XXXXXXXX)"
+mkdir -p "$OPTIN_HOME/.openclaw"
+printf '%s\n' '<!doctype html><html><head></head><body></body></html>' >"$OPTIN_HOME/index.html"
+rm -f "$MERGED_PATH"
+optin_stderr="$(
+    HOME="$OPTIN_HOME" \
+    OPENCLAW_GATEWAY_TOKEN="test-token-abc123" \
+    OPENCLAW_EXTERNAL_PORT="7860" \
+    OPENCLAW_CONFIG="$SOURCE_CONFIG" \
+    OPENCLAW_CONTROL_UI_HTML="$OPTIN_HOME/index.html" \
+    OPENCLAW_AUTO_TOKEN_JS="$OPTIN_HOME/auto-token.js" \
+    BIND_ADDRESS="127.0.0.1" \
+    LLM_MODEL="test-model" \
+    GGUF_FILE="" \
+    OLLAMA_URL="" \
+    OPENCLAW_LLM_URL="" \
+    LITELLM_KEY="" \
+    OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH="true" \
+        node "$INJECT_SCRIPT" 2>&1 >/dev/null
+)"
+OPTIN_HOME_CONFIG="$OPTIN_HOME/.openclaw/openclaw.json"
+if [[ "$(jq -r '.gateway.controlUi.dangerouslyDisableDeviceAuth' "$MERGED_PATH")" == "true" ]]; then
+    pass "opt-in: merged config disables device auth when env=true"
+else
+    fail "opt-in: merged config should disable device auth when OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=true"
+fi
+if [[ -f "$OPTIN_HOME_CONFIG" ]] && [[ "$(jq -r '.gateway.controlUi.dangerouslyDisableDeviceAuth' "$OPTIN_HOME_CONFIG")" == "true" ]]; then
+    pass "opt-in: home config disables device auth when env=true"
+else
+    fail "opt-in: home config should disable device auth when OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=true"
+fi
+if grep -Eqi 'SECURITY WARNING.*DEVICE AUTH DISABLED' <<<"$optin_stderr"; then
+    pass "opt-in: loud device-auth-disabled warning emitted"
+else
+    fail "opt-in: expected a loud device-auth-disabled startup warning on stderr"
+fi
+rm -rf "$OPTIN_HOME"
+rm -f "$MERGED_PATH"
+# Restore the default (no-opt-in) merged + home config for later assertions.
+write_test_html
+run_inject
 
 # ── Assertion 3: allowInsecureAuth still TRUE (HTTP-only deployment guard) ──
 if [[ "$(jq -r '.gateway.controlUi.allowInsecureAuth' "$MERGED_PATH")" == "true" ]]; then


### PR DESCRIPTION
# fix(openclaw): enable device auth by default, gate disable behind explicit opt-in

Fixes #1270 · follow-up to the closed #21 / #22 (which fixed the `0.0.0.0` bind)

## Problem

`config/openclaw/openclaw.json` shipped `dangerouslyDisableDeviceAuth: true`,
and — critically — `config/openclaw/inject-token.js` **unconditionally
re-forced that flag at every container start** (so editing the JSON alone is a
runtime no-op; an existing test even guarded the re-injection). The agent
gateway therefore ran without device pairing. Contained under the default
`BIND_ADDRESS=127.0.0.1`, but an unauthenticated exec/read/write agent the
moment `BIND_ADDRESS` is widened (LAN, Tailscale, `0.0.0.0`).

## Fix

- **`inject-token.js`**: device auth defaults **ON**. The disable key is
  removed unless `OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH` is exactly `"true"`,
  in which case it's disabled **and a loud multi-line redaction-safe warning
  banner is logged**. Applied in both Part 1 (home) and Part 3 (merged) via a
  shared helper. `allowInsecureAuth` (separate transport concern) untouched.
- `openclaw.json` / `pro.json` / `openclaw-strix-halo.json`: flag → `false`
  for static-source consistency.
- `compose.yaml`: gateway `--bind` mode now tracks `BIND_ADDRESS`
  (loopback → `localhost`, widened → `lan`); dropped `--allow-unconfigured`
  (merged config is always written); opt-in env passed through. Healthcheck
  still hits `127.0.0.1` in the same netns, unaffected by `--bind localhost`.
- `test-openclaw-inject-token.sh`: inverted the device-auth assertion to
  require auth ON by default; added opt-in + warning coverage.
- `.env.example`: documented the opt-in with a security warning.

Default loopback Control-UI auto-connect is preserved — token auth and device
pairing are separate gates, and the token-injection path is untouched.

## Tests

`tests/test-openclaw-device-auth-default.sh` (new, drives `inject-token.js`
headlessly so cosmetic-only edits would fail it) — 6/6.
`tests/test-openclaw-inject-token.sh` — 30/30 with the inverted contract.

## Notes

Part of a 4-PR set (#1268–#1271). Not a collaborator (can't self-assign);
I'd like to own this and will revise to feedback.
