### PR TITLE
[codex] add remote LLM tunnel support

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -94,6 +94,18 @@ ODS_TALK_VISION_URL=
 ODS_TALK_VISION_KEY=
 ODS_TALK_VISION_MODEL=user.Qwen3.6-35B-A3B-Vision
 
+# Remote OpenAI-compatible LLM over SSH tunnel. This is for a small laptop
+# running ODS while a larger LAN/Tailscale workstation serves inference.
+# Run scripts/configure-remote-llm.ps1 to set these safely.
+REMOTE_LLM_TUNNEL_ENABLED=false
+REMOTE_LLM_TUNNEL_SSH_HOST=
+REMOTE_LLM_TUNNEL_LOCAL_ADDRESS=127.0.0.1
+REMOTE_LLM_TUNNEL_LOCAL_PORT=18080
+REMOTE_LLM_TUNNEL_REMOTE_ADDRESS=127.0.0.1
+REMOTE_LLM_TUNNEL_REMOTE_PORT=8000
+REMOTE_LLM_TUNNEL_EXPECTED_MODEL=
+REMOTE_LLM_TUNNEL_TASK_NAME=ODS Remote LLM Tunnel
+
 # AMD local inference runtime selected by the installer.
 # Linux AMD: lemonade / rocm / container
 # Windows AMD: lemonade or llama-server / vulkan / host

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -71,6 +71,50 @@
       "description": "Vision-capable model id used by ODS Talk image attachments.",
       "default": "user.Qwen3.6-35B-A3B-Vision"
     },
+    "REMOTE_LLM_TUNNEL_ENABLED": {
+      "type": "boolean",
+      "description": "Whether ODS should treat a managed SSH tunnel as the active remote OpenAI-compatible LLM route.",
+      "default": false
+    },
+    "REMOTE_LLM_TUNNEL_SSH_HOST": {
+      "type": "string",
+      "description": "SSH host alias or user@host for the remote inference workstation.",
+      "default": ""
+    },
+    "REMOTE_LLM_TUNNEL_LOCAL_ADDRESS": {
+      "type": "string",
+      "description": "Loopback address where the tunnel listens on the ODS host.",
+      "default": "127.0.0.1"
+    },
+    "REMOTE_LLM_TUNNEL_LOCAL_PORT": {
+      "type": "integer",
+      "description": "Local host port forwarded to the remote OpenAI-compatible server.",
+      "default": 18080,
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "REMOTE_LLM_TUNNEL_REMOTE_ADDRESS": {
+      "type": "string",
+      "description": "Remote address, from the SSH host's perspective, for the OpenAI-compatible server.",
+      "default": "127.0.0.1"
+    },
+    "REMOTE_LLM_TUNNEL_REMOTE_PORT": {
+      "type": "integer",
+      "description": "Remote OpenAI-compatible server port reached through SSH.",
+      "default": 8000,
+      "minimum": 1,
+      "maximum": 65535
+    },
+    "REMOTE_LLM_TUNNEL_EXPECTED_MODEL": {
+      "type": "string",
+      "description": "Model id expected from /v1/models through the remote tunnel.",
+      "default": ""
+    },
+    "REMOTE_LLM_TUNNEL_TASK_NAME": {
+      "type": "string",
+      "description": "Windows scheduled task name used to auto-start the tunnel supervisor at logon.",
+      "default": "ODS Remote LLM Tunnel"
+    },
     "AMD_INFERENCE_RUNTIME": {
       "type": "string",
       "description": "Explicit AMD local inference runtime selected by the installer. Empty when AMD local inference is not active.",

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -38,6 +38,7 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-windows-llm-model-readiness.sh
 	@bash tests/contracts/test-windows-lemonade-swap-wait.sh
 	@bash tests/contracts/test-windows-hermes-config-patching.sh
+	@bash tests/test-windows-remote-llm-tunnel.sh
 	@echo ""
 	@echo "=== Overlay/plist contracts ==="
 	@bash tests/contracts/test-overlay-map-coherence.sh

--- a/ods/docs/ODS-DOCTOR.md
+++ b/ods/docs/ODS-DOCTOR.md
@@ -149,7 +149,9 @@ adds diagnoses when the evidence contradicts the selected mode:
 - `ODS-RUNTIME-CLOUD-HERMES-LOCAL-ROUTE`: cloud mode still has Hermes pointing
   at local `llama-server`.
 - `ODS-RUNTIME-CLOUD-GATEWAY-BYPASS`: cloud mode points ODS services somewhere
-  other than the LiteLLM gateway.
+  other than the LiteLLM gateway. This is suppressed when
+  `REMOTE_LLM_TUNNEL_ENABLED=true` and both `LLM_API_URL` and
+  `HERMES_LLM_BASE_URL` point at the configured remote tunnel port.
 - `ODS-RUNTIME-EXTERNAL-LEMONADE-CLOUD-OVERLAY-MISSING`: external Lemonade is
   active while cached `.compose-flags` lacks the cloud overlay that profiles
   out managed local inference.

--- a/ods/docs/README.md
+++ b/ods/docs/README.md
@@ -20,6 +20,7 @@ matches the work in front of them.
 |--------------|-----------------|----------|
 | Install the default path | [../QUICKSTART.md](../QUICKSTART.md) | [INSTALLER_TRUST.md](INSTALLER_TRUST.md), [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md), [POST-INSTALL-CHECKLIST.md](POST-INSTALL-CHECKLIST.md) |
 | Install on Windows | [WINDOWS-QUICKSTART.md](WINDOWS-QUICKSTART.md) | [WINDOWS-INSTALL-WALKTHROUGH.md](WINDOWS-INSTALL-WALKTHROUGH.md), [WINDOWS-WSL2-GPU-GUIDE.md](WINDOWS-WSL2-GPU-GUIDE.md) |
+| Run ODS on a laptop with workstation inference | [REMOTE-LLM-TUNNEL.md](REMOTE-LLM-TUNNEL.md) | [VLLM-SETUP.md](VLLM-SETUP.md), [MODE-SWITCH.md](MODE-SWITCH.md), [ODS-DOCTOR.md](ODS-DOCTOR.md) |
 | Install on Apple Silicon | [MACOS-QUICKSTART.md](MACOS-QUICKSTART.md) | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md), [TROUBLESHOOTING.md](TROUBLESHOOTING.md) |
 | Debug a broken install | [ODS-DOCTOR.md](ODS-DOCTOR.md) | [INSTALL-TROUBLESHOOTING.md](INSTALL-TROUBLESHOOTING.md), [SUPPORT-BUNDLE.md](SUPPORT-BUNDLE.md) |
 | Change installer behavior | [INSTALLER-ARCHITECTURE.md](INSTALLER-ARCHITECTURE.md) | [BACKEND-CONTRACT.md](BACKEND-CONTRACT.md), [PREFLIGHT-ENGINE.md](PREFLIGHT-ENGINE.md) |
@@ -132,6 +133,7 @@ canonical source and treat older recipes as context.
 | [PROFILES.md](PROFILES.md) | Reference | Docker Compose profiles (historical reference) |
 | [MODE-SWITCH.md](MODE-SWITCH.md) | Operators | Cloud/local/hybrid deployment modes (planned) |
 | [VLLM-SETUP.md](VLLM-SETUP.md) | Operators | Optional vLLM setup notes for high-concurrency NVIDIA inference |
+| [REMOTE-LLM-TUNNEL.md](REMOTE-LLM-TUNNEL.md) | Operators | Run ODS locally while forwarding inference to a remote OpenAI-compatible workstation |
 
 ## Troubleshooting
 

--- a/ods/docs/REMOTE-LLM-TUNNEL.md
+++ b/ods/docs/REMOTE-LLM-TUNNEL.md
@@ -1,0 +1,175 @@
+# Remote LLM Tunnel
+
+ODS can run the dashboard, Hermes, Open WebUI, voice, search, and workflows on
+a laptop while sending LLM inference to a larger workstation. The supported
+path is an SSH local-forward to a remote OpenAI-compatible server such as vLLM,
+llama.cpp server, Lemonade, LocalAI, or any endpoint with `/v1/models` and
+`/v1/chat/completions`.
+
+This keeps the remote workstation unchanged: ODS only opens an SSH session from
+the laptop and forwards a laptop loopback port to the remote loopback port.
+
+## When To Use This
+
+Use this mode when:
+
+- The laptop should remain the ODS control surface.
+- A workstation has the better GPU or already hosts the preferred model.
+- The remote server already exposes an OpenAI-compatible API on its own host.
+- You want the route to recover after laptop sleep, reboot, or conference Wi-Fi
+  reconnects.
+
+Do not use this as a public network exposure mechanism. The tunnel binds to
+`127.0.0.1` by default and should stay loopback-only.
+
+## Remote Host Prerequisites
+
+On the workstation, verify the model server from the workstation itself:
+
+```bash
+curl -fsS http://127.0.0.1:8000/v1/models
+curl -fsS http://127.0.0.1:8000/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"your-model-id","messages":[{"role":"user","content":"reply exactly: ready"}],"max_tokens":16,"temperature":0}'
+```
+
+The workstation does not need to expose this port to the LAN. The ODS laptop
+only needs key-based SSH access to the workstation.
+
+## Configure ODS On Windows
+
+From the installed ODS directory:
+
+```powershell
+cd $env:USERPROFILE\ods
+
+powershell.exe -NoProfile -ExecutionPolicy Bypass `
+  -File .\scripts\configure-remote-llm.ps1 `
+  -UseSshTunnel `
+  -SshHost workstation-ssh `
+  -RemotePort 8000 `
+  -LocalPort 18080 `
+  -Model your-model-id `
+  -Context 65536 `
+  -RegisterTask
+```
+
+Replace `workstation-ssh`, `8000`, and `your-model-id` with your SSH alias,
+remote server port, and served model id. The helper:
+
+- backs up `.env`, `.compose-flags`, LiteLLM configs, and Hermes configs under
+  `logs/remote-llm-backup-*`;
+- switches ODS to cloud/external inference mode;
+- points ODS clients at `http://host.docker.internal:<local-port>`;
+- updates Hermes's persisted config, not only its env vars;
+- writes the cloud compose overlay into `.compose-flags` so local
+  `llama-server` is profiled out;
+- registers the `ODS Remote LLM Tunnel` scheduled task when `-RegisterTask` is
+  set.
+
+Then recreate the stack:
+
+```powershell
+$flags = (Get-Content .compose-flags -Raw).Trim() -split '\s+'
+docker compose @flags up -d --remove-orphans --no-build
+docker rm -f ods-llama-server
+```
+
+The `docker rm -f` is intentional when migrating an existing local install:
+old local inference containers can otherwise keep running even though they are
+no longer in the active compose stack.
+
+## Start And Validate
+
+Start the tunnel immediately:
+
+```powershell
+Start-ScheduledTask -TaskName "ODS Remote LLM Tunnel"
+```
+
+Validate:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\scripts\check-remote-llm.ps1
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\ods.ps1 doctor
+```
+
+The validation script checks the host tunnel, container reachability, optional
+LiteLLM chat, and confirms the local `ods-llama-server` is not still running.
+
+Useful state checks:
+
+```powershell
+Get-ScheduledTask -TaskName "ODS Remote LLM Tunnel"
+Get-NetTCPConnection -LocalPort 18080 -State Listen
+Get-Content .\logs\remote-llm-tunnel.log -Tail 30
+```
+
+## Direct Remote Endpoint Without SSH
+
+If the remote API is already reachable from ODS containers, omit
+`-UseSshTunnel` and pass the container-reachable host root:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass `
+  -File .\scripts\configure-remote-llm.ps1 `
+  -EndpointRoot http://llm-workstation.local:8000 `
+  -Model your-model-id `
+  -Context 65536
+```
+
+Prefer SSH for workstation-local vLLM and laptop workflows because it keeps the
+inference server private and avoids firewall/LAN binding surprises.
+
+## Port Conflicts
+
+Windows may already have a local service on a port you expect ODS to use. For
+example, Lemonade can own `127.0.0.1:9000`, which makes host-side Whisper
+checks hang even if Docker publishes `0.0.0.0:9000`.
+
+Check ownership:
+
+```powershell
+Get-NetTCPConnection -LocalPort 9000 -State Listen |
+  Select-Object LocalAddress,LocalPort,OwningProcess,
+    @{Name='ProcessName';Expression={(Get-Process -Id $_.OwningProcess).ProcessName}}
+```
+
+If needed, set a different host port before recreating the stack:
+
+```powershell
+.\scripts\configure-remote-llm.ps1 -UseSshTunnel -SshHost workstation-ssh -Model your-model-id -WhisperPort 9001
+```
+
+Containers still use `whisper:8000`; this only changes the host-facing port.
+
+## Rollback
+
+Disable the task:
+
+```powershell
+Disable-ScheduledTask -TaskName "ODS Remote LLM Tunnel"
+```
+
+Stop the tracked SSH tunnel:
+
+```powershell
+$pidFile = ".\logs\remote-llm-tunnel.pid"
+if (Test-Path $pidFile) {
+  Stop-Process -Id ([int](Get-Content $pidFile -Raw)) -Force
+}
+```
+
+Restore the latest backup under `logs/remote-llm-backup-*`, then recreate the
+stack with the restored `.compose-flags`.
+
+## Notes For Reviewers
+
+This mode intentionally reuses the cloud overlay instead of adding another
+compose backend. The overlay profiles managed local `llama-server` out of the
+default stack, while the normal ODS services keep reading `LLM_API_URL`,
+`HERMES_LLM_BASE_URL`, and `ODS_TALK_VISION_URL`.
+
+`ods doctor` treats `REMOTE_LLM_TUNNEL_ENABLED=true` plus a matching
+`host.docker.internal:<local-port>` route as an intentional direct remote
+route. Ordinary cloud installs still warn when they bypass the LiteLLM gateway.

--- a/ods/docs/VLLM-SETUP.md
+++ b/ods/docs/VLLM-SETUP.md
@@ -136,7 +136,18 @@ The cost of doubling `--max-model-len` is doubling the per-slot KV allocation, w
 
 ## Existing ODS integration
 
-vLLM is not a first-class extension yet, but Perplexica can already be pointed at an OpenAI-compatible vLLM container on the `ods-network` in place of the default `llama-server` by changing `LLM_API_URL`. Treat that as the current integration seam: ODS has a consumer that can talk to vLLM, while a production-ready vLLM service wrapper still belongs in future work.
+vLLM is not a first-class extension yet, but ODS can route to an OpenAI-compatible
+vLLM endpoint by changing `LLM_API_URL`. For the common laptop-plus-workstation
+shape, use [REMOTE-LLM-TUNNEL.md](REMOTE-LLM-TUNNEL.md): ODS stays local, a
+self-healing SSH tunnel forwards a laptop loopback port to the remote vLLM
+server, and the cloud compose overlay keeps managed local `llama-server` out of
+the active stack.
+
+Perplexica can also be pointed at an OpenAI-compatible vLLM container on the
+`ods-network` in place of the default `llama-server` by changing `LLM_API_URL`.
+Treat that as the current integration seam: ODS has consumers that can talk to
+vLLM, while a production-ready vLLM service wrapper still belongs in future
+work.
 
 ---
 

--- a/ods/scripts/check-remote-llm.ps1
+++ b/ods/scripts/check-remote-llm.ps1
@@ -1,0 +1,149 @@
+# Validate ODS routing to a remote OpenAI-compatible model endpoint.
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "",
+    [string]$ExpectedModel = "",
+    [string]$HostBaseUrl = "",
+    [string]$ContainerBaseUrl = "",
+    [switch]$SkipDockerChecks
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Continue"
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+}
+$InstallDir = (Resolve-Path -LiteralPath $InstallDir).Path
+$EnvPath = Join-Path $InstallDir ".env"
+$results = New-Object System.Collections.Generic.List[object]
+
+function Get-OdsEnvValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ""
+    )
+    if (Test-Path -LiteralPath $EnvPath) {
+        foreach ($line in Get-Content -LiteralPath $EnvPath) {
+            if ($line -match ("^{0}=" -f [regex]::Escape($Name))) {
+                return ($line -replace ("^{0}=" -f [regex]::Escape($Name)), "").Trim().Trim('"').Trim("'")
+            }
+        }
+    }
+    return $Default
+}
+
+function Add-CheckResult {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][bool]$Ok,
+        [string]$Detail = ""
+    )
+    $results.Add([pscustomobject]@{ Name = $Name; Ok = $Ok; Detail = $Detail }) | Out-Null
+    $mark = if ($Ok) { "PASS" } else { "FAIL" }
+    Write-Host ("{0,-6} {1} {2}" -f $mark, $Name, $Detail)
+}
+
+function Invoke-JsonRequest {
+    param(
+        [Parameter(Mandatory = $true)][string]$Uri,
+        [string]$Method = "Get",
+        [object]$Body = $null,
+        [hashtable]$Headers = @{},
+        [int]$TimeoutSec = 60
+    )
+    if ($null -ne $Body) {
+        $json = $Body | ConvertTo-Json -Depth 20
+        return Invoke-RestMethod -Uri $Uri -Method $Method -ContentType "application/json" -Headers $Headers -Body $json -TimeoutSec $TimeoutSec
+    }
+    return Invoke-RestMethod -Uri $Uri -Method $Method -Headers $Headers -TimeoutSec $TimeoutSec
+}
+
+if ([string]::IsNullOrWhiteSpace($ExpectedModel)) {
+    $ExpectedModel = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_EXPECTED_MODEL" -Default (Get-OdsEnvValue -Name "LLM_MODEL")
+}
+if ([string]::IsNullOrWhiteSpace($HostBaseUrl)) {
+    $localPort = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_LOCAL_PORT" -Default "18080"
+    $HostBaseUrl = "http://127.0.0.1:$localPort"
+}
+if ([string]::IsNullOrWhiteSpace($ContainerBaseUrl)) {
+    $remoteUrl = Get-OdsEnvValue -Name "LLM_API_URL"
+    if (-not [string]::IsNullOrWhiteSpace($remoteUrl)) {
+        $ContainerBaseUrl = $remoteUrl.TrimEnd("/")
+    } else {
+        $localPort = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_LOCAL_PORT" -Default "18080"
+        $ContainerBaseUrl = "http://host.docker.internal:$localPort"
+    }
+}
+
+try {
+    $models = Invoke-JsonRequest -Uri "$HostBaseUrl/v1/models" -TimeoutSec 8
+    $modelIds = @($models.data | ForEach-Object { $_.id })
+    $ok = if ([string]::IsNullOrWhiteSpace($ExpectedModel)) { $modelIds.Count -gt 0 } else { $modelIds -contains $ExpectedModel }
+    Add-CheckResult "host remote models" $ok (($modelIds -join ", "))
+} catch {
+    Add-CheckResult "host remote models" $false $_.Exception.Message
+}
+
+if (-not [string]::IsNullOrWhiteSpace($ExpectedModel)) {
+    try {
+        $payload = @{
+            model = $ExpectedModel
+            messages = @(@{ role = "user"; content = "Reply exactly: ods-remote-llm-check" })
+            max_tokens = 24
+            temperature = 0
+            stream = $false
+        }
+        $chat = Invoke-JsonRequest -Uri "$HostBaseUrl/v1/chat/completions" -Method "Post" -Body $payload -TimeoutSec 120
+        $content = [string]$chat.choices[0].message.content
+        Add-CheckResult "host remote chat" ($content -match "ods-remote-llm-check") ($content.Trim())
+    } catch {
+        Add-CheckResult "host remote chat" $false $_.Exception.Message
+    }
+}
+
+if (-not $SkipDockerChecks) {
+    try {
+        $python = "import json,urllib.request; data=json.load(urllib.request.urlopen('$ContainerBaseUrl/v1/models', timeout=8)); print(','.join([m.get('id','') for m in data.get('data', [])]))"
+        $out = & docker exec ods-dashboard-api python3 -c $python 2>&1
+        $ok = ($LASTEXITCODE -eq 0) -and (([string]::IsNullOrWhiteSpace($ExpectedModel) -and -not [string]::IsNullOrWhiteSpace([string]$out)) -or ($out -match [regex]::Escape($ExpectedModel)))
+        Add-CheckResult "container remote models" $ok ([string]$out)
+    } catch {
+        Add-CheckResult "container remote models" $false $_.Exception.Message
+    }
+
+    try {
+        $llama = & docker ps --filter "name=ods-llama-server" --format "{{.Names}}" 2>$null
+        Add-CheckResult "local llama-server stopped" ([string]::IsNullOrWhiteSpace([string]$llama)) ([string]$llama)
+    } catch {
+        Add-CheckResult "local llama-server stopped" $false $_.Exception.Message
+    }
+
+    try {
+        $litellmKey = Get-OdsEnvValue -Name "LITELLM_KEY"
+        if ([string]::IsNullOrWhiteSpace($litellmKey)) {
+            Add-CheckResult "LiteLLM chat" $true "skipped: LITELLM_KEY unset"
+        } elseif ([string]::IsNullOrWhiteSpace($ExpectedModel)) {
+            Add-CheckResult "LiteLLM chat" $true "skipped: expected model unset"
+        } else {
+            $payload = @{
+                model = "default"
+                messages = @(@{ role = "user"; content = "Reply exactly: litellm-remote-llm-check" })
+                max_tokens = 24
+                temperature = 0
+                stream = $false
+            }
+            $chat = Invoke-JsonRequest -Uri "http://127.0.0.1:4000/v1/chat/completions" -Method "Post" -Headers @{ Authorization = "Bearer $litellmKey" } -Body $payload -TimeoutSec 120
+            $content = [string]$chat.choices[0].message.content
+            Add-CheckResult "LiteLLM chat" ($content -match "litellm-remote-llm-check") ($content.Trim())
+        }
+    } catch {
+        Add-CheckResult "LiteLLM chat" $false $_.Exception.Message
+    }
+}
+
+$failed = @($results | Where-Object { -not $_.Ok })
+if ($failed.Count -gt 0) {
+    exit 1
+}
+exit 0

--- a/ods/scripts/configure-remote-llm.ps1
+++ b/ods/scripts/configure-remote-llm.ps1
@@ -1,0 +1,235 @@
+# Configure an ODS install to use a remote OpenAI-compatible LLM endpoint.
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "",
+    [Parameter(Mandatory = $true)][string]$Model,
+    [int]$Context = 65536,
+    [string]$EndpointRoot = "",
+    [switch]$UseSshTunnel,
+    [string]$SshHost = "",
+    [string]$RemoteAddress = "127.0.0.1",
+    [int]$RemotePort = 8000,
+    [int]$LocalPort = 18080,
+    [switch]$RegisterTask,
+    [string]$TaskName = "ODS Remote LLM Tunnel",
+    [int]$WhisperPort = 0
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+}
+$InstallDir = (Resolve-Path -LiteralPath $InstallDir).Path
+$EnvPath = Join-Path $InstallDir ".env"
+if (-not (Test-Path -LiteralPath $EnvPath)) {
+    throw "Missing .env at $EnvPath"
+}
+
+if ($UseSshTunnel) {
+    if ([string]::IsNullOrWhiteSpace($SshHost)) {
+        throw "-SshHost is required with -UseSshTunnel"
+    }
+    if ([string]::IsNullOrWhiteSpace($EndpointRoot)) {
+        $EndpointRoot = "http://host.docker.internal:$LocalPort"
+    }
+} elseif ([string]::IsNullOrWhiteSpace($EndpointRoot)) {
+    throw "-EndpointRoot is required unless -UseSshTunnel is set"
+}
+
+$EndpointRoot = $EndpointRoot.TrimEnd("/")
+$EndpointBaseUrl = "$EndpointRoot/v1"
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$backupDir = Join-Path (Join-Path $InstallDir "logs") "remote-llm-backup-$timestamp"
+New-Item -ItemType Directory -Path $backupDir -Force | Out-Null
+
+function Copy-IfExists {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (Test-Path -LiteralPath $Path) {
+        $leaf = Split-Path -Leaf $Path
+        Copy-Item -LiteralPath $Path -Destination (Join-Path $backupDir $leaf) -Force
+    }
+}
+
+function Set-EnvValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Value
+    )
+    $lines = New-Object System.Collections.Generic.List[string]
+    if (Test-Path -LiteralPath $EnvPath) {
+        foreach ($line in Get-Content -LiteralPath $EnvPath) {
+            $lines.Add($line) | Out-Null
+        }
+    }
+    $pattern = "^{0}=" -f [regex]::Escape($Name)
+    $updated = $false
+    for ($i = 0; $i -lt $lines.Count; $i++) {
+        if ($lines[$i] -match $pattern) {
+            $lines[$i] = "$Name=$Value"
+            $updated = $true
+        }
+    }
+    if (-not $updated) {
+        $lines.Add("$Name=$Value") | Out-Null
+    }
+    Set-Content -LiteralPath $EnvPath -Value $lines -Encoding UTF8
+}
+
+function Write-LiteLlmConfig {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    $text = @"
+model_list:
+  - model_name: default
+    litellm_params:
+      model: openai/$Model
+      api_base: $EndpointBaseUrl
+      api_key: sk-ods-hermes-local
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+  - model_name: "*"
+    litellm_params:
+      model: openai/$Model
+      api_base: $EndpointBaseUrl
+      api_key: sk-ods-hermes-local
+      extra_body:
+        chat_template_kwargs:
+          enable_thinking: false
+
+router_settings:
+  routing_strategy: simple-shuffle
+
+general_settings:
+  master_key: os.environ/LITELLM_MASTER_KEY
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+  request_timeout: 900
+  stream_timeout: 900
+"@
+    Set-Content -LiteralPath $Path -Value $text -Encoding UTF8
+}
+
+function Update-HermesConfig {
+    param([Parameter(Mandatory = $true)][string]$Path)
+    if (-not (Test-Path -LiteralPath $Path)) {
+        return
+    }
+    $text = Get-Content -LiteralPath $Path -Raw
+    $text = [regex]::Replace($text, '(?m)^(\s*default:\s*).+$', ('$1"{0}"' -f $Model), 1)
+    $text = [regex]::Replace($text, '(?m)^(\s*base_url:\s*).+$', ('$1"{0}"' -f $EndpointBaseUrl), 1)
+    $text = [regex]::Replace($text, '(?m)^(\s*context_length:\s*)\d+', ('$1{0}' -f $Context), 1)
+    Set-Content -LiteralPath $Path -Value $text -Encoding UTF8
+}
+
+function Get-ComposeFlagsText {
+    $flagsFile = Join-Path $InstallDir ".compose-flags"
+    if (Test-Path -LiteralPath $flagsFile) {
+        return (Get-Content -LiteralPath $flagsFile -Raw).Trim()
+    }
+    $launchRecord = Join-Path (Join-Path $InstallDir "logs") "compose-launch.txt"
+    if (Test-Path -LiteralPath $launchRecord) {
+        $line = Get-Content -LiteralPath $launchRecord |
+            Where-Object { $_ -match "^compose_flags=" } |
+            Select-Object -First 1
+        if ($line) {
+            return ($line -replace "^compose_flags=", "").Trim()
+        }
+    }
+    return "--env-file .env -f docker-compose.base.yml -f docker-compose.cloud.yml -f extensions/services/litellm/compose.yaml"
+}
+
+function Set-RemoteComposeFlags {
+    $tokens = @(Get-ComposeFlagsText -split "\s+" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    $hasCloud = $tokens -contains "docker-compose.cloud.yml"
+    if (-not $hasCloud) {
+        $updated = New-Object System.Collections.Generic.List[string]
+        $inserted = $false
+        for ($i = 0; $i -lt $tokens.Count; $i++) {
+            $updated.Add($tokens[$i]) | Out-Null
+            if ($tokens[$i] -eq "docker-compose.base.yml") {
+                $updated.Add("-f") | Out-Null
+                $updated.Add("docker-compose.cloud.yml") | Out-Null
+                $inserted = $true
+            }
+        }
+        if (-not $inserted) {
+            $updated.Add("-f") | Out-Null
+            $updated.Add("docker-compose.cloud.yml") | Out-Null
+        }
+        $tokens = @($updated)
+    }
+    Set-Content -LiteralPath (Join-Path $InstallDir ".compose-flags") -Value ($tokens -join " ") -Encoding ASCII
+}
+
+Copy-IfExists -Path $EnvPath
+Copy-IfExists -Path (Join-Path $InstallDir ".compose-flags")
+Copy-IfExists -Path (Join-Path $InstallDir "config\litellm\local.yaml")
+Copy-IfExists -Path (Join-Path $InstallDir "config\litellm\cloud.yaml")
+Copy-IfExists -Path (Join-Path $InstallDir "extensions\services\hermes\cli-config.yaml.template")
+Copy-IfExists -Path (Join-Path $InstallDir "data\hermes\config.yaml")
+
+$litellmDir = Join-Path $InstallDir "config\litellm"
+New-Item -ItemType Directory -Path $litellmDir -Force | Out-Null
+$tunnelEnabled = if ($UseSshTunnel) { "true" } else { "false" }
+
+Set-EnvValue -Name "ODS_MODE" -Value "cloud"
+Set-EnvValue -Name "LLM_BACKEND" -Value "llama-server"
+Set-EnvValue -Name "LLM_API_URL" -Value $EndpointRoot
+Set-EnvValue -Name "LLM_URL" -Value $EndpointRoot
+Set-EnvValue -Name "OLLAMA_URL" -Value $EndpointRoot
+Set-EnvValue -Name "LLM_API_BASE_PATH" -Value "/v1"
+Set-EnvValue -Name "LLM_MODEL" -Value $Model
+Set-EnvValue -Name "GGUF_FILE" -Value $Model
+Set-EnvValue -Name "MAX_CONTEXT" -Value ([string]$Context)
+Set-EnvValue -Name "CTX_SIZE" -Value ([string]$Context)
+Set-EnvValue -Name "MODEL_RECOMMENDED_MODEL" -Value $Model
+Set-EnvValue -Name "MODEL_RECOMMENDED_GGUF" -Value $Model
+Set-EnvValue -Name "MODEL_RECOMMENDED_CONTEXT" -Value ([string]$Context)
+Set-EnvValue -Name "MODEL_RECOMMENDATION_SOURCE" -Value "remote-openai-compatible"
+Set-EnvValue -Name "MODEL_RECOMMENDATION_POLICY" -Value "remote-openai-compatible"
+Set-EnvValue -Name "MODEL_RECOMMENDATION_CONFIDENCE" -Value "operator-configured"
+Set-EnvValue -Name "MODEL_RECOMMENDATION_REASON" -Value "Operator configured a remote OpenAI-compatible endpoint."
+Set-EnvValue -Name "HERMES_LLM_BASE_URL" -Value $EndpointBaseUrl
+Set-EnvValue -Name "HERMES_LLM_API_KEY" -Value "sk-ods-hermes-local"
+Set-EnvValue -Name "ODS_TALK_VISION_URL" -Value $EndpointBaseUrl
+Set-EnvValue -Name "ODS_TALK_VISION_MODEL" -Value $Model
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_ENABLED" -Value $tunnelEnabled
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_SSH_HOST" -Value $SshHost
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_LOCAL_ADDRESS" -Value "127.0.0.1"
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_LOCAL_PORT" -Value ([string]$LocalPort)
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_REMOTE_ADDRESS" -Value $RemoteAddress
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_REMOTE_PORT" -Value ([string]$RemotePort)
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_EXPECTED_MODEL" -Value $Model
+Set-EnvValue -Name "REMOTE_LLM_TUNNEL_TASK_NAME" -Value $TaskName
+if ($WhisperPort -gt 0) {
+    Set-EnvValue -Name "WHISPER_PORT" -Value ([string]$WhisperPort)
+}
+
+Write-LiteLlmConfig -Path (Join-Path $litellmDir "local.yaml")
+Write-LiteLlmConfig -Path (Join-Path $litellmDir "cloud.yaml")
+Update-HermesConfig -Path (Join-Path $InstallDir "extensions\services\hermes\cli-config.yaml.template")
+Update-HermesConfig -Path (Join-Path $InstallDir "data\hermes\config.yaml")
+Set-RemoteComposeFlags
+
+if ($RegisterTask) {
+    & (Join-Path $InstallDir "scripts\register-remote-llm-tunnel-task.ps1") -InstallDir $InstallDir -TaskName $TaskName | Out-Host
+}
+
+Write-Host "Remote LLM configuration written."
+Write-Host "Backup: $backupDir"
+Write-Host "Endpoint root: $EndpointRoot"
+Write-Host "Model: $Model"
+if ($UseSshTunnel) {
+    Write-Host "Tunnel: 127.0.0.1:$LocalPort -> $SshHost $RemoteAddress`:$RemotePort"
+}
+Write-Host "Next:"
+Write-Host "  cd $InstallDir"
+Write-Host "  `$flags = (Get-Content .compose-flags -Raw).Trim() -split '\s+'"
+Write-Host "  docker compose @flags up -d --remove-orphans --no-build"
+Write-Host "  powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts\check-remote-llm.ps1"

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -652,6 +652,16 @@ def _looks_like_litellm_route(value):
     return "litellm" in lowered or ":4000" in lowered
 
 
+def _looks_like_remote_tunnel_route(value, local_port):
+    lowered = (value or "").lower().rstrip("/")
+    port = str(local_port or "").strip() or "18080"
+    return (
+        f"host.docker.internal:{port}" in lowered
+        or f"127.0.0.1:{port}" in lowered
+        or f"localhost:{port}" in lowered
+    )
+
+
 def _looks_like_local_llama_route(value):
     lowered = (value or "").lower()
     if not lowered:
@@ -739,6 +749,8 @@ def _collect_inference_contract():
     llm_backend = env_get("LLM_BACKEND", "")
     llm_api_url = env_get("LLM_API_URL", "")
     hermes_base_url = env_get("HERMES_LLM_BASE_URL", "")
+    remote_llm_tunnel = _truthy(env_get("REMOTE_LLM_TUNNEL_ENABLED"))
+    remote_llm_tunnel_port = env_get("REMOTE_LLM_TUNNEL_LOCAL_PORT", "18080")
     lemonade_external = (
         _truthy(env_get("LEMONADE_EXTERNAL"))
         or env_get("AMD_INFERENCE_RUNTIME_MODE").strip().lower() == "external-lemonade"
@@ -822,7 +834,12 @@ def _collect_inference_contract():
                     f"ODS_MODE=cloud but HERMES_LLM_BASE_URL points at local llama-server ({hermes_base_url}).",
                 )
             )
-        if llm_api_url and not _looks_like_litellm_route(llm_api_url):
+        cloud_bypass_is_remote_tunnel = (
+            remote_llm_tunnel
+            and _looks_like_remote_tunnel_route(llm_api_url, remote_llm_tunnel_port)
+            and _looks_like_remote_tunnel_route(hermes_base_url, remote_llm_tunnel_port)
+        )
+        if llm_api_url and not _looks_like_litellm_route(llm_api_url) and not cloud_bypass_is_remote_tunnel:
             issues.append(
                 _inference_issue(
                     "ODS-RUNTIME-CLOUD-GATEWAY-BYPASS",

--- a/ods/scripts/register-remote-llm-tunnel-task.ps1
+++ b/ods/scripts/register-remote-llm-tunnel-task.ps1
@@ -1,0 +1,64 @@
+# Register the remote LLM SSH tunnel supervisor to start at Windows logon.
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "",
+    [string]$TaskName = ""
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+}
+$InstallDir = (Resolve-Path -LiteralPath $InstallDir).Path
+$EnvPath = Join-Path $InstallDir ".env"
+
+function Get-OdsEnvValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ""
+    )
+    if (Test-Path -LiteralPath $EnvPath) {
+        foreach ($line in Get-Content -LiteralPath $EnvPath) {
+            if ($line -match ("^{0}=" -f [regex]::Escape($Name))) {
+                return ($line -replace ("^{0}=" -f [regex]::Escape($Name)), "").Trim().Trim('"').Trim("'")
+            }
+        }
+    }
+    return $Default
+}
+
+if ([string]::IsNullOrWhiteSpace($TaskName)) {
+    $TaskName = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_TASK_NAME" -Default "ODS Remote LLM Tunnel"
+}
+
+$scriptPath = Join-Path $InstallDir "scripts\start-remote-llm-tunnel.ps1"
+if (-not (Test-Path -LiteralPath $scriptPath)) {
+    throw "Missing tunnel supervisor script: $scriptPath"
+}
+
+$user = "$env:USERDOMAIN\$env:USERNAME"
+$action = New-ScheduledTaskAction -Execute "powershell.exe" -Argument ('-NoProfile -ExecutionPolicy Bypass -File "{0}"' -f $scriptPath)
+$trigger = New-ScheduledTaskTrigger -AtLogOn -User $user
+$settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 999 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -MultipleInstances IgnoreNew `
+    -ExecutionTimeLimit (New-TimeSpan -Days 0)
+$principal = New-ScheduledTaskPrincipal -UserId $user -LogonType Interactive -RunLevel Limited
+
+Register-ScheduledTask `
+    -TaskName $TaskName `
+    -Action $action `
+    -Trigger $trigger `
+    -Settings $settings `
+    -Principal $principal `
+    -Description "Keeps the ODS remote LLM SSH tunnel alive on user logon." `
+    -Force | Out-Null
+
+Get-ScheduledTask -TaskName $TaskName |
+    Select-Object TaskName, State, @{Name = "UserId"; Expression = { $_.Principal.UserId } }, @{Name = "RunLevel"; Expression = { $_.Principal.RunLevel } }

--- a/ods/scripts/start-remote-llm-tunnel.ps1
+++ b/ods/scripts/start-remote-llm-tunnel.ps1
@@ -1,0 +1,256 @@
+# Self-healing SSH tunnel supervisor for ODS remote OpenAI-compatible inference.
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "",
+    [string]$SshHost = "",
+    [string]$LocalAddress = "",
+    [int]$LocalPort = 0,
+    [string]$RemoteAddress = "",
+    [int]$RemotePort = 0,
+    [string]$ExpectedModel = "",
+    [int]$HealthySleepSeconds = 20,
+    [int]$RetrySleepSeconds = 10
+)
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+if ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Split-Path -Parent (Split-Path -Parent $PSCommandPath)
+}
+$InstallDir = (Resolve-Path -LiteralPath $InstallDir).Path
+$EnvPath = Join-Path $InstallDir ".env"
+
+function Get-OdsEnvValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [string]$Default = ""
+    )
+    if (Test-Path -LiteralPath $EnvPath) {
+        foreach ($line in Get-Content -LiteralPath $EnvPath) {
+            if ($line -match ("^{0}=" -f [regex]::Escape($Name))) {
+                return ($line -replace ("^{0}=" -f [regex]::Escape($Name)), "").Trim().Trim('"').Trim("'")
+            }
+        }
+    }
+    $envValue = [Environment]::GetEnvironmentVariable($Name)
+    if (-not [string]::IsNullOrWhiteSpace($envValue)) {
+        return $envValue
+    }
+    return $Default
+}
+
+if ([string]::IsNullOrWhiteSpace($SshHost)) {
+    $SshHost = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_SSH_HOST"
+}
+if ([string]::IsNullOrWhiteSpace($LocalAddress)) {
+    $LocalAddress = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_LOCAL_ADDRESS" -Default "127.0.0.1"
+}
+if ($LocalPort -le 0) {
+    $LocalPort = [int](Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_LOCAL_PORT" -Default "18080")
+}
+if ([string]::IsNullOrWhiteSpace($RemoteAddress)) {
+    $RemoteAddress = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_REMOTE_ADDRESS" -Default "127.0.0.1"
+}
+if ($RemotePort -le 0) {
+    $RemotePort = [int](Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_REMOTE_PORT" -Default "8000")
+}
+if ([string]::IsNullOrWhiteSpace($ExpectedModel)) {
+    $ExpectedModel = Get-OdsEnvValue -Name "REMOTE_LLM_TUNNEL_EXPECTED_MODEL" -Default (Get-OdsEnvValue -Name "LLM_MODEL")
+}
+if ([string]::IsNullOrWhiteSpace($SshHost)) {
+    throw "REMOTE_LLM_TUNNEL_SSH_HOST is required, or pass -SshHost."
+}
+
+$LogDir = Join-Path $InstallDir "logs"
+$LogPath = Join-Path $LogDir "remote-llm-tunnel.log"
+$StdOutPath = Join-Path $LogDir "remote-llm-tunnel-ssh.out.log"
+$StdErrPath = Join-Path $LogDir "remote-llm-tunnel-ssh.err.log"
+$PidPath = Join-Path $LogDir "remote-llm-tunnel.pid"
+$HealthUrl = "http://$LocalAddress`:$LocalPort/v1/models"
+$ForwardSpec = "{0}:{1}:{2}:{3}" -f $LocalAddress, $LocalPort, $RemoteAddress, $RemotePort
+New-Item -ItemType Directory -Path $LogDir -Force | Out-Null
+
+function Write-TunnelLog {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    try {
+        if ((Test-Path -LiteralPath $LogPath) -and ((Get-Item -LiteralPath $LogPath).Length -gt 1048576)) {
+            $rotated = "$LogPath.1"
+            Remove-Item -LiteralPath $rotated -Force -ErrorAction SilentlyContinue
+            Move-Item -LiteralPath $LogPath -Destination $rotated -Force
+        }
+    } catch {
+    }
+    Add-Content -LiteralPath $LogPath -Value ("{0} {1}" -f (Get-Date).ToString("s"), $Message) -Encoding UTF8
+}
+
+function Get-ProcessCommandLine {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+    try {
+        $proc = Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId" -ErrorAction Stop
+        return [string]$proc.CommandLine
+    } catch {
+        return ""
+    }
+}
+
+function Test-TunnelCommandLine {
+    param([string]$CommandLine)
+    if ([string]::IsNullOrWhiteSpace($CommandLine)) {
+        return $false
+    }
+    return ($CommandLine -like "*$LocalPort`:$RemoteAddress`:$RemotePort*" -or
+            $CommandLine -like "*$ForwardSpec*")
+}
+
+function Get-PortListener {
+    try {
+        $listeners = @(Get-NetTCPConnection -LocalAddress $LocalAddress -LocalPort $LocalPort -State Listen -ErrorAction SilentlyContinue)
+        if (-not $listeners) {
+            $listeners = @(Get-NetTCPConnection -LocalPort $LocalPort -State Listen -ErrorAction SilentlyContinue)
+        }
+        $listener = $listeners | Select-Object -First 1
+        if (-not $listener) {
+            return $null
+        }
+        $processName = "unknown"
+        try {
+            $processName = (Get-Process -Id $listener.OwningProcess -ErrorAction Stop).ProcessName
+        } catch {
+        }
+        return [pscustomobject]@{
+            ProcessId = [int]$listener.OwningProcess
+            ProcessName = $processName
+            CommandLine = Get-ProcessCommandLine -ProcessId ([int]$listener.OwningProcess)
+        }
+    } catch {
+        Write-TunnelLog "port listener check failed: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Test-RemoteModelEndpoint {
+    try {
+        $response = Invoke-RestMethod -Uri $HealthUrl -Method Get -TimeoutSec 5
+        $ids = @($response.data | ForEach-Object { $_.id })
+        if ([string]::IsNullOrWhiteSpace($ExpectedModel)) {
+            return ($ids.Count -gt 0)
+        }
+        return ($ids -contains $ExpectedModel)
+    } catch {
+        Write-TunnelLog "health check failed: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Stop-SshTunnelProcess {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+    try {
+        $proc = Get-Process -Id $ProcessId -ErrorAction Stop
+        if ($proc.ProcessName -ne "ssh") {
+            Write-TunnelLog "refusing to stop non-ssh process $ProcessId ($($proc.ProcessName))"
+            return
+        }
+        $commandLine = Get-ProcessCommandLine -ProcessId $ProcessId
+        if (-not (Test-TunnelCommandLine -CommandLine $commandLine)) {
+            Write-TunnelLog "refusing to stop ssh process $ProcessId because it does not match this tunnel"
+            return
+        }
+        Stop-Process -Id $ProcessId -Force -ErrorAction Stop
+        Write-TunnelLog "stopped stale ssh tunnel process $ProcessId"
+    } catch {
+        Write-TunnelLog "failed to stop ssh tunnel process $ProcessId`: $($_.Exception.Message)"
+    }
+}
+
+function Stop-TrackedTunnel {
+    if (-not (Test-Path -LiteralPath $PidPath)) {
+        return
+    }
+    try {
+        $pidText = (Get-Content -LiteralPath $PidPath -Raw).Trim()
+        if ($pidText -match "^\d+$") {
+            Stop-SshTunnelProcess -ProcessId ([int]$pidText)
+        }
+    } catch {
+        Write-TunnelLog "failed to process pid file: $($_.Exception.Message)"
+    }
+    Remove-Item -LiteralPath $PidPath -Force -ErrorAction SilentlyContinue
+}
+
+function Start-SshTunnel {
+    $sshArgs = @(
+        "-N",
+        "-T",
+        "-L", $ForwardSpec,
+        "-o", "ExitOnForwardFailure=yes",
+        "-o", "ServerAliveInterval=30",
+        "-o", "ServerAliveCountMax=3",
+        "-o", "StrictHostKeyChecking=yes",
+        "-o", "BatchMode=yes",
+        $SshHost
+    )
+    Write-TunnelLog "starting ssh tunnel: $LocalAddress`:$LocalPort -> $SshHost $RemoteAddress`:$RemotePort"
+    try {
+        $proc = Start-Process -FilePath "ssh.exe" -ArgumentList $sshArgs -PassThru -WindowStyle Hidden -RedirectStandardOutput $StdOutPath -RedirectStandardError $StdErrPath
+        Set-Content -LiteralPath $PidPath -Value ([string]$proc.Id) -Encoding ASCII
+        Write-TunnelLog "started ssh tunnel process $($proc.Id)"
+    } catch {
+        Write-TunnelLog "failed to start ssh tunnel: $($_.Exception.Message)"
+    }
+}
+
+$mutexName = "Local\ODS_Remote_LLM_Tunnel_Supervisor_$LocalPort"
+$mutex = New-Object System.Threading.Mutex($false, $mutexName)
+if (-not $mutex.WaitOne(0)) {
+    Write-TunnelLog "another remote LLM tunnel supervisor is already running for port $LocalPort; exiting"
+    exit 0
+}
+
+Write-TunnelLog "supervisor started for $HealthUrl expecting '$ExpectedModel'"
+try {
+    while ($true) {
+        if (Test-RemoteModelEndpoint) {
+            Start-Sleep -Seconds $HealthySleepSeconds
+            continue
+        }
+
+        $listener = Get-PortListener
+        if ($listener) {
+            if ($listener.ProcessName -eq "ssh" -and (Test-TunnelCommandLine -CommandLine $listener.CommandLine)) {
+                Write-TunnelLog "port $LocalPort has an unhealthy ssh listener; recycling process $($listener.ProcessId)"
+                Stop-SshTunnelProcess -ProcessId $listener.ProcessId
+            } else {
+                Write-TunnelLog "port $LocalPort is occupied by $($listener.ProcessName) pid=$($listener.ProcessId); waiting"
+                Start-Sleep -Seconds $RetrySleepSeconds
+                continue
+            }
+        } else {
+            Stop-TrackedTunnel
+        }
+
+        Start-SshTunnel
+        Start-Sleep -Seconds 4
+        if (Test-RemoteModelEndpoint) {
+            Write-TunnelLog "tunnel healthy"
+        } else {
+            Write-TunnelLog "tunnel not healthy yet; will retry"
+            try {
+                $recent = Get-Content -LiteralPath $StdErrPath -Tail 3 -ErrorAction SilentlyContinue
+                foreach ($line in $recent) {
+                    if (-not [string]::IsNullOrWhiteSpace($line)) {
+                        Write-TunnelLog "ssh stderr: $line"
+                    }
+                }
+            } catch {
+            }
+        }
+        Start-Sleep -Seconds $RetrySleepSeconds
+    }
+} finally {
+    try {
+        $mutex.ReleaseMutex()
+    } catch {
+    }
+    $mutex.Dispose()
+}

--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -79,6 +79,12 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 3
 fi
 
+jq_raw() {
+  # Windows jq.exe emits CRLF under Git Bash; strip CR so mapfile/case checks
+  # see the same keys and scalar values as Linux/macOS jq.
+  jq -r "$@" | tr -d '\r'
+}
+
 # -----------------------------
 # .env parsing (robust)
 # -----------------------------
@@ -183,9 +189,9 @@ enum_errors=()
 range_errors=()
 duplicate_errors=()
 
-mapfile -t required_keys < <(jq -r '.required[]?' "$SCHEMA_FILE")
+mapfile -t required_keys < <(jq_raw '.required[]?' "$SCHEMA_FILE")
 
-mapfile -t schema_keys < <(jq -r '.properties | keys[]' "$SCHEMA_FILE")
+mapfile -t schema_keys < <(jq_raw '.properties | keys[]' "$SCHEMA_FILE")
 declare -A SCHEMA_KEY_SET
 for key in "${schema_keys[@]}"; do
     SCHEMA_KEY_SET["$key"]=1
@@ -220,7 +226,7 @@ for key in "${schema_keys[@]}"; do
     val="${ENV_MAP[$key]-}"
     [[ -z "$val" ]] && continue
 
-    expected_type="$(jq -r --arg k "$key" '.properties[$k].type // "string"' "$SCHEMA_FILE")"
+    expected_type="$(jq_raw --arg k "$key" '.properties[$k].type // "string"' "$SCHEMA_FILE")"
 
     # Type validation
     case "$expected_type" in
@@ -250,7 +256,7 @@ for key in "${schema_keys[@]}"; do
         : # enums in our schema are for strings; ignore otherwise
       else
         if ! jq -e --arg k "$key" --arg v "$val" '.properties[$k].enum | index($v) != null' "$SCHEMA_FILE" >/dev/null 2>&1; then
-          allowed="$(jq -r --arg k "$key" '.properties[$k].enum | join(", ")' "$SCHEMA_FILE")"
+          allowed="$(jq_raw --arg k "$key" '.properties[$k].enum | join(", ")' "$SCHEMA_FILE")"
           enum_errors+=("$key: invalid value '$val' (allowed: $allowed) (line ${ENV_LINE[$key]:-?})")
         fi
       fi
@@ -259,13 +265,13 @@ for key in "${schema_keys[@]}"; do
     # Range validation (minimum/maximum) for numbers/integers
     if [[ "$expected_type" == "integer" || "$expected_type" == "number" ]]; then
       if jq -e --arg k "$key" '.properties[$k].minimum? != null' "$SCHEMA_FILE" >/dev/null 2>&1; then
-        minv="$(jq -r --arg k "$key" '.properties[$k].minimum' "$SCHEMA_FILE")"
+        minv="$(jq_raw --arg k "$key" '.properties[$k].minimum' "$SCHEMA_FILE")"
         if awk "BEGIN{exit !($val < $minv)}" 2>/dev/null; then
           range_errors+=("$key: value $val is < minimum $minv (line ${ENV_LINE[$key]:-?})")
         fi
       fi
       if jq -e --arg k "$key" '.properties[$k].maximum? != null' "$SCHEMA_FILE" >/dev/null 2>&1; then
-        maxv="$(jq -r --arg k "$key" '.properties[$k].maximum' "$SCHEMA_FILE")"
+        maxv="$(jq_raw --arg k "$key" '.properties[$k].maximum' "$SCHEMA_FILE")"
         if awk "BEGIN{exit !($val > $maxv)}" 2>/dev/null; then
           range_errors+=("$key: value $val is > maximum $maxv (line ${ENV_LINE[$key]:-?})")
         fi
@@ -348,7 +354,7 @@ log_info "Keys in schema: ${#schema_keys[@]}"
 log_info "Required keys: ${#required_keys[@]}"
 
 # Optional: print helpful summary of secrets (without values)
-secret_count=$(jq -r '.properties | to_entries[] | select(.value.secret==true) | .key' "$SCHEMA_FILE" | wc -l | tr -d ' ')
+secret_count=$(jq_raw '.properties | to_entries[] | select(.value.secret==true) | .key' "$SCHEMA_FILE" | wc -l | tr -d ' ')
 if [[ "$secret_count" =~ ^[0-9]+$ ]] && (( secret_count > 0 )); then
   log_info "Schema marks ${secret_count} key(s) as secrets (values not printed)."
 fi

--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -528,7 +528,10 @@ if grep -A16 'function Test-ODSDockerImageAvailable' installers/windows/install-
     | grep -q 'SilentlyContinue' \
     && grep -A20 'function Test-ODSDockerImageAvailable' installers/windows/install-windows.ps1 \
         | grep -q 'finally' \
-    && grep -q 'docker manifest inspect' installers/windows/install-windows.ps1; then
+    && grep -A16 'function Test-ODSDockerImageAvailable' installers/windows/install-windows.ps1 \
+        | grep -q 'image inspect' \
+    && grep -A16 'function Test-ODSDockerImageAvailable' installers/windows/install-windows.ps1 \
+        | grep -q 'manifest inspect'; then
     pass "install-windows.ps1: image availability probes restore ErrorActionPreference"
 else
     fail "install-windows.ps1: Docker image probes must not abort on missing local images"

--- a/ods/tests/test-linux-install-preflight.sh
+++ b/ods/tests/test-linux-install-preflight.sh
@@ -54,9 +54,9 @@ if "$LP" --json >"$JSON_OUT" 2>/dev/null || true; then
     :
 fi
 if command -v python3 >/dev/null 2>&1; then
-    if python3 - <<PY
+    if python3 - "$JSON_OUT" <<'PY'
 import json, sys
-path = "$JSON_OUT"
+path = sys.argv[1]
 with open(path, encoding="utf-8") as f:
     r = json.load(f)
 assert r.get("kind") == "linux-install-preflight"
@@ -100,9 +100,9 @@ EOF
     if PATH="$PODMAN_TMP:$PATH" "$LP" --json >"$PODMAN_JSON" 2>/dev/null || true; then
         :
     fi
-    if python3 - <<PY
-import json
-path = "$PODMAN_JSON"
+    if python3 - "$PODMAN_JSON" <<'PY'
+import json, sys
+path = sys.argv[1]
 with open(path, encoding="utf-8") as f:
     report = json.load(f)
 checks = {c["id"]: c for c in report["checks"]}

--- a/ods/tests/test-windows-remote-llm-tunnel.sh
+++ b/ods/tests/test-windows-remote-llm-tunnel.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+START_SCRIPT="$ROOT_DIR/scripts/start-remote-llm-tunnel.ps1"
+REGISTER_SCRIPT="$ROOT_DIR/scripts/register-remote-llm-tunnel-task.ps1"
+CHECK_SCRIPT="$ROOT_DIR/scripts/check-remote-llm.ps1"
+CONFIGURE_SCRIPT="$ROOT_DIR/scripts/configure-remote-llm.ps1"
+DOCTOR_SCRIPT="$ROOT_DIR/scripts/ods-doctor.sh"
+ENV_EXAMPLE="$ROOT_DIR/.env.example"
+ENV_SCHEMA="$ROOT_DIR/.env.schema.json"
+DOC="$ROOT_DIR/docs/REMOTE-LLM-TUNNEL.md"
+
+pass() { printf '[PASS] %s\n' "$1"; }
+fail() { printf '[FAIL] %s\n' "$1" >&2; exit 1; }
+
+require_file() {
+    [[ -f "$1" ]] && pass "$2 exists" || fail "$2 missing"
+}
+
+require_grep() {
+    local pattern="$1" file="$2" label="$3"
+    grep -Fq -- "$pattern" "$file" && pass "$label" || fail "$label"
+}
+
+reject_grep() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        fail "$label"
+    fi
+    pass "$label"
+}
+
+require_file "$START_SCRIPT" "start-remote-llm-tunnel.ps1"
+require_file "$REGISTER_SCRIPT" "register-remote-llm-tunnel-task.ps1"
+require_file "$CHECK_SCRIPT" "check-remote-llm.ps1"
+require_file "$CONFIGURE_SCRIPT" "configure-remote-llm.ps1"
+require_file "$DOC" "REMOTE-LLM-TUNNEL.md"
+
+if command -v powershell.exe >/dev/null 2>&1; then
+    PS_BIN="powershell.exe"
+elif command -v pwsh >/dev/null 2>&1; then
+    PS_BIN="pwsh"
+else
+    PS_BIN=""
+fi
+
+if [[ -n "$PS_BIN" ]]; then
+    tmp_ps="$(mktemp "${TMPDIR:-/tmp}/ods-remote-llm-parse.XXXXXX.ps1")"
+    trap 'rm -f "$tmp_ps"' EXIT
+    cat > "$tmp_ps" <<'PS_EOF'
+param([string[]]$Paths)
+$ErrorActionPreference = "Stop"
+foreach ($p in $Paths) {
+    $null = [scriptblock]::Create((Get-Content -LiteralPath $p -Raw))
+}
+Write-Host "[PASS] PowerShell scripts parse"
+PS_EOF
+    if command -v cygpath >/dev/null 2>&1; then
+        "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$(cygpath -w "$tmp_ps")" \
+            "$(cygpath -w "$START_SCRIPT")" \
+            "$(cygpath -w "$REGISTER_SCRIPT")" \
+            "$(cygpath -w "$CHECK_SCRIPT")" \
+            "$(cygpath -w "$CONFIGURE_SCRIPT")" |
+            grep -F '[PASS] PowerShell scripts parse'
+    else
+        "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$tmp_ps" \
+            "$START_SCRIPT" "$REGISTER_SCRIPT" "$CHECK_SCRIPT" "$CONFIGURE_SCRIPT" |
+            grep -F '[PASS] PowerShell scripts parse'
+    fi
+else
+    printf '[SKIP] PowerShell unavailable; static checks still run\n'
+fi
+
+require_grep 'REMOTE_LLM_TUNNEL_SSH_HOST' "$START_SCRIPT" "supervisor reads SSH host from env"
+require_grep 'REMOTE_LLM_TUNNEL_EXPECTED_MODEL' "$START_SCRIPT" "supervisor validates expected model"
+require_grep 'ExitOnForwardFailure=yes' "$START_SCRIPT" "ssh tunnel fails fast when port forward cannot bind"
+require_grep 'ServerAliveInterval=30' "$START_SCRIPT" "ssh tunnel has keepalive"
+require_grep 'BatchMode=yes' "$START_SCRIPT" "ssh tunnel is non-interactive"
+require_grep '-WindowStyle Hidden' "$START_SCRIPT" "ssh process starts hidden"
+require_grep 'Get-NetTCPConnection' "$START_SCRIPT" "supervisor checks listener ownership"
+require_grep 'System.Threading.Mutex' "$START_SCRIPT" "supervisor prevents duplicate loops"
+reject_grep 'tower2' "$START_SCRIPT" "supervisor is not Tower2-specific"
+
+require_grep 'New-ScheduledTaskTrigger -AtLogOn' "$REGISTER_SCRIPT" "task starts at user logon"
+require_grep '-RestartCount 999' "$REGISTER_SCRIPT" "task retries after launch failures"
+require_grep '-MultipleInstances IgnoreNew' "$REGISTER_SCRIPT" "task avoids duplicate supervisors"
+require_grep '-RunLevel Limited' "$REGISTER_SCRIPT" "task does not require elevation"
+
+require_grep 'docker-compose.cloud.yml' "$CONFIGURE_SCRIPT" "configure helper inserts cloud overlay"
+require_grep 'remote-llm-backup-' "$CONFIGURE_SCRIPT" "configure helper backs up runtime files"
+require_grep 'HERMES_LLM_BASE_URL' "$CONFIGURE_SCRIPT" "configure helper updates Hermes route"
+require_grep 'config\litellm\cloud.yaml' "$CONFIGURE_SCRIPT" "configure helper updates cloud LiteLLM config"
+require_grep 'REMOTE_LLM_TUNNEL_ENABLED' "$CONFIGURE_SCRIPT" "configure helper writes remote tunnel env"
+reject_grep 'tower2' "$CONFIGURE_SCRIPT" "configure helper is not Tower2-specific"
+
+require_grep 'host remote models' "$CHECK_SCRIPT" "validation checks host model list"
+require_grep 'container remote models' "$CHECK_SCRIPT" "validation checks Docker reachability"
+require_grep 'local llama-server stopped' "$CHECK_SCRIPT" "validation catches stale local inference"
+
+require_grep 'REMOTE_LLM_TUNNEL_ENABLED=false' "$ENV_EXAMPLE" "env example documents remote tunnel switch"
+require_grep '"REMOTE_LLM_TUNNEL_LOCAL_PORT"' "$ENV_SCHEMA" "env schema documents remote tunnel port"
+require_grep 'remote_llm_tunnel = _truthy(env_get("REMOTE_LLM_TUNNEL_ENABLED"))' "$DOCTOR_SCRIPT" "doctor reads remote tunnel switch"
+require_grep 'cloud_bypass_is_remote_tunnel' "$DOCTOR_SCRIPT" "doctor allows intentional direct tunnel route"
+require_grep 'Start-ScheduledTask -TaskName "ODS Remote LLM Tunnel"' "$DOC" "docs include startup command"
+
+echo "[PASS] Windows remote LLM tunnel contracts"


### PR DESCRIPTION
﻿## Summary

Adds a Windows-friendly Remote LLM Tunnel mode so an ODS laptop install can keep the local dashboard/Hermes/Open WebUI stack while forwarding OpenAI-compatible LLM inference to a workstation over a self-healing SSH local port forward.

## What changed

- Added `configure-remote-llm.ps1` to switch an installed ODS into remote inference mode, update `.env`, LiteLLM configs, Hermes configs, and `.compose-flags`, and optionally register the tunnel task.
- Added `start-remote-llm-tunnel.ps1`, a single-instance tunnel supervisor with model health checks, SSH keepalives, fail-fast port binding, log rotation, and careful stale-process cleanup.
- Added `register-remote-llm-tunnel-task.ps1` so the tunnel restarts at user logon and survives laptop reboots/sleep recovery.
- Added `check-remote-llm.ps1` for host, container, local llama-server, and optional LiteLLM validation.
- Documented the operator flow in `docs/REMOTE-LLM-TUNNEL.md` and linked it from ODS docs/vLLM docs.
- Taught `ods doctor` that an explicit remote tunnel route is an intentional cloud-mode gateway bypass.
- Added env schema/example keys plus a focused Windows remote-tunnel contract test.
- Hardened two Windows-local test harness edges found during validation: Windows `jq.exe` CRLF output in `validate-env.sh`, and native Windows Python path handling in the Linux preflight test.
- Tightened the AMD/Lemonade contract so it checks Docker image probe behavior rather than an overly literal command string.

## Validation

- `python -m json.tool ods/.env.schema.json`
- PowerShell parser check for:
  - `ods/scripts/start-remote-llm-tunnel.ps1`
  - `ods/scripts/register-remote-llm-tunnel-task.ps1`
  - `ods/scripts/check-remote-llm.ps1`
  - `ods/scripts/configure-remote-llm.ps1`
- `bash -n` for touched shell tests/scripts
- `git diff --check` for the staged file set
- `tests/test-validate-env.sh` with Windows `jq.exe`
- `tests/test-ods-doctor-install-diagnoses.sh`
- Full `ods/Makefile test` body run directly through Git Bash because `make` is not installed on this Windows host. All commands in the `test` target passed, including the new `tests/test-windows-remote-llm-tunnel.sh`.

## Notes

This intentionally reuses the existing cloud compose overlay instead of adding another backend overlay. The goal is to profile managed local `llama-server` out of the active stack while keeping the rest of ODS local and pointing model clients at a private OpenAI-compatible route.
