### PR TITLE
fix(host-agent): reject non-object JSON bodies in read_json_body

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -976,10 +976,14 @@ def read_json_body(handler) -> dict | None:
         json_response(handler, 400, {"error": "Request body required"})
         return None
     try:
-        return json.loads(handler.rfile.read(min(length, MAX_BODY)))
+        data = json.loads(handler.rfile.read(min(length, MAX_BODY)))
     except (json.JSONDecodeError, UnicodeDecodeError):
         json_response(handler, 400, {"error": "Invalid JSON"})
         return None
+    if not isinstance(data, dict):
+        json_response(handler, 400, {"error": "JSON body must be an object"})
+        return None
+    return data
 
 
 def read_optional_json_body(handler) -> dict | None:

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -3370,3 +3370,17 @@ class TestModelDownloadFileIntegrity:
         assert (models_dir / "split-model-00002-of-00002.gguf").read_bytes() == b"downloaded second part"
         status = json.loads((install_dir / "data" / "model-download-status.json").read_text(encoding="utf-8"))
         assert status["status"] == "complete"
+
+
+def test_read_json_body_rejects_non_object():
+    """A syntactically-valid but non-object JSON body ([]) must be rejected with
+    400, not returned as a list — every caller immediately does body.get(...),
+    which would raise AttributeError and drop the connection."""
+    handler = _FakeHandler(b"[]")
+    assert _mod.read_json_body(handler) is None
+    assert handler.response_code == 400
+
+
+def test_read_json_body_accepts_object():
+    handler = _FakeHandler(b'{"a": 1}')
+    assert _mod.read_json_body(handler) == {"a": 1}


### PR DESCRIPTION
## Problem

`read_json_body()` in `bin/ods-host-agent.py` returns `json.loads(...)` directly:

```python
try:
    return json.loads(handler.rfile.read(min(length, MAX_BODY)))
except (json.JSONDecodeError, UnicodeDecodeError):
    json_response(handler, 400, {"error": "Invalid JSON"})
    return None
```

A syntactically-valid but **non-object** body — `[]`, `"str"`, `42` — passes the `if body is None` guard that every caller relies on (`_handle_model_activate`, `_handle_model_download`, `_handle_core_recreate`, …), and the subsequent `body.get(...)` raises `AttributeError`. `do_POST` has no surrounding `try/except`, so the client gets a **dropped connection with no HTTP response** plus a server-side traceback.

The sibling `read_optional_json_body()` two functions below already guards this exact case (`if not isinstance(data, dict): ... 400`) — `read_json_body()` was just missing it.

## Fix

```python
if not isinstance(data, dict):
    json_response(handler, 400, {"error": "JSON body must be an object"})
    return None
return data
```

## Verification

Added `test_read_json_body_rejects_non_object` / `_accepts_object` to `tests/test_host_agent.py`. Both pass; the reject test **fails on the pre-fix code** (the raw `[]` is returned instead of a 400).