### PR TITLE
fix(qdrant): add missing CPU resource limit

### DIFF
--- a/ods/extensions/services/qdrant/compose.yaml
+++ b/ods/extensions/services/qdrant/compose.yaml
@@ -22,6 +22,7 @@ services:
     deploy:
       resources:
         limits:
+          cpus: '2.0'
           memory: 1G
     logging:
       driver: "json-file"


### PR DESCRIPTION
## Summary
- Qdrant was the only extension service with a memory limit but no CPU limit. Under load, a runaway vector search could starve other services on the host.

## Changes
- `ods/extensions/services/qdrant/compose.yaml`: add `cpus: '2.0'` alongside existing `memory: 1G`

## Testing
- [ ] `make test` (compose validation)
- [ ] `docker compose config` with Qdrant enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)