### PR TITLE
litellm: upgrade minimax to MiniMax-M3 default

### DIFF
--- a/dream-server/config/litellm/cloud.yaml
+++ b/dream-server/config/litellm/cloud.yaml
@@ -16,6 +16,12 @@ model_list:
 
   - model_name: minimax
     litellm_params:
+      model: openai/MiniMax-M3
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: minimax-legacy
+    litellm_params:
       model: openai/MiniMax-M2.7
       api_base: https://api.minimax.io/v1
       api_key: os.environ/MINIMAX_API_KEY

--- a/dream-server/config/litellm/hybrid.yaml
+++ b/dream-server/config/litellm/hybrid.yaml
@@ -12,6 +12,12 @@ model_list:
 
   - model_name: minimax
     litellm_params:
+      model: openai/MiniMax-M3
+      api_base: https://api.minimax.io/v1
+      api_key: os.environ/MINIMAX_API_KEY
+
+  - model_name: minimax-legacy
+    litellm_params:
       model: openai/MiniMax-M2.7
       api_base: https://api.minimax.io/v1
       api_key: os.environ/MINIMAX_API_KEY

--- a/dream-server/extensions/services/litellm/README.md
+++ b/dream-server/extensions/services/litellm/README.md
@@ -42,7 +42,8 @@ model_list:
   - model_name: default       # → anthropic/claude-sonnet-4-5-20250514
   - model_name: gpt4o         # → openai/gpt-4o
   - model_name: fast          # → anthropic/claude-haiku-4-5-20251001
-  - model_name: minimax       # → MiniMax-M2.7 via minimax API
+  - model_name: minimax       # → MiniMax-M3 via minimax API (default)
+  - model_name: minimax-legacy # → MiniMax-M2.7 (legacy)
   - model_name: minimax-fast  # → MiniMax-M2.7-highspeed
 ```
 


### PR DESCRIPTION
## Summary

Promote `MiniMax-M3` as the new default for the `minimax` LiteLLM
alias in both `cloud` and `hybrid` modes. M3 is MiniMax's latest
general-purpose chat model (512K context window, 128K max output).
The existing M2.7 mapping is preserved under a `minimax-legacy` alias
for installs that pinned the old default and need an explicit fallback,
and `minimax-fast` continues to point at `MiniMax-M2.7-highspeed`
(M3 does not ship a highspeed variant today).

Diff:

- `dream-server/config/litellm/cloud.yaml` — add `minimax` -> `openai/MiniMax-M3`, rename previous entry to `minimax-legacy` (`openai/MiniMax-M2.7`).
- `dream-server/config/litellm/hybrid.yaml` — same change for hybrid mode.
- `dream-server/extensions/services/litellm/README.md` — update the `cloud` alias table to reflect the new default.

No infra/env changes:

- Same `MINIMAX_API_KEY` env var, secret schema, installer wiring.
- Same `https://api.minimax.io/v1` OpenAI-compatible base URL.
- Same compose / extension manifests.

## AI Assistance

AI-assisted drafting for the YAML alias rename and README sync. The diff was reviewed by hand, focused validation listed below was run locally, and the human author is accountable for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — additive routing change targeting main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Docs touched too — only the litellm extension README's alias table.)

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: change is limited to two LiteLLM YAML files (alias rename + new entry) and one README table; no installer/compose/manifest paths touched, and the same `MINIMAX_API_KEY` / base URL / OpenAI-compatible protocol are reused.

Commands/results:

```text
# YAML parses + alias table sanity
python3 -c "import yaml; ..."  ->  6 models each, minimax -> openai/MiniMax-M3

# Existing LiteLLM / cloud-mode regression suites
bash dream-server/tests/test-linux-cloud-mode.sh
  -> 15/15 PASS (cloud overlay, gateway inclusion, Hermes default, ...)

bash dream-server/tests/contracts/test-installer-contracts.sh
  -> 34/34 PASS
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

LiteLLM model_list entries are config data consumed at runtime; no installer phase, compose generation, or lifecycle command is touched. Existing `cloud`/`hybrid` users keep working (the `minimax` alias name is unchanged, only the model behind it advances; the prior model is still reachable via `minimax-legacy`).

## Notes For Reviewers

- The naming convention `<alias>-legacy` mirrors what other LiteLLM gateways use when graduating a default; happy to swap to `minimax-m2.7` or similar if you prefer a version-explicit name.
- M3 reuses the existing `openai/...` LiteLLM prefix because MiniMax's OpenAI-compatible endpoint (`api.minimax.io/v1`) is unchanged — no SDK swap needed.
- `MINIMAX_API_KEY` and base URL remain identical, so no `.env.example` / `.env.schema.json` / installer changes were necessary.