### PR TITLE
fix(cli): retry transient compose startup failures

### DIFF
--- a/dream-server/dream-cli
+++ b/dream-server/dream-cli
@@ -723,6 +723,15 @@ _compose_run_with_summary() {
         docker compose --progress quiet "$@" >"$_compose_log" 2>&1 || _rc=$?
     fi
 
+    if (( _rc != 0 )) && $_is_compose_up \
+       && grep -Eiq 'dependency failed to start|container .* (exited|is unhealthy)|service .* failed to start|failed to start.*container' "$_compose_log"; then
+        warn "Docker reported a transient service startup failure; waiting briefly and retrying once."
+        sleep "${DREAM_COMPOSE_STARTUP_RETRY_DELAY:-15}"
+        : >"$_compose_log"
+        _rc=0
+        docker compose --progress quiet "$@" >"$_compose_log" 2>&1 || _rc=$?
+    fi
+
     if (( _rc == 0 )); then
         success "${_verb} — done"
         rm -f "$_compose_log"

--- a/dream-server/tests/bats-tests/test-compose-summary-wrapper.bats
+++ b/dream-server/tests/bats-tests/test-compose-summary-wrapper.bats
@@ -78,6 +78,19 @@ case "${DOCKER_STUB_MODE:-success}" in
         echo "Container dream-foo started"
         exit 0
         ;;
+    fail-startup-once)
+        state_file="$TMPDIR_TEST/startup-retry-count"
+        count=0
+        [[ -f "$state_file" ]] && count=$(cat "$state_file")
+        count=$((count + 1))
+        echo "$count" > "$state_file"
+        if [[ "$count" -eq 1 ]]; then
+            echo "dependency failed to start: container dream-llama-server exited (137)"
+            exit 1
+        fi
+        echo "Container dream-llama-server started"
+        exit 0
+        ;;
     fail-docker-sock)
         echo "unable to get image 'ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4': permission denied while trying to connect to the docker API at unix:///var/run/docker.sock"
         exit 1
@@ -91,6 +104,7 @@ STUB
     chmod +x "$TMPDIR_TEST/bin/docker"
     export PATH="$TMPDIR_TEST/bin:$PATH"
     export DOCKER_CALL_LOG="$TMPDIR_TEST/docker.log"
+    export DREAM_COMPOSE_STARTUP_RETRY_DELAY=0
     : > "$DOCKER_CALL_LOG"
 }
 
@@ -237,6 +251,17 @@ teardown() {
     assert_failure
     run grep -c '^DOCKER_ARGS:' "$DOCKER_CALL_LOG"
     assert_output "1"
+}
+
+@test "wrapper: compose up retries once on transient dependency startup failure" {
+    export DOCKER_STUB_MODE=fail-startup-once
+    run _compose_run_with_summary "Restarting all services" up -d
+    assert_success
+    assert_output --partial "Docker reported a transient service startup failure"
+    assert_output --partial "Restarting all services"
+    assert_output --partial "done"
+    run grep -c '^DOCKER_ARGS:' "$DOCKER_CALL_LOG"
+    assert_output "2"
 }
 
 @test "wrapper: all args after verb are passed to docker compose" {


### PR DESCRIPTION
## Summary
- Retry `docker compose up -d` once when Docker reports a transient dependency/startup failure, such as `container dream-llama-server exited (137)` during `dream restart`.
- Keep existing failure behavior for persistent compose failures: the second failure still surfaces the compact error summary and preserved compose log path.
- Add BATS coverage for the transient dependency-startup retry path.

## Verification
- Product branch: `tests/bats/bats-core/bin/bats tests/bats-tests/test-compose-summary-wrapper.bats` (15/15)
- Product branch: `bash tests/contracts/test-installer-contracts.sh`
- Product branch: `bash tests/contracts/test-installer-hardening.sh`
- Affected Linux fleet host: synthetic `dream-llama-server exited (137)` compose failure retried once and returned success with two docker calls.
- Affected Linux fleet host: real patched `./dream-cli restart` returned success; the host was restored to main CLI afterward and all services, including llama-server, reported healthy.