### PR TITLE
docs: document layered distro validation surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ If AI is becoming critical infrastructure, it shouldn’t be rented. Self-hostin
 > | **Windows** (NVIDIA + AMD) | **Supported** — install and run today |
 > | **macOS** (Apple Silicon) | **Supported** — install and run today |
 >
-> **Tested Linux distros:** Ubuntu 24.04/22.04, Debian 12, Fedora 41+, Arch Linux, CachyOS, openSUSE Tumbleweed. Other distros using apt, dnf, pacman, or zypper should also work — [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues) if yours doesn't.
+> **Tested Linux distros:** Ubuntu 24.04/22.04, Debian 12, Linux Mint 21.3, Fedora 41+, Rocky Linux 9, Arch Linux, Manjaro, CachyOS, and openSUSE Tumbleweed. Other distros using apt, dnf, pacman, or zypper should also work — [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues) if yours doesn't.
+>
+> **Testing surface:** CI and tower2 Docker containers cover broad distro installer logic; tower2 Incus VMs cover systemd + Docker daemon behavior on Ubuntu, Fedora/Rocky, Arch, and openSUSE; the real hardware fleet remains the release gate for NVIDIA/AMD/Apple GPU runtime, dashboard, Hermes, UI, and capability validation.
 >
 > **Windows:** Requires Docker Desktop with WSL2 backend. NVIDIA GPUs use Docker GPU passthrough; AMD Strix Halo runs through the platform-specific accelerated path documented in the Windows installer and support matrix.
 >
@@ -40,7 +42,7 @@ If AI is becoming critical infrastructure, it shouldn’t be rented. Self-hostin
 >
 > See the [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) for supported
 > platform claims and the [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md)
-> for the real hardware fleet used to test those claims.
+> for the layered test surface used to test those claims.
 
 ---
 
@@ -358,7 +360,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | [Build On Dream Server](dream-server/docs/BUILD-ON-DREAM-SERVER.md) | Forking, custom editions, extension templates, and downstream validation |
 | [Headless Setup](dream-server/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
-| [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) | Sanitized real-hardware fleet coverage and release-readiness evidence |
+| [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 | [Model Management](dream-server/docs/MODEL-MANAGEMENT.md) | Dashboard model downloads, switching, and manual GGUF workflows |
 | [Hardware Guide](dream-server/docs/HARDWARE-GUIDE.md) | What to buy, tier recommendations |
 | [FAQ](dream-server/FAQ.md) | Common questions and configuration |

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -123,7 +123,7 @@ at [`../../README.md`](../../README.md).
 | [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) | Operators | Post-install verification |
 | [KNOWN-GOOD-VERSIONS.md](KNOWN-GOOD-VERSIONS.md) | Operators | Tested image/version combos |
 | [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) | Developers | Platform feature matrix |
-| [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) | Operators / release reviewers | Sanitized real-hardware fleet coverage and release-readiness evidence |
+| [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) | Operators / release reviewers | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 
 ## Project
 

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -1,19 +1,20 @@
 # Dream Server Support Matrix
 
-Last updated: 2026-05-20
+Last updated: 2026-05-21
 
 ## What Works Today
 
 **Linux, Windows, and macOS are fully supported. Intel Arc is experimental.**
 
-For the real hardware evidence behind these claims, see
-[VALIDATION-MATRIX.md](VALIDATION-MATRIX.md). The matrix is sanitized so it can
-be public without exposing private lab hostnames, LAN addresses, or paths.
+For the layered evidence behind these claims, see
+[VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) and [TESTING.md](TESTING.md). The
+matrix is sanitized so it can be public without exposing private lab hostnames,
+LAN addresses, or paths.
 
 | Platform | Status | What you get today |
 |----------|--------|-------------------|
 | **Linux + AMD Strix Halo (ROCm)** | **Fully supported** | Complete install and runtime. Primary development platform. |
-| **Linux + NVIDIA (CUDA)** | **Supported** | Complete install and runtime. Broader distro test matrix still expanding. |
+| **Linux + NVIDIA (CUDA)** | **Supported** | Complete install and runtime. Distro breadth runs in CI, tower2 Docker containers, and tower2 Incus VMs; GPU runtime is validated on real NVIDIA hardware. |
 | **Windows (Docker Desktop + WSL2)** | **Supported** | Complete install and runtime via `.\install.ps1`. GPU auto-detection (NVIDIA/AMD). |
 | **macOS (Apple Silicon)** | **Supported** | Complete install and runtime via `./install.sh`. Native Metal inference + Docker services. |
 | **Linux + Intel Arc (SYCL)** | **Experimental** | Installer auto-detects Arc, assigns ARC/ARC\_LITE tier, and selects `docker-compose.arc.yml`. End-to-end runtime on A770/A750. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md). |
@@ -28,7 +29,7 @@ be public without exposing private lab hostnames, LAN addresses, or paths.
 
 | Platform | GPU Path | Installer Tier | Notes |
 |---|---|---|---|
-| Linux (Ubuntu/Debian family) | NVIDIA (llama-server/CUDA) | Tier B | Validated on real high-memory multi-GPU NVIDIA hardware; broader distro matrix continues in CI/distro testing |
+| Linux (Ubuntu/Debian family) | NVIDIA (llama-server/CUDA) | Tier B | Validated on real high-memory multi-GPU NVIDIA hardware; broader distro matrix runs in CI, tower2 Docker containers, and tower2 Incus VMs |
 | Linux (Strix Halo / AMD unified memory) | AMD (Lemonade/ROCm) | Tier A | Primary managed path via `docker-compose.base.yml` + `docker-compose.amd.yml`; validated on real Strix Halo hardware |
 | Linux (Intel Arc A770/A750) | Intel SYCL (llama-server/oneAPI) | **Tier C** | `docker-compose.arc.yml`; builds llama.cpp from `intel/oneapi-basekit`; see [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) |
 | Windows (Docker Desktop + WSL2) | NVIDIA via Docker Desktop; AMD via host Vulkan runtime | Tier B | Standalone installer (`.\install.ps1`) with GPU auto-detection, Docker orchestration, health checks, and desktop shortcuts; Windows laptop fleet target tracks Docker Desktop/WSL2 evidence |
@@ -53,14 +54,14 @@ be public without exposing private lab hostnames, LAN addresses, or paths.
 ## Current Truth
 
 - **Linux, Windows, and macOS are fully supported.**
-- Linux + NVIDIA is supported and validated on real high-memory NVIDIA hardware; broader distro coverage continues through CI and distrobox/Ventoy testing.
+- Linux + NVIDIA is supported and validated on real high-memory NVIDIA hardware; broader distro coverage now runs through CI, tower2 Docker containers, and tower2 Incus VMs.
 - Windows installs via `.\install.ps1` with Docker Desktop + WSL2 backend. Windows AMD local inference is host-managed and uses Vulkan today, either through legacy Lemonade Server or native `llama-server` fallback.
 - Windows native installer UX is Tier B (delegated via Docker Desktop + WSL2).
 - macOS installs via `./install.sh` — llama-server runs natively with Metal acceleration, all other services in Docker.
 - AMD runtime diagnostics are explicit: `.env` records runtime, location, selected backend, supported backends, and whether DreamServer manages the process. Lemonade's newer CLI/default port is documented upstream but is not the managed DreamServer path yet.
 - AMD discrete GPUs beyond the documented Strix Halo path should be treated as validation-required until the repo has tier/model benchmarks for that hardware.
 - **Intel Arc (SYCL) is Tier C / experimental.** The installer auto-detects and selects the correct compose overlay and tier. Runtime works on A770/A750 (Linux). ComfyUI and Whisper GPU acceleration are not yet available for Arc. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) for limitations.
-- Release-readiness claims should cite a matching version/tag and a fleet receipt from [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md).
+- Release-readiness claims should cite a matching version/tag, relevant distro-lab evidence, and a real-hardware fleet receipt from [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md).
 - Version baselines for triage are in `docs/KNOWN-GOOD-VERSIONS.md`.
 
 ## Roadmap
@@ -75,7 +76,7 @@ be public without exposing private lab hostnames, LAN addresses, or paths.
 
 ## Next Milestones
 
-1. Keep expanding the existing `matrix-smoke.yml` coverage with more real distro and GPU fixtures.
+1. Keep the CI/container/Incus distro matrix green and add targeted full-install VM lanes where regressions justify the cost.
 2. Keep Windows laptop fleet evidence current for Docker Desktop/WSL2, NVIDIA mobile GPU, and Intel hybrid-GPU behavior.
 3. Expand macOS test coverage across more Apple Silicon generations and RAM tiers.
 4. Validate Intel Arc B580 (Battlemage 12 GB) on the `ARC` tier.
@@ -83,7 +84,8 @@ be public without exposing private lab hostnames, LAN addresses, or paths.
 
 ## See also
 
-- [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) - real-hardware fleet coverage and release-readiness evidence.
+- [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) - layered CI, distro-lab, and real-hardware fleet release-readiness evidence.
+- [TESTING.md](TESTING.md) - local test commands, fleet distro lab, and Incus VM runner usage.
 
 - [LINUX-PORTABILITY.md](LINUX-PORTABILITY.md) — Linux installer edge cases, `.env` validation, extension manifests.
 - [config/system-tuning/README.md](../config/system-tuning/README.md) — Performance tuning for AMD Strix Halo (GRUB, modprobe, sysctl, CPU governor settings).

--- a/dream-server/docs/TESTING.md
+++ b/dream-server/docs/TESTING.md
@@ -5,10 +5,11 @@ Dream Server supports multiple Linux distributions. This guide covers how to tes
 ## Real Hardware Fleet Validation
 
 Dream Server also uses a private real-hardware fleet for release-readiness
-evidence. CI and distrobox are useful for fast installer logic checks, but the
-fleet is where fresh installs, Docker startup, GPU runtime behavior, dashboard
-flows, Hermes auth, model switching, extension install paths, and agent
-capabilities are exercised on real machines.
+evidence. CI, Docker containers, Distrobox, and Incus VMs are useful for fast
+installer logic, package-manager, systemd, and Docker-daemon checks, but the
+physical fleet is where fresh installs, Docker startup, GPU runtime behavior,
+dashboard flows, Hermes auth, model switching, extension install paths, and
+agent capabilities are exercised on real machines.
 
 The sanitized public coverage is maintained in
 [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md). Release notes should cite the
@@ -17,7 +18,8 @@ blocked, deferred, skipped, or not-run phases.
 
 Volunteer and community testers are important for broader distro, GPU, driver,
 and network coverage. Treat those reports as complementary breadth evidence;
-the fleet is the repeatable parallel gate that can run whenever code changes.
+the physical fleet is the repeatable parallel gate that can run whenever code
+changes.
 
 Fleet phases currently include:
 

--- a/dream-server/docs/VALIDATION-MATRIX.md
+++ b/dream-server/docs/VALIDATION-MATRIX.md
@@ -1,11 +1,26 @@
 # Dream Server Validation Matrix
 
-Last updated: 2026-05-20
+Last updated: 2026-05-21
 
-This page describes the real hardware and workflow coverage used to validate
-Dream Server between changes. It is intentionally sanitized: it publishes
-hardware classes, operating systems, GPU paths, and test phases without private
-hostnames, LAN addresses, usernames, or filesystem paths.
+This page describes the layered coverage used to validate Dream Server between
+changes. It is intentionally sanitized: it publishes hardware classes,
+operating systems, GPU paths, and test phases without private hostnames, LAN
+addresses, usernames, or filesystem paths.
+
+## Layered Test Surface
+
+Dream Server uses three standing validation layers:
+
+| Layer | Where it runs | Coverage | What it proves |
+|---|---|---|---|
+| CI matrix | GitHub Actions containers | Ubuntu 24.04/22.04, Debian 12, Linux Mint 21.3, Fedora 41, Rocky 9, Arch, Manjaro, CachyOS, openSUSE Tumbleweed | os-release parsing, package-manager detection, installer syntax, and dry-run logic |
+| Fleet distro lab | tower2 Docker containers + Incus VMs | 10 container distros plus VMs for Ubuntu 24.04, Fedora 42, Rocky 9, Arch current, and openSUSE Tumbleweed | fast distro breadth plus real systemd, network, Docker daemon, Compose, and installer dry-run with Docker enabled |
+| Real hardware fleet | Private local machines | Linux NVIDIA, Linux AMD, Linux ARM NVIDIA, macOS Apple Silicon, Windows laptop | fresh installs, GPU runtime, dashboard, Hermes, UI, lifecycle, and agent capabilities |
+
+Containers are breadth, not user-experience proof. Incus VMs add systemd,
+kernel, and Docker-daemon realism, but they still do not prove GPU runtime.
+Physical fleet machines remain the release gate for accelerator and product
+behavior.
 
 ## Hardware Surface
 
@@ -18,12 +33,13 @@ hostnames, LAN addresses, usernames, or filesystem paths.
 | macOS high-memory Apple Silicon | macOS | arm64 | Native Metal inference + Docker services | 120 GB+ unified | Large-model macOS validation target |
 | Windows hybrid GPU laptop | Windows 11 + Docker Desktop/WSL2 | x86_64 | NVIDIA mobile GPU plus Intel Arc integrated GPU | 32 GB+ system RAM | Windows installer, Docker Desktop, WSL2, and mobile-GPU validation target |
 
-This standing fleet is the repeatable release surface: it can run in parallel
-whenever installer, bootstrap, dashboard, agent, model, or extension code
-changes. Community and volunteer testers add broader coverage on other GPUs,
-distros, operating-system versions, storage layouts, and network environments,
-but those reports are complementary evidence rather than the always-on release
-gate.
+This standing hardware fleet is the repeatable release surface for GPU and
+product behavior: it can run in parallel whenever installer, bootstrap,
+dashboard, agent, model, or extension code changes. The CI matrix and tower2
+distro lab add repeatable distro evidence between hardware fleet runs.
+Community and volunteer testers add broader coverage on other GPUs, distros,
+operating-system versions, storage layouts, and network environments, but those
+reports are complementary evidence rather than the always-on release gate.
 
 ## Fleet Phases
 
@@ -45,8 +61,17 @@ each host where the phase is applicable.
 
 ## Representative Evidence
 
-Recent fleet runs on 2026-05-20 exercised the Linux NVIDIA, Linux AMD, Linux
-ARM NVIDIA, constrained macOS, and high-memory macOS surfaces with fresh
+Recent distro-lab runs on 2026-05-21 passed the 10-distro Docker container
+matrix and the 5-lane Incus VM matrix. Those runs exercised Ubuntu 24.04,
+Ubuntu 22.04, Debian 12, Linux Mint 21.3, Fedora, Rocky 9, Arch, Manjaro,
+CachyOS, and openSUSE installer logic, plus systemd and Docker-daemon behavior
+inside Incus VMs for Ubuntu, Fedora, Rocky, Arch, and openSUSE. The work also
+surfaced infrastructure and product-relevant issues: tower2 needed Incus
+bridge/firewall allowance, and Rocky-family installs needed a Docker CE fallback
+when distro packages were not available.
+
+Recent hardware fleet runs on 2026-05-20 exercised the Linux NVIDIA, Linux AMD,
+Linux ARM NVIDIA, constrained macOS, and high-memory macOS surfaces with fresh
 install, verify, dashboard, Hermes, and capability phases. The harness also
 surfaced an external DNS/download failure on one macOS run, which is evidence
 that environment failures are visible rather than silently converted into
@@ -60,8 +85,12 @@ artifacts for the release candidate being claimed.
 
 ## What This Proves
 
+- Installer OS and package-manager logic is exercised across 10 Linux distro
+  lanes in CI/container form.
+- Systemd, network, Docker daemon, Docker Compose, and installer dry-run
+  behavior are exercised in disposable Incus VMs for the major Linux families.
 - The installer is repeatedly exercised on real machines, not only CI
-  containers.
+  containers and VMs.
 - The release path covers heterogeneous GPU vendors, memory sizes, operating
   systems, and CPU architectures.
 - The harness records environment state before install so firewall, Docker,
@@ -73,8 +102,11 @@ artifacts for the release candidate being claimed.
 ## What This Does Not Claim
 
 - Every Linux distribution is exhaustively installed on real hardware for every
-  change. CI and distrobox cover broader distro logic; the fleet covers the
-  high-value hardware paths.
+  change. CI containers and the tower2 distro lab cover broad distro logic and
+  systemd/Docker VM behavior; the physical fleet covers the high-value hardware
+  paths.
+- The Incus VM matrix is not GPU validation. GPU runtime claims require real
+  NVIDIA, AMD, Intel, or Apple hardware evidence.
 - OS and distro rotation is periodic because reprovisioning real machines is
   intentionally slower than running the standing fleet. Release notes should
   call out any rotated distro or OS image that was included for that candidate.


### PR DESCRIPTION
## Summary
- update the README support blurb with the expanded tested distro list and the layered validation model
- document the CI/container, tower2 Incus VM, and real-hardware fleet layers in the validation matrix
- align the support matrix, docs index, and testing guide language with the new testing surface

## Validation
- `git diff --check`

Docs-only change; no runtime tests required.