### PR TITLE
feat(models): add versioned switchboard state (PR 1, observe mode)

### DIFF
--- a/ods/bin/model_switchboard/__init__.py
+++ b/ods/bin/model_switchboard/__init__.py
@@ -1,0 +1,32 @@
+"""ODS Model Switchboard support package.
+
+PR 1 scope: the versioned model-state record only. The host agent is the
+single writer; everything else reads. Stdlib-only by contract so the
+standalone host agent can import it from the installed tree.
+"""
+
+from .state import (  # noqa: F401
+    HISTORY_LIMIT,
+    SCHEMA_VERSION,
+    StateError,
+    atomic_write_state,
+    initial_state,
+    initialize_if_missing,
+    migrate_env_identity,
+    read_state,
+    record_verified_route,
+    validate_state,
+)
+
+__all__ = [
+    "HISTORY_LIMIT",
+    "SCHEMA_VERSION",
+    "StateError",
+    "atomic_write_state",
+    "initial_state",
+    "initialize_if_missing",
+    "migrate_env_identity",
+    "read_state",
+    "record_verified_route",
+    "validate_state",
+]

--- a/ods/bin/model_switchboard/state.py
+++ b/ods/bin/model_switchboard/state.py
@@ -1,0 +1,415 @@
+"""Versioned model-state record for the ODS Model Switchboard (PR 1).
+
+Contract highlights (see ods/docs/MODEL-SWITCHBOARD.md, section 3.2):
+
+- The host agent is the only writer. Writes are temp-file + flush + fsync
+  where available + atomic replace; a reader can never observe partial JSON.
+- ``seq`` increments on every mutation; ``routeSeq`` increments only when the
+  active route changes.
+- ``active`` always remains the last proven route. In observe mode this module
+  is called only after the existing activation transaction has already proved
+  success, so a failed activation never touches the record.
+- ``history`` keeps the last ``HISTORY_LIMIT`` verified active routes.
+- Startup reconstruction from ``.env`` is permitted only when no v1 state has
+  ever been committed, and is marked ``reconstructed`` with an unproven
+  completion so it can never masquerade as a verified proof.
+
+Stdlib only: the standalone host agent imports this from the installed tree.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "ods.model-state.v1"
+HISTORY_LIMIT = 10
+PUBLIC_MODEL_DEFAULT = "ods/current"
+
+_BACKEND_KINDS = {"llama-server", "lemonade", "hipfire", "unknown"}
+_OPERATION_PHASES = {
+    "requested", "staging", "verifying", "publishing",
+    "flipping", "serving", "failed", "rolling_back",
+}
+_AVAILABILITY_MODES = {"serve_active", "queue"}
+
+_WRITE_LOCK = threading.Lock()
+_LAST_GOOD: dict[str, dict[str, Any]] = {}
+
+
+class StateError(RuntimeError):
+    """Raised for unrecoverable state-record violations (writer side)."""
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def initial_state() -> dict[str, Any]:
+    return {
+        "schema": SCHEMA_VERSION,
+        "seq": 0,
+        "routeSeq": 0,
+        "operation": None,
+        "desired": None,
+        "active": None,
+        "history": [],
+        "availability": {"mode": "serve_active", "queueDeadline": None},
+    }
+
+
+def validate_state(doc: Any) -> list[str]:
+    """Structural validation without third-party dependencies.
+
+    Returns a list of human-readable problems; empty means valid. The JSON
+    Schema at ods/config/model-state.schema.v1.json is the authoritative
+    published contract; this validator must stay in agreement with it.
+    """
+    errors: list[str] = []
+    if not isinstance(doc, dict):
+        return ["state root must be an object"]
+    if doc.get("schema") != SCHEMA_VERSION:
+        errors.append(f"schema must be {SCHEMA_VERSION!r}")
+    for key in ("seq", "routeSeq"):
+        value = doc.get(key)
+        if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+            errors.append(f"{key} must be a non-negative integer")
+
+    operation = doc.get("operation")
+    if operation is not None:
+        if not isinstance(operation, dict):
+            errors.append("operation must be null or an object")
+        else:
+            if not isinstance(operation.get("id"), str) or not operation.get("id"):
+                errors.append("operation.id must be a non-empty string")
+            if operation.get("phase") not in _OPERATION_PHASES:
+                errors.append("operation.phase is not a known phase")
+            if not isinstance(operation.get("requestedModelId"), str):
+                errors.append("operation.requestedModelId must be a string")
+            if not isinstance(operation.get("startedAt"), str):
+                errors.append("operation.startedAt must be a string")
+
+    desired = doc.get("desired")
+    if desired is not None:
+        if not isinstance(desired, dict) or not isinstance(desired.get("catalogId"), str) \
+                or not desired.get("catalogId"):
+            errors.append("desired must be null or {catalogId: non-empty string}")
+
+    active = doc.get("active")
+    if active is not None:
+        if not isinstance(active, dict):
+            errors.append("active must be null or an object")
+        else:
+            if not isinstance(active.get("routeSeq"), int) or isinstance(active.get("routeSeq"), bool):
+                errors.append("active.routeSeq must be an integer")
+            for key in ("catalogId", "runtimeModelId", "publicModel"):
+                if not isinstance(active.get(key), str) or not active.get(key):
+                    errors.append(f"active.{key} must be a non-empty string")
+            backend = active.get("backend")
+            if not isinstance(backend, dict):
+                errors.append("active.backend must be an object")
+            else:
+                if backend.get("kind") not in _BACKEND_KINDS:
+                    errors.append("active.backend.kind is not a known backend kind")
+                if not isinstance(backend.get("endpointId"), str) or not backend.get("endpointId"):
+                    errors.append("active.backend.endpointId must be a non-empty string")
+                native_route = backend.get("nativeRoute")
+                if native_route is not None and not isinstance(native_route, str):
+                    errors.append("active.backend.nativeRoute must be a string or null")
+            context_length = active.get("contextLength")
+            if not isinstance(context_length, int) or isinstance(context_length, bool) or context_length < 0:
+                errors.append("active.contextLength must be a non-negative integer")
+            capabilities = active.get("capabilities")
+            if not isinstance(capabilities, dict):
+                errors.append("active.capabilities must be an object")
+            else:
+                for key in ("chat", "tools", "vision", "agentViable"):
+                    if not isinstance(capabilities.get(key), bool):
+                        errors.append(f"active.capabilities.{key} must be a boolean")
+            verified_at = active.get("verifiedAt")
+            if verified_at is not None and not isinstance(verified_at, str):
+                errors.append("active.verifiedAt must be a string or null")
+            proof = active.get("proof")
+            if not isinstance(proof, dict) or not isinstance(proof.get("completion"), bool):
+                errors.append("active.proof must be {identity, completion: bool}")
+
+    history = doc.get("history")
+    if not isinstance(history, list):
+        errors.append("history must be an array")
+    else:
+        if len(history) > HISTORY_LIMIT:
+            errors.append(f"history exceeds {HISTORY_LIMIT} entries")
+        for index, entry in enumerate(history):
+            if not isinstance(entry, dict):
+                errors.append(f"history[{index}] must be an object")
+                continue
+            if not isinstance(entry.get("routeSeq"), int) or isinstance(entry.get("routeSeq"), bool):
+                errors.append(f"history[{index}].routeSeq must be an integer")
+            for key in ("catalogId", "runtimeModelId"):
+                if not isinstance(entry.get(key), str):
+                    errors.append(f"history[{index}].{key} must be a string")
+
+    availability = doc.get("availability")
+    if not isinstance(availability, dict) or availability.get("mode") not in _AVAILABILITY_MODES:
+        errors.append("availability.mode must be serve_active or queue")
+
+    return errors
+
+
+def read_state(path: os.PathLike | str) -> tuple[dict[str, Any] | None, list[str]]:
+    """Read and validate the state record.
+
+    Returns ``(doc, [])`` on success. On a missing file returns
+    ``(None, [])``. On malformed or invalid content returns
+    ``(last_known_good_or_None, errors)`` — malformed state never promotes
+    anything and never raises out of a reader.
+    """
+    key = str(Path(path))
+    raw = None
+    last_exc: OSError | None = None
+    for _attempt in range(4):
+        try:
+            raw = Path(path).read_text(encoding="utf-8")
+            break
+        except FileNotFoundError:
+            return None, []
+        except PermissionError as exc:
+            # Windows: os.replace briefly locks the destination; a concurrent
+            # reader can hit a transient sharing violation. Retry, then fall
+            # back to the last known-good snapshot.
+            last_exc = exc
+            time.sleep(0.005)
+        except OSError as exc:
+            return _LAST_GOOD.get(key), [f"state read failed: {exc}"]
+    if raw is None:
+        return _LAST_GOOD.get(key), [f"state read failed: {last_exc}"]
+    try:
+        doc = json.loads(raw)
+    except ValueError as exc:
+        return _LAST_GOOD.get(key), [f"state is not valid JSON: {exc}"]
+    errors = validate_state(doc)
+    if errors:
+        return _LAST_GOOD.get(key), errors
+    _LAST_GOOD[key] = doc
+    return doc, []
+
+
+def atomic_write_state(path: os.PathLike | str, doc: dict[str, Any]) -> None:
+    """Atomically persist ``doc``: same-directory temp file, fsync, replace."""
+    errors = validate_state(doc)
+    if errors:
+        raise StateError("refusing to write invalid state: " + "; ".join(errors))
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(doc, indent=2, sort_keys=False) + "\n"
+    fd, tmp_name = tempfile.mkstemp(
+        prefix=target.name + ".", suffix=".tmp", dir=str(target.parent)
+    )
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(payload)
+            handle.flush()
+            try:
+                os.fsync(handle.fileno())
+            except OSError:
+                pass
+        replace_error: OSError | None = None
+        for _attempt in range(40):
+            try:
+                os.replace(tmp_name, target)
+                replace_error = None
+                break
+            except PermissionError as exc:
+                # Windows: a concurrent reader holding the destination open can
+                # make the atomic rename transiently fail with a sharing
+                # violation. Retry briefly; the writer is the single mutator.
+                replace_error = exc
+                time.sleep(0.005)
+        if replace_error is not None:
+            raise replace_error
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    try:  # best-effort directory durability on POSIX
+        dir_fd = os.open(str(target.parent), getattr(os, "O_DIRECTORY", os.O_RDONLY))
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)
+    except OSError:
+        pass
+    _LAST_GOOD[str(target)] = doc
+
+
+def record_verified_route(
+    path: os.PathLike | str,
+    *,
+    catalog_id: str,
+    runtime_model_id: str,
+    backend_kind: str,
+    endpoint_id: str,
+    context_length: int,
+    capabilities: dict[str, bool],
+    proof_identity: str | None,
+    proof_completion: bool = True,
+    native_route: str | None = None,
+    public_model: str = PUBLIC_MODEL_DEFAULT,
+    reconstructed: bool = False,
+) -> dict[str, Any]:
+    """Record a proven active route (observe mode: call only after success).
+
+    Reload-modify-write under a process lock. If the on-disk record is valid
+    and newer than our cache, the on-disk record wins as the base — a writer
+    can never regress ``seq``.
+    """
+    if backend_kind not in _BACKEND_KINDS:
+        backend_kind = "unknown"
+    with _WRITE_LOCK:
+        base, errors = read_state(path)
+        if base is None:
+            if errors:
+                # Malformed state on disk: do not guess; start a fresh record
+                # but never delete the malformed file's information silently.
+                raise StateError(
+                    "existing state is malformed; refusing blind overwrite: "
+                    + "; ".join(errors)
+                )
+            base = initial_state()
+        doc = json.loads(json.dumps(base))  # deep copy, stdlib only
+
+        previous = doc.get("active")
+        route_changed = not (
+            isinstance(previous, dict)
+            and previous.get("runtimeModelId") == runtime_model_id
+            and isinstance(previous.get("backend"), dict)
+            and previous["backend"].get("kind") == backend_kind
+            and previous["backend"].get("endpointId") == endpoint_id
+        )
+
+        doc["seq"] = int(doc["seq"]) + 1
+        if route_changed:
+            doc["routeSeq"] = int(doc["routeSeq"]) + 1
+            if isinstance(previous, dict):
+                history_entry = {
+                    "routeSeq": previous.get("routeSeq", 0),
+                    "catalogId": previous.get("catalogId", ""),
+                    "runtimeModelId": previous.get("runtimeModelId", ""),
+                    "verifiedAt": previous.get("verifiedAt"),
+                }
+                doc["history"] = ([history_entry] + list(doc.get("history") or []))[:HISTORY_LIMIT]
+
+        doc["desired"] = {"catalogId": catalog_id}
+        active: dict[str, Any] = {
+            "routeSeq": doc["routeSeq"],
+            "catalogId": catalog_id,
+            "runtimeModelId": runtime_model_id,
+            "publicModel": public_model,
+            "backend": {
+                "kind": backend_kind,
+                "endpointId": endpoint_id,
+                "nativeRoute": native_route,
+            },
+            "contextLength": int(context_length),
+            "capabilities": {
+                "chat": bool(capabilities.get("chat", True)),
+                "tools": bool(capabilities.get("tools", False)),
+                "vision": bool(capabilities.get("vision", False)),
+                "agentViable": bool(capabilities.get("agentViable", False)),
+            },
+            "verifiedAt": None if reconstructed else _utcnow_iso(),
+            "proof": {"identity": proof_identity, "completion": bool(proof_completion)},
+        }
+        if reconstructed:
+            active["reconstructed"] = True
+        doc["active"] = active
+        doc["operation"] = None
+        doc["availability"] = {"mode": "serve_active", "queueDeadline": None}
+
+        atomic_write_state(path, doc)
+        return doc
+
+
+def migrate_env_identity(env: dict[str, str]) -> dict[str, Any] | None:
+    """Derive a best-effort runtime identity from legacy ``.env`` values.
+
+    Handles the shipped forms: plain GGUF filenames, Lemonade stems,
+    ``extra.``-prefixed Lemonade IDs, and native model names. Returns ``None``
+    when the environment carries no local model identity (e.g. cloud-only).
+    """
+    gguf = str(env.get("GGUF_FILE") or "").strip()
+    lemonade = str(env.get("LEMONADE_MODEL") or "").strip()
+    llm_model = str(env.get("LLM_MODEL") or "").strip()
+
+    runtime_id = lemonade or gguf or llm_model
+    if not runtime_id:
+        return None
+
+    backend = str(env.get("LLM_BACKEND") or "").strip().lower()
+    if not backend:
+        runtime_hint = str(env.get("AMD_INFERENCE_RUNTIME") or "").strip().lower()
+        backend = "lemonade" if (lemonade or runtime_hint == "lemonade") else "llama-server"
+    if backend not in _BACKEND_KINDS:
+        backend = "unknown"
+
+    catalog_guess = llm_model
+    if not catalog_guess:
+        stem = runtime_id[len("extra."):] if runtime_id.startswith("extra.") else runtime_id
+        if stem.lower().endswith(".gguf"):
+            stem = stem[: -len(".gguf")]
+        catalog_guess = stem
+
+    try:
+        context = int(str(env.get("MAX_CONTEXT") or env.get("CTX_SIZE") or "0").strip() or 0)
+    except ValueError:
+        context = 0
+
+    return {
+        "catalogId": catalog_guess,
+        "runtimeModelId": runtime_id,
+        "backendKind": backend,
+        "contextLength": max(0, context),
+    }
+
+
+def initialize_if_missing(
+    path: os.PathLike | str,
+    env: dict[str, str],
+    *,
+    endpoint_id: str = "local-default",
+) -> dict[str, Any] | None:
+    """One-time startup reconstruction when no v1 state was ever committed.
+
+    Existing files — valid or malformed — are never overwritten here. Returns
+    the written doc, or ``None`` when nothing was written.
+    """
+    if Path(path).exists():
+        return None
+    identity = migrate_env_identity(env)
+    if identity is None:
+        return None
+    return record_verified_route(
+        path,
+        catalog_id=identity["catalogId"],
+        runtime_model_id=identity["runtimeModelId"],
+        backend_kind=identity["backendKind"],
+        endpoint_id=endpoint_id,
+        context_length=identity["contextLength"],
+        capabilities={
+            "chat": True,
+            "tools": False,
+            "vision": False,
+            "agentViable": identity["contextLength"] >= 65536,
+        },
+        proof_identity=identity["runtimeModelId"],
+        proof_completion=False,
+        reconstructed=True,
+    )

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -39,6 +39,17 @@ from socketserver import ThreadingMixIn
 from urllib import error as urllib_error, request as urllib_request
 from urllib.parse import parse_qs, unquote, urlparse
 
+# Model Switchboard (PR 1, observe mode): stdlib-only sibling package. The
+# import is fail-open — a missing/broken package disables state recording but
+# never the agent itself.
+_SWITCHBOARD_BIN_DIR = str(Path(__file__).resolve().parent)
+if _SWITCHBOARD_BIN_DIR not in sys.path:
+    sys.path.insert(0, _SWITCHBOARD_BIN_DIR)
+try:
+    from model_switchboard import state as _switchboard_state
+except Exception:  # pragma: no cover - import environment dependent
+    _switchboard_state = None
+
 VERSION = "1.0.0"
 ODS_VERSION = VERSION
 SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
@@ -5569,6 +5580,39 @@ class AgentHandler(BaseHTTPRequestHandler):
                 if opencode_snapshot is not None and opencode_runtime_state is not None:
                     opencode_restarted = _restart_managed_opencode(opencode_runtime_state)
                 committed = True  # system state is committed before the response write
+                if _switchboard_state is not None:
+                    # Observe mode: record the proven route after the existing
+                    # transaction committed. Failures are logged, never fatal,
+                    # and never alter activation behavior.
+                    try:
+                        _switchboard_state.record_verified_route(
+                            INSTALL_DIR / "data" / "model-state.json",
+                            catalog_id=str(model_id),
+                            runtime_model_id=str(
+                                lemonade_model_id or gguf_file or llm_model_name
+                            ),
+                            backend_kind=(
+                                "lemonade" if lemonade_model_id else "llama-server"
+                            ),
+                            endpoint_id=(
+                                "lemonade-default"
+                                if lemonade_model_id
+                                else "llama-server-default"
+                            ),
+                            native_route=(lemonade_model_id or None),
+                            context_length=int(context_length),
+                            capabilities={
+                                "chat": True,
+                                "tools": bool(model.get("tools")),
+                                "vision": bool(model.get("vision")),
+                                "agentViable": int(context_length) >= 65536,
+                            },
+                            proof_identity=str(
+                                lemonade_model_id or gguf_file or llm_model_name
+                            ),
+                        )
+                    except Exception as exc:
+                        logger.warning("switchboard state record failed: %s", exc)
                 json_response(
                     self,
                     200,
@@ -9155,6 +9199,13 @@ def main():
         logger.error("Neither ODS_AGENT_KEY nor DASHBOARD_API_KEY set in .env")
         sys.exit(1)
     GPU_BACKEND = env.get("GPU_BACKEND", "nvidia")
+    if _switchboard_state is not None:
+        try:
+            _switchboard_state.initialize_if_missing(
+                INSTALL_DIR / "data" / "model-state.json", env
+            )
+        except Exception as exc:
+            logger.warning("switchboard state init skipped: %s", exc)
     STARTUP_ODS_MODE = _normalize_ods_mode(env.get("ODS_MODE"))
     TIER = env.get("TIER", "1")
     GPU_COUNT = env.get("GPU_COUNT", "1")

--- a/ods/config/model-state.schema.v1.json
+++ b/ods/config/model-state.schema.v1.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://osmantic.dev/schemas/ods.model-state.v1.json",
+  "title": "ODS Model Switchboard state record (v1)",
+  "type": "object",
+  "required": ["schema", "seq", "routeSeq", "desired", "active", "history", "availability"],
+  "additionalProperties": false,
+  "properties": {
+    "schema": { "const": "ods.model-state.v1" },
+    "seq": { "type": "integer", "minimum": 0 },
+    "routeSeq": { "type": "integer", "minimum": 0 },
+    "operation": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["id", "phase", "requestedModelId", "startedAt"],
+          "additionalProperties": false,
+          "properties": {
+            "id": { "type": "string", "minLength": 1 },
+            "phase": {
+              "enum": ["requested", "staging", "verifying", "publishing", "flipping", "serving", "failed", "rolling_back"]
+            },
+            "requestedModelId": { "type": "string" },
+            "startedAt": { "type": "string" },
+            "error": { "type": ["string", "null"] }
+          }
+        }
+      ]
+    },
+    "desired": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["catalogId"],
+          "additionalProperties": false,
+          "properties": { "catalogId": { "type": "string", "minLength": 1 } }
+        }
+      ]
+    },
+    "active": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["routeSeq", "catalogId", "runtimeModelId", "publicModel", "backend", "contextLength", "capabilities", "verifiedAt", "proof"],
+          "additionalProperties": false,
+          "properties": {
+            "routeSeq": { "type": "integer", "minimum": 0 },
+            "catalogId": { "type": "string", "minLength": 1 },
+            "runtimeModelId": { "type": "string", "minLength": 1 },
+            "publicModel": { "type": "string", "minLength": 1 },
+            "backend": {
+              "type": "object",
+              "required": ["kind", "endpointId"],
+              "additionalProperties": false,
+              "properties": {
+                "kind": { "enum": ["llama-server", "lemonade", "hipfire", "unknown"] },
+                "endpointId": { "type": "string", "minLength": 1 },
+                "nativeRoute": { "type": ["string", "null"] }
+              }
+            },
+            "contextLength": { "type": "integer", "minimum": 0 },
+            "capabilities": {
+              "type": "object",
+              "required": ["chat", "tools", "vision", "agentViable"],
+              "additionalProperties": false,
+              "properties": {
+                "chat": { "type": "boolean" },
+                "tools": { "type": "boolean" },
+                "vision": { "type": "boolean" },
+                "agentViable": { "type": "boolean" }
+              }
+            },
+            "verifiedAt": { "type": ["string", "null"] },
+            "reconstructed": { "type": "boolean" },
+            "proof": {
+              "type": "object",
+              "required": ["identity", "completion"],
+              "additionalProperties": false,
+              "properties": {
+                "identity": { "type": ["string", "null"] },
+                "completion": { "type": "boolean" }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "history": {
+      "type": "array",
+      "maxItems": 10,
+      "items": {
+        "type": "object",
+        "required": ["routeSeq", "catalogId", "runtimeModelId", "verifiedAt"],
+        "additionalProperties": true,
+        "properties": {
+          "routeSeq": { "type": "integer", "minimum": 0 },
+          "catalogId": { "type": "string" },
+          "runtimeModelId": { "type": "string" },
+          "verifiedAt": { "type": ["string", "null"] }
+        }
+      }
+    },
+    "availability": {
+      "type": "object",
+      "required": ["mode", "queueDeadline"],
+      "additionalProperties": false,
+      "properties": {
+        "mode": { "enum": ["serve_active", "queue"] },
+        "queueDeadline": { "type": ["string", "null"] }
+      }
+    }
+  }
+}

--- a/ods/docs/MODEL-SWITCHBOARD.md
+++ b/ods/docs/MODEL-SWITCHBOARD.md
@@ -701,7 +701,7 @@ Merge gate: freeze the PR 9 head SHA, run section 7 with default settings, and s
 
 ## 6. Harness PRs
 
-Harness changes live in `dream-fleet-test-versioned`, are committed and pushed before deployment, and record both product and harness SHAs in every run directory and result file.
+Harness changes live in the private fleet harness repository, are committed and pushed before deployment, and record both product and harness SHAs in every run directory and result file.
 
 ### 6.1 Baseline verification commands
 
@@ -742,7 +742,7 @@ git diff --check
 Harness:
 
 ```bash
-cd dream-fleet-test-versioned
+cd "$FLEET_HARNESS_DIR"
 bash tests/run.sh
 git diff --check
 ```
@@ -860,11 +860,11 @@ Harness PR B validates exactly eight entries per expected host, six distinct via
 Canonical release invocation on Tower2 after the normal identity/lock preflight:
 
 ```bash
-cd /home/michael/dream-fleet-test
+cd "$FLEET_HARNESS_DIR"
 export MODEL_UI_PRODUCT_SHA=<40-character-pushed-product-sha>
 export MODEL_UI_MODEL_PLAN_FILE=/absolute/path/to/switchboard-release-model-plan.json
-export DREAM_FLEET_MODEL_UI_TIER=release
-export DREAM_FLEET_MODEL_UI_CYCLES=8
+export FLEET_MODEL_UI_TIER=release   # harness tier variable; exact name in the harness repo docs
+export FLEET_MODEL_UI_CYCLES=8       # harness cycle variable; exact name in the harness repo docs
 ./run.sh --phase release \
   --hosts tower2,strix-halo,spark,dgx-gpu01,m5-mbp,mac-mini,windows-laptop,strixy \
   --skip-smoke

--- a/ods/docs/MODEL-SWITCHBOARD.md
+++ b/ods/docs/MODEL-SWITCHBOARD.md
@@ -1,0 +1,938 @@
+# ODS Model Switchboard PR Plan
+
+Date: 2026-07-19
+
+Last audited: 2026-07-19; refreshed 2026-07-20 against post-merge `main` `5dd6f72d` (77-PR fix sweep + #1888 + #1766 + #1711 + #1887 + #1724 all merged)
+
+Status: proposed implementation stack. The lifecycle foundation ([#1711](https://github.com/Osmantic/ODS/pull/1711)), swap-safety manifest contract ([#1766](https://github.com/Osmantic/ODS/pull/1766)), transactional swap sync ([#1887](https://github.com/Osmantic/ODS/pull/1887)), and model management UI/actions ([#1724](https://github.com/Osmantic/ODS/pull/1724)) are already merged; the state store, data plane, reconciler, and consumer migrations in this plan are not implemented.
+
+Goal of record (local planning source): `C:\Users\conta\Desktop\ODS-MODEL-SWAP-DESIGN.md`
+
+Portability rule: the absolute paths in this header are evidence pointers for this workstation, not execution dependencies. PR 1 must add the accepted version of this plan at `ods/docs/MODEL-SWITCHBOARD.md`; subsequent PRs reference that repository file and update its decision/status table in place.
+
+Research inputs:
+
+- ODS PR [#1724](https://github.com/Osmantic/ODS/pull/1724): merged into `main` 2026-07-19 (merge commit `5dd6f72d`); its former integration-vehicle role is retired
+- ODS GitHub `main` at `5dd6f72d` (contains the merged 77-PR fix sweep, #1888, #1766, #1711, #1887 content, and #1724)
+- Fleet harness `main` at `cb84c609fe897c1361967a844521fae7ab830848`
+- Lemonade `main` at `16dc27d2f3e249f2d826c97cde3f742df3b9d593`
+- Local Lemonade audit: `C:\Users\conta\Documents\Codex\2026-07-06\cl\LEMONADE_ROUTER_AUDIT.md`
+- [Lemonade router milestone #2389](https://github.com/lemonade-sdk/lemonade/issues/2389)
+- [Lemonade classifier wiring PR #2727](https://github.com/lemonade-sdk/lemonade/pull/2727)
+- [Lemonade router LRU isolation PR #2729](https://github.com/lemonade-sdk/lemonade/pull/2729)
+- [Lemonade filtered-classifier bug #2748](https://github.com/lemonade-sdk/lemonade/issues/2748)
+- [Lemonade v11.0.0 release](https://github.com/lemonade-sdk/lemonade/releases/tag/v11.0.0)
+- [Lemonade router same-name re-pull fix #2703](https://github.com/lemonade-sdk/lemonade/pull/2703), commit `5cf1fd76d47a35cc5d413aa7e59bf7e2a74ba61f`
+- [ODS swap-safety contract PR #1766](https://github.com/Osmantic/ODS/pull/1766)
+- [LiteLLM proxy documentation](https://docs.litellm.ai/)
+
+The SHAs above freeze the research snapshot only. Each implementation PR must branch from the then-current pushed `main`, record its own base SHA in the PR body, and rerun conflict/reference checks.
+
+## 1. Decision
+
+Build an ODS-owned Model Switchboard around one stable public model name:
+
+`ods/current`
+
+Every ODS application sends that model name to the existing LiteLLM gateway. LiteLLM forwards to a small ODS-owned model-router service. The model-router reads one versioned model-state record and forwards each request to the concrete backend and runtime model currently proven healthy.
+
+Lemonade's `collection.router` is adopted as the Lemonade adapter's backend-native implementation, not as the ODS-wide control plane. This preserves one cross-platform ODS contract while still gaining deterministic backend routing and `x_lemonade_route` attestation on Lemonade v11-capable hosts.
+
+This is the target request path:
+
+```text
+Hermes / Open WebUI / Perplexica / OpenCode / OpenClaw / ODS Talk
+                              |
+                      model = ods/current
+                              |
+                    LiteLLM auth and policy
+                              |
+                       ODS model-router
+                              |
+                 active route from model-state.json
+                    /         |          \
+          llama.cpp       Lemonade       HipFire
+          concrete ID     ODS-Route-N     concrete route
+                          collection.router
+```
+
+The host agent remains the mutation authority. A model swap becomes:
+
+1. Validate the requested model and every enabled consumer's capability floor.
+2. Record the desired model while leaving the old active route intact.
+3. Ask the selected runtime adapter to stage/load the concrete model.
+4. Prove runtime identity and a real completion.
+5. Publish any backend-native alias, including Lemonade `collection.router`.
+6. Atomically flip the ODS active route.
+7. Emit completion evidence and update legacy compatibility projections.
+8. Drain/unload the old model when safe.
+
+On failure, the active route never changes, or is atomically restored to the previously proven route.
+
+### 1.1 Scope boundary
+
+In scope:
+
+- Local chat/instruction model download, activation, routing, rollback, and deletion.
+- Container and native llama.cpp, Lemonade, and HipFire text-generation backends.
+- Every installed ODS application that consumes the local text model.
+- Existing local, Lemonade, and hybrid installs. In hybrid mode, `ods/current` means the active local model; named cloud models stay separate.
+
+Out of scope for this series:
+
+- Switching `ods/current` between local and cloud providers. Cloud-only mode keeps its existing static LiteLLM provider routes and must pass no-regression tests.
+- Embedding, reranker, speech, image-generation, and ComfyUI model lifecycle.
+- Automatic model selection, classifier routing, LLM-as-router, and policy-driven smart routing.
+- New role aliases such as `ods/agent` or `ods/vision` until `ods/current` is stamped green.
+
+## 2. Why not use Lemonade or LiteLLM alone?
+
+### Lemonade alone
+
+Lemonade's deterministic `collection.router` behavior is a strong fit for AMD/Lemonade hosts. It accepts a collection name, rewrites the request to a concrete candidate, and returns route metadata. Safe same-name re-pull is release-dependent and is not present in v11.0.0, so PR 6 uses immutable per-route collections there. ODS also runs llama.cpp natively and in containers, macOS Metal, HipFire, and cloud routes. A Lemonade-only control plane would preserve the current platform asymmetry.
+
+### LiteLLM alone
+
+LiteLLM already provides the public gateway and model aliases, but ODS v1.81.3 is configured from a read-only YAML mount with no database-backed management plane. Today that YAML contains the concrete model ID, so changing the alias still requires rewriting the file and restarting LiteLLM. Enabling LiteLLM's database management stack solely for one mutable local alias would add a database, migration, and admin surface to every ODS installation.
+
+Keep LiteLLM for auth, OpenAI compatibility, policy, and provider translation. Put ODS's small mutable routing decision behind it, where ODS can test and version the behavior independently.
+
+## 3. Public contracts
+
+### 3.1 Stable names
+
+- Canonical public alias: `ods/current`
+- Compatibility aliases for one deprecation cycle: `default` and the existing wildcard route
+- Lemonade v11.0-safe registry convention: immutable `user.ODS-Route-<routeSeq>` collections, requested as `ODS-Route-<routeSeq>`
+- Optional future Lemonade stable registry name: `user.ODS-Current`, only after the installed release proves safe same-name router re-pull/overwrite
+- Concrete backend IDs remain internal and are shown in ODS UI/API as route details.
+
+Role aliases such as `ods/chat`, `ods/agent`, and `ods/vision` are deferred until `ods/current` is fleet-proven. The state schema should allow roles without exposing them in the MVP.
+
+### 3.2 State record
+
+Path: `data/model-state.json`
+
+```json
+{
+  "schema": "ods.model-state.v1",
+  "seq": 42,
+  "routeSeq": 17,
+  "operation": {
+    "id": "uuid",
+    "phase": "serving",
+    "requestedModelId": "qwen3.5-9b",
+    "startedAt": "2026-07-19T00:00:00Z",
+    "error": null
+  },
+  "desired": {
+    "catalogId": "qwen3.5-9b"
+  },
+  "active": {
+    "routeSeq": 17,
+    "catalogId": "qwen3.5-9b",
+    "runtimeModelId": "Qwen3.5-9B-Q4_K_M",
+    "publicModel": "ods/current",
+    "backend": {
+      "kind": "lemonade",
+      "endpointId": "lemonade-container",
+      "nativeRoute": "ODS-Route-17"
+    },
+    "contextLength": 131072,
+    "capabilities": {
+      "chat": true,
+      "tools": true,
+      "vision": false,
+      "agentViable": true
+    },
+    "verifiedAt": "2026-07-19T00:00:00Z",
+    "proof": {
+      "identity": "Qwen3.5-9B-Q4_K_M",
+      "completion": true
+    }
+  },
+  "history": [
+    {
+      "routeSeq": 16,
+      "catalogId": "phi-4-mini",
+      "runtimeModelId": "Phi-4-mini-Q4_K_M",
+      "verifiedAt": "2026-07-18T23:00:00Z"
+    }
+  ],
+  "availability": {
+    "mode": "serve_active",
+    "queueDeadline": null
+  }
+}
+```
+
+Rules:
+
+- The host agent is the only writer.
+- Writes use temp file, flush, fsync where available, and atomic replace.
+- `seq` increments for every state/event mutation. `routeSeq` increments only when the active route changes. UI freshness uses `seq`; route attestation uses `active.routeSeq`.
+- `active` remains the last proven route while `desired` is loading.
+- `backend.endpointId` must resolve through the model-router's static allowlist. State never contains an arbitrary upstream URL, credential, or header.
+- `history` retains the last 10 verified active-route snapshots. Rollback selects a history entry and runs it through the normal reconciler; it never edits `active` directly.
+- `.env`, `models.ini`, Hermes YAML, and other legacy values are derived compatibility outputs during migration, never competing sources of truth.
+- In `observe` mode, the existing activation transaction stays authoritative and state is written only after that transaction proves success. In `enabled` mode, the reconciler and atomic route flip are authoritative.
+- A reader keeps one last-known-good verified snapshot in memory. Malformed or missing state never promotes `desired`; startup reconstruction from runtime plus `.env` is allowed only when no v1 state has ever been committed.
+
+### 3.3 API and events
+
+Product API:
+
+- `GET /api/models/state`: sanitized desired/active/history summary and capability impact
+- `GET /api/models/events`: SSE stream keyed by `seq` and operation ID; retains at most 1,024 events for 15 minutes, emits a heartbeat every 15 seconds, supports `Last-Event-ID`, and sends a `model.state.snapshot` event before live events when the requested ID is absent or expired
+- Existing `POST /api/models/{id}/load`: unchanged user contract; backed by the reconciler
+- `POST /api/models/rollback`: activate a requested verified history entry, defaulting to the newest, through the same reconciler
+- `GET /api/models/routes/{probeId}`: authenticated dashboard-api proxy to bounded in-memory route evidence for fleet validation
+
+Host-agent API:
+
+- Existing `POST /v1/model/activate`: sole activation mutation endpoint
+- New `POST /v1/model/rollback`: validates a history `routeSeq` and invokes the same reconciler
+- New `GET /v1/model/state`: authenticated host-side diagnostic view
+
+Event sequence:
+
+```text
+model.swap.started
+model.swap.staging
+model.swap.verified
+model.route.flipped
+model.swap.completed
+```
+
+Failure sequence:
+
+```text
+model.swap.failed
+model.rollback.started
+model.rollback.verified
+model.rollback.completed
+```
+
+### 3.4 Route evidence
+
+The model-router adds these response headers where the protocol permits:
+
+- `X-ODS-Request-Id`
+- `X-ODS-Requested-Model`
+- `X-ODS-Routed-Model`
+- `X-ODS-Backend`
+- `X-ODS-Route-Seq`
+
+Consumer-visible model identity is stable by contract: the router rewrites the top-level `model` field in non-streaming responses and every SSE chunk to the requested public alias (`ods/current`, or the compatibility alias the client used). Concrete identity is available only through the authenticated state API, ODS route headers, and bounded route-evidence records. The raw upstream body is retained only inside the request lifetime for parsing/forwarding and is never logged.
+
+For Lemonade, capture and preserve `x_lemonade_route` and the `X-Lemonade-Route` header.
+
+For end-to-end app probes that do not expose upstream headers, the fleet prompt carries a signed marker: `[ODS_PROBE id=<lowercase-uuid> sig=<base64url>]`. The signature is unpadded base64url HMAC-SHA256 over the lowercase UUID bytes using the run-scoped `ODS_FLEET_PROBE_KEY`. The model-router records evidence only when that key is configured, the marker has exactly one canonical UUID/signature pair, and constant-time verification succeeds. Production installs without that test-only key ignore markers and expose no probe lookup data.
+
+The model-router keeps at most 2,048 evidence records for 15 minutes in memory. Each record contains only probe UUID, timestamp, consumer-visible requested alias, concrete route, backend, `routeSeq`, status, and response model. It never stores prompt text, messages, generated text, tokens, API keys, cookies, or authorization headers. `/internal/route-evidence/{probeId}` is reachable only on the Compose network and requires `Authorization: Bearer <ODS_ROUTER_INTERNAL_KEY>`; dashboard-api exposes the authenticated product proxy above.
+
+### 3.5 Reload behavior
+
+- If the old runtime can remain serving while the new model stages, `availability.mode=serve_active` and requests continue on `active.routeSeq` until the atomic flip.
+- If a single-model runtime must stop serving, set `availability.mode=queue` before stopping it and queue new requests for a bounded default of 60 seconds.
+- On queue timeout, return HTTP 503 with `code=model_swap_in_progress`, `Retry-After`, operation ID, and current phase.
+- Existing in-flight requests are allowed to finish where the backend supports it.
+- Do not silently retry a request against a different model after generation has begun.
+
+### 3.6 Router security boundary
+
+- The model-router is an internal core service with `expose`, no host `ports` mapping, non-root execution, `no-new-privileges`, dropped Linux capabilities, read-only root filesystem, and a read-only state mount.
+- Only explicit OpenAI-compatible paths and methods are forwarded. Unknown paths, absolute-form URLs, WebSocket upgrades, and arbitrary CONNECT/forward-proxy behavior are rejected.
+- Hop-by-hop headers and client-supplied upstream authorization are stripped. The router injects backend credentials from its own environment/config.
+- `endpointId` resolves to a startup-validated allowlist. Local endpoint IDs may resolve to Compose DNS or the installer-created native host bridge; user-controlled state cannot select an arbitrary network destination.
+- Request body, header, queue depth, connection, and timeout limits are explicit and covered by negative tests.
+
+### 3.7 Model viability contract
+
+"Viable" is product data, not a harness exception. Each catalog model exposed for local activation must publish:
+
+- Backend/runtime compatibility and downloadable artifact identity
+- Estimated disk, RAM, and VRAM requirements
+- Context length and required capability flags (`chat`, `tools`, `vision` where applicable)
+- `agentViable`, a reason code, evidence timestamp, tested runtime family/version, and catalog evidence revision
+
+A release-campaign candidate is viable on a host only when the product API reports that it fits the host, can be acquired by that runtime, and satisfies every enabled consumer's declared capability floor. If Hermes/ODS Talk is enabled, that includes `agentViable=true` and the 65,536-token context floor. A model that cannot reliably follow the Hermes instruction contract is marked non-agent-viable in catalog metadata and visibly blocked for that consumer; it is not added to a harness exclusion list. A tool-capable model receives a tool-aware probe that accepts a valid tool-call-then-answer sequence. Other consumers may still use a non-agent-viable model only when their manifests do not require agent viability.
+
+The harness obtains the candidate list, compatibility decision, reason codes, and evidence revision from the authenticated product API. It may select among product-approved candidates for host variety, but it may not override a product rejection or maintain model-name allow/deny lists. If fewer than six distinct models are viable for an enabled host, the release campaign is blocked until product catalog entries or product capability metadata are corrected and tested.
+
+## 4. Existing PR disposition
+
+| PR | Decision | Reason |
+|---|---|---|
+| [#1711](https://github.com/Osmantic/ODS/pull/1711) | Landed prerequisite | Its lifecycle lock, host-agent hardening, and model-management foundations are reused. |
+| [#1766](https://github.com/Osmantic/ODS/pull/1766) | Landed prerequisite | It already defines `ods/current`, manifest LLM consumption, `route`, `pinning`, capability floors, and dynamic probe discovery. Keep `pinning: none` for stable-alias consumers; do not introduce a conflicting `stable_alias` enum. |
+| [#1724](https://github.com/Osmantic/ODS/pull/1724) | Merged into `main` 2026-07-19 | Its model run/delete actions, bootstrap-download activation conflict guard, and Windows Lemonade runtime-ensure endpoint are on `main`. New slices target `main` directly and fleet-test from their own pushed branches. |
+| [#1887](https://github.com/Osmantic/ODS/pull/1887) | Landed prerequisite; its consumer stages are superseded by this series | Its activation transaction, lifecycle lock, snapshot/rollback proof machinery, and container-state tracking are reused by PRs 1-2. Its per-consumer rewrite stages (Hermes patch, Perplexica sync, OpenCode rewrite, OpenClaw recreate, LiteLLM refresh) are exactly what PRs 4A-5C migrate away from and PR 7 deletes; no new hardening of those stages should merge while this series is active. |
+| [#1782](https://github.com/Osmantic/ODS/pull/1782) | Closed; absorb only its regression test | Its proposed implementation regenerated YAML and restarted LiteLLM. PR 3 removes the need for that behavior; port the failing CLI-to-LiteLLM test into PR 7 and do not reopen the implementation. |
+| [#1787](https://github.com/Osmantic/ODS/pull/1787) | Existing behavior prerequisite for HipFire adapter work | It has been reduced to 22 files/+1.3k lines. PRs 1 and 3 do not wait for it. Before PR 2C starts, either #1787 is merged and HipFire becomes a required adapter, or PR 2C explicitly excludes HipFire and records #1787 as its blocking dependency. No duplicate HipFire route implementation. |
+| [#1896](https://github.com/Osmantic/ODS/pull/1896) | Land independently after its current dependencies are cleaned up | HF acquisition is complementary. PR 8 consumes pull receipts and delete semantics when available, but the switchboard must not depend on its current 55-file branch. |
+| [#1751](https://github.com/Osmantic/ODS/pull/1751) / [#1752](https://github.com/Osmantic/ODS/pull/1752) | Landed prerequisites | Brave compose and Lemonade stem-alias fixes remain valid. |
+
+### 4.1 Requirement ownership
+
+| User objective | Owning slices | Release proof |
+|---|---|---|
+| One stable model name across local runtimes | PR 3, PR 6 | Direct and app requests use `ods/current`; route evidence names the expected concrete model |
+| Atomic swap with truthful rollback | PR 1, PR 2A-2C | Failure-injection matrix never commits an unverified route; rollback is itself verified |
+| No per-app model rewrites/restarts | PR 4A-4C, PR 5A-5C, PR 7 | Consumer configs retain `ods/current` through swaps and restarts; governed-write guard passes |
+| Windows, Linux, macOS, llama.cpp, Lemonade, and HipFire parity | PR 2A-2C, PR 6, PR 7 | Affected-host gates plus the frozen all-host campaign |
+| User-visible download, activate, progress, rollback, and delete | Existing acquisition APIs, PR 7, PR 8 | Browser-only lifecycle on every release-required host; active delete is blocked and inactive delete is verified |
+| Honest compatibility/agent-viability gates | PR 5A, PR 8 | Product API/UI owns the decision and harness has no model-name exclusion list |
+| Every discovered application follows every swap | PR 4A-4C, PR 5A-5C, Harness PR A | Functional round trip plus matching route evidence after each swap and restore |
+| New-install, upgrade, restart, repair, and emergency rollback safety | PR 7, PR 9, Harness PR B | One immutable product/harness SHA passes section 7 and produces the release stamp |
+
+## 5. PR series
+
+All product PRs target `main`. #1724 is merged; slices fleet-test from their own pushed branches. If several unmerged slices must be fleet-tested together, create a disposable integration branch for that run and delete it afterward.
+
+### 5.1 Execution preflight
+
+Before each slice:
+
+```powershell
+git fetch origin main:refs/remotes/origin/main
+git status --short --branch
+git worktree add ..\ods-ms-prN -b <branch-name> origin/main
+```
+
+The new worktree must start clean. Replace `<branch-name>` with the table value below. If the branch already exists, inspect and reuse its existing worktree rather than deleting or overwriting it.
+
+PR 1's first documentation commit copies this audited plan to `ods/docs/MODEL-SWITCHBOARD.md` and adds it to `ods/docs/README.md`. Every later PR updates the repository copy's status/deviation log; the workstation copy stops being authoritative once PR 1 is open.
+
+Review-size rule: split a slice before review if it changes more than 20 production files or 1,500 net production lines, excluding tests, fixtures, generated lockfiles, and documentation. A larger slice requires a written exception in the PR body explaining why a smaller independently testable boundary is impossible.
+
+Every PR body contains:
+
+- Base and head SHAs
+- Dependency PRs and feature-flag mode
+- Exact changed contracts and rollback command
+- Local/CI commands with results
+- Affected host IDs, product SHA, harness SHA, and evidence paths
+- Known deferrals with owner; no unowned TODOs
+
+### 5.2 Dependency and branch map
+
+| Slice | Branch | Depends on | Mode after merge | Required exit artifact |
+|---|---|---|---|---|
+| PR 1 | `feat/model-switchboard-state` | #1711, #1766 | `observe` | v1 state schema/fixtures and read-only API |
+| PR 2A | `refactor/model-reconciler-core` | PR 1 | `observe` | reconciler contract + container llama.cpp adapter |
+| PR 2B | `refactor/model-adapters-native` | PR 2A | `observe` | Windows and macOS native adapters |
+| PR 2C | `refactor/model-adapters-lemonade` | PR 2A and #1787 decision | `observe` | Lemonade adapter and HipFire adapter if #1787 landed |
+| PR 3 | `feat/model-router` | PR 2A (2B/2C may proceed in parallel; observe-mode router needs only the reconciler contract and container adapter) | `observe`, canary override | internal router + static LiteLLM config |
+| PR 4A | `feat/open-webui-stable-model-route` | PR 3 | enabled only on selected canaries | Open WebUI migrated and probed |
+| PR 4B | `feat/perplexica-stable-model-route` | PR 3 | enabled only on selected canaries | Perplexica migrated and probed |
+| PR 4C | `feat/opencode-stable-model-route` | PR 3 | enabled only on selected canaries | OpenCode migrated and probed |
+| PR 5A | `feat/hermes-talk-stable-model-route` | PR 3 | enabled only on selected canaries | Hermes/ODS Talk text migrated and probed |
+| PR 5B | `feat/openclaw-stable-model-route` | PR 3 | enabled only on selected canaries | OpenClaw migrated and probed |
+| PR 5C | `fix/local-llm-direct-route-bypasses` | PR 4A-5B | enabled only on selected canaries | zero undeclared local text-model bypasses |
+| PR 6 | `feat/lemonade-virtual-route-adapter` | PR 2C, PR 3 | enabled on AMD canaries | v11 route attestation or explicit legacy fallback |
+| PR 7 | `refactor/model-mutation-single-path` | PR 4A-6 | enabled on validated hosts | UI/CLI/bootstrap/install all use reconciler |
+| PR 8 | `feat/model-switchboard-ui` | PR 7, Harness PR A | enabled on validated hosts | capability/preflight/events/rollback UI |
+| PR 9 | `chore/model-switchboard-default-on` | PR 8, Harness PR B, stamp candidate | default-on | migration cleanup, docs, and release stamp |
+
+PRs at the same lettered level may proceed in parallel, with no more than two active sidecars. PR 7 is the convergence point and cannot start deleting legacy mutation paths until all consumer slices and PR 6 have affected-host evidence.
+
+### 5.3 File ownership map
+
+Existing ownership points that implementations extend:
+
+- Host mutation authority: `ods/bin/ods-host-agent.py`
+- LiteLLM configuration renderer: `ods/scripts/render-runtime-configs.py`
+- Dashboard model API: `ods/extensions/services/dashboard-api/routers/models.py`
+- Models UI: `ods/extensions/services/dashboard/src/pages/Models.jsx`
+- Extension LLM-consumer contract source: `ods/extensions/schema/service-manifest.v1.json` (with `ods/extensions/library/schema/service-manifest.v1.json` kept in sync by the existing schema/library workflow)
+- Fleet model lifecycle: `lib/model-ui-host.sh`, `lib/model-ui-ods-adapter.sh`, and `playwright/model-management.mjs` in the harness repository
+
+New ownership points created by this series:
+
+- PR 1: `ods/config/model-state.schema.v1.json` and `ods/bin/model_switchboard/`
+- PR 1: `ods/extensions/services/dashboard-api/model_state.py`
+- PR 3: `ods/extensions/services/model-router/`
+- PR 3: one static model-router entry emitted by `ods/scripts/render-runtime-configs.py`
+
+Paths in the second list are planned files and do not exist at the audited base SHA. A slice that moves one of these responsibilities must update this map and name the new single owner in its PR body.
+
+### PR 1: `feat(models): add versioned switchboard state`
+
+Purpose: establish one observable source of truth without changing routing.
+
+Primary changes:
+
+- Add `ods/config/model-state.schema.v1.json` and `ods/bin/model_switchboard/{__init__.py,state.py}` with schema validation, atomic storage, bounded history, separate `seq`/`routeSeq`, and migration helpers.
+- In `observe` mode, write state from `ods/bin/ods-host-agent.py` only after the existing activation or rollback path has proved success; initialize once at host-agent startup from runtime identity plus `.env` when no v1 state exists.
+- Add `ods/extensions/services/dashboard-api/model_state.py`, register static routes before the existing dynamic model-ID routes, and expose read-only `GET /api/models/state`.
+- Reuse dashboard-api's existing `/data` mount; do not add a second writable state path.
+- Add the repository plan at `ods/docs/MODEL-SWITCHBOARD.md` and link it from `ods/docs/README.md`.
+- Keep all current `.env` and config propagation behavior.
+
+Tests:
+
+- Atomic write and interrupted-write recovery on Windows and POSIX.
+- Concurrent reader/writer test with no partial JSON reads.
+- Monotonic sequence and stale-state rejection.
+- Migration from `.env` with Lemonade stem, `extra.*`, GGUF, and native model IDs.
+- Cloud-only mode creates no local active route and retains its current static provider configuration.
+- Activation failure leaves `active` on the previous verified model.
+- Host-agent restart does not overwrite an existing valid v1 state with stale `.env`.
+- Fresh install creates valid state before dashboard readiness; malformed-state fixtures return a diagnostic failure without promoting `desired`.
+
+Exit criteria:
+
+- `GET /api/models/state` matches the JSON Schema and runtime identity on all four runtime families.
+- No request-routing or consumer config diff is present.
+- Feature rollback is removal of the additive state/API files; existing activation remains untouched.
+
+Fleet gate: one Windows Lemonade host, one Linux Lemonade host, one Linux llama.cpp host, and one macOS native host in observe-only mode. Existing behavior must remain green.
+
+### PR 2A-2C: `refactor(models): introduce runtime adapters and one reconciler`
+
+Purpose: move platform/runtime behavior out of the 8k-line host-agent activation method without changing externally visible behavior.
+
+Shared contract:
+
+- Extend the PR 1 sibling package under `ods/bin/model_switchboard/`; installer/package tests must prove the standalone host-agent imports it from the installed tree.
+- Define typed `stage`, `verify_identity`, `verify_completion`, `publish_native_alias`, `unload`, `delete`, and `rollback` results. Every successful verification returns concrete identity, context, capabilities, and proof timestamp.
+- Make `_do_model_activate` call one reconciler while retaining the existing lifecycle lock, HTTP contract, and snapshot rollback.
+- Do not add a cloud adapter. Cloud-only routes remain LiteLLM-owned and hybrid cloud models retain their explicit names.
+
+Slice boundaries:
+
+- PR 2A: reconciler state machine plus container llama.cpp adapter. It establishes the shared fake adapter and transaction-boundary test matrix.
+- PR 2B: native Windows and macOS llama.cpp process/bridge adapters, with no Linux changes beyond shared contracts.
+- PR 2C: Lemonade version/path/model-ID adapter and, if #1787 is merged, HipFire. The Lemonade native virtual collection remains PR 6.
+
+Each slice moves existing behavior and tests before deleting the old inline block. A source-level guard must prove there is one implementation of each migrated operation.
+
+Compatibility:
+
+- Preserve existing snapshot rollback until PR 7 removes duplicated projections.
+
+Tests:
+
+- Adapter contract suite shared by every implementation.
+- Exact command/env assertions for each OS path.
+- Identity mismatch, completion failure, process failure, timeout, and rollback proof.
+- Negative test: health-only success cannot commit a route.
+- Host-agent packaging/start tests on Linux systemd, Windows task/process, and macOS launchd.
+
+Exit criteria:
+
+- Old and new paths produce byte-equivalent compatibility projections and the same externally visible API responses for success and failure fixtures.
+- The adapter returns the concrete model carried by the proof request; configured identity alone cannot satisfy verification.
+- Reverting any PR 2 slice restores its previous inline runtime path without changing state format.
+
+Fleet gate: affected-host-only activation/rollback runs on every runtime family.
+
+### PR 3: `feat(router): add the ODS stable-alias data plane`
+
+Purpose: stop model swaps from requiring LiteLLM config rewrites and restarts.
+
+Primary changes:
+
+- Add `ods/extensions/services/model-router/` with `app/main.py`, pinned `requirements.txt`, Dockerfile, `compose.yaml`, manifest, health check, metrics, and focused tests. Reuse FastAPI/httpx versions already accepted by dashboard-api unless a documented incompatibility requires otherwise.
+- Implement OpenAI-compatible `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, and `/v1/models` forwarding.
+- Rewrite only the request model and backend base path; preserve tools, images, stream settings, request cancellation, and safe headers.
+- Read the active route from `data/model-state.json`, with sequence-aware caching.
+- Implement bounded queue-during-reload and structured 503 behavior.
+- Add route evidence and probe correlation without prompt logging.
+- Add `ods/config/model-router/endpoints.json`, generated at install from known runtime topology and mounted read-only. State selects only an `endpointId` from this file.
+- Include model-router in local, Lemonade, and hybrid Compose stacks; exclude it from cloud-only routing. It has no host port.
+- Change LiteLLM local/Lemonade templates to map `ods/current`, `default`, and the compatibility wildcard to model-router permanently when enabled.
+- Add `ODS_MODEL_SWITCHBOARD=legacy|observe|enabled`; ship `observe` by default in this PR. `legacy` renders the pre-switchboard LiteLLM config, `observe` runs router/state checks without consumer traffic, and `enabled` sends the stable aliases through model-router.
+
+Required LiteLLM shape when enabled:
+
+```yaml
+model_list:
+  - model_name: ods/current
+    litellm_params:
+      model: openai/ods/current
+      api_base: http://model-router:9099/v1
+      api_key: no-key
+  - model_name: default
+    litellm_params:
+      model: openai/ods/current
+      api_base: http://model-router:9099/v1
+      api_key: no-key
+  - model_name: "*"
+    litellm_params:
+      model: openai/ods/current
+      api_base: http://model-router:9099/v1
+      api_key: no-key
+```
+
+The renderer owns this YAML. No installer, CLI, or host-agent heredoc may maintain a second enabled-mode copy.
+
+Tests:
+
+- Byte/semantic parity for non-streaming and SSE streaming responses.
+- Consumer-visible response/chunk `model` stays on the requested public alias while authenticated route evidence records the raw concrete upstream identity.
+- Tool-call, reasoning-content, image, malformed request, large body, cancellation, disconnect, timeout, and upstream error cases.
+- `/v1/models` advertises stable aliases and reports concrete identity only as ODS metadata.
+- Router restart and stale-state recovery.
+- No model-router or LiteLLM restart across repeated route flips.
+- Negative self-tests for stale sequence, malformed state, wrong concrete ID, and false route evidence.
+- Hybrid-mode precedence: named cloud models resolve to their static provider routes and never fall through the `"*"` wildcard into model-router.
+- Steady-state footprint: model-router RSS stays within a documented budget (target: under 150 MB) at the configured connection/queue limits on an 8 GB tier-1 host profile, measured and recorded rather than assumed.
+- Local p95 added first-byte overhead target: below 10 ms on the same host, with measurements recorded rather than hidden by retries.
+
+Exit criteria:
+
+- Twenty alternating route flips complete without restarting LiteLLM or model-router and without one request reaching the wrong `routeSeq`.
+- A direct request for an arbitrary URL/model cannot turn model-router into an SSRF or forward proxy.
+- `legacy` and `observe` are behaviorally identical to pre-PR routing; `enabled` is exercised only on named canaries.
+- Cloud-only mode's resolved Compose/LiteLLM configuration is byte-equivalent except for documented formatting.
+
+Fleet gate: Tower2 runs the local NVIDIA canary and remains the orchestrator. Add one representative host for each other backend family: `strix-halo` (Linux Lemonade), `strixy` (Windows Lemonade), `windows-laptop` (Windows native llama.cpp), and `m5-mbp` (macOS native). Run repeated direct gateway swaps before migrating applications.
+
+### PR 4A-4C: migrate Open WebUI, Perplexica, and OpenCode
+
+Purpose: migrate the three consumers most likely to cache or persist model IDs.
+
+Shared rule:
+
+- Render each consumer once with LiteLLM URL plus `ods/current`.
+- Keep the merged #1766 contract: `llm.route: gateway` and `llm.pinning: none` mean the app stores no concrete model ID. Update capability floors and probe descriptors without inventing a new pinning enum.
+- Keep install-time rendering and a one-shot upgrade repair from concrete IDs.
+- Remove a consumer's per-swap rewrite only in that consumer's PR, after its focused live canary passes on the same branch. Re-run after removal before merge.
+
+Slice-specific changes:
+
+- PR 4A, Open WebUI: update its Compose/provider bootstrap to LiteLLM + `ods/current`; add deterministic fleet-admin provisioning and authenticated chat proof. No login/setup state may be hand-created during a release run.
+- PR 4B, Perplexica: make `render-runtime-configs.py` and `settings.seed.json` install/repair-only, migrate live settings once, then remove `_update_perplexica_model` from the swap path.
+- PR 4C, OpenCode: render both supported config filenames with `ods/current`, migrate once, then remove `_update_opencode_config` from the swap path. A fresh session is created for each probe.
+
+Tests:
+
+- Fresh config, upgrade from concrete ID, app restart, ODS restart, and host restart retain `ods/current`.
+- Each application performs a real user-facing round trip after swap and restore.
+- Route evidence proves the app request reached the expected concrete model.
+- Negative test: a concrete stale model in app config is detected and repaired once, not accepted as green.
+
+Per-slice exit criteria:
+
+- The app config contains `ods/current` before and after two model swaps, app restart, ODS restart, and host restart.
+- No activation code writes that app's model field.
+- The app's real functional probe and route evidence pass after swap and restore on every OS where it is enabled.
+- Reverting the slice restores only that app's legacy update path.
+
+Fleet gate: browser-driven app probes on every host where each app is installed, first affected-host-only, then one four-host mixed-OS pass.
+
+### PR 5A-5C: migrate Hermes/ODS Talk, OpenClaw, and remaining local text consumers
+
+Purpose: complete the consumer migration and remove the remaining direct backend bypasses.
+
+Slice-specific changes:
+
+- PR 5A, Hermes/ODS Talk text: Hermes uses LiteLLM + `ods/current`. Configure a static 65,536-token agent context only for models that pass the product's 65,536-token gate; do not claim dynamic per-model context support. Remove concrete model patching/restart from swap after proof. ODS Talk text is covered by a fresh Hermes session.
+- PR 5B, OpenClaw: replace direct `OLLAMA_URL`/concrete pinning with the gateway alias and remove its swap-time recreation after proof.
+- PR 5C, bypass closure: inventory enabled manifests and resolved Compose configs for local LLM endpoint/model variables. Migrate or explicitly declare every remaining local text consumer; fail CI on undeclared direct local text routes.
+- Vision remains an explicit existing route in this series and receives no-regression tests. A future `ods/vision` role is a separate design after `ods/current` is stamped green.
+- Keep install/repair logic able to convert old concrete text-model settings once.
+
+Tests:
+
+- Fresh Hermes session per probe; no looser answer matching.
+- Tool-call-then-answer is accepted for tool-capable models; non-agent-viable models are blocked by product metadata, not harness exclusions.
+- ODS Talk text, OpenClaw, direct LiteLLM, and existing vision no-regression round trips.
+- App session started before a swap and a new session after a swap both use the correct route.
+- No old model announcement after restore.
+
+Per-slice exit criteria:
+
+- No migrated consumer stores or announces a concrete active text-model ID.
+- Fresh sessions after every swap carry `ods/current` and route to the expected concrete model.
+- PR 5C's generated inventory count equals the dashboard/harness discovered-consumer count.
+- Models below the 65,536-token agent floor are visibly blocked for Hermes/ODS Talk rather than waived by the harness.
+
+Fleet gate: all discovered consumers on each affected host, with route evidence for every swap and restore.
+
+### PR 6: `feat(lemonade): add deterministic virtual-model adapter`
+
+Purpose: use Lemonade's native virtual-model primitive where available while preserving the ODS contract everywhere.
+
+Primary changes:
+
+- Start from current `main`'s actual pins (`v10.2.0` container and Windows `10.0.0`) and reconcile any newer #1724-only runtime work explicitly. Do not assume the integration branch's runtime is on main.
+- Candidate v11 baseline is Lemonade `v11.0.0`, which contains deterministic `collection.router`. Pin the container by tag plus resolved image digest. Pin `lemonade-server-minimal.msi` to release SHA-256 `771b9df062017b30af1bf2b804afc1f0c80a3499bbe7d60ea51393b73e38f521`.
+- Handle v11's cache ownership/path migration: the container runs as UID 10001 and uses `/opt/lemonade/.cache` instead of `/root/.cache`. Upgrade tests must prove existing model data is retained, permissions are repaired deliberately, and a downgrade does not delete it.
+- Add a strict runtime feature probe rather than relying only on version strings.
+- On v11.0.0, register one immutable `user.ODS-Route-<routeSeq>` collection per verified candidate. Load and verify the concrete candidate, register the collection, prove a request to `ODS-Route-<routeSeq>` routes to it, then permit the ODS route flip. Keep the prior collection through the rollback/drain window and delete it afterward.
+- Do not re-pull `user.ODS-Current` on v11.0.0. [Lemonade fix #2703](https://github.com/lemonade-sdk/lemonade/pull/2703), commit `5cf1fd76d47a35cc5d413aa7e59bf7e2a74ba61f`, fixes router-specific same-name re-pull but landed after the v11.0.0 tag. A future release may use the stable internal name only if `git merge-base --is-ancestor 5cf1fd76 <release-tag>` succeeds and the runtime feature probe passes.
+- Capture `x_lemonade_route` in ODS route evidence.
+- Preserve a legacy v10 adapter that sends the concrete Lemonade model ID through model-router.
+- Add registry cleanup for expired, non-active `user.ODS-Route-*` collections and deleted, non-active concrete models. Never delete the active or retained rollback route.
+
+Feature probe:
+
+1. Register a temporary one-candidate `collection.router` with a unique name.
+2. Send a real completion through that collection.
+3. Require response model identity plus matching `x_lemonade_route.route_to` and `x-lemonade-route` header.
+4. Delete the temporary collection and verify registry cleanup.
+5. If any step fails, report `nativeRouter=false` and use the concrete-ID adapter; do not partially enable native routing.
+
+Explicitly out of scope:
+
+- Classifier routing
+- LLM-as-router policies
+- Automatic smart model choice
+- Multiple candidates in the ODS-Current collection
+
+Those depend on unresolved or still-reviewing upstream work in Lemonade #2727, #2729, and #2748 and are not needed for reliable manual swapping.
+
+Tests:
+
+- Lemonade upstream endpoint tests mirrored as ODS integration contracts.
+- Register and route six immutable per-`routeSeq` collections across six sequential models.
+- Server restart/cache rebuild preserves the virtual model.
+- Streaming, completions, responses, and tool calls preserve route evidence.
+- Missing candidate, filtered candidate, failed re-pull, registry corruption, and rollback.
+- Legacy v10 fallback remains functional and cannot be mistaken for native-router attestation.
+
+Exit criteria:
+
+- The runtime package/image and checksum/digest are present in generated install metadata and run attestation.
+- Six swaps leave exactly one active collection plus the bounded rollback collection; no unbounded registry growth.
+- A failed new collection proof leaves the previous ODS and Lemonade routes active.
+- Windows and Linux AMD produce equivalent route evidence despite different installation mechanisms.
+
+Fleet gate: Strixy/Windows AMD first, then Strix-Halo/Linux AMD. Six sequential models, restart between repetition cycles, and registry inventory before/after deletion.
+
+### PR 7: `refactor(models): make every mutation use the reconciler`
+
+Purpose: remove the duplicated swap implementations and competing state writers.
+
+Primary changes:
+
+- Bash `ods model swap`, Windows `ods.ps1 model swap`, and macOS CLI routing call the authenticated host-agent activation contract and wait for its terminal operation result. They fail clearly if the agent is unavailable; they do not fall back to local config mutation.
+- `bootstrap-upgrade.sh` owns download and checksum verification only, then calls the running host agent for activation.
+- Fresh installers may create the bootstrap runtime/env before the agent exists, but installation is not complete until the host agent starts, reconstructs/proves initial state, and returns a matching `GET /v1/model/state`. Full-model promotion uses the normal activation endpoint.
+- Remove per-swap LiteLLM regeneration/restart, Hermes patching, Perplexica sync, OpenCode rewrite, and OpenClaw recreation code already made obsolete by PRs 3-5.
+- Keep `.env` and `models.ini` projections for external compatibility for one release, generated from state after route commit.
+- Port [#1782](https://github.com/Osmantic/ODS/pull/1782)'s regression test. That PR closed without landing; remove equivalent restart behavior only if it entered `main` through another PR.
+
+Ownership rule:
+
+- Only the running host-agent process writes `model-state.json`, active-model `.env` keys, or `models.ini` after initial installer bootstrap.
+- Dashboard-api, CLIs, bootstrap-upgrade, and repair tools are clients.
+- The compatibility projector has one module/function and a declared governed-key list. CI rejects writes to those keys elsewhere.
+
+Tests:
+
+- CLI, UI, bootstrap promotion, installer, API, and rollback all produce the same state/event sequence.
+- Failure at every transaction boundary leaves one coherent active route.
+- Restart during each phase recovers or rolls back deterministically.
+- No code path writes a consumer's concrete model ID during a swap.
+- Static analysis contract rejects new writes to governed model keys outside the state projector.
+
+Exit criteria:
+
+- UI, Bash CLI, PowerShell CLI, bootstrap promotion, rollback, and repair all generate the same operation/event/state sequence.
+- Killing any client after request submission cannot leave an untracked background mutation; the host agent operation remains queryable.
+- Host-agent unavailability produces a terminal user-facing error without changing files.
+- The #1782 regression reproducer passes without a LiteLLM restart.
+
+Fleet gate: clean install plus upgrade on Windows, macOS, Linux NVIDIA, Linux AMD, and any active HipFire host.
+
+### PR 8: `feat(models): capability gates, live progress, and verified rollback UI`
+
+Purpose: expose the new architecture honestly to users.
+
+Primary changes:
+
+- Dashboard API serves one capability contract and the 65,536-token agent context floor. Product API, UI, model selection, and harness consume this value; no separate approximate context-floor constants remain.
+- Models UI shows public alias, concrete routed model, backend, context, capability compatibility, operation phase, and last proof time.
+- Implement `GET /api/models/events` with a bounded event buffer, SSE `id: <seq>`, `Last-Event-ID`, heartbeat, disconnect cleanup, and full-state resync when history is unavailable.
+- Replace ambiguous polling with sequence-aware SSE while retaining one bounded polling fallback. UI reducers reject older `seq`; displayed route identity changes only on a newer `routeSeq`.
+- Add preflight impact dialog and visible per-app compatibility gates.
+- Add one-click verified rollback.
+- Enforce active-model delete blocking from state; integrate HF pull receipts from #1896 when present.
+- Surface agent viability as catalog/product metadata. No harness-only model exclusion lists.
+
+Tests:
+
+- Frontend reducer rejects older sequences.
+- Accessibility and responsive action controls.
+- Capability floor and app-impact contract tests.
+- User-comprehensible load, queue timeout, rollback, and delete-active errors.
+- Browser tests use only visible controls for final approval.
+
+Exit criteria:
+
+- Disconnect/reconnect, delayed poll, and out-of-order event fixtures cannot flip the UI back to an older model.
+- Preflight names every incompatible enabled consumer and the reason before the Run action is accepted.
+- Rollback is a normal reconciler operation with route proof, not a file restore shortcut.
+- The harness reads the capability floor and viability metadata from product APIs only.
+
+Fleet gate: UI-only download, run, use, rollback, and delete on all release-required hosts.
+
+### PR 9: `chore(models): default-on migration, cleanup, and documentation`
+
+Purpose: promote the switchboard and remove obsolete compatibility code only after stamped evidence exists.
+
+Primary changes:
+
+- Default `ODS_MODEL_SWITCHBOARD=enabled` for fresh installs.
+- Upgrade migration preserves the current proven model and generates state before moving consumers.
+- Retain `ODS_MODEL_SWITCHBOARD=legacy` as the explicit emergency rollback mode for one release.
+- Remove dead concrete consumer renderers and restart paths.
+- Add user guide, extension-author guide, runtime-adapter guide, route-evidence/privacy guide, and operator recovery runbook.
+- Document stable alias requirements in the service manifest schema and template.
+
+Tests:
+
+- Fresh install on every supported OS/backend.
+- Upgrade from the last non-switchboard release.
+- Reinstall/idempotence, restart, update, doctor, repair, uninstall/reinstall.
+- Emergency rollback flag restores the legacy path without data loss.
+
+Exit criteria:
+
+- The PR 9 candidate SHA is tested with no feature override, proving fresh installs really default to `enabled`.
+- Upgrade and emergency-legacy tests preserve the active concrete model and downloaded inventory.
+- The repository plan's decision/status table, user guide, extension guide, and operator runbook all match shipped commands and API paths.
+
+Merge gate: freeze the PR 9 head SHA, run section 7 with default settings, and stamp that exact candidate. Merge only that stamped SHA. After merge, run a main-branch smoke/identity check; any merge commit that changes the tree requires a new affected-host proof.
+
+## 6. Harness PRs
+
+Harness changes live in `dream-fleet-test-versioned`, are committed and pushed before deployment, and record both product and harness SHAs in every run directory and result file.
+
+### 6.1 Baseline verification commands
+
+Run focused tests while developing, then the complete gates before pushing a PR head. Commands assume a Linux/WSL shell for shell/Compose tests and the repository paths shown.
+
+Product backend/router:
+
+```bash
+cd ods
+python3 -m pytest \
+  extensions/services/dashboard-api/tests/test_model_state.py \
+  extensions/services/dashboard-api/tests/test_model_activate.py \
+  extensions/services/dashboard-api/tests/test_models.py -q
+python3 -m pytest extensions/services/model-router/tests -q
+make lint
+make test
+make smoke
+```
+
+Dashboard:
+
+```bash
+cd ods/extensions/services/dashboard
+npm ci
+npm test
+npm run lint
+npm run build
+```
+
+Full product gate before push:
+
+```bash
+cd ods
+make gate
+git diff --check
+```
+
+Harness:
+
+```bash
+cd dream-fleet-test-versioned
+bash tests/run.sh
+git diff --check
+```
+
+Windows-specific state/import tests also run with the installed interpreter (`py -3 -m pytest ...`) and the existing PowerShell contract jobs. A PR may not substitute mocked Linux results for Windows process/task or MSI behavior.
+
+### Harness PR A: route-aware consumer proof
+
+Change:
+
+- Extend `playwright/model-management.mjs` to generate a probe UUID and HMAC for every app round trip, using the run-scoped `ODS_FLEET_PROBE_KEY` provisioned by setup and removed by teardown.
+- Query authenticated route evidence after Hermes, Open WebUI, Perplexica, OpenCode, OpenClaw, LiteLLM, and any newly discovered LLM consumer.
+- Require requested alias `ods/current`, expected concrete model, expected backend, current `routeSeq`, successful response status, and Lemonade native route evidence where supported.
+- Add checks that discovered-consumer count equals functional-probe result count.
+- Preserve and assert the existing run naming/metadata contract: product SHA, harness SHA, host set, phase/tier, and clean harness status.
+
+Negative self-tests:
+
+- Correct answer from the wrong model fails.
+- Correct model with stale sequence fails.
+- Discovery-only evidence cannot satisfy a functional probe.
+- Missing app result fails rather than skips.
+- Legacy Lemonade evidence cannot claim native router coverage.
+- A forged or expired probe ID fails.
+- A validator retry cannot convert a final mismatched route into green.
+- An unsigned marker, wrong HMAC, or marker observed only in an app response without model-router evidence fails.
+
+### Harness PR B: permanent lifecycle and release gate
+
+Change:
+
+- Add switchboard setup/teardown to `lib/model-ui-host.sh` and `lib/model-ui-ods-adapter.sh`.
+- Add in-flight and during-swap cells to the release tier.
+- Add six-model campaign planning with host-specific, viable, preferably non-overlapping model sets.
+- Extend and validate `targets.json` with the release-scope fields defined in section 7.2; `enabled` never removes a release-required host from stamp accounting.
+- Encode eight release cycles per host: six distinct viable models, then repeat the baseline and one non-Phi model after restarts. `MODEL_UI_RELEASE_REQUIRED_MODELS` remains six; repeated models are repetition proof, not extra distinct coverage.
+- Make User Green require the full app/route matrix at the stamped product SHA.
+- Make confidence regeneration after a failed orchestrator verdict self-disclose.
+- Keep the drift ledger and prohibit undisclosed result-file repair.
+
+Harness files likely touched:
+
+- `playwright/model-management.mjs`
+- `lib/model-ui-host.sh`
+- `lib/model-ui-ods-adapter.sh`
+- `run-model-ui-fleet.sh`
+- `lib/report.sh`
+- `tests/test-model-ui-llm-consumer-coverage.sh`
+- `tests/test-model-ui-release-plan.sh`
+- `tests/test-release-confidence-report.sh`
+- New route-attestation and negative-self-test files
+
+## 7. Release validation program
+
+### 7.1 Iteration gates
+
+For PR 1 through PR 8, including every lettered slice:
+
+1. Unit and contract suites green.
+2. Compose/config/build checks green.
+3. Affected-host-only fleet run from pushed product and harness SHAs.
+4. Actual browser UI actions for any changed user workflow.
+5. Actual functional app probes for every discovered consumer on affected hosts.
+6. Record result and any hand repair in the coverage/drift ledgers.
+
+A single passing cycle is iteration-green only. It is not release evidence.
+
+### 7.2 Stamp candidate
+
+Freeze one immutable product SHA and one immutable harness SHA. No feature commits after the freeze; a product fix creates a new candidate and invalidates affected-host evidence at the old candidate.
+
+Per release-required host:
+
+1. Fresh install from the public bootstrap pinned to the exact product SHA.
+2. Verify model-state creation, stable alias, router health, and all discovered consumers.
+3. Through the actual Models UI, download, load, use, restore, and delete six distinct viable models in cycles 1-6.
+4. Prefer non-overlapping model sets across hosts to cover more labs, architectures, quants, sizes, and tool behaviors.
+5. After every swap and restore, run real functional round trips through every discovered app.
+6. Require route attestation for every app result.
+7. Restart between every cycle.
+8. Repeat the baseline and one non-Phi model in cycles 7-8. These repeats do not count toward the six-distinct-model requirement.
+9. Exercise one load failure, verified rollback, delete-active block, interrupted download/resume, and queue timeout path per runtime family.
+10. Run the full ordinary fleet test after the model campaign.
+
+Current canonical release-required hosts from `targets.json` at this audit:
+
+- `tower2`: Linux x86_64 NVIDIA llama.cpp and fleet orchestrator
+- `strix-halo`: Linux x86_64 AMD Lemonade
+- `spark`: Linux aarch64 NVIDIA unified llama.cpp
+- `dgx-gpu01`: Linux aarch64 DGX/GB300 llama.cpp, currently blocked: Launchpad closes SSH pre-auth (observed 2026-07-19)
+- `m5-mbp`: macOS arm64 native Metal
+- `windows-laptop`: Windows x86_64 NVIDIA native llama.cpp
+- `strixy`: Windows x86_64 AMD Lemonade, currently blocked for browser phases: no interactive console session (observed 2026-07-19)
+- `mac-mini`: macOS, currently blocked because its access/key repair is still outstanding
+
+`enabled: false` is an execution state, not a release-scope waiver. Harness PR B adds optional `release_required` to each `targets.json` host, defaulting to `true`; `release_required: false` requires non-empty `scope_owner`, `scope_reason`, and `scope_decided_at` fields. At freeze time, generate the expected set where `release_required != false`. A disabled or unreachable release-required host remains red/blocked and prevents the stamp. Removing a host requires an explicit owner-approved retirement/scope decision recorded in those fields, the coverage ledger, and the PR 9 release note; do not maintain a second hardcoded release list in the harness.
+
+Unavailable hosts are explicitly blocked with owner and reason; they are never counted as pass. On the audited fleet, three hosts are currently blocked, so restoring `mac-mini` access, `dgx-gpu01` SSH (external Launchpad pre-auth failure), and an interactive `strixy` console session are all release-stamp preconditions rather than optional extra coverage.
+
+Catalog readiness is a fourth precondition: before the stamp campaign is scheduled, the product viability API must list at least six viable models for every release-required host, including the aarch64 lanes (`spark`, `dgx-gpu01`). If it does not, catalog metadata work is on the stamp's critical path and must be finished and tested first.
+
+Release model plan shape:
+
+```json
+{
+  "hosts": {
+    "tower2": ["model-1", "model-2", "model-3", "model-4", "model-5", "model-6", "model-1", "model-2"],
+    "strix-halo": ["model-7", "model-8", "model-9", "model-10", "model-11", "model-12", "model-7", "model-8"]
+  }
+}
+```
+
+Harness PR B validates exactly eight entries per expected host, six distinct viable entries in positions 1-6, a baseline repeat in position 7, and a non-Phi repeat in position 8. The real plan contains every expected host and is committed with the harness or stored in immutable run metadata.
+
+Canonical release invocation on Tower2 after the normal identity/lock preflight:
+
+```bash
+cd /home/michael/dream-fleet-test
+export MODEL_UI_PRODUCT_SHA=<40-character-pushed-product-sha>
+export MODEL_UI_MODEL_PLAN_FILE=/absolute/path/to/switchboard-release-model-plan.json
+export DREAM_FLEET_MODEL_UI_TIER=release
+export DREAM_FLEET_MODEL_UI_CYCLES=8
+./run.sh --phase release \
+  --hosts tower2,strix-halo,spark,dgx-gpu01,m5-mbp,mac-mini,windows-laptop,strixy \
+  --skip-smoke
+```
+
+Before launch, replace the host list with the generated expected set and record it in `run-meta.json`. The run is invalid if the deployed product SHA or clean harness SHA differs from the exported/recorded values.
+
+### 7.3 App acceptance
+
+For every installed/enabled LLM consumer:
+
+- The manifest declares LLM consumption and a functional probe.
+- The app is exercised through its real user-facing API/UI, not service discovery alone.
+- Its request addresses `ods/current` or an approved switchboard role.
+- The answer contains the strict fresh-session probe result or valid tool-call-then-answer sequence.
+- Route evidence names the expected concrete model and current sequence.
+- Restarting the app or ODS does not restore a stale concrete ID.
+
+Known named consumers are Hermes/ODS Talk, Open WebUI, Perplexica, OpenCode, OpenClaw, and LiteLLM. The gate is discovery-driven so a newly installed consumer cannot be silently omitted.
+
+### 7.4 New-install and upgrade safety
+
+The release is not green until all of these pass:
+
+- Clean install with no prior `model-state.json`
+- Upgrade from pre-switchboard `.env` and concrete consumer configs
+- Reinstall/idempotent install on an enabled switchboard
+- Host reboot and ODS restart
+- Runtime upgrade, including Lemonade legacy-to-router-capable migration
+- Rollback to the previous ODS release without deleting downloaded models
+- Uninstall/reinstall with no stale router container, registry alias, task, process, or port
+
+## 8. Rollout and rollback
+
+Rollout states:
+
+1. `legacy`: pre-switchboard routing and compatibility projection; emergency fallback only after PR 3.
+2. `observe`: write and verify state while the old route remains authoritative.
+3. `enabled`: LiteLLM and migrated consumers use model-router.
+4. `default-on`: fresh installs select `enabled` after a stamped fleet run.
+5. `legacy-removed`: old per-consumer mutation code is deleted after one release with no rollback use.
+
+Emergency rollback:
+
+- Set `ODS_MODEL_SWITCHBOARD=legacy`, run the documented renderer, and recreate LiteLLM; the command and expected route proof are in the operator runbook.
+- The current active concrete model is projected from state before rollback.
+- Downloaded models and HF receipts are never deleted by route rollback.
+- Retained `user.ODS-Route-*` rollback collections may remain registered but are not used when legacy mode is active. A future stable internal collection may remain only when its release passed PR 6's ancestry and feature probes.
+
+## 9. Merge discipline
+
+- Main-targeted, review-sized PRs only.
+- #1724 is merged; there is no standing integration branch. A combined fleet test uses a disposable integration branch that is deleted after the run.
+- Product PR equals local branch at every pause.
+- Harness files are never deployed from an uncommitted state.
+- Every fleet run records product SHA, harness SHA, host, runtime version, and feature mode.
+- No validator leniency without a one-line false-red reproduction and a negative-self-test audit.
+- Use affected-host-only reruns until a fully proven stamp candidate exists.
+- At most two parallel sidecars; use them for independent docs/tests or separate host families.
+- Do not add smart routing until deterministic manual switching is stamped green.
+
+## 10. Definition of done
+
+The Model Switchboard series is complete only when:
+
+- Every release-required fleet host passes the six-model browser campaign at one frozen product/harness SHA pair; disabled/unreachable hosts block the stamp unless explicitly retired from scope.
+- Every discovered live application passes after every swap and restore with concrete route attestation.
+- New installs, upgrades, restarts, reinstall, rollback, and deletion lifecycle are green.
+- The release confidence gate includes the full model/app matrix and contains no undisclosed hand-repaired input.
+- All implementation is in CI-green main-targeted PRs, with the switchboard default-on PR merged only after the stamp.
+- The permanent fleet harness runs download, swap, use-through-all-apps, restore, delete, failure rollback, and during-swap behavior for future releases.

--- a/ods/docs/README.md
+++ b/ods/docs/README.md
@@ -129,6 +129,7 @@ canonical source and treat older recipes as context.
 | [HARDWARE-CLASSES.md](HARDWARE-CLASSES.md) | Developers | GPU-to-tier classification logic |
 | [SUPPORT-MATRIX.md](SUPPORT-MATRIX.md) | Operators | Platform/GPU support status |
 | [MODEL-MANAGEMENT.md](MODEL-MANAGEMENT.md) | Operators | Dashboard model downloads, switching, and manual GGUF workflows |
+| [MODEL-SWITCHBOARD.md](MODEL-SWITCHBOARD.md) | Contributors | Model Switchboard architecture, PR series plan, state/route contracts, and rollout gates |
 | [CAPABILITY-PROFILE.md](CAPABILITY-PROFILE.md) | Developers | Machine capability profiling schema |
 | [MULTI-USER-SETUP.md](MULTI-USER-SETUP.md) | Operators | Expose and tune one install for multiple users |
 | [PROFILES.md](PROFILES.md) | Reference | Docker Compose profiles (historical reference) |

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -62,7 +62,7 @@ from host_agent_client import (
 from agent_monitor import collect_metrics
 from routers import (
     workflows, features, setup, updates, agents, privacy, extensions,
-    gpu as gpu_router, resources, voice, models as models_router, templates,
+    gpu as gpu_router, resources, voice, models as models_router, model_state as model_state_router, templates,
     auth as auth_router,
     magic_link,
     oauth_passthrough,
@@ -1032,6 +1032,8 @@ app.include_router(extensions.router)
 app.include_router(gpu_router.router)
 app.include_router(resources.router)
 app.include_router(voice.router)
+# Static switchboard state route registers before the dynamic model-ID routes.
+app.include_router(model_state_router.router)
 app.include_router(models_router.router)
 app.include_router(templates.router)
 app.include_router(auth_router.router)

--- a/ods/extensions/services/dashboard-api/routers/model_state.py
+++ b/ods/extensions/services/dashboard-api/routers/model_state.py
@@ -1,0 +1,93 @@
+"""Read-only Model Switchboard state endpoint (PR 1, observe mode).
+
+Registered before the dynamic ``/api/models/{model_id}`` routes. The host
+agent is the only writer of ``data/model-state.json``; this endpoint is a
+sanitized reader. Malformed state is reported diagnostically — it is never
+promoted, repaired, or treated as a server error.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, Depends
+
+from config import INSTALL_DIR
+from security import verify_api_key
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["models"])
+
+_STATE_SCHEMA = "ods.model-state.v1"
+
+
+def _state_path() -> Path:
+    return Path(INSTALL_DIR) / "data" / "model-state.json"
+
+
+def _summarize(doc: dict[str, Any]) -> dict[str, Any]:
+    active = doc.get("active") if isinstance(doc.get("active"), dict) else None
+    capabilities = None
+    if active and isinstance(active.get("capabilities"), dict):
+        capabilities = active["capabilities"]
+    history = doc.get("history") if isinstance(doc.get("history"), list) else []
+    return {
+        "exists": True,
+        "valid": True,
+        "errors": [],
+        "schema": doc.get("schema"),
+        "seq": doc.get("seq"),
+        "routeSeq": doc.get("routeSeq"),
+        "operation": doc.get("operation"),
+        "desired": doc.get("desired"),
+        "active": active,
+        "history": history,
+        "historyCount": len(history),
+        "availability": doc.get("availability"),
+        "capabilityImpact": {
+            "agentViable": bool(capabilities.get("agentViable")) if capabilities else None,
+        },
+    }
+
+
+@router.get("/api/models/state")
+async def get_model_state(api_key: str = Depends(verify_api_key)):
+    """Sanitized switchboard state summary; read-only by contract."""
+    path = _state_path()
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return {
+            "exists": False,
+            "valid": False,
+            "errors": [],
+            "schema": _STATE_SCHEMA,
+            "seq": None,
+            "routeSeq": None,
+            "operation": None,
+            "desired": None,
+            "active": None,
+            "history": [],
+            "historyCount": 0,
+            "availability": None,
+            "capabilityImpact": {"agentViable": None},
+        }
+    except OSError as exc:
+        logger.warning("model-state read failed: %s", exc)
+        return {"exists": True, "valid": False, "errors": [f"read failed: {exc}"]}
+
+    try:
+        doc = json.loads(raw)
+    except ValueError as exc:
+        return {"exists": True, "valid": False, "errors": [f"not valid JSON: {exc}"]}
+    if not isinstance(doc, dict) or doc.get("schema") != _STATE_SCHEMA:
+        return {
+            "exists": True,
+            "valid": False,
+            "errors": [f"unsupported or missing schema (expected {_STATE_SCHEMA})"],
+        }
+    return _summarize(doc)

--- a/ods/extensions/services/dashboard-api/tests/test_model_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_state.py
@@ -1,0 +1,295 @@
+"""Model Switchboard PR 1 tests: state module, API endpoint, observe hook."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+_BIN_DIR = Path(__file__).resolve().parents[4] / "bin"
+if str(_BIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_BIN_DIR))
+
+from model_switchboard import state as sb  # noqa: E402
+
+_SCHEMA_PATH = Path(__file__).resolve().parents[4] / "config" / "model-state.schema.v1.json"
+
+
+def _record(path, model="qwen3.5-9b", runtime="Qwen3.5-9B-Q4_K_M.gguf", backend="llama-server",
+            endpoint="llama-server-default", context=32768):
+    return sb.record_verified_route(
+        path,
+        catalog_id=model,
+        runtime_model_id=runtime,
+        backend_kind=backend,
+        endpoint_id=endpoint,
+        context_length=context,
+        capabilities={"chat": True, "tools": False, "vision": False, "agentViable": context >= 65536},
+        proof_identity=runtime,
+    )
+
+
+class TestStateModule:
+    def test_roundtrip_and_schema_agreement(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        doc = _record(path)
+        assert doc["seq"] == 1 and doc["routeSeq"] == 1
+        read, errors = sb.read_state(path)
+        assert errors == [] and read == doc
+        assert read["active"]["runtimeModelId"] == "Qwen3.5-9B-Q4_K_M.gguf"
+        assert read["active"]["proof"] == {"identity": "Qwen3.5-9B-Q4_K_M.gguf", "completion": True}
+        assert sb.validate_state(read) == []
+        jsonschema = pytest.importorskip("jsonschema")
+        schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+        jsonschema.validate(read, schema)
+
+    def test_seq_monotonic_routeseq_only_on_change(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        _record(path)
+        doc = _record(path)  # identical route: seq moves, routeSeq does not
+        assert doc["seq"] == 2 and doc["routeSeq"] == 1 and doc["history"] == []
+        doc = _record(path, model="phi-4-mini", runtime="Phi-4-mini-Q4_K_M.gguf")
+        assert doc["seq"] == 3 and doc["routeSeq"] == 2
+        assert doc["history"][0]["runtimeModelId"] == "Qwen3.5-9B-Q4_K_M.gguf"
+        assert doc["history"][0]["routeSeq"] == 1
+
+    def test_history_bounded(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        for index in range(13):
+            _record(path, model=f"m-{index}", runtime=f"M-{index}.gguf")
+        doc, errors = sb.read_state(path)
+        assert errors == []
+        assert len(doc["history"]) == sb.HISTORY_LIMIT
+        assert doc["history"][0]["runtimeModelId"] == "M-11.gguf"
+
+    def test_interrupted_write_keeps_original(self, tmp_path, monkeypatch):
+        path = tmp_path / "model-state.json"
+        _record(path)
+        original = path.read_text(encoding="utf-8")
+        real_replace = os.replace
+
+        def exploding_replace(src, dst):
+            raise OSError("simulated crash before rename")
+
+        monkeypatch.setattr(sb.os, "replace", exploding_replace)
+        with pytest.raises(OSError):
+            _record(path, model="other", runtime="Other.gguf")
+        monkeypatch.setattr(sb.os, "replace", real_replace)
+        assert path.read_text(encoding="utf-8") == original
+        assert not list(tmp_path.glob("*.tmp"))
+
+    def test_concurrent_readers_never_see_partial(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        _record(path)
+        stop = threading.Event()
+        problems: list[str] = []
+
+        writer_error: list[str] = []
+
+        def writer():
+            try:
+                for index in range(60):
+                    _record(path, model=f"w-{index % 3}", runtime=f"W-{index % 3}.gguf")
+            except Exception as exc:  # never hang pytest on a writer fault
+                writer_error.append(repr(exc))
+            finally:
+                stop.set()
+
+        thread = threading.Thread(target=writer)
+        thread.start()
+        while not stop.is_set():
+            doc, errors = sb.read_state(path)
+            if doc is None or sb.validate_state(doc):
+                problems.append(f"bad read: {errors}")
+                break
+            time.sleep(0.001)
+        thread.join(timeout=30)
+        assert writer_error == []
+        assert problems == []
+
+    def test_malformed_state_is_diagnostic_never_promoted(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        path.write_text("{not json", encoding="utf-8")
+        doc, errors = sb.read_state(path)
+        assert doc is None and errors
+        with pytest.raises(sb.StateError):
+            _record(path)
+        assert sb.initialize_if_missing(path, {"GGUF_FILE": "X.gguf"}) is None
+        assert path.read_text(encoding="utf-8") == "{not json"
+
+    def test_validate_rejects_bad_shapes(self, tmp_path):
+        doc = sb.initial_state()
+        doc["seq"] = -1
+        assert any("seq" in e for e in sb.validate_state(doc))
+        doc = sb.initial_state()
+        doc["operation"] = {"id": "x", "phase": "warp", "requestedModelId": "m", "startedAt": "t"}
+        assert any("phase" in e for e in sb.validate_state(doc))
+        doc = _record(tmp_path / "s.json")
+        doc["active"]["backend"]["kind"] = "banana"
+        assert any("backend.kind" in e for e in sb.validate_state(doc))
+
+    @pytest.mark.parametrize(
+        "env,expected",
+        [
+            ({"GGUF_FILE": "Qwen3.5-9B-Q4_K_M.gguf", "LLM_MODEL": "qwen3.5-9b"},
+             {"catalogId": "qwen3.5-9b", "runtimeModelId": "Qwen3.5-9B-Q4_K_M.gguf", "backendKind": "llama-server"}),
+            ({"LEMONADE_MODEL": "extra.Qwen3.5-9B-Q4_K_M.gguf", "LLM_BACKEND": "lemonade"},
+             {"catalogId": "Qwen3.5-9B-Q4_K_M", "runtimeModelId": "extra.Qwen3.5-9B-Q4_K_M.gguf", "backendKind": "lemonade"}),
+            ({"GGUF_FILE": "M.gguf", "AMD_INFERENCE_RUNTIME": "lemonade"},
+             {"catalogId": "M", "runtimeModelId": "M.gguf", "backendKind": "lemonade"}),
+            ({"LLM_MODEL": "native-model"},
+             {"catalogId": "native-model", "runtimeModelId": "native-model", "backendKind": "llama-server"}),
+        ],
+    )
+    def test_migrate_env_forms(self, env, expected):
+        got = sb.migrate_env_identity(env)
+        for key, value in expected.items():
+            assert got[key] == value
+
+    def test_migrate_cloud_only_yields_none(self):
+        assert sb.migrate_env_identity({"ODS_MODE": "cloud"}) is None
+
+    def test_initialize_if_missing_reconstructs_once(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        env = {"GGUF_FILE": "Qwen3.5-9B-Q4_K_M.gguf", "LLM_MODEL": "qwen3.5-9b", "MAX_CONTEXT": "131072"}
+        doc = sb.initialize_if_missing(path, env)
+        assert doc["active"]["reconstructed"] is True
+        assert doc["active"]["verifiedAt"] is None
+        assert doc["active"]["proof"]["completion"] is False
+        assert doc["active"]["capabilities"]["agentViable"] is True
+        before = path.read_text(encoding="utf-8")
+        assert sb.initialize_if_missing(path, {"GGUF_FILE": "Other.gguf"}) is None
+        assert path.read_text(encoding="utf-8") == before
+
+    def test_initialize_cloud_only_writes_nothing(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        assert sb.initialize_if_missing(path, {"ODS_MODE": "cloud"}) is None
+        assert not path.exists()
+
+
+class TestModelStateEndpoint:
+    def _point_at(self, monkeypatch, tmp_path):
+        from routers import model_state as ms
+        monkeypatch.setattr(ms, "INSTALL_DIR", str(tmp_path))
+        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
+        return tmp_path / "data" / "model-state.json"
+
+    def test_missing_state(self, test_client, monkeypatch, tmp_path):
+        self._point_at(monkeypatch, tmp_path)
+        resp = test_client.get("/api/models/state", headers=test_client.auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["exists"] is False and body["valid"] is False
+        assert body["active"] is None and body["historyCount"] == 0
+
+    def test_valid_state_summary(self, test_client, monkeypatch, tmp_path):
+        path = self._point_at(monkeypatch, tmp_path)
+        _record(path, context=131072)
+        _record(path, model="phi-4-mini", runtime="Phi-4-mini-Q4_K_M.gguf", context=131072)
+        resp = test_client.get("/api/models/state", headers=test_client.auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["exists"] is True and body["valid"] is True
+        assert body["routeSeq"] == 2
+        assert body["active"]["catalogId"] == "phi-4-mini"
+        assert body["historyCount"] == 1
+        assert body["capabilityImpact"]["agentViable"] is True
+
+    def test_malformed_state_is_diagnostic(self, test_client, monkeypatch, tmp_path):
+        path = self._point_at(monkeypatch, tmp_path)
+        path.write_text("][", encoding="utf-8")
+        resp = test_client.get("/api/models/state", headers=test_client.auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["exists"] is True and body["valid"] is False and body["errors"]
+
+    def test_requires_auth(self, test_client, monkeypatch, tmp_path):
+        self._point_at(monkeypatch, tmp_path)
+        resp = test_client.get("/api/models/state")
+        assert resp.status_code in (401, 403)
+
+
+class TestObserveHook:
+    @pytest.fixture(autouse=True)
+    def _isolation(self, monkeypatch, tmp_path):
+        import test_model_activate as tma
+        config_dir = tmp_path / "isolated-home" / ".config" / "opencode"
+        monkeypatch.setattr(
+            tma._mod,
+            "_opencode_config_paths",
+            lambda: (config_dir / "opencode.json", config_dir / "config.json"),
+        )
+        monkeypatch.setattr(tma._mod, "_chat_completion_ready", lambda *_a, **_k: True)
+        monkeypatch.setattr(tma._mod, "_container_exists", lambda _c: False)
+        monkeypatch.setattr(tma._mod, "_container_running", lambda _c: False)
+        monkeypatch.setattr(
+            tma._mod,
+            "_capture_container_state",
+            lambda container: {"exists": False, "running": False},
+        )
+        monkeypatch.setattr(tma._mod, "_wait_for_container_health", lambda _c: None)
+        monkeypatch.setattr(
+            tma._mod,
+            "_capture_managed_opencode_state",
+            lambda: {"system": tma._mod.platform.system(), "active": False},
+        )
+        monkeypatch.setattr(tma._mod, "_opencode_installed", lambda: False)
+
+    def test_activation_success_records_state(self, tmp_path, monkeypatch):
+        import subprocess
+        import test_model_activate as tma
+
+        install_dir = tma._write_model_activation_fixture(tmp_path)[0]
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(tma._mod.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(tma._mod, "_compose_restart_llama_server", lambda _env: None)
+
+        def fake_run(cmd, **_kwargs):
+            stdout = tma._llama_identity_response("new-model.gguf") if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(tma._mod.subprocess, "run", fake_run)
+        assert tma._mod._switchboard_state is not None
+
+        handler = tma._ResponseHandler()
+        tma._mod.AgentHandler._do_model_activate(handler, "target-model")
+        assert handler.response_code == 200
+
+        state_path = install_dir / "data" / "model-state.json"
+        doc, errors = sb.read_state(state_path)
+        assert errors == [] and doc is not None
+        assert doc["routeSeq"] == 1
+        assert doc["active"]["catalogId"] == "target-model"
+        assert doc["active"]["runtimeModelId"] == "new-model.gguf"
+        assert doc["active"]["proof"]["completion"] is True
+
+    def test_activation_failure_leaves_state_untouched(self, tmp_path, monkeypatch):
+        import subprocess
+        import test_model_activate as tma
+
+        install_dir = tma._write_model_activation_fixture(tmp_path)[0]
+        state_path = install_dir / "data" / "model-state.json"
+        _record(state_path, model="previous", runtime="Previous.gguf")
+        before = state_path.read_text(encoding="utf-8")
+
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(tma._mod.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(tma._mod, "_compose_restart_llama_server", lambda _env: None)
+
+        def failing_run(cmd, **_kwargs):
+            # Identity probe returns the wrong model so verification fails.
+            stdout = tma._llama_identity_response("wrong-model.gguf") if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(tma._mod.subprocess, "run", failing_run)
+        handler = tma._ResponseHandler()
+        tma._mod.AgentHandler._do_model_activate(handler, "target-model")
+        assert handler.response_code != 200
+        assert state_path.read_text(encoding="utf-8") == before


### PR DESCRIPTION
Model Switchboard series PR 1 — see `ods/docs/MODEL-SWITCHBOARD.md` (added here) for the full plan.

**Base:** `5dd6f72d` · **Head:** `4f6bfb75` · **Depends on:** #1711, #1766 (merged) · **Mode:** observe (state is recorded only after the existing activation transaction proves success; no routing or consumer behavior changes)

## Changes
- `ods/config/model-state.schema.v1.json` — published v1 contract (seq/routeSeq, active route with backend + capabilities + proof, 10-entry history, availability).
- `ods/bin/model_switchboard/` — stdlib-only state module: atomic fsync'd writes with Windows sharing-violation retries (read and replace), routeSeq only on route change, malformed-state quarantine (never promoted, never blindly overwritten), `.env` identity migration (GGUF / Lemonade stem / `extra.*` / native), one-time `reconstructed` init with `proof.completion=false`.
- Host agent — three fail-open observe hooks: package import, post-commit route recording, startup reconstruction. A broken package or write can only log a warning.
- dashboard-api — read-only `GET /api/models/state` registered before the dynamic `/api/models/{model_id}` routes; malformed state returns a 200 diagnostic, never a 500.
- Docs — plan at `ods/docs/MODEL-SWITCHBOARD.md`, indexed in `ods/docs/README.md`.

## Tests
- `tests/test_model_state.py`: 19 passed, 1 skipped (jsonschema optional) on Windows; covers atomicity/interruption, reader-writer concurrency, seq/routeSeq discipline, bounded history, malformed-state behavior, migration forms, reconstruction rules, endpoint auth/shapes, and two observe-hook integration tests through the real activation fixture (success records state; failed verification leaves state byte-identical).
- Full dashboard-api suite: 1,515 passed locally (single known Windows-privilege symlink failure, pre-existing, green on Linux CI).
- ruff clean on all touched files.

## Rollback
Remove the additive files and the three guarded host-agent blocks; existing activation is untouched by design.

## Fleet gate
Observe-only affected-host run planned post-merge per the plan (state file + endpoint verified on the four runtime families) — will ride the next fleet pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)