### PR TITLE
feat(dashboard-api): add /api/gpu/idle endpoint and is_gpu_idle helper

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -380,6 +380,18 @@ def get_gpu_info() -> Optional[GPUInfo]:
     return None
 
 
+def is_gpu_idle(info: GPUInfo, threshold_percent: int = 10) -> Optional[bool]:
+    """Return True if aggregate GPU utilization is at or below threshold_percent.
+
+    Pure function — no I/O. `info` is an aggregate GPUInfo (see get_gpu_info).
+    Note: backends that cannot report utilization (Apple, AMD host runtime)
+    return None.
+    """
+    if info.gpu_backend == "apple" or "host runtime" in info.name.lower():
+        return None
+    return info.utilization_percent <= threshold_percent
+
+
 # ============================================================================
 # Topology — read from file written by installer / ods-cli
 # ============================================================================

--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -19,6 +19,13 @@ class GPUInfo(BaseModel):
     gpu_backend: str = GPU_BACKEND
 
 
+class GpuIdleStatus(BaseModel):
+    idle: Optional[bool]
+    utilization_percent: int
+    threshold_percent: int
+    backend: str
+
+
 class ServiceStatus(BaseModel):
     id: str
     name: str

--- a/ods/extensions/services/dashboard-api/routers/gpu.py
+++ b/ods/extensions/services/dashboard-api/routers/gpu.py
@@ -20,9 +20,10 @@ from gpu import (
     get_gpu_info_amd_detailed,
     get_gpu_info_apple,
     get_gpu_info_nvidia_detailed,
+    is_gpu_idle,
     read_gpu_topology,
 )
-from models import GPUInfo, IndividualGPU, MultiGPUStatus
+from models import GPUInfo, IndividualGPU, MultiGPUStatus, GpuIdleStatus
 from models import AmdRuntimeStatus
 from lemonade_client import LemonadeClient, LemonadeClientError, LemonadeSettings, normalize_base_url
 
@@ -39,6 +40,7 @@ _detailed_cache: dict = {"expires": 0.0, "value": None}
 _topology_cache: dict = {"expires": 0.0, "value": None}
 _GPU_DETAILED_TTL = 3.0
 _GPU_TOPOLOGY_TTL = 300.0
+_GPU_IDLE_THRESHOLD_DEFAULT = 10
 
 
 # ============================================================================
@@ -87,6 +89,11 @@ def _env_int(name: str, default: int = 0) -> int:
         return int(raw)
     except ValueError:
         return default
+
+
+def _idle_threshold() -> int:
+    """Idle utilization threshold (percent), clamped to [0, 100]."""
+    return max(0, min(100, _env_int("GPU_IDLE_THRESHOLD_PERCENT", _GPU_IDLE_THRESHOLD_DEFAULT)))
 
 
 def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
@@ -365,6 +372,26 @@ async def gpu_detailed():
     _detailed_cache["expires"] = now + _GPU_DETAILED_TTL
     _detailed_cache["value"] = result
     return result
+
+
+@router.get("/api/gpu/idle", response_model=GpuIdleStatus, dependencies=[Depends(verify_api_key)])
+async def gpu_idle():
+    """Whether the GPU is idle, from aggregate utilization vs a configurable threshold.
+
+    Idle means aggregate utilization_percent <= GPU_IDLE_THRESHOLD_PERCENT (default 10).
+    Read-only; derived from the same nvidia-smi/sysfs data as /api/gpu/detailed.
+    Note: backends that cannot report utilization (Apple, AMD host runtime) return
+    null for idle.
+    """
+    threshold = _idle_threshold()
+    detailed = await gpu_detailed()
+    info = detailed.aggregate
+    return GpuIdleStatus(
+        idle=is_gpu_idle(info, threshold),
+        utilization_percent=info.utilization_percent,
+        threshold_percent=threshold,
+        backend=info.gpu_backend,
+    )
 
 
 @router.get("/api/gpu/topology", dependencies=[Depends(verify_api_key)])

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -7,8 +7,9 @@ import pytest
 
 from gpu import (
     get_gpu_tier, get_gpu_info_nvidia, get_gpu_info_apple,
-    get_gpu_info_amd, get_gpu_info, run_command,
+    get_gpu_info_amd, get_gpu_info, run_command, is_gpu_idle,
 )
+from models import GPUInfo
 
 
 # --- get_gpu_tier (pure function, no I/O) ---
@@ -401,3 +402,27 @@ class TestGetGpuInfoDispatcher:
 
         result = get_gpu_info()
         assert result is None
+
+
+class TestIsGpuIdle:
+    @staticmethod
+    def _mk(util, backend="nvidia", name="x"):
+        return GPUInfo(name=name, memory_used_mb=0, memory_total_mb=1,
+                       memory_percent=0.0, utilization_percent=util, temperature_c=0, gpu_backend=backend)
+
+    def test_idle_below_threshold(self):
+        assert is_gpu_idle(self._mk(3)) is True
+
+    def test_idle_at_threshold_boundary(self):
+        assert is_gpu_idle(self._mk(10)) is True
+
+    def test_busy_above_threshold(self):
+        assert is_gpu_idle(self._mk(11)) is False
+
+    def test_custom_threshold(self):
+        assert is_gpu_idle(self._mk(40), threshold_percent=50) is True
+        assert is_gpu_idle(self._mk(60), threshold_percent=50) is False
+
+    def test_unknown_backends(self):
+        assert is_gpu_idle(self._mk(0, backend="apple", name="Apple M3 Max")) is None
+        assert is_gpu_idle(self._mk(0, backend="amd", name="AMD Lemonade host runtime")) is None

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -487,3 +487,93 @@ class TestGpuDetailedEndpointApple:
         finally:
             gpu_mod._detailed_cache["expires"] = 0.0
             gpu_mod._detailed_cache["value"] = None
+
+
+class TestGpuIdleEndpoint:
+    @staticmethod
+    def _gpu(util, backend="nvidia", name="RTX 4090"):
+        return GPUInfo(name=name, memory_used_mb=1000, memory_total_mb=24000,
+                       memory_percent=4.2, utilization_percent=util, temperature_c=40,
+                       gpu_backend=backend)
+
+    @staticmethod
+    def _detailed(util, backend="nvidia", name="RTX 4090"):
+        from models import MultiGPUStatus
+        return MultiGPUStatus(gpu_count=1, backend=backend, gpus=[], aggregate=TestGpuIdleEndpoint._gpu(util, backend, name))
+
+    def test_idle_true(self, monkeypatch, test_client):
+        import routers.gpu as gpu_mod
+
+        async def _mock_detailed():
+            return self._detailed(5)
+
+        monkeypatch.setattr(gpu_mod, "gpu_detailed", _mock_detailed)
+        r = test_client.get("/api/gpu/idle", headers=test_client.auth_headers)
+        assert r.status_code == 200
+        b = r.json()
+        assert b["idle"] is True
+        assert b["utilization_percent"] == 5
+        assert b["threshold_percent"] == 10
+        assert b["backend"] == "nvidia"
+
+    def test_idle_false(self, monkeypatch, test_client):
+        import routers.gpu as gpu_mod
+
+        async def _mock_detailed():
+            return self._detailed(85)
+
+        monkeypatch.setattr(gpu_mod, "gpu_detailed", _mock_detailed)
+        r = test_client.get("/api/gpu/idle", headers=test_client.auth_headers)
+        assert r.status_code == 200
+        assert r.json()["idle"] is False
+
+    def test_threshold_env_override(self, monkeypatch, test_client):
+        import routers.gpu as gpu_mod
+        monkeypatch.setenv("GPU_IDLE_THRESHOLD_PERCENT", "50")
+
+        async def _mock_detailed():
+            return self._detailed(40)
+
+        monkeypatch.setattr(gpu_mod, "gpu_detailed", _mock_detailed)
+        r = test_client.get("/api/gpu/idle", headers=test_client.auth_headers)
+        b = r.json()
+        assert b["idle"] is True
+        assert b["threshold_percent"] == 50
+
+    def test_threshold_clamped(self, monkeypatch, test_client):
+        import routers.gpu as gpu_mod
+        monkeypatch.setenv("GPU_IDLE_THRESHOLD_PERCENT", "9999")
+
+        async def _mock_detailed():
+            return self._detailed(100)
+
+        monkeypatch.setattr(gpu_mod, "gpu_detailed", _mock_detailed)
+        r = test_client.get("/api/gpu/idle", headers=test_client.auth_headers)
+        assert r.json()["threshold_percent"] == 100
+
+    def test_503_when_no_gpu(self, monkeypatch, test_client):
+        import routers.gpu as gpu_mod
+        from fastapi import HTTPException
+
+        async def _mock_detailed():
+            raise HTTPException(status_code=503, detail="No GPU data available")
+
+        monkeypatch.setattr(gpu_mod, "gpu_detailed", _mock_detailed)
+        r = test_client.get("/api/gpu/idle", headers=test_client.auth_headers)
+        assert r.status_code == 503
+
+    def test_idle_null_for_unknown_backend(self, monkeypatch, test_client):
+        import routers.gpu as gpu_mod
+
+        async def _mock_detailed():
+            return self._detailed(0, backend="apple", name="Apple M3 Max")
+
+        monkeypatch.setattr(gpu_mod, "gpu_detailed", _mock_detailed)
+        r = test_client.get("/api/gpu/idle", headers=test_client.auth_headers)
+        assert r.status_code == 200
+        assert r.json()["idle"] is None
+        assert r.json()["backend"] == "apple"
+
+    def test_requires_auth(self, test_client):
+        r = test_client.get("/api/gpu/idle")
+        assert r.status_code in (401, 403)


### PR DESCRIPTION
Adds a read-only GET /api/gpu/idle reporting whether the GPU is idle,
based on aggregate utilization vs a configurable GPU_IDLE_THRESHOLD_PERCENT
(default 10, clamped 0–100). Adds a pure is_gpu_idle() helper and typed
GpuIdleStatus model.

Why it matters: a lightweight idle signal is a common need for anything that
places or balances work across GPUs. Callers can poll one cheap endpoint for
capacity and scheduling decisions instead of parsing the full /api/gpu/detailed
payload each time.

Derived from the same data as /api/gpu/detailed (reuses the cached
aggregate -- no second detection path). Utilization-less backends (Apple,
AMD host runtime) return idle: null rather than a misleading false.
No new dependencies.

Validation: ruff clean, git diff --check clean, 81 gpu tests pass, full
dashboard-api suite 1190 passed. Read-only and auth-gated --- not an
operational change.