### PR TITLE
fix: move LAN web suggestion off dashboard home

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/features.py
+++ b/dream-server/extensions/services/dashboard-api/routers/features.py
@@ -216,8 +216,17 @@ async def feature_enable_instructions(
     comfyui_url = _svc_url("comfyui")
     opencode_url = _svc_url("opencode")
     hermes_url = _svc_url("hermes-proxy")
+    dream_proxy_url = _svc_url("dream-proxy")
 
     instructions = {
+        "lan-web": {
+            "steps": [
+                "Enable the dream-proxy extension from Extensions, or run: dream enable dream-proxy",
+                "Start or restart Dream Server so dream-proxy listens on port 80",
+                "Use the LAN hostnames such as dashboard.<device>.local, chat.<device>.local, and talk.<device>.local",
+            ],
+            "links": [{"label": "Open LAN entry", "url": dream_proxy_url}] if dream_proxy_url else [],
+        },
         "chat": {"steps": ["Chat is already enabled if llama-server is running", "Open the Dashboard and click 'Chat' to start"], "links": [{"label": "Open Chat", "url": webui_url}]},
         "voice": {"steps": [f"Ensure Whisper (STT) is running on port {_svc_port('whisper')}", f"Ensure Kokoro (TTS) is running on port {_svc_port('tts')}", "Open Open WebUI and use its voice controls"], "links": [{"label": "Open Chat", "url": webui_url}]},
         "documents": {"steps": ["Ensure Qdrant vector database is running", "Open Open WebUI and use its document/RAG controls"], "links": [{"label": "Open Chat", "url": webui_url}]},

--- a/dream-server/extensions/services/dashboard-api/tests/test_features.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_features.py
@@ -274,6 +274,35 @@ class TestFeatureEnableInstructions:
             "url": "http://dashboard.dream.local:3000",
         }
 
+    def test_lan_web_instructions_are_explicit_about_dream_proxy(self, test_client, monkeypatch):
+        test_features = [
+            {"id": "lan-web", "name": "LAN web entry", "description": "LAN entry",
+             "icon": "Globe", "category": "networking",
+             "setup_time": "Ready", "priority": 1,
+             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+             "enabled_services_all": ["dream-proxy"], "enabled_services_any": []}
+        ]
+        monkeypatch.setattr("routers.features.FEATURES", test_features)
+        monkeypatch.setattr(
+            "routers.features.SERVICES",
+            {"dream-proxy": {"external_port": 80}},
+        )
+
+        resp = test_client.get(
+            "/api/features/lan-web/enable",
+            headers={**test_client.auth_headers, "host": "dashboard.dream.local:3001"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        steps = " ".join(data["instructions"]["steps"])
+        assert "dream-proxy" in steps
+        assert "port 80" in steps
+        assert data["instructions"]["links"][0] == {
+            "label": "Open LAN entry",
+            "url": "http://dashboard.dream.local:80",
+        }
+
     def test_404_for_unknown_feature(self, test_client, monkeypatch):
         monkeypatch.setattr("routers.features.FEATURES", [])
 

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -22,7 +22,6 @@ import {
 } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { FeatureDiscoveryBanner } from '../components/FeatureDiscovery'
 
 // Helper to build external service URLs from current host
 const getExternalUrl = (port, path = '') => {
@@ -782,9 +781,6 @@ export default function Dashboard({ status, loading }) {
           {status?.version && <span>v{status.version}</span>}
         </div>
       </div>
-
-      {/* Feature Discovery Banner */}
-      <FeatureDiscoveryBanner />
 
       {/* Feature Cards */}
       <div className="liquid-metal-sequence-grid liquid-metal-sequence-grid--features grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-2.5 mb-10">

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -33,6 +33,7 @@ const baseStatus = {
 
 let mockResources
 let mockFeatures
+let mockFeatureSuggestions
 let restartCalls
 let restartDeferred
 
@@ -53,7 +54,11 @@ function installFetchMock() {
     if (String(url).includes('/api/features')) {
       return {
         ok: true,
-        json: async () => ({ features: mockFeatures }),
+        json: async () => ({
+          features: mockFeatures,
+          suggestions: mockFeatureSuggestions,
+          summary: { progress: 0 },
+        }),
       }
     }
     if (String(url).includes('/api/services/') && String(url).endsWith('/restart')) {
@@ -85,6 +90,7 @@ async function renderDashboard(status = baseStatus) {
 describe('Dashboard system overview', () => {
   beforeEach(() => {
     mockFeatures = []
+    mockFeatureSuggestions = []
     mockResources = {
       services: services.map(service => ({
         id: service.name.toLowerCase().replace(/\([^)]*\)/g, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
@@ -114,6 +120,21 @@ describe('Dashboard system overview', () => {
     expect(screen.getByText('TOKENS GENERATED')).toBeInTheDocument()
     expect(screen.getByText('Live Throughput')).toBeInTheDocument()
     expect(screen.getByText('Accumulated Output')).toBeInTheDocument()
+  })
+
+  it('does not render feature discovery suggestions as a dashboard home banner', async () => {
+    mockFeatureSuggestions = [{
+      featureId: 'lan-web',
+      name: 'LAN web entry',
+      message: 'Your hardware can run LAN web entry. Enable it?',
+      action: 'Enable LAN web entry',
+      setupTime: 'Ready',
+    }]
+
+    await renderDashboard()
+
+    expect(screen.queryByText(/Your hardware can run LAN web entry/i)).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Enable LAN web entry/i })).not.toBeInTheDocument()
   })
 
   it('renders the services table with real tab counts and default expansion state', async () => {


### PR DESCRIPTION
## Summary

Fixes #1464.

- remove the feature discovery suggestion banner from the main dashboard home
- keep the normal feature cards on the dashboard so installed/available capabilities still appear in the right place
- add explicit `lan-web` enable instructions that name `dream-proxy`, port 80, and the LAN hostnames it provides
- cover both the dashboard home behavior and backend instructions with tests

## Why

`LAN web entry` is really the optional `dream-proxy` LAN access surface. Showing it as a prominent hardware banner on the dashboard home was noisy and confusing, and clicking the banner led to empty/non-actionable enable instructions.

## Validation

- `npm.cmd test -- --run src/pages/Dashboard.test.jsx`
- `python -m pytest tests/test_features.py`
- `python -m compileall routers/features.py`
- `git diff --check`