### PR TITLE
test(dashboard-api): cover extension staleness and one-shot helpers

### DIFF
--- a/ods/extensions/services/dashboard-api/tests/test_extension_staleness.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extension_staleness.py
@@ -1,0 +1,83 @@
+"""Unit tests for two pure helpers in routers/extensions.py that were not
+directly covered:
+
+  * _is_stale — drives TTL-based cleanup of extension progress files.
+    Timezone handling matters: progress files are written with tz-aware
+    UTC ISO timestamps, and a malformed/naive timestamp must be treated as
+    stale so a corrupt file can never wedge the UI in a spinning state.
+
+  * _is_one_shot_extension — decides whether a catalog entry is a one-shot
+    CLI/setup tool, preferring the explicit ``startup_check`` flag and
+    falling back to ``port == 0`` for older catalogs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from routers.extensions import _is_stale, _is_one_shot_extension
+
+
+def _iso(delta_seconds: int) -> str:
+    """A tz-aware UTC ISO timestamp offset from now by *delta_seconds*."""
+    return (datetime.now(timezone.utc) + timedelta(seconds=delta_seconds)).isoformat()
+
+
+# ---------------------------------------------------------------------------
+# _is_stale
+# ---------------------------------------------------------------------------
+
+
+def test_old_timestamp_is_stale():
+    assert _is_stale(_iso(-7200), max_age_seconds=3600) is True
+
+
+def test_recent_timestamp_is_not_stale():
+    assert _is_stale(_iso(-60), max_age_seconds=3600) is False
+
+
+def test_future_timestamp_is_not_stale():
+    # Negative age (clock skew) must not read as stale.
+    assert _is_stale(_iso(120), max_age_seconds=3600) is False
+
+
+def test_zulu_suffix_is_accepted():
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    # A fresh 'Z'-suffixed timestamp parses and is not stale.
+    assert _is_stale(ts, max_age_seconds=3600) is False
+
+
+def test_naive_timestamp_is_treated_as_stale():
+    # No offset → subtraction against an aware "now" raises TypeError, which
+    # the helper maps to "stale" so a bad file is cleaned up rather than kept.
+    assert _is_stale("2026-01-01T00:00:00", max_age_seconds=3600) is True
+
+
+def test_malformed_timestamp_is_stale():
+    assert _is_stale("not-a-timestamp", max_age_seconds=3600) is True
+
+
+def test_empty_timestamp_is_stale():
+    assert _is_stale("", max_age_seconds=3600) is True
+
+
+# ---------------------------------------------------------------------------
+# _is_one_shot_extension
+# ---------------------------------------------------------------------------
+
+
+def test_startup_check_false_marks_one_shot():
+    assert _is_one_shot_extension({"startup_check": False, "port": 8080}) is True
+
+
+def test_startup_check_true_is_not_one_shot():
+    # Explicit flag wins even when port would otherwise suggest one-shot.
+    assert _is_one_shot_extension({"startup_check": True, "port": 0}) is False
+
+
+def test_port_zero_fallback_marks_one_shot():
+    assert _is_one_shot_extension({"port": 0}) is True
+
+
+def test_nonzero_port_without_flag_is_not_one_shot():
+    assert _is_one_shot_extension({"port": 8080}) is False


### PR DESCRIPTION
Add direct coverage for two previously-untested pure helpers in routers/extensions.py: _is_stale (TTL/timezone handling, including the Z-suffix, naive-timestamp, malformed and clock-skew cases that govern progress-file cleanup) and _is_one_shot_extension (explicit startup_check flag taking precedence over the legacy port==0 fallback).

## Summary

<!-- What changed, and why? -->

## AI Assistance

<!-- If AI tools helped draft code, docs, tests, reviews, or triage, say what they did. Use "None" when not applicable. The human author remains accountable for reading the diff, choosing the validation, and responding to review. -->

## Release Lane

<!-- Pick the lane before review. See ods/docs/RELEASE_CHANNELS.md. -->

- [ ] Stable hotfix targeting `release/2.5.x`
- [ ] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
<!-- If this targets release/2.5.x, explain the current-stable user problem it fixes. -->
```

## Changed Surface

<!-- Check every surface this PR can affect. -->

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

<!-- Use ods/docs/HIGH_RISK_CHANGE_MAP.md to pick the right level. -->

- Risk level: <!-- Low / Medium / High -->
- Validation run:
  - [ ] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [ ] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because: <!-- explain -->

Commands/results:

```text
<!-- paste the important commands and results -->
```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

<!-- Call out skipped/deferred lanes, known limitations, or rollback notes. -->
