### PR TITLE
fix(macos): correct Qwen3-30B-A3B SHA256 in macOS tier map

### DIFF
--- a/ods/installers/macos/lib/tier-map.sh
+++ b/ods/installers/macos/lib/tier-map.sh
@@ -73,7 +73,7 @@ set_qwen_tier_config() {
             LLM_MODEL="qwen3-30b-a3b"
             GGUF_FILE="Qwen3-30B-A3B-Q4_K_M.gguf"
             GGUF_URL="https://huggingface.co/unsloth/Qwen3-30B-A3B-GGUF/resolve/main/Qwen3-30B-A3B-Q4_K_M.gguf"
-            GGUF_SHA256="84b5f7f112156d63836a01a69dc3f11a6ba63b10a23b8ca7a7efaf52d5a2d806"
+            GGUF_SHA256="9f1a24700a339b09c06009b729b5c809e0b64c213b8af5b711b3dbdfd0c5ba48"
             MAX_CONTEXT=32768
             ;;
         2)

--- a/ods/tests/test-tier-map-parity.sh
+++ b/ods/tests/test-tier-map-parity.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Verifies the macOS tier map stays in sync with the canonical tier map.
+# installers/macos/lib/tier-map.sh declares "keep values byte-identical" with
+# installers/lib/tier-map.sh, but nothing enforced it — a stale GGUF_SHA256
+# in the macOS copy breaks checksum verification on the tier-map fallback path.
+# For every GGUF_FILE both maps define, the SHA256 and URL must match.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CANONICAL="$ROOT_DIR/installers/lib/tier-map.sh"
+MACOS="$ROOT_DIR/installers/macos/lib/tier-map.sh"
+
+fail() { echo "[FAIL] $*"; exit 1; }
+pass() { echo "[PASS] $*"; }
+
+[[ -f "$CANONICAL" ]] || fail "canonical tier map not found"
+[[ -f "$MACOS" ]] || fail "macOS tier map not found"
+
+# extract_pairs <file> <key> — emit "GGUF_FILE<TAB>value" for each tier block
+extract_pairs() {
+    local file="$1" key="$2"
+    awk -v key="$key" '
+        /GGUF_FILE="/ {
+            gsub(/.*GGUF_FILE="/, ""); gsub(/".*/, "")
+            current_file = $0
+            next
+        }
+        $0 ~ key"=\"" {
+            gsub(".*" key "=\"", ""); gsub(/".*/, "")
+            if (current_file != "") {
+                print current_file "\t" $0
+                current_file = ""
+            }
+        }
+    ' "$file"
+}
+
+checked=0
+mismatches=0
+for key in GGUF_SHA256 GGUF_URL; do
+    while IFS=$'\t' read -r gguf value; do
+        canonical_value=$(extract_pairs "$CANONICAL" "$key" | awk -F'\t' -v f="$gguf" '$1==f {print $2; exit}')
+        [[ -n "$canonical_value" ]] || continue  # macOS-only entry: nothing to compare
+        checked=$(( checked + 1 ))
+        if [[ "$value" != "$canonical_value" ]]; then
+            echo "[MISMATCH] $gguf $key"
+            echo "  macOS:     $value"
+            echo "  canonical: $canonical_value"
+            mismatches=$(( mismatches + 1 ))
+        fi
+    done < <(extract_pairs "$MACOS" "$key")
+done
+
+[[ $checked -gt 0 ]] || fail "no comparable GGUF entries found (extraction broken?)"
+[[ $mismatches -eq 0 ]] || fail "$mismatches value(s) differ between macOS and canonical tier maps"
+pass "macOS tier map matches canonical for $checked GGUF field(s)"


### PR DESCRIPTION
## Summary

The macOS tier map's tier-3 `GGUF_SHA256` diverged from the canonical tier map despite the header's "keep values byte-identical" contract (`installers/macos/lib/tier-map.sh` line 8). The canonical value (`9f1a2470…`, `installers/lib/tier-map.sh`) matches the HuggingFace LFS oid for `unsloth/Qwen3-30B-A3B-GGUF/Qwen3-30B-A3B-Q4_K_M.gguf`; the macOS value (`84b5f7f1…`) matches nothing.

Impact: on the tier-map fallback path (catalog selector disabled via `ODS_DISABLE_CATALOG_MODEL_SELECTOR=true`, or no usable Python), a macOS tier-3 install downloads the full 18.6 GB model and then fails checksum verification.

This PR corrects the checksum and adds `tests/test-tier-map-parity.sh`, which asserts `GGUF_SHA256` and `GGUF_URL` agree between the two tier maps for every GGUF both define (15 fields today). The existing `test-model-integrity.sh` only checks that checksums exist in the canonical map, so this drift was invisible to CI. The new test fails on the previous commit with exactly this mismatch.

## AI Assistance

Claude (Claude Code) assisted with drafting the fix and the parity test. The author reviewed the final diff and ran the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
n/a
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

- Risk level: Low
- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`

Focused tests:

- `tests/test-tier-map-parity.sh` (new): passes post-fix (15 fields verified in sync); run against the previous commit it fails with exactly this mismatch.
- Checksum verified against the authoritative source: HuggingFace LFS oid via `https://huggingface.co/api/models/unsloth/Qwen3-30B-A3B-GGUF/tree/main`.
- `bash -n` on both changed files: clean.
- Context: found during a field install on a Mac Mini M4 Pro (48GB), macOS 26.5.1, repo @ e100a6f.
