### PR TITLE
fix(n8n): make secure cookies transport-aware on loopback

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -54,6 +54,9 @@ jobs:
       - name: Health Check Tests
         run: bash tests/test-health-check.sh
 
+      - name: n8n Cookie Policy Tests
+        run: bash tests/test-n8n-cookie-policy.sh
+
       - name: Dream Doctor Tests
         run: bash tests/test-dream-doctor.sh
 

--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -369,6 +369,8 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # n8n settings
 # N8N_HOST=localhost           # n8n hostname
 # N8N_WEBHOOK_URL=http://localhost:5678  # n8n webhook URL (for external access)
+# N8N_SECURE_COOKIE=auto        # false only for loopback HTTP; true for HTTPS/LAN
+# N8N_PROXY_HOPS=0              # set to the proxy count when using HTTPS ingress
 
 # Embedding model for RAG
 # EMBEDDING_MODEL=BAAI/bge-base-en-v1.5

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -653,6 +653,18 @@
       "type": "string",
       "description": "n8n webhook URL for external access"
     },
+    "N8N_SECURE_COOKIE": {
+      "type": "string",
+      "enum": ["auto", "true", "false"],
+      "description": "n8n session-cookie policy. auto disables Secure only for loopback HTTP and enables it for HTTPS or non-loopback binds.",
+      "default": "auto"
+    },
+    "N8N_PROXY_HOPS": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of trusted reverse proxies in front of n8n.",
+      "default": 0
+    },
     "EMBEDDING_MODEL": {
       "type": "string",
       "description": "Embedding model for RAG",

--- a/dream-server/Makefile
+++ b/dream-server/Makefile
@@ -45,6 +45,7 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
+	@bash tests/test-n8n-cookie-policy.sh
 	@echo ""
 	@echo "=== dream-cli pipefail tolerance ==="
 	@bash tests/test-dream-cli-pipefail-tolerance.sh

--- a/dream-server/extensions/services/n8n/README.md
+++ b/dream-server/extensions/services/n8n/README.md
@@ -27,8 +27,15 @@ Environment variables (set in `.env`):
 | `N8N_PORT` | `5678` | External port (maps to internal 5678) |
 | `N8N_AUTH` | `true` | Deprecated: n8n v2.x has built-in user management |
 | `N8N_HOST` | `localhost` | Hostname used in generated URLs |
-| `N8N_WEBHOOK_URL` | `http://localhost:5678` | Public webhook base URL (set to your LAN IP for external access) |
+| `N8N_WEBHOOK_URL` | `http://localhost:5678` | Public webhook base URL; use the HTTPS ingress URL for remote access |
+| `N8N_SECURE_COOKIE` | `auto` | Uses a non-`Secure` session cookie only for loopback HTTP; keeps `Secure` for HTTPS and network binds |
+| `N8N_PROXY_HOPS` | `0` | Number of trusted reverse proxies in front of n8n |
 | `TIMEZONE` | `UTC` | Timezone for scheduled workflows |
+
+`N8N_SECURE_COOKIE=auto` lets Safari use a local, loopback-only Dream Server
+without weakening remote sessions. An explicit `true` or `false` overrides the
+automatic policy. Do not set it to `false` when n8n is reachable from another
+machine.
 
 ## API
 
@@ -93,8 +100,14 @@ docker compose logs n8n
 - Credentials are read on first start; to change them, update `.env` and recreate the container: `docker compose up -d --force-recreate n8n`
 
 **Webhooks not receiving external traffic:**
-- Set `N8N_WEBHOOK_URL` to your machine's LAN IP (e.g. `http://192.168.1.100:5678`)
-- Ensure port 5678 is accessible on your firewall
+- Put n8n behind an HTTPS reverse proxy and set `N8N_WEBHOOK_URL` to its public URL (e.g. `https://n8n.example.com`)
+- Set `N8N_PROXY_HOPS` to the number of trusted proxies and ensure the proxy forwards the standard `X-Forwarded-*` headers
+
+**Secure-cookie warning in the browser:**
+- Restart or recreate n8n after upgrading so the automatic cookie policy is applied
+- Loopback HTTP (`localhost`, `127.0.0.1`, or `::1`) automatically uses a local-compatible cookie
+- Remote access must use HTTPS; keep `N8N_SECURE_COOKIE=true` and set `N8N_WEBHOOK_URL` to the public HTTPS URL
+- Behind one reverse proxy, set `N8N_PROXY_HOPS=1` and forward `X-Forwarded-For`, `X-Forwarded-Host`, and `X-Forwarded-Proto`
 
 **Workflow import failing via dashboard:**
 - Confirm n8n is healthy: `curl http://localhost:5678/healthz`

--- a/dream-server/extensions/services/n8n/compose.yaml
+++ b/dream-server/extensions/services/n8n/compose.yaml
@@ -6,6 +6,7 @@ services:
     user: "${UID:-1000}:${GID:-1000}"
     security_opt:
       - no-new-privileges:true
+    entrypoint: ["tini", "--", "/opt/dream/n8n-entrypoint.sh"]
     environment:
       - N8N_DEFAULT_ADMIN_EMAIL=${N8N_USER:?N8N_USER must be set in .env}
       - N8N_DEFAULT_ADMIN_PASSWORD=${N8N_PASS:?N8N_PASS must be set in .env}
@@ -13,8 +14,13 @@ services:
       - N8N_PORT=5678
       - N8N_PROTOCOL=http
       - WEBHOOK_URL=${N8N_WEBHOOK_URL:-http://localhost:5678}
+      - N8N_PROXY_HOPS=${N8N_PROXY_HOPS:-0}
+      - DREAM_BIND_ADDRESS=${BIND_ADDRESS:-127.0.0.1}
+      - N8N_SECURE_COOKIE=${N8N_SECURE_COOKIE:-auto}
       - GENERIC_TIMEZONE=${TIMEZONE:-UTC}
     volumes:
+      - ./extensions/services/n8n/n8n-cookie-policy.sh:/opt/dream/n8n-cookie-policy.sh:ro,z
+      - ./extensions/services/n8n/n8n-entrypoint.sh:/opt/dream/n8n-entrypoint.sh:ro,z
       - ./data/n8n:/home/node/.n8n:z
       - ./config/n8n:/home/node/workflows:z
     ports:

--- a/dream-server/extensions/services/n8n/manifest.yaml
+++ b/dream-server/extensions/services/n8n/manifest.yaml
@@ -29,6 +29,12 @@ service:
       required: true
       secret: true
       description: n8n admin password
+    - key: N8N_SECURE_COOKIE
+      required: false
+      description: Session-cookie policy (auto, true, or false); auto disables Secure only for loopback HTTP
+    - key: N8N_PROXY_HOPS
+      required: false
+      description: Number of trusted reverse proxies in front of n8n
 
 features:
   - id: workflows

--- a/dream-server/extensions/services/n8n/n8n-cookie-policy.sh
+++ b/dream-server/extensions/services/n8n/n8n-cookie-policy.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Resolve n8n's session-cookie policy from the public transport and host bind.
+# The caller remains responsible for exporting the returned value.
+dream_n8n_secure_cookie_policy() {
+    _dream_cookie_setting="${1:-auto}"
+    _dream_protocol="${2:-http}"
+    _dream_bind="${3:-127.0.0.1}"
+
+    case "$_dream_cookie_setting" in
+        true|false)
+            printf '%s\n' "$_dream_cookie_setting"
+            return 0
+            ;;
+        auto|"")
+            ;;
+        *)
+            printf 'Invalid N8N_SECURE_COOKIE value: %s (expected auto, true, or false)\n' \
+                "$_dream_cookie_setting" >&2
+            return 64
+            ;;
+    esac
+
+    case "$_dream_protocol:$_dream_bind" in
+        http:127.0.0.1|http:localhost|http:::1|http:\[::1\])
+            printf 'false\n'
+            ;;
+        *)
+            printf 'true\n'
+            ;;
+    esac
+}
+
+dream_n8n_is_loopback_bind() {
+    case "${1:-}" in
+        127.0.0.1|localhost|::1|\[::1\]) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+dream_n8n_public_protocol() {
+    case "${2:-}" in
+        https://*) printf 'https\n' ;;
+        http://*) printf 'http\n' ;;
+        *) printf '%s\n' "${1:-http}" ;;
+    esac
+}

--- a/dream-server/extensions/services/n8n/n8n-entrypoint.sh
+++ b/dream-server/extensions/services/n8n/n8n-entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -eu
+
+. /opt/dream/n8n-cookie-policy.sh
+
+requested_cookie_policy="${N8N_SECURE_COOKIE:-auto}"
+public_protocol="$(dream_n8n_public_protocol \
+    "${N8N_PROTOCOL:-http}" \
+    "${WEBHOOK_URL:-}")"
+resolved_cookie_policy="$(dream_n8n_secure_cookie_policy \
+    "$requested_cookie_policy" \
+    "$public_protocol" \
+    "${DREAM_BIND_ADDRESS:-127.0.0.1}")"
+
+if [ "$requested_cookie_policy" = "false" ] \
+    && ! dream_n8n_is_loopback_bind "${DREAM_BIND_ADDRESS:-127.0.0.1}"; then
+    printf '%s\n' \
+        'WARNING: N8N_SECURE_COOKIE=false is explicitly configured on a non-loopback bind.' \
+        'Use HTTPS and N8N_SECURE_COOKIE=true before exposing n8n beyond a trusted local machine.' >&2
+fi
+
+export N8N_SECURE_COOKIE="$resolved_cookie_policy"
+exec /docker-entrypoint.sh "$@"

--- a/dream-server/tests/test-n8n-cookie-policy.sh
+++ b/dream-server/tests/test-n8n-cookie-policy.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../extensions/services/n8n/n8n-cookie-policy.sh
+source "$ROOT_DIR/extensions/services/n8n/n8n-cookie-policy.sh"
+
+failures=0
+
+assert_policy() {
+    local expected="$1" setting="$2" protocol="$3" bind="$4" actual
+    actual="$(dream_n8n_secure_cookie_policy "$setting" "$protocol" "$bind")"
+    if [[ "$actual" != "$expected" ]]; then
+        printf 'FAIL setting=%s protocol=%s bind=%s: expected %s, got %s\n' \
+            "$setting" "$protocol" "$bind" "$expected" "$actual" >&2
+        failures=$((failures + 1))
+    fi
+}
+
+assert_policy false auto http 127.0.0.1
+assert_policy false auto http localhost
+assert_policy false auto http ::1
+assert_policy false auto http '[::1]'
+assert_policy true auto https 127.0.0.1
+assert_policy true auto http 0.0.0.0
+assert_policy true auto http 192.168.1.10
+assert_policy true true http 127.0.0.1
+assert_policy false false https 0.0.0.0
+
+[[ "$(dream_n8n_public_protocol http https://n8n.example.com/)" == "https" ]] || {
+    printf 'FAIL HTTPS webhook URL did not override the internal protocol\n' >&2
+    failures=$((failures + 1))
+}
+[[ "$(dream_n8n_public_protocol http http://localhost:5678/)" == "http" ]] || {
+    printf 'FAIL HTTP webhook URL was not recognized\n' >&2
+    failures=$((failures + 1))
+}
+
+if dream_n8n_secure_cookie_policy sometimes http 127.0.0.1 >/dev/null 2>&1; then
+    printf 'FAIL invalid policy was accepted\n' >&2
+    failures=$((failures + 1))
+fi
+
+if ((failures > 0)); then
+    printf '%d n8n cookie policy test(s) failed\n' "$failures" >&2
+    exit 1
+fi
+
+printf 'n8n cookie policy tests passed\n'


### PR DESCRIPTION
## Summary

DreamServer currently starts n8n over HTTP while n8n defaults its session cookie to `Secure`. On Safari this blocks the editor even when n8n is safely bound to loopback; on other browsers it also fails when the dashboard opens a non-`localhost` loopback URL.

This change introduces a fail-closed `auto` policy that adapts the cookie attribute to the actual transport and bind scope without weakening LAN or remote deployments.

> [!IMPORTANT]
> This does **not** set `N8N_SECURE_COOKIE=false` globally. Non-loopback binds and HTTPS URLs continue to use secure cookies.

## Policy Matrix

| Requested policy | Public transport | Host bind | Effective value |
|---|---:|---:|---:|
| `auto` | HTTP | `127.0.0.1`, `localhost`, `::1` | `false` |
| `auto` | HTTP | LAN / wildcard / other | `true` |
| `auto` | HTTPS | any | `true` |
| `true` or `false` | any | any | explicit operator value |

The public transport is inferred from `N8N_WEBHOOK_URL` first, so an HTTPS reverse proxy remains secure even when the container itself receives HTTP internally. An explicit insecure value on a non-loopback bind emits a startup warning.

## Implementation

- preserves the upstream `tini` and `/docker-entrypoint.sh` startup chain
- resolves the effective cookie policy before n8n starts
- validates `N8N_SECURE_COOKIE` as `auto`, `true`, or `false`
- exposes `N8N_PROXY_HOPS` for supported reverse-proxy deployments
- keeps policy logic inside the n8n container path, shared by Linux, macOS, Windows, and WSL
- documents local Safari behavior and the required HTTPS posture for remote access
- adds a dedicated policy matrix test to `make test` and GitHub Actions

## Security Properties

| Scenario | Result |
|---|---|
| Default DreamServer install | Cookie relaxation is limited to HTTP loopback |
| `BIND_ADDRESS=0.0.0.0` | Secure cookie remains enabled |
| HTTPS ingress with loopback backend | Secure cookie remains enabled via the public webhook scheme |
| Invalid policy value | n8n fails before startup with an actionable error |
| Explicit `false` on network bind | Override is honored, but a prominent warning is logged |

For reverse proxies, the documentation now follows n8n's supported contract: HTTPS public URL, a correct `N8N_PROXY_HOPS` value, and forwarded `X-Forwarded-*` headers.

## Validation

- `make test`
- `bash tests/test-validate-env.sh`
- `bash tests/test-validate-manifests.sh`
- `bash tests/test-service-registry.sh` (`219 passed`)
- `bash tests/test-bind-address-sweep.sh`
- ShellCheck at warning severity for all new shell files
- Docker Compose resolution for loopback and wildcard bind variants
- image-level startup smoke against `n8nio/n8n:2.6.4`
- live macOS Docker Desktop recreation with preserved n8n data
- live health check: `/healthz` returned `200`
- live n8n settings: `authCookie.secure=false` on `127.0.0.1`
- browser validation: owner setup page rendered at `http://localhost:5678/setup` with no secure-cookie warning or console errors

## References

- [n8n reverse proxy webhook configuration](https://docs.n8n.io/hosting/configuration/configuration-examples/webhook-url/)
- [n8n deployment environment variables](https://docs.n8n.io/hosting/configuration/environment-variables/deployment/)
