### PR TITLE
fix(dashboard-api): block backslash open-redirect in oauth return_url

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/routers/oauth_passthrough.py
@@ -150,7 +150,14 @@ def _safe_return_path(return_url: str) -> str | None:
     pass "/talk" when it wants a button back into ODS Talk.
     """
     candidate = (return_url or "").strip()
-    if not candidate.startswith("/") or candidate.startswith("//"):
+    if not candidate.startswith("/"):
+        return None
+    # Reject protocol-relative URLs. Browsers fold backslashes to forward
+    # slashes in the authority, so "/\evil.com" and "/\\evil.com" resolve to
+    # "//evil.com" — a same-looking prefix that is really an off-origin
+    # redirect. Treat the character after the leading slash as the guard, and
+    # reject backslashes anywhere since a same-origin path never needs one.
+    if candidate[1:2] in ("/", "\\") or "\\" in candidate:
         return None
     return candidate
 

--- a/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
+++ b/ods/extensions/services/dashboard-api/tests/test_oauth_passthrough.py
@@ -224,3 +224,16 @@ def test_oauth_callback_only_reflects_relative_return_url(oauth_client):
     )
     assert "javascript:alert" not in unsafe.text
     assert "Back to ODS Talk" not in unsafe.text
+
+
+@pytest.mark.parametrize("return_url", ["//evil.com", "/\\evil.com", "/\\/evil.com"])
+def test_oauth_callback_rejects_protocol_relative_return_url(oauth_client, return_url):
+    """Browsers fold backslashes to forward slashes, so "/\\evil.com" becomes
+    the protocol-relative "//evil.com" — an off-origin redirect. The success
+    page must not render a Back button for any of these."""
+    resp = oauth_client.get(
+        "/api/oauth/callback",
+        params={"code": "fake-code", "return_url": return_url},
+    )
+    assert "evil.com" not in resp.text
+    assert "Back to ODS Talk" not in resp.text


### PR DESCRIPTION
## Problem

The OAuth passthrough success page renders a "Back to ODS Talk" button from the caller-supplied `return_url`, filtered by `_safe_return_path`:

```python
if not candidate.startswith("/") or candidate.startswith("//"):
    return None
return candidate
```

This blocks absolute (`//evil.com`) and `javascript:` links, but **not a leading slash followed by a backslash**. Browsers normalize backslashes to forward slashes in the URL authority, so:

- `return_url=/\evil.com` → `href="/\evil.com"` → browser resolves to `//evil.com` → **off-origin redirect**

`/api/oauth/callback` is a **public, unauthenticated** redirect target (it has to be — it receives provider redirects). An attacker can hand a victim a crafted callback URL; after the page renders, the "Back to ODS Talk" button points at an attacker origin. The function's own docstring states the invariant it's meant to hold ("never reflect arbitrary absolute URLs"), which the backslash case violates.

## Fix

Reject a backslash right after the leading slash, and any backslash in the path — a same-origin relative path never needs one:

```python
if not candidate.startswith("/"):
    return None
if candidate[1:2] in ("/", "\\") or "\\" in candidate:
    return None
return candidate
```

## Verification

Extended `test_oauth_callback` coverage with a parametrized case for `//`, `/\`, and `/\/` prefixes.

- With the fix: **15 passed, 1 skipped**
- Reverting only the source change: the two backslash cases **fail** (the `//` case was already handled), confirming the tests pin the exact gap.

Standalone bypass-matrix check (`/talk`, `/ok/path`, `/` still allowed; `//evil.com`, `/\evil.com`, `/\/evil.com`, `https://evil.com`, `javascript:` all rejected) passes.
