### PR TITLE
fix(installer): keep bootstrap model when macOS download finalization fails

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -4245,7 +4245,12 @@ def main():
         logger.error("docker not found in PATH")
         sys.exit(1)
 
-    INSTALL_DIR = Path(args.install_dir).resolve() if args.install_dir else Path(__file__).resolve().parent.parent
+    if args.install_dir:
+        INSTALL_DIR = Path(args.install_dir).resolve()
+    elif os.environ.get("DREAM_HOME"):
+        INSTALL_DIR = Path(os.environ["DREAM_HOME"]).resolve()
+    else:
+        INSTALL_DIR = Path(__file__).resolve().parent.parent
     if not INSTALL_DIR.is_dir():
         logger.error("Install directory not found: %s", INSTALL_DIR)
         sys.exit(1)

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1745,6 +1745,8 @@ if [[ -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && [[ -n "$AGENT_PYTHON" ]]
     <array>
         <string>${AGENT_PYTHON}</string>
         <string>${INSTALL_DIR}/bin/dream-host-agent.py</string>
+        <string>--install-dir</string>
+        <string>${INSTALL_DIR}</string>
     </array>
     <key>WorkingDirectory</key>
     <string>${INSTALL_DIR}</string>

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -224,17 +224,28 @@ else
     _monitor_pid=$!
     trap 'kill $_monitor_pid 2>/dev/null || true; write_status "failed"; exit 1' EXIT TERM INT
 
-    # Download with resume support, retry up to 3 times
+    # Download with resume support, retry up to 3 times. curl success is not
+    # enough: finalizing the .part file can fail on macOS if the file vanished
+    # or the target path is unavailable, and this script intentionally does
+    # not use set -e.
     _dl_success=false
+    _part_path="$MODELS_DIR/$FULL_GGUF_FILE.part"
+    _final_path="$MODELS_DIR/$FULL_GGUF_FILE"
     for _attempt in 1 2 3; do
         [[ $_attempt -gt 1 ]] && log "Retry attempt $_attempt of 3..." && sleep 5
         if curl -fSL -C - --connect-timeout 30 --max-time 3600 \
-                -o "$MODELS_DIR/$FULL_GGUF_FILE.part" "$FULL_GGUF_URL" 2>&1; then
-            mv "$MODELS_DIR/$FULL_GGUF_FILE.part" "$MODELS_DIR/$FULL_GGUF_FILE"
-            _dl_success=true
-            break
+                -o "$_part_path" "$FULL_GGUF_URL" 2>&1; then
+            if [[ ! -s "$_part_path" ]]; then
+                log "Download attempt $_attempt reported success but produced no partial file: $_part_path"
+            elif mv "$_part_path" "$_final_path"; then
+                _dl_success=true
+                break
+            else
+                log "Download attempt $_attempt failed while finalizing $_part_path -> $_final_path"
+            fi
+        else
+            log "Download attempt $_attempt failed"
         fi
-        log "Download attempt $_attempt failed"
     done
 
     # Stop background monitor
@@ -245,6 +256,20 @@ else
         rm -f "$MODELS_DIR/$FULL_GGUF_FILE.part"
         write_status "failed"
         fail "Download failed after 3 attempts. Bootstrap model will continue running."
+    fi
+
+    if [[ ! -s "$MODELS_DIR/$FULL_GGUF_FILE" ]]; then
+        write_status "failed"
+        fail "Downloaded model is missing or empty after finalization: $MODELS_DIR/$FULL_GGUF_FILE. Bootstrap model will continue running."
+    fi
+
+    if [[ "$TOTAL_BYTES" -gt 0 ]]; then
+        ACTUAL_BYTES=$(file_size "$MODELS_DIR/$FULL_GGUF_FILE")
+        if [[ "$ACTUAL_BYTES" -lt "$TOTAL_BYTES" ]]; then
+            rm -f "$MODELS_DIR/$FULL_GGUF_FILE"
+            write_status "failed"
+            fail "Downloaded model is smaller than expected (got $ACTUAL_BYTES, expected $TOTAL_BYTES). Bootstrap model will continue running."
+        fi
     fi
 
     write_status "complete"

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -46,6 +46,12 @@ bash tests/contracts/test-windows-amd-local-compose.sh
 echo "[contract] bootstrap hot-swap force-recreate"
 bash tests/test-bootstrap-upgrade-hotswap-contract.sh
 
+echo "[contract] bootstrap download finalization is non-destructive"
+bash tests/test-bootstrap-upgrade-download-finalization.sh
+
+echo "[contract] macOS host-agent LaunchAgent install-dir"
+bash tests/test-macos-host-agent-verification.sh
+
 echo "[contract] AMD reassign keeps HSA override Strix-only"
 grep -q '_env_set "HSA_OVERRIDE_GFX_VERSION" "11.5.1"' dream-cli \
   || { echo "[FAIL] dream-cli must set HSA override to 11.5.1 for gfx1151"; exit 1; }

--- a/dream-server/tests/test-bootstrap-upgrade-download-finalization.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-download-finalization.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Regression: bootstrap-upgrade must not promote .env or delete the bootstrap
+# GGUF unless the downloaded .part file was successfully finalized.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fakebin="$tmp/bin"
+install_dir="$tmp/install"
+mkdir -p "$fakebin" "$install_dir/data/models" "$install_dir/config/llama-server" "$install_dir/bin"
+
+cat > "$fakebin/curl" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+  *" -sI "*)
+    printf 'HTTP/2 200\r\ncontent-length: 1234\r\n\r\n'
+    exit 0
+    ;;
+esac
+# Simulate the macOS fleet failure shape: curl exits 0, but the expected
+# .part file is not present by the time bootstrap-upgrade tries to promote it.
+exit 0
+EOF
+chmod +x "$fakebin/curl"
+
+cat > "$fakebin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$fakebin/sleep"
+
+cat > "$install_dir/.env" <<'EOF'
+GGUF_FILE=Bootstrap.gguf
+LLM_MODEL=bootstrap-model
+MAX_CONTEXT=8192
+CTX_SIZE=8192
+GPU_BACKEND=apple
+EOF
+
+printf 'bootstrap model\n' > "$install_dir/data/models/Bootstrap.gguf"
+printf '999999\n' > "$install_dir/data/.llama-server.pid"
+
+set +e
+PATH="$fakebin:$PATH" bash "$TARGET" \
+    "$install_dir" \
+    "Full.gguf" \
+    "https://example.invalid/Full.gguf" \
+    "" \
+    "full-model" \
+    "32768" \
+    "Bootstrap.gguf" \
+    > "$tmp/bootstrap.log" 2>&1
+rc=$?
+set -e
+
+[[ $rc -ne 0 ]] || fail "bootstrap-upgrade must exit non-zero when curl succeeds but no finalized GGUF exists"
+grep -q 'produced no partial file' "$tmp/bootstrap.log" \
+    || fail "bootstrap-upgrade should log the missing .part/finalization failure"
+grep -q '^GGUF_FILE=Bootstrap.gguf$' "$install_dir/.env" \
+    || fail "bootstrap-upgrade must leave GGUF_FILE on the bootstrap model after download finalization failure"
+grep -q '^LLM_MODEL=bootstrap-model$' "$install_dir/.env" \
+    || fail "bootstrap-upgrade must leave LLM_MODEL unchanged after download finalization failure"
+[[ -f "$install_dir/data/models/Bootstrap.gguf" ]] \
+    || fail "bootstrap-upgrade must not delete the serving bootstrap GGUF after download finalization failure"
+[[ ! -f "$install_dir/data/models/Full.gguf" ]] \
+    || fail "bootstrap-upgrade must not leave a bogus full GGUF after download finalization failure"
+grep -q '"status": "failed"' "$install_dir/data/bootstrap-status.json" \
+    || fail "bootstrap-upgrade must mark bootstrap-status failed"
+
+pass "download finalization failure is non-destructive"

--- a/dream-server/tests/test-macos-host-agent-verification.sh
+++ b/dream-server/tests/test-macos-host-agent-verification.sh
@@ -37,6 +37,18 @@ success_block="$(awk '
 
 [[ -n "$success_block" ]] || fail "could not locate host-agent bootstrap success block"
 
+plist_block="$(awk '
+    /cat > "\$DREAM_AGENT_PLIST"/ { in_block=1 }
+    in_block { print }
+    in_block && /^AGENT_PLIST_EOF/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+grep -qF '<string>--install-dir</string>' <<<"$plist_block" \
+    || fail "host-agent LaunchAgent must pass --install-dir explicitly"
+grep -qF '<string>${INSTALL_DIR}</string>' <<<"$plist_block" \
+    || fail "host-agent LaunchAgent must pass the installer-selected INSTALL_DIR"
+pass "host-agent LaunchAgent passes explicit install directory"
+
 grep -qE 'launchctl kickstart -p "gui/\$\(id -u\)/\$\{DREAM_AGENT_PLIST_LABEL\}"' <<<"$success_block" \
     || fail "host-agent bootstrap success block must call \`launchctl kickstart -p\` to defeat launchd spawn-pending throttling"
 pass "host-agent bootstrap kickstarts the service after bootstrap"


### PR DESCRIPTION
﻿## Summary
- Pass the installer-selected `--install-dir` into the macOS host-agent LaunchAgent and cover it in the macOS host-agent contract test.
- Fix the actual m5-mbp fleet failure mode: `bootstrap-upgrade.sh` could let curl return success, fail to move the `.part` file into the final GGUF path, then still update `.env`, delete the bootstrap model, and restart services against a missing full model.
- Add a regression test that simulates curl success without a finalized `.part` file and proves the bootstrap model, `.env`, and failure status remain safe.

## Audit Notes
The original PR diagnosis was incomplete. On m5-mbp, the Qwen GGUF was not present at either `/Users/...` or `/System/Volumes/Data/...`, and `Path('/Users/conta/dream-server').resolve()` stayed under `/Users`. The damaging behavior was in `scripts/bootstrap-upgrade.sh`: without `set -e`, a failed `mv` after a successful curl still set `_dl_success=true`. This PR now fixes that root cause instead of only hardening LaunchAgent install-dir derivation.

## Verification
- `python3 -m py_compile bin/dream-host-agent.py`
- `bash -n installers/macos/install-macos.sh`
- `bash -n scripts/bootstrap-upgrade.sh`
- `bash tests/test-bootstrap-upgrade-download-finalization.sh`
- `bash tests/test-macos-host-agent-verification.sh`
- `bash tests/contracts/test-installer-contracts.sh`
