### PR TITLE
fix(dashboard-api): divide 24h token total by 24h window for throughput

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -146,10 +146,11 @@ async def _fetch_token_spy_metrics() -> None:
                 if resp.status == 200:
                     data = await resp.json()
                     agent_metrics.session_count = len(data)
-                    # total_output_tokens is a 24 h aggregate; dividing by 3600 gives
-                    # an average tokens/sec over the last hour (approximation)
+                    # Token Spy's /api/summary defaults to a 24 h window, so
+                    # total_output_tokens is a 24 h aggregate; divide by the
+                    # seconds in that window to get an average tokens/sec.
                     total_out = sum(r.get("total_output_tokens", 0) or 0 for r in data)
-                    throughput.add_sample(total_out / 3600.0)
+                    throughput.add_sample(total_out / 86400.0)
                     logger.debug("Token Spy metrics: %d sessions, %d total output tokens",
                                len(data), total_out)
                 else:

--- a/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
@@ -127,8 +127,9 @@ class TestFetchTokenSpyMetrics:
 
         assert agent_monitor.agent_metrics.session_count == 2
         assert len(agent_monitor.throughput.data_points) == 1
-        # total_out = 10800 tokens; avg tps = 10800 / 3600 = 3.0
-        assert agent_monitor.throughput.data_points[0]["tokens_per_sec"] == pytest.approx(3.0)
+        # total_out = 10800 tokens over the 24 h summary window;
+        # avg tps = 10800 / 86400 = 0.125
+        assert agent_monitor.throughput.data_points[0]["tokens_per_sec"] == pytest.approx(0.125)
 
     @pytest.mark.asyncio
     async def test_no_url_skips_fetch(self, monkeypatch):


### PR DESCRIPTION
## Summary

`_fetch_token_spy_metrics` reports a tokens/sec throughput on the dashboard by fetching Token Spy's `/api/summary` and dividing the summed `total_output_tokens` by 3600. But it calls `/api/summary` with no `hours` param, and that endpoint defaults to a **24-hour** window (`query_summary(hours=24)` in token-spy's `db.py`). So `total_output_tokens` is a 24 h aggregate, and dividing a 24 h total by 3600 overstates the average by **24×**.

Fix divides by 86400 (seconds in the 24 h window) so `tokens_per_second` is a correct average.

How I tested: updated the existing throughput test (it mirrored the old divisor) and confirmed the corrected value. Full dashboard-api suite passes (1178); `ruff` clean.

## AI Assistance

Claude Code helped trace the Token Spy summary window, confirm the divisor bug, and update the test. I reviewed the diff and verified the window default in the token-spy source.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard API / host agent

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Not required because: single-constant arithmetic fix in a read-only metrics gauge; no runtime/installer/network change

Commands/results:

```text
$ pytest -q tests/test_agent_monitor.py
19 passed

$ pytest -q          # full dashboard-api suite
1178 passed

$ ruff check agent_monitor.py tests/test_agent_monitor.py --select E,F,W --ignore E501,E701,E731,E741,E402
All checks passed!
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.

Narrower equivalent: the change is one divisor in the throughput gauge that feeds the dashboard's tokens/sec display. No control flow, routing, or runtime behavior changes; covered by the updated unit test.

## Notes For Reviewers

Evidence for the 24 h window: `ods/extensions/services/token-spy/main.py` defines `@app.get("/api/summary")` as `def api_summary(hours: int = 24)`, and `db.py::query_summary(hours=24)` sums `output_tokens WHERE timestamp > datetime('now', '-{hours} hours')`. `agent_monitor.py` fetches `/api/summary` with no `hours`, so it always gets the 24 h aggregate.
