### PR TITLE
fix(dashboard): pause remaining background pollers while the tab is hidden (#1490 follow-up)

### DIFF
--- a/dream-server/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
@@ -1,5 +1,11 @@
-import { renderHook, waitFor } from '@testing-library/react'
+import { renderHook, waitFor, act } from '@testing-library/react'
 import { useDownloadProgress } from '../useDownloadProgress'
+
+// Shadow jsdom's Document.prototype.hidden getter on the instance; deleting
+// the own property in afterEach restores the prototype behavior.
+const setDocumentHidden = (hidden) => {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+}
 
 describe('useDownloadProgress', () => {
   beforeEach(() => {
@@ -8,6 +14,7 @@ describe('useDownloadProgress', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    delete document.hidden
   })
 
   test('sets isDownloading when status is downloading', async () => {
@@ -73,6 +80,35 @@ describe('useDownloadProgress', () => {
       model: 'test-model',
       updatedAt: '2026-05-16T12:00:00Z'
     })
+  })
+
+  test('pauses idle polling while the tab is hidden and refreshes on visibilitychange', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ status: 'idle' })
+    })
+
+    vi.useFakeTimers()
+    try {
+      renderHook(() => useDownloadProgress())
+      await act(async () => {})
+      expect(fetch).toHaveBeenCalledTimes(1)
+
+      setDocumentHidden(true)
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000) })
+      expect(fetch).toHaveBeenCalledTimes(1)
+
+      setDocumentHidden(false)
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      expect(fetch).toHaveBeenCalledTimes(2)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+      expect(fetch).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('formatBytes formats GB/MB/KB correctly', () => {

--- a/dream-server/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
@@ -1,6 +1,12 @@
 import { renderHook, waitFor, act } from '@testing-library/react'
 import { useModels } from '../useModels'
 
+// Shadow jsdom's Document.prototype.hidden getter on the instance; deleting
+// the own property in afterEach restores the prototype behavior.
+const setDocumentHidden = (hidden) => {
+  Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden })
+}
+
 describe('useModels', () => {
   beforeEach(() => {
     vi.stubGlobal('fetch', vi.fn())
@@ -8,6 +14,7 @@ describe('useModels', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+    delete document.hidden
   })
 
   test('fetches models on mount', async () => {
@@ -120,6 +127,35 @@ describe('useModels', () => {
     expect(benchmarkCall).toBeTruthy()
     expect(benchmarkCall[0]).toContain('qwen3.5-9b-q4')
     expect(benchmarkCall[1].body).toContain('max_tokens')
+  })
+
+  test('pauses 30s polling while the tab is hidden and refreshes on visibilitychange', async () => {
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ models: [], gpu: null, currentModel: null })
+    })
+
+    vi.useFakeTimers()
+    try {
+      renderHook(() => useModels())
+      await act(async () => {})
+      expect(fetch).toHaveBeenCalledTimes(1)
+
+      setDocumentHidden(true)
+      await act(async () => { await vi.advanceTimersByTimeAsync(90000) })
+      expect(fetch).toHaveBeenCalledTimes(1)
+
+      setDocumentHidden(false)
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+      })
+      expect(fetch).toHaveBeenCalledTimes(2)
+
+      await act(async () => { await vi.advanceTimersByTimeAsync(30000) })
+      expect(fetch).toHaveBeenCalledTimes(3)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   test('deleteModel aborts when user cancels confirm', async () => {

--- a/dream-server/extensions/services/dashboard/src/hooks/useDownloadProgress.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useDownloadProgress.js
@@ -63,10 +63,21 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
   useEffect(() => {
     fetchProgress()
 
-    // Poll frequently only while downloading; otherwise check every 10s
+    // Poll frequently only while downloading; otherwise check every 10s.
+    // Skip ticks while the tab is hidden — nobody sees the progress bar and
+    // the visibility handler below catches state up on return (#1490).
     const activeInterval = isDownloading ? pollIntervalMs : 10000
-    const interval = setInterval(fetchProgress, activeInterval)
-    return () => clearInterval(interval)
+    const tick = () => { if (!document.hidden) fetchProgress() }
+    const interval = setInterval(tick, activeInterval)
+
+    // Resume immediately when the tab becomes visible again
+    const onVisibility = () => { if (!document.hidden) fetchProgress() }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
   }, [fetchProgress, pollIntervalMs, isDownloading])
 
   // Format helpers

--- a/dream-server/extensions/services/dashboard/src/hooks/useModels.js
+++ b/dream-server/extensions/services/dashboard/src/hooks/useModels.js
@@ -124,9 +124,19 @@ export function useModels() {
 
   useEffect(() => {
     fetchModels()
-    // Refresh every 30 seconds
-    const interval = setInterval(fetchModels, 30000)
-    return () => clearInterval(interval)
+    // Refresh every 30 seconds — but skip ticks while the tab is hidden so
+    // an idle dashboard doesn't keep polling for nobody (#1490).
+    const tick = () => { if (!document.hidden) fetchModels() }
+    const interval = setInterval(tick, 30000)
+
+    // Resume immediately when the tab becomes visible again
+    const onVisibility = () => { if (!document.hidden) fetchModels() }
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
   }, [fetchModels])
 
   const downloadModel = async (modelId) => {

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -606,10 +606,15 @@ export default function Dashboard({ status, loading }) {
     }
 
     fetchFeatures()
-    const timer = setInterval(fetchFeatures, 15000)
+    // Skip ticks while the tab is hidden; refresh immediately on return (#1490)
+    const tick = () => { if (!document.hidden) fetchFeatures() }
+    const timer = setInterval(tick, 15000)
+    const onVisibility = () => { if (!document.hidden) fetchFeatures() }
+    document.addEventListener('visibilitychange', onVisibility)
     return () => {
       mounted = false
       clearInterval(timer)
+      document.removeEventListener('visibilitychange', onVisibility)
     }
   }, [])
 
@@ -628,10 +633,17 @@ export default function Dashboard({ status, loading }) {
     }
 
     fetchServiceResources()
-    const timer = setInterval(fetchServiceResources, 10000)
+    // /api/services/resources runs `docker stats` + /data disk walks
+    // server-side (TTL-cached 20s/60s) — the most expensive poller on this
+    // page. Skip ticks while the tab is hidden; refresh on return (#1490).
+    const tick = () => { if (!document.hidden) fetchServiceResources() }
+    const timer = setInterval(tick, 10000)
+    const onVisibility = () => { if (!document.hidden) fetchServiceResources() }
+    document.addEventListener('visibilitychange', onVisibility)
     return () => {
       mounted = false
       clearInterval(timer)
+      document.removeEventListener('visibilitychange', onVisibility)
     }
   }, [])
 

--- a/dream-server/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Usage.jsx
@@ -318,10 +318,15 @@ function useUsageReport(range, reloadToken = 0) {
     }
 
     load()
-    const intervalId = window.setInterval(() => load({ silent: true }), 10000)
+    // Skip ticks while the tab is hidden; refresh immediately on return (#1490)
+    const tick = () => { if (!document.hidden) load({ silent: true }) }
+    const intervalId = window.setInterval(tick, 10000)
+    const onVisibility = () => { if (!document.hidden) load({ silent: true }) }
+    document.addEventListener('visibilitychange', onVisibility)
     return () => {
       cancelled = true
       window.clearInterval(intervalId)
+      document.removeEventListener('visibilitychange', onVisibility)
     }
   }, [range, reloadToken])
 


### PR DESCRIPTION
## Summary

Follow-up to the #1490 idle-CPU investigation, picking up the thread from the maintainer's comment there: after the CSS animation mitigation (#1499), the next suspects were *"`/api/status`, service resources, and GPU/status polling frequency"*.

The dashboard already has a blessed pattern for this — `useSystemStatus`, `useGPUDetailed`, and `ServiceMap` all skip polling while `document.hidden` and refresh on `visibilitychange`. But four pollers never got the same treatment and keep hitting dashboard-api around the clock from a backgrounded tab:

| Poller | Interval | Server-side cost |
|---|---|---|
| `Dashboard.jsx` → `/api/services/resources` | 10s | `docker stats --no-stream` sweeps + recursive `/data` disk walks via the host agent (TTL-cached 20s/60s, so a hidden tab still forces a stats sweep ~every 20s and a full models-dir walk ~every 60s, forever) |
| `Dashboard.jsx` → `/api/features` | 15s | feature/service state assembly |
| `Usage.jsx` → usage report | 10s | usage aggregation |
| `useModels` → `/api/models` | 30s | model catalog + GPU fit checks |
| `useDownloadProgress` → download-status | 10s idle | status file read |

Since the Dashboard page is the default landing page, "open dashboard, switch to another tab/screen, leave the box running" — the exact usage in the #1490 report — keeps all of these hot. The `docker stats` sweeps in particular are a plausible contributor to the reported idle CPU on the host, independent of Chrome rendering.

### Change

Each poller now skips interval ticks while `document.hidden` and refreshes immediately on `visibilitychange` — the same semantics as the three already-guarded pollers, deliberately mirrored line-for-line so the codebase has one recognizable pattern. Initial mount fetches are unchanged, and manual refresh paths (model download/delete/benchmark refreshes, Usage range changes) are unaffected because the guard lives on the interval tick, not inside the fetch functions.

Adds visibility regression tests for both hooks: polling pauses while hidden, and the catch-up fetch fires when the tab returns.

## AI Assistance

Drafted with Claude Code (mapped the polling sites, traced `/api/services/resources` through `routers/resources.py` to the host agent's `docker stats` handler, wrote the patch and tests, ran the validations below). I read the final diff and am accountable for it.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because:

Commands/results:

```text
cd dream-server/extensions/services/dashboard
npm test -- --run   ->  Test Files 20 passed, Tests 124 passed
                        (122 existing + 2 new visibility regression tests)
npm run lint        ->  clean
npm run build       ->  ✓ built in 1.58s
git diff --check    ->  clean
```

Behavior notes for review:
- A tab that mounts while hidden still does its initial fetch (unchanged), so first paint is never blocked on visibility.
- `useDownloadProgress` keeps its fast poll while a download is active and visible; while hidden, the visibilitychange handler catches the state up the moment the user returns, so completion toasts still fire.

## Operational Change Check

Frontend polling cadence only. No API contracts, auth, routing, or installer surfaces changed. Worst case regression mode is "stale panel until the tab becomes visible", at which point the immediate catch-up fetch runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)