### PR TITLE
fix(windows): strip only matched quote pairs when parsing .env values

### DIFF
--- a/ods/installers/windows/lib/llm-endpoint.ps1
+++ b/ods/installers/windows/lib/llm-endpoint.ps1
@@ -32,7 +32,18 @@ function Get-WindowsODSEnvMap {
             if ($line -match "^#" -or $line -eq "") { return }
             if ($line -match "^([A-Za-z_][A-Za-z0-9_]*)=(.*)$") {
                 $key = $Matches[1]
-                $val = $Matches[2].Trim('"').Trim("'")
+                $val = $Matches[2]
+                # Strip exactly one matching pair of surrounding quotes.
+                # Trimming each quote character independently corrupts values
+                # that legitimately start or end with the other quote: a
+                # double-quoted "'literal'" loses its inner single quotes and
+                # KEY="'" collapses to empty. Mismatched quotes are kept
+                # verbatim, matching lib/safe-env.sh on Linux.
+                if ($val.Length -ge 2 -and (
+                        ($val.StartsWith('"') -and $val.EndsWith('"')) -or
+                        ($val.StartsWith("'") -and $val.EndsWith("'")))) {
+                    $val = $val.Substring(1, $val.Length - 2)
+                }
                 $result[$key] = $val
             }
         }

--- a/ods/tests/test-windows-llm-endpoint.sh
+++ b/ods/tests/test-windows-llm-endpoint.sh
@@ -131,6 +131,45 @@ Assert-ResolvedEndpoint -Label "AMD Lemonade endpoint" `
     -ExpectedHealthUrl "http://localhost:8080/api/v1/health" `
     -ExpectedChatUrl "http://localhost:8080/api/v1/chat/completions"
 
+# --- Get-WindowsODSEnvMap quote handling ---
+# The parser must strip exactly one MATCHING pair of surrounding quotes.
+# Stripping each quote type independently corrupts values that contain or
+# end with the other quote character (mirrors lib/safe-env.sh on Linux).
+$envFixture = Join-Path ([System.IO.Path]::GetTempPath()) ("ods-envmap-test-" + [System.IO.Path]::GetRandomFileName() + ".env")
+@'
+PLAIN=plain-value
+DQ="hello world"
+SQ='single quoted'
+DQ_INNER_SQ="'literal'"
+SQ_INNER_DQ='"x"'
+MISMATCH=trailing-quote"
+LONE_DQ="
+EMPTY_DQ=""
+'@ | Set-Content -LiteralPath $envFixture -Encoding Ascii
+
+try {
+    $map = Get-WindowsODSEnvMap -Path $envFixture
+    $expected = @{
+        "PLAIN"       = 'plain-value'
+        "DQ"          = 'hello world'
+        "SQ"          = 'single quoted'
+        "DQ_INNER_SQ" = "'literal'"
+        "SQ_INNER_DQ" = '"x"'
+        "MISMATCH"    = 'trailing-quote"'
+        "LONE_DQ"     = '"'
+        "EMPTY_DQ"    = ''
+    }
+    foreach ($key in $expected.Keys) {
+        if ($map[$key] -cne $expected[$key]) {
+            throw "EnvMap quote handling: $key = <$($map[$key])> expected <$($expected[$key])>"
+        }
+    }
+    Write-Host "[PASS] Get-WindowsODSEnvMap strips only matched surrounding quote pairs"
+}
+finally {
+    Remove-Item -LiteralPath $envFixture -Force -ErrorAction SilentlyContinue
+}
+
 Write-Host "[PASS] Windows local LLM endpoint resolver"
 PS_EOF
 


### PR DESCRIPTION
## Problem
`Get-WindowsODSEnvMap` (`installers/windows/lib/llm-endpoint.ps1`) parses `.env` with:
```powershell
$val = $Matches[2].Trim('"').Trim("'")
```
`.Trim()` removes **all** leading/trailing occurrences of each quote character independently, so:
- `KEY="'literal'"` → `literal` (inner single quotes destroyed)
- `KEY="'"` → empty string
- `KEY=abc"` (value that legitimately ends with a quote, e.g. a password) → `abc`
- `KEY="` → empty instead of a literal `"`

This is the Windows sibling of the Linux `lib/safe-env.sh` matched-pair fix (#1740). It matters because this parser backs `Read-ODSEnv` / `Get-ODSEnvValue` in `ods.ps1` and the LLM endpoint resolver — corrupted values steer real behavior (ports, model names, API keys), not just display.

## Fix
Strip exactly **one matching pair** of surrounding quotes (`"…"` or `'…'`); keep mismatched or lone quotes verbatim — same semantics as `load_env_file` on Linux, so `.env` values now round-trip identically on both platforms.

## Tests
Extended `tests/test-windows-llm-endpoint.sh` (runs under powershell.exe/pwsh) with an 8-case quote matrix (plain, double-quoted, single-quoted, cross-nested quotes, mismatched trailing quote, lone quote, empty). Verified the matrix **fails against the previous parser** (`LONE_DQ = <> expected <">`) and passes with the fix. Existing endpoint-resolver assertions unchanged and passing.

Scope note: a few installer-side one-off value parses use the same double-Trim pattern on low-risk fields (category names, image tags); left untouched here to keep this focused on the shared parser — can follow up if wanted.