### PR TITLE
fix(dashboard): use exact path matching in Sidebar to prevent dual ac…

### DIFF
--- a/dream-server/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -142,6 +142,7 @@ export default function Sidebar({ status, collapsed, onToggle }) {
             <li key={path}>
               <NavLink
                 to={path}
+                end
                 title={collapsed ? label : undefined}
                 className={({ isActive }) =>
                   `flex items-center ${collapsed ? 'justify-center' : ''} gap-3 px-3 py-2.5 rounded-lg transition-colors ${


### PR DESCRIPTION
Fixes #1566

## Summary

Use exact path matching in Sidebar NavLinks to prevent parent routes from being marked active when their children are selected.

## AI Assistance

None

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard UI

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] Dashboard lint/test/build

## Operational Change Check

- [x] This is not an operational change.

## Notes For Reviewers

None
