### PR TITLE
docs: fix `ods mode status` in README management commands

### DIFF
--- a/ods/README.md
+++ b/ods/README.md
@@ -388,7 +388,7 @@ ods start                      # Start everything
 # Management scripts
 ./scripts/session-cleanup.sh             # Clean up bloated agent sessions
 ./scripts/llm-cold-storage.sh --status   # Check model hot/cold storage
-ods mode status                        # Show current mode
+ods mode                               # Show current mode
 ```
 
 ## Comparison


### PR DESCRIPTION
## Problem

README's **Management scripts** block includes:

```bash
ods mode status                        # Show current mode
```

But `ods mode` only accepts a mode argument — running `ods mode status` fails:

```
✗ Unknown mode: status. Use: local, cloud, hybrid
```

(`cmd_mode()` in `ods-cli`: `case "$mode" in local|cloud|hybrid) ;; *) error "Unknown mode: $mode. Use: local, cloud, hybrid" ;;`, and `error()` exits 1.)

The current mode is shown by **bare `ods mode`** — which this same README already documents correctly a few lines up (`ods mode  # Show current mode (local/cloud/hybrid)`).

## Fix

```diff
-ods mode status                        # Show current mode
+ods mode                               # Show current mode
```