### PR TITLE
fix(bootstrap): keep fallback model serving when compose flags are missing

### DIFF
--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -343,6 +343,23 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
     COMPOSE_ARGS=()
     if [[ -f "$INSTALL_DIR/.compose-flags" ]]; then
         read -ra COMPOSE_ARGS <<< "$(cat "$INSTALL_DIR/.compose-flags")"
+    elif [[ -x "$INSTALL_DIR/scripts/resolve-compose-stack.sh" ]]; then
+        _tier="1"
+        if [[ -f "$ENV_FILE" ]]; then
+            _tier=$(grep -E '^TIER=' "$ENV_FILE" | cut -d= -f2 | tr -d '"\047\r')
+            [[ -n "$_tier" ]] || _tier="1"
+        fi
+        _resolved_env=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
+            --script-dir "$INSTALL_DIR" \
+            --tier "$_tier" \
+            --gpu-backend "${_gpu_backend:-cpu}" \
+            --env 2>/dev/null || true)
+        _resolved_flags=$(printf '%s\n' "$_resolved_env" | sed -n 's/^COMPOSE_FLAGS="\([^"]*\)".*/\1/p')
+        if [[ -n "$_resolved_flags" ]]; then
+            read -ra COMPOSE_ARGS <<< "$_resolved_flags"
+            printf '%s\n' "$_resolved_flags" > "$INSTALL_DIR/.compose-flags"
+            log "Recovered compose flags via resolve-compose-stack.sh"
+        fi
     elif [[ -f "$INSTALL_DIR/docker-compose.base.yml" ]]; then
         COMPOSE_ARGS=(-f "$INSTALL_DIR/docker-compose.base.yml")
         case "${_gpu_backend}" in
@@ -406,17 +423,15 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
         env -u GGUF_FILE -u LLM_MODEL -u MAX_CONTEXT -u CTX_SIZE \
             $DOCKER_COMPOSE_CMD "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps llama-server 2>&1 || true
     else
-        # No compose flags — fall back to docker rm + manual recreate. On
-        # NVIDIA the original CMD points at /models/${BOOTSTRAP_GGUF_FILE}
-        # which Phase 4b just deleted; on AMD the container env still has
-        # bootstrap-tier LEMONADE_CTX_SIZE. Either way `docker start`
-        # would reuse the stale state, so we remove the container and ask
-        # the operator to bring it back up via `dream restart` (which
-        # re-runs compose with the latest .env).
-        $DOCKER_CMD stop dream-llama-server 2>&1 || true
-        $DOCKER_CMD rm dream-llama-server 2>&1 || true
-        log "WARNING: .compose-flags not found — container removed. Run 'dream restart' to bring llama-server back up with the correct model + context size."
+        # No reliable compose stack is available. Do NOT stop/remove the
+        # currently-running bootstrap container here: leaving an old but
+        # serving model online is safer than turning a completed download into
+        # an outage. The operator can repair the compose cache or re-run the
+        # installer; both paths can recreate llama-server from the updated .env.
+        log "WARNING: unable to recover compose flags — leaving the current llama-server container untouched."
+        log "Manual recovery: re-run the installer, or restore $INSTALL_DIR/.compose-flags and run the Dream Server CLI restart command."
         write_status "failed"
+        exit 1
     fi
 
     # Pick health endpoint based on GPU backend — Lemonade (AMD) serves

--- a/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -44,6 +44,25 @@ if grep -qE '\bstop[[:space:]]+llama-server\b' <<<"$active_code"; then
 fi
 pass "llama.cpp hot-swap does not use stop + up"
 
+grep -qF 'resolve-compose-stack.sh' <<<"$active_code" \
+    || fail "missing .compose-flags fallback must try resolve-compose-stack.sh before giving up"
+pass "missing .compose-flags fallback tries compose resolver"
+
+missing_flags_block="$(awk '
+    /unable to recover compose flags/ { in_block=1 }
+    in_block { print }
+    in_block && /exit 1/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+grep -qF 'write_status "failed"' <<<"$missing_flags_block" \
+    || fail "missing compose flags fallback must mark bootstrap status failed"
+grep -qF 'exit 1' <<<"$missing_flags_block" \
+    || fail "missing compose flags fallback must stop before health checks"
+if grep -qE '\b(stop|rm)[[:space:]]+dream-llama-server\b' <<<"$missing_flags_block"; then
+    fail "missing compose flags fallback must not stop/remove the serving llama-server container"
+fi
+pass "missing .compose-flags fallback is non-destructive"
+
 openclaw_recreate_block="$(awk '
     /Recreating OpenClaw to pick up model change/ { in_block=1 }
     in_block { print }


### PR DESCRIPTION
## Summary
Follow-up to #1340. This makes the bootstrap full-model swap safer when `.compose-flags` is missing or stale.

## What changed
- `bootstrap-upgrade.sh` now tries to recover compose flags through `scripts/resolve-compose-stack.sh` before recreating `llama-server`.
- If compose flags still cannot be recovered, the script now fails cleanly:
  - marks bootstrap status as failed;
  - prints a manual recovery path;
  - exits before health checks;
  - does not stop or remove the currently serving `dream-llama-server` container.
- Extends the bootstrap hot-swap contract test to cover:
  - compose resolver recovery;
  - non-destructive missing-flags failure;
  - no fallback `docker stop` / `docker rm` path.

## Why
#1340 correctly fixed the bootstrap-to-full-model swap by force-recreating `llama-server` so updated `GGUF_FILE` and context settings land. The remaining sharp edge was the missing `.compose-flags` fallback: if compose metadata was unavailable, the script could remove the running container and leave the user worse off.

A failed model swap should preserve the currently serving model whenever possible and fail with a clear recovery path.

## Validation
- `bash -n dream-server/scripts/bootstrap-upgrade.sh dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh`
- `bash dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh`
- `git diff --check`

Note: `bash tests/contracts/test-installer-contracts.sh` could not run in this local Windows shell because `jq` is not installed (`[FAIL] jq is required`).