### PR TITLE
fix(linux): bound host-agent shutdown during reinstall

### DIFF
--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -29,6 +29,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Linux install preflight ==="
 	@bash tests/test-linux-install-preflight.sh
+	@bash tests/test-linux-host-agent-stop.sh
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh

--- a/dream-server/bin/dream-host-agent.py
+++ b/dream-server/bin/dream-host-agent.py
@@ -4747,6 +4747,22 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
     daemon_threads = True
 
 
+def _request_server_shutdown(server, signum=None):
+    """Ask serve_forever() to exit from a helper thread.
+
+    HTTPServer.shutdown() deadlocks when called from the same thread that is
+    running serve_forever(). Python signal handlers run on the main thread, so
+    the SIGTERM path must bounce the shutdown request to another thread.
+    """
+    if signum is not None:
+        logger.info("Received signal %s; shutting down", signum)
+    threading.Thread(
+        target=server.shutdown,
+        name="dream-host-agent-shutdown",
+        daemon=True,
+    ).start()
+
+
 def main():
     global INSTALL_DIR, DATA_DIR, AGENT_API_KEY, GPU_BACKEND, TIER, GPU_COUNT, CORE_SERVICE_IDS
     global USER_EXTENSIONS_DIR, EXTENSIONS_DIR, DREAM_VERSION
@@ -4818,7 +4834,8 @@ def main():
     bind_addr = _resolve_agent_bind_addr(env)
 
     server = ThreadedHTTPServer((bind_addr, port), AgentHandler)
-    signal.signal(signal.SIGTERM, lambda *_: server.shutdown())
+    signal.signal(signal.SIGTERM, lambda signum, _frame: _request_server_shutdown(server, signum))
+    signal.signal(signal.SIGINT, lambda signum, _frame: _request_server_shutdown(server, signum))
     logger.info("Dream Host Agent v%s listening on %s:%d", VERSION, bind_addr, port)
     if bind_addr == "0.0.0.0":
         logger.info(

--- a/dream-server/dream-uninstall.sh
+++ b/dream-server/dream-uninstall.sh
@@ -235,7 +235,11 @@ unset _dream_uninstall_orphan_pids _pid
 # Remove system-mode dream-host-agent unit (migrated from --user mode).
 # Idempotent — no-op if the unit was never installed (e.g. older user-mode installs).
 if systemctl is-enabled dream-host-agent.service >/dev/null 2>&1; then
-    sudo systemctl disable --now dream-host-agent.service 2>/dev/null || true
+    if ! timeout 20s sudo systemctl disable --now dream-host-agent.service 2>/dev/null; then
+        log_warn "dream-host-agent did not stop cleanly; forcing service shutdown"
+        sudo systemctl kill -s SIGKILL dream-host-agent.service 2>/dev/null || true
+        timeout 10s sudo systemctl disable dream-host-agent.service 2>/dev/null || true
+    fi
 fi
 sudo rm -f /etc/systemd/system/dream-host-agent.service 2>/dev/null || true
 sudo systemctl daemon-reload 2>/dev/null || true

--- a/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -29,6 +29,7 @@ validate_core_recreate_ids = _mod.validate_core_recreate_ids
 invalidate_compose_cache = _mod.invalidate_compose_cache
 _post_install_core_recreate = _mod._post_install_core_recreate
 _split_nmcli_terse = _mod._split_nmcli_terse
+_request_server_shutdown = _mod._request_server_shutdown
 
 
 def can_create_symlinks(tmp_path: Path) -> bool:
@@ -40,6 +41,33 @@ def can_create_symlinks(tmp_path: Path) -> bool:
     except (OSError, NotImplementedError):
         return False
     return link.is_symlink()
+
+
+class TestHostAgentShutdown:
+
+    def test_signal_shutdown_runs_from_helper_thread(self, monkeypatch):
+        calls = []
+
+        class FakeServer:
+            def shutdown(self):
+                calls.append("shutdown")
+
+        class FakeThread:
+            def __init__(self, target, name=None, daemon=None):
+                calls.append(("thread", name, daemon))
+                self._target = target
+
+            def start(self):
+                calls.append("start")
+                self._target()
+
+        monkeypatch.setattr(_mod.threading, "Thread", FakeThread)
+
+        _request_server_shutdown(FakeServer(), signum=15)
+
+        assert ("thread", "dream-host-agent-shutdown", True) in calls
+        assert "start" in calls
+        assert "shutdown" in calls
 
 
 class TestResolveAgentBindAddr:

--- a/dream-server/scripts/systemd/dream-host-agent.service
+++ b/dream-server/scripts/systemd/dream-host-agent.service
@@ -12,6 +12,7 @@ Environment=DREAM_HOME=__INSTALL_DIR__
 Environment=HOME=__HOME__
 Restart=on-failure
 RestartSec=5
+TimeoutStopSec=15
 
 [Install]
 WantedBy=multi-user.target

--- a/dream-server/tests/test-linux-host-agent-stop.sh
+++ b/dream-server/tests/test-linux-host-agent-stop.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+fail() {
+  echo "[FAIL] $*" >&2
+  exit 1
+}
+
+pass() {
+  echo "[OK] $*"
+}
+
+SERVICE="scripts/systemd/dream-host-agent.service"
+UNINSTALL="dream-uninstall.sh"
+AGENT="bin/dream-host-agent.py"
+
+grep -q '^TimeoutStopSec=15$' "$SERVICE" \
+  || fail "dream-host-agent systemd unit must bound service stop time"
+pass "systemd unit has bounded stop timeout"
+
+grep -q 'timeout 20s sudo systemctl disable --now dream-host-agent.service' "$UNINSTALL" \
+  || fail "uninstall must bound systemctl disable --now for old/stuck host-agent services"
+grep -q 'systemctl kill -s SIGKILL dream-host-agent.service' "$UNINSTALL" \
+  || fail "uninstall must force-kill a stuck host-agent service after bounded stop"
+pass "uninstall has bounded stop plus force-kill fallback"
+
+grep -q 'def _request_server_shutdown' "$AGENT" \
+  || fail "host-agent must expose async-safe shutdown helper"
+grep -q 'target=server.shutdown' "$AGENT" \
+  || fail "host-agent shutdown helper must call server.shutdown from a helper thread"
+grep -q 'signal.SIGTERM.*_request_server_shutdown' "$AGENT" \
+  || fail "host-agent SIGTERM handler must use async-safe shutdown helper"
+pass "host-agent SIGTERM path is async-safe"


### PR DESCRIPTION
## Summary
- fix Linux dream-host-agent SIGTERM handling so `HTTPServer.shutdown()` runs from a helper thread instead of deadlocking the main `serve_forever()` thread
- add `TimeoutStopSec=15` to the systemd unit for bounded shutdown on new installs
- bound `dream-uninstall.sh` systemd removal with a force-kill fallback so old/stuck installed host-agent services cannot wedge fresh reinstall
- add host-agent shutdown/unit/uninstall regression coverage

## Why
A full fleet run from main (`/home/michael/dream-fleet-test/runs/2026-06-24T03-37-22Z`) hung on all Linux hosts during fresh reinstall. Tower2, strix-halo, and spark all stopped at:

```text
Reaping any orphan host-managed processes...
sudo systemctl disable --now dream-host-agent.service
```

Live systemd state showed `dream-host-agent.service` stuck in `deactivating (stop-sigterm)` for more than a minute while the Python process remained alive. Root cause: the host-agent SIGTERM handler called `server.shutdown()` from the same thread running `serve_forever()`, which Python documents as a deadlock shape. The uninstall path also had no timeout, so an old installed agent could wedge upgrade/reinstall forever.

## Validation
- `python -m py_compile bin/dream-host-agent.py`
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py -q` -> `126 passed, 3 skipped`
- Fresh Tower2 clone of this branch:
  - `bash tests/test-linux-host-agent-stop.sh`
  - `python3 -m py_compile bin/dream-host-agent.py`

Next validation step: run focused Linux reinstall/fleet from this branch, then full fleet after this PR is merged if clean.