### PR TITLE
fix(windows): cleanly recover reinstall when Docker is unavailable

### DIFF
--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -985,6 +985,24 @@ function Invoke-Start {
 
 function Invoke-Stop {
     param([string]$Service)
+
+    if (-not $Service) {
+        if (-not (Test-Path $InstallDir)) {
+            Write-AIError "Dream Server not found at $InstallDir. Set DREAM_HOME or run installer first."
+            exit 1
+        }
+        Push-Location $InstallDir
+        try {
+            # Native helpers do not depend on Docker and may hold install files or ports.
+            if ((Get-NativeInferenceBackend) -ne "none") {
+                Stop-NativeInferenceServer
+            }
+            Invoke-Agent -Action "stop"
+        } finally {
+            Pop-Location
+        }
+    }
+
     Test-Install
     Push-Location $InstallDir
     try {
@@ -1013,14 +1031,6 @@ function Invoke-Stop {
                 Write-DreamComposeDiagnostics -InstallDir $InstallDir -ComposeFlags $flags -Phase "dream.ps1 stop (all)"
                 exit 1
             }
-
-            # Stop native inference server (AMD path)
-            if ((Get-NativeInferenceBackend) -ne "none") {
-                Stop-NativeInferenceServer
-            }
-
-            # Stop host agent
-            Invoke-Agent -Action "stop"
 
             Write-AISuccess "All services stopped"
         }

--- a/dream-server/installers/windows/install-windows.ps1
+++ b/dream-server/installers/windows/install-windows.ps1
@@ -1589,3 +1589,6 @@ if ($SummaryJsonPath) {
     Write-Utf8NoBom -Path $SummaryJsonPath -Content ($summary | ConvertTo-Json -Depth 3)
     Write-AI "Summary written to $SummaryJsonPath"
 }
+
+$global:LASTEXITCODE = 0
+exit 0

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -511,6 +511,10 @@ LANGFUSE_INIT_USER_PASSWORD=$langfuseInitUserPassword
     # Those are Linux-only for AMD ROCm container device access
 
     $envPath = Join-Path $InstallDir ".env"
+    if (Test-Path -LiteralPath $envPath -PathType Container) {
+        Remove-Item -LiteralPath $envPath -Recurse -Force
+        Write-AIWarn "Removed malformed .env directory from a previous partial install."
+    }
     Write-Utf8NoBom -Path $envPath -Content $envContent
 
     if ($windowsAmdLemonade) {

--- a/dream-server/installers/windows/lib/llm-endpoint.ps1
+++ b/dream-server/installers/windows/lib/llm-endpoint.ps1
@@ -24,16 +24,20 @@ function Get-WindowsDreamEnvMap {
     }
 
     $result = @{}
-    if (-not (Test-Path $Path)) { return $result }
+    if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) { return $result }
 
-    Get-Content $Path | ForEach-Object {
-        $line = $_.Trim()
-        if ($line -match "^#" -or $line -eq "") { return }
-        if ($line -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
-            $key = $Matches[1]
-            $val = $Matches[2].Trim('"').Trim("'")
-            $result[$key] = $val
+    try {
+        Get-Content -LiteralPath $Path -ErrorAction Stop | ForEach-Object {
+            $line = $_.Trim()
+            if ($line -match "^#" -or $line -eq "") { return }
+            if ($line -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
+                $key = $Matches[1]
+                $val = $Matches[2].Trim('"').Trim("'")
+                $result[$key] = $val
+            }
         }
+    } catch {
+        return @{}
     }
 
     return $result

--- a/dream-server/installers/windows/phases/01-preflight.ps1
+++ b/dream-server/installers/windows/phases/01-preflight.ps1
@@ -184,11 +184,18 @@ $_shareOk = $true
 $_shareErr = ""
 $_probeImage = "alpine:3.20"
 try {
+    $_prevProbeEap = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
     & docker image inspect $_probeImage *> $null
-    if ($LASTEXITCODE -ne 0) {
+    $_inspectExit = $LASTEXITCODE
+    $ErrorActionPreference = $_prevProbeEap
+    if ($_inspectExit -ne 0) {
         Write-AI "Downloading Docker bind-mount probe image ($_probeImage)..."
+        $_prevPullEap = $ErrorActionPreference
+        $ErrorActionPreference = "Continue"
         $_pullOut = & docker pull $_probeImage 2>&1
         $_pullExit = $LASTEXITCODE
+        $ErrorActionPreference = $_prevPullEap
         if ($_pullExit -ne 0) {
             Write-AIError "Docker could not download $_probeImage, which is required for the file-sharing probe."
             Write-AI "  Start Docker Desktop, confirm it has internet access, then run:"
@@ -198,13 +205,16 @@ try {
                 Write-AI "  Pull output:"
                 ($_pullOut -join "`n") -split "`n" | ForEach-Object { Write-Host "    $_" }
             }
-            exit 1
+            throw "Docker probe image download failed"
         }
     }
 
     # PowerShell -v argument needs careful quoting for paths with spaces.
+    $_prevRunEap = $ErrorActionPreference
+    $ErrorActionPreference = "Continue"
     $_probeOut = & docker run --rm -v "${_fsProbe}:/check:ro" $_probeImage true 2>&1
     $_probeExit = $LASTEXITCODE
+    $ErrorActionPreference = $_prevRunEap
     $_probeText = ($_probeOut -join "`n")
     if ($_probeExit -ne 0 -and $_probeText -match "not shared from the host|Mounts denied|file sharing|filesharing") {
         $_shareOk = $false
@@ -218,9 +228,18 @@ try {
             Write-AI "  Probe output:"
             $_probeText -split "`n" | ForEach-Object { Write-Host "    $_" }
         }
-        exit 1
+        throw "Docker bind-mount probe failed"
     }
 } catch {
+    if ($_prevProbeEap) { $ErrorActionPreference = $_prevProbeEap }
+    if ($_prevPullEap) { $ErrorActionPreference = $_prevPullEap }
+    if ($_prevRunEap) { $ErrorActionPreference = $_prevRunEap }
+    if ($_.Exception.Message -in @(
+        "Docker probe image download failed",
+        "Docker bind-mount probe failed"
+    )) {
+        throw
+    }
     $_shareOk = $false
     $_shareErr = $_.Exception.Message
 }
@@ -233,7 +252,7 @@ if (-not $_shareOk) {
         Write-AI "  Probe output:"
         $_shareErr -split "`n" | ForEach-Object { Write-Host "    $_" }
     }
-    exit 1
+    throw "Docker Desktop cannot bind-mount $installDir"
 }
 Write-AISuccess "Docker Desktop file sharing OK"
 

--- a/dream-server/installers/windows/phases/02-detection.ps1
+++ b/dream-server/installers/windows/phases/02-detection.ps1
@@ -93,7 +93,7 @@ if ($cloudMode) {
 
 if (-not $env:MODEL_PROFILE) {
     $existingEnvPath = Join-Path $installDir ".env"
-    if (Test-Path $existingEnvPath) {
+    if (Test-Path -LiteralPath $existingEnvPath -PathType Leaf) {
         $existingProfile = Get-Content $existingEnvPath |
             Where-Object { $_ -match '^MODEL_PROFILE=' } |
             Select-Object -First 1
@@ -102,6 +102,9 @@ if (-not $env:MODEL_PROFILE) {
         } else {
             $env:MODEL_PROFILE = "qwen"
         }
+    } elseif (Test-Path -LiteralPath $existingEnvPath -PathType Container) {
+        Write-AIWarn "Ignoring malformed .env directory from a previous partial install."
+        $env:MODEL_PROFILE = "qwen"
     } else {
         $env:MODEL_PROFILE = "qwen"
     }

--- a/dream-server/installers/windows/phases/05-docker.ps1
+++ b/dream-server/installers/windows/phases/05-docker.ps1
@@ -43,7 +43,7 @@ if ($dryRun) {
         Write-AI "  Make sure Docker Desktop is running and the WSL2 backend is active."
         Write-AI "  Start Docker Desktop from the Start Menu, wait for it to fully initialize,"
         Write-AI "  then re-run this installer."
-        exit 1
+        throw "Docker daemon is not responding"
     }
     Write-AISuccess "Docker daemon healthy"
 
@@ -70,7 +70,7 @@ if ($dryRun) {
         Write-AIError "Docker Compose not found (tried: 'docker compose' and 'docker-compose')."
         Write-AI "  Install Docker Desktop, which bundles Compose v2:"
         Write-AI "  https://docs.docker.com/desktop/install/windows-install/"
-        exit 1
+        throw "Docker Compose not found"
     }
     Write-AISuccess "Docker Compose available: $dockerComposeCmd"
 

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -77,6 +77,17 @@ foreach ($_d in $_dirs) {
 }
 Write-AISuccess "Created directory structure under $installDir"
 
+# Docker/PowerShell partial installs can leave directories where install-root
+# dotfiles must be regular files. Remove those malformed paths before robocopy
+# and .env generation, otherwise later reads fail with "access denied".
+foreach ($_expectedFileName in @(".env", ".env.example", ".env.schema.json")) {
+    $_expectedFilePath = Join-Path $installDir $_expectedFileName
+    if (Test-Path -LiteralPath $_expectedFilePath -PathType Container) {
+        Remove-Item -LiteralPath $_expectedFilePath -Recurse -Force
+        Write-AIWarn "Removed malformed $_expectedFileName directory from a previous partial install."
+    }
+}
+
 # ── Copy source tree (skip if running in-place) ───────────────────────────────
 if ($sourceRoot -ne $installDir) {
     Write-AI "Copying source files to $installDir..."

--- a/dream-server/tests/contracts/test-windows-hermes-config-patching.sh
+++ b/dream-server/tests/contracts/test-windows-hermes-config-patching.sh
@@ -99,14 +99,30 @@ fi
 #    delegated Windows installer. The fleet harness and public docs call the
 #    root script, so fail-loud checks are useless if the wrapper always exits 0.
 # ---------------------------------------------------------------------------
-if grep -q '\$global:LASTEXITCODE = 0' "$ROOT_INSTALLER" \
-   && grep -q '& \$DreamServerInstaller @PSBoundParameters' "$ROOT_INSTALLER" \
-   && grep -q 'if (\$installerSucceeded) {' "$ROOT_INSTALLER" \
-   && grep -q 'exit 0' "$ROOT_INSTALLER" \
-   && grep -q 'exit \$installerExit' "$ROOT_INSTALLER"; then
-    pass "Root Windows installer exits 0 on success and propagates delegated failure codes"
+root_wrapper_block="$(awk '
+    /\$global:LASTEXITCODE = 0/ { in_block=1 }
+    in_block { print }
+    in_block && /exit 1/ { exit }
+' "$ROOT_INSTALLER")"
+delegated_line="$(grep -nF '& $DreamServerInstaller @PSBoundParameters' <<<"$root_wrapper_block" | head -n1 | cut -d: -f1 || true)"
+exit_capture_line="$(grep -nF '$installerExit = if ($null -ne $global:LASTEXITCODE' <<<"$root_wrapper_block" | head -n1 | cut -d: -f1 || true)"
+nonzero_line="$(grep -nF 'if ($installerExit -ne 0) {' <<<"$root_wrapper_block" | head -n1 | cut -d: -f1 || true)"
+success_line="$(grep -nF 'if ($installerSucceeded) {' <<<"$root_wrapper_block" | head -n1 | cut -d: -f1 || true)"
+
+if [[ -n "$delegated_line" && -n "$exit_capture_line" && -n "$nonzero_line" && -n "$success_line" \
+      && "$delegated_line" -lt "$exit_capture_line" \
+      && "$exit_capture_line" -lt "$nonzero_line" \
+      && "$nonzero_line" -lt "$success_line" ]]; then
+    pass "Root Windows installer checks delegated exit codes before success"
 else
-    fail "Root install.ps1 must exit 0 on success and preserve delegated Windows installer failures"
+    fail "Root install.ps1 must preserve delegated nonzero exits before trusting PowerShell success"
+fi
+
+if grep -q '\$global:LASTEXITCODE = 0' "$MONO" \
+   && tail -n 5 "$MONO" | grep -q 'exit 0'; then
+    pass "Delegated Windows installer clears native exit code on success"
+else
+    fail "install-windows.ps1 must clear LASTEXITCODE and exit 0 on the success path"
 fi
 
 echo "------------------------------------------------------------"

--- a/dream-server/tests/test-windows-compose-failure-report.sh
+++ b/dream-server/tests/test-windows-compose-failure-report.sh
@@ -12,6 +12,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DIAG_LIB="$ROOT_DIR/installers/windows/lib/compose-diagnostics.ps1"
 INSTALL_PS1="$ROOT_DIR/installers/windows/install-windows.ps1"
 PRE_SCRIPT="$ROOT_DIR/installers/windows/phases/01-preflight.ps1"
+DOCKER_PHASE="$ROOT_DIR/installers/windows/phases/05-docker.ps1"
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -38,6 +39,7 @@ echo ""
 [[ -f "$DIAG_LIB" ]] && pass "compose diagnostics library exists" || fail "compose diagnostics library missing"
 [[ -f "$INSTALL_PS1" ]] && pass "Windows installer exists" || fail "Windows installer missing"
 [[ -f "$PRE_SCRIPT" ]] && pass "Windows preflight phase exists" || fail "Windows preflight phase missing"
+[[ -f "$DOCKER_PHASE" ]] && pass "Windows Docker phase exists" || fail "Windows Docker phase missing"
 
 check 'function Write-DreamComposeFailureReport' "$DIAG_LIB" "report writer function exists"
 check 'install-report-$stamp.txt' "$DIAG_LIB" "report uses install-report timestamp path"
@@ -63,6 +65,8 @@ check '$_probeImage = "alpine:3.20"' "$PRE_SCRIPT" "preflight uses pinned Alpine
 check 'docker pull $_probeImage' "$PRE_SCRIPT" "preflight pulls missing probe image before bind-mount test"
 check 'Docker could not download $_probeImage' "$PRE_SCRIPT" "preflight reports Alpine pull failure separately"
 check 'The probe image ($_probeImage) is already available; this is a file-sharing path issue.' "$PRE_SCRIPT" "preflight separates file sharing from image availability"
+check 'throw "Docker daemon is not responding"' "$DOCKER_PHASE" "Docker daemon prerequisite failure is terminating"
+check 'throw "Docker Compose not found"' "$DOCKER_PHASE" "Docker Compose prerequisite failure is terminating"
 
 if grep -q "Write-DreamComposeDiagnostics .*SaveReport" "$ROOT_DIR/installers/windows/dream.ps1"; then
     fail "dream.ps1 command failures should not create install reports by default"

--- a/dream-server/tests/test-windows-compose-failure-report.sh
+++ b/dream-server/tests/test-windows-compose-failure-report.sh
@@ -62,9 +62,13 @@ check 'HERMES_AGENT_IMAGE_FALLBACK' "$INSTALL_PS1" "installer supports Hermes im
 check 'Validating Hermes Agent image tag before startup' "$INSTALL_PS1" "installer validates Hermes image before compose up"
 check 'ImageEnvName = "LLAMA_SERVER_IMAGE"' "$INSTALL_PS1" "image validation labels override env var"
 check '$_probeImage = "alpine:3.20"' "$PRE_SCRIPT" "preflight uses pinned Alpine probe image"
+check '$_inspectExit = $LASTEXITCODE' "$PRE_SCRIPT" "preflight captures inspect exit before deciding to pull"
 check 'docker pull $_probeImage' "$PRE_SCRIPT" "preflight pulls missing probe image before bind-mount test"
 check 'Docker could not download $_probeImage' "$PRE_SCRIPT" "preflight reports Alpine pull failure separately"
+check 'throw "Docker probe image download failed"' "$PRE_SCRIPT" "preflight image download failure terminates installer"
+check 'throw "Docker bind-mount probe failed"' "$PRE_SCRIPT" "preflight unexpected bind-mount failure terminates installer"
 check 'The probe image ($_probeImage) is already available; this is a file-sharing path issue.' "$PRE_SCRIPT" "preflight separates file sharing from image availability"
+check 'throw "Docker Desktop cannot bind-mount $installDir"' "$PRE_SCRIPT" "preflight file-sharing failure terminates installer"
 check 'throw "Docker daemon is not responding"' "$DOCKER_PHASE" "Docker daemon prerequisite failure is terminating"
 check 'throw "Docker Compose not found"' "$DOCKER_PHASE" "Docker Compose prerequisite failure is terminating"
 

--- a/dream-server/tests/test-windows-env-dotfile-recovery.sh
+++ b/dream-server/tests/test-windows-env-dotfile-recovery.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Dream Server Windows malformed dotfile recovery tests
+# ============================================================================
+# Static regression for partial Windows installs that leave install-root
+# dotfiles as directories. The installer must not try to read .env as a file
+# during phase 2, and phase 6/env generation must repair the owned paths.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PHASE02="$ROOT_DIR/installers/windows/phases/02-detection.ps1"
+PHASE06="$ROOT_DIR/installers/windows/phases/06-directories.ps1"
+ENVGEN="$ROOT_DIR/installers/windows/lib/env-generator.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+echo ""
+echo "=== Windows malformed dotfile recovery tests ==="
+echo ""
+
+[[ -f "$PHASE02" ]] && pass "Windows detection phase exists" || fail "Windows detection phase missing"
+[[ -f "$PHASE06" ]] && pass "Windows directories phase exists" || fail "Windows directories phase missing"
+[[ -f "$ENVGEN" ]] && pass "Windows env generator exists" || fail "Windows env generator missing"
+
+check 'Test-Path -LiteralPath $existingEnvPath -PathType Leaf' "$PHASE02" "phase 2 only reads .env when it is a file"
+check 'Test-Path -LiteralPath $existingEnvPath -PathType Container' "$PHASE02" "phase 2 detects malformed .env directory"
+check 'Ignoring malformed .env directory from a previous partial install.' "$PHASE02" "phase 2 warns and defaults profile for malformed .env"
+
+check '@(".env", ".env.example", ".env.schema.json")' "$PHASE06" "phase 6 owns only install-root dotfile cleanup"
+check 'Test-Path -LiteralPath $_expectedFilePath -PathType Container' "$PHASE06" "phase 6 detects dotfile directories"
+check 'Remove-Item -LiteralPath $_expectedFilePath -Recurse -Force' "$PHASE06" "phase 6 removes malformed dotfile directories before copy"
+
+check 'Test-Path -LiteralPath $envPath -PathType Container' "$ENVGEN" "env generator detects malformed .env directory"
+check 'Remove-Item -LiteralPath $envPath -Recurse -Force' "$ENVGEN" "env generator removes malformed .env directory before writing"
+check 'Write-Utf8NoBom -Path $envPath -Content $envContent' "$ENVGEN" "env generator writes .env after recovery"
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/dream-server/tests/test-windows-env-dotfile-recovery.sh
+++ b/dream-server/tests/test-windows-env-dotfile-recovery.sh
@@ -14,6 +14,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PHASE02="$ROOT_DIR/installers/windows/phases/02-detection.ps1"
 PHASE06="$ROOT_DIR/installers/windows/phases/06-directories.ps1"
 ENVGEN="$ROOT_DIR/installers/windows/lib/env-generator.ps1"
+LLM_ENDPOINT="$ROOT_DIR/installers/windows/lib/llm-endpoint.ps1"
 
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -40,6 +41,7 @@ echo ""
 [[ -f "$PHASE02" ]] && pass "Windows detection phase exists" || fail "Windows detection phase missing"
 [[ -f "$PHASE06" ]] && pass "Windows directories phase exists" || fail "Windows directories phase missing"
 [[ -f "$ENVGEN" ]] && pass "Windows env generator exists" || fail "Windows env generator missing"
+[[ -f "$LLM_ENDPOINT" ]] && pass "Windows LLM endpoint helper exists" || fail "Windows LLM endpoint helper missing"
 
 check 'Test-Path -LiteralPath $existingEnvPath -PathType Leaf' "$PHASE02" "phase 2 only reads .env when it is a file"
 check 'Test-Path -LiteralPath $existingEnvPath -PathType Container' "$PHASE02" "phase 2 detects malformed .env directory"
@@ -52,6 +54,10 @@ check 'Remove-Item -LiteralPath $_expectedFilePath -Recurse -Force' "$PHASE06" "
 check 'Test-Path -LiteralPath $envPath -PathType Container' "$ENVGEN" "env generator detects malformed .env directory"
 check 'Remove-Item -LiteralPath $envPath -Recurse -Force' "$ENVGEN" "env generator removes malformed .env directory before writing"
 check 'Write-Utf8NoBom -Path $envPath -Content $envContent' "$ENVGEN" "env generator writes .env after recovery"
+
+check 'Test-Path -LiteralPath $Path -PathType Leaf' "$LLM_ENDPOINT" "shared env parser only reads .env when it is a file"
+check 'Get-Content -LiteralPath $Path -ErrorAction Stop' "$LLM_ENDPOINT" "shared env parser reads .env defensively"
+check 'return @{}' "$LLM_ENDPOINT" "shared env parser fails closed for unreadable .env paths"
 
 echo ""
 echo "Result: $PASS passed, $FAIL failed"

--- a/dream-server/tests/test-windows-stop-native-helpers.sh
+++ b/dream-server/tests/test-windows-stop-native-helpers.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Dream Server Windows stop native-helper ordering tests
+# ============================================================================
+# Static regression for the Windows reinstall failure where Docker Desktop was
+# stopped, so dream.ps1 stop exited before stopping DreamServerHostAgent. The
+# host agent kept dream-host-agent.log open and blocked reinstall cleanup.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DREAM_PS1="$ROOT_DIR/installers/windows/dream.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+line_of() {
+    local needle="$1"
+    grep -nF -- "$needle" <<<"$stop_block" | head -n 1 | cut -d: -f1 || true
+}
+
+echo ""
+echo "=== Windows stop native-helper ordering tests ==="
+echo ""
+
+[[ -f "$DREAM_PS1" ]] && pass "dream.ps1 exists" || fail "dream.ps1 missing"
+
+stop_block="$(awk '
+    /function Invoke-Stop/ { in_block=1 }
+    in_block { print }
+    in_block && /function Invoke-Restart/ { exit }
+' "$DREAM_PS1")"
+
+[[ -n "$stop_block" ]] && pass "Invoke-Stop block extracted" || fail "Invoke-Stop block missing"
+
+service_guard_line="$(line_of 'if (-not $Service) {')"
+agent_stop_line="$(line_of 'Invoke-Agent -Action "stop"')"
+native_stop_line="$(line_of 'Stop-NativeInferenceServer')"
+test_install_line="$(line_of 'Test-Install')"
+compose_down_line="$(line_of '-ComposeArgs @("down")')"
+
+if [[ -n "$service_guard_line" && -n "$agent_stop_line" && "$agent_stop_line" -gt "$service_guard_line" ]]; then
+    pass "all-services stop has a native-helper preflight branch"
+else
+    fail "all-services stop should gate native-helper cleanup behind if (-not \$Service)"
+fi
+
+if [[ -n "$agent_stop_line" && -n "$test_install_line" && "$agent_stop_line" -lt "$test_install_line" ]]; then
+    pass "host agent stops before Docker-dependent Test-Install"
+else
+    fail "host agent must stop before Test-Install can fail on Docker Desktop"
+fi
+
+if [[ -n "$native_stop_line" && -n "$test_install_line" && "$native_stop_line" -lt "$test_install_line" ]]; then
+    pass "native inference stops before Docker-dependent Test-Install"
+else
+    fail "native inference must stop before Test-Install can fail on Docker Desktop"
+fi
+
+if [[ -n "$agent_stop_line" && -n "$compose_down_line" && "$agent_stop_line" -lt "$compose_down_line" ]]; then
+    pass "host agent stops before docker compose down"
+else
+    fail "host agent should not wait for docker compose down"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/install.ps1
+++ b/install.ps1
@@ -45,9 +45,11 @@ if (-not (Test-Path $DreamServerInstaller)) {
 $global:LASTEXITCODE = 0
 & $DreamServerInstaller @PSBoundParameters
 $installerSucceeded = $?
+$installerExit = if ($null -ne $global:LASTEXITCODE) { [int]$global:LASTEXITCODE } else { 0 }
+if ($installerExit -ne 0) {
+    exit $installerExit
+}
 if ($installerSucceeded) {
     exit 0
 }
-
-$installerExit = if ($null -ne $global:LASTEXITCODE -and [int]$global:LASTEXITCODE -ne 0) { [int]$global:LASTEXITCODE } else { 1 }
-exit $installerExit
+exit 1


### PR DESCRIPTION
## Summary

- stop Windows native helpers and the host agent before Docker-dependent `dream.ps1 stop` checks, so a reinstall can clean up even when Docker Desktop is unavailable
- propagate Windows installer prerequisite failures through the root `install.ps1` entrypoint and make Docker prerequisite/preflight failures terminating
- recover malformed install-root env dotfile directories from partial Windows installs before reading or regenerating `.env`
- add regression coverage for stop ordering, failure propagation, Docker preflight behavior, and malformed env dotfile recovery

## Root Cause

A Windows reinstall could leave the host agent running when Docker Desktop was stopped because `dream.ps1 stop` performed Docker-dependent install checks before stopping native helpers. The running host agent held files open and blocked fleet cleanup. During validation, two adjacent Windows installer issues also surfaced: delegated installer failures could be masked by the root wrapper, and dot-sourced phase/preflight failures could continue far enough to collide with malformed `.env` state from a partial install.

## Validation

- PowerShell parser checks passed for the touched Windows entrypoints/phases/libs.
- Windows installer regression tests passed: stop-native-helper ordering, compose/preflight failure reporting, malformed dotfile recovery, Hermes config patching, Hermes SOUL contract, missing-service hints, and report command.
- Targeted Windows fleet validation passed on the patched branch: fresh install exited 0, readiness was 15/15, compose started 17 containers, LLM serving was verified, and post-install verify/cloud-mode/dashboard/Hermes/capabilities probes passed.
- Windows lifecycle probe is intentionally skipped by the harness to avoid tearing down the live Windows stack; the skip is recorded as OK.

## Risk

This is limited to Windows install/stop behavior and Windows installer tests. The main compatibility risk is changing how Windows preflight failures terminate, but the new behavior is intentionally fail-fast for prerequisites that already printed fatal errors and prevents continuing into partial install state.