### PR TITLE
fix(dashboard): route LAN and extension links to usable UI surfaces

### DIFF
--- a/dream-server/config/extensions-catalog.json
+++ b/dream-server/config/extensions-catalog.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-24T03:20:28Z",
+  "generated_at": "2026-06-25T20:50:12Z",
   "schema_version": "1.0.0",
   "extensions": [
     {
@@ -17,6 +17,8 @@
       "port": 0,
       "external_port_default": 0,
       "health_endpoint": "",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "OPENAI_API_KEY",
@@ -70,6 +72,8 @@
       "port": 3001,
       "external_port_default": 7800,
       "health_endpoint": "/api/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "ANYTHINGLLM_JWT_SECRET",
@@ -150,6 +154,8 @@
       "port": 7860,
       "external_port_default": 7863,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "audio-generation",
@@ -218,6 +224,8 @@
       "port": 9200,
       "external_port_default": 9200,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "BARK_USE_SMALL_MODELS",
@@ -323,6 +331,8 @@
       "port": 80,
       "external_port_default": 3007,
       "health_endpoint": "/api/_health/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "database",
@@ -422,6 +432,8 @@
       "port": 8000,
       "external_port_default": 8000,
       "health_endpoint": "/api/v2/heartbeat",
+      "ui_path": "/docs/",
+      "external_link": true,
       "env_vars": [],
       "tags": [],
       "features": [
@@ -462,6 +474,8 @@
       "port": 8080,
       "external_port_default": 8890,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [],
       "features": [
@@ -505,6 +519,8 @@
       "port": 8501,
       "external_port_default": 8501,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "multi-agent",
@@ -621,6 +637,8 @@
       "port": 5001,
       "external_port_default": 8002,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "DIFY_SECRET_KEY",
@@ -693,6 +711,8 @@
       "port": 3000,
       "external_port_default": 7801,
       "health_endpoint": "/api/v1/ping",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "FLOWISE_USERNAME",
@@ -776,6 +796,8 @@
       "port": 7865,
       "external_port_default": 7865,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [],
       "features": [
@@ -815,6 +837,8 @@
       "port": 7861,
       "external_port_default": 7861,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "image",
@@ -923,6 +947,8 @@
       "port": 5000,
       "external_port_default": 8971,
       "health_endpoint": "/api/version",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "FRIGATE_RTSP_PASSWORD",
@@ -1038,6 +1064,8 @@
       "port": 4200,
       "external_port_default": 7822,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "GAIA_AGENT_UI_VERSION",
@@ -1122,6 +1150,8 @@
       "port": 3000,
       "external_port_default": 7830,
       "health_endpoint": "/api/healthz",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "GITEA_HOST",
@@ -1161,6 +1191,8 @@
       "port": 2283,
       "external_port_default": 2283,
       "health_endpoint": "/api/server/ping",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "IMMICH_DB_PASSWORD",
@@ -1208,6 +1240,8 @@
       "port": 9090,
       "external_port_default": 9090,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "image-generation",
@@ -1302,6 +1336,8 @@
       "port": 1337,
       "external_port_default": 1337,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "llm",
@@ -1349,6 +1385,8 @@
       "port": 8888,
       "external_port_default": 8889,
       "health_endpoint": "/tree",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "JUPYTER_TOKEN",
@@ -1395,6 +1433,8 @@
       "port": 8080,
       "external_port_default": 8086,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "labeling",
@@ -1439,6 +1479,8 @@
       "port": 7860,
       "external_port_default": 7802,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "visual",
@@ -1512,6 +1554,8 @@
       "port": 3080,
       "external_port_default": 3080,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "JWT_SECRET",
@@ -1642,6 +1686,8 @@
       "port": 8080,
       "external_port_default": 7803,
       "health_endpoint": "/healthz",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [],
       "features": [
@@ -1745,6 +1791,8 @@
       "port": 19530,
       "external_port_default": 19530,
       "health_endpoint": "/healthz",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [],
       "features": []
@@ -1763,6 +1811,8 @@
       "port": 11434,
       "external_port_default": 7804,
       "health_endpoint": "/api/tags",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "OLLAMA_MODEL",
@@ -1810,6 +1860,8 @@
       "port": 8080,
       "external_port_default": 7805,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "OPEN_INTERPRETER_API_KEY",
@@ -1877,6 +1929,8 @@
       "port": 8000,
       "external_port_default": 7807,
       "health_endpoint": "/accounts/login/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "PAPERLESS_SECRET_KEY",
@@ -1982,6 +2036,8 @@
       "port": 10200,
       "external_port_default": 10200,
       "health_endpoint": "",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "PIPER_VOICE",
@@ -2026,6 +2082,8 @@
       "port": 7865,
       "external_port_default": 7809,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "RVC_API_KEY",
@@ -2074,6 +2132,8 @@
       "port": 8000,
       "external_port_default": 8001,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [],
       "features": [
@@ -2111,6 +2171,8 @@
       "port": 7860,
       "external_port_default": 7862,
       "health_endpoint": "/",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [
         "llm",
@@ -2203,6 +2265,8 @@
       "port": 8080,
       "external_port_default": 7811,
       "health_endpoint": "/v1/.well-known/ready",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [
         {
           "key": "WEAVIATE_API_KEY",
@@ -2289,6 +2353,8 @@
       "port": 80,
       "external_port_default": 8100,
       "health_endpoint": "/health",
+      "ui_path": "/",
+      "external_link": true,
       "env_vars": [],
       "tags": [],
       "features": []

--- a/dream-server/extensions/library/services/chromadb/README.md
+++ b/dream-server/extensions/library/services/chromadb/README.md
@@ -18,7 +18,8 @@ Your data is preserved when disabling. To re-enable later: `dream enable chromad
 
 ## Access
 
-- **URL:** `http://localhost:8000`
+- **API docs:** `http://localhost:8000/docs/`
+- **REST API:** `http://localhost:8000`
 
 ## First-Time Setup
 

--- a/dream-server/extensions/library/services/chromadb/compose.yaml
+++ b/dream-server/extensions/library/services/chromadb/compose.yaml
@@ -17,12 +17,6 @@ services:
         limits:
           memory: 2G
           cpus: '2.0'
-    healthcheck:
-      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/v2/heartbeat')\""]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s
     networks:
       - dream-network
 

--- a/dream-server/extensions/library/services/chromadb/manifest.yaml
+++ b/dream-server/extensions/library/services/chromadb/manifest.yaml
@@ -11,6 +11,7 @@ service:
   external_port_env: CHROMADB_PORT
   external_port_default: 8000
   health: /api/v2/heartbeat
+  ui_path: /docs/
   type: docker
   gpu_backends: [amd, nvidia, apple]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/ape/manifest.yaml
+++ b/dream-server/extensions/services/ape/manifest.yaml
@@ -13,7 +13,7 @@ service:
   external_port_env: APE_PORT
   external_port_default: 7890
   health: /health
-  ui_path: /
+  ui_path: /docs
   type: docker
   gpu_backends: [all]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/dashboard-api/config.py
+++ b/dream-server/extensions/services/dashboard-api/config.py
@@ -52,6 +52,21 @@ def _read_manifest_file(path: Path) -> dict[str, Any]:
     return data
 
 
+def _manifest_bool(value: Any, default: bool) -> bool:
+    """Normalize manifest booleans without treating "false" as truthy."""
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)
+
+
 def load_extension_manifests(
     manifest_dir: Path, gpu_backend: str,
 ) -> tuple[dict[str, dict[str, Any]], list[dict[str, Any]], list[dict[str, str]]]:
@@ -126,11 +141,11 @@ def load_extension_manifests(
                     "health": service.get("health", "/health"),
                     "name": service.get("name", service_id),
                     "ui_path": service.get("ui_path", "/"),
-                    "external_link": bool(service.get("external_link", True)),
+                    "external_link": _manifest_bool(service.get("external_link"), True),
                     "container_name": service.get("container_name", f"dream-{service_id}"),
                     "depends_on": service.get("depends_on", []),
                     "category": service.get("category", "optional"),
-                    "host_network": bool(service.get("host_network", False)),
+                    "host_network": _manifest_bool(service.get("host_network"), False),
                     "setup_hook": service.get("setup_hook", ""),
                     "hooks": service.get("hooks", {}),
                     "gpu_backends": service.get("gpu_backends", []),

--- a/dream-server/extensions/services/dashboard-api/routers/features.py
+++ b/dream-server/extensions/services/dashboard-api/routers/features.py
@@ -15,6 +15,40 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["features"])
 
+LAN_ROUTE_SUBDOMAINS = {"api", "auth", "chat", "dashboard", "hermes", "talk"}
+
+
+def _strip_lan_route_subdomain(hostname: str) -> str:
+    """Return the parent <device>.local host for known dream-proxy subdomains."""
+    parts = (hostname or "localhost").split(".")
+    if len(parts) >= 3 and parts[-1] == "local" and parts[0] in LAN_ROUTE_SUBDOMAINS:
+        return ".".join(parts[1:])
+    return hostname or "localhost"
+
+
+def _format_host_for_url(hostname: str) -> str:
+    if ":" in hostname and not hostname.startswith("["):
+        return f"[{hostname}]"
+    return hostname
+
+
+def _hostname_from_host_header(host_header: str) -> str:
+    host = (host_header or "localhost").strip()
+    if host.startswith("["):
+        end = host.find("]")
+        return host[1:end] if end != -1 else host.strip("[]")
+    return host.rsplit(":", 1)[0] if ":" in host else host
+
+
+def _dream_proxy_entry_url(request: Request, port: int) -> str:
+    forwarded_host = request.headers.get("x-forwarded-host")
+    host_header = forwarded_host or request.headers.get("host") or "localhost"
+    hostname = _hostname_from_host_header(host_header)
+    hostname = _strip_lan_route_subdomain(hostname)
+    scheme = request.headers.get("x-forwarded-proto") or request.url.scheme or "http"
+    port_suffix = "" if int(port or 80) == 80 else f":{port}"
+    return f"{scheme}://{_format_host_for_url(hostname)}{port_suffix}"
+
 
 def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[GPUInfo]) -> dict:
     """Calculate whether a feature can be enabled and its status."""
@@ -216,14 +250,15 @@ async def feature_enable_instructions(
     comfyui_url = _svc_url("comfyui")
     opencode_url = _svc_url("opencode")
     hermes_url = _svc_url("hermes-proxy")
-    dream_proxy_url = _svc_url("dream-proxy")
+    dream_proxy_port = _svc_port("dream-proxy")
+    dream_proxy_url = _dream_proxy_entry_url(request, dream_proxy_port) if dream_proxy_port else ""
 
     instructions = {
         "lan-web": {
             "steps": [
                 "Enable the dream-proxy extension from Extensions, or run: dream enable dream-proxy",
                 "Start or restart Dream Server so dream-proxy listens on port 80",
-                "Use the LAN hostnames such as dashboard.<device>.local, chat.<device>.local, and talk.<device>.local",
+                "Use http://<device>.local when mDNS/DNS subdomains are available; direct IP or localhost access falls back to Chat",
             ],
             "links": [{"label": "Open LAN entry", "url": dream_proxy_url}] if dream_proxy_url else [],
         },

--- a/dream-server/extensions/services/dashboard-api/tests/test_config.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_config.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 import config
-from config import _detect_container_default_gateway, load_extension_manifests, _read_manifest_file
+from config import _detect_container_default_gateway, load_extension_manifests, _manifest_bool, _read_manifest_file
 
 
 VALID_MANIFEST = """\
@@ -144,6 +144,39 @@ class TestLoadExtensionManifests:
         services, _, _ = load_extension_manifests(tmp_path, "nvidia")
 
         assert services["host-network-service"]["host_network"] is True
+
+    def test_preserves_external_link_false(self, tmp_path):
+        svc_dir = tmp_path / "api-only-service"
+        svc_dir.mkdir()
+        (svc_dir / "manifest.yaml").write_text(
+            "schema_version: dream.services.v1\n"
+            "service:\n"
+            "  id: api-only-service\n"
+            "  name: API Only Service\n"
+            "  port: 9191\n"
+            "  external_link: false\n"
+        )
+
+        services, _, _ = load_extension_manifests(tmp_path, "nvidia")
+
+        assert services["api-only-service"]["external_link"] is False
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (None, True),
+            (False, False),
+            (True, True),
+            ("false", False),
+            ("no", False),
+            ("0", False),
+            ("true", True),
+            ("yes", True),
+            ("1", True),
+        ],
+    )
+    def test_manifest_bool_accepts_yaml_and_env_style_values(self, raw, expected):
+        assert _manifest_bool(raw, True) is expected
 
     def test_skips_wrong_schema_version(self, tmp_path):
         svc_dir = tmp_path / "old-service"

--- a/dream-server/extensions/services/dashboard-api/tests/test_features.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_features.py
@@ -377,7 +377,33 @@ class TestFeatureEnableInstructions:
         assert "port 80" in steps
         assert data["instructions"]["links"][0] == {
             "label": "Open LAN entry",
-            "url": "http://dashboard.dream.local:80",
+            "url": "http://dream.local",
+        }
+
+    def test_lan_web_instructions_keep_loopback_entry_usable(self, test_client, monkeypatch):
+        test_features = [
+            {"id": "lan-web", "name": "LAN web entry", "description": "LAN entry",
+             "icon": "Globe", "category": "networking",
+             "setup_time": "Ready", "priority": 1,
+             "requirements": {"vram_gb": 0, "services": [], "services_any": []},
+             "enabled_services_all": ["dream-proxy"], "enabled_services_any": []}
+        ]
+        monkeypatch.setattr("routers.features.FEATURES", test_features)
+        monkeypatch.setattr(
+            "routers.features.SERVICES",
+            {"dream-proxy": {"external_port": 80}},
+        )
+
+        resp = test_client.get(
+            "/api/features/lan-web/enable",
+            headers={**test_client.auth_headers, "host": "127.0.0.1:3001"},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["instructions"]["links"][0] == {
+            "label": "Open LAN entry",
+            "url": "http://127.0.0.1",
         }
 
     def test_hermes_sso_instructions_open_access_management(self, test_client, monkeypatch):

--- a/dream-server/extensions/services/dashboard-api/tests/test_main.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_main.py
@@ -488,6 +488,45 @@ class TestExternalLinks:
         assert "open-webui" in link_ids
         assert "litellm" not in link_ids
 
+    def test_external_links_preserve_docs_paths_and_exclude_raw_backends(self, test_client, monkeypatch):
+        import config
+        monkeypatch.setattr(config, "SERVICES", {
+            "ape": {
+                "name": "APE (Agent Policy Engine)",
+                "port": 7890,
+                "external_port": 7890,
+                "health": "/health",
+                "ui_path": "/docs",
+                "host": "ape",
+            },
+            "embeddings": {
+                "name": "TEI (Embeddings)",
+                "port": 80,
+                "external_port": 8090,
+                "health": "/health",
+                "ui_path": "/docs",
+                "host": "embeddings",
+            },
+            "llama-server": {
+                "name": "llama-server (LLM Inference)",
+                "port": 8080,
+                "external_port": 8080,
+                "health": "/health",
+                "ui_path": "/",
+                "host": "llama-server",
+                "external_link": False,
+            },
+        })
+        monkeypatch.setattr("main.SERVICES", config.SERVICES)
+
+        resp = test_client.get("/api/external-links", headers=test_client.auth_headers)
+
+        assert resp.status_code == 200
+        links = {link["id"]: link for link in resp.json()}
+        assert links["ape"]["ui_path"] == "/docs"
+        assert links["embeddings"]["ui_path"] == "/docs"
+        assert "llama-server" not in links
+
 
 # --- /api/storage ---
 

--- a/dream-server/extensions/services/dashboard-api/tests/test_user_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/tests/test_user_extensions.py
@@ -46,9 +46,12 @@ class TestScanUserExtensions:
         """Extension with compose.yaml + manifest returns correct config."""
         user_dir = tmp_path / "user"
         ext_dir = user_dir / "my-ext"
-        _write_manifest(ext_dir, _make_manifest("my-ext", port=9090,
-                                                 health="/api/health",
-                                                 name="My Extension"))
+        manifest = _make_manifest("my-ext", port=9090,
+                                  health="/api/health",
+                                  name="My Extension")
+        manifest["service"]["ui_path"] = "/docs/"
+        manifest["service"]["external_link"] = False
+        _write_manifest(ext_dir, manifest)
         (ext_dir / "compose.yaml").write_text("services:\n  my-ext:\n    image: test\n")
 
         result = scan_user_extension_services(user_dir)
@@ -58,6 +61,8 @@ class TestScanUserExtensions:
         assert cfg["port"] == 9090
         assert cfg["health"] == "/api/health"
         assert cfg["name"] == "My Extension"
+        assert cfg["ui_path"] == "/docs/"
+        assert cfg["external_link"] is False
 
     def test_scan_disabled_extension_skipped(self, tmp_path):
         """Extension with compose.yaml.disabled only is skipped."""

--- a/dream-server/extensions/services/dashboard-api/user_extensions.py
+++ b/dream-server/extensions/services/dashboard-api/user_extensions.py
@@ -86,6 +86,8 @@ def scan_user_extension_services(
                 "external_port": int(svc.get("external_port_default", port)),
                 "health": health,
                 "name": name,
+                "ui_path": svc.get("ui_path", "/"),
+                "external_link": svc.get("external_link", True),
                 # Optional: extensions whose health endpoint lives on a
                 # secondary port (e.g. milvus 9091) need an explicit
                 # health_port; check_service_health() falls back to "port"

--- a/dream-server/extensions/services/dashboard/src/components/Sidebar.jsx
+++ b/dream-server/extensions/services/dashboard/src/components/Sidebar.jsx
@@ -7,12 +7,10 @@ import {
 } from 'lucide-react'
 import { getSidebarExternalLinks, getSidebarNavItems } from '../plugins/registry'
 import { useTheme } from '../contexts/ThemeContext'
+import { buildExternalServiceUrl } from '../utils/externalUrls'
 
-// Derive external service URLs from current host
-const getExternalUrl = (port) =>
-  typeof window !== 'undefined'
-    ? `http://${window.location.hostname}:${port}`
-    : `http://localhost:${port}`
+// Derive external service URLs from current host.
+const getExternalUrl = (port, path = '', serviceId) => buildExternalServiceUrl({ port, path, serviceId })
 
 export default function Sidebar({ status, collapsed, onToggle }) {
   const { theme, cycleTheme, labels } = useTheme() // eslint-disable-line no-unused-vars -- theme switcher temporarily hidden

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -22,14 +22,10 @@ import {
 } from 'lucide-react'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { buildExternalServiceUrl } from '../utils/externalUrls'
 
-// Helper to build external service URLs from current host
-const getExternalUrl = (port, path = '') => {
-  const suffix = path && path !== '/' ? path : ''
-  return typeof window !== 'undefined'
-    ? `http://${window.location.hostname}:${port}${suffix}`
-    : `http://localhost:${port}${suffix}`
-}
+// Helper to build external service URLs from current host.
+const getExternalUrl = (port, path = '', serviceId) => buildExternalServiceUrl({ port, path, serviceId })
 
 // Compute overall health from services (excludes not_deployed from counts)
 function computeHealth(services) {
@@ -114,7 +110,7 @@ function pickFeatureLink(feature, services) {
   if (launch?.type === 'internal') return launch.path || null
   if (launch?.type === 'service') {
     const launchService = findHealthyService(services, launch.service)
-    return launchService ? getExternalUrl(launchService.port, launch.path) : null
+    return launchService ? getExternalUrl(launchService.port, launch.path, launch.service) : null
   }
 
   const req = feature?.requirements || {}

--- a/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -259,6 +259,15 @@ describe('Dashboard system overview', () => {
         launch: { type: 'none' },
         requirements: { servicesMissing: [] },
       },
+      {
+        id: 'lan-web',
+        name: 'LAN web entry',
+        description: 'Single port-80 entry',
+        icon: 'Globe',
+        status: 'enabled',
+        launch: { type: 'service', service: 'dream-proxy' },
+        requirements: { servicesMissing: [] },
+      },
     ]
 
     const statusWithLaunchTargets = {
@@ -267,6 +276,7 @@ describe('Dashboard system overview', () => {
         { id: 'llama-server', name: 'llama-server (LLM Inference)', status: 'healthy', port: 11434, uptime: 14400 },
         { id: 'open-webui', name: 'Open WebUI (Chat)', status: 'healthy', port: 3000, uptime: 14400 },
         { id: 'hermes-proxy', name: 'Hermes Auth Proxy', status: 'healthy', port: 9120, uptime: 14400 },
+        { id: 'dream-proxy', name: 'Dream Server (Web)', status: 'healthy', port: 80, uptime: 14400 },
       ],
     }
 
@@ -275,6 +285,7 @@ describe('Dashboard system overview', () => {
     expect(await screen.findByRole('link', { name: /AI Chat/ })).toHaveAttribute('href', 'http://localhost:3000')
     expect(screen.getByRole('link', { name: /Hermes Agent/ })).toHaveAttribute('href', 'http://localhost:9120')
     expect(screen.getByRole('link', { name: /Hermes Single Sign-On/ })).toHaveAttribute('href', '/invites')
+    expect(screen.getByRole('link', { name: /LAN web entry/ })).toHaveAttribute('href', 'http://localhost')
     expect(screen.queryByRole('link', { name: /Remote Access/ })).not.toBeInTheDocument()
     expect(screen.getByText('Remote Access')).toBeInTheDocument()
   })

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -15,6 +15,17 @@ export { getTemplateStatus }
 // API/backend services with no user-facing web UI — show badge instead of port link.
 const HEADLESS_EXTENSIONS = new Set(['embeddings', 'tts', 'whisper', 'privacy-shield'])
 
+const extensionPort = (ext) => ext.external_port_default || ext.port || 0
+
+const extensionUiPath = (ext) => {
+  const path = ext.ui_path || '/'
+  return path && path !== '/' ? path : ''
+}
+
+const extensionUrl = (ext) => `http://${window.location.hostname}:${extensionPort(ext)}${extensionUiPath(ext)}`
+
+const hasExternalUi = (ext) => ext.external_link !== false && !HEADLESS_EXTENSIONS.has(ext.id)
+
 // Auth: nginx injects "Authorization: Bearer ${DASHBOARD_API_KEY}" via
 // proxy_set_header for all /api/ requests (see nginx.conf).  All fetches
 // use relative URLs so they route through the nginx proxy which adds the
@@ -822,22 +833,22 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
         </div>
         <div className="flex items-center gap-2">
           <DependencyBadges dependsOn={ext.depends_on} dependencyStatus={ext.dependency_status} />
-          {status === 'enabled' && (ext.external_port_default || ext.port) && (ext.external_port_default || ext.port) !== 0 ? (
-            HEADLESS_EXTENSIONS.has(ext.id) ? (
+          {status === 'enabled' && extensionPort(ext) !== 0 ? (
+            !hasExternalUi(ext) ? (
               <span className="px-2 py-1 text-[9px] font-mono uppercase tracking-[0.12em] text-theme-text-muted/45">
                 API service
               </span>
             ) : (
               <a
-                href={`http://${window.location.hostname}:${ext.external_port_default || ext.port}`}
+                href={extensionUrl(ext)}
                 target="_blank"
                 rel="noopener noreferrer"
                 onClick={e => e.stopPropagation()}
                 className="flex items-center gap-1 px-2 py-1.5 text-[10px] font-mono text-theme-text-secondary hover:text-theme-text hover:bg-theme-surface-hover/40 rounded-lg transition-colors"
-                title={`Open on port ${ext.external_port_default || ext.port}`}
+                title={`Open ${ext.name} on port ${extensionPort(ext)}${extensionUiPath(ext)}`}
               >
                 <ExternalLink size={11} />
-                :{ext.external_port_default || ext.port}
+                :{extensionPort(ext)}
               </a>
             )
           ) : null}

--- a/dream-server/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/dream-server/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -258,4 +258,63 @@ describe('Extensions page — unhealthy + install derivations', () => {
     // L760-769: Check Logs button rendered when isUserExt && isUnhealthy.
     expect(screen.getByRole('button', { name: /Check Logs/i })).toBeInTheDocument()
   })
+
+  it('opens extension web links at their manifest ui_path', async () => {
+    installFetchMock({
+      extensions: [
+        {
+          id: 'chromadb',
+          name: 'ChromaDB',
+          status: 'enabled',
+          source: 'user',
+          installable: false,
+          port: 8000,
+          external_port_default: 8000,
+          ui_path: '/docs/',
+          external_link: true,
+          features: [baseFeature],
+          description: 'Vector database',
+        },
+      ],
+      summary: baseSummary({ installed: 1 }),
+      gpu_backend: 'apple',
+      agent_available: true,
+    })
+
+    render(<Extensions />)
+    await screen.findByText('ChromaDB')
+
+    expect(screen.getByRole('link', { name: ':8000' })).toHaveAttribute(
+      'href',
+      'http://localhost:8000/docs/',
+    )
+  })
+
+  it('does not render a port link when manifest disables external_link', async () => {
+    installFetchMock({
+      extensions: [
+        {
+          id: 'api-only',
+          name: 'API Only',
+          status: 'enabled',
+          source: 'user',
+          installable: false,
+          port: 7777,
+          external_port_default: 7777,
+          external_link: false,
+          features: [baseFeature],
+          description: 'Backend-only service',
+        },
+      ],
+      summary: baseSummary({ installed: 1 }),
+      gpu_backend: 'apple',
+      agent_available: true,
+    })
+
+    render(<Extensions />)
+    await screen.findByText('API Only')
+
+    expect(screen.getByText('API service')).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: ':7777' })).toBeNull()
+  })
 })

--- a/dream-server/extensions/services/dashboard/src/plugins/registry.js
+++ b/dream-server/extensions/services/dashboard/src/plugins/registry.js
@@ -61,12 +61,18 @@ export function getSidebarExternalLinks(context = {}) {
   }
   return deduped.map(link => {
     const healthy = link.alwaysHealthy ? true : isServiceHealthy(status, link.healthNeedles || [])
+    const uiPath = link.ui_path && link.ui_path !== '/' ? link.ui_path : ''
+    const url = link.url || (
+      typeof getExternalUrl === 'function'
+        ? getExternalUrl(link.port, uiPath, link.id)
+        : `http://localhost:${link.port}${uiPath}`
+    )
     return {
       key: link.id,
       label: link.label,
       icon: typeof link.icon === 'string' ? (ICON_MAP[link.icon] || ExternalLink) : (link.icon || ExternalLink),
       healthy,
-      url: (typeof getExternalUrl === 'function' ? getExternalUrl(link.port) : `http://localhost:${link.port}`) + (link.ui_path && link.ui_path !== '/' ? link.ui_path : ''),
+      url,
     }
   })
 }

--- a/dream-server/extensions/services/dashboard/src/utils/externalUrls.js
+++ b/dream-server/extensions/services/dashboard/src/utils/externalUrls.js
@@ -1,0 +1,27 @@
+const LAN_ROUTE_SUBDOMAINS = new Set(['api', 'auth', 'chat', 'dashboard', 'hermes', 'talk'])
+
+export function formatUrlHost(hostname = 'localhost') {
+  const host = String(hostname || 'localhost')
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host
+}
+
+export function stripLanRouteSubdomain(hostname = 'localhost') {
+  const host = String(hostname || 'localhost')
+  const parts = host.split('.')
+  if (parts.length >= 3 && parts.at(-1) === 'local' && LAN_ROUTE_SUBDOMAINS.has(parts[0])) {
+    return parts.slice(1).join('.')
+  }
+  return host
+}
+
+export function buildExternalServiceUrl({ port, path = '', serviceId, hostname } = {}) {
+  const browserHost = typeof window !== 'undefined' ? window.location.hostname : 'localhost'
+  const rawHost = hostname || browserHost
+  const targetHost = serviceId === 'dream-proxy' ? stripLanRouteSubdomain(rawHost) : rawHost
+  const cleanPath = path && path !== '/' ? path : ''
+  const portValue = Number(port)
+  const omitPort = serviceId === 'dream-proxy' && portValue === 80
+  const portPart = portValue && !omitPort ? `:${portValue}` : ''
+
+  return `http://${formatUrlHost(targetHost)}${portPart}${cleanPath}`
+}

--- a/dream-server/extensions/services/dashboard/src/utils/externalUrls.test.js
+++ b/dream-server/extensions/services/dashboard/src/utils/externalUrls.test.js
@@ -1,0 +1,21 @@
+import { buildExternalServiceUrl, formatUrlHost, stripLanRouteSubdomain } from './externalUrls'
+
+describe('external URL helpers', () => {
+  it('keeps direct localhost and IP dream-proxy entry on standard HTTP', () => {
+    expect(buildExternalServiceUrl({ serviceId: 'dream-proxy', port: 80, hostname: '127.0.0.1' })).toBe('http://127.0.0.1')
+    expect(buildExternalServiceUrl({ serviceId: 'dream-proxy', port: 80, hostname: 'localhost' })).toBe('http://localhost')
+    expect(buildExternalServiceUrl({ serviceId: 'dream-proxy', port: 80, hostname: '10.0.0.237' })).toBe('http://10.0.0.237')
+  })
+
+  it('collapses dream-proxy service subdomains back to the LAN entry host', () => {
+    expect(stripLanRouteSubdomain('dashboard.studio.local')).toBe('studio.local')
+    expect(stripLanRouteSubdomain('chat.macbook-air.local')).toBe('macbook-air.local')
+    expect(buildExternalServiceUrl({ serviceId: 'dream-proxy', port: 80, hostname: 'dashboard.studio.local' })).toBe('http://studio.local')
+  })
+
+  it('preserves non-standard proxy ports and formats IPv6 hosts', () => {
+    expect(buildExternalServiceUrl({ serviceId: 'dream-proxy', port: 8080, hostname: 'dashboard.studio.local' })).toBe('http://studio.local:8080')
+    expect(buildExternalServiceUrl({ serviceId: 'open-webui', port: 3000, hostname: '::1' })).toBe('http://[::1]:3000')
+    expect(formatUrlHost('fe80::1')).toBe('[fe80::1]')
+  })
+})

--- a/dream-server/extensions/services/dream-proxy/Caddyfile
+++ b/dream-server/extensions/services/dream-proxy/Caddyfile
@@ -57,7 +57,16 @@
 	handle @health {
 		respond "ok" 200
 	}
-	# Fall through to the host-matched blocks below.
+	# Fallback for direct IP / localhost access. Host-based .local routes below
+	# are preferred when DNS is available, but operators often click a LAN entry
+	# from localhost or type the server IP before mDNS is working. Serve Chat
+	# instead of returning an empty 200 response.
+	handle {
+		reverse_proxy open-webui:8080 {
+			header_up X-Forwarded-Proto {scheme}
+			header_up X-Forwarded-Host {host}
+		}
+	}
 }
 
 # ---------------------------------------------------------------------

--- a/dream-server/extensions/services/embeddings/manifest.yaml
+++ b/dream-server/extensions/services/embeddings/manifest.yaml
@@ -14,7 +14,7 @@ service:
   external_port_env: EMBEDDINGS_PORT
   external_port_default: 8090
   health: /health
-  ui_path: /info
+  ui_path: /docs
   type: docker
   gpu_backends: [all]
   compose_file: compose.yaml

--- a/dream-server/extensions/services/llama-server/manifest.yaml
+++ b/dream-server/extensions/services/llama-server/manifest.yaml
@@ -15,6 +15,7 @@ service:
   external_port_default: 8080
   health: /health
   ui_path: /
+  external_link: false
   health_timeout: 15
   type: docker
   gpu_backends: [amd, nvidia]

--- a/dream-server/scripts/generate-extensions-catalog.py
+++ b/dream-server/scripts/generate-extensions-catalog.py
@@ -104,6 +104,8 @@ def extract_entry(manifest: dict) -> dict | None:
         "port": service.get("port", 0),
         "external_port_default": service.get("external_port_default", 0),
         "health_endpoint": service.get("health", ""),
+        "ui_path": service.get("ui_path", "/"),
+        "external_link": service.get("external_link", True),
         "env_vars": strip_secrets(env_vars),
         "tags": manifest.get("tags") or service.get("tags", []),
         "features": manifest.get("features") or service.get("features", []),

--- a/dream-server/tests/contracts/test-network-exposure-contracts.py
+++ b/dream-server/tests/contracts/test-network-exposure-contracts.py
@@ -122,6 +122,10 @@ def test_dream_proxy_routes_talk_portal() -> None:
 
     assert_true("talk.{$DREAM_DEVICE_NAME:dream}.local" in caddyfile, "dream-proxy must route talk.<device>.local")
     assert_true("reverse_proxy dashboard:3001" in caddyfile, "Dream Talk should be served by the dashboard container")
+    assert_true(
+        ":80 {" in caddyfile and "reverse_proxy open-webui:8080" in caddyfile,
+        "dream-proxy must serve Chat for direct IP/localhost LAN entry fallback",
+    )
 
 
 def test_dashboard_csp_allows_dream_talk_tts_blob_audio() -> None:


### PR DESCRIPTION
## Overview

This PR makes Dashboard navigation resolve to usable browser surfaces instead of raw ports, blank responses, JSON-only endpoints, or backend-only services.

It covers three related paths:

- **LAN web entry** from localhost, loopback, LAN IPs, and partially configured `.local` hosts.
- **Dashboard Quick Links** generated from service manifests.
- **Extensions page open links** generated from the extension catalog.

> The common failure mode was the same in each area: the Dashboard had enough information to show a link, but not enough routing intent to guarantee that the link opened a real user-facing page.

## Problems Fixed

| Area | Before | After |
| --- | --- | --- |
| LAN web entry | `http://127.0.0.1:80` or `http://<LAN-IP>:80` could return an empty `200 OK` because no Caddy host route matched. | Direct IP and localhost requests on port 80 fall back to Open WebUI through `dream-proxy`. |
| `.local` service hosts | Dashboard could preserve noisy or overly specific hostnames when computing LAN links. | Known Dream subdomains collapse back to the parent `<device>.local` where appropriate, while host-based routes still take precedence. |
| APE Quick Link | Opened `/` and returned FastAPI `{"detail":"Not Found"}`. | Opens Swagger UI at `/docs`. |
| Embeddings Quick Link | Opened JSON-only `/info`. | Opens Swagger UI at `/docs`. |
| Raw LLM/API backends | `llama-server` / LiteLLM could appear as user-facing shortcuts. | Manifest opt-out via `external_link: false` is respected. |
| Manifest booleans | String-like values such as `"false"` could be treated as truthy by Python. | Manifest booleans are normalized intentionally. |
| ChromaDB extension link | Extensions page opened `http://<host>:8000`, where `/` returns a blank 404. | Opens `http://<host>:8000/docs/`. |
| ChromaDB health | Docker healthcheck called `python3`, but `chromadb/chroma:1.5.3` does not include `python3`, so the container became unhealthy even while the API responded. | Broken container-level healthcheck removed; dashboard-api probes the manifest health endpoint instead. |
| Extension open buttons | Extensions page ignored manifest `ui_path` and `external_link`. | Extension catalog carries `ui_path` / `external_link`, and the UI respects both. |

## Changes

### LAN Entry And `dream-proxy`

- Adds an intentional Caddy fallback for direct IP / localhost requests reaching `dream-proxy` on port 80.
- Keeps host-based routes first-class and unchanged:
  - `chat.<device>.local`
  - `dashboard.<device>.local`
  - `auth.<device>.local`
  - `api.<device>.local`
  - `talk.<device>.local`
- Updates dashboard URL generation so `dream-proxy` behaves like a LAN entry, not a normal ported service.
- Handles IPv6 host formatting and known Dream subdomain collapse.

### Quick Links

- Points APE to `/docs`.
- Points embeddings to `/docs`.
- Marks `llama-server` as `external_link: false`.
- Preserves and respects manifest `external_link` in dashboard-api external links.
- Hardens manifest boolean parsing for YAML/JSON/user-authored manifests.

### Extensions Page

- Adds `ui_path` and `external_link` to generated extension catalog entries.
- Carries those fields through user extension scanning.
- Uses `ui_path` when rendering an enabled extension's open button.
- Uses `external_link: false` to show an API-service badge instead of a misleading browser link.
- Updates ChromaDB to declare `ui_path: /docs/`.
- Removes ChromaDB's impossible `python3` healthcheck from its compose fragment.

## Behavior Matrix

| User action | Result after this PR |
| --- | --- |
| Open `http://127.0.0.1` | Open WebUI via `dream-proxy` fallback. |
| Open `http://localhost` | Open WebUI via `dream-proxy` fallback. |
| Open `http://<LAN-IP>` | Open WebUI via `dream-proxy` fallback. |
| Open `http://chat.<device>.local` | Open WebUI via host route. |
| Open `http://dashboard.<device>.local` | Dashboard via host route. |
| Open `http://<device>.local` | Existing redirect to `chat.<device>.local`. |
| Click APE Quick Link | Swagger UI at `/docs`. |
| Click embeddings Quick Link | Swagger UI at `/docs`. |
| Click ChromaDB from Extensions | Swagger UI at `/docs/`. |
| View raw `llama-server` / LiteLLM links | Not shown as user-facing links when `external_link: false` is set. |

## Cross-Platform Rationale

This is not macOS-only.

The LAN issue applies anywhere a browser reaches Caddy with a direct host header such as `127.0.0.1`, `localhost`, or a LAN IP instead of a configured Dream subdomain. That includes:

- macOS Docker Desktop
- Linux Docker hosts
- Windows Docker Desktop
- WSL-backed Docker setups
- Headless LAN installs where mDNS or subdomain DNS is incomplete

The Quick Links and Extensions fixes are also cross-platform because they live in service manifests, dashboard-api manifest/catalog loading, and frontend link rendering rather than an OS-specific installer path.

## Validation

### Local Tests

- [x] `npm test -- --run src/utils/externalUrls.test.js src/pages/Dashboard.test.jsx`
- [x] `npm test -- --run src/pages/Extensions.test.jsx`
- [x] `npm run build`
- [x] `python3 -m pytest dream-server/extensions/services/dashboard-api/tests/test_features.py -q`
- [x] `/tmp/dream-dashboard-api-test-venv/bin/python -m pytest dream-server/extensions/services/dashboard-api/tests/test_main.py::TestExternalLinks dream-server/extensions/services/dashboard-api/tests/test_config.py::TestLoadExtensionManifests -q`
- [x] `/tmp/dream-dashboard-api-test-venv/bin/python -m pytest dream-server/extensions/services/dashboard-api/tests/test_user_extensions.py -q`
- [x] `/tmp/dream-dashboard-api-test-venv/bin/python -m pytest dream-server/extensions/services/dashboard-api/tests/test_extensions.py::TestExtensionsCatalog -q`
- [x] `/tmp/dream-dashboard-api-test-venv/bin/python -m py_compile dream-server/extensions/services/dashboard-api/config.py dream-server/extensions/services/dashboard-api/main.py dream-server/extensions/services/dashboard-api/user_extensions.py`
- [x] `python3 dream-server/tests/contracts/test-network-exposure-contracts.py`
- [x] `python3 dream-server/scripts/audit-extensions.py`
- [x] `python3 dream-server/scripts/generate-extensions-catalog.py --output /tmp/dream-extensions-catalog-check.json`
- [x] `bash dream-server/tests/test-validate-manifests.sh`
- [x] `bash dream-server/tests/test-service-registry.sh`
- [x] `WEBUI_SECRET=ci-placeholder docker compose -f docker-compose.base.yml -f extensions/services/dream-proxy/compose.yaml config --quiet`
- [x] `docker run --rm -v "$PWD/extensions/services/dream-proxy/Caddyfile:/etc/caddy/Caddyfile:ro" -e DREAM_DEVICE_NAME=ci-dream caddy:2.11.3-alpine caddy validate --config /etc/caddy/Caddyfile`
- [x] `git diff --check`

### Remote CI

Current PR head has passed:

- [x] Dashboard frontend
- [x] Dashboard API
- [x] Integration smoke
- [x] Linux smoke
- [x] macOS smoke
- [x] Matrix smoke: Ubuntu, Debian, Fedora, Rocky, Arch, Manjaro, CachyOS, openSUSE Tumbleweed, Linux Mint
- [x] PowerShell lint on Windows and Ubuntu
- [x] Python Ruff
- [x] Python mypy
- [x] Shell lint
- [x] Secrets scan
- [x] Extension catalog up-to-date check
- [x] Tier 0-4 `.env` validation

<details>
<summary>Runtime smoke on macOS Docker Desktop</summary>

Applied the changes to a live Dream stack and rebuilt/recreated `dashboard`, `dashboard-api`, `dream-proxy`, and `chromadb` as needed.

Confirmed:

- `dream-proxy` healthy on `0.0.0.0:80`.
- `Host: 127.0.0.1` returns Open WebUI HTML instead of an empty `200`.
- `Host: localhost` returns Open WebUI HTML instead of an empty `200`.
- `Host: <LAN-IP>` returns Open WebUI HTML instead of an empty `200`.
- Existing `chat.<device>.local` and `dashboard.<device>.local` host routes still resolve when the Host header is present.
- `/api/external-links` returns APE as `/docs` and embeddings as `/docs`.
- `/api/external-links` excludes `llama-server` and LiteLLM when their manifests set `external_link: false`.
- Direct Quick Link smoke confirmed HTML/UI responses for APE, embeddings, dashboard, dream-proxy, Hermes proxy, n8n, Open WebUI, Perplexica, Privacy Shield, Qdrant, SearXNG, Token Spy, TTS, and Whisper when those services are running.
- ChromaDB responds at `/api/v2/heartbeat` with 200 JSON.
- ChromaDB docs open at `/docs/` with 200 HTML.
- Extensions page renders ChromaDB's open link as `http://localhost:8000/docs/`.

</details>

## Risk And Compatibility

| Risk | Assessment |
| --- | --- |
| New network exposure | Low. No new port is exposed; the LAN fallback only defines behavior for traffic already reaching `dream-proxy` on port 80. |
| Host-based `.local` routes | Low. Specific host routes remain above the fallback and keep their existing behavior. |
| Dashboard Quick Links | Low. Changes are manifest-driven and targeted at user-facing surfaces. |
| Extensions links | Low to moderate. The UI now honors explicit manifest metadata instead of assuming every extension's root path is a browser UI. |
| ChromaDB health reporting | Low. The broken container-level healthcheck is removed because the image lacks the tool it invoked; dashboard-api still checks `/api/v2/heartbeat`. |

## Review Notes

- This PR intentionally keeps the fixes grouped because they share the same operator-facing failure mode: a visible Dashboard link that opens the wrong surface.
- It does not introduce an installer-path-specific workaround.
- It avoids claiming that API-only services have a web UI. Services can now opt out with `external_link: false`, while services with UI docs can declare `ui_path`.
