### PR TITLE
[codex] clarify release channels for downstreams

### DIFF
--- a/dream-server/docs/FORKABILITY.md
+++ b/dream-server/docs/FORKABILITY.md
@@ -40,8 +40,20 @@ large fork.
 
 ## Recommended Fork Strategy
 
-Use upstream `main` or a release tag as the source of truth, then keep your
-customization layer small and explicit.
+Pick a source ref deliberately. `main` is the active development channel. Tagged
+releases are the stable default for forks, appliances, and lab images. If you
+need a commit between tags, record the exact commit and its validation receipt.
+See [RELEASE_CHANNELS.md](RELEASE_CHANNELS.md) for the channel policy.
+
+Most downstreams should choose one of two patterns:
+
+- **Fork-and-pin:** start from a tagged release or audited commit, apply a small
+  downstream layer, and update only on a cadence you control.
+- **Fork-and-mirror:** operate your own mirror of the repository and allowed
+  artifacts, then merge selected upstream tags or commits after local
+  validation.
+
+In both cases, keep your customization layer small and explicit.
 
 Recommended downstream layout:
 

--- a/dream-server/docs/OFFLINE_AND_MIRRORING.md
+++ b/dream-server/docs/OFFLINE_AND_MIRRORING.md
@@ -7,6 +7,10 @@ release receipts instead of depending on mutable upstream state at install time.
 This is not a promise that every upstream service, model, or image license
 permits redistribution. Mirror only what you are allowed to mirror.
 
+For the difference between `main`, tagged releases, pinned commits, and
+downstream fork channels, start with
+[RELEASE_CHANNELS.md](RELEASE_CHANNELS.md).
+
 ## What To Preserve
 
 For a durable downstream release, preserve:

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -24,7 +24,7 @@ matches the work in front of them.
 | Change installer behavior | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md), [PREFLIGHT-ENGINE.md](PREFLIGHT-ENGINE.md) |
 | Change model routing | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | [MODE-SWITCH.md](MODE-SWITCH.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) |
 | Add or harden a service | [EXTENSIONS.md](EXTENSIONS.md) | [../extensions/CATALOG.md](../extensions/CATALOG.md), [../extensions/schema/README.md](../extensions/schema/README.md) |
-| Build a custom edition or fork | [FORKABILITY.md](FORKABILITY.md) | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md), [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md), [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) |
+| Build a custom edition or fork | [FORKABILITY.md](FORKABILITY.md) | [RELEASE_CHANNELS.md](RELEASE_CHANNELS.md), [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md), [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md), [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) |
 | Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [TESTING.md](TESTING.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
 | Maintain a release or fork | [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md) | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md), [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md), [BRANCH_HYGIENE.md](BRANCH_HYGIENE.md) |
 | Review automation guardrails | [AI_WORKFLOW_GUARDRAILS.md](AI_WORKFLOW_GUARDRAILS.md) | [../CONTRIBUTING.md](../CONTRIBUTING.md), [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md) |
@@ -100,6 +100,7 @@ canonical source and treat older recipes as context.
 |-----|----------|-------------|
 | [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md) | Downstream builders | Forking, custom editions, source-of-truth map, extension compatibility, and validation checklist |
 | [FORKABILITY.md](FORKABILITY.md) | Downstream builders / fork operators | Fork posture, independent operation, safe extension points, and upstream relationship |
+| [RELEASE_CHANNELS.md](RELEASE_CHANNELS.md) | Downstream builders / operators | When to track `main`, pin a tag, pin a commit, or operate a downstream fork |
 | [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md) | Fork operators / appliance builders | Pinning, mirroring, and preserving release artifacts for offline or independent operation |
 | [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) | Fork operators / release reviewers | How to reproduce upstream validation layers on local hardware and record receipts |
 | [EXTENSIONS.md](EXTENSIONS.md) | Builders | Add Docker services, manifests, dashboard plugins |

--- a/dream-server/docs/RELEASE_CHANNELS.md
+++ b/dream-server/docs/RELEASE_CHANNELS.md
@@ -1,0 +1,66 @@
+# Release Channels
+
+Dream Server moves quickly because installer, hardware, model, and service
+ecosystems move quickly. Treat each ref intentionally.
+
+## Channels
+
+| Channel | Use it for | Expectation |
+|---|---|---|
+| `main` | Active development, contributor work, rapid fixes, validation candidates | Can change many times per day. Read diffs and run focused validation before using it for an appliance or fork release. |
+| Tagged releases | Stable installs, downstream forks, lab images, appliance baselines | Preferred source for users and downstream operators who want a reproducible starting point. |
+| Pinned commits | Security reviews, internal mirrors, release candidates, emergency hotfix baselines | Valid when the commit and validation receipt are recorded together. |
+| Downstream forks | Custom hardware images, labs, private extensions, offline mirrors | Should record upstream ref, downstream changes, and local validation results. |
+
+## Default Guidance
+
+- New users can follow the README quickstart.
+- Operators who want reproducibility should pin a release tag.
+- Forks should either fork-and-pin or fork-and-mirror.
+- Hardware builders should treat upstream release receipts as evidence, then add
+  their own validation receipt for local changes.
+- Do not treat `main` as a frozen API or appliance channel.
+
+## Fork-And-Pin
+
+Use this when you want a stable local edition and do not need frequent upstream
+updates.
+
+1. Choose a tagged release or audited commit.
+2. Record it in `DOWNSTREAM.md`.
+3. Apply your local extensions, model catalog changes, branding, or docs.
+4. Run the validation subset from [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md).
+5. Update only on an explicit cadence you control.
+
+## Fork-And-Mirror
+
+Use this when you want to stay closer to upstream while still owning the
+operational substrate.
+
+1. Mirror the upstream repository.
+2. Mirror allowed Docker images, model artifacts, and checksums.
+3. Track upstream tags or selected commits, not every push to `main`.
+4. Re-run downstream validation after each upstream merge.
+5. Keep release receipts with both upstream and downstream refs.
+
+See [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md) for artifact details.
+
+## Validation Receipts
+
+A ref is most useful when paired with a receipt:
+
+```text
+Upstream ref:
+Downstream ref:
+Install command:
+Hardware / OS:
+Services enabled:
+Model selected:
+Validation run:
+Skipped or deferred surfaces:
+Known local patches:
+```
+
+Use [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) to understand upstream User
+Green gates and [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md)
+to reproduce the relevant layers in your own environment.


### PR DESCRIPTION
﻿## Summary

- add `dream-server/docs/RELEASE_CHANNELS.md` for `main`, tagged releases, pinned commits, and downstream fork usage
- document fork-and-pin vs fork-and-mirror as the two recommended downstream strategies
- link the new channel guidance from the docs index, forkability guide, and offline/mirroring guide

## Risk And Validation

Risk level: Low. Docs-only guidance for downstream operators and cold auditors.

Validation run:

```text
git diff --check
doc links OK for release channel / forkability / mirroring / validation targets
```

No fleet validation required; this does not touch runtime, installer, CI, compose, auth, or service code.
