### PR TITLE
fix(installer): correct tier-3 GGUF checksum and secret-gen fallback …

### DIFF
--- a/ods/installers/macos/lib/tier-map.sh
+++ b/ods/installers/macos/lib/tier-map.sh
@@ -73,7 +73,7 @@ set_qwen_tier_config() {
             LLM_MODEL="qwen3-30b-a3b"
             GGUF_FILE="Qwen3-30B-A3B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
-            GGUF_SHA256="84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806"
+            GGUF_SHA256="9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
             MAX_CONTEXT=32768
             ;;
         2)

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -347,7 +347,7 @@ raise SystemExit(1)' 2>/dev/null && return 0
     }
 
     # Secrets: reuse existing values, generate only if missing
-    WEBUI_SECRET=$(_env_get WEBUI_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
+    WEBUI_SECRET=$(_env_get WEBUI_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
     N8N_PASS=$(_env_get N8N_PASS "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
     LITELLM_KEY=$(_env_get LITELLM_KEY "sk-ods-$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
     LITELLM_LEMONADE_API_KEY=$(_env_get LITELLM_LEMONADE_API_KEY "sk-ods-lemonade-$(openssl rand -hex 16 2>/dev/null || head -c 16 /dev/urandom | xxd -p)")
@@ -414,26 +414,26 @@ raise SystemExit(1)' 2>/dev/null && return 0
         LEMONADE_MODEL="$LEMONADE_MODEL_VALUE"
     fi
     LIVEKIT_SECRET=$(_env_get LIVEKIT_API_SECRET "$(openssl rand -base64 32 2>/dev/null || head -c 32 /dev/urandom | base64)")
-    DASHBOARD_API_KEY=$(_env_get DASHBOARD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
-    ODS_AGENT_KEY=$(_env_get ODS_AGENT_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
+    DASHBOARD_API_KEY=$(_env_get DASHBOARD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    ODS_AGENT_KEY=$(_env_get ODS_AGENT_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
     # HMAC key for signing ods-session cookies (magic-link redemption).
     # 32 random bytes hex-encoded. Rotating invalidates every issued cookie —
     # the only revocation mechanism we have today, so don't rotate casually.
-    ODS_SESSION_SECRET=$(_env_get ODS_SESSION_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
-    SHIELD_API_KEY=$(_env_get SHIELD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
-    DIFY_SECRET_KEY=$(_env_get DIFY_SECRET_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
-    QDRANT_API_KEY=$(_env_get QDRANT_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
+    ODS_SESSION_SECRET=$(_env_get ODS_SESSION_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    SHIELD_API_KEY=$(_env_get SHIELD_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    DIFY_SECRET_KEY=$(_env_get DIFY_SECRET_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
+    QDRANT_API_KEY=$(_env_get QDRANT_API_KEY "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
     _token_spy_key_default=""
     if [[ -f "$INSTALL_DIR/data/token-spy/token-spy-api-key.txt" ]]; then
         _token_spy_key_default=$(tr -d '\r\n' < "$INSTALL_DIR/data/token-spy/token-spy-api-key.txt" 2>/dev/null || true)
     fi
     if [[ -z "$_token_spy_key_default" ]]; then
-        _token_spy_key_default=$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)
+        _token_spy_key_default=$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')
     fi
     TOKEN_SPY_API_KEY=$(_env_get TOKEN_SPY_API_KEY "$_token_spy_key_default")
     unset _token_spy_key_default
     OPENCODE_SERVER_PASSWORD=$(_env_get OPENCODE_SERVER_PASSWORD "$(openssl rand -base64 16 2>/dev/null || head -c 16 /dev/urandom | base64)")
-    SEARXNG_SECRET=$(_env_get SEARXNG_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p)")
+    SEARXNG_SECRET=$(_env_get SEARXNG_SECRET "$(openssl rand -hex 32 2>/dev/null || head -c 32 /dev/urandom | xxd -p | tr -d '\n')")
 
     # Langfuse (LLM Observability). LANGFUSE_ENABLED mirrors the install-time
     # ENABLE_LANGFUSE toggle, falling back to whatever the user had in .env on

--- a/ods/installers/windows/lib/tier-map.ps1
+++ b/ods/installers/windows/lib/tier-map.ps1
@@ -196,7 +196,7 @@ function Resolve-QwenTierConfig {
                 LlmModel   = "qwen3-30b-a3b"
                 GgufFile   = "Qwen3-30B-A3B-Q4_K_M.gguf"
                 GgufUrl    = "https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
-                GgufSha256 = "84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806"
+                GgufSha256 = "9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
                 MaxContext = 32768
                 ModelProfileRequested = "qwen"
                 ModelProfileEffective = "qwen"


### PR DESCRIPTION
Two defects that break installs on specific paths:

1. **Tier-3 GGUF checksum mismatch (macOS + Windows).**
   `ods/installers/macos/lib/tier-map.sh` and `ods/installers/windows/lib/tier-map.ps1`
   paired the file `Qwen3-30B-A3B-Q4_K_M.gguf` with `GGUF_SHA256=84b5f7f1…`.
   That hash does **not** belong to that file — it is the checksum of a different
   catalog entry, `qwen3.5-27b-q4` (`Qwen3.5-27B-Q4_K_M.gguf`). The correct hash
   for `Qwen3-30B-A3B-Q4_K_M.gguf` is `9f1a247…`, which Linux
   (`ods/installers/lib/tier-map.sh`) already used. Consequence: on tier-3
   installs (macOS and Windows only), `ods/scripts/bootstrap-upgrade.sh` fails
   SHA256 verification, deletes the downloaded file, retries 6×, then gives up —
   the user is permanently stuck on the 2 B bootstrap model. Both writers now use
   the catalog hash.

2. **Multi-line secret in the openssl-absent fallback.**
   In `ods/installers/phases/06-directories.sh`, the fallback used when `openssl`
   is not installed is `head -c 32 /dev/urandom | xxd -p`. `xxd -p` wraps output
   at 60 columns, so 32 bytes (64 hex chars) become **two lines**. Command
   substitution only strips the trailing newline, so an internal newline is
   embedded into 9 generated secrets (WEBUI_SECRET, DASHBOARD_API_KEY,
   ODS_AGENT_KEY, ODS_SESSION_SECRET, SHIELD_API_KEY, DIFY_SECRET_KEY,
   QDRANT_API_KEY, SEARXNG_SECRET, _token_spy_key_default). The generated `.env`
   then has a truncated key plus an orphan hex line that the compose env-file
   parser rejects. Fix: append `| tr -d '\n'`, matching the Langfuse fallbacks
   already present in the same file.

## Summary

Corrects two shipped installer bugs. No behavior/control-flow changes — only
data-value corrections:
- Tier-3 model checksum on macOS/Windows now matches the actual GGUF file.
- Secret-generation fallback no longer emits a newline that corrupts `.env`.

## AI Assistance

Claude Code (Opus 4.8) performed the reliability audit that found both bugs,
drafted the one-line fixes, and drafted this description. The human author is
accountable for reviewing the diff, the verification below, and the merge.

## Release Lane

- [x] Stable hotfix targeting `release/2.5.x`
- [ ] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Both defects break first-run installs for current users on shipped releases:
tier-3 macOS/Windows installs can never obtain their real model, and any host
without openssl generates a corrupt .env. They are value-only corrections with
no API/UX change, which is the intended scope for a stable hotfix.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities  (model catalog / checksum surface)
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: **High**
  - Per `ods/docs/HIGH_RISK_CHANGE_MAP.md`, this change touches three
    High-risk surfaces: `installers/phases/*` ("Mutates host, config,
    services, models, or health state"), the Windows and macOS installers
    ("Separate shell/runtime semantics" / "Native Metal llama-server plus
    Docker services"), and the model catalog/checksum surface ("Determines
    first-run user experience and memory fit"). The earlier Low rating was
    incorrect; reclassified to High.
- User impact: On tier-3 macOS/Windows installs the full model can never
  pass verification today (permanent bootstrap-only state); on any host
  without `openssl` the generated `.env` is corrupt. Both are first-run
  install failures for current users.
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below (value-only correctness proof)
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation — **PENDING**
        (needs a scoped tier-3 macOS/Windows install smoke, or a
        release-manager waiver accepting the value-only proof below)
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x` — **PENDING**
- Full fleet rerun required before release: **Yes** — at minimum a scoped
  tier-3 macOS/Windows install smoke, unless a release manager signs off that
  the value-only proof is sufficient.
- Rollback strategy: revert this commit. The change is three constants plus one
  added `| tr -d '\n'` pipe with no control-flow change, so reverting restores
  the exact prior behavior (Linux was never touched).

Commands/results (value-only proof):

```text
# 1) The two hashes map to two different models (proves the mismatch)
$ python3 - <<'PY'
import json; d=json.load(open('ods/config/model-library.json'))
for m in d['models']:
    if m.get('gguf_sha256') in {'84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806',
                                '9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48'}:
        print(m['gguf_sha256'][:12], m['id'], m.get('gguf') or m.get('gguf_file'))
PY
84b5f7f11215 qwen3.5-27b-q4    Qwen3.5-27B-Q4_K_M.gguf
9f1a24700a33 qwen3-30b-a3b-q4  Qwen3-30B-A3B-Q4_K_M.gguf

# 2) Fallback newline (before vs after fix)
$ head -c 32 /dev/urandom | xxd -p | wc -l              -> 2   (bug)
$ head -c 32 /dev/urandom | xxd -p | tr -d '\n' | wc -l -> 0   (fixed: single line)

# 3) Syntax
$ bash -n ods/installers/phases/06-directories.sh ods/installers/macos/lib/tier-map.sh -> OK

# 4) No residue
$ grep -rc 84b5f7f ods/installers/            -> 0 matches
$ grep -c 'head -c 32 /dev/urandom | xxd -p)' ods/installers/phases/06-directories.sh -> 0

# 5) Whitespace
$ git diff --check origin/main -- ods/installers -> clean
```

## Operational Change Check

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [x] This is an operational change and validation is intentionally deferred for:

```text
This is a High-risk operational change (installer tier maps + .env-generation
phase). Release-grade fleet validation is DEFERRED pending one of:
  (a) a scoped tier-3 macOS/Windows install smoke confirming the full model
      downloads and verifies instead of looping on bootstrap; or
  (b) an explicit release-manager sign-off that the value-only proof above is
      sufficient for this diff.
Narrower-equivalent rationale: the diff is value-only (three constants + one
`| tr -d '\n'`), with no change to install flow, ordering, or logic. The proof
above shows the corrected hash matches the actual GGUF in the catalog and the
corrected fallback yields a single-line secret. This does NOT substitute for the
scoped hardware smoke; it is offered as the basis for a maintainer waiver.
```

## Notes For Reviewers

- Three files, +11/-11, purely value changes; Linux was already correct and is
  unchanged.
- **Blocking before merge (per advisory review):** (1) CI/check status must be
  green for this head — no checks are currently reported; (2) risk is now marked
  High (was Low); (3) the stable lane needs either scoped tier-3 macOS/Windows
  verification or a release-manager waiver.
- Separately observed during the audit (NOT fixed here): the public README
  install one-liner points at `Light-Heart-Labs/ODS` while `ods/get-ods.sh`
  clones `Osmantic/ODS`. Please confirm the canonical upstream org — it also
  determines which repo this PR should target.
