### PR TITLE
fix(compose): correct Brave Search build context

### DIFF
--- a/ods/extensions/services/brave-search/compose.yaml
+++ b/ods/extensions/services/brave-search/compose.yaml
@@ -1,7 +1,7 @@
 services:
   brave-search:
     build:
-      context: .
+      context: ./extensions/services/brave-search
       dockerfile: Dockerfile
     image: ods-brave-search:local
     container_name: ods-brave-search


### PR DESCRIPTION
## Summary
- Fix Brave Search's build context when its extension compose file is used in the resolved ODS stack.
- Keeps the PR intentionally tiny for Tier-1 main landing.

## Validation
- `docker compose -f docker-compose.base.yml -f docker-compose.nvidia.yml -f extensions/services/brave-search/compose.yaml config --quiet`
- Verified the resolved Brave build context points at `ods/extensions/services/brave-search` in the full-stack compose shape.