### PR TITLE
fix(windows): read GPU VRAM as VramMB in the install report

### DIFF
--- a/ods/installers/windows/lib/install-report.ps1
+++ b/ods/installers/windows/lib/install-report.ps1
@@ -107,7 +107,7 @@ function New-ODSInstallReport {
         gpu = [ordered]@{
             backend = $gpu.Backend
             name = $gpu.Name
-            vram_mb = $gpu.VRAM
+            vram_mb = $gpu.VramMB
             memory_type = $gpu.MemoryType
             native_inference_backend = $nativeBackend
         }


### PR DESCRIPTION
## Problem

`Write-ODSInstallReport` builds the report's GPU block from `Get-GpuInfo`'s result:

```powershell
gpu = [ordered]@{
    backend = $gpu.Backend
    name = $gpu.Name
    vram_mb = $gpu.VRAM        # <-- wrong key
    memory_type = $gpu.MemoryType
```

But `Get-GpuInfo` (`detection.ps1`) returns the field as **`VramMB`**, not `VRAM`. `install-report.ps1:110` is the **only** place in the tree that reads `.VRAM`; every other consumer (`tier-map.ps1`, `phases/02-detection.ps1`) uses `.VramMB`. Accessing the nonexistent key yields `$null`, so `ods report` always produces:

- `report.json` → `"gpu": { "vram_mb": null, ... }`
- `report.txt` → `- VRAM:  MB`

even on a GPU host that detected VRAM correctly.

## Fix

```diff
-            vram_mb = $gpu.VRAM
+            vram_mb = $gpu.VramMB
```

The adjacent fields (`$gpu.Backend`, `$gpu.Name`, `$gpu.MemoryType`) already use the correct keys from the same hashtable, confirming the intended style.

## Verify

- `Get-GpuInfo` sets `VramMB` at `detection.ps1:52/120/140` (and documents it at :20); it never sets `VRAM`.
- After the change, `grep -rn '\.VRAM\b' installers/windows/` returns nothing — the only reader is fixed, and `report.txt`'s `- VRAM: $($report.gpu.vram_mb) MB` now receives a real number.