### PR TITLE
[codex] config: add shared runtime config renderer

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Generated Config Contract Tests
         run: bash tests/test-generated-config-contracts.sh
 
+      - name: Runtime Config Renderer Tests
+        run: python3 tests/test-render-runtime-configs.py
+
       - name: CPU-Only Path Tests
         run: bash tests/test-cpu-only-path.sh
 

--- a/dream-server/scripts/render-runtime-configs.py
+++ b/dream-server/scripts/render-runtime-configs.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Render Dream Server runtime config surfaces deterministically.
+
+The first purpose of this script is read-only comparison: installers and
+runtime mutators can ask what config should look like without writing files.
+Follow-up wiring can then replace ad-hoc heredocs one surface at a time.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MODEL = "qwen3.5-9b"
+DEFAULT_GGUF = "Qwen3.5-9B-Q4_K_M.gguf"
+DEFAULT_CONTEXT = 131072
+DEFAULT_LITELLM_KEY = "sk-lemonade"
+NO_KEY = "no-key"
+
+
+@dataclass(frozen=True)
+class RenderInputs:
+    model: str
+    gguf_file: str
+    gpu_backend: str
+    dream_mode: str
+    llm_base_url: str
+    litellm_key: str
+    opencode_port: int
+    context_length: int
+
+
+@dataclass(frozen=True)
+class RenderedFile:
+    surface: str
+    path: str
+    content: str
+
+
+def ensure_trailing_newline(text: str) -> str:
+    return text if text.endswith("\n") else f"{text}\n"
+
+
+def lemonade_model_id(inputs: RenderInputs) -> str:
+    return f"extra.{inputs.gguf_file}"
+
+
+def hermes_model_id(inputs: RenderInputs) -> str:
+    if inputs.dream_mode == "lemonade" or inputs.gpu_backend == "amd":
+        return lemonade_model_id(inputs)
+    return inputs.gguf_file or inputs.model
+
+
+def opencode_key(inputs: RenderInputs) -> str:
+    return inputs.litellm_key if inputs.dream_mode == "lemonade" else NO_KEY
+
+
+def render_litellm_lemonade(inputs: RenderInputs) -> RenderedFile:
+    model = lemonade_model_id(inputs)
+    content = f"""model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/{model}
+      api_base: http://llama-server:8080/api/v1
+      api_key: {inputs.litellm_key}
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+  - model_name: "*"
+    litellm_params:
+      model: openai/{model}
+      api_base: http://llama-server:8080/api/v1
+      api_key: {inputs.litellm_key}
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 120
+  stream_timeout: 60
+"""
+    return RenderedFile("litellm-lemonade", "config/litellm/lemonade.yaml", content)
+
+
+def render_hermes(inputs: RenderInputs) -> RenderedFile:
+    model = hermes_model_id(inputs)
+    content = f"""model:
+  default: "{model}"
+  provider: "custom"
+  base_url: "{inputs.llm_base_url}"
+  context_length: {inputs.context_length}
+
+auxiliary:
+  compression:
+    context_length: {inputs.context_length}
+
+compression:
+  threshold: 0.50
+  target_ratio: 0.20
+"""
+    return RenderedFile("hermes", "data/hermes/config.yaml", content)
+
+
+def render_perplexica(inputs: RenderInputs) -> RenderedFile:
+    model = lemonade_model_id(inputs) if inputs.dream_mode == "lemonade" else (inputs.gguf_file or inputs.model)
+    payload = {
+        "modelProviders": {
+            "openai": {
+                "name": "Dream Server",
+                "baseUrl": inputs.llm_base_url,
+                "apiKey": opencode_key(inputs),
+                "chatModels": [{"name": model, "displayName": model}],
+            }
+        },
+        "preferences": {
+            "defaultChatProvider": "openai",
+            "defaultChatModel": model,
+        },
+    }
+    return RenderedFile(
+        "perplexica",
+        "data/perplexica/settings.seed.json",
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def render_opencode(inputs: RenderInputs) -> RenderedFile:
+    payload = {
+        "provider": "openai-compatible",
+        "baseURL": inputs.llm_base_url,
+        "apiKey": opencode_key(inputs),
+        "model": lemonade_model_id(inputs) if inputs.dream_mode == "lemonade" else inputs.model,
+        "port": inputs.opencode_port,
+    }
+    return RenderedFile(
+        "opencode",
+        ".opencode/auth.json",
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+    )
+
+
+def render_env(inputs: RenderInputs) -> RenderedFile:
+    lines = [
+        f"DREAM_MODE={inputs.dream_mode}",
+        f"LLM_BACKEND={'lemonade' if inputs.dream_mode == 'lemonade' else 'llama-server'}",
+        f"LLM_MODEL={inputs.model}",
+        f"GGUF_FILE={inputs.gguf_file}",
+        f"GPU_BACKEND={inputs.gpu_backend}",
+        f"LLM_API_URL={inputs.llm_base_url}",
+        f"CTX_SIZE={inputs.context_length}",
+        f"MAX_CONTEXT={inputs.context_length}",
+    ]
+    return RenderedFile("env", ".env.generated", "\n".join(lines) + "\n")
+
+
+RENDERERS: dict[str, Callable[[RenderInputs], RenderedFile]] = {
+    "env": render_env,
+    "opencode": render_opencode,
+    "litellm-lemonade": render_litellm_lemonade,
+    "perplexica": render_perplexica,
+    "hermes": render_hermes,
+}
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--surface", choices=["all", *sorted(RENDERERS)], default="all")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--gguf-file", default=DEFAULT_GGUF)
+    parser.add_argument("--gpu-backend", choices=["amd", "apple", "cpu", "nvidia"], default="nvidia")
+    parser.add_argument("--dream-mode", choices=["local", "cloud", "hybrid", "lemonade"], default="local")
+    parser.add_argument("--llm-base-url", default="http://llama-server:8080/v1")
+    parser.add_argument("--litellm-key", default=DEFAULT_LITELLM_KEY)
+    parser.add_argument("--opencode-port", type=int, default=3003)
+    parser.add_argument("--context-length", type=int, default=DEFAULT_CONTEXT)
+    parser.add_argument("--format", choices=["json", "paths"], default="json")
+    return parser.parse_args(argv)
+
+
+def select_surfaces(surface: str) -> list[str]:
+    if surface == "all":
+        return ["env", "opencode", "litellm-lemonade", "perplexica", "hermes"]
+    return [surface]
+
+
+def render(args: argparse.Namespace) -> dict[str, object]:
+    inputs = RenderInputs(
+        model=args.model,
+        gguf_file=args.gguf_file,
+        gpu_backend=args.gpu_backend,
+        dream_mode=args.dream_mode,
+        llm_base_url=args.llm_base_url,
+        litellm_key=args.litellm_key,
+        opencode_port=args.opencode_port,
+        context_length=args.context_length,
+    )
+    files = [RENDERERS[name](inputs) for name in select_surfaces(args.surface)]
+    return {
+        "version": "1",
+        "mode": "dry-run",
+        "inputs": asdict(inputs),
+        "files": [asdict(RenderedFile(item.surface, item.path, ensure_trailing_newline(item.content))) for item in files],
+    }
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    payload = render(args)
+    if args.format == "paths":
+        for item in payload["files"]:
+            print(item["path"])
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/dream-server/tests/test-render-runtime-configs.py
+++ b/dream-server/tests/test-render-runtime-configs.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Tests for scripts/render-runtime-configs.py."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "render-runtime-configs.py"
+
+
+def run_renderer(*args: str) -> dict[str, object]:
+    proc = subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def file_by_surface(payload: dict[str, object], surface: str) -> dict[str, str]:
+    for item in payload["files"]:
+        if item["surface"] == surface:
+            return item
+    raise AssertionError(f"missing surface {surface}")
+
+
+def test_all_surfaces_render() -> None:
+    payload = run_renderer("--surface", "all")
+    surfaces = {item["surface"] for item in payload["files"]}
+    assert surfaces == {"env", "opencode", "litellm-lemonade", "perplexica", "hermes"}
+    assert payload["mode"] == "dry-run"
+
+
+def test_lemonade_disables_thinking_and_uses_extra_alias() -> None:
+    payload = run_renderer(
+        "--surface",
+        "litellm-lemonade",
+        "--dream-mode",
+        "lemonade",
+        "--gpu-backend",
+        "amd",
+        "--gguf-file",
+        "Model.gguf",
+        "--litellm-key",
+        "sk-test",
+    )
+    content = file_by_surface(payload, "litellm-lemonade")["content"]
+    assert "model: openai/extra.Model.gguf" in content
+    assert "api_key: sk-test" in content
+    assert "enable_thinking: false" in content
+
+
+def test_hermes_uses_lemonade_model_id_for_amd() -> None:
+    payload = run_renderer(
+        "--surface",
+        "hermes",
+        "--dream-mode",
+        "lemonade",
+        "--gpu-backend",
+        "amd",
+        "--gguf-file",
+        "Amd.gguf",
+        "--llm-base-url",
+        "http://litellm:4000/v1",
+        "--context-length",
+        "65536",
+    )
+    content = file_by_surface(payload, "hermes")["content"]
+    assert 'default: "extra.Amd.gguf"' in content
+    assert 'base_url: "http://litellm:4000/v1"' in content
+    assert "context_length: 65536" in content
+
+
+def test_perplexica_default_model_matches_route() -> None:
+    payload = run_renderer(
+        "--surface",
+        "perplexica",
+        "--dream-mode",
+        "lemonade",
+        "--gpu-backend",
+        "amd",
+        "--gguf-file",
+        "Research.gguf",
+    )
+    content = json.loads(file_by_surface(payload, "perplexica")["content"])
+    assert content["preferences"]["defaultChatModel"] == "extra.Research.gguf"
+    assert content["modelProviders"]["openai"]["chatModels"][0]["name"] == "extra.Research.gguf"
+
+
+def main() -> int:
+    tests = [
+        test_all_surfaces_render,
+        test_lemonade_disables_thinking_and_uses_extra_alias,
+        test_hermes_uses_lemonade_model_id_for_amd,
+        test_perplexica_default_model_matches_route,
+    ]
+    for test in tests:
+        test()
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a deterministic runtime config renderer for env, OpenCode, LiteLLM Lemonade, Perplexica, and Hermes surfaces.
- Add renderer tests and Linux CI coverage.
- Keep this PR dry-run only so the renderer can be reviewed before installer wiring changes.

## Validation
- `python dream-server\tests\test-render-runtime-configs.py`
- `python -m py_compile dream-server\scripts\render-runtime-configs.py dream-server\tests\test-render-runtime-configs.py`
- `python dream-server\scripts\render-runtime-configs.py --surface litellm-lemonade --dream-mode lemonade --gpu-backend amd --gguf-file Model.gguf --format paths`
- `git diff --check`

## Stack
Stacked on `codex/generated-config-contracts`.