### PR TITLE
fix(models): align dashboard activation with local GGUF discovery

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -106,6 +106,18 @@ jobs:
             done
           }
 
+          configure_zypper_ci_network() {
+            mkdir -p /etc/zypp/zypp.conf.d
+            {
+              printf '%s\n' '[main]'
+              printf '%s\n' 'download.transfer_timeout = 600'
+              printf '%s\n' 'download.connect_timeout = 120'
+              printf '%s\n' 'download.min_download_speed = 0'
+              printf '%s\n' 'download.max_silent_tries = 3'
+              printf '%s\n' 'download.max_concurrent_connections = 2'
+            } >/etc/zypp/zypp.conf.d/99-dreamserver-ci-network.conf
+          }
+
           if command -v apt-get &>/dev/null; then
             apt-get update -qq && apt-get install -y -qq ca-certificates git curl
           elif command -v dnf &>/dev/null; then
@@ -114,6 +126,7 @@ jobs:
             prepare_pacman_keyrings
             retry pacman -Syyu --noconfirm --needed ca-certificates git curl
           elif command -v zypper &>/dev/null; then
+            configure_zypper_ci_network
             retry zypper --non-interactive --gpg-auto-import-keys refresh
             retry zypper --non-interactive install -y ca-certificates git curl
           fi

--- a/README.md
+++ b/README.md
@@ -333,7 +333,10 @@ If the new model isn't downloaded yet, pre-fetch it first:
 dream model swap T3                    # Then swap (restarts llama-server)
 ```
 
-Already have a GGUF you want to use? Drop it in `data/models/`, update `GGUF_FILE` and `LLM_MODEL` in `.env`, and restart with the CLI:
+Already have a GGUF you want to use? Drop the single `.gguf` file in
+`data/models/`, then open Dashboard -> Models and load the local entry. For
+older installs or headless maintenance, update `GGUF_FILE` and `LLM_MODEL` in
+`.env`, then restart with the CLI:
 
 ```bash
 dream restart llm

--- a/dream-server/FAQ.md
+++ b/dream-server/FAQ.md
@@ -107,7 +107,9 @@ The model file must already be downloaded. If it isn't, pre-fetch it first:
 ```
 
 ### Can I use my own GGUF model?
-Yes. Drop the `.gguf` file into `data/models/`, then update `.env`:
+Yes. Drop the single `.gguf` file into `data/models/`, then open Dashboard ->
+Models and load the local entry. For headless maintenance or older installs,
+update `.env`:
 ```bash
 GGUF_FILE=my-model.gguf
 LLM_MODEL=my-model
@@ -117,6 +119,11 @@ Restart the inference server:
 docker compose restart llama-server
 ```
 The model will load in ~30-120 seconds depending on size. If it fails, Dream Server automatically rolls back to the previous model.
+
+On Lemonade installs, load the model through Dream Server rather than only
+opening it in the Lemonade app. The Lemonade app can load the file for direct
+testing, but Open WebUI uses Dream Server's persisted LiteLLM route and may
+switch Lemonade back to the configured/default model on the next chat.
 
 ### What models are available?
 The installer auto-selects based on your GPU, but you can switch between any tier:

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -648,6 +648,57 @@ def _model_file_ready(path: Path) -> bool:
         return False
 
 
+def _local_model_name_from_gguf(gguf_file: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", Path(gguf_file).stem).strip("-._")
+    return name or "local-gguf"
+
+
+def _local_gguf_filename_from_id(model_id: str) -> str | None:
+    """Map a Dashboard/local model id to a safe GGUF filename candidate."""
+    token = str(model_id or "").strip()
+    if token.lower().startswith("extra."):
+        token = token[6:]
+    if not token or any(sep in token for sep in ("/", "\\", "\x00")):
+        return None
+    filename = token if token.lower().endswith(".gguf") else f"{token}.gguf"
+    if filename.lower().endswith(".part") or Path(filename).name != filename:
+        return None
+    return filename
+
+
+def _resolve_local_gguf_filename(model_id: str, models_dir: Path) -> str | None:
+    """Resolve a local GGUF id to the exact on-disk filename.
+
+    Dashboard fallback entries use the file stem as the public id. Preserve
+    exact filename case when the extension is `.GGUF` or otherwise mixed-case.
+    """
+    candidate = _local_gguf_filename_from_id(model_id)
+    if not candidate or not models_dir.is_dir():
+        return None
+
+    candidate_lower = candidate.lower()
+    candidate_stem = Path(candidate).stem.lower()
+    exact_matches: list[Path] = []
+    stem_matches: list[Path] = []
+    try:
+        for path in models_dir.iterdir():
+            if not path.is_file() or not path.name.lower().endswith(".gguf"):
+                continue
+            if path.name.lower() == candidate_lower:
+                exact_matches.append(path)
+            elif path.stem.lower() == candidate_stem:
+                stem_matches.append(path)
+    except OSError:
+        return None
+
+    matches = exact_matches or stem_matches
+    if len(matches) == 1:
+        return matches[0].name
+    if len(matches) > 1:
+        logger.warning("Ambiguous local GGUF model id %s matched %s", model_id, [p.name for p in matches])
+    return None
+
+
 def _read_progress_status(service_id: str) -> str | None:
     """Return the ``status`` field of the progress file, or None if absent/unreadable.
 
@@ -3051,7 +3102,7 @@ class AgentHandler(BaseHTTPRequestHandler):
             downloaded = {}
             if models_dir.is_dir():
                 for f in models_dir.iterdir():
-                    if f.is_file() and f.suffix == ".gguf" and not f.name.endswith(".part"):
+                    if f.name.lower().endswith(".gguf") and _model_file_ready(f):
                         try:
                             downloaded[f.name] = f.stat().st_size
                         except OSError:
@@ -3424,6 +3475,37 @@ class AgentHandler(BaseHTTPRequestHandler):
     def _do_model_activate(self, model_id: str):
         """Inner activate logic — called with _model_activate_lock held."""
         import time
+
+        def local_gguf_model_from_id(raw_model_id: str) -> dict | None:
+            models_dir = INSTALL_DIR / "data" / "models"
+            gguf_file = _resolve_local_gguf_filename(raw_model_id, models_dir)
+            if not gguf_file:
+                return None
+            target = (models_dir / gguf_file).resolve()
+            if not target.is_relative_to(models_dir.resolve()) or not target.is_file():
+                return None
+
+            env_values = load_env(INSTALL_DIR / ".env")
+            context_length = 32768
+            for key in ("MAX_CONTEXT", "CTX_SIZE"):
+                try:
+                    value = int(env_values.get(key) or 0)
+                except (TypeError, ValueError):
+                    continue
+                if value > 0:
+                    context_length = value
+                    break
+
+            llm_model_name = _local_model_name_from_gguf(gguf_file)
+            return {
+                "id": llm_model_name,
+                "gguf_file": gguf_file,
+                "llm_model_name": llm_model_name,
+                "context_length": context_length,
+                "runtime_profiles": [],
+                "local": True,
+            }
+
         # Look up model in library
         library_path = INSTALL_DIR / "config" / "model-library.json"
         model = None
@@ -3437,8 +3519,10 @@ class AgentHandler(BaseHTTPRequestHandler):
             except (json.JSONDecodeError, OSError):
                 pass
         if model is None:
-            json_response(self, 404, {"error": f"Model '{model_id}' not found in library"})
-            return
+            model = local_gguf_model_from_id(model_id)
+            if model is None:
+                json_response(self, 404, {"error": f"Model '{model_id}' not found in library or local GGUF files"})
+                return
 
         gguf_file = model.get("gguf_file", "")
         llm_model_name = model.get("llm_model_name", model_id)
@@ -3451,8 +3535,8 @@ class AgentHandler(BaseHTTPRequestHandler):
         if not target.is_relative_to(models_dir.resolve()):
             json_response(self, 400, {"error": "Invalid model file path"})
             return
-        if not target.exists():
-            json_response(self, 400, {"error": f"Model file not downloaded: {gguf_file}"})
+        if not _model_file_ready(target):
+            json_response(self, 400, {"error": f"Model file not downloaded or empty: {gguf_file}"})
             return
 
         env_path = INSTALL_DIR / ".env"
@@ -3568,6 +3652,8 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "LLAMA_ARG_N_CPU_MOE",
                     "LLAMA_ARG_NO_CACHE_PROMPT",
                     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS",
+                    "LLAMA_ARG_SPEC_TYPE",
+                    "LLAMA_ARG_SPEC_DRAFT_N_MAX",
                 }
                 if runtime_profile:
                     for key, value in runtime_env.items():
@@ -3584,6 +3670,8 @@ class AgentHandler(BaseHTTPRequestHandler):
                     "LLAMA_ARG_N_CPU_MOE",
                     "LLAMA_ARG_NO_CACHE_PROMPT",
                     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS",
+                    "LLAMA_ARG_SPEC_TYPE",
+                    "LLAMA_ARG_SPEC_DRAFT_N_MAX",
                     "LLAMA_SERVER_IMAGE",
                 }
                 remove_keys.difference_update(updates)

--- a/dream-server/docs/MODEL-MANAGEMENT.md
+++ b/dream-server/docs/MODEL-MANAGEMENT.md
@@ -1,8 +1,8 @@
 # Model Management
 
 Dream Server runs local language models as GGUF files from `data/models/`.
-The recommended path is the Dashboard Models page; manual model swaps are
-possible, but they are an operator workflow today.
+The recommended path is the Dashboard Models page. Manual model swaps are also
+available for headless maintenance and advanced operator workflows.
 
 ## Recommended: Dashboard Models Page
 
@@ -14,6 +14,7 @@ From there you can:
 - Check approximate model size, VRAM requirement, context length, and specialty.
 - Download a catalog model into `data/models/`.
 - Load a downloaded model.
+- Load a manually copied single-file GGUF discovered in `data/models/`.
 - Delete a downloaded catalog model.
 
 When a catalog model is loaded, Dream Server updates the active GGUF settings
@@ -101,10 +102,26 @@ curl -L \
 Then open Dashboard -> Models. If the filename matches a catalog entry, the
 model should appear as downloaded and you can load it from the Dashboard.
 
-## Manual: Bring Your Own GGUF
+## Bring Your Own GGUF
 
-Custom GGUFs are supported by the underlying stack, but not yet as a polished
-Dashboard import flow. Treat this as an operator procedure.
+For a single local `.gguf`, the normal flow is:
+
+1. Copy the file into `data/models/`.
+2. Open Dashboard -> Models.
+3. Load the local entry.
+
+The Dashboard updates `.env`, `config/llama-server/models.ini`, and the active
+runtime routing before restarting the inference service.
+
+On Lemonade installs, loading a model directly inside the Lemonade app only
+changes Lemonade's current runtime state. It does not update Dream Server's
+`.env` or LiteLLM routing. Open WebUI talks through Dream Server/LiteLLM, so
+its next chat can ask for the persisted Dream Server model and Lemonade may
+unload the model you opened manually. Use Dashboard -> Models -> Load when you
+want Open WebUI and other Dream Server clients to keep using the local GGUF.
+
+Use the manual procedure below only if you cannot access the Dashboard or need
+to repair an install by hand.
 
 1. Download the GGUF into `data/models/`.
 

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -68,6 +68,7 @@ from settings import (
     _ENV_ASSIGNMENT_RE, _ENV_COMMENTED_ASSIGNMENT_RE, _SETTINGS_APPLY_ALLOWED_SERVICES, _parse_env_text, _read_env_map_from_path,
     _slugify,
     _build_env_fields, _validate_env_values, _serialize_form_values,
+    _empty_value_unsets_env_key,
     _compute_env_apply_plan,
     _check_host_agent_available,
 )
@@ -922,6 +923,9 @@ def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]
 
     normalized_values = _serialize_form_values(submitted_values, base_fields, current_values)
     merged_values = {**current_values, **normalized_values}
+    for key, field in base_fields.items():
+        if _empty_value_unsets_env_key(key, field) and str(merged_values.get(key, "")).strip() == "":
+            merged_values.pop(key, None)
     merged_fields = _build_env_fields(schema_properties, required_keys, merged_values)
     issues = _validate_env_values(merged_values, merged_fields)
     apply_plan = _compute_env_apply_plan(current_values, merged_values)

--- a/dream-server/extensions/services/dashboard-api/performance_oracle.py
+++ b/dream-server/extensions/services/dashboard-api/performance_oracle.py
@@ -33,6 +33,11 @@ def normalize_key(value: Any) -> str:
     return re.sub(r"[^a-z0-9]+", "-", str(value or "").lower()).strip("-")
 
 
+def local_model_id(value: Any) -> str:
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "")).strip("-._")
+    return name or "local-gguf"
+
+
 def _list_value(value: Any) -> list[str]:
     if value is None:
         return []
@@ -900,7 +905,14 @@ def build_models_payload(gpu_info: Optional[GPUInfo], loaded_model: Optional[str
             for name, value in downloaded_files_override.items()
         }
     else:
-        downloaded_files = {p.name.lower(): p for p in models_dir.glob("*.gguf")} if models_dir.exists() else {}
+        downloaded_files = {}
+        if models_dir.exists():
+            for p in models_dir.iterdir():
+                try:
+                    if p.is_file() and p.name.lower().endswith(".gguf") and p.stat().st_size > 0:
+                        downloaded_files[p.name.lower()] = p
+                except OSError:
+                    continue
 
     gpu_data = None
     free_gb = 0.0
@@ -1024,7 +1036,7 @@ def build_models_payload(gpu_info: Optional[GPUInfo], loaded_model: Optional[str
             continue
         size_mb = path.stat().st_size / (1024 * 1024)
         fallback = {
-            "id": path.stem,
+            "id": local_model_id(path.stem),
             "name": path.stem,
             "gguf": path.name,
             "size_mb": size_mb,

--- a/dream-server/extensions/services/dashboard-api/routers/models.py
+++ b/dream-server/extensions/services/dashboard-api/routers/models.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import time
 import urllib.request
 import urllib.error
@@ -59,6 +60,11 @@ else:
     _GPU_VRAM_EXCEPTIONS = _GPU_VRAM_EXCEPTIONS + (pynvml.NVMLError,)
 
 
+def _local_model_name_from_gguf(gguf_file: str) -> str:
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", Path(gguf_file).stem).strip("-._")
+    return name or "local-gguf"
+
+
 def _load_library() -> list[dict]:
     """Load the model library catalog from config/model-library.json."""
     if not _LIBRARY_PATH.exists():
@@ -79,7 +85,7 @@ def _scan_downloaded_models() -> dict[str, int]:
         return downloaded
     try:
         for f in _MODELS_DIR.iterdir():
-            if f.is_file() and f.suffix == ".gguf" and not f.name.endswith(".part"):
+            if _is_final_gguf_file(f):
                 try:
                     downloaded[f.name] = f.stat().st_size
                 except OSError:
@@ -87,6 +93,13 @@ def _scan_downloaded_models() -> dict[str, int]:
     except OSError as exc:
         logger.warning("Failed to scan models directory: %s", exc)
     return downloaded
+
+
+def _is_final_gguf_file(path: Path) -> bool:
+    try:
+        return path.is_file() and path.name.lower().endswith(".gguf") and path.stat().st_size > 0
+    except OSError:
+        return False
 
 
 def _read_active_model() -> Optional[str]:
@@ -384,6 +397,87 @@ def _find_model_in_library(model_id: str) -> Optional[dict]:
     return None
 
 
+def _local_gguf_filename_from_id(model_id: str) -> str | None:
+    """Map a dashboard fallback model ID to a local GGUF filename."""
+    token = str(model_id or "").strip()
+    if token.lower().startswith("extra."):
+        token = token[6:]
+    if not token or any(sep in token for sep in ("/", "\\", "\x00")):
+        return None
+    filename = token if token.lower().endswith(".gguf") else f"{token}.gguf"
+    if filename.lower().endswith(".part") or Path(filename).name != filename:
+        return None
+    return filename
+
+
+def _resolve_local_gguf_filename(model_id: str) -> str | None:
+    candidate = _local_gguf_filename_from_id(model_id)
+    if not candidate or not _MODELS_DIR.is_dir():
+        return None
+
+    candidate_lower = candidate.lower()
+    candidate_stem = Path(candidate).stem.lower()
+    exact_matches: list[Path] = []
+    stem_matches: list[Path] = []
+    try:
+        for path in _MODELS_DIR.iterdir():
+            if not _is_final_gguf_file(path):
+                continue
+            if path.name.lower() == candidate_lower:
+                exact_matches.append(path)
+            elif path.stem.lower() == candidate_stem:
+                stem_matches.append(path)
+    except OSError as exc:
+        logger.warning("Failed to resolve local GGUF %s: %s", model_id, exc)
+        return None
+
+    matches = exact_matches or stem_matches
+    if len(matches) == 1:
+        return matches[0].name
+    if len(matches) > 1:
+        logger.warning("Ambiguous local GGUF model id %s matched %s", model_id, [p.name for p in matches])
+    return None
+
+
+def _find_local_gguf_model(model_id: str) -> Optional[dict]:
+    """Return a synthetic activation record for a manually installed GGUF."""
+    gguf_file = _resolve_local_gguf_filename(model_id)
+    if not gguf_file:
+        return None
+    models_dir = _MODELS_DIR.resolve()
+    target = (_MODELS_DIR / gguf_file).resolve()
+    if not target.is_relative_to(models_dir) or not _is_final_gguf_file(target):
+        return None
+
+    context_length = 32768
+    for key in ("MAX_CONTEXT", "CTX_SIZE"):
+        try:
+            value = int(
+                read_env_file_value(key, INSTALL_DIR)
+                or read_env_value(key, INSTALL_DIR)
+                or 0
+            )
+        except (TypeError, ValueError):
+            continue
+        if value > 0:
+            context_length = value
+            break
+
+    model_name = _local_model_name_from_gguf(gguf_file)
+    return {
+        "id": model_name,
+        "gguf_file": gguf_file,
+        "llm_model_name": model_name,
+        "context_length": context_length,
+        "runtime_profiles": [],
+        "local": True,
+    }
+
+
+def _find_loadable_model(model_id: str) -> Optional[dict]:
+    return _find_model_in_library(model_id) or _find_local_gguf_model(model_id)
+
+
 def _find_normalized_model(model_id: str) -> Optional[dict]:
     return find_catalog_model(load_model_catalog(INSTALL_DIR), model_id, None)
 
@@ -643,9 +737,9 @@ def cancel_download(api_key: str = Depends(verify_api_key)):
 @router.post("/api/models/{model_id}/load")
 def load_model(model_id: str, api_key: str = Depends(verify_api_key)):
     """Activate a model — update config and restart llama-server."""
-    model = _find_model_in_library(model_id)
+    model = _find_loadable_model(model_id)
     if model is None:
-        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found in library")
+        raise HTTPException(status_code=404, detail=f"Model '{model_id}' not found in library or local GGUF files")
 
     already_active, loaded_model = _already_active_model(model_id, model)
     if already_active:

--- a/dream-server/extensions/services/dashboard-api/settings.py
+++ b/dream-server/extensions/services/dashboard-api/settings.py
@@ -243,6 +243,13 @@ def _serialize_form_values(
 
     return serialized
 
+
+def _empty_value_unsets_env_key(key: str, field: dict[str, Any]) -> bool:
+    """Return true when an empty form value should remove a runtime env key."""
+    if field.get("required") or field.get("secret"):
+        return False
+    return key.startswith("LLAMA_ARG_")
+
 # ── Apply-plan helpers ─────────────────────────────────────────────────────────
 
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -497,6 +497,166 @@ class TestModelActivateRollback:
         assert "LLM_MODEL=new-model" in env_path.read_text(encoding="utf-8")
         assert "filename = new-model.gguf" in models_ini.read_text(encoding="utf-8")
 
+    def test_activation_accepts_local_gguf_without_catalog_entry(self, tmp_path, monkeypatch):
+        install_dir, env_path, _env_text, models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        (install_dir / "config" / "model-library.json").write_text(
+            json.dumps({"models": []}),
+            encoding="utf-8",
+        )
+        (install_dir / "data" / "models" / "Research.Model-Q8_0.gguf").write_text(
+            "model",
+            encoding="utf-8",
+        )
+        env_path.write_text(
+            "GPU_BACKEND=nvidia\n"
+            "GGUF_FILE=old-model.gguf\n"
+            "LLM_MODEL=old-model\n"
+            "MAX_CONTEXT=65536\n"
+            "LLAMA_ARG_SPEC_TYPE=draft-mtp\n"
+            "LLAMA_ARG_SPEC_DRAFT_N_MAX=3\n"
+            "OLLAMA_PORT=8080\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("DREAM_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
+
+        def fake_run(cmd, **_kwargs):
+            stdout = '{"status":"ok"}' if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "Research.Model-Q8_0")
+
+        assert handler.response_code == 200
+        assert handler.parse_response() == {"status": "activated", "model_id": "Research.Model-Q8_0"}
+        env_text = env_path.read_text(encoding="utf-8")
+        assert "GGUF_FILE=Research.Model-Q8_0.gguf" in env_text
+        assert "LLM_MODEL=Research.Model-Q8_0" in env_text
+        assert "CTX_SIZE=65536" in env_text
+        assert "LLAMA_ARG_SPEC_TYPE=" not in env_text
+        assert "LLAMA_ARG_SPEC_DRAFT_N_MAX=" not in env_text
+        assert "filename = Research.Model-Q8_0.gguf" in models_ini.read_text(encoding="utf-8")
+
+    def test_activation_resolves_local_gguf_by_stem_with_mixed_case_extension(
+        self, tmp_path, monkeypatch,
+    ):
+        install_dir, env_path, _env_text, models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        (install_dir / "config" / "model-library.json").write_text(
+            json.dumps({"models": []}),
+            encoding="utf-8",
+        )
+        (install_dir / "data" / "models" / "MixedCaseModel.GGUF").write_text(
+            "model",
+            encoding="utf-8",
+        )
+        env_path.write_text(
+            "GPU_BACKEND=nvidia\n"
+            "GGUF_FILE=old-model.gguf\n"
+            "LLM_MODEL=old-model\n"
+            "MAX_CONTEXT=32768\n"
+            "OLLAMA_PORT=8080\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("DREAM_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
+
+        def fake_run(cmd, **_kwargs):
+            stdout = '{"status":"ok"}' if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "MixedCaseModel")
+
+        assert handler.response_code == 200
+        env_text = env_path.read_text(encoding="utf-8")
+        assert "GGUF_FILE=MixedCaseModel.GGUF" in env_text
+        assert "LLM_MODEL=MixedCaseModel" in env_text
+        assert "filename = MixedCaseModel.GGUF" in models_ini.read_text(encoding="utf-8")
+
+    def test_activation_sanitizes_local_llm_model_name_for_spaced_filename(
+        self, tmp_path, monkeypatch,
+    ):
+        install_dir, env_path, _env_text, models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        (install_dir / "config" / "model-library.json").write_text(
+            json.dumps({"models": []}),
+            encoding="utf-8",
+        )
+        (install_dir / "data" / "models" / "My Custom Model.Q8_0.GGUF").write_text(
+            "model",
+            encoding="utf-8",
+        )
+        env_path.write_text(
+            "GPU_BACKEND=nvidia\n"
+            "GGUF_FILE=old-model.gguf\n"
+            "LLM_MODEL=old-model\n"
+            "MAX_CONTEXT=32768\n"
+            "OLLAMA_PORT=8080\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("DREAM_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
+
+        def fake_run(cmd, **_kwargs):
+            stdout = '{"status":"ok"}' if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "My Custom Model.Q8_0")
+
+        assert handler.response_code == 200
+        env_text = env_path.read_text(encoding="utf-8")
+        assert "GGUF_FILE=My Custom Model.Q8_0.GGUF" in env_text
+        assert "LLM_MODEL=My-Custom-Model.Q8_0" in env_text
+        assert "[My-Custom-Model.Q8_0]" in models_ini.read_text(encoding="utf-8")
+        assert "filename = My Custom Model.Q8_0.GGUF" in models_ini.read_text(encoding="utf-8")
+
+    def test_activation_rejects_empty_local_gguf_before_restart(self, tmp_path, monkeypatch):
+        install_dir, _env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        (install_dir / "config" / "model-library.json").write_text(
+            json.dumps({"models": []}),
+            encoding="utf-8",
+        )
+        (install_dir / "data" / "models" / "EmptyLocal.gguf").write_text(
+            "",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+
+        def fail_restart(_env):
+            raise AssertionError("empty GGUF should be rejected before restart")
+
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", fail_restart)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "EmptyLocal")
+
+        assert handler.response_code == 400
+        assert "not downloaded or empty" in handler.parse_response()["error"]
+
     def test_amd_activation_rewrites_lemonade_yaml_with_env_file_key(
         self, tmp_path, monkeypatch,
     ):
@@ -748,6 +908,8 @@ class TestModelActivateRollback:
                         "LLAMA_ARG_N_CPU_MOE": "30",
                         "LLAMA_ARG_NO_CACHE_PROMPT": "1",
                         "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS": "-1",
+                        "LLAMA_ARG_SPEC_TYPE": "draft-mtp",
+                        "LLAMA_ARG_SPEC_DRAFT_N_MAX": "3",
                     },
                 }],
             }]
@@ -777,6 +939,8 @@ class TestModelActivateRollback:
         assert "LLAMA_ARG_CACHE_TYPE_V=turbo3" in env_text
         assert "LLAMA_ARG_N_CPU_MOE=30" in env_text
         assert "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS=-1" in env_text
+        assert "LLAMA_ARG_SPEC_TYPE=draft-mtp" in env_text
+        assert "LLAMA_ARG_SPEC_DRAFT_N_MAX=3" in env_text
 
     def test_unexpected_failure_rolls_back_all_config_backups(self, tmp_path, monkeypatch):
         install_dir, env_path, env_text, models_ini, ini_text, lemonade_yaml, lemonade_text = (

--- a/dream-server/extensions/services/dashboard-api/tests/test_models.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_models.py
@@ -538,3 +538,97 @@ def test_load_model_delegates_when_loaded_backend_is_not_ready(test_client, monk
         "body": {"model_id": "qwen3.5-9b-q4"},
         "timeout": 600,
     }
+
+
+def test_load_model_delegates_local_gguf_without_catalog_entry(test_client, monkeypatch, tmp_path):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [])
+    (data_dir / "models" / "OpenAI-20B-NEO-CODE-DI-Uncensored-Q8_0.gguf").write_text(
+        "model",
+        encoding="utf-8",
+    )
+    (install_dir / ".env").write_text("MAX_CONTEXT=65536\n", encoding="utf-8")
+    monkeypatch.setattr(
+        models_router,
+        "_call_agent_model",
+        lambda path, body, timeout=30: {"status": "activated", "path": path, "body": body, "timeout": timeout},
+    )
+
+    resp = test_client.post(
+        "/api/models/OpenAI-20B-NEO-CODE-DI-Uncensored-Q8_0/load",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "status": "activated",
+        "path": "/v1/model/activate",
+        "body": {"model_id": "OpenAI-20B-NEO-CODE-DI-Uncensored-Q8_0"},
+        "timeout": 600,
+    }
+
+
+def test_local_gguf_scan_keeps_mixed_case_and_skips_empty(monkeypatch, tmp_path):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [])
+    (data_dir / "models" / "MixedCaseModel.GGUF").write_text("model", encoding="utf-8")
+    (data_dir / "models" / "empty.gguf").write_text("", encoding="utf-8")
+    (data_dir / "models" / "partial.gguf.part").write_text("partial", encoding="utf-8")
+
+    assert models_router._scan_downloaded_models() == {
+        "MixedCaseModel.GGUF": len("model"),
+    }
+
+
+def test_load_model_resolves_local_gguf_by_stem_with_mixed_case_extension(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [])
+    (data_dir / "models" / "MixedCaseModel.GGUF").write_text("model", encoding="utf-8")
+    monkeypatch.setattr(
+        models_router,
+        "_call_agent_model",
+        lambda path, body, timeout=30: {"status": "activated", "path": path, "body": body, "timeout": timeout},
+    )
+
+    resp = test_client.post(
+        "/api/models/MixedCaseModel/load",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    assert models_router._find_loadable_model("MixedCaseModel")["gguf_file"] == "MixedCaseModel.GGUF"
+    assert resp.json() == {
+        "status": "activated",
+        "path": "/v1/model/activate",
+        "body": {"model_id": "MixedCaseModel"},
+        "timeout": 600,
+    }
+
+
+def test_local_gguf_model_uses_safe_logical_id_for_spaced_filename(monkeypatch, tmp_path):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [])
+    (data_dir / "models" / "My Custom Model.Q8_0.GGUF").write_text("model", encoding="utf-8")
+
+    model = models_router._find_loadable_model("My Custom Model.Q8_0")
+
+    assert model["gguf_file"] == "My Custom Model.Q8_0.GGUF"
+    assert model["id"] == "My-Custom-Model.Q8_0"
+    assert model["llm_model_name"] == "My-Custom-Model.Q8_0"
+
+
+def test_load_model_rejects_local_gguf_path_separators(test_client, monkeypatch, tmp_path):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [])
+    (data_dir / "models" / "nested.gguf").write_text("model", encoding="utf-8")
+
+    resp = test_client.post(
+        "/api/models/..%5Cnested/load",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 404

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -29,7 +29,8 @@ def settings_env_fixture(tmp_path, monkeypatch):
         "# ════════════════════════════════\n"
         "OPENAI_API_KEY=\n"
         "LLM_BACKEND=local\n"
-        "WEBUI_AUTH=true\n",
+        "WEBUI_AUTH=true\n"
+        "# LLAMA_ARG_N_CPU_MOE=25\n",
         encoding="utf-8",
     )
 
@@ -53,6 +54,11 @@ def settings_env_fixture(tmp_path, monkeypatch):
                         "type": "boolean",
                         "description": "Require login for the WebUI.",
                         "default": True,
+                    },
+                    "LLAMA_ARG_N_CPU_MOE": {
+                        "type": "integer",
+                        "description": "Optional llama.cpp MoE tuning knob.",
+                        "minimum": 0,
                     },
                 },
             }
@@ -256,6 +262,50 @@ def test_api_settings_env_save_returns_llama_apply_plan(test_client, settings_en
     assert payload["applyPlan"]["status"] == "ready"
     assert payload["applyPlan"]["services"] == ["llama-server"]
     assert "llama-server" in payload["applyPlan"]["summary"]
+
+
+def test_api_settings_env_preserves_commented_empty_llama_args(test_client, settings_env_fixture):
+    env_path = settings_env_fixture["env_path"]
+
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {
+                "LLM_BACKEND": "cloud",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    updated_lines = env_path.read_text(encoding="utf-8").splitlines()
+    assert "# LLAMA_ARG_N_CPU_MOE=25" in updated_lines
+    assert not any(line.startswith("LLAMA_ARG_N_CPU_MOE=") for line in updated_lines)
+
+
+def test_api_settings_env_unsets_empty_existing_llama_arg(test_client, settings_env_fixture):
+    env_path = settings_env_fixture["env_path"]
+    env_path.write_text(
+        env_path.read_text(encoding="utf-8") + "LLAMA_ARG_N_CPU_MOE=30\n",
+        encoding="utf-8",
+    )
+
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {
+                "LLAMA_ARG_N_CPU_MOE": "",
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    updated_lines = env_path.read_text(encoding="utf-8").splitlines()
+    assert "# LLAMA_ARG_N_CPU_MOE=25" in updated_lines
+    assert not any(line.startswith("LLAMA_ARG_N_CPU_MOE=") for line in updated_lines)
 
 
 def test_api_settings_env_apply_calls_host_agent(test_client, monkeypatch):

--- a/dream-server/installers/lib/packaging.sh
+++ b/dream-server/installers/lib/packaging.sh
@@ -70,6 +70,33 @@ _pkg_prepare_pacman_keyrings() {
     done
 }
 
+_pkg_configure_zypper_ci_network() {
+    [[ "$PKG_MANAGER" == "zypper" ]] || return 0
+    [[ -n "${GITHUB_ACTIONS:-}" || -n "${CI:-}" ]] || return 0
+
+    local conf_dir="/etc/zypp/zypp.conf.d"
+    local conf_file="${conf_dir}/99-dreamserver-ci-network.conf"
+    local tmp
+
+    tmp="$(mktemp "${TMPDIR:-/tmp}/dreamserver-zypp-ci-network.XXXXXX")" || return 0
+
+    cat >"$tmp" <<'EOF'
+[main]
+download.transfer_timeout = 600
+download.connect_timeout = 120
+download.min_download_speed = 0
+download.max_silent_tries = 3
+download.max_concurrent_connections = 2
+EOF
+
+    _pkg_run mkdir -p "$conf_dir" 2>>"$LOG_FILE" || {
+        rm -f "$tmp"
+        return 0
+    }
+    _pkg_run cp "$tmp" "$conf_file" 2>>"$LOG_FILE" || true
+    rm -f "$tmp"
+}
+
 # Detect the system's package manager from /etc/os-release
 # Sets: PKG_MANAGER, DISTRO_ID, DISTRO_ID_LIKE
 detect_pkg_manager() {
@@ -133,7 +160,7 @@ pkg_update() {
         apt)    _pkg_run apt-get update -qq 2>>"$LOG_FILE" ;;
         dnf)    _pkg_run dnf check-update -q 2>>"$LOG_FILE" || true ;;  # returns 100 if updates available
         pacman) _pkg_prepare_pacman_keyrings; _pkg_retry pacman -Syyu --noconfirm 2>>"$LOG_FILE" ;;  # full sync+upgrade (partial -Sy is unsafe)
-        zypper) _pkg_retry zypper --non-interactive --gpg-auto-import-keys refresh 2>>"$LOG_FILE" ;;
+        zypper) _pkg_configure_zypper_ci_network; _pkg_retry zypper --non-interactive --gpg-auto-import-keys refresh 2>>"$LOG_FILE" ;;
         xbps)   _pkg_run xbps-install -S 2>>"$LOG_FILE" ;;
         apk)    _pkg_run apk update 2>>"$LOG_FILE" ;;
         *)      warn "Cannot update package index: unknown package manager '$PKG_MANAGER'" ;;
@@ -159,7 +186,7 @@ pkg_install() {
         apt)    _pkg_run apt-get install -y -qq "${pkgs[@]}" 2>>"$LOG_FILE" ;;
         dnf)    _pkg_run dnf install -y -q "${pkgs[@]}" 2>>"$LOG_FILE" ;;
         pacman) _pkg_prepare_pacman_keyrings; _pkg_retry pacman -S --noconfirm --needed "${pkgs[@]}" 2>>"$LOG_FILE" ;;
-        zypper) _pkg_retry zypper --non-interactive install -y "${pkgs[@]}" 2>>"$LOG_FILE" ;;
+        zypper) _pkg_configure_zypper_ci_network; _pkg_retry zypper --non-interactive install -y "${pkgs[@]}" 2>>"$LOG_FILE" ;;
         xbps)   _pkg_run xbps-install -y "${pkgs[@]}" 2>>"$LOG_FILE" ;;
         apk)    _pkg_run apk add --no-progress "${pkgs[@]}" 2>>"$LOG_FILE" ;;
         *)      warn "Cannot install packages: unknown package manager '$PKG_MANAGER'. Install manually: ${pkgs[*]}" ; return 1 ;;


### PR DESCRIPTION
## Summary

This PR fixes a Dashboard/API mismatch in the local GGUF model workflow and closes the runtime edge cases that made this failure confusing for users.

DreamServer already discovers single-file GGUF models placed in `data/models/` and surfaces them in the Dashboard model list as local entries. However, clicking **Load** on one of those manually installed models could fail before reaching Lemonade or llama-server with:

```text
Model '<local-model-id>' not found in library
```

The issue was that model discovery accepted local GGUF fallback entries, but the activation path still required every model to exist in `config/model-library.json`.

This PR aligns those paths by allowing valid local GGUF files discovered in `data/models/` to be activated through the Dashboard and host-agent, while preserving the existing curated catalog behavior.

The final hardening pass also keeps the Dashboard and host-agent consistent for manually copied files: mixed-case `.GGUF` extensions are discovered, empty files are ignored/rejected before runtime restart, path separators are rejected, and local filenames with spaces keep their real `GGUF_FILE` while using a safe logical `LLM_MODEL`.

The docs now also clarify the Lemonade-specific operator behavior behind the support report: loading a model directly in the Lemonade app is a runtime-only test path, while Open WebUI follows Dream Server's persisted LiteLLM route.

It also hardens the related llama.cpp env handling found during triage:

- Clears inherited `LLAMA_ARG_SPEC_TYPE` / `LLAMA_ARG_SPEC_DRAFT_N_MAX` values unless the selected runtime profile explicitly sets them.
- Treats empty `LLAMA_ARG_*` Settings values as unset, preventing blank llama.cpp env vars such as `LLAMA_ARG_N_CPU_MOE=` from reaching the runtime.

It also hardens the openSUSE Tumbleweed matrix smoke path observed during CI: the pre-checkout bootstrap and package helper now apply CI-only libzypp download timeout/retry settings before `zypper refresh` / `zypper install`, so slow repository metadata downloads do not fail the PR before DreamServer tests run.

## AI Assistance

Codex assisted with triage, implementation, test coverage, documentation updates, and follow-up hardening after reviewing the user-reported Lemonade/llama.cpp logs. The maintainer reviewed the code path, selected the validation scope, and remains responsible for the final diff and review responses.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A for this PR target: this is opened against main first. The fix is a good stable backport candidate for release/2.5.x after review because it addresses a current-stable BYO GGUF activation failure and related blank/stale llama.cpp env flag issues.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because:

Commands/results:

```text
python -m pytest extensions/services/dashboard-api/tests/test_models.py extensions/services/dashboard-api/tests/test_model_activate.py extensions/services/dashboard-api/tests/test_settings_env.py extensions/services/dashboard-api/tests/test_performance_oracle.py
Result: 98 passed

bash tests/test-llama-mtp-args.sh
Result: llama MTP arg contract OK

python -m ruff check dream-server/ --select E,F,W --ignore E501,E701,E731,E741,E402
Result: All checks passed

python -m py_compile dream-server/bin/dream-host-agent.py dream-server/extensions/services/dashboard-api/routers/models.py dream-server/extensions/services/dashboard-api/performance_oracle.py dream-server/extensions/services/dashboard-api/main.py dream-server/extensions/services/dashboard-api/settings.py
Result: Passed

git diff --check
Result: Passed

bash -n dream-server/installers/lib/packaging.sh
Result: Passed

python YAML parse check for .github/workflows/matrix-smoke.yml
Result: Passed; zypper CI network config is present in the pre-checkout step

Mocked _pkg_configure_zypper_ci_network validation
Result: Passed; writes the expected libzypp settings in CI and stays inactive outside CI

GitHub Actions after the previous push:
- Matrix Smoke / distro: opensuse-tw: passed
- Matrix Smoke full distro matrix: passed
- api/frontend: passed
- Ruff, shell lint, mypy, env validation, integration smoke: passed

Latest local-GGUF hardening push is running the same checks again.

python -m pytest extensions/services/dashboard-api/tests
Result: 1153 passed, 1 skipped, 2 failed locally in test_setup_sentinel.py on Windows because the diagnostic bash script returned 127 before reaching its expected sentinel. The failures are outside the changed model/Lemonade path and did not reproduce in the GitHub api/frontend checks on the previous push.
```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

The change is intentionally scoped to single-file local GGUF activation.

Catalog model activation still takes priority and keeps the existing behavior. Local fallback activation only accepts a real file directly inside `data/models/`, rejects path components, and rejects `.part` files so incomplete downloads or arbitrary filesystem paths cannot be activated.

For llama.cpp runtime flags, this PR keeps explicit runtime-profile settings intact. It only removes stale speculative/MTP flags when the selected model does not declare them, and treats empty `LLAMA_ARG_*` form values as absent instead of writing blank active env vars.

This PR does not add a full model import wizard, remote custom model downloads, split-file local GGUF import UX, or metadata editing for local models. It fixes the existing inconsistency where the Dashboard can show local GGUF models but cannot load them, plus the blank/stale env flag paths that made manual GGUF recovery brittle.


The openSUSE zypper network hardening is CI-scoped. In `packaging.sh`, it only runs when `GITHUB_ACTIONS` or `CI` is present and `PKG_MANAGER=zypper`; normal user installs do not write the libzypp drop-in. The workflow has a duplicate pre-checkout helper because repository scripts are not available until after checkout prerequisites are installed.




Local GGUF resolution now intentionally uses the real on-disk filename for `GGUF_FILE`, including case and spaces, but sanitizes the logical local model id/`LLM_MODEL` to avoid leaking spaces or unsafe characters into runtime config names.
