### PR TITLE
[codex] release: enforce dependency pin policy

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Generated Config Contract Tests
         run: bash tests/test-generated-config-contracts.sh
 
+      - name: Dependency Pin Contract Tests
+        run: python3 tests/test-dependency-pins.py
+
       - name: Runtime Config Renderer Tests
         run: python3 tests/test-render-runtime-configs.py
 

--- a/dream-server/config/dependency-lock.json
+++ b/dream-server/config/dependency-lock.json
@@ -1,0 +1,337 @@
+{
+  "version": 1,
+  "policy": {
+    "description": "Runtime container images must be pinned by tag or digest, recorded here, and intentionally allowlisted when a local build or placeholder needs a mutable tag.",
+    "latest_tags": "forbidden unless listed in allow_latest",
+    "variable_image_refs": "allowed only when the default image resolves to a locked entry and the variable ref is documented in allow_variable_refs",
+    "local_images": "allowed only when listed in allow_local_images"
+  },
+  "entries": [
+    {
+      "id": "base.llama-server",
+      "type": "image",
+      "path": "docker-compose.base.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-b9014"
+    },
+    {
+      "id": "base.open-webui",
+      "type": "image",
+      "path": "docker-compose.base.yml",
+      "value": "ghcr.io/open-webui/open-webui:v0.7.2"
+    },
+    {
+      "id": "apple.llama-server",
+      "type": "image",
+      "path": "docker-compose.apple.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-b8248"
+    },
+    {
+      "id": "cpu.llama-server",
+      "type": "image",
+      "path": "docker-compose.cpu.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-b8248"
+    },
+    {
+      "id": "intel.llama-server",
+      "type": "image",
+      "path": "docker-compose.intel.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-intel-b8248"
+    },
+    {
+      "id": "nvidia.llama-server",
+      "type": "image",
+      "path": "docker-compose.nvidia.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014"
+    },
+    {
+      "id": "ape.python",
+      "type": "image",
+      "path": "extensions/services/ape/Dockerfile",
+      "value": "python:3.12-slim"
+    },
+    {
+      "id": "brave-search.node",
+      "type": "image",
+      "path": "extensions/services/brave-search/Dockerfile",
+      "value": "node:20-alpine"
+    },
+    {
+      "id": "comfyui.amd",
+      "type": "image",
+      "path": "extensions/services/comfyui/compose.amd.yaml",
+      "value": "ignatberesnev/comfyui-gfx1151:v0.2"
+    },
+    {
+      "id": "comfyui.nvidia-runtime",
+      "type": "image",
+      "path": "extensions/services/comfyui/Dockerfile",
+      "value": "nvidia/cuda:12.8.0-runtime-ubuntu22.04"
+    },
+    {
+      "id": "dashboard.node",
+      "type": "image",
+      "path": "extensions/services/dashboard/Dockerfile",
+      "value": "node:20-alpine"
+    },
+    {
+      "id": "dashboard.nginx",
+      "type": "image",
+      "path": "extensions/services/dashboard/Dockerfile",
+      "value": "nginx:alpine"
+    },
+    {
+      "id": "dashboard-api.python",
+      "type": "image",
+      "path": "extensions/services/dashboard-api/Dockerfile",
+      "value": "python:3.11-slim"
+    },
+    {
+      "id": "dream-proxy.caddy",
+      "type": "image",
+      "path": "extensions/services/dream-proxy/compose.yaml",
+      "value": "caddy:2.11.3-alpine"
+    },
+    {
+      "id": "embeddings.tei",
+      "type": "image",
+      "path": "extensions/services/embeddings/compose.yaml",
+      "value": "ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1"
+    },
+    {
+      "id": "hermes.agent",
+      "type": "image",
+      "path": "extensions/services/hermes/compose.yaml",
+      "value": "nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f"
+    },
+    {
+      "id": "hermes-proxy.caddy",
+      "type": "image",
+      "path": "extensions/services/hermes-proxy/compose.yaml",
+      "value": "caddy:2.11.3-alpine"
+    },
+    {
+      "id": "langfuse.web",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "langfuse/langfuse:3.159.0"
+    },
+    {
+      "id": "langfuse.worker",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "langfuse/langfuse-worker:3.159.0"
+    },
+    {
+      "id": "langfuse.postgres",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "postgres:17.9-alpine"
+    },
+    {
+      "id": "langfuse.clickhouse",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "clickhouse/clickhouse-server:26.2.4.23"
+    },
+    {
+      "id": "langfuse.redis",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "redis:7.4.8-alpine"
+    },
+    {
+      "id": "langfuse.minio",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+    },
+    {
+      "id": "langfuse.minio-client",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+    },
+    {
+      "id": "litellm.proxy",
+      "type": "image",
+      "path": "extensions/services/litellm/compose.yaml",
+      "value": "ghcr.io/berriai/litellm:v1.81.3-stable"
+    },
+    {
+      "id": "llama-server.rocm-build",
+      "type": "image",
+      "path": "extensions/services/llama-server/Dockerfile.amd",
+      "raw": "rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete",
+      "value": "rocm/dev-ubuntu-24.04:7.2-complete"
+    },
+    {
+      "id": "llama-server.lemonade-runtime",
+      "type": "image",
+      "path": "extensions/services/llama-server/Dockerfile.amd",
+      "raw": "${LEMONADE_SERVER_IMAGE}",
+      "value": "ghcr.io/lemonade-sdk/lemonade-server:v10.2.0"
+    },
+    {
+      "id": "n8n.app",
+      "type": "image",
+      "path": "extensions/services/n8n/compose.yaml",
+      "value": "n8nio/n8n:2.6.4"
+    },
+    {
+      "id": "openclaw.app",
+      "type": "image",
+      "path": "extensions/services/openclaw/compose.yaml",
+      "value": "ghcr.io/openclaw/openclaw:2026.3.8"
+    },
+    {
+      "id": "perplexica.app",
+      "type": "image",
+      "path": "extensions/services/perplexica/compose.yaml",
+      "value": "itzcrazykns1337/perplexica:slim-latest@sha256:6e399abf4ff587822b0ef0df11f36088fb928e17ac61556fe89beb68d48c378e"
+    },
+    {
+      "id": "privacy-shield.python",
+      "type": "image",
+      "path": "extensions/services/privacy-shield/Dockerfile",
+      "value": "python:3.11-slim"
+    },
+    {
+      "id": "qdrant.vector-db",
+      "type": "image",
+      "path": "extensions/services/qdrant/compose.yaml",
+      "value": "qdrant/qdrant:v1.16.3"
+    },
+    {
+      "id": "searxng.search",
+      "type": "image",
+      "path": "extensions/services/searxng/compose.yaml",
+      "value": "searxng/searxng:2026.3.8-a563127a2"
+    },
+    {
+      "id": "tailscale.sidecar",
+      "type": "image",
+      "path": "extensions/services/tailscale/compose.yaml",
+      "value": "tailscale/tailscale:v1.96.5"
+    },
+    {
+      "id": "token-spy.python",
+      "type": "image",
+      "path": "extensions/services/token-spy/Dockerfile",
+      "value": "python:3.12-slim"
+    },
+    {
+      "id": "tts.kokoro",
+      "type": "image",
+      "path": "extensions/services/tts/compose.yaml",
+      "value": "ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4"
+    },
+    {
+      "id": "whisper.cpu",
+      "type": "image",
+      "path": "extensions/services/whisper/compose.yaml",
+      "raw": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu}",
+      "value": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu"
+    },
+    {
+      "id": "whisper.nvidia",
+      "type": "image",
+      "path": "extensions/services/whisper/compose.nvidia.yaml",
+      "raw": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda}",
+      "value": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda"
+    },
+    {
+      "id": "macos.placeholder-api",
+      "type": "image",
+      "path": "installers/macos/docker-compose.macos.yml",
+      "value": "busybox:1.36.1"
+    },
+    {
+      "id": "windows-amd-local.placeholder-api",
+      "type": "image",
+      "path": "installers/windows/docker-compose.windows-amd.local.yml",
+      "value": "busybox:1.36.1"
+    }
+  ],
+  "allow_latest": [
+    {
+      "path": "installers/windows/docker-compose.windows-amd.yml",
+      "value": "hello-world:latest",
+      "reason": "Windows AMD placeholder service has replicas: 0 and never pulls or runs the image during normal operation."
+    }
+  ],
+  "allow_local_images": [
+    {
+      "path": "docker-compose.amd.yml",
+      "value": "dream-lemonade-server:latest",
+      "reason": "Local image built from extensions/services/llama-server/Dockerfile.amd by the AMD installer path."
+    },
+    {
+      "path": "docker-compose.arc.yml",
+      "value": "dream-llama-sycl:local",
+      "reason": "Local image built for Intel Arc SYCL experiments."
+    },
+    {
+      "path": "extensions/services/brave-search/compose.yaml",
+      "value": "dream-brave-search:local",
+      "reason": "Local extension image built from the adjacent Dockerfile."
+    }
+  ],
+  "allow_variable_refs": [
+    {
+      "path": "docker-compose.base.yml",
+      "value": "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b9014}",
+      "default": "ghcr.io/ggml-org/llama.cpp:server-b9014",
+      "reason": "Core llama.cpp image can be overridden for testing, but the shipped default is locked."
+    },
+    {
+      "path": "docker-compose.nvidia.yml",
+      "value": "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9014}",
+      "default": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014",
+      "reason": "NVIDIA llama.cpp image can be overridden for testing, but the shipped default is locked."
+    },
+    {
+      "path": "docker-compose.cpu.yml",
+      "value": "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}",
+      "default": "ghcr.io/ggml-org/llama.cpp:server-b8248",
+      "reason": "CPU llama.cpp image can be overridden for testing, but the shipped default is locked."
+    },
+    {
+      "path": "docker-compose.intel.yml",
+      "value": "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-intel-b8248}",
+      "default": "ghcr.io/ggml-org/llama.cpp:server-intel-b8248",
+      "reason": "Intel llama.cpp image can be overridden for testing, but the shipped default is locked."
+    },
+    {
+      "path": "docker-compose.arc.yml",
+      "value": "${LLAMA_ARC_IMAGE:-dream-llama-sycl:local}",
+      "default": "dream-llama-sycl:local",
+      "reason": "Intel Arc uses a local SYCL image by default and can be overridden for experiments."
+    },
+    {
+      "path": "extensions/services/llama-server/Dockerfile.amd",
+      "value": "rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete",
+      "arg": "ROCM_VERSION",
+      "default": "7.2",
+      "reason": "ROCm builder image follows the Dockerfile ARG default unless an operator intentionally overrides it."
+    },
+    {
+      "path": "extensions/services/llama-server/Dockerfile.amd",
+      "value": "${LEMONADE_SERVER_IMAGE}",
+      "arg": "LEMONADE_SERVER_IMAGE",
+      "default": "ghcr.io/lemonade-sdk/lemonade-server:v10.2.0",
+      "reason": "AMD runtime image is overrideable for hotfix testing while the default stays locked."
+    },
+    {
+      "path": "extensions/services/whisper/compose.yaml",
+      "value": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu}",
+      "default": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu",
+      "reason": "Whisper CPU image can be overridden by operators, but the shipped default is locked."
+    },
+    {
+      "path": "extensions/services/whisper/compose.nvidia.yaml",
+      "value": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda}",
+      "default": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda",
+      "reason": "Whisper CUDA image can be overridden by operators, but the shipped default is locked."
+    }
+  ]
+}

--- a/dream-server/scripts/check-dependency-pins.py
+++ b/dream-server/scripts/check-dependency-pins.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+"""Validate pinned runtime dependency references.
+
+This is intentionally narrow: it tracks runtime container images shipped by
+Dream Server Compose files and extension Dockerfiles. The goal is to make image
+drift explicit in review instead of discovering it during an install.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LOCK_PATH = ROOT / "config" / "dependency-lock.json"
+
+IMAGE_RE = re.compile(r"^\s*image:\s*(?P<value>\S+)")
+ARG_RE = re.compile(r"^\s*ARG\s+(?P<name>[A-Za-z_][A-Za-z0-9_]*)(?:=(?P<value>\S+))?")
+VAR_RE = re.compile(
+    r"\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?:(?P<op>:-|-)(?P<default>[^}]+))?\}"
+    r"|\$(?P<plain>[A-Za-z_][A-Za-z0-9_]*)"
+)
+
+
+@dataclass(frozen=True)
+class ImageRef:
+    path: str
+    line: int
+    raw: str
+    value: str
+    source: str
+
+
+def _strip_inline_comment(line: str) -> str:
+    in_single = False
+    in_double = False
+    for idx, char in enumerate(line):
+        if char == "'" and not in_double:
+            in_single = not in_single
+        elif char == '"' and not in_single:
+            in_double = not in_double
+        elif char == "#" and not in_single and not in_double:
+            return line[:idx]
+    return line
+
+
+def _clean_value(value: str) -> str:
+    value = value.strip().strip(",")
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        value = value[1:-1]
+    return value.strip()
+
+
+def _rel(path: Path) -> str:
+    return path.relative_to(ROOT).as_posix()
+
+
+def _resolve_vars(value: str, defaults: dict[str, str]) -> str:
+    def replace(match: re.Match[str]) -> str:
+        name = match.group("braced") or match.group("plain") or ""
+        default = match.group("default")
+        if default is not None:
+            return default
+        if name in defaults:
+            return defaults[name]
+        return match.group(0)
+
+    return VAR_RE.sub(replace, value)
+
+
+def _compose_image_refs(path: Path) -> list[ImageRef]:
+    refs: list[ImageRef] = []
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        match = IMAGE_RE.match(_strip_inline_comment(line))
+        if not match:
+            continue
+        raw = _clean_value(match.group("value"))
+        refs.append(
+            ImageRef(
+                path=_rel(path),
+                line=line_no,
+                raw=raw,
+                value=_resolve_vars(raw, {}),
+                source="compose image",
+            )
+        )
+    return refs
+
+
+def _dockerfile_from_value(line: str) -> str | None:
+    line = _strip_inline_comment(line).strip()
+    if not line.upper().startswith("FROM "):
+        return None
+    tokens = line.split()[1:]
+    while tokens and tokens[0].startswith("--"):
+        tokens.pop(0)
+    if not tokens:
+        return None
+    return _clean_value(tokens[0])
+
+
+def _dockerfile_image_refs(path: Path) -> list[ImageRef]:
+    refs: list[ImageRef] = []
+    defaults: dict[str, str] = {}
+    for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        arg_match = ARG_RE.match(_strip_inline_comment(line))
+        if arg_match and arg_match.group("value") is not None:
+            defaults[arg_match.group("name")] = _clean_value(arg_match.group("value"))
+
+        raw = _dockerfile_from_value(line)
+        if raw is None:
+            continue
+        refs.append(
+            ImageRef(
+                path=_rel(path),
+                line=line_no,
+                raw=raw,
+                value=_resolve_vars(raw, defaults),
+                source="dockerfile from",
+            )
+        )
+    return refs
+
+
+def candidate_files(root: Path = ROOT) -> list[Path]:
+    files: set[Path] = set(root.glob("docker-compose*.yml"))
+    files.update(root.glob("docker-compose*.yaml"))
+    for base in (root / "installers", root / "extensions" / "services"):
+        if not base.exists():
+            continue
+        for path in base.rglob("*"):
+            if not path.is_file():
+                continue
+            name = path.name
+            if name.startswith("Dockerfile") or name.startswith("compose.") or name.startswith(
+                "docker-compose"
+            ):
+                files.add(path)
+    return sorted(files)
+
+
+def discover_image_refs(root: Path = ROOT) -> list[ImageRef]:
+    refs: list[ImageRef] = []
+    for path in candidate_files(root):
+        if path.name.startswith("Dockerfile"):
+            refs.extend(_dockerfile_image_refs(path))
+        else:
+            refs.extend(_compose_image_refs(path))
+    return refs
+
+
+def _key(item: dict[str, object]) -> tuple[str, str]:
+    return str(item.get("path", "")), str(item.get("value", ""))
+
+
+def _image_tag(value: str) -> str | None:
+    without_digest = value.split("@", 1)[0]
+    last_segment = without_digest.rsplit("/", 1)[-1]
+    if ":" not in last_segment:
+        return None
+    return last_segment.rsplit(":", 1)[1]
+
+
+def _has_digest(value: str) -> bool:
+    return "@sha256:" in value
+
+
+def _has_tag_or_digest(value: str) -> bool:
+    return _has_digest(value) or _image_tag(value) is not None
+
+
+def _is_variable_ref(value: str) -> bool:
+    return "$" in value
+
+
+def _arg_default_present(path: Path, arg: str, default: str) -> bool:
+    expected = f"ARG {arg}={default}"
+    return expected in path.read_text(encoding="utf-8")
+
+
+def _validate_lock_shape(lock: dict[str, object], root: Path) -> list[str]:
+    errors: list[str] = []
+    if lock.get("version") != 1:
+        errors.append("dependency-lock.json version must be 1")
+
+    ids: set[str] = set()
+    entry_keys: set[tuple[str, str]] = set()
+    for entry in lock.get("entries", []):
+        if not isinstance(entry, dict):
+            errors.append("lock entries must be objects")
+            continue
+        entry_id = str(entry.get("id", ""))
+        path = str(entry.get("path", ""))
+        value = str(entry.get("value", ""))
+        raw = str(entry.get("raw", value))
+        if not entry_id or not path or not value:
+            errors.append(f"lock entry is missing id/path/value: {entry!r}")
+            continue
+        if entry_id in ids:
+            errors.append(f"duplicate lock entry id: {entry_id}")
+        ids.add(entry_id)
+        if (path, value) in entry_keys:
+            errors.append(f"duplicate lock entry path/value: {path} -> {value}")
+        entry_keys.add((path, value))
+        file_path = root / path
+        if not file_path.exists():
+            errors.append(f"lock entry points at missing file: {path}")
+            continue
+        text = file_path.read_text(encoding="utf-8")
+        if raw not in text and value not in text:
+            errors.append(f"lock entry value is not present in {path}: {value}")
+
+    for list_name in ("allow_latest", "allow_local_images", "allow_variable_refs"):
+        seen: set[tuple[str, str]] = set()
+        for item in lock.get(list_name, []):
+            if not isinstance(item, dict):
+                errors.append(f"{list_name} entries must be objects")
+                continue
+            path, value = _key(item)
+            if not path or not value:
+                errors.append(f"{list_name} entry is missing path/value: {item!r}")
+                continue
+            if (path, value) in seen:
+                errors.append(f"duplicate {list_name} entry: {path} -> {value}")
+            seen.add((path, value))
+            file_path = root / path
+            if not file_path.exists():
+                errors.append(f"{list_name} entry points at missing file: {path}")
+                continue
+            if value not in file_path.read_text(encoding="utf-8"):
+                errors.append(f"{list_name} value is not present in {path}: {value}")
+            arg = item.get("arg")
+            default = item.get("default")
+            if isinstance(arg, str) and isinstance(default, str):
+                if not _arg_default_present(file_path, arg, default):
+                    errors.append(
+                        f"{list_name} entry for {path} expects ARG {arg}={default}"
+                    )
+
+    return errors
+
+
+def validate_refs(refs: Iterable[ImageRef], lock: dict[str, object], root: Path = ROOT) -> list[str]:
+    errors: list[str] = []
+    entry_keys = {_key(entry) for entry in lock.get("entries", []) if isinstance(entry, dict)}
+    latest_allow = {
+        _key(entry) for entry in lock.get("allow_latest", []) if isinstance(entry, dict)
+    }
+    local_allow = {
+        _key(entry) for entry in lock.get("allow_local_images", []) if isinstance(entry, dict)
+    }
+    variable_allow = {
+        _key(entry) for entry in lock.get("allow_variable_refs", []) if isinstance(entry, dict)
+    }
+
+    discovered_keys: set[tuple[str, str]] = set()
+    for ref in refs:
+        discovered_keys.add((ref.path, ref.value))
+        location = f"{ref.path}:{ref.line}"
+        if _is_variable_ref(ref.raw):
+            if (ref.path, ref.raw) not in variable_allow:
+                errors.append(f"{location}: variable image ref is not documented: {ref.raw}")
+            if _is_variable_ref(ref.value):
+                errors.append(f"{location}: variable image ref does not resolve to a default: {ref.raw}")
+                continue
+
+        if (ref.path, ref.value) in local_allow:
+            continue
+
+        if not _has_tag_or_digest(ref.value):
+            errors.append(f"{location}: image ref must include a tag or digest: {ref.value}")
+
+        if _image_tag(ref.value) == "latest" and not _has_digest(ref.value):
+            if (ref.path, ref.value) not in latest_allow:
+                errors.append(f"{location}: latest tag requires allow_latest: {ref.value}")
+
+        if (ref.path, ref.value) not in entry_keys and (ref.path, ref.value) not in latest_allow:
+            errors.append(f"{location}: image ref is not recorded in dependency-lock.json: {ref.value}")
+
+    for path, value in entry_keys:
+        if (path, value) not in discovered_keys:
+            errors.append(f"lock entry is stale or undiscovered: {path} -> {value}")
+
+    return errors
+
+
+def load_lock(path: Path = LOCK_PATH) -> dict[str, object]:
+    with path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("dependency-lock.json must contain a JSON object")
+    return data
+
+
+def check(path: Path = LOCK_PATH, root: Path = ROOT) -> list[str]:
+    lock = load_lock(path)
+    errors = _validate_lock_shape(lock, root)
+    errors.extend(validate_refs(discover_image_refs(root), lock, root))
+    return errors
+
+
+def main() -> int:
+    errors = check()
+    if errors:
+        for error in errors:
+            print(f"[FAIL] {error}", file=sys.stderr)
+        return 1
+    print("[PASS] dependency pins are documented and enforceable")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -24,6 +24,7 @@ bash scripts/check-compatibility.sh
 bash scripts/check-release-claims.sh
 "$PYTHON_CMD" scripts/validate-golden-paths.py
 "$PYTHON_CMD" scripts/validate-generated-configs.py
+"$PYTHON_CMD" scripts/check-dependency-pins.py
 
 echo "[gate] contracts"
 bash tests/contracts/test-installer-contracts.sh

--- a/dream-server/tests/test-dependency-pins.py
+++ b/dream-server/tests/test-dependency-pins.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Unit tests for dependency pin enforcement."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-dependency-pins.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_dependency_pins", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repo_dependency_lock_passes() -> None:
+    module = load_module()
+    errors = module.check()
+    assert errors == [], "\n".join(errors)
+
+
+def test_unallowlisted_latest_is_rejected() -> None:
+    module = load_module()
+    lock = {
+        "entries": [],
+        "allow_latest": [],
+        "allow_local_images": [],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="compose.yaml",
+        line=3,
+        raw="postgres:latest",
+        value="postgres:latest",
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert any("latest tag requires allow_latest" in error for error in errors)
+
+
+def test_variable_refs_must_be_documented() -> None:
+    module = load_module()
+    lock = {
+        "entries": [
+            {
+                "path": "compose.yaml",
+                "value": "postgres:17.9-alpine",
+            }
+        ],
+        "allow_latest": [],
+        "allow_local_images": [],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="compose.yaml",
+        line=3,
+        raw="${POSTGRES_IMAGE:-postgres:17.9-alpine}",
+        value="postgres:17.9-alpine",
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert any("variable image ref is not documented" in error for error in errors)
+
+
+def main() -> int:
+    tests = [
+        test_repo_dependency_lock_passes,
+        test_unallowlisted_latest_is_rejected,
+        test_variable_refs_must_be_documented,
+    ]
+    for test in tests:
+        test()
+    print("[PASS] dependency pin tests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a dependency lock for shipped runtime container image references.
- Add a checker that scans Compose files and Dockerfiles for undocumented image drift, unallowlisted `latest`, missing tags, and undocumented variable image refs.
- Wire the checker into CI and the release gate.

## Validation
- `python dream-server\scripts\check-dependency-pins.py`
- `python dream-server\tests\test-dependency-pins.py`
- `python -m py_compile dream-server\scripts\check-dependency-pins.py dream-server\tests\test-dependency-pins.py`
- `git diff --check`

## Stack
Stacked on `codex/security-exposure-contracts`.