### PR TITLE
feat(macos): support external Lemonade provider mode

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- macOS now has an explicit existing-Lemonade wrapper path: `./install.sh
+  --use-existing-lemonade` keeps the default native Metal `llama-server` path
+  intact, but can route Dream services through LiteLLM to an already-running
+  host Lemonade API.
+
 ## [2.5.3] - 2026-05-26
 
 ### Fixed

--- a/dream-server/docs/ENGINE-PROVIDER-MODES.md
+++ b/dream-server/docs/ENGINE-PROVIDER-MODES.md
@@ -22,6 +22,12 @@ The Lemonade provider may be either Dream-managed on platforms where that is
 already supported, or external/unmanaged when Dream Server adopts an existing
 host-native Lemonade service. The env shape must make that ownership explicit.
 
+macOS keeps native host `llama-server` with Metal acceleration as the default
+install path. Existing host-native Lemonade is a supported alternate provider
+wrapper on macOS when the operator explicitly passes `--use-existing-lemonade`;
+Dream Server must still keep Lemonade unmanaged, route Dream services through
+LiteLLM, and prove a real chat completion before reporting the install ready.
+
 ## Required Env Shape
 
 Provider mode code should converge on these names:
@@ -39,6 +45,12 @@ Provider mode code should converge on these names:
 
 Installers may retain legacy variables during migration, but new behavior should
 read and write the canonical names above.
+
+Existing external-Lemonade installs that only set `LLM_MODEL` retain a
+compatibility path when that exact id is present in Lemonade's model catalog and
+is a text/chat model. The dashboard reports a migration warning in that case.
+Operators should copy the value to `LEMONADE_MODEL`; stale tier-model values and
+specialized model ids are intentionally not accepted as implicit chat targets.
 
 ## Provider Capability Contract
 
@@ -58,6 +70,16 @@ profile is reachable through the configured provider:
 Unsupported selected capabilities must fail the install or readiness gate unless
 the user explicitly chose a profile where that capability is optional. A skipped
 selected capability is not a green install.
+
+Normal dashboard polling must remain passive: it may read health, model catalog,
+loaded-model state, and stats, but it must not trigger inference or model
+downloads. A passive check may mark a route ready only when the provider reports
+the configured model as loaded with the expected capability type. Real chat,
+embedding, rerank, STT, and TTS proofs run only through an explicit authenticated
+active-probe action because those requests may load or switch provider models.
+The active probe must finish by restoring and proving the selected chat model,
+refreshing health and model-catalog state, and reporting any final-state failure
+as degraded or blocked rather than leaving a false-ready result.
 
 ## Adapter Boundary
 
@@ -86,6 +108,9 @@ Provider modes must fail closed on network exposure:
   must be configured or the user must pass an explicit unsafe override.
 - All Dream-owned clients must pass the configured provider key before key
   enforcement is enabled by default.
+- Browser-triggered active probes must require a non-simple same-origin request
+  header in addition to API authentication so another site cannot trigger model
+  loads through the dashboard's nginx-injected credential.
 - Readiness must distinguish "provider unreachable", "auth rejected", "model
   missing", and "capability unsupported".
 

--- a/dream-server/docs/LEMONADE-SDK-COMPAT.md
+++ b/dream-server/docs/LEMONADE-SDK-COMPAT.md
@@ -1,10 +1,14 @@
 # Lemonade SDK Compatibility
 
 Dream Server's Linux installer can wrap an existing Lemonade SDK install instead
-of starting its own managed Lemonade runtime. This is intended for AMD Linux
+of starting its own managed Lemonade runtime. This was added for AMD Linux
 systems where Lemonade is already installed, configured, and serving models.
-The longer-term contract for making Lemonade a supported provider mode across
-platforms is defined in [Engine Provider Modes](ENGINE-PROVIDER-MODES.md).
+
+macOS can now use the same unmanaged wrapper pattern when Lemonade is already
+running and serving the OpenAI-compatible API. Dream Server's default macOS path
+remains host-native `llama-server` with Metal acceleration; the
+external-Lemonade path is explicit and does not install, start, stop, or upgrade
+Lemonade on macOS.
 
 ## Install Around Existing Lemonade
 
@@ -83,15 +87,52 @@ the installer supports it. Today, a Kokoro/TTS conflict on port `8880` should be
 handled with `--no-voice`. The port conflict is from the optional Dream service,
 not from Lemonade itself.
 
-Windows AMD installs already use a separate host-managed Lemonade path. These
-flags are for Linux installs that should attach to a pre-existing Lemonade SDK
-service.
+Windows AMD installs already use a separate host-managed Lemonade path. macOS
+Apple Silicon keeps native Metal `llama-server` as the default, but accepts
+these external-Lemonade flags when the operator wants Dream Server to attach to
+a pre-existing Lemonade SDK service instead.
+
+## macOS Existing Lemonade
+
+On macOS, `--use-existing-lemonade` changes only the LLM provider route:
+
+- Dream Server skips native `llama-server` startup and model download;
+- Docker services use LiteLLM as the app-facing gateway;
+- LiteLLM calls the existing Lemonade API through
+  `host.docker.internal:<port>/api/v1` when Lemonade is bound to localhost;
+- Hermes, OpenCode, Perplexica, and Open WebUI use the selected
+  `LEMONADE_MODEL` through LiteLLM;
+- voice, workflows, RAG, and other Dream-owned services remain independent
+  feature choices.
+
+For a headless or minimal macOS wrapper install:
+
+```bash
+LEMONADE_MODEL=<chat-model-id> \
+  ./install.sh --use-existing-lemonade \
+  --lemonade-url http://localhost:13305 \
+  --no-voice --no-comfyui
+```
+
+If Lemonade requires a bearer token:
+
+```bash
+LEMONADE_MODEL=<chat-model-id> \
+  ./install.sh --use-existing-lemonade \
+  --lemonade-url http://localhost:13305 \
+  --lemonade-api-key "$LEMONADE_API_KEY"
+```
+
+The installer auto-detects `localhost:13305` and `localhost:8000` when possible
+and queries `/models` to select the first chat-like downloaded model. Set
+`LEMONADE_MODEL` explicitly for repeatable installs or whenever the Lemonade
+catalog includes image, audio, embedding, rerank, or broken experimental models.
 
 ## Model Selection
 
 Dream Server auto-detects the first model id returned by Lemonade's
-`/api/v1/models` endpoint that does not look like an image-generation model
-and writes it to `LEMONADE_MODEL`.
+`/api/v1/models` endpoint that does not look like a specialized non-chat model
+(image, audio, embedding, or reranking) and writes it to `LEMONADE_MODEL`.
 
 Set `LEMONADE_MODEL` only if you want Dream Server to use a specific served
 model:
@@ -124,7 +165,7 @@ only to `127.0.0.1`. Dream Server converts a host URL such as
 `http://localhost:13305` into the container-side URL
 `http://host.docker.internal:13305`, but Lemonade must be reachable there.
 
-On a trusted host, configure Lemonade to bind beyond loopback:
+On a trusted Linux host, configure Lemonade to bind beyond loopback:
 
 ```bash
 lemonade config set host=0.0.0.0
@@ -158,8 +199,10 @@ OpenAI-compatible gateway.
 
 ## Diagnostics
 
-`dream doctor` and the dashboard AMD runtime endpoint report external Lemonade
-as:
+`dream doctor` and the dashboard `/api/providers/lemonade` endpoint report
+external Lemonade as the same provider contract even when the machine itself is
+not AMD. The older `/api/gpu/amd-runtime` endpoint remains a compatibility
+alias for clients from the original AMD/Lemonade rollout:
 
 ```text
 runtime: lemonade

--- a/dream-server/docs/SUPPORT-MATRIX.md
+++ b/dream-server/docs/SUPPORT-MATRIX.md
@@ -36,7 +36,7 @@ classes, and any deferred or skipped phases.
 | Linux (Strix Halo / AMD unified memory) | AMD (Lemonade/ROCm) | Tier A | Primary managed path via `docker-compose.base.yml` + `docker-compose.amd.yml`; validated on real Strix Halo hardware |
 | Linux (Intel Arc A770/A750) | Intel SYCL (llama-server/oneAPI) | **Tier C** | `docker-compose.arc.yml`; builds llama.cpp from `intel/oneapi-basekit`; see [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) |
 | Windows (Docker Desktop + WSL2) | NVIDIA via Docker Desktop; AMD via host Vulkan runtime | Tier B | Standalone installer (`.\install.ps1`) with GPU auto-detection, Docker orchestration, health checks, and desktop shortcuts; Windows laptop fleet target tracks Docker Desktop/WSL2 evidence |
-| macOS (Apple Silicon) | Metal (native llama-server) | Tier B | Standalone installer (`./install.sh`) with chip detection, native Metal inference, Docker services, and LaunchAgent auto-start; validated on constrained and high-memory Apple Silicon lab hosts |
+| macOS (Apple Silicon) | Metal (native llama-server); optional existing Lemonade wrapper | Tier B | Standalone installer (`./install.sh`) with chip detection, native Metal inference, Docker services, and LaunchAgent auto-start; `--use-existing-lemonade` can route through an already-running host Lemonade service via LiteLLM |
 
 ## GPU Tier Map
 
@@ -60,8 +60,8 @@ classes, and any deferred or skipped phases.
 - Linux + NVIDIA is supported and validated on real high-memory NVIDIA hardware; broader distro coverage now runs through CI, private Docker containers, and private Incus VMs.
 - Windows installs via `.\install.ps1` with Docker Desktop + WSL2 backend. Windows AMD local inference is host-managed and uses Vulkan today, either through legacy Lemonade Server or native `llama-server` fallback. Windows support is not inferred from Linux/macOS; treat it as release-current only when a Windows fleet target produces artifacts for that candidate.
 - Windows native installer UX is Tier B (delegated via Docker Desktop + WSL2).
-- macOS installs via `./install.sh` — llama-server runs natively with Metal acceleration, all other services in Docker.
-- AMD runtime diagnostics are explicit: `.env` records runtime, location, selected backend, supported backends, and whether DreamServer manages the process. DreamServer supports its managed AMD Lemonade path and a Linux external Lemonade SDK wrapper path for existing Lemonade installs; see [LEMONADE-SDK-COMPAT.md](LEMONADE-SDK-COMPAT.md).
+- macOS installs via `./install.sh` — llama-server runs natively with Metal acceleration by default, all other services in Docker. macOS can also wrap an already-running host Lemonade service with `--use-existing-lemonade`; Dream Server does not manage that Lemonade process.
+- AMD runtime diagnostics are explicit: `.env` records runtime, location, selected backend, supported backends, and whether DreamServer manages the process. DreamServer supports its managed AMD Lemonade path and Linux/macOS external Lemonade SDK wrapper paths for existing Lemonade installs; see [LEMONADE-SDK-COMPAT.md](LEMONADE-SDK-COMPAT.md).
 - AMD discrete GPUs beyond the documented Strix Halo path should be treated as validation-required until the repo has tier/model benchmarks for that hardware.
 - **Intel Arc (SYCL) is Tier C / experimental.** The installer auto-detects and selects the correct compose overlay and tier. Runtime works on A770/A750 (Linux). ComfyUI and Whisper GPU acceleration are not yet available for Arc. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) for limitations.
 - Release-readiness claims should cite a matching version/tag, relevant distro-lab evidence, and a real-hardware fleet receipt from [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md).

--- a/dream-server/installers/lib/detection.sh
+++ b/dream-server/installers/lib/detection.sh
@@ -244,7 +244,10 @@ apply_cpu_gpu_fallback() {
     GPU_MEMORY_TYPE="none"
     GPU_DEVICE_ID=""
     HAS_NPU=false
-    [[ "${DREAM_MODE:-local}" == "lemonade" ]] && DREAM_MODE="local"
+    case "${LEMONADE_EXTERNAL:-}" in
+        true|1|yes|on) ;;
+        *) [[ "${DREAM_MODE:-local}" == "lemonade" ]] && DREAM_MODE="local" ;;
+    esac
     BACKEND_ID="cpu"
     CAP_LLM_BACKEND="cpu"
     CAP_GPU_VENDOR="cpu"

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -4,9 +4,10 @@
 # ============================================================================
 # Standalone macOS Apple Silicon installer. Does not modify any existing files.
 #
-# macOS: llama-server runs natively with Metal on the host (port 8080).
+# macOS default: llama-server runs natively with Metal on the host (port 8080).
 #        Everything else runs in Docker. Containers reach llama-server via
-#        host.docker.internal.
+#        host.docker.internal. With --use-existing-lemonade, Dream Server keeps
+#        Lemonade unmanaged and routes app traffic through LiteLLM instead.
 #
 # Usage:
 #   ./install-macos.sh                  # Interactive install
@@ -15,6 +16,8 @@
 #   ./install-macos.sh --all            # Enable all optional services
 #   ./install-macos.sh --non-interactive # Headless install (defaults)
 #   ./install-macos.sh --no-bootstrap   # Wait for the full model before launch
+#   ./install-macos.sh --use-existing-lemonade
+#                                         # Use an existing Lemonade server
 #
 # ============================================================================
 
@@ -87,6 +90,11 @@ ENABLE_PERPLEXICA=false
 ENABLE_PRIVACY_SHIELD=false
 ENABLE_DREAM_PROXY=false
 ENABLE_TAILSCALE=false
+VOICE_EXPLICIT=false
+WORKFLOWS_EXPLICIT=false
+RAG_EXPLICIT=false
+RECOMMENDED_EXPLICIT=false
+HERMES_EXPLICIT=false
 # Langfuse defaults OFF because its clickhouse + postgres + minio stack adds
 # ~500MB baseline memory. Enable via --langfuse, --all, or post-install
 # `dream enable langfuse`. --no-langfuse honored as explicit override so a
@@ -96,42 +104,65 @@ NO_LANGFUSE_EXPLICIT=false
 OPENCLAW_EXPLICIT=false
 ALL_FEATURES=false
 CLOUD_MODE=false
+LEMONADE_EXTERNAL="${LEMONADE_EXTERNAL:-false}"
+LEMONADE_BASE_URL="${LEMONADE_BASE_URL:-}"
+LEMONADE_CONTAINER_BASE_URL="${LEMONADE_CONTAINER_BASE_URL:-}"
+LEMONADE_API_BASE_PATH="${LEMONADE_API_BASE_PATH:-/api/v1}"
+LEMONADE_API_KEY="${LEMONADE_API_KEY:-}"
+LEMONADE_MODEL="${LEMONADE_MODEL:-}"
 NO_BOOTSTRAP=false
 HERMES_CONTEXT_SIZE=131072
+
+_require_arg() {
+    local flag="$1"
+    local value="${2:-}"
+    if [[ -z "$value" || "$value" == --* ]]; then
+        echo "Missing value for ${flag}" >&2
+        exit 1
+    fi
+}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dry-run)       DRY_RUN=true; shift ;;
         --force)         FORCE=true; shift ;;
         --non-interactive) NON_INTERACTIVE=true; shift ;;
-        --tier)          TIER_OVERRIDE="${2:-}"; shift 2 ;;
-        --voice)         ENABLE_VOICE=true; shift ;;
-        --workflows)     ENABLE_WORKFLOWS=true; shift ;;
-        --rag)           ENABLE_RAG=true; shift ;;
-        --recommended)   ENABLE_RECOMMENDED=true; shift ;;
-        --no-recommended) ENABLE_RECOMMENDED=false; shift ;;
-        --hermes)        ENABLE_HERMES=true; shift ;;
-        --no-hermes)     ENABLE_HERMES=false; shift ;;
+        --tier)          _require_arg "$1" "${2:-}"; TIER_OVERRIDE="$2"; shift 2 ;;
+        --voice)         ENABLE_VOICE=true; VOICE_EXPLICIT=true; shift ;;
+        --no-voice)      ENABLE_VOICE=false; VOICE_EXPLICIT=true; shift ;;
+        --workflows)     ENABLE_WORKFLOWS=true; WORKFLOWS_EXPLICIT=true; shift ;;
+        --no-workflows)  ENABLE_WORKFLOWS=false; WORKFLOWS_EXPLICIT=true; shift ;;
+        --rag)           ENABLE_RAG=true; RAG_EXPLICIT=true; shift ;;
+        --no-rag)        ENABLE_RAG=false; RAG_EXPLICIT=true; shift ;;
+        --recommended)   ENABLE_RECOMMENDED=true; RECOMMENDED_EXPLICIT=true; shift ;;
+        --no-recommended) ENABLE_RECOMMENDED=false; RECOMMENDED_EXPLICIT=true; shift ;;
+        --hermes)        ENABLE_HERMES=true; HERMES_EXPLICIT=true; shift ;;
+        --no-hermes)     ENABLE_HERMES=false; HERMES_EXPLICIT=true; shift ;;
         --openclaw)      ENABLE_OPENCLAW=true; OPENCLAW_EXPLICIT=true; shift ;;
         --no-openclaw)   ENABLE_OPENCLAW=false; OPENCLAW_EXPLICIT=true; shift ;;
         --langfuse)      ENABLE_LANGFUSE=true; shift ;;
         --no-langfuse)   ENABLE_LANGFUSE=false; NO_LANGFUSE_EXPLICIT=true; shift ;;
+        --comfyui)       shift ;;
+        --no-comfyui)    shift ;;
         --all)           ALL_FEATURES=true; shift ;;
         --cloud)         CLOUD_MODE=true; shift ;;
+        --use-existing-lemonade) LEMONADE_EXTERNAL=true; shift ;;
+        --lemonade-url)  _require_arg "$1" "${2:-}"; LEMONADE_EXTERNAL=true; LEMONADE_BASE_URL="$2"; shift 2 ;;
+        --lemonade-api-key) _require_arg "$1" "${2:-}"; LEMONADE_API_KEY="$2"; shift 2 ;;
         --no-bootstrap)  NO_BOOTSTRAP=true; shift ;;
         *)               echo "Unknown option: $1"; exit 1 ;;
     esac
 done
 
 if $ALL_FEATURES; then
-    ENABLE_VOICE=true
-    ENABLE_WORKFLOWS=true
-    ENABLE_RAG=true
-    ENABLE_RECOMMENDED=true
+    $VOICE_EXPLICIT || ENABLE_VOICE=true
+    $WORKFLOWS_EXPLICIT || ENABLE_WORKFLOWS=true
+    $RAG_EXPLICIT || ENABLE_RAG=true
+    $RECOMMENDED_EXPLICIT || ENABLE_RECOMMENDED=true
     # --all enables the new default Hermes Agent. OpenClaw stays opt-in via
     # --openclaw during the deprecation release; will be removed entirely
     # in the next release.
-    ENABLE_HERMES=true
+    $HERMES_EXPLICIT || ENABLE_HERMES=true
     $OPENCLAW_EXPLICIT || ENABLE_OPENCLAW=false
     ENABLE_APE=true
     ENABLE_PERPLEXICA=true
@@ -139,6 +170,19 @@ if $ALL_FEATURES; then
     ENABLE_DREAM_PROXY=true
     # --all enables Langfuse unless the user explicitly passed --no-langfuse.
     $NO_LANGFUSE_EXPLICIT || ENABLE_LANGFUSE=true
+fi
+
+case "${LEMONADE_EXTERNAL,,}" in
+    true|1|yes|on) LEMONADE_EXTERNAL=true ;;
+    *) LEMONADE_EXTERNAL=false ;;
+esac
+
+if [[ "$LEMONADE_EXTERNAL" == "true" ]]; then
+    CLOUD_MODE=false
+    ENABLE_RECOMMENDED=true
+    NO_BOOTSTRAP=true
+    export LEMONADE_EXTERNAL LEMONADE_BASE_URL LEMONADE_CONTAINER_BASE_URL
+    export LEMONADE_API_BASE_PATH LEMONADE_API_KEY LEMONADE_MODEL
 fi
 
 # ── Locate script directory and source tree root ──
@@ -240,6 +284,265 @@ _find_opencode_bin() {
         return 0
     fi
 
+    return 1
+}
+
+_macos_external_lemonade_active() {
+    [[ "${LEMONADE_EXTERNAL:-false}" =~ ^([Tt][Rr][Uu][Ee]|1|yes|on)$ ]]
+}
+
+_strip_lemonade_api_suffix() {
+    local base="${1:-}"
+    base="${base%/}"
+    local suffix
+    for suffix in "/api/v1" "/v1" "/api"; do
+        if [[ "${base,,}" == *"${suffix}" ]]; then
+            base="${base:0:${#base}-${#suffix}}"
+            break
+        fi
+    done
+    printf '%s\n' "${base%/}"
+}
+
+_lemonade_api_url() {
+    local base="$(_strip_lemonade_api_suffix "${1:-}")"
+    local api_path="${2:-/api/v1}"
+    api_path="/${api_path#/}"
+    printf '%s%s\n' "$base" "$api_path"
+}
+
+_macos_detect_lemonade_url() {
+    local candidate api_path
+    local curl_args=(-fsS --max-time 3)
+    api_path="${LEMONADE_API_BASE_PATH:-/api/v1}"
+    [[ -n "${LEMONADE_API_KEY:-}" ]] && curl_args+=(-H "Authorization: Bearer ${LEMONADE_API_KEY}")
+    for candidate in \
+        "${LEMONADE_BASE_URL:-}" \
+        "http://localhost:13305" \
+        "http://127.0.0.1:13305" \
+        "http://localhost:8000" \
+        "http://127.0.0.1:8000"
+    do
+        [[ -n "$candidate" ]] || continue
+        candidate="$(_strip_lemonade_api_suffix "$candidate")"
+        if curl "${curl_args[@]}" "$(_lemonade_api_url "$candidate" "$api_path")/health" >/dev/null 2>&1; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+_macos_discover_lemonade_model() {
+    local api_base="$1"
+    local tmp_json pycmd
+    local curl_args=(-fsS --max-time 10)
+    tmp_json="$(mktemp /tmp/dream-macos-lemonade-models.XXXXXX.json)"
+    [[ -n "${LEMONADE_API_KEY:-}" ]] && curl_args+=(-H "Authorization: Bearer ${LEMONADE_API_KEY}")
+    if ! curl "${curl_args[@]}" "${api_base%/}/models" -o "$tmp_json" 2>/dev/null; then
+        rm -f "$tmp_json"
+        return 1
+    fi
+    pycmd="${DREAM_PYTHON_CMD:-}"
+    [[ -n "$pycmd" ]] || pycmd="$(command -v python3 2>/dev/null || true)"
+    [[ -n "$pycmd" ]] || pycmd="$(command -v python 2>/dev/null || true)"
+    if [[ -z "$pycmd" ]]; then
+        rm -f "$tmp_json"
+        return 1
+    fi
+    "$pycmd" - "$tmp_json" <<'PY'
+import json
+import sys
+
+special_labels = {"embeddings", "reranking", "transcription", "image", "edit", "tts"}
+special_markers = ("whisper", "moonshine", "kokoro", "embedding", "embed-", "rerank", "stable-diffusion", "sdxl", "flux", "image")
+special_recipes = {"sd-cpp", "whisper", "whispercpp", "kokoro", "kokoros"}
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+
+items = payload.get("data") if isinstance(payload, dict) else payload
+if not isinstance(items, list):
+    sys.exit(1)
+
+for item in items:
+    if not isinstance(item, dict):
+        continue
+    model_id = str(item.get("id") or item.get("name") or item.get("model") or "").strip()
+    if not model_id:
+        continue
+    labels = {str(label).strip().lower() for label in item.get("labels", []) if str(label).strip()} if isinstance(item.get("labels"), list) else set()
+    recipe = str(item.get("recipe") or "").lower()
+    if labels & special_labels or recipe in special_recipes or any(marker in model_id.lower() for marker in special_markers):
+        continue
+    if item.get("downloaded") is False:
+        continue
+    print(model_id)
+    sys.exit(0)
+
+sys.exit(1)
+PY
+    local rc=$?
+    rm -f "$tmp_json"
+    return "$rc"
+}
+
+_prepare_macos_external_lemonade() {
+    _macos_external_lemonade_active || return 0
+
+    LEMONADE_API_BASE_PATH="/${LEMONADE_API_BASE_PATH#/}"
+    if [[ -z "${LEMONADE_BASE_URL:-}" ]]; then
+        if LEMONADE_BASE_URL="$(_macos_detect_lemonade_url)"; then
+            ai_ok "Detected existing Lemonade server at ${LEMONADE_BASE_URL}"
+        else
+            LEMONADE_BASE_URL="http://localhost:13305"
+            ai_warn "Could not auto-detect existing Lemonade; using ${LEMONADE_BASE_URL}. Pass --lemonade-url if your server uses another port."
+        fi
+    fi
+    LEMONADE_BASE_URL="$(_strip_lemonade_api_suffix "$LEMONADE_BASE_URL")"
+
+    if [[ -z "${LEMONADE_CONTAINER_BASE_URL:-}" ]]; then
+        case "$LEMONADE_BASE_URL" in
+            http://localhost:*) LEMONADE_CONTAINER_BASE_URL="${LEMONADE_BASE_URL/http:\/\/localhost:/http:\/\/host.docker.internal:}" ;;
+            http://127.0.0.1:*) LEMONADE_CONTAINER_BASE_URL="${LEMONADE_BASE_URL/http:\/\/127.0.0.1:/http:\/\/host.docker.internal:}" ;;
+            http://[::1]:*) LEMONADE_CONTAINER_BASE_URL="${LEMONADE_BASE_URL/http:\/\/[::1]:/http:\/\/host.docker.internal:}" ;;
+            *) LEMONADE_CONTAINER_BASE_URL="$LEMONADE_BASE_URL" ;;
+        esac
+    fi
+    LEMONADE_CONTAINER_BASE_URL="$(_strip_lemonade_api_suffix "$LEMONADE_CONTAINER_BASE_URL")"
+
+    if [[ -z "${LEMONADE_MODEL:-}" ]]; then
+        local _api_base
+        _api_base="$(_lemonade_api_url "$LEMONADE_BASE_URL" "$LEMONADE_API_BASE_PATH")"
+        if LEMONADE_MODEL="$(_macos_discover_lemonade_model "$_api_base")"; then
+            ai_ok "Detected existing Lemonade chat model: ${LEMONADE_MODEL}"
+        else
+            ai_warn "Could not auto-detect a chat-capable Lemonade model from ${_api_base}/models."
+            ai_warn "Set LEMONADE_MODEL=<chat-model-id> before rerunning if install verification fails."
+        fi
+    fi
+
+    export LEMONADE_EXTERNAL LEMONADE_BASE_URL LEMONADE_CONTAINER_BASE_URL
+    export LEMONADE_API_BASE_PATH LEMONADE_API_KEY LEMONADE_MODEL
+}
+
+_read_install_env() {
+    local key="$1"
+    grep -m1 "^${key}=" "${INSTALL_DIR}/.env" 2>/dev/null | cut -d= -f2- | tr -d '"' | tr -d '\r' || true
+}
+
+_render_macos_external_lemonade_litellm_config() {
+    _macos_external_lemonade_active || return 0
+    local renderer="${INSTALL_DIR}/scripts/render-runtime-configs.py"
+    local pycmd="${DREAM_PYTHON_CMD:-python3}"
+    local litellm_key lemonade_key model api_base
+    litellm_key="$(_read_install_env LITELLM_LEMONADE_API_KEY)"
+    lemonade_key="$(_read_install_env LEMONADE_API_KEY)"
+    model="$(_read_install_env LEMONADE_MODEL)"
+    api_base="$(_lemonade_api_url "$(_read_install_env LEMONADE_CONTAINER_BASE_URL)" "$(_read_install_env LEMONADE_API_BASE_PATH)")"
+    [[ -n "$litellm_key" ]] || litellm_key="$lemonade_key"
+    [[ -n "$model" ]] || model="${LEMONADE_MODEL:-}"
+    [[ -n "$api_base" ]] || api_base="$(_lemonade_api_url "${LEMONADE_CONTAINER_BASE_URL:-http://host.docker.internal:13305}" "${LEMONADE_API_BASE_PATH:-/api/v1}")"
+
+    if [[ -f "$renderer" ]] && command -v "$pycmd" >/dev/null 2>&1; then
+        "$pycmd" "$renderer" \
+            --surface litellm-lemonade \
+            --dream-mode lemonade \
+            --gpu-backend apple \
+            --gguf-file "${GGUF_FILE:-}" \
+            --lemonade-model-id "$model" \
+            --lemonade-api-base "$api_base" \
+            --litellm-key "$litellm_key" \
+            --output-root "$INSTALL_DIR" \
+            --write >> "$DS_LOG_FILE" 2>&1 && {
+                ai_ok "Generated LiteLLM config for external Lemonade (model: ${model:-default})"
+                return 0
+            }
+        ai_warn "Runtime config renderer failed for external Lemonade; falling back to inline LiteLLM config."
+    fi
+
+    mkdir -p "$INSTALL_DIR/config/litellm"
+    cat > "$INSTALL_DIR/config/litellm/lemonade.yaml" << LITELLM_EOF
+model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/${model:-default}
+      api_base: ${api_base}
+      api_key: ${litellm_key}
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+  - model_name: "*"
+    litellm_params:
+      model: openai/${model:-default}
+      api_base: ${api_base}
+      api_key: ${litellm_key}
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 120
+  stream_timeout: 60
+LITELLM_EOF
+    ai_ok "Generated LiteLLM config for external Lemonade (model: ${model:-default})"
+}
+
+_verify_macos_external_lemonade_completion() {
+    _macos_external_lemonade_active || return 0
+    local litellm_key model response_file pycmd
+    litellm_key="$(_read_install_env LITELLM_KEY)"
+    model="$(_read_install_env LEMONADE_MODEL)"
+    [[ -n "$model" ]] || model="default"
+    response_file="$(mktemp /tmp/dream-macos-lemonade-completion.XXXXXX.json)"
+    if ! curl -fsS --max-time 180 \
+        -H "Content-Type: application/json" \
+        -H "Authorization: Bearer ${litellm_key}" \
+        -d "{\"model\":\"default\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":1,\"temperature\":0,\"stream\":false}" \
+        "http://127.0.0.1:${LITELLM_PORT:-4000}/v1/chat/completions" \
+        -o "$response_file" 2>>"$DS_LOG_FILE"; then
+        rm -f "$response_file"
+        ai_err "LiteLLM could not complete through external Lemonade (model: ${model})."
+        ai "Run: curl $(_lemonade_api_url "${LEMONADE_BASE_URL:-http://localhost:13305}" "${LEMONADE_API_BASE_PATH:-/api/v1}")/models"
+        ai "Then rerun with: LEMONADE_MODEL=<chat-model-id> ./install.sh --use-existing-lemonade ..."
+        return 1
+    fi
+    pycmd="${DREAM_PYTHON_CMD:-python3}"
+    if "$pycmd" - "$response_file" <<'PY'
+import json
+import sys
+
+try:
+    payload = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(1)
+for choice in payload.get("choices", []):
+    message = choice.get("message", {}) if isinstance(choice, dict) else {}
+    content = message.get("content") if isinstance(message, dict) else None
+    if isinstance(content, str) and content.strip():
+        sys.exit(0)
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and str(block.get("text") or "").strip():
+                sys.exit(0)
+    if isinstance(choice.get("text") if isinstance(choice, dict) else None, str) and choice["text"].strip():
+        sys.exit(0)
+sys.exit(1)
+PY
+    then
+        rm -f "$response_file"
+        ai_ok "External Lemonade completion verified through LiteLLM"
+        return 0
+    fi
+    rm -f "$response_file"
+    ai_err "External Lemonade returned no assistant content through LiteLLM (model: ${model})."
+    ai "Run: curl $(_lemonade_api_url "${LEMONADE_BASE_URL:-http://localhost:13305}" "${LEMONADE_API_BASE_PATH:-/api/v1}")/models"
+    ai "Then rerun with: LEMONADE_MODEL=<chat-model-id> ./install.sh --use-existing-lemonade ..."
     return 1
 }
 
@@ -560,9 +863,15 @@ ai_ok "Disk space OK"
 # Dream-owned venv and point shared Python helpers at that interpreter.
 _ensure_macos_pyyaml
 
+_prepare_macos_external_lemonade
+
 # Ollama conflict detection
-check_ollama_conflict
-if $OLLAMA_RUNNING; then
+if ! _macos_external_lemonade_active; then
+    check_ollama_conflict
+else
+    OLLAMA_RUNNING=false
+fi
+if ! _macos_external_lemonade_active && $OLLAMA_RUNNING; then
     ai_warn "Ollama is running (PID ${OLLAMA_PID}) and may conflict with Dream Server."
     ai "  Both use port 11434/8080. Ollama will shadow llama-server."
     if ! $NON_INTERACTIVE; then
@@ -584,7 +893,10 @@ if $OLLAMA_RUNNING; then
 fi
 
 # Port conflict checks — dynamically read from extension manifests
-_conflict_ports=(8080 11434)  # llama-server (native) + Ollama default (host conflict, no manifest)
+_conflict_ports=()
+if ! _macos_external_lemonade_active; then
+    _conflict_ports+=(8080 11434)  # llama-server (native) + Ollama default (host conflict, no manifest)
+fi
 for _manifest in "${SOURCE_ROOT}/extensions/services/"*/manifest.yaml; do
     [[ -f "$_manifest" ]] || continue
     _port=$(grep 'external_port_default:' "$_manifest" 2>/dev/null | awk '{print $2}' | tr -d '"') || true
@@ -651,7 +963,7 @@ if [[ -z "${MODEL_PROFILE:-}" ]]; then
 fi
 
 resolve_tier_config "$SELECTED_TIER"
-if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "$SELECTED_TIER" != "CLOUD" ]]; then
+if [[ "${DREAM_DISABLE_CATALOG_MODEL_SELECTOR:-false}" != "true" && "$SELECTED_TIER" != "CLOUD" ]] && ! _macos_external_lemonade_active; then
     _selector_script="${SOURCE_ROOT}/scripts/select-model.py"
     _selector_catalog="${SOURCE_ROOT}/config/model-library.json"
     if [[ -f "$_selector_script" && -f "$_selector_catalog" ]]; then
@@ -698,12 +1010,18 @@ ai_ok "Selected tier: ${SELECTED_TIER} (${TIER_NAME})"
 info_box "Model:" "${LLM_MODEL}"
 info_box "GGUF:" "${GGUF_FILE}"
 info_box "Context:" "${MAX_CONTEXT}"
+if _macos_external_lemonade_active; then
+    info_box "LLM Runtime:" "external Lemonade (${LEMONADE_BASE_URL})"
+    [[ -n "${LEMONADE_MODEL:-}" ]] && info_box "Lemonade Model:" "${LEMONADE_MODEL}"
+fi
 
 # Re-check disk space for model + Docker images. Prefer the catalog selector's
 # exact model size when available; it can choose entries that do not fit the
 # older tier-map filename heuristics.
 _model_size_mb="${LLM_MODEL_SIZE_MB:-0}"
-if [[ "$_model_size_mb" =~ ^[0-9]+$ && "$_model_size_mb" -gt 0 ]]; then
+if _macos_external_lemonade_active; then
+    NEEDED_GB=15
+elif [[ "$_model_size_mb" =~ ^[0-9]+$ && "$_model_size_mb" -gt 0 ]]; then
     _model_gb=$(( (_model_size_mb + 1023) / 1024 ))
     NEEDED_GB=$(( _model_gb + 15 ))
 elif [[ "$GGUF_FILE" =~ 80B|Coder-Next ]]; then
@@ -796,7 +1114,11 @@ fi
 
 if $ENABLE_HERMES && ! $CLOUD_MODE; then
     if [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
-        ai_warn "Hermes enabled: increasing macOS llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (128K)."
+        if _macos_external_lemonade_active; then
+            ai_warn "Hermes enabled: increasing macOS provider context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (128K)."
+        else
+            ai_warn "Hermes enabled: increasing macOS llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (128K)."
+        fi
         MAX_CONTEXT="$HERMES_CONTEXT_SIZE"
     fi
 fi
@@ -831,6 +1153,7 @@ if $DRY_RUN; then
     ai "[DRY RUN] Would create: ${INSTALL_DIR}"
     ai "[DRY RUN] Would copy source files"
     ai "[DRY RUN] Would generate .env with secrets"
+    _macos_external_lemonade_active && ai "[DRY RUN] Would configure external Lemonade runtime (${LEMONADE_BASE_URL})"
     ai "[DRY RUN] Would generate SearXNG config"
     $ENABLE_HERMES && ai "[DRY RUN] Would configure Hermes Agent (data: ${INSTALL_DIR}/data/hermes)"
     $ENABLE_OPENCLAW && ai "[DRY RUN] Would configure OpenClaw"
@@ -931,10 +1254,15 @@ else
     else
         ai_ok "Generated .env with secure secrets"
     fi
+    _render_macos_external_lemonade_litellm_config
     if $ENABLE_HERMES && ! $CLOUD_MODE; then
         upsert_env_value "${INSTALL_DIR}/.env" "MAX_CONTEXT" "$MAX_CONTEXT"
         upsert_env_value "${INSTALL_DIR}/.env" "CTX_SIZE" "$MAX_CONTEXT"
-        ai_ok "Set macOS llama context to ${MAX_CONTEXT} for Hermes"
+        if _macos_external_lemonade_active; then
+            ai_ok "Set macOS provider context to ${MAX_CONTEXT} for Hermes"
+        else
+            ai_ok "Set macOS llama context to ${MAX_CONTEXT} for Hermes"
+        fi
     fi
 
     # Generate SearXNG config
@@ -973,9 +1301,15 @@ fi
 show_phase 5 6 "LAUNCH" "2-30 minutes (model download)"
 
 if $DRY_RUN; then
-    [[ -n "$GGUF_URL" ]] && ai "[DRY RUN] Would download: ${GGUF_FILE}"
-    ai "[DRY RUN] Would download llama-server (Metal build)"
-    ai "[DRY RUN] Would start native llama-server on port 8080"
+    if _macos_external_lemonade_active; then
+        ai "[DRY RUN] Would skip native llama-server and route through external Lemonade via LiteLLM"
+    elif $CLOUD_MODE; then
+        ai "[DRY RUN] Would skip native llama-server and route through cloud APIs via LiteLLM"
+    else
+        [[ -n "$GGUF_URL" ]] && ai "[DRY RUN] Would download: ${GGUF_FILE}"
+        ai "[DRY RUN] Would download llama-server (Metal build)"
+        ai "[DRY RUN] Would start native llama-server on port 8080"
+    fi
     ai "[DRY RUN] Would run: docker compose up -d"
 else
     # Change to install directory for docker compose
@@ -983,7 +1317,7 @@ else
 
     # ── Bootstrap fast-start ──────────────────────────────────────────────
     _BOOTSTRAP_ACTIVE=false
-    if bootstrap_needed "$SELECTED_TIER" "$INSTALL_DIR" "$GGUF_FILE"; then
+    if ! _macos_external_lemonade_active && bootstrap_needed "$SELECTED_TIER" "$INSTALL_DIR" "$GGUF_FILE"; then
         _BOOTSTRAP_ACTIVE=true
         FULL_GGUF_FILE="$GGUF_FILE"
         FULL_GGUF_URL="$GGUF_URL"
@@ -1001,7 +1335,7 @@ else
     fi
 
     # ── Download GGUF model (if not cloud-only) ──
-    if [[ -n "$GGUF_URL" ]] && ! $CLOUD_MODE; then
+    if [[ -n "$GGUF_URL" ]] && ! $CLOUD_MODE && ! _macos_external_lemonade_active; then
         MODEL_PATH="${INSTALL_DIR}/data/models/${GGUF_FILE}"
 
         if [[ -f "$MODEL_PATH" ]]; then
@@ -1064,36 +1398,43 @@ else
     if ! $CLOUD_MODE; then
         _hermes_tpl="${INSTALL_DIR}/extensions/services/hermes/cli-config.yaml.template"
         if [[ -f "$_hermes_tpl" ]]; then
-            _hermes_base_url="http://host.docker.internal:${OLLAMA_PORT:-8080}/v1"
+            if _macos_external_lemonade_active; then
+                _hermes_base_url="http://litellm:4000/v1"
+                _hermes_model="${LEMONADE_MODEL:-$(_read_install_env LEMONADE_MODEL)}"
+                [[ -n "$_hermes_model" ]] || _hermes_model="default"
+            else
+                _hermes_base_url="http://host.docker.internal:${OLLAMA_PORT:-8080}/v1"
+                _hermes_model="$GGUF_FILE"
+            fi
             _hermes_patcher="${INSTALL_DIR}/scripts/patch-hermes-config.py"
             if [[ -f "$_hermes_patcher" ]]; then
                 python3 "$_hermes_patcher" "$_hermes_tpl" \
-                    --model "$GGUF_FILE" \
+                    --model "$_hermes_model" \
                     --base-url "$_hermes_base_url" \
                     --context-length "$MAX_CONTEXT" >>"$DS_LOG_FILE" 2>&1 || \
                     ai_warn "Hermes template patch failed — hand-edit ${_hermes_tpl} if prompts hang."
                 _hermes_live="${INSTALL_DIR}/data/hermes/config.yaml"
                 if [[ -f "$_hermes_live" ]]; then
                     python3 "$_hermes_patcher" "$_hermes_live" \
-                        --model "$GGUF_FILE" \
+                        --model "$_hermes_model" \
                         --base-url "$_hermes_base_url" \
                         --context-length "$MAX_CONTEXT" >>"$DS_LOG_FILE" 2>&1 || \
                         ai_warn "Hermes live config patch failed — hand-edit ${_hermes_live} and restart Hermes if prompts hang."
                 fi
             else
                 sed -i '' \
-                    -e "s|^  default: \"qwen3.5-9b\"|  default: \"${GGUF_FILE}\"|" \
+                    -e "s|^  default: \"qwen3.5-9b\"|  default: \"${_hermes_model}\"|" \
                     -e "s|^  base_url: \"http://llama-server:8080/v1\"|  base_url: \"${_hermes_base_url}\"|" \
                     -e "s|^  context_length: .*|  context_length: ${MAX_CONTEXT}|" \
                     -e "s|^    context_length: .*|    context_length: ${MAX_CONTEXT}|" \
                     "$_hermes_tpl"
             fi
-            if grep -q "host.docker.internal" "$_hermes_tpl" && \
-               grep -q "^  default: \"${GGUF_FILE}\"$" "$_hermes_tpl" && \
+            if grep -q "$_hermes_base_url" "$_hermes_tpl" && \
+               grep -q "^  default: \"${_hermes_model}\"$" "$_hermes_tpl" && \
                grep -q "^  context_length: ${MAX_CONTEXT}$" "$_hermes_tpl"; then
-                ai_ok "Patched Hermes config for macOS (model=${GGUF_FILE}, context=${MAX_CONTEXT}, base_url=host.docker.internal)"
+                ai_ok "Patched Hermes config for macOS (model=${_hermes_model}, context=${MAX_CONTEXT}, base_url=${_hermes_base_url})"
             else
-                ai_warn "Hermes template patch incomplete — Hermes may fail to reach llama-server. Hand-edit ${_hermes_tpl} if prompts hang."
+                ai_warn "Hermes template patch incomplete — Hermes may fail to reach the selected provider. Hand-edit ${_hermes_tpl} if prompts hang."
             fi
 
             # Render data/persona/SOUL.md = static persona + dynamic install
@@ -1114,7 +1455,7 @@ else
     fi
 
     # ── Download and start native llama-server (Metal) ──
-    if ! $CLOUD_MODE; then
+    if ! $CLOUD_MODE && ! _macos_external_lemonade_active; then
         chapter "NATIVE LLAMA-SERVER (METAL)"
 
         # Download llama.cpp Metal build
@@ -1315,9 +1656,11 @@ else
     # ── Assemble Docker Compose flags ──
     COMPOSE_FLAGS=("-f" "docker-compose.base.yml")
 
-    if $CLOUD_MODE; then
+    if _macos_external_lemonade_active; then
+        COMPOSE_FLAGS+=("-f" "docker-compose.cloud.yml" "-f" "docker-compose.lemonade-external.yml")
+    elif $CLOUD_MODE; then
         # Cloud mode: disable llama-server container
-        COMPOSE_FLAGS+=("-f" "installers/macos/docker-compose.macos.yml")
+        COMPOSE_FLAGS+=("-f" "docker-compose.cloud.yml")
     else
         # Normal macOS mode: native llama-server
         COMPOSE_FLAGS+=("-f" "installers/macos/docker-compose.macos.yml")
@@ -1326,7 +1669,7 @@ else
     # Discover enabled extension compose fragments via manifests
     EXT_DIR="${INSTALL_DIR}/extensions/services"
     CURRENT_BACKEND="apple"
-    $CLOUD_MODE && CURRENT_BACKEND="none"
+    { $CLOUD_MODE || _macos_external_lemonade_active; } && CURRENT_BACKEND="none"
     if ! $ENABLE_HERMES && ! $ENABLE_OPENCLAW; then
         ENABLE_APE=false
     fi
@@ -1632,21 +1975,34 @@ else
     if [[ -n "$OPENCODE_BIN" && -x "$OPENCODE_BIN" ]]; then
         mkdir -p "$OPENCODE_CONFIG_DIR"
         if [[ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]]; then
+            _opencode_provider="llama-server"
+            _opencode_provider_name="llama-server (local)"
+            _opencode_model="$LLM_MODEL"
+            _opencode_base_url="http://127.0.0.1:8080/v1"
+            _opencode_api_key="no-key"
+            if _macos_external_lemonade_active; then
+                _opencode_provider="litellm"
+                _opencode_provider_name="LiteLLM (external Lemonade)"
+                _opencode_model="${LEMONADE_MODEL:-$(_read_install_env LEMONADE_MODEL)}"
+                [[ -n "$_opencode_model" ]] || _opencode_model="default"
+                _opencode_base_url="http://127.0.0.1:${LITELLM_PORT:-4000}/v1"
+                _opencode_api_key="$(_read_install_env LITELLM_KEY)"
+            fi
             cat > "$OPENCODE_CONFIG_DIR/opencode.json" <<OPENCODE_EOF
 {
   "\$schema": "https://opencode.ai/config.json",
-  "model": "llama-server/${LLM_MODEL}",
+  "model": "${_opencode_provider}/${_opencode_model}",
   "provider": {
-    "llama-server": {
+    "${_opencode_provider}": {
       "npm": "@ai-sdk/openai-compatible",
-      "name": "llama-server (local)",
+      "name": "${_opencode_provider_name}",
       "options": {
-        "baseURL": "http://127.0.0.1:8080/v1",
-        "apiKey": "no-key"
+        "baseURL": "${_opencode_base_url}",
+        "apiKey": "${_opencode_api_key}"
       },
       "models": {
-        "${LLM_MODEL}": {
-          "name": "${LLM_MODEL}",
+        "${_opencode_model}": {
+          "name": "${_opencode_model}",
           "limit": {
             "context": ${MAX_CONTEXT:-32768},
             "output": 32768
@@ -1657,7 +2013,7 @@ else
   }
 }
 OPENCODE_EOF
-            ai_ok "OpenCode configured for local llama-server (model: ${LLM_MODEL})"
+            ai_ok "OpenCode configured for ${_opencode_provider_name} (model: ${_opencode_model})"
         else
             ai_ok "OpenCode config already exists"
         fi
@@ -1724,6 +2080,9 @@ PLIST_EOF
 fi
 
 # ── Dream Host Agent (extension lifecycle management) ──
+if $DRY_RUN; then
+    ai "[DRY RUN] Would install Dream host agent LaunchAgent"
+else
 AGENT_PYTHON="$(command -v python3)"
 if [[ -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && [[ -n "$AGENT_PYTHON" ]]; then
     # See opencode-web block above for the xpcproxy sandbox rationale behind
@@ -1815,6 +2174,7 @@ else
     [[ ! -f "${INSTALL_DIR}/bin/dream-host-agent.py" ]] && ai_warn "Host agent script not found, skipping"
     [[ -z "$AGENT_PYTHON" ]] && ai_warn "python3 not found, host agent not installed"
 fi
+fi
 
 # ============================================================================
 # PHASE 6 -- VERIFICATION
@@ -1822,8 +2182,12 @@ fi
 show_phase 6 6 "VERIFICATION" "30 seconds"
 
 if $DRY_RUN; then
+    _dry_run_llm_model="${LLM_MODEL}"
+    if _macos_external_lemonade_active; then
+        _dry_run_llm_model="${LEMONADE_MODEL:-default}"
+    fi
     ai "[DRY RUN] Would health-check all services"
-    ai "[DRY RUN] Would auto-configure Perplexica for ${LLM_MODEL}"
+    ai "[DRY RUN] Would auto-configure Perplexica for ${_dry_run_llm_model}"
     ai "[DRY RUN] Install validation complete"
     ai_ok "Dry run finished -- no changes made"
     exit 0
@@ -1840,9 +2204,15 @@ ALL_HEALTHY=true
 # runs natively on macOS via Metal; OpenCode is a LaunchAgent). Docker
 # services wait on `docker inspect ... .State.Health.Status == healthy`;
 # host-native services fall back to an HTTP probe on 127.0.0.1.
-HEALTH_NAMES=("LLM (llama-server)" "Chat UI (Open WebUI)")
-HEALTH_URLS=("http://127.0.0.1:8080/health" "http://127.0.0.1:3000")
-HEALTH_CONTAINERS=("" "dream-webui")
+if _macos_external_lemonade_active; then
+    HEALTH_NAMES=("LLM Gateway (external Lemonade via LiteLLM)" "Chat UI (Open WebUI)")
+    HEALTH_URLS=("http://127.0.0.1:${LITELLM_PORT:-4000}/health/readiness" "http://127.0.0.1:3000")
+    HEALTH_CONTAINERS=("dream-litellm" "dream-webui")
+else
+    HEALTH_NAMES=("LLM (llama-server)" "Chat UI (Open WebUI)")
+    HEALTH_URLS=("http://127.0.0.1:8080/health" "http://127.0.0.1:3000")
+    HEALTH_CONTAINERS=("" "dream-webui")
+fi
 $ENABLE_VOICE && HEALTH_NAMES+=("Whisper (STT)") && HEALTH_URLS+=("http://127.0.0.1:9000/health") && HEALTH_CONTAINERS+=("dream-whisper")
 $ENABLE_WORKFLOWS && HEALTH_NAMES+=("n8n (Workflows)") && HEALTH_URLS+=("http://127.0.0.1:5678/healthz") && HEALTH_CONTAINERS+=("dream-n8n")
 [[ -x "$OPENCODE_BIN" ]] && HEALTH_NAMES+=("OpenCode (IDE)") && HEALTH_URLS+=("http://127.0.0.1:${OPENCODE_PORT}") && HEALTH_CONTAINERS+=("")
@@ -1887,6 +2257,8 @@ for ((idx=0; idx<${#HEALTH_NAMES[@]}; idx++)); do
         ALL_HEALTHY=false
     fi
 done
+
+_verify_macos_external_lemonade_completion
 
 # ── Pre-download the Whisper STT model ──
 # Speaches does NOT auto-download on transcription requests — it returns 404.
@@ -1944,8 +2316,13 @@ fi
 
 # ── Auto-configure Perplexica ──
 ai "Configuring Perplexica..."
-if configure_perplexica 3004 "$LLM_MODEL"; then
-    ai_ok "Perplexica configured (model: ${LLM_MODEL})"
+_perplexica_model="${LLM_MODEL}"
+if _macos_external_lemonade_active; then
+    _perplexica_model="${LEMONADE_MODEL:-$(_read_install_env LEMONADE_MODEL)}"
+    [[ -n "$_perplexica_model" ]] || _perplexica_model="default"
+fi
+if configure_perplexica 3004 "$_perplexica_model"; then
+    ai_ok "Perplexica configured (model: ${_perplexica_model})"
 else
     ai_warn "Perplexica auto-config skipped -- complete setup at http://localhost:3004"
 fi
@@ -1977,7 +2354,11 @@ fi
 {
     printf 'Dashboard|http://127.0.0.1:3001|dream-dashboard|http://localhost:3001\n'
     printf 'Chat UI (Open WebUI)|http://127.0.0.1:3000|dream-webui|http://localhost:3000\n'
-    printf 'llama-server|http://127.0.0.1:8080/health||http://localhost:8080/v1\n'
+    if _macos_external_lemonade_active; then
+        printf 'External Lemonade|%s||%s\n' "$(_lemonade_api_url "${LEMONADE_BASE_URL:-http://localhost:13305}" "${LEMONADE_API_BASE_PATH:-/api/v1}")/health" "$(_lemonade_api_url "${LEMONADE_BASE_URL:-http://localhost:13305}" "${LEMONADE_API_BASE_PATH:-/api/v1}")"
+    else
+        printf 'llama-server|http://127.0.0.1:8080/health||http://localhost:8080/v1\n'
+    fi
     printf 'Dashboard API|http://127.0.0.1:3002/health|dream-dashboard-api|http://localhost:3002\n'
     printf 'LiteLLM|http://127.0.0.1:4000/health/readiness|dream-litellm|http://localhost:4000\n'
     printf 'Perplexica|http://127.0.0.1:3004|dream-perplexica|http://localhost:3004\n'

--- a/dream-server/installers/macos/lib/env-generator.sh
+++ b/dream-server/installers/macos/lib/env-generator.sh
@@ -170,9 +170,42 @@ generate_dream_env() {
     local detected_cpu_limit detected_cpu_reservation
     local tts_cpu_limit tts_cpu_reservation whisper_cpu_limit whisper_cpu_reservation
     local hermes_cpu_limit hermes_cpu_reservation comfyui_cpu_limit comfyui_cpu_reservation
+    local lemonade_external_value lemonade_base_url_value lemonade_container_base_url_value
+    local lemonade_api_base_path_value lemonade_model_value lemonade_port_value
+    local dream_mode_value llm_backend_value llm_api_url llm_api_base_path_value
+    local hermes_llm_base_url hermes_llm_api_key litellm_lemonade_api_key
     read -r cpu_limit_raw cpu_reservation_raw docker_available_cpus <<< "$(calculate_llama_cpu_budget "apple")"
     detected_cpu_limit="${cpu_limit_raw}.0"
     detected_cpu_reservation="${cpu_reservation_raw}.0"
+    lemonade_external_value="${LEMONADE_EXTERNAL:-false}"
+    case "${lemonade_external_value,,}" in
+        true|1|yes|on) lemonade_external_value="true" ;;
+        *) lemonade_external_value="false" ;;
+    esac
+    lemonade_base_url_value="${LEMONADE_BASE_URL:-}"
+    lemonade_container_base_url_value="${LEMONADE_CONTAINER_BASE_URL:-}"
+    lemonade_api_base_path_value="${LEMONADE_API_BASE_PATH:-/api/v1}"
+    lemonade_api_base_path_value="/${lemonade_api_base_path_value#/}"
+    lemonade_model_value="${LEMONADE_MODEL:-}"
+    lemonade_port_value="${AMD_INFERENCE_PORT:-13305}"
+    if [[ -n "$lemonade_base_url_value" && "$lemonade_base_url_value" =~ ^https?://[^/:]+:([0-9]+)(/|$) ]]; then
+        lemonade_port_value="${BASH_REMATCH[1]}"
+    fi
+    if [[ "$lemonade_external_value" == "true" ]]; then
+        dream_mode_value="lemonade"
+        llm_backend_value="lemonade"
+        llm_api_url="http://litellm:4000"
+        llm_api_base_path_value="$lemonade_api_base_path_value"
+        hermes_llm_base_url="http://litellm:4000/v1"
+        hermes_llm_api_key="\${LITELLM_KEY}"
+    else
+        dream_mode_value="local"
+        llm_backend_value="llama-server"
+        llm_api_url="http://host.docker.internal:8080"
+        llm_api_base_path_value="/v1"
+        hermes_llm_base_url="http://host.docker.internal:8080/v1"
+        hermes_llm_api_key="sk-dream-hermes-local"
+    fi
 
     # Idempotency: preserve existing .env (and secrets) unless --force was provided.
     if [[ -f "$env_path" ]] && [[ "$force_overwrite" != "true" ]]; then
@@ -275,6 +308,30 @@ generate_dream_env() {
                 upsert_env_value "$env_path" "HOST_LAN_IP" "$_host_lan_ip"
             fi
         fi
+        if [[ "$lemonade_external_value" == "true" ]]; then
+            litellm_lemonade_api_key="${LEMONADE_API_KEY:-$(read_env_value "$env_path" "LITELLM_LEMONADE_API_KEY")}"
+            upsert_env_value "$env_path" "DREAM_MODE" "lemonade"
+            upsert_env_value "$env_path" "LLM_BACKEND" "lemonade"
+            upsert_env_value "$env_path" "LLM_API_URL" "$llm_api_url"
+            upsert_env_value "$env_path" "LLM_API_BASE_PATH" "$llm_api_base_path_value"
+            upsert_env_value "$env_path" "LEMONADE_EXTERNAL" "true"
+            upsert_env_value "$env_path" "LEMONADE_BASE_URL" "$lemonade_base_url_value"
+            upsert_env_value "$env_path" "LEMONADE_CONTAINER_BASE_URL" "$lemonade_container_base_url_value"
+            upsert_env_value "$env_path" "LEMONADE_API_BASE_PATH" "$lemonade_api_base_path_value"
+            upsert_env_value "$env_path" "LEMONADE_MODEL" "$lemonade_model_value"
+            upsert_env_value "$env_path" "LITELLM_LEMONADE_API_KEY" "$litellm_lemonade_api_key"
+            upsert_env_value "$env_path" "AMD_INFERENCE_RUNTIME" "lemonade"
+            upsert_env_value "$env_path" "AMD_INFERENCE_BACKEND" "${AMD_INFERENCE_BACKEND:-auto}"
+            upsert_env_value "$env_path" "AMD_INFERENCE_LOCATION" "host"
+            upsert_env_value "$env_path" "AMD_INFERENCE_PORT" "$lemonade_port_value"
+            upsert_env_value "$env_path" "AMD_INFERENCE_SUPPORTED_BACKENDS" "${AMD_INFERENCE_SUPPORTED_BACKENDS:-metal,auto}"
+            upsert_env_value "$env_path" "AMD_INFERENCE_RUNTIME_MODE" "external-lemonade"
+            upsert_env_value "$env_path" "AMD_INFERENCE_MANAGED" "false"
+            upsert_env_value "$env_path" "HERMES_LLM_BASE_URL" "$hermes_llm_base_url"
+            upsert_env_value "$env_path" "HERMES_LLM_API_KEY" "$(read_env_value "$env_path" "LITELLM_KEY")"
+        else
+            [[ -z "$(read_env_value "$env_path" "LLM_BACKEND")" ]] && upsert_env_value "$env_path" "LLM_BACKEND" "llama-server"
+        fi
         return 0
     fi
 
@@ -285,6 +342,8 @@ generate_dream_env() {
     n8n_pass=$(new_secure_base64 16)
     local litellm_key
     litellm_key="sk-dream-$(new_secure_hex 16)"
+    litellm_lemonade_api_key="${LEMONADE_API_KEY:-}"
+    [[ "$lemonade_external_value" == "true" ]] && hermes_llm_api_key="$litellm_key"
     local livekit_secret
     livekit_secret=$(new_secure_base64 32)
     local livekit_api_key
@@ -345,9 +404,6 @@ generate_dream_env() {
     langfuse_init_project_id=$(new_secure_hex 16)
     local langfuse_init_user_password
     langfuse_init_user_password=$(new_secure_hex 16)
-    # macOS: llama-server runs natively, containers reach it via host.docker.internal
-    local llm_api_url="http://host.docker.internal:8080"
-
     # Host LAN IP — only populated when the operator has pre-set
     # BIND_ADDRESS=0.0.0.0 in the environment (macOS has no --lan flag).
     # Used by openclaw to extend allowedOrigins for LAN clients.
@@ -381,8 +437,23 @@ DREAM_DEVICE_NAME=${device_name}
 DREAM_AGENT_HOST=${DREAM_AGENT_HOST:-host.docker.internal}
 
 #=== LLM Backend Mode ===
-DREAM_MODE=local
+DREAM_MODE=${dream_mode_value}
+LLM_BACKEND=${llm_backend_value}
 LLM_API_URL=${llm_api_url}
+LLM_API_BASE_PATH=${llm_api_base_path_value}
+LEMONADE_EXTERNAL=${lemonade_external_value}
+LEMONADE_BASE_URL=${lemonade_base_url_value}
+LEMONADE_CONTAINER_BASE_URL=${lemonade_container_base_url_value}
+LEMONADE_API_BASE_PATH=${lemonade_api_base_path_value}
+LEMONADE_MODEL=${lemonade_model_value}
+LITELLM_LEMONADE_API_KEY=${litellm_lemonade_api_key}
+AMD_INFERENCE_RUNTIME=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "lemonade"; fi)
+AMD_INFERENCE_BACKEND=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "${AMD_INFERENCE_BACKEND:-auto}"; fi)
+AMD_INFERENCE_LOCATION=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "host"; fi)
+AMD_INFERENCE_PORT=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "$lemonade_port_value"; fi)
+AMD_INFERENCE_SUPPORTED_BACKENDS=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "${AMD_INFERENCE_SUPPORTED_BACKENDS:-metal,auto}"; fi)
+AMD_INFERENCE_RUNTIME_MODE=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "external-lemonade"; fi)
+AMD_INFERENCE_MANAGED=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "false"; fi)
 
 #=== Cloud API Keys ===
 ANTHROPIC_API_KEY=
@@ -390,7 +461,10 @@ OPENAI_API_KEY=
 TOGETHER_API_KEY=
 MINIMAX_API_KEY=
 
-#=== LLM Settings (llama-server -- native Metal) ===
+#=== Local Model Settings ===
+# Used by the native Metal llama-server path. In external Lemonade mode these
+# values remain as local fallback metadata while LEMONADE_MODEL controls the
+# app-facing chat route through LiteLLM.
 MODEL_PROFILE=${MODEL_PROFILE_REQUESTED:-${MODEL_PROFILE:-qwen}}
 # Effective model profile for this hardware: ${MODEL_PROFILE_EFFECTIVE:-qwen}
 LLM_MODEL=${LLM_MODEL}
@@ -447,9 +521,11 @@ OPENCLAW_PORT=7860
 LANGFUSE_PORT=3006
 
 #=== Hermes Agent ===
-# macOS runs llama-server natively with Metal; containers reach it via host.docker.internal.
-HERMES_LLM_BASE_URL=http://host.docker.internal:8080/v1
-HERMES_LLM_API_KEY=sk-dream-hermes-local
+# macOS local mode runs llama-server natively with Metal. External Lemonade mode
+# routes Hermes through LiteLLM so the selected Lemonade model and auth are
+# centralized in config/litellm/lemonade.yaml.
+HERMES_LLM_BASE_URL=${hermes_llm_base_url}
+HERMES_LLM_API_KEY=${hermes_llm_api_key}
 HERMES_LANGUAGE=en
 HERMES_PROXY_PORT=9120
 HERMES_PROXY_UPSTREAM=dream-hermes:9119

--- a/dream-server/installers/windows/dream.ps1
+++ b/dream-server/installers/windows/dream.ps1
@@ -647,7 +647,7 @@ function Stop-DreamOpenCodeRuntime {
     $processes = @(Get-CimInstance Win32_Process -ErrorAction SilentlyContinue)
     $byPid = @{}
     foreach ($proc in $processes) {
-        if ($proc.ProcessId -ne $null) {
+        if ($null -ne $proc.ProcessId) {
             $byPid[[int]$proc.ProcessId] = $proc
         }
     }

--- a/dream-server/tests/contracts/test-external-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-external-lemonade-contracts.sh
@@ -52,6 +52,44 @@ grep -q '_env_get_explicit_first LEMONADE_MODEL' installers/phases/06-directorie
 grep -q '_env_get_explicit_first LEMONADE_BASE_URL' installers/phases/06-directories.sh \
   || { echo "[FAIL] explicit LEMONADE_BASE_URL/--lemonade-url must override stale .env values during reinstall"; exit 1; }
 
+echo "[contract] macOS external Lemonade uses the provider route instead of native llama-server"
+grep -Fq -- '--use-existing-lemonade' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must accept --use-existing-lemonade"; exit 1; }
+grep -Fq -- '--lemonade-url' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must accept --lemonade-url"; exit 1; }
+grep -Fq '_prepare_macos_external_lemonade' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must normalize and discover external Lemonade"; exit 1; }
+grep -Fq '_render_macos_external_lemonade_litellm_config' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must render LiteLLM config for external Lemonade"; exit 1; }
+grep -Fq '_verify_macos_external_lemonade_completion' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must verify a real external Lemonade completion"; exit 1; }
+grep -Fq '_require_arg "$1" "${2:-}"' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must fail clearly when Lemonade flags are missing values"; exit 1; }
+grep -Fq 'true|1|yes|on) LEMONADE_EXTERNAL=true' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must normalize truthy LEMONADE_EXTERNAL values"; exit 1; }
+grep -Fq 'true|1|yes|on) lemonade_external_value="true"' installers/macos/lib/env-generator.sh \
+  || { echo "[FAIL] macOS env generator must normalize truthy LEMONADE_EXTERNAL values"; exit 1; }
+grep -Fq 'docker-compose.cloud.yml" "-f" "docker-compose.lemonade-external.yml' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS external Lemonade must use cloud + external Lemonade overlays"; exit 1; }
+grep -Fq 'if ! $CLOUD_MODE && ! _macos_external_lemonade_active' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS external Lemonade must not start native llama-server"; exit 1; }
+grep -Fq 'VOICE_EXPLICIT' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS installer must track explicit feature opt-outs"; exit 1; }
+grep -Fq '$VOICE_EXPLICIT || ENABLE_VOICE=true' installers/macos/install-macos.sh \
+  || { echo "[FAIL] macOS --all must not override explicit --no-voice"; exit 1; }
+grep -Fq 'LEMONADE_EXTERNAL=${lemonade_external_value}' installers/macos/lib/env-generator.sh \
+  || { echo "[FAIL] macOS env generator must write LEMONADE_EXTERNAL"; exit 1; }
+grep -Fq 'DREAM_MODE=${dream_mode_value}' installers/macos/lib/env-generator.sh \
+  || { echo "[FAIL] macOS env generator must switch DREAM_MODE for external Lemonade"; exit 1; }
+grep -Fq 'LLM_BACKEND=${llm_backend_value}' installers/macos/lib/env-generator.sh \
+  || { echo "[FAIL] macOS env generator must switch LLM_BACKEND for external Lemonade"; exit 1; }
+grep -Fq 'HERMES_LLM_BASE_URL=${hermes_llm_base_url}' installers/macos/lib/env-generator.sh \
+  || { echo "[FAIL] macOS env generator must route Hermes through the selected provider"; exit 1; }
+grep -Fq 'AMD_INFERENCE_RUNTIME_MODE=$(if [[ "$lemonade_external_value" == "true" ]]; then echo "external-lemonade"; fi)' installers/macos/lib/env-generator.sh \
+  || { echo "[FAIL] macOS env generator must mark unmanaged external Lemonade runtime mode"; exit 1; }
+grep -Fq 'litellm_lemonade_api_key="${LEMONADE_API_KEY:-$(read_env_value "$env_path" "LITELLM_LEMONADE_API_KEY")}"' installers/macos/lib/env-generator.sh \
+  || { echo "[FAIL] macOS explicit Lemonade API key must override stale LITELLM_LEMONADE_API_KEY during reinstall"; exit 1; }
+
 echo "[contract] explicit LAN binding overrides stale env during reinstall"
 grep -q 'BIND_ADDRESS_EXPLICIT' install-core.sh \
   || { echo "[FAIL] install-core must track explicit --lan/BIND_ADDRESS"; exit 1; }
@@ -88,23 +126,48 @@ grep -q 'DS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE' scripts/dream-
 grep -q 'sk-dream-lemonade-' scripts/dream-doctor.sh \
   || { echo "[FAIL] dream-doctor must distinguish installer-generated LiteLLM provider keys from user Lemonade API keys"; exit 1; }
 
-echo "[contract] resolver selects cloud + external overlay instead of managed AMD overlay"
-resolved="$(LEMONADE_EXTERNAL=true DREAM_MODE=lemonade \
-  ./scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" --dream-mode lemonade --gpu-backend amd --tier SH_LARGE --env)"
-grep -q 'docker-compose.cloud.yml' <<<"$resolved" \
-  || { echo "[FAIL] external Lemonade must include cloud overlay to disable managed llama-server"; exit 1; }
-grep -q 'docker-compose.lemonade-external.yml' <<<"$resolved" \
-  || { echo "[FAIL] external Lemonade overlay missing from resolved stack"; exit 1; }
-if grep -q 'docker-compose.amd.yml' <<<"$resolved"; then
-  echo "[FAIL] external Lemonade must not include managed AMD overlay"
-  exit 1
-fi
-if grep -q 'compose.local.yaml' <<<"$resolved"; then
-  echo "[FAIL] external Lemonade must not include local llama-server dependency overlays"
-  exit 1
-fi
-grep -Eq 'extensions[\\/]+services[\\/]+litellm[\\/]+compose.yaml' <<<"$resolved" \
-  || { echo "[FAIL] external Lemonade must keep LiteLLM gateway enabled"; exit 1; }
+echo "[contract] resolver selects cloud + external overlay instead of managed hardware overlays"
+for backend in amd nvidia cpu; do
+  resolved="$(LEMONADE_EXTERNAL=true DREAM_MODE=lemonade \
+    ./scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" --dream-mode lemonade --gpu-backend "$backend" --tier 2 --env)"
+  grep -q 'docker-compose.cloud.yml' <<<"$resolved" \
+    || { echo "[FAIL] external Lemonade must include cloud overlay to disable managed llama-server for $backend"; exit 1; }
+  grep -q 'docker-compose.lemonade-external.yml' <<<"$resolved" \
+    || { echo "[FAIL] external Lemonade overlay missing from resolved stack for $backend"; exit 1; }
+  if grep -q 'docker-compose.amd.yml' <<<"$resolved"; then
+    echo "[FAIL] external Lemonade must not include managed AMD overlay for $backend"
+    exit 1
+  fi
+  if grep -q 'docker-compose.nvidia.yml' <<<"$resolved"; then
+    echo "[FAIL] external Lemonade must not include managed NVIDIA overlay for $backend"
+    exit 1
+  fi
+  if grep -q 'docker-compose.cpu.yml' <<<"$resolved"; then
+    echo "[FAIL] external Lemonade must not include managed CPU overlay for $backend"
+    exit 1
+  fi
+  if grep -q 'compose.local.yaml' <<<"$resolved"; then
+    echo "[FAIL] external Lemonade must not include local llama-server dependency overlays for $backend"
+    exit 1
+  fi
+  grep -Eq 'extensions[\\/]+services[\\/]+litellm[\\/]+compose.yaml' <<<"$resolved" \
+    || { echo "[FAIL] external Lemonade must keep LiteLLM gateway enabled for $backend"; exit 1; }
+done
+
+echo "[contract] external Lemonade mode survives CPU fallback"
+fallback_mode="$(LEMONADE_EXTERNAL=true DREAM_MODE=lemonade bash -c '
+  set -euo pipefail
+  SCRIPT_DIR="'"$ROOT_DIR"'"
+  ai_warn() { :; }
+  ai() { :; }
+  warn() { :; }
+  log() { :; }
+  . installers/lib/detection.sh
+  apply_cpu_gpu_fallback "contract fallback"
+  printf "%s:%s\n" "$DREAM_MODE" "$GPU_BACKEND"
+')"
+[[ "$fallback_mode" == "lemonade:cpu" ]] \
+  || { echo "[FAIL] external Lemonade CPU fallback must preserve DREAM_MODE=lemonade, got $fallback_mode"; exit 1; }
 
 echo "[contract] external Lemonade resolved compose config is valid"
 if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then

--- a/dream-server/tests/test-macos-host-agent-verification.sh
+++ b/dream-server/tests/test-macos-host-agent-verification.sh
@@ -43,6 +43,18 @@ plist_block="$(awk '
     in_block && /^AGENT_PLIST_EOF/ { exit }
 ' "$TARGET" | grep -v '^[[:space:]]*#')"
 
+host_agent_section="$(awk '
+    /^# ── Dream Host Agent/ { in_block=1 }
+    in_block { print }
+    in_block && /^# ={20,}/ { exit }
+' "$TARGET" | grep -v '^[[:space:]]*#')"
+
+grep -qF 'if $DRY_RUN; then' <<<"$host_agent_section" \
+    || fail "dry-run must skip host-agent LaunchAgent mutation"
+grep -qF 'ai "[DRY RUN] Would install Dream host agent LaunchAgent"' <<<"$host_agent_section" \
+    || fail "dry-run must report host-agent LaunchAgent without installing it"
+pass "host-agent LaunchAgent is skipped during dry-run"
+
 grep -qF '<string>--install-dir</string>' <<<"$plist_block" \
     || fail "host-agent LaunchAgent must pass --install-dir explicitly"
 grep -qF '<string>${INSTALL_DIR}</string>' <<<"$plist_block" \


### PR DESCRIPTION
## Overview

This PR adds a dedicated macOS install path for operators who already have Lemonade SDK running outside Dream Server.

The default macOS runtime is unchanged: Dream Server still uses native host `llama-server` with Metal acceleration unless the operator explicitly opts into external Lemonade with `--use-existing-lemonade`.

When external Lemonade is selected, the macOS installer now treats Lemonade as an unmanaged provider, keeps Dream Server from starting native `llama-server`, and routes app traffic through LiteLLM using the selected Lemonade chat model.

## Runtime Matrix

| macOS mode | LLM process owner | Dream route | Native `llama-server` | LiteLLM | Intended use |
| --- | --- | --- | --- | --- | --- |
| Default local | Dream Server | `host.docker.internal:8080` | Enabled | Enabled for bundled services | Normal Apple Silicon / Metal install |
| Cloud | External hosted API | LiteLLM cloud route | Disabled | Enabled | Public/provider API installs |
| External Lemonade | Operator-managed Lemonade SDK | LiteLLM -> Lemonade SDK | Disabled | Enabled | Existing local/LAN Lemonade service |

## What Changed

### macOS installer support

- Adds explicit macOS flags for external Lemonade installs:
  - `--use-existing-lemonade`
  - `--lemonade-url`
  - `--lemonade-api-key`
  - `--no-voice`, `--no-workflows`, `--no-rag`, and `--no-comfyui` parity for minimal/headless installs
- Normalizes Lemonade URLs and strips accidental `/api`, `/api/v1`, or `/v1` suffixes before composing API routes.
- Maps host loopback URLs such as `localhost` and `127.0.0.1` to `host.docker.internal` for Docker Desktop containers.
- Uses bearer auth during Lemonade health/model discovery when a Lemonade API key is supplied.
- Auto-discovers a chat-capable Lemonade model when `LEMONADE_MODEL` is not provided, while avoiding obvious image/STT/TTS/embedding/rerank models.

### Runtime configuration

- Generates macOS `.env` with the external-provider contract:
  - `DREAM_MODE=lemonade`
  - `LLM_BACKEND=lemonade`
  - `LEMONADE_EXTERNAL=true`
  - `LEMONADE_BASE_URL`
  - `LEMONADE_CONTAINER_BASE_URL`
  - `LEMONADE_API_BASE_PATH`
  - `LEMONADE_MODEL`
  - unmanaged runtime diagnostics such as `AMD_INFERENCE_RUNTIME_MODE=external-lemonade`
- Renders `config/litellm/lemonade.yaml` for the selected Lemonade model and endpoint.
- Routes Hermes through `http://litellm:4000/v1` in external Lemonade mode instead of the native macOS `llama-server` route.
- Routes OpenCode and Perplexica to the selected external Lemonade model when those services are enabled.
- Verifies a real non-empty chat completion through LiteLLM before install readiness is reported.

### Safety and reinstall behavior

- Skips native Metal `llama-server`, local GGUF download, bootstrap swap, Ollama conflict checks, and local llama-server port checks when external Lemonade is active.
- Preserves `DREAM_MODE=lemonade` during CPU fallback when `LEMONADE_EXTERNAL=true`, so unmanaged Lemonade installs do not accidentally fall back to local llama-server routing.
- Lets an explicit `--lemonade-api-key` / `LEMONADE_API_KEY` override a stale `LITELLM_LEMONADE_API_KEY` during reinstall, while preserving the existing provider key when no new key is supplied.
- Keeps macOS `--dry-run` side-effect free by skipping Dream host-agent LaunchAgent registration and reporting it as a planned action instead.
- Keeps local Metal, cloud, and external Lemonade behavior separated in dry-run output and runtime setup.
- Includes a one-line Windows PSScriptAnalyzer cleanup from the current base branch so the full lint matrix stays green after rebasing.

## Scope / Non-Goals

- Does not make Lemonade the default macOS runtime.
- Does not install, start, stop, upgrade, or manage Lemonade SDK on macOS.
- Does not claim macOS ComfyUI GPU support; `--no-comfyui` is accepted only for cross-platform install-script parity and remains a no-op on macOS.
- Does not include dashboard/provider capability diagnostics work; this is a standalone macOS external-Lemonade support branch.

## User-Facing Recovery Hints

If the selected Lemonade model cannot produce chat completions, the installer now points operators toward the model list and rerun path:

```bash
curl http://localhost:13305/api/v1/models
LEMONADE_MODEL=<chat-model-id> ./install.sh --use-existing-lemonade ...
```

For macOS Docker Desktop installs, `localhost` Lemonade endpoints are translated for containers through `host.docker.internal`, while user-facing recovery commands remain host-local.

## Validation

| Area | Result |
| --- | --- |
| Shell syntax | `bash -n` passed for touched macOS/shared shell paths |
| External Lemonade contracts | `bash dream-server/tests/contracts/test-external-lemonade-contracts.sh` passed |
| Installer contracts | `bash dream-server/tests/contracts/test-installer-contracts.sh` passed |
| Runtime renderer tests | `DREAM_PYTHON_CMD=python3 python3 dream-server/tests/test-render-runtime-configs.py` passed |
| Env schema tests | `bash dream-server/tests/test-validate-env.sh` passed |
| Host-agent dry-run guard | `bash dream-server/tests/test-macos-host-agent-verification.sh` passed |
| Generated env fixture | macOS external-Lemonade `.env` validates against `.env.schema.json` |
| Reinstall fixture | Explicit Lemonade API key overrides stale provider key without rotating `LITELLM_KEY` |
| macOS dry-run | External Lemonade dry-run skips native llama-server and does not install the host-agent LaunchAgent |
| Remote CI | PR matrix is expected to cover Linux distro smoke, macOS smoke, API/frontend, integration smoke, env tiers, and PowerShell lint |

#Draft Note

Keeping this as a draft. The PR is intentionally self-contained: a focused commit, with no accumulated changes to provider-diagnostics, and the default Metal path on macOS remains unchanged unless external Lemonade is explicitly requested.
