### PR TITLE
[codex] add Hermes slash worker guardrails

### DIFF
--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -171,6 +171,38 @@ docker logs -f dream-hermes
 
 First start does a ~30s skills sync; subsequent starts are fast.
 
+### Chat slows down after many Dream Talk or Hermes sessions
+
+Some upstream Hermes builds can leave `tui_gateway.slash_worker` child
+processes running after sessions that use `/slash` commands such as
+`/no_think`. Each worker can hold model memory, so a long day of owner-card or
+fleet-test sessions may create memory pressure even though the main Hermes
+container looks healthy.
+
+Check with:
+
+```bash
+dream doctor
+docker exec dream-hermes sh -c "ps -eo pid=,etimes=,args= | grep '[t]ui_gateway[.]slash_worker'"
+```
+
+Clean up workers that exceed the age/count policy:
+
+```bash
+dream repair hermes-workers
+```
+
+Policy knobs:
+
+```bash
+HERMES_SLASH_WORKER_MAX_COUNT=8
+HERMES_SLASH_WORKER_MAX_AGE_SECONDS=3600
+```
+
+`dream doctor` reports high worker counts. `dream repair hermes-workers` is
+explicit and manual; Dream Server does not run an automatic process killer for
+active Hermes sessions.
+
 ### Hermes can't reach the LLM
 
 Inside the container, `llama-server:8080` should resolve to the llama-server container. Test with:

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -4075,6 +4075,11 @@ cmd_repair() {
 
     local target="${1:-voice}"
     case "$target" in
+        hermes-workers|slash-workers)
+            local script="$INSTALL_DIR/scripts/prune-hermes-slash-workers.sh"
+            [[ -x "$script" ]] || error "Hermes slash worker repair script not found or not executable: $script"
+            "$script" --force
+            ;;
         voice|stt|tts)
             local flags_str
             flags_str=$(get_compose_flags)
@@ -4135,7 +4140,7 @@ cmd_repair() {
             success "Voice repair complete"
             ;;
         *)
-            log "Usage: dream repair voice"
+            log "Usage: dream repair [voice|hermes-workers]"
             log_error "Unknown repair target: $target"
             return 1
             ;;
@@ -4372,7 +4377,8 @@ ${CYAN}Commands:${NC}
   chat "<message>"    Quick chat with the LLM
   benchmark           Run a quick performance test
   doctor [report|--json]   Run diagnostics (--json writes JSON to stdout)
-  repair|fix [voice]  Repair voice services and cache the STT model
+  repair|fix [voice|hermes-workers]
+                      Repair voice services or prune leaked Hermes slash workers
   template [action]   Apply pre-built service templates (list|preview|apply)
   audit [extensions]  Audit extension manifests and compose contracts
   agent [action]      Manage dream host agent (status|start|stop|restart|logs)
@@ -4458,6 +4464,7 @@ ${CYAN}Examples:${NC}
   dream agent status              # Check host agent health
   dream agent restart             # Restart host agent
   dream repair voice              # Start voice services and cache STT model
+  dream repair hermes-workers     # Prune leaked Hermes slash_worker children
 
 ${CYAN}Environment:${NC}
   DREAM_HOME          Installation directory (default: ~/dream-server)

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -298,6 +298,22 @@ collect_extension_diagnostics() {
     fi
 }
 
+# Hermes slash workers are spawned by upstream Hermes for /slash commands. A
+# leak in that worker lifecycle can create many long-lived child processes and
+# starve local models of RAM. Doctor only reports; cleanup remains explicit via
+# `dream repair hermes-workers`.
+HERMES_SLASH_WORKER_MAX_COUNT="${HERMES_SLASH_WORKER_MAX_COUNT:-8}"
+HERMES_SLASH_WORKER_COUNT="0"
+if [[ "$DOCKER_DAEMON" == "true" ]] && docker ps --format '{{.Names}}' 2>/dev/null | grep -qx 'dream-hermes'; then
+    _hermes_worker_count="$(
+        docker exec dream-hermes sh -c \
+            "(ps -eo args= 2>/dev/null || ps -ef 2>/dev/null) | grep '[t]ui_gateway[.]slash_worker' | wc -l" \
+            2>/dev/null || echo 0
+    )"
+    HERMES_SLASH_WORKER_COUNT="$(echo "$_hermes_worker_count" | tr -dc '0-9')"
+    [[ -n "$HERMES_SLASH_WORKER_COUNT" ]] || HERMES_SLASH_WORKER_COUNT="0"
+fi
+
 # Collect extension diagnostics if service registry loaded
 EXT_DIAGNOSTICS="[]"
 if [[ "${#SERVICE_IDS[@]}" -gt 0 ]]; then
@@ -312,7 +328,7 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" "$TTS_HTTP" "$TTS_PORT" "$DGX_SPARK_GPU" "$DGX_SPARK_GPU_NAME" "$DGX_SPARK_COMPUTE_CAP" "$LLAMA_CUDA_ARCHS" "$DGX_SPARK_CUDA_ARCH_STATUS" "$DGX_SPARK_CUDA_ARCH_MESSAGE" "$ROOT_DIR" <<'PY'
+"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" "$TTS_HTTP" "$TTS_PORT" "$DGX_SPARK_GPU" "$DGX_SPARK_GPU_NAME" "$DGX_SPARK_COMPUTE_CAP" "$LLAMA_CUDA_ARCHS" "$DGX_SPARK_CUDA_ARCH_STATUS" "$DGX_SPARK_CUDA_ARCH_MESSAGE" "$HERMES_SLASH_WORKER_COUNT" "$HERMES_SLASH_WORKER_MAX_COUNT" "$ROOT_DIR" <<'PY'
 import json
 import os
 import pathlib
@@ -321,12 +337,22 @@ import sys
 from datetime import datetime, timezone
 from urllib import error, request
 
-cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, tts_http, tts_port, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message, root_dir_arg = sys.argv[1:]
+cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, tts_http, tts_port, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message, hermes_slash_worker_count, hermes_slash_worker_max_count, root_dir_arg = sys.argv[1:]
 
 cap = json.load(open(cap_file, "r", encoding="utf-8"))
 pre = json.load(open(preflight_file, "r", encoding="utf-8"))
 ext_diagnostics = json.loads(ext_diagnostics_json)
 root_dir = pathlib.Path(root_dir_arg).resolve()
+
+def _int_value(raw, default=0):
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+hermes_slash_worker_count_num = _int_value(hermes_slash_worker_count)
+hermes_slash_worker_max_count_num = max(1, _int_value(hermes_slash_worker_max_count, 8))
 
 def _clean_env(name, default=""):
     return os.environ.get(name, default).strip()
@@ -827,6 +853,13 @@ report = {
             "status": dgx_spark_arch_status,
             "message": dgx_spark_arch_message,
         },
+        "hermes_slash_workers": {
+            "count": hermes_slash_worker_count_num,
+            "max_count": hermes_slash_worker_max_count_num,
+            "status": "warn"
+            if hermes_slash_worker_count_num > hermes_slash_worker_max_count_num
+            else "pass",
+        },
         "amd_runtime": amd_runtime,
     },
     "extensions": ext_diagnostics,
@@ -837,6 +870,7 @@ report = {
             (1 if dgx_spark_arch_status == "warn" else 0)
             + (1 if stt_cached in {"false", "service_down"} else 0)
             + (1 if tts_http == "false" else 0)
+            + (1 if hermes_slash_worker_count_num > hermes_slash_worker_max_count_num else 0)
             + len(amd_runtime.get("warnings", []))
         ),
         "diagnoses_total": len(diagnoses),
@@ -882,6 +916,12 @@ elif stt_cached == "service_down":
 
 if tts_http == "false":
     fix_hints.append("Kokoro TTS is not responding. Run: dream repair voice")
+
+if hermes_slash_worker_count_num > hermes_slash_worker_max_count_num:
+    fix_hints.append(
+        f"Hermes has {hermes_slash_worker_count_num} slash_worker children "
+        f"(policy max {hermes_slash_worker_max_count_num}). Run: dream repair hermes-workers"
+    )
 
 if dgx_spark_arch_status == "warn":
     fix_hints.append(
@@ -972,6 +1012,14 @@ if amd_runtime.get("available"):
     )
 elif amd_runtime.get("reason") and amd_runtime.get("reason") != "not_amd":
     print(f"  AMD Runtime:   {amd_runtime.get('reason')}")
+
+hermes_workers = data.get("runtime", {}).get("hermes_slash_workers", {})
+if hermes_workers.get("status") == "warn":
+    print(
+        "  Hermes:        "
+        f"{hermes_workers.get('count')} slash_worker processes "
+        f"(policy max {hermes_workers.get('max_count')})"
+    )
 
 diagnoses = data.get("diagnoses") or []
 if diagnoses:

--- a/dream-server/scripts/prune-hermes-slash-workers.sh
+++ b/dream-server/scripts/prune-hermes-slash-workers.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage: prune-hermes-slash-workers.sh [--force] [--dry-run] [--max-count N] [--max-age-seconds N] [--container NAME]
+
+Finds Hermes tui_gateway.slash_worker children inside the Hermes container and
+prunes only workers that exceed the age/count policy. Dry-run is the default.
+
+Environment:
+  HERMES_SLASH_WORKER_MAX_COUNT        Default: 8
+  HERMES_SLASH_WORKER_MAX_AGE_SECONDS  Default: 3600
+  HERMES_CONTAINER                     Default: dream-hermes
+EOF
+}
+
+MAX_COUNT="${HERMES_SLASH_WORKER_MAX_COUNT:-8}"
+MAX_AGE_SECONDS="${HERMES_SLASH_WORKER_MAX_AGE_SECONDS:-3600}"
+CONTAINER="${HERMES_CONTAINER:-dream-hermes}"
+FORCE=0
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --force)
+            FORCE=1
+            shift
+            ;;
+        --dry-run)
+            FORCE=0
+            shift
+            ;;
+        --max-count)
+            MAX_COUNT="${2:-}"
+            shift 2
+            ;;
+        --max-age-seconds)
+            MAX_AGE_SECONDS="${2:-}"
+            shift 2
+            ;;
+        --container)
+            CONTAINER="${2:-}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "[FAIL] Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! "$MAX_COUNT" =~ ^[0-9]+$ || "$MAX_COUNT" -lt 1 ]]; then
+    echo "[FAIL] --max-count must be a positive integer" >&2
+    exit 1
+fi
+if [[ ! "$MAX_AGE_SECONDS" =~ ^[0-9]+$ ]]; then
+    echo "[FAIL] --max-age-seconds must be a non-negative integer" >&2
+    exit 1
+fi
+if [[ -z "$CONTAINER" ]]; then
+    echo "[FAIL] --container must not be empty" >&2
+    exit 1
+fi
+
+collect_workers() {
+    if [[ -n "${DREAM_HERMES_SLASH_WORKER_PS_FIXTURE:-}" ]]; then
+        cat "$DREAM_HERMES_SLASH_WORKER_PS_FIXTURE"
+        return 0
+    fi
+
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "[FAIL] docker CLI not found" >&2
+        return 1
+    fi
+    if ! docker ps --format '{{.Names}}' 2>/dev/null | grep -qx "$CONTAINER"; then
+        echo "[INFO] $CONTAINER is not running; nothing to prune"
+        return 0
+    fi
+
+    docker exec "$CONTAINER" sh -c \
+        "ps -eo pid=,etimes=,args= 2>/dev/null || ps -ef 2>/dev/null" \
+        | grep '[t]ui_gateway[.]slash_worker' || true
+}
+
+WORKERS_FILE="$(mktemp)"
+CANDIDATES_FILE="$(mktemp)"
+OVERAGE_FILE="$(mktemp)"
+trap 'rm -f "$WORKERS_FILE" "$CANDIDATES_FILE" "$OVERAGE_FILE"' EXIT
+
+collect_workers | awk '
+    $0 ~ /tui_gateway[.]slash_worker/ {
+        pid = $1
+        age = $2
+        if (pid !~ /^[0-9]+$/) {
+            next
+        }
+        if (age !~ /^[0-9]+$/) {
+            age = -1
+        }
+        print pid "\t" age "\t" $0
+    }
+' > "$WORKERS_FILE"
+
+WORKER_COUNT="$(wc -l < "$WORKERS_FILE" | tr -d ' ')"
+if [[ "$WORKER_COUNT" -eq 0 ]]; then
+    echo "[PASS] no Hermes slash workers found"
+    exit 0
+fi
+
+awk -F '\t' -v max_age="$MAX_AGE_SECONDS" '$2 >= max_age {print}' \
+    "$WORKERS_FILE" > "$CANDIDATES_FILE"
+
+if [[ "$WORKER_COUNT" -gt "$MAX_COUNT" ]]; then
+    OVERAGE=$(( WORKER_COUNT - MAX_COUNT ))
+    sort -t "$(printf '\t')" -k2,2nr "$WORKERS_FILE" \
+        | head -n "$OVERAGE" > "$OVERAGE_FILE"
+    cat "$OVERAGE_FILE" >> "$CANDIDATES_FILE"
+fi
+
+sort -t "$(printf '\t')" -k1,1n -u "$CANDIDATES_FILE" -o "$CANDIDATES_FILE"
+CANDIDATE_COUNT="$(wc -l < "$CANDIDATES_FILE" | tr -d ' ')"
+
+echo "[INFO] found $WORKER_COUNT Hermes slash_worker process(es); policy max-count=$MAX_COUNT max-age=${MAX_AGE_SECONDS}s"
+if [[ "$CANDIDATE_COUNT" -eq 0 ]]; then
+    echo "[PASS] no slash workers exceed the prune policy"
+    exit 0
+fi
+
+echo "[INFO] $CANDIDATE_COUNT slash worker(s) selected for pruning:"
+awk -F '\t' '{printf "  pid=%s age=%ss %s\n", $1, $2, $3}' "$CANDIDATES_FILE"
+
+if [[ "$FORCE" -ne 1 ]]; then
+    echo "[DRY-RUN] rerun with --force to kill selected workers"
+    exit 0
+fi
+
+if [[ -n "${DREAM_HERMES_SLASH_WORKER_PS_FIXTURE:-}" ]]; then
+    echo "[DRY-RUN] fixture mode is read-only; not killing processes"
+    exit 0
+fi
+
+awk -F '\t' '{print $1}' "$CANDIDATES_FILE" \
+    | docker exec -i "$CONTAINER" sh -c 'while read -r pid; do kill "$pid" 2>/dev/null || true; done'
+
+echo "[PASS] requested termination for $CANDIDATE_COUNT Hermes slash_worker process(es)"

--- a/dream-server/tests/contracts/test-hermes-worker-guardrails.py
+++ b/dream-server/tests/contracts/test-hermes-worker-guardrails.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Static contracts for Hermes slash worker leak guardrails."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+DREAM_CLI = ROOT_DIR / "dream-cli"
+DOCTOR = ROOT_DIR / "scripts" / "dream-doctor.sh"
+PRUNE_SCRIPT = ROOT_DIR / "scripts" / "prune-hermes-slash-workers.sh"
+HERMES_DOCS = ROOT_DIR / "docs" / "HERMES.md"
+
+
+def fail(message: str) -> None:
+    print(f"[FAIL] {message}")
+    raise SystemExit(1)
+
+
+def require(path: Path, needle: str, message: str) -> None:
+    text = path.read_text(encoding="utf-8", errors="replace")
+    if needle not in text:
+        fail(message)
+
+
+def main() -> int:
+    for path in (DREAM_CLI, DOCTOR, PRUNE_SCRIPT, HERMES_DOCS):
+        if not path.exists():
+            fail(f"Missing expected file: {path}")
+
+    prune_text = PRUNE_SCRIPT.read_text(encoding="utf-8")
+    for needle in (
+        "HERMES_SLASH_WORKER_MAX_COUNT",
+        "HERMES_SLASH_WORKER_MAX_AGE_SECONDS",
+        "FORCE=0",
+        "--force",
+        "DREAM_HERMES_SLASH_WORKER_PS_FIXTURE",
+        "tui_gateway[.]slash_worker",
+    ):
+        if needle not in prune_text:
+            fail(f"prune script missing guardrail: {needle}")
+
+    # The first guardrail PR should keep cleanup explicit, not install an
+    # always-on process killer.
+    for forbidden in ("cron", "systemctl enable", "timer"):
+        if forbidden in prune_text:
+            fail(f"prune script should not install automatic cleanup via {forbidden}")
+
+    require(DREAM_CLI, "hermes-workers|slash-workers)", "dream repair target missing")
+    require(DREAM_CLI, "dream repair hermes-workers", "dream repair help missing")
+    require(DOCTOR, "hermes_slash_workers", "doctor JSON field missing")
+    require(DOCTOR, "dream repair hermes-workers", "doctor autofix hint missing")
+    require(HERMES_DOCS, "dream repair hermes-workers", "Hermes docs cleanup command missing")
+
+    print("[PASS] Hermes slash worker guardrail contracts")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an explicit `dream repair hermes-workers` path for pruning leaked upstream Hermes `tui_gateway.slash_worker` children
- surface high slash-worker counts in `dream doctor` JSON, summary output, and autofix hints
- document detection/cleanup in `docs/HERMES.md`
- add static contracts so the guardrails stay wired into CLI, doctor, docs, and the prune script

Fixes #1341.

## Risk
Low-medium. This touches operator CLI/doctor surfaces, but does not change install flow, compose files, Hermes config, or run any automatic process killer. Cleanup is explicit/manual only.

## Validation
- python dream-server/tests/contracts/test-hermes-worker-guardrails.py
- python -m py_compile dream-server/tests/contracts/test-hermes-worker-guardrails.py
- git diff --cached --check
- markdown local-link sanity script (`[PASS] checked 85 markdown files; local links resolve`)

Note: local Windows `bash` resolves to the broken WSL shim in this workspace, so Bash syntax/runtime checks need CI or a Linux host.