### PR TITLE
test(windows): accept CRLF LiteLLM config

### DIFF
--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -635,7 +635,7 @@ if command -v pwsh >/dev/null 2>&1; then
         if ($localText -notmatch "(?m)^  request_timeout: 900\r?$" -or $localText -notmatch "(?m)^  stream_timeout: 900\r?$") {
             throw "Windows local LiteLLM config must keep long-model proxy timeouts at 900s"
         }
-        if ($localText -notmatch "(?m)^general_settings:$" -or $localText -notmatch "(?m)^  master_key: os\.environ/LITELLM_MASTER_KEY$") {
+        if ($localText -notmatch "(?m)^general_settings:\r?$" -or $localText -notmatch "(?m)^  master_key: os\.environ/LITELLM_MASTER_KEY\r?$") {
             throw "Windows local LiteLLM config must enforce the generated LiteLLM master key"
         }
     '; then


### PR DESCRIPTION
## Summary

- accept both LF and CRLF line endings when validating the generated Windows LiteLLM configuration
- keep the existing assertions strict about the general_settings block and generated master-key reference

## Problem

The Windows AMD/Lemonade contract read a PowerShell-generated YAML file with CRLF endings but anchored two regex assertions as LF-only. The generated configuration was valid, yet the local Windows contract reported a failure.

## Validation

- 	ests/contracts/test-amd-lemonade-contracts.sh: **63 passed, 0 failed** on Windows with Git Bash and Windows PowerShell
- git diff --check: passed

## Scope

Test-only change. Runtime configuration generation and authentication behavior are unchanged.