### PR TITLE
[codex] add desktop installer guardrails

### DIFF
--- a/installer/src-tauri/src/commands.rs
+++ b/installer/src-tauri/src/commands.rs
@@ -1,7 +1,9 @@
-use crate::{docker, gpu, installer, platform};
 use crate::state::{GpuInfo, InstallPhase, InstallState};
+use crate::{docker, gpu, installer, platform};
 use serde::Serialize;
 use std::sync::Mutex;
+
+const ALLOWED_FEATURES: &[&str] = &["voice", "workflows", "rag", "image_gen", "all"];
 
 // ---- System Check ----
 
@@ -18,7 +20,11 @@ pub fn check_system() -> SystemCheckResult {
     let requirements = platform::check_requirements(&system);
     let docker = docker::check();
 
-    SystemCheckResult { system, requirements, docker }
+    SystemCheckResult {
+        system,
+        requirements,
+        docker,
+    }
 }
 
 // ---- Prerequisites ----
@@ -154,6 +160,8 @@ pub async fn start_install(
     features: Vec<String>,
     install_dir: Option<String>,
 ) -> Result<String, String> {
+    validate_install_request(tier, &features)?;
+
     let dir = install_dir
         .map(std::path::PathBuf::from)
         .unwrap_or_else(installer::default_install_dir);
@@ -169,12 +177,24 @@ pub async fn start_install(
     let state_clone = state.clone();
 
     // Run installation in a blocking thread
-    tokio::task::spawn_blocking(move || {
-        installer::run_install(state_clone, dir, tier, features)
-    })
-    .await
-    .map_err(|e| format!("Install task failed: {}", e))?
-    .map(|_| "Installation complete!".to_string())
+    tokio::task::spawn_blocking(move || installer::run_install(state_clone, dir, tier, features))
+        .await
+        .map_err(|e| format!("Install task failed: {}", e))?
+        .map(|_| "Installation complete!".to_string())
+}
+
+fn validate_install_request(tier: u8, features: &[String]) -> Result<(), String> {
+    if tier > 4 {
+        return Err(format!("Unsupported install tier: {}", tier));
+    }
+
+    for feature in features {
+        if !ALLOWED_FEATURES.contains(&feature.as_str()) {
+            return Err(format!("Unsupported feature: {}", feature));
+        }
+    }
+
+    Ok(())
 }
 
 // ---- Progress ----

--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -1,12 +1,17 @@
 use crate::state::{InstallPhase, InstallState};
 use serde::Serialize;
 use std::io::{BufRead, BufReader};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
 const REPO_URL: &str = "https://github.com/Light-Heart-Labs/DreamServer.git";
+const DEFAULT_INSTALL_REF: &str = "v2.5.0";
+
+fn install_ref() -> &'static str {
+    option_env!("DREAMSERVER_INSTALL_REF").unwrap_or(DEFAULT_INSTALL_REF)
+}
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ProgressEvent {
@@ -26,25 +31,7 @@ pub fn run_install(
     // Phase 1: Clone the repo
     update_progress(&state, "Downloading DreamServer", 5);
 
-    if !install_dir.join("dream-server").exists() {
-        let clone = Command::new("git")
-            .args([
-                "clone",
-                "--depth",
-                "1",
-                REPO_URL,
-                &install_dir.to_string_lossy(),
-            ])
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .output()
-            .map_err(|e| format!("Failed to clone repository: {}", e))?;
-
-        if !clone.status.success() {
-            let err = String::from_utf8_lossy(&clone.stderr);
-            return Err(format!("Git clone failed: {}", err));
-        }
-    }
+    ensure_checkout(&install_dir)?;
 
     update_progress(&state, "Configuring installation", 15);
 
@@ -176,6 +163,97 @@ pub fn run_install(
             Err(format!("Installation failed:\n{}", detail))
         }
     }
+}
+
+fn ensure_checkout(install_dir: &Path) -> Result<(), String> {
+    if install_dir.join("dream-server").exists() {
+        return validate_checkout(install_dir);
+    }
+
+    if install_dir.exists()
+        && install_dir
+            .read_dir()
+            .map_err(|e| e.to_string())?
+            .next()
+            .is_some()
+    {
+        return Err(format!(
+            "{} already exists but is not a DreamServer checkout. Choose an empty directory or the existing DreamServer install directory.",
+            install_dir.display()
+        ));
+    }
+
+    let clone = Command::new("git")
+        .args(["clone", "--depth", "1", "--branch", install_ref(), REPO_URL])
+        .arg(install_dir)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to clone repository: {}", e))?;
+
+    if !clone.status.success() {
+        let err = String::from_utf8_lossy(&clone.stderr);
+        return Err(format!("Git clone failed: {}", err));
+    }
+
+    validate_checkout(install_dir)
+}
+
+fn validate_checkout(install_dir: &Path) -> Result<(), String> {
+    if !install_dir.join(".git").exists() {
+        return Err(format!(
+            "{} contains a dream-server directory but is not a git checkout. Refusing to run installer scripts from an unverified directory.",
+            install_dir.display()
+        ));
+    }
+
+    let is_work_tree = run_git(install_dir, &["rev-parse", "--is-inside-work-tree"])?;
+    if is_work_tree.trim() != "true" {
+        return Err(format!(
+            "{} is not a valid git worktree.",
+            install_dir.display()
+        ));
+    }
+
+    let origin = run_git(install_dir, &["remote", "get-url", "origin"])?;
+    if normalize_repo_url(&origin) != normalize_repo_url(REPO_URL) {
+        return Err(format!(
+            "{} is not a DreamServer checkout from {}.",
+            install_dir.display(),
+            REPO_URL
+        ));
+    }
+
+    Ok(())
+}
+
+fn run_git(install_dir: &Path, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(install_dir)
+        .args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .map_err(|e| format!("Failed to run git: {}", e))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+fn normalize_repo_url(url: &str) -> String {
+    let trimmed = url.trim().trim_end_matches('/');
+    let https = if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
+        format!("https://github.com/{rest}")
+    } else if let Some(rest) = trimmed.strip_prefix("ssh://git@github.com/") {
+        format!("https://github.com/{rest}")
+    } else {
+        trimmed.to_string()
+    };
+    https.trim_end_matches(".git").to_ascii_lowercase()
 }
 
 /// Parse a progress line from the installer.

--- a/installer/src-tauri/src/state.rs
+++ b/installer/src-tauri/src/state.rs
@@ -72,8 +72,21 @@ impl InstallState {
 
     pub fn save(&self) -> Result<(), String> {
         let path = Self::state_path();
+        let tmp = path.with_extension("json.tmp");
         let json = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
-        fs::write(path, json).map_err(|e| e.to_string())
+        fs::write(&tmp, json).map_err(|e| e.to_string())?;
+        match fs::rename(&tmp, &path) {
+            Ok(()) => Ok(()),
+            Err(err) if path.exists() => {
+                fs::remove_file(&path).map_err(|remove_err| remove_err.to_string())?;
+                fs::rename(&tmp, &path).map_err(|rename_err| {
+                    format!(
+                        "Failed to replace installer state after rename error ({err}): {rename_err}"
+                    )
+                })
+            }
+            Err(err) => Err(err.to_string()),
+        }
     }
 }
 


### PR DESCRIPTION
﻿## Summary

Adds narrow guardrails around the Tauri desktop installer trust boundary:

- validates Tauri install command inputs before starting privileged installer work
- pins the cloned DreamServer checkout to the release ref compiled into the installer build, defaulting to `v2.5.0`
- refuses to run installer scripts from arbitrary non-empty or non-DreamServer directories
- verifies an existing checkout is a git worktree from the expected DreamServer origin before using it
- writes installer progress state through a temp file before replacing the visible JSON file

## Why

Cold audit feedback called out the desktop installer as a sensitive surface. This keeps the GUI installer on a known source ref, avoids executing stale/unrelated local scripts, and prevents partial progress JSON reads during polling.

## Validation

- `git diff --check`
- confirmed `v2.5.0` exists with `git ls-remote --tags origin v2.5.0`
- `npm.cmd ci` in `installer/`
- `npm.cmd run build` in `installer/`
- `npm.cmd audit` in `installer/` (0 vulnerabilities)
- `rustfmt +stable-x86_64-pc-windows-gnu --edition 2021 --check src/commands.rs src/installer.rs src/state.rs`
- `cargo +stable-x86_64-pc-windows-gnu check --locked`
- `npm.cmd run tauri -- build --debug --target x86_64-pc-windows-gnu --no-bundle --ci`

Note: `cargo check` reports the pre-existing `InstallState::load` dead-code warning.
