### PR TITLE
Add optional x402 gateway extension

### DIFF
--- a/dream-server/config/dependency-lock.json
+++ b/dream-server/config/dependency-lock.json
@@ -220,6 +220,12 @@
       "value": "python:3.12-slim"
     },
     {
+      "id": "x402-gateway.python",
+      "type": "image",
+      "path": "extensions/services/x402-gateway/Dockerfile",
+      "value": "python:3.12-slim"
+    },
+    {
       "id": "tts.kokoro",
       "type": "image",
       "path": "extensions/services/tts/compose.yaml",
@@ -274,6 +280,11 @@
       "path": "extensions/services/brave-search/compose.yaml",
       "value": "dream-brave-search:local",
       "reason": "Local extension image built from the adjacent Dockerfile."
+    },
+    {
+      "path": "extensions/services/x402-gateway/compose.yaml.disabled",
+      "value": "dream-x402-gateway:local",
+      "reason": "Local optional x402 gateway image built from extensions/services/x402-gateway/Dockerfile when the extension is enabled."
     }
   ],
   "allow_variable_refs": [

--- a/dream-server/config/network-exposure-policy.json
+++ b/dream-server/config/network-exposure-policy.json
@@ -145,6 +145,12 @@
       "lan_exposure": "operator-controlled",
       "auth_required": false,
       "notes": "Speech-to-text model API; audio may be sensitive."
+    },
+    "x402-gateway": {
+      "risk": "paid-api-gateway",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Optional payment gateway for explicitly allowlisted Dream Server routes; keep localhost/private unless deliberately publishing paid API access."
     }
   }
 }

--- a/dream-server/config/x402/config.example.json
+++ b/dream-server/config/x402/config.example.json
@@ -1,0 +1,36 @@
+{
+  "enabled": true,
+  "seller": {
+    "network": "eip155:84532",
+    "asset": "USDC",
+    "recipient": "0xYourDreamServerWallet",
+    "facilitatorUrl": "https://x402.org/facilitator"
+  },
+  "policy": {
+    "mode": "allowlist",
+    "unprotectedByDefault": true,
+    "devBypass": false
+  },
+  "audit": {
+    "logPayments": true,
+    "logUnpaidAttempts": true
+  },
+  "rules": [
+    {
+      "name": "Paid local inference",
+      "kind": "http_route",
+      "path": "/llama/v1/chat/completions",
+      "methods": ["POST"],
+      "upstream": "http://llama-server:8080/v1/chat/completions",
+      "price": {
+        "amount": "0.01",
+        "currency": "USDC"
+      },
+      "metadata": {
+        "title": "Dream Server local inference",
+        "description": "Paid access to the local llama.cpp OpenAI-compatible chat endpoint",
+        "mimeType": "application/json"
+      }
+    }
+  ]
+}

--- a/dream-server/config/x402/config.example.json
+++ b/dream-server/config/x402/config.example.json
@@ -6,6 +6,13 @@
     "recipient": "0xYourDreamServerWallet",
     "facilitatorUrl": "https://x402.org/facilitator"
   },
+  "facilitator": {
+    "url": "https://x402.org/facilitator",
+    "provider": "x402.org",
+    "auth": {
+      "type": "none"
+    }
+  },
   "policy": {
     "mode": "allowlist",
     "unprotectedByDefault": true,

--- a/dream-server/extensions/services/x402-gateway/Dockerfile
+++ b/dream-server/extensions/services/x402-gateway/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+RUN useradd --create-home --shell /usr/sbin/nologin dream
+USER dream
+
+EXPOSE 4020
+
+CMD ["python", "-m", "app.main"]

--- a/dream-server/extensions/services/x402-gateway/README.md
+++ b/dream-server/extensions/services/x402-gateway/README.md
@@ -25,6 +25,37 @@ Edit:
 - `seller.network` — `eip155:84532` for Base Sepolia testing, `eip155:8453` for Base mainnet
 - `rules` — exact gateway routes to protect
 
+For no-signup testnet usage, keep:
+
+```json
+"facilitator": {
+  "url": "https://x402.org/facilitator",
+  "provider": "x402.org",
+  "auth": { "type": "none" }
+}
+```
+
+For Base mainnet with the CDP facilitator, set:
+
+```json
+"facilitator": {
+  "url": "https://api.cdp.coinbase.com/platform/v2/x402",
+  "provider": "cdp",
+  "auth": {
+    "type": "cdp_api_key",
+    "apiKeyIdEnv": "CDP_API_KEY_ID",
+    "apiKeySecretEnv": "CDP_API_KEY_SECRET"
+  }
+}
+```
+
+and add the CDP credentials to `.env`:
+
+```bash
+CDP_API_KEY_ID=<your-cdp-key-id>
+CDP_API_KEY_SECRET=<your-base64-cdp-ed25519-secret>
+```
+
 The default example protects:
 
 ```text

--- a/dream-server/extensions/services/x402-gateway/README.md
+++ b/dream-server/extensions/services/x402-gateway/README.md
@@ -1,0 +1,67 @@
+# x402 Gateway
+
+Optional HTTP 402 payment gateway for Dream Server.
+
+The gateway protects only explicit HTTP routes listed in `config/x402/config.json`.
+It does not change `llama-server`, `dashboard-api`, or any other core service.
+
+## Status
+
+This extension is disabled by default. Enable it only after creating a config
+file with your receiving wallet address.
+
+## Configure
+
+Copy the example config:
+
+```bash
+mkdir -p config/x402
+cp config/x402/config.example.json config/x402/config.json
+```
+
+Edit:
+
+- `seller.recipient` — your receiving wallet address
+- `seller.network` — `eip155:84532` for Base Sepolia testing, `eip155:8453` for Base mainnet
+- `rules` — exact gateway routes to protect
+
+The default example protects:
+
+```text
+POST /llama/v1/chat/completions
+```
+
+and forwards successful paid requests to:
+
+```text
+http://llama-server:8080/v1/chat/completions
+```
+
+## Enable
+
+```bash
+dream enable x402-gateway
+dream start x402-gateway
+```
+
+## Test
+
+Health:
+
+```bash
+curl http://127.0.0.1:4020/health
+```
+
+An unpaid protected request should return `402 Payment Required`:
+
+```bash
+curl -i http://127.0.0.1:4020/llama/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"local","messages":[{"role":"user","content":"hello"}]}'
+```
+
+## Design
+
+V1 is route-only and allowlist-only. There is no wildcard charging mode, no
+database, and no MCP/tool interception yet. That keeps paid access explicit and
+leaves Dream Server's local/private behavior unchanged.

--- a/dream-server/extensions/services/x402-gateway/app/audit.py
+++ b/dream-server/extensions/services/x402-gateway/app/audit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -9,16 +10,27 @@ from typing import Any
 class AuditLog:
     def __init__(self, path: str | None) -> None:
         self.path = Path(path) if path else None
+        self._disabled_reason: str | None = None
         if self.path:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+            except OSError as exc:
+                self._disable(f"cannot create audit directory {self.path.parent}: {exc}")
 
     def write(self, event: str, payload: dict[str, Any]) -> None:
-        if not self.path:
+        if not self.path or self._disabled_reason:
             return
         record = {
             "ts": datetime.now(UTC).isoformat(),
             "event": event,
             **payload,
         }
-        with self.path.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+        try:
+            with self.path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, separators=(",", ":")) + "\n")
+        except OSError as exc:
+            self._disable(f"cannot write audit log {self.path}: {exc}")
+
+    def _disable(self, reason: str) -> None:
+        self._disabled_reason = reason
+        print(f"x402-gateway audit disabled: {reason}", file=sys.stderr, flush=True)

--- a/dream-server/extensions/services/x402-gateway/app/audit.py
+++ b/dream-server/extensions/services/x402-gateway/app/audit.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+class AuditLog:
+    def __init__(self, path: str | None) -> None:
+        self.path = Path(path) if path else None
+        if self.path:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+
+    def write(self, event: str, payload: dict[str, Any]) -> None:
+        if not self.path:
+            return
+        record = {
+            "ts": datetime.now(UTC).isoformat(),
+            "event": event,
+            **payload,
+        }
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, separators=(",", ":")) + "\n")

--- a/dream-server/extensions/services/x402-gateway/app/cdp_auth.py
+++ b/dream-server/extensions/services/x402-gateway/app/cdp_auth.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import secrets
+import time
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from .config import FacilitatorAuthConfig
+
+
+def _base64url(payload: bytes | str) -> str:
+    data = payload.encode("utf-8") if isinstance(payload, str) else payload
+    return base64.urlsafe_b64encode(data).decode("ascii").rstrip("=")
+
+
+def _load_private_key(raw_base64_secret: str) -> Ed25519PrivateKey:
+    raw = base64.b64decode(raw_base64_secret, validate=True)
+    if len(raw) != 64:
+        raise ValueError(f"expected 64-byte CDP Ed25519 secret, got {len(raw)} bytes")
+    return Ed25519PrivateKey.from_private_bytes(raw[:32])
+
+
+@dataclass(frozen=True)
+class CdpJwtSigner:
+    key_id: str
+    private_key: Ed25519PrivateKey
+    host: str
+    base_path: str
+
+    def sign(self, method: str, endpoint: str) -> str:
+        now = int(time.time())
+        header = {
+            "alg": "EdDSA",
+            "typ": "JWT",
+            "kid": self.key_id,
+            "nonce": secrets.token_hex(16),
+        }
+        payload = {
+            "iss": "cdp",
+            "sub": self.key_id,
+            "nbf": now,
+            "exp": now + 120,
+            "uri": f"{method} {self.host}{self.base_path}{endpoint}",
+        }
+        signing_input = (
+            f"{_base64url(json.dumps(header, separators=(',', ':')))}."
+            f"{_base64url(json.dumps(payload, separators=(',', ':')))}"
+        )
+        signature = self.private_key.sign(signing_input.encode("utf-8"))
+        return f"{signing_input}.{_base64url(signature)}"
+
+
+def create_cdp_auth_headers(
+    facilitator_url: str,
+    auth_config: FacilitatorAuthConfig,
+):
+    key_id = os.environ.get(auth_config.apiKeyIdEnv)
+    key_secret = os.environ.get(auth_config.apiKeySecretEnv)
+    if not key_id or not key_secret:
+        raise RuntimeError(
+            f"{auth_config.apiKeyIdEnv} and {auth_config.apiKeySecretEnv} "
+            "must be set for CDP facilitator auth"
+        )
+
+    parsed = urlparse(facilitator_url)
+    base_path = parsed.path.rstrip("/")
+    signer = CdpJwtSigner(
+        key_id=key_id,
+        private_key=_load_private_key(key_secret),
+        host=parsed.netloc,
+        base_path=base_path,
+    )
+
+    def headers_for(method: str, endpoint: str) -> dict[str, str]:
+        return {"Authorization": f"Bearer {signer.sign(method, endpoint)}"}
+
+    def create_headers() -> dict[str, dict[str, str]]:
+        return {
+            "verify": headers_for("POST", "/verify"),
+            "settle": headers_for("POST", "/settle"),
+            "supported": headers_for("GET", "/supported"),
+            "bazaar": headers_for("GET", "/bazaar"),
+        }
+
+    return create_headers

--- a/dream-server/extensions/services/x402-gateway/app/config.py
+++ b/dream-server/extensions/services/x402-gateway/app/config.py
@@ -14,6 +14,18 @@ class SellerConfig(BaseModel):
     facilitatorUrl: HttpUrl = Field(default="https://x402.org/facilitator")
 
 
+class FacilitatorAuthConfig(BaseModel):
+    type: Literal["none", "cdp_api_key"] = "none"
+    apiKeyIdEnv: str = "CDP_API_KEY_ID"
+    apiKeySecretEnv: str = "CDP_API_KEY_SECRET"
+
+
+class FacilitatorConfig(BaseModel):
+    url: HttpUrl = Field(default="https://x402.org/facilitator")
+    provider: Literal["x402.org", "cdp", "custom"] = "x402.org"
+    auth: FacilitatorAuthConfig = Field(default_factory=FacilitatorAuthConfig)
+
+
 class PolicyConfig(BaseModel):
     mode: Literal["allowlist"] = "allowlist"
     unprotectedByDefault: bool = True
@@ -75,6 +87,7 @@ class RouteRule(BaseModel):
 class GatewayConfig(BaseModel):
     enabled: bool = True
     seller: SellerConfig
+    facilitator: FacilitatorConfig | None = None
     policy: PolicyConfig = Field(default_factory=PolicyConfig)
     audit: AuditConfig = Field(default_factory=AuditConfig)
     rules: list[RouteRule] = Field(default_factory=list)
@@ -90,6 +103,11 @@ class GatewayConfig(BaseModel):
                     raise ValueError(f"duplicate route rule for {method} {rule.path}")
                 seen.add(key)
         return value
+
+    def facilitator_url(self) -> str:
+        if self.facilitator:
+            return str(self.facilitator.url)
+        return str(self.seller.facilitatorUrl)
 
 
 def load_config(path: str | Path) -> GatewayConfig:

--- a/dream-server/extensions/services/x402-gateway/app/config.py
+++ b/dream-server/extensions/services/x402-gateway/app/config.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field, HttpUrl, field_validator
+
+
+class SellerConfig(BaseModel):
+    network: str = "eip155:84532"
+    asset: str = "USDC"
+    recipient: str
+    facilitatorUrl: HttpUrl = Field(default="https://x402.org/facilitator")
+
+
+class PolicyConfig(BaseModel):
+    mode: Literal["allowlist"] = "allowlist"
+    unprotectedByDefault: bool = True
+    devBypass: bool = False
+
+
+class AuditConfig(BaseModel):
+    logPayments: bool = True
+    logUnpaidAttempts: bool = True
+
+
+class PriceConfig(BaseModel):
+    amount: str
+    currency: str = "USDC"
+
+    @field_validator("amount")
+    @classmethod
+    def amount_must_be_positive(cls, value: str) -> str:
+        try:
+            parsed = float(value)
+        except ValueError as exc:
+            raise ValueError("price amount must be numeric") from exc
+        if parsed <= 0:
+            raise ValueError("price amount must be positive")
+        return value
+
+
+class RuleMetadata(BaseModel):
+    title: str | None = None
+    description: str | None = None
+    mimeType: str = "application/json"
+
+
+class RouteRule(BaseModel):
+    name: str
+    kind: Literal["http_route"] = "http_route"
+    path: str
+    methods: list[str] = Field(default_factory=lambda: ["POST"])
+    upstream: HttpUrl
+    price: PriceConfig
+    metadata: RuleMetadata = Field(default_factory=RuleMetadata)
+
+    @field_validator("path")
+    @classmethod
+    def path_must_be_absolute(cls, value: str) -> str:
+        if not value.startswith("/"):
+            raise ValueError("route path must start with /")
+        return value
+
+    @field_validator("methods")
+    @classmethod
+    def normalize_methods(cls, value: list[str]) -> list[str]:
+        methods = [method.upper() for method in value]
+        if not methods:
+            raise ValueError("at least one method is required")
+        return methods
+
+
+class GatewayConfig(BaseModel):
+    enabled: bool = True
+    seller: SellerConfig
+    policy: PolicyConfig = Field(default_factory=PolicyConfig)
+    audit: AuditConfig = Field(default_factory=AuditConfig)
+    rules: list[RouteRule] = Field(default_factory=list)
+
+    @field_validator("rules")
+    @classmethod
+    def require_unique_routes(cls, value: list[RouteRule]) -> list[RouteRule]:
+        seen: set[tuple[str, str]] = set()
+        for rule in value:
+            for method in rule.methods:
+                key = (method, rule.path)
+                if key in seen:
+                    raise ValueError(f"duplicate route rule for {method} {rule.path}")
+                seen.add(key)
+        return value
+
+
+def load_config(path: str | Path) -> GatewayConfig:
+    config_path = Path(path)
+    with config_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    return GatewayConfig.model_validate(payload)

--- a/dream-server/extensions/services/x402-gateway/app/gateway.py
+++ b/dream-server/extensions/services/x402-gateway/app/gateway.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from urllib.parse import urljoin
+
+import httpx
+from fastapi import Request, Response
+
+from .audit import AuditLog
+from .config import RouteRule
+
+
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+    "host",
+}
+
+
+def _forward_headers(request: Request) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in request.headers.items()
+        if key.lower() not in HOP_BY_HOP_HEADERS
+    }
+
+
+def _response_headers(response: httpx.Response) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in response.headers.items()
+        if key.lower() not in HOP_BY_HOP_HEADERS
+    }
+
+
+async def proxy_request(
+    request: Request,
+    rule: RouteRule,
+    client: httpx.AsyncClient,
+    audit: AuditLog,
+) -> Response:
+    body = await request.body()
+    upstream_url = str(rule.upstream)
+    if request.url.query:
+        upstream_url = f"{upstream_url}?{request.url.query}"
+
+    upstream = await client.request(
+        request.method,
+        upstream_url,
+        content=body,
+        headers=_forward_headers(request),
+    )
+
+    audit.write(
+        "paid_request_forwarded",
+        {
+            "method": request.method,
+            "path": request.url.path,
+            "upstream": str(rule.upstream),
+            "status_code": upstream.status_code,
+        },
+    )
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        headers=_response_headers(upstream),
+        media_type=upstream.headers.get("content-type"),
+    )

--- a/dream-server/extensions/services/x402-gateway/app/gateway.py
+++ b/dream-server/extensions/services/x402-gateway/app/gateway.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from urllib.parse import urljoin
-
 import httpx
 from fastapi import Request, Response
 

--- a/dream-server/extensions/services/x402-gateway/app/main.py
+++ b/dream-server/extensions/services/x402-gateway/app/main.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+import httpx
+import uvicorn
+from fastapi import FastAPI, HTTPException, Request, Response
+from x402.http.middleware.fastapi import PaymentMiddlewareASGI
+
+from .audit import AuditLog
+from .config import GatewayConfig, load_config
+from .gateway import proxy_request
+from .payments import build_resource_server, build_x402_routes
+from .policy import RoutePolicy
+
+
+CONFIG_PATH = os.environ.get("X402_CONFIG_PATH", "/config/config.json")
+AUDIT_LOG_PATH = os.environ.get("X402_AUDIT_LOG", "/data/audit.jsonl")
+PORT = int(os.environ.get("X402_GATEWAY_PORT_INTERNAL", "4020"))
+
+
+def create_app(config: GatewayConfig | None = None) -> FastAPI:
+    loaded = config or load_config(CONFIG_PATH)
+    app = FastAPI(title="Dream Server x402 Gateway")
+    app.state.config = loaded
+    app.state.policy = RoutePolicy(loaded)
+    app.state.audit = AuditLog(AUDIT_LOG_PATH)
+    app.state.http = httpx.AsyncClient(timeout=60.0, follow_redirects=False)
+
+    @app.on_event("shutdown")
+    async def shutdown_http_client() -> None:
+        await app.state.http.aclose()
+
+    @app.get("/health")
+    async def health() -> dict[str, object]:
+        return {
+            "ok": True,
+            "enabled": loaded.enabled,
+            "rules": len(loaded.rules),
+        }
+
+    if loaded.enabled and not loaded.policy.devBypass:
+        app.add_middleware(
+            PaymentMiddlewareASGI,
+            routes=build_x402_routes(loaded),
+            server=build_resource_server(loaded),
+        )
+
+    for rule in loaded.rules:
+        handler = _handler_for_rule(rule.path)
+        for method in rule.methods:
+            app.add_api_route(
+                rule.path,
+                handler,
+                methods=[method],
+                name=f"x402_{method.lower()}_{rule.path.strip('/').replace('/', '_')}",
+            )
+
+    return app
+
+
+def _handler_for_rule(path: str) -> Callable[[Request], object]:
+    async def handler(request: Request) -> Response:
+        policy: RoutePolicy = request.app.state.policy
+        rule = policy.match(request.method, path)
+        if not rule:
+            raise HTTPException(status_code=404, detail="route_not_configured")
+        return await proxy_request(
+            request,
+            rule,
+            request.app.state.http,
+            request.app.state.audit,
+        )
+
+    return handler
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=PORT)

--- a/dream-server/extensions/services/x402-gateway/app/payments.py
+++ b/dream-server/extensions/services/x402-gateway/app/payments.py
@@ -5,6 +5,7 @@ from x402.http.types import RouteConfig
 from x402.mechanisms.evm.exact import ExactEvmServerScheme
 from x402.server import x402ResourceServer
 
+from .cdp_auth import create_cdp_auth_headers
 from .config import GatewayConfig
 
 
@@ -33,9 +34,20 @@ def build_x402_routes(config: GatewayConfig) -> dict[str, RouteConfig]:
 
 
 def build_resource_server(config: GatewayConfig):
-    facilitator = HTTPFacilitatorClient(
-        FacilitatorConfig(url=str(config.seller.facilitatorUrl))
-    )
+    facilitator_url = config.facilitator_url()
+    facilitator_config: FacilitatorConfig | dict[str, object]
+    if config.facilitator and config.facilitator.auth.type == "cdp_api_key":
+        facilitator_config = {
+            "url": facilitator_url,
+            "create_headers": create_cdp_auth_headers(
+                facilitator_url,
+                config.facilitator.auth,
+            ),
+        }
+    else:
+        facilitator_config = FacilitatorConfig(url=facilitator_url)
+
+    facilitator = HTTPFacilitatorClient(facilitator_config)
     server = x402ResourceServer(facilitator)
     server.register(config.seller.network, ExactEvmServerScheme())
     return server

--- a/dream-server/extensions/services/x402-gateway/app/payments.py
+++ b/dream-server/extensions/services/x402-gateway/app/payments.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from x402.http import FacilitatorConfig, HTTPFacilitatorClient, PaymentOption
+from x402.http.types import RouteConfig
+from x402.mechanisms.evm.exact import ExactEvmServerScheme
+from x402.server import x402ResourceServer
+
+from .config import GatewayConfig
+
+
+def _price(amount: str) -> str:
+    return f"${amount}"
+
+
+def build_x402_routes(config: GatewayConfig) -> dict[str, RouteConfig]:
+    routes: dict[str, RouteConfig] = {}
+    for rule in config.rules:
+        for method in rule.methods:
+            route_key = f"{method.upper()} {rule.path}"
+            routes[route_key] = RouteConfig(
+                accepts=[
+                    PaymentOption(
+                        scheme="exact",
+                        pay_to=config.seller.recipient,
+                        price=_price(rule.price.amount),
+                        network=config.seller.network,
+                    ),
+                ],
+                mime_type=rule.metadata.mimeType,
+                description=rule.metadata.description or rule.name,
+            )
+    return routes
+
+
+def build_resource_server(config: GatewayConfig):
+    facilitator = HTTPFacilitatorClient(
+        FacilitatorConfig(url=str(config.seller.facilitatorUrl))
+    )
+    server = x402ResourceServer(facilitator)
+    server.register(config.seller.network, ExactEvmServerScheme())
+    return server

--- a/dream-server/extensions/services/x402-gateway/app/policy.py
+++ b/dream-server/extensions/services/x402-gateway/app/policy.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from .config import GatewayConfig, RouteRule
+
+
+class RoutePolicy:
+    def __init__(self, config: GatewayConfig) -> None:
+        self._routes: dict[tuple[str, str], RouteRule] = {}
+        for rule in config.rules:
+            for method in rule.methods:
+                self._routes[(method.upper(), rule.path)] = rule
+
+    def match(self, method: str, path: str) -> RouteRule | None:
+        return self._routes.get((method.upper(), path))
+
+    def rules(self) -> list[RouteRule]:
+        return list({id(rule): rule for rule in self._routes.values()}.values())

--- a/dream-server/extensions/services/x402-gateway/compose.yaml.disabled
+++ b/dream-server/extensions/services/x402-gateway/compose.yaml.disabled
@@ -1,0 +1,44 @@
+services:
+  x402-gateway:
+    build:
+      context: ./extensions/services/x402-gateway
+      dockerfile: Dockerfile
+    image: dream-x402-gateway:local
+    container_name: dream-x402-gateway
+    restart: unless-stopped
+    depends_on:
+      - llama-server
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - X402_CONFIG_PATH=/config/config.json
+      - X402_AUDIT_LOG=/data/audit.jsonl
+      - X402_GATEWAY_PORT_INTERNAL=4020
+    volumes:
+      - ./config/x402:/config:ro,z
+      - ./data/x402:/data:z
+    ports:
+      - "${X402_GATEWAY_BIND:-127.0.0.1}:${X402_GATEWAY_PORT:-4020}:4020"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: ${X402_GATEWAY_MEMORY_LIMIT:-256M}
+        reservations:
+          cpus: '0.05'
+          memory: 64M
+    healthcheck:
+      test:
+        - CMD
+        - python
+        - -c
+        - "import urllib.request; urllib.request.urlopen('http://127.0.0.1:4020/health', timeout=3)"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/x402-gateway/compose.yaml.disabled
+++ b/dream-server/extensions/services/x402-gateway/compose.yaml.disabled
@@ -14,6 +14,8 @@ services:
       - X402_CONFIG_PATH=/config/config.json
       - X402_AUDIT_LOG=/data/audit.jsonl
       - X402_GATEWAY_PORT_INTERNAL=4020
+      - CDP_API_KEY_ID=${CDP_API_KEY_ID:-}
+      - CDP_API_KEY_SECRET=${CDP_API_KEY_SECRET:-}
     volumes:
       - ./config/x402:/config:ro,z
       - ./data/x402:/data:z

--- a/dream-server/extensions/services/x402-gateway/manifest.yaml
+++ b/dream-server/extensions/services/x402-gateway/manifest.yaml
@@ -1,0 +1,55 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: x402-gateway
+  name: x402 Gateway
+  aliases: [x402, paid-api, payments]
+  container_name: dream-x402-gateway
+  default_host: x402-gateway
+  port: 4020
+  external_port_env: X402_GATEWAY_PORT
+  external_port_default: 4020
+  health: /health
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: [llama-server]
+  description: >
+    Optional HTTP 402 payment gateway for Dream Server routes. The gateway
+    protects only explicit allowlisted routes from config/x402/config.json and
+    proxies paid requests to existing Dream services.
+
+  env_vars:
+    - key: X402_GATEWAY_PORT
+      required: false
+      default: "4020"
+      description: Host port the x402 gateway listens on
+    - key: X402_GATEWAY_BIND
+      required: false
+      default: "127.0.0.1"
+      description: Bind address for the gateway host port
+    - key: X402_CONFIG_PATH
+      required: false
+      default: "/config/config.json"
+      description: Path to the x402 gateway JSON config inside the container
+
+features:
+  - id: x402-paid-routes
+    name: Paid HTTP routes
+    description: x402 payment protection for explicit Dream Server HTTP routes
+    icon: BadgeDollarSign
+    category: networking
+    requirements:
+      services: [x402-gateway]
+      vram_gb: 0
+    enabled_services_all: [x402-gateway]
+    setup_time: ~2 minutes
+    priority: 55
+    launch:
+      type: service
+      service: x402-gateway
+    gpu_backends: [all]

--- a/dream-server/extensions/services/x402-gateway/manifest.yaml
+++ b/dream-server/extensions/services/x402-gateway/manifest.yaml
@@ -36,6 +36,14 @@ service:
       required: false
       default: "/config/config.json"
       description: Path to the x402 gateway JSON config inside the container
+    - key: CDP_API_KEY_ID
+      required: false
+      secret: true
+      description: CDP API key ID for the Coinbase x402 facilitator on mainnet
+    - key: CDP_API_KEY_SECRET
+      required: false
+      secret: true
+      description: Base64 CDP Ed25519 API key secret for facilitator auth
 
 features:
   - id: x402-paid-routes

--- a/dream-server/extensions/services/x402-gateway/requirements.txt
+++ b/dream-server/extensions/services/x402-gateway/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.116.1
+cryptography==46.0.3
 httpx==0.28.1
 pydantic==2.11.7
 uvicorn[standard]==0.35.0

--- a/dream-server/extensions/services/x402-gateway/requirements.txt
+++ b/dream-server/extensions/services/x402-gateway/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.116.1
+httpx==0.28.1
+pydantic==2.11.7
+uvicorn[standard]==0.35.0
+x402[fastapi,evm]==2.13.0

--- a/dream-server/lib/service-registry.sh
+++ b/dream-server/lib/service-registry.sh
@@ -287,6 +287,7 @@ sr_list_enabled() {
         local cf="${SERVICE_COMPOSE[$sid]}"
         [[ -n "$cf" && -f "$cf" ]] && echo "$sid"
     done
+    return 0
 }
 
 # Get display name for a service ID


### PR DESCRIPTION
## Summary
- Add an optional disabled-by-default x402 payment gateway extension for Dream Server.
- Protect only explicitly configured HTTP routes through an allowlist policy.
- Include config example, Dockerfile, compose stub, service manifest, audit logging, CDP facilitator auth support, and gateway docs.

## Scope
This PR is intentionally only the x402 gateway extension branch, not the later nous-hackathon vendor-contract/streaming branch.

## Testing
- Not rerun in this PR creation step.
- Branch commits include x402 gateway implementation and audit/CDP auth updates.

## Review notes
Please focus on extension isolation, default-disabled behavior, payment route allowlisting, facilitator auth, config safety, and whether this belongs as an optional extension without affecting core Dream Server services.