### PR TITLE
fix(dashboard-api): return invalid_range for calendar-invalid usage dates

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -49,8 +49,13 @@ def _date_range(start_day: date, end_day: date) -> list[str]:
 
 
 def _empty_report(start: str, end: str, status: str = "unavailable", detail: str | None = None) -> dict[str, Any]:
-    start_day = _parse_date(start)
-    end_day = _parse_date(end)
+    # The route's regex gate only checks the YYYY-MM-DD shape, so this is also
+    # reached with calendar-invalid dates (month 13, Feb 30) when reporting an
+    # invalid_range status. Those can't produce daily buckets — return none.
+    try:
+        days = _date_range(_parse_date(start), _parse_date(end))
+    except ValueError:
+        days = []
     return {
         "period": {"start": start, "end": end},
         "source": {
@@ -83,7 +88,7 @@ def _empty_report(start: str, end: str, status: str = "unavailable", detail: str
                 "cache_read_tokens": 0,
                 "cache_write_tokens": 0,
             }
-            for day in _date_range(start_day, end_day)
+            for day in days
         ],
         "models": [],
         "services": [],
@@ -556,7 +561,7 @@ async def usage_report(
         start_day = _parse_date(start)
         end_day = _parse_date(end)
     except ValueError:
-        return _empty_report(start, end, status="invalid_range", detail="Dates must use YYYY-MM-DD")
+        return _empty_report(start, end, status="invalid_range", detail="Dates must be valid YYYY-MM-DD calendar dates")
     if end_day < start_day:
         return _empty_report(start, end, status="invalid_range", detail="end must be on or after start")
 

--- a/ods/extensions/services/dashboard-api/tests/test_usage.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage.py
@@ -271,6 +271,22 @@ def test_usage_report_rejects_reversed_date_range(test_client):
     assert data["source"]["detail"] == "end must be on or after start"
 
 
+def test_usage_report_rejects_calendar_invalid_dates(test_client):
+    # Month 13 and Feb 30 pass the route's YYYY-MM-DD regex but are not real
+    # dates; the endpoint must answer with invalid_range, not crash with 500.
+    for query in ("start=2026-13-01&end=2026-13-02", "start=2026-02-30&end=2026-03-01"):
+        resp = test_client.get(
+            f"/api/usage/report?{query}",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["source"]["status"] == "invalid_range"
+        assert data["source"]["detail"] == "Dates must be valid YYYY-MM-DD calendar dates"
+        assert data["daily"] == []
+
+
 def test_usage_report_surfaces_local_runtime_counters_without_date_bucketing(test_client, monkeypatch):
     import routers.usage as usage_router
 


### PR DESCRIPTION
## Problem

`GET /api/usage/report` gates `start`/`end` with a shape-only regex (`^\d{4}-\d{2}-\d{2}$`), so calendar-invalid dates such as `2026-13-01` (month 13) or `2026-02-30` (Feb 30) reach the handler. The handler catches the `ValueError` from `date.fromisoformat` and intends to answer with a clean `invalid_range` empty report — but `_empty_report` **re-parses the same invalid dates** to build the `daily` buckets, raising `ValueError` a second time outside the guard:

```
GET /api/usage/report?start=2026-13-01&end=2026-13-02  →  500 Internal Server Error
```

The reversed-range path (`end < start`) already returns the graceful payload, so the UI contract clearly intends a 200 + `invalid_range` here too.

## Fix

`_empty_report` builds the `daily` bucket list only when both dates parse; unparseable dates yield an empty `daily` list. Narrow `except ValueError` mapping to one distinct outcome (invalid dates → no daily buckets), per the repo's error-handling rules. Also reworded the detail to "Dates must be valid YYYY-MM-DD calendar dates" since the failing inputs *do* match the YYYY-MM-DD shape.

## Verification

- Repro before fix: `start=2026-13-01` and `start=2026-02-30` both → HTTP 500. After fix: HTTP 200 with `source.status == "invalid_range"` and `daily == []` (verified via live `TestClient` against the full app).
- New regression test `test_usage_report_rejects_calendar_invalid_dates` covers both inputs.
- `pytest tests/test_usage.py`: **17/17 passed**.
- Full dashboard-api suite: **1167 passed**, 9 skipped; the 3 failures (`test_setup_sentinel`, `test_scan_symlink_skipped`) pre-exist on clean `main` in my Windows environment (bash/symlink dependent) and are untouched by this diff.