### PR TITLE
fix(extensions): close case-sensitivity bypasses in compose scanner

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -383,7 +383,7 @@ def _scan_compose_content(
         else:
             label_keys = []
         for lk in label_keys:
-            if lk.startswith("com.docker.compose."):
+            if lk.lower().startswith(("com.docker.compose.", "io.docker.")):
                 raise HTTPException(
                     status_code=400,
                     detail=f"Extension rejected: reserved Docker Compose label '{lk}' in service '{svc_name}'",
@@ -406,7 +406,8 @@ def _scan_compose_content(
         cap_add = svc_def.get("cap_add", [])
         if isinstance(cap_add, list):
             for cap in cap_add:
-                if str(cap).upper() in {
+                cap_str = str(cap).upper().removeprefix("CAP_")
+                if cap_str in {
                     "SYS_ADMIN", "NET_ADMIN", "SYS_PTRACE", "NET_RAW",
                     "DAC_OVERRIDE", "SETUID", "SETGID", "SYS_MODULE",
                     "SYS_RAWIO", "ALL",


### PR DESCRIPTION
## Summary
- Fix two case-sensitivity bypasses in `_scan_compose_content()` that allowed reserved Docker labels and dangerous Linux capabilities to pass validation.

## Changes
- `ods/extensions/services/dashboard-api/routers/extensions.py`:
  - **Label check**: `lk.startswith("com.docker.compose.")` → `lk.lower().startswith(("com.docker.compose.", "io.docker."))` — blocks mixed-case and `io.docker.*` namespace
  - **Capability check**: add `.removeprefix("CAP_")` before set membership test — `CAP_SYS_ADMIN` now correctly blocked alongside `SYS_ADMIN`

## Testing
- [ ] `cd ods/extensions/services/dashboard-api && pytest tests/`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)