### PR TITLE
feat: add MinIO S3-compatible object storage extension

### DIFF
--- a/dream-server/.env.example
+++ b/dream-server/.env.example
@@ -499,6 +499,12 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # tailscale daemon caches the node key in data/tailscale/, so you can
 # rotate or delete the auth key in the Tailscale admin.
 #
+# ── MinIO S3 Storage ──────────────────────────────────────────────────────
+# MINIO_ROOT_USER=minioadmin              # Root user (access key)
+# MINIO_ROOT_PASSWORD=                    # Root password (secret key) — auto-generated during install
+# MINIO_PORT=9002                         # S3 API external port
+# MINIO_CONSOLE_PORT=9003                 # Web console external port
+
 # TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
 # TS_HOSTNAME=                         # Defaults to DREAM_DEVICE_NAME
 # TS_EXTRA_ARGS=                       # Optional, e.g. --advertise-tags=tag:dream

--- a/dream-server/.env.schema.json
+++ b/dream-server/.env.schema.json
@@ -470,6 +470,28 @@
       "description": "Qdrant vector DB API key",
       "secret": true
     },
+    "MINIO_ROOT_USER": {
+      "type": "string",
+      "description": "MinIO root user (access key)",
+      "default": "minioadmin",
+      "minLength": 3
+    },
+    "MINIO_ROOT_PASSWORD": {
+      "type": "string",
+      "description": "MinIO root password (secret key)",
+      "secret": true,
+      "minLength": 8
+    },
+    "MINIO_PORT": {
+      "type": "integer",
+      "description": "MinIO S3 API external port",
+      "default": 9002
+    },
+    "MINIO_CONSOLE_PORT": {
+      "type": "integer",
+      "description": "MinIO web console external port",
+      "default": 9003
+    },
     "EMBEDDINGS_PORT": {
       "type": "integer",
       "description": "Text embeddings external port",

--- a/dream-server/config/core-service-ids.json
+++ b/dream-server/config/core-service-ids.json
@@ -19,5 +19,6 @@
   "searxng",
   "token-spy",
   "tts",
-  "whisper"
+  "whisper",
+  "minio"
 ]

--- a/dream-server/config/dependency-lock.json
+++ b/dream-server/config/dependency-lock.json
@@ -338,6 +338,14 @@
       "value": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda}",
       "default": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda",
       "reason": "Whisper CUDA image can be overridden by operators, but the shipped default is locked."
+    },
+    {
+      "id": "minio",
+      "type": "image",
+      "path": "extensions/services/minio/compose.yaml",
+      "value": "${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z}",
+      "default": "quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z",
+      "reason": "MinIO S3 storage image is overrideable for hotfix testing while the shipped default stays locked."
     }
   ]
 }

--- a/dream-server/config/network-exposure-policy.json
+++ b/dream-server/config/network-exposure-policy.json
@@ -145,6 +145,12 @@
       "lan_exposure": "operator-controlled",
       "auth_required": false,
       "notes": "Speech-to-text model API; audio may be sensitive."
+    },
+    "minio": {
+      "risk": "data-storage",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "S3-compatible object storage; data access controlled by root credentials."
     }
   }
 }

--- a/dream-server/config/ports.json
+++ b/dream-server/config/ports.json
@@ -130,6 +130,20 @@
       "internal_port": 3003,
       "compose_managed": false,
       "manifest_service": "opencode"
+    },
+    {
+      "env_var": "MINIO_PORT",
+      "external_default": 9002,
+      "service_id": "minio",
+      "internal_port": 9000,
+      "manifest_service": "minio"
+    },
+    {
+      "env_var": "MINIO_CONSOLE_PORT",
+      "external_default": 9003,
+      "service_id": "minio",
+      "internal_port": 9001,
+      "include_in_example": false
     }
   ]
 }

--- a/dream-server/extensions/services/minio/README.md
+++ b/dream-server/extensions/services/minio/README.md
@@ -1,0 +1,35 @@
+# MinIO (S3 Object Storage)
+
+S3-compatible object storage for Dream Server. Use it to store models, datasets,
+backups, and any other large files that need S3 API access from other services.
+
+## Usage
+
+Enable from the dashboard or CLI:
+
+```bash
+dream enable minio
+dream start minio
+```
+
+Requires `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` in `.env`.
+
+## Access
+
+| Interface | URL |
+|---|---|
+| S3 API | `http://127.0.0.1:${MINIO_PORT:-9002}` |
+| Web Console | `http://127.0.0.1:${MINIO_CONSOLE_PORT:-9003}` |
+
+From other Docker containers, use `http://minio:9000` (internal Docker DNS).
+
+## Volumes
+
+Data persists in `data/minio/` under the install directory.
+
+## Ports
+
+| Env Var | Default | Description |
+|---|---|---|
+| `MINIO_PORT` | 9002 | S3 API external port |
+| `MINIO_CONSOLE_PORT` | 9003 | Web console external port |

--- a/dream-server/extensions/services/minio/compose.yaml
+++ b/dream-server/extensions/services/minio/compose.yaml
@@ -1,0 +1,36 @@
+services:
+  minio:
+    image: quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z
+    container_name: dream-minio
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MinIO root user required — set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MinIO root password required — set MINIO_ROOT_PASSWORD in .env}
+      MINIO_VOLUMES: "/data"
+    command: server --console-address ":9001"
+    volumes:
+      - ./data/minio:/data:z
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${MINIO_PORT:-9002}:9000"
+      - "${BIND_ADDRESS:-127.0.0.1}:${MINIO_CONSOLE_PORT:-9003}:9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/minio/manifest.yaml
+++ b/dream-server/extensions/services/minio/manifest.yaml
@@ -1,0 +1,56 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: minio
+  name: MinIO (S3 Storage)
+  aliases: [s3, storage]
+  container_name: dream-minio
+  host_env: MINIO_HOST
+  default_host: minio
+  port: 9000
+  external_port_env: MINIO_PORT
+  external_port_default: 9002
+  health: /minio/health/live
+  ui_path: /
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []
+  env_vars:
+    - key: MINIO_ROOT_USER
+      required: true
+      secret: true
+      description: MinIO root user (access key)
+    - key: MINIO_ROOT_PASSWORD
+      required: true
+      secret: true
+      description: MinIO root password (secret key)
+    - key: MINIO_PORT
+      required: false
+      default: "9002"
+      description: External port for S3 API
+    - key: MINIO_CONSOLE_PORT
+      required: false
+      default: "9003"
+      description: External port for web console
+
+features:
+  - id: object-storage
+    name: Object Storage
+    description: S3-compatible object storage for models, datasets, and backups
+    icon: Database
+    category: system
+    requirements:
+      services: [minio]
+      disk_gb: 10
+    enabled_services_all: [minio]
+    setup_time: ~1 minute
+    priority: 50
+    launch:
+      type: service
+      service: minio
+    gpu_backends: [all]


### PR DESCRIPTION
Adds **MinIO** as an optional service extension for S3-compatible object storage — useful for storing models, datasets, backups, and any other large files that need S3 API access.

**New files:**
- \`extensions/services/minio/manifest.yaml\` — service metadata + object-storage feature tile
- \`extensions/services/minio/compose.yaml\` — Docker Compose with health check, persistent volume, resource limits
- \`extensions/services/minio/README.md\` — usage documentation

**Config updates:**
- \`core-service-ids.json\` — registered minio ID
- \`ports.json\` — \`MINIO_PORT\` (9002) and \`MINIO_CONSOLE_PORT\` (9003)
- \`dependency-lock.json\` — pinned image \`quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z\`
- \`network-exposure-policy.json\` — registered with auth_required
- \`.env.example\` and \`.env.schema.json\` — MinIO env vars documented

Disabled by default (\`category: optional\`). Requires \`MINIO_ROOT_USER\` and \`MINIO_ROOT_PASSWORD\` in .env.