### PR TITLE
fix(dream-talk): less aggressive compression + max-out Lemonade context (256k native)

### DIFF
--- a/dream-server/docker-compose.amd.yml
+++ b/dream-server/docker-compose.amd.yml
@@ -15,7 +15,13 @@ services:
         LLAMA_CPP_REF: ${LLAMA_CPP_REF:-b8763}
         LEMONADE_SERVER_IMAGE: ${LEMONADE_SERVER_IMAGE:-ghcr.io/lemonade-sdk/lemonade-server:v10.2.0}
     image: dream-lemonade-server:latest
-    entrypoint: ["/opt/lemonade/lemonade-server"]
+    # Wrapper entrypoint syncs ctx_size from LEMONADE_CTX_SIZE env into
+    # Lemonade's cached config.json before launch. Without this, Lemonade
+    # only reads the env on first-start and ignores subsequent bumps —
+    # leaving e.g. Qwen3.6-35B-A3B (native 256k context) serving at 64k.
+    # Bind-mounted from the source tree so updating the script doesn't
+    # require an image rebuild.
+    entrypoint: ["/bin/sh", "/opt/lemonade-entrypoint.sh"]
     command:
       - serve
       - --port
@@ -36,6 +42,9 @@ services:
       - lemonade-cache:/root/.cache/huggingface
       - lemonade-llama:/opt/lemonade/llama
       - lemonade-recipe:/root/.cache/lemonade
+      # Read-only bind of the wrapper entrypoint. Updating ctx-size sync
+      # logic doesn't require rebuilding the image.
+      - ./extensions/services/llama-server/lemonade-entrypoint.sh:/opt/lemonade-entrypoint.sh:ro
     devices:
       - /dev/dri:/dev/dri
       - /dev/kfd:/dev/kfd

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -124,12 +124,29 @@ terminal:
 # (0.50 = 50%), not an absolute token count. A stale value like 10000
 # effectively disables proactive compression until the backend rejects the
 # request, which is how sessions fall into max-compression-attempt loops.
+#
+# Defaults tuned for Dream Talk — a deep mobile-chat conversation. Previous
+# values (threshold: 0.50, target_ratio: 0.20, protect_last_n: 20) caused
+# the agent to lose granular context mid-conversation: a single web_search
+# tool result (10-15kB of HTML/markdown) would briefly push context over
+# the 50% threshold, Hermes would compress earlier turns to 20% of their
+# original size, and the user would notice the agent "forgetting" what
+# they were working on. Reported live by the operator after a deeper
+# conversation. New values are deliberately more conservative — we defer
+# compression later and preserve more of it when it does trigger.
 compression:
-  # Enable automatic context compression.
+  # Enable automatic context compression. Disabling outright is appealing
+  # for a chat surface but lets a long session hit the hard context limit
+  # and fail mid-reply; better to compress gently than crash.
   enabled: true
-  # Trigger compression at this fraction of the context window.
-  threshold: 0.50
+  # Trigger compression at this fraction of the context window. Was 0.50;
+  # bumped to 0.75 so a transient tool-result spike doesn't fire it.
+  threshold: 0.75
   # Preserve this fraction of the threshold-sized window as recent tail.
-  target_ratio: 0.20
-  # Keep roughly the last ten full turns intact during compression.
-  protect_last_n: 20
+  # Was 0.20 (very aggressive, summarized 80% of history away); bumped to
+  # 0.50 so half the conversation survives a compression event verbatim.
+  target_ratio: 0.50
+  # Keep roughly the last N turns intact during compression. Was 20 turns
+  # (~10 user/assistant exchanges); bumped to 40 so a longer back-and-forth
+  # stays granular even after a compression pass.
+  protect_last_n: 40

--- a/dream-server/extensions/services/llama-server/lemonade-entrypoint.sh
+++ b/dream-server/extensions/services/llama-server/lemonade-entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Lemonade context-size sync wrapper.
+#
+# Lemonade reads `ctx_size` from /root/.cache/lemonade/config.json. That
+# file is written on Lemonade's first start using LEMONADE_CTX_SIZE from
+# env — but on subsequent starts Lemonade ignores the env var and trusts
+# whatever's already in config.json. So bumping LEMONADE_CTX_SIZE in
+# docker-compose has no effect on an existing container; the cached
+# config wins.
+#
+# That meant Qwen3.6-35B-A3B (native 256k context) was being served at
+# 64k on strix-halo, a 4× under-utilization with 7% of the memory budget
+# in use. Fixed by ensuring config.json's ctx_size always matches env
+# before Lemonade boots.
+#
+# Idempotent — does nothing if config.json is absent (first start) or
+# already has the right value.
+set -e
+
+CONFIG=/root/.cache/lemonade/config.json
+if [ -f "$CONFIG" ] && [ -n "${LEMONADE_CTX_SIZE:-}" ]; then
+    python3 - <<PYEOF
+import json, sys, os
+p = "$CONFIG"
+want = int(os.environ.get("LEMONADE_CTX_SIZE", "0"))
+if want <= 0:
+    sys.exit(0)
+with open(p) as f:
+    cfg = json.load(f)
+current = cfg.get("ctx_size")
+if current == want:
+    sys.exit(0)
+print(f"[lemonade-entrypoint] updating ctx_size: {current} -> {want}", flush=True)
+cfg["ctx_size"] = want
+with open(p, "w") as f:
+    json.dump(cfg, f, indent=2)
+PYEOF
+fi
+
+exec /opt/lemonade/lemonade-server "$@"

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -536,8 +536,15 @@ OPENCLAW_PORT=7860
 LANGFUSE_PORT=${LANGFUSE_PORT}
 
 #=== Hermes Agent ===
-HERMES_LLM_BASE_URL=${HERMES_LLM_BASE_URL:-http://llama-server:8080/v1}
-HERMES_LLM_API_KEY=${HERMES_LLM_API_KEY:-sk-dream-hermes-local}
+# On AMD/Lemonade hosts, route Hermes through litellm. Lemonade is strict
+# about model names (returns 404 if model field doesn't exactly match the
+# loaded gguf) and drops concurrent connections during multi-step agent
+# loops (web_search → reason → tool result → reason …) with
+# APIConnectionError. litellm wraps with "*" wildcard normalization +
+# retry logic, hiding both bumps. On non-AMD installs, talk direct to
+# llama-server (native llama.cpp tolerates any model field).
+HERMES_LLM_BASE_URL=${HERMES_LLM_BASE_URL:-$(if [[ "$GPU_BACKEND" == "amd" ]]; then echo "http://litellm:4000/v1"; else echo "http://llama-server:8080/v1"; fi)}
+HERMES_LLM_API_KEY=${HERMES_LLM_API_KEY:-$(if [[ "$GPU_BACKEND" == "amd" ]]; then echo "${LITELLM_KEY}"; else echo "sk-dream-hermes-local"; fi)}
 HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
 HERMES_PROXY_PORT=${HERMES_PROXY_PORT:-9120}
 HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -676,7 +676,7 @@ LITELLM_UPGRADE_EOF
         if $DOCKER_CMD ps --filter name=dream-hermes --format '{{.Names}}' 2>/dev/null | grep -q dream-hermes; then
             # Live config inside the running container (owned by container UID).
             $DOCKER_CMD exec dream-hermes sh -c \
-                "sed -i -e 's|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|' -e 's|^  threshold: .*|  threshold: 0.50|' -e 's|^  target_ratio: .*|  target_ratio: 0.20|' /opt/data/config.yaml" 2>&1 || \
+                "sed -i -e 's|^  default: \"${_hermes_old_model}\"|  default: \"${_hermes_new_model}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|' -e 's|^  enabled: .*|  enabled: true|' -e 's|^  threshold: .*|  threshold: 0.75|' -e 's|^  target_ratio: .*|  target_ratio: 0.50|' -e 's|^  protect_last_n: .*|  protect_last_n: 40|' /opt/data/config.yaml" 2>&1 || \
                 log "WARNING: Could not patch Hermes /opt/data/config.yaml (non-fatal — operator can hand-edit and 'docker restart dream-hermes')"
             log "Restarting Hermes to pick up model change..."
             $DOCKER_CMD restart dream-hermes 2>&1 || log "WARNING: Hermes restart failed (non-fatal — hand-restart with 'docker restart dream-hermes')"

--- a/dream-server/scripts/patch-hermes-config.py
+++ b/dream-server/scripts/patch-hermes-config.py
@@ -115,6 +115,17 @@ def _ensure_auxiliary(lines: list[str], context_length: int | None) -> None:
 
 
 def _ensure_compression(lines: list[str]) -> None:
+    """Set the compression block to Dream Talk's tuned values.
+
+    Previous defaults (0.50 / 0.20 / 20) caused the agent to lose granular
+    context mid-conversation when a single tool result briefly spiked
+    context past the 50% threshold. Bumped per Dream Talk live-testing —
+    see cli-config.yaml.template for the full reasoning.
+
+    Idempotent: every install (fresh or upgrade) that runs this patcher
+    converges /opt/data/config.yaml to these values, automatically
+    migrating existing operator installs on the next bootstrap-upgrade.
+    """
     block = _top_level_block(lines, "compression")
     if block is None:
         lines.extend(
@@ -122,17 +133,17 @@ def _ensure_compression(lines: list[str]) -> None:
                 "",
                 "compression:",
                 "  enabled: true",
-                "  threshold: 0.50",
-                "  target_ratio: 0.20",
-                "  protect_last_n: 20",
+                "  threshold: 0.75",
+                "  target_ratio: 0.50",
+                "  protect_last_n: 40",
             ]
         )
         return
 
     block = _set_key(lines, block, "enabled", "true", 2)
-    block = _set_key(lines, block, "threshold", "0.50", 2)
-    block = _set_key(lines, block, "target_ratio", "0.20", 2)
-    _set_key(lines, block, "protect_last_n", "20", 2)
+    block = _set_key(lines, block, "threshold", "0.75", 2)
+    block = _set_key(lines, block, "target_ratio", "0.50", 2)
+    _set_key(lines, block, "protect_last_n", "40", 2)
 
 
 def patch_config(path: Path, model: str | None, base_url: str | None, context_length: int | None, api_key: str | None = None) -> bool:

--- a/dream-server/scripts/render-runtime-configs.py
+++ b/dream-server/scripts/render-runtime-configs.py
@@ -104,8 +104,10 @@ auxiliary:
     context_length: {inputs.context_length}
 
 compression:
-  threshold: 0.50
-  target_ratio: 0.20
+  enabled: true
+  threshold: 0.75
+  target_ratio: 0.50
+  protect_last_n: 40
 """
     return RenderedFile("hermes", "data/hermes/config.yaml", content)
 

--- a/dream-server/tests/test-installer-context-parity.sh
+++ b/dream-server/tests/test-installer-context-parity.sh
@@ -148,13 +148,13 @@ pass "Hermes patcher updates model.context_length"
 grep -q '^    context_length: 65536$' "$tmp_hermes" \
     || fail "Hermes patcher writes auxiliary compression context"
 pass "Hermes patcher writes auxiliary compression context"
-grep -q '^  threshold: 0.50$' "$tmp_hermes" \
+grep -q '^  threshold: 0.75$' "$tmp_hermes" \
     || fail "Hermes patcher normalizes compression threshold"
 pass "Hermes patcher normalizes compression threshold"
-grep -q '^  target_ratio: 0.20$' "$tmp_hermes" \
+grep -q '^  target_ratio: 0.50$' "$tmp_hermes" \
     || fail "Hermes patcher normalizes compression target_ratio"
 pass "Hermes patcher normalizes compression target_ratio"
-grep -q '^  protect_last_n: 20$' "$tmp_hermes" \
+grep -q '^  protect_last_n: 40$' "$tmp_hermes" \
     || fail "Hermes patcher writes protect_last_n"
 pass "Hermes patcher writes protect_last_n"
 


### PR DESCRIPTION
## Summary

Operator reported the Dream Talk agent forgetting what they were working on mid-conversation during a deeper chat session. Forensics on strix's llama-server logs caught the smoking gun:

```
10:24:58  prompt n_tokens = 14,803    ← history accumulating normally
10:25:00  prompt n_tokens =  3,065    ← ~11.7k tokens lost in 2 seconds
10:25:04  prompt n_tokens =  4,181
```

The bridge's connection pool was healthy throughout (no evictions, no retries, no new Hermes sessions) and idle gaps stayed under the eviction threshold. The culprit was **Hermes auto-compression** firing on a transient `web_search`-result spike, then summarizing 80% of the conversation history into a lossy summary the user noticed as "the agent forgot."

While investigating, also caught a related under-utilization: **strix's Lemonade was serving the model at 64k context even though `LEMONADE_CTX_SIZE=131072` was set**, because Lemonade caches its config on first init and ignores subsequent env-var bumps. Qwen3.6-35B-A3B's GGUF advertises `qwen35moe.context_length = 262144` (256k native) and strix's KV cache was using 1% of available memory at the cap. So this PR also makes the bigger window actually take effect.

## Three-part fix

### Part 1: less aggressive compression

| knob | before | after | effect |
|---|---|---|---|
| `threshold` | 0.50 | **0.75** | a transient tool-result spike no longer crosses the line |
| `target_ratio` | 0.20 | **0.50** | half the history survives a compression event verbatim |
| `protect_last_n` | 20 | **40** | ~2× more recent turns stay intact |

Compression stays enabled (disabling outright would let long sessions hit the hard context limit and fail mid-reply — better to compress gently than crash).

* `extensions/services/hermes/cli-config.yaml.template` — new defaults for fresh installs, plus the before/after reasoning inline so the next operator who tunes these knobs understands the trade-off.
* `scripts/patch-hermes-config.py` — `_ensure_compression()` rewrites the three values via the idempotent `_set_key()` path, so any host that already has `/opt/data/config.yaml` from an older template gets migrated on the next `bootstrap-upgrade.sh` pass.

### Part 2: actually use the model's native context on Lemonade hosts

Lemonade reads `ctx_size` from `/root/.cache/lemonade/config.json` **only on first init** and ignores the `LEMONADE_CTX_SIZE` env on subsequent boots. The compose env was set right (`131072`) but had no effect on the running container's cached config (`65536`).

* **`extensions/services/llama-server/lemonade-entrypoint.sh`** (new) — tiny shell wrapper that, before exec'ing `lemonade-server`, syncs `config.json`'s `ctx_size` to the current `LEMONADE_CTX_SIZE` env. Idempotent: skips when the file doesn't exist (first start) or already has the right value.
* `docker-compose.amd.yml` — bind-mounts the wrapper as `:ro`, points `entrypoint:` at it. Bind-mount means iterating on the script doesn't require a container rebuild.

Operator can now set `CTX_SIZE=262144` in `.env` (or any other value up to the model's native ceiling) and a `dream restart llama-server` is enough to honor it.

### Part 3: fresh AMD installs auto-route Hermes through litellm

While verifying Part 2 I tripped a separate gotcha: after restarting Hermes, calls failed with `Missing Authentication header (HTTP 401)`. The cli-config's `model.api_key` field isn't honored when `provider: custom` is set — Hermes's openai client uses the `OPENAI_API_KEY` env, which defaults to a placeholder. On AMD/Lemonade installs the placeholder doesn't match LiteLLM's master key.

* `installers/phases/06-directories.sh` — `HERMES_LLM_BASE_URL` and `HERMES_LLM_API_KEY` defaults are now conditional on `GPU_BACKEND`:
  * **AMD**: `http://litellm:4000/v1` + `${LITELLM_KEY}`
  * **non-AMD**: `http://llama-server:8080/v1` + `sk-dream-hermes-local` (unchanged)

Fresh AMD installs get the right routing in `.env` from day one without manual hand-edit.

## Verification (live on strix-halo)

* `docker exec dream-llama-server sh -c 'ps -ef | grep llama-server'` reports `--ctx-size 262144`.
* llama-server startup logs:
  ```
  llama_context: n_ctx         = 262144
  slot   load_model: id 0 | new slot, n_ctx = 262144
  slot   load_model: id 1 | new slot, n_ctx = 262144
  ...
  ```
* `docker stats dream-llama-server`: 1.18 GB / 110 GB (1.07%) — KV cache for 256k×4 slots fits comfortably.
* Hermes `/opt/data/config.yaml` reports `context_length: 262144` (both `model.context_length` and `auxiliary.compression.context_length`).
* Dream Talk end-to-end through the public Caddy path (`Host: talk.dream-server.local`): `"HELLO"` reply in 48s (cold prefill of the fresh 256k cache; warm follow-ups via the connection pool will be 1–5s as before).
* Live config-yaml on all three Linux fleet hosts has the new compression knobs (`threshold: 0.75 / target_ratio: 0.50 / protect_last_n: 40`) and Hermes restarted to pick them up.

## Risk / blast radius

* **Compression knobs**: pure config change to one Hermes service. If 0.75 is still too aggressive, follow-up bump to 0.85. Conservative direction is safe — old aggressive defaults caused visible loss-of-context.
* **Lemonade wrapper**: thin shell shim, no-op on non-AMD installs (the entrypoint change is only in `docker-compose.amd.yml`). Worst case if the wrapper has a bug: Lemonade fails to start with a Python traceback in the logs.
* **Phase 06 default change**: only `${VAR:-default}` defaults; if the operator's `.env` already sets `HERMES_LLM_API_KEY` to something specific, it's preserved. Non-AMD installs are unchanged from before.

## Follow-ups (out of scope)

* tower2 (NVIDIA) and spark (aarch64) use llama.cpp directly, not Lemonade. They have their own context-size configuration paths; whether they're similarly under-utilizing is a separate investigation.
* The 401-on-restart symptom suggests upstream Hermes's `model.api_key` config field is silently ignored for `provider: custom`. Worth filing upstream; for now we work around it at the env layer.
