### PR TITLE
fix(windows): harden install compose preflight

### DIFF
--- a/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
+++ b/dream-server/docs/WINDOWS-TROUBLESHOOTING-GUIDE.md
@@ -13,6 +13,8 @@
 | "Docker not found" | Install Docker Desktop first |
 | "GPU not detected" | Update NVIDIA drivers |
 | "Installation hangs" | Check internet connection, wait 30 min for model download |
+| "Docker Desktop cannot bind-mount..." | Add `C:\Users\<you>\dream-server` to Docker Desktop -> Settings -> Resources -> File Sharing |
+| "Docker could not download alpine..." | Run `docker pull alpine:3.20`, then re-run the installer |
 
 Do not use "Run as administrator" for the Dream Server installer unless you
 are intentionally accepting admin-owned files under your user profile. The
@@ -35,6 +37,8 @@ What the diagnostics include (in order):
 **Things to check on your machine before re-running:**
 
 - Docker Desktop is **running** (whale icon in the tray) and **WSL 2** is enabled for the engine (Settings → General).
+- Docker Desktop can pull the small bind-mount probe image: `docker pull alpine:3.20`.
+- Docker Desktop file sharing includes the **installed** Dream Server folder, usually `C:\Users\<you>\dream-server`, not just the cloned `DreamServer` source folder.
 - No other app is blocking the same **ports** as in `.env` (e.g. another stack using 3000, 8080, 11434).
 - Enough **disk space** for images and volumes.
 - If you edited compose files or added overrides, temporarily remove **`docker-compose.override.yml`** and try again.

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -690,8 +690,13 @@ if ($dryRun) {
         for ($fi = 0; $fi -lt $composeFlags.Count; $fi++) {
             if ($composeFlags[$fi] -eq "-f" -and ($fi + 1) -lt $composeFlags.Count) {
                 $cf = $composeFlags[$fi + 1]
-                if (-not (Test-Path $cf)) {
+                $cfPath = $cf
+                if (-not [System.IO.Path]::IsPathRooted($cfPath)) {
+                    $cfPath = Join-Path $installDir $cfPath
+                }
+                if (-not (Test-Path $cfPath)) {
                     Write-AIError "Compose file not found: $cf"
+                    Write-AI "  Expected path: $cfPath"
                     Write-AI "  Re-run with --Force or check that $installDir is intact."
                     exit 1
                 }
@@ -782,6 +787,7 @@ if ($dryRun) {
         }
 
         Write-AI "Running: docker compose $($composeFlags -join ' ') up -d --remove-orphans --no-build"
+        Write-AI "Compose working directory: $installDir"
         # PS 5.1 treats ANY stderr output from native commands as NativeCommandError.
         # Silence stderr-as-error so $LASTEXITCODE reflects the real compose exit code.
         # Write output to log file to avoid ForEach-Object pipeline hang on failure.
@@ -808,22 +814,29 @@ if ($dryRun) {
             $_buildServices += "privacy-shield"
         }
         if ($enableComfyui) { $_buildServices += "comfyui" }
-        Write-AI "Rebuilding local-built images (no-cache)..."
         $_buildLog = Join-Path $_composeLogDir "compose-build.log"
         "" | Out-File -FilePath $_buildLog -Encoding ascii
-        foreach ($_svc in $_buildServices) {
-            Write-AI "  building $_svc ..."
-            & docker compose @composeFlags build --no-cache $_svc *>> $_buildLog
-            if ($LASTEXITCODE -ne 0) {
-                Write-AIWarn "$_svc build failed (non-fatal - see $_buildLog)"
-            }
-        }
-        Write-AISuccess "Local images rebuilt"
 
-        Write-AI "Starting services... this may take several minutes."
-        & docker compose @composeFlags up -d --remove-orphans --no-build *> $_composeLog
-        $composeExit = $LASTEXITCODE
-        $ErrorActionPreference = $prevEAP
+        Push-Location $installDir
+        try {
+            Write-AI "Rebuilding local-built images (no-cache)..."
+            foreach ($_svc in $_buildServices) {
+                Write-AI "  building $_svc ..."
+                & docker compose @composeFlags build --no-cache $_svc *>> $_buildLog
+                if ($LASTEXITCODE -ne 0) {
+                    Write-AIWarn "$_svc build failed (non-fatal - see $_buildLog)"
+                }
+            }
+            Write-AISuccess "Local images rebuilt"
+
+            Write-AI "Starting services... this may take several minutes."
+            & docker compose @composeFlags up -d --remove-orphans --no-build *> $_composeLog
+            $composeExit = $LASTEXITCODE
+        }
+        finally {
+            Pop-Location
+            $ErrorActionPreference = $prevEAP
+        }
         # Show tail of compose output for immediate feedback
         if (Test-Path $_composeLog) {
             Get-Content $_composeLog -Tail 20 | ForEach-Object { Write-Host "  $_" }

--- a/dream-server/installers/windows/phases/01-preflight.ps1
+++ b/dream-server/installers/windows/phases/01-preflight.ps1
@@ -176,17 +176,49 @@ if ($_fsNetworked) {
 
 # ── Docker Desktop file-sharing allowlist check ──────────────────────────────
 # Bind-mounting a path outside the Docker Desktop file-sharing list fails at
-# `docker compose up` with a cryptic OCI error. Probe with a throwaway alpine
+# `docker compose up` with a cryptic OCI error. Probe with a throwaway Alpine
 # container so we surface a clear message before any compose work starts.
+# Pull the probe image first so a missing image/network problem is not reported
+# as a Docker Desktop file-sharing problem.
 $_shareOk = $true
 $_shareErr = ""
+$_probeImage = "alpine:3.20"
 try {
+    & docker image inspect $_probeImage *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-AI "Downloading Docker bind-mount probe image ($_probeImage)..."
+        $_pullOut = & docker pull $_probeImage 2>&1
+        $_pullExit = $LASTEXITCODE
+        if ($_pullExit -ne 0) {
+            Write-AIError "Docker could not download $_probeImage, which is required for the file-sharing probe."
+            Write-AI "  Start Docker Desktop, confirm it has internet access, then run:"
+            Write-AI "  docker pull $_probeImage"
+            Write-AI "  Re-run this installer after the pull succeeds."
+            if ($_pullOut) {
+                Write-AI "  Pull output:"
+                ($_pullOut -join "`n") -split "`n" | ForEach-Object { Write-Host "    $_" }
+            }
+            exit 1
+        }
+    }
+
     # PowerShell -v argument needs careful quoting for paths with spaces.
-    $_probeOut = & docker run --rm -v "${_fsProbe}:/check:ro" alpine true 2>&1
+    $_probeOut = & docker run --rm -v "${_fsProbe}:/check:ro" $_probeImage true 2>&1
+    $_probeExit = $LASTEXITCODE
     $_probeText = ($_probeOut -join "`n")
-    if ($_probeText -match "not shared from the host|Mounts denied|file sharing|filesharing") {
+    if ($_probeExit -ne 0 -and $_probeText -match "not shared from the host|Mounts denied|file sharing|filesharing") {
         $_shareOk = $false
         $_shareErr = $_probeText
+    } elseif ($_probeExit -ne 0) {
+        Write-AIError "Docker bind-mount probe failed before compose startup."
+        Write-AI "  This probe uses $_probeImage to verify Docker can mount:"
+        Write-AI "  $installDir"
+        Write-AI "  Confirm Docker Desktop is running, WSL2 backend is enabled, and $_probeImage is downloaded."
+        if ($_probeText) {
+            Write-AI "  Probe output:"
+            $_probeText -split "`n" | ForEach-Object { Write-Host "    $_" }
+        }
+        exit 1
     }
 } catch {
     $_shareOk = $false
@@ -196,6 +228,7 @@ if (-not $_shareOk) {
     Write-AIError "Docker Desktop cannot bind-mount $installDir."
     Write-AIError "Add the path to Docker Desktop > Settings > Resources > File Sharing,"
     Write-AIError "apply, then re-run this installer."
+    Write-AI "  The probe image ($_probeImage) is already available; this is a file-sharing path issue."
     if ($_shareErr) {
         Write-AI "  Probe output:"
         $_shareErr -split "`n" | ForEach-Object { Write-Host "    $_" }

--- a/dream-server/tests/test-windows-compose-failure-report.sh
+++ b/dream-server/tests/test-windows-compose-failure-report.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DIAG_LIB="$ROOT_DIR/installers/windows/lib/compose-diagnostics.ps1"
 INSTALL_PS1="$ROOT_DIR/installers/windows/install-windows.ps1"
+PRE_SCRIPT="$ROOT_DIR/installers/windows/phases/01-preflight.ps1"
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -36,6 +37,7 @@ echo ""
 
 [[ -f "$DIAG_LIB" ]] && pass "compose diagnostics library exists" || fail "compose diagnostics library missing"
 [[ -f "$INSTALL_PS1" ]] && pass "Windows installer exists" || fail "Windows installer missing"
+[[ -f "$PRE_SCRIPT" ]] && pass "Windows preflight phase exists" || fail "Windows preflight phase missing"
 
 check 'function Write-DreamComposeFailureReport' "$DIAG_LIB" "report writer function exists"
 check 'install-report-$stamp.txt' "$DIAG_LIB" "report uses install-report timestamp path"
@@ -47,6 +49,13 @@ check '[switch]$SaveReport' "$DIAG_LIB" "diagnostics only save report when reque
 check '-ComposeLogPath $_composeLog' "$INSTALL_PS1" "installer passes compose log to diagnostics"
 check '-ComposeArgs @("up", "-d", "--remove-orphans", "--no-build")' "$INSTALL_PS1" "installer passes exact compose up args"
 check '-SaveReport' "$INSTALL_PS1" "installer enables saved report on compose failure"
+check 'Compose working directory: $installDir' "$INSTALL_PS1" "installer logs compose working directory"
+check 'Push-Location $installDir' "$INSTALL_PS1" "installer runs compose build/up from install dir"
+check 'Join-Path $installDir $cfPath' "$INSTALL_PS1" "installer validates relative compose files under install dir"
+check '$_probeImage = "alpine:3.20"' "$PRE_SCRIPT" "preflight uses pinned Alpine probe image"
+check 'docker pull $_probeImage' "$PRE_SCRIPT" "preflight pulls missing probe image before bind-mount test"
+check 'Docker could not download $_probeImage' "$PRE_SCRIPT" "preflight reports Alpine pull failure separately"
+check 'The probe image ($_probeImage) is already available; this is a file-sharing path issue.' "$PRE_SCRIPT" "preflight separates file sharing from image availability"
 
 if grep -q "Write-DreamComposeDiagnostics .*SaveReport" "$ROOT_DIR/installers/windows/dream.ps1"; then
     fail "dream.ps1 command failures should not create install reports by default"


### PR DESCRIPTION
## Summary

Fixes two Windows first-time install failures reported by users:

- Docker Desktop file-sharing preflight could blame File Sharing when the real issue was that the Alpine probe image was not downloaded.
- `docker compose` could complain that `.env` was missing because the installer generated `.env` in the installed `dream-server` directory, but Compose could still run from the cloned `DreamServer` source directory.

## What changed

- Pins the Windows bind-mount probe image to `alpine:3.20`.
- Pulls the probe image before running the bind-mount test.
- Shows a clear recovery message when Docker cannot download the probe image:
  - `docker pull alpine:3.20`
- Keeps Docker Desktop File Sharing errors separate from image/network errors.
- Validates relative compose file paths against the installed DreamServer directory.
- Runs install-time `docker compose build` and `docker compose up` from `$installDir`, where `.env` and compose files actually live.
- Logs the Compose working directory for easier support.
- Updates the Windows troubleshooting guide.
- Extends the Windows compose failure regression test.

## Why

A user can have the correct folder shared in Docker Desktop and still fail the bind-mount probe if Docker has not pulled Alpine yet. The previous error only pointed them to File Sharing, which sent them to the wrong fix.

Also, Windows users often run `.\install.ps1` from the cloned repo, while the installer creates the final runtime stack under `C:\Users\<user>\dream-server`. Compose should run from that installed directory so `.env` resolution is deterministic.

## Validation

- `bash -n dream-server/tests/test-windows-compose-failure-report.sh`
- `bash dream-server/tests/test-windows-compose-failure-report.sh`
- `bash dream-server/tests/test-windows-service-plan.sh`
- `bash dream-server/tests/test-windows-readiness-summary.sh`
- PowerShell parser check for:
  - `dream-server/installers/windows/phases/01-preflight.ps1`
  - `dream-server/installers/windows/install-windows.ps1`
- PSScriptAnalyzer error-level check for the same PowerShell files
- `git diff --check`