### PR TITLE
fix(cli): keep CPU budget values locale-safe

### DIFF
--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -85,7 +85,7 @@ cap_cpu_value() {
 
 select_auto_cpu_value() {
     local existing="$1" detected="$2"
-    if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
+    if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && LC_ALL=C awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
         echo "$existing"
     else
         echo "$detected"
@@ -191,13 +191,13 @@ generate_ods_env() {
         local existing_limit existing_reservation
         existing_limit="$(read_env_value "$env_path" "LLAMA_CPU_LIMIT")"
         existing_reservation="$(read_env_value "$env_path" "LLAMA_CPU_RESERVATION")"
-        if [[ "$existing_limit" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN { exit !($existing_limit > 0 && $existing_limit <= $detected_cpu_limit) }"; then
+        if [[ "$existing_limit" =~ ^[0-9]+([.][0-9]+)?$ ]] && LC_ALL=C awk "BEGIN { exit !($existing_limit > 0 && $existing_limit <= $detected_cpu_limit) }"; then
             detected_cpu_limit="$existing_limit"
         fi
-        if [[ "$existing_reservation" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN { exit !($existing_reservation > 0 && $existing_reservation <= $detected_cpu_reservation) }"; then
+        if [[ "$existing_reservation" =~ ^[0-9]+([.][0-9]+)?$ ]] && LC_ALL=C awk "BEGIN { exit !($existing_reservation > 0 && $existing_reservation <= $detected_cpu_reservation) }"; then
             detected_cpu_reservation="$existing_reservation"
         fi
-        if awk "BEGIN { exit !($detected_cpu_reservation > $detected_cpu_limit) }"; then
+        if LC_ALL=C awk "BEGIN { exit !($detected_cpu_reservation > $detected_cpu_limit) }"; then
             detected_cpu_reservation="$detected_cpu_limit"
         fi
         upsert_env_value "$env_path" "LLAMA_CPU_LIMIT" "$detected_cpu_limit"

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -176,7 +176,7 @@ upsert_env_value() {
 select_auto_cpu_value() {
     local existing="$1"
     local detected="$2"
-    if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
+    if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && LC_ALL=C awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
         echo "$existing"
     else
         echo "$detected"
@@ -208,7 +208,7 @@ ensure_service_cpu_pair() {
     detected_reservation="$(cap_cpu_value "$desired_reservation" "$final_limit")"
     current_reservation="$(read_env_value "$env_file" "$reservation_key")"
     final_reservation="$(select_auto_cpu_value "$current_reservation" "$detected_reservation")"
-    if awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
+    if LC_ALL=C awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
         final_reservation="$final_limit"
     fi
 
@@ -242,7 +242,7 @@ ensure_llama_cpu_budget() {
     final_limit="$(select_auto_cpu_value "$current_limit" "$detected_limit")"
     final_reservation="$(select_auto_cpu_value "$current_reservation" "$detected_reservation")"
 
-    if awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
+    if LC_ALL=C awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
         final_reservation="$final_limit"
     fi
 

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -480,7 +480,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
         local key="$1" detected="$2"
         local existing
         existing=$(_env_get "$key" "")
-        if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
+        if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && LC_ALL=C awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
             echo "$existing"
         else
             echo "$detected"
@@ -516,7 +516,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
     _llama_cpu_reservation_detected="${_llama_cpu_reservation_raw}.0"
     LLAMA_CPU_LIMIT=$(_select_auto_cpu_value LLAMA_CPU_LIMIT "${_llama_cpu_limit_detected}")
     LLAMA_CPU_RESERVATION=$(_select_auto_cpu_value LLAMA_CPU_RESERVATION "${_llama_cpu_reservation_detected}")
-    if awk "BEGIN { exit !($LLAMA_CPU_RESERVATION > $LLAMA_CPU_LIMIT) }"; then
+    if LC_ALL=C awk "BEGIN { exit !($LLAMA_CPU_RESERVATION > $LLAMA_CPU_LIMIT) }"; then
         LLAMA_CPU_RESERVATION="$LLAMA_CPU_LIMIT"
     fi
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -232,7 +232,7 @@ _calculate_llama_cpu_budget() {
 
 _select_auto_cpu_value() {
     local existing="$1" detected="$2"
-    if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
+    if [[ "$existing" =~ ^[0-9]+([.][0-9]+)?$ ]] && LC_ALL=C awk "BEGIN { exit !($existing > 0 && $existing <= $detected) }"; then
         echo "$existing"
     else
         echo "$detected"
@@ -241,7 +241,7 @@ _select_auto_cpu_value() {
 
 _cap_cpu_value() {
     local desired="$1" ceiling="$2"
-    awk -v desired="$desired" -v ceiling="$ceiling" '
+    LC_ALL=C awk -v desired="$desired" -v ceiling="$ceiling" '
         BEGIN {
             if (ceiling <= 0) ceiling = 1
             value = desired
@@ -264,7 +264,7 @@ _ensure_service_cpu_pair() {
     detected_reservation="$(_cap_cpu_value "$desired_reservation" "$final_limit")"
     current_reservation="$(_env_get_raw "$reservation_key")"
     final_reservation="$(_select_auto_cpu_value "$current_reservation" "$detected_reservation")"
-    if awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
+    if LC_ALL=C awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
         final_reservation="$final_limit"
     fi
 
@@ -298,7 +298,7 @@ ensure_llama_cpu_budget() {
     final_limit="$(_select_auto_cpu_value "$current_limit" "$detected_limit")"
     final_reservation="$(_select_auto_cpu_value "$current_reservation" "$detected_reservation")"
 
-    if awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
+    if LC_ALL=C awk "BEGIN { exit !($final_reservation > $final_limit) }"; then
         final_reservation="$final_limit"
     fi
 

--- a/ods/tests/test-locale-safe-cpu-formatting.sh
+++ b/ods/tests/test-locale-safe-cpu-formatting.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Regression guard for issue #1614: CPU budget values written to .env must
+# Regression guard for issue #1662: CPU budget values written to .env must
 # always use dot decimals, even when the parent shell has a decimal-comma locale.
 
 set -euo pipefail
@@ -33,27 +33,69 @@ require_scoped_awk() {
     fi
 }
 
+require_scoped_cpu_comparisons() {
+    local file="$1"
+    local label="$2"
+    if grep -En 'awk "BEGIN \{ exit !\(' "$ROOT_DIR/$file" | grep -Fv 'LC_ALL=C awk' >/dev/null; then
+        fail "$label has CPU comparison awk without LC_ALL=C"
+    else
+        pass "$label scopes CPU comparison awk to C locale"
+    fi
+}
+
 echo ""
 echo "Locale-safe CPU formatting"
 echo "--------------------------"
 
+require_scoped_awk "ods-cli" "ods-cli"
 require_scoped_awk "installers/phases/06-directories.sh" "Linux phase 06"
 require_scoped_awk "installers/macos/lib/env-generator.sh" "macOS env generator"
 require_scoped_awk "installers/macos/ods-macos.sh" "macOS installer"
+require_scoped_cpu_comparisons "ods-cli" "ods-cli"
+require_scoped_cpu_comparisons "installers/phases/06-directories.sh" "Linux phase 06"
+require_scoped_cpu_comparisons "installers/macos/lib/env-generator.sh" "macOS env generator"
+require_scoped_cpu_comparisons "installers/macos/ods-macos.sh" "macOS installer"
 
 TMP_DIR="$(mktemp -d)"
-cat > "$TMP_DIR/awk" <<'EOF'
+FAKE_BIN="$TMP_DIR/bin"
+REAL_AWK="$(command -v awk)"
+export ODS_TEST_REAL_AWK="$REAL_AWK"
+mkdir -p "$FAKE_BIN"
+cat > "$FAKE_BIN/awk" <<'EOF'
 #!/usr/bin/env bash
-if [[ "${LC_ALL:-${LC_NUMERIC:-}}" == "C" ]]; then
-    printf '4.0\n'
-else
-    printf '4,0\n'
+if [[ "${ODS_TEST_DECIMAL_COMMA:-}" == "1" && "${LC_ALL:-}" != "C" ]]; then
+    if [[ "$*" == *'printf "%.1f"'* ]]; then
+        printf '4,0\n'
+        exit 0
+    fi
+    if [[ "$*" == *'BEGIN { exit !('* ]]; then
+        printf 'awk: decimal comma parse failure\n' >&2
+        exit 2
+    fi
 fi
+exec "$ODS_TEST_REAL_AWK" "$@"
 EOF
-chmod +x "$TMP_DIR/awk"
+chmod +x "$FAKE_BIN/awk"
+
+cat > "$FAKE_BIN/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "info" ]]; then
+    printf '4\n'
+    exit 0
+fi
+if [[ "${1:-}" == "compose" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "ps" ]]; then
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$FAKE_BIN/docker"
 
 result="$(
-    PATH="$TMP_DIR:$PATH" LC_ALL=fr_FR.UTF-8 bash -c '
+    PATH="$FAKE_BIN:$PATH" ODS_TEST_DECIMAL_COMMA=1 bash -c '
         source "$1"
         cap_cpu_value 8.0 4
     ' _ "$ROOT_DIR/installers/macos/lib/env-generator.sh"
@@ -63,6 +105,58 @@ if [[ "$result" == "4.0" ]]; then
     pass "cap_cpu_value emits dot decimals under decimal-comma parent locale"
 else
     fail "cap_cpu_value emitted '$result' instead of '4.0'"
+fi
+
+CLI_HOME="$TMP_DIR/ods-home"
+mkdir -p "$CLI_HOME/lib" "$CLI_HOME/scripts"
+cp "$ROOT_DIR/lib/service-registry.sh" "$CLI_HOME/lib/service-registry.sh"
+cat > "$CLI_HOME/.env" <<'EOF'
+GPU_BACKEND=nvidia
+LLAMA_CPU_LIMIT=8.0
+LLAMA_CPU_RESERVATION=2.0
+TTS_CPU_LIMIT=8,0
+TTS_CPU_RESERVATION=2,0
+WHISPER_CPU_LIMIT=4,0
+WHISPER_CPU_RESERVATION=1,0
+HERMES_CPU_LIMIT=4,0
+HERMES_CPU_RESERVATION=0,5
+COMFYUI_CPU_LIMIT=8,0
+COMFYUI_CPU_RESERVATION=2,0
+EOF
+cat > "$CLI_HOME/.compose-flags" <<'EOF'
+-f docker-compose.base.yml
+EOF
+touch "$CLI_HOME/docker-compose.base.yml"
+
+if PATH="$FAKE_BIN:$PATH" ODS_HOME="$CLI_HOME" ODS_TEST_DECIMAL_COMMA=1 bash "$ROOT_DIR/ods-cli" start >/dev/null 2>"$TMP_DIR/ods-cli-start.err"; then
+    if grep -Eq '^(TTS|WHISPER|HERMES|COMFYUI)_CPU_(LIMIT|RESERVATION)=[0-9]+,[0-9]$' "$CLI_HOME/.env"; then
+        fail "ods-cli start left comma decimal CPU values in .env"
+    else
+        expected_cpu_lines=(
+            'TTS_CPU_LIMIT=4.0'
+            'TTS_CPU_RESERVATION=2.0'
+            'WHISPER_CPU_LIMIT=4.0'
+            'WHISPER_CPU_RESERVATION=1.0'
+            'HERMES_CPU_LIMIT=4.0'
+            'HERMES_CPU_RESERVATION=0.5'
+            'COMFYUI_CPU_LIMIT=4.0'
+            'COMFYUI_CPU_RESERVATION=2.0'
+        )
+        missing_cpu_line=""
+        for expected_cpu_line in "${expected_cpu_lines[@]}"; do
+            if ! grep -Fxq "$expected_cpu_line" "$CLI_HOME/.env"; then
+                missing_cpu_line="$expected_cpu_line"
+                break
+            fi
+        done
+        if [[ -z "$missing_cpu_line" ]]; then
+            pass "ods-cli start rewrites corrupted comma CPU values with dot decimals"
+        else
+            fail "ods-cli start did not write expected line: $missing_cpu_line"
+        fi
+    fi
+else
+    fail "ods-cli start failed under decimal-comma locale: $(cat "$TMP_DIR/ods-cli-start.err")"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Fixes #1662 by making CPU budget formatting and CPU comparisons locale-stable anywhere ODS writes Docker Compose `cpus` values into `.env`.

Decimal-comma locales, such as `fr_FR.UTF-8`, must still produce Compose-safe values like `8.0`, `2.0`, and `0.5`.

## Root Cause

`ods-cli` still inherited the parent numeric locale for CPU budget `awk` calls.

| Path | Failure mode |
| --- | --- |
| `_cap_cpu_value()` | Could emit `8,0` instead of `8.0`. |
| `_select_auto_cpu_value()` | Could compare preserved/detected values under the parent locale. |
| Reservation clamping | Could compare CPU reservation and limit under the parent locale. |

Once comma decimals landed in `.env`, Docker Compose rejected them with `strconv.ParseFloat` errors.

## Changes

| Area | Update |
| --- | --- |
| `ods/ods-cli` | Forces `LC_ALL=C` for CPU formatting and comparisons used by `ods start`, `ods restart`, and `ods update`. |
| Linux phase 06 | Forces `LC_ALL=C` when preserving CPU values and clamping reservations. |
| macOS installer/env generator | Applies the same locale-stable comparison behavior. |
| Regression test | Covers `ods-cli` directly and verifies corrupted comma CPU values are repaired. |

## Regression Coverage

The updated test checks that CPU formatting and comparison `awk` calls in the touched shell paths are scoped to `LC_ALL=C`, then runs `ods-cli start` with a temporary `ODS_HOME` to verify values like `TTS_CPU_LIMIT=8,0` are rewritten to dot decimals.

## Validation

```text
PASS bash ods/tests/test-locale-safe-cpu-formatting.sh
PASS bash -n ods/ods-cli ods/installers/phases/06-directories.sh ods/installers/macos/ods-macos.sh ods/installers/macos/lib/env-generator.sh ods/tests/test-locale-safe-cpu-formatting.sh
PASS bash ods/tests/test-ods-cli-pipefail-tolerance.sh
PASS bash ods/tests/test-cpu-only-path.sh
PASS bash ods/tests/test-generated-config-contracts.sh
PASS bash ods/tests/test-compose-failure-report.sh
PASS git diff --check
```

Note: `shellcheck` was not installed locally; CI covers shell linting.