### PR TITLE
fix(windows): distinguish discrete AMD memory

### DIFF
--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -18,8 +18,8 @@ function Test-WindowsAmdIntegratedGpuName {
     if ([string]::IsNullOrWhiteSpace($GpuName)) { return $false }
     return [bool](
         $GpuName -match '(?i)\bRadeon(?:\(TM\))?\s+Graphics$' -or
-        $GpuName -match '(?i)\bRadeon\s+\d{3,4}[MS](?:\s+Graphics)?$' -or
-        $GpuName -match '(?i)\bRadeon\s+Vega\s+\d{1,2}\s+Graphics$' -or
+        $GpuName -match '(?i)\bRadeon(?:\(TM\))?\s+\d{3,4}[MS](?:\s+Graphics)?$' -or
+        $GpuName -match '(?i)\bRadeon(?:\(TM\))?\s+(?:RX\s+)?Vega\s+\d{1,2}\s+Graphics$' -or
         $GpuName -match '(?i)\bStrix\s+Halo\b'
     )
 }

--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -12,6 +12,82 @@
 #   Strix Halo detection: small dedicated VRAM + large system RAM = unified memory.
 # ============================================================================
 
+function Test-WindowsAmdDiscreteGpuName {
+    param([string]$GpuName)
+
+    return [bool]($GpuName -match '(?i)\bRadeon\s+(?:RX|PRO(?:\s+W)?|VII)\b|\bFirePro\b')
+}
+
+function Select-WindowsAmdPrimaryGpu {
+    param([object[]]$Gpus)
+
+    if (-not $Gpus -or $Gpus.Count -eq 0) { return $null }
+    $discrete = @($Gpus | Where-Object {
+        Test-WindowsAmdDiscreteGpuName -GpuName ([string]$_.Name)
+    } | Select-Object -First 1)
+    if ($discrete.Count -gt 0) { return $discrete[0] }
+    return $Gpus[0]
+}
+
+function Get-WindowsAmdDedicatedVramMB {
+    <#
+    .SYNOPSIS
+        Resolve dedicated VRAM without Win32_VideoController's 32-bit cap.
+    #>
+    param(
+        [string]$GpuName,
+        [uint64]$AdapterRamBytes = 0
+    )
+
+    $bestBytes = $AdapterRamBytes
+    $videoClass = 'HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}'
+    try {
+        foreach ($key in @(Get-ChildItem -LiteralPath $videoClass -ErrorAction SilentlyContinue)) {
+            $properties = Get-ItemProperty -LiteralPath $key.PSPath -ErrorAction SilentlyContinue
+            if (-not $properties -or [string]$properties.DriverDesc -ne $GpuName) { continue }
+
+            $rawValue = $properties.'HardwareInformation.qwMemorySize'
+            $registryBytes = [uint64]0
+            if ($rawValue -is [byte[]] -and $rawValue.Length -ge 8) {
+                $registryBytes = [BitConverter]::ToUInt64($rawValue, 0)
+            } elseif ($null -ne $rawValue) {
+                try { $registryBytes = [uint64]$rawValue } catch { $registryBytes = 0 }
+            }
+
+            if ($registryBytes -gt $bestBytes) { $bestBytes = $registryBytes }
+        }
+    } catch {
+        # Registry metadata is optional; retain the WMI fallback.
+    }
+
+    return [math]::Floor($bestBytes / 1048576)
+}
+
+function Test-WindowsAmdUnifiedMemory {
+    param(
+        [string]$GpuName,
+        [string]$ProcessorNames,
+        [int]$AdapterRamMB,
+        [int]$SystemRamGB
+    )
+
+    if (Test-WindowsAmdDiscreteGpuName -GpuName $GpuName) { return $false }
+
+    $hasStrixSignature = (
+        $GpuName -match '(?i)Strix|AI\s*(?:MAX|300|395)|Radeon\s+80[56]0S' -or
+        $ProcessorNames -match '(?i)Ryzen\s+AI\s+MAX|Strix\s+Halo'
+    )
+    $hasIntegratedSignature = (
+        $GpuName -match '(?i)Radeon(?:\(TM\))?\s+Graphics$|Radeon\s+(?:\d{3,4}[MS]|Vega(?:\s+\d+)?)\b'
+    )
+
+    return [bool](
+        $AdapterRamMB -le 4096 -and
+        $SystemRamGB -ge 32 -and
+        ($hasStrixSignature -or $hasIntegratedSignature)
+    )
+}
+
 function Get-GpuInfo {
     <#
     .SYNOPSIS
@@ -70,19 +146,28 @@ function Get-GpuInfo {
             Where-Object { $_.Name -match "AMD|Radeon" }
 
         if ($gpus) {
-            $primary = @($gpus)[0]
+            $gpuList = @($gpus)
+            # Hybrid systems often enumerate the integrated adapter first.
+            # Prefer an explicitly discrete Radeon when one is present.
+            $primary = Select-WindowsAmdPrimaryGpu -Gpus $gpuList
             $gpuName = $primary.Name
             $deviceId = $primary.PNPDeviceID
 
             # WMI AdapterRAM is a 32-bit field (maxes at 4 GB for discrete GPUs)
             # For APUs with unified memory, this is typically small (512MB–2GB)
-            $adapterRamMB = 0
-            if ($primary.AdapterRAM) {
-                $adapterRamMB = [math]::Floor([uint64]$primary.AdapterRAM / 1048576)
-            }
+            $adapterRamBytes = $(if ($primary.AdapterRAM) { [uint64]$primary.AdapterRAM } else { [uint64]0 })
+            $adapterRamMB = Get-WindowsAmdDedicatedVramMB `
+                -GpuName ([string]$gpuName) `
+                -AdapterRamBytes $adapterRamBytes
 
             # System RAM for unified memory calculation
             $systemRamGB = [math]::Floor((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1073741824)
+
+            $processorNames = ""
+            try {
+                $processorNames = (@(Get-CimInstance Win32_Processor -ErrorAction SilentlyContinue) |
+                    ForEach-Object { [string]$_.Name }) -join " | "
+            } catch { }
 
             # Strix Halo detection heuristic:
             #   - Small AdapterRAM (WMI caps at 4GB) + large system RAM (>= 64GB) = unified memory APU
@@ -90,16 +175,13 @@ function Get-GpuInfo {
             $isUnified = $false
             $effectiveVramMB = $adapterRamMB
 
-            if ($adapterRamMB -le 4096 -and $systemRamGB -ge 32) {
-                # Likely an APU with unified memory
-                $isUnified = $true
+            $isUnified = Test-WindowsAmdUnifiedMemory `
+                -GpuName ([string]$gpuName) `
+                -ProcessorNames $processorNames `
+                -AdapterRamMB $adapterRamMB `
+                -SystemRamGB $systemRamGB
+            if ($isUnified) {
                 # Effective VRAM: ~75% of system RAM is usable for GPU on Strix Halo
-                $effectiveVramMB = [math]::Floor($systemRamGB * 0.75 * 1024)
-            }
-
-            # Check for Strix Halo specific identifiers
-            if ($gpuName -match "Strix|AI MAX|AI 300|AI 395") {
-                $isUnified = $true
                 $effectiveVramMB = [math]::Floor($systemRamGB * 0.75 * 1024)
             }
 
@@ -118,7 +200,7 @@ function Get-GpuInfo {
                 Backend       = "amd"
                 Name          = $gpuName
                 VramMB        = $effectiveVramMB
-                Count         = @($gpus).Count
+                Count         = $gpuList.Count
                 MemoryType    = $(if ($isUnified) { "unified" } else { "discrete" })
                 DeviceId      = $deviceId
                 DriverVersion = $driverVer

--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -191,10 +191,12 @@ function Get-GpuInfo {
 
             # WMI AdapterRAM is a 32-bit field (maxes at 4 GB for discrete GPUs)
             # For APUs with unified memory, this is typically small (512MB–2GB)
+            # Keep the raw WMI-capped value for the unified-memory gate: an APU
+            # whose BIOS dedicated-VRAM carve exceeds 4 GB reports the true
+            # carve in the registry, and feeding that into the <=4GB gate would
+            # flip a genuine Strix Halo / APU to "discrete".
             $adapterRamBytes = ConvertTo-WindowsAmdAdapterRamBytes -Value $primary.AdapterRAM
-            $adapterRamMB = Get-WindowsAmdDedicatedVramMB `
-                -GpuName ([string]$gpuName) `
-                -AdapterRamBytes $adapterRamBytes
+            $adapterRamMB = [math]::Floor($adapterRamBytes / 1048576)
 
             # System RAM for unified memory calculation
             $systemRamGB = [math]::Floor((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1073741824)
@@ -219,6 +221,12 @@ function Get-GpuInfo {
             if ($isUnified) {
                 # Effective VRAM: ~75% of system RAM is usable for GPU on Strix Halo
                 $effectiveVramMB = [math]::Floor($systemRamGB * 0.75 * 1024)
+            } else {
+                # Discrete adapters only: recover true dedicated VRAM beyond
+                # WMI's 32-bit cap from the driver registry key.
+                $effectiveVramMB = Get-WindowsAmdDedicatedVramMB `
+                    -GpuName ([string]$gpuName) `
+                    -AdapterRamBytes $adapterRamBytes
             }
 
             $driverVer = $primary.DriverVersion

--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -29,6 +29,29 @@ function Select-WindowsAmdPrimaryGpu {
     return $Gpus[0]
 }
 
+function Get-WindowsAmdComputeGpuCount {
+    param([object[]]$Gpus)
+
+    if (-not $Gpus -or $Gpus.Count -eq 0) { return 0 }
+    $discreteCount = @($Gpus | Where-Object {
+        Test-WindowsAmdDiscreteGpuName -GpuName ([string]$_.Name)
+    }).Count
+    # A laptop iGPU is display hardware, not a second peer for ODS's
+    # multi-GPU topology. Count discrete adapters when any are present.
+    return $(if ($discreteCount -gt 0) { $discreteCount } else { $Gpus.Count })
+}
+
+function ConvertTo-WindowsAmdAdapterRamBytes {
+    param([object]$Value)
+
+    if ($null -eq $Value) { return [uint64]0 }
+    if ($Value -is [int] -and $Value -lt 0) {
+        # Some CIM/WMI bridges surface the uint32 AdapterRAM field as Int32.
+        return [uint64][BitConverter]::ToUInt32([BitConverter]::GetBytes([int]$Value), 0)
+    }
+    try { return [uint64]$Value } catch { return [uint64]0 }
+}
+
 function Get-WindowsAmdDedicatedVramMB {
     <#
     .SYNOPSIS
@@ -36,10 +59,10 @@ function Get-WindowsAmdDedicatedVramMB {
     #>
     param(
         [string]$GpuName,
-        [uint64]$AdapterRamBytes = 0
+        [object]$AdapterRamBytes = 0
     )
 
-    $bestBytes = $AdapterRamBytes
+    $bestBytes = ConvertTo-WindowsAmdAdapterRamBytes -Value $AdapterRamBytes
     $videoClass = 'HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}'
     try {
         foreach ($key in @(Get-ChildItem -LiteralPath $videoClass -ErrorAction SilentlyContinue)) {
@@ -155,7 +178,7 @@ function Get-GpuInfo {
 
             # WMI AdapterRAM is a 32-bit field (maxes at 4 GB for discrete GPUs)
             # For APUs with unified memory, this is typically small (512MB–2GB)
-            $adapterRamBytes = $(if ($primary.AdapterRAM) { [uint64]$primary.AdapterRAM } else { [uint64]0 })
+            $adapterRamBytes = ConvertTo-WindowsAmdAdapterRamBytes -Value $primary.AdapterRAM
             $adapterRamMB = Get-WindowsAmdDedicatedVramMB `
                 -GpuName ([string]$gpuName) `
                 -AdapterRamBytes $adapterRamBytes
@@ -200,7 +223,7 @@ function Get-GpuInfo {
                 Backend       = "amd"
                 Name          = $gpuName
                 VramMB        = $effectiveVramMB
-                Count         = $gpuList.Count
+                Count         = Get-WindowsAmdComputeGpuCount -Gpus $gpuList
                 MemoryType    = $(if ($isUnified) { "unified" } else { "discrete" })
                 DeviceId      = $deviceId
                 DriverVersion = $driverVer

--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -12,10 +12,25 @@
 #   Strix Halo detection: small dedicated VRAM + large system RAM = unified memory.
 # ============================================================================
 
+function Test-WindowsAmdIntegratedGpuName {
+    param([string]$GpuName)
+
+    if ([string]::IsNullOrWhiteSpace($GpuName)) { return $false }
+    return [bool](
+        $GpuName -match '(?i)\bRadeon(?:\(TM\))?\s+Graphics$' -or
+        $GpuName -match '(?i)\bRadeon\s+\d{3,4}[MS](?:\s+Graphics)?$' -or
+        $GpuName -match '(?i)\bRadeon\s+Vega\s+\d{1,2}\s+Graphics$' -or
+        $GpuName -match '(?i)\bStrix\s+Halo\b'
+    )
+}
+
 function Test-WindowsAmdDiscreteGpuName {
     param([string]$GpuName)
 
-    return [bool]($GpuName -match '(?i)\bRadeon\s+(?:RX|PRO(?:\s+W)?|VII)\b|\bFirePro\b')
+    if (Test-WindowsAmdIntegratedGpuName -GpuName $GpuName) { return $false }
+    # Unknown Radeon model families are safer to treat as discrete. Claiming
+    # unified memory for a discrete adapter can select a model that cannot fit.
+    return [bool]($GpuName -match '(?i)\b(?:AMD\s+)?Radeon\b|\bFirePro\b')
 }
 
 function Select-WindowsAmdPrimaryGpu {
@@ -100,9 +115,7 @@ function Test-WindowsAmdUnifiedMemory {
         $GpuName -match '(?i)Strix|AI\s*(?:MAX|300|395)|Radeon\s+80[56]0S' -or
         $ProcessorNames -match '(?i)Ryzen\s+AI\s+MAX|Strix\s+Halo'
     )
-    $hasIntegratedSignature = (
-        $GpuName -match '(?i)Radeon(?:\(TM\))?\s+Graphics$|Radeon\s+(?:\d{3,4}[MS]|Vega(?:\s+\d+)?)\b'
-    )
+    $hasIntegratedSignature = Test-WindowsAmdIntegratedGpuName -GpuName $GpuName
 
     return [bool](
         $AdapterRamMB -le 4096 -and

--- a/ods/tests/test-windows-amd-memory-detection.ps1
+++ b/ods/tests/test-windows-amd-memory-detection.ps1
@@ -18,6 +18,8 @@ Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon Vega 64") $true "Vega d
 Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon 8060S Graphics") $false "Strix integrated classification"
 Assert-Equal (Test-WindowsAmdIntegratedGpuName "AMD Radeon(TM) Graphics") $true "Generic integrated classification"
 Assert-Equal (Test-WindowsAmdIntegratedGpuName "AMD Radeon Vega 8 Graphics") $true "Vega integrated classification"
+Assert-Equal (Test-WindowsAmdIntegratedGpuName "AMD Radeon(TM) 780M Graphics") $true "TM mobile integrated classification"
+Assert-Equal (Test-WindowsAmdIntegratedGpuName "AMD Radeon(TM) RX Vega 11 Graphics") $true "TM RX Vega integrated classification"
 
 $hybridAdapters = @(
     [pscustomobject]@{ Name = "AMD Radeon(TM) Graphics" },

--- a/ods/tests/test-windows-amd-memory-detection.ps1
+++ b/ods/tests/test-windows-amd-memory-detection.ps1
@@ -1,0 +1,62 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+$detectionPath = Join-Path $root "installers\windows\lib\detection.ps1"
+. $detectionPath
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Label)
+    if ($Actual -ne $Expected) {
+        throw "$Label expected '$Expected', got '$Actual'"
+    }
+}
+
+Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon RX 9070 XT") $true "RX discrete classification"
+Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon PRO W7900") $true "Radeon PRO classification"
+Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon 8060S Graphics") $false "Strix integrated classification"
+
+$hybridAdapters = @(
+    [pscustomobject]@{ Name = "AMD Radeon(TM) Graphics" },
+    [pscustomobject]@{ Name = "AMD Radeon RX 9070 XT" }
+)
+Assert-Equal (Select-WindowsAmdPrimaryGpu -Gpus $hybridAdapters).Name `
+    "AMD Radeon RX 9070 XT" "Hybrid adapter selection"
+
+Assert-Equal (Test-WindowsAmdUnifiedMemory `
+    -GpuName "AMD Radeon RX 9070 XT" -ProcessorNames "AMD Ryzen 9 9950X" `
+    -AdapterRamMB 4095 -SystemRamGB 64) $false "RX 9070 XT must not use system RAM"
+
+Assert-Equal (Test-WindowsAmdUnifiedMemory `
+    -GpuName "AMD Radeon 8060S Graphics" -ProcessorNames "AMD Ryzen AI MAX+ 395" `
+    -AdapterRamMB 2048 -SystemRamGB 128) $true "Strix Halo unified classification"
+
+Assert-Equal (Test-WindowsAmdUnifiedMemory `
+    -GpuName "AMD Radeon 780M Graphics" -ProcessorNames "AMD Ryzen 7 7840U" `
+    -AdapterRamMB 2048 -SystemRamGB 32) $true "Integrated Radeon classification"
+
+$expectedName = "AMD Radeon RX 9070 XT"
+$registryValue = [uint64]17095983104
+function Get-ChildItem {
+    param($LiteralPath, $ErrorAction)
+    return @([pscustomobject]@{ PSPath = "mock:\\video\\0001" })
+}
+function Get-ItemProperty {
+    param($LiteralPath, $ErrorAction)
+    return [pscustomobject]@{
+        DriverDesc = $expectedName
+        'HardwareInformation.qwMemorySize' = $registryValue
+    }
+}
+
+$registryVram = Get-WindowsAmdDedicatedVramMB `
+    -GpuName $expectedName `
+    -AdapterRamBytes ([uint64]4293918720)
+Assert-Equal $registryVram 16304 "64-bit registry VRAM"
+
+$registryValue = [BitConverter]::GetBytes([uint64]17095983104)
+$registryByteVram = Get-WindowsAmdDedicatedVramMB `
+    -GpuName $expectedName `
+    -AdapterRamBytes ([uint64]4293918720)
+Assert-Equal $registryByteVram 16304 "Byte-array registry VRAM"
+
+Write-Host "[PASS] Windows AMD discrete and unified memory detection"

--- a/ods/tests/test-windows-amd-memory-detection.ps1
+++ b/ods/tests/test-windows-amd-memory-detection.ps1
@@ -21,6 +21,21 @@ $hybridAdapters = @(
 )
 Assert-Equal (Select-WindowsAmdPrimaryGpu -Gpus $hybridAdapters).Name `
     "AMD Radeon RX 9070 XT" "Hybrid adapter selection"
+Assert-Equal (Get-WindowsAmdComputeGpuCount -Gpus $hybridAdapters) 1 `
+    "Hybrid iGPU must not trigger multi-GPU"
+
+$dualDiscreteWithIgpu = @(
+    [pscustomobject]@{ Name = "AMD Radeon(TM) Graphics" },
+    [pscustomobject]@{ Name = "AMD Radeon RX 9070 XT" },
+    [pscustomobject]@{ Name = "AMD Radeon PRO W7900" }
+)
+Assert-Equal (Get-WindowsAmdComputeGpuCount -Gpus $dualDiscreteWithIgpu) 2 `
+    "Dual discrete AMD count"
+
+Assert-Equal (ConvertTo-WindowsAmdAdapterRamBytes -Value ([int]-1048576)) `
+    ([uint64]4293918720) "Signed WMI AdapterRAM reinterpretation"
+Assert-Equal (ConvertTo-WindowsAmdAdapterRamBytes -Value "invalid") `
+    ([uint64]0) "Invalid WMI AdapterRAM fallback"
 
 Assert-Equal (Test-WindowsAmdUnifiedMemory `
     -GpuName "AMD Radeon RX 9070 XT" -ProcessorNames "AMD Ryzen 9 9950X" `

--- a/ods/tests/test-windows-amd-memory-detection.ps1
+++ b/ods/tests/test-windows-amd-memory-detection.ps1
@@ -89,4 +89,31 @@ $registryByteVram = Get-WindowsAmdDedicatedVramMB `
     -AdapterRamBytes ([uint64]4293918720)
 Assert-Equal $registryByteVram 16304 "Byte-array registry VRAM"
 
+# Regression: a genuine APU whose BIOS raises the dedicated-VRAM carve above
+# 4 GB reports the true carve via the registry, but the unified-memory gate
+# must still see the raw WMI-capped value — otherwise a real Strix Halo flips
+# to "discrete" and mis-tiers.
+$expectedName = "AMD Radeon(TM) 8060S Graphics"
+$registryValue = [uint64](96GB)
+$raisedCarveRecovered = Get-WindowsAmdDedicatedVramMB `
+    -GpuName $expectedName `
+    -AdapterRamBytes ([uint64]536870912)
+Assert-Equal $raisedCarveRecovered 98304 "Raised-carve registry recovery still reads the true carve"
+$raisedCarveUnified = Test-WindowsAmdUnifiedMemory `
+    -GpuName $expectedName `
+    -ProcessorNames "AMD Ryzen AI MAX+ PRO 395" `
+    -AdapterRamMB 512 `
+    -SystemRamGB 128
+Assert-Equal $raisedCarveUnified $true "Raised-carve Strix Halo stays unified when gated on raw WMI value"
+
+# Wiring: Get-GpuInfo must gate unified detection on the WMI-capped value and
+# apply registry recovery only on the discrete branch.
+$detectionSource = Get-Content -LiteralPath $detectionPath -Raw
+if ($detectionSource -notmatch '(?s)\$adapterRamMB\s*=\s*\[math\]::Floor\(\$adapterRamBytes\s*/\s*1048576\)') {
+    throw "Get-GpuInfo must feed the unified gate the raw WMI-capped adapter RAM"
+}
+if ($detectionSource -notmatch '(?s)\}\s*else\s*\{[^}]*Get-WindowsAmdDedicatedVramMB') {
+    throw "Get-GpuInfo must apply registry VRAM recovery only on the discrete branch"
+}
+
 Write-Host "[PASS] Windows AMD discrete and unified memory detection"

--- a/ods/tests/test-windows-amd-memory-detection.ps1
+++ b/ods/tests/test-windows-amd-memory-detection.ps1
@@ -13,7 +13,11 @@ function Assert-Equal {
 
 Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon RX 9070 XT") $true "RX discrete classification"
 Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon PRO W7900") $true "Radeon PRO classification"
+Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon R9 390") $true "Legacy Radeon discrete classification"
+Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon Vega 64") $true "Vega discrete classification"
 Assert-Equal (Test-WindowsAmdDiscreteGpuName "AMD Radeon 8060S Graphics") $false "Strix integrated classification"
+Assert-Equal (Test-WindowsAmdIntegratedGpuName "AMD Radeon(TM) Graphics") $true "Generic integrated classification"
+Assert-Equal (Test-WindowsAmdIntegratedGpuName "AMD Radeon Vega 8 Graphics") $true "Vega integrated classification"
 
 $hybridAdapters = @(
     [pscustomobject]@{ Name = "AMD Radeon(TM) Graphics" },
@@ -23,6 +27,15 @@ Assert-Equal (Select-WindowsAmdPrimaryGpu -Gpus $hybridAdapters).Name `
     "AMD Radeon RX 9070 XT" "Hybrid adapter selection"
 Assert-Equal (Get-WindowsAmdComputeGpuCount -Gpus $hybridAdapters) 1 `
     "Hybrid iGPU must not trigger multi-GPU"
+
+$legacyHybridAdapters = @(
+    [pscustomobject]@{ Name = "AMD Radeon Vega 8 Graphics" },
+    [pscustomobject]@{ Name = "AMD Radeon R9 390" }
+)
+Assert-Equal (Select-WindowsAmdPrimaryGpu -Gpus $legacyHybridAdapters).Name `
+    "AMD Radeon R9 390" "Legacy hybrid adapter selection"
+Assert-Equal (Get-WindowsAmdComputeGpuCount -Gpus $legacyHybridAdapters) 1 `
+    "Legacy hybrid iGPU must not trigger multi-GPU"
 
 $dualDiscreteWithIgpu = @(
     [pscustomobject]@{ Name = "AMD Radeon(TM) Graphics" },

--- a/ods/tests/test-windows-amd-memory-detection.sh
+++ b/ods/tests/test-windows-amd-memory-detection.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if command -v powershell.exe >/dev/null 2>&1; then
+    PS_BIN="powershell.exe"
+elif command -v pwsh >/dev/null 2>&1; then
+    PS_BIN="pwsh"
+else
+    echo "[SKIP] PowerShell unavailable"
+    exit 0
+fi
+
+if command -v cygpath >/dev/null 2>&1; then
+    TEST_PATH="$(cygpath -w "$ROOT_DIR/tests/test-windows-amd-memory-detection.ps1")"
+elif [[ "$PS_BIN" == "powershell.exe" ]] && command -v wslpath >/dev/null 2>&1; then
+    TEST_PATH="$(wslpath -w "$ROOT_DIR/tests/test-windows-amd-memory-detection.ps1")"
+else
+    TEST_PATH="$ROOT_DIR/tests/test-windows-amd-memory-detection.ps1"
+fi
+
+"$PS_BIN" -NoProfile -ExecutionPolicy Bypass -File "$TEST_PATH"


### PR DESCRIPTION
## Summary

Fixes Windows AMD detection so discrete Radeon GPUs are not classified as unified-memory APUs, recovers dedicated VRAM beyond WMI's 32-bit field, and avoids false multi-GPU topology on hybrid systems.

## Root Cause

`Win32_VideoController.AdapterRAM` is a 32-bit field and can also surface as signed `Int32`. A 16 GB Radeon therefore appears close to 4 GB. The previous heuristic treated any AMD adapter at or below 4 GB on a host with at least 32 GB RAM as unified memory, inflating effective VRAM and selecting a Strix Halo policy.

Hybrid systems added a second failure mode: when the iGPU was enumerated first, it became the primary adapter and the display iGPU was counted as a second compute GPU.

## Fix

### Adapter selection and count

- Explicitly recognizes integrated Radeon naming patterns, including `(TM)`, mobile `M/S`, and RX Vega iGPU variants.
- Treats other Radeon/FirePro families, including RX, PRO, R9, Vega discrete, and legacy models, conservatively as discrete.
- Prefers a discrete Radeon when an integrated adapter is enumerated first.
- Counts discrete compute adapters when present, excluding a companion display iGPU.

### VRAM resolution

- Reinterprets signed WMI `AdapterRAM` as its underlying unsigned 32-bit value.
- Reads matching `HardwareInformation.qwMemorySize` registry metadata.
- Supports numeric and byte-array registry representations.
- Falls back safely when registry metadata is missing, protected, or invalid.

### Unified-memory classification

- Requires an integrated/Strix GPU or processor signature.
- Explicitly excludes discrete adapters.
- Preserves Strix Halo (`8060S` / Ryzen AI MAX) and integrated Radeon (`780M`, Vega iGPU) behavior.

## Real Hardware Receipt

Production `Get-GpuInfo` on the validation host returned:

```text
AMD Radeon RX 9070 XT | discrete | 16304 MB | Count=1
```

The same host was previously routed as roughly 46 GB unified memory.

## Validation

- `tests/test-windows-amd-memory-detection.ps1` - passed
- production `Get-GpuInfo` execution - passed
- `tests/contracts/test-windows-strix-tier-map.sh` - **9 passed**
- `tests/contracts/test-amd-lemonade-contracts.sh` - **63 passed**
- PowerShell parser checks - passed
- `git diff --check` - passed
- GitHub Windows/Ubuntu PowerShell, dashboard, integration, distro, Python, env-schema, and secret checks - current head running/green

## Compatibility

No NVIDIA, Apple, Linux, compose, or runtime-launch behavior changes. Windows AMD systems without readable registry metadata retain the WMI fallback.
