### PR TITLE
fix: honor bootstrap force for partial installs

### DIFF
--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -33,6 +33,15 @@ REPO_URL="${ODS_REPO_URL:-https://github.com/Light-Heart-Labs/ODS.git}"
 INSTALL_DIR="${ODS_INSTALL_DIR:-$ODS_BOOTSTRAP_ROOT/ods}"
 LEGACY_DREAMSERVER_DIR="${DREAMSERVER_INSTALL_DIR:-$ODS_BOOTSTRAP_ROOT/dream-server}"
 ODS_REF="${ODS_REF:-${ODS_BOOTSTRAP_REF:-}}"
+BOOTSTRAP_FORCE=false
+BOOTSTRAP_NON_INTERACTIVE=false
+
+for _arg in "$@"; do
+    case "$_arg" in
+        --force) BOOTSTRAP_FORCE=true ;;
+        --non-interactive) BOOTSTRAP_NON_INTERACTIVE=true ;;
+    esac
+done
 
 log()     { echo -e "${CYAN}[ods]${NC} $1"; }
 success() { echo -e "${GREEN}[  ok ]${NC} $1"; }
@@ -243,13 +252,21 @@ if [[ -d "$INSTALL_DIR" ]]; then
     else
         warn "Directory exists but incomplete install at $INSTALL_DIR"
         echo ""
-        echo -n "  Remove and reinstall? [y/N] "
-        read -r response
-        if [[ "$response" =~ ^[Yy]$ ]]; then
-            rm -rf "$INSTALL_DIR"
-        else
-            echo "  Aborting. Remove manually with: rm -rf $INSTALL_DIR"
+        if [[ "$BOOTSTRAP_FORCE" == "true" ]]; then
+            echo "  Removing incomplete install because --force was provided."
+            rm -rf "$INSTALL_DIR" || error "Failed to remove incomplete install at $INSTALL_DIR"
+        elif [[ "$BOOTSTRAP_NON_INTERACTIVE" == "true" ]]; then
+            echo "  Aborting. Re-run with --force to remove it automatically, or remove manually with: rm -rf $INSTALL_DIR"
             exit 1
+        else
+            echo -n "  Remove and reinstall? [y/N] "
+            read -r response
+            if [[ "$response" =~ ^[Yy]$ ]]; then
+                rm -rf "$INSTALL_DIR" || error "Failed to remove incomplete install at $INSTALL_DIR"
+            else
+                echo "  Aborting. Remove manually with: rm -rf $INSTALL_DIR"
+                exit 1
+            fi
         fi
     fi
 fi

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -130,6 +130,10 @@ assert_contains "$bootstrap" 'zypper --non-interactive install -y git' "bootstra
 assert_contains "$bootstrap" 'zypper --non-interactive install -y curl' "bootstrap cannot install curl on zypper distros"
 assert_contains "$bootstrap" 'ODS_REF' "bootstrap should allow PR/fleet lanes to clone a matching ref"
 assert_contains "$bootstrap" 'clone_args\+=\(--branch "\$ODS_REF"\)' "bootstrap ref override should apply to git clone"
+assert_contains "$bootstrap" 'BOOTSTRAP_FORCE=false' "bootstrap should parse --force before incomplete install prompts"
+assert_contains "$bootstrap" 'BOOTSTRAP_NON_INTERACTIVE=false' "bootstrap should parse --non-interactive before incomplete install prompts"
+assert_contains "$bootstrap" 'Removing incomplete install because --force was provided' "bootstrap --force should remove incomplete install dirs without prompting"
+assert_contains "$bootstrap" 'Re-run with --force to remove it automatically' "bootstrap --non-interactive should fail with a force hint instead of prompting"
 
 echo "[contract] runtime dispatcher supports non-gnu Linux OSTYPE"
 dispatcher_common="installers/common.sh"


### PR DESCRIPTION
## Summary
- parse `--force` and `--non-interactive` before the bootstrap incomplete-install prompt
- make `--force` remove incomplete install directories without waiting for input
- make noninteractive runs fail with a clear `--force` hint instead of hanging or default-aborting at a prompt

## Root cause
The release fleet DGX lane invokes the bootstrap with noninteractive force semantics, but `ods/get-ods.sh` checked an existing incomplete install directory before it had parsed those flags. On `dgx-gpu01`, `/home/nvidia/ods` existed without `.env`, so the bootstrap prompted and then aborted in the fleet run.

## Validation
- `bash -n ods/get-ods.sh`
- `bash -n ods/tests/contracts/test-installer-hardening.sh`
- `bash ods/tests/contracts/test-installer-hardening.sh`