### PR TITLE
fix(models): harden switchboard state foundation

### DIFF
--- a/ods/bin/model_switchboard/state.py
+++ b/ods/bin/model_switchboard/state.py
@@ -39,6 +39,21 @@ _OPERATION_PHASES = {
 }
 _AVAILABILITY_MODES = {"serve_active", "queue"}
 
+_TOP_LEVEL_KEYS = {
+    "schema", "seq", "routeSeq", "operation", "desired", "active",
+    "history", "availability",
+}
+_OPERATION_KEYS = {"id", "phase", "requestedModelId", "startedAt", "error"}
+_ACTIVE_KEYS = {
+    "routeSeq", "catalogId", "runtimeModelId", "publicModel", "backend",
+    "contextLength", "capabilities", "verifiedAt", "reconstructed", "proof",
+}
+_BACKEND_KEYS = {"kind", "endpointId", "nativeRoute"}
+_CAPABILITY_KEYS = {"chat", "tools", "vision", "agentViable"}
+_PROOF_KEYS = {"identity", "completion"}
+_HISTORY_KEYS = {"routeSeq", "catalogId", "runtimeModelId", "verifiedAt"}
+_AVAILABILITY_KEYS = {"mode", "queueDeadline"}
+
 _WRITE_LOCK = threading.Lock()
 _LAST_GOOD: dict[str, dict[str, Any]] = {}
 
@@ -49,6 +64,22 @@ class StateError(RuntimeError):
 
 def _utcnow_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _check_keys(
+    value: dict[str, Any],
+    *,
+    allowed: set[str] | None,
+    required: set[str],
+    label: str,
+    errors: list[str],
+) -> None:
+    missing = required - set(value)
+    unexpected = set(value) - allowed if allowed is not None else set()
+    if missing:
+        errors.append(f"{label} is missing required keys: {', '.join(sorted(missing))}")
+    if unexpected:
+        errors.append(f"{label} has unexpected keys: {', '.join(sorted(unexpected))}")
 
 
 def initial_state() -> dict[str, Any]:
@@ -74,6 +105,13 @@ def validate_state(doc: Any) -> list[str]:
     errors: list[str] = []
     if not isinstance(doc, dict):
         return ["state root must be an object"]
+    _check_keys(
+        doc,
+        allowed=_TOP_LEVEL_KEYS,
+        required=_TOP_LEVEL_KEYS - {"operation"},
+        label="state",
+        errors=errors,
+    )
     if doc.get("schema") != SCHEMA_VERSION:
         errors.append(f"schema must be {SCHEMA_VERSION!r}")
     for key in ("seq", "routeSeq"):
@@ -86,6 +124,13 @@ def validate_state(doc: Any) -> list[str]:
         if not isinstance(operation, dict):
             errors.append("operation must be null or an object")
         else:
+            _check_keys(
+                operation,
+                allowed=_OPERATION_KEYS,
+                required={"id", "phase", "requestedModelId", "startedAt"},
+                label="operation",
+                errors=errors,
+            )
             if not isinstance(operation.get("id"), str) or not operation.get("id"):
                 errors.append("operation.id must be a non-empty string")
             if operation.get("phase") not in _OPERATION_PHASES:
@@ -94,20 +139,48 @@ def validate_state(doc: Any) -> list[str]:
                 errors.append("operation.requestedModelId must be a string")
             if not isinstance(operation.get("startedAt"), str):
                 errors.append("operation.startedAt must be a string")
+            if operation.get("error") is not None and not isinstance(
+                operation.get("error"), str
+            ):
+                errors.append("operation.error must be a string or null")
 
     desired = doc.get("desired")
     if desired is not None:
-        if not isinstance(desired, dict) or not isinstance(desired.get("catalogId"), str) \
-                or not desired.get("catalogId"):
+        if not isinstance(desired, dict):
             errors.append("desired must be null or {catalogId: non-empty string}")
+        else:
+            _check_keys(
+                desired,
+                allowed={"catalogId"},
+                required={"catalogId"},
+                label="desired",
+                errors=errors,
+            )
+            if (
+                not isinstance(desired.get("catalogId"), str)
+                or not desired.get("catalogId")
+            ):
+                errors.append("desired.catalogId must be a non-empty string")
 
     active = doc.get("active")
     if active is not None:
         if not isinstance(active, dict):
             errors.append("active must be null or an object")
         else:
-            if not isinstance(active.get("routeSeq"), int) or isinstance(active.get("routeSeq"), bool):
-                errors.append("active.routeSeq must be an integer")
+            _check_keys(
+                active,
+                allowed=_ACTIVE_KEYS,
+                required=_ACTIVE_KEYS - {"reconstructed"},
+                label="active",
+                errors=errors,
+            )
+            active_route_seq = active.get("routeSeq")
+            if (
+                not isinstance(active_route_seq, int)
+                or isinstance(active_route_seq, bool)
+                or active_route_seq < 0
+            ):
+                errors.append("active.routeSeq must be a non-negative integer")
             for key in ("catalogId", "runtimeModelId", "publicModel"):
                 if not isinstance(active.get(key), str) or not active.get(key):
                     errors.append(f"active.{key} must be a non-empty string")
@@ -115,9 +188,19 @@ def validate_state(doc: Any) -> list[str]:
             if not isinstance(backend, dict):
                 errors.append("active.backend must be an object")
             else:
+                _check_keys(
+                    backend,
+                    allowed=_BACKEND_KEYS,
+                    required={"kind", "endpointId"},
+                    label="active.backend",
+                    errors=errors,
+                )
                 if backend.get("kind") not in _BACKEND_KINDS:
                     errors.append("active.backend.kind is not a known backend kind")
-                if not isinstance(backend.get("endpointId"), str) or not backend.get("endpointId"):
+                if (
+                    not isinstance(backend.get("endpointId"), str)
+                    or not backend.get("endpointId")
+                ):
                     errors.append("active.backend.endpointId must be a non-empty string")
                 native_route = backend.get("nativeRoute")
                 if native_route is not None and not isinstance(native_route, str):
@@ -129,15 +212,38 @@ def validate_state(doc: Any) -> list[str]:
             if not isinstance(capabilities, dict):
                 errors.append("active.capabilities must be an object")
             else:
+                _check_keys(
+                    capabilities,
+                    allowed=_CAPABILITY_KEYS,
+                    required=_CAPABILITY_KEYS,
+                    label="active.capabilities",
+                    errors=errors,
+                )
                 for key in ("chat", "tools", "vision", "agentViable"):
                     if not isinstance(capabilities.get(key), bool):
                         errors.append(f"active.capabilities.{key} must be a boolean")
             verified_at = active.get("verifiedAt")
             if verified_at is not None and not isinstance(verified_at, str):
                 errors.append("active.verifiedAt must be a string or null")
+            if "reconstructed" in active and not isinstance(active.get("reconstructed"), bool):
+                errors.append("active.reconstructed must be a boolean")
             proof = active.get("proof")
-            if not isinstance(proof, dict) or not isinstance(proof.get("completion"), bool):
+            if not isinstance(proof, dict):
                 errors.append("active.proof must be {identity, completion: bool}")
+            else:
+                _check_keys(
+                    proof,
+                    allowed=_PROOF_KEYS,
+                    required=_PROOF_KEYS,
+                    label="active.proof",
+                    errors=errors,
+                )
+                if proof.get("identity") is not None and not isinstance(
+                    proof.get("identity"), str
+                ):
+                    errors.append("active.proof.identity must be a string or null")
+                if not isinstance(proof.get("completion"), bool):
+                    errors.append("active.proof.completion must be a boolean")
 
     history = doc.get("history")
     if not isinstance(history, list):
@@ -149,15 +255,45 @@ def validate_state(doc: Any) -> list[str]:
             if not isinstance(entry, dict):
                 errors.append(f"history[{index}] must be an object")
                 continue
-            if not isinstance(entry.get("routeSeq"), int) or isinstance(entry.get("routeSeq"), bool):
-                errors.append(f"history[{index}].routeSeq must be an integer")
+            _check_keys(
+                entry,
+                allowed=None,
+                required=_HISTORY_KEYS,
+                label=f"history[{index}]",
+                errors=errors,
+            )
+            history_route_seq = entry.get("routeSeq")
+            if (
+                not isinstance(history_route_seq, int)
+                or isinstance(history_route_seq, bool)
+                or history_route_seq < 0
+            ):
+                errors.append(f"history[{index}].routeSeq must be a non-negative integer")
             for key in ("catalogId", "runtimeModelId"):
                 if not isinstance(entry.get(key), str):
                     errors.append(f"history[{index}].{key} must be a string")
+            if entry.get("verifiedAt") is not None and not isinstance(
+                entry.get("verifiedAt"), str
+            ):
+                errors.append(f"history[{index}].verifiedAt must be a string or null")
 
     availability = doc.get("availability")
-    if not isinstance(availability, dict) or availability.get("mode") not in _AVAILABILITY_MODES:
+    if not isinstance(availability, dict):
         errors.append("availability.mode must be serve_active or queue")
+    else:
+        _check_keys(
+            availability,
+            allowed=_AVAILABILITY_KEYS,
+            required=_AVAILABILITY_KEYS,
+            label="availability",
+            errors=errors,
+        )
+        if availability.get("mode") not in _AVAILABILITY_MODES:
+            errors.append("availability.mode must be serve_active or queue")
+        if availability.get("queueDeadline") is not None and not isinstance(
+            availability.get("queueDeadline"), str
+        ):
+            errors.append("availability.queueDeadline must be a string or null")
 
     return errors
 
@@ -298,7 +434,16 @@ def record_verified_route(
         doc["seq"] = int(doc["seq"]) + 1
         if route_changed:
             doc["routeSeq"] = int(doc["routeSeq"]) + 1
-            if isinstance(previous, dict):
+            previous_proof = previous.get("proof") if isinstance(previous, dict) else None
+            previous_is_verified = bool(
+                isinstance(previous, dict)
+                and isinstance(previous_proof, dict)
+                and previous_proof.get("completion") is True
+                and isinstance(previous.get("verifiedAt"), str)
+                and previous.get("verifiedAt")
+                and previous.get("reconstructed") is not True
+            )
+            if previous_is_verified:
                 history_entry = {
                     "routeSeq": previous.get("routeSeq", 0),
                     "catalogId": previous.get("catalogId", ""),
@@ -345,6 +490,9 @@ def migrate_env_identity(env: dict[str, str]) -> dict[str, Any] | None:
     ``extra.``-prefixed Lemonade IDs, and native model names. Returns ``None``
     when the environment carries no local model identity (e.g. cloud-only).
     """
+    if str(env.get("ODS_MODE") or "").strip().casefold() == "cloud":
+        return None
+
     gguf = str(env.get("GGUF_FILE") or "").strip()
     lemonade = str(env.get("LEMONADE_MODEL") or "").strip()
     llm_model = str(env.get("LLM_MODEL") or "").strip()

--- a/ods/extensions/services/dashboard-api/requirements.txt
+++ b/ods/extensions/services/dashboard-api/requirements.txt
@@ -6,5 +6,6 @@ httpx>=0.27.0,<0.29.0
 pydantic>=2.5.0,<3.0.0
 python-multipart>=0.0.9,<1.0.0
 PyYAML>=6.0,<7.0.0
+jsonschema>=4.21.0,<5.0.0
 # QR code generation for magic-link invites (Pillow optional, but improves output)
 qrcode[pil]>=7.4.0,<9.0.0

--- a/ods/extensions/services/dashboard-api/routers/model_state.py
+++ b/ods/extensions/services/dashboard-api/routers/model_state.py
@@ -10,12 +10,15 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
 from fastapi import APIRouter, Depends
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import SchemaError
 
-from config import INSTALL_DIR
+from config import DATA_DIR, INSTALL_DIR
 from security import verify_api_key
 
 logger = logging.getLogger(__name__)
@@ -26,7 +29,51 @@ _STATE_SCHEMA = "ods.model-state.v1"
 
 
 def _state_path() -> Path:
-    return Path(INSTALL_DIR) / "data" / "model-state.json"
+    data_dir = os.environ.get("ODS_DATA_DIR") or DATA_DIR
+    return Path(data_dir) / "model-state.json"
+
+
+def _schema_path() -> Path:
+    override = os.environ.get("ODS_MODEL_STATE_SCHEMA_PATH")
+    if override:
+        return Path(override)
+    return Path(INSTALL_DIR) / "config" / "model-state.schema.v1.json"
+
+
+def _invalid_response(errors: list[str], *, exists: bool = True) -> dict[str, Any]:
+    return {
+        "exists": exists,
+        "valid": False,
+        "errors": errors,
+        "schema": _STATE_SCHEMA,
+        "seq": None,
+        "routeSeq": None,
+        "operation": None,
+        "desired": None,
+        "active": None,
+        "history": [],
+        "historyCount": 0,
+        "availability": None,
+        "capabilityImpact": {"agentViable": None},
+    }
+
+
+def _validate_document(doc: Any) -> list[str]:
+    try:
+        schema = json.loads(_schema_path().read_text(encoding="utf-8"))
+        Draft202012Validator.check_schema(schema)
+        validator = Draft202012Validator(schema)
+    except (OSError, ValueError, SchemaError) as exc:
+        return [f"state schema unavailable or invalid: {exc}"]
+
+    errors = []
+    def sort_key(item):
+        return tuple(str(part) for part in item.absolute_path)
+
+    for error in sorted(validator.iter_errors(doc), key=sort_key):
+        location = ".".join(str(part) for part in error.absolute_path) or "state"
+        errors.append(f"{location}: {error.message}")
+    return errors
 
 
 def _summarize(doc: dict[str, Any]) -> dict[str, Any]:
@@ -61,33 +108,16 @@ async def get_model_state(api_key: str = Depends(verify_api_key)):
     try:
         raw = path.read_text(encoding="utf-8")
     except FileNotFoundError:
-        return {
-            "exists": False,
-            "valid": False,
-            "errors": [],
-            "schema": _STATE_SCHEMA,
-            "seq": None,
-            "routeSeq": None,
-            "operation": None,
-            "desired": None,
-            "active": None,
-            "history": [],
-            "historyCount": 0,
-            "availability": None,
-            "capabilityImpact": {"agentViable": None},
-        }
+        return _invalid_response([], exists=False)
     except OSError as exc:
         logger.warning("model-state read failed: %s", exc)
-        return {"exists": True, "valid": False, "errors": [f"read failed: {exc}"]}
+        return _invalid_response([f"read failed: {exc}"])
 
     try:
         doc = json.loads(raw)
     except ValueError as exc:
-        return {"exists": True, "valid": False, "errors": [f"not valid JSON: {exc}"]}
-    if not isinstance(doc, dict) or doc.get("schema") != _STATE_SCHEMA:
-        return {
-            "exists": True,
-            "valid": False,
-            "errors": [f"unsupported or missing schema (expected {_STATE_SCHEMA})"],
-        }
+        return _invalid_response([f"not valid JSON: {exc}"])
+    errors = _validate_document(doc)
+    if errors:
+        return _invalid_response(errors)
     return _summarize(doc)

--- a/ods/extensions/services/dashboard-api/tests/test_model_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_state.py
@@ -132,6 +132,12 @@ class TestStateModule:
         doc = _record(tmp_path / "s.json")
         doc["active"]["backend"]["kind"] = "banana"
         assert any("backend.kind" in e for e in sb.validate_state(doc))
+        doc = _record(tmp_path / "extra.json")
+        doc["unexpected"] = True
+        assert any("unexpected keys" in e for e in sb.validate_state(doc))
+        doc = _record(tmp_path / "negative.json")
+        doc["active"]["routeSeq"] = -1
+        assert any("active.routeSeq" in e for e in sb.validate_state(doc))
 
     @pytest.mark.parametrize(
         "env,expected",
@@ -152,7 +158,13 @@ class TestStateModule:
             assert got[key] == value
 
     def test_migrate_cloud_only_yields_none(self):
-        assert sb.migrate_env_identity({"ODS_MODE": "cloud"}) is None
+        env = {
+            "ODS_MODE": "cloud",
+            "LLM_MODEL": "anthropic/claude-sonnet-4-5-20250514",
+            "GGUF_FILE": "",
+            "MAX_CONTEXT": "200000",
+        }
+        assert sb.migrate_env_identity(env) is None
 
     def test_initialize_if_missing_reconstructs_once(self, tmp_path):
         path = tmp_path / "model-state.json"
@@ -168,16 +180,52 @@ class TestStateModule:
 
     def test_initialize_cloud_only_writes_nothing(self, tmp_path):
         path = tmp_path / "model-state.json"
-        assert sb.initialize_if_missing(path, {"ODS_MODE": "cloud"}) is None
+        env = {
+            "ODS_MODE": "cloud",
+            "LLM_MODEL": "anthropic/claude-sonnet-4-5-20250514",
+            "MAX_CONTEXT": "200000",
+        }
+        assert sb.initialize_if_missing(path, env) is None
         assert not path.exists()
+
+    def test_reconstructed_route_never_enters_verified_history(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        reconstructed = sb.initialize_if_missing(
+            path,
+            {
+                "ODS_MODE": "local",
+                "LLM_MODEL": "stale-model",
+                "GGUF_FILE": "Stale.gguf",
+                "MAX_CONTEXT": "65536",
+            },
+        )
+        assert reconstructed["active"]["proof"]["completion"] is False
+
+        verified = _record(
+            path,
+            model="current-model",
+            runtime="Current.gguf",
+            context=65536,
+        )
+        assert verified["active"]["proof"]["completion"] is True
+        assert verified["history"] == []
 
 
 class TestModelStateEndpoint:
     def _point_at(self, monkeypatch, tmp_path):
+        data_dir = tmp_path / "mounted-data"
+        data_dir.mkdir(parents=True, exist_ok=True)
+        monkeypatch.setenv("ODS_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("ODS_MODEL_STATE_SCHEMA_PATH", str(_SCHEMA_PATH))
+        return data_dir / "model-state.json"
+
+    def test_state_path_uses_data_mount_environment(self, monkeypatch, tmp_path):
         from routers import model_state as ms
-        monkeypatch.setattr(ms, "INSTALL_DIR", str(tmp_path))
-        (tmp_path / "data").mkdir(parents=True, exist_ok=True)
-        return tmp_path / "data" / "model-state.json"
+
+        data_dir = tmp_path / "compose-data-mount"
+        monkeypatch.setenv("ODS_DATA_DIR", str(data_dir))
+        monkeypatch.setattr(ms, "INSTALL_DIR", str(tmp_path / "ods"))
+        assert ms._state_path() == data_dir / "model-state.json"
 
     def test_missing_state(self, test_client, monkeypatch, tmp_path):
         self._point_at(monkeypatch, tmp_path)
@@ -207,6 +255,22 @@ class TestModelStateEndpoint:
         assert resp.status_code == 200
         body = resp.json()
         assert body["exists"] is True and body["valid"] is False and body["errors"]
+
+    def test_schema_invalid_state_is_diagnostic(self, test_client, monkeypatch, tmp_path):
+        path = self._point_at(monkeypatch, tmp_path)
+        doc = _record(path)
+        doc["active"]["routeSeq"] = -1
+        doc["unexpected"] = "must be rejected"
+        path.write_text(json.dumps(doc), encoding="utf-8")
+
+        resp = test_client.get("/api/models/state", headers=test_client.auth_headers)
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["exists"] is True
+        assert body["valid"] is False
+        assert body["active"] is None
+        assert any("routeSeq" in error for error in body["errors"])
+        assert any("unexpected" in error for error in body["errors"])
 
     def test_requires_auth(self, test_client, monkeypatch, tmp_path):
         self._point_at(monkeypatch, tmp_path)


### PR DESCRIPTION
## Summary
- read model state from the production data mount instead of an install-root-relative path
- validate the dashboard response against the published v1 JSON schema and fail closed
- prevent cloud-only configuration and unverified reconstructed routes from becoming trusted local history
- tighten the host-side validator to match the published schema

## Why
This corrects foundation blockers found while supervising the Model Switchboard rollout. PR #1902 remains blocked until this lands and is rebased.

## Verification
- python -m pytest ods/extensions/services/dashboard-api/tests/test_model_state.py -q (23 passed)
- python -m ruff check ods/bin/model_switchboard/state.py ods/extensions/services/dashboard-api/routers/model_state.py ods/extensions/services/dashboard-api/tests/test_model_state.py

## Fleet evidence
Not yet applicable: this is a state/API correctness fix and the router remains observe-only. Affected-host validation is still required before the integration branch advances beyond observe mode.