### PR TITLE
fix(hermes): set local provider request timeout

### DIFF
--- a/dream-server/extensions/services/hermes/cli-config.yaml.template
+++ b/dream-server/extensions/services/hermes/cli-config.yaml.template
@@ -49,6 +49,19 @@ model:
   context_length: 131072
 
 # =============================================================================
+# Provider overrides — local inference needs a generous first-token budget
+# =============================================================================
+# Local OpenAI-compatible backends can spend tens of seconds in prompt
+# processing before the first token, especially on AMD iGPUs with 35B-class
+# models and Dream Talk's full tool/persona prompt. The provider-level request
+# timeout is the supported Hermes knob for that path; without it, some client
+# paths fall back to shorter transport defaults and turn a slow local prefill
+# into retries plus a stuck "session busy" state.
+providers:
+  custom:
+    request_timeout_seconds: 180
+
+# =============================================================================
 # Auxiliary models — compression, etc.
 # =============================================================================
 # Hermes runs a separate "compression" model when the conversation history

--- a/dream-server/scripts/patch-hermes-config.py
+++ b/dream-server/scripts/patch-hermes-config.py
@@ -59,6 +59,12 @@ def _set_key(lines: list[str], block: tuple[int, int], key: str, value: str, ind
     return block[0], block[1] + 1
 
 
+def _has_key(lines: list[str], block: tuple[int, int], key: str, indent: int) -> bool:
+    prefix = " " * indent
+    pattern = re.compile(rf"^{prefix}{re.escape(key)}:\s*.*$")
+    return any(pattern.match(lines[idx]) for idx in range(block[0] + 1, block[1]))
+
+
 def _ensure_model(lines: list[str], model: str | None, base_url: str | None, context_length: int | None, api_key: str | None = None) -> None:
     block = _top_level_block(lines, "model")
     if block is None:
@@ -83,6 +89,42 @@ def _ensure_model(lines: list[str], model: str | None, base_url: str | None, con
         block = _set_key(lines, block, "api_key", f'"{api_key}"', 2)
     if context_length:
         _set_key(lines, block, "context_length", str(context_length), 2)
+
+
+def _ensure_provider_timeout(lines: list[str], provider: str = "custom", timeout_seconds: int = 180) -> None:
+    """Add Dream's local-provider timeout default without clobbering operators.
+
+    Hermes can spend a long time in local prefill before the first token on
+    35B-class models. Existing configs from older Dream installs are missing
+    providers.custom.request_timeout_seconds, so add it on migration. If the
+    operator already tuned the provider timeout, leave their value untouched.
+    """
+
+    block = _top_level_block(lines, "providers")
+    if block is None:
+        auxiliary = _top_level_block(lines, "auxiliary")
+        model = _top_level_block(lines, "model")
+        insert_at = auxiliary[0] if auxiliary else (model[1] if model else len(lines))
+        payload = [
+            "providers:",
+            f"  {provider}:",
+            f"    request_timeout_seconds: {timeout_seconds}",
+            "",
+        ]
+        lines[insert_at:insert_at] = payload
+        return
+
+    provider_block = _child_block(lines, block, provider, 2)
+    if provider_block is None:
+        insert_at = block[1]
+        lines[insert_at:insert_at] = [
+            f"  {provider}:",
+            f"    request_timeout_seconds: {timeout_seconds}",
+        ]
+        return
+
+    if not _has_key(lines, provider_block, "request_timeout_seconds", 4):
+        _set_key(lines, provider_block, "request_timeout_seconds", str(timeout_seconds), 4)
 
 
 def _ensure_auxiliary(lines: list[str], context_length: int | None) -> None:
@@ -200,6 +242,7 @@ def patch_config(path: Path, model: str | None, base_url: str | None, context_le
     lines = original.splitlines()
 
     _ensure_model(lines, model, base_url, context_length, api_key)
+    _ensure_provider_timeout(lines)
     _ensure_auxiliary(lines, context_length)
     _ensure_whatsapp_bridge(lines)
     _ensure_compression(lines)

--- a/dream-server/tests/contracts/test-network-exposure-contracts.py
+++ b/dream-server/tests/contracts/test-network-exposure-contracts.py
@@ -93,6 +93,20 @@ def test_hermes_whatsapp_bridge_avoids_open_webui_port() -> None:
     assert_true("3010:3010" not in hermes_compose, "WhatsApp bridge must not be host-bound")
 
 
+def test_hermes_local_provider_has_generous_request_timeout() -> None:
+    hermes_config = read(SERVICES / "hermes" / "cli-config.yaml.template")
+
+    assert_true("providers:" in hermes_config, "Hermes config should declare provider overrides")
+    assert_true(
+        re.search(
+            r"(?ms)^providers:\s*\n\s+custom:\s*\n(?:\s{4}.+\n)*?\s{4}request_timeout_seconds:\s*180\s*$",
+            hermes_config,
+        )
+        is not None,
+        "Hermes custom provider must allow slow local-model first-token latency",
+    )
+
+
 def test_dream_proxy_routes_talk_portal() -> None:
     caddyfile = read(SERVICES / "dream-proxy" / "Caddyfile")
 
@@ -134,6 +148,7 @@ def main() -> int:
         test_exposed_services_are_policy_labeled,
         test_hermes_is_internal_only_and_proxy_gated,
         test_hermes_whatsapp_bridge_avoids_open_webui_port,
+        test_hermes_local_provider_has_generous_request_timeout,
         test_dream_proxy_routes_talk_portal,
         test_dashboard_csp_allows_dream_talk_tts_blob_audio,
         test_openclaw_stays_deprecated_optional_and_token_gated,

--- a/dream-server/tests/test-installer-context-parity.sh
+++ b/dream-server/tests/test-installer-context-parity.sh
@@ -146,6 +146,9 @@ pass "Hermes patcher updates base_url"
 grep -q '^  context_length: 65536$' "$tmp_hermes" \
     || fail "Hermes patcher updates model.context_length"
 pass "Hermes patcher updates model.context_length"
+grep -q '^    request_timeout_seconds: 180$' "$tmp_hermes" \
+    || fail "Hermes patcher writes local provider request timeout"
+pass "Hermes patcher writes local provider request timeout"
 grep -q '^    context_length: 65536$' "$tmp_hermes" \
     || fail "Hermes patcher writes auxiliary compression context"
 pass "Hermes patcher writes auxiliary compression context"
@@ -170,6 +173,9 @@ platforms:
     enabled: true
     extra:
       bridge_port: 3456
+providers:
+  custom:
+    request_timeout_seconds: 360
 compression:
   threshold: 0.75
 HERMES_CUSTOM_EOF
@@ -182,6 +188,9 @@ pass "Hermes patcher preserves user-enabled WhatsApp"
 grep -q '^      bridge_port: 3456$' "$tmp_hermes_custom" \
     || fail "Hermes patcher preserves custom WhatsApp bridge port"
 pass "Hermes patcher preserves custom WhatsApp bridge port"
+grep -q '^    request_timeout_seconds: 360$' "$tmp_hermes_custom" \
+    || fail "Hermes patcher preserves custom provider request timeout"
+pass "Hermes patcher preserves custom provider request timeout"
 
 echo ""
 echo "Results: $PASS passed"


### PR DESCRIPTION
## Summary
- add `providers.custom.request_timeout_seconds: 180` to Dream's Hermes config template
- migrate existing Hermes configs that are missing the local provider timeout
- preserve operator-provided custom provider timeout values
- add regression coverage for the template and patcher behavior

## Why
Fixes #1457. Strix Halo fleet capabilities showed Hermes timing out while the local 35B AMD/Lemonade backend was still in prompt prefill. The direct model endpoint was healthy, but the agent session cascaded into `session busy` after LLM request timeouts. Hermes supports provider-level request timeout overrides; Dream just was not setting the local/custom provider default.

## Tests
- `python -m ruff check dream-server/scripts/patch-hermes-config.py dream-server/tests/contracts/test-network-exposure-contracts.py`
- `python dream-server/tests/contracts/test-network-exposure-contracts.py`
- `C:\Program Files\Git\bin\bash.exe dream-server/tests/test-installer-context-parity.sh`
- `python -m py_compile dream-server/scripts/patch-hermes-config.py dream-server/tests/contracts/test-network-exposure-contracts.py`