### PR TITLE
[codex] document installer trust paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Linux and macOS:
 curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/dream-server/get-dream-server.sh | bash
 ```
 
+Prefer to inspect before running or pin a release tag? See
+[Installer Trust](dream-server/docs/INSTALLER_TRUST.md).
+
 Windows users should use the PowerShell installer shown below or follow the [Windows Quickstart](dream-server/docs/WINDOWS-QUICKSTART.md).
 
 After install, open **http://localhost:3000** and start chatting.
@@ -412,6 +415,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
 | [Release Validation](dream-server/docs/RELEASE_VALIDATION.md) | User Green gates and the release-grade fleet/distro validation policy |
 | [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
+| [Installer Trust](dream-server/docs/INSTALLER_TRUST.md) | Inspect-first install paths, ref pinning, and current provenance limits |
 | [Model Management](dream-server/docs/MODEL-MANAGEMENT.md) | Dashboard model downloads, switching, and manual GGUF workflows |
 | [Hardware Guide](dream-server/docs/HARDWARE-GUIDE.md) | What to buy, tier recommendations |
 | [FAQ](dream-server/FAQ.md) | Common questions and configuration |

--- a/dream-server/docs/INSTALLER_TRUST.md
+++ b/dream-server/docs/INSTALLER_TRUST.md
@@ -1,0 +1,112 @@
+# Installer Trust And Provenance
+
+Dream Server installers set up Docker services, write local config, generate
+secrets, and may install missing prerequisites. Treat them like any other
+infrastructure installer: inspect the source, pin a release when you want
+reproducibility, and keep the default localhost security posture unless you
+intentionally expose services to your LAN.
+
+## Install Paths
+
+### Public Linux/macOS Bootstrap
+
+The README one-liner downloads this bootstrap script from GitHub:
+
+```bash
+https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/dream-server/get-dream-server.sh
+```
+
+That script:
+
+- detects Linux, WSL, or macOS;
+- installs or checks basic prerequisites where supported;
+- clones `https://github.com/Light-Heart-Labs/DreamServer.git` with sparse
+  checkout for the `dream-server/` product tree;
+- copies the runtime product files into `~/dream-server`;
+- runs `./install.sh` from that copied runtime tree.
+
+By default the bootstrap follows `main`. To pin a release tag or branch, set
+`DREAMSERVER_REF` before running the script:
+
+```bash
+DREAMSERVER_REF=v2.5.0 bash get-dream-server.sh
+```
+
+### Manual Source Install
+
+For the most auditable path, clone a known ref yourself and run the installer
+from the checked-out source:
+
+```bash
+git clone --depth 1 --branch v2.5.0 https://github.com/Light-Heart-Labs/DreamServer.git
+cd DreamServer/dream-server
+./install.sh
+```
+
+Use this path when you want to review diffs, pin an exact release tag, or make
+local modifications before install.
+
+### Windows PowerShell Install
+
+Windows users should install from a normal user PowerShell, not an elevated
+Administrator shell:
+
+```powershell
+git clone --depth 1 --branch v2.5.0 https://github.com/Light-Heart-Labs/DreamServer.git
+cd DreamServer\dream-server
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\install.ps1
+```
+
+The PowerShell installer writes runtime state under
+`$env:USERPROFILE\dream-server` by default, or `$env:DREAM_HOME` if set.
+
+### Desktop Installer
+
+The Tauri desktop installer is a convenience wrapper around the source
+installer flow. For maximum provenance control, prefer the manual source
+install above until you have reviewed the desktop installer build you are using.
+
+## Inspect Before Running
+
+If you do not want to pipe a remote script directly into a shell, download and
+inspect it first:
+
+```bash
+curl -fsSLO https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/dream-server/get-dream-server.sh
+less get-dream-server.sh
+DREAMSERVER_REF=v2.5.0 bash get-dream-server.sh
+```
+
+On Windows, clone first and inspect `install.ps1` before running it:
+
+```powershell
+git clone --depth 1 --branch v2.5.0 https://github.com/Light-Heart-Labs/DreamServer.git
+cd DreamServer\dream-server
+notepad .\install.ps1
+.\install.ps1
+```
+
+## Current Trust Boundary
+
+Dream Server currently relies on:
+
+- GitHub-hosted source and HTTPS transport;
+- release tags or explicit refs for reproducible source selection;
+- local generated secrets instead of checked-in default credentials;
+- localhost-first service binding by default;
+- release validation across zero-prereq distro bootstrap, real hardware
+  installs, product behavior, full-model capabilities, and lifecycle recovery.
+
+Dream Server does not yet publish a full signed-release or checksum/SBOM chain
+for every installer artifact. That is the next stronger trust model. Until then,
+users who need strict provenance should install from a reviewed tag or internal
+fork and record the exact commit or release tag they deployed.
+
+## Related Validation
+
+- [Release Validation](RELEASE_VALIDATION.md) explains the User Green gates.
+- [Validation Matrix](VALIDATION-MATRIX.md) summarizes the hardware, distro,
+  capability, and lifecycle evidence.
+- [Security](../SECURITY.md) documents localhost defaults, LAN tradeoffs, and
+  disclosure guidance.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -12,7 +12,7 @@ at [`../../README.md`](../../README.md).
 
 | I want to... | Read this first | Then use |
 |--------------|-----------------|----------|
-| Install the default path | [../QUICKSTART.md](../QUICKSTART.md) | [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md), [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) |
+| Install the default path | [../QUICKSTART.md](../QUICKSTART.md) | [INSTALLER_TRUST.md](INSTALLER_TRUST.md), [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md), [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) |
 | Install on Windows | [WINDOWS-QUICKSTART.md](WINDOWS-QUICKSTART.md) | [WINDOWS-INSTALL-WALKTHROUGH.md](WINDOWS-INSTALL-WALKTHROUGH.md), [WINDOWS-WSL2-GPU-GUIDE.md](WINDOWS-WSL2-GPU-GUIDE.md) |
 | Install on Apple Silicon | [MACOS-QUICKSTART.md](MACOS-QUICKSTART.md) | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md) |
 | Debug a broken install | [DREAM-DOCTOR.md](DREAM-DOCTOR.md) | [INSTALL-TROUBLESHOOTING.md](INSTALL-TROUBLESHOOTING.md), [SUPPORT-BUNDLE.md](SUPPORT-BUNDLE.md) |
@@ -52,6 +52,7 @@ at [`../../README.md`](../../README.md).
 | [../../README.md](../../README.md) | Everyone | GitHub landing page and public project overview |
 | [../README.md](../README.md) | Everyone | Product README, quickstart, architecture, and operator overview |
 | [../QUICKSTART.md](../QUICKSTART.md) | Operators | Step-by-step first install |
+| [INSTALLER_TRUST.md](INSTALLER_TRUST.md) | Operators / reviewers | Inspect-first install paths, release ref pinning, and current provenance limits |
 | [HEADLESS-SETUP.md](HEADLESS-SETUP.md) | Operators / hardware builders | Hardware-neutral QR onboarding, first-boot setup, AP mode, mDNS, and local-agent access map |
 | [../EDGE-QUICKSTART.md](../EDGE-QUICKSTART.md) | Operators | Edge devices (planned — do not follow yet; use cloud mode for CPU-only today) |
 | [../.env.example](../.env.example) | Operators | All environment variables with defaults |


### PR DESCRIPTION
﻿## Summary

Adds a public installer trust/provenance note and links it from the root README and docs index.

The new doc covers:

- what the public Linux/macOS bootstrap downloads and runs
- how to inspect the bootstrap script before executing it
- how to pin a release tag or branch with `DREAMSERVER_REF`
- manual source install paths for Linux/macOS and Windows
- the current trust boundary: GitHub source transport, generated local secrets, localhost-first defaults, and release validation
- the honest current limitation that Dream Server does not yet publish a full signed-release or checksum/SBOM chain for every installer artifact

## Why

Cold clone-and-audit reviews keep asking the right question: "what exactly does the installer fetch, and how do I inspect or pin it?" This gives prospective users and auditors a concise answer without overclaiming.

## Validation

- `git diff --cached --check`
- checked linked paths exist for README/doc references
- docs-only change; no installer/runtime code changed
