### PR TITLE
fix(installer): cap Hermes context floor at 64K

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -19,6 +19,8 @@ lint: ## Syntax check all shell scripts + Python compile check
 test: ## Run unit and contract tests
 	@echo "=== Tier map tests ==="
 	@bash tests/test-tier-map.sh
+	@bash tests/test-installer-context-parity.sh
+	@bash tests/test-hermes-context-floor.sh
 	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh

--- a/dream-server/README.md
+++ b/dream-server/README.md
@@ -77,7 +77,11 @@ By default, Dream Server uses **bootstrap mode** for instant gratification:
 
 No more staring at download bars. Start playing immediately.
 
-Hermes-enabled installs keep this fast-start path: the bootstrap model runs at a 64K context floor so Hermes can start cleanly, then the background full-model swap promotes the local context target to 128K.
+Hermes-enabled installs keep this fast-start path: the bootstrap model runs at a
+64K context floor so the agent can start cleanly, then the background full-model
+swap keeps the tier selector's chosen context for the full model. On capable
+tiers that may still be 128K; constrained tiers stay at the smaller selected
+context instead of being forced higher.
 
 Model download, switching, and manual GGUF notes: [docs/MODEL-MANAGEMENT.md](docs/MODEL-MANAGEMENT.md)
 
@@ -142,7 +146,9 @@ See [`docs/WINDOWS-QUICKSTART.md`](docs/WINDOWS-QUICKSTART.md) for details.
 
 The installer **automatically detects your GPU**, assigns a hardware tier, then uses the versioned catalog selector to choose the best installable GGUF for the detected memory envelope. Linux and macOS call `scripts/select-model.py`; Windows uses the PowerShell selector in `installers/windows/lib/tier-map.ps1`. Both read `config/model-library.json`, and the final choice is written to `.env` as `LLM_MODEL`, `GGUF_FILE`, `MAX_CONTEXT`, and `MODEL_RECOMMENDATION_*`.
 
-`MODEL_PROFILE=qwen` is the default non-Gemma catalog profile, so the effective model can be Qwen, Phi, or DeepSeek depending on fit. `MODEL_PROFILE=gemma4` and `MODEL_PROFILE=auto` are also supported where the tier map has Gemma 4 GGUFs available. When Hermes is enabled, installers keep the bootstrap model at 64K context and promote the full local model context to 128K where supported.
+`MODEL_PROFILE=qwen` is the default non-Gemma catalog profile, so the effective model can be Qwen, Phi, or DeepSeek depending on fit. `MODEL_PROFILE=gemma4` and `MODEL_PROFILE=auto` are also supported where the tier map has Gemma 4 GGUFs available. When Hermes is enabled, installers enforce a 64K minimum context for the active local model, then preserve the model selector's full-model context.
+
+Large-context tiers still use 128K where the selected tier/model supports it.
 
 The examples below are current catalog-selector outputs for common hardware envelopes. Exact installs can differ with detected VRAM/RAM, host architecture, existing downloads, or explicit profile overrides. Throughput still needs a local benchmark after first launch.
 

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -93,7 +93,11 @@ The first start takes a minute — image is ~3GB, Hermes runs its `skills_sync.p
 ## Defaults Dream Server applies
 
 - **Provider:** `custom` (OpenAI-compatible) pointing at `llama-server:8080/v1`
-- **Context:** Hermes requires at least 64K tokens. Local installers run the bootstrap model at 64K so Hermes works immediately, then move the full model and Hermes config to 128K after the background model upgrade completes.
+- **Context:** Hermes requires at least 64K tokens. Local installers run the
+  bootstrap model at 64K so the agent works immediately, then move the full model
+  and config to the model selector's chosen context after the background model
+  upgrade completes. Large-context tiers still use 128K when they select a
+  128K-capable model; constrained tiers can remain at a smaller context.
 - **Compression:** enabled at `compression.threshold: 0.50` with `target_ratio: 0.20` so long sessions compact before the backend hard-rejects an over-window request.
 - **Model name:** `qwen3.5-9b` (Dream Server's default LLM — to switch models, edit `model.default` in `data/hermes/config.yaml` after first start; there is no env-var hook for this)
 - **Persona (`SOUL.md`):** a generalist Dream-Server-aware persona (see `extensions/services/hermes/SOUL.md.template`)
@@ -241,7 +245,7 @@ grep -E "^(CTX_SIZE|MAX_CONTEXT)=" .env
 grep -n "context_length\|threshold\|target_ratio" data/hermes/config.yaml
 ```
 
-For Hermes, `CTX_SIZE` / `MAX_CONTEXT`, `model.context_length`, and `auxiliary.compression.context_length` should be at least `65536`. Fresh local installs use `65536` during bootstrap and `131072` after the full model swap.
+For Hermes, `CTX_SIZE` / `MAX_CONTEXT`, `model.context_length`, and `auxiliary.compression.context_length` should be at least `65536`. Fresh local installs use `65536` during bootstrap, then keep the model selector's chosen full-model context after the swap. On larger tiers that may be `131072`; on constrained tiers it can stay lower.
 
 ### Sessions / memories / skills disappeared after upgrade
 

--- a/dream-server/docs/MACOS-QUICKSTART.md
+++ b/dream-server/docs/MACOS-QUICKSTART.md
@@ -95,7 +95,11 @@ The installer auto-selects the best model for your unified memory:
 | 48 GB | 3 | Qwen3 30B-A3B (MoE, Q4_K_M) | 32768 |
 | 64+ GB | 4 | Qwen3 30B-A3B (MoE, Q4_K_M) | 131072 |
 
-When Hermes is enabled, the macOS installer promotes the active local context to 128K for the full model. If bootstrap mode is used, the first-run bootstrap model starts at 64K so Hermes is usable while the full model downloads.
+When Hermes is enabled, the macOS installer enforces a 64K minimum for the active
+local context. If bootstrap mode is used, the first-run bootstrap model starts at
+64K so the agent is usable while the full model downloads; after the swap, the
+full model keeps the model selector's chosen context, which may be 128K on
+larger tiers.
 
 Override: `./install.sh --tier 3`
 

--- a/dream-server/docs/MODEL-MANAGEMENT.md
+++ b/dream-server/docs/MODEL-MANAGEMENT.md
@@ -79,8 +79,9 @@ grep -E "^(LLM_MODEL|GGUF_FILE|CTX_SIZE|MAX_CONTEXT)=" ~/dream-server/.env
 
 Hermes requires at least a 64K context window. Installer bootstrap mode uses
 `65536` for the fast-start model, then switches `.env`, llama-server, and
-Hermes config to the full model context, usually `131072`, when the background
-download completes.
+Hermes config to the model selector's chosen full-model context when the
+background download completes. Larger tiers may use `131072`; constrained tiers
+can remain at a smaller selected context.
 
 ## Manual: Download a Catalog Model
 

--- a/dream-server/docs/WINDOWS-QUICKSTART.md
+++ b/dream-server/docs/WINDOWS-QUICKSTART.md
@@ -93,7 +93,12 @@ First user becomes admin. Start chatting immediately.
 
 ## Bootstrap Mode (Faster Start)
 
-The installer automatically uses bootstrap mode when applicable — a small model (~1.5 GB) downloads first so you can start chatting within 2 minutes, while the full model downloads in the background. Hermes-enabled installs run that bootstrap model at a 64K context floor, then promote the full local model context to 128K after the swap. No extra flags needed.
+The installer automatically uses bootstrap mode when applicable — a small model
+(~1.5 GB) downloads first so you can start chatting within 2 minutes, while the
+full model downloads in the background. Hermes-enabled installs run that
+bootstrap model at a 64K context floor, then keep the model selector's chosen
+full-model context after the swap. Large-context tiers still use 128K when they
+select it; constrained machines can stay lower. No extra flags needed.
 
 ---
 

--- a/dream-server/extensions/services/dashboard-api/routers/extensions.py
+++ b/dream-server/extensions/services/dashboard-api/routers/extensions.py
@@ -1211,7 +1211,9 @@ def _install_from_library(service_id: str) -> None:
                 )
 
     USER_EXTENSIONS_DIR.mkdir(parents=True, exist_ok=True)
-    tmpdir = tempfile.mkdtemp(dir=str(USER_EXTENSIONS_DIR.parent))
+    tmp_parent = USER_EXTENSIONS_DIR / ".tmp"
+    tmp_parent.mkdir(parents=True, exist_ok=True)
+    tmpdir = tempfile.mkdtemp(prefix=f".{service_id}-", dir=str(tmp_parent))
     try:
         staged = Path(tmpdir) / service_id
         _copytree_safe(source, staged)

--- a/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_extensions.py
@@ -437,6 +437,35 @@ class TestInstallExtension:
         assert data["action"] == "installed"
         assert (user_dir / "my-ext" / "compose.yaml").exists()
 
+    def test_install_stages_tmp_under_user_extensions_dir(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Library installs must not require write access to the /data mount root."""
+        import tempfile
+
+        lib_dir = _setup_library_ext(tmp_path, "my-ext")
+        user_dir = tmp_path / "user"
+        _patch_mutation_config(monkeypatch, tmp_path, lib_dir=lib_dir,
+                               user_dir=user_dir)
+
+        captured = {}
+        real_mkdtemp = tempfile.mkdtemp
+
+        def fake_mkdtemp(*args, **kwargs):
+            captured["dir"] = Path(kwargs["dir"])
+            return real_mkdtemp(*args, **kwargs)
+
+        monkeypatch.setattr("routers.extensions.tempfile.mkdtemp", fake_mkdtemp)
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/install",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert captured["dir"] == user_dir / ".tmp"
+        assert (user_dir / "my-ext" / "compose.yaml").exists()
+
     def test_install_already_installed_409(self, test_client, monkeypatch, tmp_path):
         """409 when extension is already installed."""
         lib_dir = _setup_library_ext(tmp_path, "my-ext")

--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -315,7 +315,7 @@ start_native_llama() {
 
     read_dream_env
     local gguf_file="${ENV_GGUF_FILE:-Qwen3.5-9B-Q4_K_M.gguf}"
-    local ctx_size="${ENV_CTX_SIZE:-131072}"
+    local ctx_size="${ENV_CTX_SIZE:-65536}"
     local model_path="${INSTALL_DIR}/data/models/${gguf_file}"
 
     if [[ ! -f "$model_path" ]]; then

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -97,7 +97,7 @@ OPENCLAW_EXPLICIT=false
 ALL_FEATURES=false
 CLOUD_MODE=false
 NO_BOOTSTRAP=false
-HERMES_CONTEXT_SIZE=131072
+HERMES_CONTEXT_SIZE=65536
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -796,7 +796,10 @@ fi
 
 if $ENABLE_HERMES && ! $CLOUD_MODE; then
     if [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
-        ai_warn "Hermes enabled: increasing macOS llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (128K)."
+        ai_warn "Hermes enabled: increasing macOS llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (64K floor)."
+        if [[ -n "${MODEL_RECOMMENDATION_REASON:-}" ]]; then
+            MODEL_RECOMMENDATION_REASON="${MODEL_RECOMMENDATION_REASON} Hermes requires at least 64K context, so runtime context was raised to ${HERMES_CONTEXT_SIZE}."
+        fi
         MAX_CONTEXT="$HERMES_CONTEXT_SIZE"
     fi
 fi

--- a/dream-server/installers/phases/03-features.sh
+++ b/dream-server/installers/phases/03-features.sh
@@ -90,9 +90,12 @@ if ! $INTERACTIVE && [[ "$ENABLE_COMFYUI" == "true" ]]; then
 fi
 
 if [[ "${ENABLE_HERMES:-false}" == "true" && "${DREAM_MODE:-local}" != "cloud" ]]; then
-    HERMES_CONTEXT_SIZE="${HERMES_CONTEXT_SIZE:-131072}"
+    HERMES_CONTEXT_SIZE="${HERMES_CONTEXT_SIZE:-65536}"
     if [[ "${MAX_CONTEXT:-0}" =~ ^[0-9]+$ ]] && (( MAX_CONTEXT < HERMES_CONTEXT_SIZE )); then
-        ai_warn "Hermes enabled: increasing llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (128K)."
+        ai_warn "Hermes enabled: increasing llama context from ${MAX_CONTEXT} to ${HERMES_CONTEXT_SIZE} (64K floor)."
+        if [[ -n "${MODEL_RECOMMENDATION_REASON:-}" ]]; then
+            MODEL_RECOMMENDATION_REASON="${MODEL_RECOMMENDATION_REASON} Hermes requires at least 64K context, so runtime context was raised to ${HERMES_CONTEXT_SIZE}."
+        fi
         MAX_CONTEXT="$HERMES_CONTEXT_SIZE"
     fi
 fi

--- a/dream-server/installers/phases/07-devtools.sh
+++ b/dream-server/installers/phases/07-devtools.sh
@@ -191,7 +191,7 @@ else
         "${LLM_MODEL}": {
           "name": "${LLM_MODEL}",
           "limit": {
-            "context": ${MAX_CONTEXT:-131072},
+            "context": ${MAX_CONTEXT:-65536},
             "output": 32768
           }
         }

--- a/dream-server/installers/phases/11-services.sh
+++ b/dream-server/installers/phases/11-services.sh
@@ -656,7 +656,7 @@ MODELS_INI_EOF
                 _hermes_base_url="http://litellm:4000/v1"
                 _hermes_api_key="${LITELLM_KEY:-}"
             fi
-            _hermes_context="${MAX_CONTEXT:-131072}"
+            _hermes_context="${MAX_CONTEXT:-65536}"
             _hermes_request_timeout=180
             if [[ "${DREAM_MODE:-local}" != "cloud" ]] && { [[ "${GPU_BACKEND:-}" == "amd" ]] || _phase11_external_lemonade; }; then
                 _hermes_request_timeout=900

--- a/dream-server/installers/windows/phases/03-features.ps1
+++ b/dream-server/installers/windows/phases/03-features.ps1
@@ -140,9 +140,12 @@ if ($enableComfyui -and $selectedTier -eq "CLOUD") {
 }
 
 if ($enableHermes -and -not $cloudMode) {
-    $hermesContextSize = 131072
+    $hermesContextSize = 65536
     if ([int]$tierConfig.MaxContext -lt $hermesContextSize) {
-        Write-AIWarn "Hermes enabled: increasing llama context from $($tierConfig.MaxContext) to $hermesContextSize (128K)."
+        Write-AIWarn "Hermes enabled: increasing llama context from $($tierConfig.MaxContext) to $hermesContextSize (64K floor)."
+        if ($tierConfig.ContainsKey("RecommendationReason") -and $tierConfig.RecommendationReason) {
+            $tierConfig.RecommendationReason = "$($tierConfig.RecommendationReason) Hermes requires at least 64K context, so runtime context was raised to $hermesContextSize."
+        }
         $tierConfig.MaxContext = $hermesContextSize
     }
 }

--- a/dream-server/tests/test-hermes-context-floor.sh
+++ b/dream-server/tests/test-hermes-context-floor.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Regression guard for constrained hardware: enabling Hermes must preserve a
+# usable runtime profile. Hermes needs a 64K floor, but it must not inflate
+# 8GB-class installs to 128K and starve llama-server VRAM.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+pass() { echo "  PASS: $1"; }
+fail() { echo "  FAIL: $1" >&2; exit 1; }
+
+run_linux_phase_with_context() {
+    local input_context="$1"
+    (
+        set -euo pipefail
+        INTERACTIVE=false
+        DRY_RUN=true
+        INSTALL_CHOICE=1
+        TIER=1
+        ENABLE_HERMES=true
+        ENABLE_COMFYUI=false
+        ENABLE_OPENCLAW=false
+        ENABLE_APE=false
+        ENABLE_PERPLEXICA=false
+        ENABLE_PRIVACY_SHIELD=false
+        ENABLE_LANGFUSE=false
+        DREAM_MODE=local
+        MAX_CONTEXT="$input_context"
+        MODEL_RECOMMENDATION_REASON="selector chose ${input_context} context"
+        SCRIPT_DIR="/tmp/dream-context-floor-no-compose"
+        GPU_COUNT=1
+        GPU_BACKEND=cpu
+        HOST_ARCH=x86_64
+
+        dream_progress() { :; }
+        ai_warn() { :; }
+        log() { :; }
+        warn() { :; }
+
+        # The phase returns after single-GPU assignment setup when sourced.
+        # shellcheck source=/dev/null
+        source installers/phases/03-features.sh >/dev/null
+        printf '%s\n%s\n' "$MAX_CONTEXT" "$MODEL_RECOMMENDATION_REASON"
+    )
+}
+
+constrained="$(run_linux_phase_with_context 32768)"
+constrained_context="$(printf '%s\n' "$constrained" | sed -n '1p')"
+constrained_reason="$(printf '%s\n' "$constrained" | sed -n '2p')"
+[[ "$constrained_context" == "65536" ]] \
+    || fail "Linux Hermes floor should lift 32K selector context to 64K, got ${constrained_context}"
+[[ "$constrained_reason" == *"Hermes requires at least 64K context"* ]] \
+    || fail "Linux Hermes floor should annotate recommendation reason"
+pass "Linux Hermes floor lifts constrained context to 64K"
+
+large="$(run_linux_phase_with_context 131072)"
+large_context="$(printf '%s\n' "$large" | sed -n '1p')"
+[[ "$large_context" == "131072" ]] \
+    || fail "Linux Hermes floor should not reduce existing 128K context, got ${large_context}"
+pass "Linux Hermes floor preserves 128K-capable contexts"
+
+grep -Eq 'hermesContextSize[[:space:]]*=[[:space:]]*65536' installers/windows/phases/03-features.ps1 \
+    || fail "Windows Hermes floor must be 64K"
+grep -Eq 'HERMES_CONTEXT_SIZE=65536' installers/macos/install-macos.sh \
+    || fail "macOS Hermes floor must be 64K"
+pass "Windows and macOS Hermes floors are 64K"
+
+grep -Eq 'HERMES_CONTEXT_SIZE=.*131072|hermesContextSize[[:space:]]*=[[:space:]]*131072' \
+    installers/phases/03-features.sh installers/windows/phases/03-features.ps1 \
+    && fail "Linux/Windows Hermes feature phases must not force 128K"
+pass "Linux/Windows Hermes feature phases do not force 128K"

--- a/dream-server/tests/test-installer-context-parity.sh
+++ b/dream-server/tests/test-installer-context-parity.sh
@@ -62,12 +62,12 @@ assert_grep "installers/windows/lib/tier-map.ps1" 'BOOTSTRAP_MAX_CONTEXT[[:space
 
 echo ""
 echo "Hermes target context:"
-assert_grep "installers/phases/03-features.sh" 'HERMES_CONTEXT_SIZE=.*131072' \
-    "Linux Hermes target context is 128K"
-assert_grep "installers/macos/install-macos.sh" '^HERMES_CONTEXT_SIZE=131072$' \
-    "macOS Hermes target context is 128K"
-assert_grep "installers/windows/phases/03-features.ps1" 'hermesContextSize[[:space:]]*=[[:space:]]*131072' \
-    "Windows Hermes target context is 128K"
+assert_grep "installers/phases/03-features.sh" 'HERMES_CONTEXT_SIZE=.*65536' \
+    "Linux Hermes target context floor is 64K"
+assert_grep "installers/macos/install-macos.sh" '^HERMES_CONTEXT_SIZE=65536$' \
+    "macOS Hermes target context floor is 64K"
+assert_grep "installers/windows/phases/03-features.ps1" 'hermesContextSize[[:space:]]*=[[:space:]]*65536' \
+    "Windows Hermes target context floor is 64K"
 
 echo ""
 echo ".env context parity:"
@@ -99,12 +99,16 @@ assert_grep "installers/windows/install-windows.ps1" 'CTX_SIZE=\$\(\$tierConfig\
 
 echo ""
 echo "Hermes config patch paths:"
-assert_grep "installers/phases/11-services.sh" '_hermes_context="\$\{MAX_CONTEXT:-131072\}"' \
-    "Linux Hermes patcher uses selected context"
+assert_grep "installers/phases/11-services.sh" '_hermes_context="\$\{MAX_CONTEXT:-65536\}"' \
+    "Linux Hermes patcher uses selected context with 64K fallback"
 assert_grep "installers/phases/11-services.sh" '--context-length "\$_hermes_context"' \
     "Linux Hermes patcher receives context length"
 assert_grep "installers/macos/install-macos.sh" '--context-length "\$MAX_CONTEXT"' \
     "macOS Hermes patcher receives context length"
+assert_grep "installers/macos/dream-macos.sh" 'ENV_CTX_SIZE:-65536' \
+    "macOS native llama restart defaults to 64K context"
+assert_grep "installers/phases/07-devtools.sh" '"context": \$\{MAX_CONTEXT:-65536\}' \
+    "Linux OpenCode config defaults to 64K context"
 assert_not_grep "installers/macos/install-macos.sh" '\$LOG_FILE' \
     "macOS installer uses DS_LOG_FILE, not undefined LOG_FILE"
 assert_grep "installers/windows/install-windows.ps1" 'Update-HermesConfigFile.*ContextLength \(\[int\]\$tierConfig\.MaxContext\)' \


### PR DESCRIPTION
﻿## Summary
- Lower the Hermes-enforced runtime context floor from 128K to 64K on Linux, macOS, and Windows.
- Keep larger model-selector contexts unchanged, but stop lifting constrained systems past the 64K Hermes minimum.
- Align Linux OpenCode and native macOS restart fallbacks with the 64K floor.
- Add regression coverage for the 64K floor and wire the context parity guards into `make test`.

## Why
On an 8GB RTX 5070 Laptop system, the installer selected Qwen3.5-9B with 128K context. That produced a 4GB KV cache and saturated VRAM, causing direct OpenAI-compatible completions to crawl around 0.3 tok/s or time out. Retesting the same deployment at 64K kept Hermes above its required floor while restoring usable inference, about 38 tok/s on a medium completion.

## Validation
- `bash tests/test-tier-map.sh`
- `bash tests/test-installer-context-parity.sh`
- `bash tests/test-hermes-context-floor.sh`
- `bash -n installers/phases/03-features.sh installers/phases/07-devtools.sh installers/phases/11-services.sh installers/macos/install-macos.sh installers/macos/dream-macos.sh tests/test-hermes-context-floor.sh tests/test-installer-context-parity.sh`
- PowerShell parse checks for `installers/windows/phases/03-features.ps1`, `installers/windows/lib/env-generator.ps1`, and `installers/windows/install-windows.ps1`

Fleet validation is next: the fleet harness now has a direct runtime performance capability probe to catch this class of slow-but-alive LLM runtime regression.
