### PR TITLE
fix(dashboard-api): honor client timeout on Lemonade requests

### DIFF
--- a/ods/extensions/services/dashboard-api/lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/lemonade_client.py
@@ -145,13 +145,18 @@ class LemonadeClient:
         timeout: Optional[float] = None,
     ) -> dict[str, Any]:
         client = await self._ensure_client()
+        # httpx treats an explicit `timeout=None` as "no timeout" rather than
+        # "use the client default", so passing None here would silently disable
+        # the client's configured timeout on every core request. Fall back to
+        # the client default sentinel unless the caller overrides it.
+        request_timeout = httpx.USE_CLIENT_DEFAULT if timeout is None else timeout
         try:
             response = await client.request(
                 method,
                 self.api_url(path),
                 json=json,
                 headers=self.auth_headers(),
-                timeout=timeout,
+                timeout=request_timeout,
             )
             response.raise_for_status()
             payload = response.json() if response.content else {}

--- a/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_lemonade_client.py
@@ -123,3 +123,51 @@ async def test_http_status_errors_are_classified():
     assert exc.value.status_code == 401
     assert "missing bearer" in str(exc.value)
     await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_requests_inherit_client_timeout():
+    # Regression: _request_json must not pass an explicit timeout=None. httpx
+    # reads that as "no timeout" and would silently disable the client's
+    # configured timeout on every core call, so a hung Lemonade backend would
+    # hang the request forever instead of failing fast.
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["timeout"] = request.extensions.get("timeout")
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler), timeout=20.0)
+    adapter = LemonadeClient(
+        LemonadeSettings(base_url="http://lemonade:13305"),
+        client=client,
+    )
+
+    await adapter.health()
+    await client.aclose()
+
+    assert seen["timeout"] is not None, "request must carry a resolved timeout"
+    assert seen["timeout"].get("read") == 20.0, (
+        f"core requests must inherit the client timeout, got {seen['timeout']}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_timeout_override_is_applied():
+    # An explicit per-request timeout still wins over the client default.
+    seen = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["timeout"] = request.extensions.get("timeout")
+        return httpx.Response(200, json={"status": "ok"})
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler), timeout=20.0)
+    adapter = LemonadeClient(
+        LemonadeSettings(base_url="http://lemonade:13305"),
+        client=client,
+    )
+
+    await adapter._request_json("GET", "health", timeout=5.0)
+    await client.aclose()
+
+    assert seen["timeout"].get("read") == 5.0


### PR DESCRIPTION
## Summary

`LemonadeClient._request_json` passed `timeout=timeout` to httpx, and that parameter defaults to `None`. **httpx treats an explicit `timeout=None` as "no timeout"** — not "use the client default". So every core call that doesn't pass an explicit timeout — `health`, `stats`, `models`, `chat_completion`, `embeddings`, `rerank` — ran with the client's configured **20s timeout silently disabled**.

Impact: a Lemonade (AMD) backend that accepts the TCP connection but never responds would hang the dashboard-api request **indefinitely** instead of failing fast and returning a classified `timeout` error. `helpers.py` already avoids this by adding `timeout` conditionally; this client didn't.

Fix: fall back to `httpx.USE_CLIENT_DEFAULT` when the caller doesn't override the timeout, so the client-configured timeout applies. An explicit per-request timeout still wins.

## AI Assistance

AI assistant identified the httpx `timeout=None` semantics, verified them empirically, drafted the one-line fix, and wrote the regression tests. Author reviewed the diff and validation.

## Release Lane

- [x] Mainline change targeting `main`

## Changed Surface

- [x] Dashboard API / host agent
- [x] Model routing / Hermes / capabilities  <!-- Lemonade provider-mode client -->

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below

Commands/results:

```text
$ pytest tests/test_lemonade_client.py -q
9 passed

# httpx behavior verified empirically (httpx 0.28.1):
omit / USE_CLIENT_DEFAULT -> {'connect': 20.0, 'read': 20.0, 'write': 20.0, 'pool': 20.0}
explicit None (old bug)   -> {'connect': None, 'read': None, 'write': None, 'pool': None}

# New test has teeth — reverting the fix reproduces the bug:
$ (old timeout=None) pytest tests/test_lemonade_client.py -q
FAILED test_requests_inherit_client_timeout
  AssertionError: core requests must inherit the client timeout,
  got {'connect': None, 'read': None, 'write': None, 'pool': None}
1 failed, 8 passed
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.  <!-- narrower equivalent: isolated to the Lemonade client's request timeout resolution; fully covered by the unit suite with a MockTransport that inspects the resolved per-request timeout. No network/compose/auth surface touched. -->

## Notes For Reviewers

One-line behavior fix + two tests. The tests assert the resolved per-request timeout via `request.extensions["timeout"]` under `httpx.MockTransport`: the default path must inherit the client's 20s, and an explicit `_request_json(..., timeout=5.0)` override must still apply.