### PR TITLE
installer(amd): select gfx target by VRAM, not lexicographic order

### DIFF
--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -734,7 +734,18 @@ COMFYUI_CPU_RESERVATION=${COMFYUI_CPU_RESERVATION}
 $(if [[ "$GPU_BACKEND" == "amd" ]]; then
     # Read gfx target from topology detection. Falls back to gfx1151 (Strix Halo)
     # if the topology probe failed — preserves prior behavior for the OG target.
-    _amd_gfx_detected=$(echo "${GPU_TOPOLOGY_JSON:-{\}}" | jq -r '[.gpus[]?.gfx_version] | unique | .[0] // "gfx1151"' 2>/dev/null || echo "gfx1151")
+    #
+    # Select the gfx of the GPU with the most VRAM, which is the card inference will
+    # actually run on. Do NOT use `unique | .[0]`: unique sorts ascending, so on a
+    # mixed iGPU + dGPU box the weakest device wins on a lexicographic accident
+    # (["gfx1036","gfx1201"] -> gfx1036, the Raphael display iGPU). That silently
+    # compiles the entire inference engine for a GPU it is never scheduled onto, and
+    # ROCm ships no BLAS kernels for those iGPU targets at all.
+    _amd_gfx_detected=$(echo "${GPU_TOPOLOGY_JSON:-{\}}" | jq -r '
+        [.gpus[]? | select(.gfx_version != null and .gfx_version != "unknown")]
+        | sort_by(.memory_gb // 0)
+        | reverse
+        | .[0].gfx_version // "gfx1151"' 2>/dev/null || echo "gfx1151")
     [[ -z "$_amd_gfx_detected" || "$_amd_gfx_detected" == "null" || "$_amd_gfx_detected" == "unknown" ]] && _amd_gfx_detected="gfx1151"
 
     # HSA_OVERRIDE_GFX_VERSION is a Strix Halo (gfx1151) workaround — that target


### PR DESCRIPTION
installer(amd): select gfx target by VRAM, not lexicographic order

The AMD gfx target was chosen with:

    [.gpus[]?.gfx_version] | unique | .[0]

jq's `unique` sorts ascending, so on a mixed iGPU + dGPU host the weakest device
wins by lexicographic accident: ["gfx1036","gfx1201"] -> gfx1036, the integrated
Raphael display GPU. There is no "pick the best GPU" logic anywhere in the path.

Consequences on such a host (2x Radeon AI PRO R9700 + Raphael iGPU):

  - llama.cpp is compiled for gfx1036, while docker-compose.amd.yml schedules
    inference onto the gfx1201 cards. Wrong-ISA binary on the target GPUs.
  - ROCm ships no rocBLAS/hipBLASLt kernels for gfx1036 at all, so the image also
    ends up with no usable BLAS kernels (see the companion Dockerfile.amd fix).
  - The install still reports green. The build succeeds; it is simply the wrong
    target.

Select the gfx of the highest-VRAM GPU instead (31.9GB R9700 over the 2.0GB iGPU),
which is the card inference actually runs on. The failed-probe fallback to gfx1151
is preserved.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


---

