### PR TITLE
fix(dashboard-api): tolerate non-numeric context in get_model_info

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -623,7 +623,14 @@ def get_model_info() -> Optional[ModelInfo]:
             model_name = env_values.get("LLM_MODEL")
             if model_name:
                 size_gb, quant = 15.0, None
-                context = int(env_values.get("MAX_CONTEXT") or env_values.get("CTX_SIZE") or 32768)
+                # MAX_CONTEXT/CTX_SIZE come straight from .env and may be
+                # non-numeric (e.g. "auto", "8k", or a trailing comment); fall
+                # back to the default rather than 500-ing every caller. Mirrors
+                # the guard already used in routers/models.py.
+                try:
+                    context = int(env_values.get("MAX_CONTEXT") or env_values.get("CTX_SIZE") or 32768)
+                except (TypeError, ValueError):
+                    context = 32768
 
                 import re as _re
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -63,6 +63,24 @@ class TestGetModelInfo:
         assert info.size_gb == 35.0
         assert info.quantization == "GGUF"
 
+    def test_parses_numeric_context(self, install_dir):
+        env_file = install_dir / ".env"
+        env_file.write_text('LLM_MODEL=Qwen2.5-7B-Instruct\nCTX_SIZE=8192\n')
+
+        info = get_model_info()
+        assert info is not None
+        assert info.context_length == 8192
+
+    def test_non_numeric_context_falls_back_to_default(self, install_dir):
+        # A non-numeric CTX_SIZE/MAX_CONTEXT (e.g. "auto") must not 500 every
+        # caller of get_model_info(); it falls back to the default context.
+        env_file = install_dir / ".env"
+        env_file.write_text('LLM_MODEL=Qwen2.5-7B-Instruct\nCTX_SIZE=auto\n')
+
+        info = get_model_info()
+        assert info is not None
+        assert info.context_length == 32768
+
     def test_returns_none_when_no_env(self, install_dir):
         # No .env file created
         assert get_model_info() is None


### PR DESCRIPTION
## Problem

`get_model_info()` reads the context length straight from `.env`:

```python
context = int(env_values.get("MAX_CONTEXT") or env_values.get("CTX_SIZE") or 32768)
```

This sits inside a block whose only handler is `except OSError`, so a **non-numeric** value raises `ValueError` that escapes the function and 500s every endpoint that surfaces model info (status, model readiness, etc.).

`MAX_CONTEXT`/`CTX_SIZE` are user-supplied at install time, and values like `auto`, `8k`, or a line with a trailing comment (`CTX_SIZE=32768 # tokens`) all trigger it:

```
>>> get_model_info()   # .env has CTX_SIZE=auto
ValueError: invalid literal for int() with base 10: 'auto'
```

## Fix

Guard the conversion and fall back to the default — the same guard `routers/models.py` already applies to these exact two keys (`for key in ("MAX_CONTEXT", "CTX_SIZE"): ... except (TypeError, ValueError)`):

```python
try:
    context = int(env_values.get("MAX_CONTEXT") or env_values.get("CTX_SIZE") or 32768)
except (TypeError, ValueError):
    context = 32768
```

Numeric values are unaffected; only malformed ones fall back instead of crashing.

## Tests

Added to `TestGetModelInfo`:
- `test_parses_numeric_context` — `CTX_SIZE=8192` → `context_length == 8192` (valid values still parse).
- `test_non_numeric_context_falls_back_to_default` — `CTX_SIZE=auto` → `context_length == 32768` (no crash).

`test_helpers.py::TestGetModelInfo`: **10 passed**.