### PR TITLE
fix(compose): align OLLAMA_PORT fallback with documented default

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -423,7 +423,7 @@
     "OLLAMA_PORT": {
       "type": "integer",
       "description": "llama-server external port",
-      "default": 8080
+      "default": 11434
     },
     "WEBUI_PORT": {
       "type": "integer",

--- a/ods/config/ports.json
+++ b/ods/config/ports.json
@@ -4,7 +4,7 @@
   "ports": [
     {
       "env_var": "OLLAMA_PORT",
-      "external_default": 8080,
+      "external_default": 11434,
       "service_id": "llama-server",
       "internal_port": 8080,
       "manifest_service": "llama-server",

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -29,7 +29,7 @@ services:
       - ./data/models:/models:z
       - ./config/llama-server/models.ini:/config/models.ini:ro,z
     ports:
-      - "${BIND_ADDRESS:-127.0.0.1}:${OLLAMA_PORT:-8080}:8080"
+      - "${BIND_ADDRESS:-127.0.0.1}:${OLLAMA_PORT:-11434}:8080"
     command:
       - --model
       - /models/${GGUF_FILE:-Qwen3.5-9B-Q4_K_M.gguf}

--- a/ods/docs/INTEGRATION-GUIDE.md
+++ b/ods/docs/INTEGRATION-GUIDE.md
@@ -207,7 +207,7 @@ Key variables in `.env` (see [.env.example](../.env.example) for the full list):
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `OLLAMA_PORT` | 8080 | llama-server external port (maps to internal 8080) |
+| `OLLAMA_PORT` | 11434 | llama-server external port (maps to internal 8080) |
 | `WEBUI_PORT` | 3000 | Open WebUI port |
 | `N8N_PORT` | 5678 | n8n workflows port |
 | `LLM_MODEL` | *(tier-dependent)* | Model name for OpenClaw/dashboard |

--- a/ods/extensions/services/llama-server/README.md
+++ b/ods/extensions/services/llama-server/README.md
@@ -26,7 +26,7 @@ Environment variables (set in `.env`):
 |----------|---------|-------------|
 | `GGUF_FILE` | `Qwen3.5-9B-Q4_K_M.gguf` | Model filename inside `data/models/` |
 | `CTX_SIZE` | `16384` | Context window size in tokens |
-| `OLLAMA_PORT` | `8080` | External port (maps to internal 8080) |
+| `OLLAMA_PORT` | `11434` | External host port (maps to internal 8080) |
 | `GPU_BACKEND` | `nvidia` | GPU backend: `nvidia` or `amd` |
 | `LLAMA_ARG_FLASH_ATTN` | `auto` | llama.cpp Flash Attention mode: `auto`, `on`, or `off` |
 | `LLAMA_ARG_CACHE_TYPE_K` | `f16` | KV cache key precision. Use `q8_0` to reduce long-context memory pressure |

--- a/ods/extensions/services/llama-server/manifest.yaml
+++ b/ods/extensions/services/llama-server/manifest.yaml
@@ -12,7 +12,7 @@ service:
   default_host: llama-server
   port: 8080
   external_port_env: OLLAMA_PORT
-  external_port_default: 8080
+  external_port_default: 11434
   health: /health
   ui_path: /
   health_timeout: 15


### PR DESCRIPTION
## Summary
- The compose fallback for `OLLAMA_PORT` was `8080`, but `.env.example` documents the default as `11434`. If `.env` is missing or the variable unset, the server binds to port 8080 instead of the expected 11434.

## Changes
- `ods/docker-compose.base.yml`: change `${OLLAMA_PORT:-8080}` to `${OLLAMA_PORT:-11434}`

## Testing
- [ ] `make test` (compose validation)
- [ ] `docker compose config` with OLLAMA_PORT unset — verify external port is 11434