### PR TITLE
fix(windows): route Lemonade LiteLLM through host runtime

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -3706,6 +3706,7 @@ def _render_runtime_config(
     *,
     gguf_file: str,
     lemonade_api_key: str,
+    lemonade_api_base: str,
     dream_mode: str,
     gpu_backend: str,
 ) -> bool:
@@ -3723,6 +3724,8 @@ def _render_runtime_config(
         gpu_backend,
         "--gguf-file",
         gguf_file,
+        "--lemonade-api-base",
+        lemonade_api_base,
         "--litellm-key",
         lemonade_api_key,
         "--output-root",
@@ -3760,11 +3763,16 @@ def _write_lemonade_config(install_dir: Path, gguf_file: str):
     lemonade_api_key = env.get("LITELLM_LEMONADE_API_KEY", "sk-lemonade")
     dream_mode = env.get("DREAM_MODE", "lemonade")
     gpu_backend = env.get("GPU_BACKEND", "amd")
+    lemonade_api_base = "http://llama-server:8080/api/v1"
+    if env.get("AMD_INFERENCE_LOCATION", "").lower() == "host":
+        lemonade_port = env.get("AMD_INFERENCE_PORT", "8080") or "8080"
+        lemonade_api_base = f"http://host.docker.internal:{lemonade_port}/api/v1"
     if _render_runtime_config(
         install_dir,
         "litellm-lemonade",
         gguf_file=gguf_file,
         lemonade_api_key=lemonade_api_key,
+        lemonade_api_base=lemonade_api_base,
         dream_mode=dream_mode,
         gpu_backend=gpu_backend,
     ):
@@ -3776,7 +3784,7 @@ def _write_lemonade_config(install_dir: Path, gguf_file: str):
         "  - model_name: \"*\"\n"
         "    litellm_params:\n"
         f"      model: openai/extra.{gguf_file}\n"
-        "      api_base: http://llama-server:8080/api/v1\n"
+        f"      api_base: {lemonade_api_base}\n"
         f"      api_key: {lemonade_api_key}\n"
         "      extra_body:\n"
         "        chat_template_kwargs:\n"

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -540,6 +540,7 @@ if ($dryRun) {
                 $envPath = Join-Path $installDir ".env"
                 if (Test-Path $envPath) {
                     $envContent = Get-Content $envPath -Raw
+                    $envContent = $envContent -replace "(?m)^DREAM_MODE=.*$", "DREAM_MODE=local"
                     $envContent = $envContent -replace "(?m)^LLM_BACKEND=.*$", "LLM_BACKEND=llama-server"
                     $envContent = $envContent -replace "(?m)^LLM_API_BASE_PATH=.*$", "LLM_API_BASE_PATH=/v1"
                     $envContent = $envContent -replace "(?m)^AMD_INFERENCE_RUNTIME=.*$", "AMD_INFERENCE_RUNTIME=llama-server"

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -264,22 +264,30 @@ function New-DreamEnv {
     $langfuseInitUserEmail     = Get-EnvOrNew "LANGFUSE_INIT_USER_EMAIL"   "admin@dreamserver.local"
     $langfuseInitUserPassword  = Get-EnvOrNew "LANGFUSE_INIT_USER_PASSWORD" (New-SecureHex -Bytes 16)
 
-    # Determine LLM backend engine and API URL
-    # AMD on Windows: inference server runs natively, containers reach it via host.docker.internal
-    # NVIDIA: llama-server runs in Docker, containers reach it via service name
+    # Determine LLM backend engine and API URL.
+    # AMD on Windows runs inference natively on the host. When that runtime is
+    # Lemonade, DREAM_MODE must also be lemonade so the LiteLLM container mounts
+    # config/litellm/lemonade.yaml instead of local.yaml's in-container
+    # llama-server route.
+    $windowsAmdHostInference = ($GpuBackend -eq "amd" -and $DreamMode -ne "cloud")
+    $windowsAmdLemonade = ($windowsAmdHostInference -and $AmdInferenceRuntime -eq "lemonade")
+    $effectiveDreamMode = $(if ($windowsAmdLemonade) { "lemonade" } else { $DreamMode })
+
     # NOTE: $(if ...) syntax required for PS 5.1 compatibility
-    $llmBackend = $(if ($GpuBackend -eq "amd") {
+    $llmBackend = $(if ($windowsAmdLemonade) {
         "lemonade"
     } elseif ($DreamMode -eq "cloud") {
         "litellm"
+    } elseif ($windowsAmdHostInference) {
+        "llama-server"
     } else {
         "llama-server"
     })
 
     # Lemonade serves OpenAI-compatible API at /api/v1; llama-server at /v1
-    $llmApiBasePath = $(if ($GpuBackend -eq "amd") { "/api/v1" } else { "/v1" })
+    $llmApiBasePath = $(if ($windowsAmdLemonade) { "/api/v1" } else { "/v1" })
 
-    $llmApiUrl = $(if ($GpuBackend -eq "amd") {
+    $llmApiUrl = $(if ($windowsAmdHostInference) {
         "http://host.docker.internal:8080"
     } elseif ($DreamMode -eq "cloud") {
         "http://litellm:4000"
@@ -344,7 +352,7 @@ BIND_ADDRESS=$(Get-EnvOrNew "BIND_ADDRESS" "$(if ($EnableLan) { "0.0.0.0" } else
 DREAM_AGENT_HOST=$(Get-EnvOrNew "DREAM_AGENT_HOST" "host.docker.internal")
 
 #=== LLM Backend Mode ===
-DREAM_MODE=$DreamMode
+DREAM_MODE=$effectiveDreamMode
 LLM_BACKEND=$llmBackend
 LLM_API_URL=$llmApiUrl
 LLM_API_BASE_PATH=$llmApiBasePath
@@ -492,6 +500,41 @@ LANGFUSE_INIT_USER_PASSWORD=$langfuseInitUserPassword
 
     $envPath = Join-Path $InstallDir ".env"
     Write-Utf8NoBom -Path $envPath -Content $envContent
+
+    if ($windowsAmdLemonade) {
+        $litellmDir = Join-Path (Join-Path $InstallDir "config") "litellm"
+        New-Item -ItemType Directory -Path $litellmDir -Force | Out-Null
+        $lemonadePort = $(if ($AmdInferencePort) { $AmdInferencePort } else { "8080" })
+        $lemonadeModel = "extra.$($TierConfig.GgufFile)"
+        $lemonadeApiBase = "http://host.docker.internal:$lemonadePort/api/v1"
+        $lemonadeConfig = @"
+model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/$lemonadeModel
+      api_base: $lemonadeApiBase
+      api_key: $litellmLemonadeApiKey
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+  - model_name: "*"
+    litellm_params:
+      model: openai/$lemonadeModel
+      api_base: $lemonadeApiBase
+      api_key: $litellmLemonadeApiKey
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 120
+  stream_timeout: 60
+"@
+        Write-Utf8NoBom -Path (Join-Path $litellmDir "lemonade.yaml") -Content $lemonadeConfig
+    }
 
     # Restrict .env to current user only (Windows ACL equivalent of chmod 600)
     try {

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -989,6 +989,13 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server -
             # went from "hangs indefinitely" to 1.8s end-to-end with this
             # one block added. The kwarg is a Qwen3-specific switch and is
             # safely ignored by non-Qwen3 chat templates.
+            _lemonade_api_base="http://llama-server:8080/api/v1"
+            _amd_location="$(read_env_value AMD_INFERENCE_LOCATION | tr '[:upper:]' '[:lower:]')"
+            _amd_port="$(read_env_value AMD_INFERENCE_PORT)"
+            : "${_amd_port:=8080}"
+            if [[ "$_amd_location" == "host" ]]; then
+                _lemonade_api_base="http://host.docker.internal:${_amd_port}/api/v1"
+            fi
             _renderer_ok=false
             _renderer_script="$INSTALL_DIR/scripts/render-runtime-configs.py"
             _renderer_py="${DREAM_PYTHON_CMD:-}"
@@ -1005,6 +1012,7 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-llama-server -
                     --dream-mode lemonade \
                     --gpu-backend amd \
                     --gguf-file "$FULL_GGUF_FILE" \
+                    --lemonade-api-base "$_lemonade_api_base" \
                     --litellm-key "$LITELLM_LEMONADE_API_KEY" \
                     --output-root "$INSTALL_DIR" \
                     --write >/dev/null 2>&1; then
@@ -1019,7 +1027,7 @@ model_list:
   - model_name: default
     litellm_params:
       model: openai/extra.${FULL_GGUF_FILE}
-      api_base: http://llama-server:8080/api/v1
+      api_base: ${_lemonade_api_base}
       api_key: ${LITELLM_LEMONADE_API_KEY}
       extra_body:
         chat_template_kwargs:
@@ -1028,7 +1036,7 @@ model_list:
   - model_name: "*"
     litellm_params:
       model: openai/extra.${FULL_GGUF_FILE}
-      api_base: http://llama-server:8080/api/v1
+      api_base: ${_lemonade_api_base}
       api_key: ${LITELLM_LEMONADE_API_KEY}
       extra_body:
         chat_template_kwargs:
@@ -1041,7 +1049,7 @@ litellm_settings:
   stream_timeout: 60
 LITELLM_UPGRADE_EOF
             fi
-            unset _renderer_ok _renderer_script _renderer_py
+            unset _renderer_ok _renderer_script _renderer_py _lemonade_api_base _amd_location _amd_port
             log "Restarting LiteLLM to pick up model change..."
             $DOCKER_CMD restart dream-litellm 2>&1 || log "WARNING: LiteLLM restart failed (non-fatal)"
         fi

--- a/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
@@ -319,8 +319,25 @@ if command -v pwsh >/dev/null 2>&1; then
         }
         New-DreamEnv -InstallDir $installDir -TierConfig $tier -Tier "SH" -GpuBackend "amd" -AmdInferenceRuntime "lemonade" -AmdInferenceLocation "host" | Out-Null
         $envText = Get-Content -LiteralPath (Join-Path $installDir ".env") -Raw
+        if ($envText -notmatch "(?m)^DREAM_MODE=lemonade$") {
+            throw "Expected Windows AMD Lemonade installs to write DREAM_MODE=lemonade"
+        }
+        if ($envText -notmatch "(?m)^LLM_BACKEND=lemonade$") {
+            throw "Expected Windows AMD Lemonade installs to write LLM_BACKEND=lemonade"
+        }
         if ($envText -notmatch "(?m)^WHISPER_PORT=9100$") {
             throw "Expected WHISPER_PORT=9100 for Windows AMD managed Lemonade"
+        }
+        $litellmConfig = Join-Path (Join-Path (Join-Path $installDir "config") "litellm") "lemonade.yaml"
+        if (-not (Test-Path -LiteralPath $litellmConfig)) {
+            throw "Expected Windows AMD Lemonade installs to generate config/litellm/lemonade.yaml"
+        }
+        $litellmText = Get-Content -LiteralPath $litellmConfig -Raw
+        if ($litellmText -notmatch "api_base: http://host\.docker\.internal:8080/api/v1") {
+            throw "Expected Windows AMD Lemonade LiteLLM config to route through host.docker.internal:8080/api/v1"
+        }
+        if ($litellmText -match "api_base: http://llama-server:8080/api/v1") {
+            throw "Windows AMD Lemonade LiteLLM config must not route to in-container llama-server"
         }
 
         Set-Content -LiteralPath (Join-Path $installDir ".env") -Value "WHISPER_PORT=9000`n" -NoNewline


### PR DESCRIPTION
## Summary

Fixes the Windows AMD/Lemonade LiteLLM route that showed up on Strixy: the native Lemonade runtime was healthy, but `dream-litellm` mounted `config/litellm/local.yaml` because `.env` still said `DREAM_MODE=local`. That local config routes to `http://llama-server:8080/v1`, which does not exist on Windows AMD because inference runs on the host.

This PR makes Windows AMD managed Lemonade installs write a coherent state:

- `DREAM_MODE=lemonade`
- `LLM_BACKEND=lemonade`
- generated `config/litellm/lemonade.yaml`
- LiteLLM `api_base: http://host.docker.internal:8080/api/v1`

It also keeps the native `llama-server.exe` fallback explicit by resetting `DREAM_MODE=local` when a user declines Lemonade.

## Why

Live Strixy evidence showed:

- Lemonade `:8080` model list and chat worked directly.
- `dream-litellm` could reach `host.docker.internal:8080` from inside the container.
- LiteLLM failed because its mounted config pointed to `llama-server:8080`.
- Manually changing only the LiteLLM upstream to `host.docker.internal:8080/api/v1` made LiteLLM chat return 200.

So this is a Dream Server config-generation bug, not a Lemonade model-serving failure.

## Validation

- `python -m py_compile dream-server/bin/dream-host-agent.py dream-server/scripts/render-runtime-configs.py`
- PowerShell parse check for `installers/windows/lib/env-generator.ps1` and `installers/windows/install-windows.ps1`
- `bash -n scripts/bootstrap-upgrade.sh`
- `bash -n tests/contracts/test-amd-lemonade-contracts.sh`
- `bash tests/contracts/test-amd-lemonade-contracts.sh` via Git Bash: 44 passed, 0 failed
- `bash tests/contracts/test-windows-amd-local-compose.sh` via Git Bash
- Behavioral Windows PowerShell check: generated a Windows AMD Lemonade install env/config and verified `DREAM_MODE=lemonade`, `LLM_BACKEND=lemonade`, `model: openai/extra.Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`, and `api_base: http://host.docker.internal:8080/api/v1` with no `llama-server:8080` route.