### PR TITLE
fix(AMD): Docker downgrade detection

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -24,8 +24,21 @@ jobs:
       - name: Install PSScriptAnalyzer
         shell: pwsh
         run: |
-          Set-PSRepository PSGallery -InstallationPolicy Trusted
-          Install-Module PSScriptAnalyzer -Force -Scope CurrentUser
+          $ErrorActionPreference = 'Stop'
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+          if (-not (Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue)) {
+            Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Scope CurrentUser -Force -ForceBootstrap
+          }
+
+          if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default
+          }
+          Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
+
+          Install-Module -Name PSScriptAnalyzer -Repository PSGallery -Scope CurrentUser -Force -AllowClobber
+          Import-Module PSScriptAnalyzer -ErrorAction Stop
+          Get-Module PSScriptAnalyzer | Format-Table Name, Version, Path -AutoSize
 
       - name: Run PowerShell Script Analyzer
         shell: pwsh

--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -167,13 +167,23 @@ if command -v docker &>/dev/null && ! $DRY_RUN; then
         ai "Downgrading to Docker 29.2.1 for AMD GPU compatibility..."
         # Detect package format
         if command -v apt-get &>/dev/null; then
-            _distro_codename=$(. /etc/os-release 2>/dev/null && echo "$VERSION_CODENAME" || echo "noble")
-            ds_sudo apt-get install -y --allow-downgrades \
-                docker-ce=5:29.2.1-1~ubuntu."$(. /etc/os-release && echo "$VERSION_ID")"~"$_distro_codename" \
-                docker-ce-cli=5:29.2.1-1~ubuntu."$(. /etc/os-release && echo "$VERSION_ID")"~"$_distro_codename" \
-                >> "$LOG_FILE" 2>&1 && \
-                ai_ok "Docker downgraded to 29.2.1 (AMD GPU fix)" || \
-                ai_warn "Could not downgrade Docker. GPU containers may fail. Manual fix: sudo apt install docker-ce=5:29.2.1-1~ubuntu.24.04~noble"
+            # Docker CE's apt version string embeds the distro id + codename,
+            # e.g. 5:29.2.1-1~ubuntu.24.04~noble or 5:29.2.1-1~debian.13~trixie.
+            # Resolve the exact installable 29.2.1 version from the configured
+            # repo rather than hand-constructing it — hardcoding "~ubuntu" broke
+            # the downgrade on Debian/derivatives (Debian trixie, AMD boxes).
+            _docker_2921=$(apt-cache madison docker-ce 2>/dev/null \
+                | awk '$3 ~ /(^|:)29\.2\.1/ {print $3; exit}')
+            if [[ -n "$_docker_2921" ]]; then
+                ds_sudo apt-get install -y --allow-downgrades \
+                    docker-ce="$_docker_2921" docker-ce-cli="$_docker_2921" \
+                    >> "$LOG_FILE" 2>&1 && \
+                    ai_ok "Docker downgraded to 29.2.1 (AMD GPU fix)" || \
+                    ai_warn "Could not downgrade Docker. GPU containers may fail. Manual fix: sudo apt install docker-ce=$_docker_2921"
+            else
+                ai_warn "Docker 29.2.1 not found in apt repos; cannot downgrade. AMD GPU containers may fail with /dev/dri passthrough errors."
+                ai "  Manual fix: ensure Docker's apt repo is configured (get.docker.com), then 'apt-cache madison docker-ce' to find the 29.2.1 version string."
+            fi
         elif command -v dnf &>/dev/null; then
             ds_sudo dnf downgrade -y docker-ce-29.2.1 docker-ce-cli-29.2.1 >> "$LOG_FILE" 2>&1 && \
                 ai_ok "Docker downgraded to 29.2.1 (AMD GPU fix)" || \

--- a/dream-server/installers/phases/05-docker.sh
+++ b/dream-server/installers/phases/05-docker.sh
@@ -86,6 +86,45 @@ _docker_install_dnf_rhel_family() {
 # Track whether docker group membership is active in this shell
 DOCKER_NEEDS_SUDO=false
 
+_docker_read_server_version() {
+    local version=""
+
+    if version="$(docker version --format '{{.Server.Version}}' 2>/dev/null)" && [[ -n "$version" ]]; then
+        printf '%s\n' "$version"
+        return 0
+    fi
+
+    # Fresh Linux installs often add the user to the docker group, but that
+    # membership is not active until the next login shell. The AMD downgrade
+    # must still see Docker 29.3.x in that first installer run.
+    if command -v sudo >/dev/null 2>&1; then
+        if version="$(ds_sudo docker version --format '{{.Server.Version}}' 2>/dev/null)" && [[ -n "$version" ]]; then
+            printf '%s\n' "$version"
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+_docker_server_version_for_amd_downgrade() {
+    if _docker_read_server_version; then
+        return 0
+    fi
+
+    # get.docker.com usually starts the daemon, but derivative distros and
+    # first-boot images can leave it stopped until systemd is nudged.
+    if command -v systemctl >/dev/null 2>&1; then
+        ds_sudo systemctl start docker 2>>"${LOG_FILE:-/dev/null}" || true
+        sleep 2
+        if _docker_read_server_version; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 if [[ "$SKIP_DOCKER" == "true" ]]; then
     log "Skipping Docker installation (--skip-docker)"
 elif command -v docker &> /dev/null; then
@@ -161,7 +200,7 @@ fi
 # Pin to 29.2.x until this is resolved upstream.
 # See: https://github.com/moby/moby/issues — device passthrough regression in 29.3.0
 if command -v docker &>/dev/null && ! $DRY_RUN; then
-    _docker_ver=$(docker version --format '{{.Server.Version}}' 2>/dev/null || echo "0.0.0")
+    _docker_ver="$(_docker_server_version_for_amd_downgrade || echo "0.0.0")"
     if [[ "$_docker_ver" == 29.3.* ]] && [[ "${GPU_BACKEND:-}" == "amd" ]]; then
         ai_warn "Docker $_docker_ver has a known bug with AMD GPU device passthrough."
         ai "Downgrading to Docker 29.2.1 for AMD GPU compatibility..."

--- a/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
@@ -424,6 +424,89 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 19. AMD Docker 29.3 downgrade is Debian-aware and sudo-aware
+# ---------------------------------------------------------------------------
+echo "[contract] AMD Docker downgrade handles Debian and inactive docker group"
+docker_phase="installers/phases/05-docker.sh"
+if grep -q 'apt-cache madison docker-ce' "$docker_phase"; then
+    pass "05-docker.sh: apt downgrade resolves the installable Docker CE version"
+else
+    fail "05-docker.sh: apt downgrade must resolve Docker CE 29.2.1 via apt-cache madison"
+fi
+if grep -q 'docker-ce=5:29\.2\.1-1~ubuntu' "$docker_phase" \
+    || grep -q 'docker-ce-cli=5:29\.2\.1-1~ubuntu' "$docker_phase"; then
+    fail "05-docker.sh: apt downgrade must not hardcode Ubuntu package versions"
+else
+    pass "05-docker.sh: apt downgrade no longer hardcodes Ubuntu package versions"
+fi
+if awk '/_docker_read_server_version\(\)/,/^}/' "$docker_phase" \
+    | grep -q 'ds_sudo docker version'; then
+    pass "05-docker.sh: Docker server version probe falls back through ds_sudo"
+else
+    fail "05-docker.sh: AMD downgrade must detect Docker 29.3 when docker group membership is not active"
+fi
+if awk '/_docker_server_version_for_amd_downgrade\(\)/,/^}/' "$docker_phase" \
+    | grep -q 'systemctl start docker'; then
+    pass "05-docker.sh: AMD downgrade starts docker before giving up on version detection"
+else
+    fail "05-docker.sh: AMD downgrade must retry after starting docker on systemd hosts"
+fi
+if awk '/Docker 29\.3\.x has a bug/,/fi$/' "$docker_phase" \
+    | grep -q '_docker_server_version_for_amd_downgrade'; then
+    pass "05-docker.sh: AMD downgrade uses the sudo-aware version probe"
+else
+    fail "05-docker.sh: AMD downgrade still uses a bare docker version probe"
+fi
+_amd_docker_probe_tmp="$(mktemp -d)"
+mkdir -p "$_amd_docker_probe_tmp/bin"
+cat > "$_amd_docker_probe_tmp/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "version" && "${2:-}" == "--format" ]]; then
+    if [[ "${DREAM_FAKE_DOCKER_SUDO:-}" == "1" ]]; then
+        echo "29.3.0"
+        exit 0
+    fi
+    exit 1
+fi
+exit 99
+EOF
+cat > "$_amd_docker_probe_tmp/bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+DREAM_FAKE_DOCKER_SUDO=1 "$@"
+EOF
+chmod +x "$_amd_docker_probe_tmp/bin/docker" "$_amd_docker_probe_tmp/bin/sudo"
+_docker_probe_func="$(awk '
+    /_docker_read_server_version\(\)/,/^}/ {print}
+    /_docker_server_version_for_amd_downgrade\(\)/,/^}/ {print}
+' "$docker_phase")"
+if _probe_output="$(
+    PATH="$_amd_docker_probe_tmp/bin:$PATH" bash -c '
+        set -euo pipefail
+        ds_sudo() { DREAM_FAKE_DOCKER_SUDO=1 "$@"; }
+        eval "$1"
+        _docker_server_version_for_amd_downgrade
+    ' bash "$_docker_probe_func"
+)"; then
+    if [[ "$_probe_output" == "29.3.0" ]]; then
+        pass "05-docker.sh: sudo fallback detects Docker 29.3 when bare docker is denied"
+    else
+        fail "05-docker.sh: sudo fallback returned unexpected Docker version: $_probe_output"
+    fi
+else
+    fail "05-docker.sh: sudo fallback did not recover Docker server version"
+fi
+rm -rf "$_amd_docker_probe_tmp"
+unset _amd_docker_probe_tmp _docker_probe_func _probe_output
+_sample_debian_madison=$'   docker-ce | 5:29.3.0-1~debian.13~trixie | https://download.docker.com/linux/debian trixie/stable amd64 Packages\n   docker-ce | 5:29.2.1-1~debian.13~trixie | https://download.docker.com/linux/debian trixie/stable amd64 Packages'
+_resolved_debian_2921="$(awk '$3 ~ /(^|:)29\.2\.1/ {print $3; exit}' <<<"$_sample_debian_madison")"
+if [[ "$_resolved_debian_2921" == "5:29.2.1-1~debian.13~trixie" ]]; then
+    pass "apt-cache madison parser resolves Debian trixie Docker CE 29.2.1"
+else
+    fail "apt-cache madison parser did not resolve the Debian trixie Docker CE 29.2.1 version"
+fi
+unset _sample_debian_madison _resolved_debian_2921 docker_phase
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 echo ""


### PR DESCRIPTION
## Summary

Hardens the AMD Docker 29.3.x downgrade path added in #1546.

#1546 fixes the Debian/trixie package-name bug by resolving Docker CE 29.2.1 through `apt-cache madison` instead of hardcoding an Ubuntu package version. This follow-up closes the next install-time gap: on fresh Linux installs, the current user may not have active `docker` group permissions yet, or the Docker daemon may not be running when the AMD downgrade check runs.

This PR makes the AMD downgrade version probe:
- read Docker server version with bare `docker` first;
- fall back to `ds_sudo docker version` when docker-group membership is not active yet;
- try `systemctl start docker` before giving up on systemd hosts;
- keep the Debian/Ubuntu package resolution from #1546;
- add AMD/Lemonade contract coverage for Debian trixie and sudo fallback behavior.

This is intended for the AMD Ryzen AI Halo / Strix Halo install path where Docker 29.3.x can break `/dev/dri` passthrough and the installer must downgrade to Docker 29.2.1 reliably.

## AI Assistance

Codex helped inspect the AMD/Debian install failure, identify the sudo/group-membership gap in the Docker version probe, draft the shell patch, and add focused contract tests. The human author reviewed the diff and selected the validation.

## Release Lane

- [x] Stable hotfix targeting `release/2.5.x`
- [ ] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

Current stable AMD/Linux users on Debian or Debian-derived images can fail the Docker 29.3.x -> 29.2.1 compatibility downgrade, leaving AMD GPU containers exposed to the known `/dev/dri` passthrough regression. This specifically affects AMD Ryzen AI Halo / Strix Halo install testing.

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [x] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because:

Commands/results:

`bash -n dream-server/installers/phases/05-docker.sh`
PASS

`bash -n dream-server/tests/contracts/test-amd-lemonade-contracts.sh`
PASS

`git diff --check origin/fix/docker-downgrade-debian-1545...HEAD`
PASS

`bash dream-server/tests/contracts/test-amd-lemonade-contracts.sh`
AMD/Lemonade contracts: 54 passed, 0 failed

`bash dream-server/tests/contracts/test-installer-hardening.sh`
[PASS] installer hardening contracts

`bash dream-server/tests/contracts/test-installer-contracts.sh`
[PASS] installer contracts

`bash dream-server/tests/test-network-timeouts.sh`
All tests passed (17/17)

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

This PR is intentionally stacked on #1546 and should either be merged after it or squashed into it.

It does not add Podman support. DreamServer still assumes Docker Engine + Docker Compose v2 across installer, CLI, host-agent, and lifecycle paths. This patch only makes the supported Docker path more reliable on AMD Linux systems, especially Debian/trixie-derived images where Docker 29.3.x must be downgraded for AMD `/dev/dri` passthrough compatibility.

The new contract test covers:
- no reintroduction of Ubuntu-only Docker CE package strings;
- `apt-cache madison docker-ce` package resolution;
- Debian trixie Docker CE 29.2.1 version parsing;
- sudo fallback when bare `docker version` is denied;
- retry after starting Docker on systemd hosts.