### PR TITLE
fix(installer/macos): tolerate slow model downloads

### DIFF
--- a/dream-server/installers/macos/lib/ui.sh
+++ b/dream-server/installers/macos/lib/ui.sh
@@ -76,6 +76,9 @@ download_with_progress() {
     local max_retries="${4:-3}"
 
     local part_file="${destination}.part"
+    local connect_timeout="${DREAM_DOWNLOAD_CONNECT_TIMEOUT:-30}"
+    local low_speed_time="${DREAM_DOWNLOAD_LOW_SPEED_TIME:-300}"
+    local low_speed_limit="${DREAM_DOWNLOAD_LOW_SPEED_LIMIT:-1024}"
     local attempt=1
 
     while [[ $attempt -le $max_retries ]]; do
@@ -88,8 +91,8 @@ download_with_progress() {
         fi
 
         if curl -C - -L --progress-bar \
-            --connect-timeout 10 \
-            --speed-time 30 --speed-limit 10240 \
+            --connect-timeout "$connect_timeout" \
+            --speed-time "$low_speed_time" --speed-limit "$low_speed_limit" \
             -o "$part_file" "$url"; then
             mv "$part_file" "$destination"
             ai_ok "${label} complete"

--- a/dream-server/tests/contracts/test-installer-hardening.sh
+++ b/dream-server/tests/contracts/test-installer-hardening.sh
@@ -168,6 +168,14 @@ assert_not_contains "$macos_installer" 'pip install --user .*pyyaml|pip install 
 assert_contains "$macos_installer" 'export DREAM_PYTHON_CMD' "macOS installer does not export selected Python"
 assert_contains "$macos_installer" '_ds_python_cmd_cached=' "macOS installer does not refresh python resolver cache"
 
+echo "[contract] macOS bootstrap model download tolerates slow resumable transfers"
+macos_ui="installers/macos/lib/ui.sh"
+assert_contains "$macos_ui" 'curl -C - -L --progress-bar' "macOS bootstrap model download should preserve curl resume support"
+assert_contains "$macos_ui" 'DREAM_DOWNLOAD_CONNECT_TIMEOUT:-30' "macOS bootstrap model download should allow configurable connect timeout"
+assert_contains "$macos_ui" 'DREAM_DOWNLOAD_LOW_SPEED_TIME:-300' "macOS bootstrap model download should tolerate slow but active transfers"
+assert_contains "$macos_ui" 'DREAM_DOWNLOAD_LOW_SPEED_LIMIT:-1024' "macOS bootstrap model download should use a lenient low-speed threshold"
+assert_not_contains "$macos_ui" '--speed-time 30 --speed-limit 10240' "macOS bootstrap model download should not abort active slow transfers after 30 seconds"
+
 echo "[contract] Windows bootstrap model download uses retry wrapper"
 win_installer="installers/windows/install-windows.ps1"
 assert_contains "$win_installer" 'Invoke-DownloadWithRetry -Url \$tierConfig\.GgufUrl' "Windows installer should retry/resume transient GGUF download failures"


### PR DESCRIPTION
## Summary

- make the macOS installer model download low-speed guard configurable and more tolerant
- preserve curl resume/retry behavior for interrupted GGUF downloads
- add installer-hardening contract coverage for the macOS bootstrap download path

## Root cause

The macOS fast-start bootstrap model download could abort on slow but active network links because curl treated 30 seconds below 10 KiB/s as a hard failure. The installer already writes a resumable `.part` file, but the threshold was much stricter than the other bootstrap download path and could fail otherwise healthy installs.

## Validation

- `bash tests/contracts/test-installer-hardening.sh`
- `bash -n installers/macos/lib/ui.sh tests/contracts/test-installer-hardening.sh`
- Targeted macOS Apple Silicon fleet install from this branch: install exit 0, readiness 9/9
- Targeted macOS post-install probes from the same run: regressions 16/16, verify/dashboard/Hermes/capabilities OK; full-model capability probes deferred while the bootstrap model was active
