### PR TITLE
feat(tier-map): add JETSON_ORIN_NANO tier and jetson backend

### DIFF
--- a/dream-server/config/backends/jetson.json
+++ b/dream-server/config/backends/jetson.json
@@ -1,0 +1,10 @@
+{
+  "id": "jetson",
+  "llm_engine": "llama-server",
+  "service_name": "llama-server",
+  "public_api_port": 8080,
+  "public_health_url": "http://localhost:8080/health",
+  "provider_name": "local-llama",
+  "provider_url": "http://llama-server:8080/v1",
+  "notes": "NVIDIA Jetson (Tegra) backend. Same llama-server contract as nvidia.json; the runtime difference (JetPack-pinned llama.cpp image, sm_87 for Orin Nano, Tegra container runtime) lives in docker-compose.jetson.yml, which is added in a follow-up to issue #195."
+}

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -13,6 +13,7 @@
 # Provides: detect_gpu(), load_capability_profile(),
 #           normalize_profile_tier(), tier_rank(), load_backend_contract(),
 #           fix_nvidia_secure_boot(), MIN_DRIVER_VERSION
+#           Side-effect var on Jetson: JETSON_L4T_RELEASE (e.g. "R36.4.0")
 #
 # Modder notes:
 #   Add new GPU vendors or APU detection logic here.
@@ -276,6 +277,60 @@ detect_gpu() {
     GPU_BACKEND="cpu"  # default to CPU-only fallback
     GPU_MEMORY_TYPE="none"
     GPU_DEVICE_ID=""
+
+    # Try NVIDIA Jetson (Tegra SoC) first — Tegra iGPUs do not appear as PCIe
+    # devices under /sys/class/drm with vendor 0x10de, and nvidia-smi (only in
+    # JetPack 5+) reports the GPU partially or not at all. Detect via L4T
+    # release file or device-tree signature so this never falls into the
+    # discrete-NVIDIA branch below. Test hooks: DREAM_NV_TEGRA_RELEASE,
+    # DREAM_DEVICE_TREE_COMPATIBLE, DREAM_DEVICE_TREE_MODEL, DREAM_GPU0_SYSFS,
+    # DREAM_UNAME_M.
+    local _tegra_release="${DREAM_NV_TEGRA_RELEASE:-/etc/nv_tegra_release}"
+    local _dt_compat="${DREAM_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}"
+    local _dt_model="${DREAM_DEVICE_TREE_MODEL:-/proc/device-tree/model}"
+    local _gpu0_sysfs="${DREAM_GPU0_SYSFS:-/sys/devices/gpu.0}"
+    local _uname_m="${DREAM_UNAME_M:-$(uname -m)}"
+    local _is_jetson=false
+    if [[ "$_uname_m" == "aarch64" ]]; then
+        if [[ -f "$_tegra_release" ]]; then
+            _is_jetson=true
+        elif [[ -f "$_dt_compat" ]] && tr -d '\0' < "$_dt_compat" 2>/dev/null | grep -q "nvidia,tegra"; then
+            _is_jetson=true
+        elif [[ -d "$_gpu0_sysfs" ]]; then
+            _is_jetson=true
+        fi
+    fi
+    if $_is_jetson; then
+        GPU_BACKEND="jetson"
+        GPU_MEMORY_TYPE="unified"
+        GPU_COUNT=1
+        if [[ -f "$_dt_model" ]]; then
+            GPU_NAME="$(tr -d '\0' < "$_dt_model" 2>/dev/null)"
+        fi
+        [[ -z "${GPU_NAME:-}" ]] && GPU_NAME="NVIDIA Jetson (Tegra)"
+        # Parse L4T release (e.g. "R36 (release), REVISION: 4.0, ..." -> "R36.4.0")
+        # Used by later phases to pin a JetPack-compatible llama-server image.
+        JETSON_L4T_RELEASE=""
+        if [[ -f "$_tegra_release" ]]; then
+            local _major _minor
+            _major=$(grep -oE 'R[0-9]+' "$_tegra_release" 2>/dev/null | head -1)
+            _minor=$(grep -oE 'REVISION: [0-9.]+' "$_tegra_release" 2>/dev/null | head -1 | awk '{print $2}')
+            [[ -n "$_major" && -n "$_minor" ]] && JETSON_L4T_RELEASE="${_major}.${_minor}"
+        fi
+        GPU_DEVICE_ID="$JETSON_L4T_RELEASE"
+        # Unified memory: GPU shares system RAM. Use total RAM as VRAM budget,
+        # mirroring the Grace Blackwell (GB10/GB200) unified-memory branch below.
+        local _ram_kb
+        _ram_kb=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}')
+        if [[ -n "$_ram_kb" && "$_ram_kb" -gt 0 ]]; then
+            GPU_VRAM=$((_ram_kb / 1024))
+        else
+            GPU_VRAM=0
+            warn "Jetson detected but could not read /proc/meminfo for VRAM budget"
+        fi
+        log "GPU: $GPU_NAME (Jetson L4T ${JETSON_L4T_RELEASE:-unknown}, ${GPU_VRAM}MB unified memory)"
+        return 0
+    fi
 
     # Try NVIDIA first — validate hardware via sysfs vendor ID (0x10de)
     # before trusting nvidia-smi, which may be installed without NVIDIA hardware

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -154,6 +154,21 @@ set_qwen_tier_config() {
             MAX_CONTEXT=8192
             LLM_MODEL_SIZE_MB=1500    # Qwen3.5-2B-Q4_K_M (1.28 GB)
             ;;
+        JETSON_ORIN_NANO)
+            # NVIDIA Jetson Orin Nano (8 GB unified memory, Ampere sm_87).
+            # Conservative default: 2B Q4_K_M (~1.5 GB) leaves ~5 GB unified
+            # RAM for KV cache + open-webui + dashboard-api on an 8 GB SoC.
+            # Larger Orin Nano variants and Orin NX/AGX are deliberately
+            # excluded from this milestone — see issue #195.
+            TIER_NAME="Jetson Orin Nano"
+            LLM_MODEL="qwen3.5-2b"
+            GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
+            GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
+            GGUF_SHA256=""
+            MAX_CONTEXT=8192
+            LLM_MODEL_SIZE_MB=1500
+            N_GPU_LAYERS=99           # iGPU + unified memory: offload all layers
+            ;;
         1)
             TIER_NAME="Entry Level"
             LLM_MODEL="qwen3.5-9b"
@@ -191,7 +206,7 @@ set_qwen_tier_config() {
             LLM_MODEL_SIZE_MB=18600   # 18.6 GB per HF file listing
             ;;
         *)
-            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE"
+            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE, JETSON_ORIN_NANO"
             # NOTE for modders: add your tier above this line and update this message.
             ;;
     esac
@@ -267,6 +282,20 @@ set_gemma4_tier_config() {
             MAX_CONTEXT=8192
             LLM_MODEL_SIZE_MB=1500
             ;;
+        JETSON_ORIN_NANO)
+            # Jetson Orin Nano (8 GB unified, Ampere sm_87) with gemma4 profile.
+            # E2B Q4_K_M (~2.81 GB) fits comfortably alongside the rest of the
+            # stack on 8 GB unified memory; reduced context vs entry-level to
+            # leave headroom for KV cache.
+            TIER_NAME="Jetson Orin Nano"
+            LLM_MODEL="gemma-4-e2b-it"
+            GGUF_FILE="gemma-4-E2B-it-Q4_K_M.gguf"
+            GGUF_URL="https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf"
+            GGUF_SHA256=""
+            MAX_CONTEXT=8192
+            LLM_MODEL_SIZE_MB=2810
+            N_GPU_LAYERS=99           # iGPU + unified memory: offload all layers
+            ;;
         1)
             TIER_NAME="Entry Level"
             LLM_MODEL="gemma-4-e2b-it"
@@ -304,7 +333,7 @@ set_gemma4_tier_config() {
             LLM_MODEL_SIZE_MB=19800
             ;;
         *)
-            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE"
+            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE, JETSON_ORIN_NANO"
             ;;
     esac
 }
@@ -348,6 +377,7 @@ tier_to_model() {
                 SH_COMPACT|SH)  model="gemma-4-26b-a4b-it" ;;
                 ARC)            model="gemma-4-e4b-it" ;;
                 ARC_LITE)       model="gemma-4-e2b-it" ;;
+                JETSON_ORIN_NANO) model="gemma-4-e2b-it" ;;
                 0|T0)           model="qwen3.5-2b" ;;
                 1|T1)           model="gemma-4-e2b-it" ;;
                 2|T2)           model="gemma-4-e4b-it" ;;
@@ -373,6 +403,7 @@ tier_to_model() {
                 SH_COMPACT|SH)  model="qwen3-30b-a3b" ;;
                 ARC)            model="qwen3.5-9b" ;;
                 ARC_LITE)       model="qwen3.5-4b" ;;
+                JETSON_ORIN_NANO) model="qwen3.5-2b" ;;
                 0|T0)           model="qwen3.5-2b" ;;
                 1|T1)           model="qwen3.5-9b" ;;
                 2|T2)           model="qwen3.5-9b" ;;

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -128,10 +128,11 @@ else
 
     if [[ "${CAP_PROFILE_LOADED:-false}" == "true" ]]; then
         case "${CAP_LLM_BACKEND:-}" in
-            amd)   GPU_BACKEND="amd" ;;
-            intel) GPU_BACKEND="intel" ;;
-            cpu)   GPU_BACKEND="cpu" ;;
-            apple) GPU_BACKEND="apple" ;;
+            amd)    GPU_BACKEND="amd" ;;
+            intel)  GPU_BACKEND="intel" ;;
+            cpu)    GPU_BACKEND="cpu" ;;
+            apple)  GPU_BACKEND="apple" ;;
+            jetson) GPU_BACKEND="jetson" ;;
             *) GPU_BACKEND="nvidia" ;;
         esac
         [[ -n "${CAP_GPU_MEMORY_TYPE:-}" ]] && GPU_MEMORY_TYPE="${CAP_GPU_MEMORY_TYPE}"

--- a/dream-server/scripts/build-capability-profile.sh
+++ b/dream-server/scripts/build-capability-profile.sh
@@ -109,6 +109,13 @@ if gpu_type == "amd" and memory_type == "unified":
 elif gpu_type == "nvidia":
     llm_backend = "nvidia"
     overlays = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
+elif gpu_type == "jetson":
+    # Jetson is Tegra (arm64 + iGPU + unified memory). The dedicated overlay
+    # docker-compose.jetson.yml lands in milestone 1 phase 3; until then fall
+    # back to the cpu overlay so the installer pipeline stays valid on Jetson
+    # hosts without claiming a runtime path that doesn't exist yet.
+    llm_backend = "jetson"
+    overlays = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
 elif gpu_type == "apple":
     llm_backend = "apple"
     overlays = ["docker-compose.base.yml", "docker-compose.amd.yml"]

--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -300,6 +300,51 @@ detect_amd() {
     fi
 }
 
+# Detect NVIDIA Jetson (Tegra SoC)
+# Returns: <model_name>|<l4t_release>|<ram_mb>   (pipe-delimited) or empty
+# Test hooks: DREAM_NV_TEGRA_RELEASE, DREAM_DEVICE_TREE_COMPATIBLE,
+#             DREAM_DEVICE_TREE_MODEL, DREAM_GPU0_SYSFS, DREAM_UNAME_M
+detect_jetson() {
+    local tegra_release="${DREAM_NV_TEGRA_RELEASE:-/etc/nv_tegra_release}"
+    local dt_compat="${DREAM_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}"
+    local dt_model="${DREAM_DEVICE_TREE_MODEL:-/proc/device-tree/model}"
+    local gpu0_sysfs="${DREAM_GPU0_SYSFS:-/sys/devices/gpu.0}"
+    local uname_m="${DREAM_UNAME_M:-$(uname -m)}"
+
+    [[ "$uname_m" == "aarch64" ]] || return 1
+
+    local is_jetson=false
+    if [[ -f "$tegra_release" ]]; then
+        is_jetson=true
+    elif [[ -f "$dt_compat" ]] && tr -d '\0' < "$dt_compat" 2>/dev/null | grep -q "nvidia,tegra"; then
+        is_jetson=true
+    elif [[ -d "$gpu0_sysfs" ]]; then
+        is_jetson=true
+    fi
+    $is_jetson || return 1
+
+    local model="NVIDIA Jetson (Tegra)"
+    if [[ -f "$dt_model" ]]; then
+        local raw
+        raw=$(tr -d '\0' < "$dt_model" 2>/dev/null) || raw=""
+        [[ -n "$raw" ]] && model="$raw"
+    fi
+
+    local l4t=""
+    if [[ -f "$tegra_release" ]]; then
+        local major minor
+        major=$(grep -oE 'R[0-9]+' "$tegra_release" 2>/dev/null | head -1)
+        minor=$(grep -oE 'REVISION: [0-9.]+' "$tegra_release" 2>/dev/null | head -1 | awk '{print $2}')
+        [[ -n "$major" && -n "$minor" ]] && l4t="${major}.${minor}"
+    fi
+
+    local ram_kb ram_mb=0
+    ram_kb=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}')
+    [[ -n "$ram_kb" && "$ram_kb" -gt 0 ]] && ram_mb=$(( ram_kb / 1024 ))
+
+    echo "${model}|${l4t}|${ram_mb}"
+}
+
 # Detect Apple Silicon
 detect_apple() {
     if [[ "$(detect_os)" == "macos" ]]; then
@@ -530,9 +575,27 @@ main() {
     cores=$(clamp_int "$cores" 1 1024)
     ram=$(clamp_int "$ram" 1 4096)
 
-    # Try NVIDIA first
+    # Try Jetson first — Tegra iGPUs don't show up as PCIe NVIDIA cards in
+    # sysfs and nvidia-smi is unreliable on JetPack, so detect via L4T release
+    # file / device-tree signature before the discrete-NVIDIA branch below.
+    local jetson_out=""
+    jetson_out=$(detect_jetson || true)
+    if [[ -n "$jetson_out" ]]; then
+        local _jetson_l4t _jetson_ram_mb
+        IFS='|' read -r gpu_name _jetson_l4t _jetson_ram_mb <<< "$jetson_out"
+        gpu_vram_mb=$(as_int "$_jetson_ram_mb")
+        gpu_count=1
+        gpu_type="jetson"
+        gpu_architecture="tegra"
+        memory_type="unified"
+        device_id="$_jetson_l4t"
+    fi
+
+    # Try NVIDIA next
     local nvidia_out=""
-    nvidia_out=$(detect_nvidia || true)
+    if [[ -z "$gpu_name" ]]; then
+        nvidia_out=$(detect_nvidia || true)
+    fi
     if [[ -n "$nvidia_out" ]]; then
         gpu_name=$(echo "$nvidia_out" | awk -F',' '{gsub(/^[ \t]+|[ \t]+$/,"",$1); print $1}' | xargs || true)
         gpu_vram_mb=$(parse_nvidia_vram_mb "$nvidia_out")

--- a/dream-server/tests/test-jetson-detection.sh
+++ b/dream-server/tests/test-jetson-detection.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# ============================================================================
+# Test: Jetson detection — detection.sh + detect-hardware.sh
+# ============================================================================
+# Builds a fake /etc/nv_tegra_release + /proc/device-tree/* tree and verifies:
+#   1. installers/lib/detection.sh::detect_gpu() sets GPU_BACKEND=jetson with
+#      unified-memory layout and a parsed JETSON_L4T_RELEASE.
+#   2. scripts/detect-hardware.sh emits gpu.type=jetson in --json output.
+#
+# Run: bash tests/test-jetson-detection.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+# Minimal logging stubs so detection.sh can be sourced standalone.
+log()  { :; }
+warn() { :; }
+
+# Source the module under test (detect_gpu)
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/installers/lib/detection.sh"
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_nonempty() {
+    local label="$1" actual="$2"
+    if [[ -n "$actual" ]]; then
+        echo "  PASS: $label (= '$actual')"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (empty)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_match() {
+    local label="$1" pattern="$2" actual="$3"
+    if [[ "$actual" =~ $pattern ]]; then
+        echo "  PASS: $label (matched /$pattern/)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected match /$pattern/, got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# Build a minimal Jetson fixture tree
+# ----------------------------------------------------------------------------
+FIXTURE_DIR="$(mktemp -d -t dream-jetson-fixture-XXXXXX)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# /etc/nv_tegra_release format mirrors JetPack 6 / L4T R36.4.0
+cat > "$FIXTURE_DIR/nv_tegra_release" <<'EOF'
+# R36 (release), REVISION: 4.0, GCID: 41062509, BOARD: generic, EABI: aarch64, DATE: ...
+EOF
+
+# Device-tree files are NUL-terminated on real Jetson; mimic that here.
+printf 'NVIDIA Jetson Orin Nano Developer Kit\0' > "$FIXTURE_DIR/dt_model"
+printf 'nvidia,p3768-0000+p3767-0005\0nvidia,p3768-0000+p3767-0005\0nvidia,tegra234\0nvidia,tegra\0\0' > "$FIXTURE_DIR/dt_compatible"
+
+mkdir -p "$FIXTURE_DIR/gpu.0"
+
+echo "=== Testing detect_gpu() against Jetson fixture ==="
+echo ""
+
+# Reset relevant globals before each invocation.
+unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
+
+DREAM_UNAME_M="aarch64" \
+DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+    detect_gpu
+
+assert_eq "GPU_BACKEND"      "jetson"  "${GPU_BACKEND:-}"
+assert_eq "GPU_MEMORY_TYPE"  "unified" "${GPU_MEMORY_TYPE:-}"
+assert_eq "GPU_COUNT"        "1"       "${GPU_COUNT:-}"
+assert_eq "GPU_NAME"         "NVIDIA Jetson Orin Nano Developer Kit" "${GPU_NAME:-}"
+assert_eq "JETSON_L4T_RELEASE" "R36.4.0" "${JETSON_L4T_RELEASE:-}"
+assert_eq "GPU_DEVICE_ID"    "R36.4.0" "${GPU_DEVICE_ID:-}"
+assert_nonempty "GPU_VRAM"   "${GPU_VRAM:-}"
+
+# ----------------------------------------------------------------------------
+# Non-Jetson hosts must NOT trip the new branch.
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Testing detect_gpu() on x86 host (must not detect jetson) ==="
+echo ""
+
+unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
+
+# Point every Jetson signal at a path that doesn't exist AND override uname -m.
+DREAM_UNAME_M="x86_64" \
+DREAM_NV_TEGRA_RELEASE="/dev/null/does-not-exist" \
+DREAM_DEVICE_TREE_COMPATIBLE="/dev/null/does-not-exist" \
+DREAM_DEVICE_TREE_MODEL="/dev/null/does-not-exist" \
+DREAM_GPU0_SYSFS="/dev/null/does-not-exist" \
+DREAM_DRM_SYS="$FIXTURE_DIR/empty-drm" \
+    detect_gpu || true
+
+# On a non-Jetson host with empty drm and no nvidia-smi the detector falls
+# back to cpu. The important assertion is that it didn't claim 'jetson'.
+if [[ "${GPU_BACKEND:-}" == "jetson" ]]; then
+    echo "  FAIL: x86 fallback wrongly detected as jetson"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: x86 fallback did not claim jetson (backend=${GPU_BACKEND:-unset})"
+    PASS=$((PASS + 1))
+fi
+
+# ----------------------------------------------------------------------------
+# detect-hardware.sh JSON pipeline
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Testing scripts/detect-hardware.sh --json with Jetson fixture ==="
+echo ""
+
+JSON_OUT=$(
+    DREAM_UNAME_M="aarch64" \
+    DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+    DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+    DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+    DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+        bash "$SCRIPT_DIR/scripts/detect-hardware.sh" --json-compact 2>/dev/null
+)
+
+assert_match "gpu.type=jetson"        '"type":[[:space:]]*"jetson"'           "$JSON_OUT"
+assert_match "gpu.architecture=tegra" '"architecture":[[:space:]]*"tegra"'    "$JSON_OUT"
+assert_match "gpu.memory_type=unified" '"memory_type":[[:space:]]*"unified"'  "$JSON_OUT"
+assert_match "gpu.name=Orin Nano"     'NVIDIA Jetson Orin Nano'               "$JSON_OUT"
+
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -164,6 +164,29 @@ assert_eq "GPU_BACKEND"  "sycl"                                "$GPU_BACKEND"
 assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
 echo ""
 
+# --- JETSON_ORIN_NANO (qwen profile) ---
+echo "JETSON_ORIN_NANO (NVIDIA Jetson Orin Nano, 8 GB unified, qwen):"
+run_tier JETSON_ORIN_NANO
+assert_eq "TIER_NAME"    "Jetson Orin Nano"                    "$TIER_NAME"
+assert_eq "MODEL_PROFILE_EFFECTIVE" "qwen"                   "$MODEL_PROFILE_EFFECTIVE"
+assert_eq "LLM_MODEL"    "qwen3.5-2b"                        "$LLM_MODEL"
+assert_eq "GGUF_FILE"    "Qwen3.5-2B-Q4_K_M.gguf"            "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "8192"                                "$MAX_CONTEXT"
+assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
+echo ""
+
+# --- JETSON_ORIN_NANO (gemma4 profile) ---
+echo "JETSON_ORIN_NANO (gemma4 profile):"
+MODEL_PROFILE=gemma4 run_tier JETSON_ORIN_NANO
+assert_eq "TIER_NAME"    "Jetson Orin Nano"                    "$TIER_NAME"
+assert_eq "MODEL_PROFILE_EFFECTIVE" "gemma4"                 "$MODEL_PROFILE_EFFECTIVE"
+assert_eq "LLM_MODEL"    "gemma-4-e2b-it"                    "$LLM_MODEL"
+assert_eq "GGUF_FILE"    "gemma-4-E2B-it-Q4_K_M.gguf"        "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "8192"                                "$MAX_CONTEXT"
+assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
+unset MODEL_PROFILE
+echo ""
+
 # --- Invalid tier should fail ---
 echo "Invalid tier (should fail):"
 if TIER="INVALID" resolve_tier_config 2>/dev/null; then
@@ -177,7 +200,7 @@ echo ""
 
 # --- GGUF_URL should be set for all tiers ---
 echo "GGUF_URL populated for all tiers:"
-for t in 0 1 2 3 4 NV_ULTRA SH_LARGE SH_COMPACT ARC ARC_LITE; do
+for t in 0 1 2 3 4 NV_ULTRA SH_LARGE SH_COMPACT ARC ARC_LITE JETSON_ORIN_NANO; do
     run_tier "$t"
     if [[ -n "$GGUF_URL" && "$GGUF_URL" == https://* ]]; then
         echo "  PASS: Tier $t has valid GGUF_URL"


### PR DESCRIPTION
## Summary

Phase 2 of issue #195 milestone 1. Stacks on #1479 (Phase 1 detection). Adds the `JETSON_ORIN_NANO` tier and a `jetson` backend contract — pure data, no compose changes, no runtime impact.

## Why

PR #1479 plumbs `GPU_BACKEND=jetson` through detection but the tier-map has no entry, so a user running `--tier JETSON_ORIN_NANO` today gets `error "Invalid tier"`. This PR closes that gap and lets the installer resolve a sane model and context size for Orin Nano hardware.

## Tier choices

Sized for the 8 GB unified-memory budget on Orin Nano (Ampere sm_87). Leaves ~5 GB free for KV cache + open-webui + dashboard-api + LiteLLM after the model loads.

| Profile | Model | Quant | Size on disk | Context | Rationale |
|---|---|---|---|---|---|
| qwen   | qwen3.5-2b      | Q4_K_M | ~1.5 GB  | 8K | Same model as Tier 0 — proven small-footprint default; comfortable headroom |
| gemma4 | gemma-4-e2b-it  | Q4_K_M | ~2.81 GB | 8K | Matches the gemma4 Tier 1 model; reduced context vs Tier 1 to keep KV cache room |

Both set `N_GPU_LAYERS=99` — the Tegra iGPU shares system RAM with the CPU, so partial offload has no upside on unified memory.

Larger Orin Nano variants and Orin NX/AGX are deliberately excluded; this milestone is "Orin Nano end-to-end" per the maintainer's 2026-05-10 triage on #195.

## Files changed

| File | Change |
|---|---|
| `installers/lib/tier-map.sh` | `JETSON_ORIN_NANO` case added to both `set_qwen_tier_config()` and `set_gemma4_tier_config()` switches. Validation error lists at lines 194 + 307 updated. `tier_to_model()` extended in both profile branches so `dream model swap` resolves correctly |
| `config/backends/jetson.json` (new) | Mirrors `nvidia.json` — same `llama-server` contract on port 8080, same provider URL. The runtime difference (JetPack-pinned image, Tegra container runtime) lives in `docker-compose.jetson.yml`, follow-up PR |
| `tests/test-tier-map.sh` | Added 13 assertions covering both qwen and gemma4 paths for the new tier; extended the GGUF_URL coverage loop to include `JETSON_ORIN_NANO` |

## Test plan

```bash
bash tests/test-tier-map.sh
# Results: 135 passed, 0 failed   (was 122 before; +13 new Jetson assertions)
```

Plus the Phase 1 detection test still passes unchanged:

```bash
bash tests/test-jetson-detection.sh
# Passed: 12, Failed: 0
```

End-to-end resolution check on the qwen path:

```bash
TIER=JETSON_ORIN_NANO bash -c 'source installers/lib/tier-map.sh && resolve_tier_config && echo "$LLM_MODEL $GGUF_FILE $MAX_CONTEXT $N_GPU_LAYERS"'
# Expected: qwen3.5-2b Qwen3.5-2B-Q4_K_M.gguf 8192 99
```

And gemma4:

```bash
MODEL_PROFILE=gemma4 TIER=JETSON_ORIN_NANO bash -c 'source installers/lib/tier-map.sh && resolve_tier_config && echo "$LLM_MODEL $GGUF_FILE $MAX_CONTEXT $N_GPU_LAYERS"'
# Expected: gemma-4-e2b-it gemma-4-E2B-it-Q4_K_M.gguf 8192 99
```

## Explicitly out of scope (separate follow-ups)

- `docker-compose.jetson.yml` and resolver branch in `scripts/resolve-compose-stack.sh`
- Auto-tier selection on Jetson hosts (`--tier JETSON_ORIN_NANO` required for now)
- Orin AGX/NX, Xavier, legacy Nano (different SoCs / CUDA caps)
- `docs/JETSON-QUICKSTART.md` and `SUPPORT-MATRIX.md` entry
- CI smoke (no Jetson hardware available in GH Actions)

## Stack note

Stacks on #1479 (`feat/jetson-detection`). If #1479 needs rework during review (e.g. renaming the backend value from `jetson` to `tegra`), this branch rebases cleanly — the only cross-PR dependency is the string `jetson` used as the backend identifier.
