### PR TITLE
fix(dashboard-api): check is_symlink() before is_file() in dir_size_gb

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -549,7 +549,7 @@ def dir_size_gb(path: Path) -> float:
     try:
         for f in path.rglob("*"):
             try:
-                if f.is_file() and not f.is_symlink():
+                if not f.is_symlink() and f.is_file():
                     total += f.stat().st_size
             except (PermissionError, OSError):
                 pass

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1056,3 +1056,32 @@ class TestDirSizeGb:
         invalidate_dir_size_cache(d)
         assert dir_size_gb(d) == 0.0
         assert calls["count"] == 1
+
+    def test_dangling_symlinks_are_skipped(self, tmp_path):
+        """A symlink whose target doesn't exist must not crash or contribute size."""
+        clear_dir_size_cache()
+        d = tmp_path / "dangling"
+        d.mkdir()
+        real = d / "real.bin"
+        real.write_bytes(b"\x00" * 1024)
+        dangling = d / "dangling.bin"
+        dangling.symlink_to(d / "nonexistent-target")
+        assert not dangling.exists()  # confirm it's dangling
+        assert dangling.is_symlink()  # but it is a symlink
+        result = dir_size_gb(d)
+        assert result == 0.0  # only real.bin counted (1024 bytes ≈ 0.0 GB)
+
+    def test_symlink_to_external_file_not_counted(self, tmp_path):
+        """A symlink pointing outside the scanned directory must not add size."""
+        clear_dir_size_cache()
+        external = tmp_path / "external"
+        external.mkdir()
+        ext_file = external / "big.bin"
+        ext_file.write_bytes(b"\x00" * (1024 * 1024 * 200))  # 200 MiB
+
+        d = tmp_path / "scanned"
+        d.mkdir()
+        link = d / "external_link.bin"
+        link.symlink_to(ext_file)
+        result = dir_size_gb(d)
+        assert result == 0.0  # symlink skipped, external file not counted


### PR DESCRIPTION
## Summary

In `helpers.py`'s `dir_size_gb()` function, the symlink check condition was:

```python
if f.is_file() and not f.is_symlink():
```

`Path.is_file()` follows symlinks — it stats the symlink target to determine if it's a file. This means even when we intend to skip symlinks, we still follow (and stat) the target before `not f.is_symlink()` short-circuits the condition.

This is a defense-in-depth concern: if a symlink points outside the DATA_DIR tree, the `is_file()` call leaks information about whether the target exists and is a file. The fix swaps the condition order:

```python
if not f.is_symlink() and f.is_file():
```

`is_symlink()` uses `lstat` (does not follow the link), so checking it first avoids resolving any symlinks at all. Python's short-circuit evaluation means `is_file()` is only called on non-symlink entries.

## What changed

- `dream-server/extensions/services/dashboard-api/helpers.py` line 552: swapped condition order so `is_symlink()` is checked before `is_file()`

## Behavior impact

- **Functionally identical** for all normal cases (regular files, directories, dangling symlinks)
- Avoids unnecessary symlink target resolution as a defense-in-depth measure
- No new dependencies, no API changes

## Test plan

- [x] Python syntax verification (`ast.parse`) passes
- [ ] Existing `pytest tests/` suite passes (no behavior change expected)

Closes #1590