### PR TITLE
fix(windows): stop switch fall-through producing an invalid TIMEZONE

### DIFF
--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -325,30 +325,37 @@ function New-ODSEnv {
             if ($ok -and $outIana) { $ianaId = $outIana }
         } catch { }
         if ($ianaId) { $ianaId } else {
+            # PowerShell `switch` runs *every* matching arm, and as a
+            # subexpression it collects all emitted values into an array, so
+            # multi-matching IDs (e.g. "AUS Eastern Standard Time" hits both
+            # "*AUS Eastern*" and "*Eastern*") would write an invalid
+            # "TIMEZONE=America/New_York Australia/Sydney". `break` on every arm
+            # makes the first match win; the more specific "*AUS Eastern*" is
+            # ordered ahead of "*Eastern*" so it takes precedence.
             switch -Wildcard ($tzInfo.Id) {
-                "*Eastern*"    { "America/New_York" }
-                "*Central*"    { "America/Chicago" }
-                "*Mountain*"   { "America/Denver" }
-                "*Pacific*"    { "America/Los_Angeles" }
-                "*Alaska*"     { "America/Anchorage" }
-                "*Hawaii*"     { "Pacific/Honolulu" }
-                "*UTC*"        { "UTC" }
-                "*GMT*"        { "Europe/London" }
-                "*W. Europe*"  { "Europe/Berlin" }
-                "*Romance*"    { "Europe/Paris" }
-                "*India*"      { "Asia/Kolkata" }
-                "*China*"      { "Asia/Shanghai" }
-                "*Tokyo*"      { "Asia/Tokyo" }
-                "*Korea*"      { "Asia/Seoul" }
-                "*AUS Eastern*"  { "Australia/Sydney" }
-                "*E. South America*" { "America/Sao_Paulo" }
-                "*SE Asia*"    { "Asia/Bangkok" }
-                "*Arab*"       { "Asia/Riyadh" }
-                "*Egypt*"      { "Africa/Cairo" }
-                "*South Africa*" { "Africa/Johannesburg" }
-                "*E. Europe*"  { "Europe/Bucharest" }
-                "*FLE*"        { "Europe/Kiev" }
-                default        { "UTC" }
+                "*AUS Eastern*"  { "Australia/Sydney"; break }
+                "*Eastern*"    { "America/New_York"; break }
+                "*Central*"    { "America/Chicago"; break }
+                "*Mountain*"   { "America/Denver"; break }
+                "*Pacific*"    { "America/Los_Angeles"; break }
+                "*Alaska*"     { "America/Anchorage"; break }
+                "*Hawaii*"     { "Pacific/Honolulu"; break }
+                "*UTC*"        { "UTC"; break }
+                "*GMT*"        { "Europe/London"; break }
+                "*W. Europe*"  { "Europe/Berlin"; break }
+                "*Romance*"    { "Europe/Paris"; break }
+                "*India*"      { "Asia/Kolkata"; break }
+                "*China*"      { "Asia/Shanghai"; break }
+                "*Tokyo*"      { "Asia/Tokyo"; break }
+                "*Korea*"      { "Asia/Seoul"; break }
+                "*E. South America*" { "America/Sao_Paulo"; break }
+                "*SE Asia*"    { "Asia/Bangkok"; break }
+                "*Arab*"       { "Asia/Riyadh"; break }
+                "*Egypt*"      { "Africa/Cairo"; break }
+                "*South Africa*" { "Africa/Johannesburg"; break }
+                "*E. Europe*"  { "Europe/Bucharest"; break }
+                "*FLE*"        { "Europe/Kiev"; break }
+                default        { "UTC"; break }
             }
         }
     } catch { "UTC" })


### PR DESCRIPTION
## Problem

The Windows→IANA timezone fallback in `New-ODSEnv` uses `switch -Wildcard` with **no `break`** on any arm:

```powershell
switch -Wildcard ($tzInfo.Id) {
    "*Eastern*"    { "America/New_York" }
    ...
    "*AUS Eastern*"  { "Australia/Sydney" }
    ...
}
```

PowerShell runs **every** matching arm, and as a subexpression (`$tz = $(... switch ...)`) it collects all emitted values into an **array**. So an ID like `"AUS Eastern Standard Time"` (Sydney/Melbourne/Canberra) matches both `"*Eastern*"` **and** `"*AUS Eastern*"`, and `$tz` becomes `@("America/New_York","Australia/Sydney")`. The here-string then interpolates it (`$OFS` = space):

```
TIMEZONE=America/New_York Australia/Sydney
```

— an invalid TZ written into `.env`, which flows into the containers (n8n, etc.). `"Central Pacific Standard Time"` hits the same fault via `*Central*` + `*Pacific*`.

This fallback is the **primary path on Windows PowerShell 5.1** (the default shell, which the installer supports): `TimeZoneInfo.TryConvertWindowsIdToIanaId` doesn't exist on .NET Framework 4.x, so the guarded call throws, `$ianaId` stays `$null`, and the switch runs.

## Fix

Add `break` to every arm so the **first** match wins (the switch can then only ever emit a single value), and order the more specific `"*AUS Eastern*"` ahead of `"*Eastern*"` so eastern-Australia hosts resolve to `Australia/Sydney`:

```powershell
switch -Wildcard ($tzInfo.Id) {
    "*AUS Eastern*"  { "Australia/Sydney"; break }
    "*Eastern*"    { "America/New_York"; break }
    ...
    default        { "UTC"; break }
}
```

## Notes

- `break` inside a switch (no enclosing loop here) simply exits the switch — no behavior change for single-match IDs.
- The concrete correctness win is eastern Australia (`AUS Eastern` → `Australia/Sydney` instead of a malformed value); more broadly, `TIMEZONE` can no longer be written as a space-joined multi-value string for any ID.