### PR TITLE
chore: improve contributor guidance, fix silent skip in runtime check, and add jq guard in first-boot-demo (#1852)

### DIFF
--- a/ods/extensions/services/comfyui/compose.yaml
+++ b/ods/extensions/services/comfyui/compose.yaml
@@ -1,7 +1,14 @@
 # ComfyUI — Image Generation
-# This base stub is merged with a GPU-specific overlay:
-#   compose.amd.yaml   (AMD ROCm, gfx1151)
-#   compose.nvidia.yaml (NVIDIA CUDA)
-# The GPU overlay provides the full service definition.
-# This file exists so the registry can detect comfyui as enabled.
+#
+# This stub exists so the service registry can detect ComfyUI as installed.
+# The actual container definition lives in GPU-specific overlay files that are
+# merged with this stub at runtime by the installer/compose resolver:
+#
+#   compose.amd.yaml             — AMD ROCm (single GPU, gfx1151)
+#   compose.nvidia.yaml          — NVIDIA CUDA (single GPU, builds local Dockerfile)
+#   compose.multigpu-amd.yaml    — AMD ROCm multi-GPU
+#   compose.multigpu-nvidia.yaml — NVIDIA multi-GPU
+#
+# The correct overlay is selected by the installer based on the detected GPU backend.
+# Do NOT add a service definition here; add it to the appropriate overlay file.
 services: {}

--- a/ods/scripts/first-boot-demo.sh
+++ b/ods/scripts/first-boot-demo.sh
@@ -55,6 +55,14 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Dependency check — jq is required for parsing API responses.
+if ! command -v jq >/dev/null 2>&1; then
+    echo "Error: 'jq' is required for first-boot-demo.sh but was not found in PATH."
+    echo "Install it with:  sudo apt install jq   (Debian/Ubuntu)"
+    echo "                  brew install jq        (macOS)"
+    exit 1
+fi
+
 #=============================================================================
 # Helpers
 #=============================================================================

--- a/ods/tests/test-extension-runtime-check.sh
+++ b/ods/tests/test-extension-runtime-check.sh
@@ -66,8 +66,10 @@ fi
 if docker info >/dev/null 2>&1; then
     if echo "$out" | grep -qE '\[OK\]|\[BAD\]|\[INFO\]'; then
         pass "docker available — check lines present"
+    elif echo "$out" | grep -q "nothing to check"; then
+        pass "docker available but no services registered — script exits cleanly"
     else
-        skip "docker up but no OK/BAD/INFO lines (minimal stack is OK)"
+        fail "docker available but output contained no expected status lines"
     fi
 else
     if echo "$out" | grep -qi docker; then


### PR DESCRIPTION
## Summary

Closes #1852.

This PR includes three small, self-contained quality improvements identified during a codebase audit. Each change is low-risk, isolated, and improves either contributor experience, test coverage, or user-facing diagnostics.

## Changes

### 1. `ods/extensions/services/comfyui/compose.yaml` — Expand stub comment

The existing stub comment was technically accurate but did not explain why the file exists, where the actual service definition lives, or how GPU-specific overlays are selected. The comment has been expanded to document the overlay pattern and direct contributors to the appropriate files.

---

### 2. `ods/tests/test-extension-runtime-check.sh` — Replace silent skip with explicit assertions

When Docker is available but no ODS services are deployed (the common case in CI and bare-checkout environments), the test could silently skip instead of validating the expected "nothing to check" path. This change replaces the skip with explicit pass/fail assertions so regressions in the informational output are detected.

---

### 3. `ods/scripts/first-boot-demo.sh` — Add `jq` dependency check

The script relies on `jq` to parse API responses but previously suppressed errors when it was missing, causing empty responses that appeared to indicate a broken LLM. A startup dependency check now reports a clear, actionable error if `jq` is not installed.

## Testing

- `bash -n` passes on all modified shell scripts.
- `git diff --check` reports no whitespace errors.
- Verified `test-extension-runtime-check.sh` behavior with and without Docker available.
- Verified `first-boot-demo.sh` exits with a clear error message when `jq` is not installed.

## Files Changed

| File | Change |
|------|--------|
| `ods/extensions/services/comfyui/compose.yaml` | Improve contributor documentation |
| `ods/tests/test-extension-runtime-check.sh` | Replace silent skip with explicit assertions |
| `ods/scripts/first-boot-demo.sh` | Add `jq` dependency guard |