### PR TITLE
feat(health): support non-HTTP health checks for TCP/CLI services (#666)

### DIFF
--- a/ods/config/extensions-catalog.json
+++ b/ods/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-07-02T16:46:38Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -16,6 +16,7 @@
       "depends_on": [],
       "port": 0,
       "external_port_default": 0,
+      "health_type": "none",
       "health_endpoint": "",
       "env_vars": [
         {
@@ -69,6 +70,7 @@
       ],
       "port": 3001,
       "external_port_default": 7800,
+      "health_type": "http",
       "health_endpoint": "/api/health",
       "env_vars": [
         {
@@ -149,6 +151,7 @@
       "depends_on": [],
       "port": 7860,
       "external_port_default": 7863,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [],
       "tags": [
@@ -217,6 +220,7 @@
       "depends_on": [],
       "port": 9200,
       "external_port_default": 9200,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [
         {
@@ -322,6 +326,7 @@
       "depends_on": [],
       "port": 80,
       "external_port_default": 3007,
+      "health_type": "http",
       "health_endpoint": "/api/_health/",
       "env_vars": [],
       "tags": [
@@ -421,6 +426,7 @@
       "depends_on": [],
       "port": 8000,
       "external_port_default": 8000,
+      "health_type": "http",
       "health_endpoint": "/api/v2/heartbeat",
       "env_vars": [],
       "tags": [],
@@ -461,6 +467,7 @@
       ],
       "port": 8080,
       "external_port_default": 8890,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [],
       "tags": [],
@@ -504,6 +511,7 @@
       "depends_on": [],
       "port": 8501,
       "external_port_default": 8501,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [],
       "tags": [
@@ -620,6 +628,7 @@
       "depends_on": [],
       "port": 5001,
       "external_port_default": 8002,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [
         {
@@ -692,6 +701,7 @@
       "depends_on": [],
       "port": 3000,
       "external_port_default": 7801,
+      "health_type": "http",
       "health_endpoint": "/api/v1/ping",
       "env_vars": [
         {
@@ -775,6 +785,7 @@
       "depends_on": [],
       "port": 7865,
       "external_port_default": 7865,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [],
       "tags": [],
@@ -814,6 +825,7 @@
       "depends_on": [],
       "port": 7861,
       "external_port_default": 7861,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [],
       "tags": [
@@ -922,6 +934,7 @@
       "depends_on": [],
       "port": 5000,
       "external_port_default": 8971,
+      "health_type": "http",
       "health_endpoint": "/api/version",
       "env_vars": [
         {
@@ -1037,6 +1050,7 @@
       "depends_on": [],
       "port": 4200,
       "external_port_default": 7822,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [
         {
@@ -1121,6 +1135,7 @@
       "depends_on": [],
       "port": 3000,
       "external_port_default": 7830,
+      "health_type": "http",
       "health_endpoint": "/api/healthz",
       "env_vars": [
         {
@@ -1160,6 +1175,7 @@
       "depends_on": [],
       "port": 2283,
       "external_port_default": 2283,
+      "health_type": "http",
       "health_endpoint": "/api/server/ping",
       "env_vars": [
         {
@@ -1207,6 +1223,7 @@
       "depends_on": [],
       "port": 9090,
       "external_port_default": 9090,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [],
       "tags": [
@@ -1301,6 +1318,7 @@
       "depends_on": [],
       "port": 1337,
       "external_port_default": 1337,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [],
       "tags": [
@@ -1348,6 +1366,7 @@
       "depends_on": [],
       "port": 8888,
       "external_port_default": 8889,
+      "health_type": "http",
       "health_endpoint": "/tree",
       "env_vars": [
         {
@@ -1394,6 +1413,7 @@
       "depends_on": [],
       "port": 8080,
       "external_port_default": 8086,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [],
       "tags": [
@@ -1438,6 +1458,7 @@
       "depends_on": [],
       "port": 7860,
       "external_port_default": 7802,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [],
       "tags": [
@@ -1511,6 +1532,7 @@
       "depends_on": [],
       "port": 3080,
       "external_port_default": 3080,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [
         {
@@ -1641,6 +1663,7 @@
       ],
       "port": 8080,
       "external_port_default": 7803,
+      "health_type": "http",
       "health_endpoint": "/healthz",
       "env_vars": [],
       "tags": [],
@@ -1744,6 +1767,7 @@
       "depends_on": [],
       "port": 19530,
       "external_port_default": 19530,
+      "health_type": "http",
       "health_endpoint": "/healthz",
       "env_vars": [],
       "tags": [],
@@ -1762,6 +1786,7 @@
       "depends_on": [],
       "port": 11434,
       "external_port_default": 7804,
+      "health_type": "http",
       "health_endpoint": "/api/tags",
       "env_vars": [
         {
@@ -1809,6 +1834,7 @@
       "depends_on": [],
       "port": 8080,
       "external_port_default": 7805,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [
         {
@@ -1876,6 +1902,7 @@
       "depends_on": [],
       "port": 8000,
       "external_port_default": 7807,
+      "health_type": "http",
       "health_endpoint": "/accounts/login/",
       "env_vars": [
         {
@@ -1981,6 +2008,7 @@
       "depends_on": [],
       "port": 10200,
       "external_port_default": 10200,
+      "health_type": "tcp",
       "health_endpoint": "",
       "env_vars": [
         {
@@ -2025,6 +2053,7 @@
       "depends_on": [],
       "port": 7865,
       "external_port_default": 7809,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [
         {
@@ -2073,6 +2102,7 @@
       "depends_on": [],
       "port": 8000,
       "external_port_default": 8001,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [],
       "tags": [],
@@ -2110,6 +2140,7 @@
       "depends_on": [],
       "port": 7860,
       "external_port_default": 7862,
+      "health_type": "http",
       "health_endpoint": "/",
       "env_vars": [],
       "tags": [
@@ -2202,6 +2233,7 @@
       "depends_on": [],
       "port": 8080,
       "external_port_default": 7811,
+      "health_type": "http",
       "health_endpoint": "/v1/.well-known/ready",
       "env_vars": [
         {
@@ -2288,6 +2320,7 @@
       "depends_on": [],
       "port": 80,
       "external_port_default": 8100,
+      "health_type": "http",
       "health_endpoint": "/health",
       "env_vars": [],
       "tags": [],

--- a/ods/extensions/library/schema/service-manifest.v1.json
+++ b/ods/extensions/library/schema/service-manifest.v1.json
@@ -8,6 +8,23 @@
     "schema_version": {
       "const": "ods.services.v1"
     },
+    "compatibility": {
+      "type": "object",
+      "description": "ODS version compatibility; used by validate-manifests.sh for version checks",
+      "properties": {
+        "ods_min": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Minimum ODS version this extension supports (e.g. 2.0.0)"
+        },
+        "ods_max": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Maximum ODS version this extension was tested against (optional)"
+        }
+      },
+      "additionalProperties": false
+    },
     "service": {
       "type": "object",
       "required": ["id", "name"],
@@ -87,10 +104,35 @@
           "minLength": 0,
           "description": "HTTP health path. Use an empty string for non-HTTP or one-shot services whose readiness is represented by container state/startup_check."
         },
+        "health_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300,
+          "description": "Health check timeout in seconds (default: 10)"
+        },
+        "ui_path": {
+          "type": "string",
+          "pattern": "^/.*",
+          "description": "Path to the service UI (e.g. /dashboard, /)"
+        },
+        "external_link": {
+          "type": "boolean",
+          "description": "When false, omit this service from dashboard external quicklinks while keeping it in health/status APIs."
+        },
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
+        "startup_check": {
+          "type": "boolean",
+          "description": "When false, skip the post-install running-state poll and treat compose's clean exit as success. Set this on one-shot CLI / setup-only extensions whose containers intentionally exit (default: true)."
+        },
+        "startup_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600,
+          "description": "Seconds the host agent polls for the container to reach the running state before declaring install failed (default: 15). Increase for extensions with heavy initialization (e.g. JVM, postgres, clickhouse)."
+        },
         "gpu_backends": {
           "type": "array",
-          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] },
+          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
           "minItems": 1
         },
         "compose_file": {
@@ -123,13 +165,22 @@
           },
           "description": "Environment variables used by this service"
         },
-        "description": {
-          "type": "string",
-          "description": "Human-readable service description"
-        },
         "setup_hook": {
           "type": "string",
           "description": "Relative path to a setup script run during installation (e.g. setup.sh)"
+        },
+        "hooks": {
+          "type": "object",
+          "description": "Lifecycle hook scripts. Paths relative to extension directory.",
+          "properties": {
+            "pre_install": { "type": "string" },
+            "post_install": { "type": "string" },
+            "pre_start": { "type": "string" },
+            "post_start": { "type": "string" },
+            "pre_uninstall": { "type": "string" },
+            "post_uninstall": { "type": "string" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": true
@@ -151,7 +202,6 @@
               "services": { "type": "array", "items": { "type": "string" } },
               "services_any": { "type": "array", "items": { "type": "string" } },
               "vram_gb": { "type": "number", "minimum": 0 },
-              "vram_mb": { "type": "number", "minimum": 0 },
               "disk_gb": { "type": "number", "minimum": 0 }
             },
             "additionalProperties": true
@@ -160,18 +210,25 @@
           "enabled_services_any": { "type": "array", "items": { "type": "string" } },
           "setup_time": { "type": "string" },
           "priority": { "type": "integer", "minimum": 1 },
+          "launch": {
+            "type": "object",
+            "description": "Dashboard feature-card launch target. Use type=service for user-facing service UIs, internal for dashboard routes, and none for backend/API-only features.",
+            "required": ["type"],
+            "properties": {
+              "type": { "type": "string", "enum": ["service", "internal", "none"] },
+              "service": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+              "path": { "type": "string", "pattern": "^/.*" }
+            },
+            "additionalProperties": false
+          },
           "gpu_backends": {
             "type": "array",
-            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] }
+            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
+            "minItems": 1
           }
         },
         "additionalProperties": true
       }
-    },
-    "tags": {
-      "type": "array",
-      "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
-      "description": "Categorization tags for service discovery"
     }
   },
   "additionalProperties": true

--- a/ods/extensions/library/schema/service-manifest.v1.json
+++ b/ods/extensions/library/schema/service-manifest.v1.json
@@ -10,7 +10,47 @@
     },
     "service": {
       "type": "object",
-      "required": ["id", "name", "port", "health", "description"],
+      "required": ["id", "name"],
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "host_network": { "const": true }
+            },
+            "required": ["host_network"]
+          },
+          "then": {},
+          "else": {
+            "allOf": [
+              {
+                "if": {
+                  "properties": { "health_type": { "const": "tcp" } },
+                  "required": ["health_type"]
+                },
+                "then": { "required": ["port"] }
+              },
+              {
+                "if": {
+                  "properties": { "health_type": { "const": "none" } },
+                  "required": ["health_type"]
+                },
+                "then": {}
+              },
+              {
+                "if": {
+                  "properties": { "health_type": { "const": "http" } },
+                  "required": ["health_type"]
+                },
+                "then": { "required": ["port", "health"] }
+              },
+              {
+                "if": { "not": { "required": ["health_type"] } },
+                "then": { "required": ["port", "health"] }
+              }
+            ]
+          }
+        }
+      ],
       "properties": {
         "id": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
         "name": { "type": "string", "minLength": 1 },
@@ -33,6 +73,15 @@
         "port": { "type": "integer", "minimum": 0, "maximum": 65535 },
         "external_port_env": { "type": "string" },
         "external_port_default": { "type": "integer", "minimum": 0, "maximum": 65535 },
+        "host_network": {
+          "type": "boolean",
+          "description": "True for Docker network_mode: host services that do not declare Docker-mapped ports or HTTP health paths."
+        },
+        "health_type": {
+          "type": "string",
+          "enum": ["http", "tcp", "none"],
+          "default": "http"
+        },
         "health": {
           "type": "string",
           "minLength": 0,

--- a/ods/extensions/library/services/aider/manifest.yaml
+++ b/ods/extensions/library/services/aider/manifest.yaml
@@ -10,7 +10,7 @@ service:
   port: 0
   external_port_env: ''
   external_port_default: 0
-  health: ""
+  health_type: none
   type: docker
   startup_check: false  # one-shot CLI tool; container exits 0 by design
   gpu_backends: [amd, nvidia, apple]

--- a/ods/extensions/library/services/piper-audio/manifest.yaml
+++ b/ods/extensions/library/services/piper-audio/manifest.yaml
@@ -10,7 +10,7 @@ service:
   port: 10200
   external_port_env: PIPER_PORT
   external_port_default: 10200
-  health: ""
+  health_type: tcp
   type: docker
   gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml

--- a/ods/extensions/schema/service-manifest.v1.json
+++ b/ods/extensions/schema/service-manifest.v1.json
@@ -8,6 +8,23 @@
     "schema_version": {
       "const": "ods.services.v1"
     },
+    "compatibility": {
+      "type": "object",
+      "description": "ODS version compatibility; used by validate-manifests.sh for version checks",
+      "properties": {
+        "ods_min": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Minimum ODS version this extension supports (e.g. 2.0.0)"
+        },
+        "ods_max": {
+          "type": "string",
+          "pattern": "^\\d+\\.\\d+\\.\\d+$",
+          "description": "Maximum ODS version this extension was tested against (optional)"
+        }
+      },
+      "additionalProperties": false
+    },
     "service": {
       "type": "object",
       "required": ["id", "name"],
@@ -87,10 +104,35 @@
           "minLength": 0,
           "description": "HTTP health path. Use an empty string for non-HTTP or one-shot services whose readiness is represented by container state/startup_check."
         },
+        "health_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 300,
+          "description": "Health check timeout in seconds (default: 10)"
+        },
+        "ui_path": {
+          "type": "string",
+          "pattern": "^/.*",
+          "description": "Path to the service UI (e.g. /dashboard, /)"
+        },
+        "external_link": {
+          "type": "boolean",
+          "description": "When false, omit this service from dashboard external quicklinks while keeping it in health/status APIs."
+        },
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
+        "startup_check": {
+          "type": "boolean",
+          "description": "When false, skip the post-install running-state poll and treat compose's clean exit as success. Set this on one-shot CLI / setup-only extensions whose containers intentionally exit (default: true)."
+        },
+        "startup_timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 600,
+          "description": "Seconds the host agent polls for the container to reach the running state before declaring install failed (default: 15). Increase for extensions with heavy initialization (e.g. JVM, postgres, clickhouse)."
+        },
         "gpu_backends": {
           "type": "array",
-          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] },
+          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
           "minItems": 1
         },
         "compose_file": {
@@ -123,13 +165,22 @@
           },
           "description": "Environment variables used by this service"
         },
-        "description": {
-          "type": "string",
-          "description": "Human-readable service description"
-        },
         "setup_hook": {
           "type": "string",
           "description": "Relative path to a setup script run during installation (e.g. setup.sh)"
+        },
+        "hooks": {
+          "type": "object",
+          "description": "Lifecycle hook scripts. Paths relative to extension directory.",
+          "properties": {
+            "pre_install": { "type": "string" },
+            "post_install": { "type": "string" },
+            "pre_start": { "type": "string" },
+            "post_start": { "type": "string" },
+            "pre_uninstall": { "type": "string" },
+            "post_uninstall": { "type": "string" }
+          },
+          "additionalProperties": false
         }
       },
       "additionalProperties": true
@@ -151,7 +202,6 @@
               "services": { "type": "array", "items": { "type": "string" } },
               "services_any": { "type": "array", "items": { "type": "string" } },
               "vram_gb": { "type": "number", "minimum": 0 },
-              "vram_mb": { "type": "number", "minimum": 0 },
               "disk_gb": { "type": "number", "minimum": 0 }
             },
             "additionalProperties": true
@@ -160,18 +210,25 @@
           "enabled_services_any": { "type": "array", "items": { "type": "string" } },
           "setup_time": { "type": "string" },
           "priority": { "type": "integer", "minimum": 1 },
+          "launch": {
+            "type": "object",
+            "description": "Dashboard feature-card launch target. Use type=service for user-facing service UIs, internal for dashboard routes, and none for backend/API-only features.",
+            "required": ["type"],
+            "properties": {
+              "type": { "type": "string", "enum": ["service", "internal", "none"] },
+              "service": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+              "path": { "type": "string", "pattern": "^/.*" }
+            },
+            "additionalProperties": false
+          },
           "gpu_backends": {
             "type": "array",
-            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] }
+            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
+            "minItems": 1
           }
         },
         "additionalProperties": true
       }
-    },
-    "tags": {
-      "type": "array",
-      "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
-      "description": "Categorization tags for service discovery"
     }
   },
   "additionalProperties": true

--- a/ods/extensions/schema/service-manifest.v1.json
+++ b/ods/extensions/schema/service-manifest.v1.json
@@ -8,23 +8,6 @@
     "schema_version": {
       "const": "ods.services.v1"
     },
-    "compatibility": {
-      "type": "object",
-      "description": "ODS version compatibility; used by validate-manifests.sh for version checks",
-      "properties": {
-        "ods_min": {
-          "type": "string",
-          "pattern": "^\\d+\\.\\d+\\.\\d+$",
-          "description": "Minimum ODS version this extension supports (e.g. 2.0.0)"
-        },
-        "ods_max": {
-          "type": "string",
-          "pattern": "^\\d+\\.\\d+\\.\\d+$",
-          "description": "Maximum ODS version this extension was tested against (optional)"
-        }
-      },
-      "additionalProperties": false
-    },
     "service": {
       "type": "object",
       "required": ["id", "name"],
@@ -37,7 +20,35 @@
             "required": ["host_network"]
           },
           "then": {},
-          "else": { "required": ["port", "health"] }
+          "else": {
+            "allOf": [
+              {
+                "if": {
+                  "properties": { "health_type": { "const": "tcp" } },
+                  "required": ["health_type"]
+                },
+                "then": { "required": ["port"] }
+              },
+              {
+                "if": {
+                  "properties": { "health_type": { "const": "none" } },
+                  "required": ["health_type"]
+                },
+                "then": {}
+              },
+              {
+                "if": {
+                  "properties": { "health_type": { "const": "http" } },
+                  "required": ["health_type"]
+                },
+                "then": { "required": ["port", "health"] }
+              },
+              {
+                "if": { "not": { "required": ["health_type"] } },
+                "then": { "required": ["port", "health"] }
+              }
+            ]
+          }
         }
       ],
       "properties": {
@@ -66,40 +77,20 @@
           "type": "boolean",
           "description": "True for Docker network_mode: host services that do not declare Docker-mapped ports or HTTP health paths."
         },
+        "health_type": {
+          "type": "string",
+          "enum": ["http", "tcp", "none"],
+          "default": "http"
+        },
         "health": {
           "type": "string",
           "minLength": 0,
           "description": "HTTP health path. Use an empty string for non-HTTP or one-shot services whose readiness is represented by container state/startup_check."
         },
-        "health_timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 300,
-          "description": "Health check timeout in seconds (default: 10)"
-        },
-        "ui_path": {
-          "type": "string",
-          "pattern": "^/.*",
-          "description": "Path to the service UI (e.g. /dashboard, /)"
-        },
-        "external_link": {
-          "type": "boolean",
-          "description": "When false, omit this service from dashboard external quicklinks while keeping it in health/status APIs."
-        },
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
-        "startup_check": {
-          "type": "boolean",
-          "description": "When false, skip the post-install running-state poll and treat compose's clean exit as success. Set this on one-shot CLI / setup-only extensions whose containers intentionally exit (default: true)."
-        },
-        "startup_timeout": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 600,
-          "description": "Seconds the host agent polls for the container to reach the running state before declaring install failed (default: 15). Increase for extensions with heavy initialization (e.g. JVM, postgres, clickhouse)."
-        },
         "gpu_backends": {
           "type": "array",
-          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
+          "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] },
           "minItems": 1
         },
         "compose_file": {
@@ -132,22 +123,13 @@
           },
           "description": "Environment variables used by this service"
         },
+        "description": {
+          "type": "string",
+          "description": "Human-readable service description"
+        },
         "setup_hook": {
           "type": "string",
           "description": "Relative path to a setup script run during installation (e.g. setup.sh)"
-        },
-        "hooks": {
-          "type": "object",
-          "description": "Lifecycle hook scripts. Paths relative to extension directory.",
-          "properties": {
-            "pre_install": { "type": "string" },
-            "post_install": { "type": "string" },
-            "pre_start": { "type": "string" },
-            "post_start": { "type": "string" },
-            "pre_uninstall": { "type": "string" },
-            "post_uninstall": { "type": "string" }
-          },
-          "additionalProperties": false
         }
       },
       "additionalProperties": true
@@ -169,6 +151,7 @@
               "services": { "type": "array", "items": { "type": "string" } },
               "services_any": { "type": "array", "items": { "type": "string" } },
               "vram_gb": { "type": "number", "minimum": 0 },
+              "vram_mb": { "type": "number", "minimum": 0 },
               "disk_gb": { "type": "number", "minimum": 0 }
             },
             "additionalProperties": true
@@ -177,25 +160,18 @@
           "enabled_services_any": { "type": "array", "items": { "type": "string" } },
           "setup_time": { "type": "string" },
           "priority": { "type": "integer", "minimum": 1 },
-          "launch": {
-            "type": "object",
-            "description": "Dashboard feature-card launch target. Use type=service for user-facing service UIs, internal for dashboard routes, and none for backend/API-only features.",
-            "required": ["type"],
-            "properties": {
-              "type": { "type": "string", "enum": ["service", "internal", "none"] },
-              "service": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
-              "path": { "type": "string", "pattern": "^/.*" }
-            },
-            "additionalProperties": false
-          },
           "gpu_backends": {
             "type": "array",
-            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },
-            "minItems": 1
+            "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "all", "none"] }
           }
         },
         "additionalProperties": true
       }
+    },
+    "tags": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+      "description": "Categorization tags for service discovery"
     }
   },
   "additionalProperties": true

--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -124,6 +124,7 @@ def load_extension_manifests(
                     "port": int(service.get("port", 0)),
                     "external_port": external_port,
                     "health": service.get("health", "/health"),
+                    "health_type": service.get("health_type", "http"),
                     "name": service.get("name", service_id),
                     "ui_path": service.get("ui_path", "/"),
                     "external_link": bool(service.get("external_link", True)),

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -494,9 +494,51 @@ async def check_service_health(
         return await _check_host_systemd_health(service_id, config)
 
     if config.get("host_network") and int(config.get("port") or 0) <= 0:
+        # A host-network service can legitimately declare health_type: none
+        # (e.g. a CLI daemon with no listening port). Honor that before the
+        # tailscale special case so future manifests don't need a code change.
+        if config.get("health_type") == "none":
+            return _service_status_from_config(service_id, config, "not_applicable")
         if service_id == "tailscale":
             return await _check_tailscale_health(service_id, config)
         return _service_status_from_config(service_id, config, "not_deployed")
+
+    health_type = config.get("health_type", "http")
+    if health_type == "none":
+        return _service_status_from_config(service_id, config, "not_applicable")
+
+    if health_type == "tcp":
+        host = config.get("host", "localhost")
+        health_port = int(config.get("health_port", config["port"]) or 0)
+        if health_port <= 0:
+            return _service_status_from_config(service_id, config, "not_deployed")
+
+        response_time = None
+        status = "unknown"
+        connect_timeout = (timeout.total or timeout.connect or 5) if timeout is not None else 5
+        try:
+            start = asyncio.get_event_loop().time()
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(host, health_port),
+                timeout=connect_timeout,
+            )
+            response_time = (asyncio.get_event_loop().time() - start) * 1000
+            writer.close()
+            await writer.wait_closed()
+            status = "healthy"
+        except asyncio.TimeoutError:
+            status = "degraded"
+        except OSError as e:
+            if "Name or service not known" in str(e) or "nodename nor servname" in str(e):
+                status = "not_deployed"
+            else:
+                status = "down"
+
+        return ServiceStatus(
+            id=service_id, name=config["name"], port=config["port"],
+            external_port=config.get("external_port", config["port"]),
+            status=status, response_time_ms=round(response_time, 1) if response_time else None
+        )
 
     host = config.get('host', 'localhost')
     health_port = config.get('health_port', config['port'])

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -892,7 +892,10 @@ async def extensions_catalog(
     # Only health-check extensions that declare a health endpoint.  Use a
     # short per-probe timeout so one slow extension cannot stall the catalog
     # response (frontend aborts at 8 s).
-    checkable = {sid: cfg for sid, cfg in user_svc_configs.items() if cfg.get("health")}
+    checkable = {
+        sid: cfg for sid, cfg in user_svc_configs.items()
+        if cfg.get("health") or cfg.get("health_type") == "tcp"
+    }
     user_health_tasks = [
         check_service_health(sid, cfg, timeout=_CATALOG_HEALTH_TIMEOUT)
         for sid, cfg in checkable.items()
@@ -906,7 +909,11 @@ async def extensions_catalog(
     # (presence in user_svc_configs means compose.yaml + manifest exist)
     from models import ServiceStatus
     for sid, cfg in user_svc_configs.items():
-        if not cfg.get("health") and sid not in services_by_id:
+        if (
+            not cfg.get("health")
+            and cfg.get("health_type") != "tcp"
+            and sid not in services_by_id
+        ):
             services_by_id[sid] = ServiceStatus(
                 id=sid, name=cfg.get("name", sid),
                 port=cfg.get("port", 0),
@@ -1044,7 +1051,10 @@ async def extension_detail(
 
     # Same short per-probe timeout as the catalog fan-out — one slow user
     # extension must not block the detail view.
-    checkable = {sid: cfg for sid, cfg in user_svc_configs.items() if cfg.get("health")}
+    checkable = {
+        sid: cfg for sid, cfg in user_svc_configs.items()
+        if cfg.get("health") or cfg.get("health_type") == "tcp"
+    }
     user_health_tasks = [
         check_service_health(sid, cfg, timeout=_CATALOG_HEALTH_TIMEOUT)
         for sid, cfg in checkable.items()
@@ -1056,7 +1066,11 @@ async def extension_detail(
 
     from models import ServiceStatus
     for sid, cfg in user_svc_configs.items():
-        if not cfg.get("health") and sid not in services_by_id:
+        if (
+            not cfg.get("health")
+            and cfg.get("health_type") != "tcp"
+            and sid not in services_by_id
+        ):
             services_by_id[sid] = ServiceStatus(
                 id=sid, name=cfg.get("name", sid),
                 port=cfg.get("port", 0),

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -17,7 +17,9 @@ from routers.extensions import _assert_not_core
 
 
 def _make_catalog_ext(ext_id, name="Test", category="optional",
-                      gpu_backends=None, env_vars=None, features=None):
+                      gpu_backends=None, env_vars=None, features=None,
+                      port=8080, health_endpoint="/health",
+                      health_type="http", startup_check=None):
     return {
         "id": ext_id,
         "name": name,
@@ -26,12 +28,14 @@ def _make_catalog_ext(ext_id, name="Test", category="optional",
         "gpu_backends": gpu_backends or ["nvidia", "amd", "apple"],
         "compose_file": "compose.yaml",
         "depends_on": [],
-        "port": 8080,
-        "external_port_default": 8080,
-        "health_endpoint": "/health",
+        "port": port,
+        "external_port_default": port,
+        "health_endpoint": health_endpoint,
+        "health_type": health_type,
         "env_vars": env_vars or [],
         "tags": [],
         "features": features or [],
+        **({"startup_check": startup_check} if startup_check is not None else {}),
     }
 
 
@@ -289,6 +293,111 @@ class TestUserExtensionStatus:
         ext = resp.json()["extensions"][0]
         assert ext["id"] == "my-ext"
         assert ext["status"] == "enabled"
+
+    @pytest.mark.parametrize("mock_status, expected_status", [
+        ("healthy", "enabled"),
+        ("down", "stopped"),
+    ])
+    def test_user_ext_compose_yaml_tcp_probed(self, test_client, monkeypatch, tmp_path, mock_status, expected_status):
+        """User extension with health_type: tcp is actively probed."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "my-ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml").write_text("version: '3'")
+
+        catalog = [_make_catalog_ext("my-ext", "My Extension", port=10200,
+                                     health_endpoint="", health_type="tcp")]
+        _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+
+        user_services = {
+            "my-ext": {
+                "host": "my-ext",
+                "port": 10200,
+                "external_port": 10200,
+                "health": "",
+                "health_type": "tcp",
+                "name": "My Extension",
+            }
+        }
+
+        mock_result = ServiceStatus(id="my-ext", name="My Extension", status=mock_status, port=10200, external_port=10200)
+
+        # Test /api/extensions/catalog
+        with patch("helpers.get_cached_services", return_value=None):
+            with patch("user_extensions.get_user_services_cached", return_value=user_services):
+                with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
+                    with patch("helpers.check_service_health", new_callable=AsyncMock, return_value=mock_result) as mock_probe:
+                        resp = test_client.get(
+                            "/api/extensions/catalog",
+                            headers=test_client.auth_headers,
+                        )
+                        assert resp.status_code == 200
+                        ext = resp.json()["extensions"][0]
+                        assert ext["id"] == "my-ext"
+                        assert ext["status"] == expected_status
+                        mock_probe.assert_awaited_once()
+                        assert mock_probe.call_args[0][0] == "my-ext"
+
+        # Test /api/extensions/{service_id}
+        with patch("helpers.get_cached_services", return_value=None):
+            with patch("user_extensions.get_user_services_cached", return_value=user_services):
+                with patch("helpers.get_all_services", new_callable=AsyncMock, return_value=[]):
+                    with patch("helpers.check_service_health", new_callable=AsyncMock, return_value=mock_result) as mock_probe:
+                        resp = test_client.get(
+                            "/api/extensions/my-ext",
+                            headers=test_client.auth_headers,
+                        )
+                        assert resp.status_code == 200
+                        ext = resp.json()
+                        assert ext["id"] == "my-ext"
+                        assert ext["status"] == expected_status
+                        mock_probe.assert_awaited_once()
+                        assert mock_probe.call_args[0][0] == "my-ext"
+
+    def test_user_ext_compose_yaml_none_cli_installed(self, test_client, monkeypatch, tmp_path):
+        """User extension with health_type: none and port 0 → cli_installed."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "aider"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml").write_text("version: '3'")
+
+        catalog = [_make_catalog_ext("aider", "Aider", port=0,
+                                     health_endpoint="", health_type="none",
+                                     startup_check=False)]
+        _patch_extensions_config(monkeypatch, catalog, tmp_path=tmp_path)
+        monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+
+        user_services = {
+            "aider": {
+                "host": "aider",
+                "port": 0,
+                "external_port": 0,
+                "health": "",
+                "health_type": "none",
+                "name": "Aider",
+            }
+        }
+        from routers.extensions import _is_one_shot_extension
+
+        with patch("helpers.get_cached_services", return_value=None):
+            with patch("user_extensions.get_user_services_cached",
+                       return_value=user_services):
+                with patch("helpers.get_all_services", new_callable=AsyncMock,
+                           return_value=[ServiceStatus(
+                               id="aider", name="Aider", port=0,
+                               external_port=0, status="not_applicable",
+                           )]):
+                    resp = test_client.get(
+                        "/api/extensions/catalog",
+                        headers=test_client.auth_headers,
+                    )
+
+        assert resp.status_code == 200
+        ext = resp.json()["extensions"][0]
+        assert _is_one_shot_extension(catalog[0]) is True
+        assert ext["id"] == "aider"
+        assert ext["status"] == "cli_installed"
 
     def test_user_ext_compose_yaml_no_service(self, test_client, monkeypatch, tmp_path):
         """User extension with compose.yaml but no running container → stopped."""

--- a/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_user_extensions.py
@@ -18,12 +18,15 @@ def _write_manifest(ext_dir: Path, manifest: dict) -> None:
 
 
 def _make_manifest(service_id: str, port: int = 8080, health: str = "/health",
-                   name: str | None = None, default_host: str = "badhost") -> dict:
+                   name: str | None = None, default_host: str = "badhost",
+                   health_type: str | None = None) -> dict:
     """Build a minimal manifest dict."""
     svc: dict = {"id": service_id, "port": port, "health": health,
                  "default_host": default_host}
     if name is not None:
         svc["name"] = name
+    if health_type is not None:
+        svc["health_type"] = health_type
     return {"schema_version": "ods.services.v1", "service": svc}
 
 
@@ -93,6 +96,38 @@ class TestScanUserExtensions:
         assert "my-ext" in result
         assert result["my-ext"]["health"] == ""
         assert result["my-ext"]["port"] == 8080
+
+    def test_scan_health_type_tcp_included(self, tmp_path):
+        """Extension declaring health_type: tcp is preserved in scan results."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "my-ext"
+        _write_manifest(ext_dir, _make_manifest("my-ext", port=10200,
+                                                 health="", health_type="tcp"))
+        (ext_dir / "compose.yaml").write_text("services: {}\n")
+
+        result = scan_user_extension_services(user_dir)
+        assert result["my-ext"]["health_type"] == "tcp"
+
+    def test_scan_health_type_none_included(self, tmp_path):
+        """Extension declaring health_type: none is preserved in scan results."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "my-ext"
+        _write_manifest(ext_dir, _make_manifest("my-ext", port=0,
+                                                 health="", health_type="none"))
+        (ext_dir / "compose.yaml").write_text("services: {}\n")
+
+        result = scan_user_extension_services(user_dir)
+        assert result["my-ext"]["health_type"] == "none"
+
+    def test_scan_invalid_health_type_skipped(self, tmp_path):
+        """Invalid health_type values skip the extension instead of coercing."""
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "my-ext"
+        _write_manifest(ext_dir, _make_manifest("my-ext", health_type="smtp"))
+        (ext_dir / "compose.yaml").write_text("services: {}\n")
+
+        result = scan_user_extension_services(user_dir)
+        assert "my-ext" not in result
 
     def test_scan_health_path_validation(self, tmp_path):
         """Reject paths with .., @, ?, #, and scheme prefixes."""

--- a/ods/extensions/services/dashboard-api/user_extensions.py
+++ b/ods/extensions/services/dashboard-api/user_extensions.py
@@ -62,6 +62,11 @@ def scan_user_extension_services(
         if not isinstance(svc, dict):
             continue
 
+        health_type = svc.get("health_type", "http")
+        if health_type not in {"http", "tcp", "none"}:
+            logger.warning("Skipping extension %s: invalid health_type: %r", service_id, health_type)
+            continue
+
         health = svc.get("health") or ""
 
         try:
@@ -85,6 +90,7 @@ def scan_user_extension_services(
                 "port": int(port),
                 "external_port": int(svc.get("external_port_default", port)),
                 "health": health,
+                "health_type": health_type,
                 "name": name,
                 # Optional: extensions whose health endpoint lives on a
                 # secondary port (e.g. milvus 9091) need an explicit

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -265,6 +265,13 @@ function getStatusTone(status) {
         text: 'text-amber-300',
         pill: 'border-amber-400/25 bg-amber-400/[0.08]',
       }
+    case 'not_applicable':
+      return {
+        label: 'N/A',
+        dot: 'bg-zinc-400',
+        text: 'text-zinc-300',
+        pill: 'border-zinc-400/25 bg-zinc-400/[0.08]',
+      }
     default:
       return {
         label: 'Inactive',
@@ -278,6 +285,7 @@ function getStatusTone(status) {
 function getServiceTabStatus(status) {
   if (status === 'healthy') return 'online'
   if (status === 'degraded') return 'degraded'
+  if (status === 'not_applicable') return 'online'
   return 'inactive'
 }
 

--- a/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ServiceMap.jsx
@@ -103,6 +103,7 @@ const STATUS = {
   unhealthy: { color: '#ef4444', text: 'text-red-400', dot: 'bg-red-400' },
   down: { color: '#ef4444', text: 'text-red-400', dot: 'bg-red-400' },
   not_deployed: { color: '#6b7280', text: 'text-zinc-500', dot: 'bg-zinc-500' },
+  not_applicable: { color: '#6b7280', text: 'text-zinc-400', dot: 'bg-zinc-400' },
   unknown: { color: '#6b7280', text: 'text-zinc-500', dot: 'bg-zinc-500' },
 }
 

--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -230,7 +230,7 @@ export default function Settings() {
   }
 
   const routingGroups = [
-    { key: 'online', label: 'Online', tone: 'online', services: sortRoutesBySeverity(services).filter(service => service.status === 'healthy') },
+    { key: 'online', label: 'Online', tone: 'online', services: sortRoutesBySeverity(services).filter(service => service.status === 'healthy' || service.status === 'not_applicable') },
     { key: 'degraded', label: 'Degraded', tone: 'degraded', services: sortRoutesBySeverity(services).filter(service => service.status === 'degraded') },
     { key: 'inactive', label: 'Inactive', tone: 'inactive', services: sortRoutesBySeverity(services).filter(service => ['down', 'unhealthy', 'unknown'].includes(service.status)) },
   ]

--- a/ods/lib/service-registry.sh
+++ b/ods/lib/service-registry.sh
@@ -32,6 +32,7 @@ declare -A SERVICE_COMPOSE      # service_id → compose file path
 declare -A SERVICE_CATEGORIES   # service_id → core|recommended|optional
 declare -A SERVICE_DEPENDS      # service_id → space-separated dependency IDs
 declare -A SERVICE_HEALTH       # service_id → health endpoint path
+declare -A SERVICE_HEALTH_TYPES # service_id → http|tcp|none
 declare -A SERVICE_HEALTH_TIMEOUTS  # service_id → health check timeout in seconds
 declare -A SERVICE_PORTS        # service_id → external port (what the user hits on localhost)
 declare -A SERVICE_PORT_ENVS    # service_id → env var name for the external port
@@ -183,11 +184,13 @@ for service_dir in _all_service_dirs:
         print(f'SERVICE_CATEGORIES["{_esc(sid)}"]="{_esc(category)}"')
         print(f'SERVICE_DEPENDS["{_esc(sid)}"]="{_esc(" ".join(str(d) for d in depends))}"')
         health = s.get("health", "/health")
+        health_type = s.get("health_type", "http")
         health_timeout = s.get("health_timeout", 5)  # Default 5 seconds
         port = s.get("external_port_default", s.get("port", 0))
         port_env = s.get("external_port_env", "")
         host_network = "1" if s.get("host_network") else ""
         print(f'SERVICE_HEALTH["{_esc(sid)}"]="{_esc(health)}"')
+        print(f'SERVICE_HEALTH_TYPES["{_esc(sid)}"]="{_esc(health_type)}"')
         print(f'SERVICE_HEALTH_TIMEOUTS["{_esc(sid)}"]="{_esc(health_timeout)}"')
         print(f'SERVICE_PORTS["{_esc(sid)}"]="{_esc(port)}"')
         print(f'SERVICE_PORT_ENVS["{_esc(sid)}"]="{_esc(port_env)}"')

--- a/ods/scripts/audit-extensions.py
+++ b/ods/scripts/audit-extensions.py
@@ -19,6 +19,7 @@ import yaml
 VALID_CATEGORIES = {"core", "recommended", "optional"}
 VALID_TYPES = {"docker", "host-systemd"}
 VALID_GPU_BACKENDS = {"amd", "nvidia", "apple", "all", "none"}
+VALID_HEALTH_TYPES = {"http", "tcp", "none"}
 MANIFEST_NAMES = ("manifest.yaml", "manifest.yml", "manifest.json")
 OVERLAY_SUFFIXES = {
     "amd": ("compose.amd.yaml", "compose.amd.yml"),
@@ -495,12 +496,21 @@ def validate_records(
         # compose-port-mismatch check further down.
         host_network = bool(service.get("host_network"))
 
+        health_type = str(service.get("health_type") or "http")
+        if health_type not in VALID_HEALTH_TYPES:
+            record.add_issue(
+                "error",
+                "service-health-type-invalid",
+                f"service.health_type must be one of {sorted(VALID_HEALTH_TYPES)}",
+                path=record.manifest_path,
+            )
+
         port = parse_positive_int(service.get("port"))
-        if port is None and not host_network:
+        if port is None and not host_network and health_type in {"http", "tcp"}:
             record.add_issue("error", "service-port-invalid", "service.port must be a positive integer", path=record.manifest_path)
 
         health = str(service.get("health") or "")
-        if not health.startswith("/") and not host_network:
+        if health_type == "http" and not host_network and not health.startswith("/"):
             record.add_issue(
                 "error",
                 "service-health-invalid",

--- a/ods/scripts/generate-extensions-catalog.py
+++ b/ods/scripts/generate-extensions-catalog.py
@@ -103,6 +103,7 @@ def extract_entry(manifest: dict) -> dict | None:
         "depends_on": service.get("depends_on", []),
         "port": service.get("port", 0),
         "external_port_default": service.get("external_port_default", 0),
+        "health_type": service.get("health_type", "http"),
         "health_endpoint": service.get("health", ""),
         "env_vars": strip_secrets(env_vars),
         "tags": manifest.get("tags") or service.get("tags", []),

--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -34,6 +34,10 @@ done
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)" 
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
     . "$SCRIPT_DIR/lib/service-registry.sh" 
+    if [[ -n "${ODS_EXTENSIONS_DIR:-}" ]]; then
+        # shellcheck disable=SC2034  # consumed by sr_load in service-registry.sh
+        EXTENSIONS_DIR="$ODS_EXTENSIONS_DIR"
+    fi
     sr_load 
 fi
 INSTALL_DIR="${INSTALL_DIR:-$HOME/ods}"
@@ -156,18 +160,43 @@ test_service() {
     local port_env="${SERVICE_PORT_ENVS[$sid]}"
     local default_port="${SERVICE_PORTS[$sid]}"
     local health="${SERVICE_HEALTH[$sid]}"
+    local health_type="${SERVICE_HEALTH_TYPES[$sid]:-http}"
     local timeout="${SERVICE_HEALTH_TIMEOUTS[$sid]:-$TIMEOUT}"
+
+    if [[ "$health_type" == "none" ]]; then
+        result_set "$sid" "not_applicable"
+        return 0
+    fi
 
     # Resolve port
     local port="$default_port"
     [[ -n "$port_env" ]] && port="${!port_env:-$default_port}"
 
-    [[ -z "$health" || "$port" == "0" ]] && return 1
+    if [[ "$health_type" == "tcp" ]]; then
+        [[ -z "$port" || "$port" == "0" ]] && return 1
+    else
+        [[ -z "$health" || "$port" == "0" ]] && return 1
+    fi
 
     # Check container state first (if docker available)
     local container_state
     container_state=$(check_container_state "$sid")
     if [[ -n "$container_state" && "$container_state" != "running" ]]; then
+        result_set "$sid" "fail"
+        ANY_FAIL=true
+        return 1
+    fi
+
+    if [[ "$health_type" == "tcp" ]]; then
+        if ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+            result_set "$sid" "fail"
+            ANY_FAIL=true
+            return 1
+        fi
+        if timeout "$timeout" bash -c 'cat < /dev/null > /dev/tcp/127.0.0.1/$1' _ "$port" >/dev/null 2>&1; then
+            result_set "$sid" "ok"
+            return 0
+        fi
         result_set "$sid" "fail"
         ANY_FAIL=true
         return 1
@@ -230,6 +259,10 @@ check_service() {
     local sid="$1"
     local name="${SERVICE_NAMES[$sid]:-$sid}"
     if test_service "$sid" 2>/dev/null; then
+        if [[ "$(result_get "$sid")" == "not_applicable" ]]; then
+            log "  ${CYAN}~${NC} $name - skipped (no health check)"
+            return 0
+        fi
         log "  ${GREEN}✓${NC} $name - healthy"
         return 0
     else
@@ -255,183 +288,200 @@ check_service_async() {
 }
 
 # ── Run tests ───────────────────────────────────────────────────────────────
+if [[ "${HEALTH_CHECK_LIB_ONLY:-}" != "1" ]]; then
+    # Create temp dir for parallel results
+    TEMP_DIR=$(mktemp -d)
+    trap 'rm -rf "$TEMP_DIR"' EXIT
 
-# Create temp dir for parallel results
-TEMP_DIR=$(mktemp -d)
-trap 'rm -rf "$TEMP_DIR"' EXIT
+    log "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    log "${CYAN}  ODS Health Check${NC}"
+    log "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    log ""
 
-log "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-log "${CYAN}  ODS Health Check${NC}"
-log "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-log ""
+    log "${CYAN}Core Services:${NC}"
 
-log "${CYAN}Core Services:${NC}"
-
-# llama-server (critical — does inference test, not just health)
-if test_llm 2>/dev/null; then
-    log "  ${GREEN}✓${NC} llama-server - inference working ($(result_get "llm_latency")ms)"
-else
-    log "  ${RED}✗${NC} llama-server - CRITICAL: inference failed"
-fi
-
-# Launch all other core services in parallel
-declare -a CORE_PIDS=()
-declare -a CORE_SIDS=()
-for sid in "${SERVICE_IDS[@]}"; do
-    [[ "$sid" == "llama-server" ]] && continue
-    [[ "${SERVICE_CATEGORIES[$sid]}" != "core" ]] && continue
-    result_file="$TEMP_DIR/core_$sid"
-    check_service_async "$sid" "$result_file" &
-    CORE_PIDS+=($!)
-    CORE_SIDS+=("$sid")
-done
-
-# Wait for all core service checks to complete
-for pid in "${CORE_PIDS[@]}"; do
-    wait "$pid" 2>/dev/null || true
-done
-
-# Display core service results
-for sid in "${CORE_SIDS[@]}"; do
-    result_file="$TEMP_DIR/core_$sid"
-    if [[ -f "$result_file" ]]; then
-        result=$(cat "$result_file")
-        name="${SERVICE_NAMES[$sid]:-$sid}"
-
-        # Parse result format: status:sid:container_state
-        IFS=':' read -r status sid_check container_state <<< "$result"
-
-        if [[ "$status" == "ok" ]]; then
-            log "  ${GREEN}✓${NC} $name - healthy"
-        else
-            # Use container state for better error message
-            case "$container_state" in
-                not_found)
-                    log "  ${YELLOW}!${NC} $name - container not found"
-                    ;;
-                exited|stopped)
-                    log "  ${YELLOW}!${NC} $name - container stopped"
-                    ;;
-                restarting)
-                    log "  ${YELLOW}!${NC} $name - container restarting"
-                    ;;
-                running)
-                    log "  ${YELLOW}!${NC} $name - not responding (container running)"
-                    ;;
-                *)
-                    log "  ${YELLOW}!${NC} $name - not responding"
-                    ;;
-            esac
-        fi
+    # llama-server (critical — does inference test, not just health)
+    if test_llm 2>/dev/null; then
+        log "  ${GREEN}✓${NC} llama-server - inference working ($(result_get "llm_latency")ms)"
+    else
+        log "  ${RED}✗${NC} llama-server - CRITICAL: inference failed"
     fi
-done
 
-log ""
-log "${CYAN}Extension Services:${NC}"
-
-# Launch all extension services in parallel
-declare -a EXT_PIDS=()
-declare -a EXT_SIDS=()
-for sid in "${SERVICE_IDS[@]}"; do
-    [[ "${SERVICE_CATEGORIES[$sid]}" == "core" ]] && continue
-    result_file="$TEMP_DIR/ext_$sid"
-    check_service_async "$sid" "$result_file" &
-    EXT_PIDS+=($!)
-    EXT_SIDS+=("$sid")
-done
-
-# Wait for all extension service checks to complete
-for pid in "${EXT_PIDS[@]}"; do
-    wait "$pid" 2>/dev/null || true
-done
-
-# Display extension service results
-for sid in "${EXT_SIDS[@]}"; do
-    result_file="$TEMP_DIR/ext_$sid"
-    if [[ -f "$result_file" ]]; then
-        result=$(cat "$result_file")
-        name="${SERVICE_NAMES[$sid]:-$sid}"
-
-        # Parse result format: status:sid:container_state
-        IFS=':' read -r status sid_check container_state <<< "$result"
-
-        if [[ "$status" == "ok" ]]; then
-            log "  ${GREEN}✓${NC} $name - healthy"
-        else
-            # Use container state for better error message
-            case "$container_state" in
-                not_found)
-                    log "  ${YELLOW}!${NC} $name - container not found"
-                    ;;
-                exited|stopped)
-                    log "  ${YELLOW}!${NC} $name - container stopped"
-                    ;;
-                restarting)
-                    log "  ${YELLOW}!${NC} $name - container restarting"
-                    ;;
-                running)
-                    log "  ${YELLOW}!${NC} $name - not responding (container running)"
-                    ;;
-                *)
-                    log "  ${YELLOW}!${NC} $name - not responding"
-                    ;;
-            esac
-        fi
-    fi
-done
-
-log ""
-log "${CYAN}System Resources:${NC}"
-
-# GPU
-if test_gpu 2>/dev/null; then
-    status_icon="${GREEN}✓${NC}"
-    [ "$(result_get "gpu")" = "warn" ] && status_icon="${YELLOW}!${NC}"
-    log "  ${status_icon} GPU - $(result_get "gpu_mem_used")/$(result_get "gpu_mem_total") MiB, $(result_get "gpu_util")% util, $(result_get "gpu_temp")°C"
-else
-    log "  ${YELLOW}?${NC} GPU - status unavailable"
-fi
-
-# Disk
-if test_disk 2>/dev/null; then
-    status_icon="${GREEN}✓${NC}"
-    [ "$(result_get "disk")" = "warn" ] && status_icon="${YELLOW}!${NC}"
-    log "  ${status_icon} Disk - $(result_get "disk_usage")% used"
-else
-    log "  ${YELLOW}?${NC} Disk - status unavailable"
-fi
-
-log ""
-
-# Summary
-if $CRITICAL_FAIL; then
-    log "${RED}Status: CRITICAL - Core services down${NC}"
-    EXIT_CODE=2
-elif $ANY_FAIL; then
-    log "${YELLOW}Status: DEGRADED - Some services unavailable${NC}"
-    EXIT_CODE=1
-else
-    log "${GREEN}Status: HEALTHY - All services operational${NC}"
-    EXIT_CODE=0
-fi
-
-log ""
-
-# JSON output
-if $JSON_OUTPUT; then
-    echo "{"
-    echo "  \"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\","
-    echo "  \"status\": \"$([ $EXIT_CODE -eq 0 ] && echo "healthy" || ([ $EXIT_CODE -eq 1 ] && echo "degraded" || echo "critical"))\","
-    echo "  \"services\": {"
-    first=true
-    for i in "${!RESULT_KEYS[@]}"; do
-        $first || echo ","
-        first=false
-        echo -n "    \"${RESULT_KEYS[$i]}\": \"${RESULT_VALS[$i]}\""
+    # Launch all other core services in parallel
+    declare -a CORE_PIDS=()
+    declare -a CORE_SIDS=()
+    for sid in "${SERVICE_IDS[@]}"; do
+        [[ "$sid" == "llama-server" ]] && continue
+        [[ "${SERVICE_CATEGORIES[$sid]}" != "core" ]] && continue
+        result_file="$TEMP_DIR/core_$sid"
+        check_service_async "$sid" "$result_file" &
+        CORE_PIDS+=($!)
+        CORE_SIDS+=("$sid")
     done
-    echo ""
-    echo "  }"
-    echo "}"
-fi
 
-exit $EXIT_CODE
+    # Wait for all core service checks to complete
+    for pid in "${CORE_PIDS[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+
+    # Display core service results
+    for sid in "${CORE_SIDS[@]}"; do
+        result_file="$TEMP_DIR/core_$sid"
+        if [[ -f "$result_file" ]]; then
+            result=$(cat "$result_file")
+            name="${SERVICE_NAMES[$sid]:-$sid}"
+
+            # Parse result format: status:sid:container_state
+            IFS=':' read -r status sid_check container_state <<< "$result"
+            health_type="${SERVICE_HEALTH_TYPES[$sid]:-http}"
+
+            if [[ "$status" == "ok" ]]; then
+                if [[ "$health_type" == "none" ]]; then
+                    result_set "$sid" "not_applicable"
+                    log "  ${CYAN}~${NC} $name - skipped (no health check)"
+                else
+                    result_set "$sid" "ok"
+                    log "  ${GREEN}✓${NC} $name - healthy"
+                fi
+            else
+                result_set "$sid" "fail"
+                # Use container state for better error message
+                case "$container_state" in
+                    not_found)
+                        log "  ${YELLOW}!${NC} $name - container not found"
+                        ;;
+                    exited|stopped)
+                        log "  ${YELLOW}!${NC} $name - container stopped"
+                        ;;
+                    restarting)
+                        log "  ${YELLOW}!${NC} $name - container restarting"
+                        ;;
+                    running)
+                        log "  ${YELLOW}!${NC} $name - not responding (container running)"
+                        ;;
+                    *)
+                        log "  ${YELLOW}!${NC} $name - not responding"
+                        ;;
+                esac
+            fi
+        fi
+    done
+
+    log ""
+    log "${CYAN}Extension Services:${NC}"
+
+    # Launch all extension services in parallel
+    declare -a EXT_PIDS=()
+    declare -a EXT_SIDS=()
+    for sid in "${SERVICE_IDS[@]}"; do
+        [[ "${SERVICE_CATEGORIES[$sid]}" == "core" ]] && continue
+        result_file="$TEMP_DIR/ext_$sid"
+        check_service_async "$sid" "$result_file" &
+        EXT_PIDS+=($!)
+        EXT_SIDS+=("$sid")
+    done
+
+    # Wait for all extension service checks to complete
+    for pid in "${EXT_PIDS[@]}"; do
+        wait "$pid" 2>/dev/null || true
+    done
+
+    # Display extension service results
+    for sid in "${EXT_SIDS[@]}"; do
+        result_file="$TEMP_DIR/ext_$sid"
+        if [[ -f "$result_file" ]]; then
+            result=$(cat "$result_file")
+            name="${SERVICE_NAMES[$sid]:-$sid}"
+
+            # Parse result format: status:sid:container_state
+            IFS=':' read -r status sid_check container_state <<< "$result"
+            health_type="${SERVICE_HEALTH_TYPES[$sid]:-http}"
+
+            if [[ "$status" == "ok" ]]; then
+                if [[ "$health_type" == "none" ]]; then
+                    result_set "$sid" "not_applicable"
+                    log "  ${CYAN}~${NC} $name - skipped (no health check)"
+                else
+                    result_set "$sid" "ok"
+                    log "  ${GREEN}✓${NC} $name - healthy"
+                fi
+            else
+                result_set "$sid" "fail"
+                # Use container state for better error message
+                case "$container_state" in
+                    not_found)
+                        log "  ${YELLOW}!${NC} $name - container not found"
+                        ;;
+                    exited|stopped)
+                        log "  ${YELLOW}!${NC} $name - container stopped"
+                        ;;
+                    restarting)
+                        log "  ${YELLOW}!${NC} $name - container restarting"
+                        ;;
+                    running)
+                        log "  ${YELLOW}!${NC} $name - not responding (container running)"
+                        ;;
+                    *)
+                        log "  ${YELLOW}!${NC} $name - not responding"
+                        ;;
+                esac
+            fi
+        fi
+    done
+
+    log ""
+    log "${CYAN}System Resources:${NC}"
+
+    # GPU
+    if test_gpu 2>/dev/null; then
+        status_icon="${GREEN}✓${NC}"
+        [ "$(result_get "gpu")" = "warn" ] && status_icon="${YELLOW}!${NC}"
+        log "  ${status_icon} GPU - $(result_get "gpu_mem_used")/$(result_get "gpu_mem_total") MiB, $(result_get "gpu_util")% util, $(result_get "gpu_temp")°C"
+    else
+        log "  ${YELLOW}?${NC} GPU - status unavailable"
+    fi
+
+    # Disk
+    if test_disk 2>/dev/null; then
+        status_icon="${GREEN}✓${NC}"
+        [ "$(result_get "disk")" = "warn" ] && status_icon="${YELLOW}!${NC}"
+        log "  ${status_icon} Disk - $(result_get "disk_usage")% used"
+    else
+        log "  ${YELLOW}?${NC} Disk - status unavailable"
+    fi
+
+    log ""
+
+    # Summary
+    if $CRITICAL_FAIL; then
+        log "${RED}Status: CRITICAL - Core services down${NC}"
+        EXIT_CODE=2
+    elif $ANY_FAIL; then
+        log "${YELLOW}Status: DEGRADED - Some services unavailable${NC}"
+        EXIT_CODE=1
+    else
+        log "${GREEN}Status: HEALTHY - All services operational${NC}"
+        EXIT_CODE=0
+    fi
+
+    log ""
+
+    # JSON output
+    if $JSON_OUTPUT; then
+        echo "{"
+        echo "  \"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\","
+        echo "  \"status\": \"$([ $EXIT_CODE -eq 0 ] && echo "healthy" || ([ $EXIT_CODE -eq 1 ] && echo "degraded" || echo "critical"))\","
+        echo "  \"services\": {"
+        first=true
+        for i in "${!RESULT_KEYS[@]}"; do
+            $first || echo ","
+            first=false
+            echo -n "    \"${RESULT_KEYS[$i]}\": \"${RESULT_VALS[$i]}\""
+        done
+        echo ""
+        echo "  }"
+        echo "}"
+    fi
+
+    exit $EXIT_CODE
+fi

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -242,12 +242,29 @@ collect_extension_diagnostics() {
             if [[ "$container_state" == "running" ]]; then
                 local port="${SERVICE_PORTS[$sid]:-0}"
                 local health="${SERVICE_HEALTH[$sid]:-}"
-                if [[ "$port" != "0" && -n "$health" ]]; then
-                    if curl -sf --max-time 5 "http://127.0.0.1:${port}${health}" >/dev/null 2>&1; then
-                        health_status="healthy"
-                    else
+                local health_type="${SERVICE_HEALTH_TYPES[$sid]:-http}"
+                if [[ "$health_type" == "none" ]]; then
+                    health_status="not_applicable"
+                elif [[ "$health_type" == "tcp" ]]; then
+                    if ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
                         health_status="unhealthy"
-                        issues+=("health_check_failed")
+                        issues+=("invalid_port")
+                    elif [[ "$port" != "0" ]]; then
+                        if timeout 5 bash -c 'cat < /dev/null > /dev/tcp/127.0.0.1/$1' _ "$port" >/dev/null 2>&1; then
+                            health_status="healthy"
+                        else
+                            health_status="unhealthy"
+                            issues+=("health_check_failed")
+                        fi
+                    fi
+                else
+                    if [[ "$port" != "0" && -n "$health" ]]; then
+                        if curl -sf --max-time 5 "http://127.0.0.1:${port}${health}" >/dev/null 2>&1; then
+                            health_status="healthy"
+                        else
+                            health_status="unhealthy"
+                            issues+=("health_check_failed")
+                        fi
                     fi
                 fi
             else

--- a/ods/scripts/ods-test.sh
+++ b/ods/scripts/ods-test.sh
@@ -195,7 +195,20 @@ test_tcp() {
     local host="$2"
     local port="$3"
     
-    if timeout "$TIMEOUT" bash -c "cat < /dev/null > /dev/tcp/$host/$port" 2>/dev/null; then
+    # Validate host: allow only alphanumeric, dots, hyphens, colons (IPv6)
+    if [[ -z "$host" ]] || [[ ! "$host" =~ ^[a-zA-Z0-9.:-]+$ ]]; then
+        record_result "$name" "fail" "invalid host: $host"
+        print_test "$name" "fail" "invalid host"
+        return 1
+    fi
+    # Validate port: numeric 1-65535
+    if ! [[ "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+        record_result "$name" "fail" "invalid port: $port"
+        print_test "$name" "fail" "invalid port"
+        return 1
+    fi
+
+    if timeout "$TIMEOUT" bash -c 'cat < /dev/null > /dev/tcp/$1/$2' _ "$host" "$port" 2>/dev/null; then
         record_result "$name" "pass"
         print_test "$name" "pass"
         return 0

--- a/ods/tests/fixtures/health-types/extensions/services/http-service/compose.yaml
+++ b/ods/tests/fixtures/health-types/extensions/services/http-service/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  http-service:
+    image: example/http-service:latest
+    container_name: ods-http-service
+    ports:
+      - "127.0.0.1:18081:18081"
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "--quiet", "http://localhost:18081/"]

--- a/ods/tests/fixtures/health-types/extensions/services/http-service/manifest.yaml
+++ b/ods/tests/fixtures/health-types/extensions/services/http-service/manifest.yaml
@@ -1,0 +1,13 @@
+schema_version: ods.services.v1
+
+service:
+  id: http-service
+  name: HTTP Fixture
+  container_name: ods-http-service
+  port: 18081
+  external_port_default: 18081
+  health: /
+  type: docker
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []

--- a/ods/tests/fixtures/health-types/extensions/services/none-service/compose.yaml
+++ b/ods/tests/fixtures/health-types/extensions/services/none-service/compose.yaml
@@ -1,0 +1,6 @@
+services:
+  none-service:
+    image: example/none-service:latest
+    container_name: ods-none-service
+    healthcheck:
+      test: ["CMD", "true"]

--- a/ods/tests/fixtures/health-types/extensions/services/none-service/manifest.yaml
+++ b/ods/tests/fixtures/health-types/extensions/services/none-service/manifest.yaml
@@ -1,0 +1,11 @@
+schema_version: ods.services.v1
+
+service:
+  id: none-service
+  name: None Fixture
+  container_name: ods-none-service
+  health_type: none
+  type: docker
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []

--- a/ods/tests/fixtures/health-types/extensions/services/tcp-service/compose.yaml
+++ b/ods/tests/fixtures/health-types/extensions/services/tcp-service/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  tcp-service:
+    image: example/tcp-service:latest
+    container_name: ods-tcp-service
+    ports:
+      - "127.0.0.1:18082:18082"
+    healthcheck:
+      test: ["CMD", "bash", "-c", "echo >/dev/tcp/localhost/18082"]

--- a/ods/tests/fixtures/health-types/extensions/services/tcp-service/manifest.yaml
+++ b/ods/tests/fixtures/health-types/extensions/services/tcp-service/manifest.yaml
@@ -1,0 +1,13 @@
+schema_version: ods.services.v1
+
+service:
+  id: tcp-service
+  name: TCP Fixture
+  container_name: ods-tcp-service
+  port: 18082
+  external_port_default: 18082
+  health_type: tcp
+  type: docker
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []

--- a/ods/tests/test-extension-audit.sh
+++ b/ods/tests/test-extension-audit.sh
@@ -37,7 +37,7 @@ fail() {
 
 header() {
     echo ""
-    echo -e "${BOLD}${CYAN}[$1/7]${NC} ${BOLD}$2${NC}"
+    echo -e "${BOLD}${CYAN}[$1/8]${NC} ${BOLD}$2${NC}"
     echo -e "${CYAN}$(printf '%.0s─' {1..60})${NC}"
 }
 
@@ -215,7 +215,7 @@ PY
 
 header "1" "Valid Project Passes Cleanly"
 root=$(make_fixture_root)
-trap 'rm -rf "$root" "${root2:-}" "${root3:-}" "${root4:-}" "${root5:-}" "${root6:-}" "${root7:-}"' EXIT
+trap 'rm -rf "$root" "${root2:-}" "${root3:-}" "${root4:-}" "${root5:-}" "${root6:-}" "${root7:-}" "${root8:-}" "${root9:-}"' EXIT
 create_valid_project "$root"
 report=$(mktemp)
 if run_audit "$root" --json > "$report"; then
@@ -362,6 +362,45 @@ if run_audit "$root7" --json > "$report7" 2>/dev/null; then
     pass "external_port_default=0 fixture audits successfully"
 else
     fail "external_port_default=0 should be allowed for internal-only services"
+fi
+
+header "8" "Health Type Fixtures"
+root8=$(make_fixture_root)
+cp -R "$SCRIPT_DIR/fixtures/health-types/extensions/services/." "$root8/extensions/services/"
+report8=$(mktemp)
+if run_audit "$root8" --json > "$report8"; then
+    pass "health_type fixtures audit successfully"
+else
+    fail "health_type fixtures should pass audit"
+fi
+if assert_json_value "$report8" "payload['summary']['result'] == 'pass'" >/dev/null; then
+    pass "health_type fixtures report pass"
+else
+    fail "health_type fixtures JSON did not report pass"
+fi
+
+root9=$(make_fixture_root)
+cp -R "$SCRIPT_DIR/fixtures/health-types/extensions/services/." "$root9/extensions/services/"
+python3 - "$root9/extensions/services/tcp-service/manifest.yaml" <<'PY'
+import sys
+import yaml
+
+path = sys.argv[1]
+doc = yaml.safe_load(open(path, encoding="utf-8"))
+doc["service"]["health_type"] = "smtp"
+with open(path, "w", encoding="utf-8") as handle:
+    yaml.safe_dump(doc, handle, sort_keys=False)
+PY
+report9=$(mktemp)
+if run_audit "$root9" --json > "$report9" 2>/dev/null; then
+    fail "invalid health_type should fail audit"
+else
+    pass "invalid health_type fails audit"
+fi
+if assert_json_value "$report9" "any(issue['code'] == 'service-health-type-invalid' for svc in payload['services'] for issue in svc['issues'])" >/dev/null; then
+    pass "invalid health_type is reported"
+else
+    fail "invalid health_type code was not reported"
 fi
 
 echo ""

--- a/ods/tests/test-health-check.sh
+++ b/ods/tests/test-health-check.sh
@@ -103,6 +103,83 @@ else
     fail "check_container_state missing docker availability check"
 fi
 
+# 8. Health type fixtures (http/tcp/none)
+FIXTURES_DIR="$SCRIPT_DIR/fixtures/health-types"
+if [[ ! -d "$FIXTURES_DIR" ]]; then
+    fail "Health type fixtures missing"
+elif ! python3 -c "import yaml" 2>/dev/null; then
+    skip "PyYAML not installed — skipping health_type fixture check"
+else
+    http_port=18081
+    tcp_port=18082
+    http_log=$(mktemp)
+    tcp_log=$(mktemp)
+    python3 -m http.server "$http_port" --bind 127.0.0.1 >"$http_log" 2>&1 &
+    http_pid=$!
+    sleep 0.5
+    if ! kill -0 "$http_pid" 2>/dev/null; then
+        skip "HTTP fixture server failed to start (port $http_port in use)"
+    else
+        python3 - "$tcp_port" >"$tcp_log" 2>&1 <<'PY' &
+import socket
+import sys
+import time
+
+port = int(sys.argv[1])
+sock = socket.socket()
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind(("127.0.0.1", port))
+sock.listen(1)
+sock.settimeout(5)
+try:
+    conn, _ = sock.accept()
+    conn.close()
+    time.sleep(0.5)
+except Exception:
+    time.sleep(1)
+finally:
+    sock.close()
+PY
+        tcp_pid=$!
+        sleep 0.5
+        if ! kill -0 "$tcp_pid" 2>/dev/null; then
+            skip "TCP fixture server failed to start (port $tcp_port in use)"
+        else
+            fixture_statuses=$(
+                ROOT_DIR="$ROOT_DIR" \
+                ODS_EXTENSIONS_DIR="$FIXTURES_DIR/extensions/services" \
+                HEALTH_CHECK_LIB_ONLY=1 \
+                bash -c '
+source "$ROOT_DIR/scripts/health-check.sh"
+# Fixtures run without real Docker containers. Stub the container-state
+# check so the network probe is the actual signal under test.
+check_container_state() { echo "running"; }
+set +e
+test_service "http-service" >/dev/null 2>&1
+http_status=$(result_get "http-service")
+test_service "tcp-service" >/dev/null 2>&1
+tcp_status=$(result_get "tcp-service")
+test_service "none-service" >/dev/null 2>&1
+none_status=$(result_get "none-service")
+printf "%s,%s,%s" "$http_status" "$tcp_status" "$none_status"
+'
+            )
+            if [[ "$fixture_statuses" == "ok,ok,not_applicable" ]]; then
+                pass "health_type fixtures report http ok, tcp ok, none not_applicable"
+            else
+                fail "health_type fixture statuses incorrect" "$fixture_statuses"
+            fi
+        fi
+        if kill -0 "$tcp_pid" 2>/dev/null; then
+            kill "$tcp_pid" 2>/dev/null
+        fi
+    fi
+    if kill -0 "$http_pid" 2>/dev/null; then
+        kill "$http_pid" 2>/dev/null
+    fi
+    rm -f "$http_log" "$tcp_log"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]

--- a/ods/tests/test-service-registry.sh
+++ b/ods/tests/test-service-registry.sh
@@ -45,14 +45,14 @@ skip() {
 
 header() {
     echo ""
-    echo -e "${BOLD}${CYAN}[$1]${NC} ${BOLD}$2${NC}"
+    echo -e "${BOLD}${CYAN}[$1/8]${NC} ${BOLD}$2${NC}"
     echo -e "${CYAN}$(printf '%.0s─' {1..60})${NC}"
 }
 
 # ============================================
 # TEST 1: Registry File Exists and Sources
 # ============================================
-header "1/7" "Registry Library"
+header "1" "Registry Library"
 
 if [[ -f "$PROJECT_DIR/lib/service-registry.sh" ]]; then
     pass "lib/service-registry.sh exists"
@@ -88,7 +88,7 @@ fi
 # ============================================
 # TEST 2: Manifest Schema Validation
 # ============================================
-header "2/7" "Manifest Schema Validation"
+header "2" "Manifest Schema Validation"
 
 PYTHON_CMD="python3"
 if [[ -f "$PROJECT_DIR/lib/python-cmd.sh" ]]; then
@@ -219,7 +219,7 @@ fi
 # ============================================
 # TEST 3: Core Service Manifests
 # ============================================
-header "3/7" "Core Service Manifests"
+header "3" "Core Service Manifests"
 
 expected_core=("llama-server" "open-webui" "dashboard" "dashboard-api")
 for sid in "${expected_core[@]}"; do
@@ -247,7 +247,7 @@ done
 # ============================================
 # TEST 4: Registry Resolution (Aliases)
 # ============================================
-header "4/7" "Alias Resolution"
+header "4" "Alias Resolution"
 
 # Test known aliases
 declare -A expected_aliases=(
@@ -292,7 +292,7 @@ fi
 # ============================================
 # TEST 5: Registry Data Completeness
 # ============================================
-header "5/7" "Registry Data Completeness"
+header "5" "Registry Data Completeness"
 
 for sid in "${SERVICE_IDS[@]}"; do
     # Every service should have a name
@@ -338,7 +338,7 @@ done
 # ============================================
 # TEST 6: Compose Fragment Consistency
 # ============================================
-header "6/7" "Compose Fragments"
+header "6" "Compose Fragments"
 
 for sid in "${SERVICE_IDS[@]}"; do
     cat="${SERVICE_CATEGORIES[$sid]}"
@@ -383,7 +383,7 @@ done
 # ============================================
 # TEST 7: Enable/Disable Mechanism
 # ============================================
-header "7/7" "Enable/Disable Mechanism"
+header "7" "Enable/Disable Mechanism"
 
 # Find a non-core service that's currently enabled (has compose.yaml)
 test_service=""
@@ -444,6 +444,44 @@ else
     # Clean up backup
     rm -f "$svc_dir/compose.yaml.backup"
     pass "Cleanup complete"
+fi
+
+# ============================================
+# TEST 8: Health Type Parsing
+# ============================================
+header "8" "Health Type Parsing"
+
+fixtures_dir="$PROJECT_DIR/tests/fixtures/health-types/extensions/services"
+if [[ ! -d "$fixtures_dir" ]]; then
+    fail "Health type fixtures missing" "$fixtures_dir not found"
+else
+    _SR_LOADED=false
+    EXTENSIONS_DIR="$fixtures_dir"
+    sr_load
+
+    if declare -p SERVICE_HEALTH_TYPES &>/dev/null; then
+        pass "SERVICE_HEALTH_TYPES declared"
+    else
+        fail "SERVICE_HEALTH_TYPES missing"
+    fi
+
+    if [[ "${SERVICE_HEALTH_TYPES[http-service]:-}" == "http" ]]; then
+        pass "health_type defaults to http when absent"
+    else
+        fail "health_type default incorrect" "http-service=${SERVICE_HEALTH_TYPES[http-service]:-}"
+    fi
+
+    if [[ "${SERVICE_HEALTH_TYPES[tcp-service]:-}" == "tcp" ]]; then
+        pass "tcp health_type parsed"
+    else
+        fail "tcp health_type missing" "tcp-service=${SERVICE_HEALTH_TYPES[tcp-service]:-}"
+    fi
+
+    if [[ "${SERVICE_HEALTH_TYPES[none-service]:-}" == "none" ]]; then
+        pass "none health_type parsed"
+    else
+        fail "none health_type missing" "none-service=${SERVICE_HEALTH_TYPES[none-service]:-}"
+    fi
 fi
 
 # ============================================


### PR DESCRIPTION
Closes #666. Flagged the approach in the issue and didn't hear back — opening this for review, happy to redirect if the direction's wrong.

Adds `health_type: http | tcp | none` to the service manifest. Defaults to `http`, so existing manifests don't need changes.

- `http` — unchanged
- `tcp` — opens a connection to the port, short timeout, no HTTP path needed
- `none` — skip the check, show as N/A

Wired through schema, audit, `service-registry.sh`, `health-check.sh`, `dream-doctor.sh`, and dashboard-api so all five surfaces agree on the same states.

**Real services updated**

- `piper-audio` → `tcp` (Wyoming protocol, not HTTP)
- `aider` → `none` (CLI tool, no server)

**Tests**

    bash dream-server/tests/test-service-registry.sh   # 223 pass
    bash dream-server/tests/test-health-check.sh       # 10 pass
    bash dream-server/tests/test-extension-audit.sh    # 19 pass

Health-check test spins up a real HTTP server and TCP listener and verifies `ok / ok / not_applicable`. Audit test also rejects an invalid `health_type: smtp` fixture.

21 files, +553 / -182. No new dependencies. Happy to split schema + plumbing from the manifest updates if you'd prefer.