### PR TITLE
fix: fleet lifecycle and bootstrap hardening (exact-SHA refs, dormant backups, update/restart races)

### DIFF
--- a/ods/docs/INSTALLER_TRUST.md
+++ b/ods/docs/INSTALLER_TRUST.md
@@ -55,9 +55,9 @@ The bootstrap:
 - runs `./install.sh` from that copied runtime tree.
 
 The bootstrap source and installed checkout are separate selections. The
-hosted script follows `main`; `ODS_REF` selects a compatible branch or tag for
-the repository checkout. Without `ODS_REF`, the checkout also follows the
-repository default branch, currently `main`.
+hosted script follows `main`; `ODS_REF` selects a compatible branch, tag, or
+exact 40-character commit SHA for the repository checkout. Without `ODS_REF`,
+the checkout also follows the repository default branch, currently `main`.
 
 For example:
 
@@ -121,8 +121,9 @@ https://raw.githubusercontent.com/Osmantic/ODS/AUDITED_COMMIT_SHA/ods/get-ods.sh
 ```
 
 A commit-specific bootstrap URL does not by itself make the complete install
-immutable. Use the audited source checkout when the installed payload must also
-be pinned.
+immutable. Pair it with `ODS_REF=AUDITED_COMMIT_SHA` when the installed payload
+must also be pinned, or use the audited source checkout when you want to review
+or modify the tree before installation.
 
 ### Windows PowerShell Install
 

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -521,6 +521,93 @@ def _serialize_model(model_info) -> Optional[dict]:
 HERMES_MIN_CONTEXT = 65536
 HERMES_TARGET_CONTEXT = 131072
 
+_LLM_CONSUMER_CONTRACTS: dict[str, dict[str, Any]] = {
+    "open-webui": {
+        "consumes": True,
+        "route": "openai-compatible",
+        "pinning": "active-runtime-model",
+        "minContext": 0,
+        "probe": {
+            "kind": "chat",
+            "path": "/api/chat/completions",
+            "auth": "open-webui-probe-user",
+        },
+        "swapSafe": True,
+        "badge": "Chat",
+        "swapSafeReason": "Open WebUI chat completions are routed to the active ODS runtime model.",
+    },
+    "litellm": {
+        "consumes": True,
+        "route": "openai-compatible",
+        "pinning": "default-model",
+        "minContext": 0,
+        "probe": {
+            "kind": "chat",
+            "path": "/v1/chat/completions",
+            "auth": "env:LITELLM_KEY",
+        },
+        "swapSafe": True,
+        "badge": "Gateway",
+        "swapSafeReason": "LiteLLM forwards chat completions to the active ODS runtime model.",
+    },
+    "perplexica": {
+        "consumes": True,
+        "route": "perplexica-chat",
+        "pinning": "service-config",
+        "minContext": 0,
+        "probe": {
+            "kind": "chat",
+            "path": "/api/chat",
+            "auth": "",
+        },
+        "swapSafe": True,
+        "badge": "Research",
+        "swapSafeReason": "Perplexica research chat is expected to follow active ODS model swaps.",
+    },
+    "opencode": {
+        "consumes": True,
+        "route": "opencode-provider",
+        "pinning": "service-config",
+        "minContext": 0,
+        "probe": {
+            "kind": "chat",
+            "path": "/session",
+            "auth": "env:OPENCODE_SERVER_PASSWORD",
+        },
+        "swapSafe": True,
+        "badge": "Coding",
+        "swapSafeReason": "OpenCode sessions are expected to use the active ODS model provider.",
+    },
+    "openclaw": {
+        "consumes": True,
+        "route": "openai-compatible",
+        "pinning": "active-runtime-model",
+        "minContext": 0,
+        "probe": {
+            "kind": "chat",
+            "path": "/v1/chat/completions",
+            "auth": "env:OPENCLAW_TOKEN",
+        },
+        "swapSafe": True,
+        "badge": "Agent",
+        "swapSafeReason": "OpenClaw agent requests are routed through the active ODS runtime model.",
+    },
+    "privacy-shield": {
+        "consumes": True,
+        "route": "openai-compatible",
+        "pinning": "active-runtime-model",
+        "minContext": 0,
+        "probe": {
+            "kind": "chat",
+            "path": "/chat/completions",
+            "auth": "env:SHIELD_API_KEY",
+        },
+        "swapSafe": True,
+        "badge": "Proxy",
+        "swapSafeReason": "Privacy Shield proxies chat completions to the active ODS runtime model.",
+    },
+}
+
 
 def _build_model_readiness_payload(
     *,
@@ -624,9 +711,31 @@ def _service_semantics(service_id: str, status: str) -> dict:
     }
 
 
+def _service_public_url(service_id: str, port: int | None) -> Optional[str]:
+    if not port:
+        return None
+    config = SERVICES.get(service_id, {})
+    path = str(config.get("ui_path") or "/").strip() or "/"
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return f"http://127.0.0.1:{port}{path}"
+
+
+def _service_llm_contract(service_id: str, status: str) -> Optional[dict[str, Any]]:
+    contract = _LLM_CONSUMER_CONTRACTS.get(service_id)
+    if contract is None:
+        return None
+    if service_id != "open-webui" and status != "healthy":
+        return None
+    if service_id == "open-webui" and status == "not_deployed":
+        return None
+    return dict(contract)
+
+
 def _serialize_services(service_statuses: list[ServiceStatus], uptime: int) -> list[dict]:
     serialized = []
     for service in service_statuses:
+        url = _service_public_url(service.id, service.external_port)
         item = {
             "id": service.id,
             "name": service.name,
@@ -634,6 +743,12 @@ def _serialize_services(service_statuses: list[ServiceStatus], uptime: int) -> l
             "port": service.external_port,
             "uptime": uptime if service.status == "healthy" else None,
         }
+        if url:
+            item["url"] = url
+            item["href"] = url
+        llm_contract = _service_llm_contract(service.id, service.status)
+        if llm_contract:
+            item["llm"] = llm_contract
         item.update(_service_semantics(service.id, service.status))
         serialized.append(item)
     return serialized
@@ -645,6 +760,7 @@ def _fallback_services() -> list[dict]:
         external_port = config.get("external_port", config.get("port", 0))
         if not external_port:
             continue
+        url = _service_public_url(service_id, external_port)
         item = {
             "id": service_id,
             "name": config.get("name", service_id),
@@ -652,6 +768,12 @@ def _fallback_services() -> list[dict]:
             "port": external_port,
             "uptime": None,
         }
+        if url:
+            item["url"] = url
+            item["href"] = url
+        llm_contract = _service_llm_contract(service_id, "unknown")
+        if llm_contract:
+            item["llm"] = llm_contract
         item.update(_service_semantics(service_id, "unknown"))
         links.append(item)
     return links
@@ -1330,7 +1452,14 @@ async def _build_api_status() -> dict:
 
     model_data = None
     if model_info:
-        model_data = {"name": model_info.name, "tokensPerSecond": llama_metrics_data.get("tokens_per_second") or None, "contextLength": context_size or model_info.context_length}
+        model_data = {
+            "name": model_info.name,
+            "currentModel": model_info.name,
+            "configuredModel": model_info.name,
+            "loadedModel": loaded_model or model_info.name,
+            "tokensPerSecond": llama_metrics_data.get("tokens_per_second") or None,
+            "contextLength": context_size or model_info.context_length,
+        }
 
     bootstrap_data = None
     if bootstrap_info.active:
@@ -1344,17 +1473,23 @@ async def _build_api_status() -> dict:
 
     tier = _infer_tier(gpu_info)
 
+    loaded_model_name = loaded_model or (model_data["name"] if model_data else None)
+    configured_model_name = model_data["configuredModel"] if model_data else None
+
     result = {
         "gpu": gpu_data, "services": services_data, "model": model_data,
         "bootstrap": bootstrap_data, "uptime": uptime,
         "version": app.version, "tier": tier,
+        "currentModel": configured_model_name,
+        "loadedModel": loaded_model_name,
+        "configuredModel": configured_model_name,
         "cpu": cpu_metrics, "ram": ram_metrics,
         "disk": {"used_gb": disk_info.used_gb, "total_gb": disk_info.total_gb, "percent": disk_info.percent},
         "system": {"uptime": uptime, "hostname": os.environ.get("HOSTNAME", "ods")},
         "inference": {
             "tokensPerSecond": llama_metrics_data.get("tokens_per_second", 0),
             "lifetimeTokens": llama_metrics_data.get("lifetime_tokens", 0),
-            "loadedModel": loaded_model or (model_data["name"] if model_data else None),
+            "loadedModel": loaded_model_name,
             "contextSize": context_size or (model_data["contextLength"] if model_data else None),
         },
         "manifest_errors": MANIFEST_ERRORS,

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -18,6 +18,50 @@ from main import (
 )
 
 
+def test_serialize_services_exposes_probeable_llm_consumers(monkeypatch):
+    from models import ServiceStatus
+
+    monkeypatch.setattr("main.SERVICES", {
+        "open-webui": {
+            "name": "Open WebUI",
+            "port": 8080,
+            "external_port": 3000,
+            "ui_path": "/",
+            "category": "core",
+        },
+        "litellm": {
+            "name": "LiteLLM",
+            "port": 4000,
+            "external_port": 4000,
+            "ui_path": "/ui/",
+            "category": "recommended",
+        },
+        "perplexica": {
+            "name": "Perplexica",
+            "port": 3000,
+            "external_port": 3004,
+            "ui_path": "/",
+            "category": "optional",
+        },
+    })
+
+    services = _serialize_services([
+        ServiceStatus(id="open-webui", name="Open WebUI", port=8080, external_port=3000, status="healthy"),
+        ServiceStatus(id="litellm", name="LiteLLM", port=4000, external_port=4000, status="healthy"),
+        ServiceStatus(id="perplexica", name="Perplexica", port=3000, external_port=3004, status="not_deployed"),
+    ], uptime=42)
+
+    by_id = {service["id"]: service for service in services}
+    assert by_id["open-webui"]["url"] == "http://127.0.0.1:3000/"
+    assert by_id["open-webui"]["llm"]["consumes"] is True
+    assert by_id["open-webui"]["llm"]["probe"]["kind"] == "chat"
+    assert by_id["open-webui"]["llm"]["probe"]["path"] == "/api/chat/completions"
+    assert by_id["open-webui"]["llm"]["swapSafe"] is True
+    assert by_id["litellm"]["url"] == "http://127.0.0.1:4000/ui/"
+    assert by_id["litellm"]["llm"]["probe"]["path"] == "/v1/chat/completions"
+    assert "llm" not in by_id["perplexica"]
+
+
 # --- get_allowed_origins ---
 
 
@@ -227,6 +271,12 @@ class TestBuildApiStatus:
         assert result["gpu"]["name"] == "RTX 4090"
         assert result["tier"] == "Prosumer"
         assert result["uptime"] == 3600
+        assert result["currentModel"] == "Test-32B"
+        assert result["loadedModel"] == "Test-32B"
+        assert result["configuredModel"] == "Test-32B"
+        assert result["model"]["currentModel"] == "Test-32B"
+        assert result["model"]["loadedModel"] == "Test-32B"
+        assert result["model"]["configuredModel"] == "Test-32B"
         assert result["inference"]["tokensPerSecond"] == 25.5
         assert result["inference"]["loadedModel"] == "Test-32B"
 
@@ -845,6 +895,8 @@ class TestApiStatusServiceSerialization:
             "status": "healthy",
             "port": 11434,
             "uptime": 42,
+            "url": "http://127.0.0.1:11434/",
+            "href": "http://127.0.0.1:11434/",
             "category": "core",
             "required": True,
             "impact": "core",
@@ -915,6 +967,8 @@ class TestApiStatusServiceSerialization:
             "status": "unknown",
             "port": 3002,
             "uptime": None,
+            "url": "http://127.0.0.1:3002/",
+            "href": "http://127.0.0.1:3002/",
             "category": "core",
             "required": True,
             "impact": "core",

--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -90,6 +90,16 @@ checkout_requested_sha_ref() {
     fi
 }
 
+_ods_is_install_backup_dir() {
+    local candidate_name="${1%/}"
+    candidate_name="${candidate_name##*/}"
+
+    case "$candidate_name" in
+        *.backup-[0-9]*|backup-[0-9]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 _ods_is_related_install_dir() {
     local candidate="$1"
     local compose_file=""
@@ -157,6 +167,7 @@ refuse_legacy_install() {
         while IFS= read -r -d '' candidate; do
             [[ "${candidate%/}" == "${INSTALL_DIR%/}" ]] && continue
             [[ -n "$PRE_ODS_INSTALL_DIR" && "${candidate%/}" == "${PRE_ODS_INSTALL_DIR%/}" ]] && continue
+            _ods_is_install_backup_dir "$candidate" && continue
             if _ods_is_related_install_dir "$candidate"; then
                 findings+=("related install directory: $candidate")
             fi

--- a/ods/get-ods.sh
+++ b/ods/get-ods.sh
@@ -70,6 +70,26 @@ is_truthy() {
     esac
 }
 
+ods_ref_is_exact_sha() {
+    [[ "${1:-}" =~ ^[0-9a-fA-F]{40}$ ]]
+}
+
+checkout_requested_sha_ref() {
+    local ref="${1:-}"
+    local fetch_err=""
+    local checkout_err=""
+
+    [[ -n "$ref" ]] || return 0
+    ods_ref_is_exact_sha "$ref" || return 0
+
+    fetch_err=$(git fetch --depth 1 origin "$ref" 2>&1) || true
+    if ! checkout_err=$(git checkout --detach "$ref" 2>&1); then
+        error "Failed to check out repository ref $ref after cloning.
+  git fetch said: ${fetch_err:-already present in shallow clone}
+  git checkout said: $checkout_err"
+    fi
+}
+
 _ods_is_related_install_dir() {
     local candidate="$1"
     local compose_file=""
@@ -364,7 +384,7 @@ TEMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TEMP_DIR"' EXIT
 
 clone_args=(--depth 1 --filter=blob:none --sparse)
-if [[ -n "$ODS_REF" ]]; then
+if [[ -n "$ODS_REF" ]] && ! ods_ref_is_exact_sha "$ODS_REF"; then
     clone_args+=(--branch "$ODS_REF")
 fi
 
@@ -383,17 +403,19 @@ _clone_err=$(git clone "${clone_args[@]}" "$REPO_URL" "$TEMP_DIR/repo" 2>&1) || 
 echo "$_clone_err" | tail -1
 
 cd "$TEMP_DIR/repo"
+checkout_requested_sha_ref "$ODS_REF"
 git sparse-checkout set ods 2>/dev/null || {
     # Fallback: full clone if sparse checkout fails
     cd "$ODS_BOOTSTRAP_ROOT"
     rm -rf "$TEMP_DIR/repo"
     fallback_clone_args=(--depth 1)
-    if [[ -n "$ODS_REF" ]]; then
+    if [[ -n "$ODS_REF" ]] && ! ods_ref_is_exact_sha "$ODS_REF"; then
         fallback_clone_args+=(--branch "$ODS_REF")
     fi
     git clone "${fallback_clone_args[@]}" "$REPO_URL" "$TEMP_DIR/repo" 2>&1 | tail -1 || \
         error "Failed to clone repository (fallback full clone also failed)."
     cd "$TEMP_DIR/repo"
+    checkout_requested_sha_ref "$ODS_REF"
 }
 
 # Move ods to install location (exclude dev-only files)

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -383,6 +383,7 @@ ODS_AGENT_HOST=${ODS_AGENT_HOST:-host.docker.internal}
 #=== LLM Backend Mode ===
 ODS_MODE=local
 LLM_API_URL=${llm_api_url}
+LLM_BACKEND=llama-server
 
 #=== Cloud API Keys ===
 ANTHROPIC_API_KEY=

--- a/ods/installers/phases/01-preflight.sh
+++ b/ods/installers/phases/01-preflight.sh
@@ -103,6 +103,16 @@ _ods_truthy() {
     esac
 }
 
+_ods_is_install_backup_dir() {
+    local candidate_name="${1%/}"
+    candidate_name="${candidate_name##*/}"
+
+    case "$candidate_name" in
+        *.backup-[0-9]*|backup-[0-9]*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 _ods_is_related_install_dir() {
     local candidate="$1"
     local compose_file=""
@@ -165,6 +175,7 @@ if [[ ! -d "$INSTALL_DIR" ]] && ! _ods_truthy "${ODS_ALLOW_LEGACY_PARALLEL:-}"; 
         [[ "${_pre_ods_candidate%/}" == "${INSTALL_DIR%/}" ]] && continue
         [[ "${_pre_ods_candidate%/}" == "${SCRIPT_DIR%/}" ]] && continue
         [[ -n "$_pre_ods_install_dir" && "${_pre_ods_candidate%/}" == "${_pre_ods_install_dir%/}" ]] && continue
+        _ods_is_install_backup_dir "$_pre_ods_candidate" && continue
         if _ods_is_related_install_dir "$_pre_ods_candidate"; then
             _pre_ods_findings+=("related install directory: $_pre_ods_candidate")
         fi

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -132,15 +132,86 @@ _ods_cli_bootstrap_status() {
         || true
 }
 
+_ods_cli_bootstrap_status_field() {
+    local key="$1" status_file="$INSTALL_DIR/data/bootstrap-status.json"
+    [[ -f "$status_file" ]] || return 0
+    grep -o "\"${key}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$status_file" \
+        | sed -n '1p' \
+        | sed "s/.*\"${key}\"[[:space:]]*:[[:space:]]*\"//" \
+        | sed 's/"//' \
+        || true
+}
+
+_ods_cli_bootstrap_status_number() {
+    local key="$1" status_file="$INSTALL_DIR/data/bootstrap-status.json"
+    [[ -f "$status_file" ]] || return 0
+    grep -o "\"${key}\"[[:space:]]*:[[:space:]]*[0-9][0-9.]*" "$status_file" \
+        | sed -n '1p' \
+        | sed "s/.*:[[:space:]]*//" \
+        || true
+}
+
+_ods_cli_file_size() {
+    local path="$1"
+    if stat -c %s "$path" 2>/dev/null; then
+        return 0
+    fi
+    stat -f %z "$path" 2>/dev/null || echo 0
+}
+
+_ods_cli_bootstrap_upgrade_process_running() {
+    local model="$1" args
+    [[ -n "$model" ]] || return 1
+    while IFS= read -r args; do
+        case "$args" in
+            *"/scripts/bootstrap-upgrade.sh"*" $model "*|*" scripts/bootstrap-upgrade.sh"*" $model "*)
+                return 0
+                ;;
+        esac
+    done < <(ps -eo args= 2>/dev/null || true)
+    return 1
+}
+
+_ods_cli_bootstrap_active_status_settled() {
+    local status="$1"
+    case "$status" in
+        downloading|starting|verifying|swapping) ;;
+        *) return 1 ;;
+    esac
+
+    local model env_model model_path expected_bytes actual_bytes
+    model="$(_ods_cli_bootstrap_status_field model)"
+    [[ -n "$model" ]] || return 1
+
+    if _ods_cli_bootstrap_upgrade_process_running "$model"; then
+        return 1
+    fi
+
+    env_model="$(_env_get_raw GGUF_FILE)"
+    [[ "$env_model" == "$model" ]] || return 1
+
+    model_path="$INSTALL_DIR/data/models/$model"
+    [[ -f "$model_path" ]] || return 1
+
+    expected_bytes="$(_ods_cli_bootstrap_status_number bytesTotal)"
+    if [[ "$expected_bytes" =~ ^[0-9]+$ ]] && (( expected_bytes > 0 )); then
+        actual_bytes="$(_ods_cli_file_size "$model_path")"
+        [[ "$actual_bytes" =~ ^[0-9]+$ ]] || return 1
+        (( actual_bytes >= expected_bytes )) || return 1
+    fi
+
+    return 0
+}
+
 _ods_cli_wait_for_bootstrap_compose_safe() {
     local action="${1:-service operation}"
     local status_file="$INSTALL_DIR/data/bootstrap-status.json"
     [[ -f "$status_file" ]] || return 0
 
-    local max_wait="${ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_SECONDS:-900}"
+    local max_wait="${ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_SECONDS:-1800}"
     local interval="${ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_INTERVAL:-5}"
     if ! [[ "$max_wait" =~ ^[0-9]+$ ]] || (( max_wait < 0 )); then
-        max_wait=900
+        max_wait=1800
     fi
     if ! [[ "$interval" =~ ^[0-9]+$ ]] || (( interval < 1 )); then
         interval=5
@@ -151,6 +222,14 @@ _ods_cli_wait_for_bootstrap_compose_safe() {
         status="$(_ods_cli_bootstrap_status)"
         case "$status" in
             downloading|starting|verifying|swapping)
+                if _ods_cli_bootstrap_active_status_settled "$status"; then
+                    if [[ "$announced" == "true" ]]; then
+                        log "  Model Upgrade: stale $status status already settled; continuing with $action"
+                    else
+                        warn "Model upgrade status is stale ($status) but the full model is already configured; continuing with $action."
+                    fi
+                    return 0
+                fi
                 if [[ "$announced" == "false" ]]; then
                     log "  Model Upgrade: $status; waiting before $action touches llama-server"
                     announced=true

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -150,7 +150,7 @@ _ods_cli_wait_for_bootstrap_compose_safe() {
     while true; do
         status="$(_ods_cli_bootstrap_status)"
         case "$status" in
-            starting|verifying|swapping)
+            downloading|starting|verifying|swapping)
                 if [[ "$announced" == "false" ]]; then
                     log "  Model Upgrade: $status; waiting before $action touches llama-server"
                     announced=true
@@ -904,6 +904,59 @@ _ods_cli_rebuild_images() {
     fi
 }
 
+_ods_cli_pull_external_images() {
+    local flags=("$@")
+    local helper="$INSTALL_DIR/installers/lib/compose-images.sh"
+
+    if ! command -v ods_compose_external_images >/dev/null 2>&1 && [[ -f "$helper" ]]; then
+        # Reuse the installer's image discovery contract: pull registry images,
+        # skip local build tags such as ods-lemonade-server:latest.
+        . "$helper"
+    fi
+
+    if ! command -v ods_compose_external_images >/dev/null 2>&1; then
+        _compose_run_with_summary "Pulling latest images" "${flags[@]}" pull
+        return
+    fi
+
+    local image_output=""
+    if ! image_output="$(ods_compose_external_images "docker compose" "${flags[@]}")"; then
+        warn "Could not resolve external Compose image list; falling back to docker compose pull."
+        _compose_run_with_summary "Pulling latest images" "${flags[@]}" pull
+        return
+    fi
+
+    local -a images=()
+    local image
+    while IFS= read -r image; do
+        [[ -n "$image" ]] && images+=("$image")
+    done <<< "$image_output"
+
+    if (( ${#images[@]} == 0 )); then
+        success "Pulling latest images — done"
+        return 0
+    fi
+
+    _check_docker_access
+    log "Pulling latest images..."
+
+    local count=0 total=${#images[@]} failed=0
+    for image in "${images[@]}"; do
+        count=$((count + 1))
+        log "  [$count/$total] $image"
+        if ! docker pull "$image"; then
+            failed=$((failed + 1))
+        fi
+    done
+
+    if (( failed > 0 )); then
+        log_error "Pulling latest images failed: $failed/$total image(s)"
+        return 1
+    fi
+
+    success "Pulling latest images — done"
+}
+
 #=============================================================================
 # Commands
 #=============================================================================
@@ -1217,6 +1270,10 @@ cmd_restart() {
 
     if [[ -z "$resolved_service" || "$resolved_service" == "llama-server" ]]; then
         _ods_cli_wait_for_bootstrap_compose_safe "restart"
+        load_env
+        ensure_llama_cpu_budget
+        flags_str=$(get_compose_flags)
+        read -ra flags <<< "$flags_str"
     fi
 
     if [[ -z "$resolved_service" ]]; then
@@ -1364,6 +1421,10 @@ cmd_start() {
 
     if [[ -z "$resolved_service" || "$resolved_service" == "llama-server" ]]; then
         _ods_cli_wait_for_bootstrap_compose_safe "start"
+        load_env
+        ensure_llama_cpu_budget
+        flags_str=$(get_compose_flags)
+        read -ra flags <<< "$flags_str"
     fi
 
     if [[ -z "$resolved_service" ]]; then
@@ -1596,9 +1657,15 @@ cmd_update() {
         warn "ods-update.sh and ods-backup.sh not found; skipping pre-update snapshot."
     fi
 
-    if ! _compose_run_with_summary "Pulling latest images" "${flags[@]}" pull; then
+    if ! _ods_cli_pull_external_images "${flags[@]}"; then
         error "Failed to pull latest images"
     fi
+
+    _ods_cli_wait_for_bootstrap_compose_safe "update"
+    load_env
+    ensure_llama_cpu_budget
+    flags_str=$(get_compose_flags)
+    read -ra flags <<< "$flags_str"
 
     [[ "$rebuild_images" == "true" ]] && _ods_cli_rebuild_images "${flags[@]}"
 

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -203,6 +203,34 @@ _ods_cli_bootstrap_active_status_settled() {
     return 0
 }
 
+_ods_cli_bootstrap_download_near_swap() {
+    local model percent percent_int downloaded total remaining threshold
+    model="$(_ods_cli_bootstrap_status_field model)"
+    [[ -n "$model" ]] || return 1
+    _ods_cli_bootstrap_upgrade_process_running "$model" || return 1
+
+    threshold="${ODS_CLI_BOOTSTRAP_COMPOSE_DOWNLOAD_WAIT_BYTES:-1073741824}"
+    if ! [[ "$threshold" =~ ^[0-9]+$ ]]; then
+        threshold=1073741824
+    fi
+
+    downloaded="$(_ods_cli_bootstrap_status_number bytesDownloaded)"
+    total="$(_ods_cli_bootstrap_status_number bytesTotal)"
+    if [[ "$downloaded" =~ ^[0-9]+$ && "$total" =~ ^[0-9]+$ ]] && (( total > 0 )); then
+        remaining=$(( total - downloaded ))
+        (( remaining < 0 )) && remaining=0
+        (( remaining <= threshold )) && return 0
+    fi
+
+    percent="$(_ods_cli_bootstrap_status_number percent)"
+    percent_int="${percent%%.*}"
+    if [[ "$percent_int" =~ ^[0-9]+$ ]] && (( percent_int >= 95 )); then
+        return 0
+    fi
+
+    return 1
+}
+
 _ods_cli_wait_for_bootstrap_compose_safe() {
     local action="${1:-service operation}"
     local status_file="$INSTALL_DIR/data/bootstrap-status.json"
@@ -221,7 +249,31 @@ _ods_cli_wait_for_bootstrap_compose_safe() {
     while true; do
         status="$(_ods_cli_bootstrap_status)"
         case "$status" in
-            downloading|starting|verifying|swapping)
+            downloading)
+                if _ods_cli_bootstrap_active_status_settled "$status"; then
+                    if [[ "$announced" == "true" ]]; then
+                        log "  Model Upgrade: stale $status status already settled; continuing with $action"
+                    else
+                        warn "Model upgrade status is stale ($status) but the full model is already configured; continuing with $action."
+                    fi
+                    return 0
+                fi
+                if ! _ods_cli_bootstrap_download_near_swap; then
+                    log "  Model Upgrade: downloading in background; continuing with $action before hot-swap begins"
+                    return 0
+                fi
+                if [[ "$announced" == "false" ]]; then
+                    log "  Model Upgrade: download nearly complete; waiting before $action touches llama-server"
+                    announced=true
+                fi
+                if (( waited >= max_wait )); then
+                    warn "Model upgrade is still $status after ${max_wait}s; refusing to run $action against an active hot-swap."
+                    return 1
+                fi
+                sleep "$interval"
+                waited=$(( waited + interval ))
+                ;;
+            starting|verifying|swapping)
                 if _ods_cli_bootstrap_active_status_settled "$status"; then
                     if [[ "$announced" == "true" ]]; then
                         log "  Model Upgrade: stale $status status already settled; continuing with $action"

--- a/ods/tests/bats-tests/preflight-phase.bats
+++ b/ods/tests/bats-tests/preflight-phase.bats
@@ -165,6 +165,7 @@ MOCK
         export DRY_RUN=false
         export PKG_MANAGER="apt"
         export VERSION="2.3.0"
+        export ODS_ALLOW_LEGACY_PARALLEL=1
 
         log() { :; }
         warn() { :; }

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -79,7 +79,7 @@ grep -qF 'ods/ods-cli text eol=lf' ../.gitattributes \
 
 _pre_ods_guard_tmp="$(mktemp -d)"
 _pre_ods_guard_harness="$_pre_ods_guard_tmp/bootstrap-guard.sh"
-for _pre_ods_helper in _ods_is_related_install_dir _ods_related_compose_containers; do
+for _pre_ods_helper in _ods_is_install_backup_dir _ods_is_related_install_dir _ods_related_compose_containers; do
   sed -n "/^${_pre_ods_helper}() {/,/^}/p" get-ods.sh \
     > "$_pre_ods_guard_tmp/bootstrap-${_pre_ods_helper}.sh"
   sed -n "/^${_pre_ods_helper}() {/,/^}/p" installers/phases/01-preflight.sh \
@@ -160,6 +160,25 @@ fi
 grep -qF 'related install directory' "$_pre_ods_guard_tmp/auto-path.log" \
   || { echo "[FAIL] dormant related-install rejection must identify the directory"; rm -rf "$_pre_ods_guard_tmp"; exit 1; }
 rm -rf "$_pre_ods_guard_tmp/home/related"
+
+mkdir -p "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646/data"
+touch "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646/.env"
+cat > "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646/docker-compose.base.yml" <<'COMPOSE'
+services:
+  llama-server:
+  open-webui:
+  dashboard-api:
+COMPOSE
+if ! PRE_ODS_INSTALL_DIR="" ODS_ALLOW_LEGACY_PARALLEL="" \
+    ODS_BOOTSTRAP_ROOT="$_pre_ods_guard_tmp/home" \
+    INSTALL_DIR="$_pre_ods_guard_tmp/new-install" \
+    bash "$_pre_ods_guard_harness" >"$_pre_ods_guard_tmp/backup-path.log" 2>&1; then
+  cat "$_pre_ods_guard_tmp/backup-path.log"
+  echo "[FAIL] bootstrap guard must ignore timestamped dormant backup directories"
+  rm -rf "$_pre_ods_guard_tmp"
+  exit 1
+fi
+rm -rf "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646"
 
 mkdir -p "$_pre_ods_guard_tmp/relocated/data"
 touch "$_pre_ods_guard_tmp/relocated/.env"

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -161,9 +161,9 @@ grep -qF 'related install directory' "$_pre_ods_guard_tmp/auto-path.log" \
   || { echo "[FAIL] dormant related-install rejection must identify the directory"; rm -rf "$_pre_ods_guard_tmp"; exit 1; }
 rm -rf "$_pre_ods_guard_tmp/home/related"
 
-mkdir -p "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646/data"
-touch "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646/.env"
-cat > "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646/docker-compose.base.yml" <<'COMPOSE'
+mkdir -p "$_pre_ods_guard_tmp/home/older-stack.backup-20260518-195646/data"
+touch "$_pre_ods_guard_tmp/home/older-stack.backup-20260518-195646/.env"
+cat > "$_pre_ods_guard_tmp/home/older-stack.backup-20260518-195646/docker-compose.base.yml" <<'COMPOSE'
 services:
   llama-server:
   open-webui:
@@ -178,7 +178,7 @@ if ! PRE_ODS_INSTALL_DIR="" ODS_ALLOW_LEGACY_PARALLEL="" \
   rm -rf "$_pre_ods_guard_tmp"
   exit 1
 fi
-rm -rf "$_pre_ods_guard_tmp/home/dream-server.backup-20260518-195646"
+rm -rf "$_pre_ods_guard_tmp/home/older-stack.backup-20260518-195646"
 
 mkdir -p "$_pre_ods_guard_tmp/relocated/data"
 touch "$_pre_ods_guard_tmp/relocated/.env"

--- a/ods/tests/contracts/test-installer-hardening.sh
+++ b/ods/tests/contracts/test-installer-hardening.sh
@@ -130,6 +130,8 @@ assert_contains "$bootstrap" 'zypper --non-interactive install -y git' "bootstra
 assert_contains "$bootstrap" 'zypper --non-interactive install -y curl' "bootstrap cannot install curl on zypper distros"
 assert_contains "$bootstrap" 'ODS_REF' "bootstrap should allow PR/fleet lanes to clone a matching ref"
 assert_contains "$bootstrap" 'clone_args\+=\(--branch "\$ODS_REF"\)' "bootstrap ref override should apply to git clone"
+assert_contains "$bootstrap" 'ods_ref_is_exact_sha' "bootstrap should detect exact commit SHA refs"
+assert_contains "$bootstrap" 'checkout_requested_sha_ref "\$ODS_REF"' "bootstrap should checkout exact SHA refs after cloning"
 assert_contains "$bootstrap" 'BOOTSTRAP_FORCE=false' "bootstrap should parse --force before incomplete install prompts"
 assert_contains "$bootstrap" 'BOOTSTRAP_NON_INTERACTIVE=false' "bootstrap should parse --non-interactive before incomplete install prompts"
 assert_contains "$bootstrap" 'Removing incomplete install because --force was provided' "bootstrap --force should remove incomplete install dirs without prompting"
@@ -137,6 +139,63 @@ assert_contains "$bootstrap" 'Re-run with --force to remove it automatically' "b
 assert_contains "$bootstrap" 'remove_install_dir()' "bootstrap should centralize incomplete install cleanup"
 assert_contains "$bootstrap" 'sudo -n rm -rf -- "\$target_dir"' "bootstrap --force should retry root-owned container data cleanup with sudo -n"
 assert_contains "$bootstrap" 'root-owned container data' "bootstrap sudo fallback should explain root-owned Docker data cleanup"
+
+echo "[contract] public bootstrap can install from an exact commit SHA"
+sha_repo="$tmpdir/sha-ref-repo"
+sha_home="$tmpdir/sha-home"
+sha_install="$tmpdir/sha-install"
+sha_marker="$tmpdir/sha-marker"
+mkdir -p "$sha_repo/ods/scripts" "$sha_repo/ods/extensions/library" "$sha_home" "$tmpdir/bin"
+cat > "$sha_repo/ods/install.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' first-commit > "${ODS_TEST_BOOTSTRAP_INSTALL_MARKER:?}"
+EOF
+chmod +x "$sha_repo/ods/install.sh"
+git -C "$sha_repo" init -q
+git -C "$sha_repo" add ods
+git -C "$sha_repo" \
+  -c user.name="ODS Test" \
+  -c user.email="ods-test@example.invalid" \
+  commit -q -m "first install payload"
+sha_ref="$(git -C "$sha_repo" rev-parse HEAD)"
+cat > "$sha_repo/ods/install.sh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' second-commit > "${ODS_TEST_BOOTSTRAP_INSTALL_MARKER:?}"
+EOF
+git -C "$sha_repo" add ods/install.sh
+git -C "$sha_repo" \
+  -c user.name="ODS Test" \
+  -c user.email="ods-test@example.invalid" \
+  commit -q -m "second install payload"
+
+cat > "$tmpdir/bin/docker" <<'EOF'
+#!/usr/bin/env bash
+case "${1:-}" in
+  --version) printf '%s\n' "Docker version test"; exit 0 ;;
+  compose|ps) exit 0 ;;
+esac
+exit 0
+EOF
+chmod +x "$tmpdir/bin/docker"
+
+if ! PATH="$tmpdir/bin:$PATH" \
+    HOME="$sha_home" \
+    ODS_BOOTSTRAP_ROOT="$sha_home" \
+    ODS_REPO_URL="file://$sha_repo" \
+    ODS_REF="$sha_ref" \
+    ODS_INSTALL_DIR="$sha_install" \
+    ODS_ALLOW_LEGACY_PARALLEL=1 \
+    ODS_TEST_BOOTSTRAP_INSTALL_MARKER="$sha_marker" \
+    bash get-ods.sh --non-interactive >"$tmpdir/bootstrap-sha.out" 2>&1; then
+  cat "$tmpdir/bootstrap-sha.out"
+  echo "[FAIL] bootstrap exact-SHA install failed"
+  exit 1
+fi
+grep -qF first-commit "$sha_marker" \
+  || { cat "$tmpdir/bootstrap-sha.out"; echo "[FAIL] bootstrap did not install the exact SHA payload"; exit 1; }
+assert_not_contains "$tmpdir/bootstrap-sha.out" 'Remote branch .* not found' "bootstrap treated an exact SHA as a branch name"
 
 echo "[contract] runtime dispatcher supports non-gnu Linux OSTYPE"
 dispatcher_common="installers/common.sh"

--- a/ods/tests/test-cli-bootstrap-compose-wait.sh
+++ b/ods/tests/test-cli-bootstrap-compose-wait.sh
@@ -108,6 +108,13 @@ echo ""
 echo "=== CLI bootstrap compose wait test ==="
 echo ""
 
+grep -q 'ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_SECONDS:-1800' "$ROOT_DIR/ods-cli" \
+    || fail "bootstrap compose wait default must cover release lifecycle's 1800s update window"
+grep -q 'max_wait=1800' "$ROOT_DIR/ods-cli" \
+    || fail "invalid bootstrap compose wait override must fall back to 1800s"
+
+pass "bootstrap compose wait default matches release lifecycle update window"
+
 PATH="$BIN_DIR:$PATH" \
 ODS_HOME="$INSTALL_DIR" \
 DOCKER_LOG="$DOCKER_LOG" \
@@ -125,3 +132,44 @@ if grep -q 'COMPOSE_GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf' "$DOCKER_LOG"; then
 fi
 
 pass "restart waits for bootstrap upgrade and reloads .env before compose"
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
+ODS_VERSION=2.0.0
+GPU_BACKEND=nvidia
+TIER=4
+LLM_MODEL=qwen3.6-35b-a3b
+GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
+MAX_CONTEXT=131072
+CTX_SIZE=131072
+SHIELD_API_KEY=test-fixture-key
+EOF
+
+cat > "$INSTALL_DIR/data/bootstrap-status.json" <<'EOF'
+{
+  "status": "swapping",
+  "model": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+  "percent": 100,
+  "bytesDownloaded": 100,
+  "bytesTotal": 100,
+  "speedBytesPerSec": 0,
+  "eta": "",
+  "updatedAt": "2026-07-19T00:00:02Z"
+}
+EOF
+mkdir -p "$INSTALL_DIR/data/models"
+dd if=/dev/zero of="$INSTALL_DIR/data/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf" bs=100 count=1 >/dev/null 2>&1
+: > "$DOCKER_LOG"
+
+PATH="$BIN_DIR:$PATH" \
+ODS_HOME="$INSTALL_DIR" \
+DOCKER_LOG="$DOCKER_LOG" \
+ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_SECONDS=0 \
+bash "$INSTALL_DIR/ods-cli" restart > "$OUT" 2>&1 || fail "ods restart rejected stale settled bootstrap status"
+
+grep -q 'stale (swapping) but the full model is already configured' "$OUT" \
+    || fail "restart did not identify stale settled bootstrap status"
+
+grep -q 'COMPOSE_GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf' "$DOCKER_LOG" \
+    || fail "restart did not continue with full-model GGUF after stale settled status"
+
+pass "restart treats stale settled bootstrap status as safe"

--- a/ods/tests/test-cli-bootstrap-compose-wait.sh
+++ b/ods/tests/test-cli-bootstrap-compose-wait.sh
@@ -1,9 +1,7 @@
 #!/usr/bin/env bash
 # Regression: CLI lifecycle commands must not race the background bootstrap
-# model upgrade. If restart/start compose while bootstrap-status is still
-# downloading, the hot-swap can finish after the CLI has already exported the
-# bootstrap GGUF from .env, causing compose to recreate llama-server with a
-# model file the upgrade just removed.
+# model upgrade near hot-swap, but must also not block for hours while a large
+# full-model download is still safely writing only its .part file.
 
 set -euo pipefail
 
@@ -78,6 +76,19 @@ exit 0
 SH
 chmod +x "$BIN_DIR/docker"
 
+cat > "$BIN_DIR/ps" <<'SH'
+#!/usr/bin/env bash
+if [[ "${ODS_FAKE_BOOTSTRAP_PROCESS:-}" == "1" && "${1:-}" == "-eo" && "${2:-}" == "args=" ]]; then
+    echo "bash ${ODS_HOME:?}/scripts/bootstrap-upgrade.sh ${ODS_HOME:?} Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --fixture"
+    exit 0
+fi
+if [[ -x /bin/ps ]]; then
+    exec /bin/ps "$@"
+fi
+exit 0
+SH
+chmod +x "$BIN_DIR/ps"
+
 cat > "$BIN_DIR/sleep" <<'SH'
 #!/usr/bin/env bash
 cat > "${ODS_HOME:?}/data/bootstrap-status.json" <<'JSON'
@@ -118,11 +129,12 @@ pass "bootstrap compose wait default matches release lifecycle update window"
 PATH="$BIN_DIR:$PATH" \
 ODS_HOME="$INSTALL_DIR" \
 DOCKER_LOG="$DOCKER_LOG" \
+ODS_FAKE_BOOTSTRAP_PROCESS=1 \
 ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_INTERVAL=1 \
 bash "$INSTALL_DIR/ods-cli" restart > "$OUT" 2>&1 || fail "ods restart failed"
 
-grep -q 'Model Upgrade: downloading; waiting before restart touches llama-server' "$OUT" \
-    || fail "restart did not wait while bootstrap upgrade was downloading"
+grep -q 'Model Upgrade: download nearly complete; waiting before restart touches llama-server' "$OUT" \
+    || fail "restart did not wait while bootstrap upgrade was near hot-swap"
 
 grep -q 'COMPOSE_GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf' "$DOCKER_LOG" \
     || fail "compose did not receive the reloaded full-model GGUF_FILE"
@@ -132,6 +144,50 @@ if grep -q 'COMPOSE_GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf' "$DOCKER_LOG"; then
 fi
 
 pass "restart waits for bootstrap upgrade and reloads .env before compose"
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
+ODS_VERSION=2.0.0
+GPU_BACKEND=nvidia
+TIER=4
+LLM_MODEL=qwen3.5-2b
+GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf
+MAX_CONTEXT=65536
+CTX_SIZE=65536
+SHIELD_API_KEY=test-fixture-key
+EOF
+
+cat > "$INSTALL_DIR/data/bootstrap-status.json" <<'EOF'
+{
+  "status": "downloading",
+  "model": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+  "percent": 0.4,
+  "bytesDownloaded": 186867712,
+  "bytesTotal": 48528320544,
+  "speedBytesPerSec": 3041280,
+  "eta": "264m 55s",
+  "updatedAt": "2026-07-19T00:00:02Z"
+}
+EOF
+: > "$DOCKER_LOG"
+
+PATH="$BIN_DIR:$PATH" \
+ODS_HOME="$INSTALL_DIR" \
+DOCKER_LOG="$DOCKER_LOG" \
+ODS_FAKE_BOOTSTRAP_PROCESS=1 \
+ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_INTERVAL=1 \
+bash "$INSTALL_DIR/ods-cli" restart > "$OUT" 2>&1 || fail "ods restart blocked early background download"
+
+grep -q 'Model Upgrade: downloading in background; continuing with restart before hot-swap begins' "$OUT" \
+    || fail "restart did not continue during early background download"
+
+grep -q 'COMPOSE_GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf' "$DOCKER_LOG" \
+    || fail "compose did not continue with bootstrap GGUF during early background download"
+
+if grep -q 'COMPOSE_GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf' "$DOCKER_LOG"; then
+    fail "compose unexpectedly waited for full-model GGUF during early background download"
+fi
+
+pass "restart proceeds during early background download without waiting for full model"
 
 cat > "$INSTALL_DIR/.env" <<'EOF'
 ODS_VERSION=2.0.0

--- a/ods/tests/test-cli-bootstrap-compose-wait.sh
+++ b/ods/tests/test-cli-bootstrap-compose-wait.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Regression: CLI lifecycle commands must not race the background bootstrap
+# model upgrade. If restart/start compose while bootstrap-status is still
+# downloading, the hot-swap can finish after the CLI has already exported the
+# bootstrap GGUF from .env, causing compose to recreate llama-server with a
+# model file the upgrade just removed.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+GREEN='\033[0;32m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+pass() { echo -e "  ${GREEN}PASS${NC} $1"; }
+fail() {
+    echo -e "  ${RED}FAIL${NC} $1" >&2
+    [[ -f "${OUT:-}" ]] && sed 's/^/[ods] /' "$OUT" >&2
+    [[ -f "${DOCKER_LOG:-}" ]] && sed 's/^/[docker] /' "$DOCKER_LOG" >&2
+    exit 1
+}
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/ods-cli-bootstrap-wait.XXXXXX")"
+trap 'rm -rf "$TMP"' EXIT
+
+INSTALL_DIR="$TMP/install"
+BIN_DIR="$TMP/bin"
+OUT="$TMP/ods.out"
+DOCKER_LOG="$TMP/docker.log"
+mkdir -p "$INSTALL_DIR/lib" "$INSTALL_DIR/bin" "$INSTALL_DIR/data" "$BIN_DIR"
+cp "$ROOT_DIR/ods-cli" "$INSTALL_DIR/ods-cli"
+cp "$ROOT_DIR"/lib/*.sh "$INSTALL_DIR/lib/"
+: > "$INSTALL_DIR/docker-compose.base.yml"
+
+cat > "$INSTALL_DIR/.env" <<'EOF'
+ODS_VERSION=2.0.0
+GPU_BACKEND=nvidia
+TIER=4
+LLM_MODEL=qwen3.5-2b
+GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf
+MAX_CONTEXT=65536
+CTX_SIZE=65536
+SHIELD_API_KEY=test-fixture-key
+EOF
+
+cat > "$INSTALL_DIR/data/bootstrap-status.json" <<'EOF'
+{
+  "status": "downloading",
+  "model": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+  "percent": 99.0,
+  "bytesDownloaded": 99,
+  "bytesTotal": 100,
+  "speedBytesPerSec": 1,
+  "eta": "",
+  "updatedAt": "2026-07-19T00:00:00Z"
+}
+EOF
+
+cat > "$BIN_DIR/docker" <<'SH'
+#!/usr/bin/env bash
+echo "DOCKER_ARGS: $*" >> "${DOCKER_LOG:?}"
+case "${1:-}" in
+    info)
+        echo "8"
+        ;;
+    ps)
+        exit 0
+        ;;
+    compose)
+        if [[ " $* " == *" up "* ]]; then
+            echo "COMPOSE_GGUF_FILE=${GGUF_FILE:-}" >> "${DOCKER_LOG:?}"
+        fi
+        exit 0
+        ;;
+esac
+exit 0
+SH
+chmod +x "$BIN_DIR/docker"
+
+cat > "$BIN_DIR/sleep" <<'SH'
+#!/usr/bin/env bash
+cat > "${ODS_HOME:?}/data/bootstrap-status.json" <<'JSON'
+{
+  "status": "complete",
+  "model": "Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+  "percent": 100,
+  "bytesDownloaded": 100,
+  "bytesTotal": 100,
+  "speedBytesPerSec": 0,
+  "eta": "",
+  "updatedAt": "2026-07-19T00:00:01Z"
+}
+JSON
+awk '
+  /^LLM_MODEL=/ { print "LLM_MODEL=qwen3.6-35b-a3b"; next }
+  /^GGUF_FILE=/ { print "GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"; next }
+  /^MAX_CONTEXT=/ { print "MAX_CONTEXT=131072"; next }
+  /^CTX_SIZE=/ { print "CTX_SIZE=131072"; next }
+  { print }
+' "${ODS_HOME:?}/.env" > "${ODS_HOME:?}/.env.tmp"
+mv "${ODS_HOME:?}/.env.tmp" "${ODS_HOME:?}/.env"
+exit 0
+SH
+chmod +x "$BIN_DIR/sleep"
+
+echo ""
+echo "=== CLI bootstrap compose wait test ==="
+echo ""
+
+PATH="$BIN_DIR:$PATH" \
+ODS_HOME="$INSTALL_DIR" \
+DOCKER_LOG="$DOCKER_LOG" \
+ODS_CLI_BOOTSTRAP_COMPOSE_WAIT_INTERVAL=1 \
+bash "$INSTALL_DIR/ods-cli" restart > "$OUT" 2>&1 || fail "ods restart failed"
+
+grep -q 'Model Upgrade: downloading; waiting before restart touches llama-server' "$OUT" \
+    || fail "restart did not wait while bootstrap upgrade was downloading"
+
+grep -q 'COMPOSE_GGUF_FILE=Qwen3.6-35B-A3B-UD-Q4_K_M.gguf' "$DOCKER_LOG" \
+    || fail "compose did not receive the reloaded full-model GGUF_FILE"
+
+if grep -q 'COMPOSE_GGUF_FILE=Qwen3.5-2B-Q4_K_M.gguf' "$DOCKER_LOG"; then
+    fail "compose still received the stale bootstrap GGUF_FILE"
+fi
+
+pass "restart waits for bootstrap upgrade and reloads .env before compose"

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -79,6 +79,8 @@ assert_grep "installers/macos/lib/env-generator.sh" '^MAX_CONTEXT=\$\{MAX_CONTEX
     "macOS .env generator writes MAX_CONTEXT"
 assert_grep "installers/macos/lib/env-generator.sh" '^CTX_SIZE=\$\{MAX_CONTEXT\}$' \
     "macOS .env generator writes CTX_SIZE from MAX_CONTEXT"
+assert_grep "installers/macos/lib/env-generator.sh" '^LLM_BACKEND=llama-server$' \
+    "macOS .env generator declares native llama-server backend"
 assert_grep "installers/windows/lib/env-generator.ps1" '^MAX_CONTEXT=\$\(\$TierConfig\.MaxContext\)' \
     "Windows .env generator writes MAX_CONTEXT"
 assert_grep "installers/windows/lib/env-generator.ps1" '^CTX_SIZE=\$\(\$TierConfig\.MaxContext\)' \


### PR DESCRIPTION
Standalone fixes surfaced by the 2026-07-19 fleet release sweep of the open fix-PR set (integration branch `codex/fix-pr-sweep-20260719`). These patch code that predates the open PRs, so no open PR owns them:

- **Exact-SHA bootstrap refs**: `get-ods.sh` now clones+detaches for 40-char commit SHAs instead of failing `git clone --branch <sha>` (fleet pins installs to immutable SHAs). Regression: installer contract builds a 2-commit repo and installs the older SHA.
- **Dormant install backups**: timestamped `*.backup-*` sibling dirs no longer trip the legacy-coexistence guard; live containers and explicit `ODS_LEGACY_INSTALL_DIR` still fail loud. Seen on the macOS fleet host.
- **Update pulls registry images only**: `ods update` no longer tries to `docker compose pull` locally built image tags (AMD/Lemonade lane failed on `ods-lemonade-server:latest`).
- **Bootstrap-safe start/restart/update**: waits for an active model bootstrap (downloading/verifying/swapping) before composing, reloads `.env` after the wait, and treats a stale active status with no live upgrader and the target model already landed as settled. Regressions in `test-cli-bootstrap-compose-wait.sh`.
- **Test hermeticity**: preflight BATS positive-path case isolated from host installs; legacy fixture renamed.

Evidence: proven on the 4-host fleet release runs (tower2/strix-halo/spark/m5-mbp) at `b7a43b23`→`ab5528cb`; the update-verification test additions that depend on #1717's test file ride with #1717.

Note: the one-shot `startup_check` verification fix was pushed to #1717 directly; the port-default contract to #1835; the plist fix to #1833; the scheduled-task contract to #1758.

🤖 Generated with [Claude Code](https://claude.com/claude-code)