### PR TITLE
[codex] Treat unconfigured LiveKit as optional for voice status

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/voice.py
+++ b/ods/extensions/services/dashboard-api/routers/voice.py
@@ -46,7 +46,12 @@ async def voice_status(api_key: str = Depends(verify_api_key)):
     else:
         services_status["livekit"] = {"status": "not_configured"}
 
-    all_healthy = all(s.get("status") == "healthy" for s in services_status.values())
+    availability_statuses = [
+        status
+        for service, status in services_status.items()
+        if not (service == "livekit" and status.get("status") == "not_configured")
+    ]
+    all_healthy = all(s.get("status") == "healthy" for s in availability_statuses)
 
     return {
         "available": all_healthy,

--- a/ods/extensions/services/dashboard-api/tests/test_voice.py
+++ b/ods/extensions/services/dashboard-api/tests/test_voice.py
@@ -1,0 +1,71 @@
+"""Tests for voice status endpoints."""
+
+from types import SimpleNamespace
+
+
+def test_voice_status_available_when_required_services_healthy_without_livekit(
+    test_client,
+    monkeypatch,
+):
+    """LiveKit is optional and must not make healthy STT/TTS unavailable."""
+    import config
+    import helpers
+
+    monkeypatch.setattr(
+        config,
+        "SERVICES",
+        {
+            "whisper": {"name": "Whisper", "port": 8000},
+            "tts": {"name": "Kokoro", "port": 8880},
+        },
+    )
+
+    async def healthy(service_id, cfg):
+        return SimpleNamespace(status="healthy")
+
+    monkeypatch.setattr(helpers, "check_service_health", healthy)
+
+    resp = test_client.get("/api/voice/status", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["available"] is True
+    assert payload["services"]["stt"]["status"] == "healthy"
+    assert payload["services"]["tts"]["status"] == "healthy"
+    assert payload["services"]["livekit"]["status"] == "not_configured"
+    assert payload["message"] == "All voice services operational"
+
+
+def test_voice_status_unavailable_when_configured_livekit_is_unhealthy(
+    test_client,
+    monkeypatch,
+):
+    """A configured LiveKit service still participates in health aggregation."""
+    import config
+    import helpers
+
+    monkeypatch.setattr(
+        config,
+        "SERVICES",
+        {
+            "whisper": {"name": "Whisper", "port": 8000},
+            "tts": {"name": "Kokoro", "port": 8880},
+            "livekit": {"name": "LiveKit", "port": 7880},
+        },
+    )
+
+    async def health(service_id, cfg):
+        status = "unhealthy" if service_id == "livekit" else "healthy"
+        return SimpleNamespace(status=status)
+
+    monkeypatch.setattr(helpers, "check_service_health", health)
+
+    resp = test_client.get("/api/voice/status", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["available"] is False
+    assert payload["services"]["stt"]["status"] == "healthy"
+    assert payload["services"]["tts"]["status"] == "healthy"
+    assert payload["services"]["livekit"]["status"] == "unhealthy"
+    assert payload["message"] == "Some voice services unavailable"


### PR DESCRIPTION
﻿## Summary

Fixes `/api/voice/status` so an unconfigured optional LiveKit service does not make core voice availability report `available: false` when required STT/TTS services are healthy.

Before this change, the endpoint included `livekit: not_configured` in the same `all_healthy` aggregation as Whisper and TTS. That made a normal install without LiveKit look partially unavailable even when the required voice path was healthy.

The endpoint still reports LiveKit as `not_configured`, and a configured but unhealthy LiveKit service still makes the aggregate unavailable.

## AI Assistance

AI assistance was used to inspect the existing router behavior, write the regression tests first, implement the narrow fix, and run validation. The human author remains responsible for reading the diff and responding to review.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A; this targets mainline dashboard API behavior.
```

## Changed Surface

- [ ] Docs only
- [x] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because:

Commands/results:

```text
# Regression test red before implementation
python -m pytest tests/test_voice.py::test_voice_status_available_when_required_services_healthy_without_livekit
FAILED: assert payload["available"] is True; actual False

# Focused tests after implementation
python -m pytest tests/test_voice.py tests/test_main.py
68 passed, 1 warning in 1.72s

# Whitespace check
git diff --check
passed

# Broader dashboard-api suite attempt on Windows
python -m pytest tests
1177 passed, 1 skipped, 1 warning, 2 failed in 253.52s

Failures were in tests/test_setup_sentinel.py, where temporary scripts with #!/bin/bash execute through the Windows endpoint path and return FAIL sentinels. Re-running tests/test_setup_sentinel.py with Git Bash in PATH produced the same 2 failures, so these appear unrelated to this voice-status change.
```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

This only changes aggregation logic for `/api/voice/status`. It does not start, stop, configure, or mutate any services. LiveKit remains visible in the response as `not_configured`; it simply no longer blocks the core voice availability flag when absent.
