### PR TITLE
feat(mlx): experimental opt-in MLX engine for Apple Silicon

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -460,3 +460,17 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
 # TS_HOSTNAME=                         # Defaults to DREAM_DEVICE_NAME
 # TS_EXTRA_ARGS=                       # Optional, e.g. --advertise-tags=tag:dream
+
+# MLX Engine — EXPERIMENTAL (Apple Silicon only)
+# ═══════════════════════════════════════════════════════════════════
+# Run the MLX OpenAI-compatible server (mlx_lm.server) natively beside
+# the default llama-server engine. Entirely opt-in: nothing starts MLX
+# unless you run scripts/mlx-server.sh with the gate variable set.
+# See docs/MLX.md for setup, model selection, and current limitations.
+#
+#   DREAM_ENABLE_EXPERIMENTAL_MLX=1 scripts/mlx-server.sh install
+#   DREAM_ENABLE_EXPERIMENTAL_MLX=1 scripts/mlx-server.sh start
+#
+# DREAM_ENABLE_EXPERIMENTAL_MLX=0  # 1 enables the experimental MLX manager
+# MLX_PORT=8081                    # MLX API port (native, no Docker mapping)
+# MLX_MODEL=mlx-community/Qwen3-4B-4bit  # Hugging Face MLX model repo

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -388,6 +388,22 @@
       "description": "llama-server external port",
       "default": 8080
     },
+    "DREAM_ENABLE_EXPERIMENTAL_MLX": {
+      "type": "string",
+      "description": "Set to 1 to enable the experimental native MLX engine manager (scripts/mlx-server.sh, Apple Silicon only). Mutating verbs refuse to run without it. See docs/MLX.md.",
+      "enum": ["0", "1"],
+      "default": "0"
+    },
+    "MLX_PORT": {
+      "type": "integer",
+      "description": "Experimental MLX engine API port (native process, runs beside llama-server)",
+      "default": 8081
+    },
+    "MLX_MODEL": {
+      "type": "string",
+      "description": "Hugging Face repo id of the MLX model served by the experimental MLX engine (e.g. mlx-community/Qwen3-4B-4bit)",
+      "default": "mlx-community/Qwen3-4B-4bit"
+    },
     "WEBUI_PORT": {
       "type": "integer",
       "description": "Open WebUI external port",

--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -61,6 +61,9 @@ test: ## Run unit and contract tests
 	@echo "=== macOS dream-host-agent bootstrap verification ==="
 	@bash tests/test-macos-host-agent-verification.sh
 	@echo ""
+	@echo "=== macOS MLX engine contracts ==="
+	@bash tests/contracts/test-macos-mlx-contracts.sh
+	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
 

--- a/dream-server/config/backends/apple.json
+++ b/dream-server/config/backends/apple.json
@@ -5,5 +5,14 @@
   "public_api_port": 8080,
   "public_health_url": "http://localhost:8080/health",
   "provider_name": "local-mlx",
-  "provider_url": "http://llama-server:8080/v1"
+  "provider_url": "http://llama-server:8080/v1",
+  "runtime": {
+    "mlx": {
+      "experimental": true,
+      "api_port": 8081,
+      "health_path": "/health",
+      "default_model": "mlx-community/Qwen3-4B-4bit",
+      "manager_script": "scripts/mlx-server.sh"
+    }
+  }
 }

--- a/dream-server/docs/MLX.md
+++ b/dream-server/docs/MLX.md
@@ -1,0 +1,140 @@
+# MLX Engine (Experimental)
+
+> **Status: experimental.** Opt-in, Apple Silicon only, not wired into the
+> installer, dashboard, or tier system yet. The default engine on macOS
+> remains the native Metal llama-server. Nothing in a normal install starts
+> MLX — you have to turn it on.
+
+[MLX](https://github.com/ml-explore/mlx) is Apple's machine-learning
+framework for Apple Silicon unified memory. `mlx-lm` ships an
+OpenAI-compatible inference server, and the
+[mlx-community](https://huggingface.co/mlx-community) org publishes
+ready-to-run quantized conversions of most open models. On M-series
+hardware, MLX models can outperform their GGUF equivalents for some
+workloads — and some model families ship MLX conversions before GGUF ones.
+
+Dream Server's MLX support is a self-contained native engine manager,
+`scripts/mlx-server.sh`, that runs **beside** the existing llama-server on
+its own port (default `8081`). It deliberately changes nothing about the
+default stack.
+
+## Requirements
+
+- Apple Silicon Mac (the script refuses to run elsewhere)
+- `python3` (Xcode CLT or Homebrew)
+- Disk space for model weights under `<install>/data/mlx/`
+
+## Quickstart
+
+All mutating verbs are gated behind `DREAM_ENABLE_EXPERIMENTAL_MLX=1`
+(the same opt-in pattern as experimental Jetson support). `stop`,
+`status`, and `health` work without the gate, so you can always inspect
+or bring down a server you started.
+
+```bash
+cd ~/dream-server
+
+# One-time: create the dedicated venv and install mlx-lm (PEP 668-safe —
+# never touches system or Homebrew Python site-packages)
+DREAM_ENABLE_EXPERIMENTAL_MLX=1 scripts/mlx-server.sh install
+
+# Start (first start downloads the model into data/mlx/hf-cache)
+DREAM_ENABLE_EXPERIMENTAL_MLX=1 scripts/mlx-server.sh start
+
+# Verify
+scripts/mlx-server.sh status
+curl -s http://127.0.0.1:8081/v1/models
+```
+
+Chat against it with any OpenAI-compatible client:
+
+```bash
+curl -s http://127.0.0.1:8081/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "mlx-community/Qwen3-4B-4bit",
+    "messages": [{"role": "user", "content": "/no_think hello"}],
+    "max_tokens": 200
+  }'
+```
+
+> **Thinking models:** Qwen3-family models emit internal reasoning into the
+> `reasoning` field and can spend the whole `max_tokens` budget before
+> producing `content` — the same reason the stack defaults
+> `LLAMA_REASONING=off`. Prefix prompts with `/no_think`, or raise
+> `max_tokens`.
+
+Stop it:
+
+```bash
+scripts/mlx-server.sh stop
+```
+
+## Configuration
+
+Set in `.env` (see `.env.example`) or as environment variables:
+
+| Key | Default | Meaning |
+|---|---|---|
+| `DREAM_ENABLE_EXPERIMENTAL_MLX` | `0` | `1` enables install/start/restart |
+| `MLX_PORT` | `8081` | API port (native process, no Docker mapping) |
+| `MLX_MODEL` | `mlx-community/Qwen3-4B-4bit` | Hugging Face repo to serve |
+| `MLX_START_TIMEOUT` | `600` | Seconds to wait for first health (downloads count) |
+| `BIND_ADDRESS` | `127.0.0.1` | Same knob the native llama-server honours |
+
+A different model for one run: `... mlx-server.sh start --model mlx-community/<repo>`.
+
+Pick models by RAM the same way you would GGUF quants — a 4-bit MLX model
+needs roughly the same memory as its `Q4_K_M` GGUF counterpart. Browse
+[mlx-community](https://huggingface.co/mlx-community) for conversions.
+
+Defaults live in `config/backends/apple.json` under `runtime.mlx`,
+following the same pattern as the Lemonade runtime block in
+`config/backends/amd.json`.
+
+## Using MLX from the rest of the stack
+
+The server speaks the OpenAI API at `http://127.0.0.1:8081/v1`. From
+**Open WebUI**: Admin Settings → Connections → add an OpenAI API
+connection with that base URL (from inside a container, use
+`http://host.docker.internal:8081/v1`). Any other OpenAI-compatible
+client works the same way.
+
+## State and uninstall
+
+Everything lives under the install dir:
+
+```
+data/mlx/venv/        # dedicated Python venv with mlx-lm
+data/mlx/hf-cache/    # model weights (HF_HOME)
+data/.mlx-server.pid
+data/mlx-server.log
+```
+
+Uninstall completely:
+
+```bash
+scripts/mlx-server.sh stop
+rm -rf data/mlx data/.mlx-server.pid data/mlx-server.log
+```
+
+## Current limitations (deliberate, while experimental)
+
+- Not started by the installer, `dream-cli`, or launchd — manual lifecycle only.
+- Not registered with the dashboard, LiteLLM, or Hermes; no tier-map model
+  selection (set `MLX_MODEL` yourself).
+- No SHA-pinned model verification (weights come from the Hugging Face hub
+  with its own integrity checks, unlike the curated GGUF catalog).
+- Single model per server instance.
+
+If the experiment earns its keep, the follow-up path is: `llm_engine: "mlx"`
+as a first-class engine in the apple backend contract, tier-map MLX model
+selection, dashboard/host-agent integration, and a launchd plist — each its
+own reviewed change.
+
+## Validation contract
+
+`tests/contracts/test-macos-mlx-contracts.sh` (runs in `make test` on every
+platform) pins the safety properties: experimental gate on every mutating
+verb, Bash 3.2 compatibility, PEP 668 venv-only installs, loopback-default
+bind, state containment under the install dir, and TERM→KILL shutdown.

--- a/dream-server/scripts/mlx-server.sh
+++ b/dream-server/scripts/mlx-server.sh
@@ -1,0 +1,333 @@
+#!/bin/bash
+# ============================================================================
+# mlx-server.sh — Experimental MLX engine manager (Apple Silicon)
+# ============================================================================
+# Runs the MLX OpenAI-compatible inference server (mlx_lm.server) natively on
+# Apple Silicon, beside the default native llama-server engine. MLX models
+# (mlx-community/* on Hugging Face) use Apple's unified-memory ML framework
+# and can outperform GGUF on M-series hardware for some workloads.
+#
+# EXPERIMENTAL — and deliberately additive:
+#   * Nothing in the default install path invokes this script.
+#   * Mutating verbs (install/start/restart) require
+#     DREAM_ENABLE_EXPERIMENTAL_MLX=1 (same opt-in pattern as Jetson).
+#   * stop/status/health are read-only-safe and work without the gate, so an
+#     operator can always inspect or bring down a server they started.
+#   * The default engine contract (config/backends/apple.json llm_engine)
+#     is untouched; MLX listens on its own port (default 8081).
+#
+# Usage:
+#   DREAM_ENABLE_EXPERIMENTAL_MLX=1 scripts/mlx-server.sh install
+#   DREAM_ENABLE_EXPERIMENTAL_MLX=1 scripts/mlx-server.sh start [--model <hf-id>]
+#   scripts/mlx-server.sh status
+#   scripts/mlx-server.sh health
+#   scripts/mlx-server.sh stop
+#
+# Configuration (`.env` keys or environment, all optional):
+#   MLX_PORT                       API port            (default: runtime.mlx.api_port, 8081)
+#   MLX_MODEL                      Hugging Face repo   (default: runtime.mlx.default_model)
+#   MLX_START_TIMEOUT              Health wait seconds (default: 600 — first start
+#                                  downloads the model from Hugging Face)
+#   BIND_ADDRESS                   127.0.0.1 (default) or 0.0.0.0 — same knob
+#                                  the native llama-server honours
+#
+# State lives entirely under <install>/data/mlx/ (venv + Hugging Face cache)
+# plus the .mlx-server.pid / mlx-server.log siblings of the llama-server
+# equivalents, so `rm -rf data/mlx data/.mlx-server.pid data/mlx-server.log`
+# removes every trace.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Resolve the install dir the same way the rest of the stack does: shared
+# path-utils when available (installers/lib/ in both the source tree and the
+# installed layout), DREAM_HOME fallback otherwise.
+if [[ -f "$ROOT_DIR/installers/lib/path-utils.sh" ]]; then
+    . "$ROOT_DIR/installers/lib/path-utils.sh"
+    INSTALL_DIR="$(resolve_install_dir)"
+else
+    INSTALL_DIR="${DREAM_HOME:-$HOME/dream-server}"
+fi
+
+ENV_FILE="$INSTALL_DIR/.env"
+MLX_STATE_DIR="$INSTALL_DIR/data/mlx"
+MLX_VENV_DIR="$MLX_STATE_DIR/venv"
+MLX_HF_CACHE_DIR="$MLX_STATE_DIR/hf-cache"
+MLX_PID_FILE="$INSTALL_DIR/data/.mlx-server.pid"
+MLX_LOG_FILE="$INSTALL_DIR/data/mlx-server.log"
+BACKEND_CONTRACT="$ROOT_DIR/config/backends/apple.json"
+
+GRN='\033[0;32m'; RED='\033[0;31m'; AMB='\033[0;33m'; NC='\033[0m'
+ok()   { printf "${GRN}✓${NC} %s\n" "$*"; }
+warn() { printf "${AMB}!${NC} %s\n" "$*"; }
+err()  { printf "${RED}✗${NC} %s\n" "$*" >&2; }
+die()  { err "$*"; exit 1; }
+
+usage() {
+    sed -n '/^# Usage:/,/^# Configuration/p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//' | sed '$d'
+}
+
+require_experimental_gate() {
+    if [[ "${DREAM_ENABLE_EXPERIMENTAL_MLX:-0}" != "1" ]]; then
+        err "The MLX engine is experimental and disabled by default."
+        err "Re-run with: DREAM_ENABLE_EXPERIMENTAL_MLX=1 $0 $*"
+        exit 1
+    fi
+}
+
+require_apple_silicon() {
+    [[ "$(uname -s)" == "Darwin" ]] || die "MLX requires macOS (detected $(uname -s))."
+    [[ "$(uname -m)" == "arm64" ]] || die "MLX requires Apple Silicon (detected $(uname -m))."
+}
+
+require_python3() {
+    command -v python3 >/dev/null 2>&1 \
+        || die "python3 is required. Install the Xcode CLT (xcode-select --install) or Homebrew Python."
+}
+
+# Read KEY=value from .env, stripping surrounding quotes. Empty when unset.
+read_env_var() {
+    local key="$1"
+    [[ -f "$ENV_FILE" ]] || { echo ""; return 0; }
+    grep "^${key}=" "$ENV_FILE" 2>/dev/null | tail -1 | cut -d= -f2- | tr -d '"' || true
+}
+
+# Read a runtime.mlx field from the apple backend contract. Empty on absence
+# so callers can fall back to hardcoded defaults.
+contract_mlx_field() {
+    local field="$1"
+    [[ -f "$BACKEND_CONTRACT" ]] || { echo ""; return 0; }
+    python3 - "$BACKEND_CONTRACT" "$field" <<'PY'
+import json
+import sys
+
+try:
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        contract = json.load(f)
+    value = contract.get("runtime", {}).get("mlx", {}).get(sys.argv[2], "")
+except (OSError, json.JSONDecodeError):
+    value = ""
+print(value)
+PY
+}
+
+resolve_settings() {
+    MLX_PORT="${MLX_PORT:-$(read_env_var MLX_PORT)}"
+    [[ -z "$MLX_PORT" ]] && MLX_PORT="$(contract_mlx_field api_port)"
+    [[ -z "$MLX_PORT" ]] && MLX_PORT=8081
+
+    MLX_MODEL="${MLX_MODEL:-$(read_env_var MLX_MODEL)}"
+    [[ -z "$MLX_MODEL" ]] && MLX_MODEL="$(contract_mlx_field default_model)"
+    [[ -z "$MLX_MODEL" ]] && die "No MLX model configured. Set MLX_MODEL (e.g. mlx-community/Qwen3-4B-4bit)."
+
+    BIND_ADDRESS="${BIND_ADDRESS:-$(read_env_var BIND_ADDRESS)}"
+    [[ -z "$BIND_ADDRESS" ]] && BIND_ADDRESS="127.0.0.1"
+
+    MLX_HEALTH_PATH="$(contract_mlx_field health_path)"
+    [[ -z "$MLX_HEALTH_PATH" ]] && MLX_HEALTH_PATH="/health"
+
+    MLX_START_TIMEOUT="${MLX_START_TIMEOUT:-600}"
+}
+
+get_mlx_pid() {
+    MLX_PID=""
+    if [[ -f "$MLX_PID_FILE" ]]; then
+        MLX_PID="$(tr -dc '0-9' < "$MLX_PID_FILE" 2>/dev/null || true)"
+        if [[ -z "$MLX_PID" ]] || ! kill -0 "$MLX_PID" 2>/dev/null; then
+            MLX_PID=""
+        fi
+    fi
+}
+
+# Health probe. mlx_lm.server exposes /health; older releases only have the
+# OpenAI surface, so fall back to /v1/models. Always probe 127.0.0.1: probing
+# a 0.0.0.0 bind via loopback is valid, and IPv6 ::1 resolution of
+# "localhost" can hang on macOS.
+probe_health() {
+    curl -sf --max-time 5 "http://127.0.0.1:${MLX_PORT}${MLX_HEALTH_PATH}" >/dev/null 2>&1 \
+        || curl -sf --max-time 5 "http://127.0.0.1:${MLX_PORT}/v1/models" >/dev/null 2>&1
+}
+
+cmd_install() {
+    require_apple_silicon
+    require_python3
+
+    mkdir -p "$MLX_STATE_DIR"
+
+    # PEP 668: Homebrew/system Python rejects bare `pip install` and
+    # `pip install --user`. A dedicated venv under data/mlx/ is the only
+    # install mode this script supports — it also makes uninstall a rm -rf.
+    if [[ ! -x "$MLX_VENV_DIR/bin/python" ]]; then
+        echo "Creating MLX virtualenv: $MLX_VENV_DIR"
+        python3 -m venv "$MLX_VENV_DIR"
+    fi
+
+    local spec="mlx-lm${MLX_LM_VERSION:+==$MLX_LM_VERSION}"
+    echo "Installing $spec into the MLX virtualenv (this can take a minute)..."
+    "$MLX_VENV_DIR/bin/python" -m pip install --quiet --upgrade "$spec"
+
+    local installed
+    installed="$("$MLX_VENV_DIR/bin/python" -m pip show mlx-lm 2>/dev/null | grep '^Version:' | awk '{print $2}')"
+    ok "mlx-lm ${installed:-?} installed in $MLX_VENV_DIR"
+}
+
+cmd_start() {
+    require_apple_silicon
+    resolve_settings
+
+    [[ -x "$MLX_VENV_DIR/bin/python" ]] \
+        || die "MLX virtualenv missing. Run: DREAM_ENABLE_EXPERIMENTAL_MLX=1 $0 install"
+
+    get_mlx_pid
+    if [[ -n "$MLX_PID" ]]; then
+        ok "mlx-server already running (PID $MLX_PID, port $MLX_PORT)"
+        return 0
+    fi
+
+    mkdir -p "$MLX_STATE_DIR" "$(dirname "$MLX_PID_FILE")"
+
+    # Prefer the console entry point; fall back to module invocation for
+    # mlx-lm releases that don't ship it.
+    local -a launch_cmd
+    if [[ -x "$MLX_VENV_DIR/bin/mlx_lm.server" ]]; then
+        launch_cmd=("$MLX_VENV_DIR/bin/mlx_lm.server")
+    else
+        launch_cmd=("$MLX_VENV_DIR/bin/python" -m mlx_lm.server)
+    fi
+
+    echo "Starting mlx-server: $MLX_MODEL on ${BIND_ADDRESS}:${MLX_PORT}"
+    echo "  (first start downloads the model from Hugging Face into data/mlx/hf-cache)"
+    # HF_HOME keeps model weights inside the install dir, mirroring how GGUF
+    # files live in data/models/.
+    HF_HOME="$MLX_HF_CACHE_DIR" \
+        "${launch_cmd[@]}" \
+        --model "$MLX_MODEL" \
+        --host "$BIND_ADDRESS" \
+        --port "$MLX_PORT" \
+        > "$MLX_LOG_FILE" 2>&1 &
+    local pid=$!
+    echo "$pid" > "$MLX_PID_FILE"
+
+    local waited=0
+    while [[ "$waited" -lt "$MLX_START_TIMEOUT" ]]; do
+        sleep 2
+        waited=$((waited + 2))
+        if probe_health; then
+            ok "mlx-server healthy (PID $pid, http://127.0.0.1:${MLX_PORT}/v1)"
+            return 0
+        fi
+        if ! kill -0 "$pid" 2>/dev/null; then
+            rm -f "$MLX_PID_FILE"
+            err "mlx-server process died during startup. Last log lines:"
+            tail -20 "$MLX_LOG_FILE" >&2 || true
+            exit 1
+        fi
+        if (( waited % 30 == 0 )); then
+            echo "  Still starting (model download/load)... ${waited}s — tail -f $MLX_LOG_FILE"
+        fi
+    done
+
+    err "mlx-server did not become healthy within ${MLX_START_TIMEOUT}s; leaving it running."
+    err "Inspect: tail -f $MLX_LOG_FILE — then '$0 status' or '$0 stop'."
+    exit 1
+}
+
+cmd_stop() {
+    get_mlx_pid
+    if [[ -z "$MLX_PID" ]]; then
+        echo "mlx-server not running"
+        rm -f "$MLX_PID_FILE"
+        return 0
+    fi
+
+    # SIGTERM, bounded wait, then SIGKILL — same shutdown contract as the
+    # native llama-server path.
+    kill "$MLX_PID" 2>/dev/null || true
+    local i=0
+    while [[ "$i" -lt 20 ]] && kill -0 "$MLX_PID" 2>/dev/null; do
+        sleep 0.5
+        i=$((i + 1))
+    done
+    if kill -0 "$MLX_PID" 2>/dev/null; then
+        kill -9 "$MLX_PID" 2>/dev/null || true
+    fi
+    rm -f "$MLX_PID_FILE"
+    ok "mlx-server stopped (PID $MLX_PID)"
+}
+
+cmd_status() {
+    resolve_settings 2>/dev/null || true
+    get_mlx_pid
+    if [[ -n "$MLX_PID" ]]; then
+        if probe_health; then
+            ok "mlx-server running and healthy (PID $MLX_PID, port ${MLX_PORT:-?})"
+        else
+            warn "mlx-server running (PID $MLX_PID) but not answering on port ${MLX_PORT:-?} yet"
+        fi
+    else
+        echo "mlx-server not running"
+    fi
+    if [[ -x "$MLX_VENV_DIR/bin/python" ]]; then
+        echo "  venv: $MLX_VENV_DIR"
+    else
+        echo "  venv: not installed (run: DREAM_ENABLE_EXPERIMENTAL_MLX=1 $0 install)"
+    fi
+}
+
+cmd_health() {
+    resolve_settings
+    if probe_health; then
+        ok "healthy: http://127.0.0.1:${MLX_PORT}${MLX_HEALTH_PATH}"
+    else
+        err "unhealthy: no response on port ${MLX_PORT}"
+        exit 1
+    fi
+}
+
+VERB="${1:-}"
+shift || true
+
+# Optional --model override for start
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)
+            MLX_MODEL="${2:-}"
+            shift 2
+            ;;
+        *)
+            die "Unknown argument: $1"
+            ;;
+    esac
+done
+
+case "$VERB" in
+    install)
+        require_experimental_gate install
+        cmd_install
+        ;;
+    start)
+        require_experimental_gate start
+        cmd_start
+        ;;
+    restart)
+        require_experimental_gate restart
+        cmd_stop
+        cmd_start
+        ;;
+    stop)
+        cmd_stop
+        ;;
+    status)
+        cmd_status
+        ;;
+    health)
+        cmd_health
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/dream-server/tests/contracts/test-macos-mlx-contracts.sh
+++ b/dream-server/tests/contracts/test-macos-mlx-contracts.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# Contract tests for the experimental MLX engine manager (scripts/mlx-server.sh).
+# All assertions are static — no Apple Silicon hardware, network, or Python
+# packages required — so they run on every platform in `make test`.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+MLX_SCRIPT="scripts/mlx-server.sh"
+APPLE_CONTRACT="config/backends/apple.json"
+
+PASS=0
+FAIL=0
+
+pass() { echo "[PASS] $1"; PASS=$((PASS + 1)); }
+fail() { echo "[FAIL] $1"; FAIL=$((FAIL + 1)); }
+
+json_get() {
+    python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path, key_path = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as f:
+    value = json.load(f)
+for key in key_path.split("."):
+    value = value[key]
+print(value)
+PY
+}
+
+# ---------------------------------------------------------------------------
+# 1. Script exists, is executable, and parses under Bash 3.2 constructs
+# ---------------------------------------------------------------------------
+echo "[contract] MLX manager script shape"
+if [[ -x "$MLX_SCRIPT" ]]; then
+    pass "exists and executable: $MLX_SCRIPT"
+else
+    fail "missing or not executable: $MLX_SCRIPT"
+fi
+
+if bash -n "$MLX_SCRIPT"; then
+    pass "bash -n parses"
+else
+    fail "bash -n failed"
+fi
+
+# macOS ships Bash 3.2 and this script MUST run there (it manages a native
+# macOS process). Reject Bash-4+-only constructs.
+if grep -qE 'declare -A|\$\{[A-Za-z_]+(\^\^|,,)\}|mapfile|readarray' "$MLX_SCRIPT"; then
+    fail "uses Bash 4+ constructs (declare -A / case conversion / mapfile)"
+else
+    pass "no Bash 4+ constructs (runs on stock macOS Bash 3.2)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Experimental gate: every mutating verb requires the opt-in, and the
+#    gate variable matches the DREAM_ENABLE_EXPERIMENTAL_* convention
+# ---------------------------------------------------------------------------
+echo "[contract] experimental opt-in gate"
+if grep -q 'DREAM_ENABLE_EXPERIMENTAL_MLX' "$MLX_SCRIPT"; then
+    pass "gate variable follows DREAM_ENABLE_EXPERIMENTAL_* convention"
+else
+    fail "gate variable missing or misnamed"
+fi
+
+for verb in install start restart; do
+    if awk -v verb="$verb" '
+        $0 ~ "^[[:space:]]*" verb "\\)" { in_verb=1 }
+        in_verb && /require_experimental_gate/ { found=1 }
+        in_verb && /;;/ { exit }
+        END { exit(found ? 0 : 1) }
+    ' "$MLX_SCRIPT"; then
+        pass "verb '$verb' requires the experimental gate"
+    else
+        fail "verb '$verb' does not require the experimental gate"
+    fi
+done
+
+for verb in stop status health; do
+    if awk -v verb="$verb" '
+        $0 ~ "^[[:space:]]*" verb "\\)" { in_verb=1 }
+        in_verb && /require_experimental_gate/ { found=1 }
+        in_verb && /;;/ { exit }
+        END { exit(found ? 0 : 1) }
+    ' "$MLX_SCRIPT"; then
+        fail "read-only/safe verb '$verb' must not be gated (operators must always be able to inspect/stop)"
+    else
+        pass "verb '$verb' works without the gate"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. PEP 668 discipline: dedicated venv, never pip --user / bare pip
+# ---------------------------------------------------------------------------
+echo "[contract] PEP 668 install discipline"
+if grep -q 'python3 -m venv' "$MLX_SCRIPT"; then
+    pass "installs into a dedicated venv"
+else
+    fail "must install mlx-lm into a dedicated venv"
+fi
+
+if grep -v '^[[:space:]]*#' "$MLX_SCRIPT" | grep -q 'pip install --user'; then
+    fail "must not use pip --user (Homebrew Python rejects it under PEP 668)"
+else
+    pass "no pip --user"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. State containment: every artifact lives under the install dir
+# ---------------------------------------------------------------------------
+echo "[contract] state containment"
+for var in 'MLX_STATE_DIR="$INSTALL_DIR/data/mlx"' \
+           'MLX_PID_FILE="$INSTALL_DIR/data/.mlx-server.pid"' \
+           'MLX_LOG_FILE="$INSTALL_DIR/data/mlx-server.log"'; do
+    if grep -qF "$var" "$MLX_SCRIPT"; then
+        pass "declares $var"
+    else
+        fail "missing or relocated: $var"
+    fi
+done
+
+if grep -q 'HF_HOME="\$MLX_HF_CACHE_DIR"' "$MLX_SCRIPT"; then
+    pass "model weights pinned inside the install dir via HF_HOME"
+else
+    fail "HF_HOME must point inside the install dir so weights do not land in ~/.cache"
+fi
+
+# ---------------------------------------------------------------------------
+# 5. Network defaults: loopback bind, no curl to "localhost" (IPv6 ::1 can
+#    hang on macOS — repo-wide rule), BIND_ADDRESS knob honoured
+# ---------------------------------------------------------------------------
+echo "[contract] network defaults"
+if grep -q 'BIND_ADDRESS="127.0.0.1"' "$MLX_SCRIPT"; then
+    pass "default bind is loopback (default-secure)"
+else
+    fail "default bind must be 127.0.0.1"
+fi
+
+if grep -qE 'curl[^|]*http://localhost' "$MLX_SCRIPT"; then
+    fail "curl must use 127.0.0.1, never localhost"
+else
+    pass "health probes use 127.0.0.1"
+fi
+
+if grep -q 'read_env_var BIND_ADDRESS' "$MLX_SCRIPT"; then
+    pass "honours the unified BIND_ADDRESS .env knob"
+else
+    fail "must honour BIND_ADDRESS from .env like the native llama-server"
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Process lifecycle: TERM -> bounded wait -> KILL, bounded health wait
+# ---------------------------------------------------------------------------
+echo "[contract] process lifecycle"
+if awk '
+    /^cmd_stop\(\)/ { in_stop=1 }
+    in_stop && /kill "\$MLX_PID"/ { term=1 }
+    in_stop && term && /kill -9 "\$MLX_PID"/ { found=1 }
+    in_stop && /^\}/ { exit(found ? 0 : 1) }
+    END { exit(found ? 0 : 1) }
+' "$MLX_SCRIPT"; then
+    pass "stop escalates TERM -> KILL"
+else
+    fail "stop must SIGTERM first and only then SIGKILL"
+fi
+
+if grep -q 'MLX_START_TIMEOUT' "$MLX_SCRIPT"; then
+    pass "health wait is bounded (MLX_START_TIMEOUT)"
+else
+    fail "health wait must be bounded"
+fi
+
+# ---------------------------------------------------------------------------
+# 7. Backend contract: apple.json declares the mlx runtime block
+# ---------------------------------------------------------------------------
+echo "[contract] apple backend contract"
+if [[ "$(json_get "$APPLE_CONTRACT" "runtime.mlx.experimental")" == "True" ]]; then
+    pass "runtime.mlx marked experimental"
+else
+    fail "runtime.mlx.experimental must be true"
+fi
+
+mlx_port="$(json_get "$APPLE_CONTRACT" "runtime.mlx.api_port")"
+if [[ "$mlx_port" == "8081" ]]; then
+    pass "runtime.mlx.api_port is 8081"
+else
+    fail "runtime.mlx.api_port unexpected: $mlx_port"
+fi
+
+# MLX must not squat on a port already owned by another service.
+for taken in 8080 3000 8888 3004 9000 8880 5678 6333 6334 8090 4000 7860 8085 3002 3001 8188 3005 3003 11434 7710; do
+    if [[ "$mlx_port" == "$taken" ]]; then
+        fail "runtime.mlx.api_port collides with known port $taken"
+    fi
+done
+pass "runtime.mlx.api_port does not collide with known service ports"
+
+if json_get "$APPLE_CONTRACT" "runtime.mlx.default_model" | grep -q '^mlx-community/'; then
+    pass "runtime.mlx.default_model is an mlx-community repo"
+else
+    fail "runtime.mlx.default_model should point at an mlx-community repo"
+fi
+
+if [[ "$(json_get "$APPLE_CONTRACT" "llm_engine")" == "llama-server" ]]; then
+    pass "default apple engine unchanged (llama-server)"
+else
+    fail "default apple llm_engine must remain llama-server while MLX is experimental"
+fi
+
+# ---------------------------------------------------------------------------
+# 8. Operator surface: .env.example + .env.schema.json document the knobs
+# ---------------------------------------------------------------------------
+echo "[contract] env documentation"
+for key in DREAM_ENABLE_EXPERIMENTAL_MLX MLX_PORT MLX_MODEL; do
+    if grep -q "$key" .env.example; then
+        pass ".env.example documents $key"
+    else
+        fail ".env.example missing $key"
+    fi
+    if python3 -c "
+import json, sys
+schema = json.load(open('.env.schema.json'))
+sys.exit(0 if '$key' in schema['properties'] else 1)
+"; then
+        pass ".env.schema.json declares $key"
+    else
+        fail ".env.schema.json missing $key"
+    fi
+done
+
+if [[ -f "docs/MLX.md" ]]; then
+    pass "docs/MLX.md exists"
+else
+    fail "docs/MLX.md missing"
+fi
+
+echo ""
+echo "Result: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

First concrete step toward MLX backend support (one of the alternative back ends called out as a priority for contributions). Adds `scripts/mlx-server.sh`, a self-contained manager for the MLX OpenAI-compatible inference server (`mlx_lm.server`) on Apple Silicon. MLX models ([mlx-community](https://huggingface.co/mlx-community) on Hugging Face) run on Apple's unified-memory ML framework and can outperform GGUF on M-series hardware for some workloads — and some model families get MLX conversions before GGUF ones.

### Scoped to be mergeable: additive and double-gated

Following the incremental pattern the Jetson work established (detection → opt-in gate → overlays as separate reviewed changes), this PR makes **zero changes to any default path**:

- Nothing in the installer, `dream-cli`, or lifecycle invokes the script. `config/backends/apple.json` keeps `llm_engine: llama-server`; MLX runs **beside** it on its own port (8081, verified collision-free against the known port set).
- Mutating verbs (`install`/`start`/`restart`) refuse to run without `DREAM_ENABLE_EXPERIMENTAL_MLX=1` — same opt-in convention as `DREAM_ENABLE_EXPERIMENTAL_JETSON`. `stop`/`status`/`health` stay ungated so an operator can always inspect or bring down a server they started.

### House patterns, deliberately mirrored

- **Backend contract:** `runtime.mlx` block in `apple.json` mirrors the Lemonade `runtime` block in `amd.json` (port, health path, default model). The script reads its defaults from the contract, so config stays the source of truth (OCP).
- **Process lifecycle:** PID file + log as `data/` siblings of the llama-server equivalents, bounded health wait, SIGTERM → bounded wait → SIGKILL — the native llama-server shutdown contract.
- **PEP 668:** dedicated venv under `data/mlx/venv`, never `pip --user` (the constraint your installer contracts already enforce for PyYAML). `HF_HOME` pins model weights to `data/mlx/hf-cache`, so uninstall is one `rm -rf`.
- **Bash 3.2-compatible** (runs on stock macOS bash — no `declare -A`, no case-conversion expansions), enforced by contract test.
- **Default-secure:** binds `127.0.0.1` unless the unified `BIND_ADDRESS` knob says otherwise; health probes use `127.0.0.1`, never `localhost` (repo-wide IPv6 rule).

### Operator surface

`.env.example` section + `.env.schema.json` keys (`DREAM_ENABLE_EXPERIMENTAL_MLX`, `MLX_PORT`, `MLX_MODEL`), and `docs/MLX.md` covering quickstart, Open WebUI wiring (`http://host.docker.internal:8081/v1` from containers), thinking-model caveat (`/no_think`, same reason `LLAMA_REASONING` defaults off), state layout, uninstall, and the explicit list of current limitations with the follow-up path (first-class `llm_engine: mlx`, tier-map selection, dashboard/host-agent integration, launchd plist — each as its own reviewed change).

### Contract coverage

`tests/contracts/test-macos-mlx-contracts.sh` (wired into `make test`, static-only so it runs on every platform — 33 assertions): gate required on every mutating verb and absent on read-only verbs, Bash 3.2 compatibility, venv-only installs, loopback default + no `curl localhost`, state containment under the install dir, TERM→KILL escalation, bounded health wait, port non-collision, schema/example/docs presence, and that the default apple engine remains llama-server.

## AI Assistance

Drafted with Claude Code (mapped the Lemonade/Jetson/native-llama patterns, wrote the script/contracts/docs, ran every validation below including the live Apple Silicon run). I read the final diff and am accountable for it.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Checked the two closest surfaces conservatively: a new opt-in engine manager script + backend contract field. No existing installer phase, compose file, routing config, or default behavior is modified — the diff to existing files is the `runtime.mlx` JSON block, 3 schema keys, a commented `.env.example` section, and one Makefile test line.)

## Risk And Validation

- Risk level: Low (additive + experimental-gated; default paths untouched)
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [x] Release-grade fleet or scoped hardware validation — scoped live validation on Apple Silicon hardware (below)
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because:

Commands/results:

```text
# Static
make lint                                   -> all checks passed
bash tests/contracts/test-macos-mlx-contracts.sh   -> 33 passed, 0 failed
/bin/bash tests/contracts/test-macos-mlx-contracts.sh -> 33 passed (stock Bash 3.2)
shellcheck -S error (CI gate) on both new scripts  -> clean (also clean at -S warning)
python3 json.load on .env.schema.json + apple.json -> valid
make test                                   -> exit 0, all suites green *
  (* on macOS requires the #1539 test-harness fix; validated on a local
   branch with both changes. On Linux this PR's suite addition is the
   only delta and it is platform-independent.)

# Live, Apple Silicon (macOS 26, arm64), sandboxed DREAM_HOME:
gate refusal without DREAM_ENABLE_EXPERIMENTAL_MLX  -> exit 1 with guidance
install                  -> venv created, mlx-lm 0.31.3
start (default model)    -> downloaded mlx-community/Qwen3-4B-4bit (2.1GB)
                            into data/mlx/hf-cache, healthy on first try
health                   -> ✓ http://127.0.0.1:8081/health
GET /v1/models           -> lists mlx-community/Qwen3-4B-4bit
POST /v1/chat/completions -> real completion on the Apple GPU
                            (system_fingerprint ...applegpu_g16g);
                            12 completion tokens for the smoke prompt
status                   -> running + healthy, PID + port reported
lsof -iTCP:8081          -> single listener, 127.0.0.1 only
stop                     -> SIGTERM, port released, PID file removed
stop (again)             -> idempotent "not running"
state                    -> everything under <install>/data/mlx/, removed with rm -rf
```

## Operational Change Check

No existing operational surface changes. New surface is opt-in only: a script that manages one native process on a previously unused loopback port, with state contained under `data/mlx/`. Worst case for a user who never sets the gate variable: nothing — the script is inert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)