### PR TITLE
feat(doctor): diagnose inference routing contract

### DIFF
--- a/dream-server/docs/DREAM-DOCTOR.md
+++ b/dream-server/docs/DREAM-DOCTOR.md
@@ -45,6 +45,7 @@ Runtime Environment:
   ✓ Docker Compose
   ✗ Dashboard HTTP
   ✗ WebUI HTTP
+  ✓ Inference contract: mode=local, owner=dreamserver, gateway=llama-server
   ⚠ DGX Spark llama-server CUDA arch: DGX Spark detected, but llama-server reports CUDA archs '500,610,700,750,800,860,890,1200' without sm_121.
 
 Preflight Checks:
@@ -87,6 +88,10 @@ dream doctor --json > report.json
   - `impact`: why the issue matters
   - `next_steps`: concrete recovery actions
 - **runtime**: Docker/Compose/UI reachability checks
+- **runtime.inference_contract**: A compact routing contract for the active
+  inference mode. It records `DREAM_MODE`, expected inference owner
+  (`dreamserver` vs `external`), expected gateway (`llama-server` vs
+  `litellm`), key LLM URLs, resolved compose files, and stable mismatch IDs.
 - **runtime.amd_runtime**: Explicit AMD inference runtime diagnostics from
   installer-written env state. Reports runtime (`lemonade` or `llama-server`),
   host/container location, selected backend, supported backends, DreamServer
@@ -124,6 +129,45 @@ Current install diagnoses include:
 These diagnoses are additive. Existing `autofix_hints`, `runtime`, and
 `preflight` fields remain available for scripts that already consume Doctor
 JSON.
+
+## Inference Contract Diagnoses
+
+DreamServer supports several deployment shapes, but support cases often fail
+when the install metadata and runtime routing disagree. For example, cloud mode
+should not start or target DreamServer's managed `llama-server`, and external
+Lemonade should route Dream services through LiteLLM while leaving Lemonade
+itself host-managed.
+
+Dream Doctor records those expectations under `runtime.inference_contract` and
+adds diagnoses when the evidence contradicts the selected mode:
+
+- `DS-RUNTIME-MODE-UNKNOWN`: `.env` contains an unrecognized `DREAM_MODE`.
+- `DS-RUNTIME-CLOUD-OVERLAY-MISSING`: `DREAM_MODE=cloud` but cached
+  `.compose-flags` does not include `docker-compose.cloud.yml`.
+- `DS-RUNTIME-CLOUD-LLM-LOCAL-ROUTE`: cloud mode still has `LLM_API_URL`
+  pointing at local `llama-server`.
+- `DS-RUNTIME-CLOUD-HERMES-LOCAL-ROUTE`: cloud mode still has Hermes pointing
+  at local `llama-server`.
+- `DS-RUNTIME-CLOUD-GATEWAY-BYPASS`: cloud mode points Dream services somewhere
+  other than the LiteLLM gateway.
+- `DS-RUNTIME-EXTERNAL-LEMONADE-CLOUD-OVERLAY-MISSING`: external Lemonade is
+  active while cached `.compose-flags` lacks the cloud overlay that profiles
+  out managed local inference.
+- `DS-RUNTIME-EXTERNAL-LEMONADE-OVERLAY-MISSING`: external Lemonade is active
+  while cached `.compose-flags` lacks `docker-compose.lemonade-external.yml`.
+- `DS-RUNTIME-EXTERNAL-LEMONADE-LOCAL-ROUTE`: external Lemonade still routes
+  clients to local `llama-server`.
+- `DS-RUNTIME-LOCAL-CLOUD-OVERLAY`: local mode still has the cloud overlay in
+  cached `.compose-flags`.
+- `DS-RUNTIME-LOCAL-LITELLM-ROUTE`: non-AMD local mode unexpectedly routes
+  through LiteLLM.
+
+The support bundle embeds the same contract evidence in
+`manifest/evidence.json`. Its Compose validation resolves the stack with the
+recorded `DREAM_MODE`, external Lemonade flags, and AMD runtime ownership so
+Linux, WSL, and macOS support cases show the stack the install actually
+intended to run. Bundle metadata also records whether the Linux host appears to
+be WSL and which Bash executable was selected for nested diagnostics.
 
 ## Exit Codes
 

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1867,6 +1867,21 @@ if amd_runtime.get('available'):
 elif amd_runtime.get('reason') and amd_runtime.get('reason') != 'not_amd':
     print(f"  {YELLOW}⚠{NC} AMD runtime: {amd_runtime.get('reason')}")
 
+inference_contract = runtime.get('inference_contract') or {}
+if inference_contract:
+    counts = inference_contract.get('issue_counts') or {}
+    blockers = counts.get('blockers', 0)
+    warnings = counts.get('warnings', 0)
+    symbol = GREEN + '✓' + NC if blockers == 0 and warnings == 0 else (RED + '✗' + NC if blockers else YELLOW + '⚠' + NC)
+    print(
+        f"  {symbol} Inference contract: "
+        f"mode={inference_contract.get('dream_mode', 'unknown')}, "
+        f"owner={inference_contract.get('expected_inference_owner', 'unknown')}, "
+        f"gateway={inference_contract.get('expected_gateway', 'unknown')}"
+    )
+    for issue in (inference_contract.get('issues') or [])[:3]:
+        print(f"    {YELLOW if issue.get('severity') == 'warn' else RED}⚠{NC} {issue.get('id')}: {issue.get('detail')}")
+
 print()
 
 # Voice checks

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -26,6 +26,10 @@ REPORT_FILE="${1:-/tmp/dream-doctor-report.json}"
 
 CAP_FILE="/tmp/dream-doctor-capabilities.json"
 PREFLIGHT_FILE="/tmp/dream-doctor-preflight.json"
+DOCTOR_BASH_CMD="${BASH:-}"
+if [[ -z "$DOCTOR_BASH_CMD" || ! -x "$DOCTOR_BASH_CMD" ]]; then
+    DOCTOR_BASH_CMD="$(command -v bash 2>/dev/null || printf '%s\n' bash)"
+fi
 
 # Source service registry and safe env helpers
 if [[ -f "$ROOT_DIR/lib/service-registry.sh" ]]; then
@@ -74,7 +78,7 @@ fi
 DISK_GB="$(df -k "$HOME" 2>/dev/null | tail -1 | awk '{print int($4/1024/1024)}' || echo 0)"
 
 if [[ -x "$SCRIPT_DIR/scripts/build-capability-profile.sh" ]]; then
-    CAP_ENV="$("$SCRIPT_DIR/scripts/build-capability-profile.sh" --output "$CAP_FILE" --env)"
+    CAP_ENV="$("$DOCTOR_BASH_CMD" "$SCRIPT_DIR/scripts/build-capability-profile.sh" --output "$CAP_FILE" --env)"
     load_env_from_output <<< "$CAP_ENV"
 else
     echo "scripts/build-capability-profile.sh not found/executable" >&2
@@ -82,7 +86,7 @@ else
 fi
 
 if [[ -x "$SCRIPT_DIR/scripts/preflight-engine.sh" ]]; then
-    PREFLIGHT_ENV="$("$SCRIPT_DIR/scripts/preflight-engine.sh" \
+    PREFLIGHT_ENV="$("$DOCTOR_BASH_CMD" "$SCRIPT_DIR/scripts/preflight-engine.sh" \
         --report "$PREFLIGHT_FILE" \
         --tier "${CAP_RECOMMENDED_TIER:-T1}" \
         --ram-gb "$RAM_GB" \
@@ -317,6 +321,7 @@ import json
 import os
 import pathlib
 import re
+import shlex
 import sys
 from datetime import datetime, timezone
 from urllib import error, request
@@ -528,6 +533,63 @@ def _parse_kv_lines(text):
     return values
 
 
+def _truthy(value):
+    return str(value or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_file_values():
+    env_path = root_dir / ".env"
+    if not env_path.exists():
+        return {}
+    return _parse_kv_lines(_read_text(env_path))
+
+
+def _compose_files_from_flags(flags_text):
+    if not flags_text.strip():
+        return []
+    try:
+        tokens = shlex.split(flags_text)
+    except ValueError:
+        tokens = flags_text.split()
+    files = []
+    idx = 0
+    while idx < len(tokens):
+        token = tokens[idx]
+        if token in {"-f", "--file"} and idx + 1 < len(tokens):
+            files.append(tokens[idx + 1])
+            idx += 2
+            continue
+        if token.startswith("--file="):
+            files.append(token.split("=", 1)[1])
+        idx += 1
+    return files
+
+
+def _has_compose_file(files, expected):
+    return any(pathlib.PurePosixPath(item).name == expected or item == expected for item in files)
+
+
+def _looks_like_litellm_route(value):
+    lowered = (value or "").lower()
+    return "litellm" in lowered or ":4000" in lowered
+
+
+def _looks_like_local_llama_route(value):
+    lowered = (value or "").lower()
+    if not lowered:
+        return False
+    return (
+        "llama-server" in lowered
+        or "dream-llama-server" in lowered
+        or "localhost:8080" in lowered
+        or "127.0.0.1:8080" in lowered
+        or "host.docker.internal:8080" in lowered
+        or "localhost:11434" in lowered
+        or "127.0.0.1:11434" in lowered
+        or "host.docker.internal:11434" in lowered
+    )
+
+
 def _source(path):
     try:
         return path.relative_to(root_dir).as_posix()
@@ -548,6 +610,247 @@ def _diagnosis(diag_id, severity, confidence, title, evidence, impact, next_step
         "evidence": evidence,
         "impact": impact,
         "next_steps": next_steps,
+    }
+
+
+def _inference_issue(issue_id, severity, source, detail):
+    return {
+        "id": issue_id,
+        "severity": severity,
+        "source": source,
+        "detail": detail,
+    }
+
+
+def _collect_inference_contract():
+    env_values = _env_file_values()
+
+    def env_get(name, default=""):
+        return env_values.get(name) or _clean_env(name, default)
+
+    flags_path = root_dir / ".compose-flags"
+    flags_text = _read_text(flags_path, max_chars=20_000) if flags_path.exists() else ""
+    compose_flags_exists = flags_path.exists()
+    compose_files = _compose_files_from_flags(flags_text)
+
+    dream_mode = (env_get("DREAM_MODE", "local") or "local").strip().lower()
+    gpu_backend = (env_get("GPU_BACKEND", "") or "").strip().lower()
+    llm_backend = env_get("LLM_BACKEND", "")
+    llm_api_url = env_get("LLM_API_URL", "")
+    hermes_base_url = env_get("HERMES_LLM_BASE_URL", "")
+    lemonade_external = (
+        _truthy(env_get("LEMONADE_EXTERNAL"))
+        or env_get("AMD_INFERENCE_RUNTIME_MODE").strip().lower() == "external-lemonade"
+        or (
+            env_get("AMD_INFERENCE_RUNTIME").strip().lower() == "lemonade"
+            and env_get("AMD_INFERENCE_MANAGED").strip().lower() == "false"
+        )
+    )
+
+    cloud_overlay = _has_compose_file(compose_files, "docker-compose.cloud.yml")
+    lemonade_external_overlay = _has_compose_file(compose_files, "docker-compose.lemonade-external.yml")
+    local_inference_overlay = any(
+        _has_compose_file(compose_files, name)
+        for name in (
+            "docker-compose.nvidia.yml",
+            "docker-compose.amd.yml",
+            "docker-compose.cpu.yml",
+            "docker-compose.arc.yml",
+            "docker-compose.intel.yml",
+            "docker-compose.apple.yml",
+            "docker-compose.macos.yml",
+        )
+    )
+
+    external_inference = dream_mode == "cloud" or lemonade_external
+    expected_owner = "external" if external_inference else "dreamserver"
+    expected_gateway = (
+        "litellm"
+        if external_inference or dream_mode == "lemonade" or gpu_backend == "amd"
+        else "llama-server"
+    )
+
+    issues = []
+    if dream_mode not in {"local", "cloud", "hybrid", "lemonade"}:
+        issues.append(
+            _inference_issue(
+                "DS-RUNTIME-MODE-UNKNOWN",
+                "blocker",
+                ".env",
+                f"DREAM_MODE={dream_mode!r} is not one of local/cloud/hybrid/lemonade.",
+            )
+        )
+
+    if dream_mode == "cloud":
+        if compose_flags_exists and not cloud_overlay:
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-CLOUD-OVERLAY-MISSING",
+                    "blocker",
+                    ".compose-flags",
+                    "DREAM_MODE=cloud but docker-compose.cloud.yml is not in the resolved compose stack.",
+                )
+            )
+        if _looks_like_local_llama_route(llm_api_url):
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-CLOUD-LLM-LOCAL-ROUTE",
+                    "blocker",
+                    ".env",
+                    f"DREAM_MODE=cloud but LLM_API_URL points at local llama-server ({llm_api_url}).",
+                )
+            )
+        if _looks_like_local_llama_route(hermes_base_url):
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-CLOUD-HERMES-LOCAL-ROUTE",
+                    "blocker",
+                    ".env",
+                    f"DREAM_MODE=cloud but HERMES_LLM_BASE_URL points at local llama-server ({hermes_base_url}).",
+                )
+            )
+        if llm_api_url and not _looks_like_litellm_route(llm_api_url):
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-CLOUD-GATEWAY-BYPASS",
+                    "warn",
+                    ".env",
+                    f"DREAM_MODE=cloud normally routes Dream services through LiteLLM, but LLM_API_URL={llm_api_url}.",
+                )
+            )
+
+    if lemonade_external:
+        if compose_flags_exists and not cloud_overlay:
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-EXTERNAL-LEMONADE-CLOUD-OVERLAY-MISSING",
+                    "blocker",
+                    ".compose-flags",
+                    "External Lemonade needs the cloud overlay so DreamServer does not start a managed llama-server.",
+                )
+            )
+        if compose_flags_exists and not lemonade_external_overlay:
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-EXTERNAL-LEMONADE-OVERLAY-MISSING",
+                    "warn",
+                    ".compose-flags",
+                    "External Lemonade mode is active but docker-compose.lemonade-external.yml is not in the compose stack.",
+                )
+            )
+        if _looks_like_local_llama_route(llm_api_url):
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-EXTERNAL-LEMONADE-LOCAL-ROUTE",
+                    "blocker",
+                    ".env",
+                    f"External Lemonade is configured, but LLM_API_URL points at local llama-server ({llm_api_url}).",
+                )
+            )
+
+    if dream_mode == "local" and not lemonade_external:
+        if compose_flags_exists and cloud_overlay:
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-LOCAL-CLOUD-OVERLAY",
+                    "warn",
+                    ".compose-flags",
+                    "DREAM_MODE=local but docker-compose.cloud.yml is still in the compose stack.",
+                )
+            )
+        if _looks_like_litellm_route(llm_api_url) and gpu_backend != "amd":
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-LOCAL-LITELLM-ROUTE",
+                    "warn",
+                    ".env",
+                    f"DREAM_MODE=local on non-AMD usually routes directly to llama-server, but LLM_API_URL={llm_api_url}.",
+                )
+            )
+
+    diagnoses = []
+    issue_titles = {
+        "DS-RUNTIME-MODE-UNKNOWN": "Runtime mode is not recognized",
+        "DS-RUNTIME-CLOUD-OVERLAY-MISSING": "Cloud mode is missing the cloud compose overlay",
+        "DS-RUNTIME-CLOUD-LLM-LOCAL-ROUTE": "Cloud mode still routes chat clients to local llama-server",
+        "DS-RUNTIME-CLOUD-HERMES-LOCAL-ROUTE": "Cloud mode still routes Hermes to local llama-server",
+        "DS-RUNTIME-CLOUD-GATEWAY-BYPASS": "Cloud mode bypasses the LiteLLM gateway",
+        "DS-RUNTIME-EXTERNAL-LEMONADE-CLOUD-OVERLAY-MISSING": "External Lemonade is missing the cloud compose overlay",
+        "DS-RUNTIME-EXTERNAL-LEMONADE-OVERLAY-MISSING": "External Lemonade is missing its compose overlay",
+        "DS-RUNTIME-EXTERNAL-LEMONADE-LOCAL-ROUTE": "External Lemonade still routes clients to local llama-server",
+        "DS-RUNTIME-LOCAL-CLOUD-OVERLAY": "Local mode still has the cloud compose overlay",
+        "DS-RUNTIME-LOCAL-LITELLM-ROUTE": "Local mode routes through LiteLLM unexpectedly",
+    }
+    next_steps = {
+        "DS-RUNTIME-CLOUD-OVERLAY-MISSING": [
+            "Regenerate compose flags with DREAM_MODE=cloud and include docker-compose.cloud.yml.",
+            "Run `dream restart` after correcting .env/.compose-flags.",
+        ],
+        "DS-RUNTIME-CLOUD-LLM-LOCAL-ROUTE": [
+            "Set LLM_API_URL to the LiteLLM service URL used by the stack, usually http://litellm:4000.",
+            "Do not point cloud mode at llama-server unless DreamServer is intentionally managing local inference.",
+        ],
+        "DS-RUNTIME-CLOUD-HERMES-LOCAL-ROUTE": [
+            "Set HERMES_LLM_BASE_URL to http://litellm:4000/v1 for cloud mode.",
+            "Restart Hermes after updating the generated config/template.",
+        ],
+        "DS-RUNTIME-CLOUD-GATEWAY-BYPASS": [
+            "Route Dream services through LiteLLM so hosted, private-cloud, and auth behavior stay consistent.",
+        ],
+        "DS-RUNTIME-EXTERNAL-LEMONADE-CLOUD-OVERLAY-MISSING": [
+            "Regenerate compose flags for external Lemonade so the managed llama-server is profiled out.",
+        ],
+        "DS-RUNTIME-EXTERNAL-LEMONADE-OVERLAY-MISSING": [
+            "Include docker-compose.lemonade-external.yml when LEMONADE_EXTERNAL=true.",
+        ],
+        "DS-RUNTIME-EXTERNAL-LEMONADE-LOCAL-ROUTE": [
+            "Route external Lemonade clients through LiteLLM, usually http://litellm:4000.",
+        ],
+        "DS-RUNTIME-LOCAL-CLOUD-OVERLAY": [
+            "Regenerate compose flags for local mode so local inference starts normally.",
+        ],
+        "DS-RUNTIME-LOCAL-LITELLM-ROUTE": [
+            "If this is not an AMD/Lemonade install, set LLM_API_URL back to http://llama-server:8080.",
+        ],
+        "DS-RUNTIME-MODE-UNKNOWN": [
+            "Set DREAM_MODE to local, cloud, hybrid, or lemonade.",
+        ],
+    }
+    for issue in issues:
+        diagnoses.append(
+            _diagnosis(
+                issue["id"],
+                issue["severity"],
+                "high" if issue["severity"] == "blocker" else "medium",
+                issue_titles.get(issue["id"], "Inference runtime contract mismatch"),
+                [_evidence(issue["source"], issue["detail"])],
+                "Dream services can report healthy while chat, agents, or model routing target the wrong inference owner.",
+                next_steps.get(issue["id"], ["Regenerate .env/.compose-flags with the installer and restart DreamServer."]),
+            )
+        )
+
+    return {
+        "dream_mode": dream_mode,
+        "gpu_backend": gpu_backend,
+        "llm_backend": llm_backend,
+        "expected_inference_owner": expected_owner,
+        "expected_gateway": expected_gateway,
+        "external_lemonade": lemonade_external,
+        "llm_api_url": llm_api_url,
+        "hermes_llm_base_url": hermes_base_url,
+        "compose_files": compose_files,
+        "signals": {
+            "compose_flags_exists": compose_flags_exists,
+            "cloud_overlay": cloud_overlay,
+            "lemonade_external_overlay": lemonade_external_overlay,
+            "local_inference_overlay": local_inference_overlay,
+        },
+        "issues": issues,
+        "issue_counts": {
+            "blockers": sum(1 for item in issues if item["severity"] == "blocker"),
+            "warnings": sum(1 for item in issues if item["severity"] == "warn"),
+        },
+        "diagnoses": diagnoses,
     }
 
 
@@ -799,7 +1102,10 @@ def _collect_install_diagnoses(artifacts):
 
 
 install_artifacts = _collect_install_artifacts()
-diagnoses = _collect_install_diagnoses(install_artifacts)
+inference_contract = _collect_inference_contract()
+diagnoses = _collect_install_diagnoses(install_artifacts) + inference_contract.get("diagnoses", [])
+inference_contract_public = dict(inference_contract)
+inference_contract_public.pop("diagnoses", None)
 
 report = {
     "version": "1",
@@ -828,6 +1134,7 @@ report = {
             "message": dgx_spark_arch_message,
         },
         "amd_runtime": amd_runtime,
+        "inference_contract": inference_contract_public,
     },
     "extensions": ext_diagnostics,
     "summary": {
@@ -838,7 +1145,10 @@ report = {
             + (1 if stt_cached in {"false", "service_down"} else 0)
             + (1 if tts_http == "false" else 0)
             + len(amd_runtime.get("warnings", []))
+            + inference_contract.get("issue_counts", {}).get("warnings", 0)
         ),
+        "runtime_contract_blockers": inference_contract.get("issue_counts", {}).get("blockers", 0),
+        "runtime_contract_warnings": inference_contract.get("issue_counts", {}).get("warnings", 0),
         "diagnoses_total": len(diagnoses),
         "diagnoses_blockers": sum(1 for d in diagnoses if d.get("severity") == "blocker"),
         "diagnoses_warnings": sum(1 for d in diagnoses if d.get("severity") == "warn"),

--- a/dream-server/scripts/dream-support-bundle.sh
+++ b/dream-server/scripts/dream-support-bundle.sh
@@ -68,10 +68,29 @@ detect_python() {
     fi
 }
 
+detect_bash() {
+    local candidate
+    for candidate in \
+        "${DREAM_SUPPORT_BUNDLE_BASH:-}" \
+        /opt/homebrew/bin/bash \
+        /usr/local/bin/bash \
+        "$(command -v bash 2>/dev/null || true)" \
+        /bin/bash
+    do
+        [[ -n "$candidate" && -x "$candidate" ]] || continue
+        if "$candidate" -c '[[ ${BASH_VERSINFO[0]:-0} -ge 4 ]]' >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    command -v bash 2>/dev/null || printf '%s\n' /bin/bash
+}
+
 PYTHON_CMD="$(detect_python)" || {
     echo "ERROR: python3 or python is required to build a redacted support bundle" >&2
     exit 1
 }
+BASH_CMD="$(detect_bash)"
 
 mkdir -p "$OUTPUT_DIR"
 OUTPUT_DIR="$(cd "$OUTPUT_DIR" && pwd)"
@@ -151,7 +170,7 @@ collect_shell() {
     set +e
     (
         cd "$ROOT_DIR" || exit 1
-        bash -lc "$command"
+        "$BASH_CMD" -lc "$command"
     ) > "$abs_path" 2>&1
     exit_code=$?
     set -e
@@ -280,10 +299,21 @@ PY
 }
 
 collect_system_info() {
+    write_file "system/bash.txt" <<EOF
+selected_bash=$BASH_CMD
+selected_bash_version=$("$BASH_CMD" -c 'printf "%s\n" "${BASH_VERSION:-unknown}"' 2>/dev/null || printf 'unknown\n')
+EOF
     collect_shell "system/platform.txt" "platform-summary" '
         printf "generated_at_utc="; date -u +"%Y-%m-%dT%H:%M:%SZ"
         printf "root_dir=%s\n" "$PWD"
         uname -a 2>/dev/null || true
+        if [[ -r /proc/sys/kernel/osrelease ]] && grep -qi microsoft /proc/sys/kernel/osrelease; then
+            echo "wsl=true"
+        elif [[ -r /proc/version ]] && grep -qi microsoft /proc/version; then
+            echo "wsl=true"
+        else
+            echo "wsl=false"
+        fi
         if [[ -f /etc/os-release ]]; then
             echo ""
             cat /etc/os-release
@@ -330,7 +360,7 @@ collect_config() {
 
 collect_diagnostics() {
     if [[ -f "$ROOT_DIR/scripts/dream-doctor.sh" ]]; then
-        collect_shell "diagnostics/dream-doctor.log" "dream-doctor" "$(shell_quote "$ROOT_DIR/scripts/dream-doctor.sh") $(shell_quote "$BUNDLE_DIR/diagnostics/dream-doctor.json")"
+        collect_shell "diagnostics/dream-doctor.log" "dream-doctor" "$(shell_quote "$BASH_CMD") $(shell_quote "$ROOT_DIR/scripts/dream-doctor.sh") $(shell_quote "$BUNDLE_DIR/diagnostics/dream-doctor.json")"
         redact_file "$BUNDLE_DIR/diagnostics/dream-doctor.json"
     else
         write_file "diagnostics/dream-doctor.log" <<< "scripts/dream-doctor.sh not found"
@@ -349,6 +379,10 @@ collect_compose_validation() {
     local gpu_backend
     local tier
     local gpu_count
+    local dream_mode
+    local lemonade_external
+    local amd_runtime
+    local amd_managed
     local flags_file="$BUNDLE_DIR/validation/compose-flags.txt"
     local flags_err="$BUNDLE_DIR/validation/compose-flags.err"
     local flags
@@ -357,6 +391,10 @@ collect_compose_validation() {
     gpu_backend="$(read_env_value GPU_BACKEND nvidia)"
     tier="$(read_env_value TIER 1)"
     gpu_count="$(read_env_value GPU_COUNT 1)"
+    dream_mode="$(read_env_value DREAM_MODE local)"
+    lemonade_external="$(read_env_value LEMONADE_EXTERNAL false)"
+    amd_runtime="$(read_env_value AMD_INFERENCE_RUNTIME "")"
+    amd_managed="$(read_env_value AMD_INFERENCE_MANAGED "")"
 
     if [[ ! -f "$ROOT_DIR/scripts/resolve-compose-stack.sh" ]]; then
         write_file "validation/compose-config.txt" <<< "scripts/resolve-compose-stack.sh not found"
@@ -367,11 +405,15 @@ collect_compose_validation() {
     set +e
     flags="$(
         cd "$ROOT_DIR" && \
-        scripts/resolve-compose-stack.sh \
+        LEMONADE_EXTERNAL="$lemonade_external" \
+        AMD_INFERENCE_RUNTIME="$amd_runtime" \
+        AMD_INFERENCE_MANAGED="$amd_managed" \
+        "$BASH_CMD" scripts/resolve-compose-stack.sh \
             --script-dir "$ROOT_DIR" \
             --tier "$tier" \
             --gpu-backend "$gpu_backend" \
             --gpu-count "$gpu_count" \
+            --dream-mode "$dream_mode" \
             --skip-broken \
             2> "$flags_err"
     )"
@@ -382,6 +424,10 @@ collect_compose_validation() {
         printf 'GPU_BACKEND=%s\n' "$gpu_backend"
         printf 'TIER=%s\n' "$tier"
         printf 'GPU_COUNT=%s\n' "$gpu_count"
+        printf 'DREAM_MODE=%s\n' "$dream_mode"
+        printf 'LEMONADE_EXTERNAL=%s\n' "$lemonade_external"
+        printf 'AMD_INFERENCE_RUNTIME=%s\n' "$amd_runtime"
+        printf 'AMD_INFERENCE_MANAGED=%s\n' "$amd_managed"
         printf 'COMPOSE_FLAGS=%s\n' "$flags"
         if [[ -s "$flags_err" ]]; then
             echo ""
@@ -406,7 +452,7 @@ collect_compose_validation() {
     fi
 
     local cmd
-    cmd="$(shell_quote "$ROOT_DIR/scripts/validate-compose-stack.sh") --compose-flags $(shell_quote "$flags")"
+    cmd="$(shell_quote "$BASH_CMD") $(shell_quote "$ROOT_DIR/scripts/validate-compose-stack.sh") --compose-flags $(shell_quote "$flags")"
     if [[ -f "$ROOT_DIR/.env" ]]; then
         cmd="${cmd} --env-file $(shell_quote "$ROOT_DIR/.env")"
     fi
@@ -531,6 +577,7 @@ import hashlib
 import json
 import platform
 import re
+import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -593,6 +640,16 @@ def command_statuses():
     return commands
 
 
+def is_wsl():
+    for candidate in (Path("/proc/sys/kernel/osrelease"), Path("/proc/version")):
+        try:
+            if "microsoft" in candidate.read_text(encoding="utf-8", errors="replace").lower():
+                return True
+        except OSError:
+            continue
+    return False
+
+
 def parse_compose_flags():
     path = bundle_dir / "validation" / "compose-flags.txt"
     result = {"raw": "", "files": []}
@@ -603,8 +660,22 @@ def parse_compose_flags():
         if line.startswith("COMPOSE_FLAGS="):
             raw = line.split("=", 1)[1].strip()
             result["raw"] = raw
-            parts = raw.split()
-            result["files"] = [parts[i + 1] for i, part in enumerate(parts[:-1]) if part == "-f"]
+            try:
+                parts = shlex.split(raw)
+            except ValueError:
+                parts = raw.split()
+            files = []
+            idx = 0
+            while idx < len(parts):
+                part = parts[idx]
+                if part in {"-f", "--file"} and idx + 1 < len(parts):
+                    files.append(parts[idx + 1])
+                    idx += 2
+                    continue
+                if part.startswith("--file="):
+                    files.append(part.split("=", 1)[1])
+                idx += 1
+            result["files"] = files
             break
     return result
 
@@ -642,6 +713,7 @@ evidence = {
         "release": platform.release(),
         "machine": platform.machine(),
         "python": platform.python_version(),
+        "wsl": is_wsl(),
     },
     "dream": {
         "version": manifest.get("dream_version") or manifest.get("release", {}).get("version"),
@@ -654,6 +726,7 @@ evidence = {
         "llm_backend": env.get("LLM_BACKEND"),
         "llm_model": env.get("LLM_MODEL"),
     },
+    "inference_contract": doctor.get("runtime", {}).get("inference_contract", {}),
     "env_keys": public_env_keys,
     "compose": parse_compose_flags(),
     "doctor_summary": doctor.get("summary", {}),

--- a/dream-server/tests/test-dream-doctor-install-diagnoses.sh
+++ b/dream-server/tests/test-dream-doctor-install-diagnoses.sh
@@ -104,7 +104,10 @@ trap cleanup EXIT
 
 mkdir -p "$LOGS_DIR"
 cat > "$ENV_PATH" <<'ENV'
+DREAM_MODE=cloud
 GPU_BACKEND=nvidia
+LLM_API_URL=http://llama-server:8080
+HERMES_LLM_BASE_URL=http://llama-server:8080/v1
 LLM_MODEL=qwen-test
 GGUF_FILE=qwen-test.gguf
 ENV
@@ -149,7 +152,10 @@ for id in \
     DS-DOCKER-IMAGE-UNRESOLVED \
     DS-COMPOSE-ZERO-CONTAINERS \
     DS-PYTHON-PYYAML-MISSING \
-    DS-WINDOWS-FILE-SHARING-PROBE-IMAGE
+    DS-WINDOWS-FILE-SHARING-PROBE-IMAGE \
+    DS-RUNTIME-CLOUD-OVERLAY-MISSING \
+    DS-RUNTIME-CLOUD-LLM-LOCAL-ROUTE \
+    DS-RUNTIME-CLOUD-HERMES-LOCAL-ROUTE
 do
     if jq -e --arg id "$id" '.diagnoses[] | select(.id == $id)' "$REPORT" >/dev/null; then
         pass "diagnosis present: $id"
@@ -170,10 +176,16 @@ else
     fail "Alpine probe diagnosis missing installer log evidence"
 fi
 
-if jq -e '.summary.diagnoses_blockers >= 4 and .summary.diagnoses_warnings >= 1' "$REPORT" >/dev/null; then
+if jq -e '.summary.diagnoses_blockers >= 7 and .summary.diagnoses_warnings >= 1' "$REPORT" >/dev/null; then
     pass "summary counts diagnosis blockers"
 else
     fail "summary does not count diagnosis blockers"
+fi
+
+if jq -e '.runtime.inference_contract.issue_counts.blockers >= 3 and .summary.runtime_contract_blockers >= 3' "$REPORT" >/dev/null; then
+    pass "runtime inference contract counts cloud/local mismatch blockers"
+else
+    fail "runtime inference contract missing cloud/local mismatch blockers"
 fi
 
 if jq -e '.autofix_hints[] | select(contains("known-good DreamServer version"))' "$REPORT" >/dev/null; then

--- a/dream-server/tests/test-dream-doctor.sh
+++ b/dream-server/tests/test-dream-doctor.sh
@@ -162,6 +162,14 @@ if command -v jq >/dev/null 2>&1; then
         pass "dream-doctor.sh runtime section has correct boolean fields"
     fi
 
+    jq_exit=0
+    jq -e '.runtime.inference_contract | type == "object"' "$TEMP_REPORT" >/dev/null || jq_exit=$?
+    if [[ $jq_exit -eq 0 ]]; then
+        pass "dream-doctor.sh runtime includes inference contract diagnostics"
+    else
+        fail "dream-doctor.sh runtime missing inference contract diagnostics"
+    fi
+
     amd_fields_ok=true
     for field in available runtime location runtimeMode managedByDreamServer selectedBackend supportedBackends health warnings; do
         jq_exit=0
@@ -178,7 +186,7 @@ fi
 
 # 9. summary section has expected numeric fields
 if command -v jq >/dev/null 2>&1; then
-    summary_fields=("preflight_blockers" "preflight_warnings")
+    summary_fields=("preflight_blockers" "preflight_warnings" "runtime_contract_blockers" "runtime_contract_warnings")
     summary_ok=true
 
     for field in "${summary_fields[@]}"; do

--- a/dream-server/tests/test-linux-cloud-mode.sh
+++ b/dream-server/tests/test-linux-cloud-mode.sh
@@ -45,6 +45,19 @@ contains "$flags" "extensions/services/litellm/compose.yaml" "cloud mode include
 rejects "$flags" "docker-compose.cpu.yml" "cloud mode does not include CPU llama-server overlay"
 rejects "$flags" "compose.local.yaml" "cloud mode does not include local dependency overlays"
 
+lemonade_flags="$(LEMONADE_EXTERNAL=true AMD_INFERENCE_RUNTIME=lemonade AMD_INFERENCE_MANAGED=false DREAM_PYTHON_CMD="$PY" ./scripts/resolve-compose-stack.sh \
+    --script-dir "$ROOT_DIR" \
+    --tier CLOUD \
+    --gpu-backend cpu \
+    --gpu-count 0 \
+    --dream-mode lemonade)"
+lemonade_flags="${lemonade_flags//\\//}"
+
+contains "$lemonade_flags" "docker-compose.base.yml" "external Lemonade keeps base stack"
+contains "$lemonade_flags" "docker-compose.cloud.yml" "external Lemonade profiles managed llama-server out"
+contains "$lemonade_flags" "docker-compose.lemonade-external.yml" "external Lemonade layers dedicated overlay"
+rejects "$lemonade_flags" "docker-compose.cpu.yml" "external Lemonade does not include CPU llama-server overlay"
+
 if grep -q 'profiles:' docker-compose.cloud.yml && grep -q 'local-inference' docker-compose.cloud.yml; then
     pass "cloud overlay profiles local llama-server out of default startup"
 else

--- a/dream-server/tests/test-support-bundle.sh
+++ b/dream-server/tests/test-support-bundle.sh
@@ -35,6 +35,9 @@ TMP_DIR="$(mktemp -d)"
 ENV_PATH="$ROOT_DIR/.env"
 ENV_BACKUP=""
 HAD_ENV=false
+BASH_WRAPPER_LOG="$TMP_DIR/bash-wrapper.log"
+REAL_BASH="$(command -v bash)"
+BASH_WRAPPER="$TMP_DIR/bash-wrapper"
 
 cleanup() {
     if [[ "$HAD_ENV" == "true" && -n "$ENV_BACKUP" && -f "$ENV_BACKUP" ]]; then
@@ -71,22 +74,38 @@ else
     fail "--help output is missing expected text"
 fi
 
+cat > "$BASH_WRAPPER" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$BASH_WRAPPER_LOG"
+exec "$REAL_BASH" "\$@"
+EOF
+chmod +x "$BASH_WRAPPER"
+
 SECRET_VALUE="support-bundle-super-secret"
 cat > "$ENV_PATH" <<EOF
 DASHBOARD_API_KEY=$SECRET_VALUE
 OPENAI_API_KEY=$SECRET_VALUE
 NORMAL_VALUE=visible-value
+DREAM_MODE=cloud
 GPU_BACKEND=cpu
 GPU_COUNT=1
+LLM_API_URL=http://litellm:4000
+HERMES_LLM_BASE_URL=http://litellm:4000/v1
 EOF
 
 OUTPUT_DIR="$TMP_DIR/out"
 RESULT_JSON="$TMP_DIR/result.json"
 
-if DREAM_SUPPORT_BUNDLE_DISABLE_DOCKER=1 bash "$SUPPORT_SCRIPT" --output "$OUTPUT_DIR" --no-logs --json > "$RESULT_JSON"; then
+if DREAM_SUPPORT_BUNDLE_BASH="$BASH_WRAPPER" DREAM_SUPPORT_BUNDLE_DISABLE_DOCKER=1 bash "$SUPPORT_SCRIPT" --output "$OUTPUT_DIR" --no-logs --json > "$RESULT_JSON"; then
     pass "support bundle command succeeds with Docker disabled"
 else
     fail "support bundle command failed with Docker disabled"
+fi
+
+if grep -q 'scripts/dream-doctor.sh' "$BASH_WRAPPER_LOG" && grep -q 'scripts/resolve-compose-stack.sh' "$BASH_WRAPPER_LOG"; then
+    pass "support bundle uses selected Bash for nested project scripts"
+else
+    fail "support bundle did not use selected Bash for nested project scripts"
 fi
 
 if python3 -m json.tool "$RESULT_JSON" >/dev/null; then
@@ -172,12 +191,17 @@ import sys
 evidence = json.load(open(sys.argv[1], encoding="utf-8"))
 assert evidence["version"] == "1"
 assert "platform" in evidence
+assert isinstance(evidence["platform"]["wsl"], bool)
 assert "backend" in evidence
+assert "inference_contract" in evidence
 assert "compose" in evidence
 assert "config_hashes" in evidence
 assert evidence["env_keys"]["DASHBOARD_API_KEY"]["redacted"] is True
 assert evidence["env_keys"]["DASHBOARD_API_KEY"]["value"] is None
 assert evidence["env_keys"]["NORMAL_VALUE"]["value"] == "visible-value"
+assert "docker-compose.cloud.yml" in evidence["compose"]["files"]
+assert "docker-compose.cpu.yml" not in evidence["compose"]["files"]
+assert evidence["inference_contract"]["issue_counts"]["blockers"] == 0
 PY
 then
     pass "evidence.json records redacted env and support metadata"


### PR DESCRIPTION
## Summary

Adds an inference routing contract to `dream doctor` and the redacted support bundle so support reports can tell whether DreamServer's installed mode, compose stack, and LLM URLs agree about who owns inference.

Important context: #1364 already fixed the Linux cloud runtime path so current installs should not start, wait on, or route through local `llama-server` in cloud mode. This PR does **not** re-fix that runtime path. It adds evidence-based diagnostics and tightens support-bundle evidence so stale installs, hand-edited `.env` files, old `.compose-flags`, external Lemonade drift, WSL/Linux/macOS shell differences, or future regressions are visible from one bundle.

The contract flags violations such as:

- `DREAM_MODE=cloud` but cached `.compose-flags` does not include `docker-compose.cloud.yml`
- cloud mode still routes `LLM_API_URL` to local `llama-server`
- cloud mode still routes Hermes to local `llama-server`
- external Lemonade is active without the cloud/external overlays
- local mode accidentally keeps the cloud overlay or a non-AMD LiteLLM route

## What changed

- Adds `runtime.inference_contract` to the doctor JSON report with selected mode, expected inference owner/gateway, relevant LLM URLs, compose files, stable issue IDs, and blocker/warning counts.
- Promotes contract violations into evidence-ranked `diagnoses` entries with recovery hints.
- Avoids false positives for overlay mismatch checks when `.compose-flags` is absent rather than stale.
- Displays the contract in `dream doctor` human output.
- Adds the contract snapshot to support bundle `manifest/evidence.json`.
- Fixes support-bundle compose evidence so it resolves the stack with recorded `DREAM_MODE`, external Lemonade flags, and AMD runtime ownership instead of always behaving like a local install.
- Uses the selected Bash for nested support-bundle diagnostics, compose resolution, and compose validation, and records the selected Bash in the bundle. This keeps Linux/WSL behavior normal while avoiding macOS Bash 3.2 child-script drift when a newer Bash is available.
- Records WSL detection in support-bundle evidence so Windows/WSL support cases are distinguishable from native Linux.
- Documents the contract, stable diagnosis IDs, and bundle evidence behavior in `docs/DREAM-DOCTOR.md`.

## Why

Mode bugs are currently easy to discuss abstractly and hard to support from evidence. #1364 fixed the active cloud installer behavior; this PR makes that behavior auditable after install. Local inference means DreamServer manages/targets `llama-server`; cloud/private/external inference should route Dream services through the external gateway path instead of accidentally targeting local inference.

The support bundle part is necessary because a failing user usually shares bundle evidence, not just a live terminal. If the bundle resolves Compose as local while the user configured cloud or external Lemonade, support can chase the wrong stack. If macOS runs doctor children through an older Bash, the doctor JSON can be missing even though the support script itself started successfully.

## Validation

- `bash -n dream-server/scripts/dream-doctor.sh dream-server/scripts/dream-support-bundle.sh dream-server/tests/test-support-bundle.sh dream-server/tests/test-linux-cloud-mode.sh`
- `bash dream-server/tests/test-support-bundle.sh`
- `bash dream-server/tests/test-linux-cloud-mode.sh`
- `bash dream-server/tests/test-dream-doctor-install-diagnoses.sh`
- `bash dream-server/tests/test-dream-doctor.sh`
- `bash dream-server/tests/test-doctor-command.sh`
- `bash dream-server/tests/contracts/test-external-lemonade-contracts.sh`
- `bash dream-server/tests/test-doc-links.sh`
- `git diff --check`
