### PR TITLE
fix(dashboard-api): prefer junction over edge GPU temp regardless of node order

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -551,11 +551,19 @@ def get_gpu_info_nvidia_detailed() -> Optional[list[IndividualGPU]]:
 def _find_hwmon_temp(hwmon_dir: str) -> int:
     """Find GPU temperature via hwmon label-based discovery (junction > edge > temp1)."""
     import glob as _glob
-    # Prefer junction temperature (accurate die temp), then edge
+    # Map each label to its temp*_input first, so the junction-over-edge
+    # preference holds regardless of which tempN node carries each label.
+    # On many AMD cards edge is temp1 and junction is temp2; scanning in file
+    # order would otherwise return edge even when the more accurate junction
+    # die temperature is available.
+    inputs_by_label: dict[str, str] = {}
     for label_path in sorted(_glob.glob(f"{hwmon_dir}/temp*_label")):
         label = _read_sysfs(label_path)
-        if label and label.lower() in ("junction", "edge"):
-            input_path = label_path.replace("_label", "_input")
+        if label:
+            inputs_by_label.setdefault(label.lower(), label_path.replace("_label", "_input"))
+    for preferred in ("junction", "edge"):
+        input_path = inputs_by_label.get(preferred)
+        if input_path:
             temp_str = _read_sysfs(input_path)
             if temp_str:
                 return int(temp_str) // 1000

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_amd.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_amd.py
@@ -35,6 +35,20 @@ class TestFindHwmonTemp:
         # junction (72000) is preferred over edge (65000)
         assert result == 72
 
+    def test_prefers_junction_when_edge_sorts_first(self, tmp_path):
+        """Common desktop AMD layout: temp1=edge, temp2=junction. Junction is
+        the accurate die temp and must win even though edge's node sorts first.
+        """
+        hwmon = tmp_path / "hwmon0"
+        hwmon.mkdir()
+        (hwmon / "temp1_label").write_text("edge\n")
+        (hwmon / "temp1_input").write_text("65000\n")
+        (hwmon / "temp2_label").write_text("junction\n")
+        (hwmon / "temp2_input").write_text("72000\n")
+
+        result = _find_hwmon_temp(str(hwmon))
+        assert result == 72
+
     def test_falls_back_to_edge(self, monkeypatch, tmp_path):
         """When no junction label, use edge."""
         hwmon = tmp_path / "hwmon0"


### PR DESCRIPTION
## Summary

`_find_hwmon_temp` (AMD GPU temperature) documents a `junction > edge` preference — junction is the accurate die temp — but it scanned `temp*_label` files in filename order and returned the first label matching *either* junction or edge. On the common AMD desktop layout where `temp1=edge` and `temp2=junction`, it returned edge (e.g. 65°C) even when junction (e.g. 72°C) was present.

Fix maps each label to its `temp*_input` first, then resolves `junction` before `edge`, so the documented preference holds regardless of node order.

How I tested: added a regression test for the `temp1=edge, temp2=junction` layout (the existing junction-preference test only passed because junction's node happened to sort first). Full dashboard-api suite passes (1171); `ruff` clean.

## AI Assistance

Claude Code helped spot the ordering bug, draft the fix and test, and run the suite. I reviewed the diff and confirmed the reproduction.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard API / host agent

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Not required because: read-only GPU temperature reporting; pure sysfs-label resolution, no runtime/installer/network change

Commands/results:

```text
$ pytest -q tests/test_gpu_amd.py tests/test_gpu.py tests/test_gpu_detailed.py
86 passed   # includes new test_prefers_junction_when_edge_sorts_first

$ pytest -q          # full dashboard-api suite
1171 passed

$ ruff check gpu.py tests/test_gpu_amd.py --select E,F,W --ignore E501,E701,E731,E741,E402
All checks passed!
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

Narrower equivalent: limited to how an AMD hwmon temperature label is selected for display. No detection gating, routing, or runtime behavior changes; covered by unit tests.

## Notes For Reviewers

Reproduction (before this change), common AMD layout:

```text
temp1_label=edge (65000), temp2_label=junction (72000)
_find_hwmon_temp(...) -> 65   # edge, but junction should win
```

The pre-existing `test_prefers_junction_over_edge` placed junction on `temp2` and edge on `temp3`, so junction's node sorted first and the bug was masked. The new test uses the layout where edge sorts first.
