### PR TITLE
fix(windows): seed local LiteLLM and writable runtime paths

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -810,8 +810,7 @@ def _check_agent_health() -> bool:
 @contextlib.contextmanager
 def _extensions_lock():
     """Acquire an exclusive file lock for extension mutations."""
-    lock_path = Path(DATA_DIR) / ".extensions-lock"
-    lock_path.touch(exist_ok=True)
+    lock_path = _extensions_lock_path()
     lockfile = open(lock_path, "a+b")
     try:
         if fcntl is not None:
@@ -833,6 +832,29 @@ def _extensions_lock():
                 msvcrt.locking(lockfile.fileno(), msvcrt.LK_UNLCK, 1)
         finally:
             lockfile.close()
+
+
+def _extensions_lock_candidates() -> list[Path]:
+    data_path = Path(DATA_DIR)
+    return [
+        data_path / ".extensions-lock",
+        data_path / "config" / ".extensions-lock",
+    ]
+
+
+def _extensions_lock_path() -> Path:
+    last_error: OSError | None = None
+    for lock_path in _extensions_lock_candidates():
+        try:
+            lock_path.parent.mkdir(parents=True, exist_ok=True)
+            lock_path.touch(exist_ok=True)
+            if lock_path != Path(DATA_DIR) / ".extensions-lock":
+                logger.warning("extensions lock falling back to %s", lock_path)
+            return lock_path
+        except OSError as exc:
+            last_error = exc
+    assert last_error is not None
+    raise last_error
 
 
 @router.get("/api/extensions/catalog")

--- a/dream-server/extensions/services/dashboard-api/routers/magic_link.py
+++ b/dream-server/extensions/services/dashboard-api/routers/magic_link.py
@@ -202,27 +202,55 @@ class TokenSummary(BaseModel):
 # --- Token storage helpers (file-backed, locked) ---
 
 
+def _magic_link_store_candidates() -> list[Path]:
+    return [
+        DATA_DIR / "auth" / "magic-links.json",
+        DATA_DIR / "config" / "auth" / "magic-links.json",
+    ]
+
+
+def _writable_store_path() -> Path:
+    """Return the normal token store, or a writable config-backed fallback."""
+    last_error: OSError | None = None
+    for path in _magic_link_store_candidates():
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            probe = path.parent / ".write-test"
+            probe.write_text("", encoding="utf-8")
+            try:
+                probe.unlink()
+            except OSError:
+                pass
+            if path != TOKEN_STORE_PATH:
+                logger.warning("magic-link store falling back to %s", path)
+            return path
+        except OSError as exc:
+            last_error = exc
+    assert last_error is not None
+    raise last_error
+
+
 def _ensure_store() -> dict:
     """Load the token store, creating an empty one if missing."""
-    AUTH_DIR.mkdir(parents=True, exist_ok=True)
-    if not TOKEN_STORE_PATH.exists():
+    store_path = _writable_store_path()
+    if not store_path.exists():
         return {"tokens": []}
     try:
-        return json.loads(TOKEN_STORE_PATH.read_text(encoding="utf-8"))
+        return json.loads(store_path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError):
         # Corrupted store — start fresh rather than blocking generation.
-        logger.exception("magic-link store unreadable at %s; starting fresh", TOKEN_STORE_PATH)
+        logger.exception("magic-link store unreadable at %s; starting fresh", store_path)
         return {"tokens": []}
 
 
 def _write_store(store: dict) -> None:
     """Persist the store atomically (write-tmp + rename)."""
-    AUTH_DIR.mkdir(parents=True, exist_ok=True)
-    tmp = TOKEN_STORE_PATH.with_suffix(".json.tmp")
+    store_path = _writable_store_path()
+    tmp = store_path.with_suffix(".json.tmp")
     tmp.write_text(json.dumps(store, indent=2), encoding="utf-8")
-    tmp.replace(TOKEN_STORE_PATH)
+    tmp.replace(store_path)
     try:
-        TOKEN_STORE_PATH.chmod(0o600)
+        store_path.chmod(0o600)
     except OSError:
         # Best-effort; some filesystems (Docker volumes) don't honor chmod.
         pass

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -3448,3 +3448,22 @@ class TestCallAgentErrorNarrowing:
         assert any(
             "stale-progress cleanup failed" in r.message for r in caplog.records
         )
+
+
+def test_extensions_lock_falls_back_when_data_root_is_unwritable(
+    tmp_path, monkeypatch,
+):
+    """Extension installs should still lock when /data itself is not writable."""
+    from routers import extensions as ext_module
+
+    blocked_parent = tmp_path / "blocked-parent"
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    fallback_lock = tmp_path / "config" / ".extensions-lock"
+    monkeypatch.setattr(
+        ext_module,
+        "_extensions_lock_candidates",
+        lambda: [blocked_parent / ".extensions-lock", fallback_lock],
+    )
+
+    with ext_module._extensions_lock():
+        assert fallback_lock.exists()

--- a/dream-server/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -928,3 +928,22 @@ def test_qr_endpoint_returns_data_url_when_qrcode_installed(magic_link_client):
     else:
         assert resp.status_code == 503
         assert "qrcode" in resp.json()["detail"].lower()
+
+
+def test_store_falls_back_when_primary_parent_is_unwritable(
+    magic_link_module, tmp_path, monkeypatch,
+):
+    """Docker Desktop can expose /data as non-writable while /data/config works."""
+    blocked_parent = tmp_path / "auth-blocked"
+    blocked_parent.write_text("not a directory", encoding="utf-8")
+    fallback_store = tmp_path / "config" / "auth" / "magic-links.json"
+    monkeypatch.setattr(
+        magic_link_module,
+        "_magic_link_store_candidates",
+        lambda: [blocked_parent / "magic-links.json", fallback_store],
+    )
+
+    magic_link_module._write_store({"tokens": []})
+
+    assert fallback_store.exists()
+    assert magic_link_module._ensure_store() == {"tokens": []}

--- a/dream-server/installers/windows/lib/env-generator.ps1
+++ b/dream-server/installers/windows/lib/env-generator.ps1
@@ -22,6 +22,14 @@ function Write-Utf8NoBom {
         [string]$Path,
         [string]$Content
     )
+    $parent = Split-Path -Parent $Path
+    if (-not [string]::IsNullOrWhiteSpace($parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    if (Test-Path -LiteralPath $Path -PathType Container) {
+        Remove-Item -LiteralPath $Path -Recurse -Force
+        Write-AIWarn "Removed malformed $Path directory from a previous partial install."
+    }
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
 }
@@ -516,6 +524,39 @@ LANGFUSE_INIT_USER_PASSWORD=$langfuseInitUserPassword
         Write-AIWarn "Removed malformed .env directory from a previous partial install."
     }
     Write-Utf8NoBom -Path $envPath -Content $envContent
+
+    if ($effectiveDreamMode -eq "local") {
+        $litellmDir = Join-Path (Join-Path $InstallDir "config") "litellm"
+        $localModel = $(if ($TierConfig.GgufFile) { $TierConfig.GgufFile } else { $TierConfig.LlmModel })
+        $localApiBase = "$llmApiUrl$llmApiBasePath"
+        $localConfig = @"
+model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/$localModel
+      api_base: $localApiBase
+      api_key: sk-dream-hermes-local
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+  - model_name: "*"
+    litellm_params:
+      model: openai/$localModel
+      api_base: $localApiBase
+      api_key: sk-dream-hermes-local
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 900
+  stream_timeout: 900
+"@
+        Write-Utf8NoBom -Path (Join-Path $litellmDir "local.yaml") -Content $localConfig
+    }
 
     if ($windowsAmdLemonade) {
         $litellmDir = Join-Path (Join-Path $InstallDir "config") "litellm"

--- a/dream-server/installers/windows/phases/06-directories.ps1
+++ b/dream-server/installers/windows/phases/06-directories.ps1
@@ -55,12 +55,17 @@ $_dirs = @(
     (Join-Path $_configDir "litellm"),
     (Join-Path $_configDir "openclaw"),
     (Join-Path $_configDir "llama-server"),
+    (Join-Path $_dataDir "auth"),
+    (Join-Path $_dataDir "config"),
+    (Join-Path $_dataDir "config-backups"),
+    (Join-Path $_dataDir "extension-progress"),
     (Join-Path $_dataDir "open-webui"),
     (Join-Path $_dataDir "whisper"),
     (Join-Path $_dataDir "tts"),
     (Join-Path $_dataDir "n8n"),
     (Join-Path $_dataDir "qdrant"),
     (Join-Path $_dataDir "models"),
+    (Join-Path $_dataDir "user-extensions"),
     (Join-Path $_dataDir "extensions-library"),
     (Join-Path $_dataDir "comfyui"),
     (Join-Path $_dataDir "perplexica"),
@@ -85,6 +90,9 @@ $_expectedRegularFiles = @(
     ".env",
     ".env.example",
     ".env.schema.json",
+    "config\litellm\local.yaml",
+    "config\litellm\lemonade.yaml",
+    "data\.extensions-lock",
     "extensions\services\hermes\cli-config.yaml.template",
     "extensions\services\hermes\SOUL.md.template",
     "extensions\services\hermes-proxy\Caddyfile",
@@ -100,6 +108,26 @@ foreach ($_expectedFileName in $_expectedRegularFiles) {
         Write-AIWarn "Removed malformed $_expectedFileName directory from a previous partial install."
     }
 }
+
+$_containerWritableDirs = @(
+    $_dataDir,
+    (Join-Path $_dataDir "auth"),
+    (Join-Path $_dataDir "config"),
+    (Join-Path $_dataDir "config-backups"),
+    (Join-Path $_dataDir "extension-progress"),
+    (Join-Path $_dataDir "n8n"),
+    (Join-Path $_dataDir "user-extensions")
+)
+foreach ($_writableDir in $_containerWritableDirs) {
+    if (Test-Path -LiteralPath $_writableDir -PathType Container) {
+        & icacls $_writableDir /grant "*S-1-1-0:(OI)(CI)M" /T /C /Q | Out-Null
+    }
+}
+$_extensionsLock = Join-Path $_dataDir ".extensions-lock"
+if (-not (Test-Path -LiteralPath $_extensionsLock -PathType Leaf)) {
+    New-Item -ItemType File -Path $_extensionsLock -Force | Out-Null
+}
+& icacls $_extensionsLock /grant "*S-1-1-0:M" /C /Q | Out-Null
 
 # ── Copy source tree (skip if running in-place) ───────────────────────────────
 if ($sourceRoot -ne $installDir) {

--- a/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/dream-server/tests/contracts/test-amd-lemonade-contracts.sh
@@ -449,7 +449,52 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# 17b. Linux AMD/Lemonade avoids host port 9000 collision with Whisper
+# 17b. Windows local mode always generates LiteLLM's local.yaml
+# ---------------------------------------------------------------------------
+echo "[contract] Windows local mode generates LiteLLM config"
+if command -v pwsh >/dev/null 2>&1; then
+    _ps_tmp="${TMPDIR:-/tmp}"
+    if ROOT_DIR="$ROOT_DIR" TEMP="$_ps_tmp" USERPROFILE="$_ps_tmp" pwsh -NoProfile -Command '
+        $ErrorActionPreference = "Stop"
+        function Write-AIWarn { param([string]$Message) Write-Host "WARN: $Message" }
+        . (Join-Path $env:ROOT_DIR "installers/windows/lib/env-generator.ps1")
+        $installDir = Join-Path $env:TEMP "dream-env-generator-windows-local-contract"
+        Remove-Item -LiteralPath $installDir -Recurse -Force -ErrorAction SilentlyContinue
+        New-Item -ItemType Directory -Path $installDir -Force | Out-Null
+        $litellmDir = Join-Path (Join-Path $installDir "config") "litellm"
+        New-Item -ItemType Directory -Path (Join-Path $litellmDir "local.yaml") -Force | Out-Null
+        $tier = @{
+            TierName = "Windows NVIDIA"
+            LlmModel = "test-model"
+            GgufFile = "test-local.gguf"
+            MaxContext = 4096
+        }
+        New-DreamEnv -InstallDir $installDir -TierConfig $tier -Tier "3" -GpuBackend "nvidia" -DreamMode "local" | Out-Null
+        $localConfig = Join-Path $litellmDir "local.yaml"
+        if (-not (Test-Path -LiteralPath $localConfig -PathType Leaf)) {
+            throw "Expected Windows local installs to generate config/litellm/local.yaml as a file"
+        }
+        $localText = Get-Content -LiteralPath $localConfig -Raw
+        if ($localText -notmatch "model: openai/test-local\.gguf") {
+            throw "Expected local LiteLLM config to route the selected GGUF model"
+        }
+        if ($localText -notmatch "api_base: http://llama-server:8080/v1") {
+            throw "Expected Windows NVIDIA local LiteLLM config to route through llama-server:8080/v1"
+        }
+        if ($localText -notmatch "(?m)^  request_timeout: 900$" -or $localText -notmatch "(?m)^  stream_timeout: 900$") {
+            throw "Windows local LiteLLM config must keep long-model proxy timeouts at 900s"
+        }
+    '; then
+        pass "env-generator.ps1: Windows local writes local.yaml and repairs malformed bind-mount directories"
+    else
+        fail "env-generator.ps1: Windows local LiteLLM config contract failed"
+    fi
+else
+    pass "env-generator.ps1: Windows local LiteLLM runtime test skipped (pwsh unavailable)"
+fi
+
+# ---------------------------------------------------------------------------
+# 17c. Linux AMD/Lemonade avoids host port 9000 collision with Whisper
 # ---------------------------------------------------------------------------
 echo "[contract] Linux AMD/Lemonade avoids Whisper port 9000"
 if grep -q 'AMD/Lemonade detected; reserving host port 9000' installers/phases/04-requirements.sh \


### PR DESCRIPTION
## Summary

Carries forward the Windows runtime hardening commit that was part of the green fleet stack.

- seeds local LiteLLM config for local Windows installs
- creates expected writable runtime directories during Windows install
- adds fallback writable paths for extension locks and magic-link storage when Docker Desktop exposes the primary data path as unwritable
- adds regression coverage for the fallback paths

## Validation

- Included in green fleet stack `test/fleet-contrib-stack-20260621T150103Z` at commit `4821d066`
- Fleet run `/home/michael/dream-fleet-test/runs/2026-06-21T22-31-36Z` passed all six release gates
- Enabled hosts green: tower2, strix-halo, spark, m5-mbp, windows-laptop, strixy
- Diff checked against current `main` (`ee749a42`)