### PR TITLE
fix(dashboard): match Lemonade GGUF stem model ids

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -118,6 +118,10 @@ def _model_aliases(model: dict[str, Any]) -> set[str]:
     for part in model.get("gguf_parts", []) or []:
         if isinstance(part, dict):
             aliases.add(str(part.get("file") or ""))
+    for alias in tuple(aliases):
+        path_name = re.split(r"[\\/]", alias)[-1]
+        if path_name.lower().endswith(".gguf"):
+            aliases.add(path_name[:-5])
     return {alias for alias in aliases if alias}
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -423,3 +423,33 @@ def test_published_exact_requires_matching_signature(data_dir):
     assert perf["source"] == "published_exact"
     assert perf["tokensPerSec"] == 44.2
     assert perf["sourceUrl"] == "https://example.test/bench"
+
+
+def test_published_exact_matches_gguf_stem_identity(data_dir):
+    evidence = [{
+        "model_id": "Qwen3.5-9B-Q4_K_M",
+        "model_names": [],
+        "quantization": "Q4_K_M",
+        "backend": "nvidia",
+        "gpu_name": "NVIDIA GeForce RTX 4060",
+        "vram_gb": 8,
+        "context_length": 32768,
+        "tokens_per_second": 43.7,
+        "source_url": "https://example.test/stem-bench",
+    }]
+
+    perf = evaluate_performance(
+        _model(),
+        _gpu(),
+        {"quantization": "Q4_K_M", "readable": False},
+        False,
+        0,
+        32768,
+        {},
+        evidence,
+        True,
+    )
+
+    assert perf["source"] == "published_exact"
+    assert perf["tokensPerSec"] == 43.7
+    assert perf["sourceUrl"] == "https://example.test/stem-bench"


### PR DESCRIPTION
## Summary
- Add GGUF filename stems to dashboard-api model aliases so Lemonade/runtime stem IDs can match catalog metadata.
- Keeps this as a narrow Tier-1 main PR separate from the larger model-management UI stack.

## Validation
- `python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py -q`