### PR TITLE
fix(dashboard-api): emit valid ISO-8601 timestamps in updates router

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -165,7 +165,7 @@ def _build_version_result(current: str, payload: Optional[dict]) -> dict:
         "latest": None,
         "update_available": False,
         "changelog_url": None,
-        "checked_at": datetime.now(timezone.utc).isoformat() + "Z",
+        "checked_at": datetime.now(timezone.utc).isoformat(),
     }
     if not payload:
         return result
@@ -198,7 +198,7 @@ async def _refresh_release_cache() -> Optional[dict]:
         payload = {
             "latest": data.get("tag_name", "").lstrip("v"),
             "changelog_url": data.get("html_url"),
-            "checked_at": datetime.now(timezone.utc).isoformat() + "Z",
+            "checked_at": datetime.now(timezone.utc).isoformat(),
         }
         _version_cache = {
             "expires_at": time.monotonic() + _VERSION_CACHE_TTL,
@@ -255,13 +255,13 @@ async def get_release_manifest():
                 {"version": r.get("tag_name", "").lstrip("v"), "date": r.get("published_at", ""), "title": r.get("name", ""), "changelog": r.get("body", "")[:500] + "..." if len(r.get("body", "")) > 500 else r.get("body", ""), "url": r.get("html_url", ""), "prerelease": r.get("prerelease", False)}
                 for r in releases
             ],
-            "checked_at": datetime.now(timezone.utc).isoformat() + "Z"
+            "checked_at": datetime.now(timezone.utc).isoformat()
         }
     except (httpx.HTTPError, httpx.TimeoutException, json.JSONDecodeError, OSError):
         current = await asyncio.to_thread(_read_current_version)
         return {
-            "releases": [{"version": current, "date": datetime.now(timezone.utc).isoformat() + "Z", "title": f"ODS {current}", "changelog": "Release information unavailable. Check GitHub directly.", "url": _GITHUB_RELEASES_PAGE, "prerelease": False}],
-            "checked_at": datetime.now(timezone.utc).isoformat() + "Z",
+            "releases": [{"version": current, "date": datetime.now(timezone.utc).isoformat(), "title": f"ODS {current}", "changelog": "Release information unavailable. Check GitHub directly.", "url": _GITHUB_RELEASES_PAGE, "prerelease": False}],
+            "checked_at": datetime.now(timezone.utc).isoformat(),
             "error": "Could not fetch release information"
         }
 

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -1,6 +1,7 @@
 """Tests for updates router endpoints."""
 
 import json
+from datetime import datetime
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import httpx
@@ -30,6 +31,7 @@ def test_get_version_authenticated(test_client):
     assert "latest" in data
     assert "update_available" in data
     assert "checked_at" in data
+    datetime.fromisoformat(data["checked_at"])  # valid ISO-8601 (regression: no trailing "Z" after the offset)
 
 
 def test_get_version_with_mock_github(test_client, monkeypatch):
@@ -135,6 +137,7 @@ def test_get_releases_manifest_authenticated(test_client):
     data = resp.json()
     assert "releases" in data
     assert "checked_at" in data
+    datetime.fromisoformat(data["checked_at"])  # valid ISO-8601 (regression: no trailing "Z" after the offset)
     assert isinstance(data["releases"], list)
     assert len(data["releases"]) == 1
     assert data["releases"][0]["version"] == "1.0.0"
@@ -210,6 +213,7 @@ def test_releases_manifest_with_mocked_github(test_client):
     assert data["releases"][0]["version"] == "1.5.0"
     assert data["releases"][1]["prerelease"] is True
     assert "checked_at" in data
+    datetime.fromisoformat(data["checked_at"])  # valid ISO-8601 (regression: no trailing "Z" after the offset)
 
 
 def test_releases_manifest_github_error_fallback(test_client, tmp_path, monkeypatch):


### PR DESCRIPTION
## Problem

`datetime.now(timezone.utc)` is timezone-aware, so `.isoformat()` already ends with `+00:00`. `routers/updates.py` then concatenated `"Z"`:

```python
"checked_at": datetime.now(timezone.utc).isoformat() + "Z",
```

producing `2026-07-11T16:25:29.417360+00:00Z` — a timestamp with **both** an offset and a `Z`, which is **not valid ISO-8601**. Both `datetime.fromisoformat()` and JS `new Date()` reject it:

```console
$ python3 -c "from datetime import *; datetime.fromisoformat(datetime.now(timezone.utc).isoformat()+'Z')"
ValueError: Invalid isoformat string: '...+00:00Z'
```

So the dashboard renders **"Invalid Date"** for `checked_at` (GET `/api/version`) and per-release `date` (GET `/api/releases/manifest`).

## Fix

Drop the trailing `"Z"` at the five synthesized-timestamp sites, matching the bare `.isoformat()` already used elsewhere in the codebase (`setup.py`, `magic_link.py`). GitHub's own `published_at` value is untouched.

Tightened the existing `test_updates.py` assertions from `"checked_at" in data` to `datetime.fromisoformat(data["checked_at"])` so the format is verified. `py_compile` clean.