### PR TITLE
fix(cli): invalidate stale cloud compose cache

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -612,19 +612,30 @@ get_compose_flags() {
                 fi
                 prev="$tok"
             done
-            if [[ "${DREAM_MODE:-local}" == "cloud" ]] && \
-               { [[ "$cached" == *"docker-compose.cpu.yml"* ]] || [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]]; }; then
-                stale=1
-            fi
+            local _dream_mode="${DREAM_MODE:-local}"
             local _lemonade_external="${LEMONADE_EXTERNAL:-false}"
             local _amd_runtime="${AMD_INFERENCE_RUNTIME:-}"
             local _amd_managed="${AMD_INFERENCE_MANAGED:-true}"
             _lemonade_external="${_lemonade_external,,}"
             _amd_runtime="${_amd_runtime,,}"
             _amd_managed="${_amd_managed,,}"
-            if [[ "${DREAM_MODE:-local}" == "lemonade" ]] && \
-               { [[ "$_lemonade_external" =~ ^(1|true|yes|on)$ ]] || { [[ "$_amd_runtime" == "lemonade" ]] && [[ "$_amd_managed" =~ ^(0|false|no|off)$ ]]; }; } && \
+            local _external_lemonade_active="false"
+            if [[ "$_dream_mode" == "lemonade" ]]; then
+                if [[ "$_lemonade_external" =~ ^(1|true|yes|on)$ ]] || \
+                   { [[ "$_amd_runtime" == "lemonade" ]] && [[ "$_amd_managed" =~ ^(0|false|no|off)$ ]]; }; then
+                    _external_lemonade_active="true"
+                fi
+            fi
+            if [[ "$_dream_mode" == "cloud" ]] && \
+               { [[ "$cached" == *"docker-compose.cpu.yml"* ]] || [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]]; }; then
+                stale=1
+            fi
+            if [[ "$_external_lemonade_active" == "true" ]] && \
                { [[ "$cached" == *"compose.local.yaml"* ]] || [[ "$cached" == *"docker-compose.amd.yml"* ]] || [[ "$cached" != *"docker-compose.cloud.yml"* ]] || [[ "$cached" != *"docker-compose.lemonade-external.yml"* ]]; }; then
+                stale=1
+            fi
+            if [[ "$_dream_mode" != "cloud" ]] && [[ "$_external_lemonade_active" != "true" ]] && \
+               [[ "$cached" == *"docker-compose.cloud.yml"* ]]; then
                 stale=1
             fi
             if [[ "$stale" == "0" ]]; then

--- a/dream-server/tests/contracts/test-dream-cli-contracts.py
+++ b/dream-server/tests/contracts/test-dream-cli-contracts.py
@@ -85,6 +85,11 @@ def main() -> int:
         "dream-cli must keep a top-level command dispatch case",
     )
     require(r"^cmd_help\(\) \{$", text, "dream-cli must define cmd_help")
+    require(
+        r'"\$_dream_mode" != "cloud"[\s\S]*"\$_external_lemonade_active" != "true"[\s\S]*docker-compose\.cloud\.yml',
+        text,
+        "dream-cli must reject stale cloud compose caches in local/managed modes",
+    )
 
     for command, (function_name, help_snippet) in COMMANDS.items():
         require(


### PR DESCRIPTION
## Summary
- reject cached compose flags containing docker-compose.cloud.yml when Dream is in local/managed mode
- preserve the existing cloud and external Lemonade cache validation paths
- add a static dream-cli contract so this regression stays covered

## Why
A fleet lifecycle run on Strix Halo hit perplexica is missing dependency llama-server during dream restart. The install was healthy, but restart can reuse a stale .compose-flags cache. If that cache includes the cloud overlay while local-mode Perplexica overlays are present, the cloud overlay profiles out llama-server and Docker Compose rejects the dependency graph.

## Tests
- python dream-server/tests/contracts/test-dream-cli-contracts.py
- C:\\Program Files\\Git\\bin\\bash.exe -n dream-server/dream-cli

Note: the default Windows WSL bash shim is broken in this workspace, so syntax validation used Git Bash explicitly.