### PR TITLE
fix(installer): restore Hermes image pulls for stable installs

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -406,7 +406,7 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # ═══════════════════════════════════════════════════════════════════
 # Hermes Agent (Nous Research, MIT) — chat-first generalist agent with
 # persistent memory, autonomous skill creation, and 70+ tools. Dream
-# Server runs the upstream image pinned by SHA and points it at the
+# Server runs the upstream image pinned by version and points it at the
 # local LLM. Browser UI ships in the upstream image (port 9119).
 # Enable: `dream enable hermes`. Owner-card users reach the mobile Dream
 # Talk portal at http://talk.<device>.local/talk; advanced users can still
@@ -416,6 +416,8 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 #
 # HERMES_LLM_BASE_URL=http://llama-server:8080/v1  # OpenAI-compat endpoint
 # HERMES_LLM_API_KEY=sk-dream-hermes-local  # Dummy (OpenAI SDK requires non-empty)
+# HERMES_AGENT_IMAGE=nousresearch/hermes-agent:v2026.5.16  # Upstream Hermes image
+# HERMES_AGENT_IMAGE_FALLBACK=                         # Optional explicit fallback if upstream retags
 # HERMES_LANGUAGE=en                     # UI language
 # (No HERMES_MODEL_NAME — the model lives in /opt/data/config.yaml,
 #  not in env. Edit the file after first start to switch models.)

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -1026,6 +1026,16 @@
       "description": "Dummy API key for Hermes Agent's OpenAI SDK (llama-server doesn't validate it, but the SDK requires the field to be non-empty).",
       "secret": true
     },
+    "HERMES_AGENT_IMAGE": {
+      "type": "string",
+      "description": "Container image used for Hermes Agent. Defaults to a reviewed upstream version tag; override only for deliberate hotfix testing.",
+      "default": "nousresearch/hermes-agent:v2026.5.16"
+    },
+    "HERMES_AGENT_IMAGE_FALLBACK": {
+      "type": "string",
+      "description": "Optional explicit fallback Hermes Agent image. Phase 08 uses it only if HERMES_AGENT_IMAGE cannot be resolved.",
+      "default": ""
+    },
     "HERMES_LANGUAGE": {
       "type": "string",
       "description": "UI language for Hermes Agent's web dashboard (defaults to en).",

--- a/dream-server/config/dependency-lock.json
+++ b/dream-server/config/dependency-lock.json
@@ -101,7 +101,7 @@
       "id": "hermes.agent",
       "type": "image",
       "path": "extensions/services/hermes/compose.yaml",
-      "value": "nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f"
+      "value": "nousresearch/hermes-agent:v2026.5.16"
     },
     {
       "id": "hermes-proxy.caddy",
@@ -306,6 +306,12 @@
       "value": "${LLAMA_ARC_IMAGE:-dream-llama-sycl:local}",
       "default": "dream-llama-sycl:local",
       "reason": "Intel Arc uses a local SYCL image by default and can be overridden for experiments."
+    },
+    {
+      "path": "extensions/services/hermes/compose.yaml",
+      "value": "${HERMES_AGENT_IMAGE:-nousresearch/hermes-agent:v2026.5.16}",
+      "default": "nousresearch/hermes-agent:v2026.5.16",
+      "reason": "Hermes Agent image can be overridden for upstream registry hotfixes, but the shipped default is locked."
     },
     {
       "path": "extensions/services/llama-server/Dockerfile.amd",

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -120,23 +120,28 @@ For local backends, keep `model.context_length` and `auxiliary.compression.conte
 - **The container has full network access** within Dream Server's bridge net — Hermes can make outbound HTTP requests for tools like `web_search`. If you want to restrict this, add an iptables firewall rule on the host or run Hermes behind a forward proxy.
 - **No APE policy enforcement yet.** Hermes's 70+ tools include shell + file write. The base config defaults toward less-risky tools, but Hermes can still execute shell commands inside its sandbox container. APE policy wrapping is a planned follow-up; until then, the trust model is "the user authenticated to Hermes is trusted to use the local container."
 
-## How to bump the SHA pin
+## How to bump the image pin
 
-Hermes is a young, fast-moving project (~3 months old as of v1 integration). The SHA pin in `compose.yaml` lets us audit upstream changes deliberately rather than auto-tracking `:latest`. Bumping is a 5-minute pass:
+Hermes is a young, fast-moving project. Dream Server pins a reviewed upstream image tag in `compose.yaml` instead of auto-tracking `:latest`. Operators can temporarily override it with `HERMES_AGENT_IMAGE`, and can provide `HERMES_AGENT_IMAGE_FALLBACK` for registry hotfixes, but changing the shipped default is a deliberate review-and-smoke-test pass:
 
 ```bash
-# 1. Pick the new SHA. Upstream publishes a sha-<full-sha> tag for every
-#    main push, so any commit on NousResearch/hermes-agent's main is fair game.
-gh api repos/NousResearch/hermes-agent/commits/main --jq '{sha,date:.commit.author.date,msg:.commit.message}'
+# 1. Pick a published upstream image tag.
+curl -s 'https://hub.docker.com/v2/repositories/nousresearch/hermes-agent/tags?page_size=25' \
+  | jq -r '.results[] | [.name, .last_updated] | @tsv'
 
-# 2. Read the diff since our current pin. Skim breaking changes,
-#    config-format migrations, removed env vars.
-gh api repos/NousResearch/hermes-agent/compare/<old-sha>...<new-sha> --jq '.commits[].commit.message'
+# 2. Verify Docker can resolve the tag on a clean machine.
+docker manifest inspect nousresearch/hermes-agent:<new-tag> >/dev/null
 
-# 3. Update extensions/services/hermes/compose.yaml — the only place the
-#    pin appears.
+# 3. Review upstream release notes / commits. Skim breaking changes,
+#    config-format migrations, removed env vars, and dashboard changes.
 
-# 4. Smoke test:
+# 4. Update:
+#    - extensions/services/hermes/compose.yaml
+#    - installers/phases/08-images.sh
+#    - config/dependency-lock.json
+#    - this bump-history table
+
+# 5. Smoke test:
 #    dream restart hermes
 #    docker inspect --format '{{.State.Health.Status}}' dream-hermes
 #    curl http://localhost:9120/health
@@ -240,7 +245,7 @@ For Hermes, `CTX_SIZE` / `MAX_CONTEXT`, `model.context_length`, and `auxiliary.c
 
 ### Sessions / memories / skills disappeared after upgrade
 
-The SHA pin protects you from accidental version drift, but if you DID bump and lose data, it's almost certainly because Hermes's config format changed. Check `data/hermes/config.yaml` against upstream's current `cli-config.yaml.example`. The container's first start regenerates `config.yaml` from our template only if it doesn't exist — your old config sticks around.
+The image pin protects you from accidental version drift, but if you DID bump and lose data, it's almost certainly because Hermes's config format changed. Check `data/hermes/config.yaml` against upstream's current `cli-config.yaml.example`. The container's first start regenerates `config.yaml` from our template only if it doesn't exist — your old config sticks around.
 
 ### "I don't want Hermes anymore"
 
@@ -259,6 +264,7 @@ When promoting / talking about this extension, the convention is: "Hermes Agent 
 
 ## Bump history
 
-| Date | Pinned SHA | Notes |
+| Date | Pinned image | Notes |
 |---|---|---|
+| 2026-06-01 | `nousresearch/hermes-agent:v2026.5.16` | Replace removed upstream `sha-*` tag with a published version tag; add `HERMES_AGENT_IMAGE` override/fallback path. |
 | 2026-05-12 | `dd0923bb89ed2dd56f82cb63656a1323f6f42e6f` | Initial integration. |

--- a/dream-server/extensions/services/hermes/compose.yaml
+++ b/dream-server/extensions/services/hermes/compose.yaml
@@ -1,10 +1,9 @@
 services:
   hermes:
-    # SHA-pinned to NousResearch/hermes-agent@dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
-    # (2026-05-12). Upstream's CI publishes a sha-<full-sha> tag for every main
-    # push, so this is an immutable reference. Bumping the pin is a deliberate
-    # review-and-smoke-test pass — see docs/HERMES.md "How to bump the pin."
-    image: nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f
+    # Version-pinned upstream image. Override HERMES_AGENT_IMAGE only for
+    # deliberate hotfix testing; bumping the default is a review-and-smoke-test
+    # pass — see docs/HERMES.md "How to bump the image pin."
+    image: ${HERMES_AGENT_IMAGE:-nousresearch/hermes-agent:v2026.5.16}
     container_name: dream-hermes
     restart: unless-stopped
     # NOT host networking — we use bridge so the container can resolve

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -37,7 +37,7 @@ service:
   description: >
     Hermes Agent (Nous Research) — a self-improving generalist agent with
     persistent memory, autonomous skill creation, and 70+ built-in tools.
-    Dream Server runs the upstream image pinned by SHA, points it at the
+    Dream Server runs the upstream image pinned by version, points it at the
     local LLM (llama-server), and ships no messaging-platform adapters
     (Telegram / Discord / Slack / etc.) since the web dashboard is the
     surface we ship. The container runs `hermes gateway run` with the

--- a/dream-server/installers/lib/docker-images.sh
+++ b/dream-server/installers/lib/docker-images.sh
@@ -36,6 +36,7 @@ validate_docker_image_or_fallback() {
     local image="$2"
     local label="$3"
     local fallback_env="${4:-}"
+    local primary_env="${5:-LLAMA_SERVER_IMAGE}"
     local fallback=""
 
     if docker_image_available "$image"; then
@@ -63,7 +64,9 @@ validate_docker_image_or_fallback() {
 
     ai "Docker cannot resolve this image tag before service startup."
     ai "Check the tag, registry access, and Docker Desktop/daemon network."
-    ai "To override intentionally, set LLAMA_SERVER_IMAGE to a valid image."
-    ai "To permit an explicit fallback, set LLAMA_SERVER_IMAGE_FALLBACK to a valid image."
+    ai "To override intentionally, set $primary_env to a valid image."
+    if [[ -n "$fallback_env" ]]; then
+        ai "To permit an explicit fallback, set $fallback_env to a valid image."
+    fi
     return 1
 }

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -48,10 +48,10 @@ fi
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && PULL_LIST+=("n8nio/n8n:2.6.4|N8N — automation engine")
 [[ "$ENABLE_RAG" == "true" ]] && PULL_LIST+=("qdrant/qdrant:v1.16.3|QDRANT — memory vault")
 if [[ "$ENABLE_HERMES" == "true" ]]; then
-    # SHA-pinned: see extensions/services/hermes/compose.yaml for the pin
-    # rationale + "How to bump the pin" in docs/HERMES.md. Hermes-proxy
-    # is the auth gate (Caddy) and is pulled alongside Hermes.
-    PULL_LIST+=("nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f|HERMES — default agent (Nous Research)")
+    # Version-pinned upstream image. See extensions/services/hermes/compose.yaml
+    # and docs/HERMES.md for the bump process. Hermes-proxy is the auth gate
+    # (Caddy) and is pulled alongside Hermes.
+    PULL_LIST+=("${HERMES_AGENT_IMAGE:-nousresearch/hermes-agent:v2026.5.16}|HERMES — default agent (Nous Research)")
     PULL_LIST+=("caddy:2.11.3-alpine|HERMES PROXY — magic-link auth gate (Caddy)")
 fi
 [[ "$ENABLE_OPENCLAW" == "true" ]] && PULL_LIST+=("ghcr.io/openclaw/openclaw:2026.3.8|OPENCLAW — agent framework")
@@ -98,6 +98,50 @@ else
                         sed -i.bak "s|^LLAMA_SERVER_IMAGE=.*|LLAMA_SERVER_IMAGE=${_validated_llama_image}|" "$INSTALL_DIR/.env" && rm -f "$INSTALL_DIR/.env.bak"
                     else
                         printf '\nLLAMA_SERVER_IMAGE=%s\n' "$_validated_llama_image" >> "$INSTALL_DIR/.env"
+                    fi
+                fi
+            fi
+        fi
+    fi
+
+    if [[ "${ENABLE_HERMES:-false}" == "true" ]]; then
+        _hermes_image=""
+        _hermes_label=""
+        _hermes_index=-1
+        for _idx in "${!PULL_LIST[@]}"; do
+            entry="${PULL_LIST[$_idx]}"
+            _entry_img="${entry%%|*}"
+            _entry_label="${entry##*|}"
+            if [[ "$_entry_label" == HERMES\ * ]]; then
+                _hermes_image="$_entry_img"
+                _hermes_label="$_entry_label"
+                _hermes_index="$_idx"
+                break
+            fi
+        done
+
+        if [[ -n "$_hermes_image" ]]; then
+            ai "Validating Hermes Agent image tag before download..."
+            if [[ -z "${HERMES_AGENT_IMAGE_FALLBACK:-}" && -f "$INSTALL_DIR/.env" ]]; then
+                _hermes_fallback_from_env="$(sed -n 's/^HERMES_AGENT_IMAGE_FALLBACK=//p' "$INSTALL_DIR/.env" 2>/dev/null | head -n 1 || true)"
+                _hermes_fallback_from_env="${_hermes_fallback_from_env#\"}"
+                _hermes_fallback_from_env="${_hermes_fallback_from_env%\"}"
+                _hermes_fallback_from_env="${_hermes_fallback_from_env#\'}"
+                _hermes_fallback_from_env="${_hermes_fallback_from_env%\'}"
+                [[ -n "$_hermes_fallback_from_env" ]] && HERMES_AGENT_IMAGE_FALLBACK="$_hermes_fallback_from_env"
+            fi
+            _validated_hermes_image=""
+            if ! validate_docker_image_or_fallback _validated_hermes_image "$_hermes_image" "Hermes Agent" "HERMES_AGENT_IMAGE_FALLBACK" "HERMES_AGENT_IMAGE"; then
+                exit 1
+            fi
+            if [[ "$_validated_hermes_image" != "$_hermes_image" ]]; then
+                HERMES_AGENT_IMAGE="$_validated_hermes_image"
+                PULL_LIST[$_hermes_index]="${_validated_hermes_image}|${_hermes_label}"
+                if [[ -f "$INSTALL_DIR/.env" ]]; then
+                    if grep -q '^HERMES_AGENT_IMAGE=' "$INSTALL_DIR/.env"; then
+                        sed -i.bak "s|^HERMES_AGENT_IMAGE=.*|HERMES_AGENT_IMAGE=${_validated_hermes_image}|" "$INSTALL_DIR/.env" && rm -f "$INSTALL_DIR/.env.bak"
+                    else
+                        printf '\nHERMES_AGENT_IMAGE=%s\n' "$_validated_hermes_image" >> "$INSTALL_DIR/.env"
                     fi
                 fi
             fi

--- a/dream-server/tests/test-linux-cloud-mode.sh
+++ b/dream-server/tests/test-linux-cloud-mode.sh
@@ -81,6 +81,15 @@ else
     fail "cloud health path must skip local llama-server"
 fi
 
+if grep -Fq 'image: ${HERMES_AGENT_IMAGE:-nousresearch/hermes-agent:v2026.5.16}' extensions/services/hermes/compose.yaml \
+    && grep -Fq '${HERMES_AGENT_IMAGE:-nousresearch/hermes-agent:v2026.5.16}|HERMES' installers/phases/08-images.sh \
+    && grep -Fq 'HERMES_AGENT_IMAGE_FALLBACK' installers/phases/08-images.sh \
+    && ! grep -R -q 'nousresearch/hermes-agent:sha-' extensions/services/hermes installers/phases config/dependency-lock.json; then
+    pass "Hermes image default is resolvable and overrideable for cloud installs"
+else
+    fail "Hermes image default must not rely on removed sha-* Docker tags"
+fi
+
 "$PY" - "$ROOT_DIR" <<'PY'
 from pathlib import Path
 import sys


### PR DESCRIPTION
## Summary

Fixes the Hermes Agent image reference used by the stable installer path.

The previous default pointed at `nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f`, but Docker Hub no longer exposes `sha-*` tags for `nousresearch/hermes-agent`. True-fresh installs with Hermes enabled can therefore fail before any managed containers come up.

This PR:

- switches the shipped Hermes default to the published upstream tag `nousresearch/hermes-agent:v2026.5.16`
- adds `HERMES_AGENT_IMAGE` and `HERMES_AGENT_IMAGE_FALLBACK` override hooks
- validates the Hermes image before the image-pull phase continues
- writes a selected fallback back into `.env` so Compose uses the same image later
- updates dependency-lock, env schema/example, Hermes docs, and the cloud-mode regression contract

Fixes #1486.

## Validation

- `python scripts/check-dependency-pins.py`
- `DREAM_PYTHON_CMD=python bash tests/test-linux-cloud-mode.sh`
- `bash -n installers/phases/08-images.sh installers/lib/docker-images.sh`
- `docker manifest inspect nousresearch/hermes-agent:v2026.5.16`
- direct mocked smoke of `validate_docker_image_or_fallback` for Hermes-specific guidance

## Release lane

Stable hotfix targeting `release/2.5.x`. This fixes a current-stable installer failure without changing the bundled service set or model routing policy.