### PR TITLE
llama-server(amd): make Lemonade actually use the custom ROCm binary

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -994,8 +994,8 @@
     },
     "LEMONADE_LLAMACPP": {
       "type": "string",
-      "description": "Lemonade inner llama.cpp backend selector for AMD multi-GPU. Applied by docker-compose.multigpu-amd.yml. Lemonade's schema accepts only auto|vulkan|cpu; 'auto' plus LEMONADE_LLAMACPP_ROCM_BIN picks up the custom ROCm-built binary.",
-      "enum": ["auto", "vulkan", "cpu"],
+      "description": "Lemonade inner llama.cpp backend selector for AMD multi-GPU. Applied by docker-compose.multigpu-amd.yml. 'rocm' pins the ROCm llama.cpp build (phase 06 writes this on AMD installs — 'auto' would re-run Lemonade's marketing-name gfx detection, which misses cards like the Radeon AI PRO R9700 and silently falls back to Vulkan); combined with LEMONADE_LLAMACPP_ROCM_BIN it selects the custom ROCm-built binary.",
+      "enum": ["auto", "vulkan", "cpu", "rocm"],
       "default": "auto"
     },
     "LEMONADE_LLAMACPP_ROCM_BIN": {

--- a/ods/docker-compose.amd.yml
+++ b/ods/docker-compose.amd.yml
@@ -61,15 +61,18 @@ services:
       - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}
       - HSA_XNACK=${HSA_XNACK:-1}
       - ROCBLAS_USE_HIPBLASLT=${ROCBLAS_USE_HIPBLASLT:-1}
-      # Lemonade's backend selector accepts auto|vulkan|cpu only; "rocm" is no
-      # longer a valid value. Setting auto + LEMONADE_LLAMACPP_ROCM_BIN points
-      # Lemonade at the custom ROCm-built llama-server binary while keeping the
-      # field schema-valid.
-      - LEMONADE_LLAMACPP_BACKEND=auto
-      # Custom binary at /opt/llama-custom is gfx1151-only (Strix Halo patches +
-      # AMDGPU_TARGET=gfx1151 at build time). Phase 06 sets this env var only
-      # when the detected gfx target is gfx1151; on any other AMD architecture
-      # it stays unset and Lemonade uses its bundled ROCm-aware binary.
+      # NOTE: the backend selector is LEMONADE_LLAMACPP (-> --llamacpp), set in
+      # docker-compose.multigpu-amd.yml. LEMONADE_LLAMACPP_BACKEND, which used to be set
+      # here, is NOT a variable Lemonade reads (its recognised names are visible with
+      # `grep -aoE 'LEMONADE_[A-Z_]+' /opt/lemonade/lemond`) — it was a no-op, so the
+      # comment claiming it kept us on "auto" was describing something that never ran.
+      # "rocm" IS still a valid backend value in v10.2.0, contrary to that comment;
+      # the server accepts it and logs `"backend": "rocm"`.
+      #
+      # The custom binary at /opt/llama-custom is built for ${AMDGPU_TARGET} and is the
+      # only ROCm stack in this image — the Lemonade base image ships no ROCm userspace.
+      # Left empty, Lemonade detects no ROCm device, falls back to its Vulkan llama.cpp
+      # build on radv, and may fail to load models outright.
       - LEMONADE_LLAMACPP_ROCM_BIN=${LEMONADE_LLAMACPP_ROCM_BIN:-}
       - LEMONADE_CTX_SIZE=${CTX_SIZE:-131072}
     healthcheck:

--- a/ods/docker-compose.amd.yml
+++ b/ods/docker-compose.amd.yml
@@ -30,7 +30,7 @@ services:
       - "0.0.0.0"
       - --no-tray
       - --llamacpp
-      - auto
+      - "${LEMONADE_LLAMACPP:-rocm}"
       - --llamacpp-args
       - "--metrics --host 0.0.0.0 -fa on -b 2048 -ub 256"
       - --extra-models-dir
@@ -61,8 +61,10 @@ services:
       - HSA_OVERRIDE_GFX_VERSION=${HSA_OVERRIDE_GFX_VERSION:-}
       - HSA_XNACK=${HSA_XNACK:-1}
       - ROCBLAS_USE_HIPBLASLT=${ROCBLAS_USE_HIPBLASLT:-1}
-      # NOTE: the backend selector is LEMONADE_LLAMACPP (-> --llamacpp), set in
-      # docker-compose.multigpu-amd.yml. LEMONADE_LLAMACPP_BACKEND, which used to be set
+      # NOTE: the backend selector is LEMONADE_LLAMACPP (-> --llamacpp), passed
+      # and exported here with a rocm default so single-GPU installs honor the
+      # installer-written value (docker-compose.multigpu-amd.yml overrides both
+      # on multi-GPU hosts). LEMONADE_LLAMACPP_BACKEND, which used to be set
       # here, is NOT a variable Lemonade reads (its recognised names are visible with
       # `grep -aoE 'LEMONADE_[A-Z_]+' /opt/lemonade/lemond`) — it was a no-op, so the
       # comment claiming it kept us on "auto" was describing something that never ran.
@@ -73,6 +75,7 @@ services:
       # only ROCm stack in this image — the Lemonade base image ships no ROCm userspace.
       # Left empty, Lemonade detects no ROCm device, falls back to its Vulkan llama.cpp
       # build on radv, and may fail to load models outright.
+      - LEMONADE_LLAMACPP=${LEMONADE_LLAMACPP:-rocm}
       - LEMONADE_LLAMACPP_ROCM_BIN=${LEMONADE_LLAMACPP_ROCM_BIN:-}
       - LEMONADE_CTX_SIZE=${CTX_SIZE:-131072}
     healthcheck:

--- a/ods/extensions/services/llama-server/lemonade-entrypoint.sh
+++ b/ods/extensions/services/llama-server/lemonade-entrypoint.sh
@@ -1,38 +1,93 @@
 #!/bin/sh
-# Lemonade context-size sync wrapper.
+# Lemonade config-sync wrapper.
 #
-# Lemonade reads `ctx_size` from /root/.cache/lemonade/config.json. That
-# file is written on Lemonade's first start using LEMONADE_CTX_SIZE from
-# env — but on subsequent starts Lemonade ignores the env var and trusts
-# whatever's already in config.json. So bumping LEMONADE_CTX_SIZE in
-# docker-compose has no effect on an existing container; the cached
-# config wins.
+# Lemonade reads its settings from /root/.cache/lemonade/config.json. That file is
+# written on Lemonade's first start from env — but on subsequent starts Lemonade
+# ignores the env vars and trusts whatever is already in config.json. The cached
+# config wins, so changing a value in docker-compose has no effect on an existing
+# container. This wrapper reconciles config.json with env before Lemonade boots.
 #
-# That meant Qwen3.6-35B-A3B (native 256k context) was being served at
-# 64k on strix-halo, a 4× under-utilization with 7% of the memory budget
-# in use. Fixed by ensuring config.json's ctx_size always matches env
-# before Lemonade boots.
+# Synced keys:
 #
-# Idempotent — does nothing if config.json is absent (first start) or
-# already has the right value.
+#   ctx_size          <- LEMONADE_CTX_SIZE
+#       Qwen3.6-35B-A3B (native 256k context) was being served at 64k on strix-halo,
+#       a 4x under-utilization with 7% of the memory budget in use.
+#
+#   llamacpp.rocm_bin <- LEMONADE_LLAMACPP_ROCM_BIN
+#       Without this, rocm_bin stays "builtin" and Lemonade tries to DOWNLOAD a
+#       llama-server matching the gfx arch it detects. Its arch detection maps GPU
+#       marketing names to gfx targets and does not know the Radeon AI PRO R9700, so
+#       on this host it resolved the *iGPU* and fetched
+#           llama-b1231-ubuntu-rocm-gfx1036-x64.zip  -> HTTP 404
+#       and inference failed to start. Pointing rocm_bin at the binary we build in
+#       Dockerfile.amd (correct gfx target, self-contained ROCm stack) avoids the
+#       download and the arch guess entirely.
+#
+#   llamacpp.backend  <- LEMONADE_LLAMACPP
+#       "auto" makes Lemonade probe for ROCm; the same name-based arch detection
+#       fails on unrecognised cards and it silently falls back to the Vulkan build
+#       (radv). Forcing "rocm" keeps it on the ROCm path.
+#
+# Idempotent: only writes when a value actually differs. If config.json does not yet
+# exist, it is seeded from Lemonade's shipped defaults so that even a FIRST start on
+# a fresh volume gets the right binary — otherwise the first run would attempt the
+# bad download before we ever got a chance to fix the file.
 set -e
 
+# Defensive: ROCm's HSA runtime checks whether HSA_OVERRIDE_GFX_VERSION is *defined*,
+# not whether it is non-empty. Defined-but-empty makes it try to parse "" as a gfx
+# version, fail, and enumerate ZERO devices — inference then silently drops to CPU or
+# Vulkan. Compose is supposed to omit the variable entirely (see docker-compose.amd.yml),
+# but scrub it here too: a single stray "VAR=${VAR:-}" anywhere in the compose merge
+# chain is enough to reintroduce it, and the failure mode is quiet.
+if [ -z "${HSA_OVERRIDE_GFX_VERSION:-}" ]; then unset HSA_OVERRIDE_GFX_VERSION || true; fi
+if [ -z "${HSA_XNACK:-}" ]; then unset HSA_XNACK || true; fi
+
 CONFIG=/root/.cache/lemonade/config.json
-if [ -f "$CONFIG" ] && [ -n "${LEMONADE_CTX_SIZE:-}" ]; then
-    python3 - <<PYEOF
-import json, sys, os
-p = "$CONFIG"
-want = int(os.environ.get("LEMONADE_CTX_SIZE", "0"))
-if want <= 0:
+DEFAULTS=/opt/lemonade/resources/defaults.json
+
+if [ ! -f "$CONFIG" ] && [ -f "$DEFAULTS" ]; then
+    mkdir -p "$(dirname "$CONFIG")"
+    cp "$DEFAULTS" "$CONFIG"
+    echo "[lemonade-entrypoint] seeded config.json from defaults.json" >&2
+fi
+
+if [ -f "$CONFIG" ]; then
+    python3 - <<'PYEOF'
+import json, os, sys
+
+path = "/root/.cache/lemonade/config.json"
+try:
+    with open(path) as f:
+        cfg = json.load(f)
+except (OSError, ValueError) as e:
+    print(f"[lemonade-entrypoint] cannot read config.json ({e}); leaving it alone", flush=True)
     sys.exit(0)
-with open(p) as f:
-    cfg = json.load(f)
-current = cfg.get("ctx_size")
-if current == want:
+
+changed = []
+
+ctx = os.environ.get("LEMONADE_CTX_SIZE", "")
+if ctx.isdigit() and int(ctx) > 0 and cfg.get("ctx_size") != int(ctx):
+    changed.append(f"ctx_size: {cfg.get('ctx_size')} -> {int(ctx)}")
+    cfg["ctx_size"] = int(ctx)
+
+for env_var, key in (("LEMONADE_LLAMACPP_ROCM_BIN", "rocm_bin"),
+                     ("LEMONADE_LLAMACPP", "backend")):
+    want = os.environ.get(env_var, "")
+    if not want:
+        continue
+    section = cfg.setdefault("llamacpp", {})
+    if section.get(key) != want:
+        changed.append(f"llamacpp.{key}: {section.get(key)} -> {want}")
+        section[key] = want
+
+if not changed:
     sys.exit(0)
-print(f"[lemonade-entrypoint] updating ctx_size: {current} -> {want}", flush=True)
-cfg["ctx_size"] = want
-with open(p, "w") as f:
+
+for line in changed:
+    print(f"[lemonade-entrypoint] updating {line}", flush=True)
+
+with open(path, "w") as f:
     json.dump(cfg, f, indent=2)
 PYEOF
 fi

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -748,18 +748,20 @@ $(if [[ "$GPU_BACKEND" == "amd" ]]; then
         *)       _amd_hsa_override="# HSA_OVERRIDE_GFX_VERSION unset — $_amd_gfx_detected is natively supported" ;;
     esac
 
-    # The custom llama-server binary at /opt/llama-custom is built with Strix
-    # Halo-specific patches (MMQ tile size reduced from 64 to 48 for gfx1151's
-    # register file). Pointing Lemonade at it from any other architecture either
-    # ISA-faults (kernels compiled for gfx1151) or runs a perf-regressed binary.
-    # Only opt-in when the host is actually Strix Halo; otherwise leave unset so
-    # docker-compose.amd.yml's empty default lets Lemonade use its bundled
-    # ROCm-aware binary.
-    if [[ "$_amd_gfx_detected" == "gfx1151" ]]; then
-        _amd_custom_bin="LEMONADE_LLAMACPP_ROCM_BIN=/opt/llama-custom/llama-server"
-    else
-        _amd_custom_bin="# LEMONADE_LLAMACPP_ROCM_BIN unset — custom binary is gfx1151-only; Lemonade uses bundled binary on $_amd_gfx_detected"
-    fi
+    # Point Lemonade at the custom llama-server binary we build in Dockerfile.amd.
+    #
+    # This used to be gated to gfx1151 on the theory that the custom binary carried
+    # Strix-Halo-only patches, and that on other architectures "Lemonade uses its
+    # bundled ROCm-aware binary." That second half is false: the Lemonade image ships
+    # no ROCm userspace at all (no rocminfo, no HIP runtime). Left unset, Lemonade
+    # logs "failed to initialize ROCm: no ROCm-capable device is detected", downloads
+    # the *Vulkan* llama.cpp build, and runs inference on radv — or fails outright.
+    #
+    # /opt/llama-custom is the only ROCm stack in the container: Dockerfile.amd copies
+    # libhsa-runtime64, libamdhip64, librocblas and the target's Tensile kernels in
+    # alongside the binary. It is built for ${AMDGPU_TARGET} = $_amd_gfx_detected, and
+    # the gfx1151 MMQ patch is gated to gfx1151, so it is correct for every target.
+    _amd_custom_bin="LEMONADE_LLAMACPP_ROCM_BIN=/opt/llama-custom/llama-server"
 
     cat << AMD_ENV
 #=== GPU Group IDs (for container device access) ===
@@ -774,6 +776,11 @@ ROCBLAS_USE_HIPBLASLT=1
 AMDGPU_TARGET=${_amd_gfx_detected}
 LLAMA_CPP_REF=b8763
 ${_amd_custom_bin}
+# Backend selector (becomes --llamacpp). NOT "auto": auto re-runs Lemonade's own gfx
+# detection, which maps GPU marketing names to arches and does not recognise every
+# card (e.g. "AMD Radeon AI PRO R9700"). On a miss it silently falls back to the
+# Vulkan build on radv. We already know the arch and ship a matching ROCm binary.
+LEMONADE_LLAMACPP=rocm
 
 #=== LiteLLM → Lemonade outbound key (AMD only) ===
 LITELLM_LEMONADE_API_KEY=${LITELLM_LEMONADE_API_KEY}

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -3907,13 +3907,30 @@ _gpu_reassign_update_amd_arch_env() {
         gfx_ver=""
     fi
 
+    # HSA_OVERRIDE_GFX_VERSION is a gfx1151-only workaround: that target is not in ROCm's
+    # official support list, so HSA is coerced into loading gfx1151 kernels by reporting
+    # "11.5.1". On natively-supported parts it MUST stay unset, or model load fails with
+    # HSA_STATUS_ERROR_INVALID_ISA. Note "unset" means genuinely absent — see the compose
+    # files: a defined-but-EMPTY HSA_OVERRIDE_GFX_VERSION makes ROCm enumerate zero devices.
     if [[ "$gfx_ver" == "gfx1151" ]]; then
         _env_set "HSA_OVERRIDE_GFX_VERSION" "11.5.1"
-        _env_set "LEMONADE_LLAMACPP_ROCM_BIN" "/opt/llama-custom/llama-server"
     else
         _env_unset "HSA_OVERRIDE_GFX_VERSION"
-        _env_unset "LEMONADE_LLAMACPP_ROCM_BIN"
     fi
+
+    # LEMONADE_LLAMACPP_ROCM_BIN is NOT arch-conditional and must never be unset here.
+    #
+    # It used to be set only for gfx1151, on the theory that the custom binary carried
+    # Strix-Halo-only patches and that other hosts would fall back to a bundled ROCm binary
+    # inside the Lemonade image. There is no such binary — the Lemonade image ships no ROCm
+    # userspace at all. Unsetting this sends Lemonade back to rocm_bin="builtin", where it
+    # tries to DOWNLOAD a llama-server for the arch it guesses from the GPU's marketing name
+    # and 404s on anything its table doesn't recognise.
+    #
+    # /opt/llama-custom is the only ROCm stack in the container, it is built for the detected
+    # AMDGPU_TARGET, and the gfx1151 MMQ patch is gated to gfx1151 — so it is correct for every
+    # target. `ods gpu reassign` silently deleting it turned a GPU re-pin into a dead stack.
+    _env_set "LEMONADE_LLAMACPP_ROCM_BIN" "/opt/llama-custom/llama-server"
 }
 
 _gpu_reassign() {

--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -160,6 +160,25 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 8a. Backend selector reaches the container in the base overlay
+# ---------------------------------------------------------------------------
+# With a literal `--llamacpp auto` (and no env passthrough) a single-GPU host
+# silently runs Lemonade's bundled Vulkan llama.cpp even after the installer
+# wrote LEMONADE_LLAMACPP=rocm — the multi-GPU overlay overrides both, which
+# is why multi-GPU hosts never hit this. Reproduced on Strix Halo (PR #1783).
+echo "[contract] base AMD overlay honors LEMONADE_LLAMACPP"
+if grep -q -- '"${LEMONADE_LLAMACPP:-rocm}"' docker-compose.amd.yml; then
+    pass "docker-compose.amd.yml: --llamacpp selects backend from LEMONADE_LLAMACPP (rocm default)"
+else
+    fail "docker-compose.amd.yml must pass --llamacpp \"\${LEMONADE_LLAMACPP:-rocm}\", not a literal backend"
+fi
+if grep -q 'LEMONADE_LLAMACPP=${LEMONADE_LLAMACPP:-rocm}' docker-compose.amd.yml; then
+    pass "docker-compose.amd.yml: LEMONADE_LLAMACPP exported into the Lemonade container"
+else
+    fail "docker-compose.amd.yml must export LEMONADE_LLAMACPP into the Lemonade container"
+fi
+
+# ---------------------------------------------------------------------------
 # 8b. AMD/Lemonade model routing preserves the selected GGUF
 # ---------------------------------------------------------------------------
 echo "[contract] AMD Lemonade routes selected GGUF through extra_models_dir"

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -96,8 +96,16 @@ grep -q '_env_set "HSA_OVERRIDE_GFX_VERSION" "11.5.1"' ods-cli \
   || { echo "[FAIL] ods-cli must set HSA override to 11.5.1 for gfx1151"; exit 1; }
 grep -q '_env_unset "HSA_OVERRIDE_GFX_VERSION"' ods-cli \
   || { echo "[FAIL] ods-cli must remove HSA override for non-Strix AMD GPUs"; exit 1; }
-grep -q '_env_unset "LEMONADE_LLAMACPP_ROCM_BIN"' ods-cli \
-  || { echo "[FAIL] ods-cli must remove gfx1151-only custom binary for non-Strix AMD GPUs"; exit 1; }
+# LEMONADE_LLAMACPP_ROCM_BIN is NOT gfx1151-only: /opt/llama-custom is the only ROCm
+# stack in the Lemonade image and is built for the detected AMDGPU_TARGET. Unsetting it
+# sends Lemonade to rocm_bin="builtin", which guesses the arch from the GPU marketing
+# name and 404s on unrecognised targets — reassigning GPUs must never kill inference.
+if grep -q '_env_unset "LEMONADE_LLAMACPP_ROCM_BIN"' ods-cli; then
+  echo "[FAIL] ods-cli must never unset LEMONADE_LLAMACPP_ROCM_BIN on reassign"
+  exit 1
+fi
+grep -q '_env_set "LEMONADE_LLAMACPP_ROCM_BIN" "/opt/llama-custom/llama-server"' ods-cli \
+  || { echo "[FAIL] ods-cli must pin the custom ROCm llama-server binary"; exit 1; }
 if grep -q '_env_set "HSA_OVERRIDE_GFX_VERSION" "\$gfx_ver"' ods-cli; then
   echo "[FAIL] ods-cli must not write raw gfx ids such as gfx942 to HSA_OVERRIDE_GFX_VERSION"
   exit 1


### PR DESCRIPTION
llama-server(amd): make Lemonade actually use the custom ROCm binary

On any non-gfx1151 AMD host the custom ROCm llama-server that Dockerfile.amd spends
the whole install compiling was never used, and inference ran on Vulkan or failed to
start. Three separate reasons, all fixed here.

1. Phase 06 only set LEMONADE_LLAMACPP_ROCM_BIN on gfx1151, on the stated theory that
   other hosts fall back to "Lemonade's bundled ROCm-aware binary". No such binary
   exists -- the Lemonade image ships no ROCm userspace at all (no rocminfo, no HIP
   runtime). Left unset, Lemonade reports "no ROCm-capable device is detected", pulls
   the Vulkan llama.cpp build, and runs on radv. /opt/llama-custom is the only ROCm
   stack in the container, it is built for the detected target, and its gfx1151 MMQ
   patch is gated, so point Lemonade at it on every AMD target.

2. Lemonade reads its settings from a cached config.json and ignores env on every
   start after the first, so LEMONADE_LLAMACPP_ROCM_BIN never reached it: rocm_bin
   stayed "builtin". Lemonade then tries to DOWNLOAD a llama-server matching the gfx
   arch it detects -- and its detection maps GPU *marketing names* to gfx targets
   (lemon::identify_rocm_arch_from_name), from a table that knows "Radeon RX 9000
   series" but not "AMD Radeon AI PRO R9700". It resolved the iGPU and fetched

       llama-b1231-ubuntu-rocm-gfx1036-x64.zip   -> HTTP 404

   and the model failed to load. The wrapper entrypoint already existed to reconcile
   ctx_size for exactly this "cached config wins over env" reason; it now also syncs
   llamacpp.rocm_bin and llamacpp.backend, and seeds config.json from Lemonade's
   shipped defaults when absent so that even a first start on a fresh volume gets the
   right binary rather than attempting the bad download.

3. LEMONADE_LLAMACPP_BACKEND, set in docker-compose.amd.yml, is not a variable
   Lemonade reads at all -- confirmed against the daemon's own string table:

       grep -aoE 'LEMONADE_[A-Z_]+' /opt/lemonade/lemond

   It was a no-op, so the comment explaining how it kept the backend on a
   schema-valid "auto" described code that never ran. The selector Lemonade actually
   reads is LEMONADE_LLAMACPP (-> --llamacpp), now emitted as "rocm" by phase 06.
   Contrary to that comment, "rocm" is still a valid backend value in v10.2.0: the
   server accepts it and logs `"backend": "rocm"`.

The entrypoint also defensively unsets empty HSA_OVERRIDE_GFX_VERSION / HSA_XNACK.
Compose should already omit them (see the companion compose fix), but ROCm treats a
defined-but-empty HSA_OVERRIDE_GFX_VERSION as a malformed override and enumerates
zero devices, so a single stray "VAR=${VAR:-}" anywhere in the merge chain silently
kills every GPU. Cheap to make unreachable.

Verified on 2x Radeon AI PRO R9700 (gfx1201): 25/25 layers offloaded across ROCm0 and
ROCm1, ~262 tok/s. Reverting config.json to its broken state and restarting shows the
entrypoint repairing both keys.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


---

cli(amd): stop `ods gpu reassign` from deleting LEMONADE_LLAMACPP_ROCM_BIN

Same gfx1151-only gate as phase 06, duplicated in ods-cli. Re-pinning GPUs should
not be able to kill inference, and today it does.

_gpu_reassign_update_amd_arch_env() sets HSA_OVERRIDE_GFX_VERSION and
LEMONADE_LLAMACPP_ROCM_BIN together, keyed on gfx1151:

    if [[ "$gfx_ver" == "gfx1151" ]]; then
        _env_set   "HSA_OVERRIDE_GFX_VERSION" "11.5.1"
        _env_set   "LEMONADE_LLAMACPP_ROCM_BIN" "/opt/llama-custom/llama-server"
    else
        _env_unset "HSA_OVERRIDE_GFX_VERSION"
        _env_unset "LEMONADE_LLAMACPP_ROCM_BIN"     # <-- silently kills inference
    fi

The HSA_OVERRIDE half is correct and stays. The LEMONADE_LLAMACPP_ROCM_BIN half is
not arch-conditional at all: /opt/llama-custom is the only ROCm stack in the Lemonade
image, it is built for the detected AMDGPU_TARGET, and the gfx1151 MMQ patch is gated
to gfx1151 -- so it is right for every target. Unsetting it sends Lemonade back to
rocm_bin="builtin", where it tries to DOWNLOAD a llama-server for the arch it guesses
from the GPU's marketing name and 404s on anything its table does not recognise.

So on any non-Strix-Halo AMD host, `ods gpu reassign` -- a command about *GPU
placement* -- silently deletes the setting that decides whether inference runs at all.
It does not even fail loudly: the value survives in Lemonade's cached config.json, so
everything looks fine until that volume is reset, at which point the stack dies with no
obvious cause.

Verified: a real `ods gpu reassign --auto` on 2x Radeon AI PRO R9700 now preserves
LEMONADE_LLAMACPP_ROCM_BIN, and inference keeps working.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


---

test(contracts): reassign must preserve LEMONADE_LLAMACPP_ROCM_BIN, not delete it

The installer contract still encoded the behavior the previous commit removed:
it required a literal `_env_unset "LEMONADE_LLAMACPP_ROCM_BIN"` in ods-cli,
i.e. the exact line that silently killed inference on non-Strix AMD hosts.
Invert it: ods-cli must NEVER unset the custom binary on reassign, and must
still pin /opt/llama-custom/llama-server.

This failure was invisible until now: make test aborted earlier on an
unrelated schema-parity check (HIPFIRE_PORT, fixed on the hipfire branch),
so the reassign contract never ran on this branch's stack.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


---

