### PR TITLE
feat(preflight): validate rootless Docker subordinate UID/GID ranges

### DIFF
--- a/ods/scripts/linux-install-preflight.sh
+++ b/ods/scripts/linux-install-preflight.sh
@@ -236,6 +236,59 @@ else
         "Usually fine on modern distros; if Docker fails oddly, see LINUX-TROUBLESHOOTING-GUIDE.md#cgroups."
 fi
 
+# --- Rootless Docker subordinate UID/GID ranges ---
+# Rootless Docker maps in-container users through the subordinate ID ranges
+# allocated in /etc/subuid and /etc/subgid. A missing entry, or a range
+# smaller than 65536 IDs, breaks image extraction for non-root images
+# ("failed to register layer: uid/gid map out of range") long after install.
+# Only meaningful when the daemon actually runs rootless.
+SUBUID_FILE="${ODS_SUBUID_FILE:-/etc/subuid}"
+SUBGID_FILE="${ODS_SUBGID_FILE:-/etc/subgid}"
+MIN_SUBID_RANGE=65536
+
+subid_range_total() {
+    # Sum every range allocated to the current user in a subuid/subgid file.
+    # Entries may be keyed by user name or by numeric UID (subgid is also
+    # keyed by user, not group). Multiple ranges per user are legal.
+    local file="$1" user="$2" numeric_uid="$3" total=0 owner start count
+    [[ -r "$file" ]] || { echo 0; return; }
+    while IFS=: read -r owner start count; do
+        if [[ "$owner" == "$user" || "$owner" == "$numeric_uid" ]]; then
+            [[ "$count" =~ ^[0-9]+$ ]] && total=$((total + count))
+        fi
+    done <"$file"
+    echo "$total"
+}
+
+ROOTLESS_DOCKER=false
+if [[ "${ODS_ASSUME_ROOTLESS:-0}" == "1" ]]; then
+    ROOTLESS_DOCKER=true
+elif [[ "$DOCKER_INFO_OK" == true ]] && docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q 'rootless'; then
+    ROOTLESS_DOCKER=true
+fi
+
+if [[ "$ROOTLESS_DOCKER" == true ]]; then
+    SUBID_USER="$(id -un)"
+    SUBID_UID="$(id -u)"
+    SUBUID_TOTAL="$(subid_range_total "$SUBUID_FILE" "$SUBID_USER" "$SUBID_UID")"
+    SUBGID_TOTAL="$(subid_range_total "$SUBGID_FILE" "$SUBID_USER" "$SUBID_UID")"
+    SUBID_FIX="Allocate ranges with: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $SUBID_USER, then restart the rootless Docker daemon (systemctl --user restart docker)."
+    if [[ "$SUBUID_TOTAL" -eq 0 || "$SUBGID_TOTAL" -eq 0 ]]; then
+        append_check "ROOTLESS_SUBID" "fail" \
+            "Rootless Docker detected but $SUBID_USER has no subordinate ID range (subuids=$SUBUID_TOTAL in $SUBUID_FILE, subgids=$SUBGID_TOTAL in $SUBGID_FILE) — non-root containers cannot map user namespaces" \
+            "$SUBID_FIX"
+    elif [[ "$SUBUID_TOTAL" -lt "$MIN_SUBID_RANGE" || "$SUBGID_TOTAL" -lt "$MIN_SUBID_RANGE" ]]; then
+        append_check "ROOTLESS_SUBID" "warn" \
+            "Rootless Docker: subordinate ID range for $SUBID_USER is small (subuids=$SUBUID_TOTAL, subgids=$SUBGID_TOTAL, recommended ≥$MIN_SUBID_RANGE) — images using high UIDs/GIDs may fail to extract" \
+            "$SUBID_FIX"
+    else
+        append_check "ROOTLESS_SUBID" "pass" \
+            "Rootless Docker: $SUBID_USER has subuids=$SUBUID_TOTAL, subgids=$SUBGID_TOTAL (≥$MIN_SUBID_RANGE)" ""
+    fi
+else
+    append_check "ROOTLESS_SUBID" "pass" "Docker daemon is not rootless — subordinate ID check skipped" ""
+fi
+
 # --- jq (installer often installs it; nice to have) ---
 if command -v jq >/dev/null 2>&1; then
     append_check "JQ_INSTALLED" "pass" "jq available for JSON tooling" ""

--- a/ods/scripts/linux-install-preflight.sh
+++ b/ods/scripts/linux-install-preflight.sh
@@ -272,15 +272,20 @@ if [[ "$ROOTLESS_DOCKER" == true ]]; then
     SUBID_UID="$(id -u)"
     SUBUID_TOTAL="$(subid_range_total "$SUBUID_FILE" "$SUBID_USER" "$SUBID_UID")"
     SUBGID_TOTAL="$(subid_range_total "$SUBGID_FILE" "$SUBID_USER" "$SUBID_UID")"
-    SUBID_FIX="Allocate ranges with: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $SUBID_USER, then restart the rootless Docker daemon (systemctl --user restart docker)."
+    # Two remediations: with NO allocation the standard 100000-165535 range is
+    # safe to suggest verbatim, but with an existing-but-small allocation that
+    # fixed range can overlap what the user already has (e.g. 100000:1000), so
+    # the small-range hint asks for a non-overlapping extension instead.
+    SUBID_FIX_MISSING="Allocate ranges with: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 $SUBID_USER, then restart the rootless Docker daemon (systemctl --user restart docker)."
+    SUBID_FIX_SMALL="Extend the allocation to at least $MIN_SUBID_RANGE subordinate IDs: pick a start ABOVE every range already listed in $SUBUID_FILE and $SUBGID_FILE (sudo usermod --add-subuids <start>-<start+65535> --add-subgids <start>-<start+65535> $SUBID_USER), then restart the rootless Docker daemon (systemctl --user restart docker)."
     if [[ "$SUBUID_TOTAL" -eq 0 || "$SUBGID_TOTAL" -eq 0 ]]; then
         append_check "ROOTLESS_SUBID" "fail" \
             "Rootless Docker detected but $SUBID_USER has no subordinate ID range (subuids=$SUBUID_TOTAL in $SUBUID_FILE, subgids=$SUBGID_TOTAL in $SUBGID_FILE) — non-root containers cannot map user namespaces" \
-            "$SUBID_FIX"
+            "$SUBID_FIX_MISSING"
     elif [[ "$SUBUID_TOTAL" -lt "$MIN_SUBID_RANGE" || "$SUBGID_TOTAL" -lt "$MIN_SUBID_RANGE" ]]; then
         append_check "ROOTLESS_SUBID" "warn" \
             "Rootless Docker: subordinate ID range for $SUBID_USER is small (subuids=$SUBUID_TOTAL, subgids=$SUBGID_TOTAL, recommended ≥$MIN_SUBID_RANGE) — images using high UIDs/GIDs may fail to extract" \
-            "$SUBID_FIX"
+            "$SUBID_FIX_SMALL"
     else
         append_check "ROOTLESS_SUBID" "pass" \
             "Rootless Docker: $SUBID_USER has subuids=$SUBUID_TOTAL, subgids=$SUBGID_TOTAL (≥$MIN_SUBID_RANGE)" ""

--- a/ods/tests/test-linux-install-preflight.sh
+++ b/ods/tests/test-linux-install-preflight.sh
@@ -137,6 +137,72 @@ else
     fail "ods-preflight.sh bash -n failed after edit"
 fi
 
+# --- Rootless Docker subordinate ID range validation (ROOTLESS_SUBID) ---
+# Fixture-driven: ODS_ASSUME_ROOTLESS forces the rootless path and
+# ODS_SUBUID_FILE/ODS_SUBGID_FILE point at temp files, so no rootless
+# daemon is needed to exercise the check.
+if command -v python3 >/dev/null 2>&1; then
+    SUBID_TMP="$(mktemp -d)"
+    CURRENT_USER="$(id -un)"
+    CURRENT_UID="$(id -u)"
+
+    rootless_subid_status() {
+        # $1=subuid fixture, $2=subgid fixture → echoes the check status
+        local report="$SUBID_TMP/report.json"
+        if ODS_ASSUME_ROOTLESS=1 ODS_SUBUID_FILE="$1" ODS_SUBGID_FILE="$2" \
+            "$LP" --json >"$report" 2>/dev/null || true; then
+            :
+        fi
+        python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    report = json.load(f)
+print(next(c["status"] for c in report["checks"] if c["id"] == "ROOTLESS_SUBID"))
+' "$report"
+    }
+
+    printf '%s:100000:65536\n' "$CURRENT_USER" >"$SUBID_TMP/subuid-ok"
+    printf '%s:100000:65536\n' "$CURRENT_USER" >"$SUBID_TMP/subgid-ok"
+    if [[ "$(rootless_subid_status "$SUBID_TMP/subuid-ok" "$SUBID_TMP/subgid-ok")" == "pass" ]]; then
+        pass "ROOTLESS_SUBID passes with a full 65536 range for the current user"
+    else
+        fail "ROOTLESS_SUBID should pass with a full 65536 range"
+    fi
+
+    printf 'someone-else:100000:65536\n' >"$SUBID_TMP/subuid-missing"
+    printf 'someone-else:100000:65536\n' >"$SUBID_TMP/subgid-missing"
+    if [[ "$(rootless_subid_status "$SUBID_TMP/subuid-missing" "$SUBID_TMP/subgid-missing")" == "fail" ]]; then
+        pass "ROOTLESS_SUBID fails when the user has no subordinate ID entry"
+    else
+        fail "ROOTLESS_SUBID should fail when the user has no entry"
+    fi
+
+    printf '%s:100000:1000\n' "$CURRENT_USER" >"$SUBID_TMP/subuid-small"
+    if [[ "$(rootless_subid_status "$SUBID_TMP/subuid-small" "$SUBID_TMP/subgid-ok")" == "warn" ]]; then
+        pass "ROOTLESS_SUBID warns when the allocated range is below 65536"
+    else
+        fail "ROOTLESS_SUBID should warn on a small range"
+    fi
+
+    printf '%s:100000:30000\n%s:200000:40000\n' "$CURRENT_USER" "$CURRENT_USER" >"$SUBID_TMP/subuid-split"
+    if [[ "$(rootless_subid_status "$SUBID_TMP/subuid-split" "$SUBID_TMP/subgid-ok")" == "pass" ]]; then
+        pass "ROOTLESS_SUBID sums multiple ranges allocated to the same user"
+    else
+        fail "ROOTLESS_SUBID should sum split ranges"
+    fi
+
+    printf '%s:100000:65536\n' "$CURRENT_UID" >"$SUBID_TMP/subuid-numeric"
+    if [[ "$(rootless_subid_status "$SUBID_TMP/subuid-numeric" "$SUBID_TMP/subgid-ok")" == "pass" ]]; then
+        pass "ROOTLESS_SUBID accepts entries keyed by numeric UID"
+    else
+        fail "ROOTLESS_SUBID should accept numeric-UID-keyed entries"
+    fi
+
+    rm -rf "$SUBID_TMP"
+else
+    fail "python3 not available - skipped ROOTLESS_SUBID fixtures (unexpected on CI)"
+fi
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 echo ""

--- a/ods/tests/test-linux-install-preflight.sh
+++ b/ods/tests/test-linux-install-preflight.sh
@@ -169,6 +169,16 @@ print(next(c["status"] for c in report["checks"] if c["id"] == "ROOTLESS_SUBID")
         fail "ROOTLESS_SUBID should pass with a full 65536 range"
     fi
 
+    rootless_subid_remediation() {
+        # Reads the remediation of the LAST rootless_subid_status run.
+        python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    report = json.load(f)
+print(next(c["remediation"] for c in report["checks"] if c["id"] == "ROOTLESS_SUBID"))
+' "$SUBID_TMP/report.json"
+    }
+
     printf 'someone-else:100000:65536\n' >"$SUBID_TMP/subuid-missing"
     printf 'someone-else:100000:65536\n' >"$SUBID_TMP/subgid-missing"
     if [[ "$(rootless_subid_status "$SUBID_TMP/subuid-missing" "$SUBID_TMP/subgid-missing")" == "fail" ]]; then
@@ -176,12 +186,26 @@ print(next(c["status"] for c in report["checks"] if c["id"] == "ROOTLESS_SUBID")
     else
         fail "ROOTLESS_SUBID should fail when the user has no entry"
     fi
+    if [[ "$(rootless_subid_remediation)" == *"100000-165535"* ]]; then
+        pass "missing-entry remediation suggests the standard 100000-165535 range"
+    else
+        fail "missing-entry remediation should carry the exact usermod command"
+    fi
 
     printf '%s:100000:1000\n' "$CURRENT_USER" >"$SUBID_TMP/subuid-small"
     if [[ "$(rootless_subid_status "$SUBID_TMP/subuid-small" "$SUBID_TMP/subgid-ok")" == "warn" ]]; then
         pass "ROOTLESS_SUBID warns when the allocated range is below 65536"
     else
         fail "ROOTLESS_SUBID should warn on a small range"
+    fi
+    # The fixture already occupies 100000:1000, so the warning must NOT
+    # suggest the fixed 100000-165535 range (it would overlap); it should
+    # ask for a non-overlapping extension to at least 65536 IDs instead.
+    SMALL_FIX="$(rootless_subid_remediation)"
+    if [[ "$SMALL_FIX" != *"100000-165535"* && "$SMALL_FIX" == *"65536"* ]]; then
+        pass "small-range remediation asks for a non-overlapping extension"
+    else
+        fail "small-range remediation must not reuse the fixed 100000-165535 range"
     fi
 
     printf '%s:100000:30000\n%s:200000:40000\n' "$CURRENT_USER" "$CURRENT_USER" >"$SUBID_TMP/subuid-split"


### PR DESCRIPTION
## Summary
Implements #1719: the Linux install preflight now validates subordinate UID/GID allocation when the Docker daemon runs in rootless mode.

- Detects a rootless daemon via `docker info --format '{{.SecurityOptions}}'` (only probed when the daemon check already passed).
- New `ROOTLESS_SUBID` check parses `/etc/subuid` + `/etc/subgid` for the current user:
  - **fail** — no allocation at all (rootless containers cannot map user namespaces; this is the "failed to register layer: uid/gid map out of range" failure mode reported in the issue)
  - **warn** — allocation exists but the summed range is below 65536 IDs
  - **pass** — ≥65536 subuids and subgids
- Handles entries keyed by numeric UID and multiple ranges per user (summed), and `/etc/subgid` is correctly treated as keyed by user, not group.
- Remediation message gives the exact `sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 <user>` command plus the rootless daemon restart step.
- On rootful daemons the check reports an explicit "skipped" pass so the JSON contract stays stable.

## Testability
`ODS_ASSUME_ROOTLESS=1` plus `ODS_SUBUID_FILE`/`ODS_SUBGID_FILE` overrides let tests (and operators debugging a box) exercise the check without a rootless daemon.

## Tests
Extended `tests/test-linux-install-preflight.sh` with 5 fixture cases: full range → pass, missing entry → fail, small range → warn, split ranges summed → pass, numeric-UID key → pass. All pass locally; the two pre-existing failures on Windows dev hosts (msys /tmp path vs python3) are unrelated baseline issues that pass on Linux CI.

Closes #1719