### PR TITLE
[codex] refine forkability as independent operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ Other tools get you part of the way. Dream Server gets you the whole way.
 | [Docs Index](dream-server/docs/README.md) | Maintained map for operators, contributors, and reviewers |
 | [Build On Dream Server](dream-server/docs/BUILD-ON-DREAM-SERVER.md) | Forking, custom editions, extension templates, and downstream validation |
 | [Forkability](dream-server/docs/FORKABILITY.md) | How to fork, audit, customize, and independently operate Dream Server |
-| [Maintainer Runbook](dream-server/docs/MAINTAINER_RUNBOOK.md) | Release, rollback, validation, and handoff guidance for maintainers and fork operators |
+| [Maintainer Runbook](dream-server/docs/MAINTAINER_RUNBOOK.md) | Release, rollback, validation, and operator continuity guidance for maintainers and forks |
 | [High-Risk Change Map](dream-server/docs/HIGH_RISK_CHANGE_MAP.md) | Which changes require focused checks, fleet validation, or release-grade gates |
 | [Headless Setup](dream-server/docs/HEADLESS-SETUP.md) | QR onboarding, first-boot setup, AP mode, mDNS, and local agent access |
 | [Support Matrix](dream-server/docs/SUPPORT-MATRIX.md) | Current platform and GPU support status |

--- a/dream-server/docs/FORKABILITY.md
+++ b/dream-server/docs/FORKABILITY.md
@@ -1,8 +1,9 @@
 # Forkability And Independent Operation
 
-Dream Server is Apache-licensed infrastructure. Upstream should be useful, but it
-should not be the only place where the system can be understood, operated, or
-kept alive.
+Dream Server is Apache-licensed infrastructure. The upstream repository is a
+coordination point, not a hosted control plane. Operators should be able to
+inspect the rules, run their own node, validate their own hardware, and maintain
+their own fork.
 
 This document describes the project posture for downstream maintainers,
 hardware builders, labs, schools, companies, and individuals who want to fork,
@@ -15,7 +16,7 @@ Dream Server should be:
 - forkable without asking upstream for permission;
 - auditable from a cold clone;
 - customizable through documented extension points;
-- recoverable from pinned refs and mirrored artifacts;
+- reproducible from pinned refs and mirrored artifacts;
 - validated by repeatable public and private test layers;
 - understandable by maintainers who did not write the original installer.
 

--- a/dream-server/docs/MAINTAINER_RUNBOOK.md
+++ b/dream-server/docs/MAINTAINER_RUNBOOK.md
@@ -114,11 +114,11 @@ Treat these areas as high-risk:
 Use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) to choose validation
 before merging.
 
-## Handoff Checklist
+## Operator Handoff Checklist
 
-When handing maintenance to another person or fork:
+When adding, rotating, or handing off maintenance for an upstream area or fork:
 
-- point them at this runbook;
+- point the operator at this runbook;
 - identify the current known-good commit;
 - share the latest sanitized validation result;
 - list disabled or lab-only fleet lanes;
@@ -127,5 +127,5 @@ When handing maintenance to another person or fork:
 - explain where secrets and runtime data live;
 - explain how to restore from backup or reinstall cleanly.
 
-The handoff is not complete until the next operator can run validation and
+The handoff is not complete until the receiving operator can run validation and
 interpret the result without private context.

--- a/dream-server/docs/OFFLINE_AND_MIRRORING.md
+++ b/dream-server/docs/OFFLINE_AND_MIRRORING.md
@@ -1,8 +1,8 @@
 # Offline And Mirroring Guide
 
 Dream Server should be usable as independently owned infrastructure. This guide
-explains how operators and forks can reduce reliance on mutable upstream state by
-pinning, mirroring, and recording release artifacts.
+explains how operators and forks can run from their own pinned refs, mirrors, and
+release receipts instead of depending on mutable upstream state at install time.
 
 This is not a promise that every upstream service, model, or image license
 permits redistribution. Mirror only what you are allowed to mirror.
@@ -102,9 +102,9 @@ Operator notes:
 The receipt is what lets another maintainer rebuild trust without access to the
 original lab.
 
-## Recovery If Upstream Disappears
+## Operating From Your Own Mirror
 
-If upstream is unavailable:
+When you choose to operate from a mirror:
 
 1. Use your mirrored git ref.
 2. Restore mirrored Docker images or retag local images.
@@ -113,5 +113,5 @@ If upstream is unavailable:
 5. Run the validation subset from [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md).
 6. Record a new local validation receipt.
 
-The goal is not to freeze Dream Server forever. The goal is to make each release
-understandable and recoverable without depending on mutable external state.
+The goal is not to freeze Dream Server at one point in time. The goal is to make
+each release inspectable and reproducible from artifacts an operator controls.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -139,7 +139,7 @@ at [`../../README.md`](../../README.md).
 | Doc | Audience | Description |
 |-----|----------|-------------|
 | [../CONTRIBUTING.md](../CONTRIBUTING.md) | Contributors | How to contribute |
-| [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md) | Maintainers / fork operators | Release, rollback, validation, and handoff runbook |
+| [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md) | Maintainers / fork operators | Release, rollback, validation, and operator continuity runbook |
 | [../SECURITY.md](../SECURITY.md) | Everyone | Security guide and disclosure |
 | [../../SECURITY_AUDIT.md](../../SECURITY_AUDIT.md) | Maintainers / reviewers | Historical security audit with current remediation status and receipts |
 | [../CHANGELOG.md](../CHANGELOG.md) | Everyone | Version history |


### PR DESCRIPTION
﻿## Summary

This follow-up tunes the forkability docs toward the intended independent-node framing:

- describes upstream as a coordination point, not a hosted control plane
- says operators should be able to inspect rules, run their own node, validate hardware, and maintain forks
- replaces contingency phrasing like "Recovery If Upstream Disappears" with "Operating From Your Own Mirror"
- changes "handoff guidance" labels to operator continuity language

## Why

The previous docs were directionally right, but a couple phrases could read more like founder-contingency planning than durable public infrastructure. This keeps the same substance while making the posture closer to "anyone can run, audit, fork, and validate their own node."

## User impact

Docs-only. No installer, runtime, compose, dashboard, dependency, or service behavior changes.

## Validation

- `git diff --check`
- Local Markdown link sanity check across 80 Markdown files: PASS