### PR TITLE
fix(windows): keep Hermes config on LiteLLM for Lemonade

### DIFF
--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -309,13 +309,22 @@ if ($dryRun) {
                 } else {
                     $tierConfig.LlmModel
                 })
-                $hermesBaseUrl = $(if ($gpuInfo.Backend -eq "amd") {
-                    "http://host.docker.internal:8080/api/v1"
-                } elseif ($cloudMode) {
-                    "http://litellm:4000/v1"
-                } else {
-                    "http://llama-server:8080/v1"
-                })
+                $hermesBaseUrl = ""
+                if (Test-Path $envPath) {
+                    foreach ($line in Get-Content $envPath) {
+                        if ($line -match "^HERMES_LLM_BASE_URL=(.+)$") {
+                            $hermesBaseUrl = $Matches[1].Trim().Trim('"').Trim("'")
+                            break
+                        }
+                    }
+                }
+                if ([string]::IsNullOrWhiteSpace($hermesBaseUrl)) {
+                    $hermesBaseUrl = $(if ($cloudMode -or $gpuInfo.Backend -eq "amd") {
+                        "http://litellm:4000/v1"
+                    } else {
+                        "http://llama-server:8080/v1"
+                    })
+                }
                 $hermesTemplate = Join-Path (Join-Path (Join-Path $installDir "extensions") "services\hermes") "cli-config.yaml.template"
                 $hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
                 if (-not (Test-Path $hermesTemplate)) {

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -330,13 +330,17 @@ if ($enableHermes) {
     } else {
         $tierConfig.LlmModel
     })
-    $_hermesBaseUrl = $(if ($gpuInfo.Backend -eq "amd") {
-        "http://host.docker.internal:8080/api/v1"
-    } elseif ($cloudMode) {
-        "http://litellm:4000/v1"
-    } else {
-        "http://llama-server:8080/v1"
-    })
+    $_hermesBaseUrl = ""
+    if ($_envLines.ContainsKey("HERMES_LLM_BASE_URL")) {
+        $_hermesBaseUrl = $_envLines["HERMES_LLM_BASE_URL"].Trim().Trim('"').Trim("'")
+    }
+    if ([string]::IsNullOrWhiteSpace($_hermesBaseUrl)) {
+        $_hermesBaseUrl = $(if ($cloudMode -or $gpuInfo.Backend -eq "amd") {
+            "http://litellm:4000/v1"
+        } else {
+            "http://llama-server:8080/v1"
+        })
+    }
     $_hermesTemplate = Join-Path (Join-Path (Join-Path $installDir "extensions") "services\hermes") "cli-config.yaml.template"
     $_hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
     if (-not (Test-Path $_hermesTemplate)) {

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -408,13 +408,24 @@ restart_windows_lemonade_with_full_model() {
 }
 
 patch_hermes_yaml_with_sed() {
-    local path="$1" model="$2" context_length="$3"
+    local path="$1" model="$2" context_length="$3" base_url="${4:-}"
     [[ -f "$path" ]] || return 1
 
+    local model_sed base_url_sed
+    model_sed="$(printf '%s' "$model" | sed 's/[\\&|]/\\&/g')"
+    base_url_sed="$(printf '%s' "$base_url" | sed 's/[\\&|]/\\&/g')"
+
+    local sed_args=(
+        -e "s|^  default: \".*\"[[:space:]]*$|  default: \"${model_sed}\"|"
+        -e "s|^  context_length: .*|  context_length: ${context_length}|"
+        -e "s|^    context_length: .*|    context_length: ${context_length}|"
+    )
+    if [[ -n "$base_url" ]]; then
+        sed_args+=(-e "s|^  base_url: \".*\"[[:space:]]*$|  base_url: \"${base_url_sed}\"|")
+    fi
+
     if sed -i.bak \
-        -e "s|^  default: \".*\"[[:space:]]*$|  default: \"${model}\"|" \
-        -e "s|^  context_length: .*|  context_length: ${context_length}|" \
-        -e "s|^    context_length: .*|    context_length: ${context_length}|" \
+        "${sed_args[@]}" \
         "$path" 2>&1; then
         rm -f "${path}.bak"
     else
@@ -423,13 +434,15 @@ patch_hermes_yaml_with_sed() {
     fi
 
     grep -Fq "  default: \"${model}\"" "$path" \
-        && grep -Fq "  context_length: ${context_length}" "$path"
+        && grep -Fq "  context_length: ${context_length}" "$path" \
+        && { [[ -z "$base_url" ]] || grep -Fq "  base_url: \"${base_url}\"" "$path"; }
 }
 
 patch_hermes_model_after_swap() {
-    local gpu_backend llm_backend old_model new_model tpl
+    local gpu_backend llm_backend hermes_base_url old_model new_model tpl
     gpu_backend="$(read_env_value GPU_BACKEND | tr '[:upper:]' '[:lower:]')"
     llm_backend="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
+    hermes_base_url="$(read_env_value HERMES_LLM_BASE_URL)"
     old_model="$BOOTSTRAP_GGUF_FILE"
     new_model="$FULL_GGUF_FILE"
     if [[ "$gpu_backend" == "amd" || "$llm_backend" == "lemonade" ]]; then
@@ -441,15 +454,24 @@ patch_hermes_model_after_swap() {
 
     tpl="$INSTALL_DIR/extensions/services/hermes/cli-config.yaml.template"
     if [[ -f "$tpl" ]]; then
-        if ! patch_hermes_yaml_with_sed "$tpl" "$new_model" "$FULL_MAX_CONTEXT"; then
+        if ! patch_hermes_yaml_with_sed "$tpl" "$new_model" "$FULL_MAX_CONTEXT" "$hermes_base_url"; then
             log "ERROR: Could not patch ${tpl} after full-model swap."
             return 1
         fi
     fi
 
     if [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=dream-hermes --format '{{.Names}}' 2>/dev/null | grep -q dream-hermes; then
+        local live_patch old_model_sed new_model_sed hermes_base_url_sed
+        old_model_sed="$(printf '%s' "$old_model" | sed 's/[\\&|]/\\&/g')"
+        new_model_sed="$(printf '%s' "$new_model" | sed 's/[\\&|]/\\&/g')"
+        hermes_base_url_sed="$(printf '%s' "$hermes_base_url" | sed 's/[\\&|]/\\&/g')"
+        live_patch="sed -i -e 's|^  default: \"${old_model_sed}\"|  default: \"${new_model_sed}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|'"
+        if [[ -n "$hermes_base_url" ]]; then
+            live_patch="${live_patch} -e 's|^  base_url: \".*\"|  base_url: \"${hermes_base_url_sed}\"|'"
+        fi
+        live_patch="${live_patch} /opt/data/config.yaml"
         $DOCKER_CMD exec dream-hermes sh -c \
-            "sed -i -e 's|^  default: \"${old_model}\"|  default: \"${new_model}\"|' -e 's|^  context_length: .*|  context_length: ${FULL_MAX_CONTEXT}|' -e 's|^    context_length: .*|    context_length: ${FULL_MAX_CONTEXT}|' /opt/data/config.yaml" 2>&1 || {
+            "$live_patch" 2>&1 || {
                 log "ERROR: Could not patch Hermes live config after full-model swap."
                 return 1
             }

--- a/dream-server/tests/contracts/test-windows-hermes-config-patching.sh
+++ b/dream-server/tests/contracts/test-windows-hermes-config-patching.sh
@@ -80,7 +80,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 6. The root Windows install.ps1 entrypoint must propagate failures from the
+# 6. Windows Hermes YAML patching must use the generated HERMES_LLM_BASE_URL.
+#    Windows AMD/Lemonade env generation routes Hermes through LiteLLM, and
+#    Hermes model.base_url wins over OPENAI_BASE_URL, so recomputing AMD as
+#    host.docker.internal:8080/api/v1 here silently undoes the env fix.
+# ---------------------------------------------------------------------------
+if grep -q 'HERMES_LLM_BASE_URL' "$PHASE" \
+   && grep -q 'HERMES_LLM_BASE_URL' "$MONO" \
+   && ! grep -A12 '\$_hermesBaseUrl = \$' "$PHASE" | grep -q 'host.docker.internal:8080/api/v1' \
+   && ! grep -A12 '\$hermesBaseUrl = \$' "$MONO" | grep -q 'host.docker.internal:8080/api/v1'; then
+    pass "Windows Hermes config patching follows generated HERMES_LLM_BASE_URL"
+else
+    fail "Windows Hermes config patching must not recompute AMD Hermes base_url as direct Lemonade"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. The root Windows install.ps1 entrypoint must propagate failures from the
 #    delegated Windows installer. The fleet harness and public docs call the
 #    root script, so fail-loud checks are useless if the wrapper always exits 0.
 # ---------------------------------------------------------------------------

--- a/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
+++ b/dream-server/tests/contracts/test-windows-lemonade-swap-wait.sh
@@ -152,11 +152,27 @@ fi
 # ---------------------------------------------------------------------------
 if grep -q 'patch_hermes_yaml_with_sed' "$SCRIPT" \
    && grep -Fq 'grep -Fq "  default: \"${model}\""' "$SCRIPT" \
+   && grep -Fq 'grep -Fq "  base_url: \"${base_url}\""' "$SCRIPT" \
    && grep -q 'ERROR: Could not patch ${tpl} after full-model swap.' "$SCRIPT" \
    && grep -q 'return 1' "$SCRIPT"; then
-    pass "post-swap Hermes patch is dependency-free, verified, and fail-loud"
+    pass "post-swap Hermes patch is dependency-free, verifies model/base_url, and is fail-loud"
 else
-    fail "post-swap Hermes patch must avoid Python alias failures and return non-zero if YAML patching fails"
+    fail "post-swap Hermes patch must avoid Python alias failures and verify model/base_url before success"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. Full-model swap must preserve the install-time Hermes provider route.
+#     On Windows AMD/Lemonade, HERMES_LLM_BASE_URL is the LiteLLM route; if
+#     swap patching only updates model/context, the persisted Hermes config can
+#     keep direct native Lemonade and override the fixed env value.
+# ---------------------------------------------------------------------------
+if grep -q 'hermes_base_url="$(read_env_value HERMES_LLM_BASE_URL)"' "$SCRIPT" \
+   && grep -q 'patch_hermes_yaml_with_sed "$tpl" "$new_model" "$FULL_MAX_CONTEXT" "$hermes_base_url"' "$SCRIPT" \
+   && grep -q 'hermes_base_url_sed="$(printf' "$SCRIPT" \
+   && grep -q 'base_url: \\"${hermes_base_url_sed}\\"' "$SCRIPT"; then
+    pass "post-swap Hermes patch preserves HERMES_LLM_BASE_URL in template and live config"
+else
+    fail "post-swap Hermes patch must carry HERMES_LLM_BASE_URL into persisted Hermes config"
 fi
 
 echo "------------------------------------------------------------"


### PR DESCRIPTION
﻿## Summary

- keeps Windows AMD/Lemonade Hermes config aligned with the generated `HERMES_LLM_BASE_URL` instead of recomputing direct Lemonade routing
- patches both the Windows installer config writers and the post-swap `bootstrap-upgrade.sh` path so `/opt/data/config.yaml` remains on LiteLLM after full-model swap
- adds contracts for the Windows installer patch path and the swap-time Hermes base_url preservation

## Validation

Local:
- `tests/contracts/test-windows-hermes-config-patching.sh` — 7/7 pass
- `tests/contracts/test-windows-lemonade-swap-wait.sh` — 10/10 pass
- `tests/contracts/test-amd-lemonade-contracts.sh` — 44/44 pass
- PowerShell parser: `installers/windows/phases/06-directories.ps1`, `installers/windows/install-windows.ps1` — OK
- `bash -n scripts/bootstrap-upgrade.sh`
- `git diff --check`

Focused Strixy hardware run:
- run dir: `/home/michael/dream-fleet-test/runs/2026-06-05T11-55-32Z`
- install used `DREAM_FLEET_WIN_REF=fix/windows-hermes-config-litellm-base-url`
- install completed exit 0 and full-model swap completed: `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`, `status=complete`
- post-swap `dream-hermes` persisted config stayed on `base_url: "http://litellm:4000/v1"`
- `OPENAI_BASE_URL=http://litellm:4000/v1` inside `dream-hermes`
- direct LiteLLM completion from Strixy returned `ROUTE_OK`
- direct curl from inside `dream-hermes` to `http://litellm:4000/v1/chat/completions` returned `HERMES_CONTAINER_ROUTE_OK`
- harness `hermes_to_llm_ok=true` after the focused run

## Notes

The focused Strixy run is not release-green, but the remaining failures are outside this PR's scope: Windows dashboard host-agent 503, `gpu-detailed` 503, ComfyUI missing, LAN dream-proxy root, and Hermes CLI returning `(empty)` for the seed-echo assertion. The route failure this PR targets is fixed and validated at install-time and post-swap.
