### PR TITLE
fix(dashboard-api): handle non-dict response in model error check

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -187,6 +187,8 @@ async def _probe_loaded_lemonade_model(model_name: str) -> bool:
         resp = await client.post(f"{base_url}/api/v1/chat/completions", json=payload, headers=headers)
         resp.raise_for_status()
         data = resp.json()
+        if not isinstance(data, dict):
+            return False
         if isinstance(data.get("error"), dict):
             return False
         return bool(data.get("choices"))


### PR DESCRIPTION
## Summary
- Add `isinstance(data, dict)` check before calling `data.get("error")` in `_probe_loaded_lemonade_model()`. If the Lemonade API returns a JSON list or primitive instead of a dict, `.get()` raises `AttributeError`.

## Changes
- `ods/extensions/services/dashboard-api/routers/models.py`: add type guard before `.get()` call

## Testing
- [ ] `cd ods/extensions/services/dashboard-api && pytest tests/`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)