### PR TITLE
fix(installer): use TMPDIR fallback instead of hardcoded /tmp

### DIFF
--- a/ods/installers/lib/constants.sh
+++ b/ods/installers/lib/constants.sh
@@ -26,9 +26,9 @@ else
     INSTALL_DIR="${INSTALL_DIR:-$HOME/ods}"
 fi
 
-LOG_FILE="${LOG_FILE:-/tmp/ods-install.log}"
-CAPABILITY_PROFILE_FILE="${CAPABILITY_PROFILE_FILE:-/tmp/ods-capabilities.json}"
-PREFLIGHT_REPORT_FILE="${PREFLIGHT_REPORT_FILE:-/tmp/ods-preflight-report.json}"
+LOG_FILE="${LOG_FILE:-${TMPDIR:-/tmp}/ods-install.log}"
+CAPABILITY_PROFILE_FILE="${CAPABILITY_PROFILE_FILE:-${TMPDIR:-/tmp}/ods-capabilities.json}"
+PREFLIGHT_REPORT_FILE="${PREFLIGHT_REPORT_FILE:-${TMPDIR:-/tmp}/ods-preflight-report.json}"
 INSTALL_START_EPOCH=$(date +%s)
 
 # Auto-detect system timezone (fallback to UTC)


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp` with `${TMPDIR:-/tmp}` in installer constants. Some container environments or non-standard setups may not have `/tmp` writable or available.

## Changes
- `ods/installers/lib/constants.sh`: update `LOG_FILE`, `CAPABILITY_PROFILE_FILE`, `PREFLIGHT_REPORT_FILE` defaults

## Testing
- [ ] `bash -n ods/installers/lib/constants.sh`
- [ ] `make lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)