### PR TITLE
[codex] clarify AI-assisted contribution policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,10 @@
 
 <!-- What changed, and why? -->
 
+## AI Assistance
+
+<!-- If AI tools helped draft code, docs, tests, reviews, or triage, say what they did. Use "None" when not applicable. The human author remains accountable for reading the diff, choosing the validation, and responding to review. -->
+
 ## Changed Surface
 
 <!-- Check every surface this PR can affect. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,29 @@ change needs release-grade validation before a release. Docs-only changes do not
 need the fleet; operational changes should not rely on "looks small" as the
 validation argument.
 
+## AI-Assisted Contributions
+
+AI tools are welcome for drafting, review, test ideas, documentation, and
+triage. They do not replace human authorship or maintainer judgment. If AI
+helped with a PR, say what it helped with in the pull request template.
+
+Human contributors are responsible for:
+
+- reading the final diff;
+- understanding the changed surface;
+- removing secrets, local logs, private hostnames, and raw support bundles;
+- choosing validation from
+  [dream-server/docs/HIGH_RISK_CHANGE_MAP.md](dream-server/docs/HIGH_RISK_CHANGE_MAP.md);
+- responding to review comments with project context, not tool output alone.
+
+High-risk surfaces such as installer phases, `dream-cli`, Compose generation,
+auth, proxy, model routing, host mutation, and GitHub workflows still require
+human review and appropriate validation before release.
+
+See
+**[dream-server/docs/AI_WORKFLOW_GUARDRAILS.md](dream-server/docs/AI_WORKFLOW_GUARDRAILS.md)**
+for the repository automation policy.
+
 ## Full Contributor Guide
 
 For current priorities, validation checklists, PR expectations, and style guidelines, see the detailed guide:

--- a/dream-server/docs/AI_WORKFLOW_GUARDRAILS.md
+++ b/dream-server/docs/AI_WORKFLOW_GUARDRAILS.md
@@ -22,6 +22,24 @@ the agentic CI surface without reading every workflow from scratch.
 - AI output is never release evidence by itself. Use
   [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) for release gates.
 
+## Contributor Expectations
+
+AI-assisted PRs are welcome when they are reviewable, tested, and owned by a
+human contributor. PR authors should disclose whether AI helped draft code,
+docs, tests, or analysis, and should summarize what the human author verified.
+
+Human reviewers should treat AI-assisted changes like any other changes, with
+extra attention to:
+
+- whether the diff is smaller than the problem it claims to solve;
+- whether high-risk surfaces are called out explicitly;
+- whether validation matches the changed surface;
+- whether generated prose introduced stale claims or duplicate docs;
+- whether secrets, private hostnames, raw fleet logs, or support bundles were
+  included in prompts, commits, or PR bodies.
+
+The merge decision belongs to maintainers, not automation.
+
 ## Workflow Classes
 
 | Class | Examples | Allowed behavior | Required guardrails |


### PR DESCRIPTION
﻿## Summary

- add an AI Assistance section to the pull request template
- document that AI can assist, but human contributors remain accountable for reading diffs, choosing validation, and responding to review
- extend `AI_WORKFLOW_GUARDRAILS.md` with contributor/reviewer expectations for AI-assisted changes

## Risk And Validation

Risk level: Low. Docs/process-only trust polish.

Validation run:

```text
git diff --check
doc links OK for AI workflow guardrails and high-risk change map
```

No fleet validation required; this does not touch runtime, installer, CI execution, compose, auth, or service code.
