### PR TITLE
revert(dashboard): keep Usage out of the top-level sidebar

### DIFF
--- a/dream-server/extensions/services/dashboard/src/plugins/core.js
+++ b/dream-server/extensions/services/dashboard/src/plugins/core.js
@@ -71,8 +71,10 @@ export const coreRoutes = [
     sidebar: true,
     order: 3,
   },
-  // Usage is a day-to-day operations surface. Setup / Owner stays in Settings
-  // because it is a factory/distributor/service-provider flow, not normal daily use.
+  // Usage + Setup / Owner are reachable from Settings rather than the top-level
+  // sidebar. Setup / Owner is a factory/distributor/service-provider flow, not
+  // a day-to-day dashboard surface. Direct URLs still work for bookmarks and
+  // for the magic-link redemption page which renders inside this dashboard.
   {
     id: 'usage',
     path: '/usage',
@@ -80,7 +82,7 @@ export const coreRoutes = [
     icon: CreditCard,
     component: Usage,
     getProps: ({ status }) => ({ status }),
-    sidebar: true,
+    sidebar: false,
     order: 3.5,
   },
   {


### PR DESCRIPTION
## Summary
- Revert `extensions/services/dashboard/src/plugins/core.js`'s `id: 'usage'` entry to `sidebar: false`, restoring the PR #1267 intent of "Usage and Setup/Owner are both reached from Settings, not the top-level sidebar."
- Restore the explanatory comment block from PR #1267 so future readers see the same rationale.

## Why
PR #1267 cleaned the top-level sidebar to only contain the day-to-day surfaces (Models, Extensions, etc.) and tucked both Usage and Setup/Owner into Settings → Account.

PR #1324 then put Usage back on the top-level sidebar. We're undoing that change. The dashboard's primary daily surfaces are Models / Extensions / Chat — Usage is a self-service operational view that belongs alongside the other account-scoped controls in Settings, not on the same level as the things you do every visit.

## Behavior after this PR
- Sidebar entries: Home, GPU stats, Models, Extensions, Chat, … Settings. No top-level Usage.
- Direct URL `/usage` still works (it's a registered route, just hidden from the sidebar via `sidebar: false`).
- Settings → Account → Usage still works (PR #1267 wired that in).
- The dashboard's Usage component itself is unchanged.
- The magic-link redemption page that renders inside the dashboard is unchanged.

## What's reverted
`PR #1324` (commit 9730bd3 — "fix(dashboard): show Usage in sidebar"). The two-hunk change to `plugins/core.js` is reverted:

```diff
-  // Usage is a day-to-day operations surface. Setup / Owner stays in Settings
-  // because it is a factory/distributor/service-provider flow, not normal daily use.
+  // Usage + Setup / Owner are reachable from Settings rather than the top-level
+  // sidebar. Setup / Owner is a factory/distributor/service-provider flow, not
+  // a day-to-day dashboard surface. Direct URLs still work for bookmarks and
+  // for the magic-link redemption page which renders inside this dashboard.
   {
     id: 'usage',
     ...
-    sidebar: true,
+    sidebar: false,
     order: 3.5,
   },
```

The `id: 'invites'` entry is already `sidebar: false` on main; this PR doesn't change that.

## Test plan
- [x] Dashboard renders without a top-level Usage entry in the sidebar (the fleet-test Playwright probe at `dream-fleet-test/playwright/dashboard.mjs` asserts `sidebar.no.usage.invites` — that step will fail if Usage re-appears).
- [x] Settings → Account section still surfaces Usage + Invites rows (the fleet-test `settings.account.links` step counts these).
- [x] `/usage` URL still routes to the Usage page when entered directly.
- [ ] Next fleet test on tower2: UI step `sidebar.no.usage.invites` passes (this PR is what makes it pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
