### PR TITLE
test(incus): use available dnf VM lane

### DIFF
--- a/dream-server/tests/fleet-incus-vm.sh
+++ b/dream-server/tests/fleet-incus-vm.sh
@@ -22,7 +22,7 @@ declare -a TARGETS=()
 
 declare -A IMAGES=(
     [ubuntu2404]="images:ubuntu/24.04"
-    [fedora42]="images:fedora/42"
+    [fedora42]="images:almalinux/10"
     [rocky9]="images:rockylinux/9"
     [arch]="images:archlinux/current"
     [opensuse]="images:opensuse/tumbleweed"
@@ -38,7 +38,7 @@ declare -A EXPECTED_PKG=(
 
 declare -A LABELS=(
     [ubuntu2404]="Ubuntu 24.04 LTS"
-    [fedora42]="Fedora 42"
+    [fedora42]="AlmaLinux 10 dnf VM"
     [rocky9]="Rocky Linux 9"
     [arch]="Arch Linux current"
     [opensuse]="openSUSE Tumbleweed"
@@ -99,6 +99,9 @@ Options:
 
 Default matrix:
   ubuntu2404 fedora42 rocky9 arch opensuse
+  (fedora42 currently uses an AlmaLinux dnf VM because the Incus public
+   image remote no longer advertises Fedora VM aliases; Fedora remains
+   covered by tests/fleet-multi-distro.sh container breadth.)
 
 Aliases:
   ubuntu/24.04, fedora/42, rockylinux/9, archlinux/current,


### PR DESCRIPTION
## Summary

Carries forward the Incus VM matrix adjustment that was part of the green fleet stack.

- uses an available AlmaLinux dnf VM image for the `fedora42` dnf package-manager lane
- documents that Fedora remains covered in the Docker distro breadth matrix
- keeps the VM matrix runnable when the Incus public image remote does not advertise Fedora VM aliases

## Validation

- Included in green fleet stack `test/fleet-contrib-stack-20260621T150103Z` at commit `90a4306f`
- Fleet run `/home/michael/dream-fleet-test/runs/2026-06-21T22-31-36Z` passed all six release gates
- Distro/Incus phase completed with no harness limitations in the final report
- Diff checked against current `main` (`ee749a42`)