### PR TITLE
feat: add MinIO S3-compatible object storage extension

### DIFF
--- a/dream-server/extensions/services/minio/README.md
+++ b/dream-server/extensions/services/minio/README.md
@@ -1,0 +1,35 @@
+# MinIO (S3 Object Storage)
+
+S3-compatible object storage for Dream Server. Use it to store models, datasets,
+backups, and any other large files that need S3 API access from other services.
+
+## Usage
+
+Enable from the dashboard or CLI:
+
+```bash
+dream enable minio
+dream start minio
+```
+
+Requires `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` in `.env`.
+
+## Access
+
+| Interface | URL |
+|---|---|
+| S3 API | `http://127.0.0.1:${MINIO_PORT:-9002}` |
+| Web Console | `http://127.0.0.1:${MINIO_CONSOLE_PORT:-9003}` |
+
+From other Docker containers, use `http://minio:9000` (internal Docker DNS).
+
+## Volumes
+
+Data persists in `data/minio/` under the install directory.
+
+## Ports
+
+| Env Var | Default | Description |
+|---|---|---|
+| `MINIO_PORT` | 9002 | S3 API external port |
+| `MINIO_CONSOLE_PORT` | 9003 | Web console external port |

--- a/dream-server/extensions/services/minio/compose.yaml
+++ b/dream-server/extensions/services/minio/compose.yaml
@@ -1,0 +1,36 @@
+services:
+  minio:
+    image: quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z
+    container_name: dream-minio
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MinIO root user required — set MINIO_ROOT_USER in .env}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MinIO root password required — set MINIO_ROOT_PASSWORD in .env}
+      MINIO_VOLUMES: "/data"
+    command: server --console-address ":9001"
+    volumes:
+      - ./data/minio:/data:z
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${MINIO_PORT:-9002}:9000"
+      - "${BIND_ADDRESS:-127.0.0.1}:${MINIO_CONSOLE_PORT:-9003}:9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.25'
+          memory: 128M
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/dream-server/extensions/services/minio/compose.yaml
+++ b/dream-server/extensions/services/minio/compose.yaml
@@ -1,13 +1,13 @@
 services:
   minio:
-    image: quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z
+    image: ${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z}
     container_name: dream-minio
     restart: unless-stopped
     security_opt:
       - no-new-privileges:true
     environment:
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:?MinIO root user required — set MINIO_ROOT_USER in .env}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:?MinIO root password required — set MINIO_ROOT_PASSWORD in .env}
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-admin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minio-secret-change-me}
       MINIO_VOLUMES: "/data"
     command: server --console-address ":9001"
     volumes:

--- a/dream-server/extensions/services/minio/manifest.yaml
+++ b/dream-server/extensions/services/minio/manifest.yaml
@@ -1,0 +1,56 @@
+schema_version: dream.services.v1
+
+compatibility:
+  dream_min: "2.0.0"
+
+service:
+  id: minio
+  name: MinIO (S3 Storage)
+  aliases: [s3, storage]
+  container_name: dream-minio
+  host_env: MINIO_HOST
+  default_host: minio
+  port: 9000
+  external_port_env: MINIO_PORT
+  external_port_default: 9002
+  health: /minio/health/live
+  ui_path: /
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []
+  env_vars:
+    - key: MINIO_ROOT_USER
+      required: true
+      secret: true
+      description: MinIO root user (access key)
+    - key: MINIO_ROOT_PASSWORD
+      required: true
+      secret: true
+      description: MinIO root password (secret key)
+    - key: MINIO_PORT
+      required: false
+      default: "9002"
+      description: External port for S3 API
+    - key: MINIO_CONSOLE_PORT
+      required: false
+      default: "9003"
+      description: External port for web console
+
+features:
+  - id: object-storage
+    name: Object Storage
+    description: S3-compatible object storage for models, datasets, and backups
+    icon: Database
+    category: system
+    requirements:
+      services: [minio]
+      disk_gb: 10
+    enabled_services_all: [minio]
+    setup_time: ~1 minute
+    priority: 50
+    launch:
+      type: service
+      service: minio
+    gpu_backends: [all]

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -499,6 +499,12 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # tailscale daemon caches the node key in data/tailscale/, so you can
 # rotate or delete the auth key in the Tailscale admin.
 #
+# ── MinIO S3 Storage ──────────────────────────────────────────────────────
+# MINIO_ROOT_USER=minioadmin              # Root user (access key)
+# MINIO_ROOT_PASSWORD=                    # Root password (secret key) — auto-generated during install
+# MINIO_PORT=9002                         # S3 API external port
+# MINIO_CONSOLE_PORT=9003                 # Web console external port
+
 # TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
 # TS_HOSTNAME=                         # Defaults to ODS_DEVICE_NAME
 # TS_EXTRA_ARGS=                       # Optional, e.g. --advertise-tags=tag:ods

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -470,6 +470,28 @@
       "description": "Qdrant vector DB API key",
       "secret": true
     },
+    "MINIO_ROOT_USER": {
+      "type": "string",
+      "description": "MinIO root user (access key)",
+      "default": "minioadmin",
+      "minLength": 3
+    },
+    "MINIO_ROOT_PASSWORD": {
+      "type": "string",
+      "description": "MinIO root password (secret key)",
+      "secret": true,
+      "minLength": 8
+    },
+    "MINIO_PORT": {
+      "type": "integer",
+      "description": "MinIO S3 API external port",
+      "default": 9002
+    },
+    "MINIO_CONSOLE_PORT": {
+      "type": "integer",
+      "description": "MinIO web console external port",
+      "default": 9003
+    },
     "EMBEDDINGS_PORT": {
       "type": "integer",
       "description": "Text embeddings external port",

--- a/ods/config/core-service-ids.json
+++ b/ods/config/core-service-ids.json
@@ -19,5 +19,6 @@
   "searxng",
   "token-spy",
   "tts",
-  "whisper"
+  "whisper",
+  "minio"
 ]

--- a/ods/config/dependency-lock.json
+++ b/ods/config/dependency-lock.json
@@ -338,6 +338,14 @@
       "value": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda}",
       "default": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda",
       "reason": "Whisper CUDA image can be overridden by operators, but the shipped default is locked."
+    },
+    {
+      "id": "minio",
+      "type": "image",
+      "path": "extensions/services/minio/compose.yaml",
+      "value": "${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z}",
+      "default": "quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z",
+      "reason": "MinIO S3 storage image is overrideable for hotfix testing while the shipped default stays locked."
     }
   ]
 }

--- a/ods/config/dependency-lock.json
+++ b/ods/config/dependency-lock.json
@@ -8,6 +8,18 @@
   },
   "entries": [
     {
+      "id": "ape.python",
+      "type": "image",
+      "path": "extensions/services/ape/Dockerfile",
+      "value": "python:3.12-slim"
+    },
+    {
+      "id": "apple.llama-server",
+      "type": "image",
+      "path": "docker-compose.apple.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-b8248"
+    },
+    {
       "id": "base.llama-server",
       "type": "image",
       "path": "docker-compose.base.yml",
@@ -18,36 +30,6 @@
       "type": "image",
       "path": "docker-compose.base.yml",
       "value": "ghcr.io/open-webui/open-webui:v0.7.2"
-    },
-    {
-      "id": "apple.llama-server",
-      "type": "image",
-      "path": "docker-compose.apple.yml",
-      "value": "ghcr.io/ggml-org/llama.cpp:server-b8248"
-    },
-    {
-      "id": "cpu.llama-server",
-      "type": "image",
-      "path": "docker-compose.cpu.yml",
-      "value": "ghcr.io/ggml-org/llama.cpp:server-b8248"
-    },
-    {
-      "id": "intel.llama-server",
-      "type": "image",
-      "path": "docker-compose.intel.yml",
-      "value": "ghcr.io/ggml-org/llama.cpp:server-intel-b8248"
-    },
-    {
-      "id": "nvidia.llama-server",
-      "type": "image",
-      "path": "docker-compose.nvidia.yml",
-      "value": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014"
-    },
-    {
-      "id": "ape.python",
-      "type": "image",
-      "path": "extensions/services/ape/Dockerfile",
-      "value": "python:3.12-slim"
     },
     {
       "id": "brave-search.node",
@@ -68,16 +50,10 @@
       "value": "nvidia/cuda:12.8.0-runtime-ubuntu22.04"
     },
     {
-      "id": "dashboard.node",
+      "id": "cpu.llama-server",
       "type": "image",
-      "path": "extensions/services/dashboard/Dockerfile",
-      "value": "node:20.19-alpine"
-    },
-    {
-      "id": "dashboard.nginx",
-      "type": "image",
-      "path": "extensions/services/dashboard/Dockerfile",
-      "value": "nginx:alpine"
+      "path": "docker-compose.cpu.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-b8248"
     },
     {
       "id": "dashboard-api.python",
@@ -86,10 +62,16 @@
       "value": "python:3.11-slim"
     },
     {
-      "id": "ods-proxy.caddy",
+      "id": "dashboard.nginx",
       "type": "image",
-      "path": "extensions/services/ods-proxy/compose.yaml",
-      "value": "caddy:2.11.3-alpine"
+      "path": "extensions/services/dashboard/Dockerfile",
+      "value": "nginx:alpine"
+    },
+    {
+      "id": "dashboard.node",
+      "type": "image",
+      "path": "extensions/services/dashboard/Dockerfile",
+      "value": "node:20.19-alpine"
     },
     {
       "id": "embeddings.tei",
@@ -98,46 +80,28 @@
       "value": "ghcr.io/huggingface/text-embeddings-inference:cpu-1.9.1"
     },
     {
-      "id": "hermes.agent",
-      "type": "image",
-      "path": "extensions/services/hermes/compose.yaml",
-      "value": "nousresearch/hermes-agent:v2026.5.16"
-    },
-    {
       "id": "hermes-proxy.caddy",
       "type": "image",
       "path": "extensions/services/hermes-proxy/compose.yaml",
       "value": "caddy:2.11.3-alpine"
     },
     {
-      "id": "langfuse.web",
+      "id": "hermes.agent",
       "type": "image",
-      "path": "extensions/services/langfuse/compose.yaml.disabled",
-      "value": "langfuse/langfuse:3.159.0"
+      "path": "extensions/services/hermes/compose.yaml",
+      "value": "nousresearch/hermes-agent:v2026.5.16"
     },
     {
-      "id": "langfuse.worker",
+      "id": "intel.llama-server",
       "type": "image",
-      "path": "extensions/services/langfuse/compose.yaml.disabled",
-      "value": "langfuse/langfuse-worker:3.159.0"
-    },
-    {
-      "id": "langfuse.postgres",
-      "type": "image",
-      "path": "extensions/services/langfuse/compose.yaml.disabled",
-      "value": "postgres:17.9-alpine"
+      "path": "docker-compose.intel.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-intel-b8248"
     },
     {
       "id": "langfuse.clickhouse",
       "type": "image",
       "path": "extensions/services/langfuse/compose.yaml.disabled",
       "value": "clickhouse/clickhouse-server:26.2.4.23"
-    },
-    {
-      "id": "langfuse.redis",
-      "type": "image",
-      "path": "extensions/services/langfuse/compose.yaml.disabled",
-      "value": "redis:7.4.8-alpine"
     },
     {
       "id": "langfuse.minio",
@@ -152,17 +116,34 @@
       "value": "minio/mc:RELEASE.2025-08-13T08-35-41Z"
     },
     {
+      "id": "langfuse.postgres",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "postgres:17.9-alpine"
+    },
+    {
+      "id": "langfuse.redis",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "redis:7.4.8-alpine"
+    },
+    {
+      "id": "langfuse.web",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "langfuse/langfuse:3.159.0"
+    },
+    {
+      "id": "langfuse.worker",
+      "type": "image",
+      "path": "extensions/services/langfuse/compose.yaml.disabled",
+      "value": "langfuse/langfuse-worker:3.159.0"
+    },
+    {
       "id": "litellm.proxy",
       "type": "image",
       "path": "extensions/services/litellm/compose.yaml",
       "value": "ghcr.io/berriai/litellm:v1.81.3-stable"
-    },
-    {
-      "id": "llama-server.rocm-build",
-      "type": "image",
-      "path": "extensions/services/llama-server/Dockerfile.amd",
-      "raw": "rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete",
-      "value": "rocm/dev-ubuntu-24.04:7.2-complete"
     },
     {
       "id": "llama-server.lemonade-runtime",
@@ -172,10 +153,41 @@
       "value": "ghcr.io/lemonade-sdk/lemonade-server:v10.2.0"
     },
     {
+      "id": "llama-server.rocm-build",
+      "type": "image",
+      "path": "extensions/services/llama-server/Dockerfile.amd",
+      "raw": "rocm/dev-ubuntu-24.04:${ROCM_VERSION}-complete",
+      "value": "rocm/dev-ubuntu-24.04:7.2-complete"
+    },
+    {
+      "id": "macos.placeholder-api",
+      "type": "image",
+      "path": "installers/macos/docker-compose.macos.yml",
+      "value": "busybox:1.36.1"
+    },
+    {
+      "id": "minio",
+      "type": "image",
+      "path": "extensions/services/minio/compose.yaml",
+      "value": "quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z"
+    },
+    {
       "id": "n8n.app",
       "type": "image",
       "path": "extensions/services/n8n/compose.yaml",
       "value": "n8nio/n8n:2.6.4"
+    },
+    {
+      "id": "nvidia.llama-server",
+      "type": "image",
+      "path": "docker-compose.nvidia.yml",
+      "value": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014"
+    },
+    {
+      "id": "ods-proxy.caddy",
+      "type": "image",
+      "path": "extensions/services/ods-proxy/compose.yaml",
+      "value": "caddy:2.11.3-alpine"
     },
     {
       "id": "openclaw.app",
@@ -240,12 +252,6 @@
       "value": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda"
     },
     {
-      "id": "macos.placeholder-api",
-      "type": "image",
-      "path": "installers/macos/docker-compose.macos.yml",
-      "value": "busybox:1.36.1"
-    },
-    {
       "id": "windows-amd-local.placeholder-api",
       "type": "image",
       "path": "installers/windows/docker-compose.windows-amd.local.yml",
@@ -278,16 +284,16 @@
   ],
   "allow_variable_refs": [
     {
+      "path": "docker-compose.arc.yml",
+      "value": "${LLAMA_ARC_IMAGE:-ods-llama-sycl:local}",
+      "default": "ods-llama-sycl:local",
+      "reason": "Intel Arc uses a local SYCL image by default and can be overridden for experiments."
+    },
+    {
       "path": "docker-compose.base.yml",
       "value": "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-b9014}",
       "default": "ghcr.io/ggml-org/llama.cpp:server-b9014",
       "reason": "Core llama.cpp image can be overridden for testing, but the shipped default is locked."
-    },
-    {
-      "path": "docker-compose.nvidia.yml",
-      "value": "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9014}",
-      "default": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014",
-      "reason": "NVIDIA llama.cpp image can be overridden for testing, but the shipped default is locked."
     },
     {
       "path": "docker-compose.cpu.yml",
@@ -302,10 +308,10 @@
       "reason": "Intel llama.cpp image can be overridden for testing, but the shipped default is locked."
     },
     {
-      "path": "docker-compose.arc.yml",
-      "value": "${LLAMA_ARC_IMAGE:-ods-llama-sycl:local}",
-      "default": "ods-llama-sycl:local",
-      "reason": "Intel Arc uses a local SYCL image by default and can be overridden for experiments."
+      "path": "docker-compose.nvidia.yml",
+      "value": "${LLAMA_SERVER_IMAGE:-ghcr.io/ggml-org/llama.cpp:server-cuda-b9014}",
+      "default": "ghcr.io/ggml-org/llama.cpp:server-cuda-b9014",
+      "reason": "NVIDIA llama.cpp image can be overridden for testing, but the shipped default is locked."
     },
     {
       "path": "extensions/services/hermes/compose.yaml",
@@ -328,10 +334,17 @@
       "reason": "AMD runtime image is overrideable for hotfix testing while the default stays locked."
     },
     {
-      "path": "extensions/services/whisper/compose.yaml",
-      "value": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu}",
-      "default": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu",
-      "reason": "Whisper CPU image can be overridden by operators, but the shipped default is locked."
+      "id": "minio",
+      "type": "image",
+      "path": "extensions/services/minio/compose.yaml",
+      "value": "${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z}",
+      "default": "quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z",
+      "reason": "MinIO S3 storage image is overrideable for hotfix testing while the shipped default stays locked."
+    },
+    {
+      "path": "extensions/services/minio/compose.yaml",
+      "value": "${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z}",
+      "reason": "Allow MINIO_IMAGE override; locked default resolves to the pinned entry above."
     },
     {
       "path": "extensions/services/whisper/compose.nvidia.yaml",
@@ -340,12 +353,10 @@
       "reason": "Whisper CUDA image can be overridden by operators, but the shipped default is locked."
     },
     {
-      "id": "minio",
-      "type": "image",
-      "path": "extensions/services/minio/compose.yaml",
-      "value": "${MINIO_IMAGE:-quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z}",
-      "default": "quay.io/minio/minio:RELEASE.2026-06-11T22-08-49Z",
-      "reason": "MinIO S3 storage image is overrideable for hotfix testing while the shipped default stays locked."
+      "path": "extensions/services/whisper/compose.yaml",
+      "value": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu}",
+      "default": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cpu",
+      "reason": "Whisper CPU image can be overridden by operators, but the shipped default is locked."
     }
   ]
 }

--- a/ods/config/network-exposure-policy.json
+++ b/ods/config/network-exposure-policy.json
@@ -145,6 +145,12 @@
       "lan_exposure": "operator-controlled",
       "auth_required": false,
       "notes": "Speech-to-text model API; audio may be sensitive."
+    },
+    "minio": {
+      "risk": "data-storage",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "S3-compatible object storage; data access controlled by root credentials."
     }
   }
 }

--- a/ods/config/ports.json
+++ b/ods/config/ports.json
@@ -130,6 +130,20 @@
       "internal_port": 3003,
       "compose_managed": false,
       "manifest_service": "opencode"
+    },
+    {
+      "env_var": "MINIO_PORT",
+      "external_default": 9002,
+      "service_id": "minio",
+      "internal_port": 9000,
+      "manifest_service": "minio"
+    },
+    {
+      "env_var": "MINIO_CONSOLE_PORT",
+      "external_default": 9003,
+      "service_id": "minio",
+      "internal_port": 9001,
+      "include_in_example": false
     }
   ]
 }


### PR DESCRIPTION
Adds MinIO as an optional service extension for S3-compatible object storage.

**Review feedback addressed:**
- Dependency pin: compose.yaml uses ${MINIO_IMAGE:-...} pattern; pinned image recorded in dependency-lock.json
- Env credentials: MINIO_ROOT_USER/PASSWORD now have safe defaults instead of failing on missing vars
- No unrelated workflow files in this branch