### PR TITLE
fix(macos-cli): strip only matched quote pairs when parsing .env values

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -72,6 +72,9 @@ test: ## Run unit and contract tests
 	@echo "=== macOS model download retry contract ==="
 	@bash tests/test-macos-download-retries.sh
 	@echo ""
+	@echo "=== macOS CLI .env quote handling ==="
+	@bash tests/test-macos-env-quote-strip.sh
+	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
 	@echo ""

--- a/ods/installers/macos/ods-macos.sh
+++ b/ods/installers/macos/ods-macos.sh
@@ -149,7 +149,18 @@ read_ods_env() {
         if [[ "$line" =~ ^([A-Za-z_][A-Za-z0-9_]*)=(.*)$ ]]; then
             local key="${BASH_REMATCH[1]}"
             local val="${BASH_REMATCH[2]}"
-            val=$(echo "$val" | sed 's/^["'"'"']//;s/["'"'"']$//')
+            # Strip exactly one matching pair of surrounding quotes. The old
+            # sed removed a leading and a trailing quote independently (either
+            # type), so KEY=abc" lost its trailing quote and "abc' was cut on
+            # both ends. Mismatched quotes stay verbatim, matching
+            # lib/safe-env.sh used by the Linux CLI.
+            if [[ "$val" == '"'*'"' ]]; then
+                val="${val#\"}"
+                val="${val%\"}"
+            elif [[ "$val" == "'"*"'" ]]; then
+                val="${val#\'}"
+                val="${val%\'}"
+            fi
             export "ENV_${key}=${val}"
         fi
     done < "$env_file"

--- a/ods/tests/test-macos-env-quote-strip.sh
+++ b/ods/tests/test-macos-env-quote-strip.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Fixture tests for read_ods_env in installers/macos/ods-macos.sh:
+# .env values must only lose a MATCHING pair of surrounding quotes.
+# Mirrors the lib/safe-env.sh quote contract used by the Linux CLI.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+CLI="$ROOT_DIR/installers/macos/ods-macos.sh"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+PASSED=0
+FAILED=0
+pass() { printf "  ${GREEN}✓ PASS${NC} %s\n" "$1"; PASSED=$((PASSED + 1)); }
+fail() { printf "  ${RED}✗ FAIL${NC} %s\n" "$1"; FAILED=$((FAILED + 1)); }
+
+echo ""
+echo "=== macOS CLI .env quote handling tests ==="
+echo ""
+
+if bash -n "$CLI" 2>/dev/null; then
+    pass "ods-macos.sh passes bash -n"
+else
+    fail "ods-macos.sh bash -n failed"
+fi
+
+# Extract just read_ods_env so the CLI's dispatch never runs. The function
+# is delimited by its definition line and the first column-0 brace.
+READ_ODS_ENV_SRC="$(sed -n '/^read_ods_env()/,/^}/p' "$CLI")"
+if [[ -z "$READ_ODS_ENV_SRC" ]]; then
+    fail "could not extract read_ods_env from ods-macos.sh"
+    echo "Result: $PASSED passed, $FAILED failed"
+    exit 1
+fi
+eval "$READ_ODS_ENV_SRC"
+
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+cat > "$TMP_DIR/.env" <<'EOF'
+PLAIN=plain-value
+DQ="hello world"
+SQ='single quoted'
+DQ_INNER_SQ="'literal'"
+MISMATCH=trailing-quote"
+CROSS="abc'
+LONE_DQ="
+EMPTY_DQ=""
+EOF
+
+INSTALL_DIR="$TMP_DIR"
+read_ods_env
+
+assert_env() {
+    local var="ENV_$1" expected="$2" actual
+    actual="${!var-<unset>}"
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$1 parsed as <$expected>"
+    else
+        fail "$1 parsed as <$actual>, expected <$expected>"
+    fi
+}
+
+assert_env "PLAIN" 'plain-value'
+assert_env "DQ" 'hello world'
+assert_env "SQ" 'single quoted'
+assert_env "DQ_INNER_SQ" "'literal'"
+assert_env "MISMATCH" 'trailing-quote"'
+assert_env "CROSS" '"abc'\'''
+assert_env "LONE_DQ" '"'
+assert_env "EMPTY_DQ" ''
+
+echo ""
+echo "Result: $PASSED passed, $FAILED failed"
+echo ""
+[[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Problem
`read_ods_env` in `installers/macos/ods-macos.sh` strips quotes with:
```bash
val=$(echo "$val" | sed 's/^["'\''']//;s/["'\''']$//')
```
The leading and trailing strip are independent and accept **either** quote type, so:
- `KEY=abc"` (value legitimately ending in a quote, e.g. a password) → `abc`
- `KEY="abc'` (mismatched) → `abc` (cut on both ends)
- `KEY="` → empty instead of a literal quote

These values are exported as the `ENV_*` variables the macOS CLI acts on, so the corruption affects behavior, not just display.

## Fix
Strip exactly **one matching pair** of surrounding quotes (`"…"` or `'…'`); mismatched or lone quotes stay verbatim. Same semantics as `lib/safe-env.sh` on Linux (#1740) and the Windows parser fix (#1869) — `.env` values now round-trip identically on all three platforms.

## Tests
New `tests/test-macos-env-quote-strip.sh` (registered in `make test`): extracts `read_ods_env` and asserts an 8-case quote matrix. Against the previous parser 3 cases fail (mismatched trailing quote, cross-quoted, lone quote); with the fix 9/9 pass.