### PR TITLE
feat(dream-talk): image + file attachments via paperclip (fixes the iOS video-mode trap)

### DIFF
--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -236,6 +236,18 @@ services:
       - TTS_URL=${TTS_URL:-http://tts:8880}
       - EMBEDDING_URL=${EMBEDDING_URL:-http://embeddings:80}
       - WHISPER_URL=${WHISPER_URL:-http://whisper:8000}
+      # Dream Talk's image-attachment endpoint calls the vision backend
+      # directly (bypassing litellm because litellm's wildcard model
+      # routing collapses our model id down to whatever's loaded).
+      # Defaults point at the Lemonade/llama-server service on the
+      # internal docker network — no auth needed there. Operators with
+      # an external vision server set DREAM_TALK_VISION_URL +
+      # DREAM_TALK_VISION_KEY.
+      - DREAM_TALK_VISION_URL=${DREAM_TALK_VISION_URL:-http://llama-server:8080}
+      - DREAM_TALK_VISION_KEY=${DREAM_TALK_VISION_KEY:-}
+      # Model id of the vision-capable variant. Defaults to the user.*
+      # name we register on AMD install (Qwen3.6-35B-A3B + mmproj-F16).
+      - DREAM_TALK_VISION_MODEL=${DREAM_TALK_VISION_MODEL:-user.Qwen3.6-35B-A3B-Vision}
     volumes:
       - ./scripts:/dream-server/scripts:ro
       - ./config:/dream-server/config:ro

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -42,6 +42,17 @@ MAX_DOC_CHARS = 80_000               # post-extraction character cap so a megaby
 
 # MIME types we accept on the attach surface. Anything else → 415.
 _IMAGE_MIME_PREFIXES = ("image/",)
+_IMAGE_EXTENSION_MIMES = {
+    ".avif": "image/avif",
+    ".bmp": "image/bmp",
+    ".gif": "image/gif",
+    ".heic": "image/heic",
+    ".heif": "image/heif",
+    ".jpeg": "image/jpeg",
+    ".jpg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+}
 _TEXT_LIKE_MIMES = {
     "text/plain", "text/markdown", "text/csv", "text/x-markdown",
     "application/json", "application/xml", "text/xml",
@@ -540,6 +551,8 @@ def _classify_attachment(file: UploadFile) -> str:
 
     if any(ct.startswith(p) for p in _IMAGE_MIME_PREFIXES):
         return "image"
+    if ext in _IMAGE_EXTENSION_MIMES:
+        return "image"
     if ct in _TEXT_LIKE_MIMES:
         return "text"
     if ext in _TEXT_LIKE_EXTENSIONS:
@@ -548,6 +561,17 @@ def _classify_attachment(file: UploadFile) -> str:
         status_code=415,
         detail=f"This file type isn't supported on chat yet (got {ct or 'unknown'}, {ext or 'no extension'}). Try an image, .txt, .md, .csv, .json, or code file.",
     )
+
+
+def _image_content_type(file: UploadFile) -> str:
+    """Return a browser-safe image MIME, falling back from filename extension."""
+    ct = (file.content_type or "").lower()
+    if any(ct.startswith(p) for p in _IMAGE_MIME_PREFIXES):
+        return ct
+
+    name = (file.filename or "").lower()
+    ext = "." + name.rsplit(".", 1)[-1] if "." in name else ""
+    return _IMAGE_EXTENSION_MIMES.get(ext, "image/png")
 
 
 @router.post("/api/talk/attachment")
@@ -585,7 +609,7 @@ async def talk_attachment(
             raise HTTPException(status_code=413, detail=f"Image is too large (max {MAX_IMAGE_BYTES // (1024 * 1024)} MB).")
         prompt_text = caption or "Describe what you see in this image."
         return StreamingResponse(
-            _stream_vision_chat(data, file.content_type or "image/png", prompt_text),
+            _stream_vision_chat(data, _image_content_type(file), prompt_text),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -9,11 +9,12 @@ must not grant access here.
 from __future__ import annotations
 
 import asyncio
+import base64
 import contextlib
 import json
 import logging
 import os
-from typing import Any
+from typing import Any, AsyncIterator
 
 import httpx
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
@@ -31,6 +32,129 @@ router = APIRouter(tags=["talk"])
 SESSION_COOKIE_NAME = "dream-session"
 MAX_AUDIO_BYTES = 25 * 1024 * 1024
 MAX_MESSAGE_CHARS = 8000
+
+# Attachment limits — chat surface, not document-ingestion. Pick conservative
+# ceilings that still let a phone photo + a short doc through.
+MAX_IMAGE_BYTES = 10 * 1024 * 1024   # 10 MB raw — base64 inflates to ~13 MB on the wire
+MAX_DOC_BYTES = 5 * 1024 * 1024      # 5 MB extracted text limit, generous
+MAX_DOC_CHARS = 80_000               # post-extraction character cap so a megabyte
+                                     # log doesn't blow past the model's context
+
+# MIME types we accept on the attach surface. Anything else → 415.
+_IMAGE_MIME_PREFIXES = ("image/",)
+_TEXT_LIKE_MIMES = {
+    "text/plain", "text/markdown", "text/csv", "text/x-markdown",
+    "application/json", "application/xml", "text/xml",
+    "application/x-yaml", "text/yaml", "text/x-yaml",
+}
+_TEXT_LIKE_EXTENSIONS = {  # browsers sometimes upload these as application/octet-stream
+    ".txt", ".md", ".markdown", ".csv", ".json", ".yaml", ".yml",
+    ".log", ".py", ".js", ".ts", ".tsx", ".jsx", ".html", ".css", ".sh",
+}
+
+
+def _vision_model_name() -> str:
+    """Lemonade name of the vision-capable model. Defaults match the strix
+    user.* registration we ship; operators can override per-host via env."""
+    return os.environ.get("DREAM_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
+
+
+def _vision_backend_url() -> str:
+    """Where to send multimodal requests. Defaults to Lemonade direct
+    (``http://llama-server:8080``) — NOT litellm — because litellm's
+    ``model_name: '*'`` wildcard normalises our ``user.*`` model id down to
+    whatever llama-server has currently loaded, which silently downgrades
+    image queries to the text-only model. Lemonade routes by exact model
+    id and auto-swaps to the vision variant on first multimodal call.
+
+    Operators can override with ``DREAM_TALK_VISION_URL`` for hosts where
+    vision lives somewhere else (e.g. a dedicated VL server).
+    """
+    return (os.environ.get("DREAM_TALK_VISION_URL")
+            or os.environ.get("LLM_API_URL")
+            or "http://llama-server:8080").rstrip("/")
+
+
+def _vision_backend_key() -> str:
+    """Bearer token for the vision backend. Empty when hitting Lemonade
+    direct on the internal docker network (no auth needed there); set when
+    a host routes through litellm or another authenticated proxy."""
+    return os.environ.get("DREAM_TALK_VISION_KEY") or ""
+
+
+async def _stream_vision_chat(image_bytes: bytes, content_type: str, prompt_text: str) -> AsyncIterator[bytes]:
+    """Send a single multimodal turn directly to litellm and translate the
+    streaming response into the same SSE frame shape Dream Talk already uses
+    (session / delta / complete / done / error). Bypasses Hermes for image
+    queries because Hermes's prompt.submit only takes text — the multimodal
+    content array is a litellm/llama-server-level concept.
+
+    Trade-off: image queries don't get Hermes's tool layer (no web_search,
+    memory, etc.) — they're a one-shot "describe this image" exchange. For
+    follow-up turns, users continue typing normally and Hermes resumes.
+    """
+    image_url = f"data:{content_type};base64,{base64.b64encode(image_bytes).decode('ascii')}"
+    payload = {
+        "model": _vision_model_name(),
+        "stream": True,
+        "max_tokens": 1024,
+        "messages": [
+            {"role": "user", "content": [
+                {"type": "text", "text": prompt_text},
+                {"type": "image_url", "image_url": {"url": image_url}},
+            ]},
+        ],
+    }
+    yield _sse_event("session", {"session_id": "vision-oneshot"})
+
+    accumulated: list[str] = []
+    timeout = httpx.Timeout(connect=10.0, read=180.0, write=30.0, pool=10.0)
+    headers = {"Content-Type": "application/json", "Accept": "text/event-stream"}
+    key = _vision_backend_key()
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            async with client.stream(
+                "POST",
+                f"{_vision_backend_url()}/v1/chat/completions",
+                headers=headers,
+                json=payload,
+            ) as resp:
+                if resp.status_code >= 400:
+                    body = await resp.aread()
+                    detail = body.decode("utf-8", errors="replace")[:300]
+                    yield _sse_event("error", {"status_code": resp.status_code, "detail": detail})
+                    yield _sse_event("done", {})
+                    return
+                async for raw in resp.aiter_lines():
+                    if not raw or not raw.startswith("data:"):
+                        continue
+                    payload_str = raw[5:].strip()
+                    if payload_str == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(payload_str)
+                    except json.JSONDecodeError:
+                        continue
+                    delta = chunk.get("choices", [{}])[0].get("delta", {})
+                    text = delta.get("content")
+                    if isinstance(text, str) and text:
+                        accumulated.append(text)
+                        yield _sse_event("delta", {"text": text})
+    except (httpx.ReadTimeout, httpx.ConnectError, httpx.HTTPError) as exc:
+        yield _sse_event("error", {"status_code": 502, "detail": f"Vision model unavailable: {exc}"})
+        yield _sse_event("done", {})
+        return
+
+    final_text = "".join(accumulated).strip() or "(no response)"
+    yield _sse_event("complete", {
+        "session_id": "vision-oneshot",
+        "text": final_text,
+        "status": "ok",
+        "warning": None,
+    })
+    yield _sse_event("done", {})
 
 
 def _require_session(request: Request) -> tuple[str, int]:
@@ -399,6 +523,102 @@ async def talk_message_stream(payload: dict[str, Any], request: Request) -> Stre
         _stream_hermes_sse(session_key, text, request),
         media_type="text/event-stream",
         headers=headers,
+    )
+
+
+def _classify_attachment(file: UploadFile) -> str:
+    """Return one of: ``image``, ``text``, or raise 415.
+
+    Looks at the MIME type the browser supplied first; falls back to filename
+    extension because some browsers / iOS upload everything as
+    application/octet-stream. We deliberately keep the accept-set narrow on
+    this v1 surface — chat, not document ingestion.
+    """
+    ct = (file.content_type or "").lower()
+    name = (file.filename or "").lower()
+    ext = "." + name.rsplit(".", 1)[-1] if "." in name else ""
+
+    if any(ct.startswith(p) for p in _IMAGE_MIME_PREFIXES):
+        return "image"
+    if ct in _TEXT_LIKE_MIMES:
+        return "text"
+    if ext in _TEXT_LIKE_EXTENSIONS:
+        return "text"
+    raise HTTPException(
+        status_code=415,
+        detail=f"This file type isn't supported on chat yet (got {ct or 'unknown'}, {ext or 'no extension'}). Try an image, .txt, .md, .csv, .json, or code file.",
+    )
+
+
+@router.post("/api/talk/attachment")
+async def talk_attachment(
+    request: Request,
+    file: UploadFile = File(...),
+    text: str = Form(""),
+) -> StreamingResponse:
+    """Multipart attachment endpoint. Returns the same SSE event shape as
+    ``/api/talk/message/stream`` so the SPA can use a single rendering path.
+
+    Two routing paths inside:
+
+    1. **Images** → multimodal one-shot to litellm against the vision-capable
+       model (e.g. ``user.Qwen3.6-35B-A3B-Vision`` on Lemonade hosts). Hermes's
+       prompt.submit API only accepts plain text, so vision queries bypass
+       the agent loop. Acceptable trade-off for v1: image queries don't get
+       Hermes's tool layer, but they do get a real model-vision answer.
+    2. **Text-like files** (.txt/.md/.csv/.json/code) → extract content,
+       prepend to the user's caption, route through the existing Hermes
+       bridge so the agent retains tools and memory.
+
+    PDF/docx aren't in scope for v1 (no parser dependency yet).
+    """
+    session_key, _expires_at = _require_session(request)
+    kind = _classify_attachment(file)
+
+    caption = (text or "").strip()
+    if len(caption) > MAX_MESSAGE_CHARS:
+        raise HTTPException(status_code=413, detail="Caption is too long.")
+
+    if kind == "image":
+        data = await file.read(MAX_IMAGE_BYTES + 1)
+        if len(data) > MAX_IMAGE_BYTES:
+            raise HTTPException(status_code=413, detail=f"Image is too large (max {MAX_IMAGE_BYTES // (1024 * 1024)} MB).")
+        prompt_text = caption or "Describe what you see in this image."
+        return StreamingResponse(
+            _stream_vision_chat(data, file.content_type or "image/png", prompt_text),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                "Connection": "keep-alive",
+            },
+        )
+
+    # text-like
+    data = await file.read(MAX_DOC_BYTES + 1)
+    if len(data) > MAX_DOC_BYTES:
+        raise HTTPException(status_code=413, detail=f"File is too large (max {MAX_DOC_BYTES // (1024 * 1024)} MB).")
+    try:
+        content = data.decode("utf-8")
+    except UnicodeDecodeError:
+        content = data.decode("utf-8", errors="replace")
+    if len(content) > MAX_DOC_CHARS:
+        content = content[:MAX_DOC_CHARS] + f"\n\n[Truncated — file was {len(data):,} bytes, showing first {MAX_DOC_CHARS:,} chars]"
+
+    filename = file.filename or "attachment.txt"
+    prompt = (
+        f"[Attached file: {filename}]\n"
+        f"```\n{content}\n```\n\n"
+        f"{caption or 'Take a look at this and let me know what you think.'}"
+    )
+    return StreamingResponse(
+        _stream_hermes_sse(session_key, prompt, request),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
     )
 
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -769,6 +769,103 @@ def test_talk_message_stream_status_label_handles_browser_prefix(monkeypatch):
     assert _label_for_tool("random_unknown_tool") == "Using `random_unknown_tool`…"
 
 
+def test_talk_attachment_text_file_routes_through_hermes_with_inlined_content(talk_client, monkeypatch):
+    """Text-like attachments (.txt/.md/.json/code/etc.) get their content
+    decoded and prepended to the user's caption, then routed through the
+    existing Hermes bridge — so the agent retains tools, memory, and the
+    same SSE event shape as a regular text message."""
+    captured_prompt = None
+
+    async def fake_stream(session_key, text):
+        nonlocal captured_prompt
+        captured_prompt = text
+        yield {"type": "session", "session_id": "sid"}
+        yield {"type": "complete", "session_id": "sid", "text": "Reviewed.", "status": "ok", "warning": None}
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_stream)
+
+    resp = talk_client.post(
+        "/api/talk/attachment",
+        files={"file": ("notes.md", b"# Hello\nFoo bar", "text/markdown")},
+        data={"text": "what's in this?"},
+    )
+    assert resp.status_code == 200
+    assert "Hello" in captured_prompt
+    assert "Foo bar" in captured_prompt
+    assert "what's in this?" in captured_prompt
+    assert "notes.md" in captured_prompt
+
+
+def test_talk_attachment_unknown_filetype_returns_415(talk_client):
+    """Unsupported file types (zip/exe/etc.) should be rejected at the
+    attachment surface, not silently passed through. v1 is image-and-text-
+    only by design."""
+    resp = talk_client.post(
+        "/api/talk/attachment",
+        files={"file": ("archive.zip", b"PK\x03\x04...", "application/zip")},
+        data={"text": ""},
+    )
+    assert resp.status_code == 415
+
+
+def test_talk_attachment_image_routes_to_vision_endpoint_bypassing_hermes(talk_client, monkeypatch):
+    """Images go to litellm directly (not through Hermes) because Hermes's
+    prompt.submit accepts only text — multimodal content arrays are a
+    litellm/llama-server-level concept. Regression guard that we don't
+    accidentally re-route images through the text-only Hermes path."""
+    hermes_stream_called = False
+
+    async def fake_hermes_stream(session_key, text):
+        nonlocal hermes_stream_called
+        hermes_stream_called = True
+        yield {"type": "session", "session_id": "sid"}
+        yield {"type": "complete", "session_id": "sid", "text": "wrong-path", "status": "ok", "warning": None}
+
+    async def fake_vision_stream(image_bytes, content_type, prompt_text):
+        from routers.talk import _sse_event
+        yield _sse_event("session", {"session_id": "vision"})
+        yield _sse_event("delta", {"text": "Red."})
+        yield _sse_event("complete", {"session_id": "vision", "text": "Red.", "status": "ok", "warning": None})
+        yield _sse_event("done", {})
+
+    monkeypatch.setattr("hermes_bridge.stream_prompt", fake_hermes_stream)
+    monkeypatch.setattr("routers.talk._stream_vision_chat", fake_vision_stream)
+
+    # Minimal valid PNG bytes (PNG signature + IHDR).
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    resp = talk_client.post(
+        "/api/talk/attachment",
+        files={"file": ("photo.png", png_bytes, "image/png")},
+        data={"text": "what color?"},
+    )
+    assert resp.status_code == 200
+    frames = _parse_sse_frames(resp.content)
+    assert any(f.get("type") == "complete" and f.get("text") == "Red." for f in frames)
+    # Hermes was NOT called for an image — image flow bypasses the text
+    # agent loop.
+    assert not hermes_stream_called
+
+
+def test_talk_attachment_image_too_large_returns_413(talk_client):
+    """Image size cap is enforced at the multipart boundary."""
+    big = b"\x89PNG\r\n\x1a\n" + b"x" * (11 * 1024 * 1024)
+    resp = talk_client.post(
+        "/api/talk/attachment",
+        files={"file": ("huge.png", big, "image/png")},
+    )
+    assert resp.status_code == 413
+
+
+def test_talk_attachment_requires_session(test_client):
+    """No cookie ⇒ 401 even with a valid file."""
+    resp = test_client.post(
+        "/api/talk/attachment",
+        files={"file": ("notes.md", b"hi", "text/markdown")},
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 401
+
+
 def test_talk_message_stream_sets_unbuffered_headers(talk_client, monkeypatch):
     """nginx upstream needs ``X-Accel-Buffering: no`` + ``Cache-Control: no-cache``
     so each SSE frame is forwarded immediately. Regression guard for the SSE

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -846,6 +846,34 @@ def test_talk_attachment_image_routes_to_vision_endpoint_bypassing_hermes(talk_c
     assert not hermes_stream_called
 
 
+def test_talk_attachment_image_uses_filename_when_mobile_uploads_octet_stream(talk_client, monkeypatch):
+    """Mobile browsers sometimes send captured images as octet-stream.
+    Filename fallback keeps phone uploads on the image path and gives the
+    vision model a real image MIME in the data URL."""
+    captured_content_type = None
+
+    async def fake_vision_stream(image_bytes, content_type, prompt_text):
+        nonlocal captured_content_type
+        from routers.talk import _sse_event
+        captured_content_type = content_type
+        yield _sse_event("session", {"session_id": "vision"})
+        yield _sse_event("complete", {"session_id": "vision", "text": "Red.", "status": "ok", "warning": None})
+        yield _sse_event("done", {})
+
+    monkeypatch.setattr("routers.talk._stream_vision_chat", fake_vision_stream)
+
+    png_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+    resp = talk_client.post(
+        "/api/talk/attachment",
+        files={"file": ("phone-capture.png", png_bytes, "application/octet-stream")},
+        data={"text": "what color?"},
+    )
+    assert resp.status_code == 200
+    assert captured_content_type == "image/png"
+    frames = _parse_sse_frames(resp.content)
+    assert any(f.get("type") == "complete" and f.get("text") == "Red." for f in frames)
+
+
 def test_talk_attachment_image_too_large_returns_413(talk_client):
     """Image size cap is enforced at the multipart boundary."""
     big = b"\x89PNG\r\n\x1a\n" + b"x" * (11 * 1024 * 1024)

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -67,6 +67,11 @@ export default function DreamTalk() {
     liveMic: false,
   })
 
+  const [pendingAttachment, setPendingAttachment] = useState(null)
+  // {file: File, previewUrl: string|null, kind: 'image'|'text', name: string}
+  // Held in state between picking a file and sending — lets the user add a
+  // caption in the textarea before submitting.
+
   const bottomRef = useRef(null)
   const fileInputRef = useRef(null)
   const recorderRef = useRef(null)
@@ -150,18 +155,37 @@ export default function DreamTalk() {
     }
   }, [spokenReplies, voiceState.tts])
 
-  const sendText = useCallback(async (text, { transcriptId = null } = {}) => {
+  const sendText = useCallback(async (text, { transcriptId = null, attachment = null } = {}) => {
     const clean = text.trim()
-    if (!clean || sending || status === 'expired') return
+    // Allow an attachment with no text — the backend supplies a default
+    // prompt for images ("Describe what you see in this image."). Without
+    // either a caption or an attachment, there's nothing to send.
+    if (!clean && !attachment) return
+    if (sending || status === 'expired') return
     setSending(true)
 
     const userId = transcriptId || makeId('user')
     const assistantId = makeId('assistant')
     if (!transcriptId) {
-      setMessages(items => [...items, { id: userId, role: 'user', text: clean, status: 'done' }])
+      // Show the user's bubble with the image preview inline (if any) and
+      // the caption text. The previewUrl is a blob: URL, valid until the
+      // component unmounts or we revoke it; the browser GCs it for us when
+      // the message is removed from state.
+      setMessages(items => [...items, {
+        id: userId,
+        role: 'user',
+        text: clean,
+        imageUrl: attachment?.kind === 'image' ? attachment.previewUrl : null,
+        fileName: attachment?.kind === 'text' ? attachment.name : null,
+        status: 'done',
+      }])
     }
     setMessages(items => [...items, { id: assistantId, role: 'assistant', text: '', status: 'pending' }])
     setInput('')
+    // Clear the pending-attachment slot now that we've moved it into the
+    // chat thread. Don't revoke the blob URL yet — the user message bubble
+    // is still rendering from it.
+    if (attachment) setPendingAttachment(null)
 
     // Live-streamed reply via SSE. The endpoint emits one JSON object per
     // ``data:`` frame: {type: "session" | "delta" | "complete" | "error" | "done"}.
@@ -179,13 +203,31 @@ export default function DreamTalk() {
     streamControllerRef.current?.abort()
     streamControllerRef.current = controller
     try {
-      const resp = await fetch('/api/talk/message/stream', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
-        credentials: 'same-origin',
-        body: JSON.stringify({ text: clean }),
-        signal: controller.signal,
-      })
+      // Two endpoints + body shapes — same SSE response shape on both, so
+      // the consumption loop below is unchanged.
+      let resp
+      if (attachment) {
+        const form = new FormData()
+        form.set('file', attachment.file, attachment.name)
+        form.set('text', clean)
+        resp = await fetch('/api/talk/attachment', {
+          method: 'POST',
+          // Don't set Content-Type — fetch fills in multipart/form-data
+          // with the right boundary string automatically.
+          headers: { 'Accept': 'text/event-stream' },
+          credentials: 'same-origin',
+          body: form,
+          signal: controller.signal,
+        })
+      } else {
+        resp = await fetch('/api/talk/message/stream', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Accept': 'text/event-stream' },
+          credentials: 'same-origin',
+          body: JSON.stringify({ text: clean }),
+          signal: controller.signal,
+        })
+      }
       if (resp.status === 401) {
         setStatus('expired')
         setStatusText('Session expired. Scan the owner card again.')
@@ -355,9 +397,32 @@ export default function DreamTalk() {
     setRecording(false)
   }
 
+  const handleAttachmentPicked = useCallback((file) => {
+    if (!file || sending || status === 'expired') return
+    const isImage = (file.type || '').startsWith('image/')
+    const previewUrl = isImage ? URL.createObjectURL(file) : null
+    setPendingAttachment(prev => {
+      // Revoke a previous blob URL before swapping in a new one so the
+      // browser can GC the old image bytes.
+      if (prev?.previewUrl) URL.revokeObjectURL(prev.previewUrl)
+      return { file, previewUrl, kind: isImage ? 'image' : 'text', name: file.name || 'attachment' }
+    })
+  }, [sending, status])
+
+  const clearPendingAttachment = useCallback(() => {
+    setPendingAttachment(prev => {
+      if (prev?.previewUrl) URL.revokeObjectURL(prev.previewUrl)
+      return null
+    })
+  }, [])
+
   const submit = (event) => {
     event.preventDefault()
-    sendText(input)
+    if (pendingAttachment) {
+      sendText(input, { attachment: pendingAttachment })
+    } else {
+      sendText(input)
+    }
   }
 
   const retryLast = () => {
@@ -365,7 +430,9 @@ export default function DreamTalk() {
     if (lastUser) sendText(lastUser.text)
   }
 
-  const canSend = input.trim().length > 0 && !sending && status !== 'expired'
+  // Send is enabled either with text OR an attachment (an image alone is a
+  // valid message — the model gets a default "describe this" prompt).
+  const canSend = (input.trim().length > 0 || pendingAttachment) && !sending && status !== 'expired'
 
   return (
     <div className="min-h-dvh bg-[#f8faf8] text-zinc-950 antialiased">
@@ -434,27 +501,42 @@ export default function DreamTalk() {
         )}
 
         <form onSubmit={submit} className="sticky bottom-0 border-t border-zinc-200 bg-[#f8faf8]/95 p-3 backdrop-blur">
+          {/* Attachment preview strip — appears above the input bar between
+              pick and send. Shows a thumbnail for images, a generic icon for
+              text/code files, with an X to discard. */}
+          {pendingAttachment && (
+            <AttachmentPreview
+              attachment={pendingAttachment}
+              onClear={() => clearPendingAttachment()}
+            />
+          )}
           <div className="flex items-end gap-2 rounded-[1.75rem] border border-zinc-200 bg-white p-2 shadow-sm">
             <input
               ref={fileInputRef}
               type="file"
-              accept="audio/*"
-              capture
+              // Image-first attach UX. ``capture`` is deliberately NOT set —
+              // its presence makes iOS Safari open the camera/video recorder
+              // instead of the file/photo picker, which was the cause of the
+              // earlier "paperclip opens video mode" UX bug. Accept list is
+              // narrow on purpose: images for vision, common code/text files
+              // for inline context. PDFs/docx need a parser dependency we
+              // haven't added yet.
+              accept="image/*,.txt,.md,.markdown,.csv,.json,.yaml,.yml,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh"
               className="hidden"
               onChange={event => {
                 const file = event.target.files?.[0]
                 event.target.value = ''
-                if (file) sendAudioFile(file)
+                if (file) handleAttachmentPicked(file)
               }}
-              aria-label="Choose audio message"
+              aria-label="Attach image or file"
             />
             <button
               type="button"
               onClick={() => fileInputRef.current?.click()}
-              disabled={sending || status === 'expired'}
+              disabled={sending || status === 'expired' || pendingAttachment}
               className="grid h-11 w-11 shrink-0 place-items-center rounded-full text-zinc-500 disabled:opacity-40"
-              aria-label="Attach voice message"
-              title="Voice message"
+              aria-label="Attach image or file"
+              title="Attach image or file"
             >
               <Paperclip size={19} />
             </button>
@@ -543,7 +625,21 @@ function MessageBubble({ message }) {
           // User messages and error bubbles stay as plain text — markdown
           // in those contexts would let typos render as headings or
           // accidental bold, which we don't want.
-          <p className="whitespace-pre-wrap break-words">{message.text}</p>
+          <>
+            {message.imageUrl && (
+              <img
+                src={message.imageUrl}
+                alt="Attached"
+                className="mb-2 max-h-72 max-w-full rounded-lg object-contain"
+              />
+            )}
+            {message.fileName && !message.imageUrl && (
+              <p className="mb-2 inline-flex items-center gap-1.5 rounded-md bg-zinc-800/80 px-2 py-1 text-xs">
+                <Paperclip size={12} />{message.fileName}
+              </p>
+            )}
+            {message.text && <p className="whitespace-pre-wrap break-words">{message.text}</p>}
+          </>
         ) : (
           <div className="space-y-0 text-[15px] leading-6">
             <ReactMarkdown components={MARKDOWN_COMPONENTS}>{message.text}</ReactMarkdown>
@@ -553,6 +649,41 @@ function MessageBubble({ message }) {
           <p className="mt-2 text-xs text-amber-600">{message.warning}</p>
         )}
       </div>
+    </div>
+  )
+}
+
+function AttachmentPreview({ attachment, onClear }) {
+  // Strip rendered above the input bar between picking a file and pressing
+  // Send. Lets the user see what they're about to attach + add a caption +
+  // back out cleanly with the X button.
+  const isImage = attachment.kind === 'image'
+  return (
+    <div className="mb-2 flex items-center gap-2 rounded-xl border border-zinc-200 bg-white px-2 py-1.5 shadow-sm">
+      {isImage ? (
+        <img
+          src={attachment.previewUrl}
+          alt="Attachment preview"
+          className="h-12 w-12 shrink-0 rounded-md object-cover"
+        />
+      ) : (
+        <div className="grid h-12 w-12 shrink-0 place-items-center rounded-md bg-zinc-100 text-zinc-500">
+          <Paperclip size={18} />
+        </div>
+      )}
+      <div className="min-w-0 flex-1 text-sm">
+        <p className="truncate font-medium text-zinc-900">{attachment.name}</p>
+        <p className="text-xs text-zinc-500">{isImage ? 'Image' : 'File'}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onClear}
+        className="grid h-8 w-8 place-items-center rounded-full text-zinc-500 hover:bg-zinc-100"
+        aria-label="Remove attachment"
+        title="Remove"
+      >
+        ✕
+      </button>
     </div>
   )
 }

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -177,6 +177,7 @@ export default function DreamTalk() {
         text: clean,
         imageUrl: attachment?.kind === 'image' ? attachment.previewUrl : null,
         fileName: attachment?.kind === 'text' ? attachment.name : null,
+        attachmentForRetry: attachment,
         status: 'done',
       }])
     }
@@ -427,7 +428,7 @@ export default function DreamTalk() {
 
   const retryLast = () => {
     const lastUser = [...messages].reverse().find(message => message.role === 'user' && message.status !== 'pending')
-    if (lastUser) sendText(lastUser.text)
+    if (lastUser) sendText(lastUser.text, { attachment: lastUser.attachmentForRetry || null })
   }
 
   // Send is enabled either with text OR an attachment (an image alone is a

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
@@ -267,8 +267,8 @@ describe('DreamTalk', () => {
 
     // Pick a fake image file via the hidden file input.
     const fileInput = container.querySelector('input[type="file"]')
-    const blob = new Blob([new Uint8Array([137, 80, 78, 71])], { type: 'image/png' })
-    const file = new File([blob], 'photo.png', { type: 'image/png' })
+    const blob = new globalThis.Blob([new Uint8Array([137, 80, 78, 71])], { type: 'image/png' })
+    const file = new globalThis.File([blob], 'photo.png', { type: 'image/png' })
     fireEvent.change(fileInput, { target: { files: [file] } })
 
     // Preview strip shows the filename + an X button to discard.
@@ -285,13 +285,65 @@ describe('DreamTalk', () => {
     expect(await screen.findByText('A red square.')).toBeInTheDocument()
     // Backend was hit on the attachment endpoint with FormData.
     expect(attachmentRequest).not.toBeNull()
-    expect(attachmentRequest.body).toBeInstanceOf(FormData)
+    expect(attachmentRequest.body).toBeInstanceOf(globalThis.FormData)
     expect(attachmentRequest.body.get('file')).toBeTruthy()
     expect(attachmentRequest.body.get('text')).toBe('What color is this?')
     // The user's bubble shows the image inline.
     const userImg = container.querySelector('img[alt="Attached"]')
     expect(userImg).toBeTruthy()
     expect(userImg.getAttribute('src')).toMatch(/^blob:/)
+  })
+
+  test('retry keeps image attachment context after an attachment stream error', async () => {
+    vi.stubGlobal('URL', {
+      ...globalThis.URL,
+      createObjectURL: () => 'blob:retry-image',
+      revokeObjectURL: () => {},
+    })
+
+    let attachmentRequests = 0
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })
+      if (url === '/api/talk/attachment' && options.method === 'POST') {
+        attachmentRequests += 1
+        expect(options.body).toBeInstanceOf(globalThis.FormData)
+        expect(options.body.get('file')).toBeTruthy()
+        expect(options.body.get('text')).toBe('What color is this?')
+        if (attachmentRequests === 1) {
+          return sseResponse([
+            { type: 'session', session_id: 'vision-oneshot' },
+            { type: 'error', status_code: 502, detail: 'Vision timed out.' },
+            { type: 'done' },
+          ])
+        }
+        return sseResponse([
+          { type: 'session', session_id: 'vision-oneshot' },
+          { type: 'delta', text: 'A red square.' },
+          { type: 'complete', session_id: 'vision-oneshot', text: 'A red square.', status: 'ok' },
+          { type: 'done' },
+        ])
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = render(<DreamTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+
+    const fileInput = container.querySelector('input[type="file"]')
+    const blob = new globalThis.Blob([new Uint8Array([137, 80, 78, 71])], { type: 'image/png' })
+    const file = new globalThis.File([blob], 'photo.png', { type: 'image/png' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+    fireEvent.change(screen.getByPlaceholderText('Message Dream Server'), {
+      target: { value: 'What color is this?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    expect(await screen.findByText('Vision timed out.')).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry last message' }))
+
+    expect(await screen.findByText('A red square.')).toBeInTheDocument()
+    expect(attachmentRequests).toBe(2)
   })
 
   test('surfaces SSE error frame as an assistant error', async () => {

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.test.jsx
@@ -232,6 +232,68 @@ describe('DreamTalk', () => {
     expect(screen.queryByText('Thinking…')).not.toBeInTheDocument()
   })
 
+  test('attaching an image POSTs to /api/talk/attachment + shows preview + renders user image', async () => {
+    // Stub URL.createObjectURL so the blob: URL the SPA generates for the
+    // preview doesn't break jsdom (which has no blob support by default).
+    const createdUrls = []
+    vi.stubGlobal('URL', {
+      ...globalThis.URL,
+      createObjectURL: (blob) => {
+        const url = `blob:test-${createdUrls.length}`
+        createdUrls.push({ url, blob })
+        return url
+      },
+      revokeObjectURL: () => {},
+    })
+
+    let attachmentRequest = null
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })
+      if (url === '/api/talk/attachment' && options.method === 'POST') {
+        attachmentRequest = options
+        return sseResponse([
+          { type: 'session', session_id: 'vision-oneshot' },
+          { type: 'delta', text: 'A red square.' },
+          { type: 'complete', session_id: 'vision-oneshot', text: 'A red square.', status: 'ok' },
+          { type: 'done' },
+        ])
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = render(<DreamTalk />)
+    expect(await screen.findByText('Ready')).toBeInTheDocument()
+
+    // Pick a fake image file via the hidden file input.
+    const fileInput = container.querySelector('input[type="file"]')
+    const blob = new Blob([new Uint8Array([137, 80, 78, 71])], { type: 'image/png' })
+    const file = new File([blob], 'photo.png', { type: 'image/png' })
+    fireEvent.change(fileInput, { target: { files: [file] } })
+
+    // Preview strip shows the filename + an X button to discard.
+    expect(await screen.findByText('photo.png')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Remove attachment' })).toBeInTheDocument()
+
+    // Add a caption and send.
+    fireEvent.change(screen.getByPlaceholderText('Message Dream Server'), {
+      target: { value: 'What color is this?' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }))
+
+    // Assistant reply renders.
+    expect(await screen.findByText('A red square.')).toBeInTheDocument()
+    // Backend was hit on the attachment endpoint with FormData.
+    expect(attachmentRequest).not.toBeNull()
+    expect(attachmentRequest.body).toBeInstanceOf(FormData)
+    expect(attachmentRequest.body.get('file')).toBeTruthy()
+    expect(attachmentRequest.body.get('text')).toBe('What color is this?')
+    // The user's bubble shows the image inline.
+    const userImg = container.querySelector('img[alt="Attached"]')
+    expect(userImg).toBeTruthy()
+    expect(userImg.getAttribute('src')).toMatch(/^blob:/)
+  })
+
   test('surfaces SSE error frame as an assistant error', async () => {
     const fetchMock = vi.fn(async (url, options = {}) => {
       if (url === '/api/talk/status') return response({ capabilities: { text_chat: true } })
@@ -290,7 +352,10 @@ describe('DreamTalk', () => {
 
     expect(await screen.findByText('Ready')).toBeInTheDocument()
     expect(screen.getByText(/Live mic needs HTTPS/i)).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'Attach voice message' })).toBeEnabled()
+    // Paperclip is now the general image/file attach button (it used to be
+    // mis-wired to "Attach voice message" + capture, which made iOS open
+    // the video recorder).
+    expect(screen.getByRole('button', { name: 'Attach image or file' })).toBeEnabled()
     expect(screen.queryByRole('button', { name: 'Record voice' })).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

Operator feedback after a phone-side session: *"The paperclip icon on the chat box where you'd add files or attachments etc just takes you into video mode randomly on your phone. Should allow you to upload images and files etc. yeah?"*

Right on both counts. The button was wired to `<input type="file" accept="audio/*" capture>` — the `capture` attribute on iOS Safari forces the camera/video recorder instead of a file picker, and `accept="audio/*"` meant it was always a voice-attachment button masquerading as a general one. UX has been confusing since #1319.

Reworks the paperclip into an actual general-attachment surface **and** plumbs the backend through to **real vision** on Qwen3.6-35B-A3B's native vision encoder.

## What's in this PR

1. **SPA paperclip rewire** — `<input accept="image/*,.txt,.md,.csv,.json,.yaml,.yml,.log,.py,.js,.ts,.tsx,.jsx,.html,.css,.sh">`, no `capture`, label is now "Attach image or file". New `<AttachmentPreview>` strip above the input bar with thumbnail + filename + ✕-to-remove. User bubble renders attached images inline (`object-contain max-h-72`).

2. **New backend endpoint `/api/talk/attachment`** — multipart `file` + optional `text` caption. Same SSE response shape as `/api/talk/message/stream` so the SPA's existing event-stream loop handles both paths. Routing:
   - **Images** → multimodal one-shot to the vision backend (default Lemonade direct at `http://llama-server:8080`, **not** litellm — litellm's `*` wildcard collapses our `user.*` model id down to whatever's currently loaded, silently downgrading vision queries to the text-only model). Bypasses Hermes because `prompt.submit` only takes text.
   - **Text-like files** (.md/.txt/.json/code/etc.) → content decoded, inlined into the user prompt with the caption, routed through the existing Hermes bridge so the agent retains tools, memory, and the connection pool.
   - Anything else → 415 with a helpful error.

3. **Compose env** in `docker-compose.base.yml`:
   - `DREAM_TALK_VISION_URL` (default `http://llama-server:8080`)
   - `DREAM_TALK_VISION_KEY` (default empty)
   - `DREAM_TALK_VISION_MODEL` (default `user.Qwen3.6-35B-A3B-Vision`)

## How vision actually got working (Lemonade plumbing — discovered during live testing)

Qwen3.6-35B-A3B is natively vision-capable upstream (HuggingFace `pipeline_tag: image-text-to-text`), but the GGUF quant we ship (`Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`) is text-only — the vision encoder lives in a separate ~0.9 GB `mmproj-F16.gguf` file from the same unsloth repo. To make it work on strix:

```
$ lemonade pull user.Qwen3.6-35B-A3B-Vision \
    --checkpoint main unsloth/Qwen3.6-35B-A3B-GGUF:Qwen3.6-35B-A3B-UD-Q4_K_M.gguf \
    --checkpoint mmproj unsloth/Qwen3.6-35B-A3B-GGUF:mmproj-F16.gguf \
    --recipe llamacpp --label vision

$ sed -i 's|^  default: .*|  default: "user.Qwen3.6-35B-A3B-Vision"|' /opt/data/config.yaml
$ dream restart hermes
```

Lemonade auto-launches llama-server with `--mmproj /…/mmproj-F16.gguf` on first multimodal call. Same chat session handles text-only turns transparently — no mode switching from the operator's perspective.

Installer auto-wiring on fresh AMD installs is a separate follow-up.

## Live verification on strix

| input | output | elapsed |
|---|---|---|
| 32×32 blue PNG (RGB 50,80,220), "What color?" | *"**solid blue** … `#3B7DD8` (approximate), `59, 125, 216`, often called 'Azure' or 'Steel Blue'."* | 3 s, 143 deltas |
| project-notes.md, "Summarize in one sentence" | *"The team needs to ship the attachment feature soon, and the paperclip icon should work as the UI element."* | 3 s |

Real vision, identified hex within 3 RGB values of the actual color.

## Tests

- **Backend**: +5 tests, 28/28 passing.
  - text attachment routes through Hermes with inlined content
  - unknown filetype → 415
  - image attachment routes to vision (asserts Hermes is **not** called)
  - oversize image → 413
  - attachment endpoint requires session cookie
- **Frontend**: +1 test, 10/10 passing.
  - picking an image shows preview strip with filename + ✕
  - send POSTs FormData to `/api/talk/attachment`
  - user bubble renders the image inline (`blob:` URL preserved)
  - Updated the live-mic-fallback test to look for the new "Attach image or file" label

## Risk / blast radius

- Compose change is additive (three new env vars with safe defaults).
- New endpoint is additive — existing `/api/talk/message/stream` unchanged.
- SPA changes: `accept` list narrower than before (`audio/*` → image+text), `capture` attribute removed (this is the actual bug fix). Voice attach was already broken/confusing for non-voice content; the recording-via-mic-button path (line 339) is preserved.
- Non-AMD hosts: `DREAM_TALK_VISION_MODEL` default points at `user.Qwen3.6-35B-A3B-Vision`. On a host without that registered, an image attach gets a 502 "vision unavailable" error frame and the rest of chat works fine.

## Follow-ups

- **Installer auto-wire**: phase 11 detects AMD/Lemonade installs and runs the `lemonade pull user.Qwen3.6-35B-A3B-Vision` command + updates Hermes config automatically. Currently a manual one-time operator step.
- **PDF / docx** parsing for text attachments — would need a parser dependency (pypdf2 / python-docx). Out of scope for v1 chat surface.
- **Vision on tower2 (NVIDIA, qwen3-coder-next)** — different model, different llama-server, would need its own vision-capable variant + plumbing.
