### PR TITLE
fix(windows-cli): keep other services' compose overlays on enable/disable

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Windows Compose Failure Report Tests
         run: bash tests/test-windows-compose-failure-report.sh
 
+      - name: Windows CLI Enable/Disable Tests
+        run: bash tests/test-windows-cli-enable-disable.sh
+
       - name: Windows Missing Service Hint Tests
         run: bash tests/test-windows-missing-service-hints.sh
 

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1727,116 +1727,76 @@ Start-Process -FilePath $_pythonLiteral -ArgumentList `$agentArgs -WorkingDirect
 function Update-ComposeFlags {
     <#
     .SYNOPSIS
-        Regenerate .compose-flags after an enable/disable operation.
+        Update .compose-flags in place after an enable/disable operation.
 
-        Strategy (in priority order):
-        1. If scripts/resolve-compose-stack.sh exists and bash is available,
-           delegate entirely to the canonical resolver (preserves backend
-           overlays, multi-GPU overlays, user-extension overlays, and
-           docker-compose.override.yml -- exactly the same stack the installer
-           built). This is the safe path.
-        2. Otherwise fall back to a minimal in-process swap: keep every token
-           in the existing .compose-flags that is NOT an extension service -f
-           entry, then re-scan extensions/services for enabled compose.yaml
-           fragments and append them. This preserves all backend and GPU
-           overlays (--env-file, -f docker-compose.base.yml,
-           -f docker-compose.nvidia.yml, etc.) because those paths never
-           match 'extensions/services' and are kept verbatim.
+        Only the toggled service's -f entries are rewritten. Every other token
+        is preserved verbatim and in order: --env-file, docker-compose.base.yml,
+        the backend overlay, installers/windows/docker-compose.windows-amd.yml,
+        docker-compose.tier0.yml, docker-compose.override.yml, and the compose
+        fragments of every other extension.
 
-        The fallback intentionally mirrors only what the Windows installer
-        writes: base + GPU overlay + enabled extension compose.yaml entries.
-        It does NOT add GPU-specific per-extension overlays (compose.nvidia.yaml
-        etc.) because those are the canonical resolver's responsibility and
-        we must not silently diverge from it.
+        Editing rather than regenerating is deliberate. The Windows installer
+        records a per-extension GPU overlay (compose.nvidia.yaml /
+        compose.amd.yaml) next to each compose.yaml, and gates some of them on
+        the detected driver -- Whisper's CUDA overlay is skipped below driver
+        575. Rebuilding the extension entries by re-scanning the filesystem
+        cannot see those decisions and would silently drop or resurrect them.
+
+        scripts/resolve-compose-stack.sh is intentionally not consulted here.
+        Its output is not a superset of the Windows stack: it emits neither
+        docker-compose.tier0.yml nor the Windows AMD overlay, and it selects
+        compose.local.yaml overlays from its own --ods-mode default.
     #>
+    param(
+        [Parameter(Mandatory=$true)][string]$ServiceId,
+        [Parameter(Mandatory=$true)][ValidateSet("enable", "disable")][string]$Action
+    )
+
     $flagsFile = Join-Path $InstallDir ".compose-flags"
     if (-not (Test-Path $flagsFile)) {
-        Write-AIWarn "No .compose-flags file found -- skipping regeneration."
+        Write-AIWarn "No .compose-flags file found -- skipping update."
         return
     }
 
-    # ── Path 1: delegate to the canonical resolver ────────────────────────────
-    $resolverScript = Join-Path (Join-Path $InstallDir "scripts") "resolve-compose-stack.sh"
-    $bashExe = Get-Command bash -ErrorAction SilentlyContinue
-    if ((Test-Path $resolverScript) -and $bashExe) {
-        # Read GPU_BACKEND and TIER from .env so the resolver uses the same
-        # parameters that the installer originally selected.
-        $gpuBackend = "nvidia"
-        $tier = "1"
-        try {
-            $envMap = Read-ODSEnv
-            if ($envMap.ContainsKey("GPU_BACKEND") -and $envMap["GPU_BACKEND"]) {
-                $gpuBackend = $envMap["GPU_BACKEND"].ToLower()
-            }
-            if ($envMap.ContainsKey("TIER") -and $envMap["TIER"]) {
-                $tier = $envMap["TIER"]
-            }
-        } catch { }
+    $existing = @((Get-Content $flagsFile -Raw).Trim() -split "\s+" | Where-Object { $_ })
 
-        $wslInstallDir = $InstallDir -replace "\\", "/" -replace "^([A-Za-z]):", "/mnt/`$1"
-        $wslInstallDir = $wslInstallDir.ToLower() -replace "^/mnt/([a-z])", { "/mnt/$($_.Groups[1].Value.ToLower())" }
+    # Every fragment under extensions/services/<ServiceId>/ belongs to the
+    # toggled service: compose.yaml and any per-backend overlay beside it.
+    $ownedByService = "extensions[/\\]services[/\\]$([regex]::Escape($ServiceId))[/\\]"
 
-        $resolvedFlagsRaw = & $bashExe.Source "$resolverScript" `
-            --script-dir "$InstallDir" `
-            --gpu-backend "$gpuBackend" `
-            --tier "$tier" `
-            2>$null
-        if ($LASTEXITCODE -eq 0 -and -not [string]::IsNullOrWhiteSpace($resolvedFlagsRaw)) {
-            # Prepend --env-file .env if the existing flags had it (the resolver
-            # emits only -f flags; the Windows installer adds --env-file separately).
-            $existingRaw = (Get-Content $flagsFile -Raw).Trim()
-            $newContent = $resolvedFlagsRaw.Trim()
-            if ($existingRaw -match '--env-file') {
-                $newContent = "--env-file .env " + $newContent
-            }
-            $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-            [System.IO.File]::WriteAllText($flagsFile, $newContent, $utf8NoBom)
-            Write-AI "Updated .compose-flags (via resolve-compose-stack.sh)"
-            return
-        }
-        Write-AIWarn "resolve-compose-stack.sh returned non-zero or empty output; falling back to minimal swap."
-    }
-
-    # ── Path 2: minimal in-process swap (fallback) ────────────────────────────
-    # Keep all tokens that are NOT an extension service -f entry, then
-    # re-append only the enabled compose.yaml fragments.
-    # This preserves --env-file, -f docker-compose.base.yml,
-    # -f docker-compose.nvidia.yml, and any other backend overlays verbatim.
-    $existing = (Get-Content $flagsFile -Raw).Trim() -split "\s+"
-    $baseFlags = New-Object System.Collections.Generic.List[string]
-    $skipNext = $false
+    $tokens = New-Object System.Collections.Generic.List[string]
     for ($i = 0; $i -lt $existing.Count; $i++) {
-        if ($skipNext) { $skipNext = $false; continue }
         if ($existing[$i] -eq "-f" -and ($i + 1) -lt $existing.Count) {
-            $nextVal = $existing[$i + 1]
-            # Strip extension service entries (compose.yaml and per-backend
-            # overlays such as compose.nvidia.yaml, compose.local.yaml).
-            if ($nextVal -match "extensions[/\\]services[/\\]") {
-                $skipNext = $true   # also drop the path token that follows -f
-                continue
-            }
+            $path = $existing[$i + 1]
+            $i++
+            if ($path -match $ownedByService) { continue }
+            [void]$tokens.Add("-f")
+            [void]$tokens.Add($path)
+            continue
         }
-        [void]$baseFlags.Add($existing[$i])
+        [void]$tokens.Add($existing[$i])
     }
 
-    # Re-append only compose.yaml (the base fragment) for enabled extensions.
-    # Per-backend and local-mode overlays require the canonical resolver.
-    $extDir = Join-Path (Join-Path $InstallDir "extensions") "services"
-    if (Test-Path $extDir) {
-        Get-ChildItem -Path $extDir -Directory | Sort-Object Name | ForEach-Object {
-            $composePath = Join-Path $_.FullName "compose.yaml"
-            if (Test-Path $composePath) {
-                $relPath = $composePath.Substring($InstallDir.Length + 1) -replace "\\", "/"
-                [void]$baseFlags.Add("-f")
-                [void]$baseFlags.Add($relPath)
+    if ($Action -eq "enable") {
+        $svcDir = Join-Path (Join-Path (Join-Path $InstallDir "extensions") "services") $ServiceId
+        if (Test-Path (Join-Path $svcDir "compose.yaml")) {
+            # tier0 and override are appended last by the installer so they win
+            # the merge; the new fragment has to land ahead of them.
+            $insertAt = $tokens.Count
+            for ($j = 0; $j -lt $tokens.Count - 1; $j++) {
+                if ($tokens[$j] -eq "-f" -and $tokens[$j + 1] -match "docker-compose\.(tier0|override)\.yml$") {
+                    $insertAt = $j
+                    break
+                }
             }
+            $tokens.InsertRange($insertAt, [string[]]@("-f", "extensions/services/$ServiceId/compose.yaml"))
         }
     }
 
-    $newContent = $baseFlags -join " "
+    $newContent = $tokens -join " "
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
     [System.IO.File]::WriteAllText($flagsFile, $newContent, $utf8NoBom)
-    Write-AI "Updated .compose-flags (fallback minimal swap)"
+    Write-AI "Updated .compose-flags ($Action $ServiceId)"
 }
 
 function Get-ExtensionServiceDir {
@@ -1938,7 +1898,7 @@ function Invoke-Enable {
 
     if (Test-Path $disabledPath) {
         Rename-Item -LiteralPath $disabledPath -NewName "compose.yaml" -Force
-        Update-ComposeFlags
+        Update-ComposeFlags -ServiceId $ServiceId -Action "enable"
         Write-AISuccess "$ServiceId enabled."
         Write-AI "Run '.\ods.ps1 start $ServiceId' to launch it."
         return
@@ -2011,7 +1971,7 @@ function Invoke-Disable {
 
     # Rename and refresh flags regardless of Docker state.
     Rename-Item -LiteralPath $composePath -NewName "compose.yaml.disabled" -Force
-    Update-ComposeFlags
+    Update-ComposeFlags -ServiceId $ServiceId -Action "disable"
     Write-AISuccess "$ServiceId disabled."
     Write-AI "Data preserved. Run '.\ods.ps1 enable $ServiceId' to re-enable."
 }

--- a/ods/tests/test-windows-cli-enable-disable.sh
+++ b/ods/tests/test-windows-cli-enable-disable.sh
@@ -83,33 +83,27 @@ awk '/^function Invoke-Disable/,/^}/' "$ODS_PS1" \
     || fail "Rename-Item not found in Invoke-Disable body"
 pass "Rename + flags update unconditional in Invoke-Disable"
 
-info "Static: Update-ComposeFlags delegates to resolve-compose-stack.sh when available"
-grep -q 'resolve-compose-stack.sh' "$ODS_PS1" \
-    || fail "Update-ComposeFlags does not reference resolve-compose-stack.sh"
-pass "Update-ComposeFlags references resolve-compose-stack.sh"
+info "Static: Update-ComposeFlags edits the toggled service only"
+grep -q 'Update-ComposeFlags -ServiceId .* -Action "enable"' "$ODS_PS1" \
+    || fail "Invoke-Enable does not tell Update-ComposeFlags which service it toggled"
+grep -q 'Update-ComposeFlags -ServiceId .* -Action "disable"' "$ODS_PS1" \
+    || fail "Invoke-Disable does not tell Update-ComposeFlags which service it toggled"
+pass "Update-ComposeFlags is scoped to the toggled service"
 
-info "Static: Update-ComposeFlags has safe fallback when resolver not available"
-grep -q 'fallback minimal swap\|fallback' "$ODS_PS1" \
-    || fail "Update-ComposeFlags has no fallback path"
-pass "Update-ComposeFlags has fallback path"
+info "Static: Update-ComposeFlags scopes its -f removal to the toggled service dir"
+grep -q 'ownedByService' "$ODS_PS1" \
+    || fail "Update-ComposeFlags does not scope removal to the toggled service directory"
+grep -q "extensions\[/\\\\\\\\\]services\[/\\\\\\\\\]" "$ODS_PS1" \
+    || fail "Update-ComposeFlags service-scoped pattern is missing"
+pass "Update-ComposeFlags removes only the toggled service's fragments"
 
-info "Static: Update-ComposeFlags preserves --env-file in resolver path"
-grep -q 'env-file.*resolver\|--env-file .env.*newContent\|existingRaw.*--env-file' "$ODS_PS1" \
-    || grep -q "Prepend --env-file" "$ODS_PS1" \
-    || fail "Update-ComposeFlags does not preserve --env-file when using the resolver"
-pass "Update-ComposeFlags preserves --env-file in resolver output"
-
-info "Static: Update-ComposeFlags passes GPU_BACKEND to resolver"
-grep -q 'gpuBackend\|gpu-backend' "$ODS_PS1" \
-    || fail "Update-ComposeFlags does not pass GPU_BACKEND to resolver"
-pass "Update-ComposeFlags passes GPU_BACKEND to resolver"
-
-info "Static: Update-ComposeFlags fallback preserves backend overlay -f entries"
-# The fallback keeps everything that doesn't match extensions/services
-grep -q "extensions\[/\\\\\\\\\]services" "$ODS_PS1" \
-    || grep -q 'extensions.*services' "$ODS_PS1" \
-    || fail "Update-ComposeFlags fallback does not filter on extensions/services path"
-pass "Update-ComposeFlags fallback preserves non-extension -f entries (backend overlays)"
+info "Static: Update-ComposeFlags does not delegate to the Linux resolver"
+# resolve-compose-stack.sh emits neither docker-compose.tier0.yml nor the
+# Windows AMD overlay, so its output is not a superset of the Windows stack.
+if grep -q '\$resolverScript' "$ODS_PS1"; then
+    fail "Update-ComposeFlags still invokes resolve-compose-stack.sh"
+fi
+pass "Update-ComposeFlags no longer shells out to the Linux resolver"
 
 info "Static: Update-ComposeFlags helper defined"
 grep -q 'function Update-ComposeFlags' "$ODS_PS1" \
@@ -361,6 +355,90 @@ mv "$SVCDIR/compose.yaml" "$SVCDIR/compose.yaml.disabled"
 [[ -f "$SVCDIR/compose.yaml.disabled" ]] || fail "compose.yaml.disabled not created after disable"
 [[ ! -f "$SVCDIR/compose.yaml" ]]        || fail "compose.yaml still exists after disable"
 pass "Disable renames compose.yaml to compose.yaml.disabled"
+
+# ── Behavioral: Update-ComposeFlags must not touch other services ─────────────
+# Toggling one extension used to rebuild every extension -f entry from disk,
+# which dropped the per-extension GPU overlays the installer recorded and
+# hoisted tier0/override ahead of the extension fragments.
+PS_BIN="$(command -v pwsh || command -v powershell || true)"
+if [[ -n "$PS_BIN" ]]; then
+    # Reuse $TMP so the existing EXIT trap cleans this up too.
+    PS_TMP="$TMP/compose-flags"
+    mkdir -p "$PS_TMP"
+
+    if ODS_PS1="$ODS_PS1" PS_TMP="$PS_TMP" "$PS_BIN" -NoProfile -Command '
+        $ErrorActionPreference = "Stop"
+        function Write-AIWarn { param($m) }
+        function Write-AI     { param($m) }
+
+        # ods.ps1 runs a command dispatcher on load, so lift just the function.
+        $src   = Get-Content $env:ODS_PS1 -Raw
+        $start = $src.IndexOf("function Update-ComposeFlags {")
+        $next  = $src.IndexOf("`nfunction Get-ExtensionServiceDir", $start)
+        if ($start -lt 0 -or $next -lt 0) { throw "Update-ComposeFlags not found" }
+        Invoke-Expression $src.Substring($start, $next - $start)
+
+        $InstallDir = Join-Path $env:PS_TMP "ods"
+        $svcRoot = Join-Path (Join-Path $InstallDir "extensions") "services"
+        foreach ($s in @("comfyui", "n8n", "whisper")) {
+            New-Item -ItemType Directory -Path (Join-Path $svcRoot $s) -Force | Out-Null
+            New-Item -ItemType File -Path (Join-Path (Join-Path $svcRoot $s) "compose.yaml") -Force | Out-Null
+        }
+        # comfyui and whisper also carry a per-extension NVIDIA overlay.
+        foreach ($s in @("comfyui", "whisper")) {
+            New-Item -ItemType File -Path (Join-Path (Join-Path $svcRoot $s) "compose.nvidia.yaml") -Force | Out-Null
+        }
+
+        # Token order exactly as install-windows.ps1 writes it.
+        $original = "--env-file .env -f docker-compose.base.yml -f docker-compose.nvidia.yml " +
+                    "-f extensions/services/comfyui/compose.yaml -f extensions/services/comfyui/compose.nvidia.yaml " +
+                    "-f extensions/services/n8n/compose.yaml " +
+                    "-f extensions/services/whisper/compose.yaml -f extensions/services/whisper/compose.nvidia.yaml " +
+                    "-f docker-compose.tier0.yml -f docker-compose.override.yml"
+        $flagsFile = Join-Path $InstallDir ".compose-flags"
+        [System.IO.File]::WriteAllText($flagsFile, $original, (New-Object System.Text.UTF8Encoding($false)))
+
+        # disable n8n
+        Remove-Item (Join-Path (Join-Path $svcRoot "n8n") "compose.yaml")
+        New-Item -ItemType File -Path (Join-Path (Join-Path $svcRoot "n8n") "compose.yaml.disabled") -Force | Out-Null
+        Update-ComposeFlags -ServiceId "n8n" -Action "disable"
+        $afterDisable = (Get-Content $flagsFile -Raw).Trim()
+
+        if ($afterDisable -match "n8n") { throw "n8n fragment survived disable" }
+        foreach ($keep in @("comfyui/compose.nvidia.yaml", "whisper/compose.nvidia.yaml",
+                            "docker-compose.tier0.yml", "docker-compose.override.yml")) {
+            if ($afterDisable -notmatch [regex]::Escape($keep)) { throw "disable dropped $keep" }
+        }
+        if ($afterDisable -notmatch "^--env-file \.env ") { throw "disable dropped --env-file" }
+
+        # tier0/override must stay behind the extension fragments so they win the merge
+        $iExt = $afterDisable.IndexOf("extensions/services/")
+        $iTier0 = $afterDisable.IndexOf("docker-compose.tier0.yml")
+        if ($iExt -lt 0 -or $iTier0 -lt $iExt) { throw "disable reordered tier0 ahead of extensions" }
+
+        # re-enable n8n -> byte-for-byte round trip of the token set
+        Remove-Item (Join-Path (Join-Path $svcRoot "n8n") "compose.yaml.disabled")
+        New-Item -ItemType File -Path (Join-Path (Join-Path $svcRoot "n8n") "compose.yaml") -Force | Out-Null
+        Update-ComposeFlags -ServiceId "n8n" -Action "enable"
+        $afterEnable = (Get-Content $flagsFile -Raw).Trim()
+
+        if ($afterEnable -notmatch "extensions/services/n8n/compose\.yaml") { throw "enable did not restore n8n" }
+        if ($afterEnable -notmatch "whisper/compose\.nvidia\.yaml") { throw "enable dropped whisper overlay" }
+        $iN8n = $afterEnable.IndexOf("n8n/compose.yaml")
+        $iTier0 = $afterEnable.IndexOf("docker-compose.tier0.yml")
+        if ($iTier0 -lt $iN8n) { throw "enable inserted n8n after tier0" }
+
+        $before = ($original -split "\s+" | Sort-Object) -join " "
+        $after  = ($afterEnable -split "\s+" | Sort-Object) -join " "
+        if ($before -ne $after) { throw "disable+enable round trip changed the token set" }
+    '; then
+        pass "Update-ComposeFlags preserves other services overlays and token order"
+    else
+        fail "Update-ComposeFlags corrupted .compose-flags on enable/disable"
+    fi
+else
+    info "No PowerShell on PATH -- skipping Update-ComposeFlags behavioral test"
+fi
 
 echo ""
 echo -e "${GREEN}All windows-cli-enable-disable tests passed.${NC}"


### PR DESCRIPTION
## Summary

On Windows, `ods.ps1 enable <svc>` / `disable <svc>` silently corrupts `.compose-flags`. `Update-ComposeFlags` rebuilds the entire extension section by re-scanning `extensions/services/*/compose.yaml`, which **throws away every per-extension GPU overlay** and **reorders the stack**.

Reproduced against the upstream function, using a `.compose-flags` shaped exactly the way `install-windows.ps1` writes one:

```
ORIGINAL (as written by install-windows.ps1):
  --env-file .env -f docker-compose.base.yml -f docker-compose.nvidia.yml
  -f extensions/services/comfyui/compose.yaml -f extensions/services/comfyui/compose.nvidia.yaml
  -f extensions/services/n8n/compose.yaml
  -f extensions/services/qdrant/compose.yaml
  -f extensions/services/whisper/compose.yaml -f extensions/services/whisper/compose.nvidia.yaml
  -f docker-compose.tier0.yml -f docker-compose.override.yml

AFTER 'ods disable n8n' (upstream code):
  --env-file .env -f docker-compose.base.yml -f docker-compose.nvidia.yml
  -f docker-compose.tier0.yml -f docker-compose.override.yml
  -f extensions/services/comfyui/compose.yaml
  -f extensions/services/qdrant/compose.yaml
  -f extensions/services/whisper/compose.yaml

  FAIL  whisper NVIDIA overlay survives
  FAIL  comfyui NVIDIA overlay survives
  PASS  tier0 overlay survives
  PASS  override overlay survives
  PASS  n8n fragment removed
```

Two distinct defects, one root cause (rebuild instead of edit):

1. **Per-extension GPU overlays are deleted.** Disabling an unrelated service drops `-f extensions/services/whisper/compose.nvidia.yaml` and ComfyUI's. The next `ods start` runs Whisper and ComfyUI **on CPU**. On AMD hosts the same happens to `compose.amd.yaml`.
2. **Merge order is inverted.** `docker-compose.tier0.yml` and `docker-compose.override.yml` get hoisted *ahead of* the extension fragments. The installer appends them last precisely so they win the merge; after a toggle, a user's `docker-compose.override.yml` no longer overrides the extensions.

### Why the rebuild is wrong

The old docstring justified itself like this:

> The fallback intentionally mirrors only what the Windows installer writes: base + GPU overlay + enabled extension compose.yaml entries. It does NOT add GPU-specific per-extension overlays (compose.nvidia.yaml etc.) because those are the canonical resolver's responsibility…

That premise is false. `install-windows.ps1` **does** write per-extension backend overlays next to each fragment (`installers/windows/install-windows.ps1`, the `compose.nvidia.yaml` / `compose.amd.yaml` blocks), and it gates Whisper's CUDA overlay on the detected driver (skipped below driver 575). A filesystem re-scan cannot see either decision, so it deletes them.

The fix edits the file instead of regenerating it: remove only the `-f` pairs under the toggled service's directory, insert a newly enabled fragment ahead of the `tier0`/`override` tail, and leave every other token byte-for-byte. `Update-ComposeFlags` now takes `-ServiceId` and `-Action`, so it knows what changed.

### Why the resolver delegation is removed

`Update-ComposeFlags` preferred `scripts/resolve-compose-stack.sh` and called the rebuild a "fallback". That preferred path never executes, and would be wrong if it did:

- **It cannot run.** On the supported Windows setup (WSL2), `Get-Command bash` resolves to `C:\Windows\system32\bash.exe`. WSL's bash cannot execute a script named by a Windows path. Measured on a real WSL2 box, running the exact invocation from `ods.ps1`:

  ```
  bash    = C:\Windows\system32\bash.exe
  LASTEXITCODE = 127
  output empty? = True
  ---- would Path 1 be taken? ----
  NO - silently falls back to lossy minimal swap
  ```

  A vestigial `$wslInstallDir` was computed two lines above and never used — the path translation was intended and lost.

- **It would be wrong if it did run.** `resolve-compose-stack.sh` emits neither `docker-compose.tier0.yml` (memory limits on low-RAM hosts) nor `installers/windows/docker-compose.windows-amd.yml`; it knows only the Linux layout. It also defaults to `ODS_MODE=local` and `Update-ComposeFlags` never passed `--ods-mode` or `--gpu-count` — the very omission `ods-cli`'s own `_regenerate_compose_flags` warns about: *"without it, toggling any extension would silently strip multi-GPU plumbing from the persisted cache."*

So the resolver's output is not a superset of the Windows stack, and delegating to it would trade one silent loss for another. `ods.ps1` is Windows-only, so the branch is removed rather than repaired.

## AI Assistance

Claude Code was used to investigate the code path, build the PowerShell reproduction harness, draft the fix and the regression test, and run the validation below. I read the final diff, ran the reproduction against upstream and against the fix, and confirmed the WSL `exit 127` measurement on my own machine.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a — mainline.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: **High** — `docs/HIGH_RISK_CHANGE_MAP.md` maps compose stack generation and lifecycle commands to High.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: the change rewrites one PowerShell function that edits a text file. No compose file, manifest, installer phase, or container is touched.

Commands/results:

```text
# Regression proof — upstream Update-ComposeFlags against an installer-shaped
# .compose-flags (harness lifts the function out of ods.ps1 and runs it):
  FAIL  whisper NVIDIA overlay survives
  FAIL  comfyui NVIDIA overlay survives
  Result: 3 passed, 2 failed

# Same fixture, with this PR:
  PASS  whisper NVIDIA overlay survives
  PASS  comfyui NVIDIA overlay survives
  PASS  tier0 overlay survives
  PASS  override overlay survives
  PASS  --env-file survives
  PASS  n8n fragment removed
  PASS  n8n fragment restored
  PASS  whisper overlay still intact
  PASS  n8n inserted before tier0/override
  PASS  round-trip == original token set
  Result: 10 passed, 0 failed

# Shell suites
bash tests/test-windows-cli-enable-disable.sh   -> PASS (incl. new pwsh behavioral test)
bash tests/test-windows-service-plan.sh         -> PASS
bash tests/test-windows-compose-failure-report.sh -> PASS
bash tests/test-uninstall-compose-flags.sh      -> PASS

# Lint
bash -n over all 269 shell files                 -> 0 failures
Invoke-ScriptAnalyzer -Settings ./PSScriptAnalyzerSettings.psd1 -Severity Error,Warning
  on installers/windows/ods.ps1                  -> no findings (same as upstream baseline)
python -c "yaml.safe_load(open('.github/workflows/test-linux.yml'))" -> OK
git diff --check                                 -> clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Narrower equivalent, rather than a full fleet run: `.compose-flags` is a cached token list. This PR changes how one function edits it and adds a test that asserts the edited result is token-for-token identical to the installer's output after a disable+enable round trip. Nothing about install, bootstrap, image pulls, or host mutation changes.

## Notes For Reviewers

- **`tests/test-windows-cli-enable-disable.sh` was never executed anywhere** — it is referenced by no Makefile target and no workflow. This PR wires it into `test-linux.yml`. That is why the defect shipped with a green build.
- The new behavioral test runs under `pwsh` (present on GitHub's `ubuntu-latest`) and falls back to `powershell` for Windows contributors; it skips cleanly when neither is on PATH.
- **Four static assertions were rewritten**, not deleted for convenience: they asserted the old contract (`Update-ComposeFlags` delegates to the resolver, prepends `--env-file`, passes `GPU_BACKEND`). That contract is what this PR removes, so they are replaced with assertions on the new one.
- **Deliberately out of scope**: `enable` re-adds only `compose.yaml`, not a per-backend overlay, for the newly enabled service — the same as today's behavior for that service. Adding one would mean guessing the driver gate that `install-windows.ps1` applies to Whisper, and the CLI has no access to that decision. Happy to follow up if you want `enable` to consult the manifest instead.
- **Rollback**: revert the commit. `.compose-flags` is a regenerable cache; nothing persists.
