### PR TITLE
feat(dream-talk): live status indicators ("Searching the web…" etc.) so users see what the agent is doing

### DIFF
--- a/dream-server/extensions/services/dashboard-api/hermes_bridge.py
+++ b/dream-server/extensions/services/dashboard-api/hermes_bridge.py
@@ -376,6 +376,49 @@ async def _submit_on_connection(
             if isinstance(chunk, str) and chunk:
                 chunks.append(chunk)
                 yield {"type": "delta", "text": chunk}
+        elif event_type == "status.update":
+            # Hermes (pinned image) emits status.update events with a pre-
+            # formatted human-readable text and a `kind` category. Examples
+            # we've observed in the wild:
+            #
+            #   {"kind": "lifecycle", "text": "⏳ Retrying in 5.1s (attempt 2/3)..."}
+            #   {"kind": "lifecycle", "text": "⚠️ Max retries (3) exhausted..."}
+            #
+            # Upstream is responsible for the human-readable wording (often
+            # with emoji prefixes); we just forward the text so the SPA's
+            # spinner caption shows what Hermes is actually doing. The
+            # "Searching the web…" / "Reading the page…" labels we add on
+            # the SSE-layer side are for older `tool.start`-style events
+            # that some builds may still emit; this branch handles the
+            # newer status.update path.
+            status_text = payload.get("text") if isinstance(payload.get("text"), str) else None
+            if status_text:
+                yield {
+                    "type": "status",
+                    "label": status_text,
+                    "kind": payload.get("kind") if isinstance(payload.get("kind"), str) else None,
+                }
+        elif event_type == "tool.start":
+            # Older-build path: Hermes may also emit explicit tool.start
+            # events with name + context. We translate those into status
+            # frames via the SSE layer's _label_for_tool() mapping.
+            tool_name = payload.get("name") if isinstance(payload.get("name"), str) else None
+            if tool_name:
+                yield {
+                    "type": "tool_start",
+                    "tool": tool_name,
+                    "detail": payload.get("context") if isinstance(payload.get("context"), str) else None,
+                }
+        elif event_type == "tool.complete":
+            # Older-build path companion: tool finished, clear the caption.
+            tool_name = payload.get("name") if isinstance(payload.get("name"), str) else None
+            if tool_name:
+                yield {
+                    "type": "tool_complete",
+                    "tool": tool_name,
+                    "duration_s": payload.get("duration_s") if isinstance(payload.get("duration_s"), (int, float)) else None,
+                    "summary": payload.get("summary") if isinstance(payload.get("summary"), str) else None,
+                }
         elif event_type == "message.complete":
             final_text = payload.get("text")
             if not isinstance(final_text, str) or not final_text.strip():
@@ -398,9 +441,12 @@ async def stream_prompt(session_key: str, text: str) -> AsyncIterator[dict[str, 
     """Submit a prompt to Hermes and yield delta events as they stream back.
 
     Yields dicts with:
-      {"type": "session",  "session_id": <id>}                      # once at start
-      {"type": "delta",    "text": <chunk>}                          # zero or more
-      {"type": "complete", "session_id": <id>, "text": <full>, ...}  # once at end
+      {"type": "session",        "session_id": <id>}                          # once at start
+      {"type": "tool_start",     "tool": <name>, "detail": <context|None>}    # zero or more
+      {"type": "tool_complete",  "tool": <name>, "duration_s": <float|None>,
+                                 "summary": <str|None>}                       # zero or more
+      {"type": "delta",          "text": <chunk>}                             # zero or more
+      {"type": "complete",       "session_id": <id>, "text": <full>, ...}     # once at end
 
     On error, raises HermesUnavailable / HermesBridgeError; no partial yield.
 

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -148,6 +148,49 @@ _SSE_KEEPALIVE = b": keepalive\n\n"
 _KEEPALIVE_INTERVAL = 5.0
 
 
+# Hermes tool name → human-readable spinner caption. We map by exact name
+# first, then by a few well-known prefixes. The fallback is a literal "Using
+# `<name>`…" so an unrecognised tool still produces something honest rather
+# than a blank.
+_TOOL_LABELS: dict[str, str] = {
+    "web_search": "Searching the web…",
+    "web_extract": "Reading the page…",
+    "execute_code": "Running code…",
+    "read_file": "Looking at a file…",
+    "write_file": "Saving a file…",
+    "patch": "Editing a file…",
+    "search_files": "Searching files…",
+    "memory": "Checking memory…",
+    "text_to_speech": "Generating voice…",
+    "session_search": "Searching past conversations…",
+    "todo": "Updating todos…",
+    "cronjob": "Scheduling…",
+    "delegate_task": "Delegating to a subagent…",
+    "image_generate": "Drawing an image…",
+    "vision_analyze": "Looking at an image…",
+    "clarify": "Asking for clarification…",
+    "send_message": "Sending a message…",
+}
+
+
+def _label_for_tool(tool_name: str) -> str:
+    """Map a Hermes tool name to a friendly spinner caption."""
+    if tool_name in _TOOL_LABELS:
+        return _TOOL_LABELS[tool_name]
+    # Common prefixes — browser_* / memory_* / skill_* etc.
+    if tool_name.startswith("browser_"):
+        return "Browsing…"
+    if tool_name.startswith("memory_") or tool_name.startswith("memory"):
+        return "Checking memory…"
+    if tool_name.startswith("skill_") or tool_name == "skills_list":
+        return "Loading a skill…"
+    if tool_name.startswith("github_"):
+        return "Talking to GitHub…"
+    # Honest fallback — show the literal tool name so the operator can map it
+    # in _TOOL_LABELS next pass.
+    return f"Using `{tool_name}`…"
+
+
 async def _stream_hermes_sse(session_key: str, text: str, request: Request):
     """SSE generator wrapping the bridge's stream_prompt.
 
@@ -221,6 +264,36 @@ async def _stream_hermes_sse(session_key: str, text: str, request: Request):
                 yield _sse_event("session", {"session_id": event.get("session_id", "")})
             elif et == "delta":
                 yield _sse_event("delta", {"text": event.get("text", "")})
+            elif et == "status":
+                # Hermes pre-formatted status text (e.g. "⏳ Retrying in 5.1s…",
+                # "🔎 Searching the web…"). Forward verbatim — upstream is
+                # responsible for the human-readable wording.
+                yield _sse_event("status", {
+                    "label": event.get("label"),
+                    "kind": event.get("kind"),
+                    "tool": None,
+                    "detail": None,
+                })
+            elif et == "tool_start":
+                # Translate raw bridge event into a friendly "status" frame
+                # the SPA renders as the spinner caption. The SPA replaces
+                # the caption on each new status, then drops it once
+                # message.delta frames start arriving.
+                tool_name = event.get("tool", "")
+                yield _sse_event("status", {
+                    "label": _label_for_tool(tool_name),
+                    "tool": tool_name,
+                    "detail": event.get("detail") or None,
+                })
+            elif et == "tool_complete":
+                # Tool finished — flip back to the default "Thinking…" caption
+                # until the next tool starts or message.delta arrives. SPA
+                # treats label=None as "clear and show default."
+                yield _sse_event("status", {
+                    "label": None,
+                    "tool": None,
+                    "detail": None,
+                })
             elif et == "complete":
                 yield _sse_event("complete", {
                     "session_id": event.get("session_id", ""),

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -670,6 +670,105 @@ def test_hermes_bridge_pool_sweeper_evicts_idle_connections(monkeypatch):
     assert "idle-key" in closed, f"sweeper should have called aclose(), got {closed}"
 
 
+def test_talk_message_stream_forwards_hermes_status_updates(talk_client, monkeypatch):
+    """Hermes (pinned image) emits status.update events with pre-formatted
+    human-readable text and a `kind` category, e.g.
+    ``{"kind": "lifecycle", "text": "⏳ Retrying in 5.1s (attempt 2/3)..."}``.
+    The bridge forwards them as ``status`` events and the SSE layer relays
+    them verbatim — upstream owns the wording, we just route it to the SPA.
+    Regression guard for the user-visible "spinner caption is dynamic" UX."""
+    async def fake_stream(session_key, text):
+        yield {"type": "session", "session_id": "sid"}
+        yield {"type": "status", "label": "⏳ Retrying in 5.1s (attempt 2/3)...", "kind": "lifecycle"}
+        yield {"type": "status", "label": "🔎 Searching the web…", "kind": "tool"}
+        yield {"type": "delta", "text": "OK"}
+        yield {"type": "complete", "session_id": "sid", "text": "OK", "status": "ok", "warning": None}
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "hi"})
+    assert resp.status_code == 200
+    frames = _parse_sse_frames(resp.content)
+    status_frames = [f for f in frames if f["type"] == "status"]
+    # Both status updates make it through, verbatim text + kind preserved.
+    assert len(status_frames) == 2
+    assert status_frames[0]["label"] == "⏳ Retrying in 5.1s (attempt 2/3)..."
+    assert status_frames[0]["kind"] == "lifecycle"
+    assert status_frames[1]["label"] == "🔎 Searching the web…"
+    assert status_frames[1]["kind"] == "tool"
+
+
+def test_talk_message_stream_translates_tool_events_to_status_frames(talk_client, monkeypatch):
+    """Hermes emits tool.start / tool.complete events while the agent is
+    working. The bridge surfaces those as ``tool_start`` / ``tool_complete``
+    events, and the SSE layer translates them into friendly ``status``
+    frames the SPA renders as the spinner caption. This is the user-facing
+    "what's the agent doing?" visibility added per the operator's feedback —
+    a phone shouldn't sit on a plain "Thinking" spinner for 30s while
+    web_search is mid-flight."""
+    async def fake_stream(session_key, text):
+        yield {"type": "session", "session_id": "sid"}
+        yield {"type": "tool_start", "tool": "web_search", "detail": "weather in San Francisco"}
+        yield {"type": "tool_complete", "tool": "web_search", "duration_s": 1.2, "summary": "Did 1 search"}
+        yield {"type": "delta", "text": "Sunny, 64°F."}
+        yield {"type": "complete", "session_id": "sid", "text": "Sunny, 64°F.", "status": "ok", "warning": None}
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "what is the weather?"})
+    assert resp.status_code == 200
+    frames = _parse_sse_frames(resp.content)
+    types = [f["type"] for f in frames]
+    # Required ordering: session → status(active) → status(cleared) → delta → complete → done
+    assert types[0] == "session"
+    status_frames = [f for f in frames if f["type"] == "status"]
+    assert len(status_frames) == 2, f"expected one status-active + one status-clear, got {status_frames}"
+    # First status: friendly label + tool name + detail string preserved.
+    assert status_frames[0]["label"] == "Searching the web…"
+    assert status_frames[0]["tool"] == "web_search"
+    assert status_frames[0]["detail"] == "weather in San Francisco"
+    # Second status: label=None signals SPA to drop the caption (default
+    # "Thinking…" until next status or delta).
+    assert status_frames[1]["label"] is None
+    assert status_frames[1]["tool"] is None
+    # And the actual content + complete frame still come through unchanged.
+    assert any(f["type"] == "delta" and f["text"] == "Sunny, 64°F." for f in frames)
+    assert any(f["type"] == "complete" for f in frames)
+
+
+def test_talk_message_stream_status_label_for_unknown_tool(talk_client, monkeypatch):
+    """Unknown tools should still produce a status frame — falling back to
+    a literal "Using `<name>`…" caption so the operator can map the tool in
+    a future _TOOL_LABELS pass instead of staring at a blank spinner."""
+    async def fake_stream(session_key, text):
+        yield {"type": "session", "session_id": "sid"}
+        yield {"type": "tool_start", "tool": "some_new_skill_2026", "detail": None}
+        yield {"type": "complete", "session_id": "sid", "text": "ok", "status": "ok", "warning": None}
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post("/api/talk/message/stream", json={"text": "hi"})
+    assert resp.status_code == 200
+    frames = _parse_sse_frames(resp.content)
+    status_frames = [f for f in frames if f["type"] == "status"]
+    assert len(status_frames) == 1
+    # Honest fallback — literal name appears in the caption so an operator
+    # who sees "Using `foo`…" on the phone knows exactly what to map.
+    assert "some_new_skill_2026" in status_frames[0]["label"]
+
+
+def test_talk_message_stream_status_label_handles_browser_prefix(monkeypatch):
+    """Tools we don't enumerate explicitly but share a known prefix get a
+    sensible group caption (browser_* → "Browsing…")."""
+    from routers.talk import _label_for_tool
+    assert _label_for_tool("browser_navigate") == "Browsing…"
+    assert _label_for_tool("browser_console") == "Browsing…"
+    assert _label_for_tool("memory_save") == "Checking memory…"
+    assert _label_for_tool("skill_view") == "Loading a skill…"
+    # Honest fallback for genuinely unknown:
+    assert _label_for_tool("random_unknown_tool") == "Using `random_unknown_tool`…"
+
+
 def test_talk_message_stream_sets_unbuffered_headers(talk_client, monkeypatch):
     """nginx upstream needs ``X-Accel-Buffering: no`` + ``Cache-Control: no-cache``
     so each SSE frame is forwarded immediately. Regression guard for the SSE

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -222,8 +222,26 @@ export default function DreamTalk() {
           if (payload.type === 'delta' && typeof payload.text === 'string') {
             assembled += payload.text
             const snapshot = assembled
+            // Once token deltas start arriving the spinner caption is no
+            // longer useful — clear it so the assistant bubble shows the
+            // live text instead. `status: null` signals MessageBubble to
+            // render the accumulated text rather than a spinner.
             setMessages(items => items.map(item =>
-              item.id === assistantId ? { ...item, text: snapshot, status: 'pending' } : item,
+              item.id === assistantId
+                ? { ...item, text: snapshot, status: 'pending', statusLabel: null, statusTool: null, statusDetail: null }
+                : item,
+            ))
+          } else if (payload.type === 'status') {
+            // Friendly progress caption from the bridge (e.g. "Searching the
+            // web…"). Replaces the default "Thinking…" while a tool is in
+            // flight. label=null means "tool done; flip back to default."
+            const label = typeof payload.label === 'string' ? payload.label : null
+            const tool = typeof payload.tool === 'string' ? payload.tool : null
+            const detail = typeof payload.detail === 'string' ? payload.detail : null
+            setMessages(items => items.map(item =>
+              item.id === assistantId
+                ? { ...item, statusLabel: label, statusTool: tool, statusDetail: detail }
+                : item,
             ))
           } else if (payload.type === 'complete') {
             if (typeof payload.text === 'string' && payload.text) assembled = payload.text
@@ -505,9 +523,21 @@ function MessageBubble({ message }) {
         }`}
       >
         {message.status === 'pending' && !message.text ? (
-          <span className="inline-flex items-center gap-2 text-zinc-500">
-            <Loader2 size={14} className="animate-spin" />
-            Thinking
+          // While the assistant is working but hasn't streamed any tokens
+          // yet, the spinner shows a dynamic caption sourced from the
+          // bridge's tool events ("Searching the web…", "Running code…",
+          // etc.). Falls back to "Thinking…" when no tool is active.
+          // statusDetail (e.g. the search query) is rendered below the
+          // caption when present, so the user can see *what* is being
+          // searched/read, not just "doing something."
+          <span className="inline-flex flex-col gap-0.5 text-zinc-500">
+            <span className="inline-flex items-center gap-2">
+              <Loader2 size={14} className="animate-spin" />
+              {message.statusLabel || 'Thinking…'}
+            </span>
+            {message.statusDetail && (
+              <span className="ml-6 text-xs text-zinc-400">{message.statusDetail}</span>
+            )}
           </span>
         ) : user || message.status === 'error' ? (
           // User messages and error bubbles stay as plain text — markdown

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
@@ -12,7 +12,7 @@ const response = (body, status = 200) => ({
 // of JS objects; each one is encoded as a single SSE frame (data: <json>\n\n).
 // If ``chunks`` is provided it's an array of frame-index arrays — each chunk
 // emits those frames in one reader.read() pass, simulating partial transport.
-const sseResponse = (frames, { status = 200, chunks } = {}) => {
+const sseResponse = (frames, { status = 200, chunks, holdOpen = false } = {}) => {
   const encoder = new TextEncoder()
   const frameBytes = frames.map(f => encoder.encode(`data: ${JSON.stringify(f)}\n\n`))
   const concatFrames = (group) => {
@@ -31,7 +31,14 @@ const sseResponse = (frames, { status = 200, chunks } = {}) => {
   let idx = 0
   const reader = {
     read: async () => {
-      if (idx >= chunkGroups.length) return { done: true, value: undefined }
+      if (idx >= chunkGroups.length) {
+        // ``holdOpen`` keeps the reader awaiting indefinitely after the final
+        // chunk — useful when a test wants to assert intermediate spinner /
+        // status UI without the SPA's "stream closed → finalize bubble" path
+        // wiping the state before the assertion fires.
+        if (holdOpen) return new Promise(() => {})
+        return { done: true, value: undefined }
+      }
       const value = chunkGroups[idx++]
       return { done: false, value }
     },
@@ -156,6 +163,73 @@ describe('DreamTalk', () => {
     expect(screen.getByText('alpha').closest('li')).toBeTruthy()
     // And the raw `**` is gone from the DOM text.
     expect(container.textContent).not.toContain('**')
+  })
+
+  test('renders dynamic SSE status caption + detail while a tool is in flight', async () => {
+    // Bridge emits `status` frames between session and the first delta —
+    // the SPA should swap the default "Thinking…" caption for the friendly
+    // label and show the detail string (e.g. the search query) underneath.
+    // Once message.delta frames start arriving, the caption is dropped and
+    // the bubble shows live text. Then on `complete`, the bubble settles.
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })
+      if (url === '/api/talk/message/stream' && options.method === 'POST') {
+        return sseResponse([
+          { type: 'session', session_id: 'sid' },
+          { type: 'status', label: 'Searching the web…', tool: 'web_search', detail: 'weather forecast Philadelphia' },
+        ], { chunks: [[0, 1]], holdOpen: true })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DreamTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Message Dream Server'), {
+      target: { value: 'weather?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    // The friendly caption replaces the default "Thinking…" wholesale.
+    expect(await screen.findByText('Searching the web…')).toBeInTheDocument()
+    expect(screen.queryByText('Thinking…')).not.toBeInTheDocument()
+    // The detail string (the query Hermes is running) renders below the caption.
+    expect(screen.getByText('weather forecast Philadelphia')).toBeInTheDocument()
+  })
+
+  test('drops the status caption when message.delta frames start arriving', async () => {
+    // Hermes flow on a real tool-using turn: status -> deltas -> complete.
+    // Once the first delta lands the bubble must switch from "Searching…"
+    // to live token rendering — otherwise the user keeps seeing the stale
+    // status while the model is actually writing.
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })
+      if (url === '/api/talk/message/stream' && options.method === 'POST') {
+        return sseResponse([
+          { type: 'session', session_id: 'sid' },
+          { type: 'status', label: 'Searching the web…', tool: 'web_search', detail: 'weather' },
+          { type: 'status', label: null, tool: null, detail: null },
+          { type: 'delta', text: 'It is ' },
+          { type: 'delta', text: '64°F.' },
+          { type: 'complete', session_id: 'sid', text: 'It is 64°F.', status: 'ok' },
+          { type: 'done' },
+        ])
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<DreamTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+    fireEvent.change(screen.getByPlaceholderText('Message Dream Server'), {
+      target: { value: 'weather?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    expect(await screen.findByText('It is 64°F.')).toBeInTheDocument()
+    // The status caption is gone once content has rendered.
+    expect(screen.queryByText('Searching the web…')).not.toBeInTheDocument()
+    expect(screen.queryByText('Thinking…')).not.toBeInTheDocument()
   })
 
   test('surfaces SSE error frame as an assistant error', async () => {


### PR DESCRIPTION
## Summary

Operator feedback after a recent deeper-conversation session: *"Sometimes it's hard to tell if it's hung up or still working because it just has the thinking status… leaves me wondering what it's doing out there with my request."*

Hermes is already emitting rich progress signals while it works (`tool.start`, `status.update` with `kind: lifecycle`, etc.) but our bridge dropped everything that wasn't `message.delta` or `message.complete`. So the SPA had nothing to render but the bare `Thinking…` spinner — even during a 30s `web_search` call where Hermes literally knows which tool it's running and against what query.

This PR surfaces that progress to the user as a dynamic spinner caption.

## What it looks like

A weather query now renders, in order:

```
🌀 Searching the web…
   current weather San Francisco
```

then once the model starts writing:

```
It's currently around 59°F and clear in San Francisco…
```

For a memory-checking turn the caption reads *"Checking memory…"*; for `execute_code`, *"Running code…"*; etc. Unknown tools surface as `Using \`<name>\`…` so an operator can spot what to map next.

## How it works

Three layers, each kept small:

1. **`hermes_bridge.py`** — forward two new Hermes event types to the bridge's caller:
   - `tool.start` / `tool.complete` (older builds): bridge yields `{type: tool_start, tool: <name>, detail: <context>}`.
   - `status.update` (newer builds): bridge yields `{type: status, label: <pre-formatted text>, kind: <category>}` — upstream already does the wording, we just route it.

2. **`routers/talk.py`** — translate bridge events into SSE `status` frames:
   - For `tool_start`, map the tool name through `_label_for_tool()` (e.g. `web_search → "Searching the web…"`). Known prefixes (`browser_`, `memory_`, `skill_`, `github_`) get sensible group captions. Unknown names fall back to `Using \`<name>\`…`.
   - For `tool_complete`, emit `{label: null}` to signal the SPA to clear the caption.
   - For `status.update`, pass verbatim — text already user-friendly.

3. **`DreamTalk.jsx`** — `MessageBubble`'s spinner now reads `message.statusLabel` instead of the hardcoded `Thinking`, with the optional `statusDetail` shown as a small caption underneath (e.g. the active search query). `sendText()` updates `statusLabel/Tool/Detail` on each `status` frame; once the first `message.delta` arrives the caption is cleared so the bubble flips to live token rendering.

## Friendly-label coverage

Mapped explicitly:
- `web_search → "Searching the web…"`
- `web_extract → "Reading the page…"`
- `execute_code → "Running code…"`
- `read_file / write_file / patch / search_files → "Looking at a file…"` etc.
- `memory → "Checking memory…"`
- `text_to_speech → "Generating voice…"`
- `session_search → "Searching past conversations…"`
- `image_generate / vision_analyze → drawing / looking at an image`
- a few more — see `_TOOL_LABELS` in `routers/talk.py`

Prefix-based fallbacks: `browser_*` → "Browsing…", `memory_*` → "Checking memory…", `skill_*` → "Loading a skill…", `github_*` → "Talking to GitHub…".

Final fallback for genuinely unknown tools: a literal `Using \`<name>\`…` so the operator who sees it on the phone knows exactly what to add to `_TOOL_LABELS` in a future pass.

## Test coverage

* **Backend** (`tests/test_talk.py`, +3 tests, **23/23 passing**):
  * `test_talk_message_stream_translates_tool_events_to_status_frames` — asserts session → status(active) → status(cleared) → delta → complete ordering, with `label="Searching the web…"`, `tool="web_search"`, and the operator-supplied `detail` preserved.
  * `test_talk_message_stream_status_label_for_unknown_tool` — verifies the honest fallback for genuinely unknown tool names.
  * `test_talk_message_stream_status_label_handles_browser_prefix` — exercises the prefix-based group captions.
  * `test_talk_message_stream_forwards_hermes_status_updates` — `status.update` events from newer Hermes builds pass through verbatim with `label` and `kind` preserved.
* **Frontend** (`DreamTalk.test.jsx`, +2 tests, **9/9 passing**):
  * `renders dynamic SSE status caption + detail while a tool is in flight` — friendly label replaces the default `Thinking…`, detail string renders below.
  * `drops the status caption when message.delta frames start arriving` — once content streams in, the bubble switches to live tokens.
  * `sseResponse()` helper gained a `holdOpen: true` option so tests can assert intermediate spinner state without the SPA's "stream closed → finalize bubble" path wiping the assertion subject.

## Live verification

```
$ curl -sN -X POST .../api/talk/message/stream \
    -d '{"text":"what is the weather like today in San Francisco"}'

frame types: session, status×2, delta×37, complete, done — 9s end-to-end
status #1:   "Searching the web…" — detail "current weather San Francisco"
status #2:   {label: null}  ← clear caption, deltas start
reply:       "It's currently around 59°F and clear in San Francisco. Expect cloudy
              skies early that will give way to partly cloudy conditions later,
              with a high near 63°F."
```

## Risk / blast radius

* Three small additive changes — adds new SSE event type (`status`) that older SPA builds will simply ignore. No protocol break.
* The frontend reads new optional fields (`statusLabel/Tool/Detail`); existing tests pass and the bubble continues to render the default `Thinking…` when no status frames arrive (matches old behaviour).
* No infra changes, no model changes, no compose changes.

## Follow-up (not in this PR)

Observed during verification: when llama-server hits ReadTimeouts under load, Hermes does an internal 3-retry burst that piles queued requests onto already-saturated slots, creating a cascading retry-storm that's hard to recover from without restarting Hermes + dashboard-api + llama-server together. Worth a separate look at raising litellm's read timeout above 30s so a single slow call doesn't snowball into 3 queued calls.
