### PR TITLE
feat(health): support non-HTTP health checks for TCP/CLI services

### DIFF
--- a/dream-server/extensions/library/services/aider/manifest.yaml
+++ b/dream-server/extensions/library/services/aider/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: ''
   external_port_default: 0
   health: ""
+  health_type: none
   type: docker
   startup_check: false  # one-shot CLI tool; container exits 0 by design
   gpu_backends: [amd, nvidia, apple]

--- a/dream-server/extensions/library/services/piper-audio/manifest.yaml
+++ b/dream-server/extensions/library/services/piper-audio/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: PIPER_PORT
   external_port_default: 10200
   health: ""
+  health_type: tcp
   type: docker
   gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -30,6 +30,7 @@ declare -A SERVICE_COMPOSE      # service_id → compose file path
 declare -A SERVICE_CATEGORIES   # service_id → core|recommended|optional
 declare -A SERVICE_DEPENDS      # service_id → space-separated dependency IDs
 declare -A SERVICE_HEALTH       # service_id → health endpoint path
+declare -A SERVICE_HEALTH_TYPES # service_id → health check type (http|tcp|none)
 declare -A SERVICE_HEALTH_TIMEOUTS  # service_id → health check timeout in seconds
 declare -A SERVICE_PORTS        # service_id → external port (what the user hits on localhost)
 declare -A SERVICE_PORT_ENVS    # service_id → env var name for the external port
@@ -176,11 +177,13 @@ for service_dir in _all_service_dirs:
         print(f'SERVICE_CATEGORIES["{_esc(sid)}"]="{_esc(category)}"')
         print(f'SERVICE_DEPENDS["{_esc(sid)}"]="{_esc(" ".join(str(d) for d in depends))}"')
         health = s.get("health", "/health")
+        health_type = s.get("health_type", "http")
         health_timeout = s.get("health_timeout", 5)  # Default 5 seconds
         port = s.get("external_port_default", s.get("port", 0))
         port_env = s.get("external_port_env", "")
         host_network = "1" if s.get("host_network") else ""
         print(f'SERVICE_HEALTH["{_esc(sid)}"]="{_esc(health)}"')
+        print(f'SERVICE_HEALTH_TYPES["{_esc(sid)}"]="{_esc(health_type)}"')
         print(f'SERVICE_HEALTH_TIMEOUTS["{_esc(sid)}"]="{_esc(health_timeout)}"')
         print(f'SERVICE_PORTS["{_esc(sid)}"]="{_esc(port)}"')
         print(f'SERVICE_PORT_ENVS["{_esc(sid)}"]="{_esc(port_env)}"')

--- a/dream-server/scripts/generate-extensions-catalog.py
+++ b/dream-server/scripts/generate-extensions-catalog.py
@@ -102,6 +102,7 @@ def extract_entry(manifest: dict) -> dict | None:
         "port": service.get("port", 0),
         "external_port_default": service.get("external_port_default", 0),
         "health_endpoint": service.get("health", ""),
+        "health_type": service.get("health_type", "http"),
         "env_vars": strip_secrets(env_vars),
         "tags": manifest.get("tags") or service.get("tags", []),
         "features": manifest.get("features") or service.get("features", []),

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -156,13 +156,24 @@ test_service() {
     local port_env="${SERVICE_PORT_ENVS[$sid]}"
     local default_port="${SERVICE_PORTS[$sid]}"
     local health="${SERVICE_HEALTH[$sid]}"
+    local health_type="${SERVICE_HEALTH_TYPES[$sid]:-http}"
     local timeout="${SERVICE_HEALTH_TIMEOUTS[$sid]:-$TIMEOUT}"
 
     # Resolve port
     local port="$default_port"
     [[ -n "$port_env" ]] && port="${!port_env:-$default_port}"
 
-    [[ -z "$health" || "$port" == "0" ]] && return 1
+    if [[ "$health_type" == "none" ]]; then
+        result_set "$sid" "ok"
+        return 0
+    fi
+
+    if [[ "$health_type" == "http" ]] && [[ -z "$health" || "$port" == "0" ]]; then
+        return 1
+    fi
+    if [[ "$health_type" == "tcp" ]] && [[ "$port" == "0" ]]; then
+        return 1
+    fi
 
     # Check container state first (if docker available)
     local container_state
@@ -173,10 +184,20 @@ test_service() {
         return 1
     fi
 
-    if curl -sf --max-time "$timeout" "http://127.0.0.1:${port}${health}" >/dev/null 2>&1; then
-        result_set "$sid" "ok"
-        return 0
+    if [[ "$health_type" == "tcp" ]]; then
+        # TCP connection test using Python socket
+        if python3 -c "import socket; s = socket.create_connection(('127.0.0.1', $port), timeout=$timeout); s.close()" 2>/dev/null; then
+            result_set "$sid" "ok"
+            return 0
+        fi
+    else
+        # HTTP GET test
+        if curl -sf --max-time "$timeout" "http://127.0.0.1:${port}${health}" >/dev/null 2>&1; then
+            result_set "$sid" "ok"
+            return 0
+        fi
     fi
+
     result_set "$sid" "fail"
     ANY_FAIL=true
     return 1

--- a/dream-server/scripts/health-check.sh
+++ b/dream-server/scripts/health-check.sh
@@ -163,11 +163,6 @@ test_service() {
     local port="$default_port"
     [[ -n "$port_env" ]] && port="${!port_env:-$default_port}"
 
-    if [[ "$health_type" == "none" ]]; then
-        result_set "$sid" "ok"
-        return 0
-    fi
-
     if [[ "$health_type" == "http" ]] && [[ -z "$health" || "$port" == "0" ]]; then
         return 1
     fi
@@ -175,7 +170,8 @@ test_service() {
         return 1
     fi
 
-    # Check container state first (if docker available)
+    # Check container state first (if docker available) — even for "none"
+    # services, a stopped/missing container should not report healthy.
     local container_state
     container_state=$(check_container_state "$sid")
     if [[ -n "$container_state" && "$container_state" != "running" ]]; then
@@ -184,9 +180,25 @@ test_service() {
         return 1
     fi
 
+    # CLI/no-health services: container is running (or not managed), report ok
+    if [[ "$health_type" == "none" ]]; then
+        result_set "$sid" "ok"
+        return 0
+    fi
+
+    # Validate port and timeout are numeric before use
+    if ! [[ "$port" =~ ^[0-9]+$ ]] || ! [[ "$timeout" =~ ^[0-9]+$ ]]; then
+        result_set "$sid" "fail"
+        ANY_FAIL=true
+        return 1
+    fi
+
     if [[ "$health_type" == "tcp" ]]; then
-        # TCP connection test using Python socket
-        if python3 -c "import socket; s = socket.create_connection(('127.0.0.1', $port), timeout=$timeout); s.close()" 2>/dev/null; then
+        # TCP connection test — values passed via environment to avoid
+        # interpolating unvalidated data into Python source
+        if DS_PORT="$port" DS_TIMEOUT="$timeout" python3 -c \
+            'import os,socket; s = socket.create_connection(("127.0.0.1", int(os.environ["DS_PORT"])), timeout=int(os.environ["DS_TIMEOUT"])); s.close()' \
+            2>/dev/null; then
             result_set "$sid" "ok"
             return 0
         fi


### PR DESCRIPTION
Fixes #666

## Summary

This PR adds support for TCP and CLI-only (none) health checks. Previously, `health-check.sh` defaulted to HTTP `curl` checks for all services. Services like `piper-audio` (Wyoming TCP protocol) or CLI tools like `aider` would always be flagged as unhealthy.

This introduces a `health_type` field in the manifest schema that can be set to `http`, `tcp`, or `none`.

### Changes

**`lib/service-registry.sh`**
- Declares `SERVICE_HEALTH_TYPES` associative array
- Parses `health_type` from manifest YAML (defaults to `http` for backward compatibility)

**`scripts/health-check.sh`**
- Container-state validation runs **before** `health_type=none` early return — a stopped/missing container is never reported healthy
- `none`: reports ok only after confirming container is running (or unmanaged)
- `tcp`: validates port/timeout as numeric, then uses Python socket test with values passed via environment variables (no code interpolation)
- `http`: existing curl logic unchanged

**`scripts/generate-extensions-catalog.py`**
- Propagates `health_type` into `extensions-catalog.json` so downstream consumers can distinguish check types

**Manifests**
- `piper-audio/manifest.yaml` → `health_type: tcp`
- `aider/manifest.yaml` → `health_type: none`

### Scope & Follow-up

This PR covers the registry, health-check engine, and catalog layers. The broader dashboard-api health helpers (`check_service_health()`), schema enum validation, `audit-extensions.py`, and full regression test suite are acknowledged as needed follow-up work and will be addressed in a separate PR to keep this one focused.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] CLI / Operational
- [x] Core Services (Registry)

## Risk And Validation

- Risk level: Low
- Backward compatible: services without `health_type` default to `http`
