### PR TITLE
fix(extensions): close bind-mount bypasses in the compose volume scanner

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -397,11 +397,23 @@ def _scan_compose_content(
                         status_code=400,
                         detail=f"Extension rejected: Docker socket mount in {svc_name}",
                     )
-                vol_parts = vol_str.split(":")
-                if len(vol_parts) >= 2 and vol_parts[0].startswith("/"):
+                # Resolve the host-side source for both short-form
+                # ("source:target[:opts]") and long-form ({type: bind,
+                # source: ...}) entries, so a long-form bind can't slip an
+                # absolute/relative host path past the string-only check.
+                if isinstance(vol, dict):
+                    vol_source = str(vol.get("source", ""))
+                else:
+                    vol_source = vol_str.split(":", 1)[0]
+                if vol_source.startswith("/"):
                     raise HTTPException(
                         status_code=400,
-                        detail=f"Extension rejected: absolute host path mount '{vol_parts[0]}' in {svc_name}",
+                        detail=f"Extension rejected: absolute host path mount '{vol_source}' in {svc_name}",
+                    )
+                if ".." in vol_source.split("/"):
+                    raise HTTPException(
+                        status_code=400,
+                        detail=f"Extension rejected: relative host path mount '{vol_source}' escaping the project directory in {svc_name}",
                     )
         cap_add = svc_def.get("cap_add", [])
         if isinstance(cap_add, list):

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -2048,6 +2048,64 @@ class TestScanComposeSkipNameCollision:
         assert "Docker socket" in exc.value.detail
 
 
+class TestScanComposeVolumeBypass:
+    """The volume guard must resolve the host source for long-form ({type:
+    bind, source: ...}) and relative-traversal entries, not just short-form
+    absolute strings."""
+
+    def _scan(self, tmp_path, compose_text):
+        from routers.extensions import _scan_compose_content
+        compose = tmp_path / "compose.yaml"
+        compose.write_text(compose_text)
+        _scan_compose_content(compose)
+
+    def test_rejects_long_form_absolute_bind(self, tmp_path):
+        with pytest.raises(HTTPException) as exc:
+            self._scan(
+                tmp_path,
+                "services:\n  svc:\n    image: test\n    volumes:\n"
+                "      - type: bind\n        source: /\n        target: /host\n",
+            )
+        assert exc.value.status_code == 400
+        assert "absolute host path" in exc.value.detail
+
+    def test_rejects_relative_traversal_short_form(self, tmp_path):
+        with pytest.raises(HTTPException) as exc:
+            self._scan(
+                tmp_path,
+                "services:\n  svc:\n    image: test\n"
+                "    volumes:\n      - ../../:/host\n",
+            )
+        assert exc.value.status_code == 400
+        assert "escaping the project directory" in exc.value.detail
+
+    def test_rejects_long_form_relative_traversal(self, tmp_path):
+        with pytest.raises(HTTPException) as exc:
+            self._scan(
+                tmp_path,
+                "services:\n  svc:\n    image: test\n    volumes:\n"
+                "      - type: bind\n        source: ../..\n        target: /host\n",
+            )
+        assert exc.value.status_code == 400
+        assert "escaping the project directory" in exc.value.detail
+
+    def test_allows_named_volume(self, tmp_path):
+        # A named volume (no path separator) is not a host bind and must pass.
+        self._scan(
+            tmp_path,
+            "services:\n  svc:\n    image: test\n"
+            "    volumes:\n      - mydata:/var/lib/data\n",
+        )
+
+    def test_allows_project_relative_subdir_bind(self, tmp_path):
+        # A ./subdir bind stays inside the extension's own directory.
+        self._scan(
+            tmp_path,
+            "services:\n  svc:\n    image: test\n"
+            "    volumes:\n      - ./data:/data\n",
+        )
+
+
 # --- skip_gpu_passthrough_check flag isolation ---
 
 


### PR DESCRIPTION
## Problem

`_scan_compose_content` blocks host bind mounts in extension compose files by string-splitting each volume entry and checking whether the first `:`-segment starts with `/`:

```python
vol_str = str(vol)
...
vol_parts = vol_str.split(":")
if len(vol_parts) >= 2 and vol_parts[0].startswith("/"):
    raise HTTPException(... "absolute host path mount ...")
```

This only catches **short-form absolute strings** and misses two other host-path binds:

1. **Long-form mounts** — `{type: bind, source: /, target: /host}`. `vol` is a dict, so `str(vol)` is the dict repr and `vol_parts[0]` is `"{'type'"` — the absolute-path check never fires. An extension can bind `/` (or any host path) read-write.
2. **Relative traversal** — `../../:/host`. `vol_parts[0]` is `".."` (not absolute), so it passes. Compose resolves it **above** the project/extension directory, reaching ODS's `.env` and its siblings.

The scanner already has a sibling guard against bind-mount backdoors via top-level `driver_opts` (`type/device`), so blocking host binds here is an intended security boundary — these two forms are gaps in it.

> Scope/reachability: extensions are installed from the trusted library or existing on-disk content (there is no remote/URL upload path), so this is defense-in-depth against a malicious or compromised **library** extension, in the same spirit as the existing `driver_opts` check. Not remotely reachable.

## Fix

Resolve the host-side `source` for both short- and long-form entries, then reject an absolute source or one containing a `..` path segment:

```python
if isinstance(vol, dict):
    vol_source = str(vol.get("source", ""))
else:
    vol_source = vol_str.split(":", 1)[0]
if vol_source.startswith("/"):
    raise HTTPException(... "absolute host path mount ...")
if ".." in vol_source.split("/"):
    raise HTTPException(... "relative host path mount ... escaping the project directory ...")
```

Named volumes (`mydata:/data`) and project-relative subdir binds (`./data:/data`) are unaffected — only absolute and `..`-escaping sources are rejected.

## Tests

`TestScanComposeVolumeBypass` (direct `_scan_compose_content` calls):
- long-form `{type: bind, source: /}` → **400** absolute host path
- short-form `../../:/host` → **400** escaping the project directory
- long-form `source: ../..` → **400** escaping the project directory
- `mydata:/var/lib/data` (named volume) → **allowed**
- `./data:/data` (project-relative) → **allowed**

Full `test_extensions.py`: **206 passed**.