### PR TITLE
docs(extensions): bind the example service port to loopback by default

### DIFF
--- a/ods/docs/EXTENSIONS.md
+++ b/ods/docs/EXTENSIONS.md
@@ -76,7 +76,7 @@ services:
     container_name: ods-my-service
     restart: unless-stopped
     ports:
-      - "${MY_SERVICE_PORT:-9200}:8080"
+      - "${BIND_ADDRESS:-127.0.0.1}:${MY_SERVICE_PORT:-9200}:8080"
     environment:
       - LLM_URL=http://llama-server:8080/v1
     depends_on:


### PR DESCRIPTION
## Problem

The "30-minute path" tutorial in `docs/EXTENSIONS.md` shows a compose example that publishes a host port with **no bind address**:

```yaml
ports:
  - "${MY_SERVICE_PORT:-9200}:8080"
```

Copy-pasting it exposes the new service on `0.0.0.0` (every interface). That contradicts:

- the shipped `extensions/templates/compose-template.yaml`, which uses `"${BIND_ADDRESS:-127.0.0.1}:${MY_SERVICE_PORT:-1234}:1234"`,
- every bundled extension (`brave-search`, etc.), and
- the installer's network-exposure convention (host-wide binds are flagged).

## Fix

Make the docs example match the template — bind to loopback by default:

```yaml
- "${BIND_ADDRESS:-127.0.0.1}:${MY_SERVICE_PORT:-9200}:8080"
```

Docs-only, security-positive.