### PR TITLE
[codex] guard direct updater on runtime installs

### DIFF
--- a/dream-server/dream-update.sh
+++ b/dream-server/dream-update.sh
@@ -139,6 +139,37 @@ resolve_compose_flags() {
     return 1
 }
 
+is_git_checkout() {
+    command -v git >/dev/null 2>&1 || return 1
+    git -C "${INSTALL_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+
+    local prefix top
+    top=$(git -C "${INSTALL_DIR}" rev-parse --show-toplevel 2>/dev/null || return 1)
+    prefix=$(git -C "${INSTALL_DIR}" rev-parse --show-prefix 2>/dev/null || return 1)
+    git -C "${top}" ls-files --error-unmatch "${prefix}dream-update.sh" >/dev/null 2>&1
+}
+
+runtime_update_guidance() {
+    log_info "For routine runtime/image updates, run: cd \"${INSTALL_DIR}\" && ./dream-cli update"
+    log_info "For source-code updates, reinstall or run this command from a git-backed DreamServer source checkout."
+}
+
+ensure_source_checkout_for_update() {
+    if ! command -v git >/dev/null 2>&1; then
+        log_error "git is required for dream-update.sh source-code updates."
+        runtime_update_guidance
+        return 1
+    fi
+
+    if ! is_git_checkout; then
+        log_error "dream-update.sh update only works from a git-backed DreamServer source checkout."
+        log_info "Install path: ${INSTALL_DIR}"
+        runtime_update_guidance
+        log_info "No files, services, or rollback snapshots were changed."
+        return 1
+    fi
+}
+
 # Semver compare: returns 0 if equal, 1 if v1 > v2, 2 if v1 < v2
 semver_compare() {
     local v1="${1#v}"
@@ -446,7 +477,10 @@ cmd_check() {
         2)
             log_info "Update available: ${current_version} → ${latest_version}"
             echo ""
-            echo "Run 'dream-update.sh update' to update."
+            echo "Run 'dream update' or './dream-cli update' for normal runtime updates."
+            if is_git_checkout; then
+                echo "Source checkout detected: run 'dream-update.sh update' only when you intend to pull source code."
+            fi
             ;;
     esac
     
@@ -588,6 +622,10 @@ cmd_update() {
     local current_version
     current_version=$(get_current_version)
 
+    if ! ensure_source_checkout_for_update; then
+        return 1
+    fi
+
     # ── Step 1: rollback snapshot ─────────────────────────────────────────────
     local timestamp
     timestamp=$(date +%Y%m%d-%H%M%S)
@@ -600,13 +638,6 @@ cmd_update() {
 
     # ── Step 2: pull latest changes ───────────────────────────────────────────
     log_info "Pulling latest changes..."
-    if [[ ! -d "${INSTALL_DIR}/.git" ]]; then
-        log_error "This install directory is not a git repository, so dream-update.sh cannot pull source code."
-        log_info "Install path: ${INSTALL_DIR}"
-        log_info "For routine runtime/image updates, run: cd \"${INSTALL_DIR}\" && ./dream-cli update"
-        log_info "For source-code updates, reinstall or restore this directory as a git-backed DreamServer checkout."
-        return 1
-    fi
     cd "$INSTALL_DIR"
     git fetch origin
     if ! git pull origin main && ! git pull origin master; then
@@ -917,8 +948,8 @@ Commands:
   check          Check for available updates
   status         Show current version, update status, and rollback info
   backup [name]  Create a named general backup of current configuration
-  update         Pull latest, run migrations, restart, health-check;
-                 auto-restores rollback snapshot on any failure
+  update         Source-checkout only: pull latest source, run migrations,
+                 restart, health-check, and auto-restore on failure
   rollback [id]  Restore from a rollback snapshot or general backup
                  (default: most recent pre-update snapshot)
   changelog [v]  Show changelog (optional: specific version)
@@ -941,7 +972,8 @@ Examples:
   dream-update.sh check
   dream-update.sh status
   dream-update.sh backup pre-experiment
-  dream-update.sh update
+  dream update                    # normal runtime/image update
+  dream-update.sh update          # source checkout only
   dream-update.sh rollback
   dream-update.sh rollback 20260317-120000
   dream-update.sh changelog v1.1.0

--- a/dream-server/get-dream-server.sh
+++ b/dream-server/get-dream-server.sh
@@ -192,7 +192,7 @@ if [[ -d "$INSTALL_DIR" ]]; then
         echo ""
         echo "  To start:     cd $INSTALL_DIR && docker compose up -d"
         echo "  To reinstall: rm -rf $INSTALL_DIR && re-run this script"
-        echo "  To update:    cd $INSTALL_DIR && git pull && ./install.sh --force"
+        echo "  To update:    cd $INSTALL_DIR && ./dream-cli update"
         echo ""
         exit 0
     else

--- a/dream-server/tests/test-dream-update-runtime-compose.sh
+++ b/dream-server/tests/test-dream-update-runtime-compose.sh
@@ -8,6 +8,7 @@ fail() { echo "[FAIL] $*"; exit 1; }
 pass() { echo "[PASS] $*"; }
 
 command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v git >/dev/null 2>&1 || fail "git is required"
 [[ -f "$UPDATE_SCRIPT" ]] || fail "dream-update.sh not found"
 
 TMP_DIR="$(mktemp -d)"
@@ -88,6 +89,9 @@ chmod +x "$BIN_DIR/docker"
 
 cat > "$BIN_DIR/curl" <<'SH'
 #!/usr/bin/env bash
+if [[ "$*" == *"api.github.com/repos/"*"releases/latest"* ]]; then
+    printf '%s\n' '{"tag_name":"v9.9.9"}'
+fi
 exit 0
 SH
 chmod +x "$BIN_DIR/curl"
@@ -105,16 +109,55 @@ if grep -q "No services defined in docker-compose" "$TMP_DIR/health.out"; then
 fi
 pass "dream-update health uses saved compose flags in runtime installs"
 
+cat > "$INSTALL_DIR/.version" <<'EOF'
+{"version":"1.0.0"}
+EOF
+PATH="$BIN_DIR:$PATH" bash "$INSTALL_DIR/dream-update.sh" check > "$TMP_DIR/check.out" 2>&1 \
+    || { cat "$TMP_DIR/check.out"; fail "check should pass with mocked release API"; }
+grep -q "dream update" "$TMP_DIR/check.out" \
+    || { cat "$TMP_DIR/check.out"; fail "check did not recommend runtime update command"; }
+if grep -q "Run 'dream-update.sh update' to update" "$TMP_DIR/check.out"; then
+    cat "$TMP_DIR/check.out"
+    fail "check still recommends direct source updater for runtime installs"
+fi
+pass "dream-update check recommends runtime update command"
+
+SOURCE_BIN_DIR="$TMP_DIR/source-bin"
+SOURCE_PARENT="$TMP_DIR/source-parent"
+SOURCE_INSTALL="$SOURCE_PARENT/dream-server"
+mkdir -p "$SOURCE_BIN_DIR" "$SOURCE_INSTALL"
+cp "$UPDATE_SCRIPT" "$SOURCE_INSTALL/dream-update.sh"
+chmod +x "$SOURCE_INSTALL/dream-update.sh"
+cat > "$SOURCE_BIN_DIR/curl" <<'SH'
+#!/usr/bin/env bash
+if [[ "$*" == *"api.github.com/repos/"*"releases/latest"* ]]; then
+    printf '%s\n' '{"tag_name":"v9.9.9"}'
+fi
+exit 0
+SH
+chmod +x "$SOURCE_BIN_DIR/curl"
+git -C "$SOURCE_PARENT" init -q
+git -C "$SOURCE_PARENT" add dream-server/dream-update.sh
+PATH="$SOURCE_BIN_DIR:$PATH" bash "$SOURCE_INSTALL/dream-update.sh" check > "$TMP_DIR/source-check.out" 2>&1 \
+    || { cat "$TMP_DIR/source-check.out"; fail "check should pass in nested source checkout"; }
+grep -q "Source checkout detected" "$TMP_DIR/source-check.out" \
+    || { cat "$TMP_DIR/source-check.out"; fail "nested source checkout was not recognized"; }
+pass "dream-update recognizes nested source checkout layout"
+
+: > "$DOCKER_LOG"
 set +e
 PATH="$BIN_DIR:$PATH" bash "$INSTALL_DIR/dream-update.sh" update > "$TMP_DIR/update.out" 2>&1
 update_exit=$?
 set -e
 
 [[ "$update_exit" -ne 0 ]] || fail "update without .git should fail"
-grep -q "not a git repository" "$TMP_DIR/update.out" \
+grep -q "git-backed DreamServer source checkout" "$TMP_DIR/update.out" \
     || { cat "$TMP_DIR/update.out"; fail "missing non-git install diagnosis"; }
 grep -q "./dream-cli update" "$TMP_DIR/update.out" \
     || { cat "$TMP_DIR/update.out"; fail "missing runtime update guidance"; }
-grep -q "git-backed DreamServer checkout" "$TMP_DIR/update.out" \
-    || { cat "$TMP_DIR/update.out"; fail "missing source update guidance"; }
-pass "dream-update explains non-git runtime update path"
+if find "$INSTALL_DIR/data/backups" -mindepth 1 -maxdepth 1 -type d -name 'pre-update-*' 2>/dev/null | grep -q .; then
+    find "$INSTALL_DIR/data/backups" -mindepth 1 -maxdepth 1 -type d -name 'pre-update-*'
+    fail "non-git update created a rollback snapshot before preflight"
+fi
+[[ ! -s "$DOCKER_LOG" ]] || { cat "$DOCKER_LOG"; fail "non-git update invoked Docker"; }
+pass "dream-update fails cleanly before mutating non-git runtime installs"


### PR DESCRIPTION
## Summary

Harden the legacy/direct `dream-update.sh update` path so normal runtime installs fail cleanly before any state mutation.

## Why

A user reported running `dream-update.sh update` and ending up with a confusing nested `dream-server/dream-server` layout plus missing runtime services. Current `main` did not reproduce that exact destructive behavior in a disposable runtime install, but the direct updater was still a real footgun:

- `dream-update.sh check` told users to run `dream-update.sh update`
- normal one-line installs are not git checkouts, so direct source update is the wrong command
- the direct updater created a pre-update snapshot before discovering it could not source-update
- the bootstrap installer's existing-install guidance still suggested `git pull && ./install.sh --force`

## Changes

- Add a source-checkout preflight before `dream-update.sh update` creates snapshots, calls Git, or touches Docker.
- Support valid git worktrees and this repo's nested `dream-server/` source layout by checking the tracked updater path instead of only `.git` directories.
- Update `dream-update.sh check` and help text to recommend `dream update` / `./dream-cli update` for runtime updates.
- Update bootstrap existing-install guidance to use `./dream-cli update`.
- Extend the updater regression test to assert non-git runtime installs do not create rollback snapshots or touch Docker.

## Validation

- `bash tests/test-dream-update-runtime-compose.sh`
- `bash tests/contracts/test-installer-hardening.sh`
- `bash -n dream-update.sh get-dream-server.sh tests/test-dream-update-runtime-compose.sh`
- `git diff --check`
- Disposable runtime repro: `dream-update.sh update` exits with guidance, preserves model/log sentinels, creates no nested directory, creates no rollback snapshot, and does not call Docker.
- Nested source-checkout regression: `repo-root/dream-server/dream-update.sh check` still recognizes the source checkout layout.

ShellCheck was not installed on the Linux test host, so syntax and behavior were covered by the commands above.
