### PR TITLE
fix(dashboard-api): use is_relative_to for workflow path containment

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/workflows.py
+++ b/ods/extensions/services/dashboard-api/routers/workflows.py
@@ -184,7 +184,7 @@ async def enable_workflow(workflow_id: str, api_key: str = Depends(verify_api_ke
     workflow_file = WORKFLOW_DIR / wf_info["file"]
     try:
         workflow_file = workflow_file.resolve()
-        if not str(workflow_file).startswith(str(WORKFLOW_DIR.resolve())):
+        if not workflow_file.is_relative_to(WORKFLOW_DIR.resolve()):
             raise HTTPException(status_code=400, detail="Invalid workflow file path")
     except HTTPException:
         raise

--- a/ods/extensions/services/dashboard-api/tests/test_workflows.py
+++ b/ods/extensions/services/dashboard-api/tests/test_workflows.py
@@ -911,3 +911,30 @@ def test_workflows_with_matching_n8n(test_client, tmp_path, monkeypatch):
     assert wf["n8nId"] == "55"
     assert wf["executions"] == 42
     assert wf["featured"] is True
+
+
+def test_workflow_enable_rejects_path_traversal_in_catalog_file(test_client, monkeypatch):
+    """A catalog 'file' that escapes WORKFLOW_DIR via .. must be refused by
+    the is_relative_to containment guard, not resolved and imported."""
+    import routers.workflows as wf_mod
+
+    async def _no_missing_deps(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(wf_mod, "load_workflow_catalog", lambda: {
+        "workflows": [{
+            "id": "evil-workflow",
+            "name": "Evil",
+            "file": "../n8n-evil/pwned.json",
+            "dependencies": [],
+        }],
+        "categories": {},
+    })
+    monkeypatch.setattr(wf_mod, "check_workflow_dependencies", _no_missing_deps)
+
+    resp = test_client.post(
+        "/api/workflows/evil-workflow/enable",
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Invalid workflow file path"


### PR DESCRIPTION
## Problem

`enable_workflow()` validates the resolved workflow file with a **string prefix** check:

```python
workflow_file = workflow_file.resolve()
if not str(workflow_file).startswith(str(WORKFLOW_DIR.resolve())):
    raise HTTPException(status_code=400, detail="Invalid workflow file path")
```

`str.startswith()` is not a safe containment test: a **sibling directory that shares the base as a name prefix** slips through.

```
WORKFLOW_DIR = /data/workflows
/data/workflows-evil/steal.json  → startswith('/data/workflows')  == True   (WRONG)
                                 → is_relative_to('/data/workflows') == False (CORRECT)
/data/workflows/rag.json         → is_relative_to(...)              == True   (legit, still allowed)
```

The rest of dashboard-api already uses `Path.is_relative_to()` for this exact boundary (`helpers.py:703`, `routers/extensions.py` ×6, `routers/models.py:449`). `workflows.py` was the lone holdout.

## Fix

```python
if not workflow_file.is_relative_to(WORKFLOW_DIR.resolve()):
```

The surrounding `try/except (OSError, ValueError)` still guards `.resolve()`.

## Threat model (honest scoping)

`wf_info["file"]` currently comes from the trusted workflow catalog, so this is **defense-in-depth + convention consistency** rather than a live exploit. But the code clearly treats this as a security boundary (it raises *"Invalid workflow file path"*), so it should actually hold, and match how the codebase does containment everywhere else.

## Verification

- `python -m py_compile` clean.
- Demonstrated the sibling-prefix divergence above (startswith True / is_relative_to False), and confirmed a legitimate in-dir path still passes.
- `is_relative_to` is Python 3.9+, already relied on elsewhere in this package.