### PR TITLE
fix(env): strip trailing CR when loading CRLF .env files

### DIFF
--- a/ods/lib/safe-env.sh
+++ b/ods/lib/safe-env.sh
@@ -16,6 +16,11 @@ load_env_file() {
     [[ -f "$path" ]] || return 0
     local line key value
     while IFS= read -r line || [[ -n "$line" ]]; do
+        # Strip a trailing CR so CRLF .env files (Windows editors, the Windows
+        # installer) don't leave carriage returns on every value — which would
+        # otherwise corrupt ports/paths (e.g. 8080\r) and leave the closing
+        # quote unstripped on quoted values. Matches load_env_from_output.
+        line="${line%$'\r'}"
         # Skip comments and blank lines
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
         [[ "$line" =~ ^[[:space:]]*$ ]] && continue

--- a/ods/tests/test-safe-env.sh
+++ b/ods/tests/test-safe-env.sh
@@ -111,5 +111,16 @@ load_env_file "$tmpdir/.env-readonly"
 [[ "${AFTER_READONLY_UID:-}" == "still_loads" ]] || fail "load_env_file stopped after readonly UID"
 pass "load_env_file tolerates UID from .env"
 
+echo "Test 11: load_env_file tolerates CRLF .env files (Windows/WSL2)"
+unset CRLF_PORT CRLF_PATH CRLF_QUOTED 2>/dev/null || true
+# Write a .env with Windows CRLF line endings. Without stripping the trailing
+# CR, values keep it (8080\r) and the closing quote survives on quoted values.
+printf 'CRLF_PORT=8080\r\nCRLF_PATH=/home/user/ods\r\nCRLF_QUOTED="abc123"\r\n' > "$tmpdir/.env-crlf"
+load_env_file "$tmpdir/.env-crlf"
+[[ "${CRLF_PORT:-}" == "8080" ]] || fail "CRLF_PORT has trailing CR (got len ${#CRLF_PORT}: '${CRLF_PORT:-}')"
+[[ "${CRLF_PATH:-}" == "/home/user/ods" ]] || fail "CRLF_PATH has trailing CR (got: '${CRLF_PATH:-}')"
+[[ "${CRLF_QUOTED:-}" == "abc123" ]] || fail "CRLF_QUOTED not unquoted/stripped (got: '${CRLF_QUOTED:-}')"
+pass "load_env_file strips trailing CR from CRLF .env values"
+
 echo ""
 echo "All safe-env tests passed."


### PR DESCRIPTION
## Summary

`load_env_file` in `lib/safe-env.sh` reads each line with `read -r` but **never strips a trailing carriage return**. A `.env` saved with Windows CRLF line endings — a Windows editor, or the Windows installer writing the file — therefore leaves a `\r` on every value:

- ports/paths get corrupted: `LLM_PORT=8080\r`, `INSTALL_DIR=/home/user/ods\r`
- **quoted values keep their closing quote**, because the CR sits between the `"` and end-of-line, defeating the quote-strip: `WEBUI_SECRET="abc123"` → `abc123"\r`

`load_env_file` is the canonical `.env` parser used by `health-check.sh`, the installer phases, compose selection (`compose-select.sh`), and the CLI — so this affects the whole stack on Windows/WSL2, a supported platform.

Its sibling functions `load_env_from_output` and `load_env_from_output_allowlist` **already** strip the CR (`line="${line%$'\r'}"`), and there's an existing test for that path — `load_env_file` was simply missed. This adds the same one-line strip and a matching regression test.

## AI Assistance

AI assistant found the gap (CR stripped in the stdin parsers but not the file parser), reproduced it, wrote the fix and the regression test. Author reviewed the diff and validation.

## Release Lane

- [x] Mainline change targeting `main`
- [ ] Stable hotfix targeting `release/2.5.x`

Stable hotfix reason:

```text
Arguably qualifies — this is a current-stable correctness bug for Windows/WSL2 users. Deferring lane choice to maintainers; flagged here.
```

## Changed Surface

- [x] Installer / bootstrap / lifecycle  <!-- shared .env loader used across installer + CLI + health-check -->
- [x] Tests only  <!-- plus the one-line lib fix above -->

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below

Commands/results:

```text
$ bash -n ods/lib/safe-env.sh ods/tests/test-safe-env.sh   # clean
$ bash ods/tests/test-safe-env.sh
All safe-env tests passed.          # 11 tests incl. new CRLF case
$ bash ods/tests/test-windows-env-dotfile-recovery.sh
Result: 22 passed, 0 failed

# New test has teeth — reverting the fix reproduces the bug:
$ (old, no CR strip) bash ods/tests/test-safe-env.sh
[FAIL] CRLF_PORT has trailing CR (got len 5: '8080')   # i.e. "8080\r"
```

## Operational Change Check

- [x] This is an operational change and validation is recorded above.  <!-- narrower equivalent: change is one line in the shared env parser, covered by the safe-env unit suite (incl. the new CRLF case) and the Windows env-dotfile recovery suite. Behavior is unchanged for LF files. -->

## Notes For Reviewers

Behavior is identical for normal LF `.env` files (stripping a non-existent trailing `\r` is a no-op). The fix only changes CRLF handling, bringing `load_env_file` in line with the CR-stripping the two `load_env_from_output*` functions already do in the same file.