### PR TITLE
fix(tests): share fleet distro lab lock

### DIFF
--- a/ods/docs/TESTING.md
+++ b/ods/docs/TESTING.md
@@ -108,12 +108,14 @@ tests/fleet-multi-distro.sh --pull
 ```
 
 The Docker and Incus distro runners take a shared host lock by default:
-`/tmp/ods-fleet-heavy.lock`, or `ODS_FLEET_HOST_LOCK` when set. The
-private release automation uses the same lock when launching heavy install
-work, so distro-lab dry-runs do not compete with full fleet installs for
-Docker/build I/O on the same host. Use `--lock-timeout SECONDS` when a CI or
-automation should fail instead of waiting, and reserve `--no-host-lock` for
-local debugging when you know no full fleet install is running.
+`/tmp/dream-fleet-heavy.lock`. Set `ODS_FLEET_HOST_LOCK` to override it;
+the older `DREAM_FLEET_HOST_LOCK` name is still honored for release automation
+compatibility. The private release automation uses the same lock when launching
+heavy install work, so distro-lab dry-runs do not compete with full fleet
+installs for Docker/build I/O on the same host. Use `--lock-timeout SECONDS`
+when a CI or automation should fail instead of waiting, and reserve
+`--no-host-lock` for local debugging when you know no full fleet install is
+running.
 
 Release-grade fleet runs should run the distro lab alongside the hardware
 fleet. The hardware fleet proves GPU and product behavior; the distro lab proves

--- a/ods/tests/fleet-incus-vm.sh
+++ b/ods/tests/fleet-incus-vm.sh
@@ -13,8 +13,8 @@ WAIT_TIMEOUT="600"
 KEEP_VMS=false
 RUN_INSTALLER_DRY_RUN=true
 HOST_LOCK=true
-LOCK_FILE="${ODS_FLEET_HOST_LOCK:-/tmp/ods-fleet-heavy.lock}"
-LOCK_TIMEOUT="${ODS_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-}"
+LOCK_FILE="${ODS_FLEET_HOST_LOCK:-${DREAM_FLEET_HOST_LOCK:-/tmp/dream-fleet-heavy.lock}}"
+LOCK_TIMEOUT="${ODS_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-${DREAM_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-}}"
 WORK_DIR=""
 
 declare -a CREATED_VMS=()
@@ -91,7 +91,8 @@ Options:
   --memory SIZE             Memory per VM (default: 4GiB)
   --timeout SECONDS         Wait timeout for VM agent readiness (default: 600)
   --lock-file PATH          Host lock path for coordinating with full fleet runs
-                            (default: ODS_FLEET_HOST_LOCK or /tmp/ods-fleet-heavy.lock)
+                            (default: ODS_FLEET_HOST_LOCK, DREAM_FLEET_HOST_LOCK,
+                             or /tmp/dream-fleet-heavy.lock)
   --lock-timeout SECONDS    Seconds to wait for the host lock before failing
                             (default: wait indefinitely)
   --no-host-lock            Do not take the shared host lock

--- a/ods/tests/fleet-multi-distro.sh
+++ b/ods/tests/fleet-multi-distro.sh
@@ -68,8 +68,8 @@ PULL=false
 RUN_DRY_RUN=true
 KEEP_WORK=false
 HOST_LOCK=true
-LOCK_FILE="${ODS_FLEET_HOST_LOCK:-/tmp/ods-fleet-heavy.lock}"
-LOCK_TIMEOUT="${ODS_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-}"
+LOCK_FILE="${ODS_FLEET_HOST_LOCK:-${DREAM_FLEET_HOST_LOCK:-/tmp/dream-fleet-heavy.lock}}"
+LOCK_TIMEOUT="${ODS_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-${DREAM_FLEET_HOST_LOCK_TIMEOUT_SECONDS:-}}"
 TARGETS=()
 
 usage() {
@@ -83,7 +83,8 @@ Options:
   --no-dry-run    Skip install-core.sh --dry-run inside each distro.
   --keep-work     Keep temporary host work directory for debugging.
   --lock-file P    Host lock path for coordinating with full fleet runs.
-                  Default: ODS_FLEET_HOST_LOCK or /tmp/ods-fleet-heavy.lock.
+                  Default: ODS_FLEET_HOST_LOCK, DREAM_FLEET_HOST_LOCK,
+                  or /tmp/dream-fleet-heavy.lock.
   --lock-timeout N Seconds to wait for the host lock before failing.
                   Default: wait indefinitely.
   --no-host-lock  Do not take the shared host lock.


### PR DESCRIPTION
﻿## Summary
- make the Docker and Incus fleet distro lab scripts share the same default host lock as the release fleet harness
- keep `ODS_FLEET_HOST_LOCK` as the explicit override while honoring the older `DREAM_FLEET_HOST_LOCK` env name used by release automation
- update the multi-distro testing docs to describe the shared lock compatibility behavior

## Root Cause
The release fleet harness holds `/tmp/dream-fleet-heavy.lock`, but the ODS distro lab scripts had been changed to default to `/tmp/ods-fleet-heavy.lock`. That let distro Docker/Incus runs execute concurrently with full hardware installs/builds on Tower2 instead of queueing behind them.

## Validation
- `git diff --check`
- `C:\Program Files\Git\bin\bash.exe -lc 'bash -n ods/tests/fleet-multi-distro.sh && bash -n ods/tests/fleet-incus-vm.sh'`
- observed the live release run holding `/tmp/dream-fleet-heavy.lock` while the distro lab acquired `/tmp/ods-fleet-heavy.lock`, confirming the contention guard mismatch

Draft until CI and the rerun of the distro lab on Tower2 are green.