### PR TITLE
Fix external Lemonade compose lifecycle

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -616,6 +616,17 @@ get_compose_flags() {
                { [[ "$cached" == *"docker-compose.cpu.yml"* ]] || [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]]; }; then
                 stale=1
             fi
+            local _lemonade_external="${LEMONADE_EXTERNAL:-false}"
+            local _amd_runtime="${AMD_INFERENCE_RUNTIME:-}"
+            local _amd_managed="${AMD_INFERENCE_MANAGED:-true}"
+            _lemonade_external="${_lemonade_external,,}"
+            _amd_runtime="${_amd_runtime,,}"
+            _amd_managed="${_amd_managed,,}"
+            if [[ "${DREAM_MODE:-local}" == "lemonade" ]] && \
+               { [[ "$_lemonade_external" =~ ^(1|true|yes|on)$ ]] || { [[ "$_amd_runtime" == "lemonade" ]] && [[ "$_amd_managed" =~ ^(0|false|no|off)$ ]]; }; } && \
+               { [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" == *"docker-compose.amd.yml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]] || [[ "$cached" != *"docker-compose.lemonade-external.yml"* ]]; }; then
+                stale=1
+            fi
             if [[ "$stale" == "0" ]]; then
                 echo "$cached"
                 return

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -449,7 +449,11 @@ if ext_dir.exists():
             # service_healthy` inside compose.local.yaml overlays can never be
             # satisfied and deadlocks the stack. The real LLM-ready gate on macOS
             # is the `llama-server-ready` sidecar defined in the macOS overlay.
-            if dream_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple":
+            # External Lemonade is also a host process. Its stack layers the
+            # cloud overlay to profile out Dream's managed llama-server, so
+            # local-mode overlays that wait on `llama-server: service_healthy`
+            # would point at a disabled service and break lifecycle commands.
+            if dream_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external:
                 local_mode_overlay = service_dir / "compose.local.yaml"
                 if local_mode_overlay.exists():
                     resolved.append(str(local_mode_overlay.relative_to(script_dir)))
@@ -566,8 +570,11 @@ if user_ext_dir.exists():
                 # service_healthy` inside compose.local.yaml overlays can never be
                 # satisfied and deadlocks the stack. The real LLM-ready gate on macOS
                 # is the `llama-server-ready` sidecar defined in the macOS overlay.
+                # External Lemonade likewise runs on the host and uses the cloud
+                # overlay to disable Dream's managed llama-server, so user-local
+                # overlays must not add local llama-server health dependencies.
                 # Mirrors the same guard in the built-in loop above (PR #1004).
-                if dream_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple":
+                if dream_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external:
                     local_mode_overlay = service_dir / "compose.local.yaml"
                     if local_mode_overlay.exists():
                         # Same content scan as compose.yaml/gpu overlay above —

--- a/dream-server/tests/contracts/test-external-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-external-lemonade-contracts.sh
@@ -43,11 +43,50 @@ if grep -q 'docker-compose.amd.yml' <<<"$resolved"; then
   echo "[FAIL] external Lemonade must not include managed AMD overlay"
   exit 1
 fi
+if grep -q 'compose.local.yaml' <<<"$resolved"; then
+  echo "[FAIL] external Lemonade must not include local llama-server dependency overlays"
+  exit 1
+fi
+grep -Eq 'extensions[\\/]+services[\\/]+litellm[\\/]+compose.yaml' <<<"$resolved" \
+  || { echo "[FAIL] external Lemonade must keep LiteLLM gateway enabled"; exit 1; }
+
+echo "[contract] external Lemonade resolved compose config is valid"
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  compose_file_list="$(sed -n 's/^COMPOSE_FILE_LIST="\([^"]*\)".*/\1/p' <<<"$resolved")"
+  compose_file_list="${compose_file_list//\\//}"
+  IFS=',' read -r -a compose_files <<<"$compose_file_list"
+  compose_args=()
+  for compose_file in "${compose_files[@]}"; do
+    [[ -n "$compose_file" ]] && compose_args+=(-f "$compose_file")
+  done
+  WEBUI_SECRET=test \
+  LITELLM_KEY=test \
+  OPENCLAW_TOKEN=test \
+  N8N_USER=test@example.local \
+  N8N_PASS=test \
+  SEARXNG_SECRET=test \
+  DREAM_SESSION_SECRET=test \
+  LEMONADE_EXTERNAL=true \
+  DREAM_MODE=lemonade \
+  GPU_BACKEND=amd \
+  docker compose "${compose_args[@]}" config --services >/dev/null \
+    || { echo "[FAIL] external Lemonade compose config must not have missing dependencies"; exit 1; }
+else
+  echo "[SKIP] docker compose unavailable; resolver assertions cover compose selection"
+fi
 
 echo "[contract] installer scopes firewall access for host Lemonade"
 grep -q '_phase11_allow_external_lemonade_firewall' installers/phases/11-services.sh \
   || { echo "[FAIL] phase 11 must allow container-to-host external Lemonade access"; exit 1; }
 grep -q 'dream-external-lemonade' installers/phases/11-services.sh \
   || { echo "[FAIL] external Lemonade firewall rule should be labeled"; exit 1; }
+
+echo "[contract] CLI invalidates stale external Lemonade compose flags"
+grep -q 'docker-compose.lemonade-external.yml' dream-cli \
+  || { echo "[FAIL] dream-cli must recognize external Lemonade compose cache state"; exit 1; }
+grep -q 'AMD_INFERENCE_MANAGED' dream-cli \
+  || { echo "[FAIL] dream-cli must detect unmanaged external Lemonade installs"; exit 1; }
+grep -q 'compose.local.yaml' dream-cli \
+  || { echo "[FAIL] dream-cli must invalidate stale local dependency overlays"; exit 1; }
 
 echo "[PASS] external Lemonade contracts"

--- a/dream-server/tests/fleet-external-lemonade-e2e.sh
+++ b/dream-server/tests/fleet-external-lemonade-e2e.sh
@@ -315,6 +315,7 @@ flags="$(LEMONADE_EXTERNAL=true DREAM_MODE=lemonade AMD_INFERENCE_RUNTIME=lemona
 [[ "$flags" == *"docker-compose.cloud.yml"* ]] || fail "external Lemonade stack must include cloud overlay"
 [[ "$flags" == *"docker-compose.lemonade-external.yml"* ]] || fail "external Lemonade stack must include external overlay"
 [[ "$flags" != *"docker-compose.amd.yml"* ]] || fail "external Lemonade stack must not include managed AMD overlay"
+[[ "$flags" != *"compose.local.yaml"* ]] || fail "external Lemonade stack must not include local llama-server dependency overlays"
 pass "compose resolver selects external Lemonade stack"
 
 note "Starting LiteLLM through Dream Server compose on http://127.0.0.1:${litellm_port}"

--- a/dream-server/tests/test-linux-cloud-mode.sh
+++ b/dream-server/tests/test-linux-cloud-mode.sh
@@ -74,12 +74,13 @@ import sys
 
 root = Path(sys.argv[1])
 text = (root / "installers/phases/11-services.sh").read_text(encoding="utf-8")
-model_block = text.index('if [[ "${DREAM_MODE:-local}" != "cloud" ]]; then')
+model_config = text.index('mkdir -p "$INSTALL_DIR/config/llama-server"')
+hermes_block = text.index('if [[ "${ENABLE_HERMES:-false}" == "true" ]]; then')
 soul_block = text.index('_soul_output="$INSTALL_DIR/data/persona/SOUL.md"')
-if soul_block > model_block:
-    # Make sure the local-model block was closed before SOUL render begins.
-    between = text[model_block:soul_block]
-    if '\n    if [[ "${ENABLE_HERMES:-false}" == "true" ]]; then' in between:
+if model_config < hermes_block < soul_block:
+    # Make sure the local-model block was closed before Hermes/SOUL rendering begins.
+    between = text[model_config:hermes_block]
+    if '\n    fi\n' in between:
         print("[PASS] SOUL.md render is outside local-model-only block")
         sys.exit(0)
 print("[FAIL] SOUL.md render must run for cloud installs too", file=sys.stderr)


### PR DESCRIPTION
## Summary
- skip local llama-server dependency overlays when running external Lemonade
- invalidate stale `.compose-flags` for upgraded external-Lemonade installs so `dream restart` regenerates a safe stack
- extend external-Lemonade contracts to assert no local overlays and run `docker compose config --services` on the resolved stack

## Tests
- `bash -n scripts/resolve-compose-stack.sh dream-cli tests/contracts/test-external-lemonade-contracts.sh tests/test-linux-cloud-mode.sh tests/fleet-external-lemonade-e2e.sh`
- `DREAM_PYTHON_CMD=/c/Users/conta/AppData/Local/Programs/Python/Python313/python.exe tests/contracts/test-external-lemonade-contracts.sh`
- `DREAM_PYTHON_CMD=/c/Users/conta/AppData/Local/Programs/Python/Python313/python.exe tests/test-linux-cloud-mode.sh`
- `DREAM_PYTHON_CMD=/c/Users/conta/AppData/Local/Programs/Python/Python313/python.exe tests/contracts/test-amd-lemonade-contracts.sh`