### PR TITLE
cli: make ods model swap actually reach LiteLLM

### DIFF
--- a/ods/docs/INSTALLER-ARCHITECTURE.md
+++ b/ods/docs/INSTALLER-ARCHITECTURE.md
@@ -123,7 +123,7 @@ done. This is the most common way install-time surprises survive a patch.
 |----------------|--------------|--------------|----------------|------------------------|
 | `.env` and core ports/secrets | `phases/06-directories.sh` | `installers/macos/lib/env-generator.sh` | `installers/windows/lib/env-generator.ps1` | `ods config`, `ods update`, installer re-runs |
 | OpenCode config | `phases/07-devtools.sh` | `installers/macos/install-macos.sh` | `installers/windows/lib/opencode-config.ps1` | `scripts/update-windows-opencode-config.ps1`, `scripts/bootstrap-upgrade.sh` |
-| LiteLLM Lemonade config | `phases/06-directories.sh` | n/a | n/a | `scripts/bootstrap-upgrade.sh`, `bin/ods-host-agent.py` |
+| LiteLLM Lemonade config | `phases/06-directories.sh` | n/a | n/a | `scripts/bootstrap-upgrade.sh`, `bin/ods-host-agent.py`, `ods model swap` (`ods-cli`) |
 | Perplexica config | `phases/12-health.sh`, `phases/13-summary.sh` | `installers/macos/lib/env-generator.sh`, `installers/macos/install-macos.sh` | `installers/windows/lib/env-generator.ps1`, `installers/windows/install-windows.ps1` | `scripts/bootstrap-upgrade.sh`, `scripts/repair/repair-perplexica.sh` |
 | Hermes config | `phases/11-services.sh`, `scripts/patch-hermes-config.py` | `installers/macos/install-macos.sh` | `installers/windows/phases/06-directories.ps1` | `scripts/bootstrap-upgrade.sh`, `bin/ods-host-agent.py` |
 

--- a/ods/docs/MODE-SWITCH.md
+++ b/ods/docs/MODE-SWITCH.md
@@ -151,6 +151,10 @@ ods model list
 ods model swap T3
 ```
 
+In lemonade mode, `ods model swap` also regenerates `config/litellm/lemonade.yaml`
+(which pins the model by name) and restarts `ods-litellm`, so clients pick up the
+new model without manual config edits.
+
 For Dashboard downloads, loading catalog models, and manual GGUF swaps, see
 [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md).
 

--- a/ods/docs/MODEL-MANAGEMENT.md
+++ b/ods/docs/MODEL-MANAGEMENT.md
@@ -178,6 +178,14 @@ waiting too long to compact.
 
 5. For AMD/Lemonade installs, verify `config/litellm/lemonade.yaml`.
 
+This file pins the model by name on both its `default` and `"*"` entries, and
+LiteLLM is what every client talks to — if it still names the old GGUF, the swap
+has not taken effect regardless of what `.env` says. Tier swaps via
+`ods model swap` regenerate it and restart `ods-litellm` automatically; after a
+manual `.env`/GGUF edit like this one, verify it yourself (re-run
+`scripts/render-runtime-configs.py --surface litellm-lemonade` rather than
+hand-editing).
+
 Each local model alias should use the `extra.<GGUF_FILE>` form and should keep
 Qwen3 thinking disabled for clients that do not pass that flag themselves:
 
@@ -272,6 +280,11 @@ curl http://localhost:11434/v1/models
 
 If the server is correct, refresh the app. If the server is wrong, restart
 `llama-server` and verify `.env` / `models.ini`.
+
+On AMD/Lemonade installs, also check `config/litellm/lemonade.yaml`: clients go
+through LiteLLM, which pins the model by name there. If it names the old GGUF,
+regenerate it (a tier swap via `ods model swap` does this automatically) and
+restart `ods-litellm`.
 
 ### Hermes still asks for the old model
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3040,6 +3040,83 @@ cmd_mode() {
     success "Switched to $mode mode. Run 'ods restart' to apply."
 }
 
+# Regenerate config/litellm/lemonade.yaml for the currently-configured model.
+#
+# In lemonade mode this file is the ONLY config LiteLLM mounts
+# (./config/litellm/${ODS_MODE}.yaml:/app/config.yaml), and it names the model
+# explicitly on both its `default` and `"*"` entries — Lemonade exposes models as
+# "extra.<GGUF_FILE>" and 404s on anything else, so a wildcard passthrough is not an
+# option. Until now the file was written in exactly two places: phase 06 at install,
+# and bootstrap-upgrade.sh after a hot-swap. `ods model swap` wrote LLM_MODEL/GGUF_FILE
+# to .env and stopped there — so LiteLLM kept serving the OLD model, and every consumer
+# (Open WebUI, Hermes, OpenClaw, Perplexica) went with it, no matter what .env said.
+#
+# Mirrors the renderer invocation used by bootstrap-upgrade.sh:1557 — deliberately
+# WITHOUT its inline-heredoc fallback writer: a second hand-rolled writer would
+# drift from the renderer's output, and when the renderer fails this function says
+# so loudly instead of papering over it.
+_model_refresh_litellm_lemonade() {
+    local gguf="$1"
+    local mode
+    mode="$(_env_get_raw ODS_MODE | tr -d '"\047')"
+    [[ "$mode" == "lemonade" ]] || return 0
+    [[ -n "$gguf" ]] || { warn "No GGUF_FILE resolved; LiteLLM config left unchanged"; return 1; }
+
+    local key api_base location port
+    key="$(_env_get_raw LITELLM_LEMONADE_API_KEY | tr -d '"\047')"
+    : "${key:=sk-lemonade}"
+
+    # Container-to-container this is the compose SERVICE name, not the container name.
+    api_base="http://llama-server:8080/api/v1"
+    location="$(_env_get_raw AMD_INFERENCE_LOCATION | tr -d '"\047' | tr '[:upper:]' '[:lower:]')"
+    port="$(_env_get_raw AMD_INFERENCE_PORT | tr -d '"\047')"
+    : "${port:=8080}"
+    [[ "$location" == "host" ]] && api_base="http://host.docker.internal:${port}/api/v1"
+
+    local py="${ODS_PYTHON_CMD:-}"
+    if [[ -z "$py" && -f "$INSTALL_DIR/lib/python-cmd.sh" ]]; then
+        . "$INSTALL_DIR/lib/python-cmd.sh"
+        py="$(ods_detect_python_cmd 2>/dev/null || true)"
+    fi
+    : "${py:=python3}"
+
+    local script="$INSTALL_DIR/scripts/render-runtime-configs.py"
+    if [[ ! -f "$script" ]] || ! command -v "$py" >/dev/null 2>&1; then
+        warn "Runtime config renderer unavailable; LiteLLM still points at the previous model."
+        warn "  LiteLLM is what every client talks to, so the swap will NOT take effect."
+        return 1
+    fi
+
+    local render_out
+    if ! render_out="$("$py" "$script" \
+            --surface litellm-lemonade \
+            --ods-mode lemonade \
+            --gpu-backend amd \
+            --gguf-file "$gguf" \
+            --lemonade-api-base "$api_base" \
+            --litellm-key "$key" \
+            --output-root "$INSTALL_DIR" \
+            --write 2>&1)"; then
+        warn "Renderer failed; LiteLLM still points at the previous model."
+        [[ -n "$render_out" ]] && printf '%s\n' "$render_out" >&2
+        warn "  LiteLLM is what every client talks to, so the swap will NOT take effect."
+        return 1
+    fi
+
+    success "LiteLLM config updated → extra.${gguf}"
+
+    local restart_out
+    if docker ps --filter name=ods-litellm --format '{{.Names}}' 2>/dev/null | grep -q ods-litellm; then
+        if restart_out="$(docker restart ods-litellm 2>&1)"; then
+            success "Restarted ods-litellm"
+        else
+            warn "Could not restart ods-litellm — run: docker restart ods-litellm"
+            [[ -n "$restart_out" ]] && printf '%s\n' "$restart_out" >&2
+        fi
+    fi
+    return 0
+}
+
 cmd_model() {
     check_install; cd "$INSTALL_DIR"
     local subcmd="${1:-current}"
@@ -3085,7 +3162,15 @@ cmd_model() {
             _env_set "GGUF_URL" "$GGUF_URL"
             _env_set "CTX_SIZE" "$MAX_CONTEXT"
             _env_set "MAX_CONTEXT" "$MAX_CONTEXT"
-            success "Model set to $model (tier $tier, ctx=$MAX_CONTEXT). Run 'ods restart llama-server' to apply."
+            success "Model set to $model (tier $tier, ctx=$MAX_CONTEXT)"
+
+            # Writing .env is not enough in lemonade mode: LiteLLM pins the model by name
+            # in config/litellm/lemonade.yaml, and every client goes through LiteLLM. Without
+            # this the swap silently has no effect.
+            _model_refresh_litellm_lemonade "$GGUF_FILE" \
+                || warn "LiteLLM refresh failed (non-fatal — .env is updated, but clients keep the old model until it succeeds)"
+
+            success "Run 'ods restart llama-server' to apply."
             ;;
         *)
             error "Usage: ods model <current|list|swap>"


### PR DESCRIPTION
cli: make `ods model swap` actually reach LiteLLM

In lemonade mode `ods model swap <tier>` silently does nothing. It writes LLM_MODEL /
GGUF_FILE / CTX_SIZE to .env and stops -- but every client talks to LiteLLM, and LiteLLM
pins the model BY NAME in config/litellm/lemonade.yaml:

    - model_name: default
      litellm_params:
        model: openai/extra.<OLD_GGUF>
    - model_name: "*"
      litellm_params:
        model: openai/extra.<OLD_GGUF>

That file names the model explicitly on both entries -- Lemonade exposes models as
"extra.<GGUF_FILE>" and 404s on anything else, so a wildcard passthrough is not an
option. It was written in exactly two places: phase 06 at install, and
bootstrap-upgrade.sh after a hot-swap. Nothing regenerates it on a manual swap.

So the user swaps the model, `ods restart llama-server`, and Open WebUI / Hermes /
OpenClaw / Perplexica all keep serving the OLD model -- Lemonade loads on demand by
requested name, so it happily serves whatever LiteLLM asks for. .env says one thing,
every client gets another, and nothing errors.

Observed: .env asked for Qwen3.6-35B-A3B while LiteLLM served the 2B bootstrap model on
a 64GB-VRAM box.

`ods model swap` now regenerates lemonade.yaml through the same renderer contract
bootstrap-upgrade.sh:1557 uses, and restarts ods-litellm. Non-lemonade modes are
unaffected (the helper returns early). If the renderer is missing or fails, it says so
loudly and explains that the swap will NOT take effect, rather than reporting success.

Verified: `ods model swap T0` on an install serving Qwen3.6-35B-A3B rewrote both entries
to extra.Qwen3.5-2B-Q4_K_M.gguf, restarted LiteLLM, and a completion through LiteLLM
came back from Qwen3.5-2B-Q4_K_M.gguf -- where previously it would have stayed on the 35B.

Unlike bootstrap-upgrade.sh, there is deliberately no inline fallback writer when
the renderer is unavailable: a second hand-rolled writer would drift from the
renderer's output, and failing loudly beats succeeding differently. Renderer and
docker-restart stderr are surfaced on failure, not swallowed.

Docs: adds ods model swap to INSTALLER-ARCHITECTURE.md's config-writer table
(lemonade.yaml row), documents the new behavior in MODEL-MANAGEMENT.md (BYO-GGUF
step 5 + the stale-model troubleshooting entry) and MODE-SWITCH.md.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


---

