### PR TITLE
fix(select-model): exit cleanly when the model catalog is empty

### DIFF
--- a/ods/scripts/select-model.py
+++ b/ods/scripts/select-model.py
@@ -404,6 +404,9 @@ def main() -> int:
     args = parser.parse_args()
 
     catalog = load_catalog(args.catalog)
+    if not catalog:
+        print("error: model catalog is empty (no usable models)", file=sys.stderr)
+        return 1
     profile = effective_profile(normalize_profile(args.profile), args.backend, args.tier)
     capacity_gb, memory_label = usable_memory_gb(args.backend, args.memory_type, args.vram_mb, args.ram_gb)
     confidence = "high" if args.backend not in {"unknown", "none"} and capacity_gb > 0 else "medium"


### PR DESCRIPTION
## Problem

`rank_models()` in `scripts/select-model.py` falls back to:

```python
fallback = min(fallback_pool, key=lambda m: float(m.get("vram_required_gb") or 999))
```

The `... or catalog` guard on `fallback_pool` only helps when the *filtered* pool is empty. If the **catalog itself** is empty — a `--catalog` JSON with `"models": []`, or every entry filtered out by `normalize_model` — then `min([])` raises an uncaught `ValueError` and `main()` exits with a traceback:

```console
$ echo '{"models": []}' > empty.json
$ python3 scripts/select-model.py --catalog empty.json --backend cpu --ram-gb 8
ValueError: min() arg is an empty sequence   # scripts/select-model.py:272
```

(The shipped `config/model-library.json` has 20 models, so this only fires on a degenerate/partial catalog — plausible during catalog authoring/testing.)

## Fix

Guard for an empty catalog in `main()`:

```python
if not catalog:
    print("error: model catalog is empty (no usable models)", file=sys.stderr)
    return 1
```

## Verification

Empty catalog now prints a clean error and exits `1`; the real catalog is unaffected. Before the fix the same input raised the `ValueError` traceback above.