### PR TITLE
fix(dashboard-api): bound the usage report date range

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/usage.py
+++ b/ods/extensions/services/dashboard-api/routers/usage.py
@@ -27,6 +27,11 @@ TOKEN_SPY_SERVICE_ID = "token-spy"
 TOKEN_SPY_URL = os.environ.get("TOKEN_SPY_URL", "http://token-spy:8080")
 TOKEN_SPY_API_KEY = os.environ.get("TOKEN_SPY_API_KEY", "")
 TOKEN_SPY_KEY_FILE = Path(os.environ.get("TOKEN_SPY_KEY_FILE", "/data/token-spy/token-spy-api-key.txt"))
+# Inclusive-day span cap for /report. Without it a single request for e.g.
+# 0001-01-01..9999-12-31 makes _empty_report materialize ~3.6 million daily
+# buckets in memory and on the wire. The dashboard presets top out well
+# below a year; one full year is a generous ceiling.
+MAX_REPORT_RANGE_DAYS = 366
 LLAMA_CPP_PROMETHEUS_METRICS = {
     "input_tokens": "llamacpp:prompt_tokens_total",
     "output_tokens": "llamacpp:tokens_predicted_total",
@@ -52,10 +57,18 @@ def _empty_report(start: str, end: str, status: str = "unavailable", detail: str
     # The route's regex gate only checks the YYYY-MM-DD shape, so this is also
     # reached with calendar-invalid dates (month 13, Feb 30) when reporting an
     # invalid_range status. Those can't produce daily buckets — return none.
+    # Oversized or reversed spans likewise get no buckets: materializing one
+    # dict per day is what the span cap exists to prevent.
     try:
-        days = _date_range(_parse_date(start), _parse_date(end))
+        start_day = _parse_date(start)
+        end_day = _parse_date(end)
     except ValueError:
         days = []
+    else:
+        if start_day <= end_day and (end_day - start_day).days < MAX_REPORT_RANGE_DAYS:
+            days = _date_range(start_day, end_day)
+        else:
+            days = []
     return {
         "period": {"start": start, "end": end},
         "source": {
@@ -564,6 +577,13 @@ async def usage_report(
         return _empty_report(start, end, status="invalid_range", detail="Dates must be valid YYYY-MM-DD calendar dates")
     if end_day < start_day:
         return _empty_report(start, end, status="invalid_range", detail="end must be on or after start")
+    if (end_day - start_day).days + 1 > MAX_REPORT_RANGE_DAYS:
+        return _empty_report(
+            start,
+            end,
+            status="invalid_range",
+            detail=f"Date range too large (max {MAX_REPORT_RANGE_DAYS} days)",
+        )
 
     report = await _fetch_token_spy_report(start, end)
     runtime_counters = await _fetch_local_runtime_counters()

--- a/ods/extensions/services/dashboard-api/tests/test_usage.py
+++ b/ods/extensions/services/dashboard-api/tests/test_usage.py
@@ -271,6 +271,41 @@ def test_usage_report_rejects_reversed_date_range(test_client):
     assert data["source"]["detail"] == "end must be on or after start"
 
 
+def test_usage_report_rejects_oversized_date_range(test_client):
+    # A span like 0001-01-01..9999-12-31 passes the shape and ordering checks
+    # but would materialize millions of daily buckets. The endpoint must
+    # reject it as invalid_range with an empty daily list, not build them.
+    resp = test_client.get(
+        "/api/usage/report?start=0001-01-01&end=9999-12-31",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source"]["status"] == "invalid_range"
+    assert data["source"]["detail"] == "Date range too large (max 366 days)"
+    assert data["daily"] == []
+
+
+def test_usage_report_accepts_full_year_range(test_client, monkeypatch):
+    # 366 inclusive days (a leap year) is the documented ceiling and must
+    # still produce a normal report with per-day buckets.
+    import routers.usage as usage_router
+
+    monkeypatch.setattr(usage_router, "TOKEN_SPY_URL", "")
+    monkeypatch.setattr(usage_router, "_fetch_local_runtime_counters", AsyncMock(return_value=[]))
+
+    resp = test_client.get(
+        "/api/usage/report?start=2024-01-01&end=2024-12-31",
+        headers=test_client.auth_headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source"]["status"] != "invalid_range"
+    assert len(data["daily"]) == 366
+
+
 def test_usage_report_rejects_calendar_invalid_dates(test_client):
     # Month 13 and Feb 30 pass the route's YYYY-MM-DD regex but are not real
     # dates; the endpoint must answer with invalid_range, not crash with 500.


### PR DESCRIPTION
## Problem
`GET /api/usage/report` validates date **shape** and ordering but not **span**. A single authenticated request like `start=0001-01-01&end=9999-12-31` walks `_date_range` across ~3.65 million days: whenever Token Spy is unreachable (or returns an HTTP error — both common states), `_empty_report` materializes one dict per day, so the API builds a multi-million-element `daily` list in memory and serializes it onto the wire. That's an easy accidental-DoS from a misbehaving client or a fat-fingered date picker.

## Fix
- New `MAX_REPORT_RANGE_DAYS = 366` cap (dashboard presets top out well below a year; one full leap year stays supported).
- Oversized spans get the same contract as other bad inputs: HTTP 200 with `source.status="invalid_range"`, a clear detail message, and an **empty** `daily` list.
- `_empty_report` itself now refuses to materialize buckets for reversed/oversized spans, so no invalid_range path can ever build the huge list.

## Tests
- `test_usage_report_rejects_oversized_date_range` — the 0001→9999 request returns `invalid_range` with `daily == []`.
- `test_usage_report_accepts_full_year_range` — 366 inclusive days (leap year) still produces a normal report with 366 buckets.

Full dashboard-api suite: **1173 passed**, 3 pre-existing Windows-host failures unrelated to this change (pass on Linux CI).