### PR TITLE
fix(migrate-config): version check aborts under set -e and inverts the comparison

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -136,6 +136,9 @@ jobs:
       - name: Support Bundle Evidence Tests
         run: bash tests/test-support-bundle.sh
 
+      - name: Config Migration Tests
+        run: bash tests/test-migrate-config.sh
+
       - name: Upload Installer Simulation Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -47,6 +47,9 @@ test: ## Run unit and contract tests
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh
 	@echo ""
+	@echo "=== config migration (version check under set -e) ==="
+	@bash tests/test-migrate-config.sh
+	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
 	@echo ""

--- a/ods/scripts/migrate-config.sh
+++ b/ods/scripts/migrate-config.sh
@@ -174,11 +174,15 @@ cmd_check() {
     log_info "Current version: $current_version"
     log_info "Last migrated: $last_migrated"
     
-    compare_versions "$current_version" "$last_migrated"
-    local result
-    result=$?
+    # compare_versions returns a non-zero *ordering* status, so capture it with
+    # `|| result=$?`. A bare call would trip `set -e` and abort before $? is
+    # read. result 1 => current_version > last_migrated => newer migrations are
+    # pending (this was previously checked as 2, i.e. a downgrade, so an ordinary
+    # upgrade silently reported "no migration needed").
+    local result=0
+    compare_versions "$current_version" "$last_migrated" || result=$?
 
-    if [[ $result -eq 2 ]]; then
+    if [[ $result -eq 1 ]]; then
         log_warn "Migration needed: $last_migrated → $current_version"
         
         # List pending migrations
@@ -189,8 +193,9 @@ cmd_check() {
                 local migration_version
                 migration_version=$(basename "$migration" | sed 's/migrate-v//;s/.sh//')
                 
-                compare_versions "$migration_version" "$last_migrated"
-                if [[ $? -eq 1 ]]; then
+                local mig_cmp=0
+                compare_versions "$migration_version" "$last_migrated" || mig_cmp=$?
+                if [[ $mig_cmp -eq 1 ]]; then
                     echo "  - $migration_version: $(head -5 "$migration" | grep '^# Description:' | sed 's/# Description://')"
                 fi
             fi
@@ -216,8 +221,12 @@ cmd_migrate() {
     # Create backup first
     cmd_backup >/dev/null
     
-    compare_versions "$current_version" "$last_migrated"
-    if [[ $? -ne 2 ]]; then
+    local cmp=0
+    compare_versions "$current_version" "$last_migrated" || cmp=$?
+    # Only current_version > last_migrated (cmp == 1) has pending migrations;
+    # equal (0) or a downgrade (2) means there is nothing to apply. The former
+    # `-ne 2` guard skipped every ordinary upgrade after taking a backup.
+    if [[ $cmp -ne 1 ]]; then
         log_success "Already up to date ($current_version)"
         return 0
     fi
@@ -240,8 +249,9 @@ cmd_migrate() {
             migration_version=$(basename "$migration" | sed 's/migrate-v//;s/.sh//')
             
             # Check if this migration is needed
-            compare_versions "$migration_version" "$last_migrated"
-            if [[ $? -eq 1 ]]; then
+            local mig_cmp=0
+            compare_versions "$migration_version" "$last_migrated" || mig_cmp=$?
+            if [[ $mig_cmp -eq 1 ]]; then
                 log_info "Running migration: $migration_version"
                 
                 if bash "$migration"; then
@@ -249,7 +259,7 @@ cmd_migrate() {
                     set_last_migrated_version "$migration_version"
                 else
                     log_error "Migration $migration_version failed!"
-                    ((failed++)) || true
+                    failed=$((failed + 1))
                     break
                 fi
             fi
@@ -268,7 +278,9 @@ cmd_migrate() {
 
 # Validate .env against schema
 cmd_validate() {
-    local validator="${SCRIPT_DIR}/validate-env.sh"
+    # MIGRATE_VALIDATOR lets the test suite point at a mock validator so it runs
+    # hermetically instead of overwriting the tracked scripts/validate-env.sh.
+    local validator="${MIGRATE_VALIDATOR:-${SCRIPT_DIR}/validate-env.sh}"
     local env_file="${INSTALL_DIR}/.env"
     local schema_file="${INSTALL_DIR}/.env.schema.json"
 

--- a/ods/tests/test-migrate-config.sh
+++ b/ods/tests/test-migrate-config.sh
@@ -161,23 +161,25 @@ if command -v jq >/dev/null 2>&1; then
 }
 EOF
 
-    # Create mock validator script
-    cat > "$SCRIPT_DIR/scripts/validate-env.sh" <<'EOF'
+    # Create the mock validator in the temp dir and point migrate-config.sh at
+    # it via MIGRATE_VALIDATOR. Writing to the real scripts/validate-env.sh (a
+    # tracked file) and rm-ing it afterward would delete it from the working
+    # tree — which is exactly what this suite used to do.
+    mock_validator="$TEMP_DIR/mock-validate-env.sh"
+    cat > "$mock_validator" <<'EOF'
 #!/bin/bash
 echo "Mock validation passed"
 exit 0
 EOF
-    chmod +x "$SCRIPT_DIR/scripts/validate-env.sh"
+    chmod +x "$mock_validator"
 
     validate_exit=0
-    validate_output=$(bash "$MIGRATE_CONFIG_SCRIPT" validate 2>&1) || validate_exit=$?
+    validate_output=$(MIGRATE_VALIDATOR="$mock_validator" bash "$MIGRATE_CONFIG_SCRIPT" validate 2>&1) || validate_exit=$?
     if [[ $validate_exit -eq 0 ]]; then
         pass "Behavioral test: validate command works"
     else
         skip "Behavioral test: validate command (validator not available)"
     fi
-
-    rm -f "$SCRIPT_DIR/scripts/validate-env.sh"
 else
     skip "Behavioral test: validate command (jq not available)"
 fi
@@ -206,6 +208,33 @@ if grep -q "_exit=0" "$MIGRATE_CONFIG_SCRIPT" && grep -q "|| .*_exit=\$?" "$MIGR
     pass "CLAUDE.md compliance: uses inline exit code capture pattern"
 else
     fail "CLAUDE.md compliance: missing inline exit code capture pattern"
+fi
+
+# ============================================================================
+# Test 11: check reports a pending migration when current > last migrated
+# Guards against two regressions: (a) a bare `compare_versions` call aborting
+# under `set -e` before $? is read, and (b) the inverted comparison that treated
+# only a *downgrade* as "migration needed" so ordinary upgrades were missed.
+# ============================================================================
+echo "2.4.1" > "$INSTALL_DIR/.version"
+mkdir -p "$DATA_DIR"
+echo "0.2.0" > "$DATA_DIR/.migration-state"
+check_exit=0
+check_output=$(bash "$MIGRATE_CONFIG_SCRIPT" check 2>&1) || check_exit=$?
+if [[ $check_exit -eq 2 ]] && echo "$check_output" | grep -q "Migration needed"; then
+    pass "Behavioral test: check reports pending migration (current > last migrated)"
+else
+    fail "Behavioral test: check missed pending migration (exit $check_exit): $check_output"
+fi
+
+# Test 12: with last-migrated equal to current, no migration is reported.
+echo "2.4.1" > "$DATA_DIR/.migration-state"
+check_exit=0
+check_output=$(bash "$MIGRATE_CONFIG_SCRIPT" check 2>&1) || check_exit=$?
+if [[ $check_exit -eq 0 ]] && echo "$check_output" | grep -q "No migration needed"; then
+    pass "Behavioral test: check reports up-to-date when versions match"
+else
+    fail "Behavioral test: check misreported up-to-date state (exit $check_exit): $check_output"
 fi
 
 # ============================================================================


### PR DESCRIPTION
## Problem

`scripts/migrate-config.sh` gates its work on `compare_versions`, but calls it as a **bare statement** and reads `$?` on the next line:

```sh
compare_versions "$current_version" "$last_migrated"
local result
result=$?
if [[ $result -eq 2 ]]; then ...
```

`compare_versions` returns a non-zero *ordering* status (1 = v1>v2, 2 = v1<v2). The script runs under `set -euo pipefail`, so a bare call that returns non-zero **aborts the script before `$?` is ever read**. Reproduced with a minimal harness:

```
before compare
exit code of that block: 1     # "after" line never runs
```

So `migrate-config.sh check` and `migrate` exit silently (code 1) on **any** version difference — which is exactly the case where a migration matters. `migrate` aborts right after taking a backup, never running a single migration script.

On top of that the comparison is **inverted**. `compare_versions "$current" "$last"` returns `1` when `current > last` (an upgrade → migrations pending), but the guards check `== 2` / `!= 2` (i.e. a *downgrade*). Even with the `set -e` abort fixed, an ordinary upgrade would report "already up to date" and skip everything.

This is confirmed by the repo's **own** test — `tests/test-migrate-config.sh` "check reads version file" already fails today.

## Fix

- Capture the status with `|| rc=$?` at all four `compare_versions` call sites (the pattern the suite's own "inline exit code capture" test asks for).
- Compare against `1` (`current > last`) for "migration needed".
- Replace the `((failed++)) || true` `set -e` workaround with `failed=$((failed + 1))` (no footgun, no suppression).

## Test suite was orphaned — and destructive

`tests/test-migrate-config.sh` was **not referenced by the Makefile or any CI workflow**, so its two already-failing assertions never gated anything. Worse, its `validate` test wrote a mock over the **real, tracked** `scripts/validate-env.sh` and then `rm`-ed it — running the suite deleted a 376-line source file from the working tree (observed here).

This PR:

- Wires `tests/test-migrate-config.sh` into `make test`.
- Adds a `MIGRATE_VALIDATOR` override to `cmd_validate` so the validate test points at a temp mock instead of clobbering `scripts/validate-env.sh` (default behavior unchanged).
- Adds two behavioral tests: `check` reports a pending migration when `current > last` (exit 2 + "Migration needed"), and reports up-to-date when versions match.

## Verification

- Suite on the pre-fix script: **11 passed, 3 failed** (`check reads version file`, `no silent error suppressions`, and the new `check reports pending migration` — the last shows `exit 1` and output truncated at "Current version: 2.4.1", i.e. the `set -e` abort).
- Suite after the fix: **14/14 pass**.
- `git status` after running the suite: **clean** — `scripts/validate-env.sh` is no longer touched.
- `bash -n` clean on the script and the test; the fix is bash 3.2-safe.
- Makefile insertion placed in the bind-address gap to avoid churn with other in-flight test registrations; tab-indented recipe verified.