### PR TITLE
fix(uninstall): use resolved compose stack

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -63,6 +63,9 @@ jobs:
       - name: Compose Failure Report Tests
         run: bash tests/test-compose-failure-report.sh
 
+      - name: Uninstall Compose Flags Tests
+        run: bash tests/test-uninstall-compose-flags.sh
+
       - name: Windows Compose Failure Report Tests
         run: bash tests/test-windows-compose-failure-report.sh
 

--- a/dream-server/FAQ.md
+++ b/dream-server/FAQ.md
@@ -187,11 +187,18 @@ docker compose logs llama-server
 
 ### How do I uninstall?
 ```bash
-docker compose down -v  # Stop and remove containers + volumes
-rm -rf ~/dream-server    # Remove installation directory (optional)
+cd ~/dream-server
+./dream-uninstall.sh --force
 ```
 
-This removes Docker containers and volumes. Add `-v` to also remove downloaded models and data.
+This uses Dream Server's saved `.compose-flags` stack, removes the matching containers and volumes, and then removes the install directory. Use `--keep-data` or `--keep-models` if you want to preserve local state.
+
+If you need to run Docker Compose manually, do not use bare `docker compose down`: Dream Server does not use a top-level `docker-compose.yml`. Use the saved flags instead:
+
+```bash
+cd ~/dream-server
+docker compose $(cat .compose-flags) down -v --remove-orphans
+```
 
 ---
 
@@ -302,13 +309,12 @@ docker compose logs > dream-server.log 2>&1
 
 ### How do I restart everything?
 ```bash
-docker compose down
-docker compose up -d
+dream restart
 ```
 
 Or restart specific services:
 ```bash
-docker compose restart llama-server
+dream restart llama-server
 ```
 
 ### "Connection refused" to API
@@ -388,7 +394,8 @@ docker volume prune
 
 Or remove everything (destructive):
 ```bash
-docker compose down -v
+cd ~/dream-server
+docker compose $(cat .compose-flags) down -v --remove-orphans
 ```
 
 ---

--- a/dream-server/docs/TROUBLESHOOTING.md
+++ b/dream-server/docs/TROUBLESHOOTING.md
@@ -214,8 +214,7 @@ docker network inspect dream-network
 
 ```bash
 cd ~/dream-server  # or wherever you installed
-docker compose down -v  # -v removes volumes
-rm -rf data/
+./dream-uninstall.sh --force
 ./install.sh
 ```
 

--- a/dream-server/docs/WINDOWS-INSTALL-WALKTHROUGH.md
+++ b/dream-server/docs/WINDOWS-INSTALL-WALKTHROUGH.md
@@ -250,7 +250,8 @@ Then: `docker compose up -d`
 ```powershell
 # Stop and remove containers
 cd $env:USERPROFILE\dream-server
-docker compose down -v
+$composeFlags = (Get-Content .compose-flags -Raw).Split(' ', [System.StringSplitOptions]::RemoveEmptyEntries)
+docker compose @composeFlags down -v --remove-orphans
 
 # Remove installation directory
 Remove-Item -Recurse -Force "$env:USERPROFILE\dream-server"

--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -20,6 +20,34 @@ log_ok()    { echo -e "${GREEN}[OK]${NC} $*"; }
 log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
+resolve_compose_flags() {
+    local flags=""
+
+    if [[ -f "$INSTALL_DIR/.compose-flags" ]]; then
+        flags="$(tr '\n' ' ' < "$INSTALL_DIR/.compose-flags" | xargs 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$flags" && -x "$INSTALL_DIR/scripts/resolve-compose-stack.sh" ]]; then
+        flags="$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
+            --script-dir "$INSTALL_DIR" \
+            --tier "${TIER:-1}" \
+            --gpu-backend "${GPU_BACKEND:-nvidia}" \
+            --gpu-count "${GPU_COUNT:-1}" \
+            --dream-mode "${DREAM_MODE:-local}" 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$flags" && -f "$INSTALL_DIR/docker-compose.base.yml" ]]; then
+        flags="-f docker-compose.base.yml"
+        case "${GPU_BACKEND:-}" in
+            amd|nvidia|intel|apple|arc|cpu)
+                [[ -f "$INSTALL_DIR/docker-compose.${GPU_BACKEND}.yml" ]] && flags="$flags -f docker-compose.${GPU_BACKEND}.yml"
+                ;;
+        esac
+    fi
+
+    printf '%s\n' "$flags"
+}
+
 KEEP_MODELS=false
 KEEP_DATA=false
 FORCE=false
@@ -76,6 +104,13 @@ $KEEP_MODELS && log_info "Keeping models (--keep-models)"
 $KEEP_DATA && log_info "Keeping user data (--keep-data)"
 echo ""
 
+if [[ -f "$INSTALL_DIR/.env" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    source "$INSTALL_DIR/.env" 2>/dev/null || true
+    set +a
+fi
+
 if [[ "$FORCE" != "true" ]]; then
     echo -e "${YELLOW}This will permanently remove Dream Server and its components.${NC}"
     read -rp "Are you sure? Type 'yes' to confirm: " confirm
@@ -90,8 +125,23 @@ fi
 log_info "Stopping Docker containers..."
 cd "$INSTALL_DIR" 2>/dev/null || true
 if command -v docker &>/dev/null; then
-    # Try docker compose first, fall back to finding dream containers
-    docker compose down --remove-orphans 2>/dev/null || true
+    # Use DreamServer's resolved compose stack. The repo does not ship a
+    # top-level docker-compose.yml, so bare `docker compose down` can fail with
+    # "no configuration file provided" even from the correct install dir.
+    compose_flags="$(resolve_compose_flags)"
+    compose_down_args=(down)
+    if [[ "$KEEP_DATA" != "true" ]]; then
+        compose_down_args+=(-v)
+    fi
+    compose_down_args+=(--remove-orphans)
+
+    if [[ -n "$compose_flags" ]]; then
+        read -ra compose_args <<< "$compose_flags"
+        docker compose "${compose_args[@]}" "${compose_down_args[@]}" 2>/dev/null || \
+            log_warn "docker compose cleanup failed; falling back to container/volume discovery"
+    else
+        log_warn "No compose files resolved; falling back to container/volume discovery"
+    fi
 
     # Remove any remaining dream-* containers
     dream_containers=$(docker ps -a --filter "name=dream-" --format "{{.Names}}" 2>/dev/null || true)
@@ -100,11 +150,15 @@ if command -v docker &>/dev/null; then
         echo "$dream_containers" | xargs docker rm -f 2>/dev/null || true
     fi
 
-    # Remove dream-specific Docker volumes
-    dream_volumes=$(docker volume ls --filter "name=dream" --format "{{.Name}}" 2>/dev/null || true)
-    if [[ -n "$dream_volumes" ]]; then
-        log_info "Removing Docker volumes..."
-        echo "$dream_volumes" | xargs docker volume rm 2>/dev/null || true
+    # Remove dream-specific Docker volumes unless data preservation was requested.
+    if [[ "$KEEP_DATA" == "true" ]]; then
+        log_info "Keeping Docker volumes (--keep-data)"
+    else
+        dream_volumes=$(docker volume ls --filter "name=dream" --format "{{.Name}}" 2>/dev/null || true)
+        if [[ -n "$dream_volumes" ]]; then
+            log_info "Removing Docker volumes..."
+            echo "$dream_volumes" | xargs docker volume rm 2>/dev/null || true
+        fi
     fi
 
     log_ok "Docker cleanup complete"

--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -105,10 +105,13 @@ $KEEP_DATA && log_info "Keeping user data (--keep-data)"
 echo ""
 
 if [[ -f "$INSTALL_DIR/.env" ]]; then
-    set -a
-    # shellcheck disable=SC1091
-    source "$INSTALL_DIR/.env" 2>/dev/null || true
-    set +a
+    if [[ -f "$INSTALL_DIR/lib/safe-env.sh" ]]; then
+        # shellcheck source=lib/safe-env.sh
+        . "$INSTALL_DIR/lib/safe-env.sh"
+        load_env_file "$INSTALL_DIR/.env"
+    else
+        log_warn "safe-env.sh not found; using uninstall defaults without loading .env"
+    fi
 fi
 
 if [[ "$FORCE" != "true" ]]; then

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -30,6 +30,7 @@ echo "[gate] contracts"
 bash tests/contracts/test-installer-contracts.sh
 bash tests/contracts/test-preflight-fixtures.sh
 bash tests/contracts/test-installer-hardening.sh
+bash tests/test-uninstall-compose-flags.sh
 "$PYTHON_CMD" tests/contracts/test-network-exposure-contracts.py
 
 echo "[gate] smoke"

--- a/dream-server/tests/test-uninstall-compose-flags.sh
+++ b/dream-server/tests/test-uninstall-compose-flags.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Regression checks for Dream Server uninstall compose cleanup.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/dream-uninstall.sh"
+TMP_DIR=""
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+make_stub_bin() {
+    local stub_dir="$1"
+
+    cat > "$stub_dir/docker" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+if [[ "${1:-}" == "ps" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "volume" && "${2:-}" == "ls" ]]; then
+    exit 0
+fi
+exit 0
+EOF
+    chmod +x "$stub_dir/docker"
+
+    cat > "$stub_dir/systemctl" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "is-enabled" ]]; then
+    exit 1
+fi
+exit 0
+EOF
+    chmod +x "$stub_dir/systemctl"
+
+    cat > "$stub_dir/sudo" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+    chmod +x "$stub_dir/sudo"
+
+    cat > "$stub_dir/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$stub_dir/pgrep"
+}
+
+make_install() {
+    local install_dir="$1"
+
+    mkdir -p "$install_dir/data"
+    cp "$TARGET" "$install_dir/dream-uninstall.sh"
+    touch "$install_dir/dream-cli"
+    touch "$install_dir/docker-compose.base.yml"
+    touch "$install_dir/docker-compose.cpu.yml"
+    printf '%s\n' '-f docker-compose.base.yml -f docker-compose.cpu.yml' > "$install_dir/.compose-flags"
+    printf '%s\n' 'GPU_BACKEND=cpu' > "$install_dir/.env"
+}
+
+run_uninstall() {
+    local install_dir="$1"
+    local home_dir="$2"
+    local stub_dir="$3"
+    shift 3
+
+    HOME="$home_dir" \
+    INSTALL_DIR="$install_dir" \
+    PATH="$stub_dir:$PATH" \
+    DOCKER_LOG="${DOCKER_LOG:?}" \
+        bash "$install_dir/dream-uninstall.sh" --force "$@" >/dev/null
+}
+
+main() {
+    [[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+    TMP_DIR="$(mktemp -d -t dream-uninstall-test-XXXXXX)"
+    trap 'rm -rf "$TMP_DIR"' EXIT
+
+    local stub_dir="$TMP_DIR/bin"
+    mkdir -p "$stub_dir"
+    make_stub_bin "$stub_dir"
+
+    local install_keep="$TMP_DIR/install-keep"
+    local home_keep="$TMP_DIR/home-keep"
+    local log_keep="$TMP_DIR/docker-keep.log"
+    mkdir -p "$home_keep"
+    make_install "$install_keep"
+    DOCKER_LOG="$log_keep" run_uninstall "$install_keep" "$home_keep" "$stub_dir" --keep-data
+
+    grep -qF 'compose -f docker-compose.base.yml -f docker-compose.cpu.yml down --remove-orphans' "$log_keep" \
+        || fail "uninstall must use saved .compose-flags for docker compose down"
+    if grep -qF 'down -v --remove-orphans' "$log_keep"; then
+        fail "--keep-data must not remove compose volumes with -v"
+    fi
+    pass "uninstall uses saved compose flags and preserves volumes with --keep-data"
+
+    local install_purge="$TMP_DIR/install-purge"
+    local home_purge="$TMP_DIR/home-purge"
+    local log_purge="$TMP_DIR/docker-purge.log"
+    mkdir -p "$home_purge"
+    make_install "$install_purge"
+    DOCKER_LOG="$log_purge" run_uninstall "$install_purge" "$home_purge" "$stub_dir"
+
+    grep -qF 'compose -f docker-compose.base.yml -f docker-compose.cpu.yml down -v --remove-orphans' "$log_purge" \
+        || fail "normal uninstall must remove compose volumes with -v"
+    pass "normal uninstall removes compose volumes"
+}
+
+main "$@"

--- a/dream-server/tests/test-uninstall-compose-flags.sh
+++ b/dream-server/tests/test-uninstall-compose-flags.sh
@@ -57,8 +57,9 @@ EOF
 make_install() {
     local install_dir="$1"
 
-    mkdir -p "$install_dir/data"
+    mkdir -p "$install_dir/data" "$install_dir/lib"
     cp "$TARGET" "$install_dir/dream-uninstall.sh"
+    cp "$ROOT_DIR/lib/safe-env.sh" "$install_dir/lib/safe-env.sh"
     touch "$install_dir/dream-cli"
     touch "$install_dir/docker-compose.base.yml"
     touch "$install_dir/docker-compose.cpu.yml"
@@ -81,6 +82,9 @@ run_uninstall() {
 
 main() {
     [[ -f "$TARGET" ]] || fail "missing $TARGET"
+    if grep -qF 'source "$INSTALL_DIR/.env"' "$TARGET"; then
+        fail "uninstall must load .env through lib/safe-env.sh, not source it"
+    fi
 
     TMP_DIR="$(mktemp -d -t dream-uninstall-test-XXXXXX)"
     trap 'rm -rf "$TMP_DIR"' EXIT
@@ -113,6 +117,21 @@ main() {
     grep -qF 'compose -f docker-compose.base.yml -f docker-compose.cpu.yml down -v --remove-orphans' "$log_purge" \
         || fail "normal uninstall must remove compose volumes with -v"
     pass "normal uninstall removes compose volumes"
+
+    local install_safe="$TMP_DIR/install-safe-env"
+    local home_safe="$TMP_DIR/home-safe-env"
+    local log_safe="$TMP_DIR/docker-safe-env.log"
+    mkdir -p "$home_safe"
+    make_install "$install_safe"
+    cat > "$install_safe/.env" <<'EOF'
+GPU_BACKEND=$(touch "$HOME/uninstall-env-sourced")
+EOF
+    DOCKER_LOG="$log_safe" run_uninstall "$install_safe" "$home_safe" "$stub_dir" --keep-data
+
+    if [[ -e "$home_safe/uninstall-env-sourced" ]]; then
+        fail "uninstall must not execute command substitutions from .env"
+    fi
+    pass "uninstall loads .env without executing shell substitutions"
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- make `dream-uninstall.sh` resolve Dream Server's actual compose stack before cleanup instead of calling bare `docker compose down`
- respect `--keep-data` by avoiding compose volume deletion and fallback volume cleanup
- update Linux/Windows uninstall docs to use the official uninstaller or saved `.compose-flags`
- add a regression test for compose-flag cleanup and `--keep-data` behavior

## Why
Dream Server does not ship a top-level `docker-compose.yml`; installs persist the resolved stack in `.compose-flags`. The documented/manual `docker compose down -v` path can fail with `no configuration file provided: not found` and leave users unsure which containers/volumes belong to Dream Server.

## Validation
- `bash -n dream-server/dream-uninstall.sh dream-server/tests/test-uninstall-compose-flags.sh`
- `bash dream-server/tests/test-uninstall-compose-flags.sh`
- `bash dream-server/tests/test-doc-links.sh`
- `git diff --check`