### PR TITLE
fix(dashboard-api): require auth for /api/preflight/required-ports

### DIFF
--- a/ods/extensions/services/dashboard-api/README.md
+++ b/ods/extensions/services/dashboard-api/README.md
@@ -59,7 +59,7 @@ Environment variables (set in `.env`):
 |--------|------|------|-------------|
 | `GET` | `/api/preflight/docker` | Yes | Check Docker availability |
 | `GET` | `/api/preflight/gpu` | Yes | Check GPU availability |
-| `GET` | `/api/preflight/required-ports` | No | List service ports |
+| `GET` | `/api/preflight/required-ports` | Yes | List service ports |
 | `POST` | `/api/preflight/ports` | Yes | Check port availability conflicts |
 | `GET` | `/api/preflight/disk` | Yes | Check available disk space |
 

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -1097,9 +1097,14 @@ async def preflight_gpu():
     return {"available": False, "error": "No GPU detected. Ensure NVIDIA drivers or AMD amdgpu driver is loaded."}
 
 
-@app.get("/api/preflight/required-ports")
+@app.get("/api/preflight/required-ports", dependencies=[Depends(verify_api_key)])
 async def preflight_required_ports():
-    """Return the list of service ports for preflight checking (no auth required)."""
+    """Return the list of deployed service names and ports for preflight checking.
+
+    Gated like the sibling preflight endpoints (docker/gpu/ports/disk): the
+    response enumerates which services are live and on which ports, so it must
+    not be reachable unauthenticated.
+    """
     # When health cache exists, filter out services not in the compose stack
     cached = get_cached_services()
     deployed = {s.id for s in cached if s.status != "not_deployed"} if cached else None

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -599,7 +599,9 @@ class TestPreflightRequiredPorts:
         monkeypatch.setattr("main.SERVICES", {
             "svc-a": {"name": "A", "port": 8000, "external_port": 8000},
         })
-        resp = test_client.get("/api/preflight/required-ports")
+        resp = test_client.get(
+            "/api/preflight/required-ports", headers=test_client.auth_headers
+        )
         assert resp.status_code == 200
         data = resp.json()
         assert any(p["port"] == 8000 for p in data["ports"])

--- a/ods/extensions/services/dashboard-api/tests/test_routers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_routers.py
@@ -307,9 +307,17 @@ def test_preflight_ports_empty_list(test_client):
     assert data["available"] is True
 
 
-def test_preflight_required_ports_no_auth(test_client):
-    """GET /api/preflight/required-ports → 200, no auth required."""
+def test_preflight_required_ports_requires_auth(test_client):
+    """GET /api/preflight/required-ports without auth → 401 (gated like siblings)."""
     resp = test_client.get("/api/preflight/required-ports")
+    assert resp.status_code == 401
+
+
+def test_preflight_required_ports_authenticated(test_client):
+    """GET /api/preflight/required-ports with auth → 200, returns port list."""
+    resp = test_client.get(
+        "/api/preflight/required-ports", headers=test_client.auth_headers
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert "ports" in data


### PR DESCRIPTION
## Problem

`/api/preflight/required-ports` is the **only** preflight endpoint without an auth dependency. Its four siblings all gate:

```python
@app.get("/api/preflight/docker", dependencies=[Depends(verify_api_key)])   # main.py:1058
@app.get("/api/preflight/gpu",    dependencies=[Depends(verify_api_key)])   # main.py:1083
@app.get("/api/preflight/required-ports")                                   # main.py:1100  <-- ungated
@app.post("/api/preflight/ports", dependencies=[Depends(verify_api_key)])   # main.py:1117
@app.get("/api/preflight/disk",   dependencies=[Depends(verify_api_key)])   # main.py:1137
```

Its response enumerates which services are **deployed** and their external ports:

```python
return {"ports": [{"port": ext_port, "service": ...} for ...]}
```

So any unauthenticated client that can reach dashboard-api (e.g. `api.<device>.local` on the LAN) gets a live map of running services and ports — service/port reconnaissance that the four adjacent endpoints already refuse to give up.

## Fix

Gate it the same way as its siblings:

```python
@app.get("/api/preflight/required-ports", dependencies=[Depends(verify_api_key)])
```

**Setup is unaffected.** The dashboard's `PreFlightChecks.jsx` fetches `required-ports` with the exact same bare `fetch('/api/preflight/...')` it uses for the already-gated `/docker`, `/gpu`, `/ports`, `/disk` — the dashboard nginx injects `Authorization: Bearer ${DASHBOARD_API_KEY}` into `/api/*`, so all five now work identically. Installer preflight runs its own local checks and doesn't call this HTTP route.

## Tests

- `test_preflight_required_ports_requires_auth` — no Bearer → **401**.
- `test_preflight_required_ports_authenticated` — with Bearer → **200** + port list.
- Updated `TestPreflightRequiredPorts.test_returns_ports` to send the auth header.
- Updated the README auth column (`No` → `Yes`).

Preflight test selection: **25 passed**.