### PR TITLE
docs: refine Osmantic README lockup

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # ODS
 
+**Osmantic Deployment System**
+
 <p align="center">
-  <a href="https://osmantic.com">
+  <a href="https://osmantic.com" target="_blank" rel="noopener noreferrer">
     <img src="ods/docs/images/osmantic-lockup.png" alt="Osmantic" width="800">
   </a>
 </p>
-
-**Osmantic Deployment System**
 
 **Turn your PC, Mac, or Linux box into a private AI server.**
 


### PR DESCRIPTION
## Summary
- move the Osmantic Deployment System label above the full lockup
- open the clickable Osmantic lockup in a new tab
- add `noopener noreferrer` protections to the external link

## Validation
- `git diff --check`
- `bash ods/tests/test-doc-links.sh`
- `bash ods/tests/test-install-docs.sh`

## Risk
Low; README-only presentation change.