### PR TITLE
[codex] add experimental AMD GAIA extension recipe

### DIFF
--- a/dream-server/config/extensions-catalog.json
+++ b/dream-server/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T14:01:59Z",
+  "generated_at": "2026-05-24T03:20:28Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -1024,6 +1024,90 @@
           ]
         }
       ]
+    },
+    {
+      "id": "gaia",
+      "name": "AMD GAIA",
+      "description": "Experimental AMD GAIA Agent UI recipe for local agent workflows.",
+      "category": "optional",
+      "gpu_backends": [
+        "all"
+      ],
+      "compose_file": "compose.yaml",
+      "depends_on": [],
+      "port": 4200,
+      "external_port_default": 7822,
+      "health_endpoint": "/",
+      "env_vars": [
+        {
+          "key": "GAIA_AGENT_UI_VERSION",
+          "required": false,
+          "default": "0.19.0",
+          "description": "Agent UI npm package version to install when building the container."
+        },
+        {
+          "key": "GAIA_LEMONADE_BASE_URL",
+          "required": false,
+          "default": "",
+          "description": "Remote Lemonade/OpenAI-compatible API base URL for GAIA, usually ending in /api/v1."
+        },
+        {
+          "key": "GAIA_SKIP_GAIA_INIT",
+          "required": false,
+          "default": "true",
+          "description": "Skip GAIA's first-run Lemonade/model bootstrap to avoid automatic model downloads."
+        },
+        {
+          "key": "GAIA_UI_SERVE_ONLY",
+          "required": false,
+          "default": "false",
+          "description": "Serve only the Agent UI static frontend without starting the GAIA Python backend."
+        },
+        {
+          "key": "GAIA_DISABLE_UPDATE",
+          "required": false,
+          "default": "1",
+          "description": "Disable Agent UI auto-update checks inside the container."
+        }
+      ],
+      "tags": [
+        "amd",
+        "gaia",
+        "agents",
+        "agent-ui",
+        "ryzen-ai",
+        "experimental"
+      ],
+      "features": [
+        {
+          "id": "amd-gaia-agent-ui",
+          "name": "AMD GAIA Agent UI",
+          "description": "Experimental AMD local agent UI and framework integration",
+          "icon": "Bot",
+          "category": "ai",
+          "requirements": {
+            "services": [
+              "gaia"
+            ],
+            "vram_gb": 0,
+            "disk_gb": 5
+          },
+          "enabled_services_all": [
+            "gaia"
+          ],
+          "setup_time": "~5-10 minutes first start",
+          "priority": 31,
+          "launch": {
+            "type": "service",
+            "service": "gaia",
+            "path": "/"
+          },
+          "gpu_backends": [
+            "all"
+          ]
+        }
+      ],
+      "startup_timeout": 300
     },
     {
       "id": "gitea",

--- a/dream-server/extensions/library/README.md
+++ b/dream-server/extensions/library/README.md
@@ -1,6 +1,6 @@
 # DreamServer Extensions Library
 
-**32 service extensions being tested for DreamServer. 17 are already in production — these are next.**
+**33 service extensions being tested for DreamServer. 17 are already in production — these are next.**
 
 Each extension is a self-contained directory with a `manifest.yaml` (service metadata), `compose.yaml` (Docker Compose fragment), and optional Dockerfiles, workflows, and documentation. Drop any of these into your DreamServer's `extensions/services/` directory and run `dream enable <service-id>`.
 
@@ -44,6 +44,7 @@ Each extension is a self-contained directory with a `manifest.yaml` (service met
 | [`aider/`](services/aider/) | Aider — AI pair programming in your terminal | AMD, NVIDIA, Apple |
 | [`continue/`](services/continue/) | Continue — AI coding assistant (VS Code / JetBrains) | AMD, NVIDIA, Apple |
 | [`crewai/`](services/crewai/) | CrewAI — multi-agent orchestration framework | CPU |
+| [`gaia/`](services/gaia/) | AMD GAIA — experimental local agent UI and framework | CPU |
 | [`open-interpreter/`](services/open-interpreter/) | Open Interpreter — natural language → system commands | CPU |
 | [`jupyter/`](services/jupyter/) | Jupyter — notebooks with local LLM kernel | AMD, NVIDIA |
 
@@ -100,6 +101,7 @@ Quick reference for hardware requirements. Data sourced from each service's `man
 | fooocus | ✓ | — | — | — | 8 GB |
 | forge | ✓ | — | — | — | 8 GB |
 | frigate | ✓ | — | — | — | 1 GB |
+| gaia | — | — | — | ✓ | — |
 | gitea | — | — | — | ✓ | — |
 | immich | ✓ | ✓ | — | — | 2 GB |
 | invokeai | ✓ | ✓ | — | — | 8 GB |

--- a/dream-server/extensions/library/services/gaia/Dockerfile
+++ b/dream-server/extensions/library/services/gaia/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:22-bookworm-slim@sha256:7af03b14a13c8cdd38e45058fd957bf00a72bbe17feac43b1c15a689c029c732
+
+ARG GAIA_AGENT_UI_VERSION=0.19.0
+
+LABEL org.opencontainers.image.title="Dream Server AMD GAIA Agent UI"
+LABEL org.opencontainers.image.description="Experimental Dream Server extension image for AMD GAIA Agent UI"
+LABEL org.opencontainers.image.source="https://github.com/amd/gaia"
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends bash ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN groupadd --gid 10001 gaia \
+    && useradd --uid 10001 --gid 10001 --create-home --shell /bin/bash gaia
+
+RUN npm install -g "@amd-gaia/agent-ui@${GAIA_AGENT_UI_VERSION}" \
+    && npm cache clean --force
+
+COPY docker-entrypoint.sh /usr/local/bin/dream-gaia-entrypoint
+RUN chmod 0755 /usr/local/bin/dream-gaia-entrypoint
+
+USER gaia
+WORKDIR /home/gaia
+
+ENV HOME=/home/gaia
+ENV NODE_ENV=production
+
+EXPOSE 4200
+
+ENTRYPOINT ["dream-gaia-entrypoint"]

--- a/dream-server/extensions/library/services/gaia/README.md
+++ b/dream-server/extensions/library/services/gaia/README.md
@@ -1,0 +1,80 @@
+# AMD GAIA
+
+Experimental Dream Server extension recipe for the AMD GAIA Agent UI.
+
+GAIA is AMD's local AI agent framework for Ryzen AI systems. It includes an
+Agent UI, tool-using agents, document workflows, voice, vision, MCP support,
+and Lemonade Server integration.
+
+This Dream Server entry is intentionally conservative:
+
+- It is optional and disabled by default.
+- It binds to loopback unless `BIND_ADDRESS` is changed by Dream Server.
+- It persists GAIA state under `./data/gaia`.
+- It skips GAIA's first-run model bootstrap by default so enabling the
+  extension does not unexpectedly download models.
+- It does not claim Ryzen AI NPU/iGPU acceleration from inside Docker. For
+  best native acceleration, use AMD's desktop/native GAIA installer and point
+  Dream Server tools at that endpoint where appropriate.
+
+## Enable
+
+```bash
+cp -r dream-server/extensions/library/services/gaia dream-server/extensions/services/gaia
+dream enable gaia
+dream start gaia
+```
+
+Open the UI at:
+
+```text
+http://localhost:${GAIA_PORT:-7822}
+```
+
+## Configuration
+
+Set these in `.env` before starting the extension:
+
+```env
+GAIA_PORT=7822
+GAIA_AGENT_UI_VERSION=0.19.0
+GAIA_SKIP_GAIA_INIT=true
+GAIA_DISABLE_UPDATE=1
+GAIA_LEMONADE_BASE_URL=
+```
+
+Use `GAIA_LEMONADE_BASE_URL` when you already have Lemonade Server or a
+compatible endpoint available, for example:
+
+```env
+GAIA_LEMONADE_BASE_URL=http://host.docker.internal:8000/api/v1
+```
+
+The GAIA CLI also reads `LEMONADE_BASE_URL`, `GAIA_BASE_URL`, and
+`GAIA_MODEL_ID`; the compose file passes those through for advanced setups.
+
+## Modes
+
+Default mode starts `gaia-ui` and allows the npm package to install the Python
+backend into `./data/gaia/venv` on first start. `GAIA_SKIP_GAIA_INIT=true`
+prevents the additional Lemonade/model initialization step.
+
+For a lightweight container/UI smoke test only:
+
+```env
+GAIA_UI_SERVE_ONLY=true
+```
+
+Serve-only mode is useful for validating the extension container and dashboard
+link, but it does not start the GAIA Python backend.
+
+## Known Limitations
+
+- First backend start can take several minutes while Python dependencies are
+  installed.
+- Full GAIA behavior is best with Lemonade Server. Generic OpenAI-compatible
+  endpoints may support only part of the GAIA workflow surface.
+- The container recipe does not install host GPU/NPU drivers or Lemonade Server
+  onto the host.
+- This entry is experimental and intended to graduate after AMD hardware fleet
+  validation.

--- a/dream-server/extensions/library/services/gaia/compose.yaml
+++ b/dream-server/extensions/library/services/gaia/compose.yaml
@@ -1,0 +1,47 @@
+services:
+  gaia:
+    build:
+      context: ./extensions/services/gaia
+      dockerfile: Dockerfile
+      args:
+        GAIA_AGENT_UI_VERSION: ${GAIA_AGENT_UI_VERSION:-0.19.0}
+    container_name: dream-gaia
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - HOME=/home/gaia
+      - NODE_ENV=production
+      - GAIA_DISABLE_UPDATE=${GAIA_DISABLE_UPDATE:-1}
+      - GAIA_SKIP_GAIA_INIT=${GAIA_SKIP_GAIA_INIT:-true}
+      - GAIA_UI_SERVE_ONLY=${GAIA_UI_SERVE_ONLY:-false}
+      - GAIA_LEMONADE_BASE_URL=${GAIA_LEMONADE_BASE_URL:-}
+      - LEMONADE_BASE_URL=${LEMONADE_BASE_URL:-}
+      - GAIA_BASE_URL=${GAIA_BASE_URL:-}
+      - GAIA_MODEL_ID=${GAIA_MODEL_ID:-}
+    volumes:
+      - ./data/gaia:/home/gaia/.gaia:rw
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${GAIA_PORT:-7822}:4200"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://127.0.0.1:4200/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
+    networks:
+      - dream-network
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 8G
+        reservations:
+          cpus: '0.5'
+          memory: 512M
+
+networks:
+  dream-network:
+    external: true

--- a/dream-server/extensions/library/services/gaia/docker-entrypoint.sh
+++ b/dream-server/extensions/library/services/gaia/docker-entrypoint.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+port="${GAIA_INTERNAL_PORT:-4200}"
+
+if [[ -n "${GAIA_LEMONADE_BASE_URL:-}" ]]; then
+  export LEMONADE_BASE_URL="$GAIA_LEMONADE_BASE_URL"
+fi
+
+args=(--port "$port" --no-open)
+
+case "${GAIA_UI_SERVE_ONLY:-false}" in
+  1|true|TRUE|yes|YES|on|ON)
+    args=(--serve "${args[@]}")
+    ;;
+esac
+
+exec gaia-ui "${args[@]}"

--- a/dream-server/extensions/library/services/gaia/manifest.yaml
+++ b/dream-server/extensions/library/services/gaia/manifest.yaml
@@ -1,0 +1,70 @@
+schema_version: dream.services.v1
+
+service:
+  id: gaia
+  name: AMD GAIA
+  aliases: [amd-gaia, gaia-agent-ui]
+  container_name: dream-gaia
+  host_env: GAIA_HOST
+  default_host: gaia
+  port: 4200
+  external_port_env: GAIA_PORT
+  external_port_default: 7822
+  health: /
+  ui_path: /
+  health_timeout: 30
+  startup_timeout: 300
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []
+  description: "Experimental AMD GAIA Agent UI recipe for local agent workflows."
+  env_vars:
+    - key: GAIA_AGENT_UI_VERSION
+      required: false
+      default: "0.19.0"
+      description: Agent UI npm package version to install when building the container.
+    - key: GAIA_LEMONADE_BASE_URL
+      required: false
+      default: ""
+      description: Remote Lemonade/OpenAI-compatible API base URL for GAIA, usually ending in /api/v1.
+    - key: GAIA_SKIP_GAIA_INIT
+      required: false
+      default: "true"
+      description: Skip GAIA's first-run Lemonade/model bootstrap to avoid automatic model downloads.
+    - key: GAIA_UI_SERVE_ONLY
+      required: false
+      default: "false"
+      description: Serve only the Agent UI static frontend without starting the GAIA Python backend.
+    - key: GAIA_DISABLE_UPDATE
+      required: false
+      default: "1"
+      description: Disable Agent UI auto-update checks inside the container.
+
+  tags:
+    - amd
+    - gaia
+    - agents
+    - agent-ui
+    - ryzen-ai
+    - experimental
+
+features:
+  - id: amd-gaia-agent-ui
+    name: AMD GAIA Agent UI
+    description: Experimental AMD local agent UI and framework integration
+    icon: Bot
+    category: ai
+    requirements:
+      services: [gaia]
+      vram_gb: 0
+      disk_gb: 5
+    enabled_services_all: [gaia]
+    setup_time: ~5-10 minutes first start
+    priority: 31
+    launch:
+      type: service
+      service: gaia
+      path: /
+    gpu_backends: [all]


### PR DESCRIPTION
﻿## Summary

Adds AMD GAIA to the extensions library as an experimental optional recipe.

- Adds `extensions/library/services/gaia/` with a manifest, compose fragment, Dockerfile, entrypoint, and README.
- Pins `@amd-gaia/agent-ui` to `0.19.0` and the Node base image by digest.
- Binds the Agent UI to loopback by default on `GAIA_PORT` (`7822`).
- Persists GAIA state under `./data/gaia`.
- Defaults `GAIA_SKIP_GAIA_INIT=true` so enabling the extension does not unexpectedly download GAIA/Lemonade models.
- Adds `GAIA_UI_SERVE_ONLY=true` for lightweight UI/container smoke testing.
- Updates the extension library README and regenerates `extensions-catalog.json`.

## Notes

This is intentionally a library-only experimental integration. It does not enable GAIA by default and does not claim native Ryzen AI NPU/iGPU acceleration from inside Docker. The README points users toward AMD's native GAIA/Lemonade path for best hardware acceleration.

## Validation

- `python -c "import yaml, json; from jsonschema import validate; schema=json.load(open('dream-server/extensions/schema/service-manifest.v1.json')); data=yaml.safe_load(open('dream-server/extensions/library/services/gaia/manifest.yaml')); validate(data, schema); print('gaia manifest schema valid')"`
- `docker compose -f dream-server/docker-compose.base.yml -f dream-server/extensions/library/services/gaia/compose.yaml config --quiet`
- `C:\Program Files\Git\bin\bash.exe dream-server/tests/test-bind-address-sweep.sh`
- `python dream-server/scripts/check-dependency-pins.py`
- `python -c "import json; data=json.load(open('dream-server/config/extensions-catalog.json')); e=[x for x in data['extensions'] if x['id']=='gaia']; assert len(e)==1; assert e[0]['gpu_backends']==['all']; print('catalog contains gaia extension')"`
- `git diff --cached --check`
- Tower2 smoke: copied the GAIA library entry into `extensions/services/gaia`, ran `GAIA_UI_SERVE_ONLY=true GAIA_PORT=17822 docker compose -f docker-compose.base.yml -f extensions/services/gaia/compose.yaml up -d --build gaia`, confirmed `curl http://127.0.0.1:17822/` succeeds and logs show `GAIA Agent UI v0.19.0` serving on port 4200. Cleaned the test container/image/temp checkout afterward.

Not run: full GAIA Python backend + Lemonade/model bootstrap, by design for this initial safe experimental library entry.