### PR TITLE
fix: address several pending issues

### DIFF
--- a/dream-server/extensions/services/privacy-shield/pii_scrubber.py
+++ b/dream-server/extensions/services/privacy-shield/pii_scrubber.py
@@ -130,7 +130,7 @@ class PIIDetector:
         return {
             'unique_pii_count': len(self.pii_map),
             'pii_types': list(set(
-                token.split('_')[1] for token in self.pii_map.keys()
+                token[len(self.token_prefix):-len(self.token_suffix)].rsplit('_', 1)[0] for token in self.pii_map.keys()
             ))
         }
 

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -5,7 +5,7 @@
 EXTENSIONS_DIR="${SCRIPT_DIR:-$(pwd)}/extensions/services"
 _SR_LOADED=false
 _SR_FAILED=false
-_SR_CACHE="/tmp/dream-service-registry.$$.sh"
+_SR_CACHE="$(mktemp "${TMPDIR:-/tmp}/dream-service-registry.XXXXXX")" || _SR_CACHE=""
 
 # Caching for compose flags (session-level)
 _SR_COMPOSE_FLAGS_CACHE=""

--- a/dream-server/scripts/assign_gpus.py
+++ b/dream-server/scripts/assign_gpus.py
@@ -465,6 +465,7 @@ def main():
         services = {}
         for s in enabled_services:
             services[s] = ServiceAssignment(gpus=[gpu])
+        services.setdefault("llama_server", ServiceAssignment(gpus=[gpu]))
         services["llama_server"].parallelism = parallelism
         result = AssignmentResult(strategy="single", services=services)
         print(json.dumps(build_output(result), indent=2))

--- a/dream-server/scripts/dream-test-functional.sh
+++ b/dream-server/scripts/dream-test-functional.sh
@@ -231,7 +231,7 @@ test_whisper_functional() {
         return 0
     fi
     
-    if [[ ! -f "$test_audio" ]] || [[ $(stat -c%s "$test_audio" 2>/dev/null) -lt 1000 ]]; then
+    if [[ ! -f "$test_audio" ]] || [[ "$(stat -c%s "$test_audio" 2>/dev/null || stat -f%z "$test_audio" 2>/dev/null || echo 0)" -lt 1000 ]]; then
         warn "Test audio generation failed"
         return 0
     fi

--- a/dream-server/scripts/generate-extensions-catalog.py
+++ b/dream-server/scripts/generate-extensions-catalog.py
@@ -6,6 +6,7 @@ extracts catalog-relevant fields, and writes a sorted JSON catalog
 to dream-server/config/extensions-catalog.json.
 """
 
+from __future__ import annotations
 import argparse
 import json
 import re


### PR DESCRIPTION
Fixes #1564, #1562, #1561, #1565, #1563

This PR addresses a batch of open issues and bugs discovered by reviewers:
- **Security:** build service-registry cache with mktemp to prevent TOCTOU/symlink attacks (#1564)
- **MacOS Compatibility:** use portable stat fallback in dream-test-functional.sh (#1562)
- **GPU Assignment:** assign llama_server on single-GPU hosts when omitted from --enabled-services (#1561)
- **Privacy Shield:** report full multi-word PII type in get_stats (#1565)
- **Python Compatibility:** make generate-extensions-catalog.py import correctly on Python 3.9 by adding __future__ annotations (#1563)