### PR TITLE
fix(doctor): warn on unauthenticated external Lemonade routes

### DIFF
--- a/dream-server/docs/LEMONADE-SDK-COMPAT.md
+++ b/dream-server/docs/LEMONADE-SDK-COMPAT.md
@@ -139,6 +139,12 @@ If you expose Lemonade beyond localhost, set `LEMONADE_API_KEY` or
 `LEMONADE_ADMIN_API_KEY` in Lemonade and pass the matching key to Dream Server
 with `--lemonade-api-key`.
 
+`dream doctor` warns when external Lemonade is host-routed from Docker without a
+user-provided Lemonade API key. The installer-generated
+`LITELLM_LEMONADE_API_KEY=sk-dream-lemonade-*` value is only the key LiteLLM
+sends upstream; it does not prove that the Lemonade daemon requires
+authentication.
+
 ## Managed vs External
 
 | Mode | Who owns Lemonade? | Default API target | Model storage |

--- a/dream-server/scripts/dream-doctor.sh
+++ b/dream-server/scripts/dream-doctor.sh
@@ -340,7 +340,7 @@ import re
 import shlex
 import sys
 from datetime import datetime, timezone
-from urllib import error, request
+from urllib import error, parse, request
 
 cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, tts_http, tts_port, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message, hermes_slash_worker_count, hermes_slash_worker_max_count, root_dir_arg = sys.argv[1:]
 
@@ -616,6 +616,29 @@ def _looks_like_local_llama_route(value):
     )
 
 
+def _url_host(value):
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+    candidate = raw if "://" in raw else f"http://{raw}"
+    try:
+        return (parse.urlparse(candidate).hostname or "").strip().lower()
+    except ValueError:
+        return ""
+
+
+def _is_loopback_host(host):
+    return host in {"localhost", "127.0.0.1", "::1"}
+
+
+def _is_host_gateway(host):
+    return host in {"host.docker.internal", "gateway.docker.internal"}
+
+
+def _looks_like_installer_generated_lemonade_key(value):
+    return str(value or "").strip().startswith("sk-dream-lemonade-")
+
+
 def _source(path):
     try:
         return path.relative_to(root_dir).as_posix()
@@ -670,6 +693,18 @@ def _collect_inference_contract():
         or (
             env_get("AMD_INFERENCE_RUNTIME").strip().lower() == "lemonade"
             and env_get("AMD_INFERENCE_MANAGED").strip().lower() == "false"
+        )
+    )
+    lemonade_base_url = env_get("LEMONADE_BASE_URL", "")
+    lemonade_container_base_url = env_get("LEMONADE_CONTAINER_BASE_URL", "")
+    lemonade_base_host = _url_host(lemonade_base_url)
+    lemonade_container_host = _url_host(lemonade_container_base_url)
+    lemonade_auth_configured = any(
+        value and not _looks_like_installer_generated_lemonade_key(value)
+        for value in (
+            env_get("LEMONADE_API_KEY", ""),
+            env_get("LEMONADE_ADMIN_API_KEY", ""),
+            env_get("LITELLM_LEMONADE_API_KEY", ""),
         )
     )
 
@@ -773,6 +808,24 @@ def _collect_inference_contract():
                     f"External Lemonade is configured, but LLM_API_URL points at local llama-server ({llm_api_url}).",
                 )
             )
+        host_routed_lemonade = _is_host_gateway(lemonade_container_host)
+        network_lemonade = lemonade_base_host and not _is_loopback_host(lemonade_base_host)
+        if (host_routed_lemonade or network_lemonade) and not lemonade_auth_configured:
+            detail = (
+                "External Lemonade is routed through "
+                f"{lemonade_container_base_url or lemonade_base_url or 'an unknown host route'} "
+                "without a user-provided Lemonade API key. If the Lemonade daemon is bound "
+                "beyond loopback so Docker can reach it, that same daemon may also be reachable "
+                "from the LAN."
+            )
+            issues.append(
+                _inference_issue(
+                    "DS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE",
+                    "warn",
+                    ".env",
+                    detail,
+                )
+            )
 
     if dream_mode == "local" and not lemonade_external:
         if compose_flags_exists and cloud_overlay:
@@ -804,6 +857,7 @@ def _collect_inference_contract():
         "DS-RUNTIME-EXTERNAL-LEMONADE-CLOUD-OVERLAY-MISSING": "External Lemonade is missing the cloud compose overlay",
         "DS-RUNTIME-EXTERNAL-LEMONADE-OVERLAY-MISSING": "External Lemonade is missing its compose overlay",
         "DS-RUNTIME-EXTERNAL-LEMONADE-LOCAL-ROUTE": "External Lemonade still routes clients to local llama-server",
+        "DS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE": "External Lemonade host route has no user-provided API key",
         "DS-RUNTIME-LOCAL-CLOUD-OVERLAY": "Local mode still has the cloud compose overlay",
         "DS-RUNTIME-LOCAL-LITELLM-ROUTE": "Local mode routes through LiteLLM unexpectedly",
     }
@@ -831,6 +885,11 @@ def _collect_inference_contract():
         ],
         "DS-RUNTIME-EXTERNAL-LEMONADE-LOCAL-ROUTE": [
             "Route external Lemonade clients through LiteLLM, usually http://litellm:4000.",
+        ],
+        "DS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE": [
+            "Configure Lemonade with LEMONADE_API_KEY or LEMONADE_ADMIN_API_KEY, then reinstall with --lemonade-api-key.",
+            "Prefer binding Lemonade to a host-only or Docker-reachable interface instead of exposing it broadly on 0.0.0.0.",
+            "Keep firewall rules scoped to the Docker network subnet when host-routed Lemonade is required.",
         ],
         "DS-RUNTIME-LOCAL-CLOUD-OVERLAY": [
             "Regenerate compose flags for local mode so local inference starts normally.",
@@ -870,6 +929,8 @@ def _collect_inference_contract():
             "cloud_overlay": cloud_overlay,
             "lemonade_external_overlay": lemonade_external_overlay,
             "local_inference_overlay": local_inference_overlay,
+            "lemonade_auth_configured": lemonade_auth_configured,
+            "lemonade_host_routed": _is_host_gateway(lemonade_container_host),
         },
         "issues": issues,
         "issue_counts": {

--- a/dream-server/tests/contracts/test-external-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-external-lemonade-contracts.sh
@@ -78,6 +78,12 @@ grep -q 'LiteLLM external Lemonade gateway' dream-preflight.sh \
 grep -q 'dream-litellm' dream-preflight.sh \
   || { echo "[FAIL] dream-preflight must check dream-litellm for external Lemonade"; exit 1; }
 
+echo "[contract] doctor warns on unauthenticated host-routed external Lemonade"
+grep -q 'DS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE' scripts/dream-doctor.sh \
+  || { echo "[FAIL] dream-doctor must warn when external Lemonade is host-routed without a user API key"; exit 1; }
+grep -q 'sk-dream-lemonade-' scripts/dream-doctor.sh \
+  || { echo "[FAIL] dream-doctor must distinguish installer-generated LiteLLM provider keys from user Lemonade API keys"; exit 1; }
+
 echo "[contract] resolver selects cloud + external overlay instead of managed AMD overlay"
 resolved="$(LEMONADE_EXTERNAL=true DREAM_MODE=lemonade \
   ./scripts/resolve-compose-stack.sh --script-dir "$ROOT_DIR" --dream-mode lemonade --gpu-backend amd --tier SH_LARGE --env)"

--- a/dream-server/tests/test-dream-doctor-install-diagnoses.sh
+++ b/dream-server/tests/test-dream-doctor-install-diagnoses.sh
@@ -194,6 +194,62 @@ else
     fail "diagnosis next steps missing from autofix hints"
 fi
 
+cat > "$ENV_PATH" <<'ENV'
+DREAM_MODE=lemonade
+GPU_BACKEND=amd
+LLM_API_URL=http://litellm:4000
+HERMES_LLM_BASE_URL=http://litellm:4000/v1
+LEMONADE_EXTERNAL=true
+LEMONADE_BASE_URL=http://localhost:13305
+LEMONADE_CONTAINER_BASE_URL=http://host.docker.internal:13305
+LITELLM_LEMONADE_API_KEY=sk-dream-lemonade-fixture
+AMD_INFERENCE_RUNTIME=lemonade
+AMD_INFERENCE_MANAGED=false
+AMD_INFERENCE_RUNTIME_MODE=external-lemonade
+ENV
+cat > "$FLAGS_PATH" <<'FLAGS'
+-f docker-compose.base.yml -f docker-compose.cloud.yml -f docker-compose.lemonade-external.yml
+FLAGS
+
+if (cd "$ROOT_DIR" && bash scripts/dream-doctor.sh "$REPORT" >/dev/null 2>&1); then
+    pass "dream-doctor runs with external Lemonade fixture"
+else
+    fail "dream-doctor failed with external Lemonade fixture"
+fi
+
+if jq -e '.diagnoses[] | select(.id == "DS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE")' "$REPORT" >/dev/null; then
+    pass "external Lemonade host route without user API key is diagnosed"
+else
+    fail "external Lemonade host route without user API key was not diagnosed"
+fi
+
+cat > "$ENV_PATH" <<'ENV'
+DREAM_MODE=lemonade
+GPU_BACKEND=amd
+LLM_API_URL=http://litellm:4000
+HERMES_LLM_BASE_URL=http://litellm:4000/v1
+LEMONADE_EXTERNAL=true
+LEMONADE_BASE_URL=http://localhost:13305
+LEMONADE_CONTAINER_BASE_URL=http://host.docker.internal:13305
+LEMONADE_API_KEY=sk-user-lemonade-fixture
+LITELLM_LEMONADE_API_KEY=sk-user-lemonade-fixture
+AMD_INFERENCE_RUNTIME=lemonade
+AMD_INFERENCE_MANAGED=false
+AMD_INFERENCE_RUNTIME_MODE=external-lemonade
+ENV
+
+if (cd "$ROOT_DIR" && bash scripts/dream-doctor.sh "$REPORT" >/dev/null 2>&1); then
+    pass "dream-doctor runs with authenticated external Lemonade fixture"
+else
+    fail "dream-doctor failed with authenticated external Lemonade fixture"
+fi
+
+if jq -e '.diagnoses[] | select(.id == "DS-RUNTIME-EXTERNAL-LEMONADE-UNAUTHENTICATED-HOST-ROUTE")' "$REPORT" >/dev/null; then
+    fail "authenticated external Lemonade fixture still emitted unauthenticated route diagnosis"
+else
+    pass "user API key suppresses unauthenticated external Lemonade diagnosis"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed, $SKIPPED skipped"
 [[ "$FAILED" -eq 0 ]]


### PR DESCRIPTION
Stack: 3/5. Base: ds-lemonade-mode-02-adapter.

This adds Linux/doctor guardrails around external Lemonade routing so risky unauthenticated exposure is diagnosed instead of silently accepted.

What changed:
- Extends dream doctor diagnostics for external Lemonade auth/exposure cases.
- Adds contract and diagnosis tests for the warning behavior.
- Updates Lemonade compatibility docs.

Why:
- The main risk for supported Lemonade mode is brittle or unsafe external routing as upstream Lemonade evolves.
- This keeps the failure mode visible to the operator without changing the known-good default mode.

Validation:
- Full hardware fleet release PASS: /home/michael/dream-fleet-test/runs/fleet-release-ds-lemonade-mode-05-windows-amd-bootstrap-full-20260615T003838Z/REPORT.md
- User Green PASS across tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy.
- Release report: 0 real product bugs, 0 harness limitations, 0 environment notes.
- Capability matrix green on all enabled hosts; vision is intentionally not enabled in this fleet gate.
- Distro lab PASS: /tmp/ds-ls-distro-gates-20260614T235231Z.log
- Docker multi-distro: Passed 10, Failed 0.
- Incus VM matrix: ubuntu2404, fedora42, rocky9, arch, opensuse all passed.