### PR TITLE
fix(bootstrap-upgrade): force-recreate llama-server so new GGUF takes effect

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -371,9 +371,14 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
     # Restart llama-server — strategy depends on GPU backend:
     # - AMD (Lemonade): use 'restart' to preserve cached llama-server build.
     #   Lemonade reads models.ini at startup, so it picks up the new model.
-    # - NVIDIA/CPU (llama.cpp): use 'stop + up -d' to recreate the container.
-    #   The model path is in the compose command (--model /models/${GGUF_FILE}),
-    #   which is only resolved from .env when the container is created.
+    # - NVIDIA/CPU (llama.cpp): force-recreate so the new GGUF_FILE in .env
+    #   takes effect. `compose stop` + `compose up -d` is NOT enough — when the
+    #   service has a stopped container, compose will start the existing
+    #   container in place (preserving its baked --model arg) instead of
+    #   building a fresh one from the updated .env. The original CMD points at
+    #   /models/${BOOTSTRAP_GGUF_FILE}, which Phase 4b just deleted, so the
+    #   container crash-loops. `--force-recreate --no-deps` guarantees a new
+    #   container; --no-deps avoids touching other services in the project.
     log "Restarting llama-server container (backend: ${_gpu_backend:-unknown})..."
     if [[ "$_gpu_backend" == "amd" ]]; then
         # Lemonade: restart preserves cached binary, reads models.ini on boot
@@ -383,10 +388,9 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
             $DOCKER_CMD restart dream-llama-server 2>&1 || true
         fi
     else
-        # llama.cpp: recreate to pick up new GGUF_FILE from .env
+        # llama.cpp: force-recreate to pick up new GGUF_FILE from .env
         if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
-            $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" stop llama-server 2>&1 || true
-            $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d llama-server 2>&1 || true
+            $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps llama-server 2>&1 || true
         else
             # No compose flags — use docker rm to force a fresh container that
             # re-reads GGUF_FILE from the env file. 'docker start' reuses the old
@@ -456,6 +460,24 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
         fi
         sleep 5
     done
+
+    # Assert the recreated container's --model arg actually points at the new
+    # GGUF file. If compose handed us back a started-not-recreated container
+    # (the bug --force-recreate above is meant to prevent), the health check
+    # may still pass on Lemonade (which loads on demand) but llama.cpp will
+    # crash-loop the moment the next request hits, because Phase 4b has
+    # already deleted the bootstrap GGUF the baked CMD refers to. Fail loudly
+    # so the operator does not discover this hours later via a 502.
+    if [[ "$_gpu_backend" != "amd" ]] && [[ -n "$DOCKER_CMD" ]]; then
+        _running_cmd=$($DOCKER_CMD inspect dream-llama-server --format '{{join .Config.Cmd " "}}' 2>/dev/null || echo "")
+        if [[ -n "$_running_cmd" ]] && ! [[ "$_running_cmd" == *"/models/${FULL_GGUF_FILE}"* ]]; then
+            log "ERROR: llama-server container started with stale --model arg."
+            log "  expected /models/${FULL_GGUF_FILE}, got: $_running_cmd"
+            log "  This means 'compose up -d --force-recreate' did not recreate the container."
+            log "  Recover with: cd $INSTALL_DIR && docker compose \$(cat .compose-flags) up -d --force-recreate --no-deps llama-server"
+            _healthy=false
+        fi
+    fi
 
     if $_healthy; then
         log "SUCCESS: llama-server is running with $FULL_LLM_MODEL"

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -470,12 +470,18 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
     # so the operator does not discover this hours later via a 502.
     if [[ "$_gpu_backend" != "amd" ]] && [[ -n "$DOCKER_CMD" ]]; then
         _running_cmd=$($DOCKER_CMD inspect dream-llama-server --format '{{join .Config.Cmd " "}}' 2>/dev/null || echo "")
-        if [[ -n "$_running_cmd" ]] && ! [[ "$_running_cmd" == *"/models/${FULL_GGUF_FILE}"* ]]; then
+        if [[ -z "$_running_cmd" ]]; then
+            log "ERROR: could not inspect llama-server container command after recreate."
+            log "  Recover with: cd $INSTALL_DIR && docker compose \$(cat .compose-flags) up -d --force-recreate --no-deps llama-server"
+            write_status "failed"
+            fail "llama-server command inspection failed after force-recreate."
+        elif ! [[ "$_running_cmd" == *"/models/${FULL_GGUF_FILE}"* ]]; then
             log "ERROR: llama-server container started with stale --model arg."
             log "  expected /models/${FULL_GGUF_FILE}, got: $_running_cmd"
             log "  This means 'compose up -d --force-recreate' did not recreate the container."
             log "  Recover with: cd $INSTALL_DIR && docker compose \$(cat .compose-flags) up -d --force-recreate --no-deps llama-server"
-            _healthy=false
+            write_status "failed"
+            fail "llama-server container started with stale --model arg after force-recreate."
         fi
     fi
 

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -43,6 +43,9 @@ bash tests/contracts/test-port-contracts.sh
 echo "[contract] Windows AMD local compose readiness"
 bash tests/contracts/test-windows-amd-local-compose.sh
 
+echo "[contract] bootstrap hot-swap force-recreate"
+bash tests/test-bootstrap-upgrade-hotswap-contract.sh
+
 echo "[contract] AMD reassign keeps HSA override Strix-only"
 grep -q '_env_set "HSA_OVERRIDE_GFX_VERSION" "11.5.1"' dream-cli \
   || { echo "[FAIL] dream-cli must set HSA override to 11.5.1 for gfx1151"; exit 1; }

--- a/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Regression checks for bootstrap-upgrade's llama-server hot-swap contract.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+# Strip comments so explanatory text cannot satisfy or fail the checks.
+active_code="$(grep -v '^[[:space:]]*#' "$TARGET")"
+
+grep -qF 'up -d --force-recreate --no-deps llama-server' <<<"$active_code" \
+    || fail "llama.cpp hot-swap must force-recreate llama-server without deps"
+pass "llama.cpp hot-swap uses force-recreate/no-deps"
+
+if grep -qE '\bstop[[:space:]]+llama-server\b' <<<"$active_code"; then
+    fail "llama.cpp hot-swap must not stop llama-server before compose up"
+fi
+pass "llama.cpp hot-swap does not use stop + up"
+
+grep -qF 'inspect dream-llama-server --format' <<<"$active_code" \
+    || fail "hot-swap must inspect the recreated container command"
+grep -qF '"/models/${FULL_GGUF_FILE}"' <<<"$active_code" \
+    || fail "hot-swap must assert the running command points at the full GGUF"
+pass "hot-swap asserts the running command uses the full GGUF"
+
+stale_block="$(awk '
+    /llama-server container started with stale --model arg/ { in_block=1 }
+    in_block { print }
+    in_block && /fi[[:space:]]*$/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+grep -qF 'write_status "failed"' <<<"$stale_block" \
+    || fail "stale --model assertion must mark bootstrap status failed"
+grep -qF 'fail "llama-server container started with stale --model arg after force-recreate."' <<<"$stale_block" \
+    || fail "stale --model assertion must exit non-zero"
+pass "stale --model assertion fails loudly"


### PR DESCRIPTION
## Summary

After a bootstrap → full-model hot-swap on NVIDIA / CPU hosts, `dream-llama-server` crash-loops at any subsequent restart because its baked `--model` argument still points at the bootstrap GGUF that Phase 4b deleted minutes earlier.

`scripts/bootstrap-upgrade.sh` does `compose stop llama-server` followed by `compose up -d llama-server`. When the service has an *existing stopped* container, Docker Compose starts it in place — it does **not** rebuild the container from the new `.env`. The new `GGUF_FILE` set two lines earlier in Phase 3 never makes it into the running `--model` arg, and the container keeps `--model /models/Qwen3.5-2B-Q4_K_M.gguf` even though that file was already removed.

The health check that follows is racy enough to occasionally pass on a still-warm slot, so the broken state survives the swap and surfaces as a 502 the first time anything restarts the container (host reboot, `dream restart`, OOM, etc.). Strix Halo (Lemonade/AMD) and macOS native are unaffected because their code paths re-read `.env`/`models.ini` at startup.

## Root cause

`compose up -d <service>` semantics when the existing container is *stopped*:
- **running, config changed:** recreate
- **running, config same:** noop
- **stopped:** start the existing container, preserving its baked CMD — no recreate
- **missing:** create

Phase 5 of `bootstrap-upgrade.sh` always reaches the third branch (it just ran `compose stop` itself), so the `--model` arg is never updated.

## Fix

- Use `compose up -d --force-recreate --no-deps llama-server` instead of `stop` + `up -d`. `--force-recreate` guarantees a new container; `--no-deps` keeps the blast radius to llama-server (other services keep running through the swap).
- Add a post-recreate assertion that the running container's `Config.Cmd` actually contains `/models/${FULL_GGUF_FILE}`. If a future change reintroduces this class of bug, the upgrade fails loudly with a recovery command instead of letting the operator discover it via a crash-loop hours later.

## Repro / validation

On any fresh nvidia or cpu install, after `bootstrap-status.json` reports `status: complete`:

```bash
docker inspect dream-llama-server --format '{{join .Config.Cmd " "}}' \
  | grep -qF "/models/$(grep ^GGUF_FILE= "$HOME/dream-server/.env" | cut -d= -f2)"
```

Pre-fix on Tower2 (RTX PRO 6000 ×2) and Spark (GB10): exit 1 — running CMD has `Qwen3.5-2B-Q4_K_M.gguf`, .env has `qwen3-coder-next-Q4_K_M.gguf`. Container `restartCount=26+` minutes after the hot-swap "completes".

Post-fix: exit 0, container `running`, `restartCount=0`.

## Found by

Fleet test run `2026-05-19T22-18-50Z` (hermes seed-echo probe failed on tower2 and spark; verify/dashboard/capabilities cascade-failed on the same hosts because the LLM server was crash-looping). Manual `docker compose up -d --force-recreate llama-server` against the broken install recovered the container with the correct `--model` arg, confirming the root cause.

## Test plan

- [x] Manual recovery on Tower2 reproduces the hot-swap path's expected end state (container running, CMD points at full model)
- [ ] Run `/dream-fleet-test` against a fresh nvidia install with this PR merged — bug should not recur
- [ ] Run on a host with an old install already in the broken state (`bootstrap-status.json` complete but CMD stale) — the recovery command in the log should bring it back without re-installing
- [ ] Regression fixture in `dream-fleet-test/regressions/hermes-llm-no-echo.json` to catch a future re-introduction
