### PR TITLE
feat(dashboard): surface external Lemonade runtime details

### DIFF
--- a/dream-server/extensions/services/dashboard-api/models.py
+++ b/dream-server/extensions/services/dashboard-api/models.py
@@ -147,6 +147,8 @@ class AmdRuntimeStatus(BaseModel):
     healthUrl: Optional[str] = None
     health: Optional[str] = None
     version: str = "unknown"
+    loadedModel: Optional[str] = None
+    modelCount: Optional[int] = None
     capabilities: list[str] = Field(default_factory=list)
     warnings: list[str] = Field(default_factory=list)
 

--- a/dream-server/extensions/services/dashboard-api/routers/gpu.py
+++ b/dream-server/extensions/services/dashboard-api/routers/gpu.py
@@ -24,6 +24,7 @@ from gpu import (
 )
 from models import GPUInfo, IndividualGPU, MultiGPUStatus
 from models import AmdRuntimeStatus
+from lemonade_client import LemonadeClient, LemonadeClientError, LemonadeSettings, normalize_base_url
 
 logger = logging.getLogger(__name__)
 
@@ -219,13 +220,16 @@ def _env_bool(name: str) -> bool:
     return _clean_env(name).lower() in {"1", "true", "yes", "on"}
 
 
-def _runtime_base_url(runtime: str, location: str, port: int) -> str:
-    external_lemonade = (
+def _external_lemonade_active() -> bool:
+    return (
         _env_bool("LEMONADE_EXTERNAL")
         or _clean_env("AMD_INFERENCE_RUNTIME_MODE").lower() == "external-lemonade"
         or _clean_env("AMD_INFERENCE_MANAGED").lower() == "false"
     )
-    if runtime == "lemonade" and external_lemonade:
+
+
+def _runtime_base_url(runtime: str, location: str, port: int) -> str:
+    if runtime == "lemonade" and _external_lemonade_active():
         external_base = _clean_env("LEMONADE_CONTAINER_BASE_URL") or _clean_env("LEMONADE_BASE_URL")
         if external_base:
             external_base = external_base.rstrip("/")
@@ -284,6 +288,47 @@ def _probe_amd_health(health_url: str) -> tuple[str, str, Optional[str]]:
     if 200 <= int(status) < 300:
         return "reachable", version, None
     return "unhealthy", version, f"health_http_{status}"
+
+
+def _external_lemonade_warning(prefix: str, exc: LemonadeClientError) -> str:
+    if exc.kind == "provider_unreachable":
+        return f"{prefix}_unreachable"
+    return f"{prefix}_{exc.kind}"
+
+
+def _loaded_model_from_health(payload: dict) -> Optional[str]:
+    for key in ("model_loaded", "loaded_model", "active_model", "model"):
+        value = payload.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+async def _probe_external_lemonade(api_base: str, api_path: str) -> tuple[str, str, list[str], Optional[str], Optional[int]]:
+    settings = LemonadeSettings(
+        base_url=normalize_base_url(api_base, api_path),
+        api_base_path=api_path,
+        api_key=_clean_env("LEMONADE_API_KEY") or _clean_env("LITELLM_LEMONADE_API_KEY"),
+        timeout=2.0,
+    )
+    warnings: list[str] = []
+
+    async with LemonadeClient(settings=settings) as client:
+        try:
+            health_payload = await client.health()
+        except LemonadeClientError as exc:
+            status = "unreachable" if exc.kind in {"provider_unreachable", "timeout"} else "unhealthy"
+            return status, "unknown", [_external_lemonade_warning("health", exc)], None, None
+
+        version = str(health_payload.get("version") or "unknown")
+        loaded_model = _loaded_model_from_health(health_payload)
+        model_count: Optional[int] = None
+        try:
+            model_count = len(await client.models())
+        except LemonadeClientError as exc:
+            warnings.append(_external_lemonade_warning("models", exc))
+
+    return "reachable", version, warnings, loaded_model, model_count
 
 
 # ============================================================================
@@ -422,9 +467,15 @@ async def amd_runtime():
     base_url = _runtime_base_url(runtime, location, port)
     api_base = _join_url(base_url, api_path)
     health_url = _join_url(base_url, _runtime_health_path(runtime, api_path))
-    health, version, health_warning = await asyncio.to_thread(_probe_amd_health, health_url)
-    if health_warning:
-        warnings.append(health_warning)
+    loaded_model: Optional[str] = None
+    model_count: Optional[int] = None
+    if runtime == "lemonade" and _external_lemonade_active():
+        health, version, probe_warnings, loaded_model, model_count = await _probe_external_lemonade(api_base, api_path)
+        warnings.extend(probe_warnings)
+    else:
+        health, version, health_warning = await asyncio.to_thread(_probe_amd_health, health_url)
+        if health_warning:
+            warnings.append(health_warning)
 
     return AmdRuntimeStatus(
         available=True,
@@ -440,6 +491,8 @@ async def amd_runtime():
         healthUrl=health_url,
         health=health,
         version=version,
+        loadedModel=loaded_model,
+        modelCount=model_count,
         capabilities=supported_backends,
         warnings=warnings,
     )

--- a/dream-server/extensions/services/dashboard-api/tests/test_amd_runtime.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_amd_runtime.py
@@ -11,6 +11,20 @@ def _patch_probe(monkeypatch, health="reachable", version="unknown", warning=Non
     )
 
 
+def _patch_external_probe(
+    monkeypatch,
+    health="reachable",
+    version="unknown",
+    warnings=None,
+    loaded_model="Qwen3-0.6B-GGUF",
+    model_count=1,
+):
+    async def _fake_probe(_api_base, _api_path):
+        return health, version, list(warnings or []), loaded_model, model_count
+
+    monkeypatch.setattr(gpu_router, "_probe_external_lemonade", _fake_probe)
+
+
 def test_amd_runtime_not_amd(monkeypatch, test_client):
     monkeypatch.setenv("GPU_BACKEND", "nvidia")
 
@@ -104,7 +118,7 @@ def test_amd_runtime_external_lemonade_uses_container_base_url(monkeypatch, test
     monkeypatch.setenv("AMD_INFERENCE_MANAGED", "false")
     monkeypatch.setenv("LEMONADE_CONTAINER_BASE_URL", "http://host.docker.internal:13305/api/v1")
     monkeypatch.setenv("LLM_API_BASE_PATH", "/api/v1")
-    _patch_probe(monkeypatch, version="10.2.0")
+    _patch_external_probe(monkeypatch, version="10.2.0", loaded_model="Qwen3-0.6B-GGUF", model_count=2)
 
     response = test_client.get("/api/gpu/amd-runtime", headers=test_client.auth_headers)
 
@@ -119,7 +133,39 @@ def test_amd_runtime_external_lemonade_uses_container_base_url(monkeypatch, test
     assert payload["apiBase"] == "http://host.docker.internal:13305/api/v1"
     assert payload["healthUrl"] == "http://host.docker.internal:13305/api/v1/health"
     assert payload["version"] == "10.2.0"
+    assert payload["loadedModel"] == "Qwen3-0.6B-GGUF"
+    assert payload["modelCount"] == 2
     assert payload["capabilities"] == ["auto"]
+
+
+def test_amd_runtime_external_lemonade_surfaces_adapter_warnings(monkeypatch, test_client):
+    monkeypatch.setenv("GPU_BACKEND", "amd")
+    monkeypatch.setenv("AMD_INFERENCE_RUNTIME", "lemonade")
+    monkeypatch.setenv("AMD_INFERENCE_BACKEND", "auto")
+    monkeypatch.setenv("AMD_INFERENCE_LOCATION", "host")
+    monkeypatch.setenv("AMD_INFERENCE_PORT", "13305")
+    monkeypatch.setenv("AMD_INFERENCE_SUPPORTED_BACKENDS", "auto")
+    monkeypatch.setenv("AMD_INFERENCE_RUNTIME_MODE", "external-lemonade")
+    monkeypatch.setenv("AMD_INFERENCE_MANAGED", "false")
+    monkeypatch.setenv("LEMONADE_CONTAINER_BASE_URL", "http://host.docker.internal:13305/api/v1")
+    monkeypatch.setenv("LLM_API_BASE_PATH", "/api/v1")
+    _patch_external_probe(
+        monkeypatch,
+        health="unhealthy",
+        version="unknown",
+        warnings=["health_auth_rejected"],
+        loaded_model=None,
+        model_count=None,
+    )
+
+    response = test_client.get("/api/gpu/amd-runtime", headers=test_client.auth_headers)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["health"] == "unhealthy"
+    assert payload["warnings"] == ["health_auth_rejected"]
+    assert "loadedModel" not in payload
+    assert "modelCount" not in payload
 
 
 def test_amd_runtime_windows_host_llama_server_fallback(monkeypatch, test_client):


### PR DESCRIPTION
Stack: 4/5. Base: ds-lemonade-mode-03-linux-gate.

This surfaces external Lemonade runtime details through dashboard-api GPU/runtime status, still without making Lemonade the default runtime.

What changed:
- Adds Lemonade runtime fields to dashboard-api models.
- Extends GPU/runtime routing to report external Lemonade details.
- Adds dashboard-api test coverage for AMD/runtime reporting.

Why:
- Operators need to understand which runtime mode DreamServer is actually using.
- This makes Lemonade mode observable instead of hidden behind generic GPU status.

Validation:
- Full hardware fleet release PASS: /home/michael/dream-fleet-test/runs/fleet-release-ds-lemonade-mode-05-windows-amd-bootstrap-full-20260615T003838Z/REPORT.md
- User Green PASS across tower2, strix-halo, spark, m5-mbp, windows-laptop, and strixy.
- Release report: 0 real product bugs, 0 harness limitations, 0 environment notes.
- Capability matrix green on all enabled hosts; vision is intentionally not enabled in this fleet gate.
- Distro lab PASS: /tmp/ds-ls-distro-gates-20260614T235231Z.log
- Docker multi-distro: Passed 10, Failed 0.
- Incus VM matrix: ubuntu2404, fedora42, rocky9, arch, opensuse all passed.