### PR TITLE
Add Omnigent meta-harness server as optional extension

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -270,6 +270,19 @@ WEBUI_PORT=3000            # Open WebUI (external → internal 8080)
 # TOKEN_SPY_API_KEY=
 
 # ═══════════════════════════════════════════════════════════════════
+# Omnigent (Agent Meta-Harness) — optional, disabled by default
+# ═══════════════════════════════════════════════════════════════════
+
+# Server/web UI host port (external → internal 8000)
+# OMNIGENT_PORT=6767
+# Pinned upstream server image tag — alpha upstream, bump deliberately
+# OMNIGENT_IMAGE_TAG=v0.5.1
+# Built-in accounts auth ("1" default); "0" = single-user local mode
+# OMNIGENT_AUTH_ENABLED=1
+# Session cookie secret (generate: openssl rand -hex 32)
+# OMNIGENT_ACCOUNTS_COOKIE_SECRET=
+
+# ═══════════════════════════════════════════════════════════════════
 # Langfuse (LLM Observability) — optional, disabled by default
 # ═══════════════════════════════════════════════════════════════════
 

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -234,13 +234,20 @@
     "OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH": {
       "type": "string",
       "description": "Dangerous escape hatch that disables OpenClaw device pairing. Leave empty unless you fully accept unauthenticated LAN/Tailscale agent access risk.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "BIND_ADDRESS": {
       "type": "string",
       "description": "IP address for Docker port bindings. 127.0.0.1 (default) for localhost-only access. 0.0.0.0 for LAN access on headless servers. See SECURITY.md.",
-      "enum": ["127.0.0.1", "0.0.0.0"],
+      "enum": [
+        "127.0.0.1",
+        "0.0.0.0"
+      ],
       "default": "127.0.0.1"
     },
     "HOST_LAN_IP": {
@@ -315,7 +322,11 @@
     "MODEL_RECOMMENDATION_CONFIDENCE": {
       "type": "string",
       "description": "Confidence level for the installer model recommendation.",
-      "enum": ["low", "medium", "high"]
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
     },
     "MODEL_RECOMMENDATION_REASON": {
       "type": "string",
@@ -328,7 +339,13 @@
     "MODEL_PERFORMANCE_SOURCE": {
       "type": "string",
       "description": "Initial performance source for the recommended model before local benchmarking.",
-      "enum": ["benchmark_required", "measured_local", "published_exact", "predicted_calibrated", "incompatible"]
+      "enum": [
+        "benchmark_required",
+        "measured_local",
+        "published_exact",
+        "predicted_calibrated",
+        "incompatible"
+      ]
     },
     "MODEL_PERFORMANCE_LABEL": {
       "type": "string",
@@ -676,7 +693,11 @@
     },
     "N8N_SECURE_COOKIE": {
       "type": "string",
-      "enum": ["auto", "true", "false"],
+      "enum": [
+        "auto",
+        "true",
+        "false"
+      ],
       "description": "n8n session-cookie policy. auto disables Secure only for loopback HTTP and enables it for HTTPS or non-loopback binds.",
       "default": "auto"
     },
@@ -801,6 +822,30 @@
       "description": "Dify secret key for API access",
       "secret": true
     },
+    "OMNIGENT_PORT": {
+      "type": "integer",
+      "description": "Omnigent server/web UI external port",
+      "default": 6767
+    },
+    "OMNIGENT_IMAGE_TAG": {
+      "type": "string",
+      "description": "Pinned Omnigent server image tag",
+      "default": "v0.5.1"
+    },
+    "OMNIGENT_AUTH_ENABLED": {
+      "type": "string",
+      "enum": [
+        "0",
+        "1"
+      ],
+      "description": "Omnigent built-in accounts auth (1) or single-user local mode (0)",
+      "default": "1"
+    },
+    "OMNIGENT_ACCOUNTS_COOKIE_SECRET": {
+      "type": "string",
+      "description": "Omnigent session cookie signing secret (openssl rand -hex 32)",
+      "secret": true
+    },
     "LANGFUSE_PORT": {
       "type": "integer",
       "description": "Langfuse web UI external port",
@@ -901,13 +946,21 @@
     "LLAMA_REASONING": {
       "type": "string",
       "description": "llama.cpp reasoning/thinking mode: off (default) | auto | on. Off prevents thinking models from consuming the entire token budget on internal reasoning.",
-      "enum": ["off", "auto", "on"],
+      "enum": [
+        "off",
+        "auto",
+        "on"
+      ],
       "default": "off"
     },
     "LLAMA_ARG_FLASH_ATTN": {
       "type": "string",
       "description": "llama.cpp Flash Attention mode. Use 'on' for long-context performance tuning when the selected backend supports it.",
-      "enum": ["auto", "on", "off"],
+      "enum": [
+        "auto",
+        "on",
+        "off"
+      ],
       "default": "auto"
     },
     "LLAMA_ARG_CACHE_TYPE_K": {
@@ -932,7 +985,15 @@
     "LLAMA_ARG_NO_CACHE_PROMPT": {
       "type": "string",
       "description": "Optional llama.cpp boolean flag (--no-cache-prompt) used by specific long-context runtime profiles.",
-      "enum": ["", "0", "1", "false", "true", "off", "on"]
+      "enum": [
+        "",
+        "0",
+        "1",
+        "false",
+        "true",
+        "off",
+        "on"
+      ]
     },
     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS": {
       "type": "integer",
@@ -995,7 +1056,11 @@
     "LEMONADE_LLAMACPP": {
       "type": "string",
       "description": "Lemonade inner llama.cpp backend selector for AMD multi-GPU. Applied by docker-compose.multigpu-amd.yml. Lemonade's schema accepts only auto|vulkan|cpu; 'auto' plus LEMONADE_LLAMACPP_ROCM_BIN picks up the custom ROCm-built binary.",
-      "enum": ["auto", "vulkan", "cpu"],
+      "enum": [
+        "auto",
+        "vulkan",
+        "cpu"
+      ],
       "default": "auto"
     },
     "LEMONADE_LLAMACPP_ROCM_BIN": {
@@ -1025,7 +1090,10 @@
     "APE_STRICT_MODE": {
       "type": "string",
       "description": "When true, APE blocks policy violations instead of only logging advisory decisions.",
-      "enum": ["true", "false"],
+      "enum": [
+        "true",
+        "false"
+      ],
       "default": "false"
     },
     "OPENCLAW_API_KEY": {
@@ -1044,7 +1112,11 @@
     "OPENCLAW_HTTP_API": {
       "type": "string",
       "description": "Opt-in OpenClaw OpenAI-compatible HTTP shim. Leave empty unless you are deliberately exposing the shim for advanced integrations.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "ODS_AGENT_BIND": {
@@ -1197,7 +1269,11 @@
     "WHATSAPP_ENABLED": {
       "type": "string",
       "description": "Enable Hermes's optional WhatsApp gateway integration. Disabled by default.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": "false"
     },
     "WHATSAPP_MODE": {
@@ -1212,7 +1288,11 @@
     "WHATSAPP_REQUIRE_MENTION": {
       "type": "string",
       "description": "Require a mention/prefix before Hermes replies in WhatsApp chats.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "WHATSAPP_FREE_RESPONSE_CHATS": {

--- a/ods/config/dependency-lock.json
+++ b/ods/config/dependency-lock.json
@@ -250,6 +250,13 @@
       "type": "image",
       "path": "installers/windows/docker-compose.windows-amd.local.yml",
       "value": "busybox:1.36.1"
+    },
+    {
+      "id": "omnigent.server",
+      "type": "image",
+      "path": "extensions/services/omnigent/compose.yaml.disabled",
+      "value": "ghcr.io/omnigent-ai/omnigent-server:v0.5.1",
+      "raw": "ghcr.io/omnigent-ai/omnigent-server:${OMNIGENT_IMAGE_TAG:-v0.5.1}"
     }
   ],
   "allow_latest": [
@@ -338,6 +345,12 @@
       "value": "${WHISPER_IMAGE:-ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda}",
       "default": "ghcr.io/speaches-ai/speaches:0.9.0-rc.3-cuda",
       "reason": "Whisper CUDA image can be overridden by operators, but the shipped default is locked."
+    },
+    {
+      "path": "extensions/services/omnigent/compose.yaml.disabled",
+      "value": "ghcr.io/omnigent-ai/omnigent-server:${OMNIGENT_IMAGE_TAG:-v0.5.1}",
+      "default": "ghcr.io/omnigent-ai/omnigent-server:v0.5.1",
+      "reason": "Omnigent is alpha upstream; the shipped default is locked but operators may pin a newer tag deliberately per docs/OMNIGENT.md."
     }
   ]
 }

--- a/ods/config/network-exposure-policy.json
+++ b/ods/config/network-exposure-policy.json
@@ -62,6 +62,12 @@
       "auth_required": true,
       "notes": "May contain prompts, traces, and evaluation data."
     },
+    "omnigent": {
+      "risk": "agent-orchestration-control-plane",
+      "lan_exposure": "operator-controlled",
+      "auth_required": true,
+      "notes": "Coordinates host-side agent runners and holds session artifacts/policies; keep local unless deliberately publishing with accounts auth enabled."
+    },
     "litellm": {
       "risk": "llm-api-gateway",
       "lan_exposure": "operator-controlled",

--- a/ods/docs/OMNIGENT.md
+++ b/ods/docs/OMNIGENT.md
@@ -1,0 +1,136 @@
+# Omnigent — Agent Meta-Harness on ODS
+
+Omnigent ([omnigent-ai/omnigent](https://github.com/omnigent-ai/omnigent),
+Apache 2.0) is a meta-harness: one server that coordinates sandboxed
+sessions of CLI coding agents — Claude Code, Codex, OpenCode, Cursor, Pi —
+behind a uniform API, with stateful policies (cost budgets, permission
+rules) and live session sharing.
+
+On ODS it turns "we ship one coding harness (OpenCode)" into "run any
+coding harness, governed, against your local models."
+
+> **Alpha software.** Omnigent moves fast. ODS pins the server image
+> (`OMNIGENT_IMAGE_TAG`, currently `v0.5.1`); bump it deliberately and
+> re-run the smoke checks at the bottom of this page.
+
+## The split you must understand first
+
+Enabling the extension gives you the **server only**:
+
+| Piece | Where it runs | Installed by |
+|---|---|---|
+| Omnigent server + web UI | Docker (`ods-omnigent`, port 6767) | `ods enable omnigent` |
+| Runners (execute agents, sandbox them) | **Your host machine** | You, manually (below) |
+| CLI harnesses (claude, codex, opencode, …) | Your host, driven by runners | You, per harness |
+
+This is upstream's design, not an ODS limitation: the server image
+deliberately contains no harness SDKs, no tmux, and no LLM API keys.
+It also means the sandboxing runs directly on the host, where it
+belongs — no Docker-in-Docker.
+
+## 1. Enable the server
+
+```bash
+ods enable omnigent
+echo "OMNIGENT_ACCOUNTS_COOKIE_SECRET=$(openssl rand -hex 32)" >> .env
+ods restart omnigent
+```
+
+Open `http://localhost:6767`. The first-boot admin password is written
+to `data/omnigent/admin-credentials` (also printed in
+`ods logs omnigent`). Auth is on by default; the port is bound to
+`127.0.0.1` like every ODS service.
+
+## 2. Install a runner on the host
+
+Any one of:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/omnigent-ai/omnigent/main/scripts/install_oss.sh | sh
+# or
+uv tool install omnigent
+# or
+brew install omnigent-ai/tap/omnigent
+```
+
+Register the host as a runner against the local server:
+
+```bash
+omnigent host --server http://localhost:6767
+```
+
+or run a single agent session against it:
+
+```bash
+omnigent run path/to/agent.yaml --server http://localhost:6767
+```
+
+## 3. Point harnesses at your local models
+
+Run `omnigent setup` and choose the **gateway** (OpenAI-compatible)
+credential type:
+
+- **Base URL:** `http://localhost:4000/v1` (LiteLLM — recommended, works
+  in local, cloud, and hybrid modes) or your llama-server endpoint
+  (`http://localhost:11434/v1` on Linux Docker installs,
+  `http://localhost:8080/v1` on native macOS/Windows paths).
+- **API key:** any non-empty string (llama-server does not validate it,
+  but the SDKs require the field — same trick as `HERMES_LLM_API_KEY`).
+
+Harness selection lives in the agent YAML:
+
+```yaml
+executor:
+  harness: opencode   # or: claude-sdk, claude-native, codex, cursor, pi
+```
+
+Which harnesses make sense fully local:
+
+| Harness | Fully local? | Notes |
+|---|---|---|
+| `opencode` | Yes | Same harness ODS already bundles; gateway-friendly |
+| `codex` | Yes | Works against OpenAI-compatible gateways |
+| `claude-sdk` / `claude-native` | Partly | Best with Anthropic keys or a Claude subscription; local via gateway is possible but harness features assume Claude models |
+| `cursor`, `pi` | Cloud-leaning | Expect their own accounts/keys |
+
+## 4. Policies
+
+Omnigent policies are **stateful and enforced in code**, not prompts:
+spend budgets that pause an agent at a threshold, permission rules,
+network constraints. The budget policies are the headline win for ODS
+**cloud/hybrid mode** — nothing else in the stack stops an agent from
+burning API spend. In pure local mode they matter less (your inference
+is free).
+
+### How this layers with APE
+
+- **Omnigent** governs at the *session* level: cost, permissions,
+  sharing.
+- **APE** governs at the *tool-call* level: command allowlists, path
+  guards, rate limits, tamper-evident audit log.
+
+They stack conceptually, but today **Omnigent-launched agents do not
+flow through APE** — their tool calls are not in APE's audit log. If
+APE auditing is part of your threat model, treat Omnigent sessions
+accordingly. Closing this gap is tracked in
+[Osmantic/ODS#1867](https://github.com/Osmantic/ODS/issues/1867).
+
+## Upgrading
+
+```bash
+# .env: bump the pin
+OMNIGENT_IMAGE_TAG=v0.6.0
+ods restart omnigent
+```
+
+Then smoke-check:
+
+1. `curl -fsS http://localhost:6767/health` returns 200.
+2. Web UI login works (cookie secret unchanged → sessions survive).
+3. A host runner registers and completes a trivial `omnigent run`.
+
+## State & reset
+
+Everything lives in `data/omnigent/` — SQLite DB (`artifacts/chat.db`),
+artifacts, admin credentials. `ods disable omnigent` stops the service;
+deleting `data/omnigent/` is a factory reset.

--- a/ods/docs/OMNIGENT.md
+++ b/ods/docs/OMNIGENT.md
@@ -43,7 +43,19 @@ bound to `127.0.0.1` like every ODS service.
 
 ## 2. Install a runner on the host
 
-Any one of:
+Host prerequisites (verified on a clean macOS install):
+
+- **tmux** — Omnigent spawns native-terminal harnesses inside tmux;
+  without it sessions fail with "Native OpenCode terminal failed to
+  start". `brew install tmux` (macOS) / distro package (Linux).
+- **OpenCode version pin** — Omnigent v0.5.1 requires OpenCode
+  `>=1.17.7,<1.18.0`. ODS's own opencode service may install a newer
+  CLI; if the versions clash, install a pinned copy for the runner
+  (`npm i -g opencode-ai@1.17.7`) and make sure it resolves first on
+  the PATH of the shell that runs `omnigent host`. Re-check this pin
+  whenever you bump `OMNIGENT_IMAGE_TAG`.
+
+Install the runner CLI, any one of:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/omnigent-ai/omnigent/main/scripts/install_oss.sh | sh
@@ -58,6 +70,10 @@ Register the host as a runner against the local server:
 ```bash
 omnigent host --server http://localhost:6767
 ```
+
+Keep this daemon running (its own terminal, tmux window, or a service
+manager) — if it exits, session launches fail with
+`(504): host did not respond to launch request`.
 
 or run a single agent session against it:
 

--- a/ods/docs/OMNIGENT.md
+++ b/ods/docs/OMNIGENT.md
@@ -36,10 +36,10 @@ echo "OMNIGENT_ACCOUNTS_COOKIE_SECRET=$(openssl rand -hex 32)" >> .env
 ods restart omnigent
 ```
 
-Open `http://localhost:6767`. The first-boot admin password is written
-to `data/omnigent/admin-credentials` (also printed in
-`ods logs omnigent`). Auth is on by default; the port is bound to
-`127.0.0.1` like every ODS service.
+Open `http://localhost:6767` and create the first account — Omnigent's
+accounts flow is first-user-is-admin (verified against `v0.5.1`; no
+pre-generated password exists). Auth is on by default; the port is
+bound to `127.0.0.1` like every ODS service.
 
 ## 2. Install a runner on the host
 
@@ -132,5 +132,5 @@ Then smoke-check:
 ## State & reset
 
 Everything lives in `data/omnigent/` — SQLite DB (`artifacts/chat.db`),
-artifacts, admin credentials. `ods disable omnigent` stops the service;
+artifacts, account data. `ods disable omnigent` stops the service;
 deleting `data/omnigent/` is a factory reset.

--- a/ods/docs/OMNIGENT.md
+++ b/ods/docs/OMNIGENT.md
@@ -109,7 +109,53 @@ Which harnesses make sense fully local:
 | `claude-sdk` / `claude-native` | Partly | Best with Anthropic keys or a Claude subscription; local via gateway is possible but harness features assume Claude models |
 | `cursor`, `pi` | Cloud-leaning | Expect their own accounts/keys |
 
-## 4. Policies
+## 4. Multi-agent orchestration (needs a frontier brain)
+
+Omnigent can run an *orchestrator* agent that decomposes a goal and
+delegates each piece to coding sub-agents — the multi-agent use case.
+On ODS there is one hard rule, verified the hard way:
+
+**The orchestrator brain cannot be a local model.** Small local models
+(tested on Qwen3.5-9B) do not reliably drive the sub-agent dispatch
+tools — they either answer conversationally or *hallucinate* a
+delegation (emit a convincing "worker dispatched…" narration while
+doing the work themselves, spawning no child session). Orchestration
+depends on strong tool-use the local tier doesn't have. This is why the
+bundled orchestrators (`polly`, `debby`) hardcode a `claude-sdk` brain.
+
+**The working pattern is a frontier brain + local workers.** Point the
+orchestrator's brain at a frontier model (a Claude subscription or API
+key via `omnigent setup`) and let its coding sub-agents run `opencode`
+against ODS's local llama-server. Verified end-to-end on ODS: `polly`
+(brain on a Claude subscription) dispatched a child session to an
+`opencode` worker running on the local model, which wrote and ran the
+code — confirmed by a distinct `child_sessions` dispatch in the runner
+logs, a real `opencode serve` worker process, and the file it produced.
+
+```bash
+omnigent setup                 # configure a Claude subscription/key for the brain
+omnigent polly -p "…your task…" --server http://localhost:6767
+```
+
+Practical notes from that run:
+
+- **Use the bundled orchestrators, don't hand-roll one.** A bare
+  `spawn: true` agent without polly's dispatch scaffolding does *not*
+  delegate — it silently does the work in the brain. `polly` /`debby`
+  carry the machinery; start from them.
+- **Install the harness CLIs you want delegated to.** `polly` runs a
+  roster preflight and only dispatches to harnesses whose CLI is on
+  PATH. A stock ODS host has `opencode` (and `claude` if installed);
+  `codex`, `cursor`, `hermes`, and `pi` need installing for
+  cross-vendor review to reach them.
+- Local workers still need the [runner prerequisites](#2-install-a-runner-on-the-host)
+  (tmux, the OpenCode version pin).
+
+Bottom line: single-agent coding sessions run great fully local;
+multi-agent orchestration is a **hybrid-mode** capability — frontier
+brain, local hands.
+
+## 5. Policies
 
 Omnigent policies are **stateful and enforced in code**, not prompts:
 spend budgets that pause an agent at a threshold, permission rules,

--- a/ods/docs/README.md
+++ b/ods/docs/README.md
@@ -116,6 +116,7 @@ canonical source and treat older recipes as context.
 | [INSTALLER_PHASE_CONTRACTS.md](INSTALLER_PHASE_CONTRACTS.md) | Maintainers / installer reviewers | Phase ownership, inputs, outputs, idempotency, and validation expectations |
 | [COMPOSE_RESOLVER_CONTRACTS.md](COMPOSE_RESOLVER_CONTRACTS.md) | Maintainers / backend reviewers | Compose layer rules for services, hardware overlays, modes, dependencies, and ports |
 | [HERMES.md](HERMES.md) | Developers / operators | Default Hermes Agent packaging, security posture, and operations |
+| [OMNIGENT.md](OMNIGENT.md) | Developers / operators | Optional Omnigent meta-harness: server extension, host runner setup, local LLM gateway wiring, policy layering |
 | [OAUTH_PROVIDER_SETUP.md](OAUTH_PROVIDER_SETUP.md) | Operators / maintainers | OAuth provider registry, private credential bundles, and BYOC setup |
 | [OPENCLAW-INTEGRATION.md](OPENCLAW-INTEGRATION.md) | Developers | Deprecated OpenClaw setup and migration reference |
 

--- a/ods/extensions/CATALOG.md
+++ b/ods/extensions/CATALOG.md
@@ -24,6 +24,7 @@ For adding or authoring extensions, see [EXTENSIONS.md](../docs/EXTENSIONS.md) a
 | embeddings      | TEI (Embeddings)         | optional   | 8090        | all            | Text embeddings service for RAG. |
 | langfuse        | Langfuse (LLM Observability) | optional | 3006      | all            | LLM tracing, evaluations, and prompt management. |
 | n8n             | n8n (Workflows)          | optional   | 5678        | all            | Workflow automation. |
+| omnigent        | Omnigent (Agent Meta-Harness) | optional | 6767       | all            | Meta-harness server coordinating sandboxed CLI coding-agent sessions (Claude Code, Codex, OpenCode) with policies and sharing. Runners install on the host — see [OMNIGENT.md](../docs/OMNIGENT.md). |
 | openclaw        | OpenClaw (Agents) **(deprecated)** | optional | 7860 | all | Legacy agent framework. **DEPRECATED** — removal planned in the next release. Use `hermes` instead. See [MIGRATION-OPENCLAW-TO-HERMES.md](../docs/MIGRATION-OPENCLAW-TO-HERMES.md). |
 | opencode        | OpenCode (IDE)           | optional   | 3003        | all            | Host-managed browser IDE / coding assistant wired to local inference. |
 | perplexica      | Perplexica (Deep Research) | optional | 3004        | all            | Deep research UI backed by SearXNG and local inference. |
@@ -37,7 +38,7 @@ For adding or authoring extensions, see [EXTENSIONS.md](../docs/EXTENSIONS.md) a
 
 - **core** — Always part of the base stack (llama-server, open-webui, dashboard, dashboard-api).
 - **recommended** — Enabled by default in the installer; can be disabled (litellm, searxng, token-spy, hermes, hermes-proxy).
-- **optional** — User opts in during install or later (APE, Brave Search, ComfyUI, ods-proxy, embeddings, Langfuse, n8n, OpenCode, Perplexica, Privacy Shield, Qdrant, Tailscale, TTS, Whisper). `openclaw` is also in this category but is **deprecated** as of 2026-05-12.
+- **optional** — User opts in during install or later (APE, Brave Search, ComfyUI, ods-proxy, embeddings, Langfuse, n8n, Omnigent, OpenCode, Perplexica, Privacy Shield, Qdrant, Tailscale, TTS, Whisper). `openclaw` is also in this category but is **deprecated** as of 2026-05-12.
 
 ## Ports and .env
 
@@ -72,6 +73,7 @@ extensions/services/
   comfyui/manifest.yaml
   hermes/manifest.yaml
   hermes-proxy/manifest.yaml
+  omnigent/manifest.yaml
   openclaw/manifest.yaml      # deprecated; removal planned next release
   perplexica/manifest.yaml
   embeddings/manifest.yaml

--- a/ods/extensions/services/omnigent/README.md
+++ b/ods/extensions/services/omnigent/README.md
@@ -1,0 +1,50 @@
+# Omnigent (Agent Meta-Harness)
+
+Optional extension that runs the [Omnigent](https://github.com/omnigent-ai/omnigent)
+**server** — a coordinator for sandboxed sessions of CLI coding agents
+(Claude Code, Codex, OpenCode, Cursor, Pi) with a uniform API, stateful
+policies (cost budgets, permissions), and live session sharing.
+
+## What this extension does — and does not — give you
+
+- **Enabled by the extension:** the Omnigent server + web UI on
+  `http://localhost:6767` (SQLite lite tier, localhost-bound, auth on).
+- **Not enabled by the extension:** agent execution. Omnigent runners
+  install **on the host** and register against the server — the server
+  image deliberately ships no harness SDKs, no tmux, and no LLM API
+  keys. Full walkthrough: [docs/OMNIGENT.md](../../../docs/OMNIGENT.md).
+
+## Quickstart
+
+```bash
+ods enable omnigent
+# generate a stable session-cookie secret (logins survive restarts):
+echo "OMNIGENT_ACCOUNTS_COOKIE_SECRET=$(openssl rand -hex 32)" >> .env
+ods restart omnigent
+# admin password: data/omnigent/admin-credentials
+```
+
+Then install a runner on the host and point its harness at the local
+LLM gateway (LiteLLM `http://localhost:4000/v1` or llama-server
+`/v1` with a dummy API key) — see [docs/OMNIGENT.md](../../../docs/OMNIGENT.md).
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `OMNIGENT_PORT` | `6767` | Host port for server + web UI (internal 8000) |
+| `OMNIGENT_IMAGE_TAG` | `v0.5.1` | Pinned upstream image tag — bump deliberately |
+| `OMNIGENT_AUTH_ENABLED` | `1` | Built-in accounts auth; `0` = single-user local mode (localhost only) |
+| `OMNIGENT_ACCOUNTS_COOKIE_SECRET` | _(empty)_ | Set via `openssl rand -hex 32` for stable sessions |
+
+## Governance caveat
+
+Agents launched through Omnigent are governed by Omnigent's **session**
+policies (budgets, permissions) but do **not** flow through APE's
+tool-call audit log yet. If APE auditing is part of your threat model,
+treat Omnigent-launched agents accordingly. Tracked in Osmantic/ODS#1867.
+
+## State
+
+All state lives in `data/omnigent/` (SQLite DB, artifacts, admin
+credentials). Remove the directory for a factory reset.

--- a/ods/extensions/services/omnigent/README.md
+++ b/ods/extensions/services/omnigent/README.md
@@ -21,7 +21,7 @@ ods enable omnigent
 # generate a stable session-cookie secret (logins survive restarts):
 echo "OMNIGENT_ACCOUNTS_COOKIE_SECRET=$(openssl rand -hex 32)" >> .env
 ods restart omnigent
-# admin password: data/omnigent/admin-credentials
+# then open http://localhost:6767 — first account created becomes admin
 ```
 
 Then install a runner on the host and point its harness at the local
@@ -46,5 +46,5 @@ treat Omnigent-launched agents accordingly. Tracked in Osmantic/ODS#1867.
 
 ## State
 
-All state lives in `data/omnigent/` (SQLite DB, artifacts, admin
-credentials). Remove the directory for a factory reset.
+All state lives in `data/omnigent/` (SQLite DB, artifacts, account
+data). Remove the directory for a factory reset.

--- a/ods/extensions/services/omnigent/compose.yaml.disabled
+++ b/ods/extensions/services/omnigent/compose.yaml.disabled
@@ -1,0 +1,59 @@
+# Omnigent server (coordinator only) — ODS lite-tier deployment.
+#
+# Deliberate deviations from upstream deploy/docker/docker-compose.yaml:
+#   - SQLite instead of Postgres. Single-instance homelab install; the
+#     upstream lite tier (DATABASE_URL=sqlite:...) avoids a second
+#     database container. Multi-user installs that outgrow this should
+#     follow upstream's Postgres stack (tracked in Osmantic/ODS#1867).
+#   - Bind mount ./data/omnigent instead of a named volume, matching
+#     every other ODS service so backups and `ods doctor` see it.
+#   - Port bound to 127.0.0.1 (ODS default) — upstream binds 0.0.0.0.
+#
+# Runners are NOT in this container by upstream design: the server image
+# ships no harness SDKs, tmux, or LLM API keys. Install the runner on
+# the host and register it against this server — see docs/OMNIGENT.md.
+
+services:
+  omnigent:
+    image: ghcr.io/omnigent-ai/omnigent-server:${OMNIGENT_IMAGE_TAG:-v0.5.1}
+    container_name: ods-omnigent
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    environment:
+      - DATABASE_URL=sqlite:////data/artifacts/chat.db
+      - ARTIFACT_DIR=/data/artifacts
+      - HOST=0.0.0.0
+      - PORT=8000
+      # Persist admin credentials on the data mount — the default path
+      # (/root/.omnigent/) is ephemeral and loses the bootstrap admin
+      # password on every container recreate.
+      - OMNIGENT_ADMIN_CREDENTIALS_PATH=/data/admin-credentials
+      - OMNIGENT_AUTH_ENABLED=${OMNIGENT_AUTH_ENABLED:-1}
+      - OMNIGENT_ACCOUNTS_COOKIE_SECRET=${OMNIGENT_ACCOUNTS_COOKIE_SECRET:-}
+      # No display in the container; also silences the unclickable
+      # "open this URL" log line upstream emits when set to 1.
+      - OMNIGENT_ACCOUNTS_AUTO_OPEN=0
+    volumes:
+      - ./data/omnigent:/data:z
+    ports:
+      - "${BIND_ADDRESS:-127.0.0.1}:${OMNIGENT_PORT:-6767}:8000"
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.1'
+          memory: 128M
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"

--- a/ods/extensions/services/omnigent/manifest.yaml
+++ b/ods/extensions/services/omnigent/manifest.yaml
@@ -1,0 +1,72 @@
+schema_version: ods.services.v1
+
+compatibility:
+  ods_min: "2.0.0"
+
+service:
+  id: omnigent
+  name: Omnigent (Agent Meta-Harness)
+  aliases: [meta-harness, agents-hub]
+  container_name: ods-omnigent
+  default_host: omnigent
+  # Upstream server listens on 8000 inside the container. Externally we
+  # default to 6767 — Omnigent's well-known local-CLI port — so host-side
+  # runner docs (`omnigent run … --server http://localhost:6767`) match
+  # what users see elsewhere in the Omnigent ecosystem.
+  port: 8000
+  external_port_env: OMNIGENT_PORT
+  external_port_default: 6767
+  health: /health
+  ui_path: /
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []
+  description: >
+    Omnigent server — a meta-harness that coordinates sandboxed sessions
+    of CLI coding agents (Claude Code, Codex, OpenCode, Cursor, Pi)
+    behind one API, with stateful policies (cost budgets, permissions)
+    and live session sharing. ODS ships only the coordinator container
+    (SQLite lite tier); agent runners install on the host and register
+    against this server, pointing their harnesses at the local LLM
+    gateway (LiteLLM or llama-server). See docs/OMNIGENT.md.
+
+  env_vars:
+    - key: OMNIGENT_IMAGE_TAG
+      default: "v0.5.1"
+      description: |
+        Pinned upstream server image tag. Omnigent is alpha; bump
+        deliberately and re-run the smoke checks in docs/OMNIGENT.md.
+    - key: OMNIGENT_AUTH_ENABLED
+      default: "1"
+      description: |
+        Multi-user auth switch. "1" (default) uses Omnigent's built-in
+        accounts flow — first boot writes the admin password to
+        data/omnigent/admin-credentials. "0" runs single-user local
+        mode with no login; acceptable only because ODS binds the port
+        to 127.0.0.1, never for LAN-exposed deployments.
+    - key: OMNIGENT_ACCOUNTS_COOKIE_SECRET
+      default: ""
+      description: |
+        Session cookie signing secret for accounts mode. Generate with
+        `openssl rand -hex 32` and set it in .env so logins survive
+        container restarts.
+
+features:
+  - id: meta-harness
+    name: Agent Meta-Harness
+    description: Run any CLI coding agent (Claude Code, Codex, OpenCode) against local models — sandboxed, policy-governed, shareable sessions
+    icon: Bot
+    category: productivity
+    requirements:
+      services: [omnigent]
+      services_any: [litellm, llama-server]
+    enabled_services_all: [omnigent]
+    enabled_services_any: [litellm, llama-server]
+    setup_time: ~2 minutes (image pull + host runner install)
+    priority: 12
+    launch:
+      type: service
+      service: omnigent
+    gpu_backends: [all]


### PR DESCRIPTION
## Summary

Adds [Omnigent](https://github.com/omnigent-ai/omnigent) (Apache 2.0) as a **disabled-by-default optional extension**: a meta-harness server that coordinates sandboxed sessions of CLI coding agents (Claude Code, Codex, OpenCode, Cursor, Pi) behind one API, with stateful policies (cost budgets, permissions) and live session sharing.

Closes #1865, closes #1866. Part of #1864 (scope/architecture discussion there); follow-up work tracked in #1867.

## What ships

- `extensions/services/omnigent/` — manifest (schema `ods.services.v1`), compose (shipped as `compose.yaml.disabled`, langfuse-style), extension README
- `docs/OMNIGENT.md` + docs index row — operator guide: server/runner split, host runner install, pointing harnesses at LiteLLM/llama-server, APE policy layering
- `extensions/CATALOG.md` row + `.env.example` block (`OMNIGENT_PORT`, `OMNIGENT_IMAGE_TAG`, `OMNIGENT_AUTH_ENABLED`, `OMNIGENT_ACCOUNTS_COOKIE_SECRET`)

## Design decisions

- **Server-only container** (`ghcr.io/omnigent-ai/omnigent-server`, pinned `v0.5.1`): upstream deliberately ships no harness SDKs/keys in the server image; runners install on the host and register against `http://localhost:6767`. No Docker-in-Docker sandboxing.
- **SQLite lite tier** instead of upstream's Postgres stack — single-instance homelab default; Postgres/OIDC hardening deferred to #1867.
- **Localhost-bound, auth on** (`OMNIGENT_AUTH_ENABLED=1`), admin credentials persisted to `data/omnigent/admin-credentials`, no-new-privileges, resource limits, log rotation — mirrors APE's compose conventions.
- **Port 6767 external** (Omnigent's well-known local port) → internal 8000; unique across all 25 services.
- **Governance caveat documented**: Omnigent-launched agents do not flow through APE's audit log yet (#1867); docs and extension README both flag it.

## Validation

- Manifest passes `service-manifest.v1.json` (jsonschema, Draft7)
- `tests/test-extension-integration.sh`: **37 passed, 0 failed** (port uniqueness, enable/disable cycles, health endpoints, category consistency)
- `make lint` clean (shell syntax + Python compile)
- `scripts/resolve-compose-stack.sh`: omnigent excluded while `.disabled`, merged when enabled (verified both states)
- Not yet exercised: live `docker compose up` against the pinned image (no Docker on this machine) — reviewer smoke steps are in `docs/OMNIGENT.md`
