### PR TITLE
feat(setup): apply first-boot stack selection

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -644,7 +644,7 @@ def _get_service_data_info(service_id: str) -> dict | None:
 
 # --- Host Agent Helpers ---
 
-_AGENT_TIMEOUT = 300  # seconds — image pulls can take several minutes on first install
+_AGENT_TIMEOUT = 660  # seconds — exceed the host agent's 600s start allowance
 _AGENT_LOG_TIMEOUT = 30  # seconds — log fetches should be fast
 
 

--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -127,6 +127,7 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
         _get_missing_deps_transitive, _read_direct_deps, _validate_service_id,
         _install_from_library, _is_installable,
         _call_agent_invalidate_compose_cache,
+        _has_error_progress, _write_error_progress,
     )
 
     # Blocking sections run in the thread pool so the event loop stays
@@ -141,6 +142,9 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
     def _activate_with_lock(sid: str, missing_deps, prior_results):
         deps_enabled: list[str] = []
         with _extensions_lock():
+            # Validate the whole dependency plan before the first compose
+            # mutation. A later incompatibility must not leave earlier deps
+            # silently enabled.
             for dep in missing_deps:
                 compatibility_error = _gpu_backend_error(dep)
                 if compatibility_error:
@@ -160,13 +164,25 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
                         status_code=424,
                         detail=f"Dependency {dep} was not enabled: {prior_outcome}",
                     )
-                dep_result = _activate_service(dep)
-                if dep_result.get("action") == "enabled":
-                    deps_enabled.append(dep)
-            main_result = _activate_service(sid)
+
+            try:
+                for dep in missing_deps:
+                    if dep in prior_results:
+                        continue
+                    dep_result = _activate_service(dep)
+                    if dep_result.get("action") == "enabled":
+                        deps_enabled.append(dep)
+                main_result = _activate_service(sid)
+            except HTTPException as exc:
+                # Compose activation is additive. Surface any dependency that
+                # was already enabled before a later activation failed so the
+                # caller can start and report it instead of losing that state.
+                if deps_enabled:
+                    _call_agent_invalidate_compose_cache()
+                return deps_enabled, None, exc
             if deps_enabled or main_result.get("action") == "enabled":
                 _call_agent_invalidate_compose_cache()
-        return deps_enabled, main_result
+        return deps_enabled, main_result, None
 
     service_list = get_cached_services()
     if service_list is None:
@@ -204,11 +220,29 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
             # _install_from_library produces a directory with compose.yaml
             # already in place (not compose.yaml.disabled), so _activate_service
             # will report "already_enabled" afterwards — we still want to start it.
-            if _is_installable(svc_id) and not (USER_EXTENSIONS_DIR / svc_id).is_dir():
+            installable = _is_installable(svc_id)
+            installed_dir_exists = (USER_EXTENSIONS_DIR / svc_id).is_dir()
+            has_install_error = (
+                await asyncio.to_thread(_has_error_progress, svc_id)
+                if installable and installed_dir_exists
+                else False
+            )
+            needs_library_install = installable and (
+                not installed_dir_exists or has_install_error
+            )
+            if needs_library_install:
                 try:
                     await asyncio.to_thread(_install_with_lock, svc_id)
-                    await asyncio.to_thread(_call_agent_hook, svc_id, "post_install")
                     library_installed.append(svc_id)
+                    post_install_ok = await asyncio.to_thread(
+                        _call_agent_hook, svc_id, "post_install",
+                    )
+                    if not post_install_ok:
+                        message = "post_install hook failed; retry template apply after fixing the hook"
+                        await asyncio.to_thread(_write_error_progress, svc_id, message)
+                        results[svc_id] = f"skipped: {message}"
+                        warnings.append(f"{svc_id}: {message}")
+                        continue
                 except HTTPException as exc:
                     detail = exc.detail if isinstance(exc.detail, str) else str(exc.detail)
                     logger.warning(
@@ -222,12 +256,21 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
             # _activate_service checks both user-installed and built-in extension dirs.
             missing_deps = await asyncio.to_thread(_get_missing_deps_transitive, svc_id)
 
-            deps_enabled, result = await asyncio.to_thread(
+            deps_enabled, result, activation_error = await asyncio.to_thread(
                 _activate_with_lock, svc_id, missing_deps, results,
             )
             for dep in deps_enabled:
                 enabled_services.append(dep)
                 results[dep] = "enabled_as_dependency"
+
+            if activation_error is not None:
+                detail = (
+                    activation_error.detail
+                    if isinstance(activation_error.detail, str)
+                    else str(activation_error.detail)
+                )
+                results[svc_id] = f"skipped: {detail}"
+                continue
 
             action = result.get("action", "skipped")
             if svc_id in library_installed:
@@ -277,6 +320,7 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
             else:
                 results[svc_id] = "enabled_but_start_failed"
             failed_services.append(svc_id)
+            continue
 
         post_start_ok = await asyncio.to_thread(_call_agent_hook, svc_id, "post_start")
         if not post_start_ok:

--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -16,6 +16,23 @@ _BASE_COMPOSE_SERVICES = frozenset({"llama-server", "open-webui", "dashboard", "
 router = APIRouter(tags=["templates"])
 
 
+def _gpu_backend_error(service_id: str) -> str | None:
+    """Return a compatibility error for a service on the current GPU backend."""
+    service_config = SERVICES.get(service_id)
+    if service_config is None:
+        service_config = next(
+            (entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id),
+            None,
+        )
+    if not service_config or GPU_BACKEND == "apple":
+        return None
+
+    gpu_backends = service_config.get("gpu_backends", ["amd", "nvidia", "apple"])
+    if "all" in gpu_backends or GPU_BACKEND in gpu_backends:
+        return None
+    return f"requires one of {gpu_backends}; current backend is {GPU_BACKEND}"
+
+
 @router.get("/api/templates")
 async def list_templates(api_key: str = Depends(verify_api_key)):
     """List all available service templates."""
@@ -46,7 +63,6 @@ async def preview_template(template_id: str, api_key: str = Depends(verify_api_k
     warnings = []
 
     for svc_id in template.get("services", []):
-        svc_config = SERVICES.get(svc_id)
         svc_status = services_by_id.get(svc_id)
 
         # Core services are always running — treat as already enabled
@@ -72,13 +88,11 @@ async def preview_template(template_id: str, api_key: str = Depends(verify_api_k
             already_enabled.append(svc_id)
             continue
 
-        # Check GPU compatibility (from manifest data in SERVICES)
-        if svc_config:
-            gpu_backends = svc_config.get("gpu_backends", ["amd", "nvidia", "apple"])
-            if GPU_BACKEND != "apple" and GPU_BACKEND not in gpu_backends and "all" not in gpu_backends:
-                incompatible.append(svc_id)
-                warnings.append(f"{svc_id} gpu_backends {gpu_backends} - your system: {GPU_BACKEND}")
-                continue
+        compatibility_error = _gpu_backend_error(svc_id)
+        if compatibility_error:
+            incompatible.append(svc_id)
+            warnings.append(f"{svc_id}: {compatibility_error}")
+            continue
 
         to_enable.append(svc_id)
 
@@ -128,6 +142,12 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
         deps_enabled: list[str] = []
         with _extensions_lock():
             for dep in missing_deps:
+                compatibility_error = _gpu_backend_error(dep)
+                if compatibility_error:
+                    raise HTTPException(
+                        status_code=424,
+                        detail=f"Dependency {dep} is incompatible: {compatibility_error}",
+                    )
                 if dep in prior_results:
                     prior_outcome = prior_results[dep]
                     prior_succeeded = prior_outcome in {
@@ -171,14 +191,11 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
             results[svc_id] = "core_service"
             continue
 
-        svc_config = SERVICES.get(svc_id)
-        if svc_config:
-            gpu_backends = svc_config.get("gpu_backends", ["amd", "nvidia", "apple"])
-            if GPU_BACKEND != "apple" and GPU_BACKEND not in gpu_backends and "all" not in gpu_backends:
-                detail = f"requires one of {gpu_backends}; current backend is {GPU_BACKEND}"
-                results[svc_id] = f"skipped: incompatible GPU backend: {detail}"
-                warnings.append(f"{svc_id}: {detail}")
-                continue
+        compatibility_error = _gpu_backend_error(svc_id)
+        if compatibility_error:
+            results[svc_id] = f"skipped: incompatible GPU backend: {compatibility_error}"
+            warnings.append(f"{svc_id}: {compatibility_error}")
+            continue
 
         try:
             _validate_service_id(svc_id)

--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -382,6 +382,23 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
             )
             continue
 
+        if svc_id not in library_installed:
+            # Built-ins declaring a setup/post_install hook (e.g. langfuse's
+            # data-dir chown) have never run it when they were disabled at
+            # install time; starting them without it reproduces the hook's
+            # documented first-start failure. Hooks are no-ops when
+            # undeclared and idempotent by lifecycle contract.
+            post_install_ok = await asyncio.to_thread(
+                _call_agent_hook, svc_id, "post_install",
+            )
+            if not post_install_ok:
+                results[svc_id] = "enabled_but_post_install_failed"
+                failed_services.append(svc_id)
+                warnings.append(
+                    f"{svc_id}: post_install hook failed; service was not started",
+                )
+                continue
+
         pre_start_ok = await asyncio.to_thread(_call_agent_hook, svc_id, "pre_start")
         if not pre_start_ok:
             results[svc_id] = "enabled_but_pre_start_failed"

--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -127,7 +127,7 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
         _get_missing_deps_transitive, _read_direct_deps, _validate_service_id,
         _install_from_library, _is_installable,
         _call_agent_invalidate_compose_cache,
-        _has_error_progress, _write_error_progress,
+        _has_error_progress, _sync_extension_config, _write_error_progress,
     )
 
     # Blocking sections run in the thread pool so the event loop stays
@@ -234,6 +234,13 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
                 try:
                     await asyncio.to_thread(_install_with_lock, svc_id)
                     library_installed.append(svc_id)
+                    config_synced = await asyncio.to_thread(_sync_extension_config, svc_id)
+                    if not config_synced:
+                        message = "extension config sync failed; retry template apply after restoring the host agent"
+                        await asyncio.to_thread(_write_error_progress, svc_id, message)
+                        results[svc_id] = f"skipped: {message}"
+                        warnings.append(f"{svc_id}: {message}")
+                        continue
                     post_install_ok = await asyncio.to_thread(
                         _call_agent_hook, svc_id, "post_install",
                     )

--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -16,6 +16,46 @@ _BASE_COMPOSE_SERVICES = frozenset({"llama-server", "open-webui", "dashboard", "
 router = APIRouter(tags=["templates"])
 
 
+def _runtime_dependency_order(
+    service_id: str,
+    read_direct_deps,
+    *,
+    _visiting: set[str] | None = None,
+    _visited: set[str] | None = None,
+    _order: list[str] | None = None,
+) -> list[str]:
+    """Return every dependency in leaves-first runtime start order."""
+    if _visiting is None:
+        _visiting = set()
+    if _visited is None:
+        _visited = set()
+    if _order is None:
+        _order = []
+
+    if service_id in _visiting:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Circular dependency detected involving: {service_id}",
+        )
+    if service_id in _visited:
+        return _order
+
+    _visiting.add(service_id)
+    for dep in read_direct_deps(service_id):
+        _runtime_dependency_order(
+            dep,
+            read_direct_deps,
+            _visiting=_visiting,
+            _visited=_visited,
+            _order=_order,
+        )
+        if dep not in _order:
+            _order.append(dep)
+    _visiting.remove(service_id)
+    _visited.add(service_id)
+    return _order
+
+
 def _gpu_backend_error(service_id: str) -> str | None:
     """Return a compatibility error for a service on the current GPU backend."""
     service_config = SERVICES.get(service_id)
@@ -259,7 +299,14 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
                     results[svc_id] = f"skipped: install failed: {detail}"
                     continue
 
-            # Dep-aware enable: resolve transitive deps, activate leaves first.
+            # Resolve the complete runtime dependency tree separately from the
+            # activation plan. An existing compose.yaml means enabled on disk,
+            # but does not prove that the dependency container is running.
+            runtime_deps = await asyncio.to_thread(
+                _runtime_dependency_order, svc_id, _read_direct_deps,
+            )
+
+            # Dep-aware enable: resolve missing deps, activate leaves first.
             # _activate_service checks both user-installed and built-in extension dirs.
             missing_deps = await asyncio.to_thread(_get_missing_deps_transitive, svc_id)
 
@@ -277,6 +324,28 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
                     else str(activation_error.detail)
                 )
                 results[svc_id] = f"skipped: {detail}"
+                continue
+
+            dependency_failed = False
+            successful_outcomes = {
+                "already_enabled", "core_service", "enabled",
+                "enabled_as_dependency", "library_installed",
+            }
+            for dep in runtime_deps:
+                dep_status = services_by_id.get(dep)
+                if dep in _BASE_COMPOSE_SERVICES or (
+                    dep_status and dep_status.status == "healthy"
+                ):
+                    continue
+                prior_outcome = results.get(dep)
+                if prior_outcome is not None and prior_outcome not in successful_outcomes:
+                    results[svc_id] = f"skipped: dependency {dep} was not enabled: {prior_outcome}"
+                    dependency_failed = True
+                    break
+                if prior_outcome is None:
+                    results[dep] = "already_enabled"
+                enabled_services.append(dep)
+            if dependency_failed:
                 continue
 
             action = result.get("action", "skipped")

--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -146,6 +146,7 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
     results = {}
     enabled_services = []
     library_installed: list[str] = []
+    warnings: list[str] = []
 
     for svc_id in template.get("services", []):
         # Skip services already healthy
@@ -159,6 +160,15 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
         if svc_id in _BASE_COMPOSE_SERVICES:
             results[svc_id] = "core_service"
             continue
+
+        svc_config = SERVICES.get(svc_id)
+        if svc_config:
+            gpu_backends = svc_config.get("gpu_backends", ["amd", "nvidia", "apple"])
+            if GPU_BACKEND != "apple" and GPU_BACKEND not in gpu_backends and "all" not in gpu_backends:
+                detail = f"requires one of {gpu_backends}; current backend is {GPU_BACKEND}"
+                results[svc_id] = f"skipped: incompatible GPU backend: {detail}"
+                warnings.append(f"{svc_id}: {detail}")
+                continue
 
         try:
             _validate_service_id(svc_id)
@@ -206,36 +216,50 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
             logger.warning("Template apply skipped %s: %s", svc_id, detail)
             results[svc_id] = f"skipped: {detail}"
 
-    # Start enabled services via agent (outside locks)
-    for svc_id in enabled_services:
-        # Host agent can only start user-installed extensions
-        user_ext_dir = USER_EXTENSIONS_DIR / svc_id
-        if user_ext_dir.is_dir():
-            await asyncio.to_thread(_call_agent_hook, svc_id, "pre_start")
-            start_ok = await asyncio.to_thread(_call_agent, "start", svc_id)
-            if not start_ok:
-                # Preserve library_installed label — user-visible install succeeded,
-                # only the start call failed.
-                if results.get(svc_id) != "library_installed":
-                    results[svc_id] = "enabled_but_start_failed"
-                else:
-                    logger.warning("Library-installed extension %s failed to start via agent", svc_id)
-            await asyncio.to_thread(_call_agent_hook, svc_id, "post_start")
-        elif svc_id not in library_installed:
-            # Built-in extension: compose file toggled, needs stack restart
-            results[svc_id] = "enabled"
+    # A dependency may also appear later as a top-level template service.
+    # Start each service once while preserving dependency order.
+    enabled_services = list(dict.fromkeys(enabled_services))
 
-    any_builtin = any(
-        not (USER_EXTENSIONS_DIR / svc_id).is_dir()
-        for svc_id in enabled_services
-    )
-    # Library installs add new services to the compose stack → restart needed
-    restart_required = any_builtin or bool(library_installed)
+    # Start enabled services via the same host-agent lifecycle used by the
+    # individual extension endpoint. Built-in extensions are valid host-agent
+    # targets too; the old user-extension-only gate left them enabled on disk
+    # but stopped until a manual full-stack restart.
+    failed_services: list[str] = []
+    for svc_id in enabled_services:
+        pre_start_ok = await asyncio.to_thread(_call_agent_hook, svc_id, "pre_start")
+        if not pre_start_ok:
+            results[svc_id] = "enabled_but_pre_start_failed"
+            failed_services.append(svc_id)
+            warnings.append(f"{svc_id}: pre_start hook failed; service was not started")
+            continue
+
+        start_ok = await asyncio.to_thread(_call_agent, "start", svc_id)
+        if not start_ok:
+            if svc_id in library_installed:
+                results[svc_id] = "library_installed_but_start_failed"
+            else:
+                results[svc_id] = "enabled_but_start_failed"
+            failed_services.append(svc_id)
+
+        post_start_ok = await asyncio.to_thread(_call_agent_hook, svc_id, "post_start")
+        if not post_start_ok:
+            warnings.append(f"{svc_id}: post_start hook failed; manual configuration may be needed")
+
+    skipped_services = [
+        service_id
+        for service_id, outcome in results.items()
+        if isinstance(outcome, str) and outcome.startswith("skipped:")
+    ]
+    restart_required = bool(failed_services)
 
     return {
         "template_id": template_id,
         "results": results,
         "enabled_count": len(enabled_services),
+        "started_count": len(enabled_services) - len(failed_services),
         "library_installed": library_installed,
+        "failed_services": failed_services,
+        "skipped_services": skipped_services,
+        "warnings": warnings,
         "restart_required": restart_required,
     }

--- a/ods/extensions/services/dashboard-api/routers/templates.py
+++ b/ods/extensions/services/dashboard-api/routers/templates.py
@@ -110,7 +110,7 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
     from helpers import get_cached_services, get_all_services
     from routers.extensions import (
         _activate_service, _extensions_lock, _call_agent, _call_agent_hook,
-        _get_missing_deps_transitive, _validate_service_id,
+        _get_missing_deps_transitive, _read_direct_deps, _validate_service_id,
         _install_from_library, _is_installable,
         _call_agent_invalidate_compose_cache,
     )
@@ -129,7 +129,17 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
         with _extensions_lock():
             for dep in missing_deps:
                 if dep in prior_results:
-                    continue
+                    prior_outcome = prior_results[dep]
+                    prior_succeeded = prior_outcome in {
+                        "already_enabled", "core_service", "enabled",
+                        "enabled_as_dependency", "library_installed",
+                    }
+                    if prior_succeeded:
+                        continue
+                    raise HTTPException(
+                        status_code=424,
+                        detail=f"Dependency {dep} was not enabled: {prior_outcome}",
+                    )
                 dep_result = _activate_service(dep)
                 if dep_result.get("action") == "enabled":
                     deps_enabled.append(dep)
@@ -226,6 +236,16 @@ async def apply_template(template_id: str, api_key: str = Depends(verify_api_key
     # but stopped until a manual full-stack restart.
     failed_services: list[str] = []
     for svc_id in enabled_services:
+        direct_deps = await asyncio.to_thread(_read_direct_deps, svc_id)
+        blocked_deps = [dep for dep in direct_deps if dep in failed_services]
+        if blocked_deps:
+            results[svc_id] = "enabled_but_dependency_failed"
+            failed_services.append(svc_id)
+            warnings.append(
+                f"{svc_id}: not started because dependencies failed: {', '.join(blocked_deps)}",
+            )
+            continue
+
         pre_start_ok = await asyncio.to_thread(_call_agent_hook, svc_id, "pre_start")
         if not pre_start_ok:
             results[svc_id] = "enabled_but_pre_start_failed"

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -453,6 +453,7 @@ async def test_template_apply_reports_builtin_start_failure(tmp_path):
         "services": ["builtin-svc"],
     }]
     mock_activate = MagicMock(return_value={"id": "builtin-svc", "action": "enabled"})
+    mock_hooks = MagicMock(return_value=True)
     mock_lock = MagicMock()
     mock_lock.__enter__ = MagicMock(return_value=None)
     mock_lock.__exit__ = MagicMock(return_value=False)
@@ -466,7 +467,7 @@ async def test_template_apply_reports_builtin_start_failure(tmp_path):
         patch("routers.extensions._extensions_lock", return_value=mock_lock),
         patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
         patch("routers.extensions._call_agent", return_value=False),
-        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._call_agent_hook", mock_hooks),
         patch("routers.extensions._validate_service_id"),
     ):
         from routers.templates import apply_template
@@ -476,6 +477,7 @@ async def test_template_apply_reports_builtin_start_failure(tmp_path):
     assert result["failed_services"] == ["builtin-svc"]
     assert result["started_count"] == 0
     assert result["restart_required"] is True
+    mock_hooks.assert_called_once_with("builtin-svc", "pre_start")
 
 
 @pytest.mark.asyncio
@@ -592,6 +594,53 @@ async def test_template_apply_enforces_gpu_compatibility_for_dependencies(tmp_pa
     mock_activate.assert_not_called()
     assert result["skipped_services"] == ["child-svc"]
     assert "Dependency cuda-dep is incompatible" in result["results"]["child-svc"]
+
+
+@pytest.mark.asyncio
+async def test_template_apply_reports_dependencies_enabled_before_later_activation_failure(tmp_path):
+    """A partial additive activation remains visible and gets its runtime start."""
+    from fastapi import HTTPException
+
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["child-svc"],
+    }]
+
+    def mock_activate(service_id):
+        if service_id == "bad-dep":
+            raise HTTPException(status_code=400, detail="bad dependency compose")
+        return {"id": service_id, "action": "enabled"}
+
+    mock_agent = MagicMock(return_value=True)
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", side_effect=mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch(
+            "routers.extensions._get_missing_deps_transitive",
+            return_value=["good-dep", "bad-dep"],
+        ),
+        patch("routers.extensions._call_agent", mock_agent),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._read_direct_deps", return_value=[]),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert result["results"]["good-dep"] == "enabled_as_dependency"
+    assert "bad dependency compose" in result["results"]["child-svc"]
+    assert result["enabled_count"] == 1
+    assert result["started_count"] == 1
+    mock_agent.assert_called_once_with("start", "good-dep")
 
 
 @pytest.mark.asyncio
@@ -732,6 +781,95 @@ async def test_template_apply_library_install_failure_skips_gracefully(tmp_path)
     assert result["enabled_count"] == 0
     # _activate_service must NOT have been called after the install failed
     mock_activate.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_template_apply_post_install_failure_is_retryable(tmp_path):
+    """A failed setup hook is reported and persisted for a clean reinstall retry."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["lib-svc"],
+    }]
+    user_ext = tmp_path / "user-ext"
+    user_ext.mkdir()
+
+    def mock_install(svc_id):
+        (user_ext / svc_id).mkdir(parents=True, exist_ok=True)
+
+    mock_activate = MagicMock()
+    mock_agent = MagicMock(return_value=True)
+    mock_write_error = MagicMock()
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", mock_agent),
+        patch("routers.extensions._call_agent_hook", return_value=False),
+        patch("routers.extensions._write_error_progress", mock_write_error),
+        patch("routers.extensions._validate_service_id"),
+        patch("routers.extensions._is_installable", return_value=True),
+        patch("routers.extensions._install_from_library", side_effect=mock_install),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_activate.assert_not_called()
+    mock_agent.assert_not_called()
+    mock_write_error.assert_called_once()
+    assert result["library_installed"] == ["lib-svc"]
+    assert result["skipped_services"] == ["lib-svc"]
+    assert "post_install hook failed" in result["results"]["lib-svc"]
+
+
+@pytest.mark.asyncio
+async def test_template_apply_reinstalls_library_extension_with_error_progress(tmp_path):
+    """Persisted install errors force the library setup path to run again."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["lib-svc"],
+    }]
+    user_ext = tmp_path / "user-ext"
+    (user_ext / "lib-svc").mkdir(parents=True)
+    mock_install = MagicMock()
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch(
+            "routers.extensions._activate_service",
+            return_value={"id": "lib-svc", "action": "already_enabled"},
+        ),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._read_direct_deps", return_value=[]),
+        patch("routers.extensions._validate_service_id"),
+        patch("routers.extensions._is_installable", return_value=True),
+        patch("routers.extensions._has_error_progress", return_value=True),
+        patch("routers.extensions._install_from_library", mock_install),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_install.assert_called_once_with("lib-svc")
+    assert result["results"]["lib-svc"] == "library_installed"
+    assert result["failed_services"] == []
 
 
 @pytest.mark.asyncio
@@ -950,7 +1088,9 @@ def test_apply_template_blocking_calls_run_in_to_thread():
         "_call_agent",
         "_call_agent_invalidate_compose_cache",
         "_get_missing_deps_transitive",
+        "_has_error_progress",
         "_read_direct_deps",
+        "_write_error_progress",
         "_install_from_library",
         "_install_with_lock",
         "_activate_with_lock",
@@ -1006,7 +1146,9 @@ def test_apply_template_blocking_calls_run_in_to_thread():
         "_call_agent_hook",
         "_call_agent",
         "_get_missing_deps_transitive",
+        "_has_error_progress",
         "_read_direct_deps",
+        "_write_error_progress",
         "_install_with_lock",
         "_activate_with_lock",
     }

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -6,6 +6,13 @@ import pytest
 import yaml
 
 
+@pytest.fixture(autouse=True)
+def _disable_agent_cache_invalidation():
+    """Keep template unit tests isolated from the host-agent network."""
+    with patch("routers.extensions._call_agent_invalidate_compose_cache"):
+        yield
+
+
 # --- Template loading tests ---
 
 
@@ -549,6 +556,42 @@ async def test_template_apply_skips_dependent_after_prior_activation_failure(tmp
     assert "Dependency dep-svc was not enabled" in result["results"]["child-svc"]
     assert result["enabled_count"] == 0
     assert result["skipped_services"] == ["dep-svc", "child-svc"]
+
+
+@pytest.mark.asyncio
+async def test_template_apply_enforces_gpu_compatibility_for_dependencies(tmp_path):
+    """A compatible target cannot activate an incompatible transitive dependency."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["child-svc"],
+    }]
+    mock_activate = MagicMock()
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.SERVICES", {
+            "child-svc": {"gpu_backends": ["all"]},
+            "cuda-dep": {"gpu_backends": ["nvidia"]},
+        }),
+        patch("routers.templates.GPU_BACKEND", "amd"),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=["cuda-dep"]),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_activate.assert_not_called()
+    assert result["skipped_services"] == ["child-svc"]
+    assert "Dependency cuda-dep is incompatible" in result["results"]["child-svc"]
 
 
 @pytest.mark.asyncio

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -358,8 +358,40 @@ async def test_template_apply_incompatible_skipped():
 
 
 @pytest.mark.asyncio
+async def test_template_apply_enforces_gpu_compatibility():
+    """Apply cannot bypass the GPU compatibility check performed by preview."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["cuda-only"],
+    }]
+    mock_activate = MagicMock()
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.SERVICES", {"cuda-only": {"gpu_backends": ["nvidia"]}}),
+        patch("routers.templates.GPU_BACKEND", "amd"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_activate.assert_not_called()
+    assert result["enabled_count"] == 0
+    assert result["started_count"] == 0
+    assert result["skipped_services"] == ["cuda-only"]
+    assert "incompatible GPU backend" in result["results"]["cuda-only"]
+    assert result["warnings"] == [
+        "cuda-only: requires one of ['nvidia']; current backend is amd",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_template_apply_builtin_extension(tmp_path):
-    """Apply with a built-in extension skips host agent start and sets restart_required."""
+    """Apply starts built-in extensions through the host agent."""
     mock_templates = [{
         "id": "test-tmpl",
         "name": "Test",
@@ -380,6 +412,8 @@ async def test_template_apply_builtin_extension(tmp_path):
     user_ext = tmp_path / "user-ext"
     user_ext.mkdir()
 
+    mock_agent = MagicMock(return_value=True)
+
     with (
         patch("routers.templates.TEMPLATES", mock_templates),
         patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
@@ -388,7 +422,7 @@ async def test_template_apply_builtin_extension(tmp_path):
         patch("routers.extensions._activate_service", mock_activate),
         patch("routers.extensions._extensions_lock", return_value=mock_lock),
         patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
-        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent", mock_agent),
         patch("routers.extensions._call_agent_hook", return_value=True),
         patch("routers.extensions._validate_service_id"),
     ):
@@ -396,8 +430,80 @@ async def test_template_apply_builtin_extension(tmp_path):
         result = await apply_template("test-tmpl", api_key="test")
 
     assert result["results"]["builtin-svc"] == "enabled"
-    assert result["restart_required"] is True
+    mock_agent.assert_called_once_with("start", "builtin-svc")
+    assert result["restart_required"] is False
+    assert result["failed_services"] == []
+    assert result["started_count"] == 1
     assert result["enabled_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_template_apply_reports_builtin_start_failure(tmp_path):
+    """A failed targeted start is explicit and requests manual recovery."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["builtin-svc"],
+    }]
+    mock_activate = MagicMock(return_value={"id": "builtin-svc", "action": "enabled"})
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", return_value=False),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert result["results"]["builtin-svc"] == "enabled_but_start_failed"
+    assert result["failed_services"] == ["builtin-svc"]
+    assert result["started_count"] == 0
+    assert result["restart_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_template_apply_does_not_start_after_pre_start_failure(tmp_path):
+    """A terminal pre_start hook failure blocks the service start."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["svc-a"],
+    }]
+    mock_activate = MagicMock(return_value={"id": "svc-a", "action": "enabled"})
+    mock_agent = MagicMock(return_value=True)
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", mock_agent),
+        patch("routers.extensions._call_agent_hook", return_value=False),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_agent.assert_not_called()
+    assert result["results"]["svc-a"] == "enabled_but_pre_start_failed"
+    assert result["failed_services"] == ["svc-a"]
+    assert result["restart_required"] is True
 
 
 @pytest.mark.asyncio
@@ -445,8 +551,8 @@ async def test_template_apply_auto_installs_library_extension(tmp_path):
     assert install_calls == ["lib-svc"]
     assert result["results"]["lib-svc"] == "library_installed"
     assert result["library_installed"] == ["lib-svc"]
-    # Library install → compose stack grew → restart required
-    assert result["restart_required"] is True
+    # A successful targeted host-agent start does not require a stack restart.
+    assert result["restart_required"] is False
     assert result["enabled_count"] == 1
 
 
@@ -594,8 +700,8 @@ async def test_template_apply_mixed_builtin_and_library(tmp_path):
     assert result["results"]["lib-svc"] == "library_installed"
     # Both count as enabled
     assert result["enabled_count"] == 2
-    # Either the built-in toggle or the library install forces a restart
-    assert result["restart_required"] is True
+    # Both services were started through the host agent.
+    assert result["restart_required"] is False
 
 
 @pytest.mark.asyncio

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -9,7 +9,10 @@ import yaml
 @pytest.fixture(autouse=True)
 def _disable_agent_cache_invalidation():
     """Keep template unit tests isolated from the host-agent network."""
-    with patch("routers.extensions._call_agent_invalidate_compose_cache"):
+    with (
+        patch("routers.extensions._call_agent_invalidate_compose_cache"),
+        patch("routers.extensions._sync_extension_config", return_value=True),
+    ):
         yield
 
 
@@ -814,6 +817,7 @@ async def test_template_apply_post_install_failure_is_retryable(tmp_path):
         patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
         patch("routers.extensions._call_agent", mock_agent),
         patch("routers.extensions._call_agent_hook", return_value=False),
+        patch("routers.extensions._sync_extension_config", return_value=True),
         patch("routers.extensions._write_error_progress", mock_write_error),
         patch("routers.extensions._validate_service_id"),
         patch("routers.extensions._is_installable", return_value=True),
@@ -828,6 +832,56 @@ async def test_template_apply_post_install_failure_is_retryable(tmp_path):
     assert result["library_installed"] == ["lib-svc"]
     assert result["skipped_services"] == ["lib-svc"]
     assert "post_install hook failed" in result["results"]["lib-svc"]
+
+
+@pytest.mark.asyncio
+async def test_template_apply_config_sync_failure_is_retryable(tmp_path):
+    """Library templates cannot start with missing bind-mount configuration."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["lib-svc"],
+    }]
+    user_ext = tmp_path / "user-ext"
+    user_ext.mkdir()
+
+    def mock_install(svc_id):
+        (user_ext / svc_id).mkdir(parents=True, exist_ok=True)
+
+    mock_activate = MagicMock()
+    mock_agent = MagicMock(return_value=True)
+    mock_hooks = MagicMock(return_value=True)
+    mock_write_error = MagicMock()
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", mock_agent),
+        patch("routers.extensions._call_agent_hook", mock_hooks),
+        patch("routers.extensions._sync_extension_config", return_value=False),
+        patch("routers.extensions._write_error_progress", mock_write_error),
+        patch("routers.extensions._validate_service_id"),
+        patch("routers.extensions._is_installable", return_value=True),
+        patch("routers.extensions._install_from_library", side_effect=mock_install),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_activate.assert_not_called()
+    mock_agent.assert_not_called()
+    mock_hooks.assert_not_called()
+    mock_write_error.assert_called_once()
+    assert result["library_installed"] == ["lib-svc"]
+    assert result["skipped_services"] == ["lib-svc"]
+    assert "config sync failed" in result["results"]["lib-svc"]
 
 
 @pytest.mark.asyncio
@@ -858,6 +912,7 @@ async def test_template_apply_reinstalls_library_extension_with_error_progress(t
         patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
         patch("routers.extensions._call_agent", return_value=True),
         patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._sync_extension_config", return_value=True),
         patch("routers.extensions._read_direct_deps", return_value=[]),
         patch("routers.extensions._validate_service_id"),
         patch("routers.extensions._is_installable", return_value=True),
@@ -1090,6 +1145,7 @@ def test_apply_template_blocking_calls_run_in_to_thread():
         "_get_missing_deps_transitive",
         "_has_error_progress",
         "_read_direct_deps",
+        "_sync_extension_config",
         "_write_error_progress",
         "_install_from_library",
         "_install_with_lock",
@@ -1148,6 +1204,7 @@ def test_apply_template_blocking_calls_run_in_to_thread():
         "_get_missing_deps_transitive",
         "_has_error_progress",
         "_read_direct_deps",
+        "_sync_extension_config",
         "_write_error_progress",
         "_install_with_lock",
         "_activate_with_lock",

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -329,6 +329,68 @@ async def test_template_apply_activates_deps(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_template_apply_starts_enabled_stopped_dependency_first(tmp_path):
+    """An enabled compose definition is not treated as runtime readiness."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["child-svc"],
+    }]
+
+    class MockSvc:
+        def __init__(self, id_, status):
+            self.id = id_
+            self.status = status
+
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+    starts: list[str] = []
+
+    def mock_direct_deps(service_id):
+        return ["dep-svc"] if service_id == "child-svc" else []
+
+    def mock_agent(action, service_id):
+        assert action == "start"
+        starts.append(service_id)
+        return True
+
+    user_ext = tmp_path / "user-ext"
+    for service_id in ("dep-svc", "child-svc"):
+        (user_ext / service_id).mkdir(parents=True)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", user_ext),
+        patch(
+            "helpers.get_cached_services",
+            return_value=[
+                MockSvc("dep-svc", "stopped"),
+                MockSvc("child-svc", "stopped"),
+            ],
+        ),
+        patch(
+            "routers.extensions._activate_service",
+            return_value={"id": "child-svc", "action": "already_enabled"},
+        ),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._read_direct_deps", side_effect=mock_direct_deps),
+        patch("routers.extensions._call_agent", side_effect=mock_agent),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert starts == ["dep-svc", "child-svc"]
+    assert result["results"]["dep-svc"] == "already_enabled"
+    assert result["started_count"] == 2
+    assert result["failed_services"] == []
+
+
+@pytest.mark.asyncio
 async def test_template_apply_incompatible_skipped():
     """Apply skips services that fail activation (e.g., not installed)."""
     from fastapi import HTTPException

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -542,7 +542,10 @@ async def test_template_apply_reports_builtin_start_failure(tmp_path):
     assert result["failed_services"] == ["builtin-svc"]
     assert result["started_count"] == 0
     assert result["restart_required"] is True
-    mock_hooks.assert_called_once_with("builtin-svc", "pre_start")
+    assert mock_hooks.call_args_list == [
+        call("builtin-svc", "post_install"),
+        call("builtin-svc", "pre_start"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -568,7 +571,8 @@ async def test_template_apply_does_not_start_after_pre_start_failure(tmp_path):
         patch("routers.extensions._extensions_lock", return_value=mock_lock),
         patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
         patch("routers.extensions._call_agent", mock_agent),
-        patch("routers.extensions._call_agent_hook", return_value=False),
+        patch("routers.extensions._call_agent_hook",
+              side_effect=lambda sid, hook: hook != "pre_start"),
         patch("routers.extensions._validate_service_id"),
     ):
         from routers.templates import apply_template
@@ -578,6 +582,44 @@ async def test_template_apply_does_not_start_after_pre_start_failure(tmp_path):
     assert result["results"]["svc-a"] == "enabled_but_pre_start_failed"
     assert result["failed_services"] == ["svc-a"]
     assert result["restart_required"] is True
+
+
+@pytest.mark.asyncio
+async def test_template_apply_runs_builtin_post_install_before_start(tmp_path):
+    """A built-in whose setup hook fails is not started (langfuse class)."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["svc-a"],
+    }]
+    mock_activate = MagicMock(return_value={"id": "svc-a", "action": "enabled"})
+    mock_agent = MagicMock(return_value=True)
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", mock_agent),
+        patch("routers.extensions._call_agent_hook",
+              side_effect=lambda sid, hook: hook != "post_install"),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    mock_agent.assert_not_called()
+    assert result["results"]["svc-a"] == "enabled_but_post_install_failed"
+    assert result["failed_services"] == ["svc-a"]
+    assert result["restart_required"] is True
+    assert any("post_install hook failed" in warning
+               for warning in result["warnings"])
 
 
 @pytest.mark.asyncio

--- a/ods/extensions/services/dashboard-api/tests/test_templates.py
+++ b/ods/extensions/services/dashboard-api/tests/test_templates.py
@@ -1,6 +1,6 @@
 """Tests for service template loading, preview, and apply."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 import yaml
@@ -507,6 +507,94 @@ async def test_template_apply_does_not_start_after_pre_start_failure(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_template_apply_skips_dependent_after_prior_activation_failure(tmp_path):
+    """A prior failed dependency result cannot be treated as satisfied."""
+    from fastapi import HTTPException
+
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["dep-svc", "child-svc"],
+    }]
+
+    def mock_activate(service_id):
+        if service_id == "dep-svc":
+            raise HTTPException(status_code=400, detail="dependency config invalid")
+        return {"id": service_id, "action": "enabled"}
+
+    def mock_missing_deps(service_id):
+        return ["dep-svc"] if service_id == "child-svc" else []
+
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", side_effect=mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", side_effect=mock_missing_deps),
+        patch("routers.extensions._call_agent", return_value=True),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch("routers.extensions._read_direct_deps", return_value=[]),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert "dependency config invalid" in result["results"]["dep-svc"]
+    assert "Dependency dep-svc was not enabled" in result["results"]["child-svc"]
+    assert result["enabled_count"] == 0
+    assert result["skipped_services"] == ["dep-svc", "child-svc"]
+
+
+@pytest.mark.asyncio
+async def test_template_apply_does_not_start_dependent_after_runtime_failure(tmp_path):
+    """A child is not started after its activated dependency fails at runtime."""
+    mock_templates = [{
+        "id": "test-tmpl",
+        "name": "Test",
+        "services": ["dep-svc", "child-svc"],
+    }]
+    mock_activate = MagicMock(side_effect=lambda service_id: {
+        "id": service_id,
+        "action": "enabled",
+    })
+    mock_agent = MagicMock(side_effect=lambda action, service_id: service_id != "dep-svc")
+    mock_lock = MagicMock()
+    mock_lock.__enter__ = MagicMock(return_value=None)
+    mock_lock.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("routers.templates.TEMPLATES", mock_templates),
+        patch("routers.templates._BASE_COMPOSE_SERVICES", frozenset()),
+        patch("routers.templates.USER_EXTENSIONS_DIR", tmp_path / "user-ext"),
+        patch("helpers.get_cached_services", return_value=[]),
+        patch("routers.extensions._activate_service", mock_activate),
+        patch("routers.extensions._extensions_lock", return_value=mock_lock),
+        patch("routers.extensions._get_missing_deps_transitive", return_value=[]),
+        patch("routers.extensions._call_agent", mock_agent),
+        patch("routers.extensions._call_agent_hook", return_value=True),
+        patch(
+            "routers.extensions._read_direct_deps",
+            side_effect=lambda service_id: ["dep-svc"] if service_id == "child-svc" else [],
+        ),
+        patch("routers.extensions._validate_service_id"),
+    ):
+        from routers.templates import apply_template
+        result = await apply_template("test-tmpl", api_key="test")
+
+    assert mock_agent.call_args_list == [call("start", "dep-svc")]
+    assert result["results"]["dep-svc"] == "enabled_but_start_failed"
+    assert result["results"]["child-svc"] == "enabled_but_dependency_failed"
+    assert result["failed_services"] == ["dep-svc", "child-svc"]
+    assert result["started_count"] == 0
+
+
+@pytest.mark.asyncio
 async def test_template_apply_auto_installs_library_extension(tmp_path):
     """Apply copies a library extension into USER_EXTENSIONS_DIR before activating it."""
     mock_templates = [{
@@ -819,6 +907,7 @@ def test_apply_template_blocking_calls_run_in_to_thread():
         "_call_agent",
         "_call_agent_invalidate_compose_cache",
         "_get_missing_deps_transitive",
+        "_read_direct_deps",
         "_install_from_library",
         "_install_with_lock",
         "_activate_with_lock",
@@ -874,6 +963,7 @@ def test_apply_template_blocking_calls_run_in_to_thread():
         "_call_agent_hook",
         "_call_agent",
         "_get_missing_deps_transitive",
+        "_read_direct_deps",
         "_install_with_lock",
         "_activate_with_lock",
     }

--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -44,6 +44,21 @@ server {
         proxy_set_header X-Accel-Buffering no;
     }
 
+    # Template apply may pull and start several services serially. Keep this
+    # timeout aligned with TemplatePicker's request budget.
+    location ~ ^/api/templates/[a-z0-9-]+/apply$ {
+        proxy_pass http://$dashboard_api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "close";
+        proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
+        proxy_read_timeout 1800s;
+        proxy_send_timeout 1800s;
+    }
+
     # Proxy API requests to status backend
     # Auth: nginx injects Bearer token for same-origin requests (B2 fix)
     # Token read from environment via envsubst in entrypoint

--- a/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -5,6 +5,7 @@ import {
 } from 'lucide-react'
 
 const ICON_MAP = { MessageSquare, Image, Code, Shield, Layers, Package }
+const TEMPLATE_APPLY_TIMEOUT_MS = 30 * 60 * 1000
 
 const fetchJson = async (url, options = {}) => {
   const c = new AbortController()
@@ -147,7 +148,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
     try {
       const res = await fetchJson(`/api/templates/${template.id}/apply`, {
         method: 'POST',
-        timeout: 120000,
+        timeout: TEMPLATE_APPLY_TIMEOUT_MS,
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()

--- a/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
+++ b/ods/extensions/services/dashboard/src/components/TemplatePicker.jsx
@@ -123,6 +123,7 @@ export function TemplatePreview({ template, onClose, onApplied }) {
   const [applying, setApplying] = useState(false)
   const [error, setError] = useState(null)
   const [applied, setApplied] = useState(false)
+  const [applyResult, setApplyResult] = useState(null)
 
   const Icon = ICON_MAP[template.icon] || Package
 
@@ -150,7 +151,10 @@ export function TemplatePreview({ template, onClose, onApplied }) {
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       const data = await res.json()
-      if (data.enabled_count > 0) {
+      setApplyResult(data)
+      if (data.failed_services?.length > 0 || data.skipped_services?.length > 0) {
+        setApplied('partial')
+      } else if (data.enabled_count > 0) {
         setApplied(data.restart_required ? 'restart_required' : 'enabled')
       } else {
         setApplied('already_active')
@@ -265,7 +269,9 @@ export function TemplatePreview({ template, onClose, onApplied }) {
         {/* Applied success */}
         {applied && (
           <div className="py-6 text-center">
-            <Check size={32} className="text-green-400 mx-auto mb-2" />
+            {applied === 'partial'
+              ? <AlertTriangle size={32} className="text-orange-400 mx-auto mb-2" />
+              : <Check size={32} className="text-green-400 mx-auto mb-2" />}
             {applied === 'enabled' && (
               <p className="text-sm text-green-400">Template applied — check extension cards for installation progress</p>
             )}
@@ -280,6 +286,25 @@ export function TemplatePreview({ template, onClose, onApplied }) {
                   <p className="text-xs text-orange-200/80">Run <code className="px-1.5 py-0.5 rounded bg-theme-card text-orange-100">ods restart</code> in your terminal to start the newly enabled services.</p>
                 </div>
               </>
+            )}
+            {applied === 'partial' && (
+              <div className="p-3 rounded-lg bg-orange-500/10 border border-orange-500/20 text-left">
+                <p className="text-sm text-orange-300 font-medium mb-1">Template applied with exceptions</p>
+                {applyResult?.failed_services?.length > 0 && (
+                  <p className="text-xs text-orange-200/80">
+                    Failed to start: {applyResult.failed_services.join(', ')}.
+                    {applyResult.restart_required ? ' Run ods restart to retry.' : ''}
+                  </p>
+                )}
+                {applyResult?.skipped_services?.length > 0 && (
+                  <p className="text-xs text-orange-200/80">
+                    Skipped: {applyResult.skipped_services.join(', ')}.
+                  </p>
+                )}
+                {applyResult?.warnings?.map((warning, index) => (
+                  <p key={index} className="text-xs text-orange-200/80 mt-1">{warning}</p>
+                ))}
+              </div>
             )}
           </div>
         )}

--- a/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.apply.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.apply.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, screen, waitFor } from '@testing-library/react'
 import { render } from '../../test/test-utils'
 import { TemplatePreview } from '../TemplatePicker' // eslint-disable-line no-unused-vars
 
@@ -17,7 +17,48 @@ const response = body => ({
 
 describe('TemplatePreview apply result', () => {
   afterEach(() => {
+    vi.useRealTimers()
     vi.restoreAllMocks()
+  })
+
+  test('keeps a long-running apply request alive beyond two minutes', async () => {
+    let applySignal
+    let finishApply
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response({
+        changes: { to_enable: ['svc-a'], already_enabled: [], incompatible: [] },
+        warnings: [],
+      }))
+      .mockImplementationOnce((_url, options) => {
+        applySignal = options.signal
+        return new Promise(resolve => { finishApply = resolve })
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TemplatePreview template={template} onClose={vi.fn()} />)
+    const applyButton = await screen.findByRole('button', { name: /apply template/i })
+    vi.useFakeTimers()
+    fireEvent.click(applyButton)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120001)
+    })
+    expect(applySignal.aborted).toBe(false)
+    expect(screen.queryByText(/request timed out/i)).not.toBeInTheDocument()
+
+    await act(async () => {
+      finishApply(response({
+        enabled_count: 1,
+        started_count: 1,
+        failed_services: [],
+        skipped_services: [],
+        warnings: [],
+        restart_required: false,
+      }))
+      await Promise.resolve()
+    })
+    vi.useRealTimers()
+    expect(await screen.findByText(/template applied/i)).toBeInTheDocument()
   })
 
   test('does not report all services active when apply skipped a service', async () => {

--- a/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.apply.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/TemplatePicker.apply.test.jsx
@@ -1,0 +1,71 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { render } from '../../test/test-utils'
+import { TemplatePreview } from '../TemplatePicker' // eslint-disable-line no-unused-vars
+
+const template = {
+  id: 'test-template',
+  name: 'Test Template',
+  description: 'Template apply contract',
+  services: ['svc-a'],
+}
+
+const response = body => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+})
+
+describe('TemplatePreview apply result', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  test('does not report all services active when apply skipped a service', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response({
+        changes: { to_enable: ['svc-a'], already_enabled: [], incompatible: [] },
+        warnings: [],
+      }))
+      .mockResolvedValueOnce(response({
+        enabled_count: 0,
+        started_count: 0,
+        failed_services: [],
+        skipped_services: ['svc-a'],
+        warnings: ['svc-a: incompatible GPU backend'],
+        restart_required: false,
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TemplatePreview template={template} onClose={vi.fn()} />)
+
+    const applyButton = await screen.findByRole('button', { name: /apply template/i })
+    fireEvent.click(applyButton)
+
+    expect(await screen.findByText(/applied with exceptions/i)).toBeInTheDocument()
+    expect(screen.getByText(/skipped: svc-a/i)).toBeInTheDocument()
+    expect(screen.queryByText(/all services.*already active/i)).not.toBeInTheDocument()
+  })
+
+  test('shows targeted restart recovery when a service failed to start', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(response({
+        changes: { to_enable: ['svc-a'], already_enabled: [], incompatible: [] },
+        warnings: [],
+      }))
+      .mockResolvedValueOnce(response({
+        enabled_count: 1,
+        started_count: 0,
+        failed_services: ['svc-a'],
+        skipped_services: [],
+        warnings: [],
+        restart_required: true,
+      }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<TemplatePreview template={template} onClose={vi.fn()} />)
+    fireEvent.click(await screen.findByRole('button', { name: /apply template/i }))
+
+    await waitFor(() => expect(screen.getByText(/failed to start: svc-a/i)).toBeInTheDocument())
+    expect(screen.getByText(/run ods restart to retry/i)).toBeInTheDocument()
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -149,18 +149,19 @@ export default function FirstBoot({ onComplete }) {
         }
 
         const applyResult = await applyResp.json()
-        if (
-          (applyResult.failed_services !== undefined && !Array.isArray(applyResult.failed_services)) ||
-          (applyResult.skipped_services !== undefined && !Array.isArray(applyResult.skipped_services))
-        ) {
+        const failed = applyResult.failed_services
+        const skipped = applyResult.skipped_services
+        const enabledCount = applyResult.enabled_count
+        const startedCount = applyResult.started_count
+        const invalidReceipt = !Array.isArray(failed) ||
+          !Array.isArray(skipped) ||
+          !Number.isInteger(enabledCount) || enabledCount < 0 ||
+          !Number.isInteger(startedCount) || startedCount < 0 ||
+          startedCount > enabledCount
+        if (invalidReceipt) {
           throw new Error(`${selectedStack.title} returned an invalid apply result. Retry Finish after updating ODS.`)
         }
-        const failed = applyResult.failed_services || []
-        const skipped = applyResult.skipped_services || []
-        const enabledCount = Number(applyResult.enabled_count)
-        const startedCount = Number(applyResult.started_count)
-        const incompleteStart = Number.isInteger(enabledCount) && enabledCount >= 0 &&
-          Number.isInteger(startedCount) && startedCount >= 0 && startedCount < enabledCount
+        const incompleteStart = startedCount < enabledCount
         if (failed.length > 0 || skipped.length > 0 || incompleteStart) {
           const details = [
             failed.length > 0 ? `failed to start: ${failed.join(', ')}` : null,

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -42,7 +42,7 @@ const STACK_OPTIONS = [
   {
     id: 'everything',
     title: 'Full ODS Stack',
-    blurb: 'Adds agents, voice, RAG, images, research, privacy, and observability (~16GB).',
+    blurb: 'Adds agents, voice, RAG, research, privacy, and observability (~16GB). Image generation installs separately from Extensions.',
     templateId: 'onboarding-full-stack',
     Icon: Boxes,
   },
@@ -534,7 +534,7 @@ function ConfirmStep({
       <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
         <Row label="Setup label" value={deviceName.trim() || 'ods'} hint="owner-card audit note" />
         <Row label="First user" value={username.trim()} />
-        <Row label="Stack" value={stackTitle} hint="applied before setup completes" />
+        <Row label="Stack" value={stackTitle} hint="services start in the background — verify on the dashboard after setup" />
       </dl>
 
       {ownerCardStatusLoading && (

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -149,12 +149,23 @@ export default function FirstBoot({ onComplete }) {
         }
 
         const applyResult = await applyResp.json()
+        if (
+          (applyResult.failed_services !== undefined && !Array.isArray(applyResult.failed_services)) ||
+          (applyResult.skipped_services !== undefined && !Array.isArray(applyResult.skipped_services))
+        ) {
+          throw new Error(`${selectedStack.title} returned an invalid apply result. Retry Finish after updating ODS.`)
+        }
         const failed = applyResult.failed_services || []
         const skipped = applyResult.skipped_services || []
-        if (failed.length > 0 || skipped.length > 0) {
+        const enabledCount = Number(applyResult.enabled_count)
+        const startedCount = Number(applyResult.started_count)
+        const incompleteStart = Number.isInteger(enabledCount) && enabledCount >= 0 &&
+          Number.isInteger(startedCount) && startedCount >= 0 && startedCount < enabledCount
+        if (failed.length > 0 || skipped.length > 0 || incompleteStart) {
           const details = [
             failed.length > 0 ? `failed to start: ${failed.join(', ')}` : null,
             skipped.length > 0 ? `not compatible or unavailable: ${skipped.join(', ')}` : null,
+            incompleteStart ? `started ${startedCount} of ${enabledCount} enabled services` : null,
           ].filter(Boolean).join('; ')
           const recovery = applyResult.restart_required
             ? ' Run ods restart, then retry Finish.'

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.jsx
@@ -24,28 +24,26 @@ import {
 
 const PROGRESS_KEY = 'ods-firstboot-progress'
 
-// NOTE: this picker records a preference today; it does NOT enable
-// extensions or start services. The matching backend wiring lives in
-// the Extensions panel (and a follow-up PR will let Finish apply the
-// chosen preset there). Until then the blurbs describe the *intent*
-// of each stack, with the copy honest that nothing changes yet.
 const STACK_OPTIONS = [
   {
     id: 'chat',
     title: 'Chat only',
     blurb: 'Just the chat surface. This is what runs out of the box.',
+    templateId: null,
     Icon: MessageSquare,
   },
   {
     id: 'chat-agents',
     title: 'Chat + Agents',
-    blurb: 'Adds n8n workflows and the agent runtime; enable from Extensions after setup.',
+    blurb: 'Adds Hermes, web search, usage monitoring, and n8n workflows.',
+    templateId: 'onboarding-agents',
     Icon: Workflow,
   },
   {
     id: 'everything',
-    title: 'Everything',
-    blurb: 'Voice, image generation, search, the whole catalog; enable from Extensions after setup.',
+    title: 'Full ODS Stack',
+    blurb: 'Adds agents, voice, RAG, images, research, privacy, and observability (~16GB).',
+    templateId: 'onboarding-full-stack',
     Icon: Boxes,
   },
 ]
@@ -136,6 +134,35 @@ export default function FirstBoot({ onComplete }) {
     }
     setFinishing(true)
     try {
+      const selectedStack = STACK_OPTIONS.find(option => option.id === stack)
+      if (!selectedStack) {
+        throw new Error('The selected stack is no longer available. Go back and choose another option.')
+      }
+
+      if (selectedStack.templateId) {
+        const applyResp = await fetch(`/api/templates/${selectedStack.templateId}/apply`, {
+          method: 'POST',
+        })
+        if (!applyResp.ok) {
+          const body = await applyResp.json().catch(() => ({}))
+          throw new Error(body.detail || `Failed to configure ${selectedStack.title} (${applyResp.status}).`)
+        }
+
+        const applyResult = await applyResp.json()
+        const failed = applyResult.failed_services || []
+        const skipped = applyResult.skipped_services || []
+        if (failed.length > 0 || skipped.length > 0) {
+          const details = [
+            failed.length > 0 ? `failed to start: ${failed.join(', ')}` : null,
+            skipped.length > 0 ? `not compatible or unavailable: ${skipped.join(', ')}` : null,
+          ].filter(Boolean).join('; ')
+          const recovery = applyResult.restart_required
+            ? ' Run ods restart, then retry Finish.'
+            : ' Go back and choose another stack, or resolve the listed services and retry.'
+          throw new Error(`${selectedStack.title} was only partially configured (${details}).${recovery}`)
+        }
+      }
+
       let inviteData = null
       if (!ownerCardUnavailable) {
         // Generate the owner magic-link for the named user. Reuses the same
@@ -495,7 +522,7 @@ function ConfirmStep({
       <dl className="bg-theme-card border border-theme-border rounded-xl divide-y divide-theme-border mb-8">
         <Row label="Setup label" value={deviceName.trim() || 'ods'} hint="owner-card audit note" />
         <Row label="First user" value={username.trim()} />
-        <Row label="Stack" value={stackTitle} hint="enable extras from Extensions" />
+        <Row label="Stack" value={stackTitle} hint="applied before setup completes" />
       </dl>
 
       {ownerCardStatusLoading && (
@@ -536,7 +563,7 @@ function ConfirmStep({
           className="flex-1 flex items-center justify-center gap-2 bg-theme-accent text-white py-4 rounded-xl text-base font-medium hover:opacity-90 disabled:opacity-50 transition-opacity"
         >
           {finishing && <Loader2 size={18} className="animate-spin" />}
-          {finishing ? 'Finishing...' : 'Finish'}
+          {finishing ? 'Configuring...' : 'Finish'}
         </button>
       </div>
     </div>

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
@@ -208,6 +208,54 @@ describe('FirstBoot', () => {
     expect(fetchMock).not.toHaveBeenCalledWith('/api/setup/complete', expect.anything())
   })
 
+  test('rejects an incomplete template apply receipt', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
+      if (url === '/api/templates/onboarding-agents/apply' && options.method === 'POST') {
+        return response({
+          failed_services: [],
+          skipped_services: [],
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+    await finishWizard('Chat \\+ Agents')
+
+    expect(await screen.findByText(/invalid apply result/i)).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/setup/complete', expect.anything())
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/auth/magic-link/generate', expect.anything())
+  })
+
+  test('rejects impossible template apply counts', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
+      if (url === '/api/templates/onboarding-agents/apply' && options.method === 'POST') {
+        return response({
+          enabled_count: 3,
+          started_count: 4,
+          failed_services: [],
+          skipped_services: [],
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+    await finishWizard('Chat \\+ Agents')
+
+    expect(await screen.findByText(/invalid apply result/i)).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/setup/complete', expect.anything())
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/auth/magic-link/generate', expect.anything())
+  })
+
   test('does not show success when setup completion fails', async () => {
     const fetchMock = vi.fn(async (url, options = {}) => {
       if (url === '/api/auth/magic-link/owner-card/status') {

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
@@ -157,6 +157,57 @@ describe('FirstBoot', () => {
     expect(screen.queryByRole('heading', { name: /you're set/i })).not.toBeInTheDocument()
   })
 
+  test('keeps first-run active when apply counts report an unlisted start failure', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
+      if (url === '/api/templates/onboarding-agents/apply' && options.method === 'POST') {
+        return response({
+          enabled_count: 4,
+          started_count: 3,
+          failed_services: [],
+          skipped_services: [],
+          warnings: [],
+          restart_required: true,
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+    await finishWizard('Chat \\+ Agents')
+
+    expect(await screen.findByText(/started 3 of 4 enabled services/i)).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/setup/complete', expect.anything())
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/auth/magic-link/generate', expect.anything())
+  })
+
+  test('rejects malformed template apply failure lists', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
+      if (url === '/api/templates/onboarding-agents/apply' && options.method === 'POST') {
+        return response({
+          enabled_count: 4,
+          started_count: 4,
+          failed_services: 'none',
+          skipped_services: [],
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+    await finishWizard('Chat \\+ Agents')
+
+    expect(await screen.findByText(/invalid apply result/i)).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/setup/complete', expect.anything())
+  })
+
   test('does not show success when setup completion fails', async () => {
     const fetchMock = vi.fn(async (url, options = {}) => {
       if (url === '/api/auth/magic-link/owner-card/status') {

--- a/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/FirstBoot.test.jsx
@@ -10,13 +10,16 @@ const response = (body, status = 200) => ({
 
 const ownerCardReady = { ready: true, requires: 'ods-proxy', reason: '' }
 
-async function finishWizard() {
+async function finishWizard(stackName = null) {
   fireEvent.change(screen.getByDisplayValue('ods'), { target: { value: 'spark' } })
   fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
 
   fireEvent.change(screen.getByPlaceholderText('alice'), { target: { value: 'sam' } })
   fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
 
+  if (stackName) {
+    fireEvent.click(screen.getByRole('button', { name: new RegExp(stackName, 'i') }))
+  }
   fireEvent.click(screen.getByRole('button', { name: /^continue$/i }))
   const finishButton = screen.getByRole('button', { name: /^finish$/i })
   await waitFor(() => expect(finishButton).toBeEnabled())
@@ -79,6 +82,79 @@ describe('FirstBoot', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /open dashboard/i }))
     expect(onComplete).toHaveBeenCalledTimes(1)
+  })
+
+  test('applies the selected agent stack before creating credentials or completing setup', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
+      if (url === '/api/templates/onboarding-agents/apply' && options.method === 'POST') {
+        return response({
+          enabled_count: 4,
+          started_count: 4,
+          failed_services: [],
+          skipped_services: [],
+          warnings: [],
+          restart_required: false,
+        })
+      }
+      if (url === '/api/auth/magic-link/generate' && options.method === 'POST') {
+        return response({
+          url: 'http://auth.spark.local/magic-link/agent-token',
+          target_username: 'sam',
+        })
+      }
+      if (url === '/api/setup/complete' && options.method === 'POST') {
+        return response({ success: true })
+      }
+      if (String(url).startsWith('/api/auth/magic-link/qr?url=')) {
+        return response({ data_url: 'data:image/png;base64,qrpayload' })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+    await finishWizard('Chat \\+ Agents')
+
+    expect(await screen.findByRole('heading', { name: /you're set/i })).toBeInTheDocument()
+    const urls = fetchMock.mock.calls.map(([url]) => String(url))
+    expect(urls.indexOf('/api/templates/onboarding-agents/apply')).toBeLessThan(
+      urls.indexOf('/api/auth/magic-link/generate'),
+    )
+    expect(urls.indexOf('/api/auth/magic-link/generate')).toBeLessThan(
+      urls.indexOf('/api/setup/complete'),
+    )
+  })
+
+  test('keeps first-run active when a selected stack is only partially applied', async () => {
+    const fetchMock = vi.fn(async (url, options = {}) => {
+      if (url === '/api/auth/magic-link/owner-card/status') {
+        return response(ownerCardReady)
+      }
+      if (url === '/api/templates/onboarding-full-stack/apply' && options.method === 'POST') {
+        return response({
+          enabled_count: 8,
+          started_count: 8,
+          failed_services: [],
+          skipped_services: ['comfyui'],
+          warnings: ['comfyui requires a compatible GPU'],
+          restart_required: false,
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<FirstBoot onComplete={vi.fn()} />)
+    await finishWizard('Full ODS Stack')
+
+    expect(await screen.findByText(/only partially configured/i)).toBeInTheDocument()
+    expect(screen.getByText(/not compatible or unavailable: comfyui/i)).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/setup/complete', expect.anything())
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/auth/magic-link/generate', expect.anything())
+    expect(screen.queryByRole('heading', { name: /you're set/i })).not.toBeInTheDocument()
   })
 
   test('does not show success when setup completion fails', async () => {

--- a/ods/templates/onboarding-agents.yaml
+++ b/ods/templates/onboarding-agents.yaml
@@ -1,0 +1,13 @@
+schema_version: ods.templates.v1
+template:
+  id: onboarding-agents
+  name: Chat + Agents
+  description: "ODS chat, Hermes Agent, web search, workflow automation, and usage monitoring."
+  icon: Bot
+  tags: [onboarding, chat, agents, workflows]
+  services: [litellm, searxng, token-spy, hermes, hermes-proxy, n8n]
+  tier_minimum: T1
+  estimated_disk_gb: 4
+  service_notes:
+    hermes: "General-purpose agent with tools, memory, and scheduled tasks"
+    n8n: "Workflow automation for agent and service integrations"

--- a/ods/templates/onboarding-full-stack.yaml
+++ b/ods/templates/onboarding-full-stack.yaml
@@ -2,9 +2,9 @@ schema_version: ods.templates.v1
 template:
   id: onboarding-full-stack
   name: Full ODS Stack
-  description: "The complete first-party ODS stack: agents, workflows, RAG, voice, images, research, privacy, and observability."
+  description: "The complete first-party ODS stack: agents, workflows, RAG, voice, research, privacy, and observability. Image generation (ComfyUI) is tier-gated by the installer — add it from Extensions afterward."
   icon: Layers
-  tags: [onboarding, full-stack, agents, voice, rag, images]
+  tags: [onboarding, full-stack, agents, voice, rag]
   services:
     - litellm
     - searxng
@@ -16,7 +16,6 @@ template:
     - embeddings
     - hermes
     - hermes-proxy
-    - comfyui
     - ape
     - perplexica
     - privacy-shield
@@ -24,5 +23,4 @@ template:
   tier_minimum: T2
   estimated_disk_gb: 16
   service_notes:
-    comfyui: "Requires a compatible AMD or NVIDIA GPU and is skipped on unsupported backends"
     langfuse: "Adds the observability data stack and has the largest service footprint"

--- a/ods/templates/onboarding-full-stack.yaml
+++ b/ods/templates/onboarding-full-stack.yaml
@@ -1,0 +1,28 @@
+schema_version: ods.templates.v1
+template:
+  id: onboarding-full-stack
+  name: Full ODS Stack
+  description: "The complete first-party ODS stack: agents, workflows, RAG, voice, images, research, privacy, and observability."
+  icon: Layers
+  tags: [onboarding, full-stack, agents, voice, rag, images]
+  services:
+    - litellm
+    - searxng
+    - token-spy
+    - whisper
+    - tts
+    - n8n
+    - qdrant
+    - embeddings
+    - hermes
+    - hermes-proxy
+    - comfyui
+    - ape
+    - perplexica
+    - privacy-shield
+    - langfuse
+  tier_minimum: T2
+  estimated_disk_gb: 16
+  service_notes:
+    comfyui: "Requires a compatible AMD or NVIDIA GPU and is skipped on unsupported backends"
+    langfuse: "Adds the observability data stack and has the largest service footprint"


### PR DESCRIPTION
## Summary

Turns the first-boot stack picker into an operational setup step. ODS applies the selected server-owned template before generating owner credentials or writing the setup-complete marker.

> **Merge order:** #1891 provides the failure-aware template runtime used here. Merge #1891 first; the shared commits will then disappear from this PR's diff.

## First-Boot Contract

| Selection | Behavior |
| --- | --- |
| Chat only | Keeps the always-on chat/API stack; no extension mutation |
| Chat + Agents | Enables LiteLLM, SearXNG, Token Spy, Hermes + auth proxy, and n8n |
| Full ODS Stack | Adds agents, workflows, RAG, voice, images, research, privacy, and observability |

## Transaction Ordering

1. Validate the selected stack.
2. Apply the matching template.
3. Validate response types and reject explicit or count-derived partial starts.
4. Generate the owner card when that path is ready.
5. Write `setup-complete.json` last.

A failure leaves first-run mode active and retryable. The UI names failed/skipped services and offers `ods restart` only when the backend says recovery requires it.

## Reliability Details

- Keeps **Chat only** as the safe default.
- Blocks completion when hardware compatibility skips a requested service.
- Detects incomplete starts even when a backend omits `failed_services` but reports `started_count < enabled_count`.
- Rejects malformed failure-list contracts instead of silently completing setup.
- Extends only the template-apply Nginx route to 30 minutes for multi-image pulls.
- Uses checked-in templates and manifest service IDs; the frontend performs no compose mutation.

## Validation

- `npm test -- --run` - **184 passed**
- focused `FirstBoot.test.jsx` - **7 passed**
- `npm run lint` - passed
- `npm run build` - passed
- `python -m pytest extensions/services/dashboard-api/tests/test_templates.py -q` - **29 passed**
- onboarding templates validate against `service-template.v1.json`
- every preset service ID resolves to a checked-in manifest
- `git diff --check` - passed
- GitHub dashboard API/frontend, Linux integration, distro matrix, PowerShell, shell, Python, env-schema, and secret checks - passed

## Scope

This enables first-party ODS services only. It does not silently install arbitrary third-party library extensions.
