### PR TITLE
feat(dashboard): add theme selector to settings

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
@@ -9,10 +9,13 @@ import {
   UserPlus,
   CreditCard,
   ChevronRight,
+  Moon,
+  Sun,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import EnvEditor from '../components/settings/EnvEditor'
+import { useTheme } from '../contexts/ThemeContext'
 
 const fetchJson = async (url, ms = 8000, options = {}) => {
   const c = new AbortController()
@@ -75,6 +78,7 @@ const matchesEnvSearch = (key, field, query) => {
 }
 
 export default function Settings() {
+  const { theme, setTheme } = useTheme()
   const [version, setVersion] = useState(null)
   const [storage, setStorage] = useState(null)
   const [services, setServices] = useState([])
@@ -251,6 +255,19 @@ export default function Settings() {
       <div className="max-w-5xl space-y-6 liquid-metal-sequence-grid liquid-metal-sequence-grid--services">
         <SettingsSection title="System Identity" icon={Server}><div className="grid gap-4 sm:grid-cols-2"><InfoRow label="Version" value={version?.version || 'Unknown'} /><InfoRow label="Install Date" value={version?.install_date || 'Unknown'} /><InfoRow label="Tier" value={version?.tier || 'Community'} /><InfoRow label="Uptime" value={version?.uptime || 'Unknown'} /></div></SettingsSection>
 
+        <SettingsSection title="Appearance" icon={theme === 'light' ? Sun : Moon}>
+          <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-sm font-medium text-theme-text">Color mode</p>
+              <p className="mt-1 text-xs text-theme-text-muted">Choose how the dashboard appears on this browser.</p>
+            </div>
+            <div className="inline-flex self-start rounded-lg border border-theme-border bg-black/[0.12] p-1">
+              <ThemeModeButton active={theme !== 'light'} icon={Moon} label="Dark" onClick={() => setTheme('dream')} />
+              <ThemeModeButton active={theme === 'light'} icon={Sun} label="Light" onClick={() => setTheme('light')} />
+            </div>
+          </div>
+        </SettingsSection>
+
         <SettingsSection title="Account" icon={SettingsIcon}>
           <div className="divide-y divide-theme-border">
             <SettingsNavRow
@@ -287,6 +304,24 @@ export default function Settings() {
 
 function SettingsSection({ title, icon: Icon, children }) { return <div className="liquid-metal-frame liquid-metal-sequence-card bg-theme-card border border-theme-border rounded-xl"><div className="flex items-center gap-3 p-4 border-b border-theme-border"><Icon size={20} className="text-theme-text-muted" /><h2 className="text-lg font-semibold text-theme-text">{title}</h2></div><div className="p-4">{children}</div></div> }
 function InfoRow({ label, value }) { return <div className="flex items-center justify-between py-2 gap-4"><span className="text-sm text-theme-text-muted">{label}</span><span className="text-sm text-theme-text font-medium font-mono text-right break-all">{value}</span></div> }
+
+function ThemeModeButton({ active, icon: Icon, label, onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex h-9 items-center gap-2 rounded-md px-3 text-xs font-semibold transition-colors ${
+        active
+          ? 'bg-theme-accent/25 text-theme-accent-light'
+          : 'text-theme-text-muted hover:text-theme-text'
+      }`}
+      aria-pressed={active}
+    >
+      <Icon size={14} />
+      {label}
+    </button>
+  )
+}
 
 function Banner({ tone = 'info', children, onClose }) {
   const cls = tone === 'danger' ? 'border-red-500/20 bg-red-500/10 text-red-200' : tone === 'warn' ? 'border-yellow-500/20 bg-yellow-500/10 text-yellow-100' : 'border-theme-accent/20 bg-theme-accent/10 text-theme-text'

--- a/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Settings.jsx
@@ -9,8 +9,7 @@ import {
   UserPlus,
   CreditCard,
   ChevronRight,
-  Moon,
-  Sun,
+  Palette,
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
@@ -69,6 +68,13 @@ const ROUTE_GROUP_STYLES = {
   online: { dot: 'bg-emerald-400', text: 'text-theme-text-secondary', line: 'rgba(52,211,153,0.22)' },
 }
 
+const THEME_SWATCHES = {
+  dream: 'linear-gradient(135deg, #9d00ff 0%, #18181b 100%)',
+  lemonade: 'linear-gradient(135deg, #facc15 0%, #fdfbf3 100%)',
+  light: 'linear-gradient(135deg, #60a5fa 0%, #ffffff 100%)',
+  arctic: 'linear-gradient(135deg, #38bdf8 0%, #f0f9ff 100%)',
+}
+
 const routeSeverityOrder = { down: 0, unhealthy: 1, degraded: 2, unknown: 3, healthy: 4 }
 const sortRoutesBySeverity = (items) => [...(items || [])].sort((a, b) => (routeSeverityOrder[a.status] ?? 9) - (routeSeverityOrder[b.status] ?? 9))
 
@@ -78,7 +84,7 @@ const matchesEnvSearch = (key, field, query) => {
 }
 
 export default function Settings() {
-  const { theme, setTheme } = useTheme()
+  const { theme, setTheme, themes, labels } = useTheme()
   const [version, setVersion] = useState(null)
   const [storage, setStorage] = useState(null)
   const [services, setServices] = useState([])
@@ -255,15 +261,22 @@ export default function Settings() {
       <div className="max-w-5xl space-y-6 liquid-metal-sequence-grid liquid-metal-sequence-grid--services">
         <SettingsSection title="System Identity" icon={Server}><div className="grid gap-4 sm:grid-cols-2"><InfoRow label="Version" value={version?.version || 'Unknown'} /><InfoRow label="Install Date" value={version?.install_date || 'Unknown'} /><InfoRow label="Tier" value={version?.tier || 'Community'} /><InfoRow label="Uptime" value={version?.uptime || 'Unknown'} /></div></SettingsSection>
 
-        <SettingsSection title="Appearance" icon={theme === 'light' ? Sun : Moon}>
+        <SettingsSection title="Appearance" icon={Palette}>
           <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div>
-              <p className="text-sm font-medium text-theme-text">Color mode</p>
+              <p className="text-sm font-medium text-theme-text">Theme</p>
               <p className="mt-1 text-xs text-theme-text-muted">Choose how the dashboard appears on this browser.</p>
             </div>
-            <div className="inline-flex self-start rounded-lg border border-theme-border bg-black/[0.12] p-1">
-              <ThemeModeButton active={theme !== 'light'} icon={Moon} label="Dark" onClick={() => setTheme('dream')} />
-              <ThemeModeButton active={theme === 'light'} icon={Sun} label="Light" onClick={() => setTheme('light')} />
+            <div className="grid grid-cols-2 gap-1 rounded-lg border border-theme-border bg-black/[0.12] p-1 sm:inline-grid sm:grid-cols-4">
+              {themes.map(themeId => (
+                <ThemeOptionButton
+                  key={themeId}
+                  active={theme === themeId}
+                  label={labels[themeId] || themeId}
+                  swatch={THEME_SWATCHES[themeId]}
+                  onClick={() => setTheme(themeId)}
+                />
+              ))}
             </div>
           </div>
         </SettingsSection>
@@ -305,20 +318,18 @@ export default function Settings() {
 function SettingsSection({ title, icon: Icon, children }) { return <div className="liquid-metal-frame liquid-metal-sequence-card bg-theme-card border border-theme-border rounded-xl"><div className="flex items-center gap-3 p-4 border-b border-theme-border"><Icon size={20} className="text-theme-text-muted" /><h2 className="text-lg font-semibold text-theme-text">{title}</h2></div><div className="p-4">{children}</div></div> }
 function InfoRow({ label, value }) { return <div className="flex items-center justify-between py-2 gap-4"><span className="text-sm text-theme-text-muted">{label}</span><span className="text-sm text-theme-text font-medium font-mono text-right break-all">{value}</span></div> }
 
-function ThemeModeButton({ active, icon: Icon, label, onClick }) {
+function ThemeOptionButton({ active, label, swatch, onClick }) {
   return (
     <button
       type="button"
-      onClick={onClick}
-      className={`flex h-9 items-center gap-2 rounded-md px-3 text-xs font-semibold transition-colors ${
-        active
-          ? 'bg-theme-accent/25 text-theme-accent-light'
-          : 'text-theme-text-muted hover:text-theme-text'
-      }`}
       aria-pressed={active}
+      onClick={onClick}
+      className={`flex h-9 items-center justify-center gap-2 rounded-md px-3 text-xs font-semibold transition-colors ${
+        active ? 'bg-theme-accent/25 text-theme-accent-light' : 'text-theme-text-muted hover:text-theme-text'
+      }`}
     >
-      <Icon size={14} />
-      {label}
+      <span className="h-3 w-3 shrink-0 rounded-full border border-white/20" style={{ background: swatch || 'rgb(var(--theme-accent))' }} />
+      <span>{label}</span>
     </button>
   )
 }


### PR DESCRIPTION
## Summary

The dashboard already supports multiple themes through `ThemeContext`, but Settings did not expose a clear way to select them.

This PR adds an appearance section to settings and lets allow users to switch between the themes provided by the existing theme implementation.

Resolves: #1557 

## AI Assistance

<!-- If AI tools helped draft code, docs, tests, reviews, or triage, say what they did. Use "None" when not applicable. The human author remains accountable for reading the diff, choosing the validation, and responding to review. -->

## Release Lane

<!-- Pick the lane before review. See dream-server/docs/RELEASE_CHANNELS.md. -->

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
<!-- If this targets release/2.5.x, explain the current-stable user problem it fixes. -->
```

## Changed Surface

<!-- Check every surface this PR can affect. -->

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

<!-- Use dream-server/docs/HIGH_RISK_CHANGE_MAP.md to pick the right level. -->

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [ ] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because: <!-- explain -->

Commands/results:

- npm run lint ✅
- npm test -- --run ✅
- npm run build ✅
- git diff --check ✅

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [x] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

- No backend, runtime, infrastructure, networking, or installer changes.
- Uses the existing ThemeContext implementation and storage flow.
- Verified theme selection for:
-- Dream
-- Lemonade
-- Light
-- Arctic