### PR TITLE
[codex] security: add network exposure contracts

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -103,6 +103,7 @@ jobs:
         run: |
           bash tests/contracts/test-installer-contracts.sh
           bash tests/contracts/test-preflight-fixtures.sh
+          python3 tests/contracts/test-network-exposure-contracts.py
 
       - name: Linux install preflight tests
         run: bash tests/test-linux-install-preflight.sh

--- a/dream-server/config/network-exposure-policy.json
+++ b/dream-server/config/network-exposure-policy.json
@@ -1,0 +1,150 @@
+{
+  "version": 1,
+  "description": "Host-facing or host-networked service exposure policy. Every manifest with an external port or host network entry must be listed here.",
+  "services": {
+    "ape": {
+      "risk": "agent-policy-control-plane",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Policy/audit service for agent tool calls; keep local unless explicitly publishing an agent control surface."
+    },
+    "brave-search": {
+      "risk": "paid-api-proxy",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Bridges to a paid upstream API key; exposure risks quota/key abuse."
+    },
+    "comfyui": {
+      "risk": "gpu-workload-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": false,
+      "notes": "Optional image-generation UI; should stay localhost/private by default."
+    },
+    "dashboard": {
+      "risk": "operator-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Primary control surface."
+    },
+    "dashboard-api": {
+      "risk": "operator-api",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Host-agent and setup API surface."
+    },
+    "dream-proxy": {
+      "risk": "lan-entrypoint",
+      "lan_exposure": "explicit",
+      "auth_required": true,
+      "notes": "Optional web gateway for LAN/mDNS routing."
+    },
+    "embeddings": {
+      "risk": "model-inference-api",
+      "lan_exposure": "operator-controlled",
+      "auth_required": false,
+      "notes": "Embedding model API; keep private unless a client explicitly needs it."
+    },
+    "hermes": {
+      "risk": "autonomous-agent-internal",
+      "lan_exposure": "none",
+      "auth_required": true,
+      "notes": "Must remain internal-only; users enter through hermes-proxy."
+    },
+    "hermes-proxy": {
+      "risk": "autonomous-agent-gateway",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Caddy forward_auth gate in front of Hermes."
+    },
+    "langfuse": {
+      "risk": "observability-data-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "May contain prompts, traces, and evaluation data."
+    },
+    "litellm": {
+      "risk": "llm-api-gateway",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Must enforce LITELLM_MASTER_KEY when used as a gateway."
+    },
+    "llama-server": {
+      "risk": "model-inference-api",
+      "lan_exposure": "operator-controlled",
+      "auth_required": false,
+      "notes": "Local OpenAI-compatible inference API."
+    },
+    "n8n": {
+      "risk": "workflow-automation-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Workflow automation can call local and external services."
+    },
+    "open-webui": {
+      "risk": "chat-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Primary chat UI."
+    },
+    "openclaw": {
+      "risk": "deprecated-agent",
+      "lan_exposure": "opt-in-only",
+      "auth_required": true,
+      "notes": "Deprecated legacy agent. Must remain optional and token-gated."
+    },
+    "opencode": {
+      "risk": "code-execution-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Browser IDE/coding assistant surface."
+    },
+    "perplexica": {
+      "risk": "research-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": false,
+      "notes": "Deep research UI backed by search and local inference."
+    },
+    "privacy-shield": {
+      "risk": "privacy-proxy",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "PII restoration/proxy surface; auth protects re-identification paths."
+    },
+    "qdrant": {
+      "risk": "vector-database-api",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Vector database can contain private embeddings and metadata."
+    },
+    "searxng": {
+      "risk": "search-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": false,
+      "notes": "Metasearch service; exposure can leak query history."
+    },
+    "tailscale": {
+      "risk": "remote-network-access",
+      "lan_exposure": "host-network",
+      "auth_required": true,
+      "notes": "Remote access path; host networking is intentional and must stay explicit."
+    },
+    "token-spy": {
+      "risk": "usage-observability-ui",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Usage/trace data can reveal prompts and model behavior."
+    },
+    "tts": {
+      "risk": "model-inference-api",
+      "lan_exposure": "operator-controlled",
+      "auth_required": false,
+      "notes": "Text-to-speech model API."
+    },
+    "whisper": {
+      "risk": "audio-transcription-api",
+      "lan_exposure": "operator-controlled",
+      "auth_required": false,
+      "notes": "Speech-to-text model API; audio may be sensitive."
+    }
+  }
+}

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -29,6 +29,7 @@ echo "[gate] contracts"
 bash tests/contracts/test-installer-contracts.sh
 bash tests/contracts/test-preflight-fixtures.sh
 bash tests/contracts/test-installer-hardening.sh
+"$PYTHON_CMD" tests/contracts/test-network-exposure-contracts.py
 
 echo "[gate] smoke"
 bash tests/smoke/linux-amd.sh

--- a/dream-server/tests/contracts/test-network-exposure-contracts.py
+++ b/dream-server/tests/contracts/test-network-exposure-contracts.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Network exposure contract checks for bundled services."""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SERVICES = ROOT / "extensions" / "services"
+POLICY = ROOT / "config" / "network-exposure-policy.json"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def manifest_value(text: str, key: str) -> str | None:
+    match = re.search(rf"(?m)^\s+{re.escape(key)}:\s*(.+?)\s*$", text)
+    return match.group(1).strip() if match else None
+
+
+def manifest_bool(text: str, key: str) -> bool:
+    value = manifest_value(text, key)
+    return bool(value and value.lower() == "true")
+
+
+def exposed_service_ids() -> set[str]:
+    exposed: set[str] = set()
+    for manifest in SERVICES.glob("*/manifest.yaml"):
+        text = read(manifest)
+        service_id = manifest_value(text, "id") or manifest.parent.name
+        has_external_port = manifest_value(text, "external_port_default") is not None
+        if has_external_port or manifest_bool(text, "host_network"):
+            exposed.add(service_id)
+    return exposed
+
+
+def assert_true(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def test_exposed_services_are_policy_labeled() -> None:
+    policy = json.loads(read(POLICY))
+    policy_services = set(policy["services"])
+    exposed = exposed_service_ids()
+    assert_true(exposed <= policy_services, f"missing exposure policy entries: {sorted(exposed - policy_services)}")
+    assert_true(policy_services <= exposed, f"stale exposure policy entries: {sorted(policy_services - exposed)}")
+    for service_id, entry in policy["services"].items():
+        assert_true(entry.get("risk"), f"{service_id} missing risk label")
+        assert_true(entry.get("lan_exposure"), f"{service_id} missing lan_exposure label")
+        assert_true(isinstance(entry.get("auth_required"), bool), f"{service_id} auth_required must be boolean")
+        assert_true(entry.get("notes"), f"{service_id} missing notes")
+
+
+def test_hermes_is_internal_only_and_proxy_gated() -> None:
+    hermes_compose = read(SERVICES / "hermes" / "compose.yaml")
+    hermes_manifest = read(SERVICES / "hermes" / "manifest.yaml")
+    proxy_caddyfile = read(SERVICES / "hermes-proxy" / "Caddyfile")
+    policy = json.loads(read(POLICY))["services"]
+
+    assert_true(not re.search(r"(?m)^\s{4}ports:\s*$", hermes_compose), "hermes compose must not bind host ports")
+    assert_true(re.search(r"(?m)^\s{4}expose:\s*$", hermes_compose) is not None, "hermes compose should expose only internally")
+    assert_true(manifest_value(hermes_manifest, "external_port_default") == "0", "hermes manifest external port must be 0")
+    assert_true(policy["hermes"]["lan_exposure"] == "none", "hermes policy must mark no LAN exposure")
+    assert_true("forward_auth" in proxy_caddyfile, "hermes-proxy must verify sessions with forward_auth")
+    assert_true("/api/auth/verify-session" in proxy_caddyfile, "hermes-proxy must call dashboard auth verification")
+    assert_true("reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119}" in proxy_caddyfile, "hermes-proxy must forward to internal Hermes")
+
+
+def test_openclaw_stays_deprecated_optional_and_token_gated() -> None:
+    manifest = read(SERVICES / "openclaw" / "manifest.yaml")
+    docs = read(ROOT / "docs" / "OPENCLAW-INTEGRATION.md")
+    policy = json.loads(read(POLICY))["services"]["openclaw"]
+
+    assert_true(manifest_bool(manifest, "deprecated"), "OpenClaw must remain deprecated")
+    assert_true(manifest_value(manifest, "category") == "optional", "OpenClaw must stay optional")
+    assert_true("OPENCLAW_TOKEN" in manifest, "OpenClaw manifest must require a token")
+    assert_true(policy["lan_exposure"] == "opt-in-only", "OpenClaw policy must stay opt-in-only")
+    assert_true("DEPRECATED" in docs, "OpenClaw docs must keep the deprecation notice")
+
+
+def test_litellm_gateway_auth_is_enforced() -> None:
+    compose = read(SERVICES / "litellm" / "compose.yaml")
+    amd_compose = read(ROOT / "docker-compose.amd.yml")
+    policy = json.loads(read(POLICY))["services"]["litellm"]
+
+    assert_true("LITELLM_MASTER_KEY=${LITELLM_KEY:-}" in compose, "LiteLLM must keep master-key auth")
+    assert_true("OPENAI_API_KEY=${LITELLM_KEY}" in amd_compose, "AMD clients must present LITELLM_KEY")
+    assert_true(policy["auth_required"] is True, "LiteLLM policy must require auth")
+
+
+def main() -> int:
+    tests = [
+        test_exposed_services_are_policy_labeled,
+        test_hermes_is_internal_only_and_proxy_gated,
+        test_openclaw_stays_deprecated_optional_and_token_gated,
+        test_litellm_gateway_auth_is_enforced,
+    ]
+    for test in tests:
+        test()
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add a machine-readable network exposure policy for externally reachable or host-networked services.
- Add contract coverage for Hermes proxy auth, OpenClaw deprecation/optional posture, and LiteLLM key usage.
- Wire the network exposure contract into CI and the release gate.

## Validation
- `python dream-server\tests\contracts\test-network-exposure-contracts.py`
- `python -m py_compile dream-server\tests\contracts\test-network-exposure-contracts.py`
- `git diff --check`

## Stack
Stacked on `codex/support-evidence-manifest`.