### PR TITLE
fix(dashboard-api): don't crash vision stream on empty/null choices

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -168,7 +168,12 @@ async def _stream_vision_chat(image_bytes: bytes, content_type: str, prompt_text
                         chunk = json.loads(payload_str)
                     except json.JSONDecodeError:
                         continue
-                    delta = chunk.get("choices", [{}])[0].get("delta", {})
+                    # A streaming chunk may carry an empty (usage-only) or
+                    # null-element choices list; the [{}] default only covers a
+                    # missing key, so guard the index/element to avoid killing
+                    # the generator mid-stream (mirrors routers/models.py).
+                    choices = chunk.get("choices") or []
+                    delta = (choices[0] or {}).get("delta", {}) if choices else {}
                     text = delta.get("content")
                     if isinstance(text, str) and text:
                         accumulated.append(text)

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -947,6 +947,64 @@ def test_talk_vision_url_preserves_lemonade_api_v1(monkeypatch):
     assert _vision_chat_completions_url() == "http://host.docker.internal:8080/api/v1/chat/completions"
 
 
+def test_vision_stream_tolerates_empty_and_null_choices(monkeypatch):
+    """A usage-only ({"choices": []}) or null-element chunk must not crash the
+    vision SSE generator; it still processes valid chunks and emits complete."""
+    import asyncio
+
+    from routers import talk
+
+    lines = [
+        'data: {"choices": []}',
+        'data: {"choices": [{"delta": {"content": "a cat"}}]}',
+        'data: {"choices": [null]}',
+        'data: [DONE]',
+    ]
+
+    class FakeResp:
+        status_code = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def aiter_lines(self):
+            for ln in lines:
+                yield ln
+
+        async def aread(self):
+            return b""
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        def stream(self, *a, **k):
+            return FakeResp()
+
+    monkeypatch.setattr(talk.httpx, "AsyncClient", FakeClient)
+
+    async def run():
+        frames = []
+        async for raw in talk._stream_vision_chat(b"imgbytes", "image/png", "describe"):
+            frames.append(raw)
+        return frames
+
+    text = b"".join(asyncio.run(run())).decode("utf-8")
+    # Reached the end (complete frame) without an IndexError/AttributeError
+    # tearing down the stream, and the one valid chunk was still delivered.
+    assert '"complete"' in text
+    assert "a cat" in text
+
+
 def test_talk_attachment_requires_session(test_client):
     """No cookie ⇒ 401 even with a valid file."""
     resp = test_client.post(


### PR DESCRIPTION
## Problem

`_stream_vision_chat` (ODS Talk's image path) parses each streamed chunk as:

```python
delta = chunk.get("choices", [{}])[0].get("delta", {})
```

The `[{}]` default only kicks in when the `choices` key is **absent**. An OpenAI-style **usage-only chunk** carries an explicit empty list — `{"choices": [], "usage": {...}}` — so `[][0]` raises `IndexError`; a `{"choices": [null]}` element raises `AttributeError`. The surrounding handler only catches `httpx` errors:

```python
except (httpx.ReadTimeout, httpx.ConnectError, httpx.HTTPError) as exc:
```

so the exception escapes, the async generator dies mid-stream, and the image reply is truncated with **no** `error`/`done` frame (the client just hangs / shows a broken response).

## Fix

Resolve `choices` defensively before indexing — the same pattern `routers/models.py` already uses for streamed chunks:

```python
choices = chunk.get("choices") or []
delta = (choices[0] or {}).get("delta", {}) if choices else {}
```

Handles absent / empty / null-element `choices`; valid chunks are unchanged.

## Tests

`test_vision_stream_tolerates_empty_and_null_choices` drives the real `_stream_vision_chat` with a mocked httpx stream whose lines include `{"choices": []}`, a valid delta, and `{"choices": [null]}`. It **fails before** the fix (IndexError tears down the generator) and **passes after**, still emitting the `complete` frame and the valid text. Full `test_talk.py`: **35 passed**.