### PR TITLE
Fix Hermes data ownership on Linux reinstall

### DIFF
--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -53,9 +53,21 @@ else
     mkdir -p "$INSTALL_DIR"/data/langfuse/{postgres,clickhouse,redis,minio}
     mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
+    # Hermes runs its gateway/dashboard as the in-container `hermes` user
+    # (uid 10000) and keeps HERMES_HOME at data/hermes mounted as /opt/data.
+    # Upstream intentionally makes that directory 0700. A reinstall running
+    # as the host user must not "repair" it back to uid 1000, or Hermes's web
+    # status and Dream Talk JSON-RPC paths fail with PermissionError.
+    if [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
+        sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
+            warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
+        sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
+    fi
+
     # Fix ownership of data/config dirs that may have been created by containers
     # (e.g. SearXNG runs as uid 977, ComfyUI data owned by root)
     for _data_dir in "$INSTALL_DIR"/data/*/; do
+        [[ "${ENABLE_HERMES:-false}" == "true" && "$_data_dir" == "$INSTALL_DIR/data/hermes/" ]] && continue
         if [[ -d "$_data_dir" ]] && ! [[ -w "$_data_dir" ]]; then
             sudo chown -R "$(id -u):$(id -g)" "$_data_dir" 2>/dev/null || true
         fi
@@ -72,6 +84,7 @@ else
         for _root in config data; do
             [[ -d "$INSTALL_DIR/$_root" ]] || continue
             for _d in "$INSTALL_DIR/$_root"/*/; do
+                [[ "${ENABLE_HERMES:-false}" == "true" && "$_d" == "$INSTALL_DIR/data/hermes/" ]] && continue
                 [[ -d "$_d" ]] && ! [[ -w "$_d" ]] && _cant_write="$_cant_write ${_d#$INSTALL_DIR/}"
             done
         done

--- a/dream-server/tests/test-hermes-data-ownership.sh
+++ b/dream-server/tests/test-hermes-data-ownership.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Regression guard: Linux reinstall must not chown Hermes HERMES_HOME back to
+# the host user. Hermes's dashboard/Talk path runs as uid 10000 and needs
+# data/hermes mounted as /opt/data with that owner.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PHASE06="$ROOT_DIR/installers/phases/06-directories.sh"
+
+fail() {
+    echo "FAIL: $*" >&2
+    exit 1
+}
+
+grep -Fq 'sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes"' "$PHASE06" \
+    || fail "phase 06 must restore data/hermes to Hermes uid 10000"
+
+grep -Fq 'sudo chmod 700 "$INSTALL_DIR/data/hermes"' "$PHASE06" \
+    || fail "phase 06 must preserve Hermes private HERMES_HOME mode"
+
+grep -Fq '[[ "${ENABLE_HERMES:-false}" == "true" && "$_data_dir" == "$INSTALL_DIR/data/hermes/" ]] && continue' "$PHASE06" \
+    || fail "generic data-dir ownership repair must skip data/hermes only when Hermes is enabled"
+
+grep -Fq '[[ "${ENABLE_HERMES:-false}" == "true" && "$_d" == "$INSTALL_DIR/data/hermes/" ]] && continue' "$PHASE06" \
+    || fail "bootstrap writability check must allow container-owned data/hermes when Hermes is enabled"
+
+grep -Fq 'PermissionError' "$PHASE06" \
+    || fail "phase 06 comment should document the Hermes web/Talk failure mode"
+
+echo "test-hermes-data-ownership: ok"


### PR DESCRIPTION
## Summary
- preserve data/hermes as Hermes-owned (10000:10000) during Linux reinstall
- skip data/hermes in the generic host-user ownership repair loop
- add a regression guard for the ownership contract

## Validation
- bash -n installers/phases/06-directories.sh on tower2 temp copy
- bash tests/test-hermes-data-ownership.sh on tower2 temp copy
- applied patched phase on Spark, ran ./install.sh --non-interactive --all --force successfully
- confirmed Spark dream-hermes became healthy and /api/status returned OK
- reran Spark fleet capabilities: PASS (runs/2026-05-24T21-35-10Z)