### PR TITLE
fix(windows): transact model swaps through host agent

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -71,3 +71,7 @@ jobs:
       - name: Windows Lemonade Task Cleanup Contract
         shell: pwsh
         run: ./tests/contracts/test-windows-lemonade-task-cleanup.ps1
+
+      - name: Windows Model Activation Contract
+        shell: pwsh
+        run: ./tests/test-windows-model-activation.ps1

--- a/ods/docs/MODEL-MANAGEMENT.md
+++ b/ods/docs/MODEL-MANAGEMENT.md
@@ -45,8 +45,9 @@ curl http://localhost:11434/v1/models
 On macOS native Metal and Windows native/Lemonade installs, use
 `http://localhost:8080/v1/models` unless you changed the port.
 
-Dashboard activation and `ods model swap <tier>` use the same authenticated
-host-agent transaction. The transaction updates `.env`, `models.ini`, the
+Dashboard activation, Unix `ods model swap <tier>`, and Windows
+`.\ods.ps1 model swap <tier>` use the same authenticated host-agent transaction.
+The transaction updates `.env`, `models.ini`, the
 native or container inference runtime, LiteLLM, Hermes, OpenClaw, OpenCode, and
 Perplexica when those consumers are installed. It verifies the new runtime and
 downstream routes before reporting success. A late failure restores the prior
@@ -330,7 +331,5 @@ For AMD/Lemonade, use `extra.<GGUF_FILE>`.
 - Custom GGUF import from a local file or arbitrary URL is not yet a first-class
   Dashboard workflow.
 - `ods model swap` switches ODS tiers, not arbitrary GGUF files.
-- Windows `ods.ps1 model swap` parity is tracked separately; use the Dashboard
-  Models page for transactional activation on Windows until that command lands.
 - `scripts/upgrade-model.sh` is a legacy helper for model-directory layouts and
   should not be used as the primary GGUF switch path on current installs.

--- a/ods/installers/windows/lib/model-activation.ps1
+++ b/ods/installers/windows/lib/model-activation.ps1
@@ -59,14 +59,14 @@ function Resolve-WindowsODSModelCatalogId {
         throw "Model catalog is not valid JSON: $($_.Exception.Message)"
     }
 
-    $matches = @($catalog.models | Where-Object {
+    $catalogMatches = @($catalog.models | Where-Object {
         [string]$_.gguf_file -eq $GgufFile -and
         -not [string]::IsNullOrWhiteSpace([string]$_.id)
     })
-    if ($matches.Count -ne 1) {
+    if ($catalogMatches.Count -ne 1) {
         throw "Tier model must match exactly one model catalog entry: $GgufFile"
     }
-    $modelId = ([string]$matches[0].id).Trim()
+    $modelId = ([string]$catalogMatches[0].id).Trim()
     if ($modelId.Contains("`r") -or $modelId.Contains("`n")) {
         throw "Model catalog entry contains an invalid model ID"
     }

--- a/ods/installers/windows/lib/model-activation.ps1
+++ b/ods/installers/windows/lib/model-activation.ps1
@@ -1,0 +1,171 @@
+# ============================================================================
+# ODS Windows -- transactional model activation helpers
+# ============================================================================
+
+function Resolve-WindowsODSAgentBaseUri {
+    param([hashtable]$EnvMap)
+
+    $port = 7710
+    $rawPort = [string]$EnvMap["ODS_AGENT_PORT"]
+    $parsedPort = 0
+    if (-not [string]::IsNullOrWhiteSpace($rawPort)) {
+        if (-not [int]::TryParse($rawPort.Trim(), [ref]$parsedPort) -or
+            $parsedPort -lt 1 -or $parsedPort -gt 65535) {
+            throw "ODS_AGENT_PORT must be an integer between 1 and 65535"
+        }
+        $port = $parsedPort
+    }
+
+    $hostName = [string]$EnvMap["ODS_AGENT_BIND"]
+    if ([string]::IsNullOrWhiteSpace($hostName) -or
+        $hostName.Trim() -in @("0.0.0.0", "::", "*", "+")) {
+        $hostName = "127.0.0.1"
+    } else {
+        $hostName = $hostName.Trim()
+    }
+
+    if ([Uri]::CheckHostName($hostName) -eq [UriHostNameType]::Unknown) {
+        throw "ODS_AGENT_BIND is not a valid host name or IP address"
+    }
+    if ($hostName.Contains(":")) { $hostName = "[$hostName]" }
+    return "http://${hostName}:$port"
+}
+
+function Resolve-WindowsODSModelCatalogId {
+    param(
+        [Parameter(Mandatory = $true)][string]$InstallDir,
+        [Parameter(Mandatory = $true)][string]$GgufFile
+    )
+
+    if ([IO.Path]::GetFileName($GgufFile) -ne $GgufFile -or
+        $GgufFile.Contains("/") -or $GgufFile.Contains("\")) {
+        throw "Tier model contains an invalid GGUF filename"
+    }
+
+    $modelPath = Join-Path (Join-Path $InstallDir "data\models") $GgufFile
+    if (-not (Test-Path -LiteralPath $modelPath -PathType Leaf) -or
+        (Get-Item -LiteralPath $modelPath).Length -le 0) {
+        throw "Model file is not downloaded: $modelPath"
+    }
+
+    $catalogPath = Join-Path (Join-Path $InstallDir "config") "model-library.json"
+    if (-not (Test-Path -LiteralPath $catalogPath -PathType Leaf)) {
+        throw "Model catalog is missing: $catalogPath"
+    }
+    try {
+        $catalog = Get-Content -LiteralPath $catalogPath -Raw -Encoding UTF8 |
+            ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        throw "Model catalog is not valid JSON: $($_.Exception.Message)"
+    }
+
+    $matches = @($catalog.models | Where-Object {
+        [string]$_.gguf_file -eq $GgufFile -and
+        -not [string]::IsNullOrWhiteSpace([string]$_.id)
+    })
+    if ($matches.Count -ne 1) {
+        throw "Tier model must match exactly one model catalog entry: $GgufFile"
+    }
+    $modelId = ([string]$matches[0].id).Trim()
+    if ($modelId.Contains("`r") -or $modelId.Contains("`n")) {
+        throw "Model catalog entry contains an invalid model ID"
+    }
+    return $modelId
+}
+
+function Get-WindowsODSHttpErrorDetail {
+    param([System.Management.Automation.ErrorRecord]$ErrorRecord)
+
+    $fallback = $ErrorRecord.Exception.Message
+    try {
+        $response = $ErrorRecord.Exception.Response
+        if ($null -eq $response) { return $fallback }
+        $stream = $response.GetResponseStream()
+        if ($null -eq $stream) { return $fallback }
+        $reader = New-Object IO.StreamReader($stream)
+        try { $body = $reader.ReadToEnd() } finally { $reader.Dispose() }
+        if ([string]::IsNullOrWhiteSpace($body)) { return $fallback }
+        try {
+            $parsed = $body | ConvertFrom-Json -ErrorAction Stop
+            if (-not [string]::IsNullOrWhiteSpace([string]$parsed.error)) {
+                return [string]$parsed.error
+            }
+        } catch { }
+        return $body.Substring(0, [Math]::Min(500, $body.Length))
+    } catch {
+        return $fallback
+    }
+}
+
+function Invoke-WindowsODSModelActivationTransaction {
+    param(
+        [Parameter(Mandatory = $true)][hashtable]$EnvMap,
+        [Parameter(Mandatory = $true)][string]$ModelId,
+        [Parameter(Mandatory = $true)][string]$Tier,
+        [Parameter(Mandatory = $true)][int]$ContextLength,
+        [int]$HealthTimeoutSeconds = 3,
+        [int]$ActivationTimeoutSeconds = 2700
+    )
+
+    if ($ContextLength -le 0) { throw "Context length must be positive" }
+    if ([string]::IsNullOrWhiteSpace($ModelId) -or
+        $ModelId.Contains("`r") -or $ModelId.Contains("`n")) {
+        throw "Model ID is invalid"
+    }
+    if ([string]::IsNullOrWhiteSpace($Tier) -or
+        $Tier.Contains("`r") -or $Tier.Contains("`n")) {
+        throw "Model tier is invalid"
+    }
+    if ($HealthTimeoutSeconds -le 0 -or $ActivationTimeoutSeconds -le 0) {
+        throw "Model activation timeouts must be positive"
+    }
+    $agentKey = [string]$EnvMap["ODS_AGENT_KEY"]
+    if ([string]::IsNullOrWhiteSpace($agentKey)) {
+        $agentKey = [string]$EnvMap["DASHBOARD_API_KEY"]
+    }
+    if ([string]::IsNullOrWhiteSpace($agentKey)) {
+        throw "ODS host-agent API key is missing from .env"
+    }
+    if ($agentKey.Contains("`r") -or $agentKey.Contains("`n")) {
+        throw "ODS host-agent API key contains invalid newline characters"
+    }
+
+    $baseUri = Resolve-WindowsODSAgentBaseUri -EnvMap $EnvMap
+    try {
+        $health = Invoke-WebRequest -Method Get -Uri "$baseUri/health" `
+            -UseBasicParsing -TimeoutSec $HealthTimeoutSeconds -ErrorAction Stop
+        if ([int]$health.StatusCode -lt 200 -or [int]$health.StatusCode -ge 300) {
+            throw "health endpoint returned HTTP $($health.StatusCode)"
+        }
+    } catch {
+        throw "ODS host agent is not reachable. Run '.\ods.ps1 agent restart' and retry. $($_.Exception.Message)"
+    }
+
+    $payload = [ordered]@{
+        model_id      = $ModelId
+        tier          = $Tier
+        context_length = $ContextLength
+    } | ConvertTo-Json -Compress
+    $headers = @{ Authorization = "Bearer $agentKey" }
+    try {
+        $receipt = Invoke-RestMethod -Method Post -Uri "$baseUri/v1/model/activate" `
+            -Headers $headers -ContentType "application/json" -Body $payload `
+            -UseBasicParsing -TimeoutSec $ActivationTimeoutSeconds -ErrorAction Stop
+    } catch {
+        $detail = Get-WindowsODSHttpErrorDetail -ErrorRecord $_
+        throw "Model activation failed: $detail"
+    }
+
+    $receiptContext = 0
+    $validReceiptContext = [int]::TryParse(
+        [string]$receipt.context_length,
+        [ref]$receiptContext
+    ) -and $receiptContext -gt 0
+    if ([string]$receipt.status -ne "activated" -or
+        [string]$receipt.model_id -ne $ModelId -or
+        [string]$receipt.tier -ne $Tier -or
+        -not $validReceiptContext) {
+        throw "Host agent returned an invalid model activation receipt"
+    }
+    return $receipt
+}

--- a/ods/installers/windows/lib/tier-map.ps1
+++ b/ods/installers/windows/lib/tier-map.ps1
@@ -369,9 +369,12 @@ function Resolve-GemmaTierConfig {
 }
 
 function Resolve-TierConfig {
-    param([string]$Tier)
+    param(
+        [string]$Tier,
+        [string]$ModelProfile = $env:MODEL_PROFILE
+    )
 
-    $requestedProfile = Normalize-ModelProfile
+    $requestedProfile = Normalize-ModelProfile -ModelProfile $ModelProfile
     $effectiveProfile = Resolve-EffectiveModelProfile -Tier $Tier -RequestedProfile $requestedProfile
 
     switch ($effectiveProfile) {

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -2659,8 +2659,11 @@ function Invoke-Model {
                 }
                 $tier = $tier.ToUpperInvariant()
 
-                # Retrieve the model config using tier-map functions
-                $model = ConvertTo-ModelFromTier -Tier $tier
+                # Use the persisted profile for both selection and activation
+                # validation, even when this shell has no MODEL_PROFILE set.
+                $envVars = Read-ODSEnv
+                $modelProfile = [string]$envVars["MODEL_PROFILE"]
+                $model = ConvertTo-ModelFromTier -Tier $tier -ModelProfile $modelProfile
                 if ([string]::IsNullOrWhiteSpace($model)) {
                     Write-AIError "Unknown tier: $tier"
                     return
@@ -2676,12 +2679,11 @@ function Invoke-Model {
                 }
 
                 # Resolve tier config to obtain GGUF details
-                $tierConfig = Resolve-TierConfig -Tier $normTier
+                $tierConfig = Resolve-TierConfig -Tier $normTier -ModelProfile $modelProfile
 
                 try {
                     $modelId = Resolve-WindowsODSModelCatalogId `
                         -InstallDir $InstallDir -GgufFile $tierConfig.GgufFile
-                    $envVars = Read-ODSEnv
                     Write-AI "Activating $model across ODS consumers..."
                     $receipt = Invoke-WindowsODSModelActivationTransaction `
                         -EnvMap $envVars -ModelId $modelId -Tier $normTier `

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -46,6 +46,7 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "backend-contract.ps1")
 . (Join-Path $LibDir "detection.ps1")
 . (Join-Path $LibDir "llm-endpoint.ps1")
+. (Join-Path $LibDir "model-activation.ps1")
 . (Join-Path $LibDir "install-report.ps1")
 . (Join-Path $LibDir "tier-map.ps1")
 
@@ -2677,15 +2678,19 @@ function Invoke-Model {
                 # Resolve tier config to obtain GGUF details
                 $tierConfig = Resolve-TierConfig -Tier $normTier
 
-                # Set in .env
-                Set-ODSEnvValue -Key "LLM_MODEL" -Value $model
-                Set-ODSEnvValue -Key "TIER" -Value $normTier
-                Set-ODSEnvValue -Key "GGUF_FILE" -Value $tierConfig.GgufFile
-                Set-ODSEnvValue -Key "GGUF_URL" -Value $tierConfig.GgufUrl
-                Set-ODSEnvValue -Key "CTX_SIZE" -Value $tierConfig.MaxContext
-                Set-ODSEnvValue -Key "MAX_CONTEXT" -Value $tierConfig.MaxContext
-
-                Write-AISuccess "Model set to $model (tier $tier, ctx=$($tierConfig.MaxContext)). Run '.\ods.ps1 restart' to apply."
+                try {
+                    $modelId = Resolve-WindowsODSModelCatalogId `
+                        -InstallDir $InstallDir -GgufFile $tierConfig.GgufFile
+                    $envVars = Read-ODSEnv
+                    Write-AI "Activating $model across ODS consumers..."
+                    $receipt = Invoke-WindowsODSModelActivationTransaction `
+                        -EnvMap $envVars -ModelId $modelId -Tier $normTier `
+                        -ContextLength ([int]$tierConfig.MaxContext)
+                    Write-AISuccess "Model activated everywhere: $model (tier $($receipt.tier), ctx=$($receipt.context_length))."
+                } catch {
+                    Write-AIError $_.Exception.Message
+                    exit 1
+                }
             }
             default {
                 Write-AIError "Usage: .\ods.ps1 model <current|list|swap>"

--- a/ods/tests/test-windows-cli-model.sh
+++ b/ods/tests/test-windows-cli-model.sh
@@ -62,6 +62,18 @@ if grep -q 'Set-ODSEnvValue' <<< "$invoke_model_body"; then
 fi
 pass "Invoke-Model uses transactional activation without direct env mutation"
 
+info "Static: model swap resolves the persisted MODEL_PROFILE before tier selection"
+grep -q 'ConvertTo-ModelFromTier -Tier \$tier -ModelProfile \$modelProfile' <<< "$invoke_model_body" \
+    || fail "Invoke-Model does not pass persisted MODEL_PROFILE to model selection"
+grep -q 'Resolve-TierConfig -Tier \$normTier -ModelProfile \$modelProfile' <<< "$invoke_model_body" \
+    || fail "Invoke-Model does not pass persisted MODEL_PROFILE to tier resolution"
+env_read_line=$(grep -n '\$envVars = Read-ODSEnv' <<< "$invoke_model_body" | head -1 | cut -d: -f1)
+model_select_line=$(grep -n 'ConvertTo-ModelFromTier' <<< "$invoke_model_body" | head -1 | cut -d: -f1)
+if [[ -z "$env_read_line" || -z "$model_select_line" || $env_read_line -ge $model_select_line ]]; then
+    fail "Invoke-Model must read persisted env before selecting the model"
+fi
+pass "Invoke-Model uses persisted MODEL_PROFILE consistently"
+
 info "Static: command dispatcher wires 'model'"
 grep -q '"model"' "$ODS_PS1" && grep -q 'Invoke-Model' "$ODS_PS1" \
     || fail "Dispatcher does not call Invoke-Model for 'model'"

--- a/ods/tests/test-windows-cli-model.sh
+++ b/ods/tests/test-windows-cli-model.sh
@@ -53,12 +53,14 @@ grep -q 'Resolve-TierConfig' "$ODS_PS1" \
     || fail "Invoke-Model does not call Resolve-TierConfig"
 pass "Invoke-Model integrates with tier-map functions"
 
-info "Static: Invoke-Model uses Set-ODSEnvValue to update .env on swap"
-grep -q 'Set-ODSEnvValue -Key "LLM_MODEL"' "$ODS_PS1" \
-    || fail "Invoke-Model does not set LLM_MODEL"
-grep -q 'Set-ODSEnvValue -Key "TIER"' "$ODS_PS1" \
-    || fail "Invoke-Model does not set TIER"
-pass "Invoke-Model updates .env variables correctly on swap"
+info "Static: Invoke-Model routes swaps through the host-agent transaction"
+invoke_model_body=$(sed -n '/^function Invoke-Model {/,/^function Show-Help {/p' "$ODS_PS1")
+grep -q 'Invoke-WindowsODSModelActivationTransaction' <<< "$invoke_model_body" \
+    || fail "Invoke-Model does not call the transactional activation helper"
+if grep -q 'Set-ODSEnvValue' <<< "$invoke_model_body"; then
+    fail "Invoke-Model must not bypass rollback with direct .env writes"
+fi
+pass "Invoke-Model uses transactional activation without direct env mutation"
 
 info "Static: command dispatcher wires 'model'"
 grep -q '"model"' "$ODS_PS1" && grep -q 'Invoke-Model' "$ODS_PS1" \

--- a/ods/tests/test-windows-model-activation.ps1
+++ b/ods/tests/test-windows-model-activation.ps1
@@ -2,6 +2,7 @@ $ErrorActionPreference = "Stop"
 
 $root = Split-Path -Parent $PSScriptRoot
 . (Join-Path $root "installers\windows\lib\model-activation.ps1")
+. (Join-Path $root "installers\windows\lib\tier-map.ps1")
 
 function Assert-Equal {
     param($Actual, $Expected, [string]$Label)
@@ -33,6 +34,20 @@ Set-Content -LiteralPath (Join-Path $tempRoot "data\models\model.gguf") -Value "
 } | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $tempRoot "config\model-library.json")
 
 try {
+    $previousModelProfile = $env:MODEL_PROFILE
+    try {
+        $env:MODEL_PROFILE = "qwen"
+        Assert-Equal `
+            (ConvertTo-ModelFromTier -Tier "T1" -ModelProfile "gemma4") `
+            "gemma-4-e2b-it" "Explicit model profile selection"
+        $gemmaTier = Resolve-TierConfig -Tier "1" -ModelProfile "gemma4"
+        Assert-Equal $gemmaTier.LlmModel "gemma-4-e2b-it" "Explicit tier profile model"
+        Assert-Equal $gemmaTier.GgufFile `
+            "gemma-4-E2B-it-Q4_K_M.gguf" "Explicit tier profile GGUF"
+    } finally {
+        $env:MODEL_PROFILE = $previousModelProfile
+    }
+
     Assert-Equal (Resolve-WindowsODSModelCatalogId -InstallDir $tempRoot -GgufFile "model.gguf") `
         "catalog-model" "Catalog model resolution"
     Assert-Throws { Resolve-WindowsODSModelCatalogId -InstallDir $tempRoot -GgufFile "..\model.gguf" } `

--- a/ods/tests/test-windows-model-activation.ps1
+++ b/ods/tests/test-windows-model-activation.ps1
@@ -1,0 +1,111 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path -Parent $PSScriptRoot
+. (Join-Path $root "installers\windows\lib\model-activation.ps1")
+
+function Assert-Equal {
+    param($Actual, $Expected, [string]$Label)
+    if ($Actual -ne $Expected) {
+        throw "$Label expected '$Expected', got '$Actual'"
+    }
+}
+
+function Assert-Throws {
+    param([scriptblock]$Action, [string]$Pattern, [string]$Label)
+    try {
+        & $Action
+    } catch {
+        if ($_.Exception.Message -notmatch $Pattern) {
+            throw "$Label threw the wrong error: $($_.Exception.Message)"
+        }
+        return
+    }
+    throw "$Label did not throw"
+}
+
+$tempRoot = Join-Path ([IO.Path]::GetTempPath()) "ods-windows-model-activation-contract"
+Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path (Join-Path $tempRoot "config") -Force | Out-Null
+New-Item -ItemType Directory -Path (Join-Path $tempRoot "data\models") -Force | Out-Null
+Set-Content -LiteralPath (Join-Path $tempRoot "data\models\model.gguf") -Value "fixture"
+@{
+    models = @(@{ id = "catalog-model"; gguf_file = "model.gguf" })
+} | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath (Join-Path $tempRoot "config\model-library.json")
+
+try {
+    Assert-Equal (Resolve-WindowsODSModelCatalogId -InstallDir $tempRoot -GgufFile "model.gguf") `
+        "catalog-model" "Catalog model resolution"
+    Assert-Throws { Resolve-WindowsODSModelCatalogId -InstallDir $tempRoot -GgufFile "..\model.gguf" } `
+        "invalid GGUF filename" "GGUF traversal rejection"
+
+    Assert-Equal (Resolve-WindowsODSAgentBaseUri -EnvMap @{ ODS_AGENT_BIND = "0.0.0.0" }) `
+        "http://127.0.0.1:7710" "Wildcard bind normalization"
+    Assert-Equal (Resolve-WindowsODSAgentBaseUri -EnvMap @{
+        ODS_AGENT_BIND = "::1"; ODS_AGENT_PORT = "7788"
+    }) "http://[::1]:7788" "IPv6 agent URI"
+    Assert-Throws {
+        Resolve-WindowsODSAgentBaseUri -EnvMap @{ ODS_AGENT_PORT = "70000" }
+    } "between 1 and 65535" "Invalid agent port"
+
+    $script:activationMode = "success"
+    $script:lastActivation = $null
+    function Invoke-WebRequest {
+        param($Method, $Uri, [switch]$UseBasicParsing, $TimeoutSec, $ErrorAction)
+        return [pscustomobject]@{ StatusCode = 200 }
+    }
+    function Invoke-RestMethod {
+        param($Method, $Uri, $Headers, $ContentType, $Body, [switch]$UseBasicParsing, $TimeoutSec, $ErrorAction)
+        $script:lastActivation = @{
+            Uri = $Uri; Headers = $Headers; ContentType = $ContentType
+            Body = $Body; TimeoutSec = $TimeoutSec
+        }
+        if ($script:activationMode -eq "failure") { throw "simulated activation failure" }
+        if ($script:activationMode -eq "invalid") {
+            return [pscustomobject]@{ status = "activated"; model_id = "wrong-model"; tier = "1"; context_length = 8192 }
+        }
+        return [pscustomobject]@{
+            status = "activated"; model_id = "catalog-model"; tier = "1"
+            context_length = 8192; consumers = @{ hermes = "restarted" }
+        }
+    }
+
+    $envMap = @{ ODS_AGENT_KEY = "secret"; ODS_AGENT_PORT = "7710" }
+    $receipt = Invoke-WindowsODSModelActivationTransaction -EnvMap $envMap `
+        -ModelId "catalog-model" -Tier "1" -ContextLength 8192
+    Assert-Equal $receipt.status "activated" "Activation status"
+    Assert-Equal $script:lastActivation.Uri "http://127.0.0.1:7710/v1/model/activate" "Activation URI"
+    Assert-Equal $script:lastActivation.Headers.Authorization "Bearer secret" "Bearer header"
+    Assert-Equal $script:lastActivation.TimeoutSec 2700 "Activation timeout"
+    $request = $script:lastActivation.Body | ConvertFrom-Json
+    Assert-Equal $request.model_id "catalog-model" "Activation model ID"
+    Assert-Equal $request.tier "1" "Activation tier"
+    Assert-Equal $request.context_length 8192 "Activation context"
+
+    $fallbackEnv = @{ DASHBOARD_API_KEY = "dashboard-secret" }
+    $null = Invoke-WindowsODSModelActivationTransaction -EnvMap $fallbackEnv `
+        -ModelId "catalog-model" -Tier "1" -ContextLength 8192
+    Assert-Equal $script:lastActivation.Headers.Authorization `
+        "Bearer dashboard-secret" "Dashboard key fallback"
+
+    $script:activationMode = "invalid"
+    Assert-Throws {
+        Invoke-WindowsODSModelActivationTransaction -EnvMap $envMap `
+            -ModelId "catalog-model" -Tier "1" -ContextLength 8192
+    } "invalid model activation receipt" "Receipt identity validation"
+
+    Assert-Throws {
+        Invoke-WindowsODSModelActivationTransaction `
+            -EnvMap @{ ODS_AGENT_KEY = "bad`nkey" } `
+            -ModelId "catalog-model" -Tier "1" -ContextLength 8192
+    } "invalid newline" "Bearer newline rejection"
+
+    $script:activationMode = "failure"
+    Assert-Throws {
+        Invoke-WindowsODSModelActivationTransaction -EnvMap $envMap `
+            -ModelId "catalog-model" -Tier "1" -ContextLength 8192
+    } "Model activation failed" "Activation failure propagation"
+
+    Write-Host "[PASS] Windows transactional model activation"
+} finally {
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

Brings \.\ods.ps1 model swap <tier> onto the same authenticated, rollback-capable host-agent activation transaction used by the Dashboard and Unix CLI.

## Problem

The Windows command still wrote model, tier, GGUF, and context fields directly to .env, then told the user to restart. That bypassed runtime preflight, downstream consumer synchronization, exact completion probes, lifecycle locking, and rollback. A failed or interrupted swap could therefore leave Windows configuration and active consumers on different models.

## Transaction Flow

1. Resolve the requested tier through the Windows tier map.
2. Require a non-empty downloaded GGUF with a single matching catalog entry.
3. Resolve and validate the local host-agent endpoint and bearer key.
4. Submit the exact model ID, normalized tier, and context to /v1/model/activate.
5. Wait up to 45 minutes for runtime and downstream synchronization.
6. Accept success only when the receipt matches the requested model and tier with a positive effective context.

The CLI no longer mutates .env directly. Runtime writes, consumer updates, health proof, and rollback remain owned by the host-agent transaction landed in #1887.

## Safety

- rejects missing, empty, traversing, ambiguous, or malformed catalog artifacts before the request
- validates host/port input and normalizes wildcard binds to loopback
- supports IPv4, IPv6, dedicated ODS_AGENT_KEY, and the dashboard-key fallback
- rejects newline-bearing credentials, model IDs, and tiers
- sends the bearer key in the PowerShell HTTP header, never in a process argument or file
- propagates host-agent failures without reporting activation success
- leaves the prior model untouched when preflight or the transaction fails

## Validation

- 	ests/test-windows-model-activation.ps1 - passed
- 	ests/test-windows-cli-model.sh - passed
- PowerShell parser checks - passed
- git diff --check - passed
- Windows and Ubuntu PSScriptAnalyzer plus the new behavioral contract run in CI

## Scope

This closes the Windows CLI parity item documented by #1887. Arbitrary custom GGUF import remains intentionally outside tier-based model swap.