### PR TITLE
fix(openclaw): publish UI through Docker host bind

### DIFF
--- a/dream-server/extensions/services/openclaw/compose.yaml
+++ b/dream-server/extensions/services/openclaw/compose.yaml
@@ -23,13 +23,14 @@ services:
       - OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH=${OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH:-}
       - HOME=/home/node
     user: "0:0"
-    # Gateway bind mode tracks BIND_ADDRESS: a loopback bind (127.0.0.1 /
-    # localhost / ::1) binds the gateway to localhost so the process-level
-    # binding matches the localhost intent; any widened bind exposes it on the
-    # LAN interface. The unconfigured-gateway flag is dropped: inject-token.js
-    # always writes the merged config to /tmp/openclaw-config.json
-    # (OPENCLAW_CONFIG_PATH), so the gateway is always configured at start.
-    entrypoint: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.openclaw; exec setpriv --reuid=1000 --regid=1000 --clear-groups /bin/sh -c 'node /config/inject-token.js; export OPENCLAW_CONFIG_PATH=/tmp/openclaw-config.json; case \"$${BIND_ADDRESS:-127.0.0.1}\" in 127.0.0.1|localhost|::1) BIND_MODE=localhost ;; *) BIND_MODE=lan ;; esac; exec docker-entrypoint.sh node openclaw.mjs gateway --bind \"$$BIND_MODE\"'"]
+    # OpenClaw's bind flag is process-level inside the container. Even when
+    # Dream binds the published host port to 127.0.0.1, the gateway must listen
+    # on a container-reachable interface or Docker's port publishing cannot
+    # reach it. Host exposure is still controlled by the ports mapping below.
+    # The unconfigured-gateway flag is dropped: inject-token.js always writes
+    # the merged config to /tmp/openclaw-config.json (OPENCLAW_CONFIG_PATH), so
+    # the gateway is always configured at start.
+    entrypoint: ["/bin/sh", "-c", "chown -R 1000:1000 /home/node/.openclaw; exec setpriv --reuid=1000 --regid=1000 --clear-groups /bin/sh -c 'node /config/inject-token.js; export OPENCLAW_CONFIG_PATH=/tmp/openclaw-config.json; exec docker-entrypoint.sh node openclaw.mjs gateway --bind lan'"]
     volumes:
       - ./config/openclaw:/config:ro,z
       - ./data/openclaw:/data:z

--- a/dream-server/tests/contracts/test-network-exposure-contracts.py
+++ b/dream-server/tests/contracts/test-network-exposure-contracts.py
@@ -133,6 +133,7 @@ def test_dashboard_csp_allows_dream_talk_tts_blob_audio() -> None:
 
 def test_openclaw_stays_deprecated_optional_and_token_gated() -> None:
     manifest = read(SERVICES / "openclaw" / "manifest.yaml")
+    compose = read(SERVICES / "openclaw" / "compose.yaml")
     docs = read(ROOT / "docs" / "OPENCLAW-INTEGRATION.md")
     policy = json.loads(read(POLICY))["services"]["openclaw"]
 
@@ -140,6 +141,22 @@ def test_openclaw_stays_deprecated_optional_and_token_gated() -> None:
     assert_true(manifest_value(manifest, "category") == "optional", "OpenClaw must stay optional")
     assert_true("OPENCLAW_TOKEN" in manifest, "OpenClaw manifest must require a token")
     assert_true(policy["lan_exposure"] == "opt-in-only", "OpenClaw policy must stay opt-in-only")
+    assert_true(
+        '"${BIND_ADDRESS:-127.0.0.1}:${OPENCLAW_PORT:-7860}:18789"' in compose,
+        "OpenClaw host exposure must stay controlled by the published host bind address",
+    )
+    assert_true(
+        "--bind lan" in compose,
+        "OpenClaw must listen on a Docker-publishable container interface",
+    )
+    assert_true(
+        "--bind localhost" not in compose and "BIND_MODE=localhost" not in compose,
+        "OpenClaw image 2026.3.8 rejects localhost as a gateway bind mode",
+    )
+    assert_true(
+        "--bind loopback" not in compose and "BIND_MODE=loopback" not in compose,
+        "OpenClaw loopback bind is container-local and breaks the published host UI",
+    )
     assert_true("DEPRECATED" in docs, "OpenClaw docs must keep the deprecation notice")
 
 


### PR DESCRIPTION
## Summary

This fixes the OpenClaw UI publish path after the recent bind-mode change. The current `main` compose path passes `--bind localhost`, but the pinned OpenClaw image rejects that value at startup. The older `loopback` mode starts successfully inside the container, but it binds only to the container loopback interface, so Docker port publishing cannot reach the UI from the host.

The fix keeps host exposure controlled by the existing Docker `ports:` mapping:

```yaml
${BIND_ADDRESS:-127.0.0.1}:${OPENCLAW_PORT:-7860}:18789
```

OpenClaw now listens on a Docker-publishable container interface with `--bind lan`, while `BIND_ADDRESS` continues to decide whether the host publishes the UI on loopback only or on a wider interface.

## Why this is needed

Observed on macOS Docker Desktop with the active Dream stack:

| Compose behavior | Container health | Host `127.0.0.1:7860` | Result |
| --- | --- | --- | --- |
| `--bind loopback` | healthy | empty reply | False healthy; UI unreachable from host |
| `--bind localhost` | restarting | connection refused | Image rejects the bind mode |
| `--bind lan` with host `BIND_ADDRESS=127.0.0.1` | healthy | HTTP 200 | UI reachable, host exposure still loopback-only |

This is not macOS-specific. Docker published ports reach the container network interface, not the service loopback inside the container, so the same contract matters on Linux, Windows Docker Desktop, and WSL-backed Docker.

## Validation

- `python3 dream-server/tests/contracts/test-network-exposure-contracts.py`
- `WEBUI_SECRET=ci-placeholder SEARXNG_SECRET=ci-placeholder N8N_USER=ci@example.com N8N_PASS=ci-placeholder LITELLM_KEY=ci-placeholder OPENCLAW_TOKEN=ci-placeholder docker compose -f docker-compose.base.yml -f extensions/services/openclaw/compose.yaml config --quiet`
- `bash dream-server/tests/test-validate-manifests.sh`
- `bash dream-server/tests/test-service-registry.sh`
- `git diff --check`
- Runtime smoke on macOS Docker Desktop:
  - `dream-openclaw` healthy
  - `dream-cli status --json` reports `openclaw healthy running 7860`
  - `curl -fsS http://127.0.0.1:7860/` returns the OpenClaw UI HTML

## Risk

Low and scoped to the deprecated optional OpenClaw service. The change does not widen host exposure by itself; published host binding remains controlled by `BIND_ADDRESS` in the existing `ports:` mapping.