### PR TITLE
[codex] bundle safe stabilization fixes

### DIFF
--- a/ods/docs/OFFLINE_AND_MIRRORING.md
+++ b/ods/docs/OFFLINE_AND_MIRRORING.md
@@ -57,9 +57,9 @@ docker push <your-registry>/<image>:<tag>
 Prefer digest-pinned records for release receipts. If a service still uses a tag
 pin, record the digest resolved during validation.
 
-On high-latency or unreliable links, the Linux installer retries transient
-Docker pull failures with `5 15 30` second backoff delays. Operators can tune
-this without editing the installer:
+On high-latency or unreliable links, the Linux installer gives transient Docker
+pull failures four attempts total, with `5 15 30` second waits between retries.
+Operators can tune this without editing the installer:
 
 ```bash
 ODS_DOCKER_PULL_MAX_ATTEMPTS=4 ODS_DOCKER_PULL_RETRY_DELAYS="10 30 60" ./install.sh

--- a/ods/docs/OFFLINE_AND_MIRRORING.md
+++ b/ods/docs/OFFLINE_AND_MIRRORING.md
@@ -57,6 +57,14 @@ docker push <your-registry>/<image>:<tag>
 Prefer digest-pinned records for release receipts. If a service still uses a tag
 pin, record the digest resolved during validation.
 
+On high-latency or unreliable links, the Linux installer retries transient
+Docker pull failures with `5 15 30` second backoff delays. Operators can tune
+this without editing the installer:
+
+```bash
+ODS_DOCKER_PULL_MAX_ATTEMPTS=4 ODS_DOCKER_PULL_RETRY_DELAYS="10 30 60" ./install.sh
+```
+
 ## Models
 
 For model mirrors:

--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -551,11 +551,19 @@ def get_gpu_info_nvidia_detailed() -> Optional[list[IndividualGPU]]:
 def _find_hwmon_temp(hwmon_dir: str) -> int:
     """Find GPU temperature via hwmon label-based discovery (junction > edge > temp1)."""
     import glob as _glob
-    # Prefer junction temperature (accurate die temp), then edge
+    # Map each label to its temp*_input first, so the junction-over-edge
+    # preference holds regardless of which tempN node carries each label.
+    # On many AMD cards edge is temp1 and junction is temp2; scanning in file
+    # order would otherwise return edge even when the more accurate junction
+    # die temperature is available.
+    inputs_by_label: dict[str, str] = {}
     for label_path in sorted(_glob.glob(f"{hwmon_dir}/temp*_label")):
         label = _read_sysfs(label_path)
-        if label and label.lower() in ("junction", "edge"):
-            input_path = label_path.replace("_label", "_input")
+        if label:
+            inputs_by_label.setdefault(label.lower(), label_path.replace("_label", "_input"))
+    for preferred in ("junction", "edge"):
+        input_path = inputs_by_label.get(preferred)
+        if input_path:
             temp_str = _read_sysfs(input_path)
             if temp_str:
                 return int(temp_str) // 1000

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -59,32 +59,54 @@ logger = logging.getLogger(__name__)
 # poll cycle and prevents file-descriptor exhaustion.
 
 _aio_session: Optional[aiohttp.ClientSession] = None
+_aio_session_lock: Optional[asyncio.Lock] = None
 _HEALTH_TIMEOUT = aiohttp.ClientTimeout(total=30)
 # Short timeout for the catalog fan-out: one slow probe must not stall the
 # whole Extensions page (frontend aborts after 8 s).
 _CATALOG_HEALTH_TIMEOUT = aiohttp.ClientTimeout(total=5)
 
 
+def _get_aio_session_lock() -> asyncio.Lock:
+    global _aio_session_lock
+    if _aio_session_lock is None:
+        _aio_session_lock = asyncio.Lock()
+    return _aio_session_lock
+
+
 async def _get_aio_session() -> aiohttp.ClientSession:
     """Return (and lazily create) a module-level aiohttp session."""
     global _aio_session
-    if _aio_session is None or _aio_session.closed:
-        _aio_session = aiohttp.ClientSession(
-            timeout=_HEALTH_TIMEOUT,
-            connector=aiohttp.TCPConnector(family=socket.AF_INET),
-        )
+    if _aio_session is not None and not _aio_session.closed:
+        return _aio_session
+    async with _get_aio_session_lock():
+        if _aio_session is None or _aio_session.closed:
+            _aio_session = aiohttp.ClientSession(
+                timeout=_HEALTH_TIMEOUT,
+                connector=aiohttp.TCPConnector(family=socket.AF_INET),
+            )
     return _aio_session
 
 
 # Shared httpx client for llama-server requests (connection pooling)
 _httpx_client: Optional[httpx.AsyncClient] = None
+_httpx_client_lock: Optional[asyncio.Lock] = None
+
+
+def _get_httpx_client_lock() -> asyncio.Lock:
+    global _httpx_client_lock
+    if _httpx_client_lock is None:
+        _httpx_client_lock = asyncio.Lock()
+    return _httpx_client_lock
 
 
 async def _get_httpx_client() -> httpx.AsyncClient:
     """Return (and lazily create) a module-level httpx async client."""
     global _httpx_client
-    if _httpx_client is None or _httpx_client.is_closed:
-        _httpx_client = httpx.AsyncClient(timeout=5.0)
+    if _httpx_client is not None and not _httpx_client.is_closed:
+        return _httpx_client
+    async with _get_httpx_client_lock():
+        if _httpx_client is None or _httpx_client.is_closed:
+            _httpx_client = httpx.AsyncClient(timeout=5.0)
     return _httpx_client
 
 
@@ -555,7 +577,9 @@ def dir_size_gb(path: Path) -> float:
     try:
         for f in path.rglob("*"):
             try:
-                if f.is_file() and not f.is_symlink():
+                if f.is_symlink():
+                    continue
+                if f.is_file():
                     total += f.stat().st_size
             except (PermissionError, OSError):
                 pass

--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -145,7 +145,18 @@ def _get_cached_release_payload(allow_stale: bool = False) -> Optional[dict]:
     return None
 
 
+def _normalize_version(value: Optional[str]) -> str:
+    """Normalize a version string for comparison and display.
+
+    GitHub release tags are ``vX.Y.Z`` while ``.env``/``.version`` may store
+    either form, so strip a leading ``v`` (and surrounding whitespace) to keep
+    ``current`` and ``latest`` on the same footing.
+    """
+    return (value or "").strip().lstrip("v")
+
+
 def _build_version_result(current: str, payload: Optional[dict]) -> dict:
+    current = _normalize_version(current)
     result = {
         "current": current,
         "latest": None,
@@ -156,7 +167,7 @@ def _build_version_result(current: str, payload: Optional[dict]) -> dict:
     if not payload:
         return result
 
-    latest = (payload.get("latest") or "").lstrip("v")
+    latest = _normalize_version(payload.get("latest"))
     if not latest:
         return result
 
@@ -285,6 +296,7 @@ async def get_update_dry_run():
             current = (parsed or {}).get("version", raw) or raw or "0.0.0"
         except (json.JSONDecodeError, OSError):
             pass
+    current = _normalize_version(current)
 
     # ── latest version from GitHub ────────────────────────────────────────────
     latest: Optional[str] = None
@@ -299,7 +311,7 @@ async def get_update_dry_run():
                 headers=_GITHUB_HEADERS,
             )
         data = resp.json()
-        latest = data.get("tag_name", "").lstrip("v") or None
+        latest = _normalize_version(data.get("tag_name")) or None
         changelog_url = data.get("html_url") or None
         if latest:
             def _parts(v: str) -> list[int]:

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_amd.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_amd.py
@@ -35,6 +35,20 @@ class TestFindHwmonTemp:
         # junction (72000) is preferred over edge (65000)
         assert result == 72
 
+    def test_prefers_junction_when_edge_sorts_first(self, tmp_path):
+        """Common desktop AMD layout: temp1=edge, temp2=junction. Junction is
+        the accurate die temp and must win even though edge's node sorts first.
+        """
+        hwmon = tmp_path / "hwmon0"
+        hwmon.mkdir()
+        (hwmon / "temp1_label").write_text("edge\n")
+        (hwmon / "temp1_input").write_text("65000\n")
+        (hwmon / "temp2_label").write_text("junction\n")
+        (hwmon / "temp2_input").write_text("72000\n")
+
+        result = _find_hwmon_temp(str(hwmon))
+        assert result == 72
+
     def test_falls_back_to_edge(self, monkeypatch, tmp_path):
         """When no junction label, use edge."""
         hwmon = tmp_path / "hwmon0"

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -16,7 +16,7 @@ from helpers import (
     get_llama_metrics, get_loaded_model, get_llama_context_size,
     get_disk_usage, dir_size_gb, invalidate_dir_size_cache, clear_dir_size_cache,
     _get_aio_session, set_services_cache, get_cached_services,
-    _get_lifetime_tokens,
+    _get_httpx_client, _get_lifetime_tokens,
 )
 from models import BootstrapStatus, ServiceStatus, DiskUsage
 
@@ -681,6 +681,7 @@ class TestGetAioSession:
     async def test_creates_session(self, monkeypatch):
         import helpers
         monkeypatch.setattr(helpers, "_aio_session", None)
+        monkeypatch.setattr(helpers, "_aio_session_lock", None)
         session = await _get_aio_session()
         assert session is not None
         await session.close()
@@ -689,10 +690,61 @@ class TestGetAioSession:
     async def test_reuses_session(self, monkeypatch):
         import helpers
         monkeypatch.setattr(helpers, "_aio_session", None)
+        monkeypatch.setattr(helpers, "_aio_session_lock", None)
         s1 = await _get_aio_session()
         s2 = await _get_aio_session()
         assert s1 is s2
         await s1.close()
+
+    @pytest.mark.asyncio
+    async def test_waits_for_singleton_lock_before_creating_session(self, monkeypatch):
+        import helpers
+        lock = asyncio.Lock()
+        await lock.acquire()
+        monkeypatch.setattr(helpers, "_aio_session", None)
+        monkeypatch.setattr(helpers, "_aio_session_lock", lock)
+
+        task = asyncio.create_task(_get_aio_session())
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        lock.release()
+        session = await task
+        assert session is not None
+        await session.close()
+
+
+# --- _get_httpx_client ---
+
+
+class TestGetHttpxClient:
+
+    @pytest.mark.asyncio
+    async def test_reuses_client(self, monkeypatch):
+        import helpers
+        monkeypatch.setattr(helpers, "_httpx_client", None)
+        monkeypatch.setattr(helpers, "_httpx_client_lock", None)
+        c1 = await _get_httpx_client()
+        c2 = await _get_httpx_client()
+        assert c1 is c2
+        await c1.aclose()
+
+    @pytest.mark.asyncio
+    async def test_waits_for_singleton_lock_before_creating_client(self, monkeypatch):
+        import helpers
+        lock = asyncio.Lock()
+        await lock.acquire()
+        monkeypatch.setattr(helpers, "_httpx_client", None)
+        monkeypatch.setattr(helpers, "_httpx_client_lock", lock)
+
+        task = asyncio.create_task(_get_httpx_client())
+        await asyncio.sleep(0)
+
+        assert not task.done()
+        lock.release()
+        client = await task
+        assert client is not None
+        await client.aclose()
 
 
 # --- set_services_cache / get_cached_services ---
@@ -989,6 +1041,13 @@ class TestBootstrapStatusEtaEdge:
 
 class TestDirSizeGb:
 
+    @staticmethod
+    def _symlink_or_skip(link: Path, target: Path):
+        try:
+            link.symlink_to(target)
+        except OSError as exc:
+            pytest.skip(f"symlink creation unavailable in this test environment: {exc}")
+
     def test_nonexistent_path_returns_zero(self, tmp_path):
         clear_dir_size_cache()
         assert dir_size_gb(tmp_path / "does-not-exist") == 0.0
@@ -1015,10 +1074,29 @@ class TestDirSizeGb:
         real = d / "real.bin"
         real.write_bytes(b"\x00" * 1024)
         link = d / "link.bin"
-        link.symlink_to(real)
+        self._symlink_or_skip(link, real)
         # Only real.bin should be counted (1024 B ≈ 0.0 GB when rounded to 2dp)
         result = dir_size_gb(d)
         assert result == 0.0  # 1024 bytes rounds to 0.0 GB
+
+    def test_checks_symlink_before_is_file(self, tmp_path, monkeypatch):
+        clear_dir_size_cache()
+        d = tmp_path / "withlinks"
+        d.mkdir()
+        outside = tmp_path / "outside.bin"
+        outside.write_bytes(b"\x00" * 1024)
+        link = d / "outside-link.bin"
+        self._symlink_or_skip(link, outside)
+
+        original_is_file = Path.is_file
+
+        def guarded_is_file(self):
+            if self == link:
+                raise AssertionError("dir_size_gb called is_file before skipping symlink")
+            return original_is_file(self)
+
+        monkeypatch.setattr(Path, "is_file", guarded_is_file)
+        assert dir_size_gb(d) == 0.0
 
     def test_uses_cached_value_until_invalidated(self, tmp_path, monkeypatch):
         clear_dir_size_cache()

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -61,6 +61,29 @@ def test_get_version_with_mock_github(test_client, monkeypatch):
     assert data["changelog_url"] == "https://github.com/test"
 
 
+def test_build_version_result_strips_v_prefix_from_current():
+    """Current versions stored with a 'v' prefix (matching the release tag
+    convention, e.g. a .version file of 'v2.5.3') must normalize before
+    comparison. Otherwise the numeric parser misreads them and a real update
+    is reported as unavailable.
+    """
+    from routers.updates import _build_version_result
+
+    result = _build_version_result("v2.5.3", {"latest": "2.6.0"})
+    assert result["current"] == "2.5.3"
+    assert result["update_available"] is True
+
+
+def test_build_version_result_handles_v_prefix_on_both_sides():
+    """A 'v' on either side must not affect the comparison."""
+    from routers.updates import _build_version_result
+
+    result = _build_version_result("v2.6.0", {"latest": "v2.6.0"})
+    assert result["current"] == "2.6.0"
+    assert result["latest"] == "2.6.0"
+    assert result["update_available"] is False
+
+
 def test_get_releases_manifest_requires_auth(test_client):
     """GET /api/releases/manifest without auth → 401."""
     resp = test_client.get("/api/releases/manifest")
@@ -316,6 +339,42 @@ def test_update_dry_run_version_from_json_version_file(test_client, tmp_path, mo
 
     assert resp.status_code == 200
     assert resp.json()["current_version"] == "3.1.4"
+
+
+def test_update_dry_run_normalizes_v_prefixed_version(test_client, tmp_path, monkeypatch):
+    """A .version file written as 'v2.0.1' must still compare against the latest
+    release tag correctly. Before normalization the 'v' prefix broke parsing, so
+    a newer release showed up as update_available=False.
+    """
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "dream-server"
+    install_dir.mkdir()
+    (install_dir / ".version").write_text("v2.0.1")
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {
+        "tag_name": "v2.6.0",
+        "html_url": "https://github.com/test",
+    }
+
+    async def mock_get(url, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/update/dry-run", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["current_version"] == "2.0.1"
+    assert data["latest_version"] == "2.6.0"
+    assert data["update_available"] is True
 
 
 def test_update_dry_run_reads_compose_images(test_client, tmp_path, monkeypatch):

--- a/ods/installers/lib/ui.sh
+++ b/ods/installers/lib/ui.sh
@@ -194,21 +194,61 @@ spin_task() {
   return $rc
 }
 
+_docker_pull_retry_delay() {
+  local retry_number=$1
+  local default_delays=(5 15 30)
+  local delays_raw="${ODS_DOCKER_PULL_RETRY_DELAYS:-${default_delays[*]}}"
+  local delays=()
+  read -r -a delays <<< "$delays_raw"
+
+  if (( ${#delays[@]} == 0 )); then
+    delays=("${default_delays[@]}")
+  fi
+
+  local idx=$((retry_number - 1))
+  local delay="${delays[$idx]:-}"
+
+  if [[ -z "$delay" ]]; then
+    local last_idx=$(( ${#delays[@]} - 1 ))
+    delay="${delays[$last_idx]}"
+    if ! [[ "$delay" =~ ^[0-9]+$ ]] || (( delay < 1 )); then
+      delay="${default_delays[2]}"
+    fi
+
+    local extra_steps=$((idx - last_idx))
+    local step
+    for ((step = 0; step < extra_steps; step++)); do
+      delay=$((delay * 2))
+    done
+  fi
+
+  if ! [[ "$delay" =~ ^[0-9]+$ ]] || (( delay < 1 )); then
+    delay="${default_delays[$idx]:-${default_delays[2]}}"
+  fi
+
+  printf '%s\n' "$delay"
+}
+
 # Pull wrapper that prints consistent success/fail lines with retry logic
 pull_with_progress() {
   local img=$1
   local label=$2
   local count=$3
   local total=$4
+  local configured_max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-3}"
   local max_attempts=3
   local pull_timeout=3600  # 60 minutes for large images (CUDA is ~10GB)
   local pull_pid
 
-  for attempt in $(seq 1 $max_attempts); do
+  if [[ "$configured_max_attempts" =~ ^[0-9]+$ ]] && (( configured_max_attempts >= 1 )); then
+    max_attempts=$configured_max_attempts
+  fi
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
     if [[ $attempt -gt 1 ]]; then
-      printf "  ${AMB}⟳${NC} [$count/$total] Retry attempt $attempt of $max_attempts for $label\n"
-      # Exponential backoff: 2s, 5s, 10s
-      local backoff=$((2 * (2 ** (attempt - 2)) + (attempt - 2)))
+      local backoff
+      backoff="$(_docker_pull_retry_delay "$((attempt - 1))")"
+      printf "  ${AMB}⟳${NC} [$count/$total] Retry attempt $attempt of $max_attempts for $label (waiting ${backoff}s)\n"
       sleep "$backoff"
     fi
 

--- a/ods/installers/lib/ui.sh
+++ b/ods/installers/lib/ui.sh
@@ -235,8 +235,8 @@ pull_with_progress() {
   local label=$2
   local count=$3
   local total=$4
-  local configured_max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-3}"
-  local max_attempts=3
+  local configured_max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-4}"
+  local max_attempts=4
   local pull_timeout=3600  # 60 minutes for large images (CUDA is ~10GB)
   local pull_pid
 

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -73,7 +73,7 @@ upsert_env_value() {
 
 cap_cpu_value() {
     local desired="$1" ceiling="$2"
-    awk -v desired="$desired" -v ceiling="$ceiling" '
+    LC_ALL=C awk -v desired="$desired" -v ceiling="$ceiling" '
         BEGIN {
             if (ceiling <= 0) ceiling = 1
             value = desired

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -185,7 +185,7 @@ select_auto_cpu_value() {
 
 cap_cpu_value() {
     local desired="$1" ceiling="$2"
-    awk -v desired="$desired" -v ceiling="$ceiling" '
+    LC_ALL=C awk -v desired="$desired" -v ceiling="$ceiling" '
         BEGIN {
             if (ceiling <= 0) ceiling = 1
             value = desired

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -489,7 +489,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
 
     _cap_cpu_value() {
         local desired="$1" ceiling="$2"
-        awk -v desired="$desired" -v ceiling="$ceiling" '
+        LC_ALL=C awk -v desired="$desired" -v ceiling="$ceiling" '
             BEGIN {
                 if (ceiling <= 0) ceiling = 1
                 value = desired

--- a/ods/tests/test-docker-image-pull-retry.sh
+++ b/ods/tests/test-docker-image-pull-retry.sh
@@ -184,6 +184,24 @@ else
   fi
 fi
 
+printf "  %-60s " "uses full default retry schedule before giving up..."
+rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
+export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-default-timeout"
+export SLEEP_LOG="$TMP_DIR/sleep-default-timeout.log"
+rm -f "$DOCKER_MOCK_STATE_FILE" "$SLEEP_LOG"
+if run_pull_with_progress "$TMP_DIR/docker-always-timeout" "img" "label"; then
+  print_fail "(unexpected success)"
+else
+  attempts=$(cat "$DOCKER_MOCK_STATE_FILE" 2>/dev/null || echo 0)
+  sleeps=$(sed 's/[[:space:]]*$//' "$SLEEP_LOG" 2>/dev/null || true)
+  if [[ "$attempts" == "4" && "$sleeps" == "5 15 30" ]]; then
+    print_pass
+  else
+    print_fail "(attempts=$attempts, expected 4; sleeps='$sleeps', expected '5 15 30')"
+  fi
+fi
+unset SLEEP_LOG
+
 printf "  %-60s " "supports configurable retry delays and attempts..."
 rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
 export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-configurable"
@@ -233,13 +251,13 @@ echo ""
 echo "3. Retry Strategy Tests (source-level sanity checks)"
 echo "────────────────────────────────────────────────────"
 
-printf "  %-60s " "max_attempts is 3..."
+printf "  %-60s " "max_attempts is 4..."
 retry_count=$(grep -A 15 "^pull_with_progress()" "$ROOT_DIR/installers/lib/ui.sh" | grep -m1 "max_attempts=" | grep -oE '[0-9]+' || true)
 retry_count=${retry_count:-0}
-if [[ "$retry_count" == "3" ]]; then
+if [[ "$retry_count" == "4" ]]; then
   print_pass
 else
-  print_fail "(found $retry_count, expected 3)"
+  print_fail "(found $retry_count, expected 4)"
 fi
 
 printf "  %-60s " "default retry delays are 5s, 15s, 30s..."

--- a/ods/tests/test-docker-image-pull-retry.sh
+++ b/ods/tests/test-docker-image-pull-retry.sh
@@ -49,11 +49,15 @@ run_pull_with_progress() {
     GRN=""; BGRN=""; DGRN=""; AMB=""; WHT=""; RED=""; NC=""; CURSOR=""
     VERSION="test"; INTERACTIVE="false"; DRY_RUN=false
 
-    # Keep CI fast
-    sleep() { :; }
-    spin_task() { local pid="$1"; wait "$pid"; }
+    # Keep CI fast while preserving the requested retry delays for assertions.
+    sleep() {
+      if [[ -n "${SLEEP_LOG:-}" ]]; then
+        printf "%s " "$1" >> "$SLEEP_LOG"
+      fi
+    }
 
     source "$ROOT_DIR/installers/lib/ui.sh"
+    spin_task() { local pid="$1"; wait "$pid"; }
     pull_with_progress "$IMG" "$LABEL" "$COUNT" "$TOTAL"
   ' _ "$docker_cmd" "$img" "$label" "$count" "$total" "$ROOT_DIR" \
     >>"$TMP_DIR/stdout.log" 2>>"$TMP_DIR/stderr.log"
@@ -86,11 +90,11 @@ cat >"$TMP_DIR/docker-fail-then-succeed" <<'EOF'
 #!/usr/bin/env bash
 state_file="${DOCKER_MOCK_STATE_FILE}"
 : "${state_file:?DOCKER_MOCK_STATE_FILE required}"
-count=$(cat "$state_file" 2>/dev/null || echo 0)
-count=$((count + 1))
-echo "$count" > "$state_file"
 
 if [[ "$1" == "pull" ]]; then
+  count=$(cat "$state_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$state_file"
   if [[ $count -lt 3 ]]; then
     echo "network timeout" >&2
     exit 1
@@ -102,15 +106,31 @@ exit 0
 EOF
 chmod +x "$TMP_DIR/docker-fail-then-succeed"
 
+cat >"$TMP_DIR/docker-always-timeout" <<'EOF'
+#!/usr/bin/env bash
+state_file="${DOCKER_MOCK_STATE_FILE}"
+: "${state_file:?DOCKER_MOCK_STATE_FILE required}"
+
+if [[ "$1" == "pull" ]]; then
+  count=$(cat "$state_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$state_file"
+  echo "network timeout" >&2
+  exit 1
+fi
+exit 0
+EOF
+chmod +x "$TMP_DIR/docker-always-timeout"
+
 cat >"$TMP_DIR/docker-unauthorized" <<'EOF'
 #!/usr/bin/env bash
 state_file="${DOCKER_MOCK_STATE_FILE}"
 : "${state_file:?DOCKER_MOCK_STATE_FILE required}"
-count=$(cat "$state_file" 2>/dev/null || echo 0)
-count=$((count + 1))
-echo "$count" > "$state_file"
 
 if [[ "$1" == "pull" ]]; then
+  count=$(cat "$state_file" 2>/dev/null || echo 0)
+  count=$((count + 1))
+  echo "$count" > "$state_file"
   echo "Error response from daemon: unauthorized: authentication required" >&2
   exit 1
 fi
@@ -133,17 +153,21 @@ fi
 printf "  %-60s " "retries transient failures and succeeds..."
 rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
 export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-transient"
+export SLEEP_LOG="$TMP_DIR/sleep-transient.log"
 rm -f "$DOCKER_MOCK_STATE_FILE"
+rm -f "$SLEEP_LOG"
 if run_pull_with_progress "$TMP_DIR/docker-fail-then-succeed" "img" "label"; then
   attempts=$(cat "$DOCKER_MOCK_STATE_FILE" 2>/dev/null || echo 0)
-  if [[ "$attempts" == "3" ]]; then
+  sleeps=$(sed 's/[[:space:]]*$//' "$SLEEP_LOG" 2>/dev/null || true)
+  if [[ "$attempts" == "3" && "$sleeps" == "5 15" ]]; then
     print_pass
   else
-    print_fail "(attempts=$attempts, expected 3)"
+    print_fail "(attempts=$attempts, expected 3; sleeps='$sleeps', expected '5 15')"
   fi
 else
   print_fail
 fi
+unset SLEEP_LOG
 
 printf "  %-60s " "fails fast on unauthorized (no retries)..."
 rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
@@ -159,6 +183,26 @@ else
     print_fail "(attempts=$attempts, expected 1)"
   fi
 fi
+
+printf "  %-60s " "supports configurable retry delays and attempts..."
+rm -f "$TMP_DIR/stdout.log" "$TMP_DIR/stderr.log"
+export DOCKER_MOCK_STATE_FILE="$TMP_DIR/state-configurable"
+export SLEEP_LOG="$TMP_DIR/sleep-configurable.log"
+export ODS_DOCKER_PULL_MAX_ATTEMPTS=4
+export ODS_DOCKER_PULL_RETRY_DELAYS="1 2"
+rm -f "$DOCKER_MOCK_STATE_FILE" "$SLEEP_LOG"
+if run_pull_with_progress "$TMP_DIR/docker-always-timeout" "img" "label"; then
+  print_fail "(unexpected success)"
+else
+  attempts=$(cat "$DOCKER_MOCK_STATE_FILE" 2>/dev/null || echo 0)
+  sleeps=$(sed 's/[[:space:]]*$//' "$SLEEP_LOG" 2>/dev/null || true)
+  if [[ "$attempts" == "4" && "$sleeps" == "1 2 4" ]]; then
+    print_pass
+  else
+    print_fail "(attempts=$attempts, expected 4; sleeps='$sleeps', expected '1 2 4')"
+  fi
+fi
+unset ODS_DOCKER_PULL_MAX_ATTEMPTS ODS_DOCKER_PULL_RETRY_DELAYS SLEEP_LOG
 
 echo ""
 echo "2. Integration Tests"
@@ -198,11 +242,20 @@ else
   print_fail "(found $retry_count, expected 3)"
 fi
 
-printf "  %-60s " "backoff uses exponential formula..."
-if grep -A 30 "^pull_with_progress()" "$ROOT_DIR/installers/lib/ui.sh" | grep -Fq "5 * (2 ** (attempt - 2))"; then
+printf "  %-60s " "default retry delays are 5s, 15s, 30s..."
+default_delays=$(
+  bash -c '
+    set -euo pipefail
+    source "$1"
+    _docker_pull_retry_delay 1
+    _docker_pull_retry_delay 2
+    _docker_pull_retry_delay 3
+  ' _ "$ROOT_DIR/installers/lib/ui.sh" | paste -sd ' '
+)
+if [[ "$default_delays" == "5 15 30" ]]; then
   print_pass
 else
-  print_fail
+  print_fail "(found '$default_delays')"
 fi
 
 echo ""

--- a/ods/tests/test-locale-safe-cpu-formatting.sh
+++ b/ods/tests/test-locale-safe-cpu-formatting.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Regression guard for issue #1614: CPU budget values written to .env must
+# always use dot decimals, even when the parent shell has a decimal-comma locale.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+TMP_DIR=""
+
+cleanup() {
+    [[ -n "$TMP_DIR" && -d "$TMP_DIR" ]] && rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+require_scoped_awk() {
+    local file="$1"
+    local label="$2"
+    if grep -Eq 'LC_ALL=C[[:space:]]+awk[[:space:]]+-v[[:space:]]+desired=' "$ROOT_DIR/$file"; then
+        pass "$label scopes CPU formatting awk to C locale"
+    else
+        fail "$label must use LC_ALL=C for CPU formatting awk"
+    fi
+}
+
+echo ""
+echo "Locale-safe CPU formatting"
+echo "--------------------------"
+
+require_scoped_awk "installers/phases/06-directories.sh" "Linux phase 06"
+require_scoped_awk "installers/macos/lib/env-generator.sh" "macOS env generator"
+require_scoped_awk "installers/macos/ods-macos.sh" "macOS installer"
+
+TMP_DIR="$(mktemp -d)"
+cat > "$TMP_DIR/awk" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${LC_ALL:-${LC_NUMERIC:-}}" == "C" ]]; then
+    printf '4.0\n'
+else
+    printf '4,0\n'
+fi
+EOF
+chmod +x "$TMP_DIR/awk"
+
+result="$(
+    PATH="$TMP_DIR:$PATH" LC_ALL=fr_FR.UTF-8 bash -c '
+        source "$1"
+        cap_cpu_value 8.0 4
+    ' _ "$ROOT_DIR/installers/macos/lib/env-generator.sh"
+)"
+
+if [[ "$result" == "4.0" ]]; then
+    pass "cap_cpu_value emits dot decimals under decimal-comma parent locale"
+else
+    fail "cap_cpu_value emitted '$result' instead of '4.0'"
+fi
+
+echo ""
+if [[ $FAILED -eq 0 ]]; then
+    echo -e "${GREEN}All locale-safe CPU formatting tests passed${NC} ($PASSED/$((PASSED + FAILED)))"
+    exit 0
+else
+    echo -e "${RED}Locale-safe CPU formatting tests failed${NC} ($PASSED passed, $FAILED failed)"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Bundles the low-risk stabilization fixes that were already identified as safe and important:

- Docker image pull retries now use a bounded backoff schedule for transient network/DNS failures (#1634 / #1640).
- Installer CPU-limit formatting is locale-safe under decimal-comma locales (#1614 / #1641).
- Dashboard update checks normalize `v`-prefixed current versions (#1617).
- AMD GPU telemetry prefers junction temperature over edge temperature regardless of hwmon node order (#1632).
- Dashboard API shared aiohttp/httpx clients use locked lazy initialization and `dir_size_gb()` skips symlinks before probing files (#1588 / #1590).

## Why

This is intended as a stabilization bundle: small fixes, bounded blast radius, direct regression coverage, and no feature-surface expansion.

## Local Validation So Far

- `python -m pytest -q ods/extensions/services/dashboard-api/tests/test_helpers.py::TestGetAioSession ods/extensions/services/dashboard-api/tests/test_helpers.py::TestGetHttpxClient ods/extensions/services/dashboard-api/tests/test_helpers.py::TestDirSizeGb ods/extensions/services/dashboard-api/tests/test_updates.py ods/extensions/services/dashboard-api/tests/test_gpu_amd.py -q`
  - Passed; symlink-specific tests skipped locally on Windows because the account lacks symlink privilege.
- `ods/tests/test-docker-image-pull-retry.sh`
  - 10/10 passed.
- `ods/tests/test-locale-safe-cpu-formatting.sh`
  - 4/4 passed.
- `ruff` on changed dashboard-api files
  - Passed.
- `bash -n` on changed shell files
  - Passed.
- `python -m py_compile` on changed Python modules
  - Passed.
- `git diff --check origin/main..HEAD`
  - Passed.

A full local Windows dashboard-api suite was started and produced only passing progress, but it was stopped because it was crawling one test at a time. Full CI/fleet validation is the merge gate for this draft.

## Merge Gate

This PR should stay draft until:

- GitHub CI is green on the integrated branch.
- Fleet release validation is green, with any environment-only failures clearly separated from product regressions.
- Constituent PRs are either merged, superseded, or updated with the same evidence.
