### PR TITLE
fix(restore): keep log and UI output out of command-substituted results

### DIFF
--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -128,7 +128,7 @@ list_backups() {
     local backups=()
     while IFS= read -r -d '' backup; do
         backups+=("$backup")
-    done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
+    done < <(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
 
     if [[ ${#backups[@]} -eq 0 ]]; then
         log_error "No backups found in: $BACKUP_ROOT"
@@ -178,18 +178,21 @@ list_backups() {
 }
 
 # Select backup interactively
+# The caller captures stdout (backup_id=$(select_backup)), so the table and
+# prompt go to stderr — on stdout they'd be swallowed into the captured ID
+# and the user would stare at a blank screen.
 select_backup() {
-    if ! list_backups; then
+    if ! list_backups >&2; then
         return 1
     fi
 
-    echo "Select a backup to restore (enter number):"
+    echo "Select a backup to restore (enter number):" >&2
     read -r selection
 
     local backups=()
     while IFS= read -r -d '' backup; do
         backups+=("$backup")
-    done < <(find "$BACKUP_ROOT" -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
+    done < <(find "$BACKUP_ROOT" -mindepth 1 -maxdepth 1 \( -type d -o -name "*.tar.gz" \) -print0 2>/dev/null | sort -z -r)
 
     local index=$((selection - 1))
     if [[ $index -lt 0 || $index -ge ${#backups[@]} ]]; then
@@ -201,6 +204,9 @@ select_backup() {
 }
 
 # Extract compressed backup
+# Callers capture stdout (backup_dir=$(extract_backup ...)), so every log
+# line must go to stderr — anything on stdout becomes part of the returned
+# path and breaks the restore.
 extract_backup() {
     local backup_id="$1"
     local compressed="$BACKUP_ROOT/$backup_id.tar.gz"
@@ -215,13 +221,13 @@ extract_backup() {
     if [[ -f "$compressed" ]]; then
         # Validate: reject archives with absolute paths or path traversal
         if tar -tzf "$compressed" 2>/dev/null | grep -qE '(^/|\.\./)'; then
-            log_error "Backup archive contains unsafe paths (absolute or ../) — refusing to extract"
+            log_error "Backup archive contains unsafe paths (absolute or ../) — refusing to extract" >&2
             return 1
         fi
-        log_info "Extracting compressed backup..."
+        log_info "Extracting compressed backup..." >&2
         mkdir -p "$uncompressed"
         if ! tar xzf "$compressed" --no-same-owner -C "$BACKUP_ROOT"; then
-            log_error "Failed to extract backup archive"
+            log_error "Failed to extract backup archive" >&2
             rm -rf "$uncompressed"
             return 1
         fi
@@ -229,7 +235,7 @@ extract_backup() {
         return 0
     fi
 
-    log_error "Backup not found: $backup_id"
+    log_error "Backup not found: $backup_id" >&2
     return 1
 }
 
@@ -497,7 +503,9 @@ do_restore() {
 
     # Extract if compressed
     local backup_dir
-    backup_dir=$(extract_backup "$backup_id")
+    if ! backup_dir=$(extract_backup "$backup_id"); then
+        return 1
+    fi
 
     # Validate backup (with optional checksum verification)
     if ! validate_backup "$backup_dir" "$skip_verify"; then

--- a/ods/tests/test-backup-restore-roundtrip.sh
+++ b/ods/tests/test-backup-restore-roundtrip.sh
@@ -33,6 +33,10 @@ echo "compose-content" > "$SRC/docker-compose.yml"
 echo "config-data" > "$SRC/config/settings.json"
 echo "user-data-file" > "$SRC/data/open-webui/data.txt"
 
+# Both scripts source lib/rsync.sh relative to ODS_DIR
+mkdir -p "$SRC/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$SRC/lib/"
+
 info "Creating backup from source"
 ODS_DIR="$SRC" bash "$ODS_BACKUP" --type full >/dev/null 2>&1 || fail "Backup failed"
 
@@ -45,6 +49,8 @@ pass "Backup created: $BACKUP_ID"
 DST="$TMP/dst"
 mkdir -p "$DST/data"
 mkdir -p "$DST/.backups"
+mkdir -p "$DST/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$DST/lib/"
 
 info "Restoring backup to destination"
 # Copy backup to destination's backup root
@@ -75,6 +81,41 @@ pass "All expected files/dirs present after restore"
 [[ "$(cat "$DST/data/open-webui/data.txt")" == "user-data-file" ]] || fail "data/open-webui/data.txt content mismatch"
 
 pass "All file contents match after restore"
+
+# ── Compressed round-trip ─────────────────────────────────────────────
+# extract_backup's stdout is command-substituted into the backup path, so a
+# log line leaking to stdout garbles the path and fails every .tar.gz restore.
+
+info "Creating compressed backup from source"
+ODS_DIR="$SRC" bash "$ODS_BACKUP" --type config --compress >/dev/null 2>&1 || fail "Compressed backup failed"
+
+TARBALL=$(ls -1 "$SRC/.backups"/*.tar.gz 2>/dev/null | head -n 1)
+[[ -n "$TARBALL" ]] || fail "No compressed backup created"
+CBACKUP_ID=$(basename "$TARBALL" .tar.gz)
+pass "Compressed backup created: $CBACKUP_ID.tar.gz"
+
+DST2="$TMP/dst2"
+mkdir -p "$DST2/data" "$DST2/.backups" "$DST2/lib"
+cp "$SCRIPT_DIR/../lib/rsync.sh" "$DST2/lib/"
+echo "compose-content" > "$DST2/docker-compose.yml"
+cp "$TARBALL" "$DST2/.backups/"
+
+info "Restoring from compressed backup"
+ODS_DIR="$DST2" bash "$ODS_RESTORE" -f "$CBACKUP_ID" >/dev/null 2>&1 || fail "Compressed restore failed"
+[[ -f "$DST2/.env" ]] || fail "Missing .env after compressed restore"
+[[ "$(cat "$DST2/.env")" == "test-env-value" ]] || fail ".env content mismatch after compressed restore"
+pass "Compressed backup restores correctly"
+
+# ── Interactive selection ─────────────────────────────────────────────
+# select_backup's stdout is command-substituted into backup_id, so the list
+# and prompt must print to stderr or the selection table is swallowed and
+# the captured ID is garbage.
+
+info "Restoring via interactive selection (dry run)"
+interactive_err=$(printf '1\n' | ODS_DIR="$DST2" bash "$ODS_RESTORE" -f -d 2>&1 >/dev/null) \
+    || fail "Interactive selection restore failed"
+echo "$interactive_err" | grep -q "Available Backups" || fail "Selection table not shown to the user (stderr)"
+pass "Interactive selection shows the table and resolves a clean backup ID"
 
 echo ""
 echo -e "${GREEN}✓ Round-trip backup/restore test passed${NC}"


### PR DESCRIPTION
## Problem

Two call sites in `ods-restore.sh` capture a function's stdout, and both functions also print their log/UI lines to stdout — the captured value swallows them:

**1. Compressed backups can never be restored.** `do_restore` captures `extract_backup`'s stdout as the backup path. For `.tar.gz` backups the `[INFO] Extracting compressed backup...` log line (ANSI codes included) is captured together with the path, so validation always fails:

```
[ERROR] Backup manifest not found: [0;34m[INFO][0m Extracting compressed backup...
/…/.backups/20260615-120000/manifest.json
[ERROR] Backup validation failed
```

Every backup created with `ods-backup.sh --compress` is unrestorable through this script (uncompressed backups take the early-return path that prints only the path, which is why they work).

**2. The interactive picker is unusable.** `main` captures `select_backup`'s stdout as the backup ID. The "Available Backups" table and the prompt are swallowed into the captured value — the user stares at a blank screen, and the resolved `backup_id` is the whole table plus the basename, which can never match a real backup.

**3. `.backups` offered as a backup.** The discovery `find`s lack `-mindepth 1`, so `BACKUP_ROOT` itself is listed as a selectable entry named `.backups` in the picker.

## Fix

- `extract_backup`: log lines → stderr; `do_restore` fails the capture explicitly (`if ! backup_dir=$(...)`) instead of leaning on `set -e`.
- `select_backup`: table + prompt → stderr, keeping only the resolved ID on stdout. Same convention as `snapshot_pre_update` in `ods-update.sh` ("all log calls redirect to stderr so command-substitution callers only capture the path").
- `-mindepth 1` on both discovery `find`s.

## Also fixes the test harness

`tests/test-backup-restore-roundtrip.sh` had been failing at source time on `main`: both scripts source `lib/rsync.sh` relative to `ODS_DIR`, and the test's fake ODS dirs never contained it. The harness now copies the lib in (same fix as the integrity-test harness in #1684, different file — no overlap).

## Verification

- Repro before fix: compressed restore → `Backup manifest not found: [INFO]…` exit 1; interactive picker → blank table, garbage ID, exit 1. After fix: both succeed, `.backups` row gone.
- Round-trip suite extended: compressed backup → restore → content assertions, plus an interactive-selection dry-run that asserts the table reaches the user (stderr) — **all pass**.
- Negative check: the extended test against the unfixed script fails at `Compressed restore failed`.
- `bash -n` clean. (Local runs used an rsync PATH stub — Git Bash ships no rsync; CI/dev boxes exercise the same paths with real rsync.)