### PR TITLE
[codex] fix dashboard API proxy after lifecycle churn

### DIFF
--- a/dream-server/extensions/services/dashboard/nginx.conf
+++ b/dream-server/extensions/services/dashboard/nginx.conf
@@ -5,6 +5,13 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Docker service IPs can change when lifecycle commands recreate
+    # dashboard-api. Use Docker DNS at request time instead of pinning the IP
+    # nginx resolved when this container started.
+    resolver 127.0.0.11 valid=10s ipv6=off;
+    resolver_timeout 5s;
+    set $dashboard_api_upstream dashboard-api:3002;
+
     # Gzip compression
     gzip on;
     gzip_types text/plain text/css application/json application/javascript text/xml application/xml;
@@ -21,7 +28,7 @@ server {
     # and a generous read timeout so the upstream can keep the connection open
     # while tokens trickle in.
     location ^~ /api/talk/ {
-        proxy_pass http://dashboard-api:3002;
+        proxy_pass http://$dashboard_api_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -41,7 +48,7 @@ server {
     # Auth: nginx injects Bearer token for same-origin requests (B2 fix)
     # Token read from environment via envsubst in entrypoint
     location /api/ {
-        proxy_pass http://dashboard-api:3002;
+        proxy_pass http://$dashboard_api_upstream;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -101,6 +101,19 @@ else
   echo "[SKIP] docker compose unavailable"
 fi
 
+echo "[contract] dashboard nginx re-resolves dashboard-api after lifecycle churn"
+dashboard_nginx="extensions/services/dashboard/nginx.conf"
+grep -qF 'resolver 127.0.0.11' "$dashboard_nginx" \
+  || { echo "[FAIL] dashboard nginx must use Docker DNS resolver"; exit 1; }
+grep -qF 'set $dashboard_api_upstream dashboard-api:3002;' "$dashboard_nginx" \
+  || { echo "[FAIL] dashboard nginx must proxy through a variable upstream"; exit 1; }
+grep -qF 'proxy_pass http://$dashboard_api_upstream;' "$dashboard_nginx" \
+  || { echo "[FAIL] dashboard nginx /api locations must use the dynamic upstream"; exit 1; }
+if grep -qF 'proxy_pass http://dashboard-api:3002;' "$dashboard_nginx"; then
+  echo "[FAIL] dashboard nginx must not pin dashboard-api at config-load time"
+  exit 1
+fi
+
 echo "[contract] bundled service CPU limits are env-driven"
 grep -qF "cpus: '\${TTS_CPU_LIMIT:-1.0}'" extensions/services/tts/compose.yaml \
   || { echo "[FAIL] Kokoro TTS CPU limit must be env-driven with safe fallback"; exit 1; }


### PR DESCRIPTION
## Summary
- make dashboard nginx resolve `dashboard-api` through Docker DNS at request time
- switch `/api/*` and `/api/talk/*` proxying to a variable upstream so nginx does not pin a stale dashboard-api container IP
- add a contract guard that fails if dashboard nginx goes back to config-load DNS resolution

## Why
Fleet run `/home/michael/dream-fleet-test/runs/2026-05-26T02-27-29Z` showed post-lifecycle `502 Bad Gateway` from the dashboard frontend on Spark and tower2 while direct dashboard-api requests still reached the API. Logs showed nginx proxying to a stale Docker IP after dashboard-api lifecycle churn.

## Validation
- `git diff --check`
- `python scripts/check-version-consistency.py`
- `python scripts/validate-generated-configs.py`
- Git Bash syntax check for `tests/contracts/test-installer-contracts.sh`
- attempted `nginx:alpine nginx -t`, but local Docker image pull failed twice with a CloudFront EOF before nginx could run