### PR TITLE
[codex] Fix trusted library extra_hosts scanning

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -330,6 +330,8 @@ def _scan_compose_content(
     skip_root_user_check: bool = False,
 ) -> None:
     """Reject compose files containing dangerous directives."""
+    allowed_trusted_extra_hosts = {"host.docker.internal:host-gateway"}
+
     try:
         data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
     except (yaml.YAMLError, OSError) as e:
@@ -432,11 +434,24 @@ def _scan_compose_content(
                 status_code=400,
                 detail=f"Service '{svc_name}' uses a local build — only pre-built images are allowed for user extensions",
             )
-        if svc_def.get("extra_hosts"):
+        extra_hosts = svc_def.get("extra_hosts")
+        if extra_hosts and not trusted:
             raise HTTPException(
                 status_code=400,
                 detail=f"Extension rejected: extra_hosts in {svc_name}",
             )
+        if extra_hosts and trusted:
+            if not isinstance(extra_hosts, list):
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"Extension rejected: unsupported extra_hosts in {svc_name}",
+                )
+            for entry in extra_hosts:
+                if not isinstance(entry, str) or entry.strip() not in allowed_trusted_extra_hosts:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Extension rejected: unsupported extra_hosts in {svc_name}",
+                    )
         if svc_def.get("sysctls"):
             raise HTTPException(
                 status_code=400,

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -572,6 +572,82 @@ class TestInstallExtension:
     # test_install_writes_pending_change removed — v3 uses host agent, no pending changes file
 
 
+    def test_install_allows_library_host_gateway_extra_host(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Bundled library extensions may use the host-gateway bridge."""
+        compose = (
+            "services:\n"
+            "  svc:\n"
+            "    image: test:latest\n"
+            "    extra_hosts:\n"
+            "      - host.docker.internal:host-gateway\n"
+        )
+        lib_dir = _setup_library_ext(tmp_path, "host-gateway-ext",
+                                     compose_content=compose)
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
+
+        resp = test_client.post(
+            "/api/extensions/host-gateway-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["action"] == "installed"
+
+    def test_install_rejects_untrusted_extra_hosts(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """User-installed extension compose files cannot add host aliases."""
+        compose = (
+            "services:\n"
+            "  svc:\n"
+            "    image: test:latest\n"
+            "    extra_hosts:\n"
+            "      - host.docker.internal:host-gateway\n"
+        )
+        user_dir = tmp_path / "user"
+        ext_dir = user_dir / "host-gateway-ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml.disabled").write_text(compose)
+        (ext_dir / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "dream.services.v1",
+            "service": {"id": "host-gateway-ext", "name": "host-gateway-ext"},
+        }))
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+
+        resp = test_client.post(
+            "/api/extensions/host-gateway-ext/enable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 400
+        assert "extra_hosts" in resp.json()["detail"]
+
+    def test_install_rejects_unapproved_library_extra_hosts(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Trusted library status only permits the known host-gateway mapping."""
+        compose = (
+            "services:\n"
+            "  svc:\n"
+            "    image: test:latest\n"
+            "    extra_hosts:\n"
+            "      - metadata.google.internal:169.254.169.254\n"
+        )
+        lib_dir = _setup_library_ext(tmp_path, "bad-host-ext",
+                                     compose_content=compose)
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir)
+
+        resp = test_client.post(
+            "/api/extensions/bad-host-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 400
+        assert "unsupported extra_hosts" in resp.json()["detail"]
+
+
 # --- Enable endpoint ---
 
 


### PR DESCRIPTION
## Summary

Fixes #1385.

Bundled library extensions can now use the specific `host.docker.internal:host-gateway` mapping needed by GAIA, while user-installed/uploaded extensions still cannot add arbitrary `extra_hosts` entries.

## Why

The extension security scanner treated `extra_hosts` as always unsafe. That is correct for untrusted user extensions, but it broke trusted bundled library installs that need the Docker host-gateway alias.

## Validation

- `python -m pytest tests/test_extensions.py -k "extra_hosts or host_gateway" -q`
- `python -m py_compile routers/extensions.py tests/test_extensions.py`
- `git diff --check`