### PR TITLE
docs: add release lane to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,21 @@
 
 <!-- If AI tools helped draft code, docs, tests, reviews, or triage, say what they did. Use "None" when not applicable. The human author remains accountable for reading the diff, choosing the validation, and responding to review. -->
 
+## Release Lane
+
+<!-- Pick the lane before review. See dream-server/docs/RELEASE_CHANNELS.md. -->
+
+- [ ] Stable hotfix targeting `release/2.5.x`
+- [ ] Mainline change targeting `main`
+- [ ] Next-minor work targeting the next feature/minor release
+- [ ] Not sure; reviewer should help classify
+
+Stable hotfix reason:
+
+```text
+<!-- If this targets release/2.5.x, explain the current-stable user problem it fixes. -->
+```
+
 ## Changed Surface
 
 <!-- Check every surface this PR can affect. -->
@@ -32,6 +47,7 @@
   - [ ] Dashboard lint/test/build
   - [ ] Extension audit / compose validation
   - [ ] Release-grade fleet or scoped hardware validation
+  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
   - [ ] Not required because: <!-- explain -->
 
 Commands/results:


### PR DESCRIPTION
## Summary

Adds a release-lane classification section to the PR template so authors and reviewers decide whether a change is:

- a stable hotfix for `release/2.5.x`
- normal mainline work
- next-minor work
- unclear and needs reviewer classification

Also adds a stable-lane validation checkbox under the existing validation list.

## Validation

- `git diff --check`

## Risk

Template/docs-only. No product, installer, runtime, or CI behavior changes.