### PR TITLE
feat(preflight): validate Docker rootless subuid/subgid mappings

### DIFF
--- a/ods/docs/LINUX-TROUBLESHOOTING-GUIDE.md
+++ b/ods/docs/LINUX-TROUBLESHOOTING-GUIDE.md
@@ -216,6 +216,56 @@ If you are intentionally **CPU-only**, you can ignore this after setting `GPU_BA
 
 ---
 
+### ROOTLESS_SUBUID
+
+**Symptoms:** **Fail** — Docker is running in rootless mode but `/etc/subuid` or `/etc/subgid` is missing an entry for the current user, or the allocated range is smaller than 65 536 IDs.
+
+**Typical causes:**
+
+- The user was created without subordinate UID/GID ranges (common on minimal or cloud images).
+- The ranges were assigned manually with a count below 65 536 (the minimum needed for a full Linux user namespace).
+- `/etc/subuid` or `/etc/subgid` does not exist at all on the host.
+
+**Why this matters:** Docker rootless mode uses Linux user namespaces to map container UIDs into unprivileged host ranges. Services such as n8n, Whisper, TTS, privacy-shield, and others run as non-root users inside containers and require a minimum of 65 536 subordinate IDs. Without a sufficient mapping, container startup fails with errors like `failed to register layer: uid/gid map out of range`.
+
+**Fix:**
+
+```bash
+# Allocate 65 536 subordinate IDs starting at 100000 for the current user
+sudo usermod \
+  --add-subuids 100000-165535 \
+  --add-subgids 100000-165535 \
+  "$USER"
+```
+
+Verify:
+
+```bash
+grep "^$USER:" /etc/subuid
+grep "^$USER:" /etc/subgid
+# Expected output: <username>:100000:65536 (or any range with count ≥ 65536)
+```
+
+Then restart the rootless Docker service so the new mappings take effect:
+
+```bash
+systemctl --user restart docker
+```
+
+If the files do not exist at all, install the subordinate ID support package first:
+
+```bash
+# Debian/Ubuntu
+sudo apt install -y uidmap
+
+# Fedora/RHEL
+sudo dnf install -y shadow-utils
+```
+
+**Note:** This check is skipped when Docker is not running in rootless mode. Standard (daemon-level) Docker installations use a different user namespace strategy and do not require `/etc/subuid`/`/etc/subgid` entries.
+
+---
+
 ## Common cross-cutting issues
 
 ### Firewall blocking local ports

--- a/ods/scripts/linux-install-preflight.sh
+++ b/ods/scripts/linux-install-preflight.sh
@@ -20,6 +20,8 @@ JSON_FILE=""
 STRICT=false
 ODS_ROOT="${ODS_ROOT:-$ROOT_DIR}"
 MIN_DISK_GB_FREE="${MIN_DISK_GB_FREE:-15}"
+SUBUID_FILE="${SUBUID_FILE:-/etc/subuid}"
+SUBGID_FILE="${SUBGID_FILE:-/etc/subgid}"
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -91,6 +93,22 @@ docker_cli_looks_like_podman() {
         esac
     fi
 
+    return 1
+}
+
+# Returns 0 when the given subid file has an entry for user or uid with a
+# range count >= min (typically 65536 for rootless Docker user namespaces).
+_check_subid_file() {
+    local file="$1" user="$2" uid="$3" min="$4"
+    local e_user e_start e_count
+    [[ -f "$file" ]] || return 1
+    while IFS=: read -r e_user e_start e_count _; do
+        [[ -z "${e_user:-}" ]] && continue
+        [[ "${e_user:-}" =~ ^[[:space:]]*# ]] && continue
+        [[ "$e_user" != "$user" && "$e_user" != "$uid" ]] && continue
+        [[ "${e_count:-}" =~ ^[0-9]+$ ]] || continue
+        [[ "$e_count" -ge "$min" ]] && return 0
+    done <"$file"
     return 1
 }
 
@@ -234,6 +252,50 @@ else
     append_check "CGROUP_V2" "warn" \
         "cgroup v2 not detected — some Docker/rootless setups may differ" \
         "Usually fine on modern distros; if Docker fails oddly, see LINUX-TROUBLESHOOTING-GUIDE.md#cgroups."
+fi
+
+# --- Docker rootless mode: subordinate UID/GID validation ---
+# Only meaningful when Docker is reachable and is not a Podman shim.
+if [[ "$DOCKER_INFO_OK" == true ]] && [[ "$DOCKER_IS_PODMAN" == false ]]; then
+    _ROOTLESS=false
+    if docker info 2>/dev/null | grep -qE '^[[:space:]]+rootless[[:space:]]*$'; then
+        _ROOTLESS=true
+    fi
+
+    if [[ "$_ROOTLESS" == true ]]; then
+        _SUBID_USER="${USER:-$(id -un 2>/dev/null || true)}"
+        _SUBID_UID="$(id -u 2>/dev/null || true)"
+        _SUBID_MIN=65536
+        _SUBID_FIX="sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 ${_SUBID_USER}"
+
+        _SUBUID_OK=false
+        _SUBGID_OK=false
+        if _check_subid_file "$SUBUID_FILE" "$_SUBID_USER" "$_SUBID_UID" "$_SUBID_MIN"; then
+            _SUBUID_OK=true
+        fi
+        if _check_subid_file "$SUBGID_FILE" "$_SUBID_USER" "$_SUBID_UID" "$_SUBID_MIN"; then
+            _SUBGID_OK=true
+        fi
+
+        if [[ "$_SUBUID_OK" == true && "$_SUBGID_OK" == true ]]; then
+            append_check "ROOTLESS_SUBUID" "pass" \
+                "Docker rootless: ${SUBUID_FILE} and ${SUBGID_FILE} both have a range ≥${_SUBID_MIN} for ${_SUBID_USER}" \
+                ""
+        else
+            _MISSING=""
+            [[ "$_SUBUID_OK" == false ]] && _MISSING="$SUBUID_FILE"
+            if [[ "$_SUBGID_OK" == false ]]; then
+                [[ -n "$_MISSING" ]] && _MISSING="$_MISSING and $SUBGID_FILE" || _MISSING="$SUBGID_FILE"
+            fi
+            append_check "ROOTLESS_SUBUID" "fail" \
+                "Docker rootless: ${_MISSING} missing or has a range <${_SUBID_MIN} for ${_SUBID_USER} — containers will fail with uid/gid map out of range" \
+                "$_SUBID_FIX"
+        fi
+    else
+        append_check "ROOTLESS_SUBUID" "pass" \
+            "Docker not running in rootless mode — subuid/subgid check not applicable" \
+            ""
+    fi
 fi
 
 # --- jq (installer often installs it; nice to have) ---

--- a/ods/scripts/ods-preflight.sh
+++ b/ods/scripts/ods-preflight.sh
@@ -33,6 +33,28 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
+# Subordinate UID/GID files (override for tests). Docker rootless requires
+# entries for the current user with >= 65536 IDs in each; without them,
+# non-root containers fail with "uid/gid map out of range".
+SUBUID_FILE="${SUBUID_FILE:-/etc/subuid}"
+SUBGID_FILE="${SUBGID_FILE:-/etc/subgid}"
+
+# Returns 0 when the given subid file has an entry for user or uid with a
+# range count >= min. Safe under set -euo pipefail; skips comments/blanks.
+_check_subid_file() {
+    local file="$1" user="$2" uid="$3" min="$4"
+    local e_user e_start e_count
+    [[ -f "$file" ]] || return 1
+    while IFS=: read -r e_user e_start e_count _; do
+        [[ -z "${e_user:-}" ]] && continue
+        [[ "${e_user:-}" =~ ^[[:space:]]*# ]] && continue
+        [[ "$e_user" != "$user" && "$e_user" != "$uid" ]] && continue
+        [[ "${e_count:-}" =~ ^[0-9]+$ ]] || continue
+        [[ "$e_count" -ge "$min" ]] && return 0
+    done <"$file"
+    return 1
+}
+
 echo -e "${CYAN}ODS Preflight Check${NC}"
 echo "=============================="
 echo ""
@@ -52,6 +74,30 @@ else
     echo -e "${RED}✗ not running${NC}"
     echo "  Fix: Start Docker Desktop or run 'sudo systemctl start docker'"
     exit 1
+fi
+
+# Rootless Docker: verify /etc/subuid + /etc/subgid have >= 65536 IDs for the
+# current user. Non-root containers (n8n, whisper, tts, privacy-shield, ...)
+# fail with "failed to register layer: uid/gid map out of range" otherwise.
+# Warn-only at runtime: existing containers may already be up; the warning is
+# still valuable when diagnosing why one won't start or when new services are
+# enabled.
+echo -n "Docker rootless subuid/subgid... "
+if docker info 2>/dev/null | grep -qE '^[[:space:]]+rootless[[:space:]]*$'; then
+    _SUBID_USER="${USER:-$(id -un 2>/dev/null || true)}"
+    _SUBID_UID="$(id -u 2>/dev/null || true)"
+    _SUBID_MIN=65536
+    if _check_subid_file "$SUBUID_FILE" "$_SUBID_USER" "$_SUBID_UID" "$_SUBID_MIN" \
+        && _check_subid_file "$SUBGID_FILE" "$_SUBID_USER" "$_SUBID_UID" "$_SUBID_MIN"; then
+        echo -e "${GREEN}✓ mapping ≥${_SUBID_MIN} present for ${_SUBID_USER}${NC}"
+    else
+        echo -e "${YELLOW}⚠ insufficient or missing${NC}"
+        echo "  ${SUBUID_FILE}/${SUBGID_FILE} needs a range ≥${_SUBID_MIN} for ${_SUBID_USER}"
+        echo "  Fix: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 ${_SUBID_USER}"
+        echo "       then: systemctl --user restart docker"
+    fi
+else
+    echo -e "${GREEN}✓ not rootless (n/a)${NC}"
 fi
 
 # Check containers are up

--- a/ods/tests/test-linux-install-preflight.sh
+++ b/ods/tests/test-linux-install-preflight.sh
@@ -124,6 +124,151 @@ else
     fail "python3 not available - skipped Podman shim contract (unexpected on CI)"
 fi
 
+# ROOTLESS_SUBUID: check referenced in the script
+if grep -q 'ROOTLESS_SUBUID' "$LP" && grep -q 'SUBUID_FILE' "$LP" && grep -q 'SUBGID_FILE' "$LP"; then
+    pass "ROOTLESS_SUBUID check and SUBUID_FILE/SUBGID_FILE overrides present in script"
+else
+    fail "ROOTLESS_SUBUID check or file-path overrides missing from script"
+fi
+
+# ROOTLESS_SUBUID: rootless Docker with sufficient ranges → pass
+if command -v python3 >/dev/null 2>&1; then
+    _RTMP="$(mktemp -d)"
+    # Mock docker that reports rootless mode in 'docker info'
+    cat >"$_RTMP/docker" <<'MOCKEOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "Docker version 24.0.5, build ced0996" ;;
+  info)
+    printf 'Server:\n Security Options:\n  seccomp\n  rootless\n  cgroupns\n'
+    ;;
+  compose)
+    case "${2:-}" in
+      version) echo "Docker Compose version v2.20.0" ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+MOCKEOF
+    chmod +x "$_RTMP/docker"
+    _CURRENT_USER="$(id -un)"
+    printf '%s:100000:65536\n' "$_CURRENT_USER" >"$_RTMP/subuid"
+    printf '%s:100000:65536\n' "$_CURRENT_USER" >"$_RTMP/subgid"
+    _R_JSON="$_RTMP/report.json"
+    SUBUID_FILE="$_RTMP/subuid" SUBGID_FILE="$_RTMP/subgid" \
+        PATH="$_RTMP:$PATH" "$LP" --json >"$_R_JSON" 2>/dev/null || true
+    if python3 - <<PY
+import json
+with open("$_R_JSON", encoding="utf-8") as f:
+    report = json.load(f)
+checks = {c["id"]: c for c in report["checks"]}
+c = checks.get("ROOTLESS_SUBUID")
+assert c is not None, "ROOTLESS_SUBUID check missing"
+assert c["status"] == "pass", f"expected pass, got {c['status']}: {c['message']}"
+print("ok")
+PY
+    then
+        pass "ROOTLESS_SUBUID: rootless Docker with valid ranges → pass"
+    else
+        fail "ROOTLESS_SUBUID: rootless Docker with valid ranges should be pass"
+    fi
+    rm -rf "$_RTMP"
+else
+    fail "python3 not available — skipped ROOTLESS_SUBUID valid-ranges test"
+fi
+
+# ROOTLESS_SUBUID: rootless Docker with insufficient range → fail
+if command -v python3 >/dev/null 2>&1; then
+    _RTMP="$(mktemp -d)"
+    cat >"$_RTMP/docker" <<'MOCKEOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "Docker version 24.0.5, build ced0996" ;;
+  info)
+    printf 'Server:\n Security Options:\n  seccomp\n  rootless\n  cgroupns\n'
+    ;;
+  compose)
+    case "${2:-}" in
+      version) echo "Docker Compose version v2.20.0" ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+MOCKEOF
+    chmod +x "$_RTMP/docker"
+    _CURRENT_USER="$(id -un)"
+    # Deliberately below the 65536 minimum
+    printf '%s:100000:100\n' "$_CURRENT_USER" >"$_RTMP/subuid"
+    printf '%s:100000:100\n' "$_CURRENT_USER" >"$_RTMP/subgid"
+    _R_JSON="$_RTMP/report.json"
+    SUBUID_FILE="$_RTMP/subuid" SUBGID_FILE="$_RTMP/subgid" \
+        PATH="$_RTMP:$PATH" "$LP" --json >"$_R_JSON" 2>/dev/null || true
+    if python3 - <<PY
+import json
+with open("$_R_JSON", encoding="utf-8") as f:
+    report = json.load(f)
+checks = {c["id"]: c for c in report["checks"]}
+c = checks.get("ROOTLESS_SUBUID")
+assert c is not None, "ROOTLESS_SUBUID check missing"
+assert c["status"] == "fail", f"expected fail, got {c['status']}: {c['message']}"
+assert "remediation" in c and len(c["remediation"]) > 0, "remediation missing"
+print("ok")
+PY
+    then
+        pass "ROOTLESS_SUBUID: rootless Docker with insufficient range → fail + remediation"
+    else
+        fail "ROOTLESS_SUBUID: rootless Docker with insufficient range should be fail"
+    fi
+    rm -rf "$_RTMP"
+else
+    fail "python3 not available — skipped ROOTLESS_SUBUID insufficient-range test"
+fi
+
+# ROOTLESS_SUBUID: non-rootless Docker → pass (check not applicable)
+if command -v python3 >/dev/null 2>&1; then
+    _RTMP="$(mktemp -d)"
+    cat >"$_RTMP/docker" <<'MOCKEOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) echo "Docker version 24.0.5, build ced0996" ;;
+  info)
+    # No 'rootless' line — standard daemon mode
+    printf 'Server:\n Security Options:\n  seccomp\n   Profile: builtin\n  cgroupns\n'
+    ;;
+  compose)
+    case "${2:-}" in
+      version) echo "Docker Compose version v2.20.0" ;;
+      *) exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+MOCKEOF
+    chmod +x "$_RTMP/docker"
+    _R_JSON="$_RTMP/report.json"
+    PATH="$_RTMP:$PATH" "$LP" --json >"$_R_JSON" 2>/dev/null || true
+    if python3 - <<PY
+import json
+with open("$_R_JSON", encoding="utf-8") as f:
+    report = json.load(f)
+checks = {c["id"]: c for c in report["checks"]}
+c = checks.get("ROOTLESS_SUBUID")
+assert c is not None, "ROOTLESS_SUBUID check missing"
+assert c["status"] == "pass", f"expected pass, got {c['status']}: {c['message']}"
+print("ok")
+PY
+    then
+        pass "ROOTLESS_SUBUID: non-rootless Docker → pass (not applicable)"
+    else
+        fail "ROOTLESS_SUBUID: non-rootless Docker should be pass"
+    fi
+    rm -rf "$_RTMP"
+else
+    fail "python3 not available — skipped ROOTLESS_SUBUID non-rootless test"
+fi
+
 # ods-preflight.sh delegates --install-env to linux-install-preflight
 if grep -q 'linux-install-preflight.sh' "$ROOT_PREFLIGHT" && grep -q '\-\-install-env' "$ROOT_PREFLIGHT"; then
     pass "ods-preflight.sh delegates --install-env to linux-install-preflight.sh"

--- a/ods/tests/test-preflight.sh
+++ b/ods/tests/test-preflight.sh
@@ -175,6 +175,33 @@ else
     fail "Unexpected exit code $run_exit — script may have crashed"
 fi
 
+# ── Sibling: scripts/ods-preflight.sh (runtime, service-registry-aware) ────
+
+RUNTIME_PREFLIGHT="$ROOT_DIR/scripts/ods-preflight.sh"
+if [[ -f "$RUNTIME_PREFLIGHT" ]]; then
+    if bash -n "$RUNTIME_PREFLIGHT" 2>/dev/null; then
+        pass "scripts/ods-preflight.sh passes bash -n"
+    else
+        fail "scripts/ods-preflight.sh bash -n failed"
+    fi
+
+    # Docker rootless subuid/subgid diagnostic must be present with the same
+    # helper + env-override contract as linux-install-preflight.sh, so users
+    # get consistent guidance at install and at runtime.
+    if grep -q '_check_subid_file' "$RUNTIME_PREFLIGHT" \
+        && grep -q 'SUBUID_FILE' "$RUNTIME_PREFLIGHT" \
+        && grep -q 'SUBGID_FILE' "$RUNTIME_PREFLIGHT" \
+        && grep -q 'rootless' "$RUNTIME_PREFLIGHT" \
+        && grep -q '65536' "$RUNTIME_PREFLIGHT" \
+        && grep -q 'usermod' "$RUNTIME_PREFLIGHT"; then
+        pass "scripts/ods-preflight.sh has rootless subuid/subgid diagnostic + fix cmd"
+    else
+        fail "scripts/ods-preflight.sh missing rootless subuid/subgid diagnostic"
+    fi
+else
+    fail "scripts/ods-preflight.sh not found at $RUNTIME_PREFLIGHT"
+fi
+
 # ── Summary ────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
### Summary

Adds a ROOTLESS_SUBUID check to both preflight scripts so Docker rootless users hit a clear, actionable error before deployment instead of a cryptic failed to register layer: uid/gid map out of range at first container start.

- scripts/linux-install-preflight.sh (install-time, fail) — when docker info reports rootless mode, validates /etc/subuid and /etc/subgid have an entry for the current user with ≥ 65 536 IDs. Emits a structured check with a usermod --add-subuids / --add-subgids remediation. Skipped when Docker isn't reachable or the CLI is a Podman shim, so no false positives.
- scripts/ods-preflight.sh (runtime, warn) — same detection logic for post-install diagnostics; warn-only so it doesn't fail preflight when existing containers are already up. Prints the fix + systemctl --user restart docker follow-up.
- Both scripts share a single _check_subid_file() helper and honor SUBUID_FILE / SUBGID_FILE env overrides so tests can stub the paths without touching /etc.
- Docs: new ROOTLESS_SUBUID section in LINUX-TROUBLESHOOTING-GUIDE.md (symptoms, why 65 536, usermod fix, restart step, distro packages if the files don't exist).
- Tests: three JSON-contract cases in test-linux-install-preflight.sh (valid → pass, insufficient → fail with remediation, non-rootless → pass n/a) plus a static contract check in test-preflight.sh that guards the runtime script's helper, env overrides, and fix command.

Fixes the gap where non-root services (n8n, whisper, tts, token-spy, privacy-shield, ape, langfuse, …) would silently fail to initialize user namespaces on rootless hosts without proper subordinate ID ranges.


### Release Lane

- [ ] Stable hotfix targeting release/2.5.x
- [x] Mainline change targeting main
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

### Stable hotfix reason:

N/A — mainline. Users on stable can still hit this, but the change is a
new preflight signal (not a fix to broken runtime behavior), so it lands
on main and can be backported later if triage requests it.

### Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Also touches docs and tests, but the primary surface is the preflight scripts under installer / bootstrap / lifecycle.)

### Risk And Validation

- Risk level: Low — additive check only; no existing check IDs or exit-code semantics change. Guarded on DOCKER_INFO_OK=true and DOCKER_IS_PODMAN=false in the install preflight, and on docker info succeeding in the runtime preflight, so pre-existing paths are unaffected. SUBUID_FILE/SUBGID_FILE default to /etc/subuid//etc/subgid — same behavior as if the check were hard-coded.
- Validation run:
  - [ ] git diff --check
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting release/2.5.x
  - [x] Not required because: no dashboard/compose/model-routing/network surfaces touched; the change is isolated to the two preflight scripts and their tests.

### Commands/results:

$ bash -n ods/scripts/linux-install-preflight.sh
$ bash -n ods/scripts/ods-preflight.sh
$ bash -n ods/tests/test-linux-install-preflight.sh
$ bash -n ods/tests/test-preflight.sh
# all clean

$ bash ods/tests/test-preflight.sh
Result: 24 passed, 0 failed
# includes the two new static contract checks against scripts/ods-preflight.sh

$ bash ods/tests/test-linux-install-preflight.sh
# Static + delegation checks pass locally. The three new JSON-contract
# cases (rootless-valid, rootless-insufficient, non-rootless) plus the two
# pre-existing python3-gated cases skip on this Windows Git Bash host
# (no python3). All five run on Linux/WSL/CI where python3 is available;
# please re-run on CI to confirm the JSON assertions.

### Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation, service manifests, dashboard API control flows, Hermes, model routing, GPU or runtime detection, lifecycle commands, host mutation, or network exposure, it requires release-grade fleet validation before release unless the PR explains a narrower equivalent.

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [x] This is an operational change and validation is intentionally deferred for:

The change is scoped to two preflight/diagnostic scripts. It only reads state (docker info, /etc/subuid, /etc/subgid) and prints a check result — no host mutation, no compose changes, no service/router/network wiring. Existing install and runtime paths are unaffected: the install-time check is gated on DOCKER_INFO_OK && !DOCKER_IS_PODMAN, and the runtime check is warn-only after a docker info probe that all users already pass. Narrower equivalent to fleet validation: bash-syntax check + the extended test-preflight.sh suite (24/24) covering both scripts, plus JSON-contract tests to run on CI.

### Notes For Reviewers

- Fail vs. warn split is deliberate. Install-time = fail because users can fix it before anything is deployed. Runtime = warn because existing containers may already be running fine; hard-failing preflight after install would surprise users whose stacks are healthy.
- Rootless detection uses docker info | grep -qE '^[[:space:]]+rootless[[:space:]]*$' (matches the Security Options: rootless line format). If a distro reports rootless differently, the check simply skips (pass, not applicable) — no false failures.
- _check_subid_file accepts either the username or the numeric UID as the entry key, since some provisioners write one or the other.
- Test env overrides (SUBUID_FILE, SUBGID_FILE) are only meant for the JSON-contract tests. They're plain env vars — nothing writes them from install code.
- Not backported to release/2.5.x yet; happy to open a follow-up hotfix branch if triage wants it there.
- Rollback: revert this single commit — no migrations, no state changes, no artifact rebuild required.