### PR TITLE
fix: enforce LF for ShellCheck configuration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,6 +11,7 @@ docker-entrypoint* text eol=lf
 *.yml text eol=lf
 *.json text eol=lf
 *.env text eol=lf
+*.shellcheckrc text eol=lf
 
 # PowerShell scripts can use CRLF (native Windows)
 *.ps1 text eol=crlf


### PR DESCRIPTION
## Summary

Ensure `.shellcheckrc` is checked out with LF line endings on Windows.

Without this rule, Git can convert the file to CRLF and ShellCheck reports `SC1017` errors for literal carriage returns. This causes the pre-commit ShellCheck hook to fail even though the shell scripts themselves are valid.

The change adds a single `.gitattributes` rule:

*.shellcheckrc text eol=lf

## AI Assistance

AI assistance was used to diagnose the Windows-specific pre-commit failure, identify the line-ending mismatch, run validation, and draft the PR description. I reviewed the final one-line change and validation results.

## Release Lane

<!-- Pick the lane before review. See ods/docs/RELEASE_CHANNELS.md. -->

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

N/A

## Changed Surface

<!-- Check every surface this PR can affect. -->

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

<!-- Use ods/docs/HIGH_RISK_CHANGE_MAP.md to pick the right level. -->

- Risk level: <!-- Low / Medium / High -->
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because: <!-- explain -->

Commands/results:

git diff --check
Passed

git ls-files --eol ods/.shellcheckrc
i/lf w/lf attr/text eol=lf

- python -m pre_commit run --all-files
- Detect hardcoded secrets........................Passed
- detect private key..............................Passed
- check for added large files.....................Passed
- shellcheck (installer + scripts, errors only)...Passed
- shellcheck SC2006 (no legacy backticks)..........Passed
- no-backticks-in-installer-heredocs...............Passed

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

This is intentionally a one-line repository configuration fix. It does not change runtime, installer, dashboard, or service behavior.
The change can be rolled back by removing the *.shellcheckrc text eol=lf entry from .gitattributes.

You can enable “Allow edits by maintainers.” Access to secrets is not needed for this PR.