### PR TITLE
[codex] polish docs and CI trust signals

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,38 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/installer"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "cargo"
+    directory: "/installer/src-tauri"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/dream-server/extensions/services/dashboard"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/dream-server/extensions/services/dashboard-api"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/dream-server/extensions/services/privacy-shield"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/dream-server/extensions/services/token-spy"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "pip"
+    directory: "/dream-server/extensions/services/ape"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,8 +24,13 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="8.28.0"
-          curl -sSL -o gitleaks.tgz "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz"
-          tar -xzf gitleaks.tgz gitleaks
+          ASSET="gitleaks_${VERSION}_linux_x64.tar.gz"
+          CHECKSUMS="gitleaks_${VERSION}_checksums.txt"
+          BASE_URL="https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}"
+          curl -sSLO "${BASE_URL}/${ASSET}"
+          curl -sSLO "${BASE_URL}/${CHECKSUMS}"
+          grep " ${ASSET}$" "${CHECKSUMS}" | sha256sum -c -
+          tar -xzf "${ASSET}" gitleaks
           sudo mv gitleaks /usr/local/bin/gitleaks
           gitleaks version
 

--- a/dream-server/SECURITY.md
+++ b/dream-server/SECURITY.md
@@ -8,7 +8,7 @@ Security best practices for running Dream Server.
 
 1. **Run `./install.sh`** — generates secure random secrets automatically
 2. **Never use default passwords** — if you see "changeme", change it
-3. **Bind to localhost only** — exposed by default for a reason
+3. **Keep the default localhost binding** — opt into LAN exposure only when you understand the firewall and authentication tradeoffs
 
 ---
 

--- a/dream-server/extensions/services/dashboard-api/README.md
+++ b/dream-server/extensions/services/dashboard-api/README.md
@@ -141,14 +141,14 @@ Core services cannot be installed, enabled, disabled, or uninstalled via these e
 
 ## Authentication
 
-When `DASHBOARD_API_KEY` is set in `.env`, all authenticated endpoints require the key:
+Protected endpoints always require Bearer authentication. When `DASHBOARD_API_KEY` is set in `.env`, use that key:
 
 ```bash
 curl http://localhost:3002/api/status \
   -H "Authorization: Bearer YOUR_KEY"
 ```
 
-When `DASHBOARD_API_KEY` is empty (default), all endpoints are accessible without authentication.
+When `DASHBOARD_API_KEY` is empty, dashboard-api generates a random key at startup, writes it to `/data/dashboard-api-key.txt` with mode `0600`, and still requires Bearer authentication for protected endpoints.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary
- verify the downloaded gitleaks release asset against upstream checksums before executing it in CI
- expand Dependabot coverage to installer npm, Tauri Cargo, dashboard npm, and Python services
- fix stale security/auth docs around localhost exposure and dashboard-api generated keys

## Validation
- git diff --check
- verified the gitleaks checksum command against the v8.28.0 release asset (Linux binary extraction succeeds; execution is Linux-only from CI)