### PR TITLE
dashboard-api: stop reporting a display iGPU's GTT as its GPU memory

### DIFF
--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -60,13 +60,44 @@ def _read_meminfo_mb() -> Optional[tuple[int, int]]:
 
 
 def _find_amd_gpu_sysfs() -> Optional[str]:
-    """Find the sysfs base path for an AMD GPU device."""
+    """Find the sysfs base path for an AMD GPU device.
+
+    Prefers a discrete card (one reporting a real VRAM vendor) so that on a
+    desktop where the display APU happens to sort first, the summary reflects
+    the compute GPU rather than the iGPU. Falls back to the first AMD card,
+    which on an APU-only host (Strix Halo) is the compute device.
+    """
     import glob
+    first_amd = None
     for card_dir in sorted(glob.glob("/sys/class/drm/card*/device")):
         vendor = _read_sysfs(f"{card_dir}/vendor")
-        if vendor == "0x1002":
+        if vendor != "0x1002":
+            continue
+        if first_amd is None:
+            first_amd = card_dir
+        vram_vendor = (_read_sysfs(f"{card_dir}/mem_info_vram_vendor") or "").strip().lower()
+        if vram_vendor and vram_vendor not in ("unknown", "n/a"):
             return card_dir
-    return None
+    return first_amd
+
+
+def _amd_memory_is_unified(base: str, vram_total: int, gtt_total: int) -> bool:
+    """Classify an AMD GPU as unified-memory (APU) vs discrete.
+
+    A discrete card has dedicated VRAM from a real memory vendor and says so in
+    mem_info_vram_vendor (samsung/hynix/micron/gddr6/hbm...); an APU has no
+    dedicated VRAM and reports nothing there. Check that FIRST: GTT is *system*
+    memory the GPU may map — roughly half of host RAM — so a GTT-vs-VRAM ratio
+    alone brands any modest-VRAM discrete card on a large-RAM host as unified
+    and then reports host RAM as its "GPU memory" (observed: a 2 GB display
+    iGPU shown with 111 GB, and 32 GB R9700s would flip too on a 256 GB host).
+    The ratio heuristic is kept as the fallback for kernels/devices that do not
+    expose a vendor, so real APUs (Strix Halo) still resolve to unified.
+    """
+    vendor = (_read_sysfs(f"{base}/mem_info_vram_vendor") or "").strip().lower()
+    if vendor and vendor not in ("unknown", "n/a"):
+        return False
+    return gtt_total > vram_total * 4
 
 
 def _find_hwmon_dir(device_path: str) -> Optional[str]:
@@ -100,7 +131,7 @@ def get_gpu_info_amd() -> Optional[GPUInfo]:
         gtt_used = int(gtt_used_str) if gtt_used_str else 0
         gpu_busy = int(gpu_busy_str) if gpu_busy_str else 0
 
-        is_unified = gtt_total > vram_total * 4
+        is_unified = _amd_memory_is_unified(base, vram_total, gtt_total)
 
         if is_unified:
             mem_total = gtt_total
@@ -603,9 +634,11 @@ def get_gpu_info_amd_detailed() -> Optional[list[IndividualGPU]]:
     assignment = decode_gpu_assignment()
     uuid_service_map = _build_uuid_service_map(assignment) if assignment else {}
 
-    gpus: list[IndividualGPU] = []
-    for idx, base in enumerate(amd_cards):
-        hwmon = _find_hwmon_dir(base)
+    # Pass 1: read raw memory info per card. Whether an APU should present GTT
+    # (mappable system RAM) as "its" memory depends on the whole system, so the
+    # decision is made after all cards have been read.
+    raw: list[Optional[dict]] = []
+    for base in amd_cards:
         try:
             vram_total_str = _read_sysfs(f"{base}/mem_info_vram_total")
             vram_used_str = _read_sysfs(f"{base}/mem_info_vram_used")
@@ -614,6 +647,7 @@ def get_gpu_info_amd_detailed() -> Optional[list[IndividualGPU]]:
             gpu_busy_str = _read_sysfs(f"{base}/gpu_busy_percent")
 
             if not vram_total_str or not vram_used_str:
+                raw.append(None)
                 continue
 
             vram_total = int(vram_total_str)
@@ -621,11 +655,32 @@ def get_gpu_info_amd_detailed() -> Optional[list[IndividualGPU]]:
             gtt_total = int(gtt_total_str) if gtt_total_str else 0
             gtt_used = int(gtt_used_str) if gtt_used_str else 0
             gpu_busy = int(gpu_busy_str) if gpu_busy_str else 0
+        except (ValueError, TypeError):
+            raw.append(None)
+            continue
+        raw.append({
+            "vram_total": vram_total, "vram_used": vram_used,
+            "gtt_total": gtt_total, "gtt_used": gtt_used,
+            "gpu_busy": gpu_busy,
+            "is_unified": _amd_memory_is_unified(base, vram_total, gtt_total),
+        })
 
-            is_unified = gtt_total > vram_total * 4
-            mem_total = gtt_total if is_unified else vram_total
-            mem_used = gtt_used if is_unified else vram_used
+    # An APU's GTT is the memory pool only when the APU is the compute device
+    # (Strix Halo). Next to discrete cards it is a display adapter — presenting
+    # GTT would show host RAM as GPU memory (a 2 GB display iGPU rendered as
+    # ~111 GB), so it presents its dedicated VRAM carve-out instead.
+    any_discrete = any(r is not None and not r["is_unified"] for r in raw)
 
+    gpus: list[IndividualGPU] = []
+    for idx, (base, r) in enumerate(zip(amd_cards, raw)):
+        if r is None:
+            continue
+        try:
+            use_gtt = r["is_unified"] and not any_discrete
+            mem_total = r["gtt_total"] if use_gtt else r["vram_total"]
+            mem_used = r["gtt_used"] if use_gtt else r["vram_used"]
+
+            hwmon = _find_hwmon_dir(base)
             temp = 0
             power_w = None
             if hwmon:
@@ -646,7 +701,7 @@ def get_gpu_info_amd_detailed() -> Optional[list[IndividualGPU]]:
                 memory_used_mb=mem_used_mb,
                 memory_total_mb=mem_total_mb,
                 memory_percent=round(mem_used_mb / mem_total_mb * 100, 1) if mem_total_mb > 0 else 0.0,
-                utilization_percent=gpu_busy,
+                utilization_percent=r["gpu_busy"],
                 temperature_c=temp,
                 power_w=power_w,
                 assigned_services=uuid_service_map.get(gpu_uuid, []),

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_amd.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_amd.py
@@ -3,6 +3,8 @@
 from unittest.mock import patch
 
 from gpu import (
+    _amd_memory_is_unified,
+    _find_amd_gpu_sysfs,
     _find_hwmon_power,
     _find_hwmon_temp,
     get_gpu_info_amd,
@@ -443,3 +445,144 @@ class TestGetGpuInfoAmdDetailedMultiGpu:
         assert result is not None
         assert len(result) == 1  # card0 skipped, card1 present
         assert result[0].index == 1  # Keeps enumeration index (card1)
+
+
+# ============================================================================
+# _amd_memory_is_unified — vendor-first unified/discrete classification
+# ============================================================================
+
+
+class TestAmdMemoryIsUnified:
+    """GTT is system memory the GPU may map (~half of host RAM), so the
+    GTT-vs-VRAM ratio alone misclassifies discrete cards on large-RAM hosts.
+    A real VRAM vendor must win over the ratio heuristic."""
+
+    BASE = "/sys/class/drm/card0/device"
+    GIB = 1024**3
+
+    def _classify(self, monkeypatch, vendor, vram_gb, gtt_gb):
+        monkeypatch.setattr(
+            "gpu._read_sysfs",
+            lambda path: vendor if path.endswith("/mem_info_vram_vendor") else None,
+        )
+        return _amd_memory_is_unified(self.BASE, vram_gb * self.GIB, gtt_gb * self.GIB)
+
+    def test_real_vendor_stays_discrete_despite_huge_gtt(self, monkeypatch):
+        # R9700 on a 123 GB host: 31.9 GB VRAM, ~111 GB GTT
+        assert self._classify(monkeypatch, "samsung", 2, 111) is False
+
+    def test_no_vendor_with_huge_gtt_is_unified(self, monkeypatch):
+        # Display iGPU / APU: no dedicated-VRAM vendor reported
+        assert self._classify(monkeypatch, None, 2, 111) is True
+
+    def test_vendor_unknown_falls_back_to_ratio(self, monkeypatch):
+        assert self._classify(monkeypatch, "unknown", 2, 111) is True
+
+    def test_vendor_na_falls_back_to_ratio(self, monkeypatch):
+        assert self._classify(monkeypatch, "N/A", 2, 111) is True
+
+    def test_no_vendor_small_gtt_is_discrete(self, monkeypatch):
+        assert self._classify(monkeypatch, None, 24, 16) is False
+
+
+# ============================================================================
+# Display iGPU next to discrete cards — GTT must not be shown as GPU memory
+# ============================================================================
+
+
+class TestDisplayIgpuNextToDiscrete:
+    """Regression for a 2-discrete + display-iGPU desktop (2x R9700 + Raphael):
+    the iGPU (2 GB VRAM, ~111 GB GTT) was reported with memory_total ~111 GB
+    because GTT was presented as its memory pool."""
+
+    GIB = 1024**3
+
+    def _mixed_sysfs(self):
+        sysfs = {}
+        for card, vram_gb, vendor in (
+            ("card1", 32, "samsung"),   # discrete R9700
+            ("card2", 32, "samsung"),   # discrete R9700
+            ("card3", 2, None),         # Raphael display iGPU
+        ):
+            base = f"/sys/class/drm/{card}/device"
+            sysfs.update({
+                f"{base}/mem_info_vram_total": str(vram_gb * self.GIB),
+                f"{base}/mem_info_vram_used": str(self.GIB // 2),
+                f"{base}/mem_info_gtt_total": str(111 * self.GIB),
+                f"{base}/mem_info_gtt_used": str(self.GIB // 16),
+                f"{base}/gpu_busy_percent": "5",
+                f"{base}/product_name": f"AMD ({card})",
+            })
+            if vendor:
+                sysfs[f"{base}/mem_info_vram_vendor"] = vendor
+        return sysfs
+
+    def _run_detailed(self, monkeypatch, sysfs, cards):
+        def mock_read_sysfs(path):
+            if path.endswith("/vendor") and not path.endswith("/mem_info_vram_vendor"):
+                return "0x1002"
+            return sysfs.get(path)
+
+        monkeypatch.setattr("gpu._read_sysfs", mock_read_sysfs)
+        monkeypatch.setattr("gpu._find_hwmon_dir", lambda base: None)
+        monkeypatch.setattr("gpu.read_gpu_topology", lambda: None)
+        monkeypatch.setattr("gpu.decode_gpu_assignment", lambda: None)
+        card_paths = [f"/sys/class/drm/{c}/device" for c in cards]
+        with patch("glob.glob", return_value=card_paths):
+            return get_gpu_info_amd_detailed()
+
+    def test_igpu_reports_its_vram_carveout_not_gtt(self, monkeypatch):
+        result = self._run_detailed(
+            monkeypatch, self._mixed_sysfs(), ["card1", "card2", "card3"])
+        assert result is not None and len(result) == 3
+        igpu = result[2]
+        assert igpu.memory_total_mb == 2 * 1024      # 2 GB carve-out
+        assert igpu.memory_total_mb != 111 * 1024    # not host RAM
+
+    def test_discrete_cards_report_vram(self, monkeypatch):
+        result = self._run_detailed(
+            monkeypatch, self._mixed_sysfs(), ["card1", "card2", "card3"])
+        for gpu_entry in result[:2]:
+            assert gpu_entry.memory_total_mb == 32 * 1024
+
+    def test_apu_only_host_keeps_unified_gtt_view(self, monkeypatch):
+        """Strix Halo: a lone APU (no VRAM vendor) must still present GTT."""
+        base = "/sys/class/drm/card0/device"
+        sysfs = {
+            f"{base}/mem_info_vram_total": str(4 * self.GIB),
+            f"{base}/mem_info_vram_used": str(self.GIB),
+            f"{base}/mem_info_gtt_total": str(96 * self.GIB),
+            f"{base}/mem_info_gtt_used": str(10 * self.GIB),
+            f"{base}/gpu_busy_percent": "20",
+            f"{base}/product_name": "AMD Strix Halo",
+        }
+        result = self._run_detailed(monkeypatch, sysfs, ["card0"])
+        assert result is not None and len(result) == 1
+        assert result[0].memory_total_mb == 96 * 1024
+
+
+# ============================================================================
+# _find_amd_gpu_sysfs — summary picker prefers the compute GPU
+# ============================================================================
+
+
+class TestFindAmdGpuSysfsPrefersDiscrete:
+    def _wire(self, monkeypatch, sysfs, cards):
+        monkeypatch.setattr("gpu._read_sysfs", lambda path: sysfs.get(path))
+        return [f"/sys/class/drm/{c}/device" for c in cards]
+
+    def test_prefers_discrete_when_igpu_sorts_first(self, monkeypatch):
+        sysfs = {
+            "/sys/class/drm/card0/device/vendor": "0x1002",  # iGPU, no vram vendor
+            "/sys/class/drm/card1/device/vendor": "0x1002",
+            "/sys/class/drm/card1/device/mem_info_vram_vendor": "samsung",
+        }
+        card_paths = self._wire(monkeypatch, sysfs, ["card0", "card1"])
+        with patch("glob.glob", return_value=card_paths):
+            assert _find_amd_gpu_sysfs() == "/sys/class/drm/card1/device"
+
+    def test_falls_back_to_lone_apu(self, monkeypatch):
+        sysfs = {"/sys/class/drm/card0/device/vendor": "0x1002"}
+        card_paths = self._wire(monkeypatch, sysfs, ["card0"])
+        with patch("glob.glob", return_value=card_paths):
+            assert _find_amd_gpu_sysfs() == "/sys/class/drm/card0/device"


### PR DESCRIPTION
dashboard-api: stop reporting a display iGPU's GTT as its GPU memory

The dashboard GPU page showed a 2 GB display iGPU (Raphael, next to 2x
Radeon AI PRO R9700) as having ~111 GB of memory. Two stacked causes in
gpu.py, both instances of the same GTT-heuristic mistake that the
companion branch fix/amd-igpu-assigned-real-work fixes for scheduling in
amd-topo.sh / assign_gpus.py:

1. Unified/discrete was classified by ratio alone (gtt > vram * 4). GTT is
   *system* memory the GPU may map -- roughly half of host RAM -- so the
   ratio brands modest-VRAM discrete cards on large-RAM hosts as unified
   too (a 32 GB R9700 flips on a >=256 GB host, and the memory panel with
   it). A real mem_info_vram_vendor (samsung/hynix/...) now wins first;
   the ratio remains the fallback for APUs, which report no vendor.

2. Even correctly classified, an APU next to discrete cards should not
   present GTT as "its" memory: it is a display adapter there, and its GTT
   is just host RAM (113817 MB rendered as the iGPU's memory pool).
   get_gpu_info_amd_detailed() now presents an APU's GTT only when no
   discrete GPU exists -- a pure-APU host (Strix Halo) keeps the unified
   GTT view exactly as before.

Also makes _find_amd_gpu_sysfs() (the single-GPU summary behind
/api/preflight/gpu and /gpu) prefer a discrete card over an APU, so a
desktop where the display iGPU happens to sort first does not report
"111 GB Unified" as the machine's GPU.

Observed on 2x R9700 + Raphael iGPU (123 GB host): /api/gpu/detailed
reported index 2 as 63/113817 MB. With the fix, run against the same live
sysfs: 538/2048 MB -- matching `ods gpu status` on a host that also
carries fix/amd-igpu-assigned-real-work, which makes the topology that
command reads vendor-aware in the same way. Nothing schedules from
gpu.py's numbers, so this is a display-only bug.

Adds 10 tests: vendor-first classification, the mixed-topology regression
(iGPU shows its 2 GB carve-out, R9700s their VRAM), the Strix Halo
pure-APU view preserved, and discrete-preferred summary selection.
Full dashboard-api suite: 1192 passed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


---

