### PR TITLE
fix(dashboard): add aria-label to troubleshooting search input

### DIFF
--- a/ods/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
+++ b/ods/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx
@@ -142,6 +142,7 @@ export function TroubleshootingAssistant({ serviceStatus }) {
       <input
         type="text"
         placeholder="Search issues..."
+        aria-label="Search troubleshooting issues"
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         className="w-full px-3 py-2 bg-theme-card border border-theme-border rounded-lg text-sm text-theme-text placeholder-theme-text-muted focus:outline-none focus:border-theme-accent"


### PR DESCRIPTION
## Summary
- Add `aria-label="Search troubleshooting issues"` to the search input in `TroubleshootingAssistant`. Screen readers announce `placeholder` text inconsistently, so an explicit `aria-label` ensures the field is always accessible.

## Changes
- `ods/extensions/services/dashboard/src/components/TroubleshootingAssistant.jsx`

## Testing
- [ ] `cd ods/extensions/services/dashboard && npm run lint && npm run build`