### PR TITLE
fix(windows): explain missing compose services

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Windows Compose Failure Report Tests
         run: bash tests/test-windows-compose-failure-report.sh
 
+      - name: Windows Missing Service Hint Tests
+        run: bash tests/test-windows-missing-service-hints.sh
+
       - name: Install Readiness Summary Tests
         run: bash tests/test-install-readiness-summary.sh
 

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -317,6 +317,48 @@ function Test-DreamComposeServiceAvailable {
     }
 }
 
+function Write-DreamMissingComposeServiceHint {
+    param(
+        [string[]]$ComposeFlags,
+        [Parameter(Mandatory = $true)][string]$Service
+    )
+
+    Write-AIError "Service '$Service' is not in the active Dream Server compose stack."
+
+    $serviceDir = Join-Path (Join-Path (Join-Path $InstallDir "extensions") "services") $Service
+    $composePath = Join-Path $serviceDir "compose.yaml"
+    $disabledComposePath = Join-Path $serviceDir "compose.yaml.disabled"
+
+    if (Test-Path $disabledComposePath) {
+        Write-AI "The $Service extension appears disabled in this runtime tree."
+    } elseif (Test-Path $composePath) {
+        Write-AI "The $Service extension exists, but the active .compose-flags stack does not include it."
+        Write-AI "This can happen after a reinstall with different feature choices or a stale compose cache."
+    } else {
+        Write-AI "No compose fragment for '$Service' was found under extensions/services."
+    }
+
+    if ($Service -eq "n8n" -or $Service -eq "workflows") {
+        Write-AI "n8n is optional. Install with -Workflows or -All if you want workflow automation."
+    }
+
+    Write-AI "Active compose services:"
+    try {
+        $services = & docker compose @ComposeFlags config --services 2>$null
+        if ($services) {
+            $services | ForEach-Object { Write-AI "  $_" }
+        } else {
+            Write-AI "  (none returned by docker compose config --services)"
+        }
+    } catch {
+        Write-AI "  Could not inspect compose services. Run the diagnostic command below manually."
+    }
+
+    Write-AI "Diagnostic command:"
+    Write-AI "  `$flags = (Get-Content .compose-flags -Raw).Trim() -split '\s+'"
+    Write-AI "  docker compose @flags config --services"
+}
+
 function Set-DreamEnvValue {
     <#
     .SYNOPSIS
@@ -781,6 +823,10 @@ function Invoke-Start {
         $flags = Get-ComposeFlags
         $hermesInStack = Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "hermes"
         if ($Service) {
+            if (-not (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service $Service)) {
+                Write-DreamMissingComposeServiceHint -ComposeFlags $flags -Service $Service
+                exit 1
+            }
             Write-AI "Starting $Service..."
             if ($Service -eq "hermes" -and $hermesInStack) {
                 Invoke-HermesSoulRefresh
@@ -826,6 +872,10 @@ function Invoke-Stop {
     try {
         $flags = Get-ComposeFlags
         if ($Service) {
+            if (-not (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service $Service)) {
+                Write-DreamMissingComposeServiceHint -ComposeFlags $flags -Service $Service
+                exit 1
+            }
             Write-AI "Stopping $Service..."
             $composeExit = Invoke-DreamDockerCompose -InstallDir $InstallDir -ComposeFlags $flags `
                 -ComposeArgs @("stop", $Service)
@@ -871,6 +921,10 @@ function Invoke-Restart {
         $flags = Get-ComposeFlags
         $hermesInStack = Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service "hermes"
         if ($Service) {
+            if (-not (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service $Service)) {
+                Write-DreamMissingComposeServiceHint -ComposeFlags $flags -Service $Service
+                exit 1
+            }
             Write-AI "Restarting $Service..."
             if ($Service -eq "hermes" -and $hermesInStack) {
                 Invoke-HermesSoulRefresh
@@ -928,6 +982,10 @@ function Invoke-Logs {
     Push-Location $InstallDir
     try {
         $flags = Get-ComposeFlags
+        if (-not (Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service $Service)) {
+            Write-DreamMissingComposeServiceHint -ComposeFlags $flags -Service $Service
+            exit 1
+        }
         & docker compose @flags logs -f --tail $Lines $Service
     } finally {
         Pop-Location

--- a/dream-server/scripts/release-gate.sh
+++ b/dream-server/scripts/release-gate.sh
@@ -31,6 +31,7 @@ bash tests/contracts/test-installer-contracts.sh
 bash tests/contracts/test-preflight-fixtures.sh
 bash tests/contracts/test-installer-hardening.sh
 bash tests/test-uninstall-compose-flags.sh
+bash tests/test-windows-missing-service-hints.sh
 "$PYTHON_CMD" tests/contracts/test-network-exposure-contracts.py
 
 echo "[gate] smoke"

--- a/dream-server/tests/test-windows-missing-service-hints.sh
+++ b/dream-server/tests/test-windows-missing-service-hints.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# ============================================================================
+# Dream Server Windows missing compose service hint tests
+# ============================================================================
+# Static checks for friendly Windows CLI errors when an optional service is not
+# present in the active .compose-flags stack.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DREAM_PS1="$ROOT_DIR/installers/windows/dream.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+echo ""
+echo "=== Windows missing compose service hint tests ==="
+echo ""
+
+[[ -f "$DREAM_PS1" ]] && pass "dream.ps1 exists" || fail "dream.ps1 missing"
+
+check 'function Write-DreamMissingComposeServiceHint' "$DREAM_PS1" "missing-service hint helper exists"
+check "Service '\$Service' is not in the active Dream Server compose stack." "$DREAM_PS1" "hint explains service is absent from active stack"
+check 'compose.yaml.disabled' "$DREAM_PS1" "hint checks disabled extension compose fragment"
+check 'active .compose-flags stack does not include it' "$DREAM_PS1" "hint explains stale/mismatched compose flags"
+check 'n8n is optional. Install with -Workflows or -All' "$DREAM_PS1" "hint gives n8n/workflows remediation"
+check 'docker compose @flags config --services' "$DREAM_PS1" "hint prints diagnostic compose-services command"
+
+guard_count=$(grep -Fc 'Write-DreamMissingComposeServiceHint -ComposeFlags $flags -Service $Service' "$DREAM_PS1" || true)
+if [[ "$guard_count" -ge 4 ]]; then
+    pass "start/stop/restart/logs guard missing services before docker compose"
+else
+    fail "expected missing-service guard in start/stop/restart/logs, found $guard_count"
+fi
+
+logs_block="$(awk '
+    /function Invoke-Logs/ { in_block=1 }
+    in_block { print }
+    in_block && /function Invoke-ConfigShow/ { exit }
+' "$DREAM_PS1")"
+
+if grep -Fq 'Test-DreamComposeServiceAvailable -ComposeFlags $flags -Service $Service' <<<"$logs_block" &&
+   grep -Fq 'Write-DreamMissingComposeServiceHint -ComposeFlags $flags -Service $Service' <<<"$logs_block"; then
+    pass "logs command checks compose service availability before tailing logs"
+else
+    fail "logs command does not guard missing services before tailing logs"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary
- make the Windows `dream.ps1` lifecycle commands detect when a requested service is not present in the active compose stack before calling Docker Compose
- replace raw Docker `no such service: n8n` output with an actionable Dream Server hint that explains disabled extensions, stale `.compose-flags`, and the `-Workflows` / `-All` n8n path
- cover the behavior with a new static Windows CLI contract test and wire it into Linux CI plus release-gate

## Why
A Windows support report tried to inspect n8n credentials with:

```powershell
.\dream.ps1 logs n8n 100
```

Docker returned:

```text
no such service: n8n
```

That output is technically correct but not useful for users: it means n8n is not in the runtime compose stack, usually because Workflows were not enabled, the extension compose fragment is disabled, or `.compose-flags` does not match the current install. The CLI should explain that directly and print the diagnostic command for active services.

## Validation
- `bash -n dream-server/tests/test-windows-missing-service-hints.sh dream-server/scripts/release-gate.sh`
- `bash dream-server/tests/test-windows-missing-service-hints.sh`
- PowerShell parser check for `dream-server/installers/windows/dream.ps1`
- `bash dream-server/tests/test-windows-compose-failure-report.sh`
- `bash dream-server/tests/test-windows-report-command.sh`
- `bash dream-server/tests/test-windows-service-plan.sh`
- `bash dream-server/tests/test-windows-installer-flags.sh`
- `git diff --check`