### PR TITLE
fix(auth): compare presented credentials as bytes, not str

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -960,7 +960,9 @@ def check_auth(handler) -> bool:
     if not auth.startswith("Bearer "):
         json_response(handler, 401, {"error": "Authorization header required"})
         return False
-    if not secrets.compare_digest(auth[7:], AGENT_API_KEY):
+    # Compared as UTF-8 bytes: compare_digest raises TypeError on non-ASCII
+    # str, which would turn an unauthenticated request into a 500 not a 403.
+    if not secrets.compare_digest(auth[7:].encode("utf-8"), AGENT_API_KEY.encode("utf-8")):
         json_response(handler, 403, {"error": "Invalid API key"})
         return False
     return True

--- a/ods/extensions/library/services/open-interpreter/server.py
+++ b/ods/extensions/library/services/open-interpreter/server.py
@@ -37,7 +37,11 @@ def verify_api_key(
             status_code=503,
             detail="OPEN_INTERPRETER_API_KEY not configured",
         )
-    if not hmac.compare_digest(credentials.credentials, API_KEY):
+    # Compared as UTF-8 bytes: compare_digest raises TypeError on non-ASCII
+    # str, which would turn an unauthenticated request into a 500 not a 401.
+    if not hmac.compare_digest(
+        credentials.credentials.encode("utf-8"), API_KEY.encode("utf-8")
+    ):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return credentials
 

--- a/ods/extensions/services/ape/main.py
+++ b/ods/extensions/services/ape/main.py
@@ -744,7 +744,11 @@ app.add_middleware(
 
 
 async def verify_api_key(x_api_key: Optional[str] = Header(None)):
-    if API_KEY and not secrets.compare_digest(x_api_key or "", API_KEY):
+    # Compared as UTF-8 bytes: compare_digest raises TypeError on non-ASCII
+    # str, which would turn an unauthenticated request into a 500 not a 401.
+    if API_KEY and not secrets.compare_digest(
+        (x_api_key or "").encode("utf-8"), API_KEY.encode("utf-8")
+    ):
         raise HTTPException(status_code=401, detail="Invalid API key")
     return True
 

--- a/ods/extensions/services/dashboard-api/security.py
+++ b/ods/extensions/services/dashboard-api/security.py
@@ -33,6 +33,11 @@ async def verify_api_key(credentials: HTTPAuthorizationCredentials = Security(se
             detail="Authentication required. Provide Bearer token in Authorization header.",
             headers={"WWW-Authenticate": "Bearer"}
         )
-    if not secrets.compare_digest(credentials.credentials, DASHBOARD_API_KEY):
+    # Compared as UTF-8 bytes: compare_digest raises TypeError on non-ASCII
+    # str, and the presented token is attacker-controlled, so a str compare
+    # turns an unauthenticated request into a 500 instead of a 403.
+    if not secrets.compare_digest(
+        credentials.credentials.encode("utf-8"), DASHBOARD_API_KEY.encode("utf-8")
+    ):
         raise HTTPException(status_code=403, detail="Invalid API key.")
     return credentials.credentials

--- a/ods/extensions/services/dashboard-api/session_signer.py
+++ b/ods/extensions/services/dashboard-api/session_signer.py
@@ -149,8 +149,11 @@ def verify(cookie_value: str) -> Tuple[bool, str]:
 
     payload = f"{random_id}.{expiry_str}"
     expected_sig = _sign(payload)
-    # constant-time compare to defeat signature timing oracles.
-    if not hmac.compare_digest(expected_sig, claimed_sig):
+    # Constant-time compare to defeat signature timing oracles. Encoded to
+    # UTF-8 first because compare_digest raises TypeError on non-ASCII str,
+    # and claimed_sig comes straight off an attacker-controlled cookie —
+    # verify() must return a reason, never raise.
+    if not hmac.compare_digest(expected_sig.encode("utf-8"), claimed_sig.encode("utf-8")):
         return False, "bad-signature"
 
     # Signature is good — check expiry.

--- a/ods/extensions/services/dashboard-api/tests/test_security.py
+++ b/ods/extensions/services/dashboard-api/tests/test_security.py
@@ -33,3 +33,14 @@ class TestVerifyApiKey:
         with pytest.raises(HTTPException) as exc_info:
             await security.verify_api_key(None)
         assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("token", ["\xe9", "kéy", "\U0001F600"])
+    async def test_non_ascii_key_raises_403_not_typeerror(self, token):
+        """Authorization headers decode as latin-1, so an unauthenticated
+        client can present a non-ASCII token. It must be a plain mismatch
+        rather than a TypeError surfacing as a 500."""
+        creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials=token)
+        with pytest.raises(HTTPException) as exc_info:
+            await security.verify_api_key(creds)
+        assert exc_info.value.status_code == 403

--- a/ods/extensions/services/dashboard-api/tests/test_session_signer.py
+++ b/ods/extensions/services/dashboard-api/tests/test_session_signer.py
@@ -125,6 +125,17 @@ class TestVerify:
         assert ok is False
         assert reason == "bad-signature"
 
+    def test_non_ascii_signature_is_rejected_not_raised(self):
+        """A cookie whose signature holds non-ASCII bytes must come back as
+        bad-signature. Cookie headers decode as latin-1, so a client can put
+        any byte here, and verify() promises a reason rather than raising."""
+        cookie = session_signer.issue(ttl_seconds=60)
+        random_id, expiry, _ = cookie.split(".")
+        tampered = f"{random_id}.{expiry}.\xe9\xff"
+        ok, reason = session_signer.verify(tampered)
+        assert ok is False
+        assert reason == "bad-signature"
+
     def test_extended_expiry_invalidates_signature(self):
         """An attacker who tries to extend a leaked cookie's lifetime by
         editing the expiry field breaks the signature."""

--- a/ods/extensions/services/privacy-shield/proxy.py
+++ b/ods/extensions/services/privacy-shield/proxy.py
@@ -89,7 +89,7 @@ async def verify_api_key(credentials: HTTPAuthorizationCredentials | None = Secu
             detail="Missing Authorization header",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    if not secrets.compare_digest(credentials.credentials, SHIELD_API_KEY):
+    if not _token_valid(credentials.credentials):
         raise HTTPException(status_code=403, detail="Invalid API key.")
     return credentials.credentials
 

--- a/ods/extensions/services/privacy-shield/tests/test_proxy_auth.py
+++ b/ods/extensions/services/privacy-shield/tests/test_proxy_auth.py
@@ -52,6 +52,13 @@ class TestStatsAuth:
         resp = client.get("/stats", headers={"Authorization": "Bearer wrong-key"})
         assert resp.status_code == 403
 
+    def test_stats_with_non_ascii_bearer_returns_403(self, client):
+        """Authorization headers decode as latin-1, so an unauthenticated
+        client can present a non-ASCII token. It must be a plain mismatch
+        rather than a TypeError surfacing as a 500."""
+        resp = client.get("/stats", headers={"Authorization": b"Bearer \xe9"})
+        assert resp.status_code == 403
+
 
 # --- /health ---
 

--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -295,7 +295,11 @@ async def verify_api_key(
             detail="Authentication required. Provide Bearer token in Authorization header.",
             headers={"WWW-Authenticate": "Bearer"},
         )
-    if not secrets.compare_digest(credentials.credentials, TOKEN_SPY_API_KEY):
+    # Compared as UTF-8 bytes: compare_digest raises TypeError on non-ASCII
+    # str, which would turn an unauthenticated request into a 500 not a 403.
+    if not secrets.compare_digest(
+        credentials.credentials.encode("utf-8"), TOKEN_SPY_API_KEY.encode("utf-8")
+    ):
         raise HTTPException(status_code=403, detail="Invalid API key.")
     return credentials.credentials
 


### PR DESCRIPTION
## Summary

`secrets.compare_digest` / `hmac.compare_digest` raise `TypeError` when either **str** argument holds non-ASCII characters. Every API-key check in the repo compared the caller-supplied token as a `str`, so an unauthenticated client can send a non-ASCII `Authorization: Bearer` token, `X-API-Key` header, or `ods-session` cookie and get an **unhandled 500 with a stack trace instead of a clean 401/403**.

`Authorization` and `Cookie` headers are decoded as latin-1, so any byte `0x80`–`0xFF` reaches these comparisons straight off the network.

Reproduced against the real modules (not a mock):

```
=== dashboard-api verify_api_key ===        before fix      after fix
  valid key                                 HTTP 200        HTTP 200
  wrong ASCII key                           HTTP 403        HTTP 403
  non-ASCII key (0xe9)                      HTTP 500   ->   HTTP 403
  UTF-8 emoji token                         HTTP 500   ->   HTTP 403

=== session_signer.verify (docstring: "never raises") ===
  valid cookie                              (True, 'ok')
  tampered ASCII sig                        (False, 'bad-signature')
  non-ASCII sig                             RAISED TypeError  ->  (False, 'bad-signature')
```

`session_signer.verify()` documents that it returns a reason and *never raises*. A non-ASCII cookie signature broke that contract on exactly the `forward_auth` path Caddy calls (`GET /api/auth/verify-session`).

**This is not an auth bypass.** `forward_auth` treats a 500 as non-2xx and still denies the request, and a wrong key never compares equal. The defect is an unhandled exception on unauthenticated paths: wrong status code, stack traces in logs, and a broken documented contract.

### Why this shape of fix

`privacy-shield` already carried the byte-wise form in `_token_valid()`, whose docstring says it exists so that

> a non-ASCII presented token is a clean mismatch rather than a TypeError on the pre-auth path. Same secret + `secrets.compare_digest` as `verify_api_key` / `_is_authenticated`.

…but `verify_api_key()` **in that same file** never used it. The defect class was already recognised here and just applied incompletely. This PR routes privacy-shield through its own helper and applies the same byte-wise compare at the six remaining call sites:

| File | Credential source |
|---|---|
| `dashboard-api/security.py` | `Authorization: Bearer` |
| `dashboard-api/session_signer.py` | `ods-session` cookie signature |
| `privacy-shield/proxy.py` | `Authorization: Bearer` (now via `_token_valid`) |
| `token-spy/main.py` | `Authorization: Bearer` |
| `ape/main.py` | `X-API-Key` |
| `bin/ods-host-agent.py` | `Authorization: Bearer` |
| `extensions/library/services/open-interpreter/server.py` | `Authorization: Bearer` |

Keys are encoded at call time rather than precomputed at import, because `tests/test_security.py` monkeypatches `security.DASHBOARD_API_KEY`.

Strings decoded as latin-1 cannot contain surrogates, so the added `.encode("utf-8")` cannot itself raise — verified.

## AI Assistance

Claude Code was used to grep for the defect class across services, write the reproduction script, draft the fix and the regression tests, and run the validation commands below. I read the final diff, confirmed the reproduction before and after, and confirmed the three pre-existing failures listed below are unrelated to this change.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a — mainline.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [x] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: **High** — `docs/HIGH_RISK_CHANGE_MAP.md` maps "Dashboard API auth/setup/host-agent" and "Network binding/proxy routes" to High, requiring *focused pytest, security tests, dashboard API smoke*.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: no installer, compose, manifest, routing, or host-mutation surface is touched — the diff is seven credential comparisons and their tests.

Commands/results:

```text
# Regression proof — the new tests fail on the OLD code with the exact defect.
# (source files stashed, new tests kept)
$ pytest tests/test_security.py tests/test_session_signer.py -q
  E  TypeError: comparing strings with non-ASCII characters is not supported
  session_signer.py:153: TypeError
  4 failed, 23 passed

$ pytest tests/test_proxy_auth.py -q          # privacy-shield
  E  TypeError: comparing strings with non-ASCII characters is not supported
  proxy.py:92: TypeError
  1 failed, 5 passed

# With the fix applied
dashboard-api  : pytest tests/ -q                    -> 1174 passed, 9 skipped, 3 failed
privacy-shield : pytest tests/test_proxy_auth.py -q  -> 6 passed
ape            : pytest tests/ -q                    -> 44 passed
token-spy      : pytest tests/ -q                    -> 3 passed

# The 3 dashboard-api failures are pre-existing on a clean tree (verified by
# stashing every change and re-running). They are Windows-environment issues,
# not regressions from this PR:
#   test_setup_sentinel.py::test_setup_test_emits_pass_sentinel_on_success
#   test_setup_sentinel.py::test_setup_test_emits_fail_sentinel_with_returncode_on_failure
#   test_user_extensions.py::TestScanUserExtensions::test_scan_symlink_skipped

# Lint (make lint equivalent — `make` is unavailable on this host)
bash -n on all 269 shell files                                  -> 0 failures
python -m py_compile main.py agent_monitor.py                   -> OK
ruff check ods/ --select E,F,W --ignore E501,E701,E731,E741,E402 -> All checks passed!
git diff --check                                                -> clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Narrower equivalent, rather than a full fleet run: the change cannot affect install, bootstrap, compose generation, lifecycle, model download, or host mutation — it only replaces `str` operands with their UTF-8 bytes inside seven credential comparisons. Behaviour for a valid key and for a wrong ASCII key is unchanged and is covered by the pre-existing tests in each suite. The only behaviour that changes is non-ASCII input, which previously crashed.

## Notes For Reviewers

- **Rollback**: revert the commit. No migration, no config, no schema, no persisted state.
- **Constant-time property preserved**: `compare_digest` on `bytes` is the documented constant-time path, and nothing short-circuits before it.
- `token-spy` and `open-interpreter` have no auth test suite (`token-spy/tests/` only covers usage reporting; `open-interpreter` has no `tests/`), so those two sites are fixed without a new test rather than growing a suite in this PR. Happy to add one if you would prefer.
- `ape/main.py` returns 401 (not 403) for a wrong key. I preserved each service's existing status code rather than unifying them here.
