### PR TITLE
fix(windows): guard the native-inference PID parse against a bad PID file

### DIFF
--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -643,7 +643,17 @@ function Get-NativeInferenceStatus {
 
     if (-not (Test-Path $script:INFERENCE_PID_FILE)) { return $result }
 
-    $savedPid = [int](Get-Content $script:INFERENCE_PID_FILE -Raw).Trim()
+    # Guard the PID parse: this runs with $ErrorActionPreference = "Stop", so
+    # casting an empty or non-numeric PID file to [int] throws a terminating
+    # error and crashes `ods status`/`start`/`stop`. Mirror the numeric guard
+    # used elsewhere and treat a bad PID file as "not running" (and clear it).
+    $rawPid = (Get-Content $script:INFERENCE_PID_FILE -Raw)
+    if (-not $rawPid) { $rawPid = "" }
+    if ($rawPid.Trim() -notmatch '^\d+$') {
+        Remove-Item $script:INFERENCE_PID_FILE -Force -ErrorAction SilentlyContinue
+        return $result
+    }
+    $savedPid = [int]$rawPid.Trim()
     try {
         $proc = Get-Process -Id $savedPid -ErrorAction SilentlyContinue
         if ($proc -and -not $proc.HasExited) {


### PR DESCRIPTION
## Problem

`Get-NativeInferenceStatus` parses the PID file **before** its `try` block:

```powershell
if (-not (Test-Path $script:INFERENCE_PID_FILE)) { return $result }

$savedPid = [int](Get-Content $script:INFERENCE_PID_FILE -Raw).Trim()
try {
    ...
```

`ods.ps1` sets `$ErrorActionPreference = "Stop"` at the top, so if `data/llama-server.pid` exists but is **empty** (0 bytes) or **non-numeric** — plausible after an interrupted write / partial install — `[int]""` (or `.Trim()` on the `$null` from an empty `-Raw` read) throws a *terminating* error and crashes the entire command.

`Get-NativeInferenceStatus` is called by `Invoke-Status`, `Start-NativeInferenceServer`, and `Stop-NativeInferenceServer`, so **`ods status` / `start` / `stop` / `restart` all crash** instead of treating the native server as not-running:

```
Cannot convert value "" to type "System.Int32". ...
```

## Fix

Validate the PID before casting — mirroring the `'^\d+$'` guard the **same file** already uses in its stop path (`~line 756`) — and on a bad PID file, clear it and return "not running":

```powershell
$rawPid = (Get-Content $script:INFERENCE_PID_FILE -Raw)
if (-not $rawPid) { $rawPid = "" }
if ($rawPid.Trim() -notmatch '^\d+$') {
    Remove-Item $script:INFERENCE_PID_FILE -Force -ErrorAction SilentlyContinue
    return $result
}
$savedPid = [int]$rawPid.Trim()
```

The `if (-not $rawPid)` normalization also covers a truly-empty (0-byte) file, where `Get-Content -Raw` returns `$null`. A valid numeric PID behaves exactly as before.