### PR TITLE
fix(update): resolve compose flags in manual rollback path

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -765,12 +765,19 @@ cmd_rollback() {
         log_info "Snapshot time    : ${btime}"
     fi
 
+    local compose_flags=""
+    local -a compose_args=()
+    compose_flags=$(resolve_compose_flags 2>/dev/null || true)
+    if [[ -n "$compose_flags" ]]; then
+        read -ra compose_args <<< "$compose_flags"
+    fi
+
     # Stop services
     log_info "Stopping services..."
     cd "$INSTALL_DIR"
-    if ! docker compose down; then
+    if ! docker compose "${compose_args[@]}" down; then
         log_warn "docker compose v2 down failed, trying v1..."
-        docker-compose down
+        docker-compose "${compose_args[@]}" down
     fi
 
     # Restore — use _restore_snapshot for pre-update snapshots (they include
@@ -795,9 +802,16 @@ cmd_rollback() {
 
     # Restart services
     log_info "Restarting services..."
-    if ! docker compose up -d; then
+    local restored_compose_flags=""
+    local -a restored_compose_args=()
+    restored_compose_flags=$(resolve_compose_flags 2>/dev/null || true)
+    if [[ -n "$restored_compose_flags" ]]; then
+        read -ra restored_compose_args <<< "$restored_compose_flags"
+    fi
+
+    if ! docker compose "${restored_compose_args[@]}" up -d; then
         log_warn "docker compose v2 up failed, trying v1..."
-        docker-compose up -d
+        docker-compose "${restored_compose_args[@]}" up -d
     fi
 
     # Verify health using the same timeout-aware poller as cmd_update

--- a/ods/tests/test-update-rollback-contract.sh
+++ b/ods/tests/test-update-rollback-contract.sh
@@ -50,7 +50,7 @@ EOF
 baseline_hash="$(sha256sum "$SRC/.env" "$SRC/config/settings.json" "$SRC/data/open-webui/data.txt" | sha256sum | awk '{print $1}')"
 
 ODS_DIR="$SRC" RETENTION_COUNT=10 bash "$ODS_BACKUP" --type full >/dev/null 2>&1
-BACKUP_ID="$(find "$SRC/.backups" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | tail -n 1)"
+BACKUP_ID="$(find "$SRC/.backups" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | tail -n 1)"
 [[ -n "$BACKUP_ID" ]] || fail "backup ID was not created"
 pass "backup created before update mutation: $BACKUP_ID"
 
@@ -108,3 +108,133 @@ jq -n \
   }' > "$OUT_DIR/evidence.json"
 
 pass "update rollback evidence written to artifacts/update-rollback/evidence.json"
+
+# ── Test manual rollback via ods-update.sh rollback ──────────────────────────
+# Set up a new environment representing a normal layered Compose installation.
+# Prior to rollback, GPU_BACKEND=nvidia is active.
+# Rollback restores a snapshot with GPU_BACKEND=cpu.
+ROLLBACK_SRC="$TMP/ods-rollback-test"
+mkdir -p "$ROLLBACK_SRC/lib" "$ROLLBACK_SRC/config" "$ROLLBACK_SRC/data/backups" "$ROLLBACK_SRC/bin"
+cp "$ROOT_DIR/lib/rsync.sh" "$ROLLBACK_SRC/lib/rsync.sh"
+cp "$ROOT_DIR/lib/safe-env.sh" "$ROLLBACK_SRC/lib/safe-env.sh"
+cp "$ROOT_DIR/ods-update.sh" "$ROLLBACK_SRC/ods-update.sh"
+chmod +x "$ROLLBACK_SRC/ods-update.sh"
+
+# Mock wait_for_healthy requirements (must be able to find python-cmd.sh)
+cp -r "$ROOT_DIR/lib" "$ROLLBACK_SRC/"
+
+SNAP_TIMESTAMP="20260713-120000"
+SNAP_DIR="$ROLLBACK_SRC/data/backups/pre-update-$SNAP_TIMESTAMP"
+mkdir -p "$SNAP_DIR"
+
+cat > "$SNAP_DIR/.version" <<'EOF'
+{"version":"1.0.0"}
+EOF
+cat > "$SNAP_DIR/.env" <<'EOF'
+ODS_MODE=local
+GPU_BACKEND=cpu
+GPU_COUNT=1
+TIER=1
+DASHBOARD_API_PORT=3002
+OLLAMA_PORT=8080
+EOF
+cat > "$SNAP_DIR/docker-compose.base.yml" <<'EOF'
+services:
+  placeholder:
+    image: busybox:1.36
+EOF
+cat > "$SNAP_DIR/docker-compose.cpu.yml" <<'EOF'
+services:
+  placeholder-cpu:
+    image: busybox:1.36
+EOF
+cat > "$SNAP_DIR/snapshot.json" <<'EOF'
+{"type":"pre-update","timestamp":"2026-07-13T12:00:00Z","version":"1.0.0","files_count":4,"install_dir":""}
+EOF
+
+# Pre-rollback state
+cat > "$ROLLBACK_SRC/.env" <<'EOF'
+ODS_MODE=local
+GPU_BACKEND=nvidia
+GPU_COUNT=1
+TIER=1
+DASHBOARD_API_PORT=3002
+OLLAMA_PORT=8080
+EOF
+cat > "$ROLLBACK_SRC/docker-compose.base.yml" <<'EOF'
+services:
+  placeholder:
+    image: busybox:1.36
+EOF
+cat > "$ROLLBACK_SRC/docker-compose.nvidia.yml" <<'EOF'
+services:
+  placeholder-nvidia:
+    image: busybox:1.36
+EOF
+# Ensure no cached .compose-flags exists to force dynamic resolution
+rm -f "$ROLLBACK_SRC/.compose-flags"
+
+ROLLBACK_DOCKER_LOG="$TMP/docker-rollback-args.log"
+export ROLLBACK_DOCKER_LOG
+cat > "$ROLLBACK_SRC/bin/docker" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${ROLLBACK_DOCKER_LOG:?}"
+
+if [[ "${1:-}" == "info" ]]; then
+    exit 0
+fi
+
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+    exit 0
+fi
+
+if [[ "${1:-}" == "compose" ]]; then
+    shift
+fi
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "ps" ]]; then
+        next="${args[$((i + 1))]:-}"
+        if [[ "$next" == "--services" ]]; then
+            printf '%s\n' placeholder
+            exit 0
+        fi
+        if [[ "$next" == "--format" ]]; then
+            printf '%s\n' '{"State":"running"}'
+            exit 0
+        fi
+    fi
+done
+
+exit 0
+SH
+chmod +x "$ROLLBACK_SRC/bin/docker"
+
+cat > "$ROLLBACK_SRC/bin/curl" <<SH
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$ROLLBACK_SRC/bin/curl"
+
+# Run rollback command
+PATH="$ROLLBACK_SRC/bin:$PATH" ODS_MODE=local bash "$ROLLBACK_SRC/ods-update.sh" rollback "$SNAP_TIMESTAMP" > "$TMP/rollback-run.log" 2>&1 || {
+    cat "$TMP/rollback-run.log"
+    fail "rollback execution failed"
+}
+
+# 1. Assert docker compose down receives the CURRENT stack flags (-f docker-compose.base.yml -f docker-compose.nvidia.yml)
+if ! grep -q -- "-f docker-compose.base.yml -f docker-compose.nvidia.yml down" "$ROLLBACK_DOCKER_LOG" 2>/dev/null; then
+    echo "=== DOCKER LOG ==="
+    cat "$ROLLBACK_DOCKER_LOG" 2>/dev/null || echo "(empty)"
+    fail "rollback down did not receive active pre-restore compose flags (-f docker-compose.base.yml -f docker-compose.nvidia.yml)"
+fi
+
+# 2. Assert docker compose up -d receives the RESTORED stack flags (-f docker-compose.base.yml -f docker-compose.cpu.yml)
+if ! grep -q -- "-f docker-compose.base.yml -f docker-compose.cpu.yml up -d" "$ROLLBACK_DOCKER_LOG" 2>/dev/null; then
+    echo "=== DOCKER LOG ==="
+    cat "$ROLLBACK_DOCKER_LOG" 2>/dev/null || echo "(empty)"
+    fail "rollback up did not receive restored post-restore compose flags (-f docker-compose.base.yml -f docker-compose.cpu.yml)"
+fi
+
+pass "rollback dynamically resolves distinct compose flags before and after restore"


### PR DESCRIPTION
## Summary

Fixes manual rollback so `ods-update.sh rollback` uses the resolved layered Compose stack when stopping and restarting ODS services.

`cmd_rollback()` previously invoked bare `docker compose down` and `docker compose up -d` commands. ODS relies on dynamically resolved Compose files rather than a default `docker-compose.yml`, so manual rollback could fail with `no configuration file provided: not found`.

The rollback path now resolves the current Compose stack before stopping services, restores the snapshot, then re-resolves the stack before restarting services. Re-resolving after restore is required because the restored `.env` or Compose configuration may select a different backend or overlay.

Fixes #<ISSUE_NUMBER>

## AI Assistance

AI tools assisted with code-path auditing, edge-case review, and drafting the initial regression-test approach. I reviewed the implementation and diff, reproduced the failure with a hermetic test, selected the validation scope, and verified the final behavior locally.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — this PR targets main.