### PR TITLE
fix(installer): quote variable in trap to prevent word splitting

### DIFF
--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -270,7 +270,7 @@ fi
 
 # write $GPU_TOPOLOGY_JSON into a tmpfile to use by the commands
 TOPOLOGY_FILE=$(mktemp /tmp/ods_gpu_topology.XXXXXX.json)
-trap "rm -f $TOPOLOGY_FILE" EXIT
+trap 'rm -f "$TOPOLOGY_FILE"' EXIT
 echo "$GPU_TOPOLOGY_JSON" > "$TOPOLOGY_FILE"
 
 ASSIGN_GPUS_SCRIPT="$SCRIPT_DIR/scripts/assign_gpus.py"


### PR DESCRIPTION
## Summary
- Fix unquoted `$TOPOLOGY_FILE` in trap command in phase 03-features. The variable was expanded at trap definition time inside double quotes, meaning spaces or special characters in the path could cause `rm -f` to delete the wrong files.

## Changes
- `ods/installers/phases/03-features.sh`: change `trap "rm -f $TOPOLOGY_FILE" EXIT` to `trap 'rm -f "$TOPOLOGY_FILE"' EXIT` — defers expansion to trap execution time and quotes the path.

## Testing
- [ ] `make lint`
- [ ] `bash -n ods/installers/phases/03-features.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)