### PR TITLE
fix(dashboard-api): emit valid ISO 8601 timestamps in version endpoints

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -30,6 +30,18 @@ _version_cache: dict[str, object] = {"expires_at": 0.0, "payload": None}
 _version_refresh_task: Optional[asyncio.Task] = None
 
 
+def _utc_now_z() -> str:
+    """Return the current UTC time as a valid ISO 8601 string with a 'Z' suffix.
+
+    ``datetime.now(timezone.utc)`` is timezone-aware, so ``.isoformat()`` already
+    carries a ``+00:00`` offset. Appending ``"Z"`` produced ``...+00:00Z`` — a
+    string with two UTC designators that both ``datetime.fromisoformat`` and the
+    dashboard's ``new Date(...)`` reject (the Settings page rendered "Invalid
+    Date" for the last-checked time). Swap the offset for a single ``Z``.
+    """
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
 def _read_utf8(path: Path) -> str:
     """Read repository text files consistently across Windows and Linux."""
     return path.read_text(encoding="utf-8")
@@ -162,7 +174,7 @@ def _build_version_result(current: str, payload: Optional[dict]) -> dict:
         "latest": None,
         "update_available": False,
         "changelog_url": None,
-        "checked_at": datetime.now(timezone.utc).isoformat() + "Z",
+        "checked_at": _utc_now_z(),
     }
     if not payload:
         return result
@@ -195,7 +207,7 @@ async def _refresh_release_cache() -> Optional[dict]:
         payload = {
             "latest": data.get("tag_name", "").lstrip("v"),
             "changelog_url": data.get("html_url"),
-            "checked_at": datetime.now(timezone.utc).isoformat() + "Z",
+            "checked_at": _utc_now_z(),
         }
         _version_cache = {
             "expires_at": time.monotonic() + _VERSION_CACHE_TTL,
@@ -252,13 +264,13 @@ async def get_release_manifest():
                 {"version": r.get("tag_name", "").lstrip("v"), "date": r.get("published_at", ""), "title": r.get("name", ""), "changelog": r.get("body", "")[:500] + "..." if len(r.get("body", "")) > 500 else r.get("body", ""), "url": r.get("html_url", ""), "prerelease": r.get("prerelease", False)}
                 for r in releases
             ],
-            "checked_at": datetime.now(timezone.utc).isoformat() + "Z"
+            "checked_at": _utc_now_z()
         }
     except (httpx.HTTPError, httpx.TimeoutException, json.JSONDecodeError, OSError):
         current = await asyncio.to_thread(_read_current_version)
         return {
-            "releases": [{"version": current, "date": datetime.now(timezone.utc).isoformat() + "Z", "title": f"ODS {current}", "changelog": "Release information unavailable. Check GitHub directly.", "url": "https://github.com/Light-Heart-Labs/ODS/releases", "prerelease": False}],
-            "checked_at": datetime.now(timezone.utc).isoformat() + "Z",
+            "releases": [{"version": current, "date": _utc_now_z(), "title": f"ODS {current}", "changelog": "Release information unavailable. Check GitHub directly.", "url": "https://github.com/Light-Heart-Labs/ODS/releases", "prerelease": False}],
+            "checked_at": _utc_now_z(),
             "error": "Could not fetch release information"
         }
 

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -1,10 +1,25 @@
 """Tests for updates router endpoints."""
 
 import json
+from datetime import datetime
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import httpx
 from fastapi import HTTPException
+
+
+def _assert_valid_utc_z(value: str) -> None:
+    """A timestamp field must be a single-designator UTC ISO 8601 string.
+
+    Guards against the ``...+00:00Z`` double-designator form, which
+    ``datetime.fromisoformat`` and the dashboard's ``new Date(...)`` both
+    reject.
+    """
+    assert isinstance(value, str) and value, f"expected non-empty timestamp, got {value!r}"
+    assert value.endswith("Z"), f"expected trailing 'Z', got {value!r}"
+    assert "+00:00" not in value, f"double UTC designator in {value!r}"
+    # Parseable as a real UTC instant (fromisoformat needs the offset form).
+    datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def test_get_version_requires_auth(test_client):
@@ -543,3 +558,103 @@ def test_trigger_update_action_backup(test_client, monkeypatch):
     assert calls[0][0] == "backup"
     assert calls[0][1]["backup_id"].startswith("dashboard-")
     assert calls[0][2] == 65
+
+
+# ---------------------------------------------------------------------------
+# Timestamp formatting — checked_at / date must be valid ISO 8601
+# ---------------------------------------------------------------------------
+
+
+def test_utc_now_z_is_single_designator_iso8601():
+    """The shared timestamp helper must not emit the ``+00:00Z`` double form."""
+    from routers.updates import _utc_now_z
+
+    _assert_valid_utc_z(_utc_now_z())
+
+
+def test_build_version_result_checked_at_is_valid_when_no_payload():
+    """The default checked_at (no GitHub payload) must be a valid UTC instant."""
+    from routers.updates import _build_version_result
+
+    result = _build_version_result("1.2.3", None)
+    _assert_valid_utc_z(result["checked_at"])
+
+
+def test_get_version_checked_at_is_valid_iso8601(test_client, monkeypatch):
+    """GET /api/version returns a checked_at the dashboard's Date() can parse."""
+    import routers.updates as updates_mod
+
+    monkeypatch.setattr(updates_mod, "_version_cache", {"expires_at": 0.0, "payload": None})
+    monkeypatch.setattr(updates_mod, "_version_refresh_task", None)
+
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = {"tag_name": "v2.0.0", "html_url": "https://github.com/test"}
+
+    async def mock_get(url, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/version", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    _assert_valid_utc_z(resp.json()["checked_at"])
+
+
+def test_releases_manifest_timestamps_are_valid_iso8601(test_client):
+    """GET /api/releases/manifest emits valid checked_at and per-release date."""
+    mock_resp = MagicMock()
+    mock_resp.json.return_value = [
+        {
+            "tag_name": "v1.5.0",
+            "published_at": "2025-12-01T00:00:00Z",
+            "name": "Release 1.5.0",
+            "body": "Changelog",
+            "html_url": "https://github.com/test/releases/v1.5.0",
+            "prerelease": False,
+        },
+    ]
+
+    async def mock_get(url, **kwargs):
+        return mock_resp
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/releases/manifest", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    _assert_valid_utc_z(resp.json()["checked_at"])
+
+
+def test_releases_manifest_error_fallback_timestamps_are_valid(test_client, tmp_path, monkeypatch):
+    """The GitHub-error fallback branch must also emit valid timestamps."""
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "ods"
+    install_dir.mkdir()
+    (install_dir / ".version").write_text("1.2.3")
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    async def mock_get(url, **kwargs):
+        raise httpx.HTTPError("connection failed")
+
+    mock_client = AsyncMock()
+    mock_client.get = mock_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("routers.updates.httpx.AsyncClient", return_value=mock_client):
+        resp = test_client.get("/api/releases/manifest", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    _assert_valid_utc_z(data["checked_at"])
+    _assert_valid_utc_z(data["releases"][0]["date"])


### PR DESCRIPTION
## Problem

`/api/version` and `/api/releases/manifest` return `checked_at` (and each release `date`) built with:

```python
datetime.now(timezone.utc).isoformat() + "Z"
```

`datetime.now(timezone.utc)` is timezone-**aware**, so `.isoformat()` already emits a `+00:00` offset. Appending `"Z"` yields a **double-designator** string:

```
2026-07-12T14:16:17.880690+00:00Z
```

That is not valid RFC 3339 / ISO 8601 (two UTC designators). Both parsers in the stack reject it:

- `datetime.fromisoformat("…+00:00Z")` → `ValueError: Invalid isoformat string`
- JS `new Date("…+00:00Z")` → `Invalid Date`

## User-facing impact

The dashboard **Settings → Updates** panel renders the last-checked time via:

```jsx
// dashboard/src/pages/Settings.jsx:311
`Last checked: ${new Date(version.checked_at).toLocaleString()}`
```

Since `new Date(...)` returns `Invalid Date`, users see **"Last checked: Invalid Date"** on every version check. Any downstream consumer that strictly parses these timestamps hits the same failure.

## Fix

Route the five `checked_at`/`date` fields through a shared helper that swaps the offset for a single `Z`, preserving the intended `Z`-suffixed UTC form while producing a valid instant:

```python
def _utc_now_z() -> str:
    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
```

Output: `2026-07-12T14:16:17.880690Z` — parseable by `datetime.fromisoformat` and `new Date()`.

No behavior change beyond the timestamp shape; the `Z`-suffix convention the code already intended is kept.

## Tests

Added to `tests/test_updates.py` (all assert the single-designator invariant end-to-end):

- `test_utc_now_z_is_single_designator_iso8601` — the helper.
- `test_build_version_result_checked_at_is_valid_when_no_payload` — default (offline) path.
- `test_get_version_checked_at_is_valid_iso8601` — `/api/version` (mocked GitHub).
- `test_releases_manifest_timestamps_are_valid_iso8601` — `/api/releases/manifest` happy path.
- `test_releases_manifest_error_fallback_timestamps_are_valid` — GitHub-error fallback branch (`checked_at` + release `date`).

The shared `_assert_valid_utc_z()` helper checks: trailing `Z`, no `+00:00`, and `datetime.fromisoformat`-parseable.

## Verification

- New tests: **red on the pre-fix code** (fail on the exact `…+00:00Z` string), **green after the fix**.
- Full dashboard-api suite: **1175 passed, 9 skipped, 3 failed** — the 3 failures are the pre-existing Windows baseline (`test_setup_sentinel.py` ×2 bash-dependent, `test_user_extensions.py::test_scan_symlink_skipped` symlink), unrelated to this change and present on clean `main`.
- `ruff check --select E,F,W --ignore E501,E701,E731,E741,E402` on both files: clean.