### PR TITLE
fix(dashboard): hide api-only litellm quicklink

### DIFF
--- a/dream-server/extensions/schema/service-manifest.v1.json
+++ b/dream-server/extensions/schema/service-manifest.v1.json
@@ -82,6 +82,10 @@
           "pattern": "^/.*",
           "description": "Path to the service UI (e.g. /dashboard, /)"
         },
+        "external_link": {
+          "type": "boolean",
+          "description": "When false, omit this service from dashboard external quicklinks while keeping it in health/status APIs."
+        },
         "type": { "type": "string", "enum": ["docker", "host-systemd"] },
         "startup_check": {
           "type": "boolean",

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -126,6 +126,7 @@ def load_extension_manifests(
                     "health": service.get("health", "/health"),
                     "name": service.get("name", service_id),
                     "ui_path": service.get("ui_path", "/"),
+                    "external_link": bool(service.get("external_link", True)),
                     "container_name": service.get("container_name", f"dream-{service_id}"),
                     "depends_on": service.get("depends_on", []),
                     "category": service.get("category", "optional"),

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -1385,7 +1385,7 @@ async def get_external_links(api_key: str = Depends(verify_api_key)):
     links = []
     for sid, cfg in SERVICES.items():
         ext_port = cfg.get("external_port", cfg.get("port", 0))
-        if not ext_port or sid == "dashboard-api":
+        if not ext_port or sid == "dashboard-api" or cfg.get("external_link") is False:
             continue
         links.append({
             "id": sid, "label": cfg.get("name", sid), "port": ext_port,

--- a/dream-server/extensions/services/dashboard-api/tests/test_main.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_main.py
@@ -459,6 +459,35 @@ class TestExternalLinks:
         data = resp.json()
         assert len(data) == 0
 
+    def test_excludes_api_only_services(self, test_client, monkeypatch):
+        import config
+        monkeypatch.setattr(config, "SERVICES", {
+            "litellm": {
+                "name": "LiteLLM (API Gateway)",
+                "port": 4000,
+                "external_port": 4000,
+                "health": "/health/readiness",
+                "host": "localhost",
+                "ui_path": "/ui/",
+                "external_link": False,
+            },
+            "open-webui": {
+                "name": "Open WebUI",
+                "port": 3000,
+                "external_port": 3000,
+                "health": "/health",
+                "host": "localhost",
+            },
+        })
+        monkeypatch.setattr("main.SERVICES", config.SERVICES)
+
+        resp = test_client.get("/api/external-links", headers=test_client.auth_headers)
+        assert resp.status_code == 200
+        data = resp.json()
+        link_ids = [link["id"] for link in data]
+        assert "open-webui" in link_ids
+        assert "litellm" not in link_ids
+
 
 # --- /api/storage ---
 

--- a/dream-server/extensions/services/litellm/README.md
+++ b/dream-server/extensions/services/litellm/README.md
@@ -8,6 +8,8 @@ LiteLLM is a unified API gateway that provides a single OpenAI-compatible endpoi
 
 LiteLLM runs at `http://localhost:4000` and is the recommended integration point for custom applications, scripts, and n8n workflows that need a stable, mode-independent API endpoint.
 
+Dream Server does not expose LiteLLM as a normal dashboard quicklink. The upstream LiteLLM Admin UI lives at `/ui/`, but that surface expects a proxy-admin UI setup and database-backed management flow. Dream Server's default LiteLLM container is provisioned as an API gateway, so use the OpenAI-compatible `/v1/*` endpoints with `LITELLM_KEY` instead of treating `/ui/` as the supported login path.
+
 ## Features
 
 - **Single endpoint for all modes**: Same `POST /v1/chat/completions` URL regardless of backend

--- a/dream-server/extensions/services/litellm/manifest.yaml
+++ b/dream-server/extensions/services/litellm/manifest.yaml
@@ -14,6 +14,7 @@ service:
   external_port_default: 4000
   health: /health/readiness
   ui_path: /ui/
+  external_link: false
   type: docker
   gpu_backends: [all]
   compose_file: compose.yaml


### PR DESCRIPTION
## Summary
- add a manifest-level `external_link: false` flag for API-only services
- make `/api/external-links` omit services that opt out of dashboard quicklinks
- mark LiteLLM as API-only for external quicklinks while keeping it in health/status/routing metadata
- document that Dream Server provisions LiteLLM as an OpenAI-compatible API gateway, not as the supported LiteLLM Admin UI login surface
- add dashboard-api coverage so API-only services are excluded while normal user-facing services remain linked

## Why
A Windows support report confirmed LiteLLM API auth was healthy: `LITELLM_KEY` from `.env` was passed into the container as `LITELLM_MASTER_KEY`, and `/v1/models` returned models with the Bearer token.

The remaining confusion came from `http://localhost:4000/ui/`: the LiteLLM upstream image exposes an Admin UI route, and our manifest advertised `ui_path: /ui/`, so Dream Server could present it like a normal quicklink. Dream Server's default LiteLLM stack is API-gateway-only and does not provision the database/UI management flow expected by the Admin UI. The dashboard should not steer users toward that unsupported login surface.

## Validation
- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_main.py -q`
- `python dream-server/scripts/audit-extensions.py --project-dir dream-server`
- `bash dream-server/tests/test-doc-links.sh`
- `git diff --check`

Local note: `bash dream-server/tests/test-validate-manifests.sh` could not complete on this Windows environment because `jq` is not installed locally; the Python extension audit passed with the updated manifest.