### PR TITLE
fix(windows): handle multiple Python interpreter matches

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -84,6 +84,10 @@ jobs:
         shell: pwsh
         run: ./tests/test-windows-port-preflight.ps1
 
+      - name: Windows Host Agent Python Resolver Contract
+        shell: pwsh
+        run: ./tests/test-windows-python-resolver.ps1
+
       - name: Windows Runtime Recovery Contract
         shell: pwsh
         run: ./tests/contracts/test-windows-runtime-recovery.ps1

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2148,9 +2148,12 @@ function Resolve-ODSHostAgentPython {
     }
 
     foreach ($name in @("python3", "python")) {
-        $cmd = Get-Command $name -CommandType Application -ErrorAction SilentlyContinue
-        if ($cmd -and $cmd.Source) {
-            $candidateFiles.Add($cmd.Source)
+        # Get-Command returns an array when multiple executables share a name
+        # across PATH entries; iterate so .Source is always a single string.
+        foreach ($cmd in @(Get-Command $name -CommandType Application -All -ErrorAction SilentlyContinue)) {
+            if ($cmd.Source) {
+                $candidateFiles.Add($cmd.Source)
+            }
         }
     }
 
@@ -2163,10 +2166,11 @@ function Resolve-ODSHostAgentPython {
         }
     }
 
-    $pyLauncher = Get-Command py -CommandType Application -ErrorAction SilentlyContinue
-    if ($pyLauncher -and $pyLauncher.Source -and
-        (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
-        return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+    foreach ($pyLauncher in @(Get-Command py -CommandType Application -All -ErrorAction SilentlyContinue)) {
+        if ($pyLauncher.Source -and
+            (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
+            return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+        }
     }
 
     return $null

--- a/ods/installers/windows/phases/07-devtools.ps1
+++ b/ods/installers/windows/phases/07-devtools.ps1
@@ -256,9 +256,12 @@ function Resolve-ODSHostAgentPython {
     }
 
     foreach ($name in @("python3", "python")) {
-        $cmd = Get-Command $name -CommandType Application -ErrorAction SilentlyContinue
-        if ($cmd -and $cmd.Source) {
-            $candidateFiles.Add($cmd.Source)
+        # Get-Command returns an array when multiple executables share a name
+        # across PATH entries; iterate so .Source is always a single string.
+        foreach ($cmd in @(Get-Command $name -CommandType Application -All -ErrorAction SilentlyContinue)) {
+            if ($cmd.Source) {
+                $candidateFiles.Add($cmd.Source)
+            }
         }
     }
 
@@ -271,10 +274,11 @@ function Resolve-ODSHostAgentPython {
         }
     }
 
-    $pyLauncher = Get-Command py -CommandType Application -ErrorAction SilentlyContinue
-    if ($pyLauncher -and $pyLauncher.Source -and
-        (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
-        return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+    foreach ($pyLauncher in @(Get-Command py -CommandType Application -All -ErrorAction SilentlyContinue)) {
+        if ($pyLauncher.Source -and
+            (Test-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))) {
+            return (New-ODSHostAgentPythonCandidate -FilePath $pyLauncher.Source -PrefixArgs @("-3"))
+        }
     }
 
     return $null

--- a/ods/tests/test-windows-python-resolver.ps1
+++ b/ods/tests/test-windows-python-resolver.ps1
@@ -1,0 +1,163 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Assert-Equal {
+    param(
+        [Parameter(Mandatory = $true)][AllowNull()]$Expected,
+        [Parameter(Mandatory = $true)][AllowNull()]$Actual,
+        [Parameter(Mandatory = $true)][string]$Message
+    )
+
+    if ($Expected -ne $Actual) {
+        throw "$Message (expected '$Expected', got '$Actual')"
+    }
+}
+
+function Get-ResolverDefinition {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    $tokens = $null
+    $errors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        $Path,
+        [ref]$tokens,
+        [ref]$errors
+    )
+    if ($errors.Count -gt 0) {
+        throw "PowerShell parse failed for ${Path}: $($errors[0].Message)"
+    }
+
+    $definition = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq "Resolve-ODSHostAgentPython"
+    }, $true)
+    if (-not $definition) {
+        throw "Resolve-ODSHostAgentPython was not found in $Path"
+    }
+
+    return $definition.Extent.Text
+}
+
+function Invoke-ResolverScenario {
+    param(
+        [Parameter(Mandatory = $true)][string]$Definition,
+        [Parameter(Mandatory = $true)][hashtable]$Commands,
+        [Parameter(Mandatory = $true)][AllowEmptyCollection()][string[]]$ValidCandidates
+    )
+
+    $script:resolverCommands = $Commands
+    $script:resolverValidCandidates = @($ValidCandidates)
+    $script:resolverProbes = New-Object System.Collections.Generic.List[string]
+
+    $mockGetCommand = {
+        param(
+            [string]$Name,
+            [object]$CommandType,
+            [switch]$All,
+            [object]$ErrorAction
+        )
+
+        $null = $CommandType
+        $null = $ErrorAction
+        if (-not $All) {
+            throw "Resolve-ODSHostAgentPython must enumerate all PATH matches for '$Name'"
+        }
+        if (-not $script:resolverCommands.ContainsKey($Name)) {
+            return @()
+        }
+        return @($script:resolverCommands[$Name])
+    }
+    Set-Item -Path Function:Get-Command -Value $mockGetCommand
+
+    function Test-ODSHostAgentPythonCandidate {
+        param(
+            [Parameter(Mandatory = $true)][string]$FilePath,
+            [string[]]$PrefixArgs = @()
+        )
+
+        $key = "$FilePath|$($PrefixArgs -join ',')"
+        $script:resolverProbes.Add($key)
+        return $script:resolverValidCandidates -contains $key
+    }
+
+    function New-ODSHostAgentPythonCandidate {
+        param(
+            [Parameter(Mandatory = $true)][string]$FilePath,
+            [string[]]$PrefixArgs = @()
+        )
+
+        return [pscustomobject]@{
+            FilePath   = $FilePath
+            PrefixArgs = @($PrefixArgs)
+        }
+    }
+
+    $oldLocalAppData = $env:LOCALAPPDATA
+    $oldProgramFiles = $env:ProgramFiles
+    $oldProgramFilesX86 = ${env:ProgramFiles(x86)}
+    $missingRoot = Join-Path ([System.IO.Path]::GetTempPath()) "ods-python-resolver-missing-$([guid]::NewGuid())"
+
+    try {
+        $env:LOCALAPPDATA = $missingRoot
+        $env:ProgramFiles = $missingRoot
+        ${env:ProgramFiles(x86)} = $missingRoot
+        . ([scriptblock]::Create($Definition))
+        $result = Resolve-ODSHostAgentPython
+
+        return [pscustomobject]@{
+            Result = $result
+            Probes = @($script:resolverProbes)
+        }
+    } finally {
+        $env:LOCALAPPDATA = $oldLocalAppData
+        $env:ProgramFiles = $oldProgramFiles
+        ${env:ProgramFiles(x86)} = $oldProgramFilesX86
+    }
+}
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$sources = @(
+    (Join-Path $repoRoot "installers/windows/phases/07-devtools.ps1"),
+    (Join-Path $repoRoot "installers/windows/ods.ps1")
+)
+
+foreach ($source in $sources) {
+    $definition = Get-ResolverDefinition -Path $source
+
+    $direct = Invoke-ResolverScenario -Definition $definition -Commands @{
+        python3 = @(
+            [pscustomobject]@{ Source = "C:\WindowsApps\python3.exe" },
+            [pscustomobject]@{ Source = "C:\Python312\python.exe" }
+        )
+        python = @()
+        py = @()
+    } -ValidCandidates @("C:\Python312\python.exe|")
+    Assert-Equal "C:\Python312\python.exe" $direct.Result.FilePath "$source did not select the valid direct interpreter"
+    Assert-Equal 0 $direct.Result.PrefixArgs.Count "$source added unexpected direct-interpreter arguments"
+
+    $launcher = Invoke-ResolverScenario -Definition $definition -Commands @{
+        python3 = @()
+        python = @()
+        py = @(
+            [pscustomobject]@{ Source = "C:\WindowsApps\py.exe" },
+            [pscustomobject]@{ Source = "C:\Windows\py.exe" }
+        )
+    } -ValidCandidates @("C:\Windows\py.exe|-3")
+    Assert-Equal "C:\Windows\py.exe" $launcher.Result.FilePath "$source did not select the valid py launcher"
+    Assert-Equal "-3" ($launcher.Result.PrefixArgs -join ",") "$source did not preserve the py launcher prefix"
+
+    $duplicates = Invoke-ResolverScenario -Definition $definition -Commands @{
+        python3 = @(
+            [pscustomobject]@{ Source = "C:\Python312\python.exe" },
+            [pscustomobject]@{ Source = "c:\python312\PYTHON.EXE" },
+            [pscustomobject]@{ Source = $null }
+        )
+        python = @()
+        py = @()
+    } -ValidCandidates @()
+    Assert-Equal $null $duplicates.Result "$source unexpectedly resolved an invalid candidate"
+    Assert-Equal 1 $duplicates.Probes.Count "$source did not deduplicate case-insensitive PATH candidates"
+}
+
+Write-Host "[PASS] Windows host-agent Python resolver handles multiple PATH interpreters"


### PR DESCRIPTION
## Summary

Fixes #1654.

The Windows host-agent resolver assumed `Get-Command` returned one `ApplicationInfo`. On hosts with several Python installations or launchers, `.Source` became an `Object[]`; Phase 07 then passed that array to a `[string] FilePath` parameter and stopped with `ParameterBindingArgumentTransformationException`.

This change updates both copies of `Resolve-ODSHostAgentPython` to enumerate every application match with `Get-Command -All`, validate candidates one at a time, retain the existing case-insensitive deduplication, and fall back to `py -3` only after direct interpreters fail.

A focused regression extracts and executes the resolver from both production scripts. It covers multiple `python3`/`python`/`py` results, an invalid first match followed by a valid interpreter, null sources, no valid interpreter, case-insensitive duplicates, and preservation of the `-3` launcher prefix. The contract now runs in the PowerShell CI matrix.

## AI Assistance

AI-assisted log analysis, edge-case enumeration, independent review, and regression-test drafting were used. The author reviewed the implementation, selected the validation scope, and is responsible for the final diff.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not targeting the stable release branch directly.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Behavior And Invariants

| Invariant | Evidence |
|---|---|
| Never bind an `Object[]` to `FilePath` | Every `Get-Command -All` result is iterated before `.Source` is read |
| Prefer direct Python over the launcher | Resolver order remains `python3`, `python`, then `py -3` |
| Skip invalid aliases and continue searching | Regression uses an invalid first result and a valid second result |
| Do not probe duplicate executable paths | Existing case-insensitive deduplication is regression-tested |
| Keep installer and lifecycle CLI behavior aligned | The same contract executes both resolver definitions |
| Keep reruns stateless | Resolution reads host state only and writes no installer or runtime state |

## Risk And Validation

- Risk level: Medium
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [x] Not required because: no dashboard, Compose, schema, or documentation surface changed

Commands/results:

```text
pwsh -NoProfile -File ods/tests/test-windows-python-resolver.ps1
# PASS

powershell.exe -NoProfile -ExecutionPolicy Bypass -File ods/tests/test-windows-python-resolver.ps1
# PASS (Windows PowerShell 5.1)

Invoke-ScriptAnalyzer on both production scripts and the regression test
# PASS

bash ods/tests/contracts/test-installer-hardening.sh
# PASS

PowerShell parser checks for both production scripts and the regression test
# PASS

YAML parse for .github/workflows/lint-powershell.yml
# PASS

git diff --check osmantic/main...HEAD
# PASS
```

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Compatibility And Failure Behavior

- Clean install, update, and rerun use the same corrected resolver.
- Empty command results and invalid candidates return `$null` without mutation, preserving the existing install/fallback behavior.
- Linux and macOS paths are unchanged.
- No environment, service, persistence, rollback, or Compose state is modified by this resolver.

## Notes For Reviewers

The regression reproduces the reported multi-result command shape on real Windows PowerShell 5.1 and PowerShell 7. Full installer execution is left to GitHub CI because the defect is isolated to interpreter enumeration and the test executes both production function bodies directly.

