### PR TITLE
docs(lemonade): clarify existing service scope

### DIFF
--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -59,7 +59,10 @@ On Linux Docker installs, llama-server is exposed to the host on **http://localh
 On Linux AMD hosts already running Lemonade SDK, install Dream Server around it with
 `./install.sh --use-existing-lemonade` so Dream manages the app stack while
 Lemonade keeps owning inference and model storage. See
-[docs/LEMONADE-SDK-COMPAT.md](docs/LEMONADE-SDK-COMPAT.md).
+[docs/LEMONADE-SDK-COMPAT.md](docs/LEMONADE-SDK-COMPAT.md). Existing Lemonade
+mode only reuses Lemonade for LLM inference; Full Stack still enables
+Dream-managed Whisper, Kokoro, and ComfyUI unless you pass `--no-voice` and/or
+`--no-comfyui` or choose alternate ports where supported.
 
 ### Instant Start (Bootstrap Mode)
 

--- a/dream-server/docs/LEMONADE-SDK-COMPAT.md
+++ b/dream-server/docs/LEMONADE-SDK-COMPAT.md
@@ -34,6 +34,46 @@ Dream Server will keep Lemonade unmanaged:
 - it routes Dream services through LiteLLM, which calls the existing Lemonade
   service.
 
+This only applies to the LLM runtime. Dream Server's optional voice and image
+services are separate from Lemonade:
+
+- Whisper speech-to-text listens on port `9000`;
+- Kokoro text-to-speech listens on port `8880`;
+- ComfyUI image generation listens on port `8188`.
+
+If you choose **Full Stack**, Dream Server still enables those services by
+default. That is useful when Dream should own the full app stack, but it can
+conflict with an existing local AI setup that already runs Whisper, TTS, ComfyUI,
+or other services on the same ports.
+
+To wrap an existing Lemonade install without Dream-managed voice or image
+services:
+
+```bash
+./install.sh --use-existing-lemonade --no-voice --no-comfyui
+```
+
+If you are using `--all`, put the opt-out flags after `--all` because installer
+flags are processed left to right:
+
+```bash
+./install.sh --use-existing-lemonade --all --no-voice --no-comfyui
+```
+
+If you want Dream Server's Whisper or ComfyUI services but need to avoid port
+collisions, set alternate ports before running the installer:
+
+```bash
+WHISPER_PORT=9100 COMFYUI_PORT=8190 \
+  ./install.sh --use-existing-lemonade
+```
+
+If the installer reports that ports `9000`, `8880`, or `8188` are already in
+use, either disable the matching Dream feature or choose a different port where
+the installer supports it. Today, a Kokoro/TTS conflict on port `8880` should be
+handled with `--no-voice`. The port conflict is from the optional Dream service,
+not from Lemonade itself.
+
 Windows AMD installs already use a separate host-managed Lemonade path. These
 flags are for Linux installs that should attach to a pre-existing Lemonade SDK
 service.


### PR DESCRIPTION
## Summary
- Clarify that `--use-existing-lemonade` reuses an existing Lemonade install for LLM inference only.
- Document that Full Stack still enables Dream-managed Whisper, Kokoro, and ComfyUI by default.
- Add copy-paste install commands for existing Lemonade users who need to avoid voice/image service conflicts.

## Validation
- `git diff --check`
- `bash -n install-core.sh installers/phases/03-features.sh installers/phases/04-requirements.sh installers/phases/06-directories.sh`
- `DREAM_PYTHON_CMD=python bash tests/contracts/test-external-lemonade-contracts.sh`
- Confirmed documented installer flags/env vars against installer and service manifests
- Docs-only change; no product code touched