### PR TITLE
[codex] remove stale line count claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,14 +15,14 @@ The repo has two layers:
 
 Within `dream-server/`:
 
-- **`install-core.sh`** — thin orchestrator (~184 lines) that sources libs then runs phases in order
+- **`install-core.sh`** — thin orchestrator that sources libs then runs phases in order
 - **`installers/lib/`** — pure function libraries (constants, logging, UI, GPU detection, tier mapping, packaging, compose selection)
 - **`installers/phases/`** — 13 sequential install steps (`01-preflight` through `13-summary`), each sourced by install-core
 - **`installers/macos/`**, **`installers/windows/`** — platform-specific installer variants
 - **`extensions/services/`** — 24 bundled service manifests, each a directory with `manifest.yaml` + optional `compose.yaml` and GPU overlays
 - **`extensions/library/`** — optional extension catalog, templates, workflows, and manifest schema used by the dashboard Extensions page
 - **`docker-compose.base.yml`** — core service definitions; `docker-compose.{amd,nvidia,apple}.yml` are GPU overlays
-- **`dream-cli`** — main CLI tool (~45K lines Bash) for managing the stack
+- **`dream-cli`** — main Bash CLI for managing the stack; keep changes narrow and follow `docs/DREAM_CLI_DECOMPOSITION.md` for behavior-preserving split work
 - **`config/`** — backend configs (`backends/amd.json`, `nvidia.json`, etc.), GPU database, LiteLLM config, hardware classes
 - **`extensions/services/dashboard-api/`** — Python FastAPI backend (with `routers/`, `tests/`)
 - **`extensions/services/dashboard/`** — React + Vite + Tailwind frontend (`src/`)


### PR DESCRIPTION
﻿## Summary

Removes stale brittle line-count claims from `CLAUDE.md` so clone-and-audit tools do not flag inaccurate repository guidance.

## What changed

- Removed the outdated `install-core.sh` line count from the repository structure map.
- Replaced the inaccurate `dream-cli ~45K lines` claim with a stable description and a pointer to the CLI decomposition plan.

## Impact

Docs-only. No installer, runtime, CLI behavior, dependency, or service changes.

## Validation

```text
git diff --check
[PASS]

rg "45K|~184 lines|~[0-9][0-9,.]* lines" CLAUDE.md README.md dream-server/docs/DREAM_CLI_DECOMPOSITION.md dream-server/docs/README.md
[PASS] no stale line-count claims found in checked docs

python markdown local-link sanity
[PASS] checked 84 markdown files; local links resolve
```
