### PR TITLE
fix(session-cleanup): resolve Python before deleting any session file

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -112,6 +112,9 @@ test: ## Run unit and contract tests
 	@echo ""
 	@echo "=== CLI user-extension dependency resolution ==="
 	@bash tests/test-cli-user-extension-deps.sh
+	@echo ""
+	@echo "=== session cleanup lifecycle ==="
+	@bash tests/test-session-cleanup.sh
 
 bats: ## Run BATS unit tests for shell libraries
 	@echo "=== BATS unit tests ==="

--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -35,7 +35,8 @@ usage() {
     echo "  SESSIONS_DIR   Sessions directory (default: \$OPENCLAW_DIR/agents/main/sessions)"
     echo "  MAX_SIZE       Max session file size in bytes (default: 256000)"
     echo ""
-    echo "Exit: 0 (always; missing paths are skipped with a log message)."
+    echo "Exit: 0 on success or when paths are missing (skipped with a log message);"
+    echo "      1 when no usable Python is found (refused before touching any session)."
 }
 
 case "${1:-}" in

--- a/ods/scripts/session-cleanup.sh
+++ b/ods/scripts/session-cleanup.sh
@@ -82,6 +82,23 @@ if [ "$DELETED_COUNT" -gt 0 ] || [ "$BAK_COUNT" -gt 0 ]; then
     echo "[$(date)] Cleaned up $DELETED_COUNT .deleted files, $BAK_COUNT .bak files"
 fi
 
+# ── Python (needed to update sessions.json after wipes) ───────
+# Resolved BEFORE any session file is deleted: under set -e, a failed
+# detection inside the wipe loop used to kill the script after a bloated
+# session file was already removed but before its reference was cleared
+# from sessions.json — leaving the gateway pointing at a missing file.
+PYTHON_CMD="python3"
+if [[ -f "$(dirname "$0")/../lib/python-cmd.sh" ]]; then
+    . "$(dirname "$0")/../lib/python-cmd.sh"
+    PYTHON_CMD="$(ods_detect_python_cmd)" || PYTHON_CMD=""
+elif command -v python >/dev/null 2>&1; then
+    PYTHON_CMD="python"
+fi
+if [[ -z "$PYTHON_CMD" ]] || ! "$PYTHON_CMD" -c 'import json' >/dev/null 2>&1; then
+    echo "[$(date)] ERROR: no usable Python found; refusing to prune sessions (sessions.json updates need it)" >&2
+    exit 1
+fi
+
 # ── Process session files ──────────────────────────────────────
 WIPE_IDS=""
 REMOVED_INACTIVE=0
@@ -133,14 +150,6 @@ if [ -n "$WIPE_IDS" ]; then
     cp "$SESSIONS_JSON" "$SESSIONS_JSON.bak-cleanup"
 
     for ID in $WIPE_IDS; do
-        PYTHON_CMD="python3"
-        if [[ -f "$(dirname "$0")/../lib/python-cmd.sh" ]]; then
-            . "$(dirname "$0")/../lib/python-cmd.sh"
-            PYTHON_CMD="$(ods_detect_python_cmd)"
-        elif command -v python >/dev/null 2>&1; then
-            PYTHON_CMD="python"
-        fi
-
         "$PYTHON_CMD" -c "
 import json, sys
 sessions_file = sys.argv[1]

--- a/ods/tests/test-session-cleanup.sh
+++ b/ods/tests/test-session-cleanup.sh
@@ -154,6 +154,72 @@ else
 fi
 
 # ============================================================================
+# Test 8b: Bloated wipe clears its sessions.json reference, keeps others
+# ============================================================================
+SDIR2="$TEMP_DIR/sessions2"
+mkdir -p "$SDIR2"
+cat > "$SDIR2/sessions.json" <<'EOF'
+{
+  "agent:main:main": {"sessionId": "keep-me"},
+  "agent:main:talk": {"sessionId": "bloated-one"}
+}
+EOF
+printf 'x%.0s' {1..50} > "$SDIR2/keep-me.jsonl"
+dd if=/dev/zero of="$SDIR2/bloated-one.jsonl" bs=1024 count=2 2>/dev/null
+
+cleanup_exit=0
+SESSIONS_DIR="$SDIR2" MAX_SIZE=100 bash "$SESSION_CLEANUP_SCRIPT" >/dev/null 2>&1 || cleanup_exit=$?
+if [[ $cleanup_exit -eq 0 && ! -f "$SDIR2/bloated-one.jsonl" ]] \
+    && ! grep -q 'bloated-one' "$SDIR2/sessions.json" \
+    && grep -q 'keep-me' "$SDIR2/sessions.json" \
+    && [[ -f "$SDIR2/keep-me.jsonl" ]]; then
+    pass "Bloated wipe clears its sessions.json reference and keeps healthy ones"
+else
+    fail "Bloated wipe did not update sessions.json correctly (exit $cleanup_exit)"
+fi
+
+if [[ ! -f "$SDIR2/sessions.json.bak-cleanup" ]]; then
+    pass "Temporary .bak-cleanup backup removed after successful wipe"
+else
+    fail ".bak-cleanup backup left behind"
+fi
+
+# ============================================================================
+# Test 8c: No usable Python → refuse to delete ANYTHING (ordering guard)
+# ============================================================================
+# A mid-loop Python failure used to kill the script (set -e) after a bloated
+# session file was deleted but before sessions.json was updated, leaving the
+# gateway pointing at a missing file. The guard must fail BEFORE any rm.
+SDIR3="$TEMP_DIR/sessions3"
+mkdir -p "$SDIR3"
+cat > "$SDIR3/sessions.json" <<'EOF'
+{"agent:main:talk": {"sessionId": "bloated-one"}}
+EOF
+dd if=/dev/zero of="$SDIR3/bloated-one.jsonl" bs=1024 count=2 2>/dev/null
+echo '{"x":1}' > "$SDIR3/inactive.jsonl"
+
+NOPY_BIN="$TEMP_DIR/nopy-bin"
+mkdir -p "$NOPY_BIN"
+for tool in bash sh grep sed find date basename dirname cut wc du stat rm cp mv cat ls tr uname sort head tail touch mkdir; do
+    src="$(command -v "$tool" 2>/dev/null)" || continue
+    ln -s "$src" "$NOPY_BIN/$tool" 2>/dev/null || cp "$src" "$NOPY_BIN/$tool"
+done
+
+nopy_exit=0
+PATH="$NOPY_BIN" ODS_PYTHON_CMD="" SESSIONS_DIR="$SDIR3" MAX_SIZE=100 \
+    bash "$SESSION_CLEANUP_SCRIPT" >"$TEMP_DIR/nopy.log" 2>&1 || nopy_exit=$?
+if [[ $nopy_exit -ne 0 ]]; then
+    pass "Missing Python fails loudly instead of half-completing"
+    if [[ -f "$SDIR3/bloated-one.jsonl" && -f "$SDIR3/inactive.jsonl" ]] && grep -q 'bloated-one' "$SDIR3/sessions.json"; then
+        pass "No files deleted and sessions.json untouched when Python is missing"
+    else
+        fail "Sessions were mutated despite missing Python (exit $nopy_exit)"
+    fi
+else
+    skip "Missing-Python guard (a python binary is still reachable on this host)"
+fi
+
+# ============================================================================
 # Test 9: Script does not use silent error suppression
 # ============================================================================
 suppression_count=0


### PR DESCRIPTION
## Problem
`scripts/session-cleanup.sh` deletes a bloated session file first and only then (inside the per-ID wipe loop) resolves the Python interpreter used to clear that session's reference from `sessions.json`. Under `set -euo pipefail`, a failed resolution (`ods_detect_python_cmd` returning 1 — e.g. Windows Git Bash where the resolver rejects WindowsApps store pythons, or a minimal host without python3) kills the script **between the two steps**: the `.jsonl` file is gone, but `sessions.json` still references it, so the OpenClaw gateway keeps pointing at a session file that no longer exists. The temporary `.bak-cleanup` backup is also stranded.

## Fix
- Resolve Python **once, before the file-processing loop**, and verify it can actually run (`-c 'import json'`). No usable interpreter → exit 1 with a clear message and **zero files touched** — fail-loud, but before the destructive step instead of in the middle of it.
- Removes the redundant re-source + re-detection previously executed for every wiped session ID.

## Tests (`tests/test-session-cleanup.sh`, now registered in `make test` — it previously never ran in CI)
- New: a bloated wipe must delete the file, clear its `sessions.json` reference, preserve healthy references, and remove the `.bak-cleanup` backup.
- New ordering-guard test: with a PATH stripped of every python (and `ODS_PYTHON_CMD` unset), cleanup must exit non-zero with **no** files deleted and `sessions.json` untouched. Against the previous script on Linux this catches the bug (files deleted, reference orphaned).
- Full suite: 15/15 passing locally.

The suite's existing CLAUDE.md-compliance checks (no `2>/dev/null`, no `|| true`, inline exit-capture pattern) still pass on the modified script.