### PR TITLE
fix(hermes): refresh Windows/Linux SOUL persona before compose

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -997,16 +997,24 @@ cmd_restart() {
 
     [[ "$rebuild_images" == "true" ]] && _dream_cli_rebuild_images "${flags[@]}"
 
-    local refresh_soul="false"
-    if [[ -z "$service" || "$service" == "hermes" ]]; then
-        refresh_soul="true"
+    local resolved_service="$service"
+    if [[ -n "$resolved_service" ]]; then
+        resolved_service=$(resolve_service "$resolved_service")
     fi
 
-    if [[ -z "$service" ]]; then
+    local refresh_soul="false"
+    if [[ -z "$resolved_service" || "$resolved_service" == "hermes" ]]; then
+        refresh_soul="true"
+        # Must run before compose as well as after it. If a previous failed
+        # compose created data/persona/SOUL.md as a directory, Docker will fail
+        # the Hermes file bind mount before the post-start refresh can repair it.
+        _dream_cli_refresh_soul || true
+    fi
+
+    if [[ -z "$resolved_service" ]]; then
         _compose_run_with_summary "Restarting all services" "${flags[@]}" up -d
     else
-        service=$(resolve_service "$service")
-        _compose_run_with_summary "Restarting $service" "${flags[@]}" up -d "$service"
+        _compose_run_with_summary "Restarting $resolved_service" "${flags[@]}" up -d "$resolved_service"
     fi
 
     # Refresh SOUL.md after compose has ensured Hermes is running, so the
@@ -1093,13 +1101,27 @@ cmd_start() {
 
     [[ "$rebuild_images" == "true" ]] && _dream_cli_rebuild_images "${flags[@]}"
 
-    if [[ -z "$service" ]]; then
+    local resolved_service="$service"
+    if [[ -n "$resolved_service" ]]; then
+        resolved_service=$(resolve_service "$resolved_service")
+    fi
+
+    local refresh_soul="false"
+    if [[ -z "$resolved_service" || "$resolved_service" == "hermes" ]]; then
+        refresh_soul="true"
+        _dream_cli_refresh_soul || true
+    fi
+
+    if [[ -z "$resolved_service" ]]; then
         _compose_run_with_summary "Starting all services" "${flags[@]}" up -d
     else
-        service=$(resolve_service "$service")
-        _run_hook "$service" "pre_start"
-        _compose_run_with_summary "Starting $service" "${flags[@]}" up -d "$service"
-        _run_hook "$service" "post_start"
+        _run_hook "$resolved_service" "pre_start"
+        _compose_run_with_summary "Starting $resolved_service" "${flags[@]}" up -d "$resolved_service"
+        _run_hook "$resolved_service" "post_start"
+    fi
+
+    if [[ "$refresh_soul" == "true" ]]; then
+        _dream_cli_refresh_soul || true
     fi
 }
 

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -48,7 +48,7 @@ else
     _phase06_step "create-directories"
     dream_progress 38 "directories" "Creating directory structure"
     mkdir -p "$INSTALL_DIR"/{config,data,models}
-    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield,ape,token-spy,hermes}
+    mkdir -p "$INSTALL_DIR"/data/{open-webui,whisper,tts,n8n,qdrant,models,privacy-shield,ape,token-spy,hermes,persona}
     mkdir -p "$INSTALL_DIR"/data/hermes-proxy/{caddy-data,caddy-config}
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -580,6 +580,10 @@ MODELS_INI_EOF
         _soul_output="$INSTALL_DIR/data/persona/SOUL.md"
         _soul_template="$INSTALL_DIR/extensions/services/hermes/SOUL.md.template"
         mkdir -p "$(dirname "$_soul_output")"
+        if [[ -e "$_soul_output" && ! -f "$_soul_output" ]]; then
+            rm -rf "$_soul_output" || \
+                warn "Could not replace invalid Hermes SOUL.md path at $_soul_output"
+        fi
         if [[ -n "$_python_cmd" && -f "$_soul_builder" ]]; then
             "$_python_cmd" "$_soul_builder" >>"$LOG_FILE" 2>&1 || \
                 warn "Could not generate Hermes installation-context SOUL.md (non-fatal — Hermes will use the template's default text)"

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -144,6 +144,73 @@ function Get-DreamEnvValue {
     return $Default
 }
 
+function Invoke-HermesSoulRefresh {
+    <#
+    .SYNOPSIS
+        Render data/persona/SOUL.md and optionally copy it into dream-hermes.
+    #>
+    param([switch]$SyncContainer)
+
+    $builder = Join-Path (Join-Path $InstallDir "scripts") "build-installation-context.py"
+    $template = Join-Path (Join-Path (Join-Path $InstallDir "extensions") "services\hermes") "SOUL.md.template"
+    $envPath = Join-Path $InstallDir ".env"
+    $output = Join-Path (Join-Path (Join-Path $InstallDir "data") "persona") "SOUL.md"
+    $outputDir = Split-Path -Parent $output
+
+    if (-not (Test-Path $template)) {
+        Write-AIWarn "Hermes SOUL.md template not found; skipping persona refresh."
+        return
+    }
+
+    New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
+    $rendered = $false
+    if (Test-Path $builder) {
+        $pythonCandidates = @(
+            @{ Command = "python"; Args = @() },
+            @{ Command = "python3"; Args = @() },
+            @{ Command = "py"; Args = @("-3") }
+        )
+
+        foreach ($candidate in $pythonCandidates) {
+            $cmd = Get-Command $candidate.Command -ErrorAction SilentlyContinue
+            if (-not $cmd -or -not $cmd.Source) { continue }
+            try {
+                & $cmd.Source @($candidate.Args) $builder "--template" $template "--env" $envPath "--output" $output *>> $script:DS_LOG_FILE
+                if ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $output -PathType Leaf)) {
+                    $rendered = $true
+                    break
+                }
+            } catch {
+                Add-Content -Path $script:DS_LOG_FILE -Value "Hermes SOUL.md refresh failed with $($candidate.Command): $($_.Exception.Message)"
+            }
+        }
+    }
+
+    if (-not $rendered) {
+        if (Test-Path -LiteralPath $output -PathType Container) {
+            Remove-Item -LiteralPath $output -Recurse -Force
+        }
+        if (-not (Test-Path -LiteralPath $output -PathType Leaf)) {
+            $content = Get-Content -LiteralPath $template -Raw
+            $content = $content -replace "(?m)^\s*<!-- INSTALLATION_CONTEXT -->\s*\r?\n?", ""
+            [System.IO.File]::WriteAllText($output, $content, (New-Object System.Text.UTF8Encoding($false)))
+            Write-AIWarn "Generated fallback Hermes SOUL.md without dynamic installation context"
+        }
+    }
+
+    if ($SyncContainer) {
+        $names = & docker ps --format "{{.Names}}" 2>$null
+        if ($names -contains "dream-hermes") {
+            & docker exec dream-hermes cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md *>> $script:DS_LOG_FILE
+            if ($LASTEXITCODE -eq 0) {
+                Write-AISuccess "Synced Hermes SOUL.md"
+            } else {
+                Write-AIWarn "Could not sync Hermes SOUL.md into running container"
+            }
+        }
+    }
+}
+
 function Get-DreamVoiceDiagnosis {
     $whisperPort = Get-DreamEnvValue -Name "WHISPER_PORT" -Default "9000"
     $whisperUrl = "http://localhost:$whisperPort"
@@ -653,8 +720,12 @@ function Invoke-Start {
         }
 
         $flags = Get-ComposeFlags
+        $hermesInStack = Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "hermes"
         if ($Service) {
             Write-AI "Starting $Service..."
+            if ($Service -eq "hermes" -and $hermesInStack) {
+                Invoke-HermesSoulRefresh
+            }
             $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
                 -ComposeArgs @("up", "-d", $Service)
             if ($composeExit -ne 0) {
@@ -664,7 +735,13 @@ function Invoke-Start {
                 exit 1
             }
             Write-AISuccess "$Service started"
+            if ($Service -eq "hermes" -and $hermesInStack) {
+                Invoke-HermesSoulRefresh -SyncContainer
+            }
         } else {
+            if ($hermesInStack) {
+                Invoke-HermesSoulRefresh
+            }
             Write-AI "Starting all services..."
             $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
                 -ComposeArgs @("up", "-d")
@@ -674,6 +751,9 @@ function Invoke-Start {
                 exit 1
             }
             Write-AISuccess "All services started"
+            if ($hermesInStack) {
+                Invoke-HermesSoulRefresh -SyncContainer
+            }
         }
     } finally {
         Pop-Location
@@ -730,8 +810,12 @@ function Invoke-Restart {
         Ensure-LlamaCpuBudget
 
         $flags = Get-ComposeFlags
+        $hermesInStack = Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "hermes"
         if ($Service) {
             Write-AI "Restarting $Service..."
+            if ($Service -eq "hermes" -and $hermesInStack) {
+                Invoke-HermesSoulRefresh
+            }
             $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
                 -ComposeArgs @("restart", $Service)
             if ($composeExit -ne 0) {
@@ -741,11 +825,17 @@ function Invoke-Restart {
                 exit 1
             }
             Write-AISuccess "$Service restarted"
+            if ($Service -eq "hermes" -and $hermesInStack) {
+                Invoke-HermesSoulRefresh -SyncContainer
+            }
         } else {
             # For AMD, also restart native inference server
             if (Test-Path $script:INFERENCE_PID_FILE) {
                 Stop-NativeInferenceServer
                 Start-NativeInferenceServer
+            }
+            if ($hermesInStack) {
+                Invoke-HermesSoulRefresh
             }
             Write-AI "Restarting all services..."
             $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
@@ -756,6 +846,9 @@ function Invoke-Restart {
                 exit 1
             }
             Write-AISuccess "All services restarted"
+            if ($hermesInStack) {
+                Invoke-HermesSoulRefresh -SyncContainer
+            }
         }
     } finally {
         Pop-Location

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -912,6 +912,10 @@ if ($dryRun) {
         }
         Write-AISuccess "Docker services started"
 
+        if ($enableHermes -and (Get-Command Invoke-HermesSoulRefresh -ErrorAction SilentlyContinue)) {
+            Invoke-HermesSoulRefresh -InstallRoot $installDir -SyncContainer
+        }
+
         # Save compose flags for dream.ps1 (BOM-free for reliable parsing)
         $flagsFile = Join-Path $installDir ".compose-flags"
         Write-Utf8NoBom -Path $flagsFile -Content ($composeFlags -join " ")

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -67,6 +67,7 @@ $_dirs = @(
     (Join-Path $_dataDir "token-spy"),
     (Join-Path $_dataDir "privacy-shield"),
     (Join-Path $_dataDir "hermes"),
+    (Join-Path $_dataDir "persona"),
     (Join-Path (Join-Path $_dataDir "hermes-proxy") "caddy-data"),
     (Join-Path (Join-Path $_dataDir "hermes-proxy") "caddy-config")
 )
@@ -249,6 +250,75 @@ function Update-HermesConfigFile {
     Write-Utf8NoBom -Path $Path -Content $content
 }
 
+function Invoke-HermesSoulRefresh {
+    param(
+        [Parameter(Mandatory = $true)][string]$InstallRoot,
+        [switch]$SyncContainer
+    )
+
+    $_builder = Join-Path (Join-Path $InstallRoot "scripts") "build-installation-context.py"
+    $_template = Join-Path (Join-Path (Join-Path $InstallRoot "extensions") "services\hermes") "SOUL.md.template"
+    $_envPath = Join-Path $InstallRoot ".env"
+    $_output = Join-Path (Join-Path (Join-Path $InstallRoot "data") "persona") "SOUL.md"
+    $_outputDir = Split-Path -Parent $_output
+
+    if (-not (Test-Path $_template)) {
+        Write-AIWarn "Hermes SOUL.md template not found at $_template"
+        return
+    }
+
+    New-Item -ItemType Directory -Path $_outputDir -Force | Out-Null
+    $_rendered = $false
+
+    if (Test-Path $_builder) {
+        $_pythonCandidates = @(
+            @{ Command = "python"; Args = @() },
+            @{ Command = "python3"; Args = @() },
+            @{ Command = "py"; Args = @("-3") }
+        )
+
+        foreach ($_candidate in $_pythonCandidates) {
+            $_cmd = Get-Command $_candidate.Command -ErrorAction SilentlyContinue
+            if (-not $_cmd -or -not $_cmd.Source) { continue }
+
+            try {
+                & $_cmd.Source @($_candidate.Args) $_builder "--template" $_template "--env" $_envPath "--output" $_output *>> $script:DS_LOG_FILE
+                if ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $_output -PathType Leaf)) {
+                    $_rendered = $true
+                    break
+                }
+            } catch {
+                $_msg = $_.Exception.Message
+                Add-Content -Path $script:DS_LOG_FILE -Value "Hermes SOUL.md render failed with $($_candidate.Command): $_msg"
+            }
+        }
+    }
+
+    if (-not $_rendered) {
+        if (Test-Path -LiteralPath $_output -PathType Container) {
+            Remove-Item -LiteralPath $_output -Recurse -Force
+        }
+        if (-not (Test-Path -LiteralPath $_output -PathType Leaf)) {
+            $_content = Get-Content -LiteralPath $_template -Raw
+            $_content = $_content -replace "(?m)^\s*<!-- INSTALLATION_CONTEXT -->\s*\r?\n?", ""
+            Write-Utf8NoBom -Path $_output -Content $_content
+            Write-AIWarn "Generated fallback Hermes SOUL.md without dynamic installation context"
+        }
+    }
+
+    if ($SyncContainer) {
+        $_names = & docker ps --format "{{.Names}}" 2>$null
+        if ($_names -contains "dream-hermes") {
+            & docker exec dream-hermes cp /opt/hermes/docker/SOUL.md /opt/data/SOUL.md *>> $script:DS_LOG_FILE
+            if ($LASTEXITCODE -eq 0) {
+                Write-AISuccess "Synced Hermes SOUL.md into running container"
+            } else {
+                Write-AIWarn "Could not sync Hermes SOUL.md into running container"
+            }
+        }
+    }
+}
+
 if ($enableHermes) {
     $_hermesModel = $(if ($tierConfig.GgufFile) {
         if ($gpuInfo.Backend -eq "amd") { "extra.$($tierConfig.GgufFile)" } else { $tierConfig.GgufFile }
@@ -266,6 +336,7 @@ if ($enableHermes) {
     $_hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
     Update-HermesConfigFile -Path $_hermesTemplate -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
     Update-HermesConfigFile -Path $_hermesLive -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+    Invoke-HermesSoulRefresh -InstallRoot $installDir
     Write-AISuccess "Patched Hermes config (model=$_hermesModel, context=$($tierConfig.MaxContext))"
 }
 

--- a/dream-server/tests/test-windows-hermes-soul.sh
+++ b/dream-server/tests/test-windows-hermes-soul.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Dream Server Hermes SOUL.md install contract tests
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PHASE_06="$ROOT_DIR/installers/windows/phases/06-directories.ps1"
+INSTALLER="$ROOT_DIR/installers/windows/install-windows.ps1"
+WINDOWS_CLI="$ROOT_DIR/installers/windows/dream.ps1"
+LINUX_PHASE_06="$ROOT_DIR/installers/phases/06-directories.sh"
+LINUX_PHASE_11="$ROOT_DIR/installers/phases/11-services.sh"
+LINUX_CLI="$ROOT_DIR/dream-cli"
+HERMES_COMPOSE="$ROOT_DIR/extensions/services/hermes/compose.yaml"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+reject() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        fail "$label"
+    else
+        pass "$label"
+    fi
+}
+
+echo ""
+echo "=== Hermes SOUL.md install contract tests ==="
+echo ""
+
+[[ -f "$PHASE_06" ]] && pass "Windows phase 06 exists" || fail "Windows phase 06 missing"
+[[ -f "$INSTALLER" ]] && pass "Windows installer exists" || fail "Windows installer missing"
+[[ -f "$WINDOWS_CLI" ]] && pass "Windows dream.ps1 exists" || fail "Windows dream.ps1 missing"
+[[ -f "$LINUX_PHASE_06" ]] && pass "Linux phase 06 exists" || fail "Linux phase 06 missing"
+[[ -f "$LINUX_PHASE_11" ]] && pass "Linux phase 11 exists" || fail "Linux phase 11 missing"
+[[ -f "$LINUX_CLI" ]] && pass "Linux dream-cli exists" || fail "Linux dream-cli missing"
+
+check '(Join-Path $_dataDir "persona")' "$PHASE_06" "Windows installer creates data/persona"
+check 'function Invoke-HermesSoulRefresh' "$PHASE_06" "Windows phase 06 defines Hermes SOUL refresh"
+check 'build-installation-context.py' "$PHASE_06" "Windows phase 06 calls installation-context builder"
+check 'SOUL.md.template' "$PHASE_06" "Windows phase 06 has template fallback"
+check 'INSTALLATION_CONTEXT' "$PHASE_06" "fallback removes dynamic marker"
+check 'Invoke-HermesSoulRefresh -InstallRoot $installDir' "$PHASE_06" "Windows phase 06 renders SOUL before compose"
+check 'Invoke-HermesSoulRefresh -InstallRoot $installDir -SyncContainer' "$INSTALLER" "Windows installer syncs SOUL after compose"
+
+check 'function Invoke-HermesSoulRefresh' "$WINDOWS_CLI" "Windows CLI can refresh Hermes SOUL"
+check 'Invoke-HermesSoulRefresh -SyncContainer' "$WINDOWS_CLI" "Windows CLI syncs SOUL into running Hermes"
+check 'Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "hermes"' "$WINDOWS_CLI" "Windows CLI gates SOUL refresh on Hermes compose presence"
+
+check 'hermes,persona' "$LINUX_PHASE_06" "Linux installer creates data/persona"
+check 'rm -rf "$_soul_output"' "$LINUX_PHASE_11" "Linux install self-heals directory SOUL path before compose"
+check '_dream_cli_refresh_soul || true' "$LINUX_CLI" "Linux CLI refreshes SOUL before compose"
+check 'If a previous failed' "$LINUX_CLI" "Linux CLI documents pre-compose SOUL repair"
+
+check './data/persona/SOUL.md:/opt/hermes/docker/SOUL.md:ro' "$HERMES_COMPOSE" "Hermes compose mounts generated persona file"
+reject ':/opt/data/SOUL.md' "$HERMES_COMPOSE" "Hermes compose avoids nested /opt/data/SOUL.md bind mount"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
Adds Windows parity for the Hermes `SOUL.md` persona flow.

Recent persona fixes moved Hermes to bind-mount the generated `data/persona/SOUL.md` file into `/opt/hermes/docker/SOUL.md`. Linux/macOS already render and sync that file around compose startup, but the Windows installer only created `data/hermes` and patched Hermes config. On Docker Desktop, that can leave `data/persona/SOUL.md` missing before compose, causing a file bind-mount failure or Docker creating `SOUL.md` as a directory.

## What changed
- Creates `data/persona` during Windows setup.
- Renders `data/persona/SOUL.md` from `scripts/build-installation-context.py` before compose startup when Hermes is enabled.
- Falls back to `SOUL.md.template` if Python or the dynamic renderer is unavailable, so the bind source is still a real file.
- Syncs the generated persona into the running `dream-hermes` container after compose startup.
- Adds the same refresh/sync path to Windows `dream.ps1 start hermes`, `start`, `restart hermes`, and `restart`.
- Adds a Windows Hermes SOUL contract test and wires it into the Linux smoke workflow.

## Why
This closes the Windows side of the same Docker Desktop bind-mount class recently fixed for macOS/Linux. The change is intentionally scoped to Windows and does not alter the Hermes runtime contract for Linux/macOS.

## Validation
- `bash tests/test-windows-hermes-soul.sh`
- `bash tests/test-windows-installer-flags.sh`
- PowerShell parser check for:
  - `dream-server/installers/windows/phases/06-directories.ps1`
  - `dream-server/installers/windows/install-windows.ps1`
  - `dream-server/installers/windows/dream.ps1`
- `git diff --check`