### PR TITLE
feat(compose): add docker-compose.jetson.yml + resolver branch

### DIFF
--- a/dream-server/config/backends/jetson.json
+++ b/dream-server/config/backends/jetson.json
@@ -1,0 +1,10 @@
+{
+  "id": "jetson",
+  "llm_engine": "llama-server",
+  "service_name": "llama-server",
+  "public_api_port": 8080,
+  "public_health_url": "http://localhost:8080/health",
+  "provider_name": "local-llama",
+  "provider_url": "http://llama-server:8080/v1",
+  "notes": "NVIDIA Jetson (Tegra) backend. Same llama-server contract as nvidia.json; the runtime difference (JetPack-pinned llama.cpp image, sm_87 for Orin Nano, Tegra container runtime) lives in docker-compose.jetson.yml, which is added in a follow-up to issue #195."
+}

--- a/dream-server/docker-compose.jetson.yml
+++ b/dream-server/docker-compose.jetson.yml
@@ -1,0 +1,45 @@
+# Dream Server — NVIDIA Jetson (Tegra) Overlay
+#
+# Differences from docker-compose.nvidia.yml:
+#   * Image: dustynv/llama_cpp builds target Jetson compute capability (sm_87
+#     for Orin Nano / Ampere). The stock ghcr.io/ggml-org/llama.cpp:server-cuda-*
+#     images are built for sm_75/80/86/89/90 and will not load models on Jetson.
+#   * GPU passthrough via `runtime: nvidia` (Tegra container runtime), not
+#     `deploy.resources.reservations.devices`. Required for Jetson — the
+#     reservations syntax is the discrete-GPU pattern and is unreliable on L4T.
+#   * Memory limit defaults sized for 8 GB unified memory; override via .env
+#     for larger Orin variants once they're validated.
+#
+# Prerequisites on the host:
+#   * JetPack 6.x flashed (L4T R36.x)
+#   * nvidia-container-toolkit configured as the default runtime in
+#     /etc/docker/daemon.json (the JetPack installer sets this up; verify with
+#     `docker info | grep -i runtime`)
+#
+# Use with:
+#   docker compose -f docker-compose.base.yml -f docker-compose.jetson.yml up -d
+
+services:
+  llama-server:
+    image: ${LLAMA_SERVER_IMAGE:-dustynv/llama_cpp:r36.4.0}
+    # Tegra container runtime — required on Jetson. Override via .env only if
+    # you have a custom Docker daemon configuration.
+    runtime: ${JETSON_RUNTIME:-nvidia}
+    environment:
+      # Expose all Jetson iGPU capabilities to the container. NVIDIA_VISIBLE_DEVICES
+      # is recognized by the Tegra runtime even though Jetson has only one iGPU.
+      NVIDIA_VISIBLE_DEVICES: all
+      NVIDIA_DRIVER_CAPABILITIES: compute,utility
+    deploy:
+      resources:
+        limits:
+          cpus: '${LLAMA_CPU_LIMIT:-6.0}'
+          memory: ${LLAMA_SERVER_MEMORY_LIMIT:-6G}
+
+  open-webui:
+    environment:
+      AUDIO_STT_MODEL: "${AUDIO_STT_MODEL:-deepdml/faster-whisper-large-v3-turbo-ct2}"
+      # ComfyUI image generation is disabled on Jetson in this milestone — no
+      # validated arm64 + sm_87 path yet. Override to "true" only after
+      # ComfyUI's Jetson story is solved (tracked in a follow-up to #195).
+      ENABLE_IMAGE_GENERATION: "${ENABLE_IMAGE_GENERATION:-false}"

--- a/dream-server/extensions/services/dashboard-api/manifest.yaml
+++ b/dream-server/extensions/services/dashboard-api/manifest.yaml
@@ -15,6 +15,6 @@ service:
   health: /health
   ui_path: /health
   type: docker
-  gpu_backends: [amd, nvidia]
+  gpu_backends: [amd, nvidia, jetson]
   category: core
   depends_on: []

--- a/dream-server/extensions/services/dashboard/manifest.yaml
+++ b/dream-server/extensions/services/dashboard/manifest.yaml
@@ -15,6 +15,6 @@ service:
   health: /
   ui_path: /
   type: docker
-  gpu_backends: [amd, nvidia]
+  gpu_backends: [amd, nvidia, jetson]
   category: core
   depends_on: [dashboard-api]

--- a/dream-server/extensions/services/llama-server/manifest.yaml
+++ b/dream-server/extensions/services/llama-server/manifest.yaml
@@ -17,7 +17,7 @@ service:
   ui_path: /
   health_timeout: 15
   type: docker
-  gpu_backends: [amd, nvidia]
+  gpu_backends: [amd, nvidia, jetson]
   category: core
   depends_on: []
 
@@ -36,7 +36,7 @@ features:
     launch:
       type: service
       service: open-webui
-    gpu_backends: [amd, nvidia]
+    gpu_backends: [amd, nvidia, jetson]
 
   - id: documents
     name: Document Q&A
@@ -54,4 +54,4 @@ features:
     launch:
       type: service
       service: open-webui
-    gpu_backends: [amd, nvidia]
+    gpu_backends: [amd, nvidia, jetson]

--- a/dream-server/extensions/services/open-webui/manifest.yaml
+++ b/dream-server/extensions/services/open-webui/manifest.yaml
@@ -16,6 +16,6 @@ service:
   health: /health
   ui_path: /
   type: docker
-  gpu_backends: [amd, nvidia]
+  gpu_backends: [amd, nvidia, jetson]
   category: core
   depends_on: [llama-server]

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -13,6 +13,7 @@
 # Provides: detect_gpu(), load_capability_profile(),
 #           normalize_profile_tier(), tier_rank(), load_backend_contract(),
 #           fix_nvidia_secure_boot(), MIN_DRIVER_VERSION
+#           Side-effect var on Jetson: JETSON_L4T_RELEASE (e.g. "R36.4.0")
 #
 # Modder notes:
 #   Add new GPU vendors or APU detection logic here.
@@ -276,6 +277,60 @@ detect_gpu() {
     GPU_BACKEND="cpu"  # default to CPU-only fallback
     GPU_MEMORY_TYPE="none"
     GPU_DEVICE_ID=""
+
+    # Try NVIDIA Jetson (Tegra SoC) first — Tegra iGPUs do not appear as PCIe
+    # devices under /sys/class/drm with vendor 0x10de, and nvidia-smi (only in
+    # JetPack 5+) reports the GPU partially or not at all. Detect via L4T
+    # release file or device-tree signature so this never falls into the
+    # discrete-NVIDIA branch below. Test hooks: DREAM_NV_TEGRA_RELEASE,
+    # DREAM_DEVICE_TREE_COMPATIBLE, DREAM_DEVICE_TREE_MODEL, DREAM_GPU0_SYSFS,
+    # DREAM_UNAME_M.
+    local _tegra_release="${DREAM_NV_TEGRA_RELEASE:-/etc/nv_tegra_release}"
+    local _dt_compat="${DREAM_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}"
+    local _dt_model="${DREAM_DEVICE_TREE_MODEL:-/proc/device-tree/model}"
+    local _gpu0_sysfs="${DREAM_GPU0_SYSFS:-/sys/devices/gpu.0}"
+    local _uname_m="${DREAM_UNAME_M:-$(uname -m)}"
+    local _is_jetson=false
+    if [[ "$_uname_m" == "aarch64" ]]; then
+        if [[ -f "$_tegra_release" ]]; then
+            _is_jetson=true
+        elif [[ -f "$_dt_compat" ]] && tr -d '\0' < "$_dt_compat" 2>/dev/null | grep -q "nvidia,tegra"; then
+            _is_jetson=true
+        elif [[ -d "$_gpu0_sysfs" ]]; then
+            _is_jetson=true
+        fi
+    fi
+    if $_is_jetson; then
+        GPU_BACKEND="jetson"
+        GPU_MEMORY_TYPE="unified"
+        GPU_COUNT=1
+        if [[ -f "$_dt_model" ]]; then
+            GPU_NAME="$(tr -d '\0' < "$_dt_model" 2>/dev/null)"
+        fi
+        [[ -z "${GPU_NAME:-}" ]] && GPU_NAME="NVIDIA Jetson (Tegra)"
+        # Parse L4T release (e.g. "R36 (release), REVISION: 4.0, ..." -> "R36.4.0")
+        # Used by later phases to pin a JetPack-compatible llama-server image.
+        JETSON_L4T_RELEASE=""
+        if [[ -f "$_tegra_release" ]]; then
+            local _major _minor
+            _major=$(grep -oE 'R[0-9]+' "$_tegra_release" 2>/dev/null | head -1)
+            _minor=$(grep -oE 'REVISION: [0-9.]+' "$_tegra_release" 2>/dev/null | head -1 | awk '{print $2}')
+            [[ -n "$_major" && -n "$_minor" ]] && JETSON_L4T_RELEASE="${_major}.${_minor}"
+        fi
+        GPU_DEVICE_ID="$JETSON_L4T_RELEASE"
+        # Unified memory: GPU shares system RAM. Use total RAM as VRAM budget,
+        # mirroring the Grace Blackwell (GB10/GB200) unified-memory branch below.
+        local _ram_kb
+        _ram_kb=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}')
+        if [[ -n "$_ram_kb" && "$_ram_kb" -gt 0 ]]; then
+            GPU_VRAM=$((_ram_kb / 1024))
+        else
+            GPU_VRAM=0
+            warn "Jetson detected but could not read /proc/meminfo for VRAM budget"
+        fi
+        log "GPU: $GPU_NAME (Jetson L4T ${JETSON_L4T_RELEASE:-unknown}, ${GPU_VRAM}MB unified memory)"
+        return 0
+    fi
 
     # Try NVIDIA first — validate hardware via sysfs vendor ID (0x10de)
     # before trusting nvidia-smi, which may be installed without NVIDIA hardware

--- a/dream-server/installers/lib/tier-map.sh
+++ b/dream-server/installers/lib/tier-map.sh
@@ -154,6 +154,21 @@ set_qwen_tier_config() {
             MAX_CONTEXT=8192
             LLM_MODEL_SIZE_MB=1500    # Qwen3.5-2B-Q4_K_M (1.28 GB)
             ;;
+        JETSON_ORIN_NANO)
+            # NVIDIA Jetson Orin Nano (8 GB unified memory, Ampere sm_87).
+            # Conservative default: 2B Q4_K_M (~1.5 GB) leaves ~5 GB unified
+            # RAM for KV cache + open-webui + dashboard-api on an 8 GB SoC.
+            # Larger Orin Nano variants and Orin NX/AGX are deliberately
+            # excluded from this milestone — see issue #195.
+            TIER_NAME="Jetson Orin Nano"
+            LLM_MODEL="qwen3.5-2b"
+            GGUF_FILE="Qwen3.5-2B-Q4_K_M.gguf"
+            GGUF_URL="https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf"
+            GGUF_SHA256=""
+            MAX_CONTEXT=8192
+            LLM_MODEL_SIZE_MB=1500
+            N_GPU_LAYERS=99           # iGPU + unified memory: offload all layers
+            ;;
         1)
             TIER_NAME="Entry Level"
             LLM_MODEL="qwen3.5-9b"
@@ -191,7 +206,7 @@ set_qwen_tier_config() {
             LLM_MODEL_SIZE_MB=18600   # 18.6 GB per HF file listing
             ;;
         *)
-            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE"
+            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE, JETSON_ORIN_NANO"
             # NOTE for modders: add your tier above this line and update this message.
             ;;
     esac
@@ -267,6 +282,20 @@ set_gemma4_tier_config() {
             MAX_CONTEXT=8192
             LLM_MODEL_SIZE_MB=1500
             ;;
+        JETSON_ORIN_NANO)
+            # Jetson Orin Nano (8 GB unified, Ampere sm_87) with gemma4 profile.
+            # E2B Q4_K_M (~2.81 GB) fits comfortably alongside the rest of the
+            # stack on 8 GB unified memory; reduced context vs entry-level to
+            # leave headroom for KV cache.
+            TIER_NAME="Jetson Orin Nano"
+            LLM_MODEL="gemma-4-e2b-it"
+            GGUF_FILE="gemma-4-E2B-it-Q4_K_M.gguf"
+            GGUF_URL="https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf"
+            GGUF_SHA256=""
+            MAX_CONTEXT=8192
+            LLM_MODEL_SIZE_MB=2810
+            N_GPU_LAYERS=99           # iGPU + unified memory: offload all layers
+            ;;
         1)
             TIER_NAME="Entry Level"
             LLM_MODEL="gemma-4-e2b-it"
@@ -304,7 +333,7 @@ set_gemma4_tier_config() {
             LLM_MODEL_SIZE_MB=19800
             ;;
         *)
-            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE"
+            error "Invalid tier: $TIER. Valid tiers: 0, 1, 2, 3, 4, CLOUD, NV_ULTRA, SH_LARGE, SH_COMPACT, ARC, ARC_LITE, JETSON_ORIN_NANO"
             ;;
     esac
 }
@@ -348,6 +377,7 @@ tier_to_model() {
                 SH_COMPACT|SH)  model="gemma-4-26b-a4b-it" ;;
                 ARC)            model="gemma-4-e4b-it" ;;
                 ARC_LITE)       model="gemma-4-e2b-it" ;;
+                JETSON_ORIN_NANO) model="gemma-4-e2b-it" ;;
                 0|T0)           model="qwen3.5-2b" ;;
                 1|T1)           model="gemma-4-e2b-it" ;;
                 2|T2)           model="gemma-4-e4b-it" ;;
@@ -373,6 +403,7 @@ tier_to_model() {
                 SH_COMPACT|SH)  model="qwen3-30b-a3b" ;;
                 ARC)            model="qwen3.5-9b" ;;
                 ARC_LITE)       model="qwen3.5-4b" ;;
+                JETSON_ORIN_NANO) model="qwen3.5-2b" ;;
                 0|T0)           model="qwen3.5-2b" ;;
                 1|T1)           model="qwen3.5-9b" ;;
                 2|T2)           model="qwen3.5-9b" ;;

--- a/dream-server/installers/phases/02-detection.sh
+++ b/dream-server/installers/phases/02-detection.sh
@@ -128,10 +128,11 @@ else
 
     if [[ "${CAP_PROFILE_LOADED:-false}" == "true" ]]; then
         case "${CAP_LLM_BACKEND:-}" in
-            amd)   GPU_BACKEND="amd" ;;
-            intel) GPU_BACKEND="intel" ;;
-            cpu)   GPU_BACKEND="cpu" ;;
-            apple) GPU_BACKEND="apple" ;;
+            amd)    GPU_BACKEND="amd" ;;
+            intel)  GPU_BACKEND="intel" ;;
+            cpu)    GPU_BACKEND="cpu" ;;
+            apple)  GPU_BACKEND="apple" ;;
+            jetson) GPU_BACKEND="jetson" ;;
             *) GPU_BACKEND="nvidia" ;;
         esac
         [[ -n "${CAP_GPU_MEMORY_TYPE:-}" ]] && GPU_MEMORY_TYPE="${CAP_GPU_MEMORY_TYPE}"

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -32,6 +32,12 @@ if [[ "$GPU_BACKEND" == "amd" ]]; then
     [[ "$ENABLE_COMFYUI" == "true" ]] && PULL_LIST+=("ignatberesnev/comfyui-gfx1151:v0.2|COMFYUI — image generation engine (gfx1151)")
 elif [[ "$GPU_BACKEND" == "cpu" ]]; then
     PULL_LIST+=("${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}|LLAMA-SERVER — downloading the brain (CPU)")
+elif [[ "$GPU_BACKEND" == "jetson" ]]; then
+    # Jetson (Tegra SoC, Orin Nano = sm_87). The discrete-CUDA ggml images
+    # (server-cuda-b9014) are NOT compiled for sm_87 and will fail to load
+    # kernels on Tegra. Use the Jetson-tuned llama.cpp image instead —
+    # matches the default in docker-compose.jetson.yml.
+    PULL_LIST+=("${LLAMA_SERVER_IMAGE:-dustynv/llama_cpp:r36.4.0}|LLAMA-SERVER — downloading the brain (Jetson CUDA)")
 else
     PULL_LIST+=("${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9014}|LLAMA-SERVER — downloading the brain (NVIDIA CUDA)")
 fi
@@ -60,7 +66,7 @@ fi
 if $DRY_RUN; then
     ai "[DRY RUN] I would download ${#PULL_LIST[@]} modules."
 else
-    if [[ "${DREAM_MODE:-local}" != "cloud" && ( "$GPU_BACKEND" == "nvidia" || "$GPU_BACKEND" == "cpu" || "$GPU_BACKEND" == "intel" || "$GPU_BACKEND" == "sycl" ) ]]; then
+    if [[ "${DREAM_MODE:-local}" != "cloud" && ( "$GPU_BACKEND" == "nvidia" || "$GPU_BACKEND" == "cpu" || "$GPU_BACKEND" == "intel" || "$GPU_BACKEND" == "sycl" || "$GPU_BACKEND" == "jetson" ) ]]; then
         _llama_image=""
         _llama_label=""
         _llama_index=-1

--- a/dream-server/scripts/build-capability-profile.sh
+++ b/dream-server/scripts/build-capability-profile.sh
@@ -109,6 +109,13 @@ if gpu_type == "amd" and memory_type == "unified":
 elif gpu_type == "nvidia":
     llm_backend = "nvidia"
     overlays = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
+elif gpu_type == "jetson":
+    # Jetson is Tegra (arm64 + iGPU + unified memory). The dedicated overlay
+    # docker-compose.jetson.yml lands in milestone 1 phase 3; until then fall
+    # back to the cpu overlay so the installer pipeline stays valid on Jetson
+    # hosts without claiming a runtime path that doesn't exist yet.
+    llm_backend = "jetson"
+    overlays = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
 elif gpu_type == "apple":
     llm_backend = "apple"
     overlays = ["docker-compose.base.yml", "docker-compose.amd.yml"]

--- a/dream-server/scripts/build-capability-profile.sh
+++ b/dream-server/scripts/build-capability-profile.sh
@@ -110,12 +110,11 @@ elif gpu_type == "nvidia":
     llm_backend = "nvidia"
     overlays = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
 elif gpu_type == "jetson":
-    # Jetson is Tegra (arm64 + iGPU + unified memory). The dedicated overlay
-    # docker-compose.jetson.yml lands in milestone 1 phase 3; until then fall
-    # back to the cpu overlay so the installer pipeline stays valid on Jetson
-    # hosts without claiming a runtime path that doesn't exist yet.
+    # Jetson is Tegra (arm64 + iGPU + unified memory). docker-compose.jetson.yml
+    # provides a JetPack-compatible llama.cpp image and the Tegra container
+    # runtime (`runtime: nvidia`) — see docker-compose.jetson.yml and #195.
     llm_backend = "jetson"
-    overlays = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
+    overlays = ["docker-compose.base.yml", "docker-compose.jetson.yml"]
 elif gpu_type == "apple":
     llm_backend = "apple"
     overlays = ["docker-compose.base.yml", "docker-compose.amd.yml"]

--- a/dream-server/scripts/build-capability-profile.sh
+++ b/dream-server/scripts/build-capability-profile.sh
@@ -123,18 +123,27 @@ else:
     overlays = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
 
 tier = (hardware.get("tier") or "T1").upper()
-if tier in {"T1", "T2", "T3", "T4"}:
+if tier in {"T1", "T2", "T3", "T4", "JETSON_ORIN_NANO"}:
     recommended = tier
 elif tier in {"SH_COMPACT", "SH_LARGE"}:
     recommended = tier
 else:
     recommended = "T1"
 
+# classify-hardware.sh is a data-driven lookup against gpu-database.json which
+# does not yet have Jetson entries. When the GPU is one of our explicitly-known
+# vendors (amd / nvidia / apple / jetson), the gpu_type branch above has
+# already set the correct llm_backend + overlays — letting the classifier
+# override with its "unknown → cpu" default would silently break the install
+# (e.g. on Jetson Orin Nano: jetson → cpu, jetson.yml → cpu.yml). Only let
+# classifier overrides apply when gpu_type is something we don't already
+# special-case.
+gpu_type_known = gpu_type in {"amd", "nvidia", "apple", "jetson"}
 if hw_rec_tier:
     recommended = hw_rec_tier
-if hw_rec_backend:
+if hw_rec_backend and not gpu_type_known:
     llm_backend = hw_rec_backend
-if hw_rec_overlays:
+if hw_rec_overlays and not gpu_type_known:
     overlays = hw_rec_overlays
 
 profile = {
@@ -144,7 +153,7 @@ profile = {
         "family": family,
     },
     "gpu": {
-        "vendor": gpu_type if gpu_type in {"nvidia", "amd", "apple", "none"} else "unknown",
+        "vendor": gpu_type if gpu_type in {"nvidia", "amd", "apple", "jetson", "none"} else "unknown",
         "name": gpu_name,
         "memory_type": memory_type if memory_type in {"discrete", "unified", "none"} else "unknown",
         "count": gpu_count,

--- a/dream-server/scripts/detect-hardware.sh
+++ b/dream-server/scripts/detect-hardware.sh
@@ -300,6 +300,51 @@ detect_amd() {
     fi
 }
 
+# Detect NVIDIA Jetson (Tegra SoC)
+# Returns: <model_name>|<l4t_release>|<ram_mb>   (pipe-delimited) or empty
+# Test hooks: DREAM_NV_TEGRA_RELEASE, DREAM_DEVICE_TREE_COMPATIBLE,
+#             DREAM_DEVICE_TREE_MODEL, DREAM_GPU0_SYSFS, DREAM_UNAME_M
+detect_jetson() {
+    local tegra_release="${DREAM_NV_TEGRA_RELEASE:-/etc/nv_tegra_release}"
+    local dt_compat="${DREAM_DEVICE_TREE_COMPATIBLE:-/proc/device-tree/compatible}"
+    local dt_model="${DREAM_DEVICE_TREE_MODEL:-/proc/device-tree/model}"
+    local gpu0_sysfs="${DREAM_GPU0_SYSFS:-/sys/devices/gpu.0}"
+    local uname_m="${DREAM_UNAME_M:-$(uname -m)}"
+
+    [[ "$uname_m" == "aarch64" ]] || return 1
+
+    local is_jetson=false
+    if [[ -f "$tegra_release" ]]; then
+        is_jetson=true
+    elif [[ -f "$dt_compat" ]] && tr -d '\0' < "$dt_compat" 2>/dev/null | grep -q "nvidia,tegra"; then
+        is_jetson=true
+    elif [[ -d "$gpu0_sysfs" ]]; then
+        is_jetson=true
+    fi
+    $is_jetson || return 1
+
+    local model="NVIDIA Jetson (Tegra)"
+    if [[ -f "$dt_model" ]]; then
+        local raw
+        raw=$(tr -d '\0' < "$dt_model" 2>/dev/null) || raw=""
+        [[ -n "$raw" ]] && model="$raw"
+    fi
+
+    local l4t=""
+    if [[ -f "$tegra_release" ]]; then
+        local major minor
+        major=$(grep -oE 'R[0-9]+' "$tegra_release" 2>/dev/null | head -1)
+        minor=$(grep -oE 'REVISION: [0-9.]+' "$tegra_release" 2>/dev/null | head -1 | awk '{print $2}')
+        [[ -n "$major" && -n "$minor" ]] && l4t="${major}.${minor}"
+    fi
+
+    local ram_kb ram_mb=0
+    ram_kb=$(grep MemTotal /proc/meminfo 2>/dev/null | awk '{print $2}')
+    [[ -n "$ram_kb" && "$ram_kb" -gt 0 ]] && ram_mb=$(( ram_kb / 1024 ))
+
+    echo "${model}|${l4t}|${ram_mb}"
+}
+
 # Detect Apple Silicon
 detect_apple() {
     if [[ "$(detect_os)" == "macos" ]]; then
@@ -530,9 +575,27 @@ main() {
     cores=$(clamp_int "$cores" 1 1024)
     ram=$(clamp_int "$ram" 1 4096)
 
-    # Try NVIDIA first
+    # Try Jetson first — Tegra iGPUs don't show up as PCIe NVIDIA cards in
+    # sysfs and nvidia-smi is unreliable on JetPack, so detect via L4T release
+    # file / device-tree signature before the discrete-NVIDIA branch below.
+    local jetson_out=""
+    jetson_out=$(detect_jetson || true)
+    if [[ -n "$jetson_out" ]]; then
+        local _jetson_l4t _jetson_ram_mb
+        IFS='|' read -r gpu_name _jetson_l4t _jetson_ram_mb <<< "$jetson_out"
+        gpu_vram_mb=$(as_int "$_jetson_ram_mb")
+        gpu_count=1
+        gpu_type="jetson"
+        gpu_architecture="tegra"
+        memory_type="unified"
+        device_id="$_jetson_l4t"
+    fi
+
+    # Try NVIDIA next
     local nvidia_out=""
-    nvidia_out=$(detect_nvidia || true)
+    if [[ -z "$gpu_name" ]]; then
+        nvidia_out=$(detect_nvidia || true)
+    fi
     if [[ -n "$nvidia_out" ]]; then
         gpu_name=$(echo "$nvidia_out" | awk -F',' '{gsub(/^[ \t]+|[ \t]+$/,"",$1); print $1}' | xargs || true)
         gpu_vram_mb=$(parse_nvidia_vram_mb "$nvidia_out")

--- a/dream-server/scripts/preflight-engine.sh
+++ b/dream-server/scripts/preflight-engine.sh
@@ -132,6 +132,10 @@ tier_rank_map = {
     "T4": 4,
     "SH_COMPACT": 3,
     "SH_LARGE": 4,
+    # Jetson Orin Nano (8 GB unified, sm_87) is functionally a tier-0-ish
+    # device: small model footprint, low VRAM budget. Ranked alongside tier 0
+    # for ordering purposes.
+    "JETSON_ORIN_NANO": 0,
 }
 tier_rank = tier_rank_map.get(tier_key, 1)
 
@@ -145,6 +149,10 @@ min_ram_map = {
     "4": 64,
     "SH_COMPACT": 64,
     "SH_LARGE": 96,
+    # Orin Nano ships with 8 GB unified memory; usable ~7.6 GB after kernel
+    # reservation. Require 6 GB so the preflight doesn't warn against the
+    # only memory configuration this SKU has.
+    "JETSON_ORIN_NANO": 6,
 }
 min_disk_map = {
     "0": 15,
@@ -159,6 +167,10 @@ min_disk_map = {
     "4": 150,
     "SH_COMPACT": 80,
     "SH_LARGE": 120,
+    # Qwen3.5-2B (~1.5 GB) + dustynv/llama_cpp image (~5 GB) + dashboard +
+    # litellm + qdrant + searxng + working space ≈ 15 GB. Same envelope as
+    # tier 0 since the model footprint dominates.
+    "JETSON_ORIN_NANO": 15,
 }
 min_ram = min_ram_map.get(tier_key, 16)
 min_disk = min_disk_map.get(tier_key, 50)
@@ -292,6 +304,13 @@ elif gpu_backend == "apple":
         "warn",
         "Apple backend selected (experimental path).",
         "Use macOS installer preflight + doctor and run reduced profile set until Tier A parity is complete.",
+    )
+elif gpu_backend == "jetson":
+    add_check(
+        "gpu-backend",
+        "warn",
+        "NVIDIA Jetson (Tegra) backend selected (experimental path — milestone tracked in #195).",
+        "Ensure JetPack 6.x is flashed and nvidia-container-toolkit is the default Docker runtime.",
     )
 elif gpu_backend == "cpu":
     if platform_id in {"windows", "macos"}:

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -127,6 +127,20 @@ elif tier in {"AP_ULTRA", "AP_PRO", "AP_BASE"}:
     elif existing(["docker-compose.base.yml"]):
         resolved = ["docker-compose.base.yml"]
         primary = "docker-compose.base.yml"
+elif gpu_backend == "jetson" or tier == "JETSON_ORIN_NANO":
+    # NVIDIA Jetson (Tegra SoC) — must be matched BEFORE the cpu branch.
+    # The capability-profile pipeline can clobber GPU_BACKEND to "cpu" when
+    # the hardware classifier doesn't yet have a Jetson entry, so we rely on
+    # the tier name as the authoritative signal. Separate from discrete-nvidia
+    # because the Tegra container runtime and sm_87-targeted llama.cpp image
+    # are different from the discrete-CUDA path. See docker-compose.jetson.yml
+    # and the milestone tracked in issue #195.
+    if existing(["docker-compose.base.yml", "docker-compose.jetson.yml"]):
+        resolved = ["docker-compose.base.yml", "docker-compose.jetson.yml"]
+        primary = "docker-compose.jetson.yml"
+    elif existing(["docker-compose.base.yml"]):
+        resolved = ["docker-compose.base.yml"]
+        primary = "docker-compose.base.yml"
 elif gpu_backend == "cpu":
     if existing(["docker-compose.base.yml", "docker-compose.cpu.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
@@ -149,17 +163,6 @@ elif gpu_backend == "amd":
     if existing(["docker-compose.base.yml", "docker-compose.amd.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
         primary = "docker-compose.amd.yml"
-elif gpu_backend == "jetson" or tier == "JETSON_ORIN_NANO":
-    # NVIDIA Jetson (Tegra SoC) — separate from the discrete-nvidia branch
-    # because the Tegra container runtime and sm_87-targeted llama.cpp image
-    # are different from the discrete-CUDA path. See docker-compose.jetson.yml
-    # and the milestone tracked in issue #195.
-    if existing(["docker-compose.base.yml", "docker-compose.jetson.yml"]):
-        resolved = ["docker-compose.base.yml", "docker-compose.jetson.yml"]
-        primary = "docker-compose.jetson.yml"
-    elif existing(["docker-compose.base.yml"]):
-        resolved = ["docker-compose.base.yml"]
-        primary = "docker-compose.base.yml"
 elif gpu_backend in ("intel", "sycl") or tier in ("ARC", "ARC_LITE"):
     if existing(["docker-compose.base.yml", "docker-compose.arc.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.arc.yml"]

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -149,6 +149,17 @@ elif gpu_backend == "amd":
     if existing(["docker-compose.base.yml", "docker-compose.amd.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.amd.yml"]
         primary = "docker-compose.amd.yml"
+elif gpu_backend == "jetson" or tier == "JETSON_ORIN_NANO":
+    # NVIDIA Jetson (Tegra SoC) — separate from the discrete-nvidia branch
+    # because the Tegra container runtime and sm_87-targeted llama.cpp image
+    # are different from the discrete-CUDA path. See docker-compose.jetson.yml
+    # and the milestone tracked in issue #195.
+    if existing(["docker-compose.base.yml", "docker-compose.jetson.yml"]):
+        resolved = ["docker-compose.base.yml", "docker-compose.jetson.yml"]
+        primary = "docker-compose.jetson.yml"
+    elif existing(["docker-compose.base.yml"]):
+        resolved = ["docker-compose.base.yml"]
+        primary = "docker-compose.base.yml"
 elif gpu_backend in ("intel", "sycl") or tier in ("ARC", "ARC_LITE"):
     if existing(["docker-compose.base.yml", "docker-compose.arc.yml"]):
         resolved = ["docker-compose.base.yml", "docker-compose.arc.yml"]

--- a/dream-server/scripts/validate-manifest-schema.sh
+++ b/dream-server/scripts/validate-manifest-schema.sh
@@ -131,7 +131,7 @@ try:
             error(f"Invalid dependency: {dep}")
 
     for backend in service.get("gpu_backends", []):
-        if backend not in ["amd", "nvidia", "apple", "cpu", "all"]:
+        if backend not in ["amd", "nvidia", "apple", "cpu", "all", "jetson", "none"]:
             error(f"Invalid gpu_backend: {backend}")
 
     # Check compose_file exists

--- a/dream-server/tests/test-jetson-compose-resolver.sh
+++ b/dream-server/tests/test-jetson-compose-resolver.sh
@@ -95,9 +95,23 @@ else
     pass "comfyui correctly excluded on Jetson"
 fi
 
-# --- Case 4: Non-Jetson backends still get their own overlay --------------
+# --- Case 4: Tier wins over clobbered gpu_backend (regression for #1482) --
+# The capability-profile pipeline can overwrite GPU_BACKEND from "jetson" to
+# "cpu" when the hardware classifier doesn't have a Jetson entry yet. Tier
+# alone must keep us on the jetson overlay so the user doesn't end up
+# running a CPU stack on Jetson hardware by accident.
 echo ""
-echo "=== Case 4: nvidia backend regression check ==="
+echo "=== Case 4: tier JETSON_ORIN_NANO wins over clobbered gpu_backend=cpu ==="
+OUT=$(bash "$RESOLVER" --tier JETSON_ORIN_NANO --gpu-backend cpu --env 2>&1)
+if grep -q '^COMPOSE_PRIMARY_FILE="docker-compose.jetson.yml"$' <<< "$OUT"; then
+    pass "tier JETSON_ORIN_NANO + backend=cpu still picks jetson overlay"
+else
+    fail "tier JETSON_ORIN_NANO + backend=cpu wrongly picked: $(grep COMPOSE_PRIMARY_FILE <<< "$OUT")"
+fi
+
+# --- Case 5: Non-Jetson backends still get their own overlay --------------
+echo ""
+echo "=== Case 5: nvidia backend regression check ==="
 OUT=$(bash "$RESOLVER" --tier 1 --gpu-backend nvidia --env 2>&1)
 if grep -q '^COMPOSE_PRIMARY_FILE="docker-compose.nvidia.yml"$' <<< "$OUT"; then
     pass "nvidia path unchanged — picks discrete nvidia overlay"

--- a/dream-server/tests/test-jetson-compose-resolver.sh
+++ b/dream-server/tests/test-jetson-compose-resolver.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# ============================================================================
+# Test: Jetson compose-stack resolution
+# ============================================================================
+# Verifies that scripts/resolve-compose-stack.sh selects docker-compose.jetson.yml
+# when given --gpu-backend jetson or --tier JETSON_ORIN_NANO, and that the
+# expected core services (llama-server, dashboard, dashboard-api, open-webui)
+# are present in the resolved list while comfyui (deliberately excluded on
+# Jetson per the milestone scope) is not.
+#
+# Run: bash tests/test-jetson-compose-resolver.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOLVER="$ROOT_DIR/scripts/resolve-compose-stack.sh"
+
+PASS=0
+FAIL=0
+
+pass() { echo "  PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# Move into ROOT_DIR so the resolver finds compose files via $(pwd).
+cd "$ROOT_DIR"
+
+if [[ ! -f "$RESOLVER" ]]; then
+    fail "resolver script not found at $RESOLVER"
+    echo "Passed: $PASS, Failed: $FAIL"
+    exit 1
+fi
+pass "resolver script exists"
+
+if [[ ! -f "$ROOT_DIR/docker-compose.jetson.yml" ]]; then
+    fail "docker-compose.jetson.yml is missing — Phase 3 incomplete"
+    echo "Passed: $PASS, Failed: $FAIL"
+    exit 1
+fi
+pass "docker-compose.jetson.yml exists"
+
+# --- Case 1: --gpu-backend jetson alone ----------------------------------
+echo ""
+echo "=== Case 1: --gpu-backend jetson ==="
+OUT=$(bash "$RESOLVER" --gpu-backend jetson --env 2>&1)
+
+if grep -q '^COMPOSE_PRIMARY_FILE="docker-compose.jetson.yml"$' <<< "$OUT"; then
+    pass "primary file = docker-compose.jetson.yml"
+else
+    fail "primary file is not docker-compose.jetson.yml"
+    echo "$OUT" | head -3
+fi
+
+file_list=$(grep '^COMPOSE_FILE_LIST=' <<< "$OUT" | sed 's/^COMPOSE_FILE_LIST="\(.*\)"$/\1/')
+
+if [[ ",$file_list," == *",docker-compose.base.yml,"* ]]; then
+    pass "stack contains docker-compose.base.yml"
+else
+    fail "stack missing docker-compose.base.yml"
+fi
+
+if [[ ",$file_list," == *",docker-compose.jetson.yml,"* ]]; then
+    pass "stack contains docker-compose.jetson.yml"
+else
+    fail "stack missing docker-compose.jetson.yml"
+fi
+
+# Discrete-NVIDIA overlay must NOT be in the stack on Jetson.
+if [[ ",$file_list," == *",docker-compose.nvidia.yml,"* ]]; then
+    fail "stack wrongly contains docker-compose.nvidia.yml on Jetson"
+else
+    pass "discrete-nvidia overlay correctly absent"
+fi
+
+# --- Case 2: --tier JETSON_ORIN_NANO (no --gpu-backend) -------------------
+echo ""
+echo "=== Case 2: --tier JETSON_ORIN_NANO ==="
+OUT=$(bash "$RESOLVER" --tier JETSON_ORIN_NANO --env 2>&1)
+if grep -q '^COMPOSE_PRIMARY_FILE="docker-compose.jetson.yml"$' <<< "$OUT"; then
+    pass "tier alone selects jetson overlay"
+else
+    fail "tier alone failed to select jetson overlay"
+fi
+
+# --- Case 3: ComfyUI must be excluded on Jetson ---------------------------
+echo ""
+echo "=== Case 3: ComfyUI excluded on Jetson ==="
+file_list=$(bash "$RESOLVER" --gpu-backend jetson --env 2>&1 \
+    | grep '^COMPOSE_FILE_LIST=' | sed 's/^COMPOSE_FILE_LIST="\(.*\)"$/\1/')
+
+if [[ ",$file_list," == *"comfyui/compose.yaml"* ]]; then
+    fail "comfyui compose included on Jetson (should be excluded per milestone scope)"
+else
+    pass "comfyui correctly excluded on Jetson"
+fi
+
+# --- Case 4: Non-Jetson backends still get their own overlay --------------
+echo ""
+echo "=== Case 4: nvidia backend regression check ==="
+OUT=$(bash "$RESOLVER" --tier 1 --gpu-backend nvidia --env 2>&1)
+if grep -q '^COMPOSE_PRIMARY_FILE="docker-compose.nvidia.yml"$' <<< "$OUT"; then
+    pass "nvidia path unchanged — picks discrete nvidia overlay"
+else
+    fail "nvidia path regressed — primary is not docker-compose.nvidia.yml"
+fi
+
+OUT=$(bash "$RESOLVER" --tier 1 --gpu-backend amd --env 2>&1)
+if grep -q '^COMPOSE_PRIMARY_FILE="docker-compose.amd.yml"$' <<< "$OUT"; then
+    pass "amd path unchanged"
+else
+    fail "amd path regressed — primary is not docker-compose.amd.yml"
+fi
+
+OUT=$(bash "$RESOLVER" --tier 1 --gpu-backend cpu --env 2>&1)
+if grep -q '^COMPOSE_PRIMARY_FILE="docker-compose.cpu.yml"$' <<< "$OUT"; then
+    pass "cpu path unchanged"
+else
+    fail "cpu path regressed — primary is not docker-compose.cpu.yml"
+fi
+
+# --- Summary -------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/dream-server/tests/test-jetson-detection.sh
+++ b/dream-server/tests/test-jetson-detection.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# ============================================================================
+# Test: Jetson detection — detection.sh + detect-hardware.sh
+# ============================================================================
+# Builds a fake /etc/nv_tegra_release + /proc/device-tree/* tree and verifies:
+#   1. installers/lib/detection.sh::detect_gpu() sets GPU_BACKEND=jetson with
+#      unified-memory layout and a parsed JETSON_L4T_RELEASE.
+#   2. scripts/detect-hardware.sh emits gpu.type=jetson in --json output.
+#
+# Run: bash tests/test-jetson-detection.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PASS=0
+FAIL=0
+
+# Minimal logging stubs so detection.sh can be sourced standalone.
+log()  { :; }
+warn() { :; }
+
+# Source the module under test (detect_gpu)
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/installers/lib/detection.sh"
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected '$expected', got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_nonempty() {
+    local label="$1" actual="$2"
+    if [[ -n "$actual" ]]; then
+        echo "  PASS: $label (= '$actual')"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (empty)"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_match() {
+    local label="$1" pattern="$2" actual="$3"
+    if [[ "$actual" =~ $pattern ]]; then
+        echo "  PASS: $label (matched /$pattern/)"
+        PASS=$((PASS + 1))
+    else
+        echo "  FAIL: $label (expected match /$pattern/, got '$actual')"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ----------------------------------------------------------------------------
+# Build a minimal Jetson fixture tree
+# ----------------------------------------------------------------------------
+FIXTURE_DIR="$(mktemp -d -t dream-jetson-fixture-XXXXXX)"
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+# /etc/nv_tegra_release format mirrors JetPack 6 / L4T R36.4.0
+cat > "$FIXTURE_DIR/nv_tegra_release" <<'EOF'
+# R36 (release), REVISION: 4.0, GCID: 41062509, BOARD: generic, EABI: aarch64, DATE: ...
+EOF
+
+# Device-tree files are NUL-terminated on real Jetson; mimic that here.
+printf 'NVIDIA Jetson Orin Nano Developer Kit\0' > "$FIXTURE_DIR/dt_model"
+printf 'nvidia,p3768-0000+p3767-0005\0nvidia,p3768-0000+p3767-0005\0nvidia,tegra234\0nvidia,tegra\0\0' > "$FIXTURE_DIR/dt_compatible"
+
+mkdir -p "$FIXTURE_DIR/gpu.0"
+
+echo "=== Testing detect_gpu() against Jetson fixture ==="
+echo ""
+
+# Reset relevant globals before each invocation.
+unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
+
+DREAM_UNAME_M="aarch64" \
+DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+    detect_gpu
+
+assert_eq "GPU_BACKEND"      "jetson"  "${GPU_BACKEND:-}"
+assert_eq "GPU_MEMORY_TYPE"  "unified" "${GPU_MEMORY_TYPE:-}"
+assert_eq "GPU_COUNT"        "1"       "${GPU_COUNT:-}"
+assert_eq "GPU_NAME"         "NVIDIA Jetson Orin Nano Developer Kit" "${GPU_NAME:-}"
+assert_eq "JETSON_L4T_RELEASE" "R36.4.0" "${JETSON_L4T_RELEASE:-}"
+assert_eq "GPU_DEVICE_ID"    "R36.4.0" "${GPU_DEVICE_ID:-}"
+assert_nonempty "GPU_VRAM"   "${GPU_VRAM:-}"
+
+# ----------------------------------------------------------------------------
+# Non-Jetson hosts must NOT trip the new branch.
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Testing detect_gpu() on x86 host (must not detect jetson) ==="
+echo ""
+
+unset GPU_BACKEND GPU_NAME GPU_VRAM GPU_COUNT GPU_DEVICE_ID GPU_MEMORY_TYPE JETSON_L4T_RELEASE
+
+# Point every Jetson signal at a path that doesn't exist AND override uname -m.
+DREAM_UNAME_M="x86_64" \
+DREAM_NV_TEGRA_RELEASE="/dev/null/does-not-exist" \
+DREAM_DEVICE_TREE_COMPATIBLE="/dev/null/does-not-exist" \
+DREAM_DEVICE_TREE_MODEL="/dev/null/does-not-exist" \
+DREAM_GPU0_SYSFS="/dev/null/does-not-exist" \
+DREAM_DRM_SYS="$FIXTURE_DIR/empty-drm" \
+    detect_gpu || true
+
+# On a non-Jetson host with empty drm and no nvidia-smi the detector falls
+# back to cpu. The important assertion is that it didn't claim 'jetson'.
+if [[ "${GPU_BACKEND:-}" == "jetson" ]]; then
+    echo "  FAIL: x86 fallback wrongly detected as jetson"
+    FAIL=$((FAIL + 1))
+else
+    echo "  PASS: x86 fallback did not claim jetson (backend=${GPU_BACKEND:-unset})"
+    PASS=$((PASS + 1))
+fi
+
+# ----------------------------------------------------------------------------
+# detect-hardware.sh JSON pipeline
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Testing scripts/detect-hardware.sh --json with Jetson fixture ==="
+echo ""
+
+JSON_OUT=$(
+    DREAM_UNAME_M="aarch64" \
+    DREAM_NV_TEGRA_RELEASE="$FIXTURE_DIR/nv_tegra_release" \
+    DREAM_DEVICE_TREE_COMPATIBLE="$FIXTURE_DIR/dt_compatible" \
+    DREAM_DEVICE_TREE_MODEL="$FIXTURE_DIR/dt_model" \
+    DREAM_GPU0_SYSFS="$FIXTURE_DIR/gpu.0" \
+        bash "$SCRIPT_DIR/scripts/detect-hardware.sh" --json-compact 2>/dev/null
+)
+
+assert_match "gpu.type=jetson"        '"type":[[:space:]]*"jetson"'           "$JSON_OUT"
+assert_match "gpu.architecture=tegra" '"architecture":[[:space:]]*"tegra"'    "$JSON_OUT"
+assert_match "gpu.memory_type=unified" '"memory_type":[[:space:]]*"unified"'  "$JSON_OUT"
+assert_match "gpu.name=Orin Nano"     'NVIDIA Jetson Orin Nano'               "$JSON_OUT"
+
+# ----------------------------------------------------------------------------
+echo ""
+echo "=== Summary ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/dream-server/tests/test-tier-map.sh
+++ b/dream-server/tests/test-tier-map.sh
@@ -164,6 +164,29 @@ assert_eq "GPU_BACKEND"  "sycl"                                "$GPU_BACKEND"
 assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
 echo ""
 
+# --- JETSON_ORIN_NANO (qwen profile) ---
+echo "JETSON_ORIN_NANO (NVIDIA Jetson Orin Nano, 8 GB unified, qwen):"
+run_tier JETSON_ORIN_NANO
+assert_eq "TIER_NAME"    "Jetson Orin Nano"                    "$TIER_NAME"
+assert_eq "MODEL_PROFILE_EFFECTIVE" "qwen"                   "$MODEL_PROFILE_EFFECTIVE"
+assert_eq "LLM_MODEL"    "qwen3.5-2b"                        "$LLM_MODEL"
+assert_eq "GGUF_FILE"    "Qwen3.5-2B-Q4_K_M.gguf"            "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "8192"                                "$MAX_CONTEXT"
+assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
+echo ""
+
+# --- JETSON_ORIN_NANO (gemma4 profile) ---
+echo "JETSON_ORIN_NANO (gemma4 profile):"
+MODEL_PROFILE=gemma4 run_tier JETSON_ORIN_NANO
+assert_eq "TIER_NAME"    "Jetson Orin Nano"                    "$TIER_NAME"
+assert_eq "MODEL_PROFILE_EFFECTIVE" "gemma4"                 "$MODEL_PROFILE_EFFECTIVE"
+assert_eq "LLM_MODEL"    "gemma-4-e2b-it"                    "$LLM_MODEL"
+assert_eq "GGUF_FILE"    "gemma-4-E2B-it-Q4_K_M.gguf"        "$GGUF_FILE"
+assert_eq "MAX_CONTEXT"  "8192"                                "$MAX_CONTEXT"
+assert_eq "N_GPU_LAYERS" "99"                                  "$N_GPU_LAYERS"
+unset MODEL_PROFILE
+echo ""
+
 # --- Invalid tier should fail ---
 echo "Invalid tier (should fail):"
 if TIER="INVALID" resolve_tier_config 2>/dev/null; then
@@ -177,7 +200,7 @@ echo ""
 
 # --- GGUF_URL should be set for all tiers ---
 echo "GGUF_URL populated for all tiers:"
-for t in 0 1 2 3 4 NV_ULTRA SH_LARGE SH_COMPACT ARC ARC_LITE; do
+for t in 0 1 2 3 4 NV_ULTRA SH_LARGE SH_COMPACT ARC ARC_LITE JETSON_ORIN_NANO; do
     run_tier "$t"
     if [[ -n "$GGUF_URL" && "$GGUF_URL" == https://* ]]; then
         echo "  PASS: Tier $t has valid GGUF_URL"


### PR DESCRIPTION
**Draft** — opening for visibility while Phase 4 on-hardware install evidence is captured. Marking ready-for-review only after a Jetson Orin Nano install completes end-to-end against this overlay.

## Summary

Phase 3 of issue #195 milestone 1. Stacks on #1481 (Phase 2 tier-map). Adds the runtime path for NVIDIA Jetson: a new compose overlay, a resolver branch, and the manifest-schema + core-extension updates so the resolver doesn't drop core services on Jetson hosts.

## What lands here

| Layer | Change |
|---|---|
| `docker-compose.jetson.yml` (new) | Jetson-tuned overlay. Default image `dustynv/llama_cpp:r36.4.0` (targets sm_87 for Orin Nano — stock `ghcr.io/ggml-org/llama.cpp:server-cuda-*` images won't load). `runtime: nvidia` (Tegra container runtime), not `deploy.resources.reservations.devices`. Memory limit defaults sized for 8 GB unified. Override hooks: `LLAMA_SERVER_IMAGE`, `JETSON_RUNTIME`, `LLAMA_SERVER_MEMORY_LIMIT` |
| `scripts/resolve-compose-stack.sh` | New branch for `gpu_backend == "jetson"` or `tier == "JETSON_ORIN_NANO"`, placed **before** the intel/sycl branch so it wins over the nvidia fallthrough |
| `scripts/build-capability-profile.sh` | Jetson hosts now resolve to `[base.yml, jetson.yml]` instead of the Phase 2 `[base.yml, cpu.yml]` placeholder |
| `scripts/validate-manifest-schema.sh` | `gpu_backends` enum extended to include `jetson` (also adds `none`, which was used by `resolve-compose-stack.sh` and `audit-extensions.py` but missing from the validator) |
| Core manifests | `llama-server`, `dashboard`, `dashboard-api`, `open-webui` declare `jetson` in `gpu_backends` so the resolver doesn't exclude them. ComfyUI deliberately stays `[amd, nvidia]` — no validated arm64+sm_87 path |
| `open-webui` env | `ENABLE_IMAGE_GENERATION=false` by default on Jetson since ComfyUI is unavailable |
| `tests/test-jetson-compose-resolver.sh` (new) | 11 assertions: jetson backend selects jetson overlay; `JETSON_ORIN_NANO` tier alone selects it; ComfyUI is excluded; nvidia/amd/cpu paths are regression-free |

## Why these specific runtime choices

- **Image:** `ghcr.io/ggml-org/llama.cpp:server-cuda-*` doesn't include compute capability 8.7. Jetson Orin Nano needs an image built with `CMAKE_CUDA_ARCHITECTURES=87` on a JetPack base. `dustynv/llama_cpp:r36.4.0` is the community-maintained option matching JetPack 6.x. If the maintainer prefers a vendored `Dockerfile` building from `nvcr.io/nvidia/l4t-jetpack:r36.4.0`, happy to swap — that variant is more reproducible but adds ~20 min compile time on Orin Nano.
- **`runtime: nvidia`:** the Tegra container runtime is configured by the JetPack installer in `/etc/docker/daemon.json` and is the only reliable GPU passthrough mechanism on L4T. `deploy.resources.reservations.devices` (the discrete-GPU pattern) silently fails on Jetson in some Docker daemon configurations.
- **Memory limit 6 GB:** Orin Nano has ~7.6 GB usable unified RAM. 6 GB cap for llama-server leaves ~1.5 GB for OS + open-webui + dashboard-api + LiteLLM. Validated by the model footprint chosen in #1481 (Qwen3.5-2B ~1.5 GB / Gemma E2B ~2.81 GB).

## Test plan

### Static checks
- `bash -n` clean on all changed files
- `python3 -c "import yaml; yaml.safe_load(...)"` validates the new compose YAML and all four edited manifests
- `bash scripts/validate-manifest-schema.sh` — 22/24 valid; 2 pre-existing errors on `opencode` (type `host-systemd`) and `tailscale` (missing `service.health`) untouched by this PR

### Test suites
```bash
bash tests/test-jetson-compose-resolver.sh   # NEW: 11/11 PASS
bash tests/test-jetson-detection.sh          # 12/12 PASS (Phase 1, unchanged)
bash tests/test-tier-map.sh                  # 135/135 PASS (Phase 2, unchanged)
bash tests/test-resolve-compose-resilient.sh # 31/31 PASS (existing, unchanged)
```

### Resolver sanity
```bash
bash scripts/resolve-compose-stack.sh --gpu-backend jetson --env | grep COMPOSE_PRIMARY_FILE
# COMPOSE_PRIMARY_FILE="docker-compose.jetson.yml"

bash scripts/resolve-compose-stack.sh --tier JETSON_ORIN_NANO --env | grep COMPOSE_PRIMARY_FILE
# COMPOSE_PRIMARY_FILE="docker-compose.jetson.yml"

bash scripts/resolve-compose-stack.sh --gpu-backend nvidia --env | grep COMPOSE_PRIMARY_FILE
# COMPOSE_PRIMARY_FILE="docker-compose.nvidia.yml"   ← regression-free
```

## What's deliberately NOT included (separate follow-ups)

- **On-hardware install validation** — Phase 4. PR moves to ready-for-review after a full `./install.sh --tier JETSON_ORIN_NANO --bootstrap` run on Orin Nano 8GB completes with a valid (non-`?`-flood) inference response, with logs + `tegrastats` + Open WebUI screenshot attached as a comment
- **Orin AGX/NX, Xavier, legacy Nano** — different SoCs / CUDA caps
- **ComfyUI / Whisper GPU acceleration on Jetson** — no validated path
- **`docs/JETSON-QUICKSTART.md` + `SUPPORT-MATRIX.md` entry** — Phase 5, after Phase 4 lands

## Stack note

Depends on #1479 (Phase 1) and #1481 (Phase 2). Like #1481, this targets `main` because GitHub can't accept a base branch that doesn't exist in upstream — diff shows +194/-12 total but only +194/-12 minus the prior phases is the new code in this PR.
