### PR TITLE
fix(token-spy): stop SQLite recent-window queries over-including a full day

### DIFF
--- a/ods/extensions/services/token-spy/db.py
+++ b/ods/extensions/services/token-spy/db.py
@@ -7,6 +7,17 @@ from datetime import date, timedelta
 
 DB_PATH = os.environ.get("DB_PATH", os.path.join(os.path.dirname(__file__), "data", "usage.db"))
 
+# "Last N hours" cutoff for recent-window queries. The timestamp column stores
+# strftime('%Y-%m-%dT%H:%M:%fZ', ...) (T-separated, trailing Z). A bare
+# datetime('now', ...) yields a space-separated 'YYYY-MM-DD HH:MM:SS' value, and
+# because the column is TEXT the comparison is a byte-wise sort: the space
+# separator (0x20) sorts before the stored 'T' (0x54), so every row on the
+# cutoff's calendar date compares greater than the bound regardless of its
+# time-of-day and gets pulled in — over-including up to a full extra day. Build
+# the bound in the stored format so the comparison matches wall-clock order, in
+# line with the Postgres backend's NOW() - INTERVAL arithmetic.
+_RECENT_TS_BOUND = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?)"
+
 _local = threading.local()
 
 
@@ -126,7 +137,7 @@ def log_usage(entry: dict):
 def query_usage(agent: str | None = None, hours: int = 24, limit: int = 200) -> list[dict]:
     conn = _get_conn()
     conn.row_factory = sqlite3.Row
-    sql = "SELECT * FROM usage WHERE timestamp > datetime('now', ?)"
+    sql = f"SELECT * FROM usage WHERE timestamp > {_RECENT_TS_BOUND}"
     params: list = [f"-{hours} hours"]
     if agent:
         sql += " AND agent = ?"
@@ -349,7 +360,7 @@ def query_report(start: str, end: str) -> dict:
 def query_summary(hours: int = 24) -> list[dict]:
     conn = _get_conn()
     conn.row_factory = sqlite3.Row
-    rows = conn.execute("""
+    rows = conn.execute(f"""
         SELECT
             agent,
             COUNT(*) as turns,
@@ -365,7 +376,7 @@ def query_summary(hours: int = 24) -> list[dict]:
             AVG(skill_injection_chars) as avg_skill_chars,
             AVG(base_prompt_chars) as avg_base_prompt_chars
         FROM usage
-        WHERE timestamp > datetime('now', ?)
+        WHERE timestamp > {_RECENT_TS_BOUND}
         GROUP BY agent
     """, [f"-{hours} hours"]).fetchall()
     return [dict(r) for r in rows]
@@ -382,13 +393,13 @@ def query_session_status(agent: str, char_limit: int = 200_000) -> dict:
     conn.row_factory = sqlite3.Row
 
     # Get all recent turns for this agent, ordered chronologically
-    rows = conn.execute("""
+    rows = conn.execute(f"""
         SELECT conversation_history_chars, cache_read_tokens, cache_write_tokens,
                estimated_cost_usd, timestamp
         FROM usage
-        WHERE agent = ? AND timestamp > datetime('now', '-24 hours')
+        WHERE agent = ? AND timestamp > {_RECENT_TS_BOUND}
         ORDER BY timestamp ASC
-    """, [agent]).fetchall()
+    """, [agent, "-24 hours"]).fetchall()
 
     if not rows:
         return {

--- a/ods/extensions/services/token-spy/tests/test_usage_report.py
+++ b/ods/extensions/services/token-spy/tests/test_usage_report.py
@@ -3,11 +3,17 @@
 from __future__ import annotations
 
 import importlib
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import uuid4
 
 
 TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+def _stored_ts(dt: datetime) -> str:
+    """Render a timestamp the way the usage.timestamp column stores it."""
+    return dt.strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
 def load_sqlite_db(tmp_path, monkeypatch):
@@ -115,3 +121,40 @@ def test_query_report_marks_old_positive_cost_rows_as_priced(tmp_path, monkeypat
 
     assert report["summary"]["paid_cost_usd"] == 1.5
     assert report["models"][0]["cost_source"] == "priced_from_tokens"
+
+
+def test_query_usage_excludes_rows_older_than_window(tmp_path, monkeypatch):
+    """query_usage(hours=1) must not return a row from earlier the same day.
+
+    The SQLite bound used to be datetime('now', ...) — a space-separated value
+    that byte-sorts before the stored T-separated timestamps, so every row on
+    the cutoff's calendar date leaked into the window regardless of time-of-day.
+    """
+    db = load_sqlite_db(tmp_path, monkeypatch)
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=1)
+    # A row ~hours-away but on the cutoff's calendar date — the leak case.
+    stale_same_day = cutoff.replace(hour=0, minute=0, second=1, microsecond=0)
+
+    insert_usage(db, _stored_ts(now - timedelta(minutes=10)), agent="recent")
+    insert_usage(db, _stored_ts(stale_same_day), agent="stale")
+
+    agents = {r["agent"] for r in db.query_usage(hours=1)}
+    assert "recent" in agents
+    assert "stale" not in agents
+
+
+def test_query_summary_respects_hours_window(tmp_path, monkeypatch):
+    """query_summary(hours=1) aggregates only rows inside the window."""
+    db = load_sqlite_db(tmp_path, monkeypatch)
+
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=1)
+    stale_same_day = cutoff.replace(hour=0, minute=0, second=1, microsecond=0)
+
+    insert_usage(db, _stored_ts(now - timedelta(minutes=5)), agent="recent")
+    insert_usage(db, _stored_ts(stale_same_day), agent="stale")
+
+    agents = {r["agent"] for r in db.query_summary(hours=1)}
+    assert agents == {"recent"}


### PR DESCRIPTION
## Problem

Token Spy's `usage.timestamp` column is stored in ISO form:

```sql
timestamp TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-- e.g. 2026-07-12T14:33:15.567Z   (T-separated, trailing Z)
```

But the three "last N hours" queries in the SQLite backend bound the window with `datetime('now', ?)`:

```python
# db.py — query_usage / query_summary / query_session_status
WHERE timestamp > datetime('now', ?)   # -> '2026-07-12 13:33:15'  (space, no Z)
```

`timestamp` is a `TEXT` column, so SQLite compares it **byte-wise** (BINARY collation). The bound's space separator (`0x20`) sorts *before* the stored `T` (`0x54`), so at the character right after the date, **every row on the cutoff's calendar date compares greater than the bound regardless of its time-of-day** — and leaks into the window. The `-N hours` offset is effectively ignored for same-date rows, over-including up to a full extra day.

Verified with a plain in-memory SQLite DB:

```
stored-format (default): 2026-07-12T14:33:15.567Z
query bound (datetime) : 2026-07-12 13:33:15         <-- space, no T/Z
row 2026-07-12T00:00:01.000Z (>14h old, hours=1):
  current query includes it?  YES (BUG)
  fixed   query includes it?  no (correct)
```

## Impact

- `/api/usage`, `/token-usage`, `/api/summary` (all take a `hours` param) return more than the requested window on the current day — e.g. `hours=1` can surface ~a day of rows.
- `/api/summary` feeds the dashboard's agent-monitor throughput/session counts (`agent_monitor._fetch_token_spy_metrics`), so those are inflated too.
- `query_session_status` uses the same broken 24h bound to detect the *current* session, so stale rows corrupt session-health metrics.
- **Backend divergence**: the Postgres backend (`db_postgres.py`) filters with `NOW() - INTERVAL '%s hours'` (type-correct), so the same endpoint returns different results depending on the storage backend. This fix makes SQLite agree with Postgres.

## Fix

Bound the window in the **same format the column stores**, via a shared constant:

```python
_RECENT_TS_BOUND = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now', ?)"
```

Applied to all three sites (`query_usage`, `query_summary`, `query_session_status`). Now both sides of the comparison are `…T…Z`, so the byte-wise ordering matches wall-clock order. `query_report` already used matching `…T00:00:00Z` bounds and is unchanged. No schema change; existing rows compare correctly.

## Tests

Added to `tests/test_usage_report.py` (reuse the existing `load_sqlite_db` / `insert_usage` harness):

- `test_query_usage_excludes_rows_older_than_window` — a row at the start of the cutoff day is excluded from `query_usage(hours=1)`; a 10-min-old row is included.
- `test_query_summary_respects_hours_window` — `query_summary(hours=1)` aggregates only in-window agents.

Both are deterministic on the fixed code (chronological, midnight-crossing-safe) and place the stale row on the cutoff's date so they reproduce the leak at any time of day.

## Verification

- New tests: **red on the pre-fix `db.py`** (both fail: the stale same-day row leaks in), **green after the fix**.
- Full token-spy suite: **5 passed**.
- `ruff check --select E,F,W --ignore E501,E701,E731,E741,E402` on both files: clean.