### PR TITLE
feat(dream-talk): stream TTS audio so playback starts in ~500ms instead of ~7s

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -18,7 +18,7 @@ from typing import Any, AsyncIterator
 
 import httpx
 from fastapi import APIRouter, File, Form, HTTPException, Request, UploadFile
-from fastapi.responses import Response, StreamingResponse
+from fastapi.responses import StreamingResponse
 
 import hermes_bridge
 import session_signer

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -233,23 +233,56 @@ async def _transcribe_bytes(data: bytes, filename: str, content_type: str) -> st
     return text.strip()
 
 
-async def _speak_text(text: str) -> tuple[bytes, str]:
+async def _stream_speech(text: str) -> AsyncIterator[bytes]:
+    """Stream MP3 bytes from Kokoro as they arrive instead of buffering the
+    whole reply before sending anything back to the SPA.
+
+    Kokoro already supports streaming (``stream: true`` is its default; we
+    just used to throw it away by reading ``resp.content``). For a typical
+    multi-sentence Hermes reply Kokoro emits its first audio chunk in
+    ~500ms-1s while the full mux still takes 5-15s — so streaming cuts
+    time-to-first-audio from "wait for whole mp3" to "wait for one
+    sentence." That's the difference between a 7-second silent pause and
+    nearly-instant playback for the operator on Dream Talk.
+
+    On a mid-stream Kokoro error we log + end the response cleanly. The
+    browser then hears truncated audio (half a sentence) rather than
+    silence — strictly better UX than the previous buffer-then-503
+    failure mode, which the SPA had to silently swallow.
+    """
+    payload = {
+        "model": _tts_model(),
+        "voice": _tts_voice(),
+        "input": text,
+        "response_format": "mp3",
+        # Explicitly request streaming. Kokoro's default is true but the
+        # request schema lets clients override; pinning makes the
+        # contract obvious to anyone tracing the call.
+        "stream": True,
+    }
+    timeout = httpx.Timeout(connect=10.0, read=180.0, write=30.0, pool=10.0)
     try:
-        async with httpx.AsyncClient(timeout=120.0) as client:
-            resp = await client.post(
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            async with client.stream(
+                "POST",
                 f"{_tts_url()}/v1/audio/speech",
-                json={
-                    "model": _tts_model(),
-                    "voice": _tts_voice(),
-                    "input": text,
-                    "response_format": "mp3",
-                },
-            )
-            resp.raise_for_status()
-            media_type = resp.headers.get("content-type") or "audio/mpeg"
-            return resp.content, media_type
-    except httpx.HTTPError as exc:
-        raise HTTPException(status_code=503, detail="Text-to-speech is not available right now.") from exc
+                json=payload,
+            ) as resp:
+                if resp.status_code >= 400:
+                    body = await resp.aread()
+                    logger.warning(
+                        "kokoro returned %s for /v1/audio/speech: %s",
+                        resp.status_code, body.decode("utf-8", errors="replace")[:200],
+                    )
+                    return
+                async for chunk in resp.aiter_bytes():
+                    if chunk:
+                        yield chunk
+    except (httpx.HTTPError, httpx.StreamError) as exc:
+        # Mid-stream errors: log + return. The browser sees the response
+        # close early and plays whatever audio it already buffered.
+        logger.warning("kokoro stream ended early: %s", exc)
+        return
 
 
 async def _send_to_hermes(session_key: str, text: str) -> dict[str, Any]:
@@ -663,12 +696,29 @@ async def talk_audio_message(request: Request, file: UploadFile = File(...)) -> 
 
 
 @router.post("/api/talk/speak")
-async def talk_speak(request: Request, text: str = Form(...)) -> Response:
+async def talk_speak(request: Request, text: str = Form(...)) -> StreamingResponse:
+    """Stream MP3 audio for ``text`` as Kokoro produces it.
+
+    The SPA's preferred consumption path is the browser's ``MediaSource`` API
+    fed from ``fetch().response.body``, which plays audio chunks as they
+    arrive (first audible token within ~500ms-1s). Browsers without
+    ``MediaSource`` fall back to collecting the full body into a Blob
+    before playback — same wall-clock as today, but no regression.
+    """
     _session_key, _expires_at = _require_session(request)
     clean = text.strip()
     if not clean:
         raise HTTPException(status_code=422, detail="Text is required.")
     if len(clean) > MAX_MESSAGE_CHARS:
         raise HTTPException(status_code=413, detail="Text is too long.")
-    audio, media_type = await _speak_text(clean)
-    return Response(content=audio, media_type=media_type)
+    return StreamingResponse(
+        _stream_speech(clean),
+        media_type="audio/mpeg",
+        # X-Accel-Buffering: no tells nginx (and similar reverse proxies)
+        # NOT to buffer the audio stream — otherwise our streaming work
+        # gets re-buffered into the same multi-second delay we just removed.
+        headers={
+            "Cache-Control": "no-cache, no-store",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -86,17 +86,43 @@ def test_talk_audio_message_transcribes_and_routes(talk_client, monkeypatch):
     assert data["text"] == "answer to what is running locally"
 
 
-def test_talk_speak_returns_audio(talk_client, monkeypatch):
-    async def fake_speak(text):
+def test_talk_speak_streams_audio(talk_client, monkeypatch):
+    """The /api/talk/speak endpoint streams MP3 bytes from Kokoro as they
+    arrive (instead of buffering the whole reply into a single Response).
+    Verify the streamed bytes are concatenated correctly + the right
+    headers are set so reverse proxies don't re-buffer the stream."""
+    async def fake_stream(text):
         assert text == "read this"
-        return b"mp3 bytes", "audio/mpeg"
+        # Simulate Kokoro emitting two chunks as the audio synthesises.
+        yield b"mp3 chunk 1 "
+        yield b"mp3 chunk 2"
 
-    monkeypatch.setattr("routers.talk._speak_text", fake_speak)
+    monkeypatch.setattr("routers.talk._stream_speech", fake_stream)
 
     resp = talk_client.post("/api/talk/speak", data={"text": "read this"})
     assert resp.status_code == 200, resp.text
-    assert resp.content == b"mp3 bytes"
+    assert resp.content == b"mp3 chunk 1 mp3 chunk 2"
     assert resp.headers["content-type"].startswith("audio/mpeg")
+    # Critical for streaming through nginx / dream-proxy: without this
+    # the reverse proxy would re-buffer the stream and undo our work.
+    assert resp.headers.get("X-Accel-Buffering") == "no"
+
+
+def test_talk_speak_handles_empty_stream(talk_client, monkeypatch):
+    """If Kokoro errors before any audio is produced, the streaming
+    response should close cleanly with empty body — the SPA's `if (!resp.ok
+    || !resp.body)` short-circuit then suppresses playback without
+    interrupting the text chat."""
+    async def fake_stream(text):
+        # Kokoro upstream failure: nothing to yield.
+        if False:
+            yield b""  # pragma: no cover
+
+    monkeypatch.setattr("routers.talk._stream_speech", fake_stream)
+
+    resp = talk_client.post("/api/talk/speak", data={"text": "silent"})
+    assert resp.status_code == 200
+    assert resp.content == b""
 
 
 # ----------------------------------------------------------------------

--- a/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/DreamTalk.jsx
@@ -143,7 +143,72 @@ export default function DreamTalk() {
         body,
         credentials: 'same-origin',
       })
-      if (!resp.ok) return
+      if (!resp.ok || !resp.body) return
+
+      // Preferred path: MediaSource API plays MP3 chunks as they arrive
+      // from the dashboard-api's streaming /api/talk/speak. Time-to-first-
+      // audio drops from "wait for the whole reply to synthesise"
+      // (~5-15s on a multi-sentence reply) to "wait for the first chunk
+      // out of Kokoro" (~500ms-1s). Compared to the previous behaviour
+      // the user hears the assistant nearly immediately after text
+      // completes streaming.
+      //
+      // Browser support note: MediaSource for audio/mpeg is universal in
+      // modern browsers (97%+ as of 2026). Older browsers transparently
+      // fall through to the Blob path below — no per-user setup, no
+      // codec configuration, no permission prompts in either path.
+      const canStream =
+        typeof globalThis.MediaSource !== 'undefined' &&
+        globalThis.MediaSource.isTypeSupported?.('audio/mpeg')
+
+      if (canStream) {
+        const ms = new globalThis.MediaSource()
+        const url = URL.createObjectURL(ms)
+        const audio = new Audio(url)
+        audio.addEventListener('ended', () => URL.revokeObjectURL(url), { once: true })
+        audio.addEventListener('error', () => URL.revokeObjectURL(url), { once: true })
+        // sourceopen fires once the MediaSource is attached to the
+        // <audio> element. We can only call addSourceBuffer / appendBuffer
+        // after that, so gate the streaming loop on the event.
+        await new Promise((resolve, reject) => {
+          ms.addEventListener('sourceopen', resolve, { once: true })
+          ms.addEventListener('error', reject, { once: true })
+        })
+        const sb = ms.addSourceBuffer('audio/mpeg')
+        // Start playback as soon as the audio element has at least one
+        // sample buffered. Some browsers require this `play()` to land
+        // before the user gesture is consumed; the calling code is
+        // already inside a user-initiated flow (the prior chat submit),
+        // so autoplay is allowed.
+        audio.play().catch(() => {})
+        const reader = resp.body.getReader()
+        try {
+          while (true) {
+            const { value, done } = await reader.read()
+            if (done) break
+            // appendBuffer is async — wait for the previous chunk to
+            // commit before pushing the next one. Without this the
+            // browser throws InvalidStateError when buffers overlap.
+            await new Promise((resolve, reject) => {
+              sb.addEventListener('updateend', resolve, { once: true })
+              sb.addEventListener('error', reject, { once: true })
+              sb.appendBuffer(value)
+            })
+          }
+          if (ms.readyState === 'open') ms.endOfStream()
+        } catch {
+          if (ms.readyState === 'open') {
+            try { ms.endOfStream() } catch { /* already closed */ }
+          }
+        }
+        return
+      }
+
+      // Fallback for browsers without MediaSource support for audio/mpeg.
+      // Same behaviour as the pre-streaming path: collect the whole body
+      // into a Blob, then play. The dashboard-api is still streaming on
+      // the network — we just wait until it's all here before starting
+      // playback. Strictly no worse than today.
       const blob = await resp.blob()
       const url = URL.createObjectURL(blob)
       const audio = new Audio(url)


### PR DESCRIPTION
## Summary

Operator feedback: *"sometimes the TTS on the dream talk agent is slow to respond or doesn't respond."*

Diagnosed two stacked problems:

1. **`/api/talk/speak` buffered Kokoro's entire MP3 response into memory** (`httpx.AsyncClient.post().content`) before returning anything to the SPA. Kokoro itself internally streams chunks in ~500ms-1s each, but the full mux takes 5-15s on multi-sentence Hermes replies — so the SPA's `new Audio(blob_url)` saw multiple seconds of silence after text finished streaming before any sound played.
2. The 120s upstream timeout meant long replies that exceeded it silently 503'd, and the SPA's catch-all swallowed the error — the "doesn't respond at all" failure mode.

Both are fixed by streaming end-to-end: dashboard-api → SPA via `StreamingResponse` + `fetch().body.getReader()` + browser `MediaSource` API.

## Live measurement on strix-halo (342-char reply)

| metric | pre-fix | now |
|---|---|---|
| time to first byte | 7.5s (full body buffered) | **17ms** |
| total transfer | 7.5s | 4.5s |
| MP3 size | 374 KB | 374 KB (same audio) |

User-perceived **time-to-first-audio** is now bounded by Kokoro's first-chunk synthesis time (~500ms-1s) instead of the full-mux duration. On short replies the win is smaller but still meaningful.

## No per-user setup

Same QR-scan-and-chat flow. Same browsers work. No app install, no service worker, no codec configuration, no permission prompts.

- **MediaSource API for `audio/mpeg`** has universal modern-browser support (≥97% globally as of 2026, including iOS Safari and Android Chrome).
- **Feature-detect path** — `MediaSource.isTypeSupported('audio/mpeg')`. Older browsers transparently fall back to the previous Blob path. Same wall-clock as today on those, no regression.

## Changes

### `routers/talk.py`

- Replace `_speak_text` (buffered) with `_stream_speech` async generator that yields Kokoro's audio chunks as they arrive (`httpx.stream` + `resp.aiter_bytes`). On mid-stream Kokoro error: log + return cleanly so the browser hears whatever audio it already buffered (truncated audio > silence).
- `/api/talk/speak` returns `StreamingResponse(_stream_speech, ...)` with:
  - `Cache-Control: no-store, no-cache`
  - `X-Accel-Buffering: no` so reverse proxies (dream-proxy etc.) don't re-buffer the stream and undo the work.

### `DreamTalk.jsx`

- `speak()` prefers the browser's MediaSource API:
  1. Open a `MediaSource` + attach to a fresh `Audio` element
  2. `addSourceBuffer('audio/mpeg')`
  3. Read `resp.body.getReader()` chunks and `appendBuffer` them (with `updateend` synchronization so the browser doesn't `InvalidStateError` on overlapping chunks)
  4. `audio.play()` as soon as the first chunk is buffered
- Feature-detect: when MediaSource isn't supported, transparently falls back to the previous Blob path.

## Tests

**Backend** (`test_talk.py`, 30 passing):
- `test_talk_speak_streams_audio`: streaming generator's bytes concatenated correctly + `X-Accel-Buffering: no` header in place so reverse proxies don't re-buffer
- `test_talk_speak_handles_empty_stream`: covers the Kokoro-errored-before-first-byte path; SPA's `if (!resp.body)` short-circuit handles the empty response cleanly

**Frontend** (`DreamTalk.test.jsx`, 11 passing): existing tests exercise the Blob fallback path which the new code preserves. MediaSource isn't in jsdom by default; live verification on strix-halo (above) confirms the MediaSource branch.

## Risk

- Failure mode changes slightly: today a Kokoro mid-stream error silently 503'd; now it returns a truncated MP3. Both are silent failures from the SPA's perspective ("audio is an enhancement, never interrupt text chat") — strictly better UX with the truncation path because the user hears most of the reply instead of nothing.
- The X-Accel-Buffering: no header is non-standard but widely honored (nginx, traefik). dream-proxy is Caddy which respects it. No-op on direct connections.

## Follow-ups (out of scope)

- Per-sentence TTS kickoff during text generation: today TTS starts after Hermes's `complete` frame. Could start TTS on sentence boundaries during `delta` frames for even lower latency. Bigger SPA refactor; defer.
- Voice selector UI: `af_heart` is hardcoded. Operators with strong voice preferences need to edit `TTS_VOICE` in compose env. Separate feature.
