### PR TITLE
[codex] fix dashboard feature card links

### DIFF
--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -164,6 +164,17 @@
           "enabled_services_any": { "type": "array", "items": { "type": "string" } },
           "setup_time": { "type": "string" },
           "priority": { "type": "integer", "minimum": 1 },
+          "launch": {
+            "type": "object",
+            "description": "Dashboard feature-card launch target. Use type=service for user-facing service UIs, internal for dashboard routes, and none for backend/API-only features.",
+            "required": ["type"],
+            "properties": {
+              "type": { "type": "string", "enum": ["service", "internal", "none"] },
+              "service": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+              "path": { "type": "string", "pattern": "^/.*" }
+            },
+            "additionalProperties": false
+          },
           "gpu_backends": {
             "type": "array",
             "items": { "type": "string", "enum": ["amd", "nvidia", "apple", "cpu", "none", "all"] },

--- a/dream-server/extensions/services/ape/manifest.yaml
+++ b/dream-server/extensions/services/ape/manifest.yaml
@@ -37,4 +37,6 @@ features:
     enabled_services_any: [ape]
     setup_time: Ready
     priority: 10
+    launch:
+      type: none
     gpu_backends: [all]

--- a/dream-server/extensions/services/brave-search/manifest.yaml
+++ b/dream-server/extensions/services/brave-search/manifest.yaml
@@ -41,4 +41,6 @@ features:
     enabled_services_all: [brave-search]
     setup_time: ~2 minutes
     priority: 50
+    launch:
+      type: none
     gpu_backends: [all]

--- a/dream-server/extensions/services/comfyui/manifest.yaml
+++ b/dream-server/extensions/services/comfyui/manifest.yaml
@@ -33,4 +33,7 @@ features:
     enabled_services_all: [comfyui]
     setup_time: Ready
     priority: 5
+    launch:
+      type: service
+      service: comfyui
     gpu_backends: [amd, nvidia]

--- a/dream-server/extensions/services/dashboard-api/routers/features.py
+++ b/dream-server/extensions/services/dashboard-api/routers/features.py
@@ -4,7 +4,7 @@ import logging
 import os
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from config import FEATURES, GPU_BACKEND, SERVICES
 from gpu import get_gpu_info, get_gpu_tier
@@ -76,6 +76,13 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
     else:
         status = "available"
 
+    launch = feature.get("launch")
+    if launch is None:
+        if enabled_all:
+            launch = {"type": "service", "service": enabled_all[0]}
+        elif enabled_any:
+            launch = {"type": "service", "service": enabled_any[0]}
+
     return {
         "id": feature["id"],
         "name": feature["name"],
@@ -95,6 +102,9 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
             "servicesMissing": services_missing,
             "servicesOk": services_ok,
         },
+        "enabledServicesAll": enabled_all,
+        "enabledServicesAny": enabled_any,
+        "launch": launch,
         "setupTime": feature.get("setup_time", "Unknown"),
         "priority": feature.get("priority", 99)
     }
@@ -176,7 +186,11 @@ async def api_features(api_key: str = Depends(verify_api_key)):
 
 
 @router.get("/api/features/{feature_id}/enable")
-async def feature_enable_instructions(feature_id: str, api_key: str = Depends(verify_api_key)):
+async def feature_enable_instructions(
+    feature_id: str,
+    request: Request,
+    api_key: str = Depends(verify_api_key),
+):
     """Get instructions to enable a specific feature."""
     feature = next((f for f in FEATURES if f["id"] == feature_id), None)
     if not feature:
@@ -185,23 +199,33 @@ async def feature_enable_instructions(feature_id: str, api_key: str = Depends(ve
     def _svc_url(service_id: str) -> str:
         cfg = SERVICES.get(service_id, {})
         port = cfg.get("external_port", cfg.get("port", 0))
-        return f"http://localhost:{port}" if port else ""
+        if not port:
+            return ""
+        forwarded_host = request.headers.get("x-forwarded-host")
+        host_header = forwarded_host or request.headers.get("host") or "localhost"
+        hostname = host_header.rsplit(":", 1)[0] if ":" in host_header else host_header
+        scheme = request.headers.get("x-forwarded-proto") or request.url.scheme or "http"
+        return f"{scheme}://{hostname}:{port}"
 
     def _svc_port(service_id: str) -> int:
         cfg = SERVICES.get(service_id, {})
         return cfg.get("external_port", cfg.get("port", 0))
 
     webui_url = _svc_url("open-webui")
-    dashboard_url = _svc_url("dashboard")
     n8n_url = _svc_url("n8n")
+    comfyui_url = _svc_url("comfyui")
+    opencode_url = _svc_url("opencode")
+    hermes_url = _svc_url("hermes-proxy")
 
     instructions = {
         "chat": {"steps": ["Chat is already enabled if llama-server is running", "Open the Dashboard and click 'Chat' to start"], "links": [{"label": "Open Chat", "url": webui_url}]},
-        "voice": {"steps": [f"Ensure Whisper (STT) is running on port {_svc_port('whisper')}", f"Ensure Kokoro (TTS) is running on port {_svc_port('tts')}", "Start LiveKit for WebRTC", "Open the Voice page in the Dashboard"], "links": [{"label": "Voice Dashboard", "url": f"{dashboard_url}/voice"}]},
-        "documents": {"steps": ["Ensure Qdrant vector database is running", "Enable the 'Document Q&A' workflow", "Upload documents via the workflow endpoint"], "links": [{"label": "Workflows", "url": f"{dashboard_url}/workflows"}]},
-        "workflows": {"steps": [f"Ensure n8n is running on port {_svc_port('n8n')}", "Open the Workflows page to see available automations", "Click 'Enable' on any workflow to import it"], "links": [{"label": "n8n Dashboard", "url": n8n_url}, {"label": "Workflows", "url": f"{dashboard_url}/workflows"}]},
-        "images": {"steps": ["Image generation requires additional setup", "Coming soon in a future update"], "links": []},
-        "coding": {"steps": ["Switch to a coding-oriented local model profile for best results", "Use the model manager to download and load it", "Chat will now be optimized for code"], "links": [{"label": "Model Manager", "url": f"{dashboard_url}/models"}]},
+        "voice": {"steps": [f"Ensure Whisper (STT) is running on port {_svc_port('whisper')}", f"Ensure Kokoro (TTS) is running on port {_svc_port('tts')}", "Open Open WebUI and use its voice controls"], "links": [{"label": "Open Chat", "url": webui_url}]},
+        "documents": {"steps": ["Ensure Qdrant vector database is running", "Open Open WebUI and use its document/RAG controls"], "links": [{"label": "Open Chat", "url": webui_url}]},
+        "workflows": {"steps": [f"Ensure n8n is running on port {_svc_port('n8n')}", "Open n8n to see and manage available automations"], "links": [{"label": "n8n Dashboard", "url": n8n_url}]},
+        "images": {"steps": [f"Ensure ComfyUI is running on port {_svc_port('comfyui')}", "Open ComfyUI to build and run image workflows"], "links": [{"label": "Open ComfyUI", "url": comfyui_url}]},
+        "coding": {"steps": [f"Ensure OpenCode is running on port {_svc_port('opencode')}", "Open OpenCode for the browser-based coding assistant"], "links": [{"label": "Open OpenCode", "url": opencode_url}]},
+        "hermes-agent": {"steps": [f"Ensure Hermes proxy is running on port {_svc_port('hermes-proxy')}", "Open Hermes for advanced agent access"], "links": [{"label": "Open Hermes", "url": hermes_url}]},
+        "hermes-sso": {"steps": [f"Ensure Hermes proxy is running on port {_svc_port('hermes-proxy')}", "Open Hermes through Dream SSO"], "links": [{"label": "Open Hermes", "url": hermes_url}]},
         "observability": {"steps": [f"Langfuse is running on port {_svc_port('langfuse')}", "Open Langfuse to view LLM traces and evaluations", "LiteLLM automatically sends traces — no additional configuration needed"], "links": [{"label": "Open Langfuse", "url": _svc_url("langfuse")}]},
     }
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_features.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_features.py
@@ -144,6 +144,30 @@ class TestCalculateFeatureStatusGeneral:
         assert result["status"] == "enabled"
         assert result["enabled"] is True
 
+    def test_preserves_launch_and_enabled_service_metadata(self):
+        from routers.features import calculate_feature_status
+        from models import GPUInfo
+
+        gpu = GPUInfo(
+            name="RTX 4090", memory_used_mb=2048, memory_total_mb=24576,
+            memory_percent=8.3, utilization_percent=35, temperature_c=62,
+            gpu_backend="nvidia",
+        )
+        feature = self._make_feature(
+            vram_gb=8,
+            services=["llama-server"],
+            enabled_all=["llama-server"],
+        )
+        feature["launch"] = {"type": "service", "service": "open-webui"}
+        services = [self._make_service_status("llama-server", "healthy")]
+
+        with patch("routers.features.GPU_BACKEND", "nvidia"):
+            result = calculate_feature_status(feature, services, gpu)
+
+        assert result["enabledServicesAll"] == ["llama-server"]
+        assert result["enabledServicesAny"] == []
+        assert result["launch"] == {"type": "service", "service": "open-webui"}
+
     def test_insufficient_vram(self):
         from routers.features import calculate_feature_status
         from models import GPUInfo
@@ -223,6 +247,32 @@ class TestFeatureEnableInstructions:
         assert data["featureId"] == "chat"
         assert "instructions" in data
         assert "steps" in data["instructions"]
+
+    def test_instruction_links_use_request_host(self, test_client, monkeypatch):
+        test_features = [
+            {"id": "documents", "name": "Documents", "description": "Document Q&A",
+             "icon": "FileText", "category": "productivity",
+             "setup_time": "2 min", "priority": 3,
+             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+             "enabled_services_all": [], "enabled_services_any": []}
+        ]
+        monkeypatch.setattr("routers.features.FEATURES", test_features)
+        monkeypatch.setattr(
+            "routers.features.SERVICES",
+            {"open-webui": {"external_port": 3000}},
+        )
+
+        resp = test_client.get(
+            "/api/features/documents/enable",
+            headers={**test_client.auth_headers, "host": "dashboard.dream.local:3001"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["instructions"]["links"][0] == {
+            "label": "Open Chat",
+            "url": "http://dashboard.dream.local:3000",
+        }
 
     def test_404_for_unknown_feature(self, test_client, monkeypatch):
         monkeypatch.setattr("routers.features.FEATURES", [])

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -25,10 +25,12 @@ import { Link } from 'react-router-dom'
 import { FeatureDiscoveryBanner } from '../components/FeatureDiscovery'
 
 // Helper to build external service URLs from current host
-const getExternalUrl = (port) =>
-  typeof window !== 'undefined'
-    ? `http://${window.location.hostname}:${port}`
-    : `http://localhost:${port}`
+const getExternalUrl = (port, path = '') => {
+  const suffix = path && path !== '/' ? path : ''
+  return typeof window !== 'undefined'
+    ? `http://${window.location.hostname}:${port}${suffix}`
+    : `http://localhost:${port}${suffix}`
+}
 
 // Compute overall health from services (excludes not_deployed from counts)
 function computeHealth(services) {
@@ -52,23 +54,51 @@ const FEATURE_ICONS = {
   Code,
 }
 
+const SERVICE_LINK_ALIASES = {
+  'open-webui': ['open-webui', 'open webui'],
+  'hermes-proxy': ['hermes-proxy', 'hermes auth proxy', 'hermes single sign-on', 'hermes sso'],
+  'dream-proxy': ['dream-proxy', 'dream server web', 'dream web proxy'],
+}
+
+function serviceMatchesTarget(service, target) {
+  const targetKey = normalizeServiceKey(target)
+  if (!targetKey) return false
+  const serviceKeys = [service?.id, service?.name].map(normalizeServiceKey)
+  if (serviceKeys.includes(targetKey)) return true
+
+  const aliases = SERVICE_LINK_ALIASES[targetKey] || []
+  return aliases.some(alias => serviceKeys.includes(normalizeServiceKey(alias)))
+}
+
+function findHealthyService(services, serviceId) {
+  return (services || []).find(service =>
+    service?.status === 'healthy' &&
+    service?.port &&
+    serviceMatchesTarget(service, serviceId)
+  )
+}
+
 function pickFeatureLink(feature, services) {
-  const svc = services || []
-  const req = feature?.requirements || {}
-  const wanted = [...(req.servicesAll || req.services || []), ...(req.servicesAny || req.services_any || [])]
-
-  // Match by name substring since status API uses display names, not IDs
-  const matchService = (needle) =>
-    svc.find(s => s.status === 'healthy' && s.port &&
-      (s.name || '').toLowerCase().includes(needle.toLowerCase()))
-
-  const firstHealthy = wanted.map(matchService).find(Boolean)
-  if (firstHealthy) {
-    return getExternalUrl(firstHealthy.port)
+  const launch = feature?.launch
+  if (launch?.type === 'none') return null
+  if (launch?.type === 'internal') return launch.path || null
+  if (launch?.type === 'service') {
+    const launchService = findHealthyService(services, launch.service)
+    return launchService ? getExternalUrl(launchService.port, launch.path) : null
   }
 
-  const fallbackWebUi = matchService('webui') || matchService('open webui')
-  return fallbackWebUi ? getExternalUrl(fallbackWebUi.port) : null
+  const req = feature?.requirements || {}
+  const enabledWanted = [
+    ...(feature?.enabledServicesAll || []),
+    ...(feature?.enabledServicesAny || []),
+  ]
+  const requirementWanted = [
+    ...(req.servicesAll || req.services || []),
+    ...(req.servicesAny || req.services_any || []),
+  ]
+  const wanted = enabledWanted.length ? enabledWanted : requirementWanted
+  const firstHealthy = wanted.map(serviceId => findHealthyService(services, serviceId)).find(Boolean)
+  return firstHealthy ? getExternalUrl(firstHealthy.port) : null
 }
 
 function normalizeFeatureStatus(featureStatus) {
@@ -798,6 +828,7 @@ export default function Dashboard({ status, loading }) {
 
 const FeatureCard = memo(function FeatureCard({ icon: Icon, title, description, href, status, hint }) {
   const isExternal = href?.startsWith('http')
+  const isInteractive = status !== 'disabled' && status !== 'coming' && Boolean(href)
   const statusColors = {
     ready: 'hover:border-theme-accent/30',
     disabled: 'opacity-60',
@@ -819,7 +850,7 @@ const FeatureCard = memo(function FeatureCard({ icon: Icon, title, description, 
 
   const content = (
     <div
-      className={`feature-card-compact liquid-metal-frame liquid-metal-sequence-card group h-full min-h-[56px] px-2.5 py-2 rounded-xl border ${statusColors[status]} transition-all cursor-pointer hover:shadow-md flex items-center justify-between gap-2`}
+      className={`feature-card-compact liquid-metal-frame liquid-metal-sequence-card group h-full min-h-[56px] px-2.5 py-2 rounded-xl border ${statusColors[status]} transition-all ${isInteractive ? 'cursor-pointer hover:shadow-md' : 'cursor-default'} flex items-center justify-between gap-2`}
       style={{ ...TECH_TILE_STYLE, overflow: 'visible' }}
     >
       <div className="min-w-0 flex items-center gap-2">

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -32,6 +32,7 @@ const baseStatus = {
 }
 
 let mockResources
+let mockFeatures
 let restartCalls
 let restartDeferred
 
@@ -52,7 +53,7 @@ function installFetchMock() {
     if (String(url).includes('/api/features')) {
       return {
         ok: true,
-        json: async () => ({ features: [] }),
+        json: async () => ({ features: mockFeatures }),
       }
     }
     if (String(url).includes('/api/services/') && String(url).endsWith('/restart')) {
@@ -83,6 +84,7 @@ async function renderDashboard(status = baseStatus) {
 
 describe('Dashboard system overview', () => {
   beforeEach(() => {
+    mockFeatures = []
     mockResources = {
       services: services.map(service => ({
         id: service.name.toLowerCase().replace(/\([^)]*\)/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
@@ -196,6 +198,54 @@ describe('Dashboard system overview', () => {
 
     expect(screen.getByText('2/2 core services online.')).toBeInTheDocument()
     expect(screen.getByText('Optional')).toBeInTheDocument()
+  })
+
+  it('launches feature cards to explicit user-facing targets', async () => {
+    mockFeatures = [
+      {
+        id: 'chat',
+        name: 'AI Chat',
+        description: 'Chat with a local model',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        launch: { type: 'service', service: 'open-webui' },
+        requirements: { servicesMissing: [] },
+      },
+      {
+        id: 'hermes-agent',
+        name: 'Hermes Agent',
+        description: 'Advanced Hermes agent console',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        launch: { type: 'service', service: 'hermes-proxy' },
+        requirements: { servicesAll: ['llama-server'], servicesMissing: [] },
+      },
+      {
+        id: 'remote-access',
+        name: 'Remote Access',
+        description: 'Tailscale remote access status',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        launch: { type: 'none' },
+        requirements: { servicesMissing: [] },
+      },
+    ]
+
+    const statusWithLaunchTargets = {
+      ...baseStatus,
+      services: [
+        { id: 'llama-server', name: 'llama-server (LLM Inference)', status: 'healthy', port: 11434, uptime: 14400 },
+        { id: 'open-webui', name: 'Open WebUI (Chat)', status: 'healthy', port: 3000, uptime: 14400 },
+        { id: 'hermes-proxy', name: 'Hermes Auth Proxy', status: 'healthy', port: 9120, uptime: 14400 },
+      ],
+    }
+
+    await renderDashboard(statusWithLaunchTargets)
+
+    expect(await screen.findByRole('link', { name: /AI Chat/ })).toHaveAttribute('href', 'http://localhost:3000')
+    expect(screen.getByRole('link', { name: /Hermes Agent/ })).toHaveAttribute('href', 'http://localhost:9120')
+    expect(screen.queryByRole('link', { name: /Remote Access/ })).not.toBeInTheDocument()
+    expect(screen.getByText('Remote Access')).toBeInTheDocument()
   })
 
   it('renders real service CPU and RAM metrics from the resources endpoint', async () => {

--- a/dream-server/extensions/services/dream-proxy/manifest.yaml
+++ b/dream-server/extensions/services/dream-proxy/manifest.yaml
@@ -71,4 +71,7 @@ features:
     enabled_services_all: [dream-proxy]
     setup_time: Ready
     priority: 1
+    launch:
+      type: service
+      service: dream-proxy
     gpu_backends: [all]

--- a/dream-server/extensions/services/hermes-proxy/manifest.yaml
+++ b/dream-server/extensions/services/hermes-proxy/manifest.yaml
@@ -61,4 +61,7 @@ features:
     enabled_services_all: [hermes-proxy]
     setup_time: Ready
     priority: 5
+    launch:
+      type: service
+      service: hermes-proxy
     gpu_backends: [all]

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -78,4 +78,7 @@ features:
     enabled_services_all: [hermes]
     setup_time: ~1 minute (image pull)
     priority: 5
+    launch:
+      type: service
+      service: hermes-proxy
     gpu_backends: [all]

--- a/dream-server/extensions/services/langfuse/manifest.yaml
+++ b/dream-server/extensions/services/langfuse/manifest.yaml
@@ -33,4 +33,7 @@ features:
     enabled_services_any: []
     setup_time: ~2 minutes
     priority: 10
+    launch:
+      type: service
+      service: langfuse
     gpu_backends: [all]

--- a/dream-server/extensions/services/llama-server/manifest.yaml
+++ b/dream-server/extensions/services/llama-server/manifest.yaml
@@ -33,6 +33,9 @@ features:
     enabled_services_any: [llama-server]
     setup_time: Ready
     priority: 1
+    launch:
+      type: service
+      service: open-webui
     gpu_backends: [amd, nvidia]
 
   - id: documents
@@ -48,4 +51,7 @@ features:
     enabled_services_all: [qdrant]
     setup_time: ~2 minutes
     priority: 3
+    launch:
+      type: service
+      service: open-webui
     gpu_backends: [amd, nvidia]

--- a/dream-server/extensions/services/n8n/manifest.yaml
+++ b/dream-server/extensions/services/n8n/manifest.yaml
@@ -42,4 +42,7 @@ features:
     enabled_services_all: [n8n]
     setup_time: ~1 minute
     priority: 4
+    launch:
+      type: service
+      service: n8n
     gpu_backends: [all]

--- a/dream-server/extensions/services/opencode/manifest.yaml
+++ b/dream-server/extensions/services/opencode/manifest.yaml
@@ -31,4 +31,7 @@ features:
     enabled_services_all: [opencode]
     setup_time: Ready
     priority: 6
+    launch:
+      type: service
+      service: opencode
     gpu_backends: [all]

--- a/dream-server/extensions/services/tailscale/manifest.yaml
+++ b/dream-server/extensions/services/tailscale/manifest.yaml
@@ -53,4 +53,6 @@ features:
     enabled_services_all: [tailscale]
     setup_time: ~2 minutes
     priority: 3
+    launch:
+      type: none
     gpu_backends: [all]

--- a/dream-server/extensions/services/whisper/manifest.yaml
+++ b/dream-server/extensions/services/whisper/manifest.yaml
@@ -33,4 +33,7 @@ features:
     enabled_services_all: [whisper, tts]
     setup_time: ~5 minutes
     priority: 2
+    launch:
+      type: service
+      service: open-webui
     gpu_backends: [all]


### PR DESCRIPTION
## Summary

Fixes the main dashboard feature cards so clicking a card opens the surface a person would actually want, instead of whichever backend dependency made the feature possible.

Root cause: the dashboard derived card hrefs from `requirements.services*`, so features could route to implementation services:
- AI Chat -> `llama-server` / Lemonade API (`:11434`)
- Voice -> Whisper (`:9000`)
- Documents -> Qdrant (`:6333`)
- Hermes Agent -> model API instead of Hermes SSO (`:9120`)

## Changes

- Adds explicit `launch` metadata to feature manifests.
- Updates dashboard feature-card link resolution to prefer `launch` targets.
- Marks backend/API-only features as non-clickable (`agent-governance`, `brave-web-search`, `remote-access`).
- Preserves compatibility with old feature records by falling back to enabled/required services only when no `launch` metadata exists.
- Fixes feature enable-modal links to use the request host instead of hardcoded `localhost`, so LAN browsers get usable URLs.
- Replaces stale enable-modal routes like `/voice` and `/workflows` with real surfaces (`Open WebUI`, `n8n`, `ComfyUI`, `OpenCode`, Hermes SSO).
- Adds frontend/backend tests covering explicit launch targets and host-aware enable links.

## Validation

Validated in a fresh temporary worktree on tower2:

- `python3 -m py_compile dream-server/extensions/services/dashboard-api/routers/features.py`
- `cd dream-server/extensions/services/dashboard-api && python3 -m pytest tests/test_features.py -q` -> 13 passed
- `cd dream-server/extensions/services/dashboard && npm test -- --run src/pages/Dashboard.test.jsx` -> 13 passed
- `bash scripts/validate-manifests.sh` -> pass, 24 compatible, 0 errors
- `python3 scripts/audit-extensions.py --project-dir .` -> pass, 24 services, 0 warnings/errors
- `bash tests/test-extension-audit.sh` -> 15 passed
- `git diff --check` -> clean