### PR TITLE
fix(bootstrap): clamp full-model download progress

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -643,9 +643,11 @@ def get_bootstrap_status() -> BootstrapStatus:
         percent = None
         if percent_raw is not None:
             try:
-                percent = float(percent_raw)
+                percent = max(0.0, min(100.0, float(percent_raw)))
             except (ValueError, TypeError):
                 pass
+        if bytes_total and bytes_downloaded:
+            bytes_downloaded = max(0, min(bytes_downloaded, bytes_total))
 
         return BootstrapStatus(
             active=True, model_name=data.get("model"), percent=percent,

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -796,6 +796,21 @@ class TestGetBootstrapStatusEdgeCases:
         assert abs(status.downloaded_gb - 2.0) < 0.01
         assert status.speed_mbps is not None
 
+    def test_oversized_progress_is_clamped_for_active_download(self, data_dir):
+        status_file = data_dir / "bootstrap-status.json"
+        status_file.write_text(json.dumps({
+            "status": "downloading",
+            "model": "Full.gguf",
+            "percent": 143.2,
+            "bytesDownloaded": 150,
+            "bytesTotal": 100,
+        }))
+        status = get_bootstrap_status()
+        assert status.active is True
+        assert status.percent == 100.0
+        assert status.downloaded_gb == 100 / (1024**3)
+        assert status.total_gb == 100 / (1024**3)
+
 
 # --- get_uptime platform branches ---
 

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -662,7 +662,7 @@ monitor_download() {
             fi
         fi
 
-        write_status "downloading" "$percent" "$current_bytes" "$total_bytes" "$speed" "$eta"
+        write_status "downloading" "$percent" "$progress_bytes" "$total_bytes" "$speed" "$eta"
         prev_bytes=$current_bytes
         prev_time=$now
     done

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -647,10 +647,10 @@ monitor_download() {
 
         local percent="null"
         local eta=""
+        local progress_bytes="$current_bytes"
         if [[ $total_bytes -gt 0 ]]; then
-            local progress_bytes="$current_bytes"
             [[ "$progress_bytes" -gt "$total_bytes" ]] && progress_bytes="$total_bytes"
-            percent=$(status_percent "$current_bytes" "$total_bytes")
+            percent=$(status_percent "$progress_bytes" "$total_bytes")
             if [[ $speed -gt 0 ]]; then
                 local remaining=$(( total_bytes - progress_bytes ))
                 local eta_secs=$(( remaining / speed ))

--- a/dream-server/tests/test-bootstrap-upgrade-resume-status.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-resume-status.sh
@@ -27,6 +27,10 @@ cat > "$fakebin/curl" <<'EOF'
 #!/usr/bin/env bash
 case " $* " in
   *" -sI "*)
+    if [[ "${DREAM_FAKE_NO_CONTENT_LENGTH:-0}" == "1" ]]; then
+      printf 'HTTP/2 200\r\n\r\n'
+      exit 0
+    fi
     printf 'HTTP/2 200\r\ncontent-length: 100\r\n\r\n'
     exit 0
     ;;
@@ -113,5 +117,33 @@ grep -q '"percent": 100.0' "$install_dir/data/bootstrap-status.json" \
     || fail "failed bootstrap-status percent must be capped at 100"
 grep -Eqi 'preserved.*partial file.*resume|partial file.*preserved.*resume' "$tmp/bootstrap.log" \
     || fail "bootstrap-upgrade should tell operators the partial file was preserved"
+
+unknown_install_dir="$tmp/install-unknown-size"
+mkdir -p "$unknown_install_dir/data/models" "$unknown_install_dir/config/llama-server" "$unknown_install_dir/bin"
+cp "$install_dir/.env" "$unknown_install_dir/.env"
+printf 'bootstrap model\n' > "$unknown_install_dir/data/models/Bootstrap.gguf"
+printf '999999\n' > "$unknown_install_dir/data/.llama-server.pid"
+
+set +e
+PATH="$fakebin:$PATH" DREAM_FAKE_NO_CONTENT_LENGTH=1 DREAM_BOOTSTRAP_DOWNLOAD_ATTEMPTS=1 bash "$TARGET" \
+    "$unknown_install_dir" \
+    "Full.gguf" \
+    "https://example.invalid/Full.gguf" \
+    "" \
+    "full-model" \
+    "32768" \
+    "Bootstrap.gguf" \
+    > "$tmp/bootstrap-unknown-size.log" 2>&1
+unknown_rc=$?
+set -e
+
+[[ $unknown_rc -ne 0 ]] || fail "bootstrap-upgrade unknown-size download must exit non-zero after curl failure"
+if grep -q 'progress_bytes: unbound variable' "$tmp/bootstrap-unknown-size.log"; then
+    fail "bootstrap-upgrade monitor must not trip set -u when remote size is unknown"
+fi
+grep -q '"bytesTotal": 0' "$unknown_install_dir/data/bootstrap-status.json" \
+    || fail "unknown-size bootstrap-status must preserve bytesTotal=0"
+grep -Eq '"bytesDownloaded": [1-9][0-9]*' "$unknown_install_dir/data/bootstrap-status.json" \
+    || fail "unknown-size bootstrap-status must preserve downloaded byte count"
 
 pass "failed download preserves resumable partial and status progress"

--- a/dream-server/tests/test-bootstrap-upgrade-resume-status.sh
+++ b/dream-server/tests/test-bootstrap-upgrade-resume-status.sh
@@ -82,6 +82,8 @@ grep -q 'dream-bootstrap-upgrade-' "$TARGET" \
 if grep -q 'local lock_dir="$INSTALL_DIR/data/bootstrap-upgrade.lock"' "$TARGET"; then
     fail "bootstrap-upgrade lock must not live under install data"
 fi
+grep -q 'write_status "downloading" "$percent" "$progress_bytes" "$total_bytes"' "$TARGET" \
+    || fail "active bootstrap-status must write clamped progress bytes so UI progress cannot exceed 100%"
 
 set +e
 PATH="$fakebin:$PATH" DREAM_BOOTSTRAP_DOWNLOAD_ATTEMPTS=2 bash "$TARGET" \


### PR DESCRIPTION
Fixes #1462.

  ## Summary

  - Clamp active bootstrap full-model download bytes to the expected total before writing status
  - Defensively clamp stale oversized bootstrap progress in dashboard-api
  - Add regression coverage for oversized progress status

  ## Validation

  - `bash tests/test-bootstrap-upgrade-resume-status.sh`
  - `python -m pytest extensions/services/dashboard-api/tests/test_helpers.py::TestGetBootstrapStatusEdgeCases::test_speed_and_sizes extensions/services/dashboard-api/tests/
  test_helpers.py::TestGetBootstrapStatusEdgeCases::test_oversized_progress_is_clamped_for_active_download -q`
  - `make lint`

  ## AI Assistance

  AI assistance was used for issue triage, code inspection, and drafting the fix. I reviewed the final diff and validation output.