### PR TITLE
fix(dream-uninstall): reap orphan opencode + native llama-server PIDs

### DIFF
--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -127,6 +127,54 @@ for unit in opencode-web.service openclaw-session-cleanup.timer \
 done
 systemctl --user daemon-reload 2>/dev/null || true
 
+# Reap orphan host-managed processes that survive `systemctl --user stop`.
+# These were observed in the fleet test surviving multiple uninstall/reinstall
+# cycles, holding their ports and serving stale state to users on the next
+# install:
+#
+#   - `opencode web` and `opencode serve`: the systemd unit's ExecStart has
+#     changed across versions (Dream Server moved from the legacy `web`
+#     subcommand to the newer `serve` subcommand). `systemctl stop` reaps
+#     whatever process the CURRENT unit definition started, but a leftover
+#     process from a PRIOR unit's ExecStart keeps its port. The next install
+#     rewrites the unit, the new systemd-managed process fails to bind, and
+#     the user ends up hitting the 19-hour-old orphan with no DB wired up.
+#
+#   - Native macOS llama-server: the bootstrap-upgrade.sh and install-macos.sh
+#     spawn the Metal binary directly and track it via a PID file. If the file
+#     gets out of sync (PID reused, kill not flushed, prior install path
+#     changed), the kill misses and a stale llama-server keeps port 8080.
+#     `dream-uninstall` currently has no path that catches this.
+#
+# Two passes: SIGTERM first (let the process flush state), then SIGKILL for
+# anything still alive after 2s. Patterns are anchored to the install dir's
+# `.opencode/bin/opencode` and `bin/llama-server` so we don't touch unrelated
+# `opencode` or `llama-server` binaries the user may have elsewhere.
+log_info "Reaping any orphan host-managed processes..."
+_dream_uninstall_orphan_pids=()
+if command -v pgrep >/dev/null 2>&1; then
+    # opencode (both subcommands; bin path is per-user, not per-install)
+    while IFS= read -r _pid; do
+        [[ -n "$_pid" ]] && _dream_uninstall_orphan_pids+=("$_pid")
+    done < <(pgrep -f '\.opencode/bin/opencode (web|serve)' 2>/dev/null || true)
+    # macOS-native llama-server: only matches the dream-server-shipped binary
+    while IFS= read -r _pid; do
+        [[ -n "$_pid" ]] && _dream_uninstall_orphan_pids+=("$_pid")
+    done < <(pgrep -f "$HOME/dream-server/bin/llama-server" 2>/dev/null || true)
+fi
+if (( ${#_dream_uninstall_orphan_pids[@]} > 0 )); then
+    log_info "  Sending SIGTERM to ${#_dream_uninstall_orphan_pids[@]} orphan PID(s): ${_dream_uninstall_orphan_pids[*]}"
+    for _pid in "${_dream_uninstall_orphan_pids[@]}"; do kill "$_pid" 2>/dev/null || true; done
+    sleep 2
+    for _pid in "${_dream_uninstall_orphan_pids[@]}"; do
+        if kill -0 "$_pid" 2>/dev/null; then
+            log_info "  PID $_pid still alive, sending SIGKILL"
+            kill -9 "$_pid" 2>/dev/null || true
+        fi
+    done
+fi
+unset _dream_uninstall_orphan_pids _pid
+
 # Remove system-mode dream-host-agent unit (migrated from --user mode).
 # Idempotent — no-op if the unit was never installed (e.g. older user-mode installs).
 if systemctl is-enabled dream-host-agent.service >/dev/null 2>&1; then

--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -147,8 +147,8 @@ systemctl --user daemon-reload 2>/dev/null || true
 #     `dream-uninstall` currently has no path that catches this.
 #
 # Two passes: SIGTERM first (let the process flush state), then SIGKILL for
-# anything still alive after 2s. Patterns are anchored to the install dir's
-# `.opencode/bin/opencode` and `bin/llama-server` so we don't touch unrelated
+# anything still alive after 2s. Patterns are scoped to the per-user OpenCode
+# binary path and this install's `bin/llama-server` so we don't touch unrelated
 # `opencode` or `llama-server` binaries the user may have elsewhere.
 log_info "Reaping any orphan host-managed processes..."
 _dream_uninstall_orphan_pids=()
@@ -157,10 +157,10 @@ if command -v pgrep >/dev/null 2>&1; then
     while IFS= read -r _pid; do
         [[ -n "$_pid" ]] && _dream_uninstall_orphan_pids+=("$_pid")
     done < <(pgrep -f '\.opencode/bin/opencode (web|serve)' 2>/dev/null || true)
-    # macOS-native llama-server: only matches the dream-server-shipped binary
+    # macOS-native llama-server: only matches this install's shipped binary
     while IFS= read -r _pid; do
         [[ -n "$_pid" ]] && _dream_uninstall_orphan_pids+=("$_pid")
-    done < <(pgrep -f "$HOME/dream-server/bin/llama-server" 2>/dev/null || true)
+    done < <(pgrep -f "$INSTALL_DIR/bin/llama-server" 2>/dev/null || true)
 fi
 if (( ${#_dream_uninstall_orphan_pids[@]} > 0 )); then
     log_info "  Sending SIGTERM to ${#_dream_uninstall_orphan_pids[@]} orphan PID(s): ${_dream_uninstall_orphan_pids[*]}"


### PR DESCRIPTION
## Summary

`dream-uninstall.sh` stops the systemd user services it knows about (`opencode-web.service`, etc.) but doesn't reap host-managed processes those services *previously* spawned. When the unit's `ExecStart` changes across versions — e.g. Dream Server's migration from `opencode web` to `opencode serve` as the launcher — `systemctl --user stop opencode-web` ends whatever the **current** definition started, but a process from the **prior** definition keeps its port and serves stale state to the next install.

## Observed failure

Strix Halo, 2026-05-20:

```
$ lsof -i :3003
opencode  1807 michael  ...  *:3003 (LISTEN)
$ ps -p 1807 -o etime,cmd
ETIME      CMD
19:22:56  /home/michael/.opencode/bin/opencode web --port 3003 --hostname 0.0.0.0
$ cat ~/.config/systemd/user/opencode-web.service | grep ExecStart
ExecStart=/home/michael/.opencode/bin/opencode serve --port 3003 --hostname 127.0.0.1
```

PID 1807 had survived 5+ `dream-uninstall && curl ... | bash` cycles over 19 hours. Each install rewrote the unit (`serve`) but never killed the orphan (`web`). The systemd-managed `serve` couldn't bind 3003, kept exit-1 crash-looping (restart counter 5290+), and the user's browser was talking to the 19-hour-old `web` process, which on a newer OpenCode version reports "no connected db" because its session schema is stale.

Same class of bug seen previously on m5-mbp's host-managed `llama-server` (memory note from 2026-05-19) where `dream-uninstall` left an orphan Metal binary holding port 8080 across a re-install. One data point at the time; this is the second.

## Fix

After the `systemctl --user disable --now` loop, run a focused orphan-reaper:

- `pgrep -f '\.opencode/bin/opencode (web|serve)'` — anchored to the per-user OpenCode bin path so we don't touch unrelated `opencode` binaries
- `pgrep -f "$HOME/dream-server/bin/llama-server"` — covers the macOS native Metal binary path

Two-pass kill: SIGTERM, sleep 2s, SIGKILL any survivor.

## Test plan

- [x] Manual reproducer on Strix Halo: orphan PID 1807 survived 5+ uninstall cycles; killing manually let `systemctl --user start opencode-web` succeed in <1s.
- [ ] Fresh install on Strix Halo with this PR merged → run the install loop 2-3× and confirm no orphan `opencode web` accumulates.
- [ ] m5-mbp re-install — should reap any leftover native llama-server holding port 8080.
- [ ] Regression coverage in dream-fleet-test: a new fixture asserts no orphan `opencode (web|serve)` survives across a fleet-test install cycle. Will land in the harness alongside this PR.
