### PR TITLE
fix(tests): keep fleet-multi-distro going on docker pull failure

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -49,6 +49,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh
+	@echo ""
+	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
+	@bash tests/test-fleet-multi-distro-keep-going.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/dream-server/tests/fleet-multi-distro.sh
+++ b/dream-server/tests/fleet-multi-distro.sh
@@ -323,7 +323,16 @@ for distro in "${TARGETS[@]}"; do
     echo ""
     echo "=== Fleet distro: $distro ($image) ==="
     if [[ "$PULL" == "true" ]]; then
-        docker pull "$image"
+        # A bare `docker pull "$image"` under `set -euo pipefail` aborts the
+        # entire matrix on a single registry hiccup (transient IPv6 failure,
+        # mirror outage, etc.), skipping every distro that follows. Wrap it
+        # so a pull failure marks this distro failed and the loop moves on.
+        if ! docker pull "$image"; then
+            echo "FAIL: $distro (docker pull failed for $image)"
+            fail=$((fail + 1))
+            failed+=("$distro")
+            continue
+        fi
     fi
 
     container_name="dream-fleet-${distro}-$$"

--- a/dream-server/tests/test-fleet-multi-distro-keep-going.sh
+++ b/dream-server/tests/test-fleet-multi-distro-keep-going.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression: tests/fleet-multi-distro.sh must NOT abort the entire matrix
+# when a single distro's `docker pull` fails. A bare `docker pull` under the
+# script's `set -euo pipefail` exits the loop on the first registry hiccup
+# (transient IPv6 failure, mirror outage, etc.) and silently skips every
+# distro that comes later in TARGETS. On Tower2 on 2026-05-23 an IPv6
+# `network is unreachable` on archlinux skipped manjaro, cachyos, and
+# opensuse — a class of failures the matrix exists to surface.
+#
+# This test asserts the pull failure is contained inside an `if !` guard
+# that increments `fail`, appends to `failed`, and `continue`s the loop.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/tests/fleet-multi-distro.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+# Pull the docker-pull block (between `if [[ "$PULL" == "true" ]]` and the
+# matching `fi`) inside the per-distro loop, strip comments.
+pull_block="$(awk '
+    /if \[\[ "\$PULL" == "true" \]\]; then/ { in_block=1; next }
+    in_block { print }
+    in_block && /^[[:space:]]*fi[[:space:]]*$/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+[[ -n "$pull_block" ]] || fail "could not locate per-distro docker-pull block"
+
+grep -qE 'if[[:space:]]+!.*docker pull' <<<"$pull_block" \
+    || fail "docker pull must be wrapped in an \`if !\` guard so failures don't abort the matrix under set -e"
+pass "docker pull failure is contained inside an if-guard"
+
+grep -qE 'fail=\$\(\(fail \+ 1\)\)' <<<"$pull_block" \
+    || fail "failed pull must increment the fail counter (otherwise the summary line lies)"
+pass "failed pull increments fail counter"
+
+grep -qF 'failed+=("$distro")' <<<"$pull_block" \
+    || fail "failed pull must append the distro to the failed[] array (otherwise it's missing from the summary)"
+pass "failed pull appends to failed[] array"
+
+grep -qE '^[[:space:]]*continue[[:space:]]*$' <<<"$pull_block" \
+    || fail "failed pull must \`continue\` so remaining distros still run (the bug this test catches)"
+pass "failed pull continues the loop instead of aborting"
+
+echo "[OK] fleet-multi-distro.sh keeps going on docker pull failures"


### PR DESCRIPTION
## Summary
- Wrap the per-distro `docker pull "$image"` in `tests/fleet-multi-distro.sh` in an `if !` guard so a transient pull failure marks just that distro failed and the loop moves on. The bare `docker pull` under `set -euo pipefail` aborts the entire matrix on a single registry hiccup and silently skips every distro that comes later in TARGETS.
- Add `tests/test-fleet-multi-distro-keep-going.sh` (wired into `make test`) so the four invariants (if-guard, fail counter increment, `failed[]` append, `continue`) can't silently regress.

## The bug
The per-distro loop did:

```bash
if [[ "$PULL" == "true" ]]; then
    docker pull "$image"
fi

container_name="dream-fleet-${distro}-$$"
if docker run --rm ... "$image" sh /fleet/bootstrap.sh ...; then
    pass=$((pass + 1))
else
    fail=$((fail + 1))
    failed+=("$distro")
fi
```

The `docker run` block was already wrapped — its failure was counted and the loop moved on. The `docker pull` above it wasn't. Under `set -euo pipefail`, a nonzero pull exited the whole script, so every distro after the failed one never ran.

## Reproduction (fleet test, 2026-05-23, Tower2)

```
=== Fleet distro: arch (archlinux:latest) ===
latest: Pulling from library/archlinux
failed to do request: Get "https://registry-1.docker.io/...": 
    dial tcp [2600:1f18:2148:bc01:8d54:5995:1917:4793]:443:
    connect: network is unreachable
=== docker matrix exit=1 ===
```

The matrix bailed on archlinux's transient IPv6 failure. `manjaro`, `cachyos`, and `opensuse` — three distros that come after `arch` in TARGETS — never ran, even though they each take ~30s and likely would have passed (they pass in CI).

## Fix
Mirror the existing `docker run` handling for the `docker pull`:

```bash
if [[ "$PULL" == "true" ]]; then
    if ! docker pull "$image"; then
        echo "FAIL: $distro (docker pull failed for $image)"
        fail=$((fail + 1))
        failed+=("$distro")
        continue
    fi
fi
```

A pull failure is now indistinguishable from a `docker run` failure for the purposes of the summary — same accounting, same logging, same loop semantics.

## Test plan
- [x] `bash -n tests/fleet-multi-distro.sh` clean.
- [x] `bash tests/test-fleet-multi-distro-keep-going.sh` passes: all four invariants present.
- [x] Same test correctly **fails** without the fix (`[FAIL] docker pull must be wrapped in an \`if !\` guard ...`).
- [x] `make test` includes the new test.
- [ ] Next fleet test: a deliberate `docker pull` failure (e.g. `--pull` with an unreachable mirror) lists the failed distro in the summary and still runs every later distro in TARGETS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
