### PR TITLE
Fix lifecycle health waits and compose port retry

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -695,8 +695,22 @@ _compose_run_with_summary() {
     _compose_log=$(mktemp)
     trap 'rm -f "$_compose_log"' INT TERM
 
+    local _is_compose_up=false _arg
+    for _arg in "$@"; do
+        [[ "$_arg" == "up" ]] && _is_compose_up=true
+    done
+
     local _rc=0
     docker compose --progress quiet "$@" >"$_compose_log" 2>&1 || _rc=$?
+
+    if (( _rc != 0 )) && $_is_compose_up \
+       && grep -Eiq 'port is already allocated|Bind for .* failed: port is already allocated' "$_compose_log"; then
+        warn "Docker reported a port allocation race; waiting briefly and retrying once."
+        sleep "${DREAM_COMPOSE_PORT_RETRY_DELAY:-10}"
+        : >"$_compose_log"
+        _rc=0
+        docker compose --progress quiet "$@" >"$_compose_log" 2>&1 || _rc=$?
+    fi
 
     if (( _rc == 0 )); then
         success "${_verb} — done"

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -132,8 +132,15 @@ if [[ "${DREAM_MODE:-local}" == "cloud" ]] || _phase12_external_lemonade; then
 else
     # Format: _check_health "name" "url" max_attempts timeout_per_request
     # llama-server: 150 attempts * adaptive backoff (2s->8s) = up to ~20 minutes (model loading can be slow)
+    _llm_health_attempts=150
+    if [[ "${COMPOSE_STARTED_WITH_DELAYED_HEALTH:-false}" == "true" ]]; then
+        # If phase 11 already saw Docker Compose outlive its own health-gate
+        # window, keep the installer in the long readiness loop instead of
+        # failing right as very large GGUFs finish loading after reinstall.
+        _llm_health_attempts="${DREAM_LLM_DELAYED_HEALTH_ATTEMPTS:-300}"
+    fi
     dream_progress 86 "health" "Waiting for LLM engine"
-    _check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" 150 15 "$(sr_container llama-server)"
+    _check_health "llama-server" "http://127.0.0.1:${SERVICE_PORTS[llama-server]:-8080}${SERVICE_HEALTH[llama-server]:-/health}" "$_llm_health_attempts" 15 "$(sr_container llama-server)"
 fi
 
 # ── Pre-warm the LLM slot so the first real chat doesn't 503 ──

--- a/dream-server/tests/bats-tests/test-compose-summary-wrapper.bats
+++ b/dream-server/tests/bats-tests/test-compose-summary-wrapper.bats
@@ -65,6 +65,19 @@ case "${DOCKER_STUB_MODE:-success}" in
         echo "network busy (try again later)"
         exit 1
         ;;
+    fail-port-once)
+        state_file="$TMPDIR_TEST/port-retry-count"
+        count=0
+        [[ -f "$state_file" ]] && count=$(cat "$state_file")
+        count=$((count + 1))
+        echo "$count" > "$state_file"
+        if [[ "$count" -eq 1 ]]; then
+            echo "Error response from daemon: failed to set up container networking: Bind for 127.0.0.1:11434 failed: port is already allocated"
+            exit 1
+        fi
+        echo "Container dream-foo started"
+        exit 0
+        ;;
     fail-docker-sock)
         echo "unable to get image 'ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4': permission denied while trying to connect to the docker API at unix:///var/run/docker.sock"
         exit 1
@@ -204,6 +217,27 @@ teardown() {
 }
 
 # ── docker compose args passthrough ─────────────────────────────────────────
+
+@test "wrapper: compose up retries once on transient port allocation race" {
+    export DOCKER_STUB_MODE=fail-port-once
+    export DREAM_COMPOSE_PORT_RETRY_DELAY=0
+    run _compose_run_with_summary "Restarting all services" up -d
+    assert_success
+    assert_output --partial "Docker reported a port allocation race"
+    assert_output --partial "Restarting all services"
+    assert_output --partial "done"
+    run grep -c '^DOCKER_ARGS:' "$DOCKER_CALL_LOG"
+    assert_output "2"
+}
+
+@test "wrapper: non-up command does not retry on port allocation failure" {
+    export DOCKER_STUB_MODE=fail-port-once
+    export DREAM_COMPOSE_PORT_RETRY_DELAY=0
+    run _compose_run_with_summary "Stopping all services" down
+    assert_failure
+    run grep -c '^DOCKER_ARGS:' "$DOCKER_CALL_LOG"
+    assert_output "1"
+}
 
 @test "wrapper: all args after verb are passed to docker compose" {
     export DOCKER_STUB_MODE=success

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -287,6 +287,7 @@ assert_contains "installers/phases/11-services.sh" '_compose_started_with_delaye
 assert_contains "installers/phases/11-services.sh" 'COMPOSE_STARTED_WITH_DELAYED_HEALTH=true' "Linux installer does not mark delayed compose health for strict phase 12 recovery"
 assert_contains "installers/phases/11-services.sh" 'Continuing to the longer health checks' "Linux installer no longer delegates delayed service health to phase 12"
 assert_contains "installers/phases/12-health.sh" 'COMPOSE_STARTED_WITH_DELAYED_HEALTH' "Linux delayed compose health does not make phase 12 strict"
+assert_contains "installers/phases/12-health.sh" 'DREAM_LLM_DELAYED_HEALTH_ATTEMPTS:-300' "Linux delayed compose health does not extend the LLM health wait for large GGUF reloads"
 assert_contains "installers/phases/12-health.sh" 'Docker Compose reported delayed LLM health' "Linux strict delayed-health recovery message missing"
 assert_contains "installers/macos/install-macos.sh" 'compose-launch\.txt' "macOS installer missing compose launch record"
 assert_contains "installers/macos/install-macos.sh" 'ps -q' "macOS installer does not count compose-managed containers"


### PR DESCRIPTION
## Summary

- Extend the phase 12 llama-server health window only when phase 11 already detected delayed Docker Compose health, covering large GGUF reloads during idempotent reinstall.
- Retry `docker compose up` once when Docker reports a transient port allocation race, so `dream restart` does not fail on momentary port handoff conflicts.
- Add contract/BATS coverage for both behaviors.

## Root Cause

The fleet release run exposed two lifecycle failures after otherwise clean installs:

1. `tower2` could finish launching services, then fail during phase 12 while a large model was still loading after reinstall.
2. `strix-halo` intermittently hit Docker's `port is already allocated` race during `dream restart` on the managed Lemonade container.

The strix issue was initially suspected to involve the external Lemonade placeholder, but live host inspection showed that was a misdiagnosis: strix is using managed Lemonade via `docker-compose.amd.yml`, with a real `dream-llama-server` container.

## Validation

- `git diff --check`
- `bash -n dream-server/dream-cli`
- `bash -n dream-server/installers/phases/12-health.sh`
- `bash dream-server/tests/contracts/test-installer-hardening.sh`
- `bash dream-server/tests/contracts/test-installer-contracts.sh`
- `bash dream-server/tests/test-linux-cloud-mode.sh`
- `bash dream-server/tests/contracts/test-external-lemonade-contracts.sh`
- `tests/bats/bats-core/bin/bats tests/bats-tests/test-compose-summary-wrapper.bats`
- Focused fleet lifecycle: `./run.sh --phase lifecycle --hosts tower2,strix-halo --run-dir /home/michael/dream-fleet-test/runs/2026-05-25T-codex-lifecycle-fixes`

Focused lifecycle result: PASS on both affected hosts. `tower2` and `strix-halo` both passed idempotent reinstall, `dream restart`, and `dream doctor`.