### PR TITLE
fix(n8n): register the shipped hermes-agent-trigger workflow in the catalog

### DIFF
--- a/ods/config/n8n/catalog.json
+++ b/ods/config/n8n/catalog.json
@@ -568,6 +568,20 @@
       }
     },
     {
+      "id": "hermes-agent-trigger",
+      "file": "hermes-agent-trigger.json",
+      "name": "Hermes Agent Trigger",
+      "description": "Dispatch a goal to a Hermes Agent session via its OpenAI-compatible endpoint, stream the response, and store the final result.",
+      "icon": "Bot",
+      "category": "agents",
+      "dependencies": [
+        "hermes",
+        "llama-server"
+      ],
+      "setupTime": "3 minutes",
+      "featured": true
+    },
+    {
       "id": "openclaw-agent-trigger",
       "file": "openclaw-agent-trigger.json",
       "name": "OpenClaw Agent Trigger",


### PR DESCRIPTION
## Problem

`config/n8n/hermes-agent-trigger.json` ships in this release, but it is the **only** workflow file in `config/n8n/` that is missing from `catalog.json`.

The dashboard surfaces and imports n8n templates **solely** from the catalog — `routers/workflows.py` `load_workflow_catalog()` and the import path iterate over catalog entries only. So a workflow file that isn't in the catalog is unreachable: users can neither see it in the template list nor import it, even though it ships in the repo.

This is a wiring gap, not a feature request:
- `docs/MIGRATION-OPENCLAW-TO-HERMES.md` documents that a `hermes-agent-trigger.json` ships alongside OpenClaw's for the deprecation release.
- The workflow file's own sticky note says: *"Replaces the deprecated `openclaw-agent-trigger`. Both templates ship in the deprecation release."*
- Its sibling `openclaw-agent-trigger` **is** in the catalog (and `featured`), so the replacement being absent is an oversight.

`GET /api/workflows` currently returns 17 templates; `hermes-agent-trigger` never appears.

## Fix

Add the catalog entry next to the `openclaw-agent-trigger` sibling it replaces, mirroring its shape (category `agents`, deps `hermes` + `llama-server` — both real service ids):

```json
{
  "id": "hermes-agent-trigger",
  "file": "hermes-agent-trigger.json",
  "name": "Hermes Agent Trigger",
  "description": "Dispatch a goal to a Hermes Agent session via its OpenAI-compatible endpoint, stream the response, and store the final result.",
  "icon": "Bot",
  "category": "agents",
  "dependencies": ["hermes", "llama-server"],
  "setupTime": "3 minutes",
  "featured": true
}
```

(No `diagram` — the workflow file is a manual-trigger + sticky-note template stub like the other catalog entries that omit one.)

## Verify

- `python3 -m json.tool` parses; `id`/`name` match the workflow file's `name` and `meta.templateId`.
- `GET /api/workflows` now lists **18** templates including `hermes-agent-trigger`.