### PR TITLE
fix: back off Docker image pull retries

### DIFF
--- a/ods/docs/OFFLINE_AND_MIRRORING.md
+++ b/ods/docs/OFFLINE_AND_MIRRORING.md
@@ -57,9 +57,9 @@ docker push <your-registry>/<image>:<tag>
 Prefer digest-pinned records for release receipts. If a service still uses a tag
 pin, record the digest resolved during validation.
 
-On high-latency or unreliable links, the Linux installer retries transient
-Docker pull failures with `5 15 30` second backoff delays. Operators can tune
-this without editing the installer:
+On high-latency or unreliable links, the Linux installer gives transient Docker
+pull failures four attempts total, with `5 15 30` second waits between retries.
+Operators can tune this without editing the installer:
 
 ```bash
 ODS_DOCKER_PULL_MAX_ATTEMPTS=4 ODS_DOCKER_PULL_RETRY_DELAYS="10 30 60" ./install.sh

--- a/ods/docs/OFFLINE_AND_MIRRORING.md
+++ b/ods/docs/OFFLINE_AND_MIRRORING.md
@@ -57,6 +57,14 @@ docker push <your-registry>/<image>:<tag>
 Prefer digest-pinned records for release receipts. If a service still uses a tag
 pin, record the digest resolved during validation.
 
+On high-latency or unreliable links, the Linux installer retries transient
+Docker pull failures with `5 15 30` second backoff delays. Operators can tune
+this without editing the installer:
+
+```bash
+ODS_DOCKER_PULL_MAX_ATTEMPTS=4 ODS_DOCKER_PULL_RETRY_DELAYS="10 30 60" ./install.sh
+```
+
 ## Models
 
 For model mirrors:

--- a/ods/installers/lib/ui.sh
+++ b/ods/installers/lib/ui.sh
@@ -194,21 +194,61 @@ spin_task() {
   return $rc
 }
 
+_docker_pull_retry_delay() {
+  local retry_number=$1
+  local default_delays=(5 15 30)
+  local delays_raw="${ODS_DOCKER_PULL_RETRY_DELAYS:-${default_delays[*]}}"
+  local delays=()
+  read -r -a delays <<< "$delays_raw"
+
+  if (( ${#delays[@]} == 0 )); then
+    delays=("${default_delays[@]}")
+  fi
+
+  local idx=$((retry_number - 1))
+  local delay="${delays[$idx]:-}"
+
+  if [[ -z "$delay" ]]; then
+    local last_idx=$(( ${#delays[@]} - 1 ))
+    delay="${delays[$last_idx]}"
+    if ! [[ "$delay" =~ ^[0-9]+$ ]] || (( delay < 1 )); then
+      delay="${default_delays[2]}"
+    fi
+
+    local extra_steps=$((idx - last_idx))
+    local step
+    for ((step = 0; step < extra_steps; step++)); do
+      delay=$((delay * 2))
+    done
+  fi
+
+  if ! [[ "$delay" =~ ^[0-9]+$ ]] || (( delay < 1 )); then
+    delay="${default_delays[$idx]:-${default_delays[2]}}"
+  fi
+
+  printf '%s\n' "$delay"
+}
+
 # Pull wrapper that prints consistent success/fail lines with retry logic
 pull_with_progress() {
   local img=$1
   local label=$2
   local count=$3
   local total=$4
+  local configured_max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-3}"
   local max_attempts=3
   local pull_timeout=3600  # 60 minutes for large images (CUDA is ~10GB)
   local pull_pid
 
-  for attempt in $(seq 1 $max_attempts); do
+  if [[ "$configured_max_attempts" =~ ^[0-9]+$ ]] && (( configured_max_attempts >= 1 )); then
+    max_attempts=$configured_max_attempts
+  fi
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if [[ $attempt -gt 1 ]]; then
-      printf "  ${AMB}⟳${NC} [$count/$total] Retry attempt $attempt of $max_attempts for $label\n"
-      # Exponential backoff: 2s, 5s, 10s
-      local backoff=$((2 * (2 ** (attempt - 2)) + (attempt - 2)))
+      local backoff
+      backoff="$(_docker_pull_retry_delay "$((attempt - 1))")"
+      printf "  ${AMB}⟳${NC} [$count/$total] Retry attempt $attempt of $max_attempts for $label (waiting ${backoff}s)\n"
       sleep "$backoff"
     fi
 

--- a/ods/installers/lib/ui.sh
+++ b/ods/installers/lib/ui.sh
@@ -235,8 +235,8 @@ pull_with_progress() {
   local label=$2
   local count=$3
   local total=$4
-  local configured_max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-3}"
-  local max_attempts=3
+  local configured_max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-4}"
+  local max_attempts=4
   local pull_timeout=3600  # 60 minutes for large images (CUDA is ~10GB)
   local pull_pid
 

--- a/ods/tests/test-docker-image-pull-retry.sh
+++ b/ods/tests/test-docker-image-pull-retry.sh
@@ -184,6 +184,24 @@ else
   fi
 fi
 
+printf "  %-60s " "uses full default retry schedule before giving up..."
+rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
+export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-default-timeout"
+export SLEEP_LOG="$TMP_DIR/sleep-default-timeout.log"
+rm -f "$DOCKER_MOCK_STATE_FILE" "$SLEEP_LOG"
+if run_pull_with_progress "$TMP_DIR/docker-always-timeout" "img" "label"; then
+  print_fail "(unexpected success)"
+else
+  attempts=$(cat "$DOCKER_MOCK_STATE_FILE" 2>/dev/null || echo 0)
+  sleeps=$(sed 's/[[:space:]]*$//' "$SLEEP_LOG" 2>/dev/null || true)
+  if [[ "$attempts" == "4" && "$sleeps" == "5 15 30" ]]; then
+    print_pass
+  else
+    print_fail "(attempts=$attempts, expected 4; sleeps='$sleeps', expected '5 15 30')"
+  fi
+fi
+unset SLEEP_LOG
+
 printf "  %-60s " "supports configurable retry delays and attempts..."
 rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
 export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-configurable"
@@ -233,13 +251,13 @@ echo ""
 echo "3. Retry Strategy Tests (source-level sanity checks)"
 echo "────────────────────────────────────────────────────"
 
-printf "  %-60s " "max_attempts is 3..."
+printf "  %-60s " "max_attempts is 4..."
 retry_count=$(grep -A 15 "^pull_with_progress()" "$ROOT_DIR/installers/lib/ui.sh" | grep -m1 "max_attempts=" | grep -oE '[0-9]+' || true)
 retry_count=${retry_count:-0}
-if [[ "$retry_count" == "3" ]]; then
+if [[ "$retry_count" == "4" ]]; then
   print_pass
 else
-  print_fail "(found $retry_count, expected 3)"
+  print_fail "(found $retry_count, expected 4)"
 fi
 
 printf "  %-60s " "default retry delays are 5s, 15s, 30s..."

--- a/ods/tests/test-docker-image-pull-retry.sh
+++ b/ods/tests/test-docker-image-pull-retry.sh
@@ -49,11 +49,15 @@ run_pull_with_progress() {
     GRN=""; BGRN=""; DGRN=""; AMB=""; WHT=""; RED=""; NC=""; CURSOR=""
     VERSION="test"; INTERACTIVE="false"; DRY_RUN=false
 
-    # Keep CI fast
-    sleep() { :; }
-    spin_task() { local pid="$1"; wait "$pid"; }
+    # Keep CI fast while preserving the requested retry delays for assertions.
+    sleep() {
+      if [[ -n "${SLEEP_LOG:-}" ]]; then
+        printf "%s " "$1" >> "$SLEEP_LOG"
+      fi
+    }
 
     source "$ROOT_DIR/installers/lib/ui.sh"
+    spin_task() { local pid="$1"; wait "$pid"; }
     pull_with_progress "$IMG" "$LABEL" "$COUNT" "$TOTAL"
   ' _ "$docker_cmd" "$img" "$label" "$count" "$total" "$ROOT_DIR" \
     >>"$TMP_DIR/stdout.log" 2>>"$TMP_DIR/stderr.log"
@@ -86,11 +90,11 @@ cat >"$TMP_DIR/docker-fail-then-succeed" <<'EOF'
 #!/usr/bin/env bash
 state_file="${DOCKER_MOCK_STATE_FILE}"
 : "${state_file:?DOCKER_MOCK_STATE_FILE required}"
-count=$(cat "$state_file" 2>/dev/null || echo 0)
-count=$((count + 1))
-echo "$count" > "$state_file"
 
 if [[ "$1" == "pull" ]]; then
+  count=$(cat "$state_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$state_file"
   if [[ $count -lt 3 ]]; then
     echo "network timeout" >&2
     exit 1
@@ -102,15 +106,31 @@ exit 0
 EOF
 chmod +x "$TMP_DIR/docker-fail-then-succeed"
 
+cat >"$TMP_DIR/docker-always-timeout" <<'EOF'
+#!/usr/bin/env bash
+state_file="${DOCKER_MOCK_STATE_FILE}"
+: "${state_file:?DOCKER_MOCK_STATE_FILE required}"
+
+if [[ "$1" == "pull" ]]; then
+  count=$(cat "$state_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$state_file"
+  echo "network timeout" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$TMP_DIR/docker-always-timeout"
+
 cat >"$TMP_DIR/docker-unauthorized" <<'EOF'
 #!/usr/bin/env bash
 state_file="${DOCKER_MOCK_STATE_FILE}"
 : "${state_file:?DOCKER_MOCK_STATE_FILE required}"
-count=$(cat "$state_file" 2>/dev/null || echo 0)
-count=$((count + 1))
-echo "$count" > "$state_file"
 
 if [[ "$1" == "pull" ]]; then
+  count=$(cat "$state_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$state_file"
   echo "Error response from daemon: unauthorized: authentication required" >&2
   exit 1
 fi
@@ -133,17 +153,21 @@ fi
 printf "  %-60s " "retries transient failures and succeeds..."
 rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
 export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-transient"
+export SLEEP_LOG="$TMP_DIR/sleep-transient.log"
 rm -f "$DOCKER_MOCK_STATE_FILE"
+rm -f "$SLEEP_LOG"
 if run_pull_with_progress "$TMP_DIR/docker-fail-then-succeed" "img" "label"; then
   attempts=$(cat "$DOCKER_MOCK_STATE_FILE" 2>/dev/null || echo 0)
-  if [[ "$attempts" == "3" ]]; then
+  sleeps=$(sed 's/[[:space:]]*$//' "$SLEEP_LOG" 2>/dev/null || true)
+  if [[ "$attempts" == "3" && "$sleeps" == "5 15" ]]; then
     print_pass
   else
-    print_fail "(attempts=$attempts, expected 3)"
+    print_fail "(attempts=$attempts, expected 3; sleeps='$sleeps', expected '5 15')"
   fi
 else
   print_fail
 fi
+unset SLEEP_LOG
 
 printf "  %-60s " "fails fast on unauthorized (no retries)..."
 rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
@@ -159,6 +183,26 @@ else
     print_fail "(attempts=$attempts, expected 1)"
   fi
 fi
+
+printf "  %-60s " "supports configurable retry delays and attempts..."
+rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
+export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-configurable"
+export SLEEP_LOG="$TMP_DIR/sleep-configurable.log"
+export ODS_DOCKER_PULL_MAX_ATTEMPTS=4
+export ODS_DOCKER_PULL_RETRY_DELAYS="1 2"
+rm -f "$DOCKER_MOCK_STATE_FILE" "$SLEEP_LOG"
+if run_pull_with_progress "$TMP_DIR/docker-always-timeout" "img" "label"; then
+  print_fail "(unexpected success)"
+else
+  attempts=$(cat "$DOCKER_MOCK_STATE_FILE" 2>/dev/null || echo 0)
+  sleeps=$(sed 's/[[:space:]]*$//' "$SLEEP_LOG" 2>/dev/null || true)
+  if [[ "$attempts" == "4" && "$sleeps" == "1 2 4" ]]; then
+    print_pass
+  else
+    print_fail "(attempts=$attempts, expected 4; sleeps='$sleeps', expected '1 2 4')"
+  fi
+fi
+unset ODS_DOCKER_PULL_MAX_ATTEMPTS ODS_DOCKER_PULL_RETRY_DELAYS SLEEP_LOG
 
 echo ""
 echo "2. Integration Tests"
@@ -198,11 +242,20 @@ else
   print_fail "(found $retry_count, expected 3)"
 fi
 
-printf "  %-60s " "backoff uses exponential formula..."
-if grep -A 30 "^pull_with_progress()" "$ROOT_DIR/installers/lib/ui.sh" | grep -Fq "5 * (2 ** (attempt - 2))"; then
+printf "  %-60s " "default retry delays are 5s, 15s, 30s..."
+default_delays=$(
+  bash -c '
+    set -euo pipefail
+    source "$1"
+    _docker_pull_retry_delay 1
+    _docker_pull_retry_delay 2
+    _docker_pull_retry_delay 3
+  ' _ "$ROOT_DIR/installers/lib/ui.sh" | paste -sd ' '
+)
+if [[ "$default_delays" == "5 15 30" ]]; then
   print_pass
 else
-  print_fail
+  print_fail "(found '$default_delays')"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- replace the too-aggressive Docker image pull retry waits with a configurable backoff sequence, defaulting to `5 15 30` seconds
- use four pull attempts by default: initial attempt plus three retries, so transient DNS/CDN outages get the full `5s`, `15s`, and `30s` cooldown sequence
- allow operators to tune attempts/delays for unusually slow DNS or CDN paths
- strengthen the Docker pull retry contract test to assert actual sleep delays, default give-up behavior, and configurable retry behavior
- document the installer knobs in the offline/mirroring Docker image section

Fixes #1634

## Validation
- `./ods/tests/test-docker-image-pull-retry.sh` — 10/10 passed
- `./ods/tests/test-network-timeouts.sh` — 17/17 passed
- `bash -n ods/installers/lib/ui.sh`
- `bash -n ods/tests/test-docker-image-pull-retry.sh`
- `git diff --check`