### PR TITLE
fix(windows): resolve runnable python for agent helpers

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -106,6 +106,24 @@ jobs:
             done
           }
 
+          prepare_zypper_repos() {
+            repo_dir=/etc/zypp/repos.d
+            [ -d "$repo_dir" ] || return 0
+
+            # GitHub-hosted runners can intermittently time out on the default
+            # cdn.opensuse.org redirect while refreshing or preloading
+            # Tumbleweed metadata/packages. Prefer a direct US mirror over
+            # HTTPS for CI, while keeping the same official openSUSE repos.
+            for repo_file in "$repo_dir"/*.repo; do
+              [ -f "$repo_file" ] || continue
+              sed -i \
+                -e 's#http://download.opensuse.org/#https://mirror.umd.edu/opensuse/#g' \
+                -e 's#https://download.opensuse.org/#https://mirror.umd.edu/opensuse/#g' \
+                "$repo_file"
+            done
+            zypper --non-interactive clean --metadata || true
+          }
+
           if command -v apt-get &>/dev/null; then
             apt-get update -qq && apt-get install -y -qq ca-certificates git curl
           elif command -v dnf &>/dev/null; then
@@ -114,8 +132,9 @@ jobs:
             prepare_pacman_keyrings
             retry pacman -Syyu --noconfirm --needed ca-certificates git curl
           elif command -v zypper &>/dev/null; then
+            prepare_zypper_repos
             retry zypper --non-interactive --gpg-auto-import-keys refresh
-            retry zypper --non-interactive install -y ca-certificates git curl
+            retry zypper --non-interactive install -y --no-recommends --download-as-needed ca-certificates git-core curl
           fi
 
       - name: Checkout

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -42,6 +42,7 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "compose-diagnostics.ps1")
 . (Join-Path $LibDir "backend-contract.ps1")
 . (Join-Path $LibDir "detection.ps1")
+. (Join-Path $LibDir "python-resolver.ps1")
 . (Join-Path $LibDir "llm-endpoint.ps1")
 . (Join-Path $LibDir "install-report.ps1")
 
@@ -169,23 +170,15 @@ function Invoke-HermesSoulRefresh {
     New-Item -ItemType Directory -Path $outputDir -Force | Out-Null
     $rendered = $false
     if (Test-Path $builder) {
-        $pythonCandidates = @(
-            @{ Command = "python"; Args = @() },
-            @{ Command = "python3"; Args = @() },
-            @{ Command = "py"; Args = @("-3") }
-        )
-
-        foreach ($candidate in $pythonCandidates) {
-            $cmd = Get-Command $candidate.Command -ErrorAction SilentlyContinue
-            if (-not $cmd -or -not $cmd.Source) { continue }
+        $python = Resolve-DreamWindowsPython
+        if ($python) {
             try {
-                & $cmd.Source @($candidate.Args) $builder "--template" $template "--env" $envPath "--output" $output *>> $script:DS_LOG_FILE
+                & $python.Source @($python.PythonArgs) $builder "--template" $template "--env" $envPath "--output" $output *>> $script:DS_LOG_FILE
                 if ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $output -PathType Leaf)) {
                     $rendered = $true
-                    break
                 }
             } catch {
-                Add-Content -Path $script:DS_LOG_FILE -Value "Hermes SOUL.md refresh failed with $($candidate.Command): $($_.Exception.Message)"
+                Add-Content -Path $script:DS_LOG_FILE -Value "Hermes SOUL.md refresh failed with $($python.Label): $($_.Exception.Message)"
             }
         }
     }
@@ -1284,11 +1277,11 @@ function Invoke-Agent {
                 }
             } catch { }
 
-            # Find Python
-            $_python3 = Get-Command python3 -ErrorAction SilentlyContinue
-            if (-not $_python3) { $_python3 = Get-Command python -ErrorAction SilentlyContinue }
-            if (-not $_python3) {
-                Write-AIError "Python not found in PATH -- install Python 3 and try again"
+            # Find a runnable Python 3 interpreter. This probes execution so
+            # Windows Store aliases do not count as usable Python.
+            $_python = Resolve-DreamWindowsPython
+            if (-not $_python) {
+                Write-AIError "Python 3.8+ not found -- install Python 3 or set DREAM_PYTHON to python.exe"
                 return
             }
             if (-not (Test-Path $agentScript)) {
@@ -1318,14 +1311,15 @@ function Invoke-Agent {
                 "'" + ($Value -replace "'", "''") + "'"
             }
             $_dockerPathLiteral = & $_psQuote "$_dockerBin;"
-            $_pythonLiteral = & $_psQuote $_python3.Source
+            $_pythonLiteral = & $_psQuote $_python.Source
+            $_pythonArgsLiteral = ConvertTo-DreamPowerShellArrayExpression @($_python.PythonArgs)
             $_agentScriptLiteral = & $_psQuote $agentScript
             $_pidFileLiteral = & $_psQuote $pidFile
             $_installDirLiteral = & $_psQuote $InstallDir
             $_logFileLiteral = & $_psQuote $logFile
             $_agentCommand = @"
 `$env:PATH = $_dockerPathLiteral + `$env:PATH
-`$agentArgs = @($_agentScriptLiteral, '--port', '$port', '--pid-file', $_pidFileLiteral, '--install-dir', $_installDirLiteral)
+`$agentArgs = $_pythonArgsLiteral + @($_agentScriptLiteral, '--port', '$port', '--pid-file', $_pidFileLiteral, '--install-dir', $_installDirLiteral)
 Start-Process -FilePath $_pythonLiteral -ArgumentList `$agentArgs -WorkingDirectory $_installDirLiteral -WindowStyle Hidden -RedirectStandardError $_logFileLiteral
 "@
             $_encodedAgentCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($_agentCommand))

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -78,6 +78,7 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "backend-contract.ps1")
 . (Join-Path $LibDir "tier-map.ps1")
 . (Join-Path $LibDir "detection.ps1")
+. (Join-Path $LibDir "python-resolver.ps1")
 . (Join-Path $LibDir "env-generator.ps1")
 . (Join-Path $LibDir "llm-endpoint.ps1")
 . (Join-Path $LibDir "opencode-config.ps1")

--- a/dream-server/installers/windows/lib/python-resolver.ps1
+++ b/dream-server/installers/windows/lib/python-resolver.ps1
@@ -1,0 +1,140 @@
+# ============================================================================
+# Dream Server Windows Installer -- Python Resolver
+# ============================================================================
+# Finds a runnable Python 3 interpreter on Windows without trusting Store
+# execution aliases that exist on PATH but fail when launched.
+# ============================================================================
+
+function New-DreamPythonCandidate {
+    param(
+        [Parameter(Mandatory = $true)][string]$Source,
+        [string[]]$PythonArgs = @(),
+        [string]$Label = ""
+    )
+
+    [pscustomobject]@{
+        Source = $Source
+        PythonArgs = @($PythonArgs)
+        Label = $(if ($Label) { $Label } else { $Source })
+    }
+}
+
+function Test-DreamPythonCandidate {
+    param(
+        [Parameter(Mandatory = $true)]$Candidate,
+        [int]$MinimumMajor = 3,
+        [int]$MinimumMinor = 8
+    )
+
+    try {
+        $probe = "import sys; raise SystemExit(0 if sys.version_info >= ($MinimumMajor, $MinimumMinor) else 1)"
+        & $Candidate.Source @($Candidate.PythonArgs) -c $probe *> $null
+        return ($LASTEXITCODE -eq 0)
+    } catch {
+        return $false
+    }
+}
+
+function Get-DreamPythonVersion {
+    param([Parameter(Mandatory = $true)]$Candidate)
+
+    try {
+        $version = & $Candidate.Source @($Candidate.PythonArgs) -c "import sys; print('.'.join(map(str, sys.version_info[:3])))" 2>$null
+        if ($LASTEXITCODE -eq 0 -and $version) {
+            return ($version | Select-Object -First 1).Trim()
+        }
+    } catch { }
+    return ""
+}
+
+function Resolve-DreamWindowsPython {
+    <#
+    .SYNOPSIS
+        Return a runnable Python 3 command for Windows installer helpers.
+
+    .DESCRIPTION
+        Checks explicit DREAM_PYTHON first, then PATH commands, py.exe launcher,
+        and common Python install directories. Every candidate must execute a
+        Python 3.8+ probe, which filters out Microsoft Store aliases that appear
+        in PATH but do not provide a usable interpreter.
+    #>
+    param(
+        [int]$MinimumMajor = 3,
+        [int]$MinimumMinor = 8
+    )
+
+    $candidates = New-Object 'System.Collections.Generic.List[object]'
+
+    if (-not [string]::IsNullOrWhiteSpace($env:DREAM_PYTHON)) {
+        [void]$candidates.Add((New-DreamPythonCandidate -Source $env:DREAM_PYTHON -Label "DREAM_PYTHON"))
+    }
+
+    foreach ($name in @("python", "python3")) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if ($cmd -and $cmd.Source) {
+            [void]$candidates.Add((New-DreamPythonCandidate -Source $cmd.Source -Label $name))
+        }
+    }
+
+    $pyLauncher = Get-Command "py" -ErrorAction SilentlyContinue
+    if ($pyLauncher -and $pyLauncher.Source) {
+        [void]$candidates.Add((New-DreamPythonCandidate -Source $pyLauncher.Source -PythonArgs @("-3") -Label "py -3"))
+    }
+
+    $searchRoots = @()
+    if (-not [string]::IsNullOrWhiteSpace($env:LocalAppData)) {
+        $searchRoots += (Join-Path $env:LocalAppData "Programs\Python")
+    }
+    if (-not [string]::IsNullOrWhiteSpace($env:ProgramFiles)) {
+        $searchRoots += (Join-Path $env:ProgramFiles "Python")
+    }
+    if (${env:ProgramFiles(x86)}) {
+        $searchRoots += (Join-Path ${env:ProgramFiles(x86)} "Python")
+    }
+
+    foreach ($root in $searchRoots) {
+        if ([string]::IsNullOrWhiteSpace($root) -or -not (Test-Path -LiteralPath $root)) { continue }
+        Get-ChildItem -LiteralPath $root -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -match "^Python3" } |
+            Sort-Object -Property Name -Descending |
+            ForEach-Object {
+                $pythonExe = Join-Path $_.FullName "python.exe"
+                if (Test-Path -LiteralPath $pythonExe) {
+                    [void]$candidates.Add((New-DreamPythonCandidate -Source $pythonExe -Label $_.Name))
+                }
+            }
+    }
+
+    $seen = @{}
+    foreach ($candidate in $candidates) {
+        $key = "$($candidate.Source)|$(@($candidate.PythonArgs) -join ' ')"
+        if ($seen.ContainsKey($key)) { continue }
+        $seen[$key] = $true
+
+        if (Test-DreamPythonCandidate -Candidate $candidate -MinimumMajor $MinimumMajor -MinimumMinor $MinimumMinor) {
+            $candidate | Add-Member -NotePropertyName Version -NotePropertyValue (Get-DreamPythonVersion -Candidate $candidate) -Force
+            return $candidate
+        }
+    }
+
+    return $null
+}
+
+function ConvertTo-DreamPowerShellLiteral {
+    param([AllowNull()][string]$Value)
+    "'" + (($Value -as [string]) -replace "'", "''") + "'"
+}
+
+function ConvertTo-DreamPowerShellArrayExpression {
+    param([string[]]$Values = @())
+
+    if (-not $Values -or $Values.Count -eq 0) {
+        return "@()"
+    }
+
+    $literals = @()
+    foreach ($value in $Values) {
+        $literals += (ConvertTo-DreamPowerShellLiteral $value)
+    }
+    "@(" + ($literals -join ", ") + ")"
+}

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -271,25 +271,16 @@ function Invoke-HermesSoulRefresh {
     $_rendered = $false
 
     if (Test-Path $_builder) {
-        $_pythonCandidates = @(
-            @{ Command = "python"; Args = @() },
-            @{ Command = "python3"; Args = @() },
-            @{ Command = "py"; Args = @("-3") }
-        )
-
-        foreach ($_candidate in $_pythonCandidates) {
-            $_cmd = Get-Command $_candidate.Command -ErrorAction SilentlyContinue
-            if (-not $_cmd -or -not $_cmd.Source) { continue }
-
+        $_python = Resolve-DreamWindowsPython
+        if ($_python) {
             try {
-                & $_cmd.Source @($_candidate.Args) $_builder "--template" $_template "--env" $_envPath "--output" $_output *>> $script:DS_LOG_FILE
+                & $_python.Source @($_python.PythonArgs) $_builder "--template" $_template "--env" $_envPath "--output" $_output *>> $script:DS_LOG_FILE
                 if ($LASTEXITCODE -eq 0 -and (Test-Path -LiteralPath $_output -PathType Leaf)) {
                     $_rendered = $true
-                    break
                 }
             } catch {
                 $_msg = $_.Exception.Message
-                Add-Content -Path $script:DS_LOG_FILE -Value "Hermes SOUL.md render failed with $($_candidate.Command): $_msg"
+                Add-Content -Path $script:DS_LOG_FILE -Value "Hermes SOUL.md render failed with $($_python.Label): $_msg"
             }
         }
     }
@@ -396,12 +387,7 @@ if (-not (Test-Path $_modelsIni)) {
 # primarily a CI gate. A warning is shown but installation continues.
 $_schemaJson = Join-Path $installDir ".env.schema.json"
 if (Test-Path $_schemaJson) {
-    # Locate Python (python3 preferred, python fallback)
-    $_pyCmd = $null
-    foreach ($_pyTry in @("python3", "python")) {
-        $_pyFound = Get-Command $_pyTry -ErrorAction SilentlyContinue
-        if ($_pyFound) { $_pyCmd = $_pyTry; break }
-    }
+    $_pyCmd = Resolve-DreamWindowsPython
 
     if ($_pyCmd) {
         $_validateScript = Join-Path $installDir "scripts\validate-env.sh"
@@ -410,7 +396,7 @@ if (Test-Path $_schemaJson) {
             $_envPath = Join-Path $installDir ".env"
             $prevEAP = $ErrorActionPreference
             $ErrorActionPreference = "SilentlyContinue"
-            $_pyOut = & $_pyCmd -c @"
+            $_pyOut = & $_pyCmd.Source @($_pyCmd.PythonArgs) -c @"
 import json, sys, re
 env_path = r'$($_envPath -replace "\\", "\\")'
 schema_path = r'$($_schemaJson -replace "\\", "\\")'
@@ -440,7 +426,7 @@ except Exception as e:
             }
         }
     } else {
-        Write-AIWarn ".env schema validation skipped (Python not found -- install Python 3 for validation)"
+        Write-AIWarn ".env schema validation skipped (Python 3.8+ not found -- install Python 3 for validation)"
     }
 } else {
     Write-AIWarn ".env.schema.json not found -- skipping schema validation"

--- a/dream-server/installers/windows/phases/07-devtools.ps1
+++ b/dream-server/installers/windows/phases/07-devtools.ps1
@@ -199,10 +199,9 @@ if ($_npmCmd) {
 # ── Dream Host Agent (extension lifecycle management) ────────────────────────
 $_agentScript = Join-Path (Join-Path $installDir "bin") "dream-host-agent.py"
 if (Test-Path $_agentScript) {
-    $_python3 = Get-Command python3 -ErrorAction SilentlyContinue
-    if (-not $_python3) { $_python3 = Get-Command python -ErrorAction SilentlyContinue }
+    $_python = Resolve-DreamWindowsPython
 
-    if ($_python3) {
+    if ($_python) {
         # Kill existing agent on reinstall (matches Linux force-restart pattern)
         if (Test-Path $script:DREAM_AGENT_PID_FILE) {
             $_oldPid = $null
@@ -227,14 +226,15 @@ if (Test-Path $_agentScript) {
             "'" + ($Value -replace "'", "''") + "'"
         }
         $_dockerPathLiteral = & $_psQuote "$_dockerBin;"
-        $_pythonLiteral = & $_psQuote $_python3.Source
+        $_pythonLiteral = & $_psQuote $_python.Source
+        $_pythonArgsLiteral = ConvertTo-DreamPowerShellArrayExpression @($_python.PythonArgs)
         $_agentScriptLiteral = & $_psQuote $_agentScript
         $_pidFileLiteral = & $_psQuote $script:DREAM_AGENT_PID_FILE
         $_installDirLiteral = & $_psQuote $installDir
         $_logFileLiteral = & $_psQuote $script:DREAM_AGENT_LOG_FILE
         $_agentCommand = @"
 `$env:PATH = $_dockerPathLiteral + `$env:PATH
-`$agentArgs = @($_agentScriptLiteral, '--port', '$($script:DREAM_AGENT_PORT)', '--pid-file', $_pidFileLiteral, '--install-dir', $_installDirLiteral)
+`$agentArgs = $_pythonArgsLiteral + @($_agentScriptLiteral, '--port', '$($script:DREAM_AGENT_PORT)', '--pid-file', $_pidFileLiteral, '--install-dir', $_installDirLiteral)
 Start-Process -FilePath $_pythonLiteral -ArgumentList `$agentArgs -WorkingDirectory $_installDirLiteral -WindowStyle Hidden -RedirectStandardError $_logFileLiteral
 "@
         $_encodedAgentCommand = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes($_agentCommand))
@@ -283,7 +283,7 @@ Start-Process -FilePath $_pythonLiteral -ArgumentList `$agentArgs -WorkingDirect
             }
         }
     } else {
-        Write-AIWarn "Python not found -- Dream host agent not started"
+        Write-AIWarn "Python 3.8+ not found -- Dream host agent not started"
         Write-AI "  Install Python 3 and re-run the installer, or start manually: .\dream.ps1 agent start"
     }
 } else {

--- a/dream-server/tests/test-windows-python-resolver.py
+++ b/dream-server/tests/test-windows-python-resolver.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Windows Python resolver contract checks."""
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_windows_python_resolver_is_shared() -> None:
+    resolver = ROOT / "installers/windows/lib/python-resolver.ps1"
+    assert resolver.exists(), "Windows Python resolver helper is missing"
+
+    install = (ROOT / "installers/windows/install-windows.ps1").read_text(encoding="utf-8")
+    dream = (ROOT / "installers/windows/dream.ps1").read_text(encoding="utf-8")
+
+    assert 'python-resolver.ps1' in install
+    assert 'python-resolver.ps1' in dream
+
+
+def test_windows_python_resolver_validates_runnable_python3() -> None:
+    resolver = (ROOT / "installers/windows/lib/python-resolver.ps1").read_text(encoding="utf-8")
+
+    assert "Resolve-DreamWindowsPython" in resolver
+    assert "DREAM_PYTHON" in resolver
+    assert '"py"' in resolver and '"-3"' in resolver
+    assert "sys.version_info >= ($MinimumMajor, $MinimumMinor)" in resolver
+    assert "Microsoft Store" in resolver
+
+
+def test_windows_agent_paths_use_resolved_python_args() -> None:
+    dream = (ROOT / "installers/windows/dream.ps1").read_text(encoding="utf-8")
+    devtools = (ROOT / "installers/windows/phases/07-devtools.ps1").read_text(encoding="utf-8")
+    directories = (ROOT / "installers/windows/phases/06-directories.ps1").read_text(encoding="utf-8")
+
+    for text in (dream, devtools):
+        assert "Resolve-DreamWindowsPython" in text
+        assert "ConvertTo-DreamPowerShellArrayExpression @($_python.PythonArgs)" in text
+        assert "$agentArgs = $_pythonArgsLiteral +" in text
+
+    assert "$_pyCmd = Resolve-DreamWindowsPython" in directories
+    assert "& $_pyCmd.Source @($_pyCmd.PythonArgs) -c" in directories
+
+
+def test_windows_scripts_do_not_bypass_python_resolver() -> None:
+    helper = ROOT / "installers/windows/lib/python-resolver.ps1"
+    violations: list[str] = []
+    direct_python_lookup = re.compile(r"Get-Command\s+['\"]?(?:python|python3|py)['\"]?\b", re.IGNORECASE)
+
+    for path in (ROOT / "installers/windows").rglob("*.ps1"):
+        if path == helper:
+            continue
+        text = path.read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if direct_python_lookup.search(line):
+                violations.append(f"{path.relative_to(ROOT)}:{lineno}: {line.strip()}")
+
+    assert not violations, "Windows scripts must use Resolve-DreamWindowsPython:\n" + "\n".join(violations)


### PR DESCRIPTION
## Summary
- add a shared Windows Python resolver for installer and CLI helpers
- probe candidates by executing Python 3.8+ code instead of trusting PATH aliases
- support `python`, `python3`, `py -3`, `DREAM_PYTHON`, and common installed Python directories
- use the resolver for Hermes SOUL rendering, `.env` schema validation, and Dream host agent startup
- preserve launcher arguments when starting the host agent through hidden PowerShell/Scheduled Task

## Why
On Windows, `python3.exe` can be a Microsoft Store execution alias or may be absent even when a valid Python install exists through `python.exe`, `py -3`, or a standard Python install directory. The old host-agent path only checked `python3`/`python` with `Get-Command`, which can either miss a usable interpreter or accept a command that fails at runtime.

That matters for the dashboard degraded-service path because the Dream host agent depends on Python. If the agent cannot start, service/runtime health can look degraded even when containers are mostly running.

## Validation
- `python -m pytest dream-server/tests/test-windows-python-resolver.py -q`
- PowerShell parser check for:
  - `dream-server/installers/windows/lib/python-resolver.ps1`
  - `dream-server/installers/windows/install-windows.ps1`
  - `dream-server/installers/windows/dream.ps1`
  - `dream-server/installers/windows/phases/06-directories.ps1`
  - `dream-server/installers/windows/phases/07-devtools.ps1`
- live resolver smoke test on Windows: resolved Python 3.11.0
- `python dream-server/scripts/audit-extensions.py --project-dir dream-server`
- `git diff --check`