### PR TITLE
docs: define stable release lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,14 @@ security policy, GitHub workflows, and project coordination docs. The
 `dream-server/` directory is the product runtime: services, installer phases,
 compose overlays, dashboard, CLI, tests, and operator docs.
 
-**Stable consumption:** `main` moves quickly. For forks, appliances, labs, or
-production-like installs, pin a tagged release or audited commit and keep your
-own validation receipt. See [Installer Trust](dream-server/docs/INSTALLER_TRUST.md)
-and [Forkability](dream-server/docs/FORKABILITY.md).
+**Stable consumption:** `v2.5.2` is the current stable release. `main` moves
+quickly; use it for active development and validation candidates. For forks,
+appliances, labs, or production-like installs, pin a tagged release or audited
+commit and keep your own validation receipt. Stable patch fixes land on
+`release/2.5.x` before being merged forward. See
+[Release Channels](dream-server/docs/RELEASE_CHANNELS.md),
+[Installer Trust](dream-server/docs/INSTALLER_TRUST.md), and
+[Forkability](dream-server/docs/FORKABILITY.md).
 
 ## Get Started
 

--- a/dream-server/docs/RELEASE_CHANNELS.md
+++ b/dream-server/docs/RELEASE_CHANNELS.md
@@ -3,11 +3,21 @@
 Dream Server moves quickly because installer, hardware, model, and service
 ecosystems move quickly. Treat each ref intentionally.
 
+## Current Stable
+
+The current stable release is `v2.5.2`.
+
+Use `v2.5.2` for normal installs, downstream appliance baselines, lab images,
+and forks that want a known-good starting point. Use `release/2.5.x` only for
+patches that should preserve the `v2.5.2` user experience while fixing a
+stable-user problem.
+
 ## Channels
 
 | Channel | Use it for | Expectation |
 |---|---|---|
 | `main` | Active development, contributor work, rapid fixes, validation candidates | Can change many times per day. Read diffs and run focused validation before using it for an appliance or fork release. |
+| `release/2.5.x` | Patch-only maintenance for the current stable line | Only accepts stable hotfixes, security fixes, and docs that clarify current stable behavior. No new feature work. |
 | Tagged releases | Stable installs, downstream forks, lab images, appliance baselines | Preferred source for users and downstream operators who want a reproducible starting point. |
 | Pinned commits | Security reviews, internal mirrors, release candidates, emergency hotfix baselines | Valid when the commit and validation receipt are recorded together. |
 | Downstream forks | Custom hardware images, labs, private extensions, offline mirrors | Should record upstream ref, downstream changes, and local validation results. |
@@ -15,11 +25,51 @@ ecosystems move quickly. Treat each ref intentionally.
 ## Default Guidance
 
 - New users can follow the README quickstart.
-- Operators who want reproducibility should pin a release tag.
+- Operators who want reproducibility should pin a release tag. Today that means
+  `v2.5.2` unless a newer stable release has been published.
+- Stable hotfixes should target `release/2.5.x` first, then be merged forward
+  or cherry-picked into `main`.
 - Forks should either fork-and-pin or fork-and-mirror.
 - Hardware builders should treat upstream release receipts as evidence, then add
   their own validation receipt for local changes.
 - Do not treat `main` as a frozen API or appliance channel.
+
+## Stable Patch Policy
+
+Use the stable patch lane when the change fixes a real problem for users on the
+current stable release. Good candidates include:
+
+- installer, bootstrap, reinstall, restart, or doctor regressions
+- security exposure, credential, auth, or network-binding fixes
+- dashboard, Dream Talk, model download, model swap, or lifecycle breakage in a
+  supported default path
+- docs that prevent current stable users from taking the wrong action
+
+Do not target `release/2.5.x` for:
+
+- new bundled services or changed default services
+- broad installer, CLI, manifest, or compose refactors
+- new model-routing policy unless the current policy is broken
+- dependency churn that is not required for a stable fix
+- speculative polish that can wait for the next minor release
+
+The stable branch should stay boring. If a change needs a product debate, a new
+capability, or broad retesting outside the broken surface, it belongs on `main`
+or the next minor release train first.
+
+## Triage Questions
+
+Before opening or reviewing a PR, classify the lane:
+
+1. Is this broken for users on the current stable release?
+2. Does it affect install, lifecycle, security, model download/swap, GPU
+   routing, dashboard proxy, Dream Talk, or data safety?
+3. Does it change a default behavior?
+4. Can it wait for the next minor release?
+
+If the answer to the first question is yes and the fix is narrow, consider
+`release/2.5.x`. If the answer is no, use `main`. If the change is broad or
+feature-shaped, use the next minor milestone.
 
 ## Fork-And-Pin
 


### PR DESCRIPTION
## Summary

Defines the `v2.5.2` stability posture now that the release is stamped:

- calls out `v2.5.2` as the current stable release
- defines `release/2.5.x` as the patch-only stable lane
- adds stable-patch policy and triage questions
- updates the root README stable-consumption note to link release channels

## Validation

- `git diff --check`

## Risk

Docs-only. No runtime, installer, compose, dashboard, model, GPU, or release artifact behavior changes.