### PR TITLE
fix(windows): abort installer when a phase hits a fatal error (exit 1 in dot-sourced phases is a no-op)

### DIFF
--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -191,6 +191,11 @@ Write-ODSBanner
 #  Phase 06 → $envResult (SearxngSecret, OpenclawToken)
 #  Phase 07 → (no output -- tools installed to $env:USERPROFILE)
 
+# Phases signal a fatal, already-explained failure by throwing the
+# ODS_INSTALL_ABORTED sentinel. `exit 1` inside a dot-sourced file does NOT
+# stop this orchestrator (PowerShell resumes at the next statement), which
+# previously let later phases run against half-initialized state.
+try {
 . (Join-Path $PhasesDir "01-preflight.ps1")
 . (Join-Path $PhasesDir "02-detection.ps1")
 . (Join-Path $PhasesDir "03-features.ps1")
@@ -210,6 +215,10 @@ if ($gpuInfo.Backend -eq "amd") {
 }
 . (Join-Path $PhasesDir "06-directories.ps1")
 . (Join-Path $PhasesDir "07-devtools.ps1")
+} catch {
+    if ($_.FullyQualifiedErrorId -eq "ODS_INSTALL_ABORTED") { exit 1 }
+    throw
+}
 
 # ============================================================================
 # PHASE 8 -- LAUNCH (download model, start Docker services)

--- a/ods/installers/windows/phases/01-preflight.ps1
+++ b/ods/installers/windows/phases/01-preflight.ps1
@@ -17,7 +17,8 @@
 #
 # Modder notes:
 #   Add new pre-flight checks (e.g., minimum Windows build) here.
-#   All fatal exits use `exit 1`. Non-fatal issues use Write-AIWarn.
+#   All fatal exits use `throw "ODS_INSTALL_ABORTED"` (caught by the
+#   orchestrator, which exits 1). Non-fatal issues use Write-AIWarn.
 # ============================================================================
 
 Write-Phase -Phase 1 -Total 13 -Name "PRE-FLIGHT CHECKS" -Estimate "~30 seconds"
@@ -50,7 +51,7 @@ Write-InfoBox "PowerShell:" "$($_psVer.Version)"
 if (-not $_psVer.Sufficient) {
     Write-AIError "PowerShell 5.1 or later is required."
     Write-AI "  Download: https://github.com/PowerShell/PowerShell/releases"
-    exit 1
+    throw "ODS_INSTALL_ABORTED"
 }
 Write-AISuccess "PowerShell $($_psVer.Version) OK"
 
@@ -61,7 +62,7 @@ try {
     if ($_build -lt 18362) {
         Write-AIError "Windows 10 build 18362 (version 1903) or later is required for WSL2."
         Write-AI "  Your build: $_build. Update Windows and re-run."
-        exit 1
+        throw "ODS_INSTALL_ABORTED"
     }
     $_winVer = [System.Environment]::OSVersion.Version
     Write-AISuccess "Windows $($_winVer.Major).$($_winVer.Minor) (build $_build) OK"
@@ -89,7 +90,7 @@ if (-not $preflight_docker.Installed) {
     Write-AIError "Docker Desktop is not installed."
     Write-AI "  Download: https://docs.docker.com/desktop/install/windows-install/"
     Write-AI "  After installing, enable WSL2: Docker Desktop > Settings > General > Use WSL 2 based engine"
-    exit 1
+    throw "ODS_INSTALL_ABORTED"
 }
 Write-AISuccess "Docker CLI found"
 
@@ -97,14 +98,14 @@ if (-not $preflight_docker.Running) {
     Write-AIError "Docker Desktop is not running."
     Write-AI "  Start it from the Start Menu, then re-run this installer."
     Write-Host "  & 'C:\Program Files\Docker\Docker\Docker Desktop.exe'" -ForegroundColor Cyan
-    exit 1
+    throw "ODS_INSTALL_ABORTED"
 }
 Write-AISuccess "Docker Desktop running (v$($preflight_docker.Version))"
 
 if (-not $preflight_docker.WSL2Backend) {
     Write-AIWarn "WSL2 backend not detected. GPU passthrough requires WSL2."
     Write-AI "  Enable: Docker Desktop > Settings > General > Use WSL 2 based engine"
-    if (-not $force) { exit 1 }
+    if (-not $force) { throw "ODS_INSTALL_ABORTED" }
     Write-AIWarn "--Force specified, continuing without confirmed WSL2 backend."
 }
 
@@ -151,7 +152,7 @@ if ($_fsFatal) {
     Write-AIError "permissions. $_fsType cannot represent per-user permissions,"
     Write-AIError "which would leave secrets readable by every account on this machine."
     Write-AI "  Pick a path on an NTFS/ReFS volume (e.g. C:\Users\<you>\ods) and re-run."
-    exit 1
+    throw "ODS_INSTALL_ABORTED"
 }
 Write-AISuccess "Filesystem supports POSIX-style permissions"
 
@@ -282,7 +283,7 @@ if (-not $_disk.Sufficient) {
     }
     Write-AI "  Free up space on $($_disk.Drive), or rerun from the source checkout with:"
     Write-AI "  .\install.ps1 -InstallDir $_installDirHint"
-    exit 1
+    throw "ODS_INSTALL_ABORTED"
 }
 Write-AISuccess "Disk space OK ($($_disk.FreeGB) GB free)"
 
@@ -294,7 +295,7 @@ if (-not (Test-Path $_composeBase)) {
     Write-AI "  Make sure you are running this installer from the ODS clone:"
     Write-AI "  git clone https://github.com/Osmantic/ODS.git"
     Write-AI "  cd ODS && .\install.ps1"
-    exit 1
+    throw "ODS_INSTALL_ABORTED"
 }
 Write-AISuccess "Source tree OK"
 

--- a/ods/installers/windows/phases/01-preflight.ps1
+++ b/ods/installers/windows/phases/01-preflight.ps1
@@ -67,6 +67,7 @@ try {
     $_winVer = [System.Environment]::OSVersion.Version
     Write-AISuccess "Windows $($_winVer.Major).$($_winVer.Minor) (build $_build) OK"
 } catch {
+    if ($_.FullyQualifiedErrorId -eq "ODS_INSTALL_ABORTED") { throw }
     Write-AIWarn "Could not determine Windows build -- continuing"
 }
 

--- a/ods/installers/windows/phases/02-detection.ps1
+++ b/ods/installers/windows/phases/02-detection.ps1
@@ -49,7 +49,7 @@ if ($gpuInfo.Backend -eq "nvidia") {
         Write-AIError "NVIDIA driver $($gpuInfo.DriverVersion) is below the required minimum ($($script:MIN_NVIDIA_DRIVER))."
         Write-AI "  Update your driver: https://www.nvidia.com/Download/index.aspx"
         Write-AI "  After updating, re-run this installer."
-        if (-not $force) { exit 1 }
+        if (-not $force) { throw "ODS_INSTALL_ABORTED" }
         Write-AIWarn "--Force specified, continuing with outdated driver (may fail at inference)."
     } else {
         Write-AISuccess "NVIDIA driver $($gpuInfo.DriverVersion) OK (>= $($script:MIN_NVIDIA_DRIVER) required)"
@@ -165,7 +165,7 @@ if (-not $_tierDisk.Sufficient) {
     Write-AI "  .\install.ps1 -InstallDir $_installDirHint"
     if (-not $force) {
         Write-AIError "Insufficient disk space. Free up space and re-run, or use --Force to override."
-        exit 1
+        throw "ODS_INSTALL_ABORTED"
     }
     Write-AIWarn "--Force specified, continuing with limited disk space."
 }

--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -287,7 +287,7 @@ if (-not $requirementsMet) {
         $continueChoice = Read-Host "  Continue anyway? [y/N]"
         if ($continueChoice -notmatch "^[yY]") {
             Write-AI "Resolve the issues above and re-run the installer."
-            exit 1
+            throw "ODS_INSTALL_ABORTED"
         }
     }
 } else {

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -146,7 +146,7 @@ if ($sourceRoot -ne $installDir) {
     if ($LASTEXITCODE -gt 7) {
         Write-AIError "File copy failed (robocopy exit code: $LASTEXITCODE)."
         Write-AI "  Try re-running with --Force or check that $installDir is writable."
-        exit 1
+        throw "ODS_INSTALL_ABORTED"
     }
     Write-AISuccess "Source files installed to $installDir"
 } else {
@@ -325,7 +325,7 @@ if ($_missingKeys.Count -gt 0) {
     Write-AIError ".env is missing required keys: $($_missingKeys -join ', ')"
     Write-AI "  This will cause docker compose to fail. The .env file may be corrupted."
     Write-AI "  Try deleting $(Join-Path $installDir '.env') and re-running the installer."
-    exit 1
+    throw "ODS_INSTALL_ABORTED"
 }
 Write-AISuccess "Verified .env contains all required secrets"
 
@@ -539,7 +539,7 @@ if ($enableHermes) {
     $_hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
     if (-not (Test-Path $_hermesTemplate)) {
         Write-AIError "Missing Hermes config template at $_hermesTemplate"
-        exit 1
+        throw "ODS_INSTALL_ABORTED"
     }
     if (-not (Test-Path $_hermesLive)) {
         Copy-Item -Path $_hermesTemplate -Destination $_hermesLive -Force
@@ -549,7 +549,7 @@ if ($enableHermes) {
     $_patchedHermesLive = Update-HermesConfigFile -Path $_hermesLive -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext) -RequestTimeoutSeconds $_hermesRequestTimeout -LemonadeCompact:($gpuInfo.Backend -eq "amd")
     if (-not ($_patchedHermesTemplate -and $_patchedHermesLive)) {
         Write-AIError "Failed to patch Hermes config for Windows runtime (model=$_hermesModel, base_url=$_hermesBaseUrl)"
-        exit 1
+        throw "ODS_INSTALL_ABORTED"
     }
     Invoke-HermesSoulRefresh -InstallRoot $installDir
     Write-AISuccess "Patched Hermes config (model=$_hermesModel, context=$($tierConfig.MaxContext), request_timeout=${_hermesRequestTimeout}s)"
@@ -594,7 +594,7 @@ if ($enableOpenClaw) {
             }
         } else {
             Write-AIError "Missing OpenClaw config $openClawConfig and no fallback present in repo. This is a packaging bug; please re-clone or report."
-            exit 1
+            throw "ODS_INSTALL_ABORTED"
         }
     }
 }

--- a/ods/tests/test-windows-phase-abort.sh
+++ b/ods/tests/test-windows-phase-abort.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS Windows installer phase-abort sentinel tests
+#
+# Verifies the ODS_INSTALL_ABORTED contract for dot-sourced phases:
+#   1. Phase-local broad catches must rethrow the sentinel, not swallow it.
+#   2. The orchestrator stops (exit 1) before running the next phase when a
+#      phase throws the sentinel from inside a local try/catch.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+PREFLIGHT="$ROOT_DIR/installers/windows/phases/01-preflight.ps1"
+ORCHESTRATOR="$ROOT_DIR/installers/windows/install-windows.ps1"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASS=0
+FAIL=0
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; PASS=$((PASS + 1)); }
+fail() { echo -e "  ${RED}FAIL${NC} $1"; FAIL=$((FAIL + 1)); }
+
+check() {
+    local pattern="$1" file="$2" label="$3"
+    if grep -Fq -- "$pattern" "$file"; then
+        pass "$label"
+    else
+        fail "$label"
+    fi
+}
+
+echo ""
+echo "=== Windows installer phase-abort sentinel tests ==="
+echo ""
+
+# ── Static contract checks ───────────────────────────────────────────────────
+check 'if ($_.FullyQualifiedErrorId -eq "ODS_INSTALL_ABORTED") { throw }' "$PREFLIGHT" \
+    "preflight Windows-build catch rethrows abort sentinel"
+check 'if ($_.FullyQualifiedErrorId -eq "ODS_INSTALL_ABORTED") { exit 1 }' "$ORCHESTRATOR" \
+    "orchestrator catches sentinel and exits 1"
+
+# ── Behavioral check: sentinel from a local try must stop the orchestrator ──
+PS_BIN="powershell.exe"
+if ! command -v "$PS_BIN" >/dev/null; then
+    PS_BIN="pwsh"
+fi
+
+if command -v "$PS_BIN" >/dev/null; then
+    TMPDIR_TEST="$(mktemp -d)"
+    trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+    cat > "$TMPDIR_TEST/phase-fatal.ps1" <<'EOF'
+# Mirrors the 01-preflight.ps1 shape: fatal throw inside a broad local try.
+try {
+    throw "ODS_INSTALL_ABORTED"
+} catch {
+    if ($_.FullyQualifiedErrorId -eq "ODS_INSTALL_ABORTED") { throw }
+    Write-Host "probe failed -- continuing"
+}
+EOF
+
+    cat > "$TMPDIR_TEST/phase-next.ps1" <<'EOF'
+Set-Content -Path (Join-Path $PSScriptRoot "next-phase-ran.marker") -Value "ran"
+EOF
+
+    cat > "$TMPDIR_TEST/orchestrator.ps1" <<'EOF'
+# Mirrors the install-windows.ps1 phase loop.
+$ErrorActionPreference = "Stop"
+try {
+    . (Join-Path $PSScriptRoot "phase-fatal.ps1")
+    . (Join-Path $PSScriptRoot "phase-next.ps1")
+} catch {
+    if ($_.FullyQualifiedErrorId -eq "ODS_INSTALL_ABORTED") { exit 1 }
+    throw
+}
+exit 0
+EOF
+
+    set +e
+    "$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$TMPDIR_TEST/orchestrator.ps1"
+    rc=$?
+    set -e
+
+    if [[ $rc -eq 1 ]]; then
+        pass "orchestrator exits 1 on sentinel thrown from local try"
+    else
+        fail "orchestrator exits 1 on sentinel thrown from local try (got exit $rc)"
+    fi
+
+    if [[ ! -f "$TMPDIR_TEST/next-phase-ran.marker" ]]; then
+        pass "next phase does not run after sentinel"
+    else
+        fail "next phase does not run after sentinel"
+    fi
+else
+    echo "  SKIP behavioral checks (no PowerShell available)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
## Summary

Fixes #1771.

`exit 1` inside a dot-sourced phase script does **not** stop the calling orchestrator — PowerShell resumes at the next statement. Verified with a minimal repro on PowerShell 5.1: a dot-sourced file executing `exit 1` returns control to the caller, which continues and exits 0. This affects **all 16 fatal-exit sites** across phases 01/02/04/06, not just the driver check.

Observed effect: with an outdated NVIDIA driver, Phase 2 prints the fatal driver error, then Phase 3 runs anyway and crashes with `You cannot call a method on a null-valued expression` on the never-assigned `$tierConfig`.

## Change

- Phases 01/02/04/06: replace every fatal `exit 1` with `throw "ODS_INSTALL_ABORTED"` (the phase has already printed its guidance via `Write-AIError` at these sites).
- `install-windows.ps1`: wrap the phase dot-source block in `try/catch`; on the sentinel, `exit 1` cleanly with no stack trace. Any other exception rethrows unchanged.
- Updated the modder note in `01-preflight.ps1` accordingly.

No behavior change for `-Force` paths or successful installs.

## Test

- `[System.Management.Automation.PSParser]::Tokenize` clean on all 5 edited files (0 syntax errors).
- Sentinel pattern verified standalone: fatal phase → orchestrator stops before next phase, exit code 1, no PowerShell error spam.
- Real-hardware repro of the original bug (GTX 1650 + driver 516.40, v2.5.3): error then Phase 3 crash — with this change the install stops at the driver message.
