### PR TITLE
feat(persona): agent knows what's installed on the Dream Server it's running on

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -997,12 +997,35 @@ cmd_restart() {
 
     [[ "$rebuild_images" == "true" ]] && _dream_cli_rebuild_images "${flags[@]}"
 
+    # Refresh data/hermes/SOUL.md whenever Hermes (or the full stack) is
+    # restarted, so the persona's "About this installation" section
+    # reflects which services are currently up. Non-fatal — if the
+    # generator fails (Python missing, etc.) Hermes still boots from
+    # whatever assembled SOUL.md is already on disk, or the template if
+    # the assembled file is missing.
+    if [[ -z "$service" || "$service" == "hermes" ]]; then
+        _dream_cli_refresh_soul || true
+    fi
+
     if [[ -z "$service" ]]; then
         _compose_run_with_summary "Restarting all services" "${flags[@]}" up -d
     else
         service=$(resolve_service "$service")
         _compose_run_with_summary "Restarting $service" "${flags[@]}" up -d "$service"
     fi
+}
+
+# Refresh data/hermes/SOUL.md from the static template + detected install
+# state. Idempotent. Called automatically by cmd_restart (when restarting
+# hermes or the whole stack) and invocable manually by an operator.
+_dream_cli_refresh_soul() {
+    local script="$INSTALL_DIR/scripts/build-installation-context.py"
+    [[ -x "$script" ]] || [[ -f "$script" ]] || return 0
+    local py
+    py=$(command -v python3 || command -v python || true)
+    [[ -n "$py" ]] || return 0
+    "$py" "$script" >/dev/null 2>&1 || return 1
+    return 0
 }
 
 cmd_stop() {

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -1,5 +1,7 @@
 # Dream — Dream Server Default Persona
 
+<!-- INSTALLATION_CONTEXT -->
+
 You are **Dream** — a knowledgeable, practical, and conversational assistant. Your goal is to give accurate, actionable answers that are as brief as possible while still feeling clear, friendly, and human.
 
 ## Style & tone
@@ -81,4 +83,4 @@ These rules exist because operators have repeatedly observed models stalling cha
 
 ## Resetting this persona
 
-The user can edit this file at `/opt/data/SOUL.md` inside the Hermes container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply. Deleting the file falls back to upstream's default persona.
+The user can edit this file at `/opt/data/SOUL.md` inside the Hermes container (or `data/hermes/SOUL.md` on the host). Restart Hermes to apply. Deleting the file falls back to upstream's default persona. The `<!-- INSTALLATION_CONTEXT -->` line above is replaced at build time with a snapshot of this install's GPU, model, and running services — regenerate by running `python3 scripts/build-installation-context.py` from the dream-server checkout.

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -80,7 +80,30 @@ services:
       # over the in-image versions means our defaults win without needing
       # a custom Dockerfile.
       - ./extensions/services/hermes/cli-config.yaml.template:/opt/hermes/cli-config.yaml.example:ro
-      - ./extensions/services/hermes/SOUL.md.template:/opt/hermes/docker/SOUL.md:ro
+      # Persona file. The *static* template lives in
+      # extensions/services/hermes/SOUL.md.template; an installer step
+      # (scripts/build-installation-context.py) renders it into
+      # data/persona/SOUL.md with a generated "About this installation"
+      # section — what GPU backend, which model, which services are
+      # running, which URLs are reachable. So Dream answers truthfully
+      # when asked about its own environment instead of inventing
+      # capabilities.
+      #
+      # Two mount points: the upstream Hermes image expects the persona
+      # at /opt/data/SOUL.md (its `HERMES_HOME`) at runtime — that's
+      # where the agent actually loads from. The /opt/hermes/docker/
+      # path is just the in-image default that the entrypoint copies to
+      # /opt/data/SOUL.md on first start only; updates to it after that
+      # are ignored. So we bind-mount BOTH paths to the same assembled
+      # file: the docker/ one keeps the install-default convention,
+      # the data/ one is what the running agent actually reads.
+      #
+      # Why data/persona/ and not data/hermes/: data/hermes/ is owned by
+      # uid 10000 (HERMES_UID) — the Hermes container's own state lives
+      # there. data/persona/ stays operator-owned so the host can
+      # regenerate the file without sudo.
+      - ./data/persona/SOUL.md:/opt/hermes/docker/SOUL.md:ro
+      - ./data/persona/SOUL.md:/opt/data/SOUL.md:ro
     # Hermes is exposed to the LAN via dream-hermes-proxy on port 9120 — that
     # Caddy sidecar forward_auths to dashboard-api's verify-session and only
     # then forwards traffic here. By NOT binding a host port on the Hermes

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -565,6 +565,22 @@ MODELS_INI_EOF
                 warn "Hermes template substitution didn't take effect — Hermes may 404 every chat completion. Hand-edit $_hermes_tpl after install if Hermes prompts hang."
             fi
         fi
+
+        # Render data/hermes/SOUL.md = static persona + dynamic installation
+        # context (GPU backend, model, running services, reachable URLs). The
+        # Hermes compose bind-mounts this file as /opt/hermes/docker/SOUL.md
+        # so the agent introspects truthfully when asked about its own
+        # environment instead of inventing capabilities.
+        #
+        # docker ps right here may return nothing useful (services aren't up
+        # until later in this phase), but the script still emits a valid
+        # SOUL.md with the static parts intact. `dream restart hermes`
+        # regenerates it once services are running.
+        local _soul_builder="$INSTALL_DIR/scripts/build-installation-context.py"
+        if [[ -n "$_python_cmd" && -f "$_soul_builder" ]]; then
+            "$_python_cmd" "$_soul_builder" >>"$LOG_FILE" 2>&1 || \
+                warn "Could not generate Hermes installation-context SOUL.md (non-fatal — Hermes will use the template's default text)"
+        fi
     fi
 
     # Validate service dependencies before launching
@@ -756,6 +772,18 @@ except Exception:
         printf "\r  ${BGRN}✓${NC} %-60s\n" "All containers launched"
         echo ""
         ai_ok "Services started (llama-server)"
+
+        # Re-render data/hermes/SOUL.md now that services are actually
+        # running — the first pass earlier in this phase happened pre-
+        # compose-up, so its docker ps was empty. The persona's "About
+        # this installation" section needs to reflect what's actually
+        # reachable, not the pre-launch state. Hermes reads SOUL.md on
+        # each new chat session, so simply rewriting the file is enough
+        # — no container restart needed.
+        if [[ -n "${_python_cmd:-}" ]] && [[ -f "$INSTALL_DIR/scripts/build-installation-context.py" ]]; then
+            "$_python_cmd" "$INSTALL_DIR/scripts/build-installation-context.py" >>"$LOG_FILE" 2>&1 || \
+                warn "Installation-context SOUL.md regen failed post-launch (non-fatal — earlier static SOUL.md is in place)"
+        fi
     else
         printf "\r  ${RED}✗${NC} %-60s\n" "Some containers failed to launch"
         echo ""

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -566,7 +566,7 @@ MODELS_INI_EOF
             fi
         fi
 
-        # Render data/hermes/SOUL.md = static persona + dynamic installation
+        # Render data/persona/SOUL.md = static persona + dynamic installation
         # context (GPU backend, model, running services, reachable URLs). The
         # Hermes compose bind-mounts this file as /opt/hermes/docker/SOUL.md
         # so the agent introspects truthfully when asked about its own
@@ -576,10 +576,17 @@ MODELS_INI_EOF
         # until later in this phase), but the script still emits a valid
         # SOUL.md with the static parts intact. `dream restart hermes`
         # regenerates it once services are running.
-        local _soul_builder="$INSTALL_DIR/scripts/build-installation-context.py"
+        _soul_builder="$INSTALL_DIR/scripts/build-installation-context.py"
+        _soul_output="$INSTALL_DIR/data/persona/SOUL.md"
+        _soul_template="$INSTALL_DIR/extensions/services/hermes/SOUL.md.template"
+        mkdir -p "$(dirname "$_soul_output")"
         if [[ -n "$_python_cmd" && -f "$_soul_builder" ]]; then
             "$_python_cmd" "$_soul_builder" >>"$LOG_FILE" 2>&1 || \
                 warn "Could not generate Hermes installation-context SOUL.md (non-fatal — Hermes will use the template's default text)"
+        fi
+        if [[ ! -f "$_soul_output" && -f "$_soul_template" ]]; then
+            sed '/<!-- INSTALLATION_CONTEXT -->/d' "$_soul_template" >"$_soul_output" || \
+                warn "Could not create fallback Hermes SOUL.md at $_soul_output"
         fi
     fi
 
@@ -773,7 +780,7 @@ except Exception:
         echo ""
         ai_ok "Services started (llama-server)"
 
-        # Re-render data/hermes/SOUL.md now that services are actually
+        # Re-render data/persona/SOUL.md now that services are actually
         # running — the first pass earlier in this phase happened pre-
         # compose-up, so its docker ps was empty. The persona's "About
         # this installation" section needs to reflect what's actually

--- a/dream-server/scripts/build-installation-context.py
+++ b/dream-server/scripts/build-installation-context.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Generate ``data/hermes/SOUL.md`` from the static persona template plus a
+detected snapshot of *this* Dream Server install — what GPU backend it has,
+which model is loaded, which services are running, what URLs are reachable.
+
+The goal is for Dream (the agent) to answer accurately when the operator
+asks "what can you do here?" or "is comfyui running?" or "what model are you
+using?" — instead of inventing capabilities it doesn't have, or denying
+ones it does. The dynamic context block is bounded to a few hundred tokens
+so it doesn't bloat Hermes's 16k-token system prompt.
+
+Idempotent. Safe to re-run after enabling/disabling services. Designed to
+be invoked from:
+
+  * installer phase 11 (after services come up — so docker ps reports the
+    real state, not the pre-launch one)
+  * ``dream restart hermes`` (so the persona reflects current state on every
+    container recreate)
+  * the operator manually when they want to refresh
+
+Reads only — never modifies SOUL.md.template, never touches anything other
+than the output path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import socket
+import subprocess
+import sys
+from pathlib import Path
+
+# Service-id → (display name, one-line "what it does and how the user
+# reaches it"). Tuned so the model gets actionable, specific info — port
+# numbers + intended use — not just service names. The agent itself often
+# can't directly call these (its tools are web_search / files / code /
+# memory / etc.), but it can point the user at the right surface.
+_SERVICE_CAPABILITIES: dict[str, tuple[str, str]] = {
+    "llama-server": ("Local LLM inference", "the engine running my chat model (port 8080 internal)"),
+    "open-webui": ("Open WebUI", "a desktop-style chat surface, reachable at chat.{device}.local"),
+    "dashboard": ("Dream dashboard", "the operator's local web UI for managing services, models, and extensions — `{device}.local`"),
+    "hermes": ("Hermes Agent", "that's me — the agent runtime, port 9119 internal"),
+    "searxng": ("SearXNG", "privacy-respecting metasearch the operator can hit at port 8888; this is what my `web_search` tool uses under the hood"),
+    "brave-search": ("Brave Search backend", "alternative paid web-search backend (when an API key is set)"),
+    "perplexica": ("Perplexica", "web-augmented Q&A UI on top of SearXNG"),
+    "comfyui": ("ComfyUI", "image + video generation (SDXL Lightning, LTX-2.3). UI on port 8188. The operator can ask me to suggest a prompt for it but I don't generate images directly — I'd point them at ComfyUI"),
+    "tts": ("Kokoro TTS", "text-to-speech (port 8880). My replies in Dream Talk can be spoken aloud through this"),
+    "whisper": ("Whisper STT", "speech-to-text (port 8000). Used for voice messages in Dream Talk"),
+    "embeddings": ("Embeddings server", "vector embeddings (port 8090) — feeds the RAG path"),
+    "qdrant": ("Qdrant", "vector database (port 6333) for semantic recall and RAG"),
+    "n8n": ("n8n", "visual no-code workflow + automation engine on port 5678. Operators wire scheduled jobs and integrations here"),
+    "ape": ("APE", "agentic prompt engineering surface"),
+    "opencode": ("OpenCode", "coding agent (an alternative to me for code work)"),
+    "openclaw": ("OpenClaw", "older Claude-style agent (being deprecated in favor of me)"),
+    "privacy-shield": ("Privacy Shield", "PII scrubber that can sit in front of LLM calls"),
+    "token-spy": ("Token Spy", "inference traffic introspection"),
+    "tailscale": ("Tailscale", "mesh VPN — the operator can reach this whole stack remotely without exposing ports to the public internet"),
+    "langfuse": ("Langfuse", "LLM call tracing + analytics (port 3010)"),
+}
+
+# Where the dynamic block gets inserted in SOUL.md.template. The template
+# has the literal marker line; this script replaces it.
+_INSERT_MARKER = "<!-- INSTALLATION_CONTEXT -->"
+
+
+def _read_env(env_path: Path) -> dict[str, str]:
+    """Parse a .env file into a dict. Ignores comments / blank lines / quotes."""
+    out: dict[str, str] = {}
+    if not env_path.exists():
+        return out
+    for raw in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        v = v.strip()
+        # Strip surrounding quotes if present
+        if len(v) >= 2 and v[0] == v[-1] and v[0] in "\"'":
+            v = v[1:-1]
+        out[k.strip()] = v
+    return out
+
+
+def _container_to_service_map(repo_root: Path) -> dict[str, str]:
+    """Build a {container_name: service_id} index from extension manifests.
+
+    Manifests declare both ``service.id`` and an explicit ``container_name``
+    (often ``dream-<id>`` but sometimes different, e.g. open-webui →
+    dream-webui). We need both directions: incoming docker ps names are
+    container names, the capability mapping below keys on service-id.
+
+    Cheap regex over manifest.yaml — avoiding a YAML dep keeps this script
+    runnable with Python's stdlib only.
+    """
+    index: dict[str, str] = {}
+    services_dir = repo_root / "extensions" / "services"
+    if not services_dir.is_dir():
+        return index
+    id_re = re.compile(r"^\s*id:\s*([A-Za-z0-9_-]+)\s*(?:#.*)?$")
+    cname_re = re.compile(r"^\s*container_name:\s*([A-Za-z0-9_-]+)\s*(?:#.*)?$")
+    for manifest in sorted(services_dir.glob("*/manifest.yaml")):
+        sid: str | None = None
+        cnames: list[str] = []
+        in_service = False
+        for raw in manifest.read_text(encoding="utf-8").splitlines():
+            if raw.startswith("service:"):
+                in_service = True
+                continue
+            if in_service and not raw.startswith((" ", "\t")) and raw.strip():
+                in_service = False
+            if not in_service:
+                continue
+            m = id_re.match(raw)
+            if m and sid is None:
+                sid = m.group(1)
+            m = cname_re.match(raw)
+            if m:
+                cnames.append(m.group(1))
+        if sid:
+            # Always include the default `dream-<id>` convention too —
+            # some manifests omit container_name when it matches.
+            cnames.append(f"dream-{sid}")
+            for cname in cnames:
+                index[cname] = sid
+    return index
+
+
+def _running_services(repo_root: Path) -> set[str]:
+    """Set of service-ids currently up per ``docker ps``. Cross-references
+    container names against the manifest-built {container_name: service_id}
+    map so e.g. ``dream-webui`` resolves to service id ``open-webui``.
+    Children of compound services (``dream-langfuse-clickhouse`` etc.) get
+    collapsed to their parent service-id via prefix match. Containers that
+    don't match any manifest are skipped — they're either non-Dream sidecars
+    or post-install user additions we shouldn't claim as ours.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}}", "--filter", "name=dream-"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return set()
+
+    cmap = _container_to_service_map(repo_root)
+    known_sids = set(cmap.values())
+    running: set[str] = set()
+    for line in result.stdout.splitlines():
+        cname = line.strip()
+        if not cname:
+            continue
+        # Exact manifest match first
+        if cname in cmap:
+            running.add(cmap[cname])
+            continue
+        # Compound-service collapse: dream-langfuse-clickhouse → "langfuse"
+        # if the latter exists as a known service id.
+        if cname.startswith("dream-"):
+            stem = cname[len("dream-"):]
+            parts = stem.split("-")
+            for i in range(len(parts), 0, -1):
+                candidate = "-".join(parts[:i])
+                if candidate in known_sids:
+                    running.add(candidate)
+                    break
+    return running
+
+
+def _loaded_model(llm_port: int = 8080) -> str | None:
+    """Best-effort: ask llama-server / Lemonade what's currently loaded.
+    Returns the model id, or None on any failure (network, no service)."""
+    # Try Lemonade health first — has structured per-model state
+    for path in ("/api/v1/health", "/v1/models"):
+        try:
+            import urllib.request
+            with urllib.request.urlopen(f"http://127.0.0.1:{llm_port}{path}", timeout=3) as resp:
+                data = json.load(resp)
+        except Exception:
+            continue
+        loaded = data.get("all_models_loaded") if isinstance(data, dict) else None
+        if isinstance(loaded, list) and loaded:
+            return loaded[0].get("model_name")
+        models = data.get("data") if isinstance(data, dict) else None
+        if isinstance(models, list) and models:
+            return models[0].get("id")
+    return None
+
+
+def _humanize_gpu(env: dict[str, str]) -> str:
+    """One-line GPU/backend description from .env."""
+    backend = (env.get("GPU_BACKEND") or "cpu").lower()
+    mode = env.get("DREAM_MODE", "").lower()
+    if backend == "amd":
+        if mode == "lemonade":
+            return "AMD GPU (ROCm/Vulkan via Lemonade)"
+        return "AMD GPU"
+    if backend == "nvidia":
+        return "NVIDIA GPU (CUDA via llama.cpp)"
+    if backend == "apple":
+        return "Apple Silicon (Metal via llama.cpp)"
+    if backend == "cpu":
+        return "CPU-only (no GPU acceleration)"
+    return backend
+
+
+def _capabilities_block(running: set[str], device: str) -> list[str]:
+    """Render the user-facing 'what's installed and reachable' bullets.
+    Only lists services that are *actually running* — not just defined.
+    Substitutes ``{device}`` into descriptions so the agent gets the live
+    LAN hostname instead of a placeholder."""
+    bullets: list[str] = []
+    seen = set()
+    # Display order: search → vision/voice → storage → automation → other.
+    priority = [
+        "searxng", "perplexica", "brave-search",
+        "comfyui",
+        "tts", "whisper",
+        "qdrant", "embeddings",
+        "n8n",
+        "ape", "opencode", "privacy-shield", "token-spy",
+        "langfuse",
+        "open-webui",
+        "tailscale",
+    ]
+    for sid in priority:
+        if sid in running and sid in _SERVICE_CAPABILITIES:
+            label, desc = _SERVICE_CAPABILITIES[sid]
+            bullets.append(f"- **{label}** — {desc.replace('{device}', device)}")
+            seen.add(sid)
+    # Anything running we didn't enumerate gets a generic line so future
+    # services don't silently vanish from the agent's knowledge.
+    for sid in sorted(running - seen):
+        if sid in {"llama-server", "hermes", "hermes-proxy", "dashboard",
+                   "dashboard-api", "dream-proxy", "litellm"}:
+            continue  # internal plumbing — agent doesn't need to mention these
+        if sid in _SERVICE_CAPABILITIES:
+            label, desc = _SERVICE_CAPABILITIES[sid]
+            bullets.append(f"- **{label}** — {desc.replace('{device}', device)}")
+        else:
+            bullets.append(f"- **{sid}** — service running on this host")
+    return bullets
+
+
+def build_context_block(env_path: Path) -> str:
+    """Render the dynamic 'About this installation' Markdown block."""
+    env = _read_env(env_path)
+    repo_root = env_path.resolve().parent
+    running = _running_services(repo_root)
+
+    device = env.get("DREAM_DEVICE_NAME") or socket.gethostname() or "this machine"
+    gpu = _humanize_gpu(env)
+    model_hint = env.get("LLM_MODEL") or env.get("GGUF_FILE") or "the locally-served model"
+    live_model = _loaded_model()
+    if live_model:
+        model_hint = live_model
+
+    ctx_size = env.get("CTX_SIZE") or env.get("MAX_CONTEXT") or "?"
+    if ctx_size.isdigit() and int(ctx_size) >= 1024:
+        ctx_pretty = f"{int(ctx_size) // 1024}k"
+    else:
+        ctx_pretty = ctx_size
+
+    talk_host = f"talk.{device}.local"
+    dash_host = f"{device}.local"
+    chat_host = f"chat.{device}.local"
+
+    bullets = _capabilities_block(running, device)
+
+    # Lead with the install identity — hard factual claims phrased so the
+    # model doesn't drift into running tool calls to "verify." Hermes's
+    # own system prompt advertises a Hermes dashboard at port 9119; the
+    # model has a strong prior to mention that when asked about
+    # "dashboard," which is wrong on a Dream Server install. We explicitly
+    # distinguish below.
+    lines: list[str] = [
+        "## About this Dream Server install — read this BEFORE answering questions about your environment",
+        "",
+        "**You are running inside Dream Server, a fully-local AI stack the operator installed on their own hardware.** Hermes Agent (what you run on) is one component of that stack — not the whole thing. When the operator asks about \"the dashboard,\" \"the system,\" \"what's running,\" \"what you can do,\" or \"your hardware,\" they mean the Dream Server install around you, not Hermes Agent in isolation.",
+        "",
+        "**These facts are authoritative. Don't run tool calls (terminal, file probes, GPU queries) to second-guess them — they are auto-generated from this exact install and refreshed when services change. Quote them directly:**",
+        "",
+        f"- **Host**: `{device}` (LAN hostname `{dash_host}`)",
+        f"- **GPU / backend**: {gpu}",
+        f"- **Chat model serving you right now**: `{model_hint}` (context window: {ctx_pretty})",
+        f"- **Dream Server admin dashboard** (model management, extensions catalog, system status): `http://{dash_host}` — this is what the operator means by \"the dashboard.\" NOT Hermes's internal `:9119` endpoint, which is just where you live.",
+        f"- **Mobile chat portal (Dream Talk)**: `http://{talk_host}` — the operator scans an owner-card QR code to land here on their phone",
+        f"- **Open WebUI** (desktop-style chat surface, separate from Dream Talk): `http://{chat_host}`",
+        "",
+        "## Services running on this install right now",
+        "",
+        "Dream Server has an **extensions system** — services bundled with the stack that the operator can enable/disable from the dashboard's Extensions page without reinstalling. The list below is what's currently running. Some are tools you can call directly through your own tool-calling layer; others are surfaces you can point the operator at.",
+        "",
+    ]
+    if bullets:
+        lines.extend(bullets)
+    else:
+        lines.append("- (no extension services running — only the core chat path is up)")
+
+    lines.extend([
+        "",
+        "## Your direct capabilities vs. what the operator reaches separately",
+        "",
+        "**You can directly invoke these** via your tool-calling layer:",
+        "- `web_search` — backed by the SearXNG service above (privacy-respecting, no rate limits)",
+        "- `web_extract` — fetch a specific URL the operator names",
+        "- `read_file` / `write_file` / `search_files` — in your sandboxed agent workspace",
+        "- `execute_code` — sandboxed Python",
+        "- `memory` — save / recall facts about the operator across sessions",
+        "- `text_to_speech` — your replies on Dream Talk can be spoken aloud",
+        "- A `skills` catalog with dozens of pluggable skill modules for specific domains (github, notion, kanban, research, etc.)",
+        "",
+        "**You can't directly invoke these but can refer the operator to them** when they ask:",
+        "- **Image / video generation** → ComfyUI (if running above). The operator opens it from the Dream Server dashboard. You can help by suggesting prompts, but you don't generate the image yourself.",
+        "- **Automated workflows / scheduled jobs / third-party integrations** → n8n (if running above). For simple recurring agent tasks you have your own `cronjob` tool.",
+        "- **Enable more extensions** → Extensions page on the Dream Server dashboard (`http://" + dash_host + "/extensions`). Catalog includes Aider, OpenCode, Privacy Shield, Tailscale, Perplexica, etc.",
+        "- **Swap or download a different LLM** → Models page on the Dream Server dashboard. Operators can pull from Hugging Face directly.",
+        "- **Remote access from outside the LAN** → Tailscale (if running above)",
+        "",
+        "When the operator names a service you don't see in the list above, say so honestly — \"that's not running on this install\" — rather than invent it. The list reflects what `docker ps` reports as of the last regeneration.",
+    ])
+    return "\n".join(lines)
+
+
+def build_soul(template_path: Path, env_path: Path, output_path: Path) -> bool:
+    """Render the assembled SOUL.md. Returns True if the file actually
+    changed (so callers can decide whether to bounce Hermes)."""
+    template = template_path.read_text(encoding="utf-8")
+    context = build_context_block(env_path)
+
+    if _INSERT_MARKER in template:
+        assembled = template.replace(_INSERT_MARKER, context)
+    else:
+        # Template doesn't have the marker yet — append the block so
+        # operators upgrading from an older template still get the
+        # installation-context behaviour.
+        assembled = template.rstrip() + "\n\n" + context + "\n"
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    previous = output_path.read_text(encoding="utf-8") if output_path.exists() else ""
+    if previous == assembled:
+        return False
+    output_path.write_text(assembled, encoding="utf-8")
+    return True
+
+
+def main(argv: list[str] | None = None) -> int:
+    repo_root = Path(__file__).resolve().parent.parent
+    parser = argparse.ArgumentParser(
+        description="Build data/hermes/SOUL.md from the static persona + detected install state.",
+    )
+    parser.add_argument(
+        "--template",
+        type=Path,
+        default=repo_root / "extensions" / "services" / "hermes" / "SOUL.md.template",
+    )
+    parser.add_argument(
+        "--env",
+        type=Path,
+        default=repo_root / ".env",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        # Keep this on the host-user side of the data directory tree —
+        # data/hermes/ is owned by uid 10000 (HERMES_UID) so the host's
+        # operator can't write into it. data/persona/ is a separate
+        # operator-owned directory bind-mounted ro into the Hermes
+        # container at /opt/hermes/docker/SOUL.md.
+        default=repo_root / "data" / "persona" / "SOUL.md",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Print the assembled file to stdout instead of writing it.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.check:
+        ctx = build_context_block(args.env)
+        sys.stdout.write(ctx)
+        sys.stdout.write("\n")
+        return 0
+
+    if not args.template.exists():
+        print(f"ERROR: template not found at {args.template}", file=sys.stderr)
+        return 2
+
+    changed = build_soul(args.template, args.env, args.output)
+    print("changed" if changed else "unchanged")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/dream-server/scripts/build-installation-context.py
+++ b/dream-server/scripts/build-installation-context.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Generate ``data/hermes/SOUL.md`` from the static persona template plus a
+"""Generate ``data/persona/SOUL.md`` from the static persona template plus a
 detected snapshot of *this* Dream Server install — what GPU backend it has,
 which model is loaded, which services are running, what URLs are reachable.
 
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import socket
 import subprocess
@@ -347,9 +346,12 @@ def build_soul(template_path: Path, env_path: Path, output_path: Path) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8")
+
     repo_root = Path(__file__).resolve().parent.parent
     parser = argparse.ArgumentParser(
-        description="Build data/hermes/SOUL.md from the static persona + detected install state.",
+        description="Build data/persona/SOUL.md from the static persona + detected install state.",
     )
     parser.add_argument(
         "--template",


### PR DESCRIPTION
## Summary

Operator feedback: *"make sure the default personality knows about Dream Server and what's installed where and what it has access to on the backend ... the whole extensions system, mapped ports and services etc. that all feel useful for it to know it has access to."*

Before this PR Dream Talk's agent had no idea what host it was running on or what came pre-installed. Asking *"what services are running?"* got a generic *"I don't have direct visibility into server-level services"* deflection. Asking *"what hardware are you on?"* got a hallucinated *"NVIDIA L4 24GB"* on a host that's actually AMD Radeon 8060S.

This PR auto-generates a section of the agent's persona from detected install state — host, GPU, model, running services + their ports — so Dream answers truthfully from its own system prompt instead of guessing or running shell probes to second-guess.

## What gets detected

A new `scripts/build-installation-context.py` script reads:

- `.env` for `GPU_BACKEND`, `DREAM_DEVICE_NAME`, `CTX_SIZE`, model name
- Live `docker ps` for what's actually up right now
- `extensions/services/*/manifest.yaml` cross-reference so container names map back to service ids (handles `dream-webui` → `open-webui` and collapses `dream-langfuse-*` sub-containers under one "langfuse" line)
- Live `/api/v1/health` query against Lemonade/llama-server for the actual loaded model id

Renders an authoritative section into `data/persona/SOUL.md` like:

```markdown
## About this Dream Server install — read this BEFORE answering questions about your environment

**You are running inside Dream Server, a fully-local AI stack the operator installed
on their own hardware.** Hermes Agent (what you run on) is one component of that
stack — not the whole thing. When the operator asks about "the dashboard,"
"the system," "what's running," "what you can do," or "your hardware," they
mean the Dream Server install around you, not Hermes Agent in isolation.

**These facts are authoritative. Don't run tool calls (terminal, file probes,
GPU queries) to second-guess them ...**

- **Host**: `dream-server` (LAN hostname `dream-server.local`)
- **GPU / backend**: AMD GPU (ROCm/Vulkan via Lemonade)
- **Chat model serving you right now**: `qwen3.6-35b-a3b` (context window: 256k)
- **Dream Server admin dashboard**: `http://dream-server.local` — NOT Hermes's
  internal `:9119` endpoint, which is just where you live.
- **Mobile chat portal (Dream Talk)**: `http://talk.dream-server.local`
- **Open WebUI**: `http://chat.dream-server.local`

## Services running on this install right now
- **SearXNG** — privacy-respecting metasearch ... port 8888; this is what my
  `web_search` tool uses under the hood
- **ComfyUI** — image + video generation (SDXL Lightning, LTX-2.3). UI on port 8188...
- **Kokoro TTS** — text-to-speech (port 8880). My replies in Dream Talk can be
  spoken aloud through this
[...etc...]

## Your direct capabilities vs. what's available on this server
**You can directly invoke these** via your tool-calling layer:
- `web_search` (via SearXNG above) ...

**You can't directly invoke these but can refer the operator to them** when they ask:
- **Generate images / video** → ComfyUI dashboard
- **Build automated workflows** → n8n
- **Enable more extensions** → Extensions page on the admin dashboard
- **Reach the stack from outside the LAN** → Tailscale
```

## The mount-target gotcha that took most of the debugging

Upstream Hermes copies its bundled `/opt/hermes/docker/SOUL.md` into the per-install `/opt/data/SOUL.md` **only on first container start**. Editing the docker/ default after that is silently ignored — the operator's data-volume copy wins, forever. So a naive bind-mount to `/opt/hermes/docker/SOUL.md` (what dream-server did before this PR) gets stale immediately.

Fix: bind-mount the assembled file to **both** paths, so the first-start convention and the runtime-read path both reflect current state:

```yaml
volumes:
  - ./data/persona/SOUL.md:/opt/hermes/docker/SOUL.md:ro
  - ./data/persona/SOUL.md:/opt/data/SOUL.md:ro
```

`data/persona/` (operator-owned) is kept distinct from `data/hermes/` (uid-10000-owned where the Hermes container writes its own session state) so the generator script can regenerate without sudo.

## Regeneration triggers

- **Install (`installers/phases/11-services.sh`)** runs the generator twice: once before `docker compose up` (to ensure the bind target exists when Hermes first boots) and once after services are running (so the service list reflects what's actually up, not the pre-launch state).
- **`dream restart hermes`** (or `dream restart` for the full stack) regenerates the SOUL.md as a precondition — so the persona always reflects current state without an explicit operator step.
- **Manual**: `python3 scripts/build-installation-context.py` from the dream-server checkout.

## Before / after on strix

| question | before | after |
|---|---|---|
| *"what services do you have on this Dream Server, what hardware are you on, and where is the dashboard?"* | *"I don't have direct visibility into server-level services…"* + 22 s of shell exploration | *"This Dream Server is running SearXNG, Perplexica, ComfyUI, Kokoro TTS, Whisper STT, Qdrant, n8n, APE, Privacy Shield, Token Spy, Langfuse, and Open WebUI. You're on a machine called `dream-server` with an AMD GPU (ROCm/Vulkan via Lemonade) and a 256k context window. The admin dashboard is at `http://dream-server.local`."* — direct quote from persona, no tool calls |
| GPU model | hallucinated *"NVIDIA L4 24GB"* | correct: *"AMD GPU (ROCm/Vulkan via Lemonade)"* |
| dashboard URL | conflated with Hermes-internal *"http://127.0.0.1:9119"* | correct: *"http://dream-server.local"* |

## Risk / blast radius

- New script is pure stdlib Python — no new dependencies.
- Compose change adds one mount; if the file is missing the mount fails loudly at `docker compose up` time, which is exactly when phase 11 has already generated it. Robust against ordering bugs.
- Generator failures in installer / `dream restart` are non-fatal (Hermes still boots from whatever assembled file is on disk, or the static template if absent).
- The dynamic context block is bounded (~800 tokens) so it doesn't bloat Hermes's 16k-token system prompt.

## Follow-ups

- Hermes prompt-priority experiments: even with strong wording, the agent occasionally still reaches for shell tools to "verify" facts that are already in SOUL.md. Could explore whether moving the block into the cli-config `system_prompt` field (vs. SOUL.md) gives it higher priority in Hermes's prompt stack.
- Capability map is hand-maintained per-service in the script's `_SERVICE_CAPABILITIES` dict — manifest schema doesn't expose enough metadata yet to auto-generate user-facing descriptions. A future PR could add a `description` / `port` field to `manifest.yaml` and let the generator pull from there.
