### PR TITLE
[codex] Fix curl bootstrap Python prerequisite

### DIFF
--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -84,12 +84,6 @@ source "$SCRIPT_DIR/installers/lib/python-runtime.sh"
 source "$SCRIPT_DIR/installers/lib/progress.sh"
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
     source "$SCRIPT_DIR/lib/service-registry.sh" 
-    sr_load
-    if [[ "${_SR_FAILED:-}" == "true" ]]; then
-        warn "Service registry failed to load. Will retry after dependencies are installed."
-        _SR_LOADED=false
-        _SR_FAILED=false
-    fi
 fi
 
 #=============================================================================
@@ -295,6 +289,9 @@ log "Installer run started: pid=$$, script=$0"
 ds_prepare_sudo "Dream Server installer setup"
 export DREAM_SR_AUTO_INSTALL_PYYAML=1
 ds_ensure_python_module yaml python3-pyyaml pyyaml PyYAML
+if declare -f sr_load >/dev/null 2>&1; then
+    sr_load
+fi
 
 #=============================================================================
 # Splash

--- a/dream-server/installers/lib/python-runtime.sh
+++ b/dream-server/installers/lib/python-runtime.sh
@@ -37,6 +37,35 @@ ds_python_is_env_managed() {
     return 1
 }
 
+ds_ensure_python_runtime() {
+    local pycmd
+    pycmd="$(ds_detect_python_cmd 2>/dev/null || true)"
+    if [[ -n "$pycmd" ]]; then
+        printf '%s' "$pycmd"
+        return 0
+    fi
+
+    if [[ "${DRY_RUN:-false}" == "true" ]]; then
+        ai_warn "Python is not available (dry-run: would install python3)." >&2
+        return 1
+    fi
+
+    if declare -f pkg_install >/dev/null 2>&1; then
+        ai "Installing python3 for installer helpers..." >&2
+        if declare -f pkg_update >/dev/null 2>&1; then
+            case "${PKG_MANAGER:-}" in
+                apt|apk|dnf|xbps|zypper) pkg_update >/dev/null || true ;;
+            esac
+        fi
+        pkg_install python3 >/dev/null 2>>"${LOG_FILE:-/dev/null}" || true
+        _ds_python_cmd_cached=""
+    fi
+
+    pycmd="$(ds_detect_python_cmd 2>/dev/null || true)"
+    [[ -n "$pycmd" ]] || return 1
+    printf '%s' "$pycmd"
+}
+
 ds_ensure_python_module() {
     local module="$1"
     local canonical_pkg="$2"
@@ -44,7 +73,7 @@ ds_ensure_python_module() {
     local display="${4:-$module}"
 
     local pycmd
-    pycmd="$(ds_detect_python_cmd)" || error "Python is required but no runnable python3/python was found."
+    pycmd="$(ds_ensure_python_runtime)" || error "Python is required but no runnable python3/python was found."
 
     if ds_python_has_module "$module" "$pycmd"; then
         ai_ok "$display available for $pycmd"

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -58,6 +58,90 @@ fi
 assert_contains "$missing_yaml_err" 'PyYAML is required' "resolver did not explain PyYAML requirement"
 assert_contains "$missing_yaml_err" 'conda deactivate' "resolver did not include Conda/venv recovery hint"
 
+echo "[contract] Linux Python guard installs a missing interpreter before PyYAML"
+runtime_out="$tmpdir/python-runtime.out"
+runtime_calls="$tmpdir/python-runtime.calls"
+bash -c '
+  set -euo pipefail
+  ROOT_DIR="$1"
+  tmpdir="$2"
+  calls="$3"
+  cd "$ROOT_DIR"
+
+  SCRIPT_DIR="$ROOT_DIR"
+  LOG_FILE=/dev/null
+  DRY_RUN=false
+  INTERACTIVE=false
+  PKG_MANAGER=apt
+
+  ai() { echo "AI $*"; }
+  ai_ok() { echo "OK $*"; }
+  ai_warn() { echo "WARN $*"; }
+  ai_bad() { echo "BAD $*"; }
+  error() { echo "ERROR $*" >&2; exit 1; }
+  pkg_update() { echo "pkg_update" >>"$calls"; }
+  pkg_install() {
+    local pkg
+    for pkg in "$@"; do
+      echo "pkg_install:$pkg" >>"$calls"
+      case "$pkg" in
+        python3) touch "$tmpdir/python-ready" ;;
+        python3-pyyaml|python3-yaml|pyyaml) touch "$tmpdir/yaml-ready" ;;
+      esac
+    done
+  }
+  pkg_resolve() { echo "$1"; }
+
+  fake_py="$tmpdir/fake-python3"
+  cat > "$fake_py" <<PYEOF
+#!/usr/bin/env bash
+code=""
+if [[ "\${1:-}" == "-c" ]]; then
+  code="\${2:-}"
+fi
+case "\$code" in
+  *"import sys"*) exit 0 ;;
+  *"import yaml"*) [[ -f "$tmpdir/yaml-ready" ]] && exit 0 || exit 1 ;;
+esac
+exit 0
+PYEOF
+  chmod +x "$fake_py"
+
+  source installers/lib/python-runtime.sh
+  ds_detect_python_cmd() {
+    [[ -f "$tmpdir/python-ready" ]] || return 1
+    printf "%s" "$fake_py"
+  }
+
+  ds_ensure_python_module yaml python3-pyyaml pyyaml PyYAML
+' bash "$ROOT_DIR" "$tmpdir" "$runtime_calls" >"$runtime_out"
+assert_contains "$runtime_calls" 'pkg_update' "Python guard did not update package metadata before installing"
+assert_contains "$runtime_calls" 'pkg_install:python3' "Python guard did not install missing python3"
+assert_contains "$runtime_calls" 'pkg_install:python3-pyyaml' "Python guard did not install PyYAML after python3"
+assert_contains "$runtime_out" 'OK PyYAML available' "Python guard did not re-check PyYAML after install"
+
+echo "[contract] install-core loads service registry after Python prerequisites"
+order_out="$tmpdir/install-core-order.out"
+python3 - "$ROOT_DIR/install-core.sh" >"$order_out" <<'PY'
+import sys
+from pathlib import Path
+
+lines = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+source_idx = next(i for i, line in enumerate(lines) if 'source "$SCRIPT_DIR/lib/service-registry.sh"' in line)
+ensure_idx = next(i for i, line in enumerate(lines) if "ds_ensure_python_module yaml" in line)
+load_idx = next(i for i, line in enumerate(lines) if "sr_load" in line and i > ensure_idx)
+early_loads = [
+    i for i, line in enumerate(lines)
+    if "sr_load" in line and source_idx < i < ensure_idx
+]
+if early_loads:
+    raise SystemExit("sr_load runs before Python prerequisites")
+if not (source_idx < ensure_idx < load_idx):
+    raise SystemExit("unexpected service-registry/Python prerequisite order")
+print("registry-load-after-python")
+PY
+assert_contains "$order_out" 'registry-load-after-python' "install-core does not defer service registry load until after Python prerequisites"
+
 echo "[contract] macOS PyYAML install uses private installer venv"
 macos_installer="installers/macos/install-macos.sh"
 assert_contains "$macos_installer" '_ensure_macos_pyyaml' "macOS installer missing PyYAML helper"


### PR DESCRIPTION
﻿## Summary

Fixes the documented `curl ... get-dream-server.sh | bash` install path for lean Linux hosts where `python3` is not installed yet.

The bootstrap already fetches the repo and hands off correctly, but `install-core.sh` loads the service registry and PyYAML guard before guaranteeing a runnable Python interpreter. On a minimal Ubuntu image with `curl`, `git`, and `rsync`, that can fail with:

```text
ERROR: Neither python3 nor python is available/runnable.
```

This PR makes the early registry load defer cleanly when Python is missing, then teaches the Python runtime guard to install `python3` before checking/installing PyYAML.

## Validation

- Verified all documented curl snippets point at the same raw GitHub path.
- Verified live raw script matches `dream-server/get-dream-server.sh` byte-for-byte.
- Verified sparse checkout includes installer/runtime files and extension library bundle path.
- Ran the published curl command in a fresh non-root Ubuntu container with Python present using `--dry-run --skip-docker --non-interactive --cloud`.
- Ran a Python-less Ubuntu container proof against the patched runtime guard; it installs the Python/YAML runtime and reports PyYAML available for `/usr/bin/python3`.
- Ran `bash -n` on changed shell files.
- Ran `tests/contracts/test-installer-hardening.sh`.
- Ran `scripts/simulate-installers.sh` into a temp artifact dir and validated the simulation summary.
- Ran `tests/contracts/test-installer-contracts.sh` inside an Ubuntu container with `jq`.
