### PR TITLE
fix(rollback): resolve layered compose stack in ods-update.sh + ods-restore.sh

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -133,6 +133,9 @@ jobs:
       - name: Update Rollback Contract
         run: bash tests/test-update-rollback-contract.sh
 
+      - name: ods-update rollback layered compose regression
+        run: bash tests/test-ods-update-rollback-layered-compose.sh
+
       - name: Support Bundle Evidence Tests
         run: bash tests/test-support-bundle.sh
 

--- a/ods/ods-restore.sh
+++ b/ods/ods-restore.sh
@@ -28,6 +28,41 @@ log_step() { echo -e "${CYAN}[STEP]${NC} $*"; }
 # Source shared rsync utilities
 . "$ODS_DIR/lib/rsync.sh"
 
+# resolve_compose_flags
+#   Prints the -f flags needed to address the active layered compose stack.
+#   ODS installs do not ship a top-level docker-compose.yml, so a bare
+#   `docker compose down` fails with "no configuration file provided".
+#   Preference order: cached .compose-flags -> resolve-compose-stack.sh ->
+#   base+backend fallback. Prints an empty string when nothing resolves.
+resolve_compose_flags() {
+    local flags=""
+
+    if [[ -f "$ODS_DIR/.compose-flags" ]]; then
+        flags="$(tr '\n' ' ' < "$ODS_DIR/.compose-flags" | xargs 2>/dev/null || true)"
+    fi
+
+    if [[ -z "$flags" && -x "$ODS_DIR/scripts/resolve-compose-stack.sh" ]]; then
+        flags="$("$ODS_DIR/scripts/resolve-compose-stack.sh" \
+            --script-dir "$ODS_DIR" \
+            --tier "${TIER:-1}" \
+            --gpu-backend "${GPU_BACKEND:-nvidia}" \
+            --gpu-count "${GPU_COUNT:-1}" \
+            --ods-mode "${ODS_MODE:-local}" 2>/dev/null | tail -1 || true)"
+    fi
+
+    if [[ -z "$flags" && -f "$ODS_DIR/docker-compose.base.yml" ]]; then
+        flags="-f docker-compose.base.yml"
+        case "${GPU_BACKEND:-}" in
+            amd|nvidia|intel|apple|arc|cpu|sycl)
+                [[ -f "$ODS_DIR/docker-compose.${GPU_BACKEND}.yml" ]] \
+                    && flags="$flags -f docker-compose.${GPU_BACKEND}.yml"
+                ;;
+        esac
+    fi
+
+    printf '%s\n' "$flags"
+}
+
 # Convert bytes to a human-friendly string (best-effort)
 fmt_bytes() {
     local bytes="${1:-0}"
@@ -383,10 +418,25 @@ stop_containers() {
     fi
 
     cd "$ODS_DIR"
-    if docker compose down; then
-        log_success "Containers stopped"
+    local compose_flags
+    compose_flags="$(resolve_compose_flags)"
+    if [[ -n "$compose_flags" ]]; then
+        # Word-splitting is intentional: compose_flags is a `-f a -f b` string.
+        # shellcheck disable=SC2086
+        if docker compose ${compose_flags} down; then
+            log_success "Containers stopped"
+        else
+            log_warn "Some containers may not have stopped cleanly"
+        fi
+    elif [[ -f "$ODS_DIR/docker-compose.yml" ]]; then
+        if docker compose down; then
+            log_success "Containers stopped"
+        else
+            log_warn "Some containers may not have stopped cleanly"
+        fi
     else
-        log_warn "Some containers may not have stopped cleanly"
+        log_warn "No compose stack could be resolved for: $ODS_DIR"
+        log_warn "Skipping 'docker compose down'; existing containers left running."
     fi
 }
 
@@ -545,7 +595,17 @@ do_restore() {
     echo ""
     echo "Next steps:"
     echo "  1. Review restored configuration: cat $ODS_DIR/.env"
-    echo "  2. Start services: docker compose up -d"
+    # ODS installs are layered; the restored .env may pick a different backend,
+    # so re-resolve the compose stack rather than printing stale flags here.
+    local next_flags
+    next_flags="$(resolve_compose_flags)"
+    if [[ -n "$next_flags" ]]; then
+        echo "  2. Start services: docker compose ${next_flags} up -d"
+    elif [[ -f "$ODS_DIR/docker-compose.yml" ]]; then
+        echo "  2. Start services: docker compose up -d"
+    else
+        echo "  2. Start services: ./ods-cli restart   (or run 'ods-update.sh health' first)"
+    fi
     echo "  3. Check status: ./ods-preflight.sh"
 }
 

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -765,12 +765,25 @@ cmd_rollback() {
         log_info "Snapshot time    : ${btime}"
     fi
 
-    # Stop services
+    # Stop services using the CURRENT stack's compose flags — the restored
+    # snapshot may resolve to a different overlay, so we must down the
+    # running stack before restoring, not after.
     log_info "Stopping services..."
     cd "$INSTALL_DIR"
-    if ! docker compose down; then
-        log_warn "docker compose v2 down failed, trying v1..."
-        docker-compose down
+    local pre_restore_flags=""
+    pre_restore_flags=$(resolve_compose_flags 2>/dev/null || true)
+    if [[ -n "$pre_restore_flags" ]]; then
+        if ! docker compose ${pre_restore_flags} down; then
+            log_warn "docker compose v2 down failed, trying v1..."
+            docker-compose ${pre_restore_flags} down
+        fi
+    elif [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
+        if ! docker compose down; then
+            log_warn "docker compose v2 down failed, trying v1..."
+            docker-compose down
+        fi
+    else
+        log_warn "No compose stack could be resolved; skipping 'docker compose down' before restore."
     fi
 
     # Restore — use _restore_snapshot for pre-update snapshots (they include
@@ -793,11 +806,29 @@ cmd_rollback() {
         shopt -u dotglob
     fi
 
-    # Restart services
+    # Invalidate the cached compose-flags: the restored .env / overlays may
+    # select a different backend, and the cache is NOT part of the snapshot.
+    # resolve_compose_flags will then dynamically resolve against the
+    # restored configuration.
+    rm -f "${INSTALL_DIR}/.compose-flags"
+
+    # Restart services using the RESTORED stack's compose flags.
     log_info "Restarting services..."
-    if ! docker compose up -d; then
-        log_warn "docker compose v2 up failed, trying v1..."
-        docker-compose up -d
+    local post_restore_flags=""
+    post_restore_flags=$(resolve_compose_flags 2>/dev/null || true)
+    if [[ -n "$post_restore_flags" ]]; then
+        if ! docker compose ${post_restore_flags} up -d; then
+            log_warn "docker compose v2 up failed, trying v1..."
+            docker-compose ${post_restore_flags} up -d
+        fi
+    elif [[ -f "${INSTALL_DIR}/docker-compose.yml" ]]; then
+        if ! docker compose up -d; then
+            log_warn "docker compose v2 up failed, trying v1..."
+            docker-compose up -d
+        fi
+    else
+        log_error "No compose stack could be resolved after restore; cannot restart services."
+        return 1
     fi
 
     # Verify health using the same timeout-aware poller as cmd_update

--- a/ods/scripts/release-gate.sh
+++ b/ods/scripts/release-gate.sh
@@ -46,5 +46,6 @@ bash scripts/simulate-installers.sh
 
 echo "[gate] update rollback"
 bash tests/test-update-rollback-contract.sh
+bash tests/test-ods-update-rollback-layered-compose.sh
 
 echo "[PASS] release gate"

--- a/ods/tests/test-ods-update-rollback-layered-compose.sh
+++ b/ods/tests/test-ods-update-rollback-layered-compose.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# test-ods-update-rollback-layered-compose.sh
+#
+# Regression test for the "rollback ignores layered compose stack" bug.
+#
+# Scenario (from the issue):
+#   Current stack : docker-compose.base.yml + docker-compose.nvidia.yml
+#   Snapshot stack: docker-compose.base.yml + docker-compose.cpu.yml
+#   No default docker-compose.yml exists.
+#
+# cmd_rollback() must:
+#   1. Resolve the CURRENT stack and pass those -f flags to `docker compose down`
+#      (so services actually stop on installs with no default docker-compose.yml).
+#   2. RE-resolve after restoring the snapshot and pass the NEW -f flags to
+#      `docker compose up -d` (the restored .env may pick a different backend).
+#
+# Before the fix, both invocations were bare (`docker compose down`,
+# `docker compose up -d`) and failed with "no configuration file provided".
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+UPDATE_SCRIPT="$ROOT_DIR/ods-update.sh"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+[[ -f "$UPDATE_SCRIPT" ]] || fail "ods-update.sh not found"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+INSTALL_DIR="$TMP_DIR/ods"
+BIN_DIR="$TMP_DIR/bin"
+mkdir -p "$INSTALL_DIR/data/backups" "$BIN_DIR"
+
+cp "$UPDATE_SCRIPT" "$INSTALL_DIR/ods-update.sh"
+chmod +x "$INSTALL_DIR/ods-update.sh"
+
+# ─── Current install: base + nvidia, GPU_BACKEND=nvidia ─────────────────────
+cat > "$INSTALL_DIR/.env" <<'EOF'
+ODS_MODE=local
+GPU_BACKEND=nvidia
+GPU_COUNT=1
+TIER=1
+DASHBOARD_API_PORT=3002
+OLLAMA_PORT=8080
+EOF
+
+cat > "$INSTALL_DIR/.version" <<'EOF'
+{"version":"2.0.0"}
+EOF
+
+cat > "$INSTALL_DIR/docker-compose.base.yml" <<'EOF'
+services:
+  dashboard-api:
+    image: example/dashboard-api:test
+EOF
+
+cat > "$INSTALL_DIR/docker-compose.nvidia.yml" <<'EOF'
+services:
+  llama-server:
+    image: example/llama-nvidia:test
+EOF
+
+# Cached flags for the currently-running stack. cmd_rollback() must use these
+# for `down`, not fall back to a bare `docker compose down`.
+printf '%s\n' '-f docker-compose.base.yml -f docker-compose.nvidia.yml' \
+    > "$INSTALL_DIR/.compose-flags"
+
+# NOTE: No `docker-compose.yml` — this is the exact repro condition from
+# the issue. A bare `docker compose down` would fail with "no configuration
+# file provided: not found".
+[[ ! -f "$INSTALL_DIR/docker-compose.yml" ]] || fail "test setup left a stray docker-compose.yml"
+
+# ─── Snapshot: same install BUT resolved to base + cpu, GPU_BACKEND=cpu ─────
+SNAP_TS="20260101-120000"
+SNAP_DIR="$INSTALL_DIR/data/backups/pre-update-$SNAP_TS"
+mkdir -p "$SNAP_DIR"
+
+cat > "$SNAP_DIR/.env" <<'EOF'
+ODS_MODE=local
+GPU_BACKEND=cpu
+GPU_COUNT=0
+TIER=1
+DASHBOARD_API_PORT=3002
+OLLAMA_PORT=8080
+EOF
+
+cat > "$SNAP_DIR/.version" <<'EOF'
+{"version":"1.0.0"}
+EOF
+
+# The snapshot only carries base + cpu — the restored install must not run
+# with the nvidia overlay still attached.
+cp "$INSTALL_DIR/docker-compose.base.yml" "$SNAP_DIR/docker-compose.base.yml"
+cat > "$SNAP_DIR/docker-compose.cpu.yml" <<'EOF'
+services:
+  llama-server:
+    image: example/llama-cpu:test
+EOF
+
+jq -n \
+    --arg ts  "2026-01-01T12:00:00Z" \
+    --arg ver "1.0.0" \
+    --argjson fc 4 \
+    --arg dir "$INSTALL_DIR" \
+    '{type:"pre-update", timestamp:$ts, version:$ver, files_count:$fc, install_dir:$dir}' \
+    > "$SNAP_DIR/snapshot.json"
+
+# ─── Stubbed docker: logs args, returns success, fakes ps ────────────────────
+DOCKER_LOG="$TMP_DIR/docker-args.log"
+export DOCKER_LOG
+cat > "$BIN_DIR/docker" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${DOCKER_LOG:?}"
+
+if [[ "${1:-}" == "info" ]]; then
+    exit 0
+fi
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then
+    exit 0
+fi
+
+# Strip the leading `compose` verb so we can scan the remaining args.
+if [[ "${1:-}" == "compose" ]]; then
+    shift
+fi
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "ps" ]]; then
+        next="${args[$((i + 1))]:-}"
+        if [[ "$next" == "--services" ]]; then
+            printf '%s\n' dashboard-api llama-server
+            exit 0
+        fi
+        if [[ "$next" == "--format" ]]; then
+            printf '%s\n' '{"State":"running"}'
+            exit 0
+        fi
+    fi
+done
+
+# `down` / `up -d` / everything else: succeed silently.
+exit 0
+SH
+chmod +x "$BIN_DIR/docker"
+
+# curl stub — cmd_health probes /health and /v1/models via curl.
+cat > "$BIN_DIR/curl" <<'SH'
+#!/usr/bin/env bash
+exit 0
+SH
+chmod +x "$BIN_DIR/curl"
+
+# ─── Run rollback ────────────────────────────────────────────────────────────
+: > "$DOCKER_LOG"
+set +e
+PATH="$BIN_DIR:$PATH" bash "$INSTALL_DIR/ods-update.sh" rollback "$SNAP_TS" \
+    > "$TMP_DIR/rollback.out" 2>&1
+rollback_exit=$?
+set -e
+
+if [[ "$rollback_exit" -ne 0 ]]; then
+    echo "=== rollback.out ==="
+    cat "$TMP_DIR/rollback.out"
+    echo "=== docker-args.log ==="
+    cat "$DOCKER_LOG"
+    fail "rollback exited $rollback_exit (expected 0 with stubbed docker)"
+fi
+pass "rollback command completed successfully"
+
+# ─── Assertions on docker invocations ────────────────────────────────────────
+if ! grep -qE '^compose (.* )?-f docker-compose\.base\.yml -f docker-compose\.nvidia\.yml down( |$)' "$DOCKER_LOG"; then
+    echo "=== docker-args.log ==="
+    cat "$DOCKER_LOG"
+    fail "rollback did not pass current stack flags (base+nvidia) to docker compose down"
+fi
+pass "rollback down used the pre-restore stack flags (base+nvidia)"
+
+if ! grep -qE '^compose (.* )?-f docker-compose\.base\.yml -f docker-compose\.cpu\.yml up -d( |$)' "$DOCKER_LOG"; then
+    echo "=== docker-args.log ==="
+    cat "$DOCKER_LOG"
+    fail "rollback did not pass restored stack flags (base+cpu) to docker compose up -d"
+fi
+pass "rollback up -d used the restored stack flags (base+cpu)"
+
+# Also assert the bug is really gone — no bare `compose down` / `compose up -d`
+# (without any -f flag) during the rollback path.
+if grep -qE '^compose down( |$)' "$DOCKER_LOG"; then
+    echo "=== docker-args.log ==="
+    cat "$DOCKER_LOG"
+    fail "rollback invoked bare 'docker compose down' — regression of the bug"
+fi
+if grep -qE '^compose up -d( |$)' "$DOCKER_LOG"; then
+    echo "=== docker-args.log ==="
+    cat "$DOCKER_LOG"
+    fail "rollback invoked bare 'docker compose up -d' — regression of the bug"
+fi
+pass "rollback did not fall back to bare compose commands"
+
+# ─── Post-restore state ──────────────────────────────────────────────────────
+grep -q '^GPU_BACKEND=cpu$' "$INSTALL_DIR/.env" \
+    || { cat "$INSTALL_DIR/.env"; fail ".env was not restored (GPU_BACKEND should be cpu)"; }
+pass ".env restored from snapshot (GPU_BACKEND=cpu)"
+
+# The stale .compose-flags cache pointed to base+nvidia; cmd_rollback must
+# clear it so subsequent health/updates re-resolve against the restored env.
+if [[ -f "$INSTALL_DIR/.compose-flags" ]]; then
+    cache="$(cat "$INSTALL_DIR/.compose-flags")"
+    fail ".compose-flags cache was not invalidated after restore (still: ${cache})"
+fi
+pass ".compose-flags cache invalidated after restore"
+
+[[ "$(jq -r '.version' "$INSTALL_DIR/.version")" == "1.0.0" ]] \
+    || fail ".version was not restored"
+pass ".version restored from snapshot (1.0.0)"
+
+# ─── ods-restore.sh stop_containers: same bare-compose class of bug ─────────
+# Verify ods-restore.sh (a separate script sharing the same install layout)
+# also passes resolved -f flags to `docker compose down` on layered installs.
+RESTORE_SCRIPT="$ROOT_DIR/ods-restore.sh"
+if [[ -f "$RESTORE_SCRIPT" ]]; then
+    RESTORE_DIR="$TMP_DIR/ods-restore-target"
+    mkdir -p "$RESTORE_DIR/lib"
+    # Strip the trailing `main "$@"` so we can source stop_containers alone.
+    sed -e 's|^main "\$@"$|:|' "$RESTORE_SCRIPT" > "$RESTORE_DIR/ods-restore.sh"
+    chmod +x "$RESTORE_DIR/ods-restore.sh"
+    # ods-restore.sh sources lib/rsync.sh — provide a no-op stub.
+    if [[ -f "$ROOT_DIR/lib/rsync.sh" ]]; then
+        cp "$ROOT_DIR/lib/rsync.sh" "$RESTORE_DIR/lib/rsync.sh"
+    else
+        cat > "$RESTORE_DIR/lib/rsync.sh" <<'EOF'
+rsync_with_progress() { cp -r "$1" "$2"; }
+EOF
+    fi
+
+    cat > "$RESTORE_DIR/.env" <<'EOF'
+GPU_BACKEND=nvidia
+GPU_COUNT=1
+TIER=1
+ODS_MODE=local
+EOF
+    cat > "$RESTORE_DIR/docker-compose.base.yml" <<'EOF'
+services:
+  dashboard-api:
+    image: example/dashboard-api:test
+EOF
+    cat > "$RESTORE_DIR/docker-compose.nvidia.yml" <<'EOF'
+services:
+  llama-server:
+    image: example/llama-nvidia:test
+EOF
+    printf '%s\n' '-f docker-compose.base.yml -f docker-compose.nvidia.yml' \
+        > "$RESTORE_DIR/.compose-flags"
+    [[ ! -f "$RESTORE_DIR/docker-compose.yml" ]] \
+        || fail "test setup left a stray docker-compose.yml in restore dir"
+
+    # Stub docker again with a fresh log. compose ls must report a project
+    # matching basename($RESTORE_DIR) so stop_containers doesn't early-return.
+    RESTORE_DOCKER_LOG="$TMP_DIR/docker-restore-args.log"
+    RESTORE_PROJECT_BASENAME="$(basename "$RESTORE_DIR")"
+    export RESTORE_DOCKER_LOG RESTORE_PROJECT_BASENAME
+    cat > "$BIN_DIR/docker" <<'SH'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${RESTORE_DOCKER_LOG:?}"
+
+if [[ "${1:-}" == "info" ]]; then exit 0; fi
+if [[ "${1:-}" == "compose" && "${2:-}" == "version" ]]; then exit 0; fi
+
+if [[ "${1:-}" == "compose" ]]; then shift; fi
+
+args=("$@")
+for ((i = 0; i < ${#args[@]}; i++)); do
+    if [[ "${args[$i]}" == "ls" ]]; then
+        printf '%s\n' "${RESTORE_PROJECT_BASENAME}"
+        exit 0
+    fi
+done
+
+exit 0
+SH
+    chmod +x "$BIN_DIR/docker"
+
+    : > "$RESTORE_DOCKER_LOG"
+    # Drive stop_containers directly by sourcing the script's helpers.
+    # We can't just run the script because it needs a real backup archive;
+    # sourcing lets us call stop_containers() in isolation.
+    (
+        cd "$RESTORE_DIR"
+        export ODS_DIR="$RESTORE_DIR"
+        export PATH="$BIN_DIR:$PATH"
+        # main "$@" was sed'd out above so sourcing only loads functions.
+        # shellcheck disable=SC1091
+        source "$RESTORE_DIR/ods-restore.sh"
+        stop_containers
+    ) > "$TMP_DIR/restore-stop.out" 2>&1 || {
+        cat "$TMP_DIR/restore-stop.out"
+        fail "ods-restore.sh stop_containers exited non-zero"
+    }
+
+    if ! grep -qE '^compose (.* )?-f docker-compose\.base\.yml -f docker-compose\.nvidia\.yml down( |$)' "$RESTORE_DOCKER_LOG"; then
+        echo "=== docker-restore-args.log ==="
+        cat "$RESTORE_DOCKER_LOG"
+        fail "ods-restore.sh stop_containers did not pass resolved -f flags to docker compose down"
+    fi
+    pass "ods-restore.sh stop_containers uses resolved -f flags on layered installs"
+
+    if grep -qE '^compose down( |$)' "$RESTORE_DOCKER_LOG"; then
+        echo "=== docker-restore-args.log ==="
+        cat "$RESTORE_DOCKER_LOG"
+        fail "ods-restore.sh stop_containers invoked bare 'docker compose down' — regression"
+    fi
+    pass "ods-restore.sh stop_containers did not fall back to bare compose down"
+fi
+
+echo ""
+echo "All rollback layered-compose checks passed."


### PR DESCRIPTION
**Summary**

Fix ods-update.sh rollback (and ods-restore.sh stop_containers) invoking docker compose down / up -d with no -f flags. On ODS's layered installs there is no top-level docker-compose.yml, so both bare calls failed with no configuration file provided: not found.

**ods-update.sh cmd_rollback:**
- Resolves the current stack's -f flags before down (so services actually stop).
- Invalidates the .compose-flags cache after restore (the cache is not part of the snapshot and would pin the pre-restore overlay).
- Re-resolves after restore so up -d uses the restored .env's backend — correctly handles the base+nvidia → base+cpu case from the issue.
- Fails loudly rather than silently starting with the wrong stack when nothing resolves post-restore.

ods-restore.sh gets the same class of fix: a resolve_compose_flags helper (matching the ods-uninstall.sh pattern), layered flags in stop_containers, and a corrected "Next steps" hint that no longer prints a bare docker compose up -d.


**Release Lane**

- [x] Stable hotfix targeting release/2.5.x
- [ ] Mainline change targeting main
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

**Stable hotfix reason:**

Any current-stable user on a layered install (which is every non-legacy install
— ODS does not ship a top-level docker-compose.yml) hits "no configuration file
provided: not found" the moment they run `ods-update.sh rollback` or
`ods-restore.sh -s`. Rollback is a recovery path, so the failure lands exactly
when the user is already trying to recover from something else. Behavior-
preserving on installs that do have a plain docker-compose.yml.

**Changed Surface**

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

**Risk And Validation**

- Risk level: Medium — lifecycle command touching a recovery path; behavior on plain-compose installs is preserved by fallbacks; on layered installs the change is what makes the command work at all.
- Validation run:
  - [x] git diff --check
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [x] Extension audit / compose validation (via new hermetic test — stubbed docker CLI records exact args)
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting release/2.5.x
  - [ ] Not required because:

**Commands/results:**

$ bash -n ods/ods-update.sh ods/ods-restore.sh \
        ods/scripts/release-gate.sh \
        ods/tests/test-ods-update-rollback-layered-compose.sh
# all files parse OK

# New hermetic regression test
$ bash ods/tests/test-ods-update-rollback-layered-compose.sh
[PASS] rollback command completed successfully
[PASS] rollback down used the pre-restore stack flags (base+nvidia)
[PASS] rollback up -d used the restored stack flags (base+cpu)
[PASS] rollback did not fall back to bare compose commands
[PASS] .env restored from snapshot (GPU_BACKEND=cpu)
[PASS] .compose-flags cache invalidated after restore
[PASS] .version restored from snapshot (1.0.0)
[PASS] ods-restore.sh stop_containers uses resolved -f flags on layered installs
[PASS] ods-restore.sh stop_containers did not fall back to bare compose down

# Wired into:
#   ods/scripts/release-gate.sh
#   .github/workflows/test-linux.yml

**Operational Change Check**

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [x] This is an operational change and validation is intentionally deferred for: