### PR TITLE
fix(macos): harden resumable model downloads

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -61,6 +61,9 @@ test: ## Run unit and contract tests
 	@echo "=== macOS dream-host-agent bootstrap verification ==="
 	@bash tests/test-macos-host-agent-verification.sh
 	@echo ""
+	@echo "=== macOS model download retry contract ==="
+	@bash tests/test-macos-download-retries.sh
+	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
 

--- a/dream-server/installers/macos/lib/ui.sh
+++ b/dream-server/installers/macos/lib/ui.sh
@@ -73,7 +73,11 @@ download_with_progress() {
     local url="$1"
     local destination="$2"
     local label="${3:-Downloading}"
-    local max_retries="${4:-3}"
+    local max_retries="${4:-${DREAM_MODEL_DOWNLOAD_RETRIES:-8}}"
+
+    case "$max_retries" in
+        ''|*[!0-9]*|0) max_retries=8 ;;
+    esac
 
     local part_file="${destination}.part"
     local connect_timeout="${DREAM_DOWNLOAD_CONNECT_TIMEOUT:-30}"
@@ -83,7 +87,8 @@ download_with_progress() {
 
     while [[ $attempt -le $max_retries ]]; do
         if [[ $attempt -gt 1 ]]; then
-            local wait_time=$((2 ** (attempt - 1)))  # Exponential backoff: 2, 4, 8 seconds
+            local wait_time=$((2 ** (attempt - 1)))
+            [[ "$wait_time" -gt 60 ]] && wait_time=60
             ai "Retry attempt $attempt of $max_retries (waiting ${wait_time}s)..."
             sleep $wait_time
         else

--- a/dream-server/tests/test-macos-download-retries.sh
+++ b/dream-server/tests/test-macos-download-retries.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+export DS_LOG_FILE="$TMP_DIR/install.log"
+export INSTALL_START_EPOCH=0
+export GRN="" BGRN="" AMB="" RED="" NC="" DGRN="" WHT=""
+
+mkdir -p "$TMP_DIR/bin"
+cat > "$TMP_DIR/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+count_file="${DREAM_TEST_CURL_COUNT_FILE:?}"
+count=0
+[[ -f "$count_file" ]] && count="$(cat "$count_file")"
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+exit "${DREAM_TEST_CURL_EXIT:-56}"
+EOF
+cat > "$TMP_DIR/bin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$TMP_DIR/bin/curl" "$TMP_DIR/bin/sleep"
+export PATH="$TMP_DIR/bin:$PATH"
+
+# shellcheck source=/dev/null
+source "$ROOT_DIR/installers/macos/lib/ui.sh"
+
+run_failure_case() {
+    local label="$1"
+    local expected="$2"
+    local retries="${3:-__unset__}"
+
+    local count_file="$TMP_DIR/${label}.count"
+    local target="$TMP_DIR/${label}.gguf"
+    : > "$DS_LOG_FILE"
+    rm -f "$count_file" "$target" "$target.part"
+
+    export DREAM_TEST_CURL_COUNT_FILE="$count_file"
+    if [[ "$retries" == "__unset__" ]]; then
+        unset DREAM_MODEL_DOWNLOAD_RETRIES
+    else
+        export DREAM_MODEL_DOWNLOAD_RETRIES="$retries"
+    fi
+
+    download_with_progress "https://example.invalid/model.gguf" "$target" "Downloading model" && {
+            echo "expected download_with_progress to fail for $label" >&2
+            return 1
+        }
+    unset DREAM_TEST_CURL_COUNT_FILE DREAM_MODEL_DOWNLOAD_RETRIES
+
+    local actual
+    actual="$(cat "$count_file")"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "$label: expected $expected curl attempts, got $actual" >&2
+        return 1
+    fi
+}
+
+run_failure_case default 8
+run_failure_case env_override 2 2
+run_failure_case invalid_env 8 bogus
+
+echo "macOS download retry contract passed"


### PR DESCRIPTION
## Summary

Carries forward the macOS download retry hardening commit that was part of the green fleet stack.

- increases the default macOS model download retry budget
- allows `DREAM_MODEL_DOWNLOAD_RETRIES` to tune retries safely
- caps retry backoff at 60 seconds
- adds a shell contract covering default, override, and invalid retry values

## Validation

- Included in green fleet stack `test/fleet-contrib-stack-20260621T150103Z`
- Fleet run `/home/michael/dream-fleet-test/runs/2026-06-21T22-31-36Z` passed all six release gates
- Enabled hosts green: tower2, strix-halo, spark, m5-mbp, windows-laptop, strixy
- Diff checked against current `main` (`ee749a42`)