### PR TITLE
[codex] fix low-VRAM NVIDIA fallback

### DIFF
--- a/dream-server/config/capability-profile.schema.json
+++ b/dream-server/config/capability-profile.schema.json
@@ -94,7 +94,7 @@
       "properties": {
         "recommended": {
           "type": "string",
-          "enum": ["T1", "T2", "T3", "T4", "SH_COMPACT", "SH_LARGE"]
+          "enum": ["T0", "T1", "T2", "T3", "T4", "SH_COMPACT", "SH_LARGE", "NV_ULTRA"]
         }
       },
       "additionalProperties": false

--- a/dream-server/config/gpu-database.json
+++ b/dream-server/config/gpu-database.json
@@ -408,8 +408,13 @@
       "recommended": { "backend": "nvidia", "tier": "T2" }
     },
     {
+      "id": "nvidia_low_vram_cpu_fallback",
+      "match": { "vendor": "nvidia", "memory_type": "discrete", "min_vram_mb": 0, "max_vram_mb": 4095 },
+      "recommended": { "backend": "cpu", "tier": "T0" }
+    },
+    {
       "id": "nvidia_entry",
-      "match": { "vendor": "nvidia", "memory_type": "discrete", "min_vram_mb": 0 },
+      "match": { "vendor": "nvidia", "memory_type": "discrete", "min_vram_mb": 4096 },
       "recommended": { "backend": "nvidia", "tier": "T1" }
     },
     {

--- a/dream-server/config/gpu-database.schema.json
+++ b/dream-server/config/gpu-database.schema.json
@@ -110,6 +110,7 @@
             "vendor": { "enum": ["nvidia", "amd", "apple", "intel", "none"] },
             "memory_type": { "enum": ["discrete", "unified", "none"] },
             "min_vram_mb": { "type": "integer", "minimum": 0 },
+            "max_vram_mb": { "type": "integer", "minimum": 0 },
             "min_ram_mb": { "type": "integer", "minimum": 0 }
           }
         },
@@ -125,7 +126,7 @@
         "backend": { "enum": ["nvidia", "amd", "apple", "cpu"] },
         "tier": {
           "type": "string",
-          "pattern": "^(T[1-4]|SH_LARGE|SH_COMPACT|NV_ULTRA)$"
+          "pattern": "^(T[0-4]|SH_LARGE|SH_COMPACT|NV_ULTRA)$"
         }
       }
     },

--- a/dream-server/config/hardware-classes.json
+++ b/dream-server/config/hardware-classes.json
@@ -92,13 +92,29 @@
       }
     },
     {
+      "id": "nvidia_low_vram_cpu_fallback",
+      "label": "NVIDIA Low-VRAM CPU Fallback",
+      "match": {
+        "platform_id": ["linux", "wsl"],
+        "gpu_vendor": ["nvidia"],
+        "memory_type": ["discrete"],
+        "min_vram_mb": 0,
+        "max_vram_mb": 4095
+      },
+      "recommended": {
+        "backend": "cpu",
+        "tier": "T0",
+        "compose_overlays": ["docker-compose.base.yml", "docker-compose.cpu.yml"]
+      }
+    },
+    {
       "id": "nvidia_entry",
       "label": "NVIDIA Entry",
       "match": {
         "platform_id": ["linux", "wsl"],
         "gpu_vendor": ["nvidia"],
         "memory_type": ["discrete"],
-        "min_vram_mb": 0
+        "min_vram_mb": 4096
       },
       "recommended": {
         "backend": "nvidia",

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -156,6 +156,15 @@ else
             ai "Continuing for now; AMD tuning will try to load kernel modules before services start."
         fi
     fi
+
+    if [[ "${GPU_BACKEND_REQUESTED,,}" != "nvidia" \
+        && "${TIER_FORCED:-false}" != "true" \
+        && "${GPU_BACKEND:-}" == "nvidia" \
+        && "${GPU_MEMORY_TYPE:-discrete}" == "discrete" \
+        && "${GPU_VRAM:-0}" -gt 0 \
+        && "${GPU_VRAM:-0}" -lt 4096 ]]; then
+        apply_cpu_gpu_fallback "Detected NVIDIA GPU has only ${GPU_VRAM}MB VRAM; using CPU/Tier 0 fallback to avoid CUDA OOM loops."
+    fi
 fi
 
 BACKEND_ID="$GPU_BACKEND"

--- a/dream-server/scripts/classify-hardware.sh
+++ b/dream-server/scripts/classify-hardware.sh
@@ -141,6 +141,13 @@ if not selected:
         if min_vram >= 0 and vram_mb < min_vram:
             continue
 
+        # Check max_vram_mb. This lets the database model "too small for
+        # GPU inference" classes explicitly instead of catching them in broad
+        # vendor fallbacks.
+        max_vram = match.get("max_vram_mb", -1)
+        if max_vram >= 0 and vram_mb > max_vram:
+            continue
+
         # Check min_ram_mb (for unified memory classes)
         min_ram = match.get("min_ram_mb", -1)
         if min_ram >= 0 and ram_mb < min_ram:
@@ -186,7 +193,7 @@ if selected:
         backend = rec.get("backend", "cpu")
         tier = rec.get("tier", "T1")
         m_memtype = selected.get("match", {}).get("memory_type", "")
-        memory_source = "ram" if m_memtype == "unified" else "vram"
+        memory_source = "ram" if backend == "cpu" or m_memtype == "unified" else "vram"
 else:
     class_id = "unknown"
     label = "Unknown"

--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -424,6 +424,7 @@ tier_description() {
         T4)    echo "Ultimate (48GB+): large flagship local profile with long context headroom" ;;
         T3)    echo "Pro (20-47GB): strong local profile with room for larger models" ;;
         T2)    echo "Starter (12-19GB): mid-size local profile for everyday work" ;;
+        T0)    echo "Lightweight (<4GB discrete VRAM): CPU fallback profile for install stability" ;;
         T1)    echo "Mini (<12GB): compact local profile or CPU inference" ;;
         NV_ULTRA)   echo "NVIDIA Ultra (90GB+ unified or discrete): flagship local profile (Grace Blackwell or multi-GPU)" ;;
         SH_LARGE)   echo "Strix Halo 90+: flagship unified-memory local profile" ;;
@@ -453,6 +454,7 @@ tier_model() {
             T4)    echo "gemma-4-31b-it" ;;
             T3)    echo "gemma-4-26b-a4b-it" ;;
             T2)    echo "gemma-4-e4b-it" ;;
+            T0)    echo "qwen3.5-2b" ;;
             T1)    echo "gemma-4-e2b-it" ;;
             NV_ULTRA)   echo "gemma-4-31b-it" ;;
             SH_LARGE)   echo "gemma-4-31b-it" ;;
@@ -468,6 +470,7 @@ tier_model() {
         T4)    echo "qwen3-coder-next" ;;
         T3)    echo "qwen3-30b-a3b" ;;
         T2)    echo "qwen3.5-9b" ;;
+        T0)    echo "qwen3.5-2b" ;;
         T1)    echo "qwen3.5-2b" ;;
         NV_ULTRA)   echo "qwen3-coder-next" ;;
         SH_LARGE)   echo "qwen3-coder-next" ;;
@@ -614,7 +617,9 @@ main() {
     # Determine tier
     # For unified memory AMD APUs, use system RAM — VRAM reports only carve-out, not usable UMA.
     local tier tier_desc recommended_model
-    if [[ "$memory_type" == "unified" && "$gpu_type" == "amd" ]]; then
+    if [[ "$memory_type" == "discrete" && "$gpu_type" == "nvidia" && "$gpu_vram_mb" -gt 0 && "$gpu_vram_mb" -lt 4096 ]]; then
+        tier="T0"
+    elif [[ "$memory_type" == "unified" && "$gpu_type" == "amd" ]]; then
         tier=$(get_strix_halo_tier "$ram")
     elif [[ "$memory_type" == "unified" && "$gpu_type" == "nvidia" ]]; then
         local unified_gb

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -269,11 +269,25 @@ grep -q 'data\\\\config\\\\setup-complete.json\|setup-complete.json' installers/
 # --- classify-hardware: shared device_id disambiguation ---
 echo "[contract] classify-hardware shared device_id"
 _classify() {
-  bash scripts/classify-hardware.sh --device-id "$1" --gpu-name "$2" --gpu-vendor "${3:-amd}" --vram-mb "${4:-0}" 2>/dev/null
+  bash scripts/classify-hardware.sh --device-id "$1" --gpu-name "$2" --gpu-vendor "${3:-amd}" --vram-mb "${4:-0}" --memory-type "${5:-discrete}" 2>/dev/null
 }
 _classify_id()   { _classify "$@" | jq -r '.id'; }
 _classify_tier() { _classify "$@" | jq -r '.recommended.tier'; }
+_classify_backend() { _classify "$@" | jq -r '.recommended.backend'; }
 _classify_bw()   { _classify "$@" | jq -r '.bandwidth_gbps'; }
+
+# --- Low-VRAM NVIDIA cards must not be routed to CUDA by default ---
+
+[[ "$(_classify_id "" "NVIDIA GeForce 940MX" nvidia 2048)" == "nvidia_low_vram_cpu_fallback" ]] \
+  || { echo "[FAIL] 2GB NVIDIA must match low-VRAM CPU fallback"; exit 1; }
+[[ "$(_classify_backend "" "NVIDIA GeForce 940MX" nvidia 2048)" == "cpu" ]] \
+  || { echo "[FAIL] 2GB NVIDIA must use CPU backend"; exit 1; }
+[[ "$(_classify_tier "" "NVIDIA GeForce 940MX" nvidia 2048)" == "T0" ]] \
+  || { echo "[FAIL] 2GB NVIDIA must use T0"; exit 1; }
+[[ "$(_classify_id "" "NVIDIA GeForce GTX 1650" nvidia 4096)" == "nvidia_entry" ]] \
+  || { echo "[FAIL] 4GB NVIDIA should remain entry CUDA"; exit 1; }
+[[ "$(_classify_backend "" "NVIDIA GeForce GTX 1650" nvidia 4096)" == "nvidia" ]] \
+  || { echo "[FAIL] 4GB NVIDIA should keep NVIDIA backend"; exit 1; }
 
 # --- 0x744c: XTX / XT / GRE (same die, different SKUs) ---
 


### PR DESCRIPTION
## Summary
- routes discrete NVIDIA GPUs below 4GB VRAM to the CPU/T0 fallback instead of CUDA/T1
- teaches the hardware classifier/database about `max_vram_mb` ranges so low-VRAM cards do not fall through broad NVIDIA entry heuristics
- adds contract coverage for a 2GB GeForce 940MX-style host while preserving 4GB NVIDIA entry behavior

Closes #1468.

## Validation
- `python scripts/validate-generated-configs.py`
- JSON parse + `jsonschema.validate(config/gpu-database.json, config/gpu-database.schema.json)`
- Git Bash syntax: `bash -n installers/phases/02-detection.sh && bash -n scripts/classify-hardware.sh && bash -n scripts/detect-hardware.sh && bash -n tests/contracts/test-installer-contracts.sh`
- targeted classifier checks:
  - 2GB `NVIDIA GeForce 940MX` -> `HW_REC_BACKEND=cpu`, `HW_REC_TIER=T0`
  - 4GB `NVIDIA GeForce GTX 1650` -> `HW_REC_BACKEND=nvidia`, `HW_REC_TIER=T1`
- `python scripts/check-version-consistency.py`

Note: the full local `tests/contracts/test-installer-contracts.sh` run is blocked in this Windows shell because `jq` is not installed; CI should exercise the full contract path.