### PR TITLE
gpu: stop scheduling services onto the display iGPU next to discrete cards

### DIFF
--- a/ods/docs/HARDWARE-GUIDE.md
+++ b/ods/docs/HARDWARE-GUIDE.md
@@ -191,7 +191,7 @@ Rule: 2x your model size minimum
 ## What NOT to Buy
 
 ❌ **GTX 16xx/10xx** — No FP16 tensor cores
-❌ **AMD discrete GPUs (RX 7900 etc.)** — ROCm support limited; AMD Strix Halo APUs are fully supported (see README)
+⚠️ **AMD discrete GPUs** — supported via the ROCm path and scheduled like any discrete card (validated end-to-end on Radeon AI PRO R9700 / RDNA4); consumer cards (RX 7900 etc.) are not yet benchmarked. AMD Strix Halo APUs are fully supported (see README)
 ❌ **Intel Arc** — Driver problems, limited support
 ❌ **Cloud GPUs (H100/A100)** — Can't buy, rental only
 ⚠️ **8GB cards** — Limited to smaller models (2B-7B) but functional with Tier 0

--- a/ods/installers/lib/amd-topo.sh
+++ b/ods/installers/lib/amd-topo.sh
@@ -47,11 +47,29 @@ _amd_sort_card_dirs() {
 amd_memory_type() {
     local vram_bytes="${1:-0}"
     local gtt_bytes="${2:-0}"
+    local vram_vendor="${3:-}"
     local gtt_gb_int=$(( gtt_bytes / 1073741824 ))
     local vram_gb_int=$(( vram_bytes / 1073741824 ))
 
-    # GTT is the reliable unified-memory signal for AMD APUs. VRAM alone is
-    # not: MI300X and future 32 GB+ discrete cards report large VRAM too.
+    # A discrete card has dedicated VRAM from a real memory vendor, and says so:
+    # mem_info_vram_vendor reports e.g. samsung / hynix / micron / gddr6 / hbm.
+    # An APU has no dedicated VRAM, so the file is absent or "unknown".
+    #
+    # This check must come FIRST. GTT is *system* memory the GPU may map — roughly
+    # half of host RAM — so a discrete card on a large-RAM host reports a large GTT
+    # too. The `gtt >= 32` heuristic below therefore misclassifies EVERY discrete AMD
+    # GPU on a host with >= 64 GB of RAM as "unified" (observed: 2x Radeon AI PRO
+    # R9700, 31 GB VRAM each, GTT 61 GB on a 123 GB host -> both labelled unified).
+    # That silently disables the "prefer discrete GPUs for the LLM" logic in
+    # assign_gpus.py, which can only fire when something is labelled discrete.
+    if [[ -n "$vram_vendor" && "$vram_vendor" != "unknown" && "$vram_vendor" != "N/A" ]]; then
+        echo "discrete"
+        return
+    fi
+
+    # No VRAM vendor reported → integrated/APU. Keep the original signals to
+    # distinguish a real unified-memory APU (Strix Halo, which may carve out a large
+    # VRAM window) from anything else.
     if [[ $gtt_gb_int -ge 16 && $vram_gb_int -le 4 ]] || [[ $gtt_gb_int -ge 32 ]]; then
         echo "unified"
     else
@@ -431,9 +449,10 @@ detect_amd_topo() {
             pcie_width=$(cat "$card_dir/max_link_width" 2>/dev/null | grep -oP '^\d+' || echo "unknown")
 
         # Detect memory type per card
-        local gtt_bytes mem_type
+        local gtt_bytes mem_type vram_vendor
         gtt_bytes=$(cat "$card_dir/mem_info_gtt_total" 2>/dev/null) || gtt_bytes=0
-        mem_type=$(amd_memory_type "$vram_bytes" "$gtt_bytes")
+        vram_vendor=$(cat "$card_dir/mem_info_vram_vendor" 2>/dev/null) || vram_vendor=""
+        mem_type=$(amd_memory_type "$vram_bytes" "$gtt_bytes" "$vram_vendor")
 
         gpus_tsv+="${idx}	${name}	${vram_gb}	${pcie_gen}	x${pcie_width}	${uuid}	${gfx_ver}	${render_node}	${mem_type}	${pci_bdf}"$'\n'
         idx=$((idx + 1))

--- a/ods/scripts/assign_gpus.py
+++ b/ods/scripts/assign_gpus.py
@@ -91,6 +91,25 @@ def parse_gpus(topology: dict) -> list:
     return gpus
 
 
+def drop_integrated_when_discrete_present(gpus: list) -> list:
+    """
+    Remove integrated GPUs from the assignable pool when discrete GPUs are present.
+
+    A desktop AMD box commonly exposes a display iGPU (e.g. Raphael gfx1036, ~2GB)
+    alongside the real compute cards. It is a GPU by every structural test, so it lands
+    in the pool and assign_services() hands it work: with llama_server taking both
+    discrete cards, `remaining == 1` and whisper + comfyui + embeddings all get pinned
+    to the display iGPU, which has no meaningful compute and shares system RAM.
+
+    Guarded on discrete GPUs actually existing, so a pure-APU host (Strix Halo, where the
+    integrated GPU *is* the compute device) keeps every GPU and is unaffected.
+    """
+    discrete = [g for g in gpus if g.memory_type == "discrete"]
+    if not discrete or len(discrete) == len(gpus):
+        return gpus
+    return discrete
+
+
 def parse_links(topology: dict) -> list:
     links = []
     for link in topology.get("links", []):
@@ -497,7 +516,7 @@ def main():
         return
 
     #  Phase 1: Topology analysis
-    gpus        = parse_gpus(topology)
+    gpus        = drop_integrated_when_discrete_present(parse_gpus(topology))
     links       = parse_links(topology)
     rank_matrix = build_rank_matrix(links)
     ordered     = enumerate_subsets(gpus, rank_matrix)

--- a/ods/tests/bats-tests/amd-topo.bats
+++ b/ods/tests/bats-tests/amd-topo.bats
@@ -49,6 +49,69 @@ setup() {
     assert_output "unified"
 }
 
+# Regression: GTT is *system* memory the GPU may map (~half of host RAM), so a
+# discrete card on a large-RAM host reports a large GTT too. Before the vendor
+# check, `gtt >= 32` branded every discrete AMD GPU on a >=64GB host "unified"
+# (observed: 2x Radeon AI PRO R9700, 31GB VRAM, GTT 61GB on a 123GB host).
+@test "amd_memory_type: real VRAM vendor keeps discrete card discrete despite large GTT" {
+    run amd_memory_type $((31 * 1073741824)) $((61 * 1073741824)) "samsung"
+    assert_success
+    assert_output "discrete"
+}
+
+@test "amd_memory_type: no vendor + large GTT still resolves unified (Strix Halo fallback)" {
+    # A real unified-memory APU reports no dedicated-VRAM vendor; the GTT
+    # heuristics must keep resolving it to unified, including a large VRAM carve-out.
+    run amd_memory_type $((48 * 1073741824)) $((96 * 1073741824)) ""
+    assert_success
+    assert_output "unified"
+}
+
+@test "amd_memory_type: vendor 'unknown' falls through to GTT heuristics" {
+    run amd_memory_type $((8 * 1073741824)) $((96 * 1073741824)) "unknown"
+    assert_success
+    assert_output "unified"
+}
+
+@test "amd_memory_type: vendor 'N/A' falls through to GTT heuristics" {
+    run amd_memory_type $((8 * 1073741824)) $((96 * 1073741824)) "N/A"
+    assert_success
+    assert_output "unified"
+}
+
+@test "detect_amd_topo: mem_info_vram_vendor drives memory_type per card" {
+    local drm="$BATS_TEST_TMPDIR/sys/class/drm"
+
+    # card0: discrete card on a large-RAM host — big GTT, but a real VRAM vendor
+    local card_dir="$drm/card0/device"
+    mkdir -p "$card_dir"
+    echo "0x1002" > "$card_dir/vendor"
+    echo "0x7551" > "$card_dir/device"
+    echo "$((31 * 1073741824))" > "$card_dir/mem_info_vram_total"
+    echo "$((61 * 1073741824))" > "$card_dir/mem_info_gtt_total"
+    echo "samsung" > "$card_dir/mem_info_vram_vendor"
+    echo "Discrete card" > "$card_dir/product_name"
+
+    # card1: APU — no vendor file, big GTT
+    card_dir="$drm/card1/device"
+    mkdir -p "$card_dir"
+    echo "0x1002" > "$card_dir/vendor"
+    echo "0x13c0" > "$card_dir/device"
+    echo "$((2 * 1073741824))" > "$card_dir/mem_info_vram_total"
+    echo "$((61 * 1073741824))" > "$card_dir/mem_info_gtt_total"
+    echo "Display iGPU" > "$card_dir/product_name"
+
+    amd-smi() { return 1; }
+    rocm-smi() { return 1; }
+    rocminfo() { return 1; }
+    export ODS_DRM_SYS="$drm"
+
+    local output types
+    output=$(detect_amd_topo)
+    types=$(echo "$output" | jq -r '.gpus[].memory_type' | paste -sd ',' -)
+    assert_equal "$types" "discrete,unified"
+}
+
 @test "detect_amd_topo: emits GPUs in numeric DRM card order" {
     local drm="$BATS_TEST_TMPDIR/sys/class/drm"
     local card

--- a/ods/tests/fixtures/topology_json/amd_2_discrete_plus_display_igpu.json
+++ b/ods/tests/fixtures/topology_json/amd_2_discrete_plus_display_igpu.json
@@ -1,0 +1,67 @@
+{
+  "vendor": "amd",
+  "gpu_count": 3,
+  "driver_version": "6.16.13",
+  "numa": {},
+  "gpus": [
+    {
+      "index": 0,
+      "name": "AMD GPU (0x7551)",
+      "memory_gb": 31.9,
+      "pcie_gen": "32",
+      "pcie_width": "x16",
+      "uuid": "99ff7551-0000-1000-80e9-5af35d2fae9c",
+      "gfx_version": "gfx1201",
+      "render_node": "128",
+      "memory_type": "discrete",
+      "pci_bdf": "0000:03:00.0"
+    },
+    {
+      "index": 1,
+      "name": "AMD GPU (0x7551)",
+      "memory_gb": 31.9,
+      "pcie_gen": "32",
+      "pcie_width": "x16",
+      "uuid": "43ff7551-0000-1000-8099-fbcfe5fc05fd",
+      "gfx_version": "gfx1201",
+      "render_node": "129",
+      "memory_type": "discrete",
+      "pci_bdf": "0000:07:00.0"
+    },
+    {
+      "index": 2,
+      "name": "AMD GPU (0x13c0)",
+      "memory_gb": 2.0,
+      "pcie_gen": "16",
+      "pcie_width": "x16",
+      "uuid": "00ff13c0-0000-1000-8000-000000000000",
+      "gfx_version": "gfx1036",
+      "render_node": "130",
+      "memory_type": "unified",
+      "pci_bdf": "0000:7e:00.0"
+    }
+  ],
+  "links": [
+    {
+      "gpu_a": 0,
+      "gpu_b": 1,
+      "link_type": "PCIE",
+      "link_label": "PCIe-HostBridge",
+      "rank": 30
+    },
+    {
+      "gpu_a": 0,
+      "gpu_b": 2,
+      "link_type": "PCIE",
+      "link_label": "PCIe-HostBridge",
+      "rank": 30
+    },
+    {
+      "gpu_a": 1,
+      "gpu_b": 2,
+      "link_type": "PCIE",
+      "link_label": "PCIe-HostBridge",
+      "rank": 30
+    }
+  ]
+}

--- a/ods/tests/test-assign-gpus.py
+++ b/ods/tests/test-assign-gpus.py
@@ -629,3 +629,39 @@ class TestParallelismModeSelection:
     def test_mem_util_pipeline_is_095(self):
         _, out, _ = run(fixture_path("nvidia_smi_topo_matrix_4gpus_soc.json"), 100000)
         assert parallelism(out)["gpu_memory_utilization"] == 0.95
+
+
+# ── AMD: display iGPU alongside discrete cards ────────────────────────────────
+
+class TestDiscreteWithDisplayIgpu:
+    """
+    A desktop AMD box exposes a display iGPU (Raphael gfx1036, 2GB) next to the real
+    compute cards. It is a GPU by every structural test, so it used to land in the
+    assignable pool: llama_server took both discrete cards, leaving `remaining == 1`,
+    and whisper + comfyui + embeddings were all pinned to the display iGPU — which has
+    no meaningful compute and shares system RAM.
+    """
+    TOPO = fixture_path("amd_2_discrete_plus_display_igpu.json")
+    IGPU_UUID = "00ff13c0-0000-1000-8000-000000000000"
+    DGPU_UUIDS = {
+        "99ff7551-0000-1000-80e9-5af35d2fae9c",
+        "43ff7551-0000-1000-8099-fbcfe5fc05fd",
+    }
+
+    def test_no_service_is_assigned_to_the_display_igpu(self):
+        _, out, _ = run(self.TOPO, 20000)
+        assert self.IGPU_UUID not in all_assigned_uuids(out)
+
+    def test_every_assignment_lands_on_a_discrete_gpu(self):
+        _, out, _ = run(self.TOPO, 20000)
+        assert all_assigned_uuids(out) <= self.DGPU_UUIDS
+
+    def test_llama_uses_both_discrete_gpus(self):
+        _, out, _ = run(self.TOPO, 40000)
+        assert set(llama(out)["gpus"]) == self.DGPU_UUIDS
+
+    def test_igpu_is_not_counted_toward_model_capacity(self):
+        # 60GB model fits the two 31.9GB cards only if the 2GB iGPU is excluded from
+        # the pool but the pair is still used; it must never be padded with the iGPU.
+        _, out, _ = run(self.TOPO, 60000)
+        assert self.IGPU_UUID not in all_assigned_uuids(out)


### PR DESCRIPTION
gpu: stop scheduling services onto the display iGPU next to discrete cards

On a desktop AMD box with a display iGPU (e.g. Raphael gfx1036, 2GB) alongside real
compute cards, ODS assigns whisper, comfyui AND embeddings to the iGPU. It has no
meaningful compute and shares system RAM. Two independent causes.

1. amd-topo.sh mislabels discrete GPUs as unified.

   amd_memory_type() classified on GTT size:

       if [[ $gtt_gb_int -ge 16 && $vram_gb_int -le 4 ]] || [[ $gtt_gb_int -ge 32 ]]

   GTT is *system* memory the GPU may map -- roughly half of host RAM -- so a discrete
   card on a large-RAM host reports a large GTT too. The `gtt >= 32` clause therefore
   brands EVERY discrete AMD GPU on a host with >= 64 GB of RAM as "unified". Observed
   on 2x Radeon AI PRO R9700 (31 GB VRAM each, GTT 61 GB, 123 GB host): both discrete
   cards labelled unified.

   That silently disables the "prefer discrete GPUs for the LLM" logic in
   assign_gpus.py (~L517), which can only fire when something is labelled discrete.

   Fixed by checking mem_info_vram_vendor first: a discrete card has dedicated VRAM
   from a real vendor and says so (samsung/hynix/micron/gddr6/hbm); an APU has no
   dedicated VRAM and reports nothing. The existing GTT heuristics are kept as the
   fallback for the no-vendor case, so Strix Halo -- including a large VRAM carve-out --
   still resolves to unified exactly as before.

2. assign_gpus.py treats the iGPU as assignable.

   The iGPU is a GPU by every structural test, so it lands in the pool. llama_server
   takes both discrete cards, `remaining == 1`, and assign_services() hands that one
   remaining GPU -- the display iGPU -- all three services.

   Fixed by dropping integrated GPUs from the assignable pool when discrete GPUs are
   present. Guarded on discrete GPUs actually existing, so a pure-APU host (Strix Halo,
   where the integrated GPU *is* the compute device) keeps every GPU and is unaffected.

Both causes are regression-tested:

  - Cause 1 (mislabel): five bats cases in tests/bats-tests/amd-topo.bats cover the
    vendor-first branch (real vendor + large GTT stays discrete), the unknown/N-A
    fallthrough, the no-vendor Strix Halo fallback, and mem_info_vram_vendor wiring
    through detect_amd_topo.
  - Cause 2 (assignability): a fixture for the 2-discrete + 1-display-iGPU topology
    and four scheduler tests. They fail against the current code (all three services
    land on the iGPU) and pass after. Full python suite: 89 passed.

Also updates docs/HARDWARE-GUIDE.md, which still listed AMD discrete GPUs under
"What NOT to Buy" with a blanket "ROCm support limited".

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


---

