### PR TITLE
fix: force locale-safe CPU env formatting

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -73,7 +73,7 @@ upsert_env_value() {
 
 cap_cpu_value() {
     local desired="$1" ceiling="$2"
-    awk -v desired="$desired" -v ceiling="$ceiling" '
+    LC_ALL=C awk -v desired="$desired" -v ceiling="$ceiling" '
         BEGIN {
             if (ceiling <= 0) ceiling = 1
             value = desired

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -185,7 +185,7 @@ select_auto_cpu_value() {
 
 cap_cpu_value() {
     local desired="$1" ceiling="$2"
-    awk -v desired="$desired" -v ceiling="$ceiling" '
+    LC_ALL=C awk -v desired="$desired" -v ceiling="$ceiling" '
         BEGIN {
             if (ceiling <= 0) ceiling = 1
             value = desired

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -489,7 +489,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
 
     _cap_cpu_value() {
         local desired="$1" ceiling="$2"
-        awk -v desired="$desired" -v ceiling="$ceiling" '
+        LC_ALL=C awk -v desired="$desired" -v ceiling="$ceiling" '
             BEGIN {
                 if (ceiling <= 0) ceiling = 1
                 value = desired

--- a/ods/tests/test-locale-safe-cpu-formatting.sh
+++ b/ods/tests/test-locale-safe-cpu-formatting.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression guard for issue #1614: CPU budget values written to .env must
+# always use dot decimals, even when the parent shell has a decimal-comma locale.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+TMP_DIR=""
+
+cleanup() {
+    [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+require_scoped_awk() {
+    local file="$1"
+    local label="$2"
+    if grep -Eq 'LC_ALL=C[[:space:]]+awk[[:space:]]+-v[[:space:]]+desired=' "$ROOT_DIR/$file"; then
+        pass "$label scopes CPU formatting awk to C locale"
+    else
+        fail "$label must use LC_ALL=C for CPU formatting awk"
+    fi
+}
+
+echo ""
+echo "Locale-safe CPU formatting"
+echo "--------------------------"
+
+require_scoped_awk "installers/phases/06-directories.sh" "Linux phase 06"
+require_scoped_awk "installers/macos/lib/env-generator.sh" "macOS env generator"
+require_scoped_awk "installers/macos/ods-macos.sh" "macOS installer"
+
+TMP_DIR="$(mktemp -d)"
+cat > "$TMP_DIR/awk" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${LC_ALL:-${LC_NUMERIC:-}}" == "C" ]]; then
+    printf '4.0\n'
+else
+    printf '4,0\n'
+fi
+EOF
+chmod +x "$TMP_DIR/awk"
+
+result="$(
+    PATH="$TMP_DIR:$PATH" LC_ALL=fr_FR.UTF-8 bash -c '
+        source "$1"
+        cap_cpu_value 8.0 4
+    ' _ "$ROOT_DIR/installers/macos/lib/env-generator.sh"
+)"
+
+if [[ "$result" == "4.0" ]]; then
+    pass "cap_cpu_value emits dot decimals under decimal-comma parent locale"
+else
+    fail "cap_cpu_value emitted '$result' instead of '4.0'"
+fi
+
+echo ""
+if [[ $FAILED -eq 0 ]]; then
+    echo -e "${GREEN}All locale-safe CPU formatting tests passed${NC} ($PASSED/$((PASSED + FAILED)))"
+    exit 0
+else
+    echo -e "${RED}Locale-safe CPU formatting tests failed${NC} ($PASSED passed, $FAILED failed)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- force the CPU capping awk calls to run under `LC_ALL=C` so generated `.env` CPU limits/reservations always use dot decimals
- cover Linux Phase 06, the reusable macOS env generator, and the standalone macOS installer helper
- add a focused regression test that simulates a decimal-comma parent locale with a fake `awk` and verifies the helper still emits `4.0`

Fixes #1614

## Validation
- `./ods/tests/test-locale-safe-cpu-formatting.sh` — 4/4 passed
- `bash -n ods/installers/phases/06-directories.sh`
- `bash -n ods/installers/macos/lib/env-generator.sh`
- `bash -n ods/installers/macos/ods-macos.sh`
- `bash -n ods/tests/test-locale-safe-cpu-formatting.sh`
- `git diff --check`

## Notes
PR #1636 has the same core locale fix but no reported checks; this version adds a regression guard and will run repository CI from a repo branch.