### PR TITLE
fix(windows): check the active inference port

### DIFF
--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -138,6 +138,26 @@ function Get-WindowsODSLemonadeProcesses {
     }
 }
 
+function Test-WindowsODSLemonadeOwnsPort {
+    <#
+    .SYNOPSIS
+        Return true when a listening port belongs to a known Lemonade process.
+    #>
+    param(
+        [hashtable]$PortResult,
+        [object[]]$LemonadeProcesses = @()
+    )
+
+    if (-not $PortResult -or -not $PortResult.InUse -or [int]$PortResult.ProcessId -le 0) {
+        return $false
+    }
+
+    $listenerPid = [int]$PortResult.ProcessId
+    return [bool]@($LemonadeProcesses | Where-Object {
+        $_.ProcessId -and [int]$_.ProcessId -eq $listenerPid
+    }).Count
+}
+
 function Stop-WindowsODSLemonadePortConflicts {
     <#
     .SYNOPSIS
@@ -313,10 +333,21 @@ if ($enablePrivacyShield) {
 }
 
 $_portConflicts = @()
+$_managedLemonadeProcesses = @()
+if ($_usesNativeLemonade) {
+    $_managedLemonadeProcesses = @(Get-WindowsODSLemonadeProcesses)
+}
 foreach ($svc in $_portsToCheck.Keys) {
     $port   = $_portsToCheck[$svc]
     $result = Test-WindowsPortInUse -Port $port
     if ($result.InUse) {
+        if ($svc -eq "Lemonade (LLM)" -and
+            (Test-WindowsODSLemonadeOwnsPort `
+                -PortResult $result `
+                -LemonadeProcesses $_managedLemonadeProcesses)) {
+            Write-AI "  Port $port is already owned by the managed Lemonade runtime; it will be reused."
+            continue
+        }
         $_portConflicts += "  Port $port ($svc) in use by: $($result.ProcessName) (PID $($result.ProcessId))"
         $requirementsMet = $false
     }

--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -79,20 +79,32 @@ function Resolve-WindowsLlmPreflightPort {
     param(
         [string]$GpuBackend,
         [switch]$CloudMode,
-        [int]$LemonadeDefaultPort = 8080
+        [int]$LemonadeDefaultPort = 8080,
+        [string]$InstallDir = ""
     )
 
     if ($CloudMode) { return 0 }
 
     $defaultPort = 11434
     $candidate = $null
+    $persistedEnv = @{}
+    if ($InstallDir -and (Get-Command Get-WindowsODSEnvMap -ErrorAction SilentlyContinue)) {
+        $persistedEnv = Get-WindowsODSEnvMap -InstallDir $InstallDir
+    }
     if ($GpuBackend -eq "amd") {
         $defaultPort = $LemonadeDefaultPort
         $candidate = $env:AMD_INFERENCE_PORT
+        if (-not $candidate -and $persistedEnv.ContainsKey("AMD_INFERENCE_PORT")) {
+            $candidate = $persistedEnv["AMD_INFERENCE_PORT"]
+        }
     } elseif ($env:OLLAMA_PORT) {
         $candidate = $env:OLLAMA_PORT
     } elseif ($env:LLAMA_SERVER_PORT) {
         $candidate = $env:LLAMA_SERVER_PORT
+    } elseif ($persistedEnv.ContainsKey("OLLAMA_PORT")) {
+        $candidate = $persistedEnv["OLLAMA_PORT"]
+    } elseif ($persistedEnv.ContainsKey("LLAMA_SERVER_PORT")) {
+        $candidate = $persistedEnv["LLAMA_SERVER_PORT"]
     }
 
     if ($candidate) {
@@ -258,7 +270,8 @@ $_portsToCheck = [ordered]@{
 $_llmPortToCheck = Resolve-WindowsLlmPreflightPort `
     -GpuBackend ([string]$gpuInfo.Backend) `
     -CloudMode:$cloudMode `
-    -LemonadeDefaultPort ([int]$script:LEMONADE_PORT)
+    -LemonadeDefaultPort ([int]$script:LEMONADE_PORT) `
+    -InstallDir $installDir
 if ($_llmPortToCheck -gt 0) {
     $_llmServiceLabel = $(if ($gpuInfo.Backend -eq "amd") { "Lemonade (LLM)" } else { "llama-server (LLM)" })
     $_portsToCheck[$_llmServiceLabel] = $_llmPortToCheck

--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -69,6 +69,43 @@ function Test-WindowsPortInUse {
     return @{ InUse = $false; ProcessName = ""; ProcessId = 0 }
 }
 
+function Resolve-WindowsLlmPreflightPort {
+    <#
+    .SYNOPSIS
+        Resolve the host LLM port that the selected Windows backend will bind.
+    .OUTPUTS
+        Port number, or 0 when cloud mode does not bind a local inference port.
+    #>
+    param(
+        [string]$GpuBackend,
+        [switch]$CloudMode,
+        [int]$LemonadeDefaultPort = 8080
+    )
+
+    if ($CloudMode) { return 0 }
+
+    $defaultPort = 11434
+    $candidate = $null
+    if ($GpuBackend -eq "amd") {
+        $defaultPort = $LemonadeDefaultPort
+        $candidate = $env:AMD_INFERENCE_PORT
+    } elseif ($env:OLLAMA_PORT) {
+        $candidate = $env:OLLAMA_PORT
+    } elseif ($env:LLAMA_SERVER_PORT) {
+        $candidate = $env:LLAMA_SERVER_PORT
+    }
+
+    if ($candidate) {
+        $parsedPort = 0
+        if ([int]::TryParse(([string]$candidate).Trim(), [ref]$parsedPort) -and
+            $parsedPort -ge 1 -and $parsedPort -le 65535) {
+            return $parsedPort
+        }
+    }
+
+    return $defaultPort
+}
+
 function Get-WindowsODSLemonadeProcesses {
     <#
     .SYNOPSIS
@@ -214,10 +251,17 @@ Stop-WindowsODSLemonadePortConflicts `
 # Build list of ports to check based on enabled features.
 # Default service ports match .env.example; overridden ports are not checked here.
 $_portsToCheck = [ordered]@{
-    "llama-server (LLM)"  = 11434
     "Open WebUI (chat)"   = 3000
     "Dashboard"           = 3001
     "Dashboard API"       = 3002
+}
+$_llmPortToCheck = Resolve-WindowsLlmPreflightPort `
+    -GpuBackend ([string]$gpuInfo.Backend) `
+    -CloudMode:$cloudMode `
+    -LemonadeDefaultPort ([int]$script:LEMONADE_PORT)
+if ($_llmPortToCheck -gt 0) {
+    $_llmServiceLabel = $(if ($gpuInfo.Backend -eq "amd") { "Lemonade (LLM)" } else { "llama-server (LLM)" })
+    $_portsToCheck[$_llmServiceLabel] = $_llmPortToCheck
 }
 if ($enableRecommended) {
     $_portsToCheck["LiteLLM (API gateway)"] = 4000

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -14,7 +14,11 @@ if ($errors.Count -gt 0) {
     throw "Phase 04 failed to parse: $($errors[0].Message)"
 }
 
-foreach ($name in @("Resolve-WindowsLlmPreflightPort", "Test-WindowsPortInUse")) {
+foreach ($name in @(
+    "Resolve-WindowsLlmPreflightPort",
+    "Test-WindowsPortInUse",
+    "Test-WindowsODSLemonadeOwnsPort"
+)) {
     $functionAst = $ast.Find({
         param($node)
         $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
@@ -40,6 +44,8 @@ try {
     Remove-Item Env:LLAMA_SERVER_PORT -ErrorAction SilentlyContinue
 
     Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd") 8080 "AMD default"
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -LemonadeDefaultPort 18081) `
+        18081 "AMD contract default"
     Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "nvidia") 11434 "Docker default"
     Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -CloudMode) 0 "Cloud mode"
 
@@ -92,6 +98,19 @@ try {
     } finally {
         $listener.Stop()
     }
+
+    $managedProcesses = @(
+        [pscustomobject]@{ ProcessId = 4101; Name = "lemonade-server.exe" }
+    )
+    Assert-Equal (Test-WindowsODSLemonadeOwnsPort `
+        -PortResult @{ InUse = $true; ProcessId = 4101 } `
+        -LemonadeProcesses $managedProcesses) $true "Managed Lemonade listener"
+    Assert-Equal (Test-WindowsODSLemonadeOwnsPort `
+        -PortResult @{ InUse = $true; ProcessId = 4102 } `
+        -LemonadeProcesses $managedProcesses) $false "Foreign listener"
+    Assert-Equal (Test-WindowsODSLemonadeOwnsPort `
+        -PortResult @{ InUse = $false; ProcessId = 0 } `
+        -LemonadeProcesses $managedProcesses) $false "Free port"
 } finally {
     if ($null -eq $savedAmdPort) { Remove-Item Env:AMD_INFERENCE_PORT -ErrorAction SilentlyContinue } else { $env:AMD_INFERENCE_PORT = $savedAmdPort }
     if ($null -eq $savedOllamaPort) { Remove-Item Env:OLLAMA_PORT -ErrorAction SilentlyContinue } else { $env:OLLAMA_PORT = $savedOllamaPort }

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = "Stop"
 
 $root = Split-Path -Parent $PSScriptRoot
 $phasePath = Join-Path $root "installers\windows\phases\04-requirements.ps1"
+. (Join-Path $root "installers\windows\lib\llm-endpoint.ps1")
 $tokens = $null
 $errors = $null
 $ast = [System.Management.Automation.Language.Parser]::ParseFile(
@@ -54,6 +55,27 @@ try {
 
     Remove-Item Env:OLLAMA_PORT
     Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "none") 31434 "LLAMA_SERVER_PORT fallback"
+
+    Remove-Item Env:AMD_INFERENCE_PORT -ErrorAction SilentlyContinue
+    Remove-Item Env:LLAMA_SERVER_PORT -ErrorAction SilentlyContinue
+    $installDir = Join-Path ([IO.Path]::GetTempPath()) "ods-port-preflight-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $installDir | Out-Null
+    try {
+        Set-Content -LiteralPath (Join-Path $installDir ".env") -Value @(
+            "AMD_INFERENCE_PORT=19080",
+            "OLLAMA_PORT=22434"
+        )
+        Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -InstallDir $installDir) `
+            19080 "Persisted AMD port"
+        Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "nvidia" -InstallDir $installDir) `
+            22434 "Persisted Docker port"
+
+        $env:AMD_INFERENCE_PORT = "29080"
+        Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -InstallDir $installDir) `
+            29080 "Process override wins over persisted AMD port"
+    } finally {
+        Remove-Item -LiteralPath $installDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
 
     $listener = [System.Net.Sockets.TcpListener]::new(
         [System.Net.IPAddress]::Loopback,

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -1,0 +1,79 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+$phasePath = Join-Path $root "installers\windows\phases\04-requirements.ps1"
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $phasePath,
+    [ref]$tokens,
+    [ref]$errors
+)
+if ($errors.Count -gt 0) {
+    throw "Phase 04 failed to parse: $($errors[0].Message)"
+}
+
+foreach ($name in @("Resolve-WindowsLlmPreflightPort", "Test-WindowsPortInUse")) {
+    $functionAst = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $name
+    }, $true)
+    if (-not $functionAst) { throw "Function not found: $name" }
+    . ([scriptblock]::Create($functionAst.Extent.Text))
+}
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Label)
+    if ($Actual -ne $Expected) {
+        throw "$Label expected '$Expected', got '$Actual'"
+    }
+}
+
+$savedAmdPort = $env:AMD_INFERENCE_PORT
+$savedOllamaPort = $env:OLLAMA_PORT
+$savedLlamaPort = $env:LLAMA_SERVER_PORT
+try {
+    Remove-Item Env:AMD_INFERENCE_PORT -ErrorAction SilentlyContinue
+    Remove-Item Env:OLLAMA_PORT -ErrorAction SilentlyContinue
+    Remove-Item Env:LLAMA_SERVER_PORT -ErrorAction SilentlyContinue
+
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd") 8080 "AMD default"
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "nvidia") 11434 "Docker default"
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -CloudMode) 0 "Cloud mode"
+
+    $env:AMD_INFERENCE_PORT = "18080"
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd") 18080 "AMD override"
+
+    $env:AMD_INFERENCE_PORT = "not-a-port"
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd") 8080 "Invalid AMD override"
+
+    $env:OLLAMA_PORT = "21434"
+    $env:LLAMA_SERVER_PORT = "31434"
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "nvidia") 21434 "OLLAMA_PORT precedence"
+
+    Remove-Item Env:OLLAMA_PORT
+    Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "none") 31434 "LLAMA_SERVER_PORT fallback"
+
+    $listener = [System.Net.Sockets.TcpListener]::new(
+        [System.Net.IPAddress]::Loopback,
+        0
+    )
+    $listener.Start()
+    try {
+        $port = ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+        $result = Test-WindowsPortInUse -Port $port
+        Assert-Equal $result.InUse $true "Live listener detection"
+        if ([int]$result.ProcessId -le 0) {
+            throw "Live listener detection did not return an owning PID"
+        }
+    } finally {
+        $listener.Stop()
+    }
+} finally {
+    if ($null -eq $savedAmdPort) { Remove-Item Env:AMD_INFERENCE_PORT -ErrorAction SilentlyContinue } else { $env:AMD_INFERENCE_PORT = $savedAmdPort }
+    if ($null -eq $savedOllamaPort) { Remove-Item Env:OLLAMA_PORT -ErrorAction SilentlyContinue } else { $env:OLLAMA_PORT = $savedOllamaPort }
+    if ($null -eq $savedLlamaPort) { Remove-Item Env:LLAMA_SERVER_PORT -ErrorAction SilentlyContinue } else { $env:LLAMA_SERVER_PORT = $savedLlamaPort }
+}
+
+Write-Host "[PASS] Windows backend-aware LLM port preflight"

--- a/ods/tests/test-windows-port-preflight.sh
+++ b/ods/tests/test-windows-port-preflight.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if command -v powershell.exe >/dev/null 2>&1; then
+    PS_BIN="powershell.exe"
+elif command -v pwsh >/dev/null 2>&1; then
+    PS_BIN="pwsh"
+else
+    echo "[SKIP] PowerShell unavailable"
+    exit 0
+fi
+
+if command -v cygpath >/dev/null 2>&1; then
+    TEST_PATH="$(cygpath -w "$ROOT_DIR/tests/test-windows-port-preflight.ps1")"
+elif [[ "$PS_BIN" == "powershell.exe" ]] && command -v wslpath >/dev/null 2>&1; then
+    TEST_PATH="$(wslpath -w "$ROOT_DIR/tests/test-windows-port-preflight.ps1")"
+else
+    TEST_PATH="$ROOT_DIR/tests/test-windows-port-preflight.ps1"
+fi
+
+"$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$TEST_PATH"


### PR DESCRIPTION
## Summary

Makes Windows preflight check the host inference port selected by the active backend instead of always probing Docker llama-server's `11434`.

## Root Cause

On Windows AMD/Lemonade, a foreign process could occupy `AMD_INFERENCE_PORT` while Phase 04 checked only `11434`. The installer then failed later at runtime health. A naive backend-aware check also creates a reinstall regression: it can mistake the ODS-managed Lemonade listener for an external conflict.

## Backend-Aware Resolution

| Mode | Port checked |
| --- | --- |
| AMD local | Process `AMD_INFERENCE_PORT`, existing `.env`, then Lemonade default |
| NVIDIA/CPU local | Process `OLLAMA_PORT` / `LLAMA_SERVER_PORT`, existing `.env`, then `11434` |
| Cloud | No local inference port |

- Accepts only TCP ports in `1..65535`; malformed values fall back to the backend default.
- Reports process name and PID for real conflicts.
- Labels the AMD endpoint as `Lemonade (LLM)`.
- Reuses a listener only when its PID matches a known ODS Lemonade process.
- Continues to reject an unrelated process on the same AMD port.

## Regression Coverage

- AMD, Docker, and cloud defaults
- contract-supplied Lemonade default
- process and persisted `.env` precedence
- invalid override fallback
- real loopback listener detection with owning PID
- managed Lemonade PID accepted
- foreign PID rejected
- free port remains non-conflicting

## Validation

- `powershell.exe ... tests/test-windows-port-preflight.ps1` - passed
- `bash tests/test-windows-port-preflight.sh` - passed
- `bash tests/test-windows-installer-flags.sh` - **30 passed**
- `bash tests/contracts/test-amd-lemonade-contracts.sh` - **63 passed**
- `bash tests/contracts/test-installer-hardening.sh` - passed
- PowerShell parser checks - passed
- `git diff --check` - passed
- GitHub Windows/Ubuntu PowerShell, dashboard, integration, distro, shell, Python, env-schema, and secret checks - passed

## Scope

This PR never terminates an unrelated process and never silently rewrites a configured port.