### PR TITLE
[codex] docs: publish fleet validation evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ If AI is becoming critical infrastructure, it shouldn’t be rented. Self-hostin
 >
 > **macOS:** Requires Apple Silicon (M1+) and Docker Desktop. llama-server runs natively with Metal GPU acceleration; all other services run in Docker.
 >
-> See the [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) for details.
+> See the [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) for supported
+> platform claims and the [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md)
+> for the real hardware fleet used to test those claims.
 
 ---
 
@@ -356,6 +358,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | [Build On Dream Server](dream-server/docs/BUILD-ON-DREAM-SERVER.md) | Forking, custom editions, extension templates, and downstream validation |
 | [Headless Setup](dream-server/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
+| [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) | Sanitized real-hardware fleet coverage and release-readiness evidence |
 | [Model Management](dream-server/docs/MODEL-MANAGEMENT.md) | Dashboard model downloads, switching, and manual GGUF workflows |
 | [Hardware Guide](dream-server/docs/HARDWARE-GUIDE.md) | What to buy, tier recommendations |
 | [FAQ](dream-server/FAQ.md) | Common questions and configuration |

--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -7,11 +7,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Sanitized real-hardware validation matrix documenting the fleet surface,
+  tested phases, release-readiness receipt, and current evidence boundaries.
 - AMD runtime diagnostics endpoint (`/api/gpu/amd-runtime`) reports Lemonade vs llama-server, host vs container, accelerator backend, and health from explicit installer state.
 - Explicit AMD inference env contract (`AMD_INFERENCE_RUNTIME`, `AMD_INFERENCE_BACKEND`, `AMD_INFERENCE_LOCATION`, `AMD_INFERENCE_PORT`) for Linux, Windows, and WSL/Docker Desktop installs.
 - AMD runtime capability metadata (`AMD_INFERENCE_SUPPORTED_BACKENDS`, `AMD_INFERENCE_RUNTIME_MODE`, `AMD_INFERENCE_MANAGED`) for dashboard diagnostics and `dream doctor`.
 
 ### Changed
+- Linked public support, testing, and platform-claim docs to the validation
+  matrix so release claims point at real hardware evidence.
 - Updated Dream Proxy and Hermes Proxy to `caddy:2.11.3-alpine`.
 - Centralized AMD Lemonade runtime metadata in `config/backends/amd.json` and aligned the Linux Docker image pin to `ghcr.io/lemonade-sdk/lemonade-server:v10.2.0`.
 

--- a/dream-server/docs/HEADLESS-SETUP.md
+++ b/dream-server/docs/HEADLESS-SETUP.md
@@ -15,16 +15,19 @@ The headless setup stack is implemented on `main` across the setup-card script,
 dashboard, dashboard API, host agent, mDNS announcer, AP-mode script, and Caddy
 proxy extensions.
 
-Status is **deployed in code, tested in pieces, and awaiting full end-to-end
-hardware validation** for a packaged appliance flow. In particular:
+Status is **deployed in code and partially validated on the real hardware
+fleet** for the LAN, mDNS, dashboard, magic-link, and Hermes access paths. The
+packaged appliance handoff still needs per-image validation because routers,
+Wi-Fi chipsets, AP-mode behavior, and client devices vary. In particular:
 
 - Magic-link generation, QR rendering, first-run state, and dashboard flows have
   unit/integration coverage.
 - Wi-Fi management is implemented for Linux hosts with NetworkManager / `nmcli`.
 - AP mode is available but intentionally disabled by default because it takes
   over a wireless interface.
-- mDNS plus `dream-proxy` provide the friendly LAN URLs, but local network
-  behavior should be validated on each hardware image and router environment.
+- mDNS plus `dream-proxy` provide the friendly LAN URLs. Fleet validation
+  covers representative LAN behavior, but each packaged hardware image should
+  still be validated on its target router/client environment.
 
 ## User Journey
 
@@ -93,5 +96,5 @@ Use this checklist for each target hardware profile:
 - AP mode is disabled by default because it is intentionally disruptive to a
   wireless interface.
 - mDNS behavior varies by client OS, router, VPN, and enterprise network policy.
-- The complete appliance flow still needs repeated end-to-end testing on target
-  packaged hardware.
+- The complete AP-mode appliance handoff still needs repeated end-to-end
+  testing on each target packaged hardware image.

--- a/dream-server/docs/PLATFORM-TRUTH-TABLE.md
+++ b/dream-server/docs/PLATFORM-TRUTH-TABLE.md
@@ -2,7 +2,10 @@
 
 Use this file as the canonical source for launch claims.
 
-Last updated: 2026-03-05
+Last updated: 2026-05-20
+
+For release evidence, pair this claim table with the sanitized
+[Validation Matrix](VALIDATION-MATRIX.md).
 
 | Platform path | Claim | Current level | Target | Evidence required before promoting |
 |---|---|---|---|---|
@@ -11,8 +14,8 @@ Last updated: 2026-03-05
 | Linux NVIDIA | CUDA/llama-server path | Tier B | — | Real install + model load + runtime/throughput checks |
 | Windows (Docker Desktop + WSL2) | Standalone installer with full runtime | Tier B | — | `.\install.ps1` real run + GPU detection + Docker compose up + health checks pass |
 | Windows via WSL2 | Delegated installer flow (Docker Desktop backend) | Tier B | — | Same as above. |
-| macOS Apple Silicon | Native Metal inference + Docker services | Tier B | — | `./install.sh` real run + chip detection + llama-server Metal healthy + 16/17 services online + health checks pass |
-| macOS Apple Silicon (release gates) | Installer MVP / experimental in manifest | Tier C | — | CI treats as Tier C for claim checks. |
+| macOS Apple Silicon | Native Metal inference + Docker services | Tier B | — | `./install.sh` real run + chip detection + llama-server Metal healthy + service health checks pass |
+| macOS Apple Silicon release evidence | Constrained and high-memory lab hosts | Tier B | — | Fleet smoke/post-install artifacts on the release candidate |
 
 ## Release language guardrails
 
@@ -22,4 +25,5 @@ Last updated: 2026-03-05
   - macOS support (Apple Silicon with Metal acceleration).
 - Not safe to claim now:
   - Full macOS runtime parity with Linux (ComfyUI not available on macOS — no GPU backend for image generation).
-  - macOS Tier A (needs broader hardware validation across M1/M2/M3/M4 variants).
+  - macOS Tier A across all Apple Silicon generations.
+  - Intel Arc Tier B without a release-candidate fleet run on the claimed Arc hardware.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -20,7 +20,7 @@ at [`../../README.md`](../../README.md).
 | Change model routing | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | [MODE-SWITCH.md](MODE-SWITCH.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) |
 | Add or harden a service | [EXTENSIONS.md](EXTENSIONS.md) | [../extensions/CATALOG.md](../extensions/CATALOG.md), [../extensions/schema/README.md](../extensions/schema/README.md) |
 | Build a custom edition or fork | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) | [EXTENSIONS.md](EXTENSIONS.md), [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md), [../extensions/templates/README.md](../extensions/templates/README.md) |
-| Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [TESTING.md](TESTING.md), [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) |
+| Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [TESTING.md](TESTING.md), [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
 
 ## Current Truths
 
@@ -123,6 +123,7 @@ at [`../../README.md`](../../README.md).
 | [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) | Operators | Post-install verification |
 | [KNOWN-GOOD-VERSIONS.md](KNOWN-GOOD-VERSIONS.md) | Operators | Tested image/version combos |
 | [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) | Developers | Platform feature matrix |
+| [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) | Operators / release reviewers | Sanitized real-hardware fleet coverage and release-readiness evidence |
 
 ## Project
 

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -6,6 +6,10 @@ Last updated: 2026-05-20
 
 **Linux, Windows, and macOS are fully supported. Intel Arc is experimental.**
 
+For the real hardware evidence behind these claims, see
+[VALIDATION-MATRIX.md](VALIDATION-MATRIX.md). The matrix is sanitized so it can
+be public without exposing private lab hostnames, LAN addresses, or paths.
+
 | Platform | Status | What you get today |
 |----------|--------|-------------------|
 | **Linux + AMD Strix Halo (ROCm)** | **Fully supported** | Complete install and runtime. Primary development platform. |
@@ -24,11 +28,11 @@ Last updated: 2026-05-20
 
 | Platform | GPU Path | Installer Tier | Notes |
 |---|---|---|---|
-| Linux (Ubuntu/Debian family) | NVIDIA (llama-server/CUDA) | Tier B | Installer path exists in `install-core.sh`; broader distro test matrix still pending |
-| Linux (Strix Halo / AMD unified memory) | AMD (Lemonade/ROCm) | Tier A | Primary managed path via `docker-compose.base.yml` + `docker-compose.amd.yml` |
+| Linux (Ubuntu/Debian family) | NVIDIA (llama-server/CUDA) | Tier B | Validated on real high-memory multi-GPU NVIDIA hardware; broader distro matrix continues in CI/distro testing |
+| Linux (Strix Halo / AMD unified memory) | AMD (Lemonade/ROCm) | Tier A | Primary managed path via `docker-compose.base.yml` + `docker-compose.amd.yml`; validated on real Strix Halo hardware |
 | Linux (Intel Arc A770/A750) | Intel SYCL (llama-server/oneAPI) | **Tier C** | `docker-compose.arc.yml`; builds llama.cpp from `intel/oneapi-basekit`; see [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) |
-| Windows (Docker Desktop + WSL2) | NVIDIA via Docker Desktop; AMD via host Vulkan runtime | Tier B | Standalone installer (`.\install.ps1`) with GPU auto-detection, Docker orchestration, health checks, and desktop shortcuts |
-| macOS (Apple Silicon) | Metal (native llama-server) | Tier B | Standalone installer (`./install.sh`) with chip detection, native Metal inference, Docker services, and LaunchAgent auto-start |
+| Windows (Docker Desktop + WSL2) | NVIDIA via Docker Desktop; AMD via host Vulkan runtime | Tier B | Standalone installer (`.\install.ps1`) with GPU auto-detection, Docker orchestration, health checks, and desktop shortcuts; Windows laptop fleet target tracks Docker Desktop/WSL2 evidence |
+| macOS (Apple Silicon) | Metal (native llama-server) | Tier B | Standalone installer (`./install.sh`) with chip detection, native Metal inference, Docker services, and LaunchAgent auto-start; validated on constrained and high-memory Apple Silicon lab hosts |
 
 ## GPU Tier Map
 
@@ -49,14 +53,14 @@ Last updated: 2026-05-20
 ## Current Truth
 
 - **Linux, Windows, and macOS are fully supported.**
-- Linux + NVIDIA is supported but needs broader validation and CI matrix coverage.
+- Linux + NVIDIA is supported and validated on real high-memory NVIDIA hardware; broader distro coverage continues through CI and distrobox/Ventoy testing.
 - Windows installs via `.\install.ps1` with Docker Desktop + WSL2 backend. Windows AMD local inference is host-managed and uses Vulkan today, either through legacy Lemonade Server or native `llama-server` fallback.
 - Windows native installer UX is Tier B (delegated via Docker Desktop + WSL2).
 - macOS installs via `./install.sh` — llama-server runs natively with Metal acceleration, all other services in Docker.
 - AMD runtime diagnostics are explicit: `.env` records runtime, location, selected backend, supported backends, and whether DreamServer manages the process. Lemonade's newer CLI/default port is documented upstream but is not the managed DreamServer path yet.
 - AMD discrete GPUs beyond the documented Strix Halo path should be treated as validation-required until the repo has tier/model benchmarks for that hardware.
 - **Intel Arc (SYCL) is Tier C / experimental.** The installer auto-detects and selects the correct compose overlay and tier. Runtime works on A770/A750 (Linux). ComfyUI and Whisper GPU acceleration are not yet available for Arc. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) for limitations.
-- For release gates (CI), macOS (Apple Silicon) is documented as Tier C (installer MVP) in manifest; SUPPORT-MATRIX table may show Tier B for user-facing status.
+- Release-readiness claims should cite a matching version/tag and a fleet receipt from [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md).
 - Version baselines for triage are in `docs/KNOWN-GOOD-VERSIONS.md`.
 
 ## Roadmap
@@ -72,12 +76,14 @@ Last updated: 2026-05-20
 ## Next Milestones
 
 1. Keep expanding the existing `matrix-smoke.yml` coverage with more real distro and GPU fixtures.
-2. Expand macOS test coverage across M1/M2/M3/M4 variants and RAM tiers.
-3. Promote macOS from Tier B to Tier A after broader real-hardware validation.
+2. Keep Windows laptop fleet evidence current for Docker Desktop/WSL2, NVIDIA mobile GPU, and Intel hybrid-GPU behavior.
+3. Expand macOS test coverage across more Apple Silicon generations and RAM tiers.
 4. Validate Intel Arc B580 (Battlemage 12 GB) on the `ARC` tier.
 5. Promote Intel Arc from Tier C to Tier B after A770 + B580 real-hardware validation.
 
 ## See also
+
+- [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) - real-hardware fleet coverage and release-readiness evidence.
 
 - [LINUX-PORTABILITY.md](LINUX-PORTABILITY.md) — Linux installer edge cases, `.env` validation, extension manifests.
 - [config/system-tuning/README.md](../config/system-tuning/README.md) — Performance tuning for AMD Strix Halo (GRUB, modprobe, sysctl, CPU governor settings).

--- a/dream-server/docs/TESTING.md
+++ b/dream-server/docs/TESTING.md
@@ -2,10 +2,44 @@
 
 Dream Server supports multiple Linux distributions. This guide covers how to test across distros efficiently.
 
+## Real Hardware Fleet Validation
+
+Dream Server also uses a private real-hardware fleet for release-readiness
+evidence. CI and distrobox are useful for fast installer logic checks, but the
+fleet is where fresh installs, Docker startup, GPU runtime behavior, dashboard
+flows, Hermes auth, model switching, extension install paths, and agent
+capabilities are exercised on real machines.
+
+The sanitized public coverage is maintained in
+[VALIDATION-MATRIX.md](VALIDATION-MATRIX.md). Release notes should cite the
+fleet run date, hardware classes covered, regression replay result, and any
+blocked, deferred, skipped, or not-run phases.
+
+Volunteer and community testers are important for broader distro, GPU, driver,
+and network coverage. Treat those reports as complementary breadth evidence;
+the fleet is the repeatable parallel gate that can run whenever code changes.
+
+Fleet phases currently include:
+
+- regression replay for previously fixed fleet bugs;
+- a constrained Apple Silicon smoke gate before parallel installs;
+- read-only preflight snapshots for OS, RAM, disk, Docker, firewall, ports, and
+  prior install state;
+- non-interactive fresh installs from the public bootstrap path;
+- core HTTP verification for dashboard-api, dashboard UI, llama-server, and
+  Hermes proxy;
+- dashboard model and extension flows;
+- Hermes magic-link auth and seeded chat checks;
+- Playwright dashboard UI checks;
+- agent capability probes for chat, web search, files, code, skills, and model
+  identity;
+- opt-in lifecycle checks for reinstall, restart, and doctor behavior.
+
 ## Quick Reference
 
 | Method | Speed | GPU Testing | Kernel Testing | Best For |
 |--------|-------|-------------|----------------|----------|
+| **Fleet harness** | 15-75 min | Yes | Yes | Release readiness on real heterogeneous hardware |
 | **Distrobox** | Instant (2s) | Yes | No | Daily dev, package manager validation |
 | **Ventoy USB** | 5-10 min boot | Yes | Yes | Weekly full-stack validation |
 | **CI Matrix** | Automatic | No | No | Every PR, syntax + detection checks |

--- a/dream-server/docs/VALIDATION-MATRIX.md
+++ b/dream-server/docs/VALIDATION-MATRIX.md
@@ -1,0 +1,103 @@
+# Dream Server Validation Matrix
+
+Last updated: 2026-05-20
+
+This page describes the real hardware and workflow coverage used to validate
+Dream Server between changes. It is intentionally sanitized: it publishes
+hardware classes, operating systems, GPU paths, and test phases without private
+hostnames, LAN addresses, usernames, or filesystem paths.
+
+## Hardware Surface
+
+| Test surface | OS family | Architecture | Accelerator path | Memory class | Fleet role |
+|---|---|---:|---|---:|---|
+| Linux NVIDIA workstation | Ubuntu 24.04 | x86_64 | Dual high-memory Blackwell CUDA GPUs | 90 GB+ VRAM per GPU | Primary multi-GPU CUDA install, dashboard, UI, and capability target |
+| Linux AMD unified-memory workstation | Ubuntu 24.04 | x86_64 | AMD Strix Halo / ROCm-Lemonade path | 120 GB+ unified | Primary AMD install/runtime validation target |
+| Linux NVIDIA unified-memory appliance | NVIDIA Ubuntu derivative | aarch64 | Grace Blackwell / CUDA path | 120 GB+ unified | ARM Linux + NVIDIA appliance validation target |
+| macOS constrained Apple Silicon | macOS | arm64 | Native Metal inference + Docker services | 16 GB unified | Smoke gate and tight-memory macOS validation target |
+| macOS high-memory Apple Silicon | macOS | arm64 | Native Metal inference + Docker services | 120 GB+ unified | Large-model macOS validation target |
+| Windows hybrid GPU laptop | Windows 11 + Docker Desktop/WSL2 | x86_64 | NVIDIA mobile GPU plus Intel Arc integrated GPU | 32 GB+ system RAM | Windows installer, Docker Desktop, WSL2, and mobile-GPU validation target |
+
+This standing fleet is the repeatable release surface: it can run in parallel
+whenever installer, bootstrap, dashboard, agent, model, or extension code
+changes. Community and volunteer testers add broader coverage on other GPUs,
+distros, operating-system versions, storage layouts, and network environments,
+but those reports are complementary evidence rather than the always-on release
+gate.
+
+## Fleet Phases
+
+The private fleet harness runs these phases and records structured artifacts for
+each host where the phase is applicable.
+
+| Phase | What it proves | Normal cadence |
+|---|---|---|
+| Regression replay | Previously fixed fleet bugs have not returned | Every full fleet run |
+| Smoke gate | The smallest Apple Silicon target can fresh-install and pass core health before the larger fleet starts | Every full fleet run |
+| Preflight | OS, RAM, disk, Docker, firewall, port conflicts, prior install state | Every install run |
+| Fresh install | The public bootstrap path can nuke prior state and install non-interactively | Every full fleet run |
+| Core verify | Dashboard API, dashboard UI, llama-server models/chat, and Hermes proxy are reachable | Every post-install run |
+| Dashboard API flows | Model listing, model download/switch, and extension install state transitions | Every post-install run |
+| Hermes auth/chat | Magic-link session auth, gated Hermes access, and seed echo through the agent path | Every post-install run |
+| Browser UI | Dashboard navigation, model/extension surfaces, and Open WebUI model proxy behavior | Default UI target every run; scheduled wider UI sweeps |
+| Capability probes | Chat coherence, web search, file write/read, code execution, skills list, and loaded-model identity | Every post-install run, with LLM probes deferred while bootstrap is still active |
+| Lifecycle | Reinstall, restart, and doctor checks after state changes | Release-candidate or explicit lifecycle runs |
+
+## Representative Evidence
+
+Recent fleet runs on 2026-05-20 exercised the Linux NVIDIA, Linux AMD, Linux
+ARM NVIDIA, constrained macOS, and high-memory macOS surfaces with fresh
+install, verify, dashboard, Hermes, and capability phases. The harness also
+surfaced an external DNS/download failure on one macOS run, which is evidence
+that environment failures are visible rather than silently converted into
+product passes.
+
+The Windows laptop is part of the validation surface so Windows + Docker
+Desktop/WSL2 + mobile NVIDIA/Intel hybrid GPU behavior is not inferred from
+Linux or macOS results. Treat Windows evidence as release-relevant only when
+the Windows target produces preflight, install, verify, dashboard, and UI
+artifacts for the release candidate being claimed.
+
+## What This Proves
+
+- The installer is repeatedly exercised on real machines, not only CI
+  containers.
+- The release path covers heterogeneous GPU vendors, memory sizes, operating
+  systems, and CPU architectures.
+- The harness records environment state before install so firewall, Docker,
+  disk, DNS, and port issues can be separated from product bugs.
+- The user-facing path is tested beyond service liveness: dashboard actions,
+  model switching, Hermes auth, agent capabilities, and regression fixtures are
+  part of the gate.
+
+## What This Does Not Claim
+
+- Every Linux distribution is exhaustively installed on real hardware for every
+  change. CI and distrobox cover broader distro logic; the fleet covers the
+  high-value hardware paths.
+- OS and distro rotation is periodic because reprovisioning real machines is
+  intentionally slower than running the standing fleet. Release notes should
+  call out any rotated distro or OS image that was included for that candidate.
+- Intel Arc is still experimental unless a release cites a successful Arc fleet
+  run for that release candidate.
+- AP-mode and packaged appliance handoff still require target-image validation
+  because router, Wi-Fi, mDNS, and client-device behavior vary.
+- A fresh fleet pass is not a long-term soak test. Bench, thermal, and
+  overnight stability runs are separate evidence.
+
+## Release Readiness Receipt
+
+Before a release is described as ready, the release notes should cite:
+
+- the Dream Server version and matching Git tag or release;
+- the fleet run date and sanitized hardware classes covered;
+- regression replay result;
+- install/verify/dashboard/Hermes/capability result summary;
+- any skipped, deferred, blocked-by-environment, or not-run phases;
+- known gaps that should not be read as supported behavior.
+
+The version signal should be internally consistent before publication:
+`manifest.json`, the changelog section, the Git tag/release, and any release
+notes should all name the same version. If a candidate has not been tagged yet,
+describe it as unreleased or release-candidate evidence rather than as a shipped
+stable release.


### PR DESCRIPTION
## Summary

- add a sanitized validation matrix for the real hardware fleet and release-readiness evidence
- link the matrix from the README, testing guide, support matrix, docs index, platform truth table, and changelog
- update stale validation language so platform claims distinguish standing fleet coverage, volunteer tester breadth, and remaining limits

## Security / Privacy

- publishes hardware classes and evidence categories only
- intentionally omits private hostnames, usernames, LAN addresses, filesystem paths, and secret values
- release-readiness guidance calls out version/tag consistency without publishing private run artifacts

## Validation

- `bash dream-server/tests/test-doc-links.sh`
- `git diff --check`
- sensitive-info scan over touched docs for hostnames, private paths, LAN IPs, usernames, and secret patterns
- observed private fleet run `/home/michael/dream-fleet-test/runs/2026-05-20T17-57-18Z` completed `OVERALL: PASS` before syncing harness-side follow-up work