### PR TITLE
fix(dashboard-api): handle impossible calendar dates in usage report

### DIFF
--- a/dream-server/extensions/services/dashboard-api/routers/usage.py
+++ b/dream-server/extensions/services/dashboard-api/routers/usage.py
@@ -49,8 +49,12 @@ def _date_range(start_day: date, end_day: date) -> list[str]:
 
 
 def _empty_report(start: str, end: str, status: str = "unavailable", detail: str | None = None) -> dict[str, Any]:
-    start_day = _parse_date(start)
-    end_day = _parse_date(end)
+    # The query regex (^\d{4}-\d{2}-\d{2}$) accepts calendar-invalid dates like
+    # 2026-02-30, so the daily breakdown is only built when both bounds parse.
+    try:
+        days = _date_range(_parse_date(start), _parse_date(end))
+    except ValueError:
+        days = []
     return {
         "period": {"start": start, "end": end},
         "source": {
@@ -83,7 +87,7 @@ def _empty_report(start: str, end: str, status: str = "unavailable", detail: str
                 "cache_read_tokens": 0,
                 "cache_write_tokens": 0,
             }
-            for day in _date_range(start_day, end_day)
+            for day in days
         ],
         "models": [],
         "services": [],

--- a/dream-server/extensions/services/dashboard-api/tests/test_usage.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_usage.py
@@ -271,6 +271,28 @@ def test_usage_report_rejects_reversed_date_range(test_client):
     assert data["source"]["detail"] == "end must be on or after start"
 
 
+def test_usage_report_rejects_invalid_calendar_dates(test_client):
+    # The query regex accepts well-formed but non-existent calendar dates
+    # (e.g. February 30th); they must degrade to a graceful invalid_range
+    # report instead of crashing with a 500.
+    for start, end in [
+        ("2026-02-30", "2026-03-01"),
+        ("2026-13-01", "2026-13-02"),
+        ("2025-02-29", "2025-03-01"),
+    ]:
+        resp = test_client.get(
+            f"/api/usage/report?start={start}&end={end}",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"]["status"] == "invalid_range"
+        assert data["source"]["detail"] == "Dates must use YYYY-MM-DD"
+        assert data["period"] == {"start": start, "end": end}
+        assert data["daily"] == []
+
+
 def test_usage_report_surfaces_local_runtime_counters_without_date_bucketing(test_client, monkeypatch):
     import routers.usage as usage_router
 


### PR DESCRIPTION
`/api/usage/report` only checks dates against `^\d{4}-\d{2}-\d{2}$`, so dates like
`2026-02-30` or `2026-13-01` pass the regex but blow up when parsed. The handler
tries to return an `invalid_range` response, but `_empty_report` parses the dates
again outside the try/except, so the request 500s instead.

Fix: only build the daily list when both dates parse, otherwise leave it empty.

Repro before the fix: `GET /api/usage/report?start=2026-02-30&end=2026-03-01` → 500.

Added a test for Feb 30, month 13, and Feb 29 on a non-leap year. Fails on main,
passes here.