### PR TITLE
fix(dashboard-api): add exception logging to voice router health checks

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/voice.py
+++ b/ods/extensions/services/dashboard-api/routers/voice.py
@@ -29,7 +29,7 @@ async def voice_status(api_key: str = Depends(verify_api_key)):
                 result = await check_service_health(svc_key, cfg)
                 services_status[display_name] = {"status": result.status}
             except Exception:
-                logger.warning("Health check failed for %s", svc_key)
+                logger.warning("Health check failed for %s", svc_key, exc_info=True)
                 services_status[display_name] = {"status": "unavailable"}
         else:
             services_status[display_name] = {"status": "not_configured"}
@@ -41,7 +41,7 @@ async def voice_status(api_key: str = Depends(verify_api_key)):
             result = await check_service_health("livekit", livekit_cfg)
             services_status["livekit"] = {"status": result.status}
         except Exception:
-            logger.warning("Health check failed for livekit")
+            logger.warning("Health check failed for livekit", exc_info=True)
             services_status["livekit"] = {"status": "unavailable"}
     else:
         services_status["livekit"] = {"status": "not_configured"}


### PR DESCRIPTION
This PR addresses an issue in the voice router health check (`routers/voice.py`) where broad exception blocks (`except Exception:`) were silencing tracebacks. 

By adding `exc_info=True` to the logger calls, any unexpected errors during the health check (such as JSON parsing failures, unexpected connection issues, or type errors) will now properly log their full stack traces. This ensures that failures are not hidden and makes production debugging much easier.