### PR TITLE
fix(update): resolve runtime compose stacks in health checks

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -80,15 +80,42 @@ jobs:
       - name: Install checkout prerequisites (distro-aware)
         working-directory: /
         run: |
+          retry() {
+            attempt=1
+            max=3
+            delay=15
+            until "$@"; do
+              status=$?
+              if [ "$attempt" -ge "$max" ]; then
+                return "$status"
+              fi
+              echo "Command failed (attempt ${attempt}/${max}): $*"
+              echo "Retrying in ${delay}s..."
+              sleep "$delay"
+              attempt=$((attempt + 1))
+            done
+          }
+
+          prepare_pacman_keyrings() {
+            command -v pacman-key >/dev/null 2>&1 || return 0
+            pacman-key --init || true
+            for ring in archlinux manjaro cachyos; do
+              if [ -f "/usr/share/pacman/keyrings/${ring}.gpg" ]; then
+                pacman-key --populate "$ring" || true
+              fi
+            done
+          }
+
           if command -v apt-get &>/dev/null; then
             apt-get update -qq && apt-get install -y -qq ca-certificates git curl
           elif command -v dnf &>/dev/null; then
             dnf install -y -q ca-certificates git curl-minimal
           elif command -v pacman &>/dev/null; then
-            pacman -Syu --noconfirm --needed ca-certificates git curl
+            prepare_pacman_keyrings
+            retry pacman -Syyu --noconfirm --needed ca-certificates git curl
           elif command -v zypper &>/dev/null; then
-            zypper --non-interactive refresh
-            zypper --non-interactive install ca-certificates git curl
+            retry zypper --non-interactive --gpg-auto-import-keys refresh
+            retry zypper --non-interactive install -y ca-certificates git curl
           fi
 
       - name: Checkout

--- a/dream-server/dream-update.sh
+++ b/dream-server/dream-update.sh
@@ -57,6 +57,88 @@ get_current_version() {
     fi
 }
 
+env_file_value() {
+    local key="$1"
+    [[ -f "${INSTALL_DIR}/.env" ]] || return 0
+    awk -F= -v key="$key" '
+        $1 == key {
+            value = substr($0, index($0, "=") + 1)
+            gsub(/\r$/, "", value)
+            gsub(/^["'\'']|["'\'']$/, "", value)
+            print value
+            exit
+        }
+    ' "${INSTALL_DIR}/.env" 2>/dev/null || true
+}
+
+compose_flags_files_exist() {
+    local flags="$1"
+    local prev="" tok
+    for tok in $flags; do
+        if [[ "$prev" == "-f" ]]; then
+            if [[ "$tok" = /* ]]; then
+                [[ -f "$tok" ]] || return 1
+            else
+                [[ -f "${INSTALL_DIR}/${tok}" ]] || return 1
+            fi
+        fi
+        prev="$tok"
+    done
+    return 0
+}
+
+resolve_compose_flags() {
+    local cached=""
+    if [[ -f "${INSTALL_DIR}/.compose-flags" ]]; then
+        cached="$(tr '\n' ' ' < "${INSTALL_DIR}/.compose-flags" | xargs 2>/dev/null || true)"
+        if [[ -n "$cached" ]] && compose_flags_files_exist "$cached"; then
+            echo "$cached"
+            return 0
+        fi
+        log_warn "Cached compose flags are missing or stale; trying dynamic compose resolution." >&2
+    fi
+
+    local gpu_backend tier gpu_count dream_mode
+    gpu_backend="$(env_file_value GPU_BACKEND)"
+    tier="$(env_file_value TIER)"
+    gpu_count="$(env_file_value GPU_COUNT)"
+    dream_mode="$(env_file_value DREAM_MODE)"
+
+    local resolved=""
+    if [[ -x "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" ]]; then
+        resolved=$(bash "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" \
+            --script-dir "$INSTALL_DIR" \
+            --tier "${tier:-1}" \
+            --gpu-backend "${gpu_backend:-nvidia}" \
+            --gpu-count "${gpu_count:-1}" \
+            --dream-mode "${dream_mode:-local}" | tail -1) || resolved=""
+        if [[ -n "$resolved" ]] && compose_flags_files_exist "$resolved"; then
+            echo "$resolved"
+            return 0
+        fi
+    fi
+
+    if [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
+        echo "-f docker-compose.yml"
+        return 0
+    fi
+
+    if [[ -f "${INSTALL_DIR}/docker-compose.base.yml" ]]; then
+        local fallback="-f docker-compose.base.yml"
+        case "${gpu_backend:-}" in
+            nvidia|amd|cpu|apple|intel|sycl)
+                if [[ -f "${INSTALL_DIR}/docker-compose.${gpu_backend}.yml" ]]; then
+                    fallback="$fallback -f docker-compose.${gpu_backend}.yml"
+                fi
+                ;;
+        esac
+        echo "$fallback"
+        return 0
+    fi
+
+    return 1
+}
+
 # Semver compare: returns 0 if equal, 1 if v1 > v2, 2 if v1 < v2
 semver_compare() {
     local v1="${1#v}"
@@ -512,39 +594,17 @@ cmd_update() {
     local snap_dir
     snap_dir=$(snapshot_pre_update "$timestamp")
 
-    # Read GPU config from .env for compose resolution
-    local _update_gpu_backend _update_tier _update_gpu_count
-    _update_gpu_backend=$(grep '^GPU_BACKEND=' "${INSTALL_DIR}/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
-    _update_tier=$(grep '^TIER=' "${INSTALL_DIR}/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
-    _update_gpu_count=$(grep '^GPU_COUNT=' "${INSTALL_DIR}/.env" 2>/dev/null | cut -d= -f2 | tr -d '"' || echo "")
-
     # Resolve compose flags once — used in restart and rollback paths.
-    # --gpu-count gates the multigpu-{backend}.yml overlay; without it,
-    # restarts after update would silently drop multi-GPU plumbing.
     local compose_flags=""
-    if [[ -x "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" ]]; then
-        compose_flags=$(bash "${INSTALL_DIR}/scripts/resolve-compose-stack.sh" \
-            --script-dir "$INSTALL_DIR" \
-            --tier "${_update_tier:-1}" \
-            --gpu-backend "${_update_gpu_backend:-nvidia}" \
-            --gpu-count "${_update_gpu_count:-1}" | tail -1)
-    fi
-    if [[ -n "${compose_flags}" ]]; then
-        local all_exist=true
-        for flag_file in $(echo "$compose_flags" | grep -o -- '-f [^ ]*' | cut -d' ' -f2); do
-            if [[ ! -f "${INSTALL_DIR}/${flag_file}" ]]; then
-                log_warn "Compose file not found: ${flag_file} — falling back to docker-compose.yml"
-                all_exist=false
-                break
-            fi
-        done
-        [[ "$all_exist" == "true" ]] || compose_flags=""
-    fi
+    compose_flags=$(resolve_compose_flags 2>/dev/null || true)
 
     # ── Step 2: pull latest changes ───────────────────────────────────────────
     log_info "Pulling latest changes..."
     if [[ ! -d "${INSTALL_DIR}/.git" ]]; then
-        log_error "Not a git repository. Manual update required."
+        log_error "This install directory is not a git repository, so dream-update.sh cannot pull source code."
+        log_info "Install path: ${INSTALL_DIR}"
+        log_info "For routine runtime/image updates, run: cd \"${INSTALL_DIR}\" && ./dream-cli update"
+        log_info "For source-code updates, reinstall or restore this directory as a git-backed DreamServer checkout."
         return 1
     fi
     cd "$INSTALL_DIR"
@@ -768,22 +828,40 @@ cmd_health() {
     
     # Check containers
     cd "$INSTALL_DIR"
-    local compose_cmd="docker compose"
-    if ! $compose_cmd version &>/dev/null; then
-        compose_cmd="docker-compose"
+    local -a compose_cmd
+    if docker compose version &>/dev/null; then
+        compose_cmd=(docker compose)
+    elif command -v docker-compose >/dev/null 2>&1; then
+        compose_cmd=(docker-compose)
+    else
+        log_error "Docker Compose is not available"
+        return 1
+    fi
+
+    local compose_flags=""
+    local -a compose_args=()
+    compose_flags=$(resolve_compose_flags 2>/dev/null || true)
+    if [[ -n "$compose_flags" ]]; then
+        read -ra compose_args <<< "$compose_flags"
     fi
     
     local services
-    services=$($compose_cmd ps --services 2>/dev/null || echo "")
+    services=$("${compose_cmd[@]}" "${compose_args[@]}" ps --services 2>/dev/null || echo "")
     
     if [[ -z "$services" ]]; then
-        log_warn "No services defined in docker-compose"
-        return 0
+        if [[ -n "$compose_flags" ]]; then
+            log_warn "No services found for resolved compose stack: ${compose_flags}"
+        else
+            log_warn "No compose stack could be resolved for this install"
+        fi
+        return 1
     fi
     
     for service in $services; do
         local status
-        status=$($compose_cmd ps --format json "$service" 2>/dev/null | jq -r '.[0].State // .State // "unknown"' 2>/dev/null || echo "unknown")
+        status=$("${compose_cmd[@]}" "${compose_args[@]}" ps --format json "$service" 2>/dev/null \
+            | jq -r 'if type == "array" then (.[0].State // "unknown") else (.State // "unknown") end' 2>/dev/null \
+            || echo "unknown")
         
         if [[ "$status" == "running" ]]; then
             log_ok "Service ${service}: running"
@@ -794,7 +872,9 @@ cmd_health() {
     done
     
     # Check dashboard API health endpoint
-    local dashboard_api_port="${DASHBOARD_API_PORT:-3002}"
+    local dashboard_api_port="${DASHBOARD_API_PORT:-}"
+    [[ -n "$dashboard_api_port" ]] || dashboard_api_port="$(env_file_value DASHBOARD_API_PORT)"
+    dashboard_api_port="${dashboard_api_port:-3002}"
     if curl -sf "http://127.0.0.1:${dashboard_api_port}/health" &>/dev/null; then
         log_ok "Dashboard API: healthy"
     elif curl -sf "http://127.0.0.1:${dashboard_api_port}/api/status" &>/dev/null; then
@@ -804,7 +884,10 @@ cmd_health() {
     fi
     
     # Check llama-server health
-    local llama_server_port="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-11434}}"
+    local llama_server_port="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-}}"
+    [[ -n "$llama_server_port" ]] || llama_server_port="$(env_file_value OLLAMA_PORT)"
+    [[ -n "$llama_server_port" ]] || llama_server_port="$(env_file_value LLAMA_SERVER_PORT)"
+    llama_server_port="${llama_server_port:-8080}"
     if curl -sf "http://127.0.0.1:${llama_server_port}/v1/models" &>/dev/null; then
         log_ok "llama-server: healthy"
     else
@@ -851,7 +934,7 @@ Environment Variables:
   UPDATE_CHANNEL      stable|beta|nightly (default: stable)
   MAX_BACKUPS         Number of snapshots/backups to retain (default: 10)
   HEALTH_TIMEOUT      Seconds to wait for healthy services (default: 120)
-  DASHBOARD_PORT      Dashboard API port (default: 3002)
+  DASHBOARD_API_PORT  Dashboard API port (default: 3002)
   OLLAMA_PORT         llama-server port (default: 8080)
 
 Examples:

--- a/dream-server/installers/lib/packaging.sh
+++ b/dream-server/installers/lib/packaging.sh
@@ -28,6 +28,48 @@ if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
     fi
 fi
 
+_pkg_run() {
+    if [[ -n "$_SUDO" ]]; then
+        "$_SUDO" "$@"
+    else
+        "$@"
+    fi
+}
+
+_pkg_retry() {
+    local max="${PKG_RETRY_ATTEMPTS:-3}"
+    local delay="${PKG_RETRY_DELAY:-15}"
+    local attempt=1 status=0
+
+    while (( attempt <= max )); do
+        if _pkg_run "$@"; then
+            return 0
+        fi
+        status=$?
+        if (( attempt >= max )); then
+            return "$status"
+        fi
+        warn "Package command failed (attempt ${attempt}/${max}): $*; retrying in ${delay}s"
+        sleep "$delay"
+        attempt=$(( attempt + 1 ))
+    done
+
+    return "$status"
+}
+
+_pkg_prepare_pacman_keyrings() {
+    command -v pacman-key >/dev/null 2>&1 || return 0
+
+    _pkg_run pacman-key --init 2>>"$LOG_FILE" || true
+
+    local ring
+    for ring in archlinux manjaro cachyos; do
+        if [[ -f "/usr/share/pacman/keyrings/${ring}.gpg" ]]; then
+            _pkg_run pacman-key --populate "$ring" 2>>"$LOG_FILE" || true
+        fi
+    done
+}
+
 # Detect the system's package manager from /etc/os-release
 # Sets: PKG_MANAGER, DISTRO_ID, DISTRO_ID_LIKE
 detect_pkg_manager() {
@@ -88,12 +130,12 @@ detect_pkg_manager() {
 # Update the package index
 pkg_update() {
     case "$PKG_MANAGER" in
-        apt)    $_SUDO apt-get update -qq 2>>"$LOG_FILE" ;;
-        dnf)    $_SUDO dnf check-update -q 2>>"$LOG_FILE" || true ;;  # returns 100 if updates available
-        pacman) $_SUDO pacman -Syu --noconfirm 2>>"$LOG_FILE" ;;      # full sync+upgrade (partial -Sy is unsafe)
-        zypper) $_SUDO zypper --non-interactive refresh 2>>"$LOG_FILE" ;;
-        xbps)   $_SUDO xbps-install -S 2>>"$LOG_FILE" ;;
-        apk)    $_SUDO apk update 2>>"$LOG_FILE" ;;
+        apt)    _pkg_run apt-get update -qq 2>>"$LOG_FILE" ;;
+        dnf)    _pkg_run dnf check-update -q 2>>"$LOG_FILE" || true ;;  # returns 100 if updates available
+        pacman) _pkg_prepare_pacman_keyrings; _pkg_retry pacman -Syyu --noconfirm 2>>"$LOG_FILE" ;;  # full sync+upgrade (partial -Sy is unsafe)
+        zypper) _pkg_retry zypper --non-interactive --gpg-auto-import-keys refresh 2>>"$LOG_FILE" ;;
+        xbps)   _pkg_run xbps-install -S 2>>"$LOG_FILE" ;;
+        apk)    _pkg_run apk update 2>>"$LOG_FILE" ;;
         *)      warn "Cannot update package index: unknown package manager '$PKG_MANAGER'" ;;
     esac
 }
@@ -114,12 +156,12 @@ pkg_install() {
 
     log "Installing packages (${PKG_MANAGER}): ${pkgs[*]}"
     case "$PKG_MANAGER" in
-        apt)    $_SUDO apt-get install -y -qq "${pkgs[@]}" 2>>"$LOG_FILE" ;;
-        dnf)    $_SUDO dnf install -y -q "${pkgs[@]}" 2>>"$LOG_FILE" ;;
-        pacman) $_SUDO pacman -S --noconfirm --needed "${pkgs[@]}" 2>>"$LOG_FILE" ;;
-        zypper) $_SUDO zypper --non-interactive install "${pkgs[@]}" 2>>"$LOG_FILE" ;;
-        xbps)   $_SUDO xbps-install -y "${pkgs[@]}" 2>>"$LOG_FILE" ;;
-        apk)    $_SUDO apk add --no-progress "${pkgs[@]}" 2>>"$LOG_FILE" ;;
+        apt)    _pkg_run apt-get install -y -qq "${pkgs[@]}" 2>>"$LOG_FILE" ;;
+        dnf)    _pkg_run dnf install -y -q "${pkgs[@]}" 2>>"$LOG_FILE" ;;
+        pacman) _pkg_prepare_pacman_keyrings; _pkg_retry pacman -S --noconfirm --needed "${pkgs[@]}" 2>>"$LOG_FILE" ;;
+        zypper) _pkg_retry zypper --non-interactive install -y "${pkgs[@]}" 2>>"$LOG_FILE" ;;
+        xbps)   _pkg_run xbps-install -y "${pkgs[@]}" 2>>"$LOG_FILE" ;;
+        apk)    _pkg_run apk add --no-progress "${pkgs[@]}" 2>>"$LOG_FILE" ;;
         *)      warn "Cannot install packages: unknown package manager '$PKG_MANAGER'. Install manually: ${pkgs[*]}" ; return 1 ;;
     esac
 }

--- a/dream-server/tests/test-dream-update-runtime-compose.sh
+++ b/dream-server/tests/test-dream-update-runtime-compose.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE_SCRIPT="$ROOT_DIR/dream-update.sh"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+[[ -f "$UPDATE_SCRIPT" ]] || fail "dream-update.sh not found"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INSTALL_DIR="$TMP_DIR/dream-server"
+BIN_DIR="$TMP_DIR/bin"
+mkdir -p "$INSTALL_DIR/data" "$INSTALL_DIR/config/litellm" "$BIN_DIR"
+
+cp "$UPDATE_SCRIPT" "$INSTALL_DIR/dream-update.sh"
+chmod +x "$INSTALL_DIR/dream-update.sh"
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
+DREAM_MODE=local
+GPU_BACKEND=cpu
+GPU_COUNT=1
+TIER=1
+DASHBOARD_API_PORT=3002
+OLLAMA_PORT=8080
+EOF
+
+cat > "$INSTALL_DIR/.version" <<'EOF'
+{"version":"test-runtime"}
+EOF
+
+cat > "$INSTALL_DIR/docker-compose.base.yml" <<'EOF'
+services:
+  dashboard-api:
+    image: example/dashboard-api:test
+  litellm:
+    image: example/litellm:test
+EOF
+
+cat > "$INSTALL_DIR/docker-compose.cpu.yml" <<'EOF'
+services:
+  llama-server:
+    image: example/llama:test
+EOF
+
+printf '%s\n' '-f docker-compose.base.yml -f docker-compose.cpu.yml' > "$INSTALL_DIR/.compose-flags"
+
+DOCKER_LOG="$TMP_DIR/docker-args.log"
+export DOCKER_LOG
+cat > "$BIN_DIR/docker" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+
+if [[ "${1:-}" == "info" ]]; then
+    exit 0
+fi
+
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+    exit 0
+fi
+
+if [[ "${1:-}" == "compose" ]]; then
+    shift
+fi
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "ps" ]]; then
+        next="${args[$((i + 1))]:-}"
+        if [[ "$next" == "--services" ]]; then
+            printf '%s\n' dashboard-api litellm
+            exit 0
+        fi
+        if [[ "$next" == "--format" ]]; then
+            printf '%s\n' '{"State":"running"}'
+            exit 0
+        fi
+    fi
+done
+
+exit 0
+SH
+chmod +x "$BIN_DIR/docker"
+
+cat > "$BIN_DIR/curl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$BIN_DIR/curl"
+
+PATH="$BIN_DIR:$PATH" bash "$INSTALL_DIR/dream-update.sh" health > "$TMP_DIR/health.out" 2>&1 \
+    || { cat "$TMP_DIR/health.out"; fail "health should pass with saved compose flags"; }
+
+grep -q "Service dashboard-api: running" "$TMP_DIR/health.out" \
+    || { cat "$TMP_DIR/health.out"; fail "health did not inspect dashboard-api"; }
+grep -q -- "-f docker-compose.base.yml -f docker-compose.cpu.yml ps --services" "$DOCKER_LOG" \
+    || { cat "$DOCKER_LOG"; fail "health did not pass saved compose flags to docker compose ps"; }
+if grep -q "No services defined in docker-compose" "$TMP_DIR/health.out"; then
+    cat "$TMP_DIR/health.out"
+    fail "health emitted stale bare-compose warning"
+fi
+pass "dream-update health uses saved compose flags in runtime installs"
+
+set +e
+PATH="$BIN_DIR:$PATH" bash "$INSTALL_DIR/dream-update.sh" update > "$TMP_DIR/update.out" 2>&1
+update_exit=$?
+set -e
+
+[[ "$update_exit" -ne 0 ]] || fail "update without .git should fail"
+grep -q "not a git repository" "$TMP_DIR/update.out" \
+    || { cat "$TMP_DIR/update.out"; fail "missing non-git install diagnosis"; }
+grep -q "./dream-cli update" "$TMP_DIR/update.out" \
+    || { cat "$TMP_DIR/update.out"; fail "missing runtime update guidance"; }
+grep -q "git-backed DreamServer checkout" "$TMP_DIR/update.out" \
+    || { cat "$TMP_DIR/update.out"; fail "missing source update guidance"; }
+pass "dream-update explains non-git runtime update path"


### PR DESCRIPTION
## Summary
- make `dream-update.sh health` resolve the active compose stack from `.compose-flags`, `scripts/resolve-compose-stack.sh`, or safe compose fallbacks before calling `docker compose ps`
- make non-git runtime installs fail with actionable update guidance instead of the vague `Not a git repository. Manual update required.`
- read health ports from `.env` when they are not exported in the current shell
- harden `docker compose ps --format json` parsing for both object and array JSON shapes

## Why
A field install reported:

```text
./dream-update.sh update
[ERROR] Not a git repository. Manual update required.
./dream-update.sh health
[WARN] No services defined in docker-compose
```

The install had already created a rollback snapshot, but the update path then failed because the install directory was not a git checkout. The follow-up health check also used bare `docker compose ps`, so it could miss Dream Server installs that rely on `docker-compose.base.yml` plus overlays cached in `.compose-flags`.

This keeps source-code updates git-backed, but makes the failure explicit and points routine runtime/image updates at `./dream-cli update`.

## Validation
- `bash dream-server/tests/test-dream-update-runtime-compose.sh`
- `bash -n dream-server/dream-update.sh dream-server/tests/test-dream-update-runtime-compose.sh`
- `bash dream-server/tests/contracts/test-installer-contracts.sh`
- `bash dream-server/tests/test-linux-cloud-mode.sh`
- `git diff --check`

Local note: `tests/test-update-rollback-contract.sh` still uses GNU `find -printf`, so it is not meaningful on this macOS host without GNU find. This change adds a targeted runtime-compose updater test instead.