### PR TITLE
fix(windows-cli): redact all sensitive keys in config show output

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1263,8 +1263,13 @@ function Invoke-ConfigShow {
     Get-Content $envFile | ForEach-Object {
         $line = $_.Trim()
         if ($line -match "^#" -or $line -eq "") { return }
-        if ($line -match "(SECRET|PASS|TOKEN|KEY)=") {
-            $key = ($line -split "=")[0]
+        # Redact any key whose NAME contains a sensitive keyword, mirroring the
+        # Linux CLI's `ods config show` over-mask policy. Anchoring keywords to
+        # the "=" (the old behavior) let *_PASSWORD, *_SALT, and similar values
+        # print in cleartext because the keyword is not the last token before "=".
+        $key = ($line -split '=', 2)[0].Trim()
+        if ($line.Contains('=') -and
+            $key -match '(?i)secret|password|pass|token|key|salt|bearer|user|email') {
             Write-Host "  $key=***" -ForegroundColor DarkGray
         } else {
             Write-Host "  $line" -ForegroundColor White


### PR DESCRIPTION
## Problem

`.\ods.ps1 config` masks values only when `SECRET`, `PASS`, `TOKEN`, or `KEY` appears **immediately before** `=`:

```powershell
if ($line -match "(SECRET|PASS|TOKEN|KEY)=") {
```

Keys where the keyword is not the last token before `=` never match, so their values print in **cleartext**:

- `OPENCODE_SERVER_PASSWORD=...` (`PASS` is followed by `WORD`, not `=`)
- `LANGFUSE_DB_PASSWORD=`, `LANGFUSE_CLICKHOUSE_PASSWORD=`, `LANGFUSE_REDIS_PASSWORD=`, `LANGFUSE_INIT_USER_PASSWORD=`
- `LANGFUSE_SALT=`

All of these ship in `.env.example` / `.env.schema.json` and are written by the installer.

## Fix

Match the Linux CLI's `ods config show` over-mask policy (see `_cmd_config_is_secret` keyword fallback in `ods-cli`): redact any key whose **name** contains a sensitive keyword — `secret|password|pass|token|key|salt|bearer|user|email` — case-insensitively, checked against the key portion only (`($line -split '=', 2)[0]`).

This also matches the existing Windows precedent in `installers/windows/lib/compose-diagnostics.ps1`, which already keyword-matches the key name rather than anchoring to `=`.

Note: the key is captured **before** the keyword `-match` runs, because a second `-match` clobbers `$Matches`.

## Verification

Ran the new logic against a representative `.env`:

```
SHOWN   LLM_MODEL=qwen3.5-7b
MASKED  OPENCODE_SERVER_PASSWORD=***
MASKED  LANGFUSE_DB_PASSWORD=***
MASKED  LANGFUSE_SALT=***
MASKED  ANTHROPIC_API_KEY=***
MASKED  WEBUI_SECRET_KEY=***
MASKED  N8N_BASIC_AUTH_USER=***
SHOWN   ODS_MODE=local
SHOWN   GPU_BACKEND=nvidia
SHOWN   MALFORMED LINE WITHOUT EQUALS
```

Cross-checked `.env.schema.json`: all 43 `secret: true` keys match the keyword list.

- PowerShell parse: OK
- PSScriptAnalyzer on changed region: only the pre-existing `PSAvoidUsingWriteHost` style warning shared by the whole file