### PR TITLE
fix(rsync): detect caller log_info function with declare -F

### DIFF
--- a/ods/lib/rsync.sh
+++ b/ods/lib/rsync.sh
@@ -23,7 +23,15 @@ rsync_with_progress() {
     local dest="$2"
     local label="${3:-Copying}"
 
-    [[ -n "${log_info:-}" ]] && log_info "$label..." || echo "[INFO] $label..."
+    # Prefer the caller's styled logger when it exists. log_info is a *function*
+    # in the scripts that source this lib (ods-backup.sh, ods-restore.sh), so it
+    # must be probed with `declare -F`, not `${log_info:-}` (which only ever sees
+    # a variable and is always empty — the styled path was previously dead code).
+    if declare -F log_info >/dev/null 2>&1; then
+        log_info "$label..."
+    else
+        echo "[INFO] $label..."
+    fi
 
     # Use --info=progress2 for compact single-line progress updates
     # Fallback to basic rsync if progress2 not supported


### PR DESCRIPTION
## Problem

`lib/rsync.sh`'s `rsync_with_progress()` tries to use the caller's styled logger when available:

```bash
[[ -n "${log_info:-}" ]] && log_info "$label..." || echo "[INFO] $label..."
```

But `${log_info:-}` is a **variable** expansion. `log_info` is a **function** in every script that sources this lib (`ods-backup.sh:26`, `ods-restore.sh:22`), never a variable — so the guard is **always false** and the styled branch is dead code. Every backup/restore progress label ("Backing up config/…", "Restoring …") prints through the plain `echo` fallback instead of the colored `${BLUE}[INFO]${NC}` logger the callers define.

The `&& … || …` chain also has a latent double-print: if the `log_info` function ever returned non-zero, the `|| echo` would fire too.

## Fix

Probe the function with `declare -F log_info` and branch with `if/else`:

```bash
if declare -F log_info >/dev/null 2>&1; then
    log_info "$label..."
else
    echo "[INFO] $label..."
fi
```

## Verification

Sourced the lib under `set -euo pipefail` with a stubbed `rsync`:

- **Caller defines `log_info`** → styled path now runs (`STYLED[INFO] TestLabel...`). Previously printed the plain fallback.
- **No `log_info`** → plain `[INFO] TestLabel2...` fallback, unchanged.

`bash -n` clean. No behavior change for the fallback path; the styled path now works as originally intended.