### PR TITLE
fix(installer): fail loud on Podman docker shims

### DIFF
--- a/dream-server/scripts/linux-install-preflight.sh
+++ b/dream-server/scripts/linux-install-preflight.sh
@@ -72,6 +72,28 @@ print(json.dumps({
 ' >>"$CHECKS_JSONL"
 }
 
+docker_cli_looks_like_podman() {
+    local docker_version=""
+    docker_version="$(docker --version 2>/dev/null || true)"
+    if printf '%s\n' "$docker_version" | grep -qi 'podman'; then
+        return 0
+    fi
+
+    # podman-docker commonly installs a docker-compatible shim. Dream Server
+    # currently relies on Docker Engine semantics, so the shim must fail loud.
+    local docker_path=""
+    docker_path="$(command -v docker 2>/dev/null || true)"
+    if [[ -n "$docker_path" ]] && command -v readlink >/dev/null 2>&1; then
+        local docker_real=""
+        docker_real="$(readlink -f "$docker_path" 2>/dev/null || true)"
+        case "$(basename "$docker_real")" in
+            podman|podman-docker) return 0 ;;
+        esac
+    fi
+
+    return 1
+}
+
 # --- Distro fingerprint (from /etc/os-release) ---
 DISTRO_ID=""
 DISTRO_VERSION_ID=""
@@ -106,6 +128,7 @@ else
 fi
 
 # --- Docker CLI ---
+DOCKER_IS_PODMAN=false
 if ! command -v docker >/dev/null 2>&1; then
     append_check "DOCKER_INSTALLED" "fail" \
         "Docker CLI not found in PATH" \
@@ -113,11 +136,23 @@ if ! command -v docker >/dev/null 2>&1; then
 else
     DV="$(docker --version 2>/dev/null | head -1 || true)"
     append_check "DOCKER_INSTALLED" "pass" "Docker CLI: ${DV:-present}" ""
+    if docker_cli_looks_like_podman; then
+        DOCKER_IS_PODMAN=true
+        append_check "DOCKER_ENGINE" "fail" \
+            "docker resolves to Podman compatibility mode, not Docker Engine" \
+            "Install Docker Engine and Docker Compose v2. Podman is not a supported Dream Server runtime yet; remove podman-docker or put Docker Engine first in PATH."
+    else
+        append_check "DOCKER_ENGINE" "pass" "Docker CLI appears to target Docker Engine" ""
+    fi
 fi
 
 # --- Docker daemon ---
 DOCKER_INFO_OK=false
-if command -v docker >/dev/null 2>&1; then
+if [[ "$DOCKER_IS_PODMAN" == true ]]; then
+    append_check "DOCKER_DAEMON" "fail" \
+        "Skipped Docker daemon probe because docker resolves to Podman" \
+        "Install Docker Engine; Dream Server does not currently support Podman as the container runtime."
+elif command -v docker >/dev/null 2>&1; then
     if docker info >/dev/null 2>&1; then
         DOCKER_INFO_OK=true
         append_check "DOCKER_DAEMON" "pass" "Docker daemon is reachable" ""
@@ -131,7 +166,11 @@ else
 fi
 
 # --- Docker Compose v2 / v1 ---
-if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+if [[ "$DOCKER_IS_PODMAN" == true ]]; then
+    append_check "COMPOSE_CLI" "fail" \
+        "Skipped Compose probe because docker resolves to Podman" \
+        "Install Docker Engine with the Docker Compose v2 plugin. podman compose is not a supported substitute for Dream Server installs yet."
+elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
     CV="$(docker compose version 2>/dev/null | head -1 || true)"
     append_check "COMPOSE_CLI" "pass" "Compose: $CV" ""
 elif command -v docker-compose >/dev/null 2>&1; then

--- a/dream-server/tests/test-linux-install-preflight.sh
+++ b/dream-server/tests/test-linux-install-preflight.sh
@@ -80,6 +80,50 @@ else
     fail "python3 not available — skipped JSON contract (unexpected on CI)"
 fi
 
+# Podman compatibility shims are intentionally not accepted as Docker Engine.
+if command -v python3 >/dev/null 2>&1; then
+    PODMAN_TMP="$(mktemp -d)"
+    cat >"$PODMAN_TMP/docker" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version)
+    echo "podman version 5.0.0"
+    ;;
+  *)
+    echo "podman shim called: $*" >&2
+    exit 125
+    ;;
+esac
+EOF
+    chmod +x "$PODMAN_TMP/docker"
+    PODMAN_JSON="$PODMAN_TMP/report.json"
+    if PATH="$PODMAN_TMP:$PATH" "$LP" --json >"$PODMAN_JSON" 2>/dev/null || true; then
+        :
+    fi
+    if python3 - <<PY
+import json
+path = "$PODMAN_JSON"
+with open(path, encoding="utf-8") as f:
+    report = json.load(f)
+checks = {c["id"]: c for c in report["checks"]}
+assert checks["DOCKER_INSTALLED"]["status"] == "pass"
+assert checks["DOCKER_ENGINE"]["status"] == "fail"
+assert checks["DOCKER_DAEMON"]["status"] == "fail"
+assert checks["COMPOSE_CLI"]["status"] == "fail"
+assert "Podman" in checks["DOCKER_ENGINE"]["message"]
+assert report["summary"]["exit_ok"] is False
+print("ok")
+PY
+    then
+        pass "Podman docker shim fails loud as unsupported runtime"
+    else
+        fail "Podman docker shim did not produce the expected fail-loud checks"
+    fi
+    rm -rf "$PODMAN_TMP"
+else
+    fail "python3 not available - skipped Podman shim contract (unexpected on CI)"
+fi
+
 # dream-preflight.sh delegates --install-env to linux-install-preflight
 if grep -q 'linux-install-preflight.sh' "$ROOT_PREFLIGHT" && grep -q '\-\-install-env' "$ROOT_PREFLIGHT"; then
     pass "dream-preflight.sh delegates --install-env to linux-install-preflight.sh"


### PR DESCRIPTION
## Summary

- make Linux install preflight detect when `docker` is a Podman compatibility shim
- fail loud with a clear Docker Engine requirement instead of letting unsupported Podman paths look partially valid
- add a regression contract that injects a fake Podman-flavored `docker` command and asserts the JSON report fails on `DOCKER_ENGINE`, `DOCKER_DAEMON`, and `COMPOSE_CLI`

## Why

User asked about Debian/Podman behavior. Dream Server currently relies on Docker Engine and Docker Compose semantics; Podman is not a supported runtime yet. This makes that policy explicit so fleet/preflight output does not accidentally imply Podman support.

## Validation

On Tower2, in an isolated Linux worktree based on current `origin/main`:

- `bash -n scripts/linux-install-preflight.sh`
- `bash -n tests/test-linux-install-preflight.sh`
- `bash tests/test-linux-install-preflight.sh` ? 8 passed, 0 failed
- `make test` ? passed, including Debian trixie Docker 29.2.1 downgrade contracts and the new Podman shim contract