### PR TITLE
fix(windows): repair stale bind-mounted config paths

### DIFF
--- a/dream-server/installers/windows/phases/05-docker.ps1
+++ b/dream-server/installers/windows/phases/05-docker.ps1
@@ -74,6 +74,26 @@ if ($dryRun) {
     }
     Write-AISuccess "Docker Compose available: $dockerComposeCmd"
 
+    # A reinstall can begin while Docker Desktop is still starting. If old Dream
+    # containers come back after the install tree was removed, file bind mounts
+    # may recreate missing host-side files as directories. Remove stale Dream
+    # containers while Docker is definitely available, before Phase 06 rewrites
+    # the bind-mounted install tree.
+    try {
+        $_dreamContainerNames = @(& docker ps -a --format "{{.Names}}" 2>$null | Where-Object { $_ -like "dream-*" })
+        if ($_dreamContainerNames.Count -gt 0) {
+            Write-AI "Stopping existing Dream containers before reinstall..."
+            $null = & docker rm -f @_dreamContainerNames 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Write-AISuccess "Stopped existing Dream containers"
+            } else {
+                Write-AIWarn "Could not remove all existing Dream containers; continuing with file-path repair."
+            }
+        }
+    } catch {
+        Write-AIWarn "Could not inspect existing Dream containers: $($_.Exception.Message)"
+    }
+
     # ── Compose file syntax validation ────────────────────────────────────────
     # Quick config check on the base compose file to catch syntax errors early.
     $_baseCompose = Join-Path $sourceRoot "docker-compose.base.yml"

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -77,10 +77,19 @@ foreach ($_d in $_dirs) {
 }
 Write-AISuccess "Created directory structure under $installDir"
 
-# Docker/PowerShell partial installs can leave directories where install-root
-# dotfiles must be regular files. Remove those malformed paths before robocopy
-# and .env generation, otherwise later reads fail with "access denied".
-foreach ($_expectedFileName in @(".env", ".env.example", ".env.schema.json")) {
+# Docker/PowerShell partial installs and stale Docker bind mounts can leave
+# directories where install-owned regular files must exist. Remove those
+# malformed paths before robocopy and config generation, otherwise later reads
+# fail with "access denied".
+$_expectedRegularFiles = @(
+    ".env",
+    ".env.example",
+    ".env.schema.json",
+    "extensions\services\hermes\cli-config.yaml.template",
+    "extensions\services\hermes\SOUL.md.template",
+    "data\persona\SOUL.md"
+)
+foreach ($_expectedFileName in $_expectedRegularFiles) {
     $_expectedFilePath = Join-Path $installDir $_expectedFileName
     if (Test-Path -LiteralPath $_expectedFilePath -PathType Container) {
         Remove-Item -LiteralPath $_expectedFilePath -Recurse -Force

--- a/dream-server/tests/test-windows-env-dotfile-recovery.sh
+++ b/dream-server/tests/test-windows-env-dotfile-recovery.sh
@@ -12,6 +12,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 PHASE02="$ROOT_DIR/installers/windows/phases/02-detection.ps1"
+PHASE05="$ROOT_DIR/installers/windows/phases/05-docker.ps1"
 PHASE06="$ROOT_DIR/installers/windows/phases/06-directories.ps1"
 ENVGEN="$ROOT_DIR/installers/windows/lib/env-generator.ps1"
 LLM_ENDPOINT="$ROOT_DIR/installers/windows/lib/llm-endpoint.ps1"
@@ -39,6 +40,7 @@ echo "=== Windows malformed dotfile recovery tests ==="
 echo ""
 
 [[ -f "$PHASE02" ]] && pass "Windows detection phase exists" || fail "Windows detection phase missing"
+[[ -f "$PHASE05" ]] && pass "Windows docker phase exists" || fail "Windows docker phase missing"
 [[ -f "$PHASE06" ]] && pass "Windows directories phase exists" || fail "Windows directories phase missing"
 [[ -f "$ENVGEN" ]] && pass "Windows env generator exists" || fail "Windows env generator missing"
 [[ -f "$LLM_ENDPOINT" ]] && pass "Windows LLM endpoint helper exists" || fail "Windows LLM endpoint helper missing"
@@ -47,9 +49,15 @@ check 'Test-Path -LiteralPath $existingEnvPath -PathType Leaf' "$PHASE02" "phase
 check 'Test-Path -LiteralPath $existingEnvPath -PathType Container' "$PHASE02" "phase 2 detects malformed .env directory"
 check 'Ignoring malformed .env directory from a previous partial install.' "$PHASE02" "phase 2 warns and defaults profile for malformed .env"
 
-check '@(".env", ".env.example", ".env.schema.json")' "$PHASE06" "phase 6 owns only install-root dotfile cleanup"
+check 'docker rm -f @_dreamContainerNames' "$PHASE05" "phase 5 removes stale Dream containers after Docker is available"
+check 'file bind mounts' "$PHASE05" "phase 5 documents stale bind-mount directory hazard"
+
+check '$_expectedRegularFiles = @(' "$PHASE06" "phase 6 uses explicit owned regular-file cleanup list"
+check 'extensions\services\hermes\cli-config.yaml.template' "$PHASE06" "phase 6 repairs malformed Hermes config template directory"
+check 'extensions\services\hermes\SOUL.md.template' "$PHASE06" "phase 6 repairs malformed Hermes SOUL template directory"
+check 'data\persona\SOUL.md' "$PHASE06" "phase 6 repairs malformed generated persona file directory"
 check 'Test-Path -LiteralPath $_expectedFilePath -PathType Container' "$PHASE06" "phase 6 detects dotfile directories"
-check 'Remove-Item -LiteralPath $_expectedFilePath -Recurse -Force' "$PHASE06" "phase 6 removes malformed dotfile directories before copy"
+check 'Remove-Item -LiteralPath $_expectedFilePath -Recurse -Force' "$PHASE06" "phase 6 removes malformed regular-file directories before copy"
 
 check 'Test-Path -LiteralPath $envPath -PathType Container' "$ENVGEN" "env generator detects malformed .env directory"
 check 'Remove-Item -LiteralPath $envPath -Recurse -Force' "$ENVGEN" "env generator removes malformed .env directory before writing"


### PR DESCRIPTION
## Summary

- remove stale `dream-*` containers after Docker Desktop is reachable during Windows installs, before Phase 06 rewrites bind-mounted files
- repair malformed install-owned regular-file paths that may have become directories during a partial reinstall or stale bind mount
- extend the Windows malformed-dotfile regression to cover Hermes config/persona paths and stale container cleanup

## Why

A Windows-laptop fleet reinstall failed when `extensions/services/hermes/cli-config.yaml.template` existed as a directory in the install target. The old Dream containers were still running when Docker Desktop came back online, and the Hermes compose bind mount can recreate a missing host-side file path as a directory. Phase 06 then tried to read the template as a file and crashed with `UnauthorizedAccessException`.

## Validation

- PowerShell parser: `05-docker.ps1` and `06-directories.ps1` parse cleanly
- `tests/test-windows-env-dotfile-recovery.sh` via Git Bash: 22 passed, 0 failed
- Focused live Windows-laptop reinstall on `fix/windows-reinstall-bind-path-repair`: install exit 0, readiness 15/15, LLM serving verified
- Focused Windows-laptop post-install phases on same run dir: verify PASS, dashboard PASS, Hermes PASS, capabilities PASS

Live proof run dir: `/home/michael/dream-fleet-test/runs/2026-06-12T21-26-00Z-windows-bind-repair`