### PR TITLE
[codex] fix Hermes WhatsApp bridge port

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -415,6 +415,13 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
 #  not in env. Edit the file after first start to switch models.)
 #
+# Optional Hermes WhatsApp gateway. Disabled by default; Dream's Hermes
+# config pins WhatsApp's internal bridge to 3010 so it does not collide with
+# Open WebUI's host port 3000 when users intentionally enable WhatsApp.
+# WHATSAPP_ENABLED=false
+# WHATSAPP_MODE=self-chat
+# WHATSAPP_ALLOWED_USERS=15551234567
+#
 # Hermes is reached on the LAN via dream-hermes-proxy (Caddy sidecar) which
 # verifies the dream-session cookie against dashboard-api's verify endpoint
 # (forward_auth → HMAC signature check via DREAM_SESSION_SECRET).

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -97,7 +97,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 - **Compression:** enabled at `compression.threshold: 0.50` with `target_ratio: 0.20` so long sessions compact before the backend hard-rejects an over-window request.
 - **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
-- **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server owner-card users reach Hermes through the Dream Talk mobile portal, while advanced users can still open the full Hermes web dashboard. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
+- **Messaging gateways DISABLED:** Telegram / Discord / Slack / WhatsApp / Signal / Teams / Google Chat / Matrix / Mattermost / SMS — all off by default. Dream Server owner-card users reach Hermes through the Dream Talk mobile portal, while advanced users can still open the full Hermes web dashboard. WhatsApp is pre-seeded as disabled with `bridge_port: 3010` so upstream's default `3000` bridge does not collide with Open WebUI when users intentionally enable it. To enable any platform, see [upstream messaging docs](https://hermes-agent.nousresearch.com/docs/user-guide/messaging/).
 - **Network exposure:** Hermes is **not directly LAN-reachable**. Once the `hermes-proxy` extension is enabled (see [docs/HERMES-SSO.md](HERMES-SSO.md)), the proxy at port 9120 fronts Hermes and gates access on Dream Server's magic-link cookie. Hermes's own port 9119 is internal-only. To restore direct access (e.g. for testing without auth), re-add a `ports:` binding to `extensions/services/hermes/compose.yaml`.
 - **Resource caps:** 4 CPUs / 4GB RAM hard limit, 0.5 CPU / 1GB reservation. Hermes's playwright + ML deps can be hungry; adjust in `extensions/services/hermes/compose.yaml` if needed.
 
@@ -106,7 +106,7 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 Three layers, highest to lowest precedence:
 
 1. **Edit `data/hermes/config.yaml`** directly — Hermes's own config file, copied from our template on first start. Survives container restarts. Reset by deleting and restarting. **The model name lives here**, not in env.
-2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_LLM_API_KEY`, `HERMES_LANGUAGE`, and the `HERMES_PROXY_*` proxy settings. Hermes itself has no host-port env knob in the auth-gated stack; the LAN-facing port is `HERMES_PROXY_PORT`.
+2. **Set env vars in Dream Server's `.env`** — `HERMES_LLM_BASE_URL`, `HERMES_LLM_API_KEY`, `HERMES_LANGUAGE`, optional `WHATSAPP_*` gateway settings, and the `HERMES_PROXY_*` proxy settings. Hermes itself has no host-port env knob in the auth-gated stack; the LAN-facing port is `HERMES_PROXY_PORT`.
 3. **Fall back to Dream Server's defaults** — defined in `extensions/services/hermes/cli-config.yaml.template`.
 
 To bring up Hermes pointing at a different LLM (e.g. OpenRouter, OpenAI, Anthropic), edit `data/hermes/config.yaml`'s `model.provider` and `model.base_url` and restart. The whole gamut of provider options is listed in the upstream config — Hermes supports OpenRouter / Anthropic / OpenAI / Hugging Face / NVIDIA NIM / z.ai / Kimi / Gemini / Ollama Cloud / LM Studio / etc. out of the box.
@@ -180,6 +180,20 @@ docker exec dream-hermes curl -fs http://llama-server:8080/v1/models
 ```
 
 If that fails, the most likely cause is that the Hermes container isn't on Dream Server's docker network. Check `docker network inspect dream-server_default`.
+
+### WhatsApp reports port 3000 already in use
+
+Dream Server's bundled Hermes config uses `platforms.whatsapp.extra.bridge_port: 3010`, and the Hermes container does not bind that bridge to the host. If you see a WhatsApp bridge conflict on port 3000, you are probably running Hermes Agent natively, running upstream Hermes with host networking, or using an older `data/hermes/config.yaml` copied before this default existed.
+
+Set the WhatsApp bridge port in `data/hermes/config.yaml` and restart Hermes:
+
+```yaml
+platforms:
+  whatsapp:
+    enabled: true
+    extra:
+      bridge_port: 3010
+```
 
 ### Hermes says context length exceeded or max compression attempts reached
 

--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -102,19 +102,32 @@ terminal:
 # =============================================================================
 # Hermes ships with Telegram / Discord / Slack / WhatsApp / Signal / email /
 # Teams / Google Chat / Matrix / Mattermost / SMS gateway adapters. Dream
-# Server users reach Hermes via the web dashboard, not platform bots — so
-# none of these are configured here.
+# Server users reach Hermes via the web dashboard, not platform bots — so none
+# of these are enabled here.
 #
 # IMPORTANT: there is NO top-level `gateway.enabled: false` switch in
 # upstream's config schema. Earlier drafts of this template had one; it
 # was silently ignored. The gateway is "disabled" by simply not
-# configuring any adapter (no TELEGRAM_TOKEN, no DISCORD_TOKEN, etc.),
-# which means `hermes gateway run` starts, ticks cron, hosts the
-# dashboard, and has no platforms to message on.
+# enabling any adapter (no TELEGRAM_TOKEN, no DISCORD_TOKEN, etc.), which
+# means `hermes gateway run` starts, ticks cron, hosts the dashboard, and
+# has no platforms to message on.
+#
+# WhatsApp is pre-seeded as disabled only to override upstream's bridge
+# default. Upstream's WhatsApp bridge listens on 127.0.0.1:3000 by default
+# and attempts to clear that port before starting; Dream Server already uses
+# host port 3000 for Open WebUI. The bridge is internal to the Hermes
+# container in Dream's default compose network, but an explicit non-3000
+# value keeps native/host-network experiments from colliding with Open WebUI
+# when users intentionally enable WhatsApp.
 #
 # To enable a platform, follow upstream's adapter docs and add the
 # matching block under the platform-specific config keys, then restart
 # the container.
+platforms:
+  whatsapp:
+    enabled: false
+    extra:
+      bridge_port: 3010
 
 # =============================================================================
 # Compression — keep memory bounded on small devices

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -32,6 +32,16 @@ services:
       # Locale + timezone match the rest of the stack.
       - TZ=${TIMEZONE:-UTC}
       - HERMES_LANGUAGE=${HERMES_LANGUAGE:-en}
+      # Optional WhatsApp adapter pass-through. These list-form entries are
+      # only populated when the operator sets them in the compose environment;
+      # otherwise the disabled config block in cli-config.yaml.template remains
+      # authoritative and Hermes's own persisted .env is not masked by blanks.
+      - WHATSAPP_ENABLED
+      - WHATSAPP_MODE
+      - WHATSAPP_ALLOWED_USERS
+      - WHATSAPP_REQUIRE_MENTION
+      - WHATSAPP_FREE_RESPONSE_CHATS
+      - WHATSAPP_REPLY_PREFIX
       # Embed the dashboard inside the gateway process (see `command` below).
       # Upstream reads these env vars to configure the dashboard listener
       # without separate CLI flags.

--- a/dream-server/scripts/patch-hermes-config.py
+++ b/dream-server/scripts/patch-hermes-config.py
@@ -146,6 +146,54 @@ def _ensure_compression(lines: list[str]) -> None:
     _set_key(lines, block, "protect_last_n", "40", 2)
 
 
+def _ensure_whatsapp_bridge(lines: list[str]) -> None:
+    """Keep WhatsApp off by default while avoiding upstream's port 3000 bridge.
+
+    Existing operator choices win: if a WhatsApp block already exists we do not
+    change its enabled state, and if it already has extra.bridge_port we leave
+    that value alone.
+    """
+
+    platforms = _top_level_block(lines, "platforms")
+    if platforms is None:
+        lines.extend(
+            [
+                "",
+                "platforms:",
+                "  whatsapp:",
+                "    enabled: false",
+                "    extra:",
+                "      bridge_port: 3010",
+            ]
+        )
+        return
+
+    whatsapp = _child_block(lines, platforms, "whatsapp", 2)
+    if whatsapp is None:
+        insert_at = platforms[1]
+        lines[insert_at:insert_at] = [
+            "  whatsapp:",
+            "    enabled: false",
+            "    extra:",
+            "      bridge_port: 3010",
+        ]
+        return
+
+    extra = _child_block(lines, whatsapp, "extra", 4)
+    if extra is None:
+        insert_at = whatsapp[1]
+        lines[insert_at:insert_at] = [
+            "    extra:",
+            "      bridge_port: 3010",
+        ]
+        return
+
+    for idx in range(extra[0] + 1, extra[1]):
+        if re.match(r"^\s{6}bridge_port:\s*.*$", lines[idx]):
+            return
+    _set_key(lines, extra, "bridge_port", "3010", 6)
+
+
 def patch_config(path: Path, model: str | None, base_url: str | None, context_length: int | None, api_key: str | None = None) -> bool:
     original = path.read_text(encoding="utf-8")
     trailing_newline = original.endswith("\n")
@@ -153,6 +201,7 @@ def patch_config(path: Path, model: str | None, base_url: str | None, context_le
 
     _ensure_model(lines, model, base_url, context_length, api_key)
     _ensure_auxiliary(lines, context_length)
+    _ensure_whatsapp_bridge(lines)
     _ensure_compression(lines)
 
     updated = "\n".join(lines)

--- a/dream-server/tests/contracts/test-network-exposure-contracts.py
+++ b/dream-server/tests/contracts/test-network-exposure-contracts.py
@@ -72,6 +72,27 @@ def test_hermes_is_internal_only_and_proxy_gated() -> None:
     assert_true("reverse_proxy {$HERMES_PROXY_UPSTREAM:dream-hermes:9119}" in proxy_caddyfile, "hermes-proxy must forward to internal Hermes")
 
 
+def test_hermes_whatsapp_bridge_avoids_open_webui_port() -> None:
+    hermes_compose = read(SERVICES / "hermes" / "compose.yaml")
+    hermes_config = read(SERVICES / "hermes" / "cli-config.yaml.template")
+
+    assert_true("whatsapp:" in hermes_config, "Hermes config should pre-seed WhatsApp settings")
+    assert_true("enabled: false" in hermes_config, "WhatsApp must remain disabled by default")
+    assert_true(
+        re.search(r"(?m)^\s+bridge_port:\s*3010\s*$", hermes_config) is not None,
+        "WhatsApp bridge must default away from Open WebUI port 3000",
+    )
+    assert_true(
+        re.search(r"(?m)^\s+bridge_port:\s*3000\s*$", hermes_config) is None,
+        "WhatsApp bridge must not use upstream's port 3000 default",
+    )
+    assert_true(
+        re.search(r"(?m)^\s+-\s+WHATSAPP_ENABLED\s*$", hermes_compose) is not None,
+        "Hermes compose should pass intentional WhatsApp enables without blank defaults",
+    )
+    assert_true("3010:3010" not in hermes_compose, "WhatsApp bridge must not be host-bound")
+
+
 def test_dream_proxy_routes_talk_portal() -> None:
     caddyfile = read(SERVICES / "dream-proxy" / "Caddyfile")
 
@@ -112,6 +133,7 @@ def main() -> int:
     tests = [
         test_exposed_services_are_policy_labeled,
         test_hermes_is_internal_only_and_proxy_gated,
+        test_hermes_whatsapp_bridge_avoids_open_webui_port,
         test_dream_proxy_routes_talk_portal,
         test_dashboard_csp_allows_dream_talk_tts_blob_audio,
         test_openclaw_stays_deprecated_optional_and_token_gated,

--- a/dream-server/tests/test-installer-context-parity.sh
+++ b/dream-server/tests/test-installer-context-parity.sh
@@ -116,7 +116,8 @@ python_cmd="$(command -v python3 2>/dev/null || command -v python 2>/dev/null ||
 [[ -n "$python_cmd" ]] || fail "python is required to test Hermes config patcher"
 
 tmp_hermes="$(mktemp)"
-trap 'rm -f "$tmp_hermes"' EXIT
+tmp_hermes_custom="$(mktemp)"
+trap 'rm -f "$tmp_hermes" "$tmp_hermes_custom"' EXIT
 cat > "$tmp_hermes" <<'HERMES_EOF'
 model:
   default: "old-model"
@@ -157,6 +158,30 @@ pass "Hermes patcher normalizes compression target_ratio"
 grep -q '^  protect_last_n: 40$' "$tmp_hermes" \
     || fail "Hermes patcher writes protect_last_n"
 pass "Hermes patcher writes protect_last_n"
+grep -q '^      bridge_port: 3010$' "$tmp_hermes" \
+    || fail "Hermes patcher writes WhatsApp bridge port away from Open WebUI"
+pass "Hermes patcher writes WhatsApp bridge port away from Open WebUI"
+
+cat > "$tmp_hermes_custom" <<'HERMES_CUSTOM_EOF'
+model:
+  default: "old-model"
+platforms:
+  whatsapp:
+    enabled: true
+    extra:
+      bridge_port: 3456
+compression:
+  threshold: 0.75
+HERMES_CUSTOM_EOF
+
+"$python_cmd" scripts/patch-hermes-config.py "$tmp_hermes_custom" >/dev/null
+
+grep -q '^    enabled: true$' "$tmp_hermes_custom" \
+    || fail "Hermes patcher preserves user-enabled WhatsApp"
+pass "Hermes patcher preserves user-enabled WhatsApp"
+grep -q '^      bridge_port: 3456$' "$tmp_hermes_custom" \
+    || fail "Hermes patcher preserves custom WhatsApp bridge port"
+pass "Hermes patcher preserves custom WhatsApp bridge port"
 
 echo ""
 echo "Results: $PASS passed"


### PR DESCRIPTION
﻿## Summary

- Pre-seeds Hermes WhatsApp as disabled with `extra.bridge_port: 3010`, avoiding upstream's default `3000` bridge that can collide with Dream Server's Open WebUI port.
- Passes through intentional `WHATSAPP_*` compose env vars without blank defaults, so operators can enable WhatsApp while existing Hermes persisted env/config is not masked.
- Extends the Hermes config patcher so existing `data/hermes/config.yaml` files get a safe bridge port when missing, while preserving user-enabled WhatsApp and custom bridge ports.
- Documents the port behavior and adds contract coverage for the no-host-bind / no-3000 invariant.

## Root Cause

Upstream Hermes Agent's WhatsApp bridge defaults to `127.0.0.1:3000` and attempts to clear that port before starting. Dream Server already uses host port `3000` for Open WebUI. In the default Dream container setup the bridge is internal-only, but native Hermes, host-network experiments, or older configs can still hit the conflict.

## Validation

- `python dream-server/tests/contracts/test-network-exposure-contracts.py`
- `C:\Program Files\Git\bin\bash.exe dream-server/tests/test-installer-context-parity.sh`
- YAML parse check for `extensions/services/hermes/cli-config.yaml.template` and `extensions/services/hermes/compose.yaml`
- `docker compose -f dream-server/extensions/services/hermes/compose.yaml config --services`
- `docker compose -f dream-server/extensions/services/hermes/compose.yaml config` with and without `WHATSAPP_ENABLED=true`
- `git diff --check`

Note: `python dream-server/tests/contracts/test-port-contracts.py` still fails before/independent of this PR because the test expects legacy `ports.json` keys (`env`/`default`) while the current file uses `env_var`/`external_default`. This PR does not touch the port registry.