### PR TITLE
docs: define engine provider mode contract

### DIFF
--- a/dream-server/docs/ENGINE-PROVIDER-MODES.md
+++ b/dream-server/docs/ENGINE-PROVIDER-MODES.md
@@ -1,0 +1,138 @@
+# Engine Provider Modes
+
+Dream Server has one default install path and several engine provider shapes.
+This document names the supported contract before adding more provider-specific
+installer behavior. It is a maintainer contract, not a new user-facing switch in
+this change.
+
+## Decision
+
+Dream Server's default install remains the managed local stack. Provider modes
+are supported alternatives that must prove the same product capabilities before
+an install reports ready.
+
+| Mode | Ownership | Intended use |
+|------|-----------|--------------|
+| `local` | Dream Server manages llama-server and its model files | Default local install path |
+| `cloud` | Dream Server manages LiteLLM routing to remote APIs | CPU-only or remote-model installs |
+| `hybrid` | Dream Server manages local-first plus cloud fallback routing | Local default with explicit fallback |
+| `lemonade` | A Lemonade engine provides OpenAI-compatible local APIs | Supported local engine mode, not the default |
+
+The Lemonade provider may be either Dream-managed on platforms where that is
+already supported, or external/unmanaged when Dream Server adopts an existing
+host-native Lemonade service. The env shape must make that ownership explicit.
+
+## Required Env Shape
+
+Provider mode code should converge on these names:
+
+| Variable | Meaning |
+|----------|---------|
+| `DREAM_MODE=lemonade` | Dream Server is running with the Lemonade provider |
+| `LLM_BACKEND=lemonade` | Dashboard/API code should use Lemonade-compatible API paths |
+| `LEMONADE_EXTERNAL=true|false` | Whether Dream Server owns the Lemonade process lifecycle |
+| `LEMONADE_BASE_URL` | Host-side Lemonade base URL used by installers and host tools |
+| `LEMONADE_CONTAINER_BASE_URL` | Container-side Lemonade base URL used by compose services |
+| `LEMONADE_API_BASE_PATH=/api/v1` | Lemonade OpenAI-compatible API path |
+| `LEMONADE_MODEL` | Chat model id routed through LiteLLM |
+| `LEMONADE_API_KEY` | Optional bearer key for engine calls |
+
+Installers may retain legacy variables during migration, but new behavior should
+read and write the canonical names above.
+
+## Provider Capability Contract
+
+A provider mode is ready only when every capability selected by the install
+profile is reachable through the configured provider:
+
+| Capability | Minimum proof |
+|------------|---------------|
+| Liveness | Health endpoint answers and reports an accepted version |
+| Chat | A real chat completion succeeds through the same route apps use |
+| Embeddings | An embedding request succeeds when RAG embeddings are enabled |
+| STT | An audio transcription request succeeds when voice input is enabled |
+| TTS | A speech generation request succeeds when voice output is enabled |
+| Rerank | A rerank request succeeds when reranking is enabled |
+| Stats | Dashboard can read throughput or returns an explicit unsupported state |
+
+Unsupported selected capabilities must fail the install or readiness gate unless
+the user explicitly chose a profile where that capability is optional. A skipped
+selected capability is not a green install.
+
+## Adapter Boundary
+
+Dream Server should not spread provider-specific HTTP details across installer
+phases, dashboard routers, compose templates, and probes. Each provider needs a
+small adapter boundary that owns:
+
+- URL normalization for host and container clients;
+- API key/bearer header behavior;
+- health, version, model list, and loaded-model detection;
+- chat, embeddings, STT, TTS, rerank, and stats probes;
+- error classification and recovery hints.
+
+For Lemonade, this means calls to `/api/v1/health`, `/api/v1/models`,
+`/api/v1/chat/completions`, `/api/v1/embeddings`, `/api/v1/audio/*`,
+`/api/v1/reranking`, and `/api/v1/stats` should be centralized before more
+platform-specific behavior is added.
+
+## Security Contract
+
+Provider modes must fail closed on network exposure:
+
+- Dream Server must not bind an unauthenticated local engine to the LAN by
+  default.
+- If an engine is reachable outside loopback or a host-only bridge, bearer auth
+  must be configured or the user must pass an explicit unsafe override.
+- All Dream-owned clients must pass the configured provider key before key
+  enforcement is enabled by default.
+- Readiness must distinguish "provider unreachable", "auth rejected", "model
+  missing", and "capability unsupported".
+
+## Compose Contract
+
+Provider modes may replace managed services, but only through the compose
+resolver. A provider mode must define which services are:
+
+- owned by Dream Server;
+- replaced by the provider;
+- optional and absent;
+- still enabled through user extensions.
+
+After extension changes, dashboard actions, `dream restart`, and lifecycle
+commands, the resolver must regenerate the same provider-aware compose surface.
+Provider mode support is not complete if a later restart revives services the
+mode intentionally replaced.
+
+## Compatibility Policy
+
+Dream Server should install or recommend a known-good provider version, but it
+must also handle an already-installed provider conservatively:
+
+- accept the known-good pin and documented version floor;
+- accept newer versions only after provider contract probes pass;
+- reject older versions with a targeted recovery message;
+- keep a CI/mock contract for API shapes and a fleet contract for real hardware.
+
+The Lemonade provider is especially sensitive to upstream changes in model ids,
+backend recipe names, health/stat payloads, installer packaging, and auth
+semantics. Those are provider-contract changes, not ad hoc installer quirks.
+
+## Non-Goals
+
+- This contract does not make Lemonade the default install path.
+- This contract does not remove the existing local, cloud, or hybrid modes.
+- This contract does not require Dream Server to own every provider process.
+- This contract does not bless a hidden fork or product variant outside main.
+
+## Validation Expectations
+
+Provider-mode PRs should add validation at the layer they touch:
+
+- docs-only contract changes: markdown link checks;
+- adapter changes: mocked provider API unit tests;
+- installer changes: platform contract tests and dry runs;
+- compose changes: resolver tests for restart/cache regeneration;
+- dashboard changes: readiness/features/status tests for default and provider
+  modes;
+- release candidates: distro lab plus real-hardware fleet validation.

--- a/dream-server/docs/LEMONADE-SDK-COMPAT.md
+++ b/dream-server/docs/LEMONADE-SDK-COMPAT.md
@@ -3,6 +3,8 @@
 Dream Server's Linux installer can wrap an existing Lemonade SDK install instead
 of starting its own managed Lemonade runtime. This is intended for AMD Linux
 systems where Lemonade is already installed, configured, and serving models.
+The longer-term contract for making Lemonade a supported provider mode across
+platforms is defined in [Engine Provider Modes](ENGINE-PROVIDER-MODES.md).
 
 ## Install Around Existing Lemonade
 

--- a/dream-server/docs/MODE-SWITCH.md
+++ b/dream-server/docs/MODE-SWITCH.md
@@ -27,7 +27,10 @@ dream restart
 
 ## How It Works
 
-One env var (`LLM_API_URL`) controls where all services send LLM requests. Three modes are user-selectable via `dream mode`; a fourth (`lemonade`) is auto-configured by the installer on AMD hardware — see [Lemonade Mode](#lemonade-mode-amd--auto-configured) below.
+One env var (`LLM_API_URL`) controls where all services send LLM requests.
+Three modes are user-selectable via `dream mode`; a fourth (`lemonade`) is
+auto-configured by the installer on AMD hardware today. The maintainer contract
+for provider modes lives in [Engine Provider Modes](ENGINE-PROVIDER-MODES.md).
 
 | Mode | `LLM_API_URL` | `DREAM_MODE` | LiteLLM config |
 |------|---------------|--------------|-----------------|
@@ -105,6 +108,8 @@ For AMD Strix Halo performance tuning (GRUB, kernel module, sysctl settings), se
 
 Existing Lemonade SDK installs on Linux AMD hosts can be wrapped without letting
 Dream Server manage the Lemonade runtime. See [Lemonade SDK Compatibility](LEMONADE-SDK-COMPAT.md).
+Future Lemonade work should follow the provider-mode contract rather than
+adding one-off installer or dashboard paths.
 
 ---
 

--- a/dream-server/docs/README.md
+++ b/dream-server/docs/README.md
@@ -22,7 +22,7 @@ matches the work in front of them.
 | Install on Apple Silicon | [MACOS-QUICKSTART.md](MACOS-QUICKSTART.md) | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md) |
 | Debug a broken install | [DREAM-DOCTOR.md](DREAM-DOCTOR.md) | [INSTALL-TROUBLESHOOTING.md](INSTALL-TROUBLESHOOTING.md), [SUPPORT-BUNDLE.md](SUPPORT-BUNDLE.md) |
 | Change installer behavior | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md), [PREFLIGHT-ENGINE.md](PREFLIGHT-ENGINE.md) |
-| Change model routing | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | [MODE-SWITCH.md](MODE-SWITCH.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) |
+| Change model routing | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | [MODE-SWITCH.md](MODE-SWITCH.md), [ENGINE-PROVIDER-MODES.md](ENGINE-PROVIDER-MODES.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) |
 | Add or harden a service | [EXTENSIONS.md](EXTENSIONS.md) | [../extensions/CATALOG.md](../extensions/CATALOG.md), [../extensions/schema/README.md](../extensions/schema/README.md) |
 | Build a custom edition or fork | [FORKABILITY.md](FORKABILITY.md) | [RELEASE_CHANNELS.md](RELEASE_CHANNELS.md), [BUILD-ON-DREAM-SERVER.md](BUILD-ON-DREAM-SERVER.md), [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md), [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) |
 | Review a PR | [../CONTRIBUTING.md](../CONTRIBUTING.md) | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [TESTING.md](TESTING.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md), [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md) |
@@ -53,7 +53,7 @@ canonical source and treat older recipes as context.
 
 | Status | Meaning | Examples |
 |--------|---------|----------|
-| Canonical contract | Defines behavior reviewers should enforce | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md), [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) |
+| Canonical contract | Defines behavior reviewers should enforce | [HIGH_RISK_CHANGE_MAP.md](HIGH_RISK_CHANGE_MAP.md), [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md), [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md), [ENGINE-PROVIDER-MODES.md](ENGINE-PROVIDER-MODES.md), [RELEASE_VALIDATION.md](RELEASE_VALIDATION.md) |
 | Operator guide | Helps users install, operate, or troubleshoot | [../QUICKSTART.md](../QUICKSTART.md), [DREAM-DOCTOR.md](DREAM-DOCTOR.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md), [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) |
 | Maintainer runbook | Explains how to preserve or release the project | [MAINTAINER_RUNBOOK.md](MAINTAINER_RUNBOOK.md), [FORKABILITY.md](FORKABILITY.md), [OFFLINE_AND_MIRRORING.md](OFFLINE_AND_MIRRORING.md), [VALIDATION_REPRODUCIBILITY.md](VALIDATION_REPRODUCIBILITY.md) |
 | Deep dive | Explains a subsystem or design area | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md), [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md), [DREAM_CLI_DECOMPOSITION.md](DREAM_CLI_DECOMPOSITION.md) |
@@ -111,6 +111,7 @@ canonical source and treat older recipes as context.
 | [DREAM_CLI_DECOMPOSITION.md](DREAM_CLI_DECOMPOSITION.md) | Maintainers / CLI contributors | Behavior-preserving plan for splitting the large Bash operator CLI without a risky rewrite |
 | [INTEGRATION-GUIDE.md](INTEGRATION-GUIDE.md) | Developers | Connect apps via OpenAI SDK, LangChain, n8n |
 | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md) | Developers | Backend runtime contract JSON schema |
+| [ENGINE-PROVIDER-MODES.md](ENGINE-PROVIDER-MODES.md) | Maintainers / backend reviewers | Provider mode contract for local, cloud, hybrid, and Lemonade-backed installs |
 | [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md) | Maintainers / installer reviewers | Phase ownership, inputs, outputs, idempotency, and validation expectations |
 | [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md) | Maintainers / backend reviewers | Compose layer rules for services, hardware overlays, modes, dependencies, and ports |
 | [HERMES.md](HERMES.md) | Developers / operators | Default Hermes Agent packaging, security posture, and operations |


### PR DESCRIPTION
Stack: 1/5. Base: main.

This is the contract/documentation slice for the supported engine provider mode work. It defines the DreamServer mode vocabulary and documents how bundled/local/cloud/external providers relate without making Lemonade the default path.

What changed:
- Adds ENGINE-PROVIDER-MODES.md.
- Updates Lemonade SDK compatibility, mode-switching, and docs README references.

Why:
- Gives the rest of the stack a clear product contract to implement against.
- Keeps DS-LS/Lemonade behavior framed as a supported mode, not a default runtime change.

Validation:
- Full hardware fleet release PASS: /home/michael/dream-fleet-test/runs/fleet-release-ds-lemonade-mode-05-windows-amd-bootstrap-full-20260615T003838Z/REPORT.md
- User Green PASS across tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy.
- Release report: 0 real product bugs, 0 harness limitations, 0 environment notes.
- Capability matrix green on all enabled hosts; vision is intentionally not enabled in this fleet gate.
- Distro lab PASS: /tmp/ds-ls-distro-gates-20260614T235231Z.log
- Docker multi-distro: Passed 10, Failed 0.
- Incus VM matrix: ubuntu2404, fedora42, rocky9, arch, opensuse all passed.