### PR TITLE
fix(installer): only auto-enable OpenClaw when an actual install exists

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -237,9 +237,36 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [[ "$OPENCLAW_EXPLICIT" != "true" && -f "$INSTALL_DIR/extensions/services/openclaw/compose.yaml" ]]; then
-    ENABLE_OPENCLAW=true
-    log "Existing OpenClaw install detected; preserving it for this deprecation release"
+# OpenClaw deprecation back-compat: preserve OpenClaw on UPGRADES of installs
+# that previously had it enabled. The earlier heuristic — "does the compose
+# file exist on disk?" — was wrong: extensions/services/openclaw/compose.yaml
+# is part of the source tree, so every fresh install (including `--all` which
+# explicitly sets ENABLE_OPENCLAW=false) was being silently re-enabled. That
+# tacked ~20 minutes onto every install (a slow OpenClaw container blocking
+# the phase-12 health-link loop) and contradicted both the deprecation policy
+# AND what `--all` claims to do.
+#
+# Correct heuristic: there's an actual OpenClaw container on this host (running
+# or stopped from a prior install), OR there's persisted OpenClaw data on disk.
+# Either signal means the user already opted in once, so preserve their choice
+# through the deprecation window. A fresh install matches neither and leaves
+# ENABLE_OPENCLAW at its --no-openclaw / --all / default-false value.
+if [[ "$OPENCLAW_EXPLICIT" != "true" ]]; then
+    _existing_openclaw=false
+    if command -v docker >/dev/null 2>&1 \
+       && docker ps -a --filter "name=^/dream-openclaw$" --format '{{.Names}}' 2>/dev/null \
+            | grep -q '^dream-openclaw$'; then
+        _existing_openclaw=true
+    fi
+    if [[ -d "$INSTALL_DIR/data/openclaw" ]] \
+       && [[ -n "$(ls -A "$INSTALL_DIR/data/openclaw" 2>/dev/null)" ]]; then
+        _existing_openclaw=true
+    fi
+    if $_existing_openclaw; then
+        ENABLE_OPENCLAW=true
+        log "Existing OpenClaw install detected; preserving it for this deprecation release"
+    fi
+    unset _existing_openclaw
 fi
 
 # Detect distro + package manager (after arg parsing so --help still shows

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -229,9 +229,22 @@ _require_docker_cpu_budget() {
 # ── Resolve install directory ──
 INSTALL_DIR="${DS_INSTALL_DIR}"
 
-if ! $OPENCLAW_EXPLICIT && [[ -f "${INSTALL_DIR}/extensions/services/openclaw/compose.yaml" ]]; then
-    ENABLE_OPENCLAW=true
-    ai "Existing OpenClaw install detected; preserving it for this deprecation release"
+if ! $OPENCLAW_EXPLICIT; then
+    _existing_openclaw=false
+    if command -v docker >/dev/null 2>&1 \
+       && docker ps -a --filter "name=^/dream-openclaw$" --format '{{.Names}}' 2>/dev/null \
+            | grep -q '^dream-openclaw$'; then
+        _existing_openclaw=true
+    fi
+    if [[ -d "${INSTALL_DIR}/data/openclaw" ]] \
+       && [[ -n "$(ls -A "${INSTALL_DIR}/data/openclaw" 2>/dev/null)" ]]; then
+        _existing_openclaw=true
+    fi
+    if $_existing_openclaw; then
+        ENABLE_OPENCLAW=true
+        ai "Existing OpenClaw install detected; preserving it for this deprecation release"
+    fi
+    unset _existing_openclaw
 fi
 
 # Initialize log file

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -183,6 +183,20 @@ for svc in litellm searxng token-spy hermes hermes-proxy openclaw ape perplexica
     || { echo "[FAIL] Windows service plan missing '$svc'"; exit 1; }
 done
 
+echo "[contract] OpenClaw deprecation preserves actual installs only"
+for installer in install-core.sh installers/macos/install-macos.sh; do
+  grep -q 'name=^/dream-openclaw$' "$installer" \
+    || { echo "[FAIL] $installer must preserve OpenClaw when a prior container exists"; exit 1; }
+  grep -q 'data/openclaw' "$installer" \
+    || { echo "[FAIL] $installer must preserve OpenClaw when persisted data exists"; exit 1; }
+  installer_code="$(sed '/^[[:space:]]*#/d' "$installer")"
+  if grep -q 'extensions/services/openclaw/compose.yaml' <<<"$installer_code"; then
+    echo "[FAIL] $installer must not auto-enable OpenClaw just because the bundled compose file exists"
+    exit 1
+  fi
+  unset installer_code
+done
+
 echo "[contract] Token Spy dashboard ships offline chart assets"
 test -f extensions/services/token-spy/dashboard_charts.js || { echo "[FAIL] missing extensions/services/token-spy/dashboard_charts.js"; exit 1; }
 grep -q '/dashboard-assets/charts.js' extensions/services/token-spy/main.py || \

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -185,12 +185,12 @@ done
 
 echo "[contract] OpenClaw deprecation preserves actual installs only"
 for installer in install-core.sh installers/macos/install-macos.sh; do
-  grep -q 'name=^/dream-openclaw$' "$installer" \
+  grep -Fq 'name=^/dream-openclaw$' "$installer" \
     || { echo "[FAIL] $installer must preserve OpenClaw when a prior container exists"; exit 1; }
-  grep -q 'data/openclaw' "$installer" \
+  grep -Fq 'data/openclaw' "$installer" \
     || { echo "[FAIL] $installer must preserve OpenClaw when persisted data exists"; exit 1; }
   installer_code="$(sed '/^[[:space:]]*#/d' "$installer")"
-  if grep -q 'extensions/services/openclaw/compose.yaml' <<<"$installer_code"; then
+  if grep -Fq 'extensions/services/openclaw/compose.yaml' <<<"$installer_code"; then
     echo "[FAIL] $installer must not auto-enable OpenClaw just because the bundled compose file exists"
     exit 1
   fi


### PR DESCRIPTION
## Summary

The OpenClaw deprecation back-compat in `install-core.sh:240-243` used file existence of `extensions/services/openclaw/compose.yaml` as the "is this an upgrade with OpenClaw already enabled?" probe. That file ships with the source repo — it always exists. So every fresh install was being classified as an upgrade and silently re-enabling OpenClaw, overriding both:

- The `ENABLE_OPENCLAW=false` default declared at install-core.sh:112 (with comment "new installs no longer enable it by default")
- The explicit `ENABLE_OPENCLAW=false` that `--all` sets (install-core.sh:229)

## Real-world impact

Every fresh `--all --non-interactive` install ran the deprecated OpenClaw container. OpenClaw's first-start health check is slow — it takes 20+ minutes to come up healthy, and during that time it blocks the phase-12 "Linking <service>" loop (which polls services serially in `installers/phases/12-health.sh`). Three back-to-back fleet test runs on the dream-fleet-test rig all stalled on `Linking OpenClaw [1190s]` on Tower2 and Spark (both Linux NVIDIA) for the same 20-min window. The container eventually times out with the "OpenClaw delayed (may still be starting)" warning and the install continues, but the user-visible result is a 20-minute apparently-frozen spinner on every fresh install. On Strix Halo (AMD) the same stall occurred, just less visible because OpenClaw was waiting on Hermes which was waiting on llama-server which... etc.

The deprecation comment at install-core.sh:106-110 explicitly states "new installs no longer enable it by default. Users who explicitly pass `--openclaw` or upgrade an existing install with OpenClaw enabled keep it working until the removal release." That was the intent; this shim silently undid it.

## Fix

Replace the file-existence heuristic with two signals that actually distinguish an upgrade from a fresh install:

1. `docker ps -a --filter "name=^/dream-openclaw$"` returns a container (running OR stopped from a prior install — `docker rm` would be needed to clear it, which a normal upgrade does not do)
2. `$INSTALL_DIR/data/openclaw/` exists and is non-empty (persistent OpenClaw state on disk — survives `docker rm`)

Either matches → previous opt-in, preserve through the deprecation window. Neither matches → fresh install, leave `ENABLE_OPENCLAW` at whatever the flag parser set (`--all` = false, `--openclaw` = true, `--no-openclaw` = false, default = false).

## Test plan

- [x] On a fresh tree (no docker container, no `data/openclaw/`): `bash install-core.sh --all --dry-run` no longer logs "Existing OpenClaw install detected"; the eventual compose stack does not include `extensions/services/openclaw/compose.yaml`.
- [ ] On a host with a stopped `dream-openclaw` container from a prior install: re-running `bash install-core.sh --all` still preserves OpenClaw (back-compat path).
- [ ] On a host with `data/openclaw/` non-empty (e.g. config files persisted across a `docker rm` cycle): same preservation.
- [ ] `bash install-core.sh --openclaw` always enables OpenClaw regardless of fresh-vs-upgrade — the `OPENCLAW_EXPLICIT=true` early-out is unchanged.
- [ ] Fleet test on this branch: `Linking OpenClaw` stall on Tower2 + Spark + Strix Halo should disappear, knocking ~20 minutes off each install.

## Expected before/after

Before (typical fresh nvidia install):
```
... 33 minutes of healthy install ...
[1190s] Linking OpenClaw  (starting up)
[1190s] ⚠ OpenClaw delayed (may still be starting)
⚠ OpenClaw not responding yet. I will continue.
```

After (same install):
```
... no OpenClaw step ...
✓ Hermes Agent online
[install completes ~20 minutes faster]
```
