### PR TITLE
fix(windows): redact user/email env values in compose failure reports

### DIFF
--- a/ods/installers/windows/lib/compose-diagnostics.ps1
+++ b/ods/installers/windows/lib/compose-diagnostics.ps1
@@ -108,7 +108,12 @@ function Get-ODSComposeSensitiveEnvValues {
             if ($line -notmatch '^([A-Za-z_][A-Za-z0-9_]*)=(.*)$') { continue }
             $key = $Matches[1]
             $value = $Matches[2].Trim().Trim('"').Trim("'")
-            if ($value.Length -ge 4 -and $key -match '(?i)(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)') {
+            # USER|EMAIL|BEARER cover schema secret:true keys the shorter set
+            # missed - N8N_USER, LANGFUSE_INIT_USER_EMAIL, LANGFUSE_MINIO_ROOT_USER -
+            # whose values would otherwise ship in the shareable failure report.
+            # Keep in sync with ConvertTo-ODSComposeRedactedLine below and the
+            # Linux support bundle's redaction set.
+            if ($value.Length -ge 4 -and $key -match '(?i)(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL|USER|EMAIL|BEARER)') {
                 $values += $value
             }
         }
@@ -128,7 +133,8 @@ function ConvertTo-ODSComposeRedactedLine {
     )
 
     $redacted = $Line
-    if ($redacted -match '(?i)(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL)' -and $redacted -match '[:=]') {
+    # Key set kept in sync with Get-ODSComposeSensitiveEnvValues above.
+    if ($redacted -match '(?i)(KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL|USER|EMAIL|BEARER)' -and $redacted -match '[:=]') {
         $separatorMatch = [regex]::Match($redacted, '[:=]\s*')
         if ($separatorMatch.Success) {
             $redacted = $redacted.Substring(0, $separatorMatch.Index + $separatorMatch.Length) + "[REDACTED]"

--- a/ods/tests/test-windows-compose-failure-report.sh
+++ b/ods/tests/test-windows-compose-failure-report.sh
@@ -106,6 +106,8 @@ if [[ "$1" == "compose" ]]; then
     echo "    environment:"
     echo "      DASHBOARD_API_KEY: super-secret-dashboard-key"
     echo "      OPENCLAW_TOKEN: super-secret-openclaw-token"
+    echo "      N8N_USER: super-secret-n8n-user"
+    echo "      LANGFUSE_INIT_USER_EMAIL: super-secret-langfuse-email"
     exit 0
   fi
   if [[ "$*" == *" ps -a"* ]]; then
@@ -122,6 +124,8 @@ GPU_BACKEND=nvidia
 LLAMA_SERVER_IMAGE=ghcr.io/ggml-org/llama.cpp:server-cuda-b8648
 DASHBOARD_API_KEY=super-secret-dashboard-key
 OPENCLAW_TOKEN=super-secret-openclaw-token
+N8N_USER=super-secret-n8n-user
+LANGFUSE_INIT_USER_EMAIL=super-secret-langfuse-email
 OLLAMA_PORT=39134
 EOF
 
@@ -146,12 +150,19 @@ EOF
             "ghcr.io/ggml-org/llama.cpp:server-cuda-b8648",
             "Compose config tail (redacted)",
             "DASHBOARD_API_KEY: [REDACTED]",
-            "OPENCLAW_TOKEN: [REDACTED]"
+            "OPENCLAW_TOKEN: [REDACTED]",
+            "N8N_USER: [REDACTED]",
+            "LANGFUSE_INIT_USER_EMAIL: [REDACTED]"
         )) {
             if (-not $text.Contains($needle)) { throw "missing $needle" }
         }
-        if ($text.Contains("super-secret-dashboard-key") -or $text.Contains("super-secret-openclaw-token")) {
-            throw "sensitive compose config value leaked"
+        foreach ($secret in @(
+            "super-secret-dashboard-key",
+            "super-secret-openclaw-token",
+            "super-secret-n8n-user",
+            "super-secret-langfuse-email"
+        )) {
+            if ($text.Contains($secret)) { throw "sensitive compose config value leaked: $secret" }
         }
     '; then
         pass "PowerShell report writer creates redacted report with mocked docker"


### PR DESCRIPTION
## Problem
`installers/windows/lib/compose-diagnostics.ps1` writes the install failure report that Windows users are explicitly asked to attach to public GitHub issues. Its redaction key set (`KEY|TOKEN|SECRET|PASSWORD|PASS|SALT|AUTH|CREDENTIAL`) misses keys that `.env.schema.json` marks `secret: true`:

- `N8N_USER`
- `LANGFUSE_INIT_USER_EMAIL`
- `LANGFUSE_MINIO_ROOT_USER`

Both the `docker compose config` tail and the global sensitive-value scrub let those values through, so a shared report leaks the operator's login identifiers in cleartext.

## Fix
Add `USER|EMAIL|BEARER` to both places that carry the key set:
- `Get-ODSComposeSensitiveEnvValues` (collects .env values for global scrubbing), and
- `ConvertTo-ODSComposeRedactedLine` (per-line compose-config redactor),

with comments keeping the two in sync. This mirrors the Linux support bundle's redaction set (#1846) so both platforms redact the same key classes.

## Tests
Extended `tests/test-windows-compose-failure-report.sh`: the mocked `docker compose config` and fixture `.env` now include `N8N_USER` + `LANGFUSE_INIT_USER_EMAIL`; the runtime assertion requires both to appear as `[REDACTED]` and fails if any raw value leaks anywhere in the report. Also verified both functions directly on Windows PowerShell 5.1:
```
N8N_USER: [REDACTED]
LANGFUSE_INIT_USER_EMAIL: [REDACTED]
OLLAMA_PORT: 39134        # non-secret values untouched
```
Full test file: 39 passed. PowerShell AST parse: clean.