### PR TITLE
Fix Windows Strix Halo model tier selection

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -31,6 +31,7 @@ test: ## Run unit and contract tests
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
 	@bash tests/test-litellm-amd-auth-enforced.sh
+	@bash tests/contracts/test-windows-strix-tier-map.sh
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@echo ""
 	@echo "=== Overlay/plist contracts ==="

--- a/dream-server/installers/windows/lib/tier-map.ps1
+++ b/dream-server/installers/windows/lib/tier-map.ps1
@@ -14,6 +14,8 @@
 $script:CATALOG_SELECTOR_POLICY = "context-aware-largest-capable-general-v1"
 $script:SPARK_AARCH64_POLICY = "spark-aarch64-nv-ultra-a3b-v1"
 $script:SPARK_AARCH64_MODEL_ID = "qwen3.6-35b-a3b-ud-q4"
+$script:UNIFIED_MEMORY_POLICY = "unified-memory-coder-next-a3b-v1"
+$script:UNIFIED_MEMORY_MODEL_ID = "qwen3.6-35b-a3b-ud-q4"
 
 function Normalize-ModelProfile {
     param([string]$ModelProfile = $env:MODEL_PROFILE)
@@ -115,13 +117,17 @@ function Resolve-QwenTierConfig {
             }
         }
         "SH_LARGE" {
+            # Strix Halo (AMD Ryzen AI MAX+ 395, 124GB unified) should stay
+            # on the A3B MoE path proven by fleet. Dense 70B/Coder Next choices
+            # are too aggressive for Windows Lemonade first-run recovery.
             return @{
                 TierName   = "Strix Halo 90+"
-                LlmModel   = "qwen3-coder-next"
-                GgufFile   = "qwen3-coder-next-Q4_K_M.gguf"
-                GgufUrl    = "https://huggingface.co/unsloth/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M.gguf"
-                GgufSha256 = ""
+                LlmModel   = "qwen3.6-35b-a3b"
+                GgufFile   = "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+                GgufUrl    = "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+                GgufSha256 = "ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61"
                 MaxContext = 131072
+                ModelSizeMB = 21110
                 ModelProfileRequested = "qwen"
                 ModelProfileEffective = "qwen"
                 LlamaServerImage = ""
@@ -581,6 +587,15 @@ function Resolve-CatalogModelRecommendation {
         $hostArchName = Get-HostArchitecture
     }
 
+    $backendName = "$($GpuInfo.Backend)".ToLowerInvariant()
+    $memoryTypeName = "$($GpuInfo.MemoryType)".ToLowerInvariant()
+    $isAmdUnifiedStrixLarge = (
+        $Tier -eq "SH_LARGE" -and
+        $modelProfileName -eq "qwen" -and
+        $backendName -eq "amd" -and
+        $memoryTypeName -eq "unified"
+    )
+
     if ($Tier -eq "NV_ULTRA" -and $modelProfileName -eq "qwen" -and $hostArchName -eq "arm64") {
         $selectedArchModel = Get-CatalogModelById -Catalog $catalog -ModelId $script:SPARK_AARCH64_MODEL_ID
         if ($selectedArchModel -and $selectedArchModel.gguf_url) {
@@ -602,6 +617,31 @@ function Resolve-CatalogModelRecommendation {
             $TierConfig["RecommendationConfidence"] = "high"
             $TierConfig["RecommendationReason"] = $reason
             $TierConfig["RecommendationAlternatives"] = "$($selectedArchModel.id):$([int]$selectedArchModel.context_length):$([double]$selectedRequiredGb)"
+            return $TierConfig
+        }
+    }
+
+    if ($isAmdUnifiedStrixLarge) {
+        $selectedUnifiedModel = Get-CatalogModelById -Catalog $catalog -ModelId $script:UNIFIED_MEMORY_MODEL_ID
+        if ($selectedUnifiedModel -and $selectedUnifiedModel.gguf_url) {
+            $selectedRequiredGb = Get-CatalogModelSelectorRequiredGB -Model $selectedUnifiedModel
+            $contextK = [int]([int]$selectedUnifiedModel.context_length / 1024)
+            $reason = "Arch-aware catalog policy ($script:UNIFIED_MEMORY_POLICY): $($selectedUnifiedModel.name) is selected for AMD unified-memory SH_LARGE hosts because Qwen3.6-35B-A3B is the fleet-proven Windows Lemonade target. Dense 70B and Coder Next defaults are avoided for first-run recovery. It needs about ${selectedRequiredGb}GB including context/KV, fits $([Math]::Round($capacityGb, 1))GB $($memory.Label), and gives ${contextK}K context. Throughput requires a local benchmark after first launch."
+
+            $TierConfig["LlmModel"] = $selectedUnifiedModel.llm_model_name
+            $TierConfig["GgufFile"] = $selectedUnifiedModel.gguf_file
+            $TierConfig["GgufUrl"] = $selectedUnifiedModel.gguf_url
+            $TierConfig["GgufSha256"] = $selectedUnifiedModel.gguf_sha256
+            $TierConfig["MaxContext"] = [int]$selectedUnifiedModel.context_length
+            $TierConfig["ModelSizeMB"] = [int][Math]::Round([double]$selectedUnifiedModel.size_mb)
+            if ($selectedUnifiedModel.llama_server_image) {
+                $TierConfig["LlamaServerImage"] = $selectedUnifiedModel.llama_server_image
+            }
+            $TierConfig["RecommendationSource"] = "catalog_arch_policy_pre_download"
+            $TierConfig["RecommendationPolicy"] = "$script:CATALOG_SELECTOR_POLICY+$script:UNIFIED_MEMORY_POLICY"
+            $TierConfig["RecommendationConfidence"] = "high"
+            $TierConfig["RecommendationReason"] = $reason
+            $TierConfig["RecommendationAlternatives"] = "$($selectedUnifiedModel.id):$([int]$selectedUnifiedModel.context_length):$([double]$selectedRequiredGb)"
             return $TierConfig
         }
     }
@@ -737,7 +777,7 @@ function ConvertTo-ModelFromTier {
     switch -Regex ($Tier) {
         "^CLOUD$"                { return "anthropic/claude-sonnet-4-5-20250514" }
         "^NV_ULTRA$"             { return "qwen3-coder-next" }
-        "^SH_LARGE$"             { return "qwen3-coder-next" }
+        "^SH_LARGE$"             { return "qwen3.6-35b-a3b" }
         "^(SH_COMPACT|SH)$"      { return "qwen3-30b-a3b" }
         "^(0|T0)$"               { return "qwen3.5-2b" }
         "^(1|T1)$"               { return "qwen3.5-9b" }

--- a/dream-server/tests/contracts/test-windows-strix-tier-map.sh
+++ b/dream-server/tests/contracts/test-windows-strix-tier-map.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Windows Strix Halo tier-map contract.
+# Guards first-run recovery: SH_LARGE on AMD unified-memory Windows hosts must
+# select the fleet-proven Qwen3.6 35B-A3B MoE, not Coder Next or dense 70B.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+TIER_MAP="installers/windows/lib/tier-map.ps1"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+echo "[contract] Windows SH_LARGE static tier uses Qwen3.6 35B-A3B"
+qwen_block="$(awk '
+    /"SH_LARGE" \{/ { in_block=1 }
+    in_block { print }
+    in_block && /^\s*\}/ { exit }
+' "$TIER_MAP")"
+
+if grep -q 'LlmModel   = "qwen3.6-35b-a3b"' <<<"$qwen_block"; then
+    pass "Resolve-QwenTierConfig SH_LARGE uses qwen3.6-35b-a3b"
+else
+    fail "Resolve-QwenTierConfig SH_LARGE must use qwen3.6-35b-a3b"
+fi
+
+if grep -q 'GgufFile   = "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"' <<<"$qwen_block"; then
+    pass "Resolve-QwenTierConfig SH_LARGE uses Qwen3.6 A3B GGUF"
+else
+    fail "Resolve-QwenTierConfig SH_LARGE must use Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+fi
+
+if grep -q 'qwen3-coder-next\|DeepSeek-R1-Distill-Llama-70B' <<<"$qwen_block"; then
+    fail "Resolve-QwenTierConfig SH_LARGE must not default to Coder Next or dense 70B"
+else
+    pass "Resolve-QwenTierConfig SH_LARGE avoids Coder Next and dense 70B"
+fi
+
+echo "[contract] Windows catalog selector has AMD unified-memory SH_LARGE override"
+if grep -q '\$script:UNIFIED_MEMORY_POLICY = "unified-memory-coder-next-a3b-v1"' "$TIER_MAP" \
+    && grep -q '\$script:UNIFIED_MEMORY_MODEL_ID = "qwen3.6-35b-a3b-ud-q4"' "$TIER_MAP"; then
+    pass "unified-memory A3B policy constants exist"
+else
+    fail "Windows tier map must define unified-memory A3B policy constants"
+fi
+
+if grep -q '\$isAmdUnifiedStrixLarge' "$TIER_MAP" \
+    && grep -q 'Get-CatalogModelById -Catalog \$catalog -ModelId \$script:UNIFIED_MEMORY_MODEL_ID' "$TIER_MAP"; then
+    pass "catalog selector forces Qwen3.6 A3B for AMD unified SH_LARGE"
+else
+    fail "catalog selector must force Qwen3.6 A3B for AMD unified SH_LARGE before generic ranking"
+fi
+
+if awk '/function ConvertTo-ModelFromTier/,/^}/' "$TIER_MAP" | grep -q '\^SH_LARGE\$.*qwen3.6-35b-a3b'; then
+    pass "ConvertTo-ModelFromTier SH_LARGE returns qwen3.6-35b-a3b"
+else
+    fail "ConvertTo-ModelFromTier SH_LARGE must return qwen3.6-35b-a3b"
+fi
+
+ps_bin=""
+for candidate in pwsh powershell powershell.exe; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        ps_bin="$candidate"
+        break
+    fi
+done
+
+if [[ -n "$ps_bin" ]]; then
+    echo "[contract] behavioral: Windows resolver returns Qwen3.6 A3B for Strix Halo"
+    ps_code='
+        $ErrorActionPreference = "Stop"
+        $env:MODEL_PROFILE = "qwen"
+        $env:HOST_ARCH = "amd64"
+        . "./installers/windows/lib/tier-map.ps1"
+        $tierConfig = Resolve-TierConfig -Tier "SH_LARGE"
+        $gpu = @{ Backend = "amd"; MemoryType = "unified"; VramMB = 0 }
+        $resolved = Resolve-CatalogModelRecommendation -TierConfig $tierConfig -Tier "SH_LARGE" -GpuInfo $gpu -SystemRamGB 124 -SourceRoot (Resolve-Path ".")
+        Write-Output ("STATIC={0}|{1}" -f $tierConfig.LlmModel, $tierConfig.GgufFile)
+        Write-Output ("RESOLVED={0}|{1}|{2}" -f $resolved.LlmModel, $resolved.GgufFile, $resolved.RecommendationPolicy)
+    '
+    OUT="$("$ps_bin" -NoProfile -ExecutionPolicy Bypass -Command "$ps_code" 2>/dev/null || true)"
+    if grep -q 'STATIC=qwen3.6-35b-a3b|Qwen3.6-35B-A3B-UD-Q4_K_M.gguf' <<<"$OUT" \
+        && grep -q 'RESOLVED=qwen3.6-35b-a3b|Qwen3.6-35B-A3B-UD-Q4_K_M.gguf|context-aware-largest-capable-general-v1+unified-memory-coder-next-a3b-v1' <<<"$OUT"; then
+        pass "PowerShell resolver selects Qwen3.6 A3B with unified-memory policy"
+    else
+        fail "PowerShell resolver should select Qwen3.6 A3B; got: $OUT"
+    fi
+else
+    echo "[skip] PowerShell not available - behavioral resolver check skipped"
+fi
+
+echo
+echo "Windows Strix tier-map contract: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary
- align Windows Strix Halo SH_LARGE with the fleet-proven Qwen3.6 35B-A3B model
- add an AMD unified-memory SH_LARGE catalog override so the generic largest-fit selector cannot pick Coder Next or dense 70B for first-run recovery
- add a Windows Strix tier-map contract and wire it into `make test`

## Why
A real Windows Strix Halo focused run proved the #1512 fail-loud recovery path, but the full-model swap was trying to prove a dense 70B-class model. That is the wrong default for Strix Halo/Lemonade. Qwen3.6-35B-A3B has already passed fleet capability testing on Strix-class unified-memory hardware and is a better stability target.

## Validation
- `bash tests/contracts/test-windows-strix-tier-map.sh`
- `bash tests/test-tier-map.sh`
- `bash tests/contracts/test-windows-llm-model-readiness.sh`
- PowerShell parser check for `installers/windows/lib/tier-map.ps1`
- `git diff --check`