### PR TITLE
[codex] Fix GAIA data ownership

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -299,6 +299,16 @@ def _precreate_data_dirs(service_id: str):
         return
     if not isinstance(data, dict):
         return
+    manifest_uid = None
+    manifest = _read_manifest(ext_dir)
+    if isinstance(manifest, dict):
+        service_def = manifest.get("service", {})
+        if isinstance(service_def, dict):
+            container_uid = service_def.get("container_uid")
+            if isinstance(container_uid, int):
+                manifest_uid = container_uid
+            elif isinstance(container_uid, str) and container_uid.isdigit():
+                manifest_uid = int(container_uid)
     for svc_name, svc_def in data.get("services", {}).items():
         if not isinstance(svc_def, dict):
             continue
@@ -311,6 +321,8 @@ def _precreate_data_dirs(service_id: str):
                 uid = int(m.group(1))
             elif user_str.isdigit():
                 uid = int(user_str)
+        if uid is None:
+            uid = manifest_uid
         volumes = svc_def.get("volumes", [])
         if not isinstance(volumes, list):
             continue

--- a/dream-server/extensions/library/schema/service-manifest.v1.json
+++ b/dream-server/extensions/library/schema/service-manifest.v1.json
@@ -23,6 +23,11 @@
           "type": "string",
           "description": "Docker container name for dream shell"
         },
+        "container_uid": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Numeric UID the container process runs as when it is not visible from compose.user. Used by the host agent to prepare bind-mounted data directories."
+        },
         "host_env": { "type": "string" },
         "default_host": { "type": "string" },
         "port": { "type": "integer", "minimum": 0, "maximum": 65535 },

--- a/dream-server/extensions/library/services/gaia/compose.yaml
+++ b/dream-server/extensions/library/services/gaia/compose.yaml
@@ -6,6 +6,7 @@ services:
       args:
         GAIA_AGENT_UI_VERSION: ${GAIA_AGENT_UI_VERSION:-0.19.0}
     container_name: dream-gaia
+    user: "10001:10001"
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true

--- a/dream-server/extensions/library/services/gaia/hooks/post_install.sh
+++ b/dream-server/extensions/library/services/gaia/hooks/post_install.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# GAIA post_install hook - Linux bind-mount uid alignment.
+#
+# The GAIA container runs as uid/gid 10001. On native Linux Docker, bind
+# mounts preserve host ownership, so data/gaia must be owned by 10001:10001
+# before the container can write first-run state.
+
+set -euo pipefail
+
+INSTALL_DIR="${1:-}"
+GAIA_DATA_DIR="$INSTALL_DIR/data/gaia"
+GAIA_OWNER="10001:10001"
+
+log() {
+    echo "gaia post_install: $*" >&2
+}
+
+if [[ -z "$INSTALL_DIR" ]]; then
+    log "ERROR: INSTALL_DIR (arg 1) is required"
+    exit 2
+fi
+
+PLATFORM="$(uname -s)"
+if [[ "$PLATFORM" != "Linux" ]]; then
+    log "Skipping chown on $PLATFORM (uid alignment only needed on native Linux Docker)"
+    exit 0
+fi
+
+SUDO=()
+if [[ "$(id -u)" -ne 0 ]]; then
+    if command -v sudo >/dev/null 2>&1; then
+        SUDO=(sudo -n)
+    else
+        log "ERROR: sudo is unavailable and this hook is not running as root."
+        log "Run manually: sudo mkdir -p '$GAIA_DATA_DIR' && sudo chown -R $GAIA_OWNER '$GAIA_DATA_DIR', then retry the install."
+        exit 1
+    fi
+fi
+
+if [[ ! -d "$GAIA_DATA_DIR" ]]; then
+    log "creating $GAIA_DATA_DIR"
+    if ! "${SUDO[@]}" mkdir -p "$GAIA_DATA_DIR"; then
+        log "ERROR: failed to create $GAIA_DATA_DIR"
+        exit 1
+    fi
+fi
+
+log "chown -R $GAIA_OWNER $GAIA_DATA_DIR"
+if ! "${SUDO[@]}" chown -R "$GAIA_OWNER" "$GAIA_DATA_DIR"; then
+    log "ERROR: failed to chown $GAIA_DATA_DIR."
+    log "Run manually: sudo chown -R $GAIA_OWNER '$GAIA_DATA_DIR', then retry the install."
+    exit 1
+fi
+
+log "done"

--- a/dream-server/extensions/library/services/gaia/manifest.yaml
+++ b/dream-server/extensions/library/services/gaia/manifest.yaml
@@ -7,6 +7,7 @@ service:
   container_name: dream-gaia
   host_env: GAIA_HOST
   default_host: gaia
+  container_uid: 10001
   port: 4200
   external_port_env: GAIA_PORT
   external_port_default: 7822
@@ -18,6 +19,7 @@ service:
   gpu_backends: [all]
   compose_file: compose.yaml
   category: optional
+  setup_hook: hooks/post_install.sh
   depends_on: []
   description: "Experimental AMD GAIA Agent UI recipe for local agent workflows."
   env_vars:

--- a/dream-server/extensions/schema/README.md
+++ b/dream-server/extensions/schema/README.md
@@ -49,6 +49,7 @@ Identifies the service and how the registry and compose resolver use it.
 | `name`                | string  | yes      | Human-readable name (e.g. "Open WebUI (Chat)"). |
 | `aliases`             | array   | no       | Shorthand ids for CLI (e.g. `[webui, ui]`). |
 | `container_name`      | string  | no       | Docker container name (e.g. `dream-webui`). |
+| `container_uid`       | integer | no       | Numeric UID the container process runs as when compose does not declare `user`. The host agent uses this to prepare bind-mounted data directories. |
 | `host_env`            | string  | no       | Env var for host override. |
 | `default_host`        | string  | no       | Default hostname inside the stack. |
 | `port`                | integer | yes      | Internal port (0–65535). |

--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -52,6 +52,11 @@
           "type": "string",
           "description": "Docker container name for dream shell"
         },
+        "container_uid": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Numeric UID the container process runs as when it is not visible from compose.user. Used by the host agent to prepare bind-mounted data directories."
+        },
         "host_env": { "type": "string" },
         "default_host": { "type": "string" },
         "port": { "type": "integer", "minimum": 0, "maximum": 65535 },

--- a/dream-server/extensions/services/dashboard-api/tests/test_hooks.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_hooks.py
@@ -263,3 +263,21 @@ class TestLangfuseManifestHook:
             "The langfuse postgres uid 70 install fix ships this file; "
             "if removed, langfuse silently regresses to broken Linux behavior."
         )
+
+
+class TestGaiaManifestHook:
+    """Structural guard for GAIA's native Linux bind-mount uid alignment."""
+
+    def _ext_dir(self) -> Path:
+        return Path(__file__).resolve().parents[3] / "library" / "services" / "gaia"
+
+    def test_gaia_manifest_declares_post_install_hook(self):
+        ext_dir = self._ext_dir()
+        manifest = yaml.safe_load((ext_dir / "manifest.yaml").read_text())
+        service = manifest.get("service", {})
+        assert service.get("container_uid") == 10001
+        assert service.get("setup_hook") == "hooks/post_install.sh"
+
+    def test_gaia_post_install_hook_file_exists(self):
+        hook_path = self._ext_dir() / "hooks" / "post_install.sh"
+        assert hook_path.is_file()

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1844,6 +1844,30 @@ class TestPrecreateDataDirs:
             encoding="utf-8",
         )
 
+    def _write_compose_with_user(
+        self, ext_dir: Path, volumes: list[str], user: str,
+    ):
+        vol_yaml = "\n".join(f"      - {v}" for v in volumes)
+        ext_dir.mkdir(parents=True, exist_ok=True)
+        (ext_dir / "compose.yaml").write_text(
+            "services:\n"
+            "  svc:\n"
+            "    image: test:latest\n"
+            f"    user: \"{user}\"\n"
+            "    volumes:\n" + vol_yaml + "\n",
+            encoding="utf-8",
+        )
+
+    def _write_manifest(self, ext_dir: Path, service_id: str, container_uid: int):
+        (ext_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n"
+            f"  id: {service_id}\n"
+            f"  name: {service_id}\n"
+            f"  container_uid: {container_uid}\n",
+            encoding="utf-8",
+        )
+
     def test_creates_dirs_for_builtin_ext_via_find_ext_dir(self, tmp_path, monkeypatch):
         """Defect 1/2: built-in extensions resolved via _find_ext_dir, not USER_EXTENSIONS_DIR."""
         pytest.importorskip("yaml")
@@ -1889,6 +1913,78 @@ class TestPrecreateDataDirs:
         # INSTALL_DIR (the Compose project directory).
         assert (install_dir / "upload").is_dir()
         assert (install_dir / "data" / "state").is_dir()
+
+    def test_manifest_container_uid_fallback_chowns_when_root(
+        self, tmp_path, monkeypatch,
+    ):
+        """Manifest container_uid covers images that set USER in Dockerfile."""
+        pytest.importorskip("yaml")
+        user_root = tmp_path / "user"
+        builtin_root = tmp_path / "builtin"
+        install_dir = tmp_path / "install"
+        user_root.mkdir()
+        builtin_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = user_root / "svc-u"
+        self._write_compose(ext_dir, ["./data/gaia:/home/gaia/.gaia"])
+        self._write_manifest(ext_dir, "svc-u", 10001)
+        chowns = []
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "_fs_type", lambda path: None)
+        monkeypatch.setattr(_mod.os, "getuid", lambda: 0, raising=False)
+        monkeypatch.setattr(
+            _mod.os,
+            "chown",
+            lambda path, uid, gid: chowns.append((Path(path), uid, gid)),
+            raising=False,
+        )
+
+        _mod._precreate_data_dirs("svc-u")
+
+        data_dir = install_dir / "data" / "gaia"
+        assert data_dir.is_dir()
+        assert chowns == [(data_dir, 10001, 10001)]
+
+    def test_compose_user_takes_precedence_over_manifest_uid(
+        self, tmp_path, monkeypatch,
+    ):
+        """Explicit compose user remains the source of truth when present."""
+        pytest.importorskip("yaml")
+        user_root = tmp_path / "user"
+        builtin_root = tmp_path / "builtin"
+        install_dir = tmp_path / "install"
+        user_root.mkdir()
+        builtin_root.mkdir()
+        install_dir.mkdir()
+        ext_dir = user_root / "svc-u"
+        self._write_compose_with_user(
+            ext_dir,
+            ["./data/gaia:/home/gaia/.gaia"],
+            "12345:12345",
+        )
+        self._write_manifest(ext_dir, "svc-u", 10001)
+        chowns = []
+
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "_fs_type", lambda path: None)
+        monkeypatch.setattr(_mod.os, "getuid", lambda: 0, raising=False)
+        monkeypatch.setattr(
+            _mod.os,
+            "chown",
+            lambda path, uid, gid: chowns.append((Path(path), uid, gid)),
+            raising=False,
+        )
+
+        _mod._precreate_data_dirs("svc-u")
+
+        data_dir = install_dir / "data" / "gaia"
+        assert data_dir.is_dir()
+        assert chowns == [(data_dir, 12345, 12345)]
 
     def test_skips_named_volumes(self, tmp_path, monkeypatch):
         """Named volumes (no '/') must not trigger filesystem creation."""


### PR DESCRIPTION
## Summary

Fixes #1386.

GAIA now declares the UID it runs as and ships a Linux post-install ownership hook so `data/gaia` is writable by the container before first start.

## Why

GAIA sets `USER gaia` in its Dockerfile, so the host-agent could not infer the runtime UID from compose alone. On native Linux Docker, bind mounts preserve host ownership, which can leave `data/gaia` unwritable for UID 10001.

## Changes

- Add `user: "10001:10001"` to GAIA compose.
- Add `service.container_uid: 10001` and `setup_hook: hooks/post_install.sh` to the GAIA manifest.
- Add a GAIA post-install hook that creates/chowns `data/gaia` on native Linux.
- Teach the host-agent to use manifest `container_uid` as a fallback when compose omits `user`.
- Document/allow `container_uid` in the service manifest schemas.

## Validation

- `python -m pytest tests/test_host_agent.py -k "PrecreateDataDirs" -q`
- `python -m pytest tests/test_hooks.py -q`
- `python -m py_compile bin/dream-host-agent.py`
- `python dream-server/scripts/audit-extensions.py --project-dir dream-server`
- `python dream-server/scripts/generate-extensions-catalog.py --library-dir dream-server/extensions/library/services --output $env:TEMP/dream-extensions-catalog.json`
- `git diff --cached --check`

Note: `bash -n` could not run in this Windows environment because `bash.exe` resolves to a broken WSL shim (`/bin/bash` missing). The hook follows the existing Langfuse post-install ownership pattern.