### PR TITLE
fix(release-gate): report missing files instead of crashing version check

### DIFF
--- a/ods/scripts/check-version-consistency.py
+++ b/ods/scripts/check-version-consistency.py
@@ -58,7 +58,7 @@ def add_regex_check(
 ) -> None:
     try:
         checks.append((label, first_match(path, pattern, label)))
-    except ValueError as exc:
+    except (ValueError, OSError) as exc:
         errors.append(str(exc))
 
 


### PR DESCRIPTION
## Problem

`add_regex_check()` in `scripts/check-version-consistency.py` is designed to convert a per-file failure into a collected error + a clean `[FAIL]`:

```python
try:
    checks.append((label, first_match(path, pattern, label)))
except ValueError as exc:
    errors.append(str(exc))
```

But `first_match()` → `path.read_text()` raises `FileNotFoundError` when a referenced file is missing. `FileNotFoundError` is a subclass of **`OSError`, not `ValueError`**, so it escapes the handler and kills the release gate with a traceback instead of a reported failure — most plausibly for `ARCHITECTURE.md`, which is checked outside the `ods/` tree and could be renamed/moved.

```console
$ python3 -c "from pathlib import Path; Path('/no/such.md').read_text()"
FileNotFoundError  # isinstance OSError=True, ValueError=False
```

## Fix

```python
except (ValueError, OSError) as exc:
    errors.append(str(exc))
```

## Verification

`add_regex_check(..., Path('/no/such/ARCHITECTURE.md'), ...)` now appends the error instead of raising; the gate still passes clean on the real tree.