### PR TITLE
Clarify release validation coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ After install, open **http://localhost:3000** and start chatting.
 >
 > **Tested Linux distros:** Ubuntu 24.04/22.04, Debian 12, Linux Mint 21.3, Fedora 41+, Rocky Linux 9, Arch Linux, Manjaro, CachyOS, and openSUSE Tumbleweed. Other distros using apt, dnf, pacman, or zypper should also work — [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues) if yours doesn't.
 >
-> **Testing surface:** CI and tower2 Docker containers cover broad distro installer logic; tower2 Incus VMs cover systemd + Docker daemon behavior on Ubuntu, Fedora/Rocky, Arch, and openSUSE; the real hardware fleet remains the release gate for NVIDIA/AMD/Apple GPU runtime, dashboard, Hermes, UI, and capability validation.
+> **Release validation:** CI checks installer syntax and distro detection; zero-prereq bootstrap checks exercise the public `curl` path on clean Linux containers; the distro lab covers 10 Linux containers plus systemd-capable Incus VMs; the release fleet runs real NVIDIA, AMD, ARM Linux, and Apple Silicon installs through dashboard, Hermes, UI, capability, restart, reinstall, and `dream doctor` gates. See [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) for what a green run proves.
 >
 > **Windows:** Requires Docker Desktop with WSL2 backend. NVIDIA GPUs use Docker GPU passthrough; AMD Strix Halo runs through the platform-specific accelerated path documented in the Windows installer and support matrix.
 >

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -1,6 +1,6 @@
 # Dream Server Support Matrix
 
-Last updated: 2026-05-21
+Last updated: 2026-05-25
 
 ## What Works Today
 
@@ -9,13 +9,15 @@ Last updated: 2026-05-21
 For the layered evidence behind these claims, see
 [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) and [TESTING.md](TESTING.md). The
 matrix is sanitized so it can be public without exposing private lab hostnames,
-LAN addresses, or paths.
+LAN addresses, or paths. Support status means the project has an intended
+installer/runtime path for that platform; release evidence should still name the
+current run, enabled hardware classes, and any deferred or skipped phases.
 
 | Platform | Status | What you get today |
 |----------|--------|-------------------|
 | **Linux + AMD Strix Halo (ROCm)** | **Fully supported** | Complete install and runtime. Primary development platform. |
-| **Linux + NVIDIA (CUDA)** | **Supported** | Complete install and runtime. Distro breadth runs in CI, tower2 Docker containers, and tower2 Incus VMs; GPU runtime is validated on real NVIDIA hardware. |
-| **Windows (Docker Desktop + WSL2)** | **Supported** | Complete install and runtime via `.\install.ps1`. GPU auto-detection (NVIDIA/AMD). |
+| **Linux + NVIDIA (CUDA)** | **Supported** | Complete install and runtime. Distro breadth runs in CI, private Docker containers, and private Incus VMs; GPU runtime is validated on real NVIDIA hardware. |
+| **Windows (Docker Desktop + WSL2)** | **Supported** | Complete install and runtime via `.\install.ps1`. GPU auto-detection (NVIDIA/AMD). Count Windows as current release-fleet evidence only when the Windows target is enabled and produces artifacts for that candidate. |
 | **macOS (Apple Silicon)** | **Supported** | Complete install and runtime via `./install.sh`. Native Metal inference + Docker services. |
 | **Linux + Intel Arc (SYCL)** | **Experimental** | Installer auto-detects Arc, assigns ARC/ARC\_LITE tier, and selects `docker-compose.arc.yml`. End-to-end runtime on A770/A750. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md). |
 
@@ -29,7 +31,7 @@ LAN addresses, or paths.
 
 | Platform | GPU Path | Installer Tier | Notes |
 |---|---|---|---|
-| Linux (Ubuntu/Debian family) | NVIDIA (llama-server/CUDA) | Tier B | Validated on real high-memory multi-GPU NVIDIA hardware; broader distro matrix runs in CI, tower2 Docker containers, and tower2 Incus VMs |
+| Linux (Ubuntu/Debian family) | NVIDIA (llama-server/CUDA) | Tier B | Validated on real high-memory multi-GPU NVIDIA hardware; broader distro matrix runs in CI, private Docker containers, and private Incus VMs |
 | Linux (Strix Halo / AMD unified memory) | AMD (Lemonade/ROCm) | Tier A | Primary managed path via `docker-compose.base.yml` + `docker-compose.amd.yml`; validated on real Strix Halo hardware |
 | Linux (Intel Arc A770/A750) | Intel SYCL (llama-server/oneAPI) | **Tier C** | `docker-compose.arc.yml`; builds llama.cpp from `intel/oneapi-basekit`; see [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) |
 | Windows (Docker Desktop + WSL2) | NVIDIA via Docker Desktop; AMD via host Vulkan runtime | Tier B | Standalone installer (`.\install.ps1`) with GPU auto-detection, Docker orchestration, health checks, and desktop shortcuts; Windows laptop fleet target tracks Docker Desktop/WSL2 evidence |
@@ -54,14 +56,15 @@ LAN addresses, or paths.
 ## Current Truth
 
 - **Linux, Windows, and macOS are fully supported.**
-- Linux + NVIDIA is supported and validated on real high-memory NVIDIA hardware; broader distro coverage now runs through CI, tower2 Docker containers, and tower2 Incus VMs.
-- Windows installs via `.\install.ps1` with Docker Desktop + WSL2 backend. Windows AMD local inference is host-managed and uses Vulkan today, either through legacy Lemonade Server or native `llama-server` fallback.
+- Linux + NVIDIA is supported and validated on real high-memory NVIDIA hardware; broader distro coverage now runs through CI, private Docker containers, and private Incus VMs.
+- Windows installs via `.\install.ps1` with Docker Desktop + WSL2 backend. Windows AMD local inference is host-managed and uses Vulkan today, either through legacy Lemonade Server or native `llama-server` fallback. Windows support is not inferred from Linux/macOS; treat it as release-current only when a Windows fleet target produces artifacts for that candidate.
 - Windows native installer UX is Tier B (delegated via Docker Desktop + WSL2).
 - macOS installs via `./install.sh` — llama-server runs natively with Metal acceleration, all other services in Docker.
 - AMD runtime diagnostics are explicit: `.env` records runtime, location, selected backend, supported backends, and whether DreamServer manages the process. DreamServer supports its managed AMD Lemonade path and a Linux external Lemonade SDK wrapper path for existing Lemonade installs; see [LEMONADE-SDK-COMPAT.md](LEMONADE-SDK-COMPAT.md).
 - AMD discrete GPUs beyond the documented Strix Halo path should be treated as validation-required until the repo has tier/model benchmarks for that hardware.
 - **Intel Arc (SYCL) is Tier C / experimental.** The installer auto-detects and selects the correct compose overlay and tier. Runtime works on A770/A750 (Linux). ComfyUI and Whisper GPU acceleration are not yet available for Arc. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) for limitations.
 - Release-readiness claims should cite a matching version/tag, relevant distro-lab evidence, and a real-hardware fleet receipt from [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md).
+- A supported platform can have code and installer support even when it is not included in every default private release-fleet run. Release notes should cite which hardware classes actually ran, which phases passed, and which surfaces were deferred or skipped.
 - Version baselines for triage are in `docs/KNOWN-GOOD-VERSIONS.md`.
 
 ## Roadmap

--- a/dream-server/docs/TESTING.md
+++ b/dream-server/docs/TESTING.md
@@ -23,19 +23,39 @@ changes.
 
 Fleet phases currently include:
 
+- zero-prereq bootstrap checks from clean distro containers that do not assume
+  Git, jq, Python, Docker, or Compose are already installed;
 - regression replay for previously fixed fleet bugs;
 - a constrained Apple Silicon smoke gate before parallel installs;
 - read-only preflight snapshots for OS, RAM, disk, Docker, firewall, ports, and
   prior install state;
 - non-interactive fresh installs from the public bootstrap path;
+- cloud-mode contract checks for local, cloud, hybrid, and external-backend
+  compose/config behavior;
 - core HTTP verification for dashboard-api, dashboard UI, llama-server, and
   Hermes proxy;
 - dashboard model and extension flows;
 - Hermes magic-link auth and seeded chat checks;
 - Playwright dashboard UI checks;
-- agent capability probes for chat, web search, files, code, skills, and model
-  identity;
-- opt-in lifecycle checks for reinstall, restart, and doctor behavior.
+- agent capability probes for chat, web search, files, code, skills, loaded-model
+  identity, context, and Dream Talk/owner-portal surfaces where enabled;
+- lifecycle checks for idempotent reinstall, `dream restart`, and
+  `dream doctor`;
+- release-confidence reporting that rolls the run up into zero-prereq,
+  install, product, capability, lifecycle, and user-facing gates.
+
+`--phase all` is the faster development sweep. It covers the main install and
+post-install product surfaces but intentionally avoids the slowest release-only
+gates. The `/dream-fleet-test` skill and `--phase release` path are the
+release-grade sweep: they add zero-prereq bootstrap and lifecycle checks so a
+green result means the installer, product, capability, and recovery paths all
+passed or were explicitly accounted for.
+
+Use the release-grade sweep after operational code changes: installer phases,
+bootstrap, compose stack generation, service wiring, dashboard/API behavior,
+Hermes, model routing, GPU detection, lifecycle commands, or any runtime path
+that could affect a user's install or running stack. Docs-only and cosmetic
+changes can usually rely on CI plus focused documentation checks.
 
 External Lemonade SDK compatibility has a focused fleet smoke:
 
@@ -58,7 +78,7 @@ tests/fleet-external-lemonade-e2e.sh --real
 
 | Method | Speed | GPU Testing | Kernel Testing | Best For |
 |--------|-------|-------------|----------------|----------|
-| **Fleet harness** | 15-75 min | Yes | Yes | Release readiness on real heterogeneous hardware |
+| **Fleet harness** | 15-75 min | Yes | Yes | Release readiness and User Green confidence on real heterogeneous hardware |
 | **Fleet distro lab** | 5-20 min | No | Container: no / VM: yes | Multi-distro installer and Docker lifecycle coverage on tower2 |
 | **Distrobox** | Instant (2s) | Yes | No | Daily dev, package manager validation |
 | **Ventoy USB** | 5-10 min boot | Yes | Yes | Weekly full-stack validation |
@@ -95,6 +115,11 @@ install work, so distro-lab dry-runs do not compete with full fleet installs
 for Docker/build I/O on the same host. Use `--lock-timeout SECONDS` when a CI
 or automation should fail instead of waiting, and reserve `--no-host-lock` for
 local debugging when you know no full fleet install is running.
+
+Release-grade `/dream-fleet-test` invocations should run the distro lab
+alongside the hardware fleet. The hardware fleet proves GPU and product
+behavior; the distro lab proves the same installer logic still handles broad
+Linux package-manager and Docker-daemon surfaces.
 
 Run a focused subset while debugging:
 

--- a/dream-server/docs/VALIDATION-MATRIX.md
+++ b/dream-server/docs/VALIDATION-MATRIX.md
@@ -1,6 +1,6 @@
 # Dream Server Validation Matrix
 
-Last updated: 2026-05-21
+Last updated: 2026-05-25
 
 This page describes the layered coverage used to validate Dream Server between
 changes. It is intentionally sanitized: it publishes hardware classes,
@@ -9,13 +9,14 @@ addresses, usernames, or filesystem paths.
 
 ## Layered Test Surface
 
-Dream Server uses three standing validation layers:
+Dream Server uses four standing validation layers:
 
 | Layer | Where it runs | Coverage | What it proves |
 |---|---|---|---|
-| CI matrix | GitHub Actions containers | Ubuntu 24.04/22.04, Debian 12, Linux Mint 21.3, Fedora 41, Rocky 9, Arch, Manjaro, CachyOS, openSUSE Tumbleweed | os-release parsing, package-manager detection, installer syntax, and dry-run logic |
-| Fleet distro lab | tower2 Docker containers + Incus VMs | 10 container distros plus VMs for Ubuntu 24.04, Fedora 42, Rocky 9, Arch current, and openSUSE Tumbleweed | fast distro breadth plus real systemd, network, Docker daemon, Compose, and installer dry-run with Docker enabled |
-| Real hardware fleet | Private local machines | Linux NVIDIA, Linux AMD, Linux ARM NVIDIA, macOS Apple Silicon, Windows laptop | fresh installs, GPU runtime, dashboard, Hermes, UI, lifecycle, and agent capabilities |
+| CI matrix | GitHub Actions containers | Installer, shell, Python, PowerShell, dashboard, environment, and distro smoke checks | Fast pull-request safety for syntax, parsing, and cheap regressions |
+| Zero-prereq bootstrap lab | Release harness distro containers | Bare Ubuntu, Debian, Fedora, Rocky, Arch, and openSUSE images with no assumed Git, jq, Python, Docker, or Compose | The public `curl` bootstrap path can provision its own prerequisites on clean Linux systems |
+| Fleet distro lab | Private lab Docker containers + Incus VMs | 10 container distros plus VMs for Ubuntu, Fedora, Rocky, Arch, and openSUSE | Fast distro breadth plus real systemd, network, Docker daemon, Compose, and installer dry-run with Docker enabled |
+| Real hardware fleet | Private local machines | Linux NVIDIA, Linux AMD, Linux ARM NVIDIA, macOS Apple Silicon, and optional Windows laptop targets | Fresh installs, GPU runtime, dashboard, Hermes, UI, lifecycle, Dream Talk, and agent capabilities |
 
 Containers are breadth, not user-experience proof. Incus VMs add systemd,
 kernel, and Docker-daemon realism, but they still do not prove GPU runtime.
@@ -26,20 +27,21 @@ behavior.
 
 | Test surface | OS family | Architecture | Accelerator path | Memory class | Fleet role |
 |---|---|---:|---|---:|---|
-| Linux NVIDIA workstation | Ubuntu 24.04 | x86_64 | Dual high-memory Blackwell CUDA GPUs | 90 GB+ VRAM per GPU | Primary multi-GPU CUDA install, dashboard, UI, and capability target |
+| Linux NVIDIA workstation | Ubuntu 24.04 | x86_64 | High-memory CUDA GPUs | 90 GB+ VRAM per GPU | Primary CUDA install, dashboard, UI, and capability target |
 | Linux AMD unified-memory workstation | Ubuntu 24.04 | x86_64 | AMD Strix Halo / ROCm-Lemonade path | 120 GB+ unified | Primary AMD install/runtime validation target |
 | Linux NVIDIA unified-memory appliance | NVIDIA Ubuntu derivative | aarch64 | Grace Blackwell / CUDA path | 120 GB+ unified | ARM Linux + NVIDIA appliance validation target |
 | macOS constrained Apple Silicon | macOS | arm64 | Native Metal inference + Docker services | 16 GB unified | Smoke gate and tight-memory macOS validation target |
 | macOS high-memory Apple Silicon | macOS | arm64 | Native Metal inference + Docker services | 120 GB+ unified | Large-model macOS validation target |
-| Windows hybrid GPU laptop | Windows 11 + Docker Desktop/WSL2 | x86_64 | NVIDIA mobile GPU plus Intel Arc integrated GPU | 32 GB+ system RAM | Windows installer, Docker Desktop, WSL2, and mobile-GPU validation target |
+| Windows hybrid GPU laptop | Windows 11 + Docker Desktop/WSL2 | x86_64 | NVIDIA mobile GPU plus Intel integrated GPU | 32 GB+ system RAM | Windows installer, Docker Desktop, WSL2, and mobile-GPU validation target when enabled for a run |
 
 This standing hardware fleet is the repeatable release surface for GPU and
 product behavior: it can run in parallel whenever installer, bootstrap,
-dashboard, agent, model, or extension code changes. The CI matrix and tower2
-distro lab add repeatable distro evidence between hardware fleet runs.
-Community and volunteer testers add broader coverage on other GPUs, distros,
-operating-system versions, storage layouts, and network environments, but those
-reports are complementary evidence rather than the always-on release gate.
+dashboard, agent, model, or extension code changes. The CI matrix, zero-prereq
+bootstrap lab, and distro lab add repeatable distro evidence between hardware
+fleet runs. Community and volunteer testers add broader coverage on other GPUs,
+distros, operating-system versions, storage layouts, and network environments,
+but those reports are complementary evidence rather than the always-on release
+gate.
 
 ## Fleet Phases
 
@@ -48,57 +50,81 @@ each host where the phase is applicable.
 
 | Phase | What it proves | Normal cadence |
 |---|---|---|
+| Zero-prereq bootstrap | The public installer can bootstrap clean distro containers without preinstalled developer tools or Docker | Every release-grade run |
 | Regression replay | Previously fixed fleet bugs have not returned | Every full fleet run |
-| Smoke gate | The smallest Apple Silicon target can fresh-install and pass core health before the larger fleet starts | Every full fleet run |
+| Smoke gate | A constrained Apple Silicon target can fresh-install and pass core health before the larger fleet starts | Every full fleet run |
 | Preflight | OS, RAM, disk, Docker, firewall, port conflicts, prior install state | Every install run |
 | Fresh install | The public bootstrap path can nuke prior state and install non-interactively | Every full fleet run |
 | Core verify | Dashboard API, dashboard UI, llama-server models/chat, and Hermes proxy are reachable | Every post-install run |
+| Cloud-mode contracts | Cloud and hybrid modes do not accidentally require local llama-server and still render required configs | Every release-grade run |
 | Dashboard API flows | Model listing, model download/switch, and extension install state transitions | Every post-install run |
 | Hermes auth/chat | Magic-link session auth, gated Hermes access, and seed echo through the agent path | Every post-install run |
 | Browser UI | Dashboard navigation, model/extension surfaces, and Open WebUI model proxy behavior | Default UI target every run; scheduled wider UI sweeps |
-| Capability probes | Chat coherence, web search, file write/read, code execution, skills list, and loaded-model identity | Every post-install run, with LLM probes deferred while bootstrap is still active |
-| Lifecycle | Reinstall, restart, and doctor checks after state changes | Release-candidate or explicit lifecycle runs |
+| Capability probes | Chat coherence, web search, file write/read, code execution, skills list, loaded-model identity, context, and Dream Talk/owner-portal surfaces where enabled | Every post-install run, with LLM probes deferred while bootstrap is still active |
+| Lifecycle | Idempotent reinstall, `dream restart`, and `dream doctor` after state changes | Every release-grade run; optional for lighter development runs |
+| Release confidence report | The run is summarized into product, capability, lifecycle, and user-facing gates | Every release-grade run |
 
-## Representative Evidence
+`--phase all` is intended for a faster full-product development sweep. The
+release-grade path used by `/dream-fleet-test` and `--phase release` adds
+zero-prereq bootstrap and lifecycle gates so a green release run means more than
+"fresh install worked once."
 
-The 2.5.0 release-candidate fleet run on 2026-05-21 passed in
-`/home/michael/dream-fleet-test/runs/2026-05-21T15-48-27Z`. The run exercised
-tower2, Strix Halo, Spark, Mac mini, and M5 MacBook Pro with fresh install,
-7/7 verify, Hermes seeded echo, UI checks, and applicable capability probes.
-Strix Halo and the M5 MacBook Pro fully proved capability probes on
-Qwen3.6-35B-A3B; the Mac mini fully proved capability probes on Qwen3.5-9B;
-tower2 and Spark deferred capability probes while still in bootstrap mode.
-Regression replay finished 9/9 fixtures green with 0 bugs detected and 0 PRs
-opened.
+Run the release-grade fleet after operational code changes: installer phases,
+bootstrap, compose stack generation, service wiring, dashboard/API behavior,
+Hermes, model routing, GPU detection, lifecycle commands, or anything else that
+can affect a user's install or running stack. Docs-only and cosmetic changes can
+usually rely on CI and focused documentation checks.
 
-The same release-candidate pass included the distro lab. The Docker matrix
-validated 10/10 distros: Ubuntu 24.04, Ubuntu 22.04, Debian 12, Linux Mint
-21.3, Fedora 41, Rocky 9, Arch, Manjaro, CachyOS, and openSUSE Tumbleweed.
-Linux Mint and Fedora hit transient I/O contention while tower2 was also doing
-a heavy fleet install, then passed cleanly on solo retry. The Incus VM matrix
-validated 5/5 VMs: Ubuntu 24.04, Fedora 42, Rocky 9, Arch current, and
-openSUSE Tumbleweed, each booting real systemd + Docker and running the
-installer dry-run cleanly. The tower2 distro runners now use a shared host
-lock with the fleet harness so full fleet installs and distro-lab Docker/Incus
-work do not run heavy build surfaces against the same host at the same time.
+## Release Confidence Gates
 
-Earlier 2026-05-21 distro-lab work also surfaced infrastructure and
-product-relevant issues: tower2 needed Incus bridge/firewall allowance, and
-Rocky-family installs needed a Docker CE fallback when distro packages were not
-available. The harness also previously surfaced an external DNS/download
-failure on one macOS run, which is evidence that environment failures are
-visible rather than silently converted into product passes.
+Release-grade runs render a machine-readable confidence summary plus a human
+report. The top-level gates are:
 
-The Windows laptop is part of the validation surface so Windows + Docker
-Desktop/WSL2 + mobile NVIDIA/Intel hybrid GPU behavior is not inferred from
-Linux or macOS results. Treat Windows evidence as release-relevant only when
-the Windows target produces preflight, install, verify, dashboard, and UI
-artifacts for the release candidate being claimed.
+| Gate | Pass signal |
+|---|---|
+| Zero-prereq bootstrap | Bare distro containers can fetch the public installer and provision prerequisites |
+| Install Green | Every enabled hardware host completed a fresh public-path install |
+| Product Green | Core services, cloud contracts, dashboard flows, Hermes auth/chat, and UI checks passed |
+| Capability Green | Full-model capability probes passed, or were explicitly deferred/skipped for documented reasons |
+| Lifecycle Green | Idempotent reinstall, restart, and doctor checks passed on enabled hosts |
+| User Green | The combined release-readiness gate: zero-prereq, install, product, capability, and lifecycle evidence are all clean or explicitly accounted for |
+
+This is why a green release fleet pass is stronger than ordinary service
+health. It exercises the user-visible setup path, first-run behavior,
+post-install actions, real agent work, and lifecycle recovery after state has
+changed.
+
+## Evidence Receipts
+
+Release notes should cite sanitized evidence from the current candidate, not a
+private run directory. A useful receipt includes:
+
+- the Dream Server commit, tag, or release candidate;
+- the run date;
+- sanitized hardware classes covered;
+- distro lab breadth;
+- regression replay result;
+- install, verify, dashboard, Hermes, UI, capability, and lifecycle summaries;
+- skipped, deferred, blocked-by-environment, or not-run phases;
+- any known gaps that should not be read as supported behavior.
+
+Private artifacts keep detailed logs, JSON events, and host-specific evidence
+inside the lab. Public docs should quote the sanitized summary only, especially
+when a run includes local hostnames, LAN addresses, usernames, or filesystem
+paths.
+
+Treat Windows evidence as release-relevant only when the Windows target produces
+preflight, install, verify, dashboard, and UI artifacts for the candidate being
+claimed. A supported platform can have installer and code support even when it
+is not included in every default private release-fleet run; release notes should
+say which hardware classes actually ran.
 
 ## What This Proves
 
-- Installer OS and package-manager logic is exercised across 10 Linux distro
-  lanes in CI/container form.
+- Installer OS and package-manager logic is exercised across the major Linux
+  package-manager families.
+- The public `curl` bootstrap path is tested from clean Linux images that do
+  not assume developer tools or Docker are already present.
 - Systemd, network, Docker daemon, Docker Compose, and installer dry-run
   behavior are exercised in disposable Incus VMs for the major Linux families.
 - The installer is repeatedly exercised on real machines, not only CI
@@ -108,13 +134,15 @@ artifacts for the release candidate being claimed.
 - The harness records environment state before install so firewall, Docker,
   disk, DNS, and port issues can be separated from product bugs.
 - The user-facing path is tested beyond service liveness: dashboard actions,
-  model switching, Hermes auth, agent capabilities, and regression fixtures are
-  part of the gate.
+  model switching, Hermes auth, agent capabilities, Dream Talk surfaces, and
+  regression fixtures are part of the gate.
+- Lifecycle behavior is part of release-grade confidence: reinstall, restart,
+  and `dream doctor` must recover cleanly after state has changed.
 
 ## What This Does Not Claim
 
 - Every Linux distribution is exhaustively installed on real hardware for every
-  change. CI containers and the tower2 distro lab cover broad distro logic and
+  change. CI containers and the distro lab cover broad distro logic and
   systemd/Docker VM behavior; the physical fleet covers the high-value hardware
   paths.
 - The Incus VM matrix is not GPU validation. GPU runtime claims require real
@@ -124,10 +152,14 @@ artifacts for the release candidate being claimed.
   call out any rotated distro or OS image that was included for that candidate.
 - Intel Arc is still experimental unless a release cites a successful Arc fleet
   run for that release candidate.
-- AP-mode and packaged appliance handoff still require target-image validation
-  because router, Wi-Fi, mDNS, and client-device behavior vary.
+- Dream Talk, LAN, AP-mode, packaged appliance handoff, router, Wi-Fi, mDNS,
+  and client-device behavior require target-mode validation because home
+  networks vary.
 - A fresh fleet pass is not a long-term soak test. Bench, thermal, and
   overnight stability runs are separate evidence.
+- A green fleet pass is a strong release signal, not a promise that every
+  unsupported driver, storage layout, firewall, network, or optional hardware
+  combination will work perfectly.
 
 ## Release Readiness Receipt
 
@@ -136,7 +168,8 @@ Before a release is described as ready, the release notes should cite:
 - the Dream Server version and matching Git tag or release;
 - the fleet run date and sanitized hardware classes covered;
 - regression replay result;
-- install/verify/dashboard/Hermes/capability result summary;
+- zero-prereq bootstrap and distro-lab result summary;
+- install/verify/dashboard/Hermes/UI/capability/lifecycle result summary;
 - any skipped, deferred, blocked-by-environment, or not-run phases;
 - known gaps that should not be read as supported behavior.
 


### PR DESCRIPTION
## Summary
- add a clearer README release-validation trust signal that links to the validation matrix
- refresh the validation matrix with zero-prereq bootstrap, release-grade lifecycle, capability, and User Green gates
- update testing/support docs to distinguish supported platforms from current release evidence and `--phase all` from `/dream-fleet-test` / `--phase release`

## Testing
- `git diff --check`
- `bash tests/test-doc-links.sh`