### PR TITLE
[codex] document forkable infrastructure operations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,16 @@ No CLA, no hoops.
 
 Building on Dream Server for a hardware appliance, lab image, vertical bundle,
 or downstream distribution? Start with
+**[dream-server/docs/FORKABILITY.md](dream-server/docs/FORKABILITY.md)** and
 **[dream-server/docs/BUILD-ON-DREAM-SERVER.md](dream-server/docs/BUILD-ON-DREAM-SERVER.md)**.
-It explains the extension points, source-of-truth files, validation commands,
-and rebase-friendly patterns that keep custom work easy to maintain.
+They explain the extension points, source-of-truth files, validation commands,
+independent operation posture, and rebase-friendly patterns that keep custom
+work easy to maintain.
+
+For changes to installer, compose, lifecycle, auth, model routing, or host
+mutation surfaces, use
+**[dream-server/docs/HIGH_RISK_CHANGE_MAP.md](dream-server/docs/HIGH_RISK_CHANGE_MAP.md)**
+to choose the right validation before opening a PR.
 
 ## Full Contributor Guide
 

--- a/README.md
+++ b/README.md
@@ -411,16 +411,23 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | [Quickstart](dream-server/QUICKSTART.md) | Step-by-step install guide with troubleshooting |
 | [Docs Index](dream-server/docs/README.md) | Maintained map for operators, contributors, and reviewers |
 | [Build On Dream Server](dream-server/docs/BUILD-ON-DREAM-SERVER.md) | Forking, custom editions, extension templates, and downstream validation |
+| [Forkability](dream-server/docs/FORKABILITY.md) | How to fork, audit, customize, and independently operate Dream Server |
+| [Maintainer Runbook](dream-server/docs/MAINTAINER_RUNBOOK.md) | Release, rollback, validation, and handoff guidance for maintainers and fork operators |
+| [High-Risk Change Map](dream-server/docs/HIGH_RISK_CHANGE_MAP.md) | Which changes require focused checks, fleet validation, or release-grade gates |
 | [Headless Setup](dream-server/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |
 | [Release Validation](dream-server/docs/RELEASE_VALIDATION.md) | User Green gates and the release-grade fleet/distro validation policy |
 | [Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md) | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
+| [Validation Reproducibility](dream-server/docs/VALIDATION_REPRODUCIBILITY.md) | How forks and operators can reproduce the validation story on their own hardware |
+| [Offline And Mirroring](dream-server/docs/OFFLINE_AND_MIRRORING.md) | Pinning, mirroring, and preserving release artifacts for independent operation |
 | [Installer Trust](dream-server/docs/INSTALLER_TRUST.md) | Inspect-first install paths, ref pinning, and current provenance limits |
 | [Model Management](dream-server/docs/MODEL-MANAGEMENT.md) | Dashboard model downloads, switching, and manual GGUF workflows |
 | [Hardware Guide](dream-server/docs/HARDWARE-GUIDE.md) | What to buy, tier recommendations |
 | [FAQ](dream-server/FAQ.md) | Common questions and configuration |
 | [Extensions](dream-server/docs/EXTENSIONS.md) | How to add custom services |
 | [Installer Architecture](dream-server/docs/INSTALLER-ARCHITECTURE.md) | Modular installer deep dive |
+| [Installer Phase Contracts](dream-server/docs/INSTALLER_PHASE_CONTRACTS.md) | Phase ownership, idempotency, failure modes, and validation expectations |
+| [Compose Resolver Contracts](dream-server/docs/COMPOSE_RESOLVER_CONTRACTS.md) | Rules for compose layers, extensions, backends, ports, and mode overlays |
 | [Changelog](dream-server/CHANGELOG.md) | Version history and release notes |
 | [Contributing](CONTRIBUTING.md) | How to contribute |
 

--- a/dream-server/docs/BUILD-ON-DREAM-SERVER.md
+++ b/dream-server/docs/BUILD-ON-DREAM-SERVER.md
@@ -3,6 +3,12 @@
 This guide is for people who want to fork Dream Server, ship a custom edition,
 build a hardware appliance, or add services without fighting the upstream repo.
 
+For the higher-level independent operation posture, start with
+[FORKABILITY.md](FORKABILITY.md). For offline, mirrored, or appliance-style
+distribution, see [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md). For
+validation receipts in a fork, see
+[VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md).
+
 Dream Server is designed to be extended through isolated service directories,
 compose overlays, versioned manifests, and installer libraries. The safest path
 is to keep custom work in those extension points and avoid patching generated

--- a/dream-server/docs/COMPOSE_RESOLVER_CONTRACTS.md
+++ b/dream-server/docs/COMPOSE_RESOLVER_CONTRACTS.md
@@ -1,0 +1,120 @@
+# Compose Resolver Contracts
+
+Dream Server assembles its runtime from a base compose file, hardware overlays,
+mode overlays, and extension compose fragments. This document defines the
+expected contract so maintainers and forks can add services or backends without
+breaking unrelated install paths.
+
+## Compose Layer Model
+
+The resolved stack is built from these layers:
+
+1. Base stack: common networks, volumes, and core services.
+2. Hardware overlays: NVIDIA, AMD/Lemonade, Apple Silicon, Intel Arc, CPU, or
+   other backend-specific runtime settings.
+3. Mode overlays: local, cloud, hybrid, external Lemonade, or other routing
+   modes.
+4. Extension fragments: enabled service `compose.yaml` files and optional GPU
+   overlays.
+5. Operator overrides: local environment variables and supported flags.
+
+The resolver, installer, CLI, dashboard, and validation tests should agree on
+the same file set for a given mode and hardware class.
+
+## Resolver Rules
+
+- Do not require users to hand-compose files for supported install modes.
+- Do not make a compose fragment valid only by accident of local state.
+- A service referenced by `depends_on` must exist in every resolved file set
+  that includes that dependency.
+- Optional services should be gated by install/profile state, not by relying on
+  missing files.
+- Host ports must be declared through the port contract where applicable.
+- Internal container ports should stay stable unless every dependent service and
+  generated config writer is updated.
+- Hardware overlays should change runtime flags, devices, images, or build
+  targets only for the relevant backend.
+
+## Adding A Service
+
+Use the extension path unless the service is a core boot dependency.
+
+Required files:
+
+```text
+extensions/services/<service-id>/manifest.yaml
+extensions/services/<service-id>/compose.yaml
+```
+
+Recommended validation:
+
+```bash
+python scripts/audit-extensions.py --project-dir . <service-id>
+python scripts/audit-extensions.py --project-dir .
+docker compose -f docker-compose.base.yml -f extensions/services/<service-id>/compose.yaml config
+```
+
+If the service needs GPU-specific runtime flags, add backend overlays in the
+service directory instead of modifying unrelated global overlays.
+
+## Adding A Backend Or Mode
+
+When adding a backend or mode:
+
+1. Define the backend contract or mode behavior.
+2. Add the compose overlay.
+3. Update installer detection and compose selection.
+4. Update generated config writers.
+5. Update dashboard-api service/status assumptions if needed.
+6. Add resolver validation for the exact file set.
+7. Add support matrix and validation docs.
+
+Backends commonly touch more than compose. Model selection, service URLs, health
+checks, and dashboard diagnostics often need matching updates.
+
+## Dependency Placeholders
+
+Sometimes a mode uses an external or native process where another compose layer
+expects a service name. If a placeholder is needed:
+
+- document why it exists;
+- avoid host port bindings when the placeholder never runs;
+- keep health semantics honest;
+- validate restart and reinstall behavior;
+- prefer a ready-sidecar only when it checks a real external endpoint.
+
+Placeholders should satisfy the compose dependency graph without claiming a
+container is doing work that actually happens elsewhere.
+
+## Port And Network Policy
+
+- Default user-facing services should bind to localhost unless a LAN path is
+  explicitly enabled.
+- LAN and owner-card routes should use the documented proxy path.
+- Internal service-to-service traffic should use container DNS and internal
+  ports.
+- Host-facing port defaults belong in `config/ports.json` and service manifests.
+- Dashboard/API docs should match the actual auth and binding behavior.
+
+Run the network exposure contract tests when changing host bindings or proxy
+routes.
+
+## Validation Commands
+
+Use focused checks while developing:
+
+```bash
+python scripts/validate-golden-paths.py
+python scripts/validate-generated-configs.py
+python scripts/audit-extensions.py --project-dir .
+```
+
+Then validate representative compose sets for changed modes. For operational
+changes, use the release-grade gate described in
+[RELEASE_VALIDATION.md](RELEASE_VALIDATION.md).
+
+## Manual Compose Use
+
+Manual compose commands are useful for debugging, but supported users should not
+need to know the full file set. If a doc shows a manual compose command, include
+all required base, mode, hardware, and extension files or point to the resolver.

--- a/dream-server/docs/FORKABILITY.md
+++ b/dream-server/docs/FORKABILITY.md
@@ -1,0 +1,146 @@
+# Forkability And Independent Operation
+
+Dream Server is Apache-licensed infrastructure. Upstream should be useful, but it
+should not be the only place where the system can be understood, operated, or
+kept alive.
+
+This document describes the project posture for downstream maintainers,
+hardware builders, labs, schools, companies, and individuals who want to fork,
+mirror, audit, customize, or run Dream Server independently.
+
+## Goals
+
+Dream Server should be:
+
+- forkable without asking upstream for permission;
+- auditable from a cold clone;
+- customizable through documented extension points;
+- recoverable from pinned refs and mirrored artifacts;
+- validated by repeatable public and private test layers;
+- understandable by maintainers who did not write the original installer.
+
+Upstream is one implementation and coordination point. It is not meant to be a
+single point of control.
+
+## What To Fork
+
+Fork the repository when you need a durable downstream edition, such as:
+
+- a hardware appliance image with fixed service defaults;
+- a lab or school distribution with curated models and workflows;
+- a company-local appliance with private extensions;
+- a research workstation image with extra tooling;
+- an offline or low-connectivity distribution;
+- a security-reviewed variant with stricter policies.
+
+For smaller changes, prefer extensions, model catalogs, presets, and docs over
+patching installer internals. A small extension is easier to keep current than a
+large fork.
+
+## Recommended Fork Strategy
+
+Use upstream `main` or a release tag as the source of truth, then keep your
+customization layer small and explicit.
+
+Recommended downstream layout:
+
+```text
+extensions/services/<your-service>/
+extensions/library/services/<your-library-service>/
+docs/<your-edition>/
+config/<your-edition>/
+DOWNSTREAM.md
+```
+
+Keep a `DOWNSTREAM.md` in your fork that records:
+
+- upstream commit or release tag last merged;
+- changed defaults;
+- added, removed, or disabled services;
+- hardware assumptions;
+- model and image pins;
+- private patches to installer, CLI, compose, or dashboard code;
+- validation commands and fleet receipts used after each upstream merge.
+
+## What To Avoid Patching First
+
+These areas are powerful but high blast radius:
+
+- `install-core.sh` and `installers/phases/*`;
+- `dream-cli`;
+- `installers/lib/compose-select.sh`;
+- `scripts/resolve-compose-stack.sh`;
+- `docker-compose.base.yml` and hardware overlays;
+- dashboard-api auth, host-agent, and extension install routes;
+- generated config writers for `.env`, LiteLLM, Hermes, OpenCode, and Perplexica.
+
+Patch them when you need to, but do it with the validation map in
+[HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md).
+
+## Safer Extension Points
+
+Prefer these first:
+
+- `extensions/services/*` for bundled Docker services;
+- `extensions/library/services/*` for optional dashboard-installable services;
+- `extensions/templates/*` for local starter patterns;
+- `config/model-library.json` for model catalog changes;
+- `config/ports.json` for deliberate port policy changes;
+- `.env.example` for downstream defaults;
+- dashboard theme or branding files for a distinct product surface;
+- docs under `docs/<your-edition>/`.
+
+The extension path lets forks add value without diverging from upstream
+installer and lifecycle behavior.
+
+## Pinning Upstream
+
+For a reproducible fork release:
+
+1. Pick an upstream commit or tag.
+2. Record it in `DOWNSTREAM.md`.
+3. Record model, image, driver, and package-manager assumptions.
+4. Run the validation subset appropriate to your changes.
+5. Keep the validation result with the release notes.
+
+Do not build a downstream release from an unnamed local checkout. Future you
+should be able to answer exactly what upstream code was used.
+
+## Validation Expectations
+
+At minimum, a downstream fork should run:
+
+```bash
+git diff --check
+python scripts/audit-extensions.py --project-dir .
+python scripts/validate-generated-configs.py
+python scripts/validate-golden-paths.py
+```
+
+If you touch installer, compose, lifecycle, dashboard-api, model routing, or
+service manifests, use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) to
+choose the stronger validation path.
+
+If you publish a hardware image, keep a release receipt with:
+
+- upstream ref;
+- downstream ref;
+- install command;
+- target hardware;
+- enabled services;
+- model selected and served;
+- validation gates passed, skipped, or deferred.
+
+## Relationship To Upstream
+
+Good fork hygiene helps everyone:
+
+- keep local-only changes documented;
+- upstream bug fixes that help the shared platform;
+- avoid private patches to generated runtime files when an extension or config
+  contract would work;
+- report validation gaps when a fork reveals a new hardware or distro class.
+
+Dream Server should be useful whether you stay close to upstream or maintain a
+private appliance. The project is healthier when independent operators can own
+their stack without needing centralized approval.

--- a/dream-server/docs/HIGH_RISK_CHANGE_MAP.md
+++ b/dream-server/docs/HIGH_RISK_CHANGE_MAP.md
@@ -1,0 +1,71 @@
+# High-Risk Change Map
+
+This map turns maintainer intuition into review policy. Use it to decide what
+validation is required before merging a change.
+
+The goal is not to slow small work down. The goal is to make high-impact areas
+obvious to contributors, fork operators, and auditors.
+
+## Risk Levels
+
+| Level | Meaning | Typical validation |
+|---|---|---|
+| Low | Cannot affect installed runtime behavior | `git diff --check`, link/doc sanity |
+| Medium | Affects one service, UI flow, or contract | Focused tests plus relevant build/lint |
+| High | Affects install, lifecycle, auth, compose, model routing, or host mutation | Focused tests plus release-grade or hardware-backed validation |
+
+## Change Map
+
+| Area | Risk | Why | Required validation |
+|---|---|---|---|
+| Docs only | Low | No runtime impact | `git diff --check`; markdown/link sanity when available |
+| Extension manifest metadata | Medium | Can affect dashboard, CLI, health, and compose discovery | `python scripts/audit-extensions.py --project-dir .` |
+| New or changed service compose | High | Can break stack resolution, ports, health, and dependencies | Extension audit, compose config, resolver checks, install smoke |
+| `install-core.sh` | High | Orchestrates every Linux install phase | Installer syntax, golden paths, release-grade install/lifecycle |
+| `installers/phases/*` | High | Mutates host, config, services, models, or health state | Phase syntax, generated config tests if applicable, release-grade lane for operational changes |
+| Installer libraries | Medium/High | Shared by multiple phases and platform paths | Focused unit/contract tests plus install smoke when behavior changes |
+| Windows installer | High | Separate shell/runtime semantics and Docker Desktop assumptions | PowerShell lint/tests, Windows smoke, fleet Windows lane when available |
+| macOS installer | High | Native Metal llama-server plus Docker services | macOS smoke, lifecycle, model swap when applicable |
+| `dream-cli` | High | User lifecycle, config, restart, backup, mode, and extension control | CLI smoke, `dream restart`, `dream doctor`, lifecycle lane |
+| Compose resolver | High | Determines actual runtime stack | Resolver tests, compose matrix, distro smoke, fleet if operational |
+| Base or hardware compose overlays | High | Can break every install in a hardware class | Compose matrix plus matching real-hardware lane |
+| Dashboard UI | Medium | Operator workflows and setup visibility | `npm test`, `npm run lint`, `npm run build`, Playwright smoke for visible flows |
+| Dashboard API auth/setup/host-agent | High | Protected control plane and host mutation boundary | Focused pytest, security tests, dashboard API smoke |
+| Dashboard API status/read-only routes | Medium | Can affect UI and diagnostics | Focused pytest and dashboard build/test |
+| Hermes, LiteLLM, model routing | High | Affects agent behavior and inference path | Agent seed test, model identity, capability probes |
+| Model catalog or selector | High | Determines first-run user experience and memory fit | Selector tests, hardware truth table review, model swap smoke |
+| Network binding/proxy routes | High | Affects LAN exposure and security posture | Network exposure contracts, auth checks, owner-card/Talk lane when enabled |
+| Dependency updates | Medium/High | Risk depends on runtime surface | Package tests plus service startup smoke; release-grade if installer/runtime wiring changes |
+| CI-only workflow changes | Low/Medium | Does not affect users but can hide failures | Workflow review and green checks |
+
+## Release-Grade Trigger
+
+Run the release-grade fleet or an explicitly scoped equivalent when a change can
+affect:
+
+- clean install;
+- zero-prereq bootstrap;
+- compose stack generation;
+- lifecycle recovery;
+- service health;
+- model download/swap;
+- dashboard API control flows;
+- Hermes or capability probes;
+- host mutation;
+- LAN/proxy exposure.
+
+When a full fleet run is not practical, record the narrower validation and the
+reason it is enough.
+
+## PR Body Checklist
+
+For medium or high-risk PRs, include:
+
+- changed surface;
+- user impact;
+- validation commands and results;
+- skipped or deferred lanes;
+- rollback strategy if the change is risky;
+- whether a full fleet rerun is required before release.
+
+For docs-only PRs, say that no runtime behavior changed.

--- a/dream-server/docs/INSTALLER-ARCHITECTURE.md
+++ b/dream-server/docs/INSTALLER-ARCHITECTURE.md
@@ -5,6 +5,9 @@ shared service registry, and 13 ordered phases. This guide is the map for
 understanding, changing, and reviewing install behavior without missing a
 parallel Linux/macOS/Windows or upgrade-time writer.
 
+For the per-phase ownership and validation contract, see
+[INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md).
+
 ## Directory Tree
 
 ```
@@ -190,3 +193,5 @@ bash tests/integration-test.sh
 - [CONTRIBUTING.md](../CONTRIBUTING.md) — Contributor validation checklist
 - [EXTENSIONS.md](EXTENSIONS.md) — Adding Docker services (not installer mods)
 - [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) — Backend runtime contract format
+- [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md) - Phase
+  ownership, idempotency, and validation expectations

--- a/dream-server/docs/INSTALLER_PHASE_CONTRACTS.md
+++ b/dream-server/docs/INSTALLER_PHASE_CONTRACTS.md
@@ -1,0 +1,86 @@
+# Installer Phase Contracts
+
+Dream Server's Linux installer is an ordered, sourced Bash pipeline. This
+document records the operational contract for each phase so maintainers and fork
+operators can review changes without rediscovering the installer from scratch.
+
+For the file map and mod recipes, see
+[INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md).
+
+## Global Rules
+
+- Installer libraries in `installers/lib/*` should define functions and
+  constants only.
+- Phase files in `installers/phases/*` execute when sourced.
+- Phases share one Bash namespace through `install-core.sh`.
+- A phase should mutate only the surfaces it owns.
+- Re-running the installer should preserve generated secrets and user data
+  unless a force/reset path explicitly says otherwise.
+- Linux, macOS, Windows, host-agent, and bootstrap-upgrade writers must stay in
+  sync for shared generated config.
+
+## Phase Contracts
+
+| Phase | Owns | Inputs | Outputs / mutations | Idempotency expectation | Common failure modes |
+|---|---|---|---|---|---|
+| 01 preflight | User, OS, shell, basic command checks | CLI flags, host OS, current user | Early warnings/errors, phase state | Safe to rerun | Unsupported shell, root/admin mismatch, missing base tools |
+| 02 detection | Hardware and backend detection | GPU tools, CPU/RAM, backend contracts | Hardware tier, backend choice, compose hints | Safe to rerun | Missing drivers, WSL/container ambiguity, unsupported GPU |
+| 03 features | Feature/profile selection | CLI flags, non-interactive mode, defaults | Enabled service/profile choices | Preserve explicit user choices | Interactive prompt in automation, invalid feature combo |
+| 04 requirements | Resource and port preflight | Tier, selected services, disk/RAM/ports | Warnings or blocking errors | Safe to rerun | Port conflict, low disk, low memory, stale service holding a port |
+| 05 docker | Docker and runtime prerequisites | OS/package manager, GPU backend | Docker, Compose, GPU runtime packages | Do not reinstall unnecessarily | Package repo failure, daemon unavailable, NVIDIA/ROCm toolkit mismatch |
+| 06 directories | Filesystem layout and generated config | Repo path, `.env.example`, selected services | Install dirs, `.env`, generated config, data dirs | Preserve secrets and user state | Permission mismatch, stale generated config, missing data dirs |
+| 07 devtools | Optional developer tools | Feature flags, user shell | Codex/Claude/OpenCode helpers | Skip already-installed tools | Network failure, unsupported host shell |
+| 08 images | Image pull/build plan | Compose set, service manifests, GPU backend | Pulled/built images | Resume pulls/builds where possible | Registry failure, source build timeout, bad image tag |
+| 09 offline | Offline/air-gapped helpers | Offline flags, cached assets | Offline cache/config | Safe when disabled | Missing cache, stale artifact checksum |
+| 10 AMD tuning | AMD APU host tuning | AMD detection, privileges | sysctl/modprobe/GRUB/tuned changes | Avoid duplicate host config | Insufficient privilege, unsupported kernel/ROCm state |
+| 11 services | Model bootstrap and stack launch | Compose set, model catalog, `.env` | Models, `models.ini`, running containers | Preserve existing models and secrets | Compose invalid, model download failure, slow health transition |
+| 12 health | Service linking and post-start readiness | Running stack, expected ports, generated config | Health verdicts, Perplexica/STT setup | Extend or defer when a model swap is active | Slow model load, route unavailable, optional service disabled |
+| 13 summary | User-facing completion output | Install state, hostnames, service URLs | Summary JSON, shortcuts, setup output | Regenerate safely | Bad hostname, shortcut failure, stale URL |
+
+## Required Validation By Phase
+
+| Changed area | Minimum validation |
+|---|---|
+| Phase syntax only | `bash -n installers/phases/<phase>.sh` plus `git diff --check` |
+| Detection or tier logic | hardware-class tests, model selector tests, platform truth table review |
+| Requirements or ports | port contract tests and `.env` schema validation |
+| Docker/runtime setup | distro smoke plus relevant GPU/backend lane |
+| Generated config | `python scripts/validate-generated-configs.py` |
+| Compose launch | compose resolver validation and at least one install/lifecycle lane |
+| Health/lifecycle | idempotent reinstall, `dream restart`, and `dream doctor` |
+| Summary/setup output | install smoke plus UI/setup-card sanity when applicable |
+
+For operational code, use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md)
+and [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) to decide whether focused
+checks are enough.
+
+## Generated Config Synchronization
+
+If a phase writes `.env`, LiteLLM, Hermes, OpenCode, Perplexica, model routing,
+or service URLs, check all writer paths:
+
+- Linux installer;
+- macOS installer;
+- Windows installer;
+- bootstrap upgrade;
+- host-agent activation or repair;
+- dashboard-api management routes.
+
+Generated config regressions often happen when only one platform writer is
+updated.
+
+## Reinstall Contract
+
+An idempotent reinstall should:
+
+- keep user secrets;
+- keep downloaded models when valid;
+- keep runtime data under `data/`;
+- refresh generated config when source contracts changed;
+- recover services after compose or model health delays;
+- exit non-zero only when the installed product is not recoverable or an
+  explicit blocking preflight fails.
+
+If a reinstall fails but `dream restart` and `dream doctor` pass immediately
+afterward, investigate health budgets and phase handoff timing before assuming
+the runtime is broken.

--- a/dream-server/docs/INSTALLER_TRUST.md
+++ b/dream-server/docs/INSTALLER_TRUST.md
@@ -108,5 +108,9 @@ fork and record the exact commit or release tag they deployed.
 - [Release Validation](RELEASE_VALIDATION.md) explains the User Green gates.
 - [Validation Matrix](VALIDATION-MATRIX.md) summarizes the hardware, distro,
   capability, and lifecycle evidence.
+- [Forkability](FORKABILITY.md) explains how downstream operators can fork,
+  pin, and independently operate Dream Server.
+- [Offline And Mirroring](OFFLINE_AND_MIRRORING.md) covers preserving release
+  refs, images, model artifacts, and validation receipts.
 - [Security](../SECURITY.md) documents localhost defaults, LAN tradeoffs, and
   disclosure guidance.

--- a/dream-server/docs/MAINTAINER_RUNBOOK.md
+++ b/dream-server/docs/MAINTAINER_RUNBOOK.md
@@ -1,0 +1,131 @@
+# Maintainer Runbook
+
+This runbook is for maintainers and downstream fork operators who need to ship,
+triage, roll back, or safely review operational changes.
+
+It is intentionally practical. The goal is to make Dream Server operable by
+people who did not write the original installer.
+
+## Maintainer Responsibilities
+
+Maintainers are expected to protect:
+
+- install reliability across supported platforms;
+- localhost-first security defaults;
+- generated secret handling;
+- service manifest and compose consistency;
+- dashboard-api auth and host-agent boundaries;
+- release validation receipts;
+- rebase-friendly extension and fork paths.
+
+When in doubt, prefer a smaller change with stronger validation over a clever
+change with broad invisible effects.
+
+## Release Checklist
+
+Before publishing or recommending a release candidate:
+
+1. Confirm the commit under test.
+2. Confirm no unrelated local changes are included.
+3. Run required CI and focused checks for changed areas.
+4. For operational changes, run the release-grade fleet or an explicitly scoped
+   release substitute.
+5. Confirm capability deferrals are resolved by the capabilities watcher or
+   called out as deferred.
+6. Confirm lifecycle checks pass: idempotent reinstall, `dream restart`, and
+   `dream doctor`.
+7. Record skipped optional surfaces, such as owner-card Talk, vision probes, AP
+   mode, or disabled hardware lanes.
+8. Update release notes with the commit, date, validation layer, and known
+   limitations.
+
+## When Release-Grade Fleet Is Required
+
+Use the release-grade gate after changes to:
+
+- installer phases or installer libraries;
+- public bootstrap or prerequisite installation;
+- Docker Compose stack selection or resolver behavior;
+- core service manifests or ports;
+- dashboard-api behavior used by install, setup, model, extension, or service
+  management flows;
+- Hermes, model routing, LiteLLM, Lemonade, or llama-server lifecycle;
+- GPU/runtime detection;
+- `dream-cli` lifecycle commands;
+- dependency/runtime wiring for installed services.
+
+Docs-only and narrow test-only changes normally use focused validation.
+
+## Reading Fleet Results
+
+Use [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) for the public gate
+definition. Operationally:
+
+- `PASS` means the lane completed and validated the expected surface.
+- `DEFERRED` means the lane has not failed, but is waiting on a known condition
+  such as a full model download.
+- `SKIPPED` means the surface is not enabled for that install mode, such as
+  owner-card Talk on a non-LAN install.
+- `FAIL` means the release gate should stop until the failure is classified.
+
+Classify failures before fixing:
+
+| Failure shape | First question |
+|---|---|
+| Install exits non-zero | Did the product fail, or did a health wait/time budget expire while services recovered? |
+| Compose error | Is the selected file set valid for the mode, hardware, and enabled extensions? |
+| Capability failure | Is the full model loaded, or is the host still on the bootstrap model? |
+| Talk failure | Is `dream-proxy` enabled and healthy, or is the owner-card surface not part of this install? |
+| Dashboard API failure | Is auth configured, service state healthy, and the expected route protected? |
+| Lifecycle failure | Did reinstall, restart, or doctor fail independently, or did one transient poison the next probe? |
+
+## Rollback Procedure
+
+If a release or merge breaks operational behavior:
+
+1. Stop new merges into the affected area.
+2. Identify the last known-good commit and validation receipt.
+3. Reproduce the failure on the smallest matching surface.
+4. Decide whether to revert or forward-fix.
+5. If reverting, revert only the offending commit or PR.
+6. Rerun the focused failing lane.
+7. Rerun release-grade validation if installer, compose, lifecycle, or runtime
+   behavior was affected.
+8. Document the incident in the PR or release notes.
+
+Avoid broad repository resets or unrelated cleanup while handling a release
+rollback.
+
+## High-Risk Areas
+
+Treat these areas as high-risk:
+
+- `dream-cli`;
+- `install-core.sh`;
+- `installers/phases/*`;
+- `installers/lib/compose-select.sh`;
+- `scripts/resolve-compose-stack.sh`;
+- `docker-compose.*.yml`;
+- `extensions/services/*/manifest.yaml`;
+- dashboard-api auth, host-agent, setup, extension, and model routes;
+- generated config writers;
+- model download, verification, swap, and bootstrap logic.
+
+Use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) to choose validation
+before merging.
+
+## Handoff Checklist
+
+When handing maintenance to another person or fork:
+
+- point them at this runbook;
+- identify the current known-good commit;
+- share the latest sanitized validation result;
+- list disabled or lab-only fleet lanes;
+- list outstanding release-blocking issues;
+- list active private patches if this is a fork;
+- explain where secrets and runtime data live;
+- explain how to restore from backup or reinstall cleanly.
+
+The handoff is not complete until the next operator can run validation and
+interpret the result without private context.

--- a/dream-server/docs/OFFLINE_AND_MIRRORING.md
+++ b/dream-server/docs/OFFLINE_AND_MIRRORING.md
@@ -1,0 +1,117 @@
+# Offline And Mirroring Guide
+
+Dream Server should be usable as independently owned infrastructure. This guide
+explains how operators and forks can reduce reliance on mutable upstream state by
+pinning, mirroring, and recording release artifacts.
+
+This is not a promise that every upstream service, model, or image license
+permits redistribution. Mirror only what you are allowed to mirror.
+
+## What To Preserve
+
+For a durable downstream release, preserve:
+
+- the Dream Server git ref;
+- release notes and validation receipt;
+- Docker image references and digests where available;
+- model filenames, URLs, checksums, and licenses;
+- extension manifests and compose fragments;
+- installer command and flags;
+- generated `.env.example` defaults for the edition;
+- hardware and driver assumptions.
+
+## Git Mirroring
+
+For an internal mirror:
+
+```bash
+git clone --mirror https://github.com/Light-Heart-Labs/DreamServer.git
+cd DreamServer.git
+git remote set-url --push origin <your-mirror-url>
+git push --mirror
+```
+
+For a working fork, pin your release in `DOWNSTREAM.md`:
+
+```text
+Upstream: Light-Heart-Labs/DreamServer
+Upstream ref: <commit-or-tag>
+Downstream ref: <commit-or-tag>
+Validation receipt: <date-and-run-id-or-local-report>
+```
+
+## Docker Images
+
+Where licensing permits, mirror images needed by your selected service set:
+
+```bash
+docker pull <image>:<tag>
+docker tag <image>:<tag> <your-registry>/<image>:<tag>
+docker push <your-registry>/<image>:<tag>
+```
+
+Prefer digest-pinned records for release receipts. If a service still uses a tag
+pin, record the digest resolved during validation.
+
+## Models
+
+For model mirrors:
+
+- record source URL;
+- record filename;
+- record SHA256 or provider checksum;
+- record license and redistribution terms;
+- keep partial downloads out of the final mirror;
+- test that the installer or model swap path can use the mirrored location.
+
+If a model cannot be redistributed, document the required download source and
+checksum so operators can reproduce the artifact themselves.
+
+## Extension Assets
+
+Custom extensions should keep assets near the extension when practical:
+
+```text
+extensions/services/<service-id>/
+  manifest.yaml
+  compose.yaml
+  assets/
+  README.md
+```
+
+For large assets, store checksums and retrieval instructions in the extension
+README.
+
+## Offline Release Receipt
+
+Keep a receipt with every offline-capable image or appliance:
+
+```text
+Dream Server ref:
+Downstream ref:
+Install mode:
+Hardware class:
+Docker images mirrored:
+Models mirrored:
+Services enabled:
+Validation commands:
+Known skipped surfaces:
+Operator notes:
+```
+
+The receipt is what lets another maintainer rebuild trust without access to the
+original lab.
+
+## Recovery If Upstream Disappears
+
+If upstream is unavailable:
+
+1. Use your mirrored git ref.
+2. Restore mirrored Docker images or retag local images.
+3. Restore mirrored model files and checksums.
+4. Use pinned installer commands or local install scripts.
+5. Run the validation subset from [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md).
+6. Record a new local validation receipt.
+
+The goal is not to freeze Dream Server forever. The goal is to make each release
+understandable and recoverable without depending on mutable external state.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -19,8 +19,9 @@ at [`../../README.md`](../../README.md).
 | Change installer behavior | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md), [PREFLIGHT-ENGINE.md](PREFLIGHT-ENGINE.md) |
 | Change model routing | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | [MODE-SWITCH.md](MODE-SWITCH.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) |
 | Add or harden a service | [EXTENSIONS.md](EXTENSIONS.md) | [../extensions/CATALOG.md](../extensions/CATALOG.md), [../extensions/schema/README.md](../extensions/schema/README.md) |
-| Build a custom edition or fork | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) | [EXTENSIONS.md](EXTENSIONS.md), [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md), [../extensions/templates/README.md](../extensions/templates/README.md) |
-| Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [TESTING.md](TESTING.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md), [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
+| Build a custom edition or fork | [FORKABILITY.md](FORKABILITY.md) | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md), [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md), [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) |
+| Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [TESTING.md](TESTING.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
+| Maintain a release or fork | [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md) | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md), [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md) |
 
 ## Current Truths
 
@@ -62,12 +63,17 @@ at [`../../README.md`](../../README.md).
 | Doc | Audience | Description |
 |-----|----------|-------------|
 | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) | Downstream builders | Forking, custom editions, source-of-truth map, extension compatibility, and validation checklist |
+| [FORKABILITY.md](FORKABILITY.md) | Downstream builders / fork operators | Fork posture, independent operation, safe extension points, and upstream relationship |
+| [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md) | Fork operators / appliance builders | Pinning, mirroring, and preserving release artifacts for offline or independent operation |
+| [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) | Fork operators / release reviewers | How to reproduce upstream validation layers on local hardware and record receipts |
 | [EXTENSIONS.md](EXTENSIONS.md) | Builders | Add Docker services, manifests, dashboard plugins |
 | [../extensions/templates/README.md](../extensions/templates/README.md) | Builders | Starter manifest, compose, GPU overlay, and dashboard plugin templates |
 | [../extensions/CATALOG.md](../extensions/CATALOG.md) | Builders / reviewers | Current bundled service manifest catalog |
 | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | Modders | Installer module map, mod recipes, header convention |
 | [INTEGRATION-GUIDE.md](INTEGRATION-GUIDE.md) | Developers | Connect apps via OpenAI SDK, LangChain, n8n |
 | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) | Developers | Backend runtime contract JSON schema |
+| [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md) | Maintainers / installer reviewers | Phase ownership, inputs, outputs, idempotency, and validation expectations |
+| [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md) | Maintainers / backend reviewers | Compose layer rules for services, hardware overlays, modes, dependencies, and ports |
 | [HERMES.md](HERMES.md) | Developers / operators | Default Hermes Agent packaging, security posture, and operations |
 | [OPENCLAW-INTEGRATION.md](OPENCLAW-INTEGRATION.md) | Developers | Deprecated OpenClaw setup and migration reference |
 
@@ -126,12 +132,14 @@ at [`../../README.md`](../../README.md).
 | [PLATFORM-TRUTH-TABLE.md](PLATFORM-TRUTH-TABLE.md) | Developers | Platform feature matrix |
 | [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) | Operators / release reviewers | User Green gates and when operational changes require release-grade fleet validation |
 | [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) | Operators / release reviewers | Sanitized CI, distro lab, and real-hardware fleet release-readiness evidence |
+| [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) | Contributors / maintainers | Risk levels and required validation by changed surface |
 
 ## Project
 
 | Doc | Audience | Description |
 |-----|----------|-------------|
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | Contributors | How to contribute |
+| [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md) | Maintainers / fork operators | Release, rollback, validation, and handoff runbook |
 | [../SECURITY.md](../SECURITY.md) | Everyone | Security guide and disclosure |
 | [../../SECURITY_AUDIT.md](../../SECURITY_AUDIT.md) | Maintainers / reviewers | Historical security audit with current remediation status and receipts |
 | [../CHANGELOG.md](../CHANGELOG.md) | Everyone | Version history |

--- a/dream-server/docs/VALIDATION_REPRODUCIBILITY.md
+++ b/dream-server/docs/VALIDATION_REPRODUCIBILITY.md
@@ -1,0 +1,116 @@
+# Validation Reproducibility
+
+Dream Server's full release-grade validation uses public CI, distro labs, and a
+private real-hardware fleet. Not every fork can reproduce every lane, but every
+operator should be able to understand what was tested and run an appropriate
+subset for their own hardware.
+
+Use this guide with [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md),
+[VALIDATION-MATRIX.md](VALIDATION-MATRIX.md), and
+[HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md).
+
+## Validation Layers
+
+| Layer | Publicly reproducible | Purpose |
+|---|---|---|
+| Static checks | Yes | Syntax, contracts, docs, manifest health, config drift |
+| Dashboard tests | Yes | UI/API unit and build confidence |
+| Compose matrix | Yes | Validates stack file combinations without full hardware |
+| Distro containers | Mostly | Package-manager and bootstrap behavior across distro families |
+| Incus/systemd VMs | Lab-dependent | Docker daemon and systemd behavior |
+| Real hardware fleet | Hardware-dependent | GPU/backend, model, lifecycle, and full-product behavior |
+| Full-model capabilities | Hardware/model-dependent | Proves agent, search, files, code, model identity, and context after model swap |
+
+## Minimum Local Audit Set
+
+From `dream-server/`:
+
+```bash
+git diff --check
+python scripts/audit-extensions.py --project-dir .
+python scripts/validate-generated-configs.py
+python scripts/validate-golden-paths.py
+python scripts/validate-dependency-pins.py
+```
+
+Add dashboard checks when dashboard code or dashboard-api behavior changes.
+
+## Reproducing Installer Confidence
+
+For a local fork or appliance candidate:
+
+1. Start from a clean checkout.
+2. Record the commit.
+3. Run a fresh install on representative hardware.
+4. Confirm service health.
+5. Exercise dashboard model and extension flows.
+6. Confirm Hermes can answer a seed prompt.
+7. Wait for full model download and hot-swap.
+8. Run capability probes or an equivalent manual checklist.
+9. Run idempotent reinstall, `dream restart`, and `dream doctor`.
+10. Record skipped surfaces honestly.
+
+If you cannot run the full fleet, say which hardware and distro classes were not
+tested.
+
+## Capability Deferrals
+
+Capability checks should not fail just because a large model is still
+downloading. A valid report distinguishes:
+
+- bootstrap model active;
+- full model downloading;
+- full model downloaded but not served yet;
+- full model served and capability probes passed;
+- full model served and a probe failed.
+
+Do not mark a release as fully validated until deferred full-model checks have
+resolved or are explicitly excluded from that release.
+
+## Owner-Card And Talk Probes
+
+Dream Talk owner-card probes only gate releases when the owner-card surface is
+enabled and `dream-proxy` is healthy. A default non-LAN install should skip
+those probes rather than failing a surface the user did not expose.
+
+If your fork depends on owner-card access, add a dedicated validation lane for
+the LAN/proxy path.
+
+## Recording A Validation Receipt
+
+Use a concise receipt:
+
+```text
+Project ref:
+Downstream ref:
+Date:
+Hardware:
+OS/distro:
+Install command:
+Services enabled:
+Model selected:
+Gates passed:
+Gates skipped/deferred:
+Known limitations:
+Logs/report path:
+```
+
+Validation receipts are most valuable when they are boring, specific, and easy
+to compare with the next run.
+
+## How To Read Upstream Claims
+
+Upstream validation proves the upstream candidate on the tested hardware and
+software surface. It is a strong signal for forks, but it does not automatically
+validate:
+
+- private extensions;
+- changed model catalogs;
+- changed compose overlays;
+- custom LAN exposure;
+- different Docker Desktop versions;
+- different GPU drivers;
+- unsupported distros or hardware.
+
+Forks should cite upstream receipts and add their own downstream receipt for
+local changes.


### PR DESCRIPTION
﻿## Summary

This PR adds the missing maintainer/fork-operator documentation layer for Dream Server as serious distributable infrastructure.

It adds docs for:

- forkability and independent operation
- maintainer release, rollback, validation, and handoff workflows
- installer phase ownership and idempotency contracts
- compose resolver rules for services, hardware overlays, modes, dependencies, and ports
- high-risk change validation policy
- offline/mirroring practices for preserving releases and artifacts
- validation reproducibility for forks and local operators

It also links the new docs from the root README, docs index, contributor guide, installer trust doc, builder guide, and installer architecture doc.

## Why

Recent cold clone-and-audit feedback identified the next maturity concern as bus factor and operational concentration, not basic repo credibility. These docs make the project easier to fork, audit, mirror, maintain, and validate independently without changing product behavior.

## User impact

Docs-only. No installer, runtime, compose, dashboard, dependency, or service behavior changes.

## Validation

- `git diff --check`
- Local Markdown link sanity check across 80 Markdown files: PASS
- Attempted `bash dream-server/tests/test-doc-links.sh`, but this Windows environment resolves `bash` to a broken WSL shim (`/bin/bash` missing), so I ran an equivalent local-link check in Python.

## Risk

Very low. This PR only adds and links documentation.