### PR TITLE
feat(doctor): report rootless Docker subordinate ID allocation

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -35,6 +35,9 @@ test: ## Run unit and contract tests
 	@bash tests/test-linux-install-preflight.sh
 	@bash tests/test-linux-host-agent-stop.sh
 	@echo ""
+	@echo "=== ods-doctor rootless subordinate IDs ==="
+	@bash tests/test-ods-doctor-rootless-subid.sh
+	@echo ""
 	@echo "=== AMD/Lemonade contracts ==="
 	@bash tests/contracts/test-amd-lemonade-contracts.sh
 	@bash tests/test-litellm-amd-auth-enforced.sh

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -1382,13 +1382,27 @@ if runtime["docker_daemon"] and not runtime["webui_http"]:
 
 # Rootless daemon without (enough) subordinate IDs: images fail to extract
 # with "uid/gid map out of range" long after doctor reports healthy Docker.
+# Two hints: the fixed 100000-165535 range is only safe to suggest when the
+# user has NO allocation; with an existing-but-small range that command
+# could overlap what is already allocated, so ask for a non-overlapping
+# extension instead.
 _rootless_subid = report["runtime"]["rootless_subid_check"]
-if _rootless_subid["status"] in {"warn", "fail"}:
+if _rootless_subid["status"] == "fail":
     fix_hints.append(
-        "Rootless Docker: subordinate ID ranges for "
-        f"{_rootless_subid['user']} are missing or below 65536 "
+        "Rootless Docker: no subordinate ID allocation for "
+        f"{_rootless_subid['user']} "
         f"(subuids={_rootless_subid['subuid_total']}, subgids={_rootless_subid['subgid_total']}). "
         f"Run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 {_rootless_subid['user']} "
+        "then restart the rootless Docker daemon (systemctl --user restart docker)."
+    )
+elif _rootless_subid["status"] == "warn":
+    fix_hints.append(
+        "Rootless Docker: subordinate ID allocation for "
+        f"{_rootless_subid['user']} is below 65536 "
+        f"(subuids={_rootless_subid['subuid_total']}, subgids={_rootless_subid['subgid_total']}). "
+        "Extend it to at least 65536 IDs with a range that does not overlap "
+        "existing entries in /etc/subuid and /etc/subgid "
+        f"(sudo usermod --add-subuids <start>-<start+65535> --add-subgids <start>-<start+65535> {_rootless_subid['user']}), "
         "then restart the rootless Docker daemon (systemctl --user restart docker)."
     )
 

--- a/ods/scripts/ods-doctor.sh
+++ b/ods/scripts/ods-doctor.sh
@@ -329,6 +329,44 @@ if [[ "$DOCKER_DAEMON" == "true" ]]; then
     )"
 fi
 
+# Rootless Docker subordinate ID ranges — runtime half of the install
+# preflight's ROOTLESS_SUBID check. A rootless daemon maps in-container
+# users through /etc/subuid + /etc/subgid; a missing entry or a range under
+# 65536 IDs breaks layer extraction for non-root images with cryptic
+# "uid/gid map out of range" errors, so doctor surfaces it with the fix.
+ROOTLESS_DOCKER="false"
+ROOTLESS_SUBID_STATUS="skipped"
+ROOTLESS_SUBUID_TOTAL="0"
+ROOTLESS_SUBGID_TOTAL="0"
+ROOTLESS_SUBID_USER="$(id -un 2>/dev/null || echo unknown)"
+if [[ "${ODS_ASSUME_ROOTLESS:-0}" == "1" ]] || { [[ "$DOCKER_DAEMON" == "true" ]] \
+    && docker info --format '{{.SecurityOptions}}' 2>/dev/null | grep -q 'rootless'; }; then
+    ROOTLESS_DOCKER="true"
+    subid_range_total() {
+        # Sum every range allocated to the user; entries may be keyed by
+        # name or numeric UID (subgid is also keyed by user, not group).
+        local file="$1" user="$2" numeric_uid="$3" total=0 owner start count
+        [[ -r "$file" ]] || { echo 0; return; }
+        while IFS=: read -r owner start count; do
+            if [[ "$owner" == "$user" || "$owner" == "$numeric_uid" ]]; then
+                [[ "$count" =~ ^[0-9]+$ ]] && total=$((total + count))
+            fi
+        done <"$file"
+        echo "$total"
+    }
+    _subid_uid="$(id -u)"
+    ROOTLESS_SUBUID_TOTAL="$(subid_range_total "${ODS_SUBUID_FILE:-/etc/subuid}" "$ROOTLESS_SUBID_USER" "$_subid_uid")"
+    ROOTLESS_SUBGID_TOTAL="$(subid_range_total "${ODS_SUBGID_FILE:-/etc/subgid}" "$ROOTLESS_SUBID_USER" "$_subid_uid")"
+    if [[ "$ROOTLESS_SUBUID_TOTAL" -eq 0 || "$ROOTLESS_SUBGID_TOTAL" -eq 0 ]]; then
+        ROOTLESS_SUBID_STATUS="fail"
+    elif [[ "$ROOTLESS_SUBUID_TOTAL" -lt 65536 || "$ROOTLESS_SUBGID_TOTAL" -lt 65536 ]]; then
+        ROOTLESS_SUBID_STATUS="warn"
+    else
+        ROOTLESS_SUBID_STATUS="pass"
+    fi
+fi
+export ROOTLESS_DOCKER ROOTLESS_SUBID_STATUS ROOTLESS_SUBUID_TOTAL ROOTLESS_SUBGID_TOTAL ROOTLESS_SUBID_USER
+
 # Collect extension diagnostics if service registry loaded
 EXT_DIAGNOSTICS="[]"
 if [[ "${#SERVICE_IDS[@]}" -gt 0 ]]; then
@@ -1285,6 +1323,13 @@ report = {
             if hermes_slash_worker_count_num > hermes_slash_worker_max_count_num
             else "pass",
         },
+        "rootless_docker": os.environ.get("ROOTLESS_DOCKER") == "true",
+        "rootless_subid_check": {
+            "status": os.environ.get("ROOTLESS_SUBID_STATUS", "skipped"),
+            "user": os.environ.get("ROOTLESS_SUBID_USER", ""),
+            "subuid_total": _int_value(os.environ.get("ROOTLESS_SUBUID_TOTAL")),
+            "subgid_total": _int_value(os.environ.get("ROOTLESS_SUBGID_TOTAL")),
+        },
         "amd_runtime": amd_runtime,
         "inference_contract": inference_contract_public,
     },
@@ -1297,6 +1342,7 @@ report = {
             + (1 if stt_cached in {"false", "service_down"} else 0)
             + (1 if tts_http == "false" else 0)
             + (1 if hermes_slash_worker_count_num > hermes_slash_worker_max_count_num else 0)
+            + (1 if os.environ.get("ROOTLESS_SUBID_STATUS") in {"warn", "fail"} else 0)
             + len(amd_runtime.get("warnings", []))
             + inference_contract.get("issue_counts", {}).get("warnings", 0)
         ),
@@ -1333,6 +1379,18 @@ if runtime["docker_daemon"] and not runtime["dashboard_http"]:
     fix_hints.append(f"Run installer/start command, then verify dashboard on http://127.0.0.1:{dashboard_port}.")
 if runtime["docker_daemon"] and not runtime["webui_http"]:
     fix_hints.append(f"Verify Open WebUI container and port {webui_port} mapping.")
+
+# Rootless daemon without (enough) subordinate IDs: images fail to extract
+# with "uid/gid map out of range" long after doctor reports healthy Docker.
+_rootless_subid = report["runtime"]["rootless_subid_check"]
+if _rootless_subid["status"] in {"warn", "fail"}:
+    fix_hints.append(
+        "Rootless Docker: subordinate ID ranges for "
+        f"{_rootless_subid['user']} are missing or below 65536 "
+        f"(subuids={_rootless_subid['subuid_total']}, subgids={_rootless_subid['subgid_total']}). "
+        f"Run: sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 {_rootless_subid['user']} "
+        "then restart the rootless Docker daemon (systemctl --user restart docker)."
+    )
 
 # STT model cache: service up but model missing is a common silent failure
 if stt_cached == "false" and stt_recovery:

--- a/ods/tests/test-ods-doctor-rootless-subid.sh
+++ b/ods/tests/test-ods-doctor-rootless-subid.sh
@@ -47,13 +47,21 @@ run_doctor() {
 }
 
 subid_status() {
+    # Prints: <status> <rootless_docker> <hint_count> <hint_kind>
+    # hint_kind: fixed-range | non-overlapping | none — the fail hint may
+    # suggest the standard 100000-165535 block, but the warn hint must ask
+    # for a non-overlapping extension because a small allocation (e.g.
+    # 100000:1000) can already occupy part of that fixed block.
     python3 -c '
 import json, sys
 with open(sys.argv[1], encoding="utf-8") as f:
     report = json.load(f)
 check = report["runtime"]["rootless_subid_check"]
-hints = [h for h in report.get("autofix_hints", []) if "subordinate" in h]
-print(check["status"], report["runtime"]["rootless_docker"], len(hints))
+hints = [h for h in report.get("autofix_hints", []) if "subordinate" in h.lower()]
+kind = "none"
+if hints:
+    kind = "fixed-range" if "100000-165535" in hints[0] else "non-overlapping"
+print(check["status"], report["runtime"]["rootless_docker"], len(hints), kind)
 ' "$1"
 }
 
@@ -63,7 +71,7 @@ printf 'someone-else:100000:65536\n' >"$TMP_DIR/subuid-missing"
 printf '%s:100000:1000\n' "$CURRENT_USER" >"$TMP_DIR/subuid-small"
 
 if run_doctor "$TMP_DIR/subuid-ok" "$TMP_DIR/subgid-ok" "$TMP_DIR/report-ok.json"; then
-    read -r status rootless hints <<<"$(subid_status "$TMP_DIR/report-ok.json")"
+    read -r status rootless hints _ <<<"$(subid_status "$TMP_DIR/report-ok.json")"
     [[ "$status" == "pass" ]] && pass "full 65536 range reports pass" || fail "expected pass, got $status"
     [[ "$rootless" == "True" ]] && pass "report marks the daemon rootless" || fail "rootless_docker not True"
     [[ "$hints" == "0" ]] && pass "no subordinate-ID fix hint on pass" || fail "unexpected fix hint on pass"
@@ -73,17 +81,21 @@ else
 fi
 
 if run_doctor "$TMP_DIR/subuid-missing" "$TMP_DIR/subgid-ok" "$TMP_DIR/report-missing.json"; then
-    read -r status _ hints <<<"$(subid_status "$TMP_DIR/report-missing.json")"
+    read -r status _ hints kind <<<"$(subid_status "$TMP_DIR/report-missing.json")"
     [[ "$status" == "fail" ]] && pass "missing user entry reports fail" || fail "expected fail, got $status"
     [[ "$hints" == "1" ]] && pass "missing entry surfaces the usermod fix hint" || fail "fix hint missing on fail"
+    [[ "$kind" == "fixed-range" ]] && pass "missing entry hint suggests the standard 100000-165535 range" \
+        || fail "missing entry hint should carry the exact usermod command (got $kind)"
 else
     fail "doctor did not produce a report for the missing-entry fixture"
 fi
 
 if run_doctor "$TMP_DIR/subuid-small" "$TMP_DIR/subgid-ok" "$TMP_DIR/report-small.json"; then
-    read -r status _ hints <<<"$(subid_status "$TMP_DIR/report-small.json")"
+    read -r status _ hints kind <<<"$(subid_status "$TMP_DIR/report-small.json")"
     [[ "$status" == "warn" ]] && pass "sub-65536 range reports warn" || fail "expected warn, got $status"
-    [[ "$hints" == "1" ]] && pass "small range surfaces the usermod fix hint" || fail "fix hint missing on warn"
+    [[ "$hints" == "1" ]] && pass "small range surfaces a fix hint" || fail "fix hint missing on warn"
+    [[ "$kind" == "non-overlapping" ]] && pass "small range hint asks for a non-overlapping extension" \
+        || fail "small range hint must not reuse the fixed 100000-165535 range (got $kind)"
 else
     fail "doctor did not produce a report for the small-range fixture"
 fi

--- a/ods/tests/test-ods-doctor-rootless-subid.sh
+++ b/ods/tests/test-ods-doctor-rootless-subid.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Fixture tests for the ROOTLESS_SUBID runtime check in scripts/ods-doctor.sh.
+# ODS_ASSUME_ROOTLESS forces the rootless path and ODS_SUBUID_FILE /
+# ODS_SUBGID_FILE point at temp fixtures, so no rootless daemon is needed.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCTOR="$ROOT_DIR/scripts/ods-doctor.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { printf "  ${GREEN}✓ PASS${NC} %s\n" "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf "  ${RED}✗ FAIL${NC} %s\n" "$1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "=== ods-doctor rootless subordinate ID tests ==="
+echo ""
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "[SKIP] python3 not available — doctor cannot run here"
+    exit 0
+fi
+
+if bash -n "$DOCTOR" 2>/dev/null; then
+    pass "ods-doctor.sh passes bash -n"
+else
+    fail "ods-doctor.sh bash -n failed"
+fi
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+CURRENT_USER="$(id -un)"
+
+# Doctor exits non-zero when the report records blockers/warnings from the
+# host environment; only the report content matters for these assertions.
+run_doctor() {
+    # $1=subuid fixture, $2=subgid fixture, $3=report path
+    ODS_ASSUME_ROOTLESS=1 \
+    ODS_SUBUID_FILE="$1" \
+    ODS_SUBGID_FILE="$2" \
+        bash "$DOCTOR" "$3" >/dev/null 2>&1 || true
+    [[ -f "$3" ]]
+}
+
+subid_status() {
+    python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as f:
+    report = json.load(f)
+check = report["runtime"]["rootless_subid_check"]
+hints = [h for h in report.get("autofix_hints", []) if "subordinate" in h]
+print(check["status"], report["runtime"]["rootless_docker"], len(hints))
+' "$1"
+}
+
+printf '%s:100000:65536\n' "$CURRENT_USER" >"$TMP_DIR/subuid-ok"
+printf '%s:100000:65536\n' "$CURRENT_USER" >"$TMP_DIR/subgid-ok"
+printf 'someone-else:100000:65536\n' >"$TMP_DIR/subuid-missing"
+printf '%s:100000:1000\n' "$CURRENT_USER" >"$TMP_DIR/subuid-small"
+
+if run_doctor "$TMP_DIR/subuid-ok" "$TMP_DIR/subgid-ok" "$TMP_DIR/report-ok.json"; then
+    read -r status rootless hints <<<"$(subid_status "$TMP_DIR/report-ok.json")"
+    [[ "$status" == "pass" ]] && pass "full 65536 range reports pass" || fail "expected pass, got $status"
+    [[ "$rootless" == "True" ]] && pass "report marks the daemon rootless" || fail "rootless_docker not True"
+    [[ "$hints" == "0" ]] && pass "no subordinate-ID fix hint on pass" || fail "unexpected fix hint on pass"
+else
+    echo "[SKIP] doctor did not produce a report on this host (missing deps?)"
+    exit 0
+fi
+
+if run_doctor "$TMP_DIR/subuid-missing" "$TMP_DIR/subgid-ok" "$TMP_DIR/report-missing.json"; then
+    read -r status _ hints <<<"$(subid_status "$TMP_DIR/report-missing.json")"
+    [[ "$status" == "fail" ]] && pass "missing user entry reports fail" || fail "expected fail, got $status"
+    [[ "$hints" == "1" ]] && pass "missing entry surfaces the usermod fix hint" || fail "fix hint missing on fail"
+else
+    fail "doctor did not produce a report for the missing-entry fixture"
+fi
+
+if run_doctor "$TMP_DIR/subuid-small" "$TMP_DIR/subgid-ok" "$TMP_DIR/report-small.json"; then
+    read -r status _ hints <<<"$(subid_status "$TMP_DIR/report-small.json")"
+    [[ "$status" == "warn" ]] && pass "sub-65536 range reports warn" || fail "expected warn, got $status"
+    [[ "$hints" == "1" ]] && pass "small range surfaces the usermod fix hint" || fail "fix hint missing on warn"
+else
+    fail "doctor did not produce a report for the small-range fixture"
+fi
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary
Runtime-diagnostics half of #1719 (the install-preflight half is #1858 — independent PRs, either merges standalone). When `docker info` says the daemon is rootless, `ods doctor` now validates the current user's subordinate UID/GID allocation and surfaces the failure mode *before* users hit `failed to register layer: uid/gid map out of range` on non-root images.

## What the report gains
`runtime.rootless_docker` (bool) and `runtime.rootless_subid_check`:
```json
{"status": "fail|warn|pass|skipped", "user": "alice", "subuid_total": 0, "subgid_total": 65536}
```
- **fail** — no allocation in `/etc/subuid` or `/etc/subgid` (rootless containers can't map user namespaces)
- **warn** — allocation exists but the summed range is under 65536 IDs
- **pass** — ≥65536 both; **skipped** — daemon is rootful
- Entries keyed by numeric UID and multiple ranges per user are handled (summed); `/etc/subgid` is correctly treated as keyed by user, not group.
- warn/fail increments `summary.runtime_warnings` and appends an `autofix_hints` entry with the exact `sudo usermod --add-subuids 100000-165535 --add-subgids 100000-165535 <user>` command + rootless daemon restart step.

## Tests
New `tests/test-ods-doctor-rootless-subid.sh` (registered in `make test`) drives the **full doctor** with `ODS_ASSUME_ROOTLESS=1` + fixture subuid/subgid files and asserts the generated report JSON for the pass/fail/warn matrix, the rootless flag, and hint presence/absence — 8/8 passing locally end-to-end. Skips gracefully on hosts where doctor's dependencies are unavailable.

Refs #1719