### PR TITLE
fix(dashboard): persist dismissed update banner across reloads

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useVersion.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useVersion.test.js
@@ -61,6 +61,38 @@ describe('useVersion', () => {
     expect(result.current.version.update_available).toBe(false)
   })
 
+  test('suppresses update banner for a previously dismissed version', async () => {
+    globalThis.localStorage.setItem('dismissed-update', '2.0.0')
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ current: '1.0.0', latest: '2.0.0', update_available: true })
+    })
+
+    const { result } = renderHook(() => useVersion())
+
+    await waitFor(() => {
+      expect(result.current.version).toBeTruthy()
+    })
+    // Dismissed 2.0.0 → banner stays hidden even though the API reports it.
+    expect(result.current.version.update_available).toBe(false)
+  })
+
+  test('re-surfaces the banner when a newer version supersedes the dismissed one', async () => {
+    globalThis.localStorage.setItem('dismissed-update', '2.0.0')
+    fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ current: '1.0.0', latest: '3.0.0', update_available: true })
+    })
+
+    const { result } = renderHook(() => useVersion())
+
+    await waitFor(() => {
+      expect(result.current.version).toBeTruthy()
+    })
+    // 3.0.0 != dismissed 2.0.0 → the new release still surfaces.
+    expect(result.current.version.update_available).toBe(true)
+  })
+
   test('handles fetch error gracefully', async () => {
     fetch.mockRejectedValue(new Error('network error'))
 

--- a/ods/extensions/services/dashboard/src/hooks/useVersion.js
+++ b/ods/extensions/services/dashboard/src/hooks/useVersion.js
@@ -15,6 +15,16 @@ export function useVersion() {
           throw new Error('Failed to check version')
         }
         const data = await response.json()
+        // Honor a previous dismissal across reloads. dismissUpdate() records
+        // the dismissed `latest` in localStorage, but that value was never read
+        // back — so every reload re-fetched update_available:true and the update
+        // banner reappeared despite the user dismissing it. Suppress it only for
+        // the exact version that was dismissed; a genuinely newer `latest` no
+        // longer matches and surfaces normally.
+        if (data.update_available && data.latest &&
+            localStorage.getItem('dismissed-update') === data.latest) {
+          data.update_available = false
+        }
         setVersion(data)
       } catch (err) {
         setError(err.message)


### PR DESCRIPTION
## Problem

`useVersion().dismissUpdate()` records the dismissed release and hides the banner:

```js
localStorage.setItem('dismissed-update', version.latest)
setVersion({ ...version, update_available: false })
```

But `dismissed-update` was **write-only** — nothing ever read it back (the only `getItem('dismissed-update')` in the tree is a test asserting the write). So on the next mount/reload, `useVersion` re-fetches `/api/version`, gets `update_available: true` again, and the update banner **reappears**. "Dismiss" effectively lasted only until the next page refresh.

## Fix

Read `dismissed-update` after each fetch and clear `update_available` when it matches the reported `latest`:

```js
if (data.update_available && data.latest &&
    localStorage.getItem('dismissed-update') === data.latest) {
  data.update_available = false
}
```

The dismissal is version-specific: a genuinely newer `latest` no longer matches, so a new release still surfaces (users don't get stuck permanently hiding all future updates).

## Tests

Added to `useVersion.test.js`:
- dismissed version stays hidden on the next fetch;
- a newer version supersedes the dismissal and re-surfaces.

```
Test Files  1 passed (1)
     Tests  6 passed (6)   # 4 existing + 2 new
```
eslint clean.