### PR TITLE
fix install docker cloud

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -625,6 +625,7 @@ get_compose_flags() {
 _compose_run_with_summary() {
     local _verb="$1"; shift
     log "${_verb}..."
+    _check_docker_access
 
     local _compose_log
     _compose_log=$(mktemp)
@@ -642,13 +643,19 @@ _compose_run_with_summary() {
 
     log_error "${_verb} failed:"
     local _surfaced
-    _surfaced=$(grep -iE 'error|unhealthy|failed|dependency' "$_compose_log" \
+    _surfaced=$(grep -iE 'error|unhealthy|failed|dependency|permission denied|docker API|docker daemon|docker\.sock|/var/run/docker\.sock' "$_compose_log" \
         | sed 's/^/  /' \
         | head -20 || true)
     if [[ -n "$_surfaced" ]]; then
         printf '%s\n' "$_surfaced"
     else
         warn "(no error keywords matched in compose log)"
+    fi
+    if grep -qiE 'permission denied.*(docker API|docker daemon|docker\.sock|/var/run/docker\.sock)|/var/run/docker\.sock.*permission denied' "$_compose_log"; then
+        warn "Docker socket permission denied. Add your user to the docker group, then start a new login shell:"
+        warn "  sudo usermod -aG docker \"\$USER\""
+        warn "  newgrp docker   # or log out and back in"
+        warn "Then verify with: docker ps"
     fi
     echo ""
     log "Full compose output: $_compose_log"
@@ -667,12 +674,17 @@ _compose_run_with_summary() {
 #=============================================================================
 _check_docker_access() {
     [[ "$(uname -s)" == Linux* ]] || return 0
-    if id -nG 2>/dev/null | grep -qw docker && docker ps >/dev/null 2>&1; then
+    local _docker_ps_output
+    if _docker_ps_output=$(docker ps 2>&1); then
         return 0
     fi
-    warn "Current user cannot reach the Docker daemon (not in 'docker' group, or daemon unreachable)."
-    warn "If the next step fails with 'permission denied', run:  newgrp docker  (current shell)"
-    warn "or log out and back in (all shells), then re-run your dream command."
+    if grep -qiE 'permission denied.*(docker API|docker daemon|docker\.sock|/var/run/docker\.sock)|/var/run/docker\.sock.*permission denied' <<<"$_docker_ps_output"; then
+        warn "Current user cannot reach the Docker daemon: Docker socket permission denied."
+        warn "Run: sudo usermod -aG docker \"\$USER\""
+        warn "Then run: newgrp docker  (or log out and back in) and retry."
+    else
+        warn "Current user cannot reach the Docker daemon. Start Docker and verify with: docker ps"
+    fi
 }
 
 #=============================================================================

--- a/dream-server/installers/phases/04-requirements.sh
+++ b/dream-server/installers/phases/04-requirements.sh
@@ -264,8 +264,17 @@ if [[ "$REQUIREMENTS_MET" != "true" ]]; then
     warn "Some requirements not met. Installation may have limited functionality."
     if $INTERACTIVE && ! $DRY_RUN; then
         read -p "  Continue anyway? [y/N] " -r < /dev/tty
-        [[ ! $REPLY =~ ^[Yy]$ ]] && exit 1
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+        warn "Continuing despite unmet requirements at user request."
     elif $DRY_RUN; then
         log "[DRY RUN] Would prompt to continue despite unmet requirements"
     fi
 fi
+
+# This file is sourced by install-core.sh under `set -e`. Keep the phase's
+# final status successful when the user explicitly chose to continue; otherwise
+# a false [[ ... ]] test in the prompt branch can make `source phase-04` return
+# 1 and trip the top-level error trap.
+true

--- a/dream-server/scripts/preflight-engine.sh
+++ b/dream-server/scripts/preflight-engine.sh
@@ -120,6 +120,7 @@ except Exception:
 tier_key = str(tier).upper()
 tier_rank_map = {
     "0": 0,
+    "CLOUD": 0,
     "1": 1,
     "2": 2,
     "3": 3,
@@ -136,6 +137,7 @@ tier_rank = tier_rank_map.get(tier_key, 1)
 
 min_ram_map = {
     "0": 4,
+    "CLOUD": 4,
     "T0": 4,
     "1": 16,
     "2": 32,
@@ -146,6 +148,10 @@ min_ram_map = {
 }
 min_disk_map = {
     "0": 15,
+    # Cloud mode skips local GGUF downloads and local llama-server model
+    # storage. It still needs room for core Docker images, configs, logs, and
+    # optional services, but it should not inherit the 50GB local-model default.
+    "CLOUD": 25,
     "T0": 15,
     "1": 30,
     "2": 50,

--- a/dream-server/tests/bats-tests/test-compose-summary-wrapper.bats
+++ b/dream-server/tests/bats-tests/test-compose-summary-wrapper.bats
@@ -33,7 +33,8 @@ setup() {
     success()   { echo "✓ $1"; }
     warn()      { echo "⚠ $1"; }
     log_error() { echo "✗ $1" >&2; }
-    export -f log success warn log_error
+    _check_docker_access() { :; }
+    export -f log success warn log_error _check_docker_access
 
     # Extract _compose_run_with_summary from dream-cli.
     local _cli="$BATS_TEST_DIRNAME/../../dream-cli"
@@ -62,6 +63,10 @@ case "${DOCKER_STUB_MODE:-success}" in
     fail-nomatch)
         echo "Container dream-foo starting"
         echo "network busy (try again later)"
+        exit 1
+        ;;
+    fail-docker-sock)
+        echo "unable to get image 'ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4': permission denied while trying to connect to the docker API at unix:///var/run/docker.sock"
         exit 1
         ;;
     *)
@@ -161,6 +166,7 @@ teardown() {
         success()   { echo "✓ $1"; }
         warn()      { echo "⚠ $1"; }
         log_error() { echo "✗ $1" >&2; }
+        _check_docker_access() { :; }
         eval "$(awk "/^_compose_run_with_summary\(\) \{/,/^\}$/" "'"$BATS_TEST_DIRNAME/../../dream-cli"'")"
         _compose_run_with_summary "Stopping service y" down y
     '
@@ -179,10 +185,22 @@ teardown() {
         success()   { echo "✓ $1"; }
         warn()      { echo "⚠ $1"; }
         log_error() { echo "✗ $1" >&2; }
+        _check_docker_access() { :; }
         eval "$(awk "/^_compose_run_with_summary\(\) \{/,/^\}$/" "'"$BATS_TEST_DIRNAME/../../dream-cli"'")"
         _compose_run_with_summary "Stopping" down
     '
     [ "$status" -eq 1 ]
+}
+
+@test "wrapper: docker socket permission denied is surfaced with a fix hint" {
+    export DOCKER_STUB_MODE=fail-docker-sock
+    run _compose_run_with_summary "Restarting all services" up -d
+    assert_failure
+    assert_output --partial "permission denied while trying to connect to the docker API"
+    assert_output --partial "Docker socket permission denied"
+    assert_output --partial "sudo usermod -aG docker"
+    assert_output --partial "newgrp docker"
+    assert_output --partial "Full compose output:"
 }
 
 # ── docker compose args passthrough ─────────────────────────────────────────

--- a/dream-server/tests/contracts/test-preflight-fixtures.sh
+++ b/dream-server/tests/contracts/test-preflight-fixtures.sh
@@ -94,4 +94,39 @@ if [[ "$blockers" -lt 1 ]]; then
   exit 1
 fi
 
+echo "[contract] preflight fixture: cloud-low-storage-good"
+scripts/preflight-engine.sh \
+  --report "$tmpdir/cloud-low-storage-good.json" \
+  --tier CLOUD \
+  --ram-gb 8 \
+  --disk-gb 44 \
+  --gpu-backend cpu \
+  --gpu-vram-mb 0 \
+  --gpu-name "None" \
+  --platform-id linux \
+  --compose-overlays docker-compose.base.yml \
+  --script-dir "$ROOT_DIR" \
+  --env >/dev/null
+blockers="$(json_summary_blockers "$tmpdir/cloud-low-storage-good.json")"
+assert_eq "$blockers" "0" "cloud-low-storage-good blockers"
+
+echo "[contract] preflight fixture: cloud-disk-blocker"
+scripts/preflight-engine.sh \
+  --report "$tmpdir/cloud-disk-blocker.json" \
+  --tier CLOUD \
+  --ram-gb 8 \
+  --disk-gb 20 \
+  --gpu-backend cpu \
+  --gpu-vram-mb 0 \
+  --gpu-name "None" \
+  --platform-id linux \
+  --compose-overlays docker-compose.base.yml \
+  --script-dir "$ROOT_DIR" \
+  --env >/dev/null
+blockers="$(json_summary_blockers "$tmpdir/cloud-disk-blocker.json")"
+if [[ "$blockers" -lt 1 ]]; then
+  echo "[FAIL] cloud-disk-blocker expected >=1 blocker, got $blockers"
+  exit 1
+fi
+
 echo "[PASS] preflight fixture contracts"


### PR DESCRIPTION
## Summary
Fixes two install/restart issues seen during Discord testing.

## What changed
- Detects Docker socket permission failures during `dream restart` and prints a clear Linux fix instead of `(no error keywords matched)`.
- Adds CLOUD-specific preflight sizing so cloud/external-LLM installs do not inherit the 50GB local-model disk requirement.
- Keeps genuinely low cloud disk installs blocked.
- Fixes phase 04 so answering `y` to `Continue anyway?` actually continues instead of returning a failing shell status.

## Validation
- `bash dream-server/tests/contracts/test-preflight-fixtures.sh`
- `git diff --check origin/main...HEAD`