### PR TITLE
refactor(dashboard-api): add TTLCache.invalidate() and .clear() public API

### DIFF
--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -562,12 +562,12 @@ def dir_size_gb(path: Path) -> float:
 
 def invalidate_dir_size_cache(path: Path):
     """Remove cached size for a specific path after it has been modified."""
-    _dir_size_cache._store.pop(str(path.resolve()), None)
+    _dir_size_cache.invalidate(str(path.resolve()))
 
 
 def clear_dir_size_cache():
     """Clear the entire dir_size_gb cache (e.g. after bulk operations)."""
-    _dir_size_cache._store.clear()
+    _dir_size_cache.clear()
 
 
 def get_disk_usage() -> DiskUsage:

--- a/dream-server/extensions/services/dashboard-api/helpers.py
+++ b/dream-server/extensions/services/dashboard-api/helpers.py
@@ -40,6 +40,14 @@ class _DirSizeCache:
     def set(self, path: Path, value: float):
         self._store[str(path.resolve())] = (time.monotonic() + self._ttl, value)
 
+    def invalidate(self, key: str) -> None:
+        """Remove a single cached entry (no-op if missing or expired)."""
+        self._store.pop(key, None)
+
+    def clear(self) -> None:
+        """Drop every cached entry."""
+        self._store.clear()
+
 
 _dir_size_cache = _DirSizeCache()
 

--- a/dream-server/extensions/services/dashboard-api/main.py
+++ b/dream-server/extensions/services/dashboard-api/main.py
@@ -99,6 +99,14 @@ class TTLCache:
     def set(self, key: str, value: object, ttl: float):
         self._store[key] = (time.monotonic() + ttl, value)
 
+    def invalidate(self, key: str) -> None:
+        """Remove a single cached entry (no-op if missing or expired)."""
+        self._store.pop(key, None)
+
+    def clear(self) -> None:
+        """Drop every cached entry."""
+        self._store.clear()
+
 
 _cache = TTLCache()
 
@@ -802,7 +810,7 @@ def _render_env_from_values(values: dict[str, str]) -> str:
 
 def _clear_settings_caches():
     for key in ("settings_summary", "settings_env", "status"):
-        _cache._store.pop(key, None)
+        _cache.invalidate(key)
 
 
 def _call_agent_core_recreate(service_ids: list[str]) -> dict[str, Any]:

--- a/dream-server/extensions/services/dashboard-api/routers/resources.py
+++ b/dream-server/extensions/services/dashboard-api/routers/resources.py
@@ -218,5 +218,5 @@ async def restart_service(service_id: str, api_key: str = Depends(verify_api_key
     )
 
     from main import _cache  # noqa: PLC0415 — deferred import to avoid circular dependency
-    _cache._store.pop("service_resources_containers", None)
+    _cache.invalidate("service_resources_containers")
     return result

--- a/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1056,3 +1056,33 @@ class TestDirSizeGb:
         invalidate_dir_size_cache(d)
         assert dir_size_gb(d) == 0.0
         assert calls["count"] == 1
+
+    def test_clear_dir_size_cache_forces_refresh_all(self, tmp_path, monkeypatch):
+        """clear_dir_size_cache() should drop every cached path."""
+        clear_dir_size_cache()
+        d1 = tmp_path / "one"
+        d1.mkdir()
+        (d1 / "a.bin").write_bytes(b"\x00" * 1024)
+        d2 = tmp_path / "two"
+        d2.mkdir()
+        (d2 / "b.bin").write_bytes(b"\x00" * 1024)
+
+        assert dir_size_gb(d1) == 0.0
+        assert dir_size_gb(d2) == 0.0
+
+        original_rglob = Path.rglob
+        calls = {"count": 0}
+
+        def _tracking_rglob(self, pattern):
+            calls["count"] += 1
+            return original_rglob(self, pattern)
+
+        monkeypatch.setattr(Path, "rglob", _tracking_rglob)
+        assert dir_size_gb(d1) == 0.0
+        assert dir_size_gb(d2) == 0.0
+        assert calls["count"] == 0
+
+        clear_dir_size_cache()
+        assert dir_size_gb(d1) == 0.0
+        assert dir_size_gb(d2) == 0.0
+        assert calls["count"] == 2

--- a/dream-server/extensions/services/dashboard-api/tests/test_main.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_main.py
@@ -675,7 +675,7 @@ class TestGpuEndpoint:
 
     def test_gpu_no_cache_no_gpu(self, test_client, monkeypatch):
         import main
-        main._cache._store.pop("gpu_info", None)
+        main._cache.invalidate("gpu_info")
         monkeypatch.setattr("main.get_gpu_info", lambda: None)
         resp = test_client.get("/gpu", headers=test_client.auth_headers)
         assert resp.status_code == 503

--- a/dream-server/extensions/services/dashboard-api/tests/test_main.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_main.py
@@ -531,6 +531,39 @@ class TestTTLCache:
         cache = TTLCache()
         assert cache.get("nope") is None
 
+    def test_invalidate_removes_key(self):
+        cache = TTLCache()
+        cache.set("a", 1, ttl=10)
+        cache.set("b", 2, ttl=10)
+        cache.invalidate("a")
+        assert cache.get("a") is None
+        assert cache.get("b") == 2
+
+    def test_invalidate_nonexistent_key_is_noop(self):
+        cache = TTLCache()
+        cache.invalidate("missing")  # should not raise
+
+    def test_clear_removes_all_keys(self):
+        cache = TTLCache()
+        cache.set("x", 10, ttl=10)
+        cache.set("y", 20, ttl=10)
+        cache.set("z", 30, ttl=10)
+        cache.clear()
+        assert cache.get("x") is None
+        assert cache.get("y") is None
+        assert cache.get("z") is None
+
+    def test_clear_on_empty_cache_is_noop(self):
+        cache = TTLCache()
+        cache.clear()  # should not raise
+
+    def test_set_after_invalidate(self):
+        cache = TTLCache()
+        cache.set("k", "old", ttl=10)
+        cache.invalidate("k")
+        cache.set("k", "new", ttl=10)
+        assert cache.get("k") == "new"
+
 
 # --- /api/preflight/docker edge cases ---
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_resources.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_resources.py
@@ -122,8 +122,8 @@ class TestServiceResources:
     def _clear_resource_cache():
         """Remove cached resource entries so each test gets fresh data."""
         from main import _cache
-        _cache._store.pop("service_resources_containers", None)
-        _cache._store.pop("service_resources_disk", None)
+        _cache.invalidate("service_resources_containers")
+        _cache.invalidate("service_resources_disk")
 
     def test_requires_auth(self, test_client):
         """GET /api/services/resources without auth header returns 401."""

--- a/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -87,7 +87,7 @@ def settings_env_fixture(tmp_path, monkeypatch):
 
     from main import _cache
 
-    _cache._store.clear()
+    _cache.clear()
 
     return {
         "install_root": install_root,


### PR DESCRIPTION
## Summary

- **Add `invalidate(key)` and `clear()` methods** to the `TTLCache` class in `main.py`, giving callers a proper public API for cache invalidation.
- **Replace all 8 callsites** that reached into `_cache._store.pop()` / `_cache._store.clear()` directly, across `main.py`, `helpers.py`, `routers/resources.py`, and 3 test files.

## Problem

The `TTLCache` class only exposed `get()` and `set()`. To invalidate entries, callers had to reach into the private `_store` dict:

```python
_cache._store.pop(key, None)     # 6 callsites
_cache._store.clear()            # 2 callsites
```

This breaks encapsulation -- every caller is coupled to the dict-based implementation, making it impossible to swap the storage backend (e.g., to an LRU dict or Redis) without updating 8 callsites across 6 files.

## Fix

Two new methods on `TTLCache`:

```python
def invalidate(self, key: str) -> None:
    """Remove a single cached entry (no-op if missing or expired)."""
    self._store.pop(key, None)

def clear(self) -> None:
    """Drop every cached entry."""
    self._store.clear()
```

All `_store.pop` / `_store.clear` usages replaced with `invalidate()` / `clear()` calls.

## Files changed

| File | Change |
|------|--------|
| `main.py` | Add methods + replace 1 callsite |
| `helpers.py` | Replace 2 callsites |
| `routers/resources.py` | Replace 1 callsite |
| `tests/test_main.py` | Replace 1 callsite |
| `tests/test_resources.py` | Replace 2 callsites |
| `tests/test_settings_env.py` | Replace 1 callsite |

## Test plan

- [x] All 6 modified files pass `ast.parse()` syntax check
- [x] No remaining `_store.pop` or `_store.clear` outside the TTLCache class itself
- [ ] CI passes (existing tests exercise all changed callsites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #1591