### PR TITLE
fix(bootstrap): force C locale for status percent to keep JSON valid

### DIFF
--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -104,7 +104,7 @@ status_percent() {
     local display_bytes="$downloaded"
     [[ "$display_bytes" -lt 0 ]] && display_bytes=0
     [[ "$display_bytes" -gt "$total" ]] && display_bytes="$total"
-    awk "BEGIN { printf \"%.1f\", ($display_bytes / $total) * 100 }"
+    LC_ALL=C awk "BEGIN { printf \"%.1f\", ($display_bytes / $total) * 100 }"
 }
 
 write_failed_download_status() {


### PR DESCRIPTION
## Problem

`status_percent()` in `scripts/bootstrap-upgrade.sh` formats the download-progress percent with `awk printf "%.1f"`:

```sh
awk "BEGIN { printf \"%.1f\", ($display_bytes / $total) * 100 }"
```

On a host whose locale uses a comma decimal separator (de_DE, pt_BR, fr_FR, es_ES, …), `printf "%.1f"` emits `37,0` instead of `37.0`. `write_status()` then writes that straight into `data/bootstrap-status.json` as a **raw JSON number**:

```json
"percent": 37,0,
```

which is **invalid JSON** — the host-agent / dashboard consumers of `bootstrap-status.json` fail to parse it, and it breaks the `"percent": 100.0` assertion in `tests/test-bootstrap-upgrade-resume-status.sh`.

**Reproduce:**
```console
$ LC_ALL=pt_BR.UTF-8 awk 'BEGIN { printf "%.1f", 37 }'
37,0
```

## Fix

Prefix the awk with `LC_ALL=C` so the percent is always dot-decimal. This is the same locale-safe awk idiom already merged across the tree (#1619/#1635/#1636/#1641/#1666/#1667); this is the same class in a distinct, untouched location (the JSON status file rather than `.env`).

**After:**
```console
$ LC_ALL=pt_BR.UTF-8 bash -c '...; status_percent 37 100'
37.0
```

One-token change; `bash -n` clean.