### PR TITLE
fix(dashboard): replace CPU-heavy SVG filter with hardware-accelerated CSS drop-shadow

### DIFF
--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -1100,13 +1100,7 @@ const OverviewChart = memo(function OverviewChart({
             <stop offset="58%" stopColor={fill} stopOpacity="0.24" />
             <stop offset="100%" stopColor={fill} stopOpacity="0" />
           </linearGradient>
-          <filter id={`overview-glow-${chartId}`} x="-20%" y="-35%" width="140%" height="170%">
-            <feGaussianBlur stdDeviation="4" result="blur" />
-            <feMerge>
-              <feMergeNode in="blur" />
-              <feMergeNode in="SourceGraphic" />
-            </feMerge>
-          </filter>
+
         </defs>
 
         {[36, 72, 108, 144, 160].map((y) => (
@@ -1147,7 +1141,7 @@ const OverviewChart = memo(function OverviewChart({
             stroke={`url(#overview-line-${chartId})`}
             strokeWidth="3"
             strokeLinecap="round"
-            filter={`url(#overview-glow-${chartId})`}
+            style={{ filter: `drop-shadow(0 0 4px ${accent})` }}
           />
         ) : (
           <text

--- a/dream-server/extensions/services/dashboard/src/pages/Usage.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Usage.jsx
@@ -635,18 +635,12 @@ function Sparkline({ shape, accent, compact = false }) {
           <stop offset="0%" stopColor={accent} stopOpacity="0.42" />
           <stop offset="100%" stopColor={accent} stopOpacity="0.02" />
         </linearGradient>
-        <filter id={`${id}-glow`} x="-20%" y="-80%" width="140%" height="260%">
-          <feGaussianBlur stdDeviation="2.2" result="blur" />
-          <feMerge>
-            <feMergeNode in="blur" />
-            <feMergeNode in="SourceGraphic" />
-          </feMerge>
-        </filter>
+
       </defs>
       {shape?.line ? (
         <>
           <path d={shape.area} fill={`url(#${id}-fill)`} />
-          <path d={shape.line} fill="none" stroke={`url(#${id}-line)`} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" filter={`url(#${id}-glow)`} />
+          <path d={shape.line} fill="none" stroke={`url(#${id}-line)`} strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round" style={{ filter: `drop-shadow(0 0 2.2px ${accent})` }} />
         </>
       ) : (
         <line x1="8" x2="118" y1="34" y2="34" stroke="rgba(255,255,255,0.12)" strokeDasharray="4 5" />


### PR DESCRIPTION
Fixes #1490

## Summary

This PR addresses a performance bug where the dashboard consumed 60-80% CPU on Linux (CachyOS) while idle. The issue was traced to the use of heavy SVG `<feGaussianBlur>` filters in the custom SVG line charts in `Dashboard.jsx` and `Usage.jsx`, which can fall back to expensive software rendering paths on certain browser/driver combinations.

This patch removes the SVG filter block and replaces the `filter="url(#...)"` attribute on the SVG paths with an inline CSS filter: `style={{ filter: 'drop-shadow(...)' }}`. This is expected to reduce idle renderer CPU usage, as CSS `drop-shadow()` typically has a lower paint cost compared to SVG Gaussian blur on affected configurations.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard UI

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `npm run lint` — passes
  - [x] `npm test` — 124 tests passing across 20 test files
  - [x] `npm run build` — passes
  - [x] `git diff --check` — clean

## Notes For Reviewers

- The charts are implemented using custom SVG rendering (not Recharts components)
- `ServiceMap.jsx` still contains an SVG `feDropShadow` effect — intentionally left out of scope for this PR since the reported issue specifically concerns dashboard idle CPU from the overview/usage charts. Worth monitoring as a follow-up if elevated idle CPU persists after this lands.
