### PR TITLE
fix(bootstrap-upgrade): update Perplexica defaultChatModel after hot-swap

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -847,6 +847,77 @@ else
     log "Docker services not running. Config updated — full model will load on next start."
 fi
 
+# ── Phase 5c: Update Perplexica's defaultChatModel ──
+# Phase 12 of the installer configures Perplexica with whatever LLM_MODEL was
+# in scope at that time — which on bootstrap installs is the bootstrap model
+# name (e.g. qwen3.5-2b), NOT the full model. Without an update here,
+# Perplexica's settings.preferences.defaultChatModel stays "qwen3.5-2b"
+# forever, even after the hot-swap replaces the underlying GGUF. The UI
+# shows the wrong model name in the dropdown, and the chatModels list under
+# the OpenAI provider keeps the bootstrap entry instead of the full model.
+#
+# Requests still functionally route via LiteLLM's `*` wildcard or llama.cpp's
+# served-model-passthrough, so this hasn't been a hard failure — but it's a
+# cosmetic + future-proofing issue (a non-wildcard router would 404 the
+# stale model id). Mirror the install-time logic from
+# installers/phases/12-health.sh:194-238: update modelProviders + preferences
+# via Perplexica's `/api/config` PUT endpoint.
+PERPLEXICA_PORT=$(grep -E '^PERPLEXICA_PORT=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"\047\r')
+: "${PERPLEXICA_PORT:=3004}"
+_perplexica_url="http://127.0.0.1:${PERPLEXICA_PORT}"
+if curl -sf --max-time 3 "${_perplexica_url}/api/config" >/dev/null 2>&1; then
+    log "Updating Perplexica config to point at ${FULL_LLM_MODEL}..."
+    _py_cmd="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+    if [[ -n "$_py_cmd" ]]; then
+        # On Lemonade, LiteLLM exposes the model id as "extra.<GGUF_FILE>".
+        # On NVIDIA/Apple/CPU, llama.cpp serves under the bare model id —
+        # Phase 12 picks the friendly LLM_MODEL string, so do the same.
+        _px_model="$FULL_LLM_MODEL"
+        _gpu_backend_for_perplexica=$(grep -E '^GPU_BACKEND=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"\047\r' || echo "")
+        if [[ "$_gpu_backend_for_perplexica" == "amd" ]]; then
+            _px_model="extra.$FULL_GGUF_FILE"
+        fi
+        _litellm_key=$(grep -E '^LITELLM_KEY=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"\047\r' || echo "no-key")
+        : "${_litellm_key:=no-key}"
+        if curl -sf --max-time 3 "${_perplexica_url}/api/config" 2>/dev/null | \
+            PERPLEXICA_URL="$_perplexica_url" \
+            PX_MODEL="$_px_model" \
+            PX_KEY="$_litellm_key" \
+            "$_py_cmd" -c '
+import os, sys, json, urllib.request
+config = json.load(sys.stdin)["values"]
+providers = config.get("modelProviders", [])
+openai_prov = next((p for p in providers if p["type"] == "openai"), None)
+if not openai_prov:
+    sys.exit(0)  # Perplexica has no OpenAI provider configured; skip (non-fatal)
+url = os.environ["PERPLEXICA_URL"] + "/api/config"
+model = os.environ["PX_MODEL"]
+key = os.environ["PX_KEY"]
+def post(k, v):
+    data = json.dumps({"key": k, "value": v}).encode()
+    req = urllib.request.Request(url, data=data, headers={"Content-Type": "application/json"})
+    urllib.request.urlopen(req, timeout=5)
+openai_prov["chatModels"] = [{"key": model, "name": model}]
+# Preserve baseURL on the provider config but refresh the key
+prov_config = openai_prov.get("config") or {}
+prov_config["apiKey"] = key
+openai_prov["config"] = prov_config
+post("modelProviders", providers)
+prefs = config.get("preferences", {})
+prefs["defaultChatModel"] = model
+prefs["defaultChatProvider"] = openai_prov["id"]
+post("preferences", prefs)
+print("ok")
+' >/dev/null 2>&1; then
+            log "Perplexica defaultChatModel updated to ${_px_model}."
+        else
+            log "WARNING: Perplexica config update failed (non-fatal — defaultChatModel may still read the bootstrap value)"
+        fi
+    else
+        log "WARNING: python3 not found, skipping Perplexica config update"
+    fi
+fi
+
 # ── Phase 6: Restart host agent (if running) ──
 # The host agent may cache stale state — restart it so it picks up the new
 # model config and any updated endpoints.


### PR DESCRIPTION
## Summary

After a bootstrap → full-model hot-swap, Perplexica's `preferences.defaultChatModel` and the OpenAI provider's `chatModels` list stayed pinned to the bootstrap model name (e.g. `qwen3.5-2b`) forever. The full model loads, swaps in, and serves traffic — but Perplexica's settings still advertise the bootstrap name. Add a Phase 5c step to `bootstrap-upgrade.sh` that mirrors the install-time logic in `installers/phases/12-health.sh:194-238` against Perplexica's `/api/config` PUT endpoint, updating both fields to the full model.

## Observed state (fleet-wide)

After a clean fresh install on commit `03ad527`:

```
strix-halo  defaultChatModel: qwen3.5-2b   (loaded: extra.Qwen3.6-35B-A3B-UD-Q4_K_M.gguf)
spark       defaultChatModel: qwen3.5-2b   (loaded: Qwen3.6-35B-A3B-UD-Q4_K_M.gguf)
mac-mini    defaultChatModel: qwen3.5-2b   (loaded: Qwen3.5-9B-Q4_K_M.gguf)
m5-mbp      defaultChatModel: qwen3.5-2b   (loaded: Qwen3-30B-A3B-Q4_K_M.gguf)
tower2      defaultChatModel: qwen3.5-2b   (loaded: qwen3-coder-next-Q4_K_M.gguf)
```

All five hosts. The request flow still works because both LiteLLM (`*` wildcard catch-all) and llama.cpp's OpenAI-compat server (ignores the requested model id, serves whatever's loaded) treat the stale name as a passthrough — but the Perplexica UI shows the wrong model in its selector, and any future router that doesn't have a wildcard would 404 the request.

## Fix

In `scripts/bootstrap-upgrade.sh`, after Phase 5 finishes (regardless of Docker vs macOS-native branch), add a Phase 5c step that:

1. Checks if Perplexica's `/api/config` is reachable
2. If so, runs a small inline Python heredoc that fetches the current config, rewrites:
   - `modelProviders[type=openai].chatModels` to `[{key: <full_model>, name: <full_model>}]`
   - `modelProviders[type=openai].config.apiKey` to the current `LITELLM_KEY` (in case it changed)
   - `preferences.defaultChatModel` to `<full_model>`
   - `preferences.defaultChatProvider` to the openai provider id
3. Posts each back via PUT
4. Logs success/warning

Reuses the install-time pattern from `12-health.sh:212-235`. Non-fatal if Perplexica isn't reachable (e.g. user disabled it).

Model id matches the same Lemonade `extra.` prefix rule the Hermes-update branch already uses (Phase 5 line ~540).

## Test plan

- [x] On a host with Perplexica running and the bootstrap-upgrade.sh patch applied, running the script as a one-shot updates `/api/config` to point at the full model (validated by re-fetching `/api/config` and grepping the defaultChatModel field).
- [ ] Fleet test on a fresh install with this PR merged → every host's Perplexica should have `defaultChatModel` matching `.env`'s `LLM_MODEL` (the full model name).

## Regression coverage

Adds `dream-fleet-test/regressions/perplexica-default-model-1286.json`:

```bash
EXPECTED=$(grep -m1 ^LLM_MODEL= $HOME/dream-server/.env | cut -d= -f2-)
ACTUAL=$(curl -sS -m 3 http://127.0.0.1:3004/api/config | jq -r .values.preferences.defaultChatModel)
[[ "$ACTUAL" == "$EXPECTED" ]]
```

Catches a future hot-swap that drops the Perplexica update (or the install-time path getting out of sync with the post-swap path again).
