### PR TITLE
api: harden oauth pending and windows tests

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/oauth_passthrough.py
+++ b/dream-server/extensions/services/dashboard-api/routers/oauth_passthrough.py
@@ -58,8 +58,10 @@ import time
 from pathlib import Path
 from typing import Optional
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Depends, Query
 from fastapi.responses import HTMLResponse
+
+from security import verify_api_key
 
 logger = logging.getLogger(__name__)
 
@@ -174,6 +176,10 @@ async def oauth_callback(
     try:
         tmp = target.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        try:
+            tmp.chmod(0o600)
+        except OSError:
+            logger.debug("oauth callback could not chmod temp file %s", tmp, exc_info=True)
         tmp.replace(target)
     except OSError as exc:
         logger.exception("oauth callback failed to write %s: %s", target, exc)
@@ -187,7 +193,7 @@ async def oauth_callback(
 
 
 @router.get("/api/oauth/pending")
-async def oauth_pending():
+async def oauth_pending(api_key: str = Depends(verify_api_key)):
     """Convenience endpoint the agent or operator can poll to find out
     whether an OAuth callback has arrived but not yet been consumed. The
     agent normally reads the file directly via its filesystem tools, but

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import json
+import os
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -38,6 +39,17 @@ def _make_service_status(sid, status="healthy"):
     return ServiceStatus(
         id=sid, name=sid, port=8080, external_port=8080, status=status,
     )
+
+
+def can_create_symlinks(tmp_path: Path) -> bool:
+    target = tmp_path / "symlink-target"
+    link = tmp_path / "symlink-probe"
+    target.write_text("probe", encoding="utf-8")
+    try:
+        link.symlink_to(target)
+    except (OSError, NotImplementedError):
+        return False
+    return link.is_symlink()
 
 
 def _patch_extensions_config(monkeypatch, catalog, services=None,
@@ -2397,6 +2409,8 @@ class TestSymlinkHandling:
 
     def test_copytree_safe_skips_symlinks(self, tmp_path):
         """_copytree_safe skips symlinks in source directory."""
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
         from routers.extensions import _copytree_safe
 
         src = tmp_path / "src"
@@ -2414,6 +2428,8 @@ class TestSymlinkHandling:
         self, test_client, monkeypatch, tmp_path,
     ):
         """Enable stopped ext rejects a compose.yaml that is a symlink."""
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
         ext_dir.mkdir(parents=True)
@@ -2434,6 +2450,8 @@ class TestSymlinkHandling:
         self, test_client, monkeypatch, tmp_path,
     ):
         """Enable rejects a compose.yaml.disabled that is a symlink."""
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
         ext_dir.mkdir(parents=True)

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -3,6 +3,7 @@
 import importlib.util
 import io
 import json
+import os
 import subprocess
 import sys
 import time
@@ -28,6 +29,17 @@ validate_core_recreate_ids = _mod.validate_core_recreate_ids
 invalidate_compose_cache = _mod.invalidate_compose_cache
 _post_install_core_recreate = _mod._post_install_core_recreate
 _split_nmcli_terse = _mod._split_nmcli_terse
+
+
+def can_create_symlinks(tmp_path: Path) -> bool:
+    target = tmp_path / "symlink-target"
+    link = tmp_path / "symlink-probe"
+    target.mkdir()
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        return False
+    return link.is_symlink()
 
 
 class TestResolveAgentBindAddr:
@@ -631,9 +643,10 @@ class TestSyncExtensionConfigWire:
             target = install_dir / "config" / "fakesvc"
             assert (target / "settings.yaml").read_text(encoding="utf-8") == "server: ok\n"
             # .sh files become executable
-            import stat as _s
-            mode = (target / "entrypoint.sh").stat().st_mode
-            assert mode & _s.S_IXUSR
+            if os.name != "nt":
+                import stat as _s
+                mode = (target / "entrypoint.sh").stat().st_mode
+                assert mode & _s.S_IXUSR
         finally:
             server.shutdown()
             server.server_close()
@@ -738,6 +751,8 @@ class TestSyncExtensionConfigWire:
         """Symlinks (file or directory, top-level or nested) must be rejected
         outright. _copytree_safe strips symlinks at install time so legitimate
         user extensions never have any; one here implies tampering."""
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
         import threading
         from http.server import HTTPServer
 
@@ -783,6 +798,8 @@ class TestSyncExtensionConfigWire:
 
     def test_rejects_symlinked_file_in_config_tree(self, tmp_path, monkeypatch):
         """Symlinked files (not just directories) are also rejected."""
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
         import threading
         from http.server import HTTPServer
 
@@ -820,6 +837,8 @@ class TestSyncExtensionConfigWire:
     def test_rejects_when_config_dir_itself_is_symlink(self, tmp_path, monkeypatch):
         """Top-level `config/` itself a symlink — covers the upfront
         ext_config.is_symlink() guard, separate from the dirs+files walk."""
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
         import threading
         from http.server import HTTPServer
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
@@ -5,6 +5,8 @@ having to copy-paste a code."""
 from __future__ import annotations
 
 import json
+import os
+import stat
 import tempfile
 from pathlib import Path
 
@@ -22,6 +24,7 @@ def oauth_client(monkeypatch):
     monkeypatch.setenv("DREAM_PERSONA_DIR", tmp)
     client = TestClient(main_module.app)
     client.tmp = Path(tmp)
+    client.auth_headers = {"Authorization": "Bearer test-key-12345"}
     return client
 
 
@@ -48,6 +51,17 @@ def test_oauth_callback_writes_pending_file_and_returns_success_html(oauth_clien
     assert payload["code"] == "fake-code-abc123"
     assert payload["state"] == "google-workspace"
     assert isinstance(payload["captured_at"], int)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX file mode bits are not reliable on Windows")
+def test_oauth_callback_file_is_owner_only(oauth_client):
+    resp = oauth_client.get(
+        "/api/oauth/callback",
+        params={"code": "fake-code-abc123", "state": "google-workspace"},
+    )
+    assert resp.status_code == 200
+    callback = oauth_client.tmp / "oauth_callback.json"
+    assert stat.S_IMODE(callback.stat().st_mode) == 0o600
 
 
 def test_oauth_callback_handles_provider_error(oauth_client):
@@ -89,7 +103,10 @@ def test_oauth_callback_defaults_state_to_google_workspace(oauth_client):
 def test_oauth_pending_endpoint_returns_false_when_no_callback(oauth_client):
     """The pending endpoint is a debugging helper for the agent / operator.
     Returns ``{"pending": false}`` when nothing's waiting."""
-    resp = oauth_client.get("/api/oauth/pending")
+    unauth = oauth_client.get("/api/oauth/pending")
+    assert unauth.status_code == 401
+
+    resp = oauth_client.get("/api/oauth/pending", headers=oauth_client.auth_headers)
     assert resp.status_code == 200
     body = resp.json()
     assert body == {"pending": False}
@@ -103,7 +120,7 @@ def test_oauth_pending_endpoint_returns_true_after_callback(oauth_client):
         "/api/oauth/callback",
         params={"code": "fresh-code", "state": "google-workspace"},
     )
-    resp = oauth_client.get("/api/oauth/pending")
+    resp = oauth_client.get("/api/oauth/pending", headers=oauth_client.auth_headers)
     body = resp.json()
     assert body["pending"] is True
     assert body["state"] == "google-workspace"


### PR DESCRIPTION
## Summary
- require dashboard API auth on `/api/oauth/pending` while leaving `/api/oauth/callback` public for provider redirects
- chmod OAuth callback temp files to 0600 before atomic replace where supported
- skip POSIX executable-bit and symlink-security tests on Windows only when the OS lacks the required privileges/semantics

## Validation
- python -m py_compile routers\oauth_passthrough.py
- python -m pytest tests\test_oauth_passthrough.py tests\test_host_agent.py tests\test_extensions_deps.py tests\test_security.py tests\test_auth_router.py -q (149 passed, 4 skipped)
- python -m pytest tests\test_extensions.py::TestSymlinkHandling -q (3 skipped on this Windows host because symlink privileges are unavailable)
- git diff --check

## Notes
- Full `tests\test_extensions.py` exceeded the local 5 minute timeout on this Windows machine; the touched symlink subset and the extension dependency suite were run separately.
