### PR TITLE
fix(installer): harden python setup diagnostics

### DIFF
--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -157,6 +157,9 @@ if [[ -f "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh" ]]; then
     source "${SOURCE_ROOT}/installers/lib/compose-failure-report.sh"
 fi
 source "${SOURCE_ROOT}/lib/safe-env.sh"
+if [[ -f "${SOURCE_ROOT}/lib/python-cmd.sh" ]]; then
+    source "${SOURCE_ROOT}/lib/python-cmd.sh"
+fi
 source "${SOURCE_ROOT}/installers/lib/readiness-summary.sh"
 
 # ── File-local helpers ──
@@ -224,6 +227,72 @@ _require_docker_cpu_budget() {
         exit 1
     fi
     ai_ok "Docker CPU budget: ${docker_ncpu} (>=${min_cpus} required for ${workload})"
+}
+
+_set_installer_python_cmd() {
+    local pycmd="$1"
+    export DREAM_PYTHON_CMD="$pycmd"
+    # python-cmd.sh caches the first runnable interpreter. Keep the cache aligned
+    # when this installer creates a private venv after the first detection.
+    if declare -p _ds_python_cmd_cached >/dev/null 2>&1; then
+        _ds_python_cmd_cached="$pycmd"
+    fi
+}
+
+_ensure_macos_pyyaml() {
+    local pycmd=""
+    if declare -f ds_detect_python_cmd >/dev/null 2>&1; then
+        pycmd="$(ds_detect_python_cmd 2>/dev/null || true)"
+    fi
+    if [[ -z "$pycmd" ]]; then
+        pycmd="$(command -v python3 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$pycmd" ]]; then
+        ai_err "python3 not available — required for compose resolver"
+        exit 1
+    fi
+
+    if "$pycmd" -c 'import yaml' >/dev/null 2>&1; then
+        _set_installer_python_cmd "$pycmd"
+        ai_ok "PyYAML available for $pycmd"
+        return 0
+    fi
+
+    ai "Installing PyYAML (required by compose resolver)..."
+    if "$pycmd" -m pip install --user --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$DS_LOG_FILE" >/dev/null \
+       && "$pycmd" -c 'import yaml' >/dev/null 2>&1; then
+        _set_installer_python_cmd "$pycmd"
+        ai_ok "PyYAML installed (python3 -m pip --user)"
+        return 0
+    fi
+
+    ai_warn "PyYAML install via --user failed; trying a private Dream Server installer venv."
+    local venv_dir="${INSTALL_DIR}/.installer-venv"
+    local venv_py="${venv_dir}/bin/python"
+    mkdir -p "$INSTALL_DIR"
+    if ! "$pycmd" -m venv "$venv_dir" 2>&1 | tee -a "$DS_LOG_FILE" >/dev/null; then
+        ai_err "Failed to create installer Python venv at $venv_dir."
+        ai "  Your Python may be missing the venv module."
+        ai "  Try: brew install python"
+        ai "  Then re-run this installer."
+        exit 1
+    fi
+
+    if "$venv_py" -m pip install --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$DS_LOG_FILE" >/dev/null \
+       && "$venv_py" -c 'import yaml' >/dev/null 2>&1; then
+        _set_installer_python_cmd "$venv_py"
+        ai_ok "PyYAML installed in private installer venv"
+        return 0
+    fi
+
+    ai_err "Failed to install PyYAML for the macOS installer."
+    ai "  Log file: $DS_LOG_FILE"
+    ai "  Manual recovery:"
+    ai "    $pycmd -m pip install --user pyyaml"
+    ai "  Or:"
+    ai "    $pycmd -m venv $venv_dir && $venv_py -m pip install pyyaml"
+    exit 1
 }
 
 # ── Resolve install directory ──
@@ -400,24 +469,7 @@ ai_ok "Disk space OK"
 # the system python; macOS does not. Without PyYAML, every extension install
 # fails at compose resolution with a cryptic "ModuleNotFoundError: No module
 # named 'yaml'" returned through the dashboard-api as state=error.
-if command -v python3 >/dev/null 2>&1; then
-    if python3 -c 'import yaml' >/dev/null 2>&1; then
-        ai_ok "PyYAML available"
-    else
-        ai "Installing PyYAML (required by compose resolver)..."
-        if python3 -m pip install --user --quiet --no-warn-script-location pyyaml 2>&1 | tee -a "$DS_LOG_FILE" >/dev/null \
-           && python3 -c 'import yaml' >/dev/null 2>&1; then
-            ai_ok "PyYAML installed (python3 -m pip --user)"
-        else
-            ai_err "Failed to install PyYAML for $(command -v python3)."
-            ai_err "Run manually: python3 -m pip install --user pyyaml"
-            exit 1
-        fi
-    fi
-else
-    ai_err "python3 not available — required for compose resolver"
-    exit 1
-fi
+_ensure_macos_pyyaml
 
 # Ollama conflict detection
 check_ollama_conflict

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -28,6 +28,12 @@
 dream_progress 38 "directories" "Preparing installation directory"
 chapter "SETTING UP INSTALLATION"
 
+_phase06_step() {
+    local step="$1"
+    export INSTALL_PHASE="06-directories/${step}"
+    log "Phase 06 step: ${step}"
+}
+
 if $DRY_RUN; then
     log "[DRY RUN] Would create: $INSTALL_DIR/{config,data,models}"
     log "[DRY RUN] Would copy compose files ($COMPOSE_FLAGS) and source tree"
@@ -38,6 +44,7 @@ if $DRY_RUN; then
     log "[DRY RUN] Would validate .env against schema"
 else
     # Create directories
+    _phase06_step "create-directories"
     dream_progress 38 "directories" "Creating directory structure"
     mkdir -p "$INSTALL_DIR"/{config,data,models}
     mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield,ape,token-spy,hermes}
@@ -75,6 +82,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     fi
 
     # Copy entire source tree to install dir (skip if same directory)
+    _phase06_step "copy-source"
     dream_progress 39 "directories" "Copying source files"
     if [[ "$SCRIPT_DIR" != "$INSTALL_DIR" ]]; then
         ai "Copying source files to $INSTALL_DIR..."
@@ -117,6 +125,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     # files. Delete only the retired service code so stale compose files cannot
     # be picked up; preserve data/dreamforge for users who want to archive it.
     _retired_dreamforge_dir="$INSTALL_DIR/extensions/services/dreamforge"
+    _phase06_step "prune-retired-services"
     if [[ -d "$_retired_dreamforge_dir" ]]; then
         rm -rf "$_retired_dreamforge_dir"
         log "Removed retired DreamForge service files from extensions/services"
@@ -129,6 +138,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     # Without one of these paths, dashboard-api's /api/extensions/{id}/install
     # endpoint returns 503 "Extensions library is unavailable" and the
     # dashboard's Extensions page is non-functional.
+    _phase06_step "copy-extensions-library"
     _ext_lib_src=""
     for _candidate in \
         "$SCRIPT_DIR/extensions/library/services" \
@@ -146,6 +156,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     fi
 
     # Select tier-appropriate OpenClaw config
+    _phase06_step "configure-legacy-openclaw"
     if [[ "$ENABLE_OPENCLAW" == "true" && -n "$OPENCLAW_CONFIG" ]]; then
         OPENCLAW_MODEL="$LLM_MODEL"
         OPENCLAW_CONTEXT=$MAX_CONTEXT
@@ -212,9 +223,11 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     fi
 
     # token-spy container runs as uid 1000 (baked in Dockerfile) — fix ownership
+    _phase06_step "prepare-service-permissions"
     chown -R 1000:1000 "$INSTALL_DIR/data/token-spy" || warn "Failed to chown data/token-spy to 1000:1000 (non-fatal); container may crash if installer ran as a different uid"
 
     # ── .env merge logic: preserve user-configured values on re-install ──
+    _phase06_step "generate-env"
     dream_progress 40 "directories" "Generating secrets and configuration"
     # If an existing .env exists, read user-editable values so we don't
     # destroy API keys, custom ports, or manually-set secrets.
@@ -638,6 +651,7 @@ ENV_EOF
     # requests to the concrete model ID that lemonade actually serves.
     # bootstrap-upgrade.sh regenerates this config when the model swaps.
     if [[ "$GPU_BACKEND" == "amd" ]]; then
+        _phase06_step "render-amd-litellm-config"
         mkdir -p "$INSTALL_DIR/config/litellm"
         # Source bootstrap-model.sh for BOOTSTRAP_GGUF_FILE and bootstrap_needed().
         # Pure library (zero side effects), all deps available by phase 06.
@@ -715,6 +729,7 @@ LITELLM_EOF
     fi
 
     # Validate generated .env against schema (fails fast on missing/unknown keys).
+    _phase06_step "validate-env"
     dream_progress 41 "directories" "Validating configuration"
     if [[ -f "$SCRIPT_DIR/scripts/validate-env.sh" && -f "$SCRIPT_DIR/.env.schema.json" ]]; then
         if bash "$SCRIPT_DIR/scripts/validate-env.sh" "$INSTALL_DIR/.env" "$SCRIPT_DIR/.env.schema.json" >> "$LOG_FILE" 2>&1; then
@@ -728,6 +743,7 @@ LITELLM_EOF
 
     # Generate SearXNG config with randomized secret key
     # Fix ownership from previous container runs (SearXNG writes as uid 977)
+    _phase06_step "generate-searxng-config"
     mkdir -p "$INSTALL_DIR/config/searxng"
     if [[ -f "$INSTALL_DIR/config/searxng/settings.yml" ]] && ! [[ -w "$INSTALL_DIR/config/searxng/settings.yml" ]]; then
         sudo chown "$(id -u):$(id -g)" "$INSTALL_DIR/config/searxng/settings.yml" 2>/dev/null || true

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -305,10 +305,16 @@ result=$(_classify_id "0xFFFF" "Unknown GPU" amd 8192)
   || { echo "[FAIL] unknown GPU crashed"; exit 1; }
 
 echo "[contract] macOS compose resolver installs PyYAML into checked python3"
-grep -q "python3 -c 'import yaml'" installers/macos/install-macos.sh \
-  || { echo "[FAIL] macOS installer does not verify PyYAML with python3"; exit 1; }
-grep -q 'python3 -m pip install --user .*pyyaml' installers/macos/install-macos.sh \
-  || { echo "[FAIL] macOS installer must install PyYAML via python3 -m pip, not a possibly unrelated pip3"; exit 1; }
+grep -q '_ensure_macos_pyyaml' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer does not use the PyYAML readiness helper"; exit 1; }
+grep -q 'python-cmd.sh' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer does not load the shared Python resolver"; exit 1; }
+grep -q '\$pycmd" -c '\''import yaml'\''' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer does not verify PyYAML with the selected Python"; exit 1; }
+grep -q '\$pycmd" -m pip install --user .*pyyaml' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must install PyYAML through the selected Python, not a possibly unrelated pip"; exit 1; }
+grep -q 'export DREAM_PYTHON_CMD' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer does not export the selected Python for resolver scripts"; exit 1; }
 
 echo "[contract] Hermes context defaults are installer-wide"
 bash tests/test-installer-context-parity.sh

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -58,6 +58,22 @@ fi
 assert_contains "$missing_yaml_err" 'PyYAML is required' "resolver did not explain PyYAML requirement"
 assert_contains "$missing_yaml_err" 'conda deactivate' "resolver did not include Conda/venv recovery hint"
 
+echo "[contract] macOS PyYAML install falls back to private installer venv"
+macos_installer="installers/macos/install-macos.sh"
+assert_contains "$macos_installer" '_ensure_macos_pyyaml' "macOS installer missing PyYAML helper"
+assert_contains "$macos_installer" 'python-cmd.sh' "macOS installer does not load python command resolver"
+assert_contains "$macos_installer" 'python3 -m pip --user' "macOS installer no longer tries user-site PyYAML first"
+assert_contains "$macos_installer" '\.installer-venv' "macOS installer missing private venv fallback"
+assert_contains "$macos_installer" 'export DREAM_PYTHON_CMD' "macOS installer does not export selected Python"
+assert_contains "$macos_installer" '_ds_python_cmd_cached=' "macOS installer does not refresh python resolver cache"
+
+echo "[contract] Linux phase 06 reports substeps on failure"
+phase06="installers/phases/06-directories.sh"
+assert_contains "$phase06" 'export INSTALL_PHASE="06-directories/\$\{step\}"' "phase 06 missing substep INSTALL_PHASE updates"
+for step in create-directories copy-source copy-extensions-library generate-env validate-env generate-searxng-config; do
+  assert_contains "$phase06" "_phase06_step \"$step\"" "phase 06 missing substep: $step"
+done
+
 echo "[contract] ds_sudo uses sudo -n in non-interactive mode"
 fakebin="$tmpdir/fakebin"
 mkdir -p "$fakebin"


### PR DESCRIPTION
## Summary

Hardens macOS/Linux installer setup around Python dependencies and phase 6 diagnostics.

## What changed

- macOS PyYAML setup now uses the shared Python resolver when available.
- If `python3 -m pip install --user pyyaml` fails, the installer falls back to a private installer venv at `.installer-venv`.
- The selected Python is exported through `DREAM_PYTHON_CMD` so later resolver/config scripts use the interpreter that can actually import `yaml`.
- Linux phase 6 now records substeps in `INSTALL_PHASE`, making failures point to the exact setup area instead of only `06-directories`.

## Why

A macOS install can fail when user-site pip installs are blocked or unavailable. Previously that stopped the installer with a generic PyYAML failure.

On Linux/Ubuntu, phase 6 is large. If a command exits under `set -e`, users only see that phase 6 failed, which makes support hard. Substep labels make failures actionable.

## Validation

- `bash -n dream-server/install-core.sh dream-server/installers/macos/install-macos.sh dream-server/installers/phases/06-directories.sh`
- `bash dream-server/tests/contracts/test-installer-hardening.sh`
- `python dream-server/tests/test-runtime-config-wiring.py`
- `git diff --check`

Note: full `test-installer-contracts.sh` could not run in this local shell because `jq` is unavailable.