### PR TITLE
fix(dashboard-api): resolve depends_on for built-in extensions in enable/disable

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1385,17 +1385,8 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
     }
 
 
-def _read_direct_deps(service_id: str) -> list[str]:
-    """Return direct depends_on list for a service from its manifest."""
-    ext_dir = USER_EXTENSIONS_DIR / service_id
-    manifest_path = None
-    for name in ("manifest.yaml", "manifest.yml"):
-        candidate = ext_dir / name
-        if candidate.exists():
-            manifest_path = candidate
-            break
-    if manifest_path is None:
-        return []
+def _parse_manifest_deps(manifest_path: Path) -> list[str]:
+    """Parse the service.depends_on list from a manifest file."""
     try:
         manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
     except (yaml.YAMLError, OSError):
@@ -1407,6 +1398,25 @@ def _read_direct_deps(service_id: str) -> list[str]:
     if not isinstance(depends_on, list):
         return []
     return [d for d in depends_on if isinstance(d, str) and _SERVICE_ID_RE.match(d)]
+
+
+def _read_direct_deps(service_id: str) -> list[str]:
+    """Return direct depends_on list for a service from its manifest.
+
+    Checks user-extensions first, then built-in extensions — the same
+    shadowing order as _resolve_extension_dir. A user directory without a
+    manifest still shadows a built-in of the same id.
+    """
+    for base in (USER_EXTENSIONS_DIR, EXTENSIONS_DIR):
+        ext_dir = base / service_id
+        if not ext_dir.is_dir():
+            continue
+        for name in ("manifest.yaml", "manifest.yml"):
+            candidate = ext_dir / name
+            if candidate.exists():
+                return _parse_manifest_deps(candidate)
+        return []
+    return []
 
 
 def _is_dep_satisfied(dep: str) -> bool:
@@ -1655,29 +1665,28 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
             status_code=409, detail=f"Extension already disabled: {service_id}",
         )
 
-    # Check reverse dependents (warn, don't block)
+    # Check reverse dependents (warn, don't block). Scan user and built-in
+    # extensions — user dirs shadow built-ins of the same id, mirroring
+    # _resolve_extension_dir. Only currently-enabled peers (compose.yaml
+    # present) are reported: a disabled dependent is unaffected, while an
+    # enabled one is left pointing at a service the merged compose project
+    # no longer defines, which fails compose config for the whole stack.
     dependents_warning = []
-    try:
-        if USER_EXTENSIONS_DIR.is_dir():
-            for peer_dir in USER_EXTENSIONS_DIR.iterdir():
-                if not peer_dir.is_dir() or peer_dir.name == service_id:
-                    continue
-                peer_manifest = peer_dir / "manifest.yaml"
-                if not peer_manifest.exists():
-                    continue
-                try:
-                    peer_data = yaml.safe_load(
-                        peer_manifest.read_text(encoding="utf-8"),
-                    )
-                    if isinstance(peer_data, dict):
-                        peer_svc = peer_data.get("service", {})
-                        deps = peer_svc.get("depends_on", []) if isinstance(peer_svc, dict) else []
-                        if isinstance(deps, list) and service_id in deps:
-                            dependents_warning.append(peer_dir.name)
-                except (yaml.YAMLError, OSError) as e:
-                    logger.debug("Could not read peer manifest %s: %s", peer_manifest, e)
-    except OSError:
-        pass
+    seen_peers: set[str] = set()
+    for base in (USER_EXTENSIONS_DIR, EXTENSIONS_DIR):
+        try:
+            peer_dirs = list(base.iterdir()) if base.is_dir() else []
+        except OSError:
+            continue
+        for peer_dir in peer_dirs:
+            if (not peer_dir.is_dir() or peer_dir.name == service_id
+                    or peer_dir.name in seen_peers):
+                continue
+            seen_peers.add(peer_dir.name)
+            if not (peer_dir / "compose.yaml").exists():
+                continue
+            if service_id in _read_direct_deps(peer_dir.name):
+                dependents_warning.append(peer_dir.name)
 
     # Call agent to stop BEFORE renaming (prevents zombie containers)
     agent_ok = _call_agent("stop", service_id)

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -1175,6 +1175,70 @@ class TestDisableExtension:
         data = resp.json()
         assert "dependent-ext" in data["dependents_warning"]
 
+    def test_disable_warns_about_builtin_dependents(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Disable warns when an enabled built-in extension depends on the target.
+
+        Mirrors the real hermes / hermes-proxy pair: both are built-ins, and
+        disabling hermes while hermes-proxy stays enabled breaks the merged
+        compose project.
+        """
+        builtin_root = tmp_path / "builtin"
+        ext_dir = builtin_root / "my-ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
+        dep_dir = builtin_root / "dependent-ext"
+        dep_dir.mkdir()
+        (dep_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
+        (dep_dir / "manifest.yaml").write_text(
+            yaml.dump({"service": {"depends_on": ["my-ext"]}}),
+        )
+        _patch_mutation_config(monkeypatch, tmp_path)
+        monkeypatch.setattr("routers.extensions._call_agent", lambda action, sid: True)
+
+        def _mock_compose_rename(action, service_id):
+            (ext_dir / "compose.yaml").rename(ext_dir / "compose.yaml.disabled")
+            return True
+
+        monkeypatch.setattr(
+            "routers.extensions._call_agent_compose_rename",
+            _mock_compose_rename,
+        )
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/disable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert "dependent-ext" in resp.json()["dependents_warning"]
+
+    def test_disable_skips_disabled_dependents(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """A dependent that is itself disabled does not trigger the warning."""
+        user_dir = tmp_path / "user"
+        user_dir.mkdir()
+        ext_dir = user_dir / "my-ext"
+        ext_dir.mkdir()
+        (ext_dir / "compose.yaml").write_text(_SAFE_COMPOSE)
+        dep_dir = user_dir / "dependent-ext"
+        dep_dir.mkdir()
+        (dep_dir / "compose.yaml.disabled").write_text(_SAFE_COMPOSE)
+        (dep_dir / "manifest.yaml").write_text(
+            yaml.dump({"service": {"depends_on": ["my-ext"]}}),
+        )
+        _patch_mutation_config(monkeypatch, tmp_path, user_dir=user_dir)
+
+        resp = test_client.post(
+            "/api/extensions/my-ext/disable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["dependents_warning"] == []
+
     def test_disable_requires_auth(self, test_client):
         """POST disable without auth → 401."""
         resp = test_client.post("/api/extensions/my-ext/disable")

--- a/ods/extensions/services/dashboard-api/tests/test_extensions_deps.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions_deps.py
@@ -226,3 +226,113 @@ class TestAutoEnableDeps:
 
         assert resp.status_code == 400
         assert "Circular" in resp.json().get("detail", "")
+
+
+# --- Built-in extension dependencies ---
+
+
+def _setup_builtin_ext(tmp_path, sid, deps=None, enabled=False):
+    """Create a built-in extension under tmp_path/ext with a manifest."""
+    d = tmp_path / "ext" / sid
+    d.mkdir(parents=True)
+    compose_name = "compose.yaml" if enabled else "compose.yaml.disabled"
+    (d / compose_name).write_text("services: {}")
+    (d / "manifest.yaml").write_text(yaml.dump({
+        "schema_version": "ods.services.v1",
+        "service": {
+            "id": sid, "name": sid, "port": 8080, "health": "/health",
+            "depends_on": deps or [],
+        },
+    }))
+    return d
+
+
+def _patch_builtin_config(monkeypatch, tmp_path):
+    user_dir = tmp_path / "user"
+    user_dir.mkdir(exist_ok=True)
+    monkeypatch.setattr("routers.extensions.USER_EXTENSIONS_DIR", user_dir)
+    monkeypatch.setattr("routers.extensions.EXTENSIONS_DIR", tmp_path / "ext")
+    monkeypatch.setattr("routers.extensions.CORE_SERVICE_IDS", frozenset())
+    monkeypatch.setattr("routers.extensions.DATA_DIR", str(tmp_path))
+
+
+class TestBuiltinExtensionDeps:
+    """Dependency resolution must read built-in extension manifests too.
+
+    Built-in extensions live under EXTENSIONS_DIR (e.g. hermes-proxy with
+    depends_on: [hermes]); enabling one with a disabled dependency, or
+    disabling a dependency while a built-in dependent is enabled, breaks
+    the merged compose project for the entire stack.
+    """
+
+    def test_enable_builtin_missing_deps_returns_list(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        """Enable of a built-in with a disabled built-in dep → 400 + dep list."""
+        _setup_builtin_ext(tmp_path, "svc-b", enabled=False)
+        _setup_builtin_ext(tmp_path, "svc-a", deps=["svc-b"], enabled=False)
+        _patch_builtin_config(monkeypatch, tmp_path)
+
+        resp = test_client.post(
+            "/api/extensions/svc-a/enable",
+            headers=test_client.auth_headers,
+        )
+
+        assert resp.status_code == 400
+        body = resp.json()["detail"]
+        assert "svc-b" in body["missing_dependencies"]
+        assert body["auto_enable_available"] is True
+
+    def test_enable_builtin_auto_deps(self, test_client, monkeypatch, tmp_path):
+        """auto_enable_deps=true activates the built-in dep first via host agent."""
+        dep_dir = _setup_builtin_ext(tmp_path, "svc-b", enabled=False)
+        ext_dir = _setup_builtin_ext(tmp_path, "svc-a", deps=["svc-b"], enabled=False)
+        _patch_builtin_config(monkeypatch, tmp_path)
+
+        rename_calls = []
+
+        def _mock_compose_rename(action, service_id):
+            rename_calls.append((action, service_id))
+            d = dep_dir if service_id == "svc-b" else ext_dir
+            (d / "compose.yaml.disabled").rename(d / "compose.yaml")
+            return True
+
+        with patch("routers.extensions._call_agent", return_value=True), \
+             patch("routers.extensions._call_agent_hook", return_value=True), \
+             patch("routers.extensions._call_agent_compose_rename",
+                   side_effect=_mock_compose_rename):
+            resp = test_client.post(
+                "/api/extensions/svc-a/enable?auto_enable_deps=true",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["enabled_services"] == ["svc-b", "svc-a"]
+        assert rename_calls == [("activate", "svc-b"), ("activate", "svc-a")]
+        assert (dep_dir / "compose.yaml").exists()
+        assert (ext_dir / "compose.yaml").exists()
+
+    def test_user_manifest_shadows_builtin(self, test_client, monkeypatch, tmp_path):
+        """A user extension of the same id takes precedence over the built-in manifest."""
+        # Built-in declares a dep that would be missing; the user copy declares none.
+        _setup_builtin_ext(tmp_path, "svc-a", deps=["svc-missing"], enabled=False)
+        _patch_builtin_config(monkeypatch, tmp_path)
+
+        user_ext = tmp_path / "user" / "svc-a"
+        user_ext.mkdir(parents=True)
+        (user_ext / "compose.yaml.disabled").write_text("services: {}")
+        (user_ext / "manifest.yaml").write_text(yaml.dump({
+            "schema_version": "ods.services.v1",
+            "service": {"id": "svc-a", "name": "A", "port": 8080, "health": "/health"},
+        }))
+
+        with patch("routers.extensions._call_agent", return_value=True), \
+             patch("routers.extensions._call_agent_hook", return_value=True):
+            resp = test_client.post(
+                "/api/extensions/svc-a/enable",
+                headers=test_client.auth_headers,
+            )
+
+        assert resp.status_code == 200
+        assert (user_ext / "compose.yaml").exists()


### PR DESCRIPTION
## Summary

The dashboard-api extensions router supports enabling/disabling **built-in** extensions (`_resolve_extension_dir` and `_activate_service` handle the `EXTENSIONS_DIR` + host-agent-rename path), but its **dependency resolution never did** — both `_read_direct_deps` and the disable-time dependents scan only looked at `USER_EXTENSIONS_DIR`.

For built-in pairs like `hermes-proxy` → `depends_on: [hermes, dashboard-api]` (both `category: recommended`, both toggleable from the dashboard):

- **Enable:** `POST /api/extensions/hermes-proxy/enable` with hermes disabled finds no manifest under user-extensions, reads an **empty dep list**, and enables the proxy alone. The merged compose project now has `depends_on` on an undefined service → `docker compose config` rejects the **whole project**, so `ods start`/`restart` takes down every service, not just the pair.
- **Disable:** `POST /api/extensions/hermes/disable` scans only user-extensions for dependents, so it disables hermes with **no warning at all** while hermes-proxy stays enabled — same stack-wide failure on the next compose operation.

This is the dashboard-API sibling of #1712 (Windows CLI) and the same failure mode the Linux CLI already guards against: `ods-cli` resolves deps from the full service registry (built-ins included) in both directions.

## Changes

- `_read_direct_deps` now resolves the manifest **user-first, then built-in**, matching `_resolve_extension_dir`'s shadowing order. The existing missing-deps `400` response and `auto_enable_deps=true` cascade now work for built-in extensions (activation of built-in deps already worked — it goes through `_activate_service` → host-agent rename).
- Extracted `_parse_manifest_deps` so the disable-time dependents scan reuses the same manifest parsing instead of its inline copy.
- The disable dependents scan covers **both** directories (user shadows built-in) and only reports peers whose `compose.yaml` is present: a disabled dependent is unaffected by the disable, and warning about it was noise. This mirrors the Linux CLI, which skips disabled dependents (`[[ ! -f "$dep_cf" ]] && continue`).
- Disable stays **warn-don't-block** — unchanged API contract; only the scan's coverage is fixed.

Note: the catalog endpoint already computed `dependents` across the whole `EXTENSION_CATALOG`, so the UI displayed the exact relationship the mutation endpoints ignored.

## Tests

New cases (all fail on `main`, pass with this change):

- `TestBuiltinExtensionDeps::test_enable_builtin_missing_deps_returns_list` — enabling a built-in with a disabled built-in dep returns `400` + `missing_dependencies` + `auto_enable_available`.
- `TestBuiltinExtensionDeps::test_enable_builtin_auto_deps` — `auto_enable_deps=true` activates the dep first via `("activate", dep)` host-agent rename, then the target.
- `TestBuiltinExtensionDeps::test_user_manifest_shadows_builtin` — a user copy of the same id takes precedence over the built-in manifest.
- `TestDisableExtension::test_disable_warns_about_builtin_dependents` — disabling a built-in with an enabled built-in dependent surfaces `dependents_warning` (the hermes/hermes-proxy shape).
- `TestDisableExtension::test_disable_skips_disabled_dependents` — a dependent that is itself disabled no longer triggers the warning.

## Verification

- `pytest tests/` (dashboard-api): **1175 passed**, 9 skipped; the only failures are the 3 pre-existing Windows-host baseline failures (`test_setup_sentinel.py` ×2 bash-dependent, `test_user_extensions.py::test_scan_symlink_skipped`), identical on clean `main`.
- `ruff check ods/ --select E,F,W --ignore E501,E701,E731,E741,E402`: clean.
