### PR TITLE
docs: correct two commands that fail as written

### DIFF
--- a/ods/README.md
+++ b/ods/README.md
@@ -393,7 +393,7 @@ ods start                      # Start everything
 # Management scripts
 ./scripts/session-cleanup.sh             # Clean up bloated agent sessions
 ./scripts/llm-cold-storage.sh --status   # Check model hot/cold storage
-ods mode status                        # Show current mode
+ods mode                               # Show current mode
 ```
 
 ## Comparison

--- a/ods/docs/VALIDATION_REPRODUCIBILITY.md
+++ b/ods/docs/VALIDATION_REPRODUCIBILITY.md
@@ -30,7 +30,7 @@ git diff --check
 python scripts/audit-extensions.py --project-dir .
 python scripts/validate-generated-configs.py
 python scripts/validate-golden-paths.py
-python scripts/validate-dependency-pins.py
+python scripts/check-dependency-pins.py
 ```
 
 Add dashboard checks when dashboard code or dashboard-api behavior changes.


### PR DESCRIPTION
Two documented commands error out when run verbatim (originally split as #1814/#1815 — combined here to reduce review overhead):

**1. `docs/VALIDATION_REPRODUCIBILITY.md`** — the "Minimum Local Audit Set" block calls:
```
python scripts/validate-dependency-pins.py
```
That script doesn't exist (`No such file or directory`). The real one is `scripts/check-dependency-pins.py` — *"Validate pinned runtime dependency references"* — invoked by `scripts/release-gate.sh:27`. The block's three other scripts all exist; only this name is wrong.

**2. `README.md`** — the "Management scripts" block lists:
```
ods mode status                        # Show current mode
```
But `ods-cli` `cmd_mode()` only accepts `local|cloud|hybrid`; `status` prints `✗ Unknown mode: status. Use: local, cloud, hybrid` and exits 1. The current mode is shown by **bare** `ods mode` — which README already documents correctly a few lines up.

Both are one-token fixes to runnable commands.