### PR TITLE
fix(host-agent): keep .env mode 0600 after a settings save

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -2256,6 +2256,11 @@ class AgentHandler(BaseHTTPRequestHandler):
             payload_text = raw_text if raw_text.endswith("\n") else raw_text + "\n"
             tmp_path = env_path.with_name(".env.tmp")
             tmp_path.write_text(payload_text, encoding="utf-8")
+            # .env holds service secrets (DASHBOARD_API_KEY, ODS_AGENT_KEY,
+            # JWT_SECRET, OAuth secrets). The fresh tmp file is created at the
+            # umask default (0644); tighten before os.replace() swaps it in so
+            # the live .env keeps mode 0600 instead of inheriting 0644.
+            os.chmod(tmp_path, 0o600)
             os.replace(str(tmp_path), str(env_path))
         except OSError as exc:
             logger.warning("env_update OSError from %s: %s", client_ip, exc)


### PR DESCRIPTION
## Problem (local secret disclosure)

The host-agent's `env_update` handler (dashboard **Settings → save**) writes the new `.env` atomically:

```python
tmp_path = env_path.with_name(".env.tmp")
tmp_path.write_text(payload_text, encoding="utf-8")
os.replace(str(tmp_path), str(env_path))
```

`.env.tmp` is created fresh at the umask default (typically **0644**). Because `os.replace` swaps in that new inode, the live `.env` **inherits 0644**, discarding the `0600` it was created with (`installers/phases/06-directories.sh` does `chmod 600 .env`).

`.env` holds the service secrets — `DASHBOARD_API_KEY`, `ODS_AGENT_KEY`, `JWT_SECRET`, OAuth client secrets, etc. So after **any** dashboard Settings save, they become readable by every local user on the host.

```console
# reproduction of the umask/replace behavior
BEFORE fix: .env after os.replace = 0o644
AFTER fix:  .env after os.replace = 0o600
```

## Fix

`chmod` the tmp file to `0600` before the atomic replace, so the live `.env` keeps `0600` with no intermediate 0644 window. This mirrors the sibling secret writers that already do it: `oauth_passthrough.py:241`, `magic_link.py:253`, `security.py:19`.

One-line change; `py_compile` clean.