### PR TITLE
[codex] Guard owner cards on dream-proxy readiness

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/magic_link.py
+++ b/dream-server/extensions/services/dashboard-api/routers/magic_link.py
@@ -56,6 +56,8 @@ import os
 import secrets
 import threading
 import time
+import urllib.error
+import urllib.request
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
@@ -65,6 +67,7 @@ from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 import session_signer
+from config import SERVICES
 from security import verify_api_key
 
 logger = logging.getLogger(__name__)
@@ -478,7 +481,47 @@ def _cookie_domain(url_mode: str = "auto") -> Optional[str]:
     return f"{_device_name()}.local"
 
 
+def _dream_proxy_lan_ready() -> tuple[bool, str]:
+    """Return whether owner-card LAN URLs can actually be served."""
+    service = SERVICES.get("dream-proxy")
+    if not service:
+        return (
+            False,
+            "Dream Talk owner cards require dream-proxy. Enable LAN web access before generating an owner card.",
+        )
+
+    host = service.get("host") or "dream-proxy"
+    port = int(service.get("port") or 80)
+    health = str(service.get("health") or "/health")
+    if not health.startswith("/"):
+        health = f"/{health}"
+    url = f"http://{host}:{port}{health}"
+    try:
+        with urllib.request.urlopen(url, timeout=1.0) as resp:
+            status = getattr(resp, "status", 0)
+            if 200 <= status < 400:
+                return True, ""
+            return False, f"dream-proxy health returned HTTP {status}"
+    except (OSError, TimeoutError, urllib.error.URLError) as exc:
+        return False, f"dream-proxy is enabled but not reachable: {exc}"
+
+
+def _owner_card_requires_lan_proxy(payload: GenerateRequest) -> bool:
+    return payload.token_type == "owner" and not _use_public_url(payload.url_mode)
+
+
 # --- Endpoints ---
+
+
+@router.get("/api/auth/magic-link/owner-card/status", dependencies=[Depends(verify_api_key)])
+def owner_card_status() -> dict:
+    """Report whether LAN owner-card URLs can be generated safely."""
+    ready, reason = _dream_proxy_lan_ready()
+    return {
+        "ready": ready,
+        "requires": "dream-proxy",
+        "reason": "" if ready else reason,
+    }
 
 
 @router.post("/api/auth/magic-link/generate", dependencies=[Depends(verify_api_key)])
@@ -489,6 +532,10 @@ def generate_magic_link(payload: GenerateRequest, request: Request) -> GenerateR
             status_code=400,
             detail="url_mode=public requires DREAM_PUBLIC_URL to be configured",
         )
+    if _owner_card_requires_lan_proxy(payload):
+        ready, reason = _dream_proxy_lan_ready()
+        if not ready:
+            raise HTTPException(status_code=409, detail=reason)
     token = secrets.token_urlsafe(32)
     token_hash = _hash_token(token)
     created_at = datetime.now(timezone.utc)

--- a/dream-server/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -44,6 +44,7 @@ def magic_link_module(tmp_path, monkeypatch):
 
     # Reset in-memory rate-limit table between tests.
     ml._RATE_LIMIT_BUCKETS.clear()
+    monkeypatch.setattr(ml, "_dream_proxy_lan_ready", lambda: (True, ""))
 
     # The main app already imported the router at module load — re-include the
     # reloaded one so the TestClient routes to fresh module state.
@@ -85,6 +86,11 @@ def test_revoke_requires_auth(magic_link_client):
 
 def test_qr_requires_auth(magic_link_client):
     resp = magic_link_client.get("/api/auth/magic-link/qr?url=http://example/")
+    assert resp.status_code == 401
+
+
+def test_owner_card_status_requires_auth(magic_link_client):
+    resp = magic_link_client.get("/api/auth/magic-link/owner-card/status")
     assert resp.status_code == 401
 
 
@@ -278,6 +284,23 @@ def test_generate_owner_token_defaults_to_revoke_only_hermes_lan(magic_link_clie
     assert data["url"].startswith("http://auth.dream.local/magic-link/")
 
 
+def test_generate_owner_lan_requires_dream_proxy(magic_link_client, magic_link_module, monkeypatch):
+    monkeypatch.setattr(
+        magic_link_module,
+        "_dream_proxy_lan_ready",
+        lambda: (False, "Dream Talk owner cards require dream-proxy"),
+    )
+
+    resp = magic_link_client.post(
+        "/api/auth/magic-link/generate",
+        json={"target_username": "owner", "token_type": "owner"},
+        headers=magic_link_client.auth_headers,
+    )
+
+    assert resp.status_code == 409
+    assert "dream-proxy" in resp.json()["detail"]
+
+
 def test_generate_owner_rejects_expiry(magic_link_client):
     resp = magic_link_client.post(
         "/api/auth/magic-link/generate",
@@ -298,6 +321,48 @@ def test_owner_public_url_mode_uses_public_url_when_requested(magic_link_client,
     data = resp.json()
     assert data["url_mode"] == "public"
     assert data["url"].startswith("https://dream.example/auth/magic-link/")
+
+
+def test_owner_public_url_mode_does_not_require_dream_proxy(
+    magic_link_client, magic_link_module, monkeypatch,
+):
+    monkeypatch.setenv("DREAM_PUBLIC_URL", "https://dream.example")
+    monkeypatch.setattr(
+        magic_link_module,
+        "_dream_proxy_lan_ready",
+        lambda: (False, "Dream Talk owner cards require dream-proxy"),
+    )
+
+    resp = magic_link_client.post(
+        "/api/auth/magic-link/generate",
+        json={"target_username": "owner", "token_type": "owner", "url_mode": "public"},
+        headers=magic_link_client.auth_headers,
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["url"].startswith("https://dream.example/auth/magic-link/")
+
+
+def test_owner_card_status_reports_proxy_state(
+    magic_link_client, magic_link_module, monkeypatch,
+):
+    monkeypatch.setattr(
+        magic_link_module,
+        "_dream_proxy_lan_ready",
+        lambda: (False, "dream-proxy is not enabled"),
+    )
+
+    resp = magic_link_client.get(
+        "/api/auth/magic-link/owner-card/status",
+        headers=magic_link_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "ready": False,
+        "requires": "dream-proxy",
+        "reason": "dream-proxy is not enabled",
+    }
 
 
 def test_public_url_mode_requires_public_url(magic_link_client):

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -86,6 +86,7 @@ export default function FirstBoot({ onComplete }) {
   const [finishing, setFinishing] = useState(false)
   const [finishError, setFinishError] = useState(null)
   const [invite, setInvite] = useState(null)
+  const [ownerCardStatus, setOwnerCardStatus] = useState(null)
 
   // Persist progress whenever the user moves forward.
   useEffect(() => {
@@ -94,29 +95,68 @@ export default function FirstBoot({ onComplete }) {
 
   const next = () => setStep(s => Math.min(s + 1, TOTAL_STEPS))
   const prev = () => setStep(s => Math.max(s - 1, 1))
+  const ownerCardStatusLoading = ownerCardStatus === null
+  const ownerCardUnavailable = ownerCardStatus?.ready === false
+  const ownerCardUnavailableReason = ownerCardStatus?.reason || 'Enable Dream proxy before generating owner cards.'
+
+  useEffect(() => {
+    let cancelled = false
+    const loadOwnerCardStatus = async () => {
+      try {
+        const resp = await fetch('/api/auth/magic-link/owner-card/status')
+        if (!resp.ok) {
+          if (!cancelled) {
+            setOwnerCardStatus({
+              ready: false,
+              reason: `Owner-card status unavailable (${resp.status})`,
+            })
+          }
+          return
+        }
+        const data = await resp.json()
+        if (!cancelled) setOwnerCardStatus(data)
+      } catch {
+        if (!cancelled) {
+          setOwnerCardStatus({
+            ready: false,
+            reason: 'Owner-card status unavailable.',
+          })
+        }
+      }
+    }
+    loadOwnerCardStatus()
+    return () => { cancelled = true }
+  }, [])
 
   const finish = async () => {
-    setFinishing(true)
     setFinishError(null)
+    if (ownerCardStatusLoading) {
+      setFinishError('Checking owner-card readiness. Try again in a moment.')
+      return
+    }
+    setFinishing(true)
     try {
-      // Generate the owner magic-link for the named user. Reuses the same
-      // backend the Setup / Owner page consumes.
-      const genResp = await fetch('/api/auth/magic-link/generate', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          target_username: username,
-          token_type: 'owner',
-          scope: 'hermes',
-          url_mode: 'lan',
-          note: `First-boot owner card (${deviceName.trim() || 'dream'})`,
-        }),
-      })
-      if (!genResp.ok) {
-        const body = await genResp.json().catch(() => ({}))
-        throw new Error(body.detail || `generate failed: ${genResp.status}`)
+      let inviteData = null
+      if (!ownerCardUnavailable) {
+        // Generate the owner magic-link for the named user. Reuses the same
+        // backend the Setup / Owner page consumes.
+        const genResp = await fetch('/api/auth/magic-link/generate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            target_username: username,
+            token_type: 'owner',
+            scope: 'hermes',
+            url_mode: 'lan',
+            note: `First-boot owner card (${deviceName.trim() || 'dream'})`,
+          }),
+        })
+        if (!genResp.ok) {
+          const body = await genResp.json().catch(() => ({}))
+          throw new Error(body.detail || `generate failed: ${genResp.status}`)
+        }
+        inviteData = await genResp.json()
       }
-      const inviteData = await genResp.json()
 
       // Flip the server-side sentinel so this device is "configured".
       // Check the response; an earlier draft fired the request and
@@ -127,8 +167,11 @@ export default function FirstBoot({ onComplete }) {
       const completeResp = await fetch('/api/setup/complete', { method: 'POST' })
       if (!completeResp.ok) {
         const body = await completeResp.json().catch(() => ({}))
+        const fallback = inviteData
+          ? `Failed to mark setup complete (${completeResp.status}). Your owner card was generated; ask the admin to re-run setup.`
+          : `Failed to mark setup complete (${completeResp.status}).`
         throw new Error(
-          body.detail || `Failed to mark setup complete (${completeResp.status}). Your owner card was generated; ask the admin to re-run setup.`,
+          body.detail || fallback,
         )
       }
 
@@ -154,11 +197,15 @@ export default function FirstBoot({ onComplete }) {
         console.warn('[dream-session] admin-session network failure:', err)
       }
 
-      setInvite(inviteData)
       clearProgress()
-      // Stay on the success screen until the user taps "Open dashboard".
-      // Calling onComplete() immediately would route them away before they
-      // can copy the QR. onComplete fires on the final tap.
+      if (inviteData) {
+        setInvite(inviteData)
+        // Stay on the success screen until the user taps "Open dashboard".
+        // Calling onComplete() immediately would route them away before they
+        // can copy the QR. onComplete fires on the final tap.
+      } else {
+        onComplete?.()
+      }
     } catch (err) {
       setFinishError(err.message)
     } finally {
@@ -215,6 +262,8 @@ export default function FirstBoot({ onComplete }) {
                   onFinish={finish}
                   finishing={finishing}
                   error={finishError}
+                  ownerCardStatus={ownerCardStatus}
+                  ownerCardStatusLoading={ownerCardStatusLoading}
                 />
               )}
             </>
@@ -423,8 +472,19 @@ function StackStep({ stack, setStack, onNext, onBack }) {
 // Step 4 - Confirm & finish
 // ---------------------------------------------------------------------------
 
-function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing, error }) {
+function ConfirmStep({
+  deviceName,
+  username,
+  stack,
+  onBack,
+  onFinish,
+  finishing,
+  error,
+  ownerCardStatus,
+  ownerCardStatusLoading,
+}) {
   const stackTitle = STACK_OPTIONS.find(s => s.id === stack)?.title || stack
+  const ownerCardUnavailable = ownerCardStatus?.ready === false
   return (
     <div>
       <h1 className="text-3xl font-bold text-theme-text mb-6">Ready?</h1>
@@ -437,6 +497,23 @@ function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing,
         <Row label="First user" value={username.trim()} />
         <Row label="Stack" value={stackTitle} hint="enable extras from Extensions" />
       </dl>
+
+      {ownerCardStatusLoading && (
+        <div className="mb-6 p-4 bg-theme-card border border-theme-border rounded-xl text-theme-text-muted text-sm flex items-start gap-2">
+          <Loader2 size={18} className="animate-spin flex-shrink-0 mt-0.5" />
+          <span>Checking owner-card readiness...</span>
+        </div>
+      )}
+
+      {ownerCardUnavailable && (
+        <div className="mb-6 p-4 bg-amber-500/10 border border-amber-500/30 rounded-xl text-amber-100 text-sm flex items-start gap-2">
+          <AlertCircle size={18} className="flex-shrink-0 mt-0.5" />
+          <span>
+            {ownerCardStatus.reason || 'Enable Dream proxy before generating owner cards.'}
+            {' '}Finish setup now, then print an owner card from Settings / Setup / Owner after LAN access is enabled.
+          </span>
+        </div>
+      )}
 
       {error && (
         <div className="mb-6 p-4 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm flex items-start gap-2">
@@ -455,7 +532,7 @@ function ConfirmStep({ deviceName, username, stack, onBack, onFinish, finishing,
         </button>
         <button
           onClick={onFinish}
-          disabled={finishing}
+          disabled={finishing || ownerCardStatusLoading}
           className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
         >
           {finishing && <Loader2 size={18} className="animate-spin" />}

--- a/dream-server/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
@@ -8,7 +8,9 @@ const response = (body, status = 200) => ({
   json: async () => body,
 })
 
-function finishWizard() {
+const ownerCardReady = { ready: true, requires: 'dream-proxy', reason: '' }
+
+async function finishWizard() {
   fireEvent.change(screen.getByDisplayValue('dream'), { target: { value: 'spark' } })
   fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
 
@@ -16,7 +18,9 @@ function finishWizard() {
   fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
 
   fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
-  fireEvent.click(screen.getByRole('button', { name: /^finish$/i }))
+  const finishButton = screen.getByRole('button', { name: /^finish$/i })
+  await waitFor(() => expect(finishButton).toBeEnabled())
+  fireEvent.click(finishButton)
 }
 
 describe('FirstBoot', () => {
@@ -32,6 +36,9 @@ describe('FirstBoot', () => {
   test('generates the owner card, marks setup complete, and shows the QR', async () => {
     const onComplete = vi.fn()
     const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
       if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
         return response({
           url: 'http://auth.spark.local/magic-link/first-token',
@@ -55,7 +62,7 @@ describe('FirstBoot', () => {
 
     render(<FirstBoot onComplete={onComplete} />)
 
-    finishWizard()
+    await finishWizard()
 
     expect(await screen.findByRole('heading', { name: /you're set/i })).toBeInTheDocument()
     const generateCall = fetchMock.mock.calls.find(([url]) => url === '/api/auth/magic-link/generate')
@@ -76,6 +83,9 @@ describe('FirstBoot', () => {
 
   test('does not show success when setup completion fails', async () => {
     const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
       if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
         return response({
           url: 'http://auth.spark.local/magic-link/first-token',
@@ -96,9 +106,42 @@ describe('FirstBoot', () => {
 
     render(<FirstBoot onComplete={vi.fn()} />)
 
-    finishWizard()
+    await finishWizard()
 
     await waitFor(() => expect(screen.getByText(/sentinel write failed/i)).toBeInTheDocument())
     expect(screen.queryByRole('heading', { name: /you're set/i })).not.toBeInTheDocument()
+  })
+
+  test('finishes setup without an owner card when LAN access is unavailable', async () => {
+    const onComplete = vi.fn()
+    const fetchMock = vi.fn(async (url) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response({
+          ready: false,
+          requires: 'dream-proxy',
+          reason: 'Dream Talk owner cards require dream-proxy.',
+        })
+      }
+      if (url === '/api/setup/complete') {
+        return response({ success: true })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={onComplete} />)
+
+    fireEvent.change(screen.getByDisplayValue('dream'), { target: { value: 'spark' } })
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    fireEvent.change(screen.getByPlaceholderText('alice'), { target: { value: 'sam' } })
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+    fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
+
+    expect(await screen.findByText(/owner cards require dream-proxy/i)).toBeInTheDocument()
+    fireEvent.click(screen.getByRole('button', { name: /^finish$/i }))
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1))
+    expect(fetchMock).toHaveBeenCalledWith('/api/setup/complete', { method: 'POST' })
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/auth/magic-link/generate', expect.anything())
   })
 })

--- a/dream-server/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Invites.jsx
@@ -78,16 +78,32 @@ export default function Invites() {
   const [showGuestCreate, setShowGuestCreate] = useState(false)
   const [generated, setGenerated] = useState(null)
   const [refreshing, setRefreshing] = useState(false)
+  const [ownerCardStatus, setOwnerCardStatus] = useState(null)
 
   const refresh = useCallback(async () => {
     setRefreshing(true)
     try {
-      const resp = await fetchJson('/api/auth/magic-link/list')
+      const [resp, ownerStatusResp] = await Promise.all([
+        fetchJson('/api/auth/magic-link/list'),
+        fetchJson('/api/auth/magic-link/owner-card/status'),
+      ])
       if (!resp.ok) throw new Error(`list failed: ${resp.status}`)
       const data = await resp.json()
+      if (ownerStatusResp.ok) {
+        setOwnerCardStatus(await ownerStatusResp.json())
+      } else {
+        setOwnerCardStatus({
+          ready: false,
+          reason: `Owner-card status unavailable (${ownerStatusResp.status})`,
+        })
+      }
       setTokens(data.tokens || [])
       setError(null)
     } catch (err) {
+      setOwnerCardStatus(current => current || {
+        ready: false,
+        reason: 'Owner-card status unavailable.',
+      })
       setError(err.message)
     } finally {
       setLoading(false)
@@ -126,6 +142,7 @@ export default function Invites() {
 
   const ownerTokens = tokens.filter(isOwnerToken)
   const guestTokens = tokens.filter(t => !isOwnerToken(t))
+  const ownerCardUnavailable = ownerCardStatus?.ready === false
 
   return (
     <div className="p-8">
@@ -170,15 +187,26 @@ export default function Invites() {
           </div>
           <button
             onClick={() => setShowOwnerCreate(true)}
-            className="inline-flex items-center justify-center gap-2 bg-theme-accent text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity"
+            disabled={ownerCardUnavailable}
+            className="inline-flex items-center justify-center gap-2 bg-theme-accent text-white px-4 py-2 rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
           >
             <Printer size={18} />
             Print owner card
           </button>
         </div>
 
+        {ownerCardUnavailable && (
+          <div className="mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100 flex items-start gap-2">
+            <AlertCircle size={16} className="mt-0.5 flex-shrink-0" />
+            <span>{ownerCardStatus.reason || 'Enable Dream proxy before generating owner cards.'}</span>
+          </div>
+        )}
+
         {ownerTokens.length === 0 ? (
-          <EmptyOwnerState onCreate={() => setShowOwnerCreate(true)} />
+          <EmptyOwnerState
+            onCreate={() => setShowOwnerCreate(true)}
+            disabled={ownerCardUnavailable}
+          />
         ) : (
           <div className="mt-5 space-y-3">
             {ownerTokens.map(t => (
@@ -221,6 +249,7 @@ export default function Invites() {
 
       {showOwnerCreate && (
         <CreateOwnerModal
+          ownerCardStatus={ownerCardStatus}
           onClose={() => setShowOwnerCreate(false)}
           onCreated={(record) => {
             setShowOwnerCreate(false)
@@ -272,7 +301,7 @@ function VoiceReadiness() {
   )
 }
 
-function EmptyOwnerState({ onCreate }) {
+function EmptyOwnerState({ onCreate, disabled }) {
   return (
     <div className="mt-5 rounded-xl border border-dashed border-theme-border p-6 text-center">
       <ShieldCheck size={32} className="mx-auto mb-3 text-theme-text-muted" />
@@ -282,7 +311,8 @@ function EmptyOwnerState({ onCreate }) {
       </p>
       <button
         onClick={onCreate}
-        className="inline-flex items-center gap-2 bg-theme-accent text-white px-4 py-2 rounded-lg hover:opacity-90 transition-opacity"
+        disabled={disabled}
+        className="inline-flex items-center gap-2 bg-theme-accent text-white px-4 py-2 rounded-lg hover:opacity-90 disabled:opacity-50 transition-opacity"
       >
         <Printer size={18} />
         Create owner card
@@ -355,15 +385,20 @@ function TokenRow({ token, onRevoke }) {
   )
 }
 
-function CreateOwnerModal({ onClose, onCreated }) {
+function CreateOwnerModal({ ownerCardStatus, onClose, onCreated }) {
   const [username, setUsername] = useState('')
   const [note, setNote] = useState('Factory owner card')
   const [submitting, setSubmitting] = useState(false)
   const [formError, setFormError] = useState(null)
+  const ownerCardUnavailable = ownerCardStatus?.ready === false
 
   const handleSubmit = async (e) => {
     e.preventDefault()
     setFormError(null)
+    if (ownerCardUnavailable) {
+      setFormError(ownerCardStatus.reason || 'Enable Dream proxy before generating owner cards.')
+      return
+    }
     const trimmed = username.trim()
     if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
       setFormError('Username may only contain letters, numbers, dot, dash, and underscore.')
@@ -407,8 +442,19 @@ function CreateOwnerModal({ onClose, onCreated }) {
             Owner cards are reusable until revoked and redirect to Dream Talk.
           </span>
         </label>
+        {ownerCardUnavailable && (
+          <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-amber-100 flex items-start gap-2">
+            <AlertCircle size={16} className="mt-0.5 flex-shrink-0" />
+            <span>{ownerCardStatus.reason || 'Enable Dream proxy before generating owner cards.'}</span>
+          </div>
+        )}
         <FormError message={formError} />
-        <ModalActions onCancel={onClose} submitting={submitting} submitLabel="Generate owner QR" disabled={!username.trim()} />
+        <ModalActions
+          onCancel={onClose}
+          submitting={submitting}
+          submitLabel="Generate owner QR"
+          disabled={!username.trim() || ownerCardUnavailable}
+        />
       </form>
     </Modal>
   )

--- a/dream-server/extensions/services/dashboard/src/pages/Invites.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Invites.test.jsx
@@ -9,6 +9,7 @@ const response = (body, status = 200) => ({
 })
 
 const future = new Date(Date.now() + 3_600_000).toISOString()
+const ownerCardReady = { ready: true, requires: 'dream-proxy', reason: '' }
 
 describe('Invites', () => {
   afterEach(() => {
@@ -36,6 +37,9 @@ describe('Invites', () => {
             note: 'factory card',
           }] : [],
         })
+      }
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
       }
       if (url === '/api/auth/magic-link/abc12345' && options.method === 'DELETE') {
         return response({ revoked: true })
@@ -66,6 +70,9 @@ describe('Invites', () => {
     const fetchMock = vi.fn(async (url, options = {}) => {
       if (url === '/api/auth/magic-link/list') {
         return response({ tokens: [] })
+      }
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
       }
       if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
         return response({
@@ -112,6 +119,9 @@ describe('Invites', () => {
       if (url === '/api/auth/magic-link/list') {
         return response({ tokens: [] })
       }
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
       if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
         return response({
           token: 'plain-secret-token',
@@ -155,6 +165,7 @@ describe('Invites', () => {
     Object.defineProperty(window, 'isSecureContext', { configurable: true, value: false })
     const fetchMock = vi.fn(async (url) => {
       if (url === '/api/auth/magic-link/list') return response({ tokens: [] })
+      if (url === '/api/auth/magic-link/owner-card/status') return response(ownerCardReady)
       throw new Error(`unexpected request: ${url}`)
     })
     vi.stubGlobal('fetch', fetchMock)
@@ -165,5 +176,26 @@ describe('Invites', () => {
     expect(screen.getByText(/Mobile browsers usually block live microphone access/i)).toBeInTheDocument()
 
     if (descriptor) Object.defineProperty(window, 'isSecureContext', descriptor)
+  })
+
+  test('warns and disables owner card creation when dream-proxy is unavailable', async () => {
+    const fetchMock = vi.fn(async (url) => {
+      if (url === '/api/auth/magic-link/list') return response({ tokens: [] })
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response({
+          ready: false,
+          requires: 'dream-proxy',
+          reason: 'Dream Talk owner cards require dream-proxy.',
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Invites />)
+
+    expect(await screen.findByText(/Dream Talk owner cards require dream-proxy/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Print owner card' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: 'Create owner card' })).toBeDisabled()
   })
 })


### PR DESCRIPTION
## Summary

Fixes #1387.

Owner-card generation now checks whether the LAN owner-card surface can actually be served before minting a Dream Talk QR URL. The Setup / Owner dashboard page also shows a warning and disables owner-card creation when `dream-proxy` is unavailable.

## Why

Owner-card QR links use `auth.<device>.local` and redirect to `talk.<device>.local/talk`, which depends on `dream-proxy`. When `dream-proxy` is disabled, the old flow could generate a valid-looking but unreachable QR code.

## Changes

- Add `/api/auth/magic-link/owner-card/status`.
- Check `dream-proxy` service presence and `/health` reachability for LAN owner cards.
- Reject owner LAN generation with HTTP 409 and an actionable message when proxy is unavailable.
- Keep `url_mode=public` owner cards working without `dream-proxy` when `DREAM_PUBLIC_URL` is configured.
- Show owner-card readiness in the dashboard Setup / Owner page and disable creation when unavailable.

## Validation

- `python -m pytest tests/test_magic_link.py -q`
- `python -m pytest tests/test_magic_link.py -k "owner_card or owner_lan or owner_public" -q`
- `python -m py_compile routers/magic_link.py tests/test_magic_link.py`
- `npm.cmd test -- --run src/pages/Invites.test.jsx`
- `npm.cmd run lint` (passes with 4 pre-existing warnings in `src/hooks/useVoiceAgent.js`)
- `npm.cmd run build`
- `git diff --check`