### PR TITLE
fix(preflight): respect custom dashboard port

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -121,7 +121,9 @@ jobs:
           python3 tests/contracts/test-network-exposure-contracts.py
 
       - name: Linux install preflight tests
-        run: bash tests/test-linux-install-preflight.sh
+        run: |
+          bash tests/test-linux-install-preflight.sh
+          bash tests/test-preflight-dashboard-port.sh
 
       - name: Installer Simulation Harness
         run: |

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -30,6 +30,7 @@ test: ## Run unit and contract tests
 	@echo "=== Linux install preflight ==="
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
+	@bash tests/test-preflight-dashboard-port.sh
 	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh

--- a/ods/ods-preflight.sh
+++ b/ods/ods-preflight.sh
@@ -288,7 +288,8 @@ log ""
 
 # 8. Dashboard check (replaces LiveKit — more useful for all backends)
 log "[8/8] Checking Dashboard..."
-DASHBOARD_ENDPOINTS=("http://${SERVICE_HOST}:3001" "http://127.0.0.1:3001")
+DASHBOARD_PORT_RESOLVED="${DASHBOARD_PORT:-3001}"
+DASHBOARD_ENDPOINTS=("http://${SERVICE_HOST}:${DASHBOARD_PORT_RESOLVED}" "http://127.0.0.1:${DASHBOARD_PORT_RESOLVED}")
 DASHBOARD_FOUND=false
 
 for ENDPOINT in "${DASHBOARD_ENDPOINTS[@]}"; do
@@ -300,7 +301,7 @@ for ENDPOINT in "${DASHBOARD_ENDPOINTS[@]}"; do
 done
 
 if [ "$DASHBOARD_FOUND" = false ]; then
-    warn "Dashboard not found at port 3001"
+    warn "Dashboard not found at port ${DASHBOARD_PORT_RESOLVED}"
 fi
 log ""
 

--- a/ods/tests/test-preflight-dashboard-port.sh
+++ b/ods/tests/test-preflight-dashboard-port.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+# ============================================================================
+# Regression Test: Preflight Dashboard Port Resolution
+# ============================================================================
+# Proves that ods-preflight.sh respects the configured DASHBOARD_PORT.
+#
+# Hermetic test: does not require running Docker.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFLIGHT="$ROOT_DIR/ods-preflight.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+echo "Running Preflight Dashboard Port Regression Test..."
+
+# Create a temporary directory for stubs
+STUB_DIR=$(mktemp -d)
+export STUB_DIR
+trap 'rm -rf "$STUB_DIR"' EXIT
+
+# Write stub curl to intercept requested URLs
+cat > "$STUB_DIR/curl" << 'EOF'
+#!/bin/bash
+# Append all arguments to a log file in the stub directory
+echo "$@" >> "$STUB_DIR/curl_calls.log"
+# Return failure so the check continues to try other endpoints / doesn't pass prematurely
+exit 1
+EOF
+chmod +x "$STUB_DIR/curl"
+
+# Prepend stub directory to PATH so our fake curl is used
+export PATH="$STUB_DIR:$PATH"
+
+# Run ods-preflight.sh with a custom DASHBOARD_PORT override
+export DASHBOARD_PORT=4500
+export SERVICE_HOST=localhost
+
+echo "Executing preflight check..."
+set +e
+bash "$PREFLIGHT" > "$STUB_DIR/preflight.log" 2>&1
+preflight_status=$?
+set -e
+
+# Verify what URLs were requested by curl
+LOG_FILE="$STUB_DIR/curl_calls.log"
+if [[ ! -f "$LOG_FILE" ]]; then
+    echo -e "${RED}FAIL:${NC} curl was not called by the preflight script."
+    echo "Preflight exit status: $preflight_status"
+    echo "Preflight log:"
+    cat "$STUB_DIR/preflight.log"
+    exit 1
+fi
+
+echo "Captured curl probe arguments:"
+cat "$LOG_FILE"
+
+# Track failures
+FAILED_ASSERTION=false
+
+# 1. Assert http://localhost:4500 was probed
+if ! grep -q -F "http://localhost:4500" "$LOG_FILE"; then
+    echo -e "${RED}FAIL:${NC} Expected probe http://localhost:4500 was missing."
+    FAILED_ASSERTION=true
+fi
+
+# 2. Assert http://127.0.0.1:4500 was probed
+if ! grep -q -F "http://127.0.0.1:4500" "$LOG_FILE"; then
+    echo -e "${RED}FAIL:${NC} Expected probe http://127.0.0.1:4500 was missing."
+    FAILED_ASSERTION=true
+fi
+
+# 3. Assert http://localhost:3001 was NOT probed
+if grep -q -F "http://localhost:3001" "$LOG_FILE"; then
+    echo -e "${RED}FAIL:${NC} Stale Dashboard probe http://localhost:3001 was found."
+    FAILED_ASSERTION=true
+fi
+
+# 4. Assert http://127.0.0.1:3001 was NOT probed
+if grep -q -F "http://127.0.0.1:3001" "$LOG_FILE"; then
+    echo -e "${RED}FAIL:${NC} Stale Dashboard probe http://127.0.0.1:3001 was found."
+    FAILED_ASSERTION=true
+fi
+
+if [ "$FAILED_ASSERTION" = true ]; then
+    echo "Preflight exit status: $preflight_status"
+    exit 1
+else
+    echo -e "${GREEN}SUCCESS:${NC} Dashboard probe respected DASHBOARD_PORT=4500 and did not probe default port 3001."
+    exit 0
+fi


### PR DESCRIPTION
## Summary

Fixes the Dashboard check in `ods-preflight.sh` so it respects the configured `DASHBOARD_PORT` instead of always probing the default port `3001`.

The preflight script already loads `.env`, but the Dashboard probe constructed its endpoints with a hardcoded port. This caused a healthy Dashboard running on a custom external port to be reported as unavailable.

The check now resolves `DASHBOARD_PORT` with the existing `3001` default and uses the resolved value for both endpoint probes and diagnostic output.

Adds a behavioral regression test that stubs `curl` and verifies both Dashboard endpoints use the configured custom port without probing the stale default port.

Fixes #1767 

## AI Assistance

AI tools assisted with configuration-path auditing, reproduction design, edge-case review, and drafting the regression-test approach.

I reviewed the implementation and diff, reproduced the failure against the pre-fix script, selected the validation scope, and verified the final behavior locally.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A — this PR targets main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because: N/A

Commands/results:

```text
bash ods/tests/test-preflight-dashboard-port.sh
PASS — Dashboard probe respected DASHBOARD_PORT=4500 and did not probe default port 3001.

bash ods/tests/test-preflight.sh
PASS

bash -n ods/ods-preflight.sh ods/tests/test-preflight-dashboard-port.sh
PASS

shellcheck ods/ods-preflight.sh ods/tests/test-preflight-dashboard-port.sh
PASS

git diff --check
PASS

make -C ods test
PASS
```

The behavioral regression was also verified against the pre-fix `ods-preflight.sh`. Before the fix, the Dashboard probe used:

```text
http://localhost:3001
http://127.0.0.1:3001
```

instead of the configured `DASHBOARD_PORT=4500`.

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

This change is limited to the standalone preflight Dashboard availability diagnostic.

`DASHBOARD_PORT` is the configurable external port for the Dashboard UI and defaults to `3001`. `DASHBOARD_API_PORT` controls the separate Dashboard API service on default port `3002` and is not changed by this PR.

The regression test is hermetic and does not require Docker. It intercepts `curl` calls and requires both `http://localhost:4500` and `http://127.0.0.1:4500` to be probed when `DASHBOARD_PORT=4500`, while explicitly rejecting stale Dashboard probes on port `3001`.