### PR TITLE
[codex] harden boring install contracts

### DIFF
--- a/dream-server/installers/lib/readiness-summary.sh
+++ b/dream-server/installers/lib/readiness-summary.sh
@@ -57,6 +57,10 @@ dream_readiness_summary() {
     local ready_lines=()
     local attention_lines=()
     local total=0
+    local launch_record="${DREAM_COMPOSE_LAUNCH_RECORD:-}"
+    if [[ -z "$launch_record" && -n "${INSTALL_DIR:-}" && -f "$INSTALL_DIR/logs/compose-launch.txt" ]]; then
+        launch_record="$INSTALL_DIR/logs/compose-launch.txt"
+    fi
 
     while IFS='|' read -r name health_url container open_url; do
         [[ -n "$name" ]] || continue
@@ -112,5 +116,13 @@ dream_readiness_summary() {
     echo "  - Open dashboard: $dashboard_url"
     echo "  - Check status: $status_cmd"
     [[ -n "$log_file" ]] && echo "  - Logs: $log_file"
+    if [[ -n "$launch_record" ]]; then
+        echo "  - Compose launch: $launch_record"
+        if [[ -f "$launch_record" ]]; then
+            local compose_logs_cmd
+            compose_logs_cmd="$(sed -n 's/^compose_logs_command=//p' "$launch_record" 2>/dev/null | head -n 1 || true)"
+            [[ -n "$compose_logs_cmd" ]] && echo "  - Compose logs: $compose_logs_cmd"
+        fi
+    fi
     echo ""
 }

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -156,6 +156,7 @@ source "${LIB_DIR}/env-generator.sh"
 if [[ -f "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh" ]]; then
     source "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh"
 fi
+source "${SOURCE_ROOT}/lib/safe-env.sh"
 source "${SOURCE_ROOT}/installers/lib/readiness-summary.sh"
 
 # ── File-local helpers ──
@@ -526,7 +527,7 @@ if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "$SELECTED_T
                 --installable-only \
                 --env 2>>"$LOG_FILE" || true)"
             if [[ -n "$_selector_env" ]]; then
-                eval "$_selector_env"
+                load_model_selector_env_from_output <<< "$_selector_env"
                 ai "Model selector: ${MODEL_RECOMMENDATION_REASON:-$LLM_MODEL}"
             else
                 ai "Model selector unavailable; using tier-map model ${LLM_MODEL}"
@@ -1329,9 +1330,29 @@ else
     done
     ai_ok "Local images rebuilt"
 
-    ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build"
     _compose_up_log="${INSTALL_DIR}/logs/compose-up.log"
     mkdir -p "${INSTALL_DIR}/logs"
+    _compose_launch_record="${INSTALL_DIR}/logs/compose-launch.txt"
+    {
+        printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+        printf 'cwd=%s\n' "$INSTALL_DIR"
+        printf 'compose_command=docker compose %s up -d --remove-orphans --no-build\n' "${COMPOSE_FLAGS[*]}"
+        printf 'compose_flags=%s\n' "${COMPOSE_FLAGS[*]}"
+        printf 'compose_flags_file=%s\n' "$INSTALL_DIR/.compose-flags"
+        printf "compose_ps_command=cd '%s' && docker compose %s ps -a\n" "$INSTALL_DIR" "${COMPOSE_FLAGS[*]}"
+        printf "compose_logs_command=cd '%s' && docker compose %s logs --tail 200\n" "$INSTALL_DIR" "${COMPOSE_FLAGS[*]}"
+        printf 'compose_files=\n'
+        _expect_file=false
+        for _arg in "${COMPOSE_FLAGS[@]}"; do
+            if $_expect_file; then
+                printf '  - %s\n' "$_arg"
+                _expect_file=false
+            elif [[ "$_arg" == "-f" ]]; then
+                _expect_file=true
+            fi
+        done
+    } > "$_compose_launch_record"
+    ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build"
     : > "$_compose_up_log"
     set +o pipefail  # pipefail would abort on compose exit before PIPESTATUS is read; capture it first
     docker compose "${COMPOSE_FLAGS[@]}" up -d --remove-orphans --no-build 2>&1 | tee -a "$_compose_up_log" | while IFS= read -r line; do
@@ -1353,6 +1374,25 @@ else
             [[ -n "${_compose_report_path:-}" ]] && ai_warn "Compose failure report saved: $_compose_report_path"
         fi
         ai_err "docker compose up failed"
+        exit 1
+    fi
+    _compose_container_ids="$(docker compose "${COMPOSE_FLAGS[@]}" ps -q 2>>"$DS_LOG_FILE" || true)"
+    _compose_container_count="$(printf '%s\n' "$_compose_container_ids" | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]')"
+    if [[ "${_compose_container_count:-0}" -eq 0 ]]; then
+        if command -v write_compose_failure_report >/dev/null 2>&1; then
+            _compose_report_path="$(COMPOSE_FLAGS_REPORT="${COMPOSE_FLAGS[*]}" write_compose_failure_report \
+                "$INSTALL_DIR" \
+                "install-macos zero managed containers" \
+                "docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build" \
+                "$_compose_up_log" \
+                "apple" \
+                "No Dream Server containers were created. Run the saved ps/logs commands from logs/compose-launch.txt, fix the compose/runtime failure, then re-run ./installers/macos.sh." |
+                tail -n 1)" || true
+            [[ -n "${_compose_report_path:-}" ]] && ai_warn "Compose failure report saved: $_compose_report_path"
+        fi
+        ai_err "docker compose up completed but created no managed containers"
+        ai "Launch record: $_compose_launch_record"
+        ai "Inspect with: cd '$INSTALL_DIR' && docker compose ${COMPOSE_FLAGS[*]} ps -a"
         exit 1
     fi
     ai_ok "Docker services started"

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -24,6 +24,8 @@
 #   Change tier auto-detection thresholds or add new hardware classes here.
 # ============================================================================
 
+[[ -f "${SCRIPT_DIR:-}/lib/safe-env.sh" ]] && . "$SCRIPT_DIR/lib/safe-env.sh"
+
 dream_progress 12 "detection" "Detecting GPU hardware"
 chapter "SYSTEM DETECTION"
 
@@ -529,8 +531,12 @@ if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "${TIER:-}" 
                 --installable-only \
                 --env 2>>"$LOG_FILE" || true)"
             if [[ -n "$_selector_env" ]]; then
-                eval "$_selector_env"
-                log "Catalog model selector: ${MODEL_RECOMMENDATION_REASON:-$LLM_MODEL}"
+                if command -v load_model_selector_env_from_output >/dev/null 2>&1; then
+                    load_model_selector_env_from_output <<< "$_selector_env"
+                    log "Catalog model selector: ${MODEL_RECOMMENDATION_REASON:-$LLM_MODEL}"
+                else
+                    log "Catalog model selector output ignored; safe env loader unavailable"
+                fi
             else
                 log "Catalog model selector unavailable; using tier-map model ${LLM_MODEL}"
             fi

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -733,7 +733,7 @@ except Exception:
     _phase11_allow_host_agent_firewall dream-network
 
     if $compose_ok; then
-        if ! _phase11_assert_managed_containers false; then
+        if ! _phase11_assert_managed_containers; then
             exit 1
         fi
         printf "\r  ${BGRN}✓${NC} %-60s\n" "All containers launched"

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -160,6 +160,67 @@ else
     echo "$COMPOSE_FLAGS" > "$INSTALL_DIR/.compose-flags" || warn "Could not cache compose flags (non-fatal)"
     log "Saved compose flags to $INSTALL_DIR/.compose-flags"
 
+    _phase11_compose_command_text() {
+        printf '%s' "$DOCKER_COMPOSE_CMD"
+        printf ' %s' "${COMPOSE_FLAGS_ARR[@]}"
+    }
+
+    _phase11_write_compose_launch_record() {
+        local path="$INSTALL_DIR/logs/compose-launch.txt"
+        local command_text
+        command_text="$(_phase11_compose_command_text)"
+        {
+            printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+            printf 'cwd=%s\n' "$INSTALL_DIR"
+            printf 'compose_command=%s up -d --remove-orphans --no-build\n' "$command_text"
+            printf 'compose_flags=%s\n' "${COMPOSE_FLAGS_ARR[*]}"
+            printf 'compose_flags_file=%s\n' "$INSTALL_DIR/.compose-flags"
+            printf "compose_ps_command=cd '%s' && %s ps -a\n" "$INSTALL_DIR" "$command_text"
+            printf "compose_logs_command=cd '%s' && %s logs --tail 200\n" "$INSTALL_DIR" "$command_text"
+            printf 'compose_files=\n'
+            local _expect_file=false _arg
+            for _arg in "${COMPOSE_FLAGS_ARR[@]}"; do
+                if $_expect_file; then
+                    printf '  - %s\n' "$_arg"
+                    _expect_file=false
+                elif [[ "$_arg" == "-f" ]]; then
+                    _expect_file=true
+                fi
+            done
+        } > "$path"
+        log "Saved compose launch record to $path"
+    }
+
+    _phase11_assert_managed_containers() {
+        local write_report="${1:-true}"
+        local command_text ids count report_path
+        command_text="$(_phase11_compose_command_text)"
+        ids="$($DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" ps -q 2>>"$LOG_FILE" || true)"
+        count=$(printf '%s\n' "$ids" | sed '/^[[:space:]]*$/d' | wc -l | tr -d '[:space:]')
+        if [[ "${count:-0}" -gt 0 ]]; then
+            log "Compose managed container count after launch: $count"
+            return 0
+        fi
+
+        ai_bad "Docker Compose did not create any managed containers."
+        ai "Launch record: $INSTALL_DIR/logs/compose-launch.txt"
+        ai "Inspect with:"
+        ai "  cd '$INSTALL_DIR' && $command_text ps -a"
+        ai "  cd '$INSTALL_DIR' && $command_text logs --tail 200"
+        if [[ "$write_report" != "false" ]] && command -v write_compose_failure_report >/dev/null 2>&1; then
+            report_path="$(COMPOSE_FLAGS_REPORT="${COMPOSE_FLAGS_ARR[*]}" write_compose_failure_report \
+                "$INSTALL_DIR" \
+                "install-core phase 11 zero managed containers" \
+                "$command_text up -d --remove-orphans --no-build" \
+                "$LOG_FILE" \
+                "${GPU_BACKEND:-unknown}" \
+                "No Dream Server containers were created. Run the saved ps/logs commands from the launch record, fix the compose/runtime failure, then re-run ./install.sh." |
+                tail -n 1)" || true
+            [[ -n "${report_path:-}" ]] && ai_warn "Compose failure report saved: $report_path"
+        fi
+        return 1
+    }
+
     # Cloud mode: skip model downloads, auto-enable litellm
     if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
         ai "Cloud mode — skipping model download"
@@ -625,6 +686,7 @@ except Exception:
     # on each retry. Up to 3 attempts with increasing wait
     # between retries — on AMD/Lemonade, the first boot builds a cached
     # llama-server binary which can take 3-5 min.
+    _phase11_write_compose_launch_record
     for _attempt in 1 2 3; do
         $DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" up -d --remove-orphans --no-build >> "$LOG_FILE" 2>&1 &
         compose_pid=$!
@@ -671,6 +733,9 @@ except Exception:
     _phase11_allow_host_agent_firewall dream-network
 
     if $compose_ok; then
+        if ! _phase11_assert_managed_containers false; then
+            exit 1
+        fi
         printf "\r  ${BGRN}✓${NC} %-60s\n" "All containers launched"
         echo ""
         ai_ok "Services started (llama-server)"
@@ -690,6 +755,10 @@ except Exception:
                 tail -n 1)" || true
             [[ -n "${_compose_report_path:-}" ]] && ai_warn "Compose failure report saved: $_compose_report_path"
         fi
+        if ! _phase11_assert_managed_containers; then
+            exit 1
+        fi
+        exit 1
     fi
 
     # ── Bootstrap: launch background full-model download + auto hot-swap ──

--- a/dream-server/lib/safe-env.sh
+++ b/dream-server/lib/safe-env.sh
@@ -39,17 +39,83 @@ load_env_file() {
     done < "$path"
 }
 
+_safe_env_unescape_double_quoted() {
+    local value="$1"
+    # Decode the small shell-compatible escape set emitted by repository
+    # helper scripts. This is parsing, not eval: no command substitution,
+    # expansion, globbing, or word splitting is performed.
+    value="${value//\\\"/\"}"
+    value="${value//\\\$/\$}"
+    value="${value//\\\`/\`}"
+    value="${value//\\\\/\\}"
+    printf '%s' "$value"
+}
+
+_safe_env_key_allowed() {
+    local key="$1"
+    shift || true
+    local allowed
+    for allowed in "$@"; do
+        [[ "$key" == "$allowed" ]] && return 0
+    done
+    return 1
+}
+
 load_env_from_output() {
     local line key value
     while IFS= read -r line; do
+        line="${line%$'\r'}"
         [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
         if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=\"(.*)\"$ ]]; then
             key="${BASH_REMATCH[1]}"
-            value="${BASH_REMATCH[2]}"
-            # Unescape: \\ -> \, \" -> "
-            value="${value//\\\\/\\}"
-            value="${value//\\\"/\"}"
+            value="$(_safe_env_unescape_double_quoted "${BASH_REMATCH[2]}")"
             export "$key=$value"
         fi
     done
+}
+
+load_env_from_output_allowlist() {
+    local line key value
+    [[ "$#" -gt 0 ]] || return 0
+    while IFS= read -r line; do
+        line="${line%$'\r'}"
+        [[ -z "$line" || "$line" =~ ^[[:space:]]*# ]] && continue
+        if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=\"(.*)\"$ ]]; then
+            key="${BASH_REMATCH[1]}"
+            _safe_env_key_allowed "$key" "$@" || continue
+            value="$(_safe_env_unescape_double_quoted "${BASH_REMATCH[2]}")"
+            export "$key=$value"
+        fi
+    done
+}
+
+load_model_selector_env_from_output() {
+    load_env_from_output_allowlist \
+        LLM_MODEL \
+        GGUF_FILE \
+        GGUF_URL \
+        GGUF_SHA256 \
+        MAX_CONTEXT \
+        LLM_MODEL_SIZE_MB \
+        MODEL_RECOMMENDATION_SOURCE \
+        MODEL_RECOMMENDATION_POLICY \
+        MODEL_RECOMMENDATION_CONFIDENCE \
+        MODEL_RECOMMENDATION_REASON \
+        MODEL_RECOMMENDED_ALTERNATIVES \
+        MODEL_RUNTIME_PROFILE \
+        MODEL_RUNTIME_PROFILE_LABEL \
+        MODEL_RUNTIME_PROFILE_SOURCE \
+        LLAMA_SERVER_IMAGE \
+        LLAMA_CPP_RELEASE_TAG_OVERRIDE \
+        LLAMA_CPP_SERVER_BINARY \
+        LLAMA_ARG_FLASH_ATTN \
+        LLAMA_ARG_CACHE_TYPE_K \
+        LLAMA_ARG_CACHE_TYPE_V \
+        LLAMA_ARG_N_CPU_MOE \
+        LLAMA_ARG_NO_CACHE_PROMPT \
+        LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS \
+        LLAMA_ARG_SPEC_TYPE \
+        LLAMA_ARG_SPEC_DRAFT_N_MAX \
+        LLAMA_ARG_SPLIT_MODE \
+        LLAMA_ARG_TENSOR_SPLIT
 }

--- a/dream-server/scripts/select-model.py
+++ b/dream-server/scripts/select-model.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-import shlex
 import sys
 from pathlib import Path
 from typing import Any
@@ -293,7 +292,14 @@ def is_spark_aarch64_excluded_model(model: dict[str, Any]) -> bool:
 
 
 def shell_value(value: Any) -> str:
-    return shlex.quote(str(value or ""))
+    text = str(value or "")
+    text = (
+        text.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("$", "\\$")
+        .replace("`", "\\`")
+    )
+    return f'"{text}"'
 
 
 def recommendation_reason(model: dict[str, Any], capacity_gb: float, memory_label: str,

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -132,4 +132,27 @@ PATH="$open_bin:$PATH" bash -c '
   validate_nvidia_blackwell_open_modules
 '
 
+echo "[contract] catalog selector output is parsed without eval"
+assert_contains "lib/safe-env.sh" 'load_model_selector_env_from_output' "safe env loader missing model selector allowlist"
+assert_contains "scripts/select-model.py" 'return f' "model selector no longer emits parser-friendly quoted values"
+if grep -q 'import shlex' scripts/select-model.py; then
+  echo "[FAIL] model selector should not require shell quoting for installer consumption"
+  exit 1
+fi
+for f in installers/phases/02-detection.sh installers/macos/install-macos.sh tests/test-tier-map.sh; do
+  if grep -q 'eval "$_selector_env"' "$f"; then
+    echo "[FAIL] $f still evals model selector output"
+    exit 1
+  fi
+  assert_contains "$f" 'load_model_selector_env_from_output' "$f does not use the allowlisted selector loader"
+done
+
+echo "[contract] compose launch cannot silently produce zero containers"
+assert_contains "installers/phases/11-services.sh" 'logs/compose-launch\.txt' "Linux installer missing compose launch record"
+assert_contains "installers/phases/11-services.sh" 'ps -q' "Linux installer does not count compose-managed containers"
+assert_contains "installers/phases/11-services.sh" 'Docker Compose did not create any managed containers' "Linux installer does not fail loud on zero managed containers"
+assert_contains "installers/macos/install-macos.sh" 'compose-launch\.txt' "macOS installer missing compose launch record"
+assert_contains "installers/macos/install-macos.sh" 'ps -q' "macOS installer does not count compose-managed containers"
+assert_contains "installers/macos/install-macos.sh" 'docker compose up completed but created no managed containers' "macOS installer does not fail loud on zero managed containers"
+
 echo "[PASS] installer hardening contracts"

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -17,6 +17,19 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+  local file="$1"
+  local pattern="$2"
+  local msg="$3"
+  if grep -qE "$pattern" "$file"; then
+    echo "[FAIL] $msg"
+    echo "---- output ----"
+    cat "$file"
+    echo "----------------"
+    exit 1
+  fi
+}
+
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
@@ -151,6 +164,7 @@ echo "[contract] compose launch cannot silently produce zero containers"
 assert_contains "installers/phases/11-services.sh" 'logs/compose-launch\.txt' "Linux installer missing compose launch record"
 assert_contains "installers/phases/11-services.sh" 'ps -q' "Linux installer does not count compose-managed containers"
 assert_contains "installers/phases/11-services.sh" 'Docker Compose did not create any managed containers' "Linux installer does not fail loud on zero managed containers"
+assert_not_contains "installers/phases/11-services.sh" '_phase11_assert_managed_containers false' "Linux zero-container path must write a compose failure report"
 assert_contains "installers/macos/install-macos.sh" 'compose-launch\.txt' "macOS installer missing compose launch record"
 assert_contains "installers/macos/install-macos.sh" 'ps -q' "macOS installer does not count compose-managed containers"
 assert_contains "installers/macos/install-macos.sh" 'docker compose up completed but created no managed containers' "macOS installer does not fail loud on zero managed containers"

--- a/dream-server/tests/test-install-readiness-summary.sh
+++ b/dream-server/tests/test-install-readiness-summary.sh
@@ -84,6 +84,8 @@ chmod +x "$TMP_DIR/bin/sudo"
 export PATH="$TMP_DIR/bin:$PATH"
 export DOCKER_CMD="sudo docker"
 export SUDO_MARKER="$TMP_DIR/sudo-marker"
+export DREAM_COMPOSE_LAUNCH_RECORD="$TMP_DIR/compose-launch.txt"
+printf "compose_logs_command=cd '%s' && docker compose logs --tail 200\n" "$TMP_DIR" > "$DREAM_COMPOSE_LAUNCH_RECORD"
 
 source "$SUMMARY_LIB"
 
@@ -111,6 +113,8 @@ assert_contains "$OUTPUT" "HTTP 000" "summary includes failed HTTP code"
 assert_contains "$OUTPUT" "Open dashboard: http://localhost:3001" "summary shows dashboard next step"
 assert_contains "$OUTPUT" "Check status: dream status" "summary shows status command"
 assert_contains "$OUTPUT" "Logs: /tmp/dream-install.log" "summary shows log path"
+assert_contains "$OUTPUT" "Compose launch: $DREAM_COMPOSE_LAUNCH_RECORD" "summary shows compose launch record"
+assert_contains "$OUTPUT" "Compose logs: cd '$TMP_DIR' && docker compose logs --tail 200" "summary shows compose logs command"
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"

--- a/dream-server/tests/test-safe-env.sh
+++ b/dream-server/tests/test-safe-env.sh
@@ -71,5 +71,35 @@ load_env_from_output < <(echo 'FROM_STDIN="hello from stdin"')
 [[ "${FROM_STDIN:-}" == "hello from stdin" ]] || fail "FROM_STDIN not set (got: ${FROM_STDIN:-})"
 pass "load_env_from_output exports from stdin"
 
+echo "Test 6: load_env_from_output tolerates CRLF script output"
+unset FROM_CRLF 2>/dev/null || true
+load_env_from_output < <(printf 'FROM_CRLF="windows python"\r\n')
+[[ "${FROM_CRLF:-}" == "windows python" ]] || fail "FROM_CRLF not set from CRLF output"
+pass "load_env_from_output strips trailing CR"
+
+echo "Test 7: load_env_from_output parses escaped characters without eval"
+unset ESCAPED DANGEROUS 2>/dev/null || true
+load_env_from_output < <(printf '%s\n' 'ESCAPED="a \"quote\" and C:\\tmp and \$HOME and \`uname\`"')
+[[ "${ESCAPED:-}" == 'a "quote" and C:\tmp and $HOME and `uname`' ]] || fail "ESCAPED not decoded safely (got: ${ESCAPED:-})"
+_owned="$tmpdir/owned"
+load_env_from_output < <(printf 'DANGEROUS="$(touch %s)"\n' "$_owned")
+[[ "${DANGEROUS:-}" == "\$(touch $_owned)" ]] || fail "DANGEROUS value changed unexpectedly"
+[[ ! -e "$_owned" ]] || fail "load_env_from_output executed command substitution"
+pass "load_env_from_output does not evaluate values"
+
+echo "Test 8: load_env_from_output_allowlist ignores unapproved keys"
+unset ALLOWED NOT_ALLOWED 2>/dev/null || true
+load_env_from_output_allowlist ALLOWED < <(printf '%s\n' 'ALLOWED="yes"' 'NOT_ALLOWED="no"')
+[[ "${ALLOWED:-}" == "yes" ]] || fail "ALLOWED was not loaded"
+[[ -z "${NOT_ALLOWED:-}" ]] || fail "NOT_ALLOWED should not be loaded"
+pass "allowlist loader ignores unapproved keys"
+
+echo "Test 9: model selector loader only accepts approved selector keys"
+unset LLM_MODEL EVIL_SELECTOR_KEY 2>/dev/null || true
+load_model_selector_env_from_output < <(printf '%s\n' 'LLM_MODEL="qwen-test"' 'EVIL_SELECTOR_KEY="nope"')
+[[ "${LLM_MODEL:-}" == "qwen-test" ]] || fail "LLM_MODEL was not loaded"
+[[ -z "${EVIL_SELECTOR_KEY:-}" ]] || fail "EVIL_SELECTOR_KEY should not be loaded"
+pass "model selector loader is allowlisted"
+
 echo ""
 echo "All safe-env tests passed."

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -19,6 +19,11 @@ error() { echo "ERROR: $*" >&2; return 1; }
 
 # Source the module under test
 source "$SCRIPT_DIR/installers/lib/tier-map.sh"
+source "$SCRIPT_DIR/lib/safe-env.sh"
+
+load_selector_env() {
+    load_model_selector_env_from_output <<< "$1"
+}
 
 assert_eq() {
     local label="$1" expected="$2" actual="$3"
@@ -247,7 +252,7 @@ _selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
     --installable-only \
     --env)"
 LLM_MODEL="" GGUF_FILE="" MODEL_RECOMMENDATION_POLICY=""
-eval "$_selector_env"
+load_selector_env "$_selector_env"
 assert_eq "SELECTOR_LLM_MODEL" "qwen3-coder-next" "$LLM_MODEL"
 assert_eq "SELECTOR_GGUF_FILE" "qwen3-coder-next-Q4_K_M.gguf" "$GGUF_FILE"
 assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1" "$MODEL_RECOMMENDATION_POLICY"
@@ -266,7 +271,7 @@ _selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
     --installable-only \
     --env)"
 LLM_MODEL="" GGUF_FILE="" MODEL_RECOMMENDATION_POLICY=""
-eval "$_selector_env"
+load_selector_env "$_selector_env"
 assert_eq "SELECTOR_LLM_MODEL" "qwen3.6-35b-a3b" "$LLM_MODEL"
 assert_eq "SELECTOR_GGUF_FILE" "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" "$GGUF_FILE"
 assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1+spark-aarch64-nv-ultra-a3b-v1" "$MODEL_RECOMMENDATION_POLICY"
@@ -285,7 +290,7 @@ _selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
     --installable-only \
     --env)"
 LLM_MODEL="" GGUF_FILE="" MAX_CONTEXT="" MODEL_RUNTIME_PROFILE="" LLAMA_ARG_N_CPU_MOE="" LLAMA_ARG_CACHE_TYPE_V="" LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS=""
-eval "$_selector_env"
+load_selector_env "$_selector_env"
 assert_eq "SELECTOR_LLM_MODEL" "qwen3.5-9b" "$LLM_MODEL"
 assert_eq "SELECTOR_GGUF_FILE" "Qwen3.5-9B-Q4_K_M.gguf" "$GGUF_FILE"
 assert_eq "SELECTOR_CONTEXT" "32768" "$MAX_CONTEXT"
@@ -308,7 +313,7 @@ _selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
     --installable-only \
     --env)"
 LLM_MODEL="" GGUF_FILE="" MAX_CONTEXT="" MODEL_RUNTIME_PROFILE="" LLAMA_ARG_N_CPU_MOE="" LLAMA_ARG_CACHE_TYPE_V=""
-eval "$_selector_env"
+load_selector_env "$_selector_env"
 assert_eq "SELECTOR_LLM_MODEL" "gemma-4-e4b-it" "$LLM_MODEL"
 assert_eq "SELECTOR_GGUF_FILE" "gemma-4-E4B-it-Q4_K_M.gguf" "$GGUF_FILE"
 assert_eq "SELECTOR_CONTEXT" "32768" "$MAX_CONTEXT"


### PR DESCRIPTION
## What changed

- Fail hard when Linux or macOS compose launch completes without creating any managed containers.
- Save `logs/compose-launch.txt` with cwd, compose flags, compose files, and exact `ps`/`logs` commands for recovery.
- Replace model selector `eval` usage with an allowlisted safe env parser.
- Make selector env parsing tolerate CRLF output from Windows/Git Bash Python.
- Surface the compose launch record and logs command in the install readiness summary.
- Add focused tests for safe env parsing, selector loading, readiness output, and installer hardening contracts.

## Why

The installer should not report success when Docker Compose produced no managed containers, and selector output should be parsed as data rather than executed as shell. This moves the install flow closer to boring, observable, reversible infrastructure: failure leaves artifacts and exact next commands; safe parser boundaries are explicit.

## Validation

- `bash -n installers/phases/02-detection.sh installers/phases/11-services.sh installers/macos/install-macos.sh installers/lib/readiness-summary.sh lib/safe-env.sh tests/test-safe-env.sh tests/test-tier-map.sh tests/test-install-readiness-summary.sh tests/contracts/test-installer-hardening.sh`
- `python -m py_compile scripts/select-model.py`
- `tests/test-safe-env.sh`
- `tests/test-tier-map.sh` (`107 passed, 0 failed`)
- `tests/test-install-readiness-summary.sh` (`15 passed, 0 failed`)
- `tests/contracts/test-installer-hardening.sh`
- `git diff --check`

Note: `tests/contracts/test-installer-contracts.sh` was not runnable in this Windows workspace because `jq` is not installed.
