### PR TITLE
fix(token-spy): generate shared api key on desktop installers

### DIFF
--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -39,6 +39,13 @@ read_env_value() {
     grep -E "^${key}=" "$env_path" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r' || true
 }
 
+read_token_spy_api_key() {
+    local install_dir="$1"
+    local token_spy_key_path="${install_dir}/data/token-spy/token-spy-api-key.txt"
+    [[ -f "$token_spy_key_path" ]] || { echo ""; return 0; }
+    tr -d '\r\n' < "$token_spy_key_path" 2>/dev/null || true
+}
+
 # Read SearXNG secret_key from an existing settings.yml file.
 # Arguments:
 #   1) settings_path: full path to settings.yml
@@ -225,6 +232,17 @@ generate_dream_env() {
         if [[ -z "$(read_env_value "$env_path" "SHIELD_API_KEY")" ]]; then
             upsert_env_value "$env_path" "SHIELD_API_KEY" "$(new_secure_hex 32)"
         fi
+        # Upsert TOKEN_SPY_API_KEY when missing so dashboard-api and the
+        # Token Spy UI share the same login key. Preserve Token Spy's existing
+        # fallback key file on upgrades where the container created one first.
+        if [[ -z "$(read_env_value "$env_path" "TOKEN_SPY_API_KEY")" ]]; then
+            local _token_spy_api_key
+            _token_spy_api_key="$(read_token_spy_api_key "$install_dir")"
+            if [[ -z "$_token_spy_api_key" ]]; then
+                _token_spy_api_key="$(new_secure_hex 32)"
+            fi
+            upsert_env_value "$env_path" "TOKEN_SPY_API_KEY" "$_token_spy_api_key"
+        fi
         # Upsert DREAM_SESSION_SECRET when missing — HMAC key for the
         # dream-session cookie minted by magic-link redemption. Without
         # this, dashboard-api refuses to issue cookies (and the magic-link
@@ -279,6 +297,11 @@ generate_dream_env() {
     dream_session_secret=$(new_secure_hex 32)
     local shield_api_key
     shield_api_key=$(new_secure_hex 32)
+    local token_spy_api_key
+    token_spy_api_key="$(read_token_spy_api_key "$install_dir")"
+    if [[ -z "$token_spy_api_key" ]]; then
+        token_spy_api_key=$(new_secure_hex 32)
+    fi
     tts_cpu_limit="$(select_env_service_cpu_limit "$env_path" "TTS_CPU_LIMIT" "8.0" "$docker_available_cpus")"
     tts_cpu_reservation="$(select_env_service_cpu_reservation "$env_path" "TTS_CPU_RESERVATION" "2.0" "$tts_cpu_limit")"
     whisper_cpu_limit="$(select_env_service_cpu_limit "$env_path" "WHISPER_CPU_LIMIT" "4.0" "$docker_available_cpus")"
@@ -445,6 +468,7 @@ LIVEKIT_API_KEY=${livekit_api_key}
 LIVEKIT_API_SECRET=${livekit_secret}
 OPENCLAW_TOKEN=${openclaw_token}
 QDRANT_API_KEY=${qdrant_api_key}
+TOKEN_SPY_API_KEY=${token_spy_api_key}
 SEARXNG_SECRET=${searxng_secret}
 
 #=== OpenCode Settings ===

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -112,6 +112,17 @@ function New-DreamEnv {
         return $Default
     }
 
+    function Get-ExistingTokenSpyApiKey {
+        $tokenSpyKeyFile = Join-Path $InstallDir "data\token-spy\token-spy-api-key.txt"
+        if (Test-Path $tokenSpyKeyFile) {
+            $value = (Get-Content -Raw -Path $tokenSpyKeyFile -ErrorAction SilentlyContinue)
+            if (-not [string]::IsNullOrWhiteSpace($value)) {
+                return $value.Trim()
+            }
+        }
+        return ""
+    }
+
     function Select-AutoCpuValue {
         param(
             [string]$Key,
@@ -192,6 +203,11 @@ function New-DreamEnv {
     # the magic-link gate effectively breaks.
     $dreamSessionSecret = Get-EnvOrNew "DREAM_SESSION_SECRET" (New-SecureHex -Bytes 32)
     $shieldApiKey    = Get-EnvOrNew "SHIELD_API_KEY"     (New-SecureHex -Bytes 32)
+    $tokenSpyApiKeyDefault = Get-ExistingTokenSpyApiKey
+    if ([string]::IsNullOrWhiteSpace($tokenSpyApiKeyDefault)) {
+        $tokenSpyApiKeyDefault = New-SecureHex -Bytes 32
+    }
+    $tokenSpyApiKey = Get-EnvOrNew "TOKEN_SPY_API_KEY" $tokenSpyApiKeyDefault
     $openclawToken   = Get-EnvOrNew "OPENCLAW_TOKEN"     (New-SecureHex -Bytes 24)
     $searxngSecret   = Get-EnvOrNew "SEARXNG_SECRET"     (New-SecureHex -Bytes 32)
     $difySecretKey    = Get-EnvOrNew "DIFY_SECRET_KEY"           (New-SecureHex -Bytes 32)
@@ -419,6 +435,7 @@ LIVEKIT_API_SECRET=$livekitSecret
 OPENCLAW_TOKEN=$openclawToken
 OPENCODE_SERVER_PASSWORD=$opencodePassword
 OPENCODE_PORT=3003
+TOKEN_SPY_API_KEY=$tokenSpyApiKey
 SEARXNG_SECRET=$searxngSecret
 DIFY_SECRET_KEY=$difySecretKey
 

--- a/dream-server/tests/test-fedora-strix-compat.py
+++ b/dream-server/tests/test-fedora-strix-compat.py
@@ -90,13 +90,21 @@ def test_token_spy_key_wiring() -> None:
     token_spy_compose = (ROOT / "extensions/services/token-spy/compose.yaml").read_text(encoding="utf-8")
     dashboard_compose = (ROOT / "docker-compose.base.yml").read_text(encoding="utf-8")
     phase06 = (ROOT / "installers/phases/06-directories.sh").read_text(encoding="utf-8")
+    windows_env = (ROOT / "installers/windows/lib/env-generator.ps1").read_text(encoding="utf-8")
+    macos_env = (ROOT / "installers/macos/lib/env-generator.sh").read_text(encoding="utf-8")
     schema = (ROOT / ".env.schema.json").read_text(encoding="utf-8")
 
     required = {
         "token-spy compose": "TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}" in token_spy_compose,
         "dashboard-api compose": "TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}" in dashboard_compose,
-        "installer generation": "TOKEN_SPY_API_KEY=$(_env_get TOKEN_SPY_API_KEY" in phase06,
-        "installer output": "TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY}" in phase06,
+        "linux installer generation": "TOKEN_SPY_API_KEY=$(_env_get TOKEN_SPY_API_KEY" in phase06,
+        "linux installer output": "TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY}" in phase06,
+        "windows installer generation": "Get-EnvOrNew \"TOKEN_SPY_API_KEY\"" in windows_env,
+        "windows preserves token-spy key file": "token-spy-api-key.txt" in windows_env,
+        "windows installer output": "TOKEN_SPY_API_KEY=$tokenSpyApiKey" in windows_env,
+        "macos installer generation": "read_token_spy_api_key" in macos_env,
+        "macos preserves token-spy key file": "token-spy-api-key.txt" in macos_env,
+        "macos installer output": "TOKEN_SPY_API_KEY=${token_spy_api_key}" in macos_env,
         "env schema": '"TOKEN_SPY_API_KEY"' in schema,
     }
     missing = [name for name, ok in required.items() if not ok]


### PR DESCRIPTION
## Summary
- generate `TOKEN_SPY_API_KEY` in the Windows installer `.env` output
- generate and backfill `TOKEN_SPY_API_KEY` in the macOS installer `.env` output
- preserve an existing `data/token-spy/token-spy-api-key.txt` fallback key on upgrades/reinstalls
- extend the Fedora/Strix compatibility contract so Token Spy key wiring is checked across Linux, Windows, and macOS installers

## Why
Token Spy has a real dashboard login, and both `token-spy` and `dashboard-api` are wired to receive `TOKEN_SPY_API_KEY`. Linux already generated this key, but Windows and macOS could leave it missing from `.env`. In that state Token Spy may generate its own fallback file while dashboard-api still has a blank key, and the Settings environment editor reports the key as `Not set`.

This aligns desktop installers with the existing Linux Phase 06 behavior.

## Validation
- `python dream-server/tests/test-fedora-strix-compat.py`
- `bash -n dream-server/installers/macos/lib/env-generator.sh`
- PowerShell parser check for `dream-server/installers/windows/lib/env-generator.ps1`
- `python dream-server/scripts/audit-extensions.py --project-dir dream-server`
- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_settings_env.py -q`
- `git diff --check`