### PR TITLE
fix(ci): isolate Claude execution in issue-to-pr workflow

### DIFF
--- a/.github/workflows/issue-to-pr.yml
+++ b/.github/workflows/issue-to-pr.yml
@@ -64,6 +64,8 @@ jobs:
     if: needs.validate.outputs.should_proceed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
     outputs:
       has_changes: ${{ steps.detect.outputs.has_changes }}
 
@@ -72,7 +74,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
@@ -114,7 +116,7 @@ jobs:
             --print \
             --model claude-sonnet-4-6-v1 \
             --max-turns 30 \
-            --allowedTools "Read,Edit,Write,Glob,Grep,Bash(git diff *),Bash(git log *),Bash(git status),Bash(ruff *),Bash(python -m py_compile *),Bash(pytest *),Bash(shellcheck *),Bash(bash -n *),Bash(ls *)"
+            --allowedTools "Read,Edit,Write,Glob,Grep"
 
       - name: Detect changes
         id: detect

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -144,6 +144,9 @@ jobs:
       - name: Support Bundle Evidence Tests
         run: bash tests/test-support-bundle.sh
 
+      - name: Issue-to-PR Security Contract Tests
+        run: bash tests/test-issue-to-pr-security.sh
+
       - name: Upload Installer Simulation Artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -71,12 +71,14 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== macOS model download retry contract ==="
 	@bash tests/test-macos-download-retries.sh
-	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
 	@echo ""
 	@echo "=== fleet host lock behavior ==="
 	@bash tests/test-fleet-host-lock.sh
+	@echo ""
+	@echo "=== issue-to-pr security check ==="
+	@bash tests/test-issue-to-pr-security.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/ods/tests/test-issue-to-pr-security.sh
+++ b/ods/tests/test-issue-to-pr-security.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+WORKFLOW="$ROOT_DIR/../.github/workflows/issue-to-pr.yml"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+PASSED=0
+FAILED=0
+
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "╔═══════════════════════════════════════════════╗"
+echo "║   issue-to-pr.yml Security Contract Tests     ║"
+echo "╚═══════════════════════════════════════════════╝"
+echo ""
+
+if [[ ! -f "$WORKFLOW" ]]; then
+    fail "issue-to-pr.yml not found at $WORKFLOW"
+    exit 1
+fi
+pass "issue-to-pr.yml exists"
+
+# Extract the implement job block (from '  implement:' to the start of '  guardrails:')
+IMPLEMENT_BLOCK=$(awk '/^  implement:/, /^  guardrails:/' "$WORKFLOW")
+if [[ -z "$IMPLEMENT_BLOCK" ]]; then
+    fail "Could not locate implement job block in issue-to-pr.yml"
+    exit 1
+fi
+pass "Located implement job block"
+
+# 1. Check checkout step has persist-credentials: false
+if echo "$IMPLEMENT_BLOCK" | grep -q "uses: actions/checkout"; then
+    CHECKOUT_STEP=$(echo "$IMPLEMENT_BLOCK" | grep -A 5 "uses: actions/checkout")
+    if echo "$CHECKOUT_STEP" | grep -q "persist-credentials: false"; then
+        pass "Checkout in implement job correctly sets persist-credentials: false"
+    else
+        fail "Checkout in implement job does not set persist-credentials: false"
+    fi
+else
+    fail "Could not find actions/checkout step in implement job"
+fi
+
+# 2. Check allowedTools contains only safe, non-executing tools
+if echo "$IMPLEMENT_BLOCK" | grep -q "\-\-allowedTools"; then
+    TOOLS_VAL=$(echo "$IMPLEMENT_BLOCK" | grep -A 2 "\-\-allowedTools")
+
+    # Assert no Bash execution or other conditional execution capabilities are present
+    if echo "$TOOLS_VAL" | grep -q "Bash"; then
+        fail "Claude allowedTools contains Bash capabilities: $TOOLS_VAL"
+    else
+        pass "Claude allowedTools contains no Bash capabilities at all"
+    fi
+
+    # Verify presence of expected file-analysis/edit tools
+    for tool in Read Edit Write Glob Grep; do
+        if echo "$TOOLS_VAL" | grep -q "$tool"; then
+            pass "Claude allowedTools includes expected tool: $tool"
+        else
+            fail "Claude allowedTools is missing expected tool: $tool"
+        fi
+    done
+else
+    fail "Could not locate --allowedTools configuration in implement job"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]]

--- a/ods/tests/test-issue-to-pr-security.sh
+++ b/ods/tests/test-issue-to-pr-security.sh
@@ -70,6 +70,30 @@ else
     fail "Could not locate --allowedTools configuration in implement job"
 fi
 
+# 3. Check implement job permissions
+IMPLEMENT_HEADER=$(awk '/^  implement:/, /^    steps:/' "$WORKFLOW")
+if [[ -z "$IMPLEMENT_HEADER" ]]; then
+    fail "Could not locate implement job header in issue-to-pr.yml"
+else
+    if echo "$IMPLEMENT_HEADER" | grep -q "permissions:" && echo "$IMPLEMENT_HEADER" | grep -q "contents: read"; then
+        pass "Implement job permissions contain contents: read"
+    else
+        fail "Implement job permissions missing contents: read"
+    fi
+
+    if echo "$IMPLEMENT_HEADER" | grep -q "issues: write"; then
+        fail "Implement job permissions contain issues: write (must not have write access)"
+    else
+        pass "Implement job permissions do not contain issues: write"
+    fi
+
+    if echo "$IMPLEMENT_HEADER" | grep -q "pull-requests: write"; then
+        fail "Implement job permissions contain pull-requests: write (must not have write access)"
+    else
+        pass "Implement job permissions do not contain pull-requests: write"
+    fi
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

Restricts execution capabilities and credential exposure in the issue-to-PR Claude implementation step.

## Security Impact

The implementation step processes issue content supplied by external users while exposing `ANTHROPIC_API_KEY` to the Claude process.

Previously, Claude also had access to Bash execution tools including `pytest`. Because Claude can write workspace files, `pytest` could execute agent-written Python through test or `conftest.py` imports before the later guardrails job inspected the resulting diff.

The implementation checkout also persisted GitHub credentials in the workspace.

## Root Cause

The workflow combined:

- untrusted issue content in the Claude prompt
- workspace write access
- Bash execution capabilities
- `ANTHROPIC_API_KEY` in the Claude process environment
- persisted checkout credentials

The prompt instruction to ignore commands embedded in issue content was not a structural security boundary.

## Fix

- Restrict Claude to `Read`, `Edit`, `Write`, `Glob`, and `Grep`
- Remove Bash execution tools from the Claude implementation step
- Disable checkout credential persistence in the secret-bearing implementation workspace
- Add a workflow security contract test covering these boundaries

Validation remains outside the secret-bearing Claude execution step.

## Test Coverage

Added `ods/tests/test-issue-to-pr-security.sh` to verify that:

- the `implement` job is located and inspected explicitly
- the implementation checkout uses `persist-credentials: false`
- Claude has no `Bash(...)` execution capability
- the expected non-executing file analysis and editing tools remain available

The regression test is registered in both the normal `ods/Makefile` test target and the Linux CI workflow.

## Validation

`./tests/test-issue-to-pr-security.sh`

9 tests passed, 0 failed.

`git diff --check upstream/main...HEAD` also passes.

Fixes #1788