### PR TITLE
fix(proxy): cap request body sizes and pre-stage HSTS header

### DIFF
--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -71,4 +71,7 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-XSS-Protection "1; mode=block" always;
     add_header Content-Security-Policy "default-src 'self'; script-src 'self' https://unpkg.com https://cdn.jsdelivr.net; style-src 'self' https://cdn.jsdelivr.net 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; media-src 'self' blob:; font-src 'self' https://cdn.jsdelivr.net;" always;
+    # Pre-stage HSTS so it activates automatically when TLS lands via
+    # Caddy/Tailscale. Harmless over plain HTTP (browsers ignore it).
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains" always;
 }

--- a/ods/extensions/services/hermes-proxy/Caddyfile
+++ b/ods/extensions/services/hermes-proxy/Caddyfile
@@ -43,6 +43,11 @@
 # Listen on the proxy's internal port. Compose maps this to the external
 # HERMES_PROXY_PORT via the host port mapping.
 :9120 {
+	# Cap request body at 50 MB to protect against abuse of the Hermes
+	# proxy paths while still allowing file attachments in agent prompts.
+	request_body {
+		max_size 50MB
+	}
 	# Caddy's global directive order would otherwise run forward_auth before
 	# these local handle blocks. Keep the literal order so health, favicon,
 	# and invite-help assets remain public, while every other path is gated.

--- a/ods/extensions/services/ods-proxy/Caddyfile
+++ b/ods/extensions/services/ods-proxy/Caddyfile
@@ -64,6 +64,11 @@
 # chat.<device>.local → Open WebUI (root-mounted)
 # ---------------------------------------------------------------------
 http://chat.{$ODS_DEVICE_NAME:ods}.local {
+	# Cap request body at 200 MB — enough for document uploads to Open WebUI
+	# while preventing abuse of the LLM proxy paths from runaway clients.
+	request_body {
+		max_size 200MB
+	}
 	reverse_proxy open-webui:8080 {
 		header_up X-Forwarded-Proto {scheme}
 		header_up X-Forwarded-Host {host}
@@ -119,6 +124,10 @@ http://auth.{$ODS_DEVICE_NAME:ods}.local {
 # whole hostname keeps the backend root-mounted.
 # ---------------------------------------------------------------------
 http://api.{$ODS_DEVICE_NAME:ods}.local {
+	# Cap request body at 50 MB for the admin API surface.
+	request_body {
+		max_size 50MB
+	}
 	reverse_proxy dashboard-api:3002 {
 		header_up X-Forwarded-Proto {scheme}
 		header_up X-Forwarded-Host {host}

--- a/ods/tests/contracts/test-network-exposure-contracts.py
+++ b/ods/tests/contracts/test-network-exposure-contracts.py
@@ -28,6 +28,28 @@ def manifest_bool(text: str, key: str) -> bool:
     return bool(value and value.lower() == "true")
 
 
+def caddy_block_body(text: str, opener: str) -> str:
+    """Return the body of the Caddy block whose opening line equals `opener`.
+
+    `opener` is the literal site line ending in the block's opening brace, e.g.
+    ``http://chat.{$ODS_DEVICE_NAME:ods}.local {``. Depth counting starts at that
+    brace; inline placeholders like ``{scheme}`` or ``{$ENV}`` are brace-balanced,
+    so they net to zero and do not disturb the match. This keeps assertions scoped
+    to the intended host block rather than the file as a whole.
+    """
+    idx = text.index(opener)
+    brace = idx + len(opener) - 1  # opener ends with the block's opening "{"
+    depth = 0
+    for i in range(brace, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace + 1 : i]
+    raise AssertionError(f"unbalanced braces after Caddy block opener {opener!r}")
+
+
 def exposed_service_ids() -> set[str]:
     exposed: set[str] = set()
     for manifest in SERVICES.glob("*/manifest.yaml"):
@@ -131,6 +153,47 @@ def test_dashboard_csp_allows_ods_talk_tts_blob_audio() -> None:
     assert_true("media-src 'self' blob:" in nginx_conf, "ODS Talk TTS playback uses blob: audio URLs")
 
 
+def test_ods_proxy_caps_request_body_sizes() -> None:
+    caddyfile = read(SERVICES / "ods-proxy" / "Caddyfile")
+
+    chat_block = caddy_block_body(caddyfile, "http://chat.{$ODS_DEVICE_NAME:ods}.local {")
+    assert_true(
+        re.search(r"request_body\s*\{\s*max_size\s+200MB\s*\}", chat_block) is not None,
+        "ods-proxy chat host must cap request body at 200MB (Open WebUI document uploads)",
+    )
+
+    api_block = caddy_block_body(caddyfile, "http://api.{$ODS_DEVICE_NAME:ods}.local {")
+    assert_true(
+        re.search(r"request_body\s*\{\s*max_size\s+50MB\s*\}", api_block) is not None,
+        "ods-proxy api host must cap request body at 50MB (admin surface)",
+    )
+
+
+def test_hermes_proxy_caps_request_body() -> None:
+    caddyfile = read(SERVICES / "hermes-proxy" / "Caddyfile")
+
+    site_block = caddy_block_body(caddyfile, ":9120 {")
+    assert_true(
+        re.search(r"request_body\s*\{\s*max_size\s+50MB\s*\}", site_block) is not None,
+        "hermes-proxy must cap request body at 50MB (agent prompt attachments)",
+    )
+
+
+def test_dashboard_pre_stages_hsts() -> None:
+    nginx_conf = read(SERVICES / "dashboard" / "nginx.conf")
+
+    # HSTS is pre-staged so it activates once TLS lands via Caddy/Tailscale.
+    # Browsers ignore the header over plain HTTP, so it is inert until then.
+    assert_true(
+        re.search(
+            r'add_header\s+Strict-Transport-Security\s+"max-age=\d+;[^"]*includeSubDomains',
+            nginx_conf,
+        )
+        is not None,
+        "dashboard nginx must pre-stage a Strict-Transport-Security header with includeSubDomains",
+    )
+
+
 def test_openclaw_stays_deprecated_optional_and_token_gated() -> None:
     manifest = read(SERVICES / "openclaw" / "manifest.yaml")
     docs = read(ROOT / "docs" / "OPENCLAW-INTEGRATION.md")
@@ -161,6 +224,9 @@ def main() -> int:
         test_hermes_local_provider_has_generous_timeouts,
         test_ods_proxy_routes_talk_portal,
         test_dashboard_csp_allows_ods_talk_tts_blob_audio,
+        test_ods_proxy_caps_request_body_sizes,
+        test_hermes_proxy_caps_request_body,
+        test_dashboard_pre_stages_hsts,
         test_openclaw_stays_deprecated_optional_and_token_gated,
         test_litellm_gateway_auth_is_enforced,
     ]

--- a/ods/tests/test-hermes-proxy-caddyfile.sh
+++ b/ods/tests/test-hermes-proxy-caddyfile.sh
@@ -43,6 +43,14 @@ grep -Eq '^[[:space:]]*@health[[:space:]]+path([[:space:]]+/[A-Za-z]+)*[[:space:
 echo "[PASS] Hermes proxy auth redirect uses explicit wildcard matcher"
 echo "[PASS] Hermes proxy /health and /healthz both anonymous"
 
+# Cap request body size so abusive clients can't stream unbounded uploads
+# through the Hermes proxy, while still leaving room for agent attachments.
+grep -Eq '^[[:space:]]*request_body[[:space:]]*\{' "$CADDYFILE" \
+    || fail "Hermes proxy must define a request_body block to cap upload size"
+grep -Eq '^[[:space:]]*max_size[[:space:]]+50MB([[:space:]]|$)' "$CADDYFILE" \
+    || fail "Hermes proxy request_body must cap at 50MB"
+echo "[PASS] Hermes proxy caps request body at 50MB"
+
 grep -q 'Setup / Owner' "$AUTH_PAGE" \
     || fail "Hermes auth-required page should point operators to Setup / Owner"
 if grep -Eq 'Invites|scope[[:space:]]+<code>.*all|scope: chat or all' "$AUTH_PAGE"; then


### PR DESCRIPTION
## Summary

One concern: **harden the LAN-facing proxy surfaces** — cap request body sizes on the Caddy proxies and pre-stage HSTS on the dashboard nginx.

This is the proxy slice split out of #1605 per the maintainer feedback there (one PR, one concern), re-based onto the `ods/` layout. Second slice after #1650.

## Changes

- **`ods/extensions/services/ods-proxy/Caddyfile`**
  - `chat.<device>.local`: `request_body max_size 200MB` — document uploads to Open WebUI still fit comfortably, but runaway or abusive clients can no longer stream unbounded bodies through the LLM proxy path.
  - `api.<device>.local`: `request_body max_size 50MB` for the admin API surface.
- **`ods/extensions/services/hermes-proxy/Caddyfile`** — `request_body max_size 50MB` on `:9120`, keeping room for file attachments in agent prompts. Placed before the `route` block, so the health/favicon/auth ordering contract is untouched.
- **`ods/extensions/services/dashboard/nginx.conf`** — pre-stage `Strict-Transport-Security "max-age=63072000; includeSubDomains"` alongside the existing security headers. Browsers ignore HSTS over plain HTTP, so it's inert today and activates automatically when TLS lands via Caddy/Tailscale.

17 insertions, no deletions — additive only.

## Testing

- `caddy validate --adapter caddyfile` — **Valid configuration** for both modified Caddyfiles (Caddy 2.6.2).
- `bash ods/tests/test-hermes-proxy-caddyfile.sh` — pass (route → health → forward_auth ordering and redirect-matcher contracts intact).
- `python3 ods/tests/test_mdns_subdomains.py` — OK (ods-proxy hostname set unchanged).
- `python3 ods/tests/contracts/test-network-exposure-contracts.py` — pass (CSP contract intact next to the new HSTS header).
- `bash ods/tests/contracts/test-installer-contracts.sh` — 37 passed (dashboard-nginx dynamic-upstream contracts intact).
