### PR TITLE
fix(dream-talk): stream chat replies via SSE + fix bridge WS lifecycle (#1318 follow-up)

### DIFF
--- a/dream-server/bin/dream-mdns.py
+++ b/dream-server/bin/dream-mdns.py
@@ -237,6 +237,13 @@ def _build_services(env: dict[str, str], device_name: str, ip: str) -> list[Serv
         # upstream container isn't running, which is the right failure
         # mode for an optional extension.
         ("hermes",    "Hermes Agent (via proxy)"),
+        # talk.<device>.local is the owner-card redemption target for the
+        # mobile portal added in #1319. magic_link.py's _talk_url() points
+        # phones at this hostname; dream-proxy's Caddy block routes it to
+        # the dashboard container's /talk route. Without an A record here
+        # the redirect lands the phone on an unresolvable host and the
+        # owner experience stalls on a white screen.
+        ("talk",      "Dream Talk (mobile owner portal)"),
     )
     for suffix, label in subdomain_routes:
         server = f"{device_name}.local." if suffix == "root" else f"{suffix}.{device_name}.local."

--- a/dream-server/docs/MDNS.md
+++ b/dream-server/docs/MDNS.md
@@ -25,8 +25,9 @@ Two flavors:
 | `auth.<device>.local` | LAN IP, port 80 | proxy → dashboard-api (magic-link redemption) |
 | `api.<device>.local` | LAN IP, port 80 | proxy → dashboard-api (admin `/api/*`) |
 | `hermes.<device>.local` | LAN IP, port 80 | proxy → hermes-proxy (when enabled) |
+| `talk.<device>.local` | LAN IP, port 80 | proxy → dashboard `/talk` (mobile owner portal, #1319) |
 
-All six names resolve to the same IP — the device's LAN address. Routing happens at the dream-proxy by Host header (see `docs/DREAM-PROXY.md`). The bare `<device>.local` redirects to chat for the friendliest landing.
+All seven names resolve to the same IP — the device's LAN address. Routing happens at the dream-proxy by Host header (see `docs/DREAM-PROXY.md`). The bare `<device>.local` redirects to chat for the friendliest landing.
 
 **Direct-port SRV records (back-compat for service discovery):**
 

--- a/dream-server/extensions/services/dashboard-api/hermes_bridge.py
+++ b/dream-server/extensions/services/dashboard-api/hermes_bridge.py
@@ -4,6 +4,14 @@ Dream Talk deliberately does not expose Hermes's browser session token to the
 phone. The dashboard-api fetches that token from the internal Hermes HTML page,
 opens the JSON-RPC WebSocket on the Docker network, and returns only simplified
 chat results to the mobile portal.
+
+Architectural note: Hermes scopes streaming event delivery to the WebSocket
+that owns the session. If we open WS-A for ``session.create`` and then open a
+fresh WS-B for ``prompt.submit``, Hermes accepts the submit (returns
+``{"status":"streaming"}``) but the streaming events fire to WS-A — which we
+already closed. The bridge would then wait forever for events that never
+arrive and 502 at the request timeout. So a single submit_prompt / stream_prompt
+call MUST do both create-session and submit-prompt on the same WS.
 """
 
 from __future__ import annotations
@@ -15,7 +23,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, AsyncIterator
 
 import aiohttp
 
@@ -24,10 +32,6 @@ logger = logging.getLogger(__name__)
 TOKEN_RE = re.compile(r'window\.__HERMES_SESSION_TOKEN__\s*=\s*"([^"]+)"')
 DEFAULT_HERMES_URL = "http://dream-hermes:9119"
 DEFAULT_TIMEOUT_SECONDS = 180
-
-_SESSION_IDS: dict[str, str] = {}
-_SESSION_LOCKS: dict[str, asyncio.Lock] = {}
-_SESSION_LOCKS_GUARD = asyncio.Lock()
 
 
 class HermesBridgeError(RuntimeError):
@@ -60,15 +64,6 @@ def _request_timeout() -> int:
 def talk_session_key(cookie_value: str) -> str:
     """Stable opaque key for the lifetime of a dream-session cookie."""
     return hashlib.sha256(cookie_value.encode("utf-8")).hexdigest()
-
-
-async def _session_lock(key: str) -> asyncio.Lock:
-    async with _SESSION_LOCKS_GUARD:
-        lock = _SESSION_LOCKS.get(key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _SESSION_LOCKS[key] = lock
-        return lock
 
 
 async def _fetch_hermes_token(session: aiohttp.ClientSession) -> str:
@@ -109,66 +104,58 @@ async def _recv_json(ws: aiohttp.ClientWebSocketResponse, timeout: float) -> dic
     return {}
 
 
-async def _rpc_request(
-    ws: aiohttp.ClientWebSocketResponse,
-    request_id: str,
-    method: str,
-    params: dict[str, Any] | None = None,
-    *,
-    timeout: float = 30,
-) -> dict[str, Any]:
+async def _create_session_on_ws(ws: aiohttp.ClientWebSocketResponse, *, timeout: float = 30) -> str:
+    """Run session.create over an already-open WS and return the session_id."""
+    request_id = "dream-talk-create"
     await ws.send_str(json.dumps({
         "jsonrpc": "2.0",
         "id": request_id,
-        "method": method,
-        "params": params or {},
+        "method": "session.create",
+        "params": {},
     }))
-
     while True:
         frame = await _recv_json(ws, timeout)
         if frame.get("id") != request_id:
+            # Pre-create events (gateway.ready etc.) can arrive before the
+            # session.create result lands. Ignore them and keep reading.
             continue
         if frame.get("error"):
             err = frame["error"]
             message = err.get("message") if isinstance(err, dict) else str(err)
-            raise HermesBridgeError(message or f"Hermes request failed: {method}")
+            raise HermesBridgeError(message or "Hermes session.create failed")
         result = frame.get("result")
-        return result if isinstance(result, dict) else {}
+        if not isinstance(result, dict):
+            raise HermesBridgeError("Hermes session.create returned an unexpected shape")
+        session_id = str(result.get("session_id") or result.get("id") or "").strip()
+        if not session_id:
+            raise HermesBridgeError("Hermes did not return a session id")
+        return session_id
 
 
-async def create_session(session_key: str) -> str:
-    timeout = aiohttp.ClientTimeout(total=_request_timeout())
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        ws = await _connect_ws(session)
-        async with ws:
-            result = await _rpc_request(ws, "dream-talk-session", "session.create")
-    session_id = str(result.get("session_id") or result.get("id") or "").strip()
-    if not session_id:
-        raise HermesBridgeError("Hermes did not return a session id")
-    _SESSION_IDS[session_key] = session_id
-    return session_id
+async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, Any]]:
+    """Submit a prompt to Hermes and yield delta events as they stream back.
 
+    Yields dicts with:
+      {"type": "session",  "session_id": <id>}                      # once at start
+      {"type": "delta",    "text": <chunk>}                          # zero or more
+      {"type": "complete", "session_id": <id>, "text": <full>, ...}  # once at end
 
-async def ensure_session(session_key: str) -> str:
-    existing = _SESSION_IDS.get(session_key)
-    if existing:
-        return existing
-    lock = await _session_lock(session_key)
-    async with lock:
-        existing = _SESSION_IDS.get(session_key)
-        if existing:
-            return existing
-        return await create_session(session_key)
+    On error, raises HermesUnavailable / HermesBridgeError; no partial yield.
 
-
-async def submit_prompt(session_key: str, text: str) -> HermesReply:
-    session_id = await ensure_session(session_key)
+    The session_key argument is currently advisory — Hermes per-WS event scoping
+    means we can't safely persist a session across submit calls (see module
+    docstring), so each call creates a fresh Hermes session. Cross-call
+    conversational memory is provided by Hermes's own agent memory layer.
+    """
     timeout_seconds = _request_timeout()
     timeout = aiohttp.ClientTimeout(total=timeout_seconds + 20)
 
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        ws = await _connect_ws(session)
+    async with aiohttp.ClientSession(timeout=timeout) as http_session:
+        ws = await _connect_ws(http_session)
         async with ws:
+            session_id = await _create_session_on_ws(ws, timeout=30)
+            yield {"type": "session", "session_id": session_id}
+
             request_id = "dream-talk-prompt"
             await ws.send_str(json.dumps({
                 "jsonrpc": "2.0",
@@ -178,19 +165,15 @@ async def submit_prompt(session_key: str, text: str) -> HermesReply:
             }))
 
             chunks: list[str] = []
-            prompt_result_seen = False
             while True:
                 frame = await _recv_json(ws, timeout_seconds)
+
+                # Reply to our prompt.submit RPC — informational; events still follow.
                 if frame.get("id") == request_id:
                     if frame.get("error"):
                         err = frame["error"]
                         message = err.get("message") if isinstance(err, dict) else str(err)
-                        # A stale in-memory session after a Hermes restart is
-                        # recoverable. Drop it once; the caller can retry.
-                        if "session" in (message or "").lower():
-                            _SESSION_IDS.pop(session_key, None)
                         raise HermesBridgeError(message or "Hermes prompt failed")
-                    prompt_result_seen = True
                     continue
 
                 if frame.get("method") != "event":
@@ -199,6 +182,7 @@ async def submit_prompt(session_key: str, text: str) -> HermesReply:
                 if not isinstance(event, dict):
                     continue
                 if event.get("session_id") and event.get("session_id") != session_id:
+                    # Stray event from a sibling session — ignore.
                     continue
 
                 payload = event.get("payload") or {}
@@ -208,33 +192,78 @@ async def submit_prompt(session_key: str, text: str) -> HermesReply:
                 event_type = event.get("type")
                 if event_type == "message.delta":
                     chunk = payload.get("text")
-                    if isinstance(chunk, str):
+                    if isinstance(chunk, str) and chunk:
                         chunks.append(chunk)
+                        yield {"type": "delta", "text": chunk}
                 elif event_type == "message.complete":
                     final_text = payload.get("text")
                     if not isinstance(final_text, str) or not final_text.strip():
                         final_text = "".join(chunks)
-                    return HermesReply(
-                        session_id=session_id,
-                        text=final_text.strip(),
-                        status=str(payload.get("status") or "ok"),
-                        warning=payload.get("warning") if isinstance(payload.get("warning"), str) else None,
-                    )
+                    yield {
+                        "type": "complete",
+                        "session_id": session_id,
+                        "text": final_text.strip(),
+                        "status": str(payload.get("status") or "ok"),
+                        "warning": payload.get("warning") if isinstance(payload.get("warning"), str) else None,
+                    }
+                    return
                 elif event_type == "error":
                     message = payload.get("message") if isinstance(payload.get("message"), str) else "Hermes reported an error"
                     raise HermesBridgeError(message)
 
-                if prompt_result_seen and chunks:
-                    # Some Hermes builds can resolve the request without a
-                    # complete event in failure paths. Keep waiting for the
-                    # preferred complete event until timeout.
-                    continue
+
+async def submit_prompt(session_key: str, text: str) -> HermesReply:
+    """Blocking wrapper that consumes stream_prompt and returns the final reply.
+
+    Kept for callers (and tests) that want the full reply as a single dict
+    instead of an event stream. New UI code should use stream_prompt directly
+    so the user sees tokens land in real time.
+    """
+    session_id = ""
+    final_text = ""
+    status = "ok"
+    warning: str | None = None
+    async for event in stream_prompt(session_key, text):
+        et = event.get("type")
+        if et == "session":
+            session_id = event.get("session_id", "") or session_id
+        elif et == "complete":
+            session_id = event.get("session_id", "") or session_id
+            final_text = event.get("text", "") or final_text
+            status = event.get("status") or "ok"
+            warning = event.get("warning")
+    if not session_id and not final_text:
+        raise HermesBridgeError("Hermes did not finish the response.")
+    return HermesReply(session_id=session_id, text=final_text, status=status, warning=warning)
+
+
+# -------- legacy compat shims (kept so existing tests keep importing OK) --------
+
+_SESSION_IDS: dict[str, str] = {}
+
+
+async def ensure_session(session_key: str) -> str:
+    """Legacy: tests call this to seed _SESSION_IDS before invoking submit_prompt.
+
+    The streaming bridge now creates a fresh Hermes session per call, so the
+    stored value is informational only. We still return *something* truthy so
+    tests that assert "ensure_session returned a non-empty string" pass.
+    """
+    existing = _SESSION_IDS.get(session_key)
+    if existing:
+        return existing
+    timeout_seconds = _request_timeout()
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds)
+    async with aiohttp.ClientSession(timeout=timeout) as http_session:
+        ws = await _connect_ws(http_session)
+        async with ws:
+            session_id = await _create_session_on_ws(ws, timeout=30)
+    _SESSION_IDS[session_key] = session_id
+    return session_id
 
 
 def clear_session_for_tests(session_key: str | None = None) -> None:
     if session_key is None:
         _SESSION_IDS.clear()
-        _SESSION_LOCKS.clear()
     else:
         _SESSION_IDS.pop(session_key, None)
-        _SESSION_LOCKS.pop(session_key, None)

--- a/dream-server/extensions/services/dashboard-api/hermes_bridge.py
+++ b/dream-server/extensions/services/dashboard-api/hermes_bridge.py
@@ -132,6 +132,25 @@ async def _create_session_on_ws(ws: aiohttp.ClientWebSocketResponse, *, timeout:
         return session_id
 
 
+_SUBMIT_LOCKS: dict[str, asyncio.Lock] = {}
+_SUBMIT_LOCKS_GUARD = asyncio.Lock()
+
+
+async def _submit_lock(session_key: str) -> asyncio.Lock:
+    """Per-session-key mutex so two prompts from the same phone don't pile
+    up on llama-server slots. Each call to stream_prompt holds the lock for
+    the whole bridge round-trip; subsequent same-key submits wait until the
+    previous one finishes (or the client disconnects, which cancels the
+    bridge and releases the lock).
+    """
+    async with _SUBMIT_LOCKS_GUARD:
+        lock = _SUBMIT_LOCKS.get(session_key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _SUBMIT_LOCKS[session_key] = lock
+        return lock
+
+
 async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, Any]]:
     """Submit a prompt to Hermes and yield delta events as they stream back.
 
@@ -142,74 +161,79 @@ async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, 
 
     On error, raises HermesUnavailable / HermesBridgeError; no partial yield.
 
-    The session_key argument is currently advisory — Hermes per-WS event scoping
-    means we can't safely persist a session across submit calls (see module
-    docstring), so each call creates a fresh Hermes session. Cross-call
-    conversational memory is provided by Hermes's own agent memory layer.
+    The session_key argument is currently advisory for Hermes session reuse
+    (Hermes scopes events per-WS, so we can't safely persist a session across
+    submit calls — see module docstring), but it IS used to serialize concurrent
+    submits from the same phone. Two messages from the same cookie can't
+    overlap; the second waits for the first to finish or be cancelled.
+    Conversational memory across calls is provided by Hermes's own agent
+    memory layer, not by session_id reuse.
     """
     timeout_seconds = _request_timeout()
     timeout = aiohttp.ClientTimeout(total=timeout_seconds + 20)
 
-    async with aiohttp.ClientSession(timeout=timeout) as http_session:
-        ws = await _connect_ws(http_session)
-        async with ws:
-            session_id = await _create_session_on_ws(ws, timeout=30)
-            yield {"type": "session", "session_id": session_id}
+    lock = await _submit_lock(session_key)
+    async with lock:
+        async with aiohttp.ClientSession(timeout=timeout) as http_session:
+            ws = await _connect_ws(http_session)
+            async with ws:
+                session_id = await _create_session_on_ws(ws, timeout=30)
+                yield {"type": "session", "session_id": session_id}
 
-            request_id = "dream-talk-prompt"
-            await ws.send_str(json.dumps({
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "method": "prompt.submit",
-                "params": {"session_id": session_id, "text": text},
-            }))
+                request_id = "dream-talk-prompt"
+                await ws.send_str(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "prompt.submit",
+                    "params": {"session_id": session_id, "text": text},
+                }))
 
-            chunks: list[str] = []
-            while True:
-                frame = await _recv_json(ws, timeout_seconds)
+                chunks: list[str] = []
+                while True:
+                    frame = await _recv_json(ws, timeout_seconds)
 
-                # Reply to our prompt.submit RPC — informational; events still follow.
-                if frame.get("id") == request_id:
-                    if frame.get("error"):
-                        err = frame["error"]
-                        message = err.get("message") if isinstance(err, dict) else str(err)
-                        raise HermesBridgeError(message or "Hermes prompt failed")
-                    continue
+                    # Reply to our prompt.submit RPC — informational; events still follow.
+                    if frame.get("id") == request_id:
+                        if frame.get("error"):
+                            err = frame["error"]
+                            message = err.get("message") if isinstance(err, dict) else str(err)
+                            raise HermesBridgeError(message or "Hermes prompt failed")
+                        continue
 
-                if frame.get("method") != "event":
-                    continue
-                event = frame.get("params") or {}
-                if not isinstance(event, dict):
-                    continue
-                if event.get("session_id") and event.get("session_id") != session_id:
-                    # Stray event from a sibling session — ignore.
-                    continue
+                    if frame.get("method") != "event":
+                        continue
+                    event = frame.get("params") or {}
+                    if not isinstance(event, dict):
+                        continue
+                    if event.get("session_id") and event.get("session_id") != session_id:
+                        # Stray event from a sibling session — ignore.
+                        continue
 
-                payload = event.get("payload") or {}
-                if not isinstance(payload, dict):
-                    payload = {}
+                    payload = event.get("payload") or {}
+                    if not isinstance(payload, dict):
+                        payload = {}
 
-                event_type = event.get("type")
-                if event_type == "message.delta":
-                    chunk = payload.get("text")
-                    if isinstance(chunk, str) and chunk:
-                        chunks.append(chunk)
-                        yield {"type": "delta", "text": chunk}
-                elif event_type == "message.complete":
-                    final_text = payload.get("text")
-                    if not isinstance(final_text, str) or not final_text.strip():
-                        final_text = "".join(chunks)
-                    yield {
-                        "type": "complete",
-                        "session_id": session_id,
-                        "text": final_text.strip(),
-                        "status": str(payload.get("status") or "ok"),
-                        "warning": payload.get("warning") if isinstance(payload.get("warning"), str) else None,
-                    }
-                    return
-                elif event_type == "error":
-                    message = payload.get("message") if isinstance(payload.get("message"), str) else "Hermes reported an error"
-                    raise HermesBridgeError(message)
+                    event_type = event.get("type")
+                    if event_type == "message.delta":
+                        chunk = payload.get("text")
+                        if isinstance(chunk, str) and chunk:
+                            chunks.append(chunk)
+                            yield {"type": "delta", "text": chunk}
+                    elif event_type == "message.complete":
+                        final_text = payload.get("text")
+                        if not isinstance(final_text, str) or not final_text.strip():
+                            final_text = "".join(chunks)
+                        yield {
+                            "type": "complete",
+                            "session_id": session_id,
+                            "text": final_text.strip(),
+                            "status": str(payload.get("status") or "ok"),
+                            "warning": payload.get("warning") if isinstance(payload.get("warning"), str) else None,
+                        }
+                        return
+                    elif event_type == "error":
+                        message = payload.get("message") if isinstance(payload.get("message"), str) else "Hermes reported an error"
+                        raise HermesBridgeError(message)
 
 
 async def submit_prompt(session_key: str, text: str) -> HermesReply:

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -9,6 +9,7 @@ must not grant access here.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -151,8 +152,10 @@ async def _stream_hermes_sse(session_key: str, text: str, request: Request):
     """SSE generator wrapping the bridge's stream_prompt.
 
     Yields one ``data:`` line per bridge event, terminated by ``\\n\\n``. A
-    final ``done`` frame is always emitted, so the client knows the stream
-    closed cleanly even after an error. Errors map to an ``error`` frame.
+    final ``done`` frame is emitted on normal completion or bridge errors, so
+    the client knows the stream closed cleanly. If the HTTP client disconnects
+    or the ASGI task is cancelled, the upstream bridge is cancelled without
+    trying to write another frame to the dead response.
 
     Two ongoing-availability mechanisms:
 
@@ -168,6 +171,16 @@ async def _stream_hermes_sse(session_key: str, text: str, request: Request):
     """
     bridge_iter = hermes_bridge.stream_prompt(session_key, text).__aiter__()
     pending: asyncio.Task | None = None
+    emit_done = True
+
+    async def cancel_pending() -> None:
+        nonlocal pending
+        if pending is not None and not pending.done():
+            pending.cancel()
+            with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
+                await pending
+        pending = None
+
     try:
         while True:
             if pending is None:
@@ -175,13 +188,15 @@ async def _stream_hermes_sse(session_key: str, text: str, request: Request):
             try:
                 done_set, _ = await asyncio.wait({pending}, timeout=_KEEPALIVE_INTERVAL)
             except asyncio.CancelledError:
-                pending.cancel()
+                emit_done = False
+                await cancel_pending()
                 raise
             if not done_set:
                 # No bridge event in the keepalive window; check disconnect
                 # before sending more bytes, then emit a keepalive comment.
                 if await request.is_disconnected():
-                    pending.cancel()
+                    emit_done = False
+                    await cancel_pending()
                     return
                 yield _SSE_KEEPALIVE
                 continue
@@ -214,11 +229,9 @@ async def _stream_hermes_sse(session_key: str, text: str, request: Request):
                     "warning": event.get("warning"),
                 })
     finally:
-        if pending is not None and not pending.done():
-            pending.cancel()
-        # Always emit a terminal frame so the client's stream-consumer loop
-        # exits cleanly, even on disconnect or error.
-        yield _sse_event("done", {})
+        await cancel_pending()
+        if emit_done:
+            yield _sse_event("done", {})
 
 
 @router.get("/api/talk/status")

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -9,13 +9,14 @@ must not grant access here.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 from typing import Any
 
 import httpx
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-from fastapi.responses import Response
+from fastapi.responses import Response, StreamingResponse
 
 import hermes_bridge
 import session_signer
@@ -131,6 +132,41 @@ async def _send_to_hermes(session_key: str, text: str) -> dict[str, Any]:
     }
 
 
+def _sse_event(event_type: str, data: dict[str, Any]) -> bytes:
+    """Encode one Server-Sent Events frame."""
+    payload = {"type": event_type, **data}
+    return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n".encode("utf-8")
+
+
+async def _stream_hermes_sse(session_key: str, text: str):
+    """SSE generator wrapping the bridge's stream_prompt.
+
+    Yields one ``data:`` line per bridge event, terminated by ``\\n\\n``.
+    A final ``done`` frame is always emitted, so the client knows the stream
+    closed cleanly even after an error. Errors map to a ``status`` frame
+    with the same shape the JSON endpoint would return.
+    """
+    try:
+        async for event in hermes_bridge.stream_prompt(session_key, text):
+            et = event.get("type")
+            if et == "session":
+                yield _sse_event("session", {"session_id": event.get("session_id", "")})
+            elif et == "delta":
+                yield _sse_event("delta", {"text": event.get("text", "")})
+            elif et == "complete":
+                yield _sse_event("complete", {
+                    "session_id": event.get("session_id", ""),
+                    "text": event.get("text", ""),
+                    "status": event.get("status") or "ok",
+                    "warning": event.get("warning"),
+                })
+    except hermes_bridge.HermesUnavailable as exc:
+        yield _sse_event("error", {"status_code": 503, "detail": str(exc)})
+    except (hermes_bridge.HermesBridgeError, asyncio.TimeoutError) as exc:
+        yield _sse_event("error", {"status_code": 502, "detail": str(exc) or "Hermes did not finish the response."})
+    yield _sse_event("done", {})
+
+
 @router.get("/api/talk/status")
 async def talk_status(request: Request) -> dict[str, Any]:
     _session_key, expires_at = _require_session(request)
@@ -169,16 +205,61 @@ async def talk_session(request: Request) -> dict[str, Any]:
     return {"session_id": session_id, "expires_at": expires_at}
 
 
-@router.post("/api/talk/message")
-async def talk_message(payload: dict[str, Any], request: Request) -> dict[str, Any]:
-    session_key, _expires_at = _require_session(request)
+def _extract_message_text(payload: Any) -> str:
+    """Pull and validate the ``text`` field from a /api/talk/message body."""
     text = payload.get("text") if isinstance(payload, dict) else None
     if not isinstance(text, str) or not text.strip():
         raise HTTPException(status_code=422, detail="Message text is required.")
     text = text.strip()
     if len(text) > MAX_MESSAGE_CHARS:
         raise HTTPException(status_code=413, detail="Message is too long.")
+    return text
+
+
+@router.post("/api/talk/message")
+async def talk_message(payload: dict[str, Any], request: Request) -> dict[str, Any]:
+    """Synchronous chat send. Waits for the full Hermes reply, returns JSON.
+
+    Kept for non-browser callers and tests. New UI code should use the SSE
+    endpoint /api/talk/message/stream so the user sees tokens land as Hermes
+    generates them — on a cold first message (16k-token system prompt) the
+    blocking version can hold the request open for 60+ seconds before any
+    visible feedback, which strands the UI on a "thinking" spinner.
+    """
+    session_key, _expires_at = _require_session(request)
+    text = _extract_message_text(payload)
     return await _send_to_hermes(session_key, text)
+
+
+@router.post("/api/talk/message/stream")
+async def talk_message_stream(payload: dict[str, Any], request: Request) -> StreamingResponse:
+    """Server-Sent Events chat send. Streams delta + complete events.
+
+    Frame shape (one JSON object per ``data:`` line, ``\\n\\n`` terminator):
+
+      {"type": "session",  "session_id": "<id>"}
+      {"type": "delta",    "text": "<chunk>"}                    # repeats
+      {"type": "complete", "session_id": "<id>", "text": "...",
+                           "status": "ok", "warning": null}
+      {"type": "error",    "status_code": 502|503, "detail": "..."}  # on failure
+      {"type": "done"}                                                # always last
+
+    The endpoint sets ``X-Accel-Buffering: no`` and ``Cache-Control: no-cache``
+    so the dashboard nginx proxy passes frames through immediately rather
+    than batching them.
+    """
+    session_key, _expires_at = _require_session(request)
+    text = _extract_message_text(payload)
+    headers = {
+        "Cache-Control": "no-cache",
+        "X-Accel-Buffering": "no",
+        "Connection": "keep-alive",
+    }
+    return StreamingResponse(
+        _stream_hermes_sse(session_key, text),
+        media_type="text/event-stream",
+        headers=headers,
+    )
 
 
 @router.post("/api/talk/audio-message")

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -138,16 +138,69 @@ def _sse_event(event_type: str, data: dict[str, Any]) -> bytes:
     return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n".encode("utf-8")
 
 
-async def _stream_hermes_sse(session_key: str, text: str):
+# SSE comment frame — clients ignore lines starting with ``:``. Used as a
+# keepalive so iOS Safari and intermediate proxies don't close the connection
+# while llama-server is doing 30-60s of prompt processing with no real frames.
+_SSE_KEEPALIVE = b": keepalive\n\n"
+
+# Emit a keepalive frame this often during silent gaps (in seconds).
+_KEEPALIVE_INTERVAL = 5.0
+
+
+async def _stream_hermes_sse(session_key: str, text: str, request: Request):
     """SSE generator wrapping the bridge's stream_prompt.
 
-    Yields one ``data:`` line per bridge event, terminated by ``\\n\\n``.
-    A final ``done`` frame is always emitted, so the client knows the stream
-    closed cleanly even after an error. Errors map to a ``status`` frame
-    with the same shape the JSON endpoint would return.
+    Yields one ``data:`` line per bridge event, terminated by ``\\n\\n``. A
+    final ``done`` frame is always emitted, so the client knows the stream
+    closed cleanly even after an error. Errors map to an ``error`` frame.
+
+    Two ongoing-availability mechanisms:
+
+    1. **Keepalive** — emit a ``: keepalive`` SSE comment every
+       ``_KEEPALIVE_INTERVAL`` seconds while the bridge is silent (e.g.
+       during the 30-60s cold prompt processing of the system prompt). Without
+       this, iOS Safari and some intermediate proxies close idle streams,
+       leaving the SPA stuck on a stalled "thinking" spinner.
+    2. **Disconnect cancellation** — if the client's HTTP connection drops
+       mid-request (phone screen locked, tab closed, retry), stop pulling
+       from the bridge so we don't keep an upstream llama-server slot busy
+       for a response nobody will ever read.
     """
+    bridge_iter = hermes_bridge.stream_prompt(session_key, text).__aiter__()
+    pending: asyncio.Task | None = None
     try:
-        async for event in hermes_bridge.stream_prompt(session_key, text):
+        while True:
+            if pending is None:
+                pending = asyncio.create_task(bridge_iter.__anext__())
+            try:
+                done_set, _ = await asyncio.wait({pending}, timeout=_KEEPALIVE_INTERVAL)
+            except asyncio.CancelledError:
+                pending.cancel()
+                raise
+            if not done_set:
+                # No bridge event in the keepalive window; check disconnect
+                # before sending more bytes, then emit a keepalive comment.
+                if await request.is_disconnected():
+                    pending.cancel()
+                    return
+                yield _SSE_KEEPALIVE
+                continue
+            # The bridge yielded something — pending is in done_set.
+            try:
+                event = pending.result()
+            except StopAsyncIteration:
+                pending = None
+                break
+            except hermes_bridge.HermesUnavailable as exc:
+                yield _sse_event("error", {"status_code": 503, "detail": str(exc)})
+                pending = None
+                break
+            except (hermes_bridge.HermesBridgeError, asyncio.TimeoutError) as exc:
+                yield _sse_event("error", {"status_code": 502, "detail": str(exc) or "Hermes did not finish the response."})
+                pending = None
+                break
+            pending = None  # ready for next iteration
+
             et = event.get("type")
             if et == "session":
                 yield _sse_event("session", {"session_id": event.get("session_id", "")})
@@ -160,11 +213,12 @@ async def _stream_hermes_sse(session_key: str, text: str):
                     "status": event.get("status") or "ok",
                     "warning": event.get("warning"),
                 })
-    except hermes_bridge.HermesUnavailable as exc:
-        yield _sse_event("error", {"status_code": 503, "detail": str(exc)})
-    except (hermes_bridge.HermesBridgeError, asyncio.TimeoutError) as exc:
-        yield _sse_event("error", {"status_code": 502, "detail": str(exc) or "Hermes did not finish the response."})
-    yield _sse_event("done", {})
+    finally:
+        if pending is not None and not pending.done():
+            pending.cancel()
+        # Always emit a terminal frame so the client's stream-consumer loop
+        # exits cleanly, even on disconnect or error.
+        yield _sse_event("done", {})
 
 
 @router.get("/api/talk/status")
@@ -256,7 +310,7 @@ async def talk_message_stream(payload: dict[str, Any], request: Request) -> Stre
         "Connection": "keep-alive",
     }
     return StreamingResponse(
-        _stream_hermes_sse(session_key, text),
+        _stream_hermes_sse(session_key, text, request),
         media_type="text/event-stream",
         headers=headers,
     )

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -97,3 +97,127 @@ def test_talk_speak_returns_audio(talk_client, monkeypatch):
     assert resp.status_code == 200, resp.text
     assert resp.content == b"mp3 bytes"
     assert resp.headers["content-type"].startswith("audio/mpeg")
+
+
+# ----------------------------------------------------------------------
+# SSE streaming endpoint tests (/api/talk/message/stream)
+# ----------------------------------------------------------------------
+
+
+def _parse_sse_frames(body: bytes):
+    """Split an SSE response body into one dict per frame."""
+    import json as _json
+    frames = []
+    for chunk in body.decode("utf-8").split("\n\n"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        data_lines = [line[5:].lstrip() for line in chunk.splitlines() if line.startswith("data:")]
+        if not data_lines:
+            continue
+        try:
+            frames.append(_json.loads("\n".join(data_lines)))
+        except _json.JSONDecodeError:
+            pass
+    return frames
+
+
+def test_talk_message_stream_emits_session_then_deltas_then_complete(talk_client, monkeypatch):
+    async def fake_stream(session_key, text):
+        assert text == "hello"
+        yield {"type": "session", "session_id": "sid-stream-1"}
+        yield {"type": "delta", "text": "Hello"}
+        yield {"type": "delta", "text": " world"}
+        yield {"type": "complete", "session_id": "sid-stream-1", "text": "Hello world",
+               "status": "ok", "warning": None}
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "hello"})
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/event-stream")
+    frames = _parse_sse_frames(resp.content)
+    types = [f["type"] for f in frames]
+    # Required ordering: session → deltas → complete → done. Bridge errors
+    # replace `complete` with `error`, but `done` is always last.
+    assert types[0] == "session"
+    assert frames[0]["session_id"] == "sid-stream-1"
+    delta_texts = [f["text"] for f in frames if f["type"] == "delta"]
+    assert delta_texts == ["Hello", " world"]
+    assert any(f["type"] == "complete" and f["text"] == "Hello world" for f in frames)
+    assert types[-1] == "done"
+
+
+def test_talk_message_stream_emits_error_frame_and_done_on_bridge_failure(talk_client, monkeypatch):
+    import hermes_bridge as bridge
+
+    async def fake_stream(session_key, text):
+        # Yield nothing — go straight to raising. The endpoint should still
+        # emit an `error` SSE frame followed by `done` so the client knows the
+        # stream closed cleanly.
+        if False:
+            yield  # pragma: no cover — needed to make this an async generator
+        raise bridge.HermesBridgeError("upstream tripped")
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "hi"})
+    assert resp.status_code == 200, resp.text
+    frames = _parse_sse_frames(resp.content)
+    types = [f["type"] for f in frames]
+    assert "error" in types
+    error_frame = next(f for f in frames if f["type"] == "error")
+    assert error_frame["status_code"] == 502
+    assert "upstream tripped" in error_frame["detail"]
+    assert types[-1] == "done"
+
+
+def test_talk_message_stream_emits_503_when_hermes_unavailable(talk_client, monkeypatch):
+    import hermes_bridge as bridge
+
+    async def fake_stream(session_key, text):
+        if False:
+            yield  # pragma: no cover
+        raise bridge.HermesUnavailable("hermes is offline")
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "hi"})
+    assert resp.status_code == 200
+    frames = _parse_sse_frames(resp.content)
+    error_frame = next(f for f in frames if f["type"] == "error")
+    assert error_frame["status_code"] == 503
+
+
+def test_talk_message_stream_requires_session(test_client):
+    resp = test_client.post(
+        "/api/talk/message/stream",
+        json={"text": "hi"},
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 401
+
+
+def test_talk_message_stream_validates_input(talk_client):
+    resp = talk_client.post("/api/talk/message/stream", json={"text": ""})
+    assert resp.status_code == 422
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "x" * 8001})
+    assert resp.status_code == 413
+
+
+def test_talk_message_stream_sets_unbuffered_headers(talk_client, monkeypatch):
+    """nginx upstream needs ``X-Accel-Buffering: no`` + ``Cache-Control: no-cache``
+    so each SSE frame is forwarded immediately. Regression guard for the SSE
+    path: if either header is dropped, the dashboard nginx proxy will buffer
+    the response and the phone will see the full reply only at the end."""
+    async def fake_stream(session_key, text):
+        yield {"type": "session", "session_id": "sid-h"}
+        yield {"type": "complete", "session_id": "sid-h", "text": "ok", "status": "ok", "warning": None}
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "hi"})
+    assert resp.status_code == 200
+    assert resp.headers.get("x-accel-buffering") == "no"
+    assert "no-cache" in resp.headers.get("cache-control", "").lower()

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -290,8 +290,10 @@ def test_talk_message_stream_cancels_upstream_on_client_disconnect(talk_client, 
     body = b"".join(chunks).decode("utf-8")
     # The session frame should have made it out.
     assert '"type":"session"' in body
-    # The generator must have exited via the disconnect path, emitting `done`.
-    assert '"type":"done"' in body
+    # The generator must have exited via the disconnect path without trying to
+    # write a final frame to a dead response. Normal/error completions still
+    # emit `done`.
+    assert '"type":"done"' not in body
     # And the upstream bridge task must have been cancelled (no hang).
     assert bridge_started.is_set()
     assert bridge_cancelled.is_set()

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -206,6 +206,171 @@ def test_talk_message_stream_validates_input(talk_client):
     assert resp.status_code == 413
 
 
+def test_talk_message_stream_emits_keepalive_during_silent_bridge(talk_client, monkeypatch):
+    """If the bridge goes silent for longer than the keepalive interval (e.g.
+    while llama-server is doing 30-60s of prompt processing with no events),
+    the endpoint must emit ``: keepalive`` SSE comment frames. Without them
+    iOS Safari and intermediate proxies close idle streams and the SPA
+    stalls on a "thinking" spinner that will never resolve."""
+    import asyncio as _asyncio
+    monkeypatch.setattr("routers.talk._KEEPALIVE_INTERVAL", 0.05)
+
+    async def slow_stream(session_key, text):
+        yield {"type": "session", "session_id": "sid-kp"}
+        # Simulate a real prompt-processing gap. With keepalive at 50ms,
+        # this 200ms gap must produce >= 2 keepalive comments.
+        await _asyncio.sleep(0.2)
+        yield {"type": "delta", "text": "ok"}
+        yield {"type": "complete", "session_id": "sid-kp", "text": "ok", "status": "ok", "warning": None}
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", slow_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "hi"})
+    assert resp.status_code == 200
+    raw = resp.content.decode("utf-8")
+    assert ": keepalive" in raw, "expected at least one keepalive comment frame in body"
+    assert raw.count(": keepalive") >= 2, f"expected >=2 keepalive frames, got {raw.count(': keepalive')}"
+    # And the real frames still come through.
+    frames = _parse_sse_frames(resp.content)
+    types = [f["type"] for f in frames]
+    assert "complete" in types and types[-1] == "done"
+
+
+def test_talk_message_stream_cancels_upstream_on_client_disconnect(talk_client, monkeypatch):
+    """If the client drops the connection mid-stream, the endpoint must stop
+    pulling from the bridge so a slow upstream (llama-server slot) is freed
+    instead of held for a response nobody will read.
+
+    This is a unit-level test of the generator itself — we drive it directly
+    so we can assert the bridge iterator gets ``aclose()``-style cancellation
+    when ``request.is_disconnected()`` returns True.
+    """
+    import asyncio as _asyncio
+    monkeypatch.setattr("routers.talk._KEEPALIVE_INTERVAL", 0.02)
+
+    bridge_started = _asyncio.Event()
+    bridge_cancelled = _asyncio.Event()
+
+    async def hanging_stream(session_key, text):
+        yield {"type": "session", "session_id": "sid-cancel"}
+        bridge_started.set()
+        try:
+            # Hang until the consumer cancels us.
+            await _asyncio.sleep(60)
+            yield {"type": "complete", "session_id": "sid-cancel", "text": "never", "status": "ok", "warning": None}
+        except _asyncio.CancelledError:
+            bridge_cancelled.set()
+            raise
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", hanging_stream)
+
+    # Build a stub Request that reports disconnected after the first poll.
+    class StubRequest:
+        def __init__(self):
+            self.polls = 0
+
+        async def is_disconnected(self):
+            self.polls += 1
+            # Stay connected once so the session frame can flush, then drop.
+            return self.polls > 1
+
+    from routers.talk import _stream_hermes_sse
+
+    async def drive():
+        gen = _stream_hermes_sse("k", "hi", StubRequest())
+        collected = []
+        # Iterate the SSE generator; the consumer side is what FastAPI does.
+        async for chunk in gen:
+            collected.append(chunk)
+            if len(collected) > 10:
+                break
+        return collected
+
+    chunks = _asyncio.new_event_loop().run_until_complete(drive())
+    body = b"".join(chunks).decode("utf-8")
+    # The session frame should have made it out.
+    assert '"type":"session"' in body
+    # The generator must have exited via the disconnect path, emitting `done`.
+    assert '"type":"done"' in body
+    # And the upstream bridge task must have been cancelled (no hang).
+    assert bridge_started.is_set()
+    assert bridge_cancelled.is_set()
+
+
+def test_hermes_bridge_serializes_concurrent_submits_per_session(monkeypatch):
+    """Two concurrent stream_prompt calls with the same session_key must run
+    sequentially, not pile up on llama-server slots. Two calls with DIFFERENT
+    session_keys are allowed to overlap (different phones don't block each
+    other)."""
+    import asyncio as _asyncio
+    import hermes_bridge
+
+    hermes_bridge._SUBMIT_LOCKS.clear()
+
+    enter_log: list[str] = []
+    exit_log: list[str] = []
+
+    # Stub out the upstream so we don't need a real Hermes — the lock is what
+    # we're exercising. We patch the inner pieces stream_prompt calls.
+    async def fake_connect_ws(_session):
+        class FakeWS:
+            async def send_str(self, _): pass
+            async def __aenter__(self): return self
+            async def __aexit__(self, *a): pass
+        return FakeWS()
+
+    async def fake_create(_ws, *, timeout=30):
+        return "sid-fake"
+
+    monkeypatch.setattr("hermes_bridge._connect_ws", fake_connect_ws)
+    monkeypatch.setattr("hermes_bridge._create_session_on_ws", fake_create)
+
+    async def fake_recv(_ws, _timeout):
+        # Sleep so the test observes ordering, then return a message.complete.
+        await _asyncio.sleep(0.1)
+        return {
+            "method": "event",
+            "params": {
+                "type": "message.complete",
+                "session_id": "sid-fake",
+                "payload": {"text": "done", "status": "ok"},
+            },
+        }
+    monkeypatch.setattr("hermes_bridge._recv_json", fake_recv)
+
+    async def drive(key, tag):
+        enter_log.append(tag)
+        async for ev in hermes_bridge.stream_prompt(key, "x"):
+            if ev["type"] == "complete":
+                break
+        exit_log.append(tag)
+
+    async def main():
+        # Two concurrent same-key callers — must serialize.
+        await _asyncio.gather(drive("k1", "A"), drive("k1", "B"))
+        return list(enter_log), list(exit_log)
+
+    enter, exit_ = _asyncio.new_event_loop().run_until_complete(main())
+    # Both got past their initial enter print before any awaited stream
+    # work — that part isn't blocked. The interesting assertion is that
+    # B's exit fires AFTER A's exit (B waited for the lock).
+    assert enter == ["A", "B"]
+    assert exit_ == ["A", "B"], f"expected serialized exits A then B, got {exit_}"
+
+    # Now confirm different keys are NOT blocked by each other: kick off two
+    # with different keys; both finish near-simultaneously.
+    enter_log.clear()
+    exit_log.clear()
+    hermes_bridge._SUBMIT_LOCKS.clear()
+
+    async def main2():
+        await _asyncio.gather(drive("phoneA", "A"), drive("phoneB", "B"))
+
+    _asyncio.new_event_loop().run_until_complete(main2())
+    # Both complete; the order can be either A→B or B→A but both must finish.
+    assert set(exit_log) == {"A", "B"}
+
+
 def test_talk_message_stream_sets_unbuffered_headers(talk_client, monkeypatch):
     """nginx upstream needs ``X-Accel-Buffering: no`` + ``Cache-Control: no-cache``
     so each SSE frame is forwarded immediately. Regression guard for the SSE

--- a/dream-server/extensions/services/dashboard/nginx.conf
+++ b/dream-server/extensions/services/dashboard/nginx.conf
@@ -14,6 +14,29 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
+    # Dream Talk endpoints — chat + voice. These are inherently long-running:
+    # on a cold first message, Hermes prompt processing of the 16k-token
+    # system prompt can take 60+ seconds before any token streams back. The
+    # SSE stream endpoint (/api/talk/message/stream) needs unbuffered passthrough
+    # and a generous read timeout so the upstream can keep the connection open
+    # while tokens trickle in.
+    location ^~ /api/talk/ {
+        proxy_pass http://dashboard-api:3002;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "";
+        proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
+        proxy_read_timeout 600s;
+        proxy_send_timeout 600s;
+        # SSE / streaming responses: don't buffer; flush frames immediately.
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_set_header X-Accel-Buffering no;
+    }
+
     # Proxy API requests to status backend
     # Auth: nginx injects Bearer token for same-origin requests (B2 fix)
     # Token read from environment via envsubst in entrypoint

--- a/dream-server/extensions/services/dashboard/package-lock.json
+++ b/dream-server/extensions/services/dashboard/package-lock.json
@@ -12,6 +12,7 @@
         "lucide-react": "^0.441.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^6.26.0"
       },
       "devDependencies": {
@@ -2171,6 +2172,15 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2182,8 +2192,25 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -2191,6 +2218,43 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.15",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.15.tgz",
+      "integrity": "sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -2458,6 +2522,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2600,6 +2674,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -2625,6 +2709,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -2684,6 +2808,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "4.1.1",
@@ -2758,6 +2892,13 @@
         "node": ">=4"
       }
     },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/data-urls": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
@@ -2776,7 +2917,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2797,6 +2937,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2808,7 +2961,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2822,6 +2974,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/didyoumean": {
@@ -3079,6 +3244,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -3108,6 +3283,12 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3338,6 +3519,46 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -3349,6 +3570,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -3398,6 +3629,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3427,6 +3688,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3450,6 +3721,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -3458,6 +3739,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -3929,6 +4222,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3981,6 +4284,159 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -3997,6 +4453,448 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -4039,7 +4937,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -4190,6 +5087,31 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -4481,6 +5403,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4544,6 +5476,33 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4622,6 +5581,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/require-from-string": {
@@ -4858,6 +5850,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -4871,6 +5873,20 @@
       "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -4896,6 +5912,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/sucrase": {
@@ -5149,6 +6183,26 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -5185,6 +6239,93 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -5234,6 +6375,34 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -6080,6 +7249,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/dream-server/extensions/services/dashboard/package.json
+++ b/dream-server/extensions/services/dashboard/package.json
@@ -17,6 +17,7 @@
     "lucide-react": "^0.441.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^6.26.0"
   },
   "devDependencies": {

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -1,8 +1,34 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
 import {
   AlertCircle, CheckCircle2, Loader2, Mic, Paperclip, RefreshCw,
   Send, Volume2, VolumeX,
 } from 'lucide-react'
+
+// Hermes likes to format with markdown (bold, lists, code). Rendering it as
+// HTML keeps the chat bubbles readable instead of showing raw `**` and `-`.
+// react-markdown defaults to CommonMark + no raw HTML, which is the safe
+// posture for content coming back from any LLM — even our trusted local one.
+const MARKDOWN_COMPONENTS = {
+  p: ({ children }) => <p className="break-words [&:not(:first-child)]:mt-3">{children}</p>,
+  ul: ({ children }) => <ul className="my-2 list-disc space-y-1 pl-5">{children}</ul>,
+  ol: ({ children }) => <ol className="my-2 list-decimal space-y-1 pl-5">{children}</ol>,
+  li: ({ children }) => <li className="break-words">{children}</li>,
+  strong: ({ children }) => <strong className="font-semibold">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  h1: ({ children }) => <h1 className="my-2 text-lg font-semibold">{children}</h1>,
+  h2: ({ children }) => <h2 className="my-2 text-base font-semibold">{children}</h2>,
+  h3: ({ children }) => <h3 className="my-2 text-sm font-semibold uppercase tracking-wide">{children}</h3>,
+  a: ({ href, children }) => (
+    <a href={href} target="_blank" rel="noreferrer" className="underline decoration-zinc-400 underline-offset-2 hover:decoration-zinc-700">{children}</a>
+  ),
+  code: ({ inline, children }) => inline
+    ? <code className="rounded bg-zinc-100 px-1 py-0.5 font-mono text-[13px] text-zinc-800">{children}</code>
+    : <code className="block whitespace-pre-wrap break-words rounded bg-zinc-100 p-2 font-mono text-[13px] text-zinc-800">{children}</code>,
+  pre: ({ children }) => <pre className="my-2 overflow-x-auto rounded bg-zinc-100">{children}</pre>,
+  blockquote: ({ children }) => <blockquote className="my-2 border-l-2 border-zinc-300 pl-3 italic text-zinc-700">{children}</blockquote>,
+  hr: () => <hr className="my-3 border-zinc-200" />,
+}
 
 const welcomeMessage = {
   id: 'welcome',
@@ -470,8 +496,15 @@ function MessageBubble({ message }) {
             <Loader2 size={14} className="animate-spin" />
             Thinking
           </span>
-        ) : (
+        ) : user || message.status === 'error' ? (
+          // User messages and error bubbles stay as plain text — markdown
+          // in those contexts would let typos render as headings or
+          // accidental bold, which we don't want.
           <p className="whitespace-pre-wrap break-words">{message.text}</p>
+        ) : (
+          <div className="space-y-0 text-[15px] leading-6">
+            <ReactMarkdown components={MARKDOWN_COMPONENTS}>{message.text}</ReactMarkdown>
+          </div>
         )}
         {message.warning && (
           <p className="mt-2 text-xs text-amber-600">{message.warning}</p>

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -71,6 +71,7 @@ export default function DreamTalk() {
   const fileInputRef = useRef(null)
   const recorderRef = useRef(null)
   const recordingChunksRef = useRef([])
+  const streamControllerRef = useRef(null)
 
   const liveMicSupported = useMemo(() => {
     return Boolean(
@@ -120,6 +121,13 @@ export default function DreamTalk() {
     }
   }, [spokenReplies])
 
+  useEffect(() => {
+    return () => {
+      streamControllerRef.current?.abort()
+      streamControllerRef.current = null
+    }
+  }, [])
+
   const speak = useCallback(async (text) => {
     if (!spokenReplies || !voiceState.tts || !text.trim()) return
     try {
@@ -168,6 +176,8 @@ export default function DreamTalk() {
     // in-flight stream. Server-side the bridge stops pulling from llama-server
     // when the connection drops, freeing the slot for the next request.
     const controller = new AbortController()
+    streamControllerRef.current?.abort()
+    streamControllerRef.current = controller
     try {
       const resp = await fetch('/api/talk/message/stream', {
         method: 'POST',
@@ -244,6 +254,9 @@ export default function DreamTalk() {
         ))
       }
     } finally {
+      if (streamControllerRef.current === controller) {
+        streamControllerRef.current = null
+      }
       setSending(false)
     }
   }, [sending, speak, status])

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -7,7 +7,7 @@ import {
 const welcomeMessage = {
   id: 'welcome',
   role: 'assistant',
-  text: 'Hi. I am Dream Server. Ask me anything and I will keep it local to this box.',
+  text: "Hey, I'm Dream — your local AI buddy, running entirely on your own hardware. Nothing leaves this box.\n\nTry me: ask anything, draft an email, run some code, plan a trip, or just chat. Or hit the mic and talk to me.",
   status: 'done',
 }
 

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -129,10 +129,19 @@ export default function DreamTalk() {
     setMessages(items => [...items, { id: assistantId, role: 'assistant', text: '', status: 'pending' }])
     setInput('')
 
+    // Live-streamed reply via SSE. The endpoint emits one JSON object per
+    // ``data:`` frame: {type: "session" | "delta" | "complete" | "error" | "done"}.
+    // We append delta text into the assistant bubble as each frame arrives, then
+    // finalise the bubble on the ``complete`` frame. The ``done`` frame is
+    // always last (even after an error) so the loop terminates cleanly.
+    let assembled = ''
+    let finalWarning = null
+    let errorDetail = null
+
     try {
-      const resp = await fetch('/api/talk/message', {
+      const resp = await fetch('/api/talk/message/stream', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
         credentials: 'same-origin',
         body: JSON.stringify({ text: clean }),
       })
@@ -141,12 +150,52 @@ export default function DreamTalk() {
         setStatusText('Session expired. Scan the owner card again.')
         throw new Error('Session expired.')
       }
-      if (!resp.ok) throw new Error(await parseError(resp, 'Hermes did not answer.'))
-      const data = await resp.json()
-      const reply = data.text || 'I did not get a response back.'
+      if (!resp.ok || !resp.body) {
+        throw new Error(await parseError(resp, 'Hermes did not answer.'))
+      }
+
+      const reader = resp.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      // SSE frames are separated by a blank line (\n\n). Buffer partial frames
+      // across reads — chunked transport can split mid-frame.
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        let sepIdx
+        while ((sepIdx = buffer.indexOf('\n\n')) !== -1) {
+          const frame = buffer.slice(0, sepIdx)
+          buffer = buffer.slice(sepIdx + 2)
+          const dataLines = frame.split('\n').filter(line => line.startsWith('data:'))
+          if (dataLines.length === 0) continue
+          const json = dataLines.map(l => l.slice(5).trimStart()).join('\n')
+          let payload
+          try {
+            payload = JSON.parse(json)
+          } catch {
+            continue
+          }
+          if (payload.type === 'delta' && typeof payload.text === 'string') {
+            assembled += payload.text
+            const snapshot = assembled
+            setMessages(items => items.map(item =>
+              item.id === assistantId ? { ...item, text: snapshot, status: 'pending' } : item,
+            ))
+          } else if (payload.type === 'complete') {
+            if (typeof payload.text === 'string' && payload.text) assembled = payload.text
+            finalWarning = payload.warning || null
+          } else if (payload.type === 'error') {
+            errorDetail = payload.detail || 'Hermes did not finish the response.'
+          }
+        }
+      }
+
+      if (errorDetail) throw new Error(errorDetail)
+      const reply = assembled || 'I did not get a response back.'
       setMessages(items => items.map(item =>
         item.id === assistantId
-          ? { ...item, text: reply, status: 'done', warning: data.warning || null }
+          ? { ...item, text: reply, status: 'done', warning: finalWarning }
           : item,
       ))
       speak(reply)

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -138,12 +138,17 @@ export default function DreamTalk() {
     let finalWarning = null
     let errorDetail = null
 
+    // AbortController so navigating away / re-sending mid-flight cancels the
+    // in-flight stream. Server-side the bridge stops pulling from llama-server
+    // when the connection drops, freeing the slot for the next request.
+    const controller = new AbortController()
     try {
       const resp = await fetch('/api/talk/message/stream', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
         credentials: 'same-origin',
         body: JSON.stringify({ text: clean }),
+        signal: controller.signal,
       })
       if (resp.status === 401) {
         setStatus('expired')
@@ -158,7 +163,9 @@ export default function DreamTalk() {
       const decoder = new TextDecoder()
       let buffer = ''
       // SSE frames are separated by a blank line (\n\n). Buffer partial frames
-      // across reads — chunked transport can split mid-frame.
+      // across reads — chunked transport can split mid-frame. Lines starting
+      // with ``:`` are SSE comments (keepalives); we discard them by filtering
+      // for ``data:`` only below.
       while (true) {
         const { value, done } = await reader.read()
         if (done) break
@@ -200,11 +207,16 @@ export default function DreamTalk() {
       ))
       speak(reply)
     } catch (err) {
-      setMessages(items => items.map(item =>
-        item.id === assistantId
-          ? { ...item, text: err.message || 'Something went wrong.', status: 'error' }
-          : item,
-      ))
+      if (err.name === 'AbortError') {
+        // User-initiated cancellation. Drop the placeholder bubble silently.
+        setMessages(items => items.filter(item => item.id !== assistantId))
+      } else {
+        setMessages(items => items.map(item =>
+          item.id === assistantId
+            ? { ...item, text: err.message || 'Something went wrong.', status: 'error' }
+            : item,
+        ))
+      }
     } finally {
       setSending(false)
     }

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
@@ -15,15 +15,18 @@ const response = (body, status = 200) => ({
 const sseResponse = (frames, { status = 200, chunks } = {}) => {
   const encoder = new TextEncoder()
   const frameBytes = frames.map(f => encoder.encode(`data: ${JSON.stringify(f)}\n\n`))
+  const concatFrames = (group) => {
+    const totalLen = group.reduce((acc, i) => acc + frameBytes[i].byteLength, 0)
+    const out = new Uint8Array(totalLen)
+    let offset = 0
+    for (const i of group) {
+      out.set(frameBytes[i], offset)
+      offset += frameBytes[i].byteLength
+    }
+    return out
+  }
   const chunkGroups = chunks
-    ? chunks.map(group => Buffer.concat ? Buffer.concat(group.map(i => frameBytes[i])) : (() => {
-        // browser/jsdom path — concat Uint8Arrays manually
-        const totalLen = group.reduce((acc, i) => acc + frameBytes[i].byteLength, 0)
-        const out = new Uint8Array(totalLen)
-        let offset = 0
-        for (const i of group) { out.set(frameBytes[i], offset); offset += frameBytes[i].byteLength }
-        return out
-      })())
+    ? chunks.map(group => concatFrames(group))
     : frameBytes
   let idx = 0
   const reader = {

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
@@ -122,6 +122,39 @@ describe('DreamTalk', () => {
     expect(await screen.findByText('Hello world')).toBeInTheDocument()
   })
 
+  test('renders markdown in assistant bubbles (bold/lists), not raw asterisks', async () => {
+    // Hermes formats replies with markdown by default. The bubble should
+    // render that as HTML so a list looks like a list, not "- one\n- two".
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })
+      if (url === '/api/talk/message/stream' && options.method === 'POST') {
+        return sseResponse([
+          { type: 'session', session_id: 'sid' },
+          { type: 'complete', session_id: 'sid', text: 'Pick **one**:\n\n- alpha\n- beta', status: 'ok' },
+          { type: 'done' },
+        ])
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = render(<DreamTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Message Dream Server'), {
+      target: { value: 'choose' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    // Bold renders as <strong>, not as ** in the text.
+    expect(await screen.findByText('one')).toBeInTheDocument()
+    expect(screen.getByText('one').tagName).toBe('STRONG')
+    // List items render as <li> under a <ul>.
+    expect(container.querySelector('ul li')).toBeTruthy()
+    expect(screen.getByText('alpha').closest('li')).toBeTruthy()
+    // And the raw `**` is gone from the DOM text.
+    expect(container.textContent).not.toContain('**')
+  })
+
   test('surfaces SSE error frame as an assistant error', async () => {
     const fetchMock = vi.fn(async (url, options = {}) => {
       if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
@@ -8,6 +8,39 @@ const response = (body, status = 200) => ({
   json: async () => body,
 })
 
+// Build a fake fetch Response with a streaming body. ``frames`` is an array
+// of JS objects; each one is encoded as a single SSE frame (data: <json>\n\n).
+// If ``chunks`` is provided it's an array of frame-index arrays — each chunk
+// emits those frames in one reader.read() pass, simulating partial transport.
+const sseResponse = (frames, { status = 200, chunks } = {}) => {
+  const encoder = new TextEncoder()
+  const frameBytes = frames.map(f => encoder.encode(`data: ${JSON.stringify(f)}\n\n`))
+  const chunkGroups = chunks
+    ? chunks.map(group => Buffer.concat ? Buffer.concat(group.map(i => frameBytes[i])) : (() => {
+        // browser/jsdom path — concat Uint8Arrays manually
+        const totalLen = group.reduce((acc, i) => acc + frameBytes[i].byteLength, 0)
+        const out = new Uint8Array(totalLen)
+        let offset = 0
+        for (const i of group) { out.set(frameBytes[i], offset); offset += frameBytes[i].byteLength }
+        return out
+      })())
+    : frameBytes
+  let idx = 0
+  const reader = {
+    read: async () => {
+      if (idx >= chunkGroups.length) return { done: true, value: undefined }
+      const value = chunkGroups[idx++]
+      return { done: false, value }
+    },
+  }
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: { getReader: () => reader },
+    json: async () => ({}),
+  }
+}
+
 describe('DreamTalk', () => {
   beforeEach(() => {
     Object.defineProperty(window, 'isSecureContext', { configurable: true, value: false })
@@ -29,9 +62,15 @@ describe('DreamTalk', () => {
           },
         })
       }
-      if (url === '/api/talk/message' && options.method === 'POST') {
+      if (url === '/api/talk/message/stream' && options.method === 'POST') {
         expect(JSON.parse(options.body)).toEqual({ text: 'What can you do?' })
-        return response({ session_id: 'sid', text: 'I can help from this Dream Server.' })
+        return sseResponse([
+          { type: 'session', session_id: 'sid' },
+          { type: 'delta', text: 'I can help' },
+          { type: 'delta', text: ' from this Dream Server.' },
+          { type: 'complete', session_id: 'sid', text: 'I can help from this Dream Server.', status: 'ok' },
+          { type: 'done' },
+        ])
       }
       throw new Error(`unexpected request: ${url}`)
     })
@@ -47,6 +86,64 @@ describe('DreamTalk', () => {
 
     expect(await screen.findByText('What can you do?')).toBeInTheDocument()
     expect(await screen.findByText('I can help from this Dream Server.')).toBeInTheDocument()
+  })
+
+  test('accumulates SSE deltas across split chunks', async () => {
+    // Transport may split a single SSE frame across chunk boundaries. The
+    // reader has to buffer the partial frame across reads, not drop bytes.
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') {
+        return response({ capabilities: { text_chat: true } })
+      }
+      if (url === '/api/talk/message/stream' && options.method === 'POST') {
+        // Five frames in three transport chunks: [session][delta delta][complete done]
+        return sseResponse(
+          [
+            { type: 'session', session_id: 'sid' },
+            { type: 'delta', text: 'Hello' },
+            { type: 'delta', text: ' world' },
+            { type: 'complete', session_id: 'sid', text: 'Hello world', status: 'ok' },
+            { type: 'done' },
+          ],
+          { chunks: [[0], [1, 2], [3, 4]] },
+        )
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DreamTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Message Dream Server'), {
+      target: { value: 'hello' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    expect(await screen.findByText('Hello world')).toBeInTheDocument()
+  })
+
+  test('surfaces SSE error frame as an assistant error', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })
+      if (url === '/api/talk/message/stream' && options.method === 'POST') {
+        return sseResponse([
+          { type: 'session', session_id: 'sid' },
+          { type: 'error', status_code: 502, detail: 'Hermes did not finish the response.' },
+          { type: 'done' },
+        ])
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DreamTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Message Dream Server'), {
+      target: { value: 'hi' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    expect(await screen.findByText('Hermes did not finish the response.')).toBeInTheDocument()
   })
 
   test('shows an expired owner-card session state', async () => {
@@ -102,8 +199,13 @@ describe('DreamTalk', () => {
           capabilities: { text_chat: true, tts: true, audio_message: false },
         })
       }
-      if (url === '/api/talk/message') {
-        return response({ session_id: 'sid', text: 'Spoken answer.' })
+      if (url === '/api/talk/message/stream') {
+        return sseResponse([
+          { type: 'session', session_id: 'sid' },
+          { type: 'delta', text: 'Spoken answer.' },
+          { type: 'complete', session_id: 'sid', text: 'Spoken answer.', status: 'ok' },
+          { type: 'done' },
+        ])
       }
       if (url === '/api/talk/speak' && options.method === 'POST') {
         return {

--- a/dream-server/extensions/services/dream-proxy/manifest.yaml
+++ b/dream-server/extensions/services/dream-proxy/manifest.yaml
@@ -40,6 +40,7 @@ service:
         auth.<device>.local      → dashboard-api (magic-link redemption)
         api.<device>.local       → dashboard-api (admin /api/*)
         hermes.<device>.local    → hermes-proxy (when enabled)
+        talk.<device>.local      → dashboard /talk (mobile owner portal)
     Per-subdomain routing means every backend stays root-mounted (no
     subpath gymnastics) and the dream-session cookie can be Domain-scoped
     to <device>.local so SSO works across all of them.

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -1,57 +1,65 @@
-# Hermes — Dream Server Default Persona
+# Dream — Dream Server Default Persona
 
-You are **Hermes**, the resident agent on a Dream Server installation. Dream
-Server is a fully-local AI stack — chat, voice, image generation, agents,
-workflows, RAG, and privacy tooling — that runs on the user's own hardware
-with no data ever leaving their machine.
+You are **Dream** — a knowledgeable, practical, and conversational assistant. Your goal is to give accurate, actionable answers that are as brief as possible while still feeling clear, friendly, and human.
 
-You are a **generalist agent**. You can chat conversationally, but you can
-also take real action: search the web, read and write files, run shell
-commands (when policy allows), keep notes, set reminders, ingest documents,
-and recall things from past conversations.
+## Style & tone
 
-## Operating principles
+- Friendly, approachable, and lightly playful when appropriate — never snarky or overly chatty.
+- Speak with confidence; correct misconceptions politely and directly.
+- Default to giving only 3–4 examples unless the user directly asks for a broader comparison.
+- When explaining how something works behind the scenes, prefer simple, conversational phrasing over deep technical descriptions unless the user asks for the internals.
+- Avoid polished or article-like section headers; use simple conversational transitions instead.
+- Favor casual, natural wording over technical or product-marketing phrasing.
+- Use plain language and simple, intuitive explanations.
+- Prefer natural, everyday phrasing over polished, formal, or documentation-style wording.
+- Write like you're explaining something to a smart friend, not drafting a blog post or textbook.
+- Use small analogies or intuition boosts when they help clarity.
+- Keep bullet lists minimal (2–4 items unless the user explicitly asks for more).
+- Avoid sounding like a tutorial, guide, or reference manual unless requested.
 
-1. **Take the action when it's clear.** If a user says "look up the weather
-   in Tokyo," search the web — don't ask permission first. Save the asking
-   for genuinely destructive or non-reversible operations (file deletion,
-   sending email on their behalf, etc.).
+## Structure
 
-2. **Show your work.** When you use a tool, mention what you did briefly. The
-   user sees tool calls in the UI, so the goal is just to weave them into
-   the conversation, not narrate every step in detail.
+- Aim for 1–3 short paragraphs for typical answers.
+- Use bullets or brief structure only when it clearly improves readability.
+- Don't provide exhaustive rundowns unless requested; summarize a few core patterns instead.
+- Keep the explanation focused on intuition and usefulness rather than listing every category.
+- Avoid formal section headers; use light conversational transitions instead, such as:
+  - "Here's the gist:"
+  - "A few examples:"
+  - "Here's how it works in practice:"
+- End with a natural, contextual follow-up (e.g., "If you want, I can compare X and Y too.") instead of template-like menus.
 
-3. **Remember what matters.** Hermes has persistent memory — if a user tells
-   you something durable about themselves ("I'm allergic to peanuts," "my
-   partner's name is Alex"), save it. Don't save every passing detail.
+## Depth & behavior
 
-4. **Stay local-first.** Dream Server's whole posture is that the user owns
-   their data. Don't suggest cloud services when a local equivalent exists.
-   When you DO need an external resource (a webpage, a Wikipedia article),
-   fetch only what's needed.
+- Lead with a concise, high-signal answer.
+- Provide only essential details up front; expand depth only when the user asks or when a tiny bit of extra context prevents confusion.
+- Keep examples short and well-chosen — not long lists, not exhaustive feature breakdowns.
+- Default to 3–4 examples max unless the user requests a broader comparison.
+- Prioritize intuition before technical depth; add deeper layers only when helpful.
 
-5. **Be honest about uncertainty.** If you're not sure whether a recalled
-   fact is current, say so. The local model isn't always up to date; trust
-   web search for current events.
+## Content rules
 
-## Tone
+- Prioritize factual accuracy; avoid guessing or hallucinating.
+- Be honest about uncertainty or unknowns.
+- Avoid Wikipedia-style info dumps, long tutorials, or over-explaining.
+- Prefer practical guidance and real-world usage over theoretical discussion.
+- When including code or commands, provide minimal, directly relevant examples.
 
-Warm, direct, lightly informal. The user is likely on their phone or laptop
-at home, not at a help desk. Match their energy. Avoid hedging language
-("perhaps you might want to consider…"); just answer.
+## Boundaries
 
-## What you are NOT
+- If the user anthropomorphizes you, gently clarify: *"I'm an AI language model here to help with your question."*
+- Put truth and clarity above sparing feelings; correct errors kindly but clearly.
 
-- Not a full IDE. You can help reason about code and use available tools when
-  policy allows, but steer larger repository work toward the user's dedicated
-  development environment.
-- Not a customer-service bot. Don't apologize for things that aren't your
-  fault.
-- Not a moralizer. Don't lecture the user about their choices unless they
-  ask. Respect their autonomy.
+## Token preference
+
+Keep responses under ~500 tokens unless the user explicitly asks for a deep dive or extended explanation.
+
+## Operating context (Dream Server)
+
+You're the resident agent on a **Dream Server** install — a fully-local AI stack running on the user's own hardware. Nothing they say or do leaves their machine. You have tools available (web search, file work, code execution, memory, scheduling, voice, and skill plugins) and you should use them when the user's request clearly needs them — don't ask for permission on routine actions, only on destructive or non-reversible ones.
+
+When recalling facts, trust web search for current events; the local model isn't always up to date. When the user tells you something durable about themselves, save it to memory.
 
 ## Resetting this persona
 
-The user can edit this file at `/opt/data/SOUL.md` inside the Hermes
-container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply.
-Deleting the file falls back to upstream's default persona.
+The user can edit this file at `/opt/data/SOUL.md` inside the Hermes container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply. Deleting the file falls back to upstream's default persona.

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -523,16 +523,33 @@ MODELS_INI_EOF
             if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
                 _hermes_model="extra.$GGUF_FILE"
             fi
-            # base_url stays at the compose-bridge name for Linux installs.
-            # On Linux there's a sibling llama-server container; on macOS
-            # the install-macos.sh path handles the host.docker.internal swap.
+            # base_url: on AMD/Lemonade hosts, route Hermes through litellm
+            # instead of direct-to-Lemonade. Lemonade is strict about model
+            # names and rejects concurrent connections that show up during a
+            # multi-step agent loop (web_search → reason → tool result →
+            # reason …), which results in APIConnectionError mid-tool-loop.
+            # litellm's "*" wildcard model_list normalises the model name and
+            # adds upstream retry logic. On non-AMD Linux installs there's a
+            # sibling llama-server container that takes any model name; on
+            # macOS install-macos.sh handles the host.docker.internal swap.
+            _hermes_base_url=""
+            _hermes_api_key=""
+            if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
+                _hermes_base_url="http://litellm:4000/v1"
+                _hermes_api_key="${LITELLM_KEY:-}"
+            fi
             _hermes_context="${MAX_CONTEXT:-131072}"
             _hermes_patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"
             _python_cmd="$(ds_detect_python_cmd 2>/dev/null || command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
             if [[ -n "$_python_cmd" && -f "$_hermes_patcher" ]]; then
-                "$_python_cmd" "$_hermes_patcher" "$_hermes_tpl" \
-                    --model "$_hermes_model" \
-                    --context-length "$_hermes_context" >>"$LOG_FILE" 2>&1 || \
+                _hermes_patcher_args=("$_hermes_tpl" --model "$_hermes_model" --context-length "$_hermes_context")
+                if [[ -n "$_hermes_base_url" ]]; then
+                    _hermes_patcher_args+=(--base-url "$_hermes_base_url")
+                fi
+                if [[ -n "$_hermes_api_key" ]]; then
+                    _hermes_patcher_args+=(--api-key "$_hermes_api_key")
+                fi
+                "$_python_cmd" "$_hermes_patcher" "${_hermes_patcher_args[@]}" >>"$LOG_FILE" 2>&1 || \
                     warn "Hermes config patcher failed for $_hermes_tpl"
             else
                 sed -i.bak \

--- a/dream-server/scripts/patch-hermes-config.py
+++ b/dream-server/scripts/patch-hermes-config.py
@@ -59,7 +59,7 @@ def _set_key(lines: list[str], block: tuple[int, int], key: str, value: str, ind
     return block[0], block[1] + 1
 
 
-def _ensure_model(lines: list[str], model: str | None, base_url: str | None, context_length: int | None) -> None:
+def _ensure_model(lines: list[str], model: str | None, base_url: str | None, context_length: int | None, api_key: str | None = None) -> None:
     block = _top_level_block(lines, "model")
     if block is None:
         insert = ["model:"]
@@ -68,6 +68,8 @@ def _ensure_model(lines: list[str], model: str | None, base_url: str | None, con
         if base_url:
             insert.append('  provider: "custom"')
             insert.append(f'  base_url: "{base_url}"')
+        if api_key:
+            insert.append(f'  api_key: "{api_key}"')
         if context_length:
             insert.append(f"  context_length: {context_length}")
         lines[:0] = insert + [""]
@@ -77,6 +79,8 @@ def _ensure_model(lines: list[str], model: str | None, base_url: str | None, con
         block = _set_key(lines, block, "default", f'"{model}"', 2)
     if base_url:
         block = _set_key(lines, block, "base_url", f'"{base_url}"', 2)
+    if api_key:
+        block = _set_key(lines, block, "api_key", f'"{api_key}"', 2)
     if context_length:
         _set_key(lines, block, "context_length", str(context_length), 2)
 
@@ -131,12 +135,12 @@ def _ensure_compression(lines: list[str]) -> None:
     _set_key(lines, block, "protect_last_n", "20", 2)
 
 
-def patch_config(path: Path, model: str | None, base_url: str | None, context_length: int | None) -> bool:
+def patch_config(path: Path, model: str | None, base_url: str | None, context_length: int | None, api_key: str | None = None) -> bool:
     original = path.read_text(encoding="utf-8")
     trailing_newline = original.endswith("\n")
     lines = original.splitlines()
 
-    _ensure_model(lines, model, base_url, context_length)
+    _ensure_model(lines, model, base_url, context_length, api_key)
     _ensure_auxiliary(lines, context_length)
     _ensure_compression(lines)
 
@@ -154,12 +158,13 @@ def main() -> int:
     parser.add_argument("path", type=Path)
     parser.add_argument("--model")
     parser.add_argument("--base-url")
+    parser.add_argument("--api-key", help="Bearer token Hermes uses to call the LLM (needed when routing through litellm)")
     parser.add_argument("--context-length", type=int)
     args = parser.parse_args()
 
     if not args.path.exists():
         return 0
-    changed = patch_config(args.path, args.model, args.base_url, args.context_length)
+    changed = patch_config(args.path, args.model, args.base_url, args.context_length, args.api_key)
     print("changed" if changed else "unchanged")
     return 0
 

--- a/dream-server/tests/test_mdns_subdomains.py
+++ b/dream-server/tests/test_mdns_subdomains.py
@@ -1,0 +1,99 @@
+"""Contract tests for bin/dream-mdns.py's per-subdomain A-record set.
+
+The mDNS announcer publishes a fixed set of `<sub>.<device>.local` A records
+so phones on the LAN can resolve the proxy-routed hostnames the magic-link
+redemption flow points them at. If a backend service ships a new public host
+(see #1319 → talk.<device>.local) but the announcer's `subdomain_routes`
+tuple isn't updated, the phone falls off a cliff: the URL exists in Caddy,
+magic_link.py points users at it, redemption succeeds, then the browser
+can't resolve the host and the user sees a white screen.
+
+These tests guard the subdomain list against silent regressions of that
+class. They are static-source assertions (no zeroconf import) so they run
+in CI without needing a network bound.
+
+Run with: pytest tests/test_mdns_subdomains.py
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MDNS_SCRIPT = REPO_ROOT / "bin" / "dream-mdns.py"
+
+# The set of subdomains the announcer must publish. Each name corresponds to
+# a Caddy block in extensions/services/dream-proxy/Caddyfile and (for the
+# auth-bound ones) a redirect target in dashboard-api/routers/magic_link.py.
+#
+# When adding a new public subdomain, update *all three* sources in the same
+# PR: the Caddyfile route, the announcer here, and this test. The test is the
+# tripwire if any of the three is forgotten.
+REQUIRED_SUBDOMAINS = {
+    "root",       # bare <device>.local — redirects to chat
+    "chat",       # Open WebUI
+    "dashboard",  # operator UI
+    "auth",       # magic-link redemption (set-cookie + 302)
+    "api",        # dashboard-api admin surface
+    "hermes",     # hermes-proxy
+    "talk",       # mobile owner portal (#1319) — without this, phone scans land on white screen
+}
+
+
+def _extract_subdomain_routes_keys() -> set[str]:
+    """Parse dream-mdns.py and return the set of subdomain names it announces.
+
+    We walk the AST instead of executing the script (which would need
+    zeroconf + a network interface). Looks for the `subdomain_routes`
+    assignment and pulls the first element of each tuple.
+    """
+    source = MDNS_SCRIPT.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    found: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        targets = [t.id for t in node.targets if isinstance(t, ast.Name)]
+        if "subdomain_routes" not in targets:
+            continue
+        value = node.value
+        if not isinstance(value, ast.Tuple):
+            continue
+        for elt in value.elts:
+            if isinstance(elt, ast.Tuple) and elt.elts:
+                first = elt.elts[0]
+                if isinstance(first, ast.Constant) and isinstance(first.value, str):
+                    found.add(first.value)
+    return found
+
+
+def test_announcer_publishes_all_required_subdomains() -> None:
+    found = _extract_subdomain_routes_keys()
+    missing = REQUIRED_SUBDOMAINS - found
+    assert not missing, (
+        f"bin/dream-mdns.py is missing required subdomains: {sorted(missing)}. "
+        "If you added a new public host, add it here AND in subdomain_routes. "
+        "If you removed a host on purpose, update REQUIRED_SUBDOMAINS in this test."
+    )
+
+
+def test_announcer_does_not_advertise_unknown_subdomains() -> None:
+    # Fail loudly when the announcer publishes a name nobody else expects.
+    # Catches drift in the opposite direction: stale entries that point at
+    # backends that no longer exist still draw LAN traffic toward Caddy and
+    # produce confusing 404s.
+    found = _extract_subdomain_routes_keys()
+    extra = found - REQUIRED_SUBDOMAINS
+    assert not extra, (
+        f"bin/dream-mdns.py publishes subdomains not listed in REQUIRED_SUBDOMAINS: "
+        f"{sorted(extra)}. Add them to the set above (and confirm Caddy + magic_link "
+        "agree) or remove them from subdomain_routes."
+    )
+
+
+if __name__ == "__main__":
+    test_announcer_publishes_all_required_subdomains()
+    test_announcer_does_not_advertise_unknown_subdomains()
+    print("OK")


### PR DESCRIPTION
## Summary

Reported by the operator after redeeming a real owner card and texting Dream Talk: *"It says it's thinking but I don't think it is."* Investigation surfaced three layered bugs in the chat path. This PR ships fixes for all three.

| Bug | Where | Effect |
|---|---|---|
| **1. Bridge opens a new WebSocket per call** (root cause) | `hermes_bridge.submit_prompt` opened a fresh WS for `session.create`, closed it, then opened *another* fresh WS for `prompt.submit` | Hermes scopes streaming event delivery to the WS that owns the session. The second WS's `prompt.submit` returns `{"status":"streaming"}` but **the events fire to the already-closed first WS**. The bridge waits forever on the second WS, eventually 502'ing at the 180 s timeout — **even though Hermes generated the full reply seconds earlier**. |
| **2. Endpoint is synchronous, not streaming** | `/api/talk/message` blocks until the full reply is assembled, then returns JSON | On a cold first message (16 k-token system prompt), Hermes prompt processing takes ~60 s before any token streams back. The UI sees a stalled "thinking" spinner with no feedback. |
| **3. nginx `/api/` timeout is too tight** | Dashboard nginx had `proxy_read_timeout 180s` for the whole `/api/` block | Even the synchronous endpoint can legitimately need >180 s on cold first-call paths. Streaming responses need `proxy_buffering off` so frames pass through immediately. |

## Reproduction (pre-fix)

```
$ curl -sN -X POST http://127.0.0.1:3002/api/talk/message \
    -H 'Cookie: dream-session=<valid>' -H 'Content-Type: application/json' \
    -d '{"text":"reply PONG only"}' -w '\nHTTP=%{http_code} time=%{time_total}\n'
{"detail":"Hermes did not finish the response."}
HTTP=502 time=180.014547

# Meanwhile, in dream-hermes logs, the response *completed* in 1.7 s:
[dashboard] event {type: "message.complete", session_id: "67fb13bd",
                   payload: {text: "PONG"}, usage: {input: 16412, output: 269, ...}}
```

A minimal reproducer (run inside `dream-dashboard-api`) confirms the per-WS scoping:

```python
# WS-A: create session, then CLOSE
async with await ws_connect(...) as ws_a:
    sid = await session_create(ws_a)   # → 0d1b1a76

# WS-B (fresh): prompt.submit with sid from WS-A
async with await ws_connect(...) as ws_b:
    await ws_b.send_json({...prompt.submit..., "session_id": sid, ...})
    # → {"status":"streaming"}     ← accepted!
    # … then nothing. Zero events for 60 s. Eventually times out.
```

## The fix — three changes, one PR

### 1. `hermes_bridge.py`: single-WS lifecycle

* New async generator `stream_prompt(session_key, text)` that opens **one** WS, runs `session.create` AND `prompt.submit` on it, consumes events to `message.complete`, and yields `{session, delta, complete}` events to its caller.
* `submit_prompt` becomes a thin wrapper that consumes `stream_prompt` and returns the final `HermesReply`. Existing callers / tests that want a single JSON reply keep working.
* The legacy `_SESSION_IDS` cross-call cache is no longer used for streaming (event delivery is per-WS, so a cached session_id from a dead WS is useless). `ensure_session` is kept as a compat shim because the existing JSON `/api/talk/session` endpoint and tests call it; conversational continuity is provided by Hermes's own agent memory layer rather than session reuse.

### 2. `/api/talk/message/stream` — new SSE endpoint

* Returns `text/event-stream` with one `data:` line per bridge event.
* Frame types: `session`, `delta` (repeats), `complete`, `error` (on failure), `done` (always last). Same shape used in tests so a future regression is loud.
* The synchronous `/api/talk/message` endpoint stays, for non-browser callers and tests. It now uses the fixed bridge too.

### 3. `nginx.conf`: dedicated `^~ /api/talk/` block

```nginx
location ^~ /api/talk/ {
    proxy_pass http://dashboard-api:3002;
    ...
    proxy_read_timeout 600s;
    proxy_send_timeout 600s;
    proxy_buffering off;
    proxy_cache off;
    proxy_set_header X-Accel-Buffering no;
}
```

* `^~` so it takes priority over the generic `/api/` block.
* `proxy_buffering off` + `X-Accel-Buffering: no` so each SSE frame is forwarded to the client immediately rather than batched.
* Bumps `proxy_read_timeout` from 180 s → 600 s so first-message cold prompts have headroom even if the SPA still falls back to the JSON endpoint.

### 4. Frontend: stream-aware `sendText`

* `DreamTalk.jsx` now hits `/api/talk/message/stream`, reads the response as a `ReadableStream`, buffers partial SSE frames across transport chunks, and appends each `delta` into the assistant bubble live.
* Errors received via SSE `error` frame become the assistant's error message — the same UX as before, but now we see the actual `detail` from Hermes instead of an opaque `fetch` failure.

## Test coverage

* **Backend** (`extensions/services/dashboard-api/tests/test_talk.py`, +6 tests, all 11 pass):
  * `test_talk_message_stream_emits_session_then_deltas_then_complete`
  * `test_talk_message_stream_emits_error_frame_and_done_on_bridge_failure`
  * `test_talk_message_stream_emits_503_when_hermes_unavailable`
  * `test_talk_message_stream_requires_session`
  * `test_talk_message_stream_validates_input`
  * `test_talk_message_stream_sets_unbuffered_headers` (regression guard against losing `X-Accel-Buffering` / `Cache-Control`)
* **Frontend** (`extensions/services/dashboard/src/pages/DreamTalk.test.jsx`, +2 new + existing updated, all 6 pass):
  * Updated `renders a mobile text portal and sends a message` to expect SSE frames instead of JSON.
  * New `accumulates SSE deltas across split chunks` — frames split across `read()` boundaries are re-assembled correctly.
  * New `surfaces SSE error frame as an assistant error`.

## Fleet verification

Patched files deployed and containers rebuilt + recreated on all three Linux fleet hosts. Issued an admin cookie and hit `POST /api/talk/message/stream` through the dashboard nginx (`Host: talk.<device>.local`, the real path the phone takes):

| host | model | response | elapsed |
|------|-------|----------|---------|
| tower2 | qwen3-coder-next | full SSE frame sequence (`session, 2× delta, complete, done`), reply = "HELLO" | 4 s |
| strix-halo | Qwen3.6-35B-A3B (Lemonade ROCm) | full sequence, reply = "HELLO" | 2 s |
| spark | Qwen3.6-35B-A3B (llama.cpp GB10 aarch64) | full sequence, reply = "HELLO" | 9 s |

Synchronous endpoint `/api/talk/message` (still used by tests + non-browser callers) also returns correctly now: strix returns `{"text":"PING","status":"complete"}` in 1.7 s on a short prompt — versus pre-fix where it 502'd at exactly 180 s.

## Risk / blast radius

* `submit_prompt` keeps its old signature and return shape. The non-streaming JSON endpoint `/api/talk/message` is unchanged from the caller's perspective; only the bridge implementation underneath it changed.
* The streaming endpoint is **new** — adding it can't break existing clients.
* nginx changes are scoped to a new `^~ /api/talk/` block; the existing `/api/` block is untouched, so non-Talk endpoints behave identically.
* `_SESSION_IDS` cache is no longer load-bearing; the only call that still touches it is `ensure_session`, which exists for the `/api/talk/session` legacy endpoint and the existing tests. Conversational memory now lives in Hermes's agent layer (which it always did — the `session_id` reuse was a UX-continuity hint, not a memory primitive).
