### PR TITLE
fix(dashboard): floor fractional seconds in download ETA

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useDownloadProgress.test.js
@@ -137,6 +137,9 @@ describe('useDownloadProgress', () => {
 
     expect(result.current.formatEta(90)).toBe('1m 30s')
     expect(result.current.formatEta(30)).toBe('30s')
+    // Fractional eta (bytes-remaining / rate) must not leak float noise.
+    expect(result.current.formatEta(90.7)).toBe('1m 30s')
+    expect(result.current.formatEta(30.9)).toBe('30s')
     expect(result.current.formatEta(null)).toBe('calculating...')
     expect(result.current.formatEta('calculating...')).toBe('calculating...')
   })

--- a/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
+++ b/ods/extensions/services/dashboard/src/hooks/useDownloadProgress.js
@@ -96,7 +96,10 @@ export function useDownloadProgress(pollIntervalMs = 1000) {
     if (!eta || eta === 'calculating...') return 'calculating...'
     if (typeof eta === 'number') {
       const mins = Math.floor(eta / 60)
-      const secs = eta % 60
+      // Floor the seconds too — a fractional eta (bytes-remaining / rate is a
+      // float) otherwise renders as "1m 30.700000000000003s". Mirrors the
+      // Math.floor already applied to minutes.
+      const secs = Math.floor(eta % 60)
       if (mins > 0) return `${mins}m ${secs}s`
       return `${secs}s`
     }


### PR DESCRIPTION
## Problem

`useDownloadProgress`'s `formatEta()` floors the minutes but not the seconds:

```js
const mins = Math.floor(eta / 60)
const secs = eta % 60            // not floored
```

The ETA comes from bytes-remaining / rate, so it is generally a **float**. A value like `90.7` renders in the model-download progress UI as:

```
1m 30.700000000000003s
```

## Fix

Floor the seconds too, mirroring the minutes:

```js
const secs = Math.floor(eta % 60)   // → '1m 30s'
```

## Tests

Extended the existing `formatEta` test with fractional inputs (`90.7 → '1m 30s'`, `30.9 → '30s'`). Integer cases unchanged.

```
Test Files  1 passed (1)
     Tests  6 passed (6)
```
eslint clean.