### PR TITLE
fix(dashboard-api): emit UTC-aware timestamps from agent monitor

### DIFF
--- a/ods/extensions/services/dashboard-api/agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/agent_monitor.py
@@ -6,7 +6,7 @@ Collects real-time metrics on agent swarms, sessions, and throughput.
 import asyncio
 import json
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List
 import os
 
@@ -22,7 +22,7 @@ class AgentMetrics:
     """Real-time agent monitoring metrics"""
 
     def __init__(self):
-        self.last_update = datetime.now()
+        self.last_update = datetime.now(timezone.utc)
         self.session_count = 0
         self.tokens_per_second = 0.0  # no data source located; use throughput.get_stats() for live rate
         self.error_rate_1h = 0.0
@@ -96,12 +96,12 @@ class ThroughputMetrics:
     def add_sample(self, tokens_per_sec: float):
         """Add a new throughput sample"""
         self.data_points.append({
-            "timestamp": datetime.now().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "tokens_per_sec": tokens_per_sec
         })
 
         # Prune old data
-        cutoff = datetime.now() - timedelta(minutes=self.history_minutes)
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=self.history_minutes)
         self.data_points = [
             p for p in self.data_points
             if datetime.fromisoformat(p["timestamp"]) > cutoff
@@ -173,7 +173,7 @@ async def collect_metrics():
             # Update agent session count and throughput from Token Spy
             await _fetch_token_spy_metrics()
 
-            agent_metrics.last_update = datetime.now()
+            agent_metrics.last_update = datetime.now(timezone.utc)
 
         except FileNotFoundError as e:
             logger.debug("Metrics collection failed: command not found - %s", e)
@@ -190,7 +190,7 @@ async def collect_metrics():
 def get_full_agent_metrics() -> dict:
     """Get all agent monitoring metrics as a dict"""
     return {
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "agent": agent_metrics.to_dict(),
         "cluster": cluster_status.to_dict(),
         "throughput": throughput.get_stats()

--- a/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
+++ b/ods/extensions/services/dashboard-api/tests/test_agent_monitor.py
@@ -1,6 +1,6 @@
 """Tests for agent_monitor.py — throughput metrics and data classes."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
@@ -35,8 +35,10 @@ class TestThroughputMetrics:
     def test_prunes_old_data(self):
         tm = ThroughputMetrics(history_minutes=5)
 
-        # Insert an old data point by manipulating the list directly
-        old_time = (datetime.now() - timedelta(minutes=10)).isoformat()
+        # Insert an old data point by manipulating the list directly. The
+        # fixture must be UTC-aware like real samples: the prune cutoff is
+        # aware, and comparing it against a naive timestamp raises TypeError.
+        old_time = (datetime.now(timezone.utc) - timedelta(minutes=10)).isoformat()
         tm.data_points.append({"timestamp": old_time, "tokens_per_sec": 99.0})
 
         # Adding a new sample triggers pruning


### PR DESCRIPTION
## Problem

`agent_monitor.py` builds every timestamp with a bare `datetime.now()` — **naive**, local wall-clock:

```python
self.last_update = datetime.now()                       # AgentMetrics.__init__
"timestamp": datetime.now().isoformat()                 # ThroughputMetrics.add_sample
cutoff = datetime.now() - timedelta(...)                 # prune
agent_metrics.last_update = datetime.now()               # collect_metrics
"timestamp": datetime.now().isoformat()                 # get_full_agent_metrics
```

`to_dict()` and `get_full_agent_metrics()` serialize those with `.isoformat()`, so `GET /api/agents/metrics` returns `last_update` / `timestamp` **with no timezone designator**.

Every other dashboard-api module emits `datetime.now(timezone.utc)` (offset-aware). A browser parsing a no-offset ISO string with `new Date()` interprets it as **local** time. On the common setup — container clock in UTC, viewer in another zone — the agent-monitor times drift by the UTC offset and any "time since last update" math is wrong.

```
OLD (naive): 2026-07-16T11:28:01.676062            → new Date() reads as LOCAL
NEW (aware): 2026-07-16T04:28:01.676086+00:00      → new Date() reads as UTC
```
(same instant; a UTC+7 viewer saw a 7-hour skew)

## Fix

Switch all five `datetime.now()` call sites to `datetime.now(timezone.utc)` and import `timezone`. This matches the rest of the API and produces valid offset-aware ISO 8601.

## Verification

- `python -m py_compile` clean.
- Prune comparison stays consistent (aware vs aware): re-ran `add_sample` logic, `datetime.fromisoformat(p["timestamp"]) > cutoff` works, both retained.
- Emitted value now ends with `+00:00` and round-trips through `fromisoformat` as tz-aware.
- Existing `test_agents.py` unaffected — it sets `last_update` explicitly and asserts HTML escaping, not tz format.