### PR TITLE
 feat(dashboard-api): surface GGUF sliding-window attention metadata

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -214,6 +214,7 @@ def inspect_gguf(path: Path | str, max_metadata_bytes: int = 8 * 1024 * 1024) ->
             "embedding_length": _first_int(metadata, (".embedding_length",)),
             "attention_head_count": _first_int(metadata, (".attention.head_count",)),
             "attention_head_count_kv": _first_int(metadata, (".attention.head_count_kv",)),
+            "attention_sliding_window": _first_int(metadata, (".attention.sliding_window",)),
             "expert_count": _first_int(metadata, (".expert_count", ".expert.count")),
             "expert_used_count": _first_int(metadata, (".expert_used_count", ".expert.used_count")),
             "model_name": _first_value(metadata, ("general.name",)),

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -1006,6 +1006,7 @@ def build_models_payload(gpu_info: Optional[GPUInfo], loaded_model: Optional[str
                 "blockCount": metadata.get("block_count"),
                 "expertCount": metadata.get("expert_count"),
                 "expertUsedCount": metadata.get("expert_used_count"),
+                "slidingWindow": metadata.get("attention_sliding_window"),
             },
             "status": "loaded" if is_loaded else status_if_not_loaded,
             "recommended": is_recommended,

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -1,0 +1,57 @@
+from pathlib import Path
+import struct
+
+from gguf_inspector import _first_int, inspect_gguf
+
+
+def _pack_string(s: str) -> bytes:
+    b = s.encode("utf-8")
+    return struct.pack("<Q", len(b)) + b
+
+
+def _build_minimal_gguf(metadata_uint32s: dict[str, int]) -> bytes:
+    data = b"GGUF"
+    data += struct.pack("<I", 3)  # version
+    data += struct.pack("<Q", 0)  # tensor count
+    data += struct.pack("<Q", len(metadata_uint32s))  # metadata count
+
+    for key, value in metadata_uint32s.items():
+        data += _pack_string(key)
+        data += struct.pack("<I", 4)  # value_type = 4 (uint32)
+        data += struct.pack("<I", value)
+
+    return data
+
+
+def test_gguf_sliding_window_extraction(tmp_path: Path):
+    gguf_path = tmp_path / "test.gguf"
+    
+    # Build minimal valid GGUF with uint32 values
+    content = _build_minimal_gguf({
+        "llama.block_count": 32,
+        "llama.attention.head_count": 32,
+        "llama.attention.sliding_window": 4096,
+    })
+    
+    gguf_path.write_bytes(content)
+    
+    result = inspect_gguf(gguf_path)
+    
+    assert result["readable"] is True
+    assert result["attention_sliding_window"] == 4096
+
+
+def test_first_int_suffix_matching():
+    # Test valid extraction
+    dict_with_swa = {
+        "some.other.key": 123,
+        "llama.attention.sliding_window": 8192,
+    }
+    assert _first_int(dict_with_swa, (".attention.sliding_window",)) == 8192
+
+    # Test regression guard: absent key must yield None
+    dict_without_swa = {
+        "llama.block_count": 32,
+        "llama.attention.head_count": 32,
+    }
+    assert _first_int(dict_without_swa, (".attention.sliding_window",)) is None


### PR DESCRIPTION
Extracts the `.attention.sliding_window` metadata key from GGUF files and passes it through the model payload to the dashboard. 

**Significance & Context:** 
Modern architectures (such as Gemma 2/3, Ministral, Phi-3, and GPT-OSS) rely heavily on Sliding Window Attention (SWA) to keep memory usage low at high context lengths. Historically, this critical metadata was ignored during model inspection. This PR safely exposes the window size without altering existing behavior. 

By surfacing this metadata, we lay the foundational data required to fix massive VRAM miscalculations for long-context models downstream.

**Safety:**
This is strictly additive. The `_first_int` extractor yields `None` if the key is absent, ensuring no regressions for standard dense models or missing catalog data.