### PR TITLE
fix(bootstrap-upgrade): recreate llama-server after model swap so new CTX_SIZE lands (Hermes/OpenCode empty-response bug on AMD)

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -380,38 +380,43 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
     #   container crash-loops. `--force-recreate --no-deps` guarantees a new
     #   container; --no-deps avoids touching other services in the project.
     log "Restarting llama-server container (backend: ${_gpu_backend:-unknown})..."
-    if [[ "$_gpu_backend" == "amd" ]]; then
-        # Lemonade: restart preserves cached binary, reads models.ini on boot
-        if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
-            $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" restart llama-server 2>&1 || true
-        else
-            $DOCKER_CMD restart dream-llama-server 2>&1 || true
-        fi
+    # Both backends need a container *recreate*, not just a restart, so the
+    # updated CTX_SIZE / MAX_CONTEXT / GGUF_FILE env values from the
+    # freshly-bumped .env land in the new container. A plain `compose
+    # restart` preserves the original env vars from when the container
+    # first started — which on AMD/Lemonade leaves LEMONADE_CTX_SIZE pinned
+    # at the bootstrap-tier value (e.g. 8192) even after .env says 131072.
+    # The lemonade-entrypoint.sh wrapper then sees the stale env value,
+    # never updates /root/.cache/lemonade/config.json, and Lemonade serves
+    # the full model at the bootstrap context size — Hermes then returns
+    # empty responses in ~1s because its 16k-token tool catalog overruns
+    # the 8k context window. OpenCode hits the same wall.
+    #
+    # `env -u` strips the model-config vars from compose's shell so the
+    # freshly-updated .env wins interpolation. Compose precedence is
+    # shell-env > .env > compose default, and Phase 11 (parent of this
+    # nohup'd script) sets the bootstrap-tier values as shell variables.
+    #
+    # Named volumes (lemonade-cache / lemonade-llama / lemonade-recipe on
+    # AMD) survive --force-recreate, so the Lemonade binary cache + HF
+    # cache + recipe state all persist across the recreate. The older
+    # "AMD uses restart to preserve cached binary" comment was wrong —
+    # named volumes are decoupled from the container lifecycle.
+    if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
+        env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE \
+            $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps llama-server 2>&1 || true
     else
-        # llama.cpp: force-recreate to pick up new GGUF_FILE from .env.
-        # `env -u` strips the model-config vars from compose's shell so they
-        # cannot win interpolation over the freshly-updated .env. Compose
-        # variable precedence is shell-env > .env file > compose default,
-        # and Phase 11 of the installer (parent of this nohup'd script) sets
-        # GGUF_FILE / LLM_MODEL / MAX_CONTEXT / CTX_SIZE to the bootstrap
-        # values as shell variables before forking us. Empirically those
-        # leak into our env on Linux even without an explicit `export`, and
-        # without this guard compose silently recreates the container with
-        # `--model /models/${BOOTSTRAP_GGUF_FILE}` — pointing at the file
-        # Phase 4b just deleted, hence the crash-loop on next restart.
-        if [[ ${#COMPOSE_ARGS[@]} -gt 0 && -n "$DOCKER_COMPOSE_CMD" ]]; then
-            env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE \
-                $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps llama-server 2>&1 || true
-        else
-            # No compose flags — use docker rm to force a fresh container that
-            # re-reads GGUF_FILE from the env file. 'docker start' reuses the old
-            # baked environment and would crash-loop if the bootstrap model was
-            # already deleted in Phase 4b.
-            $DOCKER_CMD stop dream-llama-server 2>&1 || true
-            $DOCKER_CMD rm dream-llama-server 2>&1 || true
-            log "WARNING: .compose-flags not found — container removed. Run 'dream restart' to bring llama-server back up with the correct model."
-            write_status "failed"
-        fi
+        # No compose flags — fall back to docker rm + manual recreate. On
+        # NVIDIA the original CMD points at /models/${BOOTSTRAP_GGUF_FILE}
+        # which Phase 4b just deleted; on AMD the container env still has
+        # bootstrap-tier LEMONADE_CTX_SIZE. Either way `docker start`
+        # would reuse the stale state, so we remove the container and ask
+        # the operator to bring it back up via `dream restart` (which
+        # re-runs compose with the latest .env).
+        $DOCKER_CMD stop dream-llama-server 2>&1 || true
+        $DOCKER_CMD rm dream-llama-server 2>&1 || true
+        log "WARNING: .compose-flags not found — container removed. Run 'dream restart' to bring llama-server back up with the correct model + context size."
+        write_status "failed"
     fi
 
     # Pick health endpoint based on GPU backend — Lemonade (AMD) serves

--- a/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -21,11 +21,11 @@ pass() {
 active_code="$(grep -v '^[[:space:]]*#' "$TARGET")"
 
 grep -qF 'up -d --force-recreate --no-deps llama-server' <<<"$active_code" \
-    || fail "llama.cpp hot-swap must force-recreate llama-server without deps"
-pass "llama.cpp hot-swap uses force-recreate/no-deps"
+    || fail "llama-server hot-swap must force-recreate llama-server without deps"
+pass "llama-server hot-swap uses force-recreate/no-deps"
 
 llama_recreate_block="$(awk '
-    /force-recreate to pick up new GGUF_FILE/ { in_block=1 }
+    /Restarting llama-server container/ { in_block=1 }
     in_block { print }
     in_block && /up -d --force-recreate --no-deps llama-server/ { exit }
 ' "$TARGET" | grep -v '^[[:space:]]*#')"
@@ -33,6 +33,11 @@ llama_recreate_block="$(awk '
 grep -qF 'env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE' <<<"$llama_recreate_block" \
     || fail "llama-server recreate must strip model vars so .env wins compose interpolation"
 pass "llama-server recreate strips model env before compose"
+
+if grep -qE '\brestart[[:space:]]+(llama-server|dream-llama-server)\b' <<<"$active_code"; then
+    fail "llama-server hot-swap must not use restart; recreate is required so updated env lands"
+fi
+pass "llama-server hot-swap does not use restart shortcut"
 
 if grep -qE '\bstop[[:space:]]+llama-server\b' <<<"$active_code"; then
     fail "llama.cpp hot-swap must not stop llama-server before compose up"


### PR DESCRIPTION
## Summary

Operator-reported on strix-halo right after a fresh install:

> *"I type something to hermes in the chat and it just responds (empty) instantly. Open Code seems to be having response issues as well"*

Root cause: after the bootstrap → full-model swap, the llama-server container kept running with the bootstrap-tier `LEMONADE_CTX_SIZE` env var (8192) even though `.env` had been bumped to 131072. Lemonade served the full Qwen3.6-35B-A3B at 8k context. Hermes's 16k-token tool catalog overran the window; llama-server returned empty content; Hermes finished the response in ~1 second with no text. OpenCode hit the same wall — same llama-server.

## Repro

1. Fresh install on an AMD/Lemonade host (strix-halo).
2. Wait for bootstrap to finish + full model to swap in.
3. Open the dashboard chat (Hermes) or hit OpenCode.
4. → empty / broken response in <1s.

`docker exec dream-llama-server env | grep LEMONADE_CTX_SIZE` shows `8192` even when `.env` shows `CTX_SIZE=131072`.

## Why

`scripts/bootstrap-upgrade.sh` had two branches:

```bash
if [[ "$_gpu_backend" == "amd" ]]; then
    # Lemonade: restart preserves cached binary, reads models.ini on boot
    $DOCKER_COMPOSE_CMD ... restart llama-server
else
    # llama.cpp: force-recreate to pick up new GGUF_FILE from .env.
    env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE \
        $DOCKER_COMPOSE_CMD ... up -d --force-recreate --no-deps llama-server
fi
```

`compose restart` only restarts the **process** — it does NOT re-read env from `.env`. The container keeps the env vars it was originally created with. So the AMD path was leaving the container pinned at the bootstrap-tier env values forever.

The NVIDIA path uses `--force-recreate` which actually recreates the container with the current `.env` in scope — so it picks up the new `CTX_SIZE`/`GGUF_FILE`/etc.

The original comment claimed `restart` was needed on AMD to preserve the cached Lemonade binary. That's not true — `lemonade-cache` / `lemonade-llama` / `lemonade-recipe` are **named volumes** in `docker-compose.amd.yml`, and named volumes survive `--force-recreate`.

## Fix

Unify both branches to use `compose up -d --force-recreate --no-deps llama-server`. Same `env -u` guard against bootstrap-tier shell vars leaking into compose interpolation (Phase 11 of the installer sets those vars before forking the nohup'd swap script — on AMD they used to be irrelevant because we didn't recreate; now they would leak in if not stripped).

```bash
env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE \
    $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps llama-server
```

## Verification

Live-fixed strix-halo:

```bash
$ dream restart llama-server          # recreates container, picks up new .env
$ docker exec dream-llama-server env | grep LEMONADE_CTX_SIZE
LEMONADE_CTX_SIZE=131072              # was 8192
$ docker exec dream-llama-server cat /root/.cache/lemonade/config.json | jq .ctx_size
131072                                # was 8192

# Hermes chat now works:
$ curl POST /api/talk/message/stream -d '{"text":"hi, what services do you have here?"}'
elapsed=66s
reply: "Here's what's running on this Dream Server install right now:
        - **SearXNG** — privacy-respecting web search (port 8888)
        - **n8n** — no-code automation workflows (port 5678)
        - **Qdrant** — vector database for semantic search (port 6333)
        - **Kokoro TTS** — text-to-speech (port 8880)
        - **Whisper STT** — speech-to-text (port 8000) ..."
```

## Regression fixture

Added `dream-fleet-test/regressions/lemonade-ctx-recreate-after-swap.json` — asserts the AMD branch is gone and the unified `--force-recreate` is in place. Will catch any future refactor that re-introduces the plain `restart` shortcut.

## Risk

- Named volumes survive `--force-recreate` — no cache loss on either backend.
- Same behaviour as the existing NVIDIA path on the bootstrap → full-model swap. NVIDIA hosts have been using `--force-recreate` in production without issue.
- Slight extra downtime during recreate (a few seconds longer than `restart`), but only happens once per install when the bootstrap → full model swap fires. Acceptable trade-off.

## Follow-up (out of scope, file separately if needed)

- The capabilities-phase probes (#1339 follow-up) don't currently catch the empty-1s-response failure mode — `chat` probe says "the response came back, length > 0" but for some short prompts even with broken context the model returns something. A targeted probe that sends a prompt of length > bootstrap_ctx_size and asserts a non-trivial response would catch this exact bug. Will fold into #1339 when those probes are wired in.
