### PR TITLE
fix(backup): restrict the compressed backup archive to owner-only

### DIFF
--- a/ods/ods-backup.sh
+++ b/ods/ods-backup.sh
@@ -462,6 +462,10 @@ compress_backup() {
     parent_dir=$(dirname "$backup_dir")
 
     tar czf "$parent_dir/$backup_name.tar.gz" -C "$parent_dir" "$backup_name"
+    # The archive bundles the raw .env (DASHBOARD_API_KEY, session secret, service
+    # passwords). Restrict it to the owner rather than leaving it world-readable
+    # at the umask default, matching the 0600 the .env itself carries.
+    chmod 600 "$parent_dir/$backup_name.tar.gz"
     local compressed_size
     compressed_size=$(du -sh "$parent_dir/$backup_name.tar.gz" | cut -f1)
 


### PR DESCRIPTION
## Problem (local secret disclosure)

`compress_backup()` in `ods-backup.sh` creates the backup archive and never restricts its permissions:

```sh
tar czf "$parent_dir/$backup_name.tar.gz" -C "$parent_dir" "$backup_name"
```

Under the default umask the `.tar.gz` lands at **0644** — world-readable. The archive bundles the raw `.env`, which the config backup copies in verbatim (`DASHBOARD_API_KEY`, `ODS_SESSION_SECRET`, service passwords, `LANGFUSE_*` secrets, …). So on a multi-user host, any local user can read a compressed backup and extract **every** ODS secret.

The uncompressed backup keeps `.env` at `0600` (because `cp` carries the source mode) — only the compressed archive leaks.

```console
BEFORE fix: archive mode = 644
AFTER fix:  archive mode = 600
```

## Fix

`chmod 600` the archive right after `tar czf`, matching the `0600` the `.env` itself carries. Reachable via `ods-backup.sh -t full -c` / `-t config -c`. `bash -n` clean.