### PR TITLE
fix(dashboard-api): strip v-prefix from current version before update check

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -145,7 +145,18 @@ def _get_cached_release_payload(allow_stale: bool = False) -> Optional[dict]:
     return None
 
 
+def _normalize_version(value: Optional[str]) -> str:
+    """Normalize a version string for comparison and display.
+
+    GitHub release tags are ``vX.Y.Z`` while ``.env``/``.version`` may store
+    either form, so strip a leading ``v`` (and surrounding whitespace) to keep
+    ``current`` and ``latest`` on the same footing.
+    """
+    return (value or "").strip().lstrip("v")
+
+
 def _build_version_result(current: str, payload: Optional[dict]) -> dict:
+    current = _normalize_version(current)
     result = {
         "current": current,
         "latest": None,
@@ -156,7 +167,7 @@ def _build_version_result(current: str, payload: Optional[dict]) -> dict:
     if not payload:
         return result
 
-    latest = (payload.get("latest") or "").lstrip("v")
+    latest = _normalize_version(payload.get("latest"))
     if not latest:
         return result
 
@@ -285,6 +296,7 @@ async def get_update_dry_run():
             current = (parsed or {}).get("version", raw) or raw or "0.0.0"
         except (json.JSONDecodeError, OSError):
             pass
+    current = _normalize_version(current)
 
     # ── latest version from GitHub ────────────────────────────────────────────
     latest: Optional[str] = None
@@ -299,7 +311,7 @@ async def get_update_dry_run():
                 headers=_GITHUB_HEADERS,
             )
         data = resp.json()
-        latest = data.get("tag_name", "").lstrip("v") or None
+        latest = _normalize_version(data.get("tag_name")) or None
         changelog_url = data.get("html_url") or None
         if latest:
             def _parts(v: str) -> list[int]:

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -61,6 +61,29 @@ def test_get_version_with_mock_github(test_client, monkeypatch):
     assert data["changelog_url"] == "https://github.com/test"
 
 
+def test_build_version_result_strips_v_prefix_from_current():
+    """Current versions stored with a 'v' prefix (matching the release tag
+    convention, e.g. a .version file of 'v2.5.3') must normalize before
+    comparison. Otherwise the numeric parser misreads them and a real update
+    is reported as unavailable.
+    """
+    from routers.updates import _build_version_result
+
+    result = _build_version_result("v2.5.3", {"latest": "2.6.0"})
+    assert result["current"] == "2.5.3"
+    assert result["update_available"] is True
+
+
+def test_build_version_result_handles_v_prefix_on_both_sides():
+    """A 'v' on either side must not affect the comparison."""
+    from routers.updates import _build_version_result
+
+    result = _build_version_result("v2.6.0", {"latest": "v2.6.0"})
+    assert result["current"] == "2.6.0"
+    assert result["latest"] == "2.6.0"
+    assert result["update_available"] is False
+
+
 def test_get_releases_manifest_requires_auth(test_client):
     """GET /api/releases/manifest without auth → 401."""
     resp = test_client.get("/api/releases/manifest")
@@ -316,6 +339,42 @@ def test_update_dry_run_version_from_json_version_file(test_client, tmp_path, mo
 
     assert resp.status_code == 200
     assert resp.json()["current_version"] == "3.1.4"
+
+
+def test_update_dry_run_normalizes_v_prefixed_version(test_client, tmp_path, monkeypatch):
+    """A .version file written as 'v2.0.1' must still compare against the latest
+    release tag correctly. Before normalization the 'v' prefix broke parsing, so
+    a newer release showed up as update_available=False.
+    """
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "dream-server"
+    install_dir.mkdir()
+    (install_dir / ".version").write_text("v2.0.1")
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "tag_name": "v2.6.0",
+        "html_url": "https://github.com/test",
+    }
+
+    async def mock_get(url, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/update/dry-run", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["current_version"] == "2.0.1"
+    assert data["latest_version"] == "2.6.0"
+    assert data["update_available"] is True
 
 
 def test_update_dry_run_reads_compose_images(test_client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

The update check compared the installed version against the latest GitHub release, but only the release tag was normalized with `lstrip("v")` — the installed version was used as-is. Release tags are `vX.Y.Z` and the `.version` file is read verbatim, so a current version like `v2.5.3` got parsed into the wrong numeric parts and a genuine update was reported as `update_available=false`. Users silently miss upgrades.

Fix normalizes the current version the same way as latest (strip a leading `v`/whitespace) in both `/api/version` and `/api/update/dry-run`.

How I tested: added unit + integration tests for the `v`-prefix case; `pytest` on the full dashboard-api suite passes (1173 tests); `ruff` clean.

## AI Assistance

Claude Code helped find the asymmetry, draft the fix and tests, and run the suite. I reviewed the diff and confirmed the reproduction and results.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard API / host agent

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Not required because: pure version-string normalization, no network/runtime/installer behavior change

Commands/results:

```text
$ pytest -q          # extensions/services/dashboard-api
1173 passed

$ pytest -q tests/test_updates.py
24 passed   # includes 3 new tests for the v-prefix case

$ ruff check ... --select E,F,W --ignore E501,E701,E731,E741,E402
All checks passed!
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

Narrower equivalent: the change is limited to version-string parsing in two read-only GET endpoints. No containers, network exposure, model routing, or installer paths are affected, and the logic is covered by unit + integration tests.

## Notes For Reviewers

Reproduction (before this change):

```text
_build_version_result("v2.5.3", {"latest": "2.6.0"})  ->  update_available=False   # wrong
_build_version_result("2.5.3",  {"latest": "2.6.0"})  ->  update_available=True    # correct
```

The `v` reaches `current` via a `.version` file written as `v2.5.3` (returned verbatim by `_read_current_version`) or a `DREAM_VERSION` set with the tag's `v`.
