### PR TITLE
[codex] config: use renderer for Lemonade runtime config

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -93,6 +93,9 @@ jobs:
       - name: Runtime Config Renderer Tests
         run: python3 tests/test-render-runtime-configs.py
 
+      - name: Runtime Config Wiring Tests
+        run: python3 tests/test-runtime-config-wiring.py
+
       - name: CPU-Only Path Tests
         run: bash tests/test-cpu-only-path.sh
 

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -3386,40 +3386,7 @@ class AgentHandler(BaseHTTPRequestHandler):
             # Regenerate LiteLLM lemonade config so it routes to the new model.
             # Only written on AMD installs where lemonade.yaml exists.
             if lemonade_yaml.exists():
-                # Read from .env (already loaded as env_pre above). The host-agent
-                # systemd unit does not source .env as an EnvironmentFile, so
-                # os.environ is unreliable for installer-written values like the
-                # rotated LITELLM_LEMONADE_API_KEY — falling back to the legacy
-                # static "sk-lemonade" would silently revert key rotation.
-                lemonade_api_key = env_pre.get("LITELLM_LEMONADE_API_KEY", "sk-lemonade")
-                lemonade_yaml.write_text(
-                    f"model_list:\n"
-                    f"  - model_name: default\n"
-                    f"    litellm_params:\n"
-                    f"      model: openai/extra.{gguf_file}\n"
-                    f"      api_base: http://llama-server:8080/api/v1\n"
-                    f"      api_key: {lemonade_api_key}\n"
-                    f"      extra_body:\n"
-                    f"        chat_template_kwargs:\n"
-                    f"          enable_thinking: false\n"
-                    f"\n"
-                    f"  - model_name: \"*\"\n"
-                    f"    litellm_params:\n"
-                    f"      model: openai/extra.{gguf_file}\n"
-                    f"      api_base: http://llama-server:8080/api/v1\n"
-                    f"      api_key: {lemonade_api_key}\n"
-                    f"      extra_body:\n"
-                    f"        chat_template_kwargs:\n"
-                    f"          enable_thinking: false\n"
-                    f"\n"
-                    f"litellm_settings:\n"
-                    f"  drop_params: true\n"
-                    f"  set_verbose: false\n"
-                    f"  request_timeout: 120\n"
-                    f"  stream_timeout: 60\n",
-                    encoding="utf-8",
-                )
-                logger.info("Regenerated lemonade.yaml for model: extra.%s", gguf_file)
+                _write_lemonade_config(INSTALL_DIR, gguf_file)
 
             hermes_model_name = f"extra.{gguf_file}" if gpu_backend == "amd" else gguf_file
             try:
@@ -3721,6 +3688,50 @@ def _send_lemonade_warmup(host: str, port: str, gguf_file: str, attempt: int) ->
     return False
 
 
+def _render_runtime_config(
+    install_dir: Path,
+    surface: str,
+    *,
+    gguf_file: str,
+    lemonade_api_key: str,
+    dream_mode: str,
+    gpu_backend: str,
+) -> bool:
+    renderer = install_dir / "scripts" / "render-runtime-configs.py"
+    if not renderer.exists():
+        return False
+    cmd = [
+        sys.executable,
+        str(renderer),
+        "--surface",
+        surface,
+        "--dream-mode",
+        dream_mode,
+        "--gpu-backend",
+        gpu_backend,
+        "--gguf-file",
+        gguf_file,
+        "--litellm-key",
+        lemonade_api_key,
+        "--output-root",
+        str(install_dir),
+        "--write",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("Runtime config renderer failed for %s: %s", surface, exc)
+        return False
+    if result.returncode != 0:
+        logger.warning(
+            "Runtime config renderer failed for %s: %s",
+            surface,
+            (result.stderr or result.stdout).strip(),
+        )
+        return False
+    return True
+
+
 def _write_lemonade_config(install_dir: Path, gguf_file: str):
     """Regenerate lemonade.yaml with the correct model ID for LiteLLM.
 
@@ -3733,7 +3744,21 @@ def _write_lemonade_config(install_dir: Path, gguf_file: str):
     # unit does not source .env as an EnvironmentFile, so os.environ is
     # unreliable for installer-written values; falling back to the legacy
     # static "sk-lemonade" would silently revert key rotation.
-    lemonade_api_key = load_env(install_dir / ".env").get("LITELLM_LEMONADE_API_KEY", "sk-lemonade")
+    env = load_env(install_dir / ".env")
+    lemonade_api_key = env.get("LITELLM_LEMONADE_API_KEY", "sk-lemonade")
+    dream_mode = env.get("DREAM_MODE", "lemonade")
+    gpu_backend = env.get("GPU_BACKEND", "amd")
+    if _render_runtime_config(
+        install_dir,
+        "litellm-lemonade",
+        gguf_file=gguf_file,
+        lemonade_api_key=lemonade_api_key,
+        dream_mode=dream_mode,
+        gpu_backend=gpu_backend,
+    ):
+        logger.info("Wrote lemonade.yaml via runtime renderer for model: extra.%s", gguf_file)
+        return
+
     content = (
         "model_list:\n"
         "  - model_name: \"*\"\n"

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -659,7 +659,31 @@ ENV_EOF
         # lemonade config regardless of which model the install resolves to.
         # bootstrap-upgrade.sh mirrors this when it regenerates the file
         # after a hot-swap.
-        cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
+        _renderer_ok=false
+        _renderer_py="${DREAM_PYTHON_CMD:-}"
+        if [[ -z "$_renderer_py" && -f "$SCRIPT_DIR/lib/python-cmd.sh" ]]; then
+            . "$SCRIPT_DIR/lib/python-cmd.sh"
+            _renderer_py="$(ds_detect_python_cmd 2>/dev/null || true)"
+        fi
+        if [[ -z "$_renderer_py" ]]; then
+            _renderer_py="python3"
+        fi
+        if [[ -f "$SCRIPT_DIR/scripts/render-runtime-configs.py" ]] && command -v "$_renderer_py" >/dev/null 2>&1; then
+            if "$_renderer_py" "$SCRIPT_DIR/scripts/render-runtime-configs.py" \
+                --surface litellm-lemonade \
+                --dream-mode lemonade \
+                --gpu-backend amd \
+                --gguf-file "$_active_gguf" \
+                --litellm-key "$LITELLM_LEMONADE_API_KEY" \
+                --output-root "$INSTALL_DIR" \
+                --write >> "$LOG_FILE" 2>&1; then
+                _renderer_ok=true
+            else
+                warn "Runtime config renderer failed for Lemonade; falling back to inline writer"
+            fi
+        fi
+        if [[ "$_renderer_ok" != "true" ]]; then
+            cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
 model_list:
   - model_name: default
     litellm_params:
@@ -685,7 +709,9 @@ litellm_settings:
   request_timeout: 120
   stream_timeout: 60
 LITELLM_EOF
+        fi
         ai_ok "Generated LiteLLM config for Lemonade (model: extra.${_active_gguf})"
+        unset _renderer_ok _renderer_py
     fi
 
     # Validate generated .env against schema (fails fast on missing/unknown keys).

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -537,7 +537,32 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
             # went from "hangs indefinitely" to 1.8s end-to-end with this
             # one block added. The kwarg is a Qwen3-specific switch and is
             # safely ignored by non-Qwen3 chat templates.
-            cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_UPGRADE_EOF
+            _renderer_ok=false
+            _renderer_script="$INSTALL_DIR/scripts/render-runtime-configs.py"
+            _renderer_py="${DREAM_PYTHON_CMD:-}"
+            if [[ -z "$_renderer_py" && -f "$INSTALL_DIR/lib/python-cmd.sh" ]]; then
+                . "$INSTALL_DIR/lib/python-cmd.sh"
+                _renderer_py="$(ds_detect_python_cmd 2>/dev/null || true)"
+            fi
+            if [[ -z "$_renderer_py" ]]; then
+                _renderer_py="python3"
+            fi
+            if [[ -f "$_renderer_script" ]] && command -v "$_renderer_py" >/dev/null 2>&1; then
+                if "$_renderer_py" "$_renderer_script" \
+                    --surface litellm-lemonade \
+                    --dream-mode lemonade \
+                    --gpu-backend amd \
+                    --gguf-file "$FULL_GGUF_FILE" \
+                    --litellm-key "$LITELLM_LEMONADE_API_KEY" \
+                    --output-root "$INSTALL_DIR" \
+                    --write >/dev/null 2>&1; then
+                    _renderer_ok=true
+                else
+                    log "WARNING: Runtime config renderer failed for LiteLLM; falling back to inline writer"
+                fi
+            fi
+            if [[ "$_renderer_ok" != "true" ]]; then
+                cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_UPGRADE_EOF
 model_list:
   - model_name: default
     litellm_params:
@@ -563,6 +588,8 @@ litellm_settings:
   request_timeout: 120
   stream_timeout: 60
 LITELLM_UPGRADE_EOF
+            fi
+            unset _renderer_ok _renderer_script _renderer_py
             log "Restarting LiteLLM to pick up model change..."
             $DOCKER_CMD restart dream-litellm 2>&1 || log "WARNING: LiteLLM restart failed (non-fatal)"
         fi

--- a/dream-server/scripts/render-runtime-configs.py
+++ b/dream-server/scripts/render-runtime-configs.py
@@ -183,6 +183,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--opencode-port", type=int, default=3003)
     parser.add_argument("--context-length", type=int, default=DEFAULT_CONTEXT)
     parser.add_argument("--format", choices=["json", "paths"], default="json")
+    parser.add_argument("--output-root", default=".", help="Root directory used with --write")
+    parser.add_argument("--write", action="store_true", help="Write rendered files under --output-root")
     return parser.parse_args(argv)
 
 
@@ -204,11 +206,20 @@ def render(args: argparse.Namespace) -> dict[str, object]:
         context_length=args.context_length,
     )
     files = [RENDERERS[name](inputs) for name in select_surfaces(args.surface)]
+    written: list[str] = []
+    if args.write:
+        output_root = Path(args.output_root)
+        for item in files:
+            target = output_root / item.path
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(ensure_trailing_newline(item.content), encoding="utf-8")
+            written.append(str(target))
     return {
         "version": "1",
-        "mode": "dry-run",
+        "mode": "write" if args.write else "dry-run",
         "inputs": asdict(inputs),
         "files": [asdict(RenderedFile(item.surface, item.path, ensure_trailing_newline(item.content))) for item in files],
+        "written": written,
     }
 
 

--- a/dream-server/tests/test-render-runtime-configs.py
+++ b/dream-server/tests/test-render-runtime-configs.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -95,12 +96,44 @@ def test_perplexica_default_model_matches_route() -> None:
     assert content["modelProviders"]["openai"]["chatModels"][0]["name"] == "extra.Research.gguf"
 
 
+def test_write_mode_writes_under_output_root() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--surface",
+                "litellm-lemonade",
+                "--dream-mode",
+                "lemonade",
+                "--gpu-backend",
+                "amd",
+                "--gguf-file",
+                "Written.gguf",
+                "--output-root",
+                tmp,
+                "--write",
+            ],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        payload = json.loads(proc.stdout)
+        target = Path(tmp) / "config" / "litellm" / "lemonade.yaml"
+        assert payload["mode"] == "write"
+        assert target.exists()
+        assert "openai/extra.Written.gguf" in target.read_text(encoding="utf-8")
+
+
 def main() -> int:
     tests = [
         test_all_surfaces_render,
         test_lemonade_disables_thinking_and_uses_extra_alias,
         test_hermes_uses_lemonade_model_id_for_amd,
         test_perplexica_default_model_matches_route,
+        test_write_mode_writes_under_output_root,
     ]
     for test in tests:
         test()

--- a/dream-server/tests/test-runtime-config-wiring.py
+++ b/dream-server/tests/test-runtime-config-wiring.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Contract checks for runtime config renderer wiring."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8", errors="replace")
+
+
+def test_linux_installer_uses_renderer_with_fallback() -> None:
+    text = read("installers/phases/06-directories.sh")
+    assert "scripts/render-runtime-configs.py" in text
+    assert "--surface litellm-lemonade" in text
+    assert "LITELLM_EOF" in text
+    assert "falling back to inline writer" in text
+
+
+def test_bootstrap_upgrade_uses_renderer_with_fallback() -> None:
+    text = read("scripts/bootstrap-upgrade.sh")
+    assert "scripts/render-runtime-configs.py" in text
+    assert "--surface litellm-lemonade" in text
+    assert "LITELLM_UPGRADE_EOF" in text
+    assert "falling back to inline writer" in text
+
+
+def test_host_agent_uses_renderer_with_fallback() -> None:
+    text = read("bin/dream-host-agent.py")
+    assert "def _render_runtime_config" in text
+    assert "--surface" in text
+    assert "litellm-lemonade" in text
+    assert "Runtime config renderer failed" in text
+    assert "model_list:\\n" in text
+
+
+def main() -> int:
+    for test in (
+        test_linux_installer_uses_renderer_with_fallback,
+        test_bootstrap_upgrade_uses_renderer_with_fallback,
+        test_host_agent_uses_renderer_with_fallback,
+    ):
+        test()
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add write mode to the runtime config renderer.
- Wire Lemonade LiteLLM config generation through the shared renderer in installer, upgrade, and host-agent paths.
- Preserve fallback rendering when Python or the renderer is unavailable.

## Validation
- `python dream-server\tests\test-render-runtime-configs.py`
- `python dream-server\tests\test-runtime-config-wiring.py`
- `python -m py_compile dream-server\scripts\render-runtime-configs.py dream-server\tests\test-runtime-config-wiring.py dream-server\bin\dream-host-agent.py`
- `python dream-server\scripts\validate-generated-configs.py dream-server\config\generated-config-contracts.json`
- `git diff --check`

## Stack
Stacked on `codex/runtime-config-renderer`.