### PR TITLE
[codex] test: emit golden path simulation evidence

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -112,6 +112,7 @@ jobs:
           path: |
             dream-server/artifacts/installer-sim/summary.json
             dream-server/artifacts/installer-sim/SUMMARY.md
+            dream-server/artifacts/installer-sim/golden-paths.json
             dream-server/artifacts/installer-sim/linux-dryrun.log
             dream-server/artifacts/installer-sim/macos-installer.log
             dream-server/artifacts/installer-sim/windows-preflight-sim.json

--- a/dream-server/scripts/simulate-installers.sh
+++ b/dream-server/scripts/simulate-installers.sh
@@ -14,6 +14,8 @@ MACOS_DOCTOR_JSON="${OUT_DIR}/macos-doctor.json"
 DOCTOR_JSON="${OUT_DIR}/doctor.json"
 SUMMARY_JSON="${OUT_DIR}/summary.json"
 SUMMARY_MD="${OUT_DIR}/SUMMARY.md"
+GOLDEN_CONTRACT_JSON="${ROOT_DIR}/config/golden-paths.json"
+GOLDEN_EVIDENCE_JSON="${OUT_DIR}/golden-paths.json"
 
 FAKEBIN="$(mktemp -d)"
 trap 'rm -rf "$FAKEBIN"' EXIT
@@ -65,7 +67,7 @@ elif command -v python >/dev/null 2>&1; then
   PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$SUMMARY_JSON" "$SUMMARY_MD" "$LINUX_LOG" "$MACOS_LOG" "$WINDOWS_SIM_JSON" "$MACOS_PREFLIGHT_JSON" "$MACOS_DOCTOR_JSON" "$DOCTOR_JSON" "$LINUX_SUMMARY_JSON" "$LINUX_EXIT" "$MACOS_EXIT" "$DOCTOR_EXIT" <<'PY'
+"$PYTHON_CMD" - "$SUMMARY_JSON" "$SUMMARY_MD" "$GOLDEN_EVIDENCE_JSON" "$GOLDEN_CONTRACT_JSON" "$LINUX_LOG" "$MACOS_LOG" "$WINDOWS_SIM_JSON" "$MACOS_PREFLIGHT_JSON" "$MACOS_DOCTOR_JSON" "$DOCTOR_JSON" "$LINUX_SUMMARY_JSON" "$LINUX_EXIT" "$MACOS_EXIT" "$DOCTOR_EXIT" <<'PY'
 import json
 import pathlib
 import re
@@ -75,6 +77,8 @@ from datetime import datetime, timezone
 (
     summary_json_path,
     summary_md_path,
+    golden_evidence_json_path,
+    golden_contract_json_path,
     linux_log,
     macos_log,
     windows_sim_json,
@@ -86,6 +90,8 @@ from datetime import datetime, timezone
     macos_exit,
     doctor_exit,
 ) = sys.argv[1:]
+
+root_dir = pathlib.Path.cwd()
 
 def load_json(path):
     p = pathlib.Path(path)
@@ -133,7 +139,99 @@ summary = {
     },
 }
 
+def run_status(run_name, run):
+    if run_name == "linux_dryrun":
+        signals = run.get("signals") or {}
+        return {
+            "ok": run.get("exit_code") == 0 and all(signals.values()),
+            "exit_code": run.get("exit_code"),
+            "required_signals": signals,
+        }
+    if run_name == "macos_installer_mvp":
+        summary_block = ((run.get("preflight") or {}).get("summary") or {})
+        blockers = summary_block.get("blockers")
+        return {
+            "ok": run.get("exit_code") == 0 and (blockers in (0, None)),
+            "exit_code": run.get("exit_code"),
+            "blockers": blockers,
+            "warnings": summary_block.get("warnings"),
+        }
+    if run_name == "windows_scenario_preflight":
+        summary_block = ((run.get("report") or {}).get("summary") or {})
+        blockers = summary_block.get("blockers")
+        return {
+            "ok": blockers == 0,
+            "blockers": blockers,
+            "warnings": summary_block.get("warnings"),
+        }
+    return {"ok": run is not None}
+
+def build_golden_evidence():
+    contract = load_json(golden_contract_json_path) or {"scenarios": []}
+    evidence = {
+        "version": "1",
+        "generated_at": summary["generated_at"],
+        "contract": golden_contract_json_path,
+        "scenarios": [],
+    }
+
+    runs = summary.get("runs") or {}
+    for scenario in contract.get("scenarios", []):
+        installer = scenario.get("installer") or {}
+        expected = scenario.get("expected") or {}
+        run_name = installer.get("ci_simulation")
+        run = runs.get(run_name) if run_name else None
+        compose_files = expected.get("compose_files") or []
+        generated_configs = expected.get("generated_configs") or []
+        health_checks = expected.get("health_checks") or []
+        missing_compose = [
+            path for path in compose_files
+            if not (root_dir / path).exists()
+        ]
+
+        status = run_status(run_name, run or {})
+        scenario_ok = bool(status.get("ok")) and not missing_compose
+        evidence["scenarios"].append({
+            "id": scenario.get("id"),
+            "label": scenario.get("label"),
+            "status": "pass" if scenario_ok else "fail",
+            "simulation_run": run_name,
+            "simulation_status": status,
+            "expected": {
+                "dream_mode": expected.get("dream_mode"),
+                "llm_backend": expected.get("llm_backend"),
+                "llm_host_port": expected.get("llm_host_port"),
+                "llm_container_port": expected.get("llm_container_port"),
+                "model_route": expected.get("model_route") or {},
+                "compose_files": compose_files,
+                "generated_config_surfaces": [
+                    item.get("surface") for item in generated_configs
+                    if isinstance(item, dict)
+                ],
+                "health_check_services": [
+                    item.get("service") for item in health_checks
+                    if isinstance(item, dict)
+                ],
+            },
+            "checks": {
+                "compose_files_exist": not missing_compose,
+                "missing_compose_files": missing_compose,
+                "generated_config_count": len(generated_configs),
+                "health_check_count": len(health_checks),
+            },
+        })
+    return evidence
+
+golden_evidence = build_golden_evidence()
+summary["golden_paths"] = {
+    "contract": golden_contract_json_path,
+    "evidence": golden_evidence_json_path,
+    "scenario_count": len(golden_evidence.get("scenarios", [])),
+    "pass_count": sum(1 for item in golden_evidence.get("scenarios", []) if item.get("status") == "pass"),
+}
+
 pathlib.Path(summary_json_path).write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+pathlib.Path(golden_evidence_json_path).write_text(json.dumps(golden_evidence, indent=2) + "\n", encoding="utf-8")
 
 lines = []
 lines.append("# Installer Simulation Summary")
@@ -172,6 +270,14 @@ lines.append("## Doctor Snapshot")
 lines.append(f"- Exit code: {doctor_exit}")
 lines.append(f"- Runtime ready: {dsum.get('runtime_ready', 'n/a')}")
 lines.append(f"- Report: `{doctor_json}`")
+lines.append("")
+lines.append("## Golden Paths")
+for item in golden_evidence.get("scenarios", []):
+    status = item.get("status", "unknown")
+    label = item.get("label") or item.get("id")
+    run_name = item.get("simulation_run") or "n/a"
+    lines.append(f"- {label}: {status} via `{run_name}`")
+lines.append(f"- Evidence JSON: `{golden_evidence_json_path}`")
 
 pathlib.Path(summary_md_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
 PY
@@ -183,3 +289,4 @@ fi
 echo "Installer simulation complete."
 echo "  JSON: $SUMMARY_JSON"
 echo "  MD:   $SUMMARY_MD"
+echo "  Golden paths: $GOLDEN_EVIDENCE_JSON"

--- a/dream-server/scripts/validate-sim-summary.py
+++ b/dream-server/scripts/validate-sim-summary.py
@@ -248,6 +248,25 @@ def validate_doctor_snapshot(v: Validator, doctor: Mapping[str, Any], path: str)
             _require_type(v, summary.get("runtime_ready"), f"{path}.report.summary.runtime_ready", "bool")
 
 
+def validate_golden_paths(v: Validator, golden: Mapping[str, Any], path: str) -> None:
+    contract = _require_key(v, golden, path, "contract")
+    _require_path_like(v, contract, f"{path}.contract")
+
+    evidence = _require_key(v, golden, path, "evidence")
+    _require_path_like(v, evidence, f"{path}.evidence")
+
+    scenario_count = _require_key(v, golden, path, "scenario_count")
+    _require_type(v, scenario_count, f"{path}.scenario_count", "int")
+
+    pass_count = _require_key(v, golden, path, "pass_count")
+    _require_type(v, pass_count, f"{path}.pass_count", "int")
+
+    if _is_int(scenario_count) and scenario_count <= 0:
+        v.add(f"{path}.scenario_count", "must be greater than zero")
+    if _is_int(pass_count) and _is_int(scenario_count) and pass_count > scenario_count:
+        v.add(f"{path}.pass_count", "must be less than or equal to scenario_count")
+
+
 def validate_summary(v: Validator, data: Mapping[str, Any]) -> None:
     # version
     version = data.get("version")
@@ -298,9 +317,15 @@ def validate_summary(v: Validator, data: Mapping[str, Any]) -> None:
     if isinstance(doc, Mapping):
         validate_doctor_snapshot(v, doc, "$.runs.doctor_snapshot")
 
+    if "golden_paths" in data:
+        _require_type(v, data.get("golden_paths"), "$.golden_paths", "object")
+        golden = data.get("golden_paths")
+        if isinstance(golden, Mapping):
+            validate_golden_paths(v, golden, "$.golden_paths")
+
     # Strict mode: warn on unknown top-level keys
     if v.strict:
-        allowed_top = {"version", "generated_at", "runs"}
+        allowed_top = {"version", "generated_at", "runs", "golden_paths"}
         for k in data.keys():
             if k not in allowed_top:
                 v.add("$", f"unknown top-level key '{k}' (strict mode)")

--- a/dream-server/tests/test-validate-sim-summary.sh
+++ b/dream-server/tests/test-validate-sim-summary.sh
@@ -76,6 +76,12 @@ cat > "$TMP_DIR/valid.json" <<'EOF'
 {
   "version": "1",
   "generated_at": "2026-03-15T12:34:56Z",
+  "golden_paths": {
+    "contract": "config/golden-paths.json",
+    "evidence": "artifacts/installer-sim/golden-paths.json",
+    "scenario_count": 4,
+    "pass_count": 4
+  },
   "runs": {
     "linux_dryrun": {
       "exit_code": 0,
@@ -129,6 +135,32 @@ if echo "$out" | grep -q "\[PASS\]"; then
     pass "valid summary prints PASS marker"
 else
     fail "valid summary should print PASS marker"
+fi
+
+python3 - <<'PY' "$TMP_DIR/valid.json" "$TMP_DIR/bad-golden-count.json"
+import json
+import sys
+src, dest = sys.argv[1], sys.argv[2]
+with open(src, encoding="utf-8") as f:
+    data = json.load(f)
+data["golden_paths"]["pass_count"] = 5
+with open(dest, "w", encoding="utf-8") as f:
+    json.dump(data, f)
+PY
+
+set +e
+out=$(python3 "$ROOT_DIR/scripts/validate-sim-summary.py" "$TMP_DIR/bad-golden-count.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]]; then
+    pass "invalid golden path pass count exits 2"
+else
+    fail "invalid golden path pass count should exit 2, got $r"
+fi
+if echo "$out" | grep -q "pass_count"; then
+    pass "golden path validation error mentions pass_count"
+else
+    fail "golden path validation error should mention pass_count"
 fi
 
 python3 - <<'PY' "$TMP_DIR/valid.json" "$TMP_DIR/missing-signal.json"


### PR DESCRIPTION
## Summary
- Teach installer simulation to emit golden-path evidence.
- Validate optional golden-path evidence in simulation summaries.
- Upload the new evidence artifact from Linux CI.

## Validation
- `python -m py_compile dream-server\scripts\validate-sim-summary.py dream-server\scripts\validate-golden-paths.py`
- `python dream-server\scripts\validate-sim-summary.py <temp-summary> --strict`
- `git diff --check`

## Stack
Stacked on `codex/golden-path-definitions`.