### PR TITLE
fix(installer): OpenCode uses LITELLM_KEY, not hardcoded "no-key"

### DIFF
--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -121,10 +121,27 @@ else
             DREAM_MODE=$(grep -m1 '^DREAM_MODE=' "$INSTALL_DIR/.env" | cut -d= -f2-)
             [[ -z "${LITELLM_KEY:-}" ]] && LITELLM_KEY=$(grep -m1 '^LITELLM_KEY=' "$INSTALL_DIR/.env" | cut -d= -f2-)
         fi
-        # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise
+        # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise.
+        #
+        # The Lemonade branch hits LiteLLM at :4000. LiteLLM is NOT auth-disabled
+        # on this install — its container env carries LITELLM_MASTER_KEY from
+        # .env (phase 06 wires it; the docker-compose for LiteLLM honors it),
+        # and any request without a matching Authorization header gets 401.
+        # OpenCode previously sent `apiKey: "no-key"` here (comment claimed
+        # auth was removed for local installs — never was), and every chat
+        # completion came back 401. The user-visible symptom is OpenCode
+        # showing "no connected db" because its provider probe to /v1/models
+        # fails auth before it can populate the model selector. Verified on
+        # strix-halo + spark + mac-mini + m5-mbp 2026-05-20:
+        #   $ curl -sSI http://127.0.0.1:4000/v1/models   → 401
+        #   $ curl -sSI -H "Authorization: Bearer $LITELLM_KEY" ... → 200
+        #
+        # Use LITELLM_KEY (read above at line 122) on the lemonade branch.
+        # The llama-server-direct branch keeps "no-key" — llama.cpp's OpenAI-
+        # compat server doesn't validate the key.
         if [[ "${DREAM_MODE:-local}" == "lemonade" ]]; then
             _opencode_url="http://127.0.0.1:4000/v1"
-            _opencode_key="no-key"  # LiteLLM auth removed for local-only installs
+            _opencode_key="${LITELLM_KEY:-no-key}"
         else
             _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1"
             _opencode_key="no-key"


### PR DESCRIPTION
## Summary

`installers/phases/07-devtools.sh:127` hardcodes `_opencode_key="no-key"` for the AMD/Lemonade install path with a comment claiming "LiteLLM auth removed for local-only installs." That's not true — phase 06 generates `LITELLM_MASTER_KEY=sk-dream-...` in `.env`, the LiteLLM container honors it, and any request without a matching `Authorization: Bearer` header returns 401. OpenCode sends `apiKey: "no-key"` and so its provider probe to `/v1/models` 401s before the model selector can populate. The UI shows "no connected db".

## Confirmed fleet-wide

Verified on every host that has LiteLLM:

```
strix-halo:  noauth=401  withauth=200
spark:       noauth=401  withauth=200
mac-mini:    noauth=401  withauth=200
m5-mbp:      (LiteLLM not running on this tier — non-applicable)
```

All four had `opencode.json` containing `"apiKey": "no-key"` and `LITELLM_KEY=sk-dream-...` in `.env`. The mismatch was 100% reproducible across fresh installs.

## Real-world impact

Users open OpenCode Web on Strix Halo / Spark / Mac and get a non-functional model selector with a "no connected db" banner. The OpenCode service itself is fine (sessions/, messages/, vcs/, mcp/ endpoints all return 200) — only the chat/completion provider probe fails.

## Fix

Read `LITELLM_KEY` from `.env` (already loaded at line 122 of this same block) and use it as `_opencode_key` on the lemonade branch:

```bash
if [[ "${DREAM_MODE:-local}" == "lemonade" ]]; then
    _opencode_url="http://127.0.0.1:4000/v1"
    _opencode_key="${LITELLM_KEY:-no-key}"
else
    _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1"
    _opencode_key="no-key"
fi
```

`LITELLM_KEY` matches `LITELLM_MASTER_KEY` inside the LiteLLM container (set together in phase 06). The `${LITELLM_KEY:-no-key}` fallback keeps the old behavior on installs that for some reason don't have the key — they'll still see "no connected db" but at least the variable won't be unbound under `set -u`.

The `llama-server`-direct branch is unchanged — llama.cpp's OpenAI-compat server doesn't validate the API key, "no-key" is fine there.

## Test plan

- [x] On strix-halo with this PR's logic manually backported: `curl -H "Authorization: Bearer $LITELLM_KEY" http://127.0.0.1:4000/v1/models` returns 200 and lists `*` wildcard; streaming chat returns the expected token.
- [ ] Fresh fleet test: `~/.config/opencode/opencode.json` on each lemonade-mode host should have `"apiKey": "sk-dream-..."` matching `LITELLM_KEY` in that host's `.env`.
- [ ] Open OpenCode Web in a browser; the "no connected db" banner should be gone and the model selector should populate.

## Regression coverage

Will land alongside this PR as `dream-fleet-test/regressions/opencode-litellm-key-1284.json`:

```
docker exec dream-litellm env | grep ^LITELLM_MASTER_KEY= | cut -d= -f2 \
  | xargs -I{} grep -qF '"apiKey": "{}"' $HOME/.config/opencode/opencode.json
```

Asserts the OpenCode config's apiKey matches LiteLLM's master key on every lemonade-mode host. Fires the moment the hardcoded "no-key" comes back, or LITELLM_KEY substitution gets dropped from the install.
