### PR TITLE
fix(macos): use portable stat fallback in dream-test-functional.sh

### DIFF
--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -231,7 +231,7 @@ test_whisper_functional() {
         return 0
     fi
     
-    if [[ ! -f "$test_audio" ]] || [[ $(stat -c%s "$test_audio" 2>/dev/null) -lt 1000 ]]; then
+    if [[ ! -f "$test_audio" ]] || [[ "$(stat -c%s "$test_audio" 2>/dev/null || stat -f%z "$test_audio" 2>/dev/null || echo 0)" -lt 1000 ]]; then
         warn "Test audio generation failed"
         return 0
     fi


### PR DESCRIPTION
## Problem

`scripts/dream-test-functional.sh` sizes the generated Whisper test audio with a GNU-only `stat` flag:

```bash
if [[ ! -f "$test_audio" ]] || [[ $(stat -c%s "$test_audio" 2>/dev/null) -lt 1000 ]]; then
    warn "Test audio generation failed"
    return 0
fi
```

On macOS, `stat` is BSD and rejects `-c`. The `2>/dev/null` swallows the error, so the command substitution is **empty**, and `[[ "" -lt 1000 ]]` evaluates **true**. Result: a perfectly valid audio file is reported as *"Test audio generation failed"* and the Whisper functional test is **silently skipped** on every Mac.

The script already requires Bash 4+ (`brew install bash`), but that does not change the system `/usr/bin/stat`, so the bug fires regardless.

**Reproduce on macOS** (same predicate, against a valid 2 KB file):

```console
$ f=$(mktemp); head -c 2048 /dev/zero > "$f"
$ if [[ $(stat -c%s "$f" 2>/dev/null) -lt 1000 ]]; then echo "FAILED (bug)"; else echo ok; fi
FAILED (bug)
$ stat -c%s "$f"
stat: illegal option -- c
```

## Fix

Add the BSD `stat -f%z` fallback, matching the portable form **already used in the same file** for the TTS file-size check (line 154):

```bash
... || [[ "$(stat -c%s "$test_audio" 2>/dev/null || stat -f%z "$test_audio" 2>/dev/null || echo 0)" -lt 1000 ]]; then
```

After the fix, the 2 KB file is correctly treated as valid, while a genuinely tiny file is still flagged:

| file | before | after |
|---|---|---|
| 2048-byte valid audio | `FAILED` (bug) | `ok` |
| 10-byte tiny file | `FAILED` | `FAILED` (correct) |

One-line change, mirrors existing in-file convention. `make lint` passes.
