### PR TITLE
fix(installer): cap bundled service CPU limits

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -182,6 +182,14 @@ SYSTEM_RAM_GB=32
 # LLAMA_ARG_SPEC_DRAFT_N_MAX=3        # Optional: speculative draft cap; benchmark per model/runtime.
 # LLAMA_CPU_LIMIT=12.0       # Auto-generated: capped to CPUs actually exposed by Docker
 # LLAMA_CPU_RESERVATION=2.0  # Auto-generated: reservation capped to the same ceiling
+# TTS_CPU_LIMIT=8.0          # Auto-generated: capped to Docker CPUs
+# TTS_CPU_RESERVATION=2.0    # Auto-generated: capped to the TTS limit
+# WHISPER_CPU_LIMIT=4.0      # Auto-generated: capped to Docker CPUs
+# WHISPER_CPU_RESERVATION=1.0 # Auto-generated: capped to the Whisper limit
+# HERMES_CPU_LIMIT=4.0       # Auto-generated: capped to Docker CPUs
+# HERMES_CPU_RESERVATION=0.5 # Auto-generated: capped to the Hermes limit
+# COMFYUI_CPU_LIMIT=16.0     # Auto-generated: capped to Docker CPUs
+# COMFYUI_CPU_RESERVATION=2.0 # Auto-generated: capped to the ComfyUI limit
 # LLAMA_START_PERIOD=240s    # Healthcheck grace window for cold model load (bump for 70B-class on slow NVMe)
 
 # ═══════════════════════════════════════════════════════════════════
@@ -373,7 +381,7 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # llama-server memory limit (Docker)
 # LLAMA_SERVER_MEMORY_LIMIT=64G
 
-# llama-server CPU core limit (macOS/CPU-only mode — static default 8.0)
+# llama-server CPU core limit (auto-capped during install/update)
 # Tune this to control how many CPU cores llama-server may use.
 # LLAMA_CPU_LIMIT=8.0
 # ═══════════════════════════════════════════════════════════════════

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -305,6 +305,46 @@
       "description": "Auto-capped Docker CPU reservation for llama-server",
       "minimum": 0.01
     },
+    "TTS_CPU_LIMIT": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU limit for Kokoro TTS",
+      "minimum": 0.01
+    },
+    "TTS_CPU_RESERVATION": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU reservation for Kokoro TTS",
+      "minimum": 0.01
+    },
+    "WHISPER_CPU_LIMIT": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU limit for Whisper STT",
+      "minimum": 0.01
+    },
+    "WHISPER_CPU_RESERVATION": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU reservation for Whisper STT",
+      "minimum": 0.01
+    },
+    "HERMES_CPU_LIMIT": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU limit for Hermes Agent",
+      "minimum": 0.01
+    },
+    "HERMES_CPU_RESERVATION": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU reservation for Hermes Agent",
+      "minimum": 0.01
+    },
+    "COMFYUI_CPU_LIMIT": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU limit for ComfyUI",
+      "minimum": 0.01
+    },
+    "COMFYUI_CPU_RESERVATION": {
+      "type": "number",
+      "description": "Auto-capped Docker CPU reservation for ComfyUI",
+      "minimum": 0.01
+    },
     "LLAMA_START_PERIOD": {
       "type": "string",
       "description": "Healthcheck grace window for llama-server cold model load (Docker duration, e.g. 240s, 5m). Bump for 70B-class GGUFs on slow NVMe."

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -189,6 +189,45 @@ _select_auto_cpu_value() {
     fi
 }
 
+_cap_cpu_value() {
+    local desired="$1" ceiling="$2"
+    awk -v desired="$desired" -v ceiling="$ceiling" '
+        BEGIN {
+            if (ceiling <= 0) ceiling = 1
+            value = desired
+            if (value > ceiling) value = ceiling
+            if (value < 0.01) value = 0.01
+            printf "%.1f", value
+        }'
+}
+
+_ensure_service_cpu_pair() {
+    local available="$1" name="$2" desired_limit="$3" desired_reservation="$4"
+    local limit_key="${name}_CPU_LIMIT"
+    local reservation_key="${name}_CPU_RESERVATION"
+    local detected_limit detected_reservation current_limit current_reservation final_limit final_reservation
+
+    detected_limit="$(_cap_cpu_value "$desired_limit" "$available")"
+    current_limit="$(_env_get_raw "$limit_key")"
+    final_limit="$(_select_auto_cpu_value "$current_limit" "$detected_limit")"
+
+    detected_reservation="$(_cap_cpu_value "$desired_reservation" "$final_limit")"
+    current_reservation="$(_env_get_raw "$reservation_key")"
+    final_reservation="$(_select_auto_cpu_value "$current_reservation" "$detected_reservation")"
+    if awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
+        final_reservation="$final_limit"
+    fi
+
+    if [[ "$current_limit" != "$final_limit" ]]; then
+        _env_set "$limit_key" "$final_limit"
+        SERVICE_CPU_BUDGET_CHANGED=true
+    fi
+    if [[ "$current_reservation" != "$final_reservation" ]]; then
+        _env_set "$reservation_key" "$final_reservation"
+        SERVICE_CPU_BUDGET_CHANGED=true
+    fi
+}
+
 ensure_llama_cpu_budget() {
     local env_file="$INSTALL_DIR/.env"
     [[ -f "$env_file" ]] || return 0
@@ -226,6 +265,16 @@ ensure_llama_cpu_budget() {
     if [[ "$changed" == "true" ]]; then
         log "Auto-adjusted llama-server CPU budget: limit=${final_limit}, reservation=${final_reservation} (Docker CPUs: ${available})"
     fi
+
+    SERVICE_CPU_BUDGET_CHANGED=false
+    _ensure_service_cpu_pair "$available" "TTS" "8.0" "2.0"
+    _ensure_service_cpu_pair "$available" "WHISPER" "4.0" "1.0"
+    _ensure_service_cpu_pair "$available" "HERMES" "4.0" "0.5"
+    _ensure_service_cpu_pair "$available" "COMFYUI" "16.0" "2.0"
+    if [[ "$SERVICE_CPU_BUDGET_CHANGED" == "true" ]]; then
+        log "Auto-adjusted bundled service CPU budgets (Docker CPUs: ${available})"
+    fi
+    unset SERVICE_CPU_BUDGET_CHANGED
 }
 
 check_install() {

--- a/dream-server/extensions/services/comfyui/compose.amd.yaml
+++ b/dream-server/extensions/services/comfyui/compose.amd.yaml
@@ -26,10 +26,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16.0'
+          cpus: '${COMFYUI_CPU_LIMIT:-1.0}'
           memory: 96G
         reservations:
-          cpus: '2.0'
+          cpus: '${COMFYUI_CPU_RESERVATION:-0.5}'
           memory: 4G
     healthcheck:
       test: ["CMD", "curl", "-f", "http://127.0.0.1:8188/"]

--- a/dream-server/extensions/services/comfyui/compose.nvidia.yaml
+++ b/dream-server/extensions/services/comfyui/compose.nvidia.yaml
@@ -18,7 +18,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '16.0'
+          cpus: '${COMFYUI_CPU_LIMIT:-1.0}'
           memory: 24G
         reservations:
           devices:

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -152,10 +152,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4.0'
+          cpus: '${HERMES_CPU_LIMIT:-1.0}'
           memory: 4G
         reservations:
-          cpus: '0.5'
+          cpus: '${HERMES_CPU_RESERVATION:-0.5}'
           memory: 1G
     security_opt:
       - no-new-privileges:true

--- a/dream-server/extensions/services/tts/README.md
+++ b/dream-server/extensions/services/tts/README.md
@@ -92,7 +92,7 @@ docker compose logs tts
 
 **Slow synthesis:**
 - The CPU image processes speech on CPU; synthesis takes 1–5 seconds depending on text length
-- Ensure the container has sufficient CPU allocation (`cpus: '8.0'` limit in `compose.yaml`)
+- Ensure the container has sufficient CPU allocation (`TTS_CPU_LIMIT` in `.env`; the installer auto-caps it to Docker's visible CPU count)
 
 **Wrong voice:**
 - List available voices: `curl http://localhost:8880/v1/voices`

--- a/dream-server/extensions/services/tts/compose.yaml
+++ b/dream-server/extensions/services/tts/compose.yaml
@@ -14,10 +14,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '8.0'
+          cpus: '${TTS_CPU_LIMIT:-1.0}'
           memory: 4G
         reservations:
-          cpus: '2.0'
+          cpus: '${TTS_CPU_RESERVATION:-0.5}'
           memory: 1G
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8880/health', timeout=5)"]

--- a/dream-server/extensions/services/whisper/compose.nvidia.yaml
+++ b/dream-server/extensions/services/whisper/compose.nvidia.yaml
@@ -14,7 +14,7 @@ services:
               count: 1
               capabilities: [gpu]
         limits:
-          cpus: '4.0'
+          cpus: '${WHISPER_CPU_LIMIT:-1.0}'
           memory: 8G
     logging:
       driver: "json-file"

--- a/dream-server/extensions/services/whisper/compose.yaml
+++ b/dream-server/extensions/services/whisper/compose.yaml
@@ -19,10 +19,10 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '4.0'
+          cpus: '${WHISPER_CPU_LIMIT:-1.0}'
           memory: 4G
         reservations:
-          cpus: '1.0'
+          cpus: '${WHISPER_CPU_RESERVATION:-0.5}'
           memory: 1G
     healthcheck:
       test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')"]

--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -183,6 +183,45 @@ select_auto_cpu_value() {
     fi
 }
 
+cap_cpu_value() {
+    local desired="$1" ceiling="$2"
+    awk -v desired="$desired" -v ceiling="$ceiling" '
+        BEGIN {
+            if (ceiling <= 0) ceiling = 1
+            value = desired
+            if (value > ceiling) value = ceiling
+            if (value < 0.01) value = 0.01
+            printf "%.1f", value
+        }'
+}
+
+ensure_service_cpu_pair() {
+    local env_file="$1" available="$2" name="$3" desired_limit="$4" desired_reservation="$5"
+    local limit_key="${name}_CPU_LIMIT"
+    local reservation_key="${name}_CPU_RESERVATION"
+    local detected_limit current_limit final_limit detected_reservation current_reservation final_reservation
+
+    detected_limit="$(cap_cpu_value "$desired_limit" "$available")"
+    current_limit="$(read_env_value "$env_file" "$limit_key")"
+    final_limit="$(select_auto_cpu_value "$current_limit" "$detected_limit")"
+
+    detected_reservation="$(cap_cpu_value "$desired_reservation" "$final_limit")"
+    current_reservation="$(read_env_value "$env_file" "$reservation_key")"
+    final_reservation="$(select_auto_cpu_value "$current_reservation" "$detected_reservation")"
+    if awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
+        final_reservation="$final_limit"
+    fi
+
+    if [[ "$current_limit" != "$final_limit" ]]; then
+        upsert_env_value "$env_file" "$limit_key" "$final_limit"
+        SERVICE_CPU_BUDGET_CHANGED=true
+    fi
+    if [[ "$current_reservation" != "$final_reservation" ]]; then
+        upsert_env_value "$env_file" "$reservation_key" "$final_reservation"
+        SERVICE_CPU_BUDGET_CHANGED=true
+    fi
+}
+
 ensure_llama_cpu_budget() {
     local env_file="${INSTALL_DIR}/.env"
     [[ -f "$env_file" ]] || return 0
@@ -220,6 +259,16 @@ ensure_llama_cpu_budget() {
     if [[ "$changed" == "true" ]]; then
         ai "Auto-adjusted llama-server CPU budget: limit=${final_limit}, reservation=${final_reservation} (Docker CPUs: ${available})"
     fi
+
+    SERVICE_CPU_BUDGET_CHANGED=false
+    ensure_service_cpu_pair "$env_file" "$available" "TTS" "8.0" "2.0"
+    ensure_service_cpu_pair "$env_file" "$available" "WHISPER" "4.0" "1.0"
+    ensure_service_cpu_pair "$env_file" "$available" "HERMES" "4.0" "0.5"
+    ensure_service_cpu_pair "$env_file" "$available" "COMFYUI" "16.0" "2.0"
+    if [[ "$SERVICE_CPU_BUDGET_CHANGED" == "true" ]]; then
+        ai "Auto-adjusted bundled service CPU budgets (Docker CPUs: ${available})"
+    fi
+    unset SERVICE_CPU_BUDGET_CHANGED
 }
 
 # ── Native llama-server management ──

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -64,6 +64,37 @@ upsert_env_value() {
     fi
 }
 
+cap_cpu_value() {
+    local desired="$1" ceiling="$2"
+    awk -v desired="$desired" -v ceiling="$ceiling" '
+        BEGIN {
+            if (ceiling <= 0) ceiling = 1
+            value = desired
+            if (value > ceiling) value = ceiling
+            if (value < 0.01) value = 0.01
+            printf "%.1f", value
+        }'
+}
+
+select_auto_cpu_value() {
+    local existing="$1" detected="$2"
+    if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
+        echo "$existing"
+    else
+        echo "$detected"
+    fi
+}
+
+select_env_service_cpu_limit() {
+    local env_path="$1" key="$2" desired="$3" available="$4"
+    select_auto_cpu_value "$(read_env_value "$env_path" "$key")" "$(cap_cpu_value "$desired" "$available")"
+}
+
+select_env_service_cpu_reservation() {
+    local env_path="$1" key="$2" desired="$3" limit="$4"
+    select_auto_cpu_value "$(read_env_value "$env_path" "$key")" "$(cap_cpu_value "$desired" "$limit")"
+}
+
 # Detect the host's LAN IP. Used to populate HOST_LAN_IP when the operator
 # has set BIND_ADDRESS=0.0.0.0 (macOS has no --lan flag; this is opt-in via
 # manual .env edit). Returns empty string when no non-loopback address can
@@ -130,6 +161,8 @@ generate_dream_env() {
     local searx_settings_path="${install_dir}/config/searxng/settings.yml"
     local cpu_limit_raw cpu_reservation_raw docker_available_cpus
     local detected_cpu_limit detected_cpu_reservation
+    local tts_cpu_limit tts_cpu_reservation whisper_cpu_limit whisper_cpu_reservation
+    local hermes_cpu_limit hermes_cpu_reservation comfyui_cpu_limit comfyui_cpu_reservation
     read -r cpu_limit_raw cpu_reservation_raw docker_available_cpus <<< "$(calculate_llama_cpu_budget "apple")"
     detected_cpu_limit="${cpu_limit_raw}.0"
     detected_cpu_reservation="${cpu_reservation_raw}.0"
@@ -162,6 +195,22 @@ generate_dream_env() {
         fi
         upsert_env_value "$env_path" "LLAMA_CPU_LIMIT" "$detected_cpu_limit"
         upsert_env_value "$env_path" "LLAMA_CPU_RESERVATION" "$detected_cpu_reservation"
+        tts_cpu_limit="$(select_env_service_cpu_limit "$env_path" "TTS_CPU_LIMIT" "8.0" "$docker_available_cpus")"
+        tts_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "TTS_CPU_RESERVATION" "2.0" "$tts_cpu_limit")"
+        whisper_cpu_limit="$(select_env_service_cpu_limit "$env_path" "WHISPER_CPU_LIMIT" "4.0" "$docker_available_cpus")"
+        whisper_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "WHISPER_CPU_RESERVATION" "1.0" "$whisper_cpu_limit")"
+        hermes_cpu_limit="$(select_env_service_cpu_limit "$env_path" "HERMES_CPU_LIMIT" "4.0" "$docker_available_cpus")"
+        hermes_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "HERMES_CPU_RESERVATION" "0.5" "$hermes_cpu_limit")"
+        comfyui_cpu_limit="$(select_env_service_cpu_limit "$env_path" "COMFYUI_CPU_LIMIT" "16.0" "$docker_available_cpus")"
+        comfyui_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "COMFYUI_CPU_RESERVATION" "2.0" "$comfyui_cpu_limit")"
+        upsert_env_value "$env_path" "TTS_CPU_LIMIT" "$tts_cpu_limit"
+        upsert_env_value "$env_path" "TTS_CPU_RESERVATION" "$tts_cpu_reservation"
+        upsert_env_value "$env_path" "WHISPER_CPU_LIMIT" "$whisper_cpu_limit"
+        upsert_env_value "$env_path" "WHISPER_CPU_RESERVATION" "$whisper_cpu_reservation"
+        upsert_env_value "$env_path" "HERMES_CPU_LIMIT" "$hermes_cpu_limit"
+        upsert_env_value "$env_path" "HERMES_CPU_RESERVATION" "$hermes_cpu_reservation"
+        upsert_env_value "$env_path" "COMFYUI_CPU_LIMIT" "$comfyui_cpu_limit"
+        upsert_env_value "$env_path" "COMFYUI_CPU_RESERVATION" "$comfyui_cpu_reservation"
 
         # Upsert DREAM_AGENT_KEY when missing (pre-PR-#979 upgrade path)
         if [[ -z "$(read_env_value "$env_path" "DREAM_AGENT_KEY")" ]]; then
@@ -230,6 +279,14 @@ generate_dream_env() {
     dream_session_secret=$(new_secure_hex 32)
     local shield_api_key
     shield_api_key=$(new_secure_hex 32)
+    tts_cpu_limit="$(select_env_service_cpu_limit "$env_path" "TTS_CPU_LIMIT" "8.0" "$docker_available_cpus")"
+    tts_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "TTS_CPU_RESERVATION" "2.0" "$tts_cpu_limit")"
+    whisper_cpu_limit="$(select_env_service_cpu_limit "$env_path" "WHISPER_CPU_LIMIT" "4.0" "$docker_available_cpus")"
+    whisper_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "WHISPER_CPU_RESERVATION" "1.0" "$whisper_cpu_limit")"
+    hermes_cpu_limit="$(select_env_service_cpu_limit "$env_path" "HERMES_CPU_LIMIT" "4.0" "$docker_available_cpus")"
+    hermes_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "HERMES_CPU_RESERVATION" "0.5" "$hermes_cpu_limit")"
+    comfyui_cpu_limit="$(select_env_service_cpu_limit "$env_path" "COMFYUI_CPU_LIMIT" "16.0" "$docker_available_cpus")"
+    comfyui_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "COMFYUI_CPU_RESERVATION" "2.0" "$comfyui_cpu_limit")"
     local openclaw_token
     openclaw_token=$(new_secure_hex 24)
     local qdrant_api_key
@@ -340,6 +397,16 @@ LLAMA_ARG_CACHE_TYPE_V=${LLAMA_ARG_CACHE_TYPE_V:-f16}
 # LLAMA_ARG_SPEC_DRAFT_N_MAX=3
 LLAMA_CPU_LIMIT=${detected_cpu_limit}
 LLAMA_CPU_RESERVATION=${detected_cpu_reservation}
+
+#=== Bundled Service CPU Budgets ===
+TTS_CPU_LIMIT=${tts_cpu_limit}
+TTS_CPU_RESERVATION=${tts_cpu_reservation}
+WHISPER_CPU_LIMIT=${whisper_cpu_limit}
+WHISPER_CPU_RESERVATION=${whisper_cpu_reservation}
+HERMES_CPU_LIMIT=${hermes_cpu_limit}
+HERMES_CPU_RESERVATION=${hermes_cpu_reservation}
+COMFYUI_CPU_LIMIT=${comfyui_cpu_limit}
+COMFYUI_CPU_RESERVATION=${comfyui_cpu_reservation}
 
 #=== Ports ===
 OLLAMA_PORT=8080

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -313,6 +313,28 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         fi
     }
 
+    _cap_cpu_value() {
+        local desired="$1" ceiling="$2"
+        awk -v desired="$desired" -v ceiling="$ceiling" '
+            BEGIN {
+                if (ceiling <= 0) ceiling = 1
+                value = desired
+                if (value > ceiling) value = ceiling
+                if (value < 0.01) value = 0.01
+                printf "%.1f", value
+            }'
+    }
+
+    _select_service_cpu_limit() {
+        local key="$1" desired="$2" available="$3"
+        _select_auto_cpu_value "$key" "$(_cap_cpu_value "$desired" "$available")"
+    }
+
+    _select_service_cpu_reservation() {
+        local key="$1" desired="$2" limit="$3"
+        _select_auto_cpu_value "$key" "$(_cap_cpu_value "$desired" "$limit")"
+    }
+
     _cpu_backend="${GPU_BACKEND:-cpu}"
     [[ "$_cpu_backend" == "none" ]] && _cpu_backend="cpu"
     read -r _llama_cpu_limit_raw _llama_cpu_reservation_raw _docker_available_cpus <<< "$(calculate_llama_cpu_budget "$_cpu_backend")"
@@ -323,6 +345,15 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     if awk "BEGIN { exit !($LLAMA_CPU_RESERVATION > $LLAMA_CPU_LIMIT) }"; then
         LLAMA_CPU_RESERVATION="$LLAMA_CPU_LIMIT"
     fi
+
+    TTS_CPU_LIMIT=$(_select_service_cpu_limit TTS_CPU_LIMIT "8.0" "$_docker_available_cpus")
+    TTS_CPU_RESERVATION=$(_select_service_cpu_reservation TTS_CPU_RESERVATION "2.0" "$TTS_CPU_LIMIT")
+    WHISPER_CPU_LIMIT=$(_select_service_cpu_limit WHISPER_CPU_LIMIT "4.0" "$_docker_available_cpus")
+    WHISPER_CPU_RESERVATION=$(_select_service_cpu_reservation WHISPER_CPU_RESERVATION "1.0" "$WHISPER_CPU_LIMIT")
+    HERMES_CPU_LIMIT=$(_select_service_cpu_limit HERMES_CPU_LIMIT "4.0" "$_docker_available_cpus")
+    HERMES_CPU_RESERVATION=$(_select_service_cpu_reservation HERMES_CPU_RESERVATION "0.5" "$HERMES_CPU_LIMIT")
+    COMFYUI_CPU_LIMIT=$(_select_service_cpu_limit COMFYUI_CPU_LIMIT "16.0" "$_docker_available_cpus")
+    COMFYUI_CPU_RESERVATION=$(_select_service_cpu_reservation COMFYUI_CPU_RESERVATION "2.0" "$COMFYUI_CPU_LIMIT")
 
     # Network binding (--lan sets 0.0.0.0; default is localhost-only)
     BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
@@ -481,6 +512,17 @@ LLAMA_PARALLEL=${LLAMA_PARALLEL:-1}
 # LLAMA_ARG_SPEC_DRAFT_N_MAX=3
 LLAMA_CPU_LIMIT=${LLAMA_CPU_LIMIT}
 LLAMA_CPU_RESERVATION=${LLAMA_CPU_RESERVATION}
+
+# Bundled service CPU budgets. These are capped to CPUs exposed by Docker so
+# small hosts do not fail container creation on fixed compose limits.
+TTS_CPU_LIMIT=${TTS_CPU_LIMIT}
+TTS_CPU_RESERVATION=${TTS_CPU_RESERVATION}
+WHISPER_CPU_LIMIT=${WHISPER_CPU_LIMIT}
+WHISPER_CPU_RESERVATION=${WHISPER_CPU_RESERVATION}
+HERMES_CPU_LIMIT=${HERMES_CPU_LIMIT}
+HERMES_CPU_RESERVATION=${HERMES_CPU_RESERVATION}
+COMFYUI_CPU_LIMIT=${COMFYUI_CPU_LIMIT}
+COMFYUI_CPU_RESERVATION=${COMFYUI_CPU_RESERVATION}
 
 $(if [[ "$GPU_BACKEND" == "amd" ]]; then
     # Read gfx target from topology detection. Falls back to gfx1151 (Strix Halo)

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -374,6 +374,28 @@ function Select-AutoCpuValue {
     return $Detected
 }
 
+function Select-CappedCpuValue {
+    param(
+        [string]$Desired,
+        [string]$Ceiling
+    )
+
+    $desiredNumber = 0.0
+    $ceilingNumber = 0.0
+    $style = [System.Globalization.NumberStyles]::Float
+    $culture = [System.Globalization.CultureInfo]::InvariantCulture
+    if (-not [double]::TryParse($Desired, $style, $culture, [ref]$desiredNumber)) {
+        $desiredNumber = 1.0
+    }
+    if (-not [double]::TryParse($Ceiling, $style, $culture, [ref]$ceilingNumber) -or $ceilingNumber -le 0) {
+        $ceilingNumber = 1.0
+    }
+
+    $value = [Math]::Min($desiredNumber, $ceilingNumber)
+    if ($value -lt 0.01) { $value = 0.01 }
+    return $value.ToString("0.0", $culture)
+}
+
 function Ensure-LlamaCpuBudget {
     <#
     .SYNOPSIS
@@ -416,6 +438,43 @@ function Ensure-LlamaCpuBudget {
     if ($changed) {
         Write-AI ("Auto-adjusted llama-server CPU budget: limit={0}, reservation={1} (Docker CPUs: {2})" -f `
             $llamaCpuLimit, $llamaCpuReservation, $budget.Available)
+    }
+
+    $serviceChanged = $false
+    $serviceBudgets = @(
+        @{ Name = "TTS"; DesiredLimit = "8.0"; DesiredReservation = "2.0" },
+        @{ Name = "WHISPER"; DesiredLimit = "4.0"; DesiredReservation = "1.0" },
+        @{ Name = "HERMES"; DesiredLimit = "4.0"; DesiredReservation = "0.5" },
+        @{ Name = "COMFYUI"; DesiredLimit = "16.0"; DesiredReservation = "2.0" }
+    )
+    foreach ($service in $serviceBudgets) {
+        $limitKey = "$($service.Name)_CPU_LIMIT"
+        $reservationKey = "$($service.Name)_CPU_RESERVATION"
+        $detectedLimit = Select-CappedCpuValue -Desired $service.DesiredLimit -Ceiling $budget.Available
+        $finalLimit = Select-AutoCpuValue -Existing $envVars[$limitKey] -Detected $detectedLimit
+        $detectedReservation = Select-CappedCpuValue -Desired $service.DesiredReservation -Ceiling $finalLimit
+        $finalReservation = Select-AutoCpuValue -Existing $envVars[$reservationKey] -Detected $detectedReservation
+
+        $finalLimitNumber = 0.0
+        $finalReservationNumber = 0.0
+        if ([double]::TryParse($finalLimit, $style, $culture, [ref]$finalLimitNumber) -and
+            [double]::TryParse($finalReservation, $style, $culture, [ref]$finalReservationNumber) -and
+            $finalReservationNumber -gt $finalLimitNumber) {
+            $finalReservation = $finalLimit
+        }
+
+        if ($envVars[$limitKey] -ne $finalLimit) {
+            Set-DreamEnvValue -Key $limitKey -Value $finalLimit
+            $serviceChanged = $true
+        }
+        if ($envVars[$reservationKey] -ne $finalReservation) {
+            Set-DreamEnvValue -Key $reservationKey -Value $finalReservation
+            $serviceChanged = $true
+        }
+    }
+
+    if ($serviceChanged) {
+        Write-AI ("Auto-adjusted bundled service CPU budgets (Docker CPUs: {0})" -f $budget.Available)
     }
 }
 

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -136,6 +136,46 @@ function New-DreamEnv {
         return $Detected
     }
 
+    function Select-CappedCpuValue {
+        param(
+            [string]$Desired,
+            [string]$Ceiling
+        )
+
+        $desiredNumber = 0.0
+        $ceilingNumber = 0.0
+        $style = [System.Globalization.NumberStyles]::Float
+        $culture = [System.Globalization.CultureInfo]::InvariantCulture
+        if (-not [double]::TryParse($Desired, $style, $culture, [ref]$desiredNumber)) {
+            $desiredNumber = 1.0
+        }
+        if (-not [double]::TryParse($Ceiling, $style, $culture, [ref]$ceilingNumber) -or $ceilingNumber -le 0) {
+            $ceilingNumber = 1.0
+        }
+
+        $value = [Math]::Min($desiredNumber, $ceilingNumber)
+        if ($value -lt 0.01) { $value = 0.01 }
+        return $value.ToString("0.0", $culture)
+    }
+
+    function Select-ServiceCpuLimit {
+        param(
+            [string]$Key,
+            [string]$Desired,
+            [string]$Available
+        )
+        return Select-AutoCpuValue -Key $Key -Detected (Select-CappedCpuValue -Desired $Desired -Ceiling $Available)
+    }
+
+    function Select-ServiceCpuReservation {
+        param(
+            [string]$Key,
+            [string]$Desired,
+            [string]$Limit
+        )
+        return Select-AutoCpuValue -Key $Key -Detected (Select-CappedCpuValue -Desired $Desired -Ceiling $Limit)
+    }
+
     # Generate secrets (reuse existing on re-install)
     $webuiSecret     = Get-EnvOrNew "WEBUI_SECRET"       (New-SecureHex -Bytes 32)
     $n8nPass         = Get-EnvOrNew "N8N_PASS"           (New-SecureBase64 -Bytes 16)
@@ -169,6 +209,14 @@ function New-DreamEnv {
             $llamaCpuReservation = $llamaCpuLimit
         }
     }
+    $ttsCpuLimit = Select-ServiceCpuLimit -Key "TTS_CPU_LIMIT" -Desired "8.0" -Available $cpuBudget.Available
+    $ttsCpuReservation = Select-ServiceCpuReservation -Key "TTS_CPU_RESERVATION" -Desired "2.0" -Limit $ttsCpuLimit
+    $whisperCpuLimit = Select-ServiceCpuLimit -Key "WHISPER_CPU_LIMIT" -Desired "4.0" -Available $cpuBudget.Available
+    $whisperCpuReservation = Select-ServiceCpuReservation -Key "WHISPER_CPU_RESERVATION" -Desired "1.0" -Limit $whisperCpuLimit
+    $hermesCpuLimit = Select-ServiceCpuLimit -Key "HERMES_CPU_LIMIT" -Desired "4.0" -Available $cpuBudget.Available
+    $hermesCpuReservation = Select-ServiceCpuReservation -Key "HERMES_CPU_RESERVATION" -Desired "0.5" -Limit $hermesCpuLimit
+    $comfyuiCpuLimit = Select-ServiceCpuLimit -Key "COMFYUI_CPU_LIMIT" -Desired "16.0" -Available $cpuBudget.Available
+    $comfyuiCpuReservation = Select-ServiceCpuReservation -Key "COMFYUI_CPU_RESERVATION" -Desired "2.0" -Limit $comfyuiCpuLimit
 
     # Langfuse observability secrets
     $langfusePort              = Get-EnvOrNew "LANGFUSE_PORT"              "3006"
@@ -324,6 +372,16 @@ $(if ($TierConfig.LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS) { "LLAMA_ARG_CHECKPOINT_E
 # LLAMA_ARG_SPEC_DRAFT_N_MAX=3
 LLAMA_CPU_LIMIT=$llamaCpuLimit
 LLAMA_CPU_RESERVATION=$llamaCpuReservation
+
+#=== Bundled Service CPU Budgets ===
+TTS_CPU_LIMIT=$ttsCpuLimit
+TTS_CPU_RESERVATION=$ttsCpuReservation
+WHISPER_CPU_LIMIT=$whisperCpuLimit
+WHISPER_CPU_RESERVATION=$whisperCpuReservation
+HERMES_CPU_LIMIT=$hermesCpuLimit
+HERMES_CPU_RESERVATION=$hermesCpuReservation
+COMFYUI_CPU_LIMIT=$comfyuiCpuLimit
+COMFYUI_CPU_RESERVATION=$comfyuiCpuReservation
 
 #=== Ports ===
 OLLAMA_PORT=11434

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -87,6 +87,24 @@ else
   echo "[SKIP] docker compose unavailable"
 fi
 
+echo "[contract] bundled service CPU limits are env-driven"
+grep -qF "cpus: '\${TTS_CPU_LIMIT:-1.0}'" extensions/services/tts/compose.yaml \
+  || { echo "[FAIL] Kokoro TTS CPU limit must be env-driven with safe fallback"; exit 1; }
+grep -qF "cpus: '\${WHISPER_CPU_LIMIT:-1.0}'" extensions/services/whisper/compose.yaml \
+  || { echo "[FAIL] Whisper CPU limit must be env-driven with safe fallback"; exit 1; }
+grep -qF "cpus: '\${WHISPER_CPU_LIMIT:-1.0}'" extensions/services/whisper/compose.nvidia.yaml \
+  || { echo "[FAIL] Whisper NVIDIA CPU limit must be env-driven with safe fallback"; exit 1; }
+grep -qF "cpus: '\${HERMES_CPU_LIMIT:-1.0}'" extensions/services/hermes/compose.yaml \
+  || { echo "[FAIL] Hermes CPU limit must be env-driven with safe fallback"; exit 1; }
+grep -qF "cpus: '\${COMFYUI_CPU_LIMIT:-1.0}'" extensions/services/comfyui/compose.nvidia.yaml \
+  || { echo "[FAIL] ComfyUI NVIDIA CPU limit must be env-driven with safe fallback"; exit 1; }
+grep -qF "cpus: '\${COMFYUI_CPU_LIMIT:-1.0}'" extensions/services/comfyui/compose.amd.yaml \
+  || { echo "[FAIL] ComfyUI AMD CPU limit must be env-driven with safe fallback"; exit 1; }
+for key in TTS_CPU_LIMIT TTS_CPU_RESERVATION WHISPER_CPU_LIMIT WHISPER_CPU_RESERVATION HERMES_CPU_LIMIT HERMES_CPU_RESERVATION COMFYUI_CPU_LIMIT COMFYUI_CPU_RESERVATION; do
+  jq -e --arg key "$key" '.properties[$key]' .env.schema.json >/dev/null \
+    || { echo "[FAIL] .env.schema.json missing bundled service CPU key: $key"; exit 1; }
+done
+
 echo "[contract] resolver scripts executable"
 for s in scripts/build-capability-profile.sh scripts/classify-hardware.sh scripts/load-backend-contract.sh scripts/resolve-compose-stack.sh scripts/preflight-engine.sh scripts/dream-doctor.sh scripts/simulate-installers.sh; do
   test -x "$s" || { echo "[FAIL] script not executable: $s"; exit 1; }

--- a/dream-server/tests/smoke/installer-env-smoke.sh
+++ b/dream-server/tests/smoke/installer-env-smoke.sh
@@ -142,7 +142,7 @@ export ENABLE_OPENCLAW=true
 
     docker() {
         if [[ \"\$1\" == \"info\" && \"\${2:-}\" == \"--format\" ]]; then
-            echo 6
+            echo 4
             return 0
         fi
         command docker \"\$@\"
@@ -173,7 +173,7 @@ else
 fi
 
 if [[ "$ENV_GENERATED" == true && -f "$INSTALL_DIR/.env" ]]; then
-    if grep -q '^LLAMA_CPU_LIMIT=6.0$' "$INSTALL_DIR/.env"; then
+    if grep -q '^LLAMA_CPU_LIMIT=4.0$' "$INSTALL_DIR/.env"; then
         pass "LLAMA_CPU_LIMIT auto-caps to Docker CPU count"
     else
         fail "LLAMA_CPU_LIMIT was not auto-capped as expected"
@@ -183,6 +183,20 @@ if [[ "$ENV_GENERATED" == true && -f "$INSTALL_DIR/.env" ]]; then
         pass "LLAMA_CPU_RESERVATION stays within the capped limit"
     else
         fail "LLAMA_CPU_RESERVATION was not written as expected"
+    fi
+
+    if grep -q '^TTS_CPU_LIMIT=4.0$' "$INSTALL_DIR/.env"; then
+        pass "TTS_CPU_LIMIT auto-caps to Docker CPU count"
+    else
+        fail "TTS_CPU_LIMIT was not auto-capped as expected"
+    fi
+
+    if grep -q '^WHISPER_CPU_LIMIT=4.0$' "$INSTALL_DIR/.env" \
+        && grep -q '^HERMES_CPU_LIMIT=4.0$' "$INSTALL_DIR/.env" \
+        && grep -q '^COMFYUI_CPU_LIMIT=4.0$' "$INSTALL_DIR/.env"; then
+        pass "Bundled service CPU limits stay at or below Docker CPU count"
+    else
+        fail "Bundled service CPU limits were not written as expected"
     fi
 fi
 


### PR DESCRIPTION
﻿## Summary

Fixes #1356.

The installer already auto-capped `llama-server` CPU limits to Docker's visible CPU count, but bundled extension services still had fixed `deploy.resources.limits.cpus` values. On a 4-CPU Docker daemon, Full Stack includes Kokoro TTS, whose compose file hardcoded `cpus: '8.0'`; Docker rejects that during container creation with:

```text
range of CPUs is from 0.01 to 4.00, as there are only 4 CPUs available
```

This PR makes the bundled voice/agent/image service CPU budgets env-driven and auto-capped the same way `llama-server` already is.

## Changes

- Replace fixed CPU limits in Kokoro TTS, Whisper, Hermes, and ComfyUI compose files with `.env`-driven values and safe low fallbacks.
- Generate capped CPU budget keys on fresh Linux, macOS, and Windows installs:
  - `TTS_CPU_LIMIT` / `TTS_CPU_RESERVATION`
  - `WHISPER_CPU_LIMIT` / `WHISPER_CPU_RESERVATION`
  - `HERMES_CPU_LIMIT` / `HERMES_CPU_RESERVATION`
  - `COMFYUI_CPU_LIMIT` / `COMFYUI_CPU_RESERVATION`
- Backfill/cap those keys for existing installs through `dream-cli`, `dream-macos.sh`, and Windows `dream.ps1` before compose actions.
- Add schema/example docs for the new keys and update the TTS troubleshooting note.
- Add smoke/contract coverage so 4-CPU env generation and env-driven compose limits are guarded.

## Validation

- `bash -n dream-cli installers/phases/06-directories.sh installers/macos/dream-macos.sh installers/macos/lib/env-generator.sh tests/smoke/installer-env-smoke.sh tests/contracts/test-installer-contracts.sh`
- `python -m json.tool dream-server/.env.schema.json`
- PowerShell scriptblock parse for:
  - `dream-server/installers/windows/lib/env-generator.ps1`
  - `dream-server/installers/windows/dream.ps1`
- `bash tests/smoke/installer-env-smoke.sh`
  - Local note: Git Bash needed temporary wrappers for Windows `jq.exe` CRLF output and `python3` -> `python`; the test itself passed with Docker CPU count mocked to `4`.
- `bash tests/contracts/test-installer-contracts.sh`
  - Same local wrappers as above.
- Rendered the affected compose stack with a 4-CPU env file and confirmed no rendered `cpus:` value exceeded `4`.

## Risk

Low install-risk change. The compose fallbacks are intentionally conservative so older `.env` files do not fail container creation. Fresh installs and normal CLI-managed updates get host-appropriate caps, preserving the previous larger caps on machines that can actually support them.
