### PR TITLE
fix(dashboard-api): bound redemptions list to prevent storage bloat

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/magic_link.py
+++ b/ods/extensions/services/dashboard-api/routers/magic_link.py
@@ -721,6 +721,10 @@ def redeem_magic_link(token: str, request: Request, response: Response) -> Redir
             "ip": ip,
             "user_agent": user_agent,
         })
+        # Prevent unbounded storage bloat for reusable tokens
+        if len(record["redemptions"]) > 50:
+            record["redemptions"] = record["redemptions"][-50:]
+
         _write_store(store)
 
     # Build the response. The session cookie is HMAC-signed via

--- a/ods/extensions/services/dashboard-api/tests/test_magic_link.py
+++ b/ods/extensions/services/dashboard-api/tests/test_magic_link.py
@@ -771,6 +771,25 @@ def test_reusable_token_can_be_redeemed_multiple_times(
     assert len(redemptions) == 3
 
 
+def test_reusable_token_redemptions_are_capped_at_50(
+    magic_link_client, magic_link_module
+):
+    gen = magic_link_client.post(
+        "/api/auth/magic-link/generate",
+        json={"target_username": "family", "reusable": True},
+        headers=magic_link_client.auth_headers,
+    )
+    token = gen.json()["token"]
+
+    for _ in range(55):
+        res = magic_link_client.get(f"/auth/magic-link/{token}", follow_redirects=False)
+        assert res.status_code == 302
+
+    store = magic_link_module._ensure_store()
+    redemptions = store["tokens"][0]["redemptions"]
+    assert len(redemptions) == 50
+
+
 def test_owner_token_survives_pruning(magic_link_module):
     store = {
         "tokens": [


### PR DESCRIPTION
### Summary
This PR fixes a storage leak where reusable magic links would unbounded-ly bloat the `tokens.json` file.

### Issue
If a magic link was marked as `reusable`, every single redemption added a new entry to the `redemptions` list. An automated bot or heavy usage of a single token could cause the list to grow to millions of items, crashing the API due to memory exhaustion upon JSON load.

### Solution
- Caps the `redemptions` list on reusable magic links to the 50 most recent entries.

*(Authored by ananyavashistha)*