### PR TITLE
fix(select-model): exclude coder-next on any unified-memory host, not just Spark aarch64

### DIFF
--- a/dream-server/scripts/select-model.py
+++ b/dream-server/scripts/select-model.py
@@ -21,6 +21,14 @@ VRAM_FIT_TOLERANCE_GB = 0.25
 POLICY = "context-aware-largest-capable-general-v1"
 SPARK_AARCH64_POLICY = "spark-aarch64-nv-ultra-a3b-v1"
 SPARK_AARCH64_MODEL_ID = "qwen3.6-35b-a3b-ud-q4"
+# Unified-memory hosts (Strix Halo SH_LARGE, future AMD/NV unified-memory
+# tiers) hit the same coder-next correctness pathology as Spark aarch64.
+# Until upstream fixes coder-next on unified-memory backends, route the
+# qwen profile to the same 35B-A3B substitution used for Spark — same
+# model id, separate policy tag so the recommendation_reason is honest
+# about why the substitution fired.
+UNIFIED_MEMORY_POLICY = "unified-memory-coder-next-a3b-v1"
+UNIFIED_MEMORY_MODEL_ID = SPARK_AARCH64_MODEL_ID
 
 
 def normalize_key(value: Any) -> str:
@@ -275,19 +283,46 @@ def rank_models(catalog: list[dict[str, Any]], capacity_gb: float, profile: str,
 
 
 def arch_policy_model(catalog: list[dict[str, Any]], tier: str, profile: str,
-                      host_arch: str, installable_only: bool) -> dict[str, Any] | None:
-    """Return an architecture-specific model override when the tier map requires one."""
-    if normalize_key(tier) != "nv-ultra" or profile != "qwen" or normalize_host_arch(host_arch) != "arm64":
-        return None
+                      host_arch: str, memory_type: str,
+                      installable_only: bool) -> tuple[dict[str, Any] | None, str | None]:
+    """Return (model, policy_tag) for an architecture-specific override, or (None, None).
+
+    Two routes both substitute coder-next → Qwen3.6-35B-A3B-UD on unified
+    memory hosts where the qwen profile would otherwise pick coder-next
+    (which produces all-`?` tokens on those backends — see in-source
+    notes in installers/lib/tier-map.sh NV_ULTRA + SH_LARGE blocks):
+
+      - nv-ultra + qwen + arm64: Spark / GB10 Grace Blackwell.
+      - any-tier + qwen + memory_type=unified: Strix Halo + future
+        unified-memory NV/AMD tiers. Memory-type is the authoritative
+        signal (not arch or tier alone) because that's the actual
+        characteristic that triggers the pathology.
+    """
+    if profile != "qwen":
+        return None, None
+
+    is_spark_aarch64 = (
+        normalize_key(tier) == "nv-ultra"
+        and normalize_host_arch(host_arch) == "arm64"
+    )
+    is_unified_memory = normalize_key(memory_type) == "unified"
+    if not (is_spark_aarch64 or is_unified_memory):
+        return None, None
+
     for model in catalog:
         if installable_only and not model.get("gguf_url"):
             continue
         if normalize_key(model.get("id")) == normalize_key(SPARK_AARCH64_MODEL_ID):
-            return model
-    return None
+            policy = SPARK_AARCH64_POLICY if is_spark_aarch64 else UNIFIED_MEMORY_POLICY
+            return model, policy
+    return None, None
 
 
 def is_spark_aarch64_excluded_model(model: dict[str, Any]) -> bool:
+    """True if `model` is the coder-next entry that we route around on
+    unified-memory backends. Function name preserved for backwards compat
+    with existing callers; the broader semantic is "excluded on unified
+    memory" (see arch_policy_model)."""
     return normalize_key(model.get("llm_model_name")) == "qwen3-coder-next"
 
 
@@ -325,16 +360,27 @@ def recommendation_reason(model: dict[str, Any], capacity_gb: float, memory_labe
     )
 
 
-def arch_policy_reason(model: dict[str, Any], capacity_gb: float, memory_label: str) -> str:
+def arch_policy_reason(model: dict[str, Any], capacity_gb: float,
+                       memory_label: str, policy_tag: str) -> str:
     context_k = int((model.get("context_length") or 0) / 1024)
     required = selector_required_memory_gb(model)
+    if policy_tag == UNIFIED_MEMORY_POLICY:
+        rationale = (
+            "is selected for unified-memory hosts (e.g. Strix Halo, future "
+            "AMD/NV unified-memory tiers) because qwen3-coder-next produces "
+            "all-`?` tokens on unified-memory backends"
+        )
+    else:
+        rationale = (
+            "is selected for arm64 NV_ULTRA Spark-class NVIDIA hosts because "
+            "qwen3-coder-next is excluded on this architecture by the tier map"
+        )
     return (
-        f"Arch-aware catalog policy ({SPARK_AARCH64_POLICY}): {model['name']} "
-        f"is selected for arm64 NV_ULTRA Spark-class NVIDIA hosts because "
-        f"qwen3-coder-next is excluded on this architecture by the tier map. "
-        f"It needs about {required:g}GB including context/KV, fits {capacity_gb:.1f}GB "
-        f"{memory_label}, and gives {context_k}K context. "
-        f"Throughput requires a local benchmark after first launch."
+        f"Arch-aware catalog policy ({policy_tag}): {model['name']} "
+        f"{rationale}. It needs about {required:g}GB including context/KV, "
+        f"fits {capacity_gb:.1f}GB {memory_label}, and gives "
+        f"{context_k}K context. Throughput requires a local benchmark after "
+        f"first launch."
     )
 
 
@@ -356,7 +402,9 @@ def main() -> int:
     profile = effective_profile(normalize_profile(args.profile), args.backend, args.tier)
     capacity_gb, memory_label = usable_memory_gb(args.backend, args.memory_type, args.vram_mb, args.ram_gb)
     confidence = "high" if args.backend not in {"unknown", "none"} and capacity_gb > 0 else "medium"
-    arch_selected = arch_policy_model(catalog, args.tier, profile, args.host_arch, args.installable_only)
+    arch_selected, arch_policy_tag = arch_policy_model(
+        catalog, args.tier, profile, args.host_arch, args.memory_type, args.installable_only,
+    )
     ranked = rank_models(
         catalog,
         capacity_gb,
@@ -374,9 +422,9 @@ def main() -> int:
             model for model in ranked
             if model["id"] != selected["id"] and not is_spark_aarch64_excluded_model(model)
         ][:2]
-        policy = f"{POLICY}+{SPARK_AARCH64_POLICY}"
+        policy = f"{POLICY}+{arch_policy_tag}"
         source = "catalog_arch_policy_pre_download"
-        reason = arch_policy_reason(selected, capacity_gb, memory_label)
+        reason = arch_policy_reason(selected, capacity_gb, memory_label, arch_policy_tag)
     else:
         selected = ranked[0]
         alternatives = ranked[:3]

--- a/dream-server/scripts/select-model.py
+++ b/dream-server/scripts/select-model.py
@@ -284,7 +284,8 @@ def rank_models(catalog: list[dict[str, Any]], capacity_gb: float, profile: str,
 
 def arch_policy_model(catalog: list[dict[str, Any]], tier: str, profile: str,
                       host_arch: str, memory_type: str,
-                      installable_only: bool) -> tuple[dict[str, Any] | None, str | None]:
+                      installable_only: bool,
+                      selected_model: dict[str, Any] | None = None) -> tuple[dict[str, Any] | None, str | None]:
     """Return (model, policy_tag) for an architecture-specific override, or (None, None).
 
     Two routes both substitute coder-next → Qwen3.6-35B-A3B-UD on unified
@@ -305,8 +306,12 @@ def arch_policy_model(catalog: list[dict[str, Any]], tier: str, profile: str,
         normalize_key(tier) == "nv-ultra"
         and normalize_host_arch(host_arch) == "arm64"
     )
-    is_unified_memory = normalize_key(memory_type) == "unified"
-    if not (is_spark_aarch64 or is_unified_memory):
+    is_unified_coder_next = (
+        normalize_key(memory_type) == "unified"
+        and selected_model is not None
+        and is_spark_aarch64_excluded_model(selected_model)
+    )
+    if not (is_spark_aarch64 or is_unified_coder_next):
         return None, None
 
     for model in catalog:
@@ -402,9 +407,6 @@ def main() -> int:
     profile = effective_profile(normalize_profile(args.profile), args.backend, args.tier)
     capacity_gb, memory_label = usable_memory_gb(args.backend, args.memory_type, args.vram_mb, args.ram_gb)
     confidence = "high" if args.backend not in {"unknown", "none"} and capacity_gb > 0 else "medium"
-    arch_selected, arch_policy_tag = arch_policy_model(
-        catalog, args.tier, profile, args.host_arch, args.memory_type, args.installable_only,
-    )
     ranked = rank_models(
         catalog,
         capacity_gb,
@@ -415,6 +417,9 @@ def main() -> int:
         args.vram_mb,
         args.ram_gb,
         args.host_arch,
+    )
+    arch_selected, arch_policy_tag = arch_policy_model(
+        catalog, args.tier, profile, args.host_arch, args.memory_type, args.installable_only, ranked[0],
     )
     if arch_selected:
         selected = arch_selected

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -277,6 +277,28 @@ assert_eq "SELECTOR_GGUF_FILE" "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" "$GGUF_FILE"
 assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1+spark-aarch64-nv-ultra-a3b-v1" "$MODEL_RECOMMENDATION_POLICY"
 echo ""
 
+# Strix Halo (SH_LARGE, AMD Ryzen AI MAX+ 395, 124 GB unified) hit the same
+# coder-next pathology as Spark aarch64. The selector should substitute to
+# 35B-A3B via the unified-memory policy (distinct tag from the Spark one).
+echo "Catalog selector (amd unified SH_LARGE substitutes coder-next → A3B):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend amd \
+    --memory-type unified \
+    --vram-mb 0 \
+    --ram-gb 124 \
+    --profile qwen \
+    --tier SH_LARGE \
+    --host-arch amd64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE="" MODEL_RECOMMENDATION_POLICY=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_LLM_MODEL" "qwen3.6-35b-a3b" "$LLM_MODEL"
+assert_eq "SELECTOR_GGUF_FILE" "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" "$GGUF_FILE"
+assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1+unified-memory-coder-next-a3b-v1" "$MODEL_RECOMMENDATION_POLICY"
+echo ""
+
 echo "Catalog selector (8GB NVIDIA qwen uses upstream catalog fit):"
 _selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
     --catalog "$SCRIPT_DIR/config/model-library.json" \

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -299,6 +299,66 @@ assert_eq "SELECTOR_GGUF_FILE" "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" "$GGUF_FILE"
 assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1+unified-memory-coder-next-a3b-v1" "$MODEL_RECOMMENDATION_POLICY"
 echo ""
 
+echo "Catalog selector (16GB Apple unified qwen keeps ranked fit):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend metal \
+    --memory-type unified \
+    --vram-mb 0 \
+    --ram-gb 16 \
+    --profile qwen \
+    --tier 1 \
+    --host-arch arm64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE="" MODEL_RECOMMENDATION_SOURCE="" MODEL_RECOMMENDATION_POLICY=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_LLM_MODEL" "qwen3.5-9b" "$LLM_MODEL"
+assert_eq "SELECTOR_GGUF_FILE" "Qwen3.5-9B-Q4_K_M.gguf" "$GGUF_FILE"
+assert_eq "SELECTOR_SOURCE" "catalog_fit_pre_download" "$MODEL_RECOMMENDATION_SOURCE"
+assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1" "$MODEL_RECOMMENDATION_POLICY"
+echo ""
+
+echo "Catalog selector (32GB Apple unified qwen keeps ranked fit):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend metal \
+    --memory-type unified \
+    --vram-mb 0 \
+    --ram-gb 32 \
+    --profile qwen \
+    --tier 2 \
+    --host-arch arm64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE="" MODEL_RECOMMENDATION_SOURCE="" MODEL_RECOMMENDATION_POLICY=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_LLM_MODEL" "phi-4" "$LLM_MODEL"
+assert_eq "SELECTOR_GGUF_FILE" "phi-4-Q4_K_M.gguf" "$GGUF_FILE"
+assert_eq "SELECTOR_SOURCE" "catalog_fit_pre_download" "$MODEL_RECOMMENDATION_SOURCE"
+assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1" "$MODEL_RECOMMENDATION_POLICY"
+echo ""
+
+echo "Catalog selector (amd unified SH_COMPACT uses ranked A3B without override):"
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$SCRIPT_DIR/config/model-library.json" \
+    --backend amd \
+    --memory-type unified \
+    --vram-mb 0 \
+    --ram-gb 64 \
+    --profile qwen \
+    --tier SH_COMPACT \
+    --host-arch amd64 \
+    --installable-only \
+    --env)"
+LLM_MODEL="" GGUF_FILE="" MODEL_RECOMMENDATION_SOURCE="" MODEL_RECOMMENDATION_POLICY=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_LLM_MODEL" "qwen3.6-35b-a3b" "$LLM_MODEL"
+assert_eq "SELECTOR_GGUF_FILE" "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" "$GGUF_FILE"
+assert_eq "SELECTOR_SOURCE" "catalog_fit_pre_download" "$MODEL_RECOMMENDATION_SOURCE"
+assert_eq "SELECTOR_POLICY" "context-aware-largest-capable-general-v1" "$MODEL_RECOMMENDATION_POLICY"
+echo ""
+
 echo "Catalog selector (8GB NVIDIA qwen uses upstream catalog fit):"
 _selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
     --catalog "$SCRIPT_DIR/config/model-library.json" \


### PR DESCRIPTION
## Summary

Follow-up to #1265 (Strix Halo qwen3-coder-next substitution). That PR fixed `installers/lib/tier-map.sh`, but phase 02-detection.sh routes via `scripts/select-model.py` (the "capabilities oracle") which had a Spark-aarch64-specific override that didn't catch Strix.

## Evidence (2026-05-19 fleet run round 4, after #1265 merged)

```
$ ssh strix-halo 'grep "Capabilities override\|Model:" /home/michael/dream-server/.../install.log'
[INFO] Capabilities override detection: backend=amd, memory=unified, tier=SH_LARGE
[INFO]   Model: qwen3-coder-next        ← still wrong
```

bootstrap-upgrade.sh then began downloading the 48.5GB coder-next that would not have worked on Strix Halo anyway (verified pathology: all-`?` tokens on unified-memory backends — see in-source notes in tier-map.sh).

## Fix

The real signal is `memory_type == unified`, not arch or tier. Extend `arch_policy_model()` in `select-model.py` to fire on `profile=qwen + memory_type=unified` for any tier, returning the same Qwen3.6-35B-A3B-UD-Q4_K_M substitution under a new policy tag (`unified-memory-coder-next-a3b-v1`, distinct from `spark-aarch64-nv-ultra-a3b-v1`).

`arch_policy_model()` now returns `(model, policy_tag)` so callers can distinguish the two routes; `arch_policy_reason()` renders different rationales for unified-memory vs Spark aarch64.

## Test plan

- [x] `python3 -m py_compile scripts/select-model.py` clean
- [x] `bash tests/test-tier-map.sh` — **110 passed, 0 failed** (added 3 SH_LARGE assertions)
- [x] amd64 NV_ULTRA (Tower2) still selects coder-next (discrete memory, no policy tag added)
- [x] arm64 NV_ULTRA (Spark) still selects 35B-A3B with the spark-aarch64 policy tag (unchanged)
- [x] amd unified SH_LARGE (Strix) now selects 35B-A3B with the new unified-memory policy tag
- [ ] Manual: re-install on strix-halo → install.log reports "Model: qwen3.6-35b-a3b" and bootstrap-upgrade downloads the ~22GB model

🤖 Generated with [Claude Code](https://claude.com/claude-code)