### PR TITLE
[codex] add root security policy and repo map

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,16 @@ full-model capabilities, lifecycle recovery, and the final User Green gate. See
 [Release Validation](dream-server/docs/RELEASE_VALIDATION.md) for what a green
 run proves.
 
+**Repo layout:** the repository root holds the public README, installers,
+security policy, GitHub workflows, and project coordination docs. The
+`dream-server/` directory is the product runtime: services, installer phases,
+compose overlays, dashboard, CLI, tests, and operator docs.
+
+**Stable consumption:** `main` moves quickly. For forks, appliances, labs, or
+production-like installs, pin a tagged release or audited commit and keep your
+own validation receipt. See [Installer Trust](dream-server/docs/INSTALLER_TRUST.md)
+and [Forkability](dream-server/docs/FORKABILITY.md).
+
 ## Get Started
 
 Linux and macOS:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+Dream Server is local infrastructure that can manage Docker, models, secrets,
+network exposure, and host-side installer state. Please report security issues
+privately before opening a public issue.
+
+## Report A Vulnerability
+
+Use GitHub's private vulnerability reporting for this repository when available.
+If you cannot use private reporting, open a minimal public issue that asks for a
+maintainer contact path without including exploit details, secrets, logs, or
+proof-of-concept payloads.
+
+## Security Documentation
+
+- [Security guide](dream-server/SECURITY.md) covers operator hardening,
+  generated secrets, network binding, and service exposure guidance.
+- [Security audit receipts](SECURITY_AUDIT.md) track historical findings,
+  remediation status, and regression evidence.
+- [Installer trust](dream-server/docs/INSTALLER_TRUST.md) explains inspect-first
+  install paths, release-ref pinning, and current provenance limits.
+- [AI workflow guardrails](dream-server/docs/AI_WORKFLOW_GUARDRAILS.md)
+  documents how AI-assisted automation is constrained by human review,
+  protected paths, and validation.
+
+## Supported Code
+
+Use tagged releases for stable installs and downstream forks. The `main` branch
+moves quickly and is validated continuously, but it is still the development
+line. For release confidence, see
+[Release Validation](dream-server/docs/RELEASE_VALIDATION.md) and the
+[Validation Matrix](dream-server/docs/VALIDATION-MATRIX.md).
+
+## Public Exposure
+
+Dream Server defaults to localhost-bound services. Treat LAN exposure, reverse
+proxy changes, OAuth credentials, owner-card access, and extension installation
+as high-risk surfaces. Do not expose a default install directly to the public
+internet without an additional security review and deployment boundary.


### PR DESCRIPTION
﻿## Summary

- add a root `SECURITY.md` so GitHub and cold auditors find the security policy immediately
- point the root security policy at the operator security guide, audit receipts, installer trust doc, and AI workflow guardrails
- add a short root README note explaining the repo/root vs `dream-server/` runtime layout and stable consumption guidance

## Risk And Validation

Risk level: Low. Docs-only trust/navigation polish.

Validation run:

```text
git diff --check
doc links OK for SECURITY.md / README.md targets
```

No fleet validation required; this does not touch runtime, installer, CI, compose, auth, or service code.
