### PR TITLE
[codex] fix(perplexica): cap scrape_url context

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -99,6 +99,9 @@ jobs:
       - name: Runtime Config Wiring Tests
         run: python3 tests/test-runtime-config-wiring.py
 
+      - name: Perplexica Entrypoint Contract Tests
+        run: python3 tests/test-perplexica-entrypoint.py
+
       - name: CPU-Only Path Tests
         run: bash tests/test-cpu-only-path.sh
 

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -323,6 +323,12 @@
       "description": "Perplexica external port",
       "default": 3004
     },
+    "PERPLEXICA_SCRAPE_URL_MAX_CHARS": {
+      "type": "integer",
+      "description": "Maximum characters kept per URL from Perplexica scrape_url before synthesis",
+      "default": 30000,
+      "minimum": 1000
+    },
     "WHISPER_PORT": {
       "type": "integer",
       "description": "Whisper STT external port",

--- a/dream-server/extensions/services/perplexica/README.md
+++ b/dream-server/extensions/services/perplexica/README.md
@@ -32,6 +32,7 @@ Environment variables (set in `.env`):
 |----------|---------|-------------|
 | `PERPLEXICA_PORT` | 3004 | External port for the Perplexica web UI |
 | `LLM_API_URL` | `http://llama-server:8080` | Base URL of the LLM backend (OpenAI-compatible) |
+| `PERPLEXICA_SCRAPE_URL_MAX_CHARS` | 30000 | Per-URL cap applied to Perplexica's internal `scrape_url` tool output before synthesis |
 
 > **LLM API key:** Perplexica uses `LITELLM_KEY` automatically when LiteLLM auth is enabled, then falls back to `OPENAI_API_KEY`, then `no-key` for direct llama-server installs that do not require authentication. No changes needed for local use.
 
@@ -115,3 +116,4 @@ docker compose logs dream-perplexica
 **Slow or incomplete answers:**
 - Perplexica performance is limited by LLM inference speed. Ensure llama-server has GPU access.
 - Reduce the number of search results by adjusting SearXNG settings
+- DreamServer caps Perplexica's internal `scrape_url` output at startup so oversized web pages do not overflow local model context windows. If a specific page needs more context, raise `PERPLEXICA_SCRAPE_URL_MAX_CHARS` in `.env` and restart Perplexica.

--- a/dream-server/extensions/services/perplexica/compose.yaml
+++ b/dream-server/extensions/services/perplexica/compose.yaml
@@ -10,9 +10,12 @@ services:
       - OPENAI_BASE_URL=${LLM_API_URL:-http://llama-server:8080}/v1
       - OPENAI_API_KEY=${LITELLM_KEY:-${OPENAI_API_KEY:-no-key}}
       - HOSTNAME=0.0.0.0
+      - PERPLEXICA_SCRAPE_URL_MAX_CHARS=${PERPLEXICA_SCRAPE_URL_MAX_CHARS:-30000}
+    entrypoint: ["/bin/sh", "-c", "until [ -x /app/dream-entrypoint.sh ]; do sleep 0.5; done; exec /app/dream-entrypoint.sh \"$@\"", "dream-entrypoint"]
     volumes:
       - perplexica-data:/home/perplexica/data
       - perplexica-uploads:/home/perplexica/uploads
+      - ./extensions/services/perplexica/docker-entrypoint.sh:/app/dream-entrypoint.sh:ro
     ports:
       - "${BIND_ADDRESS:-127.0.0.1}:${PERPLEXICA_PORT:-3004}:3000"
     deploy:

--- a/dream-server/extensions/services/perplexica/docker-entrypoint.sh
+++ b/dream-server/extensions/services/perplexica/docker-entrypoint.sh
@@ -1,0 +1,92 @@
+#!/bin/sh
+# DreamServer Perplexica Entrypoint
+#
+# Perplexica's bundled action orchestrator can let local models call
+# scrape_url even when the prompt says not to. The upstream tool then sends
+# full-page markdown into the final synthesis prompt, which can exceed smaller
+# fleet context windows and produce empty answers. Patch the pinned bundle at
+# container startup so scrape_url keeps at most N characters per URL.
+
+set -eu
+
+log() {
+    echo "[dream-perplexica] $*" >&2
+}
+
+SCRAPE_MAX_CHARS="${PERPLEXICA_SCRAPE_URL_MAX_CHARS:-30000}"
+case "$SCRAPE_MAX_CHARS" in
+    ''|*[!0-9]*)
+        log "Invalid PERPLEXICA_SCRAPE_URL_MAX_CHARS='$SCRAPE_MAX_CHARS'; using 30000"
+        SCRAPE_MAX_CHARS=30000
+        ;;
+esac
+
+if [ "$SCRAPE_MAX_CHARS" -lt 1000 ]; then
+    log "PERPLEXICA_SCRAPE_URL_MAX_CHARS is too small; using 30000"
+    SCRAPE_MAX_CHARS=30000
+fi
+
+patch_scrape_url() {
+    search_root="/home/perplexica/.next/server"
+
+    if [ ! -d "$search_root" ]; then
+        log "Perplexica server bundle not found at $search_root; skipping scrape_url patch"
+        return 0
+    fi
+
+    files_list="${TMPDIR:-/tmp}/dream-perplexica-scrape-files.$$"
+    grep -Rsl 'name:"scrape_url"' "$search_root" > "$files_list" 2>/dev/null || true
+    if [ ! -s "$files_list" ]; then
+        rm -f "$files_list"
+        log "scrape_url tool not found in bundled server JS; no patch needed"
+        return 0
+    fi
+
+    patched=0
+    inspected=0
+    while IFS= read -r file; do
+        inspected=$((inspected + 1))
+        if node - "$file" "$SCRAPE_MAX_CHARS" <<'NODE'
+const fs = require("fs");
+
+const [file, maxRaw] = process.argv.slice(2);
+const max = Number.parseInt(maxRaw, 10);
+const source = fs.readFileSync(file, "utf8");
+
+if (source.includes(`content:k.slice(0,${max})`)) {
+  process.exit(0);
+}
+
+const pattern = /([A-Za-z_$][\w$]*\.push\(\{content:)([A-Za-z_$][\w$]*)(,metadata:\{url:[A-Za-z_$][\w$]*,title:[A-Za-z_$][\w$]*\}\}\))/g;
+let replacements = 0;
+const patched = source.replace(pattern, (match, prefix, contentVar, suffix) => {
+  replacements += 1;
+  return `${prefix}${contentVar}.slice(0,${max})${suffix}`;
+});
+
+if (replacements === 0) {
+  process.exit(2);
+}
+
+fs.writeFileSync(file, patched);
+NODE
+        then
+            patched=$((patched + 1))
+            log "scrape_url output cap active in ${file} (${SCRAPE_MAX_CHARS} chars per URL)"
+        else
+            log "ERROR: found scrape_url in ${file}, but could not patch its result push site"
+            rm -f "$files_list"
+            return 1
+        fi
+    done < "$files_list"
+    rm -f "$files_list"
+
+    if [ "$patched" -eq 0 ] && [ "$inspected" -gt 0 ]; then
+        log "ERROR: inspected scrape_url bundle files but did not patch any"
+        return 1
+    fi
+}
+
+patch_scrape_url
+
+exec docker-entrypoint.sh "$@"

--- a/dream-server/tests/test-perplexica-entrypoint.py
+++ b/dream-server/tests/test-perplexica-entrypoint.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Static contract tests for Perplexica's DreamServer entrypoint patch."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENV_SCHEMA = ROOT / ".env.schema.json"
+SERVICE_DIR = ROOT / "extensions" / "services" / "perplexica"
+COMPOSE = SERVICE_DIR / "compose.yaml"
+ENTRYPOINT = SERVICE_DIR / "docker-entrypoint.sh"
+
+
+def test_compose_uses_dreamserver_entrypoint() -> None:
+    compose = COMPOSE.read_text(encoding="utf-8")
+    assert "PERPLEXICA_SCRAPE_URL_MAX_CHARS=${PERPLEXICA_SCRAPE_URL_MAX_CHARS:-30000}" in compose
+    assert "/app/dream-entrypoint.sh" in compose
+    assert "./extensions/services/perplexica/docker-entrypoint.sh:/app/dream-entrypoint.sh:ro" in compose
+    assert 'exec /app/dream-entrypoint.sh \\"$@\\"' in compose
+
+
+def test_entrypoint_patches_scrape_url_result_content() -> None:
+    script = ENTRYPOINT.read_text(encoding="utf-8")
+    assert "name:\"scrape_url\"" in script
+    assert "PERPLEXICA_SCRAPE_URL_MAX_CHARS" in script
+    assert "content:k.slice(0,${max})" in script
+
+    sample = 'g.push({content:k,metadata:{url:a,title:j}})'
+    pattern = re.compile(
+        r"([A-Za-z_$][\w$]*\.push\(\{content:)"
+        r"([A-Za-z_$][\w$]*)"
+        r"(,metadata:\{url:[A-Za-z_$][\w$]*,title:[A-Za-z_$][\w$]*\}\}\))"
+    )
+    patched = pattern.sub(lambda m: f"{m.group(1)}{m.group(2)}.slice(0,30000){m.group(3)}", sample)
+    assert patched == 'g.push({content:k.slice(0,30000),metadata:{url:a,title:j}})'
+
+
+def test_env_schema_allows_scrape_cap_override() -> None:
+    schema = json.loads(ENV_SCHEMA.read_text(encoding="utf-8"))
+    property_schema = schema["properties"]["PERPLEXICA_SCRAPE_URL_MAX_CHARS"]
+    assert property_schema["type"] == "integer"
+    assert property_schema["default"] == 30000
+    assert property_schema["minimum"] == 1000
+
+
+if __name__ == "__main__":
+    test_compose_uses_dreamserver_entrypoint()
+    test_entrypoint_patches_scrape_url_result_content()
+    test_env_schema_allows_scrape_cap_override()


### PR DESCRIPTION
## Summary

Fixes #1307 by capping Perplexica's internal `scrape_url` tool output before the final synthesis prompt.

What changed:
- Add a DreamServer Perplexica entrypoint wrapper that patches the pinned bundled server JS at container startup.
- Cap each `scrape_url` result body to `PERPLEXICA_SCRAPE_URL_MAX_CHARS` chars, defaulting to 30000.
- Mount the wrapper through Perplexica compose so the patch applies on fresh installs, dashboard enable flows, normal restarts, and image recreates.
- Document the new cap setting and add a CI contract test.

## Why

Perplexica's action orchestrator can call `scrape_url` even when the prompt tells it not to. On affected fleet hosts, that can feed 200-800 KB of scraped markdown into the synthesis request, overflowing local model context windows and producing empty answers or the fallback response. Capping the tool output preserves the source-scraping path while bounding the worst-case prompt size.

## Validation

- `python dream-server\tests\test-perplexica-entrypoint.py`
- `docker run --rm --entrypoint /bin/sh -v <entrypoint>:/app/dream-entrypoint.sh:ro itzcrazykns1337/perplexica:slim-latest@sha256:6e399abf4ff587822b0ef0df11f36088fb928e17ac61556fe89beb68d48c378e -c 'sh -n /app/dream-entrypoint.sh && /app/dream-entrypoint.sh true; grep -R content:k.slice /home/perplexica/.next/server/chunks/641.js >/dev/null'`
- `docker compose -f dream-server\extensions\services\perplexica\compose.yaml config --services`
- `python dream-server\scripts\audit-extensions.py --project-dir dream-server`
- `git diff --check`

Fixes #1307