### PR TITLE
fix(dashboard-api): return a graceful reply when /api/chat gets empty choices

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -215,7 +215,8 @@ async def chat(request: ChatRequest, api_key: str = Depends(verify_api_key)):
             async with session.post(f"{llm_url}{_api_path}/chat/completions", json=payload, headers={"Content-Type": "application/json"}) as resp:
                 if resp.status == 200:
                     data = await resp.json()
-                    response_text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
+                    choices = data.get("choices") or [{}]
+                    response_text = (choices[0] or {}).get("message", {}).get("content", "")
                     # Strip thinking model tags — content may contain <think>...</think> blocks
                     response_text = re.sub(r'<think>[\s\S]*?</think>\s*', '', response_text).strip()
                     return {"response": response_text, "success": True}

--- a/ods/extensions/services/dashboard-api/tests/test_setup.py
+++ b/ods/extensions/services/dashboard-api/tests/test_setup.py
@@ -1,6 +1,35 @@
 """Tests for routers/setup.py — setup wizard, persona selection, and completion."""
 
 import json
+from unittest.mock import patch, MagicMock, AsyncMock
+
+
+def test_chat_handles_empty_choices(test_client, monkeypatch):
+    """A 200 LLM response with empty/absent `choices` (e.g. content-filtered)
+    must return a graceful empty reply, not an unhandled 500."""
+    monkeypatch.setenv("OLLAMA_URL", "http://llama-server:8080")
+
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.json = AsyncMock(return_value={"choices": []})
+    post_cm = MagicMock()
+    post_cm.__aenter__ = AsyncMock(return_value=mock_resp)
+    post_cm.__aexit__ = AsyncMock(return_value=False)
+    mock_session = MagicMock()
+    mock_session.post = MagicMock(return_value=post_cm)
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+    session_cm.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.setup.aiohttp.ClientSession", return_value=session_cm):
+        resp = test_client.post(
+            "/api/chat", json={"message": "hi"}, headers=test_client.auth_headers
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is True
+    assert data["response"] == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The setup assistant (`POST /api/chat`) reads the LLM reply as:

```python
response_text = data.get("choices", [{}])[0].get("message", {}).get("content", "")
```

The `[{}]` default only covers a **missing** `choices` key. An OpenAI-compatible backend that returns HTTP **200** with `{"choices": []}` (content-filtered or empty generation) — or `{"choices": null}` — makes `[0]` raise `IndexError` / `TypeError`. The only handler is `except aiohttp.ClientError`, which catches neither, so the endpoint returns an unhandled **500** instead of a graceful reply.

```console
$ python3 -c "print({'choices': []}.get('choices',[{}])[0])"
IndexError: list index out of range
```

## Fix

```python
choices = data.get("choices") or [{}]
response_text = (choices[0] or {}).get("message", {}).get("content", "")
```

Empty/null `choices` now yields an empty response; the normal path is unchanged.

## Verification

Added `test_chat_handles_empty_choices` to `tests/test_setup.py` (mocks the LLM backend returning `200 {"choices": []}`). Passes on Python 3.11; **fails on the pre-fix code** with `IndexError`.