### PR TITLE
fix(installer): make Lemonade retry hint runnable

### DIFF
--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -268,6 +268,16 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         echo "$default"
     }
 
+    _env_get_explicit_first() {
+        local key="$1" default="${2:-}" val
+        val="${!key-}"
+        if [[ -n "$val" ]]; then
+            echo "$val"
+            return
+        fi
+        _env_get "$key" "$default"
+    }
+
     _phase06_detect_lemonade_url() {
         command -v curl >/dev/null 2>&1 || return 1
         local candidate
@@ -346,13 +356,13 @@ raise SystemExit(1)' 2>/dev/null && return 0
     if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" && -n "${LEMONADE_API_KEY:-}" ]]; then
         LITELLM_LEMONADE_API_KEY="$LEMONADE_API_KEY"
     fi
-    LEMONADE_API_BASE_PATH_VALUE="$(_env_get LEMONADE_API_BASE_PATH "/api/v1")"
+    LEMONADE_API_BASE_PATH_VALUE="$(_env_get_explicit_first LEMONADE_API_BASE_PATH "/api/v1")"
     [[ "$LEMONADE_API_BASE_PATH_VALUE" == /* ]] || LEMONADE_API_BASE_PATH_VALUE="/$LEMONADE_API_BASE_PATH_VALUE"
     LEMONADE_BASE_URL_VALUE=""
     LEMONADE_CONTAINER_BASE_URL_VALUE=""
     LEMONADE_PORT_VALUE=""
     if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then
-        LEMONADE_BASE_URL_VALUE="$(_env_get LEMONADE_BASE_URL "${LEMONADE_BASE_URL:-}")"
+        LEMONADE_BASE_URL_VALUE="$(_env_get_explicit_first LEMONADE_BASE_URL "")"
         if [[ -z "$LEMONADE_BASE_URL_VALUE" ]]; then
             if LEMONADE_BASE_URL_VALUE="$(_phase06_detect_lemonade_url)"; then
                 ai_ok "Detected existing Lemonade server at ${LEMONADE_BASE_URL_VALUE}"
@@ -375,7 +385,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
                 LEMONADE_PORT_VALUE="13305"
             fi
         fi
-        LEMONADE_CONTAINER_BASE_URL_VALUE="$(_env_get LEMONADE_CONTAINER_BASE_URL "")"
+        LEMONADE_CONTAINER_BASE_URL_VALUE="$(_env_get_explicit_first LEMONADE_CONTAINER_BASE_URL "")"
         if [[ -z "$LEMONADE_CONTAINER_BASE_URL_VALUE" ]]; then
             case "$LEMONADE_BASE_URL_VALUE" in
                 http://localhost:*) LEMONADE_CONTAINER_BASE_URL_VALUE="${LEMONADE_BASE_URL_VALUE/http:\/\/localhost:/http:\/\/host.docker.internal:}" ;;
@@ -390,7 +400,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
     LEMONADE_CONTAINER_API_BASE_VALUE="$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${LEMONADE_CONTAINER_BASE_URL_VALUE}${LEMONADE_API_BASE_PATH_VALUE}"; else echo "http://llama-server:8080/api/v1"; fi)"
     LEMONADE_MODEL_VALUE=""
     if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then
-        LEMONADE_MODEL_VALUE="$(_env_get LEMONADE_MODEL "${LEMONADE_MODEL:-}")"
+        LEMONADE_MODEL_VALUE="$(_env_get_explicit_first LEMONADE_MODEL "")"
         if [[ -z "$LEMONADE_MODEL_VALUE" ]]; then
             if LEMONADE_MODEL_VALUE="$(_phase06_discover_lemonade_model "$LEMONADE_API_BASE_VALUE")"; then
                 ai_ok "Detected existing Lemonade model: ${LEMONADE_MODEL_VALUE}"

--- a/dream-server/installers/phases/12-health.sh
+++ b/dream-server/installers/phases/12-health.sh
@@ -169,7 +169,11 @@ _phase12_verify_external_lemonade_completion() {
         ai_warn "The selected Lemonade model looks like an image/non-chat model. DreamServer needs a text/chat model for the LLM route."
     fi
     ai_warn "Run: curl ${LEMONADE_BASE_URL:-$(_phase12_env_get LEMONADE_BASE_URL http://127.0.0.1:13305)}${LEMONADE_API_BASE_PATH:-$(_phase12_env_get LEMONADE_API_BASE_PATH /api/v1)}/models"
-    ai_warn "Then rerun with LEMONADE_MODEL=<chat-model-id> ./install.sh --use-existing-lemonade ..."
+    if [[ -f "${SCRIPT_DIR}/install.sh" ]]; then
+        ai_warn "Then rerun from ${SCRIPT_DIR}: LEMONADE_MODEL=<chat-model-id> ./install.sh --use-existing-lemonade ..."
+    else
+        ai_warn "Then rerun from ${SCRIPT_DIR}: LEMONADE_MODEL=<chat-model-id> bash install-core.sh --use-existing-lemonade ..."
+    fi
     printf '%s\n' "$response" >> "$LOG_FILE"
     return 1
 }

--- a/dream-server/tests/contracts/test-external-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-external-lemonade-contracts.sh
@@ -43,6 +43,10 @@ if grep -q 'LLM_MODEL_VALUE' installers/phases/06-directories.sh; then
 fi
 grep -q 'LEMONADE_MODEL_VALUE' installers/phases/06-directories.sh \
   || { echo "[FAIL] phase 06 must write a resolved LEMONADE_MODEL value"; exit 1; }
+grep -q '_env_get_explicit_first LEMONADE_MODEL' installers/phases/06-directories.sh \
+  || { echo "[FAIL] explicit LEMONADE_MODEL must override stale .env values during reinstall"; exit 1; }
+grep -q '_env_get_explicit_first LEMONADE_BASE_URL' installers/phases/06-directories.sh \
+  || { echo "[FAIL] explicit LEMONADE_BASE_URL/--lemonade-url must override stale .env values during reinstall"; exit 1; }
 
 echo "[contract] explicit LAN binding overrides stale env during reinstall"
 grep -q 'BIND_ADDRESS_EXPLICIT' install-core.sh \
@@ -61,6 +65,10 @@ grep -q '/v1/chat/completions' installers/phases/12-health.sh \
   || { echo "[FAIL] phase 12 completion check must call the LiteLLM chat route"; exit 1; }
 grep -q '_phase12_model_looks_non_chat' installers/phases/12-health.sh \
   || { echo "[FAIL] phase 12 must explain image/non-chat Lemonade model failures"; exit 1; }
+grep -q 'bash install-core.sh --use-existing-lemonade' installers/phases/12-health.sh \
+  || { echo "[FAIL] phase 12 Lemonade recovery hint must work when install.sh is absent from the runtime tree"; exit 1; }
+grep -q 'LEMONADE_MODEL=<chat-model-id>' installers/phases/12-health.sh \
+  || { echo "[FAIL] phase 12 Lemonade recovery hint must show inline LEMONADE_MODEL assignment"; exit 1; }
 
 echo "[contract] external Lemonade preflight checks LiteLLM instead of managed llama-server"
 grep -q 'is_external_lemonade()' dream-preflight.sh \


### PR DESCRIPTION
## Summary
- make the external Lemonade Phase 12 retry hint choose an available installer entrypoint
- fall back to `bash install-core.sh` when `install.sh` is absent from a copied runtime tree
- show `LEMONADE_MODEL=<chat-model-id>` inline so the model override is inherited by the retry command
- let explicit Lemonade retry inputs (`LEMONADE_MODEL`, `LEMONADE_BASE_URL`, `LEMONADE_API_BASE_PATH`, `LEMONADE_CONTAINER_BASE_URL`) override stale values preserved in `.env` during reinstall
- add contract coverage for the runtime-tree fallback, inline model assignment, and explicit Lemonade overrides

## Validation
- `bash -n installers/phases/06-directories.sh installers/phases/12-health.sh tests/contracts/test-external-lemonade-contracts.sh`
- `DREAM_PYTHON_CMD=python3 bash tests/contracts/test-external-lemonade-contracts.sh`
- `bash tests/contracts/test-installer-contracts.sh`
- `git diff --check`