### PR TITLE
fix(privacy-shield): report full multi-word PII type in get_stats()

### DIFF
--- a/dream-server/extensions/services/privacy-shield/pii_scrubber.py
+++ b/dream-server/extensions/services/privacy-shield/pii_scrubber.py
@@ -130,7 +130,11 @@ class PIIDetector:
         return {
             'unique_pii_count': len(self.pii_map),
             'pii_types': list(set(
-                token.split('_')[1] for token in self.pii_map.keys()
+                # A type may itself contain underscores (ip_address, credit_card),
+                # so take everything between the prefix and the trailing _<hash>
+                # rather than split('_')[1], which would yield "ip" / "credit".
+                token[len(self.token_prefix):-len(self.token_suffix)].rsplit('_', 1)[0]
+                for token in self.pii_map.keys()
             ))
         }
 

--- a/dream-server/extensions/services/privacy-shield/tests/test_pii_scrubber.py
+++ b/dream-server/extensions/services/privacy-shield/tests/test_pii_scrubber.py
@@ -221,3 +221,11 @@ class TestStats:
         stats = detector.get_stats()
         assert stats["unique_pii_count"] == 0
         assert stats["pii_types"] == []
+
+    def test_stats_reports_multiword_type(self, detector):
+        # Regression: a multi-word PII type (ip_address) must be reported in
+        # full, not truncated to "ip" by a naive token.split('_')[1].
+        detector.scrub("Server IP 192.168.1.100")
+        types = detector.get_stats()["pii_types"]
+        assert "ip_address" in types
+        assert "ip" not in types


### PR DESCRIPTION
## Problem

`PIIDetector.get_stats()` derived the list of PII types like this:

```python
'pii_types': list(set(
    token.split('_')[1] for token in self.pii_map.keys()
))
```

Tokens are formatted `<PII_{type}_{hash}>` (see `_generate_token`). `split('_')[1]` keeps only the **first** underscore-delimited segment of the type, so any multi-word type is truncated:

- `ip_address` → `"ip"`
- `credit_card` → `"credit"`

Any consumer reading `get_stats()["pii_types"]` (metrics, logging, the privacy-shield API) gets a wrong type label.

**Reproduce:**

```console
$ python3 -c "import pii_scrubber; d=pii_scrubber.PIIDetector(); d.scrub('Server IP 192.168.1.100'); print(d.get_stats()['pii_types'])"
['ip']      # should be ['ip_address']
```

## Fix

Parse the type as everything between the prefix and the trailing `_<hash>`:

```python
token[len(self.token_prefix):-len(self.token_suffix)].rsplit('_', 1)[0]
```

Single-word types (`email`, `phone`) are unaffected. Adds a regression test for the multi-word (`ip_address`) case — the existing stats tests only covered single-word types, which is why this slipped.

## Verification

- After fix: `get_stats()['pii_types']` → `['ip_address']`.
- `pytest tests/test_pii_scrubber.py` → **29 passed**.
- The new test **fails on the pre-fix code** (`assert 'ip_address' in ['ip']`) and passes after.
