### PR TITLE
fix(installer/macos): rename $LOG_FILE -> $DS_LOG_FILE in 4 sites

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -392,7 +392,7 @@ if command -v python3 >/dev/null 2>&1; then
         ai_ok "PyYAML available"
     else
         ai "Installing PyYAML (required by compose resolver)..."
-        if python3 -m pip install --user --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$LOG_FILE" >/dev/null \
+        if python3 -m pip install --user --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$DS_LOG_FILE" >/dev/null \
            && python3 -c 'import yaml' >/dev/null 2>&1; then
             ai_ok "PyYAML installed (python3 -m pip --user)"
         else
@@ -525,7 +525,7 @@ if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "$SELECTED_T
                 --tier "$SELECTED_TIER" \
                 --host-arch "$(uname -m 2>/dev/null || echo unknown)" \
                 --installable-only \
-                --env 2>>"$LOG_FILE" || true)"
+                --env 2>>"$DS_LOG_FILE" || true)"
             if [[ -n "$_selector_env" ]]; then
                 load_model_selector_env_from_output <<< "$_selector_env"
                 ai "Model selector: ${MODEL_RECOMMENDATION_REASON:-$LLM_MODEL}"
@@ -916,14 +916,14 @@ else
                 python3 "$_hermes_patcher" "$_hermes_tpl" \
                     --model "$GGUF_FILE" \
                     --base-url "$_hermes_base_url" \
-                    --context-length "$MAX_CONTEXT" >>"$LOG_FILE" 2>&1 || \
+                    --context-length "$MAX_CONTEXT" >>"$DS_LOG_FILE" 2>&1 || \
                     ai_warn "Hermes template patch failed — hand-edit ${_hermes_tpl} if prompts hang."
                 _hermes_live="${INSTALL_DIR}/data/hermes/config.yaml"
                 if [[ -f "$_hermes_live" ]]; then
                     python3 "$_hermes_patcher" "$_hermes_live" \
                         --model "$GGUF_FILE" \
                         --base-url "$_hermes_base_url" \
-                        --context-length "$MAX_CONTEXT" >>"$LOG_FILE" 2>&1 || \
+                        --context-length "$MAX_CONTEXT" >>"$DS_LOG_FILE" 2>&1 || \
                         ai_warn "Hermes live config patch failed — hand-edit ${_hermes_live} and restart Hermes if prompts hang."
                 fi
             else

--- a/dream-server/tests/test-installer-context-parity.sh
+++ b/dream-server/tests/test-installer-context-parity.sh
@@ -36,6 +36,19 @@ assert_grep() {
     fi
 }
 
+assert_not_grep() {
+    local file="$1"
+    local pattern="$2"
+    local label="$3"
+
+    [[ -f "$file" ]] || fail "missing $file"
+    if grep -Eq -- "$pattern" "$file"; then
+        fail "$label"
+    else
+        pass "$label"
+    fi
+}
+
 echo "=== Installer context parity ==="
 
 echo ""
@@ -92,6 +105,8 @@ assert_grep "installers/phases/11-services.sh" '--context-length "\$_hermes_cont
     "Linux Hermes patcher receives context length"
 assert_grep "installers/macos/install-macos.sh" '--context-length "\$MAX_CONTEXT"' \
     "macOS Hermes patcher receives context length"
+assert_not_grep "installers/macos/install-macos.sh" '\$LOG_FILE' \
+    "macOS installer uses DS_LOG_FILE, not undefined LOG_FILE"
 assert_grep "installers/windows/install-windows.ps1" 'Update-HermesConfigFile.*ContextLength \(\[int\]\$tierConfig\.MaxContext\)' \
     "Windows Hermes patcher receives context length"
 


### PR DESCRIPTION
## Summary

`installers/macos/install-macos.sh` runs under `set -euo pipefail` and references `$LOG_FILE` in four redirection sites, but the variable is actually named `$DS_LOG_FILE` (defined once near the top, used consistently in the other 9 sites). Under `set -u`, `$LOG_FILE` is an unbound-variable error that fires *before* the redirected command runs — so the python3 invocation that's supposed to patch Hermes's `cli-config.yaml.template` never executes, the `|| ai_warn "patch failed"` fallback triggers, and the install moves on with the warning.

Visible failure in mac-mini's install log:

```
/Users/michaelbradley/dream-server/installers/macos/install-macos.sh: line 916: LOG_FILE: unbound variable
  [!!] Hermes template patch failed — hand-edit /Users/michaelbradley/dream-server/extensions/services/hermes/cli-config.yaml.template if prompts hang.
  [!!] Hermes template patch incomplete — Hermes may fail to reach llama-server. Hand-edit /Users/michaelbradley/dream-server/extensions/services/hermes/cli-config.yaml.template if prompts hang.
```

## Downstream impact

Hermes's `cli-config.yaml.template` ships with `base_url: "http://llama-server:8080/v1"`. The macOS overlay (`installers/macos/docker-compose.macos.yml`) sets `llama-server` to `replicas: 0` because llama-server runs natively on the host via Metal — there's no container by that name, and the bridge-network DNS lookup returns nothing usable. The install-time patch (lines 911-942) is what rewrites `base_url` to `http://host.docker.internal:8080/v1`. With this patch silently failing, the container keeps the broken URL and every Hermes CLI invocation (`hermes --yolo -z ...`) fails with `API call failed after 3 retries: Connection error`.

The fleet test caught this twice — the agent capability probes (`chat`, `search`, `files`, `code`) all fail on mac-mini and m5-mbp with that exact error string, while `skills` and `model_identity` (which don't call the LLM) pass. The cookie-based seed-echo path in `hermes-agentic.sh` happened to be a false-positive — it curls llama-server directly from the host, not through Hermes — so the broken state slipped past three full fleet runs.

## Fix

`s/\$LOG_FILE/\$DS_LOG_FILE/g` at all four sites in `installers/macos/install-macos.sh`:

- L395 — `pip install pyyaml` output
- L528 — `build-capability-profile.sh --env` stderr
- L919, L926 — `python3 patch-hermes-config.py` stderr (the actual symptom)

Other 9 references to `DS_LOG_FILE` are correct and unchanged.

## Test plan

- [x] On a current mac-mini install with the bug present: `grep "base_url" /Users/michaelbradley/dream-server/extensions/services/hermes/cli-config.yaml.template` returns `base_url: "http://llama-server:8080/v1"` (unpatched).
- [x] Running `python3 scripts/patch-hermes-config.py <template> --model X --base-url Y --context-length Z` manually on the host succeeds (`exit=0`). The script itself is fine; only the shell redirection was broken.
- [ ] Fleet test with this PR merged — mac-mini + m5-mbp capability probes (chat/search/files/code) should flip to ✓ once Hermes can actually reach llama-server.
- [ ] Regression coverage: harness will get a probe in `lib/hermes-agentic.sh` that actually exercises Hermes → LLM (separate harness change; in flight).
