### PR TITLE
fix(dashboard-api): guard disk usage calculation against zero total

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -604,7 +604,8 @@ def get_disk_usage() -> DiskUsage:
     """Get disk usage for the ODS install directory."""
     path = INSTALL_DIR if os.path.exists(INSTALL_DIR) else os.path.expanduser("~")
     total, used, free = shutil.disk_usage(path)
-    return DiskUsage(path=path, used_gb=round(used / (1024**3), 2), total_gb=round(total / (1024**3), 2), percent=round(used / total * 100, 1))
+    percent = round(used / total * 100, 1) if total > 0 else 0.0
+    return DiskUsage(path=path, used_gb=round(used / (1024**3), 2), total_gb=round(total / (1024**3), 2), percent=percent)
 
 
 def get_model_info() -> Optional[ModelInfo]:


### PR DESCRIPTION
## Summary
- Guard `DiskUsage` percent calculation against `ZeroDivisionError` when `shutil.disk_usage` reports `total == 0` (edge case on some systems/containers).

## Changes
- `ods/extensions/services/dashboard-api/helpers.py`: extract percent into guarded expression `round(used / total * 100, 1) if total > 0 else 0.0`

## Testing
- [ ] `cd ods/extensions/services/dashboard-api && pytest tests/`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)