### PR TITLE
fix(perplexica): restore CMD lost by entrypoint override (#1307 follow-up)

### DIFF
--- a/dream-server/extensions/services/perplexica/compose.yaml
+++ b/dream-server/extensions/services/perplexica/compose.yaml
@@ -12,6 +12,10 @@ services:
       - HOSTNAME=0.0.0.0
       - PERPLEXICA_SCRAPE_URL_MAX_CHARS=${PERPLEXICA_SCRAPE_URL_MAX_CHARS:-30000}
     entrypoint: ["/bin/sh", "-c", "until [ -x /app/dream-entrypoint.sh ]; do sleep 0.5; done; exec /app/dream-entrypoint.sh \"$@\"", "dream-entrypoint"]
+    # Docker drops the image CMD when `entrypoint:` is overridden, so the
+    # upstream command (`node server.js`) must be restated here. Without this
+    # the patched entrypoint exits 0 with no app process, restart-looping.
+    command: ["node", "server.js"]
     volumes:
       - perplexica-data:/home/perplexica/data
       - perplexica-uploads:/home/perplexica/uploads

--- a/dream-server/extensions/services/perplexica/docker-entrypoint.sh
+++ b/dream-server/extensions/services/perplexica/docker-entrypoint.sh
@@ -89,4 +89,11 @@ NODE
 
 patch_scrape_url
 
+# When compose overrides `entrypoint:`, Docker drops the image's CMD
+# (`node server.js`), so $@ arrives empty. Fall back to the image's default
+# command so the upstream docker-entrypoint.sh has something to exec.
+if [ "$#" -eq 0 ]; then
+    set -- node server.js
+fi
+
 exec docker-entrypoint.sh "$@"

--- a/dream-server/tests/test-perplexica-entrypoint.py
+++ b/dream-server/tests/test-perplexica-entrypoint.py
@@ -47,7 +47,25 @@ def test_env_schema_allows_scrape_cap_override() -> None:
     assert property_schema["minimum"] == 1000
 
 
+def test_compose_restores_image_command() -> None:
+    # Setting `entrypoint:` in compose drops the upstream image's CMD
+    # (`node server.js`). The override must restate it or the patched
+    # entrypoint exits 0 with no app process, restart-looping.
+    compose = COMPOSE.read_text(encoding="utf-8")
+    assert 'command: ["node", "server.js"]' in compose
+
+
+def test_entrypoint_falls_back_to_node_server_when_no_args() -> None:
+    # Belt-and-suspenders: even if a future compose change drops `command:`,
+    # the entrypoint should still launch the app instead of exiting 0.
+    script = ENTRYPOINT.read_text(encoding="utf-8")
+    assert 'if [ "$#" -eq 0 ]' in script
+    assert "set -- node server.js" in script
+
+
 if __name__ == "__main__":
     test_compose_uses_dreamserver_entrypoint()
     test_entrypoint_patches_scrape_url_result_content()
     test_env_schema_allows_scrape_cap_override()
+    test_compose_restores_image_command()
+    test_entrypoint_falls_back_to_node_server_when_no_args()


### PR DESCRIPTION
## Summary

PR `a01083f` ("fix(perplexica): cap scrape_url context", fix for #1307) introduced a startup entrypoint that patches `scrape_url` output. Setting `entrypoint:` in `extensions/services/perplexica/compose.yaml` has a side-effect: **Docker drops the image's `CMD` (`node server.js`)** unless `command:` is also restated.

Result: the patched entrypoint runs, prints `[dream-perplexica] scrape_url output cap active …`, then calls `exec docker-entrypoint.sh "$@"` with `$@` empty. The upstream `docker-entrypoint.sh` has nothing to exec, returns 0 immediately, container exits, restart policy bounces it. Every container start logs the patch line and exits in ~120 ms — Perplexica is unavailable on every Linux fleet host.

## Reproduction

On every Linux fleet host (tower2 / strix-halo / spark) after PR `a01083f` landed:

```
$ docker ps --format '{{.Names}}\t{{.Status}}' | grep perplexica
dream-perplexica  Restarting (0) 12 seconds ago

$ docker logs --tail 5 dream-perplexica
[dream-perplexica] scrape_url output cap active in /home/perplexica/.next/server/chunks/641.js (30000 chars per URL)
[dream-perplexica] scrape_url output cap active in /home/perplexica/.next/server/chunks/641.js (30000 chars per URL)
[dream-perplexica] scrape_url output cap active in /home/perplexica/.next/server/chunks/641.js (30000 chars per URL)
[dream-perplexica] scrape_url output cap active in /home/perplexica/.next/server/chunks/641.js (30000 chars per URL)
[dream-perplexica] scrape_url output cap active in /home/perplexica/.next/server/chunks/641.js (30000 chars per URL)

$ docker inspect dream-perplexica --format '{{.State.Status}} | exit={{.State.ExitCode}}'
restarting | exit=0
```

Confirmed on `tower2`, `strix-halo`, `spark` (the three Linux hosts running Perplexica) during the 2026-05-21 `/dream-fleet-test` run.

## Root cause

The image's manifest has `Entrypoint=[docker-entrypoint.sh]` and `Cmd=[node server.js]`. After the compose override, `docker inspect` shows:

```
Entrypoint(config)=[/bin/sh -c until [ -x /app/dream-entrypoint.sh ]; do sleep 0.5; done; exec /app/dream-entrypoint.sh "$@" dream-entrypoint]
Cmd(config)=[]
```

— `Cmd` is empty. When `/app/dream-entrypoint.sh` reaches its final line:

```sh
exec docker-entrypoint.sh "$@"
```

…`$@` is empty. The upstream entrypoint at `/usr/local/bin/docker-entrypoint.sh` is designed for `docker-entrypoint.sh node server.js` and has nothing to do without args, so it exits 0. The healthcheck-free 120 ms restart loop is the visible symptom.

## Fix

Two complementary changes (belt-and-suspenders so a future compose tweak can't reintroduce the same trap):

1. **`compose.yaml`** — restate `command: ["node", "server.js"]` so the override no longer drops the image's CMD.
2. **`docker-entrypoint.sh`** — if `$#` is 0, set `--` to `node server.js` before the final `exec`. Even if a future compose change strips `command:`, the entrypoint still launches the app instead of exiting 0.

## Tests

`tests/test-perplexica-entrypoint.py` gains two assertions:

- `test_compose_restores_image_command` — fails if `command: ["node", "server.js"]` is dropped from compose.yaml.
- `test_entrypoint_falls_back_to_node_server_when_no_args` — fails if the script no longer has the `$# -eq 0` guard.

All five tests pass:

```
$ python3 tests/test-perplexica-entrypoint.py && echo TESTS PASS
TESTS PASS
```

## Verification — end-to-end on every Linux fleet host

Applied the patched files to each host, re-seeded Perplexica config (the data volume was reset when compose recreated the container), then issued the same web-search query that originally triggered #1307:

| host | LLM | container after fix | search result | elapsed |
|------|------|---------------------|--------------|---------|
| **tower2** | qwen3-coder-next | Up 22 min (healthy), RestartCount=0, /api/config HTTP 200 | "The capital of France is Paris" (158 chars, done=1) | 2 s |
| **spark** | qwen3.6-35b-a3b | Up 21 min (healthy), RestartCount=0, /api/config HTTP 200 | "Paris" answer (546 chars, done=1) | 5 s |
| **strix-halo** | extra.Qwen3.6-35B-A3B (Lemonade ROCm) | Up 31 min (healthy), RestartCount=0, /api/config HTTP 200 | full answer (415 chars, done=1) | 8 s |

`docker logs --tail 5 dream-perplexica` after the fix is the expected Next.js boot trace:

```
✓ Starting...
Running database migrations...
Applied migration: 0000_fuzzy_randall.sql
Applied migration: 0001_wise_rockslide.sql
Applied migration: 0002_daffy_wrecker.sql
Database migrations completed successfully
✓ Ready in 177ms
```

## Collateral damage worth flagging (not in scope for this PR)

The crashloop did not just make Perplexica unavailable — on `strix-halo` it also put the Lemonade-ROCm llama-server into a wedged state. Each ~120 ms restart cycle re-triggered Perplexica's startup probes against `litellm:4000` → `llama-server`, and one of those queued requests (task 2469 in the llama-server logs, a 23 000-token prompt-processing job) jammed the single inference slot. After the crashloop fix is applied, Perplexica is healthy but the queued task continues to occupy the slot — chat completions hang with HTTP 000 until the llama-server container is **stopped and recreated** (not just `dream restart`, which signaled but did not clear the wedge).

We recovered strix by `docker rm -f dream-llama-server && dream restart llama-server` (forcing a full recreate). After that strix served the end-to-end test in 8 s as shown above.

This suggests a follow-up worth filing: `dream repair llama-server` (or the healthcheck-driven restart policy) should be willing to recreate the container, not just restart the process, when health has been failing for N minutes. Out of scope for this PR.

## Risk / blast radius

Local-only change to Perplexica's compose + entrypoint shim. No effect on other services. The new tests gate the contract so a future override can't silently re-introduce this trap.
