### PR TITLE
Validate subordinate UID/GID range allocation for rootless Docker in preflight and doctor checks

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -70,6 +70,10 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
+	@echo ""
+	@echo "=== Rootless Docker subuid validation ==="
+	@bash tests/test-rootless-subuid-validation.sh
+
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -109,6 +109,50 @@ if command -v docker &> /dev/null; then
 
     if docker info &> /dev/null; then
         pass "Docker daemon running"
+
+        # Detect rootless mode
+        if docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q rootless; then
+            # Subordinate UID/GID checks
+            user_name=$(id -un)
+            subuid_file="${ODS_TEST_SUBUID_FILE:-/etc/subuid}"
+            subgid_file="${ODS_TEST_SUBGID_FILE:-/etc/subgid}"
+            min_range=65536
+
+            if [[ "$(uname -s)" == "Linux" ]]; then
+                range_ok=true
+                if [[ ! -f "$subuid_file" ]]; then
+                    warn "Subordinate UID allocation file $subuid_file is missing. Rootless containers will fail to start."
+                    warn "  To fix, run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $user_name"
+                    range_ok=false
+                fi
+                if [[ ! -f "$subgid_file" ]]; then
+                    warn "Subordinate GID allocation file $subgid_file is missing. Rootless containers will fail to start."
+                    warn "  To fix, run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $user_name"
+                    range_ok=false
+                fi
+
+                if $range_ok; then
+                    subuid_total=$(awk -F: -v user="$user_name" '$1 == user {s+=$3} END {print s+0}' "$subuid_file" 2>/dev/null || echo 0)
+                    subgid_total=$(awk -F: -v user="$user_name" '$1 == user {s+=$3} END {print s+0}' "$subgid_file" 2>/dev/null || echo 0)
+
+                    if [[ -z "$subuid_total" || "$subuid_total" -eq 0 ]]; then
+                        warn "No subordinate UID range allocated for user '$user_name' in $subuid_file."
+                        warn "  To fix, run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $user_name"
+                    elif [[ "$subuid_total" -lt "$min_range" ]]; then
+                        warn "Subordinate UID range ($subuid_total) for user '$user_name' is smaller than the required minimum ($min_range)."
+                        warn "  To fix, run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $user_name"
+                    fi
+
+                    if [[ -z "$subgid_total" || "$subgid_total" -eq 0 ]]; then
+                        warn "No subordinate GID range allocated for user '$user_name' in $subgid_file."
+                        warn "  To fix, run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $user_name"
+                    elif [[ "$subgid_total" -lt "$min_range" ]]; then
+                        warn "Subordinate GID range ($subgid_total) for user '$user_name' is smaller than the required minimum ($min_range)."
+                        warn "  To fix, run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $user_name"
+                    fi
+                fi
+            fi
+        fi
     else
         fail "Docker daemon not running — start with: sudo systemctl start docker"
     fi

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -106,6 +106,9 @@ fi
 
 DOCKER_CLI="false"
 DOCKER_DAEMON="false"
+DOCKER_ROOTLESS="false"
+DOCKER_ROOTLESS_SUBID_WARNING=""
+user_name=""
 COMPOSE_CLI="false"
 DASHBOARD_HTTP="false"
 WEBUI_HTTP="false"
@@ -117,6 +120,46 @@ if command -v docker >/dev/null 2>&1; then
     DOCKER_CLI="true"
     if docker info >/dev/null 2>&1; then
         DOCKER_DAEMON="true"
+        # Detect rootless mode
+        if docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q rootless; then
+            DOCKER_ROOTLESS="true"
+            # Subordinate UID/GID checks
+            user_name=$(id -un)
+            subuid_file="${ODS_TEST_SUBUID_FILE:-/etc/subuid}"
+            subgid_file="${ODS_TEST_SUBGID_FILE:-/etc/subgid}"
+            min_range=65536
+
+            if [[ "$(uname -s)" == "Linux" ]]; then
+                has_subuid=true
+                has_subgid=true
+                if [[ ! -f "$subuid_file" ]]; then
+                    DOCKER_ROOTLESS_SUBID_WARNING="Missing $subuid_file range allocation."
+                    has_subuid=false
+                fi
+                if [[ ! -f "$subgid_file" ]]; then
+                    if [[ -z "$DOCKER_ROOTLESS_SUBID_WARNING" ]]; then
+                        DOCKER_ROOTLESS_SUBID_WARNING="Missing $subgid_file range allocation."
+                    else
+                        DOCKER_ROOTLESS_SUBID_WARNING="Missing $subuid_file and $subgid_file range allocations."
+                    fi
+                    has_subgid=false
+                fi
+
+                if $has_subuid && $has_subgid; then
+                    subuid_total=$(awk -F: -v user="$user_name" '$1 == user {s+=$3} END {print s+0}' "$subuid_file" 2>/dev/null || echo 0)
+                    subgid_total=$(awk -F: -v user="$user_name" '$1 == user {s+=$3} END {print s+0}' "$subgid_file" 2>/dev/null || echo 0)
+                    if [[ -z "$subuid_total" || "$subuid_total" -eq 0 ]]; then
+                        DOCKER_ROOTLESS_SUBID_WARNING="No subordinate UID range allocated for user '$user_name' in $subuid_file."
+                    elif [[ -z "$subgid_total" || "$subgid_total" -eq 0 ]]; then
+                        DOCKER_ROOTLESS_SUBID_WARNING="No subordinate GID range allocated for user '$user_name' in $subgid_file."
+                    elif [[ "$subuid_total" -lt "$min_range" ]]; then
+                        DOCKER_ROOTLESS_SUBID_WARNING="Subordinate UID range ($subuid_total) in $subuid_file is smaller than required minimum ($min_range)."
+                    elif [[ "$subgid_total" -lt "$min_range" ]]; then
+                        DOCKER_ROOTLESS_SUBID_WARNING="Subordinate GID range ($subgid_total) in $subgid_file is smaller than required minimum ($min_range)."
+                    fi
+                fi
+            fi
+        fi
     fi
     if docker compose version >/dev/null 2>&1 || command -v docker-compose >/dev/null 2>&1; then
         COMPOSE_CLI="true"
@@ -343,7 +386,7 @@ elif command -v python >/dev/null 2>&1; then
     PYTHON_CMD="python"
 fi
 
-"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" "$TTS_HTTP" "$TTS_PORT" "$DGX_SPARK_GPU" "$DGX_SPARK_GPU_NAME" "$DGX_SPARK_COMPUTE_CAP" "$LLAMA_CUDA_ARCHS" "$DGX_SPARK_CUDA_ARCH_STATUS" "$DGX_SPARK_CUDA_ARCH_MESSAGE" "$HERMES_SLASH_WORKER_COUNT" "$HERMES_SLASH_WORKER_MAX_COUNT" "$ODS_MANAGED_CONTAINER_COUNT" "$ODS_RUNNING_CONTAINER_COUNT" "$ROOT_DIR" <<'PY'
+"$PYTHON_CMD" - "$CAP_FILE" "$PREFLIGHT_FILE" "$REPORT_FILE" "$DOCKER_CLI" "$DOCKER_DAEMON" "$COMPOSE_CLI" "$DASHBOARD_HTTP" "$WEBUI_HTTP" "$_DASHBOARD_PORT" "$_WEBUI_PORT" "$EXT_DIAGNOSTICS" "$STT_MODEL_CACHED" "$STT_MODEL_NAME" "$STT_RECOVERY_HINT" "$TTS_HTTP" "$TTS_PORT" "$DGX_SPARK_GPU" "$DGX_SPARK_GPU_NAME" "$DGX_SPARK_COMPUTE_CAP" "$LLAMA_CUDA_ARCHS" "$DGX_SPARK_CUDA_ARCH_STATUS" "$DGX_SPARK_CUDA_ARCH_MESSAGE" "$HERMES_SLASH_WORKER_COUNT" "$HERMES_SLASH_WORKER_MAX_COUNT" "$ODS_MANAGED_CONTAINER_COUNT" "$ODS_RUNNING_CONTAINER_COUNT" "$ROOT_DIR" "$DOCKER_ROOTLESS" "$DOCKER_ROOTLESS_SUBID_WARNING" "$user_name" <<'PY'
 import json
 import os
 import pathlib
@@ -353,7 +396,7 @@ import sys
 from datetime import datetime, timezone
 from urllib import error, parse, request
 
-cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, tts_http, tts_port, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message, hermes_slash_worker_count, hermes_slash_worker_max_count, ods_managed_container_count, ods_running_container_count, root_dir_arg = sys.argv[1:]
+cap_file, preflight_file, report_file, docker_cli, docker_daemon, compose_cli, dashboard_http, webui_http, dashboard_port, webui_port, ext_diagnostics_json, stt_cached, stt_model_name, stt_recovery, tts_http, tts_port, dgx_spark_gpu, dgx_spark_gpu_name, dgx_spark_compute_cap, llama_cuda_archs, dgx_spark_arch_status, dgx_spark_arch_message, hermes_slash_worker_count, hermes_slash_worker_max_count, ods_managed_container_count, ods_running_container_count, root_dir_arg, docker_rootless, docker_rootless_subid_warning, current_user = sys.argv[1:]
 
 cap = json.load(open(cap_file, "r", encoding="utf-8"))
 pre = json.load(open(preflight_file, "r", encoding="utf-8"))
@@ -1287,6 +1330,8 @@ report = {
         },
         "amd_runtime": amd_runtime,
         "inference_contract": inference_contract_public,
+        "docker_rootless": docker_rootless == "true",
+        "docker_rootless_subid_warning": docker_rootless_subid_warning,
     },
     "extensions": ext_diagnostics,
     "summary": {
@@ -1297,6 +1342,7 @@ report = {
             + (1 if stt_cached in {"false", "service_down"} else 0)
             + (1 if tts_http == "false" else 0)
             + (1 if hermes_slash_worker_count_num > hermes_slash_worker_max_count_num else 0)
+            + (1 if docker_rootless_subid_warning else 0)
             + len(amd_runtime.get("warnings", []))
             + inference_contract.get("issue_counts", {}).get("warnings", 0)
         ),
@@ -1333,6 +1379,14 @@ if runtime["docker_daemon"] and not runtime["dashboard_http"]:
     fix_hints.append(f"Run installer/start command, then verify dashboard on http://127.0.0.1:{dashboard_port}.")
 if runtime["docker_daemon"] and not runtime["webui_http"]:
     fix_hints.append(f"Verify Open WebUI container and port {webui_port} mapping.")
+
+if runtime["docker_rootless_subid_warning"]:
+    fix_hints.append(
+        f"Docker rootless subordinate ranges invalid: {runtime['docker_rootless_subid_warning']}\n"
+        f"  Configure subordinate ranges via:\n"
+        f"    sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 {current_user}\n"
+        f"  then run: systemctl --user restart docker"
+    )
 
 # STT model cache: service up but model missing is a common silent failure
 if stt_cached == "false" and stt_recovery:
@@ -1425,6 +1479,14 @@ ext_issues = summary.get("extensions_issues", 0)
 
 if ext_total > 0:
     print(f"  Extensions:    {ext_healthy}/{ext_total} healthy, {ext_issues} with issues")
+
+runtime_info = data.get("runtime", {})
+if runtime_info.get("docker_rootless"):
+    subid_warn = runtime_info.get("docker_rootless_subid_warning")
+    if subid_warn:
+        print(f"  Docker:        rootless mode (warning: {subid_warn})")
+    else:
+        print("  Docker:        rootless mode (subordinate ID range OK)")
 
 dgx_check = data.get("runtime", {}).get("dgx_spark_cuda_arch_check", {})
 if dgx_check.get("status") == "warn":

--- a/ods/tests/test-rootless-subuid-validation.sh
+++ b/ods/tests/test-rootless-subuid-validation.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+set -eo pipefail
+
+# ANSI color codes
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Determine directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Define absolute paths to scripts
+ODS_PREFLIGHT="$ROOT_DIR/ods-preflight.sh"
+ODS_DOCTOR="$ROOT_DIR/scripts/ods-doctor.sh"
+
+fail() {
+    echo -e "${RED}✗ $1${NC}" >&2
+    exit 1
+}
+
+pass() {
+    echo -e "${GREEN}✓ $1${NC}"
+}
+
+info() {
+    echo -e "ℹ $1"
+}
+
+# ── Test: Subordinate UID/GID range verification in preflight and doctor ─────
+
+info "Subuid/Subgid: Preflight warns when subordinate files are missing"
+TMP_SUBID="$(mktemp -d)"
+MOCK_BIN="$TMP_SUBID/bin"
+mkdir -p "$MOCK_BIN"
+
+cat > "$MOCK_BIN/docker" << 'EOF'
+#!/bin/bash
+if [[ "$*" == *"SecurityOptions"* ]]; then
+    echo "rootless"
+    exit 0
+fi
+exit 0
+EOF
+chmod +x "$MOCK_BIN/docker"
+
+cat > "$MOCK_BIN/uname" << 'EOF'
+#!/bin/bash
+echo "Linux"
+EOF
+chmod +x "$MOCK_BIN/uname"
+
+cat > "$MOCK_BIN/id" << 'EOF'
+#!/bin/bash
+echo "testuser"
+EOF
+chmod +x "$MOCK_BIN/id"
+
+cat > "$MOCK_BIN/curl" << 'EOF'
+#!/bin/bash
+exit 0
+EOF
+chmod +x "$MOCK_BIN/curl"
+
+# Set up environment variables
+export PATH="$MOCK_BIN:$PATH"
+export ODS_TEST_SUBUID_FILE="$TMP_SUBID/missing_subuid"
+export ODS_TEST_SUBGID_FILE="$TMP_SUBID/missing_subgid"
+
+# Create a minimal .env file so the preflight script loads it without errors
+echo "GPU_BACKEND=cpu" > "$TMP_SUBID/.env"
+
+# Run preflight in a subshell capturing stdout/stderr
+PREFLIGHT_OUT="$TMP_SUBID/preflight.out"
+(
+    cd "$TMP_SUBID"
+    # Copy preflight script to temp dir so it works relative to its location
+    cp "$ODS_PREFLIGHT" ./ods-preflight.sh
+    mkdir -p lib
+    echo "load_env_file() { :; }" > lib/safe-env.sh
+    bash ./ods-preflight.sh > "$PREFLIGHT_OUT" 2>&1 || true
+)
+
+grep -q "Subordinate UID allocation file.*missing" "$PREFLIGHT_OUT" \
+    || { cat "$PREFLIGHT_OUT"; fail "Preflight did not warn on missing subuid file"; }
+grep -q "Subordinate GID allocation file.*missing" "$PREFLIGHT_OUT" \
+    || { cat "$PREFLIGHT_OUT"; fail "Preflight did not warn on missing subgid file"; }
+pass "Preflight warns when subordinate files are missing"
+
+info "Subuid/Subgid: Preflight warns when subordinate range is insufficient"
+SUBUID_FILE="$TMP_SUBID/subuid_low"
+SUBGID_FILE="$TMP_SUBID/subgid_low"
+echo "testuser:100000:1000" > "$SUBUID_FILE"
+echo "testuser:100000:1000" > "$SUBGID_FILE"
+
+export ODS_TEST_SUBUID_FILE="$SUBUID_FILE"
+export ODS_TEST_SUBGID_FILE="$SUBGID_FILE"
+
+PREFLIGHT_OUT2="$TMP_SUBID/preflight2.out"
+(
+    cd "$TMP_SUBID"
+    bash ./ods-preflight.sh > "$PREFLIGHT_OUT2" 2>&1 || true
+)
+
+grep -q "Subordinate UID range (1000).*smaller than.*65536" "$PREFLIGHT_OUT2" \
+    || { cat "$PREFLIGHT_OUT2"; fail "Preflight did not warn on low subuid range"; }
+grep -q "Subordinate GID range (1000).*smaller than.*65536" "$PREFLIGHT_OUT2" \
+    || { cat "$PREFLIGHT_OUT2"; fail "Preflight did not warn on low subgid range"; }
+pass "Preflight warns when subordinate range is insufficient"
+
+info "Subuid/Subgid: Preflight passes when subordinate range is sufficient"
+SUBUID_OK="$TMP_SUBID/subuid_ok"
+SUBGID_OK="$TMP_SUBID/subgid_ok"
+echo "testuser:100000:65536" > "$SUBUID_OK"
+echo "testuser:100000:65536" > "$SUBGID_OK"
+
+export ODS_TEST_SUBUID_FILE="$SUBUID_OK"
+export ODS_TEST_SUBGID_FILE="$SUBGID_OK"
+
+PREFLIGHT_OUT3="$TMP_SUBID/preflight3.out"
+(
+    cd "$TMP_SUBID"
+    bash ./ods-preflight.sh > "$PREFLIGHT_OUT3" 2>&1 || true
+)
+
+grep -q "smaller than" "$PREFLIGHT_OUT3" && fail "Preflight warned on valid subuid/subgid range"
+grep -q "missing" "$PREFLIGHT_OUT3" && fail "Preflight warned on missing valid subuid/subgid range"
+pass "Preflight passes when subordinate range is sufficient"
+
+info "Subuid/Subgid: Doctor warns when subordinate range is insufficient"
+# Copy lib, scripts, and config from the repository to our temp folder first
+cp -r "$ROOT_DIR/lib" "$TMP_SUBID/"
+cp -r "$ROOT_DIR/scripts" "$TMP_SUBID/"
+cp -r "$ROOT_DIR/config" "$TMP_SUBID/"
+
+mkdir -p "$TMP_SUBID/data"
+echo "{}" > "$TMP_SUBID/data/preflight-report.json"
+
+cat > "$TMP_SUBID/scripts/preflight-engine.sh" << 'EOF'
+#!/bin/bash
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --report)
+            echo "{}" > "$2"
+            shift 2
+            ;;
+        *)
+            shift
+            ;;
+    esac
+done
+echo "GPU_BACKEND=cpu"
+EOF
+chmod +x "$TMP_SUBID/scripts/preflight-engine.sh"
+
+cp "$ODS_DOCTOR" "$TMP_SUBID/scripts/ods-doctor.sh"
+
+export ODS_TEST_SUBUID_FILE="$SUBUID_FILE"
+export ODS_TEST_SUBGID_FILE="$SUBGID_FILE"
+
+DOCTOR_OUT="$TMP_SUBID/doctor.out"
+(
+    cd "$TMP_SUBID"
+    bash ./scripts/ods-doctor.sh > "$DOCTOR_OUT" 2>&1 || true
+)
+
+grep -q "rootless mode.*warning.*Subordinate UID range" "$DOCTOR_OUT" \
+    || { cat "$DOCTOR_OUT"; fail "Doctor did not display subuid warning in stdout"; }
+grep -q "Docker rootless subordinate ranges invalid" "$DOCTOR_OUT" \
+    || { cat "$DOCTOR_OUT"; fail "Doctor did not output autofix hint for subuid range"; }
+pass "Doctor warns when subordinate range is insufficient"
+
+info "Subuid/Subgid: Preflight warns when subid files exist but have no entry for current user"
+SUBUID_NO_ENTRY="$TMP_SUBID/subuid_no_entry"
+SUBGID_NO_ENTRY="$TMP_SUBID/subgid_no_entry"
+echo "otheruser:100000:65536" > "$SUBUID_NO_ENTRY"
+echo "otheruser:100000:65536" > "$SUBGID_NO_ENTRY"
+
+export ODS_TEST_SUBUID_FILE="$SUBUID_NO_ENTRY"
+export ODS_TEST_SUBGID_FILE="$SUBGID_NO_ENTRY"
+
+PREFLIGHT_OUT4="$TMP_SUBID/preflight4.out"
+(
+    cd "$TMP_SUBID"
+    bash ./ods-preflight.sh > "$PREFLIGHT_OUT4" 2>&1 || true
+)
+
+grep -q "No subordinate UID range allocated for user" "$PREFLIGHT_OUT4" \
+    || { cat "$PREFLIGHT_OUT4"; fail "Preflight did not warn when no subuid entry exists for user"; }
+grep -q "No subordinate GID range allocated for user" "$PREFLIGHT_OUT4" \
+    || { cat "$PREFLIGHT_OUT4"; fail "Preflight did not warn when no subgid entry exists for user"; }
+pass "Preflight warns when subid files exist but have no entry for current user"
+
+rm -rf "$TMP_SUBID"
+
+echo ""
+echo -e "${GREEN}All rootless-subuid-validation tests passed.${NC}"


### PR DESCRIPTION
## Problem

When Docker is running in rootless mode, it relies on subordinate UID/GID mappings configured in `/etc/subuid` and `/etc/subgid`. If the current user does not have a valid subordinate ID range, or if the allocated range is smaller than the required minimum (typically 65536 IDs), rootless containers can fail to start or encounter permission and user namespace mapping errors.

Currently, ODS does not validate this prerequisite during installation preflight checks or runtime diagnostics (`ods doctor`), leaving users to discover these issues only after deployment when containers fail.

## Fixes #<issue-number>

## Solution

This PR adds subordinate UID/GID range validation to both the installer preflight and the `ods doctor` diagnostic tool, allowing rootless Docker configuration issues to be detected before they cause container failures.

### Preflight Validation (`ods-preflight.sh`)

* Detects whether Docker is running in rootless mode using `docker info`.
* On Linux, verifies that `/etc/subuid` and `/etc/subgid` exist for the current user.
* Sums all subordinate UID/GID ranges assigned to the user, including multiple entries if present.
* Validates that the total allocated range meets the minimum requirement of **65536** IDs.
* Displays a warning with a copy-pasteable remediation command when validation fails.

Example remediation:

```bash
sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 <user>
```

### Runtime Diagnostics (`scripts/ods-doctor.sh`)

* Performs the same subordinate UID/GID validation during `ods doctor`.
* Reports the result in the JSON output under `docker_rootless_subid_warning`.
* Displays clear warnings in the console output.
* Includes the remediation command in the **Suggested fixes** section when validation fails.

### Test Coverage

Added a new hermetic test suite using `ODS_TEST_SUBUID_FILE` and `ODS_TEST_SUBGID_FILE` overrides to validate:

* Missing `/etc/subuid` or `/etc/subgid`
* Insufficient subordinate UID/GID ranges
* Valid subordinate UID/GID configuration
* Preflight and `ods doctor` validation paths using stubbed binaries

## Files Changed

* `ods-preflight.sh`

  * Added subordinate UID/GID range validation for rootless Docker.

* `scripts/ods-doctor.sh`

  * Added subordinate range validation to diagnostics.
  * Extended JSON output with `docker_rootless_subid_warning`.
  * Added remediation guidance to console output.

* `tests/test-rootless-subuid-validation.sh` *(new)*

  * Added integration tests covering missing, insufficient, and valid subordinate ID configurations.

* `Makefile`

  * Registered the new test in the test suite.
