### PR TITLE
feat(dashboard-api): add /api/node/capabilities diagnostics endpoint

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -63,6 +63,7 @@ from routers import (
     talk,
     tailscale,
     usage,
+    node,
 )
 from settings import (
     _ENV_ASSIGNMENT_RE, _ENV_COMMENTED_ASSIGNMENT_RE, _SETTINGS_APPLY_ALLOWED_SERVICES, _parse_env_text, _read_env_map_from_path,
@@ -1014,6 +1015,7 @@ app.include_router(oauth_passthrough.router)
 app.include_router(talk.router)
 app.include_router(tailscale.router)
 app.include_router(usage.router)
+app.include_router(node.router)
 
 
 # ================================================================

--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -28,6 +28,15 @@ class ServiceStatus(BaseModel):
     response_time_ms: Optional[float] = None
 
 
+class NodeCapabilities(BaseModel):
+    ods_version: str
+    gpu: Optional[GPUInfo] = None
+    loaded_model: Optional[str] = None
+    services: list[ServiceStatus] = []
+    service_count: int = 0
+    running_service_count: int = 0
+
+
 class DiskUsage(BaseModel):
     path: str
     used_gb: float

--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -24,7 +24,7 @@ class ServiceStatus(BaseModel):
     name: str
     port: int
     external_port: int
-    status: str  # "healthy", "unhealthy", "unknown", "down", "not_deployed"
+    status: str  # "healthy", "unhealthy", "unknown", "degraded", "down", "not_deployed"
     response_time_ms: Optional[float] = None
 
 

--- a/ods/extensions/services/dashboard-api/routers/node.py
+++ b/ods/extensions/services/dashboard-api/routers/node.py
@@ -1,0 +1,96 @@
+"""Node capabilities — one-call diagnostics snapshot (GPU, model, services, version)."""
+
+import asyncio
+import json
+from pathlib import Path
+
+from fastapi import APIRouter, Depends, Request
+
+from config import INSTALL_DIR
+from gpu import get_gpu_info
+from helpers import get_all_services, get_loaded_model
+from models import NodeCapabilities
+from security import verify_api_key
+import settings
+
+router = APIRouter(tags=["node"])
+
+# Service statuses that indicate the container is up (as opposed to down /
+# not_deployed). Used to compute running_service_count.
+_RUNNING_STATUSES = {"healthy", "unhealthy", "unknown"}
+
+
+def _install_root() -> Path:
+    """Resolve the ODS install root, preferring the in-container /ods mount.
+
+    Mirrors main._resolve_install_root so the version read is consistent whether
+    the API runs in the container (/ods) or on the host (INSTALL_DIR).
+    """
+    host_root = Path("/ods")
+    if host_root.exists():
+        return host_root
+    return Path(INSTALL_DIR)
+
+
+def _read_ods_version(fallback: str) -> str:
+    """Read the installed ODS version from the install .env or .version file.
+
+    Order: ODS_VERSION in .env, then .version (plain string or {"version": ...}).
+    Falls back to *fallback* (the running app version) when neither is present.
+    """
+    root = _install_root()
+
+    env_file = root / ".env"
+    env_vars, _ = settings._read_env_map_from_path(env_file)
+    if "ODS_VERSION" in env_vars and env_vars["ODS_VERSION"]:
+        return env_vars["ODS_VERSION"]
+
+    version_file = root / ".version"
+    try:
+        raw = version_file.read_text().strip()
+        if raw:
+            if raw.startswith("{"):
+                data = json.loads(raw)
+                if isinstance(data, dict) and data.get("version"):
+                    return str(data["version"])
+            else:
+                return raw
+    except (OSError, json.JSONDecodeError, ValueError):
+        pass
+
+    return fallback
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+@router.get(
+    "/api/node/capabilities",
+    response_model=NodeCapabilities,
+    dependencies=[Depends(verify_api_key)],
+)
+async def node_capabilities(request: Request):
+    """Aggregated node snapshot for diagnostics and support bundles.
+
+    Combines GPU type/VRAM (see gpu.get_gpu_info), the currently loaded model,
+    service health, and the installed ODS version in a single call. Read-only.
+    running_service_count counts services whose container is up (healthy,
+    unhealthy, or unknown), excluding down / not_deployed.
+    """
+    gpu_info, loaded_model, services = await asyncio.gather(
+        asyncio.to_thread(get_gpu_info),
+        get_loaded_model(),
+        get_all_services(),
+    )
+
+    running = [s for s in services if s.status in _RUNNING_STATUSES]
+
+    return NodeCapabilities(
+        ods_version=_read_ods_version(request.app.version),
+        gpu=gpu_info,
+        loaded_model=loaded_model,
+        services=services,
+        service_count=len(services),
+        running_service_count=len(running),
+    )

--- a/ods/extensions/services/dashboard-api/routers/node.py
+++ b/ods/extensions/services/dashboard-api/routers/node.py
@@ -16,8 +16,10 @@ import settings
 router = APIRouter(tags=["node"])
 
 # Service statuses that indicate the container is up (as opposed to down /
-# not_deployed). Used to compute running_service_count.
-_RUNNING_STATUSES = {"healthy", "unhealthy", "unknown"}
+# not_deployed). "degraded" means reachable but slow (see
+# helpers.check_service_health), so it counts as up. Used to compute
+# running_service_count.
+_RUNNING_STATUSES = {"healthy", "unhealthy", "unknown", "degraded"}
 
 
 def _install_root() -> Path:
@@ -76,7 +78,7 @@ async def node_capabilities(request: Request):
     Combines GPU type/VRAM (see gpu.get_gpu_info), the currently loaded model,
     service health, and the installed ODS version in a single call. Read-only.
     running_service_count counts services whose container is up (healthy,
-    unhealthy, or unknown), excluding down / not_deployed.
+    unhealthy, unknown, or degraded), excluding down / not_deployed.
     """
     gpu_info, loaded_model, services = await asyncio.gather(
         asyncio.to_thread(get_gpu_info),

--- a/ods/extensions/services/dashboard-api/tests/test_node.py
+++ b/ods/extensions/services/dashboard-api/tests/test_node.py
@@ -1,0 +1,131 @@
+"""Tests for /api/node/capabilities — aggregated node diagnostics snapshot."""
+
+from models import GPUInfo, ServiceStatus
+
+
+def _gpu():
+    return GPUInfo(name="RTX 4090", memory_used_mb=1000, memory_total_mb=24000,
+                   memory_percent=4.2, utilization_percent=5, temperature_c=40,
+                   gpu_backend="nvidia")
+
+
+def _services():
+    return [
+        ServiceStatus(id="llama-server", name="Llama Server", port=8080,
+                      external_port=8080, status="healthy", response_time_ms=12.0),
+        ServiceStatus(id="open-webui", name="Open WebUI", port=3000,
+                      external_port=3000, status="down", response_time_ms=None),
+        ServiceStatus(id="qdrant", name="Qdrant", port=6333,
+                      external_port=6333, status="unhealthy", response_time_ms=None),
+    ]
+
+
+class TestNodeCapabilitiesEndpoint:
+    def test_full_payload(self, monkeypatch, tmp_path, test_client):
+        import routers.node as node_mod
+
+        async def _loaded():
+            return "qwen2.5-7b-instruct"
+
+        async def _svcs():
+            return _services()
+
+        monkeypatch.setattr(node_mod, "get_gpu_info", _gpu)
+        monkeypatch.setattr(node_mod, "get_loaded_model", _loaded)
+        monkeypatch.setattr(node_mod, "get_all_services", _svcs)
+        (tmp_path / ".env").write_text("ODS_VERSION=9.9.9\n")
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+
+        r = test_client.get("/api/node/capabilities", headers=test_client.auth_headers)
+        assert r.status_code == 200
+        b = r.json()
+        assert b["ods_version"] == "9.9.9"
+        assert b["gpu"]["gpu_backend"] == "nvidia"
+        assert b["gpu"]["memory_total_mb"] == 24000
+        assert b["loaded_model"] == "qwen2.5-7b-instruct"
+        assert b["service_count"] == 3
+        assert b["running_service_count"] == 2  # healthy + unhealthy, not down
+        assert len(b["services"]) == 3
+
+    def test_gpu_and_model_absent(self, monkeypatch, tmp_path, test_client):
+        import routers.node as node_mod
+
+        async def _loaded():
+            return None
+
+        async def _svcs():
+            return []
+
+        monkeypatch.setattr(node_mod, "get_gpu_info", lambda: None)
+        monkeypatch.setattr(node_mod, "get_loaded_model", _loaded)
+        monkeypatch.setattr(node_mod, "get_all_services", _svcs)
+        (tmp_path / ".env").write_text("ODS_VERSION=1.2.3\n")
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+
+        r = test_client.get("/api/node/capabilities", headers=test_client.auth_headers)
+        assert r.status_code == 200
+        b = r.json()
+        assert b["gpu"] is None
+        assert b["loaded_model"] is None
+        assert b["service_count"] == 0
+        assert b["running_service_count"] == 0
+
+    def test_version_falls_back_to_app_version(self, monkeypatch, tmp_path, test_client):
+        import routers.node as node_mod
+
+        async def _loaded():
+            return None
+
+        async def _svcs():
+            return []
+
+        monkeypatch.setattr(node_mod, "get_gpu_info", lambda: None)
+        monkeypatch.setattr(node_mod, "get_loaded_model", _loaded)
+        monkeypatch.setattr(node_mod, "get_all_services", _svcs)
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)  # empty dir
+
+        r = test_client.get("/api/node/capabilities", headers=test_client.auth_headers)
+        assert r.status_code == 200
+        assert r.json()["ods_version"] == "2.5.3"  # app.version fallback
+
+    def test_requires_auth(self, test_client):
+        r = test_client.get("/api/node/capabilities")
+        assert r.status_code in (401, 403)
+
+
+class TestReadOdsVersion:
+    def test_reads_env_ods_version(self, monkeypatch, tmp_path):
+        import routers.node as node_mod
+        (tmp_path / ".env").write_text("FOO=bar\nODS_VERSION=3.1.4\n")
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+        assert node_mod._read_ods_version("fallback") == "3.1.4"
+
+    def test_reads_plain_version_file(self, monkeypatch, tmp_path):
+        import routers.node as node_mod
+        (tmp_path / ".version").write_text("7.7.7\n")
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+        assert node_mod._read_ods_version("fallback") == "7.7.7"
+
+    def test_reads_json_version_file(self, monkeypatch, tmp_path):
+        import routers.node as node_mod
+        (tmp_path / ".version").write_text('{"version": "8.0.0"}')
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+        assert node_mod._read_ods_version("fallback") == "8.0.0"
+
+    def test_env_takes_precedence_over_version_file(self, monkeypatch, tmp_path):
+        import routers.node as node_mod
+        (tmp_path / ".env").write_text("ODS_VERSION=env-wins\n")
+        (tmp_path / ".version").write_text("file-loses")
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+        assert node_mod._read_ods_version("fallback") == "env-wins"
+
+    def test_fallback_when_absent(self, monkeypatch, tmp_path):
+        import routers.node as node_mod
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+        assert node_mod._read_ods_version("fb-1.0") == "fb-1.0"
+
+    def test_reads_quoted_ods_version(self, monkeypatch, tmp_path):
+        import routers.node as node_mod
+        (tmp_path / ".env").write_text('ODS_VERSION="3.1.4"\n')
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+        assert node_mod._read_ods_version("fallback") == "3.1.4"

--- a/ods/extensions/services/dashboard-api/tests/test_node.py
+++ b/ods/extensions/services/dashboard-api/tests/test_node.py
@@ -20,6 +20,17 @@ def _services():
     ]
 
 
+def _services_with_degraded():
+    return [
+        ServiceStatus(id="llama-server", name="Llama Server", port=8080,
+                      external_port=8080, status="healthy", response_time_ms=12.0),
+        ServiceStatus(id="open-webui", name="Open WebUI", port=3000,
+                      external_port=3000, status="degraded", response_time_ms=None),
+        ServiceStatus(id="qdrant", name="Qdrant", port=6333,
+                      external_port=6333, status="down", response_time_ms=None),
+    ]
+
+
 class TestNodeCapabilitiesEndpoint:
     def test_full_payload(self, monkeypatch, tmp_path, test_client):
         import routers.node as node_mod
@@ -46,6 +57,32 @@ class TestNodeCapabilitiesEndpoint:
         assert b["service_count"] == 3
         assert b["running_service_count"] == 2  # healthy + unhealthy, not down
         assert len(b["services"]) == 3
+
+    def test_degraded_service_counts_as_running(self, monkeypatch, tmp_path, test_client):
+        import routers.node as node_mod
+
+        async def _loaded():
+            return None
+
+        async def _svcs():
+            return _services_with_degraded()
+
+        monkeypatch.setattr(node_mod, "get_gpu_info", lambda: None)
+        monkeypatch.setattr(node_mod, "get_loaded_model", _loaded)
+        monkeypatch.setattr(node_mod, "get_all_services", _svcs)
+        (tmp_path / ".env").write_text("ODS_VERSION=1.0.0\n")
+        monkeypatch.setattr(node_mod, "_install_root", lambda: tmp_path)
+
+        r = test_client.get("/api/node/capabilities", headers=test_client.auth_headers)
+        assert r.status_code == 200
+        b = r.json()
+        # degraded == reachable-but-slow == up. Regression: it must be listed
+        # under services AND counted in running_service_count (healthy + degraded),
+        # while down is excluded.
+        assert b["service_count"] == 3
+        assert b["running_service_count"] == 2
+        statuses = {s["id"]: s["status"] for s in b["services"]}
+        assert statuses["open-webui"] == "degraded"
 
     def test_gpu_and_model_absent(self, monkeypatch, tmp_path, test_client):
         import routers.node as node_mod


### PR DESCRIPTION
Adds a read-only GET /api/node/capabilities that returns a one-call node
snapshot -- GPU type/VRAM, loaded model, per-service health, and installed
ODS version -- for diagnostics and support bundles.

Why it matters: capability discovery is a natural building block for any
multi-node ODS deployment. A single authenticated read describes what a node
is and what it's currently running, so fleet dashboards, support tooling, and
higher-level coordination can query one endpoint instead of stitching the GPU,
model, and health calls together.

Reuses existing helpers (get_gpu_info, get_loaded_model, get_all_services);
sync GPU call thread-offloaded, async helpers gathered. Wired via a single
include_router line. No schema/compose/dependency changes.

Validation: ruff clean, git diff --check clean, 10 new tests, full
dashboard-api suite 1188 passed. Read-only and auth-gated -- not an
operational change.