### PR TITLE
release: stamp 2.5.4 stable Hermes image fix

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # Dream Server Architecture
 
-> Version 2.5.3 | Fully local AI stack deployed on user hardware with a single command
+> Version 2.5.4 | Fully local AI stack deployed on user hardware with a single command
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ security policy, GitHub workflows, and project coordination docs. The
 `dream-server/` directory is the product runtime: services, installer phases,
 compose overlays, dashboard, CLI, tests, and operator docs.
 
-**Stable consumption:** `main` moves quickly. For forks, appliances, labs, or
-production-like installs, pin a tagged release or audited commit and keep your
-own validation receipt. See [Installer Trust](dream-server/docs/INSTALLER_TRUST.md)
-and [Forkability](dream-server/docs/FORKABILITY.md).
+**Stable consumption:** `v2.5.4` is the current stable release. `main` moves
+quickly. For forks, appliances, labs, or production-like installs, pin a tagged
+release or audited commit and keep your own validation receipt. See
+[Installer Trust](dream-server/docs/INSTALLER_TRUST.md) and
+[Forkability](dream-server/docs/FORKABILITY.md).
 
 ## Get Started
 

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -6,7 +6,7 @@
 # secure random secrets. This file documents all available variables.
 
 # Dream Server version (auto-set by installer, used by dream-cli for compat checks)
-# DREAM_VERSION=2.5.3
+# DREAM_VERSION=2.5.4
 
 # LiteLLM proxy API key for internal service auth
 # TARGET_API_KEY=not-needed

--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [2.5.4] - 2026-06-12
+
+### Fixed
+- Stable installs no longer depend on the removed upstream
+  `nousresearch/hermes-agent:sha-*` image tag. Hermes now defaults to the
+  retained `nousresearch/hermes-agent:v2026.5.16` image and keeps the
+  `HERMES_AGENT_IMAGE` / `HERMES_AGENT_IMAGE_FALLBACK` override path for
+  emergency registry hotfixes.
+- Stable-facing version metadata, docs, and the desktop installer default ref
+  now point at `v2.5.4` so new stable installs avoid the broken `v2.5.2` and
+  `v2.5.3` Hermes image pin.
+
+### Validation
+- `docker manifest inspect nousresearch/hermes-agent:v2026.5.16` succeeds.
+- Installer contracts lock the Hermes default image to a durable version tag
+  and fail if release-critical files reintroduce `nousresearch/hermes-agent:sha-*`.
+
 ## [2.5.3] - 2026-05-26
 
 ### Fixed

--- a/dream-server/docs/INSTALLER_TRUST.md
+++ b/dream-server/docs/INSTALLER_TRUST.md
@@ -29,7 +29,7 @@ By default the bootstrap follows `main`. To pin a release tag or branch, set
 `DREAMSERVER_REF` before running the script:
 
 ```bash
-DREAMSERVER_REF=v2.5.0 bash get-dream-server.sh
+DREAMSERVER_REF=v2.5.4 bash get-dream-server.sh
 ```
 
 ### Manual Source Install
@@ -38,7 +38,7 @@ For the most auditable path, clone a known ref yourself and run the installer
 from the checked-out source:
 
 ```bash
-git clone --depth 1 --branch v2.5.0 https://github.com/Light-Heart-Labs/DreamServer.git
+git clone --depth 1 --branch v2.5.4 https://github.com/Light-Heart-Labs/DreamServer.git
 cd DreamServer/dream-server
 ./install.sh
 ```
@@ -52,7 +52,7 @@ Windows users should install from a normal user PowerShell, not an elevated
 Administrator shell:
 
 ```powershell
-git clone --depth 1 --branch v2.5.0 https://github.com/Light-Heart-Labs/DreamServer.git
+git clone --depth 1 --branch v2.5.4 https://github.com/Light-Heart-Labs/DreamServer.git
 cd DreamServer\dream-server
 Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
 .\install.ps1
@@ -75,17 +75,20 @@ inspect it first:
 ```bash
 curl -fsSLO https://raw.githubusercontent.com/Light-Heart-Labs/DreamServer/main/dream-server/get-dream-server.sh
 less get-dream-server.sh
-DREAMSERVER_REF=v2.5.0 bash get-dream-server.sh
+DREAMSERVER_REF=v2.5.4 bash get-dream-server.sh
 ```
 
 On Windows, clone first and inspect `install.ps1` before running it:
 
 ```powershell
-git clone --depth 1 --branch v2.5.0 https://github.com/Light-Heart-Labs/DreamServer.git
+git clone --depth 1 --branch v2.5.4 https://github.com/Light-Heart-Labs/DreamServer.git
 cd DreamServer\dream-server
 notepad .\install.ps1
 .\install.ps1
 ```
+
+> `v2.5.2` and `v2.5.3` used an upstream Hermes Agent `sha-*` image tag that
+> was later pruned from Docker Hub. Use `v2.5.4` or newer for stable installs.
 
 ## Current Trust Boundary
 

--- a/dream-server/docs/RELEASE_CHANNELS.md
+++ b/dream-server/docs/RELEASE_CHANNELS.md
@@ -15,7 +15,7 @@ ecosystems move quickly. Treat each ref intentionally.
 ## Default Guidance
 
 - New users can follow the README quickstart.
-- Operators who want reproducibility should pin a release tag.
+- `v2.5.4` is the current stable tag for operators who want reproducibility.
 - Forks should either fork-and-pin or fork-and-mirror.
 - Hardware builders should treat upstream release receipts as evidence, then add
   their own validation receipt for local changes.

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -948,7 +948,7 @@ async def _lifespan(app: FastAPI):
 
 app = FastAPI(
     title="Dream Server Dashboard API",
-    version="2.5.3",
+    version="2.5.4",
     description="System status API for Dream Server Dashboard",
     lifespan=_lifespan,
 )

--- a/dream-server/installers/lib/constants.sh
+++ b/dream-server/installers/lib/constants.sh
@@ -14,7 +14,7 @@
 #   Change VERSION for custom builds. Add new color codes here.
 # ============================================================================
 
-VERSION="2.5.3"
+VERSION="2.5.4"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 
 # Source path utilities for cross-platform path resolution

--- a/dream-server/installers/macos/lib/constants.sh
+++ b/dream-server/installers/macos/lib/constants.sh
@@ -11,7 +11,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-DS_VERSION="2.5.3"
+DS_VERSION="2.5.4"
 
 # Install location - use shared path resolution if available.
 # constants.sh lives at two different depths depending on layout:

--- a/dream-server/installers/phases/06-directories.sh
+++ b/dream-server/installers/phases/06-directories.sh
@@ -519,7 +519,7 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
 # Tier: ${TIER} (${TIER_NAME})
 
 #=== Dream Server Version (used by dream-cli update for version-compat checks) ===
-DREAM_VERSION=${VERSION:-2.5.1}
+DREAM_VERSION=${VERSION:-2.5.4}
 
 #=== Network Binding ===
 # 127.0.0.1 = localhost only (secure default)

--- a/dream-server/installers/windows/lib/constants.ps1
+++ b/dream-server/installers/windows/lib/constants.ps1
@@ -10,7 +10,7 @@
 #   Change DS_VERSION for custom builds. Must match constants.sh VERSION.
 # ============================================================================
 
-$script:DS_VERSION = "2.5.1"
+$script:DS_VERSION = "2.5.4"
 
 # Install location (override via $env:DREAM_HOME)
 # NOTE: $(if ...) syntax required for PS 5.1 compatibility (bare if-as-expression is PS 7+ only)

--- a/dream-server/manifest.json
+++ b/dream-server/manifest.json
@@ -1,12 +1,12 @@
 {
   "schema_version": 2,
-  "dream_version": "2.5.3",
+  "dream_version": "2.5.4",
   "min_compatible_dream_version": "1.0.0",
   "manifestVersion": "1.0.0",
   "release": {
-    "version": "2.5.3",
+    "version": "2.5.4",
     "channel": "stable",
-    "date": "2026-05-26"
+    "date": "2026-06-12"
   },
   "compatibility": {
     "os": {

--- a/dream-server/tests/contracts/test-installer-contracts.sh
+++ b/dream-server/tests/contracts/test-installer-contracts.sh
@@ -132,6 +132,30 @@ for key in TTS_CPU_LIMIT TTS_CPU_RESERVATION WHISPER_CPU_LIMIT WHISPER_CPU_RESER
     || { echo "[FAIL] .env.schema.json missing bundled service CPU key: $key"; exit 1; }
 done
 
+echo "[contract] Hermes Agent image pin is durable and overrideable"
+hermes_default="nousresearch/hermes-agent:v2026.5.16"
+grep -qF "image: \${HERMES_AGENT_IMAGE:-${hermes_default}}" extensions/services/hermes/compose.yaml \
+  || { echo "[FAIL] Hermes compose must default to ${hermes_default} behind HERMES_AGENT_IMAGE"; exit 1; }
+grep -qF "\${HERMES_AGENT_IMAGE:-${hermes_default}}|HERMES" installers/phases/08-images.sh \
+  || { echo "[FAIL] image preflight must validate the same Hermes default used by compose"; exit 1; }
+grep -qF '"HERMES_AGENT_IMAGE_FALLBACK"' installers/phases/08-images.sh \
+  || { echo "[FAIL] Hermes image preflight must keep the fallback override path"; exit 1; }
+jq -e --arg image "$hermes_default" '
+  any(.entries[]?; .id == "hermes.agent" and .value == $image)
+  and any(.allow_variable_refs[]?; .path == "extensions/services/hermes/compose.yaml" and .default == $image)
+' config/dependency-lock.json >/dev/null \
+  || { echo "[FAIL] dependency-lock must record the durable Hermes image default"; exit 1; }
+if grep -R -n 'nousresearch/hermes-agent:sha-' \
+  .env.example .env.schema.json config/dependency-lock.json \
+  extensions/services/hermes installers/phases >/dev/null; then
+  echo "[FAIL] release-critical files must not pin upstream Hermes sha-* images"
+  grep -R -n 'nousresearch/hermes-agent:sha-' \
+    .env.example .env.schema.json config/dependency-lock.json \
+    extensions/services/hermes installers/phases || true
+  exit 1
+fi
+unset hermes_default
+
 echo "[contract] resolver scripts executable"
 for s in scripts/build-capability-profile.sh scripts/classify-hardware.sh scripts/load-backend-contract.sh scripts/resolve-compose-stack.sh scripts/preflight-engine.sh scripts/dream-doctor.sh scripts/simulate-installers.sh; do
   test -x "$s" || { echo "[FAIL] script not executable: $s"; exit 1; }

--- a/installer/src-tauri/src/installer.rs
+++ b/installer/src-tauri/src/installer.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 use std::thread;
 
 const REPO_URL: &str = "https://github.com/Light-Heart-Labs/DreamServer.git";
-const DEFAULT_INSTALL_REF: &str = "v2.5.0";
+const DEFAULT_INSTALL_REF: &str = "v2.5.4";
 
 fn install_ref() -> &'static str {
     option_env!("DREAMSERVER_INSTALL_REF").unwrap_or(DEFAULT_INSTALL_REF)


### PR DESCRIPTION
## Summary

Addresses #1544 by preparing the next stable stamp (`2.5.4`) from the already-repaired `release/2.5.x` line, where Hermes defaults to the retained upstream image tag:

- `nousresearch/hermes-agent:v2026.5.16`

This PR does not rewrite historical `v2.5.2` or `v2.5.3` tags. Instead, it makes `v2.5.4` the stable install target and documents that the older tags used a pruned upstream Hermes `sha-*` image.

## Changes

- Stamp stable metadata/docs from `2.5.3` to `2.5.4`.
- Point the desktop installer default ref at `v2.5.4`.
- Update installer-trust docs to use `v2.5.4` examples and warn about the broken `v2.5.2` / `v2.5.3` Hermes pin.
- Add an installer contract that fails if release-critical Hermes files reintroduce `nousresearch/hermes-agent:sha-*`.

## Validation

From a clean Tower2 clone of this branch:

- `python3 scripts/check-version-consistency.py` - PASS (`2.5.4`)
- `bash -n tests/contracts/test-installer-contracts.sh installers/phases/08-images.sh installers/phases/06-directories.sh installers/lib/constants.sh installers/macos/lib/constants.sh` - PASS
- `bash tests/contracts/test-installer-contracts.sh` - PASS (`34 passed`)
- `bash tests/test-linux-cloud-mode.sh` - PASS
- `docker manifest inspect nousresearch/hermes-agent:v2026.5.16` - PASS

## Risk

Low product-runtime risk. This is a stable stamp/docs/guardrail PR; the actual Hermes default image fix was already present on `release/2.5.x`. The behavioral change is that stable-facing metadata and the desktop installer default ref now point to `v2.5.4` instead of older stable tags.

## Follow-up

After merge, publish the `v2.5.4` tag/release from `release/2.5.x`, then close #1544 with the release receipt.