### PR TITLE
[codex] group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,38 +4,99 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directory: "/installer"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      installer-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "cargo"
     directory: "/installer/src-tauri"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      tauri-cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "npm"
     directory: "/dream-server/extensions/services/dashboard"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      dashboard-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 
   - package-ecosystem: "pip"
     directory: "/dream-server/extensions/services/dashboard-api"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      dashboard-api-python:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/dream-server/extensions/services/privacy-shield"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      privacy-shield-python:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/dream-server/extensions/services/token-spy"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      token-spy-python:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/dream-server/extensions/services/ape"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      ape-python:
+        patterns:
+          - "*"


### PR DESCRIPTION
﻿## Summary

Tames the initial Dependabot flood by grouping routine updates and limiting each configured ecosystem/path to one open Dependabot PR at a time.

- groups GitHub Actions into one PR
- groups installer npm minor/patch updates into one PR
- groups Tauri Cargo minor/patch updates into one PR
- groups dashboard npm minor/patch updates into one PR
- groups each watched Python service into one PR
- ignores semver-major updates for npm/Cargo ecosystems so migrations like Tailwind 4, Vite 8, ESLint 10, and major Rust utility bumps do not appear as routine maintenance PRs

## Why

Expanding Dependabot coverage was useful, but it immediately opened dozens of standalone PRs. Grouping keeps the dependency signal while making review/merge policy sane.

## Validation

- `git diff --check`
- parsed `.github/dependabot.yml` with PyYAML
- verified each configured update block has `open-pull-requests-limit` and `groups`
