### PR TITLE
[codex] label docs and plan manifest v2

### DIFF
--- a/dream-server/docs/EXTENSIONS.md
+++ b/dream-server/docs/EXTENSIONS.md
@@ -27,6 +27,12 @@ extensions/services/
 
 **Extension services** have both `manifest.yaml` and `compose.yaml`. The compose fragment is merged into the stack automatically by `resolve-compose-stack.sh`.
 
+The current manifest schema is v1. If you are proposing new manifest semantics
+rather than filling existing fields, read
+[SERVICE_MANIFEST_V2_PLAN.md](SERVICE_MANIFEST_V2_PLAN.md) first. v1 remains
+the supported schema until migration tooling and compatibility policy are in
+place.
+
 ## What You Can Extend
 
 - **Docker services** via `extensions/services/<name>/compose.yaml`

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -45,6 +45,20 @@ changes get the validation surface they can affect.
 Use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) for the full policy and
 [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) for the User Green release gate.
 
+## Document Status
+
+Some docs are canonical contracts; others are operator guides, implementation
+deep dives, or historical/planned notes. When docs overlap, prefer the
+canonical source and treat older recipes as context.
+
+| Status | Meaning | Examples |
+|--------|---------|----------|
+| Canonical contract | Defines behavior reviewers should enforce | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md), [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) |
+| Operator guide | Helps users install, operate, or troubleshoot | [../QUICKSTART.md](../QUICKSTART.md), [DREAM-DOCTOR.md](DREAM-DOCTOR.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md), [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) |
+| Maintainer runbook | Explains how to preserve or release the project | [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md), [FORKABILITY.md](FORKABILITY.md), [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md), [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) |
+| Deep dive | Explains a subsystem or design area | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md), [DREAM_CLI_DECOMPOSITION.md](DREAM_CLI_DECOMPOSITION.md) |
+| Historical or planned | Records a past migration, launch checklist, or future direction | [PROFILES.md](PROFILES.md), [OSS-LAUNCH-CHECKLIST.md](OSS-LAUNCH-CHECKLIST.md), [SERVICE_MANIFEST_V2_PLAN.md](SERVICE_MANIFEST_V2_PLAN.md) |
+
 ## Current Truths
 
 - The golden paths are Linux NVIDIA, Windows with Docker Desktop + WSL2 for
@@ -91,6 +105,7 @@ Use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) for the full policy and
 | [EXTENSIONS.md](EXTENSIONS.md) | Builders | Add Docker services, manifests, dashboard plugins |
 | [../extensions/templates/README.md](../extensions/templates/README.md) | Builders | Starter manifest, compose, GPU overlay, and dashboard plugin templates |
 | [../extensions/CATALOG.md](../extensions/CATALOG.md) | Builders / reviewers | Current bundled service manifest catalog |
+| [SERVICE_MANIFEST_V2_PLAN.md](SERVICE_MANIFEST_V2_PLAN.md) | Maintainers / extension reviewers | Non-breaking plan for future manifest schema evolution |
 | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | Modders | Installer module map, mod recipes, header convention |
 | [DREAM_CLI_DECOMPOSITION.md](DREAM_CLI_DECOMPOSITION.md) | Maintainers / CLI contributors | Behavior-preserving plan for splitting the large Bash operator CLI without a risky rewrite |
 | [INTEGRATION-GUIDE.md](INTEGRATION-GUIDE.md) | Developers | Connect apps via OpenAI SDK, LangChain, n8n |

--- a/dream-server/docs/SERVICE_MANIFEST_V2_PLAN.md
+++ b/dream-server/docs/SERVICE_MANIFEST_V2_PLAN.md
@@ -1,0 +1,82 @@
+# Service Manifest v2 Plan
+
+Dream Server's bundled and library services use the v1 manifest schema today.
+The v1 schema remains supported. This document is a planning note for a future
+v2 schema so maintainers can evolve service metadata deliberately instead of
+stretching one version forever.
+
+This is not an implementation PR and does not change validation behavior.
+
+## Why Plan v2
+
+The v1 schema has held up well, but several concepts now carry more meaning
+than the original service catalog needed:
+
+- health checks can be HTTP, TCP, container-state, CLI, or intentionally absent;
+- services may be core, optional, deprecated, owner-card-only, or backend-specific;
+- GPU backend support now spans NVIDIA, AMD/Lemonade, Apple Metal, Intel Arc,
+  CPU, cloud, and hybrid paths;
+- dashboard, CLI, compose resolver, installer summary, and extension audit all
+  consume overlapping manifest fields;
+- compatibility bounds such as `dream_min` and `dream_max` are doing real work
+  for downstream forks and extension catalogs.
+
+A v2 schema should make these semantics explicit while preserving a stable v1
+compatibility window.
+
+## Goals
+
+- Keep v1 manifests valid during the migration window.
+- Add clearer health semantics without forcing HTTP-only health endpoints.
+- Separate user-facing catalog metadata from runtime/compose behavior where that
+  reduces ambiguity.
+- Make backend and lifecycle capabilities machine-readable for installers,
+  dashboards, audits, and forks.
+- Provide migration tooling before requiring v2 for bundled services.
+
+## Non-Goals
+
+- No immediate breaking change to existing manifests.
+- No dashboard catalog redesign in the same step.
+- No removal of v1 validation until v2 conversion and compatibility tooling are
+  proven.
+- No new service behavior implied by schema metadata alone.
+
+## Candidate v2 Concepts
+
+| Area | v1 pressure | v2 direction |
+|------|-------------|--------------|
+| Health | `health` can mean HTTP path, empty string, or container-state fallback | Add explicit `health.type` such as `http`, `tcp`, `container`, `cli`, or `none` |
+| Lifecycle | Startup, optionality, and restart expectations are spread across manifests and compose | Add explicit lifecycle capabilities such as `startable`, `restartable`, `requires_host_runtime` |
+| Backend support | `gpu_backends` is useful but overloaded for service availability and acceleration | Split acceleration support from required platform/runtime constraints if needed |
+| Exposure | Network exposure policy lives outside manifests | Keep policy external, but allow manifests to declare intended exposure class for auditing |
+| Catalog metadata | Dashboard library fields and runtime fields share one document | Consider nested `catalog` and `runtime` sections |
+| Compatibility | `dream_min`/`dream_max` are already useful | Keep explicit compatibility bounds and document fork behavior |
+
+## Migration Shape
+
+1. Add v2 schema alongside v1.
+2. Add a converter or linter that can suggest v2 fields for v1 manifests.
+3. Convert a small non-core service first.
+4. Teach extension audit and catalog generation to read both versions.
+5. Convert bundled services in batches.
+6. Keep v1 accepted until release notes announce the deprecation window.
+
+## Validation Required
+
+Any v2 implementation PR should run:
+
+- manifest schema validation for v1 and v2;
+- extension audit;
+- compose resolver checks;
+- dashboard extension catalog generation;
+- focused dashboard extension UI/API tests when catalog fields change;
+- release-grade validation before a release if bundled service runtime behavior
+  or compose generation changes.
+
+## Fork Guidance
+
+Forks should not invent incompatible v2 fields privately if they intend to
+rebase onto upstream. Prefer adding namespaced experimental fields under an
+`x_` prefix, documenting the behavior, and upstreaming the field once it proves
+useful across more than one service or hardware class.


### PR DESCRIPTION
## Summary
- add a document-status table so overlapping docs have clearer authority levels
- add a non-breaking service manifest v2 planning note
- point extension authors at the v2 plan before inventing new manifest semantics

## Risk
Docs-only. No installer, runtime, schema validator, compose, or dashboard behavior changes.

## Validation
- git diff --check
- local markdown link sanity script (`[PASS] checked 86 markdown files; local links resolve`)