### PR TITLE
test(installer): reject ephemeral Docker sha tags

### DIFF
--- a/dream-server/scripts/check-dependency-pins.py
+++ b/dream-server/scripts/check-dependency-pins.py
@@ -25,7 +25,7 @@ VAR_RE = re.compile(
     r"\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?:(?P<op>:-|-)(?P<default>[^}]+))?\}"
     r"|\$(?P<plain>[A-Za-z_][A-Za-z0-9_]*)"
 )
-EPHEMERAL_SHA_TAG_RE = re.compile(r"^sha-[0-9a-f]{7,40}$", re.IGNORECASE)
+EPHEMERAL_SHA_TAG_RE = re.compile(r"^sha-[0-9a-f]{7,64}$", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -59,8 +59,8 @@ def _clean_value(value: str) -> str:
     return value.strip()
 
 
-def _rel(path: Path) -> str:
-    return path.relative_to(ROOT).as_posix()
+def _rel(path: Path, root: Path = ROOT) -> str:
+    return path.relative_to(root).as_posix()
 
 
 def _resolve_vars(value: str, defaults: dict[str, str]) -> str:
@@ -76,7 +76,7 @@ def _resolve_vars(value: str, defaults: dict[str, str]) -> str:
     return VAR_RE.sub(replace, value)
 
 
-def _compose_image_refs(path: Path) -> list[ImageRef]:
+def _compose_image_refs(path: Path, root: Path = ROOT) -> list[ImageRef]:
     refs: list[ImageRef] = []
     for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
         match = IMAGE_RE.match(_strip_inline_comment(line))
@@ -85,7 +85,7 @@ def _compose_image_refs(path: Path) -> list[ImageRef]:
         raw = _clean_value(match.group("value"))
         refs.append(
             ImageRef(
-                path=_rel(path),
+                path=_rel(path, root),
                 line=line_no,
                 raw=raw,
                 value=_resolve_vars(raw, {}),
@@ -107,7 +107,7 @@ def _dockerfile_from_value(line: str) -> str | None:
     return _clean_value(tokens[0])
 
 
-def _dockerfile_image_refs(path: Path) -> list[ImageRef]:
+def _dockerfile_image_refs(path: Path, root: Path = ROOT) -> list[ImageRef]:
     refs: list[ImageRef] = []
     defaults: dict[str, str] = {}
     for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
@@ -120,7 +120,7 @@ def _dockerfile_image_refs(path: Path) -> list[ImageRef]:
             continue
         refs.append(
             ImageRef(
-                path=_rel(path),
+                path=_rel(path, root),
                 line=line_no,
                 raw=raw,
                 value=_resolve_vars(raw, defaults),
@@ -130,10 +130,9 @@ def _dockerfile_image_refs(path: Path) -> list[ImageRef]:
     return refs
 
 
-def candidate_files(root: Path = ROOT) -> list[Path]:
-    files: set[Path] = set(root.glob("docker-compose*.yml"))
-    files.update(root.glob("docker-compose*.yaml"))
-    for base in (root / "installers", root / "extensions" / "services"):
+def _image_ref_files(bases: Iterable[Path]) -> set[Path]:
+    files: set[Path] = set()
+    for base in bases:
         if not base.exists():
             continue
         for path in base.rglob("*"):
@@ -144,17 +143,37 @@ def candidate_files(root: Path = ROOT) -> list[Path]:
                 "docker-compose"
             ):
                 files.add(path)
+    return files
+
+
+def candidate_files(root: Path = ROOT) -> list[Path]:
+    files: set[Path] = set(root.glob("docker-compose*.yml"))
+    files.update(root.glob("docker-compose*.yaml"))
+    files.update(_image_ref_files((root / "installers", root / "extensions" / "services")))
     return sorted(files)
 
 
-def discover_image_refs(root: Path = ROOT) -> list[ImageRef]:
+def extension_library_candidate_files(root: Path = ROOT) -> list[Path]:
+    files = _image_ref_files((root / "extensions" / "library" / "services",))
+    return sorted(files)
+
+
+def _image_refs_from_files(files: Iterable[Path], root: Path) -> list[ImageRef]:
     refs: list[ImageRef] = []
-    for path in candidate_files(root):
+    for path in files:
         if path.name.startswith("Dockerfile"):
-            refs.extend(_dockerfile_image_refs(path))
+            refs.extend(_dockerfile_image_refs(path, root))
         else:
-            refs.extend(_compose_image_refs(path))
+            refs.extend(_compose_image_refs(path, root))
     return refs
+
+
+def discover_image_refs(root: Path = ROOT) -> list[ImageRef]:
+    return _image_refs_from_files(candidate_files(root), root)
+
+
+def discover_extension_library_image_refs(root: Path = ROOT) -> list[ImageRef]:
+    return _image_refs_from_files(extension_library_candidate_files(root), root)
 
 
 def _key(item: dict[str, object]) -> tuple[str, str]:
@@ -184,6 +203,14 @@ def _is_variable_ref(value: str) -> bool:
 def _is_ephemeral_sha_tag(value: str) -> bool:
     tag = _image_tag(value)
     return tag is not None and EPHEMERAL_SHA_TAG_RE.match(tag) is not None
+
+
+def _ephemeral_sha_tag_error(ref: ImageRef) -> str:
+    location = f"{ref.path}:{ref.line}"
+    return (
+        f"{location}: ephemeral sha-* image tags are not release-stable; "
+        f"pin to a retained version tag or @sha256 digest: {ref.value}"
+    )
 
 
 def _arg_default_present(path: Path, arg: str, default: str) -> bool:
@@ -288,10 +315,7 @@ def validate_refs(refs: Iterable[ImageRef], lock: dict[str, object], root: Path 
                 errors.append(f"{location}: latest tag requires allow_latest: {ref.value}")
 
         if _is_ephemeral_sha_tag(ref.value) and not _has_digest(ref.value):
-            errors.append(
-                f"{location}: ephemeral sha-* image tags are not release-stable; "
-                f"pin to a retained version tag or @sha256 digest: {ref.value}"
-            )
+            errors.append(_ephemeral_sha_tag_error(ref))
 
         if (ref.path, ref.value) not in entry_keys and (ref.path, ref.value) not in latest_allow:
             errors.append(f"{location}: image ref is not recorded in dependency-lock.json: {ref.value}")
@@ -300,6 +324,14 @@ def validate_refs(refs: Iterable[ImageRef], lock: dict[str, object], root: Path 
         if (path, value) not in discovered_keys:
             errors.append(f"lock entry is stale or undiscovered: {path} -> {value}")
 
+    return errors
+
+
+def validate_ephemeral_sha_tags(refs: Iterable[ImageRef]) -> list[str]:
+    errors: list[str] = []
+    for ref in refs:
+        if _is_ephemeral_sha_tag(ref.value) and not _has_digest(ref.value):
+            errors.append(_ephemeral_sha_tag_error(ref))
     return errors
 
 
@@ -315,6 +347,7 @@ def check(path: Path = LOCK_PATH, root: Path = ROOT) -> list[str]:
     lock = load_lock(path)
     errors = _validate_lock_shape(lock, root)
     errors.extend(validate_refs(discover_image_refs(root), lock, root))
+    errors.extend(validate_ephemeral_sha_tags(discover_extension_library_image_refs(root)))
     return errors
 
 

--- a/dream-server/scripts/check-dependency-pins.py
+++ b/dream-server/scripts/check-dependency-pins.py
@@ -25,6 +25,7 @@ VAR_RE = re.compile(
     r"\$\{(?P<braced>[A-Za-z_][A-Za-z0-9_]*)(?:(?P<op>:-|-)(?P<default>[^}]+))?\}"
     r"|\$(?P<plain>[A-Za-z_][A-Za-z0-9_]*)"
 )
+EPHEMERAL_SHA_TAG_RE = re.compile(r"^sha-[0-9a-f]{7,40}$", re.IGNORECASE)
 
 
 @dataclass(frozen=True)
@@ -180,6 +181,11 @@ def _is_variable_ref(value: str) -> bool:
     return "$" in value
 
 
+def _is_ephemeral_sha_tag(value: str) -> bool:
+    tag = _image_tag(value)
+    return tag is not None and EPHEMERAL_SHA_TAG_RE.match(tag) is not None
+
+
 def _arg_default_present(path: Path, arg: str, default: str) -> bool:
     expected = f"ARG {arg}={default}"
     return expected in path.read_text(encoding="utf-8")
@@ -280,6 +286,12 @@ def validate_refs(refs: Iterable[ImageRef], lock: dict[str, object], root: Path 
         if _image_tag(ref.value) == "latest" and not _has_digest(ref.value):
             if (ref.path, ref.value) not in latest_allow:
                 errors.append(f"{location}: latest tag requires allow_latest: {ref.value}")
+
+        if _is_ephemeral_sha_tag(ref.value) and not _has_digest(ref.value):
+            errors.append(
+                f"{location}: ephemeral sha-* image tags are not release-stable; "
+                f"pin to a retained version tag or @sha256 digest: {ref.value}"
+            )
 
         if (ref.path, ref.value) not in entry_keys and (ref.path, ref.value) not in latest_allow:
             errors.append(f"{location}: image ref is not recorded in dependency-lock.json: {ref.value}")

--- a/dream-server/tests/test-dependency-pins.py
+++ b/dream-server/tests/test-dependency-pins.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import sys
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -95,6 +96,31 @@ def test_ephemeral_sha_tags_are_rejected() -> None:
     assert any("ephemeral sha-* image tags are not release-stable" in error for error in errors)
 
 
+def test_ephemeral_sha256_length_tags_are_rejected() -> None:
+    module = load_module()
+    image = "nousresearch/hermes-agent:sha-" + ("a" * 64)
+    lock = {
+        "entries": [
+            {
+                "path": "extensions/services/hermes/compose.yaml",
+                "value": image,
+            }
+        ],
+        "allow_latest": [],
+        "allow_local_images": [],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="extensions/services/hermes/compose.yaml",
+        line=6,
+        raw=image,
+        value=image,
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert any("ephemeral sha-* image tags are not release-stable" in error for error in errors)
+
+
 def test_sha256_digest_pins_are_allowed() -> None:
     module = load_module()
     image = (
@@ -123,13 +149,44 @@ def test_sha256_digest_pins_are_allowed() -> None:
     assert errors == [], "\n".join(errors)
 
 
+def test_extension_library_sha_tags_are_rejected() -> None:
+    module = load_module()
+    with TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        config = root / "config"
+        service = root / "extensions" / "library" / "services" / "example"
+        config.mkdir()
+        service.mkdir(parents=True)
+        lock_path = config / "dependency-lock.json"
+        lock_path.write_text(
+            (
+                '{"version": 1, "entries": [], "allow_latest": [], '
+                '"allow_local_images": [], "allow_variable_refs": []}\n'
+            ),
+            encoding="utf-8",
+        )
+        (service / "compose.yaml").write_text(
+            "services:\n  app:\n    image: example/runtime:sha-1234567890abcdef\n",
+            encoding="utf-8",
+        )
+
+        errors = module.check(lock_path, root)
+
+    assert any("ephemeral sha-* image tags are not release-stable" in error for error in errors)
+    assert any(
+        "extensions/library/services/example/compose.yaml:3" in error for error in errors
+    )
+
+
 def main() -> int:
     tests = [
         test_repo_dependency_lock_passes,
         test_unallowlisted_latest_is_rejected,
         test_variable_refs_must_be_documented,
         test_ephemeral_sha_tags_are_rejected,
+        test_ephemeral_sha256_length_tags_are_rejected,
         test_sha256_digest_pins_are_allowed,
+        test_extension_library_sha_tags_are_rejected,
     ]
     for test in tests:
         test()

--- a/dream-server/tests/test-dependency-pins.py
+++ b/dream-server/tests/test-dependency-pins.py
@@ -71,11 +71,65 @@ def test_variable_refs_must_be_documented() -> None:
     assert any("variable image ref is not documented" in error for error in errors)
 
 
+def test_ephemeral_sha_tags_are_rejected() -> None:
+    module = load_module()
+    lock = {
+        "entries": [
+            {
+                "path": "extensions/services/hermes/compose.yaml",
+                "value": "nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f",
+            }
+        ],
+        "allow_latest": [],
+        "allow_local_images": [],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="extensions/services/hermes/compose.yaml",
+        line=6,
+        raw="nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f",
+        value="nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f",
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert any("ephemeral sha-* image tags are not release-stable" in error for error in errors)
+
+
+def test_sha256_digest_pins_are_allowed() -> None:
+    module = load_module()
+    image = (
+        "nousresearch/hermes-agent@sha256:"
+        "6e399abf4ff587822b0ef0df11f36088fb928e17ac61556fe89beb68d48c378e"
+    )
+    lock = {
+        "entries": [
+            {
+                "path": "extensions/services/hermes/compose.yaml",
+                "value": image,
+            }
+        ],
+        "allow_latest": [],
+        "allow_local_images": [],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="extensions/services/hermes/compose.yaml",
+        line=6,
+        raw=image,
+        value=image,
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert errors == [], "\n".join(errors)
+
+
 def main() -> int:
     tests = [
         test_repo_dependency_lock_passes,
         test_unallowlisted_latest_is_rejected,
         test_variable_refs_must_be_documented,
+        test_ephemeral_sha_tags_are_rejected,
+        test_sha256_digest_pins_are_allowed,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
## Summary

Refs #1544.

This is a follow-up hardening change after the 2.5.4 stable Hermes image fix in #1548.

#1548 protects release-critical Hermes files from reintroducing `nousresearch/hermes-agent:sha-*`. This PR extends the dependency pin policy more generally, so future runtime image references cannot use ephemeral upstream `sha-<commit>` tags.

Proper immutable digest pins using `@sha256:` remain allowed.

## AI Assistance

AI helped inspect issue #1544 and the related merged PRs, identify the remaining dependency pin policy gap, draft the validation tests, and run local verification.

I reviewed the final diff and am accountable for it.

## Release Lane

* [ ] Stable hotfix targeting `release/2.5.x`
* [x] Mainline change targeting `main`
* [ ] Next-minor work targeting the next feature/minor release
* [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

* [ ] Docs only
* [x] Tests only
* [ ] Dashboard UI
* [ ] Dashboard API / host agent
* [ ] Installer / bootstrap / lifecycle
* [ ] Docker Compose / service manifests
* [ ] Model routing / Hermes / capabilities
* [ ] Network exposure / auth / proxy
* [x] Dependencies / runtime wiring

## Risk And Validation

Risk level: Low

Validation run:

* [x] `git diff --check`
* [ ] Markdown/link sanity for docs
* [x] Focused tests listed below
* [ ] Dashboard lint/test/build
* [ ] Extension audit / compose validation
* [ ] Release-grade fleet or scoped hardware validation
* [ ] Stable-lane patch validation, if targeting `release/2.5.x`
* [ ] Not required because:

Commands/results:

```bash
python3 tests/test-dependency-pins.py
```

```text
[PASS] dependency pin tests
```

```bash
python3 scripts/check-dependency-pins.py
```

```text
[PASS] dependency pins are documented and enforceable
```

```bash
PYTHONPYCACHEPREFIX=/tmp/dreamserver-pycache python3 -m py_compile scripts/check-dependency-pins.py tests/test-dependency-pins.py
```

```text
passed
```

```bash
PYTHONPYCACHEPREFIX=/tmp/dreamserver-pycache make lint
```

```text
All lint checks passed.
```

```bash
bash tests/test-linux-cloud-mode.sh
```

```text
[PASS] linux cloud mode contracts
```

```bash
git diff --check
```

```text
passed
```

## Operational Change Check

* [x] This is not an operational change.
* [ ] This is an operational change and validation is recorded above.
* [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

This PR does not change the current Hermes image pin or stable release metadata.

It adds a general dependency lock guard so future third-party upstream image references cannot use ephemeral `sha-*` tags that may disappear from registries after release.

#1548 already handled the immediate stable Hermes install break by stamping 2.5.4 and guarding release-critical Hermes files. This PR keeps that same failure mode from reappearing elsewhere in runtime dependency pins.
