### PR TITLE
fix(windows): give Lemonade full-model swap time to register; report real bytes on failure

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -33,6 +33,7 @@ test: ## Run unit and contract tests
 	@bash tests/test-litellm-amd-auth-enforced.sh
 	@bash tests/contracts/test-windows-strix-tier-map.sh
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
+	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
 	@echo ""
 	@echo "=== Overlay/plist contracts ==="
 	@bash tests/contracts/test-overlay-map-coherence.sh

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -233,9 +233,16 @@ restart_windows_lemonade_with_full_model() {
     }
 
     log "Waiting for native Windows Lemonade to serve extra.$FULL_GGUF_FILE ..."
-    local model_id
+    local model_id _swap_attempts
     model_id="extra.${FULL_GGUF_FILE//\"/\\\"}"
-    for _i in $(seq 1 12); do
+    # A freshly-swapped full model can take several minutes to register in
+    # --extra-models-dir and then load on the first completion. The old 12x10s
+    # (~2 min) budget timed out before a 22 GB MoE (Qwen3.6-35B-A3B) was even
+    # listed, so the swap reverted to bootstrap (#1517). Use the same longer
+    # budget as the llama.cpp warm-up path; override with DREAM_LEMONADE_SWAP_ATTEMPTS.
+    _swap_attempts="${DREAM_LEMONADE_SWAP_ATTEMPTS:-60}"
+    case "$_swap_attempts" in ''|*[!0-9]*|0) _swap_attempts=60 ;; esac
+    for _i in $(seq 1 "$_swap_attempts"); do
         if curl -sf --max-time 5 "http://127.0.0.1:${lemonade_port}/api/v1/models" 2>/dev/null \
             | grep -q "\"id\"[[:space:]]*:[[:space:]]*\"${model_id}\""; then
             if curl -sf --max-time 240 -X POST \
@@ -246,14 +253,14 @@ restart_windows_lemonade_with_full_model() {
                 log "SUCCESS: native Windows Lemonade completed with ${model_id}"
                 return 0
             fi
-            log "Windows Lemonade lists ${model_id}, but completion is not ready yet (attempt $_i/12)."
+            log "Windows Lemonade lists ${model_id}, but completion is not ready yet (attempt $_i/${_swap_attempts})."
         else
-            log "Waiting for Windows Lemonade to register ${model_id} (attempt $_i/12)."
+            log "Waiting for Windows Lemonade to register ${model_id} (attempt $_i/${_swap_attempts})."
         fi
         sleep 10
     done
 
-    log "WARNING: native Windows Lemonade did not complete with ${model_id}; keeping bootstrap model for recovery."
+    log "WARNING: native Windows Lemonade did not complete with ${model_id} after ${_swap_attempts} attempts; keeping bootstrap model for recovery."
     return 1
 }
 
@@ -558,12 +565,23 @@ fi
 if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
     if restart_windows_lemonade_with_full_model; then
         if ! patch_hermes_model_after_swap; then
-            write_status "failed"
+            # The full model downloaded, verified, and loaded; only the Hermes
+            # config patch failed. Report the real byte counts and the actual
+            # cause, not a bare write_status "failed" that zeroes the byte fields
+            # and reads as a 0-byte download failure (#1517).
+            write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+                "Full model downloaded and loaded, but the Hermes config patch failed after swap. Re-run to retry."
             exit 1
         fi
         HOT_SWAP_VERIFIED=true
     else
-        write_status "failed"
+        # The model downloaded and verified (byte counts are real); the native
+        # Windows Lemonade swap did not register/load it within the wait window,
+        # so the bootstrap model is kept. Report the real bytes + cause instead
+        # of a bare write_status "failed" that zeroes bytesDownloaded/bytesTotal
+        # and misreads as a 0-byte download failure (#1517).
+        write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+            "Model downloaded and verified, but native Windows Lemonade did not load it after swap (registration timeout). Bootstrap model kept; re-run to retry the swap."
         exit 1
     fi
 elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --format '{{.Names}}' 2>/dev/null | grep -q dream-llama-server; then

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -103,6 +103,56 @@ write_failed_download_status() {
     write_status "failed" "$percent" "$downloaded" "$total" 0 "$message"
 }
 
+ACTIVE_CONFIG_SNAPSHOT_DIR=""
+
+snapshot_active_model_config() {
+    local snapshot_base
+    snapshot_base="${INSTALL_DIR}/data"
+    mkdir -p "$snapshot_base" 2>/dev/null || return 1
+    ACTIVE_CONFIG_SNAPSHOT_DIR="$(mktemp -d "${snapshot_base}/bootstrap-upgrade-active-config.XXXXXX" 2>/dev/null || true)"
+    [[ -n "$ACTIVE_CONFIG_SNAPSHOT_DIR" ]] || return 1
+
+    if [[ -f "$ENV_FILE" ]]; then
+        cp -p "$ENV_FILE" "$ACTIVE_CONFIG_SNAPSHOT_DIR/env" || return 1
+    else
+        : > "$ACTIVE_CONFIG_SNAPSHOT_DIR/env.missing"
+    fi
+
+    if [[ -f "$MODELS_INI" ]]; then
+        mkdir -p "$ACTIVE_CONFIG_SNAPSHOT_DIR/config-llama-server" || return 1
+        cp -p "$MODELS_INI" "$ACTIVE_CONFIG_SNAPSHOT_DIR/config-llama-server/models.ini" || return 1
+    else
+        : > "$ACTIVE_CONFIG_SNAPSHOT_DIR/models.ini.missing"
+    fi
+}
+
+restore_active_model_config() {
+    [[ -n "${ACTIVE_CONFIG_SNAPSHOT_DIR:-}" && -d "$ACTIVE_CONFIG_SNAPSHOT_DIR" ]] || return 1
+
+    if [[ -f "$ACTIVE_CONFIG_SNAPSHOT_DIR/env" ]]; then
+        cp -p "$ACTIVE_CONFIG_SNAPSHOT_DIR/env" "$ENV_FILE" || return 1
+    elif [[ -f "$ACTIVE_CONFIG_SNAPSHOT_DIR/env.missing" ]]; then
+        rm -f "$ENV_FILE"
+    fi
+
+    if [[ -f "$ACTIVE_CONFIG_SNAPSHOT_DIR/config-llama-server/models.ini" ]]; then
+        mkdir -p "$(dirname "$MODELS_INI")" || return 1
+        cp -p "$ACTIVE_CONFIG_SNAPSHOT_DIR/config-llama-server/models.ini" "$MODELS_INI" || return 1
+    elif [[ -f "$ACTIVE_CONFIG_SNAPSHOT_DIR/models.ini.missing" ]]; then
+        rm -f "$MODELS_INI"
+    fi
+
+    rm -rf "$ACTIVE_CONFIG_SNAPSHOT_DIR"
+    ACTIVE_CONFIG_SNAPSHOT_DIR=""
+}
+
+discard_active_model_config_snapshot() {
+    if [[ -n "${ACTIVE_CONFIG_SNAPSHOT_DIR:-}" ]]; then
+        rm -rf "$ACTIVE_CONFIG_SNAPSHOT_DIR"
+        ACTIVE_CONFIG_SNAPSHOT_DIR=""
+    fi
+}
+
 sync_windows_opencode_config() {
     case "$(uname -s)" in
         MINGW*|MSYS*|CYGWIN*) ;;
@@ -504,6 +554,25 @@ if [[ -n "$FULL_GGUF_SHA256" ]]; then
     fi
 fi
 
+_windows_lemonade_swap_applies=false
+if is_windows_bash; then
+    _runtime_for_swap="$(read_env_value AMD_INFERENCE_RUNTIME | tr '[:upper:]' '[:lower:]')"
+    _backend_for_swap="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
+    if [[ "$_runtime_for_swap" == "lemonade" || "$_backend_for_swap" == "lemonade" ]]; then
+        _windows_lemonade_swap_applies=true
+    fi
+fi
+
+if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
+    log "Snapshotting active Windows Lemonade model config before full-model swap..."
+    if ! snapshot_active_model_config; then
+        discard_active_model_config_snapshot
+        write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+            "Full model downloaded and verified, but Dream Server could not snapshot active model config before swap. Bootstrap model left unchanged; re-run to retry."
+        exit 1
+    fi
+fi
+
 # ── Phase 3: Update .env ──
 write_status "swapping" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 ""
 log "Updating .env..."
@@ -553,15 +622,6 @@ if [[ -f "$ENV_FILE" ]]; then
     OLLAMA_PORT=$(grep -E '^OLLAMA_PORT=' "$ENV_FILE" | cut -d= -f2 | tr -d '"\047\r')
 fi
 
-_windows_lemonade_swap_applies=false
-if is_windows_bash; then
-    _runtime_for_swap="$(read_env_value AMD_INFERENCE_RUNTIME | tr '[:upper:]' '[:lower:]')"
-    _backend_for_swap="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
-    if [[ "$_runtime_for_swap" == "lemonade" || "$_backend_for_swap" == "lemonade" ]]; then
-        _windows_lemonade_swap_applies=true
-    fi
-fi
-
 if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
     if restart_windows_lemonade_with_full_model; then
         if ! patch_hermes_model_after_swap; then
@@ -569,19 +629,24 @@ if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
             # config patch failed. Report the real byte counts and the actual
             # cause, not a bare write_status "failed" that zeroes the byte fields
             # and reads as a 0-byte download failure (#1517).
+            log "Restoring previous active model config after Hermes patch failure..."
+            restore_active_model_config || log "WARNING: could not restore active model config; inspect $ENV_FILE and $MODELS_INI"
             write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
-                "Full model downloaded and loaded, but the Hermes config patch failed after swap. Re-run to retry."
+                "Full model downloaded and loaded, but the Hermes config patch failed after swap. Previous active model config restored; re-run to retry."
             exit 1
         fi
         HOT_SWAP_VERIFIED=true
+        discard_active_model_config_snapshot
     else
         # The model downloaded and verified (byte counts are real); the native
         # Windows Lemonade swap did not register/load it within the wait window,
         # so the bootstrap model is kept. Report the real bytes + cause instead
         # of a bare write_status "failed" that zeroes bytesDownloaded/bytesTotal
         # and misreads as a 0-byte download failure (#1517).
+        log "Restoring previous active model config after Windows Lemonade swap timeout..."
+        restore_active_model_config || log "WARNING: could not restore active model config; inspect $ENV_FILE and $MODELS_INI"
         write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
-            "Model downloaded and verified, but native Windows Lemonade did not load it after swap (registration timeout). Bootstrap model kept; re-run to retry the swap."
+            "Model downloaded and verified, but native Windows Lemonade did not load it after swap (registration timeout). Previous active model config restored and bootstrap model kept; re-run to retry the swap."
         exit 1
     fi
 elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server --format '{{.Names}}' 2>/dev/null | grep -q dream-llama-server; then

--- a/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
+++ b/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Windows Lemonade full-model swap-wait contract (#1517).
+#
+# Guards two regressions in the BACKGROUND full-model swap on native Windows
+# Lemonade (scripts/bootstrap-upgrade.sh):
+#
+#   1. The register/load wait must not be the too-short hardcoded 12-attempt
+#      (~2 min) budget. A 22 GB MoE (Qwen3.6-35B-A3B) was not even *listed* by
+#      Lemonade within 2 min of the swap restart, so the swap reverted to the
+#      bootstrap model. The wait must be configurable and default to a longer
+#      budget (>= 60 attempts), matching the llama.cpp warm-up path.
+#
+#   2. On swap failure the status JSON must report the REAL downloaded byte
+#      counts (the model did download + verify) plus the actual cause — not a
+#      bare `write_status "failed"` that zeroes bytesDownloaded/bytesTotal and
+#      reads as a 0-byte download failure (which is what originally misled
+#      triage into thinking the download never started).
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+SCRIPT="scripts/bootstrap-upgrade.sh"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+echo "[contract] Windows Lemonade swap wait + failure reporting (#1517)"
+
+# ---------------------------------------------------------------------------
+# 1. The swap wait must not hardcode the too-short 12-attempt budget.
+# ---------------------------------------------------------------------------
+if grep -Eq 'for _i in \$\(seq 1 12\)' "$SCRIPT"; then
+    fail "swap wait still hardcodes 'seq 1 12' (~2 min) — too short for a large MoE to register"
+else
+    pass "swap wait no longer hardcodes the 12-attempt (~2 min) budget"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The swap wait must be configurable with a sane longer default (>= 60).
+# ---------------------------------------------------------------------------
+if grep -Eq 'DREAM_LEMONADE_SWAP_ATTEMPTS:-(6[0-9]|[7-9][0-9]|[1-9][0-9]{2,})' "$SCRIPT"; then
+    pass "swap wait is configurable (DREAM_LEMONADE_SWAP_ATTEMPTS) with a >= 60 default"
+else
+    fail "swap wait must read DREAM_LEMONADE_SWAP_ATTEMPTS with a default of at least 60"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The swap-registration-timeout failure must report real bytes + cause,
+#    not a bare zero-byte write_status "failed".
+# ---------------------------------------------------------------------------
+if grep -q 'did not load it after swap (registration timeout)' "$SCRIPT" \
+   && grep -Eq 'write_status "failed" 100 "\$TOTAL_BYTES" "\$TOTAL_BYTES"' "$SCRIPT"; then
+    pass "swap-timeout failure reports real downloaded bytes + cause (not a 0-byte failure)"
+else
+    fail "swap-timeout failure must write_status with real TOTAL_BYTES and the registration-timeout cause"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. The post-swap Hermes-patch failure must likewise carry real bytes.
+# ---------------------------------------------------------------------------
+if grep -q 'Hermes config patch failed after swap' "$SCRIPT"; then
+    pass "post-swap Hermes-patch failure reports real bytes + cause"
+else
+    fail "post-swap Hermes-patch failure must report real bytes + cause, not a bare failed status"
+fi
+
+echo "------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
+++ b/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
@@ -15,6 +15,11 @@
 #      bare `write_status "failed"` that zeroes bytesDownloaded/bytesTotal and
 #      reads as a 0-byte download failure (which is what originally misled
 #      triage into thinking the download never started).
+#
+#   3. The full-model swap must not leave active config split-brained. The
+#      script updates .env/models.ini before restarting native Lemonade; if the
+#      full model cannot be proven, it must restore the previous active config
+#      so the bootstrap model remains the last-known-good runtime.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -65,6 +70,26 @@ if grep -q 'Hermes config patch failed after swap' "$SCRIPT"; then
     pass "post-swap Hermes-patch failure reports real bytes + cause"
 else
     fail "post-swap Hermes-patch failure must report real bytes + cause, not a bare failed status"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Windows Lemonade swap must snapshot and restore active config on failure.
+# ---------------------------------------------------------------------------
+if grep -q 'snapshot_active_model_config' "$SCRIPT" \
+   && grep -q 'restore_active_model_config' "$SCRIPT" \
+   && grep -q 'Restoring previous active model config after Windows Lemonade swap timeout' "$SCRIPT"; then
+    pass "Windows Lemonade swap snapshots active config and restores it on timeout"
+else
+    fail "Windows Lemonade swap failure must restore the previous active .env/models.ini config"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Failure status should tell operators the active config was restored.
+# ---------------------------------------------------------------------------
+if grep -q 'Previous active model config restored and bootstrap model kept' "$SCRIPT"; then
+    pass "swap-timeout status tells the operator the previous active config was restored"
+else
+    fail "swap-timeout status should explicitly say the previous active config was restored"
 fi
 
 echo "------------------------------------------------------------"


### PR DESCRIPTION
## Problem

On native Windows Lemonade (AMD) hosts, the **background** full-model upgrade downloads the full model fine, then restarts Lemonade with it and waits for it to register + serve. That wait was a hardcoded **12×10s (~2 min)** loop.

A 22 GB MoE (`Qwen3.6-35B-A3B-UD-Q4_K_M`) is not even *listed* by Lemonade within 2 min of the restart, so the swap times out and reverts to the bootstrap model. The host then serves the 2 B bootstrap while `.env`/`models.ini` already point at the full model.

Worse, on that timeout the code called a bare `write_status "failed"`, which zeroes `bytesDownloaded`/`bytesTotal`. So `bootstrap-status.json` read `{"status":"failed","bytesDownloaded":0,"bytesTotal":0}` — i.e. it **misreported a swap/registration timeout as a 0-byte download failure**, even though the 22 GB GGUF was on disk and SHA-verified.

Evidence (host `strixy`, fleet run `2026-06-04T11-04-47Z`): `logs/model-upgrade.log` shows `Download complete` + `SHA256 verified`, then `Waiting for Windows Lemonade to register … (attempt 1/12 … 12/12)` over 07:17:11–07:19:13, then `keeping bootstrap model for recovery`. The full GGUF (22,134,528,992 bytes) is on disk.

This runs *after* install completes, so it is not covered by #1512 (whose install-time readiness gate correctly passed against the bootstrap model).

## Fix (`scripts/bootstrap-upgrade.sh`)

1. **`restart_windows_lemonade_with_full_model`**: replace the hardcoded `seq 1 12` with a configurable budget defaulting to **60 attempts** (`DREAM_LEMONADE_SWAP_ATTEMPTS`), matching the existing llama.cpp warm-up path's longer budget so a large MoE has time to register and load. Validation mirrors the existing `DREAM_BOOTSTRAP_DOWNLOAD_ATTEMPTS` pattern.
2. **Honest failure status**: on swap-registration timeout (and the post-swap Hermes-patch failure), report the real byte counts + the actual cause instead of a bare zeroed `failed`. `status` stays `failed` (the full model genuinely isn't serving), but the bytes and message no longer read as a phantom 0-byte download failure.

## Test

`tests/contracts/test-windows-lemonade-swap-wait.sh` (wired into `make test`) guards both regressions: no hardcoded 12-attempt wait, configurable ≥60 default, and byte-bearing failure status. Passes 4/4 locally; `bash -n` clean.

## Out of scope (follow-ups)

- A post-swap readiness signal so a reverted-to-bootstrap state surfaces after install already reported LIVE.
- Linux Phase 12 (`12-health.sh`) only treats `starting|downloading|verifying|swapping` as "download active"; a `failed` status falls through to a bootstrap `/health` 200 — the Linux-side twin of what #1512 fixed for Windows (latent, since Linux downloads have been succeeding).

Fixes #1517.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
