### PR TITLE
fix(windows): harden Lemonade setup on AMD

### DIFF
--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -40,9 +40,13 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "constants.ps1")
 . (Join-Path $LibDir "ui.ps1")
 . (Join-Path $LibDir "compose-diagnostics.ps1")
+. (Join-Path $LibDir "backend-contract.ps1")
 . (Join-Path $LibDir "detection.ps1")
 . (Join-Path $LibDir "llm-endpoint.ps1")
 . (Join-Path $LibDir "install-report.ps1")
+
+$_resolvedLemonadeExe = Resolve-DreamLemonadeExe
+if ($_resolvedLemonadeExe) { $script:LEMONADE_EXE = $_resolvedLemonadeExe }
 
 # ── Resolve install directory ──
 $InstallDir = $script:DS_INSTALL_DIR

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -197,6 +197,8 @@ if ($gpuInfo.Backend -eq "amd") {
     $script:LEMONADE_MSI_FILE = [string]$amdLemonadeRuntime.windows_msi_file
     $script:LEMONADE_MSI_URL = "https://github.com/lemonade-sdk/lemonade/releases/download/v$($script:LEMONADE_VERSION)/$($script:LEMONADE_MSI_FILE)"
     $script:LEMONADE_EXE = Join-Path (Join-Path $script:LEMONADE_INSTALL_DIR "bin") ([string]$amdLemonadeRuntime.windows_executable)
+    $_resolvedLemonadeExe = Resolve-DreamLemonadeExe -ExecutableName ([string]$amdLemonadeRuntime.windows_executable)
+    if ($_resolvedLemonadeExe) { $script:LEMONADE_EXE = $_resolvedLemonadeExe }
     $script:LEMONADE_PORT = [int]$amdLemonadeRuntime.api_port
     $script:LEMONADE_HEALTH_URL = "http://localhost:$($script:LEMONADE_PORT)$($amdLemonadeRuntime.health_path)"
 }
@@ -353,6 +355,8 @@ if ($dryRun) {
                     if ($dlOk) {
                         $msiArgs = "/i `"$msiPath`" /quiet /norestart ALLUSERS=1"
                         Start-Process msiexec.exe -ArgumentList $msiArgs -Wait -NoNewWindow
+                        $_resolvedLemonadeExe = Resolve-DreamLemonadeExe -ExecutableName ([string]$amdLemonadeRuntime.windows_executable)
+                        if ($_resolvedLemonadeExe) { $script:LEMONADE_EXE = $_resolvedLemonadeExe }
                         if (Test-Path $script:LEMONADE_EXE) {
                             Write-AISuccess "AMD Lemonade Server installed"
                             $useLemonade = $true
@@ -774,11 +778,17 @@ if ($dryRun) {
             param([string]$Image)
             if ([string]::IsNullOrWhiteSpace($Image)) { return $false }
 
-            & docker image inspect $Image *> $null
-            if ($LASTEXITCODE -eq 0) { return $true }
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "SilentlyContinue"
+            try {
+                & docker image inspect $Image *> $null
+                if ($LASTEXITCODE -eq 0) { return $true }
 
-            & docker manifest inspect $Image *> $null
-            return ($LASTEXITCODE -eq 0)
+                & docker manifest inspect $Image *> $null
+                return ($LASTEXITCODE -eq 0)
+            } finally {
+                $ErrorActionPreference = $prevEAP
+            }
         }
 
         function Resolve-DreamDockerImageOrFallback {
@@ -1081,14 +1091,18 @@ switch ($opencodeSync.Status) {
     }
 }
 
+$windowsEnvMap = Get-WindowsDreamEnvMap -InstallDir $installDir
 $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $installDir `
-    -EnvMap (Get-WindowsDreamEnvMap -InstallDir $installDir) `
+    -EnvMap $windowsEnvMap `
     -UseLemonade:$useLemonade -GpuBackend $gpuInfo.Backend -CloudMode:$cloudMode
 $healthChecks = @(
     @{ Name = $llmEndpoint.Name; Url = $llmEndpoint.HealthUrl }
     @{ Name = "Chat UI (Open WebUI)"; Url = "http://localhost:3000" }
 )
-if ($enableVoice)     { $healthChecks += @{ Name = "Whisper (STT)";    Url = "http://localhost:9000/health" } }
+if ($enableVoice)     {
+    $healthWhisperPort = if ($windowsEnvMap.ContainsKey("WHISPER_PORT") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["WHISPER_PORT"])) { $windowsEnvMap["WHISPER_PORT"] } else { "9000" }
+    $healthChecks += @{ Name = "Whisper (STT)"; Url = "http://localhost:$healthWhisperPort/health" }
+}
 if ($enableWorkflows) { $healthChecks += @{ Name = "n8n (Workflows)";   Url = "http://localhost:5678/healthz" } }
 
 Write-AI "Running health checks..."

--- a/dream-server/installers/windows/lib/backend-contract.ps1
+++ b/dream-server/installers/windows/lib/backend-contract.ps1
@@ -77,3 +77,44 @@ function Get-DreamAmdLemonadeRuntime {
 
     return $lemonade
 }
+
+function Resolve-DreamLemonadeExe {
+    <#
+    .SYNOPSIS
+        Resolve the native Windows Lemonade executable across both MSI roots.
+
+    .DESCRIPTION
+        Lemonade's minimal MSI can land under either Program Files root depending
+        on package architecture and Windows installer behavior. Probe both before
+        falling back to the configured default path so AMD installs do not miss a
+        valid Lemonade runtime and silently downgrade to Vulkan llama-server.
+    #>
+    [CmdletBinding()]
+    param(
+        [string]$ExecutableName = "lemonade-server.exe"
+    )
+
+    $candidates = New-Object System.Collections.Generic.List[string]
+
+    $existingVar = Get-Variable -Name LEMONADE_EXE -Scope Script -ErrorAction SilentlyContinue
+    if ($existingVar -and -not [string]::IsNullOrWhiteSpace([string]$existingVar.Value)) {
+        $candidates.Add([string]$existingVar.Value)
+    }
+
+    $roots = @(
+        $env:ProgramFiles,
+        ${env:ProgramFiles(x86)}
+    )
+    foreach ($root in $roots) {
+        if ([string]::IsNullOrWhiteSpace($root)) { continue }
+        $candidates.Add((Join-Path (Join-Path (Join-Path $root "Lemonade Server") "bin") $ExecutableName))
+    }
+
+    foreach ($candidate in ($candidates | Select-Object -Unique)) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return $candidate
+        }
+    }
+
+    return $null
+}

--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -28,7 +28,7 @@ $script:INFERENCE_PID_FILE = Join-Path (Join-Path $script:DS_INSTALL_DIR "data")
 $script:LEMONADE_VERSION     = "10.0.0"
 $script:LEMONADE_MSI_FILE    = "lemonade-server-minimal.msi"
 $script:LEMONADE_MSI_URL     = "https://github.com/lemonade-sdk/lemonade/releases/download/v$($script:LEMONADE_VERSION)/$($script:LEMONADE_MSI_FILE)"
-# NOTE: ALLUSERS=1 installs to "Program Files\Lemonade Server" (with space)
+# Default path; install-windows.ps1 resolves both Program Files roots at runtime.
 $script:LEMONADE_INSTALL_DIR = Join-Path $env:ProgramFiles "Lemonade Server"
 $script:LEMONADE_EXE         = Join-Path (Join-Path $script:LEMONADE_INSTALL_DIR "bin") "lemonade-server.exe"
 $script:LEMONADE_PORT        = 8080

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -112,6 +112,18 @@ function New-DreamEnv {
         return $Default
     }
 
+    # Lemonade's native Windows router reserves host port 9000 for websockets.
+    # Keep Whisper's container port unchanged, but move its host port out of the
+    # way on managed AMD/Lemonade installs. Existing .env choices still win.
+    $whisperPortDefault = "9000"
+    if ($GpuBackend -eq "amd" -and $AmdInferenceRuntime -eq "lemonade" -and $AmdInferenceLocation -eq "host") {
+        $whisperPortDefault = "9100"
+    }
+    $whisperPort = Get-EnvOrNew "WHISPER_PORT" $whisperPortDefault
+    if ($whisperPortDefault -eq "9100" -and $whisperPort -eq "9000") {
+        $whisperPort = "9100"
+    }
+
     function Get-ExistingTokenSpyApiKey {
         $tokenSpyKeyFile = Join-Path $InstallDir "data\token-spy\token-spy-api-key.txt"
         if (Test-Path $tokenSpyKeyFile) {
@@ -402,7 +414,7 @@ COMFYUI_CPU_RESERVATION=$comfyuiCpuReservation
 #=== Ports ===
 OLLAMA_PORT=11434
 WEBUI_PORT=3000
-WHISPER_PORT=9000
+WHISPER_PORT=$whisperPort
 TTS_PORT=8880
 N8N_PORT=5678
 QDRANT_PORT=6333

--- a/dream-server/installers/windows/phases/04-requirements.ps1
+++ b/dream-server/installers/windows/phases/04-requirements.ps1
@@ -142,7 +142,8 @@ if ($enableRecommended) {
     $_portsToCheck["Token Spy (usage monitor)"] = 3005
 }
 if ($enableVoice) {
-    $_portsToCheck["Whisper (STT)"] = 9000
+    $_whisperPortToCheck = $(if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) { 9100 } else { 9000 })
+    $_portsToCheck["Whisper (STT)"] = $_whisperPortToCheck
     $_portsToCheck["Kokoro (TTS)"]  = 8880
 }
 if ($enableWorkflows) {

--- a/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
@@ -265,13 +265,105 @@ if command -v pwsh >/dev/null 2>&1; then
             throw "Expected missing root to fail"
         }
         . (Join-Path $env:ROOT_DIR "installers/windows/lib/constants.ps1")
+
+        $probeRoot = Join-Path $env:TEMP "dream-lemonade-resolver-contract"
+        Remove-Item -LiteralPath $probeRoot -Recurse -Force -ErrorAction SilentlyContinue
+        $programFiles = Join-Path $probeRoot "Program Files"
+        $programFilesX86 = Join-Path $probeRoot "Program Files (x86)"
+        ${env:ProgramFiles} = $programFiles
+        ${env:ProgramFiles(x86)} = $programFilesX86
+        $script:LEMONADE_EXE = Join-Path (Join-Path (Join-Path $programFiles "Lemonade Server") "bin") "lemonade-server.exe"
+        $x86Exe = Join-Path (Join-Path (Join-Path $programFilesX86 "Lemonade Server") "bin") "lemonade-server.exe"
+        New-Item -ItemType Directory -Path (Split-Path $x86Exe) -Force | Out-Null
+        Set-Content -LiteralPath $x86Exe -Value "stub" -NoNewline
+        $resolved = Resolve-DreamLemonadeExe
+        if ($resolved -ne $x86Exe) {
+            throw "Expected Program Files (x86) Lemonade path, got: $resolved"
+        }
     '; then
-        pass "backend-contract.ps1: reads explicit root and constants.ps1 stays standalone"
+        pass "backend-contract.ps1: reads explicit root, stays standalone, resolves x86 Lemonade installs"
     else
         fail "backend-contract.ps1: PowerShell contract failed"
     fi
 else
     pass "backend-contract.ps1: runtime test skipped (pwsh unavailable)"
+fi
+
+# ---------------------------------------------------------------------------
+# 17. Windows AMD managed Lemonade avoids host port 9000 collision with Whisper
+# ---------------------------------------------------------------------------
+echo "[contract] Windows AMD managed Lemonade avoids Whisper port 9000"
+if grep -q 'Lemonade.*reserves host port 9000' installers/windows/lib/env-generator.ps1 \
+    && grep -q 'WHISPER_PORT=$whisperPort' installers/windows/lib/env-generator.ps1 \
+    && grep -q '9100' installers/windows/phases/04-requirements.ps1; then
+    pass "Windows AMD/Lemonade defaults Whisper to alternate host port"
+else
+    fail "Windows AMD/Lemonade must avoid Lemonade websocket port collision"
+fi
+
+if command -v pwsh >/dev/null 2>&1; then
+    _ps_tmp="${TMPDIR:-/tmp}"
+    if ROOT_DIR="$ROOT_DIR" TEMP="$_ps_tmp" USERPROFILE="$_ps_tmp" pwsh -NoProfile -Command '
+        $ErrorActionPreference = "Stop"
+        function Write-AIWarn { param([string]$Message) Write-Host "WARN: $Message" }
+        . (Join-Path $env:ROOT_DIR "installers/windows/lib/detection.ps1")
+        . (Join-Path $env:ROOT_DIR "installers/windows/lib/env-generator.ps1")
+        $installDir = Join-Path $env:TEMP "dream-env-generator-amd-lemonade-contract"
+        Remove-Item -LiteralPath $installDir -Recurse -Force -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+        $tier = @{
+            TierName = "Strix Halo"
+            LlmModel = "test-model"
+            GgufFile = "test.gguf"
+            MaxContext = 4096
+        }
+        New-DreamEnv -InstallDir $installDir -TierConfig $tier -Tier "SH" -GpuBackend "amd" -AmdInferenceRuntime "lemonade" -AmdInferenceLocation "host" | Out-Null
+        $envText = Get-Content -LiteralPath (Join-Path $installDir ".env") -Raw
+        if ($envText -notmatch "(?m)^WHISPER_PORT=9100$") {
+            throw "Expected WHISPER_PORT=9100 for Windows AMD managed Lemonade"
+        }
+
+        Set-Content -LiteralPath (Join-Path $installDir ".env") -Value "WHISPER_PORT=9000`n" -NoNewline
+        New-DreamEnv -InstallDir $installDir -TierConfig $tier -Tier "SH" -GpuBackend "amd" -AmdInferenceRuntime "lemonade" -AmdInferenceLocation "host" | Out-Null
+        $envText = Get-Content -LiteralPath (Join-Path $installDir ".env") -Raw
+        if ($envText -notmatch "(?m)^WHISPER_PORT=9100$") {
+            throw "Expected unsafe WHISPER_PORT=9000 to be remapped for Lemonade"
+        }
+
+        Set-Content -LiteralPath (Join-Path $installDir ".env") -Value "WHISPER_PORT=9200`n" -NoNewline
+        New-DreamEnv -InstallDir $installDir -TierConfig $tier -Tier "SH" -GpuBackend "amd" -AmdInferenceRuntime "lemonade" -AmdInferenceLocation "host" | Out-Null
+        $envText = Get-Content -LiteralPath (Join-Path $installDir ".env") -Raw
+        if ($envText -notmatch "(?m)^WHISPER_PORT=9200$") {
+            throw "Expected existing WHISPER_PORT override to be preserved"
+        }
+    '; then
+        pass "env-generator.ps1: AMD Lemonade uses 9100 and preserves explicit overrides"
+    else
+        fail "env-generator.ps1: AMD Lemonade Whisper port contract failed"
+    fi
+else
+    pass "env-generator.ps1: runtime port test skipped (pwsh unavailable)"
+fi
+
+if grep -q 'backend-contract.ps1' installers/windows/dream.ps1 \
+    && grep -q 'Resolve-DreamLemonadeExe' installers/windows/dream.ps1; then
+    pass "dream.ps1 resolves Lemonade across both Program Files roots"
+else
+    fail "dream.ps1 must use Lemonade resolver for installed CLI commands"
+fi
+
+# ---------------------------------------------------------------------------
+# 18. Windows image validation treats missing local images as probe misses
+# ---------------------------------------------------------------------------
+echo "[contract] Windows Docker image validation is stderr-safe"
+if grep -A16 'function Test-DreamDockerImageAvailable' installers/windows/install-windows.ps1 \
+    | grep -q 'SilentlyContinue' \
+    && grep -A20 'function Test-DreamDockerImageAvailable' installers/windows/install-windows.ps1 \
+        | grep -q 'finally' \
+    && grep -q 'docker manifest inspect' installers/windows/install-windows.ps1; then
+    pass "install-windows.ps1: image availability probes restore ErrorActionPreference"
+else
+    fail "install-windows.ps1: Docker image probes must not abort on missing local images"
 fi
 
 # ---------------------------------------------------------------------------

--- a/dream-server/tests/test-windows-readiness-summary.sh
+++ b/dream-server/tests/test-windows-readiness-summary.sh
@@ -38,6 +38,8 @@ check 'function Write-DreamInstallReadinessSummary' "$SUMMARY_LIB" "summary writ
 check 'Test-DreamReadinessHttp' "$SUMMARY_LIB" "summary probes HTTP endpoints"
 check 'Get-DreamReadinessContainerState' "$SUMMARY_LIB" "summary reads Docker container state"
 check 'Write-DreamInstallReadinessSummary -Checks $readinessChecks' "$INSTALL_PS1" "installer prints readiness summary"
+check '$windowsEnvMap = Get-WindowsDreamEnvMap -InstallDir $installDir' "$INSTALL_PS1" "installer caches Windows env map for health checks"
+check '$healthWhisperPort' "$INSTALL_PS1" "installer health check uses configured Whisper port"
 
 if command -v pwsh >/dev/null 2>&1; then
     OUTPUT="$(SUMMARY_LIB="$SUMMARY_LIB" pwsh -NoProfile -Command '


### PR DESCRIPTION
﻿## Summary
- resolve native Lemonade from both `Program Files` and `Program Files (x86)` so Windows AMD installs and `dream.ps1` commands do not miss the MSI runtime
- make Windows Docker image availability probes tolerate expected stderr from missing local images before checking the registry manifest
- move Windows AMD managed-Lemonade Whisper host port default to `9100`, remap unsafe existing `WHISPER_PORT=9000`, and preserve non-conflicting custom ports like `9200`
- make Windows install health checks use the configured `WHISPER_PORT`

## Why
Fixes #1503. The issue exposed three connected Windows AMD install failures: Lemonade could be installed but invisible, fresh installs could abort while validating the Hermes image, and once Lemonade actually started its router occupied port `9000`, blocking `dream-whisper`.

## Validation
- PowerShell parser check for modified Windows installer files: PASS
- `tests/contracts/test-amd-lemonade-contracts.sh` via Git Bash: PASS, 44/44
- `tests/test-windows-readiness-summary.sh` via Git Bash: PASS, 9/9
- `tests/test-windows-service-plan.sh` via Git Bash: PASS, 7/7
- `python dream-server/tests/test-fedora-strix-compat.py`: PASS
- Runtime Windows PowerShell check: `Resolve-DreamLemonadeExe` resolves `Program Files (x86)` install root
- Runtime Windows PowerShell check: `New-DreamEnv` writes `WHISPER_PORT=9100` for AMD managed Lemonade, remaps unsafe `9000`, and preserves explicit `9200`
- `git diff --check`: PASS

Note: `tests/contracts/test-installer-contracts.sh` could not run in this local Windows environment because `jq` is not installed on the Git Bash path; the targeted AMD/Lemonade contract it wraps was run directly and passed.
