### PR TITLE
fix(mdns): publish talk.<device>.local so owner-card phones can resolve it (#1319 follow-up)

### DIFF
--- a/dream-server/bin/dream-mdns.py
+++ b/dream-server/bin/dream-mdns.py
@@ -237,6 +237,13 @@ def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[Serv
         # upstream container isn't running, which is the right failure
         # mode for an optional extension.
         ("hermes",    "Hermes Agent (via proxy)"),
+        # talk.<device>.local is the owner-card redemption target for the
+        # mobile portal added in #1319. magic_link.py's _talk_url() points
+        # phones at this hostname; dream-proxy's Caddy block routes it to
+        # the dashboard container's /talk route. Without an A record here
+        # the redirect lands the phone on an unresolvable host and the
+        # owner experience stalls on a white screen.
+        ("talk",      "Dream Talk (mobile owner portal)"),
     )
     for suffix, label in subdomain_routes:
         server = f"{device_name}.local." if suffix == "root" else f"{suffix}.{device_name}.local."

--- a/dream-server/docs/MDNS.md
+++ b/dream-server/docs/MDNS.md
@@ -25,8 +25,9 @@ Two flavors:
 | `auth.<device>.local` | LAN IP, port 80 | proxy → dashboard-api (magic-link redemption) |
 | `api.<device>.local` | LAN IP, port 80 | proxy → dashboard-api (admin `/api/*`) |
 | `hermes.<device>.local` | LAN IP, port 80 | proxy → hermes-proxy (when enabled) |
+| `talk.<device>.local` | LAN IP, port 80 | proxy → dashboard `/talk` (mobile owner portal, #1319) |
 
-All six names resolve to the same IP — the device's LAN address. Routing happens at the dream-proxy by Host header (see `docs/DREAM-PROXY.md`). The bare `<device>.local` redirects to chat for the friendliest landing.
+All seven names resolve to the same IP — the device's LAN address. Routing happens at the dream-proxy by Host header (see `docs/DREAM-PROXY.md`). The bare `<device>.local` redirects to chat for the friendliest landing.
 
 **Direct-port SRV records (back-compat for service discovery):**
 

--- a/dream-server/extensions/services/dream-proxy/manifest.yaml
+++ b/dream-server/extensions/services/dream-proxy/manifest.yaml
@@ -40,6 +40,7 @@ service:
         auth.<device>.local      → dashboard-api (magic-link redemption)
         api.<device>.local       → dashboard-api (admin /api/*)
         hermes.<device>.local    → hermes-proxy (when enabled)
+        talk.<device>.local      → dashboard /talk (mobile owner portal)
     Per-subdomain routing means every backend stays root-mounted (no
     subpath gymnastics) and the dream-session cookie can be Domain-scoped
     to <device>.local so SSO works across all of them.

--- a/dream-server/tests/test_mdns_subdomains.py
+++ b/dream-server/tests/test_mdns_subdomains.py
@@ -1,0 +1,99 @@
+"""Contract tests for bin/dream-mdns.py's per-subdomain A-record set.
+
+The mDNS announcer publishes a fixed set of `<sub>.<device>.local` A records
+so phones on the LAN can resolve the proxy-routed hostnames the magic-link
+redemption flow points them at. If a backend service ships a new public host
+(see #1319 → talk.<device>.local) but the announcer's `subdomain_routes`
+tuple isn't updated, the phone falls off a cliff: the URL exists in Caddy,
+magic_link.py points users at it, redemption succeeds, then the browser
+can't resolve the host and the user sees a white screen.
+
+These tests guard the subdomain list against silent regressions of that
+class. They are static-source assertions (no zeroconf import) so they run
+in CI without needing a network bound.
+
+Run with: pytest tests/test_mdns_subdomains.py
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MDNS_SCRIPT = REPO_ROOT / "bin" / "dream-mdns.py"
+
+# The set of subdomains the announcer must publish. Each name corresponds to
+# a Caddy block in extensions/services/dream-proxy/Caddyfile and (for the
+# auth-bound ones) a redirect target in dashboard-api/routers/magic_link.py.
+#
+# When adding a new public subdomain, update *all three* sources in the same
+# PR: the Caddyfile route, the announcer here, and this test. The test is the
+# tripwire if any of the three is forgotten.
+REQUIRED_SUBDOMAINS = {
+    "root",       # bare <device>.local — redirects to chat
+    "chat",       # Open WebUI
+    "dashboard",  # operator UI
+    "auth",       # magic-link redemption (set-cookie + 302)
+    "api",        # dashboard-api admin surface
+    "hermes",     # hermes-proxy
+    "talk",       # mobile owner portal (#1319) — without this, phone scans land on white screen
+}
+
+
+def _extract_subdomain_routes_keys() -> set[str]:
+    """Parse dream-mdns.py and return the set of subdomain names it announces.
+
+    We walk the AST instead of executing the script (which would need
+    zeroconf + a network interface). Looks for the `subdomain_routes`
+    assignment and pulls the first element of each tuple.
+    """
+    source = MDNS_SCRIPT.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "subdomain_routes" not in targets:
+            continue
+        value = node.value
+        if not isinstance(value, ast.Tuple):
+            continue
+        for elt in value.elts:
+            if isinstance(elt, ast.Tuple) and elt.elts:
+                first = elt.elts[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    found.add(first.value)
+    return found
+
+
+def test_announcer_publishes_all_required_subdomains() -> None:
+    found = _extract_subdomain_routes_keys()
+    missing = REQUIRED_SUBDOMAINS - found
+    assert not missing, (
+        f"bin/dream-mdns.py is missing required subdomains: {sorted(missing)}. "
+        "If you added a new public host, add it here AND in subdomain_routes. "
+        "If you removed a host on purpose, update REQUIRED_SUBDOMAINS in this test."
+    )
+
+
+def test_announcer_does_not_advertise_unknown_subdomains() -> None:
+    # Fail loudly when the announcer publishes a name nobody else expects.
+    # Catches drift in the opposite direction: stale entries that point at
+    # backends that no longer exist still draw LAN traffic toward Caddy and
+    # produce confusing 404s.
+    found = _extract_subdomain_routes_keys()
+    extra = found - REQUIRED_SUBDOMAINS
+    assert not extra, (
+        f"bin/dream-mdns.py publishes subdomains not listed in REQUIRED_SUBDOMAINS: "
+        f"{sorted(extra)}. Add them to the set above (and confirm Caddy + magic_link "
+        "agree) or remove them from subdomain_routes."
+    )
+
+
+if __name__ == "__main__":
+    test_announcer_publishes_all_required_subdomains()
+    test_announcer_does_not_advertise_unknown_subdomains()
+    print("OK")


### PR DESCRIPTION
## Summary

The Dream Talk mobile portal (added in #1319) is reached at `talk.<device>.local`. Caddy in `dream-proxy` routes that host correctly, and `magic_link.py`'s `_talk_url()` points owner-card redemptions at it. **But `bin/dream-mdns.py`'s `subdomain_routes` tuple was never updated to publish an A record for `talk`**, so the phone has no way to resolve the host after the redirect.

User-visible failure (reported on a phone scanning a real owner card):

> "Factory owner card works, dashboard can see the card being used, but on my phone no portal is coming up — just a white screen on a new load."

That matches exactly: the redemption side (auth → cookie set → 302) all succeeds, but the redirect target (`http://talk.<device>.local/talk`) is a hostname nobody on the LAN ever announced.

## Root cause

`bin/dream-mdns.py:230` lists every subdomain it publishes:

```python
subdomain_routes = (
    ("root",     "Dream Root Redirect (via proxy)"),
    ("chat",      "Dream Chat (via proxy)"),
    ("dashboard", "Dream Dashboard (via proxy)"),
    ("auth",      "Dream Auth (magic-link redemption)"),
    ("api",       "Dream API (admin)"),
    ("hermes",    "Hermes Agent (via proxy)"),
)
```

`talk` was missing. The Caddy block at `extensions/services/dream-proxy/Caddyfile:92` (`http://talk.{$DREAM_DEVICE_NAME:dream}.local`) exists, and `magic_link.py:425` `_talk_url()` returns `http://talk.<device>.local/talk`, but the LAN never learns the IP for that name.

## Fix

One-line tuple entry that brings the announcer in sync with the rest of the stack:

```python
("talk",      "Dream Talk (mobile owner portal)"),
```

Plus the corresponding line in the `docs/MDNS.md` subdomain table and the `extensions/services/dream-proxy/manifest.yaml` enumeration so they don't drift again.

## Verification

Restarted the announcer on tower2 with the patched code; log now shows the missing publication:

```
2026-05-21 16:34:13 [dream-mdns] INFO Published tower2-proxy-talk._http._tcp.local. → 192.168.0.175:80 (server talk.tower2.local.)
```

Other subdomains continue to announce as before. The published A record is what a phone's mDNS client listens for on the multicast broadcast — `getent` on the host itself doesn't see it unless avahi-daemon is bridging zeroconf into NSS, which is independent of this fix.

## Contract test (prevents the same class of drift)

Adds `dream-server/tests/test_mdns_subdomains.py` that AST-parses `dream-mdns.py` and asserts the published subdomain set matches a `REQUIRED_SUBDOMAINS` constant.

- If anyone adds a new public host (new Caddy block + new magic-link target) without updating `subdomain_routes`, the test fails and explicitly names the file to edit.
- If anyone removes a host from `subdomain_routes` without updating the test, the same.

```
$ python3 tests/test_mdns_subdomains.py
OK
```

**Follow-up to wire into CI:** I tried to add this to `.github/workflows/test-linux.yml` alongside the existing `Perplexica Entrypoint Contract Tests` step but GitHub rejected the push because the OAuth app this branch was pushed from lacks the `workflow` scope. The one-line addition that should land separately:

```yaml
- name: mDNS Subdomain Contract Tests
  run: python3 tests/test_mdns_subdomains.py
```

## Risk / blast radius

Local config-only change to the mDNS announcer + two doc updates + one new test. No effect on other services. The contract test pins the set so future merges can't quietly drop `talk` (or any other) subdomain again.
