### PR TITLE
fix(talk): normalize vision backend base URL

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -84,6 +84,13 @@ LLM_BACKEND=llama-server
 LLM_API_BASE_PATH=/v1
 LLM_API_URL=http://llama-server:8080
 
+# Dream Talk image attachment vision backend. Leave empty to use the local
+# inference backend. May be a host root (http://host:8080) or an
+# OpenAI-compatible base URL (http://host:8080/v1 or /api/v1).
+DREAM_TALK_VISION_URL=
+DREAM_TALK_VISION_KEY=
+DREAM_TALK_VISION_MODEL=user.Qwen3.6-35B-A3B-Vision
+
 # AMD local inference runtime selected by the installer.
 # Linux AMD: lemonade / rocm / container
 # Windows AMD: lemonade or llama-server / vulkan / host

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -52,6 +52,21 @@
       "description": "Base API path for the inference backend",
       "default": "/v1"
     },
+    "DREAM_TALK_VISION_URL": {
+      "type": "string",
+      "description": "Optional OpenAI-compatible base URL for Dream Talk image attachments. Accepts either a host root or a base path ending in /v1 or /api/v1.",
+      "default": ""
+    },
+    "DREAM_TALK_VISION_KEY": {
+      "type": "string",
+      "description": "Optional bearer token for the Dream Talk vision backend.",
+      "default": ""
+    },
+    "DREAM_TALK_VISION_MODEL": {
+      "type": "string",
+      "description": "Vision-capable model id used by Dream Talk image attachments.",
+      "default": "user.Qwen3.6-35B-A3B-Vision"
+    },
     "AMD_INFERENCE_RUNTIME": {
       "type": "string",
       "description": "Explicit AMD local inference runtime selected by the installer. Empty when AMD local inference is not active.",

--- a/dream-server/docker-compose.base.yml
+++ b/dream-server/docker-compose.base.yml
@@ -239,11 +239,11 @@ services:
       # Dream Talk's image-attachment endpoint calls the vision backend
       # directly (bypassing litellm because litellm's wildcard model
       # routing collapses our model id down to whatever's loaded).
-      # Defaults point at the Lemonade/llama-server service on the
-      # internal docker network — no auth needed there. Operators with
+      # Defaults point at the Lemonade/llama-server OpenAI-compatible base URL
+      # on the internal docker network — no auth needed there. Operators with
       # an external vision server set DREAM_TALK_VISION_URL +
       # DREAM_TALK_VISION_KEY.
-      - DREAM_TALK_VISION_URL=${DREAM_TALK_VISION_URL:-http://llama-server:8080}
+      - DREAM_TALK_VISION_URL=${DREAM_TALK_VISION_URL:-http://llama-server:8080${LLM_API_BASE_PATH:-/v1}}
       - DREAM_TALK_VISION_KEY=${DREAM_TALK_VISION_KEY:-}
       # Model id of the vision-capable variant. Defaults to the user.*
       # name we register on AMD install (Qwen3.6-35B-A3B + mmproj-F16).

--- a/dream-server/extensions/services/dashboard-api/routers/talk.py
+++ b/dream-server/extensions/services/dashboard-api/routers/talk.py
@@ -70,20 +70,40 @@ def _vision_model_name() -> str:
     return os.environ.get("DREAM_TALK_VISION_MODEL", "user.Qwen3.6-35B-A3B-Vision")
 
 
-def _vision_backend_url() -> str:
-    """Where to send multimodal requests. Defaults to Lemonade direct
-    (``http://llama-server:8080``) — NOT litellm — because litellm's
+def _vision_backend_base_url() -> str:
+    """OpenAI-compatible base URL for multimodal requests.
+
+    Defaults to Lemonade / llama-server direct (``http://llama-server:8080/v1``)
+    — NOT litellm — because litellm's
     ``model_name: '*'`` wildcard normalises our ``user.*`` model id down to
     whatever llama-server has currently loaded, which silently downgrades
     image queries to the text-only model. Lemonade routes by exact model
     id and auto-swaps to the vision variant on first multimodal call.
 
-    Operators can override with ``DREAM_TALK_VISION_URL`` for hosts where
-    vision lives somewhere else (e.g. a dedicated VL server).
+    ``DREAM_TALK_VISION_URL`` accepts either a host root
+    (``http://host:8080``) or a full OpenAI-compatible base
+    (``http://host:8080/v1`` / ``http://host:8080/api/v1``). Normalising here
+    keeps Linux container, Windows host, llama-server, and Lemonade paths from
+    accidentally becoming ``/v1/v1`` or ``/api/v1/v1``.
     """
-    return (os.environ.get("DREAM_TALK_VISION_URL")
-            or os.environ.get("LLM_API_URL")
-            or "http://llama-server:8080").rstrip("/")
+    raw = (
+        os.environ.get("DREAM_TALK_VISION_URL")
+        or os.environ.get("LLM_API_URL")
+        or "http://llama-server:8080"
+    ).rstrip("/")
+    if raw.endswith("/v1") or raw.endswith("/api/v1"):
+        return raw
+
+    base_path = (os.environ.get("LLM_API_BASE_PATH") or "/v1").strip()
+    if not base_path:
+        base_path = "/v1"
+    if not base_path.startswith("/"):
+        base_path = f"/{base_path}"
+    return f"{raw}{base_path.rstrip('/')}"
+
+
+def _vision_chat_completions_url() -> str:
+    return f"{_vision_backend_base_url()}/chat/completions"
 
 
 def _vision_backend_key() -> str:
@@ -128,7 +148,7 @@ async def _stream_vision_chat(image_bytes: bytes, content_type: str, prompt_text
         async with httpx.AsyncClient(timeout=timeout) as client:
             async with client.stream(
                 "POST",
-                f"{_vision_backend_url()}/v1/chat/completions",
+                _vision_chat_completions_url(),
                 headers=headers,
                 json=payload,
             ) as resp:

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -910,6 +910,37 @@ def test_talk_attachment_image_too_large_returns_413(talk_client):
     assert resp.status_code == 413
 
 
+def test_talk_vision_url_defaults_to_openai_v1(monkeypatch):
+    """A root inference URL should be normalized to an OpenAI-compatible base."""
+    from routers.talk import _vision_chat_completions_url
+
+    monkeypatch.delenv("DREAM_TALK_VISION_URL", raising=False)
+    monkeypatch.setenv("LLM_API_URL", "http://llama-server:8080")
+    monkeypatch.setenv("LLM_API_BASE_PATH", "/v1")
+
+    assert _vision_chat_completions_url() == "http://llama-server:8080/v1/chat/completions"
+
+
+def test_talk_vision_url_does_not_duplicate_v1(monkeypatch):
+    """Operators may pass a full OpenAI base URL; do not append /v1 twice."""
+    from routers.talk import _vision_chat_completions_url
+
+    monkeypatch.setenv("DREAM_TALK_VISION_URL", "http://vision.local:8080/v1")
+    monkeypatch.setenv("LLM_API_BASE_PATH", "/v1")
+
+    assert _vision_chat_completions_url() == "http://vision.local:8080/v1/chat/completions"
+
+
+def test_talk_vision_url_preserves_lemonade_api_v1(monkeypatch):
+    """Lemonade deployments can use /api/v1 as their OpenAI-compatible base."""
+    from routers.talk import _vision_chat_completions_url
+
+    monkeypatch.setenv("DREAM_TALK_VISION_URL", "http://host.docker.internal:8080/api/v1")
+    monkeypatch.setenv("LLM_API_BASE_PATH", "/v1")
+
+    assert _vision_chat_completions_url() == "http://host.docker.internal:8080/api/v1/chat/completions"
+
+
 def test_talk_attachment_requires_session(test_client):
     """No cookie ⇒ 401 even with a valid file."""
     resp = test_client.post(

--- a/dream-server/installers/windows/docker-compose.windows-amd.yml
+++ b/dream-server/installers/windows/docker-compose.windows-amd.yml
@@ -25,6 +25,11 @@ services:
       - AMD_INFERENCE_SUPPORTED_BACKENDS=${AMD_INFERENCE_SUPPORTED_BACKENDS:-}
       - AMD_INFERENCE_RUNTIME_MODE=${AMD_INFERENCE_RUNTIME_MODE:-unknown}
       - AMD_INFERENCE_MANAGED=${AMD_INFERENCE_MANAGED:-false}
+      # The base compose default points Dream Talk image attachments at the
+      # in-network llama-server service. On Windows AMD, inference runs on the
+      # host instead, so route vision calls through host.docker.internal using
+      # the same API path selected by the installer.
+      - DREAM_TALK_VISION_URL=${DREAM_TALK_VISION_URL:-http://host.docker.internal:${AMD_INFERENCE_PORT:-8080}${LLM_API_BASE_PATH:-/v1}}
 
   open-webui:
     environment:

--- a/dream-server/tests/contracts/test-windows-amd-local-compose.sh
+++ b/dream-server/tests/contracts/test-windows-amd-local-compose.sh
@@ -13,6 +13,9 @@ for f in \
   test -f "$f" || { echo "[FAIL] missing $f"; exit 1; }
 done
 
+grep -q 'DREAM_TALK_VISION_URL=.*host.docker.internal' installers/windows/docker-compose.windows-amd.yml \
+  || { echo "[FAIL] Windows AMD overlay must route Dream Talk vision calls to the host runtime"; exit 1; }
+
 if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>&1; then
   echo "[SKIP] docker compose unavailable"
   exit 0
@@ -39,6 +42,8 @@ grep -q 'http://host.docker.internal:8080/api/v1/health' <<<"$rendered" \
   || { echo "[FAIL] Lemonade readiness probe must use native Windows port 8080"; exit 1; }
 grep -q 'http://host.docker.internal:8080/health' <<<"$rendered" \
   || { echo "[FAIL] llama-server readiness probe must use native Windows port 8080"; exit 1; }
+grep -q 'DREAM_TALK_VISION_URL: http://host.docker.internal:8080/api/v1' <<<"$rendered" \
+  || { echo "[FAIL] Dream Talk vision URL must use the Windows AMD host runtime API path"; exit 1; }
 if grep -q 'host.docker.internal:11434' <<<"$rendered"; then
   echo "[FAIL] Windows AMD local overlay must not inherit OLLAMA_PORT=11434"
   exit 1


### PR DESCRIPTION
## Summary
Fixes Dream Talk image attachment routing so the vision backend URL works across llama-server, Lemonade, Linux containers, and Windows AMD host runtimes.

## What changed
- Normalizes `DREAM_TALK_VISION_URL` as an OpenAI-compatible base URL.
- Accepts either:
  - host root: `http://host:8080`
  - full base: `http://host:8080/v1`
  - Lemonade-style base: `http://host:8080/api/v1`
- Prevents accidental `/v1/v1` or `/api/v1/v1` request paths.
- Updates the default Docker compose value to include `LLM_API_BASE_PATH`.
- Fixes Windows AMD compose so Dream Talk image attachments call the host runtime through `host.docker.internal`, instead of the disabled in-network `llama-server` placeholder.
- Documents the Dream Talk vision envs in `.env.example` and `.env.schema.json`.
- Adds tests for root URL, `/v1`, and `/api/v1` handling.
- Extends the Windows AMD compose contract to guard this path.

## Why
Dream Talk image attachments bypass Hermes and call the vision backend directly. That path was fragile because different supported runtimes expose different OpenAI-compatible base paths, and Windows AMD runs inference on the host instead of inside the Docker network.

Without this, image attachments can fail on Windows AMD or on deployments that provide a full `/v1` or `/api/v1` base URL.

## Validation
- `pytest dream-server/extensions/services/dashboard-api/tests/test_talk.py -q`
- `python -m py_compile dream-server/extensions/services/dashboard-api/routers/talk.py`
- `bash -n dream-server/tests/contracts/test-windows-amd-local-compose.sh`
- `bash dream-server/tests/contracts/test-windows-amd-local-compose.sh`
- `docker compose --env-file <tmp> -f dream-server/docker-compose.base.yml -f dream-server/installers/windows/docker-compose.windows-amd.yml -f dream-server/installers/windows/docker-compose.windows-amd.local.yml config dashboard-api`
- `git diff --check`