### PR TITLE
fix(installer): use TMPDIR in mktemp calls for portability

### DIFF
--- a/ods/installers/phases/03-features.sh
+++ b/ods/installers/phases/03-features.sh
@@ -269,7 +269,7 @@ fi
 # Multi-GPU Configuration
 
 # write $GPU_TOPOLOGY_JSON into a tmpfile to use by the commands
-TOPOLOGY_FILE=$(mktemp /tmp/ods_gpu_topology.XXXXXX.json)
+TOPOLOGY_FILE=$(mktemp "${TMPDIR:-/tmp}/ods_gpu_topology.XXXXXX.json")
 trap 'rm -f "$TOPOLOGY_FILE"' EXIT
 echo "$GPU_TOPOLOGY_JSON" > "$TOPOLOGY_FILE"
 

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -365,7 +365,7 @@ wait_for_healthy() {
     local attempt=0
     local delay=10
     local health_log
-    health_log=$(mktemp /tmp/ods-health-XXXXXX.log)
+    health_log=$(mktemp "${TMPDIR:-/tmp}/ods-health-XXXXXX.log")
 
     log_info "Waiting for services (timeout: ${HEALTH_TIMEOUT}s)..."
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `/tmp` in `mktemp` calls with `${TMPDIR:-/tmp}`. Some container runtimes and non-standard environments may not have `/tmp` writable.

## Changes
- `ods/ods-update.sh`: health log temp file
- `ods/installers/phases/03-features.sh`: GPU topology temp file

## Testing
- [ ] `bash -n ods/ods-update.sh`
- [ ] `bash -n ods/installers/phases/03-features.sh`
- [ ] `make lint`