### PR TITLE
docs: sanitize release validation references

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -16,15 +16,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Validation
 - Fleet test run on 2026-05-26 at commit `cff3b21` passed regressions,
   zero-prereq bootstrap, installs, verify, cloud-mode, dashboard, Hermes, UI,
-  lifecycle, and distro lab validation across tower2, Strix Halo, Spark, and
-  M5 MacBook Pro.
+  lifecycle, and distro lab validation across Linux NVIDIA, AMD Strix Halo,
+  Linux ARM NVIDIA, and Apple Silicon targets.
 - The new `dream-proxy-owner-card-readiness-1474` regression fixture passed on
   Strix Halo from both already-enabled and disabled states, proving owner-card
   status returns `ready: true` without restarting `dashboard-api`.
-- Capability reruns confirmed initial Strix Halo and M5 MacBook Pro failures
-  were model/timing flakes; full-model capability probes passed on Strix Halo
-  and M5 MacBook Pro while tower2 and Spark correctly deferred on bootstrap
-  models.
+- Capability reruns confirmed initial AMD Strix Halo and high-memory Apple
+  Silicon failures were model/timing flakes; full-model capability probes passed
+  on those targets while Linux NVIDIA and Linux ARM NVIDIA targets correctly
+  deferred on bootstrap models.
 - Distro lab passed 10/10 Docker lanes and 5/5 Incus VM lanes.
 
 ## [2.5.2] - 2026-05-26
@@ -40,7 +40,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Validation
 - Fleet test run on 2026-05-26 at commit `c1df395` passed User Green: true
   fresh install, product, full-model capabilities, lifecycle, and UI validation
-  across tower2, Strix Halo, Spark, and M5 MacBook Pro.
+  across Linux NVIDIA, AMD Strix Halo, Linux ARM NVIDIA, and Apple Silicon
+  targets.
 - Full-model capability probes passed on all 4 enabled hosts, including chat,
   search, files, code, 76 Hermes skills, Dream Talk SSE streaming, session
   pooling, SOUL.md context, and install-context grounding.
@@ -105,9 +106,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Validation
 - Fleet test run 11 on 2026-05-26 passed true fresh install, lifecycle, product,
-  and core capability validation on tower2, Strix Halo, Spark, and M5 MacBook
-  Pro after Docker images, volumes, build cache, and stale model files were
-  removed.
+  and core capability validation on Linux NVIDIA, AMD Strix Halo, Linux ARM
+  NVIDIA, and Apple Silicon targets after Docker images, volumes, build cache,
+  and stale model files were removed.
 - Full target-model core capabilities passed on all 4 hardware platforms; Dream
   Talk capability probes passed where the Talk surface was enabled, with
   unavailable Talk surfaces correctly skipped.
@@ -121,7 +122,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Multi-distro release validation covering Ubuntu 24.04/22.04, Debian 12,
   Linux Mint 21.3, Fedora 41, Rocky Linux 9, Arch, Manjaro, CachyOS, and
   openSUSE Tumbleweed in CI/container form.
-- tower2 Incus VM distro lab for real systemd, network, Docker daemon, Docker
+- Private Incus VM distro lab for real systemd, network, Docker daemon, Docker
   Compose, and installer dry-run coverage on Ubuntu 24.04, Fedora 42, Rocky 9,
   Arch current, and openSUSE Tumbleweed.
 - Sanitized validation matrix documenting the layered CI, distro lab, and
@@ -168,18 +169,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   support bundles, and secret scanning.
 
 ### Validation
-- Full fleet pass on 2026-05-21 in
-  `/home/michael/dream-fleet-test/runs/2026-05-21T15-48-27Z`.
-- Hardware fleet: tower2, Strix Halo, Spark, Mac mini, and M5 MacBook Pro all
-  passed install, 7/7 verify, Hermes seeded echo, UI checks, and applicable
-  capability probes.
+- Full fleet pass on 2026-05-21 for the v2.5.0 release candidate.
+- Hardware fleet: Linux NVIDIA, AMD Strix Halo, Linux ARM NVIDIA, constrained
+  Apple Silicon, and high-memory Apple Silicon targets all passed install, 7/7
+  verify, Hermes seeded echo, UI checks, and applicable capability probes.
 - Regressions: 9/9 fixtures green, 0 bugs detected, 0 PRs opened.
 - Distro lab: Docker matrix passed 10/10 distros; Incus VM matrix passed 5/5
   VMs with real systemd + Docker and clean installer dry-runs.
-- Known follow-up: concurrent `fleet-multi-distro.sh` and a heavy
-  `dream-fleet-test` install on the same host can create I/O contention. Prefer
-  serialization or a future `--parallel-limit` flag when running both surfaces
-  together.
+- Known follow-up: concurrent distro-lab and hardware-fleet installs on the
+  same host can create I/O contention. Prefer serialization or a future
+  `--parallel-limit` flag when running both surfaces together.
 
 ## [2.4.0] - 2026-03-24
 

--- a/dream-server/docs/TESTING.md
+++ b/dream-server/docs/TESTING.md
@@ -46,10 +46,9 @@ Fleet phases currently include:
 
 `--phase all` is the faster development sweep. It covers the main install and
 post-install product surfaces but intentionally avoids the slowest release-only
-gates. The `/dream-fleet-test` skill and `--phase release` path are the
-release-grade sweep: they add zero-prereq bootstrap and lifecycle checks so a
-green result means the installer, product, capability, and recovery paths all
-passed or were explicitly accounted for.
+gates. The private release-grade sweep adds zero-prereq bootstrap and lifecycle
+checks so a green result means the installer, product, capability, and recovery
+paths all passed or were explicitly accounted for.
 
 Use the release-grade sweep after operational code changes: installer phases,
 bootstrap, compose stack generation, service wiring, dashboard/API behavior,
@@ -79,15 +78,15 @@ tests/fleet-external-lemonade-e2e.sh --real
 | Method | Speed | GPU Testing | Kernel Testing | Best For |
 |--------|-------|-------------|----------------|----------|
 | **Fleet harness** | 15-75 min | Yes | Yes | Release readiness and User Green confidence on real heterogeneous hardware |
-| **Fleet distro lab** | 5-20 min | No | Container: no / VM: yes | Multi-distro installer and Docker lifecycle coverage on tower2 |
+| **Fleet distro lab** | 5-20 min | No | Container: no / VM: yes | Multi-distro installer and Docker lifecycle coverage on a private lab host |
 | **Distrobox** | Instant (2s) | Yes | No | Daily dev, package manager validation |
 | **Ventoy USB** | 5-10 min boot | Yes | Yes | Weekly full-stack validation |
 | **CI Matrix** | Automatic | No | No | Every PR, syntax + detection checks |
 
-## Fleet Distro Lab (tower2)
+## Fleet Distro Lab
 
 The fleet distro lab is the repeatable middle rung between CI containers and
-full hardware fleet runs. `tower2` is provisioned with:
+full hardware fleet runs. The private lab host is provisioned with:
 
 - Docker for fast disposable distro containers;
 - Distrobox for interactive distro debugging;
@@ -110,16 +109,16 @@ tests/fleet-multi-distro.sh --pull
 
 The Docker and Incus distro runners take a shared host lock by default:
 `/tmp/dream-fleet-heavy.lock`, or `DREAM_FLEET_HOST_LOCK` when set. The
-`/dream-fleet-test` harness uses the same lock when launching heavy tower2
-install work, so distro-lab dry-runs do not compete with full fleet installs
-for Docker/build I/O on the same host. Use `--lock-timeout SECONDS` when a CI
-or automation should fail instead of waiting, and reserve `--no-host-lock` for
+private release automation uses the same lock when launching heavy install
+work, so distro-lab dry-runs do not compete with full fleet installs for
+Docker/build I/O on the same host. Use `--lock-timeout SECONDS` when a CI or
+automation should fail instead of waiting, and reserve `--no-host-lock` for
 local debugging when you know no full fleet install is running.
 
-Release-grade `/dream-fleet-test` invocations should run the distro lab
-alongside the hardware fleet. The hardware fleet proves GPU and product
-behavior; the distro lab proves the same installer logic still handles broad
-Linux package-manager and Docker-daemon surfaces.
+Release-grade fleet runs should run the distro lab alongside the hardware
+fleet. The hardware fleet proves GPU and product behavior; the distro lab proves
+the same installer logic still handles broad Linux package-manager and
+Docker-daemon surfaces.
 
 Run a focused subset while debugging:
 

--- a/dream-server/docs/VALIDATION-MATRIX.md
+++ b/dream-server/docs/VALIDATION-MATRIX.md
@@ -65,9 +65,8 @@ each host where the phase is applicable.
 | Release confidence report | The run is summarized into product, capability, lifecycle, and user-facing gates | Every release-grade run |
 
 `--phase all` is intended for a faster full-product development sweep. The
-release-grade path used by `/dream-fleet-test` and `--phase release` adds
-zero-prereq bootstrap and lifecycle gates so a green release run means more than
-"fresh install worked once."
+private release-grade path adds zero-prereq bootstrap and lifecycle gates so a
+green release run means more than "fresh install worked once."
 
 Run the release-grade fleet after operational code changes: installer phases,
 bootstrap, compose stack generation, service wiring, dashboard/API behavior,

--- a/dream-server/tests/fleet-multi-distro.sh
+++ b/dream-server/tests/fleet-multi-distro.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # Dream Server fleet multi-distro runner.
 #
-# This is the noninteractive distro gate intended for fleet hosts such as
-# tower2. It uses Docker directly instead of Distrobox so it can run from SSH,
-# cron, or a fleet harness without pre-created per-distro containers.
+# This is the noninteractive distro gate intended for fleet hosts. It uses
+# Docker directly instead of Distrobox so it can run from SSH, cron, or a fleet
+# harness without pre-created per-distro containers.
 
 set -euo pipefail
 

--- a/dream-server/tests/test-fleet-multi-distro-keep-going.sh
+++ b/dream-server/tests/test-fleet-multi-distro-keep-going.sh
@@ -3,7 +3,7 @@
 # when a single distro's `docker pull` fails. A bare `docker pull` under the
 # script's `set -euo pipefail` exits the loop on the first registry hiccup
 # (transient IPv6 failure, mirror outage, etc.) and silently skips every
-# distro that comes later in TARGETS. On Tower2 on 2026-05-23 an IPv6
+# distro that comes later in TARGETS. During a fleet run on 2026-05-23, an IPv6
 # `network is unreachable` on archlinux skipped manjaro, cachyos, and
 # opensuse — a class of failures the matrix exists to surface.
 #

--- a/dream-server/tests/test-hermes-proxy-caddyfile.sh
+++ b/dream-server/tests/test-hermes-proxy-caddyfile.sh
@@ -32,7 +32,7 @@ if grep -Eq '^[[:space:]]*redir[[:space:]]+/auth/required[[:space:]]+303([[:spac
 fi
 
 # Health matcher must cover BOTH /health and /healthz. The Docker healthcheck
-# uses /health; k8s and dream-fleet-test verify probes use /healthz. Anything
+# uses /health; Kubernetes-style and fleet verify probes use /healthz. Anything
 # left out of the matcher falls through to forward_auth and gets bounced to
 # /auth/required (303) — health monitors then mark the proxy unhealthy.
 grep -Eq '^[[:space:]]*@health[[:space:]]+path([[:space:]]+/[A-Za-z]+)*[[:space:]]+/healthz([[:space:]]|$)' "$CADDYFILE" \

--- a/dream-server/tests/test-macos-host-agent-verification.sh
+++ b/dream-server/tests/test-macos-host-agent-verification.sh
@@ -7,8 +7,8 @@
 #      while the agent is actually down.
 #
 # Without both, dashboard-api hits "Host agent unreachable" on every model and
-# extension action even though the installer reports success (observed on
-# m5-mbp during the 2026-05-23 fleet test).
+# extension action even though the installer reports success (observed on an
+# Apple Silicon fleet target during the 2026-05-23 fleet test).
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary
- update release notes to describe validation coverage by hardware class instead of lab-specific host labels
- remove a local run-directory reference from public release evidence
- tighten testing docs and comments so release validation references stay sanitized while public distro commands remain documented

## Validation
- git diff --check
- targeted search for old lab host labels, local run paths, and private harness names returned no matches
