### PR TITLE
test: serialize fleet distro lab on tower2

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fleet distro lab Docker and Incus runners now take a shared host lock so
+  tower2 distro dry-runs do not contend with heavy full-fleet install/build
+  work on the same host.
+
 ## [2.5.0] - 2026-05-21
 
 ### Added

--- a/dream-server/docs/TESTING.md
+++ b/dream-server/docs/TESTING.md
@@ -71,6 +71,14 @@ cd ~/DreamServer/dream-server
 tests/fleet-multi-distro.sh --pull
 ```
 
+The Docker and Incus distro runners take a shared host lock by default:
+`/tmp/dream-fleet-heavy.lock`, or `DREAM_FLEET_HOST_LOCK` when set. The
+`/dream-fleet-test` harness uses the same lock when launching heavy tower2
+install work, so distro-lab dry-runs do not compete with full fleet installs
+for Docker/build I/O on the same host. Use `--lock-timeout SECONDS` when a CI
+or automation should fail instead of waiting, and reserve `--no-host-lock` for
+local debugging when you know no full fleet install is running.
+
 Run a focused subset while debugging:
 
 ```bash

--- a/dream-server/docs/VALIDATION-MATRIX.md
+++ b/dream-server/docs/VALIDATION-MATRIX.md
@@ -78,7 +78,9 @@ Linux Mint and Fedora hit transient I/O contention while tower2 was also doing
 a heavy fleet install, then passed cleanly on solo retry. The Incus VM matrix
 validated 5/5 VMs: Ubuntu 24.04, Fedora 42, Rocky 9, Arch current, and
 openSUSE Tumbleweed, each booting real systemd + Docker and running the
-installer dry-run cleanly.
+installer dry-run cleanly. The tower2 distro runners now use a shared host
+lock with the fleet harness so full fleet installs and distro-lab Docker/Incus
+work do not run heavy build surfaces against the same host at the same time.
 
 Earlier 2026-05-21 distro-lab work also surfaced infrastructure and
 product-relevant issues: tower2 needed Incus bridge/firewall allowance, and

--- a/dream-server/tests/fleet-incus-vm.sh
+++ b/dream-server/tests/fleet-incus-vm.sh
@@ -12,6 +12,9 @@ MEMORY="4GiB"
 WAIT_TIMEOUT="600"
 KEEP_VMS=false
 RUN_INSTALLER_DRY_RUN=true
+HOST_LOCK=true
+LOCK_FILE="${DREAM_FLEET_HOST_LOCK:-/tmp/dream-fleet-heavy.lock}"
+LOCK_TIMEOUT="${DREAM_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-}"
 WORK_DIR=""
 
 declare -a CREATED_VMS=()
@@ -87,6 +90,11 @@ Options:
   --cpu N                   vCPUs per VM (default: 2)
   --memory SIZE             Memory per VM (default: 4GiB)
   --timeout SECONDS         Wait timeout for VM agent readiness (default: 600)
+  --lock-file PATH          Host lock path for coordinating with full fleet runs
+                            (default: DREAM_FLEET_HOST_LOCK or /tmp/dream-fleet-heavy.lock)
+  --lock-timeout SECONDS    Seconds to wait for the host lock before failing
+                            (default: wait indefinitely)
+  --no-host-lock            Do not take the shared host lock
   -h, --help                Show this help
 
 Default matrix:
@@ -116,6 +124,32 @@ canonical_lane() {
         return 0
     fi
     return 1
+}
+
+acquire_host_lock() {
+    if [[ "$HOST_LOCK" != "true" ]]; then
+        return 0
+    fi
+
+    if ! command -v flock >/dev/null 2>&1; then
+        log "WARN: flock is unavailable; running without host-level contention guard."
+        return 0
+    fi
+
+    local lock_dir
+    lock_dir="$(dirname "$LOCK_FILE")"
+    mkdir -p "$lock_dir"
+
+    exec 9>"$LOCK_FILE"
+    log "Acquiring fleet host lock: $LOCK_FILE"
+    if [[ -n "$LOCK_TIMEOUT" ]]; then
+        if ! flock -w "$LOCK_TIMEOUT" 9; then
+            fail "Timed out waiting for fleet host lock: $LOCK_FILE"
+        fi
+    else
+        flock 9
+    fi
+    log "Acquired fleet host lock: $LOCK_FILE"
 }
 
 cleanup() {
@@ -168,6 +202,18 @@ while (($# > 0)); do
             WAIT_TIMEOUT="${2:?missing value for --timeout}"
             shift 2
             ;;
+        --lock-file)
+            LOCK_FILE="${2:?missing value for --lock-file}"
+            shift 2
+            ;;
+        --lock-timeout)
+            LOCK_TIMEOUT="${2:?missing value for --lock-timeout}"
+            shift 2
+            ;;
+        --no-host-lock)
+            HOST_LOCK=false
+            shift
+            ;;
         -h|--help)
             usage
             exit 0
@@ -189,6 +235,8 @@ fi
 
 command -v incus >/dev/null 2>&1 || fail "incus command not found"
 incus info >/dev/null 2>&1 || fail "incus is not initialized or this user cannot access it"
+
+acquire_host_lock
 
 WORK_DIR="$(mktemp -d)"
 PAYLOAD="$WORK_DIR/dream-server-src.tgz"

--- a/dream-server/tests/fleet-multi-distro.sh
+++ b/dream-server/tests/fleet-multi-distro.sh
@@ -67,6 +67,9 @@ ORDER=(ubuntu2404 ubuntu2204 debian12 mint213 fedora41 rocky9 arch manjaro cachy
 PULL=false
 RUN_DRY_RUN=true
 KEEP_WORK=false
+HOST_LOCK=true
+LOCK_FILE="${DREAM_FLEET_HOST_LOCK:-/tmp/dream-fleet-heavy.lock}"
+LOCK_TIMEOUT="${DREAM_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-}"
 TARGETS=()
 
 usage() {
@@ -79,6 +82,11 @@ Options:
   --pull          Pull/refresh distro images before running.
   --no-dry-run    Skip install-core.sh --dry-run inside each distro.
   --keep-work     Keep temporary host work directory for debugging.
+  --lock-file P    Host lock path for coordinating with full fleet runs.
+                  Default: DREAM_FLEET_HOST_LOCK or /tmp/dream-fleet-heavy.lock.
+  --lock-timeout N Seconds to wait for the host lock before failing.
+                  Default: wait indefinitely.
+  --no-host-lock  Do not take the shared host lock.
   --list          List supported distro IDs and images.
   -h, --help      Show this help.
 
@@ -101,6 +109,33 @@ normalize_distro() {
     printf '%s\n' "${ALIASES[$distro]:-$distro}"
 }
 
+acquire_host_lock() {
+    if [[ "$HOST_LOCK" != "true" ]]; then
+        return 0
+    fi
+
+    if ! command -v flock >/dev/null 2>&1; then
+        echo "WARN: flock is unavailable; running without host-level contention guard." >&2
+        return 0
+    fi
+
+    local lock_dir
+    lock_dir="$(dirname "$LOCK_FILE")"
+    mkdir -p "$lock_dir"
+
+    exec 9>"$LOCK_FILE"
+    echo "Acquiring fleet host lock: $LOCK_FILE"
+    if [[ -n "$LOCK_TIMEOUT" ]]; then
+        if ! flock -w "$LOCK_TIMEOUT" 9; then
+            echo "ERROR: timed out waiting for fleet host lock: $LOCK_FILE" >&2
+            exit 1
+        fi
+    else
+        flock 9
+    fi
+    echo "Acquired fleet host lock: $LOCK_FILE"
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --pull)
@@ -113,6 +148,18 @@ while [[ $# -gt 0 ]]; do
             ;;
         --keep-work)
             KEEP_WORK=true
+            shift
+            ;;
+        --lock-file)
+            LOCK_FILE="${2:?missing value for --lock-file}"
+            shift 2
+            ;;
+        --lock-timeout)
+            LOCK_TIMEOUT="${2:?missing value for --lock-timeout}"
+            shift 2
+            ;;
+        --no-host-lock)
+            HOST_LOCK=false
             shift
             ;;
         --list)
@@ -155,6 +202,8 @@ if ! docker info >/dev/null 2>&1; then
     echo "ERROR: docker daemon is not reachable." >&2
     exit 1
 fi
+
+acquire_host_lock
 
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dream-fleet-distro.XXXXXX")"
 cleanup() {


### PR DESCRIPTION
## Summary
- add shared host locking to the tower2 Docker and Incus distro-lab runners
- document the lock contract for `/dream-fleet-test` and the validation surface
- note the issue #1314 contention fix in the changelog

## Tower2 local updates
- updated `/home/michael/dream-fleet-test/run.sh` so install/lifecycle phases take `/tmp/dream-fleet-heavy.lock`
- updated `~/.claude/skills/dream-fleet-test/SKILL.md` so `/dream-fleet-test` knows the distro lab and full fleet harness share that lock

Fixes #1314.

## Validation
- `bash -n dream-server/tests/fleet-multi-distro.sh`
- `bash -n dream-server/tests/fleet-incus-vm.sh`
- `dream-server/tests/fleet-multi-distro.sh --help`
- `dream-server/tests/fleet-incus-vm.sh --help`
- tower2: `bash -n /home/michael/dream-fleet-test/run.sh`
- tower2 held-lock simulation: `fleet-multi-distro.sh --lock-timeout 1` timed out before launching heavy work
- tower2 held-lock simulation: `fleet-incus-vm.sh --lock-timeout 1` timed out before launching heavy work