### PR TITLE
fix(windows): harden Lemonade swaps and Hermes config

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -34,6 +34,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-windows-strix-tier-map.sh
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
+	@bash tests/contracts/test-windows-hermes-config-patching.sh
 	@echo ""
 	@echo "=== Overlay/plist contracts ==="
 	@bash tests/contracts/test-overlay-map-coherence.sh

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -318,8 +318,19 @@ if ($dryRun) {
                 })
                 $hermesTemplate = Join-Path (Join-Path (Join-Path $installDir "extensions") "services\hermes") "cli-config.yaml.template"
                 $hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
-                Update-HermesConfigFile -Path $hermesTemplate -Model $hermesModel -BaseUrl $hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
-                Update-HermesConfigFile -Path $hermesLive -Model $hermesModel -BaseUrl $hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+                if (-not (Test-Path $hermesTemplate)) {
+                    Write-AIError "Missing Hermes config template at $hermesTemplate"
+                    exit 1
+                }
+                if (-not (Test-Path $hermesLive)) {
+                    Copy-Item -Path $hermesTemplate -Destination $hermesLive -Force
+                }
+                $patchedHermesTemplate = Update-HermesConfigFile -Path $hermesTemplate -Model $hermesModel -BaseUrl $hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+                $patchedHermesLive = Update-HermesConfigFile -Path $hermesLive -Model $hermesModel -BaseUrl $hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+                if (-not ($patchedHermesTemplate -and $patchedHermesLive)) {
+                    Write-AIError "Failed to patch Hermes config for Windows runtime (model=$hermesModel, base_url=$hermesBaseUrl)"
+                    exit 1
+                }
                 Write-AISuccess "Patched Hermes config for bootstrap model (model=$hermesModel, context=$($tierConfig.MaxContext))"
             }
         }

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -208,13 +208,14 @@ function Update-HermesConfigFile {
         [int]$ContextLength
     )
 
-    if (-not (Test-Path $Path)) { return }
+    if (-not (Test-Path $Path)) { return $false }
 
-    $content = Get-Content $Path -Raw
-    $content = $content -replace '(?m)^  default: ".*"$', "  default: `"$Model`""
-    $content = $content -replace '(?m)^  base_url: ".*"$', "  base_url: `"$BaseUrl`""
-    $content = $content -replace '(?m)^  context_length: .+$', "  context_length: $ContextLength"
-    $content = $content -replace '(?m)^    context_length: .+$', "    context_length: $ContextLength"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    $content = [System.IO.File]::ReadAllText($Path, $utf8NoBom)
+    $content = $content -replace '(?m)^  default: ".*"\r?$', "  default: `"$Model`""
+    $content = $content -replace '(?m)^  base_url: ".*"\r?$', "  base_url: `"$BaseUrl`""
+    $content = $content -replace '(?m)^  context_length: .+\r?$', "  context_length: $ContextLength"
+    $content = $content -replace '(?m)^    context_length: .+\r?$', "    context_length: $ContextLength"
 
     if ($content -notmatch '(?m)^auxiliary:\s*$') {
         if ($content -match '(?m)^terminal:\s*$') {
@@ -247,7 +248,11 @@ function Update-HermesConfigFile {
         }
     }
 
-    Write-Utf8NoBom -Path $Path -Content $content
+    [System.IO.File]::WriteAllText($Path, $content, $utf8NoBom)
+    $verified = [System.IO.File]::ReadAllText($Path, $utf8NoBom)
+    if (-not $verified.Contains("  default: `"$Model`"")) { return $false }
+    if (-not $verified.Contains("  base_url: `"$BaseUrl`"")) { return $false }
+    return $true
 }
 
 function Invoke-HermesSoulRefresh {
@@ -334,8 +339,19 @@ if ($enableHermes) {
     })
     $_hermesTemplate = Join-Path (Join-Path (Join-Path $installDir "extensions") "services\hermes") "cli-config.yaml.template"
     $_hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
-    Update-HermesConfigFile -Path $_hermesTemplate -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
-    Update-HermesConfigFile -Path $_hermesLive -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+    if (-not (Test-Path $_hermesTemplate)) {
+        Write-AIError "Missing Hermes config template at $_hermesTemplate"
+        exit 1
+    }
+    if (-not (Test-Path $_hermesLive)) {
+        Copy-Item -Path $_hermesTemplate -Destination $_hermesLive -Force
+    }
+    $_patchedHermesTemplate = Update-HermesConfigFile -Path $_hermesTemplate -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+    $_patchedHermesLive = Update-HermesConfigFile -Path $_hermesLive -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext)
+    if (-not ($_patchedHermesTemplate -and $_patchedHermesLive)) {
+        Write-AIError "Failed to patch Hermes config for Windows runtime (model=$_hermesModel, base_url=$_hermesBaseUrl)"
+        exit 1
+    }
     Invoke-HermesSoulRefresh -InstallRoot $installDir
     Write-AISuccess "Patched Hermes config (model=$_hermesModel, context=$($tierConfig.MaxContext))"
 }

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -153,6 +153,31 @@ discard_active_model_config_snapshot() {
     fi
 }
 
+BOOTSTRAP_SWAP_BACKUP_PATH=""
+
+move_bootstrap_model_aside_for_windows_swap() {
+    [[ -f "$BOOTSTRAP_PATH" ]] || return 0
+
+    BOOTSTRAP_SWAP_BACKUP_PATH="${BOOTSTRAP_PATH}.dream-swap-backup"
+    rm -f "$BOOTSTRAP_SWAP_BACKUP_PATH"
+    mv "$BOOTSTRAP_PATH" "$BOOTSTRAP_SWAP_BACKUP_PATH" || return 1
+    log "Moved bootstrap model aside before Windows Lemonade full-model restart: $(basename "$BOOTSTRAP_PATH")"
+}
+
+restore_bootstrap_model_after_windows_swap_failure() {
+    [[ -n "$BOOTSTRAP_SWAP_BACKUP_PATH" && -f "$BOOTSTRAP_SWAP_BACKUP_PATH" ]] || return 0
+
+    mv "$BOOTSTRAP_SWAP_BACKUP_PATH" "$BOOTSTRAP_PATH" || return 1
+    log "Restored bootstrap model after Windows Lemonade swap failure: $(basename "$BOOTSTRAP_PATH")"
+}
+
+discard_bootstrap_model_backup_after_windows_swap() {
+    [[ -n "$BOOTSTRAP_SWAP_BACKUP_PATH" && -f "$BOOTSTRAP_SWAP_BACKUP_PATH" ]] || return 0
+
+    rm -f "$BOOTSTRAP_SWAP_BACKUP_PATH"
+    log "Removed bootstrap model after verified Windows Lemonade full-model serving: $(basename "$BOOTSTRAP_PATH")"
+}
+
 sync_windows_opencode_config() {
     case "$(uname -s)" in
         MINGW*|MSYS*|CYGWIN*) ;;
@@ -215,10 +240,17 @@ windows_ps_command() {
 restart_windows_lemonade_with_full_model() {
     is_windows_bash || return 1
 
-    local runtime llm_backend
+    local runtime llm_backend managed runtime_mode lemonade_external
     runtime="$(read_env_value AMD_INFERENCE_RUNTIME | tr '[:upper:]' '[:lower:]')"
     llm_backend="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
     [[ "$runtime" == "lemonade" || "$llm_backend" == "lemonade" ]] || return 1
+    managed="$(read_env_value AMD_INFERENCE_MANAGED | tr '[:upper:]' '[:lower:]')"
+    runtime_mode="$(read_env_value AMD_INFERENCE_RUNTIME_MODE | tr '[:upper:]' '[:lower:]')"
+    lemonade_external="$(read_env_value LEMONADE_EXTERNAL | tr '[:upper:]' '[:lower:]')"
+    if [[ "$managed" == "false" || "$runtime_mode" == "external-lemonade" || "$lemonade_external" == "true" ]]; then
+        log "Skipping native Windows Lemonade restart because the runtime is externally managed."
+        return 1
+    fi
 
     local ps_cmd
     ps_cmd="$(windows_ps_command)"
@@ -241,19 +273,6 @@ restart_windows_lemonade_with_full_model() {
     DREAM_WIN_LEMONADE_PORT="$lemonade_port" \
     "$ps_cmd" -NoProfile -ExecutionPolicy Bypass -Command '
         $ErrorActionPreference = "Stop"
-        $pidPath = $env:DREAM_WIN_PID_FILE
-        if (Test-Path $pidPath) {
-            $rawPid = (Get-Content -LiteralPath $pidPath -Raw).Trim()
-            if ($rawPid -match "^\d+$") {
-                Stop-Process -Id ([int]$rawPid) -Force -ErrorAction SilentlyContinue
-                for ($i = 0; $i -lt 20; $i++) {
-                    $old = Get-Process -Id ([int]$rawPid) -ErrorAction SilentlyContinue
-                    if (-not $old) { break }
-                    Start-Sleep -Milliseconds 500
-                }
-            }
-            Remove-Item -LiteralPath $pidPath -Force -ErrorAction SilentlyContinue
-        }
 
         $roots = @()
         if ($env:ProgramFiles) { $roots += $env:ProgramFiles }
@@ -266,6 +285,66 @@ restart_windows_lemonade_with_full_model() {
         }
         if (-not $exe) { throw "lemonade-server.exe not found under Program Files roots" }
 
+        function Stop-DreamProcessId {
+            param([int]$ProcessId)
+            Stop-Process -Id $ProcessId -Force -ErrorAction SilentlyContinue
+            for ($i = 0; $i -lt 30; $i++) {
+                $old = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+                if (-not $old) { return }
+                Start-Sleep -Milliseconds 500
+            }
+        }
+
+        $pidPath = $env:DREAM_WIN_PID_FILE
+        if (Test-Path $pidPath) {
+            $rawPid = (Get-Content -LiteralPath $pidPath -Raw).Trim()
+            if ($rawPid -match "^\d+$") {
+                Stop-DreamProcessId -ProcessId ([int]$rawPid)
+            }
+            Remove-Item -LiteralPath $pidPath -Force -ErrorAction SilentlyContinue
+        }
+
+        # Lemonade also has a process-wide router singleton. If the saved PID
+        # is stale or points at a child that has already exited, Start-Process
+        # can report success while the new router immediately exits with
+        # "Another instance of lemonade-router is already running"; the swap
+        # then polls the old bootstrap instance forever. Clear the configured
+        # listener and any Lemonade Server child processes before launching the
+        # full-model instance.
+        $port = [int]$env:DREAM_WIN_LEMONADE_PORT
+        $deadline = (Get-Date).AddSeconds(20)
+        do {
+            $listeners = @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue)
+            foreach ($listener in $listeners) {
+                if ($listener.OwningProcess -gt 0) {
+                    Stop-DreamProcessId -ProcessId ([int]$listener.OwningProcess)
+                }
+            }
+            if ($listeners.Count -eq 0) { break }
+            Start-Sleep -Milliseconds 500
+        } while ((Get-Date) -lt $deadline)
+
+        $binDir = Split-Path -Parent $exe
+        $userProfile = [Environment]::GetFolderPath("UserProfile")
+        $lemonadeCacheBin = if ($userProfile) { Join-Path (Join-Path (Join-Path $userProfile ".cache") "lemonade") "bin" } else { $null }
+        $dreamModelsDir = $env:DREAM_WIN_MODELS_DIR
+        $lemonadeChildren = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue | Where-Object {
+            ($_.ExecutablePath -and $_.ExecutablePath.StartsWith($binDir, [StringComparison]::OrdinalIgnoreCase)) -or
+            ($lemonadeCacheBin -and $_.ExecutablePath -and $_.ExecutablePath.StartsWith($lemonadeCacheBin, [StringComparison]::OrdinalIgnoreCase)) -or
+            ($dreamModelsDir -and $_.CommandLine -and $_.CommandLine.IndexOf($dreamModelsDir, [StringComparison]::OrdinalIgnoreCase) -ge 0)
+        })
+        foreach ($child in $lemonadeChildren) {
+            Stop-DreamProcessId -ProcessId ([int]$child.ProcessId)
+        }
+
+        $stillListening = @(Get-NetTCPConnection -LocalPort $port -State Listen -ErrorAction SilentlyContinue)
+        if ($stillListening.Count -gt 0) {
+            throw "port $port is still occupied after stopping the previous Lemonade instance"
+        }
+
+        $logPath = Join-Path $env:TEMP "lemonade-server.log"
+        Remove-Item -LiteralPath $logPath -Force -ErrorAction SilentlyContinue
+
         $args = @(
             "serve",
             "--port", $env:DREAM_WIN_LEMONADE_PORT,
@@ -277,6 +356,20 @@ restart_windows_lemonade_with_full_model() {
         $proc = Start-Process -FilePath $exe -ArgumentList $args -WindowStyle Hidden -PassThru
         New-Item -ItemType Directory -Path (Split-Path -Parent $pidPath) -Force | Out-Null
         Set-Content -LiteralPath $pidPath -Value $proc.Id
+
+        Start-Sleep -Seconds 2
+        $started = Get-Process -Id $proc.Id -ErrorAction SilentlyContinue
+        if (-not $started) {
+            try {
+                $health = Invoke-WebRequest -Uri ("http://127.0.0.1:{0}/api/v1/models" -f $port) -TimeoutSec 3 -UseBasicParsing
+                if ([int]$health.StatusCode -eq 200) { return }
+            } catch { }
+            $tail = ""
+            if (Test-Path $logPath) {
+                $tail = (Get-Content -LiteralPath $logPath -Tail 8 -ErrorAction SilentlyContinue) -join " "
+            }
+            throw "lemonade-server exited immediately after restart. $tail"
+        }
     ' >/dev/null 2>&1 || {
         log "WARNING: native Windows Lemonade restart failed."
         return 1
@@ -314,8 +407,27 @@ restart_windows_lemonade_with_full_model() {
     return 1
 }
 
+patch_hermes_yaml_with_sed() {
+    local path="$1" model="$2" context_length="$3"
+    [[ -f "$path" ]] || return 1
+
+    if sed -i.bak \
+        -e "s|^  default: \".*\"[[:space:]]*$|  default: \"${model}\"|" \
+        -e "s|^  context_length: .*|  context_length: ${context_length}|" \
+        -e "s|^    context_length: .*|    context_length: ${context_length}|" \
+        "$path" 2>&1; then
+        rm -f "${path}.bak"
+    else
+        [[ -f "${path}.bak" ]] && mv "${path}.bak" "$path"
+        return 1
+    fi
+
+    grep -Fq "  default: \"${model}\"" "$path" \
+        && grep -Fq "  context_length: ${context_length}" "$path"
+}
+
 patch_hermes_model_after_swap() {
-    local gpu_backend llm_backend old_model new_model tpl patcher py_cmd
+    local gpu_backend llm_backend old_model new_model tpl
     gpu_backend="$(read_env_value GPU_BACKEND | tr '[:upper:]' '[:lower:]')"
     llm_backend="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
     old_model="$BOOTSTRAP_GGUF_FILE"
@@ -328,20 +440,10 @@ patch_hermes_model_after_swap() {
     log "Patching Hermes config after full-model swap: ${old_model} -> ${new_model}"
 
     tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
-    patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"
-    py_cmd="$(command -v python3 2>/dev/null || command -v python 2>/dev/null || true)"
     if [[ -f "$tpl" ]]; then
-        if [[ -n "$py_cmd" && -f "$patcher" ]]; then
-            "$py_cmd" "$patcher" "$tpl" --model "$new_model" --context-length "$FULL_MAX_CONTEXT" 2>&1 || \
-                log "WARNING: Could not patch ${tpl} with patch-hermes-config.py"
-        elif sed -i.bak \
-            -e "s|^  default: \"${old_model}\"|  default: \"${new_model}\"|" \
-            -e "s|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|" \
-            -e "s|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|" \
-            "$tpl" 2>&1; then
-            rm -f "${tpl}.bak"
-        else
-            log "WARNING: Could not patch ${tpl}"
+        if ! patch_hermes_yaml_with_sed "$tpl" "$new_model" "$FULL_MAX_CONTEXT"; then
+            log "ERROR: Could not patch ${tpl} after full-model swap."
+            return 1
         fi
     fi
 
@@ -623,6 +725,13 @@ if [[ -f "$ENV_FILE" ]]; then
 fi
 
 if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
+    if ! move_bootstrap_model_aside_for_windows_swap; then
+        restore_active_model_config || log "WARNING: could not restore active model config; inspect $ENV_FILE and $MODELS_INI"
+        write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+            "Full model downloaded and verified, but Dream Server could not move the bootstrap model aside before the Windows Lemonade swap. Previous active model config restored; re-run to retry."
+        exit 1
+    fi
+
     if restart_windows_lemonade_with_full_model; then
         if ! patch_hermes_model_after_swap; then
             # The full model downloaded, verified, and loaded; only the Hermes
@@ -631,12 +740,14 @@ if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
             # and reads as a 0-byte download failure (#1517).
             log "Restoring previous active model config after Hermes patch failure..."
             restore_active_model_config || log "WARNING: could not restore active model config; inspect $ENV_FILE and $MODELS_INI"
+            restore_bootstrap_model_after_windows_swap_failure || log "WARNING: could not restore bootstrap model; inspect $BOOTSTRAP_PATH"
             write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
                 "Full model downloaded and loaded, but the Hermes config patch failed after swap. Previous active model config restored; re-run to retry."
             exit 1
         fi
         HOT_SWAP_VERIFIED=true
         discard_active_model_config_snapshot
+        discard_bootstrap_model_backup_after_windows_swap
     else
         # The model downloaded and verified (byte counts are real); the native
         # Windows Lemonade swap did not register/load it within the wait window,
@@ -645,6 +756,7 @@ if [[ "$_windows_lemonade_swap_applies" == "true" ]]; then
         # and misreads as a 0-byte download failure (#1517).
         log "Restoring previous active model config after Windows Lemonade swap timeout..."
         restore_active_model_config || log "WARNING: could not restore active model config; inspect $ENV_FILE and $MODELS_INI"
+        restore_bootstrap_model_after_windows_swap_failure || log "WARNING: could not restore bootstrap model; inspect $BOOTSTRAP_PATH"
         write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
             "Model downloaded and verified, but native Windows Lemonade did not load it after swap (registration timeout). Previous active model config restored and bootstrap model kept; re-run to retry the swap."
         exit 1

--- a/dream-server/tests/contracts/test-windows-hermes-config-patching.sh
+++ b/dream-server/tests/contracts/test-windows-hermes-config-patching.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Windows Hermes config patching contract.
+#
+# Guards the Windows-AMD failure where the installer printed "Patched Hermes
+# config" but both the mounted template and data/hermes/config.yaml still held
+# the upstream defaults:
+#
+#   model.default: qwen3.5-9b
+#   base_url: http://llama-server:8080/v1
+#
+# That leaves Hermes on an invalid/wrong local config for native Lemonade. The
+# Windows installer must create the live config before first container start,
+# patch template + live config, and fail loudly if either patch did not land.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+PHASE="installers/windows/phases/06-directories.ps1"
+MONO="installers/windows/install-windows.ps1"
+ROOT_INSTALLER="../install.ps1"
+
+PASS=0
+FAIL=0
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+echo "[contract] Windows Hermes config patching"
+
+# ---------------------------------------------------------------------------
+# 1. The patch helper must not silently no-op when the target file is missing.
+# ---------------------------------------------------------------------------
+if grep -q 'if (-not (Test-Path \$Path)) { return \$false }' "$PHASE"; then
+    pass "Update-HermesConfigFile reports missing targets as failure"
+else
+    fail "Update-HermesConfigFile must return false when the target file is missing"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. The helper must use explicit UTF-8 reads and UTF-8-no-BOM writes.
+# ---------------------------------------------------------------------------
+if grep -q 'ReadAllText(\$Path, \$utf8NoBom)' "$PHASE" \
+   && grep -q '\[System.IO.File\]::WriteAllText(\$Path, \$content, \$utf8NoBom)' "$PHASE"; then
+    pass "Hermes config patching uses dependency-free explicit UTF-8 read/write"
+else
+    fail "Hermes config patching must use dependency-free explicit UTF-8 read/write"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. The helper must verify the requested model/base URL after writing.
+# ---------------------------------------------------------------------------
+if grep -Fq 'default: ".*"\r?$' "$PHASE" \
+   && grep -Fq 'base_url: ".*"\r?$' "$PHASE" \
+   && grep -q '\.Contains("  default: `"\$Model`"")' "$PHASE" \
+   && grep -q '\.Contains("  base_url: `"\$BaseUrl`"")' "$PHASE"; then
+    pass "Hermes config patching is CRLF-tolerant and verifies model/base_url after write"
+else
+    fail "Hermes config patching must handle CRLF YAML and verify model/base_url after write"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Windows phase 06 must create data/hermes/config.yaml before Hermes first
+#    start so the container cannot copy stale upstream defaults into /opt/data.
+# ---------------------------------------------------------------------------
+if grep -q 'Copy-Item -Path \$_hermesTemplate -Destination \$_hermesLive -Force' "$PHASE"; then
+    pass "Phase 06 seeds the live Hermes config before first container start"
+else
+    fail "Phase 06 must copy the template to data/hermes/config.yaml before patching"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Both Windows installer paths must fail loudly if either template or live
+#    config did not receive the patch.
+# ---------------------------------------------------------------------------
+if grep -q 'Failed to patch Hermes config for Windows runtime' "$PHASE" \
+   && grep -q 'Failed to patch Hermes config for Windows runtime' "$MONO"; then
+    pass "Windows installer paths fail loudly when Hermes config patching does not land"
+else
+    fail "Windows installer paths must fail loudly when Hermes config patching does not land"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. The root Windows install.ps1 entrypoint must propagate failures from the
+#    delegated Windows installer. The fleet harness and public docs call the
+#    root script, so fail-loud checks are useless if the wrapper always exits 0.
+# ---------------------------------------------------------------------------
+if grep -q '\$global:LASTEXITCODE = 0' "$ROOT_INSTALLER" \
+   && grep -q '& \$DreamServerInstaller @PSBoundParameters' "$ROOT_INSTALLER" \
+   && grep -q 'if (\$installerSucceeded) {' "$ROOT_INSTALLER" \
+   && grep -q 'exit 0' "$ROOT_INSTALLER" \
+   && grep -q 'exit \$installerExit' "$ROOT_INSTALLER"; then
+    pass "Root Windows installer exits 0 on success and propagates delegated failure codes"
+else
+    fail "Root install.ps1 must exit 0 on success and preserve delegated Windows installer failures"
+fi
+
+echo "------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
+++ b/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
@@ -20,6 +20,29 @@
 #      script updates .env/models.ini before restarting native Lemonade; if the
 #      full model cannot be proven, it must restore the previous active config
 #      so the bootstrap model remains the last-known-good runtime.
+#
+#   4. The swap must stop the existing native Lemonade router/listener before
+#      launching the replacement. Otherwise Lemonade exits with "Another
+#      instance of lemonade-router is already running", while probes keep
+#      hitting the stale bootstrap process forever.
+#
+#   5. The restart helper must refuse to stop externally-managed Lemonade
+#      runtimes, and it must accept daemon-style launches where the parent
+#      process exits after leaving a healthy listener behind.
+#
+#   6. The post-swap Hermes patch must be dependency-free and fail-loud.
+#      Windows Git Bash can resolve `python` to the Microsoft Store alias,
+#      causing the Python patcher path to fail even though `command -v python`
+#      returns something. The swap must patch with shell tools, verify the
+#      YAML, and return non-zero if the patch does not land.
+#
+#   7. The Windows swap must move the bootstrap GGUF aside before launching
+#      the full-model Lemonade process. Lemonade registers files present at
+#      launch, so deleting the bootstrap after launch leaves stale bootstrap
+#      model metadata that naïve clients/probes can select.
+#
+#   8. Native Lemonade cleanup must also stop the per-user cached llama.cpp
+#      child process; it does not live under the Program Files Lemonade bin dir.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
@@ -77,10 +100,13 @@ fi
 # ---------------------------------------------------------------------------
 if grep -q 'snapshot_active_model_config' "$SCRIPT" \
    && grep -q 'restore_active_model_config' "$SCRIPT" \
+   && grep -q 'move_bootstrap_model_aside_for_windows_swap' "$SCRIPT" \
+   && grep -q 'restore_bootstrap_model_after_windows_swap_failure' "$SCRIPT" \
+   && grep -q 'discard_bootstrap_model_backup_after_windows_swap' "$SCRIPT" \
    && grep -q 'Restoring previous active model config after Windows Lemonade swap timeout' "$SCRIPT"; then
-    pass "Windows Lemonade swap snapshots active config and restores it on timeout"
+    pass "Windows Lemonade swap snapshots config and protects bootstrap model recovery"
 else
-    fail "Windows Lemonade swap failure must restore the previous active .env/models.ini config"
+    fail "Windows Lemonade swap failure must restore previous config and bootstrap model backup"
 fi
 
 # ---------------------------------------------------------------------------
@@ -90,6 +116,47 @@ if grep -q 'Previous active model config restored and bootstrap model kept' "$SC
     pass "swap-timeout status tells the operator the previous active config was restored"
 else
     fail "swap-timeout status should explicitly say the previous active config was restored"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Native Windows Lemonade restart must clear the old router/listener before
+#    launching the replacement process.
+# ---------------------------------------------------------------------------
+if grep -q 'Get-NetTCPConnection -LocalPort' "$SCRIPT" \
+   && grep -q 'lemonade-router is already running' "$SCRIPT" \
+   && grep -q 'lemonade-server exited immediately after restart' "$SCRIPT" \
+   && grep -q 'lemonadeCacheBin' "$SCRIPT" \
+   && grep -q 'DREAM_WIN_MODELS_DIR' "$SCRIPT"; then
+    pass "Windows Lemonade restart clears stale listeners, cached llama.cpp children, and singleton-router failures"
+else
+    fail "Windows Lemonade restart must stop stale listeners/cache children and detect singleton-router launch failures"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. The restart helper must stay scoped to Dream-managed native Windows
+#    Lemonade and avoid false-failing daemon-style launches.
+# ---------------------------------------------------------------------------
+if grep -q 'AMD_INFERENCE_MANAGED' "$SCRIPT" \
+   && grep -q 'AMD_INFERENCE_RUNTIME_MODE' "$SCRIPT" \
+   && grep -q 'LEMONADE_EXTERNAL' "$SCRIPT" \
+   && grep -q 'externally managed' "$SCRIPT" \
+   && grep -q '/api/v1/models' "$SCRIPT"; then
+    pass "Windows Lemonade restart is scoped to managed runtimes and allows healthy daemonized launches"
+else
+    fail "Windows Lemonade restart must avoid external runtimes and accept healthy daemonized launches"
+fi
+
+# ---------------------------------------------------------------------------
+# 9. Post-swap Hermes patching must not depend on Python being callable from
+#    Git Bash, and it must verify the YAML before returning success.
+# ---------------------------------------------------------------------------
+if grep -q 'patch_hermes_yaml_with_sed' "$SCRIPT" \
+   && grep -Fq 'grep -Fq "  default: \"${model}\""' "$SCRIPT" \
+   && grep -q 'ERROR: Could not patch ${tpl} after full-model swap.' "$SCRIPT" \
+   && grep -q 'return 1' "$SCRIPT"; then
+    pass "post-swap Hermes patch is dependency-free, verified, and fail-loud"
+else
+    fail "post-swap Hermes patch must avoid Python alias failures and return non-zero if YAML patching fails"
 fi
 
 echo "------------------------------------------------------------"

--- a/install.ps1
+++ b/install.ps1
@@ -39,5 +39,15 @@ if (-not (Test-Path $DreamServerInstaller)) {
     exit 1
 }
 
-# Forward all bound parameters to the real installer
+# Forward all bound parameters to the real installer.
+# A successful PowerShell script can leave a stale $LASTEXITCODE from a handled
+# native command, so only use $LASTEXITCODE when the delegated installer fails.
+$global:LASTEXITCODE = 0
 & $DreamServerInstaller @PSBoundParameters
+$installerSucceeded = $?
+if ($installerSucceeded) {
+    exit 0
+}
+
+$installerExit = if ($null -ne $global:LASTEXITCODE -and [int]$global:LASTEXITCODE -ne 0) { [int]$global:LASTEXITCODE } else { 1 }
+exit $installerExit


### PR DESCRIPTION
## Summary

This PR hardens two Windows-only failure modes found in the `2026-06-04T23-41-44Z` fleet run after #1518:

- fixes native Windows Lemonade full-model swaps getting stuck on the old bootstrap router when `lemonade-server` exits with `Another instance of lemonade-router is already running`
- makes Windows Hermes config patching fail loudly if the template or live `data/hermes/config.yaml` does not actually receive the Windows runtime model/base URL
- adds contracts for both guarantees and wires the Hermes config contract into `make test`

## Root cause

On Strixy, the full Qwen3.6-35B GGUF was downloaded and verified, but Lemonade never registered it. The live Lemonade log showed the replacement process exited immediately because another `lemonade-router` instance was still running, so the swap loop kept polling the stale bootstrap process.

The same run also showed Hermes falling back because the mounted config still had upstream defaults (`qwen3.5-9b`, `http://llama-server:8080/v1`) even though the installer logged that it patched Hermes. The helper silently no-opped when the live config was missing.

## Changes

- Windows Lemonade swap now:
  - refuses to touch externally managed Lemonade runtimes
  - stops the saved PID, the configured port listener, and Lemonade child processes under the Lemonade install bin dir before relaunch
  - fails with the Lemonade log tail if the replacement exits immediately
  - avoids false failure if the launcher parent exits but leaves a healthy `/api/v1/models` listener behind
- Windows Hermes config patching now:
  - seeds `data/hermes/config.yaml` from the template before first Hermes start when missing
  - reads/writes explicit UTF-8 without BOM
  - verifies `model.default` and `base_url` after writing
  - fails the installer if either the template or live config did not patch

## Validation

- `git diff --check`
- PowerShell parser check: `installers/windows/phases/06-directories.ps1`
- PowerShell parser check: `installers/windows/install-windows.ps1`
- Git Bash: `bash -n scripts/bootstrap-upgrade.sh`
- Git Bash: `bash tests/contracts/test-windows-lemonade-swap-wait.sh`
- Git Bash: `bash tests/contracts/test-windows-hermes-config-patching.sh`

`make test` was not runnable from this Windows shell because `make` is not installed here; the new contract is wired into `make test` for CI/Linux environments.

## Risk

Scoped to Windows installer/runtime paths and the Windows branch inside `bootstrap-upgrade.sh`. Linux, macOS, cloud mode, and external Lemonade installs are not touched. The main behavior change is fail-loud: if Hermes config patching does not land, Windows install now stops instead of printing a false success.