### PR TITLE
perf(hermes-bridge): pool one Hermes session per cookie (closes #1322)

### DIFF
--- a/dream-server/extensions/services/dashboard-api/hermes_bridge.py
+++ b/dream-server/extensions/services/dashboard-api/hermes_bridge.py
@@ -44,8 +44,16 @@ TOKEN_RE = re.compile(r'window\.__HERMES_SESSION_TOKEN__\s*=\s*"([^"]+)"')
 DEFAULT_HERMES_URL = "http://dream-hermes:9119"
 DEFAULT_TIMEOUT_SECONDS = 180
 
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    raw = os.environ.get(name, "")
+    if raw.isdigit():
+        return max(minimum, int(raw))
+    return default
+
+
 # Connection pool tuning. Override per environment if needed.
-_IDLE_EXPIRY_SECONDS = int(os.environ.get("DREAM_TALK_IDLE_EXPIRY", "300"))  # 5 min default
+_IDLE_EXPIRY_SECONDS = _env_int("DREAM_TALK_IDLE_EXPIRY", 300)  # 5 min default
 _IDLE_SWEEP_INTERVAL = 60  # how often the background sweeper runs
 
 
@@ -55,6 +63,16 @@ class HermesBridgeError(RuntimeError):
 
 class HermesUnavailable(HermesBridgeError):
     """Hermes is not reachable or did not expose the expected dashboard API."""
+
+
+class HermesConnectionStale(HermesUnavailable):
+    """The pooled WebSocket died before a prompt was submitted.
+
+    This is safe to retry transparently because Hermes never accepted the
+    prompt on that transport. Once prompt.submit has been sent, later
+    connection drops surface as errors instead of retrying and potentially
+    duplicating tool calls or streamed text.
+    """
 
 
 @dataclass
@@ -249,6 +267,11 @@ async def _sweep_idle_connections() -> None:
             stale: list[tuple[str, _HermesConnection]] = []
             async with _POOL_GUARD:
                 for key, conn in list(_CONNECTION_POOL.items()):
+                    if conn.lock.locked():
+                        # Active prompt. Do not close the WS while Hermes is
+                        # streaming or pre-filling a long response; last_used
+                        # is refreshed again when the prompt completes.
+                        continue
                     if conn.closed or conn.ws.closed:
                         stale.append((key, conn))
                         _CONNECTION_POOL.pop(key, None)
@@ -307,6 +330,7 @@ async def _submit_on_connection(
     """
     request_id = f"dream-talk-prompt-{int(time.monotonic() * 1000)}"
     try:
+        conn.last_used = time.monotonic()
         await conn.ws.send_str(json.dumps({
             "jsonrpc": "2.0",
             "id": request_id,
@@ -316,9 +340,10 @@ async def _submit_on_connection(
     except (aiohttp.ClientError, ConnectionResetError, ConnectionError) as exc:
         # Pooled WS was closed under us between the freshness check and this
         # send (Hermes restart, network blip, idle timeout that hadn't been
-        # noticed yet). Surface as HermesUnavailable so stream_prompt evicts
-        # the pool entry + retries on a fresh connection.
-        raise HermesUnavailable(f"Hermes WS closed on send: {exc}") from exc
+        # noticed yet). Surface as HermesConnectionStale so stream_prompt
+        # evicts the pool entry + retries on a fresh connection. This is the
+        # only transparent-retry case because the prompt was not submitted.
+        raise HermesConnectionStale(f"Hermes WS closed before prompt submit: {exc}") from exc
 
     chunks: list[str] = []
     while True:
@@ -395,12 +420,11 @@ async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, 
     _ensure_sweeper_running()
     timeout_seconds = _request_timeout()
 
-    # Attempt twice: the first try uses the pooled connection (warm cache,
-    # fast path); if that connection turns out to be dead (Hermes restart,
-    # idle timeout that hadn't been swept yet, network reset), evict it and
-    # try once more with a freshly-opened connection. Two attempts max so a
-    # truly broken Hermes doesn't loop forever — the second failure surfaces
-    # as HermesUnavailable to the SSE layer, which renders an error frame.
+    # Attempt twice only for the pre-submit stale-WS case: the first try uses
+    # the pooled connection (warm cache, fast path); if send_str fails before
+    # Hermes accepts prompt.submit, evict it and try once more with a fresh
+    # connection. Once prompt.submit has been sent, later WS failures surface
+    # as errors instead of retrying and duplicating tool calls or text.
     session_frame_emitted = False
     for attempt in (1, 2):
         conn = await _get_connection(session_key)
@@ -416,14 +440,17 @@ async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, 
                 async for event in _submit_on_connection(conn, text, timeout_seconds):
                     yield event
                 return
-            except HermesUnavailable as exc:
+            except HermesConnectionStale as exc:
                 await _drop_connection(session_key, conn)
                 if attempt == 2:
                     # Already retried once; give up and surface the failure.
                     raise
-                logger.info("hermes-bridge: retrying once after dead WS (%s)", exc)
+                logger.info("hermes-bridge: retrying once after stale WS (%s)", exc)
                 # Drop the lock + loop to attempt 2 with a fresh connection.
                 continue
+            except HermesUnavailable:
+                await _drop_connection(session_key, conn)
+                raise
 
 
 async def submit_prompt(session_key: str, text: str) -> HermesReply:

--- a/dream-server/extensions/services/dashboard-api/hermes_bridge.py
+++ b/dream-server/extensions/services/dashboard-api/hermes_bridge.py
@@ -12,6 +12,16 @@ fresh WS-B for ``prompt.submit``, Hermes accepts the submit (returns
 already closed. The bridge would then wait forever for events that never
 arrive and 502 at the request timeout. So a single submit_prompt / stream_prompt
 call MUST do both create-session and submit-prompt on the same WS.
+
+Per-cookie connection pool (issue #1322): instead of opening a new WS for
+every Dream Talk message, we hold one ``HermesConnection`` per ``session_key``
+in a process-wide pool and reuse the same Hermes session across messages from
+the same phone. Hermes's per-WS event scoping makes this work — the same WS
+is the owner, so events keep flowing. The big win is llama-server's
+prompt-cache stays warm across messages, so the second "hey" doesn't pay the
+30-60s prefill of the 16k-token agent system prompt. An idle sweeper closes
+connections that have been quiet for >5 minutes so a fleet of one-time
+visitors doesn't pin Hermes resources forever.
 """
 
 from __future__ import annotations
@@ -22,7 +32,8 @@ import json
 import logging
 import os
 import re
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Any, AsyncIterator
 
 import aiohttp
@@ -32,6 +43,10 @@ logger = logging.getLogger(__name__)
 TOKEN_RE = re.compile(r'window\.__HERMES_SESSION_TOKEN__\s*=\s*"([^"]+)"')
 DEFAULT_HERMES_URL = "http://dream-hermes:9119"
 DEFAULT_TIMEOUT_SECONDS = 180
+
+# Connection pool tuning. Override per environment if needed.
+_IDLE_EXPIRY_SECONDS = int(os.environ.get("DREAM_TALK_IDLE_EXPIRY", "300"))  # 5 min default
+_IDLE_SWEEP_INTERVAL = 60  # how often the background sweeper runs
 
 
 class HermesBridgeError(RuntimeError):
@@ -132,23 +147,219 @@ async def _create_session_on_ws(ws: aiohttp.ClientWebSocketResponse, *, timeout:
         return session_id
 
 
-_SUBMIT_LOCKS: dict[str, asyncio.Lock] = {}
-_SUBMIT_LOCKS_GUARD = asyncio.Lock()
+@dataclass
+class _HermesConnection:
+    """One long-lived WS + Hermes session, scoped to a single phone cookie.
 
+    Holding the WS open across messages lets Hermes reuse its session_id and
+    keeps the 16k-token system prompt warm in llama-server's KV cache. Each
+    new prompt on the same connection costs ~1k tokens of context (the user
+    message + maybe a tool result), not 16k+1k. Big latency win.
 
-async def _submit_lock(session_key: str) -> asyncio.Lock:
-    """Per-session-key mutex so two prompts from the same phone don't pile
-    up on llama-server slots. Each call to stream_prompt holds the lock for
-    the whole bridge round-trip; subsequent same-key submits wait until the
-    previous one finishes (or the client disconnects, which cancels the
-    bridge and releases the lock).
+    The per-connection ``lock`` serializes two prompts from the same phone:
+    Hermes can't multiplex two prompt.submit calls on one session anyway,
+    and the SPA's UI already enforces "wait for the previous reply" — this
+    is the server-side belt to that suspenders.
     """
-    async with _SUBMIT_LOCKS_GUARD:
-        lock = _SUBMIT_LOCKS.get(session_key)
-        if lock is None:
-            lock = asyncio.Lock()
-            _SUBMIT_LOCKS[session_key] = lock
-        return lock
+    http_session: aiohttp.ClientSession
+    ws: aiohttp.ClientWebSocketResponse
+    session_id: str
+    last_used: float = field(default_factory=time.monotonic)
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    closed: bool = False
+
+    async def aclose(self) -> None:
+        if self.closed:
+            return
+        self.closed = True
+        try:
+            await self.ws.close()
+        except Exception:  # pragma: no cover — best-effort cleanup
+            logger.debug("ws.close raised during pool eviction", exc_info=True)
+        try:
+            await self.http_session.close()
+        except Exception:  # pragma: no cover
+            logger.debug("http_session.close raised during pool eviction", exc_info=True)
+
+
+_CONNECTION_POOL: dict[str, _HermesConnection] = {}
+_POOL_GUARD = asyncio.Lock()
+_SWEEPER_TASK: asyncio.Task | None = None
+
+
+async def _open_connection(session_key: str) -> _HermesConnection:
+    """Open one fresh WS + run session.create. Caller holds _POOL_GUARD."""
+    timeout_seconds = _request_timeout()
+    timeout = aiohttp.ClientTimeout(total=timeout_seconds + 20)
+    http_session = aiohttp.ClientSession(timeout=timeout)
+    try:
+        ws = await _connect_ws(http_session)
+    except Exception:
+        await http_session.close()
+        raise
+    try:
+        session_id = await _create_session_on_ws(ws, timeout=30)
+    except Exception:
+        await ws.close()
+        await http_session.close()
+        raise
+    conn = _HermesConnection(http_session=http_session, ws=ws, session_id=session_id)
+    logger.info("hermes-bridge: opened pooled connection for %s (session_id=%s)", session_key[:8], session_id)
+    return conn
+
+
+async def _get_connection(session_key: str) -> _HermesConnection:
+    """Look up the pooled connection for this session_key, or create one.
+
+    Caller must use ``async with conn.lock:`` around any send/receive cycle
+    to keep concurrent same-key prompts from interleaving on the same WS.
+    """
+    async with _POOL_GUARD:
+        conn = _CONNECTION_POOL.get(session_key)
+        if conn is not None and not conn.closed and not conn.ws.closed:
+            return conn
+        # Either no entry, marked closed, or the underlying ws died. Drop
+        # whatever is in the slot and open fresh.
+        if conn is not None:
+            await conn.aclose()
+        new_conn = await _open_connection(session_key)
+        _CONNECTION_POOL[session_key] = new_conn
+        return new_conn
+
+
+async def _drop_connection(session_key: str, conn: _HermesConnection) -> None:
+    """Evict a connection from the pool (e.g. after a dead-WS error)."""
+    async with _POOL_GUARD:
+        current = _CONNECTION_POOL.get(session_key)
+        if current is conn:
+            _CONNECTION_POOL.pop(session_key, None)
+    await conn.aclose()
+
+
+async def _sweep_idle_connections() -> None:
+    """Background task: close pool entries idle for > _IDLE_EXPIRY_SECONDS.
+
+    Runs forever; the task is held in ``_SWEEPER_TASK``. Cancelled by
+    ``shutdown_pool()`` on app shutdown.
+    """
+    while True:
+        try:
+            await asyncio.sleep(_IDLE_SWEEP_INTERVAL)
+            now = time.monotonic()
+            stale: list[tuple[str, _HermesConnection]] = []
+            async with _POOL_GUARD:
+                for key, conn in list(_CONNECTION_POOL.items()):
+                    if conn.closed or conn.ws.closed:
+                        stale.append((key, conn))
+                        _CONNECTION_POOL.pop(key, None)
+                        continue
+                    if now - conn.last_used > _IDLE_EXPIRY_SECONDS:
+                        stale.append((key, conn))
+                        _CONNECTION_POOL.pop(key, None)
+            for key, conn in stale:
+                logger.info("hermes-bridge: evicting idle connection for %s", key[:8])
+                await conn.aclose()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # pragma: no cover — keep sweeper alive on bugs
+            logger.exception("hermes-bridge: idle sweeper hit an error; continuing")
+
+
+def _ensure_sweeper_running() -> None:
+    """Lazily start the idle sweeper on first use. Idempotent."""
+    global _SWEEPER_TASK
+    if _SWEEPER_TASK is not None and not _SWEEPER_TASK.done():
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    _SWEEPER_TASK = loop.create_task(_sweep_idle_connections())
+
+
+async def shutdown_pool() -> None:
+    """Close every pooled connection. Call from a FastAPI lifespan handler
+    so a graceful shutdown doesn't leak WSes / file descriptors."""
+    global _SWEEPER_TASK
+    if _SWEEPER_TASK is not None:
+        _SWEEPER_TASK.cancel()
+        try:
+            await _SWEEPER_TASK
+        except (asyncio.CancelledError, Exception):
+            pass
+        _SWEEPER_TASK = None
+    async with _POOL_GUARD:
+        connections = list(_CONNECTION_POOL.values())
+        _CONNECTION_POOL.clear()
+    for conn in connections:
+        await conn.aclose()
+
+
+async def _submit_on_connection(
+    conn: _HermesConnection, text: str, timeout_seconds: int,
+) -> AsyncIterator[dict[str, Any]]:
+    """Send one prompt on an already-open pooled connection and yield events.
+
+    Caller must hold ``conn.lock`` for the duration of this generator so two
+    same-key prompts can't interleave on the same WS. Mutates ``conn.last_used``
+    on completion. Raises HermesUnavailable / HermesBridgeError on failure;
+    the caller decides whether to evict the pool entry.
+    """
+    request_id = f"dream-talk-prompt-{int(time.monotonic() * 1000)}"
+    await conn.ws.send_str(json.dumps({
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": "prompt.submit",
+        "params": {"session_id": conn.session_id, "text": text},
+    }))
+
+    chunks: list[str] = []
+    while True:
+        frame = await _recv_json(conn.ws, timeout_seconds)
+
+        # Reply to our prompt.submit RPC — informational; events still follow.
+        if frame.get("id") == request_id:
+            if frame.get("error"):
+                err = frame["error"]
+                message = err.get("message") if isinstance(err, dict) else str(err)
+                raise HermesBridgeError(message or "Hermes prompt failed")
+            continue
+
+        if frame.get("method") != "event":
+            continue
+        event = frame.get("params") or {}
+        if not isinstance(event, dict):
+            continue
+        if event.get("session_id") and event.get("session_id") != conn.session_id:
+            # Stray event from a sibling session — ignore.
+            continue
+
+        payload = event.get("payload") or {}
+        if not isinstance(payload, dict):
+            payload = {}
+
+        event_type = event.get("type")
+        if event_type == "message.delta":
+            chunk = payload.get("text")
+            if isinstance(chunk, str) and chunk:
+                chunks.append(chunk)
+                yield {"type": "delta", "text": chunk}
+        elif event_type == "message.complete":
+            final_text = payload.get("text")
+            if not isinstance(final_text, str) or not final_text.strip():
+                final_text = "".join(chunks)
+            conn.last_used = time.monotonic()
+            yield {
+                "type": "complete",
+                "session_id": conn.session_id,
+                "text": final_text.strip(),
+                "status": str(payload.get("status") or "ok"),
+                "warning": payload.get("warning") if isinstance(payload.get("warning"), str) else None,
+            }
+            return
+        elif event_type == "error":
+            message = payload.get("message") if isinstance(payload.get("message"), str) else "Hermes reported an error"
+            raise HermesBridgeError(message)
 
 
 async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, Any]]:
@@ -161,79 +372,45 @@ async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, 
 
     On error, raises HermesUnavailable / HermesBridgeError; no partial yield.
 
-    The session_key argument is currently advisory for Hermes session reuse
-    (Hermes scopes events per-WS, so we can't safely persist a session across
-    submit calls — see module docstring), but it IS used to serialize concurrent
-    submits from the same phone. Two messages from the same cookie can't
-    overlap; the second waits for the first to finish or be cancelled.
-    Conversational memory across calls is provided by Hermes's own agent
-    memory layer, not by session_id reuse.
+    Uses the per-cookie connection pool so subsequent messages from the same
+    phone reuse the same Hermes session_id (and therefore keep llama-server's
+    prompt cache warm for the 16k-token agent system prompt). On the first
+    call for a cookie, opens a fresh WS and runs session.create; on later
+    calls, reuses the pooled connection and just sends prompt.submit. The
+    pool's idle sweeper closes inactive connections after
+    DREAM_TALK_IDLE_EXPIRY seconds (default 300s = 5 min) so a fleet of
+    one-time visitors doesn't pin resources forever.
+
+    Two same-key prompts can't overlap (per-connection ``lock`` serializes
+    them); two different-key prompts run in parallel as long as
+    llama-server's slots can absorb the load.
     """
+    _ensure_sweeper_running()
     timeout_seconds = _request_timeout()
-    timeout = aiohttp.ClientTimeout(total=timeout_seconds + 20)
 
-    lock = await _submit_lock(session_key)
-    async with lock:
-        async with aiohttp.ClientSession(timeout=timeout) as http_session:
-            ws = await _connect_ws(http_session)
-            async with ws:
-                session_id = await _create_session_on_ws(ws, timeout=30)
-                yield {"type": "session", "session_id": session_id}
+    conn = await _get_connection(session_key)
+    async with conn.lock:
+        # Yield the session frame from inside the lock so the SPA's first
+        # frame always carries the live session_id (and not one stale from a
+        # connection that got swapped out between yield and submit).
+        yield {"type": "session", "session_id": conn.session_id}
 
-                request_id = "dream-talk-prompt"
-                await ws.send_str(json.dumps({
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "method": "prompt.submit",
-                    "params": {"session_id": session_id, "text": text},
-                }))
+        try:
+            async for event in _submit_on_connection(conn, text, timeout_seconds):
+                yield event
+            return
+        except HermesUnavailable:
+            # WS died (closed, reset, etc). Evict + retry ONCE on a fresh
+            # connection so a Hermes container restart looks like a one-call
+            # blip, not a sticky failure for the cookie.
+            await _drop_connection(session_key, conn)
+            raise
 
-                chunks: list[str] = []
-                while True:
-                    frame = await _recv_json(ws, timeout_seconds)
-
-                    # Reply to our prompt.submit RPC — informational; events still follow.
-                    if frame.get("id") == request_id:
-                        if frame.get("error"):
-                            err = frame["error"]
-                            message = err.get("message") if isinstance(err, dict) else str(err)
-                            raise HermesBridgeError(message or "Hermes prompt failed")
-                        continue
-
-                    if frame.get("method") != "event":
-                        continue
-                    event = frame.get("params") or {}
-                    if not isinstance(event, dict):
-                        continue
-                    if event.get("session_id") and event.get("session_id") != session_id:
-                        # Stray event from a sibling session — ignore.
-                        continue
-
-                    payload = event.get("payload") or {}
-                    if not isinstance(payload, dict):
-                        payload = {}
-
-                    event_type = event.get("type")
-                    if event_type == "message.delta":
-                        chunk = payload.get("text")
-                        if isinstance(chunk, str) and chunk:
-                            chunks.append(chunk)
-                            yield {"type": "delta", "text": chunk}
-                    elif event_type == "message.complete":
-                        final_text = payload.get("text")
-                        if not isinstance(final_text, str) or not final_text.strip():
-                            final_text = "".join(chunks)
-                        yield {
-                            "type": "complete",
-                            "session_id": session_id,
-                            "text": final_text.strip(),
-                            "status": str(payload.get("status") or "ok"),
-                            "warning": payload.get("warning") if isinstance(payload.get("warning"), str) else None,
-                        }
-                        return
-                    elif event_type == "error":
-                        message = payload.get("message") if isinstance(payload.get("message"), str) else "Hermes reported an error"
-                        raise HermesBridgeError(message)
+    # NOTE: a fully-fledged "retry once on dead connection" path would require
+    # nesting another acquire here. For now we surface HermesUnavailable to
+    # the SSE layer, which renders an error frame; the SPA's next send creates
+    # a fresh connection. Two-tap recovery is acceptable for v1; a transparent
+    # retry can land in a follow-up if real-world data shows it's needed.
 
 
 async def submit_prompt(session_key: str, text: str) -> HermesReply:

--- a/dream-server/extensions/services/dashboard-api/hermes_bridge.py
+++ b/dream-server/extensions/services/dashboard-api/hermes_bridge.py
@@ -302,16 +302,23 @@ async def _submit_on_connection(
 
     Caller must hold ``conn.lock`` for the duration of this generator so two
     same-key prompts can't interleave on the same WS. Mutates ``conn.last_used``
-    on completion. Raises HermesUnavailable / HermesBridgeError on failure;
-    the caller decides whether to evict the pool entry.
+    on completion. Raises HermesUnavailable when the WS is dead (caller is
+    expected to evict + reopen), HermesBridgeError on protocol-level errors.
     """
     request_id = f"dream-talk-prompt-{int(time.monotonic() * 1000)}"
-    await conn.ws.send_str(json.dumps({
-        "jsonrpc": "2.0",
-        "id": request_id,
-        "method": "prompt.submit",
-        "params": {"session_id": conn.session_id, "text": text},
-    }))
+    try:
+        await conn.ws.send_str(json.dumps({
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": "prompt.submit",
+            "params": {"session_id": conn.session_id, "text": text},
+        }))
+    except (aiohttp.ClientError, ConnectionResetError, ConnectionError) as exc:
+        # Pooled WS was closed under us between the freshness check and this
+        # send (Hermes restart, network blip, idle timeout that hadn't been
+        # noticed yet). Surface as HermesUnavailable so stream_prompt evicts
+        # the pool entry + retries on a fresh connection.
+        raise HermesUnavailable(f"Hermes WS closed on send: {exc}") from exc
 
     chunks: list[str] = []
     while True:
@@ -388,29 +395,35 @@ async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, 
     _ensure_sweeper_running()
     timeout_seconds = _request_timeout()
 
-    conn = await _get_connection(session_key)
-    async with conn.lock:
-        # Yield the session frame from inside the lock so the SPA's first
-        # frame always carries the live session_id (and not one stale from a
-        # connection that got swapped out between yield and submit).
-        yield {"type": "session", "session_id": conn.session_id}
-
-        try:
-            async for event in _submit_on_connection(conn, text, timeout_seconds):
-                yield event
-            return
-        except HermesUnavailable:
-            # WS died (closed, reset, etc). Evict + retry ONCE on a fresh
-            # connection so a Hermes container restart looks like a one-call
-            # blip, not a sticky failure for the cookie.
-            await _drop_connection(session_key, conn)
-            raise
-
-    # NOTE: a fully-fledged "retry once on dead connection" path would require
-    # nesting another acquire here. For now we surface HermesUnavailable to
-    # the SSE layer, which renders an error frame; the SPA's next send creates
-    # a fresh connection. Two-tap recovery is acceptable for v1; a transparent
-    # retry can land in a follow-up if real-world data shows it's needed.
+    # Attempt twice: the first try uses the pooled connection (warm cache,
+    # fast path); if that connection turns out to be dead (Hermes restart,
+    # idle timeout that hadn't been swept yet, network reset), evict it and
+    # try once more with a freshly-opened connection. Two attempts max so a
+    # truly broken Hermes doesn't loop forever — the second failure surfaces
+    # as HermesUnavailable to the SSE layer, which renders an error frame.
+    session_frame_emitted = False
+    for attempt in (1, 2):
+        conn = await _get_connection(session_key)
+        async with conn.lock:
+            if not session_frame_emitted:
+                # Yield the session frame once, from the *first* attempt's
+                # connection. If the connection dies before any deltas, the
+                # retry's session_id will be different but the SPA only cares
+                # about the most recent — replacing the frame is fine.
+                yield {"type": "session", "session_id": conn.session_id}
+                session_frame_emitted = True
+            try:
+                async for event in _submit_on_connection(conn, text, timeout_seconds):
+                    yield event
+                return
+            except HermesUnavailable as exc:
+                await _drop_connection(session_key, conn)
+                if attempt == 2:
+                    # Already retried once; give up and surface the failure.
+                    raise
+                logger.info("hermes-bridge: retrying once after dead WS (%s)", exc)
+                # Drop the lock + loop to attempt 2 with a fresh connection.
+                continue
 
 
 async def submit_prompt(session_key: str, text: str) -> HermesReply:

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -933,7 +933,16 @@ async def _lifespan(app: FastAPI):
     asyncio.create_task(collect_metrics())
     asyncio.create_task(_poll_service_health())
     asyncio.create_task(gpu_router.poll_gpu_history())
-    yield
+    try:
+        yield
+    finally:
+        # Close any open Hermes WebSockets in the Dream Talk connection pool
+        # so a graceful uvicorn shutdown doesn't leak FDs into stale state.
+        try:
+            import hermes_bridge
+            await hermes_bridge.shutdown_pool()
+        except Exception:
+            logger.debug("hermes_bridge.shutdown_pool raised at app shutdown", exc_info=True)
 
 
 app = FastAPI(

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -416,7 +416,6 @@ def test_hermes_bridge_transparent_retry_on_send_reset(monkeypatch):
     raced with the freshness check). The bridge must catch that, evict, and
     transparently retry once on a fresh connection — the user shouldn't see
     "load failed" just because Hermes restarted in the background."""
-    import asyncio as _asyncio
     import aiohttp
     import hermes_bridge
 
@@ -470,11 +469,55 @@ def test_hermes_bridge_transparent_retry_on_send_reset(monkeypatch):
     assert opens == 2, f"expected 1 retry (opens == 2), got {opens}"
 
 
+def test_hermes_bridge_does_not_retry_after_prompt_submit(monkeypatch):
+    """A receive-side WS failure happens after prompt.submit was sent, so the
+    bridge must not retry the same prompt. Retrying there can duplicate tool
+    calls or append a second answer after partial streamed text. Only the
+    pre-submit send failure is safe to retry transparently."""
+    import hermes_bridge
+
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._SWEEPER_TASK = None
+
+    class FakeWS:
+        closed = False
+        async def send_str(self, _): pass
+        async def close(self): self.closed = True
+
+    class FakeHTTP:
+        async def close(self): pass
+
+    open_calls = 0
+
+    async def fake_open(session_key):
+        nonlocal open_calls
+        open_calls += 1
+        return hermes_bridge._HermesConnection(
+            http_session=FakeHTTP(), ws=FakeWS(), session_id=f"sid-{open_calls}",
+        )
+
+    monkeypatch.setattr("hermes_bridge._open_connection", fake_open)
+
+    async def fake_recv(_ws, _timeout):
+        raise hermes_bridge.HermesUnavailable("closed after submit")
+
+    monkeypatch.setattr("hermes_bridge._recv_json", fake_recv)
+
+    async def main():
+        with pytest.raises(hermes_bridge.HermesUnavailable):
+            async for _event in hermes_bridge.stream_prompt("no-retry-key", "hi"):
+                pass
+        return open_calls, "no-retry-key" in hermes_bridge._CONNECTION_POOL
+
+    opens, still_pooled = _run_with_one_loop(main)
+    assert opens == 1, f"receive-side failure must not retry submitted prompt, got {opens} opens"
+    assert not still_pooled, "failed connection should be evicted before surfacing the error"
+
+
 def test_hermes_bridge_pool_evicts_and_recreates_on_dead_ws(monkeypatch):
     """If the cached WS has closed (e.g. Hermes container restarted between
     messages), the pool must evict it and open a fresh connection on the
     next ``stream_prompt`` call rather than silently failing forever."""
-    import asyncio as _asyncio
     import hermes_bridge
 
     hermes_bridge._CONNECTION_POOL.clear()
@@ -525,6 +568,55 @@ def test_hermes_bridge_pool_evicts_and_recreates_on_dead_ws(monkeypatch):
     creates, sid = _run_with_one_loop(main)
     assert creates == 2, f"expected 2 connection opens (initial + after dead WS), got {creates}"
     assert sid == "sid-2", f"pool should hold the new connection, has {sid}"
+
+
+def test_hermes_bridge_pool_sweeper_skips_active_connections(monkeypatch):
+    """A prompt can run longer than the idle timeout on a slow first turn.
+    The sweeper must not close a connection while its per-connection lock is
+    held, even if last_used is old."""
+    import asyncio as _asyncio
+    import hermes_bridge
+
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._SWEEPER_TASK = None
+
+    monkeypatch.setattr("hermes_bridge._IDLE_EXPIRY_SECONDS", 0.05)
+    monkeypatch.setattr("hermes_bridge._IDLE_SWEEP_INTERVAL", 0.02)
+
+    closed_calls: list[str] = []
+
+    class FakeWS:
+        def __init__(self): self.closed = False
+        async def close(self): self.closed = True
+
+    class FakeHTTP:
+        async def close(self): pass
+
+    async def fake_open(session_key):
+        conn = hermes_bridge._HermesConnection(http_session=FakeHTTP(), ws=FakeWS(), session_id="sid")
+        original_close = conn.aclose
+        async def _tracked_close():
+            closed_calls.append(session_key)
+            await original_close()
+        conn.aclose = _tracked_close
+        return conn
+
+    monkeypatch.setattr("hermes_bridge._open_connection", fake_open)
+
+    async def main():
+        conn = await hermes_bridge._get_connection("active-key")
+        await conn.lock.acquire()
+        try:
+            conn.last_used -= 100
+            hermes_bridge._ensure_sweeper_running()
+            await _asyncio.sleep(0.15)
+            return "active-key" in hermes_bridge._CONNECTION_POOL, list(closed_calls)
+        finally:
+            conn.lock.release()
+
+    still_in_pool, closed = _run_with_one_loop(main)
+    assert still_in_pool, "active connection should not be swept while its lock is held"
+    assert closed == [], f"sweeper should not close active connection, got {closed}"
 
 
 def test_hermes_bridge_pool_sweeper_evicts_idle_connections(monkeypatch):

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -299,42 +299,76 @@ def test_talk_message_stream_cancels_upstream_on_client_disconnect(talk_client, 
     assert bridge_cancelled.is_set()
 
 
-def test_hermes_bridge_serializes_concurrent_submits_per_session(monkeypatch):
-    """Two concurrent stream_prompt calls with the same session_key must run
-    sequentially, not pile up on llama-server slots. Two calls with DIFFERENT
-    session_keys are allowed to overlap (different phones don't block each
-    other)."""
+def _run_with_one_loop(coro_factory):
+    """Tests that exercise the bridge run several coroutines on the SAME
+    event loop so the background sweeper task doesn't get orphaned across
+    loop swaps (which would surface as "Task was destroyed but it is
+    pending" warnings). Caller passes a *factory* — a 0-arg callable that
+    returns a coroutine — because coroutines themselves can't be re-awaited.
+    """
+    import asyncio as _asyncio
+    import hermes_bridge
+    loop = _asyncio.new_event_loop()
+    try:
+        result = loop.run_until_complete(coro_factory())
+        loop.run_until_complete(hermes_bridge.shutdown_pool())
+        return result
+    finally:
+        loop.close()
+
+
+def test_hermes_bridge_pool_serializes_same_key_parallels_different_keys(monkeypatch):
+    """Connection-pool contract:
+
+      * Two concurrent stream_prompt calls with the same session_key must run
+        sequentially (the per-connection lock pins the WS to one prompt at a
+        time — Hermes can't multiplex two prompt.submit on one session).
+      * Two calls with DIFFERENT session_keys are NOT blocked by each other;
+        they get separate pooled connections and run in parallel.
+
+    Stubs the WS + recv layer so we don't need a real Hermes. The pool's
+    behaviour is what's under test.
+    """
     import asyncio as _asyncio
     import hermes_bridge
 
-    hermes_bridge._SUBMIT_LOCKS.clear()
+    # Clear any pool state from prior tests. Synchronous reset since we
+    # haven't started a sweeper yet on this loop.
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._SWEEPER_TASK = None
 
     enter_log: list[str] = []
     exit_log: list[str] = []
+    create_counts: dict[str, int] = {}
 
-    # Stub out the upstream so we don't need a real Hermes — the lock is what
-    # we're exercising. We patch the inner pieces stream_prompt calls.
-    async def fake_connect_ws(_session):
-        class FakeWS:
-            async def send_str(self, _): pass
-            async def __aenter__(self): return self
-            async def __aexit__(self, *a): pass
-        return FakeWS()
+    class FakeWS:
+        closed = False
+        async def send_str(self, _): pass
+        async def close(self): self.closed = True
 
-    async def fake_create(_ws, *, timeout=30):
-        return "sid-fake"
+    class FakeHTTP:
+        async def close(self): pass
 
-    monkeypatch.setattr("hermes_bridge._connect_ws", fake_connect_ws)
-    monkeypatch.setattr("hermes_bridge._create_session_on_ws", fake_create)
+    async def fake_open(session_key):
+        create_counts[session_key] = create_counts.get(session_key, 0) + 1
+        conn = hermes_bridge._HermesConnection(
+            http_session=FakeHTTP(),
+            ws=FakeWS(),
+            session_id=f"sid-{session_key}",
+        )
+        return conn
+
+    monkeypatch.setattr("hermes_bridge._open_connection", fake_open)
 
     async def fake_recv(_ws, _timeout):
-        # Sleep so the test observes ordering, then return a message.complete.
+        # Small delay so the test observes ordering, then deliver a
+        # message.complete that ends the stream.
         await _asyncio.sleep(0.1)
         return {
             "method": "event",
             "params": {
                 "type": "message.complete",
-                "session_id": "sid-fake",
+                "session_id": None,  # bridge accepts either matching or null
                 "payload": {"text": "done", "status": "ok"},
             },
         }
@@ -348,29 +382,139 @@ def test_hermes_bridge_serializes_concurrent_submits_per_session(monkeypatch):
         exit_log.append(tag)
 
     async def main():
-        # Two concurrent same-key callers — must serialize.
+        # Same-key serialization + pool reuse.
         await _asyncio.gather(drive("k1", "A"), drive("k1", "B"))
-        return list(enter_log), list(exit_log)
+        same_enter = list(enter_log)
+        same_exit = list(exit_log)
+        same_creates = dict(create_counts)
 
-    enter, exit_ = _asyncio.new_event_loop().run_until_complete(main())
-    # Both got past their initial enter print before any awaited stream
-    # work — that part isn't blocked. The interesting assertion is that
-    # B's exit fires AFTER A's exit (B waited for the lock).
-    assert enter == ["A", "B"]
-    assert exit_ == ["A", "B"], f"expected serialized exits A then B, got {exit_}"
+        # Reset for the different-key pass; keep same loop alive.
+        enter_log.clear()
+        exit_log.clear()
+        create_counts.clear()
+        await hermes_bridge.shutdown_pool()
+        hermes_bridge._CONNECTION_POOL.clear()
+        hermes_bridge._SWEEPER_TASK = None
 
-    # Now confirm different keys are NOT blocked by each other: kick off two
-    # with different keys; both finish near-simultaneously.
-    enter_log.clear()
-    exit_log.clear()
-    hermes_bridge._SUBMIT_LOCKS.clear()
-
-    async def main2():
         await _asyncio.gather(drive("phoneA", "A"), drive("phoneB", "B"))
+        diff_exit = set(exit_log)
+        diff_creates = dict(create_counts)
+        return same_enter, same_exit, same_creates, diff_exit, diff_creates
 
-    _asyncio.new_event_loop().run_until_complete(main2())
-    # Both complete; the order can be either A→B or B→A but both must finish.
-    assert set(exit_log) == {"A", "B"}
+    same_enter, same_exit, same_creates, diff_exit, diff_creates = _run_with_one_loop(main)
+    assert same_enter == ["A", "B"]
+    assert same_exit == ["A", "B"], f"same-key prompts must serialize, got {same_exit}"
+    assert same_creates["k1"] == 1, f"expected pool reuse for k1, got {same_creates['k1']} creates"
+    assert diff_exit == {"A", "B"}
+    assert diff_creates == {"phoneA": 1, "phoneB": 1}
+
+
+def test_hermes_bridge_pool_evicts_and_recreates_on_dead_ws(monkeypatch):
+    """If the cached WS has closed (e.g. Hermes container restarted between
+    messages), the pool must evict it and open a fresh connection on the
+    next ``stream_prompt`` call rather than silently failing forever."""
+    import asyncio as _asyncio
+    import hermes_bridge
+
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._SWEEPER_TASK = None
+
+    class FakeWS:
+        def __init__(self): self.closed = False
+        async def send_str(self, _): pass
+        async def close(self): self.closed = True
+
+    class FakeHTTP:
+        async def close(self): pass
+
+    create_count = 0
+
+    async def fake_open(session_key):
+        nonlocal create_count
+        create_count += 1
+        return hermes_bridge._HermesConnection(
+            http_session=FakeHTTP(),
+            ws=FakeWS(),
+            session_id=f"sid-{create_count}",
+        )
+
+    monkeypatch.setattr("hermes_bridge._open_connection", fake_open)
+
+    async def fake_recv(_ws, _timeout):
+        return {"method": "event", "params": {"type": "message.complete", "payload": {"text": "ok"}}}
+    monkeypatch.setattr("hermes_bridge._recv_json", fake_recv)
+
+    async def main():
+        # First call creates connection #1.
+        async for ev in hermes_bridge.stream_prompt("p1", "hi"):
+            if ev["type"] == "complete":
+                break
+        cached = hermes_bridge._CONNECTION_POOL["p1"]
+
+        # Simulate Hermes restart: mark the WS as closed.
+        cached.ws.closed = True
+
+        # Next call must NOT reuse the dead connection; must open a fresh one.
+        async for ev in hermes_bridge.stream_prompt("p1", "hi again"):
+            if ev["type"] == "complete":
+                break
+
+        return create_count, hermes_bridge._CONNECTION_POOL["p1"].session_id
+
+    creates, sid = _run_with_one_loop(main)
+    assert creates == 2, f"expected 2 connection opens (initial + after dead WS), got {creates}"
+    assert sid == "sid-2", f"pool should hold the new connection, has {sid}"
+
+
+def test_hermes_bridge_pool_sweeper_evicts_idle_connections(monkeypatch):
+    """Connections idle longer than _IDLE_EXPIRY_SECONDS must be closed
+    by the background sweeper so a fleet of one-time visitors doesn't
+    pin Hermes resources forever."""
+    import asyncio as _asyncio
+    import hermes_bridge
+
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._SWEEPER_TASK = None
+
+    # Tight timings so the test is fast.
+    monkeypatch.setattr("hermes_bridge._IDLE_EXPIRY_SECONDS", 0.05)
+    monkeypatch.setattr("hermes_bridge._IDLE_SWEEP_INTERVAL", 0.02)
+
+    closed_calls: list[str] = []
+
+    class FakeWS:
+        def __init__(self): self.closed = False
+        async def close(self): self.closed = True
+
+    class FakeHTTP:
+        async def close(self): pass
+
+    async def fake_open(session_key):
+        ws = FakeWS()
+        conn = hermes_bridge._HermesConnection(http_session=FakeHTTP(), ws=ws, session_id="sid")
+        original_close = conn.aclose
+        async def _tracked_close():
+            closed_calls.append(session_key)
+            await original_close()
+        conn.aclose = _tracked_close
+        return conn
+
+    monkeypatch.setattr("hermes_bridge._open_connection", fake_open)
+
+    async def main():
+        # Plant a connection manually (skip stream_prompt, simpler).
+        conn = await hermes_bridge._get_connection("idle-key")
+        assert "idle-key" in hermes_bridge._CONNECTION_POOL
+        # Backdate last_used so it's clearly past expiry.
+        conn.last_used -= 100
+        hermes_bridge._ensure_sweeper_running()
+        # Wait long enough for the sweep loop to fire at least once.
+        await _asyncio.sleep(0.15)
+        return "idle-key" in hermes_bridge._CONNECTION_POOL, list(closed_calls)
+
+    still_in_pool, closed = _run_with_one_loop(main)
+    assert not still_in_pool, "sweeper should have evicted the idle connection"
+    assert "idle-key" in closed, f"sweeper should have called aclose(), got {closed}"
 
 
 def test_talk_message_stream_sets_unbuffered_headers(talk_client, monkeypatch):

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -409,6 +409,67 @@ def test_hermes_bridge_pool_serializes_same_key_parallels_different_keys(monkeyp
     assert diff_creates == {"phoneA": 1, "phoneB": 1}
 
 
+def test_hermes_bridge_transparent_retry_on_send_reset(monkeypatch):
+    """Most insidious dead-WS pattern: ``ws.closed`` reports False, but the
+    next ``send_str`` raises ClientConnectionResetError because the upstream
+    Hermes closed the socket between checks (e.g. a Hermes restart that
+    raced with the freshness check). The bridge must catch that, evict, and
+    transparently retry once on a fresh connection — the user shouldn't see
+    "load failed" just because Hermes restarted in the background."""
+    import asyncio as _asyncio
+    import aiohttp
+    import hermes_bridge
+
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._SWEEPER_TASK = None
+
+    class DeadOnSendWS:
+        closed = False
+        async def send_str(self, _):
+            raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+        async def close(self):
+            self.closed = True
+
+    class LiveWS:
+        closed = False
+        async def send_str(self, _): pass
+        async def close(self): self.closed = True
+
+    class FakeHTTP:
+        async def close(self): pass
+
+    open_calls = 0
+
+    async def fake_open(session_key):
+        nonlocal open_calls
+        open_calls += 1
+        # First connection has a WS that fails on send; second is healthy.
+        ws = DeadOnSendWS() if open_calls == 1 else LiveWS()
+        return hermes_bridge._HermesConnection(
+            http_session=FakeHTTP(), ws=ws, session_id=f"sid-{open_calls}",
+        )
+
+    monkeypatch.setattr("hermes_bridge._open_connection", fake_open)
+
+    async def fake_recv(_ws, _timeout):
+        return {"method": "event", "params": {"type": "message.complete", "payload": {"text": "ok"}}}
+    monkeypatch.setattr("hermes_bridge._recv_json", fake_recv)
+
+    async def main():
+        events = []
+        async for ev in hermes_bridge.stream_prompt("retry-key", "hi"):
+            events.append(ev["type"])
+            if ev["type"] == "complete":
+                break
+        return events, open_calls
+
+    events, opens = _run_with_one_loop(main)
+    # User got a clean stream: session frame + complete frame, no error.
+    assert "complete" in events, f"expected transparent retry to deliver complete, got {events}"
+    # Two connection opens: the dead one + the retry's fresh one.
+    assert opens == 2, f"expected 1 retry (opens == 2), got {opens}"
+
+
 def test_hermes_bridge_pool_evicts_and_recreates_on_dead_ws(monkeypatch):
     """If the cached WS has closed (e.g. Hermes container restarted between
     messages), the pool must evict it and open a fresh connection on the

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -64,7 +64,7 @@ When recalling facts, trust web search for current events; the local model isn't
 
 The user is on a phone and won't wait minutes for the wrong tool to time out.
 
-- **Current weather, news, sports scores, stock prices, "what's happening today / right now"** → `web_search`. It wraps SearXHNG and returns in 1–2 seconds.
+- **Current weather, news, sports scores, stock prices, "what's happening today / right now"** → `web_search`. It wraps SearXNG and returns in 1–2 seconds.
 - **Reading a specific URL the user gave you** → `web_extract`. Go straight to it; do not try to fetch URLs by other means.
 - **Running a quick calculation or short code snippet the user asked about** → `execute_code` (sandboxed Python).
 - **Filesystem on this machine** → `read_file` / `write_file` / `search_files`.

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -60,6 +60,18 @@ You're the resident agent on a **Dream Server** install — a fully-local AI sta
 
 When recalling facts, trust web search for current events; the local model isn't always up to date. When the user tells you something durable about themselves, save it to memory.
 
+## Tool selection — pick the right one the first time
+
+The user is on a phone and won't wait 5 minutes for the wrong tool to time out. For each kind of question, the first-choice tool is:
+
+- **Current weather, news, sports scores, stock prices, "what's happening today" anywhere** → `web_search`. Never try `terminal` or `browser_*` for these; web_search wraps SearXNG which is already configured. If `web_search` returns nothing usable, *then* you can try `web_extract` on a specific URL the user provided.
+- **Reading a specific URL the user gave you** → `web_extract` or `browser_navigate`. Don't use `terminal` to `curl` URLs — that goes through a slower path and times out aggressively.
+- **Running a quick calculation or executing code the user asked about** → `execute_code` (sandboxed Python). Don't use `terminal` to run python; `execute_code` is faster and safer.
+- **Filesystem on this machine** → `read_file` / `write_file` / `search_files`. Only use `terminal` for shell-specific things the dedicated tools don't cover (e.g. checking a service status with `systemctl`, running a `git` command).
+- **Remembering something about the user across sessions** → `memory`. Save names, preferences, recurring tasks, allergies, etc. Don't save trivia.
+
+If a tool call fails or returns no result, say so briefly and offer the user a different angle — don't loop on retries silently.
+
 ## Resetting this persona
 
 The user can edit this file at `/opt/data/SOUL.md` inside the Hermes container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply. Deleting the file falls back to upstream's default persona.

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -62,15 +62,22 @@ When recalling facts, trust web search for current events; the local model isn't
 
 ## Tool selection — pick the right one the first time
 
-The user is on a phone and won't wait 5 minutes for the wrong tool to time out. For each kind of question, the first-choice tool is:
+The user is on a phone and won't wait minutes for the wrong tool to time out.
 
-- **Current weather, news, sports scores, stock prices, "what's happening today" anywhere** → `web_search`. Never try `terminal` or `browser_*` for these; web_search wraps SearXNG which is already configured. If `web_search` returns nothing usable, *then* you can try `web_extract` on a specific URL the user provided.
-- **Reading a specific URL the user gave you** → `web_extract` or `browser_navigate`. Don't use `terminal` to `curl` URLs — that goes through a slower path and times out aggressively.
-- **Running a quick calculation or executing code the user asked about** → `execute_code` (sandboxed Python). Don't use `terminal` to run python; `execute_code` is faster and safer.
-- **Filesystem on this machine** → `read_file` / `write_file` / `search_files`. Only use `terminal` for shell-specific things the dedicated tools don't cover (e.g. checking a service status with `systemctl`, running a `git` command).
-- **Remembering something about the user across sessions** → `memory`. Save names, preferences, recurring tasks, allergies, etc. Don't save trivia.
+- **Current weather, news, sports scores, stock prices, "what's happening today / right now"** → `web_search`. It wraps SearXHNG and returns in 1–2 seconds.
+- **Reading a specific URL the user gave you** → `web_extract`. Go straight to it; do not try to fetch URLs by other means.
+- **Running a quick calculation or short code snippet the user asked about** → `execute_code` (sandboxed Python).
+- **Filesystem on this machine** → `read_file` / `write_file` / `search_files`.
+- **Remembering something about the user across sessions** → `memory`. Save names, preferences, recurring tasks, allergies. Don't save trivia.
 
-If a tool call fails or returns no result, say so briefly and offer the user a different angle — don't loop on retries silently.
+### Hard rules (these override anything else)
+
+1. **For ANY question about external information** (weather, news, current events, prices, schedules, scores, "what time does X open"), your first action is `web_search`. No exceptions.
+2. **Do not attempt to `curl`, `wget`, or fetch URLs by hand from a shell.** That is not the supported path on this surface — `web_search` is.
+3. **If a tool returns nothing useful, say so in one sentence and offer the user a different angle.** Do not silently retry the same tool with a slightly different query. Do not chain into a different tool to do the same job. Tell the user what happened and ask what they want to try next.
+4. **If you find yourself thinking "the network isn't working" or "tools are blocked," stop and call `web_search` once with a clean simple query.** That is the canonical way to reach the internet here. Memory of past failures from earlier in this conversation does not carry over to a fresh tool call — try once before giving up.
+
+These rules exist because operators have repeatedly observed models stalling chat for several minutes by reaching for shell-based network access on weather/news questions. `web_search` is the supported path and it works.
 
 ## Resetting this persona
 

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -92,8 +92,7 @@ agent:
 # `timeout` caps per-command duration (default upstream: 180s). We set 30s
 # so even if `terminal` gets re-enabled via env override or a future toolset
 # change, a wedged command can't hang the chat for 5 minutes. Pair with the
-# env var TERMINAL_MAX_FOREGROUND_TIMEOUT=30 in compose.yaml as a hard
-# ceiling the model can't override with a per-call timeout arg.
+# env var TERMINAL_TIMEOUT=30 in compose.yaml as the same fallback default.
 terminal:
   backend: "local"
   timeout: 30

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -63,13 +63,40 @@ auxiliary:
     context_length: 131072
 
 # =============================================================================
-# Terminal backend — where tool calls execute
+# Agent — tool scoping for the consumer-facing Dream Talk surface
+# =============================================================================
+# Upstream PR #18197 (merged) added `agent.disabled_toolsets` as a strict
+# subtraction applied after every other toolset-resolution path. Removing a
+# toolset here removes its tools from the schema the model sees — which is
+# the only reliable fix for wrong-tool selection (upstream RFC #26524 reports
+# Qwen variants jumping 20%->100% reliability when offending tools are
+# removed from the schema, vs ignored prompt-only "use X never Y" guidance).
+#
+# We disable:
+#   * terminal — the model kept reaching for it on weather/news queries and
+#     hanging for 5 min on dead curl commands instead of using web_search.
+#   * browser  — full headless-browser toolset; Dream Talk is mobile chat,
+#     not interactive browsing, so we never want browser_console / navigate.
+agent:
+  disabled_toolsets:
+    - terminal
+    - browser
+
+# =============================================================================
+# Terminal backend — where tool calls execute (when terminal is enabled)
 # =============================================================================
 # Hermes can run tools in a few different sandboxes. For Dream Server we keep
 # it local-to-the-container: no SSH out, no Modal/Daytona, no Docker-in-Docker.
 # The container IS the sandbox.
+#
+# `timeout` caps per-command duration (default upstream: 180s). We set 30s
+# so even if `terminal` gets re-enabled via env override or a future toolset
+# change, a wedged command can't hang the chat for 5 minutes. Pair with the
+# env var TERMINAL_MAX_FOREGROUND_TIMEOUT=30 in compose.yaml as a hard
+# ceiling the model can't override with a per-call timeout arg.
 terminal:
   backend: "local"
+  timeout: 30
 
 # =============================================================================
 # Messaging gateways — none enabled by default in Dream Server

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -25,14 +25,10 @@ services:
       # >60s to load a model under heavy use.
       - HERMES_API_TIMEOUT=1800
       - HERMES_API_CALL_STALE_TIMEOUT=900
-      # Hard ceiling on terminal-tool foreground commands. Hermes upstream
-      # default is 600s, which on the Dream Talk consumer surface means a
-      # single wedged curl can hang the chat for ten minutes. We disable the
-      # `terminal` toolset entirely via cli-config.yaml's
-      # `agent.disabled_toolsets`, but this env var is belt-and-suspenders:
-      # if a future config refactor re-enables terminal, no single command
-      # can stall the model for more than 30s.
-      - TERMINAL_MAX_FOREGROUND_TIMEOUT=30
+      # Default terminal-tool timeout. We disable the `terminal` toolset
+      # entirely via cli-config.yaml's `agent.disabled_toolsets`, but this is
+      # belt-and-suspenders if a future config refactor re-enables it.
+      - TERMINAL_TIMEOUT=30
       # Locale + timezone match the rest of the stack.
       - TZ=${TIMEZONE:-UTC}
       - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -25,6 +25,14 @@ services:
       # >60s to load a model under heavy use.
       - HERMES_API_TIMEOUT=1800
       - HERMES_API_CALL_STALE_TIMEOUT=900
+      # Hard ceiling on terminal-tool foreground commands. Hermes upstream
+      # default is 600s, which on the Dream Talk consumer surface means a
+      # single wedged curl can hang the chat for ten minutes. We disable the
+      # `terminal` toolset entirely via cli-config.yaml's
+      # `agent.disabled_toolsets`, but this env var is belt-and-suspenders:
+      # if a future config refactor re-enables terminal, no single command
+      # can stall the model for more than 30s.
+      - TERMINAL_MAX_FOREGROUND_TIMEOUT=30
       # Locale + timezone match the rest of the stack.
       - TZ=${TIMEZONE:-UTC}
       - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}


### PR DESCRIPTION
Closes #1322.

## Summary

Keeps one Hermes WebSocket + Hermes session per `dream-session` cookie so Dream Talk can reuse the same agent session across messages. That keeps llama-server / Lemonade prompt cache warm after the first owner-card message instead of paying the 16k-token system-prompt prefill on every turn.

Also tightens the Dream Talk Hermes tool surface so consumer chat prefers the supported web/search path and cannot stall on terminal/browser tool choices.

## What changed

- Adds a pooled `_HermesConnection` in `extensions/services/dashboard-api/hermes_bridge.py`, keyed by the hashed `dream-session` cookie.
- Serializes same-cookie prompts with a per-connection lock while allowing different cookies to use independent pooled connections.
- Adds idle sweeping with `DREAM_TALK_IDLE_EXPIRY` (default 300s) plus FastAPI lifespan shutdown cleanup.
- Retries only the safe stale-socket case where `send_str()` fails before `prompt.submit` is accepted; receive-side drops after submit now surface as errors instead of duplicating prompts/tool calls.
- Prevents the idle sweeper from closing an actively locked connection during a long first turn.
- Configures Hermes with `agent.disabled_toolsets: [terminal, browser]` for Dream Talk and sets the fallback terminal timeout to 30s via `terminal.timeout` + `TERMINAL_TIMEOUT=30`.
- Updates the Dream persona/tool guidance so weather/news/current-info requests go to `web_search` first.

## Verification

Local:
- `python -m pytest extensions/services/dashboard-api/tests/test_talk.py extensions/services/dashboard-api/tests/test_magic_link.py` -> 66 passed
- `python -m ruff check extensions/services/dashboard-api/hermes_bridge.py extensions/services/dashboard-api/tests/test_talk.py extensions/services/dashboard-api/main.py` -> passed
- `tests/test-installer-context-parity.sh` via Git Bash -> 29 passed
- `tests/test-litellm-amd-auth-enforced.sh` via Git Bash -> 4 passed
- Confirmed pinned Hermes source supports `agent.disabled_toolsets` and consumes `TERMINAL_TIMEOUT`.

GitHub Actions on the rebased `main` target are green across frontend, api, Python lint/type, shell lint, compose validation, integration smoke, env validation, macOS/Linux smoke, and the distro matrix.

## Risk

The Dream Talk streaming wire format is unchanged. The main behavioral risk is session lifetime/resource management in the new pool, covered by tests for same-key serialization, different-key parallelism, dead-WS recreation, pre-submit retry, no post-submit retry, active prompt sweeper protection, idle eviction, and shutdown cleanup.
