### PR TITLE
fix(installer): keep cloud mode off local llama-server

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -7,6 +7,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
+- Linux cloud installs no longer launch or health-gate on local `llama-server`;
+  the compose resolver now selects a cloud overlay, skips local-mode dependency
+  overlays, and keeps Hermes SOUL persona generation outside the local-model
+  path.
 - Fleet distro lab Docker and Incus runners now take a shared host lock so
   tower2 distro dry-runs do not contend with heavy full-fleet install/build
   work on the same host.

--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -23,6 +23,7 @@ test: ## Run unit and contract tests
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
 	@bash tests/contracts/test-preflight-fixtures.sh
+	@bash tests/test-linux-cloud-mode.sh
 	@echo ""
 	@echo "=== Linux install preflight ==="
 	@bash tests/test-linux-install-preflight.sh

--- a/dream-server/docker-compose.cloud.yml
+++ b/dream-server/docker-compose.cloud.yml
@@ -1,0 +1,11 @@
+# Dream Server - Cloud / external LLM overlay
+#
+# Cloud mode keeps the Dream services running but does not launch a local
+# llama-server container. Open WebUI, Hermes, Perplexica, and other clients
+# route through LLM_API_URL / HERMES_LLM_BASE_URL instead.
+
+services:
+  llama-server:
+    profiles:
+      - local-inference
+    restart: "no"

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -509,7 +509,7 @@ _regenerate_compose_flags() {
         # from the persisted cache.
         "$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
             --script-dir "$INSTALL_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" \
-            --gpu-count "${GPU_COUNT:-1}" \
+            --gpu-count "${GPU_COUNT:-1}" --dream-mode "${DREAM_MODE:-local}" \
             > "$INSTALL_DIR/.compose-flags" 2>/dev/null || rm -f "$INSTALL_DIR/.compose-flags"
     else
         rm -f "$INSTALL_DIR/.compose-flags"
@@ -612,6 +612,10 @@ get_compose_flags() {
                 fi
                 prev="$tok"
             done
+            if [[ "${DREAM_MODE:-local}" == "cloud" ]] && \
+               { [[ "$cached" == *"docker-compose.cpu.yml"* ]] || [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]]; }; then
+                stale=1
+            fi
             if [[ "$stale" == "0" ]]; then
                 echo "$cached"
                 return
@@ -628,7 +632,7 @@ get_compose_flags() {
         # this fallback path resolves to a single-GPU stack on multi-GPU hosts.
         base_flags=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
             --script-dir "$INSTALL_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" \
-            --gpu-count "${GPU_COUNT:-1}")
+            --gpu-count "${GPU_COUNT:-1}" --dream-mode "${DREAM_MODE:-local}")
         echo "$base_flags"
     elif [[ -f "$INSTALL_DIR/docker-compose.base.yml" ]]; then
         base_flags="-f docker-compose.base.yml"
@@ -2740,6 +2744,7 @@ EOF
 #=============================================================================
 cmd_mode() {
     check_install; cd "$INSTALL_DIR"
+    load_env || true
     local mode="${1:-}"
 
     if [[ -z "$mode" ]]; then
@@ -2794,9 +2799,15 @@ cmd_mode() {
     if [[ "$mode" == "local" ]]; then
         api_url="http://llama-server:8080"
         _env_set "LLM_API_URL" "$api_url"
+        _env_set "HERMES_LLM_BASE_URL" "http://llama-server:8080/v1"
+        _env_set "HERMES_LLM_API_KEY" "sk-dream-hermes-local"
     else
         api_url="http://litellm:4000"
         _env_set "LLM_API_URL" "$api_url"
+        _env_set "HERMES_LLM_BASE_URL" "http://litellm:4000/v1"
+        if [[ -n "${LITELLM_KEY:-}" ]]; then
+            _env_set "HERMES_LLM_API_KEY" "$LITELLM_KEY"
+        fi
         # Auto-enable litellm
         local litellm_cf="$INSTALL_DIR/extensions/services/litellm/compose.yaml"
         local litellm_disabled="${litellm_cf}.disabled"
@@ -2816,6 +2827,8 @@ cmd_mode() {
     echo -e "${BLUE}━━━ Mode updated ━━━${NC}"
     echo "  DREAM_MODE  = $mode"
     echo "  LLM_API_URL = $api_url"
+    load_env || true
+    _regenerate_compose_flags
     success "Switched to $mode mode. Run 'dream restart' to apply."
 }
 

--- a/dream-server/installers/lib/compose-select.sh
+++ b/dream-server/installers/lib/compose-select.sh
@@ -92,6 +92,7 @@ resolve_compose_config() {
             --gpu-backend "$GPU_BACKEND" \
             --profile-overlays "${CAP_COMPOSE_OVERLAYS:-}" \
             --gpu-count "${GPU_COUNT:-1}" \
+            --dream-mode "${DREAM_MODE:-local}" \
             --env 2>>"$LOG_FILE")"
         load_env_from_output <<< "$COMPOSE_ENV"
     fi

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -198,7 +198,7 @@ if [[ -x "$SCRIPT_DIR/scripts/resolve-compose-stack.sh" ]]; then
     # plumbing on installs that already detected GPU_COUNT >= 2 in Phase 02.
     _refreshed_flags=$("$SCRIPT_DIR/scripts/resolve-compose-stack.sh" \
         --script-dir "$SCRIPT_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" \
-        --gpu-count "${GPU_COUNT:-1}" 2>/dev/null) || true
+        --gpu-count "${GPU_COUNT:-1}" --dream-mode "${DREAM_MODE:-local}" 2>/dev/null) || true
     if [[ -n "$_refreshed_flags" ]]; then
         COMPOSE_FLAGS="$_refreshed_flags"
         log "Compose flags refreshed after feature selection"

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -301,6 +301,24 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     LANGFUSE_INIT_USER_EMAIL=$(_env_get LANGFUSE_INIT_USER_EMAIL "admin@dreamserver.local")
     LANGFUSE_INIT_USER_PASSWORD=$(_env_get LANGFUSE_INIT_USER_PASSWORD "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
     MODEL_PROFILE_VALUE=$(_env_get MODEL_PROFILE "${MODEL_PROFILE_REQUESTED:-${MODEL_PROFILE:-qwen}}")
+    DREAM_MODE_VALUE="$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo "${DREAM_MODE:-local}"; fi)"
+    _default_llm_api_url="$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "http://litellm:4000"; elif [[ "${DREAM_MODE:-local}" == "local" ]]; then echo "http://llama-server:8080"; else echo "http://litellm:4000"; fi)"
+    LLM_API_URL_VALUE=$(_env_get LLM_API_URL "$_default_llm_api_url")
+    if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
+        _default_hermes_base_url="http://litellm:4000/v1"
+        _default_hermes_api_key="${LITELLM_KEY}"
+    elif [[ "$GPU_BACKEND" == "amd" ]]; then
+        _default_hermes_base_url="http://litellm:4000/v1"
+        _default_hermes_api_key="${LITELLM_KEY}"
+    else
+        _default_hermes_base_url="http://llama-server:8080/v1"
+        _default_hermes_api_key="sk-dream-hermes-local"
+    fi
+    HERMES_LLM_BASE_URL_VALUE=$(_env_get HERMES_LLM_BASE_URL "$_default_hermes_base_url")
+    HERMES_LLM_API_KEY_VALUE=$(_env_get HERMES_LLM_API_KEY "$_default_hermes_api_key")
+    LLM_API_URL="$LLM_API_URL_VALUE"
+    HERMES_LLM_BASE_URL="$HERMES_LLM_BASE_URL_VALUE"
+    HERMES_LLM_API_KEY="$HERMES_LLM_API_KEY_VALUE"
 
     _select_auto_cpu_value() {
         local key="$1" detected="$2"
@@ -457,8 +475,8 @@ BIND_ADDRESS=${BIND_ADDRESS}
 HOST_LAN_IP=${HOST_LAN_IP}
 
 #=== LLM Backend Mode ===
-DREAM_MODE=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo "${DREAM_MODE:-local}"; fi)
-LLM_API_URL=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "http://litellm:4000"; elif [[ "${DREAM_MODE:-local}" == "local" ]]; then echo "http://llama-server:8080"; else echo "http://litellm:4000"; fi)
+DREAM_MODE=${DREAM_MODE_VALUE}
+LLM_API_URL=${LLM_API_URL_VALUE}
 AMD_INFERENCE_RUNTIME=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo ""; fi)
 AMD_INFERENCE_BACKEND=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
 AMD_INFERENCE_LOCATION=$(if [[ "$GPU_BACKEND" == "amd" && "${DREAM_MODE:-local}" == "local" ]]; then echo "container"; else echo ""; fi)
@@ -608,8 +626,8 @@ LANGFUSE_PORT=${LANGFUSE_PORT}
 # APIConnectionError. litellm wraps with "*" wildcard normalization +
 # retry logic, hiding both bumps. On non-AMD installs, talk direct to
 # llama-server (native llama.cpp tolerates any model field).
-HERMES_LLM_BASE_URL=${HERMES_LLM_BASE_URL:-$(if [[ "$GPU_BACKEND" == "amd" ]]; then echo "http://litellm:4000/v1"; else echo "http://llama-server:8080/v1"; fi)}
-HERMES_LLM_API_KEY=${HERMES_LLM_API_KEY:-$(if [[ "$GPU_BACKEND" == "amd" ]]; then echo "${LITELLM_KEY}"; else echo "sk-dream-hermes-local"; fi)}
+HERMES_LLM_BASE_URL=${HERMES_LLM_BASE_URL_VALUE}
+HERMES_LLM_API_KEY=${HERMES_LLM_API_KEY_VALUE}
 HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
 HERMES_PROXY_PORT=${HERMES_PROXY_PORT:-9120}
 HERMES_PROXY_UPSTREAM=${HERMES_PROXY_UPSTREAM:-dream-hermes:9119}

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -164,7 +164,7 @@ else
         # for the rest of the install AND every subsequent dream-cli invocation.
         _refreshed_flags=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
             --script-dir "$INSTALL_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" \
-            --gpu-count "${GPU_COUNT:-1}" 2>/dev/null) || true
+            --gpu-count "${GPU_COUNT:-1}" --dream-mode "${DREAM_MODE:-local}" 2>/dev/null) || true
         if [[ -n "$_refreshed_flags" ]]; then
             COMPOSE_FLAGS="$_refreshed_flags"
             log "Compose flags refreshed from install directory"
@@ -509,9 +509,9 @@ MODELS_INI_EOF
                 fi
             fi
         fi
+    fi
 
-        # ── Hermes config substitution ──
-        #
+    if [[ "${ENABLE_HERMES:-false}" == "true" ]]; then
         # The Hermes Agent extension ships a config template at
         # extensions/services/hermes/cli-config.yaml.template which is
         # mounted into the container at /opt/hermes/cli-config.yaml.example.
@@ -534,12 +534,17 @@ MODELS_INI_EOF
         #
         # Substitute both values now, then verify. macOS does its own
         # substitution in installers/macos/install-macos.sh.
+        _python_cmd="$(ds_detect_python_cmd 2>/dev/null || command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
         _hermes_tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
         if [[ -f "$_hermes_tpl" ]]; then
-            # Model name: Lemonade prefixes with "extra.", llama.cpp uses
-            # the file name as-is.
-            _hermes_model="$GGUF_FILE"
-            if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
+            # Model name: cloud mode uses the routed model id; Lemonade
+            # prefixes GGUF files with "extra."; llama.cpp uses the file name.
+            if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
+                _hermes_model="${LLM_MODEL:-default}"
+            else
+                _hermes_model="$GGUF_FILE"
+            fi
+            if [[ "${GPU_BACKEND:-}" == "amd" && "${DREAM_MODE:-local}" != "cloud" ]]; then
                 _hermes_model="extra.$GGUF_FILE"
             fi
             # base_url: on AMD/Lemonade hosts, route Hermes through litellm
@@ -553,13 +558,15 @@ MODELS_INI_EOF
             # macOS install-macos.sh handles the host.docker.internal swap.
             _hermes_base_url=""
             _hermes_api_key=""
-            if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
+            if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
+                _hermes_base_url="${HERMES_LLM_BASE_URL:-http://litellm:4000/v1}"
+                _hermes_api_key="${HERMES_LLM_API_KEY:-${LITELLM_KEY:-}}"
+            elif [[ "${GPU_BACKEND:-}" == "amd" ]]; then
                 _hermes_base_url="http://litellm:4000/v1"
                 _hermes_api_key="${LITELLM_KEY:-}"
             fi
             _hermes_context="${MAX_CONTEXT:-131072}"
             _hermes_patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"
-            _python_cmd="$(ds_detect_python_cmd 2>/dev/null || command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
             if [[ -n "$_python_cmd" && -f "$_hermes_patcher" ]]; then
                 _hermes_patcher_args=("$_hermes_tpl" --model "$_hermes_model" --context-length "$_hermes_context")
                 if [[ -n "$_hermes_base_url" ]]; then

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -105,11 +105,18 @@ _check_container_health() {
     return 1
 }
 
-# Core service health checks with adaptive timeouts
-# Format: _check_health "name" "url" max_attempts timeout_per_request
-# llama-server: 150 attempts * adaptive backoff (2s->8s) = up to ~20 minutes (model loading can be slow)
-dream_progress 86 "health" "Waiting for LLM engine"
-_check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15 "$(sr_container llama-server)"
+# Core service health checks with adaptive timeouts.
+# Cloud mode does not launch local llama-server; LiteLLM/external APIs are the
+# LLM surface, so do not wait on a container that intentionally is not running.
+if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
+    dream_progress 86 "health" "Waiting for LiteLLM gateway"
+    _check_health "LiteLLM" "http://127.0.0.1:${SERVICE_PORTS[litellm]:-4000}${SERVICE_HEALTH[litellm]:-/health/readiness}" 60 10 "$(sr_container litellm)"
+else
+    # Format: _check_health "name" "url" max_attempts timeout_per_request
+    # llama-server: 150 attempts * adaptive backoff (2s->8s) = up to ~20 minutes (model loading can be slow)
+    dream_progress 86 "health" "Waiting for LLM engine"
+    _check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15 "$(sr_container llama-server)"
+fi
 
 # ── Pre-warm the LLM slot so the first real chat doesn't 503 ──
 #
@@ -128,21 +135,25 @@ _check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-80
 # cold path inside the installer (where time isn't surprising) so Hermes
 # lands on an already-hot slot. Bounded by curl --max-time so a stalled
 # llama-server doesn't hang phase 12.
-dream_progress 87 "health" "Pre-warming LLM slot"
-_prewarm_api_path="/v1"
-_prewarm_model="${GGUF_FILE:-${LLM_MODEL:-default}}"
-if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
-    _prewarm_api_path="/api/v1"
-    [[ -n "${GGUF_FILE:-}" ]] && _prewarm_model="extra.${GGUF_FILE}"
-fi
-_prewarm_url="http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${_prewarm_api_path}/chat/completions"
-_prewarm_body="{\"model\":\"${_prewarm_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}"
-if curl -sf --max-time 120 -X POST "$_prewarm_url" \
-    -H "Content-Type: application/json" \
-    -d "$_prewarm_body" >/dev/null 2>&1; then
-    ai_ok "LLM slot pre-warmed (first real chat will be fast)"
+if [[ "${DREAM_MODE:-local}" == "cloud" ]]; then
+    ai "Cloud mode - skipping local llama-server pre-warm"
 else
-    ai_warn "LLM pre-warm timed out — first Hermes prompt may need a retry or two while the slot finishes warming."
+    dream_progress 87 "health" "Pre-warming LLM slot"
+    _prewarm_api_path="/v1"
+    _prewarm_model="${GGUF_FILE:-${LLM_MODEL:-default}}"
+    if [[ "${GPU_BACKEND:-}" == "amd" ]]; then
+        _prewarm_api_path="/api/v1"
+        [[ -n "${GGUF_FILE:-}" ]] && _prewarm_model="extra.${GGUF_FILE}"
+    fi
+    _prewarm_url="http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${_prewarm_api_path}/chat/completions"
+    _prewarm_body="{\"model\":\"${_prewarm_model}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}"
+    if curl -sf --max-time 120 -X POST "$_prewarm_url" \
+        -H "Content-Type: application/json" \
+        -d "$_prewarm_body" >/dev/null 2>&1; then
+        ai_ok "LLM slot pre-warmed (first real chat will be fast)"
+    else
+        ai_warn "LLM pre-warm timed out — first Hermes prompt may need a retry or two while the slot finishes warming."
+    fi
 fi
 
 # Open WebUI: 150 attempts * adaptive backoff = up to ~20 minutes

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -8,6 +8,7 @@ PROFILE_OVERLAYS=""
 ENV_MODE="false"
 SKIP_BROKEN="false"
 GPU_COUNT="1"
+DREAM_MODE="${DREAM_MODE:-local}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -39,6 +40,10 @@ while [[ $# -gt 0 ]]; do
             GPU_COUNT="${2:-$GPU_COUNT}"
             shift 2
             ;;
+        --dream-mode)
+            DREAM_MODE="${2:-$DREAM_MODE}"
+            shift 2
+            ;;
         *)
             echo "Unknown argument: $1" >&2
             exit 1
@@ -63,7 +68,7 @@ if ! "$PYTHON_CMD" -c 'import yaml' >/dev/null 2>&1; then
     exit 2
 fi
 
-"$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" <<'PY'
+"$PYTHON_CMD" - "$SCRIPT_DIR" "$TIER" "$GPU_BACKEND" "$PROFILE_OVERLAYS" "$ENV_MODE" "$SKIP_BROKEN" "$GPU_COUNT" "$DREAM_MODE" <<'PY'
 import os
 import pathlib
 import platform
@@ -76,8 +81,8 @@ gpu_backend = (sys.argv[3] or "nvidia").lower()
 profile_overlays = [x.strip() for x in (sys.argv[4] or "").split(",") if x.strip()]
 env_mode = (sys.argv[5] or "false").lower() == "true"
 skip_broken = (sys.argv[6] or "false").lower() == "true"
-dream_mode = os.environ.get("DREAM_MODE", "local").lower()
 gpu_count = int(sys.argv[7] or "1")
+dream_mode = (sys.argv[8] or os.environ.get("DREAM_MODE", "local")).lower()
 
 IS_DARWIN = platform.system() == "Darwin"
 APPLE_OVERLAY = "installers/macos/docker-compose.macos.yml" if IS_DARWIN else "docker-compose.apple.yml"
@@ -91,6 +96,13 @@ primary = "docker-compose.yml"
 if profile_overlays and existing(profile_overlays):
     resolved = profile_overlays
     primary = profile_overlays[-1]
+elif dream_mode == "cloud" or tier == "CLOUD":
+    if existing(["docker-compose.base.yml", "docker-compose.cloud.yml"]):
+        resolved = ["docker-compose.base.yml", "docker-compose.cloud.yml"]
+        primary = "docker-compose.cloud.yml"
+    elif existing(["docker-compose.base.yml"]):
+        resolved = ["docker-compose.base.yml"]
+        primary = "docker-compose.base.yml"
 elif tier in {"AP_ULTRA", "AP_PRO", "AP_BASE"}:
     if existing(["docker-compose.base.yml", APPLE_OVERLAY]):
         resolved = ["docker-compose.base.yml", APPLE_OVERLAY]
@@ -420,7 +432,7 @@ if ext_dir.exists():
             # service_healthy` inside compose.local.yaml overlays can never be
             # satisfied and deadlocks the stack. The real LLM-ready gate on macOS
             # is the `llama-server-ready` sidecar defined in the macOS overlay.
-            if dream_mode in ("local", "hybrid", "lemonade") and gpu_backend != "apple":
+            if dream_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple":
                 local_mode_overlay = service_dir / "compose.local.yaml"
                 if local_mode_overlay.exists():
                     resolved.append(str(local_mode_overlay.relative_to(script_dir)))
@@ -538,7 +550,7 @@ if user_ext_dir.exists():
                 # satisfied and deadlocks the stack. The real LLM-ready gate on macOS
                 # is the `llama-server-ready` sidecar defined in the macOS overlay.
                 # Mirrors the same guard in the built-in loop above (PR #1004).
-                if dream_mode in ("local", "hybrid", "lemonade") and gpu_backend != "apple":
+                if dream_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple":
                     local_mode_overlay = service_dir / "compose.local.yaml"
                     if local_mode_overlay.exists():
                         # Same content scan as compose.yaml/gpu overlay above —

--- a/dream-server/tests/test-linux-cloud-mode.sh
+++ b/dream-server/tests/test-linux-cloud-mode.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Regression checks for Linux cloud mode. Cloud/external LLM installs must not
+# require a local llama-server container or local-mode dependency overlays.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+pass() { printf '[PASS] %s\n' "$1"; }
+fail() { printf '[FAIL] %s\n' "$1" >&2; exit 1; }
+
+contains() {
+    local haystack="$1" needle="$2" label="$3"
+    [[ "$haystack" == *"$needle"* ]] && pass "$label" || fail "$label"
+}
+
+rejects() {
+    local haystack="$1" needle="$2" label="$3"
+    [[ "$haystack" != *"$needle"* ]] && pass "$label" || fail "$label"
+}
+
+PY="${DREAM_PYTHON_CMD:-}"
+if [[ -z "$PY" ]]; then
+    if command -v python3 >/dev/null 2>&1; then
+        PY=python3
+    elif command -v python >/dev/null 2>&1; then
+        PY=python
+    else
+        fail "python is required"
+    fi
+fi
+
+flags="$(DREAM_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
+    --script-dir "$ROOT_DIR" \
+    --tier CLOUD \
+    --gpu-backend cpu \
+    --gpu-count 0 \
+    --dream-mode cloud)"
+flags="${flags//\\//}"
+
+contains "$flags" "docker-compose.base.yml" "cloud mode keeps base stack"
+contains "$flags" "docker-compose.cloud.yml" "cloud mode layers cloud overlay"
+contains "$flags" "extensions/services/litellm/compose.yaml" "cloud mode includes LiteLLM gateway"
+rejects "$flags" "docker-compose.cpu.yml" "cloud mode does not include CPU llama-server overlay"
+rejects "$flags" "compose.local.yaml" "cloud mode does not include local dependency overlays"
+
+if grep -q 'profiles:' docker-compose.cloud.yml && grep -q 'local-inference' docker-compose.cloud.yml; then
+    pass "cloud overlay profiles local llama-server out of default startup"
+else
+    fail "cloud overlay must profile local llama-server out of default startup"
+fi
+
+if grep -Fq -- '--dream-mode "${DREAM_MODE:-local}"' installers/lib/compose-select.sh \
+    && grep -Fq -- '--dream-mode "${DREAM_MODE:-local}"' installers/phases/03-features.sh \
+    && grep -Fq -- '--dream-mode "${DREAM_MODE:-local}"' installers/phases/11-services.sh \
+    && grep -Fq -- '--dream-mode "${DREAM_MODE:-local}"' dream-cli; then
+    pass "installer and CLI pass dream mode to compose resolver"
+else
+    fail "all installer/CLI resolver calls must pass --dream-mode"
+fi
+
+if grep -q 'DREAM_MODE:-local.*cloud' installers/phases/12-health.sh \
+    && grep -Fq 'LiteLLM' installers/phases/12-health.sh \
+    && grep -Fq 'skipping local llama-server pre-warm' installers/phases/12-health.sh; then
+    pass "cloud health path skips local llama-server"
+else
+    fail "cloud health path must skip local llama-server"
+fi
+
+"$PY" - "$ROOT_DIR" <<'PY'
+from pathlib import Path
+import sys
+
+root = Path(sys.argv[1])
+text = (root / "installers/phases/11-services.sh").read_text(encoding="utf-8")
+model_block = text.index('if [[ "${DREAM_MODE:-local}" != "cloud" ]]; then')
+soul_block = text.index('_soul_output="$INSTALL_DIR/data/persona/SOUL.md"')
+if soul_block > model_block:
+    # Make sure the local-model block was closed before SOUL render begins.
+    between = text[model_block:soul_block]
+    if '\n    if [[ "${ENABLE_HERMES:-false}" == "true" ]]; then' in between:
+        print("[PASS] SOUL.md render is outside local-model-only block")
+        sys.exit(0)
+print("[FAIL] SOUL.md render must run for cloud installs too", file=sys.stderr)
+sys.exit(1)
+PY
+
+echo "[PASS] linux cloud mode contracts"


### PR DESCRIPTION
﻿## Summary

This patches the Linux cloud/external-LLM install path so it no longer starts, waits on, or inherits dependencies on the local `llama-server` container.

Root cause from the user report:
- `resolve-compose-stack.sh` only read `DREAM_MODE` from the environment, but installer callers were passing it as a shell variable rather than a resolver argument.
- `gpu_backend=cpu` was selected before cloud mode, so `--cloud` could still resolve `docker-compose.cpu.yml`.
- Local-mode extension overlays such as `extensions/services/litellm/compose.local.yaml` could still be included, reintroducing `depends_on: llama-server`.
- Phase 12 always waited on and pre-warmed `llama-server`, even when cloud mode should not launch it.
- Hermes SOUL rendering was still nested behind the local-model path, which left cloud installs vulnerable to the file-vs-directory bind mount failure.

Fixes:
- Add `docker-compose.cloud.yml` to profile `llama-server` out of default cloud startup.
- Add `--dream-mode` to the compose resolver and all Linux installer / CLI resolver calls.
- Resolve cloud mode before CPU/local overlays and suppress local dependency overlays for `tier=CLOUD`.
- Regenerate stale `.compose-flags` when a cloud install still points at CPU/local overlays.
- Preserve cloud/external LLM URL settings in `.env` and set Hermes defaults to the LiteLLM route in cloud mode.
- Move Hermes config/SOUL generation outside the local-model-only block.
- Make Phase 12 check LiteLLM in cloud mode and skip local `llama-server` pre-warm.
- Add `tests/test-linux-cloud-mode.sh` and wire it into `make test`.

## Validation

Passed:
- `bash -n scripts/resolve-compose-stack.sh installers/lib/compose-select.sh installers/phases/03-features.sh installers/phases/06-directories.sh installers/phases/11-services.sh installers/phases/12-health.sh dream-cli tests/test-linux-cloud-mode.sh`
- `DREAM_PYTHON_CMD=python bash tests/test-linux-cloud-mode.sh`
- `DREAM_PYTHON_CMD=python DREAM_MODE=cloud ./scripts/resolve-compose-stack.sh --script-dir . --tier CLOUD --gpu-backend cpu --gpu-count 0`
- `DREAM_PYTHON_CMD=python ./scripts/resolve-compose-stack.sh --script-dir . --tier CLOUD --gpu-backend cpu --gpu-count 0 --dream-mode cloud --env`
- `docker compose ... config --quiet` for the resolved cloud stack with required env set
- `docker compose ... config --services` for the resolved cloud stack; service list did not include `llama-server`
- `tests/test-tier-map.sh`
- `tests/contracts/test-installer-contracts.sh`
- `tests/contracts/test-preflight-fixtures.sh`
- `tests/test-linux-install-preflight.sh`
- `tests/contracts/test-amd-lemonade-contracts.sh`
- `tests/test-litellm-amd-auth-enforced.sh`
- `tests/contracts/test-overlay-map-coherence.sh`
- `tests/contracts/test-plist-log-paths.sh`
- `tests/test-bind-address-sweep.sh`
- `tests/test-dream-cli-pipefail-tolerance.sh`
- `tests/test-bash32-guards.sh`
- `tests/test-bootstrap-openclaw-compose-guard.sh`
- `tests/test-macos-host-agent-verification.sh`
- `tests/test-fleet-multi-distro-keep-going.sh`
- `DREAM_PYTHON_CMD=python bash tests/test-cpu-only-path.sh`
- `DREAM_PYTHON_CMD=python bash tests/test-windows-hermes-soul.sh`
- `git diff --check`

Environment notes:
- `make test` itself was not available on this Windows workstation because `make` is not installed, so I ran the relevant constituent scripts directly.
- `tests/test-bootstrap-upgrade-close-inherited-fds.sh` could not complete on this workstation because Git Bash does not provide `flock` here.
- One broad secret-mask test path is sensitive to Windows Python reading Git Bash `/tmp` paths; unrelated to this cloud installer path.

## Security / privacy

Reviewed the diff for private hostnames, usernames, LAN IPs, and token/private-key patterns. No user/private data was added. The only key-like value touched is the existing dummy local Hermes token (`sk-dream-hermes-local`).
