### PR TITLE
fix(safe-env): strip only matched surrounding quote pairs from .env values

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -90,6 +90,9 @@ jobs:
       - name: Validate Env Tests
         run: bash tests/test-validate-env.sh
 
+      - name: Safe Env Loading Tests
+        run: bash tests/test-safe-env.sh
+
       - name: Validate Simulation Summary Tests
         run: bash tests/test-validate-sim-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -43,6 +43,9 @@ test: ## Run unit and contract tests
 	@bash tests/contracts/test-overlay-map-coherence.sh
 	@bash tests/contracts/test-plist-log-paths.sh
 	@echo ""
+	@echo "=== safe .env loading (quote/CRLF handling) ==="
+	@bash tests/test-safe-env.sh
+	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh

--- a/ods/lib/safe-env.sh
+++ b/ods/lib/safe-env.sh
@@ -38,12 +38,20 @@ load_env_file() {
         # UID=1000 is valid for Docker Compose, but exporting it here aborts
         # lifecycle commands under set -e before they can reach compose.
         [[ "$key" == "UID" ]] && continue
-        # Strip optional surrounding quotes and one leading space
+        # Strip one leading space, then a single matching pair of surrounding
+        # quotes. Only strip when both ends carry the SAME quote character —
+        # stripping each quote type independently corrupts values whose content
+        # legitimately begins or ends with the other quote (e.g. a double-quoted
+        # "'literal'" would otherwise lose its inner single quotes, and KEY="'"
+        # would collapse to empty).
         value="${value# }"
-        value="${value%\"}"
-        value="${value#\"}"
-        value="${value%\'}"
-        value="${value#\'}"
+        if [[ "$value" == '"'*'"' ]]; then
+            value="${value#\"}"
+            value="${value%\"}"
+        elif [[ "$value" == "'"*"'" ]]; then
+            value="${value#\'}"
+            value="${value%\'}"
+        fi
         export "$key=$value"
     done < "$path"
 }

--- a/ods/tests/test-safe-env.sh
+++ b/ods/tests/test-safe-env.sh
@@ -122,5 +122,24 @@ load_env_file "$tmpdir/.env-crlf"
 [[ "${CRLF_QUOTED:-}" == "abc123" ]] || fail "CRLF_QUOTED not unquoted/stripped (got: '${CRLF_QUOTED:-}')"
 pass "load_env_file strips trailing CR from CRLF .env values"
 
+echo "Test 12: load_env_file only strips a matching pair of surrounding quotes"
+unset DQ_INNER_SINGLE SQ_INNER_DOUBLE DQ_ONLY_SINGLE PLAIN_DQ PLAIN_SQ 2>/dev/null || true
+# A double-quoted value whose content is itself single-quoted must keep the
+# inner single quotes; the previous independent per-quote stripping dropped them.
+cat > "$tmpdir/.env-quotes" << 'EOF'
+DQ_INNER_SINGLE="'literal'"
+SQ_INNER_DOUBLE='"json"'
+DQ_ONLY_SINGLE="'"
+PLAIN_DQ="plain"
+PLAIN_SQ='plain'
+EOF
+load_env_file "$tmpdir/.env-quotes"
+[[ "${DQ_INNER_SINGLE:-}" == "'literal'" ]] || fail "DQ_INNER_SINGLE lost inner single quotes (got: '${DQ_INNER_SINGLE:-}')"
+[[ "${SQ_INNER_DOUBLE:-}" == '"json"' ]] || fail "SQ_INNER_DOUBLE lost inner double quotes (got: '${SQ_INNER_DOUBLE:-}')"
+[[ "${DQ_ONLY_SINGLE:-}" == "'" ]] || fail "DQ_ONLY_SINGLE collapsed (got: '${DQ_ONLY_SINGLE:-}')"
+[[ "${PLAIN_DQ:-}" == "plain" ]] || fail "PLAIN_DQ not unquoted (got: '${PLAIN_DQ:-}')"
+[[ "${PLAIN_SQ:-}" == "plain" ]] || fail "PLAIN_SQ not unquoted (got: '${PLAIN_SQ:-}')"
+pass "load_env_file strips only matched surrounding quote pairs"
+
 echo ""
 echo "All safe-env tests passed."


### PR DESCRIPTION
## Problem

`load_env_file` in `lib/safe-env.sh` unquotes a value by stripping a surrounding double quote and then a surrounding single quote **independently**:

```sh
value="${value%\"}"; value="${value#\"}"   # strip a trailing/leading "
value="${value%\'}"; value="${value#\'}"   # strip a trailing/leading '
```

Because the two quote types are stripped in sequence, a value that is quoted with one character but whose *content* begins or ends with the other character loses that content character.

Reproduction (plain bash, mirrors the loader):

```
KEY="'literal'"   -> literal     (want: 'literal')
KEY="'"           ->             (want: ')          # collapses to empty
KEY='"json"'      -> json        (want: "json")
KEY="value"       -> value       (ok)
KEY='value'       -> value       (ok)
KEY="don't"       -> don't       (ok)
```

So any `.env` value wrapped in one quote type whose payload starts or ends with the other quote — e.g. a JSON-ish or quote-bearing secret/password — is silently corrupted before it reaches the process environment, Docker Compose, etc.

## Fix

Strip a surrounding pair **only when both ends carry the same quote character**, using a bash 3.2-safe glob match (macOS `/bin/bash` is 3.2):

```sh
value="${value# }"
if [[ "$value" == '"'*'"' ]]; then
    value="${value#\"}"; value="${value%\"}"
elif [[ "$value" == "'"*"'" ]]; then
    value="${value#\'}"; value="${value%\'}"
fi
```

Now `KEY="'literal'"` → `'literal'`, `KEY="'"` → `'`, while the common cases (`"value"`, `'value'`, `"don't"`, unquoted, CRLF) are unchanged. This is a sibling of the CRLF handling in the same block (which also had to reason about the closing quote).

## Test wiring (bonus)

`tests/test-safe-env.sh` already existed and covers `load_env_file` / `load_env_from_output`, but **it was not referenced by the Makefile or any CI workflow** — its coverage never gated anything. This PR:

- Adds `Test 12` to that suite for the matched-pair behavior (double-quoted-single, single-quoted-double, `"'"`, and plain-quoted controls).
- Wires `tests/test-safe-env.sh` into `make test` so the whole safe-env suite (11 pre-existing tests + the new one) runs in CI.

## Verification

- `Test 12`: **red on the pre-fix code** (`DQ_INNER_SINGLE` loads as `literal`), **green after the fix**.
- Full `tests/test-safe-env.sh`: **12/12 pass**; the pre-existing 11 are unaffected.
- `bash -n` clean on both `lib/safe-env.sh` and `tests/test-safe-env.sh`; the new construct is standard bash / shellcheck-clean and bash 3.2-safe (glob match, no negative-index substring).
- Makefile insertion placed away from other in-flight test registrations to avoid merge churn; tab-indented recipe verified.