### PR TITLE
Support Docker rootless mode for non-root container services

### DIFF
--- a/ods/extensions/services/langfuse/hooks/post_install.sh
+++ b/ods/extensions/services/langfuse/hooks/post_install.sh
@@ -58,6 +58,21 @@ if [[ "$(id -u)" -ne 0 ]]; then
     fi
 fi
 
+# In rootless Docker mode, sudo chown cannot reach container UIDs.
+# Use a helper container running as root instead (root in container = host user).
+_is_rootless_docker() {
+    docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q "rootless"
+}
+
+_rootless_chown_dir() {
+    local dir="$1" owner="$2"  # owner format: uid:gid
+    [[ -d "$dir" ]] || return 0
+    docker run --rm --user 0:0 \
+        -v "$dir:/data" \
+        alpine sh -c "chown -R ${owner} /data" 2>/dev/null || \
+        log "WARNING: rootless chown failed for $dir (non-fatal)"
+}
+
 is_container_running() {
     # Returns:
     #   0 = container is running
@@ -142,10 +157,18 @@ chown_dir() {
 }
 
 # postgres official image: uid 70 (postgres user baked into image)
-chown_dir "$POSTGRES_DIR" "70:70" "ods-langfuse-postgres"
+if _is_rootless_docker; then
+    _rootless_chown_dir "$POSTGRES_DIR" "70:70"
+else
+    chown_dir "$POSTGRES_DIR" "70:70" "ods-langfuse-postgres"
+fi
 
 # clickhouse-server image: uid 101 (clickhouse user)
-chown_dir "$CLICKHOUSE_DIR" "101:101" "ods-langfuse-clickhouse"
+if _is_rootless_docker; then
+    _rootless_chown_dir "$CLICKHOUSE_DIR" "101:101"
+else
+    chown_dir "$CLICKHOUSE_DIR" "101:101" "ods-langfuse-clickhouse"
+fi
 
 log "done"
 exit 0

--- a/ods/installers/lib/constants.sh
+++ b/ods/installers/lib/constants.sh
@@ -84,4 +84,5 @@ ROOTLESS_SERVICE_UIDS=(
     "langfuse/postgres:70"
     "langfuse/clickhouse:101"
     "hermes:10000"
+    "comfyui:1000"
 )

--- a/ods/installers/lib/constants.sh
+++ b/ods/installers/lib/constants.sh
@@ -66,3 +66,22 @@ _sed_i() {
         sed -i '' "$@"
     fi
 }
+
+
+#=============================================================================
+# Rootless Docker — non-root container service UID map
+#=============================================================================
+# Each entry is "service:container_uid". Used by the installer, ods-cli, and
+# ods-preflight to fix data directory ownership when Docker runs in rootless mode.
+ROOTLESS_SERVICE_UIDS=(
+    "n8n:1000"
+    "whisper:1000"
+    "tts:1000"
+    "token-spy:1000"
+    "privacy-shield:1000"
+    "ape:100"
+    "langfuse:1001"
+    "langfuse/postgres:70"
+    "langfuse/clickhouse:101"
+    "hermes:10000"
+)

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -65,17 +65,9 @@ if $DRY_RUN; then
     #the container where UID 10000 is valid.
 
     if [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
-    if _is_rootless_docker; then
-        _rootless_chown_data_dir "hermes" 10000
-        docker run --rm --user 0:0 \
-            -v "$INSTALL_DIR/data/hermes:/data" \
-            alpine sh -c "chmod 700 /data" 2>/dev/null || true
-    else
-        sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
-            warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
-        sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
+        log "[DRY RUN] Would fix data/hermes ownership to uid 10000:10000 (hermes user, chmod 700)"
     fi
-fi
+
     [[ "$ENABLE_OPENCLAW" == "true" ]] && log "[DRY RUN] Would configure OpenClaw (model: $LLM_MODEL, config: ${OPENCLAW_CONFIG:-default})"
     log "[DRY RUN] Would validate .env against schema"
 else
@@ -94,9 +86,17 @@ else
     # as the host user must not "repair" it back to uid 1000, or Hermes's web
     # status and ODS Talk JSON-RPC paths fail with PermissionError.
     if [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
-        sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
-            warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
-        sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
+        if _is_rootless_docker; then
+            _rootless_chown_data_dir "hermes" 10000
+            docker run --rm --user 0:0 \
+                -v "$INSTALL_DIR/data/hermes:/data" \
+                alpine sh -c "chmod 700 /data" 2>/dev/null || \
+                warn "Rootless chmod failed for hermes (non-fatal)"
+        else
+            sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
+                warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
+            sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
+        fi
     fi
 
     # Fix ownership of data/config dirs that may have been created by containers

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -35,12 +35,47 @@ _phase06_step() {
     log "Phase 06 step: ${step}"
 }
 
+# Detect if the docker is running in rootless mode
+
+_is_rootless_docker() {
+    docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q "rootless"
+}
+
+# Chown a data directory to a specific UID using a helper container.
+# In rootless mode, 'root' in a container maps to the host user,
+# so this is the only way to set ownership for non-root container users.
+_rootless_chown_data_dir() {
+    local svc="$1" uid="$2"
+    local dir="$INSTALL_DIR/data/$svc"
+    [[ -d "$dir" ]] || return 0
+    docker run --rm --user 0:0 \
+        -v "$dir:/data" \
+        alpine sh -c "chown -R ${uid}:${uid} /data" 2>/dev/null || \
+        warn "Rootless chown failed for $svc (non-fatal)"
+}
+
 if $DRY_RUN; then
     log "[DRY RUN] Would create: $INSTALL_DIR/{config,data,models}"
     log "[DRY RUN] Would copy compose files ($COMPOSE_FLAGS) and source tree"
     log "[DRY RUN] Would generate .env with secrets (WEBUI_SECRET, N8N_PASS, LITELLM_KEY, etc.)"
     log "[DRY RUN] Would generate SearXNG config with randomized secret key"
-    [[ "$ENABLE_HERMES" == "true" ]] && log "[DRY RUN] Would configure Hermes Agent (LLM endpoint: http://llama-server:8080/v1; data dir: $INSTALL_DIR/data/hermes)"
+
+    #The original sudo chown sets ownership using the host's understanding of UID 10000 — which doesn't exist in rootless mode 
+    #and doesn't map to what the container sees. In rootless mode we use the helper container instead, which chowns from inside
+    #the container where UID 10000 is valid.
+
+    if [[ "${ENABLE_HERMES:-false}" == "true" && -d "$INSTALL_DIR/data/hermes" ]]; then
+    if _is_rootless_docker; then
+        _rootless_chown_data_dir "hermes" 10000
+        docker run --rm --user 0:0 \
+            -v "$INSTALL_DIR/data/hermes:/data" \
+            alpine sh -c "chmod 700 /data" 2>/dev/null || true
+    else
+        sudo chown -R 10000:10000 "$INSTALL_DIR/data/hermes" 2>/dev/null || \
+            warn "Failed to restore data/hermes ownership to Hermes uid 10000 (Hermes dashboard may be unhealthy)"
+        sudo chmod 700 "$INSTALL_DIR/data/hermes" 2>/dev/null || true
+    fi
+fi
     [[ "$ENABLE_OPENCLAW" == "true" ]] && log "[DRY RUN] Would configure OpenClaw (model: $LLM_MODEL, config: ${OPENCLAW_CONFIG:-default})"
     log "[DRY RUN] Would validate .env against schema"
 else
@@ -77,6 +112,20 @@ else
             sudo chown -R "$(id -u):$(id -g)" "$_cfg_dir" 2>/dev/null || true
         fi
     done
+
+
+    # In rootless Docker mode, fix ownership of non-root service data directories
+    # using a helper container (host chown cannot reach container UIDs)
+    if _is_rootless_docker; then
+        ai "Rootless Docker detected — fixing data directory ownership for non-root containers..."
+        for _entry in "${ROOTLESS_SERVICE_UIDS[@]}"; do
+            _svc="${_entry%%:*}"
+            _uid="${_entry##*:}"
+            [[ "$_svc" == "hermes" ]] && continue  # hermes handled separately above (needs chmod 700 too)
+            _rootless_chown_data_dir "$_svc" "$_uid"
+        done
+        ai_ok "Rootless ownership fix applied"
+    fi
 
     # Ensure we can write to config/data subtrees (rsync will fail otherwise)
     if [[ "$SCRIPT_DIR" != "$INSTALL_DIR" ]]; then
@@ -233,7 +282,9 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         # Pre-create data/openclaw so chown doesn't fail on a fresh install where
         # the directory hasn't been touched yet.
         mkdir -p "$INSTALL_DIR/data/openclaw"
-        chown -R 1000:1000 "$INSTALL_DIR/data/openclaw" "$INSTALL_DIR/config/openclaw/workspace" || warn "Failed to chown openclaw paths to 1000:1000 (non-fatal); container may need uid fixup"
+        if ! _is_rootless_docker; then
+            chown -R 1000:1000 "$INSTALL_DIR/data/openclaw" "$INSTALL_DIR/config/openclaw/workspace" || warn "Failed to chown openclaw paths to 1000:1000 (non-fatal); container may need uid fixup"
+fi
     fi
 
     # token-spy container runs as uid 1000 (baked in Dockerfile) — fix ownership

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3228,6 +3228,7 @@ cmd_backup() {
         [[ -z "$id" ]] && error "Usage: ods backup verify <backup_id|backup_id.tar.gz>"
         "$INSTALL_DIR/ods-backup.sh" verify "$id"
         return
+    fi
     # Default: create backup (pass all args through)
     "$INSTALL_DIR/ods-backup.sh" "$@"
 }

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1328,6 +1328,7 @@ _ods_cli_fix_rootless_ownership() {
         "langfuse/postgres:70"
         "langfuse/clickhouse:101"
         "hermes:10000"
+        "comfyui:1000"
     )
 
     local _dir _svc _uid

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1219,6 +1219,7 @@ cmd_restart() {
         _ods_cli_wait_for_bootstrap_compose_safe "restart"
     fi
 
+     _ods_cli_fix_rootless_ownership
     if [[ -z "$resolved_service" ]]; then
         _compose_run_with_summary "Restarting all services" "${flags[@]}" up -d
     else
@@ -1306,6 +1307,48 @@ _ods_cli_refresh_soul() {
     return 0
 }
 
+# In rootless Docker mode, fix ownership of non-root service data dirs before
+# starting containers. Uses a helper container running as root (which maps to
+# the host user in rootless mode) to chown from inside the container namespace.
+_ods_cli_fix_rootless_ownership() {
+    docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q "rootless" || return 0
+    log "Rootless Docker detected — verifying data directory ownership..."
+
+    # Mirrors ROOTLESS_SERVICE_UIDS in installers/lib/constants.sh — keep in sync
+    #ods-cli is a standalone script — it never sources constants.sh. 
+    #Using local -a keeps the array scoped to the function so it doesn't pollute anything else. The comment is there so a future developer knows where to update both when adding a new service.
+    local -a _svc_uids=(
+        "n8n:1000"
+        "whisper:1000"
+        "tts:1000"
+        "token-spy:1000"
+        "privacy-shield:1000"
+        "ape:100"
+        "langfuse:1001"
+        "langfuse/postgres:70"
+        "langfuse/clickhouse:101"
+        "hermes:10000"
+    )
+
+    local _dir _svc _uid
+    for _entry in "${_svc_uids[@]}"; do
+        _svc="${_entry%%:*}"
+        _uid="${_entry##*:}"
+        _dir="$INSTALL_DIR/data/$_svc"
+        [[ -d "$_dir" ]] || continue
+
+        if [[ "$_svc" == "hermes" ]]; then
+            docker run --rm --user 0:0 \
+                -v "$_dir:/data" \
+                alpine sh -c "chown -R ${_uid}:${_uid} /data && chmod 700 /data" 2>/dev/null || true
+        else
+            docker run --rm --user 0:0 \
+                -v "$_dir:/data" \
+                alpine sh -c "chown -R ${_uid}:${_uid} /data" 2>/dev/null || true
+        fi
+    done
+}
+
 cmd_stop() {
     check_install
     cd "$INSTALL_DIR"
@@ -1366,6 +1409,7 @@ cmd_start() {
         _ods_cli_wait_for_bootstrap_compose_safe "start"
     fi
 
+     _ods_cli_fix_rootless_ownership
     if [[ -z "$resolved_service" ]]; then
         _compose_run_with_summary "Starting all services" "${flags[@]}" up -d
     else
@@ -3183,8 +3227,6 @@ cmd_backup() {
         [[ -z "$id" ]] && error "Usage: ods backup verify <backup_id|backup_id.tar.gz>"
         "$INSTALL_DIR/ods-backup.sh" verify "$id"
         return
-    fi
-
     # Default: create backup (pass all args through)
     "$INSTALL_DIR/ods-backup.sh" "$@"
 }

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -115,6 +115,62 @@ if command -v docker &> /dev/null; then
 else
     fail "Docker not installed"
 fi
+
+# Rootless Docker ownership check
+# The preflight check is what users run when something looks broken. Without this,
+# a rootless user would see cryptic EACCES errors deep in container logs with no guidance.
+# This surfaces the problem at the right level — tells the user exactly which services have wrong ownership
+# and gives them a one-line fix. It also uses ROOTLESS_SERVICE_UIDS from constants.sh 
+# so it stays in sync automatically when new services are added.
+if docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q "rootless"; then
+    warn "Docker is running in rootless mode"
+    log "  Checking data directory ownership for non-root containers..."
+
+    # Mirrors ROOTLESS_SERVICE_UIDS in installers/lib/constants.sh — keep in sync
+    # _preflight_svc_uids instead of local -a: ods-preflight.sh uses plain bash without function wrapping for its check blocks
+    # everything runs at the top level of the script. local is only valid inside functions, so we use a regular array 
+    # with a prefixed name (_preflight_) to avoid clashing with anything else in the script.
+    _preflight_svc_uids=(
+        "n8n:1000"
+        "whisper:1000"
+        "tts:1000"
+        "token-spy:1000"
+        "privacy-shield:1000"
+        "ape:100"
+        "langfuse:1001"
+        "langfuse/postgres:70"
+        "langfuse/clickhouse:101"
+        "hermes:10000"
+    )
+
+    _rootless_owner_ok() {
+        local svc="$1" uid="$2"
+        local dir="${ODS_HOME:-$HOME/ods}/data/$svc"
+        [[ -d "$dir" ]] || return 0
+        local actual_uid
+        actual_uid=$(docker run --rm --user 0:0 \
+            -v "$dir:/data" \
+            alpine sh -c "stat -c '%u' /data" 2>/dev/null || echo "unknown")
+        [[ "$actual_uid" == "$uid" ]]
+    }
+
+    _rootless_bad=()
+    for _entry in "${_preflight_svc_uids[@]}"; do
+        _svc="${_entry%%:*}"
+        _uid="${_entry##*:}"
+        if ! _rootless_owner_ok "$_svc" "$_uid"; then
+            _rootless_bad+=("$_svc (needs uid $_uid)")
+        fi
+    done
+
+    if [[ ${#_rootless_bad[@]} -gt 0 ]]; then
+        fail "Rootless ownership mismatch for: ${_rootless_bad[*]}"
+        warn "Fix with: ods restart  (ownership is corrected automatically on start/restart)"
+    else
+        pass "Rootless Docker: data directory ownership correct"
+    fi
+fi
+
 log ""
 
 # 2. Docker Compose check

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -141,6 +141,7 @@ if docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q "rootless";
         "langfuse/postgres:70"
         "langfuse/clickhouse:101"
         "hermes:10000"
+        "comfyui:1000"
     )
 
     _rootless_owner_ok() {


### PR DESCRIPTION
#Summary

Non-root container services (n8n, hermes, whisper, tts, token-spy, privacy-shield, ape, langfuse) fail with EACCES: permission denied on Docker rootless installs. In rootless mode, container UIDs are remapped — container UID 1000 maps to host UID 100999, not host UID 1000 — so directories created by the installer (owned by the host user) are inaccessible to non-root containers.

Fix by detecting rootless mode and using a helper container (--user 0:0, which maps to the host user in rootless) to chown data directories to the correct container UID before services start. Adds ROOTLESS_SERVICE_UIDS to constants.sh as a single source of truth for the service→UID map.

Affected files: installers/lib/constants.sh, installers/phases/06-directories.sh, ods-cli, ods-preflight.sh, extensions/services/langfuse/hooks/post_install.sh

AI Assistance

Gemini helped analyse the rootless UID remapping mechanics, identify all affected services and their container UIDs.

#Release Lane

- [x] Stable hotfix targeting release/2.5.x
- [ ] Mainline change targeting main
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

#Stable hotfix reason:

Docker rootless is increasingly adopted as a security best practice.
Affected users cannot start n8n, hermes, whisper, tts, token-spy,
privacy-shield, ape, or langfuse at all — core stack is broken on
install. No workaround without manual docker run commands per service.

#Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

#Risk And Validation

- Risk level: Low
- Validation run:
  - [x] git diff --check
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting release/2.5.x
  - [ ] Not required because:

#Commands/results:

# Non-rootless path — verify no regression
./install.sh --dry-run
ods start
ods restart
ods-preflight.sh

# Rootless path — verify fix
dockerd-rootless.sh
ods start   # all non-root services should start without EACCES
ods restart # ownership fix re-applied cleanly
ods-preflight.sh # should pass rootless ownership check

#Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

Notes For Reviewers

- The fix is a no-op on non-rootless installs — _is_rootless_docker returns early, nothing else runs
- ods-cli and ods-preflight.sh cannot source constants.sh (standalone scripts), so they carry inline copies of the UID map with a comment to keep them in sync
- Langfuse has 3 non-root users (nextjs/1001, postgres/70, clickhouse/101) — all three are covered
- The helper container approach (alpine sh -c "chown -R uid:uid /data") is the only reliable method in rootless mode since host-side chown and sudo chown cannot reach remapped UIDs
