### PR TITLE
[codex] test: add update rollback release contract

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -114,6 +114,9 @@ jobs:
           test -f artifacts/installer-sim/SUMMARY.md
           python3 scripts/validate-sim-summary.py artifacts/installer-sim/summary.json
 
+      - name: Update Rollback Contract
+        run: bash tests/test-update-rollback-contract.sh
+
       - name: Upload Installer Simulation Artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -128,3 +131,4 @@ jobs:
             dream-server/artifacts/installer-sim/macos-preflight.json
             dream-server/artifacts/installer-sim/macos-doctor.json
             dream-server/artifacts/installer-sim/doctor.json
+            dream-server/artifacts/update-rollback/evidence.json

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -40,4 +40,7 @@ echo "[gate] installer simulation"
 bash scripts/simulate-installers.sh
 "$PYTHON_CMD" scripts/validate-sim-summary.py artifacts/installer-sim/summary.json
 
+echo "[gate] update rollback"
+bash tests/test-update-rollback-contract.sh
+
 echo "[PASS] release gate"

--- a/dream-server/tests/test-update-rollback-contract.sh
+++ b/dream-server/tests/test-update-rollback-contract.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DREAM_BACKUP="$ROOT_DIR/dream-backup.sh"
+DREAM_RESTORE="$ROOT_DIR/dream-restore.sh"
+OUT_DIR="$ROOT_DIR/artifacts/update-rollback"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v rsync >/dev/null 2>&1 || fail "rsync is required"
+command -v sha256sum >/dev/null 2>&1 || fail "sha256sum is required"
+
+[[ -x "$DREAM_BACKUP" ]] || fail "dream-backup.sh is not executable"
+[[ -x "$DREAM_RESTORE" ]] || fail "dream-restore.sh is not executable"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+SRC="$TMP/dream"
+mkdir -p "$SRC/lib" "$SRC/config" "$SRC/data/open-webui" "$SRC/data/hermes"
+cp "$ROOT_DIR/lib/rsync.sh" "$SRC/lib/rsync.sh"
+
+cat > "$SRC/.version" <<'EOF'
+1.0.0
+EOF
+cat > "$SRC/.env" <<'EOF'
+DREAM_MODE=local
+LLM_MODEL=baseline-model
+SECRET_TOKEN=baseline-secret
+EOF
+cat > "$SRC/docker-compose.yml" <<'EOF'
+services:
+  placeholder:
+    image: busybox:1.36
+EOF
+cat > "$SRC/config/settings.json" <<'EOF'
+{"mode":"baseline","model":"baseline-model"}
+EOF
+cat > "$SRC/data/open-webui/data.txt" <<'EOF'
+baseline-user-data
+EOF
+cat > "$SRC/data/hermes/config.yaml" <<'EOF'
+model:
+  default: "baseline-model"
+EOF
+
+baseline_hash="$(sha256sum "$SRC/.env" "$SRC/config/settings.json" "$SRC/data/open-webui/data.txt" | sha256sum | awk '{print $1}')"
+
+DREAM_DIR="$SRC" RETENTION_COUNT=10 bash "$DREAM_BACKUP" --type full >/dev/null 2>&1
+BACKUP_ID="$(find "$SRC/.backups" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | tail -n 1)"
+[[ -n "$BACKUP_ID" ]] || fail "backup ID was not created"
+pass "backup created before update mutation: $BACKUP_ID"
+
+cat > "$SRC/.version" <<'EOF'
+2.0.0
+EOF
+cat > "$SRC/.env" <<'EOF'
+DREAM_MODE=lemonade
+LLM_MODEL=updated-model
+SECRET_TOKEN=updated-secret
+EOF
+cat > "$SRC/config/settings.json" <<'EOF'
+{"mode":"updated","model":"updated-model"}
+EOF
+cat > "$SRC/data/open-webui/data.txt" <<'EOF'
+updated-user-data
+EOF
+
+updated_hash="$(sha256sum "$SRC/.env" "$SRC/config/settings.json" "$SRC/data/open-webui/data.txt" | sha256sum | awk '{print $1}')"
+[[ "$updated_hash" != "$baseline_hash" ]] || fail "update mutation did not change the test state"
+pass "update mutation changed config and data"
+
+DREAM_DIR="$SRC" bash "$DREAM_RESTORE" -f "$BACKUP_ID" >/dev/null 2>&1
+
+[[ "$(cat "$SRC/.version")" == "1.0.0" ]] || fail ".version did not roll back"
+grep -q "LLM_MODEL=baseline-model" "$SRC/.env" || fail ".env model did not roll back"
+grep -q "SECRET_TOKEN=baseline-secret" "$SRC/.env" || fail ".env secret did not roll back"
+grep -q '"mode":"baseline"' "$SRC/config/settings.json" || fail "config did not roll back"
+grep -q "baseline-user-data" "$SRC/data/open-webui/data.txt" || fail "user data did not roll back"
+
+rollback_hash="$(sha256sum "$SRC/.env" "$SRC/config/settings.json" "$SRC/data/open-webui/data.txt" | sha256sum | awk '{print $1}')"
+[[ "$rollback_hash" == "$baseline_hash" ]] || fail "rollback hash does not match baseline"
+pass "rollback restored baseline hash"
+
+mkdir -p "$OUT_DIR"
+jq -n \
+  --arg backup_id "$BACKUP_ID" \
+  --arg baseline_hash "$baseline_hash" \
+  --arg updated_hash "$updated_hash" \
+  --arg rollback_hash "$rollback_hash" \
+  '{
+    version: "1",
+    scenario: "install-backup-update-rollback",
+    backup_id: $backup_id,
+    checks: {
+      backup_created: true,
+      update_changed_state: ($baseline_hash != $updated_hash),
+      rollback_matches_baseline: ($baseline_hash == $rollback_hash)
+    },
+    hashes: {
+      baseline: $baseline_hash,
+      updated: $updated_hash,
+      rollback: $rollback_hash
+    }
+  }' > "$OUT_DIR/evidence.json"
+
+pass "update rollback evidence written to artifacts/update-rollback/evidence.json"


### PR DESCRIPTION
## Summary
- Add a release-gate contract for backup/restore rollback across update-like mutations.
- Emit rollback evidence under `artifacts/update-rollback/evidence.json`.
- Upload rollback evidence in Linux CI.

## Validation
- `git diff --check`
- Bash rollback test is wired for Linux CI; local Windows environment does not have the required Bash/rsync execution path.

## Stack
Stacked on `codex/runtime-config-writer-wiring`.