### PR TITLE
docs: document release validation gates

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Dream Server installs and wires together everything you need to run AI locally, 
 
 No cloud required. No subscriptions required. Your prompts and data stay on your machine unless you choose otherwise. Cloud and hybrid API modes are optional when you want them.
 
+**Release validation:** Operational changes are checked with a release-grade
+fleet and distro lab: zero-prereq bootstrap, fresh installs, product flows,
+full-model capabilities, lifecycle recovery, and the final User Green gate. See
+[Release Validation](dream-server/docs/RELEASE_VALIDATION.md) for what a green
+run proves.
+
 ## Get Started
 
 Linux and macOS:
@@ -88,7 +94,11 @@ After install, open **http://localhost:3000** and start chatting.
 >
 > **Tested Linux distros:** Ubuntu 24.04/22.04, Debian 12, Linux Mint 21.3, Fedora 41+, Rocky Linux 9, Arch Linux, Manjaro, CachyOS, and openSUSE Tumbleweed. Other distros using apt, dnf, pacman, or zypper should also work — [open an issue](https://github.com/Light-Heart-Labs/DreamServer/issues) if yours doesn't.
 >
-> **Release validation:** CI checks installer syntax and distro detection; zero-prereq bootstrap checks exercise the public `curl` path on clean Linux containers; the distro lab covers 10 Linux containers plus systemd-capable Incus VMs; the release fleet runs real NVIDIA, AMD, ARM Linux, and Apple Silicon installs through dashboard, Hermes, UI, capability, restart, reinstall, and `dream doctor` gates. See [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) for what a green run proves.
+> **Release validation:** Operational changes run through a release-grade gate
+> that covers zero-prereq bootstrap, clean installs, product behavior,
+> full-model capabilities, lifecycle recovery, and User Green. See
+> [Release Validation](dream-server/docs/RELEASE_VALIDATION.md) and the
+> [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md).
 >
 > **Windows:** Requires Docker Desktop with WSL2 backend. NVIDIA GPUs use Docker GPU passthrough; AMD Strix Halo runs through the platform-specific accelerated path documented in the Windows installer and support matrix.
 >
@@ -400,6 +410,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | [Build On Dream Server](dream-server/docs/BUILD-ON-DREAM-SERVER.md) | Forking, custom editions, extension templates, and downstream validation |
 | [Headless Setup](dream-server/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
+| [Release Validation](dream-server/docs/RELEASE_VALIDATION.md) | User Green gates and the release-grade fleet/distro validation policy |
 | [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 | [Model Management](dream-server/docs/MODEL-MANAGEMENT.md) | Dashboard model downloads, switching, and manual GGUF workflows |
 | [Hardware Guide](dream-server/docs/HARDWARE-GUIDE.md) | What to buy, tier recommendations |

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -20,7 +20,7 @@ at [`../../README.md`](../../README.md).
 | Change model routing | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | [MODE-SWITCH.md](MODE-SWITCH.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) |
 | Add or harden a service | [EXTENSIONS.md](EXTENSIONS.md) | [../extensions/CATALOG.md](../extensions/CATALOG.md), [../extensions/schema/README.md](../extensions/schema/README.md) |
 | Build a custom edition or fork | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) | [EXTENSIONS.md](EXTENSIONS.md), [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md), [../extensions/templates/README.md](../extensions/templates/README.md) |
-| Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [TESTING.md](TESTING.md), [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
+| Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [TESTING.md](TESTING.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md), [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
 
 ## Current Truths
 
@@ -123,6 +123,7 @@ at [`../../README.md`](../../README.md).
 | [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) | Operators | Post-install verification |
 | [KNOWN-GOOD-VERSIONS.md](KNOWN-GOOD-VERSIONS.md) | Operators | Tested image/version combos |
 | [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) | Developers | Platform feature matrix |
+| [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) | Operators / release reviewers | User Green gates and when operational changes require release-grade fleet validation |
 | [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) | Operators / release reviewers | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
 
 ## Project

--- a/dream-server/docs/RELEASE_VALIDATION.md
+++ b/dream-server/docs/RELEASE_VALIDATION.md
@@ -1,0 +1,113 @@
+# Release Validation
+
+Last updated: 2026-05-25
+
+Dream Server is validated as an installed appliance, not only as a collection of
+unit tests. The release-grade path combines CI, clean distro bootstrap checks,
+a distro lab, and a private real-hardware fleet so operational changes are
+tested against the surfaces users actually touch: the public install command,
+service startup, dashboard flows, model routing, Hermes, full-model
+capabilities, reinstall, restart, and `dream doctor`.
+
+This document is a public, sanitized summary of that release gate. It describes
+what a green run proves without publishing private hostnames, LAN addresses,
+usernames, local paths, or raw run logs. For the broader hardware and distro
+surface, see [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md). For day-to-day local
+test commands, see [TESTING.md](TESTING.md).
+
+## When We Run It
+
+Run the release-grade fleet after operational code changes: installer phases,
+bootstrap logic, Docker Compose stack generation, service manifests, dashboard
+API behavior, Hermes, model routing, GPU/runtime detection, lifecycle commands,
+or anything that can affect a user's install or running stack.
+
+Docs-only, comment-only, and narrow test-only changes usually use focused
+validation instead. Dependency or runtime wiring changes should use the
+release-grade gate even when the code diff is small.
+
+## User Green
+
+`User Green` is the top-level release-readiness result. It is not a marketing
+claim that every possible machine or network will work. It means the enabled
+release surfaces passed or were explicitly accounted for in the current
+candidate run.
+
+| Gate | What it proves |
+|---|---|
+| Zero-prereq bootstrap | Bare Linux distro containers can fetch the public installer and provision missing prerequisites such as Git, Python, Docker, and Compose. |
+| Install Green | Enabled real-hardware hosts can fresh-install from the public bootstrap path. |
+| Product Green | Core services, cloud-mode contracts, dashboard flows, Hermes auth/chat, and UI checks pass after install. |
+| Capability Green | Full-model capability probes pass after large model downloads and swaps complete. |
+| Lifecycle Green | Idempotent reinstall, `dream restart`, and `dream doctor` recover cleanly after state changes. |
+| User Green | The combined release gate is clean, with failures, skips, and deferrals resolved or documented. |
+
+## Release-Grade Surfaces
+
+The release harness normally combines these layers:
+
+| Layer | Coverage | Why it matters |
+|---|---|---|
+| CI | Fast syntax, contract, dashboard, shell, Python, and PowerShell checks | Catches cheap regressions before hardware time is spent. |
+| Zero-prereq bootstrap | Clean Ubuntu, Debian, Fedora, Rocky, Arch, and openSUSE containers | Proves the public `curl` path does not assume a developer workstation. |
+| Distro lab | 10 Linux container lanes plus systemd-capable Incus VM lanes | Exercises package-manager, systemd, Docker daemon, and Compose behavior across distro families. |
+| Real hardware fleet | Linux NVIDIA, Linux AMD/ROCm-Lemonade, ARM Linux NVIDIA, and Apple Silicon hardware classes | Proves accelerator/runtime behavior and the installed product on actual machines. |
+
+The latest release-grade fleet run for the current candidate should be cited in
+release notes with its commit, date, enabled hardware classes, and any skipped
+or deferred surfaces. Public docs should summarize the sanitized evidence
+rather than linking raw private run artifacts.
+
+## What We Check
+
+A release-grade run includes:
+
+- public bootstrap and zero-prereq install checks;
+- fresh install on enabled real-hardware targets;
+- core service health and generated config contracts;
+- cloud and hybrid mode contracts;
+- dashboard API flows such as model download, model switch, and extension install;
+- Hermes authentication and agent chat with seed verification;
+- browser UI checks on the default UI target;
+- full-model capabilities such as chat, search, file read/write, code execution,
+  skills, model identity, and context;
+- lifecycle checks: idempotent reinstall, `dream restart`, and `dream doctor`;
+- regression replay for previously fixed fleet failures.
+
+Capability probes can be deferred while a large model is still downloading or
+hot-swapping. The capabilities watcher polls until the model is ready, reruns
+the probes, and updates the report so a release is not marked User Green just
+because the first pass arrived before the model did.
+
+## Known Limits
+
+- Dream Talk and owner-card probes only gate when the owner-card surface is
+  enabled and `dream-proxy` is actually available, such as a LAN-enabled install.
+  Default non-LAN installs skip those probes instead of false-failing a surface
+  the user did not expose.
+- Vision probes are opt-in and should be called out explicitly when enabled for
+  a candidate run.
+- Incus Arch and openSUSE VM lanes can hit nested Docker limitations in the lab.
+  The container lanes and real-hardware fleet are used to separate those lab
+  limitations from product regressions.
+- The fleet is not an exhaustive promise for every driver, firewall, storage
+  layout, Docker Desktop version, home router, or unsupported hardware
+  combination.
+- A green release run is a strong release signal, not a soak test. Long-running
+  thermal, benchmark, and overnight stability evidence is tracked separately.
+
+## Reading A Green Run
+
+A current User Green pass should give contributors and auditors high confidence
+that the main supported install paths are working at release time:
+
+- clean machines can reach the installer through the public bootstrap path;
+- supported hardware classes can install and start the product;
+- users can exercise dashboard, Hermes, model, and extension workflows;
+- full-model AI capabilities are validated after downloads complete;
+- reinstall, restart, and diagnostic paths recover after state changes.
+
+It should not be read as a claim that all optional modes ran in that candidate.
+Release notes should name any skipped or opt-in surfaces, especially Windows
+fleet targets, Dream Talk owner-card flows, vision probes, AP mode, and network
+topologies that vary by lab.

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -6,12 +6,13 @@ Last updated: 2026-05-25
 
 **Linux, Windows, and macOS are fully supported. Intel Arc is experimental.**
 
-For the layered evidence behind these claims, see
-[VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) and [TESTING.md](TESTING.md). The
-matrix is sanitized so it can be public without exposing private lab hostnames,
-LAN addresses, or paths. Support status means the project has an intended
-installer/runtime path for that platform; release evidence should still name the
-current run, enabled hardware classes, and any deferred or skipped phases.
+For the release gate behind these claims, see
+[RELEASE_VALIDATION.md](RELEASE_VALIDATION.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md),
+and [TESTING.md](TESTING.md). The validation docs are sanitized so they can be
+public without exposing private lab hostnames, LAN addresses, or paths. Support
+status means the project has an intended installer/runtime path for that
+platform; release evidence should still name the current run, enabled hardware
+classes, and any deferred or skipped phases.
 
 | Platform | Status | What you get today |
 |----------|--------|-------------------|


### PR DESCRIPTION
﻿## Summary
- add `dream-server/docs/RELEASE_VALIDATION.md` describing the User Green gate and the six release-grade validation layers
- add a concise README trust signal near the top plus docs-index links
- link the support matrix to the public release validation policy alongside the deeper validation matrix/testing docs

## Validation
- `git diff --check`
- PowerShell local Markdown link sanity check for README and touched docs
- checked the new release-validation doc for private hostnames/paths and overclaim language such as "zero bugs" or "works perfectly"

## Notes
Docs-only change. This documents that operational code changes should go through the release-grade fleet, while docs/test-only changes can use focused validation.
