### PR TITLE
chore: add Docker image updates to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -100,3 +100,84 @@ updates:
       ape-python:
         patterns:
           - "*"
+
+  # ── Docker: Core services with custom Dockerfiles ─────────────────
+  - package-ecosystem: "docker"
+    directory: "/dream-server/extensions/services/comfyui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dream-server/extensions/services/brave-search"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dream-server/extensions/services/dashboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dream-server/extensions/services/dashboard-api"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dream-server/extensions/services/privacy-shield"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dream-server/extensions/services/token-spy"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dream-server/extensions/services/ape"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "docker"
+    directory: "/dream-server/images/llama-sycl"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 1
+    groups:
+      docker-core:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds Docker image update coverage via Dependabot. No unrelated workflow files.