### PR TITLE
fix(ci): reject ephemeral sha-<commit> image tags that upstream registries prune

### DIFF
--- a/dream-server/scripts/check-dependency-pins.py
+++ b/dream-server/scripts/check-dependency-pins.py
@@ -176,6 +176,18 @@ def _has_tag_or_digest(value: str) -> bool:
     return _has_digest(value) or _image_tag(value) is not None
 
 
+def _is_ephemeral_sha_tag(value: str) -> bool:
+    """Return True if the image tag looks like an ephemeral CI sha-<commit> tag.
+
+    Upstream registries routinely prune these tags, so pinning to them makes
+    releases unreproducible.  See issue #1544.
+    """
+    tag = _image_tag(value)
+    if tag is None:
+        return False
+    return bool(re.match(r'^sha-[0-9a-f]{7,}$', tag))
+
+
 def _is_variable_ref(value: str) -> bool:
     return "$" in value
 
@@ -280,6 +292,16 @@ def validate_refs(refs: Iterable[ImageRef], lock: dict[str, object], root: Path 
         if _image_tag(ref.value) == "latest" and not _has_digest(ref.value):
             if (ref.path, ref.value) not in latest_allow:
                 errors.append(f"{location}: latest tag requires allow_latest: {ref.value}")
+
+        # Reject ephemeral sha-<commit> tags on third-party images (issue #1544).
+        # These tags are pruned by upstream registries without notice, breaking
+        # installs that pin to them.  Pin to retained vYYYY.M.D / semver tags
+        # or a full @sha256: digest instead.
+        if _is_ephemeral_sha_tag(ref.value) and (ref.path, ref.value) not in local_allow:
+            errors.append(
+                f"{location}: ephemeral sha-<commit> tag will be pruned by upstream "
+                f"— pin to a retained version tag or @sha256: digest instead: {ref.value}"
+            )
 
         if (ref.path, ref.value) not in entry_keys and (ref.path, ref.value) not in latest_allow:
             errors.append(f"{location}: image ref is not recorded in dependency-lock.json: {ref.value}")

--- a/dream-server/tests/test-dependency-pins.py
+++ b/dream-server/tests/test-dependency-pins.py
@@ -97,12 +97,66 @@ def test_ephemeral_sha_tag_is_rejected() -> None:
     assert any("ephemeral sha-<commit> tag" in error for error in errors)
 
 
+def test_digest_ref_is_accepted() -> None:
+    """Full @sha256: digest refs must be accepted (they are immutable, not ephemeral)."""
+    module = load_module()
+    lock = {
+        "entries": [
+            {
+                "id": "test.digest",
+                "path": "compose.yaml",
+                "value": "myrepo/myimage:slim-latest@sha256:6e399abf4ff587822b0ef0df11f36088fb928e17ac61556fe89beb68d48c378e",
+            }
+        ],
+        "allow_latest": [],
+        "allow_local_images": [],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="compose.yaml",
+        line=3,
+        raw="myrepo/myimage:slim-latest@sha256:6e399abf4ff587822b0ef0df11f36088fb928e17ac61556fe89beb68d48c378e",
+        value="myrepo/myimage:slim-latest@sha256:6e399abf4ff587822b0ef0df11f36088fb928e17ac61556fe89beb68d48c378e",
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert not any("ephemeral" in e for e in errors), f"Digest ref should not be rejected: {errors}"
+
+
+def test_local_allowlisted_sha_is_accepted() -> None:
+    """Locally-built images with sha-style tags must be accepted when allowlisted."""
+    module = load_module()
+    lock = {
+        "entries": [],
+        "allow_latest": [],
+        "allow_local_images": [
+            {
+                "path": "compose.yaml",
+                "value": "dream-custom:sha-abc1234567",
+                "reason": "Local image built from adjacent Dockerfile.",
+            }
+        ],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="compose.yaml",
+        line=3,
+        raw="dream-custom:sha-abc1234567",
+        value="dream-custom:sha-abc1234567",
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert not any("ephemeral" in e for e in errors), f"Local allowlisted sha ref should not be rejected: {errors}"
+
+
 def main() -> int:
     tests = [
         test_repo_dependency_lock_passes,
         test_unallowlisted_latest_is_rejected,
         test_variable_refs_must_be_documented,
         test_ephemeral_sha_tag_is_rejected,
+        test_digest_ref_is_accepted,
+        test_local_allowlisted_sha_is_accepted,
     ]
     for test in tests:
         test()

--- a/dream-server/tests/test-dependency-pins.py
+++ b/dream-server/tests/test-dependency-pins.py
@@ -71,11 +71,38 @@ def test_variable_refs_must_be_documented() -> None:
     assert any("variable image ref is not documented" in error for error in errors)
 
 
+def test_ephemeral_sha_tag_is_rejected() -> None:
+    """Ephemeral sha-<commit> tags must be rejected (issue #1544)."""
+    module = load_module()
+    lock = {
+        "entries": [
+            {
+                "id": "test.sha-pin",
+                "path": "compose.yaml",
+                "value": "nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f",
+            }
+        ],
+        "allow_latest": [],
+        "allow_local_images": [],
+        "allow_variable_refs": [],
+    }
+    ref = module.ImageRef(
+        path="compose.yaml",
+        line=6,
+        raw="nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f",
+        value="nousresearch/hermes-agent:sha-dd0923bb89ed2dd56f82cb63656a1323f6f42e6f",
+        source="compose image",
+    )
+    errors = module.validate_refs([ref], lock)
+    assert any("ephemeral sha-<commit> tag" in error for error in errors)
+
+
 def main() -> int:
     tests = [
         test_repo_dependency_lock_passes,
         test_unallowlisted_latest_is_rejected,
         test_variable_refs_must_be_documented,
+        test_ephemeral_sha_tag_is_rejected,
     ]
     for test in tests:
         test()


### PR DESCRIPTION
Fixes #1544

## Summary

Issue #1544 was caused by the 2.5.2 release pinning the Hermes Agent image to an ephemeral `sha-<commit>` tag (`sha-dd0923bb...`) that upstream (`nousresearch/hermes-agent`) later pruned from Docker Hub, causing a hard 404 on install.

While `main` already moved to a retained `v2026.5.16` tag, there was **no CI guard** to prevent this from happening again. This PR adds one.

### Changes

**`scripts/check-dependency-pins.py`**
- Added `_is_ephemeral_sha_tag()` helper that detects `sha-[0-9a-f]{7,}` tag patterns
- Added a validation rule in `validate_refs()` that rejects any image using an ephemeral sha-commit tag (unless it's a locally-built allowlisted image)
- Error message guides contributors to use retained version tags or `@sha256:` digests instead

**`tests/test-dependency-pins.py`**
- `test_ephemeral_sha_tag_is_rejected()` — verifies the guard catches the exact tag pattern from the original issue
- `test_digest_ref_is_accepted()` — verifies immutable `@sha256:` digest refs pass clean (intended escape path)
- `test_local_allowlisted_sha_is_accepted()` — verifies locally-built images with sha-style tags are not rejected when allowlisted (intended escape path)

### Scope

This guard currently covers **bundled runtime services** (`extensions/services/`, `installers/`, and root compose files). The extension library catalog (`extensions/library/services/`) is not yet covered by the dependency pin scanner — those ~40 images would need to be registered in `dependency-lock.json` first, which is a separate effort. Filed as a follow-up scope expansion.

### Test results
```
$ python3 tests/test-dependency-pins.py
[PASS] dependency pin tests  (6 tests)
```

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] CI / Testing

## Risk And Validation

- Risk level: Low — additive CI guard only, no runtime behavior changes
- Validation: All 6 dependency pin tests pass
