### PR TITLE
fix(dashboard-api): cap PortCheckRequest.ports length

### DIFF
--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -66,7 +66,10 @@ PortNumber = Annotated[int, Field(ge=1, le=65535)]
 
 
 class PortCheckRequest(BaseModel):
-    ports: list[PortNumber]
+    # preflight_ports binds a socket per entry synchronously on the event loop,
+    # so cap the list. A real install exposes a couple dozen service ports;
+    # 128 leaves ample headroom while preventing bind-probe amplification.
+    ports: Annotated[list[PortNumber], Field(max_length=128)]
 
 
 class PortConflict(BaseModel):

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -648,6 +648,16 @@ class TestPreflightPorts:
         )
         assert resp.status_code == 200
 
+    def test_rejects_oversized_port_list(self, test_client):
+        # The list is capped so a caller can't force thousands of synchronous
+        # socket binds on the event loop. Rejected by validation before any bind.
+        resp = test_client.post(
+            "/api/preflight/ports",
+            json={"ports": [8000] * 129},
+            headers=test_client.auth_headers,
+        )
+        assert resp.status_code == 422
+
 
 # --- /gpu endpoint (cached paths) ---
 


### PR DESCRIPTION
## Problem

`preflight_ports()` binds a socket per requested port, synchronously, on the event-loop thread:

```python
@app.post("/api/preflight/ports", dependencies=[Depends(verify_api_key)])
async def preflight_ports(request: PortCheckRequest):
    ...
    for port in request.ports:
        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
            sock.settimeout(1)
            sock.bind(("0.0.0.0", port))
```

`PortCheckRequest.ports` was unbounded:

```python
class PortCheckRequest(BaseModel):
    ports: list[PortNumber]
```

`PortNumber` bounds each *value* to 1–65535, but nothing bounds the list *length* (and duplicates are allowed), so a single authenticated request carrying tens of thousands of entries forces that many blocking `socket()`/`bind()`/`close()` cycles on the event loop — a bind-probe amplification / self-DoS.

## Fix

Cap the list length, matching the defensive input-bounding already used elsewhere in this module (e.g. `message: str = Field(..., max_length=100000)`):

```python
ports: Annotated[list[PortNumber], Field(max_length=128)]
```

A real install exposes ~two dozen service ports, and the dashboard sends one entry per required service (`PreFlightChecks.jsx` → `ports.map(p => p.port)`), so 128 is comfortable headroom. Oversized lists now fail validation with **422** before any socket work runs.

## Tests

Added `TestPreflightPorts.test_rejects_oversized_port_list` — a 129-entry list → **422**. Existing valid-range / invalid-value / in-use tests still pass (**8 passed** in the ports selection).