### PR TITLE
refactor(models): runtime adapters and one reconciler (PR 2A, observe)

### DIFF
--- a/ods/bin/model_switchboard/__init__.py
+++ b/ods/bin/model_switchboard/__init__.py
@@ -5,6 +5,7 @@ single writer; everything else reads. Stdlib-only by contract so the
 standalone host agent can import it from the installed tree.
 """
 
+from . import adapters, reconciler  # noqa: F401
 from .state import (  # noqa: F401
     HISTORY_LIMIT,
     SCHEMA_VERSION,

--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -1,0 +1,130 @@
+"""Runtime adapter contract for the ODS Model Switchboard (PR 2A).
+
+An adapter owns exactly one runtime family's mechanics for the activation
+sequence. Every operation returns a typed result dict (stdlib only):
+
+    {"ok": bool, "detail": str, ...extras}
+
+Successful verification must carry concrete evidence — the runtime-reported
+identity and a completed generation — never configuration echoes. The
+reconciler treats a missing or false ``ok`` as a transaction-boundary
+failure; adapters must not raise for expected runtime failures.
+
+PR 2A ships the shared contract, the transaction fake used by the boundary
+test matrix, and the container llama.cpp adapter. Native Windows/macOS and
+Lemonade/HipFire adapters land in PR 2B/2C and must pass the same contract
+suite.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol
+
+
+def result(ok: bool, detail: str = "", **extras: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"ok": bool(ok), "detail": str(detail)}
+    payload.update(extras)
+    return payload
+
+
+class RuntimeAdapter(Protocol):
+    """Contract implemented by every runtime family."""
+
+    kind: str
+
+    def stage(self, env: dict[str, str]) -> dict[str, Any]:
+        """Start/restart the runtime so it serves the staged model."""
+
+    def verify_identity(self, env: dict[str, str]) -> dict[str, Any]:
+        """Prove the runtime reports the staged model. Extras: ``identity``."""
+
+    def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
+        """Prove a real completion. Extras: ``identity`` when reported."""
+
+
+class ContainerLlamaAdapter:
+    """Compose-managed llama.cpp runtime (Linux/NVIDIA container path).
+
+    Behavior lives in the host agent's existing, fleet-proven helpers; this
+    adapter is the single seam the reconciler drives. Callables are injected
+    so the standalone host agent remains the one owner of process/compose
+    mechanics and tests can substitute the transaction fake.
+    """
+
+    kind = "llama-server"
+
+    def __init__(
+        self,
+        *,
+        restart: Callable[[dict[str, str]], None],
+        wait_ready: Callable[..., bool],
+        expected_gguf: str,
+        context_length: int,
+        lemonade_model_id: str = "",
+    ) -> None:
+        self._restart = restart
+        self._wait_ready = wait_ready
+        self._expected_gguf = expected_gguf
+        self._context_length = int(context_length)
+        self._lemonade_model_id = lemonade_model_id
+
+    def stage(self, env: dict[str, str]) -> dict[str, Any]:
+        try:
+            self._restart(env)
+        except Exception as exc:  # expected runtime failures become results
+            return result(False, f"container restart failed: {exc}")
+        return result(True, "compose restart issued")
+
+    def verify_identity(self, env: dict[str, str]) -> dict[str, Any]:
+        # Readiness in the container path proves identity and serving state
+        # in one bounded wait, mirroring the pre-adapter inline behavior.
+        try:
+            healthy = self._wait_ready(
+                env,
+                self._expected_gguf,
+                self._context_length,
+                lemonade_model_id=self._lemonade_model_id,
+            )
+        except Exception as exc:
+            return result(False, f"readiness wait failed: {exc}")
+        if not healthy:
+            return result(False, "runtime did not report the staged model")
+        return result(True, "runtime reports staged model", identity=self._expected_gguf)
+
+    def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
+        # _wait_for_model_readiness already requires a meaningful completion
+        # before returning True; a separate probe here would double-generate.
+        return result(True, "completion proven during readiness wait",
+                      identity=self._expected_gguf)
+
+
+class FakeAdapter:
+    """Shared transaction fake for the boundary test matrix (test-only).
+
+    ``plan`` maps operation name -> list of results returned in call order;
+    the last entry repeats. ``calls`` records the exact sequence.
+    """
+
+    kind = "fake"
+
+    def __init__(self, plan: dict[str, list[dict[str, Any]]] | None = None) -> None:
+        self.plan = plan or {}
+        self.calls: list[str] = []
+
+    def _next(self, op: str) -> dict[str, Any]:
+        self.calls.append(op)
+        queue = self.plan.get(op)
+        if not queue:
+            return result(True, f"{op} default ok")
+        if len(queue) > 1:
+            return queue.pop(0)
+        return queue[0]
+
+    def stage(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("stage")
+
+    def verify_identity(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("verify_identity")
+
+    def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("verify_completion")

--- a/ods/bin/model_switchboard/reconciler.py
+++ b/ods/bin/model_switchboard/reconciler.py
@@ -1,0 +1,72 @@
+"""Runtime activation sequence for the ODS Model Switchboard (PR 2A).
+
+One orchestration of the runtime phase of a model swap:
+
+    stage -> verify_identity -> verify_completion
+
+The reconciler owns sequencing and failure classification only. Snapshots,
+consumer projection, HTTP contracts, and rollback proof remain with the host
+agent's activation transaction until later slices migrate them. A phase
+failure stops the sequence immediately and reports which boundary failed so
+the caller's existing rollback machinery takes over.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .adapters import RuntimeAdapter, result
+
+PHASES = ("stage", "verify_identity", "verify_completion")
+
+
+def run_runtime_activation(
+    adapter: RuntimeAdapter,
+    env: dict[str, str],
+) -> dict[str, Any]:
+    """Drive the runtime phases; first failure wins.
+
+    Returns ``{"ok": bool, "phase": str, "detail": str, "identity": str|None}``.
+    ``phase`` is the last phase attempted. Health-style success without an
+    identity cannot satisfy verification: a verify_identity result that omits
+    ``identity`` is treated as a failed boundary even when ``ok`` is true.
+    """
+    identity: str | None = None
+    for phase in PHASES:
+        try:
+            outcome = getattr(adapter, phase)(env)
+        except Exception as exc:  # adapter contract violation, not runtime state
+            return {
+                "ok": False,
+                "phase": phase,
+                "detail": f"adapter raised: {exc}",
+                "identity": identity,
+            }
+        if not isinstance(outcome, dict) or "ok" not in outcome:
+            return {
+                "ok": False,
+                "phase": phase,
+                "detail": "adapter returned a non-contract result",
+                "identity": identity,
+            }
+        if phase == "verify_identity" and outcome.get("ok") and not outcome.get("identity"):
+            return {
+                "ok": False,
+                "phase": phase,
+                "detail": "identity verification returned no concrete identity",
+                "identity": identity,
+            }
+        if outcome.get("identity"):
+            identity = str(outcome["identity"])
+        if not outcome.get("ok"):
+            return {
+                "ok": False,
+                "phase": phase,
+                "detail": str(outcome.get("detail") or f"{phase} failed"),
+                "identity": identity,
+            }
+    return {"ok": True, "phase": PHASES[-1], "detail": "runtime activation proven",
+            "identity": identity}
+
+
+__all__ = ["PHASES", "run_runtime_activation", "result"]

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -49,6 +49,12 @@ try:
     from model_switchboard import state as _switchboard_state
 except Exception:  # pragma: no cover - import environment dependent
     _switchboard_state = None
+try:
+    from model_switchboard import adapters as _switchboard_adapters
+    from model_switchboard import reconciler as _switchboard_reconciler
+except Exception:  # pragma: no cover - import environment dependent
+    _switchboard_adapters = None
+    _switchboard_reconciler = None
 
 VERSION = "1.0.0"
 ODS_VERSION = VERSION
@@ -5392,6 +5398,20 @@ class AgentHandler(BaseHTTPRequestHandler):
                 f"n-ctx = {context_length}\n",
             )
 
+            # Switchboard runtime adapter (PR 2A): the non-Lemonade container
+            # llama paths stage+verify through one reconciler sequence. All
+            # other strategies keep their inline flow until PR 2B/2C.
+            switchboard_adapter = None
+
+            def _sb_wait_ready(_env, _gguf, _ctx, lemonade_model_id=""):
+                return _wait_for_model_readiness(
+                    _env,
+                    model_id=model_id,
+                    gguf_file=_gguf,
+                    llm_model_name=llm_model_name,
+                    lemonade_model_id=lemonade_model_id,
+                )
+
             # Restart llama-server with the new model.
             # Three strategies depending on platform / agent location:
             # - apple (macOS): llama-server runs natively via Metal, not Docker.
@@ -5437,10 +5457,29 @@ class AgentHandler(BaseHTTPRequestHandler):
                     )
                 )
                 runtime_restart_strategy = "container-llama"
-                _recreate_llama_server(env, override_image=override_image)
+                if _switchboard_adapters is not None and not lemonade_runtime:
+                    _sb_override = override_image
+                    switchboard_adapter = _switchboard_adapters.ContainerLlamaAdapter(
+                        restart=lambda _e, _img=_sb_override: _recreate_llama_server(
+                            _e, override_image=_img
+                        ),
+                        wait_ready=_sb_wait_ready,
+                        expected_gguf=gguf_file,
+                        context_length=int(context_length),
+                    )
+                else:
+                    _recreate_llama_server(env, override_image=override_image)
             else:
                 runtime_restart_strategy = "compose-llama"
-                _compose_restart_llama_server(env)
+                if _switchboard_adapters is not None and not lemonade_runtime:
+                    switchboard_adapter = _switchboard_adapters.ContainerLlamaAdapter(
+                        restart=_compose_restart_llama_server,
+                        wait_ready=_sb_wait_ready,
+                        expected_gguf=gguf_file,
+                        context_length=int(context_length),
+                    )
+                else:
+                    _compose_restart_llama_server(env)
 
             if lemonade_runtime:
                 lemonade_host, lemonade_port = _lemonade_runtime_address(env)
@@ -5464,13 +5503,25 @@ class AgentHandler(BaseHTTPRequestHandler):
                 "http://litellm:4000/v1" if windows_host_lemonade else None
             )
 
-            healthy = _wait_for_model_readiness(
-                env,
-                model_id=model_id,
-                gguf_file=gguf_file,
-                llm_model_name=llm_model_name,
-                lemonade_model_id=lemonade_model_id,
-            )
+            if switchboard_adapter is not None:
+                switchboard_run = _switchboard_reconciler.run_runtime_activation(
+                    switchboard_adapter, env
+                )
+                healthy = bool(switchboard_run["ok"])
+                if not healthy:
+                    logger.error(
+                        "switchboard runtime activation failed at %s: %s",
+                        switchboard_run.get("phase"),
+                        switchboard_run.get("detail"),
+                    )
+            else:
+                healthy = _wait_for_model_readiness(
+                    env,
+                    model_id=model_id,
+                    gguf_file=gguf_file,
+                    llm_model_name=llm_model_name,
+                    lemonade_model_id=lemonade_model_id,
+                )
 
             if healthy:
                 if lemonade_runtime:

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -1,0 +1,210 @@
+"""Switchboard PR 2A: adapter contract + reconciler transaction boundaries."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_BIN_DIR = Path(__file__).resolve().parents[4] / "bin"
+if str(_BIN_DIR) not in sys.path:
+    sys.path.insert(0, str(_BIN_DIR))
+
+from model_switchboard import adapters as ad  # noqa: E402
+from model_switchboard import reconciler as rc  # noqa: E402
+
+
+class TestReconcilerBoundaries:
+    def test_success_runs_phases_in_order(self):
+        fake = ad.FakeAdapter({
+            "verify_identity": [ad.result(True, identity="M.gguf")],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is True
+        assert run["identity"] == "M.gguf"
+        assert fake.calls == list(rc.PHASES)
+
+    def test_stage_failure_stops_sequence(self):
+        fake = ad.FakeAdapter({"stage": [ad.result(False, "boom")]})
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False and run["phase"] == "stage"
+        assert "boom" in run["detail"]
+        assert fake.calls == ["stage"]
+
+    def test_identity_failure_stops_before_completion(self):
+        fake = ad.FakeAdapter({
+            "verify_identity": [ad.result(False, "wrong model")],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+        assert fake.calls == ["stage", "verify_identity"]
+
+    def test_identity_ok_without_identity_cannot_pass(self):
+        # Health-only success must not satisfy verification.
+        fake = ad.FakeAdapter({"verify_identity": [ad.result(True)]})
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+        assert "no concrete identity" in run["detail"]
+
+    def test_completion_failure_reports_boundary(self):
+        fake = ad.FakeAdapter({
+            "verify_identity": [ad.result(True, identity="M.gguf")],
+            "verify_completion": [ad.result(False, "no tokens")],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False and run["phase"] == "verify_completion"
+        assert run["identity"] == "M.gguf"
+
+    def test_adapter_exception_is_contract_violation(self):
+        class Exploding(ad.FakeAdapter):
+            def stage(self, env):
+                raise RuntimeError("adapter bug")
+
+        run = rc.run_runtime_activation(Exploding(), {})
+        assert run["ok"] is False and run["phase"] == "stage"
+        assert "adapter raised" in run["detail"]
+
+    def test_non_contract_result_fails(self):
+        class Weird(ad.FakeAdapter):
+            def stage(self, env):
+                return "ok"  # not a contract dict
+
+        run = rc.run_runtime_activation(Weird(), {})
+        assert run["ok"] is False and run["phase"] == "stage"
+        assert "non-contract" in run["detail"]
+
+
+class TestContainerLlamaAdapter:
+    def test_delegates_with_expected_arguments(self):
+        seen = {}
+
+        def restart(env):
+            seen["restart_env"] = env
+
+        def wait_ready(env, gguf, ctx, lemonade_model_id=""):
+            seen["wait"] = (gguf, ctx, lemonade_model_id)
+            return True
+
+        adapter = ad.ContainerLlamaAdapter(
+            restart=restart,
+            wait_ready=wait_ready,
+            expected_gguf="Model.gguf",
+            context_length=4096,
+        )
+        env = {"GPU_BACKEND": "nvidia"}
+        run = rc.run_runtime_activation(adapter, env)
+        assert run["ok"] is True
+        assert run["identity"] == "Model.gguf"
+        assert seen["restart_env"] is env
+        assert seen["wait"] == ("Model.gguf", 4096, "")
+
+    def test_restart_exception_becomes_stage_failure(self):
+        adapter = ad.ContainerLlamaAdapter(
+            restart=lambda _env: (_ for _ in ()).throw(OSError("compose down")),
+            wait_ready=lambda *a, **k: True,
+            expected_gguf="M.gguf",
+            context_length=1024,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "stage"
+        assert "compose down" in run["detail"]
+
+    def test_not_ready_is_identity_failure(self):
+        adapter = ad.ContainerLlamaAdapter(
+            restart=lambda _env: None,
+            wait_ready=lambda *a, **k: False,
+            expected_gguf="M.gguf",
+            context_length=1024,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+
+
+class TestHostAgentWiring:
+    def test_compose_llama_path_flows_through_reconciler(self, tmp_path, monkeypatch):
+        import subprocess
+        import test_model_activate as tma
+
+        install_dir = tma._write_model_activation_fixture(tmp_path)[0]
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(tma._mod.time, "sleep", lambda _s: None)
+
+        order: list[str] = []
+        monkeypatch.setattr(
+            tma._mod, "_compose_restart_llama_server",
+            lambda _env: order.append("restart"),
+        )
+        real_wait = tma._mod._wait_for_model_readiness
+
+        def spying_wait(env, **kwargs):
+            order.append("wait")
+            return real_wait(env, **kwargs)
+
+        monkeypatch.setattr(tma._mod, "_wait_for_model_readiness", spying_wait)
+
+        def fake_run(cmd, **_kwargs):
+            stdout = tma._llama_identity_response("new-model.gguf") if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(tma._mod.subprocess, "run", fake_run)
+        assert tma._mod._switchboard_adapters is not None
+
+        handler = tma._ResponseHandler()
+        tma._mod.AgentHandler._do_model_activate(handler, "target-model")
+        assert handler.response_code == 200
+        assert order[:2] == ["restart", "wait"]
+
+    def test_reconciler_failure_uses_existing_rollback(self, tmp_path, monkeypatch):
+        import subprocess
+        import test_model_activate as tma
+
+        install_dir = tma._write_model_activation_fixture(tmp_path)[0]
+        env_path = install_dir / ".env"
+        before_env = env_path.read_text(encoding="utf-8")
+
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(tma._mod.time, "sleep", lambda _s: None)
+        monkeypatch.setattr(
+            tma._mod, "_compose_restart_llama_server", lambda _env: None
+        )
+
+        def failing_run(cmd, **_kwargs):
+            stdout = tma._llama_identity_response("wrong-model.gguf") if cmd and cmd[0] == "curl" else ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(tma._mod.subprocess, "run", failing_run)
+        handler = tma._ResponseHandler()
+        tma._mod.AgentHandler._do_model_activate(handler, "target-model")
+        assert handler.response_code != 200
+        # rollback restored the pre-activation env exactly as before PR 2A
+        assert env_path.read_text(encoding="utf-8") == before_env
+
+
+@pytest.fixture(autouse=True)
+def _isolation(monkeypatch, tmp_path, request):
+    if "TestHostAgentWiring" not in str(request.node.nodeid):
+        yield
+        return
+    import test_model_activate as tma
+    config_dir = tmp_path / "isolated-home" / ".config" / "opencode"
+    monkeypatch.setattr(
+        tma._mod, "_opencode_config_paths",
+        lambda: (config_dir / "opencode.json", config_dir / "config.json"),
+    )
+    monkeypatch.setattr(tma._mod, "_chat_completion_ready", lambda *_a, **_k: True)
+    monkeypatch.setattr(tma._mod, "_container_exists", lambda _c: False)
+    monkeypatch.setattr(tma._mod, "_container_running", lambda _c: False)
+    monkeypatch.setattr(
+        tma._mod, "_capture_container_state",
+        lambda container: {"exists": False, "running": False},
+    )
+    monkeypatch.setattr(tma._mod, "_wait_for_container_health", lambda _c: None)
+    monkeypatch.setattr(
+        tma._mod, "_capture_managed_opencode_state",
+        lambda: {"system": tma._mod.platform.system(), "active": False},
+    )
+    monkeypatch.setattr(tma._mod, "_opencode_installed", lambda: False)
+    yield


### PR DESCRIPTION
Model Switchboard series PR 2A — plan: `ods/docs/MODEL-SWITCHBOARD.md`.

**Base:** `55a51170` · **Head:** `3878b8fb` · **Depends on:** #1899 (merged) · **Mode:** observe; behavior-preserving

## Changes
- `model_switchboard.adapters`: typed result contract, `RuntimeAdapter` protocol, `ContainerLlamaAdapter` (injected delegation to the existing fleet-proven restart/readiness helpers — mechanics stay in the host agent), shared `FakeAdapter` for the boundary matrix.
- `model_switchboard.reconciler`: single `stage → verify_identity → verify_completion` sequence; first failure wins; identity-less success cannot pass verification; adapter exceptions/non-contract results are boundary failures.
- Host agent: non-Lemonade container/compose llama strategies route the runtime phase through the reconciler (fail-open — missing package falls back to the inline flow); reconciler failure feeds the existing rollback machinery unchanged. Native Windows/macOS and Lemonade flows untouched until PR 2B/2C.

## Equivalence & tests
- Two integration tests through the real activation fixture prove the reroute's call order and that a verification failure produces the byte-identical pre-2A rollback.
- 12 new boundary/contract tests; PR 1 suite re-green; activation suites (`test_model_activate`, `test_host_agent`, `test_models`) 404 passed locally; ruff clean.
- The heavy activation fixtures monkeypatch the same helpers the adapter delegates to, so the 1,500+-test suite exercises the new path directly.

## Rollback
Revert restores the two inline call sites; the module files are additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)