### PR TITLE
fix(bootstrap): default ODS clone URLs to Osmantic

### DIFF
--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # ODS Bootstrap Installer
-# curl -fsSL https://raw.githubusercontent.com/Light-Heart-Labs/ODS/main/ods/get-ods.sh | bash
+# curl -fsSL https://raw.githubusercontent.com/Osmantic/ODS/main/ods/get-ods.sh | bash
 #
 # Detects OS, clones repo, runs installer.
 
@@ -29,7 +29,7 @@ CYAN='\033[0;36m'
 BOLD='\033[1m'
 NC='\033[0m'
 
-REPO_URL="${ODS_REPO_URL:-https://github.com/Light-Heart-Labs/ODS.git}"
+REPO_URL="${ODS_REPO_URL:-https://github.com/Osmantic/ODS.git}"
 INSTALL_DIR="${ODS_INSTALL_DIR:-$ODS_BOOTSTRAP_ROOT/ods}"
 LEGACY_DREAMSERVER_DIR="${DREAMSERVER_INSTALL_DIR:-$ODS_BOOTSTRAP_ROOT/dream-server}"
 ODS_REF="${ODS_REF:-${ODS_BOOTSTRAP_REF:-}}"

--- a/ods/installers/windows/phases/01-preflight.ps1
+++ b/ods/installers/windows/phases/01-preflight.ps1
@@ -292,7 +292,7 @@ $_composeBase = Join-Path $sourceRoot "docker-compose.base.yml"
 if (-not (Test-Path $_composeBase)) {
     Write-AIError "docker-compose.base.yml not found in: $sourceRoot"
     Write-AI "  Make sure you are running this installer from the ODS clone:"
-    Write-AI "  git clone https://github.com/Light-Heart-Labs/ODS.git"
+    Write-AI "  git clone https://github.com/Osmantic/ODS.git"
     Write-AI "  cd ODS && .\install.ps1"
     exit 1
 }

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -27,7 +27,7 @@ ROLLBACK_DIR="${INSTALL_DIR}/data/backups"   # pre-update rollback snapshots liv
 MAX_BACKUPS="${MAX_BACKUPS:-10}"
 UPDATE_CHANNEL="${UPDATE_CHANNEL:-stable}"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
-GITHUB_REPO="${GITHUB_REPO:-Light-Heart-Labs/ODS}"
+GITHUB_REPO="${GITHUB_REPO:-Osmantic/ODS}"
 
 # Colors
 RED='\033[0;31m'

--- a/ods/tests/test-phase-c-p1.sh
+++ b/ods/tests/test-phase-c-p1.sh
@@ -205,10 +205,10 @@ echo -e "${CYAN}-- C9. ods-update.sh GitHub Repo --------------------------"
 
 UPDATE_SCRIPT="${SCRIPT_DIR}/../ods-update.sh"
 if [ -f "$UPDATE_SCRIPT" ]; then
-    if grep -q "GITHUB_REPO.*Light-Heart-Labs/ODS" "$UPDATE_SCRIPT" 2>/dev/null; then
+    if grep -q "GITHUB_REPO.*Osmantic/ODS" "$UPDATE_SCRIPT" 2>/dev/null; then
         log_pass "ods-update.sh GitHub repo configuration is correct (ODS)"
     else
-        log_fail "ods-update.sh missing correct GitHub repo (should be Light-Heart-Labs/ODS)"
+        log_fail "ods-update.sh missing correct GitHub repo (should be Osmantic/ODS)"
     fi
 else
     log_warn "ods-update.sh not found"


### PR DESCRIPTION
## Summary
- default Linux bootstrap clone URL to https://github.com/Osmantic/ODS.git
- update Windows preflight guidance to Osmantic/ODS
- default ods-update release lookup to Osmantic/ODS

## Validation
- bash -n ods/get-ods.sh
- bash -n ods/ods-update.sh
- ordered merge validation: updated #1669, then updated #1687, passed AMD/Lemonade contracts
- included in fleet/fix-stack-20260709, which passed full fleet release, capabilities, lifecycle, Docker distro matrix, and Incus VM matrix.