### PR TITLE
fix(health): warn on GPU memory pressure, not utilization

### DIFF
--- a/ods/scripts/health-check.sh
+++ b/ods/scripts/health-check.sh
@@ -195,8 +195,16 @@ test_gpu() {
             result_set "gpu_util" "${gpu_util// /}"
             result_set "gpu_temp" "${temp// /}"
 
-            # Warn if GPU memory > 95% or temp > 80C
-            if [ "$(result_get "gpu_util")" -gt 95 ] 2>/dev/null; then
+            # Warn if GPU memory > 95% (approaching OOM) or temp > 80C.
+            # Deliberately NOT based on utilization: a llama-server doing
+            # inference legitimately pins the GPU at ~100% util, so a
+            # util-based warning would fire during normal, healthy load.
+            local mem_used mem_total
+            mem_used="$(result_get "gpu_mem_used")"
+            mem_total="$(result_get "gpu_mem_total")"
+            if [[ "$mem_used" =~ ^[0-9]+$ && "$mem_total" =~ ^[0-9]+$ ]] \
+                && [ "$mem_total" -gt 0 ] \
+                && [ $(( mem_used * 100 / mem_total )) -gt 95 ]; then
                 result_set "gpu" "warn"
             fi
             if [ "$(result_get "gpu_temp")" -gt 80 ] 2>/dev/null; then

--- a/ods/tests/test-health-check.sh
+++ b/ods/tests/test-health-check.sh
@@ -103,6 +103,42 @@ else
     fail "check_container_state missing docker availability check"
 fi
 
+# Helper: run health-check.sh --json with a mock nvidia-smi that reports
+# "mem_used, mem_total, util, temp" and echo the resulting gpu status.
+_gpu_status_with_mock() {
+    local csv="$1" mock_dir gpu_json
+    mock_dir=$(mktemp -d)
+    {
+        echo '#!/usr/bin/env bash'
+        echo "echo '$csv'"
+    } > "$mock_dir/nvidia-smi"
+    chmod +x "$mock_dir/nvidia-smi"
+    set +e
+    gpu_json=$(cd "$ROOT_DIR" && PATH="$mock_dir:$PATH" bash scripts/health-check.sh --json 2>&1)
+    set -e
+    rm -rf "$mock_dir"
+    echo "$gpu_json" | grep -o '"gpu": "[^"]*"' | head -1
+}
+
+# 8. A fully-utilized GPU with low memory must NOT warn. An LLM server pins
+# util at ~100% during normal inference; the old util>95 check flagged that
+# healthy state as "warn". Memory is only 8% here, so status must be "ok".
+gpu_busy=$(_gpu_status_with_mock "2048, 24576, 100, 60")
+if echo "$gpu_busy" | grep -q '"gpu": "ok"'; then
+    pass "test_gpu does not warn on 100% utilization when memory is low"
+else
+    fail "test_gpu warned on healthy high-util GPU; got: ${gpu_busy:-<none>}"
+fi
+
+# 9. High memory pressure (>95%) SHOULD warn — the OOM signal the probe means
+# to surface. 24000/24576 = 97%.
+gpu_full=$(_gpu_status_with_mock "24000, 24576, 30, 60")
+if echo "$gpu_full" | grep -q '"gpu": "warn"'; then
+    pass "test_gpu warns when GPU memory exceeds 95%"
+else
+    fail "test_gpu did not warn on >95% memory; got: ${gpu_full:-<none>}"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

`test_gpu` in `scripts/health-check.sh` warned when `utilization.gpu > 95%`, but the inline comment documents the intent as **"GPU memory > 95%"**. For a local LLM server the two signals are very different:

- A `llama-server` actively serving inference **legitimately pins GPU utilization at ~100%**. The util-based check therefore flagged that normal, healthy state as `"warn"` on every busy poll.
- Meanwhile the signal the probe *meant* to surface — memory approaching full (OOM risk) — went unwatched.

This PR computes memory usage from the already-collected `memory.used`/`memory.total` values and warns at `>95%`, matching the documented intent. The division is guarded against non-numeric/zero totals so the probe never errors on odd `nvidia-smi` output.

## AI Assistance

AI assistant flagged the comment/code mismatch, drafted the fix, and wrote the regression tests. Author reviewed the diff and validation.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard API / host agent  <!-- health-check.sh drives post-install checks & doctor -->
- [x] Tests only  <!-- plus the script fix above -->

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below

Commands/results:

```text
$ bash -n ods/scripts/health-check.sh ods/tests/test-health-check.sh   # clean
$ bash ods/tests/test-health-check.sh
Result: 11 passed, 0 failed

# Tests have teeth — reverting to the old util>95 check reproduces the bug:
$ (old util-based warn) bash ods/tests/test-health-check.sh
  ✗ FAIL test_gpu warned on healthy high-util GPU; got: "gpu": "warn"
  ✗ FAIL test_gpu did not warn on >95% memory; got: "gpu": "ok"
Result: 9 passed, 2 failed
```

New tests mock `nvidia-smi`: a 100%-util / 8%-memory GPU must stay `"ok"`, and a 97%-memory GPU must `"warn"`.

## Operational Change Check

- [x] This is an operational change and validation is recorded above.  <!-- narrower equivalent: change is isolated to test_gpu's warn heuristic and covered by the health-check unit suite; no service/network/runtime surface touched -->

## Notes For Reviewers

Behavior change is intentional and narrow: it only affects when the GPU probe reports `warn` (a soft, non-critical status). If you'd actually prefer a *separate* high-utilization notice in addition to the memory warning, happy to add that — but a busy GPU on an inference box shouldn't read as a warning by itself.