### PR TITLE
Fix dashboard status for host-managed services

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -23,6 +23,7 @@ import re
 import secrets
 import shutil
 import signal
+import socket
 import stat as stat_mod
 import subprocess
 import sys
@@ -32,6 +33,7 @@ from datetime import datetime, timezone
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from pathlib import Path
 from socketserver import ThreadingMixIn
+from urllib.parse import parse_qs, urlparse
 
 VERSION = "1.0.0"
 DREAM_VERSION = VERSION
@@ -1275,26 +1277,74 @@ class AgentHandler(BaseHTTPRequestHandler):
         logger.info(fmt, *args)
 
     def do_GET(self):
-        if self.path == "/health":
+        parsed = urlparse(self.path)
+        path = parsed.path
+        if path == "/health":
             json_response(self, 200, {"status": "ok", "version": VERSION})
-        elif self.path == "/v1/service/stats":
+        elif path == "/v1/service/stats":
             self._handle_service_stats()
-        elif self.path == "/v1/model/list":
+        elif path == "/v1/model/list":
             self._handle_model_list()
-        elif self.path == "/v1/model/status":
+        elif path == "/v1/model/status":
             self._handle_model_status()
-        elif self.path == "/v1/network/wifi-scan":
+        elif path == "/v1/network/wifi-scan":
             self._handle_network_wifi_scan()
-        elif self.path == "/v1/network/status":
+        elif path == "/v1/network/status":
             self._handle_network_status()
-        elif self.path == "/v1/tailscale/status":
+        elif path == "/v1/tailscale/status":
             self._handle_tailscale_status()
-        elif self.path == "/v1/ap-mode/status":
+        elif path == "/v1/ap-mode/status":
             self._handle_ap_mode_status()
-        elif self.path == "/v1/update/status":
+        elif path == "/v1/update/status":
             self._handle_update_status()
+        elif path == "/v1/host/port":
+            self._handle_host_port_status(parse_qs(parsed.query))
         else:
             json_response(self, 404, {"error": "Not found"})
+
+    def _handle_host_port_status(self, query: dict[str, list[str]]):
+        """Return whether a host-local TCP port is reachable.
+
+        Dashboard-api runs in Docker, so it cannot reliably probe services that
+        intentionally bind to the host loopback interface (for example
+        OpenCode). Keep this endpoint local-only to avoid turning the host-agent
+        into a network scanner.
+        """
+        if not check_auth(self):
+            return
+
+        host = (query.get("host") or ["127.0.0.1"])[0]
+        if host not in {"127.0.0.1", "localhost", "::1"}:
+            json_response(self, 400, {"error": "host must be loopback"})
+            return
+
+        try:
+            port = int((query.get("port") or [""])[0])
+        except ValueError:
+            json_response(self, 400, {"error": "port must be an integer"})
+            return
+        if port < 1 or port > 65535:
+            json_response(self, 400, {"error": "port out of range"})
+            return
+
+        started = time.monotonic()
+        reachable = False
+        error = ""
+        try:
+            with socket.create_connection((host, port), timeout=2):
+                reachable = True
+        except OSError as exc:
+            error = str(exc)
+
+        payload = {
+            "host": host,
+            "port": port,
+            "reachable": reachable,
+            "response_time_ms": round((time.monotonic() - started) * 1000, 1),
+        }
+        if error:
+            payload["error"] = error[:200]
+        json_response(self, 200, payload)
 
     def _write_tailscale_status_payload(self, payload: dict, source: str):
         """Distill `tailscale status --json` into the dashboard response."""

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -114,6 +114,44 @@ async def _check_tailscale_health(service_id: str, config: dict) -> ServiceStatu
     return _service_status_from_config(service_id, config, "unhealthy")
 
 
+async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceStatus:
+    """Check a host-managed service through the authenticated host-agent.
+
+    Host-systemd services such as OpenCode usually bind to host loopback. From
+    inside Docker, probing ``localhost`` checks the dashboard-api container
+    instead of the real host, so ask the host-agent to prove the local port is
+    open. If the proof is unavailable, fail closed so the dashboard does not
+    launch users into a dead localhost URL.
+    """
+    port = int(config.get("health_port") or config.get("external_port") or config.get("port") or 0)
+    if port <= 0:
+        return _service_status_from_config(service_id, config, "not_deployed")
+
+    headers = {"Authorization": f"Bearer {DREAM_AGENT_KEY}"} if DREAM_AGENT_KEY else {}
+    try:
+        client = await _get_httpx_client()
+        resp = await client.get(
+            f"{AGENT_URL}/v1/host/port",
+            params={"host": "127.0.0.1", "port": port},
+            headers=headers,
+        )
+        if resp.status_code >= 400:
+            return _service_status_from_config(service_id, config, "down")
+        payload = resp.json()
+    except (httpx.HTTPError, httpx.TimeoutException, ValueError, OSError):
+        return _service_status_from_config(service_id, config, "down")
+
+    status = "healthy" if payload.get("reachable") else "not_deployed"
+    return ServiceStatus(
+        id=service_id,
+        name=config["name"],
+        port=config["port"],
+        external_port=config.get("external_port", config["port"]),
+        status=status,
+        response_time_ms=payload.get("response_time_ms"),
+    )
+
+
 # --- Token Tracking ---
 
 _TOKEN_FILE = Path(DATA_DIR) / "token_counter.json"
@@ -406,10 +444,7 @@ async def check_service_health(
     stall the entire Extensions page.
     """
     if config.get("type") == "host-systemd":
-        # Host-systemd services bind to 127.0.0.1 and are unreachable from
-        # inside Docker.  The installer manages them via systemd (auto-restart
-        # on failure), so treat them as healthy when configured.
-        return _service_status_from_config(service_id, config, "healthy")
+        return await _check_host_systemd_health(service_id, config)
 
     if config.get("host_network") and int(config.get("port") or 0) <= 0:
         if service_id == "tailscale":

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -418,10 +418,29 @@ async def get_llama_context_size(model_hint: Optional[str] = None) -> Optional[i
 _services_cache: Optional[list] = None  # list[ServiceStatus], set by poll loop
 
 
+def _normalize_cached_service_status(status: ServiceStatus) -> ServiceStatus:
+    """Avoid treating absent optional host-managed tools as broken services."""
+    config = SERVICES.get(status.id, {})
+    if (
+        status.status == "down"
+        and config.get("type") == "host-systemd"
+        and not config.get("required", False)
+    ):
+        return ServiceStatus(
+            id=status.id,
+            name=status.name,
+            port=status.port,
+            external_port=status.external_port,
+            status="not_deployed",
+            response_time_ms=status.response_time_ms,
+        )
+    return status
+
+
 def set_services_cache(statuses: list) -> None:
     """Store latest health check results (called by background poll)."""
     global _services_cache
-    _services_cache = statuses
+    _services_cache = [_normalize_cached_service_status(status) for status in statuses]
 
 
 def get_cached_services() -> Optional[list]:

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -729,14 +729,56 @@ class TestGetLifetimeTokens:
 class TestCheckServiceHealthSystemd:
 
     @pytest.mark.asyncio
-    async def test_host_systemd_returns_healthy(self):
+    async def test_host_systemd_returns_healthy_when_host_agent_proves_port(self, monkeypatch):
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {"reachable": True, "response_time_ms": 12.3}
+
+        class FakeClient:
+            async def get(self, url, *, params=None, headers=None):
+                assert url.endswith("/v1/host/port")
+                assert params == {"host": "127.0.0.1", "port": 3003}
+                return FakeResponse()
+
+        async def fake_client():
+            return FakeClient()
+
+        monkeypatch.setattr("helpers._get_httpx_client", fake_client)
+
         config = {
             "name": "opencode", "port": 3003, "external_port": 3003,
             "health": "/health", "host": "localhost", "type": "host-systemd",
         }
         result = await check_service_health("opencode", config)
         assert result.status == "healthy"
-        assert result.response_time_ms is None
+        assert result.response_time_ms == 12.3
+
+    @pytest.mark.asyncio
+    async def test_host_systemd_returns_not_deployed_when_host_port_closed(self, monkeypatch):
+        class FakeResponse:
+            status_code = 200
+
+            def json(self):
+                return {"reachable": False, "response_time_ms": 2.0}
+
+        class FakeClient:
+            async def get(self, url, *, params=None, headers=None):
+                return FakeResponse()
+
+        async def fake_client():
+            return FakeClient()
+
+        monkeypatch.setattr("helpers._get_httpx_client", fake_client)
+
+        config = {
+            "name": "opencode", "port": 3003, "external_port": 3003,
+            "health": "/health", "host": "localhost", "type": "host-systemd",
+        }
+        result = await check_service_health("opencode", config)
+        assert result.status == "not_deployed"
+        assert result.response_time_ms == 2.0
 
 
 # --- get_model_info error branch ---

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -706,7 +706,50 @@ class TestServicesCache:
         assert get_cached_services() is None
         fake = [ServiceStatus(id="s", name="S", port=80, external_port=80, status="healthy")]
         set_services_cache(fake)
-        assert get_cached_services() is fake
+        assert get_cached_services() == fake
+
+    def test_optional_host_systemd_down_is_cached_as_not_deployed(self, monkeypatch):
+        import helpers
+        monkeypatch.setattr(helpers, "_services_cache", None)
+        monkeypatch.setattr(helpers, "SERVICES", {
+            "opencode": {
+                "name": "OpenCode (IDE)",
+                "port": 3003,
+                "external_port": 3003,
+                "health": "/",
+                "host": "localhost",
+                "type": "host-systemd",
+                "category": "optional",
+            },
+            "dashboard-api": {
+                "name": "Dashboard API",
+                "port": 3002,
+                "external_port": 3002,
+                "health": "/health",
+                "host": "localhost",
+            },
+        })
+
+        set_services_cache([
+            ServiceStatus(
+                id="opencode",
+                name="OpenCode (IDE)",
+                port=3003,
+                external_port=3003,
+                status="down",
+            ),
+            ServiceStatus(
+                id="dashboard-api",
+                name="Dashboard API",
+                port=3002,
+                external_port=3002,
+                status="down",
+            ),
+        ])
+
+        cached = {service.id: service for service in get_cached_services()}
+        assert cached["opencode"].status == "not_deployed"
+        assert cached["dashboard-api"].status == "down"
 
 
 # --- _get_lifetime_tokens ---


### PR DESCRIPTION
## Summary

- Add an authenticated host-agent loopback port probe for host-managed services.
- Make dashboard-api verify host-systemd service ports instead of assuming they are healthy.
- Keep optional host tools like OpenCode disabled/not_deployed when their local port is closed, so the dashboard does not link to a dead localhost URL.

## Validation

- `python3 -m py_compile bin/dream-host-agent.py extensions/services/dashboard-api/helpers.py`
- Direct asyncio behavioral check: reachable host port -> healthy; closed host port -> not_deployed.
- Local Windows live proof: `127.0.0.1:3003` closed, `/v1/host/port` returned `reachable:false`, dashboard `/api/status` reported `opencode:not_deployed` and `countsAsIssue:false`.

## Notes

The full ad-hoc helper test file needs `pytest-asyncio` in the Tower2 scratch environment; the new async behavior was validated directly and should run under normal CI.
