### PR TITLE
fix(windows): route Hermes through LiteLLM on Lemonade

### DIFF
--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -295,6 +295,15 @@ function New-DreamEnv {
         "http://llama-server:8080"
     })
 
+    # Hermes streams through the OpenAI-compatible provider. On Windows AMD
+    # Lemonade, direct streaming against Lemonade can close chunked responses
+    # early; LiteLLM normalizes that path and already fronts the same runtime
+    # for Open WebUI. Match the Linux AMD behavior and authenticate with the
+    # LiteLLM master key whenever Hermes targets LiteLLM.
+    $hermesUsesLiteLlm = ($windowsAmdLemonade -or $DreamMode -eq "cloud")
+    $hermesLlmBaseUrl = $(if ($hermesUsesLiteLlm) { "http://litellm:4000/v1" } else { "$llmApiUrl$llmApiBasePath" })
+    $hermesLlmApiKey = $(if ($hermesUsesLiteLlm) { $litellmKey } else { "sk-dream-hermes-local" })
+
     # Timezone -- convert Windows timezone ID to IANA for Docker containers
     $tz = $(try {
         $tzInfo = [System.TimeZoneInfo]::Local
@@ -433,8 +442,8 @@ OPENCLAW_PORT=7860
 SEARXNG_PORT=8888
 
 #=== Hermes Agent ===
-HERMES_LLM_BASE_URL=$llmApiUrl$llmApiBasePath
-HERMES_LLM_API_KEY=sk-dream-hermes-local
+HERMES_LLM_BASE_URL=$hermesLlmBaseUrl
+HERMES_LLM_API_KEY=$hermesLlmApiKey
 HERMES_LANGUAGE=en
 HERMES_PROXY_PORT=9120
 HERMES_PROXY_UPSTREAM=dream-hermes:9119

--- a/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
@@ -325,6 +325,19 @@ if command -v pwsh >/dev/null 2>&1; then
         if ($envText -notmatch "(?m)^LLM_BACKEND=lemonade$") {
             throw "Expected Windows AMD Lemonade installs to write LLM_BACKEND=lemonade"
         }
+        $litellmKey = [regex]::Match($envText, "(?m)^LITELLM_KEY=([^\r\n]+)\r?$").Groups[1].Value
+        if ([string]::IsNullOrWhiteSpace($litellmKey)) {
+            throw "Expected Windows AMD Lemonade installs to generate LITELLM_KEY"
+        }
+        if ($envText -notmatch "(?m)^HERMES_LLM_BASE_URL=http://litellm:4000/v1$") {
+            throw "Expected Windows AMD Lemonade Hermes to route through LiteLLM"
+        }
+        if ($envText -notmatch "(?m)^HERMES_LLM_API_KEY=$([regex]::Escape($litellmKey))\r?$") {
+            throw "Expected Windows AMD Lemonade Hermes to authenticate with LITELLM_KEY"
+        }
+        if ($envText -match "(?m)^HERMES_LLM_BASE_URL=http://host\.docker\.internal:8080/api/v1$") {
+            throw "Windows AMD Lemonade Hermes must not stream directly against native Lemonade"
+        }
         if ($envText -notmatch "(?m)^WHISPER_PORT=9100$") {
             throw "Expected WHISPER_PORT=9100 for Windows AMD managed Lemonade"
         }


### PR DESCRIPTION
## Summary
- Route Windows AMD/Lemonade Hermes traffic through LiteLLM instead of streaming directly against native Lemonade
- Reuse the LiteLLM master key for Hermes when Hermes targets LiteLLM
- Add a Windows AMD/Lemonade contract assertion so this route cannot regress

## Validation
- Windows PowerShell env-generator runtime check: DREAM_MODE=lemonade, Hermes base URL=http://litellm:4000/v1, Hermes key equals LITELLM_KEY
- Git Bash: dream-server/tests/contracts/test-amd-lemonade-contracts.sh (44 passed, 0 failed)

## Live finding this fixes
On Strixy, direct Lemonade and authenticated LiteLLM both completed successfully, but Hermes still used http://host.docker.internal:8080/api/v1 and failed with RemoteProtocolError / incomplete chunked read. This makes Hermes use the same LiteLLM route that already normalizes the Lemonade backend for Open WebUI.