### PR TITLE
fix(installer): skip Qdrant on 64K arm64 hosts

### DIFF
--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -7,13 +7,13 @@
 #
 # Expects: INTERACTIVE, DRY_RUN, TIER, ENABLE_VOICE, ENABLE_WORKFLOWS,
 #           ENABLE_RAG, ENABLE_HERMES, ENABLE_OPENCLAW, GPU_COUNT, GPU_BACKEND,
-#           HOST_ARCH,
+#           HOST_ARCH, HOST_PAGE_SIZE,
 #           GPU_TOPOLOGY_JSON, LLM_MODEL_SIZE_MB, SCRIPT_DIR, VERBOSE, DEBUG,
 #           GPU_INDICES, GPU_UUIDS (arrays from topology),
 #           show_phase(), show_install_menu(), chapter(), bootline(),
 #           success(), log(), warn(), error(), signal()
 # Provides: ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG, ENABLE_EMBEDDINGS,
-#           ENABLE_HERMES, ENABLE_OPENCLAW, OPENCLAW_CONFIG, GPU_ASSIGNMENT_JSON,
+#           ENABLE_QDRANT, ENABLE_HERMES, ENABLE_OPENCLAW, OPENCLAW_CONFIG, GPU_ASSIGNMENT_JSON,
 #           LLAMA_SERVER_GPU_UUIDS, WHISPER_GPU_UUID, COMFYUI_GPU_UUID,
 #           EMBEDDINGS_GPU_UUID, LLAMA_ARG_SPLIT_MODE, LLAMA_ARG_TENSOR_SPLIT
 #
@@ -131,6 +131,35 @@ _sync_extension_compose() {
 
 if ! $DRY_RUN; then
     ENABLE_EMBEDDINGS="${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}"
+    ENABLE_QDRANT="${ENABLE_QDRANT:-${ENABLE_RAG:-false}}"
+
+    # Linux arm64/aarch64 compatibility guard.
+    #
+    # The official qdrant/qdrant arm64 image is currently linked against a
+    # jemalloc build that aborts on larger-than-4K kernel pages. This is
+    # observed on NVIDIA DGX/Brev GB300 Ubuntu 64K kernels:
+    #
+    #   <jemalloc>: Unsupported system page size
+    #
+    # Keep the rest of ODS installable on that host class by excluding only
+    # Qdrant until upstream publishes a compatible image.
+    _host_arch="${HOST_ARCH:-$(uname -m 2>/dev/null || echo unknown)}"
+    _host_page_size="${HOST_PAGE_SIZE:-$(getconf PAGE_SIZE 2>/dev/null || echo 4096)}"
+    if [[ "$_host_arch" == "arm64" || "$_host_arch" == "aarch64" ]]; then
+        if [[ "$_host_page_size" =~ ^[0-9]+$ ]] && (( _host_page_size > 4096 )); then
+            if [[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]]; then
+                ai_warn "Qdrant: upstream arm64 image is incompatible with ${_host_page_size}-byte kernel pages - disabled on this host."
+                ENABLE_QDRANT=false
+            fi
+        fi
+
+        if [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]]; then
+            ai_warn "Embeddings (TEI): upstream image is amd64-only - disabled on aarch64."
+            ENABLE_EMBEDDINGS=false
+        fi
+    fi
+    unset _host_arch _host_page_size
+
     if [[ "${ENABLE_HERMES:-false}" != "true" && "${ENABLE_OPENCLAW:-false}" != "true" ]]; then
         ENABLE_APE=false
     fi
@@ -140,12 +169,11 @@ if ! $DRY_RUN; then
     _sync_extension_compose "${ENABLE_VOICE:-}"      whisper    "Whisper (STT)" "voice not enabled"
     _sync_extension_compose "${ENABLE_VOICE:-}"      tts        "Kokoro (TTS)"  "voice not enabled"
     _sync_extension_compose "${ENABLE_WORKFLOWS:-}"  n8n        "n8n"           "workflows not enabled"
-    # RAG = qdrant (vector store) + embeddings (TEI). Both must follow
-    # ENABLE_RAG, otherwise opting out leaves the embeddings container
-    # being pulled and started even though nothing queries it. aarch64 Linux
-    # has a temporary TEI-only exception below while Qdrant remains enabled.
-    _sync_extension_compose "${ENABLE_RAG:-}"        qdrant     "Qdrant"        "RAG not enabled"
-    _sync_extension_compose "${ENABLE_RAG:-}"        embeddings "Embeddings (TEI)" "RAG not enabled"
+    # RAG = qdrant (vector store) + embeddings (TEI). Both default from
+    # ENABLE_RAG, then host-specific guards above may disable the concrete
+    # service when an upstream image cannot run on this machine.
+    _sync_extension_compose "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" qdrant "Qdrant" "RAG not enabled or unsupported on this host"
+    _sync_extension_compose "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" embeddings "Embeddings (TEI)" "RAG not enabled or unsupported on this host"
     # Hermes is the default agent as of 2026-05-12. hermes-proxy is the
     # auth gate in front of it (magic-link cookie verification) and is
     # not separately toggleable — without the proxy, Hermes's dashboard
@@ -162,29 +190,6 @@ if ! $DRY_RUN; then
     _sync_extension_compose "${ENABLE_LANGFUSE:-}"   langfuse   "Langfuse"      "LLM observability not enabled"
     _sync_extension_compose "${ENABLE_BRAVE_SEARCH:-false}" brave-search "Brave Search" "Brave Search API not enabled"
 
-    # ── arm64 / aarch64 platform guard ──
-    # One extension in the current --all bundle ships amd64-only binaries
-    # inside its image and crash-loops on aarch64 (DGX Spark, ARM SBCs,
-    # etc.) with `exec /usr/local/bin/...: exec format error`:
-    #
-    #   - embeddings (HF text-embeddings-inference) — upstream tag
-    #     `cpu-1.9.1` is amd64-only. The compose file pins
-    #     `platform: linux/amd64`, which works under Rosetta 2 on Apple
-    #     Silicon but produces ENOEXEC on aarch64 Linux without QEMU.
-    #
-    # Until upstream ships a multi-arch image, exclude this from the
-    # compose stack on aarch64 hosts. The other services run cleanly on
-    # arm64 and the operator gets a clear "not available on aarch64" line
-    # rather than hours of crash-loop forensics.
-    _host_arch="${HOST_ARCH:-$(uname -m 2>/dev/null || echo unknown)}"
-    if [[ "$_host_arch" == "arm64" || "$_host_arch" == "aarch64" ]]; then
-        if [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]]; then
-            ai_warn "Embeddings (TEI): upstream image is amd64-only — disabled on aarch64. Qdrant remains enabled; only the embeddings router is skipped."
-            _sync_extension_compose "false" embeddings "Embeddings (TEI)"  "amd64-only image, no arm64 multi-arch yet"
-            ENABLE_EMBEDDINGS=false
-        fi
-    fi
-    unset _host_arch
 fi
 
 # Re-resolve compose flags now that feature selection may have disabled services.

--- a/ods/installers/phases/04-requirements.sh
+++ b/ods/installers/phases/04-requirements.sh
@@ -8,7 +8,7 @@
 # Expects: SCRIPT_DIR, LOG_FILE, TIER, RAM_GB, DISK_AVAIL, GPU_BACKEND,
 #           GPU_VRAM, GPU_NAME, GPU_COUNT, INTERACTIVE, DRY_RUN,
 #           PREFLIGHT_REPORT_FILE, CAP_PLATFORM_ID, CAP_COMPOSE_OVERLAYS,
-#           ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG,
+#           ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG, ENABLE_QDRANT,
 #           tier_rank(), chapter(), ai_ok(), ai_bad(), ai_warn(), log(), warn()
 # Provides: REQUIREMENTS_MET, TIER_RANK
 #
@@ -266,7 +266,7 @@ fi
 PORTS_TO_CHECK="${SERVICE_PORTS[llama-server]:-8080} ${SERVICE_PORTS[open-webui]:-3000}"
 [[ "$ENABLE_VOICE" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[whisper]:-9000} ${SERVICE_PORTS[tts]:-8880}"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[n8n]:-5678}"
-[[ "$ENABLE_RAG" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[qdrant]:-6333}"
+[[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[qdrant]:-6333}"
 [[ "$ENABLE_COMFYUI" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[comfyui]:-8188}"
 
 for port in $PORTS_TO_CHECK; do

--- a/ods/installers/phases/08-images.sh
+++ b/ods/installers/phases/08-images.sh
@@ -6,7 +6,7 @@
 # Purpose: Build image pull list and download all Docker images
 #
 # Expects: DRY_RUN, GPU_BACKEND, ENABLE_VOICE, ENABLE_WORKFLOWS,
-#           ENABLE_RAG, ENABLE_EMBEDDINGS, ENABLE_HERMES, ENABLE_OPENCLAW,
+#           ENABLE_RAG, ENABLE_QDRANT, ENABLE_EMBEDDINGS, ENABLE_HERMES, ENABLE_OPENCLAW,
 #           DOCKER_CMD, LOG_FILE, BGRN, AMB, NC,
 #           show_phase(), bootline(), signal(), ai(), ai_ok(), ai_warn(),
 #           pull_with_progress()
@@ -52,7 +52,7 @@ if [[ "$ENABLE_VOICE" == "true" ]]; then
     PULL_LIST+=("ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.4|KOKORO — voice module")
 fi
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && PULL_LIST+=("n8nio/n8n:2.6.4|N8N — automation engine")
-[[ "$ENABLE_RAG" == "true" ]] && PULL_LIST+=("qdrant/qdrant:v1.16.3|QDRANT — memory vault")
+[[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]] && PULL_LIST+=("qdrant/qdrant:v1.16.3|QDRANT — memory vault")
 if [[ "$ENABLE_HERMES" == "true" ]]; then
     # Version-pinned upstream image. See extensions/services/hermes/compose.yaml
     # and docs/HERMES.md for the bump process. Hermes-proxy is the auth gate

--- a/ods/installers/phases/12-health.sh
+++ b/ods/installers/phases/12-health.sh
@@ -6,7 +6,7 @@
 # Purpose: Verify all services are responding, configure Perplexica,
 #          pre-download STT model
 #
-# Expects: DRY_RUN, GPU_BACKEND, ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG,
+# Expects: DRY_RUN, GPU_BACKEND, ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG, ENABLE_QDRANT,
 #           ENABLE_EMBEDDINGS, ENABLE_HERMES, ENABLE_OPENCLAW, LLM_MODEL,
 #           LOG_FILE, BGRN, AMB, NC,
 #           WHISPER_PORT, TTS_PORT, OPENCLAW_PORT,
@@ -41,7 +41,7 @@ if $DRY_RUN; then
     [[ "$ENABLE_OPENCLAW" == "true" ]] && log "[DRY RUN]   - OpenClaw"
     [[ "$ENABLE_VOICE" == "true" ]] && log "[DRY RUN]   - Whisper (STT), Kokoro (TTS), pre-download STT model"
     [[ "$ENABLE_WORKFLOWS" == "true" ]] && log "[DRY RUN]   - n8n"
-    [[ "$ENABLE_RAG" == "true" ]] && log "[DRY RUN]   - Qdrant"
+    [[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]] && log "[DRY RUN]   - Qdrant"
     [[ "${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}" == "true" ]] && log "[DRY RUN]   - Embeddings (TEI)"
     echo ""
     signal "All systems nominal. (dry run)"
@@ -491,7 +491,7 @@ fi
 
 ods_progress 96 "health" "Checking workflow and RAG services"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && _check_health "n8n" "http://127.0.0.1:${SERVICE_PORTS[n8n]:-5678}${SERVICE_HEALTH[n8n]:-/healthz}" 150 10 "$(sr_container n8n)"
-[[ "$ENABLE_RAG" == "true" ]] && _check_health "Qdrant" "http://127.0.0.1:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 150 10 "$(sr_container qdrant)"
+[[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]] && _check_health "Qdrant" "http://127.0.0.1:${SERVICE_PORTS[qdrant]:-6333}${SERVICE_HEALTH[qdrant]:-/}" 150 10 "$(sr_container qdrant)"
 
 ods_progress 97 "health" "Health checks complete"
 echo ""

--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -8,7 +8,7 @@
 #
 # Expects: DRY_RUN, INSTALL_DIR, SCRIPT_DIR, LOG_FILE, INTERACTIVE,
 #           TIER, TIER_NAME, VERSION, GPU_BACKEND, LLM_MODEL, OFFLINE_MODE,
-#           ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG, ENABLE_HERMES, ENABLE_OPENCLAW,
+#           ENABLE_VOICE, ENABLE_WORKFLOWS, ENABLE_RAG, ENABLE_QDRANT, ENABLE_HERMES, ENABLE_OPENCLAW,
 #           COMPOSE_FLAGS, SUMMARY_JSON_FILE, PREFLIGHT_REPORT_FILE,
 #           BGRN, GRN, AMB, WHT, NC, DASHBOARD_PORT (:-3001),
 #           CAP_HARDWARE_CLASS_ID (:-unknown), CAP_HARDWARE_CLASS_LABEL (:-Unknown),
@@ -132,7 +132,7 @@ systemctl --user is-active opencode-web &>/dev/null && echo "  • OpenCode:    
 [[ "$ENABLE_VOICE" == "true" ]] && echo "  • Whisper STT:   http://localhost:${SERVICE_PORTS[whisper]:-9000}"
 [[ "$ENABLE_VOICE" == "true" ]] && echo "  • TTS (Kokoro):  http://localhost:${SERVICE_PORTS[tts]:-8880}"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && echo "  • n8n:           http://localhost:${SERVICE_PORTS[n8n]:-5678}"
-[[ "$ENABLE_RAG" == "true" ]] && echo "  • Qdrant:        http://localhost:${SERVICE_PORTS[qdrant]:-6333}"
+[[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]] && echo "  • Qdrant:        http://localhost:${SERVICE_PORTS[qdrant]:-6333}"
 echo ""
 
 # Configuration summary
@@ -377,7 +377,7 @@ if command -v ods_readiness_summary >/dev/null 2>&1; then
             "${SERVICE_PORTS[tts]:-8880}" "${SERVICE_HEALTH[tts]:-/health}" "$(sr_container tts)" "http://localhost:${SERVICE_PORTS[tts]:-8880}"
         [[ "$ENABLE_WORKFLOWS" == "true" ]] && printf 'n8n|http://127.0.0.1:%s%s|%s|%s\n' \
             "${SERVICE_PORTS[n8n]:-5678}" "${SERVICE_HEALTH[n8n]:-/healthz}" "$(sr_container n8n)" "http://localhost:${SERVICE_PORTS[n8n]:-5678}"
-        [[ "$ENABLE_RAG" == "true" ]] && printf 'Qdrant|http://127.0.0.1:%s%s|%s|%s\n' \
+        [[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]] && printf 'Qdrant|http://127.0.0.1:%s%s|%s|%s\n' \
             "${SERVICE_PORTS[qdrant]:-6333}" "${SERVICE_HEALTH[qdrant]:-/}" "$(sr_container qdrant)" "http://localhost:${SERVICE_PORTS[qdrant]:-6333}"
         [[ "${ENABLE_COMFYUI:-}" == "true" ]] && printf 'ComfyUI|http://127.0.0.1:%s%s|%s|%s\n' \
             "${SERVICE_PORTS[comfyui]:-8188}" "${SERVICE_HEALTH[comfyui]:-/}" "$(sr_container comfyui)" "http://localhost:${SERVICE_PORTS[comfyui]:-8188}"

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -175,18 +175,108 @@ grep -q 'MINIO_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml.
   grep -q 'MINIO_TELEMETRY_DISABLED.*1' extensions/services/langfuse/compose.yaml 2>/dev/null || \
   { echo "[FAIL] MinIO telemetry not disabled"; exit 1; }
 
-echo "[contract] ENABLE_RAG opt-out disables both qdrant and embeddings"
-# RAG = qdrant (vector store) + embeddings (TEI). Both compose files must
-# be gated on ENABLE_RAG in installers/phases/03-features.sh; otherwise
-# answering 'n' to the Custom-menu RAG prompt still leaves embeddings
-# being pulled and started.
+echo "[contract] RAG service flags gate qdrant and embeddings"
+# RAG = qdrant (vector store) + embeddings (TEI). Both default from
+# ENABLE_RAG, then host-specific guards can disable the concrete service
+# when an upstream image cannot run on that machine.
 features_phase="ods/installers/phases/03-features.sh"
 test -f "$features_phase" || features_phase="installers/phases/03-features.sh"
 test -f "$features_phase" || { echo "[FAIL] cannot locate 03-features.sh"; exit 1; }
-for svc in qdrant embeddings; do
-  grep -qE "_sync_extension_compose +\"\\\$\\{ENABLE_RAG:-\\}\" +$svc\\b" "$features_phase" \
-    || { echo "[FAIL] ENABLE_RAG opt-out missing sync for '$svc' in $features_phase"; exit 1; }
+grep -q 'ENABLE_QDRANT="${ENABLE_QDRANT:-${ENABLE_RAG:-false}}"' "$features_phase" \
+  || { echo "[FAIL] ENABLE_QDRANT does not default from ENABLE_RAG in $features_phase"; exit 1; }
+grep -q 'ENABLE_EMBEDDINGS="${ENABLE_EMBEDDINGS:-${ENABLE_RAG:-false}}"' "$features_phase" \
+  || { echo "[FAIL] ENABLE_EMBEDDINGS does not default from ENABLE_RAG in $features_phase"; exit 1; }
+grep -qE '_sync_extension_compose +"\$\{ENABLE_QDRANT:-\$\{ENABLE_RAG:-false\}\}" +qdrant\b' "$features_phase" \
+  || { echo "[FAIL] Qdrant compose is not gated by ENABLE_QDRANT in $features_phase"; exit 1; }
+grep -qE '_sync_extension_compose +"\$\{ENABLE_EMBEDDINGS:-\$\{ENABLE_RAG:-false\}\}" +embeddings\b' "$features_phase" \
+  || { echo "[FAIL] Embeddings compose is not gated by ENABLE_EMBEDDINGS in $features_phase"; exit 1; }
+grep -q 'HOST_PAGE_SIZE:-$(getconf PAGE_SIZE' "$features_phase" \
+  || { echo "[FAIL] Qdrant arm64 page-size guard missing from $features_phase"; exit 1; }
+for f in installers/phases/04-requirements.sh installers/phases/08-images.sh installers/phases/12-health.sh installers/phases/13-summary.sh; do
+  test -f "$f" || { echo "[FAIL] missing installer phase: $f"; exit 1; }
+  grep -q 'ENABLE_QDRANT:-${ENABLE_RAG:-false}' "$f" \
+    || { echo "[FAIL] $f still gates Qdrant on ENABLE_RAG directly"; exit 1; }
 done
+
+run_phase03_rag_guard() {
+  local arch="$1" page_size="$2" tmpdir
+  tmpdir="$(mktemp -d)"
+  mkdir -p "$tmpdir/extensions/services/qdrant" "$tmpdir/extensions/services/embeddings"
+  printf 'services: {}\n' >"$tmpdir/extensions/services/qdrant/compose.yaml"
+  printf 'services: {}\n' >"$tmpdir/extensions/services/embeddings/compose.yaml"
+
+  (
+    set -euo pipefail
+    INTERACTIVE=false
+    DRY_RUN=false
+    INSTALL_CHOICE=1
+    TIER=1
+    ODS_MODE=local
+    ENABLE_RAG=true
+    ENABLE_HERMES=false
+    ENABLE_OPENCLAW=false
+    ENABLE_COMFYUI=false
+    ENABLE_WORKFLOWS=false
+    ENABLE_VOICE=false
+    GPU_COUNT=1
+    GPU_BACKEND=cpu
+    HOST_ARCH="$arch"
+    HOST_PAGE_SIZE="$page_size"
+    SCRIPT_DIR="$tmpdir"
+    INSTALL_DIR="$tmpdir/install"
+    MAX_CONTEXT=4096
+    LLM_MODEL_SIZE_MB=0
+
+    ods_progress() { :; }
+    ai_warn() { :; }
+    log() { :; }
+    warn() { :; }
+    success() { :; }
+    chapter() { :; }
+    bootline() { :; }
+    signal() { :; }
+    show_phase() { :; }
+    show_install_menu() { :; }
+
+    # shellcheck source=/dev/null
+    source "$features_phase" >/dev/null
+
+    printf 'ENABLE_QDRANT=%s\n' "${ENABLE_QDRANT:-}"
+    printf 'ENABLE_EMBEDDINGS=%s\n' "${ENABLE_EMBEDDINGS:-}"
+    if [[ -f "$tmpdir/extensions/services/qdrant/compose.yaml" ]]; then
+      printf 'QDRANT_COMPOSE=enabled\n'
+    elif [[ -f "$tmpdir/extensions/services/qdrant/compose.yaml.disabled" ]]; then
+      printf 'QDRANT_COMPOSE=disabled\n'
+    else
+      printf 'QDRANT_COMPOSE=missing\n'
+    fi
+    if [[ -f "$tmpdir/extensions/services/embeddings/compose.yaml" ]]; then
+      printf 'EMBEDDINGS_COMPOSE=enabled\n'
+    elif [[ -f "$tmpdir/extensions/services/embeddings/compose.yaml.disabled" ]]; then
+      printf 'EMBEDDINGS_COMPOSE=disabled\n'
+    else
+      printf 'EMBEDDINGS_COMPOSE=missing\n'
+    fi
+  )
+
+  rm -rf "$tmpdir"
+}
+
+guard_64k="$(run_phase03_rag_guard aarch64 65536)"
+echo "$guard_64k" | grep -q '^ENABLE_QDRANT=false$' \
+  || { echo "[FAIL] 64K-page aarch64 must disable ENABLE_QDRANT"; echo "$guard_64k"; exit 1; }
+echo "$guard_64k" | grep -q '^QDRANT_COMPOSE=disabled$' \
+  || { echo "[FAIL] 64K-page aarch64 must disable Qdrant compose"; echo "$guard_64k"; exit 1; }
+
+guard_4k="$(run_phase03_rag_guard aarch64 4096)"
+echo "$guard_4k" | grep -q '^ENABLE_QDRANT=true$' \
+  || { echo "[FAIL] 4K-page aarch64 must keep ENABLE_QDRANT enabled"; echo "$guard_4k"; exit 1; }
+echo "$guard_4k" | grep -q '^QDRANT_COMPOSE=enabled$' \
+  || { echo "[FAIL] 4K-page aarch64 must keep Qdrant compose enabled"; echo "$guard_4k"; exit 1; }
+echo "$guard_4k" | grep -q '^ENABLE_EMBEDDINGS=false$' \
+  || { echo "[FAIL] aarch64 must still disable amd64-only embeddings"; echo "$guard_4k"; exit 1; }
+echo "$guard_4k" | grep -q '^EMBEDDINGS_COMPOSE=disabled$' \
+  || { echo "[FAIL] aarch64 must still disable embeddings compose"; echo "$guard_4k"; exit 1; }
 
 echo "[contract] non-interactive reinstall reuses valid GPU assignment"
 grep -q '_load_existing_gpu_assignment_json' "$features_phase" \


### PR DESCRIPTION
﻿## Summary
- disable Qdrant on Linux arm64/aarch64 hosts when the kernel page size is larger than 4K
- keep RAG service checks, image pulls, health checks, and install summary keyed off the concrete `ENABLE_QDRANT` flag
- preserve the existing aarch64 TEI/embeddings guard and add contract coverage for 64K-page and 4K-page arm64 cases

## Root cause
DGX (`dgx-gpu01`, hostname `brev-testing-gpu01`) runs Ubuntu aarch64 with 64K kernel pages (`getconf PAGESIZE` = `65536`). The official `qdrant/qdrant:v1.16.3` arm64 image aborts under that kernel with:

```text
<jemalloc>: Unsupported system page size
terminate called without an active exception
```

That left `ods-qdrant` restart-looping during the full fleet install and blocked main from going green.

Supersedes the stale/conflicting idea in #1611 with a fresh branch on current main.

## Validation
- `git diff --check`
- `bash -n ods/installers/phases/03-features.sh ods/installers/phases/04-requirements.sh ods/installers/phases/08-images.sh ods/installers/phases/12-health.sh ods/installers/phases/13-summary.sh ods/tests/contracts/test-installer-contracts.sh`
- `cd ods && bash tests/contracts/test-installer-contracts.sh`

## Fleet evidence
- Failed run: `/home/michael/dream-fleet-test/runs/20260630T061405Z-main-e62948477b95-full-green-loop`
- DGX failure: `ods-qdrant` exited 134 with the jemalloc page-size abort above
- DGX kernel page size: `65536`