### PR TITLE
fix(update): bound post-update health-check curls with --max-time

### DIFF
--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -906,9 +906,9 @@ cmd_health() {
     local dashboard_api_port="${DASHBOARD_API_PORT:-}"
     [[ -n "$dashboard_api_port" ]] || dashboard_api_port="$(env_file_value DASHBOARD_API_PORT)"
     dashboard_api_port="${dashboard_api_port:-3002}"
-    if curl -sf "http://127.0.0.1:${dashboard_api_port}/health" &>/dev/null; then
+    if curl -sf --max-time 15 "http://127.0.0.1:${dashboard_api_port}/health" &>/dev/null; then
         log_ok "Dashboard API: healthy"
-    elif curl -sf "http://127.0.0.1:${dashboard_api_port}/api/status" &>/dev/null; then
+    elif curl -sf --max-time 15 "http://127.0.0.1:${dashboard_api_port}/api/status" &>/dev/null; then
         log_ok "Dashboard API: responding"
     else
         log_warn "Dashboard API: not responding on port ${dashboard_api_port}"
@@ -919,7 +919,7 @@ cmd_health() {
     [[ -n "$llama_server_port" ]] || llama_server_port="$(env_file_value OLLAMA_PORT)"
     [[ -n "$llama_server_port" ]] || llama_server_port="$(env_file_value LLAMA_SERVER_PORT)"
     llama_server_port="${llama_server_port:-8080}"
-    if curl -sf "http://127.0.0.1:${llama_server_port}/v1/models" &>/dev/null; then
+    if curl -sf --max-time 15 "http://127.0.0.1:${llama_server_port}/v1/models" &>/dev/null; then
         log_ok "llama-server: healthy"
     else
         log_warn "llama-server: not responding on port ${llama_server_port}"


### PR DESCRIPTION
## Problem

After an update, `ods-update.sh` verifies services with bare, unbounded curls:

```sh
if   curl -sf "http://127.0.0.1:${dashboard_api_port}/health"     &>/dev/null; then   # 909
elif curl -sf "http://127.0.0.1:${dashboard_api_port}/api/status" &>/dev/null; then   # 911
...
if   curl -sf "http://127.0.0.1:${llama_server_port}/v1/models"   &>/dev/null; then   # 922
```

None carries `--max-time`, so a service that is listening but wedged (e.g. mid-restart, or a model still loading) makes the request block with no ceiling and hangs the tail of `ods update`.

## Fix

Add `--max-time 15` to each probe — the value `ods-update.sh` **already** uses on its other curls (the release-check calls at lines 824 and 839), so the file stays internally consistent:

```diff
-    if curl -sf "http://127.0.0.1:${dashboard_api_port}/health" &>/dev/null; then
+    if curl -sf --max-time 15 "http://127.0.0.1:${dashboard_api_port}/health" &>/dev/null; then
```

(applied to all three health probes)

## Verify

`bash -n ods-update.sh` passes; the three probes are now bounded.