### PR TITLE
fix(update): stop backup abort after first copied file under set -e

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -59,6 +59,9 @@ test: ## Run unit and contract tests
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh
 	@echo ""
+	@echo "=== ods-update.sh backup command ==="
+	@bash tests/test-update-script-backup.sh
+	@echo ""
 	@echo "=== bootstrap-upgrade spawn closes inherited FDs ==="
 	@bash tests/test-bootstrap-upgrade-close-inherited-fds.sh
 	@echo ""

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -570,20 +570,23 @@ cmd_backup() {
     mkdir -p "$backup_path"
     
     # Backup compose files
+    # NB: x=$((x + 1)) not ((x++)) — the post-increment form evaluates to 0
+    # on the first increment, which set -e treats as failure and aborts the
+    # backup after copying a single file.
     local files_backed_up=0
     for pattern in "docker-compose*.yml" "docker-compose*.yaml" ".env" ".env.*"; do
         for file in "${INSTALL_DIR}"/${pattern}; do
             if [[ -f "$file" ]]; then
                 cp "$file" "$backup_path/"
-                ((files_backed_up++))
+                files_backed_up=$((files_backed_up + 1))
             fi
         done
     done
-    
+
     # Backup version file
     if [[ -f "$VERSION_FILE" ]]; then
         cp "$VERSION_FILE" "$backup_path/.version"
-        ((files_backed_up++))
+        files_backed_up=$((files_backed_up + 1))
     fi
     
     # Generate metadata (use jq for safe JSON construction)
@@ -604,7 +607,7 @@ cmd_backup() {
     backup_dirs=$(find "$BACKUP_DIR" -maxdepth 1 -type d -name "backup-*" | sort -r)
     local count=0
     for dir in $backup_dirs; do
-        ((count++))
+        count=$((count + 1))
         if ((count > MAX_BACKUPS)); then
             log_info "Removing old backup: $(basename "$dir")"
             rm -rf "$dir"

--- a/ods/tests/test-update-script-backup.sh
+++ b/ods/tests/test-update-script-backup.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# ============================================================================
+# ods-update.sh backup command test
+# ============================================================================
+# cmd_backup counted copied files with ((files_backed_up++)). Bash
+# post-increment evaluates to the old value, so the first increment
+# (0 -> 1) returns status 1 and set -e killed the script right after
+# copying the first compose file: no metadata.json, no "Backup created",
+# exit 1. Since ods-cli's cmd_update delegates its pre-update snapshot to
+# `ods-update.sh backup`, the safety net always failed with
+# "Pre-update snapshot failed; proceeding without safety net."
+# The rotation loop's ((count++)) had the same defect.
+#
+# Strategy: run the real script from a throwaway install dir with HOME
+# pointed at a fixture so BACKUP_DIR ($HOME/.ods/backups) is isolated.
+#
+# Usage: ./tests/test-update-script-backup.sh
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/ods-update-backup.XXXXXX")"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+# INSTALL_DIR is the script's own directory; BACKUP_DIR is $HOME/.ods/backups
+mkdir -p "$FIXTURE/home"
+cp "$ROOT_DIR/ods-update.sh" "$FIXTURE/ods-update.sh"
+: > "$FIXTURE/docker-compose.base.yml"
+: > "$FIXTURE/docker-compose.nvidia.yml"
+echo "GPU_BACKEND=nvidia" > "$FIXTURE/.env"
+echo '{"version": "2.0.0"}' > "$FIXTURE/.version"
+
+BACKUPS="$FIXTURE/home/.ods/backups"
+
+run_backup() {
+    # Never let a non-zero exit kill the test; callers assert on output/state
+    HOME="$FIXTURE/home" bash "$FIXTURE/ods-update.sh" backup "$@" 2>&1 || true
+}
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   ods-update.sh backup test                   ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+# ---------------------------------------------------------------------------
+# 1. backup completes past the first copied file
+# ---------------------------------------------------------------------------
+output=$(run_backup snaptest)
+backup_dir=$(find "$BACKUPS" -maxdepth 1 -type d -name "backup-snaptest-*" | head -1)
+
+if echo "$output" | grep -q "Backup created"; then
+    pass "backup runs to completion"
+else
+    fail "backup aborted mid-copy: $output"
+fi
+if [[ -n "$backup_dir" && -f "$backup_dir/metadata.json" ]]; then
+    pass "backup wrote metadata.json"
+else
+    fail "metadata.json missing (backup died before writing it)"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. all eligible files are copied and counted
+# ---------------------------------------------------------------------------
+# 2 compose files + .env + .version = 4
+if echo "$output" | grep -q "Files backed up: 4"; then
+    pass "backup counted all 4 files"
+else
+    fail "wrong file count: $(echo "$output" | grep 'Files backed up' || echo "$output")"
+fi
+if [[ -f "$backup_dir/docker-compose.nvidia.yml" && -f "$backup_dir/.version" ]]; then
+    pass "backup copied files beyond the first one"
+else
+    fail "backup stopped after the first file"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. rotation prunes down to MAX_BACKUPS without aborting
+# ---------------------------------------------------------------------------
+rm -rf "$BACKUPS"
+mkdir -p "$BACKUPS"
+for i in 01 02 03 04 05; do
+    mkdir -p "$BACKUPS/backup-2020010${i#0}-00000$i"
+done
+
+output=$(MAX_BACKUPS=3 run_backup rotate)
+remaining=$(find "$BACKUPS" -maxdepth 1 -type d -name "backup-*" | wc -l)
+
+if [[ "$remaining" -eq 3 ]]; then
+    pass "rotation kept exactly MAX_BACKUPS backups"
+else
+    fail "rotation left $remaining backups (expected 3): $output"
+fi
+if find "$BACKUPS" -maxdepth 1 -type d -name "backup-rotate-*" | grep -q .; then
+    pass "newest backup survived rotation"
+else
+    fail "rotation removed the backup it just created"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Third instance of the `((x++))` + `set -e` abort found while sweeping for the class after #1716/#1717 — this one takes out the pre-update safety net.

`cmd_backup` in `ods-update.sh` counts copied files with `((files_backed_up++))`. Bash post-increment evaluates to the *old* value, so the first increment (0→1) returns status 1 and `set -euo pipefail` kills the script right after copying the first compose file: no `metadata.json`, no `Backup created` log, exit 1. Trivially reproducible on current `main`:

```
$ ods-update.sh backup snaptest
[INFO] Creating backup: backup-snaptest-...
$ echo $?
1        # backup dir contains exactly one file, no metadata.json
```

Impact: `ods-cli`'s `cmd_update` delegates its pre-update snapshot to `ods-update.sh backup` — so the snapshot **always** fails and every update proceeds with only the warning *"Pre-update snapshot failed; proceeding without safety net"*, i.e. without the rollback backup it was designed to have. The rotation loop's `((count++))` has the same defect, so old backups were never pruned either (unreachable until now anyway, since the function died earlier).

## Fix

Count with `x=$((x + 1))`, same as #1716/#1717, with a comment on the `set -e` interaction. This was the last unguarded post-increment in a `set -e` script in the repo's shell surface — `ods-restore.sh`'s `((i++))` starts at 1 (safe), `llm-cold-storage.sh` and `test-stack.sh` don't set `-e`, and the rest are `|| true`-guarded.

## Tests

New `tests/test-update-script-backup.sh` (registered in `make test`): runs the real script with `HOME` pointed at a fixture so `BACKUP_DIR` is isolated:

- backup completes past the first file, writes `metadata.json`, logs `Backup created`
- all 4 eligible files copied and counted (`Files backed up: 4`)
- rotation prunes to `MAX_BACKUPS` and keeps the newest backup — exercises the `count` counter through and past the threshold

On unfixed `main` the test fails 5/6; with the fix 6/6 pass. `bash -n` clean.

## Related

- #1716 — same abort in `ods preset load`
- #1717 — same abort in `ods update` post-verification