### PR TITLE
feat(installer): reuse validated Ollama and LM Studio models

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -167,6 +167,8 @@ jobs:
       - name: Installer Contract Checks
         run: |
           bash tests/contracts/test-installer-contracts.sh
+          bash tests/test-external-services.sh
+          bash tests/test-resolve-compose-resilient.sh
           bash tests/test-phase03-multigpu-tty.sh
           bash tests/contracts/test-preflight-fixtures.sh
           bash tests/test-preflight-resolver-bug.sh

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -81,7 +81,8 @@ ODS_MODE=local
 # enabled routes supported apps through the stable ods/current alias.
 ODS_MODEL_SWITCHBOARD=observe
 
-# Inference backend engine: llama-server (NVIDIA/CPU), lemonade (AMD), litellm (cloud)
+# Inference backend engine: llama-server (NVIDIA/CPU), lemonade (AMD),
+# litellm (cloud), or external (installer-validated Ollama/LM Studio)
 # AMD hardware auto-selects lemonade for NPU/Vulkan/ROCm acceleration
 LLM_BACKEND=llama-server
 
@@ -92,6 +93,22 @@ LLM_API_URL=http://llama-server:8080
 OPEN_WEBUI_LLM_BASE_URL=
 OPEN_WEBUI_LLM_API_KEY=
 # LLM_URL=                  # Optional dashboard-api diagnostics override; normally follows LLM_API_URL
+
+# Reuse a host-managed Ollama or LM Studio model instead of downloading and
+# starting ODS's llama-server. Configure this through install.sh so the
+# endpoint/model are validated and the Compose topology is updated atomically:
+#   ./install.sh --external-llm-url http://127.0.0.1:11434 \
+#     --external-llm-provider ollama --external-llm-model qwen3.5:9b
+# Interactive installs can discover a matching model and ask before reuse.
+# Non-interactive discovery is opt-in with --reuse-external-llm.
+# Use ./install.sh --no-external-llm to return a persisted install to managed
+# local inference. EXTERNAL_LLM_URL is host-facing; the installer derives the
+# container-facing host.docker.internal URL.
+EXTERNAL_LLM_URL=
+EXTERNAL_LLM_CONTAINER_URL=
+EXTERNAL_LLM_PROVIDER=
+EXTERNAL_LLM_MODEL=
+SKIP_MODEL_DOWNLOAD=false
 
 # Remote GPU provider metadata. Remote routing is active only when
 # ODS_MODE=cloud and REMOTE_LLM_ENABLED=true. Provider API keys, peer tokens,

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -127,8 +127,42 @@
     },
     "LLM_BACKEND": {
       "type": "string",
-      "description": "Inference backend: llama-server or lemonade",
+      "description": "Inference backend. Current installers write llama-server, lemonade, litellm, or external; legacy values remain accepted for upgrade compatibility.",
       "default": "llama-server"
+    },
+    "EXTERNAL_LLM_URL": {
+      "type": "string",
+      "description": "Host-facing base URL of an installer-validated Ollama or LM Studio runtime. Configure with install.sh rather than editing this field alone.",
+      "default": ""
+    },
+    "EXTERNAL_LLM_CONTAINER_URL": {
+      "type": "string",
+      "description": "Container-facing base URL derived from EXTERNAL_LLM_URL. Loopback hosts are normalized to host.docker.internal.",
+      "default": ""
+    },
+    "EXTERNAL_LLM_PROVIDER": {
+      "type": "string",
+      "description": "Validated external local model provider.",
+      "enum": [
+        "",
+        "ollama",
+        "lmstudio"
+      ],
+      "default": ""
+    },
+    "EXTERNAL_LLM_MODEL": {
+      "type": "string",
+      "description": "Exact model id exposed by the selected external provider.",
+      "default": ""
+    },
+    "SKIP_MODEL_DOWNLOAD": {
+      "type": "string",
+      "description": "Installer-owned receipt indicating that a validated external model replaces the ODS-managed GGUF download.",
+      "enum": [
+        "true",
+        "false"
+      ],
+      "default": "false"
     },
     "MODEL_PROFILE": {
       "type": "string",

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -32,6 +32,8 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
+	@bash tests/test-external-services.sh
+	@bash tests/test-resolve-compose-resilient.sh
 	@bash tests/test-phase03-multigpu-tty.sh
 	@bash tests/contracts/test-preflight-fixtures.sh
 	@bash tests/test-preflight-resolver-bug.sh

--- a/ods/docker-compose.external-llm.yml
+++ b/ods/docker-compose.external-llm.yml
@@ -1,0 +1,36 @@
+# Host-managed Ollama / LM Studio overlay.
+#
+# The selected endpoint is reached through host.docker.internal. The explicit
+# host-gateway mappings make that name available on plain Linux Docker Engine
+# as well as Docker Desktop.
+services:
+  llama-server:
+    profiles:
+      - local-inference
+    restart: "no"
+
+  model-router:
+    profiles:
+      - local-inference
+    restart: "no"
+
+  open-webui:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      OPENAI_API_KEY: "${OPEN_WEBUI_LLM_API_KEY:-}"
+
+  dashboard-api:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    environment:
+      LLM_BACKEND: external
+      LLM_API_BASE_PATH: /v1
+      ODS_TALK_VISION_URL: "${EXTERNAL_LLM_CONTAINER_URL}/v1"
+      AMD_INFERENCE_RUNTIME: ""
+      AMD_INFERENCE_BACKEND: ""
+      AMD_INFERENCE_LOCATION: ""
+      AMD_INFERENCE_PORT: ""
+      AMD_INFERENCE_SUPPORTED_BACKENDS: ""
+      AMD_INFERENCE_RUNTIME_MODE: ""
+      AMD_INFERENCE_MANAGED: ""

--- a/ods/docs/FAQ.md
+++ b/ods/docs/FAQ.md
@@ -289,6 +289,46 @@ Applying a template only enables services — it doesn't disable anything you've
 
 ---
 
+### Can ODS reuse a model already running in Ollama or LM Studio?
+
+The Linux installer can reuse a host-managed text/chat model instead of
+downloading and starting a duplicate GGUF with ODS's llama-server.
+
+Interactive installs discover matching local services and ask before adopting
+one. Non-interactive installs require an explicit decision:
+
+```bash
+./install.sh --reuse-external-llm --non-interactive
+```
+
+Or configure the endpoint and exact provider model directly:
+
+```bash
+./install.sh \
+  --external-llm-url http://127.0.0.1:11434 \
+  --external-llm-provider ollama \
+  --external-llm-model qwen3.5:9b
+```
+
+The installer verifies the model and a real completion before changing the
+Compose topology. Open WebUI, ODS Talk, Hermes, Perplexica, Privacy Shield, and
+Token Spy then use the container-safe external endpoint. ODS does not stop the
+external process and does not activate local catalog models while that backend
+is selected.
+
+To return an existing installation to ODS-managed llama-server:
+
+```bash
+./install.sh --no-external-llm
+```
+
+This integration routes text/chat inference; it does not import or synchronize
+Ollama/LM Studio model files, VLMs, embedding models, or rerankers. The
+installer flags in this release are Linux-only. Windows Lemonade and macOS
+native llama-server keep their existing platform lifecycle.
+
+---
+
 ### Can I chat while models are downloading?
 
 Yes. During install, a small bootstrap model (~1.5GB, Qwen 3.5 2B) downloads first so you can start chatting within a couple of minutes. The bootstrap context is 64K so Hermes can work during the first session. The full tier-appropriate model downloads in the background.

--- a/ods/docs/INSTALLER-ARCHITECTURE.md
+++ b/ods/docs/INSTALLER-ARCHITECTURE.md
@@ -35,6 +35,7 @@ installers/
   phases/                     # Sequential install steps — execute on source
     01-preflight.sh           #   Root/OS/tools checks, existing installation check
     02-detection.sh           #   Hardware detection → tier assignment → compose config
+    02b-external-services.sh  #   Validate/offer host Ollama or LM Studio reuse
     03-features.sh            #   Interactive feature selection menu
     04-requirements.sh        #   RAM, disk, GPU, and port availability checks
     05-docker.sh              #   Install Docker, Docker Compose, NVIDIA Container Toolkit
@@ -126,6 +127,7 @@ done. This is the most common way install-time surprises survive a patch.
 | LiteLLM Lemonade config | `phases/06-directories.sh` | n/a | n/a | `scripts/bootstrap-upgrade.sh`, `bin/ods-host-agent.py` |
 | Perplexica config | `phases/12-health.sh`, `phases/13-summary.sh` | `installers/macos/lib/env-generator.sh`, `installers/macos/install-macos.sh` | `installers/windows/lib/env-generator.ps1`, `installers/windows/install-windows.ps1` | `scripts/bootstrap-upgrade.sh`, `scripts/repair/repair-perplexica.sh` |
 | Hermes config | `phases/11-services.sh`, `scripts/patch-hermes-config.py` | `installers/macos/install-macos.sh` | `installers/windows/phases/06-directories.ps1` | `scripts/bootstrap-upgrade.sh`, `bin/ods-host-agent.py` |
+| External text/chat route | `phases/02b-external-services.sh`, `phases/06-directories.sh` | Not installer-managed | Not installer-managed | Linux installer re-runs |
 
 Recent examples: OpenCode on Linux Lemonade mode must use `LITELLM_KEY` because
 LiteLLM enforces auth, while direct llama-server paths keep `no-key`; Lemonade
@@ -133,6 +135,15 @@ LiteLLM enforces auth, while direct llama-server paths keep `no-key`; Lemonade
 false` in install, bootstrap upgrade, and host-agent model activation paths;
 Perplexica's persisted `defaultChatModel` must be refreshed after bootstrap
 hot-swap.
+
+Linux external-LLM reuse is an explicit topology choice, not ambient discovery
+state. Interactive installs may offer a matching Ollama or LM Studio model;
+non-interactive installs adopt one only with `--reuse-external-llm` or an
+explicit URL/provider/model tuple. Phase 02b validates the host endpoint, phase
+06 writes both host-facing and container-facing routes, phase 11 omits managed
+llama-server/model-router and duplicate downloads, and phase 12 proves the
+configured model through host and container completion requests. A rerun with
+`--no-external-llm` clears those routes and restores managed inference.
 
 ## Cross-Platform Architecture
 

--- a/ods/extensions/services/dashboard-api/config.py
+++ b/ods/extensions/services/dashboard-api/config.py
@@ -153,6 +153,54 @@ def _apply_host_native_llm_service_override(
     logger.info("Host-native AMD inference detected; routing LLM probes to %s:%d", parsed.hostname, port)
 
 
+def _apply_external_llm_service_override(
+    services: dict[str, dict[str, Any]],
+    environment: Mapping[str, str] | None = None,
+) -> None:
+    """Route dashboard LLM probes to a validated external Ollama/LM Studio endpoint."""
+    env = environment if environment is not None else os.environ
+    if str(env.get("LLM_BACKEND", "")).strip().lower() != "external":
+        return
+    service = services.get("llama-server")
+    if not service:
+        return
+
+    configured_url = (
+        env.get("EXTERNAL_LLM_CONTAINER_URL")
+        or env.get("LLM_API_URL")
+        or ""
+    )
+    parsed = urlparse(str(configured_url).strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        logger.warning("Ignoring invalid external LLM URL: %s", configured_url)
+        return
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError:
+        logger.warning("Ignoring invalid external LLM port in URL: %s", configured_url)
+        return
+
+    provider = str(env.get("EXTERNAL_LLM_PROVIDER", "")).strip().lower()
+    health_paths = {
+        "ollama": "/api/tags",
+        "lmstudio": "/v1/models",
+    }
+    service["host"] = parsed.hostname
+    service["port"] = port
+    service["health"] = health_paths.get(provider, "/v1/models")
+    service["name"] = {
+        "ollama": "Ollama (External LLM)",
+        "lmstudio": "LM Studio (External LLM)",
+    }.get(provider, "External LLM")
+    logger.info(
+        "External %s inference detected; routing LLM probes to %s:%d%s",
+        provider or "OpenAI-compatible",
+        parsed.hostname,
+        port,
+        service["health"],
+    )
+
+
 def _read_env_value(key: str) -> str:
     return (os.environ.get(key) or _read_env_from_file(key)).strip()
 
@@ -382,6 +430,7 @@ if not SERVICES:
 # health path so the dashboard poll loop hits the correct endpoint.
 LLM_BACKEND = os.environ.get("LLM_BACKEND", "")
 _apply_host_native_llm_service_override(SERVICES, GPU_BACKEND)
+_apply_external_llm_service_override(SERVICES)
 if LLM_BACKEND == "lemonade" and "llama-server" in SERVICES:
     SERVICES["llama-server"]["health"] = "/api/v1/health"
     logger.info("Lemonade backend detected — overriding llama-server health to /api/v1/health")

--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -230,3 +230,4 @@ class ModelLibraryResponse(BaseModel):
     modelLifecycle: Optional[dict[str, Any]] = None
     odsMode: str = "unknown"
     configuredMode: str = "unknown"
+    llmBackend: str = "unknown"

--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -147,11 +147,21 @@ def _configured_ods_mode() -> str:
 def _model_activation_mode_denial(
     effective_mode: str,
     configured_mode: str,
+    llm_backend: str = "",
 ) -> dict[str, str] | None:
     """Describe why this runtime cannot safely perform a local model swap."""
     effective_mode = normalize_ods_mode(effective_mode)
     configured_mode = normalize_ods_mode(configured_mode)
-    if "unknown" in {effective_mode, configured_mode}:
+    normalized_backend = str(llm_backend or "").strip().lower()
+    if normalized_backend == "external":
+        code = "external_llm_managed"
+        reason = "external_backend_selected"
+        message = (
+            "Local model activation is unavailable while ODS is using an "
+            "external Ollama or LM Studio backend. Re-run the installer with "
+            "--no-external-llm before activating a downloaded local model."
+        )
+    elif "unknown" in {effective_mode, configured_mode}:
         code = "ods_mode_unknown"
         reason = "mode_unknown"
         message = (
@@ -182,6 +192,7 @@ def _model_activation_mode_denial(
         "message": message,
         "effectiveMode": effective_mode,
         "configuredMode": configured_mode,
+        "llmBackend": normalized_backend or "unknown",
     }
 
 try:
@@ -1340,6 +1351,7 @@ async def list_models(api_key: str = Depends(verify_api_key)):
         )
     payload["odsMode"] = ODS_MODE_EFFECTIVE
     payload["configuredMode"] = _configured_ods_mode()
+    payload["llmBackend"] = LLM_BACKEND or "unknown"
     loaded_entry = next((model for model in payload["models"] if model["status"] == "loaded"), None)
     payload["activationReadyModel"] = (
         payload.get("currentModel")
@@ -1978,6 +1990,7 @@ def load_model(
     mode_denial = _model_activation_mode_denial(
         ODS_MODE_EFFECTIVE,
         _configured_ods_mode(),
+        LLM_BACKEND,
     )
     if mode_denial is not None:
         raise HTTPException(

--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -86,6 +86,11 @@ _READ_ONLY_ENV_FIELDS = {
     "MODEL_RECOMMENDATION_CONFIDENCE": "Recommendation confidence is managed by the installer.",
     "MODEL_RECOMMENDATION_REASON": "Recommendation rationale is managed by the installer.",
     "MODEL_RECOMMENDED_ALTERNATIVES": "Recommended alternatives are managed by the installer.",
+    "EXTERNAL_LLM_URL": "External inference topology is validated and managed by the installer.",
+    "EXTERNAL_LLM_CONTAINER_URL": "The container route is derived and validated by the installer.",
+    "EXTERNAL_LLM_PROVIDER": "The external provider is detected and validated by the installer.",
+    "EXTERNAL_LLM_MODEL": "The external model id is verified against the provider by the installer.",
+    "SKIP_MODEL_DOWNLOAD": "Model download skipping is an installer-owned validation receipt.",
 }
 
 # ── Env parsing ────────────────────────────────────────────────────────────────

--- a/ods/extensions/services/dashboard-api/tests/test_config.py
+++ b/ods/extensions/services/dashboard-api/tests/test_config.py
@@ -7,6 +7,7 @@ import pytest
 
 import config
 from config import (
+    _apply_external_llm_service_override,
     _apply_host_native_llm_service_override,
     _detect_container_default_gateway,
     load_extension_manifests,
@@ -166,6 +167,57 @@ class TestHostNativeLlmResolution:
         )
 
         assert services["llama-server"] == {"host": "llama-server", "port": 8080}
+
+
+class TestExternalLlmResolution:
+
+    @pytest.mark.parametrize(
+        ("provider", "url", "expected_port", "expected_health", "expected_name"),
+        [
+            ("ollama", "http://host.docker.internal:11434", 11434, "/api/tags", "Ollama (External LLM)"),
+            ("lmstudio", "http://host.docker.internal:1234", 1234, "/v1/models", "LM Studio (External LLM)"),
+            ("", "https://llm.example.test", 443, "/v1/models", "External LLM"),
+        ],
+    )
+    def test_routes_external_runtime_to_configured_endpoint(
+        self, provider, url, expected_port, expected_health, expected_name,
+    ):
+        services = {"llama-server": {"host": "llama-server", "port": 8080, "health": "/health"}}
+
+        _apply_external_llm_service_override(
+            services,
+            {
+                "LLM_BACKEND": "external",
+                "EXTERNAL_LLM_PROVIDER": provider,
+                "EXTERNAL_LLM_CONTAINER_URL": url,
+            },
+        )
+
+        assert services["llama-server"] == {
+            "host": "host.docker.internal" if "host.docker.internal" in url else "llm.example.test",
+            "port": expected_port,
+            "health": expected_health,
+            "name": expected_name,
+        }
+
+    @pytest.mark.parametrize(
+        "environment",
+        [
+            {},
+            {"LLM_BACKEND": "llama-server", "EXTERNAL_LLM_CONTAINER_URL": "http://host.docker.internal:11434"},
+            {"LLM_BACKEND": "external", "EXTERNAL_LLM_CONTAINER_URL": "not-a-url"},
+        ],
+    )
+    def test_leaves_service_unchanged_without_valid_external_contract(self, environment):
+        services = {"llama-server": {"host": "llama-server", "port": 8080, "health": "/health"}}
+
+        _apply_external_llm_service_override(services, environment)
+
+        assert services["llama-server"] == {
+            "host": "llama-server",
+            "port": 8080,
+            "health": "/health",
+        }
 
 
 class TestLoadExtensionManifests:

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -1494,7 +1494,27 @@ def _patch_model_router_paths(monkeypatch, tmp_path):
 def test_model_activation_mode_policy_allows_matching_local_modes(mode):
     import routers.models as models_router
 
-    assert models_router._model_activation_mode_denial(mode, mode) is None
+    assert models_router._model_activation_mode_denial(mode, mode, "llama-server") is None
+
+
+def test_model_activation_mode_policy_rejects_external_backend():
+    import routers.models as models_router
+
+    denial = models_router._model_activation_mode_denial("local", "local", "external")
+
+    assert denial == {
+        "error": "local_mode_required",
+        "code": "external_llm_managed",
+        "reason": "external_backend_selected",
+        "message": (
+            "Local model activation is unavailable while ODS is using an "
+            "external Ollama or LM Studio backend. Re-run the installer with "
+            "--no-external-llm before activating a downloaded local model."
+        ),
+        "effectiveMode": "local",
+        "configuredMode": "local",
+        "llmBackend": "external",
+    }
 
 
 @pytest.mark.parametrize(
@@ -1522,6 +1542,7 @@ def test_load_model_rejects_unsafe_mode_before_lookup_or_agent_call(
         encoding="utf-8",
     )
     monkeypatch.setattr(models_router, "ODS_MODE_EFFECTIVE", effective_mode)
+    monkeypatch.setattr(models_router, "LLM_BACKEND", "llama-server")
     monkeypatch.setattr(
         models_router,
         "_call_agent_model",
@@ -1545,8 +1566,39 @@ def test_load_model_rejects_unsafe_mode_before_lookup_or_agent_call(
         "reason": expected_reason,
         "effectiveMode": models_router.normalize_ods_mode(effective_mode),
         "configuredMode": models_router.normalize_ods_mode(configured_mode),
+        "llmBackend": "llama-server",
         "requestedModelId": "not-installed",
     }
+
+
+def test_load_model_rejects_external_backend_before_lookup_or_agent_call(
+    test_client,
+    monkeypatch,
+    tmp_path,
+):
+    models_router, install_dir, _data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    (install_dir / ".env").write_text("ODS_MODE=local\n", encoding="utf-8")
+    monkeypatch.setattr(models_router, "ODS_MODE_EFFECTIVE", "local")
+    monkeypatch.setattr(models_router, "LLM_BACKEND", "external")
+    monkeypatch.setattr(
+        models_router,
+        "_find_loadable_model",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("external activation reached model lookup")
+        ),
+    )
+
+    response = test_client.post(
+        "/api/models/downloaded-model/load",
+        headers=test_client.auth_headers,
+    )
+
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["code"] == "external_llm_managed"
+    assert detail["reason"] == "external_backend_selected"
+    assert detail["llmBackend"] == "external"
+    assert detail["requestedModelId"] == "downloaded-model"
 
 
 def _gpu():

--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
@@ -28,6 +28,7 @@ const modelsResponse = (models, overrides = {}) => ({
       : (overrides.currentModel ?? null),
     odsMode: 'local',
     configuredMode: 'local',
+    llmBackend: 'llama-server',
     ...overrides,
   })
 })
@@ -153,6 +154,28 @@ describe('useModels', () => {
     expect(activationPosts).toHaveLength(0)
     expect(result.current.actionLoading).toBeNull()
     expect(result.current.error).toBe('ODS is running in cloud mode. A local-mode installation is required to run downloaded models.')
+  })
+
+  test('keeps browsing available but blocks local activation for an external backend', async () => {
+    const target = 'downloaded-model'
+    fetch.mockResolvedValue(modelsResponse(
+      [{ id: target, status: 'downloaded' }],
+      { odsMode: 'local', configuredMode: 'local', llmBackend: 'external' }
+    ))
+
+    const { result } = renderHook(() => useModels())
+    await waitFor(() => expect(result.current.llmBackend).toBe('external'))
+
+    expect(result.current.models).toHaveLength(1)
+    expect(result.current.canActivateModels).toBe(false)
+
+    await act(async () => {
+      await result.current.loadModel(target)
+    })
+
+    const activationPosts = fetch.mock.calls.filter(([, options]) => options?.method === 'POST')
+    expect(activationPosts).toHaveLength(0)
+    expect(result.current.error).toContain('external Ollama or LM Studio backend')
   })
 
   test('does not activate when effective and configured modes differ', async () => {

--- a/ods/extensions/services/dashboard/src/hooks/useModels.js
+++ b/ods/extensions/services/dashboard/src/hooks/useModels.js
@@ -145,7 +145,10 @@ function normalizeOdsMode(value) {
   return ODS_MODES.has(mode) ? mode : 'unknown'
 }
 
-function modelActivationModeError(effectiveMode, configuredMode) {
+function modelActivationModeError(effectiveMode, configuredMode, llmBackend) {
+  if (llmBackend === 'external') {
+    return 'ODS is using an external Ollama or LM Studio backend. Re-run the installer with --no-external-llm before activating a downloaded local model.'
+  }
   if (effectiveMode === 'unknown' || configuredMode === 'unknown') {
     return 'ODS could not verify the active runtime mode. Repair or restart ODS before running a local model.'
   }
@@ -167,6 +170,7 @@ export function useModels() {
   const [modelLifecycle, setModelLifecycle] = useState(null)
   const [odsMode, setOdsMode] = useState(USE_MOCK_DATA ? MOCK_MODES.odsMode : 'unknown')
   const [configuredMode, setConfiguredMode] = useState(USE_MOCK_DATA ? MOCK_MODES.configuredMode : 'unknown')
+  const [llmBackend, setLlmBackend] = useState(USE_MOCK_DATA ? 'llama-server' : 'unknown')
   const [recommendationAlternatives, setRecommendationAlternatives] = useState([])
   const [hermesMinimumContext, setHermesMinimumContext] = useState(DEFAULT_HERMES_MIN_CONTEXT)
   const [loading, setLoading] = useState(USE_MOCK_DATA ? false : true)
@@ -245,6 +249,7 @@ export function useModels() {
       const effectiveMode = normalizeOdsMode(data.odsMode)
       setOdsMode(effectiveMode)
       setConfiguredMode(normalizeOdsMode(data.configuredMode ?? data.odsMode))
+      setLlmBackend(typeof data.llmBackend === 'string' ? data.llmBackend.trim().toLowerCase() : 'unknown')
       setRecommendationAlternatives(data.recommendationAlternatives ?? [])
       setHermesMinimumContext(Number(data.hermesMinimumContext || DEFAULT_HERMES_MIN_CONTEXT))
       setFetchError(null)
@@ -330,7 +335,7 @@ export function useModels() {
   }
 
   const loadModel = async (modelId, options = {}) => {
-    const modeError = modelActivationModeError(odsMode, configuredMode)
+    const modeError = modelActivationModeError(odsMode, configuredMode, llmBackend)
     if (modeError) {
       setMutationError(modeError)
       return
@@ -476,7 +481,7 @@ export function useModels() {
     ].filter(Boolean)),
   ]
   const error = mutationError || fetchError
-  const activationModeError = modelActivationModeError(odsMode, configuredMode)
+  const activationModeError = modelActivationModeError(odsMode, configuredMode, llmBackend)
 
   return {
     models,
@@ -487,6 +492,7 @@ export function useModels() {
     modelLifecycle,
     odsMode,
     configuredMode,
+    llmBackend,
     canActivateModels: activationModeError === null,
     activationModeError,
     recommendationAlternatives,

--- a/ods/extensions/services/hermes/compose.yaml
+++ b/ods/extensions/services/hermes/compose.yaml
@@ -1,5 +1,7 @@
 services:
   hermes:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # Version-pinned upstream image. Override HERMES_AGENT_IMAGE only for
     # deliberate hotfix testing; bumping the default is a review-and-smoke-test
     # pass — see docs/HERMES.md "How to bump the image pin."

--- a/ods/extensions/services/openclaw/compose.yaml
+++ b/ods/extensions/services/openclaw/compose.yaml
@@ -1,5 +1,7 @@
 services:
   openclaw:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     image: ghcr.io/openclaw/openclaw:2026.3.8
     container_name: ods-openclaw
     restart: unless-stopped

--- a/ods/extensions/services/perplexica/compose.yaml
+++ b/ods/extensions/services/perplexica/compose.yaml
@@ -1,5 +1,7 @@
 services:
   perplexica:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     image: itzcrazykns1337/perplexica:slim-latest@sha256:6e399abf4ff587822b0ef0df11f36088fb928e17ac61556fe89beb68d48c378e
     container_name: ods-perplexica
     restart: unless-stopped

--- a/ods/extensions/services/privacy-shield/compose.yaml
+++ b/ods/extensions/services/privacy-shield/compose.yaml
@@ -1,5 +1,7 @@
 services:
   privacy-shield:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     build:
       context: ./extensions/services/privacy-shield
       dockerfile: Dockerfile

--- a/ods/extensions/services/token-spy/compose.yaml
+++ b/ods/extensions/services/token-spy/compose.yaml
@@ -1,6 +1,8 @@
 # Token Spy — LLM usage monitoring service
 services:
   token-spy:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     build:
       context: ./extensions/services/token-spy
       dockerfile: Dockerfile

--- a/ods/install-core.sh
+++ b/ods/install-core.sh
@@ -87,6 +87,7 @@ source "$SCRIPT_DIR/installers/lib/packaging.sh"
 source "$SCRIPT_DIR/installers/lib/python-runtime.sh"
 source "$SCRIPT_DIR/installers/lib/progress.sh"
 source "$SCRIPT_DIR/installers/lib/model-lifecycle-lock.sh"
+source "$SCRIPT_DIR/installers/lib/external-services.sh"
 if [[ -f "$SCRIPT_DIR/lib/service-registry.sh" ]]; then 
     source "$SCRIPT_DIR/lib/service-registry.sh" 
 fi
@@ -133,6 +134,11 @@ BIND_ADDRESS_EXPLICIT=false
 [[ -n "${BIND_ADDRESS:-}" ]] && BIND_ADDRESS_EXPLICIT=true
 BIND_ADDRESS="${BIND_ADDRESS:-127.0.0.1}"
 SUMMARY_JSON_FILE="${SUMMARY_JSON_FILE:-}"
+EXTERNAL_LLM_URL="${EXTERNAL_LLM_URL:-}"
+EXTERNAL_LLM_PROVIDER="${EXTERNAL_LLM_PROVIDER:-auto}"
+EXTERNAL_LLM_MODEL="${EXTERNAL_LLM_MODEL:-}"
+EXTERNAL_LLM_AUTO_REUSE="${EXTERNAL_LLM_AUTO_REUSE:-false}"
+EXTERNAL_LLM_DISABLE=false
 
 usage() {
     cat << EOF
@@ -152,6 +158,16 @@ Options:
                       (auto-detects localhost:13305, then localhost:8000 when omitted)
     --lemonade-api-key K
                       API key LiteLLM should send to the existing Lemonade server
+    --external-llm-url U
+                      Reuse an OpenAI-compatible Ollama or LM Studio endpoint
+    --external-llm-provider P
+                      External provider: auto, ollama, or lmstudio
+    --external-llm-model M
+                      Exact model id exposed by the external provider
+    --reuse-external-llm
+                      Allow non-interactive reuse of a detected matching model
+    --no-external-llm
+                      Disable a persisted external LLM selection on this rerun
     --voice           Enable voice services (Whisper + Kokoro)
     --no-voice        Disable voice services
     --workflows       Enable n8n workflow automation
@@ -211,6 +227,11 @@ while [[ $# -gt 0 ]]; do
         --use-existing-lemonade) LEMONADE_EXTERNAL=true; ODS_MODE="lemonade"; shift ;;
         --lemonade-url) LEMONADE_EXTERNAL=true; ODS_MODE="lemonade"; LEMONADE_BASE_URL="$2"; shift 2 ;;
         --lemonade-api-key) LEMONADE_API_KEY="$2"; shift 2 ;;
+        --external-llm-url) EXTERNAL_LLM_URL="$2"; shift 2 ;;
+        --external-llm-provider) EXTERNAL_LLM_PROVIDER="$2"; shift 2 ;;
+        --external-llm-model) EXTERNAL_LLM_MODEL="$2"; shift 2 ;;
+        --reuse-external-llm) EXTERNAL_LLM_AUTO_REUSE=true; shift ;;
+        --no-external-llm) EXTERNAL_LLM_DISABLE=true; shift ;;
         --voice) ENABLE_VOICE=true; shift ;;
         --no-voice) ENABLE_VOICE=false; shift ;;
         --workflows) ENABLE_WORKFLOWS=true; shift ;;
@@ -256,6 +277,9 @@ if [[ "${LEMONADE_EXTERNAL,,}" == "true" ]]; then
     ENABLE_RECOMMENDED=true
     export LEMONADE_EXTERNAL LEMONADE_BASE_URL LEMONADE_API_KEY
 fi
+
+export EXTERNAL_LLM_URL EXTERNAL_LLM_PROVIDER EXTERNAL_LLM_MODEL
+export EXTERNAL_LLM_AUTO_REUSE EXTERNAL_LLM_DISABLE
 
 # OpenClaw deprecation back-compat: preserve OpenClaw on UPGRADES of installs
 # that previously had it enabled. The earlier heuristic — "does the compose
@@ -313,6 +337,7 @@ $DRY_RUN && echo -e "${AMB}>>> DRY RUN MODE — I will simulate everything. No c
 #=============================================================================
 INSTALL_PHASE="01-preflight";    source "$SCRIPT_DIR/installers/phases/01-preflight.sh"
 INSTALL_PHASE="02-detection";    source "$SCRIPT_DIR/installers/phases/02-detection.sh"
+INSTALL_PHASE="02b-external-services"; source "$SCRIPT_DIR/installers/phases/02b-external-services.sh"
 INSTALL_PHASE="03-features";     source "$SCRIPT_DIR/installers/phases/03-features.sh"
 INSTALL_PHASE="04-requirements"; source "$SCRIPT_DIR/installers/phases/04-requirements.sh"
 INSTALL_PHASE="05-docker";       source "$SCRIPT_DIR/installers/phases/05-docker.sh"

--- a/ods/installers/lib/external-services.sh
+++ b/ods/installers/lib/external-services.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+# External Ollama / LM Studio discovery and validation helpers.
+
+external_llm_normalize_model_name() {
+    local value="${1:-}"
+    value="${value##*/}"
+    value="${value,,}"
+    value="${value%.gguf}"
+    value="$(printf '%s' "$value" | sed -E \
+        -e 's/[-_.](q[0-9]+([_.][a-z0-9]+)*|iq[0-9]+([_.][a-z0-9]+)*|fp(8|16|32)|bf16)([-_.].*)?$//' \
+        -e 's/:/-/' \
+        -e 's/[[:space:]_]+/-/g' \
+        -e 's/-+/-/g' \
+        -e 's/^-|-$//g')"
+    printf '%s\n' "$value"
+}
+
+external_llm_model_matches() {
+    local expected actual
+    expected="$(external_llm_normalize_model_name "${1:-}")"
+    actual="$(external_llm_normalize_model_name "${2:-}")"
+    [[ -n "$expected" && "$expected" == "$actual" ]]
+}
+
+external_llm_find_matching_model() {
+    local target="${1:-}" candidate
+    while IFS= read -r candidate; do
+        if [[ -n "$candidate" ]] && external_llm_model_matches "$target" "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+external_llm_strip_url() {
+    local url="${1:-}"
+    url="${url%/}"
+    case "$url" in
+        */api/v1) url="${url%/api/v1}" ;;
+        */v1) url="${url%/v1}" ;;
+    esac
+    printf '%s\n' "$url"
+}
+
+external_llm_validate_url() {
+    local url="${1:-}"
+    EXTERNAL_LLM_VALIDATE_URL="$url" python3 - <<'PY'
+import os
+import sys
+from urllib.parse import urlsplit
+
+try:
+    parsed = urlsplit(os.environ["EXTERNAL_LLM_VALIDATE_URL"])
+    _ = parsed.port
+except (KeyError, ValueError):
+    sys.exit(1)
+
+if (
+    parsed.scheme not in {"http", "https"}
+    or not parsed.hostname
+    or parsed.username is not None
+    or parsed.password is not None
+    or parsed.query
+    or parsed.fragment
+    or parsed.path.rstrip("/") not in {"", "/v1", "/api/v1"}
+):
+    sys.exit(1)
+PY
+}
+
+external_llm_host_url() {
+    local url
+    url="$(external_llm_strip_url "${1:-}")"
+    url="${url/host.docker.internal/127.0.0.1}"
+    printf '%s\n' "$url"
+}
+
+external_llm_container_url() {
+    local url
+    url="$(external_llm_strip_url "${1:-}")"
+    if [[ "$url" =~ ^(https?://)(localhost|127\.0\.0\.1|\[::1\])([:/].*|$) ]]; then
+        url="${BASH_REMATCH[1]}host.docker.internal${BASH_REMATCH[3]}"
+    fi
+    printf '%s\n' "$url"
+}
+
+external_llm_models() {
+    local provider="${1:-}" url="${2:-}" response
+    url="$(external_llm_host_url "$url")"
+    case "$provider" in
+        ollama)
+            response="$(curl -fsS --max-time 5 "${url}/api/tags" 2>/dev/null)" || return 1
+            ;;
+        lmstudio)
+            response="$(curl -fsS --max-time 5 "${url}/v1/models" 2>/dev/null)" || return 1
+            ;;
+        *)
+            return 2
+            ;;
+    esac
+
+    python3 -c '
+import json
+import sys
+
+provider = sys.argv[1]
+payload = json.load(sys.stdin)
+if provider == "ollama":
+    values = (item.get("name") or item.get("model") for item in payload.get("models", []))
+else:
+    values = (item.get("id") for item in payload.get("data", []))
+for value in values:
+    if isinstance(value, str) and value:
+        print(value)
+' "$provider" <<<"$response"
+}
+
+external_llm_detect_provider() {
+    local url="${1:-}"
+    if external_llm_models ollama "$url" >/dev/null 2>&1; then
+        printf 'ollama\n'
+        return 0
+    fi
+    if external_llm_models lmstudio "$url" >/dev/null 2>&1; then
+        printf 'lmstudio\n'
+        return 0
+    fi
+    return 1
+}
+
+external_llm_resolve_model() {
+    local provider="${1:-}" url="${2:-}" requested="${3:-}" target="${4:-}"
+    local models
+    models="$(external_llm_models "$provider" "$url")" || return 1
+    if [[ -n "$requested" ]]; then
+        if grep -Fqx -- "$requested" <<<"$models"; then
+            printf '%s\n' "$requested"
+            return 0
+        fi
+        return 2
+    fi
+    external_llm_find_matching_model "$target" <<<"$models"
+}
+
+external_llm_probe_completion() {
+    local url="${1:-}" model="${2:-}" body
+    url="$(external_llm_host_url "$url")"
+    body="$(
+        EXTERNAL_LLM_MODEL_VALUE="$model" python3 - <<'PY'
+import json
+import os
+
+print(json.dumps({
+    "model": os.environ["EXTERNAL_LLM_MODEL_VALUE"],
+    "messages": [{"role": "user", "content": "Reply with OK."}],
+    "max_tokens": 1,
+    "temperature": 0,
+    "stream": False,
+}))
+PY
+    )"
+    curl -fsS --max-time "${EXTERNAL_LLM_PROBE_TIMEOUT:-60}" \
+        -H "Content-Type: application/json" \
+        -d "$body" \
+        "${url}/v1/chat/completions" >/dev/null
+}
+
+external_llm_env_value() {
+    local env_file="${1:-}" key="${2:-}" value
+    [[ -f "$env_file" ]] || return 1
+    value="$(grep -m1 "^${key}=" "$env_file" 2>/dev/null | cut -d= -f2- || true)"
+    value="${value%\"}"
+    value="${value#\"}"
+    value="${value%\'}"
+    value="${value#\'}"
+    printf '%s\n' "$value"
+}

--- a/ods/installers/phases/02b-external-services.sh
+++ b/ods/installers/phases/02b-external-services.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Detect or validate an explicitly selected host Ollama / LM Studio runtime.
+
+ods_progress 15 "detection" "Checking external LLM services"
+
+_external_disable="${EXTERNAL_LLM_DISABLE:-false}"
+_external_url="${EXTERNAL_LLM_URL:-}"
+_external_provider="${EXTERNAL_LLM_PROVIDER:-}"
+_external_model="${EXTERNAL_LLM_MODEL:-}"
+
+if [[ "$_external_disable" != "true" && -z "$_external_url" && -f "${INSTALL_DIR:-}/.env" ]]; then
+    _external_url="$(external_llm_env_value "$INSTALL_DIR/.env" EXTERNAL_LLM_URL || true)"
+    _external_provider="$(external_llm_env_value "$INSTALL_DIR/.env" EXTERNAL_LLM_PROVIDER || true)"
+    _external_model="$(external_llm_env_value "$INSTALL_DIR/.env" EXTERNAL_LLM_MODEL || true)"
+    if [[ -n "$_external_url" ]]; then
+        log "Reusing the external LLM selection from the existing installation"
+    fi
+fi
+
+if [[ "$_external_disable" == "true" ]]; then
+    EXTERNAL_LLM_URL=""
+    EXTERNAL_LLM_CONTAINER_URL=""
+    EXTERNAL_LLM_PROVIDER=""
+    EXTERNAL_LLM_MODEL=""
+    SKIP_MODEL_DOWNLOAD=false
+    EXTERNAL_LLM_RESET=true
+    export EXTERNAL_LLM_URL EXTERNAL_LLM_CONTAINER_URL EXTERNAL_LLM_PROVIDER
+    export EXTERNAL_LLM_MODEL SKIP_MODEL_DOWNLOAD EXTERNAL_LLM_RESET
+    log "External LLM reuse disabled explicitly"
+    return 0
+fi
+
+if [[ -z "$_external_url" && "${ODS_MODE:-local}" == "local" && "${LEMONADE_EXTERNAL:-false}" != "true" ]]; then
+    _detected_provider=""
+    _detected_url=""
+    _detected_model=""
+    for _candidate in "ollama|http://127.0.0.1:11434" "lmstudio|http://127.0.0.1:1234"; do
+        _candidate_provider="${_candidate%%|*}"
+        _candidate_url="${_candidate#*|}"
+        _candidate_model="$(external_llm_resolve_model \
+            "$_candidate_provider" "$_candidate_url" "" "${GGUF_FILE:-${LLM_MODEL:-}}" || true)"
+        if [[ -n "$_candidate_model" ]]; then
+            _detected_provider="$_candidate_provider"
+            _detected_url="$_candidate_url"
+            _detected_model="$_candidate_model"
+            break
+        fi
+    done
+
+    if [[ -n "$_detected_model" ]]; then
+        if [[ "${INTERACTIVE:-false}" == "true" && "${DRY_RUN:-false}" != "true" ]]; then
+            ai_ok "Found ${_detected_model} in the running ${_detected_provider} service"
+            ai "ODS can reuse it and skip the duplicate GGUF download."
+            read -r -p "  Reuse this external model service? [Y/n] " _external_reply < /dev/tty
+            if [[ ! "$_external_reply" =~ ^[Nn] ]]; then
+                _external_url="$_detected_url"
+                _external_provider="$_detected_provider"
+                _external_model="$_detected_model"
+            fi
+        elif [[ "${EXTERNAL_LLM_AUTO_REUSE:-false}" == "true" ]]; then
+            _external_url="$_detected_url"
+            _external_provider="$_detected_provider"
+            _external_model="$_detected_model"
+            log "Explicit auto-reuse selected ${_detected_provider} model ${_detected_model}"
+        else
+            log "Matching ${_detected_provider} model detected but not reused in non-interactive mode without --reuse-external-llm"
+        fi
+    fi
+fi
+
+if [[ -z "$_external_url" ]]; then
+    EXTERNAL_LLM_URL=""
+    EXTERNAL_LLM_CONTAINER_URL=""
+    EXTERNAL_LLM_PROVIDER=""
+    EXTERNAL_LLM_MODEL=""
+    SKIP_MODEL_DOWNLOAD=false
+    export EXTERNAL_LLM_URL EXTERNAL_LLM_CONTAINER_URL EXTERNAL_LLM_PROVIDER
+    export EXTERNAL_LLM_MODEL SKIP_MODEL_DOWNLOAD
+    return 0
+fi
+
+if [[ "${ODS_MODE:-local}" != "local" ]]; then
+    ai_bad "External Ollama / LM Studio reuse is only supported in local mode."
+    ai "Use --no-external-llm before selecting cloud or hybrid mode."
+    return 1
+fi
+if [[ "${LEMONADE_EXTERNAL:-false}" == "true" ]]; then
+    ai_bad "External Ollama / LM Studio reuse cannot be combined with external Lemonade."
+    ai "Select one host-managed inference backend, or use --no-external-llm."
+    return 1
+fi
+if ! external_llm_validate_url "$_external_url"; then
+    ai_bad "Invalid external LLM URL: ${_external_url}"
+    ai "Use an http(s) base URL without credentials, query parameters, or fragments."
+    return 1
+fi
+
+_external_url="$(external_llm_strip_url "$_external_url")"
+if [[ -z "$_external_provider" || "$_external_provider" == "auto" ]]; then
+    _external_provider="$(external_llm_detect_provider "$_external_url" || true)"
+fi
+case "$_external_provider" in
+    ollama|lmstudio) ;;
+    *)
+        ai_bad "Could not identify the external LLM provider at ${_external_url}"
+        ai "Use --external-llm-provider ollama|lmstudio and verify the service is running."
+        return 1
+        ;;
+esac
+
+_resolved_external_model="$(external_llm_resolve_model \
+    "$_external_provider" "$_external_url" "$_external_model" "${GGUF_FILE:-${LLM_MODEL:-}}" || true)"
+if [[ -z "$_resolved_external_model" ]]; then
+    ai_bad "The selected external ${_external_provider} service does not expose the required model."
+    ai "Expected a model matching ${GGUF_FILE:-${LLM_MODEL:-unknown}}."
+    ai "Use --external-llm-model MODEL to select an exact model exposed by the service."
+    return 1
+fi
+
+EXTERNAL_LLM_URL="$_external_url"
+EXTERNAL_LLM_CONTAINER_URL="$(external_llm_container_url "$_external_url")"
+EXTERNAL_LLM_PROVIDER="$_external_provider"
+EXTERNAL_LLM_MODEL="$_resolved_external_model"
+SKIP_MODEL_DOWNLOAD=true
+export EXTERNAL_LLM_URL EXTERNAL_LLM_CONTAINER_URL EXTERNAL_LLM_PROVIDER
+export EXTERNAL_LLM_MODEL SKIP_MODEL_DOWNLOAD
+
+ai_ok "Using external ${EXTERNAL_LLM_PROVIDER} model ${EXTERNAL_LLM_MODEL}"
+resolve_compose_config

--- a/ods/installers/phases/04-requirements.sh
+++ b/ods/installers/phases/04-requirements.sh
@@ -136,7 +136,7 @@ else
     fi
 fi
 
-if [[ "${LLM_MODEL_SIZE_MB:-0}" =~ ^[0-9]+$ && "${LLM_MODEL_SIZE_MB:-0}" -gt 0 && "${TIER:-}" != "CLOUD" ]]; then
+if [[ -z "${EXTERNAL_LLM_URL:-}" && "${LLM_MODEL_SIZE_MB:-0}" =~ ^[0-9]+$ && "${LLM_MODEL_SIZE_MB:-0}" -gt 0 && "${TIER:-}" != "CLOUD" ]]; then
     _model_disk_gb=$(( (LLM_MODEL_SIZE_MB + 1023) / 1024 ))
     _model_needed_gb=$(( _model_disk_gb + 15 ))
     if [[ "${DISK_AVAIL:-0}" -lt "$_model_needed_gb" ]]; then
@@ -221,7 +221,7 @@ check_ollama_conflict() {
 
 # Ollama conflict detection (must happen before port checks)
 check_ollama_conflict
-if $OLLAMA_RUNNING; then
+if $OLLAMA_RUNNING && [[ "${EXTERNAL_LLM_PROVIDER:-}" != "ollama" ]]; then
     ai_warn "Ollama is running (PID ${OLLAMA_PID}) and may conflict with ODS."
     ai "  Note: this is usually not a port collision. Open WebUI may auto-discover Ollama (11434) and prefer it over the local llama-server (8080)."
     if $INTERACTIVE && ! $DRY_RUN; then
@@ -263,7 +263,8 @@ if [[ "${ENABLE_VOICE:-false}" == "true" ]] && _phase04_lemonade_uses_host_9000;
 fi
 
 # Port conflict detection with detailed process information
-PORTS_TO_CHECK="${SERVICE_PORTS[llama-server]:-8080} ${SERVICE_PORTS[open-webui]:-3000}"
+PORTS_TO_CHECK="${SERVICE_PORTS[open-webui]:-3000}"
+[[ -z "${EXTERNAL_LLM_URL:-}" ]] && PORTS_TO_CHECK="${SERVICE_PORTS[llama-server]:-8080} ${PORTS_TO_CHECK}"
 [[ "$ENABLE_VOICE" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[whisper]:-9000} ${SERVICE_PORTS[tts]:-8880}"
 [[ "$ENABLE_WORKFLOWS" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[n8n]:-5678}"
 [[ "${ENABLE_QDRANT:-${ENABLE_RAG:-false}}" == "true" ]] && PORTS_TO_CHECK="$PORTS_TO_CHECK ${SERVICE_PORTS[qdrant]:-6333}"

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -469,18 +469,47 @@ raise SystemExit(1)' 2>/dev/null && return 0
     LANGFUSE_INIT_USER_EMAIL=$(_env_get LANGFUSE_INIT_USER_EMAIL "admin@ods.local")
     LANGFUSE_INIT_USER_PASSWORD=$(_env_get LANGFUSE_INIT_USER_PASSWORD "$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
     MODEL_PROFILE_VALUE=$(_env_get MODEL_PROFILE "${MODEL_PROFILE_REQUESTED:-${MODEL_PROFILE:-qwen}}")
-    ODS_MODE_VALUE="$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "lemonade"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo "${ODS_MODE:-local}"; fi)"
+    MODEL_RECOMMENDED_MODEL_VALUE="${LLM_MODEL}"
+    MODEL_RECOMMENDED_GGUF_VALUE="${GGUF_FILE}"
+    MODEL_RECOMMENDED_CONTEXT_VALUE="${MAX_CONTEXT}"
+    EXTERNAL_LLM_URL_VALUE="${EXTERNAL_LLM_URL:-}"
+    EXTERNAL_LLM_CONTAINER_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL:-}"
+    EXTERNAL_LLM_PROVIDER_VALUE="${EXTERNAL_LLM_PROVIDER:-}"
+    EXTERNAL_SELECTED_MODEL="${EXTERNAL_LLM_MODEL:-}"
+    EXTERNAL_LLM_ACTIVE=false
+    if [[ -n "$EXTERNAL_LLM_URL_VALUE" ]]; then
+        if [[ -z "$EXTERNAL_LLM_CONTAINER_URL_VALUE" || -z "$EXTERNAL_LLM_PROVIDER_VALUE" || -z "$EXTERNAL_SELECTED_MODEL" ]]; then
+            error "External LLM selection is incomplete. Re-run with a reachable endpoint and model, or use --no-external-llm."
+        fi
+        EXTERNAL_LLM_ACTIVE=true
+        LLM_MODEL="$EXTERNAL_SELECTED_MODEL"
+    fi
+    ODS_MODE_VALUE="$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo "local"; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "lemonade"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo "${ODS_MODE:-local}"; fi)"
     ODS_MODEL_SWITCHBOARD_VALUE=$(_env_get ODS_MODEL_SWITCHBOARD "${ODS_MODEL_SWITCHBOARD:-observe}")
     case "$ODS_MODEL_SWITCHBOARD_VALUE" in
         legacy|observe|enabled) ;;
         *) ODS_MODEL_SWITCHBOARD_VALUE="observe" ;;
     esac
+    if [[ "$EXTERNAL_LLM_ACTIVE" == "true" && "$ODS_MODEL_SWITCHBOARD_VALUE" == "enabled" ]]; then
+        ai_warn "External LLM reuse bypasses the managed model router; setting ODS_MODEL_SWITCHBOARD=observe."
+        ODS_MODEL_SWITCHBOARD_VALUE="observe"
+    fi
     _default_llm_api_url="$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "http://litellm:4000"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "http://litellm:4000"; elif [[ "${ODS_MODE:-local}" == "local" ]]; then echo "http://llama-server:8080"; else echo "http://litellm:4000"; fi)"
-    LLM_API_URL_VALUE=$(_env_get LLM_API_URL "$_default_llm_api_url")
-    if [[ "$ODS_MODEL_SWITCHBOARD_VALUE" == "enabled" ]]; then
+    if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then
+        LLM_API_URL_VALUE="$EXTERNAL_LLM_CONTAINER_URL_VALUE"
+        OPEN_WEBUI_LLM_BASE_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL_VALUE}/v1"
+        OPEN_WEBUI_LLM_API_KEY_VALUE=""
+    elif [[ "${EXTERNAL_LLM_RESET:-false}" == "true" ]]; then
+        LLM_API_URL_VALUE="$_default_llm_api_url"
+        OPEN_WEBUI_LLM_BASE_URL_VALUE=""
+        OPEN_WEBUI_LLM_API_KEY_VALUE=""
+    else
+        LLM_API_URL_VALUE=$(_env_get LLM_API_URL "$_default_llm_api_url")
+    fi
+    if [[ "$EXTERNAL_LLM_ACTIVE" != "true" && "${EXTERNAL_LLM_RESET:-false}" != "true" && "$ODS_MODEL_SWITCHBOARD_VALUE" == "enabled" ]]; then
         OPEN_WEBUI_LLM_BASE_URL_VALUE=$(_env_get OPEN_WEBUI_LLM_BASE_URL "http://litellm:4000")
         OPEN_WEBUI_LLM_API_KEY_VALUE=$(_env_get OPEN_WEBUI_LLM_API_KEY "${LITELLM_KEY}")
-    else
+    elif [[ "$EXTERNAL_LLM_ACTIVE" != "true" && "${EXTERNAL_LLM_RESET:-false}" != "true" ]]; then
         OPEN_WEBUI_LLM_BASE_URL_VALUE=$(_env_get OPEN_WEBUI_LLM_BASE_URL "")
         OPEN_WEBUI_LLM_API_KEY_VALUE=$(_env_get OPEN_WEBUI_LLM_API_KEY "")
     fi
@@ -498,8 +527,16 @@ raise SystemExit(1)' 2>/dev/null && return 0
         _default_hermes_base_url="http://litellm:4000/v1"
         _default_hermes_api_key="${LITELLM_KEY}"
     fi
-    HERMES_LLM_BASE_URL_VALUE=$(_env_get HERMES_LLM_BASE_URL "$_default_hermes_base_url")
-    HERMES_LLM_API_KEY_VALUE=$(_env_get HERMES_LLM_API_KEY "$_default_hermes_api_key")
+    if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then
+        HERMES_LLM_BASE_URL_VALUE="${EXTERNAL_LLM_CONTAINER_URL_VALUE}/v1"
+        HERMES_LLM_API_KEY_VALUE="not-needed"
+    elif [[ "${EXTERNAL_LLM_RESET:-false}" == "true" ]]; then
+        HERMES_LLM_BASE_URL_VALUE="$_default_hermes_base_url"
+        HERMES_LLM_API_KEY_VALUE="$_default_hermes_api_key"
+    else
+        HERMES_LLM_BASE_URL_VALUE=$(_env_get HERMES_LLM_BASE_URL "$_default_hermes_base_url")
+        HERMES_LLM_API_KEY_VALUE=$(_env_get HERMES_LLM_API_KEY "$_default_hermes_api_key")
+    fi
     LLM_API_URL="$LLM_API_URL_VALUE"
     HERMES_LLM_BASE_URL="$HERMES_LLM_BASE_URL_VALUE"
     HERMES_LLM_API_KEY="$HERMES_LLM_API_KEY_VALUE"
@@ -698,15 +735,20 @@ ODS_MODEL_SWITCHBOARD=${ODS_MODEL_SWITCHBOARD_VALUE}
 LLM_API_URL=${LLM_API_URL_VALUE}
 OPEN_WEBUI_LLM_BASE_URL=${OPEN_WEBUI_LLM_BASE_URL_VALUE}
 OPEN_WEBUI_LLM_API_KEY=${OPEN_WEBUI_LLM_API_KEY_VALUE}
-LLM_BACKEND=$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "lemonade"; else echo "llama-server"; fi)
+LLM_BACKEND=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo "external"; elif [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "lemonade"; else echo "llama-server"; fi)
 LLM_API_BASE_PATH=$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "${LEMONADE_API_BASE_PATH_VALUE}"; else echo "/v1"; fi)
-AMD_INFERENCE_RUNTIME=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" || ( "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ) ]]; then echo "lemonade"; else echo ""; fi)
-AMD_INFERENCE_BACKEND=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_BACKEND:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
-AMD_INFERENCE_LOCATION=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "host"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "container"; else echo ""; fi)
-AMD_INFERENCE_PORT=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${LEMONADE_PORT_VALUE}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_API_PORT:-8080}"; else echo ""; fi)
-AMD_INFERENCE_SUPPORTED_BACKENDS=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_SUPPORTED_BACKENDS:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
-AMD_INFERENCE_RUNTIME_MODE=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "external-lemonade"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "linux-container"; else echo ""; fi)
-AMD_INFERENCE_MANAGED=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "false"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "true"; else echo ""; fi)
+EXTERNAL_LLM_URL=${EXTERNAL_LLM_URL_VALUE}
+EXTERNAL_LLM_CONTAINER_URL=${EXTERNAL_LLM_CONTAINER_URL_VALUE}
+EXTERNAL_LLM_PROVIDER=${EXTERNAL_LLM_PROVIDER_VALUE}
+EXTERNAL_LLM_MODEL=${EXTERNAL_SELECTED_MODEL}
+SKIP_MODEL_DOWNLOAD=${EXTERNAL_LLM_ACTIVE}
+AMD_INFERENCE_RUNTIME=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" || ( "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ) ]]; then echo "lemonade"; else echo ""; fi)
+AMD_INFERENCE_BACKEND=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_BACKEND:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
+AMD_INFERENCE_LOCATION=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "host"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "container"; else echo ""; fi)
+AMD_INFERENCE_PORT=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${LEMONADE_PORT_VALUE}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_API_PORT:-8080}"; else echo ""; fi)
+AMD_INFERENCE_SUPPORTED_BACKENDS=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_SUPPORTED_BACKENDS:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
+AMD_INFERENCE_RUNTIME_MODE=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "external-lemonade"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "linux-container"; else echo ""; fi)
+AMD_INFERENCE_MANAGED=$(if [[ "$EXTERNAL_LLM_ACTIVE" == "true" ]]; then echo ""; elif [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "false"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "true"; else echo ""; fi)
 LEMONADE_EXTERNAL=${LEMONADE_EXTERNAL_VALUE}
 LEMONADE_BASE_URL=${LEMONADE_BASE_URL_VALUE}
 LEMONADE_CONTAINER_BASE_URL=${LEMONADE_CONTAINER_BASE_URL_VALUE}
@@ -729,9 +771,9 @@ LLM_MODEL=${LLM_MODEL}
 GGUF_FILE=${GGUF_FILE}
 MAX_CONTEXT=${MAX_CONTEXT}
 CTX_SIZE=${MAX_CONTEXT}
-MODEL_RECOMMENDED_MODEL=${LLM_MODEL}
-MODEL_RECOMMENDED_GGUF=${GGUF_FILE}
-MODEL_RECOMMENDED_CONTEXT=${MAX_CONTEXT}
+MODEL_RECOMMENDED_MODEL=${MODEL_RECOMMENDED_MODEL_VALUE}
+MODEL_RECOMMENDED_GGUF=${MODEL_RECOMMENDED_GGUF_VALUE}
+MODEL_RECOMMENDED_CONTEXT=${MODEL_RECOMMENDED_CONTEXT_VALUE}
 MODEL_RECOMMENDATION_SOURCE=${MODEL_RECOMMENDATION_SOURCE:-installer_tier_map}
 MODEL_RECOMMENDATION_POLICY=${MODEL_RECOMMENDATION_POLICY:-tier-map}
 MODEL_RECOMMENDATION_CONFIDENCE=${MODEL_RECOMMENDATION_CONFIDENCE:-medium}

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -240,6 +240,14 @@ else
         [[ "${external,,}" == "true" ]] || [[ "${mode,,}" == "lemonade" && "${managed,,}" == "false" ]]
     }
 
+    _phase11_external_llm() {
+        local url model skip
+        url="${EXTERNAL_LLM_URL:-$(_phase11_env_get EXTERNAL_LLM_URL "")}"
+        model="${EXTERNAL_LLM_MODEL:-$(_phase11_env_get EXTERNAL_LLM_MODEL "")}"
+        skip="${SKIP_MODEL_DOWNLOAD:-$(_phase11_env_get SKIP_MODEL_DOWNLOAD false)}"
+        [[ -n "$url" && -n "$model" && "${skip,,}" == "true" ]]
+    }
+
     _phase11_close_inherited_fds_for_daemon() {
         local fd fd_dir fd_name
 
@@ -390,6 +398,30 @@ else
             "ods-external-lemonade" \
             "" \
             "external Lemonade"
+    }
+
+    _phase11_allow_external_llm_firewall() {
+        _phase11_external_llm || return 0
+
+        local network_name="${1:-ods-network}"
+        local base without_scheme host_port port
+        base="${EXTERNAL_LLM_URL:-$(_phase11_env_get EXTERNAL_LLM_URL "")}"
+        base="${base%/}"
+        case "$base" in
+            http://localhost:*|http://127.0.0.1:*|http://\[::1\]:*) ;;
+            *) return 0 ;;
+        esac
+        without_scheme="${base#*://}"
+        host_port="${without_scheme%%/*}"
+        port="${host_port##*:}"
+        [[ "$port" =~ ^[0-9]+$ ]] || return 0
+
+        _phase11_allow_container_host_firewall \
+            "$network_name" \
+            "$port" \
+            "ods-external-llm" \
+            "" \
+            "external ${EXTERNAL_LLM_PROVIDER:-LLM}"
     }
 
     if [[ "${GPU_BACKEND:-}" == "amd" ]] && ! amd_gpu_runtime_devices_available; then
@@ -587,6 +619,8 @@ else
             mv "$litellm_disabled" "$litellm_cf"
             ai_ok "Auto-enabled litellm for external Lemonade mode"
         fi
+    elif _phase11_external_llm; then
+        ai "External ${EXTERNAL_LLM_PROVIDER:-LLM} mode - skipping ODS-managed GGUF download"
     fi
 
     # Ensure model directory exists
@@ -597,7 +631,7 @@ else
     # immediately. The full model downloads in the background and hot-swaps.
     [[ -f "$SCRIPT_DIR/installers/lib/bootstrap-model.sh" ]] && . "$SCRIPT_DIR/installers/lib/bootstrap-model.sh"
     _BOOTSTRAP_ACTIVE=false
-    if type bootstrap_needed &>/dev/null && bootstrap_needed; then
+    if ! _phase11_external_llm && type bootstrap_needed &>/dev/null && bootstrap_needed; then
         _BOOTSTRAP_ACTIVE=true
         # Save full model config for the background upgrade
         FULL_GGUF_FILE="$GGUF_FILE"
@@ -620,7 +654,9 @@ else
     # Download GGUF model if not already present (with retry and integrity verification)
     ods_progress 76 "services" "Checking AI model"
     GGUF_DIR="$INSTALL_DIR/data/models"
-    if [[ "${ODS_MODE:-local}" != "cloud" && -n "$GGUF_URL" ]] && ! _phase11_external_lemonade; then
+    if [[ "${ODS_MODE:-local}" != "cloud" && -n "$GGUF_URL" ]] \
+        && ! _phase11_external_lemonade \
+        && ! _phase11_external_llm; then
         # Check if model exists and verify integrity
         if [[ -f "$GGUF_DIR/$GGUF_FILE" ]]; then
             if [[ -n "$GGUF_SHA256" ]]; then
@@ -757,7 +793,9 @@ else
         fi
 
         # Abort if model download/verification failed
-        if [[ "${ODS_MODE:-local}" != "cloud" && -n "$GGUF_URL" && ! -f "$GGUF_DIR/$GGUF_FILE" ]] && ! _phase11_external_lemonade; then
+        if [[ "${ODS_MODE:-local}" != "cloud" && -n "$GGUF_URL" && ! -f "$GGUF_DIR/$GGUF_FILE" ]] \
+            && ! _phase11_external_lemonade \
+            && ! _phase11_external_llm; then
             ai_bad "Model file missing or verification failed. Cannot proceed without a valid model."
             ai "Re-run the installer to retry the download."
             exit 1
@@ -848,7 +886,9 @@ else
     fi
 
     # Generate models.ini for llama-server (skip in cloud mode)
-    if [[ "${ODS_MODE:-local}" != "cloud" ]] && ! _phase11_external_lemonade; then
+    if [[ "${ODS_MODE:-local}" != "cloud" ]] \
+        && ! _phase11_external_lemonade \
+        && ! _phase11_external_llm; then
         mkdir -p "$INSTALL_DIR/config/llama-server"
         cat > "$INSTALL_DIR/config/llama-server/models.ini" << MODELS_INI_EOF
 [${LLM_MODEL}]
@@ -941,6 +981,8 @@ MODELS_INI_EOF
                 _hermes_model="ods/current"
             elif [[ "${ODS_MODE:-local}" == "cloud" ]]; then
                 _hermes_model="${LLM_MODEL:-default}"
+            elif _phase11_external_llm; then
+                _hermes_model="${EXTERNAL_LLM_MODEL:-$(_phase11_env_get EXTERNAL_LLM_MODEL "${LLM_MODEL:-default}")}"
             elif _phase11_external_lemonade; then
                 _hermes_model="${LEMONADE_MODEL:-$(_phase11_env_get LEMONADE_MODEL "${LLM_MODEL:-default}")}"
             else
@@ -966,6 +1008,9 @@ MODELS_INI_EOF
             elif [[ "${ODS_MODE:-local}" == "cloud" ]]; then
                 _hermes_base_url="${HERMES_LLM_BASE_URL:-http://litellm:4000/v1}"
                 _hermes_api_key="${HERMES_LLM_API_KEY:-${LITELLM_KEY:-}}"
+            elif _phase11_external_llm; then
+                _hermes_base_url="${HERMES_LLM_BASE_URL:-$(_phase11_env_get HERMES_LLM_BASE_URL "")}"
+                _hermes_api_key="${HERMES_LLM_API_KEY:-$(_phase11_env_get HERMES_LLM_API_KEY not-needed)}"
             elif [[ "${GPU_BACKEND:-}" == "amd" ]] || _phase11_external_lemonade; then
                 _hermes_base_url="http://litellm:4000/v1"
                 _hermes_api_key="${LITELLM_KEY:-}"
@@ -975,6 +1020,8 @@ MODELS_INI_EOF
             if [[ "$_hermes_switchboard_mode" == "enabled" ]]; then
                 _hermes_request_timeout=900
             elif [[ "${ODS_MODE:-local}" != "cloud" ]] && { [[ "${GPU_BACKEND:-}" == "amd" ]] || _phase11_external_lemonade; }; then
+                _hermes_request_timeout=900
+            elif _phase11_external_llm; then
                 _hermes_request_timeout=900
             fi
             _hermes_patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"
@@ -1153,6 +1200,7 @@ MODELS_INI_EOF
     # so we allow the actual Docker subnet instead of a broad RFC1918 range.
     _phase11_allow_host_agent_firewall ods-network
     _phase11_allow_external_lemonade_firewall ods-network
+    _phase11_allow_external_llm_firewall ods-network
 
     _compose_started_with_delayed_health=false
     if ! $compose_ok && _phase11_compose_failure_is_delayed_health && _phase11_has_managed_containers; then

--- a/ods/installers/phases/12-health.sh
+++ b/ods/installers/phases/12-health.sh
@@ -124,6 +124,14 @@ _phase12_external_lemonade() {
     [[ "${external,,}" == "true" ]] || [[ "${mode,,}" == "lemonade" && "${managed,,}" == "false" ]]
 }
 
+_phase12_external_llm() {
+    local url model skip
+    url="${EXTERNAL_LLM_URL:-$(_phase12_env_get EXTERNAL_LLM_URL "")}"
+    model="${EXTERNAL_LLM_MODEL:-$(_phase12_env_get EXTERNAL_LLM_MODEL "")}"
+    skip="${SKIP_MODEL_DOWNLOAD:-$(_phase12_env_get SKIP_MODEL_DOWNLOAD false)}"
+    [[ -n "$url" && -n "$model" && "${skip,,}" == "true" ]]
+}
+
 _phase12_model_looks_non_chat() {
     local model_lc="${1,,}"
     [[ "$model_lc" == *flux* ]] \
@@ -179,10 +187,81 @@ _phase12_verify_external_lemonade_completion() {
     return 1
 }
 
+_phase12_verify_external_llm_completion() {
+    local host_url container_url provider model dashboard_container response
+    local -a docker_cmd_arr=()
+    host_url="${EXTERNAL_LLM_URL:-$(_phase12_env_get EXTERNAL_LLM_URL "")}"
+    container_url="${EXTERNAL_LLM_CONTAINER_URL:-$(_phase12_env_get EXTERNAL_LLM_CONTAINER_URL "")}"
+    provider="${EXTERNAL_LLM_PROVIDER:-$(_phase12_env_get EXTERNAL_LLM_PROVIDER "")}"
+    model="${EXTERNAL_LLM_MODEL:-$(_phase12_env_get EXTERNAL_LLM_MODEL "")}"
+    dashboard_container="$(sr_container dashboard-api 2>/dev/null || echo ods-dashboard-api)"
+    read -r -a docker_cmd_arr <<< "${DOCKER_CMD:-docker}"
+    [[ ${#docker_cmd_arr[@]} -gt 0 ]] || docker_cmd_arr=(docker)
+
+    if [[ -z "$host_url" || -z "$container_url" || -z "$provider" || -z "$model" ]]; then
+        ai_bad "External LLM configuration is incomplete."
+        ai "Re-run with --external-llm-url, --external-llm-provider, and --external-llm-model, or use --no-external-llm."
+        return 1
+    fi
+
+    ai "Verifying external ${provider} model from the host..."
+    if ! external_llm_resolve_model "$provider" "$host_url" "$model" "$model" >/dev/null 2>&1; then
+        ai_bad "External ${provider} no longer exposes model ${model}."
+        ai "Restore the model/service, or re-run the installer with --no-external-llm."
+        return 1
+    fi
+    if ! external_llm_probe_completion "$host_url" "$model"; then
+        ai_bad "External ${provider} accepted discovery but failed a real completion for ${model}."
+        ai "Check the provider logs and model readiness, then re-run the installer."
+        return 1
+    fi
+
+    ai "Verifying the external model route from the ODS Docker network..."
+    response="$(
+        "${docker_cmd_arr[@]}" exec "$dashboard_container" python -c '
+import json
+import sys
+import urllib.request
+
+base = sys.argv[1].rstrip("/")
+model = sys.argv[2]
+payload = json.dumps({
+    "model": model,
+    "messages": [{"role": "user", "content": "Reply with OK."}],
+    "max_tokens": 1,
+    "temperature": 0,
+    "stream": False,
+}).encode()
+request = urllib.request.Request(
+    base + "/v1/chat/completions",
+    data=payload,
+    headers={"Content-Type": "application/json"},
+)
+with urllib.request.urlopen(request, timeout=90) as result:
+    body = json.load(result)
+content = body.get("choices", [{}])[0].get("message", {}).get("content")
+if content is None:
+    raise SystemExit("completion response did not contain assistant content")
+' "$container_url" "$model" 2>&1
+    )" || {
+        ai_bad "ODS containers cannot use external ${provider} at ${container_url}."
+        ai "On Linux, bind the provider to a container-reachable interface (for example 0.0.0.0 on a trusted host) and allow the ODS Docker subnet through the firewall."
+        printf '%s\n' "$response" >> "$LOG_FILE"
+        return 1
+    }
+
+    printf "  ${BGRN}OK${NC} External ${provider} route and completion healthy\n"
+}
+
 # Core service health checks with adaptive timeouts.
 # Cloud mode does not launch local llama-server; LiteLLM/external APIs are the
 # LLM surface, so do not wait on a container that intentionally is not running.
-if [[ "${ODS_MODE:-local}" == "cloud" ]] || _phase12_external_lemonade; then
+if _phase12_external_llm; then
+    ods_progress 86 "health" "Verifying external LLM route"
+    if ! _phase12_verify_external_llm_completion; then
+        exit 1
+    fi
+elif [[ "${ODS_MODE:-local}" == "cloud" ]] || _phase12_external_lemonade; then
     ods_progress 86 "health" "Waiting for LiteLLM gateway"
     _check_health "LiteLLM" "http://127.0.0.1:${SERVICE_PORTS[litellm]:-4000}${SERVICE_HEALTH[litellm]:-/health/readiness}" 60 10 "$(sr_container litellm)"
     if _phase12_external_lemonade; then
@@ -249,7 +328,7 @@ fi
 # cold path inside the installer (where time isn't surprising) so Hermes
 # lands on an already-hot slot. Bounded by curl --max-time so a stalled
 # llama-server doesn't hang phase 12.
-if [[ "${ODS_MODE:-local}" == "cloud" ]] || _phase12_external_lemonade; then
+if [[ "${ODS_MODE:-local}" == "cloud" ]] || _phase12_external_lemonade || _phase12_external_llm; then
     ai "External LLM mode - skipping local llama-server pre-warm"
 else
     ods_progress 87 "health" "Pre-warming LLM slot"

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3407,6 +3407,12 @@ cmd_mode() {
         *) error "Unknown mode: $mode. Use: local, cloud, hybrid" ;;
     esac
 
+    local configured_backend
+    configured_backend=$(grep -m1 "^LLM_BACKEND=" .env 2>/dev/null | cut -d= -f2- | tr -d '"\047\r' || true)
+    if [[ "${configured_backend,,}" == "external" ]]; then
+        error "External LLM routing is installer-managed. Run './install.sh --no-external-llm' first, then retry 'ods mode $mode'."
+    fi
+
     # Update .env
     _env_set "ODS_MODE" "$mode"
 

--- a/ods/scripts/mode-switch.sh
+++ b/ods/scripts/mode-switch.sh
@@ -67,6 +67,12 @@ switch_mode() {
 
     [[ -f "$ENV_FILE" ]] || error ".env not found at $ENV_FILE"
 
+    local configured_backend
+    configured_backend=$(grep -m1 "^LLM_BACKEND=" "$ENV_FILE" 2>/dev/null | cut -d= -f2- | tr -d '"\047\r' || true)
+    if [[ "${configured_backend,,}" == "external" ]]; then
+        error "External LLM routing is installer-managed. Run './install.sh --no-external-llm' first, then retry the mode switch."
+    fi
+
     # Update .env
     env_set "ODS_MODE" "$mode"
 

--- a/ods/scripts/resolve-compose-stack.sh
+++ b/ods/scripts/resolve-compose-stack.sh
@@ -100,6 +100,7 @@ lemonade_external = (
         and os.environ.get("AMD_INFERENCE_MANAGED", "").lower() == "false"
     )
 )
+external_llm = bool(os.environ.get("EXTERNAL_LLM_URL", "").strip())
 
 IS_DARWIN = platform.system() == "Darwin"
 APPLE_OVERLAY = "installers/macos/docker-compose.macos.yml" if IS_DARWIN else "docker-compose.apple.yml"
@@ -573,7 +574,7 @@ if ext_dir.exists():
             # cloud overlay to profile out ODS's managed llama-server, so
             # local-mode overlays that wait on `llama-server: service_healthy`
             # would point at a disabled service and break lifecycle commands.
-            if ods_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external:
+            if ods_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
                 local_mode_overlay = service_dir / "compose.local.yaml"
                 if local_mode_overlay.exists():
                     resolved.append(str(local_mode_overlay.relative_to(script_dir)))
@@ -678,7 +679,7 @@ if user_ext_dir.exists():
                 # overlay to disable ODS's managed llama-server, so user-local
                 # overlays must not add local llama-server health dependencies.
                 # Mirrors the same guard in the built-in loop above (PR #1004).
-                if ods_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external:
+                if ods_mode in ("local", "hybrid", "lemonade") and tier != "CLOUD" and gpu_backend != "apple" and not lemonade_external and not external_llm:
                     local_mode_overlay = service_dir / "compose.local.yaml"
                     if local_mode_overlay.exists():
                         # Same content scan as compose.yaml/gpu overlay above —
@@ -722,6 +723,16 @@ if user_ext_dir.exists():
                     raise
     except OSError as e:
         print(f"WARNING: Could not scan user-extensions: {e}", file=sys.stderr)
+
+# External host runtimes disable ODS-managed inference and add the Linux
+# host-gateway alias to always-on clients. Append this before the operator
+# override so explicit local customization remains the final authority.
+external_llm_overlay = script_dir / "docker-compose.external-llm.yml"
+if external_llm:
+    if not external_llm_overlay.exists():
+        print("ERROR: EXTERNAL_LLM_URL is set but docker-compose.external-llm.yml is missing", file=sys.stderr)
+        sys.exit(1)
+    resolved.append("docker-compose.external-llm.yml")
 
 # Include docker-compose.override.yml if it exists (user customizations).
 # Even though the operator placed this file themselves, the resolver runs

--- a/ods/tests/test-external-services.sh
+++ b/ods/tests/test-external-services.sh
@@ -1,0 +1,431 @@
+#!/usr/bin/env bash
+# External Ollama / LM Studio discovery and installer-selection contracts.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=../installers/lib/external-services.sh
+source "$ROOT_DIR/installers/lib/external-services.sh"
+
+PASSED=0
+FAILED=0
+
+pass() {
+    printf '[PASS] %s\n' "$1"
+    PASSED=$((PASSED + 1))
+}
+
+fail() {
+    printf '[FAIL] %s\n' "$1" >&2
+    FAILED=$((FAILED + 1))
+}
+
+assert_eq() {
+    local actual="$1" expected="$2" label="$3"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$label"
+    else
+        fail "$label (expected '$expected', got '$actual')"
+    fi
+}
+
+assert_true() {
+    local label="$1"
+    shift
+    if "$@"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+assert_eq "$(external_llm_normalize_model_name 'qwen3.5:9b')" \
+    "qwen3.5-9b" "normalizes Ollama tags"
+assert_eq "$(external_llm_normalize_model_name 'Qwen3.5-9B-Q4_K_M.gguf')" \
+    "qwen3.5-9b" "removes GGUF quantization suffixes"
+assert_eq "$(external_llm_container_url 'http://localhost:11434/v1')" \
+    "http://host.docker.internal:11434" "normalizes localhost for containers"
+assert_eq "$(external_llm_container_url 'http://[::1]:1234/api/v1')" \
+    "http://host.docker.internal:1234" "normalizes IPv6 loopback for containers"
+assert_eq "$(external_llm_host_url 'http://host.docker.internal:11434/v1')" \
+    "http://127.0.0.1:11434" "normalizes the Docker host alias for host probes"
+assert_true "accepts a supported external base URL" \
+    external_llm_validate_url "http://127.0.0.1:11434/v1"
+if external_llm_validate_url "file:///tmp/models"; then
+    fail "rejects non-HTTP external URLs"
+else
+    pass "rejects non-HTTP external URLs"
+fi
+if external_llm_validate_url "http://user:secret@127.0.0.1:11434"; then
+    fail "rejects credentials embedded in external URLs"
+else
+    pass "rejects credentials embedded in external URLs"
+fi
+if external_llm_validate_url "http://127.0.0.1:11434?token=secret"; then
+    fail "rejects query data embedded in external URLs"
+else
+    pass "rejects query data embedded in external URLs"
+fi
+assert_true "matches equivalent Ollama and GGUF model names" \
+    external_llm_model_matches "Qwen3.5-9B-Q4_K_M.gguf" "qwen3.5:9b"
+if external_llm_model_matches "qwen3.5:9b" "llama3.2:3b"; then
+    fail "rejects unrelated model families"
+else
+    pass "rejects unrelated model families"
+fi
+
+run_phase_case() {
+    set -euo pipefail
+
+    local case_name="$1"
+    local install_dir="$2"
+
+    ods_progress() { :; }
+    log() { :; }
+    ai() { :; }
+    ai_ok() { :; }
+    ai_bad() { :; }
+    resolve_compose_config() { :; }
+
+    curl() {
+        local url="${*: -1}"
+        case "$url" in
+            */api/tags)
+                [[ "${MOCK_OLLAMA:-down}" == "up" ]] || return 22
+                printf '{"models":[{"name":"qwen3.5:9b"},{"name":"llama3.2:3b"}]}'
+                ;;
+            */v1/models)
+                [[ "${MOCK_LMSTUDIO:-down}" == "up" ]] || return 22
+                printf '{"data":[{"id":"qwen3.5-9b"},{"id":"local-model"}]}'
+                ;;
+            */v1/chat/completions)
+                printf '{"choices":[{"message":{"content":"OK"}}]}'
+                ;;
+            *)
+                return 22
+                ;;
+        esac
+    }
+
+    INTERACTIVE=false
+    DRY_RUN=false
+    ODS_MODE=local
+    INSTALL_DIR="$install_dir"
+    GGUF_FILE="Qwen3.5-9B-Q4_K_M.gguf"
+    LLM_MODEL="qwen3.5-9b"
+    unset EXTERNAL_LLM_URL EXTERNAL_LLM_CONTAINER_URL EXTERNAL_LLM_PROVIDER
+    unset EXTERNAL_LLM_MODEL EXTERNAL_LLM_AUTO_REUSE EXTERNAL_LLM_DISABLE
+    unset EXTERNAL_LLM_RESET SKIP_MODEL_DOWNLOAD LEMONADE_EXTERNAL
+
+    case "$case_name" in
+        default)
+            MOCK_OLLAMA=up
+            ;;
+        auto)
+            MOCK_OLLAMA=up
+            EXTERNAL_LLM_AUTO_REUSE=true
+            ;;
+        persisted)
+            MOCK_OLLAMA=up
+            ;;
+        disabled)
+            MOCK_OLLAMA=up
+            EXTERNAL_LLM_DISABLE=true
+            ;;
+        disabled-cloud)
+            MOCK_OLLAMA=up
+            ODS_MODE=cloud
+            EXTERNAL_LLM_DISABLE=true
+            ;;
+        explicit-offline)
+            EXTERNAL_LLM_URL="http://127.0.0.1:11434"
+            EXTERNAL_LLM_PROVIDER="ollama"
+            EXTERNAL_LLM_MODEL="qwen3.5:9b"
+            ;;
+        explicit-cloud)
+            MOCK_OLLAMA=up
+            ODS_MODE=cloud
+            EXTERNAL_LLM_URL="http://127.0.0.1:11434"
+            EXTERNAL_LLM_PROVIDER="ollama"
+            EXTERNAL_LLM_MODEL="qwen3.5:9b"
+            ;;
+        explicit-hybrid)
+            MOCK_OLLAMA=up
+            ODS_MODE=hybrid
+            EXTERNAL_LLM_URL="http://127.0.0.1:11434"
+            EXTERNAL_LLM_PROVIDER="ollama"
+            EXTERNAL_LLM_MODEL="qwen3.5:9b"
+            ;;
+        explicit-lemonade)
+            MOCK_OLLAMA=up
+            LEMONADE_EXTERNAL=true
+            EXTERNAL_LLM_URL="http://127.0.0.1:11434"
+            EXTERNAL_LLM_PROVIDER="ollama"
+            EXTERNAL_LLM_MODEL="qwen3.5:9b"
+            ;;
+        *)
+            return 99
+            ;;
+    esac
+
+    # shellcheck source=../installers/phases/02b-external-services.sh
+    source "$ROOT_DIR/installers/phases/02b-external-services.sh"
+}
+
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+if output="$(run_phase_case default "$TEMP_DIR/default"; printf '%s|%s\n' "${EXTERNAL_LLM_URL:-}" "${SKIP_MODEL_DOWNLOAD:-}")"; then
+    assert_eq "$output" "|false" "non-interactive ambient discovery is inert by default"
+else
+    fail "default non-interactive phase completes"
+fi
+
+if output="$(run_phase_case auto "$TEMP_DIR/auto"; printf '%s|%s|%s|%s\n' \
+    "${EXTERNAL_LLM_PROVIDER:-}" "${EXTERNAL_LLM_MODEL:-}" \
+    "${EXTERNAL_LLM_CONTAINER_URL:-}" "${SKIP_MODEL_DOWNLOAD:-}")"; then
+    assert_eq "$output" \
+        "ollama|qwen3.5:9b|http://host.docker.internal:11434|true" \
+        "explicit auto-reuse validates and persists an exact external route"
+else
+    fail "opt-in auto-reuse phase completes"
+fi
+
+mkdir -p "$TEMP_DIR/persisted"
+cat > "$TEMP_DIR/persisted/.env" <<'EOF'
+EXTERNAL_LLM_URL=http://127.0.0.1:11434
+EXTERNAL_LLM_CONTAINER_URL=http://host.docker.internal:11434
+EXTERNAL_LLM_PROVIDER=ollama
+EXTERNAL_LLM_MODEL=qwen3.5:9b
+SKIP_MODEL_DOWNLOAD=true
+EOF
+if output="$(run_phase_case persisted "$TEMP_DIR/persisted"; printf '%s|%s\n' \
+    "${EXTERNAL_LLM_MODEL:-}" "${SKIP_MODEL_DOWNLOAD:-}")"; then
+    assert_eq "$output" "qwen3.5:9b|true" \
+        "rerun revalidates and preserves a reachable external selection"
+else
+    fail "persisted external selection rerun completes"
+fi
+
+mkdir -p "$TEMP_DIR/disabled"
+cp "$TEMP_DIR/persisted/.env" "$TEMP_DIR/disabled/.env"
+if output="$(run_phase_case disabled "$TEMP_DIR/disabled"; printf '%s|%s|%s\n' \
+    "${EXTERNAL_LLM_URL:-}" "${SKIP_MODEL_DOWNLOAD:-}" "${EXTERNAL_LLM_RESET:-}")"; then
+    assert_eq "$output" "|false|true" \
+        "--no-external-llm clears the persisted topology for managed inference"
+else
+    fail "external reset phase completes"
+fi
+
+if output="$(run_phase_case disabled-cloud "$TEMP_DIR/disabled"; printf '%s|%s|%s\n' \
+    "${EXTERNAL_LLM_URL:-}" "${SKIP_MODEL_DOWNLOAD:-}" "${EXTERNAL_LLM_RESET:-}")"; then
+    assert_eq "$output" "|false|true" \
+        "--no-external-llm permits an intentional transition to cloud mode"
+else
+    fail "external reset followed by cloud mode completes"
+fi
+
+if run_phase_case explicit-offline "$TEMP_DIR/offline"; then
+    fail "explicit unavailable provider must fail closed"
+else
+    pass "explicit unavailable provider fails closed"
+fi
+
+if run_phase_case explicit-cloud "$TEMP_DIR/cloud"; then
+    fail "external reuse must reject cloud mode"
+else
+    pass "external reuse rejects cloud mode without mutating the topology"
+fi
+
+if run_phase_case explicit-hybrid "$TEMP_DIR/hybrid"; then
+    fail "external reuse must reject hybrid mode"
+else
+    pass "external reuse rejects hybrid mode without bypassing LiteLLM"
+fi
+
+if run_phase_case explicit-lemonade "$TEMP_DIR/lemonade"; then
+    fail "external reuse must reject a second host-managed backend"
+else
+    pass "external reuse rejects simultaneous external Lemonade"
+fi
+
+run_phase06_env_cycle() (
+    set -euo pipefail
+
+    local install_dir="$TEMP_DIR/phase06-install"
+    mkdir -p "$install_dir"
+    tar -C "$ROOT_DIR" \
+        --exclude='./.env' \
+        --exclude='./extensions/services/dashboard/node_modules' \
+        --exclude='./extensions/services/dashboard/dist' \
+        -cf - . | tar -C "$install_dir" -xf -
+
+    export INSTALL_DIR="$install_dir"
+    export SCRIPT_DIR="$install_dir"
+    export LOG_FILE="$install_dir/phase06.log"
+    export DRY_RUN=false
+    export INTERACTIVE=false
+    export ODS_MODE=local
+    export GPU_BACKEND=cpu
+    export TIER=T1
+    export TIER_NAME=Entry
+    export LLM_MODEL=qwen3-1.7b
+    export GGUF_FILE=Qwen3-1.7B-Q4_K_M.gguf
+    export MAX_CONTEXT=4096
+    export ODS_VERSION=2.1.0
+    export ENABLE_VOICE=false
+    export ENABLE_WORKFLOWS=false
+    export ENABLE_RAG=false
+    export ENABLE_HERMES=false
+    export ENABLE_OPENCLAW=false
+    export EXTERNAL_LLM_URL=http://127.0.0.1:11434
+    export EXTERNAL_LLM_CONTAINER_URL=http://host.docker.internal:11434
+    export EXTERNAL_LLM_PROVIDER=ollama
+    export EXTERNAL_LLM_MODEL=qwen3.5:9b
+    export LEMONADE_EXTERNAL=false
+
+    # shellcheck source=../installers/lib/constants.sh
+    source "$install_dir/installers/lib/constants.sh"
+    # shellcheck source=../installers/lib/logging.sh
+    source "$install_dir/installers/lib/logging.sh"
+    # shellcheck source=../installers/lib/ui.sh
+    source "$install_dir/installers/lib/ui.sh"
+    # shellcheck source=../installers/lib/detection.sh
+    source "$install_dir/installers/lib/detection.sh"
+    # shellcheck source=../installers/lib/progress.sh
+    source "$install_dir/installers/lib/progress.sh"
+
+    ods_progress() { :; }
+    ai() { :; }
+    ai_ok() { :; }
+    ai_warn() { :; }
+    ai_bad() { :; }
+    chapter() { :; }
+    signal() { :; }
+    show_phase() { :; }
+    sudo() { return 0; }
+    docker() {
+        if [[ "${1:-}" == "info" && "${2:-}" == "--format" ]]; then
+            printf '4\n'
+            return 0
+        fi
+        command docker "$@"
+    }
+
+    # shellcheck source=../installers/phases/06-directories.sh
+    source "$install_dir/installers/phases/06-directories.sh"
+
+    grep -qx 'LLM_BACKEND=external' "$install_dir/.env"
+    grep -qx 'LLM_MODEL=qwen3.5:9b' "$install_dir/.env"
+    grep -qx 'LLM_API_URL=http://host.docker.internal:11434' "$install_dir/.env"
+    grep -qx 'OPEN_WEBUI_LLM_BASE_URL=http://host.docker.internal:11434/v1' "$install_dir/.env"
+    grep -qx 'HERMES_LLM_BASE_URL=http://host.docker.internal:11434/v1' "$install_dir/.env"
+    grep -qx 'EXTERNAL_LLM_PROVIDER=ollama' "$install_dir/.env"
+    grep -qx 'SKIP_MODEL_DOWNLOAD=true' "$install_dir/.env"
+    grep -qx 'MODEL_RECOMMENDED_MODEL=qwen3-1.7b' "$install_dir/.env"
+
+    export LLM_MODEL=qwen3-1.7b
+    export GGUF_FILE=Qwen3-1.7B-Q4_K_M.gguf
+    export MAX_CONTEXT=4096
+    export EXTERNAL_LLM_URL=
+    export EXTERNAL_LLM_CONTAINER_URL=
+    export EXTERNAL_LLM_PROVIDER=
+    export EXTERNAL_LLM_MODEL=
+    export EXTERNAL_LLM_RESET=true
+
+    source "$install_dir/installers/phases/06-directories.sh"
+
+    grep -qx 'LLM_BACKEND=llama-server' "$install_dir/.env"
+    grep -qx 'LLM_MODEL=qwen3-1.7b' "$install_dir/.env"
+    grep -qx 'LLM_API_URL=http://llama-server:8080' "$install_dir/.env"
+    grep -qx 'OPEN_WEBUI_LLM_BASE_URL=' "$install_dir/.env"
+    grep -qx 'HERMES_LLM_BASE_URL=http://llama-server:8080/v1' "$install_dir/.env"
+    grep -qx 'EXTERNAL_LLM_URL=' "$install_dir/.env"
+    grep -qx 'EXTERNAL_LLM_PROVIDER=' "$install_dir/.env"
+    grep -qx 'SKIP_MODEL_DOWNLOAD=false' "$install_dir/.env"
+)
+
+if run_phase06_env_cycle; then
+    pass "phase 06 persists external routing and restores managed inference on reset"
+else
+    fail "phase 06 external routing/reset cycle"
+fi
+
+run_phase06_amd_external() (
+    set -euo pipefail
+
+    local install_dir="$TEMP_DIR/phase06-amd"
+    mkdir -p "$install_dir"
+    tar -C "$ROOT_DIR" \
+        --exclude='./.env' \
+        --exclude='./extensions/services/dashboard/node_modules' \
+        --exclude='./extensions/services/dashboard/dist' \
+        -cf - . | tar -C "$install_dir" -xf -
+
+    export INSTALL_DIR="$install_dir"
+    export SCRIPT_DIR="$install_dir"
+    export LOG_FILE="$install_dir/phase06.log"
+    export DRY_RUN=false
+    export INTERACTIVE=false
+    export ODS_MODE=local
+    export GPU_BACKEND=amd
+    export TIER=T1
+    export TIER_NAME=Entry
+    export LLM_MODEL=qwen3-1.7b
+    export GGUF_FILE=Qwen3-1.7B-Q4_K_M.gguf
+    export MAX_CONTEXT=4096
+    export ODS_VERSION=2.1.0
+    export ENABLE_VOICE=false
+    export ENABLE_WORKFLOWS=false
+    export ENABLE_RAG=false
+    export ENABLE_HERMES=false
+    export ENABLE_OPENCLAW=false
+    export EXTERNAL_LLM_URL=http://127.0.0.1:11434
+    export EXTERNAL_LLM_CONTAINER_URL=http://host.docker.internal:11434
+    export EXTERNAL_LLM_PROVIDER=ollama
+    export EXTERNAL_LLM_MODEL=qwen3.5:9b
+    export LEMONADE_EXTERNAL=false
+
+    source "$install_dir/installers/lib/constants.sh"
+    source "$install_dir/installers/lib/logging.sh"
+    source "$install_dir/installers/lib/ui.sh"
+    source "$install_dir/installers/lib/detection.sh"
+    source "$install_dir/installers/lib/progress.sh"
+
+    ods_progress() { :; }
+    ai() { :; }
+    ai_ok() { :; }
+    ai_warn() { :; }
+    ai_bad() { :; }
+    chapter() { :; }
+    signal() { :; }
+    show_phase() { :; }
+    sudo() { return 0; }
+    docker() {
+        if [[ "${1:-}" == "info" && "${2:-}" == "--format" ]]; then
+            printf '4\n'
+            return 0
+        fi
+        command docker "$@"
+    }
+
+    source "$install_dir/installers/phases/06-directories.sh"
+
+    grep -qx 'ODS_MODE=local' "$install_dir/.env"
+    grep -qx 'LLM_BACKEND=external' "$install_dir/.env"
+    grep -qx 'LLM_API_BASE_PATH=/v1' "$install_dir/.env"
+    grep -qx 'AMD_INFERENCE_RUNTIME=' "$install_dir/.env"
+    grep -qx 'AMD_INFERENCE_BACKEND=' "$install_dir/.env"
+    grep -qx 'AMD_INFERENCE_LOCATION=' "$install_dir/.env"
+    grep -qx 'AMD_INFERENCE_PORT=' "$install_dir/.env"
+    grep -qx 'AMD_INFERENCE_MANAGED=' "$install_dir/.env"
+)
+
+if run_phase06_amd_external; then
+    pass "AMD external reuse writes one coherent non-Lemonade backend contract"
+else
+    fail "AMD external reuse .env contract"
+fi
+
+printf '\nResult: %d passed, %d failed\n' "$PASSED" "$FAILED"
+[[ "$FAILED" -eq 0 ]]

--- a/ods/tests/test-mode-switch-status.sh
+++ b/ods/tests/test-mode-switch-status.sh
@@ -120,7 +120,22 @@ printf 'ODS_MODE=cloud\n' > "$ROOT/.env"
 run_mode "$ROOT" local > /dev/null
 check_eq "switching back to local repoints LLM_API_URL" "LLM_API_URL=http://llama-server:8080" "$(grep -m1 '^LLM_API_URL=' "$ROOT/.env")"
 
-# ── 6. Bad input is rejected ──────────────────────────────────────────────
+# ── 6. External topology cannot be partially overwritten ─────────────────
+
+ROOT="$(new_root)"
+cat > "$ROOT/.env" <<'EOF'
+ODS_MODE=local
+LLM_BACKEND=external
+LLM_API_URL=http://host.docker.internal:11434
+EXTERNAL_LLM_URL=http://127.0.0.1:11434
+EOF
+BEFORE="$(cat "$ROOT/.env")"
+OUT="$(run_mode "$ROOT" cloud)"
+check_eq "external backend rejects direct mode switch" "1" "$(run_rc "$ROOT" cloud)"
+check_contains "external backend points to the transactional reset" "--no-external-llm" "$OUT"
+check_eq "rejected external mode switch leaves .env unchanged" "$BEFORE" "$(cat "$ROOT/.env")"
+
+# ── 7. Bad input is rejected ──────────────────────────────────────────────
 
 ROOT="$(new_root)"
 printf 'ODS_MODE=local\n' > "$ROOT/.env"

--- a/ods/tests/test-ods-cli-pipefail-tolerance.sh
+++ b/ods/tests/test-ods-cli-pipefail-tolerance.sh
@@ -115,6 +115,23 @@ else
     fail "mode display exited $rc with missing optional .env keys"
 fi
 
+cat > "$INSTALL_DIR/.env" <<'EOF'
+ODS_MODE=local
+LLM_BACKEND=external
+LLM_API_URL=http://host.docker.internal:11434
+EXTERNAL_LLM_URL=http://127.0.0.1:11434
+EOF
+before_external_env="$(cat "$INSTALL_DIR/.env")"
+result="$(run_ods mode cloud)"
+rc="$(printf '%s\n' "$result" | sed -n '1p')"
+if [[ "$rc" != "0" ]] \
+    && grep -q -- '--no-external-llm' <<<"$result" \
+    && [[ "$(cat "$INSTALL_DIR/.env")" == "$before_external_env" ]]; then
+    pass "mode switch rejects partial mutation of installer-managed external routing"
+else
+    fail "mode switch partially mutated installer-managed external routing"
+fi
+
 result="$(run_ods model current)"
 rc="$(printf '%s\n' "$result" | sed -n '1p')"
 if [[ "$rc" == "0" ]]; then

--- a/ods/tests/test-resolve-compose-resilient.sh
+++ b/ods/tests/test-resolve-compose-resilient.sh
@@ -584,6 +584,151 @@ fi
 
 rm -rf "$TEMP_DIR/data/user-extensions/shadow-core"
 
+# ============================================================================
+# 24. External LLM overlay selection is explicit and deterministic
+# ============================================================================
+cat > "$TEMP_DIR/docker-compose.external-llm.yml" <<'EOF'
+services:
+  base-service:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+EOF
+
+external_flags=$(EXTERNAL_LLM_URL="http://127.0.0.1:11434" \
+    bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>/dev/null)
+if contains_path "$external_flags" "docker-compose.external-llm.yml"; then
+    pass "External endpoint selects the dedicated external-LLM overlay"
+else
+    fail "External endpoint did not select the dedicated external-LLM overlay"
+fi
+
+managed_flags=$(EXTERNAL_LLM_URL="" \
+    bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$TEMP_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>/dev/null)
+if contains_path "$managed_flags" "docker-compose.external-llm.yml"; then
+    fail "Managed inference unexpectedly selected the external-LLM overlay"
+else
+    pass "Managed inference does not select the external-LLM overlay"
+fi
+
+# ============================================================================
+# 25. Every direct external-LLM consumer receives a Linux host-gateway route
+# ============================================================================
+consumer_route_files=(
+    "$ROOT_DIR/docker-compose.external-llm.yml"
+    "$ROOT_DIR/extensions/services/hermes/compose.yaml"
+    "$ROOT_DIR/extensions/services/openclaw/compose.yaml"
+    "$ROOT_DIR/extensions/services/perplexica/compose.yaml"
+    "$ROOT_DIR/extensions/services/privacy-shield/compose.yaml"
+    "$ROOT_DIR/extensions/services/token-spy/compose.yaml"
+)
+consumer_routes_ok=true
+for consumer_file in "${consumer_route_files[@]}"; do
+    if ! grep -Fq "host.docker.internal:host-gateway" "$consumer_file"; then
+        fail "$(basename "$consumer_file") is missing the external-LLM host-gateway route"
+        consumer_routes_ok=false
+    fi
+done
+if $consumer_routes_ok; then
+    pass "All direct external-LLM consumers define a Linux host-gateway route"
+fi
+
+# ============================================================================
+# 26. The real external-LLM stack renders without local inference dependencies
+# ============================================================================
+real_external_flags=$(EXTERNAL_LLM_URL="http://127.0.0.1:11434" \
+    ODS_MODE=local \
+    bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+    --script-dir "$ROOT_DIR" --tier 1 --gpu-backend nvidia --skip-broken \
+    2>/dev/null)
+
+if printf '%s\n' "$real_external_flags" | grep -Fq "compose.local.yaml"; then
+    fail "External-LLM stack retained a local llama-server dependency overlay"
+else
+    pass "External-LLM stack excludes local llama-server dependency overlays"
+fi
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    compose_config_file="$TEMP_DIR/external-compose-config.yml"
+    # shellcheck disable=SC2086
+    if (
+        cd "$ROOT_DIR"
+        export EXTERNAL_LLM_URL="http://127.0.0.1:11434"
+        export EXTERNAL_LLM_CONTAINER_URL="http://host.docker.internal:11434"
+        export EXTERNAL_LLM_PROVIDER="ollama"
+        export EXTERNAL_LLM_MODEL="qwen3.5:9b"
+        export LLM_API_URL="$EXTERNAL_LLM_CONTAINER_URL"
+        export HERMES_LLM_BASE_URL="${EXTERNAL_LLM_CONTAINER_URL}/v1"
+        export WEBUI_SECRET="external-llm-compose-test"
+        export DASHBOARD_API_KEY="external-llm-compose-test"
+        export ODS_AGENT_KEY="external-llm-compose-test"
+        export N8N_USER="admin@example.invalid"
+        export N8N_PASS="external-llm-compose-test"
+        export OPENCLAW_TOKEN="external-llm-compose-test"
+        export SEARXNG_SECRET="external-llm-compose-test"
+        docker compose $real_external_flags config > "$compose_config_file"
+    ); then
+        if grep -Eq '^[[:space:]]+llama-server:$' "$compose_config_file"; then
+            fail "Rendered external-LLM stack still contains managed llama-server"
+        elif grep -Eq '^[[:space:]]+model-router:$' "$compose_config_file"; then
+            fail "Rendered external-LLM stack still contains model-router"
+        elif ! grep -Fq 'ODS_TALK_VISION_URL: http://host.docker.internal:11434/v1' "$compose_config_file"; then
+            fail "Rendered external-LLM stack does not route ODS Talk vision to the external backend"
+        else
+            pass "Real external-LLM Compose stack renders without managed inference and routes ODS Talk externally"
+        fi
+    else
+        fail "Real external-LLM Compose stack failed docker compose config"
+    fi
+
+    amd_external_flags=$(EXTERNAL_LLM_URL="http://127.0.0.1:11434" \
+        ODS_MODE=local \
+        bash "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$ROOT_DIR" --tier 1 --gpu-backend amd --skip-broken \
+        2>/dev/null)
+    amd_compose_config_file="$TEMP_DIR/external-amd-compose-config.yml"
+    # shellcheck disable=SC2086
+    if (
+        cd "$ROOT_DIR"
+        export EXTERNAL_LLM_URL="http://127.0.0.1:11434"
+        export EXTERNAL_LLM_CONTAINER_URL="http://host.docker.internal:11434"
+        export EXTERNAL_LLM_PROVIDER="ollama"
+        export EXTERNAL_LLM_MODEL="qwen3.5:9b"
+        export LLM_API_URL="$EXTERNAL_LLM_CONTAINER_URL"
+        export OPEN_WEBUI_LLM_BASE_URL="${EXTERNAL_LLM_CONTAINER_URL}/v1"
+        export OPEN_WEBUI_LLM_API_KEY=""
+        export WEBUI_SECRET="external-llm-compose-test"
+        export DASHBOARD_API_KEY="external-llm-compose-test"
+        export ODS_AGENT_KEY="external-llm-compose-test"
+        export N8N_USER="admin@example.invalid"
+        export N8N_PASS="external-llm-compose-test"
+        export OPENCLAW_TOKEN="external-llm-compose-test"
+        export SEARXNG_SECRET="external-llm-compose-test"
+        docker compose $amd_external_flags config > "$amd_compose_config_file"
+    ); then
+        if grep -Eq '^[[:space:]]+llama-server:$' "$amd_compose_config_file"; then
+            fail "Rendered AMD external stack retained managed Lemonade"
+        elif ! grep -Fq 'LLM_BACKEND: external' "$amd_compose_config_file"; then
+            fail "Rendered AMD external stack overwrote the API backend with Lemonade"
+        elif ! grep -Fq 'LLM_API_BASE_PATH: /v1' "$amd_compose_config_file"; then
+            fail "Rendered AMD external stack retained the Lemonade API base path"
+        elif ! grep -Fq 'OPENAI_API_KEY: ""' "$amd_compose_config_file"; then
+            fail "Rendered AMD external stack leaked the LiteLLM key into Open WebUI"
+        elif ! grep -Fq 'AMD_INFERENCE_RUNTIME: ""' "$amd_compose_config_file"; then
+            fail "Rendered AMD external stack advertised a managed AMD runtime"
+        else
+            pass "Real AMD external stack overrides Lemonade routing without changing GPU telemetry"
+        fi
+    else
+        fail "Real AMD external-LLM stack failed docker compose config"
+    fi
+else
+    skip "Docker Compose unavailable; real external-LLM render skipped"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

Adds an explicit, validated Linux installer path for reusing a host-managed Ollama or LM Studio text model instead of downloading and running a duplicate ODS `llama-server`.

The implementation treats external inference as a complete routing contract rather than a URL substitution: it validates the provider and exact model, derives separate host/container URLs, profiles managed inference out, rewires every direct consumer, health-proves a real completion, and provides a transactional path back to managed inference.

## User-visible behavior

### Interactive install

When a matching Ollama or LM Studio model is running locally, the installer offers to reuse it.

### Non-interactive install

Ambient services do not change the install topology unless reuse is explicitly requested:

```bash
./install.sh --reuse-external-llm --non-interactive
```

An endpoint and exact model can also be selected explicitly:

```bash
./install.sh \
  --external-llm-url http://127.0.0.1:11434 \
  --external-llm-provider ollama \
  --external-llm-model qwen3.5:9b
```

Return to ODS-managed inference with:

```bash
./install.sh --no-external-llm
```

## Runtime contract

- Validates `http`/`https` base URLs and rejects embedded credentials, query strings, fragments, unsupported paths, and invalid ports.
- Accepts only `ollama` or `lmstudio`, and requires the selected model to be present in the provider inventory.
- Converts host loopback URLs to `host.docker.internal` only for container consumers.
- Adds Linux `host-gateway` routes to every direct LLM consumer.
- Profiles `llama-server`, `model-router`, and their local readiness dependencies out of the external stack.
- Routes Open WebUI, Dashboard API/ODS Talk, Hermes, OpenClaw, Perplexica, Privacy Shield, and Token Spy to the external endpoint.
- Skips duplicate GGUF/bootstrap downloads while preserving the local model library for browsing and downloads.
- Blocks local model activation while the external backend owns inference, with a clear recovery command.
- Requires host and container model inventory plus a real chat completion before installation succeeds.
- Rejects direct local/cloud/hybrid mode changes while external routing is active so `.env` cannot become internally inconsistent.

## Invariants

| Invariant | Enforcement |
|---|---|
| Automation is deterministic | Non-interactive ambient discovery is inert without explicit opt-in |
| One active inference owner | External reuse cannot be combined with cloud, hybrid, or external Lemonade |
| Host and containers use reachable URLs | Host URL is retained separately from the normalized container URL |
| No partial success | Missing provider/model or failed completion aborts installation |
| Reruns preserve valid intent | Existing external selection is revalidated before reuse |
| Reset restores managed inference | `--no-external-llm` clears external state and restores local routes/download behavior |
| AMD metadata remains coherent | External routing clears Lemonade runtime fields and wins topology selection |
| Local activation cannot split state | Dashboard API/UI reject activation until external mode is disabled |

## Compatibility and scope

- Linux installer lifecycle: implemented and covered.
- Docker Desktop and plain Linux Engine container routing: covered by rendered Compose contracts.
- AMD/NVIDIA Linux topology: external routing remains independent of GPU backend; AMD Lemonade metadata is cleared when external inference is selected.
- Windows/macOS installer adoption flags: not introduced in this PR. Shared Dashboard API and Compose behavior remain compatible, while native installer lifecycle changes stay out of scope.
- This reuses provider-served text/chat models. It does not import model files, synchronize VLM/embedding/reranker stores, configure authenticated endpoints, or manage multiple external models.

## Validation

| Validation | Result |
|---|---:|
| External discovery, validation, rerun, reset, mode conflicts, AMD contract | 22 passed |
| Compose resolver, host routes, excluded dependencies, real NVIDIA/AMD render | 37 passed |
| Mode switch lifecycle | 20 passed |
| AMD/Lemonade compatibility contracts | 65 passed |
| Dashboard API focused suite | 229 passed |
| Dashboard frontend suite | 256 passed |
| PowerShell parser | 23 files passed |
| Bash parser | Changed shell files passed |
| JSON/YAML parsing | 8 changed structured files passed |
| Frontend production build | Passed |
| Ruff, Python compilation, `git diff --check` | Passed |

The full `make gate` was intentionally not used as the final local receipt because it is long-running on this Windows/WSL host. The focused official suites above cover every changed behavioral surface; GitHub CI remains the authoritative full matrix.

## Security and failure handling

- URLs containing credentials are rejected so secrets are not persisted in `.env` or Compose metadata.
- Non-interactive installs cannot silently adopt an ambient host process.
- Provider/model identity is checked before mutation and rechecked during health validation.
- Unreachable or incomplete external inference fails closed instead of leaving ODS without a usable LLM.

## Independent review

A second review was performed without assuming the implementation was correct. It exercised invalid ports and paths, fragments, IPv4/IPv6 loopback normalization, literal model IDs with metacharacters, persisted reruns, reset behavior, mode conflicts, AMD precedence, Compose dependency removal, and local activation blocking. No additional reproducible in-scope defect was found, so no speculative changes were added.

## Issue

Addresses #1649. The broader request for importing/synchronizing every external model class remains separate from this host text-inference reuse path.