### PR TITLE
fix(gpu): assign llama_server on single-GPU hosts when --enabled-services omits it

### DIFF
--- a/dream-server/scripts/assign_gpus.py
+++ b/dream-server/scripts/assign_gpus.py
@@ -465,6 +465,11 @@ def main():
         services = {}
         for s in enabled_services:
             services[s] = ServiceAssignment(gpus=[gpu])
+        # llama_server always runs on the single GPU, even when the caller's
+        # --enabled-services list omits it. This mirrors the multi-GPU path,
+        # where assign_services() assigns llama_server unconditionally; without
+        # it, the line below raised KeyError: 'llama_server'.
+        services.setdefault("llama_server", ServiceAssignment(gpus=[gpu]))
         services["llama_server"].parallelism = parallelism
         result = AssignmentResult(strategy="single", services=services)
         print(json.dumps(build_output(result), indent=2))

--- a/dream-server/tests/test-assign-gpus.py
+++ b/dream-server/tests/test-assign-gpus.py
@@ -9,11 +9,11 @@ FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures/topology_json")
 def fixture_path(name):
     return os.path.join(FIXTURES_DIR, name)
 
-def run(topology_path, model_size_mb):
-    result = subprocess.run(
-        [sys.executable, SCRIPT, "--topology", topology_path, "--model-size", str(model_size_mb)],
-        capture_output=True, text=True,
-    )
+def run(topology_path, model_size_mb, enabled_services=None):
+    cmd = [sys.executable, SCRIPT, "--topology", topology_path, "--model-size", str(model_size_mb)]
+    if enabled_services is not None:
+        cmd += ["--enabled-services", enabled_services]
+    result = subprocess.run(cmd, capture_output=True, text=True)
     output = None
     if result.returncode == 0:
         output = json.loads(result.stdout)["gpu_assignment"]
@@ -67,6 +67,34 @@ class TestSingleGpu:
     def test_no_topology_analysis_needed(self):
         rc, out, _ = run(self.TOPO, 10000)
         assert rc == 0
+
+
+# ── 1 GPU — custom --enabled-services ─────────────────────────────────────────
+
+class TestSingleGpuEnabledServices:
+    """Regression: the single-GPU path must not crash when --enabled-services
+    omits llama_server, and must still assign llama_server (as the multi-GPU
+    path does)."""
+    TOPO = fixture_path("nvidia_smi_topo_matrix_1gpu_pcie.json")
+    UUID = "GPU-12345678-1234-1234-1234-123456789012"
+
+    def test_omitting_llama_server_does_not_crash(self):
+        rc, _, stderr = run(self.TOPO, 10000, enabled_services="whisper,embeddings")
+        assert rc == 0, stderr
+
+    def test_llama_server_assigned_even_when_omitted(self):
+        _, out, _ = run(self.TOPO, 10000, enabled_services="whisper,embeddings")
+        assert out["services"]["llama_server"]["gpus"] == [self.UUID]
+        assert parallelism(out)["mode"] == "none"
+
+    def test_only_requested_services_plus_llama(self):
+        _, out, _ = run(self.TOPO, 10000, enabled_services="whisper,embeddings")
+        assert set(out["services"]) == {"llama_server", "whisper", "embeddings"}
+
+    def test_explicit_llama_server_unchanged(self):
+        _, out, _ = run(self.TOPO, 10000, enabled_services="llama_server,whisper")
+        assert set(out["services"]) == {"llama_server", "whisper"}
+        assert out["services"]["whisper"]["gpus"] == [self.UUID]
 
 
 # ── 2 GPU — rank-first means PHB pair always wins over single GPU ─────────────


### PR DESCRIPTION
## Problem

On a single-GPU host, `scripts/assign_gpus.py` crashes with `KeyError: 'llama_server'` when `--enabled-services` is passed without `llama_server`.

The single-GPU early-exit builds its service map purely from `--enabled-services`, then indexes `services["llama_server"]` unconditionally to attach parallelism:

```python
services = {}
for s in enabled_services:
    services[s] = ServiceAssignment(gpus=[gpu])
services["llama_server"].parallelism = parallelism   # KeyError if not in the list
```

**Reproduce:**

```console
$ python3 scripts/assign_gpus.py \
    --topology tests/fixtures/topology_json/nvidia_smi_topo_matrix_1gpu_pcie.json \
    --model-size 10000 --enabled-services whisper,embeddings
Traceback (most recent call last):
  ...
  File "scripts/assign_gpus.py", line 468, in main
    services["llama_server"].parallelism = parallelism
KeyError: 'llama_server'
```

`--enabled-services` is a documented flag (it's in the script's own usage header).

## Fix

The multi-GPU path never has this bug — `assign_services()` assigns `llama_server` unconditionally. This makes the single-GPU path follow the same contract via `setdefault`, so `llama_server` always gets the GPU even when the caller's list omits it:

```python
services.setdefault("llama_server", ServiceAssignment(gpus=[gpu]))
services["llama_server"].parallelism = parallelism
```

## Tests

Adds a `TestSingleGpuEnabledServices` regression class to `tests/test-assign-gpus.py` covering the `--enabled-services` path (no-crash, `llama_server` still assigned, requested services present, explicit-include unchanged). The new tests **fail on the pre-fix code** and pass after.

- `python3 -m pytest tests/test-assign-gpus.py` → **84 passed** (80 existing + 4 new)
- Default invocation (no `--enabled-services`) output is unchanged.

One concern, ~5-line fix + test. No behavior change to existing paths.
