### PR TITLE
fix(dashboard-api): catch JSONDecodeError in host-agent response parsing

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/resources.py
+++ b/ods/extensions/services/dashboard-api/routers/resources.py
@@ -88,7 +88,11 @@ def _post_agent_json(path: str, body: dict, timeout: int = 65) -> dict:
     )
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp:
-            return json.loads(resp.read().decode() or "{}")
+            raw = resp.read().decode()
+            return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        logger.warning("Host agent returned invalid JSON for %s", path)
+        return {}
     except urllib.error.HTTPError as exc:
         try:
             detail = json.loads(exc.read().decode() or "{}").get("error")
@@ -96,7 +100,8 @@ def _post_agent_json(path: str, body: dict, timeout: int = 65) -> dict:
             detail = exc.reason
         raise HTTPException(status_code=exc.code, detail=detail or "Host agent request failed") from exc
     except (urllib.error.URLError, OSError) as exc:
-        raise HTTPException(status_code=503, detail=f"Host agent unavailable: {exc}") from exc
+        logger.warning("Host agent unavailable at %s: %s", path, exc)
+        raise HTTPException(status_code=503, detail="Host agent unavailable") from exc
 
 
 @router.get("/api/services/resources")


### PR DESCRIPTION
## Summary
- `_post_agent_json()` in resources.py did not catch `json.JSONDecodeError`. A malformed or empty response from the host agent would crash with an unhandled 500 instead of returning an empty dict gracefully.
- Also removes `{exc}` from the `OSError` detail to stop leaking internal error details to the client.

## Changes
- `ods/extensions/services/dashboard-api/routers/resources.py`: add `json.JSONDecodeError` handler, log warning server-side, return `{}` as fallback. Replace f-string detail with generic message.

## Testing
- [ ] `cd ods/extensions/services/dashboard-api && pytest tests/`
- [ ] `make lint`