### PR TITLE
fix: STRICT mode test coverage and tier-aware model in first-boot-demo

### DIFF
--- a/ods/scripts/first-boot-demo.sh
+++ b/ods/scripts/first-boot-demo.sh
@@ -37,6 +37,9 @@ WHISPER_URL="${WHISPER_URL:-http://localhost:${SERVICE_PORTS[whisper]:-9000}}"
 PIPER_URL="${PIPER_URL:-http://localhost:${SERVICE_PORTS[tts]:-8880}}"
 N8N_URL="${N8N_URL:-http://localhost:${SERVICE_PORTS[n8n]:-5678}}"
 WEBUI_URL="${WEBUI_URL:-http://localhost:${SERVICE_PORTS[open-webui]:-3000}}"
+# Use the installed model from .env if available; fall back to a widely-known default
+# so the demo works out-of-the-box on any tier without hardcoding a specific model name.
+DEMO_MODEL="${LLM_MODEL:-Qwen/Qwen2.5-32B-Instruct-AWQ}"
 
 QUICK_MODE=false
 ALL_MODE=false
@@ -193,12 +196,8 @@ demo "Asking your local AI a question..."
 
 RESPONSE=$(curl -sf "${LLM_URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
-    -d '{
-        "model": "Qwen/Qwen2.5-32B-Instruct-AWQ",
-        "messages": [{"role": "user", "content": "In one sentence, what makes local AI special?"}],
-        "max_tokens": 100,
-        "temperature": 0.7
-    }' 2>/dev/null | jq -r '.choices[0].message.content' 2>/dev/null || echo "")
+    -d "{\"model\": \"${DEMO_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"In one sentence, what makes local AI special?\"}], \"max_tokens\": 100, \"temperature\": 0.7}" \
+    2>/dev/null | jq -r '.choices[0].message.content' 2>/dev/null || echo "")
 
 if [[ -n "$RESPONSE" && "$RESPONSE" != "null" ]]; then
     echo ""
@@ -221,12 +220,8 @@ demo "Asking for help with a Python function..."
 
 CODE_RESPONSE=$(curl -sf "${LLM_URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
-    -d '{
-        "model": "Qwen/Qwen2.5-32B-Instruct-AWQ",
-        "messages": [{"role": "user", "content": "Write a Python one-liner to reverse a string. Just the code, no explanation."}],
-        "max_tokens": 50,
-        "temperature": 0.3
-    }' 2>/dev/null | jq -r '.choices[0].message.content' 2>/dev/null || echo "")
+    -d "{\"model\": \"${DEMO_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Write a Python one-liner to reverse a string. Just the code, no explanation.\"}], \"max_tokens\": 50, \"temperature\": 0.3}" \
+    2>/dev/null | jq -r '.choices[0].message.content' 2>/dev/null || echo "")
 
 if [[ -n "$CODE_RESPONSE" && "$CODE_RESPONSE" != "null" ]]; then
     echo ""
@@ -251,13 +246,8 @@ echo ""
 # Simple streaming demo - just show it works
 curl -sN "${LLM_URL}/v1/chat/completions" \
     -H "Content-Type: application/json" \
-    -d '{
-        "model": "Qwen/Qwen2.5-32B-Instruct-AWQ",
-        "messages": [{"role": "user", "content": "Count from 1 to 5, one number per line."}],
-        "max_tokens": 50,
-        "temperature": 0,
-        "stream": true
-    }' 2>/dev/null | while read -r line; do
+    -d "{\"model\": \"${DEMO_MODEL}\", \"messages\": [{\"role\": \"user\", \"content\": \"Count from 1 to 5, one number per line.\"}], \"max_tokens\": 50, \"temperature\": 0, \"stream\": true}" \
+    2>/dev/null | while read -r line; do
         if [[ "$line" == data:* ]]; then
             content=$(echo "${line#data: }" | jq -r '.choices[0].delta.content // empty' 2>/dev/null)
             if [[ -n "$content" ]]; then

--- a/ods/tests/test-extension-runtime-check.sh
+++ b/ods/tests/test-extension-runtime-check.sh
@@ -77,6 +77,122 @@ else
     fi
 fi
 
+# ============================================================================
+# STRICT mode tests — simulate a running container with a failing health probe
+# ============================================================================
+# Strategy:
+#   1. Build a minimal fixture ODS root containing lib/service-registry.sh,
+#      a manifest with one optional extension that has a health path, and a
+#      stub compose.yaml so the registry sees it as enabled.
+#   2. Inject a mock PATH with a docker that reports the container as "running"
+#      and a curl that always returns exit 1 (probe failure).
+#   3. Assert exit 0 in normal mode and exit 1 in STRICT mode.
+
+FIXTURE_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ods-strict-test.XXXXXX")
+
+strict_cleanup() { rm -rf "$FIXTURE_DIR"; }
+trap strict_cleanup EXIT
+
+# Mirror the lib/ directory the script needs
+mkdir -p "$FIXTURE_DIR/lib"
+cp "$ROOT_DIR/lib/service-registry.sh" "$FIXTURE_DIR/lib/service-registry.sh"
+[[ -f "$ROOT_DIR/lib/safe-env.sh" ]] && cp "$ROOT_DIR/lib/safe-env.sh" "$FIXTURE_DIR/lib/safe-env.sh"
+
+# Minimal extension directory with a manifest and stub compose
+EXT_DIR="$FIXTURE_DIR/extensions/services/test-svc"
+mkdir -p "$EXT_DIR"
+cat > "$EXT_DIR/manifest.yaml" << 'MANIFEST'
+schema_version: ods.services.v1
+compatibility:
+  ods_min: "2.0.0"
+service:
+  id: test-svc
+  name: Test Service
+  aliases: []
+  container_name: ods-test-svc
+  default_host: test-svc
+  port: 19999
+  external_port_env: TEST_SVC_PORT
+  external_port_default: 19999
+  health: /health
+  type: docker
+  gpu_backends: [all]
+  compose_file: compose.yaml
+  category: optional
+  depends_on: []
+MANIFEST
+cat > "$EXT_DIR/compose.yaml" << 'COMPOSE'
+services:
+  test-svc:
+    image: alpine
+    container_name: ods-test-svc
+COMPOSE
+
+# Create a mock bin directory with stub docker and curl executables
+MOCK_BIN=$(mktemp -d "${TMPDIR:-/tmp}/ods-strict-mock-bin.XXXXXX")
+
+# docker stub: "info" → exit 0 (daemon reachable); "inspect" → exit 0 (container exists);
+#              "inspect -f {{.State.Status}}" → "running"
+cat > "$MOCK_BIN/docker" << 'DOCKER_STUB'
+#!/bin/bash
+case "${1:-}" in
+    info)   exit 0 ;;
+    inspect)
+        if [[ "${*}" == *"{{.State.Status}}"* ]]; then
+            echo "running"
+        fi
+        exit 0
+        ;;
+    *)      exit 0 ;;
+esac
+DOCKER_STUB
+chmod +x "$MOCK_BIN/docker"
+
+# curl stub: always fails (simulates a health probe timeout/404)
+cat > "$MOCK_BIN/curl" << 'CURL_STUB'
+#!/bin/bash
+exit 1
+CURL_STUB
+chmod +x "$MOCK_BIN/curl"
+
+# Run in normal mode — should exit 0 even though the health probe fails
+set +e
+out_normal=$(PATH="$MOCK_BIN:$PATH" bash "$CHK" "$FIXTURE_DIR" 2>&1)
+code_normal=$?
+set -e
+
+if [[ $code_normal -eq 0 ]]; then
+    pass "STRICT=0 (default): exits 0 even when health probe fails"
+else
+    fail "STRICT=0 (default): expected exit 0 on probe failure, got $code_normal"
+fi
+
+if echo "$out_normal" | grep -q "\[BAD\]"; then
+    pass "STRICT=0: [BAD] line emitted for failing probe"
+else
+    fail "STRICT=0: expected [BAD] line in output, got: $(echo "$out_normal" | tail -5)"
+fi
+
+# Run in STRICT mode — must exit 1 when a running container fails its health probe
+set +e
+out_strict=$(PATH="$MOCK_BIN:$PATH" EXTENSION_RUNTIME_CHECK_STRICT=1 bash "$CHK" "$FIXTURE_DIR" 2>&1)
+code_strict=$?
+set -e
+
+if [[ $code_strict -eq 1 ]]; then
+    pass "STRICT=1: exits 1 on health probe failure"
+else
+    fail "STRICT=1: expected exit 1 on probe failure, got $code_strict"
+fi
+
+if echo "$out_strict" | grep -q "\[BAD\]"; then
+    pass "STRICT=1: [BAD] line emitted for failing probe"
+else
+    fail "STRICT=1: expected [BAD] line in output, got: $(echo "$out_strict" | tail -5)"
+fi
+
+rm -rf "$MOCK_BIN"
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed, $SKIPPED skipped"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

Closes #1875.

This PR addresses two medium-priority issues identified during a codebase audit. One adds regression coverage for a documented but previously untested exit path, while the other fixes the first-boot demo so it automatically uses the model configured during installation instead of assuming a high-tier deployment.

## Changes

### 1. `ods/tests/test-extension-runtime-check.sh` — Add `STRICT` mode regression tests

`scripts/extension-runtime-check.sh` documents `EXTENSION_RUNTIME_CHECK_STRICT=1` as a public interface that causes the script to exit with status `1` when a running extension fails its health probe. Prior to this change, the test suite never exercised this code path.

Added a self-contained fixture that runs entirely under `/tmp` and:

- Copies `lib/service-registry.sh` into a minimal temporary ODS root.
- Creates a valid `manifest.yaml` for a single optional extension with a `health` endpoint and stub `compose.yaml`.
- Provides a mock `docker` executable that reports the extension container as running.
- Provides a mock `curl` executable that always exits with failure, simulating a failed health probe.
- Verifies that the script exits with status `0` in the default (non-strict) mode while emitting a `[BAD]` status.
- Verifies that the script exits with status `1` when `EXTENSION_RUNTIME_CHECK_STRICT=1` is enabled while still emitting a `[BAD]` status.
- Cleans up the temporary fixture using a `trap` on exit.

This adds regression coverage for both the default and strict execution paths of the runtime check.

---

### 2. `ods/scripts/first-boot-demo.sh` — Use the configured model from `.env`

The demo previously hardcoded the model name:

```text
Qwen/Qwen2.5-32B-Instruct-AWQ
```

for all three API requests. This only works on higher-tier installations where that model is deployed. On T0/T1 installations, the installer configures a different model, causing every demo request to fail with an unknown model error that was subsequently hidden by the existing error handling.

The script already loads `LLM_MODEL` from `.env` through the service registry initialization, but the value was never used.

Added after the URL configuration block:

```bash
# Use the installed model from .env if available; fall back to the T3 default.
DEMO_MODEL="${LLM_MODEL:-Qwen/Qwen2.5-32B-Instruct-AWQ}"
```

Replaced all three hardcoded model names (chat, code assistant, and streaming demos) with `${DEMO_MODEL}`.

The fallback preserves the previous behavior for users running the script outside the normal installer flow while allowing installed systems to automatically use the model that was actually configured.

## Testing

- `bash -n` passes on both modified shell scripts.
- `git diff --check` reports no whitespace issues.
- Verified `bash ods/tests/test-extension-runtime-check.sh` passes locally, including all newly added `STRICT` mode assertions.

## Files Changed

| File | Change |
|------|--------|
| `ods/tests/test-extension-runtime-check.sh` | Add fixture-based regression tests covering both default and `EXTENSION_RUNTIME_CHECK_STRICT=1` behavior |
| `ods/scripts/first-boot-demo.sh` | Introduce `DEMO_MODEL` from `.env` and replace hardcoded model names in all three demo API requests |