### PR TITLE
[codex] pin remaining github actions

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -15,10 +15,10 @@ jobs:
         working-directory: dream-server/extensions/services/dashboard
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: "20"
 
@@ -41,10 +41,10 @@ jobs:
         working-directory: dream-server/extensions/services/dashboard-api
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -19,7 +19,7 @@ jobs:
         working-directory: dream-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install PSScriptAnalyzer
         shell: pwsh

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -14,10 +14,10 @@ jobs:
     name: Lint Python with Ruff
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/lint-shell.yml
+++ b/.github/workflows/lint-shell.yml
@@ -14,7 +14,7 @@ jobs:
     name: Lint shell scripts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install ShellCheck
         run: |

--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -18,7 +18,7 @@ jobs:
         working-directory: dream-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -92,7 +92,7 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -167,7 +167,7 @@ jobs:
         working-directory: dream-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 

--- a/.github/workflows/openclaw-image-diff.yml
+++ b/.github/workflows/openclaw-image-diff.yml
@@ -38,7 +38,7 @@ jobs:
     env:
       OPENCLAW_IMAGE: ghcr.io/openclaw/openclaw:2026.3.8
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Pull openclaw image
         run: docker pull "$OPENCLAW_IMAGE"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -14,7 +14,7 @@ jobs:
     name: Scan for secrets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload gitleaks report (always)
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: gitleaks-report
           path: gitleaks-report.json

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -15,7 +15,7 @@ jobs:
         working-directory: dream-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Docs Link Checks
         run: bash tests/test-doc-links.sh
@@ -128,7 +128,7 @@ jobs:
         run: bash tests/test-support-bundle.sh
 
       - name: Upload Installer Simulation Artifacts
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: installer-sim
           path: |

--- a/.github/workflows/type-check-python.yml
+++ b/.github/workflows/type-check-python.yml
@@ -20,10 +20,10 @@ jobs:
     name: Type check with mypy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/validate-catalog.yml
+++ b/.github/workflows/validate-catalog.yml
@@ -22,10 +22,10 @@ jobs:
     name: Check catalog is up-to-date
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/validate-compose.yml
+++ b/.github/workflows/validate-compose.yml
@@ -26,7 +26,7 @@ jobs:
     name: Validate Docker Compose files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Validate main docker-compose.base.yml
         env:

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -20,7 +20,7 @@ jobs:
         working-directory: dream-server
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install jq
         run: sudo apt-get install -y -qq jq


### PR DESCRIPTION
## Summary

Pins the remaining GitHub Actions references that still used moving version tags.

## Changes

- Replaces unpinned `actions/checkout@v6`, `actions/setup-node@v6`, `actions/setup-python@v6`, and `actions/upload-artifact@v7` references with resolved commit SHAs.
- Keeps a version comment beside each pinned action for readability.

## Validation

- Resolved action tag SHAs with `git ls-remote` against the upstream `actions/*` repositories.
- Verified no remaining `uses: actions/{checkout,setup-node,setup-python,upload-artifact}@v...` references under `.github/workflows`.
- `git diff --check`

## Risk

CI-only change. No installer or runtime behavior changes.