### PR TITLE
fix(security): build service-registry cache with mktemp, not a predictable /tmp path

### DIFF
--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -5,7 +5,9 @@
 EXTENSIONS_DIR="${SCRIPT_DIR:-$(pwd)}/extensions/services"
 _SR_LOADED=false
 _SR_FAILED=false
-_SR_CACHE="/tmp/dream-service-registry.$$.sh"
+# Created on demand in sr_load() via mktemp. Its contents are sourced as bash,
+# so a predictable /tmp path would be a local code-injection vector.
+_SR_CACHE=""
 
 # Caching for compose flags (session-level)
 _SR_COMPOSE_FLAGS_CACHE=""
@@ -79,6 +81,11 @@ sr_load() {
             return 0
         fi
     fi
+
+    # Create the cache as a race-safe, private (mode 0600) temp file. Its
+    # contents are sourced as bash below, so a predictable /tmp name would be a
+    # local code-injection vector (symlink / TOCTOU race).
+    _SR_CACHE="$(mktemp "${TMPDIR:-/tmp}/dream-service-registry.XXXXXX")" || _SR_CACHE=""
 
     if ! "$PYTHON_CMD" - "$EXTENSIONS_DIR" <<'PYEOF' > "$_SR_CACHE"
 import yaml, sys, os


### PR DESCRIPTION
## Problem (local code injection / privilege escalation)

`lib/service-registry.sh` cached the parsed manifest registry at a **predictable** path and then **sourced it as bash**:

```bash
_SR_CACHE="/tmp/dream-service-registry.$$.sh"
...
"$PYTHON_CMD" - ... > "$_SR_CACHE"   # write
. "$_SR_CACHE"                        # source == execute
```

The path lives in world-writable `/tmp` with only the PID (`$$`) as entropy, so on a multi-user host a local unprivileged user can:

- **pre-create it as a symlink** → the `>` redirect truncates an arbitrary file the runner can write; or
- **win the write→source race (TOCTOU)** → inject arbitrary bash that runs with the runner's privileges.

`install-core.sh` and ~20 other scripts (`dream-doctor.sh`, `health-check.sh`, `dream-test.sh`, …) source this library, frequently under `sudo` — so this is a realistic local code-injection / privilege-escalation vector. It is the only place in the repo that sources a file from a predictable `/tmp` path.

## Fix

Create the cache with `mktemp` — unpredictable name, mode `0600`, `O_EXCL` race-safe — built lazily at the point of use, mirroring the `mktemp` idiom already used elsewhere in the repo:

```bash
_SR_CACHE="$(mktemp "${TMPDIR:-/tmp}/dream-service-registry.XXXXXX")" || _SR_CACHE=""
```

Downstream code references `$_SR_CACHE` (not the literal path), so there is **no behavior change** for legitimate use. Nothing in the repo depends on the old filename.

## Verification

- `mktemp` on macOS yields `-rw-------` (0600), random name under `$TMPDIR`.
- `tests/test-service-registry.sh` → **219 passed, 0 failed**
- `tests/test-service-registry-cache.sh` → **15 passed, 0 failed**
- `make lint` passes.
