### PR TITLE
fix(updates): query canonical Osmantic/ODS repo so update-check works

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -188,7 +188,7 @@ async def _refresh_release_cache() -> Optional[dict]:
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             response = await client.get(
-                "https://api.github.com/repos/Light-Heart-Labs/ODS/releases/latest",
+                "https://api.github.com/repos/Osmantic/ODS/releases/latest",
                 headers=_GITHUB_HEADERS,
             )
         data = response.json()
@@ -241,7 +241,7 @@ async def get_release_manifest():
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
             resp = await client.get(
-                "https://api.github.com/repos/Light-Heart-Labs/ODS/releases?per_page=5",
+                "https://api.github.com/repos/Osmantic/ODS/releases?per_page=5",
                 headers=_GITHUB_HEADERS,
             )
         releases = resp.json()
@@ -307,7 +307,7 @@ async def get_update_dry_run():
     try:
         async with httpx.AsyncClient(timeout=8.0) as client:
             resp = await client.get(
-                "https://api.github.com/repos/Light-Heart-Labs/ODS/releases/latest",
+                "https://api.github.com/repos/Osmantic/ODS/releases/latest",
                 headers=_GITHUB_HEADERS,
             )
         data = resp.json()

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1427,7 +1427,7 @@ cmd_dry_run() {
         # Direct GitHub fallback
         local gh_resp
         gh_resp=$(curl -sf --max-time 8 \
-            "https://api.github.com/repos/Light-Heart-Labs/ODS/releases/latest" 2>/dev/null || true)
+            "https://api.github.com/repos/Osmantic/ODS/releases/latest" 2>/dev/null || true)
         if [[ -n "$gh_resp" ]] && command -v jq >/dev/null 2>&1; then
             latest_ver=$(echo "$gh_resp" | jq -r '.tag_name // empty' 2>/dev/null | sed 's/^v//' || true)
             changelog_url=$(echo "$gh_resp" | jq -r '.html_url // empty' 2>/dev/null || true)


### PR DESCRIPTION
## Problem

The update-check queries the GitHub API at the **old** repo path:

```
https://api.github.com/repos/Light-Heart-Labs/ODS/releases/latest
```

Since the repo was renamed/transferred to `Osmantic/ODS`, that endpoint now returns **301**, and neither caller follows the redirect:

- `routers/updates.py` uses `httpx.AsyncClient` — default `follow_redirects=False`.
- `ods-cli` uses `curl -sf` (no `-L`).

So the latest release is never parsed → `latest` comes back empty → **"update available" never fires**, and the CLI fallback reports "up to date" regardless.

**Verify:**
```console
$ curl -s -o /dev/null -w "%{http_code}\n" https://api.github.com/repos/Light-Heart-Labs/ODS/releases/latest
301
$ curl -s -o /dev/null -w "%{http_code}\n" https://api.github.com/repos/Osmantic/ODS/releases/latest
200
```

## Fix

Point the three GitHub **API** calls in `routers/updates.py` (release check, releases manifest, retry) and the `ods-cli` update fallback at `api.github.com/repos/Osmantic/ODS/...`, which returns 200 — completing the canonical-URL migration from #1673 for the update path.

The browser-facing `github.com/...` link in the offline fallback payload is intentionally left unchanged (browsers follow the redirect). `py_compile` + `bash -n` clean.