### PR TITLE
Fix public bootstrap on zypper Linux distros

### DIFF
--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -31,6 +31,7 @@ NC='\033[0m'
 
 REPO_URL="https://github.com/Light-Heart-Labs/DreamServer.git"
 INSTALL_DIR="$DREAM_BOOTSTRAP_ROOT/dream-server"
+DREAMSERVER_REF="${DREAMSERVER_REF:-${DREAM_BOOTSTRAP_REF:-}}"
 
 log()     { echo -e "${CYAN}[dream]${NC} $1"; }
 success() { echo -e "${GREEN}[  ok ]${NC} $1"; }
@@ -55,9 +56,9 @@ echo ""
 detect_os() {
     if [[ -f /proc/version ]] && grep -qi microsoft /proc/version 2>/dev/null; then
         echo "wsl"
-    elif [[ "$OSTYPE" == "darwin"* ]]; then
+    elif [[ "${OSTYPE:-}" == "darwin"* ]]; then
         echo "macos"
-    elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    elif [[ "${OSTYPE:-}" == linux* ]]; then
         echo "linux"
     else
         echo "unknown"
@@ -138,6 +139,9 @@ else
             sudo yum install -y -q git
         elif command -v pacman &> /dev/null; then
             sudo pacman -Sy --noconfirm git
+        elif command -v zypper &> /dev/null; then
+            sudo zypper --non-interactive --gpg-auto-import-keys refresh
+            sudo zypper --non-interactive install -y git
         else
             error "Cannot install git automatically. Please install git and re-run."
         fi
@@ -154,6 +158,13 @@ else
         sudo apt-get install -y -qq curl
     elif command -v dnf &> /dev/null; then
         sudo dnf install -y -q curl
+    elif command -v yum &> /dev/null; then
+        sudo yum install -y -q curl
+    elif command -v pacman &> /dev/null; then
+        sudo pacman -Sy --noconfirm curl
+    elif command -v zypper &> /dev/null; then
+        sudo zypper --non-interactive --gpg-auto-import-keys refresh
+        sudo zypper --non-interactive install -y curl
     else
         error "Please install curl and re-run."
     fi
@@ -200,12 +211,20 @@ fi
 
 # ── Clone repository ──────────────────────────────
 log "Cloning Dream Server..."
+if [[ -n "$DREAMSERVER_REF" ]]; then
+    log "Using repository ref: $DREAMSERVER_REF"
+fi
 
 # Clone just the dream-server subdirectory using sparse checkout
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
-_clone_err=$(git clone --depth 1 --filter=blob:none --sparse "$REPO_URL" "$TEMP_DIR/repo" 2>&1) || {
+clone_args=(--depth 1 --filter=blob:none --sparse)
+if [[ -n "$DREAMSERVER_REF" ]]; then
+    clone_args+=(--branch "$DREAMSERVER_REF")
+fi
+
+_clone_err=$(git clone "${clone_args[@]}" "$REPO_URL" "$TEMP_DIR/repo" 2>&1) || {
     case "$_clone_err" in
         *"Unable to read current working directory"*|*"getcwd"*)
             error "git could not read the current working directory. This usually means the directory you launched from has been deleted (e.g. you uninstalled Dream Server and re-ran the bootstrap from the same shell). Run \`cd ~\` and re-run the bootstrap." ;;
@@ -224,7 +243,11 @@ git sparse-checkout set dream-server 2>/dev/null || {
     # Fallback: full clone if sparse checkout fails
     cd "$DREAM_BOOTSTRAP_ROOT"
     rm -rf "$TEMP_DIR/repo"
-    git clone --depth 1 "$REPO_URL" "$TEMP_DIR/repo" 2>&1 | tail -1 || \
+    fallback_clone_args=(--depth 1)
+    if [[ -n "$DREAMSERVER_REF" ]]; then
+        fallback_clone_args+=(--branch "$DREAMSERVER_REF")
+    fi
+    git clone "${fallback_clone_args[@]}" "$REPO_URL" "$TEMP_DIR/repo" 2>&1 | tail -1 || \
         error "Failed to clone repository (fallback full clone also failed)."
     cd "$TEMP_DIR/repo"
 }

--- a/dream-server/installers/common.sh
+++ b/dream-server/installers/common.sh
@@ -66,7 +66,7 @@ detect_platform() {
         echo "windows"
     elif [[ "${OSTYPE:-}" == "darwin"* ]]; then
         echo "macos"
-    elif [[ "${OSTYPE:-}" == "linux-gnu"* ]]; then
+    elif [[ "${OSTYPE:-}" == linux* ]]; then
         echo "linux"
     else
         echo "unknown"

--- a/dream-server/tests/bats-tests/dispatch.bats
+++ b/dream-server/tests/bats-tests/dispatch.bats
@@ -77,3 +77,12 @@ setup() {
     assert_success
     assert_output --partial "/install-core.sh"
 }
+
+@test "detect_platform: treats non-gnu Linux OSTYPE values as Linux" {
+    unset DREAM_PLATFORM_OVERRIDE
+    OSTYPE="linux"
+
+    run detect_platform
+    assert_success
+    assert_output "linux"
+}

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -120,6 +120,21 @@ assert_contains "$runtime_calls" 'pkg_install:python3' "Python guard did not ins
 assert_contains "$runtime_calls" 'pkg_install:python3-pyyaml' "Python guard did not install PyYAML after python3"
 assert_contains "$runtime_out" 'OK PyYAML available' "Python guard did not re-check PyYAML after install"
 
+echo "[contract] public bootstrap supports non-gnu Linux OSTYPE and zypper prerequisites"
+bootstrap="get-dream-server.sh"
+assert_contains "$bootstrap" '\$\{OSTYPE:-\}' "bootstrap should guard OSTYPE when detecting Linux"
+assert_contains "$bootstrap" '== linux\*' "bootstrap should treat openSUSE/Tumbleweed linux variants as Linux"
+assert_contains "$bootstrap" 'command -v zypper' "bootstrap missing zypper package-manager branch"
+assert_contains "$bootstrap" 'zypper --non-interactive install -y git' "bootstrap cannot install git on zypper distros"
+assert_contains "$bootstrap" 'zypper --non-interactive install -y curl' "bootstrap cannot install curl on zypper distros"
+assert_contains "$bootstrap" 'DREAMSERVER_REF' "bootstrap should allow PR/fleet lanes to clone a matching ref"
+assert_contains "$bootstrap" 'clone_args\+=\(--branch "\$DREAMSERVER_REF"\)' "bootstrap ref override should apply to git clone"
+
+echo "[contract] runtime dispatcher supports non-gnu Linux OSTYPE"
+dispatcher_common="installers/common.sh"
+assert_contains "$dispatcher_common" '\$\{OSTYPE:-\}' "dispatcher should guard OSTYPE when detecting Linux"
+assert_contains "$dispatcher_common" '== linux\*' "dispatcher should treat openSUSE/Tumbleweed linux variants as Linux"
+
 echo "[contract] install-core loads service registry after Python prerequisites"
 order_out="$tmpdir/install-core-order.out"
 python3 - "$ROOT_DIR/install-core.sh" >"$order_out" <<'PY'


### PR DESCRIPTION
## Summary
- detect non-GNU Linux `OSTYPE` values as Linux in `get-dream-server.sh`
- add zypper branches for automatic git/curl prerequisite installation
- add installer hardening contract coverage for the public bootstrap path

## Validation
- `bash -n get-dream-server.sh tests/contracts/test-installer-hardening.sh`
- `tests/contracts/test-installer-hardening.sh`

This was exposed by the new tower2 zero-prereq public curl bootstrap lane: Ubuntu/Debian/Fedora/Arch got through bootstrap prerequisites, while openSUSE failed before the installer because the bootstrap script detected `OS=unknown` and had no zypper prerequisite path.