### PR TITLE
fix(backup): make list, retention, and delete manage the script's own backups

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -135,6 +135,24 @@ ensure_backup_space() {
     fi
 }
 
+# Collect backup entries (dirs or .tar.gz archives) under BACKUP_ROOT into
+# the global COLLECTED_BACKUPS array, newest first.
+#
+# Backup IDs are YYYYMMDD-HHMMSS (this script) or <prefix>-YYYYMMDD-HHMMSS
+# (dashboard/host-agent). Match that shape explicitly: retention deletes
+# whatever this collects, so an operator's unrelated files in the backup
+# directory must never qualify.
+COLLECTED_BACKUPS=()
+collect_backups() {
+    COLLECTED_BACKUPS=()
+    local entry base
+    while IFS= read -r -d '' entry; do
+        base=$(basename "$entry")
+        [[ "$base" =~ ^([A-Za-z0-9_]+-)?[0-9]{8}-[0-9]{6}(\.tar\.gz)?$ ]] || continue
+        COLLECTED_BACKUPS+=("$entry")
+    done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
+}
+
 # Show usage
 usage() {
     cat << EOF
@@ -180,12 +198,9 @@ list_backups() {
         return 0
     fi
 
-    local backups=()
-    while IFS= read -r -d '' backup; do
-        backups+=("$backup")
-    done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -name "*-*-*" -print0 2>/dev/null | sort -z -r)
+    collect_backups
 
-    if [[ ${#backups[@]} -eq 0 ]]; then
+    if [[ ${#COLLECTED_BACKUPS[@]} -eq 0 ]]; then
         log_info "No backups found"
         return 0
     fi
@@ -196,7 +211,7 @@ list_backups() {
     printf "%-20s %-12s %-10s %s\n" "ID" "Type" "Size" "Description"
     echo "───────────────────────────────────────────────────────────────────"
 
-    for backup in "${backups[@]}"; do
+    for backup in "${COLLECTED_BACKUPS[@]}"; do
         local id
         id=$(basename "$backup")
         local backup_type="unknown"
@@ -234,17 +249,23 @@ delete_backup() {
         return 1
     fi
 
-    local backup_dir="$BACKUP_ROOT/$backup_id"
+    local target="$BACKUP_ROOT/$backup_id"
 
-    if [[ ! -d "$backup_dir" ]]; then
+    # Compressed backups are .tar.gz files, not directories; also accept the
+    # bare ID for an archive-only backup.
+    if [[ ! -e "$target" && -f "$target.tar.gz" ]]; then
+        target="$target.tar.gz"
+    fi
+
+    if [[ ! -e "$target" ]]; then
         log_error "Backup not found: $backup_id"
         return 1
     fi
 
-    read -rp "Are you sure you want to delete backup $backup_id? [y/N] " confirm
+    read -rp "Are you sure you want to delete backup $(basename "$target")? [y/N] " confirm
     if [[ "$confirm" =~ ^[Yy]$ ]]; then
-        rm -rf "$backup_dir"
-        log_success "Deleted backup: $backup_id"
+        rm -rf "$target"
+        log_success "Deleted backup: $(basename "$target")"
     else
         log_info "Deletion cancelled"
     fi
@@ -413,18 +434,15 @@ backup_cache() {
 apply_retention() {
     log_info "Applying retention policy (keeping last $RETENTION_COUNT backups)..."
 
-    local backups=()
-    while IFS= read -r -d '' backup; do
-        backups+=("$backup")
-    done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -name "*-*-*" -print0 2>/dev/null | sort -z -r)
+    collect_backups
 
-    local count=${#backups[@]}
+    local count=${#COLLECTED_BACKUPS[@]}
     if [[ $count -gt $RETENTION_COUNT ]]; then
         local to_delete=$((count - RETENTION_COUNT))
         log_info "Removing $to_delete old backup(s)..."
 
         for ((i=RETENTION_COUNT; i<count; i++)); do
-            local old_backup="${backups[$i]}"
+            local old_backup="${COLLECTED_BACKUPS[$i]}"
             log_warn "Removing old backup: $(basename "$old_backup")"
             rm -rf "$old_backup"
         done

--- a/ods/tests/test-backup-integrity.sh
+++ b/ods/tests/test-backup-integrity.sh
@@ -27,6 +27,10 @@ FAKE_ODS="$TMP_ROOT/ods"
 mkdir -p "$FAKE_ODS/data/open-webui"
 mkdir -p "$FAKE_ODS/config"
 
+# ods-backup.sh sources lib/rsync.sh relative to ODS_DIR
+mkdir -p "$FAKE_ODS/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$FAKE_ODS/lib/"
+
 # Required by create_manifest()
 echo "test" > "$FAKE_ODS/.version"
 
@@ -62,3 +66,43 @@ if [[ $rc -eq 0 ]]; then
 fi
 
 pass "verify fails after tampering"
+
+# ── Lifecycle: list, retention, and delete must see the script's own IDs ──
+# Backup IDs are YYYYMMDD-HHMMSS (one hyphen); a glob requiring two hyphens
+# regressed list/retention into ignoring every backup this script creates.
+
+LIFECYCLE_DIR="$TMP_ROOT/lifecycle-backups"
+mkdir -p "$LIFECYCLE_DIR"
+
+# Six pre-existing backups in the script's own ID format, plus operator
+# debris that retention must never delete.
+for i in 1 2 3 4 5 6; do
+  d="$LIFECYCLE_DIR/2026010${i}-00000${i}"
+  mkdir -p "$d"
+  echo '{"backup_type": "user-data", "description": "old"}' > "$d/manifest.json"
+done
+mkdir -p "$LIFECYCLE_DIR/my-notes"
+
+info "Listing pre-existing backups"
+list_out=$(ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$LIFECYCLE_DIR" --list)
+echo "$list_out" | grep -q "20260101-000001" || fail "--list does not show own-format backup IDs"
+if echo "$list_out" | grep -q "my-notes"; then
+  fail "--list shows non-backup directories"
+fi
+pass "--list shows own-format backup IDs and skips other directories"
+
+info "Running backup with RETENTION_COUNT=5"
+ODS_DIR="$FAKE_ODS" RETENTION_COUNT=5 "$ODS_BACKUP" --output "$LIFECYCLE_DIR" --type config >/dev/null
+
+[[ ! -d "$LIFECYCLE_DIR/20260101-000001" ]] || fail "retention kept the oldest backup beyond RETENTION_COUNT"
+[[ ! -d "$LIFECYCLE_DIR/20260102-000002" ]] || fail "retention kept the second-oldest backup beyond RETENTION_COUNT"
+[[ -d "$LIFECYCLE_DIR/20260103-000003" ]] || fail "retention deleted a backup inside RETENTION_COUNT"
+[[ -d "$LIFECYCLE_DIR/my-notes" ]] || fail "retention deleted an unrelated directory"
+pass "retention prunes oldest own-format backups and leaves other directories"
+
+info "Deleting a compressed backup by bare ID"
+(cd "$LIFECYCLE_DIR" && mkdir -p 20260601-120000 && echo x > 20260601-120000/f \
+  && tar czf 20260601-120000.tar.gz 20260601-120000 && rm -rf 20260601-120000)
+echo y | ODS_DIR="$FAKE_ODS" "$ODS_BACKUP" --output "$LIFECYCLE_DIR" -d 20260601-120000 >/dev/null
+[[ ! -f "$LIFECYCLE_DIR/20260601-120000.tar.gz" ]] || fail "delete left the compressed backup behind"
+pass "delete removes compressed backups by bare ID"


### PR DESCRIPTION
## Problem

`ods-backup.sh` names its backups `$(date +%Y%m%d-%H%M%S)` — **one** hyphen (e.g. `20260707-103450`). But `list_backups` and `apply_retention` discovered entries with `find -name "*-*-*"`, which requires **two** hyphens. Every backup this script creates was therefore invisible to both:

- `--list` reports **"No backups found"** immediately after a successful backup.
- `apply_retention` logs *"Applying retention policy (keeping last 5 backups)"* on every run while **never deleting anything**. Full backups include `models/` (tens of GB), so the silent unbounded growth eventually exhausts the backup disk — the exact failure the retention policy exists to prevent.

Only dashboard-initiated backups (`dashboard-YYYYMMDD-HHMMSS`, two hyphens) matched the old glob, which is presumably why this went unnoticed.

Separately, `delete_backup` only handled directories — a `.tar.gz` created with `--compress` could **never be deleted by ID** (`-d <id>` → "Backup not found").

## Fix

- Extract a shared `collect_backups` helper (used by list + retention) that matches the actual ID shapes: `YYYYMMDD-HHMMSS` with optional `<prefix>-` and `.tar.gz` suffix. Retention **deletes** what it matches, so the filter stays strict — unrelated files an operator drops into `.backups/` never qualify (covered by a test).
- `delete_backup` accepts both the bare ID and the full archive name for compressed backups.
- Bash 3.2-safe: no empty-array expansions under `set -u` (script is macOS-compatible).

## Also fixes the test harness

`tests/test-backup-integrity.sh` had been failing at source time on current `main` — `ods-backup.sh` sources `lib/rsync.sh` relative to `ODS_DIR`, and the test's fake ODS dir never had it (`line 32: .../ods/lib/rsync.sh: No such file or directory`). The harness now copies the lib in, so the pre-existing checksum/verify assertions run again.

## Verification

- New lifecycle regression tests: `--list` shows own-format IDs and skips non-backup dirs; retention prunes the oldest beyond `RETENTION_COUNT` and leaves unrelated dirs; `-d` removes a compressed backup by bare ID. Full suite: **6/6 pass**.
- Negative check: the extended test run against the unfixed script fails at `--list does not show own-format backup IDs` — the regression test bites.
- `bash -n` clean on both files. (Local runs used an `rsync` PATH stub — Git Bash has no rsync; CI/dev boxes with real rsync exercise the same paths.)