### PR TITLE
fix(dashboard): close Invites modal on Escape key press

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Invites.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Invites.jsx
@@ -550,6 +550,12 @@ function CreateGuestModal({ onClose, onCreated }) {
 }
 
 function Modal({ title, label, onClose, children }) {
+  useEffect(() => {
+    const handleKey = (e) => { if (e.key === 'Escape') onClose() }
+    document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" onClick={onClose}>
       <div


### PR DESCRIPTION
## Summary
- Add Escape key handler to the Modal component in Invites.jsx. WCAG 2.1 requires dialogs to be dismissible via keyboard. The component already had proper `role="dialog"` and `aria-modal="true"` attributes but was missing the keydown listener.

## Changes
- `ods/extensions/services/dashboard/src/pages/Invites.jsx`: add `useEffect` with `keydown` listener for Escape key in `Modal` component

## Testing
- [ ] `cd ods/extensions/services/dashboard && npm run lint && npm run build`
- [ ] Open Invites modal, press Escape — should close