### PR TITLE
[codex] polish version and agent template validation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dream Server Architecture
 
-> Version 2.4.0 | Fully local AI stack deployed on user hardware with a single command
+> Version 2.5.0 | Fully local AI stack deployed on user hardware with a single command
 
 ## Overview
 

--- a/dream-server/scripts/check-version-consistency.py
+++ b/dream-server/scripts/check-version-consistency.py
@@ -103,6 +103,13 @@ def main() -> int:
         ROOT / "installers/macos/lib/constants.sh",
         r'^DS_VERSION="([^"]+)"',
     )
+    add_regex_check(
+        checks,
+        errors,
+        "ARCHITECTURE.md version",
+        ROOT.parent / "ARCHITECTURE.md",
+        r"^> Version ([0-9]+\.[0-9]+\.[0-9]+)\s+\|",
+    )
 
     version_file = optional_version_file()
     if version_file is not None:

--- a/dream-server/tests/validate-agent-templates.py
+++ b/dream-server/tests/validate-agent-templates.py
@@ -1,15 +1,28 @@
 #!/usr/bin/env python3
 """
-M7 Agent Template Validation
-Tests that agent templates work reliably on local qwen2.5-32b-instruct via llama-server.
+M7 Agent Template Validation.
+
+Runs live prompt checks against a local OpenAI-compatible llama-server when it is
+available. By default, missing local model infrastructure is reported as SKIP so
+cold static audits do not fail because no Dream Server stack is running. Set
+DREAM_REQUIRE_AGENT_TEMPLATE_SERVER=1 to make that condition a hard failure.
 """
 
-import requests
-import time
-import sys
+from __future__ import annotations
 
-LLAMA_SERVER_URL = "http://localhost:8080"
-MODEL = "qwen2.5-32b-instruct"
+import os
+import sys
+import time
+
+import requests
+
+
+LLAMA_SERVER_URL = os.environ.get("DREAM_AGENT_TEMPLATE_BASE_URL", "http://localhost:8080")
+MODEL = os.environ.get("DREAM_AGENT_TEMPLATE_MODEL", "qwen2.5-32b-instruct")
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
 
 TEMPLATES = {
     "code-assistant": {
@@ -17,48 +30,57 @@ TEMPLATES = {
         "tests": [
             "Write a Python function to calculate factorial",
             "Debug this: for i in range(len(items)): print(items[i])",
-        ]
+        ],
     },
     "research-assistant": {
         "system": "You are a research assistant. Provide factual, well-sourced information.",
         "tests": [
             "Summarize what Python list comprehensions are",
             "Explain the difference between a stack and a queue",
-        ]
+        ],
     },
     "data-analyst": {
         "system": "You are a data analysis assistant. Help process and understand data.",
         "tests": [
             "How would you find the average of a list of numbers in Python?",
             "Explain what pandas DataFrame.describe() does",
-        ]
+        ],
     },
     "writing-assistant": {
         "system": "You are a writing assistant. Improve clarity and fix errors.",
         "tests": [
             "Fix the grammar: 'Their going to the store'",
             "Make this more concise: 'Due to the fact that it was raining, we decided to stay inside'",
-        ]
+        ],
     },
     "system-admin": {
         "system": "You are a system administration assistant. Help with Docker and Linux.",
         "tests": [
             "What command shows running Docker containers?",
             "How do you check disk usage on Linux?",
-        ]
-    }
+        ],
+    },
 }
 
 
+def server_available() -> bool:
+    """Return True when a local OpenAI-compatible model endpoint is reachable."""
+    try:
+        response = requests.get(f"{LLAMA_SERVER_URL}/v1/models", timeout=2)
+        return response.status_code < 500
+    except requests.RequestException:
+        return False
+
+
 def test_template(name: str, config: dict) -> dict:
-    """Test a single template"""
-    print(f"\n🧪 Testing {name}...")
+    """Test a single template."""
+    print(f"\n[TEST] {name}")
 
     results = {
         "template": name,
         "tests": [],
         "passed": 0,
-        "failed": 0
+        "failed": 0,
     }
 
     for test_prompt in config["tests"]:
@@ -66,10 +88,10 @@ def test_template(name: str, config: dict) -> dict:
             "model": MODEL,
             "messages": [
                 {"role": "system", "content": config["system"]},
-                {"role": "user", "content": test_prompt}
+                {"role": "user", "content": test_prompt},
             ],
             "max_tokens": 200,
-            "temperature": 0.7
+            "temperature": 0.7,
         }
 
         try:
@@ -77,7 +99,7 @@ def test_template(name: str, config: dict) -> dict:
             response = requests.post(
                 f"{LLAMA_SERVER_URL}/v1/chat/completions",
                 json=payload,
-                timeout=30
+                timeout=30,
             )
             elapsed = (time.time() - start) * 1000
 
@@ -85,48 +107,63 @@ def test_template(name: str, config: dict) -> dict:
                 data = response.json()
                 content = data["choices"][0]["message"]["content"]
 
-                # Basic validation - response should be non-empty and relevant
-                passed = len(content) > 50 and len(content) < 2000
+                # Basic validation: response should be non-empty and bounded.
+                passed = 50 < len(content) < 2000
 
-                results["tests"].append({
-                    "prompt": test_prompt[:50],
-                    "passed": passed,
-                    "time_ms": elapsed,
-                    "response_preview": content[:100]
-                })
+                results["tests"].append(
+                    {
+                        "prompt": test_prompt[:50],
+                        "passed": passed,
+                        "time_ms": elapsed,
+                        "response_preview": content[:100],
+                    }
+                )
 
                 if passed:
                     results["passed"] += 1
-                    print(f"  ✓ {test_prompt[:40]}... ({elapsed:.0f}ms)")
+                    print(f"  [PASS] {test_prompt[:40]}... ({elapsed:.0f}ms)")
                 else:
                     results["failed"] += 1
-                    print(f"  ✗ {test_prompt[:40]}... (empty or too long)")
+                    print(f"  [FAIL] {test_prompt[:40]}... (empty or too long)")
             else:
-                results["tests"].append({
+                results["tests"].append(
+                    {
+                        "prompt": test_prompt[:50],
+                        "passed": False,
+                        "error": f"HTTP {response.status_code}",
+                    }
+                )
+                results["failed"] += 1
+                print(f"  [FAIL] {test_prompt[:40]}... (HTTP {response.status_code})")
+
+        except Exception as exc:  # noqa: BLE001 - diagnostic script should continue
+            results["tests"].append(
+                {
                     "prompt": test_prompt[:50],
                     "passed": False,
-                    "error": f"HTTP {response.status_code}"
-                })
-                results["failed"] += 1
-                print(f"  ✗ {test_prompt[:40]}... (HTTP {response.status_code})")
-
-        except Exception as e:
-            results["tests"].append({
-                "prompt": test_prompt[:50],
-                "passed": False,
-                "error": str(e)
-            })
+                    "error": str(exc),
+                }
+            )
             results["failed"] += 1
-            print(f"  ✗ {test_prompt[:40]}... ({e})")
+            print(f"  [FAIL] {test_prompt[:40]}... ({exc})")
 
     return results
 
 
-def main():
+def main() -> int:
     print("=" * 60)
     print("M7 Agent Template Validation")
-    print("Testing on qwen2.5-32b-instruct")
+    print(f"Testing {MODEL} at {LLAMA_SERVER_URL}")
     print("=" * 60)
+
+    if not server_available():
+        message = f"LLM server unavailable at {LLAMA_SERVER_URL}"
+        if os.environ.get("DREAM_REQUIRE_AGENT_TEMPLATE_SERVER") == "1":
+            print(f"[FAIL] {message}")
+            return 1
+        print(f"[SKIP] {message}")
+        print("Set DREAM_REQUIRE_AGENT_TEMPLATE_SERVER=1 to make this a hard failure.")
+        return 0
 
     all_results = []
     total_passed = 0
@@ -138,24 +175,29 @@ def main():
         total_passed += result["passed"]
         total_failed += result["failed"]
 
-    # Summary
     print("\n" + "=" * 60)
     print("VALIDATION SUMMARY")
     print("=" * 60)
 
     for result in all_results:
-        status = "✅ PASS" if result["failed"] == 0 else "⚠️ PARTIAL" if result["passed"] > 0 else "❌ FAIL"
-        print(f"{result['template']:20} {status} ({result['passed']}/{result['passed']+result['failed']} tests)")
+        if result["failed"] == 0:
+            status = "[PASS]"
+        elif result["passed"] > 0:
+            status = "[PARTIAL]"
+        else:
+            status = "[FAIL]"
+        total = result["passed"] + result["failed"]
+        print(f"{result['template']:20} {status} ({result['passed']}/{total} tests)")
 
     print("-" * 60)
     print(f"Total: {total_passed} passed, {total_failed} failed")
 
     if total_failed == 0:
-        print("\n✅ All templates validated successfully!")
+        print("\n[PASS] All templates validated successfully!")
         return 0
-    else:
-        print(f"\n⚠️ {total_failed} tests failed - review needed")
-        return 1
+
+    print(f"\n[FAIL] {total_failed} tests failed - review needed")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Cleans up static-audit polish around version drift and live agent-template validation.

## Changes

- Updates `ARCHITECTURE.md` to the current Dream Server version (`2.5.0`).
- Adds the architecture doc version to `check-version-consistency.py` so this drift is caught by the release gate going forward.
- Rewrites `validate-agent-templates.py` output to be UTF-8/ASCII-safe on Windows consoles.
- Makes agent-template validation skip when no local OpenAI-compatible model server is running, unless `DREAM_REQUIRE_AGENT_TEMPLATE_SERVER=1` is set.
- Adds `DREAM_AGENT_TEMPLATE_BASE_URL` and `DREAM_AGENT_TEMPLATE_MODEL` overrides for explicit live validation runs.

## Validation

- `python dream-server/scripts/check-version-consistency.py`
- `python dream-server/tests/validate-agent-templates.py` (skips cleanly without local model server)
- `DREAM_REQUIRE_AGENT_TEMPLATE_SERVER=1 python dream-server/tests/validate-agent-templates.py` (hard-fails when server is absent)
- `python -m py_compile dream-server/tests/validate-agent-templates.py dream-server/scripts/check-version-consistency.py`
- `git diff --check`

## Risk

Low. Docs/test script only; no installer or runtime behavior changes.