### PR TITLE
fix(extensions): make generate-extensions-catalog.py import on Python 3.9

### DIFF
--- a/dream-server/scripts/generate-extensions-catalog.py
+++ b/dream-server/scripts/generate-extensions-catalog.py
@@ -6,6 +6,8 @@ extracts catalog-relevant fields, and writes a sorted JSON catalog
 to dream-server/config/extensions-catalog.json.
 """
 
+from __future__ import annotations
+
 import argparse
 import json
 import re


### PR DESCRIPTION
## Problem

`scripts/generate-extensions-catalog.py` uses PEP 604 / PEP 585 annotations that are evaluated at definition time:

```python
def load_manifest(manifest_path: Path) -> dict | None:   # line 54
...
def ... -> list[dict]:
```

On **Python 3.9** — which macOS ships as `/usr/bin/python3` — importing the module raises:

```console
$ python3 scripts/generate-extensions-catalog.py --help
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'   (line 54)
```

`docs/EXTENSIONS.md` (the "add an extension" path) and `.github/workflows/validate-catalog.yml` both invoke this script. CI passes only because it pins Python 3.12, so a contributor following the docs and regenerating the catalog locally on a Mac hits the crash.

## Fix

Add `from __future__ import annotations` (PEP 563 — annotations become lazy strings), matching the sibling scripts in the same directory that already do this: `select-model.py:10` and `audit-extensions.py`. The repo even documents this exact failure mode in `bin/dream-host-agent.py`.

One line. Behavior-preserving — the script does no runtime `get_type_hints()`.

## Verification (Python 3.9.6, macOS)

```console
$ python3 scripts/generate-extensions-catalog.py --output /tmp/cat.json
Generated catalog with 33 extensions at /tmp/cat.json
```

Before the fix: `TypeError` on import. After: runs clean, exit 0.
