### PR TITLE
[codex] polish runtime audit findings

### DIFF
--- a/dream-server/docker-compose.lemonade-external.yml
+++ b/dream-server/docker-compose.lemonade-external.yml
@@ -3,6 +3,19 @@
 # Use when Lemonade is already installed and running on the host. This overlay
 # keeps Dream Server's managed llama-server disabled and routes Dream services
 # through LiteLLM, which calls the existing Lemonade service.
+#
+# This file is intentionally not standalone. It is selected by
+# scripts/resolve-compose-stack.sh together with:
+#
+#   docker-compose.base.yml
+#   docker-compose.cloud.yml
+#   extensions/services/litellm/compose.yaml
+#   docker-compose.lemonade-external.yml
+#
+# Validate the resolved stack with:
+#
+#   LEMONADE_EXTERNAL=true DREAM_MODE=lemonade \
+#     ./scripts/resolve-compose-stack.sh --dream-mode lemonade --gpu-backend amd --tier SH_LARGE
 
 services:
   litellm:

--- a/dream-server/extensions/services/privacy-shield/proxy.py
+++ b/dream-server/extensions/services/privacy-shield/proxy.py
@@ -11,6 +11,7 @@ import time
 import httpx
 import secrets
 import hashlib
+from contextlib import asynccontextmanager
 from fastapi import FastAPI, Request, Depends, HTTPException, Security, WebSocket
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
@@ -93,7 +94,15 @@ async def verify_api_key(credentials: HTTPAuthorizationCredentials | None = Secu
     return credentials.credentials
 
 
-app = FastAPI(title="API Privacy Shield", version="0.2.0")
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    try:
+        yield
+    finally:
+        await http_client.aclose()
+
+
+app = FastAPI(title="API Privacy Shield", version="0.2.0", lifespan=lifespan)
 
 # Configuration from environment
 TARGET_API_BASE = os.getenv("TARGET_API_URL", "http://llama-server:8080/v1")
@@ -506,12 +515,6 @@ async def proxy_websocket(client_ws: WebSocket, path: str):
             await client_ws.close(code=1011)
         except RuntimeError:
             pass
-
-
-@app.on_event("shutdown")
-async def shutdown():
-    """Cleanup on shutdown."""
-    await http_client.aclose()
 
 
 if __name__ == "__main__":

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -43,6 +43,9 @@ bash tests/contracts/test-port-contracts.sh
 echo "[contract] Windows AMD local compose readiness"
 bash tests/contracts/test-windows-amd-local-compose.sh
 
+echo "[contract] external Lemonade compose overlay readiness"
+bash tests/contracts/test-external-lemonade-contracts.sh
+
 echo "[contract] bootstrap hot-swap force-recreate"
 bash tests/test-bootstrap-upgrade-hotswap-contract.sh
 


### PR DESCRIPTION
## Summary

Cleans up two narrow runtime-adjacent audit findings: Privacy Shield FastAPI shutdown handling and external Lemonade overlay validation visibility.

## Changes

- Replaces Privacy Shield's deprecated FastAPI `@app.on_event("shutdown")` hook with a lifespan handler that closes the shared `httpx.AsyncClient`.
- Documents that `docker-compose.lemonade-external.yml` is an overlay selected by `scripts/resolve-compose-stack.sh`, not a standalone compose file.
- Adds the external Lemonade contract to the installer contract suite so the resolved overlay stack is validated in CI.

## Validation

- `python -m pytest tests -q` in `dream-server/extensions/services/privacy-shield` (`50 passed`)
- `python -m py_compile dream-server/extensions/services/privacy-shield/proxy.py`
- `DREAM_PYTHON_CMD=python bash tests/contracts/test-external-lemonade-contracts.sh` via Git Bash (`PASS`)
- `git diff --check`

## Risk

Low to medium-low. Privacy Shield behavior is unchanged aside from using FastAPI's current lifespan API. The Lemonade change is documentation plus CI contract coverage for an already-supported resolver path.