### PR TITLE
release: prepare 2.5.0

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,21 +6,71 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-05-21
+
 ### Added
-- Sanitized real-hardware validation matrix documenting the fleet surface,
-  tested phases, release-readiness receipt, and current evidence boundaries.
-- AMD runtime diagnostics endpoint (`/api/gpu/amd-runtime`) reports Lemonade vs llama-server, host vs container, accelerator backend, and health from explicit installer state.
-- Explicit AMD inference env contract (`AMD_INFERENCE_RUNTIME`, `AMD_INFERENCE_BACKEND`, `AMD_INFERENCE_LOCATION`, `AMD_INFERENCE_PORT`) for Linux, Windows, and WSL/Docker Desktop installs.
-- AMD runtime capability metadata (`AMD_INFERENCE_SUPPORTED_BACKENDS`, `AMD_INFERENCE_RUNTIME_MODE`, `AMD_INFERENCE_MANAGED`) for dashboard diagnostics and `dream doctor`.
+- Multi-distro release validation covering Ubuntu 24.04/22.04, Debian 12,
+  Linux Mint 21.3, Fedora 41, Rocky Linux 9, Arch, Manjaro, CachyOS, and
+  openSUSE Tumbleweed in CI/container form.
+- tower2 Incus VM distro lab for real systemd, network, Docker daemon, Docker
+  Compose, and installer dry-run coverage on Ubuntu 24.04, Fedora 42, Rocky 9,
+  Arch current, and openSUSE Tumbleweed.
+- Sanitized validation matrix documenting the layered CI, distro lab, and
+  real-hardware fleet surface, tested phases, release-readiness receipt, and
+  current evidence boundaries.
+- AMD runtime diagnostics endpoint (`/api/gpu/amd-runtime`) reports Lemonade vs
+  llama-server, host vs container, accelerator backend, and health from
+  explicit installer state.
+- Explicit AMD inference env contract (`AMD_INFERENCE_RUNTIME`,
+  `AMD_INFERENCE_BACKEND`, `AMD_INFERENCE_LOCATION`, `AMD_INFERENCE_PORT`) for
+  Linux, Windows, and WSL/Docker Desktop installs.
+- AMD runtime capability metadata (`AMD_INFERENCE_SUPPORTED_BACKENDS`,
+  `AMD_INFERENCE_RUNTIME_MODE`, `AMD_INFERENCE_MANAGED`) for dashboard
+  diagnostics and `dream doctor`.
+- Release evidence and golden-path contracts for generated config, update
+  rollback behavior, and downstream builder validation.
 
 ### Changed
 - Linked public support, testing, and platform-claim docs to the validation
-  matrix so release claims point at real hardware evidence.
+  matrix so release claims point at layered evidence instead of informal
+  maintainer memory.
 - Updated Dream Proxy and Hermes Proxy to `caddy:2.11.3-alpine`.
-- Centralized AMD Lemonade runtime metadata in `config/backends/amd.json` and aligned the Linux Docker image pin to `ghcr.io/lemonade-sdk/lemonade-server:v10.2.0`.
+- Centralized AMD Lemonade runtime metadata in `config/backends/amd.json` and
+  aligned the Linux Docker image pin to
+  `ghcr.io/lemonade-sdk/lemonade-server:v10.2.0`.
+- Hardened installer/runtime defaults for Hermes, OpenCode, Perplexica,
+  bootstrap model swaps, update flows, and extension gating.
 
 ### Fixed
-- Windows AMD installs now pass deterministic runtime state into dashboard-api instead of requiring the container to infer host-side Lemonade vs Vulkan fallback.
+- Rocky/RHEL-family Docker installation now falls back to Docker's CentOS/RHEL
+  repository when distro packages are unavailable.
+- DNF package resolution now avoids `curl` vs `curl-minimal` conflicts on
+  Fedora/RHEL-style systems.
+- Windows AMD installs now pass deterministic runtime state into dashboard-api
+  instead of requiring the container to infer host-side Lemonade vs Vulkan
+  fallback.
+- Perplexica, LiteLLM, OpenCode, bootstrap-upgrade, uninstall, macOS logging,
+  and model-selection regressions fixed across the 2.5.0 cycle.
+
+### Security
+- Documented the retired LiveKit credential exposure as resolved so public audit
+  readers do not mistake retired leaked values for active secrets.
+- Added or expanded release contracts for dependency pinning, network exposure,
+  support bundles, and secret scanning.
+
+### Validation
+- Full fleet pass on 2026-05-21 in
+  `/home/michael/dream-fleet-test/runs/2026-05-21T15-48-27Z`.
+- Hardware fleet: tower2, Strix Halo, Spark, Mac mini, and M5 MacBook Pro all
+  passed install, 7/7 verify, Hermes seeded echo, UI checks, and applicable
+  capability probes.
+- Regressions: 9/9 fixtures green, 0 bugs detected, 0 PRs opened.
+- Distro lab: Docker matrix passed 10/10 distros; Incus VM matrix passed 5/5
+  VMs with real systemd + Docker and clean installer dry-runs.
+- Known follow-up: concurrent `fleet-multi-distro.sh` and a heavy
+  `dream-fleet-test` install on the same host can create I/O contention. Prefer
+  serialization or a future `--parallel-limit` flag when running both surfaces
+  together.
 
 ## [2.4.0] - 2026-03-24
 

--- a/dream-server/docs/VALIDATION-MATRIX.md
+++ b/dream-server/docs/VALIDATION-MATRIX.md
@@ -61,21 +61,31 @@ each host where the phase is applicable.
 
 ## Representative Evidence
 
-Recent distro-lab runs on 2026-05-21 passed the 10-distro Docker container
-matrix and the 5-lane Incus VM matrix. Those runs exercised Ubuntu 24.04,
-Ubuntu 22.04, Debian 12, Linux Mint 21.3, Fedora, Rocky 9, Arch, Manjaro,
-CachyOS, and openSUSE installer logic, plus systemd and Docker-daemon behavior
-inside Incus VMs for Ubuntu, Fedora, Rocky, Arch, and openSUSE. The work also
-surfaced infrastructure and product-relevant issues: tower2 needed Incus
-bridge/firewall allowance, and Rocky-family installs needed a Docker CE fallback
-when distro packages were not available.
+The 2.5.0 release-candidate fleet run on 2026-05-21 passed in
+`/home/michael/dream-fleet-test/runs/2026-05-21T15-48-27Z`. The run exercised
+tower2, Strix Halo, Spark, Mac mini, and M5 MacBook Pro with fresh install,
+7/7 verify, Hermes seeded echo, UI checks, and applicable capability probes.
+Strix Halo and the M5 MacBook Pro fully proved capability probes on
+Qwen3.6-35B-A3B; the Mac mini fully proved capability probes on Qwen3.5-9B;
+tower2 and Spark deferred capability probes while still in bootstrap mode.
+Regression replay finished 9/9 fixtures green with 0 bugs detected and 0 PRs
+opened.
 
-Recent hardware fleet runs on 2026-05-20 exercised the Linux NVIDIA, Linux AMD,
-Linux ARM NVIDIA, constrained macOS, and high-memory macOS surfaces with fresh
-install, verify, dashboard, Hermes, and capability phases. The harness also
-surfaced an external DNS/download failure on one macOS run, which is evidence
-that environment failures are visible rather than silently converted into
-product passes.
+The same release-candidate pass included the distro lab. The Docker matrix
+validated 10/10 distros: Ubuntu 24.04, Ubuntu 22.04, Debian 12, Linux Mint
+21.3, Fedora 41, Rocky 9, Arch, Manjaro, CachyOS, and openSUSE Tumbleweed.
+Linux Mint and Fedora hit transient I/O contention while tower2 was also doing
+a heavy fleet install, then passed cleanly on solo retry. The Incus VM matrix
+validated 5/5 VMs: Ubuntu 24.04, Fedora 42, Rocky 9, Arch current, and
+openSUSE Tumbleweed, each booting real systemd + Docker and running the
+installer dry-run cleanly.
+
+Earlier 2026-05-21 distro-lab work also surfaced infrastructure and
+product-relevant issues: tower2 needed Incus bridge/firewall allowance, and
+Rocky-family installs needed a Docker CE fallback when distro packages were not
+available. The harness also previously surfaced an external DNS/download
+failure on one macOS run, which is evidence that environment failures are
+visible rather than silently converted into product passes.
 
 The Windows laptop is part of the validation surface so Windows + Docker
 Desktop/WSL2 + mobile NVIDIA/Intel hybrid GPU behavior is not inferred from

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -937,7 +937,7 @@ async def _lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Dream Server Dashboard API",
-    version="2.4.0",
+    version="2.5.0",
     description="System status API for Dream Server Dashboard",
     lifespan=_lifespan,
 )

--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.4.0"
+VERSION="2.5.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Source path utilities for cross-platform path resolution

--- a/dream-server/installers/macos/lib/constants.sh
+++ b/dream-server/installers/macos/lib/constants.sh
@@ -11,7 +11,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-DS_VERSION="2.4.0"
+DS_VERSION="2.5.0"
 
 # Install location - use shared path resolution if available.
 # constants.sh lives at two different depths depending on layout:

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -392,7 +392,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
 # Tier: ${TIER} (${TIER_NAME})
 
 #=== Dream Server Version (used by dream-cli update for version-compat checks) ===
-DREAM_VERSION=${VERSION:-2.4.0}
+DREAM_VERSION=${VERSION:-2.5.0}
 
 #=== Network Binding ===
 # 127.0.0.1 = localhost only (secure default)

--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -10,7 +10,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-$script:DS_VERSION = "2.4.0"
+$script:DS_VERSION = "2.5.0"
 
 # Install location (override via $env:DREAM_HOME)
 # NOTE: $(if ...) syntax required for PS 5.1 compatibility (bare if-as-expression is PS 7+ only)

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 2,
-  "dream_version": "2.4.0",
+  "dream_version": "2.5.0",
   "min_compatible_dream_version": "1.0.0",
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.4.0",
+    "version": "2.5.0",
     "channel": "stable",
-    "date": "2026-03-24"
+    "date": "2026-05-21"
   },
   "compatibility": {
     "os": {


### PR DESCRIPTION
## Summary
- bump Dream Server version metadata to `2.5.0` across manifest, Linux/macOS/Windows installer constants, generated `.env` fallback, and dashboard-api metadata
- convert the changelog into a `2.5.0` release section with installer, distro-lab, validation, security, and runtime highlights
- update the public validation matrix with the 2026-05-21 fleet pass receipt and distro-lab result

## Fleet receipt
Full fleet pass: `/home/michael/dream-fleet-test/runs/2026-05-21T15-48-27Z`

- tower2, Strix Halo, Spark, Mac mini, and M5 MacBook Pro passed install + 7/7 verify + Hermes seeded echo + UI checks
- Strix Halo, Mac mini, and M5 MacBook Pro fully proved capability probes on loaded models; tower2 and Spark deferred caps while in bootstrap
- regressions: 9/9 fixtures green, 0 bugs detected, 0 PRs opened
- distro lab: Docker matrix 10/10 and Incus VM matrix 5/5

## Validation
- `git diff --check HEAD~1..HEAD`
- `python dream-server/scripts/check-version-consistency.py`
- `python -m py_compile dream-server/extensions/services/dashboard-api/main.py`
- `python -m json.tool dream-server/manifest.json`
- Git Bash syntax check: `bash -n dream-server/installers/lib/constants.sh dream-server/installers/macos/lib/constants.sh dream-server/installers/phases/06-directories.sh`
- PowerShell parse check for `dream-server/installers/windows/lib/constants.ps1`

Note: `dream-server/scripts/validate-manifests.sh` could not run in this Windows/Git Bash environment because `jq` is not installed; the version consistency script and JSON parser passed.

## Follow-up noted
The fleet run surfaced a non-release-blocking test-infra improvement: concurrent `fleet-multi-distro.sh` plus a heavy `dream-fleet-test` install on tower2 can cause I/O contention. The changelog records this as a known follow-up for serialization or a future `--parallel-limit` flag.