### PR TITLE
fix(dashboard-api): guard Prometheus metric parsing against malformed lines

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -365,9 +365,15 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
             if line.startswith("#"):
                 continue
             if "tokens_predicted_total" in line:
-                metrics["tokens_predicted_total"] = float(line.split()[-1])
+                try:
+                    metrics["tokens_predicted_total"] = float(line.split()[-1])
+                except (ValueError, IndexError):
+                    pass
             if "tokens_predicted_seconds_total" in line:
-                metrics["tokens_predicted_seconds_total"] = float(line.split()[-1])
+                try:
+                    metrics["tokens_predicted_seconds_total"] = float(line.split()[-1])
+                except (ValueError, IndexError):
+                    pass
 
         now = time.time()
         curr = metrics.get("tokens_predicted_total", 0)


### PR DESCRIPTION
## Summary
- Wrap Prometheus metric extraction (`tokens_predicted_total`, `tokens_predicted_seconds_total`) in `try/except (ValueError, IndexError)`. Previously, `line.split()[-1]` would throw `IndexError` on empty/whitespace-only lines matching the keyword, and `float()` would throw `ValueError` on non-numeric content. Both were uncaught since the outer handler only covers `httpx` and `OSError`.

## Changes
- `ods/extensions/services/dashboard-api/helpers.py`: add per-metric `try/except` guards

## Testing
- [ ] `cd ods/extensions/services/dashboard-api && pytest tests/`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)