### PR TITLE
fix(macos): launch native llama from install dir

### DIFF
--- a/dream-server/installers/macos/dream-macos.sh
+++ b/dream-server/installers/macos/dream-macos.sh
@@ -349,7 +349,10 @@ start_native_llama() {
     [[ -n "${ENV_LLAMA_ARG_SPEC_TYPE:-}" ]] && llama_args+=(--spec-type "$ENV_LLAMA_ARG_SPEC_TYPE")
     [[ -n "${ENV_LLAMA_ARG_SPEC_DRAFT_N_MAX:-}" ]] && llama_args+=(--spec-draft-n-max "$ENV_LLAMA_ARG_SPEC_DRAFT_N_MAX")
 
-    "$LLAMA_SERVER_BIN" "${llama_args[@]}" > "$LLAMA_SERVER_LOG" 2>&1 &
+    (
+        cd "$INSTALL_DIR" || exit 1
+        exec "$LLAMA_SERVER_BIN" "${llama_args[@]}"
+    ) > "$LLAMA_SERVER_LOG" 2>&1 &
     local pid=$!
     echo "$pid" > "$LLAMA_SERVER_PID_FILE"
 

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1261,7 +1261,10 @@ else
         [[ -n "$_spec_type" ]] && _llama_args+=(--spec-type "$_spec_type")
         [[ -n "$_spec_draft_n_max" ]] && _llama_args+=(--spec-draft-n-max "$_spec_draft_n_max")
 
-        "$LLAMA_SERVER_BIN" "${_llama_args[@]}" > "$LLAMA_SERVER_LOG" 2>&1 &
+        (
+            cd "$INSTALL_DIR" || exit 1
+            exec "$LLAMA_SERVER_BIN" "${_llama_args[@]}"
+        ) > "$LLAMA_SERVER_LOG" 2>&1 &
         LLAMA_PID=$!
         echo "$LLAMA_PID" > "$LLAMA_SERVER_PID_FILE"
 

--- a/dream-server/installers/macos/install-macos.sh
+++ b/dream-server/installers/macos/install-macos.sh
@@ -1481,6 +1481,13 @@ else
     # here guarantees a clean slate regardless of what happens below.
     launchctl bootout "gui/$(id -u)/${DREAM_AGENT_PLIST_LABEL}" 2>/dev/null || true
     launchctl bootout "gui/$(id -u)/${OPENCODE_PLIST_LABEL}" 2>/dev/null || true
+    for _legacy_plist_label in \
+        com.dreamserver.llama-server \
+        com.dreamserver.full-model-download; do
+        launchctl bootout "gui/$(id -u)/${_legacy_plist_label}" 2>/dev/null || true
+        rm -f "$HOME/Library/LaunchAgents/${_legacy_plist_label}.plist" 2>/dev/null || true
+    done
+    unset _legacy_plist_label
 
     # ── Start Docker services ──
     chapter "STARTING SERVICES"

--- a/dream-server/scripts/bootstrap-upgrade.sh
+++ b/dream-server/scripts/bootstrap-upgrade.sh
@@ -35,14 +35,27 @@ FULL_LLM_MODEL="$5"
 FULL_MAX_CONTEXT="$6"
 BOOTSTRAP_GGUF_FILE="${7:-Qwen3.5-2B-Q4_K_M.gguf}"
 
-MODELS_DIR="$INSTALL_DIR/data/models"
-ENV_FILE="$INSTALL_DIR/.env"
-MODELS_INI="$INSTALL_DIR/config/llama-server/models.ini"
 LOG_TAG="[BOOTSTRAP-UPGRADE]"
 
 log()  { echo "$LOG_TAG $(date '+%H:%M:%S') $*"; }
 fail() { log "ERROR: $*"; release_upgrade_lock; exit 1; }
 
+if [[ -z "$INSTALL_DIR" || ! -d "$INSTALL_DIR" ]]; then
+    log "ERROR: install directory does not exist: ${INSTALL_DIR:-<empty>}"
+    exit 1
+fi
+if ! INSTALL_DIR="$(cd "$INSTALL_DIR" && pwd -P)"; then
+    log "ERROR: could not resolve install directory: $INSTALL_DIR"
+    exit 1
+fi
+cd "$INSTALL_DIR" || {
+    log "ERROR: could not enter install directory: $INSTALL_DIR"
+    exit 1
+}
+
+MODELS_DIR="$INSTALL_DIR/data/models"
+ENV_FILE="$INSTALL_DIR/.env"
+MODELS_INI="$INSTALL_DIR/config/llama-server/models.ini"
 STATUS_FILE="$INSTALL_DIR/data/bootstrap-status.json"
 UPGRADE_LOCK_DIR=""
 
@@ -1779,7 +1792,10 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
 
             # Relaunch with new model
             log "Starting native llama-server with ${_gguf_file}..."
-            "$LLAMA_SERVER_BIN" "${_llama_args[@]}" > "$LLAMA_SERVER_LOG" 2>&1 &
+            (
+                cd "$INSTALL_DIR" || exit 1
+                exec "$LLAMA_SERVER_BIN" "${_llama_args[@]}"
+            ) > "$LLAMA_SERVER_LOG" 2>&1 &
             _new_pid=$!
             echo "$_new_pid" > "$LLAMA_SERVER_PID_FILE"
 
@@ -1805,14 +1821,16 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
                     kill -9 "$_new_pid" 2>/dev/null || true
                 fi
                 if [[ -n "${_old_model_path:-}" && -f "$_old_model_path" ]]; then
-                    "$LLAMA_SERVER_BIN" \
-                        --host "$_bind" --port 8080 \
-                        --model "$_old_model_path" \
-                        --ctx-size "$_ctx_size" \
-                        --n-gpu-layers 999 \
-                        --reasoning-format "${_reasoning_fmt:-none}" \
-                        --metrics \
-                        > "$LLAMA_SERVER_LOG" 2>&1 &
+                    (
+                        cd "$INSTALL_DIR" || exit 1
+                        exec "$LLAMA_SERVER_BIN" \
+                            --host "$_bind" --port 8080 \
+                            --model "$_old_model_path" \
+                            --ctx-size "$_ctx_size" \
+                            --n-gpu-layers 999 \
+                            --reasoning-format "${_reasoning_fmt:-none}" \
+                            --metrics
+                    ) > "$LLAMA_SERVER_LOG" 2>&1 &
                     _rollback_pid=$!
                     echo "$_rollback_pid" > "$LLAMA_SERVER_PID_FILE"
                     log "Rolled back to previous model: $(basename "$_old_model_path") (PID $_rollback_pid)"
@@ -1820,6 +1838,9 @@ elif [[ -f "$INSTALL_DIR/data/.llama-server.pid" ]]; then
                     log "WARNING: Could not rollback — previous model not found."
                     log "Run './dream-macos.sh restart' to manually recover."
                 fi
+                write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 \
+                    "Full model downloaded and verified, but native macOS llama-server did not load it after swap. Bootstrap model kept; run './dream-macos.sh restart' or re-run to retry."
+                exit 1
             fi
         fi
     fi

--- a/dream-server/tests/test-macos-native-llama-launch-cwd.sh
+++ b/dream-server/tests/test-macos-native-llama-launch-cwd.sh
@@ -46,6 +46,12 @@ assert_llama_exec_anchored "$bootstrap" "bootstrap hot-swap"
 assert_llama_exec_anchored "$installer" "macOS installer"
 assert_llama_exec_anchored "$cli" "dream-macos restart"
 
+grep -qF 'com.dreamserver.llama-server' "$installer" \
+    || fail "macOS installer must unload legacy llama-server LaunchAgent"
+grep -qF 'com.dreamserver.full-model-download' "$installer" \
+    || fail "macOS installer must unload legacy full-model-download LaunchAgent"
+pass "macOS installer clears legacy native llama LaunchAgents"
+
 grep -qF 'Full model downloaded and verified, but native macOS llama-server did not load it after swap' "$bootstrap" \
     || fail "macOS native hot-swap failure must persist an honest failed status"
 grep -qF 'write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES"' "$bootstrap" \

--- a/dream-server/tests/test-macos-native-llama-launch-cwd.sh
+++ b/dream-server/tests/test-macos-native-llama-launch-cwd.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Regression: native macOS llama-server must launch from the install directory.
+# llama.cpp probes its current directory while loading backends; if the detached
+# upgrader inherits a removed cwd from a reinstall, it aborts before serving.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+assert_llama_exec_anchored() {
+    local target="$1" label="$2"
+
+    [[ -f "$target" ]] || fail "missing $target"
+
+    awk '
+        /cd "\$INSTALL_DIR" \|\| exit 1/ { cd_seen=3 }
+        /exec "\$LLAMA_SERVER_BIN"/ {
+            if (!cd_seen) exit 1
+            exec_count++
+        }
+        { if (cd_seen > 0) cd_seen-- }
+        END { if (exec_count == 0) exit 2 }
+    ' "$target" || fail "$label: native llama-server exec must be immediately preceded by cd \"\$INSTALL_DIR\""
+
+    pass "$label: native llama-server launches from INSTALL_DIR"
+}
+
+bootstrap="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+installer="$ROOT_DIR/installers/macos/install-macos.sh"
+cli="$ROOT_DIR/installers/macos/dream-macos.sh"
+
+grep -qF 'cd "$INSTALL_DIR" || {' "$bootstrap" \
+    || fail "bootstrap-upgrade.sh must anchor its own cwd to INSTALL_DIR"
+pass "bootstrap-upgrade.sh anchors the detached upgrader cwd"
+
+assert_llama_exec_anchored "$bootstrap" "bootstrap hot-swap"
+assert_llama_exec_anchored "$installer" "macOS installer"
+assert_llama_exec_anchored "$cli" "dream-macos restart"
+
+grep -qF 'Full model downloaded and verified, but native macOS llama-server did not load it after swap' "$bootstrap" \
+    || fail "macOS native hot-swap failure must persist an honest failed status"
+grep -qF 'write_status "failed" 100 "$TOTAL_BYTES" "$TOTAL_BYTES"' "$bootstrap" \
+    || fail "macOS native hot-swap failure must report real downloaded bytes"
+pass "macOS native hot-swap failure is reported as failed"
+
+echo "[OK] macOS native llama launch cwd contract holds"


### PR DESCRIPTION
## Summary
- launch native macOS llama-server from the DreamServer install directory during bootstrap upgrade and installer-managed starts
- mark detached native macOS hotswap as failed if the full model cannot be loaded
- unload/remove stale legacy native llama/full-model LaunchAgents during macOS install
- add a shell contract test for native llama launch cwd behavior and stale agent cleanup

## Why
After PRs #1602 and #1604 were merged, the fresh release fleet surfaced a macOS-only native llama crash on `m5-mbp`:

```
filesystem error: in current_path: call to getcwd failed: No such file or directory
```

The detached bootstrap full-model hotswap inherited a working directory that could disappear during reinstall/upgrade. llama.cpp probes its current directory at startup, so the native server crashed before exposing the expected model even though bootstrap status had already been written as complete.

## Validation
- `bash -n dream-server/tests/test-macos-native-llama-launch-cwd.sh dream-server/scripts/bootstrap-upgrade.sh dream-server/installers/macos/install-macos.sh dream-server/installers/macos/dream-macos.sh`
- `dream-server/tests/test-macos-native-llama-launch-cwd.sh`
- `dream-server/tests/test-bootstrap-upgrade-hotswap-contract.sh`
- `git diff --check`
- full Dream fleet run `/home/michael/dream-fleet-test/runs/2026-06-25T01-19-39Z`: PASS / User Green
- fleet triage: `0 failures found`
- distro/VM matrix: ubuntu2404, fedora42, rocky9, arch, opensuse PASS