### PR TITLE
fix(dashboard): show bytes for sub-1KB sizes instead of "0 KB"

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
@@ -122,6 +122,7 @@ describe('useDownloadProgress', () => {
     expect(result.current.formatBytes(5e9)).toBe('4.66 GB')
     expect(result.current.formatBytes(5e6)).toBe('4.8 MB')
     expect(result.current.formatBytes(5000)).toBe('5 KB')
+    expect(result.current.formatBytes(512)).toBe('512 B')
     expect(result.current.formatBytes(0)).toBe('0 B')
     expect(result.current.formatBytes(null)).toBe('0 B')
   })

--- a/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
+++ b/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
@@ -87,7 +87,9 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
     if (gb >= 1) return `${gb.toFixed(2)} GB`
     const mb = bytes / (1024 ** 2)
     if (mb >= 1) return `${mb.toFixed(1)} MB`
-    return `${(bytes / 1024).toFixed(0)} KB`
+    const kb = bytes / 1024
+    if (kb >= 1) return `${kb.toFixed(0)} KB`
+    return `${bytes.toFixed(0)} B`
   }
 
   const formatEta = (eta) => {


### PR DESCRIPTION
## Summary

`formatBytes` in `useDownloadProgress` has branches for GB, MB, and KB, but no branch for values under 1 KB. Any non-zero size below 1024 bytes falls into the KB branch and rounds to `"0 KB"` (e.g. `512` → `"0 KB"`), which can show early in a download before the first KB has transferred.

Fix adds a `kb >= 1` guard and a bytes fallback so `512` renders as `"512 B"`.

How I tested: extended the existing `formatBytes` test with the sub-KB case. Full dashboard test suite passes (124), eslint clean.

## AI Assistance

Claude Code helped spot the missing branch, draft the fix and test, and run the suite. I reviewed the diff and confirmed the outputs.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard UI

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Dashboard lint/test/build
  - [x] Focused tests listed below

Commands/results:

```text
$ npx vitest run src/hooks/__tests__/useDownloadProgress.test.js
6 passed

$ npx vitest run            # full dashboard suite
Test Files 20 passed | Tests 124 passed

$ npm run lint              # eslint src
clean
```

## Operational Change Check

- [x] This is not an operational change.

## Notes For Reviewers

Before: `formatBytes(512)` → `"0 KB"`. After: `"512 B"`. Existing outputs are unchanged (`5000` → `"5 KB"`, `5e6` → `"4.8 MB"`, `5e9` → `"4.66 GB"`, `0`/`null` → `"0 B"`).
