### PR TITLE
fix(windows): restore dashboard extension installs

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -90,6 +90,55 @@ def _to_bash_path(path: Path) -> str:
         return f"/{drive.lower()}/{tail}"
     return normalized
 
+
+def _find_usable_bash() -> str | None:
+    """Return a Bash executable that can run shell scripts on this host."""
+    global _usable_bash
+    if isinstance(_usable_bash, str):
+        return _usable_bash
+    if _usable_bash is False:
+        return None
+
+    candidates: list[str] = []
+    found = shutil.which("bash")
+    if found:
+        candidates.append(found)
+
+    if platform.system() == "Windows":
+        candidates.extend([
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\usr\bin\bash.exe",
+        ])
+        local_appdata = os.environ.get("LOCALAPPDATA")
+        if local_appdata:
+            candidates.extend([
+                str(Path(local_appdata) / "Programs" / "Git" / "bin" / "bash.exe"),
+                str(Path(local_appdata) / "Programs" / "Git" / "usr" / "bin" / "bash.exe"),
+            ])
+
+    seen: set[str] = set()
+    for bash in candidates:
+        if not bash or bash in seen:
+            continue
+        seen.add(bash)
+        if not Path(bash).exists() and shutil.which(bash) is None:
+            continue
+        try:
+            result = subprocess.run(
+                [bash, "-lc", "printf ok"],
+                capture_output=True, text=True, timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if result.returncode == 0 and result.stdout == "ok":
+            _usable_bash = bash
+            return bash
+
+    _usable_bash = False
+    return None
+
 # Model download state — only one download at a time
 _model_download_lock = threading.Lock()
 _model_download_thread: threading.Thread | None = None
@@ -102,6 +151,7 @@ _update_lock = threading.Lock()
 _update_status_lock = threading.Lock()
 _update_thread: threading.Thread | None = None
 _update_usable_bash: str | bool | None = None
+_usable_bash: str | bool | None = None
 
 
 def load_env(env_path: Path) -> dict:
@@ -207,12 +257,19 @@ def resolve_compose_flags() -> list:
             return raw.split()
 
     script = INSTALL_DIR / "scripts" / "resolve-compose-stack.sh"
+    # Contract note: every resolver launch below must include --gpu-count.
     if not script.exists():
         raise RuntimeError(f"resolve-compose-stack.sh not found at {script}")
+    bash = _find_usable_bash()
+    if not bash:
+        raise RuntimeError(
+            "Compose resolution requires a usable Bash runtime. "
+            "Install Git Bash or run Dream Server through WSL/Linux."
+        )
     # --gpu-count gates the multigpu-{backend}.yml overlay; without it,
     # the host agent would resolve a single-GPU stack on multi-GPU hosts.
     result = subprocess.run(
-        ["bash", _to_bash_path(script), "--script-dir", _to_bash_path(INSTALL_DIR),
+        [bash, _to_bash_path(script), "--script-dir", _to_bash_path(INSTALL_DIR),
          "--tier", TIER, "--gpu-backend", GPU_BACKEND, "--gpu-count", GPU_COUNT],
         capture_output=True, text=True, check=True,
         cwd=str(INSTALL_DIR), timeout=30,
@@ -575,9 +632,14 @@ def _run_post_install_hook(service_id: str, ext_dir: Path) -> tuple[bool, str]:
         "GPU_BACKEND": GPU_BACKEND,
         "HOOK_NAME": "post_install",
     }
+    bash = _find_usable_bash()
+    if not bash:
+        msg = "post_install hook requires a usable Bash runtime. Install Git Bash or run Dream Server through WSL/Linux."
+        _write_progress(service_id, "error", "Setup failed", error=msg)
+        return (False, msg)
     try:
         result = subprocess.run(
-            ["bash", str(hook_path), str(INSTALL_DIR), GPU_BACKEND],
+            [bash, str(hook_path), str(INSTALL_DIR), GPU_BACKEND],
             cwd=str(ext_dir), env=hook_env,
             capture_output=True, text=True,
             timeout=SUBPROCESS_TIMEOUT_START,
@@ -1100,23 +1162,9 @@ def _find_update_bash() -> str | None:
     if _update_usable_bash is False:
         return None
 
-    bash = shutil.which("bash")
-    if not bash:
-        _update_usable_bash = False
-        return None
-    try:
-        result = subprocess.run(
-            [bash, "-lc", "printf ok"],
-            capture_output=True, text=True, timeout=5,
-        )
-    except (OSError, subprocess.SubprocessError):
-        _update_usable_bash = False
-        return None
-    if result.returncode == 0 and result.stdout == "ok":
-        _update_usable_bash = bash
-        return bash
-    _update_usable_bash = False
-    return None
+    bash = _find_usable_bash()
+    _update_usable_bash = bash if bash else False
+    return bash
 
 
 def _update_command(script_path: Path, *args: str) -> list[str]:
@@ -2616,19 +2664,34 @@ class AgentHandler(BaseHTTPRequestHandler):
             "GPU_BACKEND": GPU_BACKEND,
             "HOOK_NAME": hook_name,
         }
+        bash = _find_usable_bash()
+        if not bash:
+            json_response(self, 500, {
+                "error": f"Cannot run hook: {hook_name} hook requires a usable Bash runtime. Install Git Bash or run Dream Server through WSL/Linux."
+            })
+            return
 
         logger.info("Running %s hook for %s: %s", hook_name, service_id, hook_path)
         try:
+            popen_kwargs = {
+                "cwd": str(ext_dir),
+                "env": hook_env,
+                "stdout": subprocess.PIPE,
+                "stderr": subprocess.PIPE,
+            }
+            if platform.system() != "Windows":
+                popen_kwargs["preexec_fn"] = os.setsid
             proc = subprocess.Popen(
-                ["bash", str(hook_path), str(INSTALL_DIR), GPU_BACKEND],
-                cwd=str(ext_dir), env=hook_env,
-                stdout=subprocess.PIPE, stderr=subprocess.PIPE,
-                preexec_fn=os.setsid,
+                [bash, str(hook_path), str(INSTALL_DIR), GPU_BACKEND],
+                **popen_kwargs,
             )
             try:
                 stdout, stderr = proc.communicate(timeout=HOOK_TIMEOUT)
             except subprocess.TimeoutExpired:
-                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                if platform.system() == "Windows":
+                    proc.kill()
+                else:
+                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
                 proc.wait()
                 json_response(self, 500, {"error": f"{hook_name} hook timed out ({HOOK_TIMEOUT}s)"})
                 return

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -260,6 +260,39 @@ class TestToBashPath:
         assert _to_bash_path(Path(r"C:\Users\Gabriel\dream-server")) == "/c/Users/Gabriel/dream-server"
 
 
+class TestFindUsableBash:
+
+    def test_windows_skips_unusable_path_bash_and_uses_git_bash(self, monkeypatch):
+        bad_bash = r"C:\Windows\System32\bash.exe"
+        git_bash = r"C:\Program Files\Git\bin\bash.exe"
+        seen = []
+
+        monkeypatch.setattr(_mod, "_usable_bash", None)
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod.shutil, "which", lambda name: bad_bash if name == "bash" else None)
+
+        real_exists = _mod.Path.exists
+
+        def fake_exists(path):
+            if str(path) in {bad_bash, git_bash}:
+                return True
+            return real_exists(path)
+
+        def fake_run(cmd, *args, **kwargs):
+            seen.append(cmd[0])
+            if cmd[0] == bad_bash:
+                return subprocess.CompletedProcess(cmd, 127, "", "WSL execvpe(/bin/bash) failed")
+            if cmd[0] == git_bash:
+                return subprocess.CompletedProcess(cmd, 0, "ok", "")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        monkeypatch.setattr(_mod.Path, "exists", fake_exists)
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        assert _mod._find_usable_bash() == git_bash
+        assert seen[:2] == [bad_bash, git_bash]
+
+
 class TestValidateCoreRecreateIds:
 
     def test_accepts_allowed_core_service(self, monkeypatch):
@@ -2158,6 +2191,7 @@ class TestEnableRetry:
         monkeypatch.setattr(_mod, "EXTENSIONS_DIR", builtin_root)
         monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
         monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+        monkeypatch.setattr(_mod, "_usable_bash", "bash")
 
         # Drop the per-service lock so retries across tests don't deadlock.
         _mod._service_locks.pop("fakesvc", None)
@@ -2201,7 +2235,7 @@ class TestEnableRetry:
         assert handler.parse_response()["status"] == "retrying"
         # post_install hook was invoked via bash against setup.sh
         assert any(
-            len(c) >= 2 and c[0] == "bash" and c[1].endswith("setup.sh")
+            len(c) >= 2 and c[0] == _mod._usable_bash and c[1].endswith("setup.sh")
             for c in hook_cmds
         ), f"expected setup.sh bash invocation, saw {hook_cmds}"
         # docker compose start was called after the hook

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -110,6 +110,29 @@ if (Test-Path $_retiredDreamForge) {
     Write-AI "Removed retired DreamForge service files from extensions/services"
 }
 
+# Copy extensions library to data dir for dashboard portal. Keep this in
+# parity with Linux phase 06 and macOS install: dashboard-api installs
+# optional extensions from data/extensions-library, not from the source tree.
+$_extLibSrc = $null
+foreach ($_candidate in @(
+    (Join-Path $sourceRoot "extensions\library\services"),
+    (Join-Path $installDir "extensions\library\services"),
+    (Join-Path $installDir "extensions-library-bundle\services")
+)) {
+    if (Test-Path $_candidate) {
+        $_extLibSrc = $_candidate
+        break
+    }
+}
+if ($null -ne $_extLibSrc) {
+    $_extLibDst = Join-Path $installDir "data\extensions-library"
+    New-Item -ItemType Directory -Path $_extLibDst -Force | Out-Null
+    Copy-Item -Path (Join-Path $_extLibSrc "*") -Destination $_extLibDst -Recurse -Force
+    Write-AISuccess "Extensions library copied to data/extensions-library (from $_extLibSrc)"
+} else {
+    Write-AIWarn "Extensions library not found; dashboard Extensions page will return 503 until populated"
+}
+
 # Copies from the Windows installer directory to the install root so users
 # can manage Dream Server with: .\dream.ps1 status
 # $ScriptDir is set by install-windows.ps1 (installers/windows/) and is

--- a/dream-server/lib/python-cmd.sh
+++ b/dream-server/lib/python-cmd.sh
@@ -13,6 +13,47 @@ _ds_python_runnable() {
     "$candidate" -c 'import sys; sys.exit(0)' >/dev/null 2>&1
 }
 
+_ds_python_has_module() {
+    local candidate="$1" module="$2"
+    _ds_python_runnable "$candidate" || return 1
+    "$candidate" - "$module" <<'PY' >/dev/null 2>&1
+import importlib
+import sys
+
+importlib.import_module(sys.argv[1])
+PY
+}
+
+_ds_windows_path_to_unix() {
+    local path="$1" drive rest
+    path="${path//\\//}"
+    if [[ "$path" =~ ^([A-Za-z]):/(.*)$ ]]; then
+        drive="$(printf '%s' "${BASH_REMATCH[1]}" | tr '[:upper:]' '[:lower:]')"
+        rest="${BASH_REMATCH[2]}"
+        printf '/%s/%s' "$drive" "$rest"
+    else
+        printf '%s' "$path"
+    fi
+}
+
+_ds_python_windows_candidates() {
+    local local_appdata=""
+    if [[ -n "${LOCALAPPDATA:-}" ]]; then
+        local_appdata="$(_ds_windows_path_to_unix "$LOCALAPPDATA")"
+    elif [[ -n "${USERPROFILE:-}" ]]; then
+        local_appdata="$(_ds_windows_path_to_unix "$USERPROFILE")/AppData/Local"
+    fi
+    [[ -n "$local_appdata" ]] || return 0
+
+    local candidate
+    for candidate in \
+        "$local_appdata"/Programs/Python/Python*/python.exe \
+        "$local_appdata"/Python/bin/python.exe
+    do
+        [[ -e "$candidate" ]] && printf '%s\n' "$candidate"
+    done
+}
+
 # Prints the python command name to stdout.
 # Order:
 #  1) python3 (must be runnable)
@@ -54,5 +95,45 @@ ds_detect_python_cmd() {
     fi
 
     echo "ERROR: Neither python3 nor python is available/runnable." >&2
+    return 1
+}
+
+# Prints a Python command that can import the requested module.
+# This is intentionally separate from ds_detect_python_cmd: generic scripts
+# should still prefer python3, while YAML/JSON-schema helpers need the
+# interpreter that actually has their dependency installed. On Windows Git
+# Bash, python3 can resolve to a Microsoft Store/App Installer Python without
+# PyYAML while python has the module, so "runnable" is not enough.
+ds_detect_python_cmd_with_module() {
+    local module="$1"
+    [[ -n "$module" ]] || return 1
+
+    if [[ -n "${DREAM_PYTHON_CMD:-}" ]] && _ds_python_has_module "$DREAM_PYTHON_CMD" "$module"; then
+        printf '%s' "$DREAM_PYTHON_CMD"
+        return 0
+    fi
+
+    if [[ "${DREAM_PYTHON_PREFER_SYSTEM:-}" == "1" && -x /usr/bin/python3 ]]; then
+        if _ds_python_has_module /usr/bin/python3 "$module"; then
+            printf '%s' "/usr/bin/python3"
+            return 0
+        fi
+    fi
+
+    local candidate
+    for candidate in python3 python; do
+        if _ds_python_has_module "$candidate" "$module"; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done
+
+    while IFS= read -r candidate; do
+        if _ds_python_has_module "$candidate" "$module"; then
+            printf '%s' "$candidate"
+            return 0
+        fi
+    done < <(_ds_python_windows_candidates)
+
     return 1
 }

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -55,7 +55,7 @@ sr_load() {
     PYTHON_CMD="python3"
     if [[ -f "${SCRIPT_DIR:-$(pwd)}/lib/python-cmd.sh" ]]; then
         . "${SCRIPT_DIR:-$(pwd)}/lib/python-cmd.sh"
-        PYTHON_CMD="$(ds_detect_python_cmd)"
+        PYTHON_CMD="$(ds_detect_python_cmd_with_module yaml 2>/dev/null || ds_detect_python_cmd)"
     elif command -v python >/dev/null 2>&1; then
         PYTHON_CMD="python"
     fi

--- a/dream-server/scripts/resolve-compose-stack.sh
+++ b/dream-server/scripts/resolve-compose-stack.sh
@@ -55,7 +55,7 @@ ROOT_DIR="$SCRIPT_DIR"
 PYTHON_CMD="python3"
 if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then
     . "$ROOT_DIR/lib/python-cmd.sh"
-    PYTHON_CMD="$(ds_detect_python_cmd)"
+    PYTHON_CMD="$(ds_detect_python_cmd_with_module yaml 2>/dev/null || ds_detect_python_cmd)"
 elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -49,9 +49,10 @@ echo "unexpected fake python invocation: $*" >&2
 exit 99
 PYEOF
 chmod +x "$fake_py"
+cp "$fake_py" "$tmpdir/python"
 
 missing_yaml_err="$tmpdir/missing-yaml.err"
-if DREAM_PYTHON_CMD="$fake_py" scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" >"$tmpdir/missing-yaml.out" 2>"$missing_yaml_err"; then
+if PATH="$tmpdir:$PATH" USERPROFILE="" LOCALAPPDATA="" DREAM_PYTHON_CMD="$fake_py" scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" >"$tmpdir/missing-yaml.out" 2>"$missing_yaml_err"; then
   echo "[FAIL] resolver should fail when selected Python cannot import yaml"
   exit 1
 fi
@@ -173,6 +174,41 @@ assert_contains "$phase06" 'export INSTALL_PHASE="06-directories/\$\{step\}"' "p
 for step in create-directories copy-source copy-extensions-library generate-env validate-env generate-searxng-config; do
   assert_contains "$phase06" "_phase06_step \"$step\"" "phase 06 missing substep: $step"
 done
+
+echo "[contract] Windows phase 06 stages the extension library"
+win_phase06="installers/windows/phases/06-directories.ps1"
+assert_contains "$win_phase06" 'extensions\\library\\services' "Windows phase 06 does not search the source extension library"
+assert_contains "$win_phase06" 'data\\extensions-library' "Windows phase 06 does not stage data/extensions-library"
+assert_contains "$win_phase06" 'Extensions library copied to data/extensions-library' "Windows phase 06 does not report extension library copy success"
+
+echo "[contract] Python resolver can select a module-capable fallback"
+pybin="$tmpdir/python-module-fallback"
+mkdir -p "$pybin"
+cat > "$pybin/python3" <<'PY3'
+#!/usr/bin/env bash
+# Runnable, but cannot import yaml.
+if [[ "${1:-}" == "-c" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" == "-" && "${2:-}" == "yaml" ]]; then
+  exit 1
+fi
+exit 0
+PY3
+cat > "$pybin/python" <<'PY'
+#!/usr/bin/env bash
+exit 0
+PY
+chmod +x "$pybin/python3" "$pybin/python"
+module_py="$(PATH="$pybin:$PATH" bash -c '
+  set -euo pipefail
+  source lib/python-cmd.sh
+  ds_detect_python_cmd_with_module yaml
+')"
+if [[ "$module_py" != "python" ]]; then
+  echo "[FAIL] Python resolver did not fall back to module-capable python (got: $module_py)"
+  exit 1
+fi
 
 echo "[contract] ds_sudo uses sudo -n in non-interactive mode"
 fakebin="$tmpdir/fakebin"


### PR DESCRIPTION
## Summary
- Stage the bundled extension library during Windows installs so the dashboard Extensions page can install services like Aider.
- Make host-agent Bash discovery probe executability and prefer a working Git Bash when PATH `bash` resolves to an unusable WSL relay.
- Let compose/service-registry helpers choose a Python interpreter that can import PyYAML, including Windows per-user Python installs.
- Add regression coverage for Windows extension-library staging, module-capable Python fallback, and Windows Bash selection.

## Validation
- `python -m py_compile dream-server/bin/dream-host-agent.py`
- `python -m pytest dream-server/extensions/services/dashboard-api/tests/test_host_agent.py -q` -> 121 passed, 3 skipped
- `C:\Program Files\Git\bin\bash.exe dream-server/tests/contracts/test-installer-hardening.sh` -> PASS
- Local Windows behavior check: `ds_detect_python_cmd_with_module yaml` selects `python` on this machine, avoiding the `python3` without PyYAML path.
- Local host-agent import check: `_find_usable_bash()` selects `C:\Program Files\Git\bin\bash.exe` instead of the broken PATH `bash` relay.

## Live evidence from windows-laptop bring-up
- Public-main install on the RTX 5070 Windows laptop reached healthy readiness and LLM chat, but dashboard extension install failed because `data/extensions-library` was absent.
- Copying the source extension library into `data/extensions-library` made the dashboard catalog available.
- Aider install then reached compose resolution and exposed two Windows runtime gaps fixed here: PyYAML-capable Python selection and host-agent Bash selection.

## Follow-up before full fleet
A stale pre-fix host-agent process is still holding port 7710 on the Windows laptop, so a meaningful dashboard rerun requires killing that process or rebooting the laptop so the fixed agent starts. After this lands, run a focused `windows-laptop` lane first, then full fleet if it is green.