### PR TITLE
fix(windows): verify LLM readiness and Lemonade swaps

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -31,6 +31,7 @@ test: ## Run unit and contract tests
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
 	@bash tests/test-litellm-amd-auth-enforced.sh
+	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@echo ""
 	@echo "=== Overlay/plist contracts ==="
 	@bash tests/contracts/test-overlay-map-coherence.sh

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -1189,6 +1189,28 @@ foreach ($check in $healthChecks) {
     }
 }
 
+# ── LLM model-serving gate ───────────────────────────────────────────────────
+# A healthy LLM process is NOT proof the model can serve: if the GGUF backing file
+# was never placed on disk, /v1/models still lists it but every completion 500s.
+# Prove the file exists AND a minimal completion succeeds before this install may
+# report healthy — otherwise fail loud instead of a "health says yes, chat says no"
+# green install.
+if (-not $cloudMode) {
+    Write-AI "Verifying the LLM can actually serve a completion..."
+    $llmReady = Test-WindowsLlmModelReadiness -Endpoint $llmEndpoint -InstallDir $installDir `
+        -GgufFile $tierConfig.GgufFile -GpuBackend $gpuInfo.Backend -TimeoutSec 120
+    if ($llmReady.Ok) {
+        Write-AISuccess "LLM serving verified (model: $($llmReady.ModelId))"
+    } else {
+        $allHealthy = $false
+        Write-AIError "LLM not serving: $($llmReady.Detail)"
+        if (-not $llmReady.FileExists) {
+            Write-Host "    Model file missing: $($llmReady.ModelFile)" -ForegroundColor DarkGray
+            Write-Host "    Re-run the installer to (re)download it: .\install.ps1" -ForegroundColor DarkGray
+        }
+    }
+}
+
 # ── Pre-download the Whisper STT model ───────────────────────────────────────
 # Speaches does NOT auto-download on transcription requests — it returns 404.
 # Trigger the download explicitly, verify it completed, surface recovery

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -1198,7 +1198,7 @@ foreach ($check in $healthChecks) {
 if (-not $cloudMode) {
     Write-AI "Verifying the LLM can actually serve a completion..."
     $llmReady = Test-WindowsLlmModelReadiness -Endpoint $llmEndpoint -InstallDir $installDir `
-        -GgufFile $tierConfig.GgufFile -GpuBackend $gpuInfo.Backend -TimeoutSec 120
+        -GgufFile $tierConfig.GgufFile -TimeoutSec 120
     if ($llmReady.Ok) {
         Write-AISuccess "LLM serving verified (model: $($llmReady.ModelId))"
     } else {

--- a/dream-server/installers/windows/lib/llm-endpoint.ps1
+++ b/dream-server/installers/windows/lib/llm-endpoint.ps1
@@ -142,3 +142,82 @@ function Get-WindowsLocalLlmEndpoint {
         ChatCompletionsUrl = "http://localhost:${port}${apiBasePath}/chat/completions"
     }
 }
+
+function Test-WindowsLlmModelReadiness {
+    <#
+    .SYNOPSIS
+        Prove the local LLM can actually serve, not just that its process is alive.
+    .DESCRIPTION
+        A healthy Lemonade/llama-server process is NOT proof the model works: if the
+        GGUF backing file was never placed on disk, /v1/models still lists the model
+        but every chat/completions returns 500. This gate proves two things before an
+        install may report healthy:
+          1. the GGUF backing file exists at the path the backend loads from, and
+          2. a minimal completion actually succeeds (the real user path).
+        Returns a result hashtable; the caller decides fatality.
+    .OUTPUTS
+        @{ Ok; FileExists; ModelFile; ModelId; CompletionOk; Detail }
+    #>
+    param(
+        [Parameter(Mandatory = $true)] [hashtable]$Endpoint,
+        [Parameter(Mandatory = $true)] [string]$InstallDir,
+        [string]$GgufFile = "",
+        [string]$GpuBackend = "",
+        [int]$TimeoutSec = 120
+    )
+
+    $result = @{ Ok = $false; FileExists = $false; ModelFile = ""; ModelId = ""; CompletionOk = $false; Detail = "" }
+
+    # 1. The backing GGUF must exist on disk where the backend loads it from.
+    if (-not [string]::IsNullOrWhiteSpace($GgufFile)) {
+        $modelPath = Join-Path (Join-Path (Join-Path $InstallDir "data") "models") $GgufFile
+        $result.ModelFile = $modelPath
+        $result.FileExists = Test-Path $modelPath
+    } else {
+        # No local GGUF configured (e.g. cloud/managed backend) -> file gate N/A.
+        $result.FileExists = $true
+    }
+
+    # 2. Resolve the served model id (AMD Lemonade prefixes discovered GGUFs with 'extra.').
+    $modelId = $GgufFile
+    if (-not [string]::IsNullOrWhiteSpace($GgufFile) -and $GpuBackend.ToLowerInvariant() -eq "amd") {
+        $modelId = "extra.$GgufFile"
+    }
+    if ([string]::IsNullOrWhiteSpace($modelId)) { $modelId = "default" }
+    $result.ModelId = $modelId
+
+    # 3. A minimal completion must actually succeed -- this is the real user path that
+    #    a "registered but missing file" install silently fails.
+    $body = @{
+        model       = $modelId
+        messages    = @(@{ role = "user"; content = "hi" })
+        max_tokens  = 1
+        temperature = 0
+        stream      = $false
+    } | ConvertTo-Json -Compress -Depth 5
+
+    try {
+        $resp = Invoke-WebRequest -Method POST -Uri $Endpoint.ChatCompletionsUrl `
+            -ContentType "application/json" -Body $body -TimeoutSec $TimeoutSec `
+            -UseBasicParsing -ErrorAction Stop
+        if ([int]$resp.StatusCode -ge 200 -and [int]$resp.StatusCode -lt 300) {
+            $result.CompletionOk = $true
+        }
+    } catch [System.Net.WebException] {
+        # Narrow I/O-boundary catch: map the failed completion to a meaningful status.
+        $code = -1
+        if ($_.Exception.Response) { $code = [int]$_.Exception.Response.StatusCode }
+        $result.Detail = "completion request failed (status=$code)"
+    }
+
+    if ($result.FileExists -and $result.CompletionOk) {
+        $result.Ok = $true
+        $result.Detail = "model file present and completion succeeded"
+    } elseif (-not $result.FileExists) {
+        $result.Detail = "model '$modelId' is registered but its backing file is missing: $($result.ModelFile)"
+    } elseif ([string]::IsNullOrWhiteSpace($result.Detail)) {
+        $result.Detail = "completion did not succeed"
+    }
+
+    return $result
+}

--- a/dream-server/installers/windows/lib/llm-endpoint.ps1
+++ b/dream-server/installers/windows/lib/llm-endpoint.ps1
@@ -162,7 +162,6 @@ function Test-WindowsLlmModelReadiness {
         [Parameter(Mandatory = $true)] [hashtable]$Endpoint,
         [Parameter(Mandatory = $true)] [string]$InstallDir,
         [string]$GgufFile = "",
-        [string]$GpuBackend = "",
         [int]$TimeoutSec = 120
     )
 
@@ -178,9 +177,18 @@ function Test-WindowsLlmModelReadiness {
         $result.FileExists = $true
     }
 
-    # 2. Resolve the served model id (AMD Lemonade prefixes discovered GGUFs with 'extra.').
+    # 2. Resolve the served model id. Lemonade prefixes discovered GGUFs with
+    #    'extra.', while the native llama-server fallback serves the GGUF name
+    #    directly. Key this off the resolved endpoint, not the broader AMD GPU
+    #    family, so a valid Vulkan fallback install does not false-fail.
     $modelId = $GgufFile
-    if (-not [string]::IsNullOrWhiteSpace($GgufFile) -and $GpuBackend.ToLowerInvariant() -eq "amd") {
+    $isLemonadeEndpoint = $false
+    if ($Endpoint.ContainsKey("Backend")) {
+        $isLemonadeEndpoint = ([string]$Endpoint.Backend).ToLowerInvariant() -eq "lemonade"
+    } elseif ($Endpoint.ContainsKey("ApiBasePath")) {
+        $isLemonadeEndpoint = ([string]$Endpoint.ApiBasePath) -eq "/api/v1"
+    }
+    if (-not [string]::IsNullOrWhiteSpace($GgufFile) -and $isLemonadeEndpoint) {
         $modelId = "extra.$GgufFile"
     }
     if ([string]::IsNullOrWhiteSpace($modelId)) { $modelId = "default" }

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -132,6 +132,177 @@ sync_windows_opencode_config() {
         >/dev/null 2>&1 || log "WARNING: OpenCode config refresh failed (non-fatal)"
 }
 
+read_env_value() {
+    local key="$1"
+    [[ -f "$ENV_FILE" ]] || return 0
+    grep -E "^${key}=" "$ENV_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"\047\r'
+}
+
+is_windows_bash() {
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+windows_path() {
+    local path="$1"
+    if command -v cygpath >/dev/null 2>&1; then
+        cygpath -w "$path"
+    else
+        printf '%s\n' "$path"
+    fi
+}
+
+windows_ps_command() {
+    if command -v powershell.exe >/dev/null 2>&1; then
+        printf '%s\n' "powershell.exe"
+    elif command -v pwsh.exe >/dev/null 2>&1; then
+        printf '%s\n' "pwsh.exe"
+    fi
+}
+
+restart_windows_lemonade_with_full_model() {
+    is_windows_bash || return 1
+
+    local runtime llm_backend
+    runtime="$(read_env_value AMD_INFERENCE_RUNTIME | tr '[:upper:]' '[:lower:]')"
+    llm_backend="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
+    [[ "$runtime" == "lemonade" || "$llm_backend" == "lemonade" ]] || return 1
+
+    local ps_cmd
+    ps_cmd="$(windows_ps_command)"
+    [[ -n "$ps_cmd" ]] || {
+        log "WARNING: no PowerShell executable found; cannot restart native Windows Lemonade."
+        return 1
+    }
+
+    local pid_file bind_addr lemonade_port
+    pid_file="$INSTALL_DIR/data/llama-server.pid"
+    bind_addr="$(read_env_value BIND_ADDRESS)"
+    [[ -n "$bind_addr" ]] || bind_addr="127.0.0.1"
+    lemonade_port="$(read_env_value AMD_INFERENCE_PORT)"
+    [[ -n "$lemonade_port" ]] || lemonade_port="8080"
+
+    log "Restarting native Windows Lemonade with full model..."
+    DREAM_WIN_PID_FILE="$(windows_path "$pid_file")" \
+    DREAM_WIN_MODELS_DIR="$(windows_path "$MODELS_DIR")" \
+    DREAM_WIN_BIND_ADDR="$bind_addr" \
+    DREAM_WIN_LEMONADE_PORT="$lemonade_port" \
+    "$ps_cmd" -NoProfile -ExecutionPolicy Bypass -Command '
+        $ErrorActionPreference = "Stop"
+        $pidPath = $env:DREAM_WIN_PID_FILE
+        if (Test-Path $pidPath) {
+            $rawPid = (Get-Content -LiteralPath $pidPath -Raw).Trim()
+            if ($rawPid -match "^\d+$") {
+                Stop-Process -Id ([int]$rawPid) -Force -ErrorAction SilentlyContinue
+                for ($i = 0; $i -lt 20; $i++) {
+                    $old = Get-Process -Id ([int]$rawPid) -ErrorAction SilentlyContinue
+                    if (-not $old) { break }
+                    Start-Sleep -Milliseconds 500
+                }
+            }
+            Remove-Item -LiteralPath $pidPath -Force -ErrorAction SilentlyContinue
+        }
+
+        $roots = @()
+        if ($env:ProgramFiles) { $roots += $env:ProgramFiles }
+        $pf86 = [Environment]::GetFolderPath("ProgramFilesX86")
+        if ($pf86) { $roots += $pf86 }
+        $exe = $null
+        foreach ($root in $roots) {
+            $candidate = Join-Path (Join-Path (Join-Path $root "Lemonade Server") "bin") "lemonade-server.exe"
+            if (Test-Path $candidate) { $exe = $candidate; break }
+        }
+        if (-not $exe) { throw "lemonade-server.exe not found under Program Files roots" }
+
+        $args = @(
+            "serve",
+            "--port", $env:DREAM_WIN_LEMONADE_PORT,
+            "--host", $env:DREAM_WIN_BIND_ADDR,
+            "--no-tray",
+            "--llamacpp", "vulkan",
+            "--extra-models-dir", $env:DREAM_WIN_MODELS_DIR
+        )
+        $proc = Start-Process -FilePath $exe -ArgumentList $args -WindowStyle Hidden -PassThru
+        New-Item -ItemType Directory -Path (Split-Path -Parent $pidPath) -Force | Out-Null
+        Set-Content -LiteralPath $pidPath -Value $proc.Id
+    ' >/dev/null 2>&1 || {
+        log "WARNING: native Windows Lemonade restart failed."
+        return 1
+    }
+
+    log "Waiting for native Windows Lemonade to serve extra.$FULL_GGUF_FILE ..."
+    local model_id
+    model_id="extra.${FULL_GGUF_FILE//\"/\\\"}"
+    for _i in $(seq 1 12); do
+        if curl -sf --max-time 5 "http://127.0.0.1:${lemonade_port}/api/v1/models" 2>/dev/null \
+            | grep -q "\"id\"[[:space:]]*:[[:space:]]*\"${model_id}\""; then
+            if curl -sf --max-time 240 -X POST \
+                "http://127.0.0.1:${lemonade_port}/api/v1/chat/completions" \
+                -H "Content-Type: application/json" \
+                -d "{\"model\":\"${model_id}\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}" \
+                >/dev/null 2>&1; then
+                log "SUCCESS: native Windows Lemonade completed with ${model_id}"
+                return 0
+            fi
+            log "Windows Lemonade lists ${model_id}, but completion is not ready yet (attempt $_i/12)."
+        else
+            log "Waiting for Windows Lemonade to register ${model_id} (attempt $_i/12)."
+        fi
+        sleep 10
+    done
+
+    log "WARNING: native Windows Lemonade did not complete with ${model_id}; keeping bootstrap model for recovery."
+    return 1
+}
+
+patch_hermes_model_after_swap() {
+    local gpu_backend llm_backend old_model new_model tpl patcher py_cmd
+    gpu_backend="$(read_env_value GPU_BACKEND | tr '[:upper:]' '[:lower:]')"
+    llm_backend="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
+    old_model="$BOOTSTRAP_GGUF_FILE"
+    new_model="$FULL_GGUF_FILE"
+    if [[ "$gpu_backend" == "amd" || "$llm_backend" == "lemonade" ]]; then
+        old_model="extra.$BOOTSTRAP_GGUF_FILE"
+        new_model="extra.$FULL_GGUF_FILE"
+    fi
+
+    log "Patching Hermes config after full-model swap: ${old_model} -> ${new_model}"
+
+    tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
+    patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"
+    py_cmd="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
+    if [[ -f "$tpl" ]]; then
+        if [[ -n "$py_cmd" && -f "$patcher" ]]; then
+            "$py_cmd" "$patcher" "$tpl" --model "$new_model" --context-length "$FULL_MAX_CONTEXT" 2>&1 || \
+                log "WARNING: Could not patch ${tpl} with patch-hermes-config.py"
+        elif sed -i.bak \
+            -e "s|^  default: \"${old_model}\"|  default: \"${new_model}\"|" \
+            -e "s|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|" \
+            -e "s|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|" \
+            "$tpl" 2>&1; then
+            rm -f "${tpl}.bak"
+        else
+            log "WARNING: Could not patch ${tpl}"
+        fi
+    fi
+
+    if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-hermes --format '{{.Names}}' 2>/dev/null | grep -q dream-hermes; then
+        $DOCKER_CMD exec dream-hermes sh -c \
+            "sed -i -e 's|^  default: \"${old_model}\"|  default: \"${new_model}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|' /opt/data/config.yaml" 2>&1 || {
+                log "ERROR: Could not patch Hermes live config after full-model swap."
+                return 1
+            }
+        $DOCKER_CMD restart dream-hermes 2>&1 || {
+            log "ERROR: Could not restart Hermes after full-model swap."
+            return 1
+        }
+    fi
+
+    return 0
+}
+
 # Background monitor: polls .part file size every 2s
 monitor_download() {
     local part_file="$1" total_bytes="$2"
@@ -365,17 +536,9 @@ n-ctx = ${FULL_MAX_CONTEXT}
 EOF
 log "models.ini updated"
 
-# ── Phase 4b: Remove bootstrap model ──
-# Lemonade's --extra-models-dir auto-discovers all GGUFs in /models and may
-# load the bootstrap model instead of the full one specified in models.ini.
-# Remove the bootstrap file to prevent this.
 BOOTSTRAP_GGUF="${BOOTSTRAP_GGUF_FILE:-Qwen3.5-2B-Q4_K_M.gguf}"
 BOOTSTRAP_PATH="$MODELS_DIR/$BOOTSTRAP_GGUF"
-if [[ -f "$BOOTSTRAP_PATH" && "$FULL_GGUF_FILE" != "$BOOTSTRAP_GGUF" ]]; then
-    log "Removing bootstrap model: $BOOTSTRAP_GGUF"
-    rm -f "$BOOTSTRAP_PATH"
-    log "Bootstrap model removed"
-fi
+HOT_SWAP_VERIFIED=false
 
 # ── Phase 5: Hot-swap llama-server (if running) ──
 # Read OLLAMA_PORT from .env (nohup doesn't inherit env vars from parent)
@@ -383,7 +546,27 @@ if [[ -f "$ENV_FILE" ]]; then
     OLLAMA_PORT=$(grep -E '^OLLAMA_PORT=' "$ENV_FILE" | cut -d= -f2 | tr -d '"\047\r')
 fi
 
-if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --format '{{.Names}}' 2>/dev/null | grep -q dream-llama-server; then
+_windows_lemonade_swap_applies=false
+if is_windows_bash; then
+    _runtime_for_swap="$(read_env_value AMD_INFERENCE_RUNTIME | tr '[:upper:]' '[:lower:]')"
+    _backend_for_swap="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
+    if [[ "$_runtime_for_swap" == "lemonade" || "$_backend_for_swap" == "lemonade" ]]; then
+        _windows_lemonade_swap_applies=true
+    fi
+fi
+
+if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
+    if restart_windows_lemonade_with_full_model; then
+        if ! patch_hermes_model_after_swap; then
+            write_status "failed"
+            exit 1
+        fi
+        HOT_SWAP_VERIFIED=true
+    else
+        write_status "failed"
+        exit 1
+    fi
+elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --format '{{.Names}}' 2>/dev/null | grep -q dream-llama-server; then
     log "Restarting llama-server with full model..."
 
     # Read GPU backend from .env (needed for health endpoint and restart strategy)
@@ -584,6 +767,7 @@ if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --f
 
     if $_healthy; then
         log "SUCCESS: llama-server is running with $FULL_LLM_MODEL"
+        HOT_SWAP_VERIFIED=true
         # Regenerate lemonade.yaml with the new model ID and restart LiteLLM.
         # Lemonade exposes models as "extra.<GGUF_FILE>" — the config must
         # reference the exact ID, not a wildcard passthrough.
@@ -939,6 +1123,7 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
 
             if $_healthy; then
                 log "SUCCESS: Native llama-server running with ${_gguf_file} (PID $_new_pid)"
+                HOT_SWAP_VERIFIED=true
             else
                 log "WARNING: New model failed to load. Attempting rollback..."
                 kill "$_new_pid" 2>/dev/null || true
@@ -967,6 +1152,20 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
     fi
 else
     log "Docker services not running. Config updated — full model will load on next start."
+fi
+
+# ── Phase 5b: Remove bootstrap model only after verified full-model serving ──
+# Lemonade's --extra-models-dir auto-discovers all GGUFs in /models. Removing
+# the bootstrap too early can wedge Windows Lemonade: it may keep serving the
+# old model id while the file is gone, producing 500s until a manual restart.
+# Keep the bootstrap as the recovery path unless the new model has answered a
+# real completion.
+if [[ "$HOT_SWAP_VERIFIED" == "true" && -f "$BOOTSTRAP_PATH" && "$FULL_GGUF_FILE" != "$BOOTSTRAP_GGUF" ]]; then
+    log "Removing bootstrap model after verified full-model serving: $BOOTSTRAP_GGUF"
+    rm -f "$BOOTSTRAP_PATH"
+    log "Bootstrap model removed"
+elif [[ "$FULL_GGUF_FILE" != "$BOOTSTRAP_GGUF" && -f "$BOOTSTRAP_PATH" ]]; then
+    log "Keeping bootstrap model until the full model is verified serving: $BOOTSTRAP_GGUF"
 fi
 
 # ── Phase 5c: Update Perplexica's defaultChatModel ──

--- a/dream-server/tests/contracts/test-windows-llm-model-readiness.sh
+++ b/dream-server/tests/contracts/test-windows-llm-model-readiness.sh
@@ -41,6 +41,16 @@ if grep -Eq '\$result\.Ok = \$true' "$LIB" && grep -q 'FileExists -and \$result.
 else
     fail "Ok must require file present AND completion success"
 fi
+if grep -q '\$isLemonadeEndpoint' "$LIB" && grep -q 'Endpoint.ContainsKey("Backend")' "$LIB"; then
+    pass "readiness derives Lemonade model ids from the resolved endpoint"
+else
+    fail "readiness must key Lemonade model-id prefixing off the resolved endpoint"
+fi
+if grep -q 'GpuBackend.ToLowerInvariant() -eq "amd"' "$LIB"; then
+    fail "readiness must not prefix every AMD backend with extra. (llama-server fallback uses plain GGUF id)"
+else
+    pass "AMD llama-server fallback is not treated as Lemonade for model ids"
+fi
 
 # ---------------------------------------------------------------------------
 # 2. The installer wires the gate and fails loud (flips healthy) on failure.
@@ -74,7 +84,7 @@ if command -v pwsh >/dev/null 2>&1; then
         # Dead endpoint so the completion cannot succeed; nonexistent GGUF file.
         \$ep = @{ ChatCompletionsUrl = 'http://127.0.0.1:1/api/v1/chat/completions' }
         \$r = Test-WindowsLlmModelReadiness -Endpoint \$ep -InstallDir 'C:\\__dream_nope__' \`
-                -GgufFile 'Qwen3.5-2B-Q4_K_M.gguf' -GpuBackend 'amd' -TimeoutSec 2
+                -GgufFile 'Qwen3.5-2B-Q4_K_M.gguf' -TimeoutSec 2
         Write-Output (\"OK=\" + \$r.Ok + \";FILE=\" + \$r.FileExists + \";DETAIL=\" + \$r.Detail)
     " 2>/dev/null || true)"
     if echo "$OUT" | grep -q 'OK=False' && echo "$OUT" | grep -qi 'backing file is missing'; then

--- a/dream-server/tests/contracts/test-windows-llm-model-readiness.sh
+++ b/dream-server/tests/contracts/test-windows-llm-model-readiness.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Windows LLM model-readiness contract.
+# Guards the "registered but missing GGUF" false-green: /v1/models lists a model
+# whose backing file is absent, so completions 500 while install reports healthy.
+# The Windows installer must prove (a) the file exists and (b) a minimal completion
+# succeeds before it may report healthy.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+LIB="installers/windows/lib/llm-endpoint.ps1"
+INSTALLER="installers/windows/install-windows.ps1"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# 1. The readiness function exists and gates on BOTH file + completion.
+# ---------------------------------------------------------------------------
+echo "[contract] readiness function exists and checks file + completion"
+if grep -q 'function Test-WindowsLlmModelReadiness' "$LIB"; then
+    pass "Test-WindowsLlmModelReadiness defined in $LIB"
+else
+    fail "Test-WindowsLlmModelReadiness missing from $LIB"
+fi
+if grep -q 'Test-Path \$modelPath' "$LIB"; then
+    pass "readiness checks the GGUF backing file exists on disk"
+else
+    fail "readiness must verify the GGUF backing file exists (Test-Path)"
+fi
+if grep -q 'ChatCompletionsUrl' "$LIB" && grep -q 'CompletionOk' "$LIB"; then
+    pass "readiness performs a real completion (ChatCompletionsUrl -> CompletionOk)"
+else
+    fail "readiness must POST a minimal completion and record CompletionOk"
+fi
+if grep -Eq '\$result\.Ok = \$true' "$LIB" && grep -q 'FileExists -and \$result.CompletionOk' "$LIB"; then
+    pass "Ok requires BOTH file present AND completion success"
+else
+    fail "Ok must require file present AND completion success"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The installer wires the gate and fails loud (flips healthy) on failure.
+# ---------------------------------------------------------------------------
+echo "[contract] installer calls the gate and flips healthy on failure"
+if grep -q 'Test-WindowsLlmModelReadiness' "$INSTALLER"; then
+    pass "install-windows.ps1 invokes the readiness gate"
+else
+    fail "install-windows.ps1 must invoke Test-WindowsLlmModelReadiness"
+fi
+# The gate block must set $allHealthy = $false when not Ok, and healthy = $allHealthy
+# must flow into the install summary.
+if awk '/Test-WindowsLlmModelReadiness/{f=1} f&&/allHealthy = \$false/{print; exit}' "$INSTALLER" | grep -q 'allHealthy'; then
+    pass "readiness failure sets \$allHealthy = \$false"
+else
+    fail "readiness failure must set \$allHealthy = \$false (fail loud)"
+fi
+if grep -Eq 'healthy\s*=\s*\$allHealthy' "$INSTALLER"; then
+    pass "install summary healthy = \$allHealthy (gate flows to summary)"
+else
+    fail "install summary must derive healthy from \$allHealthy"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Behavioral (pwsh): a registered model whose file is missing fails readiness.
+# ---------------------------------------------------------------------------
+if command -v pwsh >/dev/null 2>&1; then
+    echo "[contract] behavioral: missing backing file => readiness NOT ok"
+    OUT="$(pwsh -NoProfile -Command "
+        . '$ROOT_DIR/$LIB'
+        # Dead endpoint so the completion cannot succeed; nonexistent GGUF file.
+        \$ep = @{ ChatCompletionsUrl = 'http://127.0.0.1:1/api/v1/chat/completions' }
+        \$r = Test-WindowsLlmModelReadiness -Endpoint \$ep -InstallDir 'C:\\__dream_nope__' \`
+                -GgufFile 'Qwen3.5-2B-Q4_K_M.gguf' -GpuBackend 'amd' -TimeoutSec 2
+        Write-Output (\"OK=\" + \$r.Ok + \";FILE=\" + \$r.FileExists + \";DETAIL=\" + \$r.Detail)
+    " 2>/dev/null || true)"
+    if echo "$OUT" | grep -q 'OK=False' && echo "$OUT" | grep -qi 'backing file is missing'; then
+        pass "missing file => Ok=False with 'backing file is missing' detail"
+    else
+        fail "expected Ok=False + missing-file detail, got: $OUT"
+    fi
+else
+    echo "[skip] pwsh not available — behavioral readiness check skipped (source invariants still enforced)"
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "Windows LLM model-readiness contract: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]

--- a/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -79,6 +79,39 @@ grep -qF '"/models/${FULL_GGUF_FILE}"' <<<"$active_code" \
     || fail "hot-swap must assert the running command points at the full GGUF"
 pass "hot-swap asserts the running command uses the full GGUF"
 
+grep -qF 'restart_windows_lemonade_with_full_model' <<<"$active_code" \
+    || fail "Windows Lemonade hot-swap must restart the native Lemonade process"
+grep -qF 'extra.${FULL_GGUF_FILE' <<<"$active_code" \
+    || fail "Windows Lemonade hot-swap must verify the full GGUF model id"
+pass "Windows Lemonade hot-swap restarts native inference and verifies the full model"
+
+grep -qF 'patch_hermes_model_after_swap' <<<"$active_code" \
+    || fail "Windows Lemonade hot-swap must patch Hermes off the bootstrap model"
+windows_lemonade_block="$(awk '
+    /_windows_lemonade_swap_applies/ { in_block=1 }
+    in_block { print }
+    in_block && /HOT_SWAP_VERIFIED=true/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+grep -qF 'patch_hermes_model_after_swap' <<<"$windows_lemonade_block" \
+    || fail "Windows Lemonade must patch Hermes before marking the swap verified"
+pass "Windows Lemonade hot-swap patches Hermes before cleanup"
+
+grep -qF 'HOT_SWAP_VERIFIED=true' <<<"$active_code" \
+    || fail "hot-swap must record when the full model is verified serving"
+grep -qF 'Removing bootstrap model after verified full-model serving' <<<"$active_code" \
+    || fail "bootstrap GGUF cleanup must happen only after verified full-model serving"
+bootstrap_cleanup_block="$(awk '
+    /HOT_SWAP_VERIFIED.*true.*BOOTSTRAP_PATH/ { in_block=1 }
+    in_block { print }
+    in_block && /Bootstrap model removed/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+if grep -qF 'HOT_SWAP_VERIFIED' <<<"$bootstrap_cleanup_block" \
+    && grep -qF 'Removing bootstrap model after verified full-model serving' <<<"$bootstrap_cleanup_block"; then
+    pass "bootstrap cleanup is gated by verified full-model serving"
+else
+    fail "bootstrap cleanup must be gated by HOT_SWAP_VERIFIED"
+fi
+
 stale_block="$(awk '
     /llama-server container started with stale --model arg/ { in_block=1 }
     in_block { print }
@@ -90,3 +123,14 @@ grep -qF 'write_status "failed"' <<<"$stale_block" \
 grep -qF 'fail "llama-server container started with stale --model arg after force-recreate."' <<<"$stale_block" \
     || fail "stale --model assertion must exit non-zero"
 pass "stale --model assertion fails loudly"
+
+windows_failure_block="$(awk '
+    /_windows_lemonade_swap_applies/ { in_block=1 }
+    in_block { print }
+    in_block && /exit 1/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+grep -qF 'write_status "failed"' <<<"$windows_failure_block" \
+    || fail "Windows Lemonade hot-swap failure must mark bootstrap status failed"
+grep -qF 'exit 1' <<<"$windows_failure_block" \
+    || fail "Windows Lemonade hot-swap failure must exit non-zero"
+pass "Windows Lemonade hot-swap failure is honest"


### PR DESCRIPTION
## Problem

Fixes #1511 and the Windows Strix/Lemonade post-bootstrap false-green found in fleet run `2026-06-04T00-42-46Z`.

There were two related trust gaps:

1. Windows Phase 9 treated a healthy Lemonade/llama-server process as enough, even if the registered model could not actually complete.
2. On Windows AMD/Lemonade, the background bootstrap upgrade could download the full model and update `.env`, then leave the native Lemonade process serving the deleted bootstrap model. That produced the Strixy state we observed: `/api/v1/models` listed only `extra.Qwen3.5-2B-Q4_K_M.gguf`, the 70B file existed on disk, completion against the 70B returned 404, and completion against the deleted 2B returned 500.

## Fix

- Add `Test-WindowsLlmModelReadiness` to prove both that the GGUF backing file exists and that a minimal completion succeeds before a local Windows install can report healthy.
- Key Lemonade model-id prefixing off the resolved endpoint (`Backend=lemonade` / `/api/v1`), not every AMD backend, so the native llama-server Vulkan fallback keeps the plain GGUF model id.
- Add a Windows Lemonade branch to `bootstrap-upgrade.sh` that restarts the native Lemonade process after the full model is downloaded, waits for the new `extra.<GGUF>` model to register, verifies a real completion, patches Hermes off the bootstrap model, and only then removes the bootstrap GGUF.
- Mark bootstrap upgrade status failed if Windows Lemonade cannot prove the full-model swap, instead of reporting complete while the runtime is wedged.

## Validation

Local checks run:

- `bash -n dream-server/scripts/bootstrap-upgrade.sh`
- `bash dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh`
- `bash dream-server/tests/contracts/test-windows-llm-model-readiness.sh`
- `bash dream-server/tests/test-bootstrap-upgrade-download-finalization.sh`
- `bash dream-server/tests/test-bootstrap-upgrade-resume-status.sh`
- PowerShell parse checks for `install-windows.ps1` and `llm-endpoint.ps1`
- `git diff --check`

Notes: the wider installer contract bundle could not run in this local Windows Git Bash because `jq` is absent; WSL on this machine also lacks `bash`. The targeted contracts for the changed paths pass.