### PR TITLE
fix(schema): correct PRIVACY_SHIELD_PORT default to 8085

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -1080,7 +1080,7 @@
     "PRIVACY_SHIELD_PORT": {
       "type": "integer",
       "description": "Privacy Shield PII proxy port",
-      "default": 7860
+      "default": 8085
     },
     "LIVEKIT_PORT": {
       "type": "integer",


### PR DESCRIPTION
## Problem

`.env.schema.json` declares the Privacy Shield port default as **7860**:

```json
"PRIVACY_SHIELD_PORT": {
  "type": "integer",
  "description": "Privacy Shield PII proxy port",
  "default": 7860
},
```

But `7860` is **OpenClaw's** port — `OPENCLAW_PORT`'s default in the same file — evidently a copy-paste. Every authoritative source puts Privacy Shield on **8085**, including the schema's own other entry for the same service:

| Source | Port |
|---|---|
| `.env.schema.json` → `SHIELD_PORT` (the var the container actually binds) | 8085 |
| `config/ports.json` (privacy-shield) | 8085 |
| `extensions/services/privacy-shield/manifest.yaml` (`port` / `external_port_default`) | 8085 |
| `extensions/services/privacy-shield/compose.yaml` (`SHIELD_PORT:-8085`, `:8085`) | 8085 |
| `scripts/ods-test.sh` — the only reader of `PRIVACY_SHIELD_PORT` | falls back to 8085 |

The schema literally contradicts itself (`SHIELD_PORT`=8085 vs `PRIVACY_SHIELD_PORT`=7860 for the same service), and `.env.schema.json` is a live contract. Anyone configuring from the documented default would point tooling (e.g. `ods-test.sh`'s health probe) at the wrong port; nothing runs Privacy Shield on 7860.

## Fix

One line — align the default with the service's real port:

```diff
-      "default": 7860
+      "default": 8085
```

`json.load` still parses; no code relies on `7860` for Privacy Shield (grep confirms `7860` appears nowhere under `extensions/services/privacy-shield/`).