### PR TITLE
fix(dashboard-api): make test suite pass across supported dependency versions

### DIFF
--- a/dream-server/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -306,7 +306,7 @@ class TestGpuHistoryBuffer:
         saved = list(gpu_mod._GPU_HISTORY)
         gpu_mod._GPU_HISTORY.clear()
         try:
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 gpu_mod.gpu_history()
             )
             assert result == {"timestamps": [], "gpus": {}}
@@ -328,7 +328,7 @@ class TestGpuHistoryBuffer:
                         "1": {"utilization": 30 + i, "memory_percent": 40.0, "temperature": 70, "power_w": 300.0},
                     },
                 })
-            result = asyncio.get_event_loop().run_until_complete(
+            result = asyncio.run(
                 gpu_mod.gpu_history()
             )
             assert len(result["timestamps"]) == 3

--- a/dream-server/extensions/services/dashboard-api/tests/test_talk.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_talk.py
@@ -448,10 +448,16 @@ def test_hermes_bridge_transparent_retry_on_send_reset(monkeypatch):
     hermes_bridge._CONNECTION_POOL.clear()
     hermes_bridge._SWEEPER_TASK = None
 
+    # aiohttp.ClientConnectionResetError only exists in aiohttp >= 3.10;
+    # requirements.txt allows >= 3.9, where send_str on a closing transport
+    # raises the builtin ConnectionResetError instead. The bridge catches
+    # both, so the test must raise whichever this aiohttp actually has.
+    reset_error = getattr(aiohttp, "ClientConnectionResetError", ConnectionResetError)
+
     class DeadOnSendWS:
         closed = False
         async def send_str(self, _):
-            raise aiohttp.ClientConnectionResetError("Cannot write to closing transport")
+            raise reset_error("Cannot write to closing transport")
         async def close(self):
             self.closed = True
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_workflows.py
@@ -169,7 +169,7 @@ def test_get_n8n_workflows_success(test_client, monkeypatch):
 
     with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(wf_mod.get_n8n_workflows())
+        result = asyncio.run(wf_mod.get_n8n_workflows())
 
     assert len(result) == 1
     assert result[0]["name"] == "My Workflow"
@@ -186,7 +186,7 @@ def test_get_n8n_workflows_failure(test_client, monkeypatch):
 
     with patch("routers.workflows.aiohttp.ClientSession", return_value=session_mock):
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(wf_mod.get_n8n_workflows())
+        result = asyncio.run(wf_mod.get_n8n_workflows())
 
     assert result == []
 
@@ -211,7 +211,7 @@ def test_check_workflow_dependencies_all_healthy(test_client, monkeypatch):
     monkeypatch.setattr("helpers.check_service_health", mock_health)
 
     import asyncio
-    result = asyncio.get_event_loop().run_until_complete(
+    result = asyncio.run(
         wf_mod.check_workflow_dependencies(["llama-server"])
     )
     # "llama-server" should be checked directly (no alias mapping)
@@ -233,7 +233,7 @@ def test_check_workflow_dependencies_with_alias(test_client, monkeypatch):
     monkeypatch.setattr("helpers.check_service_health", mock_fn)
 
     import asyncio
-    result = asyncio.get_event_loop().run_until_complete(
+    result = asyncio.run(
         wf_mod.check_workflow_dependencies(["ollama"])
     )
     assert result["ollama"] is True
@@ -256,7 +256,7 @@ def test_check_workflow_dependencies_unhealthy(test_client, monkeypatch):
     monkeypatch.setattr("helpers.check_service_health", mock_fn)
 
     import asyncio
-    result = asyncio.get_event_loop().run_until_complete(
+    result = asyncio.run(
         wf_mod.check_workflow_dependencies(["ollama"])
     )
     assert result["ollama"] is False
@@ -267,7 +267,7 @@ def test_check_workflow_dependencies_unknown_dep(test_client, monkeypatch):
     import routers.workflows as wf_mod
 
     import asyncio
-    result = asyncio.get_event_loop().run_until_complete(
+    result = asyncio.run(
         wf_mod.check_workflow_dependencies(["totally-unknown-service-xyz"])
     )
     assert result["totally-unknown-service-xyz"] is True
@@ -282,7 +282,7 @@ def test_check_workflow_dependencies_uses_cache(test_client, monkeypatch):
 
     cache = {"llama-server": True}
     import asyncio
-    result = asyncio.get_event_loop().run_until_complete(
+    result = asyncio.run(
         wf_mod.check_workflow_dependencies(["ollama"], health_cache=cache)
     )
     assert result["ollama"] is True
@@ -313,7 +313,7 @@ def test_check_n8n_available_success(test_client):
 
     with patch("helpers._get_aio_session", side_effect=fake_get_session):
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(wf_mod.check_n8n_available())
+        result = asyncio.run(wf_mod.check_n8n_available())
 
     assert result is True
 
@@ -330,7 +330,7 @@ def test_check_n8n_available_failure(test_client):
 
     with patch("helpers._get_aio_session", side_effect=fake_get_session):
         import asyncio
-        result = asyncio.get_event_loop().run_until_complete(wf_mod.check_n8n_available())
+        result = asyncio.run(wf_mod.check_n8n_available())
 
     assert result is False
 


### PR DESCRIPTION
## Summary

Two groups of dashboard-api tests crash on dependency versions the project supports, producing failures that read like product regressions:

1. **`test_talk.py::test_hermes_bridge_transparent_retry_on_send_reset`** raises `aiohttp.ClientConnectionResetError`, which only exists in **aiohttp ≥ 3.10**, while `requirements.txt` allows `aiohttp>=3.9.0`. On 3.9.x the test dies with `AttributeError: module aiohttp has no attribute ClientConnectionResetError` before asserting anything. The bridge itself is fine — `hermes_bridge.py` catches `(aiohttp.ClientError, ConnectionResetError, ConnectionError)`, which covers both generations (3.9 raises the builtin `ConnectionResetError` on a closing transport; 3.10+ raises `ClientConnectionResetError`, a `ClientError` subclass). The test now raises whichever class the installed aiohttp actually has, so it exercises the same product code path on both.

2. **`test_workflows.py` (9 sites) and `test_gpu_detailed.py` (2 sites)** drive coroutines with `asyncio.get_event_loop().run_until_complete(...)`. **pytest-asyncio 1.4** (what a fresh `pip install pytest-asyncio` resolves to today) no longer leaves a current event loop set for synchronous tests, so all 11 fail with `RuntimeError: There is no current event loop`. `get_event_loop()` outside a running loop has been deprecated since Python 3.12; `asyncio.run()` is the supported replacement and is behavior-identical for these single-coroutine call sites (each one awaits one coroutine to completion with no loop state shared between calls — the aiohttp sessions involved are mocked).

Why it matters: CI environments with cached/older plugin versions stay green while every fresh contributor environment fails 12 tests out of the box — exactly the kind of misleading first-contact failure that makes people distrust the suite.

## AI Assistance

Drafted with Claude Code (found the failures by running the suite against both ends of the declared dependency range, wrote the patch, ran the validations below). I read the final diff and am accountable for it.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: tests-only change; no product code touched

Commands/results:

```text
# Environment A — requirements floor era: aiohttp 3.9.1, pytest-asyncio 1.3.0, Python 3.13
python3 -m pytest tests/ -q
  before: 1 failed (test_hermes_bridge_transparent_retry_on_send_reset, AttributeError), 1122 passed
  after:  1123 passed

# Environment B — fresh venv, everything latest-in-range: aiohttp 3.14.1, pytest-asyncio 1.4.0
python -m pytest tests/ -q
  before: 11 failed (RuntimeError: There is no current event loop), 1112 passed
  after:  1123 passed

git diff --check: clean
```

## Operational Change Check

No operational surface changed — dashboard-api tests only. `requirements.txt` is untouched; the suite simply passes across the range it already declares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)