### PR TITLE
fix(dashboard-api): prevent memory leak in _DirSizeCache

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -38,7 +38,15 @@ class _DirSizeCache:
         return value
 
     def set(self, path: Path, value: float):
-        self._store[str(path.resolve())] = (time.monotonic() + self._ttl, value)
+        now = time.monotonic()
+        expired_keys = [k for k, (expires_at, _) in self._store.items() if now > expires_at]
+        for k in expired_keys:
+            del self._store[k]
+        key = str(path.resolve())
+        if len(self._store) >= 1000 and key not in self._store:
+            oldest_key = next(iter(self._store))
+            del self._store[oldest_key]
+        self._store[key] = (now + self._ttl, value)
 
     def invalidate(self, path: Path) -> None:
         self._store.pop(str(path.resolve()), None)

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1134,3 +1134,18 @@ class TestDirSizeGb:
         invalidate_dir_size_cache(d)
         assert dir_size_gb(d) == 0.0
         assert calls["count"] == 1
+
+    def test_dir_size_cache_bound(self, tmp_path):
+        from helpers import _dir_size_cache
+        _dir_size_cache.clear()
+
+        # Fill cache with 1005 items
+        for i in range(1005):
+            path = tmp_path / f"test_dir_{i}"
+            _dir_size_cache.set(path, 1.0)
+
+        assert len(_dir_size_cache._store) == 1000
+
+        # Verify older items were evicted
+        first_path = tmp_path / "test_dir_0"
+        assert _dir_size_cache.get(first_path) is None


### PR DESCRIPTION
### Summary
This PR fixes a severe memory leak in the `_DirSizeCache` class within the Dashboard API helpers.

### Issue
Previously, the cache dictionary only cleared stale entries if the exact same path was queried again. For unique or temporary paths that are only queried once, the entries remained in the dictionary forever, causing unbounded memory growth.

### Solution
- Added an LRU-style eviction mechanism to enforce a maximum dictionary size.
- Prunes all expired keys whenever a new entry is added.

