### PR TITLE
[codex] add PR validation entrypoints

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,53 @@
+## Summary
+
+<!-- What changed, and why? -->
+
+## Changed Surface
+
+<!-- Check every surface this PR can affect. -->
+
+- [ ] Docs only
+- [ ] Tests only
+- [ ] Dashboard UI
+- [ ] Dashboard API / host agent
+- [ ] Installer / bootstrap / lifecycle
+- [ ] Docker Compose / service manifests
+- [ ] Model routing / Hermes / capabilities
+- [ ] Network exposure / auth / proxy
+- [ ] Dependencies / runtime wiring
+
+## Risk And Validation
+
+<!-- Use dream-server/docs/HIGH_RISK_CHANGE_MAP.md to pick the right level. -->
+
+- Risk level: <!-- Low / Medium / High -->
+- Validation run:
+  - [ ] `git diff --check`
+  - [ ] Markdown/link sanity for docs
+  - [ ] Focused tests listed below
+  - [ ] Dashboard lint/test/build
+  - [ ] Extension audit / compose validation
+  - [ ] Release-grade fleet or scoped hardware validation
+  - [ ] Not required because: <!-- explain -->
+
+Commands/results:
+
+```text
+<!-- paste the important commands and results -->
+```
+
+## Operational Change Check
+
+If this PR touches installer phases, bootstrap logic, compose stack generation,
+service manifests, dashboard API control flows, Hermes, model routing, GPU or
+runtime detection, lifecycle commands, host mutation, or network exposure, it
+requires release-grade fleet validation before release unless the PR explains a
+narrower equivalent.
+
+- [ ] This is not an operational change.
+- [ ] This is an operational change and validation is recorded above.
+- [ ] This is an operational change and validation is intentionally deferred for:
+
+## Notes For Reviewers
+
+<!-- Call out skipped/deferred lanes, known limitations, or rollback notes. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,12 @@ mutation surfaces, use
 **[dream-server/docs/HIGH_RISK_CHANGE_MAP.md](dream-server/docs/HIGH_RISK_CHANGE_MAP.md)**
 to choose the right validation before opening a PR.
 
+Every PR should make its changed surface obvious. The pull request template asks
+contributors to classify the risk, list the checks they ran, and say whether the
+change needs release-grade validation before a release. Docs-only changes do not
+need the fleet; operational changes should not rely on "looks small" as the
+validation argument.
+
 ## Full Contributor Guide
 
 For current priorities, validation checklists, PR expectations, and style guidelines, see the detailed guide:

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -10,6 +10,11 @@ at [`../../README.md`](../../README.md).
 
 ## Start Here By Job
 
+Use this table as the "you are here" map. Dream Server has many deep-dive
+docs because the project covers install, compose, model routing, agents,
+security, and release validation. Most contributors only need the row that
+matches the work in front of them.
+
 | I want to... | Read this first | Then use |
 |--------------|-----------------|----------|
 | Install the default path | [../QUICKSTART.md](../QUICKSTART.md) | [INSTALLER_TRUST.md](INSTALLER_TRUST.md), [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md), [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) |
@@ -22,6 +27,22 @@ at [`../../README.md`](../../README.md).
 | Build a custom edition or fork | [FORKABILITY.md](FORKABILITY.md) | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md), [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md), [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) |
 | Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [TESTING.md](TESTING.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
 | Maintain a release or fork | [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md) | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md), [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md) |
+
+## Choosing Validation
+
+The shortest useful rule is: docs-only changes get docs checks; operational
+changes get the validation surface they can affect.
+
+| Change type | Start with | Escalate when |
+|-------------|------------|---------------|
+| Docs, comments, examples | `git diff --check`, markdown/link sanity | The docs change makes or changes a support claim |
+| UI-only dashboard work | Dashboard tests, lint, and build | It changes setup, auth, service control, or model workflows |
+| Service manifest or extension metadata | Extension audit and catalog validation | It changes compose, ports, health, dependencies, or defaults |
+| Installer, compose, CLI, auth, proxy, model routing | Focused tests plus release-grade validation | Always consider this operational code |
+| Dependency/runtime wiring | Package tests and service smoke | The package affects installer, dashboard-api, services, or container startup |
+
+Use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) for the full policy and
+[RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) for the User Green release gate.
 
 ## Current Truths
 

--- a/dream-server/docs/RELEASE_VALIDATION.md
+++ b/dream-server/docs/RELEASE_VALIDATION.md
@@ -26,6 +26,11 @@ Docs-only, comment-only, and narrow test-only changes usually use focused
 validation instead. Dependency or runtime wiring changes should use the
 release-grade gate even when the code diff is small.
 
+PRs should state their changed surface and validation level explicitly. Use
+[HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) to decide whether focused
+checks are enough or whether the candidate needs release-grade fleet validation
+before it is treated as releasable.
+
 ## User Green
 
 `User Green` is the top-level release-readiness result. It is not a marketing


### PR DESCRIPTION
﻿## Summary

Adds contributor-facing validation entrypoints so PRs classify their changed surface, risk level, and required checks up front.

## What changed

- Added a GitHub pull request template with changed-surface, risk, validation, and operational-change sections.
- Added a short validation chooser to the docs index so contributors can get from "what did I touch?" to the right test surface quickly.
- Linked the PR process back to the high-risk change map and release validation docs from `CONTRIBUTING.md` and `RELEASE_VALIDATION.md`.

## Impact

Docs/process only. No installer, runtime, service, or dependency behavior changes.

## Validation

```text
git diff --check
[PASS]

python markdown local-link sanity
[PASS] checked 81 markdown files; local links resolve
```
