### PR TITLE
[codex] add provenance and CLI roadmap

### DIFF
--- a/dream-server/docs/DREAM_CLI_DECOMPOSITION.md
+++ b/dream-server/docs/DREAM_CLI_DECOMPOSITION.md
@@ -1,0 +1,92 @@
+# Dream CLI Decomposition Plan
+
+`dream-cli` is the operator control surface for status, lifecycle, config,
+model, extension, backup, and diagnostic commands. It is intentionally shell
+native because it lives beside a shell-first installer, but the file is large
+enough that future changes need a staged decomposition plan.
+
+This is a behavior-preserving roadmap. It is not a rewrite proposal.
+
+## Goals
+
+- Keep the installed `dream` command stable.
+- Split low-risk helpers before lifecycle or host-mutating commands.
+- Preserve Bash portability for installed hosts.
+- Add or keep contract tests before moving command groups.
+- Make future forks able to modify one command family without understanding the
+  whole CLI at once.
+
+## Non-Goals
+
+- No big-bang Rust, Go, Python, or Node rewrite.
+- No command syntax changes as part of extraction.
+- No change to install location, symlink behavior, or support-bundle output.
+- No hidden dependency on developer-only tooling.
+
+## Current Command Families
+
+| Family | Examples | Risk |
+|--------|----------|------|
+| Read-only status | `status`, `list`, `logs`, `config show` | Medium |
+| Diagnostics | `doctor`, support-bundle helpers | High |
+| Lifecycle | `start`, `stop`, `restart`, service restart aliases | High |
+| Model management | `model current`, `model list`, `model swap` | High |
+| Mode/config | `mode local`, `mode cloud`, presets, env mutation | High |
+| Extensions | `enable`, `disable`, audit/list commands | High |
+| Backup/restore | backup, restore, preset import/export | High |
+
+## Extraction Order
+
+1. **Read-only formatting helpers**
+   - Move table rendering, service alias lookup, and masked config formatting
+     into small sourced modules.
+   - Validation: CLI smoke and snapshot-style output checks.
+
+2. **Read-only status and logs**
+   - Extract commands that inspect Docker/service state without mutating host
+     files.
+   - Validation: `dream status`, `dream list`, and log alias tests.
+
+3. **Diagnostics**
+   - Extract `dream doctor` orchestration while keeping individual diagnostic
+     scripts as the source of truth.
+   - Validation: doctor smoke, support-bundle redaction tests.
+
+4. **Model and mode commands**
+   - Extract model catalog, swap, and mode helpers only after current contract
+     tests cover rollback, model identity, and generated config writers.
+   - Validation: model selector tests, generated config tests, model swap smoke.
+
+5. **Extensions**
+   - Extract extension enable/disable/list behavior after manifest and compose
+     resolver contracts cover the changed paths.
+   - Validation: extension audit, compose resolver checks, dashboard extension
+     flow when behavior changes.
+
+6. **Lifecycle and backup/restore last**
+   - Keep start/stop/restart and restore flows in the main file until lower-risk
+     extractions are proven.
+   - Validation: lifecycle lane, `dream restart`, `dream doctor`, backup/restore
+     round trip where applicable.
+
+## Guardrails For Each PR
+
+Each decomposition PR should:
+
+- move one command family or helper family only;
+- keep the public command syntax unchanged;
+- include a before/after validation note;
+- avoid changing compose flags, env parsing, or service aliases unless that is
+  the explicit purpose of the PR;
+- preserve shellcheck/lint behavior where available;
+- explain whether release-grade fleet validation is required before release.
+
+## Success Criteria
+
+The CLI is healthier when:
+
+- `dream-cli` becomes a dispatcher plus shared compatibility glue;
+- command families live in files with narrow ownership;
+- tests prove behavior before and after each move;
+- forks can safely override or patch a command family without modifying the
+  entire operator CLI.

--- a/dream-server/docs/HIGH_RISK_CHANGE_MAP.md
+++ b/dream-server/docs/HIGH_RISK_CHANGE_MAP.md
@@ -26,7 +26,7 @@ obvious to contributors, fork operators, and auditors.
 | Installer libraries | Medium/High | Shared by multiple phases and platform paths | Focused unit/contract tests plus install smoke when behavior changes |
 | Windows installer | High | Separate shell/runtime semantics and Docker Desktop assumptions | PowerShell lint/tests, Windows smoke, fleet Windows lane when available |
 | macOS installer | High | Native Metal llama-server plus Docker services | macOS smoke, lifecycle, model swap when applicable |
-| `dream-cli` | High | User lifecycle, config, restart, backup, mode, and extension control | CLI smoke, `dream restart`, `dream doctor`, lifecycle lane |
+| `dream-cli` | High | User lifecycle, config, restart, backup, mode, and extension control | CLI smoke, `dream restart`, `dream doctor`, lifecycle lane; use [DREAM_CLI_DECOMPOSITION.md](DREAM_CLI_DECOMPOSITION.md) for behavior-preserving split work |
 | Compose resolver | High | Determines actual runtime stack | Resolver tests, compose matrix, distro smoke, fleet if operational |
 | Base or hardware compose overlays | High | Can break every install in a hardware class | Compose matrix plus matching real-hardware lane |
 | Dashboard UI | Medium | Operator workflows and setup visibility | `npm test`, `npm run lint`, `npm run build`, Playwright smoke for visible flows |

--- a/dream-server/docs/INSTALLER_TRUST.md
+++ b/dream-server/docs/INSTALLER_TRUST.md
@@ -103,6 +103,23 @@ for every installer artifact. That is the next stronger trust model. Until then,
 users who need strict provenance should install from a reviewed tag or internal
 fork and record the exact commit or release tag they deployed.
 
+## Provenance Roadmap
+
+The current installer trust model is source-visible and ref-pinnable. The next
+steps toward a stronger binary and release provenance chain are:
+
+1. Publish checksums for release installer artifacts and document how to verify
+   them before running installers.
+2. Sign release artifacts and tags with maintainer-controlled signing keys.
+3. Publish SBOMs for release artifacts and core container images.
+4. Record build provenance for desktop installer artifacts.
+5. Document the exact validation receipt tied to each release candidate.
+6. Keep the inspect-first and manual source install paths available even after
+   signed artifacts exist.
+
+These are roadmap items, not current guarantees. Release notes should clearly
+say which provenance pieces are present for a given release.
+
 ## Related Validation
 
 - [Release Validation](RELEASE_VALIDATION.md) explains the User Green gates.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -70,6 +70,7 @@ at [`../../README.md`](../../README.md).
 | [../extensions/templates/README.md](../extensions/templates/README.md) | Builders | Starter manifest, compose, GPU overlay, and dashboard plugin templates |
 | [../extensions/CATALOG.md](../extensions/CATALOG.md) | Builders / reviewers | Current bundled service manifest catalog |
 | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | Modders | Installer module map, mod recipes, header convention |
+| [DREAM_CLI_DECOMPOSITION.md](DREAM_CLI_DECOMPOSITION.md) | Maintainers / CLI contributors | Behavior-preserving plan for splitting the large Bash operator CLI without a risky rewrite |
 | [INTEGRATION-GUIDE.md](INTEGRATION-GUIDE.md) | Developers | Connect apps via OpenAI SDK, LangChain, n8n |
 | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) | Developers | Backend runtime contract JSON schema |
 | [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md) | Maintainers / installer reviewers | Phase ownership, inputs, outputs, idempotency, and validation expectations |


### PR DESCRIPTION
﻿## Summary

Adds the explicit roadmap for installer provenance and a behavior-preserving plan to split the large Bash `dream-cli` safely over time.

## What changed

- Added `DREAM_CLI_DECOMPOSITION.md` with goals, non-goals, command families, extraction order, and per-PR guardrails.
- Extended `INSTALLER_TRUST.md` with a provenance roadmap for checksums, signatures, SBOMs, build provenance, and validation receipts.
- Linked the CLI roadmap from the docs index and high-risk change map.

## Impact

Docs/process only. No installer, CLI, service, dependency, or runtime behavior changes.

## Validation

```text
git diff --check
[PASS]

python markdown local-link sanity
[PASS] checked 81 markdown files; local links resolve
```
