### PR TITLE
[codex] release 2.5.2 stamp

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dream Server Architecture
 
-> Version 2.5.1 | Fully local AI stack deployed on user hardware with a single command
+> Version 2.5.2 | Fully local AI stack deployed on user hardware with a single command
 
 ## Overview
 

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -6,7 +6,7 @@
 # secure random secrets. This file documents all available variables.
 
 # Dream Server version (auto-set by installer, used by dream-cli for compat checks)
-# DREAM_VERSION=2.5.1
+# DREAM_VERSION=2.5.2
 
 # LiteLLM proxy API key for internal service auth
 # TARGET_API_KEY=not-needed

--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,26 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.2] - 2026-05-26
+
+### Fixed
+- Dashboard nginx now re-resolves the `dashboard-api` service through Docker
+  DNS at request time so lifecycle recreation cannot leave `/api/*` and Dream
+  Talk routes pinned to a stale container IP.
+- Discrete NVIDIA GPUs with less than 4GB VRAM now route to the CPU/Tier 0
+  fallback by default instead of entering a green install with a crash-looping
+  CUDA `llama-server`.
+
+### Validation
+- Fleet test run on 2026-05-26 at commit `c1df395` passed User Green: true
+  fresh install, product, full-model capabilities, lifecycle, and UI validation
+  across tower2, Strix Halo, Spark, and M5 MacBook Pro.
+- Full-model capability probes passed on all 4 enabled hosts, including chat,
+  search, files, code, 76 Hermes skills, Dream Talk SSE streaming, session
+  pooling, SOUL.md context, and install-context grounding.
+- Distro lab passed 10/10 Docker lanes and 5/5 Incus VM lanes, and all 14
+  prior regression fixtures stayed green.
+
 ## [2.5.1] - 2026-05-26
 
 ### Added

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -948,7 +948,7 @@ async def _lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Dream Server Dashboard API",
-    version="2.5.1",
+    version="2.5.2",
     description="System status API for Dream Server Dashboard",
     lifespan=_lifespan,
 )

--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.5.1"
+VERSION="2.5.2"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Source path utilities for cross-platform path resolution

--- a/dream-server/installers/macos/lib/constants.sh
+++ b/dream-server/installers/macos/lib/constants.sh
@@ -11,7 +11,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-DS_VERSION="2.5.1"
+DS_VERSION="2.5.2"
 
 # Install location - use shared path resolution if available.
 # constants.sh lives at two different depths depending on layout:

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
-  "dream_version": "2.5.1",
+  "dream_version": "2.5.2",
   "min_compatible_dream_version": "1.0.0",
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.5.1",
+    "version": "2.5.2",
     "channel": "stable",
     "date": "2026-05-26"
   },


### PR DESCRIPTION
## Summary
- bumps Dream Server release metadata from 2.5.1 to 2.5.2
- adds 2.5.2 changelog notes for the post-2.5.1 stability fixes
- records the clean 2026-05-26 fleet result: User Green, full-model capabilities on all enabled hosts, clean distro lab, and 14/14 regression fixtures

## Scope
Metadata/release-stamp only. No installer, compose, runtime, or dependency behavior changes beyond version strings.

## Validation
- `python scripts/check-version-consistency.py`
- `python scripts/validate-generated-configs.py`
- `python -m compileall -q extensions/services/dashboard-api/main.py`
- Git Bash syntax: `bash -n installers/lib/constants.sh && bash -n installers/macos/lib/constants.sh`
- `git diff --check`