### PR TITLE
fix(dashboard): show Usage in sidebar

### DIFF
--- a/dream-server/extensions/services/dashboard/src/plugins/core.js
+++ b/dream-server/extensions/services/dashboard/src/plugins/core.js
@@ -71,9 +71,9 @@ export const coreRoutes = [
     sidebar: true,
     order: 3,
   },
-  // Usage + Setup / Owner are reachable from Settings rather than the top-level
-  // sidebar. Setup / Owner is a factory/distributor/service-provider flow, not
-  // a day-to-day dashboard surface. Direct URLs still work for bookmarks and
+  // Setup / Owner is reachable from Settings rather than the top-level
+  // sidebar. It is a factory/distributor/service-provider flow, not a
+  // day-to-day dashboard surface. Direct URLs still work for bookmarks and
   // for the magic-link redemption page which renders inside this dashboard.
   {
     id: 'usage',
@@ -82,7 +82,7 @@ export const coreRoutes = [
     icon: CreditCard,
     component: Usage,
     getProps: ({ status }) => ({ status }),
-    sidebar: false,
+    sidebar: true,
     order: 3.5,
   },
   {


### PR DESCRIPTION
## Summary
Expose the existing Usage route in the main dashboard sidebar.

The Usage page already exists at `/usage`, but it was registered with `sidebar: false`, which makes the feature look missing after install unless the user knows the direct URL. This keeps `Setup / Owner` hidden as intended, while making Usage visible as a normal day-to-day dashboard surface between Models and Settings.

## What changed
- Sets the `usage` route sidebar flag to `true`.
- Updates the nearby comment so it only describes the hidden Setup / Owner flow.
- Leaves the Usage page, backend, Token Spy integration, and routing behavior unchanged.

## Why this matters
Users expect usage/cost tracking to be discoverable from the dashboard navigation. The route was working, but hidden, so a full install could appear to be missing the merged Usage dashboard.

## Validation
- Rebuilt the dashboard image locally with Docker Compose.
- Recreated only the `dream-dashboard` container.
- Verified `/usage` loads.
- Verified the sidebar now lists `Usage` between `Models` and `Settings`.

## Follow-up issues observed while validating
These are not included in this PR to keep the diff focused:

- Full-stack NVIDIA install can fail on Docker Desktop when ComfyUI requests `cpus: 16.0` on hosts exposing fewer CPUs.
- The ComfyUI NVIDIA memory limit is currently high for some Docker Desktop defaults and may need host-aware capping.
- `/api/status` can report deployed services as `degraded` even while Docker health is `healthy` and direct in-container health probes return HTTP 200.
- Usage local llama.cpp counters are detected, but not merged into date-bounded totals because Prometheus counters are cumulative and lack request timestamps.
- Scripted Windows install selection via piped input does not reliably drive the interactive `Read-Host` profile prompt; an explicit non-interactive profile flag would be safer.