### PR TITLE
fix(dashboard): align Hermes Agent and SSO launch contracts

### DIFF
--- a/dream-server/CHANGELOG.md
+++ b/dream-server/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Dashboard Hermes readiness now accepts either llama-server or LiteLLM and
+  requires the complete authenticated runtime chain. Hermes Single Sign-On now
+  opens owner and support access management instead of duplicating the Agent
+  runtime link.
+
 ## [2.5.3] - 2026-05-26
 
 ### Fixed

--- a/dream-server/docs/HERMES.md
+++ b/dream-server/docs/HERMES.md
@@ -2,7 +2,7 @@
 
 Dream Server ships **Hermes Agent** — the [Nous Research open-source agent](https://github.com/nousresearch/hermes-agent) packaged as a Dream Server service. Hermes is a self-improving generalist agent with persistent memory, autonomous skill creation, and 70+ tools built in.
 
-When enabled, Hermes runs in a container alongside the rest of the stack, serves its own browser dashboard on internal port 9119, and talks to the local LLM via an OpenAI-compatible API. End users should enter through `hermes-proxy` on port 9120; direct host access to 9119 is intentionally not bound in the default stack.
+When enabled, Hermes runs in a container alongside the rest of the stack, serves its own browser dashboard on internal port 9119, and talks to the selected model provider through an OpenAI-compatible API. End users should enter through `hermes-proxy` on port 9120; direct host access to 9119 is intentionally not bound in the default stack.
 
 ## What you get
 
@@ -17,6 +17,15 @@ Hermes ships its own complete web UI — Dream Server is just packaging it. Afte
 - **Models** — pick which LLM Hermes uses (defaults to your llama-server)
 - **Config / Env** — Hermes's own settings
 - **Logs / Analytics** — operational visibility
+
+### Dashboard feature cards
+
+The Dream Server dashboard exposes two separate Hermes entry points:
+
+- **Hermes Agent** opens the authenticated Hermes runtime through `hermes-proxy` on port 9120. It must never link to a raw inference endpoint such as llama-server or LiteLLM.
+- **Hermes Single Sign-On** opens the dashboard's **Setup / Owner** page at `/invites`, where operators manage owner cards and temporary support magic links. It is an access-management surface, not a second link to the Hermes runtime.
+
+Hermes readiness is provider-neutral. A healthy local `llama-server` or a healthy LiteLLM route can satisfy the inference dependency, so the same feature contract works for local, cloud, and external-provider installations on Linux, macOS, Windows, and WSL.
 
 ## Architecture
 

--- a/dream-server/extensions/services/dashboard-api/routers/features.py
+++ b/dream-server/extensions/services/dashboard-api/routers/features.py
@@ -234,7 +234,13 @@ async def feature_enable_instructions(
         "images": {"steps": [f"Ensure ComfyUI is running on port {_svc_port('comfyui')}", "Open ComfyUI to build and run image workflows"], "links": [{"label": "Open ComfyUI", "url": comfyui_url}]},
         "coding": {"steps": [f"Ensure OpenCode is running on port {_svc_port('opencode')}", "Open OpenCode for the browser-based coding assistant"], "links": [{"label": "Open OpenCode", "url": opencode_url}]},
         "hermes-agent": {"steps": [f"Ensure Hermes proxy is running on port {_svc_port('hermes-proxy')}", "Open Hermes for advanced agent access"], "links": [{"label": "Open Hermes", "url": hermes_url}]},
-        "hermes-sso": {"steps": [f"Ensure Hermes proxy is running on port {_svc_port('hermes-proxy')}", "Open Hermes through Dream SSO"], "links": [{"label": "Open Hermes", "url": hermes_url}]},
+        "hermes-sso": {
+            "steps": [
+                "Ensure Hermes, Hermes proxy, and Dashboard API are running",
+                "Open Setup / Owner to manage owner cards and temporary support invites",
+            ],
+            "links": [{"label": "Manage Hermes access", "url": "/invites"}],
+        },
         "observability": {"steps": [f"Langfuse is running on port {_svc_port('langfuse')}", "Open Langfuse to view LLM traces and evaluations", "LiteLLM automatically sends traces — no additional configuration needed"], "links": [{"label": "Open Langfuse", "url": _svc_url("langfuse")}]},
     }
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_features.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_features.py
@@ -223,6 +223,83 @@ class TestCalculateFeatureStatusGeneral:
         assert result["status"] == "available"
 
 
+class TestHermesFeatureContracts:
+    @staticmethod
+    def _service(service_id, status="healthy"):
+        from models import ServiceStatus
+        return ServiceStatus(
+            id=service_id,
+            name=service_id,
+            port=9120 if service_id == "hermes-proxy" else 0,
+            external_port=9120 if service_id == "hermes-proxy" else 0,
+            status=status,
+        )
+
+    @staticmethod
+    def _feature(feature_id):
+        from pathlib import Path
+
+        import yaml
+
+        services_dir = Path(__file__).resolve().parents[2]
+        manifest_name = "hermes-proxy" if feature_id == "hermes-sso" else "hermes"
+        manifest = yaml.safe_load((services_dir / manifest_name / "manifest.yaml").read_text())
+        return next(feature for feature in manifest["features"] if feature["id"] == feature_id)
+
+    def test_agent_uses_authenticated_proxy_and_accepts_local_provider(self):
+        services = [
+            self._service("hermes"),
+            self._service("hermes-proxy"),
+            self._service("dashboard-api"),
+            self._service("llama-server"),
+        ]
+
+        result = calculate_feature_status(self._feature("hermes-agent"), services, None)
+
+        assert result["status"] == "enabled"
+        assert result["launch"] == {"type": "service", "service": "hermes-proxy"}
+        assert result["requirements"]["servicesAny"] == ["llama-server", "litellm"]
+
+    def test_agent_accepts_litellm_without_llama_server(self):
+        services = [
+            self._service("hermes"),
+            self._service("hermes-proxy"),
+            self._service("dashboard-api"),
+            self._service("litellm"),
+        ]
+
+        result = calculate_feature_status(self._feature("hermes-agent"), services, None)
+
+        assert result["status"] == "enabled"
+        assert result["requirements"]["servicesOk"] is True
+
+    def test_agent_is_not_ready_without_auth_proxy(self):
+        services = [
+            self._service("hermes"),
+            self._service("dashboard-api"),
+            self._service("litellm"),
+        ]
+
+        result = calculate_feature_status(self._feature("hermes-agent"), services, None)
+
+        assert result["status"] == "services_needed"
+        assert result["enabled"] is False
+        assert "hermes-proxy" in result["requirements"]["servicesMissing"]
+
+    def test_sso_opens_access_management_and_requires_complete_chain(self):
+        services = [
+            self._service("hermes"),
+            self._service("hermes-proxy"),
+            self._service("dashboard-api"),
+        ]
+
+        result = calculate_feature_status(self._feature("hermes-sso"), services, None)
+
+        assert result["status"] == "enabled"
+        assert result["launch"] == {"type": "internal", "path": "/invites"}
+        assert result["enabledServicesAll"] == ["hermes", "hermes-proxy", "dashboard-api"]
+
+
 # --- /api/features/{feature_id}/enable ---
 
 
@@ -302,6 +379,26 @@ class TestFeatureEnableInstructions:
             "label": "Open LAN entry",
             "url": "http://dashboard.dream.local:80",
         }
+
+    def test_hermes_sso_instructions_open_access_management(self, test_client, monkeypatch):
+        test_features = [
+            {"id": "hermes-sso", "name": "Hermes Single Sign-On",
+             "description": "Manage Hermes access", "icon": "Shield",
+             "category": "privacy", "setup_time": "Ready", "priority": 5,
+             "requirements": {"vram_gb": 0, "services": ["hermes", "hermes-proxy", "dashboard-api"]},
+             "enabled_services_all": ["hermes", "hermes-proxy", "dashboard-api"]}
+        ]
+        monkeypatch.setattr("routers.features.FEATURES", test_features)
+
+        resp = test_client.get(
+            "/api/features/hermes-sso/enable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        instructions = resp.json()["instructions"]
+        assert instructions["links"] == [{"label": "Manage Hermes access", "url": "/invites"}]
+        assert "owner cards" in " ".join(instructions["steps"]).lower()
 
     def test_404_for_unknown_feature(self, test_client, monkeypatch):
         monkeypatch.setattr("routers.features.FEATURES", [])

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -64,7 +64,7 @@ const FEATURE_LAUNCH_FALLBACKS = {
   voice: { type: 'service', service: 'open-webui' },
   documents: { type: 'service', service: 'open-webui' },
   'hermes-agent': { type: 'service', service: 'hermes-proxy' },
-  'hermes-sso': { type: 'service', service: 'hermes-proxy' },
+  'hermes-sso': { type: 'internal', path: '/invites' },
   images: { type: 'service', service: 'comfyui' },
   workflows: { type: 'service', service: 'n8n' },
   coding: { type: 'service', service: 'opencode' },

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -239,7 +239,16 @@ describe('Dashboard system overview', () => {
         icon: 'MessageSquare',
         status: 'enabled',
         launch: { type: 'service', service: 'hermes-proxy' },
-        requirements: { servicesAll: ['llama-server'], servicesMissing: [] },
+        requirements: { servicesAll: ['hermes', 'hermes-proxy', 'dashboard-api'], servicesAny: ['llama-server', 'litellm'], servicesMissing: [] },
+      },
+      {
+        id: 'hermes-sso',
+        name: 'Hermes Single Sign-On',
+        description: 'Manage Hermes access',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        launch: { type: 'internal', path: '/invites' },
+        requirements: { servicesAll: ['hermes', 'hermes-proxy', 'dashboard-api'], servicesMissing: [] },
       },
       {
         id: 'remote-access',
@@ -265,6 +274,7 @@ describe('Dashboard system overview', () => {
 
     expect(await screen.findByRole('link', { name: /AI Chat/ })).toHaveAttribute('href', 'http://localhost:3000')
     expect(screen.getByRole('link', { name: /Hermes Agent/ })).toHaveAttribute('href', 'http://localhost:9120')
+    expect(screen.getByRole('link', { name: /Hermes Single Sign-On/ })).toHaveAttribute('href', '/invites')
     expect(screen.queryByRole('link', { name: /Remote Access/ })).not.toBeInTheDocument()
     expect(screen.getByText('Remote Access')).toBeInTheDocument()
   })
@@ -286,6 +296,14 @@ describe('Dashboard system overview', () => {
         icon: 'MessageSquare',
         status: 'enabled',
         requirements: { servicesAll: ['llama-server'], servicesMissing: [] },
+      },
+      {
+        id: 'hermes-sso',
+        name: 'Hermes Single Sign-On',
+        description: 'Manage Hermes access',
+        icon: 'MessageSquare',
+        status: 'enabled',
+        requirements: { servicesAll: ['hermes', 'dashboard-api'], servicesMissing: [] },
       },
       {
         id: 'usage-api',
@@ -312,6 +330,7 @@ describe('Dashboard system overview', () => {
 
     expect(await screen.findByRole('link', { name: /AI Chat/ })).toHaveAttribute('href', 'http://localhost:3000')
     expect(screen.getByRole('link', { name: /Hermes Agent/ })).toHaveAttribute('href', 'http://localhost:9120')
+    expect(screen.getByRole('link', { name: /Hermes Single Sign-On/ })).toHaveAttribute('href', '/invites')
     expect(screen.queryByRole('link', { name: /Usage API/ })).not.toBeInTheDocument()
     expect(screen.queryByRole('link', { name: /AI Chat/ })).not.toHaveAttribute('href', 'http://localhost:11434')
     expect(screen.queryByRole('link', { name: /Hermes Agent/ })).not.toHaveAttribute('href', 'http://localhost:11434')

--- a/dream-server/extensions/services/hermes-proxy/manifest.yaml
+++ b/dream-server/extensions/services/hermes-proxy/manifest.yaml
@@ -52,16 +52,16 @@ service:
 features:
   - id: hermes-sso
     name: Hermes Single Sign-On
-    description: Magic-link SSO gating in front of Hermes Agent
+    description: Manage owner cards and support magic links for authenticated Hermes access
     icon: Shield
     category: privacy
     requirements:
-      services: [hermes, dashboard-api]
+      services: [hermes, hermes-proxy, dashboard-api]
       vram_gb: 0
-    enabled_services_all: [hermes-proxy]
+    enabled_services_all: [hermes, hermes-proxy, dashboard-api]
     setup_time: Ready
     priority: 5
     launch:
-      type: service
-      service: hermes-proxy
+      type: internal
+      path: /invites
     gpu_backends: [all]

--- a/dream-server/extensions/services/hermes/manifest.yaml
+++ b/dream-server/extensions/services/hermes/manifest.yaml
@@ -73,9 +73,11 @@ features:
     icon: Bot
     category: productivity
     requirements:
-      services: [llama-server]
+      services: [hermes, hermes-proxy, dashboard-api]
+      services_any: [llama-server, litellm]
       vram_gb: 0
-    enabled_services_all: [hermes]
+    enabled_services_all: [hermes, hermes-proxy, dashboard-api]
+    enabled_services_any: [llama-server, litellm]
     setup_time: ~1 minute (image pull)
     priority: 5
     launch:


### PR DESCRIPTION
## Summary

This PR completes and separates the launch contracts for the two Hermes cards on the Dashboard:

| Dashboard card | Destination | Purpose |
|---|---|---|
| Hermes Agent | `hermes-proxy` on port `9120` | Open the authenticated Hermes runtime |
| Hermes Single Sign-On | `/invites` | Manage owner cards and temporary support magic links |

It also makes Hermes feature readiness provider-neutral: the authenticated Hermes chain must be healthy, while inference may be supplied by either `llama-server` or LiteLLM.

> [!IMPORTANT]
> The Agent card must never resolve to a raw inference endpoint. `llama-server` and LiteLLM are backend dependencies, not user-facing Hermes interfaces.

## Problem

Current `main` already points the explicit Hermes Agent launch target at `hermes-proxy`, but the surrounding feature contract remained incomplete: legacy link resolution needed a protected regression contract, Single Sign-On duplicated the Agent destination, and readiness still assumed a local `llama-server`.

That produced three concrete contract problems:

1. A future or legacy fallback could regress toward a model API instead of the authenticated Agent UI.
2. The Single Sign-On card did not expose its actual administrative surface.
3. Hermes readiness assumed `llama-server`, even when cloud or external-provider installations correctly route Hermes through LiteLLM.

## What Changed

### Launch contracts

- Locks `hermes-proxy` as the only service launch target for Hermes Agent, including the legacy frontend fallback.
- Declares `/invites` as the internal launch target for Hermes Single Sign-On.
- Updates legacy frontend fallbacks to preserve those same destinations when an older API response omits launch metadata.
- Updates enable instructions so SSO directs operators to access management rather than opening Hermes again.

### Health contracts

- Requires `hermes`, `hermes-proxy`, and `dashboard-api` to be healthy before either feature is reported as enabled.
- Accepts either `llama-server` or `litellm` as the Agent inference dependency.
- Prevents a healthy inference backend from masking a missing authentication proxy.

### Regression coverage

- Covers local `llama-server` routing.
- Covers LiteLLM routing without `llama-server`.
- Covers a missing Hermes auth proxy.
- Covers explicit launch metadata and legacy frontend fallbacks.
- Covers the SSO access-management URL and enable instructions.

## Platform And Deployment Matrix

The changed Dashboard, API, and manifest contracts are shared across supported hosts; no platform-specific URL is introduced.

| Environment | Inference contract | Hermes Agent | Hermes SSO |
|---|---|---|---|
| Linux local | `llama-server` or LiteLLM | `hermes-proxy` | `/invites` |
| macOS local / Metal | `llama-server` or LiteLLM | `hermes-proxy` | `/invites` |
| Windows native | `llama-server` or LiteLLM | `hermes-proxy` | `/invites` |
| WSL | `llama-server` or LiteLLM | `hermes-proxy` | `/invites` |
| Cloud or external provider | LiteLLM | `hermes-proxy` | `/invites` |

> [!NOTE]
> This PR does not alter installer selection, Compose overlays, provider configuration, proxy authentication, or port exposure. It corrects how their existing runtime state is represented and launched by the Dashboard.

## AI Assistance

AI-assisted repository analysis, implementation review, test design, and validation were used. The author reviewed the resulting diff, selected the scope, and remains responsible for the change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not applicable; this PR targets main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [x] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because: not applicable

Commands/results:

```text
git diff --check
PASS

python -m pytest extensions/services/dashboard-api/tests/test_features.py -q
19 passed

python -m pytest extensions/services/dashboard-api/tests -q
1170 passed

npm test -- --run src/pages/Dashboard.test.jsx
15 passed

npm test -- --run
20 files passed, 124 tests passed

npm run build
PASS

bash tests/test-service-registry.sh
219 passed, 0 failed

python tests/contracts/test-network-exposure-contracts.py
PASS

bash tests/test-installer-contracts.sh
PASS, including 37 Linux/macOS/Windows parity checks

DREAM_PYTHON_CMD=python bash tests/test-linux-cloud-mode.sh
PASS

python tests/test-render-runtime-configs.py
PASS
```

## Operational Change Check

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [x] This is an operational change and validation is intentionally deferred for: release-grade hardware/fleet validation. The changed manifests contain Dashboard feature metadata only; no Compose service definition, installer path, authentication implementation, runtime configuration, or host mutation is changed. The narrower equivalent is the API, frontend, registry, network-exposure, installer-parity, and cloud-mode contract coverage recorded above.

## Notes For Reviewers

- The main review boundary is the distinction between an authenticated runtime entry point and its access-management surface.
- The frontend fallback remains intentional compatibility for API responses that predate explicit `launch` metadata.
- The full template validator produced 9/10 passing cases; one live writing-assistant response was empty or exceeded its concision threshold. That model-output check is nondeterministic and unrelated to the Dashboard/Hermes paths changed here.
- Rollback is limited to the eight files in this PR; no state migration is involved.
