### PR TITLE
Add PR-Agent (DeepSeek) + Qodo Merge dual review workflows

### DIFF
--- a/.github/workflows/pr-agent-review.yml
+++ b/.github/workflows/pr-agent-review.yml
@@ -1,0 +1,30 @@
+name: pr-agent-review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+jobs:
+  pr_agent_job:
+    name: PR-Agent (DeepSeek)
+    runs-on: ubuntu-latest
+    if: ${{ github.event.sender.type != 'Bot' && secrets.DEEPSEEK_API_KEY != '' }}
+    steps:
+      - name: PR Agent review
+        uses: the-pr-agent/pr-agent@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          config.model: "deepseek/deepseek-chat"
+          config.fallback_models: '["deepseek/deepseek-chat"]'
+          github_action_config.auto_review: "true"
+          github_action_config.auto_describe: "true"
+          github_action_config.auto_improve: "true"
+          pr_description.publish_labels: "true"
+          pr_description.publish_description_as: "suggestion"
+          pr_reviewer.require_score_review: "false"
+          pr_reviewer.num_code_suggestions: "4"

--- a/.github/workflows/qodo-merge.yml
+++ b/.github/workflows/qodo-merge.yml
@@ -1,0 +1,19 @@
+name: qodo-merge
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+jobs:
+  qodo-merge:
+    if: ${{ secrets.QODO_API_KEY != "" }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Qodo Merge Review
+        uses: qodo-ai/qodo-merge@main
+        env:
+          QODO_API_KEY: ${{ secrets.QODO_API_KEY }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Sets up two CI workflows for automated code review on every PR:\n\n- **PR-Agent** (DeepSeek) — auto-review, auto-describe, auto-improve with 4 code suggestions\n- **Qodo Merge** — second-pass review for broader coverage\n\nRequires two secrets to be set in the repo:\n- \`DEEPSEEK_API_KEY\`\n- \`QODO_API_KEY\`