### PR TITLE
fix(windows-cli): validate logs line count instead of crashing on bad input

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2082,7 +2082,20 @@ switch ($Command.ToLower()) {
     "restart" { Invoke-Restart -Service ($Arguments | Select-Object -First 1) }
     "logs"    {
         $svc = $Arguments | Select-Object -First 1
-        $n = $(if ($Arguments.Count -ge 2) { [int]$Arguments[1] } else { 100 })
+        # Validate the optional line count instead of a bare [int] cast, which
+        # throws an unhandled .NET conversion error on non-numeric input
+        # (e.g. `ods logs llama-server 5m`). Mirrors the [int]::TryParse guard
+        # used elsewhere in this script; the Unix CLIs pass the value straight
+        # to `docker compose --tail`, which rejects bad input gracefully too.
+        $n = 100
+        if ($Arguments.Count -ge 2) {
+            $parsedLines = 0
+            if ([int]::TryParse([string]$Arguments[1], [ref]$parsedLines) -and $parsedLines -gt 0) {
+                $n = $parsedLines
+            } else {
+                Write-AIWarn "Invalid line count '$($Arguments[1])'; using $n."
+            }
+        }
         Invoke-Logs -Service $svc -Lines $n
     }
     "config"  {


### PR DESCRIPTION
## Problem

The Windows CLI's `logs` command computes its tail count with a **bare cast**:

```powershell
$n = $(if ($Arguments.Count -ge 2) { [int]$Arguments[1] } else { 100 })
```

`[int]` on non-numeric input throws an unhandled `RuntimeException`, so:

```
PS> .\ods.ps1 logs llama-server 5m
Cannot convert value "5m" to type "System.Int32". …   ← raw .NET stack trace
```

Any typo in the optional line-count argument crashes the command. The **Linux/macOS CLIs** pass the value straight to `docker compose --tail`, which rejects bad input gracefully — Windows is the only surface that hard-crashes.

## Fix

Guard the parse with `[int]::TryParse` — the same pattern already used for the Lemonade port (`ods.ps1:178`) — fall back to the 100-line default, and warn on invalid or non-positive values:

```powershell
$n = 100
if ($Arguments.Count -ge 2) {
    $parsedLines = 0
    if ([int]::TryParse([string]$Arguments[1], [ref]$parsedLines) -and $parsedLines -gt 0) {
        $n = $parsedLines
    } else {
        Write-AIWarn "Invalid line count '$($Arguments[1])'; using $n."
    }
}
```

## Verification

- `[System.Management.Automation.Language.Parser]::ParseFile` → clean.
- Behavior table: `50`→50, `abc`→warn+100, `5m`→warn+100, `-3`→warn+100, missing→100.
- Confirmed the bare `[int]"5m"` throws before the fix.
- PSScriptAnalyzer: no new findings (pre-existing plural-noun / Write-Host notes only).