### PR TITLE
fix(release-gate): report cleanly when a version file is missing

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -187,6 +187,9 @@ jobs:
       - name: Offline Model Validation Tests
         run: python3 tests/test-offline-model-validation.py
 
+      - name: Version Consistency Error Reporting Tests
+        run: python3 tests/test-version-consistency-error-reporting.py
+
       - name: Runtime Config Renderer Tests
         run: python3 tests/test-render-runtime-configs.py
 

--- a/ods/scripts/check-version-consistency.py
+++ b/ods/scripts/check-version-consistency.py
@@ -17,15 +17,34 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _display_path(path: Path) -> str:
+    """Repo-relative path for messages, tolerant of paths outside ROOT.
+
+    ARCHITECTURE.md lives at ROOT.parent, so a plain path.relative_to(ROOT)
+    would raise ValueError and mask the real error.
+    """
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
 def first_match(path: Path, pattern: str, label: str) -> str:
-    match = re.search(pattern, read_text(path), re.MULTILINE | re.DOTALL)
+    try:
+        text = read_text(path)
+    except OSError as exc:
+        raise ValueError(f"{label}: cannot read {_display_path(path)}: {exc}") from exc
+    match = re.search(pattern, text, re.MULTILINE | re.DOTALL)
     if not match:
-        raise ValueError(f"{label}: could not find version in {path.relative_to(ROOT)}")
+        raise ValueError(f"{label}: could not find version in {_display_path(path)}")
     return match.group(1)
 
 
 def latest_changelog_release() -> tuple[str, str]:
-    changelog = read_text(ROOT / "CHANGELOG.md")
+    try:
+        changelog = read_text(ROOT / "CHANGELOG.md")
+    except OSError as exc:
+        raise ValueError(f"CHANGELOG.md: cannot read file: {exc}") from exc
     for match in re.finditer(r"^## \[([^\]]+)\](?: - ([0-9]{4}-[0-9]{2}-[0-9]{2}))?", changelog, re.MULTILINE):
         version, date = match.group(1), match.group(2) or ""
         if version.lower() != "unreleased":

--- a/ods/tests/test-version-consistency-error-reporting.py
+++ b/ods/tests/test-version-consistency-error-reporting.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Unit tests for check-version-consistency.py error reporting.
+
+The release gate must fail *cleanly* (collect an error string) when a version
+authority is missing or lives outside ROOT, not crash with a raw traceback.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "check-version-consistency.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("check_version_consistency", SCRIPT)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_first_match_missing_file_raises_valueerror() -> None:
+    """A missing file must surface as ValueError (caught by add_regex_check),
+    not FileNotFoundError, which would escape and crash the gate."""
+    module = load_module()
+    missing = module.ROOT / "does-not-exist-xyz.sh"
+    try:
+        module.first_match(missing, r'^VERSION="([^"]+)"', "missing file")
+    except ValueError as exc:
+        assert "missing file" in str(exc)
+    except OSError as exc:  # pragma: no cover - this is the bug being guarded
+        raise AssertionError(f"first_match leaked OSError instead of ValueError: {exc}")
+    else:
+        raise AssertionError("first_match did not raise for a missing file")
+
+
+def test_add_regex_check_records_error_for_missing_file() -> None:
+    """add_regex_check must append a clean error string, never propagate."""
+    module = load_module()
+    errors: list[str] = []
+    checks: list[tuple[str, str]] = []
+    module.add_regex_check(
+        checks,
+        errors,
+        "missing constants",
+        module.ROOT / "does-not-exist-xyz.sh",
+        r'^VERSION="([^"]+)"',
+    )
+    assert checks == []
+    assert len(errors) == 1
+    assert "missing constants" in errors[0]
+
+
+def test_display_path_tolerates_paths_outside_root() -> None:
+    """ARCHITECTURE.md lives at ROOT.parent; the message helper must not raise
+    when a checked file is outside ROOT."""
+    module = load_module()
+    outside = module.ROOT.parent / "ARCHITECTURE.md"
+    # Must return a string rather than raising ValueError from relative_to.
+    assert isinstance(module._display_path(outside), str)
+
+
+def test_first_match_unmatched_pattern_outside_root_reports_cleanly() -> None:
+    """A file outside ROOT whose pattern does not match must still yield a
+    clean ValueError, not a relative_to() ValueError with a confusing message."""
+    module = load_module()
+    outside = module.ROOT.parent / "ARCHITECTURE.md"
+    if not outside.exists():
+        return  # nothing to assert if the outer file isn't checked out
+    try:
+        module.first_match(outside, r"^THIS_PATTERN_WILL_NOT_MATCH_ANYTHING=(x)$", "arch")
+    except ValueError as exc:
+        assert "could not find version" in str(exc)
+        assert "arch" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for an unmatched pattern")
+
+
+def main() -> int:
+    tests = [
+        test_first_match_missing_file_raises_valueerror,
+        test_add_regex_check_records_error_for_missing_file,
+        test_display_path_tolerates_paths_outside_root,
+        test_first_match_unmatched_pattern_outside_root_reports_cleanly,
+    ]
+    for test in tests:
+        test()
+    print("[PASS] version consistency error-reporting tests")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿﻿## Problem

`scripts/check-version-consistency.py` is the release-gate step that fails when ODS version authorities drift. It is meant to fail **cleanly** — `main()` even wraps the manifest read with a `# noqa: BLE001 - gate should report cleanly` comment. But two paths bypass that intent:

1. **Missing file crashes the gate.** `add_regex_check` catches only `ValueError`:

   ```python
   try:
       checks.append((label, first_match(path, pattern, label)))
   except ValueError as exc:
       errors.append(str(exc))
   ```

   `first_match` → `read_text` → `path.read_text()` raises `FileNotFoundError` (an `OSError`, **not** a `ValueError`) when a version-authority file is absent — e.g. a refactor renames `installers/windows/lib/constants.ps1`, or `ARCHITECTURE.md` isn't present in a sparse checkout. The exception escapes and the gate dies with a raw traceback instead of a `[FAIL]` summary listing the missing file.

2. **`relative_to(ROOT)` raises for `ARCHITECTURE.md`.** On the "could not find version" path, `first_match` builds its message with `path.relative_to(ROOT)`. The `ARCHITECTURE.md` check uses `ROOT.parent / "ARCHITECTURE.md"`, which is **not** under `ROOT`, so `relative_to` itself raises `ValueError` — masking the real "pattern not found" message.

## Fix

- Wrap the read in `first_match` and re-raise `OSError` as a `ValueError` with a clean message.
- Add a `_display_path` helper that falls back to the absolute path when `relative_to(ROOT)` can't apply (paths outside `ROOT`).
- Guard the `CHANGELOG.md` read in `latest_changelog_release` the same way.

## Tests

New `tests/test-version-consistency-error-reporting.py` (wired into the Linux CI job next to the other `python3 tests/test-*.py` steps):

- `first_match` on a missing file raises `ValueError`, not `OSError`
- `add_regex_check` records a clean error string and never propagates
- `_display_path` tolerates a path outside `ROOT`
- an unmatched pattern on an outside-`ROOT` file reports "could not find version" instead of a `relative_to` error

Verified:
- With the fix: **[PASS]**, and the real gate still passes (`[PASS] version consistency (2.5.3)`).
- Reverting only the source change: the missing-file test **fails** with `first_match leaked OSError instead of ValueError`, pinning the exact bug.

## Why this matters

Release validation is an operator-facing gate. A missing version authority should produce one actionable validation error rather than a Python traceback that obscures the broken release input.

## Overlap check

Triage refresh (2026-08-08): searched open and closed Osmantic/ODS PRs by semantic keywords (version consistency missing file), inspected the changed production files, and checked patch equivalence against current upstream/main. No strict duplicate or merged equivalent was found.
