### PR TITLE
fix(installer): harden external Lemonade model and bind selection

### DIFF
--- a/dream-server/docs/LEMONADE-SDK-COMPAT.md
+++ b/dream-server/docs/LEMONADE-SDK-COMPAT.md
@@ -88,7 +88,8 @@ service.
 ## Model Selection
 
 Dream Server auto-detects the first model id returned by Lemonade's
-`/api/v1/models` endpoint and writes it to `LEMONADE_MODEL`.
+`/api/v1/models` endpoint that does not look like an image-generation model
+and writes it to `LEMONADE_MODEL`.
 
 Set `LEMONADE_MODEL` only if you want Dream Server to use a specific served
 model:
@@ -104,10 +105,15 @@ example:
 curl http://localhost:13305/api/v1/models
 ```
 
+Use a text/chat model for `LEMONADE_MODEL`. Image models such as Flux, SDXL, or
+Stable Diffusion can appear in Lemonade's model list, but they are not valid for
+Dream Server's chat/completions route.
+
 Phase 12 verifies the selected model with a real chat completion through
 LiteLLM. If Lemonade is reachable from the host but not from Docker containers,
-or if the selected model id is wrong, the installer fails there with a recovery
-hint instead of finishing with a broken chat path.
+if the selected model id is wrong, or if the selected model is an image/non-chat
+model, the installer fails there with a recovery hint instead of finishing with
+a broken chat path.
 
 ## Linux Docker Networking
 

--- a/dream-server/install-core.sh
+++ b/dream-server/install-core.sh
@@ -124,6 +124,8 @@ LEMONADE_BASE_URL="${LEMONADE_BASE_URL:-}"
 LEMONADE_API_KEY="${LEMONADE_API_KEY:-}"
 OFFLINE_MODE=false   # M1 integration: fully air-gapped operation
 NO_BOOTSTRAP=false  # Skip bootstrap fast-start, download full model in foreground
+BIND_ADDRESS_EXPLICIT=false
+[[ -n "${BIND_ADDRESS:-}" ]] && BIND_ADDRESS_EXPLICIT=true
 BIND_ADDRESS="${BIND_ADDRESS:-127.0.0.1}"
 SUMMARY_JSON_FILE="${SUMMARY_JSON_FILE:-}"
 
@@ -236,7 +238,7 @@ while [[ $# -gt 0 ]]; do
         --all) ENABLE_VOICE=true; ENABLE_WORKFLOWS=true; ENABLE_RAG=true; ENABLE_RECOMMENDED=true; ENABLE_HERMES=true; ENABLE_OPENCLAW=false; ENABLE_COMFYUI=true; ENABLE_APE=true; ENABLE_PERPLEXICA=true; ENABLE_PRIVACY_SHIELD=true; ENABLE_LANGFUSE=true; ENABLE_DREAM_PROXY=true; shift ;;
         --non-interactive) INTERACTIVE=false; shift ;;
         --offline) OFFLINE_MODE=true; shift ;;
-        --lan) BIND_ADDRESS="0.0.0.0"; shift ;;
+        --lan) BIND_ADDRESS="0.0.0.0"; BIND_ADDRESS_EXPLICIT=true; shift ;;
         --no-bootstrap) NO_BOOTSTRAP=true; shift ;;
         --summary-json) SUMMARY_JSON_FILE="$2"; shift 2 ;;
         -h|--help) usage ;;

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -36,38 +36,33 @@ if $INTERACTIVE && ! $DRY_RUN; then
 
     # Only show individual feature prompts for Custom installs
     if [[ "${INSTALL_CHOICE:-1}" == "3" ]]; then
+        _phase03_prompt_bool() {
+            local var_name="$1" prompt="$2" current="${!1:-false}" reply label
+            if [[ "$current" == "true" ]]; then
+                label="[Y/n]"
+            else
+                label="[y/N]"
+            fi
+            read -p "  ${prompt} ${label} " -r reply < /dev/tty
+            echo
+            case "$reply" in
+                [Yy]*) printf -v "$var_name" '%s' "true" ;;
+                [Nn]*) printf -v "$var_name" '%s' "false" ;;
+            esac
+        }
+
         # Explicitly set each flag from the user's answer — do NOT rely on
         # the pre-existing default. Previously these read 'reply || flag=true',
         # which only *set* the flag to true when the answer wasn't N and
         # never set it to false; combined with all defaults being true from
         # install-core.sh, pressing 'n' was a no-op.
-        read -p "  Enable voice (Whisper STT + Kokoro TTS)? [Y/n] " -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Nn]$ ]]; then ENABLE_VOICE=false; else ENABLE_VOICE=true; fi
-
-        read -p "  Enable n8n workflow automation? [Y/n] " -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Nn]$ ]]; then ENABLE_WORKFLOWS=false; else ENABLE_WORKFLOWS=true; fi
-
-        read -p "  Enable Qdrant vector database (for RAG)? [Y/n] " -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Nn]$ ]]; then ENABLE_RAG=false; else ENABLE_RAG=true; fi
-
-        read -p "  Enable Hermes Agent (default AI agent framework)? [Y/n] " -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Nn]$ ]]; then ENABLE_HERMES=false; else ENABLE_HERMES=true; fi
-
-        read -p "  Enable OpenClaw AI agent framework (DEPRECATED — Hermes replaces it)? [y/N] " -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then ENABLE_OPENCLAW=true; else ENABLE_OPENCLAW=false; fi
-
-        read -p "  Enable image generation (ComfyUI + SDXL Lightning, ~6.5GB)? [Y/n] " -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Nn]$ ]]; then ENABLE_COMFYUI=false; else ENABLE_COMFYUI=true; fi
-
-        read -p "  Enable Langfuse (LLM observability + telemetry, ~500MB)? [y/N] " -r < /dev/tty
-        echo
-        if [[ $REPLY =~ ^[Yy]$ ]]; then ENABLE_LANGFUSE=true; else ENABLE_LANGFUSE=false; fi
+        _phase03_prompt_bool ENABLE_VOICE "Enable voice (Whisper STT + Kokoro TTS)?"
+        _phase03_prompt_bool ENABLE_WORKFLOWS "Enable n8n workflow automation?"
+        _phase03_prompt_bool ENABLE_RAG "Enable Qdrant vector database (for RAG)?"
+        _phase03_prompt_bool ENABLE_HERMES "Enable Hermes Agent (default AI agent framework)?"
+        _phase03_prompt_bool ENABLE_OPENCLAW "Enable OpenClaw AI agent framework (DEPRECATED - Hermes replaces it)?"
+        _phase03_prompt_bool ENABLE_COMFYUI "Enable image generation (ComfyUI + SDXL Lightning, ~6.5GB)?"
+        _phase03_prompt_bool ENABLE_LANGFUSE "Enable Langfuse (LLM observability + telemetry, ~500MB)?"
 
         # Warn if ComfyUI enabled on low-tier hardware
         if [[ "$ENABLE_COMFYUI" == "true" ]]; then

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -292,13 +292,29 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         [[ -n "$py" ]] || py="python3"
         if command -v "$py" >/dev/null 2>&1; then
             printf '%s' "$json" | "$py" -c 'import json,sys
+IMAGE_MARKERS = (
+    "flux", "stable-diffusion", "sdxl", "sd-", "diffusion",
+    "dall-e", "image", "img2img", "txt2img", "comfy", "kolors",
+)
+
+def looks_non_chat(model_id):
+    lowered = (model_id or "").lower()
+    return any(marker in lowered for marker in IMAGE_MARKERS)
+
 try:
     data=json.load(sys.stdin).get("data", [])
+    fallback = ""
     for item in data:
         model_id=item.get("id") if isinstance(item, dict) else None
         if model_id:
+            fallback = fallback or model_id
+            if looks_non_chat(model_id):
+                continue
             print(model_id)
             raise SystemExit(0)
+    if fallback:
+        print(fallback)
+        raise SystemExit(0)
 except Exception:
     pass
 raise SystemExit(1)' 2>/dev/null && return 0
@@ -503,8 +519,13 @@ raise SystemExit(1)' 2>/dev/null && return 0
     COMFYUI_CPU_LIMIT=$(_select_service_cpu_limit COMFYUI_CPU_LIMIT "16.0" "$_docker_available_cpus")
     COMFYUI_CPU_RESERVATION=$(_select_service_cpu_reservation COMFYUI_CPU_RESERVATION "2.0" "$COMFYUI_CPU_LIMIT")
 
-    # Network binding (--lan sets 0.0.0.0; default is localhost-only)
-    BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
+    # Network binding (--lan or exported BIND_ADDRESS wins over a stale .env;
+    # otherwise preserve the existing .env value and default to localhost-only).
+    if [[ "${BIND_ADDRESS_EXPLICIT:-false}" == "true" && -n "${BIND_ADDRESS:-}" ]]; then
+        BIND_ADDRESS="${BIND_ADDRESS}"
+    else
+        BIND_ADDRESS=$(_env_get BIND_ADDRESS "${BIND_ADDRESS:-127.0.0.1}")
+    fi
 
     # Host LAN IP — only meaningful when BIND_ADDRESS=0.0.0.0. Some services
     # (e.g. openclaw) need to know the host's LAN address so the Control UI

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -123,6 +123,19 @@ _phase12_external_lemonade() {
     [[ "${external,,}" == "true" ]] || [[ "${mode,,}" == "lemonade" && "${managed,,}" == "false" ]]
 }
 
+_phase12_model_looks_non_chat() {
+    local model_lc="${1,,}"
+    [[ "$model_lc" == *flux* ]] \
+        || [[ "$model_lc" == *stable-diffusion* ]] \
+        || [[ "$model_lc" == *sdxl* ]] \
+        || [[ "$model_lc" == *diffusion* ]] \
+        || [[ "$model_lc" == *dall-e* ]] \
+        || [[ "$model_lc" == *image* ]] \
+        || [[ "$model_lc" == *img2img* ]] \
+        || [[ "$model_lc" == *txt2img* ]] \
+        || [[ "$model_lc" == *comfy* ]]
+}
+
 _phase12_verify_external_lemonade_completion() {
     local litellm_port="${SERVICE_PORTS[litellm]:-4000}"
     local litellm_key="${LITELLM_KEY:-$(_phase12_env_get LITELLM_KEY "")}"
@@ -152,6 +165,11 @@ _phase12_verify_external_lemonade_completion() {
 
     printf "  ${RED}ERR${NC} External Lemonade returned no assistant content\n"
     ai_warn "LiteLLM reached external Lemonade but did not receive non-empty assistant content (model: ${model})."
+    if _phase12_model_looks_non_chat "$model"; then
+        ai_warn "The selected Lemonade model looks like an image/non-chat model. DreamServer needs a text/chat model for the LLM route."
+    fi
+    ai_warn "Run: curl ${LEMONADE_BASE_URL:-$(_phase12_env_get LEMONADE_BASE_URL http://127.0.0.1:13305)}${LEMONADE_API_BASE_PATH:-$(_phase12_env_get LEMONADE_API_BASE_PATH /api/v1)}/models"
+    ai_warn "Then rerun with LEMONADE_MODEL=<chat-model-id> ./install.sh --use-existing-lemonade ..."
     printf '%s\n' "$response" >> "$LOG_FILE"
     return 1
 }

--- a/dream-server/tests/contracts/test-external-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-external-lemonade-contracts.sh
@@ -35,12 +35,20 @@ grep -q 'host.docker.internal:13305/api/v1' <<<"$rendered" \
 echo "[contract] installer discovers external Lemonade model and avoids stale fallbacks"
 grep -q '_phase06_discover_lemonade_model' installers/phases/06-directories.sh \
   || { echo "[FAIL] phase 06 must discover the model served by external Lemonade"; exit 1; }
+grep -q 'IMAGE_MARKERS' installers/phases/06-directories.sh \
+  || { echo "[FAIL] phase 06 must avoid auto-selecting obvious image models for the chat route"; exit 1; }
 if grep -q 'LLM_MODEL_VALUE' installers/phases/06-directories.sh; then
   echo "[FAIL] phase 06 must not reference undefined LLM_MODEL_VALUE"
   exit 1
 fi
 grep -q 'LEMONADE_MODEL_VALUE' installers/phases/06-directories.sh \
   || { echo "[FAIL] phase 06 must write a resolved LEMONADE_MODEL value"; exit 1; }
+
+echo "[contract] explicit LAN binding overrides stale env during reinstall"
+grep -q 'BIND_ADDRESS_EXPLICIT' install-core.sh \
+  || { echo "[FAIL] install-core must track explicit --lan/BIND_ADDRESS"; exit 1; }
+grep -q 'BIND_ADDRESS_EXPLICIT' installers/phases/06-directories.sh \
+  || { echo "[FAIL] phase 06 must let explicit BIND_ADDRESS override stale .env"; exit 1; }
 
 echo "[contract] external Lemonade does not pull managed Lemonade image"
 grep -q '_lemonade_external' installers/phases/08-images.sh \
@@ -51,6 +59,8 @@ grep -q '_phase12_verify_external_lemonade_completion' installers/phases/12-heal
   || { echo "[FAIL] phase 12 must verify a real external Lemonade completion"; exit 1; }
 grep -q '/v1/chat/completions' installers/phases/12-health.sh \
   || { echo "[FAIL] phase 12 completion check must call the LiteLLM chat route"; exit 1; }
+grep -q '_phase12_model_looks_non_chat' installers/phases/12-health.sh \
+  || { echo "[FAIL] phase 12 must explain image/non-chat Lemonade model failures"; exit 1; }
 
 echo "[contract] external Lemonade preflight checks LiteLLM instead of managed llama-server"
 grep -q 'is_external_lemonade()' dream-preflight.sh \


### PR DESCRIPTION
## Summary

Fixes three installer edge cases surfaced by an external Lemonade install using:

```bash
./install.sh --use-existing-lemonade --no-voice --no-comfyui
```

The reported install reached LiteLLM and the external Lemonade server, but failed Phase 12 with no assistant content because the selected Lemonade model was `Flux-2-Klein-9B-GGUF`, which is an image-generation model rather than a chat/text model. The same report also noted that a requested LAN bind still came up localhost-only after install.

## What changed

- External Lemonade model auto-detection now skips obvious image-generation model ids such as Flux/SDXL/Stable Diffusion when another model is available from `/api/v1/models`.
- Phase 12 now gives a specific recovery hint when the selected Lemonade model looks like an image/non-chat model and the LiteLLM chat completion returns no assistant content.
- `--lan` and exported `BIND_ADDRESS=0.0.0.0` are now treated as explicit install-time choices and can override a stale existing `.env` value during reinstall.
- Custom feature prompts now reflect the current flag value, so `--no-voice` and `--no-comfyui` show `[y/N]` instead of visually defaulting back to yes.
- Lemonade compatibility docs now call out that `LEMONADE_MODEL` must be a text/chat model, not an image model.

## Why

This was easy to misread as a ComfyUI problem because the selected model was Flux and the user had disabled ComfyUI. The actual failing path is the LLM chat route: DreamServer verifies `/v1/chat/completions` through LiteLLM, and an image model can be reachable while still returning no assistant message content.

The bind behavior is separate but came from the same install report. On reruns, Phase 06 preserved `BIND_ADDRESS` from an existing `.env` before considering the current explicit `--lan`/environment request, so the dashboard could remain localhost-only even after the operator opted into LAN binding.

## Validation

- `bash -n dream-server/install-core.sh dream-server/installers/phases/03-features.sh dream-server/installers/phases/06-directories.sh dream-server/installers/phases/12-health.sh dream-server/tests/contracts/test-external-lemonade-contracts.sh`
- `bash dream-server/tests/contracts/test-external-lemonade-contracts.sh`
- `bash dream-server/tests/test-network-timeouts.sh`
- `bash dream-server/tests/test-doc-links.sh`
- `bash dream-server/tests/test-bind-address-sweep.sh`
- `bash dream-server/tests/contracts/test-installer-hardening.sh`
- `git diff --check`

Local note: `tests/smoke/installer-env-smoke.sh` passed through env generation, schema validation, dependency validation, compose validation, and the first function-resolution check
