### PR TITLE
feat(detection): add NVIDIA Jetson (Tegra) hardware detection

### DIFF
--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -291,7 +291,7 @@ detect_gpu() {
     local _gpu0_sysfs="${DREAM_GPU0_SYSFS:-/sys/devices/gpu.0}"
     local _uname_m="${DREAM_UNAME_M:-$(uname -m)}"
     local _is_jetson=false
-    if [[ "$_uname_m" == "aarch64" ]]; then
+    if [[ "${DREAM_ENABLE_EXPERIMENTAL_JETSON:-0}" == "1" && "$_uname_m" == "aarch64" ]]; then
         if [[ -f "$_tegra_release" ]]; then
             _is_jetson=true
         elif [[ -f "$_dt_compat" ]] && tr -d '\0' < "$_dt_compat" 2>/dev/null | grep -q "nvidia,tegra"; then

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -13,6 +13,7 @@
 # Provides: detect_gpu(), load_capability_profile(),
 #           normalize_profile_tier(), tier_rank(), load_backend_contract(),
 #           fix_nvidia_secure_boot(), MIN_DRIVER_VERSION
+#           Side-effect var on Jetson: JETSON_L4T_RELEASE (e.g. "R36.4.0")
 #
 # Modder notes:
 #   Add new GPU vendors or APU detection logic here.
@@ -276,6 +277,60 @@ detect_gpu() {
     GPU_BACKEND="cpu"  # default to CPU-only fallback
     GPU_MEMORY_TYPE="none"
     GPU_DEVICE_ID=""
+
+    # Try NVIDIA Jetson (Tegra SoC) first — Tegra iGPUs do not appear as PCIe
+    # devices under /sys/class/drm with vendor 0x10de, and nvidia-smi (only in
+    # JetPack 5+) reports the GPU partially or not at all. Detect via L4T
+    # release file or device-tree signature so this never falls into the
+    # discrete-NVIDIA branch below. Test hooks: DREAM_NV_TEGRA_RELEASE,
+    # DREAM_DEVICE_TREE_COMPATIBLE, DREAM_DEVICE_TREE_MODEL, DREAM_GPU0_SYSFS,
+    # DREAM_UNAME_M.
+    local _tegra_release="${DREAM_NV_TEGRA_RELEASE:-/etc/nv_tegra_release}"
+    local _dt_compat="${DREAM_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}"
+    local _dt_model="${DREAM_DEVICE_TREE_MODEL:-/proc/device-tree/model}"
+    local _gpu0_sysfs="${DREAM_GPU0_SYSFS:-/sys/devices/gpu.0}"
+    local _uname_m="${DREAM_UNAME_M:-$(uname -m)}"
+    local _is_jetson=false
+    if [[ "$_uname_m" == "aarch64" ]]; then
+        if [[ -f "$_tegra_release" ]]; then
+            _is_jetson=true
+        elif [[ -f "$_dt_compat" ]] && tr -d '\0' < "$_dt_compat" 2>/dev/null | grep -q "nvidia,tegra"; then
+            _is_jetson=true
+        elif [[ -d "$_gpu0_sysfs" ]]; then
+            _is_jetson=true
+        fi
+    fi
+    if $_is_jetson; then
+        GPU_BACKEND="jetson"
+        GPU_MEMORY_TYPE="unified"
+        GPU_COUNT=1
+        if [[ -f "$_dt_model" ]]; then
+            GPU_NAME="$(tr -d '\0' < "$_dt_model" 2>/dev/null)"
+        fi
+        [[ -z "${GPU_NAME:-}" ]] && GPU_NAME="NVIDIA Jetson (Tegra)"
+        # Parse L4T release (e.g. "R36 (release), REVISION: 4.0, ..." -> "R36.4.0")
+        # Used by later phases to pin a JetPack-compatible llama-server image.
+        JETSON_L4T_RELEASE=""
+        if [[ -f "$_tegra_release" ]]; then
+            local _major _minor
+            _major=$(grep -oE 'R[0-9]+' "$_tegra_release" 2>/dev/null | head -1)
+            _minor=$(grep -oE 'REVISION: [0-9.]+' "$_tegra_release" 2>/dev/null | head -1 | awk '{print $2}')
+            [[ -n "$_major" && -n "$_minor" ]] && JETSON_L4T_RELEASE="${_major}.${_minor}"
+        fi
+        GPU_DEVICE_ID="$JETSON_L4T_RELEASE"
+        # Unified memory: GPU shares system RAM. Use total RAM as VRAM budget,
+        # mirroring the Grace Blackwell (GB10/GB200) unified-memory branch below.
+        local _ram_kb
+        _ram_kb=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}')
+        if [[ -n "$_ram_kb" && "$_ram_kb" -gt 0 ]]; then
+            GPU_VRAM=$((_ram_kb / 1024))
+        else
+            GPU_VRAM=0
+            warn "Jetson detected but could not read /proc/meminfo for VRAM budget"
+        fi
+        log "GPU: $GPU_NAME (Jetson L4T ${JETSON_L4T_RELEASE:-unknown}, ${GPU_VRAM}MB unified memory)"
+        return 0
+    fi
 
     # Try NVIDIA first — validate hardware via sysfs vendor ID (0x10de)
     # before trusting nvidia-smi, which may be installed without NVIDIA hardware

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -132,7 +132,13 @@ else
             intel)  GPU_BACKEND="intel" ;;
             cpu)    GPU_BACKEND="cpu" ;;
             apple)  GPU_BACKEND="apple" ;;
-            jetson) GPU_BACKEND="jetson" ;;
+            jetson)
+                if [[ "${DREAM_ENABLE_EXPERIMENTAL_JETSON:-0}" == "1" ]]; then
+                    GPU_BACKEND="jetson"
+                else
+                    GPU_BACKEND="cpu"
+                fi
+                ;;
             *) GPU_BACKEND="nvidia" ;;
         esac
         [[ -n "${CAP_GPU_MEMORY_TYPE:-}" ]] && GPU_MEMORY_TYPE="${CAP_GPU_MEMORY_TYPE}"

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -128,10 +128,11 @@ else
 
     if [[ "${CAP_PROFILE_LOADED:-false}" == "true" ]]; then
         case "${CAP_LLM_BACKEND:-}" in
-            amd)   GPU_BACKEND="amd" ;;
-            intel) GPU_BACKEND="intel" ;;
-            cpu)   GPU_BACKEND="cpu" ;;
-            apple) GPU_BACKEND="apple" ;;
+            amd)    GPU_BACKEND="amd" ;;
+            intel)  GPU_BACKEND="intel" ;;
+            cpu)    GPU_BACKEND="cpu" ;;
+            apple)  GPU_BACKEND="apple" ;;
+            jetson) GPU_BACKEND="jetson" ;;
             *) GPU_BACKEND="nvidia" ;;
         esac
         [[ -n "${CAP_GPU_MEMORY_TYPE:-}" ]] && GPU_MEMORY_TYPE="${CAP_GPU_MEMORY_TYPE}"

--- a/dream-server/scripts/build-capability-profile.sh
+++ b/dream-server/scripts/build-capability-profile.sh
@@ -69,6 +69,7 @@ _LLM_HEALTH="${SERVICE_HEALTH[llama-server]:-/health}"
 
 "$PYTHON_CMD" - "$HARDWARE_JSON" "$OUTPUT_FILE" "$ENV_MODE" "${HW_CLASS_ID:-unknown}" "${HW_CLASS_LABEL:-Unknown}" "${HW_REC_BACKEND:-cpu}" "${HW_REC_TIER:-T1}" "${HW_REC_COMPOSE_OVERLAYS:-}" "$_LLM_PORT" "$_LLM_HEALTH" <<'PY'
 import json
+import os
 import pathlib
 import sys
 
@@ -99,6 +100,7 @@ gpu_name = gpu.get("name") or "None"
 memory_type = (gpu.get("memory_type") or "none").lower()
 vram_mb = int(gpu.get("vram_mb") or 0)
 gpu_count = int(gpu.get("count") or (1 if gpu_type not in {"none", ""} else 0))
+experimental_jetson = os.environ.get("DREAM_ENABLE_EXPERIMENTAL_JETSON") == "1"
 
 llm_health_url = f"http://localhost:{llm_port}{llm_health}"
 llm_api_port = llm_port
@@ -109,7 +111,7 @@ if gpu_type == "amd" and memory_type == "unified":
 elif gpu_type == "nvidia":
     llm_backend = "nvidia"
     overlays = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
-elif gpu_type == "jetson":
+elif gpu_type == "jetson" and experimental_jetson:
     # Jetson is Tegra (arm64 + iGPU + unified memory). The dedicated overlay
     # docker-compose.jetson.yml lands in milestone 1 phase 3; until then fall
     # back to the cpu overlay so the installer pipeline stays valid on Jetson

--- a/dream-server/scripts/build-capability-profile.sh
+++ b/dream-server/scripts/build-capability-profile.sh
@@ -109,6 +109,13 @@ if gpu_type == "amd" and memory_type == "unified":
 elif gpu_type == "nvidia":
     llm_backend = "nvidia"
     overlays = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
+elif gpu_type == "jetson":
+    # Jetson is Tegra (arm64 + iGPU + unified memory). The dedicated overlay
+    # docker-compose.jetson.yml lands in milestone 1 phase 3; until then fall
+    # back to the cpu overlay so the installer pipeline stays valid on Jetson
+    # hosts without claiming a runtime path that doesn't exist yet.
+    llm_backend = "jetson"
+    overlays = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
 elif gpu_type == "apple":
     llm_backend = "apple"
     overlays = ["docker-compose.base.yml", "docker-compose.amd.yml"]

--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -305,6 +305,8 @@ detect_amd() {
 # Test hooks: DREAM_NV_TEGRA_RELEASE, DREAM_DEVICE_TREE_COMPATIBLE,
 #             DREAM_DEVICE_TREE_MODEL, DREAM_GPU0_SYSFS, DREAM_UNAME_M
 detect_jetson() {
+    [[ "${DREAM_ENABLE_EXPERIMENTAL_JETSON:-0}" == "1" ]] || return 1
+
     local tegra_release="${DREAM_NV_TEGRA_RELEASE:-/etc/nv_tegra_release}"
     local dt_compat="${DREAM_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}"
     local dt_model="${DREAM_DEVICE_TREE_MODEL:-/proc/device-tree/model}"

--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -300,6 +300,51 @@ detect_amd() {
     fi
 }
 
+# Detect NVIDIA Jetson (Tegra SoC)
+# Returns: <model_name>|<l4t_release>|<ram_mb>   (pipe-delimited) or empty
+# Test hooks: DREAM_NV_TEGRA_RELEASE, DREAM_DEVICE_TREE_COMPATIBLE,
+#             DREAM_DEVICE_TREE_MODEL, DREAM_GPU0_SYSFS, DREAM_UNAME_M
+detect_jetson() {
+    local tegra_release="${DREAM_NV_TEGRA_RELEASE:-/etc/nv_tegra_release}"
+    local dt_compat="${DREAM_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}"
+    local dt_model="${DREAM_DEVICE_TREE_MODEL:-/proc/device-tree/model}"
+    local gpu0_sysfs="${DREAM_GPU0_SYSFS:-/sys/devices/gpu.0}"
+    local uname_m="${DREAM_UNAME_M:-$(uname -m)}"
+
+    [[ "$uname_m" == "aarch64" ]] || return 1
+
+    local is_jetson=false
+    if [[ -f "$tegra_release" ]]; then
+        is_jetson=true
+    elif [[ -f "$dt_compat" ]] && tr -d '\0' < "$dt_compat" 2>/dev/null | grep -q "nvidia,tegra"; then
+        is_jetson=true
+    elif [[ -d "$gpu0_sysfs" ]]; then
+        is_jetson=true
+    fi
+    $is_jetson || return 1
+
+    local model="NVIDIA Jetson (Tegra)"
+    if [[ -f "$dt_model" ]]; then
+        local raw
+        raw=$(tr -d '\0' < "$dt_model" 2>/dev/null) || raw=""
+        [[ -n "$raw" ]] && model="$raw"
+    fi
+
+    local l4t=""
+    if [[ -f "$tegra_release" ]]; then
+        local major minor
+        major=$(grep -oE 'R[0-9]+' "$tegra_release" 2>/dev/null | head -1)
+        minor=$(grep -oE 'REVISION: [0-9.]+' "$tegra_release" 2>/dev/null | head -1 | awk '{print $2}')
+        [[ -n "$major" && -n "$minor" ]] && l4t="${major}.${minor}"
+    fi
+
+    local ram_kb ram_mb=0
+    ram_kb=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}')
+    [[ -n "$ram_kb" && "$ram_kb" -gt 0 ]] && ram_mb=$(( ram_kb / 1024 ))
+
+    echo "${model}|${l4t}|${ram_mb}"
+}
+
 # Detect Apple Silicon
 detect_apple() {
     if [[ "$(detect_os)" == "macos" ]]; then
@@ -530,9 +575,27 @@ main() {
     cores=$(clamp_int "$cores" 1 1024)
     ram=$(clamp_int "$ram" 1 4096)
 
-    # Try NVIDIA first
+    # Try Jetson first — Tegra iGPUs don't show up as PCIe NVIDIA cards in
+    # sysfs and nvidia-smi is unreliable on JetPack, so detect via L4T release
+    # file / device-tree signature before the discrete-NVIDIA branch below.
+    local jetson_out=""
+    jetson_out=$(detect_jetson || true)
+    if [[ -n "$jetson_out" ]]; then
+        local _jetson_l4t _jetson_ram_mb
+        IFS='|' read -r gpu_name _jetson_l4t _jetson_ram_mb <<< "$jetson_out"
+        gpu_vram_mb=$(as_int "$_jetson_ram_mb")
+        gpu_count=1
+        gpu_type="jetson"
+        gpu_architecture="tegra"
+        memory_type="unified"
+        device_id="$_jetson_l4t"
+    fi
+
+    # Try NVIDIA next
     local nvidia_out=""
-    nvidia_out=$(detect_nvidia || true)
+    if [[ -z "$gpu_name" ]]; then
+        nvidia_out=$(detect_nvidia || true)
+    fi
     if [[ -n "$nvidia_out" ]]; then
         gpu_name=$(echo "$nvidia_out" | awk -F',' '{gsub(/^[ \t]+|[ \t]+$/,"",$1); print $1}' | xargs || true)
         gpu_vram_mb=$(parse_nvidia_vram_mb "$nvidia_out")

--- a/dream-server/tests/test-jetson-detection.sh
+++ b/dream-server/tests/test-jetson-detection.sh
@@ -3,9 +3,11 @@
 # Test: Jetson detection — detection.sh + detect-hardware.sh
 # ============================================================================
 # Builds a fake /etc/nv_tegra_release + /proc/device-tree/* tree and verifies:
-#   1. installers/lib/detection.sh::detect_gpu() sets GPU_BACKEND=jetson with
+#   1. installers/lib/detection.sh::detect_gpu() only sets GPU_BACKEND=jetson
+#      when DREAM_ENABLE_EXPERIMENTAL_JETSON=1, with
 #      unified-memory layout and a parsed JETSON_L4T_RELEASE.
-#   2. scripts/detect-hardware.sh emits gpu.type=jetson in --json output.
+#   2. scripts/detect-hardware.sh only emits gpu.type=jetson in --json output
+#      when DREAM_ENABLE_EXPERIMENTAL_JETSON=1.
 #
 # Run: bash tests/test-jetson-detection.sh
 # ============================================================================
@@ -57,6 +59,17 @@ assert_match() {
     fi
 }
 
+assert_no_match() {
+    local label="$1" pattern="$2" actual="$3"
+    if [[ "$actual" =~ $pattern ]]; then
+        echo "  FAIL: $label (unexpected match /$pattern/, got '$actual')"
+        FAIL=$((FAIL + 1))
+    else
+        echo "  PASS: $label (no match /$pattern/)"
+        PASS=$((PASS + 1))
+    fi
+}
+
 # ----------------------------------------------------------------------------
 # Build a minimal Jetson fixture tree
 # ----------------------------------------------------------------------------
@@ -74,12 +87,35 @@ printf 'nvidia,p3768-0000+p3767-0005\0nvidia,p3768-0000+p3767-0005\0nvidia,tegra
 
 mkdir -p "$FIXTURE_DIR/gpu.0"
 
-echo "=== Testing detect_gpu() against Jetson fixture ==="
+echo "=== Testing detect_gpu() against Jetson fixture with opt-in disabled ==="
 echo ""
 
 # Reset relevant globals before each invocation.
 unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
 
+DREAM_UNAME_M="aarch64" \
+DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+DREAM_DRM_SYS="$FIXTURE_DIR/empty-drm" \
+    detect_gpu || true
+
+if [[ "${GPU_BACKEND:-}" == "jetson" ]]; then
+    echo "  FAIL: default-off fixture wrongly detected as jetson"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: default-off fixture did not claim jetson (backend=${GPU_BACKEND:-unset})"
+    PASS=$((PASS + 1))
+fi
+
+echo ""
+echo "=== Testing detect_gpu() against Jetson fixture with opt-in enabled ==="
+echo ""
+
+unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
+
+DREAM_ENABLE_EXPERIMENTAL_JETSON=1 \
 DREAM_UNAME_M="aarch64" \
 DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
 DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
@@ -131,6 +167,7 @@ echo "=== Testing scripts/detect-hardware.sh --json with Jetson fixture ==="
 echo ""
 
 JSON_OUT=$(
+    DREAM_ENABLE_EXPERIMENTAL_JETSON=1 \
     DREAM_UNAME_M="aarch64" \
     DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
     DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
@@ -143,6 +180,21 @@ assert_match "gpu.type=jetson"        '"type":[[:space:]]*"jetson"'           "$
 assert_match "gpu.architecture=tegra" '"architecture":[[:space:]]*"tegra"'    "$JSON_OUT"
 assert_match "gpu.memory_type=unified" '"memory_type":[[:space:]]*"unified"'  "$JSON_OUT"
 assert_match "gpu.name=Orin Nano"     'NVIDIA Jetson Orin Nano'               "$JSON_OUT"
+
+echo ""
+echo "=== Testing scripts/detect-hardware.sh --json default-off against Jetson fixture ==="
+echo ""
+
+JSON_OUT_DEFAULT_OFF=$(
+    DREAM_UNAME_M="aarch64" \
+    DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+    DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+    DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+    DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+        bash "$SCRIPT_DIR/scripts/detect-hardware.sh" --json-compact 2>/dev/null
+)
+
+assert_no_match "default-off gpu.type is not jetson" '"type":[[:space:]]*"jetson"' "$JSON_OUT_DEFAULT_OFF"
 
 # ----------------------------------------------------------------------------
 echo ""

--- a/dream-server/tests/test-jetson-detection.sh
+++ b/dream-server/tests/test-jetson-detection.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# ============================================================================
+# Test: Jetson detection — detection.sh + detect-hardware.sh
+# ============================================================================
+# Builds a fake /etc/nv_tegra_release + /proc/device-tree/* tree and verifies:
+#   1. installers/lib/detection.sh::detect_gpu() sets GPU_BACKEND=jetson with
+#      unified-memory layout and a parsed JETSON_L4T_RELEASE.
+#   2. scripts/detect-hardware.sh emits gpu.type=jetson in --json output.
+#
+# Run: bash tests/test-jetson-detection.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+# Minimal logging stubs so detection.sh can be sourced standalone.
+log()  { :; }
+warn() { :; }
+
+# Source the module under test (detect_gpu)
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/installers/lib/detection.sh"
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_nonempty() {
+    local label="$1" actual="$2"
+    if [[ -n "$actual" ]]; then
+        echo "  PASS: $label (= '$actual')"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (empty)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_match() {
+    local label="$1" pattern="$2" actual="$3"
+    if [[ "$actual" =~ $pattern ]]; then
+        echo "  PASS: $label (matched /$pattern/)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected match /$pattern/, got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# Build a minimal Jetson fixture tree
+# ----------------------------------------------------------------------------
+FIXTURE_DIR="$(mktemp -d -t dream-jetson-fixture-XXXXXX)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# /etc/nv_tegra_release format mirrors JetPack 6 / L4T R36.4.0
+cat > "$FIXTURE_DIR/nv_tegra_release" <<'EOF'
+# R36 (release), REVISION: 4.0, GCID: 41062509, BOARD: generic, EABI: aarch64, DATE: ...
+EOF
+
+# Device-tree files are NUL-terminated on real Jetson; mimic that here.
+printf 'NVIDIA Jetson Orin Nano Developer Kit\0' > "$FIXTURE_DIR/dt_model"
+printf 'nvidia,p3768-0000+p3767-0005\0nvidia,p3768-0000+p3767-0005\0nvidia,tegra234\0nvidia,tegra\0\0' > "$FIXTURE_DIR/dt_compatible"
+
+mkdir -p "$FIXTURE_DIR/gpu.0"
+
+echo "=== Testing detect_gpu() against Jetson fixture ==="
+echo ""
+
+# Reset relevant globals before each invocation.
+unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
+
+DREAM_UNAME_M="aarch64" \
+DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+    detect_gpu
+
+assert_eq "GPU_BACKEND"      "jetson"  "${GPU_BACKEND:-}"
+assert_eq "GPU_MEMORY_TYPE"  "unified" "${GPU_MEMORY_TYPE:-}"
+assert_eq "GPU_COUNT"        "1"       "${GPU_COUNT:-}"
+assert_eq "GPU_NAME"         "NVIDIA Jetson Orin Nano Developer Kit" "${GPU_NAME:-}"
+assert_eq "JETSON_L4T_RELEASE" "R36.4.0" "${JETSON_L4T_RELEASE:-}"
+assert_eq "GPU_DEVICE_ID"    "R36.4.0" "${GPU_DEVICE_ID:-}"
+assert_nonempty "GPU_VRAM"   "${GPU_VRAM:-}"
+
+# ----------------------------------------------------------------------------
+# Non-Jetson hosts must NOT trip the new branch.
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Testing detect_gpu() on x86 host (must not detect jetson) ==="
+echo ""
+
+unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
+
+# Point every Jetson signal at a path that doesn't exist AND override uname -m.
+DREAM_UNAME_M="x86_64" \
+DREAM_NV_TEGRA_RELEASE="/dev/null/does-not-exist" \
+DREAM_DEVICE_TREE_COMPATIBLE="/dev/null/does-not-exist" \
+DREAM_DEVICE_TREE_MODEL="/dev/null/does-not-exist" \
+DREAM_GPU0_SYSFS="/dev/null/does-not-exist" \
+DREAM_DRM_SYS="$FIXTURE_DIR/empty-drm" \
+    detect_gpu || true
+
+# On a non-Jetson host with empty drm and no nvidia-smi the detector falls
+# back to cpu. The important assertion is that it didn't claim 'jetson'.
+if [[ "${GPU_BACKEND:-}" == "jetson" ]]; then
+    echo "  FAIL: x86 fallback wrongly detected as jetson"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: x86 fallback did not claim jetson (backend=${GPU_BACKEND:-unset})"
+    PASS=$((PASS + 1))
+fi
+
+# ----------------------------------------------------------------------------
+# detect-hardware.sh JSON pipeline
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Testing scripts/detect-hardware.sh --json with Jetson fixture ==="
+echo ""
+
+JSON_OUT=$(
+    DREAM_UNAME_M="aarch64" \
+    DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+    DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+    DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+    DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+        bash "$SCRIPT_DIR/scripts/detect-hardware.sh" --json-compact 2>/dev/null
+)
+
+assert_match "gpu.type=jetson"        '"type":[[:space:]]*"jetson"'           "$JSON_OUT"
+assert_match "gpu.architecture=tegra" '"architecture":[[:space:]]*"tegra"'    "$JSON_OUT"
+assert_match "gpu.memory_type=unified" '"memory_type":[[:space:]]*"unified"'  "$JSON_OUT"
+assert_match "gpu.name=Orin Nano"     'NVIDIA Jetson Orin Nano'               "$JSON_OUT"
+
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

First milestone toward [#195](https://github.com/Light-Heart-Labs/DreamServer/issues/195) (NVIDIA Jetson support). Adds Jetson (Tegra SoC) detection across the existing hardware-detection pipeline so a Jetson host is identified as `GPU_BACKEND=jetson` end-to-end. Scope is intentionally narrow — **detection only**, matching the maintainer's 2026-05-10 triage:

> A practical first milestone would be narrower than full Jetson support:
> - detect Jetson reliably (`/etc/nv_tegra_release`, `aarch64`, Tegra devices);
> - add a minimal Orin Nano/Orin class in the hardware/profile layer;

No tier-map entries, no compose overlay, no docs — those land in follow-ups once detection is reviewed in isolation.

## Why

Tegra iGPUs don't appear as PCIe devices under `/sys/class/drm` with vendor `0x10de`, and `nvidia-smi` is unreliable on JetPack (missing in JetPack 4.x, present but partial in 5+). The existing NVIDIA branch in `detect_gpu()` therefore can't see a Jetson at all — it falls through to the CPU fallback. This PR adds a dedicated detection branch that runs **before** the discrete-NVIDIA path.

## Detection signals (any sufficient, gated by `uname -m == aarch64`)

1. `/etc/nv_tegra_release` exists — definitive
2. `/proc/device-tree/compatible` contains `nvidia,tegra` — fallback when L4T file missing
3. `/sys/devices/gpu.0/` exists — last-resort sysfs witness

All file paths are overridable via `DREAM_*` env vars (mirrors the existing `DREAM_DRM_SYS` test hook) so the detection is unit-testable on x86.

## Files changed

| File | Change |
|---|---|
| `installers/lib/detection.sh` | New Jetson branch at top of `detect_gpu()`; sets `GPU_BACKEND=jetson`, `GPU_MEMORY_TYPE=unified`, `GPU_VRAM` from system RAM (mirrors the GB10 unified-memory pattern), parses `JETSON_L4T_RELEASE` from `/etc/nv_tegra_release` |
| `installers/phases/02-detection.sh` | Added `jetson)` case to the `CAP_LLM_BACKEND` mapping so a capability-profile override doesn't silently coerce Jetson to `nvidia` via the `*)` fallthrough |
| `scripts/detect-hardware.sh` | New `detect_jetson()` helper, called ahead of `detect_nvidia()` in `main()`. Emits `gpu.type=jetson`, `architecture=tegra`, `memory_type=unified` in JSON output |
| `scripts/build-capability-profile.sh` | New `gpu_type == "jetson"` branch in the Python block. Sets `llm_backend=jetson`; compose overlay temporarily defaults to `[base, cpu]` since the jetson overlay doesn't exist yet (follow-up PR) |
| `tests/test-jetson-detection.sh` (new) | Fixture-based unit test: builds fake `/etc/nv_tegra_release` + NUL-terminated device-tree files and verifies the full chain. Also asserts a non-Jetson x86 host does **not** trip the new branch |

## Explicitly out of scope (follow-up PRs)

- Tier-map entry (`JETSON_ORIN_NANO`) and `config/backends/jetson.json`
- `docker-compose.jetson.yml` and resolver branch in `scripts/resolve-compose-stack.sh`
- Per-tier model selection for Jetson hardware
- `docs/JETSON-QUICKSTART.md` and `SUPPORT-MATRIX.md` entry
- CI smoke (no Jetson hardware available in GH Actions; would add an on-device-only smoke later)

## Test plan

### Unit tests (cross-platform, no Jetson required)

```bash
bash tests/test-jetson-detection.sh   # 12/12 PASS
bash tests/test-tier-map.sh           # 122/122 PASS (unchanged)
```

### On-hardware acceptance — NVIDIA Jetson Orin Nano Super (8GB), JetPack R36.4.7

Real-hardware run by an Infrastructure Contributor applicant (myself, see #195 thread):

```
GPU_BACKEND        = jetson
GPU_MEMORY_TYPE    = unified
GPU_NAME           = NVIDIA Jetson Orin Nano Engineering Reference Developer Kit Super
GPU_VRAM           = 7619 MB
GPU_COUNT          = 1
GPU_DEVICE_ID      = R36.4.7
JETSON_L4T_RELEASE = R36.4.7
```

`bash scripts/detect-hardware.sh` (text mode):

```
GPU:
  Type:     jetson
  Name:     NVIDIA Jetson Orin Nano Engineering Reference Developer Kit Super
  Memory:   7GB (Unified)
```

Full hardware log attached on the issue thread.

### Non-Jetson regression check

`bash scripts/detect-hardware.sh --json-compact` on an x86 Linux host with no GPU still reports `gpu.type=none` — the new branch does not false-positive (gated on `uname -m`).

## Reviewer notes

- All new file reads are guarded by `[[ -f ... ]]` / `[[ -d ... ]]`; the `2>/dev/null` on reads matches the surrounding NVIDIA/AMD detection style.
- Function size: detect_gpu() grows by ~50 lines; following the existing inline-vendor-block pattern rather than extracting a helper to keep style consistent with NVIDIA/Intel/AMD branches.
- Device-tree files (`/proc/device-tree/*`) are NUL-terminated; reads use `tr -d '\0'` to strip the trailing NUL.