### PR TITLE
fix(dashboard-api): stop the Hermes pool guard blocking all phones during a cold connection open

### DIFF
--- a/ods/extensions/services/dashboard-api/hermes_bridge.py
+++ b/ods/extensions/services/dashboard-api/hermes_bridge.py
@@ -202,11 +202,19 @@ class _HermesConnection:
 
 _CONNECTION_POOL: dict[str, _HermesConnection] = {}
 _POOL_GUARD = asyncio.Lock()
+# Per-key creation locks: two concurrent first-messages from the same phone
+# share one open instead of racing, without holding the global guard.
+_OPENING_LOCKS: dict[str, asyncio.Lock] = {}
 _SWEEPER_TASK: asyncio.Task | None = None
 
 
 async def _open_connection(session_key: str) -> _HermesConnection:
-    """Open one fresh WS + run session.create. Caller holds _POOL_GUARD."""
+    """Open one fresh WS + run session.create.
+
+    Caller holds the per-key opening lock, NOT _POOL_GUARD — this does
+    network I/O that can hang for the full client timeout when Hermes is
+    slow or down, and must never stall other phones' pool lookups.
+    """
     timeout_seconds = _request_timeout()
     timeout = aiohttp.ClientTimeout(total=timeout_seconds + 20)
     http_session = aiohttp.ClientSession(timeout=timeout)
@@ -231,17 +239,35 @@ async def _get_connection(session_key: str) -> _HermesConnection:
 
     Caller must use ``async with conn.lock:`` around any send/receive cycle
     to keep concurrent same-key prompts from interleaving on the same WS.
+
+    _POOL_GUARD is held only for dict bookkeeping. Opening a connection
+    (token fetch + ws connect + session.create) is network I/O that can
+    hang for the full client timeout when Hermes is slow or down; holding
+    the global guard across it would head-of-line block every other
+    phone's warm-connection lookup behind one cold open. The per-key
+    opening lock keeps concurrent same-key calls from opening duplicates.
     """
     async with _POOL_GUARD:
         conn = _CONNECTION_POOL.get(session_key)
         if conn is not None and not conn.closed and not conn.ws.closed:
             return conn
-        # Either no entry, marked closed, or the underlying ws died. Drop
-        # whatever is in the slot and open fresh.
-        if conn is not None:
-            await conn.aclose()
+        opening = _OPENING_LOCKS.setdefault(session_key, asyncio.Lock())
+
+    async with opening:
+        # Re-check under the guard: another same-key call may have finished
+        # opening while this one waited on the opening lock.
+        async with _POOL_GUARD:
+            conn = _CONNECTION_POOL.get(session_key)
+            if conn is not None and not conn.closed and not conn.ws.closed:
+                return conn
+            # Either no entry, marked closed, or the underlying ws died.
+            # Drop whatever is in the slot and open fresh.
+            stale = _CONNECTION_POOL.pop(session_key, None)
+        if stale is not None:
+            await stale.aclose()
         new_conn = await _open_connection(session_key)
-        _CONNECTION_POOL[session_key] = new_conn
+        async with _POOL_GUARD:
+            _CONNECTION_POOL[session_key] = new_conn
         return new_conn
 
 
@@ -279,6 +305,11 @@ async def _sweep_idle_connections() -> None:
                     if now - conn.last_used > _IDLE_EXPIRY_SECONDS:
                         stale.append((key, conn))
                         _CONNECTION_POOL.pop(key, None)
+                # Opening locks are keyed by cookie hash and would otherwise
+                # grow forever; drop the ones that are idle and unpooled.
+                for key, lock in list(_OPENING_LOCKS.items()):
+                    if not lock.locked() and key not in _CONNECTION_POOL:
+                        del _OPENING_LOCKS[key]
             for key, conn in stale:
                 logger.info("hermes-bridge: evicting idle connection for %s", key[:8])
                 await conn.aclose()
@@ -314,6 +345,7 @@ async def shutdown_pool() -> None:
     async with _POOL_GUARD:
         connections = list(_CONNECTION_POOL.values())
         _CONNECTION_POOL.clear()
+        _OPENING_LOCKS.clear()
     for conn in connections:
         await conn.aclose()
 

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -435,6 +435,69 @@ def test_hermes_bridge_pool_serializes_same_key_parallels_different_keys(monkeyp
     assert diff_creates == {"phoneA": 1, "phoneB": 1}
 
 
+def test_hermes_bridge_slow_open_does_not_block_other_keys(monkeypatch):
+    """Opening a connection is network I/O (token fetch + ws connect +
+    session.create) that can hang for the full client timeout when Hermes
+    is slow or down. That open must not hold the global pool guard:
+
+      * another phone with a warm pooled connection gets it immediately;
+      * a second call for the SAME key waits for the in-flight open and
+        shares its result instead of opening a duplicate.
+    """
+    import asyncio as _asyncio
+    import hermes_bridge
+
+    hermes_bridge._CONNECTION_POOL.clear()
+    hermes_bridge._OPENING_LOCKS.clear()
+    hermes_bridge._SWEEPER_TASK = None
+
+    class FakeWS:
+        closed = False
+        async def close(self): self.closed = True
+
+    class FakeHTTP:
+        async def close(self): pass
+
+    async def main():
+        open_started = _asyncio.Event()
+        release_open = _asyncio.Event()
+        open_calls = {"n": 0}
+
+        async def slow_open(session_key):
+            open_calls["n"] += 1
+            open_started.set()
+            await release_open.wait()
+            return hermes_bridge._HermesConnection(
+                http_session=FakeHTTP(), ws=FakeWS(), session_id=f"sid-{session_key}",
+            )
+
+        monkeypatch.setattr("hermes_bridge._open_connection", slow_open)
+
+        warm = hermes_bridge._HermesConnection(
+            http_session=FakeHTTP(), ws=FakeWS(), session_id="sid-warm",
+        )
+        hermes_bridge._CONNECTION_POOL["warm-key"] = warm
+
+        slow_task = _asyncio.create_task(hermes_bridge._get_connection("cold-key"))
+        await open_started.wait()
+
+        # While cold-key's open hangs, the warm key must still be served.
+        got = await _asyncio.wait_for(hermes_bridge._get_connection("warm-key"), timeout=1.0)
+        assert got is warm
+
+        # A concurrent same-key call shares the in-flight open's result.
+        second_task = _asyncio.create_task(hermes_bridge._get_connection("cold-key"))
+        await _asyncio.sleep(0.05)
+        release_open.set()
+        first = await _asyncio.wait_for(slow_task, timeout=1.0)
+        second = await _asyncio.wait_for(second_task, timeout=1.0)
+        assert first is second
+        assert open_calls["n"] == 1, f"expected one open for cold-key, got {open_calls['n']}"
+        return True
+
+    assert _run_with_one_loop(main)
+
+
 def test_hermes_bridge_transparent_retry_on_send_reset(monkeypatch):
     """Most insidious dead-WS pattern: ``ws.closed`` reports False, but the
     next ``send_str`` raises ClientConnectionResetError because the upstream


### PR DESCRIPTION
## Problem
`hermes_bridge._get_connection` holds the **global** `_POOL_GUARD` while calling `_open_connection`, which performs real network I/O: dashboard token fetch, WebSocket connect, and `session.create` — up to the full client timeout (~200s) when Hermes is slow, restarting, or down.

Consequence: one phone's cold open head-of-line blocks **every** other phone's pool lookup — including phones whose pooled connection is warm and ready. That directly contradicts the pool's own contract ("two different-key prompts run in parallel") and turns a single Hermes hiccup into a full ODS Talk outage for all connected phones.

## Fix
- `_POOL_GUARD` is now held only for dict bookkeeping (lookup, evict, insert).
- The open itself runs outside the guard, serialized by a **per-key opening lock**, so two concurrent first-messages from the same phone share one open instead of racing into duplicate Hermes sessions.
- After acquiring the opening lock the pool is re-checked, so the second waiter adopts the connection the first one just opened.
- Housekeeping: the idle sweeper prunes unlocked, unpooled opening locks (they're keyed by cookie hash and would otherwise grow forever); `shutdown_pool` clears them.

## Tests
New `test_hermes_bridge_slow_open_does_not_block_other_keys`:
- while `cold-key`'s open hangs on an event, `warm-key`'s pooled connection is served within 1s (this **times out against the old implementation** — verified by running the test against upstream `hermes_bridge.py`: fails there, passes here);
- a concurrent same-key call shares the in-flight open's result with exactly one `_open_connection` call.

`tests/test_talk.py`: 35 passed (all existing pool contracts — same-key serialization, transparent retry, dead-WS eviction, sweeper behavior — unchanged).