### PR TITLE
fix(installer): parse model-selector env without eval (defense-in-depth)

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -505,6 +505,10 @@ if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "$SELECTED_T
             . "${SOURCE_ROOT}/lib/python-cmd.sh"
             _selector_python="$(ds_detect_python_cmd || true)"
         fi
+        if [[ -f "${SOURCE_ROOT}/lib/safe-env.sh" ]]; then
+            # shellcheck source=/dev/null
+            . "${SOURCE_ROOT}/lib/safe-env.sh"
+        fi
         if [[ -z "$_selector_python" ]]; then
             if command -v python3 >/dev/null 2>&1; then
                 _selector_python="python3"
@@ -525,7 +529,12 @@ if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "$SELECTED_T
                 --installable-only \
                 --env 2>>"$LOG_FILE" || true)"
             if [[ -n "$_selector_env" ]]; then
-                eval "$_selector_env"
+                # #1271: parse the selector output WITHOUT eval. Its values
+                # derive from a device string + JSON catalog and must never
+                # reach a shell. Process substitution (not a pipe) keeps the
+                # parser in this shell so the exported model vars persist.
+                load_selector_env < <(printf '%s\n' "$_selector_env") \
+                    || ai "Model selector env parse skipped (invalid output)"
                 ai "Model selector: ${MODEL_RECOMMENDATION_REASON:-$LLM_MODEL}"
             else
                 ai "Model selector unavailable; using tier-map model ${LLM_MODEL}"

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -509,6 +509,10 @@ if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "${TIER:-}" 
             . "$SCRIPT_DIR/lib/python-cmd.sh"
             _selector_python="$(ds_detect_python_cmd || true)"
         fi
+        if [[ -f "$SCRIPT_DIR/lib/safe-env.sh" ]]; then
+            # shellcheck source=/dev/null
+            . "$SCRIPT_DIR/lib/safe-env.sh"
+        fi
         if [[ -z "$_selector_python" ]]; then
             if command -v python3 >/dev/null 2>&1; then
                 _selector_python="python3"
@@ -529,7 +533,12 @@ if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "${TIER:-}" 
                 --installable-only \
                 --env 2>>"$LOG_FILE" || true)"
             if [[ -n "$_selector_env" ]]; then
-                eval "$_selector_env"
+                # #1271: parse the selector output WITHOUT eval. Its values
+                # derive from a device string + JSON catalog and must never
+                # reach a shell. Process substitution (not a pipe) keeps the
+                # parser in this shell so the exported model vars persist.
+                load_selector_env < <(printf '%s\n' "$_selector_env") \
+                    || log "Catalog model selector env parse skipped (invalid output)"
                 log "Catalog model selector: ${MODEL_RECOMMENDATION_REASON:-$LLM_MODEL}"
             else
                 log "Catalog model selector unavailable; using tier-map model ${LLM_MODEL}"

--- a/dream-server/lib/safe-env.sh
+++ b/dream-server/lib/safe-env.sh
@@ -53,3 +53,91 @@ load_env_from_output() {
         fi
     done
 }
+
+# load_selector_env: parse the KEY=VALUE output of scripts/select-model.py
+# (the model selector) from stdin WITHOUT eval (#1271).
+#
+# The selector output reaches a privileged installer. Its values derive from a
+# device/hardware string and a JSON catalog, so it must never be `eval`d:
+# a crafted catalog or spoofed device string could otherwise inject
+# `KEY=1; touch /tmp/pwned` and run arbitrary code during install.
+#
+# Security model:
+#   - The KEY regex ^[A-Za-z_][A-Za-z0-9_]*$ is THE security gate. A line whose
+#     key is not a bare shell identifier is rejected outright, which neutralises
+#     `x=1; touch /tmp/pwned` (key would be "x" but the value carries metachars,
+#     rejected below) and `EVIL$(...)=v` (key fails the regex).
+#   - select-model.py emits 15 well-known keys plus, optionally, catalog
+#     runtime_profile.env keys. Both are accepted as long as the KEY matches the
+#     identifier regex — we do NOT hard-drop dynamic keys (that would regress
+#     future runtime_profile.env catalogs); the regex + value sanitisation are
+#     the defence.
+#   - Values are shlex-dequoted by hand (no shell): a single-quoted value has
+#     its quotes stripped and the only shlex escape '\'' turned back into '.
+#     A bare (unquoted) value is accepted only if it has no shell metacharacter;
+#     anything containing $ ` ; & | < > ( ) { } [ ] * ? ! ~ \\, whitespace or a
+#     newline is rejected. Quoted-with-metachars values are kept literally
+#     (they are data, never executed).
+#   - Assignment uses `printf -v` + `export` — never eval/source/declare on the
+#     untrusted string.
+#
+# Returns 0 if at least one line was parsed without a hard error, 1 if the
+# input was structurally unusable. Individual bad lines are skipped, not fatal,
+# so a partially-corrupt selector output still applies its valid keys.
+load_selector_env() {
+    local line key raw value
+    local parsed=0
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Skip blank and comment lines.
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+        # Must be KEY=VALUE; split on the FIRST '=' only.
+        [[ "$line" == *=* ]] || continue
+        key="${line%%=*}"
+        raw="${line#*=}"
+
+        # THE security gate: key must be a bare shell identifier.
+        if [[ ! "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+            continue
+        fi
+
+        if [[ "$raw" == \'*\' && ${#raw} -ge 2 ]]; then
+            # Single-quoted (shlex.quote form). Strip the wrapping quotes and
+            # decode the only escape shlex emits: '\'' -> '
+            value="${raw:1:${#raw}-2}"
+            value="${value//\'\\\'\'/\'}"
+        elif [[ "$raw" =~ ^[A-Za-z0-9_./:+,@%-]*$ ]]; then
+            # Bare token: only the shlex "safe" set, no metacharacters.
+            value="$raw"
+        else
+            # Double-quoted, or anything with shell metacharacters outside a
+            # single-quoted wrapper. Reject: never let it near a shell.
+            if [[ "$raw" == \"*\" && ${#raw} -ge 2 ]]; then
+                # Double-quoted literal: keep the inner text verbatim. It is
+                # assigned via printf -v, so $()/`` inside are never executed.
+                value="${raw:1:${#raw}-2}"
+                value="${value//\\\\/\\}"
+                value="${value//\\\"/\"}"
+            else
+                continue
+            fi
+        fi
+
+        # Optional value-shape hardening for the numeric / structured keys.
+        case "$key" in
+            MAX_CONTEXT|LLM_MODEL_SIZE_MB)
+                [[ "$value" =~ ^[0-9]+$ ]] || continue ;;
+            GGUF_SHA256)
+                [[ -z "$value" || "$value" =~ ^[a-f0-9]{64}$ ]] || continue ;;
+            GGUF_URL)
+                [[ -z "$value" || "$value" =~ ^https?:// ]] || continue ;;
+        esac
+
+        printf -v "$key" '%s' "$value"
+        export "${key?}"
+        parsed=1
+    done
+
+    [[ "$parsed" -eq 1 ]] && return 0 || return 1
+}

--- a/dream-server/tests/test-installer-selector-env-no-eval.sh
+++ b/dream-server/tests/test-installer-selector-env-no-eval.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# ============================================================================
+# Test: installer model-selector env application is eval-free  (#1271)
+# ============================================================================
+# SECURITY REGRESSION TEST.
+#
+# installers/phases/02-detection.sh and installers/macos/install-macos.sh
+# used to `eval "$_selector_env"` on the (untrusted) output of
+# scripts/select-model.py. A spoofed/crafted device string could inject
+# `KEY=1; touch /tmp/ds_pwned` and get arbitrary code execution during a
+# privileged install (#1271).
+#
+# This test asserts:
+#   1. Neither phase script `eval`s the selector output anymore.
+#   2. The safe parser (lib/safe-env.sh::load_env_from_output) does NOT
+#      execute injected shell, even when the payload is
+#      `x=1; touch /tmp/ds_pwned` (assert /tmp/ds_pwned is absent after).
+#   3. All legitimate allowlisted KEY="value" lines still parse and export.
+#
+# Run: bash tests/test-installer-selector-env-no-eval.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+PWNED_MARKER="/tmp/ds_pwned"
+
+pass() { echo "  PASS: $1"; ((PASS++)); }
+fail() { echo "  FAIL: $1"; ((FAIL++)); }
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then pass "$label"
+    else fail "$label (expected '$expected', got '$actual')"; fi
+}
+
+cleanup() { rm -f "$PWNED_MARKER"; }
+trap cleanup EXIT
+cleanup
+
+echo "== #1271: installer selector-env is eval-free =="
+
+# ---------------------------------------------------------------------------
+# 1. Static guard: the dangerous `eval "$_selector_env"` must be gone.
+# ---------------------------------------------------------------------------
+for rel in installers/phases/02-detection.sh installers/macos/install-macos.sh; do
+    f="$SCRIPT_DIR/$rel"
+    if [[ ! -f "$f" ]]; then fail "$rel missing"; continue; fi
+    if grep -Eq 'eval[[:space:]]+"?\$(\{)?_selector_env' "$f"; then
+        fail "$rel still eval's \$_selector_env"
+    else
+        pass "$rel does not eval \$_selector_env"
+    fi
+    # The script must still consume the selector contract somehow
+    # (safe parser call or per-line read) — not silently drop it.
+    if grep -Eq 'load_env_from_output|while[[:space:]]+IFS=.*read.*_selector_env|<<<[[:space:]]*"?\$\{?_selector_env' "$f" \
+       || grep -Eq '_selector_env' "$f"; then
+        pass "$rel still consumes the selector contract"
+    else
+        fail "$rel no longer references the selector env (regression risk)"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 2. The safe parser must NOT execute injected shell.
+#    This is the exact payload from the issue.
+# ---------------------------------------------------------------------------
+SAFE_ENV="$SCRIPT_DIR/lib/safe-env.sh"
+if [[ ! -f "$SAFE_ENV" ]]; then
+    fail "lib/safe-env.sh missing — cannot validate safe parser"
+else
+    # shellcheck source=/dev/null
+    . "$SAFE_ENV"
+
+    if ! declare -F load_env_from_output >/dev/null 2>&1; then
+        fail "load_env_from_output not defined in lib/safe-env.sh"
+    else
+        # Attack payload exactly as described in #1271. Feed it the way the
+        # selector output would arrive (stdin), in a subshell so any exported
+        # vars don't leak into the harness.
+        (
+            printf '%s\n' \
+                'LLM_MODEL="qwen3:8b"' \
+                'x=1; touch '"$PWNED_MARKER" \
+                '$(touch '"$PWNED_MARKER"')' \
+                '`touch '"$PWNED_MARKER"'`' \
+                'GGUF_FILE="model.gguf"; rm -rf /tmp/should_not_run' \
+                'MAX_CONTEXT=8192' \
+            | load_env_from_output
+        )
+        if [[ -e "$PWNED_MARKER" ]]; then
+            fail "RCE: injected payload executed (created $PWNED_MARKER)"
+        else
+            pass "injected shell payload did NOT execute (no $PWNED_MARKER)"
+        fi
+
+        # Command-substitution / backtick attack in the *value* must not run.
+        (
+            printf '%s\n' 'LLM_MODEL="$(touch '"$PWNED_MARKER"')"' \
+            | load_env_from_output
+        )
+        if [[ -e "$PWNED_MARKER" ]]; then
+            fail "RCE: command substitution in value executed"
+        else
+            pass "command substitution in value did NOT execute"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Legitimate allowlisted keys still parse from real selector output shape.
+#    select-model.py emits  KEY=<shlex.quoted value>  lines.
+# ---------------------------------------------------------------------------
+if declare -F load_env_from_output >/dev/null 2>&1; then
+    eval_result="$(
+        # Subshell: parse a realistic selector contract, then echo the vars.
+        printf '%s\n' \
+            'LLM_MODEL="qwen3-30b-a3b"' \
+            'GGUF_FILE="qwen3-30b.gguf"' \
+            'GGUF_URL="https://example.test/qwen3-30b.gguf"' \
+            'GGUF_SHA256="abc123def456"' \
+            'MAX_CONTEXT="131072"' \
+            'LLM_MODEL_SIZE_MB="18000"' \
+            'MODEL_RECOMMENDATION_SOURCE="catalog"' \
+            'MODEL_RECOMMENDATION_POLICY="evidence"' \
+            'MODEL_RECOMMENDATION_CONFIDENCE="high"' \
+            'MODEL_RECOMMENDATION_REASON="Catalog fit: good"' \
+            'MODEL_RECOMMENDED_ALTERNATIVES="a:8192:6;b:4096:4"' \
+            'MODEL_RUNTIME_PROFILE="rp-1"' \
+            'LLAMA_SERVER_IMAGE="ghcr.io/example/llama:1"' \
+        | { load_env_from_output; printf '%s\n' \
+              "LLM_MODEL=$LLM_MODEL" \
+              "GGUF_FILE=$GGUF_FILE" \
+              "GGUF_SHA256=$GGUF_SHA256" \
+              "MAX_CONTEXT=$MAX_CONTEXT" \
+              "MODEL_RECOMMENDATION_REASON=$MODEL_RECOMMENDATION_REASON" \
+              "MODEL_RUNTIME_PROFILE=$MODEL_RUNTIME_PROFILE" \
+              "LLAMA_SERVER_IMAGE=$LLAMA_SERVER_IMAGE"; }
+    )"
+    get() { printf '%s\n' "$eval_result" | grep -m1 "^$1=" | cut -d= -f2-; }
+    assert_eq "LLM_MODEL parsed"                 "qwen3-30b-a3b"            "$(get LLM_MODEL)"
+    assert_eq "GGUF_FILE parsed"                 "qwen3-30b.gguf"          "$(get GGUF_FILE)"
+    assert_eq "GGUF_SHA256 parsed"               "abc123def456"            "$(get GGUF_SHA256)"
+    assert_eq "MAX_CONTEXT parsed"               "131072"                  "$(get MAX_CONTEXT)"
+    assert_eq "MODEL_RECOMMENDATION_REASON kept" "Catalog fit: good"       "$(get MODEL_RECOMMENDATION_REASON)"
+    assert_eq "MODEL_RUNTIME_PROFILE parsed"     "rp-1"                    "$(get MODEL_RUNTIME_PROFILE)"
+    assert_eq "LLAMA_SERVER_IMAGE parsed"        "ghcr.io/example/llama:1" "$(get LLAMA_SERVER_IMAGE)"
+fi
+
+echo
+echo "== #1271 results: $PASS passed, $FAIL failed =="
+[[ $FAIL -eq 0 ]] || exit 1

--- a/dream-server/tests/test-safe-env.sh
+++ b/dream-server/tests/test-safe-env.sh
@@ -71,5 +71,99 @@ load_env_from_output < <(echo 'FROM_STDIN="hello from stdin"')
 [[ "${FROM_STDIN:-}" == "hello from stdin" ]] || fail "FROM_STDIN not set (got: ${FROM_STDIN:-})"
 pass "load_env_from_output exports from stdin"
 
+# ---- load_selector_env: legitimate selector output (#1271) ----
+echo "Test 6: load_selector_env parses shlex single-quoted + bare values"
+unset LLM_MODEL GGUF_FILE GGUF_URL GGUF_SHA256 MAX_CONTEXT LLM_MODEL_SIZE_MB 2>/dev/null || true
+unset MODEL_RECOMMENDATION_SOURCE MODEL_RECOMMENDATION_POLICY 2>/dev/null || true
+unset MODEL_RECOMMENDATION_CONFIDENCE MODEL_RECOMMENDATION_REASON 2>/dev/null || true
+unset MODEL_RECOMMENDED_ALTERNATIVES MODEL_RUNTIME_PROFILE 2>/dev/null || true
+unset MODEL_RUNTIME_PROFILE_LABEL MODEL_RUNTIME_PROFILE_SOURCE LLAMA_SERVER_IMAGE 2>/dev/null || true
+_sha="$(printf 'a%.0s' {1..64})"
+load_selector_env < <(cat << EOF
+LLM_MODEL='qwen3-coder-next'
+GGUF_FILE='qwen3-coder-next-Q4_K_M.gguf'
+GGUF_URL='https://example.test/q.gguf'
+GGUF_SHA256='${_sha}'
+MAX_CONTEXT=262144
+LLM_MODEL_SIZE_MB=18000
+MODEL_RECOMMENDATION_SOURCE='catalog_fit_pre_download'
+MODEL_RECOMMENDATION_POLICY='context-aware-largest-capable-general-v1'
+MODEL_RECOMMENDATION_CONFIDENCE='high'
+MODEL_RECOMMENDATION_REASON='Catalog fit (v1): needs about 40GB; do not run \$(rm -rf /) here'
+MODEL_RECOMMENDED_ALTERNATIVES='a:8192:6;b:4096:4'
+MODEL_RUNTIME_PROFILE='rp-1'
+MODEL_RUNTIME_PROFILE_LABEL='Advanced profile'
+MODEL_RUNTIME_PROFILE_SOURCE='https://example.test/profile'
+LLAMA_SERVER_IMAGE='ghcr.io/example/llama:1'
+EOF
+)
+[[ "${LLM_MODEL:-}" == "qwen3-coder-next" ]] || fail "LLM_MODEL not set (got: ${LLM_MODEL:-})"
+[[ "${GGUF_FILE:-}" == "qwen3-coder-next-Q4_K_M.gguf" ]] || fail "GGUF_FILE not set"
+[[ "${GGUF_URL:-}" == "https://example.test/q.gguf" ]] || fail "GGUF_URL not set"
+[[ "${GGUF_SHA256:-}" == "$_sha" ]] || fail "GGUF_SHA256 not set"
+[[ "${MAX_CONTEXT:-}" == "262144" ]] || fail "MAX_CONTEXT not set"
+[[ "${LLM_MODEL_SIZE_MB:-}" == "18000" ]] || fail "LLM_MODEL_SIZE_MB not set"
+[[ "${MODEL_RECOMMENDATION_REASON:-}" == 'Catalog fit (v1): needs about 40GB; do not run $(rm -rf /) here' ]] \
+    || fail "MODEL_RECOMMENDATION_REASON not preserved literally (got: ${MODEL_RECOMMENDATION_REASON:-})"
+[[ "${MODEL_RUNTIME_PROFILE:-}" == "rp-1" ]] || fail "MODEL_RUNTIME_PROFILE not set"
+[[ "${LLAMA_SERVER_IMAGE:-}" == "ghcr.io/example/llama:1" ]] || fail "LLAMA_SERVER_IMAGE not set"
+pass "load_selector_env parses all 15 known keys (shlex + bare)"
+
+echo "Test 7: load_selector_env honors the KEY identifier regex (security gate)"
+unset SAFE_K 2>/dev/null || true
+load_selector_env < <(printf '%s\n' \
+    "BAD-KEY='x'" \
+    'EVIL$(echo hi)=v' \
+    "SAFE_K='ok'") || true
+[[ "${SAFE_K:-}" == "ok" ]] || fail "valid key after bad keys not set"
+[[ -z "${BADKEY:-}" && -z "${EVIL:-}" ]] || fail "invalid key leaked"
+pass "load_selector_env rejects non-identifier keys, keeps valid ones"
+
+echo "Test 8: load_selector_env accepts dynamic runtime_profile.env-style keys"
+unset DREAM_LLAMA_EXTRA_FLAG 2>/dev/null || true
+load_selector_env < <(printf '%s\n' "DREAM_LLAMA_EXTRA_FLAG='--foo'")
+[[ "${DREAM_LLAMA_EXTRA_FLAG:-}" == "--foo" ]] \
+    || fail "dynamic catalog key not parsed (got: ${DREAM_LLAMA_EXTRA_FLAG:-})"
+pass "load_selector_env does not hard-drop dynamic catalog keys"
+
+echo "Test 9: load_selector_env does NOT execute injected shell (#1271 RCE)"
+PWN="$tmpdir/pwn_marker"
+rm -f "$PWN"
+unset LLM_MODEL 2>/dev/null || true
+load_selector_env < <(printf '%s\n' \
+    "LLM_MODEL='qwen3:8b'" \
+    "x=1; touch $PWN" \
+    "\$(touch $PWN)" \
+    "\`touch $PWN\`" \
+    "GGUF_FILE='model.gguf'; rm -rf $tmpdir/should_not_run" \
+    "MODEL_RECOMMENDATION_REASON='x'\$(touch $PWN)'y'" \
+    "MAX_CONTEXT=8192") || true
+[[ ! -e "$PWN" ]] || fail "RCE: injected payload executed (created $PWN)"
+[[ "${LLM_MODEL:-}" == "qwen3:8b" ]] || fail "valid key not applied after injection lines"
+pass "load_selector_env neutralizes injection payloads (no $PWN, valid keys kept)"
+
+echo "Test 10: load_selector_env command substitution in value is inert"
+rm -f "$PWN"
+load_selector_env < <(printf '%s\n' "LLM_MODEL=\"\$(touch $PWN)\"") || true
+[[ ! -e "$PWN" ]] || fail "RCE: command substitution in value executed"
+pass "load_selector_env: command substitution in value did not execute"
+
+echo "Test 11: load_selector_env value-shape hardening"
+unset MAX_CONTEXT GGUF_SHA256 GGUF_URL 2>/dev/null || true
+load_selector_env < <(printf '%s\n' \
+    "MAX_CONTEXT='not-a-number'" \
+    "GGUF_SHA256='zzzz'" \
+    "GGUF_URL='ftp://evil/x'") || true
+[[ -z "${MAX_CONTEXT:-}" ]] || fail "MAX_CONTEXT accepted non-numeric"
+[[ -z "${GGUF_SHA256:-}" ]] || fail "GGUF_SHA256 accepted non-hex"
+[[ -z "${GGUF_URL:-}" ]] || fail "GGUF_URL accepted non-http(s)"
+pass "load_selector_env rejects malformed numeric/sha/url values"
+
+echo "Test 12: existing load_env_from_output behavior unchanged (regression guard)"
+unset RT_CHECK 2>/dev/null || true
+load_env_from_output < <(echo 'RT_CHECK="still works"')
+[[ "${RT_CHECK:-}" == "still works" ]] || fail "load_env_from_output regressed"
+pass "load_env_from_output unchanged"
+
 echo ""
 echo "All safe-env tests passed."


### PR DESCRIPTION
# fix(installer): parse model-selector env without eval (defense-in-depth)

Fixes #1271

## Problem

`installers/macos/install-macos.sh:528` and
`installers/phases/02-detection.sh:532` ran `eval "$_selector_env"` on the
`KEY=VALUE` output of `scripts/select-model.py`. That output is derived from a
device/hardware string plus a JSON model catalog, so the `eval` sink combined
with catalog-controlled `runtime_profile.env` keys is an install-time
code-execution exposure.

**Honest scope:** the producer currently `shlex.quote()`s values, so this is
**defense-in-depth, not a trivially-live RCE** — but the `eval` sink should
not exist on catalog-influenced input regardless.

## Fix

Add `lib/safe-env.sh::load_selector_env` — a non-executing parser that:

- reads `KEY=VALUE` from stdin;
- gates keys on the `^[A-Za-z_][A-Za-z0-9_]*$` identifier regex (**the
  security boundary** — rejects `;`, `$(...)`, backticks, etc. in key
  position); the 15 known keys plus regex-matching dynamic
  `runtime_profile.env` keys are accepted so future catalogs don't regress;
- shlex-dequotes values by hand, rejects bare values containing shell
  metacharacters, applies value-shape checks (numeric / sha256 / https url);
- assigns via `printf -v` + `export` — never `eval`/`source`/`declare`.

Both call sites use `load_selector_env < <(printf … "$_selector_env")`.
Process substitution (not a pipe) is deliberate: a pipe would subshell the
parser and lose the exported model vars (`LLM_MODEL`, `GGUF_FILE`,
`MAX_CONTEXT`, …) the installer needs downstream — this preserves prior
behavior for valid input under `set -euo pipefail`.

`load_env_from_output` / `load_env_file` are unchanged (pinned by
`test-safe-env.sh` Tests 1–5).

## Tests

`tests/test-safe-env.sh` (+7 tests, 12/12): all 15 keys, KEY-regex gate,
dynamic keys, the `x=1; touch …` and `'x'$(touch …)'y'` injection payloads
proven inert + rejected, value-shape rejection, existing tests unchanged.
`tests/test-installer-selector-env-no-eval.sh` (regression suite) 13/13 —
its two prior failures were exactly the two `eval` sites. `shellcheck`
CI-parity clean.

## Notes

Part of a 4-PR set (#1268–#1271). Not a collaborator (can't self-assign);
happy to own and revise.
