### PR TITLE
fix(tests,cli,docs): resolve dashboard-api Bearer auth across the stack

### DIFF
--- a/ods/extensions/services/n8n/README.md
+++ b/ods/extensions/services/n8n/README.md
@@ -54,12 +54,17 @@ n8n exposes its own REST API at `/api/v1/`. The ODS Dashboard API uses this to m
 
 The ODS dashboard provides a curated catalog of workflow templates at `/api/workflows`. Templates are stored in `config/n8n/` as JSON files and can be installed with one click from the Workflows page.
 
+The dashboard API requires a Bearer token — export `DASHBOARD_API_KEY` (found in your install's `.env`) before running these calls.
+
 ```bash
 # Check available workflows via dashboard API
-curl http://localhost:3002/api/workflows
+curl -H "Authorization: Bearer $DASHBOARD_API_KEY" \
+  http://localhost:3002/api/workflows
 
 # Install a workflow
-curl -X POST http://localhost:3002/api/workflows/my-workflow-id/enable
+curl -X POST \
+  -H "Authorization: Bearer $DASHBOARD_API_KEY" \
+  http://localhost:3002/api/workflows/my-workflow-id/enable
 ```
 
 ## Data Persistence

--- a/ods/extensions/services/privacy-shield/README.md
+++ b/ods/extensions/services/privacy-shield/README.md
@@ -35,18 +35,23 @@ Privacy Shield sits between your applications and the LLM API, automatically scr
 
 Privacy Shield is included as a core service and starts automatically with the stack.
 
-**Via Dashboard API:**
+**Via Dashboard API:** the dashboard API requires a Bearer token — export `DASHBOARD_API_KEY` (found in your install's `.env`) before running these calls.
+
 ```bash
 # Check status
-curl http://localhost:3002/api/privacy-shield/status
+curl -H "Authorization: Bearer $DASHBOARD_API_KEY" \
+  http://localhost:3002/api/privacy-shield/status
 
 # Enable
-curl -X POST http://localhost:3002/api/privacy-shield/toggle \
+curl -X POST \
+  -H "Authorization: Bearer $DASHBOARD_API_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"enable": true}'
+  -d '{"enable": true}' \
+  http://localhost:3002/api/privacy-shield/toggle
 
 # Get stats
-curl http://localhost:3002/api/privacy-shield/stats
+curl -H "Authorization: Bearer $DASHBOARD_API_KEY" \
+  http://localhost:3002/api/privacy-shield/stats
 ```
 
 ### Configuration

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -1406,14 +1406,21 @@ cmd_dry_run() {
     fi
 
     # Try dashboard API first; fall back to direct GitHub query.
+    # Two prior bugs fixed here:
+    #   1) DASHBOARD_PORT (3001) is the UI port, not the API port; the API
+    #      lives on DASHBOARD_API_PORT (3002). Hitting the UI port here
+    #      would route through nginx which does not proxy /api/update/*.
+    #   2) dashboard-api/security.py uses HTTPBearer, not X-API-Key. The
+    #      old X-API-Key header was always ignored → always 401 → silent
+    #      fallback to GitHub.
     local api_json=""
-    local dashboard_port="${DASHBOARD_PORT:-3002}"
+    local dashboard_api_port="${DASHBOARD_API_PORT:-3002}"
     local api_key=""
     api_key=$(grep '^DASHBOARD_API_KEY=' "$INSTALL_DIR/.env" 2>/dev/null | cut -d= -f2 | tr -d '[:space:]' || true)
     if [[ -n "$api_key" ]]; then
         api_json=$(curl -sf --max-time 5 \
-            -H "X-API-Key: ${api_key}" \
-            "http://127.0.0.1:${dashboard_port}/api/update/dry-run" 2>/dev/null || true)
+            -H "Authorization: Bearer ${api_key}" \
+            "http://127.0.0.1:${dashboard_api_port}/api/update/dry-run" 2>/dev/null || true)
     fi
 
     local latest_ver="" changelog_url="" update_status=""

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -902,14 +902,17 @@ cmd_health() {
         fi
     done
     
-    # Check dashboard API health endpoint
+    # Check dashboard API health endpoint. /health is the only unauth'd
+    # route on dashboard-api (see security.py), and it is always present
+    # when the container is up — no fallback needed. (The previous
+    # `/api/status` fallback was dead code: it requires Bearer auth, so
+    # `curl -sf` without a header would always 401 → non-zero → drop to
+    # the warn branch anyway.)
     local dashboard_api_port="${DASHBOARD_API_PORT:-}"
     [[ -n "$dashboard_api_port" ]] || dashboard_api_port="$(env_file_value DASHBOARD_API_PORT)"
     dashboard_api_port="${dashboard_api_port:-3002}"
     if curl -sf "http://127.0.0.1:${dashboard_api_port}/health" &>/dev/null; then
         log_ok "Dashboard API: healthy"
-    elif curl -sf "http://127.0.0.1:${dashboard_api_port}/api/status" &>/dev/null; then
-        log_ok "Dashboard API: responding"
     else
         log_warn "Dashboard API: not responding on port ${dashboard_api_port}"
     fi

--- a/ods/test-stack.sh
+++ b/ods/test-stack.sh
@@ -133,23 +133,33 @@ if $VOICE || $STRESS; then
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
     echo -e "${BOLD}Voice Pipeline Health Check${NC}"
     echo ""
-    
-    # Quick voice health
-    if curl -s http://127.0.0.1:3002/api/voice/status | grep -q '"available":true'; then
-        echo -e "${GREEN}✓ Voice services available${NC}"
-        
-        # Check individual services
-        for svc in stt tts livekit; do
-            if curl -s http://127.0.0.1:3002/api/voice/status | jq -e ".services.$svc.status == \"healthy\"" >/dev/null 2>&1; then
-                echo -e "  ${GREEN}✓${NC} $svc healthy"
-            else
-                echo -e "  ${RED}✗${NC} $svc unhealthy"
-            fi
-        done
-        ((SUITE_PASSED++))
+
+    # /api/voice/status requires a Bearer token (see dashboard-api
+    # security.py). Shared helper handles env resolution + CRLF scrubbing.
+    # shellcheck source=tests/lib/auth-env.sh
+    . "$TESTS_DIR/lib/auth-env.sh"
+    ae_resolve "$SCRIPT_DIR"
+
+    if ! ae_key_available; then
+        echo -e "${YELLOW}○ Skipped: DASHBOARD_API_KEY not found (checked env + $ae_env_file)${NC}"
     else
-        echo -e "${RED}✗ Voice services unavailable${NC}"
-        ((SUITE_FAILED++))
+        _VOICE_URL="$ae_api_base/api/voice/status"
+        # Fetch once, reuse — avoids the "available" check racing the per-svc probe.
+        _VOICE_JSON="$(curl -s --max-time 10 "${AE_AUTH_HEADER[@]}" "$_VOICE_URL" 2>/dev/null || echo '')"
+        if echo "$_VOICE_JSON" | grep -q '"available":true'; then
+            echo -e "${GREEN}✓ Voice services available${NC}"
+            for svc in stt tts livekit; do
+                if echo "$_VOICE_JSON" | jq -e ".services.$svc.status == \"healthy\"" >/dev/null 2>&1; then
+                    echo -e "  ${GREEN}✓${NC} $svc healthy"
+                else
+                    echo -e "  ${RED}✗${NC} $svc unhealthy"
+                fi
+            done
+            ((SUITE_PASSED++))
+        else
+            echo -e "${RED}✗ Voice services unavailable${NC}"
+            ((SUITE_FAILED++))
+        fi
     fi
     echo ""
 fi

--- a/ods/tests/dashboard-load-test.py
+++ b/ods/tests/dashboard-load-test.py
@@ -10,6 +10,8 @@ Usage:
 """
 
 import argparse
+import os
+import sys
 import threading
 import urllib.request
 import urllib.error
@@ -17,7 +19,39 @@ import time
 from datetime import datetime
 import queue
 
-DASHBOARD_API = "http://localhost:3002"
+# Dashboard-api endpoints under /api/* require Authorization: Bearer <key>
+# (see extensions/services/dashboard-api/security.py). The key lives in the
+# installer's .env; we read it from the environment or fall back to the
+# nearest .env file on disk. Without a key every request 401s and the load
+# report becomes meaningless — abort with a clear message instead.
+def _load_api_key() -> str:
+    key = os.environ.get("DASHBOARD_API_KEY", "").strip()
+    if key:
+        return key
+    here = os.path.dirname(os.path.abspath(__file__))
+    env_path = os.environ.get("ODS_INSTALL_DIR", os.path.dirname(here))
+    env_file = os.path.join(env_path, ".env")
+    if os.path.isfile(env_file):
+        with open(env_file, "r", encoding="utf-8", errors="replace") as f:
+            for line in f:
+                # CRLF-safe, quote/comment-safe
+                line = line.rstrip("\r\n").split("#", 1)[0]
+                if line.startswith("DASHBOARD_API_KEY="):
+                    v = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    if v:
+                        return v
+    return ""
+
+
+API_KEY = _load_api_key()
+if not API_KEY:
+    sys.stderr.write(
+        "ERROR: DASHBOARD_API_KEY not found. Export the variable or run this "
+        "test from an ODS install directory whose .env holds the key.\n"
+    )
+    sys.exit(2)
+
+DASHBOARD_API = os.environ.get("DASHBOARD_API_URL", "http://localhost:3002")
 ENDPOINTS = [
     "/api/agents/metrics",
     "/api/agents/cluster",
@@ -47,6 +81,7 @@ class LoadTester:
                 try:
                     req = urllib.request.Request(url, method='GET')
                     req.add_header('Accept', 'application/json')
+                    req.add_header('Authorization', f'Bearer {API_KEY}')
 
                     with urllib.request.urlopen(req, timeout=5) as resp:
                         elapsed = (time.time() - req_start) * 1000

--- a/ods/tests/lib/auth-env.sh
+++ b/ods/tests/lib/auth-env.sh
@@ -55,15 +55,41 @@ _ae_read_env() {
 
 # ae_resolve: populate DASHBOARD_API_KEY, DASHBOARD_API_PORT, SERVICE_HOST,
 # ae_env_file, ae_api_base. Idempotent — safe to call more than once.
+#
+# .env discovery order (first hit wins):
+#   1. $ODS_INSTALL_DIR/.env  (explicit override)
+#   2. <caller_dir>/.env      (caller runs from install root)
+#   3. <caller_dir>/../.env   (caller is ods/tests/, .env lives in ods/)
+# If none is found, ae_env_file is set to the last-tried path for diagnostics.
 ae_resolve() {
     local caller_dir="${1:-}"
     if [[ -z "$caller_dir" ]]; then
         # Assume caller sourced us; use their SCRIPT_DIR if present, else pwd.
         caller_dir="${SCRIPT_DIR:-$PWD}"
     fi
-    local root="${ODS_INSTALL_DIR:-$(cd "$caller_dir/.." 2>/dev/null && pwd)}"
-    [[ -z "$root" ]] && root="$caller_dir"
-    ae_env_file="$root/.env"
+
+    ae_env_file=""
+    if [[ -n "${ODS_INSTALL_DIR:-}" ]]; then
+        # Explicit override wins unconditionally. Even if the file doesn't
+        # exist, we don't hunt elsewhere — the override is authoritative
+        # ("look here for this install's .env"). Missing file just means
+        # no key from .env; ae_key_available will report false, and callers
+        # skip auth-required checks with a clear diagnostic pointing at
+        # this path.
+        ae_env_file="$ODS_INSTALL_DIR/.env"
+    elif [[ -f "$caller_dir/.env" ]]; then
+        ae_env_file="$caller_dir/.env"
+    else
+        local up
+        up="$(cd "$caller_dir/.." 2>/dev/null && pwd || true)"
+        if [[ -n "$up" && -f "$up/.env" ]]; then
+            ae_env_file="$up/.env"
+        else
+            # Nothing found — expose the most-likely install path for
+            # diagnostic messages ("checked $ae_env_file").
+            ae_env_file="${up:-$caller_dir}/.env"
+        fi
+    fi
 
     # Key: shell env wins; else read from .env (scrubbed).
     local key="${DASHBOARD_API_KEY:-}"

--- a/ods/tests/lib/auth-env.sh
+++ b/ods/tests/lib/auth-env.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS — shared auth + port resolution for test scripts
+# ============================================================================
+# Source this from any test script that hits the dashboard-api. Provides:
+#
+#   ae_resolve       Populate DASHBOARD_API_KEY, DASHBOARD_API_PORT, and
+#                    SERVICE_HOST from (in order) shell env → installer .env.
+#                    Contract: shell env wins over .env. Scrubs CRLF, quotes,
+#                    inline `# comments`, and trailing whitespace on every
+#                    .env-sourced value.
+#
+#   ae_key_available Returns 0 when DASHBOARD_API_KEY is non-empty, 1 otherwise.
+#
+#   AE_AUTH_HEADER   Array populated by ae_resolve — either
+#                    (-H "Authorization: Bearer <key>") when auth is
+#                    available, or () when not. Only splat as
+#                    "${AE_AUTH_HEADER[@]}" INSIDE an `if ae_key_available`
+#                    guard; empty-array expansion under `set -u` errors on
+#                    bash 3.2 (macOS default).
+#
+#   ae_env_file      Absolute path to the .env file being read (or "" if none).
+#   ae_api_base      Composed base URL: http://$SERVICE_HOST:$DASHBOARD_API_PORT
+#
+# Env inputs (any of these can override the .env value at any time):
+#   ODS_INSTALL_DIR      Where to look for .env (defaults to script's ../).
+#   DASHBOARD_API_KEY    Bearer token; shell value wins.
+#   DASHBOARD_API_PORT   API port; shell value wins.
+#   SERVICE_HOST         Bind host; defaults to 127.0.0.1.
+#
+# All helpers are read-only and safe under `set -uo pipefail`.
+# ============================================================================
+
+# _ae_clean_env_value: normalize a raw .env value — strip trailing CR (Windows
+# / WSL cross-usage), surrounding quotes, any inline `# comment`, and trailing
+# whitespace. Bash 3.2 compatible.
+_ae_clean_env_value() {
+    local v="$1"
+    v="${v%$'\r'}"
+    v="${v#\"}"; v="${v%\"}"
+    v="${v#\'}"; v="${v%\'}"
+    v="${v%%#*}"
+    while [[ "$v" == *[[:space:]] ]]; do v="${v%[[:space:]]}"; done
+    printf '%s' "$v"
+}
+
+# _ae_read_env: grep + scrub a single KEY from a .env file. Prints value or "".
+_ae_read_env() {
+    local key="$1" file="$2"
+    [[ -f "$file" ]] || return 0
+    local raw
+    raw="$(grep -E "^${key}=" "$file" 2>/dev/null | head -1 | cut -d= -f2-)"
+    _ae_clean_env_value "$raw"
+}
+
+# ae_resolve: populate DASHBOARD_API_KEY, DASHBOARD_API_PORT, SERVICE_HOST,
+# ae_env_file, ae_api_base. Idempotent — safe to call more than once.
+ae_resolve() {
+    local caller_dir="${1:-}"
+    if [[ -z "$caller_dir" ]]; then
+        # Assume caller sourced us; use their SCRIPT_DIR if present, else pwd.
+        caller_dir="${SCRIPT_DIR:-$PWD}"
+    fi
+    local root="${ODS_INSTALL_DIR:-$(cd "$caller_dir/.." 2>/dev/null && pwd)}"
+    [[ -z "$root" ]] && root="$caller_dir"
+    ae_env_file="$root/.env"
+
+    # Key: shell env wins; else read from .env (scrubbed).
+    local key="${DASHBOARD_API_KEY:-}"
+    if [[ -z "$key" ]]; then
+        key="$(_ae_read_env DASHBOARD_API_KEY "$ae_env_file")"
+    fi
+    # One last CR strip in case the value came from a pre-loaded environment
+    # where load_env_file / another loader didn't scrub trailing CR.
+    key="${key%$'\r'}"
+    DASHBOARD_API_KEY="$key"
+
+    # Port: shell env wins; else .env; else default 3002.
+    local port="${DASHBOARD_API_PORT:-}"
+    if [[ -z "$port" ]]; then
+        port="$(_ae_read_env DASHBOARD_API_PORT "$ae_env_file")"
+    fi
+    port="${port%$'\r'}"
+    DASHBOARD_API_PORT="${port:-3002}"
+
+    # Bind host.
+    SERVICE_HOST="${SERVICE_HOST:-127.0.0.1}"
+    SERVICE_HOST="${SERVICE_HOST%$'\r'}"
+
+    ae_api_base="http://${SERVICE_HOST}:${DASHBOARD_API_PORT}"
+
+    # Build the Bearer-header array for callers to splat into `curl (...)`.
+    # Kept as an array so single-arg forms like -H "Authorization: Bearer key"
+    # survive word-splitting cleanly even when the key contains punctuation.
+    if [[ -n "${DASHBOARD_API_KEY:-}" ]]; then
+        AE_AUTH_HEADER=(-H "Authorization: Bearer ${DASHBOARD_API_KEY}")
+    else
+        AE_AUTH_HEADER=()
+    fi
+}
+
+# ae_key_available: 0 if DASHBOARD_API_KEY is set + non-empty, 1 otherwise.
+ae_key_available() {
+    [[ -n "${DASHBOARD_API_KEY:-}" ]]
+}

--- a/ods/tests/test-auth-env.sh
+++ b/ods/tests/test-auth-env.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Contract tests for ods/tests/lib/auth-env.sh
+# ============================================================================
+# Proves the auth-env resolver behaves correctly under every realistic input
+# without needing a live dashboard-api:
+#
+#   1. Key from shell env (no .env)            → AE_AUTH_HEADER populated
+#   2. Key from .env only                      → AE_AUTH_HEADER populated
+#   3. Shell env wins over .env                → shell value used
+#   4. CRLF-mangled .env value                 → \r stripped
+#   5. Inline `# comment` in .env value        → comment stripped
+#   6. Surrounding double/single quotes        → quotes stripped
+#   7. Trailing whitespace in .env value       → stripped
+#   8. Neither shell nor .env has the key      → AE_AUTH_HEADER empty
+#   9. ae_api_base composed from resolved port + host
+#  10. Port from .env used when shell env unset
+#
+# Also runs test-integration.sh --quick under both key-present and
+# key-absent conditions and confirms the SKIP-vs-FAIL banner semantics
+# demanded by the review (without needing a real dashboard-api — the
+# SKIP branches fire from the AUTH_AVAILABLE=false path).
+#
+# Usage:  bash tests/test-auth-env.sh
+# Exit:   0 = all pass, 1 = one or more failures.
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/lib/auth-env.sh"
+INTEGRATION="$SCRIPT_DIR/test-integration.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+pass() { printf "  ${GREEN}✓ PASS${NC} %s\n" "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf "  ${RED}✗ FAIL${NC} %s\n  reason: %s\n" "$1" "$2"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "╔══════════════════════════════════════════════════════════╗"
+echo "║   auth-env.sh contract tests                             ║"
+echo "╚══════════════════════════════════════════════════════════╝"
+echo ""
+
+# Fail loud if the helper isn't present.
+if [[ ! -f "$LIB" ]]; then
+    echo "FATAL: helper not found at $LIB"
+    exit 2
+fi
+pass "auth-env.sh exists"
+
+if ! bash -n "$LIB" 2>/dev/null; then
+    fail "bash -n on helper" "syntax error"
+    exit 2
+fi
+pass "bash -n on auth-env.sh"
+
+# Each subshell resolves independently so state doesn't leak between cases.
+# Uses `env -i` to null out inherited env so shell-vs-.env precedence tests
+# don't get polluted by a real DASHBOARD_API_KEY in the caller's env.
+
+_run_case() {
+    # _run_case <case-label> <bash -c script>
+    local label="$1" script="$2"
+    local out
+    out="$(env -i HOME="$HOME" PATH="$PATH" bash -c "$script" 2>&1)" || true
+    printf '%s' "$out"
+}
+
+# ── 1. Key from shell env, no .env file ─────────────────────────────────────
+tmp="$(mktemp -d)"
+out="$(_run_case case1 "
+    set -u
+    export DASHBOARD_API_KEY='shell-key-abc'
+    . '$LIB'
+    ae_resolve '$tmp'
+    ae_key_available && echo AVAIL=yes || echo AVAIL=no
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+    echo API_BASE=\$ae_api_base
+")"
+if grep -q 'AVAIL=yes' <<<"$out" \
+    && grep -q 'HDRS=-H|Authorization: Bearer shell-key-abc|' <<<"$out"; then
+    pass "case 1: shell env sets DASHBOARD_API_KEY → AE_AUTH_HEADER populated"
+else
+    fail "case 1: shell-env key" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 2. Key from .env file, no shell env ─────────────────────────────────────
+tmp="$(mktemp -d)"
+printf 'DASHBOARD_API_KEY=envfile-key-xyz\n' >"$tmp/.env"
+out="$(_run_case case2 "
+    set -u
+    . '$LIB'
+    ae_resolve '$tmp'
+    ae_key_available && echo AVAIL=yes || echo AVAIL=no
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+")"
+if grep -q 'AVAIL=yes' <<<"$out" \
+    && grep -q 'HDRS=-H|Authorization: Bearer envfile-key-xyz|' <<<"$out"; then
+    pass "case 2: .env-only key → AE_AUTH_HEADER populated"
+else
+    fail "case 2: .env-only key" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 3. Shell env wins over .env ─────────────────────────────────────────────
+tmp="$(mktemp -d)"
+printf 'DASHBOARD_API_KEY=envfile-loser\n' >"$tmp/.env"
+out="$(_run_case case3 "
+    set -u
+    export DASHBOARD_API_KEY='shell-winner'
+    . '$LIB'
+    ae_resolve '$tmp'
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+")"
+if grep -q 'HDRS=-H|Authorization: Bearer shell-winner|' <<<"$out"; then
+    pass "case 3: shell env wins over .env (precedence contract)"
+else
+    fail "case 3: precedence" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 4. CRLF in .env value stripped ──────────────────────────────────────────
+tmp="$(mktemp -d)"
+printf 'DASHBOARD_API_KEY=crlf-key-value\r\n' >"$tmp/.env"
+out="$(_run_case case4 "
+    set -u
+    . '$LIB'
+    ae_resolve '$tmp'
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+")"
+if grep -q 'HDRS=-H|Authorization: Bearer crlf-key-value|' <<<"$out"; then
+    pass "case 4: CRLF from Windows-edited .env stripped"
+else
+    fail "case 4: CRLF strip" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 5. Inline # comment in .env value stripped ──────────────────────────────
+tmp="$(mktemp -d)"
+printf 'DASHBOARD_API_KEY=cleanpart # rotated 2026-06\n' >"$tmp/.env"
+out="$(_run_case case5 "
+    set -u
+    . '$LIB'
+    ae_resolve '$tmp'
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+")"
+if grep -q 'HDRS=-H|Authorization: Bearer cleanpart|' <<<"$out"; then
+    pass "case 5: inline # comment in .env value stripped"
+else
+    fail "case 5: inline comment strip" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 6. Surrounding quotes stripped (both flavors) ───────────────────────────
+tmp="$(mktemp -d)"
+printf 'DASHBOARD_API_KEY="double-quoted-key"\n' >"$tmp/.env"
+out="$(_run_case case6a "
+    set -u
+    . '$LIB'
+    ae_resolve '$tmp'
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+")"
+if grep -q 'HDRS=-H|Authorization: Bearer double-quoted-key|' <<<"$out"; then
+    pass "case 6a: double-quoted .env value → quotes stripped"
+else
+    fail "case 6a: double quotes" "$out"
+fi
+rm -rf "$tmp"
+
+tmp="$(mktemp -d)"
+printf "DASHBOARD_API_KEY='single-quoted-key'\n" >"$tmp/.env"
+out="$(_run_case case6b "
+    set -u
+    . '$LIB'
+    ae_resolve '$tmp'
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+")"
+if grep -q "HDRS=-H|Authorization: Bearer single-quoted-key|" <<<"$out"; then
+    pass "case 6b: single-quoted .env value → quotes stripped"
+else
+    fail "case 6b: single quotes" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 7. Trailing whitespace stripped ─────────────────────────────────────────
+tmp="$(mktemp -d)"
+printf 'DASHBOARD_API_KEY=trimmed-key   \t  \n' >"$tmp/.env"
+out="$(_run_case case7 "
+    set -u
+    . '$LIB'
+    ae_resolve '$tmp'
+    printf 'HDRS='; printf '%s|' \"\${AE_AUTH_HEADER[@]}\"; echo
+")"
+if grep -q 'HDRS=-H|Authorization: Bearer trimmed-key|' <<<"$out"; then
+    pass "case 7: trailing whitespace stripped"
+else
+    fail "case 7: trailing whitespace" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 8. No key anywhere → AE_AUTH_HEADER empty ───────────────────────────────
+tmp="$(mktemp -d)"
+# .env exists but no DASHBOARD_API_KEY line
+printf 'SOME_OTHER=1\n' >"$tmp/.env"
+out="$(_run_case case8 "
+    set -uo pipefail
+    . '$LIB'
+    ae_resolve '$tmp'
+    ae_key_available && echo AVAIL=yes || echo AVAIL=no
+    echo COUNT=\${#AE_AUTH_HEADER[@]}
+")"
+if grep -q 'AVAIL=no' <<<"$out" && grep -q 'COUNT=0' <<<"$out"; then
+    pass "case 8: no key anywhere → AE_AUTH_HEADER empty, ae_key_available=false"
+else
+    fail "case 8: no-key path" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 9. ae_api_base composed from resolved host + port ───────────────────────
+tmp="$(mktemp -d)"
+out="$(_run_case case9 "
+    set -u
+    export DASHBOARD_API_PORT=3999
+    export SERVICE_HOST=example.local
+    . '$LIB'
+    ae_resolve '$tmp'
+    echo BASE=\$ae_api_base
+")"
+if grep -q 'BASE=http://example.local:3999' <<<"$out"; then
+    pass "case 9: ae_api_base composed from shell-env host + port"
+else
+    fail "case 9: ae_api_base composition" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 10. Port from .env used when shell env unset ────────────────────────────
+tmp="$(mktemp -d)"
+printf 'DASHBOARD_API_PORT=4444\n' >"$tmp/.env"
+out="$(_run_case case10 "
+    set -u
+    . '$LIB'
+    ae_resolve '$tmp'
+    echo BASE=\$ae_api_base
+")"
+if grep -q 'BASE=http://127.0.0.1:4444' <<<"$out"; then
+    pass "case 10: port from .env used when shell env unset"
+else
+    fail "case 10: .env port fallback" "$out"
+fi
+rm -rf "$tmp"
+
+# ── 11. test-integration.sh --quick without key → SKIP semantics fire ───────
+# Verifies the SKIP-vs-FAIL contract the reviewer asked for. Runs the real
+# script under an env that has no key and no dashboard-api reachable; every
+# auth-required check should SKIP with the "no DASHBOARD_API_KEY" reason
+# rather than be counted as FAIL.
+if [[ -f "$INTEGRATION" ]] && command -v jq >/dev/null 2>&1; then
+    tmp="$(mktemp -d)"
+    out="$(env -i HOME="$HOME" PATH="$PATH" ODS_INSTALL_DIR="$tmp" \
+        bash "$INTEGRATION" --quick 2>&1 || true)"
+    # Expect the banner and at least one SKIP with the exact reason string
+    if grep -q 'DASHBOARD_API_KEY not found' <<<"$out" \
+        && grep -qE '\(no DASHBOARD_API_KEY\)' <<<"$out"; then
+        # And expect the results line to include the skipped count, not
+        # a slew of FAILs for the auth-required checks.
+        _skips=$(grep -oE '[0-9]+ skipped' <<<"$out" | head -1 | grep -oE '[0-9]+' || echo 0)
+        if [[ "${_skips:-0}" -ge 5 ]]; then
+            pass "case 11: --quick without key produces SKIP banner + ≥5 skips (auth-required)"
+        else
+            fail "case 11: --quick without key" \
+                "expected ≥5 skips (auth-required checks), got $_skips
+--- output ---
+$out"
+        fi
+    else
+        fail "case 11: --quick without key" \
+            "SKIP banner or reason string not found
+--- output ---
+$out"
+    fi
+    rm -rf "$tmp"
+else
+    printf "  (skipped case 11: %s)\n" \
+        "$( [[ -f "$INTEGRATION" ]] && echo 'jq unavailable' || echo 'test-integration.sh not found' )"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ $FAILED -eq 0 ]]

--- a/ods/tests/test-dashboard-integration.sh
+++ b/ods/tests/test-dashboard-integration.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # ODS Dashboard Integration Test
 # Validates Dashboard API endpoints and connectivity
+#
+# Auth: dashboard-api routes require Authorization: Bearer $DASHBOARD_API_KEY
+# (see security.py). Key resolved via tests/lib/auth-env.sh from shell env or
+# installer .env. Missing key → auth-required checks SKIP rather than FAIL.
 
 set -e
 
@@ -11,21 +15,30 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-# Config with environment variable support
-API_URL="${API_URL:-http://localhost:3002}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/auth-env.sh
+. "$SCRIPT_DIR/lib/auth-env.sh"
+ae_resolve "$SCRIPT_DIR"
+
+# API_URL override still honored (external test rigs); default uses the
+# resolver's host+port, which reflects .env overrides + shell env precedence.
+API_URL="${API_URL:-$ae_api_base}"
 CURL_TIMEOUT=10  # seconds
 PASS_FILE=$(mktemp)
 FAIL_FILE=$(mktemp)
+SKIP_FILE=$(mktemp)
 
 # Cleanup temp files on exit
 cleanup() {
-    rm -f "$PASS_FILE" "$FAIL_FILE"
+    rm -f "$PASS_FILE" "$FAIL_FILE" "$SKIP_FILE" \
+          "$PASS_FILE.lock" "$FAIL_FILE.lock" "$SKIP_FILE.lock"
 }
 trap cleanup EXIT
 
 # Initialize counters
 echo "0" > "$PASS_FILE"
 echo "0" > "$FAIL_FILE"
+echo "0" > "$SKIP_FILE"
 
 # Thread-safe counter increment using file locking
 increment_pass() {
@@ -55,28 +68,40 @@ echo -e "${CYAN}  Dashboard API Integration Tests${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
 
-# Test function
+increment_skip() {
+    # Skipped auth-required checks — separate counter so summary is honest.
+    (
+        flock -x 200
+        local count
+        count=$(cat "$SKIP_FILE")
+        echo $((count + 1)) > "$SKIP_FILE"
+    ) 200>"$SKIP_FILE.lock"
+}
+get_skipped() { cat "$SKIP_FILE"; }
+
+# Test function. Always splats AE_AUTH_HEADER — harmless on /health (extra
+# header ignored), required on every other dashboard-api endpoint.
 test_endpoint() {
     local name=$1
     local endpoint=$2
     local expected_field=$3
-    
+
     echo -n "  Testing $name ($endpoint)... "
-    
+
     # Fetch with timeout
-    response=$(curl -sf -m "$CURL_TIMEOUT" "${API_URL}${endpoint}" 2>/dev/null) || {
+    response=$(curl -sf -m "$CURL_TIMEOUT" "${AE_AUTH_HEADER[@]}" "${API_URL}${endpoint}" 2>/dev/null) || {
         echo -e "${RED}FAIL${NC} (connection error)"
         increment_fail
         return 1
     }
-    
+
     # Validate response is valid JSON before jq processing
     if ! echo "$response" | jq empty 2>/dev/null; then
         echo -e "${RED}FAIL${NC} (invalid JSON)"
         increment_fail
         return 1
     fi
-    
+
     if echo "$response" | jq -e ".$expected_field" > /dev/null 2>&1; then
         echo -e "${GREEN}PASS${NC}"
         increment_pass
@@ -88,27 +113,42 @@ test_endpoint() {
     fi
 }
 
+# Auth-required wrapper: skips (does NOT fail) when no bearer key is
+# available, so a working install without .env in the test environment
+# doesn't produce spurious FAILs for endpoints that are behaving correctly
+# but locked. Returns 0 in either case so `set -e` doesn't abort the suite.
+test_endpoint_auth() {
+    local name=$1 endpoint=$2 expected_field=$3
+    if ae_key_available; then
+        test_endpoint "$name" "$endpoint" "$expected_field" || true
+    else
+        echo -e "  Testing $name ($endpoint)... ${YELLOW}SKIP${NC} (no DASHBOARD_API_KEY)"
+        increment_skip
+    fi
+    return 0
+}
+
 # Test for JSON array response
 test_array_endpoint() {
     local name=$1
     local endpoint=$2
-    
+
     echo -n "  Testing $name ($endpoint)... "
-    
+
     # Fetch with timeout
-    response=$(curl -sf -m "$CURL_TIMEOUT" "${API_URL}${endpoint}" 2>/dev/null) || {
+    response=$(curl -sf -m "$CURL_TIMEOUT" "${AE_AUTH_HEADER[@]}" "${API_URL}${endpoint}" 2>/dev/null) || {
         echo -e "${RED}FAIL${NC} (connection error)"
         increment_fail
         return 1
     }
-    
+
     # Validate response is valid JSON
     if ! echo "$response" | jq empty 2>/dev/null; then
         echo -e "${RED}FAIL${NC} (invalid JSON)"
         increment_fail
         return 1
     fi
-    
+
     if echo "$response" | jq -e 'type == "array"' > /dev/null 2>&1; then
         count=$(echo "$response" | jq 'length')
         echo -e "${GREEN}PASS${NC} ($count items)"
@@ -121,12 +161,29 @@ test_array_endpoint() {
     fi
 }
 
+test_array_endpoint_auth() {
+    local name=$1 endpoint=$2
+    if ae_key_available; then
+        test_array_endpoint "$name" "$endpoint" || true
+    else
+        echo -e "  Testing $name ($endpoint)... ${YELLOW}SKIP${NC} (no DASHBOARD_API_KEY)"
+        increment_skip
+    fi
+    return 0
+}
+
 # Test response structure
 test_status_structure() {
     echo -n "  Testing /api/status structure... "
-    
+
+    if ! ae_key_available; then
+        echo -e "${YELLOW}SKIP${NC} (no DASHBOARD_API_KEY)"
+        increment_skip
+        return 0
+    fi
+
     # Fetch with timeout
-    response=$(curl -sf -m "$CURL_TIMEOUT" "${API_URL}/api/status" 2>/dev/null) || {
+    response=$(curl -sf -m "$CURL_TIMEOUT" "${AE_AUTH_HEADER[@]}" "${API_URL}/api/status" 2>/dev/null) || {
         echo -e "${RED}FAIL${NC} (connection error)"
         increment_fail
         return 1
@@ -160,12 +217,19 @@ test_status_structure() {
     fi
 }
 
-# Run tests
+if ! ae_key_available; then
+    echo -e "${YELLOW}Note:${NC} DASHBOARD_API_KEY not found (checked shell env + $ae_env_file)."
+    echo -e "${YELLOW}      Auth-required checks will be skipped (not failed).${NC}"
+    echo ""
+fi
+
+# Run tests. /health is the only public endpoint on dashboard-api — everything
+# else (see security.py) requires Authorization: Bearer $DASHBOARD_API_KEY.
 echo -e "${CYAN}Core Endpoints:${NC}"
 test_endpoint "Health" "/health" "status"
-test_endpoint "Disk" "/disk" "used_gb"
-test_endpoint "Bootstrap" "/bootstrap" "active"
-test_array_endpoint "Services" "/services"
+test_endpoint_auth "Disk" "/disk" "used_gb"
+test_endpoint_auth "Bootstrap" "/bootstrap" "active"
+test_array_endpoint_auth "Services" "/services"
 
 echo ""
 echo -e "${CYAN}Dashboard Endpoint:${NC}"
@@ -173,13 +237,13 @@ test_status_structure
 
 echo ""
 echo -e "${CYAN}Optional Endpoints (may fail without GPU/services):${NC}"
-test_endpoint "GPU" "/gpu" "name" || true
-test_endpoint "Model" "/model" "name" || true
+test_endpoint_auth "GPU" "/gpu" "name"
+test_endpoint_auth "Model" "/model" "name"
 
 # Summary
 echo ""
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "  Results: ${GREEN}$(get_passed) passed${NC}, ${RED}$(get_failed) failed${NC}"
+echo -e "  Results: ${GREEN}$(get_passed) passed${NC}, ${RED}$(get_failed) failed${NC}, ${YELLOW}$(get_skipped) skipped${NC}"
 echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
 

--- a/ods/tests/test-integration.sh
+++ b/ods/tests/test-integration.sh
@@ -3,20 +3,29 @@
 # Validates all services are working end-to-end
 #
 # Usage: ./tests/test-integration.sh [--verbose] [--quick]
+#
+# Auth: dashboard-api routes under /api/*, /status, /gpu, /services now require
+# a Bearer token (see security.py). This script resolves the API key from, in
+# order: $DASHBOARD_API_KEY, the ODS install .env, or falls back to skipping
+# authenticated checks with a clear warning. Never invents a key.
+#
+# Ports: honor env-var overrides from .env so the checks track whatever ports
+# the installer actually wrote for this host (e.g. Strix Halo AMD writes
+# WHISPER_PORT=9100 to avoid Lemonade's port 9000).
 
 # Note: Intentionally NOT using set -e here — test functions return 1 on failure
 # and we want to continue running all tests, tracking results via PASSED/FAILED counters
 set -uo pipefail
 
-# Check for required dependencies
-command -v jq >/dev/null 2>&1 || { echo -e "${RED}✗${NC} jq is required but not installed. Install with: apt-get install jq (Debian/Ubuntu) or brew install jq (macOS)"; exit 1; }
-
-# Colors
+# Colors (must be defined before any log_* call, including the jq check below)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m'
+
+# Check for required dependencies
+command -v jq >/dev/null 2>&1 || { echo -e "${RED}✗${NC} jq is required but not installed. Install with: apt-get install jq (Debian/Ubuntu) or brew install jq (macOS)"; exit 1; }
 
 # Config
 VERBOSE=${VERBOSE:-false}
@@ -47,22 +56,118 @@ log_fail() { echo -e "${RED}✗${NC} $1"; ((FAILED++)); }
 log_skip() { echo -e "${YELLOW}○${NC} $1 (skipped)"; ((SKIPPED++)); }
 log_verbose() { $VERBOSE && echo -e "  ${NC}$1" || true; }
 
-# Test helpers
+# ─── Resolve host, ports, and API key from installer .env ────────────────────
+# Shared helper handles: shell-env-wins precedence, CRLF scrubbing, inline
+# comment / quote stripping, and default fallbacks. Also populates the
+# AE_AUTH_HEADER array we splat into curl.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/auth-env.sh
+. "$SCRIPT_DIR/lib/auth-env.sh"
+
+ODS_ROOT="${ODS_INSTALL_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# Load .env safely for the extra port env vars (WHISPER_PORT, TTS_PORT, …)
+# that aren't part of the auth helper's remit. Capture shell overrides first
+# so they still win over .env (load_env_file exports unconditionally).
+_shell_DASHBOARD_PORT="${DASHBOARD_PORT:-}"
+_shell_WHISPER_PORT="${WHISPER_PORT:-}"
+_shell_TTS_PORT="${TTS_PORT:-}"
+_shell_N8N_PORT="${N8N_PORT:-}"
+_shell_QDRANT_PORT="${QDRANT_PORT:-}"
+_shell_LIVEKIT_PORT="${LIVEKIT_PORT:-}"
+_shell_OLLAMA_PORT="${OLLAMA_PORT:-}"
+_shell_LLAMA_SERVER_PORT="${LLAMA_SERVER_PORT:-}"
+
+if [[ -f "$ODS_ROOT/lib/safe-env.sh" ]]; then
+    # shellcheck source=/dev/null
+    . "$ODS_ROOT/lib/safe-env.sh"
+    load_env_file "$ODS_ROOT/.env"
+fi
+
+[[ -n "$_shell_DASHBOARD_PORT"      ]] && DASHBOARD_PORT="$_shell_DASHBOARD_PORT"
+[[ -n "$_shell_WHISPER_PORT"        ]] && WHISPER_PORT="$_shell_WHISPER_PORT"
+[[ -n "$_shell_TTS_PORT"            ]] && TTS_PORT="$_shell_TTS_PORT"
+[[ -n "$_shell_N8N_PORT"            ]] && N8N_PORT="$_shell_N8N_PORT"
+[[ -n "$_shell_QDRANT_PORT"         ]] && QDRANT_PORT="$_shell_QDRANT_PORT"
+[[ -n "$_shell_LIVEKIT_PORT"        ]] && LIVEKIT_PORT="$_shell_LIVEKIT_PORT"
+[[ -n "$_shell_OLLAMA_PORT"         ]] && OLLAMA_PORT="$_shell_OLLAMA_PORT"
+[[ -n "$_shell_LLAMA_SERVER_PORT"   ]] && LLAMA_SERVER_PORT="$_shell_LLAMA_SERVER_PORT"
+
+# CRLF scrub every port variable so a Windows-edited .env doesn't leak `\r`
+# into URLs (silent curl failure).
+for _p in DASHBOARD_PORT WHISPER_PORT TTS_PORT N8N_PORT QDRANT_PORT \
+          LIVEKIT_PORT OLLAMA_PORT LLAMA_SERVER_PORT; do
+    _v="${!_p:-}"; printf -v "$_p" '%s' "${_v%$'\r'}"
+done
+unset _p _v
+
+# Resolve API key + port + host + AE_AUTH_HEADER via the shared helper.
+ae_resolve "$SCRIPT_DIR"
+
+# Ports — canonical manifest defaults from ods/extensions/services/*/manifest.yaml.
+DASHBOARD_PORT="${DASHBOARD_PORT:-3001}"
+WHISPER_PORT="${WHISPER_PORT:-9000}"
+TTS_PORT="${TTS_PORT:-8880}"
+N8N_PORT="${N8N_PORT:-5678}"
+QDRANT_PORT="${QDRANT_PORT:-6333}"
+LIVEKIT_PORT="${LIVEKIT_PORT:-7880}"
+# llama-server: OLLAMA_PORT (installer alias) → LLAMA_SERVER_PORT → 8080.
+# 8080 is the canonical default (docker-compose.base.yml); 11434 is only
+# the Strix Halo AMD override written by installer phase 06 into .env.
+LLM_PORT="${OLLAMA_PORT:-${LLAMA_SERVER_PORT:-8080}}"
+
+API_BASE="$ae_api_base"
+
+# Back-compat aliases so the rest of the script reads cleanly.
+API_KEY="$DASHBOARD_API_KEY"
+if ae_key_available; then AUTH_AVAILABLE=true; else AUTH_AVAILABLE=false; fi
+# Historical name kept for local grep. AE_AUTH_HEADER is the canonical array.
+declare -a AUTH_HEADER_ARGS
+if $AUTH_AVAILABLE; then
+    AUTH_HEADER_ARGS=("${AE_AUTH_HEADER[@]}")
+else
+    AUTH_HEADER_ARGS=()
+fi
+
 test_http() {
     local name="$1"
     local url="$2"
     local expected="${3:-200}"
     local method="${4:-GET}"
     local data="${5:-}"
-    
+
     local args=(-s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT")
     [[ -n "$data" ]] && args+=(-X "$method" -H "Content-Type: application/json" -d "$data")
-    
+
     local code
     code=$(curl "${args[@]}" "$url" 2>/dev/null) || code="000"
-    
+
     if [[ "$code" == "$expected" ]]; then
         log_pass "$name"
+        return 0
+    else
+        log_fail "$name (expected $expected, got $code)"
+        return 1
+    fi
+}
+
+# Like test_http but treats connection failure (000) as SKIP rather than
+# FAIL — the service is optional / not deployed. Also stops the shell from
+# double-counting via the old `test_http ... || log_skip` pattern which fired
+# both log_fail and log_skip on the same check.
+test_http_optional() {
+    local name="$1"
+    local url="$2"
+    local expected="${3:-200}"
+
+    local code
+    code=$(curl -s -o /dev/null -w "%{http_code}" --max-time "$TIMEOUT" "$url" 2>/dev/null) || code="000"
+
+    if [[ "$code" == "$expected" ]]; then
+        log_pass "$name"
+        return 0
+    elif [[ "$code" == "000" ]]; then
+        log_skip "$name (service not running)"
         return 0
     else
         log_fail "$name (expected $expected, got $code)"
@@ -74,10 +179,39 @@ test_json() {
     local name="$1"
     local url="$2"
     local jq_filter="$3"
-    
+
     local response
     response=$(curl -s --max-time $TIMEOUT "$url" 2>/dev/null) || response=""
-    
+
+    if echo "$response" | jq -e "$jq_filter" >/dev/null 2>&1; then
+        log_pass "$name"
+        local summary
+        summary=$(echo "$response" | jq -c '.' 2>/dev/null || echo "$response")
+        log_verbose "Response: ${summary:0:100}"
+        return 0
+    else
+        log_fail "$name (jq filter failed: $jq_filter)"
+        log_verbose "Response: ${response:0:100}"
+        return 1
+    fi
+}
+
+# Auth-aware variant. Skips (does not fail) when no API key is available,
+# so a dev running this without an install .env doesn't see spurious FAIL
+# lines for endpoints that are behaving correctly but locked.
+test_json_auth() {
+    local name="$1"
+    local url="$2"
+    local jq_filter="$3"
+
+    if ! $AUTH_AVAILABLE; then
+        log_skip "$name (no DASHBOARD_API_KEY)"
+        return 0
+    fi
+
+    local response
+    response=$(curl -s --max-time "$TIMEOUT" "${AUTH_HEADER_ARGS[@]}" "$url" 2>/dev/null) || response=""
+
     if echo "$response" | jq -e "$jq_filter" >/dev/null 2>&1; then
         log_pass "$name"
         local summary
@@ -95,7 +229,7 @@ test_llm() {
     local name="$1"
     local url="$2"
     local prompt="$3"
-    
+
     local data
     data=$(jq -n --arg prompt "$prompt" '{
         model: "qwen2.5-32b-instruct",
@@ -103,13 +237,13 @@ test_llm() {
         max_tokens: 50,
         stream: false
     }')
-    
+
     local response
     response=$(curl -s --max-time 30 -X POST \
         -H "Content-Type: application/json" \
         -d "$data" \
         "$url/v1/chat/completions" 2>/dev/null) || response=""
-    
+
     if echo "$response" | jq -e '.choices[0].message.content' >/dev/null 2>&1; then
         local content
         content=$(echo "$response" | jq -r '.choices[0].message.content' | head -c 100)
@@ -130,15 +264,41 @@ echo -e "${BLUE}║${NC}  ODS Integration Tests                              ${B
 echo -e "${BLUE}╚══════════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
+if ! $AUTH_AVAILABLE; then
+    log_info "DASHBOARD_API_KEY not found (checked \$DASHBOARD_API_KEY and $ENV_FILE)."
+    log_info "Authenticated /api/* checks will be skipped — set the env var or run after install."
+    echo ""
+fi
+
 # ========================================
 # Dashboard API Tests
 # ========================================
 echo -e "${BLUE}▸ Dashboard API${NC}"
 
-test_http "API health check" "http://localhost:3002/health"
-test_json "API status endpoint" "http://localhost:3002/api/status" '.gpu or .services'
-test_json "GPU metrics" "http://localhost:3002/gpu" '.name and .memory_used_mb'
-test_json "Service list" "http://localhost:3002/services" '. | length > 0'
+test_http "API health check" "$API_BASE/health"
+test_json_auth "API status endpoint" "$API_BASE/api/status" '(.gpu != null) or ((.services // []) | length > 0)'
+# GPU may legitimately be absent on CPU-only installs (503) — treat as skip.
+# Single fetch with -w emits body then '\n<code>' so we can classify + reuse
+# without hitting the endpoint twice.
+if $AUTH_AVAILABLE; then
+    _gpu_resp=$(curl -s -w '\n%{http_code}' --max-time "$TIMEOUT" \
+        "${AUTH_HEADER_ARGS[@]}" "$API_BASE/gpu" 2>/dev/null || printf '\n000')
+    _gpu_code="${_gpu_resp##*$'\n'}"
+    _gpu_body="${_gpu_resp%$'\n'*}"
+    if [[ "$_gpu_code" == "503" ]]; then
+        log_skip "GPU metrics (CPU-only install — /gpu returned 503)"
+    elif [[ "$_gpu_code" == "200" ]] && \
+         echo "$_gpu_body" | jq -e '.name and (.memory_used_mb != null)' >/dev/null 2>&1; then
+        log_pass "GPU metrics"
+    else
+        log_fail "GPU metrics (http=$_gpu_code, jq filter: .name and .memory_used_mb)"
+        log_verbose "Response: ${_gpu_body:0:100}"
+    fi
+    unset _gpu_resp _gpu_code _gpu_body
+else
+    log_skip "GPU metrics (no DASHBOARD_API_KEY)"
+fi
+test_json_auth "Service list" "$API_BASE/services" '. | length > 0'
 
 # ========================================
 # Model API Tests
@@ -146,8 +306,29 @@ test_json "Service list" "http://localhost:3002/services" '. | length > 0'
 echo ""
 echo -e "${BLUE}▸ Model Manager API${NC}"
 
-test_json "Model catalog" "http://localhost:3002/api/models" '.models | length > 0'
-test_json "VRAM info in catalog" "http://localhost:3002/api/models" '.gpu.vramTotal > 0'
+# Fetch /api/models once and drive both the catalog + VRAM checks from it —
+# saves a redundant round-trip and eliminates the race window between them.
+if $AUTH_AVAILABLE; then
+    _models_body=$(curl -s --max-time "$TIMEOUT" "${AUTH_HEADER_ARGS[@]}" "$API_BASE/api/models" 2>/dev/null || echo '')
+    if echo "$_models_body" | jq -e '.models | length > 0' >/dev/null 2>&1; then
+        log_pass "Model catalog"
+        log_verbose "Response: ${_models_body:0:100}"
+    else
+        log_fail "Model catalog (jq filter failed: .models | length > 0)"
+        log_verbose "Response: ${_models_body:0:100}"
+    fi
+    if echo "$_models_body" | jq -e '.gpu == null' >/dev/null 2>&1; then
+        log_skip "VRAM info in catalog (CPU-only install — .gpu is null)"
+    elif echo "$_models_body" | jq -e '.gpu.vramTotal > 0' >/dev/null 2>&1; then
+        log_pass "VRAM info in catalog"
+    else
+        log_fail "VRAM info in catalog (jq filter failed: .gpu.vramTotal > 0)"
+    fi
+    unset _models_body
+else
+    log_skip "Model catalog (no DASHBOARD_API_KEY)"
+    log_skip "VRAM info in catalog (no DASHBOARD_API_KEY)"
+fi
 
 # ========================================
 # Workflow API Tests
@@ -155,8 +336,8 @@ test_json "VRAM info in catalog" "http://localhost:3002/api/models" '.gpu.vramTo
 echo ""
 echo -e "${BLUE}▸ Workflow API${NC}"
 
-test_json "Workflow catalog" "http://localhost:3002/api/workflows" '.workflows | length > 0'
-test_json "Workflow categories" "http://localhost:3002/api/workflows" '.categories | keys | length > 0'
+test_json_auth "Workflow catalog" "$API_BASE/api/workflows" '.workflows | length > 0'
+test_json_auth "Workflow categories" "$API_BASE/api/workflows" '.categories | keys | length > 0'
 
 # ========================================
 # Voice API Tests
@@ -164,7 +345,7 @@ test_json "Workflow categories" "http://localhost:3002/api/workflows" '.categori
 echo ""
 echo -e "${BLUE}▸ Voice API${NC}"
 
-test_json "Voice status" "http://localhost:3002/api/voice/status" '.services'
+test_json_auth "Voice status" "$API_BASE/api/voice/status" '.services'
 
 # ========================================
 # Core Service Tests
@@ -174,17 +355,15 @@ echo -e "${BLUE}▸ Core Services${NC}"
 
 # llama-server
 if ! $QUICK; then
-    test_http "llama-server health" "http://localhost:8080/health"
-    test_llm "llama-server inference" "http://localhost:8080" "Say hello in exactly 3 words."
+    test_http "llama-server health" "http://${SERVICE_HOST}:${LLM_PORT}/health"
+    test_llm "llama-server inference" "http://${SERVICE_HOST}:${LLM_PORT}" "Say hello in exactly 3 words."
 else
     log_skip "llama-server inference test"
 fi
 
-# n8n
-test_http "n8n health" "http://localhost:5678/healthz" || log_skip "n8n not running"
-
-# Qdrant
-test_http "Qdrant health" "http://localhost:6333/" || log_skip "Qdrant not running"
+# n8n / Qdrant — optional in the default stack
+test_http_optional "n8n health" "http://${SERVICE_HOST}:${N8N_PORT}/healthz"
+test_http_optional "Qdrant health" "http://${SERVICE_HOST}:${QDRANT_PORT}/"
 
 # ========================================
 # Voice Services Tests
@@ -192,9 +371,16 @@ test_http "Qdrant health" "http://localhost:6333/" || log_skip "Qdrant not runni
 echo ""
 echo -e "${BLUE}▸ Voice Services${NC}"
 
-test_http "Whisper STT" "http://localhost:9001/" || log_skip "Whisper not running"
-test_http "Kokoro TTS" "http://localhost:8880/" || log_skip "Kokoro not running"
-test_http "LiveKit" "http://localhost:7880/" || log_skip "LiveKit not running"
+# Whisper (Speaches container): serves /health, not /. Default port 9000
+# per manifest (not 9001). AMD Lemonade installs may override to 9100 via
+# WHISPER_PORT in .env — respected above.
+test_http_optional "Whisper STT" "http://${SERVICE_HOST}:${WHISPER_PORT}/health"
+# Kokoro-FastAPI serves /health; the root path 404s.
+test_http_optional "Kokoro TTS" "http://${SERVICE_HOST}:${TTS_PORT}/health"
+# LiveKit's HTTP port is a WebSocket-signaling endpoint; GET / returns 404
+# when the service is up and healthy. Only a connection-refused (000) means
+# it's not running. Treat 404 as the "up" signature.
+test_http_optional "LiveKit" "http://${SERVICE_HOST}:${LIVEKIT_PORT}/" "404"
 
 # ========================================
 # Dashboard UI Tests
@@ -202,7 +388,7 @@ test_http "LiveKit" "http://localhost:7880/" || log_skip "LiveKit not running"
 echo ""
 echo -e "${BLUE}▸ Dashboard UI${NC}"
 
-test_http "Dashboard serves" "http://localhost:3001/"
+test_http "Dashboard serves" "http://${SERVICE_HOST}:${DASHBOARD_PORT}/"
 
 # ========================================
 # Summary

--- a/ods/tests/test-phase-c-p1.sh
+++ b/ods/tests/test-phase-c-p1.sh
@@ -14,8 +14,14 @@ NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Config
-API_URL="http://localhost:3002"
+# Shared auth + port resolution (shell env → installer .env, CRLF-safe).
+# Populates DASHBOARD_API_KEY, DASHBOARD_API_PORT, ae_api_base, AE_AUTH_HEADER.
+# shellcheck source=lib/auth-env.sh
+. "$SCRIPT_DIR/lib/auth-env.sh"
+ae_resolve "$SCRIPT_DIR"
+
+# Config — API_URL honors override for external test rigs.
+API_URL="${API_URL:-$ae_api_base}"
 DASHBOARD_API_URL="http://localhost:3001"
 TEST_TIMEOUT=10
 
@@ -38,6 +44,15 @@ log_warn() {
     WARN_COUNT=$((WARN_COUNT + 1))
 }
 
+# Auth-aware curl for dashboard-api. Splats AE_AUTH_HEADER (empty when no
+# key), so /health still works; auth-required endpoints get the Bearer
+# header. Call sites for auth-required probes should gate on
+# ae_key_available and log_warn otherwise, since curl -sf on a 401 returns
+# empty and the downstream grep would misreport "endpoint missing".
+api_curl() {
+    curl -sf -m "$TEST_TIMEOUT" "${AE_AUTH_HEADER[@]}" "$@"
+}
+
 echo ""
 echo "================================================================"
 echo "  ODS Phase C (P1) - Broken Features"
@@ -45,21 +60,32 @@ echo "  Prioritized CI Pipeline Tests"
 echo "================================================================"
 echo ""
 
+if ! ae_key_available; then
+    echo "NOTE: DASHBOARD_API_KEY not found (checked shell env + $ae_env_file)."
+    echo "      Auth-required checks (C1, C2, C4, C5) will be WARNed as skipped,"
+    echo "      not FAILed — set the key to run them."
+    echo ""
+fi
+
 # ==============================================================═
 # C1. Settings page is a static mockup
 # ==============================================================═
 echo -e "${CYAN}-- C1. Settings Page Mockup Detection -----------------------"
 
-SETTINGS_TEST=$(curl -sf -m $TEST_TIMEOUT "${API_URL}/api/settings" 2>/dev/null || echo "")
-if [ -n "$SETTINGS_TEST" ] && echo "$SETTINGS_TEST" | jq -e '.version, .installDate, .tier, .uptime, .storage' >/dev/null 2>&1; then
-    # Check if values are hardcoded (static string detection)
-    if echo "$SETTINGS_TEST" | grep -qE '"version":"1\.0\.0"|"installDate":"202[0-9]-' 2>/dev/null; then
-        log_fail "Settings page returns hardcoded mockup values"
-    else
-        log_pass "Settings page returns dynamic values"
-    fi
+if ! ae_key_available; then
+    log_warn "C1 skipped — no DASHBOARD_API_KEY"
 else
-    log_warn "Settings endpoint not implemented (404)"
+    SETTINGS_TEST=$(api_curl "${API_URL}/api/settings" 2>/dev/null || echo "")
+    if [ -n "$SETTINGS_TEST" ] && echo "$SETTINGS_TEST" | jq -e '.version, .installDate, .tier, .uptime, .storage' >/dev/null 2>&1; then
+        # Check if values are hardcoded (static string detection)
+        if echo "$SETTINGS_TEST" | grep -qE '"version":"1\.0\.0"|"installDate":"202[0-9]-' 2>/dev/null; then
+            log_fail "Settings page returns hardcoded mockup values"
+        else
+            log_pass "Settings page returns dynamic values"
+        fi
+    else
+        log_warn "Settings endpoint not implemented (404)"
+    fi
 fi
 
 # ==============================================================═
@@ -67,44 +93,48 @@ fi
 # ==============================================================═
 echo -e "${CYAN}-- C2. Setup Wizard Endpoints -------------------------------"
 
-# Test /api/setup/test endpoint
-SETUP_TEST=$(curl -sf -m $TEST_TIMEOUT -X POST "${API_URL}/api/setup/test" 2>/dev/null || echo "")
-if echo "$SETUP_TEST" | grep -qE "404|Not Found"; then
-    log_fail "Setup wizard calls non-existent endpoint: POST /api/setup/test"
+if ! ae_key_available; then
+    log_warn "C2 skipped — no DASHBOARD_API_KEY"
 else
-    log_pass "Setup wizard endpoints exist"
-fi
+    # Test /api/setup/test endpoint
+    SETUP_TEST=$(api_curl -X POST "${API_URL}/api/setup/test" 2>/dev/null || echo "")
+    if echo "$SETUP_TEST" | grep -qE "404|Not Found"; then
+        log_fail "Setup wizard calls non-existent endpoint: POST /api/setup/test"
+    else
+        log_pass "Setup wizard endpoints exist"
+    fi
 
-# Test LLM test endpoint
-LLM_TEST=$(curl -sf -m $TEST_TIMEOUT "${API_URL}/api/test/llm" 2>/dev/null || echo "")
-if echo "$LLM_TEST" | grep -qE "404|Not Found"; then
-    log_fail "Missing endpoint: GET /api/test/llm"
-else
-    log_pass "LLM test endpoint exists"
-fi
+    # Test LLM test endpoint
+    LLM_TEST=$(api_curl "${API_URL}/api/test/llm" 2>/dev/null || echo "")
+    if echo "$LLM_TEST" | grep -qE "404|Not Found"; then
+        log_fail "Missing endpoint: GET /api/test/llm"
+    else
+        log_pass "LLM test endpoint exists"
+    fi
 
-# Test voice test endpoint
-VOICE_TEST=$(curl -sf -m $TEST_TIMEOUT "${API_URL}/api/test/voice" 2>/dev/null || echo "")
-if echo "$VOICE_TEST" | grep -qE "404|Not Found"; then
-    log_fail "Missing endpoint: GET /api/test/voice"
-else
-    log_pass "Voice test endpoint exists"
-fi
+    # Test voice test endpoint
+    VOICE_TEST=$(api_curl "${API_URL}/api/test/voice" 2>/dev/null || echo "")
+    if echo "$VOICE_TEST" | grep -qE "404|Not Found"; then
+        log_fail "Missing endpoint: GET /api/test/voice"
+    else
+        log_pass "Voice test endpoint exists"
+    fi
 
-# Test RAG test endpoint
-RAG_TEST=$(curl -sf -m $TEST_TIMEOUT "${API_URL}/api/test/rag" 2>/dev/null || echo "")
-if echo "$RAG_TEST" | grep -qE "404|Not Found"; then
-    log_fail "Missing endpoint: GET /api/test/rag"
-else
-    log_pass "RAG test endpoint exists"
-fi
+    # Test RAG test endpoint
+    RAG_TEST=$(api_curl "${API_URL}/api/test/rag" 2>/dev/null || echo "")
+    if echo "$RAG_TEST" | grep -qE "404|Not Found"; then
+        log_fail "Missing endpoint: GET /api/test/rag"
+    else
+        log_pass "RAG test endpoint exists"
+    fi
 
-# Test workflows test endpoint
-WORKFLOWS_TEST=$(curl -sf -m $TEST_TIMEOUT "${API_URL}/api/test/workflows" 2>/dev/null || echo "")
-if echo "$WORKFLOWS_TEST" | grep -qE "404|Not Found"; then
-    log_fail "Missing endpoint: GET /api/test/workflows"
-else
-    log_pass "Workflows test endpoint exists"
+    # Test workflows test endpoint
+    WORKFLOWS_TEST=$(api_curl "${API_URL}/api/test/workflows" 2>/dev/null || echo "")
+    if echo "$WORKFLOWS_TEST" | grep -qE "404|Not Found"; then
+        log_fail "Missing endpoint: GET /api/test/workflows"
+    else
+        log_pass "Workflows test endpoint exists"
+    fi
 fi
 
 # ==============================================================═
@@ -112,9 +142,9 @@ fi
 # ==============================================================═
 echo -e "${CYAN}-- C3. Setup Wizard Step Validation -------------------------"
 
-# The setup wizard should not allow skipping the name step
-# This is a frontend validation issue - we test the API contract
-if curl -sf -m $TEST_TIMEOUT "${API_URL}/api/setup/wizard" >/dev/null 2>&1; then
+if ! ae_key_available; then
+    log_warn "C3 skipped — no DASHBOARD_API_KEY"
+elif api_curl "${API_URL}/api/setup/wizard" >/dev/null 2>&1; then
     log_pass "Setup wizard API exists (validation should be in frontend)"
 else
     log_warn "Setup wizard API not found"
@@ -125,33 +155,41 @@ fi
 # ==============================================================═
 echo -e "${CYAN}-- C4. Voice Settings Persistence ---------------------------"
 
-# Try to save and retrieve voice settings
-VOICE_SETTINGS_TEST=$(curl -sf -m $TEST_TIMEOUT "${API_URL}/api/voice/settings" 2>/dev/null || echo "")
-if [ -n "$VOICE_SETTINGS_TEST" ]; then
-    # Check if settings endpoint returns data
-    if echo "$VOICE_SETTINGS_TEST" | jq -e '.voice, .speed, .wakeWord' >/dev/null 2>&1; then
-        log_pass "Voice settings endpoint returns structured data"
-    else
-        log_warn "Voice settings endpoint exists but structure unclear"
-    fi
+if ! ae_key_available; then
+    log_warn "C4 skipped — no DASHBOARD_API_KEY"
 else
-    log_warn "Voice settings endpoint not implemented"
+    # Try to save and retrieve voice settings
+    VOICE_SETTINGS_TEST=$(api_curl "${API_URL}/api/voice/settings" 2>/dev/null || echo "")
+    if [ -n "$VOICE_SETTINGS_TEST" ]; then
+        # Check if settings endpoint returns data
+        if echo "$VOICE_SETTINGS_TEST" | jq -e '.voice, .speed, .wakeWord' >/dev/null 2>&1; then
+            log_pass "Voice settings endpoint returns structured data"
+        else
+            log_warn "Voice settings endpoint exists but structure unclear"
+        fi
+    else
+        log_warn "Voice settings endpoint not implemented"
+    fi
 fi
 
 # ==============================================================═
 # C5. Voice agent operation order
 echo -e "${CYAN}-- C5. Voice Agent Operation Order --------------------------"
 
-# Check if voice agent service is running properly
-VOICE_STATUS=$(curl -sf -m $TEST_TIMEOUT "${API_URL}/api/voice/status" 2>/dev/null || echo "")
-if [ -n "$VOICE_STATUS" ]; then
-    if echo "$VOICE_STATUS" | jq -e '.available == true' >/dev/null 2>&1; then
-        log_pass "Voice agent available and operational"
-    else
-        log_fail "Voice agent not available"
-    fi
+if ! ae_key_available; then
+    log_warn "C5 skipped — no DASHBOARD_API_KEY"
 else
-    log_warn "Voice status endpoint not responding"
+    # Check if voice agent service is running properly
+    VOICE_STATUS=$(api_curl "${API_URL}/api/voice/status" 2>/dev/null || echo "")
+    if [ -n "$VOICE_STATUS" ]; then
+        if echo "$VOICE_STATUS" | jq -e '.available == true' >/dev/null 2>&1; then
+            log_pass "Voice agent available and operational"
+        else
+            log_fail "Voice agent not available"
+        fi
+    else
+        log_warn "Voice status endpoint not responding"
+    fi
 fi
 
 # ==============================================================═


### PR DESCRIPTION
## Summary

`test-stack.sh --quick` reported false failures against a working ODS stack. Root causes were dashboard-api Bearer auth (every `/api/*`, `/status`, `/gpu`, `/services`, `/disk`, `/bootstrap`, `/model` route requires `Authorization: Bearer $DASHBOARD_API_KEY` per `security.py`, and none of the probes sent one → 401 → misreported as "connection error" / "endpoint missing" / "voice unavailable"), plus stale Whisper (`:9001` instead of `:9000`) and Kokoro (`/` root instead of `/health`) probes.

A project-wide sweep found the same class of bug in three more consumers, all fixed on this PR to close the whole class in one pass:

- **Shared resolver** at `ods/tests/lib/auth-env.sh` — reads `DASHBOARD_API_KEY` / `DASHBOARD_API_PORT` / `SERVICE_HOST` from shell env → installer `.env` with shell-wins precedence; scrubs CRLF, surrounding quotes, inline `# comments`, trailing whitespace; exposes `AE_AUTH_HEADER` array for `curl` splat. Bash 3.2 compatible (macOS default shell).
- **Test scripts hit by `--quick`**: `test-integration.sh`, `test-dashboard-integration.sh`, `test-phase-c-p1.sh` (also CI-invoked via `test-linux.yml`), `test-stack.sh` voice probe — all consume the shared resolver; auth-required calls SKIP (not FAIL) when no key is available; CPU-only `/gpu` (503) skips; LiveKit `404`-is-healthy signature accepted; installer port overrides (e.g. Strix Halo AMD `WHISPER_PORT=9100`) respected; single-fetch for `/gpu` and `/api/models` (no redundant round-trips).
- **`dashboard-load-test.py`**: Bearer header on every worker request; aborts with `exit 2` and a clear message when no key found (previously produced meaningless "401 × N" load reports).
- **`ods-cli` update check**: was hitting `DASHBOARD_PORT` (3001 UI/nginx) with `X-API-Key` (unrecognized by `HTTPBearer`) — both always 401'd and the CLI silently fell back to GitHub. Fixed to `DASHBOARD_API_PORT` + `Authorization: Bearer`.
- **`ods-update.sh`**: dropped dead `/api/status` fallback branch (needed auth to succeed, so `curl -sf` always failed → dropped to warn anyway).
- **Docs** (`n8n/README.md`, `privacy-shield/README.md`): copy-paste `curl` snippets now include Bearer (matches pattern already used in `TAILSCALE.md`, `OAUTH_PROVIDER_SETUP.md`, `dashboard-api/README.md`).

Behavior after this PR: on a working install with `.env` present, `test-stack.sh --quick` reports the truth. Without a key (fresh checkout, CI without secret), auth-required checks SKIP with a single banner explaining why, rather than reporting every one as FAIL.

## AI Assistance

Claude Code (Sonnet 4.6 / Opus 4.7) drove the investigation and edits: mapped each failing check in the user report to its actual FastAPI route + schema, ran a project-wide sweep for the same class of bug across `ods/tests/`, `ods/scripts/`, `ods-cli`, `ods-update.sh`, `.github/workflows/`, and `ods/extensions/**/README.md`, drafted the shared `auth-env.sh` helper, and did an adversarial self-review pass that caught three additional real bugs (voice port gate inversion, CRLF corruption from Windows-edited `.env`, and env-var precedence silently reversed by `load_env_file`) before commit. Human author reviewed the diff, chose the fail-vs-skip semantics, and ran the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — mainline. Users on stable can also hit this (auth was added
without updating test consumers), but the change touches the test
surface + a CLI diagnostic + one dead-code fallback in ods-update.sh.
Not a runtime regression fix. Happy to open a backport if triage
requests it.

Changed Surface

- [ ] Docs only
- [x] Tests only (primary — 4 test scripts + new helper)
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle (ods-cli update check, ods-update.sh health probe)
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy (consumers of the existing auth model, not the model itself)
- [ ] Dependencies / runtime wiring

Also touches two service READMEs (docs), but the primary surface is Tests and CLI diagnostics.

Risk And Validation

- Risk level: Low — no runtime behavior of the stack changes; consumers now speak the same auth protocol the API has been enforcing. ods update check gains a working path it was missing (silent fallback → real result). ods-update.sh loses one dead code branch that could never fire.
- Validation run:
  - [ ] git diff --check
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting release/2.5.x
  - [x] Not required because: change is scoped to test consumers + one CLI diagnostic + one dead-code removal. No dashboard/compose/model-routing/network surfaces touched. Runtime request paths are unchanged.

Commands/results:

$ bash -n ods/tests/lib/auth-env.sh
$ bash -n ods/tests/test-integration.sh
$ bash -n ods/tests/test-dashboard-integration.sh
$ bash -n ods/tests/test-phase-c-p1.sh
$ bash -n ods/test-stack.sh
$ bash -n ods/ods-cli
$ bash -n ods/ods-update.sh
# all clean

# dashboard-load-test.py — visual review only (no python in this
# dev env). Change surface is a _load_api_key() helper + a single
# req.add_header('Authorization', f'Bearer {API_KEY}') line + an
# early sys.exit(2) when no key. Please re-run on CI/macOS to
# confirm `python3 ods/tests/dashboard-load-test.py --help` works.

# Adversarial self-review confirmed:
#   - Empty-array expansion under set -u is guarded on every splat
#     of ${AE_AUTH_HEADER[@]} (safe on macOS bash 3.2).
#   - jq filters short-circuit correctly on missing keys / CPU-only.
#   - Shell env wins over .env for DASHBOARD_API_KEY and port vars.
#   - CRLF from Windows/WSL-edited .env is stripped everywhere it
#     is read (helper + ods-cli's tr scrub + Python's rstrip).

Operational Change Check

Touches ods-cli and ods-update.sh — both are lifecycle commands. Argument for narrower equivalent:

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [x] This is an operational change and validation is intentionally deferred for:

The lifecycle changes are: (a) ods-cli update check swaps two wrong constants (port var + header name) for the correct ones — the pre-fix code always 401'd and silently fell back to a GitHub HTTP call, so this restores an intended path that has never worked. It cannot make the CLI behave worse than the current silent fallback, and the fallback still runs when the dashboard-api call fails for any reason (network, container down). (b) ods-update.sh removes a dead branch (/api/status fallback) that was unreachable without a Bearer header. Post-change behavior for a keyless / down dashboard-api is identical (drop to log_warn). No host mutation, no compose changes, no service wiring, no network exposure. Fleet validation would repeat what static reasoning already establishes; narrower equivalent is the syntax + adversarial-review + manual read-through captured above.
