### PR TITLE
[codex] Add downstream builder guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,14 @@ Thanks for wanting to contribute. Dream Server is open source and we welcome hel
 
 No CLA, no hoops.
 
+## Forks and Custom Editions
+
+Building on Dream Server for a hardware appliance, lab image, vertical bundle,
+or downstream distribution? Start with
+**[dream-server/docs/BUILD-ON-DREAM-SERVER.md](dream-server/docs/BUILD-ON-DREAM-SERVER.md)**.
+It explains the extension points, source-of-truth files, validation commands,
+and rebase-friendly patterns that keep custom work easy to maintain.
+
 ## Full Contributor Guide
 
 For current priorities, validation checklists, PR expectations, and style guidelines, see the detailed guide:

--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 |---|---|
 | [Quickstart](dream-server/QUICKSTART.md) | Step-by-step install guide with troubleshooting |
 | [Docs Index](dream-server/docs/README.md) | Maintained map for operators, contributors, and reviewers |
+| [Build On Dream Server](dream-server/docs/BUILD-ON-DREAM-SERVER.md) | Forking, custom editions, extension templates, and downstream validation |
 | [Headless Setup](dream-server/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
 | [Model Management](dream-server/docs/MODEL-MANAGEMENT.md) | Dashboard model downloads, switching, and manual GGUF workflows |

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -426,6 +426,7 @@ dream mode status                        # Show current mode
 ## Documentation
 
 - [docs/README.md](docs/README.md) — **Full documentation index** (start here)
+- [BUILD-ON-DREAM-SERVER.md](docs/BUILD-ON-DREAM-SERVER.md) — Forking, custom editions, extension templates, and downstream validation
 - [QUICKSTART.md](QUICKSTART.md) — Detailed setup guide
 - [HEADLESS-SETUP.md](docs/HEADLESS-SETUP.md) — QR onboarding, first-boot setup, AP mode, mDNS, and local agent access
 - [MODEL-MANAGEMENT.md](docs/MODEL-MANAGEMENT.md) — Dashboard model downloads, switching, and manual GGUF use

--- a/dream-server/docs/BUILD-ON-DREAM-SERVER.md
+++ b/dream-server/docs/BUILD-ON-DREAM-SERVER.md
@@ -1,0 +1,219 @@
+# Build On Dream Server
+
+This guide is for people who want to fork Dream Server, ship a custom edition,
+build a hardware appliance, or add services without fighting the upstream repo.
+
+Dream Server is designed to be extended through isolated service directories,
+compose overlays, versioned manifests, and installer libraries. The safest path
+is to keep custom work in those extension points and avoid patching generated
+runtime files directly.
+
+## What You Can Build
+
+Good downstream shapes include:
+
+- a research workstation with curated models, notebooks, and document tools
+- a small-business private AI box with local chat, RAG, search, and workflows
+- a school, lab, or nonprofit edition with a fixed service set and onboarding
+- a hardware-specific image for NVIDIA, AMD Strix Halo, Apple Silicon, or Intel Arc
+- a minimal local chat distribution with most optional services disabled
+- a vertical edition with custom n8n workflows, prompts, templates, and services
+
+Start with an extension or overlay when possible. Fork the installer only when
+you need to change hardware detection, install phases, generated config, or
+platform-specific runtime behavior.
+
+## The Preferred Extension Path
+
+Use this path when you are adding a Docker service, exposing a new feature tile,
+or wiring another tool into the local stack.
+
+1. Copy the service templates from `extensions/templates/`.
+2. Create `extensions/services/<your-service>/`.
+3. Add `manifest.yaml` and `compose.yaml`.
+4. Add GPU overlays only when the service needs backend-specific runtime flags.
+5. Run the extension audit and compose checks before opening a PR.
+
+Useful starting files:
+
+- `extensions/templates/service-template.yaml`
+- `extensions/templates/compose-template.yaml`
+- `extensions/templates/compose-gpu-swap.yaml`
+- `extensions/templates/compose-gpu-only.yaml`
+- `extensions/templates/dashboard-plugin-template.js`
+
+The core contract is simple: a service manifest describes what the service is,
+and a compose fragment describes how it runs. The registry, CLI, dashboard,
+health checks, and compose resolver discover the service from those files.
+
+## The Fork Path
+
+Use a fork when you want to publish a distinct downstream edition. Keep your
+changes easy to rebase by separating them from upstream-owned internals.
+
+Safe places to customize:
+
+- `extensions/services/<custom-service>/` for custom bundled services
+- `extensions/library/services/<custom-service>/` for optional catalog services
+- `extensions/templates/` for local starter patterns
+- `config/model-library.json` for curated model catalogs
+- `config/ports.json` for port policy changes
+- `.env.example` and docs for downstream defaults
+- dashboard branding and theme files when the edition needs a distinct product surface
+- installer flags and presets when you need a different default service bundle
+
+Be careful with:
+
+- generated `.env` output
+- generated runtime configs for LiteLLM, Hermes, OpenCode, Perplexica, and Lemonade
+- platform-specific installer phases
+- base compose files shared by every install path
+- service IDs, aliases, and ports used by existing manifests
+
+Do not patch files under `data/` as source files. Treat them as runtime state.
+
+## Source Of Truth Map
+
+| Area | Source of truth | Notes |
+|------|-----------------|-------|
+| Bundled service metadata | `extensions/services/*/manifest.yaml` | IDs, ports, aliases, categories, dependencies, health paths |
+| Optional extension catalog | `extensions/library/services/*/manifest.yaml` | Dashboard/library installables |
+| Manifest schema | `extensions/schema/service-manifest.v1.json` | Validate fields before relying on them |
+| Compose stack | `docker-compose.base.yml` plus overlays and extension compose files | Resolved by installer/compose helper paths |
+| Model catalog | `config/model-library.json` | Versioned installable model metadata |
+| Linux/macOS model selector | `scripts/select-model.py` | Reads the model catalog and hardware envelope |
+| Windows model selector | `installers/windows/lib/tier-map.ps1` | PowerShell selector backed by the same model catalog |
+| Hardware tier maps | `installers/lib/tier-map.sh`, `installers/macos/lib/tier-map.sh`, `installers/windows/lib/tier-map.ps1` | Keep platform behavior aligned when changing tiers |
+| Generated config contracts | `config/generated-config-contracts.json` | Documents which writers must stay in sync |
+| Installer phases | `installers/phases/*`, `installers/macos/install-macos.sh`, `installers/windows/*` | Change only the owning phase/library |
+| Docs index | `docs/README.md` | Link new operator/builder docs here |
+
+## Generated Config Rule
+
+If you change a runtime setting, find every writer before shipping. The same
+setting may be written during Linux install, macOS install, Windows install,
+bootstrap upgrade, and host-agent activation.
+
+Run:
+
+```bash
+python scripts/validate-generated-configs.py
+```
+
+If the contract fails, update the writer map or the expected generated output
+alongside your code change.
+
+## Extension Compatibility Contract
+
+For minor releases, downstream extensions should keep working when they:
+
+- use `schema_version: dream.services.v1`
+- keep service IDs unique and lowercase
+- declare real health paths and container names
+- avoid alias and port collisions
+- use `compose_file: compose.yaml` for Docker services
+- keep persistent state under `./data/<service-id>/`
+- declare required secrets in `service.env_vars`
+- declare GPU support through `service.gpu_backends` and compose overlays
+- pass `scripts/audit-extensions.py`
+
+Anything that imports private shell functions, mutates generated files directly,
+or depends on a specific install phase ordering should be treated as an internal
+fork patch and rechecked on every upstream merge.
+
+## Keeping A Fork Rebase-Friendly
+
+Recommended downstream layout:
+
+```text
+extensions/services/your-service/
+extensions/library/services/your-library-service/
+docs/your-edition/
+config/your-edition-presets/
+```
+
+Recommended maintenance loop:
+
+```bash
+git fetch upstream
+git switch your-edition-main
+git merge upstream/main
+python scripts/audit-extensions.py --project-dir .
+python scripts/validate-generated-configs.py
+python scripts/validate-golden-paths.py
+git diff --check
+```
+
+For larger forks, keep a `DOWNSTREAM.md` in your fork that lists:
+
+- changed defaults
+- added services
+- removed services
+- hardware assumptions
+- files intentionally patched from upstream
+- validation commands used after each upstream merge
+
+## Validation Checklist
+
+For docs-only or template changes:
+
+```bash
+git diff --check
+python scripts/audit-extensions.py --project-dir .
+```
+
+For a new service extension:
+
+```bash
+python scripts/audit-extensions.py --project-dir . <service-id>
+python scripts/audit-extensions.py --project-dir .
+docker compose -f docker-compose.base.yml -f extensions/services/<service-id>/compose.yaml config
+```
+
+For generated config or installer behavior:
+
+```bash
+python scripts/validate-generated-configs.py
+python scripts/validate-golden-paths.py
+```
+
+For dashboard-facing behavior, also run the dashboard API and frontend tests
+from their service directories.
+
+## Example Downstream Editions
+
+Research workstation:
+
+- enable Open WebUI, LiteLLM, SearXNG, Qdrant, embeddings, Jupyter, and n8n
+- add notebook and paper-ingestion extensions
+- document model and storage requirements in `docs/your-edition/`
+
+Small-business private AI:
+
+- keep Hermes, RAG, search, backups, and dashboard health checks prominent
+- add prebuilt n8n workflows for email, CRM, and document handling
+- keep LAN exposure and invite flows documented
+
+Hardware appliance:
+
+- pin a known hardware class
+- keep a dated validation receipt for installer runs
+- document selected model, backend, driver versions, and expected ports
+
+Minimal local chat:
+
+- keep only core inference, Open WebUI, dashboard, and model management
+- disable optional services by default
+- keep the fork small and easy to merge upstream
+
+## PR Expectations For Builder Changes
+
+A good builder-facing PR should include:
+
+- the user story: who is building on Dream Server and what becomes easier
+- the files downstream authors should copy or edit
+- validation commands and their results
+- any compatibility promises or limits
+- links from `docs/README.md` and relevant feature docs
+
+When in doubt, add a template or example rather than another abstract paragraph.

--- a/dream-server/docs/EXTENSIONS.md
+++ b/dream-server/docs/EXTENSIONS.md
@@ -6,6 +6,7 @@
 |---|---|---|
 | Add a Docker service (new container, health check, dashboard tile) | Service extension | This guide (below) |
 | Change the installer itself (new tier, swap theme, add/skip phase) | Installer mod | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) |
+| Build a custom downstream edition or appliance | Fork / downstream build | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) |
 
 This guide is the fastest path to extend Dream Server without editing core internals.
 
@@ -39,13 +40,13 @@ extensions/services/
 
 ```bash
 mkdir extensions/services/my-service
+cp extensions/templates/service-template.yaml extensions/services/my-service/manifest.yaml
+cp extensions/templates/compose-template.yaml extensions/services/my-service/compose.yaml
 ```
+
+The commented starter files live in [`extensions/templates/`](../extensions/templates/README.md).
 
 ### Step 2: Create the manifest
-
-```bash
-cp extensions/templates/service-template.yaml extensions/services/my-service/manifest.yaml
-```
 
 Edit the manifest:
 - set `service.id` to a unique kebab-case ID

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -19,6 +19,7 @@ at [`../../README.md`](../../README.md).
 | Change installer behavior | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md), [PREFLIGHT-ENGINE.md](PREFLIGHT-ENGINE.md) |
 | Change model routing | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | [MODE-SWITCH.md](MODE-SWITCH.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) |
 | Add or harden a service | [EXTENSIONS.md](EXTENSIONS.md) | [../extensions/CATALOG.md](../extensions/CATALOG.md), [../extensions/schema/README.md](../extensions/schema/README.md) |
+| Build a custom edition or fork | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) | [EXTENSIONS.md](EXTENSIONS.md), [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md), [../extensions/templates/README.md](../extensions/templates/README.md) |
 | Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [TESTING.md](TESTING.md), [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) |
 
 ## Current Truths
@@ -59,7 +60,9 @@ at [`../../README.md`](../../README.md).
 
 | Doc | Audience | Description |
 |-----|----------|-------------|
+| [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) | Downstream builders | Forking, custom editions, source-of-truth map, extension compatibility, and validation checklist |
 | [EXTENSIONS.md](EXTENSIONS.md) | Builders | Add Docker services, manifests, dashboard plugins |
+| [../extensions/templates/README.md](../extensions/templates/README.md) | Builders | Starter manifest, compose, GPU overlay, and dashboard plugin templates |
 | [../extensions/CATALOG.md](../extensions/CATALOG.md) | Builders / reviewers | Current bundled service manifest catalog |
 | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | Modders | Installer module map, mod recipes, header convention |
 | [INTEGRATION-GUIDE.md](INTEGRATION-GUIDE.md) | Developers | Connect apps via OpenAI SDK, LangChain, n8n |

--- a/dream-server/extensions/README.md
+++ b/dream-server/extensions/README.md
@@ -7,6 +7,8 @@ This directory contains all service extensions that ship with Dream Server. Each
 | Document | What it covers |
 |----------|----------------|
 | [Extension Authoring Guide](../docs/EXTENSIONS.md) | How to create a new extension: directory structure, manifest contract, compose patterns, GPU overlays, enable/disable mechanism, validation, and runtime lifecycle |
+| [Build On Dream Server](../docs/BUILD-ON-DREAM-SERVER.md) | How to fork Dream Server, ship a custom edition, keep changes rebase-friendly, and validate downstream changes |
+| [Extension Templates](templates/README.md) | Copy-ready manifest, compose, GPU overlay, and dashboard plugin starter files |
 | [Extension Catalog](CATALOG.md) | List of all bundled extensions with ports, categories, and GPU compatibility |
 | [Manifest Schema Reference](schema/README.md) | JSON Schema specification for `manifest.yaml` — all fields, types, and validation rules |
 | [Host Agent API](../docs/HOST-AGENT-API.md) | API contract for the host agent that starts/stops extension containers from outside Docker |
@@ -21,6 +23,11 @@ extensions/
   schema/
     service-manifest.v1.json  # JSON Schema for manifest validation
     README.md                 # Schema documentation
+  templates/
+    service-template.yaml      # Commented manifest starter
+    compose-template.yaml      # Commented compose starter
+    compose-gpu-swap.yaml      # CPU base + GPU image swap pattern
+    compose-gpu-only.yaml      # GPU-only overlay pattern
   services/
     <service-id>/
       manifest.yaml           # Service metadata (required)
@@ -36,6 +43,8 @@ Core services (llama-server, open-webui, dashboard, dashboard-api) only have a `
 ## Quick Links
 
 - **Add an extension**: [30-Minute Path](../docs/EXTENSIONS.md#30-minute-path-add-a-service)
+- **Build a custom edition**: [Build On Dream Server](../docs/BUILD-ON-DREAM-SERVER.md)
+- **Copy starter files**: [Extension Templates](templates/README.md)
 - **Validate manifests**: `bash scripts/validate-manifests.sh` or `dream config validate`
 - **Audit extensions**: `python3 scripts/audit-extensions.py --project-dir .`
 - **Enable/disable from CLI**: `dream enable <id>` / `dream disable <id>`

--- a/dream-server/extensions/templates/README.md
+++ b/dream-server/extensions/templates/README.md
@@ -1,0 +1,76 @@
+# Extension Templates
+
+These files are starter patterns for downstream builders and service authors.
+They are templates only; they are not loaded by the service registry until you
+copy them into `extensions/services/<your-service>/` and rename the manifest to
+`manifest.yaml`.
+
+## Files
+
+| Template | Use it when |
+|----------|-------------|
+| `service-template.yaml` | You need a commented `manifest.yaml` starting point |
+| `compose-template.yaml` | Your service has one normal Docker Compose definition |
+| `compose-gpu-swap.yaml` | Your service has a CPU base image and GPU-specific image tags |
+| `compose-gpu-only.yaml` | Your service only runs with a GPU and needs backend-specific compose files |
+| `dashboard-plugin-template.js` | Your service needs a dashboard plugin entry point |
+
+## Copy Path
+
+```bash
+mkdir -p extensions/services/my-service
+cp extensions/templates/service-template.yaml extensions/services/my-service/manifest.yaml
+cp extensions/templates/compose-template.yaml extensions/services/my-service/compose.yaml
+```
+
+Then edit:
+
+- `service.id`
+- `service.name`
+- `service.container_name`
+- `service.default_host`
+- `service.port`
+- `service.external_port_env`
+- `service.external_port_default`
+- `service.health`
+- `service.depends_on`
+- `service.env_vars`
+- feature IDs and required services
+- compose service name, image, ports, volumes, and healthcheck
+
+The manifest `service.id`, compose service key, `container_name`, and data
+directory should all use the same service identity.
+
+## Validation
+
+From the `dream-server/` directory:
+
+```bash
+python scripts/audit-extensions.py --project-dir . my-service
+python scripts/audit-extensions.py --project-dir .
+docker compose -f docker-compose.base.yml -f extensions/services/my-service/compose.yaml config
+git diff --check
+```
+
+If your service has GPU overlays, run compose config with the relevant platform
+overlay as well:
+
+```bash
+docker compose -f docker-compose.base.yml -f docker-compose.nvidia.yml \
+  -f extensions/services/my-service/compose.yaml \
+  -f extensions/services/my-service/compose.nvidia.yaml config
+```
+
+## Compatibility Notes
+
+Extensions are most stable when they:
+
+- keep persistent data under `./data/<service-id>/`
+- expose only the ports users need
+- declare secrets in `service.env_vars`
+- use healthchecks that work before login
+- avoid broad host filesystem mounts
+- avoid changing core service IDs or aliases
+
+For broader downstream guidance, read
+[`docs/BUILD-ON-DREAM-SERVER.md`](../../docs/BUILD-ON-DREAM-SERVER.md).


### PR DESCRIPTION
## Summary

- Adds `docs/BUILD-ON-DREAM-SERVER.md`, a practical downstream-builder guide for forks, appliances, custom editions, source-of-truth files, validation, and rebase-friendly maintenance.
- Adds `extensions/templates/README.md` so the existing manifest, compose, GPU overlay, and dashboard plugin templates are easier to copy correctly.
- Links the new builder path from the docs index, root README, product README, extension guide, extension README, and contributing guide.

## Why

Dream Server already has extension points and templates, but downstream builders had to infer the safest path by reading several docs and source directories. This PR gives fork authors a clear front door: what to customize, what to avoid patching directly, how to validate changes, and how to keep a fork mergeable with upstream.

## Validation

- `git diff --check HEAD~1 HEAD`
- `python scripts/audit-extensions.py --project-dir .`
- `python scripts/validate-generated-configs.py`
- `python scripts/validate-golden-paths.py`
- local markdown link check across the changed docs