### PR TITLE
feat(installer): add llmfit model advisor with fallback to tier map

### DIFF
--- a/ods/config/llmfit-model-map.json
+++ b/ods/config/llmfit-model-map.json
@@ -1,41 +1,29 @@
 {
-  "_comment": "Maps llmfit HuggingFace model IDs to ODS GGUF catalog entries. Update when new models are added to ODS tier map. Pin llmfit version: 0.4.2",
-  "_llmfit_version": "0.4.2",
+  "_comment": "ods_hardware_classes intentionally omitted — hardware-class enforcement deferred to integration PR that wires advisor into classify-hardware.sh",
   "mappings": [
     {
-      "llmfit_model_id": "Qwen/Qwen3-0.6B-GGUF",
+      "llmfit_model_id": "Qwen/Qwen3.5-2B-GGUF",
       "llmfit_quant": "Q4_K_M",
-      "ods_gguf_file": "Qwen3-0.6B-Q4_K_M.gguf",
-      "ods_tier": "T0",
-      "ods_hardware_classes": ["cpu_fallback"]
+      "ods_gguf_file": "Qwen3.5-2B-Q4_K_M.gguf",
+      "ods_tier": "T1"
     },
     {
-      "llmfit_model_id": "Qwen/Qwen3-1.7B-GGUF",
+      "llmfit_model_id": "Qwen/Qwen3.5-9B-GGUF",
       "llmfit_quant": "Q4_K_M",
-      "ods_gguf_file": "Qwen3-1.7B-Q4_K_M.gguf",
-      "ods_tier": "T1",
-      "ods_hardware_classes": ["cpu_fallback", "apple_silicon"]
+      "ods_gguf_file": "Qwen3.5-9B-Q4_K_M.gguf",
+      "ods_tier": "T2"
     },
     {
-      "llmfit_model_id": "Qwen/Qwen3-8B-GGUF",
+      "llmfit_model_id": "Qwen/Qwen3-30B-A3B-GGUF",
       "llmfit_quant": "Q4_K_M",
-      "ods_gguf_file": "Qwen3-8B-Q4_K_M.gguf",
-      "ods_tier": "T2",
-      "ods_hardware_classes": ["nvidia_pro", "apple_silicon", "strix_unified"]
+      "ods_gguf_file": "Qwen3-30B-A3B-Q4_K_M.gguf",
+      "ods_tier": "T3"
     },
     {
-      "llmfit_model_id": "Qwen/Qwen3-14B-GGUF",
+      "llmfit_model_id": "Qwen/Qwen3.6-35B-A3B-GGUF",
       "llmfit_quant": "Q4_K_M",
-      "ods_gguf_file": "Qwen3-14B-Q4_K_M.gguf",
-      "ods_tier": "T3",
-      "ods_hardware_classes": ["nvidia_pro", "strix_unified"]
-    },
-    {
-      "llmfit_model_id": "Qwen/Qwen3-32B-GGUF",
-      "llmfit_quant": "Q4_K_M",
-      "ods_gguf_file": "Qwen3-32B-Q4_K_M.gguf",
-      "ods_tier": "T4",
-      "ods_hardware_classes": ["nvidia_pro", "strix_unified"]
+      "ods_gguf_file": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+      "ods_tier": "T4"
     }
   ]
 }

--- a/ods/config/llmfit-model-map.json
+++ b/ods/config/llmfit-model-map.json
@@ -1,0 +1,41 @@
+{
+  "_comment": "Maps llmfit HuggingFace model IDs to ODS GGUF catalog entries. Update when new models are added to ODS tier map. Pin llmfit version: 0.4.2",
+  "_llmfit_version": "0.4.2",
+  "mappings": [
+    {
+      "llmfit_model_id": "Qwen/Qwen3-0.6B-GGUF",
+      "llmfit_quant": "Q4_K_M",
+      "ods_gguf_file": "Qwen3-0.6B-Q4_K_M.gguf",
+      "ods_tier": "T0",
+      "ods_hardware_classes": ["cpu_fallback"]
+    },
+    {
+      "llmfit_model_id": "Qwen/Qwen3-1.7B-GGUF",
+      "llmfit_quant": "Q4_K_M",
+      "ods_gguf_file": "Qwen3-1.7B-Q4_K_M.gguf",
+      "ods_tier": "T1",
+      "ods_hardware_classes": ["cpu_fallback", "apple_silicon"]
+    },
+    {
+      "llmfit_model_id": "Qwen/Qwen3-8B-GGUF",
+      "llmfit_quant": "Q4_K_M",
+      "ods_gguf_file": "Qwen3-8B-Q4_K_M.gguf",
+      "ods_tier": "T2",
+      "ods_hardware_classes": ["nvidia_pro", "apple_silicon", "strix_unified"]
+    },
+    {
+      "llmfit_model_id": "Qwen/Qwen3-14B-GGUF",
+      "llmfit_quant": "Q4_K_M",
+      "ods_gguf_file": "Qwen3-14B-Q4_K_M.gguf",
+      "ods_tier": "T3",
+      "ods_hardware_classes": ["nvidia_pro", "strix_unified"]
+    },
+    {
+      "llmfit_model_id": "Qwen/Qwen3-32B-GGUF",
+      "llmfit_quant": "Q4_K_M",
+      "ods_gguf_file": "Qwen3-32B-Q4_K_M.gguf",
+      "ods_tier": "T4",
+      "ods_hardware_classes": ["nvidia_pro", "strix_unified"]
+    }
+  ]
+}

--- a/ods/scripts/llmfit-advisor.sh
+++ b/ods/scripts/llmfit-advisor.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# ============================================================================
+# ODS Installer — llmfit Model Advisor
+# ============================================================================
+# Part of: scripts/
+# Purpose: Query llmfit binary (if available) for hardware-aware model
+#          recommendation. Falls back silently to existing tier map if
+#          llmfit is absent, times out, or returns unmapped output.
+#
+# Expects: HARDWARE_CLASS (set by classify-hardware.sh)
+#          ODS_HOME (optional, for vendored binary lookup)
+# Provides: LLMFIT_ODS_GGUF, LLMFIT_ODS_TIER, LLMFIT_TOKENSEC (exported)
+#           Returns 0 on successful recommendation, 1 on any failure
+#
+# Modder notes:
+#   This is a pure advisor — it never writes to .env or disk.
+#   All side effects belong in the calling phase script.
+#   LLMFIT_VERSION is pinned — update intentionally, not automatically.
+#   Model map is in config/llmfit-model-map.json — update when ODS
+#   tier map changes.
+# ============================================================================
+
+set -euo pipefail
+
+LLMFIT_VERSION="0.4.2"
+LLMFIT_TIMEOUT=10
+
+if [ -n "${SCRIPT_DIR:-}" ]; then
+    if [ -f "$SCRIPT_DIR/config/llmfit-model-map.json" ]; then
+        LLMFIT_MODEL_MAP="$SCRIPT_DIR/config/llmfit-model-map.json"
+    elif [ -f "$SCRIPT_DIR/../config/llmfit-model-map.json" ]; then
+        LLMFIT_MODEL_MAP="$SCRIPT_DIR/../config/llmfit-model-map.json"
+    else
+        LLMFIT_MODEL_MAP="$SCRIPT_DIR/llmfit-model-map.json"
+    fi
+else
+    LLMFIT_MODEL_MAP="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../config/llmfit-model-map.json"
+fi
+
+_log() {
+    if command -v log >/dev/null 2>&1; then
+        log "$@"
+    else
+        echo "[INFO] $@"
+    fi
+}
+
+_warn() {
+    if command -v warn >/dev/null 2>&1; then
+        warn "$@"
+    else
+        echo "[WARN] $@" >&2
+    fi
+}
+
+# Locate llmfit binary — vendored first, then PATH
+_llmfit_binary() {
+    local vendored="${ODS_HOME:-$HOME/ods}/bin/llmfit-${LLMFIT_VERSION}"
+    if [ -x "$vendored" ]; then
+        echo "$vendored"
+        return 0
+    fi
+    if command -v llmfit > /dev/null 2>&1; then
+        echo "llmfit"
+        return 0
+    fi
+    return 1
+}
+
+# Parse llmfit JSON output and map to ODS GGUF catalog
+# Returns 0 and exports LLMFIT_ODS_GGUF/TIER/TOKENSEC on success
+# Returns 1 on parse failure or unmapped model
+_parse_llmfit_output() {
+    local json="$1"
+    local result
+    result=$(python3 - "$json" "$LLMFIT_MODEL_MAP" << 'EOF'
+import sys, json
+
+llmfit_json, map_path = sys.argv[1], sys.argv[2]
+
+try:
+    recommendations = json.loads(llmfit_json)['recommendations']
+    with open(map_path) as f:
+        model_map = json.load(f)['mappings']
+except (KeyError, json.JSONDecodeError, FileNotFoundError) as e:
+    sys.exit(1)
+
+# Find first recommendation that maps to a known ODS GGUF
+for rec in recommendations:
+    model_id = rec.get('model_id', '')
+    quant = rec.get('quantization', '')
+    tokensec = rec.get('estimated_tokens_per_sec', 'unknown')
+
+    for entry in model_map:
+        if (entry['llmfit_model_id'] == model_id and
+                entry['llmfit_quant'] == quant):
+            print(f"{entry['ods_gguf_file']}|{entry['ods_tier']}|{tokensec}")
+            sys.exit(0)
+
+# No mapping found
+sys.exit(1)
+EOF
+    ) || return 1
+
+    LLMFIT_ODS_GGUF=$(echo "$result" | cut -d'|' -f1)
+    LLMFIT_ODS_TIER=$(echo "$result" | cut -d'|' -f2)
+    LLMFIT_TOKENSEC=$(echo "$result" | cut -d'|' -f3)
+    export LLMFIT_ODS_GGUF LLMFIT_ODS_TIER LLMFIT_TOKENSEC
+    return 0
+}
+
+# Main entry point — call this from installer phases
+# Returns 0 with LLMFIT_ODS_GGUF/TIER/TOKENSEC set, or 1 to use tier map
+query_llmfit_recommendation() {
+    local category="${1:-general}"
+    local binary
+
+    binary=$(_llmfit_binary) || {
+        # Silent — llmfit not installed is expected, not an error
+        return 1
+    }
+
+    local output
+    output=$(timeout "$LLMFIT_TIMEOUT" \
+        "$binary" --json --category "$category" 2>/dev/null) || {
+        _warn "llmfit timed out or failed — using tier map fallback"
+        return 1
+    }
+
+    _parse_llmfit_output "$output" || {
+        _warn "llmfit recommendation not in ODS model catalog — using tier map fallback"
+        return 1
+    }
+
+    return 0
+}

--- a/ods/tests/fixtures/llmfit/amd-strix-halo.json
+++ b/ods/tests/fixtures/llmfit/amd-strix-halo.json
@@ -1,0 +1,16 @@
+{
+  "hardware": {
+    "gpu_vendor": "amd",
+    "vram_gb": 96.0,
+    "ram_gb": 128.0
+  },
+  "recommendations": [
+    {
+      "model_id": "Qwen/Qwen3-14B-GGUF",
+      "quantization": "Q4_K_M",
+      "estimated_tokens_per_sec": 28.3,
+      "score": 0.88,
+      "fits": true
+    }
+  ]
+}

--- a/ods/tests/fixtures/llmfit/amd-strix-halo.json
+++ b/ods/tests/fixtures/llmfit/amd-strix-halo.json
@@ -6,7 +6,7 @@
   },
   "recommendations": [
     {
-      "model_id": "Qwen/Qwen3-14B-GGUF",
+      "model_id": "Qwen/Qwen3-30B-A3B-GGUF",
       "quantization": "Q4_K_M",
       "estimated_tokens_per_sec": 28.3,
       "score": 0.88,

--- a/ods/tests/fixtures/llmfit/apple-m3-16gb.json
+++ b/ods/tests/fixtures/llmfit/apple-m3-16gb.json
@@ -6,7 +6,7 @@
   },
   "recommendations": [
     {
-      "model_id": "Qwen/Qwen3-8B-GGUF",
+      "model_id": "Qwen/Qwen3.5-9B-GGUF",
       "quantization": "Q4_K_M",
       "estimated_tokens_per_sec": 18.5,
       "score": 0.81,

--- a/ods/tests/fixtures/llmfit/apple-m3-16gb.json
+++ b/ods/tests/fixtures/llmfit/apple-m3-16gb.json
@@ -1,0 +1,16 @@
+{
+  "hardware": {
+    "gpu_vendor": "apple",
+    "vram_gb": 11.2,
+    "ram_gb": 16.0
+  },
+  "recommendations": [
+    {
+      "model_id": "Qwen/Qwen3-8B-GGUF",
+      "quantization": "Q4_K_M",
+      "estimated_tokens_per_sec": 18.5,
+      "score": 0.81,
+      "fits": true
+    }
+  ]
+}

--- a/ods/tests/fixtures/llmfit/cpu-only.json
+++ b/ods/tests/fixtures/llmfit/cpu-only.json
@@ -6,7 +6,7 @@
   },
   "recommendations": [
     {
-      "model_id": "Qwen/Qwen3-1.7B-GGUF",
+      "model_id": "Qwen/Qwen3.5-2B-GGUF",
       "quantization": "Q4_K_M",
       "estimated_tokens_per_sec": 8.1,
       "score": 0.72,

--- a/ods/tests/fixtures/llmfit/cpu-only.json
+++ b/ods/tests/fixtures/llmfit/cpu-only.json
@@ -1,0 +1,16 @@
+{
+  "hardware": {
+    "gpu_vendor": "none",
+    "vram_gb": 0,
+    "ram_gb": 16.0
+  },
+  "recommendations": [
+    {
+      "model_id": "Qwen/Qwen3-1.7B-GGUF",
+      "quantization": "Q4_K_M",
+      "estimated_tokens_per_sec": 8.1,
+      "score": 0.72,
+      "fits": true
+    }
+  ]
+}

--- a/ods/tests/fixtures/llmfit/nvidia-24gb.json
+++ b/ods/tests/fixtures/llmfit/nvidia-24gb.json
@@ -6,14 +6,14 @@
   },
   "recommendations": [
     {
-      "model_id": "Qwen/Qwen3-14B-GGUF",
+      "model_id": "Qwen/Qwen3-30B-A3B-GGUF",
       "quantization": "Q4_K_M",
       "estimated_tokens_per_sec": 42.5,
       "score": 0.91,
       "fits": true
     },
     {
-      "model_id": "Qwen/Qwen3-8B-GGUF",
+      "model_id": "Qwen/Qwen3.5-9B-GGUF",
       "quantization": "Q4_K_M",
       "estimated_tokens_per_sec": 68.2,
       "score": 0.87,

--- a/ods/tests/fixtures/llmfit/nvidia-24gb.json
+++ b/ods/tests/fixtures/llmfit/nvidia-24gb.json
@@ -1,0 +1,23 @@
+{
+  "hardware": {
+    "gpu_vendor": "nvidia",
+    "vram_gb": 24.0,
+    "ram_gb": 32.0
+  },
+  "recommendations": [
+    {
+      "model_id": "Qwen/Qwen3-14B-GGUF",
+      "quantization": "Q4_K_M",
+      "estimated_tokens_per_sec": 42.5,
+      "score": 0.91,
+      "fits": true
+    },
+    {
+      "model_id": "Qwen/Qwen3-8B-GGUF",
+      "quantization": "Q4_K_M",
+      "estimated_tokens_per_sec": 68.2,
+      "score": 0.87,
+      "fits": true
+    }
+  ]
+}

--- a/ods/tests/fixtures/llmfit/nvidia-8gb.json
+++ b/ods/tests/fixtures/llmfit/nvidia-8gb.json
@@ -1,0 +1,23 @@
+{
+  "hardware": {
+    "gpu_vendor": "nvidia",
+    "vram_gb": 8.0,
+    "ram_gb": 16.0
+  },
+  "recommendations": [
+    {
+      "model_id": "Qwen/Qwen3-8B-GGUF",
+      "quantization": "Q4_K_M",
+      "estimated_tokens_per_sec": 31.4,
+      "score": 0.82,
+      "fits": true
+    },
+    {
+      "model_id": "Qwen/Qwen3-1.7B-GGUF",
+      "quantization": "Q4_K_M",
+      "estimated_tokens_per_sec": 95.1,
+      "score": 0.75,
+      "fits": true
+    }
+  ]
+}

--- a/ods/tests/fixtures/llmfit/nvidia-8gb.json
+++ b/ods/tests/fixtures/llmfit/nvidia-8gb.json
@@ -6,14 +6,14 @@
   },
   "recommendations": [
     {
-      "model_id": "Qwen/Qwen3-8B-GGUF",
+      "model_id": "Qwen/Qwen3.5-9B-GGUF",
       "quantization": "Q4_K_M",
       "estimated_tokens_per_sec": 31.4,
       "score": 0.82,
       "fits": true
     },
     {
-      "model_id": "Qwen/Qwen3-1.7B-GGUF",
+      "model_id": "Qwen/Qwen3.5-2B-GGUF",
       "quantization": "Q4_K_M",
       "estimated_tokens_per_sec": 95.1,
       "score": 0.75,

--- a/ods/tests/test-llmfit-advisor.sh
+++ b/ods/tests/test-llmfit-advisor.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FIXTURES_DIR="$ROOT_DIR/tests/fixtures/llmfit"
+
+# Source the advisor with SCRIPT_DIR set so model map path resolves
+SCRIPT_DIR="$ROOT_DIR/scripts"
+source "$ROOT_DIR/scripts/llmfit-advisor.sh"
+
+_assert_eq() {
+    local got="$1" expected="$2" label="$3"
+    if [ "$got" != "$expected" ]; then
+        echo "[FAIL] ${label}: expected '${expected}', got '${got}'"
+        exit 1
+    fi
+    echo "[PASS] ${label}"
+}
+
+# Test each hardware fixture maps to expected ODS GGUF + tier
+
+# NVIDIA 24GB → T3 (14B model fits)
+_parse_llmfit_output "$(cat "$FIXTURES_DIR/nvidia-24gb.json")"
+_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3-14B-Q4_K_M.gguf" "nvidia-24gb maps to T3 GGUF"
+_assert_eq "$LLMFIT_ODS_TIER" "T3"                      "nvidia-24gb maps to T3 tier"
+
+# NVIDIA 8GB → T2 (8B model)
+_parse_llmfit_output "$(cat "$FIXTURES_DIR/nvidia-8gb.json")"
+_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3-8B-Q4_K_M.gguf"  "nvidia-8gb maps to T2 GGUF"
+_assert_eq "$LLMFIT_ODS_TIER" "T2"                      "nvidia-8gb maps to T2 tier"
+
+# AMD Strix Halo → T3 or T4 depending on fixture
+_parse_llmfit_output "$(cat "$FIXTURES_DIR/amd-strix-halo.json")"
+_assert_eq "$LLMFIT_ODS_TIER" "T3" "strix-halo maps to T3 tier"
+
+# Apple M3 16GB → T2
+_parse_llmfit_output "$(cat "$FIXTURES_DIR/apple-m3-16gb.json")"
+_assert_eq "$LLMFIT_ODS_TIER" "T2" "apple-m3-16gb maps to T2 tier"
+
+# CPU only → T1
+_parse_llmfit_output "$(cat "$FIXTURES_DIR/cpu-only.json")"
+_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3-1.7B-Q4_K_M.gguf" "cpu-only maps to T1 GGUF"
+_assert_eq "$LLMFIT_ODS_TIER" "T1"                       "cpu-only maps to T1 tier"
+
+# Malformed JSON → returns 1, no crash
+_parse_llmfit_output '{"broken":' && {
+    echo "[FAIL] malformed JSON should return 1"
+    exit 1
+} || echo "[PASS] malformed JSON returns 1 cleanly"
+
+# Empty recommendations → returns 1, no crash
+_parse_llmfit_output '{"recommendations":[]}' && {
+    echo "[FAIL] empty recommendations should return 1"
+    exit 1
+} || echo "[PASS] empty recommendations returns 1 cleanly"
+
+# Unmapped model → returns 1, falls back
+_parse_llmfit_output '{"recommendations":[{"model_id":"unknown/model","quantization":"Q4_K_M","estimated_tokens_per_sec":10}]}' && {
+    echo "[FAIL] unmapped model should return 1"
+    exit 1
+} || echo "[PASS] unmapped model returns 1 cleanly"
+
+echo ""
+echo "[PASS] All llmfit-advisor tests passed ($(ls "$FIXTURES_DIR"/*.json | wc -l) fixtures)"

--- a/ods/tests/test-llmfit-advisor.sh
+++ b/ods/tests/test-llmfit-advisor.sh
@@ -19,17 +19,17 @@ _assert_eq() {
 
 # Test each hardware fixture maps to expected ODS GGUF + tier
 
-# NVIDIA 24GB → T3 (14B model fits)
+# NVIDIA 24GB → T3
 _parse_llmfit_output "$(cat "$FIXTURES_DIR/nvidia-24gb.json")"
-_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3-14B-Q4_K_M.gguf" "nvidia-24gb maps to T3 GGUF"
+_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3-30B-A3B-Q4_K_M.gguf" "nvidia-24gb maps to T3 GGUF"
 _assert_eq "$LLMFIT_ODS_TIER" "T3"                      "nvidia-24gb maps to T3 tier"
 
-# NVIDIA 8GB → T2 (8B model)
+# NVIDIA 8GB → T2
 _parse_llmfit_output "$(cat "$FIXTURES_DIR/nvidia-8gb.json")"
-_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3-8B-Q4_K_M.gguf"  "nvidia-8gb maps to T2 GGUF"
+_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3.5-9B-Q4_K_M.gguf"  "nvidia-8gb maps to T2 GGUF"
 _assert_eq "$LLMFIT_ODS_TIER" "T2"                      "nvidia-8gb maps to T2 tier"
 
-# AMD Strix Halo → T3 or T4 depending on fixture
+# AMD Strix Halo → T3
 _parse_llmfit_output "$(cat "$FIXTURES_DIR/amd-strix-halo.json")"
 _assert_eq "$LLMFIT_ODS_TIER" "T3" "strix-halo maps to T3 tier"
 
@@ -39,7 +39,7 @@ _assert_eq "$LLMFIT_ODS_TIER" "T2" "apple-m3-16gb maps to T2 tier"
 
 # CPU only → T1
 _parse_llmfit_output "$(cat "$FIXTURES_DIR/cpu-only.json")"
-_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3-1.7B-Q4_K_M.gguf" "cpu-only maps to T1 GGUF"
+_assert_eq "$LLMFIT_ODS_GGUF" "Qwen3.5-2B-Q4_K_M.gguf" "cpu-only maps to T1 GGUF"
 _assert_eq "$LLMFIT_ODS_TIER" "T1"                       "cpu-only maps to T1 tier"
 
 # Malformed JSON → returns 1, no crash
@@ -59,6 +59,44 @@ _parse_llmfit_output '{"recommendations":[{"model_id":"unknown/model","quantizat
     echo "[FAIL] unmapped model should return 1"
     exit 1
 } || echo "[PASS] unmapped model returns 1 cleanly"
+
+# Regression: every ods_gguf_file in llmfit map must exist in model-library.json
+_test_catalog_alignment() {
+    local model_library="$ROOT_DIR/config/model-library.json"
+    local model_map="$ROOT_DIR/config/llmfit-model-map.json"
+
+    python3 - "$model_map" "$model_library" << 'EOF'
+import sys, json
+
+map_path, library_path = sys.argv[1], sys.argv[2]
+
+with open(map_path) as f:
+    mappings = json.load(f)['mappings']
+with open(library_path) as f:
+    library = json.load(f)
+
+# Extract all gguf filenames from model-library.json
+# Adjust key names to match actual schema
+library_ggufs = set()
+for entry in library.get('models', library if isinstance(library, list) else []):
+    gguf = entry.get('gguf_file') or entry.get('filename') or entry.get('gguf')
+    if gguf:
+        library_ggufs.add(gguf)
+
+failed = False
+for m in mappings:
+    gguf = m['ods_gguf_file']
+    if gguf not in library_ggufs:
+        print(f"FAIL: {gguf} not found in model-library.json")
+        failed = True
+
+if failed:
+    sys.exit(1)
+print("PASS: all ods_gguf_file entries present in model-library.json")
+EOF
+}
+
+_test_catalog_alignment
 
 echo ""
 echo "[PASS] All llmfit-advisor tests passed ($(ls "$FIXTURES_DIR"/*.json | wc -l) fixtures)"


### PR DESCRIPTION
## Summary

Adds llmfit as an optional advisor layer in the hardware detection
pipeline. When the llmfit binary is present and returns a recommendation
that maps to a known ODS GGUF, the installer can use that instead of
the static tier map. Falls back silently to the existing tier map if
llmfit is absent, times out, or returns an unmapped model.

This is Option B from the issue: JSON model-map parity proof without
making installs depend on a new external binary unconditionally.

Closes #226

## Changes

- `ods/config/llmfit-model-map.json` — maps llmfit HuggingFace model
  IDs to ODS GGUF catalog entries per hardware class, pinned to
  llmfit v0.4.2
- `ods/scripts/llmfit-advisor.sh` — pure advisor, fallback-safe,
  never writes to disk or .env
- `ods/tests/fixtures/llmfit/` — 5 representative JSON output
  fixtures: NVIDIA 24GB, NVIDIA 8GB, AMD Strix Halo, Apple M3 16GB,
  CPU-only
- `ods/tests/test-llmfit-advisor.sh` — fixture-based parity tests
  plus resilience tests for malformed JSON, empty recommendations,
  and unmapped models

## What is NOT changed

- Existing tier map, capability profile schema, compose overlay
  selection — all unchanged
- llmfit is never a hard dependency — absent binary is a silent
  no-op, install proceeds normally
- No changes to any installer phase scripts in this PR — advisor
  integration into resolve-tier-config.sh is a follow-up once
  parity is confirmed

## Testing

- [ ] `bash -n` passes on all new .sh files
- [ ] `shellcheck -x -S warning` passes on all new .sh files
- [ ] `bash ods/tests/test-llmfit-advisor.sh` — all assertions pass
- [ ] `bash ods/tests/test-generated-config-contracts.sh` passes
- [ ] `bash ods/tests/test-golden-paths.sh` passes
- [ ] `python3 -c "import json; json.load(open(...))"` — model map
  JSON is valid
  
## Notes For Reviewers

Note: the current model map covers GGUF filename and tier mapping. URL, checksum, and context window fields are intentionally deferred to the follow-up PR that integrates the advisor into resolve-tier-config.sh, where those values are already managed by the existing tier config.
