### PR TITLE
fix(dashboard-api): keep GPUs with [N/A] utilization/temperature in detailed view

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -537,8 +537,8 @@ def get_gpu_info_nvidia_detailed() -> Optional[list[IndividualGPU]]:
                 memory_used_mb=mem_used,
                 memory_total_mb=mem_total,
                 memory_percent=round(mem_used / mem_total * 100, 1) if mem_total > 0 else 0.0,
-                utilization_percent=int(parts[5]),
-                temperature_c=int(parts[6]),
+                utilization_percent=int(parts[5]) if parts[5] not in na_values else 0,
+                temperature_c=int(parts[6]) if parts[6] not in na_values else 0,
                 power_w=power_w,
                 assigned_services=uuid_service_map.get(uuid, []),
             ))

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -137,6 +137,22 @@ class TestGetGpuInfoNvidiaDetailed:
         assert g.power_w == 285.5
         assert g.assigned_services == []
 
+    def test_keeps_gpu_with_na_util_temp(self, monkeypatch):
+        # nvidia-smi reports [N/A] for utilization/temperature on MIG/vGPU and
+        # unified-memory parts. The GPU must be kept (util/temp default to 0),
+        # not dropped by an int("[N/A]") crash.
+        csv = "0, GPU-abc123, NVIDIA A100, 2048, 40536, [N/A], [N/A], 100.0"
+        monkeypatch.setattr("gpu.run_command", lambda cmd, **kw: (True, csv))
+        monkeypatch.delenv("GPU_ASSIGNMENT_JSON_B64", raising=False)
+
+        result = get_gpu_info_nvidia_detailed()
+        assert result is not None
+        assert len(result) == 1
+        g = result[0]
+        assert g.uuid == "GPU-abc123"
+        assert g.utilization_percent == 0
+        assert g.temperature_c == 0
+
     def test_parses_multi_gpu(self, monkeypatch):
         csv = (
             "0, GPU-aaa, NVIDIA GeForce RTX 4090, 2048, 24564, 35, 62, 285.5\n"


### PR DESCRIPTION
## Problem

`get_gpu_info_nvidia_detailed()` (`gpu.py`) parsed utilization/temperature with a bare cast:

```python
utilization_percent=int(parts[5]),
temperature_c=int(parts[6]),
```

`nvidia-smi` returns `[N/A]` for these on MIG-partitioned A100/H100, many vGPU/passthrough setups, and unified-memory parts. `int("[N/A]")` raises `ValueError`, which the row's `except (ValueError, IndexError)` catches by **dropping the entire GPU** ("Skipping unparseable nvidia-smi row") — and if all GPUs are affected the function returns `None`.

This is inconsistent within the codebase: the aggregate `get_gpu_info_nvidia()` already guards util/temp against the same `na_values` (lines 190-191), and this very function already guards memory (524) and power (518). So the aggregate `/api` view shows the GPU (util/temp = 0) while the detailed view silently loses it.

## Fix

Guard util/temp against `na_values` (defaulting to `0`), matching the sibling:

```python
utilization_percent=int(parts[5]) if parts[5] not in na_values else 0,
temperature_c=int(parts[6]) if parts[6] not in na_values else 0,
```

## Verification

Added `test_keeps_gpu_with_na_util_temp` to `tests/test_gpu_detailed.py`. The detailed-GPU test class passes **8/8**; the new test **fails on the pre-fix code** (GPU dropped) and passes after.