### PR TITLE
fix: resume failed bootstrap model downloads

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1124,6 +1124,48 @@ cmd_restart() {
     if [[ "$refresh_soul" == "true" ]]; then
         _dream_cli_refresh_soul || true
     fi
+
+    if [[ -z "$resolved_service" || "$resolved_service" == "llama-server" ]]; then
+        _dream_cli_maybe_resume_bootstrap_upgrade || true
+    fi
+}
+
+_dream_cli_maybe_resume_bootstrap_upgrade() {
+    local status_file="$INSTALL_DIR/data/bootstrap-status.json"
+    local args_file="$INSTALL_DIR/data/bootstrap-upgrade.args"
+    [[ -f "$status_file" && -f "$args_file" && -f "$INSTALL_DIR/scripts/bootstrap-upgrade.sh" ]] || return 0
+
+    local bs_status
+    bs_status=$(grep -o '"status"[[:space:]]*:[[:space:]]*"[^"]*"' "$status_file" | sed -n '1p' | sed 's/.*"status"[[:space:]]*:[[:space:]]*"//' | sed 's/"//' || true)
+    [[ "$bs_status" == "failed" ]] || return 0
+
+    if command -v pgrep >/dev/null 2>&1 && pgrep -f "bootstrap-upgrade.sh.*$INSTALL_DIR" >/dev/null 2>&1; then
+        log "  Model Upgrade: retry already running"
+        return 0
+    fi
+
+    local full_gguf_file full_gguf_url full_gguf_sha256 full_llm_model full_max_context bootstrap_gguf_file
+    full_gguf_file=$(sed -n '1p' "$args_file")
+    full_gguf_url=$(sed -n '2p' "$args_file")
+    full_gguf_sha256=$(sed -n '3p' "$args_file")
+    full_llm_model=$(sed -n '4p' "$args_file")
+    full_max_context=$(sed -n '5p' "$args_file")
+    bootstrap_gguf_file=$(sed -n '6p' "$args_file")
+
+    if [[ -z "$full_gguf_file" || -z "$full_gguf_url" || -z "$full_llm_model" || -z "$full_max_context" || -z "$bootstrap_gguf_file" ]]; then
+        warn "Bootstrap model upgrade failed previously, but retry metadata is incomplete."
+        return 0
+    fi
+
+    mkdir -p "$INSTALL_DIR/logs"
+    nohup bash "$INSTALL_DIR/scripts/bootstrap-upgrade.sh" \
+        "$INSTALL_DIR" "$full_gguf_file" "$full_gguf_url" \
+        "$full_gguf_sha256" "$full_llm_model" "$full_max_context" \
+        "$bootstrap_gguf_file" \
+        > "$INSTALL_DIR/logs/model-upgrade.log" 2>&1 &
+
+    log "  Model Upgrade: previous download failed; retrying in background ($full_llm_model)"
+    log "  Check progress: tail -f $INSTALL_DIR/logs/model-upgrade.log"
 }
 
 # Refresh data/hermes/SOUL.md from the static template + detected install

--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -1266,6 +1266,10 @@ cmd_start() {
     if [[ "$refresh_soul" == "true" ]]; then
         _dream_cli_refresh_soul || true
     fi
+
+    if [[ -z "$resolved_service" || "$resolved_service" == "llama-server" ]]; then
+        _dream_cli_maybe_resume_bootstrap_upgrade || true
+    fi
 }
 
 cmd_dry_run() {

--- a/dream-server/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
@@ -31,6 +31,25 @@ describe('useDownloadProgress', () => {
     expect(result.current.progress.model).toBe('test-model')
   })
 
+  test('clamps progress percentage at 100 when downloaded bytes exceed total', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        status: 'downloading',
+        model: 'test-model',
+        bytesDownloaded: 12e9,
+        bytesTotal: 10e9,
+      })
+    })
+
+    const { result } = renderHook(() => useDownloadProgress())
+
+    await waitFor(() => {
+      expect(result.current.isDownloading).toBe(true)
+    })
+    expect(result.current.progress.percent).toBe(100)
+  })
+
   test('clears progress when status is complete', async () => {
     fetch.mockResolvedValue({
       ok: true,

--- a/dream-server/extensions/services/dashboard/src/hooks/useDownloadProgress.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useDownloadProgress.js
@@ -20,7 +20,8 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
       if (data.status === 'downloading' || data.status === 'verifying') {
         const downloaded = data.bytesDownloaded || 0
         const total = data.bytesTotal || 0
-        const percent = total > 0 ? (downloaded / total) * 100 : 0
+        const rawPercent = total > 0 ? (downloaded / total) * 100 : 0
+        const percent = Math.min(100, Math.max(0, rawPercent))
 
         setIsDownloading(true)
         setProgress({

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -986,6 +986,18 @@ except Exception:
             . "$SCRIPT_DIR/installers/lib/background-tasks.sh"
         fi
 
+        _bootstrap_upgrade_args="$INSTALL_DIR/data/bootstrap-upgrade.args"
+        {
+            printf '%s\n' "$FULL_GGUF_FILE"
+            printf '%s\n' "$FULL_GGUF_URL"
+            printf '%s\n' "$FULL_GGUF_SHA256"
+            printf '%s\n' "$FULL_LLM_MODEL"
+            printf '%s\n' "$FULL_MAX_CONTEXT"
+            printf '%s\n' "$BOOTSTRAP_GGUF_FILE"
+        } > "$_bootstrap_upgrade_args.tmp" && mv "$_bootstrap_upgrade_args.tmp" "$_bootstrap_upgrade_args" || \
+            warn "Could not persist bootstrap-upgrade retry metadata"
+        chmod 600 "$_bootstrap_upgrade_args" 2>/dev/null || true
+
         # Start the long-lived downloader from a child shell that closes inherited
         # non-stdio FDs first. Otherwise caller-owned advisory locks (FD 9, FD
         # 200, etc.) can stay held until the model download exits.

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -18,8 +18,8 @@
 # Phase 4b cleanup step removes the actual bootstrap model after hot-swap.
 #
 # On failure: logs the error, preserves any .part download for resume, and
-# exits. The bootstrap model continues running; `dream restart` or re-running
-# the installer retries the full-model upgrade.
+# exits. The bootstrap model continues running; `dream start`, `dream restart`,
+# or re-running the installer retries the full-model upgrade.
 # ============================================================================
 
 set -uo pipefail

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -17,8 +17,9 @@
 # canonical $BOOTSTRAP_GGUF_FILE from installers/lib/bootstrap-model.sh so the
 # Phase 4b cleanup step removes the actual bootstrap model after hot-swap.
 #
-# On failure: logs the error and exits. The bootstrap model continues
-# running — the user can retry via re-running the installer.
+# On failure: logs the error, preserves any .part download for resume, and
+# exits. The bootstrap model continues running; `dream restart` or re-running
+# the installer retries the full-model upgrade.
 # ============================================================================
 
 set -uo pipefail
@@ -78,6 +79,28 @@ write_status() {
 }
 STATUSEOF
     mv "$STATUS_FILE.tmp" "$STATUS_FILE"
+}
+
+status_percent() {
+    local downloaded="${1:-0}" total="${2:-0}"
+    if [[ "$total" -le 0 ]]; then
+        echo ""
+        return
+    fi
+    local display_bytes="$downloaded"
+    [[ "$display_bytes" -lt 0 ]] && display_bytes=0
+    [[ "$display_bytes" -gt "$total" ]] && display_bytes="$total"
+    awk "BEGIN { printf \"%.1f\", ($display_bytes / $total) * 100 }"
+}
+
+write_failed_download_status() {
+    local part_file="${1:-}" total="${2:-0}" message="${3:-}"
+    local downloaded=0 percent=""
+    if [[ -n "$part_file" && -f "$part_file" ]]; then
+        downloaded=$(file_size "$part_file")
+    fi
+    percent=$(status_percent "$downloaded" "$total")
+    write_status "failed" "$percent" "$downloaded" "$total" 0 "$message"
 }
 
 sync_windows_opencode_config() {
@@ -141,9 +164,11 @@ monitor_download() {
         local percent="null"
         local eta=""
         if [[ $total_bytes -gt 0 ]]; then
-            percent=$(awk "BEGIN { printf \"%.1f\", ($current_bytes / $total_bytes) * 100 }")
+            local progress_bytes="$current_bytes"
+            [[ "$progress_bytes" -gt "$total_bytes" ]] && progress_bytes="$total_bytes"
+            percent=$(status_percent "$current_bytes" "$total_bytes")
             if [[ $speed -gt 0 ]]; then
-                local remaining=$(( total_bytes - current_bytes ))
+                local remaining=$(( total_bytes - progress_bytes ))
                 local eta_secs=$(( remaining / speed ))
                 local eta_min=$(( eta_secs / 60 ))
                 local eta_sec=$(( eta_secs % 60 ))
@@ -222,18 +247,22 @@ else
     # Start background download monitor
     monitor_download "$MODELS_DIR/$FULL_GGUF_FILE.part" "$TOTAL_BYTES" &
     _monitor_pid=$!
-    trap 'kill $_monitor_pid 2>/dev/null || true; write_status "failed"; exit 1' EXIT TERM INT
-
-    # Download with resume support, retry up to 3 times. curl success is not
-    # enough: finalizing the .part file can fail on macOS if the file vanished
-    # or the target path is unavailable, and this script intentionally does
-    # not use set -e.
-    _dl_success=false
     _part_path="$MODELS_DIR/$FULL_GGUF_FILE.part"
     _final_path="$MODELS_DIR/$FULL_GGUF_FILE"
-    for _attempt in 1 2 3; do
-        [[ $_attempt -gt 1 ]] && log "Retry attempt $_attempt of 3..." && sleep 5
+    trap 'kill $_monitor_pid 2>/dev/null || true; write_failed_download_status "$_part_path" "$TOTAL_BYTES" "Download interrupted; partial file preserved for resume."; exit 1' EXIT TERM INT
+
+    # Download with resume support. curl success is not enough: finalizing the
+    # .part file can fail on macOS if the file vanished or the target path is
+    # unavailable, and this script intentionally does not use set -e.
+    _dl_success=false
+    _download_attempts="${DREAM_BOOTSTRAP_DOWNLOAD_ATTEMPTS:-6}"
+    case "$_download_attempts" in
+        ''|*[!0-9]*|0) _download_attempts=6 ;;
+    esac
+    for ((_attempt=1; _attempt<=_download_attempts; _attempt++)); do
+        [[ $_attempt -gt 1 ]] && log "Retry attempt $_attempt of $_download_attempts..." && sleep 5
         if curl -fSL -C - --connect-timeout 30 --max-time 3600 \
+                --retry 10 --retry-delay 5 --retry-connrefused --retry-all-errors \
                 -o "$_part_path" "$FULL_GGUF_URL" 2>&1; then
             if [[ ! -s "$_part_path" ]]; then
                 log "Download attempt $_attempt reported success but produced no partial file: $_part_path"
@@ -253,21 +282,20 @@ else
     trap - EXIT TERM INT
 
     if [[ "$_dl_success" != "true" ]]; then
-        rm -f "$MODELS_DIR/$FULL_GGUF_FILE.part"
-        write_status "failed"
-        fail "Download failed after 3 attempts. Bootstrap model will continue running."
+        write_failed_download_status "$_part_path" "$TOTAL_BYTES" "Download failed after $_download_attempts attempts; partial file preserved for resume."
+        fail "Download failed after $_download_attempts attempts. Preserved partial file for resume: $_part_path. Bootstrap model will continue running."
     fi
 
     if [[ ! -s "$MODELS_DIR/$FULL_GGUF_FILE" ]]; then
-        write_status "failed"
+        write_failed_download_status "$_part_path" "$TOTAL_BYTES" "Downloaded model missing or empty after finalization."
         fail "Downloaded model is missing or empty after finalization: $MODELS_DIR/$FULL_GGUF_FILE. Bootstrap model will continue running."
     fi
 
     if [[ "$TOTAL_BYTES" -gt 0 ]]; then
         ACTUAL_BYTES=$(file_size "$MODELS_DIR/$FULL_GGUF_FILE")
         if [[ "$ACTUAL_BYTES" -lt "$TOTAL_BYTES" ]]; then
-            rm -f "$MODELS_DIR/$FULL_GGUF_FILE"
-            write_status "failed"
+            mv "$MODELS_DIR/$FULL_GGUF_FILE" "$_part_path" 2>/dev/null || rm -f "$MODELS_DIR/$FULL_GGUF_FILE"
+            write_failed_download_status "$_part_path" "$TOTAL_BYTES" "Downloaded model is smaller than expected; partial file preserved for resume."
             fail "Downloaded model is smaller than expected (got $ACTUAL_BYTES, expected $TOTAL_BYTES). Bootstrap model will continue running."
         fi
     fi

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -52,6 +52,15 @@ bash tests/test-bootstrap-upgrade-hotswap-contract.sh
 echo "[contract] bootstrap download finalization is non-destructive"
 bash tests/test-bootstrap-upgrade-download-finalization.sh
 
+echo "[contract] bootstrap download failures preserve resume state"
+bash tests/test-bootstrap-upgrade-resume-status.sh
+
+echo "[contract] bootstrap failed upgrades are restart-resumable"
+grep -q 'bootstrap-upgrade.args' installers/phases/11-services.sh \
+  || { echo "[FAIL] Phase 11 must persist bootstrap-upgrade retry metadata"; exit 1; }
+grep -q '_dream_cli_maybe_resume_bootstrap_upgrade' dream-cli \
+  || { echo "[FAIL] dream restart must retry failed bootstrap upgrades"; exit 1; }
+
 echo "[contract] macOS host-agent LaunchAgent install-dir"
 bash tests/test-macos-host-agent-verification.sh
 

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -55,11 +55,13 @@ bash tests/test-bootstrap-upgrade-download-finalization.sh
 echo "[contract] bootstrap download failures preserve resume state"
 bash tests/test-bootstrap-upgrade-resume-status.sh
 
-echo "[contract] bootstrap failed upgrades are restart-resumable"
+echo "[contract] bootstrap failed upgrades are start/restart-resumable"
 grep -q 'bootstrap-upgrade.args' installers/phases/11-services.sh \
   || { echo "[FAIL] Phase 11 must persist bootstrap-upgrade retry metadata"; exit 1; }
-grep -q '_dream_cli_maybe_resume_bootstrap_upgrade' dream-cli \
+awk '/cmd_restart\(\)/,/^}/' dream-cli | grep -q '_dream_cli_maybe_resume_bootstrap_upgrade' \
   || { echo "[FAIL] dream restart must retry failed bootstrap upgrades"; exit 1; }
+awk '/cmd_start\(\)/,/^}/' dream-cli | grep -q '_dream_cli_maybe_resume_bootstrap_upgrade' \
+  || { echo "[FAIL] dream start must retry failed bootstrap upgrades"; exit 1; }
 
 echo "[contract] macOS host-agent LaunchAgent install-dir"
 bash tests/test-macos-host-agent-verification.sh

--- a/dream-server/tests/test-bootstrap-upgrade-resume-status.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-resume-status.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Regression: failed bootstrap full-model downloads must preserve the .part
+# file and report real progress so the next retry can resume.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fakebin="$tmp/bin"
+install_dir="$tmp/install"
+mkdir -p "$fakebin" "$install_dir/data/models" "$install_dir/config/llama-server" "$install_dir/bin"
+
+cat > "$fakebin/curl" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+  *" -sI "*)
+    printf 'HTTP/2 200\r\ncontent-length: 100\r\n\r\n'
+    exit 0
+    ;;
+esac
+
+out=""
+prev=""
+for arg in "$@"; do
+    if [[ "$prev" == "-o" ]]; then
+        out="$arg"
+        break
+    fi
+    prev="$arg"
+done
+
+[[ -n "$out" ]] || exit 2
+mkdir -p "$(dirname "$out")"
+printf 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx' >> "$out"
+exit 56
+EOF
+chmod +x "$fakebin/curl"
+
+cat > "$fakebin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$fakebin/sleep"
+
+cat > "$install_dir/.env" <<'EOF'
+GGUF_FILE=Bootstrap.gguf
+LLM_MODEL=bootstrap-model
+MAX_CONTEXT=8192
+CTX_SIZE=8192
+GPU_BACKEND=apple
+EOF
+
+printf 'bootstrap model\n' > "$install_dir/data/models/Bootstrap.gguf"
+printf '999999\n' > "$install_dir/data/.llama-server.pid"
+
+set +e
+PATH="$fakebin:$PATH" DREAM_BOOTSTRAP_DOWNLOAD_ATTEMPTS=2 bash "$TARGET" \
+    "$install_dir" \
+    "Full.gguf" \
+    "https://example.invalid/Full.gguf" \
+    "" \
+    "full-model" \
+    "32768" \
+    "Bootstrap.gguf" \
+    > "$tmp/bootstrap.log" 2>&1
+rc=$?
+set -e
+
+[[ $rc -ne 0 ]] || fail "bootstrap-upgrade must exit non-zero after repeated curl failures"
+[[ -f "$install_dir/data/models/Full.gguf.part" ]] \
+    || fail "bootstrap-upgrade must preserve the partial download for resume"
+[[ ! -f "$install_dir/data/models/Full.gguf" ]] \
+    || fail "bootstrap-upgrade must not promote a failed partial download"
+grep -q '"status": "failed"' "$install_dir/data/bootstrap-status.json" \
+    || fail "bootstrap-upgrade must mark bootstrap-status failed"
+grep -Eq '"bytesDownloaded": [1-9][0-9]*' "$install_dir/data/bootstrap-status.json" \
+    || fail "failed bootstrap-status must preserve downloaded byte count"
+grep -q '"bytesTotal": 100' "$install_dir/data/bootstrap-status.json" \
+    || fail "failed bootstrap-status must preserve expected byte count"
+grep -q '"percent": 100.0' "$install_dir/data/bootstrap-status.json" \
+    || fail "failed bootstrap-status percent must be capped at 100"
+grep -Eqi 'preserved.*partial file.*resume|partial file.*preserved.*resume' "$tmp/bootstrap.log" \
+    || fail "bootstrap-upgrade should tell operators the partial file was preserved"
+
+pass "failed download preserves resumable partial and status progress"


### PR DESCRIPTION
## Summary

Fixes #1463 and covers the #1462 progress symptom.

- preserve failed full-model `.part` downloads instead of deleting resumable bytes
- increase bootstrap download attempts and add curl transient retry flags
- keep failed bootstrap status populated with real downloaded/total bytes while capping percent at 100
- persist bootstrap-upgrade retry metadata during install so `dream restart` can resume a failed background upgrade
- clamp dashboard model-download progress when downloaded bytes exceed the reported total
- add regression and installer contract coverage for the resume path

## Why

Fresh WiFi installs can lose a 20GB+ model download near the end. Before this change, `bootstrap-upgrade.sh` deleted the partial file, wrote `bytesDownloaded: 0`, and left the host on the bootstrap model until a manual reinstall. That is brittle for normal consumer networks.

## Validation

- `bash -n scripts/bootstrap-upgrade.sh installers/phases/11-services.sh dream-cli tests/test-bootstrap-upgrade-resume-status.sh`
- `bash tests/test-bootstrap-upgrade-download-finalization.sh`
- `bash tests/test-bootstrap-upgrade-resume-status.sh`
- `npm.cmd test -- --run src/hooks/__tests__/useDownloadProgress.test.js`
- `git diff --check`

Could not run the full installer contract suite locally because this Windows Git Bash environment does not have `jq` installed (`[FAIL] jq is required`).