### PR TITLE
refactor(models): native Windows and macOS llama adapters (PR 2B, observe)

### DIFF
--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -98,6 +98,17 @@ class ContainerLlamaAdapter:
                       identity=self._expected_gguf)
 
 
+class NativeLlamaAdapter(ContainerLlamaAdapter):
+    """Native llama.cpp runtime (Windows process / macOS launchd+PID paths).
+
+    Identical sequencing to the container adapter; only the injected restart
+    mechanics differ (PR 2B). A distinct class keeps the runtime family
+    explicit in state/evidence and lets 2C-era policy diverge if needed.
+    """
+
+    kind = "llama-server"
+
+
 class FakeAdapter:
     """Shared transaction fake for the boundary test matrix (test-only).
 

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5433,19 +5433,42 @@ class AgentHandler(BaseHTTPRequestHandler):
                     )
             elif windows_native_llama:
                 runtime_restart_strategy = "windows-native-llama"
-                _restart_windows_native_llama_server(env_path, env)
+                if _switchboard_adapters is not None:
+                    switchboard_adapter = _switchboard_adapters.NativeLlamaAdapter(
+                        restart=lambda _e: _restart_windows_native_llama_server(
+                            env_path, _e
+                        ),
+                        wait_ready=_sb_wait_ready,
+                        expected_gguf=gguf_file,
+                        context_length=int(context_length),
+                    )
+                else:
+                    _restart_windows_native_llama_server(env_path, env)
             elif gpu_backend == "apple":
                 # macOS: manage native llama-server process via PID file
                 if not all((apple_llama_bin, apple_llama_log, apple_pid_file)):
                     raise RuntimeError("macOS native runtime preflight state is unavailable")
 
                 runtime_restart_strategy = "macos-native-llama"
-                _restart_macos_native_llama_server(
-                    env_path,
-                    apple_llama_bin,
-                    apple_llama_log,
-                    apple_pid_file,
-                )
+                if _switchboard_adapters is not None:
+                    switchboard_adapter = _switchboard_adapters.NativeLlamaAdapter(
+                        restart=lambda _e: _restart_macos_native_llama_server(
+                            env_path,
+                            apple_llama_bin,
+                            apple_llama_log,
+                            apple_pid_file,
+                        ),
+                        wait_ready=_sb_wait_ready,
+                        expected_gguf=gguf_file,
+                        context_length=int(context_length),
+                    )
+                else:
+                    _restart_macos_native_llama_server(
+                        env_path,
+                        apple_llama_bin,
+                        apple_llama_log,
+                        apple_pid_file,
+                    )
             elif _in_container:
                 override_image = (
                     llama_server_image

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -121,6 +121,32 @@ class TestContainerLlamaAdapter:
         assert run["ok"] is False and run["phase"] == "verify_identity"
 
 
+class TestNativeLlamaAdapter:
+    def test_windows_native_delegation_and_kind(self):
+        calls = []
+        adapter = ad.NativeLlamaAdapter(
+            restart=lambda _e: calls.append("restart"),
+            wait_ready=lambda *a, **k: (calls.append("wait"), True)[1],
+            expected_gguf="Win.gguf",
+            context_length=8192,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is True and run["identity"] == "Win.gguf"
+        assert adapter.kind == "llama-server"
+        assert calls == ["restart", "wait"]
+
+    def test_native_restart_failure_is_stage_boundary(self):
+        adapter = ad.NativeLlamaAdapter(
+            restart=lambda _e: (_ for _ in ()).throw(RuntimeError("launchd bootout failed")),
+            wait_ready=lambda *a, **k: True,
+            expected_gguf="Mac.gguf",
+            context_length=8192,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "stage"
+        assert "launchd bootout failed" in run["detail"]
+
+
 class TestHostAgentWiring:
     def test_compose_llama_path_flows_through_reconciler(self, tmp_path, monkeypatch):
         import subprocess


### PR DESCRIPTION
Model Switchboard series PR 2B — plan: `ods/docs/MODEL-SWITCHBOARD.md`.

**Depends on:** #1900 (merged) · **Mode:** observe; behavior-preserving

`NativeLlamaAdapter` wraps the existing Windows process and macOS launchd/PID restart mechanics via injection; both native strategies stage+verify through the PR 2A reconciler with the same fail-open fallback to the inline flow. No Linux changes beyond the shared contract.

Tests: adapter delegation/boundary cases added to the shared contract suite; switchboard + full activation suites 186 passed locally (the native activation fixtures monkeypatch the same injected helpers, exercising the new path directly); ruff clean.

Rollback: revert restores the two inline call sites; the adapter class is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)