### PR TITLE
Fix dry-run mode executing sudo operations in devtools phase

### DIFF
--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -18,6 +18,8 @@ ods_progress 42 "devtools" "Installing developer tools"
 if $DRY_RUN; then
     log "[DRY RUN] Would install AI developer tools (Claude Code, Codex CLI, OpenCode)"
     log "[DRY RUN] Would configure OpenCode for local llama-server (user-level systemd service on port 3003)"
+    log "[DRY RUN] Would install ODS host agent systemd service (system-mode, port 7710)"
+    log "[DRY RUN] Would install ODS mDNS announcer systemd service (if zeroconf available)"
 else
     ai "Installing AI developer tools..."
 
@@ -273,6 +275,10 @@ OPENCODE_EOF
         fi
     fi
 fi
+
+# The host-agent and mDNS blocks below use real sudo/systemctl calls.
+# Gate them behind DRY_RUN so dry-run never touches the host.
+if $DRY_RUN; then return 0; fi
 
 # ── ODS Host Agent (extension lifecycle management) ──
 # System-mode systemd unit (was --user mode pre-#573). Installs to


### PR DESCRIPTION
## Summary

Fixes a dry-run safety issue in `ods/installers/phases/07-devtools.sh`.

When running `./install.sh --dry-run`, Phase 7 could still continue into the ODS Host Agent and mDNS service setup blocks. Those blocks perform real host-level operations such as `sudo install`, `systemctl daemon-reload`, `systemctl enable --now`, and package installation.

This PR adds dry-run log messages for those actions and returns before the Host Agent / mDNS blocks, ensuring dry-run mode does not prompt for sudo or mutate the host.

## AI Assistance

AI tools helped identify the dry-run control-flow issue, propose the minimal guard, draft the PR description, and review the validation output. The human author inspected the diff, ran the validation commands, and confirmed the behaviour.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

N/A — targeting mainline. If maintainers consider dry-run host mutation a current-stable safety issue, this may also be suitable for `release/2.5.x`.

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [ ] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because:

Commands/results:

    bash -n ods/installers/phases/07-devtools.sh && echo "Syntax OK"
    Syntax OK

    ./install.sh --dry-run

Result:

- Dry-run completed without prompting for sudo.
- Dry-run logged Host Agent and mDNS as simulated actions:
  - `[DRY RUN] Would install ODS host agent systemd service (system-mode, port 7710)`
  - `[DRY RUN] Would install ODS mDNS announcer systemd service (if zeroconf available)`

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation, service manifests, dashboard API control flows, Hermes, model routing, GPU or runtime detection, lifecycle commands, host mutation, or network exposure, it requires release-grade fleet validation before release unless the PR explains a narrower equivalent.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

This is a narrow installer dry-run safety fix. It only affects the dry-run path in Phase 7.

The change intentionally avoids restructuring the surrounding Bash logic. Because this phase file is sourced by the installer runner, the guard uses `return 0` rather than `exit 0`.

During validation, a separate dry-run/post-validation issue appeared after the installation summary: the extension runtime check attempted to use the configured install directory even though dry-run had not created it. That appears unrelated to this Host Agent / mDNS sudo issue and may be worth tracking separately.