### PR TITLE
fix(tests): make 'make test' pass on macOS hosts

### DIFF
--- a/dream-server/tests/test-bootstrap-upgrade-close-inherited-fds.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-close-inherited-fds.sh
@@ -88,7 +88,15 @@ assert_runtime_lock_release() {
 
 assert_fd_close_spawn "$ROOT_DIR/installers/phases/11-services.sh"   "linux/wsl phase 11"
 assert_fd_close_spawn "$ROOT_DIR/installers/macos/install-macos.sh" "macos installer"
-assert_runtime_lock_release 9
-assert_runtime_lock_release 200
+
+# flock(1) is util-linux and does not exist on macOS. The static spawn-site
+# checks above cover the product contract on every platform; the runtime
+# lock-release simulation only runs where flock is available.
+if command -v flock >/dev/null 2>&1; then
+    assert_runtime_lock_release 9
+    assert_runtime_lock_release 200
+else
+    echo "[SKIP] runtime lock-release checks: flock(1) not available on this platform"
+fi
 
 echo "[OK] all bootstrap-upgrade spawn sites close inherited non-stdio FDs"

--- a/dream-server/tests/test-dream-cli-pipefail-tolerance.sh
+++ b/dream-server/tests/test-dream-cli-pipefail-tolerance.sh
@@ -3,6 +3,22 @@
 
 set -euo pipefail
 
+# dream-cli requires Bash 4+; macOS ships Bash 3.2, so running this suite
+# there makes every case fail with a misleading exit 1 from the CLI's own
+# version guard. Re-exec under Homebrew bash when available (mirrors
+# scripts/health-check.sh); otherwise skip — without Bash 4+ there is no
+# meaningful dream-cli behavior to test on this host.
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    for _modern_bash in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        if [ -x "$_modern_bash" ] && [ "$("$_modern_bash" -c 'echo "${BASH_VERSINFO[0]}"')" -ge 4 ]; then
+            exec "$_modern_bash" "$0" "$@"
+        fi
+    done
+    echo "[SKIP] dream-cli requires Bash 4+; this host only has Bash ${BASH_VERSION} (brew install bash)"
+    echo "Result: 0 passed, 0 failed, 1 skipped"
+    exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DREAM_CLI="$ROOT_DIR/dream-cli"
@@ -24,9 +40,13 @@ fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
 skip() { echo "[SKIP] $1"; SKIP=$((SKIP + 1)); }
 
 run_dream() {
+    # Invoke through "$BASH" (the interpreter running this test) instead of
+    # the #!/usr/bin/env bash shebang: on macOS, env can resolve to the
+    # system Bash 3.2 even when this suite runs under a modern bash. Same
+    # pattern as test-validate-env.sh and test-dream-config-secret-mask.sh.
     local output rc
     set +e
-    output=$(DREAM_HOME="$INSTALL_DIR" NO_COLOR=1 "$DREAM_CLI" "$@" 2>&1)
+    output=$(DREAM_HOME="$INSTALL_DIR" NO_COLOR=1 "$BASH" "$DREAM_CLI" "$@" 2>&1)
     rc=$?
     set -e
     printf '%s\n' "$rc"

--- a/dream-server/tests/test-dream-config-secret-mask.sh
+++ b/dream-server/tests/test-dream-config-secret-mask.sh
@@ -19,6 +19,21 @@
 
 set -euo pipefail
 
+# dream-cli requires Bash 4+; macOS ships Bash 3.2, so "$BASH" "$DREAM_CLI"
+# below would hit the CLI's version guard and report 9 misleading failures.
+# Re-exec under Homebrew bash when available (mirrors scripts/health-check.sh);
+# otherwise skip — without Bash 4+ dream-cli cannot run on this host at all.
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+    for _modern_bash in /opt/homebrew/bin/bash /usr/local/bin/bash; do
+        if [ -x "$_modern_bash" ] && [ "$("$_modern_bash" -c 'echo "${BASH_VERSINFO[0]}"')" -ge 4 ]; then
+            exec "$_modern_bash" "$0" "$@"
+        fi
+    done
+    echo "[SKIP] dream-cli requires Bash 4+; this host only has Bash ${BASH_VERSION} (brew install bash)"
+    echo "Result: 0 passed, 0 failed (skipped: no Bash 4+ on host)"
+    exit 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DREAM_CLI="$ROOT_DIR/dream-cli"


### PR DESCRIPTION
## Summary

`make test` cannot pass on a macOS checkout today — three suites fail for host-environment reasons and report misleading product-level failures:

- **`tests/test-dream-cli-pipefail-tolerance.sh`** invokes `dream-cli` through its `#!/usr/bin/env bash` shebang. On stock macOS that resolves to the system Bash 3.2, so every case trips dream-cli's own Bash 4+ guard and the suite reports 9 failures that read like CLI regressions (`config show exited 1 for empty .env`, etc.).
- **`tests/test-dream-config-secret-mask.sh`** runs `"$BASH" "$DREAM_CLI"` where `$BASH` is `/bin/bash` 3.2 — all 9 masking cases fail the same way, including scary-looking `LEAKED` messages that are really just the version guard's stderr.
- **`tests/test-bootstrap-upgrade-close-inherited-fds.sh`** hard-requires `flock(1)`, which is util-linux and does not exist on macOS — the suite dies with exit 127 mid-run.

This matters because the macOS fleet hosts (and any contributor on a Mac) currently get a wall of false failures before reaching the suites that actually validate their platform.

### Fix (follows existing repo patterns)

- Both dream-cli suites now **re-exec under Homebrew bash** when the running interpreter is older than Bash 4 — same probe order (`/opt/homebrew/bin/bash`, `/usr/local/bin/bash`) as the existing guard in `scripts/health-check.sh`. When no modern bash exists at all, they **skip with one clear line** (pointing at `brew install bash`) instead of failing 9 times each, matching the suite's existing PyYAML skip precedent.
- The pipefail suite now invokes dream-cli via `"$BASH" "$DREAM_CLI"` so the interpreter is deterministic regardless of PATH — the same pattern `test-validate-env.sh` and `test-dream-config-secret-mask.sh` already use, and the same routing `test-bash32-guards.sh` asserts for dream-cli itself.
- The inherited-FDs **runtime** lock checks are gated on `command -v flock`; the **static** spawn-site contract checks (which verify the actual product code in phase 11 and the macOS installer) still run on every platform.

### Linux/CI impact: none

The version guard is a no-op under Bash 4+, and `flock` is always present on ubuntu-latest, so CI runs exactly the same assertions as before. The only Linux-visible change is `bash dream-cli` vs `./dream-cli` invocation in one suite, which is how the secret-mask suite has always invoked it.

## AI Assistance

Drafted with Claude Code (investigation, patch, and validation runs below). I read the final diff and ran every validation command on my own machine.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: tests-only change; no installer, compose, auth, or runtime surface touched

Commands/results:

```text
Host: macOS 26 (Darwin 25.5.0, arm64)

# Configuration 1 — stock /bin/bash 3.2.57, no Homebrew bash, no flock
bash tests/test-dream-cli-pipefail-tolerance.sh
  [SKIP] dream-cli requires Bash 4+; this host only has Bash 3.2.57(1)-release (brew install bash)
  Result: 0 passed, 0 failed, 1 skipped   (rc=0; was: 9 failed)
bash tests/test-dream-config-secret-mask.sh
  [SKIP] dream-cli requires Bash 4+ ...   (rc=0; was: 9 failed)
bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
  2x [PASS] static spawn-site checks
  [SKIP] runtime lock-release checks: flock(1) not available on this platform
  (rc=0; was: rc=127 "flock: command not found")
make test  ->  exit 0 (previously aborted at dream-cli pipefail tolerance)

# Configuration 2 — after brew install bash (5.3.15)
bash tests/test-dream-cli-pipefail-tolerance.sh -> re-execs, Result: 11 passed, 0 failed, 0 skipped
bash tests/test-dream-config-secret-mask.sh    -> re-execs, Result: 9 passed, 0 failed
make test  ->  exit 0, all suites running their full assertions

# Lint
bash -n on all three files: OK
shellcheck: no warning/error-severity findings (two SC2016 info notes on the
intentional single-quoted child-bash probe, identical to the existing
construct in scripts/health-check.sh)
git diff --check: clean
```

## Operational Change Check

No operational surface changed — test harness only. The product's Bash 4+ guard in dream-cli and the installer's Homebrew bash bootstrap are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)