### PR TITLE
fix(cli): tolerate UID in safe env loading

### DIFF
--- a/dream-server/lib/safe-env.sh
+++ b/dream-server/lib/safe-env.sh
@@ -29,6 +29,10 @@ load_env_file() {
         key="${key%"${key##*[![:space:]]}"}"
         [[ -z "$key" ]] && continue
         [[ "$key" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]] || continue
+        # Bash exposes UID as a readonly shell variable. A .env line such as
+        # UID=1000 is valid for Docker Compose, but exporting it here aborts
+        # lifecycle commands under set -e before they can reach compose.
+        [[ "$key" == "UID" ]] && continue
         # Strip optional surrounding quotes and one leading space
         value="${value# }"
         value="${value%\"}"

--- a/dream-server/tests/test-safe-env.sh
+++ b/dream-server/tests/test-safe-env.sh
@@ -101,5 +101,15 @@ load_model_selector_env_from_output < <(printf '%s\n' 'LLM_MODEL="qwen-test"' 'E
 [[ -z "${EVIL_SELECTOR_KEY:-}" ]] || fail "EVIL_SELECTOR_KEY should not be loaded"
 pass "model selector loader is allowlisted"
 
+echo "Test 10: load_env_file skips Bash readonly UID"
+cat > "$tmpdir/.env-readonly" << 'EOF'
+UID=12345
+AFTER_READONLY_UID=still_loads
+EOF
+load_env_file "$tmpdir/.env-readonly"
+[[ "${UID}" != "12345" ]] || fail "UID should not be overwritten"
+[[ "${AFTER_READONLY_UID:-}" == "still_loads" ]] || fail "load_env_file stopped after readonly UID"
+pass "load_env_file tolerates UID from .env"
+
 echo ""
 echo "All safe-env tests passed."


### PR DESCRIPTION
## Summary
- skip Bash's readonly `UID` variable when loading `.env` through `lib/safe-env.sh`
- keep later `.env` keys loading normally after a `UID=...` line
- add a regression test for lifecycle commands that load `.env` before reaching Docker Compose

## Why
A user reported `dream restart` failing with:

```text
/home/phil/dream-server/lib/safe-env.sh: line 38: UID: readonly variable
```

`UID=...` is a valid Docker Compose-style setting in `.env`, but Bash exposes `UID` as a readonly shell variable. Exporting it from `load_env_file` can abort `dream restart`, `dream doctor`, and other lifecycle commands under `set -e` before they can reach compose. Docker Compose can still read `UID` from `.env`; the shell loader just should not try to re-export it.

The follow-up `sudo dream restart` failure is separate: sudo changes `$HOME` to `/root`, so the CLI looks for `/root/dream-server` unless `DREAM_HOME` is preserved or set explicitly.

## Validation
- `bash -n dream-server/lib/safe-env.sh dream-server/tests/test-safe-env.sh`
- `bash dream-server/tests/test-safe-env.sh`
- `git diff --check`