### PR TITLE
fix(installer): guard compose pulls on desktop installers

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -979,7 +979,7 @@ if $DRY_RUN; then
     [[ -n "$GGUF_URL" ]] && ai "[DRY RUN] Would download: ${GGUF_FILE}"
     ai "[DRY RUN] Would download llama-server (Metal build)"
     ai "[DRY RUN] Would start native llama-server on port 8080"
-    ai "[DRY RUN] Would run: docker compose up -d"
+    ai "[DRY RUN] Would run: docker compose up -d --remove-orphans --no-build --pull never"
 else
     # Change to install directory for docker compose
     cd "$INSTALL_DIR"
@@ -1492,6 +1492,104 @@ else
     # ── Start Docker services ──
     chapter "STARTING SERVICES"
 
+    _macos_compose_up_args=(up -d --remove-orphans --no-build --pull never)
+
+    _macos_is_local_image() {
+        local image="${1:-}"
+        case "$image" in
+            ""|ods-*|ods-*:*|docker.io/library/ods-*|localhost/*|localhost:*/*|127.0.0.1:*/*)
+                return 0
+                ;;
+        esac
+        return 1
+    }
+
+    _macos_compose_external_images() {
+        local config_json
+        if config_json="$(docker compose "${COMPOSE_FLAGS[@]}" config --format json 2>>"$ODS_LOG_FILE")"; then
+            if printf '%s' "$config_json" | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+
+for service in (data.get("services") or {}).values():
+    if service.get("build") is not None:
+        continue
+    image = str(service.get("image") or "").strip()
+    if image:
+        print(image)
+' | while IFS= read -r _image; do
+                _macos_is_local_image "$_image" && continue
+                printf '%s\n' "$_image"
+            done | awk '!seen[$0]++'; then
+                return 0
+            fi
+        fi
+
+        docker compose "${COMPOSE_FLAGS[@]}" config --images 2>>"$ODS_LOG_FILE" | while IFS= read -r _image; do
+            _macos_is_local_image "$_image" && continue
+            printf '%s\n' "$_image"
+        done | awk '!seen[$0]++'
+    }
+
+    _macos_pull_image_with_retry() {
+        local image="$1" attempt max_attempts delay
+        local -a delays=(5 15 30)
+
+        if docker image inspect "$image" >/dev/null 2>&1; then
+            log "Compose image already cached: $image"
+            return 0
+        fi
+
+        max_attempts="${ODS_DOCKER_PULL_MAX_ATTEMPTS:-4}"
+        for ((attempt=1; attempt<=max_attempts; attempt++)); do
+            ai "Pulling Compose image ($attempt/$max_attempts): $image"
+            if docker pull "$image" >>"$ODS_LOG_FILE" 2>&1; then
+                ai_ok "Pulled $image"
+                return 0
+            fi
+            if (( attempt < max_attempts )); then
+                delay="${delays[$((attempt - 1))]:-30}"
+                ai_warn "Pull failed for $image; retrying in ${delay}s"
+                sleep "$delay"
+            fi
+        done
+
+        ai_err "Failed to pull Compose image after retries: $image"
+        return 1
+    }
+
+    _macos_pre_pull_compose_images() {
+        local image_output image failed
+        image_output="$(_macos_compose_external_images)" || {
+            ai_err "Could not resolve macOS Docker Compose images before service launch"
+            ai "Inspect compose config with: cd '$INSTALL_DIR' && docker compose ${COMPOSE_FLAGS[*]} config --images"
+            return 1
+        }
+        [[ -n "$image_output" ]] || return 0
+
+        ai "Verifying Compose image cache before launch..."
+        failed=0
+        while IFS= read -r image; do
+            [[ -n "$image" ]] || continue
+            _macos_pull_image_with_retry "$image" || failed=$((failed + 1))
+        done <<< "$image_output"
+
+        if [[ "$failed" -eq 0 ]]; then
+            ai_ok "Compose image cache ready"
+            return 0
+        fi
+
+        ai_err "$failed Compose image(s) could not be pulled before launch"
+        ai "macOS installer will not allow Docker Compose to pull images implicitly."
+        ai "Fix Docker registry/network/disk access, then re-run ./installers/macos/install-macos.sh."
+        return 1
+    }
+
     # ── Rebuild local-built images ─────────────────────────────────────
     # Mirrors phases/11-services.sh on Linux: local Dockerfiles can drift from
     # baked images, so rebuild the local services that are actually present in
@@ -1526,13 +1624,30 @@ else
     done
     ai_ok "Local images rebuilt"
 
-    _compose_up_log="${INSTALL_DIR}/logs/compose-up.log"
     mkdir -p "${INSTALL_DIR}/logs"
+    _compose_up_log="${INSTALL_DIR}/logs/compose-up.log"
+    : > "$_compose_up_log"
+
+    if ! _macos_pre_pull_compose_images; then
+        if command -v write_compose_failure_report >/dev/null 2>&1; then
+            _compose_report_path="$(COMPOSE_FLAGS_REPORT="${COMPOSE_FLAGS[*]}" write_compose_failure_report \
+                "$INSTALL_DIR" \
+                "install-macos compose image preflight" \
+                "docker compose ${COMPOSE_FLAGS[*]} ${_macos_compose_up_args[*]}" \
+                "$_compose_up_log" \
+                "apple" \
+                "A required Compose image did not download during the retry-protected preflight. Fix Docker registry/network/disk access, then re-run ./installers/macos/install-macos.sh." |
+                tail -n 1)" || true
+            [[ -n "${_compose_report_path:-}" ]] && ai_warn "Compose failure report saved: $_compose_report_path"
+        fi
+        exit 1
+    fi
+
     _compose_launch_record="${INSTALL_DIR}/logs/compose-launch.txt"
     {
         printf 'timestamp=%s\n' "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
         printf 'cwd=%s\n' "$INSTALL_DIR"
-        printf 'compose_command=docker compose %s up -d --remove-orphans --no-build\n' "${COMPOSE_FLAGS[*]}"
+        printf 'compose_command=docker compose %s %s\n' "${COMPOSE_FLAGS[*]}" "${_macos_compose_up_args[*]}"
         printf 'compose_flags=%s\n' "${COMPOSE_FLAGS[*]}"
         printf 'compose_flags_file=%s\n' "$INSTALL_DIR/.compose-flags"
         printf "compose_ps_command=cd '%s' && docker compose %s ps -a\n" "$INSTALL_DIR" "${COMPOSE_FLAGS[*]}"
@@ -1548,10 +1663,9 @@ else
             fi
         done
     } > "$_compose_launch_record"
-    ai "Running: docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build"
-    : > "$_compose_up_log"
+    ai "Running: docker compose ${COMPOSE_FLAGS[*]} ${_macos_compose_up_args[*]}"
     set +o pipefail  # pipefail would abort on compose exit before PIPESTATUS is read; capture it first
-    docker compose "${COMPOSE_FLAGS[@]}" up -d --remove-orphans --no-build 2>&1 | tee -a "$_compose_up_log" | while IFS= read -r line; do
+    docker compose "${COMPOSE_FLAGS[@]}" "${_macos_compose_up_args[@]}" 2>&1 | tee -a "$_compose_up_log" | while IFS= read -r line; do
         echo "  $line"
     done
     compose_exit="${PIPESTATUS[0]}"
@@ -1562,7 +1676,7 @@ else
             _compose_report_path="$(COMPOSE_FLAGS_REPORT="${COMPOSE_FLAGS[*]}" write_compose_failure_report \
                 "$INSTALL_DIR" \
                 "install-macos docker compose up" \
-                "docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build" \
+                "docker compose ${COMPOSE_FLAGS[*]} ${_macos_compose_up_args[*]}" \
                 "$_compose_up_log" \
                 "apple" \
                 "Open the saved report, fix the failed image/port/compose error it identifies, then re-run ./installers/macos.sh." |
@@ -1579,7 +1693,7 @@ else
             _compose_report_path="$(COMPOSE_FLAGS_REPORT="${COMPOSE_FLAGS[*]}" write_compose_failure_report \
                 "$INSTALL_DIR" \
                 "install-macos zero managed containers" \
-                "docker compose ${COMPOSE_FLAGS[*]} up -d --remove-orphans --no-build" \
+                "docker compose ${COMPOSE_FLAGS[*]} ${_macos_compose_up_args[*]}" \
                 "$_compose_up_log" \
                 "apple" \
                 "No ODS containers were created. Run the saved ps/logs commands from logs/compose-launch.txt, fix the compose/runtime failure, then re-run ./installers/macos.sh." |

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -224,7 +224,7 @@ if ($dryRun) {
         Write-AI "[DRY RUN] Would install AMD Lemonade Server (or fallback to llama-server Vulkan)"
         Write-AI "[DRY RUN] Would start native inference server on port 8080"
     }
-    Write-AI "[DRY RUN] Would run: docker compose up -d"
+    Write-AI "[DRY RUN] Would run: docker compose up -d --remove-orphans --no-build --pull never"
 } else {
     Push-Location $installDir
     # Sync .NET CWD so in-process .NET API calls using relative paths (e.g., Test-Path
@@ -1124,6 +1124,139 @@ litellm_settings:
             return ""
         }
 
+        function Test-ODSWindowsLocalImageTag {
+            param([string]$Image)
+
+            if ([string]::IsNullOrWhiteSpace($Image)) { return $true }
+            return (
+                $Image -match '^ods-' -or
+                $Image -match '^docker\.io/library/ods-' -or
+                $Image -match '^localhost[/:]' -or
+                $Image -match '^127\.0\.0\.1:'
+            )
+        }
+
+        function Get-ODSWindowsComposeExternalImages {
+            param(
+                [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
+                [Parameter(Mandatory = $true)][string[]]$ComposeFlags
+            )
+
+            $images = New-Object System.Collections.Generic.List[string]
+            $seen = @{}
+            $configJson = & docker @DockerClientArgs compose @ComposeFlags config --format json 2>$null
+            if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($configJson)) {
+                try {
+                    $composeConfig = ($configJson -join "`n") | ConvertFrom-Json
+                    foreach ($serviceProperty in $composeConfig.services.PSObject.Properties) {
+                        $service = $serviceProperty.Value
+                        $hasBuild = $false
+                        if ($service.PSObject.Properties["build"] -and $null -ne $service.build) {
+                            $hasBuild = $true
+                        }
+                        if ($hasBuild) { continue }
+
+                        $image = [string]$service.image
+                        if ([string]::IsNullOrWhiteSpace($image)) { continue }
+                        if (Test-ODSWindowsLocalImageTag -Image $image) { continue }
+                        if (-not $seen.ContainsKey($image)) {
+                            $seen[$image] = $true
+                            [void]$images.Add($image)
+                        }
+                    }
+                    return @($images)
+                } catch {
+                    Write-AIWarn "Could not parse Docker Compose JSON image list: $($_.Exception.Message)"
+                }
+            }
+
+            $imageLines = @(& docker @DockerClientArgs compose @ComposeFlags config --images 2>$null |
+                Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+            if ($LASTEXITCODE -ne 0) {
+                throw "docker compose config --images failed"
+            }
+
+            foreach ($image in $imageLines) {
+                $image = [string]$image
+                if (Test-ODSWindowsLocalImageTag -Image $image) { continue }
+                if (-not $seen.ContainsKey($image)) {
+                    $seen[$image] = $true
+                    [void]$images.Add($image)
+                }
+            }
+            return @($images)
+        }
+
+        function Invoke-ODSWindowsDockerPullWithRetry {
+            param(
+                [Parameter(Mandatory = $true)][string]$Image,
+                [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
+                [Parameter(Mandatory = $true)][string]$LogPath,
+                [int]$MaxAttempts = 4
+            )
+
+            & docker @DockerClientArgs image inspect $Image *> $null
+            if ($LASTEXITCODE -eq 0) {
+                Add-Content -LiteralPath $LogPath -Value "Compose image already cached: $Image"
+                return $true
+            }
+
+            $delays = @(5, 15, 30)
+            for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+                Write-AI "Pulling Compose image ($attempt/$MaxAttempts): $Image"
+                & docker @DockerClientArgs pull $Image *>> $LogPath
+                if ($LASTEXITCODE -eq 0) {
+                    Write-AISuccess "Pulled $Image"
+                    return $true
+                }
+                if ($attempt -lt $MaxAttempts) {
+                    $delay = $delays[[Math]::Min($attempt - 1, $delays.Count - 1)]
+                    Write-AIWarn "Pull failed for $Image; retrying in ${delay}s"
+                    Start-Sleep -Seconds $delay
+                }
+            }
+
+            Write-AIError "Failed to pull Compose image after retries: $Image"
+            return $false
+        }
+
+        function Invoke-ODSWindowsComposeImagePreflight {
+            param(
+                [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
+                [Parameter(Mandatory = $true)][string[]]$ComposeFlags,
+                [Parameter(Mandatory = $true)][string]$LogPath
+            )
+
+            try {
+                $images = @(Get-ODSWindowsComposeExternalImages -DockerClientArgs $DockerClientArgs -ComposeFlags $ComposeFlags)
+            } catch {
+                Write-AIError "Could not resolve Windows Docker Compose images before service launch."
+                Write-AI "  Inspect compose config with: docker compose $($ComposeFlags -join ' ') config --images"
+                Add-Content -LiteralPath $LogPath -Value "compose image preflight failed: $($_.Exception.Message)"
+                return $false
+            }
+
+            if ($images.Count -eq 0) { return $true }
+
+            Write-AI "Verifying Compose image cache before launch..."
+            $failed = New-Object System.Collections.Generic.List[string]
+            foreach ($image in $images) {
+                if (-not (Invoke-ODSWindowsDockerPullWithRetry -Image $image -DockerClientArgs $DockerClientArgs -LogPath $LogPath)) {
+                    [void]$failed.Add($image)
+                }
+            }
+
+            if ($failed.Count -eq 0) {
+                Write-AISuccess "Compose image cache ready"
+                return $true
+            }
+
+            Write-AIError "$($failed.Count) Compose image(s) could not be pulled before launch."
+            Write-AI "Windows installer will not allow Docker Compose to pull images implicitly."
+            Write-AI "Fix Docker registry/network/disk access, then re-run .\install-windows.ps1."
+            return $false
+        }
+
         if (-not $cloudMode -and $currentBackend -ne "amd") {
             $envLlamaImage = ""
             $envFallbackImage = ""
@@ -1191,10 +1324,11 @@ litellm_settings:
         }
 
         Assert-ODSWindowsComposeCwd -InstallDir $installDir
+        $composeUpArgs = @("up", "-d", "--remove-orphans", "--no-build", "--pull", "never")
         Write-ODSWindowsComposeLaunchRecord -InstallDir $installDir -ComposeFlags $composeFlags `
-            -ComposeArgs @("up", "-d", "--remove-orphans", "--no-build")
+            -ComposeArgs $composeUpArgs
 
-        Write-AI "Running: docker --config `"$($env:DOCKER_CONFIG)`" compose $($composeFlags -join ' ') up -d --remove-orphans --no-build"
+        Write-AI "Running: docker --config `"$($env:DOCKER_CONFIG)`" compose $($composeFlags -join ' ') $($composeUpArgs -join ' ')"
         Write-AI "Compose working directory: $installDir"
         # PS 5.1 treats ANY stderr output from native commands as NativeCommandError.
         # Silence stderr-as-error so $LASTEXITCODE reflects the real compose exit code.
@@ -1279,8 +1413,18 @@ litellm_settings:
             }
             Write-AISuccess "Local images rebuilt"
 
+            if (-not (Invoke-ODSWindowsComposeImagePreflight -DockerClientArgs $dockerClientArgs -ComposeFlags $composeFlags -LogPath $_composeLog)) {
+                Write-ODSComposeDiagnostics -InstallDir $installDir -ComposeFlags $composeFlags `
+                    -ComposeArgs $composeUpArgs `
+                    -ComposeLogPath $_composeLog `
+                    -Phase "install-windows.ps1 compose image preflight" `
+                    -NextStep "A required Compose image did not download during the retry-protected preflight. Fix Docker registry/network/disk access, then re-run .\install-windows.ps1." `
+                    -SaveReport
+                exit 1
+            }
+
             Write-AI "Starting services... this may take several minutes."
-            & docker @dockerClientArgs compose @composeFlags up -d --remove-orphans --no-build *> $_composeLog
+            & docker @dockerClientArgs compose @composeFlags @composeUpArgs *> $_composeLog
             $composeExit = $LASTEXITCODE
         }
         finally {
@@ -1294,7 +1438,7 @@ litellm_settings:
         if ($composeExit -ne 0) {
             Write-AIError "docker compose up failed (exit code: $composeExit)"
             Write-ODSComposeDiagnostics -InstallDir $installDir -ComposeFlags $composeFlags `
-                -ComposeArgs @("up", "-d", "--remove-orphans", "--no-build") `
+                -ComposeArgs $composeUpArgs `
                 -ComposeLogPath $_composeLog `
                 -Phase "install-windows.ps1 docker compose up -d" `
                 -SaveReport

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -1195,10 +1195,16 @@ litellm_settings:
                 [int]$MaxAttempts = 4
             )
 
-            & docker @DockerClientArgs image inspect $Image *> $null
-            if ($LASTEXITCODE -eq 0) {
-                Add-Content -LiteralPath $LogPath -Value "Compose image already cached: $Image"
-                return $true
+            $prevEAP = $ErrorActionPreference
+            $ErrorActionPreference = "SilentlyContinue"
+            try {
+                & docker @DockerClientArgs image inspect $Image *> $null
+                if ($LASTEXITCODE -eq 0) {
+                    Add-Content -LiteralPath $LogPath -Value "Compose image already cached: $Image"
+                    return $true
+                }
+            } finally {
+                $ErrorActionPreference = $prevEAP
             }
 
             $delays = @(5, 15, 30)

--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -528,8 +528,12 @@ if grep -A16 'function Test-ODSDockerImageAvailable' installers/windows/install-
     | grep -q 'SilentlyContinue' \
     && grep -A20 'function Test-ODSDockerImageAvailable' installers/windows/install-windows.ps1 \
         | grep -q 'finally' \
-    && grep -q 'docker manifest inspect' installers/windows/install-windows.ps1; then
-    pass "install-windows.ps1: image availability probes restore ErrorActionPreference"
+    && grep -q 'manifest inspect' installers/windows/install-windows.ps1 \
+    && grep -A24 'function Invoke-ODSWindowsDockerPullWithRetry' installers/windows/install-windows.ps1 \
+        | grep -q 'SilentlyContinue' \
+    && grep -A30 'function Invoke-ODSWindowsDockerPullWithRetry' installers/windows/install-windows.ps1 \
+        | grep -q 'finally'; then
+    pass "install-windows.ps1: image probes restore ErrorActionPreference"
 else
     fail "install-windows.ps1: Docker image probes must not abort on missing local images"
 fi

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -438,9 +438,13 @@ assert_contains "extensions/services/embeddings/compose.yaml" 'HF_HUB_ETAG_TIMEO
 assert_contains "installers/macos/install-macos.sh" 'compose-launch\.txt' "macOS installer missing compose launch record"
 assert_contains "installers/macos/install-macos.sh" 'ps -q' "macOS installer does not count compose-managed containers"
 assert_contains "installers/macos/install-macos.sh" 'docker compose up completed but created no managed containers' "macOS installer does not fail loud on zero managed containers"
+assert_contains "installers/macos/install-macos.sh" '_macos_pre_pull_compose_images' "macOS installer does not preflight compose images before launch"
+assert_contains "installers/macos/install-macos.sh" '--pull never' "macOS installer still allows implicit compose pulls during install launch"
 assert_contains "installers/windows/install-windows.ps1" 'Assert-ODSWindowsManagedContainers' "Windows installer does not assert compose-managed containers"
 assert_contains "installers/windows/install-windows.ps1" 'Docker Compose did not create any managed Windows containers' "Windows installer does not fail loud on zero managed containers"
 assert_contains "installers/windows/install-windows.ps1" 'dashboard", "dashboard-api", "open-webui' "Windows installer does not require core container services"
+assert_contains "installers/windows/install-windows.ps1" 'Invoke-ODSWindowsComposeImagePreflight' "Windows installer does not preflight compose images before launch"
+assert_contains "installers/windows/install-windows.ps1" '--pull", "never' "Windows installer still allows implicit compose pulls during install launch"
 
 echo "[contract] Windows host agent ignores Store Python aliases and bootstraps real Python"
 assert_contains "installers/windows/phases/07-devtools.ps1" 'Resolve-ODSHostAgentPython' "Windows installer does not resolve a real host-agent Python"

--- a/ods/tests/test-windows-compose-failure-report.sh
+++ b/ods/tests/test-windows-compose-failure-report.sh
@@ -49,7 +49,8 @@ check 'Get-NetTCPConnection' "$DIAG_LIB" "report includes Windows port checks"
 check 'Compose config tail (redacted)' "$DIAG_LIB" "report captures redacted compose config"
 check '[switch]$SaveReport' "$DIAG_LIB" "diagnostics only save report when requested"
 check '-ComposeLogPath $_composeLog' "$INSTALL_PS1" "installer passes compose log to diagnostics"
-check '-ComposeArgs @("up", "-d", "--remove-orphans", "--no-build")' "$INSTALL_PS1" "installer passes exact compose up args"
+check '$composeUpArgs = @("up", "-d", "--remove-orphans", "--no-build", "--pull", "never")' "$INSTALL_PS1" "installer passes guarded compose up args"
+check 'Invoke-ODSWindowsComposeImagePreflight' "$INSTALL_PS1" "installer preflights compose images before up"
 check '-SaveReport' "$INSTALL_PS1" "installer enables saved report on compose failure"
 check 'function Assert-ODSWindowsComposeCwd' "$INSTALL_PS1" "installer asserts compose cwd before launch"
 check 'Write-ODSWindowsComposeLaunchRecord' "$INSTALL_PS1" "installer writes compose launch record"
@@ -183,7 +184,7 @@ EOF
             Assert-ODSWindowsComposeCwd -InstallDir $env:INSTALL_DIR
             Write-ODSWindowsComposeLaunchRecord -InstallDir $env:INSTALL_DIR `
                 -ComposeFlags @("--env-file", ".env", "-f", "docker-compose.base.yml") `
-                -ComposeArgs @("up", "-d", "--remove-orphans", "--no-build")
+                -ComposeArgs @("up", "-d", "--remove-orphans", "--no-build", "--pull", "never")
         }
         finally {
             [Environment]::CurrentDirectory = $previous
@@ -197,7 +198,7 @@ EOF
             "cwd=$env:INSTALL_DIR",
             "dotnet_cwd=$env:INSTALL_DIR",
             "docker_config=$expectedDockerConfig",
-            "compose_command=docker --config `"$expectedDockerConfig`" compose --env-file .env -f docker-compose.base.yml up -d --remove-orphans --no-build",
+            "compose_command=docker --config `"$expectedDockerConfig`" compose --env-file .env -f docker-compose.base.yml up -d --remove-orphans --no-build --pull never",
             "compose_ps_command=cd"
         )) {
             if (-not $text.Contains($needle)) { throw "missing $needle" }


### PR DESCRIPTION
## Summary

Follow-up to #1668 for the desktop installers.

The Linux installer now prevents Docker Compose from performing hidden image pulls during `compose up`. This PR applies the same install-time safety contract to macOS and Windows so the platform-specific installers do not regress into the same TLS-handshake-timeout / zero-container failure mode.

## What Changed

| Platform | Change |
| --- | --- |
| macOS | Resolves external images from the final Compose config, skips local ODS build outputs, pulls missing images with retry, then launches with `--pull never`. |
| Windows | Resolves external images from `docker compose config --format json`, skips services with local build tags, pulls missing images with retry, then launches with `--pull never`. |
| Reports | Launch records and compose diagnostics now include the guarded install command. |
| Tests | Hardening contracts and Windows compose report tests now assert the preflight and guarded args. |

## Why

`docker compose up --no-build` can still pull missing external images/layers unless pull behavior is disabled. If that pull happens during install launch, a transient registry or TLS timeout can abort startup before Compose creates any managed containers.

The desktop installers already rebuild local Dockerfile services before `up`; this PR keeps those local builds local while moving external registry access into explicit retry-protected preflight code.

## Scope

This intentionally changes the install-time launch path only.

It does not change post-install `update` commands, because those commands are explicitly meant to pull refreshed images before recreating services.

## Verification

- [x] `bash -n ods/installers/macos/install-macos.sh ods/tests/contracts/test-installer-hardening.sh ods/tests/test-windows-compose-failure-report.sh`
- [x] PowerShell parser check for `ods/installers/windows/install-windows.ps1`
- [x] `bash ods/tests/contracts/test-installer-hardening.sh`
- [x] `bash ods/tests/test-windows-compose-failure-report.sh`
- [x] `bash ods/tests/contracts/test-installer-contracts.sh`
- [x] `git diff --check`

Note: local `shellcheck` is not installed in this workstation; GitHub CI will run the repository shell lint workflow.