### PR TITLE
fix(windows): handle multiple Python interpreters in Resolve-ODSHostAgentPython

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1511,9 +1511,10 @@ function Resolve-ODSHostAgentPython {
     }
 
     foreach ($name in @("python3", "python")) {
-        $cmd = Get-Command $name -CommandType Application -ErrorAction SilentlyContinue
-        if ($cmd -and $cmd.Source) {
-            $candidateFiles.Add($cmd.Source)
+        foreach ($cmd in @(Get-Command $name -CommandType Application -ErrorAction SilentlyContinue)) {
+            if ($cmd -and $cmd.Source) {
+                $candidateFiles.Add($cmd.Source)
+            }
         }
     }
 
@@ -1526,10 +1527,11 @@ function Resolve-ODSHostAgentPython {
         }
     }
 
-    $pyLauncher = Get-Command py -CommandType Application -ErrorAction SilentlyContinue
-    if ($pyLauncher -and $pyLauncher.Source -and
-        (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
-        return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+    foreach ($pyLauncher in @(Get-Command py -CommandType Application -ErrorAction SilentlyContinue)) {
+        if ($pyLauncher.Source -and
+            (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
+            return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+        }
     }
 
     return $null

--- a/ods/installers/windows/phases/07-devtools.ps1
+++ b/ods/installers/windows/phases/07-devtools.ps1
@@ -256,9 +256,10 @@ function Resolve-ODSHostAgentPython {
     }
 
     foreach ($name in @("python3", "python")) {
-        $cmd = Get-Command $name -CommandType Application -ErrorAction SilentlyContinue
-        if ($cmd -and $cmd.Source) {
-            $candidateFiles.Add($cmd.Source)
+        foreach ($cmd in @(Get-Command $name -CommandType Application -ErrorAction SilentlyContinue)) {
+            if ($cmd -and $cmd.Source) {
+                $candidateFiles.Add($cmd.Source)
+            }
         }
     }
 
@@ -271,10 +272,11 @@ function Resolve-ODSHostAgentPython {
         }
     }
 
-    $pyLauncher = Get-Command py -CommandType Application -ErrorAction SilentlyContinue
-    if ($pyLauncher -and $pyLauncher.Source -and
-        (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
-        return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+    foreach ($pyLauncher in @(Get-Command py -CommandType Application -ErrorAction SilentlyContinue)) {
+        if ($pyLauncher.Source -and
+            (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
+            return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+        }
     }
 
     return $null


### PR DESCRIPTION
## Summary

On dev machines with multiple Python executables on PATH (venv + global 
install + Microsoft Store alias), Get-Command returns an array instead 
of a single ApplicationInfo object. Accessing .Source directly on that 
array throws ParameterBindingArgumentTransformationException, crashing 
the installer at Phase 07.

Closes #1654

## Changes

- `ods/installers/windows/phases/07-devtools.ps1` — wrapped both 
  Get-Command calls in @() inside Resolve-ODSHostAgentPython so .Source 
  is always accessed on a single object per iteration
- `ods/installers/windows/ods.ps1` — applied the identical fix to the 
  same function (noted but not patched by the reporter)

## Testing

- [ ] `bash -n` passes on all changed files
- [ ] PSScriptAnalyzer passes with PSScriptAnalyzerSettings.psd1
- [ ] Verified fix covers both active installer and ods.ps1
