### PR TITLE
[codex] release: stamp 2.5.1

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dream Server Architecture
 
-> Version 2.5.0 | Fully local AI stack deployed on user hardware with a single command
+> Version 2.5.1 | Fully local AI stack deployed on user hardware with a single command
 
 ## Overview
 

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -6,7 +6,7 @@
 # secure random secrets. This file documents all available variables.
 
 # Dream Server version (auto-set by installer, used by dream-cli for compat checks)
-# DREAM_VERSION=2.4.0
+# DREAM_VERSION=2.5.1
 
 # LiteLLM proxy API key for internal service auth
 # TARGET_API_KEY=not-needed

--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,14 +6,73 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-05-26
+
+### Added
+- Dream Talk owner-portal work for mobile use: local owner-card routing,
+  streamed SSE replies, live status frames, TTS streaming, paperclip image/file
+  attachments, and install-context grounding so the agent can describe the
+  services actually running on a node.
+- OAuth browser-redirect passthrough and provider-readiness metadata so the
+  agent and dashboard can guide provider setup without guessing.
+- Evidence-based `dream doctor` install and inference diagnostics, including
+  local/cloud routing checks and clearer remediation messages.
+- External AMD Lemonade SDK runtime support and an experimental AMD GAIA recipe
+  for operators testing alternate AMD paths.
+- Forkability, installer trust, release-channel, AI-contribution, branch
+  hygiene, and CLI-roadmap documentation for downstream operators.
+
+### Changed
+- Moved long contributor credits out of the README and tightened README
+  positioning so first-time operators see the product path faster.
+- Expanded release validation entrypoints, validation gates, static contracts,
+  and distro-lab locking so fleet, Docker, and Incus runs are less likely to
+  contend with each other on the same host.
+- Updated dashboard developer dependencies and grouped Dependabot updates after
+  audit review.
+
 ### Fixed
+- Bootstrap full-model downloads now preserve partial `.part` files, retry with
+  resume support, keep failed status counters populated, cap progress display at
+  100%, and recover cleanly on the next `dream start`, `dream restart`, or
+  reinstall.
+- Hermes local-provider calls now set a longer request timeout for slow
+  time-to-first-token backends, and slash-worker guardrails prevent repeated
+  agent sessions from accumulating runaway workers.
 - Linux cloud installs no longer launch or health-gate on local `llama-server`;
-  the compose resolver now selects a cloud overlay, skips local-mode dependency
+  the compose resolver selects a cloud overlay, skips local-mode dependency
   overlays, and keeps Hermes SOUL persona generation outside the local-model
   path.
-- Fleet distro lab Docker and Incus runners now take a shared host lock so
-  tower2 distro dry-runs do not contend with heavy full-fleet install/build
-  work on the same host.
+- Lifecycle, reinstall, and bootstrap-model paths were hardened across compose
+  health waits, delayed port reuse, model-swap container recreation, stale cloud
+  compose-cache invalidation, bundled service CPU limits, and fallback model
+  serving when compose flags are missing.
+- Installer portability fixes for Fedora/RHEL, openSUSE bootstrap detection,
+  Python prerequisite setup, PATH-installed OpenCode, macOS launchd services,
+  Windows compose working directories, and Docker-cloud install paths.
+- Dashboard feature-card and LAN web guidance now point users at the intended
+  proxy surfaces instead of raw API ports or misplaced homepage banners.
+- Extension/security regressions fixed for trusted `extra_hosts`, Gaia data
+  ownership, Hermes data ownership on reinstall, and inherited file descriptors
+  in bootstrap upgrade workers.
+
+### Security
+- Pinned remaining GitHub Actions, added a root security policy/repo map, and
+  strengthened desktop installer guardrails and installer trust documentation.
+- Hardened OAuth pending-state handling, dashboard feature-card links, network
+  exposure checks, and static audit contracts.
+
+### Validation
+- Fleet test run 11 on 2026-05-26 passed true fresh install, lifecycle, product,
+  and core capability validation on tower2, Strix Halo, Spark, and M5 MacBook
+  Pro after Docker images, volumes, build cache, and stale model files were
+  removed.
+- Full target-model core capabilities passed on all 4 hardware platforms; Dream
+  Talk capability probes passed where the Talk surface was enabled, with
+  unavailable Talk surfaces correctly skipped.
+- Distro lab passed 10/10 Docker lanes and 5/5 Incus VM lanes.
+- Session total: 11 fleet runs, 35+ commits, 7 issues filed, 6 resolved, 4
+  harness improvements, and zero product regressions.
 
 ## [2.5.0] - 2026-05-21
 

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -948,7 +948,7 @@ async def _lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Dream Server Dashboard API",
-    version="2.5.0",
+    version="2.5.1",
     description="System status API for Dream Server Dashboard",
     lifespan=_lifespan,
 )

--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.5.0"
+VERSION="2.5.1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Source path utilities for cross-platform path resolution

--- a/dream-server/installers/macos/lib/constants.sh
+++ b/dream-server/installers/macos/lib/constants.sh
@@ -11,7 +11,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-DS_VERSION="2.5.0"
+DS_VERSION="2.5.1"
 
 # Install location - use shared path resolution if available.
 # constants.sh lives at two different depths depending on layout:

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -519,7 +519,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
 # Tier: ${TIER} (${TIER_NAME})
 
 #=== Dream Server Version (used by dream-cli update for version-compat checks) ===
-DREAM_VERSION=${VERSION:-2.5.0}
+DREAM_VERSION=${VERSION:-2.5.1}
 
 #=== Network Binding ===
 # 127.0.0.1 = localhost only (secure default)

--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -10,7 +10,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-$script:DS_VERSION = "2.5.0"
+$script:DS_VERSION = "2.5.1"
 
 # Install location (override via $env:DREAM_HOME)
 # NOTE: $(if ...) syntax required for PS 5.1 compatibility (bare if-as-expression is PS 7+ only)

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 2,
-  "dream_version": "2.5.0",
+  "dream_version": "2.5.1",
   "min_compatible_dream_version": "1.0.0",
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.5.0",
+    "version": "2.5.1",
     "channel": "stable",
-    "date": "2026-05-21"
+    "date": "2026-05-26"
   },
   "compatibility": {
     "os": {


### PR DESCRIPTION
## Summary
- stamps Dream Server version authorities to `2.5.1` with release date `2026-05-26`
- adds the `2.5.1` changelog entry covering the fleet-validated bootstrap, lifecycle, Talk, installer, security, and docs work since `2.5.0`
- updates installer, macOS, Windows, dashboard API, manifest, architecture, and `.env.example` version surfaces

## Validation
- `python scripts/check-version-consistency.py`
- `git diff --check`
- `python scripts/validate-golden-paths.py`
- `python scripts/validate-generated-configs.py`
- `python scripts/check-dependency-pins.py`
- `python tests/contracts/test-network-exposure-contracts.py`
- attempted `bash scripts/release-gate.sh` with Git Bash; local Windows environment stops at compatibility checks because `jq` is not installed (shell syntax phase completed before that)

## Release Evidence
Fleet run 11 (`/home/michael/dream-fleet-test/runs/2026-05-26T01-22-18Z`) validated true fresh install, lifecycle, product, distro lab, and full core capabilities across the 4-host fleet at `4ac9305`.