### PR TITLE
[codex] update security audit status

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -1,253 +1,102 @@
-# DreamServer Security Audit
-**Analyst:** latentcollapse
-**Date:** 2026-03-08
-**Scope:** `Light-Heart-Labs/DreamServer` public repository, local clone only — no live infrastructure touched
-**Tools:** gitleaks 8.x, bandit 1.9.4, semgrep (auto config), shellcheck, manual review
-**Method:** Passive static analysis. Apache 2.0 license permits full code audit.
-
----
-
-## Summary
-
-| Severity | Count |
-|----------|-------|
-| Critical | 1 |
-| High | 3 |
-| Medium | 5 |
-| Low | 2 |
-
-The Critical finding should be addressed immediately — format-valid credentials traced to the founder's home path have been sitting in a public repository since the voice agent framework was committed. All other findings are fixable in a normal development cycle.
-
----
-
-## CRITICAL
-
-### C1 — Likely real LiveKit credentials committed to public repo
-
-**Historical file:** legacy voice-agent framework token server, removed from the maintained product tree
-**Detected by:** gitleaks (generic-api-key)
-
-```python
-API_KEY    = 'APIRUdt****'
-API_SECRET = 'bTpgs0****'
-```
-
-The file header reads `Deploy to: /home/michael/hvac-token-server.py`. The org contact on GitHub is `michael@lightheartlabs.com`. The credentials are format-valid:
-
-- `API_KEY` is 15 characters — matches LiveKit API key format
-- `API_SECRET` is 43 characters — matches LiveKit API secret format
-
-These are not placeholder values. They appear to be real LiveKit credentials belonging to the founder, committed as part of a voice agent reference implementation.
-
-**Impact:** Anyone with repo access can generate valid LiveKit JWT tokens, join or publish to any LiveKit room associated with this account, and potentially eavesdrop on or inject into live voice sessions.
-
-**Remediation:**
-1. Rotate the LiveKit API key and secret immediately at console.livekit.io
-2. Remove the historical file from git history with `git filter-repo` if the project chooses to rewrite public history
-3. Replace with environment variable references: `API_KEY = os.environ['LIVEKIT_API_KEY']`
-
----
-
-## HIGH
-
-### H1 — SearXNG static shared secret key
-
-**File:** `dream-server/config/searxng/settings.yml:3`
-**Detected by:** gitleaks (generic-api-key)
-
-```yaml
-secret_key: "9d0e105e00289d066f0532614b135e5df22eeb2b6e0228bd4c0a4426ae3f39f0"
-```
-
-Every DreamServer installation ships with this identical static secret. SearXNG uses `secret_key` for HMAC-signing session cookies and CSRF tokens. A user who has read this repo can forge valid session tokens on any DreamServer install that hasn't manually changed this value.
-
-**Impact:** Session forgery and CSRF bypass on all default installations.
-
-**Remediation:** Generate a unique secret during install (the installer already generates other secrets via `openssl rand`) and inject it into `settings.yml` at install time rather than shipping a static value in the repo.
-
----
-
-### H2 — `eval` on external script output creates command injection surface
-
-**Files:**
-- `dream-server/installers/lib/detection.sh:32` — `eval "$env_out"` (capability profile)
-- `dream-server/installers/lib/detection.sh:75` — `eval "$env_out"` (backend contract)
-- `dream-server/installers/macos.sh:81` — `eval "$PREFLIGHT_ENV"`
-- `dream-server/installers/phases/04-requirements.sh:38` — `eval "$PREFLIGHT_ENV"`
-
-The installer uses `eval "$env_out"` to source variables from `build-capability-profile.sh` → `classify-hardware.sh`. This pipeline ingests hardware metadata including GPU name (from nvidia-smi output). If a GPU name contains shell metacharacters — either from a malicious driver, a spoofed nvidia-smi binary earlier in `$PATH`, or a future code change that passes user input — the `eval` will execute arbitrary commands with the privileges of the user running the installer.
-
-**Impact:** Privilege escalation / arbitrary code execution during install on any system where the hardware detection pipeline can be influenced.
-
-**Remediation:** Replace `eval` with a parser that only accepts `KEY=value` lines matching a strict allowlist of expected variable names. Example:
-```bash
-while IFS='=' read -r key value; do
-    case "$key" in
-        CAP_PLATFORM_ID|CAP_GPU_VENDOR|CAP_RECOMMENDED_TIER|...)
-            printf -v "$key" '%s' "$value" ;;
-    esac
-done <<< "$env_out"
-```
-
----
-
-### H3 — OpenClaw `dangerouslyDisableDeviceAuth` + `0.0.0.0` binding (upstream)
-
-**Files:**
-- `dream-server/config/openclaw/openclaw.json:47-55`
-- `dream-server/config/openclaw/openclaw-strix-halo.json:47-55`
-- `dream-server/extensions/services/openclaw/compose.yaml:16,23`
-
-Three dangerous flags are active simultaneously in the default config:
-
-```json
-"gateway": {
-    "host": "0.0.0.0",
-    "controlUi": {
-        "allowInsecureAuth": true,
-        "dangerouslyDisableDeviceAuth": true,
-        "dangerouslyAllowHostHeaderOriginFallback": true
-    }
-}
-```
-
-Combined with the Docker port mapping (`${OPENCLAW_PORT:-7860}:18789` — also binds to `0.0.0.0` by default) and the entrypoint flag `--bind lan`, this results in completely unauthenticated access to an agent framework with `exec`, `read`, `write`, and sub-agent spawning tools exposed to all network interfaces.
-
-Note: `--bind lan` in the entrypoint **overrides** the `host` field in the JSON config — both must be fixed together.
-
-**Impact:** Anyone on the local network (or internet, if port-forwarded) can run arbitrary commands on the host machine without any authentication.
-
-**Remediation (partially addressed in PR #67):**
-- `"host": "0.0.0.0"` → `"host": "127.0.0.1"` in both JSON configs ✓
-- `--bind lan` → `--bind localhost` in entrypoint ✓
-- Port binding → `127.0.0.1:${OPENCLAW_PORT:-7860}:18789` ✓
-- Follow-up needed: remove or gate `dangerouslyDisableDeviceAuth: true`
-
----
-
-## MEDIUM
-
-### M1 — SQL injection pattern in token-spy
-
-**File:** `dream-server/extensions/services/token-spy/db.py:77`
-**Detected by:** bandit (B608), semgrep (sqlalchemy-execute-raw-query)
-
-```python
-conn.execute(f"ALTER TABLE usage ADD COLUMN {col} {typedef}")
-```
-
-`col` and `typedef` are currently sourced from a hardcoded list, so this is not directly exploitable today. However the pattern is dangerous — any future refactor that passes externally-derived column names or type definitions here lands directly in a raw SQL string without parameterization. SQLite's `ALTER TABLE` does not support parameterized column names, but the value should at minimum be validated against a strict allowlist before interpolation.
-
-**Remediation:** Add an explicit allowlist check: `assert col in ALLOWED_COLS` before the execute, and `assert typedef in ALLOWED_TYPES`.
-
----
-
-### M2 — dashboard and token-spy containers running as root
-
-**Files:** `extensions/services/dashboard/Dockerfile`, `extensions/services/token-spy/Dockerfile`
-**Detected by:** semgrep (missing-user-entrypoint, missing-user)
-
-Neither Dockerfile contains a `USER` directive. Processes inside both containers run as root. The dashboard container is internet-facing (port 3001).
-
-**Impact:** If either container is compromised via a vulnerability in nginx, the React app, or the token-spy proxy, the attacker has root inside the container with full access to mounted volumes.
-
-**Remediation:**
-```dockerfile
-RUN addgroup -S dream && adduser -S dream -G dream
-USER dream
-```
-
----
-
-### M3 — Nginx H2C smuggling conditions
-
-**File:** `extensions/services/dashboard/nginx.conf:22`
-**Detected by:** semgrep (possible-nginx-h2c-smuggling)
-
-```nginx
-proxy_http_version 1.1;
-proxy_set_header Upgrade $http_upgrade;
-proxy_set_header Connection 'upgrade';
-```
-
-This combination creates known HTTP/2 cleartext (H2C) smuggling conditions. An attacker on the local network could potentially craft requests that bypass nginx's auth header injection and reach the dashboard-api backend directly, circumventing the `Authorization: Bearer` token.
-
-**Remediation:** Unless WebSocket upgrades are explicitly needed on the `/api/` path, change `Connection` to a static value: `proxy_set_header Connection "close";`
-
----
-
-### M4 — Voice agent WebSocket connection unencrypted
-
-**File:** `extensions/services/dashboard/src/hooks/useVoiceAgent.js:12`
-**Detected by:** semgrep (detect-insecure-websocket)
-
-```javascript
-const LIVEKIT_URL = import.meta.env.VITE_LIVEKIT_URL || `ws://${getHost()}:7880`
-```
-
-The fallback LiveKit URL uses `ws://` (unencrypted WebSocket). All voice audio is transmitted in cleartext when `VITE_LIVEKIT_URL` is not explicitly set.
-
-**Remediation:** Default to `wss://` and document that users need a valid TLS cert or self-signed cert accepted by the browser for local use.
-
----
-
-### M5 — `local` keyword used outside function scope *(addressed in PR #72)*
-
-**File:** `dream-server/installers/phases/11-services.sh:32-33`
-**Detected by:** shellcheck (SC2168, severity: error)
+# DreamServer Security Audit Status
+
+- **Original audit date:** 2026-03-08
+- **Original analyst:** latentcollapse
+- **Status review:** 2026-05-20
+- **Scope:** `Light-Heart-Labs/DreamServer` public repository, local clone only. No live infrastructure was touched.
+- **Current operator guide:** [`dream-server/SECURITY.md`](dream-server/SECURITY.md)
+
+This document tracks the remediation status of the March 2026 static security
+audit. It is not a live list of active vulnerabilities. Treat a finding as
+currently active only when its status says `Open` or `Needs confirmation`.
+
+The original audit used gitleaks 8.x, bandit 1.9.4, semgrep auto config,
+shellcheck, and manual review. The status review below was based on the current
+repository tree, targeted regression tests, and security-relevant docs.
+
+## Status Key
+
+| Status | Meaning |
+|--------|---------|
+| `Remediated in tree` | Current source or config contains the mitigation, with file or test evidence. |
+| `Mitigated / accepted local risk` | The behavior changed, but a local-only or operator-controlled residual risk remains by design. |
+| `Needs confirmation` | Repository state cannot prove the full remediation, usually because it requires an external secret rotation or live-site change. |
+| `External / out of repo` | The finding concerns infrastructure or web properties not represented in this repository. |
+
+## Current Summary
+
+| Original severity | Original count | Current status |
+|-------------------|----------------|----------------|
+| Critical | 1 | Code artifact is historical/removed from the maintained product tree; credential rotation still needs private confirmation. |
+| High | 3 | All three have current code/config mitigations and regression evidence. |
+| Medium | 5 | Four are remediated in tree; one is mitigated by HTTPS-aware behavior with local HTTP accepted. |
+| Low | 2 | One is remediated in tree; one concerns the external marketing site and is outside repository verification. |
+
+## Findings Status
+
+| ID | Original finding | Current status | Evidence / receipt | Remaining action |
+|----|------------------|----------------|--------------------|------------------|
+| C1 | Likely real LiveKit credentials committed to a historical voice-agent token server | Needs confirmation | The file is described as historical and removed from the maintained product tree. The repository cannot prove whether LiveKit credentials were rotated. | Security owner should keep a private incident record confirming key rotation and revocation. Do not publish unredacted credentials. |
+| H1 | SearXNG shipped a static shared `secret_key` | Remediated in tree | [`dream-server/config/searxng/settings.yml`](dream-server/config/searxng/settings.yml) now contains an installer placeholder; Linux and Windows installers generate `SEARXNG_SECRET`; [`dream-server/extensions/services/searxng/compose.yaml`](dream-server/extensions/services/searxng/compose.yaml) requires it. | Keep generated secrets out of committed config and support bundles. |
+| H2 | Installer used `eval` on helper script output | Remediated in tree | [`dream-server/lib/safe-env.sh`](dream-server/lib/safe-env.sh) provides non-evaluating parsers; maintained installer paths call `load_env_from_output`; [`dream-server/tests/test-safe-env.sh`](dream-server/tests/test-safe-env.sh) verifies command substitutions are not executed. | Keep docs and future scripts on `safe-env.sh`; avoid reintroducing `eval "$(...)"` examples. |
+| H3 | OpenClaw gateway combined disabled device auth with LAN binding | Remediated in tree | OpenClaw is deprecated and optional in [`dream-server/extensions/services/openclaw/manifest.yaml`](dream-server/extensions/services/openclaw/manifest.yaml); compose requires `OPENCLAW_TOKEN`; static configs set `dangerouslyDisableDeviceAuth` false; [`dream-server/tests/contracts/test-network-exposure-contracts.py`](dream-server/tests/contracts/test-network-exposure-contracts.py) keeps OpenClaw opt-in and token-gated. | Keep OpenClaw legacy-only; default users should use Hermes plus `hermes-proxy`. |
+| M1 | Token-spy SQL migration interpolated identifiers | Remediated in tree | [`dream-server/extensions/services/token-spy/db.py`](dream-server/extensions/services/token-spy/db.py) uses `ALLOWED_COLUMNS` and a safe SQL identifier regex before `ALTER TABLE`. | Preserve the allowlist if columns are made dynamic later. |
+| M2 | Dashboard and token-spy containers ran as root | Remediated in tree | [`dream-server/extensions/services/dashboard/Dockerfile`](dream-server/extensions/services/dashboard/Dockerfile) and [`dream-server/extensions/services/token-spy/Dockerfile`](dream-server/extensions/services/token-spy/Dockerfile) create and run as non-root users. | Keep new service Dockerfiles covered by extension audit and review. |
+| M3 | Dashboard nginx config had H2C smuggling conditions | Remediated in tree | [`dream-server/extensions/services/dashboard/nginx.conf`](dream-server/extensions/services/dashboard/nginx.conf) sets `proxy_set_header Connection "close"` on the API proxy path. | If WebSocket upgrade support is added to that path, re-review the proxy headers. |
+| M4 | Voice agent defaulted to unencrypted `ws://` | Mitigated / accepted local risk | [`dream-server/extensions/services/dashboard/src/hooks/useVoiceAgent.js`](dream-server/extensions/services/dashboard/src/hooks/useVoiceAgent.js) now derives `wss:` when the dashboard is served over HTTPS and `ws:` for local HTTP. [`dream-server/SECURITY.md`](dream-server/SECURITY.md) recommends TLS or VPN for network exposure. | Plain HTTP on localhost/LAN remains cleartext by design; use TLS or Tailscale/WireGuard for sensitive shared deployments. |
+| M5 | `local` was used outside function scope in installer service phase | Remediated in tree | Current [`dream-server/installers/phases/11-services.sh`](dream-server/installers/phases/11-services.sh) keeps `local` declarations inside functions. | Continue running shellcheck or installer contract tests on shell changes. |
+| L1 | CDN-loaded dashboard assets lacked Subresource Integrity | Remediated in tree | [`dream-server/extensions/services/dashboard/public/agents.html`](dream-server/extensions/services/dashboard/public/agents.html) and [`dream-server/extensions/services/dashboard/templates/index.html`](dream-server/extensions/services/dashboard/templates/index.html) include `integrity` and `crossorigin` on CDN assets. | Keep SRI hashes updated when CDN versions change. |
+| L2 | `dreamserver.ai` marketing site missed common security headers | External / out of repo | This repository does not contain the marketing-site hosting config, CDN config, or deployed headers. | Track separately with the website host/CDN owner; re-check with a live header scan before claiming fixed. |
+
+## Current Security Receipts
+
+These files and tests are the strongest in-repository evidence that the project
+has moved beyond the original audit findings:
+
+| Area | Receipt |
+|------|---------|
+| Operator posture | [`dream-server/SECURITY.md`](dream-server/SECURITY.md) documents localhost defaults, LAN tradeoffs, host-agent binding, TLS/VPN guidance, API gateway auth, and disclosure. |
+| Network exposure policy | [`dream-server/config/network-exposure-policy.json`](dream-server/config/network-exposure-policy.json) labels every host-facing or host-networked service with risk, LAN exposure, and auth expectations. |
+| Exposure contracts | [`dream-server/tests/contracts/test-network-exposure-contracts.py`](dream-server/tests/contracts/test-network-exposure-contracts.py) enforces Hermes internal-only behavior, `hermes-proxy` auth gating, OpenClaw deprecation/token gating, and LiteLLM auth. |
+| Safe env parsing | [`dream-server/lib/safe-env.sh`](dream-server/lib/safe-env.sh) and [`dream-server/tests/test-safe-env.sh`](dream-server/tests/test-safe-env.sh) replace shell `eval` ingestion for helper output and `.env` loading. |
+| Secret checks | [`dream-server/tests/test-secret-security.sh`](dream-server/tests/test-secret-security.sh) scans for hardcoded secrets, auth patterns, `.gitignore` coverage, and the token-spy SQL guard. |
+| Extension hardening | [`dream-server/scripts/audit-extensions.py`](dream-server/scripts/audit-extensions.py) rejects unsafe compose patterns for bundled and user extensions. |
+| Support bundle redaction | [`dream-server/docs/SUPPORT-BUNDLE.md`](dream-server/docs/SUPPORT-BUNDLE.md) documents redaction expectations before users share diagnostics. |
+
+## Residual Risks To Keep Visible
+
+- Secret rotation cannot be proven from git. The LiveKit finding needs a
+  private rotation record outside this public repository.
+- `--lan` and `BIND_ADDRESS=0.0.0.0` are operator-controlled exposure choices.
+  They are useful for headless devices and private networks, but they should be
+  paired with firewall rules, TLS, or a VPN.
+- Dream Server is still local-first. Public internet deployments need an
+  additional reverse proxy, TLS, rate limiting, and service-specific auth review.
+- Local HTTP voice traffic remains unencrypted unless HTTPS or a VPN is placed
+  in front of it.
+- External properties such as `dreamserver.ai` need their own security receipt
+  trail because this repository cannot validate deployed headers or CDN policy.
+
+## Verification Commands
+
+Use these from the repository root when updating this status page:
 
 ```bash
-local some_var=...   # line 32 — outside any function
-local other_var=...  # line 33 — outside any function
+python dream-server/tests/contracts/test-network-exposure-contracts.py
+bash dream-server/tests/test-safe-env.sh
+bash dream-server/tests/test-openclaw-device-auth-default.sh
+python dream-server/scripts/audit-extensions.py --project-dir dream-server
+git diff --check
 ```
 
-`local` is only valid inside functions. On bash this silently becomes a global variable; on strict POSIX shells (`dash`, `sh`) this is a syntax error and the installer will abort at this phase.
+If a command is skipped because a local dependency is unavailable, note that in
+the PR body rather than silently treating the receipt as current.
 
-**Remediation:** Remove `local` keyword or wrap the code block in a function.
+## Maintainer Checklist For Future Audit Updates
 
----
-
-## LOW
-
-### L1 — Missing Subresource Integrity (SRI) on CDN-loaded scripts
-
-**Files:** `extensions/services/dashboard/public/agents.html:7-9`, `extensions/services/dashboard/templates/index.html:7-9`
-**Detected by:** semgrep (missing-integrity)
-
-External scripts loaded from CDNs without `integrity` attributes. If the CDN is compromised or the resource URL is hijacked, malicious JavaScript executes in the dashboard context with full access to API tokens and service credentials.
-
-**Remediation:** Add `integrity="sha384-..."` and `crossorigin="anonymous"` to all CDN `<script>` and `<link>` tags.
-
----
-
-### L2 — Missing security headers on dreamserver.ai
-
-**Method:** Passive HTTP header inspection
-**Tool:** Python urllib
-
-The landing page at `dreamserver.ai` is missing all standard security headers:
-
-| Header | Status |
-|--------|--------|
-| `Strict-Transport-Security` | Missing |
-| `Content-Security-Policy` | Missing |
-| `X-Frame-Options` | Missing |
-| `X-Content-Type-Options` | Missing |
-| `Referrer-Policy` | Missing |
-| `Permissions-Policy` | Missing |
-
-Low severity for a static marketing page, but notable for a product whose core value proposition is security and privacy.
-
-**Remediation:** Add headers via Hostinger's CDN configuration or a `_headers` file (Netlify/Vercel-style). Five-minute fix.
-
----
-
-## Disclosure Notes
-
-- No live infrastructure was accessed. All findings are from static analysis of the public repository.
-- The LiveKit credential finding (C1) should be treated as a responsible disclosure. Recommend rotating before this report is shared publicly.
-- All other findings are standard code quality / security hygiene items appropriate for a public bug report or PR.
-
----
-
-*Report generated using ArchMCP red-team container (BlackArch Linux) + gitleaks, bandit, semgrep, shellcheck.*
+- Update the `Status review` date.
+- Keep original finding IDs stable so older discussions remain searchable.
+- Link to the code, config, test, or PR that proves each remediation.
+- Separate code remediation from external actions such as credential rotation.
+- Keep active risks in present tense and historical risks in past tense.
+- Prefer adding regression tests before marking a finding `Remediated in tree`.

--- a/dream-server/docs/BACKEND-CONTRACT.md
+++ b/dream-server/docs/BACKEND-CONTRACT.md
@@ -22,7 +22,9 @@ Each contract defines:
 Example:
 
 ```bash
-eval "$(scripts/load-backend-contract.sh --backend amd --env)"
+source lib/safe-env.sh
+BACKEND_ENV="$(scripts/load-backend-contract.sh --backend amd --env)"
+load_env_from_output <<< "$BACKEND_ENV"
 echo "$BACKEND_PUBLIC_HEALTH_URL $BACKEND_PROVIDER_URL"
 ```
 

--- a/dream-server/docs/CAPABILITY-PROFILE.md
+++ b/dream-server/docs/CAPABILITY-PROFILE.md
@@ -18,7 +18,9 @@ scripts/build-capability-profile.sh --output /tmp/dream-server-capabilities.json
 For shell-driven installers:
 
 ```bash
-eval "$(scripts/build-capability-profile.sh --env)"
+source lib/safe-env.sh
+CAPABILITY_ENV="$(scripts/build-capability-profile.sh --env)"
+load_env_from_output <<< "$CAPABILITY_ENV"
 ```
 
 This exports:

--- a/dream-server/docs/PREFLIGHT-ENGINE.md
+++ b/dream-server/docs/PREFLIGHT-ENGINE.md
@@ -49,6 +49,8 @@ scripts/preflight-engine.sh \
 For shell integration:
 
 ```bash
-eval "$(scripts/preflight-engine.sh --env ...)"
+source lib/safe-env.sh
+PREFLIGHT_ENV="$(scripts/preflight-engine.sh --env ...)"
+load_env_from_output <<< "$PREFLIGHT_ENV"
 echo "$PREFLIGHT_BLOCKERS $PREFLIGHT_WARNINGS $PREFLIGHT_CAN_PROCEED"
 ```

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -127,6 +127,7 @@ at [`../../README.md`](../../README.md).
 |-----|----------|-------------|
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | Contributors | How to contribute |
 | [../SECURITY.md](../SECURITY.md) | Everyone | Security guide and disclosure |
+| [../../SECURITY_AUDIT.md](../../SECURITY_AUDIT.md) | Maintainers / reviewers | Historical security audit with current remediation status and receipts |
 | [../CHANGELOG.md](../CHANGELOG.md) | Everyone | Version history |
 | [COMPOSABILITY-EXECUTION-BOARD.md](COMPOSABILITY-EXECUTION-BOARD.md) | Maintainers | Internal project tracking |
 | [OSS-LAUNCH-CHECKLIST.md](OSS-LAUNCH-CHECKLIST.md) | Maintainers | Open-source launch tasks |


### PR DESCRIPTION
## Summary

- Reframe `SECURITY_AUDIT.md` from a stale static report into a remediation-status ledger with current findings, evidence links, residual risks, and verification commands.
- Add the audit status doc to the docs index.
- Replace stale `eval "$(...)"` shell-integration examples with `safe-env.sh` / `load_env_from_output` usage in related technical docs.

## Why

The old audit still read like every March 2026 finding was live. The current repo has since hardened SearXNG secrets, safe env parsing, OpenClaw exposure, non-root containers, nginx proxy headers, SQL identifier validation, and SRI coverage. This PR turns that into clearer receipts while still calling out what cannot be proven from git, especially external credential rotation and marketing-site headers.

## Validation

- `git diff --check`
- `python dream-server/tests/contracts/test-network-exposure-contracts.py`
- `"C:\Program Files\Git\bin\bash.exe" dream-server/tests/test-safe-env.sh`
- `"C:\Program Files\Git\bin\bash.exe" dream-server/tests/test-openclaw-device-auth-default.sh`
- `python dream-server/scripts/audit-extensions.py --project-dir dream-server`
- Local markdown link check across changed docs
- Confirmed no changed Markdown docs still contain `eval "$(...)"` examples

## Notes

- `bash dream-server/tests/test-secret-security.sh` was attempted locally but timed out after 124s in this checkout, so it is not listed as a passing validation result.
