### PR TITLE
release: forward-port 2.5.3 stamp to main

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dream Server Architecture
 
-> Version 2.5.2 | Fully local AI stack deployed on user hardware with a single command
+> Version 2.5.3 | Fully local AI stack deployed on user hardware with a single command
 
 ## Overview
 

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -6,7 +6,7 @@
 # secure random secrets. This file documents all available variables.
 
 # Dream Server version (auto-set by installer, used by dream-cli for compat checks)
-# DREAM_VERSION=2.5.2
+# DREAM_VERSION=2.5.3
 
 # LiteLLM proxy API key for internal service auth
 # TARGET_API_KEY=not-needed

--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.3] - 2026-05-26
+
+### Fixed
+- Owner-card readiness now notices `dream-proxy` after `dream enable
+  dream-proxy` and `dream start dream-proxy` without requiring a manual
+  `dashboard-api` restart.
+
+### Validation
+- Fleet test run on 2026-05-26 at commit `cff3b21` passed regressions,
+  zero-prereq bootstrap, installs, verify, cloud-mode, dashboard, Hermes, UI,
+  lifecycle, and distro lab validation across tower2, Strix Halo, Spark, and
+  M5 MacBook Pro.
+- The new `dream-proxy-owner-card-readiness-1474` regression fixture passed on
+  Strix Halo from both already-enabled and disabled states, proving owner-card
+  status returns `ready: true` without restarting `dashboard-api`.
+- Capability reruns confirmed initial Strix Halo and M5 MacBook Pro failures
+  were model/timing flakes; full-model capability probes passed on Strix Halo
+  and M5 MacBook Pro while tower2 and Spark correctly deferred on bootstrap
+  models.
+- Distro lab passed 10/10 Docker lanes and 5/5 Incus VM lanes.
+
 ## [2.5.2] - 2026-05-26
 
 ### Fixed

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -948,7 +948,7 @@ async def _lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Dream Server Dashboard API",
-    version="2.5.2",
+    version="2.5.3",
     description="System status API for Dream Server Dashboard",
     lifespan=_lifespan,
 )

--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.5.2"
+VERSION="2.5.3"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Source path utilities for cross-platform path resolution

--- a/dream-server/installers/macos/lib/constants.sh
+++ b/dream-server/installers/macos/lib/constants.sh
@@ -11,7 +11,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-DS_VERSION="2.5.2"
+DS_VERSION="2.5.3"
 
 # Install location - use shared path resolution if available.
 # constants.sh lives at two different depths depending on layout:

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": 2,
-  "dream_version": "2.5.2",
+  "dream_version": "2.5.3",
   "min_compatible_dream_version": "1.0.0",
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.5.2",
+    "version": "2.5.3",
     "channel": "stable",
     "date": "2026-05-26"
   },


### PR DESCRIPTION
## Summary

Forward-port the `v2.5.3` release stamp from `release/2.5.x` to `main`.

This keeps the public default bootstrap path aligned: README currently fetches `dream-server/get-dream-server.sh` from `main`, and that script clones the default branch unless `DREAMSERVER_REF` is set. Since `main` already contains the #1474 code fix, it should also report `2.5.3` instead of `2.5.2`.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [x] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `python dream-server/scripts/check-version-consistency.py`
  - [x] `git diff --check origin/main...HEAD`

Commands/results:

```text
python dream-server/scripts/check-version-consistency.py
[PASS] version consistency (2.5.3)

git diff --check origin/main...HEAD
```

## Notes For Reviewers

`v2.5.3` is already tagged and released from `release/2.5.x` at `d7784673`. This PR only keeps `main`'s version authorities and changelog aligned with that stable release.