### PR TITLE
fix(bootstrap): pass GPU_COUNT and ODS_MODE when recovering compose flags

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Update Rollback Contract
         run: bash tests/test-update-rollback-contract.sh
 
+      - name: Bootstrap Upgrade Compose Flags Recovery Tests
+        run: bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
+
       - name: Support Bundle Evidence Tests
         run: bash tests/test-support-bundle.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -62,6 +62,9 @@ test: ## Run unit and contract tests
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
 	@echo ""
+	@echo "=== bootstrap-upgrade compose-flags recovery ==="
+	@bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
+	@echo ""
 	@echo "=== macOS ods-host-agent bootstrap verification ==="
 	@bash tests/test-macos-host-agent-verification.sh
 	@echo ""

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -1360,14 +1360,26 @@ elif [[ -n "$DOCKER_CMD" ]] && $DOCKER_CMD ps --filter name=ods-llama-server --f
         read -ra COMPOSE_ARGS <<< "$(cat "$INSTALL_DIR/.compose-flags")"
     elif [[ -x "$INSTALL_DIR/scripts/resolve-compose-stack.sh" ]]; then
         _tier="1"
+        _gpu_count="1"
+        _ods_mode="local"
         if [[ -f "$ENV_FILE" ]]; then
             _tier=$(grep -E '^TIER=' "$ENV_FILE" | cut -d= -f2 | tr -d '"\047\r')
             [[ -n "$_tier" ]] || _tier="1"
+            _gpu_count=$(grep -E '^GPU_COUNT=' "$ENV_FILE" | cut -d= -f2 | tr -d '"\047\r')
+            [[ -n "$_gpu_count" ]] || _gpu_count="1"
+            _ods_mode=$(grep -E '^ODS_MODE=' "$ENV_FILE" | cut -d= -f2 | tr -d '"\047\r')
+            [[ -n "$_ods_mode" ]] || _ods_mode="local"
         fi
+        # --gpu-count gates the multigpu-{backend} overlays and --ods-mode gates
+        # the compose.local.yaml overlays. The resolver reads neither from the
+        # environment, and the flags below are persisted to .compose-flags, so
+        # omitting them writes a single-GPU local-mode stack over the real one.
         _resolved_env=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
             --script-dir "$INSTALL_DIR" \
             --tier "$_tier" \
             --gpu-backend "${_gpu_backend:-cpu}" \
+            --gpu-count "$_gpu_count" \
+            --ods-mode "$_ods_mode" \
             --env 2>/dev/null || true)
         _resolved_flags=$(printf '%s\n' "$_resolved_env" | sed -n 's/^COMPOSE_FLAGS="\([^"]*\)".*/\1/p')
         if [[ -n "$_resolved_flags" ]]; then

--- a/ods/tests/test-bootstrap-upgrade-compose-flags-recovery.sh
+++ b/ods/tests/test-bootstrap-upgrade-compose-flags-recovery.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Regression: when .compose-flags is missing, the Docker restart path recovers
+# it via resolve-compose-stack.sh and persists the result. The resolver reads
+# neither GPU_COUNT nor ODS_MODE from the environment, so both must be passed
+# explicitly -- otherwise the recovered cache pins a single-GPU, local-mode
+# stack over a multi-GPU or cloud-mode install.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/scripts/bootstrap-upgrade.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    if [[ -n "${tmp:-}" ]]; then
+        [[ -f "$tmp/bootstrap.log" ]] && sed 's/^/[bootstrap] /' "$tmp/bootstrap.log" >&2
+        [[ -f "${resolver_calls:-}" ]] && sed 's/^/[resolver] /' "$resolver_calls" >&2
+    fi
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+fakebin="$tmp/bin"
+install_dir="$tmp/install"
+resolver_calls="$tmp/resolver-calls.log"
+mkdir -p "$fakebin" "$install_dir/data/models" "$install_dir/config/llama-server" "$install_dir/scripts"
+
+cat > "$fakebin/curl" <<'EOF'
+#!/usr/bin/env bash
+case " $* " in
+  *" -sI "*)
+    printf 'HTTP/2 200\r\ncontent-length: 10\r\n\r\n'
+    exit 0
+    ;;
+esac
+exit 7
+EOF
+chmod +x "$fakebin/curl"
+
+cat > "$fakebin/sleep" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$fakebin/sleep"
+
+cat > "$fakebin/uname" <<'EOF'
+#!/usr/bin/env bash
+printf 'Linux\n'
+EOF
+chmod +x "$fakebin/uname"
+
+# Docker is "up" with a running llama-server so the restart branch is taken.
+# inspect reports a restarting container so the health wait aborts quickly.
+cat > "$fakebin/docker" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+    info) exit 0 ;;
+    compose) exit 0 ;;
+    ps)
+        if [[ " $* " == *"name=ods-llama-server"* ]]; then
+            printf 'ods-llama-server\n'
+        fi
+        exit 0
+        ;;
+    inspect)
+        if [[ "${2:-}" == "ods-llama-server" && " $* " == *".State.Status"* ]]; then
+            printf 'restarting true 1\n'
+        fi
+        exit 0
+        ;;
+esac
+exit 0
+EOF
+chmod +x "$fakebin/docker"
+
+# Stub resolver: record argv, then emit an --env style payload.
+cat > "$install_dir/scripts/resolve-compose-stack.sh" <<EOF
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$resolver_calls"
+printf 'COMPOSE_FLAGS="-f docker-compose.base.yml -f docker-compose.multigpu-nvidia.yml"\n'
+EOF
+chmod +x "$install_dir/scripts/resolve-compose-stack.sh"
+
+# Multi-GPU, cloud-mode install. Neither value reaches the resolver unless
+# bootstrap-upgrade.sh forwards it explicitly.
+cat > "$install_dir/.env" <<'EOF'
+GGUF_FILE=Bootstrap.gguf
+LLM_MODEL=bootstrap-model
+MAX_CONTEXT=8192
+CTX_SIZE=8192
+GPU_BACKEND=nvidia
+GPU_COUNT=2
+ODS_MODE=cloud
+TIER=3
+OLLAMA_PORT=11434
+EOF
+
+cat > "$install_dir/config/llama-server/models.ini" <<'EOF'
+[bootstrap-model]
+filename = Bootstrap.gguf
+load-on-startup = true
+n-ctx = 8192
+EOF
+
+printf 'bootstrap\n' > "$install_dir/data/models/Bootstrap.gguf"
+printf 'full-model\n' > "$install_dir/data/models/Full.gguf"
+
+# No .compose-flags on purpose -- that is what triggers the recovery path.
+[[ ! -f "$install_dir/.compose-flags" ]] || fail "fixture must not pre-create .compose-flags"
+
+# The upgrade itself is expected to fail (the container never goes healthy);
+# we only care that the recovery invoked the resolver correctly beforehand.
+set +e
+PATH="$fakebin:$PATH" bash "$TARGET" \
+    "$install_dir" \
+    "Full.gguf" \
+    "https://example.invalid/Full.gguf" \
+    "" \
+    "full-model" \
+    "32768" \
+    "Bootstrap.gguf" \
+    > "$tmp/bootstrap.log" 2>&1
+set -e
+
+[[ -s "$resolver_calls" ]] \
+    || fail "recovery path never invoked resolve-compose-stack.sh"
+
+grep -q -- '--gpu-count 2' "$resolver_calls" \
+    || fail "resolver called without --gpu-count 2; multi-GPU overlays would be stripped from the persisted cache"
+
+grep -q -- '--ods-mode cloud' "$resolver_calls" \
+    || fail "resolver called without --ods-mode cloud; local-mode overlays would be forced onto a cloud install"
+
+grep -q -- '--tier 3' "$resolver_calls" \
+    || fail "resolver called without the installed tier"
+
+grep -q -- '--gpu-backend nvidia' "$resolver_calls" \
+    || fail "resolver called without the installed GPU backend"
+
+[[ -f "$install_dir/.compose-flags" ]] \
+    || fail "recovered compose flags were not persisted"
+
+grep -q 'docker-compose.multigpu-nvidia.yml' "$install_dir/.compose-flags" \
+    || fail "persisted .compose-flags dropped the resolver's multi-GPU overlay"
+
+pass "compose-flags recovery forwards GPU_COUNT and ODS_MODE to the resolver"


### PR DESCRIPTION
## Summary

When `.compose-flags` is missing, `scripts/bootstrap-upgrade.sh` re-resolves the compose stack and **persists** the result. It called the resolver with only `--tier` and `--gpu-backend`:

```bash
"$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
    --script-dir "$INSTALL_DIR" \
    --tier "$_tier" \
    --gpu-backend "${_gpu_backend:-cpu}" \
    --env
```

Two inputs are missing, and each corrupts the persisted cache in a different way.

**`--gpu-count` — multi-GPU overlays are dropped.** `resolve-compose-stack.sh` sets `GPU_COUNT="1"` as a plain literal, not `${GPU_COUNT:-1}`. It is the only resolver input that ignores the environment entirely, so a caller that omits the flag always resolves a single-GPU stack. Measured against the real resolver on this repo:

```
A) exactly what bootstrap-upgrade.sh runs (no --gpu-count, no --ods-mode)
   multigpu fragments: 0

B) the call every other caller makes (--gpu-count 2 --ods-mode local)
   docker-compose.multigpu-nvidia.yml
   extensions/services/comfyui/compose.multigpu-nvidia.yaml
   extensions/services/embeddings/compose.multigpu-nvidia.yaml
   extensions/services/whisper/compose.multigpu-nvidia.yaml
   multigpu fragments: 4
```

**`--ods-mode` — local-mode overlays are forced onto cloud installs.** The resolver *does* read `ODS_MODE` from the environment, but `bootstrap-upgrade.sh` greps individual keys out of `.env` instead of sourcing it, so `ODS_MODE` is unset in that process and the resolver falls back to `local`:

```
bootstrap default (ODS_MODE unset -> 'local'): local-mode overlays = 6
explicit --ods-mode cloud                    : local-mode overlays = 0
```

Both wrong results are written straight to `$INSTALL_DIR/.compose-flags` and stick until something else regenerates them.

### Reachability

This is not a dead branch. `ods-cli` deletes `.compose-flags` in normal operation:

- when the cache is stale or corrupt (`rm -f "$INSTALL_DIR/.compose-flags"` before falling through to dynamic resolution);
- when `_regenerate_compose_flags` runs and the resolver fails or is absent.

A subsequent model upgrade then hits the recovery branch and re-creates the file — incorrectly.

### Why this shape of fix

`ods-cli` already carries the reason, twice, next to its own resolver calls:

> `--gpu-count` gates the multigpu-{backend}.yml overlay; without it, toggling any extension would silently strip multi-GPU plumbing from the persisted cache.

`bootstrap-upgrade.sh` is the **only** one of the eleven resolver call sites that passes no `--gpu-count` at all. `GPU_COUNT` and `ODS_MODE` are both written to `.env` by the installer (`installers/phases/06-directories.sh`), so the fix reads them exactly the way `TIER` and `GPU_BACKEND` are already read a few lines above, and forwards them.

`scripts/ods-preflight.sh` and `scripts/validate.sh` also omit `--ods-mode`, but both call `load_env_file` first, so `ODS_MODE` reaches the resolver through the environment. They are correct as written and are left alone.

## AI Assistance

Claude Code was used to enumerate the resolver call sites, run the before/after resolver measurements quoted above, draft the fix and the regression test, and run the validation below. I read the final diff and confirmed the new test fails on upstream and passes with the fix.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a — mainline.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: **High** — `docs/HIGH_RISK_CHANGE_MAP.md` maps compose stack generation and bootstrap/lifecycle to High.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: the change adds two already-persisted `.env` values to one resolver invocation. No compose file, manifest, or installer phase is modified.

Commands/results:

```text
# Regression proof — the new test on upstream bootstrap-upgrade.sh:
$ bash tests/test-bootstrap-upgrade-compose-flags-recovery.sh
[FAIL] resolver called without --gpu-count 2; multi-GPU overlays would be
       stripped from the persisted cache
[resolver] --script-dir /tmp/.../install --tier 3 --gpu-backend nvidia --env

# Same test with this PR:
[PASS] compose-flags recovery forwards GPU_COUNT and ODS_MODE to the resolver

# Neighbouring bootstrap-upgrade suites (no regressions)
test-bootstrap-upgrade-docker-rollback           PASS
test-bootstrap-upgrade-hotswap-contract          PASS
test-bootstrap-upgrade-sha-retry                 PASS
test-bootstrap-upgrade-resume-status             PASS
test-bootstrap-upgrade-download-finalization     PASS
test-bootstrap-upgrade-close-inherited-fds       PASS
test-uninstall-compose-flags                     PASS

# Lint (shellcheck run with the repo's .shellcheckrc and CI's flags)
shellcheck --exclude=SC1091,SC2034 --severity=error   -> NO ERRORS
shellcheck --exclude=SC1091,SC2034 --severity=warning -> NO WARNINGS (new test)
                                                      -> no new warnings in the changed hunk
bash -n on both changed shell files                   -> OK
python -c "yaml.safe_load(open('.github/workflows/test-linux.yml'))" -> OK
git diff --check                                      -> clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Narrower equivalent, rather than a full fleet run: the diff forwards two existing `.env` values into one resolver call. The resolver's own behaviour is unchanged, and the new hermetic test asserts the exact argv it receives plus the contents of the persisted `.compose-flags`. Reproducing the fault needs a multi-GPU or cloud-mode host, which the fleet lane would cover; the argv assertion covers it without one.

## Notes For Reviewers

- The new test drives the real `bootstrap-upgrade.sh` end to end with a fake `docker`/`curl`/`uname` on `PATH` and a stub resolver that records its argv — the same harness style as `tests/test-bootstrap-upgrade-docker-rollback.sh`.
- **Most `test-bootstrap-upgrade-*.sh` suites are not wired into CI or `make test`** (only `close-inherited-fds` and the OpenClaw guard are). I wired the new one into both rather than adding it to the unrun pile. Happy to wire the remaining six in a separate PR if you want them running.
- The fix keeps `bootstrap-upgrade.sh`'s existing "grep one key at a time" style rather than sourcing `.env`, to avoid pulling the whole environment into a script that runs `docker compose`. The script uses `set -uo pipefail` (no `-e`), so a missing key yields an empty string and the explicit `[[ -n ... ]] ||` defaults apply.
- **Rollback**: revert the commit. `.compose-flags` is a regenerable cache.
