### PR TITLE
fix(dashboard-api): guard async HTTP client creation with asyncio.Lock

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -53,6 +53,7 @@ logger = logging.getLogger(__name__)
 # poll cycle and prevents file-descriptor exhaustion.
 
 _aio_session: Optional[aiohttp.ClientSession] = None
+_session_lock = asyncio.Lock()
 _HEALTH_TIMEOUT = aiohttp.ClientTimeout(total=30)
 # Short timeout for the catalog fan-out: one slow probe must not stall the
 # whole Extensions page (frontend aborts after 8 s).
@@ -62,12 +63,15 @@ _CATALOG_HEALTH_TIMEOUT = aiohttp.ClientTimeout(total=5)
 async def _get_aio_session() -> aiohttp.ClientSession:
     """Return (and lazily create) a module-level aiohttp session."""
     global _aio_session
-    if _aio_session is None or _aio_session.closed:
-        _aio_session = aiohttp.ClientSession(
-            timeout=_HEALTH_TIMEOUT,
-            connector=aiohttp.TCPConnector(family=socket.AF_INET),
-        )
-    return _aio_session
+    if _aio_session is not None and not _aio_session.closed:
+        return _aio_session
+    async with _session_lock:
+        if _aio_session is None or _aio_session.closed:
+            _aio_session = aiohttp.ClientSession(
+                timeout=_HEALTH_TIMEOUT,
+                connector=aiohttp.TCPConnector(family=socket.AF_INET),
+            )
+        return _aio_session
 
 
 # Shared httpx client for llama-server requests (connection pooling)
@@ -77,9 +81,12 @@ _httpx_client: Optional[httpx.AsyncClient] = None
 async def _get_httpx_client() -> httpx.AsyncClient:
     """Return (and lazily create) a module-level httpx async client."""
     global _httpx_client
-    if _httpx_client is None or _httpx_client.is_closed:
-        _httpx_client = httpx.AsyncClient(timeout=5.0)
-    return _httpx_client
+    if _httpx_client is not None and not _httpx_client.is_closed:
+        return _httpx_client
+    async with _session_lock:
+        if _httpx_client is None or _httpx_client.is_closed:
+            _httpx_client = httpx.AsyncClient(timeout=5.0)
+        return _httpx_client
 
 
 def _service_status_from_config(service_id: str, config: dict, status: str) -> ServiceStatus:

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -15,7 +15,7 @@ from helpers import (
     check_service_health, get_all_services,
     get_llama_metrics, get_loaded_model, get_llama_context_size,
     get_disk_usage, dir_size_gb, invalidate_dir_size_cache, clear_dir_size_cache,
-    _get_aio_session, set_services_cache, get_cached_services,
+    _get_aio_session, _get_httpx_client, set_services_cache, get_cached_services,
     _get_lifetime_tokens,
 )
 from models import BootstrapStatus, ServiceStatus, DiskUsage
@@ -693,6 +693,49 @@ class TestGetAioSession:
         s2 = await _get_aio_session()
         assert s1 is s2
         await s1.close()
+
+
+class TestSessionRaceSafety:
+    """Verify that concurrent _get_aio_session / _get_httpx_client calls
+    don't create duplicate sessions (i.e. the asyncio.Lock guard works)."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_aio_session_returns_same_instance(self, monkeypatch):
+        """Multiple concurrent calls should all get the same session."""
+        import helpers
+        monkeypatch.setattr(helpers, "_aio_session", None)
+        sessions = await asyncio.gather(
+            _get_aio_session(),
+            _get_aio_session(),
+            _get_aio_session(),
+        )
+        assert all(s is sessions[0] for s in sessions)
+        await sessions[0].close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_httpx_client_returns_same_instance(self, monkeypatch):
+        """Multiple concurrent calls should all get the same httpx client."""
+        import helpers
+        monkeypatch.setattr(helpers, "_httpx_client", None)
+        clients = await asyncio.gather(
+            _get_httpx_client(),
+            _get_httpx_client(),
+            _get_httpx_client(),
+        )
+        assert all(c is clients[0] for c in clients)
+        await clients[0].aclose()
+
+    @pytest.mark.asyncio
+    async def test_aio_session_recreated_after_close(self, monkeypatch):
+        """After closing the session, next call should create a new one."""
+        import helpers
+        monkeypatch.setattr(helpers, "_aio_session", None)
+        s1 = await _get_aio_session()
+        await s1.close()
+        s2 = await _get_aio_session()
+        assert s2 is not s1
+        assert not s2.closed
+        await s2.close()
 
 
 # --- set_services_cache / get_cached_services ---


### PR DESCRIPTION
## Summary

- **Bug**: `_get_aio_session()` and `_get_httpx_client()` in `helpers.py` have a race condition where multiple concurrent coroutines can simultaneously observe the session as `None`/closed and each create a new client, leaking the earlier one (orphaned TCP connections, potential file-descriptor exhaustion).
- **How it manifests**: At dashboard startup, `get_all_services()` fans out ~24 concurrent health checks via `asyncio.gather()`. On first call, all 24 coroutines hit the lazy initializer before any session exists. Without synchronization, several can race past the `is None` check and each instantiate a new `aiohttp.ClientSession` / `httpx.AsyncClient`, with only the last one surviving in the module global.
- **Fix**: Add a module-level `asyncio.Lock` and apply double-checked locking to both functions. The fast path (session already exists and is open) returns immediately without acquiring the lock. The slow path (session needs creation) acquires the lock and re-checks before creating, ensuring exactly one session is ever active.

## Changes

`dream-server/extensions/services/dashboard-api/helpers.py`:
- Add `_session_lock = asyncio.Lock()` at module level
- Rewrite `_get_aio_session()` with double-checked locking pattern
- Rewrite `_get_httpx_client()` with double-checked locking pattern

## Test plan

- [x] Python syntax verified via `ast.parse()`
- [ ] Existing `pytest tests/` suite passes (CI will verify)
- [ ] Manual: confirm dashboard health polling works correctly on startup with concurrent service checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1588