### PR TITLE
fix(dashboard): keep legacy feature cards off raw API ports

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -60,6 +60,36 @@ const SERVICE_LINK_ALIASES = {
   'dream-proxy': ['dream-proxy', 'dream server web', 'dream web proxy'],
 }
 
+const FEATURE_LAUNCH_FALLBACKS = {
+  chat: { type: 'service', service: 'open-webui' },
+  voice: { type: 'service', service: 'open-webui' },
+  documents: { type: 'service', service: 'open-webui' },
+  'hermes-agent': { type: 'service', service: 'hermes-proxy' },
+  'hermes-sso': { type: 'service', service: 'hermes-proxy' },
+  images: { type: 'service', service: 'comfyui' },
+  workflows: { type: 'service', service: 'n8n' },
+  coding: { type: 'service', service: 'opencode' },
+  observability: { type: 'service', service: 'langfuse' },
+  'lan-web': { type: 'service', service: 'dream-proxy' },
+  'remote-access': { type: 'none' },
+  'agent-governance': { type: 'none' },
+  'brave-web-search': { type: 'none' },
+}
+
+const NON_USER_FACING_LINK_SERVICES = new Set([
+  'dashboard-api',
+  'embeddings',
+  'hermes',
+  'litellm',
+  'llama-server',
+  'privacy-shield',
+  'qdrant',
+  'searxng',
+  'token-spy',
+  'tts',
+  'whisper',
+])
+
 function serviceMatchesTarget(service, target) {
   const targetKey = normalizeServiceKey(target)
   if (!targetKey) return false
@@ -79,7 +109,8 @@ function findHealthyService(services, serviceId) {
 }
 
 function pickFeatureLink(feature, services) {
-  const launch = feature?.launch
+  const featureKey = normalizeServiceKey(feature?.id)
+  const launch = feature?.launch || FEATURE_LAUNCH_FALLBACKS[featureKey]
   if (launch?.type === 'none') return null
   if (launch?.type === 'internal') return launch.path || null
   if (launch?.type === 'service') {
@@ -97,7 +128,10 @@ function pickFeatureLink(feature, services) {
     ...(req.servicesAny || req.services_any || []),
   ]
   const wanted = enabledWanted.length ? enabledWanted : requirementWanted
-  const firstHealthy = wanted.map(serviceId => findHealthyService(services, serviceId)).find(Boolean)
+  const firstHealthy = wanted
+    .filter(serviceId => !NON_USER_FACING_LINK_SERVICES.has(normalizeServiceKey(serviceId)))
+    .map(serviceId => findHealthyService(services, serviceId))
+    .find(Boolean)
   return firstHealthy ? getExternalUrl(firstHealthy.port) : null
 }
 

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -248,6 +248,54 @@ describe('Dashboard system overview', () => {
     expect(screen.getByText('Remote Access')).toBeInTheDocument()
   })
 
+  it('keeps legacy feature cards away from raw backend API ports', async () => {
+    mockFeatures = [
+      {
+        id: 'chat',
+        name: 'AI Chat',
+        description: 'Chat with a local model',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        requirements: { servicesAny: ['llama-server'], servicesMissing: [] },
+      },
+      {
+        id: 'hermes-agent',
+        name: 'Hermes Agent',
+        description: 'Advanced Hermes agent console',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        requirements: { servicesAll: ['llama-server'], servicesMissing: [] },
+      },
+      {
+        id: 'usage-api',
+        name: 'Usage API',
+        description: 'Internal usage telemetry backend',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        requirements: { servicesAll: ['token-spy'], servicesMissing: [] },
+      },
+    ]
+
+    const statusWithRawBackends = {
+      ...baseStatus,
+      services: [
+        { id: 'llama-server', name: 'llama-server (LLM Inference)', status: 'healthy', port: 11434, uptime: 14400 },
+        { id: 'litellm', name: 'LiteLLM (API Gateway)', status: 'healthy', port: 4000, uptime: 14400 },
+        { id: 'token-spy', name: 'Token Spy (Usage Monitor)', status: 'healthy', port: 3005, uptime: 14400 },
+        { id: 'open-webui', name: 'Open WebUI (Chat)', status: 'healthy', port: 3000, uptime: 14400 },
+        { id: 'hermes-proxy', name: 'Hermes Auth Proxy', status: 'healthy', port: 9120, uptime: 14400 },
+      ],
+    }
+
+    await renderDashboard(statusWithRawBackends)
+
+    expect(await screen.findByRole('link', { name: /AI Chat/ })).toHaveAttribute('href', 'http://localhost:3000')
+    expect(screen.getByRole('link', { name: /Hermes Agent/ })).toHaveAttribute('href', 'http://localhost:9120')
+    expect(screen.queryByRole('link', { name: /Usage API/ })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /AI Chat/ })).not.toHaveAttribute('href', 'http://localhost:11434')
+    expect(screen.queryByRole('link', { name: /Hermes Agent/ })).not.toHaveAttribute('href', 'http://localhost:11434')
+  })
+
   it('renders real service CPU and RAM metrics from the resources endpoint', async () => {
     mockResources = {
       services: [


### PR DESCRIPTION
## Summary
- add dashboard-side launch fallbacks for known feature cards when `/api/features` returns legacy metadata without `launch`
- keep Chat/Voice/Documents pointed at Open WebUI and Hermes cards pointed at Hermes SSO/proxy
- prevent generic fallback links from opening raw backend/API services like `llama-server`, `litellm`, `token-spy`, `qdrant`, etc.

## Why
A fresh Fedora/Strix user reported the dashboard feature cards opening `http://<host>:11434/`, which is the Lemonade/OpenAI-compatible backend, not a human-facing UI. PR #1353 added manifest/API `launch` metadata, but the frontend should still be defensive when it sees stale or legacy feature payloads.

## Tests
- `npm test -- --run src/pages/Dashboard.test.jsx`
- `npm run build`

Note: full dashboard lint is currently blocked by existing warnings in `src/hooks/useVoiceAgent.js`; this PR only touches Dashboard files and the targeted dashboard tests pass.
