### PR TITLE
fix(macos-cli): redact all sensitive keys in ods config show

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -60,6 +60,9 @@ test: ## Run unit and contract tests
 	@echo "=== ods config show secret-mask matrix ==="
 	@bash tests/test-ods-config-secret-mask.sh
 	@echo ""
+	@echo "=== macOS ods config show secret-mask ==="
+	@bash tests/test-macos-config-show-secret-mask.sh
+	@echo ""
 	@echo "=== bootstrap OpenClaw compose-guard regression ==="
 	@bash tests/test-bootstrap-openclaw-compose-guard.sh
 	@echo ""

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -584,13 +584,24 @@ cmd_config_show() {
         line_trimmed=$(echo "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
         [[ "$line_trimmed" =~ ^# ]] && echo -e "  ${DGRN}${line_trimmed}${NC}" && continue
         [[ -z "$line_trimmed" ]] && continue
-        if echo "$line_trimmed" | grep -qE "(SECRET|PASS|TOKEN|KEY)="; then
-            local key
-            key=$(echo "$line_trimmed" | cut -d= -f1)
-            echo -e "  ${DGRN}${key}=***${NC}"
-        else
-            echo -e "  ${WHT}${line_trimmed}${NC}"
-        fi
+        # Non KEY=VALUE lines: print verbatim.
+        [[ "$line_trimmed" == *=* ]] || { echo -e "  ${WHT}${line_trimmed}${NC}"; continue; }
+        # Mask by KEY NAME, not "keyword immediately before =". The old
+        # `(SECRET|PASS|TOKEN|KEY)=` regex only matched when the keyword was
+        # adjacent to `=`, so OPENCODE_SERVER_PASSWORD, LANGFUSE_DB_PASSWORD,
+        # LANGFUSE_SALT, N8N_USER, LANGFUSE_INIT_USER_EMAIL, ... printed their
+        # (auto-generated) secret values in cleartext. Match the key name
+        # against the same keyword set the Linux CLI's _cmd_config_is_secret
+        # falls back to (tr for lowercasing keeps this Bash 3.2 / macOS safe).
+        local key key_lc
+        key="${line_trimmed%%=*}"
+        key_lc=$(printf '%s' "$key" | tr '[:upper:]' '[:lower:]')
+        case "$key_lc" in
+            *secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*|*user*|*email*)
+                echo -e "  ${DGRN}${key}=***${NC}" ;;
+            *)
+                echo -e "  ${WHT}${line_trimmed}${NC}" ;;
+        esac
     done < "$env_file"
     echo ""
 }

--- a/ods/tests/test-macos-config-show-secret-mask.sh
+++ b/ods/tests/test-macos-config-show-secret-mask.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Regression: macOS `ods config show` (installers/macos/ods-macos.sh) must
+# mask secret VALUES, not just keys whose keyword sits immediately before `=`.
+# ============================================================================
+# The previous `grep -qE "(SECRET|PASS|TOKEN|KEY)="` check only matched when
+# the keyword was adjacent to `=`, so keys like OPENCODE_SERVER_PASSWORD,
+# LANGFUSE_DB_PASSWORD, LANGFUSE_SALT, N8N_USER and LANGFUSE_INIT_USER_EMAIL
+# printed their auto-generated secret values in cleartext. Masking now matches
+# the key NAME against the same keyword set the Linux CLI's _cmd_config_is_secret
+# falls back to. This test exercises the real script end-to-end.
+# ============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$ROOT_DIR/installers/macos/ods-macos.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { echo -e "  ${GREEN}✓ PASS${NC} $1"; PASSED=$((PASSED + 1)); }
+fail() { echo -e "  ${RED}✗ FAIL${NC} $1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "=== macOS ods config show — secret masking ==="
+echo ""
+
+if [[ ! -f "$CLI" ]]; then
+    fail "ods-macos.sh not found at $CLI"
+    echo ""; echo "Result: $PASSED passed, $FAILED failed"; exit 1
+fi
+
+TEMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TEMP_DIR"' EXIT
+
+# `test_install` needs INSTALL_DIR to exist with a compose file, plus a running
+# Docker; shim `docker info` so the check passes without Docker Desktop.
+SHIM_DIR="$TEMP_DIR/bin"
+mkdir -p "$SHIM_DIR"
+printf '#!/bin/sh\nexit 0\n' > "$SHIM_DIR/docker"
+chmod +x "$SHIM_DIR/docker"
+
+INSTALL_SCAFFOLD="$TEMP_DIR/install"
+mkdir -p "$INSTALL_SCAFFOLD"
+touch "$INSTALL_SCAFFOLD/docker-compose.base.yml"
+
+cat > "$INSTALL_SCAFFOLD/.env" <<'EOF'
+# Test fixture
+OLLAMA_PORT=11434
+BIND_ADDRESS=127.0.0.1
+OPENCODE_SERVER_PASSWORD=leak-pw-value
+LANGFUSE_SALT=leak-salt-value
+LANGFUSE_DB_PASSWORD=leak-dbpw-value
+N8N_USER=leak-user-value
+LANGFUSE_INIT_USER_EMAIL=leak@example.test
+DASHBOARD_API_KEY=leak-key-value
+ODS_SESSION_SECRET=leak-secret-value
+LLM_MODEL=some-model
+EOF
+
+# Sentinel values whose appearance in stdout would prove a leak.
+SECRETS=(leak-pw-value leak-salt-value leak-dbpw-value leak-user-value \
+         leak@example.test leak-key-value leak-secret-value)
+
+# Strip ANSI colors so assertions match on plain text.
+OUT=$(ODS_HOME="$INSTALL_SCAFFOLD" PATH="$SHIM_DIR:$PATH" \
+    bash "$CLI" config show 2>&1 | sed 's/\x1b\[[0-9;]*m//g')
+
+for secret in "${SECRETS[@]}"; do
+    if grep -qF "$secret" <<<"$OUT"; then
+        fail "secret value LEAKED in cleartext: $secret"
+        echo "  --- output ---"; awk '{print "  " $0}' <<<"$OUT"
+    else
+        pass "secret value masked: $secret"
+    fi
+done
+
+# The masked keys must still be listed (as KEY=***), not dropped entirely.
+for key in OPENCODE_SERVER_PASSWORD LANGFUSE_SALT N8N_USER LANGFUSE_INIT_USER_EMAIL DASHBOARD_API_KEY; do
+    if grep -qF "${key}=***" <<<"$OUT"; then
+        pass "$key shown as masked ***"
+    else
+        fail "$key not rendered as ${key}=***"
+    fi
+done
+
+# Non-secret keys must NOT be masked (no over-mask regression).
+for kv in "OLLAMA_PORT=11434" "BIND_ADDRESS=127.0.0.1" "LLM_MODEL=some-model"; do
+    if grep -qF "$kv" <<<"$OUT"; then
+        pass "non-secret shown in clear: $kv"
+    else
+        fail "non-secret missing or masked: $kv"
+    fi
+done
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Problem

macOS `ods config show` (`installers/macos/ods-macos.sh` → `cmd_config_show`) masked secrets with:

```bash
grep -qE "(SECRET|PASS|TOKEN|KEY)="
```

That only matches when the keyword is **immediately before `=`**. Keys whose sensitive word sits elsewhere in the name printed their (auto-generated) values in **cleartext**:

| Key (all `secret:true` in `.env.schema.json`) | Old result |
|---|---|
| `OPENCODE_SERVER_PASSWORD` | ❌ leaked (`PASSWORD=` ≠ `PASS=`) |
| `LANGFUSE_DB_PASSWORD`, `LANGFUSE_CLICKHOUSE_PASSWORD`, `LANGFUSE_REDIS_PASSWORD` | ❌ leaked |
| `LANGFUSE_SALT` | ❌ leaked (no `SALT` keyword) |
| `N8N_USER`, `LANGFUSE_INIT_USER_EMAIL` | ❌ leaked |

Same class of bug fixed for the Windows CLI (`ods.ps1`).

## Fix

Extract the key name first, then match it (lowercased with `tr` — Bash 3.2 / macOS safe) against the same keyword set the Linux CLI's `_cmd_config_is_secret` falls back to:

```
*secret*|*password*|*pass*|*token*|*key*|*salt*|*bearer*|*user*|*email*
```

Every `secret:true` key in the current schema matches this set. Non-`KEY=VALUE` lines and non-secret keys are unaffected.

## Test

`tests/test-macos-config-show-secret-mask.sh` (wired into `make test`) drives the real script end-to-end against a scaffold install (with a `docker` shim for the running-Docker check) and asserts secret values never appear, masked keys render as `KEY=***`, and non-secret keys stay in clear.

```
old code: 6 passed, 9 failed   (5 secret values leaked in cleartext)
fixed:   15 passed, 0 failed
```
`bash -n` clean.