### PR TITLE
[codex] Add fleet multi-distro testing surface

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -7,6 +7,9 @@ on:
       - main
       - master
 
+permissions:
+  contents: read
+
 jobs:
   linux-smoke:
     runs-on: ubuntu-latest
@@ -16,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: AMD Path Smoke
         run: bash tests/smoke/linux-amd.sh
@@ -44,11 +49,23 @@ jobs:
           - distro: debian-12
             container: debian:12
             expected_pkg: apt
+          - distro: linux-mint-21.3
+            container: linuxmintd/mint21.3-amd64:latest
+            expected_pkg: apt
           - distro: fedora-41
             container: fedora:41
             expected_pkg: dnf
+          - distro: rocky-9
+            container: rockylinux:9
+            expected_pkg: dnf
           - distro: archlinux
             container: archlinux:latest
+            expected_pkg: pacman
+          - distro: manjaro
+            container: manjarolinux/base:latest
+            expected_pkg: pacman
+          - distro: cachyos
+            container: cachyos/cachyos:latest
             expected_pkg: pacman
           - distro: opensuse-tw
             container: opensuse/tumbleweed:latest
@@ -60,21 +77,24 @@ jobs:
         working-directory: dream-server
     name: "distro: ${{ matrix.distro }}"
     steps:
-      - name: Install git (distro-aware)
+      - name: Install checkout prerequisites (distro-aware)
         working-directory: /
         run: |
           if command -v apt-get &>/dev/null; then
-            apt-get update -qq && apt-get install -y -qq git curl
+            apt-get update -qq && apt-get install -y -qq ca-certificates git curl
           elif command -v dnf &>/dev/null; then
-            dnf install -y -q git curl
+            dnf install -y -q ca-certificates git curl-minimal
           elif command -v pacman &>/dev/null; then
-            pacman -Sy --noconfirm git curl
+            pacman -Syu --noconfirm --needed ca-certificates git curl
           elif command -v zypper &>/dev/null; then
-            zypper --non-interactive install git curl
+            zypper --non-interactive refresh
+            zypper --non-interactive install ca-certificates git curl
           fi
 
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Verify /etc/os-release
         working-directory: /
@@ -116,13 +136,19 @@ jobs:
           source installers/lib/packaging.sh
           detect_pkg_manager
           pkg_update
-          pkg_install curl jq || echo "WARN: jq install failed (may not be in repos)"
+          pkg_install curl jq rsync || echo "WARN: jq/rsync install failed (may not be in repos)"
 
-          # Verify at least curl works
+          # Verify the core tools used by installer phases.
           if command -v curl &>/dev/null; then
             echo "PASS: curl available"
           else
             echo "FAIL: curl not available after pkg_install"
+            exit 1
+          fi
+          if command -v rsync &>/dev/null; then
+            echo "PASS: rsync available"
+          else
+            echo "FAIL: rsync not available after pkg_install"
             exit 1
           fi
 
@@ -142,6 +168,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: macOS Dispatch Smoke
         run: bash tests/smoke/macos-dispatch.sh

--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -3,7 +3,7 @@
 
 SHELL_FILES := $(shell find . -name '*.sh' -not -path './node_modules/*' -not -path './.git/*' -not -path './data/*' -not -path './token-spy/*')
 
-.PHONY: help lint test bats smoke simulate gate doctor
+.PHONY: help lint test bats smoke simulate fleet-distros gate doctor
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
@@ -64,6 +64,9 @@ smoke: ## Run platform smoke tests
 
 simulate: ## Run installer simulation harness
 	@bash scripts/simulate-installers.sh
+
+fleet-distros: ## Run disposable Docker multi-distro fleet checks
+	@bash tests/fleet-multi-distro.sh
 
 doctor: ## Run diagnostic report
 	@bash scripts/dream-doctor.sh

--- a/dream-server/docs/TESTING.md
+++ b/dream-server/docs/TESTING.md
@@ -40,9 +40,67 @@ Fleet phases currently include:
 | Method | Speed | GPU Testing | Kernel Testing | Best For |
 |--------|-------|-------------|----------------|----------|
 | **Fleet harness** | 15-75 min | Yes | Yes | Release readiness on real heterogeneous hardware |
+| **Fleet distro lab** | 5-20 min | No | Container: no / VM: yes | Multi-distro installer and Docker lifecycle coverage on tower2 |
 | **Distrobox** | Instant (2s) | Yes | No | Daily dev, package manager validation |
 | **Ventoy USB** | 5-10 min boot | Yes | Yes | Weekly full-stack validation |
 | **CI Matrix** | Automatic | No | No | Every PR, syntax + detection checks |
+
+## Fleet Distro Lab (tower2)
+
+The fleet distro lab is the repeatable middle rung between CI containers and
+full hardware fleet runs. `tower2` is provisioned with:
+
+- Docker for fast disposable distro containers;
+- Distrobox for interactive distro debugging;
+- Incus + KVM/QEMU for disposable systemd-capable VMs.
+
+Use the Docker runner for every fleet run:
+
+```bash
+cd ~/DreamServer/dream-server
+tests/fleet-multi-distro.sh --pull
+```
+
+Run a focused subset while debugging:
+
+```bash
+tests/fleet-multi-distro.sh ubuntu/24.04 archlinux/current mint
+tests/fleet-multi-distro.sh --no-dry-run ubuntu2404
+```
+
+The fast fleet matrix currently covers:
+
+| Distro ID | Image | Package Manager |
+|-----------|-------|-----------------|
+| `ubuntu2404` | `ubuntu:24.04` | apt |
+| `ubuntu2204` | `ubuntu:22.04` | apt |
+| `debian12` | `debian:12` | apt |
+| `mint213` | `linuxmintd/mint21.3-amd64:latest` | apt |
+| `fedora41` | `fedora:41` | dnf |
+| `rocky9` | `rockylinux:9` | dnf |
+| `arch` | `archlinux:latest` | pacman |
+| `manjaro` | `manjarolinux/base:latest` | pacman |
+| `cachyos` | `cachyos/cachyos:latest` | pacman |
+| `opensuse` | `opensuse/tumbleweed:latest` | zypper |
+
+Aliases such as `ubuntu/24.04`, `ubuntu/22.04`, `debian/12`,
+`fedora/41`, `archlinux/current`, `opensuse/tumbleweed`, and `mint` are
+accepted by the runner for quick ad-hoc checks. The matrix uses Linux Mint
+21.3 because the current Mint 22 Docker images report plain Ubuntu in
+`/etc/os-release`, which is less useful for distro detection.
+
+Use Incus VMs when a regression needs real systemd, boot, kernel, or Docker
+daemon behavior:
+
+```bash
+incus launch images:ubuntu/24.04 ds-ubuntu2404 --vm -c limits.cpu=4 -c limits.memory=8GiB
+incus exec ds-ubuntu2404 -- bash -lc 'cat /etc/os-release; systemctl is-system-running || true'
+incus delete -f ds-ubuntu2404
+```
+
+For CachyOS, use the container matrix for package-manager coverage. Keep a
+manual CachyOS VM template for systemd/kernel coverage because CachyOS publishes
+installer ISOs rather than a standard Incus cloud image.
 
 ## Distrobox (Daily Testing)
 
@@ -57,9 +115,13 @@ curl -s https://raw.githubusercontent.com/89luca89/distrobox/main/install | sudo
 # Create test containers for target distros
 distrobox create --name dream-test-fedora --image fedora:41
 distrobox create --name dream-test-arch --image archlinux:latest
+distrobox create --name dream-test-manjaro --image manjarolinux/base:latest
+distrobox create --name dream-test-cachyos --image cachyos/cachyos:latest
 distrobox create --name dream-test-opensuse --image opensuse/tumbleweed:latest
 distrobox create --name dream-test-debian --image debian:12
 distrobox create --name dream-test-ubuntu2204 --image ubuntu:22.04
+distrobox create --name dream-test-mint213 --image linuxmintd/mint21.3-amd64:latest
+distrobox create --name dream-test-rocky9 --image rockylinux:9
 ```
 
 ### Usage
@@ -116,7 +178,9 @@ Boot any Linux distro from a single USB drive. Pick from a menu, boot into a liv
 | CachyOS | Arch-based, issue #33 | pacman |
 | openSUSE Tumbleweed | Rolling release | zypper |
 | Debian 12 | apt but not Ubuntu | apt |
-| Linux Mint 22 | Ubuntu derivative | apt |
+| Linux Mint 21.3 | Ubuntu derivative with `ID=linuxmint` | apt |
+| Rocky Linux 9 | RHEL-family server baseline | dnf |
+| Manjaro | Arch derivative with desktop-user reach | pacman |
 
 Total: ~25GB for all ISOs.
 
@@ -157,7 +221,7 @@ Run installer validation across all Distrobox containers automatically:
 ./tests/test-multi-distro.sh
 
 # Run specific distros
-./tests/test-multi-distro.sh fedora41 arch
+./tests/test-multi-distro.sh fedora41 arch cachyos mint213
 
 # Clean up
 ./tests/test-multi-distro.sh --cleanup
@@ -184,7 +248,7 @@ Run installer validation across all Distrobox containers automatically:
 
 ## CI Matrix
 
-Every PR automatically tests installer detection on 6 distros via GitHub Actions containers. See `.github/workflows/matrix-smoke.yml`.
+Every PR automatically tests installer detection on 10 distros via GitHub Actions containers. See `.github/workflows/matrix-smoke.yml`.
 
 **Tested per PR:**
 - `/etc/os-release` parsing
@@ -196,6 +260,8 @@ Every PR automatically tests installer detection on 6 distros via GitHub Actions
 
 1. Add the distro ID to `installers/lib/packaging.sh` in the `detect_pkg_manager()` case block
 2. Add a test entry in `tests/test-multi-distro.sh` DISTROS array
-3. Add a CI matrix entry in `.github/workflows/matrix-smoke.yml`
-4. Test with Distrobox: `distrobox create --name dream-test-newdistro --image newdistro:latest`
-5. Run: `./tests/test-multi-distro.sh newdistro`
+3. Add a fleet entry in `tests/fleet-multi-distro.sh`
+4. Add a CI matrix entry in `.github/workflows/matrix-smoke.yml`
+5. Test with Distrobox: `distrobox create --name dream-test-newdistro --image newdistro:latest`
+6. Run: `./tests/test-multi-distro.sh newdistro`
+7. Run the fleet matrix path: `./tests/fleet-multi-distro.sh newdistro`

--- a/dream-server/installers/lib/packaging.sh
+++ b/dream-server/installers/lib/packaging.sh
@@ -101,7 +101,15 @@ pkg_update() {
 # Install one or more packages
 # Usage: pkg_install curl jq rsync
 pkg_install() {
-    local pkgs=("$@")
+    local requested=("$@")
+    local pkgs=()
+    local pkg resolved
+    for pkg in "${requested[@]}"; do
+        resolved="$(pkg_resolve "$pkg")"
+        # Some canonical packages intentionally expand to multiple packages.
+        # shellcheck disable=SC2206
+        pkgs+=($resolved)
+    done
     [[ ${#pkgs[@]} -eq 0 ]] && return 0
 
     log "Installing packages (${PKG_MANAGER}): ${pkgs[*]}"
@@ -145,6 +153,13 @@ pkg_resolve() {
             ;;
         dnf)
             case "$canonical" in
+                curl)
+                    if command -v rpm &>/dev/null && rpm -q curl-minimal &>/dev/null; then
+                        echo "curl-minimal"
+                    else
+                        echo "curl"
+                    fi
+                    ;;
                 docker-compose-plugin) echo "docker-compose-plugin" ;;
                 python3-pyyaml)        echo "python3-pyyaml" ;;
                 build-essential)       echo "gcc gcc-c++ make" ;;

--- a/dream-server/tests/bats-tests/packaging.bats
+++ b/dream-server/tests/bats-tests/packaging.bats
@@ -55,6 +55,28 @@ setup() {
     assert_output "curl"
 }
 
+@test "pkg_resolve: dnf keeps curl-minimal when it is already installed" {
+    rpm() {
+        [[ "$1" == "-q" && "$2" == "curl-minimal" ]]
+    }
+    export -f rpm
+
+    PKG_MANAGER="dnf"
+    run pkg_resolve curl
+    assert_output "curl-minimal"
+}
+
+@test "pkg_install resolves canonical package names before invoking dnf" {
+    dnf() { echo "$*"; }
+    export -f dnf
+
+    PKG_MANAGER="dnf"
+    _SUDO=""
+    run pkg_install build-essential
+    assert_success
+    assert_output "install -y -q gcc gcc-c++ make"
+}
+
 # ── pkg_resolve: pacman ─────────────────────────────────────────────────────
 
 @test "pkg_resolve: pacman maps docker-compose-plugin to docker-compose" {

--- a/dream-server/tests/fleet-multi-distro.sh
+++ b/dream-server/tests/fleet-multi-distro.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# Dream Server fleet multi-distro runner.
+#
+# This is the noninteractive distro gate intended for fleet hosts such as
+# tower2. It uses Docker directly instead of Distrobox so it can run from SSH,
+# cron, or a fleet harness without pre-created per-distro containers.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+declare -A IMAGES=(
+    [ubuntu2404]="ubuntu:24.04"
+    [ubuntu2204]="ubuntu:22.04"
+    [debian12]="debian:12"
+    [mint213]="linuxmintd/mint21.3-amd64:latest"
+    [fedora41]="fedora:41"
+    [rocky9]="rockylinux:9"
+    [arch]="archlinux:latest"
+    [manjaro]="manjarolinux/base:latest"
+    [cachyos]="cachyos/cachyos:latest"
+    [opensuse]="opensuse/tumbleweed:latest"
+)
+
+declare -A EXPECTED_PKG=(
+    [ubuntu2404]="apt"
+    [ubuntu2204]="apt"
+    [debian12]="apt"
+    [mint213]="apt"
+    [fedora41]="dnf"
+    [rocky9]="dnf"
+    [arch]="pacman"
+    [manjaro]="pacman"
+    [cachyos]="pacman"
+    [opensuse]="zypper"
+)
+
+declare -A ALIASES=(
+    [ubuntu/24.04]="ubuntu2404"
+    [ubuntu-24.04]="ubuntu2404"
+    [ubuntu/22.04]="ubuntu2204"
+    [ubuntu-22.04]="ubuntu2204"
+    [debian/12]="debian12"
+    [debian-12]="debian12"
+    [linuxmint]="mint213"
+    [linuxmint/21.3]="mint213"
+    [mint]="mint213"
+    [mint/21.3]="mint213"
+    [fedora/41]="fedora41"
+    [fedora-41]="fedora41"
+    [rocky]="rocky9"
+    [rockylinux]="rocky9"
+    [rockylinux/9]="rocky9"
+    [rocky/9]="rocky9"
+    [archlinux]="arch"
+    [archlinux/current]="arch"
+    [manjaro/current]="manjaro"
+    [cachyos/current]="cachyos"
+    [cachyOS]="cachyos"
+    [opensuse/tumbleweed]="opensuse"
+    [opensuse-tumbleweed]="opensuse"
+    [tumbleweed]="opensuse"
+)
+
+ORDER=(ubuntu2404 ubuntu2204 debian12 mint213 fedora41 rocky9 arch manjaro cachyos opensuse)
+
+PULL=false
+RUN_DRY_RUN=true
+KEEP_WORK=false
+TARGETS=()
+
+usage() {
+    cat <<'EOF'
+Usage: tests/fleet-multi-distro.sh [options] [distro...]
+
+Run Dream Server distro compatibility checks in disposable Docker containers.
+
+Options:
+  --pull          Pull/refresh distro images before running.
+  --no-dry-run    Skip install-core.sh --dry-run inside each distro.
+  --keep-work     Keep temporary host work directory for debugging.
+  --list          List supported distro IDs and images.
+  -h, --help      Show this help.
+
+Examples:
+  tests/fleet-multi-distro.sh --pull
+  tests/fleet-multi-distro.sh ubuntu/24.04 archlinux/current mint
+  tests/fleet-multi-distro.sh --no-dry-run ubuntu2404
+EOF
+}
+
+list_distros() {
+    printf '%-12s %-36s %s\n' "ID" "IMAGE" "PACKAGE_MANAGER"
+    for distro in "${ORDER[@]}"; do
+        printf '%-12s %-36s %s\n' "$distro" "${IMAGES[$distro]}" "${EXPECTED_PKG[$distro]}"
+    done
+}
+
+normalize_distro() {
+    local distro="$1"
+    printf '%s\n' "${ALIASES[$distro]:-$distro}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --pull)
+            PULL=true
+            shift
+            ;;
+        --no-dry-run)
+            RUN_DRY_RUN=false
+            shift
+            ;;
+        --keep-work)
+            KEEP_WORK=true
+            shift
+            ;;
+        --list)
+            list_distros
+            exit 0
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            while [[ $# -gt 0 ]]; do
+                TARGETS+=("$1")
+                shift
+            done
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+        *)
+            TARGETS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+    TARGETS=("${ORDER[@]}")
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "ERROR: docker is required for fleet multi-distro tests." >&2
+    exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+    echo "ERROR: docker daemon is not reachable." >&2
+    exit 1
+fi
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dream-fleet-distro.XXXXXX")"
+cleanup() {
+    if [[ "$KEEP_WORK" == "true" ]]; then
+        echo "Keeping work dir: $WORK_DIR"
+    else
+        rm -rf "$WORK_DIR"
+    fi
+}
+trap cleanup EXIT
+
+cat > "$WORK_DIR/bootstrap.sh" <<'EOF'
+#!/bin/sh
+set -eu
+
+install_deps() {
+    if command -v apt-get >/dev/null 2>&1; then
+        apt-get update -qq
+        DEBIAN_FRONTEND=noninteractive apt-get install -y -qq bash ca-certificates curl gawk git jq python3 python3-yaml rsync sudo
+    elif command -v dnf >/dev/null 2>&1; then
+        dnf install -y -q bash ca-certificates curl-minimal gawk git jq python3 python3-pyyaml rsync sudo
+    elif command -v pacman >/dev/null 2>&1; then
+        pacman -Syu --noconfirm --needed bash ca-certificates curl gawk git jq python python-yaml rsync sudo
+    elif command -v zypper >/dev/null 2>&1; then
+        zypper --non-interactive refresh
+        zypper --non-interactive install -y bash ca-certificates curl gawk git jq python3 python3-PyYAML rsync sudo
+    else
+        echo "ERROR: no supported package manager found in container" >&2
+        exit 1
+    fi
+}
+
+install_deps
+
+if ! id dreamtest >/dev/null 2>&1; then
+    useradd -m -s /bin/bash dreamtest
+fi
+mkdir -p /etc/sudoers.d
+echo 'dreamtest ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/dreamtest
+chmod 0440 /etc/sudoers.d/dreamtest
+
+exec bash /fleet/check.sh "$@"
+EOF
+
+cat > "$WORK_DIR/check.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+name="$1"
+expected_pkg="$2"
+run_dry_run="$3"
+
+cd /work
+
+echo "=== $name: os-release ==="
+cat /etc/os-release
+
+export LOG_FILE=/dev/null
+log() { echo "[INFO] $*"; }
+warn() { echo "[WARN] $*"; }
+error() { echo "[ERROR] $*" >&2; exit 1; }
+
+source installers/lib/packaging.sh
+detect_pkg_manager
+echo "Detected package manager: $PKG_MANAGER"
+if [[ "$PKG_MANAGER" != "$expected_pkg" ]]; then
+    echo "FAIL: expected $expected_pkg, got $PKG_MANAGER" >&2
+    exit 1
+fi
+
+pkg_install curl git jq >/tmp/pkg-install.log 2>&1 || {
+    cat /tmp/pkg-install.log >&2
+    exit 1
+}
+
+bash -n install-core.sh
+bash -n installers/lib/packaging.sh
+bash -n scripts/resolve-compose-stack.sh
+
+flags="$(bash scripts/resolve-compose-stack.sh --script-dir "$PWD" --tier 1 --gpu-backend cpu)"
+echo "Compose flags: $flags"
+grep -q -- "-f docker-compose.base.yml" <<<"$flags"
+
+if [[ "$run_dry_run" == "true" ]]; then
+    echo "=== $name: installer dry-run ==="
+    if command -v runuser >/dev/null 2>&1; then
+        dry_run_cmd=(runuser -u dreamtest -- bash -lc 'cd /work && bash install-core.sh --dry-run --non-interactive --skip-docker --force')
+    else
+        dry_run_cmd=(su dreamtest -s /bin/bash -c 'cd /work && bash install-core.sh --dry-run --non-interactive --skip-docker --force')
+    fi
+    if ! "${dry_run_cmd[@]}" >/tmp/install-dry-run.log 2>&1; then
+        tail -80 /tmp/install-dry-run.log >&2
+        exit 1
+    fi
+fi
+
+echo "PASS: $name"
+EOF
+
+chmod +x "$WORK_DIR/bootstrap.sh" "$WORK_DIR/check.sh"
+
+pass=0
+fail=0
+failed=()
+
+for distro in "${TARGETS[@]}"; do
+    distro="$(normalize_distro "$distro")"
+    image="${IMAGES[$distro]:-}"
+    expected="${EXPECTED_PKG[$distro]:-}"
+    if [[ -z "$image" || -z "$expected" ]]; then
+        echo "FAIL: unknown distro '$distro' (use --list)" >&2
+        failed+=("$distro")
+        fail=$((fail + 1))
+        continue
+    fi
+
+    echo ""
+    echo "=== Fleet distro: $distro ($image) ==="
+    if [[ "$PULL" == "true" ]]; then
+        docker pull "$image"
+    fi
+
+    container_name="dream-fleet-${distro}-$$"
+    if docker run --rm \
+        --name "$container_name" \
+        -v "$ROOT_DIR:/work:ro" \
+        -v "$WORK_DIR:/fleet:ro" \
+        -w /work \
+        "$image" \
+        sh /fleet/bootstrap.sh "$distro" "$expected" "$RUN_DRY_RUN"; then
+        pass=$((pass + 1))
+    else
+        fail=$((fail + 1))
+        failed+=("$distro")
+    fi
+done
+
+echo ""
+echo "=== Fleet multi-distro summary ==="
+echo "Passed: $pass"
+echo "Failed: $fail"
+if [[ ${#failed[@]} -gt 0 ]]; then
+    printf 'Failed distros: %s\n' "${failed[*]}"
+    exit 1
+fi

--- a/dream-server/tests/test-multi-distro.sh
+++ b/dream-server/tests/test-multi-distro.sh
@@ -7,7 +7,7 @@
 #
 # Usage:
 #   ./tests/test-multi-distro.sh              # Run all distros
-#   ./tests/test-multi-distro.sh fedora arch  # Run specific distros
+#   ./tests/test-multi-distro.sh fedora41 arch cachyos mint213  # Run specific distros
 #   ./tests/test-multi-distro.sh --create     # Create containers only
 #   ./tests/test-multi-distro.sh --cleanup    # Remove all test containers
 #
@@ -40,8 +40,12 @@ declare -A DISTROS=(
     [ubuntu2404]="ubuntu:24.04"
     [ubuntu2204]="ubuntu:22.04"
     [debian12]="debian:12"
+    [mint213]="linuxmintd/mint21.3-amd64:latest"
     [fedora41]="fedora:41"
+    [rocky9]="rockylinux:9"
     [arch]="archlinux:latest"
+    [manjaro]="manjarolinux/base:latest"
+    [cachyos]="cachyos/cachyos:latest"
     [opensuse]="opensuse/tumbleweed:latest"
 )
 
@@ -50,8 +54,12 @@ declare -A EXPECTED_PKG=(
     [ubuntu2404]="apt"
     [ubuntu2204]="apt"
     [debian12]="apt"
+    [mint213]="apt"
     [fedora41]="dnf"
+    [rocky9]="dnf"
     [arch]="pacman"
+    [manjaro]="pacman"
+    [cachyos]="pacman"
     [opensuse]="zypper"
 )
 


### PR DESCRIPTION
## Summary
- provision a Docker-based fleet multi-distro runner for tower2/fleet hosts
- expand distro coverage to Ubuntu 24.04/22.04, Debian 12, Linux Mint 21.3, Fedora 41, Rocky 9, Arch, Manjaro, CachyOS, and openSUSE Tumbleweed
- extend CI/Distrobox docs and smoke coverage for the same surfaces
- fix the dnf/Rocky curl-minimal conflict by resolving curl to curl-minimal when that package is already installed

## Why
Dream Server needs a fast compatibility gate for common local-AI Linux surfaces without reprovisioning a new OS for every check. Containers are not a replacement for real fleet installs, but they catch package-manager, distro detection, dependency, syntax, compose-resolution, and non-root dry-run regressions quickly.

## Validation
- tower2 provisioned with Docker, Distrobox, Incus, and KVM/QEMU
- Incus container probe: Debian 12 launched and exec succeeded
- Incus VM probe: Ubuntu 24.04 VM launched, systemd running, exec succeeded
- CachyOS container probe: package manager and os-release verified
- `tests/fleet-multi-distro.sh mint` passed with `ID=linuxmint`
- `tests/fleet-multi-distro.sh` passed all 10 distros on tower2
- `tests/bats/bats-core/bin/bats tests/bats-tests/packaging.bats` passed on tower2
- `git diff --cached --check` passed