### PR TITLE
fix(dashboard-api): catch IndexError when parsing /proc/uptime

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -768,7 +768,7 @@ def get_uptime() -> int:
         elif _system == "Windows":
             import ctypes
             return ctypes.windll.kernel32.GetTickCount64() // 1000
-    except (OSError, subprocess.SubprocessError, ValueError, AttributeError) as e:
+    except (OSError, subprocess.SubprocessError, ValueError, IndexError, AttributeError) as e:
         logger.debug("get_uptime failed on %s: %s", _system, e)
     return 0
 


### PR DESCRIPTION
## Summary
- Add `IndexError` to the except clause in `get_uptime()`. Reading `/proc/uptime` and calling `f.read().split()[0]` raises `IndexError` if the file is empty or malformed. The existing handler caught `OSError`, `ValueError`, etc. but not `IndexError`.

## Changes
- `ods/extensions/services/dashboard-api/helpers.py`: add `IndexError` to the except tuple in `get_uptime()`

## Testing
- [ ] `cd ods/extensions/services/dashboard-api && pytest tests/`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)