### PR TITLE
fix(preflight): resolve shared Python command path

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -118,6 +118,7 @@ jobs:
         run: |
           bash tests/contracts/test-installer-contracts.sh
           bash tests/contracts/test-preflight-fixtures.sh
+          bash tests/test-preflight-resolver-bug.sh
           python3 tests/contracts/test-network-exposure-contracts.py
 
       - name: Linux install preflight tests

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -25,6 +25,7 @@ test: ## Run unit and contract tests
 	@echo "=== Installer contracts ==="
 	@bash tests/contracts/test-installer-contracts.sh
 	@bash tests/contracts/test-preflight-fixtures.sh
+	@bash tests/test-preflight-resolver-bug.sh
 	@bash tests/test-linux-cloud-mode.sh
 	@echo ""
 	@echo "=== Linux install preflight ==="

--- a/ods/scripts/preflight-engine.sh
+++ b/ods/scripts/preflight-engine.sh
@@ -10,7 +10,7 @@ GPU_VRAM_MB="${GPU_VRAM_MB:-0}"
 GPU_NAME="${GPU_NAME:-Unknown}"
 PLATFORM_ID="${PLATFORM_ID:-linux}"
 COMPOSE_OVERLAYS="${COMPOSE_OVERLAYS:-}"
-SCRIPT_DIR="${SCRIPT_DIR:-$(pwd)}"
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 STRICT="false"
 ENV_MODE="false"
 
@@ -71,7 +71,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ROOT_DIR="$SCRIPT_DIR"
 PYTHON_CMD="python3"
 if [[ -f "$ROOT_DIR/lib/python-cmd.sh" ]]; then
     . "$ROOT_DIR/lib/python-cmd.sh"

--- a/ods/tests/test-preflight-resolver-bug.sh
+++ b/ods/tests/test-preflight-resolver-bug.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS preflight-engine.sh Shared Resolver Bug Regression Test
+# ============================================================================
+set -euo pipefail
+
+# Create temporary directory layout
+TEMP_WORKSPACE="$(mktemp -d)"
+trap 'rm -rf "$TEMP_WORKSPACE"' EXIT
+
+# Create temporary ODS root directory
+TEMP_ODS="$TEMP_WORKSPACE/ods"
+mkdir -p "$TEMP_ODS/lib"
+mkdir -p "$TEMP_ODS/scripts"
+
+# Create a mock python-cmd.sh
+cat > "$TEMP_ODS/lib/python-cmd.sh" <<'EOF'
+ods_detect_python_cmd() {
+  echo "$MOCK_PYTHON"
+}
+EOF
+
+# Copy the real preflight-engine.sh to our mock location
+cp ods/scripts/preflight-engine.sh "$TEMP_ODS/scripts/"
+
+# Create a mock python script that preflight-engine.sh should run
+MOCK_PYTHON_BIN="$TEMP_WORKSPACE/mock_python"
+export MOCK_PYTHON="$MOCK_PYTHON_BIN"
+cat > "$MOCK_PYTHON_BIN" <<'EOF'
+#!/bin/bash
+echo "MOCK PYTHON CALLED"
+exit 0
+EOF
+chmod +x "$MOCK_PYTHON_BIN"
+
+# Mask system python3 and python to prevent fallback from succeeding.
+MASK_DIR="$TEMP_WORKSPACE/mask"
+mkdir -p "$MASK_DIR"
+cat > "$MASK_DIR/python3" <<'EOF'
+#!/bin/bash
+echo "FAIL: System python3 called" >&2
+exit 99
+EOF
+cat > "$MASK_DIR/python" <<'EOF'
+#!/bin/bash
+echo "FAIL: System python called" >&2
+exit 99
+EOF
+chmod +x "$MASK_DIR/python3" "$MASK_DIR/python"
+
+echo "Running preflight-engine.sh with --script-dir $TEMP_ODS"
+set +e
+OUTPUT=$(PATH="$MASK_DIR:$PATH" bash "$TEMP_ODS/scripts/preflight-engine.sh" \
+  --report "$TEMP_WORKSPACE/report.json" \
+  --script-dir "$TEMP_ODS" \
+  --tier 1 \
+  --ram-gb 16 \
+  --disk-gb 50 \
+  --gpu-backend cpu \
+  --platform-id linux 2>&1)
+EXIT_CODE=$?
+set -e
+
+echo "Exit code: $EXIT_CODE"
+echo "Output: $OUTPUT"
+
+if [[ "$OUTPUT" == *"MOCK PYTHON CALLED"* ]]; then
+  echo "SUCCESS: Shared resolver was loaded and used!"
+  exit 0
+else
+  echo "FAILURE: Shared resolver was NOT loaded/used!"
+  exit 1
+fi

--- a/ods/tests/test-preflight-resolver-bug.sh
+++ b/ods/tests/test-preflight-resolver-bug.sh
@@ -4,6 +4,9 @@
 # ============================================================================
 set -euo pipefail
 
+# Derive ODS root directory from test file location
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
 # Create temporary directory layout
 TEMP_WORKSPACE="$(mktemp -d)"
 trap 'rm -rf "$TEMP_WORKSPACE"' EXIT
@@ -21,7 +24,7 @@ ods_detect_python_cmd() {
 EOF
 
 # Copy the real preflight-engine.sh to our mock location
-cp ods/scripts/preflight-engine.sh "$TEMP_ODS/scripts/"
+cp "$ROOT_DIR/scripts/preflight-engine.sh" "$TEMP_ODS/scripts/"
 
 # Create a mock python script that preflight-engine.sh should run
 MOCK_PYTHON_BIN="$TEMP_WORKSPACE/mock_python"


### PR DESCRIPTION
## Summary

Fixes `preflight-engine.sh` so it correctly loads the shared Python command resolver when `--script-dir` points to the ODS root.

Existing callers pass the ODS root through `--script-dir`, but the preflight engine previously moved one directory above that path before looking for `lib/python-cmd.sh`. This silently skipped the shared resolver and fell back directly to `python3` or `python` from `PATH`.

Fixes #1753 
## AI Assistance

AI tools assisted with code-path auditing, reproduction design, edge-case review, and drafting the regression-test approach. I reviewed the implementation and diff, reproduced the failure hermetically, selected the validation scope, and verified the final behavior locally.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — this PR targets main.