### PR TITLE
fix(bootstrap-upgrade): strip shell env so compose reads the new .env

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -388,9 +388,20 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
             $DOCKER_CMD restart dream-llama-server 2>&1 || true
         fi
     else
-        # llama.cpp: force-recreate to pick up new GGUF_FILE from .env
+        # llama.cpp: force-recreate to pick up new GGUF_FILE from .env.
+        # `env -u` strips the model-config vars from compose's shell so they
+        # cannot win interpolation over the freshly-updated .env. Compose
+        # variable precedence is shell-env > .env file > compose default,
+        # and Phase 11 of the installer (parent of this nohup'd script) sets
+        # GGUF_FILE / LLM_MODEL / MAX_CONTEXT / CTX_SIZE to the bootstrap
+        # values as shell variables before forking us. Empirically those
+        # leak into our env on Linux even without an explicit `export`, and
+        # without this guard compose silently recreates the container with
+        # `--model /models/${BOOTSTRAP_GGUF_FILE}` — pointing at the file
+        # Phase 4b just deleted, hence the crash-loop on next restart.
         if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
-            $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps llama-server 2>&1 || true
+            env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE \
+                $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps llama-server 2>&1 || true
         else
             # No compose flags — use docker rm to force a fresh container that
             # re-reads GGUF_FILE from the env file. 'docker start' reuses the old
@@ -478,8 +489,21 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
         elif ! [[ "$_running_cmd" == *"/models/${FULL_GGUF_FILE}"* ]]; then
             log "ERROR: llama-server container started with stale --model arg."
             log "  expected /models/${FULL_GGUF_FILE}, got: $_running_cmd"
-            log "  This means 'compose up -d --force-recreate' did not recreate the container."
-            log "  Recover with: cd $INSTALL_DIR && docker compose \$(cat .compose-flags) up -d --force-recreate --no-deps llama-server"
+            log "  This means 'compose up -d --force-recreate' did not pick up the updated .env."
+            # Dump what compose would have seen so a future regression can be
+            # diagnosed from logs alone. If any of these have non-empty values,
+            # they overrode the .env at compose interpolation time.
+            for _k in GGUF_FILE LLM_MODEL MAX_CONTEXT CTX_SIZE; do
+                _v="$(printenv "$_k" 2>/dev/null || true)"
+                if [[ -n "$_v" ]]; then
+                    log "  shell env leak: $_k=$_v (overrode .env's $_k)"
+                fi
+            done
+            log "  .env now has:"
+            for _k in GGUF_FILE LLM_MODEL MAX_CONTEXT CTX_SIZE; do
+                log "    $(grep -E "^${_k}=" "$ENV_FILE" 2>/dev/null || echo "${_k}=<missing>")"
+            done
+            log "  Recover with: cd $INSTALL_DIR && env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE docker compose \$(cat .compose-flags) up -d --force-recreate --no-deps llama-server"
             write_status "failed"
             fail "llama-server container started with stale --model arg after force-recreate."
         fi

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -547,6 +547,8 @@ LITELLM_UPGRADE_EOF
         # Recreate OpenClaw so inject-token.js picks up the new GGUF_FILE/LLM_MODEL
         # from .env. A restart alone won't work — env vars are baked in at container
         # creation time, and inject-token.js builds the Lemonade model name from them.
+        # Strip the same model-config vars here as the llama-server recreate path
+        # so shell-env pollution cannot override the freshly-updated .env.
         if $DOCKER_CMD ps --filter name=dream-openclaw --format '{{.Names}}' 2>/dev/null | grep -q dream-openclaw; then
             log "Recreating OpenClaw to pick up model change..."
             # Guard on BOTH compose args AND a non-empty $DOCKER_COMPOSE_CMD —
@@ -558,10 +560,11 @@ LITELLM_UPGRADE_EOF
             # which executes the first compose-arg (e.g. `-f`) as a binary.
             # Skip the recreate and surface a clear warning instead.
             if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
-                $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
+                env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE \
+                    $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate openclaw 2>&1 || \
                     log "WARNING: OpenClaw recreate failed (non-fatal)"
             else
-                log "WARNING: No compose binary available (DOCKER_COMPOSE_CMD empty or compose args missing) — OpenClaw was NOT recreated. The new model will not take effect until OpenClaw is recreated manually with: docker compose up -d --force-recreate openclaw"
+                log "WARNING: No compose binary available (DOCKER_COMPOSE_CMD empty or compose args missing) — OpenClaw was NOT recreated. The new model will not take effect until OpenClaw is recreated manually with: env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE docker compose up -d --force-recreate openclaw"
             fi
         fi
         # Patch Hermes Agent's config so it stops asking the LLM server for the

--- a/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -24,10 +24,30 @@ grep -qF 'up -d --force-recreate --no-deps llama-server' <<<"$active_code" \
     || fail "llama.cpp hot-swap must force-recreate llama-server without deps"
 pass "llama.cpp hot-swap uses force-recreate/no-deps"
 
+llama_recreate_block="$(awk '
+    /force-recreate to pick up new GGUF_FILE/ { in_block=1 }
+    in_block { print }
+    in_block && /up -d --force-recreate --no-deps llama-server/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+grep -qF 'env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE' <<<"$llama_recreate_block" \
+    || fail "llama-server recreate must strip model vars so .env wins compose interpolation"
+pass "llama-server recreate strips model env before compose"
+
 if grep -qE '\bstop[[:space:]]+llama-server\b' <<<"$active_code"; then
     fail "llama.cpp hot-swap must not stop llama-server before compose up"
 fi
 pass "llama.cpp hot-swap does not use stop + up"
+
+openclaw_recreate_block="$(awk '
+    /Recreating OpenClaw to pick up model change/ { in_block=1 }
+    in_block { print }
+    in_block && /up -d --force-recreate openclaw/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+grep -qF 'env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE' <<<"$openclaw_recreate_block" \
+    || fail "OpenClaw recreate must strip model vars so .env wins compose interpolation"
+pass "OpenClaw recreate strips model env before compose"
 
 grep -qF 'inspect dream-llama-server --format' <<<"$active_code" \
     || fail "hot-swap must inspect the recreated container command"
@@ -38,7 +58,7 @@ pass "hot-swap asserts the running command uses the full GGUF"
 stale_block="$(awk '
     /llama-server container started with stale --model arg/ { in_block=1 }
     in_block { print }
-    in_block && /fi[[:space:]]*$/ { exit }
+    in_block && /fail "llama-server container started with stale --model arg after force-recreate."/ { exit }
 ' "$TARGET" | grep -v '^[[:space:]]*#')"
 
 grep -qF 'write_status "failed"' <<<"$stale_block" \


### PR DESCRIPTION
## Summary

Follow-up to #1279. The previous fix added `--force-recreate --no-deps` to the NVIDIA/CPU hot-swap path and a post-recreate assertion. The validation regression fixture passes in isolation, but on a fresh end-to-end install the assertion **still fires**: `docker compose ... up -d --force-recreate --no-deps llama-server` recreates the container but the new container's `--model` arg keeps pointing at the bootstrap GGUF that Phase 4b deleted.

Root cause: **shell-env pollution.** Compose's variable interpolation precedence is `shell env > .env file > compose default`. Phase 11 of the installer sets `GGUF_FILE`, `LLM_MODEL`, `MAX_CONTEXT`, and `CTX_SIZE` as shell variables before forking us via `nohup bash scripts/bootstrap-upgrade.sh ...`. Despite no explicit `export` in the installer source, those values reliably reach `bootstrap-upgrade.sh`'s process environment on Linux. When `compose up -d --force-recreate` runs, it interpolates `${GGUF_FILE}` from the polluted shell env (the bootstrap value Phase 11 set hours earlier) instead of the freshly-updated `.env` value (the full model). Result: a "recreated" container with a stale `--model` arg pointing at a file we already deleted, crash-looping at the next restart.

Reproducer:

```bash
cd /home/michael/dream-server
# .env says GGUF_FILE=qwen3-coder-next-Q4_K_M.gguf
GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf docker compose \
    -f docker-compose.base.yml -f docker-compose.nvidia.yml \
    config llama-server | grep -A2 command
#     command:
#       - --model
#       - /models/Qwen3.5-2B-Q4_K_M.gguf    ← shell wins over .env

# Same command, shell env stripped:
GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf env -u GGUF_FILE docker compose ... | grep -A2 command
#     command:
#       - --model
#       - /models/qwen3-coder-next-Q4_K_M.gguf    ← .env wins
```

## Fix

`env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE` in front of the `compose up -d --force-recreate --no-deps` call. Strip the four model-config vars from compose's invocation environment so the freshly-updated `.env` wins variable interpolation, regardless of what Phase 11 left in the parent shell. Safe — these are the exact four vars Phase 3 of this script just wrote to `.env` and nothing else in the compose stack reads them from any other source.

Also enriches the post-recreate assertion's error log to dump shell-env values and `.env` values when it ever fires again, so a future regression of this class is debuggable from the run log alone (we burned a couple of cycles diagnosing this one without that signal).

## Why #1279 alone wasn't enough

PR #1279 swapped `compose stop` + `compose up -d` for `compose up -d --force-recreate --no-deps`. That correctly addresses the "started not recreated" failure mode (compose starts a stopped container in place rather than rebuilding). But the second-order failure mode — recreating WITH stale interpolation because shell env overrode `.env` — was masked by the first one. Until the assertion fired on the freshly-merged code, the stale-interpolation path was indistinguishable from the no-recreate path.

The defensive assertion added in #1279 caught the regression on this run within seconds of bootstrap-upgrade.sh finishing — exactly the failure mode it was designed for.

## Test plan

- [x] Manual reproducer: `GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf docker compose config llama-server` shows the bug; same command with `env -u GGUF_FILE` shows the fix.
- [x] Tower2 fleet-test run on commit `c814d78` (PR #1279 merged) reproduced the bug with the post-recreate assertion firing as designed.
- [ ] Fleet test on a fresh Tower2 install after this PR merges — bug should not recur, capabilities matrix should go green.
- [x] Regression fixture `hotswap-force-recreate-1279` in dream-fleet-test already covers the symptom; this PR keeps that fixture valid.
