### PR TITLE
fix(host-agent): validate backup_id to prevent path traversal in backups

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -38,6 +38,10 @@ from urllib.parse import parse_qs, urlparse
 VERSION = "1.0.0"
 ODS_VERSION = VERSION
 SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+# backup_id is interpolated into a backup directory name by ods-update.sh
+# (BACKUP_DIR/backup-<backup_id>-<ts>). Restrict it to a plain label so it can
+# never contain a path separator or ".." and escape BACKUP_DIR.
+BACKUP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 MAX_BODY = 16384
 SUBPROCESS_TIMEOUT_START = 600  # 10 min — image pulls can be slow
 SUBPROCESS_TIMEOUT_STOP = 120   # 2 min — stop should be fast
@@ -1714,6 +1718,9 @@ class AgentHandler(BaseHTTPRequestHandler):
             backup_id = body.get("backup_id")
             if not isinstance(backup_id, str) or not backup_id.strip():
                 backup_id = f"dashboard-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+            elif not BACKUP_ID_RE.match(backup_id.strip()):
+                json_response(self, 400, {"error": "Invalid backup_id"})
+                return
             self._handle_update_backup(backup_id.strip())
         elif endpoint_action == "start":
             self._handle_update_start()

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -734,6 +734,96 @@ class TestUpdateWire:
             server.server_close()
             thread.join(timeout=2)
 
+    def test_backup_rejects_path_traversal_backup_id(self, tmp_path, monkeypatch):
+        import threading
+        import urllib.error
+        import urllib.request
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "ods"
+        install_dir.mkdir()
+
+        calls = []
+
+        def spy_run(action, *args, timeout):
+            calls.append((action, args))
+            return subprocess.CompletedProcess(["ods-update", action, *args], 0, "", "")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+        monkeypatch.setattr(_mod, "_run_update_script", spy_run)
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/update/backup",
+                data=json.dumps({"backup_id": "../../../../tmp/exfil"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer wire-test-secret",
+                },
+                method="POST",
+            )
+            with pytest.raises(urllib.error.HTTPError) as excinfo:
+                urllib.request.urlopen(req, timeout=2)
+
+            assert excinfo.value.code == 400
+            # The traversal id must be rejected before it ever reaches the
+            # update script that would copy .env into the escaped directory.
+            assert calls == []
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_backup_accepts_plain_backup_id(self, tmp_path, monkeypatch):
+        import threading
+        import urllib.request
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "ods"
+        install_dir.mkdir()
+
+        calls = []
+
+        def spy_run(action, *args, timeout):
+            calls.append((action, args))
+            return subprocess.CompletedProcess(
+                ["ods-update", action, *args], 0, "backed up\n", ""
+            )
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+        monkeypatch.setattr(_mod, "_run_update_script", spy_run)
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            req = urllib.request.Request(
+                f"http://127.0.0.1:{port}/v1/update/backup",
+                data=json.dumps({"backup_id": "dashboard-20260715-143022"}).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "Authorization": "Bearer wire-test-secret",
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                data = json.loads(resp.read().decode("utf-8"))
+
+            assert resp.status == 200
+            assert data["success"] is True
+            assert calls == [("backup", ("dashboard-20260715-143022",))]
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
 
 class TestComposeToggleWire:
     """End-to-end HTTP test for built-in compose toggles via the host agent."""


### PR DESCRIPTION
## Problem

The host-agent `POST /v1/update/backup` handler accepts any non-empty `backup_id` and passes it straight through to `ods-update.sh`:

```python
# bin/ods-host-agent.py (before)
elif endpoint_action == "backup":
    backup_id = body.get("backup_id")
    if not isinstance(backup_id, str) or not backup_id.strip():
        backup_id = f"dashboard-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
    self._handle_update_backup(backup_id.strip())
```

`ods-update.sh` interpolates that value into the backup **directory name** and then copies `.env` into it:

```sh
# ods-update.sh cmd_backup
backup_id="backup-${backup_name}-${timestamp}"
local backup_path="${BACKUP_DIR}/${backup_id}"
mkdir -p "$backup_path"
for pattern in "docker-compose*.yml" ... ".env" ".env.*"; do
    ... cp "$file" "$backup_path/"   # copies .env
```

A `backup_id` like `../../../../tmp/exfil` collapses `backup_path` **outside** `BACKUP_DIR`, so the caller controls where the secret-bearing `.env` (`DASHBOARD_API_KEY`, `ODS_AGENT_KEY`, JWT/session secret, provider API keys) is written — an arbitrary-directory-create + secret-disclosure primitive.

The host agent is explicitly the privilege boundary meant to bound a compromised/malicious dashboard-api, and every **other** host-agent input is already strictly validated (`SERVICE_ID_RE`, env-key regex, `is_relative_to` on model paths, loopback-guarded ports…). `backup_id` was the one field that escaped that boundary.

## Fix

Gate `backup_id` with a strict label regex at the host-agent boundary, mirroring the existing `SERVICE_ID_RE` idiom, so it can never contain a path separator or `..`:

```python
BACKUP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
...
elif not BACKUP_ID_RE.match(backup_id.strip()):
    json_response(self, 400, {"error": "Invalid backup_id"})
    return
```

- The server-generated default (`dashboard-<timestamp>`) and the only caller (`routers/updates.py` → `dashboard-<timestamp>`) both pass unchanged.
- Malformed ids now return `400` **before** the update script runs.

Charset demo (what `ods-update.sh` would build):

```
REJECT  '../../../../tmp/exfil'      -> /home/user/tmp/exfil-<ts>   <== ESCAPES BACKUP_DIR
REJECT  'a/b'                        (path separator)
REJECT  '.hidden'                    (leading dot)
ACCEPT  'dashboard-20260715-143022'  -> .../backups/backup-dashboard-...
ACCEPT  'manual-note_1'              -> .../backups/backup-manual-note_1-...
```

## Tests

Added to `TestUpdateWire` in `test_host_agent.py`:
- `test_backup_rejects_path_traversal_backup_id` — a `../`-laden id returns `400` and the update script is **never invoked**.
- `test_backup_accepts_plain_backup_id` — a normal `dashboard-<ts>` id still reaches the script and succeeds.

Full `test_host_agent.py` suite: **131 passed**.