### PR TITLE
fix(config): use 127.0.0.1 instead of localhost in backend health URLs

### DIFF
--- a/ods/config/backends/amd.json
+++ b/ods/config/backends/amd.json
@@ -3,7 +3,7 @@
   "llm_engine": "lemonade",
   "service_name": "llama-server",
   "public_api_port": 8080,
-  "public_health_url": "http://localhost:8080/api/v1/health",
+  "public_health_url": "http://127.0.0.1:8080/api/v1/health",
   "provider_name": "local-lemonade",
   "provider_url": "http://llama-server:8080/api/v1",
   "runtime": {

--- a/ods/config/backends/apple.json
+++ b/ods/config/backends/apple.json
@@ -3,7 +3,7 @@
   "llm_engine": "llama-server",
   "service_name": "llama-server",
   "public_api_port": 8080,
-  "public_health_url": "http://localhost:8080/health",
+  "public_health_url": "http://127.0.0.1:8080/health",
   "provider_name": "local-mlx",
   "provider_url": "http://llama-server:8080/v1"
 }

--- a/ods/config/backends/cpu.json
+++ b/ods/config/backends/cpu.json
@@ -3,7 +3,7 @@
   "llm_engine": "llama-server",
   "service_name": "llama-server",
   "public_api_port": 8080,
-  "public_health_url": "http://localhost:8080/health",
+  "public_health_url": "http://127.0.0.1:8080/health",
   "provider_name": "local-llama",
   "provider_url": "http://llama-server:8080/v1"
 }

--- a/ods/config/backends/nvidia.json
+++ b/ods/config/backends/nvidia.json
@@ -3,7 +3,7 @@
   "llm_engine": "llama-server",
   "service_name": "llama-server",
   "public_api_port": 8080,
-  "public_health_url": "http://localhost:8080/health",
+  "public_health_url": "http://127.0.0.1:8080/health",
   "provider_name": "local-llama",
   "provider_url": "http://llama-server:8080/v1"
 }


### PR DESCRIPTION
## Summary
- Replace `localhost` with `127.0.0.1` in all backend health URLs. On macOS, `localhost` can resolve to `::1` (IPv6) causing health checks to hang. The project's own lint rules already guard against this pattern in shell scripts.

## Changes
- `ods/config/backends/nvidia.json`: `localhost` → `127.0.0.1`
- `ods/config/backends/cpu.json`: same
- `ods/config/backends/apple.json`: same
- `ods/config/backends/amd.json`: same (health path `/api/v1/health` preserved)

## Testing
- [ ] `make test`
- [ ] Verify health checks pass on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)