### PR TITLE
fix(dashboard-api): parse quoted ODS_VERSION in update dry-run

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/updates.py
+++ b/ods/extensions/services/dashboard-api/routers/updates.py
@@ -291,6 +291,12 @@ async def get_update_dry_run():
         for line in _read_utf8(env_file).splitlines():
             if line.startswith("ODS_VERSION="):
                 current = line.split("=", 1)[1].strip()
+                # Match _read_current_version's quote handling: a quoted
+                # ODS_VERSION would otherwise reach the semver comparison
+                # with its quotes attached, so every digit fails isdigit()
+                # and the update verdict is computed against 0.0.0.
+                if len(current) >= 2 and current[0] == current[-1] and current[0] in "\"'":
+                    current = current[1:-1]
                 break
     if current == "0.0.0" and version_file.exists():
         try:

--- a/ods/extensions/services/dashboard-api/tests/test_updates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_updates.py
@@ -312,6 +312,24 @@ def test_update_dry_run_with_env_and_version(test_client, tmp_path, monkeypatch)
     assert "SOME_OTHER_KEY" not in data["env_keys"]
 
 
+def test_update_dry_run_parses_quoted_ods_version(test_client, tmp_path, monkeypatch):
+    """A quoted ODS_VERSION must not leak its quotes into the semver compare."""
+    import routers.updates as updates_mod
+
+    install_dir = tmp_path / "ods"
+    install_dir.mkdir()
+    (install_dir / ".env").write_text('ODS_VERSION="1.3.0"\n')
+
+    monkeypatch.setattr(updates_mod, "INSTALL_DIR", str(install_dir))
+
+    with patch("routers.updates.httpx.AsyncClient.get",
+               side_effect=httpx.ConnectError("mocked network failure")):
+        resp = test_client.get("/api/update/dry-run", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["current_version"] == "1.3.0"
+
+
 def test_update_dry_run_version_from_version_file(test_client, tmp_path, monkeypatch):
     """GET /api/update/dry-run falls back to .version file when .env has no ODS_VERSION."""
     import routers.updates as updates_mod


### PR DESCRIPTION
## Problem
`GET /api/update/dry-run` re-parses `ODS_VERSION` from `.env` with a plain `.strip()` — unlike `_read_current_version` (used by `/api/version`), it never strips surrounding quotes. With `ODS_VERSION="1.3.0"` in `.env`:

- `current` stays `"1.3.0"` (with quotes),
- in `_parts()` every dotted component fails `isdigit()` (`'"1'`, `'0"'`), so the current version degrades to `[0,0,0]`,
- `update_available` reports **true against any GitHub release**, and the endpoint shows a bogus `current_version`.

Meanwhile `/api/version` (which does strip quotes) reports the correct version — the two endpoints disagree about the same install.

## Fix
Strip one matching pair of surrounding quotes in the dry-run parse, mirroring `_read_current_version`'s handling (with matched-pair semantics per the platform-wide quote contract: #1740/#1869/#1870/#1871). No contract changes — the `0.0.0` no-files fallback and the `.version`/JSON fallbacks behave exactly as the existing tests lock them.

## Tests
New `test_update_dry_run_parses_quoted_ods_version` — fails against the previous code (`current_version == '"1.3.0"'`), passes with the fix. `tests/test_updates.py`: **26 passed**.