### PR TITLE
fix(windows): fail loud when container stack is absent

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -763,6 +763,48 @@ if ($dryRun) {
             Write-AI "Saved compose launch record to $recordPath"
         }
 
+        function Assert-DreamWindowsManagedContainers {
+            param(
+                [string]$InstallDir,
+                [string[]]$ComposeFlags,
+                [string[]]$RequiredServices
+            )
+
+            Push-Location $InstallDir
+            try {
+                $managedIds = @(& docker compose @ComposeFlags ps -q 2>$null |
+                    Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                if ($managedIds.Count -eq 0) {
+                    Write-AIError "Docker Compose did not create any managed Windows containers."
+                    Write-AI "  Native inference may be healthy, but Dream Server also needs the dashboard/chat container stack."
+                    Write-AI "  Inspect with: docker compose $($ComposeFlags -join ' ') ps -a"
+                    return $false
+                }
+
+                $missingServices = New-Object System.Collections.Generic.List[string]
+                foreach ($service in $RequiredServices) {
+                    $serviceIds = @(& docker compose @ComposeFlags ps -q $service 2>$null |
+                        Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+                    if ($serviceIds.Count -eq 0) {
+                        [void]$missingServices.Add($service)
+                    }
+                }
+
+                if ($missingServices.Count -gt 0) {
+                    Write-AIError "Docker Compose did not start required Windows service(s): $($missingServices -join ', ')"
+                    Write-AI "  Native inference may be healthy, but Dream Server is not ready without these containers."
+                    Write-AI "  Inspect with: docker compose $($ComposeFlags -join ' ') ps -a"
+                    return $false
+                }
+
+                Write-AISuccess "Compose-managed Windows stack running ($($managedIds.Count) container(s))"
+                return $true
+            }
+            finally {
+                Pop-Location
+            }
+        }
+
         # ── Start Docker services ─────────────────────────────────────────────
         Write-Chapter "STARTING SERVICES"
 
@@ -977,6 +1019,16 @@ if ($dryRun) {
             exit 1
         }
         Write-AISuccess "Docker services started"
+        if (-not (Assert-DreamWindowsManagedContainers -InstallDir $installDir -ComposeFlags $composeFlags `
+                    -RequiredServices @("dashboard", "dashboard-api", "open-webui"))) {
+            Write-DreamComposeDiagnostics -InstallDir $installDir -ComposeFlags $composeFlags `
+                -ComposeArgs @("ps", "-a") `
+                -ComposeLogPath $_composeLog `
+                -Phase "install-windows.ps1 managed container assertion" `
+                -NextStep "Fix the missing Windows container stack shown above, then re-run .\install-windows.ps1." `
+                -SaveReport
+            exit 1
+        }
 
         if ($enableHermes -and (Get-Command Invoke-HermesSoulRefresh -ErrorAction SilentlyContinue)) {
             Invoke-HermesSoulRefresh -InstallRoot $installDir -SyncContainer
@@ -1352,10 +1404,10 @@ if ($allHealthy) {
     Write-SuccessCard
 } else {
     Write-Host ""
-    Write-AIWarn "Some services may still be starting. Check status with:"
+    Write-AIWarn "Install finished, but one or more services are not ready yet. Check status with:"
     Write-Host "  .\dream.ps1 status" -ForegroundColor Cyan
+    Write-AIWarn "Dream Server is not being marked fully healthy until readiness recovers."
     Write-Host ""
-    Write-SuccessCard
 }
 
 # ── Pre-mark setup wizard complete ────────────────────────────────────────────

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -297,5 +297,8 @@ assert_contains "scripts/bootstrap-upgrade.sh" 'write_status "swapping"' "Bootst
 assert_contains "installers/macos/install-macos.sh" 'compose-launch\.txt' "macOS installer missing compose launch record"
 assert_contains "installers/macos/install-macos.sh" 'ps -q' "macOS installer does not count compose-managed containers"
 assert_contains "installers/macos/install-macos.sh" 'docker compose up completed but created no managed containers' "macOS installer does not fail loud on zero managed containers"
+assert_contains "installers/windows/install-windows.ps1" 'Assert-DreamWindowsManagedContainers' "Windows installer does not assert compose-managed containers"
+assert_contains "installers/windows/install-windows.ps1" 'Docker Compose did not create any managed Windows containers' "Windows installer does not fail loud on zero managed containers"
+assert_contains "installers/windows/install-windows.ps1" 'dashboard", "dashboard-api", "open-webui' "Windows installer does not require core container services"
 
 echo "[PASS] installer hardening contracts"

--- a/dream-server/tests/test-windows-readiness-summary.sh
+++ b/dream-server/tests/test-windows-readiness-summary.sh
@@ -40,6 +40,10 @@ check 'Get-DreamReadinessContainerState' "$SUMMARY_LIB" "summary reads Docker co
 check 'Write-DreamInstallReadinessSummary -Checks $readinessChecks' "$INSTALL_PS1" "installer prints readiness summary"
 check '$windowsEnvMap = Get-WindowsDreamEnvMap -InstallDir $installDir' "$INSTALL_PS1" "installer caches Windows env map for health checks"
 check '$healthWhisperPort' "$INSTALL_PS1" "installer health check uses configured Whisper port"
+check 'Assert-DreamWindowsManagedContainers' "$INSTALL_PS1" "installer asserts compose-managed containers exist"
+check 'Docker Compose did not create any managed Windows containers' "$INSTALL_PS1" "installer fails loud on zero Windows containers"
+check '-RequiredServices @("dashboard", "dashboard-api", "open-webui")' "$INSTALL_PS1" "installer requires core Windows container services"
+check 'Dream Server is not being marked fully healthy until readiness recovers.' "$INSTALL_PS1" "installer avoids success card wording on degraded readiness"
 
 if command -v pwsh >/dev/null 2>&1; then
     OUTPUT="$(SUMMARY_LIB="$SUMMARY_LIB" pwsh -NoProfile -Command '


### PR DESCRIPTION
## Summary

Fixes #1508 by preventing Windows AMD installs from reporting healthy when native Lemonade is running but the Docker-managed Dream Server stack is absent.

This adds a post-compose assertion that the current compose project has running managed containers and that the core Windows services are present:

- dashboard
- dashboard-api
- open-webui

If compose starts no containers, or misses those core services, the installer now prints compose diagnostics and exits instead of continuing to a healthy-looking summary.

## Why

The Strixy fleet run showed a trust-breaking false green: Lemonade was healthy on the host, but `docker ps` / `docker compose ls` showed no Dream Server container stack, while the install summary still said `healthy:true`.

Native inference alone is not a complete Dream Server install. The dashboard/chat container stack must be present too.

## Validation

- PowerShell parser check for `installers/windows/install-windows.ps1`
- `tests/test-windows-readiness-summary.sh`
- `tests/contracts/test-installer-hardening.sh`
- `git diff --check`

## Risk

Low to moderate. This only changes Windows install readiness behavior after `docker compose up` returns. Healthy installs should keep passing. Broken installs now fail loudly instead of looking successful.