### PR TITLE
fix(dashboard): forward-port dream-proxy owner-card readiness

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/magic_link.py
+++ b/dream-server/extensions/services/dashboard-api/routers/magic_link.py
@@ -67,7 +67,7 @@ from fastapi.responses import RedirectResponse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 import session_signer
-from config import SERVICES
+from config import EXTENSIONS_DIR, GPU_BACKEND, SERVICES, load_extension_manifests
 from security import verify_api_key
 
 logger = logging.getLogger(__name__)
@@ -481,9 +481,30 @@ def _cookie_domain(url_mode: str = "auto") -> Optional[str]:
     return f"{_device_name()}.local"
 
 
+def _dream_proxy_service() -> Optional[dict]:
+    """Return dream-proxy service config, refreshing once for post-enable state.
+
+    dashboard-api loads extension manifests at process startup, but `dream
+    enable dream-proxy` flips compose.yaml.disabled to compose.yaml while this
+    process is still running. Owner-card readiness must see that transition
+    without requiring an operator to restart dashboard-api manually.
+    """
+    service = SERVICES.get("dream-proxy")
+    if service:
+        return service
+
+    refreshed_services, _, errors = load_extension_manifests(EXTENSIONS_DIR, GPU_BACKEND)
+    if errors:
+        logger.debug("Manifest refresh while checking dream-proxy reported %d errors", len(errors))
+    service = refreshed_services.get("dream-proxy")
+    if service:
+        SERVICES["dream-proxy"] = service
+    return service
+
+
 def _dream_proxy_lan_ready() -> tuple[bool, str]:
     """Return whether owner-card LAN URLs can actually be served."""
-    service = SERVICES.get("dream-proxy")
+    service = _dream_proxy_service()
     if not service:
         return (
             False,

--- a/dream-server/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -365,6 +365,56 @@ def test_owner_card_status_reports_proxy_state(
     }
 
 
+def test_dream_proxy_service_refreshes_stale_manifest_cache(magic_link_module, monkeypatch):
+    """Owner-card readiness should see dream-proxy after CLI enable.
+
+    The dashboard API imports SERVICES at startup. When `dream enable
+    dream-proxy` renames compose.yaml.disabled to compose.yaml, the running
+    process can have a stale SERVICES cache. The owner-card gate should refresh
+    that one service instead of requiring a manual dashboard-api restart.
+    """
+    magic_link_module.SERVICES.clear()
+
+    refreshed = {
+        "dream-proxy": {
+            "host": "dream-proxy",
+            "port": 80,
+            "health": "/health",
+            "name": "Dream Proxy",
+        }
+    }
+
+    def fake_load_extension_manifests(_extensions_dir, _gpu_backend):
+        return refreshed, [], []
+
+    monkeypatch.setattr(
+        magic_link_module,
+        "load_extension_manifests",
+        fake_load_extension_manifests,
+    )
+
+    service = magic_link_module._dream_proxy_service()
+
+    assert service == refreshed["dream-proxy"]
+    assert magic_link_module.SERVICES["dream-proxy"] == refreshed["dream-proxy"]
+
+
+def test_dream_proxy_service_keeps_disabled_state(magic_link_module, monkeypatch):
+    magic_link_module.SERVICES.clear()
+
+    def fake_load_extension_manifests(_extensions_dir, _gpu_backend):
+        return {}, [], []
+
+    monkeypatch.setattr(
+        magic_link_module,
+        "load_extension_manifests",
+        fake_load_extension_manifests,
+    )
+
+    assert magic_link_module._dream_proxy_service() is None
+    assert "dream-proxy" not in magic_link_module.SERVICES
+
+
 def test_public_url_mode_requires_public_url(magic_link_client):
     resp = magic_link_client.post(
         "/api/auth/magic-link/generate",


### PR DESCRIPTION
## Summary

Forward-port of #1475 from `release/2.5.x` to `main`.

Fixes #1474.

Owner-card readiness now refreshes the `dream-proxy` service manifest if the startup `SERVICES` cache does not contain it. This handles the normal flow where an operator runs `dream enable dream-proxy` and `dream start dream-proxy` while `dashboard-api` is already running.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low/Medium
- Validation run:
  - [x] `git diff --check origin/main...HEAD`
  - [x] Focused tests listed below

Commands/results:

```text
python -m compileall -q dream-server/extensions/services/dashboard-api/routers/magic_link.py dream-server/extensions/services/dashboard-api/tests/test_magic_link.py
python -m pytest dream-server/extensions/services/dashboard-api/tests/test_magic_link.py -q
53 passed in 1.96s
git diff --check origin/main...HEAD
```

## Notes For Reviewers

Stable branch PR #1475 is already merged. This PR keeps `main` aligned with the current stable hotfix.