### PR TITLE
fix(support-bundle): redact user/email secret keys in shared bundle

### DIFF
--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -215,7 +215,11 @@ from pathlib import Path
 
 src = Path(sys.argv[1])
 dest = Path(sys.argv[2])
-secret = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)", re.I)
+# USER|EMAIL|BEARER cover schema secret:true keys the old pattern missed —
+# N8N_USER, LANGFUSE_INIT_USER_EMAIL, LANGFUSE_MINIO_ROOT_USER — which are
+# published in cleartext when this env.redacted is shared on a public issue.
+# Match .env.schema.json's secret set / the CLI's config-show masking.
+secret = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL|USER|EMAIL|BEARER)", re.I)
 
 lines = []
 for line in src.read_text(encoding="utf-8", errors="replace").splitlines():
@@ -586,7 +590,10 @@ bundle_dir = Path(sys.argv[1])
 root_dir = Path(sys.argv[2])
 status_path = bundle_dir / "manifest" / "command-status.tsv"
 
-secret = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)", re.I)
+# Keep in sync with write_redacted_env's key set. USER|EMAIL|BEARER cover
+# schema secret:true keys (N8N_USER, LANGFUSE_INIT_USER_EMAIL,
+# LANGFUSE_MINIO_ROOT_USER) whose VALUES would otherwise land in evidence.json.
+secret = re.compile(r"(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL|USER|EMAIL|BEARER)", re.I)
 
 
 def load_json(path):

--- a/ods/tests/test-support-bundle.sh
+++ b/ods/tests/test-support-bundle.sh
@@ -85,6 +85,8 @@ SECRET_VALUE="support-bundle-super-secret"
 cat > "$ENV_PATH" <<EOF
 DASHBOARD_API_KEY=$SECRET_VALUE
 OPENAI_API_KEY=$SECRET_VALUE
+N8N_USER=$SECRET_VALUE
+LANGFUSE_INIT_USER_EMAIL=$SECRET_VALUE
 NORMAL_VALUE=visible-value
 ODS_MODE=cloud
 GPU_BACKEND=cpu
@@ -170,6 +172,15 @@ if [[ -f "$BUNDLE_DIR/config/env.redacted" ]] && grep -q "DASHBOARD_API_KEY=\\[R
     pass ".env is included only as redacted env"
 else
     fail "redacted env file is missing expected redaction"
+fi
+
+# Schema secret:true user/email keys must be redacted too — they ship in the
+# publicly shared bundle. The old keyword set omitted USER/EMAIL.
+if grep -q "N8N_USER=\\[REDACTED\\]" "$BUNDLE_DIR/config/env.redacted" \
+    && grep -q "LANGFUSE_INIT_USER_EMAIL=\\[REDACTED\\]" "$BUNDLE_DIR/config/env.redacted"; then
+    pass "schema-secret user/email env keys are redacted"
+else
+    fail "N8N_USER / LANGFUSE_INIT_USER_EMAIL leaked into env.redacted"
 fi
 
 if grep -R "$SECRET_VALUE" "$BUNDLE_DIR" >/dev/null 2>&1; then


### PR DESCRIPTION
## Problem

`ods-support-bundle.sh` builds a diagnostics archive intended to be attached to **public** issues — its header promises *"Raw .env is never included; only config/env.redacted is written."* But the redaction keyword set was:

```
KEY | TOKEN | SECRET | PASSWORD | PASS | SALT | AUTH | CREDENTIAL
```

— missing **USER** and **EMAIL**. Keys marked `secret: true` in `.env.schema.json` therefore shipped in **cleartext** in two places:

| Surface | Function |
|---|---|
| `config/env.redacted` | `write_redacted_env` |
| `manifest/evidence.json` → `env_keys[..].value` | evidence generator |

Affected keys: `N8N_USER`, `LANGFUSE_INIT_USER_EMAIL` (PII), `LANGFUSE_MINIO_ROOT_USER`.

```
# old env.redacted
N8N_USER=admin-username           ← leaked
LANGFUSE_INIT_USER_EMAIL=a@b.test ← leaked (PII)
```

## Fix

Add `USER|EMAIL|BEARER` to **both env-key-scoped** patterns (`write_redacted_env` and the evidence generator), matching `.env.schema.json`'s secret set and the CLI's `config show` masking.

`redact_file` (arbitrary logs / JSON / `docker compose config`) is **intentionally left unchanged** — adding `user`/`email` to its JSON pattern would over-redact container `user: "1000:1000"` UID/GID and `*user*`-suffixed diagnostic fields, hurting debuggability. The two patterns fixed here key off env variable **names**, so there is zero over-redaction.

## Test

Extends `tests/test-support-bundle.sh` (already gated in `test-linux.yml`): the fixture `.env` now carries `N8N_USER` and `LANGFUSE_INIT_USER_EMAIL`, plus an explicit `env.redacted` redaction assertion.

```
old code: 17 passed, 3 failed   (env.redacted, evidence.json, archive all leaked the sentinel)
fixed:    20 passed, 0 failed
```
Verified end-to-end via the real script (WSL); `bash -n` clean.