### PR TITLE
fix(dashboard-api): stop leaking system details in error responses

### DIFF
--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -1522,9 +1522,10 @@ async def api_settings_env_save(
             detail={"message": "ODS host agent is not reachable. Start the host agent, then try again."},
         ) from exc
     except OSError as exc:
+        logger.error("Failed to contact host agent for env update: %s", exc)
         raise HTTPException(
             status_code=500,
-            detail={"message": "Could not contact host agent to write environment file.", "reason": str(exc)},
+            detail={"message": "Could not contact host agent to write environment file."},
         ) from exc
     backup_relative = agent_resp.get("backup_path")
 
@@ -1585,7 +1586,7 @@ async def api_settings_env_apply(
         logger.exception("Settings apply failed")
         raise HTTPException(
             status_code=500,
-            detail={"message": f"Could not apply runtime changes: {exc}"},
+            detail={"message": "Could not apply runtime changes via host agent."},
         ) from exc
 
 


### PR DESCRIPTION
## Summary
- Remove system-level error details (`str(exc)`) from HTTP error responses sent to clients. Internal paths, hostnames, and OS error messages were being exposed via the `reason` field in two settings endpoints.

## Changes
- `ods/extensions/services/dashboard-api/main.py`:
  - `api_settings_env_save`: remove `"reason": str(exc)` from 500 response, add `logger.error(...)` instead
  - `api_settings_env_apply`: replace f-string embedding `{exc}` with generic message (existing `logger.exception()` already captures details)

## Testing
- [ ] `cd ods/extensions/services/dashboard-api && pytest tests/`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)