### PR TITLE
feat: experimental Android Lite (Termux) profile — native CPU llama.cpp + ods-mobile CLI

### DIFF
--- a/.github/workflows/matrix-smoke.yml
+++ b/.github/workflows/matrix-smoke.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Mobile Dispatch Smoke
         run: bash tests/smoke/mobile-dispatch.sh
 
+      - name: Android Lite Smoke
+        run: bash tests/smoke/android-lite.sh
+
   # Multi-distro installer detection tests (dry-run, no GPU required)
   distro-matrix:
     strategy:

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -88,6 +88,8 @@ smoke: ## Run platform smoke tests
 	@bash tests/smoke/linux-nvidia.sh
 	@bash tests/smoke/wsl-logic.sh
 	@bash tests/smoke/macos-dispatch.sh
+	@bash tests/smoke/mobile-dispatch.sh
+	@bash tests/smoke/android-lite.sh
 	@echo "All smoke tests passed."
 
 simulate: ## Run installer simulation harness

--- a/ods/config/mobile-models.json
+++ b/ods/config/mobile-models.json
@@ -1,0 +1,42 @@
+{
+  "version": 1,
+  "default_model": "bonsai-8b-q1",
+  "models": [
+    {
+      "id": "bonsai-8b-q1",
+      "name": "Bonsai 8B (Q1_0)",
+      "family": "bonsai",
+      "gguf_file": "Bonsai-8B-Q1_0.gguf",
+      "gguf_url": "https://huggingface.co/prism-ml/Bonsai-8B-gguf/resolve/main/Bonsai-8B-Q1_0.gguf",
+      "gguf_sha256": "284a335aa3fb2ced3b1b01fcb40b08aa783e3b70832767f0dd2e3fdfa134bd54",
+      "size_bytes": 1158654496,
+      "min_ram_gb": 12,
+      "context_default": 4096,
+      "context_max": 8192,
+      "gen_defaults": {
+        "temp": 0.5,
+        "top_k": 20,
+        "top_p": 0.9
+      },
+      "specialty": "Default",
+      "description": "8B-class ternary-quantized model, ~1.16 GB on disk. Default for high-end Android phones (Snapdragon 8 Gen 3 / 8 Elite class, 12 GB+ RAM). Experimental — quality and speed on phones are unmeasured until real-device benchmarks land.",
+      "provenance": "sha256/size from Hugging Face LFS metadata, independently verified by full download on 2026-07-19"
+    },
+    {
+      "id": "qwen3.5-2b-q4",
+      "name": "Qwen 3.5 2B (Q4_K_M)",
+      "family": "qwen",
+      "gguf_file": "Qwen3.5-2B-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf",
+      "gguf_sha256": "aaf42c8b7c3cab2bf3d69c355048d4a0ee9973d48f16c731c0520ee914699223",
+      "size_bytes": 1280835840,
+      "min_ram_gb": 6,
+      "context_default": 4096,
+      "context_max": 8192,
+      "gen_defaults": null,
+      "specialty": "Fallback",
+      "description": "Low-RAM fallback for mid-range phones. Same checksum as the desktop catalog entry in model-library.json; proves the Android Lite profile is model-agnostic.",
+      "provenance": "sha256 matches config/model-library.json; size from Hugging Face LFS metadata on 2026-07-19"
+    }
+  ]
+}

--- a/ods/docs/ANDROID-LITE.md
+++ b/ods/docs/ANDROID-LITE.md
@@ -1,0 +1,172 @@
+# ODS Android Lite (Termux) — Experimental
+
+**Status: Tier C / experimental. Termux-only. CPU-only. Not "Android support."**
+
+Android Lite is a minimal, native profile of ODS for Android phones: a pinned
+llama.cpp CPU runtime, a verified model download, and a small `ods-mobile`
+CLI. It is deliberately **not** the ODS stack — there is no Docker, no
+n8n, no Open WebUI, no dashboard, no extension system, and no host-agent on
+Android. It is a local runtime plus a thin CLI.
+
+Nothing in this document claims phone performance. No throughput number for
+this profile may be published until it is measured on a real device with full
+provenance (see [Benchmark protocol](#benchmark-protocol)).
+
+## What you get
+
+- Upstream llama.cpp (pinned tag, see `installers/mobile/lib/constants.sh`)
+  built on-device for CPU
+- A model-agnostic mobile catalog (`config/mobile-models.json`) with pinned
+  sha256 checksums — default model: **Bonsai 8B Q1_0** (~1.16 GB)
+- `ods-mobile` CLI: `status`, `chat`, `serve` (OpenAI-compatible API on
+  `127.0.0.1:8080`), `bench`, `models`
+
+The default model is a default, not the architecture: any llama.cpp-compatible
+GGUF can be added to the catalog with a pinned checksum.
+
+## Requirements
+
+- Android phone, **aarch64**, with [Termux](https://termux.dev)
+  (F-Droid or GitHub build recommended)
+- **12 GB+ RAM recommended** for the default 8B model; 6 GB+ works with the
+  `qwen3.5-2b-q4` fallback
+- ~8 GB free storage (build tree + binaries + one model)
+- Patience: llama.cpp compiles on the phone. Keep the screen on or run
+  `termux-wake-lock` first.
+
+Sensible first target devices: Snapdragon 8 Gen 3 / 8 Elite class, 12 GB+ RAM.
+Fold-style phones need thermal testing before any sustained-use claims.
+
+## Install
+
+Inside Termux:
+
+```bash
+pkg install -y git
+git clone --depth 1 https://github.com/Osmantic/ODS.git
+cd ODS/ods
+bash installers/mobile/install-mobile.sh
+```
+
+Useful variants:
+
+```bash
+bash installers/mobile/install-mobile.sh --skip-model     # runtime + CLI only
+bash installers/mobile/install-mobile.sh --model qwen3.5-2b-q4
+bash installers/mobile/install-mobile.sh --dry-run        # print the plan, change nothing
+bash installers/mobile/install-mobile.sh --rebuild        # force fresh llama.cpp build
+```
+
+`--skip-model` leaves a fully working runtime; pull models later with
+`ods-mobile models pull <id>`.
+
+Everything lives under `~/.ods-mobile`:
+
+```
+~/.ods-mobile/
+  env         # config (model, context, host/port, pinned llama.cpp tag+commit)
+  bin/        # llama-cli, llama-server, llama-bench (self-contained)
+  models/     # verified GGUFs
+  config/     # installed copy of mobile-models.json
+  lib/        # shared model download/verify code
+  llama.cpp/  # source checkout — deletable after install to reclaim space
+  logs/
+```
+
+Uninstall = delete `~/.ods-mobile` and `$PREFIX/bin/ods-mobile`.
+
+## Usage
+
+```bash
+ods-mobile status                 # runtime, models, config, RAM/disk
+ods-mobile chat                   # interactive chat with the default model
+ods-mobile chat --ctx 2048        # smaller context = less memory
+ods-mobile serve                  # OpenAI-compatible API on 127.0.0.1:8080
+ods-mobile serve --port 8081 --ctx 8192
+ods-mobile bench                  # llama-bench + provenance template
+ods-mobile models list
+ods-mobile models pull qwen3.5-2b-q4
+ods-mobile models use qwen3.5-2b-q4
+```
+
+### Context is the memory control
+
+`--ctx` (default **4096**) is the primary knob on phones. If Android kills the
+process, lower it. If you have RAM headroom and need longer conversations,
+raise it up to the model's `context_max`. Generation sampling defaults (for
+Bonsai: temp 0.5, top-k 20, top-p 0.9) come from the catalog per model, not
+from code.
+
+`serve` binds to `127.0.0.1` by default. Binding wider exposes an
+unauthenticated LLM API to your network — the CLI warns if you do.
+
+## Model catalog and checksums
+
+`config/mobile-models.json` pins a real sha256 and byte size for every model,
+with a provenance note recording when and how it was verified. Downloads
+resume on flaky connections and are verified before being kept; a checksum
+mismatch deletes the download and fails loudly. **Never bypass a checksum
+failure** — if upstream re-published a file, the catalog entry must be
+re-verified and updated instead.
+
+Adding a model: add an entry with `id`, `gguf_file`, `gguf_url`, a
+freshly-verified `gguf_sha256` (64-char hex — CI rejects placeholders),
+`size_bytes`, `min_ram_gb`, `context_default`/`context_max`, and either
+`gen_defaults` or `null` to use llama.cpp defaults.
+
+## Benchmark protocol
+
+Any published tok/s number for Android Lite **must** include all of:
+
+| Field | Example |
+|---|---|
+| Device model | (exact retail model) |
+| SoC + RAM | Snapdragon 8 Elite, 12 GB |
+| Backend | CPU (llama.cpp, no GPU offload) |
+| llama.cpp tag + commit | from `ods-mobile status` |
+| Model file + sha256 | from catalog |
+| Context depth | 4096 (`ods-mobile bench --ctx N` → `llama-bench -d N`; use `--ctx 0` for the community-standard zero-depth run) |
+| Thermal state | cold vs soaked; screen on/off; charging |
+| Run length | n runs × tokens per run |
+
+`ods-mobile bench` prints this template before running `llama-bench`.
+A number without every field is not a result. Third-party published figures
+(e.g. community numbers for other devices/backends) are not ODS validation
+evidence and must not be presented as such.
+
+## Real-device validation checklist (pre-Tier-B)
+
+- [ ] Fresh Termux → full install completes on a clean device
+- [ ] Reinstall is idempotent (`install-mobile.sh` again → skips build, verifies model)
+- [ ] `ods-mobile chat` holds a multi-turn conversation
+- [ ] `ods-mobile serve` + `curl 127.0.0.1:8080/v1/models` from Termux
+- [ ] `ods-mobile bench` with full provenance recorded, cold and thermally soaked
+- [ ] `--skip-model` install then `models pull` works
+- [ ] Behavior under phantom process killer documented (with/without wake lock)
+- [ ] Battery/thermal notes for a 30-minute serve session
+
+## Troubleshooting
+
+- **Build or server dies in the background** — Android 12+ kills "phantom"
+  child processes aggressively. Run `termux-wake-lock` before long operations,
+  keep Termux in the foreground, and consider disabling battery optimization
+  for Termux.
+- **Model load or generation OOM-killed** — lower `--ctx`, close other apps,
+  or switch to the low-RAM fallback: `ods-mobile models use qwen3.5-2b-q4`
+  (pull it first).
+- **Out of disk** — after a successful install the binaries are
+  self-contained; delete `~/.ods-mobile/llama.cpp` to reclaim the build tree.
+- **Checksum mismatch on download** — retry once (network corruption); if it
+  persists, upstream changed the file. Do not bypass — see the catalog policy
+  above.
+
+## Non-goals (this iteration) and roadmap
+
+Out of scope today: OpenCL/Adreno and Vulkan acceleration, iOS, pairing with a
+home ODS server, any part of the Docker stack, NNTrainer/FSU-style large-MoE
+phone modes, and Termux:Boot autostart.
+
+Planned order: (1) measured CPU baseline on real devices → (2) OpenCL/Adreno
+evaluation with same-device A/B numbers → (3) Vulkan only if measured wins →
+(4) optional pairing with a home ODS instance. GPU work lands only with
+same-device, same-model, full-provenance comparisons against the CPU baseline.

--- a/ods/docs/SUPPORT-MATRIX.md
+++ b/ods/docs/SUPPORT-MATRIX.md
@@ -1,6 +1,6 @@
 # ODS Support Matrix
 
-Last updated: 2026-05-25
+Last updated: 2026-07-19
 
 ## What Works Today
 
@@ -21,6 +21,7 @@ classes, and any deferred or skipped phases.
 | **Windows (Docker Desktop + WSL2)** | **Supported** | Complete install and runtime via `.\install.ps1`. GPU auto-detection (NVIDIA/AMD). Count Windows as current release-fleet evidence only when the Windows target is enabled and produces artifacts for that candidate. |
 | **macOS (Apple Silicon)** | **Supported** | Complete install and runtime via `./install.sh`. Native Metal inference + Docker services. |
 | **Linux + Intel Arc (SYCL)** | **Experimental** | Installer auto-detects Arc, assigns ARC/ARC\_LITE tier, and selects `docker-compose.arc.yml`. End-to-end runtime on A770/A750. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md). |
+| **Android (Termux) — "Android Lite"** | **Experimental** | Native CPU llama.cpp runtime + `ods-mobile` CLI only — no Docker stack. Termux-only, aarch64, unmeasured on real phones. See [ANDROID-LITE.md](ANDROID-LITE.md). |
 
 ## Support Tiers
 
@@ -37,6 +38,7 @@ classes, and any deferred or skipped phases.
 | Linux (Intel Arc A770/A750) | Intel SYCL (llama-server/oneAPI) | **Tier C** | `docker-compose.arc.yml`; builds llama.cpp from `intel/oneapi-basekit`; see [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) |
 | Windows (Docker Desktop + WSL2) | NVIDIA via Docker Desktop; AMD via host Vulkan runtime | Tier B | Standalone installer (`.\install.ps1`) with GPU auto-detection, Docker orchestration, health checks, and desktop shortcuts; Windows laptop fleet target tracks Docker Desktop/WSL2 evidence |
 | macOS (Apple Silicon) | Metal (native llama-server) | Tier B | Standalone installer (`./install.sh`) with chip detection, native Metal inference, Docker services, and LaunchAgent auto-start; validated on constrained and high-memory Apple Silicon lab hosts |
+| Android (Termux, aarch64) | CPU only (native llama.cpp, pinned tag) | **Tier C** | Experimental "Android Lite" profile: native runtime + `ods-mobile` CLI, model-agnostic mobile catalog (Bonsai 8B Q1_0 default). No Docker/compose stack on Android. Unmeasured on real devices — see [ANDROID-LITE.md](ANDROID-LITE.md) |
 
 ## GPU Tier Map
 
@@ -64,6 +66,7 @@ classes, and any deferred or skipped phases.
 - AMD runtime diagnostics are explicit: `.env` records runtime, location, selected backend, supported backends, and whether ODS manages the process. ODS supports its managed AMD Lemonade path and a Linux external Lemonade SDK wrapper path for existing Lemonade installs; see [LEMONADE-SDK-COMPAT.md](LEMONADE-SDK-COMPAT.md).
 - AMD discrete GPUs beyond the documented Strix Halo path should be treated as validation-required until the repo has tier/model benchmarks for that hardware.
 - **Intel Arc (SYCL) is Tier C / experimental.** The installer auto-detects and selects the correct compose overlay and tier. Runtime works on A770/A750 (Linux). ComfyUI and Whisper GPU acceleration are not yet available for Arc. See [INTEL-ARC-GUIDE.md](INTEL-ARC-GUIDE.md) for limitations.
+- **Android Lite (Termux) is Tier C / experimental — Android is NOT "supported."** It installs a native CPU llama.cpp runtime and the `ods-mobile` CLI only; the Docker stack does not run on Android. No performance numbers exist for this profile until real-device benchmarks with full provenance (device, SoC, RAM, backend, llama.cpp commit, model file + SHA, context, thermal state, run length) are recorded. See [ANDROID-LITE.md](ANDROID-LITE.md).
 - Release-readiness claims should cite a matching version/tag, relevant distro-lab evidence, and a real-hardware fleet receipt from [VALIDATION-MATRIX.md](VALIDATION-MATRIX.md).
 - A supported platform can have code and installer support even when it is not included in every default private release-fleet run. Release notes should cite which hardware classes actually ran, which phases passed, and which surfaces were deferred or skipped.
 - Version baselines for triage are in `docs/KNOWN-GOOD-VERSIONS.md`.
@@ -74,6 +77,8 @@ classes, and any deferred or skipped phases.
 |--------|-----------|
 | **Now** | Linux AMD + NVIDIA + Windows + macOS fully supported |
 | **Now** | Intel Arc (SYCL) experimental — installer + runtime on A770/A750 |
+| **Now** | Android Lite (Termux) experimental — native CPU runtime + `ods-mobile` CLI, pending real-device measurement |
+| **Planned** | Android Lite: measured CPU baselines on Snapdragon 8 Gen 3 / 8 Elite devices, then OpenCL/Adreno evaluation |
 | **Ongoing** | CI smoke matrix expansion for all platforms |
 | **Planned** | Promote Intel Arc to Tier B after broader A770/B580 validation |
 | **Planned** | Arc-accelerated Whisper STT overlay |

--- a/ods/installers/mobile/install-mobile.sh
+++ b/ods/installers/mobile/install-mobile.sh
@@ -1,23 +1,304 @@
 #!/bin/bash
-# Minimal mobile dispatch target. The Android and iOS preview installers land in
-# follow-up PRs so this infrastructure change stays reviewable on its own.
+# Purpose: Android Lite (Termux) installer — native CPU llama.cpp runtime,
+#   verified model download, and the ods-mobile CLI. No Docker, no compose,
+#   none of the desktop stack.
+# Expects: run inside Termux on aarch64. --dry-run runs anywhere with
+#   ODS_PLATFORM_OVERRIDE=android-termux and performs no side effects.
+# Provides: $ODS_MOBILE_HOME runtime tree, $PREFIX/bin/ods-mobile.
+# Modder notes: phases are functions run in order; each sets INSTALL_PHASE for
+#   the ERR trap. Model download/verify lives in lib/model-pull.sh (shared with
+#   the ods-mobile CLI — change it there, not here). iOS a-Shell intentionally
+#   still exits 1: Android Lite is Termux-only in this iteration.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$SCRIPT_DIR/installers/common.sh"
+source "$SCRIPT_DIR/installers/mobile/lib/constants.sh"
+source "$SCRIPT_DIR/installers/mobile/lib/model-pull.sh"
 
+INSTALL_PHASE="init"
+trap 'echo "[ERROR] Android Lite install failed during phase: $INSTALL_PHASE" >&2' ERR
+
+CATALOG_SRC="$SCRIPT_DIR/config/mobile-models.json"
+CLI_SRC="$SCRIPT_DIR/installers/mobile/ods-mobile"
+
+DRY_RUN=false
+SKIP_MODEL=false
+REBUILD=false
+MODEL_ID=""
+
+usage() {
+    cat <<'EOF'
+Usage: install-mobile.sh [options]
+
+Experimental Android Lite installer (Termux only).
+
+Options:
+  --dry-run        Print the planned phases without changing anything.
+  --model <id>     Install a specific catalog model (default: catalog default).
+  --skip-model     Install runtime + CLI only; pull models later with
+                   'ods-mobile models pull <id>'.
+  --rebuild        Force a fresh llama.cpp checkout and build.
+  -h, --help       Show this help.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true ;;
+        --skip-model) SKIP_MODEL=true ;;
+        --rebuild) REBUILD=true ;;
+        --model)
+            shift
+            MODEL_ID="${1:?--model requires a catalog model id}"
+            ;;
+        -h|--help) usage; exit 0 ;;
+        *)
+            echo "[ERROR] Unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+# ── Platform gate ───────────────────────────────────────────────────────────
+INSTALL_PHASE="platform-gate"
 platform="$(detect_platform)"
-
 case "$platform" in
-    android-termux|ios-ashell)
-        echo "[INFO] ODS detected mobile platform: $platform" >&2
-        echo "[ERROR] Mobile preview installer is split into a follow-up PR." >&2
-        echo "        This PR only adds the dispatcher and platform detection contract." >&2
+    android-termux)
+        echo "[INFO] ODS detected mobile platform: $platform"
+        ;;
+    ios-ashell)
+        echo "[ERROR] iOS a-Shell is not yet supported." >&2
+        echo "        Android Lite is Termux-only in this iteration." >&2
         exit 1
         ;;
     *)
-        echo "[ERROR] install-mobile.sh only handles Android Termux or iOS a-Shell." >&2
+        echo "[ERROR] install-mobile.sh only handles Android Termux." >&2
+        echo "        (CI dry-runs: set ODS_PLATFORM_OVERRIDE=android-termux" >&2
+        echo "        and pass --dry-run.)" >&2
         exit 1
         ;;
 esac
+
+phase_preflight() {
+    INSTALL_PHASE="preflight"
+    if $DRY_RUN; then
+        echo "[dry-run] preflight: would require aarch64, writable \$PREFIX/bin,"
+        echo "[dry-run]   and >= $((ODS_MOBILE_MIN_DISK_KB / 1024 / 1024)) GB free in \$HOME."
+        return 0
+    fi
+
+    local arch
+    arch="$(uname -m)"
+    if [[ "$arch" != "aarch64" ]]; then
+        echo "[ERROR] Android Lite requires aarch64, found: $arch" >&2
+        exit 1
+    fi
+
+    if [[ -z "${PREFIX:-}" || ! -d "$PREFIX/bin" || ! -w "$PREFIX/bin" ]]; then
+        echo "[ERROR] \$PREFIX/bin is missing or not writable." >&2
+        echo "        Android Lite must run inside Termux (https://termux.dev)." >&2
+        exit 1
+    fi
+
+    local avail_kb
+    avail_kb="$(df -Pk "$HOME" | awk 'NR==2 {print $4}')"
+    if [[ "$avail_kb" -lt "$ODS_MOBILE_MIN_DISK_KB" ]]; then
+        echo "[ERROR] Need ~$((ODS_MOBILE_MIN_DISK_KB / 1024 / 1024)) GB free in \$HOME, found $((avail_kb / 1024 / 1024)) GB." >&2
+        exit 1
+    fi
+
+    echo "[WARN] Android 12+ aggressively kills background processes (phantom"
+    echo "[WARN] process killer). For long builds or serving, acquire a wake"
+    echo "[WARN] lock first: termux-wake-lock. See docs/ANDROID-LITE.md."
+}
+
+phase_packages() {
+    INSTALL_PHASE="packages"
+    if $DRY_RUN; then
+        echo "[dry-run] packages: would run: pkg install -y $ODS_MOBILE_PACKAGES"
+        return 0
+    fi
+    # shellcheck disable=SC2086
+    pkg install -y $ODS_MOBILE_PACKAGES
+}
+
+# Runs AFTER phase_packages: a fresh Termux has no jq until then, so nothing
+# before this point may parse the catalog.
+phase_resolve_model() {
+    INSTALL_PHASE="model-selection"
+    if $DRY_RUN && ! command -v jq >/dev/null 2>&1; then
+        # Fresh-host dry-run: jq is not installed yet (phase_packages would
+        # install it), so resolution is only described, never executed.
+        MODEL_ID="${MODEL_ID:-(catalog default)}"
+        MODEL_FILE="(resolved from catalog once jq is installed)"
+        MODEL_CTX_DEFAULT="$ODS_MOBILE_DEFAULT_CTX"
+        echo "[dry-run] model-selection: would resolve '$MODEL_ID' from $CATALOG_SRC"
+        echo "[dry-run]   (jq not present yet; installed by the packages phase)."
+        return 0
+    fi
+
+    if [[ -z "$MODEL_ID" ]]; then
+        MODEL_ID="$(jq -re '.default_model' "$CATALOG_SRC")"
+    fi
+    # Fails loudly if the id is not in the catalog:
+    MODEL_FILE="$(ods_mobile_model_field "$CATALOG_SRC" "$MODEL_ID" gguf_file)"
+    MODEL_MIN_RAM_GB="$(ods_mobile_model_field "$CATALOG_SRC" "$MODEL_ID" min_ram_gb)"
+    MODEL_CTX_DEFAULT="$(ods_mobile_model_field "$CATALOG_SRC" "$MODEL_ID" context_default)"
+
+    if $DRY_RUN; then
+        echo "[dry-run] model-selection: resolved '$MODEL_ID' ($MODEL_FILE) from catalog;"
+        echo "[dry-run]   would warn below ${MODEL_MIN_RAM_GB} GB RAM."
+        return 0
+    fi
+
+    local mem_kb mem_gb
+    mem_kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+    mem_gb=$((mem_kb / 1024 / 1024))
+    echo "[INFO] Detected ~${mem_gb} GB RAM."
+    if [[ "$mem_gb" -lt "$MODEL_MIN_RAM_GB" ]]; then
+        echo "[WARN] Model '$MODEL_ID' targets ${MODEL_MIN_RAM_GB} GB+ RAM devices."
+        echo "[WARN] It may be killed by Android's low-memory killer here."
+        echo "[WARN] Consider: --model qwen3.5-2b-q4 (low-RAM fallback)."
+    fi
+}
+
+phase_build() {
+    INSTALL_PHASE="build-llama-cpp"
+    if $DRY_RUN; then
+        echo "[dry-run] build: would clone $LLAMA_CPP_ANDROID_REPO at tag $LLAMA_CPP_ANDROID_TAG"
+        echo "[dry-run]   into $ODS_MOBILE_SRC_DIR and build (CPU-only):"
+        echo "[dry-run]   cmake -B build $LLAMA_CPP_ANDROID_CMAKE_FLAGS"
+        echo "[dry-run]   cmake --build build --config Release --target $LLAMA_CPP_ANDROID_TARGETS"
+        return 0
+    fi
+
+    local recorded_tag=""
+    if [[ -f "$ODS_MOBILE_ENV_FILE" ]]; then
+        recorded_tag="$(awk -F= '/^ODS_MOBILE_LLAMA_TAG=/ {print $2}' "$ODS_MOBILE_ENV_FILE")"
+    fi
+    if [[ -x "$ODS_MOBILE_BIN_DIR/llama-cli" && "$recorded_tag" == "$LLAMA_CPP_ANDROID_TAG" ]] && ! $REBUILD; then
+        LLAMA_COMMIT="$(awk -F= '/^ODS_MOBILE_LLAMA_COMMIT=/ {print $2}' "$ODS_MOBILE_ENV_FILE")"
+        echo "[INFO] llama.cpp $LLAMA_CPP_ANDROID_TAG already built — skipping (use --rebuild to force)."
+        return 0
+    fi
+
+    if [[ -d "$ODS_MOBILE_SRC_DIR" ]]; then
+        if $REBUILD; then
+            echo "[INFO] --rebuild: removing previous checkout $ODS_MOBILE_SRC_DIR"
+            rm -rf "$ODS_MOBILE_SRC_DIR"
+        else
+            echo "[ERROR] $ODS_MOBILE_SRC_DIR exists but does not match tag $LLAMA_CPP_ANDROID_TAG." >&2
+            echo "        Re-run with --rebuild to replace it." >&2
+            exit 1
+        fi
+    fi
+
+    echo "[INFO] Cloning llama.cpp @ $LLAMA_CPP_ANDROID_TAG (shallow) ..."
+    git clone --depth 1 --branch "$LLAMA_CPP_ANDROID_TAG" \
+        "$LLAMA_CPP_ANDROID_REPO" "$ODS_MOBILE_SRC_DIR"
+
+    echo "[INFO] Building llama.cpp (CPU). This takes a while on a phone — keep"
+    echo "[INFO] the screen on or hold a wake lock (termux-wake-lock)."
+    # shellcheck disable=SC2086
+    cmake -S "$ODS_MOBILE_SRC_DIR" -B "$ODS_MOBILE_SRC_DIR/build" $LLAMA_CPP_ANDROID_CMAKE_FLAGS
+    # shellcheck disable=SC2086
+    cmake --build "$ODS_MOBILE_SRC_DIR/build" --config Release -j"$(nproc)" \
+        --target $LLAMA_CPP_ANDROID_TARGETS
+
+    mkdir -p "$ODS_MOBILE_BIN_DIR"
+    local target
+    for target in $LLAMA_CPP_ANDROID_TARGETS; do
+        cp "$ODS_MOBILE_SRC_DIR/build/bin/$target" "$ODS_MOBILE_BIN_DIR/$target"
+    done
+    LLAMA_COMMIT="$(git -C "$ODS_MOBILE_SRC_DIR" rev-parse HEAD)"
+    echo "[INFO] Built $LLAMA_CPP_ANDROID_TAG ($LLAMA_COMMIT)."
+    echo "[INFO] Binaries are self-contained; you may delete $ODS_MOBILE_SRC_DIR"
+    echo "[INFO] later to reclaim disk space."
+}
+
+phase_model() {
+    INSTALL_PHASE="model-download"
+    if $SKIP_MODEL; then
+        echo "[INFO] --skip-model: skipping model download."
+        echo "[INFO] Pull later with: ods-mobile models pull $MODEL_ID"
+        return 0
+    fi
+    if $DRY_RUN; then
+        echo "[dry-run] model: would download $MODEL_FILE for '$MODEL_ID'"
+        echo "[dry-run]   into $ODS_MOBILE_MODELS_DIR and verify its pinned sha256."
+        return 0
+    fi
+    mkdir -p "$ODS_MOBILE_MODELS_DIR"
+    ods_mobile_pull_model "$CATALOG_SRC" "$MODEL_ID" "$ODS_MOBILE_MODELS_DIR"
+}
+
+phase_configure() {
+    INSTALL_PHASE="configure"
+    if $DRY_RUN; then
+        echo "[dry-run] configure: would create $ODS_MOBILE_HOME/{models,bin,lib,config,logs},"
+        echo "[dry-run]   install the mobile catalog + model-pull lib there,"
+        echo "[dry-run]   write $ODS_MOBILE_ENV_FILE (model=$MODEL_ID ctx=$MODEL_CTX_DEFAULT"
+        echo "[dry-run]   host=$ODS_MOBILE_DEFAULT_HOST port=$ODS_MOBILE_DEFAULT_PORT),"
+        echo "[dry-run]   and install ods-mobile to \$PREFIX/bin/ods-mobile."
+        return 0
+    fi
+
+    mkdir -p "$ODS_MOBILE_MODELS_DIR" "$ODS_MOBILE_BIN_DIR" "$ODS_MOBILE_LIB_DIR" \
+             "$ODS_MOBILE_CONFIG_DIR" "$ODS_MOBILE_LOGS_DIR"
+
+    cp "$CATALOG_SRC" "$ODS_MOBILE_CATALOG"
+    cp "$SCRIPT_DIR/installers/mobile/lib/model-pull.sh" "$ODS_MOBILE_LIB_DIR/model-pull.sh"
+
+    cat > "$ODS_MOBILE_ENV_FILE" <<EOF
+# Generated by install-mobile.sh — edit freely; regenerated on reinstall.
+ODS_MOBILE_MODEL=$MODEL_ID
+ODS_MOBILE_CTX=$MODEL_CTX_DEFAULT
+ODS_MOBILE_HOST=$ODS_MOBILE_DEFAULT_HOST
+ODS_MOBILE_PORT=$ODS_MOBILE_DEFAULT_PORT
+ODS_MOBILE_LLAMA_TAG=$LLAMA_CPP_ANDROID_TAG
+ODS_MOBILE_LLAMA_COMMIT=${LLAMA_COMMIT:-unknown}
+EOF
+
+    install -m 755 "$CLI_SRC" "$PREFIX/bin/ods-mobile"
+    echo "[INFO] Installed ods-mobile to \$PREFIX/bin/ods-mobile"
+}
+
+phase_summary() {
+    INSTALL_PHASE="summary"
+    echo ""
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo " ODS Android Lite (experimental) — Termux, CPU-only"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo " llama.cpp: $LLAMA_CPP_ANDROID_TAG"
+    echo " model:     $MODEL_ID ($MODEL_FILE)$($SKIP_MODEL && echo ' [skipped — pull later]')"
+    echo " context:   $MODEL_CTX_DEFAULT (override: --ctx)"
+    echo " state:     $ODS_MOBILE_HOME"
+    echo ""
+    echo " Next steps:"
+    echo "   ods-mobile status"
+    echo "   ods-mobile chat"
+    echo "   ods-mobile serve     # OpenAI-compatible API on $ODS_MOBILE_DEFAULT_HOST:$ODS_MOBILE_DEFAULT_PORT"
+    echo "   ods-mobile bench     # record provenance before quoting any numbers"
+    echo ""
+    echo " This profile is experimental. Performance on phones is unmeasured"
+    echo " until real-device benchmarks are recorded (docs/ANDROID-LITE.md)."
+    if $DRY_RUN; then
+        echo ""
+        echo " (dry-run: nothing was installed or downloaded)"
+    fi
+}
+
+# Order matters: packages before jq-dependent model resolution (fresh Termux
+# has no jq), and configure before the model pull so a failed download still
+# leaves a working CLI ('ods-mobile models pull <id>' recovers).
+phase_preflight
+phase_packages
+phase_resolve_model
+phase_build
+phase_configure
+phase_model
+phase_summary

--- a/ods/installers/mobile/lib/constants.sh
+++ b/ods/installers/mobile/lib/constants.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Purpose: Shared constants for the Android Lite (Termux) installer and CLI.
+# Expects: HOME set. May be sourced standalone (pure — no side effects).
+# Provides: ODS_MOBILE_* paths, llama.cpp pin, Termux package list, CMake flags.
+# Modder notes: Change LLAMA_CPP_ANDROID_TAG only after (1) confirming the tag
+#   builds under the Termux toolchain — the termux-packages llama-cpp pin is a
+#   good known-good signal — and (2) re-checking the CMake option names below
+#   against that exact tag; llama.cpp renames options between releases
+#   (LLAMA_CURL is already deprecated at b9934, LLAMA_BUILD_WEBUI became
+#   LLAMA_BUILD_UI).
+
+# Runtime layout — everything lives under one deletable directory in Termux HOME.
+ODS_MOBILE_HOME="${ODS_MOBILE_HOME:-$HOME/.ods-mobile}"
+ODS_MOBILE_MODELS_DIR="$ODS_MOBILE_HOME/models"
+ODS_MOBILE_BIN_DIR="$ODS_MOBILE_HOME/bin"
+ODS_MOBILE_LIB_DIR="$ODS_MOBILE_HOME/lib"
+ODS_MOBILE_CONFIG_DIR="$ODS_MOBILE_HOME/config"
+ODS_MOBILE_LOGS_DIR="$ODS_MOBILE_HOME/logs"
+ODS_MOBILE_SRC_DIR="$ODS_MOBILE_HOME/llama.cpp"
+ODS_MOBILE_ENV_FILE="$ODS_MOBILE_HOME/env"
+ODS_MOBILE_CATALOG="$ODS_MOBILE_CONFIG_DIR/mobile-models.json"
+
+# llama.cpp pin for the Android CPU path.
+# b9934 is the tag the official termux-packages llama-cpp package builds with
+# the Termux toolchain (checked 2026-07-19), and it builds clean on Linux CPU
+# with the exact flag set below. Real-device validation checklist:
+# docs/ANDROID-LITE.md.
+LLAMA_CPP_ANDROID_TAG="b9934"
+LLAMA_CPP_ANDROID_REPO="https://github.com/ggml-org/llama.cpp.git"
+
+# Termux packages required to build and run. libandroid-spawn is required by
+# llama.cpp on Termux (per upstream docs/android.md and the termux-packages
+# build recipe). jq is used by the catalog/model tooling.
+ODS_MOBILE_PACKAGES="git cmake clang make ninja curl jq libandroid-spawn"
+
+# CPU-only, deterministic, offline-friendly build. Verified against tag b9934:
+# - BUILD_SHARED_LIBS=OFF     → self-contained binaries we can copy to bin/
+# - GGML_OPENMP=OFF           → matches the termux-packages known-good recipe
+# - LLAMA_BUILD_UI=OFF + LLAMA_USE_PREBUILT_UI=OFF
+#                             → skips the web-UI npm build AND the HF asset
+#                               download (the prebuilt bundle for b9934 is
+#                               missing loading.html and hard-fails the build)
+# - LLAMA_OPENSSL=OFF         → no TLS dep; model downloads use our own curl
+LLAMA_CPP_ANDROID_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DGGML_OPENMP=OFF -DLLAMA_BUILD_TESTS=OFF -DLLAMA_BUILD_EXAMPLES=OFF -DLLAMA_BUILD_UI=OFF -DLLAMA_USE_PREBUILT_UI=OFF -DLLAMA_OPENSSL=OFF"
+LLAMA_CPP_ANDROID_TARGETS="llama-cli llama-server llama-bench"
+
+# Conservative runtime defaults. Context is the primary Android memory control;
+# 4096 keeps an 8B-class model workable on 12 GB phones. Override per command
+# with --ctx or persistently in $ODS_MOBILE_ENV_FILE.
+ODS_MOBILE_DEFAULT_CTX=4096
+ODS_MOBILE_DEFAULT_HOST="127.0.0.1"
+ODS_MOBILE_DEFAULT_PORT=8080
+
+# Rough disk requirement for build tree + binaries + one model (KB, ~8 GB).
+ODS_MOBILE_MIN_DISK_KB=8388608

--- a/ods/installers/mobile/lib/model-pull.sh
+++ b/ods/installers/mobile/lib/model-pull.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Purpose: Shared model download + sha256 verification for Android Lite.
+# Expects: curl, jq, sha256sum on PATH. Pure at source time (functions only).
+# Provides: ods_mobile_model_field(), ods_mobile_pull_model()
+# Modder notes: Sourced by BOTH install-mobile.sh (from the repo) and the
+#   installed ods-mobile CLI (from $ODS_MOBILE_HOME/lib/ — the installer copies
+#   this file there). One download/verify path, no duplication. Keep it free of
+#   Termux-specific calls so it also runs in CI and on Linux hosts.
+
+# ods_mobile_model_field <catalog.json> <model-id> <field>
+# Prints the field value; exits non-zero if the model or field is missing/null.
+ods_mobile_model_field() {
+    local catalog="$1" model_id="$2" field="$3"
+
+    jq -re --arg id "$model_id" --arg f "$field" \
+        '.models[] | select(.id == $id) | .[$f]' "$catalog"
+}
+
+# ods_mobile_pull_model <catalog.json> <model-id> <dest-dir>
+# Downloads the model GGUF with resume support and verifies its pinned sha256.
+# A checksum mismatch deletes the partial file and fails loudly — never keeps
+# unverified model bytes on disk.
+ods_mobile_pull_model() {
+    local catalog="$1" model_id="$2" dest_dir="$3"
+    local gguf_file gguf_url gguf_sha size_bytes dest
+
+    gguf_file="$(ods_mobile_model_field "$catalog" "$model_id" gguf_file)"
+    gguf_url="$(ods_mobile_model_field "$catalog" "$model_id" gguf_url)"
+    gguf_sha="$(ods_mobile_model_field "$catalog" "$model_id" gguf_sha256)"
+    size_bytes="$(ods_mobile_model_field "$catalog" "$model_id" size_bytes)"
+    dest="$dest_dir/$gguf_file"
+
+    if [[ -f "$dest" ]]; then
+        echo "[INFO] $gguf_file already present, verifying checksum..."
+        if echo "$gguf_sha  $dest" | sha256sum -c - >/dev/null; then
+            echo "[INFO] checksum OK — nothing to download."
+            return 0
+        fi
+        echo "[ERROR] Existing $dest fails its pinned sha256." >&2
+        echo "        Remove it (ods-mobile models rm $model_id) and pull again." >&2
+        return 1
+    fi
+
+    echo "[INFO] Downloading $gguf_file ($((size_bytes / 1024 / 1024)) MB) ..."
+    curl -fL --retry 3 -C - -o "$dest.part" "$gguf_url"
+
+    echo "[INFO] Verifying sha256 ..."
+    if ! echo "$gguf_sha  $dest.part" | sha256sum -c - >/dev/null; then
+        rm -f "$dest.part"
+        echo "[ERROR] sha256 mismatch for $gguf_file — deleted the download." >&2
+        echo "        Expected: $gguf_sha" >&2
+        echo "        The upstream file changed or the download corrupted." >&2
+        echo "        If upstream re-published the model, the pinned catalog" >&2
+        echo "        entry must be re-verified and updated — do not bypass." >&2
+        return 1
+    fi
+
+    mv "$dest.part" "$dest"
+    echo "[INFO] Verified and installed: $dest"
+}

--- a/ods/installers/mobile/ods-mobile
+++ b/ods/installers/mobile/ods-mobile
@@ -1,0 +1,298 @@
+#!/bin/bash
+# Purpose: Android Lite CLI — status / chat / serve / bench / models for the
+#   Termux CPU runtime installed by install-mobile.sh.
+# Expects: $ODS_MOBILE_HOME (default ~/.ods-mobile) created by the installer.
+#   jq for catalog commands. Read-only commands also work off-device (CI).
+# Provides: user-facing wrapper around llama-cli / llama-server / llama-bench.
+# Modder notes: this file is installed VERBATIM to $PREFIX/bin/ods-mobile —
+#   keep it static and self-contained. Model download/verify logic is sourced
+#   from $ODS_MOBILE_HOME/lib/model-pull.sh (shared with the installer);
+#   do not duplicate it here.
+
+set -euo pipefail
+
+ODS_MOBILE_VERSION="0.1.0-experimental"
+
+ODS_MOBILE_HOME="${ODS_MOBILE_HOME:-$HOME/.ods-mobile}"
+ENV_FILE="$ODS_MOBILE_HOME/env"
+CATALOG="$ODS_MOBILE_HOME/config/mobile-models.json"
+BIN_DIR="$ODS_MOBILE_HOME/bin"
+MODELS_DIR="$ODS_MOBILE_HOME/models"
+PULL_LIB="$ODS_MOBILE_HOME/lib/model-pull.sh"
+
+# Conservative defaults; env file (written by the installer) overrides them,
+# and per-command flags override both. Context is the primary Android memory
+# control — keep it visible.
+ODS_MOBILE_MODEL=""
+ODS_MOBILE_CTX=4096
+ODS_MOBILE_HOST=127.0.0.1
+ODS_MOBILE_PORT=8080
+ODS_MOBILE_LLAMA_TAG=""
+ODS_MOBILE_LLAMA_COMMIT=""
+
+if [[ -f "$ENV_FILE" ]]; then
+    # shellcheck disable=SC1090
+    source "$ENV_FILE"
+fi
+
+usage() {
+    cat <<EOF
+ods-mobile $ODS_MOBILE_VERSION — experimental ODS Android Lite (Termux, CPU)
+
+Usage: ods-mobile <command> [options]
+
+Commands:
+  status                       Runtime, models, and config overview
+  chat   [--model ID] [--ctx N]
+                               Interactive chat (llama-cli conversation mode)
+  serve  [--model ID] [--ctx N] [--host H] [--port P]
+                               OpenAI-compatible API server (default 127.0.0.1:8080)
+  bench  [--model ID] [--ctx N]
+                               llama-bench + provenance template for honest numbers
+  models list                  Show catalog and download state
+  models pull <id>             Download + sha256-verify a catalog model
+  models use  <id>             Set the default model
+  models rm   <id>             Delete a downloaded model file (asks first)
+  help | version
+
+Context (--ctx) is the main memory knob on phones: lower it if Android kills
+the process, raise it (up to the model's context_max) if you have headroom.
+EOF
+}
+
+die() {
+    echo "[ERROR] $*" >&2
+    exit 1
+}
+
+require_runtime() {
+    [[ -d "$ODS_MOBILE_HOME" ]] || die "$ODS_MOBILE_HOME not found — run the Android Lite installer first."
+}
+
+require_bin() {
+    local bin="$1"
+    [[ -x "$BIN_DIR/$bin" ]] || die "$BIN_DIR/$bin missing — re-run the installer (or --rebuild)."
+}
+
+catalog_field() {
+    local model_id="$1" field="$2"
+    jq -re --arg id "$model_id" --arg f "$field" \
+        '.models[] | select(.id == $id) | .[$f]' "$CATALOG"
+}
+
+resolve_model_path() {
+    local model_id="$1" gguf_file
+    gguf_file="$(catalog_field "$model_id" gguf_file)" \
+        || die "Model '$model_id' is not in the catalog ($CATALOG)."
+    MODEL_PATH="$MODELS_DIR/$gguf_file"
+    [[ -f "$MODEL_PATH" ]] \
+        || die "Model '$model_id' is not downloaded. Run: ods-mobile models pull $model_id"
+}
+
+# Sampling defaults ride in the catalog per model (gen_defaults), not in code.
+# Emits flags on stdout; emits nothing when gen_defaults is null.
+gen_flags() {
+    local model_id="$1"
+    jq -r --arg id "$model_id" '
+        .models[] | select(.id == $id) | .gen_defaults
+        | if . == null then ""
+          else "--temp \(.temp) --top-k \(.top_k) --top-p \(.top_p)"
+          end' "$CATALOG"
+}
+
+parse_run_flags() {
+    RUN_MODEL="$ODS_MOBILE_MODEL"
+    RUN_CTX="$ODS_MOBILE_CTX"
+    RUN_HOST="$ODS_MOBILE_HOST"
+    RUN_PORT="$ODS_MOBILE_PORT"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --model) shift; RUN_MODEL="${1:?--model requires an id}" ;;
+            --ctx)   shift; RUN_CTX="${1:?--ctx requires a number}" ;;
+            --host)  shift; RUN_HOST="${1:?--host requires an address}" ;;
+            --port)  shift; RUN_PORT="${1:?--port requires a number}" ;;
+            *) die "Unknown option: $1" ;;
+        esac
+        shift
+    done
+    [[ -n "$RUN_MODEL" ]] || die "No model configured — run: ods-mobile models use <id>"
+}
+
+cmd_status() {
+    require_runtime
+    echo "ods-mobile $ODS_MOBILE_VERSION (experimental, Termux CPU)"
+    echo ""
+    echo "runtime:"
+    echo "  home:      $ODS_MOBILE_HOME"
+    echo "  llama.cpp: ${ODS_MOBILE_LLAMA_TAG:-unknown} (${ODS_MOBILE_LLAMA_COMMIT:-unknown})"
+    local bin
+    for bin in llama-cli llama-server llama-bench; do
+        if [[ -x "$BIN_DIR/$bin" ]]; then
+            echo "  $bin: OK"
+        else
+            echo "  $bin: MISSING"
+        fi
+    done
+    echo ""
+    echo "config:"
+    echo "  model: ${ODS_MOBILE_MODEL:-unset}"
+    echo "  ctx:   $ODS_MOBILE_CTX"
+    echo "  serve: $ODS_MOBILE_HOST:$ODS_MOBILE_PORT"
+    echo ""
+    echo "models ($MODELS_DIR):"
+    local found=false f
+    if [[ -d "$MODELS_DIR" ]]; then
+        for f in "$MODELS_DIR"/*.gguf; do
+            [[ -e "$f" ]] || continue
+            found=true
+            echo "  $(basename "$f")  $(( $(stat -c %s "$f") / 1024 / 1024 )) MB"
+        done
+    fi
+    $found || echo "  (none downloaded)"
+    if [[ -r /proc/meminfo ]]; then
+        echo ""
+        echo "device:"
+        echo "  RAM: $(awk '/^MemTotal:/ {printf "%.1f GB", $2/1024/1024}' /proc/meminfo)"
+        echo "  free disk: $(df -Pk "$HOME" | awk 'NR==2 {printf "%.1f GB", $4/1024/1024}')"
+    fi
+}
+
+cmd_chat() {
+    require_runtime
+    require_bin llama-cli
+    parse_run_flags "$@"
+    resolve_model_path "$RUN_MODEL"
+    local flags
+    flags="$(gen_flags "$RUN_MODEL")"
+    echo "[INFO] chat: $RUN_MODEL ctx=$RUN_CTX ${flags:+($flags)}"
+    # shellcheck disable=SC2086
+    exec "$BIN_DIR/llama-cli" -m "$MODEL_PATH" -c "$RUN_CTX" -cnv $flags
+}
+
+cmd_serve() {
+    require_runtime
+    require_bin llama-server
+    parse_run_flags "$@"
+    resolve_model_path "$RUN_MODEL"
+    local flags
+    flags="$(gen_flags "$RUN_MODEL")"
+    echo "[INFO] serve: $RUN_MODEL ctx=$RUN_CTX on http://$RUN_HOST:$RUN_PORT"
+    if [[ "$RUN_HOST" != "127.0.0.1" ]]; then
+        echo "[WARN] Binding beyond loopback exposes an unauthenticated LLM API"
+        echo "[WARN] to your network. Only do this on networks you trust."
+    fi
+    echo "[INFO] Long runs: hold a wake lock first (termux-wake-lock)."
+    # shellcheck disable=SC2086
+    exec "$BIN_DIR/llama-server" -m "$MODEL_PATH" -c "$RUN_CTX" \
+        --host "$RUN_HOST" --port "$RUN_PORT" $flags
+}
+
+cmd_bench() {
+    require_runtime
+    require_bin llama-bench
+    parse_run_flags "$@"
+    resolve_model_path "$RUN_MODEL"
+    local device="unknown" sha
+    if command -v getprop >/dev/null 2>&1; then
+        device="$(getprop ro.product.model) ($(getprop ro.product.board), Android $(getprop ro.build.version.release))"
+    fi
+    sha="$(catalog_field "$RUN_MODEL" gguf_sha256)"
+    cat <<EOF
+━━━ benchmark provenance — record ALL fields before quoting any number ━━━
+  device:        $device
+  SoC / RAM:     <fill in: SoC, RAM GB>
+  backend:       CPU (llama.cpp, no GPU offload)
+  llama.cpp:     ${ODS_MOBILE_LLAMA_TAG:-unknown} (${ODS_MOBILE_LLAMA_COMMIT:-unknown})
+  model:         $(basename "$MODEL_PATH")
+  sha256:        $sha
+  context depth: $RUN_CTX (passed to llama-bench as -d/--n-depth; use --ctx 0
+                 for the community-standard zero-depth run)
+  thermal state: <fill in: cold / soaked; screen on/off; charging?>
+  run length:    <fill in: n runs, tokens per run>
+A number without every field above is not a result. Do not publish it.
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+EOF
+    # llama-bench at the pinned tag has no -c/--ctx-size; -d sets the KV/context
+    # depth the pp/tg tests run at, which is what "context" means for a phone.
+    exec "$BIN_DIR/llama-bench" -m "$MODEL_PATH" -d "$RUN_CTX"
+}
+
+cmd_models() {
+    require_runtime
+    [[ -f "$CATALOG" ]] || die "Catalog missing: $CATALOG — re-run the installer."
+    local sub="${1:-list}"
+    case "$sub" in
+        list)
+            local id name file marker state
+            while IFS=$'\t' read -r id name file; do
+                marker=" "
+                [[ "$id" == "$ODS_MOBILE_MODEL" ]] && marker="*"
+                state="not downloaded"
+                [[ -f "$MODELS_DIR/$file" ]] && state="downloaded"
+                printf '%s %-18s %-24s [%s]\n' "$marker" "$id" "$name" "$state"
+            done < <(jq -r '.models[] | [.id, .name, .gguf_file] | @tsv' "$CATALOG")
+            echo ""
+            echo "(* = default; switch with: ods-mobile models use <id>)"
+            ;;
+        pull)
+            local model_id="${2:?usage: ods-mobile models pull <id>}"
+            [[ -f "$PULL_LIB" ]] || die "Missing $PULL_LIB — re-run the installer."
+            # shellcheck disable=SC1090
+            source "$PULL_LIB"
+            mkdir -p "$MODELS_DIR"
+            ods_mobile_pull_model "$CATALOG" "$model_id" "$MODELS_DIR"
+            ;;
+        use)
+            local model_id="${2:?usage: ods-mobile models use <id>}"
+            catalog_field "$model_id" id >/dev/null \
+                || die "Model '$model_id' is not in the catalog."
+            local tmp
+            tmp="$(mktemp)"
+            if [[ -f "$ENV_FILE" ]]; then
+                grep -v '^ODS_MOBILE_MODEL=' "$ENV_FILE" > "$tmp"
+            fi
+            echo "ODS_MOBILE_MODEL=$model_id" >> "$tmp"
+            mv "$tmp" "$ENV_FILE"
+            echo "[INFO] Default model set to: $model_id"
+            ;;
+        rm)
+            local model_id="${2:?usage: ods-mobile models rm <id>}" gguf_file target reply
+            gguf_file="$(catalog_field "$model_id" gguf_file)" \
+                || die "Model '$model_id' is not in the catalog."
+            target="$MODELS_DIR/$gguf_file"
+            [[ -f "$target" ]] || die "Not downloaded: $target"
+            read -r -p "Delete $target? [y/N] " reply
+            case "$reply" in
+                y|Y|yes|YES)
+                    rm -f "$target"
+                    echo "[INFO] Deleted $target"
+                    ;;
+                *)
+                    echo "[INFO] Kept $target"
+                    ;;
+            esac
+            ;;
+        *)
+            die "Unknown models subcommand: $sub (list|pull|use|rm)"
+            ;;
+    esac
+}
+
+cmd="${1:-help}"
+if [[ $# -gt 0 ]]; then
+    shift
+fi
+
+case "$cmd" in
+    status) cmd_status "$@" ;;
+    chat) cmd_chat "$@" ;;
+    serve) cmd_serve "$@" ;;
+    bench) cmd_bench "$@" ;;
+    models) cmd_models "$@" ;;
+    version|--version|-v) echo "ods-mobile $ODS_MOBILE_VERSION (llama.cpp ${ODS_MOBILE_LLAMA_TAG:-not installed})" ;;
+    help|--help|-h) usage ;;
+    *)
+        usage >&2
+        die "Unknown command: $cmd"
+        ;;
+esac

--- a/ods/tests/smoke/android-lite.sh
+++ b/ods/tests/smoke/android-lite.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Android Lite (Termux) contract smoke — runs in CI on Linux, no phone required.
+# Proves: script syntax, mobile catalog integrity (real pinned checksums),
+# side-effect-free dry-run, CLI surface, and no full-stack (Docker) leakage.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "[smoke] android-lite contract"
+
+# ── 1. Script syntax ────────────────────────────────────────────────────────
+for file in installers/mobile/install-mobile.sh \
+            installers/mobile/ods-mobile \
+            installers/mobile/lib/constants.sh \
+            installers/mobile/lib/model-pull.sh \
+            tests/smoke/android-lite.sh; do
+    bash -n "$file"
+done
+
+# ── 2. Mobile catalog integrity ─────────────────────────────────────────────
+CATALOG=config/mobile-models.json
+jq -e '.version == 1' "$CATALOG" >/dev/null
+
+default_model="$(jq -r '.default_model' "$CATALOG")"
+jq -e --arg id "$default_model" \
+    '.models[] | select(.id == $id)' "$CATALOG" >/dev/null
+
+# Every entry must carry real provenance: a 64-hex sha256 (no placeholders),
+# a positive byte size, RAM floor, and context defaults.
+jq -e '.models | length > 1' "$CATALOG" >/dev/null   # model-agnostic: >1 entry
+jq -e '.models | all(
+        (.id | length > 0) and
+        (.gguf_file | length > 0) and
+        (.gguf_url | startswith("https://")) and
+        (.gguf_sha256 | test("^[0-9a-f]{64}$")) and
+        (.size_bytes > 0) and
+        (.min_ram_gb > 0) and
+        (.context_default > 0) and
+        (.provenance | length > 0)
+      )' "$CATALOG" >/dev/null
+
+# ── 3. Dry-run is side-effect-free and full-stack-free ──────────────────────
+# Runs with a throwaway HOME on a non-Termux host: must exit 0, write nothing,
+# and never mention the Docker stack. A dry-run that tried to call pkg/git/curl
+# for real would fail loudly here.
+fake_home="$(mktemp -d)"
+dry_out="$(HOME="$fake_home" ODS_PLATFORM_OVERRIDE=android-termux \
+    bash installers/mobile/install-mobile.sh --dry-run)"
+
+test -z "$(ls -A "$fake_home")"   # no writes into HOME
+rmdir "$fake_home"
+
+# shellcheck disable=SC1091
+llama_tag="$(source installers/mobile/lib/constants.sh && echo "$LLAMA_CPP_ANDROID_TAG")"
+grep -q "$llama_tag" <<<"$dry_out"
+grep -q "$default_model" <<<"$dry_out"
+if grep -qiE "docker|compose|n8n|open-webui|dashboard-api|host-agent" <<<"$dry_out"; then
+    echo "[smoke] FAIL: android-lite dry-run mentions the full Docker stack" >&2
+    exit 1
+fi
+
+# --skip-model dry-run still plans a working runtime + CLI
+skip_out="$(ODS_PLATFORM_OVERRIDE=android-termux \
+    bash installers/mobile/install-mobile.sh --dry-run --skip-model)"
+grep -q "$llama_tag" <<<"$skip_out"
+grep -qi "skip" <<<"$skip_out"
+
+# Fresh-install ordering: a fresh Termux has no jq until phase_packages installs
+# it, so the installer must not need jq before then. Prove it: dry-run must
+# succeed with jq absent from PATH entirely.
+nojq_bin="$(mktemp -d)"
+ln -s "$(command -v dirname)" "$nojq_bin/dirname"
+nojq_out="$(PATH="$nojq_bin" ODS_PLATFORM_OVERRIDE=android-termux \
+    /bin/bash installers/mobile/install-mobile.sh --dry-run)"
+grep -q "pkg install" <<<"$nojq_out"
+rm -rf "$nojq_bin"
+
+# Phase order contract: packages install before jq-dependent model resolution,
+# and the CLI/catalog configure step lands before the model pull so a failed
+# download still leaves 'ods-mobile models pull' available for recovery.
+phase_seq="$(grep -E '^phase_[a-z_]+$' installers/mobile/install-mobile.sh | tr '\n' ' ')"
+test "$phase_seq" = "phase_preflight phase_packages phase_resolve_model phase_build phase_configure phase_model phase_summary "
+
+# ── 4. ods-mobile CLI surface ───────────────────────────────────────────────
+CLI=installers/mobile/ods-mobile
+for cmd in status chat serve bench models; do
+    grep -q "$cmd)" "$CLI"
+done
+grep -q -- "--ctx" "$CLI"          # context exposed on chat/serve/bench
+grep -q "127.0.0.1" "$CLI"         # loopback default
+grep -q "4096" "$CLI"              # conservative context default
+
+# bench must actually pass the context to llama-bench, not just print it.
+# llama-bench at the pinned tag has no -c/--ctx-size; context depth is -d.
+grep -qE 'llama-bench" -m "\$MODEL_PATH" -d "\$RUN_CTX"' "$CLI"
+
+bash "$CLI" help >/dev/null
+bash "$CLI" version >/dev/null
+
+# Functional check against a fixture home (read-only commands work off-device).
+fixture="$(mktemp -d)"
+mkdir -p "$fixture/config" "$fixture/models" "$fixture/bin" "$fixture/lib"
+cp "$CATALOG" "$fixture/config/mobile-models.json"
+cp installers/mobile/lib/model-pull.sh "$fixture/lib/"
+models_out="$(ODS_MOBILE_HOME="$fixture" bash "$CLI" models list)"
+grep -q "$default_model" <<<"$models_out"
+rm -rf "$fixture"
+
+# ── 5. Installer installs the static CLI file (never generates one) ─────────
+grep -q 'CLI_SRC="$SCRIPT_DIR/installers/mobile/ods-mobile"' installers/mobile/install-mobile.sh
+grep -q 'install -m 755 "$CLI_SRC"' installers/mobile/install-mobile.sh
+
+echo "[smoke] PASS android-lite"


### PR DESCRIPTION
## Summary

Replaces the mobile dispatch stub with a real, Termux-only "Android Lite" installer. This is
experimental infrastructure (Tier C), not Android support: it installs a native CPU llama.cpp
runtime (pinned tag `b9934`), a checksum-verified model, and a small `ods-mobile` CLI
(`status` / `chat` / `serve` / `bench` / `models`). None of the Docker stack (n8n, Open WebUI,
dashboard-api, extensions, host-agent) runs on Android.

Design points:
- **Model-agnostic catalog** (`ods/config/mobile-models.json`): every entry pins a real
  sha256 + byte size with a dated provenance note. Bonsai 8B Q1_0 (~1.16 GB) is the default;
  Qwen 3.5 2B Q4 ships as a low-RAM fallback. The default is one catalog edit to replace.
- **Pinned, verified toolchain**: llama.cpp `b9934` is the same tag the official
  termux-packages `llama-cpp` recipe builds with the Termux toolchain. The CMake flag set is
  verified against that exact tag (`LLAMA_CURL` is deprecated there; the prebuilt web-UI
  download is broken at that tag and must stay off — see `installers/mobile/lib/constants.sh`).
- **One download/verify path** (`installers/mobile/lib/model-pull.sh`) shared by the installer
  and `ods-mobile models pull`. Checksum mismatch deletes the file and fails loudly.
- **Context (`--ctx`, default 4096) is the primary memory control** and is exposed on
  `chat`, `serve`, and `bench`. `serve` binds `127.0.0.1:8080` and warns on wider binds.
- **CI-safe contract**: `tests/smoke/android-lite.sh` runs on Linux with no phone — catalog
  integrity (64-hex checksums enforced, no placeholders), a provably side-effect-free
  `--dry-run`, a no-Docker-stack-leakage guard, and CLI surface checks. Also wires the
  previously unwired `mobile-dispatch.sh` into `make smoke`.

iOS a-Shell still exits unsupported. Desktop/laptop installer paths are untouched — dispatch
already routed `android-termux` here, and the previous behavior was `exit 1`.

## AI Assistance

AI-assisted planning and implementation support was used locally. The maintainer
reviewed the final diff and validation before publication.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

(Also touches `.github/workflows/matrix-smoke.yml` — adds one smoke step.)

## Risk And Validation

- Risk level: Low for existing platforms (purely additive; the android-termux dispatch target
  previously exited 1, and no desktop/laptop code path changed). The new Android surface
  itself is experimental and unvalidated on real devices — documented as such.
- Validation run:
  - [x] `git diff --check`
  - [x] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build — not touched
  - [ ] Extension audit / compose validation — not touched
  - [ ] Release-grade fleet or scoped hardware validation — see Operational Change Check
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x` — n/a

Commands/results:

```text
make lint    → All lint checks passed.
make test    → all suites pass (tier map 122, installer/preflight contracts,
               AMD/Lemonade 62, overlays, bash 3.2 guards, fleet lock, etc.)
make smoke   → linux-amd, linux-nvidia, wsl-logic, macos-dispatch,
               mobile-dispatch, android-lite: all PASS
git diff --check → clean
shellcheck (CI settings: -e SC1091,SC2034 -S warning) on all new/changed
               shell files incl. ods-mobile → clean

Smoke contracts (run in CI, no phone): catalog integrity (64-hex sha256
enforced, no placeholders), side-effect-free dry-run, dry-run succeeds with
jq absent from PATH (fresh-Termux ordering), exact installer phase-order
assertion (packages before jq-dependent model resolution; CLI/catalog
configure before model pull for recovery), no-Docker-stack-leakage guard,
bench must pass context depth to llama-bench (-d) so reported context
matches the run.

Functional verification (Linux x86_64 — NOT a phone):
- llama.cpp b9934 built clean with the exact installer flag set (CPU, static);
  llama-cli / llama-server / llama-bench all run, no shared-lib deps (ldd)
- Bonsai-8B-Q1_0.gguf downloaded in full; sha256 matches the pinned catalog
  value and Hugging Face LFS metadata (1158654496 bytes)
- Single-turn generation succeeded via the exact invocation `ods-mobile chat`
  uses (model + catalog sampling defaults)
- llama-server served the model on /v1/models (OpenAI-compatible endpoint)
- llama-bench accepts -d and labels results with the depth (context
  provenance verified against a real run)
- Full simulated ODS_MOBILE_HOME: status / models list / pull-verify /
  models use all exercised against the real binaries and model

NOT validated: any real Android device. No performance numbers exist for this
profile and none are claimed anywhere in this PR.
```

## Operational Change Check

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [x] This is an operational change and validation is intentionally deferred for:
  real-device Termux validation (checklist in `ods/docs/ANDROID-LITE.md`). The change cannot
  affect existing installs: it only rewrites the android-termux dispatch target, which
  previously printed an error and exited 1. Fleet validation of desktop surfaces is not
  applicable to this diff; the Android surface has no fleet hardware yet.

## Notes For Reviewers

- **This PR is experimental infrastructure, not validated Android support.** It must not be
  read, released, or announced as "ODS supports Android." Tier C wording is enforced in
  SUPPORT-MATRIX.md and ANDROID-LITE.md, including the benchmark provenance protocol
  (device, SoC, RAM, backend, llama.cpp commit, model file + SHA, context, thermal state,
  run length) required before any tok/s number may be published.
- Known limitation at llama.cpp b9934: the default prebuilt-UI fetch hard-fails (bundle
  missing loading.html), so the build pins `-DLLAMA_BUILD_UI=OFF -DLLAMA_USE_PREBUILT_UI=OFF`
  (rationale in `installers/mobile/lib/constants.sh`).
- `ods-mobile bench --ctx N` maps to `llama-bench -d N` (context/KV depth) —
  b9934's llama-bench has no `-c` flag. `--ctx 0` gives the community-standard
  zero-depth run; either way the provenance template reports exactly what ran.
- Rollback: revert this commit — fully additive, no migrations, no desktop behavior change.
- Deliberately out of scope: OpenCL/Adreno, Vulkan, iOS, home-ODS pairing, anything Docker,
  NNTrainer/FSU, Termux:Boot, performance claims.
