### PR TITLE
[codex] add OAuth provider readiness registry

### DIFF
--- a/dream-server/docs/OAUTH_PROVIDER_SETUP.md
+++ b/dream-server/docs/OAUTH_PROVIDER_SETUP.md
@@ -1,0 +1,93 @@
+# OAuth Provider Setup
+
+Dream Server's OAuth passthrough removes the copy-paste-code step: a provider
+redirect lands on `/api/oauth/callback`, dashboard-api captures the short-lived
+code, and Hermes can finish the skill setup.
+
+Provider registration is the separate preflight step. Public Dream Server
+releases do not commit shared OAuth client secrets to git. A distributor can
+ship a private credential bundle, and operators can always bring their own
+credentials.
+
+## Provider Registry
+
+The provider registry lives at:
+
+```text
+extensions/services/hermes/oauth-providers.json
+```
+
+It records provider IDs, skill IDs, expected credential filenames, preferred
+flows, redirect URI patterns, and provider-verification notes. It is metadata
+only; it contains no client secrets.
+
+Dashboard API exposes a secret-free readiness endpoint:
+
+```bash
+curl -H "Authorization: Bearer $DASHBOARD_API_KEY" \
+  http://127.0.0.1:3002/api/oauth/providers
+```
+
+The endpoint reports whether each provider has a credential file in one of the
+configured search roots. It never returns credential contents.
+
+## Credential Search Roots
+
+By default dashboard-api checks:
+
+```text
+data/hermes/
+data/hermes/credentials/
+data/persona/oauth/
+```
+
+Override with `DREAM_OAUTH_CREDENTIAL_DIRS` using the platform path separator
+if a fork or appliance stores credentials somewhere else.
+
+## Private Distribution Bundle
+
+A downstream distributor can provide credentials out of band, for example:
+
+```text
+credentials/oauth/
+  google_client_secret.json
+  spotify_client.json
+  github_oauth.json
+```
+
+Copy the relevant files into `data/hermes/` or `data/hermes/credentials/` on
+the installed system, then make sure Hermes can read them. On Linux installs
+Hermes usually owns `data/hermes/` as uid `10000`, so preserve owner-only file
+modes and ownership.
+
+## Bring Your Own Credentials
+
+Operators who prefer their own OAuth app should create provider credentials
+with redirect URIs matching their install. Common local patterns are:
+
+```text
+http://dream-server.local:3002/api/oauth/callback
+http://localhost:3002/api/oauth/callback
+http://127.0.0.1:3002/api/oauth/callback
+```
+
+If the device uses a custom `DREAM_DEVICE_NAME`, add the matching
+`http://<device>.local:3002/api/oauth/callback` URI in the provider console.
+
+## Provider Notes
+
+- Google Workspace scopes such as Gmail and Drive can require verification
+  before the consent screen feels polished. Unverified apps may still work for
+  testing, but the warning is bad user experience.
+- Spotify supports PKCE for public clients. Prefer PKCE when the skill supports
+  it so local appliances do not need a shared client secret.
+- GitHub skills should prefer device flow when possible. It avoids shipping a
+  client secret and fits local appliances well.
+
+## Safety Rules
+
+- Do not commit real OAuth client secrets to the public repository.
+- Do not print credential contents in dashboard-api responses, logs, support
+  bundles, or docs.
+- Keep `/api/oauth/callback` public because providers must redirect to it.
+- Keep readiness/status endpoints auth-gated.

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -98,6 +98,7 @@ Use [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) for the full policy and
 | [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md) | Maintainers / installer reviewers | Phase ownership, inputs, outputs, idempotency, and validation expectations |
 | [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md) | Maintainers / backend reviewers | Compose layer rules for services, hardware overlays, modes, dependencies, and ports |
 | [HERMES.md](HERMES.md) | Developers / operators | Default Hermes Agent packaging, security posture, and operations |
+| [OAUTH_PROVIDER_SETUP.md](OAUTH_PROVIDER_SETUP.md) | Operators / maintainers | OAuth provider registry, private credential bundles, and BYOC setup |
 | [OPENCLAW-INTEGRATION.md](OPENCLAW-INTEGRATION.md) | Developers | Deprecated OpenClaw setup and migration reference |
 
 ## Hardware & Configuration

--- a/dream-server/extensions/services/dashboard-api/routers/oauth_passthrough.py
+++ b/dream-server/extensions/services/dashboard-api/routers/oauth_passthrough.py
@@ -81,6 +81,67 @@ def _callback_dir() -> Path:
     return base
 
 
+def _install_dir() -> Path:
+    return Path(os.environ.get("DREAM_INSTALL_DIR", "/dream-server"))
+
+
+def _data_dir() -> Path:
+    return Path(os.environ.get("DREAM_DATA_DIR", "/data"))
+
+
+def _providers_file() -> Path:
+    override = os.environ.get("DREAM_OAUTH_PROVIDERS_FILE", "").strip()
+    if override:
+        return Path(override)
+    return _install_dir() / "extensions" / "services" / "hermes" / "oauth-providers.json"
+
+
+def _credential_roots() -> list[Path]:
+    override = os.environ.get("DREAM_OAUTH_CREDENTIAL_DIRS", "").strip()
+    if override:
+        return [Path(item) for item in override.split(os.pathsep) if item.strip()]
+    data_dir = _data_dir()
+    return [
+        data_dir / "hermes",
+        data_dir / "hermes" / "credentials",
+        data_dir / "persona" / "oauth",
+    ]
+
+
+def _load_provider_registry() -> dict:
+    path = _providers_file()
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {"schema_version": "dream.oauth-providers.v1", "providers": []}
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning("oauth provider registry unavailable at %s: %s", path, exc)
+        return {"schema_version": "dream.oauth-providers.v1", "providers": [], "error": str(exc)}
+    if not isinstance(payload, dict):
+        return {"schema_version": "dream.oauth-providers.v1", "providers": [], "error": "registry root must be an object"}
+    providers = payload.get("providers")
+    if not isinstance(providers, list):
+        payload["providers"] = []
+        payload["error"] = "providers must be a list"
+    return payload
+
+
+def _credential_status(provider: dict) -> tuple[bool, list[str]]:
+    found: list[str] = []
+    credential_files = provider.get("credential_files") or []
+    if not isinstance(credential_files, list):
+        return False, found
+    for filename in credential_files:
+        if not isinstance(filename, str) or not filename or Path(filename).is_absolute():
+            continue
+        for root in _credential_roots():
+            candidate = root / filename
+            if candidate.is_file():
+                found.append(f"{root.name}/{filename}")
+                break
+    return bool(found), found
+
+
 def _safe_return_path(return_url: str) -> str | None:
     """Return a same-origin relative path, or None for unsafe links.
 
@@ -213,4 +274,36 @@ async def oauth_pending(api_key: str = Depends(verify_api_key)):
         "captured_at": payload.get("captured_at"),
         "age_seconds": age,
         "stale": age > 900,  # codes typically expire ~10 min at the provider
+    }
+
+
+@router.get("/api/oauth/providers")
+async def oauth_providers(api_key: str = Depends(verify_api_key)):
+    """Report OAuth provider bootstrap readiness without exposing secrets."""
+    registry = _load_provider_registry()
+    providers = []
+    for raw_provider in registry.get("providers", []):
+        if not isinstance(raw_provider, dict):
+            continue
+        configured, found_files = _credential_status(raw_provider)
+        providers.append(
+            {
+                "id": raw_provider.get("id"),
+                "name": raw_provider.get("name"),
+                "skill_id": raw_provider.get("skill_id"),
+                "flow": raw_provider.get("flow"),
+                "configured": configured,
+                "credential_files": raw_provider.get("credential_files", []),
+                "found_credentials": found_files,
+                "redirect_uris": raw_provider.get("redirect_uris", []),
+                "requires_provider_verification": bool(raw_provider.get("requires_provider_verification", False)),
+                "notes": raw_provider.get("notes", ""),
+            }
+        )
+    return {
+        "schema_version": registry.get("schema_version", "dream.oauth-providers.v1"),
+        "registry_available": "error" not in registry,
+        "error": registry.get("error"),
+        "credential_roots": [path.name for path in _credential_roots()],
+        "providers": providers,
     }

--- a/dream-server/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
@@ -129,6 +129,56 @@ def test_oauth_pending_endpoint_returns_true_after_callback(oauth_client):
     assert body["stale"] is False
 
 
+def test_oauth_providers_requires_auth(oauth_client):
+    resp = oauth_client.get("/api/oauth/providers")
+    assert resp.status_code == 401
+
+
+def test_oauth_providers_reports_credential_status(oauth_client, monkeypatch):
+    registry = oauth_client.tmp / "providers.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": "dream.oauth-providers.v1",
+                "providers": [
+                    {
+                        "id": "google",
+                        "name": "Google Workspace",
+                        "skill_id": "google-workspace",
+                        "flow": "authorization_code",
+                        "credential_files": ["google_client_secret.json"],
+                        "redirect_uris": ["http://localhost:3002/api/oauth/callback"],
+                    },
+                    {
+                        "id": "spotify",
+                        "name": "Spotify",
+                        "skill_id": "spotify",
+                        "flow": "authorization_code_pkce",
+                        "credential_files": ["spotify_client.json"],
+                        "redirect_uris": ["http://localhost:3002/api/oauth/callback"],
+                    },
+                ],
+            }
+        )
+    )
+    data_dir = oauth_client.tmp / "data"
+    hermes_dir = data_dir / "hermes"
+    hermes_dir.mkdir(parents=True)
+    (hermes_dir / "google_client_secret.json").write_text("{}")
+
+    monkeypatch.setenv("DREAM_OAUTH_PROVIDERS_FILE", str(registry))
+    monkeypatch.setenv("DREAM_DATA_DIR", str(data_dir))
+
+    resp = oauth_client.get("/api/oauth/providers", headers=oauth_client.auth_headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == "dream.oauth-providers.v1"
+    by_id = {provider["id"]: provider for provider in body["providers"]}
+    assert by_id["google"]["configured"] is True
+    assert by_id["spotify"]["configured"] is False
+    assert by_id["google"]["found_credentials"] == ["hermes/google_client_secret.json"]
+
+
 def test_oauth_callback_atomic_write(oauth_client):
     """The handler writes via a .tmp + rename so a concurrent read by the
     agent never sees a half-written file. Verify the tmp file is gone

--- a/dream-server/extensions/services/hermes/SOUL.md.template
+++ b/dream-server/extensions/services/hermes/SOUL.md.template
@@ -38,7 +38,7 @@ The canonical setup pattern (this is how the bundled skills' setup.py scripts ar
 
 ### Generating the OAuth URL with the right redirect
 
-When you call `setup.py --auth-url`, the script bakes the redirect URL into the auth link. The default is whatever the operator's `client_secret.json` was registered with. The right redirect_uri to register against Dream Server is **`http://<device>.local:3002/api/oauth/callback`** (replacing `<device>` with the install's `DREAM_DEVICE_NAME`, e.g. `http://dream-server.local:3002/api/oauth/callback`). If the user hasn't set that up yet, walk them through registering it in Google Cloud Console — once.
+When you call `setup.py --auth-url`, the script bakes the redirect URL into the auth link. The default is whatever the operator's credential file was registered with. The right redirect_uri to register against Dream Server is **`http://<device>.local:3002/api/oauth/callback`** (replacing `<device>` with the install's `DREAM_DEVICE_NAME`, e.g. `http://dream-server.local:3002/api/oauth/callback`). If credentials are missing, explain that the operator can provide a private OAuth credential bundle or bring their own provider credentials; don't imply that public Dream Server releases ship shared client secrets in git.
 
 ### What to do if a skill doesn't exist yet
 

--- a/dream-server/extensions/services/hermes/oauth-providers.json
+++ b/dream-server/extensions/services/hermes/oauth-providers.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "dream.oauth-providers.v1",
+  "providers": [
+    {
+      "id": "google",
+      "name": "Google Workspace",
+      "skill_id": "google-workspace",
+      "flow": "authorization_code",
+      "credential_files": [
+        "google_client_secret.json",
+        "client_secret.json"
+      ],
+      "redirect_uris": [
+        "http://dream-server.local:3002/api/oauth/callback",
+        "http://localhost:3002/api/oauth/callback",
+        "http://127.0.0.1:3002/api/oauth/callback"
+      ],
+      "requires_provider_verification": true,
+      "notes": "Google Calendar/Gmail/Drive scopes may show an unverified-app warning until the distribution's OAuth app passes Google verification."
+    },
+    {
+      "id": "spotify",
+      "name": "Spotify",
+      "skill_id": "spotify",
+      "flow": "authorization_code_pkce",
+      "credential_files": [
+        "spotify_client.json"
+      ],
+      "redirect_uris": [
+        "http://dream-server.local:3002/api/oauth/callback",
+        "http://localhost:3002/api/oauth/callback",
+        "http://127.0.0.1:3002/api/oauth/callback"
+      ],
+      "requires_provider_verification": false,
+      "notes": "Prefer PKCE where supported so local installs do not need a shared client secret."
+    },
+    {
+      "id": "github",
+      "name": "GitHub",
+      "skill_id": "github",
+      "flow": "device_or_authorization_code",
+      "credential_files": [
+        "github_oauth.json"
+      ],
+      "redirect_uris": [
+        "http://dream-server.local:3002/api/oauth/callback",
+        "http://localhost:3002/api/oauth/callback",
+        "http://127.0.0.1:3002/api/oauth/callback"
+      ],
+      "requires_provider_verification": false,
+      "notes": "Use device flow when a skill supports it; it avoids storing a client secret on local appliances."
+    }
+  ]
+}


### PR DESCRIPTION
﻿## Summary

Adds a secret-free OAuth provider readiness layer for Hermes skill setup:

- adds `extensions/services/hermes/oauth-providers.json` with provider metadata for Google Workspace, Spotify, and GitHub
- adds auth-gated `GET /api/oauth/providers` so dashboard/operator tooling can tell whether expected credential files are present without exposing their contents
- documents private credential bundles and bring-your-own-credentials setup in `docs/OAUTH_PROVIDER_SETUP.md`
- updates the Hermes persona template so it no longer implies public releases ship shared OAuth client secrets in git

## Why

Refs #1348. The missing piece is provider bootstrap clarity: public Dream Server should not commit shared OAuth secrets, but operators and downstream distributors need a clean way to see which providers are ready and where credentials should live.

This PR is intentionally a foundation, not a public shared-credential bundle.

## Risk

Low to medium.

- Dashboard API behavior is additive: one new auth-gated status endpoint.
- OAuth callback behavior is unchanged.
- No installer, compose, or runtime service startup paths are changed.
- No credential contents or public client secrets are committed.

## Validation

- `python -m py_compile dream-server/extensions/services/dashboard-api/routers/oauth_passthrough.py dream-server/extensions/services/dashboard-api/tests/test_oauth_passthrough.py`
- `python -m json.tool dream-server/extensions/services/hermes/oauth-providers.json`
- `python -m pytest tests/test_oauth_passthrough.py` from `dream-server/extensions/services/dashboard-api` -> 12 passed, 1 skipped
- `git diff --cached --check`
- docs local-link sanity check
