### PR TITLE
fix(macos): verify dream-host-agent is responding before reporting install OK

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -49,6 +49,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh
+	@echo ""
+	@echo "=== macOS dream-host-agent bootstrap verification ==="
+	@bash tests/test-macos-host-agent-verification.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1749,7 +1749,32 @@ AGENT_PLIST_EOF
     launchctl bootout "gui/$(id -u)/${DREAM_AGENT_PLIST_LABEL}" >/dev/null 2>&1 || true
     _agent_bootstrap_err="$(launchctl bootstrap "gui/$(id -u)" "$DREAM_AGENT_PLIST" 2>&1)" && _agent_bootstrap_rc=0 || _agent_bootstrap_rc=$?
     if [[ $_agent_bootstrap_rc -eq 0 ]]; then
-        ai_ok "Dream host agent installed (LaunchAgent, port ${DREAM_AGENT_PORT})"
+        # `launchctl bootstrap` can succeed (definition loaded) while launchd
+        # leaves the service in "pended nondemand spawn = speculative" and
+        # never actually launches the process — common right after a
+        # same-session bootout because the throttler hasn't reset yet, and
+        # `RunAtLoad=true` doesn't override the throttle. Force the spawn
+        # with `kickstart`, then poll /health so we don't report success
+        # while the agent is still down. Without this verification the
+        # dashboard-api will hit "Host agent unreachable" on every model and
+        # extension action even though the installer printed [OK].
+        launchctl kickstart -p "gui/$(id -u)/${DREAM_AGENT_PLIST_LABEL}" >/dev/null 2>&1 || true
+        _agent_health_ok=false
+        for _agent_health_i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS --max-time 1 "http://127.0.0.1:${DREAM_AGENT_PORT}/health" >/dev/null 2>&1; then
+                _agent_health_ok=true
+                break
+            fi
+            sleep 1
+        done
+        if [[ "$_agent_health_ok" == "true" ]]; then
+            ai_ok "Dream host agent installed (LaunchAgent, port ${DREAM_AGENT_PORT})"
+        else
+            ai_warn "Dream host agent loaded but not responding on :${DREAM_AGENT_PORT} after 10s."
+            ai_warn "  Log:         tail -F ~/Library/Logs/DreamServer/dream-host-agent.log"
+            ai_warn "  Force start: launchctl kickstart -p gui/\$(id -u)/${DREAM_AGENT_PLIST_LABEL}"
+            ai_warn "  Dashboard model + extension actions will fail until the agent comes up."
+        fi
     else
         ai_warn "Dream host agent LaunchAgent failed (rc=${_agent_bootstrap_rc}): ${_agent_bootstrap_err}"
         if [[ "${_agent_bootstrap_err}" == *"Input/output error"* ]]; then

--- a/dream-server/tests/test-macos-host-agent-verification.sh
+++ b/dream-server/tests/test-macos-host-agent-verification.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Regression: after launchctl bootstrap succeeds for dream-host-agent, the
+# macOS installer MUST:
+#   1. force the spawn with `launchctl kickstart -p` (bootstrap alone can leave
+#      the service "pended speculative" under launchd throttling), AND
+#   2. poll /health before printing the [OK] line, so we never report success
+#      while the agent is actually down.
+#
+# Without both, dashboard-api hits "Host agent unreachable" on every model and
+# extension action even though the installer reports success (observed on
+# m5-mbp during the 2026-05-23 fleet test).
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/installers/macos/install-macos.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+# Pull the block that runs after `launchctl bootstrap ... DREAM_AGENT_PLIST`
+# returns rc 0 and ends at the matching `ai_ok "Dream host agent installed"`.
+# Strip comments so descriptions cannot satisfy or fail the checks.
+success_block="$(awk '
+    /_agent_bootstrap_err=.*launchctl bootstrap.*DREAM_AGENT_PLIST/ { in_block=1 }
+    in_block { print }
+    in_block && /^[[:space:]]*ai_warn "Dream host agent LaunchAgent failed/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+[[ -n "$success_block" ]] || fail "could not locate host-agent bootstrap success block"
+
+grep -qE 'launchctl kickstart -p "gui/\$\(id -u\)/\$\{DREAM_AGENT_PLIST_LABEL\}"' <<<"$success_block" \
+    || fail "host-agent bootstrap success block must call \`launchctl kickstart -p\` to defeat launchd spawn-pending throttling"
+pass "host-agent bootstrap kickstarts the service after bootstrap"
+
+grep -qE 'curl[^|]*"http://127\.0\.0\.1:\$\{DREAM_AGENT_PORT\}/health"' <<<"$success_block" \
+    || fail "host-agent bootstrap success block must poll /health on 127.0.0.1:\${DREAM_AGENT_PORT} before declaring [OK]"
+pass "host-agent bootstrap polls /health before declaring success"
+
+grep -qE 'ai_warn[[:space:]]+"Dream host agent loaded but not responding' <<<"$success_block" \
+    || fail "host-agent bootstrap success block must surface an ai_warn when the agent fails health-check (silent false success is the bug)"
+pass "host-agent bootstrap warns on health-check timeout"
+
+echo "[OK] macOS installer verifies dream-host-agent is responding before declaring success"


### PR DESCRIPTION
## Summary
- Force-spawn `dream-host-agent` with `launchctl kickstart -p` after a successful `launchctl bootstrap`. launchd's spawn throttler frequently leaves the service in `pended nondemand spawn = speculative` so `RunAtLoad=true` never fires; kickstart bypasses the throttle.
- Verify the agent is actually answering `http://127.0.0.1:${DREAM_AGENT_PORT}/health` (poll 10x) before printing `[OK] Dream host agent installed`. If the poll fails, surface an `ai_warn` with the log path and the kickstart recovery command instead of falsely reporting success.
- Add `tests/test-macos-host-agent-verification.sh` (wired into `make test`) so the kickstart, health poll, and the failure-path warning can't silently regress.

## The bug
`launchctl bootstrap "gui/$(id -u)" $DREAM_AGENT_PLIST` exits 0 once launchd has accepted the LaunchAgent definition — but acceptance is not the same as launch. Under throttling (very common right after the `launchctl bootout` that the installer runs immediately before bootstrap), launchd leaves the service in `pended nondemand spawn = speculative` and the process never actually starts. `RunAtLoad=true` does not override the throttle.

The installer was treating `bootstrap rc=0` as "agent is up" and printing the green check, while the agent had `runs = 0`. The dashboard-api then returned 503 on every model/extension action with `Host agent unreachable: <urlopen error [Errno 101] Network is unreachable>` because there was no listener on the agent port.

## Reproduction (fleet test, 2026-05-23)
On `m5-mbp` (Apple M5 Max, macOS 26.4):

```
$ launchctl print gui/$(id -u)/com.dreamserver.host-agent
gui/501/com.dreamserver.host-agent = {
    active count = 0
    state = not running
    runs = 0
    last exit code = (never exited)
    pended nondemand spawn = speculative
    ...
}
$ docker exec dream-dashboard-api curl -fsS http://host.docker.internal:7710/health
# fails — agent isn't bound
```

`launchctl kickstart -p gui/$(id -u)/com.dreamserver.host-agent` immediately brought the agent up and the dashboard-api recovered.

## Fix
In `installers/macos/install-macos.sh`, the success branch of the bootstrap block goes from:

```bash
if [[ $_agent_bootstrap_rc -eq 0 ]]; then
    ai_ok "Dream host agent installed (LaunchAgent, port ${DREAM_AGENT_PORT})"
```

to:

```bash
if [[ $_agent_bootstrap_rc -eq 0 ]]; then
    # bootstrap rc=0 means "definition loaded", not "process running"
    launchctl kickstart -p "gui/$(id -u)/${DREAM_AGENT_PLIST_LABEL}" >/dev/null 2>&1 || true
    _agent_health_ok=false
    for _agent_health_i in 1 2 3 4 5 6 7 8 9 10; do
        if curl -fsS --max-time 1 "http://127.0.0.1:${DREAM_AGENT_PORT}/health" >/dev/null 2>&1; then
            _agent_health_ok=true
            break
        fi
        sleep 1
    done
    if [[ "$_agent_health_ok" == "true" ]]; then
        ai_ok "Dream host agent installed (LaunchAgent, port ${DREAM_AGENT_PORT})"
    else
        ai_warn "Dream host agent loaded but not responding on :${DREAM_AGENT_PORT} after 10s."
        ai_warn "  Log:         tail -F ~/Library/Logs/DreamServer/dream-host-agent.log"
        ai_warn "  Force start: launchctl kickstart -p gui/\$(id -u)/${DREAM_AGENT_PLIST_LABEL}"
        ai_warn "  Dashboard model + extension actions will fail until the agent comes up."
    fi
else
    # ... existing bootstrap-rc-nonzero handling unchanged ...
```

The bootstrap-failed branch is untouched; behavior matches before for that path.

## Test plan
- [x] `bash -n installers/macos/install-macos.sh` clean.
- [x] `bash tests/test-macos-host-agent-verification.sh` passes: kickstart present, /health poll present, ai_warn on failure path present.
- [x] Test fails when the fix is reverted (`[FAIL] host-agent bootstrap success block must call launchctl kickstart -p`).
- [x] `make test` includes the new test.
- [ ] Next macOS fleet run: install-macos.sh either reports `[OK]` *and* dashboard model/extension actions succeed, OR it surfaces the explicit `ai_warn` with the log/kickstart hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
