### PR TITLE
Fix Windows Lemonade active model reloads

### DIFF
--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -3434,6 +3434,18 @@ class AgentHandler(BaseHTTPRequestHandler):
             env_pre = load_env(env_path)
             gpu_backend = env_pre.get("GPU_BACKEND", "nvidia")
             windows_host_lemonade = _is_windows_host_lemonade(env_pre)
+            windows_lemonade_already_serving = False
+            if windows_host_lemonade and env_pre.get("GGUF_FILE") == gguf_file:
+                lemonade_port = env_pre.get("AMD_INFERENCE_PORT", "8080") or "8080"
+                windows_lemonade_already_serving = _lemonade_completion_ready(
+                    "127.0.0.1", lemonade_port, gguf_file,
+                )
+                if windows_lemonade_already_serving:
+                    logger.info(
+                        "Windows Lemonade is already serving %s; refreshing configs "
+                        "without restarting native Lemonade",
+                        gguf_file,
+                    )
             runtime_profile = _select_runtime_profile(model, env_pre)
             runtime_env = {}
             if runtime_profile:
@@ -3574,7 +3586,8 @@ class AgentHandler(BaseHTTPRequestHandler):
             _in_container = bool(os.environ.get("DREAM_HOST_INSTALL_DIR"))
 
             if windows_host_lemonade:
-                _restart_windows_lemonade(env)
+                if not windows_lemonade_already_serving:
+                    _restart_windows_lemonade(env)
             elif gpu_backend == "apple":
                 # macOS: manage native llama-server process via PID file
                 pid_file = INSTALL_DIR / "data" / ".llama-server.pid"
@@ -3849,6 +3862,30 @@ def _send_lemonade_warmup(host: str, port: str, gguf_file: str, attempt: int) ->
     except subprocess.TimeoutExpired:
         pass
     return False
+
+
+def _lemonade_completion_ready(host: str, port: str, gguf_file: str) -> bool:
+    """Return True when Lemonade can complete against the requested GGUF."""
+    model_id = f"extra.{gguf_file}"
+    url = f"http://{host}:{port}/api/v1/chat/completions"
+    payload = json.dumps({
+        "model": model_id,
+        "messages": [{"role": "user", "content": "reply ok"}],
+        "max_tokens": 1,
+        "temperature": 0,
+    })
+    try:
+        result = subprocess.run(
+            ["curl", "-sf", "--max-time", "30", "-X", "POST", url,
+             "-H", "Content-Type: application/json", "-d", payload],
+            capture_output=True, text=True, timeout=35,
+        )
+        if result.returncode != 0:
+            return False
+        data = json.loads(result.stdout or "{}")
+        return bool(data.get("choices"))
+    except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError):
+        return False
 
 
 def _is_windows_host_lemonade(env: dict) -> bool:

--- a/dream-server/extensions/services/dashboard-api/routers/models.py
+++ b/dream-server/extensions/services/dashboard-api/routers/models.py
@@ -30,6 +30,7 @@ from performance_oracle import (
     find_catalog_model,
     load_model_catalog,
     model_files_dir,
+    read_env_file_value,
     read_env_value,
 )
 from security import verify_api_key
@@ -198,7 +199,11 @@ def _already_active_model(model_id: str, model: dict) -> tuple[bool, str | None]
         return False, None
     if _read_active_model() != gguf_file:
         return False, None
-    if read_env_value("LLM_MODEL", INSTALL_DIR) not in {model.get("llm_model_name"), model_id}:
+    configured_llm = (
+        read_env_file_value("LLM_MODEL", INSTALL_DIR)
+        or read_env_value("LLM_MODEL", INSTALL_DIR)
+    )
+    if not (_model_name_tokens(configured_llm) & _catalog_model_tokens(model)):
         return False, None
     if not (Path(DATA_DIR) / "models" / gguf_file).exists():
         return False, None
@@ -433,6 +438,20 @@ async def _fetch_llama_loaded_model(host: str, port: int, api_prefix: str) -> st
                 status = model.get("status", {})
                 if isinstance(status, dict) and status.get("value") == "loaded":
                     return model.get("id")
+            desired_tokens = (
+                _model_name_tokens(_read_active_model())
+                | _model_name_tokens(read_env_value("LLM_MODEL", INSTALL_DIR))
+            )
+            if api_prefix == "/api/v1" and desired_tokens:
+                for model in data:
+                    model_tokens = _model_name_tokens(model.get("id"))
+                    model_tokens.update(_model_name_tokens(model.get("checkpoint")))
+                    checkpoints = model.get("checkpoints")
+                    if isinstance(checkpoints, dict):
+                        for checkpoint in checkpoints.values():
+                            model_tokens.update(_model_name_tokens(checkpoint))
+                    if desired_tokens & model_tokens:
+                        return model.get("id")
             if data and data[0].get("id"):
                 return data[0]["id"]
         except (httpx.HTTPError, ValueError):

--- a/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -19,6 +19,7 @@ _spec.loader.exec_module(_mod)
 
 _check_lemonade_health = _mod._check_lemonade_health
 _send_lemonade_warmup = _mod._send_lemonade_warmup
+_lemonade_completion_ready = _mod._lemonade_completion_ready
 _write_lemonade_config = _mod._write_lemonade_config
 _patch_hermes_model_config = _mod._patch_hermes_model_config
 _compose_restart_llama_server = _mod._compose_restart_llama_server
@@ -107,6 +108,42 @@ class TestSendLemonadeWarmup:
         monkeypatch.setattr(subprocess, "run", fake_run)
         _send_lemonade_warmup("dream-llama-server", "8080", "model.gguf", 0)
         assert "http://dream-llama-server:8080/api/v1/chat/completions" in calls[0]
+
+
+class TestLemonadeCompletionReady:
+
+    def test_success_when_completion_has_choices(self, monkeypatch):
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout='{"choices":[{"message":{"content":"ok"}}]}',
+                stderr="",
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert _lemonade_completion_ready("127.0.0.1", "8080", "model.gguf") is True
+        assert "http://127.0.0.1:8080/api/v1/chat/completions" in calls[0]
+        payload = calls[0][calls[0].index("-d") + 1]
+        assert '"extra.model.gguf"' in payload
+
+    def test_false_on_nonzero_exit(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert _lemonade_completion_ready("127.0.0.1", "8080", "model.gguf") is False
+
+    def test_false_on_invalid_json(self, monkeypatch):
+        def fake_run(cmd, **kwargs):
+            return subprocess.CompletedProcess(cmd, 0, stdout="not-json", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert _lemonade_completion_ready("127.0.0.1", "8080", "model.gguf") is False
 
 
 # --- _write_lemonade_config ---
@@ -454,6 +491,61 @@ class TestModelActivateRollback:
         assert "api_key: sk-inline-from-env-file-67890" in content
         assert "api_key: sk-lemonade" not in content
         assert "enable_thinking: false" in content
+
+    def test_windows_lemonade_already_serving_skips_native_restart(
+        self, tmp_path, monkeypatch,
+    ):
+        install_dir, env_path, _env_text, _models_ini, _ini_text, lemonade_yaml, _yaml_text = (
+            _write_model_activation_fixture(
+                tmp_path,
+                gpu_backend="amd",
+                lemonade=True,
+                lemonade_api_key="sk-inline-from-env-file-67890",
+            )
+        )
+        env_path.write_text(
+            "GPU_BACKEND=amd\n"
+            "LLM_BACKEND=lemonade\n"
+            "AMD_INFERENCE_RUNTIME=lemonade\n"
+            "AMD_INFERENCE_LOCATION=host\n"
+            "AMD_INFERENCE_PORT=8080\n"
+            "GGUF_FILE=new-model.gguf\n"
+            "LLM_MODEL=new-model\n"
+            "CTX_SIZE=4096\n"
+            "LITELLM_LEMONADE_API_KEY=sk-inline-from-env-file-67890\n",
+            encoding="utf-8",
+        )
+
+        calls = []
+
+        def fake_run(cmd, **_kwargs):
+            calls.append(cmd)
+            stdout = (
+                '{"status": "ok", "model_loaded": "extra.new-model.gguf"}'
+                if cmd and cmd[0] == "curl"
+                else ""
+            )
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        def fail_restart(_env):
+            raise AssertionError("native Lemonade restart should be skipped")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.delenv("DREAM_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.delenv("LITELLM_LEMONADE_API_KEY", raising=False)
+        monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(_mod, "_lemonade_completion_ready", lambda *_args: True)
+        monkeypatch.setattr(_mod, "_restart_windows_lemonade", fail_restart)
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "target-model")
+
+        assert handler.response_code == 200
+        content = lemonade_yaml.read_text(encoding="utf-8")
+        assert "model: openai/extra.new-model.gguf" in content
+        assert ["docker", "restart", "dream-litellm"] in calls
 
     def test_activation_patches_hermes_configs_and_restarts_hermes(self, tmp_path, monkeypatch):
         install_dir, _env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (

--- a/dream-server/extensions/services/dashboard-api/tests/test_models.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_models.py
@@ -177,8 +177,6 @@ def test_already_active_model_uses_env_file_before_stale_process_env(
     monkeypatch,
     tmp_path,
 ):
-    import routers.models as models_router
-
     models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
     (install_dir / ".env").write_text(
         "GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf\n"

--- a/dream-server/extensions/services/dashboard-api/tests/test_models.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_models.py
@@ -103,6 +103,112 @@ def test_fetch_loaded_model_falls_back_to_models_when_lemonade_health_empty(monk
     ]
 
 
+def test_fetch_loaded_model_prefers_configured_lemonade_gguf_over_catalog_first(
+    monkeypatch,
+    tmp_path,
+):
+    import routers.models as models_router
+
+    seen_urls: list[str] = []
+    install_dir = tmp_path / "dream-server"
+    install_dir.mkdir()
+    (install_dir / ".env").write_text(
+        "GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf\n"
+        "LLM_MODEL=qwen3.6-35b-a3b-ud-q4\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models_router, "INSTALL_DIR", str(install_dir))
+    monkeypatch.setattr(models_router, "_ENV_PATH", install_dir / ".env")
+
+    class _Response:
+        def __init__(self, payload):
+            self.payload = payload
+
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return self.payload
+
+    class _Client:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url):
+            seen_urls.append(url)
+            if url.endswith("/health"):
+                return _Response({"status": "ok", "model_loaded": None})
+            return _Response({
+                "data": [
+                    {"id": "Qwen3-Coder-Next-GGUF", "downloaded": True},
+                    {
+                        "id": "extra.Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                        "checkpoint": "C:\\users\\conta\\dream-server\\data\\models\\Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                        "downloaded": True,
+                    },
+                ],
+            })
+
+    monkeypatch.setenv("LLM_URL", "http://host.docker.internal:8080")
+    monkeypatch.setattr(models_router.httpx, "AsyncClient", _Client)
+
+    loop = asyncio.new_event_loop()
+    try:
+        result = loop.run_until_complete(
+            models_router._fetch_llama_loaded_model("llama-server", 8080, "/api/v1")
+        )
+    finally:
+        loop.close()
+
+    assert result == "extra.Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+    assert seen_urls == [
+        "http://host.docker.internal:8080/api/v1/health",
+        "http://host.docker.internal:8080/api/v1/models",
+    ]
+
+
+def test_already_active_model_uses_env_file_before_stale_process_env(
+    monkeypatch,
+    tmp_path,
+):
+    import routers.models as models_router
+
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    (install_dir / ".env").write_text(
+        "GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf\n"
+        "LLM_MODEL=qwen3.6-35b-a3b\n",
+        encoding="utf-8",
+    )
+    model_file = data_dir / "models" / "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+    model_file.parent.mkdir(parents=True, exist_ok=True)
+    model_file.write_text("model", encoding="utf-8")
+    monkeypatch.setenv("LLM_MODEL", "qwen3.5-2b")
+    monkeypatch.setattr(
+        models_router,
+        "_fetch_loaded_model_sync",
+        lambda: "extra.Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+    )
+    monkeypatch.setattr(models_router, "_loaded_model_backend_ready_sync", lambda _model: True)
+
+    already_active, loaded_model = models_router._already_active_model(
+        "qwen3.6-35b-a3b-ud-q4",
+        {
+            "id": "qwen3.6-35b-a3b-ud-q4",
+            "gguf_file": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+            "llm_model_name": "qwen3.6-35b-a3b",
+        },
+    )
+
+    assert already_active is True
+    assert loaded_model == "extra.Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+
+
 def test_get_gpu_vram_returns_none_on_nvml_error(monkeypatch):
     """Operational NVML failures should degrade to unknown GPU rather than 500."""
 


### PR DESCRIPTION
## Summary

- Avoid restarting native Windows Lemonade when the requested GGUF is already the active, completing model.
- Prefer the file-backed `.env` LLM model over stale dashboard-api process environment when deciding whether a model is already active.
- Make Lemonade model listing prefer Dream Server's configured GGUF instead of arbitrary built-in catalog rows.

## Validation

- `python3 -m py_compile bin/dream-host-agent.py extensions/services/dashboard-api/routers/models.py`
- `python3 -m pytest extensions/services/dashboard-api/tests/test_model_activate.py extensions/services/dashboard-api/tests/test_models.py -q` -> 49 passed
- Focused Strixy Windows run from this branch: install exit 0; dashboard model load returned `already_active` for the serving bootstrap model instead of restarting Lemonade; follow-up verify/capabilities passed after harness active-GGUF selection fix.

## Risk

Scoped to Windows/native Lemonade model activation and dashboard model selection. Managed Docker llama-server paths keep their existing restart/load behavior.