### PR TITLE
fix(lemonade): harden existing runtime installs

### DIFF
--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -58,7 +58,9 @@ On Linux Docker installs, llama-server is exposed to the host on **http://localh
 
 On Linux AMD hosts already running Lemonade SDK, install Dream Server around it with
 `./install.sh --use-existing-lemonade` so Dream manages the app stack while
-Lemonade keeps owning inference and model storage. See
+Lemonade keeps owning inference and model storage. The installer auto-detects
+common Lemonade ports and the first served model, then verifies a real completion
+through LiteLLM before declaring success. See
 [docs/LEMONADE-SDK-COMPAT.md](docs/LEMONADE-SDK-COMPAT.md). Existing Lemonade
 mode only reuses Lemonade for LLM inference; Full Stack still enables
 Dream-managed Whisper, Kokoro, and ComfyUI unless you pass `--no-voice` and/or

--- a/dream-server/docs/LEMONADE-SDK-COMPAT.md
+++ b/dream-server/docs/LEMONADE-SDK-COMPAT.md
@@ -18,6 +18,13 @@ If Lemonade is not using its default URL, pass it explicitly:
 ./install.sh --use-existing-lemonade --lemonade-url http://localhost:13305
 ```
 
+When `--lemonade-url` is omitted, Dream Server checks `http://localhost:13305`
+first, then `http://localhost:8000`. This covers current Lemonade Server
+packages and older Python SDK installs. If neither endpoint is reachable, the
+installer falls back to `http://localhost:13305` and the Phase 12 completion
+check will fail with a targeted Lemonade routing error instead of declaring a
+false-green install.
+
 If Lemonade requires an API key:
 
 ```bash
@@ -80,8 +87,11 @@ service.
 
 ## Model Selection
 
-Set `LEMONADE_MODEL` if the default Dream model id does not match a model in
-your Lemonade library:
+Dream Server auto-detects the first model id returned by Lemonade's
+`/api/v1/models` endpoint and writes it to `LEMONADE_MODEL`.
+
+Set `LEMONADE_MODEL` only if you want Dream Server to use a specific served
+model:
 
 ```bash
 LEMONADE_MODEL=Qwen3-0.6B-GGUF ./install.sh --use-existing-lemonade
@@ -93,6 +103,11 @@ example:
 ```bash
 curl http://localhost:13305/api/v1/models
 ```
+
+Phase 12 verifies the selected model with a real chat completion through
+LiteLLM. If Lemonade is reachable from the host but not from Docker containers,
+or if the selected model id is wrong, the installer fails there with a recovery
+hint instead of finishing with a broken chat path.
 
 ## Linux Docker Networking
 
@@ -121,7 +136,7 @@ with `--lemonade-api-key`.
 | Mode | Who owns Lemonade? | Default API target | Model storage |
 | --- | --- | --- | --- |
 | Managed AMD Lemonade | Dream Server | `llama-server:8080/api/v1` inside Docker | Dream `data/models` |
-| Existing Lemonade SDK | User / OS service | `host.docker.internal:13305/api/v1` from containers | Lemonade cache |
+| Existing Lemonade SDK | User / OS service | Auto-detected `host.docker.internal:<port>/api/v1` from containers | Lemonade cache |
 
 In both modes, Dream services talk to LiteLLM first. LiteLLM normalizes model
 routing and gives Open WebUI, Hermes, Perplexica, and other services one stable

--- a/dream-server/dream-preflight.sh
+++ b/dream-server/dream-preflight.sh
@@ -68,6 +68,13 @@ detect_backend() {
 
 BACKEND=$(detect_backend)
 
+is_external_lemonade() {
+    local external="${LEMONADE_EXTERNAL:-false}"
+    local managed="${AMD_INFERENCE_MANAGED:-}"
+    local mode="${DREAM_MODE:-local}"
+    [[ "${external,,}" == "true" ]] || [[ "${mode,,}" == "lemonade" && "${managed,,}" == "false" ]]
+}
+
 # Colors
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -185,16 +192,26 @@ log ""
 # OLLAMA_PORT=11434 to .env automatically — it will be picked up via the
 # ${OLLAMA_PORT:-...} expansion below, so the fallback should be 8080.
 log "[4/8] Checking LLM endpoint..."
-LLM_PORT="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-8080}}"
-# Also probe the actual mapped port in case docker remapped it
-EXTERNAL_PORT=$(docker port dream-llama-server 8080/tcp 2>/dev/null | head -1 | cut -d: -f2 || echo "$LLM_PORT")
-LLM_ENDPOINTS=("http://${SERVICE_HOST}:${EXTERNAL_PORT}" "http://127.0.0.1:${EXTERNAL_PORT}" "http://127.0.0.1:${LLM_PORT}")
-LLM_SERVICE_NAME="llama-server"
-LLM_START_CMD="docker compose up -d llama-server"
+if is_external_lemonade; then
+    LLM_PORT="${LITELLM_PORT:-4000}"
+    LLM_ENDPOINTS=("http://${SERVICE_HOST}:${LLM_PORT}/health/readiness" "http://127.0.0.1:${LLM_PORT}/health/readiness" "http://127.0.0.1:${LLM_PORT}/v1/models")
+    LLM_SERVICE_NAME="LiteLLM external Lemonade gateway"
+    LLM_CONTAINER_MATCH="dream-litellm"
+    LLM_START_CMD="docker compose up -d litellm"
+else
+    LLM_PORT="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-8080}}"
+    # Also probe the actual mapped port in case docker remapped it
+    EXTERNAL_PORT="$(docker port dream-llama-server 8080/tcp 2>/dev/null | head -1 | cut -d: -f2 || true)"
+    [[ -n "$EXTERNAL_PORT" ]] || EXTERNAL_PORT="$LLM_PORT"
+    LLM_ENDPOINTS=("http://${SERVICE_HOST}:${EXTERNAL_PORT}/health" "http://${SERVICE_HOST}:${EXTERNAL_PORT}/v1/models" "http://127.0.0.1:${EXTERNAL_PORT}/health" "http://127.0.0.1:${EXTERNAL_PORT}/v1/models" "http://127.0.0.1:${LLM_PORT}/health" "http://127.0.0.1:${LLM_PORT}/v1/models")
+    LLM_SERVICE_NAME="llama-server"
+    LLM_CONTAINER_MATCH="dream-llama-server"
+    LLM_START_CMD="docker compose up -d llama-server"
+fi
 
 LLM_FOUND=false
 for ENDPOINT in "${LLM_ENDPOINTS[@]}"; do
-    if curl -sf "$ENDPOINT/health" &> /dev/null || curl -sf "$ENDPOINT/v1/models" &> /dev/null; then
+    if curl -sf "$ENDPOINT" &> /dev/null; then
         pass "LLM endpoint ($LLM_SERVICE_NAME) responding at $ENDPOINT"
         LLM_FOUND=true
         break
@@ -203,7 +220,7 @@ done
 
 if [ "$LLM_FOUND" = false ]; then
     # Check if container is running but model still loading
-    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qi "${LLM_SERVICE_NAME}"; then
+    if docker ps --format '{{.Names}}' 2>/dev/null | grep -qi "${LLM_CONTAINER_MATCH}"; then
         warn "$LLM_SERVICE_NAME container running but not responding yet (model may still be loading)"
     else
         fail "No LLM endpoint found — checked: ${LLM_ENDPOINTS[*]}"

--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -141,7 +141,8 @@ Options:
     --cloud           Cloud mode: skip GPU detection, use LiteLLM + cloud APIs
     --use-existing-lemonade
                       Use an already-running Lemonade SDK server as the AMD LLM runtime
-    --lemonade-url U  Lemonade server URL for --use-existing-lemonade (default: http://localhost:13305)
+    --lemonade-url U  Lemonade server URL for --use-existing-lemonade
+                      (auto-detects localhost:13305, then localhost:8000 when omitted)
     --lemonade-api-key K
                       API key LiteLLM should send to the existing Lemonade server
     --voice           Enable voice services (Whisper + Kokoro)
@@ -246,7 +247,6 @@ done
 if [[ "${LEMONADE_EXTERNAL,,}" == "true" ]]; then
     DREAM_MODE="lemonade"
     ENABLE_RECOMMENDED=true
-    LEMONADE_BASE_URL="${LEMONADE_BASE_URL:-http://localhost:13305}"
     export LEMONADE_EXTERNAL LEMONADE_BASE_URL LEMONADE_API_KEY
 fi
 

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -268,6 +268,58 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         echo "$default"
     }
 
+    _phase06_detect_lemonade_url() {
+        command -v curl >/dev/null 2>&1 || return 1
+        local candidate
+        for candidate in "http://localhost:13305" "http://localhost:8000"; do
+            if curl -fsS --max-time 3 "${candidate}/api/v1/models" >/dev/null 2>&1 || \
+               curl -fsS --max-time 3 "${candidate}/api/v1/health" >/dev/null 2>&1 || \
+               curl -fsS --max-time 3 "${candidate}/health" >/dev/null 2>&1; then
+                printf '%s\n' "$candidate"
+                return 0
+            fi
+        done
+        return 1
+    }
+
+    _phase06_first_model_id_from_json() {
+        local json="$1"
+        local py="${DREAM_PYTHON_CMD:-}"
+        if [[ -z "$py" && -f "$SCRIPT_DIR/lib/python-cmd.sh" ]]; then
+            . "$SCRIPT_DIR/lib/python-cmd.sh"
+            py="$(ds_detect_python_cmd 2>/dev/null || true)"
+        fi
+        [[ -n "$py" ]] || py="python3"
+        if command -v "$py" >/dev/null 2>&1; then
+            printf '%s' "$json" | "$py" -c 'import json,sys
+try:
+    data=json.load(sys.stdin).get("data", [])
+    for item in data:
+        model_id=item.get("id") if isinstance(item, dict) else None
+        if model_id:
+            print(model_id)
+            raise SystemExit(0)
+except Exception:
+    pass
+raise SystemExit(1)' 2>/dev/null && return 0
+        fi
+        printf '%s' "$json" \
+            | grep -o '"id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+            | head -n 1 \
+            | sed 's/.*"id"[[:space:]]*:[[:space:]]*"//; s/".*//'
+    }
+
+    _phase06_discover_lemonade_model() {
+        local api_base="$1"
+        command -v curl >/dev/null 2>&1 || return 1
+        local models_json model_id
+        models_json="$(curl -fsS --max-time 10 "${api_base%/}/models" 2>/dev/null || true)"
+        [[ -n "$models_json" ]] || return 1
+        model_id="$(_phase06_first_model_id_from_json "$models_json" || true)"
+        [[ -n "$model_id" ]] || return 1
+        printf '%s\n' "$model_id"
+    }
+
     # Secrets: reuse existing values, generate only if missing
     WEBUI_SECRET=$(_env_get WEBUI_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
     N8N_PASS=$(_env_get N8N_PASS "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
@@ -284,7 +336,15 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     LEMONADE_CONTAINER_BASE_URL_VALUE=""
     LEMONADE_PORT_VALUE=""
     if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then
-        LEMONADE_BASE_URL_VALUE="$(_env_get LEMONADE_BASE_URL "${LEMONADE_BASE_URL:-http://localhost:13305}")"
+        LEMONADE_BASE_URL_VALUE="$(_env_get LEMONADE_BASE_URL "${LEMONADE_BASE_URL:-}")"
+        if [[ -z "$LEMONADE_BASE_URL_VALUE" ]]; then
+            if LEMONADE_BASE_URL_VALUE="$(_phase06_detect_lemonade_url)"; then
+                ai_ok "Detected existing Lemonade server at ${LEMONADE_BASE_URL_VALUE}"
+            else
+                LEMONADE_BASE_URL_VALUE="http://localhost:13305"
+                warn "Could not auto-detect existing Lemonade; using ${LEMONADE_BASE_URL_VALUE}. Pass --lemonade-url if your server uses another port."
+            fi
+        fi
         LEMONADE_BASE_URL_VALUE="${LEMONADE_BASE_URL_VALUE%/}"
         for _lemonade_suffix in "/api/v1" "/v1" "/api"; do
             if [[ "$LEMONADE_BASE_URL_VALUE" == *"$_lemonade_suffix" ]]; then
@@ -312,6 +372,21 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
     fi
     LEMONADE_API_BASE_VALUE="${LEMONADE_BASE_URL_VALUE}${LEMONADE_API_BASE_PATH_VALUE}"
     LEMONADE_CONTAINER_API_BASE_VALUE="$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${LEMONADE_CONTAINER_BASE_URL_VALUE}${LEMONADE_API_BASE_PATH_VALUE}"; else echo "http://llama-server:8080/api/v1"; fi)"
+    LEMONADE_MODEL_VALUE=""
+    if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then
+        LEMONADE_MODEL_VALUE="$(_env_get LEMONADE_MODEL "${LEMONADE_MODEL:-}")"
+        if [[ -z "$LEMONADE_MODEL_VALUE" ]]; then
+            if LEMONADE_MODEL_VALUE="$(_phase06_discover_lemonade_model "$LEMONADE_API_BASE_VALUE")"; then
+                ai_ok "Detected existing Lemonade model: ${LEMONADE_MODEL_VALUE}"
+            elif [[ -n "${GGUF_FILE:-}" ]]; then
+                LEMONADE_MODEL_VALUE="extra.${GGUF_FILE}"
+                warn "Could not auto-detect a Lemonade model from ${LEMONADE_API_BASE_VALUE}/models; using ${LEMONADE_MODEL_VALUE}. Phase 12 will verify the route before declaring install success."
+            else
+                warn "Could not auto-detect a Lemonade model from ${LEMONADE_API_BASE_VALUE}/models. Set LEMONADE_MODEL to the id returned by that endpoint."
+            fi
+        fi
+        LEMONADE_MODEL="$LEMONADE_MODEL_VALUE"
+    fi
     LIVEKIT_SECRET=$(_env_get LIVEKIT_API_SECRET "$(openssl rand -base64 32 2>/dev/null || head -c 32 /dev/urandom | base64)")
     DASHBOARD_API_KEY=$(_env_get DASHBOARD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
     DREAM_AGENT_KEY=$(_env_get DREAM_AGENT_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
@@ -545,7 +620,7 @@ LEMONADE_EXTERNAL=${LEMONADE_EXTERNAL_VALUE}
 LEMONADE_BASE_URL=${LEMONADE_BASE_URL_VALUE}
 LEMONADE_CONTAINER_BASE_URL=${LEMONADE_CONTAINER_BASE_URL_VALUE}
 LEMONADE_API_BASE_PATH=${LEMONADE_API_BASE_PATH_VALUE}
-LEMONADE_MODEL=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${LEMONADE_MODEL:-${LLM_MODEL_VALUE}}"; else echo "${LEMONADE_MODEL:-}"; fi)
+LEMONADE_MODEL=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${LEMONADE_MODEL_VALUE:-}"; else echo "${LEMONADE_MODEL:-}"; fi)
 
 #=== Cloud API Keys ===
 ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
@@ -804,7 +879,7 @@ ENV_EOF
         fi
         _lemonade_model_id=""
         if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then
-            _lemonade_model_id="${LEMONADE_MODEL:-${LLM_MODEL_VALUE:-default}}"
+            _lemonade_model_id="${LEMONADE_MODEL_VALUE:-}"
         fi
         # Pass chat_template_kwargs.enable_thinking=false to Lemonade so Qwen3
         # thinking-mode is OFF by default for every client. Perplexica and any

--- a/dream-server/installers/phases/08-images.sh
+++ b/dream-server/installers/phases/08-images.sh
@@ -27,8 +27,14 @@ fi
 # Format: "image|friendly_name"
 PULL_LIST=()
 if [[ "$GPU_BACKEND" == "amd" ]]; then
-    _lemonade_image="${LEMONADE_SERVER_IMAGE:-${BACKEND_LEMONADE_CONTAINER_IMAGE:-ghcr.io/lemonade-sdk/lemonade-server:v10.2.0}}"
-    PULL_LIST+=("${_lemonade_image}|LEMONADE — downloading the brain (AMD ROCm)")
+    case "${LEMONADE_EXTERNAL:-false}" in
+        true|TRUE|1|yes|YES|on|ON) _lemonade_external=true ;;
+        *) _lemonade_external=false ;;
+    esac
+    if [[ "$_lemonade_external" != "true" ]]; then
+        _lemonade_image="${LEMONADE_SERVER_IMAGE:-${BACKEND_LEMONADE_CONTAINER_IMAGE:-ghcr.io/lemonade-sdk/lemonade-server:v10.2.0}}"
+        PULL_LIST+=("${_lemonade_image}|LEMONADE — downloading the brain (AMD ROCm)")
+    fi
     [[ "$ENABLE_COMFYUI" == "true" ]] && PULL_LIST+=("ignatberesnev/comfyui-gfx1151:v0.2|COMFYUI — image generation engine (gfx1151)")
 elif [[ "$GPU_BACKEND" == "cpu" ]]; then
     PULL_LIST+=("${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b8248}|LLAMA-SERVER — downloading the brain (CPU)")

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -123,12 +123,51 @@ _phase12_external_lemonade() {
     [[ "${external,,}" == "true" ]] || [[ "${mode,,}" == "lemonade" && "${managed,,}" == "false" ]]
 }
 
+_phase12_verify_external_lemonade_completion() {
+    local litellm_port="${SERVICE_PORTS[litellm]:-4000}"
+    local litellm_key="${LITELLM_KEY:-$(_phase12_env_get LITELLM_KEY "")}"
+    local model="${LEMONADE_MODEL:-$(_phase12_env_get LEMONADE_MODEL default)}"
+    [[ -n "$model" ]] || model="default"
+    local auth_header=()
+    [[ -n "$litellm_key" ]] && auth_header=(-H "Authorization: Bearer ${litellm_key}")
+    local body response
+    body='{"model":"default","messages":[{"role":"user","content":"Reply with exactly OK. /no_think"}],"max_tokens":16,"temperature":0,"stream":false}'
+
+    ai "Verifying external Lemonade completion route through LiteLLM..."
+    response="$(curl -sS --max-time 180 -X POST "http://127.0.0.1:${litellm_port}/v1/chat/completions" \
+        "${auth_header[@]}" \
+        -H "Content-Type: application/json" \
+        -d "$body" 2>&1)" || {
+        printf "  ${RED}ERR${NC} External Lemonade completion failed\n"
+        ai_warn "LiteLLM could not complete through external Lemonade (model: ${model})."
+        ai_warn "Check that Lemonade is reachable from Docker containers, is bound to 0.0.0.0 on trusted hosts, and that LEMONADE_MODEL matches /api/v1/models."
+        printf '%s\n' "$response" >> "$LOG_FILE"
+        return 1
+    }
+
+    if printf '%s\n' "$response" | grep -Eq '"content"[[:space:]]*:[[:space:]]*"[^"]+'; then
+        printf "  ${BGRN}OK${NC} External Lemonade completion route healthy\n"
+        return 0
+    fi
+
+    printf "  ${RED}ERR${NC} External Lemonade returned no assistant content\n"
+    ai_warn "LiteLLM reached external Lemonade but did not receive non-empty assistant content (model: ${model})."
+    printf '%s\n' "$response" >> "$LOG_FILE"
+    return 1
+}
+
 # Core service health checks with adaptive timeouts.
 # Cloud mode does not launch local llama-server; LiteLLM/external APIs are the
 # LLM surface, so do not wait on a container that intentionally is not running.
 if [[ "${DREAM_MODE:-local}" == "cloud" ]] || _phase12_external_lemonade; then
     dream_progress 86 "health" "Waiting for LiteLLM gateway"
     _check_health "LiteLLM" "http://127.0.0.1:${SERVICE_PORTS[litellm]:-4000}${SERVICE_HEALTH[litellm]:-/health/readiness}" 60 10 "$(sr_container litellm)"
+    if _phase12_external_lemonade; then
+        dream_progress 87 "health" "Verifying external Lemonade route"
+        if ! _phase12_verify_external_lemonade_completion; then
+            exit 1
+        fi
+    fi
 else
     # Format: _check_health "name" "url" max_attempts timeout_per_request
     # llama-server: 150 attempts * adaptive backoff (2s->8s) = up to ~20 minutes (model loading can be slow)

--- a/dream-server/tests/contracts/test-external-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-external-lemonade-contracts.sh
@@ -32,6 +32,26 @@ grep -q 'openai/Qwen3-0.6B-GGUF' <<<"$rendered" \
 grep -q 'host.docker.internal:13305/api/v1' <<<"$rendered" \
   || { echo "[FAIL] renderer must use supplied Lemonade API base"; exit 1; }
 
+echo "[contract] installer discovers external Lemonade model and avoids stale fallbacks"
+grep -q '_phase06_discover_lemonade_model' installers/phases/06-directories.sh \
+  || { echo "[FAIL] phase 06 must discover the model served by external Lemonade"; exit 1; }
+if grep -q 'LLM_MODEL_VALUE' installers/phases/06-directories.sh; then
+  echo "[FAIL] phase 06 must not reference undefined LLM_MODEL_VALUE"
+  exit 1
+fi
+grep -q 'LEMONADE_MODEL_VALUE' installers/phases/06-directories.sh \
+  || { echo "[FAIL] phase 06 must write a resolved LEMONADE_MODEL value"; exit 1; }
+
+echo "[contract] external Lemonade does not pull managed Lemonade image"
+grep -q '_lemonade_external' installers/phases/08-images.sh \
+  || { echo "[FAIL] phase 08 must skip managed Lemonade image pulls in external mode"; exit 1; }
+
+echo "[contract] external Lemonade install verifies real completion"
+grep -q '_phase12_verify_external_lemonade_completion' installers/phases/12-health.sh \
+  || { echo "[FAIL] phase 12 must verify a real external Lemonade completion"; exit 1; }
+grep -q '/v1/chat/completions' installers/phases/12-health.sh \
+  || { echo "[FAIL] phase 12 completion check must call the LiteLLM chat route"; exit 1; }
+
 echo "[contract] resolver selects cloud + external overlay instead of managed AMD overlay"
 resolved="$(LEMONADE_EXTERNAL=true DREAM_MODE=lemonade \
   ./scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" --dream-mode lemonade --gpu-backend amd --tier SH_LARGE --env)"

--- a/dream-server/tests/contracts/test-external-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-external-lemonade-contracts.sh
@@ -52,6 +52,14 @@ grep -q '_phase12_verify_external_lemonade_completion' installers/phases/12-heal
 grep -q '/v1/chat/completions' installers/phases/12-health.sh \
   || { echo "[FAIL] phase 12 completion check must call the LiteLLM chat route"; exit 1; }
 
+echo "[contract] external Lemonade preflight checks LiteLLM instead of managed llama-server"
+grep -q 'is_external_lemonade()' dream-preflight.sh \
+  || { echo "[FAIL] dream-preflight must detect external Lemonade mode"; exit 1; }
+grep -q 'LiteLLM external Lemonade gateway' dream-preflight.sh \
+  || { echo "[FAIL] dream-preflight must label the external Lemonade LiteLLM route"; exit 1; }
+grep -q 'dream-litellm' dream-preflight.sh \
+  || { echo "[FAIL] dream-preflight must check dream-litellm for external Lemonade"; exit 1; }
+
 echo "[contract] resolver selects cloud + external overlay instead of managed AMD overlay"
 resolved="$(LEMONADE_EXTERNAL=true DREAM_MODE=lemonade \
   ./scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" --dream-mode lemonade --gpu-backend amd --tier SH_LARGE --env)"

--- a/dream-server/tests/test-preflight.sh
+++ b/dream-server/tests/test-preflight.sh
@@ -120,9 +120,18 @@ else
     fail "Does not probe actual Docker port mapping"
 fi
 
+# 11. External Lemonade mode checks LiteLLM, not a managed llama-server container
+if grep -q 'is_external_lemonade()' "$PREFLIGHT" \
+   && grep -q 'LiteLLM external Lemonade gateway' "$PREFLIGHT" \
+   && grep -q 'dream-litellm' "$PREFLIGHT"; then
+    pass "External Lemonade preflight checks LiteLLM gateway"
+else
+    fail "External Lemonade preflight must not require managed dream-llama-server"
+fi
+
 # ── Runtime smoke test (no Docker required) ─────────────────────────────────
 
-# 11. Script runs to completion without unbound variable or syntax errors
+# 12. Script runs to completion without unbound variable or syntax errors
 #     (Services won't be up, so we expect exit 1 — that is correct behavior)
 set +e
 err_output=$(
@@ -141,7 +150,7 @@ else
     pass "Script runs without shell errors (exit $run_exit is expected)"
 fi
 
-# 12. Exit code is 0 or 1; never an unexpected crash code
+# 13. Exit code is 0 or 1; never an unexpected crash code
 if [[ "$run_exit" -eq 0 ]] || [[ "$run_exit" -eq 1 ]]; then
     pass "Exit code is valid (0=pass, 1=fail): $run_exit"
 else


### PR DESCRIPTION
## Summary
- Auto-detect existing Lemonade on common ports (`13305`, then `8000`) when `--lemonade-url` is omitted.
- Auto-detect the first served Lemonade model from `/api/v1/models` and remove the stale `LLM_MODEL_VALUE` fallback.
- Skip pulling Dream's managed Lemonade image when external Lemonade owns inference.
- Add a Phase 12 real completion check through LiteLLM so broken external Lemonade routing fails clearly instead of finishing false-green.
- Update the Lemonade compatibility docs and README to match the new behavior.

## Why
External Lemonade users can have an already-running Lemonade runtime but still end up with a broken Dream LLM route if Dream guesses the wrong model, talks to the wrong port, or if Docker containers cannot reach the host Lemonade server. This makes that path explicit and verified.

## Validation
- `git diff --check origin/main...HEAD`
- `bash -n install-core.sh installers/phases/06-directories.sh installers/phases/08-images.sh installers/phases/12-health.sh tests/contracts/test-external-lemonade-contracts.sh`
- `DREAM_PYTHON_CMD=python bash tests/contracts/test-external-lemonade-contracts.sh`
- `python tests/test-render-runtime-configs.py`

## Notes
- Docker Desktop is not running on this Windows workstation, so I could not run `tests/fleet-external-lemonade-e2e.sh --mock` locally.
- The new Phase 12 check is the live-install receipt: it calls LiteLLM `/v1/chat/completions`, which forces LiteLLM inside Docker to reach the external Lemonade service and selected model.