### PR TITLE
fix(persona): drop nested SOUL.md bind-mount that breaks Docker Desktop (virtiofs)

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1025,6 +1025,24 @@ _dream_cli_refresh_soul() {
     py=$(command -v python3 || command -v python || true)
     [[ -n "$py" ]] || return 0
     "$py" "$script" >/dev/null 2>&1 || return 1
+
+    # Push the updated assembled SOUL.md into the running container's
+    # data dir, where Hermes actually reads from at session.create
+    # time. The bind-mount target (/opt/hermes/docker/SOUL.md) is just
+    # the upstream-default that Hermes's entrypoint copies to
+    # /opt/data/SOUL.md ONLY on first start; the per-install file is
+    # what's read after that. macOS Docker Desktop's virtiofs refuses
+    # to bind-mount /opt/data/SOUL.md directly (nested-mount limit),
+    # so we use docker exec for the in-container copy — works on
+    # Linux + macOS uniformly. Container has to be running for this
+    # to matter; if it's not, the entrypoint will pick up the docker/
+    # default on next start anyway.
+    if command -v docker >/dev/null 2>&1; then
+        if docker ps --format '{{.Names}}' 2>/dev/null | grep -q '^dream-hermes$'; then
+            docker exec dream-hermes cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md \
+                >/dev/null 2>&1 || true
+        fi
+    fi
     return 0
 }
 

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -997,14 +997,9 @@ cmd_restart() {
 
     [[ "$rebuild_images" == "true" ]] && _dream_cli_rebuild_images "${flags[@]}"
 
-    # Refresh data/hermes/SOUL.md whenever Hermes (or the full stack) is
-    # restarted, so the persona's "About this installation" section
-    # reflects which services are currently up. Non-fatal — if the
-    # generator fails (Python missing, etc.) Hermes still boots from
-    # whatever assembled SOUL.md is already on disk, or the template if
-    # the assembled file is missing.
+    local refresh_soul="false"
     if [[ -z "$service" || "$service" == "hermes" ]]; then
-        _dream_cli_refresh_soul || true
+        refresh_soul="true"
     fi
 
     if [[ -z "$service" ]]; then
@@ -1012,6 +1007,13 @@ cmd_restart() {
     else
         service=$(resolve_service "$service")
         _compose_run_with_summary "Restarting $service" "${flags[@]}" up -d "$service"
+    fi
+
+    # Refresh SOUL.md after compose has ensured Hermes is running, so the
+    # generated install context can be copied into /opt/data/SOUL.md without
+    # needing the Docker Desktop-hostile nested bind mount.
+    if [[ "$refresh_soul" == "true" ]]; then
+        _dream_cli_refresh_soul || true
     fi
 }
 

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -86,24 +86,30 @@ services:
       # data/persona/SOUL.md with a generated "About this installation"
       # section — what GPU backend, which model, which services are
       # running, which URLs are reachable. So Dream answers truthfully
-      # when asked about its own environment instead of inventing
-      # capabilities.
+      # about its own environment instead of inventing capabilities.
       #
-      # Two mount points: the upstream Hermes image expects the persona
-      # at /opt/data/SOUL.md (its `HERMES_HOME`) at runtime — that's
-      # where the agent actually loads from. The /opt/hermes/docker/
-      # path is just the in-image default that the entrypoint copies to
-      # /opt/data/SOUL.md on first start only; updates to it after that
-      # are ignored. So we bind-mount BOTH paths to the same assembled
-      # file: the docker/ one keeps the install-default convention,
-      # the data/ one is what the running agent actually reads.
+      # Why only ONE mount here, not two: Hermes reads the persona at
+      # /opt/data/SOUL.md (its HERMES_HOME) at runtime, but its
+      # entrypoint copies the in-image /opt/hermes/docker/SOUL.md to
+      # /opt/data/SOUL.md ONLY on first start. We used to bind-mount
+      # BOTH paths so updates after first start would land, but macOS
+      # Docker Desktop's virtiofs layer refuses nested bind-mounts (a
+      # file mount inside the /opt/data directory mount) with:
       #
-      # Why data/persona/ and not data/hermes/: data/hermes/ is owned by
-      # uid 10000 (HERMES_UID) — the Hermes container's own state lives
+      #   create mountpoint for /opt/data/SOUL.md ... mountpoint "..."
+      #   is outside of rootfs
+      #
+      # So we mount only the non-nested docker/ path here. For updates
+      # after first install, the dream-cli's refresh-soul step does
+      # `docker exec dream-hermes cp /opt/hermes/docker/SOUL.md
+      # /opt/data/SOUL.md` — same source, container-side copy, works
+      # uniformly on Linux + macOS (colima AND Docker Desktop).
+      #
+      # Why data/persona/ and not data/hermes/: data/hermes/ is owned
+      # by uid 10000 (HERMES_UID) — the container's own state lives
       # there. data/persona/ stays operator-owned so the host can
       # regenerate the file without sudo.
       - ./data/persona/SOUL.md:/opt/hermes/docker/SOUL.md:ro
-      - ./data/persona/SOUL.md:/opt/data/SOUL.md:ro
     # Hermes is exposed to the LAN via dream-hermes-proxy on port 9120 — that
     # Caddy sidecar forward_auths to dashboard-api's verify-session and only
     # then forwards traffic here. By NOT binding a host port on the Hermes

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1425,6 +1425,21 @@ else
     fi
     ai_ok "Docker services started"
 
+    # Refresh the generated Hermes persona now that the stack is actually
+    # running, then copy it into Hermes's runtime data dir from inside the
+    # container. This avoids Docker Desktop's nested bind-mount restriction
+    # while still keeping /opt/data/SOUL.md current for new sessions.
+    _soul_builder="${INSTALL_DIR}/scripts/build-installation-context.py"
+    if [[ -f "$_soul_builder" ]]; then
+        python3 "$_soul_builder" >>"$DS_LOG_FILE" 2>&1 || \
+            ai_warn "Could not refresh Hermes installation-context SOUL.md after compose-up"
+        if docker ps --format '{{.Names}}' 2>/dev/null | grep -qx 'dream-hermes'; then
+            docker exec dream-hermes cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md \
+                >>"$DS_LOG_FILE" 2>&1 || \
+                ai_warn "Could not sync installation-context SOUL.md into running Hermes container"
+        fi
+    fi
+
     # Save compose flags for dream-macos.sh
     echo "${COMPOSE_FLAGS[*]}" > "${INSTALL_DIR}/.compose-flags"
 

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -784,12 +784,18 @@ except Exception:
         # running — the first pass earlier in this phase happened pre-
         # compose-up, so its docker ps was empty. The persona's "About
         # this installation" section needs to reflect what's actually
-        # reachable, not the pre-launch state. Hermes reads SOUL.md on
-        # each new chat session, so simply rewriting the file is enough
-        # — no container restart needed.
+        # reachable, not the pre-launch state. Hermes reads from
+        # /opt/data/SOUL.md at session time; because macOS Docker Desktop
+        # rejects the old nested bind mount, copy the generated file into
+        # the running container instead.
         if [[ -n "${_python_cmd:-}" ]] && [[ -f "$INSTALL_DIR/scripts/build-installation-context.py" ]]; then
             "$_python_cmd" "$INSTALL_DIR/scripts/build-installation-context.py" >>"$LOG_FILE" 2>&1 || \
                 warn "Installation-context SOUL.md regen failed post-launch (non-fatal — earlier static SOUL.md is in place)"
+            if $DOCKER_CMD ps --format '{{.Names}}' 2>/dev/null | grep -qx 'dream-hermes'; then
+                $DOCKER_CMD exec dream-hermes cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md \
+                    >>"$LOG_FILE" 2>&1 || \
+                    warn "Could not sync installation-context SOUL.md into running Hermes container"
+            fi
         fi
     else
         printf "\r  ${RED}✗${NC} %-60s\n" "Some containers failed to launch"


### PR DESCRIPTION
## Summary

PR #1337 fixed the directory-auto-create issue on the static-template mount, but kept the second *nested* bind mount that was added in PR #1335:

```yaml
volumes:
  - ./data/hermes:/opt/data                                # outer dir mount
  ...
  - ./data/persona/SOUL.md:/opt/hermes/docker/SOUL.md:ro   # OK — non-nested
  - ./data/persona/SOUL.md:/opt/data/SOUL.md:ro            # ← nested, broke macOS
```

The second one lands `/opt/data/SOUL.md` *inside* the `/opt/data` directory that's already bound from `./data/hermes`. That's a file-mount inside a directory-mount.

- **Linux Docker**: handles it.
- **mac-mini (colima)**: handles it. (Smoke gate passed.)
- **m5-mbp (Docker Desktop, virtiofs)**: refuses with:
  ```
  error mounting "/host_mnt/.../data/persona/SOUL.md" to rootfs at "/opt/data/SOUL.md":
  create mountpoint for /opt/data/SOUL.md mount: mountpoint
  "/run/host_virtiofs/.../data/hermes/SOUL.md" is outside of rootfs ...
  ```

Caught when re-running `/dream-fleet-test` after #1337 merged — m5-mbp's install bombed at compose-up in ~1.5 min on this error. mac-mini passed because colima ≠ Docker Desktop.

## The fix

Drop the second nested mount. The first (non-nested) `/opt/hermes/docker/SOUL.md` bind stays — Hermes's entrypoint copies it to `/opt/data/SOUL.md` on first container start, which covers fresh installs uniformly across both Docker backends.

For *updates* after first install (where Hermes's entrypoint won't re-copy on its own — that's a first-start-only behavior), `dream-cli`'s `_dream_cli_refresh_soul` now runs:

```bash
docker exec dream-hermes cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md
```

after regenerating the file. Container-side cp, same source path the bind-mount already provides, no nested mount needed. Works uniformly on Linux + colima + Docker Desktop. Container has to be running for this to matter; if it's not, the entrypoint will pick up the docker/ default on next start anyway.

## Verification

- Fresh install: Hermes entrypoint copies `/opt/hermes/docker/SOUL.md` → `/opt/data/SOUL.md` on first container start (existing upstream behavior). Both paths now resolve to the same content because we mount the assembled file at the docker/ default.
- Subsequent regen via `dream restart hermes`: the script writes `data/persona/SOUL.md` → `docker exec cp` copies it into the container's per-install dir → next chat session reads it. Verified manually on strix earlier in the session.
- macOS no longer hits the nested-mount restriction because we no longer have a nested mount.

## Risk

Pure compose + dream-cli change. No data migration. If the docker exec fails on a host (e.g. container not running), regen is non-fatal — Hermes will pick up the new content on next container restart via the docker/ default path.
