### PR TITLE
fix(windows): mask all password/salt vars in 'ods.ps1 config show'

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1263,7 +1263,7 @@ function Invoke-ConfigShow {
     Get-Content $envFile | ForEach-Object {
         $line = $_.Trim()
         if ($line -match "^#" -or $line -eq "") { return }
-        if ($line -match "(SECRET|PASS|TOKEN|KEY)=") {
+        if ($line -match "^[^=]*(SECRET|PASS|TOKEN|KEY|SALT)[^=]*=") {
             $key = ($line -split "=")[0]
             Write-Host "  $key=***" -ForegroundColor DarkGray
         } else {


### PR DESCRIPTION
## Summary

`.\ods.ps1 config show` promises "secrets masked" but leaked `OPENCODE_SERVER_PASSWORD`, `LANGFUSE_DB_PASSWORD`, `LANGFUSE_CLICKHOUSE_PASSWORD`, `LANGFUSE_REDIS_PASSWORD`, `LANGFUSE_INIT_USER_PASSWORD` and `LANGFUSE_SALT` in plaintext.

The regex `(SECRET|PASS|TOKEN|KEY)=` only matched when the keyword sat immediately before `=`. Now the keyword is matched anywhere in the variable name, and `SALT` is added to the list.

Fixes #1769

## Test

Verified against a fresh v2.5.3 install `.env` on Windows 11: all `*PASSWORD*`, `*SALT*`, `*SECRET*`, `*KEY*`, `*TOKEN*`, `*PASS*` variables mask; non-secret vars (`WEBUI_PORT`, `TIMEZONE`, `MODEL_PROFILE`, ...) stay visible.
