### PR TITLE
feat(cloud): add OpenRouter provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ After install, open **http://localhost:3000** and start chatting.
 
 > **API endpoint:** Linux Docker installs expose llama-server on **http://localhost:11434** by default (`OLLAMA_PORT`) while containers use `llama-server:8080`. macOS native Metal and Windows native/Lemonade paths use **http://localhost:8080** unless overridden. Open WebUI stays on **http://localhost:3000**.
 
-> **No GPU?** ODS also runs in cloud mode — same full stack, powered by OpenAI/Anthropic/Together APIs instead of local inference:
+> **No GPU?** ODS also runs in cloud mode — same full stack, powered by OpenAI, Anthropic, OpenRouter, MiniMax, or other LiteLLM-backed APIs instead of local inference:
 > ```bash
 > ./install.sh --cloud
 > ```

--- a/ods/.env.example
+++ b/ods/.env.example
@@ -118,6 +118,11 @@ ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 TOGETHER_API_KEY=
 MINIMAX_API_KEY=
+OPENROUTER_API_KEY=
+OPENROUTER_API_BASE=
+OPENROUTER_MODEL=openrouter/auto
+OPENROUTER_SITE_URL=
+OPENROUTER_APP_NAME=ODS
 
 # ═══════════════════════════════════════════════════════════════════
 # LLM Settings (llama-server)

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -38,7 +38,7 @@
     },
     "LLM_BACKEND": {
       "type": "string",
-      "description": "Inference backend: llama-server or lemonade",
+      "description": "Inference backend: llama-server, litellm, or lemonade",
       "default": "llama-server"
     },
     "MODEL_PROFILE": {
@@ -168,6 +168,32 @@
       "description": "MiniMax API key for MiniMax models (cloud/hybrid modes)",
       "secret": true,
       "minLength": 10
+    },
+    "OPENROUTER_API_KEY": {
+      "type": "string",
+      "description": "OpenRouter API key for cloud/hybrid modes",
+      "secret": true,
+      "minLength": 10
+    },
+    "OPENROUTER_API_BASE": {
+      "type": "string",
+      "description": "Optional OpenRouter-compatible API base URL. Leave empty for https://openrouter.ai/api/v1.",
+      "format": "uri"
+    },
+    "OPENROUTER_MODEL": {
+      "type": "string",
+      "description": "OpenRouter model slug used by the dynamic LiteLLM alias 'openrouter'. Defaults to openrouter/auto.",
+      "default": "openrouter/auto"
+    },
+    "OPENROUTER_SITE_URL": {
+      "type": "string",
+      "description": "Optional OpenRouter HTTP-Referer header for app attribution/ranking.",
+      "format": "uri"
+    },
+    "OPENROUTER_APP_NAME": {
+      "type": "string",
+      "description": "Optional OpenRouter X-Title header for app attribution.",
+      "default": "ODS"
     },
     "WEBUI_SECRET": {
       "type": "string",

--- a/ods/config/litellm/cloud.yaml
+++ b/ods/config/litellm/cloud.yaml
@@ -14,6 +14,16 @@ model_list:
       model: anthropic/claude-haiku-4-5-20251001
       api_key: os.environ/ANTHROPIC_API_KEY
 
+  - model_name: openrouter-auto
+    litellm_params:
+      model: openrouter/openrouter/auto
+      api_key: os.environ/OPENROUTER_API_KEY
+
+  - model_name: openrouter-free
+    litellm_params:
+      model: openrouter/openrouter/free
+      api_key: os.environ/OPENROUTER_API_KEY
+
   - model_name: minimax
     litellm_params:
       model: openai/MiniMax-M2.7

--- a/ods/docker-compose.cloud.yml
+++ b/ods/docker-compose.cloud.yml
@@ -9,3 +9,13 @@ services:
     profiles:
       - local-inference
     restart: "no"
+
+  open-webui:
+    environment:
+      OPENAI_API_KEY: "${LITELLM_KEY:-${OPENAI_API_KEY:-}}"
+
+  dashboard-api:
+    environment:
+      - ODS_TALK_VISION_URL=${ODS_TALK_VISION_URL:-http://litellm:4000/v1}
+      - ODS_TALK_VISION_KEY=${ODS_TALK_VISION_KEY:-${LITELLM_KEY:-}}
+      - ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-${LLM_MODEL:-default}}

--- a/ods/docs/MODE-SWITCH.md
+++ b/ods/docs/MODE-SWITCH.md
@@ -63,7 +63,7 @@ LLM requests routed through LiteLLM to cloud APIs.
 
 | Aspect | Details |
 |--------|---------|
-| **LLM** | Claude, GPT-4o, MiniMax via LiteLLM |
+| **LLM** | Claude, GPT-4o, OpenRouter, MiniMax via LiteLLM |
 | **Cost** | ~$0.003-0.06/1K tokens |
 | **Requires** | Internet, API keys |
 | **GPU** | Not needed |
@@ -77,6 +77,25 @@ ods mode cloud
 ANTHROPIC_API_KEY=sk-ant-...
 OPENAI_API_KEY=sk-...
 ```
+
+For OpenRouter-only installs, set the OpenRouter key instead:
+
+```bash
+OPENROUTER_API_KEY=sk-or-v1-...
+OPENROUTER_MODEL=openrouter/auto
+```
+
+Cloud mode exposes these LiteLLM model aliases by default:
+
+| Alias | Provider route | Notes |
+|-------|----------------|-------|
+| `default` | Anthropic Sonnet | Existing default alias for Anthropic-backed cloud installs |
+| `gpt4o` | OpenAI GPT-4o | Requires `OPENAI_API_KEY` |
+| `fast` | Anthropic Haiku | Requires `ANTHROPIC_API_KEY` |
+| `openrouter-auto` | OpenRouter Auto Router | Requires `OPENROUTER_API_KEY` |
+| `openrouter-free` | OpenRouter Free Router | Requires `OPENROUTER_API_KEY`; subject to OpenRouter limits/availability |
+| `openrouter` | `OPENROUTER_MODEL` | Dynamic alias rendered at LiteLLM start; defaults to `openrouter/auto` |
+| `minimax` / `minimax-fast` | MiniMax | Requires `MINIMAX_API_KEY` |
 
 ### Hybrid Mode
 Local llama-server as primary, cloud APIs as fallback via LiteLLM.
@@ -123,6 +142,11 @@ adding one-off installer or dashboard paths.
 | `OPENAI_API_KEY` | *(empty)* | OpenAI API key (cloud/hybrid) |
 | `TOGETHER_API_KEY` | *(empty)* | Together AI API key (optional) |
 | `MINIMAX_API_KEY` | *(empty)* | MiniMax API key (optional, cloud/hybrid) |
+| `OPENROUTER_API_KEY` | *(empty)* | OpenRouter API key (cloud/hybrid) |
+| `OPENROUTER_API_BASE` | *(empty)* | Optional OpenRouter-compatible API base override; leave empty for the hosted OpenRouter API |
+| `OPENROUTER_MODEL` | `openrouter/auto` | Model slug used by the dynamic `openrouter` LiteLLM alias |
+| `OPENROUTER_SITE_URL` | *(empty)* | Optional OpenRouter attribution header |
+| `OPENROUTER_APP_NAME` | `ODS` | Optional OpenRouter attribution header |
 
 ---
 
@@ -135,6 +159,18 @@ Install in cloud mode (skips GPU detection and model download):
 ```
 
 This sets `ODS_MODE=cloud`, `LLM_API_URL=http://litellm:4000`, and auto-enables the LiteLLM extension.
+
+For constrained hosts that should run Hermes through OpenRouter, a lightweight
+install can start with:
+
+```bash
+OPENROUTER_API_KEY=sk-or-v1-... ./install.sh --cloud --hermes --no-comfyui --no-voice --no-workflows --no-rag --no-langfuse
+```
+
+After the stack starts, select `openrouter`, `openrouter-auto`, or
+`openrouter-free` in the chat surface. If you change OpenRouter values from
+Settings, apply the returned LiteLLM restart plan so the generated proxy config
+is rebuilt.
 
 ---
 

--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -258,6 +258,10 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "llama-server"
     if key == "SEARXNG_URL":
         return "hermes"
+    if key.startswith("LITELLM_") or key.startswith("OPENROUTER_") or key in {
+        "ANTHROPIC_API_KEY", "OPENAI_API_KEY", "TOGETHER_API_KEY", "MINIMAX_API_KEY",
+    }:
+        return "litellm"
     if (
         key in _OPEN_WEBUI_APPLY_KEYS
         or key.startswith("WEBUI_")
@@ -269,8 +273,6 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "token-spy"
     if key in _PRIVACY_SHIELD_APPLY_KEYS or key.startswith("SHIELD_"):
         return "privacy-shield"
-    if key.startswith("LITELLM_"):
-        return "litellm"
     if key.startswith("LANGFUSE_"):
         return "langfuse"
     if key.startswith("N8N_"):

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -405,6 +405,52 @@ def test_settings_apply_plan_maps_agent_and_proxy_env_keys():
     assert plan["manualKeys"] == []
 
 
+def test_settings_apply_plan_maps_openrouter_env_keys_to_litellm():
+    from settings import _compute_env_apply_plan
+
+    previous = {
+        "OPENROUTER_API_KEY": "",
+        "OPENROUTER_MODEL": "openrouter/auto",
+        "OPENROUTER_SITE_URL": "",
+        "OPENROUTER_APP_NAME": "ODS",
+    }
+    updated = {
+        "OPENROUTER_API_KEY": "sk-or-v1-test",
+        "OPENROUTER_MODEL": "qwen/qwen3-235b-a22b:free",
+        "OPENROUTER_SITE_URL": "https://example.test",
+        "OPENROUTER_APP_NAME": "ODS Lab",
+    }
+
+    plan = _compute_env_apply_plan(previous, updated)
+
+    assert plan["status"] == "ready"
+    assert plan["services"] == ["litellm"]
+    assert plan["manualKeys"] == []
+
+
+def test_settings_apply_plan_maps_cloud_provider_keys_to_litellm():
+    from settings import _compute_env_apply_plan
+
+    previous = {
+        "ANTHROPIC_API_KEY": "sk-ant-old",
+        "OPENAI_API_KEY": "sk-old",
+        "TOGETHER_API_KEY": "",
+        "MINIMAX_API_KEY": "",
+    }
+    updated = {
+        "ANTHROPIC_API_KEY": "sk-ant-new",
+        "OPENAI_API_KEY": "sk-new",
+        "TOGETHER_API_KEY": "tog-new",
+        "MINIMAX_API_KEY": "mm-new",
+    }
+
+    plan = _compute_env_apply_plan(previous, updated)
+
+    assert plan["status"] == "ready"
+    assert plan["services"] == ["litellm"]
+    assert plan["manualKeys"] == []
+
+
 # --- Render round-trip fidelity ---
 
 
@@ -511,6 +557,7 @@ def test_render_env_preserves_commented_key_absent_from_values(commented_example
         "ANTHROPIC_API_KEY",
         "OPENAI_API_KEY",
         "TOGETHER_API_KEY",
+        "OPENROUTER_API_KEY",
         "LIVEKIT_API_KEY",
         "AUDIO_STT_OPENAI_API_KEY",
         "AUDIO_TTS_OPENAI_API_KEY",

--- a/ods/extensions/services/litellm/compose.yaml
+++ b/ods/extensions/services/litellm/compose.yaml
@@ -11,6 +11,13 @@ services:
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
       - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENROUTER_API_BASE=${OPENROUTER_API_BASE:-}
+      - OPENROUTER_MODEL=${OPENROUTER_MODEL:-openrouter/auto}
+      - OPENROUTER_SITE_URL=${OPENROUTER_SITE_URL:-}
+      - OPENROUTER_APP_NAME=${OPENROUTER_APP_NAME:-ODS}
+      - OR_SITE_URL=${OPENROUTER_SITE_URL:-}
+      - OR_APP_NAME=${OPENROUTER_APP_NAME:-ODS}
       - LANGFUSE_ENABLED=${LANGFUSE_ENABLED:-false}
     volumes:
       - ./config/litellm/${ODS_MODE:-local}.yaml:/app/config.yaml:ro,z
@@ -19,19 +26,43 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command:
       - |
-        if [ "$$LANGFUSE_ENABLED" = "true" ]; then
-          python3 -c "
+        python3 - <<'PY'
+        import os
         import yaml
+
+        def openrouter_litellm_model(raw):
+            model = (raw or "openrouter/auto").strip() or "openrouter/auto"
+            if model in {"openrouter/auto", "openrouter/free"}:
+                return f"openrouter/{model}"
+            if model.startswith("openrouter/"):
+                return model
+            return f"openrouter/{model}"
+
         with open('/app/config.yaml') as f:
             cfg = yaml.safe_load(f)
-        cfg.setdefault('litellm_settings', {})['success_callback'] = ['langfuse']
+
+        if os.environ.get("OPENROUTER_API_KEY"):
+            model_name = os.environ.get("OPENROUTER_MODEL_NAME", "openrouter")
+            model_list = cfg.setdefault("model_list", [])
+            model_list[:] = [
+                item for item in model_list
+                if item.get("model_name") != model_name
+            ]
+            params = {
+                "model": openrouter_litellm_model(os.environ.get("OPENROUTER_MODEL")),
+                "api_key": "os.environ/OPENROUTER_API_KEY",
+            }
+            if os.environ.get("OPENROUTER_API_BASE"):
+                params["api_base"] = os.environ["OPENROUTER_API_BASE"]
+            model_list.append({"model_name": model_name, "litellm_params": params})
+
+        if os.environ.get("LANGFUSE_ENABLED") == "true":
+            cfg.setdefault('litellm_settings', {})['success_callback'] = ['langfuse']
+
         with open('/tmp/config.yaml', 'w') as f:
             yaml.dump(cfg, f, default_flow_style=False)
-        "
-          exec litellm --config /tmp/config.yaml --port 4000
-        else
-          exec litellm --config /app/config.yaml --port 4000
-        fi
+        PY
+        exec litellm --config /tmp/config.yaml --port 4000
     deploy:
       resources:
         limits:

--- a/ods/install-core.sh
+++ b/ods/install-core.sh
@@ -189,6 +189,8 @@ Examples:
     $0 --tier 2 --voice          # Tier 2 with voice
     $0 --all --non-interactive   # Full stack, no prompts
     $0 --cloud                   # Cloud mode (no GPU needed, uses API keys)
+    OPENROUTER_API_KEY=sk-or-v1-... $0 --cloud
+                                  # Cloud mode through OpenRouter
     $0 --use-existing-lemonade   # Wrap an existing Lemonade SDK runtime
     $0 --offline --all           # Fully offline (M1 mode) with all services
     $0 --dry-run                 # Preview installation

--- a/ods/installers/macos/docker-compose.macos.cloud.yml
+++ b/ods/installers/macos/docker-compose.macos.cloud.yml
@@ -1,0 +1,18 @@
+# ODS -- macOS cloud overlay
+#
+# Cloud mode routes Open WebUI through LiteLLM and does not launch the native
+# Metal llama-server readiness sidecar used by docker-compose.macos.yml.
+
+services:
+  dashboard-api:
+    environment:
+      - OLLAMA_URL=${LLM_API_URL:-http://litellm:4000}
+      # gpu.py routes to get_gpu_info_apple() which reads HOST_* env vars.
+      # config.py defaults include 'apple' so all manifests are discovered.
+      - GPU_BACKEND=apple
+      # Static host hardware info written to .env by install-macos.sh (Phase 2).
+      - HOST_RAM_GB=${HOST_RAM_GB:-0}
+
+  open-webui:
+    environment:
+      OPENAI_API_BASE_URL: "${LLM_API_URL:-http://litellm:4000}/v1"

--- a/ods/installers/macos/docker-compose.macos.yml
+++ b/ods/installers/macos/docker-compose.macos.yml
@@ -46,7 +46,7 @@ services:
 
   dashboard-api:
     environment:
-      - OLLAMA_URL=http://host.docker.internal:8080
+      - OLLAMA_URL=${LLM_API_URL:-http://host.docker.internal:8080}
       - OLLAMA_HOST=host.docker.internal
       - OLLAMA_PORT=8080        # llama-server runs natively on macOS at this port
       # gpu.py routes to get_gpu_info_apple() which reads HOST_* env vars.
@@ -60,4 +60,4 @@ services:
       llama-server-ready:
         condition: service_healthy
     environment:
-      OPENAI_API_BASE_URL: "http://host.docker.internal:8080/v1"
+      OPENAI_API_BASE_URL: "${LLM_API_URL:-http://host.docker.internal:8080}/v1"

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1322,11 +1322,13 @@ else
     COMPOSE_FLAGS=("-f" "docker-compose.base.yml")
 
     if $CLOUD_MODE; then
-        # Cloud mode: disable llama-server container
-        COMPOSE_FLAGS+=("-f" "installers/macos/docker-compose.macos.yml")
+        # Cloud mode: disable llama-server container and route clients through LiteLLM.
+        COMPOSE_FLAGS+=("-f" "docker-compose.cloud.yml")
+        COMPOSE_FLAGS+=("-f" "installers/macos/docker-compose.macos.cloud.yml")
     else
         # Normal macOS mode: native llama-server
         COMPOSE_FLAGS+=("-f" "installers/macos/docker-compose.macos.yml")
+        COMPOSE_FLAGS+=("--profile" "local-inference")
     fi
 
     # Discover enabled extension compose fragments via manifests

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -148,6 +148,34 @@ detect_device_name() {
     sanitize_device_name "$raw"
 }
 
+is_cloud_litellm_alias() {
+    # Keep in sync with config/litellm/cloud.yaml plus the dynamic OpenRouter
+    # alias injected by extensions/services/litellm/compose.yaml.
+    case "${1:-}" in
+        default|gpt4o|fast|openrouter|openrouter-auto|openrouter-free|minimax|minimax-fast)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+select_cloud_llm_model() {
+    local candidate="${1:-}" previous_mode="${2:-}"
+    if [[ -n "$candidate" && "$candidate" != "anthropic/claude-sonnet-4-5-20250514" ]]; then
+        if [[ "$previous_mode" == "cloud" ]] || is_cloud_litellm_alias "$candidate"; then
+            printf '%s\n' "$candidate"
+            return
+        fi
+    fi
+    if [[ -n "${OPENROUTER_API_KEY:-}" && -z "${ANTHROPIC_API_KEY:-}" && -z "${OPENAI_API_KEY:-}" && -z "${MINIMAX_API_KEY:-}" ]]; then
+        printf 'openrouter\n'
+    else
+        printf 'default\n'
+    fi
+}
+
 # Detect system timezone (macOS-specific)
 detect_timezone() {
     local tz=""
@@ -275,6 +303,43 @@ generate_ods_env() {
                 upsert_env_value "$env_path" "HOST_LAN_IP" "$_host_lan_ip"
             fi
         fi
+
+        if [[ "${CLOUD_MODE:-false}" == "true" ]]; then
+            local _previous_ods_mode _cloud_llm_candidate _cloud_llm_model _cloud_litellm_key
+            _previous_ods_mode="$(read_env_value "$env_path" "ODS_MODE")"
+            _cloud_llm_candidate="${LLM_MODEL:-$(read_env_value "$env_path" "LLM_MODEL")}"
+            _cloud_llm_model="$(select_cloud_llm_model "$_cloud_llm_candidate" "$_previous_ods_mode")"
+            _cloud_litellm_key="${HERMES_LLM_API_KEY:-$(read_env_value "$env_path" "LITELLM_KEY")}"
+
+            upsert_env_value "$env_path" "ODS_MODE" "cloud"
+            upsert_env_value "$env_path" "LLM_BACKEND" "litellm"
+            upsert_env_value "$env_path" "LLM_API_URL" "http://litellm:4000"
+            upsert_env_value "$env_path" "ANTHROPIC_API_KEY" "${ANTHROPIC_API_KEY:-$(read_env_value "$env_path" "ANTHROPIC_API_KEY")}"
+            upsert_env_value "$env_path" "OPENAI_API_KEY" "${OPENAI_API_KEY:-$(read_env_value "$env_path" "OPENAI_API_KEY")}"
+            upsert_env_value "$env_path" "TOGETHER_API_KEY" "${TOGETHER_API_KEY:-$(read_env_value "$env_path" "TOGETHER_API_KEY")}"
+            upsert_env_value "$env_path" "MINIMAX_API_KEY" "${MINIMAX_API_KEY:-$(read_env_value "$env_path" "MINIMAX_API_KEY")}"
+            upsert_env_value "$env_path" "OPENROUTER_API_KEY" "${OPENROUTER_API_KEY:-$(read_env_value "$env_path" "OPENROUTER_API_KEY")}"
+            upsert_env_value "$env_path" "OPENROUTER_API_BASE" "${OPENROUTER_API_BASE:-$(read_env_value "$env_path" "OPENROUTER_API_BASE")}"
+            upsert_env_value "$env_path" "OPENROUTER_MODEL" "${OPENROUTER_MODEL:-$(read_env_value "$env_path" "OPENROUTER_MODEL")}"
+            upsert_env_value "$env_path" "OPENROUTER_SITE_URL" "${OPENROUTER_SITE_URL:-$(read_env_value "$env_path" "OPENROUTER_SITE_URL")}"
+            upsert_env_value "$env_path" "OPENROUTER_APP_NAME" "${OPENROUTER_APP_NAME:-$(read_env_value "$env_path" "OPENROUTER_APP_NAME")}"
+            if [[ -z "$(read_env_value "$env_path" "OPENROUTER_MODEL")" ]]; then
+                upsert_env_value "$env_path" "OPENROUTER_MODEL" "openrouter/auto"
+            fi
+            if [[ -z "$(read_env_value "$env_path" "OPENROUTER_APP_NAME")" ]]; then
+                upsert_env_value "$env_path" "OPENROUTER_APP_NAME" "ODS"
+            fi
+            upsert_env_value "$env_path" "LLM_MODEL" "$_cloud_llm_model"
+            upsert_env_value "$env_path" "MODEL_RECOMMENDED_MODEL" "$_cloud_llm_model"
+            upsert_env_value "$env_path" "MODEL_RECOMMENDATION_SOURCE" "cloud_provider_alias"
+            upsert_env_value "$env_path" "MODEL_RECOMMENDATION_POLICY" "litellm-cloud-provider"
+            upsert_env_value "$env_path" "MODEL_RECOMMENDATION_CONFIDENCE" "high"
+            upsert_env_value "$env_path" "MODEL_RECOMMENDATION_REASON" "Selected LiteLLM cloud alias ${_cloud_llm_model}; change LLM_MODEL or provider keys to use a different cloud route."
+            upsert_env_value "$env_path" "HERMES_LLM_BASE_URL" "http://litellm:4000/v1"
+            if [[ -n "$_cloud_litellm_key" ]]; then
+                upsert_env_value "$env_path" "HERMES_LLM_API_KEY" "$_cloud_litellm_key"
+            fi
+        fi
         return 0
     fi
 
@@ -345,8 +410,38 @@ generate_ods_env() {
     langfuse_init_project_id=$(new_secure_hex 16)
     local langfuse_init_user_password
     langfuse_init_user_password=$(new_secure_hex 16)
-    # macOS: llama-server runs natively, containers reach it via host.docker.internal
+    # macOS: local mode runs llama-server natively, containers reach it via
+    # host.docker.internal. Cloud mode routes every OpenAI-compatible client
+    # through the LiteLLM gateway, matching Linux/Windows provider mode.
+    local ods_mode_value="local"
+    local llm_backend_value="llama-server"
     local llm_api_url="http://host.docker.internal:8080"
+    local hermes_llm_base_url="http://host.docker.internal:8080/v1"
+    local hermes_llm_api_key="sk-ods-hermes-local"
+    if [[ "${CLOUD_MODE:-false}" == "true" ]]; then
+        ods_mode_value="cloud"
+        llm_backend_value="litellm"
+        llm_api_url="http://litellm:4000"
+        hermes_llm_base_url="http://litellm:4000/v1"
+        hermes_llm_api_key="${HERMES_LLM_API_KEY:-${litellm_key}}"
+        local cloud_llm_candidate="${LLM_MODEL:-}"
+        local previous_ods_mode=""
+        if [[ -f "$env_path" ]]; then
+            previous_ods_mode="$(read_env_value "$env_path" "ODS_MODE")"
+            if [[ "$previous_ods_mode" == "cloud" ]]; then
+                local previous_llm_model
+                previous_llm_model="$(read_env_value "$env_path" "LLM_MODEL")"
+                if [[ -n "$previous_llm_model" ]]; then
+                    cloud_llm_candidate="$previous_llm_model"
+                fi
+            fi
+        fi
+        LLM_MODEL="$(select_cloud_llm_model "$cloud_llm_candidate" "$previous_ods_mode")"
+        MODEL_RECOMMENDATION_SOURCE="${MODEL_RECOMMENDATION_SOURCE:-cloud_provider_alias}"
+        MODEL_RECOMMENDATION_POLICY="${MODEL_RECOMMENDATION_POLICY:-litellm-cloud-provider}"
+        MODEL_RECOMMENDATION_CONFIDENCE="${MODEL_RECOMMENDATION_CONFIDENCE:-high}"
+        MODEL_RECOMMENDATION_REASON="${MODEL_RECOMMENDATION_REASON:-Selected LiteLLM cloud alias ${LLM_MODEL}; change LLM_MODEL or provider keys to use a different cloud route.}"
+    fi
 
     # Host LAN IP — only populated when the operator has pre-set
     # BIND_ADDRESS=0.0.0.0 in the environment (macOS has no --lan flag).
@@ -381,14 +476,20 @@ ODS_DEVICE_NAME=${device_name}
 ODS_AGENT_HOST=${ODS_AGENT_HOST:-host.docker.internal}
 
 #=== LLM Backend Mode ===
-ODS_MODE=local
+ODS_MODE=${ods_mode_value}
+LLM_BACKEND=${llm_backend_value}
 LLM_API_URL=${llm_api_url}
 
 #=== Cloud API Keys ===
-ANTHROPIC_API_KEY=
-OPENAI_API_KEY=
-TOGETHER_API_KEY=
-MINIMAX_API_KEY=
+ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+OPENAI_API_KEY=${OPENAI_API_KEY:-}
+TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
+MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+OPENROUTER_API_BASE=${OPENROUTER_API_BASE:-}
+OPENROUTER_MODEL=${OPENROUTER_MODEL:-openrouter/auto}
+OPENROUTER_SITE_URL=${OPENROUTER_SITE_URL:-}
+OPENROUTER_APP_NAME=${OPENROUTER_APP_NAME:-ODS}
 
 #=== LLM Settings (llama-server -- native Metal) ===
 MODEL_PROFILE=${MODEL_PROFILE_REQUESTED:-${MODEL_PROFILE:-qwen}}
@@ -447,9 +548,10 @@ OPENCLAW_PORT=7860
 LANGFUSE_PORT=3006
 
 #=== Hermes Agent ===
-# macOS runs llama-server natively with Metal; containers reach it via host.docker.internal.
-HERMES_LLM_BASE_URL=http://host.docker.internal:8080/v1
-HERMES_LLM_API_KEY=sk-ods-hermes-local
+# Local macOS routes Hermes to the native Metal llama-server; cloud mode routes
+# Hermes through LiteLLM so OpenRouter/OpenAI/Anthropic provider aliases work.
+HERMES_LLM_BASE_URL=${hermes_llm_base_url}
+HERMES_LLM_API_KEY=${hermes_llm_api_key}
 HERMES_LANGUAGE=en
 HERMES_PROXY_PORT=9120
 HERMES_PROXY_UPSTREAM=ods-hermes:9119

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -278,6 +278,67 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         _env_get "$key" "$default"
     }
 
+    _phase06_is_cloud_litellm_alias() {
+        # Keep in sync with config/litellm/cloud.yaml plus the dynamic
+        # OpenRouter alias injected by extensions/services/litellm/compose.yaml.
+        case "${1:-}" in
+            default|gpt4o|fast|openrouter|openrouter-auto|openrouter-free|minimax|minimax-fast)
+                return 0
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    }
+
+    _phase06_select_cloud_llm_model() {
+        local candidate="${1:-}" previous_mode="${2:-}"
+        if [[ -n "$candidate" && "$candidate" != "anthropic/claude-sonnet-4-5-20250514" ]]; then
+            if [[ "$previous_mode" == "cloud" ]] || _phase06_is_cloud_litellm_alias "$candidate"; then
+                printf '%s\n' "$candidate"
+                return
+            fi
+        fi
+        if [[ -n "$OPENROUTER_API_KEY" && -z "$ANTHROPIC_API_KEY" && -z "$OPENAI_API_KEY" && -z "$MINIMAX_API_KEY" ]]; then
+            printf 'openrouter\n'
+        else
+            printf 'default\n'
+        fi
+    }
+
+    _phase06_select_llm_api_url() {
+        local ods_mode_value="${1:-}" default_url="${2:-}" existing_url="${3:-}"
+        if [[ "$ods_mode_value" == "cloud" ]]; then
+            printf 'http://litellm:4000\n'
+        elif [[ -n "$existing_url" ]]; then
+            printf '%s\n' "$existing_url"
+        else
+            printf '%s\n' "$default_url"
+        fi
+    }
+
+    _phase06_select_hermes_llm_base_url() {
+        local ods_mode_value="${1:-}" default_url="${2:-}" existing_url="${3:-}"
+        if [[ "$ods_mode_value" == "cloud" ]]; then
+            printf 'http://litellm:4000/v1\n'
+        elif [[ -n "$existing_url" ]]; then
+            printf '%s\n' "$existing_url"
+        else
+            printf '%s\n' "$default_url"
+        fi
+    }
+
+    _phase06_select_hermes_llm_api_key() {
+        local ods_mode_value="${1:-}" default_key="${2:-}" existing_key="${3:-}"
+        if [[ "$ods_mode_value" == "cloud" ]]; then
+            printf '%s\n' "$default_key"
+        elif [[ -n "$existing_key" ]]; then
+            printf '%s\n' "$existing_key"
+        else
+            printf '%s\n' "$default_key"
+        fi
+    }
+
     _phase06_detect_lemonade_url() {
         command -v curl >/dev/null 2>&1 || return 1
         local candidate
@@ -456,7 +517,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
     MODEL_PROFILE_VALUE=$(_env_get MODEL_PROFILE "${MODEL_PROFILE_REQUESTED:-${MODEL_PROFILE:-qwen}}")
     ODS_MODE_VALUE="$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "lemonade"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "lemonade"; else echo "${ODS_MODE:-local}"; fi)"
     _default_llm_api_url="$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "http://litellm:4000"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "http://litellm:4000"; elif [[ "${ODS_MODE:-local}" == "local" ]]; then echo "http://llama-server:8080"; else echo "http://litellm:4000"; fi)"
-    LLM_API_URL_VALUE=$(_env_get LLM_API_URL "$_default_llm_api_url")
+    LLM_API_URL_VALUE="$(_phase06_select_llm_api_url "$ODS_MODE_VALUE" "$_default_llm_api_url" "$(_env_get LLM_API_URL "")")"
     if [[ "${ODS_MODE:-local}" == "cloud" ]]; then
         _default_hermes_base_url="http://litellm:4000/v1"
         _default_hermes_api_key="${LITELLM_KEY}"
@@ -467,8 +528,8 @@ raise SystemExit(1)' 2>/dev/null && return 0
         _default_hermes_base_url="http://llama-server:8080/v1"
         _default_hermes_api_key="sk-ods-hermes-local"
     fi
-    HERMES_LLM_BASE_URL_VALUE=$(_env_get HERMES_LLM_BASE_URL "$_default_hermes_base_url")
-    HERMES_LLM_API_KEY_VALUE=$(_env_get HERMES_LLM_API_KEY "$_default_hermes_api_key")
+    HERMES_LLM_BASE_URL_VALUE="$(_phase06_select_hermes_llm_base_url "$ODS_MODE_VALUE" "$_default_hermes_base_url" "$(_env_get HERMES_LLM_BASE_URL "")")"
+    HERMES_LLM_API_KEY_VALUE="$(_phase06_select_hermes_llm_api_key "$ODS_MODE_VALUE" "$_default_hermes_api_key" "$(_env_get HERMES_LLM_API_KEY "")")"
     LLM_API_URL="$LLM_API_URL_VALUE"
     HERMES_LLM_BASE_URL="$HERMES_LLM_BASE_URL_VALUE"
     HERMES_LLM_API_KEY="$HERMES_LLM_API_KEY_VALUE"
@@ -624,6 +685,21 @@ raise SystemExit(1)' 2>/dev/null && return 0
     OPENAI_API_KEY=$(_env_get OPENAI_API_KEY "${OPENAI_API_KEY:-}")
     TOGETHER_API_KEY=$(_env_get TOGETHER_API_KEY "${TOGETHER_API_KEY:-}")
     MINIMAX_API_KEY=$(_env_get MINIMAX_API_KEY "${MINIMAX_API_KEY:-}")
+    OPENROUTER_API_KEY=$(_env_get OPENROUTER_API_KEY "${OPENROUTER_API_KEY:-}")
+    OPENROUTER_API_BASE=$(_env_get OPENROUTER_API_BASE "${OPENROUTER_API_BASE:-}")
+    OPENROUTER_MODEL=$(_env_get OPENROUTER_MODEL "${OPENROUTER_MODEL:-openrouter/auto}")
+    OPENROUTER_SITE_URL=$(_env_get OPENROUTER_SITE_URL "${OPENROUTER_SITE_URL:-}")
+    OPENROUTER_APP_NAME=$(_env_get OPENROUTER_APP_NAME "${OPENROUTER_APP_NAME:-ODS}")
+    if [[ "$ODS_MODE_VALUE" == "cloud" ]]; then
+        _existing_llm_model="$(_env_get LLM_MODEL "")"
+        _existing_ods_mode="$(_env_get ODS_MODE "")"
+        LLM_MODEL="$(_phase06_select_cloud_llm_model "$_existing_llm_model" "$_existing_ods_mode")"
+        MODEL_RECOMMENDATION_SOURCE="cloud_provider_alias"
+        MODEL_RECOMMENDATION_POLICY="litellm-cloud-provider"
+        MODEL_RECOMMENDATION_CONFIDENCE="high"
+        MODEL_RECOMMENDATION_REASON="Selected LiteLLM cloud alias ${LLM_MODEL}; change LLM_MODEL or provider keys to use a different cloud route."
+        unset _existing_llm_model _existing_ods_mode
+    fi
     # Base64-encode GPU assignment JSON for safe .env storage
     if [[ -n "${GPU_ASSIGNMENT_JSON:-}" && "${GPU_ASSIGNMENT_JSON:-}" != "{}" ]]; then
         GPU_ASSIGNMENT_JSON_B64=$(echo "$GPU_ASSIGNMENT_JSON" | jq -c '.' | base64 -w0)
@@ -659,7 +735,7 @@ HOST_LAN_IP=${HOST_LAN_IP}
 #=== LLM Backend Mode ===
 ODS_MODE=${ODS_MODE_VALUE}
 LLM_API_URL=${LLM_API_URL_VALUE}
-LLM_BACKEND=$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "lemonade"; else echo "llama-server"; fi)
+LLM_BACKEND=$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "lemonade"; elif [[ "$ODS_MODE_VALUE" == "cloud" ]]; then echo "litellm"; else echo "llama-server"; fi)
 LLM_API_BASE_PATH=$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "${LEMONADE_API_BASE_PATH_VALUE}"; else echo "/v1"; fi)
 AMD_INFERENCE_RUNTIME=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" || ( "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ) ]]; then echo "lemonade"; else echo ""; fi)
 AMD_INFERENCE_BACKEND=$(if [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]]; then echo "${AMD_INFERENCE_BACKEND:-auto}"; elif [[ "$GPU_BACKEND" == "amd" && "${ODS_MODE:-local}" == "local" ]]; then echo "${BACKEND_LEMONADE_LINUX_BACKEND:-rocm}"; else echo ""; fi)
@@ -679,6 +755,11 @@ ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
 OPENAI_API_KEY=${OPENAI_API_KEY:-}
 TOGETHER_API_KEY=${TOGETHER_API_KEY:-}
 MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
+OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+OPENROUTER_API_BASE=${OPENROUTER_API_BASE:-}
+OPENROUTER_MODEL=${OPENROUTER_MODEL:-openrouter/auto}
+OPENROUTER_SITE_URL=${OPENROUTER_SITE_URL:-}
+OPENROUTER_APP_NAME=${OPENROUTER_APP_NAME:-ODS}
 
 #=== Service Auth (LiteLLM proxy) ===
 TARGET_API_KEY=not-needed

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -62,6 +62,47 @@ function New-SecureBase64 {
     return [Convert]::ToBase64String($buf)
 }
 
+function Test-ODSCloudLiteLLMAlias {
+    param([string]$Model)
+    # Keep in sync with config/litellm/cloud.yaml plus the dynamic OpenRouter
+    # alias injected by extensions/services/litellm/compose.yaml.
+    return @(
+        "default",
+        "gpt4o",
+        "fast",
+        "openrouter",
+        "openrouter-auto",
+        "openrouter-free",
+        "minimax",
+        "minimax-fast"
+    ) -contains $Model
+}
+
+function Select-ODSCloudLlmModel {
+    param(
+        [string]$CandidateModel,
+        [string]$PreviousOdsMode,
+        [string]$OpenRouterApiKey,
+        [string]$AnthropicApiKey,
+        [string]$OpenAiApiKey,
+        [string]$MiniMaxApiKey
+    )
+
+    if (-not [string]::IsNullOrWhiteSpace($CandidateModel) -and
+        $CandidateModel -ne "anthropic/claude-sonnet-4-5-20250514") {
+        if ($PreviousOdsMode -eq "cloud" -or (Test-ODSCloudLiteLLMAlias $CandidateModel)) {
+            return $CandidateModel
+        }
+    }
+    if (-not [string]::IsNullOrWhiteSpace($OpenRouterApiKey) -and
+        [string]::IsNullOrWhiteSpace($AnthropicApiKey) -and
+        [string]::IsNullOrWhiteSpace($OpenAiApiKey) -and
+        [string]::IsNullOrWhiteSpace($MiniMaxApiKey)) {
+        return "openrouter"
+    }
+    return "default"
+}
+
 function New-ODSEnv {
     <#
     .SYNOPSIS
@@ -303,6 +344,35 @@ function New-ODSEnv {
         "http://llama-server:8080"
     })
 
+    $anthropicApiKey = Get-EnvOrNew "ANTHROPIC_API_KEY" $env:ANTHROPIC_API_KEY
+    $openaiApiKey = Get-EnvOrNew "OPENAI_API_KEY" $env:OPENAI_API_KEY
+    $togetherApiKey = Get-EnvOrNew "TOGETHER_API_KEY" $env:TOGETHER_API_KEY
+    $minimaxApiKey = Get-EnvOrNew "MINIMAX_API_KEY" $env:MINIMAX_API_KEY
+    $openrouterApiKey = Get-EnvOrNew "OPENROUTER_API_KEY" $env:OPENROUTER_API_KEY
+    $openrouterApiBase = Get-EnvOrNew "OPENROUTER_API_BASE" $env:OPENROUTER_API_BASE
+    $openrouterModel = Get-EnvOrNew "OPENROUTER_MODEL" $(if ($env:OPENROUTER_MODEL) { $env:OPENROUTER_MODEL } else { "openrouter/auto" })
+    $openrouterSiteUrl = Get-EnvOrNew "OPENROUTER_SITE_URL" $env:OPENROUTER_SITE_URL
+    $openrouterAppName = Get-EnvOrNew "OPENROUTER_APP_NAME" $(if ($env:OPENROUTER_APP_NAME) { $env:OPENROUTER_APP_NAME } else { "ODS" })
+    $cloudLlmModel = Get-EnvOrNew "LLM_MODEL" "$($TierConfig.LlmModel)"
+    $previousOdsMode = $(if ($existingEnv.ContainsKey("ODS_MODE")) { $existingEnv["ODS_MODE"] } else { "" })
+    $cloudRecommendationSource = $(if ($TierConfig.RecommendationSource) { $TierConfig.RecommendationSource } else { "installer_tier_map" })
+    $cloudRecommendationPolicy = $(if ($TierConfig.RecommendationPolicy) { $TierConfig.RecommendationPolicy } else { "tier-map" })
+    $cloudRecommendationConfidence = $(if ($TierConfig.RecommendationConfidence) { $TierConfig.RecommendationConfidence } else { "medium" })
+    $cloudRecommendationReason = $(if ($TierConfig.RecommendationReason) { $TierConfig.RecommendationReason } else { "Selected by installer tier $Tier ($($TierConfig.TierName)) for $GpuBackend backend; benchmark locally after first launch." })
+    if ($ODSMode -eq "cloud") {
+        $cloudLlmModel = Select-ODSCloudLlmModel `
+            -CandidateModel $cloudLlmModel `
+            -PreviousOdsMode $previousOdsMode `
+            -OpenRouterApiKey $openrouterApiKey `
+            -AnthropicApiKey $anthropicApiKey `
+            -OpenAiApiKey $openaiApiKey `
+            -MiniMaxApiKey $minimaxApiKey
+        $cloudRecommendationSource = "cloud_provider_alias"
+        $cloudRecommendationPolicy = "litellm-cloud-provider"
+        $cloudRecommendationConfidence = "high"
+        $cloudRecommendationReason = "Selected LiteLLM cloud alias $cloudLlmModel; change LLM_MODEL or provider keys to use a different cloud route."
+    }
+
     # Hermes streams through the OpenAI-compatible provider. On Windows AMD
     # Lemonade, direct streaming against Lemonade can close chunked responses
     # early; LiteLLM normalizes that path and already fronts the same runtime
@@ -385,24 +455,29 @@ AMD_INFERENCE_RUNTIME_MODE=$AmdInferenceRuntimeMode
 AMD_INFERENCE_MANAGED=$AmdInferenceManaged
 
 #=== Cloud API Keys ===
-ANTHROPIC_API_KEY=$(Get-EnvOrNew "ANTHROPIC_API_KEY" "")
-OPENAI_API_KEY=$(Get-EnvOrNew "OPENAI_API_KEY" "")
-TOGETHER_API_KEY=$(Get-EnvOrNew "TOGETHER_API_KEY" "")
-MINIMAX_API_KEY=$(Get-EnvOrNew "MINIMAX_API_KEY" "")
+ANTHROPIC_API_KEY=$anthropicApiKey
+OPENAI_API_KEY=$openaiApiKey
+TOGETHER_API_KEY=$togetherApiKey
+MINIMAX_API_KEY=$minimaxApiKey
+OPENROUTER_API_KEY=$openrouterApiKey
+OPENROUTER_API_BASE=$openrouterApiBase
+OPENROUTER_MODEL=$openrouterModel
+OPENROUTER_SITE_URL=$openrouterSiteUrl
+OPENROUTER_APP_NAME=$openrouterAppName
 
 #=== LLM Settings (llama-server) ===
 MODEL_PROFILE=$(Get-EnvOrNew "MODEL_PROFILE" "$(if ($TierConfig.ModelProfileRequested) { $TierConfig.ModelProfileRequested } else { "qwen" })")
-LLM_MODEL=$($TierConfig.LlmModel)
+LLM_MODEL=$cloudLlmModel
 GGUF_FILE=$($TierConfig.GgufFile)
 MAX_CONTEXT=$($TierConfig.MaxContext)
 CTX_SIZE=$($TierConfig.MaxContext)
-MODEL_RECOMMENDED_MODEL=$($TierConfig.LlmModel)
+MODEL_RECOMMENDED_MODEL=$cloudLlmModel
 MODEL_RECOMMENDED_GGUF=$($TierConfig.GgufFile)
 MODEL_RECOMMENDED_CONTEXT=$($TierConfig.MaxContext)
-MODEL_RECOMMENDATION_SOURCE=$(if ($TierConfig.RecommendationSource) { $TierConfig.RecommendationSource } else { "installer_tier_map" })
-MODEL_RECOMMENDATION_POLICY=$(if ($TierConfig.RecommendationPolicy) { $TierConfig.RecommendationPolicy } else { "tier-map" })
-MODEL_RECOMMENDATION_CONFIDENCE=$(if ($TierConfig.RecommendationConfidence) { $TierConfig.RecommendationConfidence } else { "medium" })
-MODEL_RECOMMENDATION_REASON=$(if ($TierConfig.RecommendationReason) { $TierConfig.RecommendationReason } else { "Selected by installer tier $Tier ($($TierConfig.TierName)) for $GpuBackend backend; benchmark locally after first launch." })
+MODEL_RECOMMENDATION_SOURCE=$cloudRecommendationSource
+MODEL_RECOMMENDATION_POLICY=$cloudRecommendationPolicy
+MODEL_RECOMMENDATION_CONFIDENCE=$cloudRecommendationConfidence
+MODEL_RECOMMENDATION_REASON=$cloudRecommendationReason
 MODEL_RECOMMENDED_ALTERNATIVES=$(if ($TierConfig.RecommendationAlternatives) { $TierConfig.RecommendationAlternatives } else { "" })
 MODEL_RUNTIME_PROFILE=$(if ($TierConfig.RuntimeProfile) { $TierConfig.RuntimeProfile } else { "" })
 MODEL_RUNTIME_PROFILE_LABEL=$(if ($TierConfig.RuntimeProfileLabel) { $TierConfig.RuntimeProfileLabel } else { "" })

--- a/ods/tests/test-litellm-cloud-openrouter.py
+++ b/ods/tests/test-litellm-cloud-openrouter.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import json
+import pathlib
+import re
+import shutil
+import subprocess
+
+import pytest
+import yaml
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _litellm_compose_command() -> str:
+    compose = yaml.safe_load((ROOT / "extensions/services/litellm/compose.yaml").read_text(encoding="utf-8"))
+    return compose["services"]["litellm"]["command"][0]
+
+
+def _load_openrouter_litellm_model():
+    command = _litellm_compose_command()
+    start = command.index("def openrouter_litellm_model")
+    end = command.index("\n\nwith open('/app/config.yaml')")
+    namespace: dict[str, object] = {}
+    exec(command[start:end], namespace)
+    return namespace["openrouter_litellm_model"]
+
+
+def _shell_function(source: str, name: str) -> str:
+    match = re.search(rf"(?ms)^(?P<indent>[ \t]*){re.escape(name)}\(\) \{{.*?^\1\}}", source)
+    assert match, f"{name}() not found"
+    return match.group(0)
+
+
+def _run_bash(script: str) -> subprocess.CompletedProcess[str]:
+    bash = shutil.which("bash")
+    if not bash:
+        pytest.skip("bash is not available in this environment")
+    probe = subprocess.run([bash, "-lc", "printf ok"], capture_output=True, text=True)
+    if probe.returncode != 0:
+        pytest.skip("bash is installed but not usable in this environment")
+    return subprocess.run([bash, "-lc", script], check=True, capture_output=True, text=True)
+
+
+def _run_powershell(script: str) -> subprocess.CompletedProcess[str]:
+    powershell = shutil.which("pwsh") or shutil.which("powershell")
+    if not powershell:
+        pytest.skip("PowerShell is not available in this environment")
+    args = [powershell, "-NoProfile"]
+    if pathlib.Path(powershell).name.lower() == "powershell.exe":
+        args.extend(["-ExecutionPolicy", "Bypass"])
+    args.extend(["-Command", script])
+    return subprocess.run(args, check=True, capture_output=True, text=True)
+
+
+def _compose_env_file(tmp_path: pathlib.Path) -> pathlib.Path:
+    env_file = tmp_path / "compose.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "WEBUI_SECRET=sk-test-webui-secret",
+                "DASHBOARD_API_KEY=sk-test-dashboard",
+                "ODS_AGENT_KEY=sk-test-agent",
+                "ODS_SESSION_SECRET=sk-test-session",
+                "SHIELD_API_KEY=sk-test-shield",
+                "N8N_PASS=test-password",
+                "LITELLM_KEY=sk-test-litellm",
+                "LIVEKIT_API_KEY=lk-test",
+                "LIVEKIT_API_SECRET=lk-secret",
+                "OPENCLAW_TOKEN=oc-token",
+                "QDRANT_API_KEY=qdrant-key",
+                "TOKEN_SPY_API_KEY=token-key",
+                "SEARXNG_SECRET=searxng-secret",
+                "ODS_MODE=cloud",
+                "LLM_API_URL=http://litellm:4000",
+                "BIND_ADDRESS=127.0.0.1",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return env_file
+
+
+def _render_compose(tmp_path: pathlib.Path, files: list[str], profiles: list[str] | None = None) -> dict:
+    docker = shutil.which("docker")
+    if not docker:
+        pytest.skip("docker is not available in this environment")
+    env_file = _compose_env_file(tmp_path)
+    args = [docker, "compose", "--env-file", str(env_file)]
+    for file in files:
+        args.extend(["-f", file])
+    for profile in profiles or []:
+        args.extend(["--profile", profile])
+    args.extend(["config", "--format", "json"])
+    proc = subprocess.run(args, cwd=ROOT, check=True, capture_output=True, text=True)
+    return json.loads(proc.stdout)
+
+
+def _cloud_aliases() -> set[str]:
+    cfg = yaml.safe_load((ROOT / "config/litellm/cloud.yaml").read_text(encoding="utf-8"))
+    aliases = {entry["model_name"] for entry in cfg["model_list"]}
+    aliases.add("openrouter")
+    return aliases
+
+
+def test_cloud_litellm_config_exposes_openrouter_presets() -> None:
+    cfg = yaml.safe_load((ROOT / "config/litellm/cloud.yaml").read_text(encoding="utf-8"))
+    by_name = {entry["model_name"]: entry["litellm_params"] for entry in cfg["model_list"]}
+
+    assert by_name["openrouter-auto"]["model"] == "openrouter/openrouter/auto"
+    assert by_name["openrouter-auto"]["api_key"] == "os.environ/OPENROUTER_API_KEY"
+    assert by_name["openrouter-free"]["model"] == "openrouter/openrouter/free"
+    assert by_name["openrouter-free"]["api_key"] == "os.environ/OPENROUTER_API_KEY"
+
+
+def test_cloud_alias_allowlists_match_litellm_cloud_config() -> None:
+    aliases = _cloud_aliases()
+    linux = (ROOT / "installers/phases/06-directories.sh").read_text(encoding="utf-8")
+    macos = (ROOT / "installers/macos/lib/env-generator.sh").read_text(encoding="utf-8")
+    windows = (ROOT / "installers/windows/lib/env-generator.ps1").read_text(encoding="utf-8")
+
+    for alias in aliases:
+        assert alias in linux
+        assert alias in macos
+        assert f'"{alias}"' in windows
+
+
+def test_dynamic_openrouter_alias_renders_litellm_provider_strings() -> None:
+    helper = _load_openrouter_litellm_model()
+
+    assert helper(None) == "openrouter/openrouter/auto"
+    assert helper("") == "openrouter/openrouter/auto"
+    assert helper("openrouter/auto") == "openrouter/openrouter/auto"
+    assert helper("openrouter/free") == "openrouter/openrouter/free"
+    assert helper("qwen/qwen3-235b-a22b:free") == "openrouter/qwen/qwen3-235b-a22b:free"
+    assert helper("openrouter/qwen/qwen3-235b-a22b:free") == "openrouter/qwen/qwen3-235b-a22b:free"
+
+
+def test_litellm_compose_forwards_openrouter_runtime_env() -> None:
+    compose = yaml.safe_load((ROOT / "extensions/services/litellm/compose.yaml").read_text(encoding="utf-8"))
+    env = set(compose["services"]["litellm"]["environment"])
+    command = _litellm_compose_command()
+
+    assert "OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}" in env
+    assert "OPENROUTER_MODEL=${OPENROUTER_MODEL:-openrouter/auto}" in env
+    assert "OR_SITE_URL=${OPENROUTER_SITE_URL:-}" in env
+    assert "OR_APP_NAME=${OPENROUTER_APP_NAME:-ODS}" in env
+    assert "OPENROUTER_MODEL_NAME" in command
+    assert "openrouter_litellm_model" in command
+    assert "exec litellm --config /tmp/config.yaml --port 4000" in command
+
+
+def test_cloud_overlay_authenticates_open_webui_to_litellm() -> None:
+    cloud = yaml.safe_load((ROOT / "docker-compose.cloud.yml").read_text(encoding="utf-8"))
+
+    webui_env = cloud["services"]["open-webui"]["environment"]
+    dashboard_env = set(cloud["services"]["dashboard-api"]["environment"])
+
+    assert webui_env["OPENAI_API_KEY"] == "${LITELLM_KEY:-${OPENAI_API_KEY:-}}"
+    assert "ODS_TALK_VISION_URL=${ODS_TALK_VISION_URL:-http://litellm:4000/v1}" in dashboard_env
+    assert "ODS_TALK_VISION_KEY=${ODS_TALK_VISION_KEY:-${LITELLM_KEY:-}}" in dashboard_env
+    assert "ODS_TALK_VISION_MODEL=${ODS_TALK_VISION_MODEL:-${LLM_MODEL:-default}}" in dashboard_env
+
+
+def test_linux_cloud_env_routes_backend_through_litellm() -> None:
+    phase06 = (ROOT / "installers/phases/06-directories.sh").read_text(encoding="utf-8")
+
+    assert 'elif [[ "$ODS_MODE_VALUE" == "cloud" ]]; then echo "litellm"' in phase06
+    assert "_phase06_select_cloud_llm_model" in phase06
+    assert "OPENROUTER_API_KEY=$(_env_get OPENROUTER_API_KEY" in phase06
+    assert "OPENROUTER_MODEL=${OPENROUTER_MODEL:-openrouter/auto}" in phase06
+    assert "printf 'openrouter\\n'" in phase06
+    assert "printf 'default\\n'" in phase06
+
+
+def test_macos_cloud_env_routes_hermes_and_services_through_litellm() -> None:
+    env_generator = (ROOT / "installers/macos/lib/env-generator.sh").read_text(encoding="utf-8")
+    compose = yaml.safe_load((ROOT / "installers/macos/docker-compose.macos.yml").read_text(encoding="utf-8"))
+    installer = (ROOT / "installers/macos/install-macos.sh").read_text(encoding="utf-8")
+
+    assert 'ods_mode_value="cloud"' in env_generator
+    assert 'llm_backend_value="litellm"' in env_generator
+    assert 'llm_api_url="http://litellm:4000"' in env_generator
+    assert 'hermes_llm_base_url="http://litellm:4000/v1"' in env_generator
+    assert "select_cloud_llm_model" in env_generator
+    assert 'upsert_env_value "$env_path" "ODS_MODE" "cloud"' in env_generator
+    assert 'upsert_env_value "$env_path" "LLM_BACKEND" "litellm"' in env_generator
+    assert 'upsert_env_value "$env_path" "LLM_MODEL" "$_cloud_llm_model"' in env_generator
+    assert 'upsert_env_value "$env_path" "HERMES_LLM_BASE_URL" "http://litellm:4000/v1"' in env_generator
+    assert "printf 'openrouter\\n'" in env_generator
+    assert "printf 'default\\n'" in env_generator
+    assert "OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}" in env_generator
+    assert "OLLAMA_URL=${LLM_API_URL:-http://host.docker.internal:8080}" in compose["services"]["dashboard-api"]["environment"]
+    assert compose["services"]["open-webui"]["environment"]["OPENAI_API_BASE_URL"] == "${LLM_API_URL:-http://host.docker.internal:8080}/v1"
+    assert "docker-compose.cloud.yml" in installer
+    assert "docker-compose.macos.cloud.yml" in installer
+    assert '"--profile" "local-inference"' in installer
+
+
+def test_macos_local_open_webui_waits_for_native_llama_ready(tmp_path: pathlib.Path) -> None:
+    rendered = _render_compose(
+        tmp_path,
+        ["docker-compose.base.yml", "installers/macos/docker-compose.macos.yml"],
+        profiles=["local-inference"],
+    )
+
+    services = rendered["services"]
+    assert "llama-server-ready" in services
+    assert services["open-webui"]["depends_on"]["llama-server-ready"]["condition"] == "service_healthy"
+
+
+def test_macos_cloud_open_webui_does_not_wait_for_native_llama_ready(tmp_path: pathlib.Path) -> None:
+    rendered = _render_compose(
+        tmp_path,
+        [
+            "docker-compose.base.yml",
+            "docker-compose.cloud.yml",
+            "installers/macos/docker-compose.macos.cloud.yml",
+        ],
+    )
+
+    services = rendered["services"]
+    assert "llama-server-ready" not in services
+    assert "depends_on" not in services["open-webui"]
+
+
+def test_windows_env_generator_preserves_openrouter_values() -> None:
+    env_generator = (ROOT / "installers/windows/lib/env-generator.ps1").read_text(encoding="utf-8")
+
+    assert '$anthropicApiKey = Get-EnvOrNew "ANTHROPIC_API_KEY" $env:ANTHROPIC_API_KEY' in env_generator
+    assert '$openrouterApiKey = Get-EnvOrNew "OPENROUTER_API_KEY" $env:OPENROUTER_API_KEY' in env_generator
+    assert '$openrouterModel = Get-EnvOrNew "OPENROUTER_MODEL" $(if ($env:OPENROUTER_MODEL) { $env:OPENROUTER_MODEL } else { "openrouter/auto" })' in env_generator
+    assert '$openrouterAppName = Get-EnvOrNew "OPENROUTER_APP_NAME" $(if ($env:OPENROUTER_APP_NAME) { $env:OPENROUTER_APP_NAME } else { "ODS" })' in env_generator
+    assert "Select-ODSCloudLlmModel" in env_generator
+    assert 'return "openrouter"' in env_generator
+    assert 'return "default"' in env_generator
+
+
+def test_linux_cloud_model_selection_does_not_preserve_local_model() -> None:
+    phase06 = (ROOT / "installers/phases/06-directories.sh").read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            _shell_function(phase06, "_phase06_is_cloud_litellm_alias"),
+            _shell_function(phase06, "_phase06_select_cloud_llm_model"),
+            "ANTHROPIC_API_KEY= OPENAI_API_KEY= MINIMAX_API_KEY= OPENROUTER_API_KEY=sk-or",
+            '[[ "$(_phase06_select_cloud_llm_model qwen3.5-9b local)" == "openrouter" ]]',
+            '[[ "$(_phase06_select_cloud_llm_model gpt4o local)" == "gpt4o" ]]',
+            '[[ "$(_phase06_select_cloud_llm_model openrouter local)" == "openrouter" ]]',
+            '[[ "$(_phase06_select_cloud_llm_model custom-cloud-route cloud)" == "custom-cloud-route" ]]',
+        ]
+    )
+
+    _run_bash(script)
+
+
+def test_linux_cloud_rerun_rewrites_local_llm_runtime_routes() -> None:
+    phase06 = (ROOT / "installers/phases/06-directories.sh").read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            "set -euo pipefail",
+            _shell_function(phase06, "_env_get"),
+            _shell_function(phase06, "_phase06_is_cloud_litellm_alias"),
+            _shell_function(phase06, "_phase06_select_cloud_llm_model"),
+            _shell_function(phase06, "_phase06_select_llm_api_url"),
+            _shell_function(phase06, "_phase06_select_hermes_llm_base_url"),
+            _shell_function(phase06, "_phase06_select_hermes_llm_api_key"),
+            '_env_existing="$(mktemp)"',
+            'trap \'rm -f "$_env_existing"\' EXIT',
+            "cat > \"$_env_existing\" <<'EOF'\n"
+            "ODS_MODE=local\n"
+            "LLM_API_URL=http://llama-server:8080\n"
+            "HERMES_LLM_BASE_URL=http://llama-server:8080/v1\n"
+            "HERMES_LLM_API_KEY=sk-ods-hermes-local\n"
+            "LLM_MODEL=qwen3.5-9b\n"
+            "OPENROUTER_API_KEY=sk-or-test\n"
+            "EOF",
+            "ANTHROPIC_API_KEY= OPENAI_API_KEY= MINIMAX_API_KEY=",
+            'OPENROUTER_API_KEY="$(_env_get OPENROUTER_API_KEY "")"',
+            "LITELLM_KEY=sk-ods-litellm-test",
+            "ODS_MODE_VALUE=cloud",
+            'LLM_API_URL_VALUE="$(_phase06_select_llm_api_url "$ODS_MODE_VALUE" "http://litellm:4000" "$(_env_get LLM_API_URL "")")"',
+            'HERMES_LLM_BASE_URL_VALUE="$(_phase06_select_hermes_llm_base_url "$ODS_MODE_VALUE" "http://litellm:4000/v1" "$(_env_get HERMES_LLM_BASE_URL "")")"',
+            'HERMES_LLM_API_KEY_VALUE="$(_phase06_select_hermes_llm_api_key "$ODS_MODE_VALUE" "$LITELLM_KEY" "$(_env_get HERMES_LLM_API_KEY "")")"',
+            'LLM_MODEL="$(_phase06_select_cloud_llm_model "$(_env_get LLM_MODEL "")" "$(_env_get ODS_MODE "")")"',
+            'LLM_BACKEND="$(if [[ "$ODS_MODE_VALUE" == "lemonade" ]]; then echo "lemonade"; elif [[ "$ODS_MODE_VALUE" == "cloud" ]]; then echo "litellm"; else echo "llama-server"; fi)"',
+            '[[ "$LLM_API_URL_VALUE" == "http://litellm:4000" ]]',
+            '[[ "$HERMES_LLM_BASE_URL_VALUE" == "http://litellm:4000/v1" ]]',
+            '[[ "$HERMES_LLM_API_KEY_VALUE" == "sk-ods-litellm-test" ]]',
+            '[[ "$LLM_MODEL" == "openrouter" ]]',
+            '[[ "$LLM_BACKEND" == "litellm" ]]',
+        ]
+    )
+
+    _run_bash(script)
+
+
+def test_macos_cloud_model_selection_does_not_preserve_local_model() -> None:
+    env_generator = (ROOT / "installers/macos/lib/env-generator.sh").read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            _shell_function(env_generator, "is_cloud_litellm_alias"),
+            _shell_function(env_generator, "select_cloud_llm_model"),
+            "ANTHROPIC_API_KEY= OPENAI_API_KEY= MINIMAX_API_KEY= OPENROUTER_API_KEY=sk-or",
+            '[[ "$(select_cloud_llm_model qwen3.5-9b local)" == "openrouter" ]]',
+            '[[ "$(select_cloud_llm_model gpt4o local)" == "gpt4o" ]]',
+            '[[ "$(select_cloud_llm_model openrouter local)" == "openrouter" ]]',
+            '[[ "$(select_cloud_llm_model custom-cloud-route cloud)" == "custom-cloud-route" ]]',
+        ]
+    )
+
+    _run_bash(script)
+
+
+def test_windows_cloud_model_selection_does_not_preserve_local_model() -> None:
+    generator = ROOT / "installers/windows/lib/env-generator.ps1"
+    generator_path = str(generator).replace("'", "''")
+    script = f"""
+. '{generator_path}'
+$model = Select-ODSCloudLlmModel -CandidateModel 'qwen3.5-9b' -PreviousOdsMode 'local' -OpenRouterApiKey 'sk-or-test' -AnthropicApiKey '' -OpenAiApiKey '' -MiniMaxApiKey ''
+if ($model -ne 'openrouter') {{ throw "Expected openrouter, got $model" }}
+"""
+
+    _run_powershell(script)
+
+
+def test_windows_cloud_model_selection_preserves_cloud_alias() -> None:
+    generator = ROOT / "installers/windows/lib/env-generator.ps1"
+    generator_path = str(generator).replace("'", "''")
+    script = f"""
+. '{generator_path}'
+$cloudAlias = Select-ODSCloudLlmModel -CandidateModel 'gpt4o' -PreviousOdsMode 'local' -OpenRouterApiKey 'sk-or-test' -AnthropicApiKey '' -OpenAiApiKey '' -MiniMaxApiKey ''
+if ($cloudAlias -ne 'gpt4o') {{ throw "Expected gpt4o, got $cloudAlias" }}
+$customCloudAlias = Select-ODSCloudLlmModel -CandidateModel 'custom-cloud-route' -PreviousOdsMode 'cloud' -OpenRouterApiKey 'sk-or-test' -AnthropicApiKey '' -OpenAiApiKey '' -MiniMaxApiKey ''
+if ($customCloudAlias -ne 'custom-cloud-route') {{ throw "Expected custom-cloud-route, got $customCloudAlias" }}
+"""
+
+    _run_powershell(script)


### PR DESCRIPTION
## Summary

This PR makes OpenRouter a first-class cloud provider in ODS instead of a post-install manual LiteLLM edit.

It also tightens the cloud-mode runtime contract so Linux, macOS, and Windows agree that cloud installs route OpenAI-compatible traffic through LiteLLM, including Open WebUI, Hermes, ODS Talk vision requests, and dashboard service health paths.

## What Changed

- Adds OpenRouter cloud env fields to the ODS config surface:
  - `OPENROUTER_API_KEY`
  - `OPENROUTER_API_BASE`
  - `OPENROUTER_MODEL`
  - `OPENROUTER_SITE_URL`
  - `OPENROUTER_APP_NAME`
- Adds LiteLLM cloud aliases:
  - `openrouter-auto` -> OpenRouter Auto Router
  - `openrouter-free` -> OpenRouter Free Router
  - `openrouter` -> dynamic alias backed by `OPENROUTER_MODEL`
- Passes OpenRouter env through the LiteLLM compose service, including OpenRouter attribution envs expected by LiteLLM.
- Renders a runtime LiteLLM config at container start so users can change `OPENROUTER_MODEL` from `.env` / Settings without editing `config/litellm/cloud.yaml`.
- Updates Settings apply planning so cloud provider key changes restart `litellm`, not unrelated services.
- Preserves cloud provider env values from existing `.env` and process env on Windows, matching the Linux/macOS install pattern.
- Preserves OpenRouter fields in Linux, macOS, and Windows installer-generated `.env` files.
- Selects a LiteLLM alias as `LLM_MODEL` in cloud mode:
  - `openrouter` when only OpenRouter is configured
  - `default` otherwise, preserving the existing Anthropic-backed default route
- Fixes cloud backend metadata:
  - Linux cloud `.env` now writes `LLM_BACKEND=litellm`.
  - macOS `--cloud` now writes `ODS_MODE=cloud`, `LLM_BACKEND=litellm`, `LLM_API_URL=http://litellm:4000`, and routes Hermes through `http://litellm:4000/v1`.
- Fixes cloud compose routing:
  - Open WebUI authenticates to LiteLLM with `LITELLM_KEY`.
  - ODS Talk vision requests default to LiteLLM in cloud mode instead of the profiled-out `llama-server`.
  - macOS cloud includes `docker-compose.cloud.yml` and no longer waits on the native llama-server readiness sidecar.
  - macOS Open WebUI/dashboard runtime URLs now follow `LLM_API_URL` rather than always forcing `host.docker.internal:8080`.
- Documents OpenRouter cloud setup in `MODE-SWITCH.md` and the top-level README.

## User Flow

A constrained machine can now run a lightweight cloud/Hermes install like:

```bash
OPENROUTER_API_KEY=sk-or-v1-... ./install.sh --cloud --hermes --no-comfyui --no-voice --no-workflows --no-rag --no-langfuse
```

Then the user can select one of these model aliases from the chat surface / provider-backed clients:

| Alias | Route |
|---|---|
| `openrouter` | Uses `OPENROUTER_MODEL`, defaulting to `openrouter/auto` |
| `openrouter-auto` | OpenRouter Auto Router |
| `openrouter-free` | OpenRouter Free Router |

## Platform Coverage

| Platform | Coverage |
|---|---|
| Linux | Installer preserves OpenRouter envs, writes cloud backend as LiteLLM, selects cloud aliases, and routes cloud Open WebUI/ODS Talk through LiteLLM |
| macOS | Cloud env generation now routes services and Hermes through LiteLLM; cloud compose includes the cloud overlay and avoids the local llama readiness gate |
| Windows | Env generator preserves OpenRouter/provider values from existing `.env` or process env and selects cloud aliases consistently |
| Dashboard Settings | OpenRouter/provider keys are secret fields and apply through a LiteLLM restart plan |
| LiteLLM | Static aliases plus dynamic `openrouter` alias are rendered before proxy start |

## Validation

Ran locally:

```bash
python -m pytest ods/tests/test-litellm-cloud-openrouter.py ods/extensions/services/dashboard-api/tests/test_settings_env.py -q
python -m py_compile ods/extensions/services/dashboard-api/settings.py
python -c "import json,pathlib,yaml; json.loads(pathlib.Path('ods/.env.schema.json').read_text()); yaml.safe_load(pathlib.Path('ods/config/litellm/cloud.yaml').read_text()); yaml.safe_load(pathlib.Path('ods/extensions/services/litellm/compose.yaml').read_text()); yaml.safe_load(pathlib.Path('ods/docker-compose.cloud.yml').read_text()); yaml.safe_load(pathlib.Path('ods/installers/macos/docker-compose.macos.yml').read_text()); print('ok')"
powershell -NoProfile -Command '$tokens=$null; $errs=$null; $null=[System.Management.Automation.Language.Parser]::ParseFile("ods/installers/windows/lib/env-generator.ps1",[ref]$tokens,[ref]$errs); if ($errs.Count) { $errs | Format-List; exit 1 }'
docker compose --env-file <temp-cloud-env> -f ods/docker-compose.base.yml -f ods/docker-compose.cloud.yml -f ods/extensions/services/litellm/compose.yaml config --quiet
docker compose --env-file <temp-cloud-env> -f ods/docker-compose.base.yml -f ods/docker-compose.cloud.yml -f ods/installers/macos/docker-compose.macos.yml -f ods/extensions/services/litellm/compose.yaml config --quiet
git diff --check
```

Results:

- Targeted pytest run: 36 passed
- JSON/YAML parse check: passed
- PowerShell parser check: passed
- Linux-style cloud compose config: passed
- macOS cloud compose config: passed
- `git diff --check`: passed

Not run locally:

- Bash contract tests such as `ods/tests/test-linux-cloud-mode.sh` and `ods/tests/contracts/test-installer-contracts.sh`, because this Windows host currently has WSL/Hyper-V unavailable (`HCS_E_HYPERV_NOT_INSTALLED`). CI should cover those lanes.
- Live OpenRouter API smoke with a real key. The PR wires the route and validates local config/compose generation; a maintainer or release validation run should still record a real provider completion before release.

## Risk Notes

- Existing `default`, `gpt4o`, `fast`, `minimax`, and `minimax-fast` aliases are left in place.
- The new `openrouter` dynamic alias is only appended when `OPENROUTER_API_KEY` is set, so installs without OpenRouter keep their current LiteLLM config shape apart from the harmless static aliases.
- `openrouter/openrouter/auto` and `openrouter/openrouter/free` are intentional LiteLLM provider strings: LiteLLM prefixes provider routes as `openrouter/<OpenRouter model id>`, and the OpenRouter model ids are `openrouter/auto` and `openrouter/free`.
- OpenRouter availability, free-router limits, and selected downstream model behavior remain controlled by OpenRouter.
