### PR TITLE
fix(models): require runtime-carried activation proof

### DIFF
--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -18,6 +18,7 @@ suite.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
 
 
@@ -25,6 +26,10 @@ def result(ok: bool, detail: str = "", **extras: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"ok": bool(ok), "detail": str(detail)}
     payload.update(extras)
     return payload
+
+
+def _utcnow_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class RuntimeAdapter(Protocol):
@@ -40,6 +45,18 @@ class RuntimeAdapter(Protocol):
 
     def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
         """Prove a real completion. Extras: ``identity`` when reported."""
+
+    def publish_native_alias(self, env: dict[str, str]) -> dict[str, Any]:
+        """Publish a runtime-native alias when the backend supports one."""
+
+    def unload(self, env: dict[str, str]) -> dict[str, Any]:
+        """Unload the staged or previous runtime model."""
+
+    def delete(self, env: dict[str, str]) -> dict[str, Any]:
+        """Delete a non-active model artifact through the runtime."""
+
+    def rollback(self, env: dict[str, str]) -> dict[str, Any]:
+        """Restore the adapter's previously captured runtime state."""
 
 
 class ContainerLlamaAdapter:
@@ -57,29 +74,55 @@ class ContainerLlamaAdapter:
         self,
         *,
         restart: Callable[[dict[str, str]], None],
-        wait_ready: Callable[..., bool],
+        wait_ready: Callable[..., bool | str],
         expected_gguf: str,
         context_length: int,
         lemonade_model_id: str = "",
+        capabilities: dict[str, bool] | None = None,
+        unload: Callable[[dict[str, str]], None] | None = None,
+        delete: Callable[[dict[str, str]], None] | None = None,
+        rollback: Callable[[dict[str, str]], None] | None = None,
     ) -> None:
         self._restart = restart
         self._wait_ready = wait_ready
         self._expected_gguf = expected_gguf
         self._context_length = int(context_length)
         self._lemonade_model_id = lemonade_model_id
+        supplied_capabilities = capabilities or {}
+        self._capabilities = {
+            "chat": bool(supplied_capabilities.get("chat", True)),
+            "tools": bool(supplied_capabilities.get("tools", False)),
+            "vision": bool(supplied_capabilities.get("vision", False)),
+            "agentViable": bool(supplied_capabilities.get("agentViable", False)),
+        }
+        self._unload = unload
+        self._delete = delete
+        self._rollback = rollback
+        self._verified_identity = ""
+        self._verified_at = ""
+
+    def _verification_result(self, detail: str) -> dict[str, Any]:
+        return result(
+            True,
+            detail,
+            identity=self._verified_identity,
+            contextLength=self._context_length,
+            capabilities=dict(self._capabilities),
+            verifiedAt=self._verified_at,
+        )
 
     def stage(self, env: dict[str, str]) -> dict[str, Any]:
         try:
             self._restart(env)
         except Exception as exc:  # expected runtime failures become results
-            return result(False, f"container restart failed: {exc}")
+            return result(False, str(exc))
         return result(True, "compose restart issued")
 
     def verify_identity(self, env: dict[str, str]) -> dict[str, Any]:
         # Readiness in the container path proves identity and serving state
         # in one bounded wait, mirroring the pre-adapter inline behavior.
         try:
-            healthy = self._wait_ready(
+            runtime_identity = self._wait_ready(
                 env,
                 self._expected_gguf,
                 self._context_length,
@@ -87,15 +130,46 @@ class ContainerLlamaAdapter:
             )
         except Exception as exc:
             return result(False, f"readiness wait failed: {exc}")
-        if not healthy:
+        if not isinstance(runtime_identity, str) or not runtime_identity.strip():
             return result(False, "runtime did not report the staged model")
-        return result(True, "runtime reports staged model", identity=self._expected_gguf)
+        self._verified_identity = runtime_identity.strip()
+        self._verified_at = _utcnow_iso()
+        return self._verification_result(
+            "runtime reports staged model and completed proof request"
+        )
 
     def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
-        # _wait_for_model_readiness already requires a meaningful completion
-        # before returning True; a separate probe here would double-generate.
-        return result(True, "completion proven during readiness wait",
-                      identity=self._expected_gguf)
+        # _wait_for_model_readiness returns an identity only after a meaningful
+        # completion reports the same concrete model. Do not echo configuration.
+        if not self._verified_identity:
+            return result(False, "completion proof has no runtime identity")
+        return self._verification_result("completion proven during readiness wait")
+
+    def publish_native_alias(self, env: dict[str, str]) -> dict[str, Any]:
+        return result(True, "native alias not required for llama.cpp")
+
+    @staticmethod
+    def _optional_operation(
+        operation: str,
+        callback: Callable[[dict[str, str]], None] | None,
+        env: dict[str, str],
+    ) -> dict[str, Any]:
+        if callback is None:
+            return result(False, f"{operation} is not configured")
+        try:
+            callback(env)
+        except Exception as exc:
+            return result(False, str(exc))
+        return result(True, f"{operation} completed")
+
+    def unload(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._optional_operation("unload", self._unload, env)
+
+    def delete(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._optional_operation("delete", self._delete, env)
+
+    def rollback(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._optional_operation("rollback", self._rollback, env)
 
 
 class NativeLlamaAdapter(ContainerLlamaAdapter):
@@ -191,3 +265,15 @@ class FakeAdapter:
 
     def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
         return self._next("verify_completion")
+
+    def publish_native_alias(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("publish_native_alias")
+
+    def unload(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("unload")
+
+    def delete(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("delete")
+
+    def rollback(self, env: dict[str, str]) -> dict[str, Any]:
+        return self._next("rollback")

--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -18,7 +18,6 @@ suite.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Callable, Protocol
 
 
@@ -26,10 +25,6 @@ def result(ok: bool, detail: str = "", **extras: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"ok": bool(ok), "detail": str(detail)}
     payload.update(extras)
     return payload
-
-
-def _utcnow_iso() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 class RuntimeAdapter(Protocol):
@@ -59,6 +54,18 @@ class RuntimeAdapter(Protocol):
         """Restore the adapter's previously captured runtime state."""
 
 
+class ReadinessProbe(Protocol):
+    """Return runtime-carried identity, context, and proof time."""
+
+    def __call__(
+        self,
+        env: dict[str, str],
+        gguf_file: str,
+        context_length: int,
+        lemonade_model_id: str = "",
+    ) -> dict[str, Any]: ...
+
+
 class ContainerLlamaAdapter:
     """Compose-managed llama.cpp runtime (Linux/NVIDIA container path).
 
@@ -74,7 +81,7 @@ class ContainerLlamaAdapter:
         self,
         *,
         restart: Callable[[dict[str, str]], None],
-        wait_ready: Callable[..., bool | str],
+        wait_ready: ReadinessProbe,
         expected_gguf: str,
         context_length: int,
         lemonade_model_id: str = "",
@@ -99,6 +106,7 @@ class ContainerLlamaAdapter:
         self._delete = delete
         self._rollback = rollback
         self._verified_identity = ""
+        self._verified_context = 0
         self._verified_at = ""
 
     def _verification_result(self, detail: str) -> dict[str, Any]:
@@ -106,7 +114,7 @@ class ContainerLlamaAdapter:
             True,
             detail,
             identity=self._verified_identity,
-            contextLength=self._context_length,
+            contextLength=self._verified_context,
             capabilities=dict(self._capabilities),
             verifiedAt=self._verified_at,
         )
@@ -122,7 +130,7 @@ class ContainerLlamaAdapter:
         # Readiness in the container path proves identity and serving state
         # in one bounded wait, mirroring the pre-adapter inline behavior.
         try:
-            runtime_identity = self._wait_ready(
+            runtime_proof = self._wait_ready(
                 env,
                 self._expected_gguf,
                 self._context_length,
@@ -130,10 +138,24 @@ class ContainerLlamaAdapter:
             )
         except Exception as exc:
             return result(False, f"readiness wait failed: {exc}")
+        if not isinstance(runtime_proof, dict):
+            return result(False, "runtime did not return a proof record")
+        runtime_identity = runtime_proof.get("identity")
+        runtime_context = runtime_proof.get("contextLength")
+        verified_at = runtime_proof.get("verifiedAt")
         if not isinstance(runtime_identity, str) or not runtime_identity.strip():
             return result(False, "runtime did not report the staged model")
+        if (
+            not isinstance(runtime_context, int)
+            or isinstance(runtime_context, bool)
+            or runtime_context <= 0
+        ):
+            return result(False, "runtime did not report a valid context length")
+        if not isinstance(verified_at, str) or not verified_at.strip():
+            return result(False, "runtime proof has no timestamp")
         self._verified_identity = runtime_identity.strip()
-        self._verified_at = _utcnow_iso()
+        self._verified_context = runtime_context
+        self._verified_at = verified_at.strip()
         return self._verification_result(
             "runtime reports staged model and completed proof request"
         )

--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -107,6 +107,7 @@ class ContainerLlamaAdapter:
         self._rollback = rollback
         self._verified_identity = ""
         self._verified_context = 0
+        self._context_verified = False
         self._verified_at = ""
 
     def _verification_result(self, detail: str) -> dict[str, Any]:
@@ -115,6 +116,7 @@ class ContainerLlamaAdapter:
             detail,
             identity=self._verified_identity,
             contextLength=self._verified_context,
+            contextVerified=self._context_verified,
             capabilities=dict(self._capabilities),
             verifiedAt=self._verified_at,
         )
@@ -142,6 +144,7 @@ class ContainerLlamaAdapter:
             return result(False, "runtime did not return a proof record")
         runtime_identity = runtime_proof.get("identity")
         runtime_context = runtime_proof.get("contextLength")
+        context_verified = runtime_proof.get("contextVerified")
         verified_at = runtime_proof.get("verifiedAt")
         if not isinstance(runtime_identity, str) or not runtime_identity.strip():
             return result(False, "runtime did not report the staged model")
@@ -151,10 +154,13 @@ class ContainerLlamaAdapter:
             or runtime_context <= 0
         ):
             return result(False, "runtime did not report a valid context length")
+        if not isinstance(context_verified, bool):
+            return result(False, "runtime proof has no context-verification status")
         if not isinstance(verified_at, str) or not verified_at.strip():
             return result(False, "runtime proof has no timestamp")
         self._verified_identity = runtime_identity.strip()
         self._verified_context = runtime_context
+        self._context_verified = context_verified
         self._verified_at = verified_at.strip()
         return self._verification_result(
             "runtime reports staged model and completed proof request"
@@ -245,6 +251,7 @@ class LemonadeAdapter:
         self._rollback = rollback
         self._verified_identity = ""
         self._verified_context = 0
+        self._context_verified = False
         self._verified_at = ""
 
     def _verification_result(self, detail: str) -> dict[str, Any]:
@@ -253,6 +260,7 @@ class LemonadeAdapter:
             detail,
             identity=self._verified_identity,
             contextLength=self._verified_context,
+            contextVerified=self._context_verified,
             capabilities=dict(self._capabilities),
             verifiedAt=self._verified_at,
         )
@@ -278,6 +286,7 @@ class LemonadeAdapter:
             return result(False, "lemonade runtime did not return a proof record")
         runtime_identity = runtime_proof.get("identity")
         runtime_context = runtime_proof.get("contextLength")
+        context_verified = runtime_proof.get("contextVerified")
         verified_at = runtime_proof.get("verifiedAt")
         if not isinstance(runtime_identity, str) or not runtime_identity.strip():
             return result(False, "lemonade runtime did not report the staged model")
@@ -287,10 +296,15 @@ class LemonadeAdapter:
             or runtime_context <= 0
         ):
             return result(False, "lemonade runtime did not report a valid context length")
+        if not isinstance(context_verified, bool):
+            return result(
+                False, "lemonade runtime proof has no context-verification status"
+            )
         if not isinstance(verified_at, str) or not verified_at.strip():
             return result(False, "lemonade runtime proof has no timestamp")
         self._verified_identity = runtime_identity.strip()
         self._verified_context = runtime_context
+        self._context_verified = context_verified
         self._verified_at = verified_at.strip()
         return self._verification_result("lemonade runtime reports staged model")
 

--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -220,15 +220,42 @@ class LemonadeAdapter:
     def __init__(
         self,
         *,
-        wait_ready: Callable[..., bool],
+        wait_ready: ReadinessProbe,
         expected_gguf: str,
         context_length: int,
         lemonade_model_id: str,
+        capabilities: dict[str, bool] | None = None,
+        unload: Callable[[dict[str, str]], None] | None = None,
+        delete: Callable[[dict[str, str]], None] | None = None,
+        rollback: Callable[[dict[str, str]], None] | None = None,
     ) -> None:
         self._wait_ready = wait_ready
         self._expected_gguf = expected_gguf
         self._context_length = int(context_length)
         self._lemonade_model_id = lemonade_model_id
+        supplied_capabilities = capabilities or {}
+        self._capabilities = {
+            "chat": bool(supplied_capabilities.get("chat", True)),
+            "tools": bool(supplied_capabilities.get("tools", False)),
+            "vision": bool(supplied_capabilities.get("vision", False)),
+            "agentViable": bool(supplied_capabilities.get("agentViable", False)),
+        }
+        self._unload = unload
+        self._delete = delete
+        self._rollback = rollback
+        self._verified_identity = ""
+        self._verified_context = 0
+        self._verified_at = ""
+
+    def _verification_result(self, detail: str) -> dict[str, Any]:
+        return result(
+            True,
+            detail,
+            identity=self._verified_identity,
+            contextLength=self._verified_context,
+            capabilities=dict(self._capabilities),
+            verifiedAt=self._verified_at,
+        )
 
     def stage(self, env: dict[str, str]) -> dict[str, Any]:
         # Restart + model-ID resolution already completed inline before the
@@ -239,7 +266,7 @@ class LemonadeAdapter:
 
     def verify_identity(self, env: dict[str, str]) -> dict[str, Any]:
         try:
-            healthy = self._wait_ready(
+            runtime_proof = self._wait_ready(
                 env,
                 self._expected_gguf,
                 self._context_length,
@@ -247,14 +274,46 @@ class LemonadeAdapter:
             )
         except Exception as exc:
             return result(False, f"lemonade readiness wait failed: {exc}")
-        if not healthy:
+        if not isinstance(runtime_proof, dict):
+            return result(False, "lemonade runtime did not return a proof record")
+        runtime_identity = runtime_proof.get("identity")
+        runtime_context = runtime_proof.get("contextLength")
+        verified_at = runtime_proof.get("verifiedAt")
+        if not isinstance(runtime_identity, str) or not runtime_identity.strip():
             return result(False, "lemonade runtime did not report the staged model")
-        return result(True, "lemonade runtime reports staged model",
-                      identity=self._lemonade_model_id)
+        if (
+            not isinstance(runtime_context, int)
+            or isinstance(runtime_context, bool)
+            or runtime_context <= 0
+        ):
+            return result(False, "lemonade runtime did not report a valid context length")
+        if not isinstance(verified_at, str) or not verified_at.strip():
+            return result(False, "lemonade runtime proof has no timestamp")
+        self._verified_identity = runtime_identity.strip()
+        self._verified_context = runtime_context
+        self._verified_at = verified_at.strip()
+        return self._verification_result("lemonade runtime reports staged model")
 
     def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
-        return result(True, "completion proven during lemonade readiness wait",
-                      identity=self._lemonade_model_id)
+        if not self._verified_identity:
+            return result(False, "completion proof has no runtime identity")
+        return self._verification_result(
+            "completion proven during lemonade readiness wait"
+        )
+
+    def publish_native_alias(self, env: dict[str, str]) -> dict[str, Any]:
+        return result(True, "native Lemonade alias is deferred to the route adapter")
+
+    def unload(self, env: dict[str, str]) -> dict[str, Any]:
+        return ContainerLlamaAdapter._optional_operation("unload", self._unload, env)
+
+    def delete(self, env: dict[str, str]) -> dict[str, Any]:
+        return ContainerLlamaAdapter._optional_operation("delete", self._delete, env)
+
+    def rollback(self, env: dict[str, str]) -> dict[str, Any]:
+        return ContainerLlamaAdapter._optional_operation(
+            "rollback", self._rollback, env
+        )
 
 
 class FakeAdapter:

--- a/ods/bin/model_switchboard/reconciler.py
+++ b/ods/bin/model_switchboard/reconciler.py
@@ -18,6 +18,29 @@ from typing import Any
 from .adapters import RuntimeAdapter, result
 
 PHASES = ("stage", "verify_identity", "verify_completion")
+_CAPABILITY_KEYS = {"chat", "tools", "vision", "agentViable"}
+
+
+def _verification_error(outcome: dict[str, Any]) -> str:
+    identity = outcome.get("identity")
+    if not isinstance(identity, str) or not identity.strip():
+        return "verification returned no concrete identity"
+    context_length = outcome.get("contextLength")
+    if (
+        not isinstance(context_length, int)
+        or isinstance(context_length, bool)
+        or context_length < 0
+    ):
+        return "verification returned no valid context length"
+    capabilities = outcome.get("capabilities")
+    if not isinstance(capabilities, dict) or set(capabilities) != _CAPABILITY_KEYS:
+        return "verification returned no complete capability record"
+    if any(not isinstance(capabilities[key], bool) for key in _CAPABILITY_KEYS):
+        return "verification returned invalid capability values"
+    verified_at = outcome.get("verifiedAt")
+    if not isinstance(verified_at, str) or not verified_at.strip():
+        return "verification returned no proof timestamp"
+    return ""
 
 
 def run_runtime_activation(
@@ -26,12 +49,16 @@ def run_runtime_activation(
 ) -> dict[str, Any]:
     """Drive the runtime phases; first failure wins.
 
-    Returns ``{"ok": bool, "phase": str, "detail": str, "identity": str|None}``.
-    ``phase`` is the last phase attempted. Health-style success without an
-    identity cannot satisfy verification: a verify_identity result that omits
-    ``identity`` is treated as a failed boundary even when ``ok`` is true.
+    Successful runs carry the runtime identity, context length, capabilities,
+    and proof timestamp. ``phase`` is the last phase attempted. Health-style
+    success without the complete proof contract cannot satisfy verification.
     """
-    identity: str | None = None
+    proof: dict[str, Any] = {
+        "identity": None,
+        "contextLength": None,
+        "capabilities": None,
+        "verifiedAt": None,
+    }
     for phase in PHASES:
         try:
             outcome = getattr(adapter, phase)(env)
@@ -40,33 +67,51 @@ def run_runtime_activation(
                 "ok": False,
                 "phase": phase,
                 "detail": f"adapter raised: {exc}",
-                "identity": identity,
+                **proof,
             }
         if not isinstance(outcome, dict) or "ok" not in outcome:
             return {
                 "ok": False,
                 "phase": phase,
                 "detail": "adapter returned a non-contract result",
-                "identity": identity,
+                **proof,
             }
-        if phase == "verify_identity" and outcome.get("ok") and not outcome.get("identity"):
-            return {
-                "ok": False,
-                "phase": phase,
-                "detail": "identity verification returned no concrete identity",
-                "identity": identity,
+        if phase.startswith("verify_") and outcome.get("ok"):
+            contract_error = _verification_error(outcome)
+            if contract_error:
+                return {
+                    "ok": False,
+                    "phase": phase,
+                    "detail": contract_error,
+                    **proof,
+                }
+            outcome_identity = str(outcome["identity"]).strip()
+            if phase == "verify_completion" and proof["identity"] != outcome_identity:
+                return {
+                    "ok": False,
+                    "phase": phase,
+                    "detail": "completion proof identity does not match identity proof",
+                    **proof,
+                }
+            proof = {
+                "identity": outcome_identity,
+                "contextLength": int(outcome["contextLength"]),
+                "capabilities": dict(outcome["capabilities"]),
+                "verifiedAt": str(outcome["verifiedAt"]),
             }
-        if outcome.get("identity"):
-            identity = str(outcome["identity"])
         if not outcome.get("ok"):
             return {
                 "ok": False,
                 "phase": phase,
                 "detail": str(outcome.get("detail") or f"{phase} failed"),
-                "identity": identity,
+                **proof,
             }
-    return {"ok": True, "phase": PHASES[-1], "detail": "runtime activation proven",
-            "identity": identity}
+    return {
+        "ok": True,
+        "phase": PHASES[-1],
+        "detail": "runtime activation proven",
+        **proof,
+    }
 
 
 __all__ = ["PHASES", "run_runtime_activation", "result"]

--- a/ods/bin/model_switchboard/reconciler.py
+++ b/ods/bin/model_switchboard/reconciler.py
@@ -13,6 +13,7 @@ the caller's existing rollback machinery takes over.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 from .adapters import RuntimeAdapter, result
@@ -29,7 +30,7 @@ def _verification_error(outcome: dict[str, Any]) -> str:
     if (
         not isinstance(context_length, int)
         or isinstance(context_length, bool)
-        or context_length < 0
+        or context_length <= 0
     ):
         return "verification returned no valid context length"
     capabilities = outcome.get("capabilities")
@@ -40,6 +41,12 @@ def _verification_error(outcome: dict[str, Any]) -> str:
     verified_at = outcome.get("verifiedAt")
     if not isinstance(verified_at, str) or not verified_at.strip():
         return "verification returned no proof timestamp"
+    try:
+        parsed_time = datetime.fromisoformat(verified_at.replace("Z", "+00:00"))
+    except ValueError:
+        return "verification returned an invalid proof timestamp"
+    if parsed_time.tzinfo is None or parsed_time.utcoffset() != timezone.utc.utcoffset(None):
+        return "verification proof timestamp is not UTC"
     return ""
 
 
@@ -93,12 +100,20 @@ def run_runtime_activation(
                     "detail": "completion proof identity does not match identity proof",
                     **proof,
                 }
-            proof = {
+            outcome_proof = {
                 "identity": outcome_identity,
                 "contextLength": int(outcome["contextLength"]),
                 "capabilities": dict(outcome["capabilities"]),
                 "verifiedAt": str(outcome["verifiedAt"]),
             }
+            if phase == "verify_completion" and outcome_proof != proof:
+                return {
+                    "ok": False,
+                    "phase": phase,
+                    "detail": "completion proof metadata does not match identity proof",
+                    **proof,
+                }
+            proof = outcome_proof
         if not outcome.get("ok"):
             return {
                 "ok": False,

--- a/ods/bin/model_switchboard/reconciler.py
+++ b/ods/bin/model_switchboard/reconciler.py
@@ -33,6 +33,8 @@ def _verification_error(outcome: dict[str, Any]) -> str:
         or context_length <= 0
     ):
         return "verification returned no valid context length"
+    if not isinstance(outcome.get("contextVerified"), bool):
+        return "verification returned no context-verification status"
     capabilities = outcome.get("capabilities")
     if not isinstance(capabilities, dict) or set(capabilities) != _CAPABILITY_KEYS:
         return "verification returned no complete capability record"
@@ -63,6 +65,7 @@ def run_runtime_activation(
     proof: dict[str, Any] = {
         "identity": None,
         "contextLength": None,
+        "contextVerified": None,
         "capabilities": None,
         "verifiedAt": None,
     }
@@ -103,10 +106,16 @@ def run_runtime_activation(
             outcome_proof = {
                 "identity": outcome_identity,
                 "contextLength": int(outcome["contextLength"]),
+                "contextVerified": bool(outcome["contextVerified"]),
                 "capabilities": dict(outcome["capabilities"]),
                 "verifiedAt": str(outcome["verifiedAt"]),
             }
-            stable_fields = ("identity", "contextLength", "capabilities")
+            stable_fields = (
+                "identity",
+                "contextLength",
+                "contextVerified",
+                "capabilities",
+            )
             if phase == "verify_completion" and any(
                 outcome_proof[field] != proof[field] for field in stable_fields
             ):

--- a/ods/bin/model_switchboard/reconciler.py
+++ b/ods/bin/model_switchboard/reconciler.py
@@ -106,7 +106,10 @@ def run_runtime_activation(
                 "capabilities": dict(outcome["capabilities"]),
                 "verifiedAt": str(outcome["verifiedAt"]),
             }
-            if phase == "verify_completion" and outcome_proof != proof:
+            stable_fields = ("identity", "contextLength", "capabilities")
+            if phase == "verify_completion" and any(
+                outcome_proof[field] != proof[field] for field in stable_fields
+            ):
                 return {
                     "ok": False,
                     "phase": phase,

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5402,6 +5402,13 @@ class AgentHandler(BaseHTTPRequestHandler):
             # llama paths stage+verify through one reconciler sequence. All
             # other strategies keep their inline flow until PR 2B/2C.
             switchboard_adapter = None
+            switchboard_run = None
+            switchboard_capabilities = {
+                "chat": True,
+                "tools": bool(model.get("tools")),
+                "vision": bool(model.get("vision")),
+                "agentViable": int(context_length) >= 65536,
+            }
 
             def _sb_wait_ready(_env, _gguf, _ctx, lemonade_model_id=""):
                 return _wait_for_model_readiness(
@@ -5410,6 +5417,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     gguf_file=_gguf,
                     llm_model_name=llm_model_name,
                     lemonade_model_id=lemonade_model_id,
+                    return_identity=True,
                 )
 
             # Restart llama-server with the new model.
@@ -5441,6 +5449,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                         wait_ready=_sb_wait_ready,
                         expected_gguf=gguf_file,
                         context_length=int(context_length),
+                        capabilities=switchboard_capabilities,
                     )
                 else:
                     _restart_windows_native_llama_server(env_path, env)
@@ -5461,6 +5470,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                         wait_ready=_sb_wait_ready,
                         expected_gguf=gguf_file,
                         context_length=int(context_length),
+                        capabilities=switchboard_capabilities,
                     )
                 else:
                     _restart_macos_native_llama_server(
@@ -5489,6 +5499,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                         wait_ready=_sb_wait_ready,
                         expected_gguf=gguf_file,
                         context_length=int(context_length),
+                        capabilities=switchboard_capabilities,
                     )
                 else:
                     _recreate_llama_server(env, override_image=override_image)
@@ -5500,6 +5511,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                         wait_ready=_sb_wait_ready,
                         expected_gguf=gguf_file,
                         context_length=int(context_length),
+                        capabilities=switchboard_capabilities,
                     )
                 else:
                     _compose_restart_llama_server(env)
@@ -5544,6 +5556,10 @@ class AgentHandler(BaseHTTPRequestHandler):
                         switchboard_run.get("phase"),
                         switchboard_run.get("detail"),
                     )
+                    if switchboard_run.get("phase") == "stage":
+                        raise RuntimeError(
+                            str(switchboard_run.get("detail") or "runtime stage failed")
+                        )
             else:
                 healthy = _wait_for_model_readiness(
                     env,
@@ -5666,12 +5682,24 @@ class AgentHandler(BaseHTTPRequestHandler):
                     # transaction committed. Failures are logged, never fatal,
                     # and never alter activation behavior.
                     try:
+                        verified_runtime_identity = str(
+                            (switchboard_run or {}).get("identity")
+                            or lemonade_model_id
+                            or gguf_file
+                            or llm_model_name
+                        )
+                        verified_context_length = int(
+                            (switchboard_run or {}).get("contextLength")
+                            or context_length
+                        )
+                        verified_capabilities = (
+                            (switchboard_run or {}).get("capabilities")
+                            or switchboard_capabilities
+                        )
                         _switchboard_state.record_verified_route(
                             INSTALL_DIR / "data" / "model-state.json",
                             catalog_id=str(model_id),
-                            runtime_model_id=str(
-                                lemonade_model_id or gguf_file or llm_model_name
-                            ),
+                            runtime_model_id=verified_runtime_identity,
                             backend_kind=(
                                 "lemonade" if lemonade_model_id else "llama-server"
                             ),
@@ -5681,16 +5709,9 @@ class AgentHandler(BaseHTTPRequestHandler):
                                 else "llama-server-default"
                             ),
                             native_route=(lemonade_model_id or None),
-                            context_length=int(context_length),
-                            capabilities={
-                                "chat": True,
-                                "tools": bool(model.get("tools")),
-                                "vision": bool(model.get("vision")),
-                                "agentViable": int(context_length) >= 65536,
-                            },
-                            proof_identity=str(
-                                lemonade_model_id or gguf_file or llm_model_name
-                            ),
+                            context_length=verified_context_length,
+                            capabilities=verified_capabilities,
+                            proof_identity=verified_runtime_identity,
                         )
                     except Exception as exc:
                         logger.warning("switchboard state record failed: %s", exc)
@@ -6065,13 +6086,31 @@ def _check_llama_model_identity(
     llm_model_name: str,
 ) -> bool:
     """Return True only when llama.cpp reports the requested model loaded."""
+    return bool(
+        _llama_loaded_model_identity(
+            body,
+            model_id=model_id,
+            gguf_file=gguf_file,
+            llm_model_name=llm_model_name,
+        )
+    )
+
+
+def _llama_loaded_model_identity(
+    body: str,
+    *,
+    model_id: str,
+    gguf_file: str,
+    llm_model_name: str,
+) -> str:
+    """Return the concrete identity carried by llama.cpp's loaded-model row."""
     try:
         data = json.loads(body)
     except (json.JSONDecodeError, TypeError):
-        return False
+        return ""
     models = data.get("data") if isinstance(data, dict) else None
     if not isinstance(models, list):
-        return False
+        return ""
     for model in models:
         if not isinstance(model, dict):
             continue
@@ -6086,8 +6125,8 @@ def _check_llama_model_identity(
             gguf_file=gguf_file,
             llm_model_name=llm_model_name,
         ):
-            return True
-    return False
+            return str(model["id"]).strip()
+    return ""
 
 
 def _live_runtime_has_model(env: dict, gguf_file: str) -> bool | None:
@@ -6160,27 +6199,46 @@ def _check_lemonade_health(
     requires a non-empty string identity; false and empty values are never
     treated as a loaded model.
     """
+    return bool(
+        _lemonade_loaded_model_identity(
+            body,
+            expected_gguf_file=expected_gguf_file,
+            expected_model_id=expected_model_id,
+            expected_context=expected_context,
+        )
+    )
+
+
+def _lemonade_loaded_model_identity(
+    body: str,
+    expected_gguf_file: str | None = None,
+    expected_model_id: str = "",
+    expected_context: int | None = None,
+) -> str:
+    """Return the concrete identity carried by a valid Lemonade health row."""
     try:
         data = json.loads(body)
         if expected_gguf_file is not None or expected_model_id:
             if not isinstance(data, dict) or str(data.get("status") or "").casefold() != "ok":
-                return False
+                return ""
             if not _runtime_model_identity_matches(
                 data.get("model_loaded"),
                 model_id=expected_model_id,
                 gguf_file=expected_gguf_file or "",
             ):
-                return False
-            return _lemonade_loaded_context_is_sufficient(
+                return ""
+            if not _lemonade_loaded_context_is_sufficient(
                 data,
                 expected_gguf_file=expected_gguf_file or "",
                 expected_model_id=expected_model_id,
                 expected_context=expected_context,
-            )
+            ):
+                return ""
+            return str(data.get("model_loaded") or "").strip()
         loaded = data.get("model_loaded")
-        return isinstance(loaded, str) and bool(loaded.strip())
+        return loaded.strip() if isinstance(loaded, str) else ""
     except (AttributeError, json.JSONDecodeError, TypeError):
-        return False
+        return ""
 
 
 def _positive_int(value: object) -> int | None:
@@ -6308,8 +6366,12 @@ def _chat_completion_ready(
     model_name: str,
     api_prefix: str = "/v1",
     api_key: str = "",
+    *,
+    expected_model_id: str = "",
+    expected_gguf_file: str = "",
+    expected_llm_model_name: str = "",
 ) -> bool:
-    """Require one bounded deterministic, meaningful chat completion."""
+    """Require a meaningful completion and, when requested, its model identity."""
     prefix = "/" + api_prefix.strip("/")
     url = f"http://{host}:{port}{prefix}/chat/completions"
     payload = json.dumps({
@@ -6338,7 +6400,18 @@ def _chat_completion_ready(
         )
         if result.returncode != 0:
             return False
-        return _meaningful_completion(json.loads(result.stdout or "{}"))
+        response = json.loads(result.stdout or "{}")
+        if not _meaningful_completion(response):
+            return False
+        if expected_model_id or expected_gguf_file or expected_llm_model_name:
+            if not isinstance(response, dict) or not _runtime_model_identity_matches(
+                response.get("model"),
+                model_id=expected_model_id,
+                gguf_file=expected_gguf_file,
+                llm_model_name=expected_llm_model_name,
+            ):
+                return False
+        return True
     except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError):
         return False
 
@@ -6525,8 +6598,13 @@ def _wait_for_model_readiness(
     attempts: int = 60,
     initial_delay: float = 5,
     interval: float = 5,
-) -> bool:
-    """Prove exact runtime identity and one meaningful completion."""
+    return_identity: bool = False,
+) -> bool | str:
+    """Prove exact runtime identity and one matching meaningful completion.
+
+    Legacy callers receive a boolean. Runtime adapters request the concrete
+    identity carried by the runtime response so state never echoes config.
+    """
     gpu_backend = str(env.get("GPU_BACKEND") or "nvidia").lower()
     windows_native_llama = _is_windows_host_llama_server(env)
     is_lemonade = gpu_backend == "amd" and not windows_native_llama
@@ -6565,7 +6643,7 @@ def _wait_for_model_readiness(
     if initial_delay > 0:
         time.sleep(initial_delay)
     for attempt in range(max(1, attempts)):
-        identity_ready = False
+        runtime_identity = ""
         try:
             result = subprocess.run(
                 ["curl", "-s", "--max-time", "5", identity_url],
@@ -6575,13 +6653,13 @@ def _wait_for_model_readiness(
             )
             body = result.stdout.strip()
             if is_lemonade:
-                identity_ready = _check_lemonade_health(
+                runtime_identity = _lemonade_loaded_model_identity(
                     body,
                     gguf_file,
                     lemonade_model_id,
                     expected_context,
                 )
-                if not identity_ready and body and (not warmup_sent or attempt % 3 == 0):
+                if not runtime_identity and body and (not warmup_sent or attempt % 3 == 0):
                     warmup_sent = _send_lemonade_warmup(
                         host,
                         port,
@@ -6589,33 +6667,36 @@ def _wait_for_model_readiness(
                         attempt,
                     )
             else:
-                identity_ready = _check_llama_model_identity(
+                runtime_identity = _llama_loaded_model_identity(
                     body,
                     model_id=model_id,
                     gguf_file=gguf_file,
                     llm_model_name=llm_model_name,
                 )
-            if identity_ready and _chat_completion_ready(
+            if runtime_identity and _chat_completion_ready(
                 host,
                 port,
                 str(completion_model),
                 completion_prefix,
+                expected_model_id=str(runtime_identity),
+                expected_gguf_file=gguf_file,
+                expected_llm_model_name=llm_model_name,
             ):
                 logger.info("Model %s ready after %d attempts", gguf_file, attempt + 1)
-                return True
+                return runtime_identity if return_identity else True
             if attempt % 6 == 0:
                 logger.info(
                     "Model %s readiness incomplete (attempt %d, identity=%s)",
                     gguf_file,
                     attempt + 1,
-                    identity_ready,
+                    bool(runtime_identity),
                 )
         except subprocess.TimeoutExpired:
             if attempt % 6 == 0:
                 logger.info("Model readiness attempt %d timed out", attempt + 1)
         if attempt + 1 < attempts and interval > 0:
             time.sleep(interval)
-    return False
+    return "" if return_identity else False
 
 
 def _is_windows_host_lemonade(env: dict) -> bool:

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5417,7 +5417,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     gguf_file=_gguf,
                     llm_model_name=llm_model_name,
                     lemonade_model_id=lemonade_model_id,
-                    return_identity=True,
+                    return_proof=True,
                 )
 
             # Restart llama-server with the new model.
@@ -5556,18 +5556,16 @@ class AgentHandler(BaseHTTPRequestHandler):
                         switchboard_run.get("phase"),
                         switchboard_run.get("detail"),
                     )
-                    if switchboard_run.get("phase") == "stage":
-                        raise RuntimeError(
-                            str(switchboard_run.get("detail") or "runtime stage failed")
-                        )
             else:
-                healthy = _wait_for_model_readiness(
+                runtime_identity = _wait_for_model_readiness(
                     env,
                     model_id=model_id,
                     gguf_file=gguf_file,
                     llm_model_name=llm_model_name,
                     lemonade_model_id=lemonade_model_id,
+                    return_identity=True,
                 )
+                healthy = bool(runtime_identity)
 
             if healthy:
                 if lemonade_runtime:
@@ -5677,24 +5675,23 @@ class AgentHandler(BaseHTTPRequestHandler):
                 if opencode_snapshot is not None and opencode_runtime_state is not None:
                     opencode_restarted = _restart_managed_opencode(opencode_runtime_state)
                 committed = True  # system state is committed before the response write
-                if _switchboard_state is not None:
+                if (
+                    _switchboard_state is not None
+                    and switchboard_run
+                    and switchboard_run.get("ok")
+                ):
                     # Observe mode: record the proven route after the existing
                     # transaction committed. Failures are logged, never fatal,
                     # and never alter activation behavior.
                     try:
                         verified_runtime_identity = str(
-                            (switchboard_run or {}).get("identity")
-                            or lemonade_model_id
-                            or gguf_file
-                            or llm_model_name
+                            switchboard_run.get("identity") or ""
                         )
                         verified_context_length = int(
-                            (switchboard_run or {}).get("contextLength")
-                            or context_length
+                            switchboard_run.get("contextLength") or 0
                         )
                         verified_capabilities = (
-                            (switchboard_run or {}).get("capabilities")
-                            or switchboard_capabilities
+                            switchboard_run.get("capabilities") or {}
                         )
                         _switchboard_state.record_verified_route(
                             INSTALL_DIR / "data" / "model-state.json",
@@ -5715,6 +5712,11 @@ class AgentHandler(BaseHTTPRequestHandler):
                         )
                     except Exception as exc:
                         logger.warning("switchboard state record failed: %s", exc)
+                elif _switchboard_state is not None:
+                    logger.info(
+                        "switchboard verified-state publication deferred for runtime %s",
+                        "lemonade" if lemonade_model_id else runtime_restart_strategy,
+                    )
                 json_response(
                     self,
                     200,
@@ -5769,11 +5771,17 @@ class AgentHandler(BaseHTTPRequestHandler):
             else:
                 logger.warning("Model activation failed — rolling back")
                 rolled_back, rollback_error = rollback_and_prove()
+                failure_reason = "Health check failed"
+                if switchboard_run and not switchboard_run.get("ok"):
+                    failure_reason = (
+                        f"Runtime {switchboard_run.get('phase') or 'verification'} failed: "
+                        f"{switchboard_run.get('detail') or 'unknown failure'}"
+                    )
                 error = (
-                    "Health check failed — rolled back to previous model"
+                    f"{failure_reason} — rolled back to previous model"
                     if rolled_back
                     else (
-                        "Health check failed; previous model restoration could not be proved: "
+                        f"{failure_reason}; previous model restoration could not be proved: "
                         f"{rollback_error}"
                     )
                 )
@@ -6289,9 +6297,32 @@ def _lemonade_loaded_context_is_sufficient(
     expected_context = _positive_int(expected_context)
     if not expected_context:
         return True
+    actual_context = _lemonade_loaded_context_length(
+        data,
+        expected_gguf_file=expected_gguf_file,
+        expected_model_id=expected_model_id,
+    )
+    if actual_context is not None:
+        return actual_context >= expected_context
+    return not _lemonade_version_at_least(data.get("version"), 10, 7)
+
+
+def _lemonade_loaded_context_length(
+    body_or_data: str | dict,
+    *,
+    expected_gguf_file: str,
+    expected_model_id: str,
+) -> int | None:
+    """Return the context reported for the matching loaded Lemonade model."""
+    try:
+        data = json.loads(body_or_data) if isinstance(body_or_data, str) else body_or_data
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
     loaded = data.get("all_models_loaded")
     if not isinstance(loaded, list):
-        return not _lemonade_version_at_least(data.get("version"), 10, 7)
+        return None
     for entry in loaded:
         if not isinstance(entry, dict):
             continue
@@ -6312,9 +6343,28 @@ def _lemonade_loaded_context_is_sufficient(
         recipe_options = entry.get("recipe_options")
         if not isinstance(recipe_options, dict):
             recipe_options = {}
-        actual_context = _positive_int(recipe_options.get("ctx_size") or entry.get("ctx_size"))
-        return bool(actual_context and actual_context >= expected_context)
-    return False
+        return _positive_int(recipe_options.get("ctx_size") or entry.get("ctx_size"))
+    return None
+
+
+def _llama_runtime_context_length(host: str, port: str) -> int:
+    """Return llama.cpp's actual context from its /props endpoint."""
+    try:
+        result = subprocess.run(
+            ["curl", "-s", "--max-time", "5", f"http://{host}:{port}/props"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return 0
+        data = json.loads(result.stdout or "{}")
+        settings = data.get("default_generation_settings")
+        if not isinstance(settings, dict):
+            return 0
+        return _positive_int(settings.get("n_ctx")) or 0
+    except (json.JSONDecodeError, subprocess.TimeoutExpired, OSError, TypeError):
+        return 0
 
 
 def _completion_text(data: object) -> str:
@@ -6599,11 +6649,12 @@ def _wait_for_model_readiness(
     initial_delay: float = 5,
     interval: float = 5,
     return_identity: bool = False,
-) -> bool | str:
+    return_proof: bool = False,
+) -> bool | str | dict[str, object]:
     """Prove exact runtime identity and one matching meaningful completion.
 
-    Legacy callers receive a boolean. Runtime adapters request the concrete
-    identity carried by the runtime response so state never echoes config.
+    Legacy callers receive a boolean. Identity callers receive the concrete
+    runtime identity. Adapters receive identity, actual context, and proof time.
     """
     gpu_backend = str(env.get("GPU_BACKEND") or "nvidia").lower()
     windows_native_llama = _is_windows_host_llama_server(env)
@@ -6644,6 +6695,7 @@ def _wait_for_model_readiness(
         time.sleep(initial_delay)
     for attempt in range(max(1, attempts)):
         runtime_identity = ""
+        runtime_context = 0
         try:
             result = subprocess.run(
                 ["curl", "-s", "--max-time", "5", identity_url],
@@ -6659,6 +6711,12 @@ def _wait_for_model_readiness(
                     lemonade_model_id,
                     expected_context,
                 )
+                if runtime_identity:
+                    runtime_context = _lemonade_loaded_context_length(
+                        body,
+                        expected_gguf_file=gguf_file,
+                        expected_model_id=lemonade_model_id,
+                    ) or 0
                 if not runtime_identity and body and (not warmup_sent or attempt % 3 == 0):
                     warmup_sent = _send_lemonade_warmup(
                         host,
@@ -6673,6 +6731,10 @@ def _wait_for_model_readiness(
                     gguf_file=gguf_file,
                     llm_model_name=llm_model_name,
                 )
+                if runtime_identity:
+                    runtime_context = _llama_runtime_context_length(host, port)
+                    if expected_context and runtime_context < expected_context:
+                        runtime_identity = ""
             if runtime_identity and _chat_completion_ready(
                 host,
                 port,
@@ -6683,6 +6745,14 @@ def _wait_for_model_readiness(
                 expected_llm_model_name=llm_model_name,
             ):
                 logger.info("Model %s ready after %d attempts", gguf_file, attempt + 1)
+                if return_proof:
+                    if runtime_context <= 0:
+                        return {}
+                    return {
+                        "identity": runtime_identity,
+                        "contextLength": runtime_context,
+                        "verifiedAt": _iso_now(),
+                    }
                 return runtime_identity if return_identity else True
             if attempt % 6 == 0:
                 logger.info(
@@ -6696,6 +6766,8 @@ def _wait_for_model_readiness(
                 logger.info("Model readiness attempt %d timed out", attempt + 1)
         if attempt + 1 < attempts and interval > 0:
             time.sleep(interval)
+    if return_proof:
+        return {}
     return "" if return_identity else False
 
 

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5407,7 +5407,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                 "chat": True,
                 "tools": bool(model.get("tools")),
                 "vision": bool(model.get("vision")),
-                "agentViable": int(context_length) >= 65536,
+                "agentViable": _model_agent_viable(model, int(context_length)),
             }
 
             def _sb_wait_ready(_env, _gguf, _ctx, lemonade_model_id=""):
@@ -5684,6 +5684,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                     _switchboard_state is not None
                     and switchboard_run
                     and switchboard_run.get("ok")
+                    and switchboard_run.get("contextVerified") is True
                 ):
                     # Observe mode: record the proven route after the existing
                     # transaction committed. Failures are logged, never fatal,
@@ -6286,6 +6287,19 @@ def _recommended_activation_context(model_id: str, model: dict, env: dict) -> in
     return None
 
 
+def _model_agent_viable(model: dict, context_length: int) -> bool:
+    compatibility = model.get("app_compatibility")
+    if not isinstance(compatibility, dict):
+        compatibility = {}
+    viability = compatibility.get("agent_viability")
+    if not isinstance(viability, dict):
+        viability = {}
+    return (
+        int(context_length) >= 65536
+        and viability.get("status") != "not_agent_viable"
+    )
+
+
 def _lemonade_version_at_least(value: object, major: int, minor: int) -> bool:
     match = re.match(r"^\s*(\d+)\.(\d+)", str(value or ""))
     if not match:
@@ -6755,11 +6769,13 @@ def _wait_for_model_readiness(
             ):
                 logger.info("Model %s ready after %d attempts", gguf_file, attempt + 1)
                 if return_proof:
-                    if runtime_context <= 0:
+                    reported_context = runtime_context or expected_context or 0
+                    if reported_context <= 0:
                         return {}
                     return {
                         "identity": runtime_identity,
-                        "contextLength": runtime_context,
+                        "contextLength": reported_context,
+                        "contextVerified": runtime_context > 0,
                         "verifiedAt": _iso_now(),
                     }
                 return runtime_identity if return_identity else True

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5043,6 +5043,7 @@ class AgentHandler(BaseHTTPRequestHandler):
         apple_llama_bin: Path | None = None
         apple_llama_log: Path | None = None
         apple_pid_file: Path | None = None
+        switchboard_run: dict | None = None
 
         def restore_backups():
             if env_snapshot is not None:
@@ -5402,7 +5403,6 @@ class AgentHandler(BaseHTTPRequestHandler):
             # llama paths stage+verify through one reconciler sequence. All
             # other strategies keep their inline flow until PR 2B/2C.
             switchboard_adapter = None
-            switchboard_run = None
             switchboard_capabilities = {
                 "chat": True,
                 "tools": bool(model.get("tools")),
@@ -5534,6 +5534,7 @@ class AgentHandler(BaseHTTPRequestHandler):
                         expected_gguf=gguf_file,
                         context_length=int(context_length),
                         lemonade_model_id=lemonade_model_id,
+                        capabilities=switchboard_capabilities,
                     )
 
             hermes_model_name = (
@@ -5556,6 +5557,10 @@ class AgentHandler(BaseHTTPRequestHandler):
                         switchboard_run.get("phase"),
                         switchboard_run.get("detail"),
                     )
+                    if switchboard_run.get("phase") == "stage":
+                        raise RuntimeError(
+                            str(switchboard_run.get("detail") or "runtime stage failed")
+                        )
             else:
                 runtime_identity = _wait_for_model_readiness(
                     env,
@@ -5771,24 +5776,22 @@ class AgentHandler(BaseHTTPRequestHandler):
             else:
                 logger.warning("Model activation failed — rolling back")
                 rolled_back, rollback_error = rollback_and_prove()
-                failure_reason = "Health check failed"
-                if switchboard_run and not switchboard_run.get("ok"):
-                    failure_reason = (
-                        f"Runtime {switchboard_run.get('phase') or 'verification'} failed: "
-                        f"{switchboard_run.get('detail') or 'unknown failure'}"
-                    )
                 error = (
-                    f"{failure_reason} — rolled back to previous model"
+                    "Health check failed — rolled back to previous model"
                     if rolled_back
                     else (
-                        f"{failure_reason}; previous model restoration could not be proved: "
+                        "Health check failed; previous model restoration could not be proved: "
                         f"{rollback_error}"
                     )
                 )
+                payload = {"error": error, "rolled_back": rolled_back}
+                if switchboard_run and not switchboard_run.get("ok"):
+                    payload["failure_phase"] = switchboard_run.get("phase")
+                    payload["failure_detail"] = switchboard_run.get("detail")
                 json_response(
                     self,
                     500,
-                    {"error": error, "rolled_back": rolled_back},
+                    payload,
                 )
 
         except Exception as exc:
@@ -5803,6 +5806,9 @@ class AgentHandler(BaseHTTPRequestHandler):
             payload = {"error": error}
             if mutation_started:
                 payload["rolled_back"] = rolled_back
+            if switchboard_run and not switchboard_run.get("ok"):
+                payload["failure_phase"] = switchboard_run.get("phase")
+                payload["failure_detail"] = switchboard_run.get("detail")
             json_response(self, 500, payload)
 
     def _handle_model_delete(self):
@@ -6297,6 +6303,9 @@ def _lemonade_loaded_context_is_sufficient(
     expected_context = _positive_int(expected_context)
     if not expected_context:
         return True
+    loaded = data.get("all_models_loaded")
+    if not isinstance(loaded, list):
+        return not _lemonade_version_at_least(data.get("version"), 10, 7)
     actual_context = _lemonade_loaded_context_length(
         data,
         expected_gguf_file=expected_gguf_file,
@@ -6304,7 +6313,7 @@ def _lemonade_loaded_context_is_sufficient(
     )
     if actual_context is not None:
         return actual_context >= expected_context
-    return not _lemonade_version_at_least(data.get("version"), 10, 7)
+    return False
 
 
 def _lemonade_loaded_context_length(

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2660,6 +2660,15 @@ class TestModelActivationModeAndMacosBridge:
         def fake_run(cmd, **_kwargs):
             if cmd and cmd[0] == "curl":
                 events.append(("validate-runtime", cmd[-1]))
+                if str(cmd[-1]).endswith("/props"):
+                    return subprocess.CompletedProcess(
+                        cmd,
+                        0,
+                        stdout=json.dumps({
+                            "default_generation_settings": {"n_ctx": 4096},
+                        }),
+                        stderr="",
+                    )
                 return subprocess.CompletedProcess(
                     cmd,
                     0,

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -447,8 +447,8 @@ class TestLemonadeCompletionReady:
                 stderr="",
             )
 
-        def fake_completion(host, port, model, prefix):
-            completion_calls.append((host, port, model, prefix))
+        def fake_completion(host, port, model, prefix, **expected):
+            completion_calls.append((host, port, model, prefix, expected))
             return True
 
         monkeypatch.setattr(_mod.subprocess, "run", fake_run)
@@ -469,8 +469,53 @@ class TestLemonadeCompletionReady:
             interval=0,
         ) is True
         assert completion_calls == [
-            ("127.0.0.1", "8080", "Modern-Model", "/api/v1"),
+            (
+                "127.0.0.1",
+                "8080",
+                "Modern-Model",
+                "/api/v1",
+                {
+                    "expected_model_id": "Modern-Model",
+                    "expected_gguf_file": "Model.gguf",
+                    "expected_llm_model_name": "model",
+                },
+            ),
         ]
+
+    @pytest.mark.parametrize(
+        ("completion_model", "expected_identity"),
+        [
+            ("runtime/new-model.gguf", "runtime/new-model.gguf"),
+            ("old-model.gguf", ""),
+        ],
+    )
+    def test_readiness_returns_only_completion_verified_runtime_identity(
+        self, monkeypatch, completion_model, expected_identity
+    ):
+        def fake_run(cmd, **_kwargs):
+            url = next((str(part) for part in cmd if str(part).startswith("http")), "")
+            if url.endswith("/v1/models"):
+                body = _llama_identity_response("runtime/new-model.gguf")
+            else:
+                body = json.dumps({
+                    "model": completion_model,
+                    "choices": [{"message": {"content": "READY"}}],
+                })
+            return subprocess.CompletedProcess(cmd, 0, stdout=body, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        identity = _mod._wait_for_model_readiness(
+            {"GPU_BACKEND": "nvidia", "OLLAMA_PORT": "8080"},
+            model_id="new-model",
+            gguf_file="new-model.gguf",
+            llm_model_name="new-model",
+            attempts=1,
+            initial_delay=0,
+            interval=0,
+            return_identity=True,
+        )
+        assert identity == expected_identity
 
 
 # --- _write_lemonade_config ---
@@ -775,6 +820,50 @@ class TestDownstreamRouteVerification:
             "secret",
         )
         assert "Authorization: Bearer secret" in commands[0]
+
+    def test_completion_probe_requires_response_model_when_identity_expected(
+        self, monkeypatch
+    ):
+        def fake_run(_cmd, **_kwargs):
+            return subprocess.CompletedProcess(
+                _cmd,
+                0,
+                stdout=json.dumps({
+                    "model": "old-model.gguf",
+                    "choices": [{"message": {"content": "READY"}}],
+                }),
+                stderr="",
+            )
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        assert not _mod._chat_completion_ready(
+            "127.0.0.1",
+            "8080",
+            "new-model.gguf",
+            expected_gguf_file="new-model.gguf",
+        )
+
+    def test_completion_probe_accepts_matching_runtime_identity(self, monkeypatch):
+        def fake_run(_cmd, **_kwargs):
+            return subprocess.CompletedProcess(
+                _cmd,
+                0,
+                stdout=json.dumps({
+                    "model": "runtime/new-model.gguf",
+                    "choices": [{"message": {"content": "READY"}}],
+                }),
+                stderr="",
+            )
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+
+        assert _mod._chat_completion_ready(
+            "127.0.0.1",
+            "8080",
+            "new-model.gguf",
+            expected_gguf_file="new-model.gguf",
+        )
 
     def test_litellm_probe_uses_default_route_and_master_key(self, monkeypatch):
         calls = []
@@ -1612,6 +1701,13 @@ def _llama_identity_response(model_id):
     })
 
 
+def _mock_verified_readiness(*_args, **kwargs):
+    """Mirror the production bool/identity readiness return contract."""
+    if kwargs.get("return_identity"):
+        return str(kwargs.get("gguf_file") or "mock-runtime-model.gguf")
+    return True
+
+
 def _write_model_activation_fixture(
     tmp_path,
     gpu_backend="nvidia",
@@ -2392,7 +2488,7 @@ class TestModelActivateRollback:
             "_restart_windows_lemonade",
             lambda env: restarts.append(env["GGUF_FILE"]),
         )
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         monkeypatch.setattr(
             _mod, "_capture_perplexica_config", lambda _env, _state=None: snapshot
         )
@@ -2713,7 +2809,7 @@ class TestModelActivateRollback:
         monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
         monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(_mod, "_restart_windows_native_llama_server", restart_then_recover)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         handler = _ResponseHandler()
 
         _mod.AgentHandler._do_model_activate(handler, "target-model")
@@ -3141,7 +3237,7 @@ class TestModelActivateRollback:
                 )
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-        def completion_ready(_host, _port, model_name, _prefix):
+        def completion_ready(_host, _port, model_name, _prefix, **_expected):
             completion_models.append(model_name)
             return model_name == "old-model"
 
@@ -3175,6 +3271,8 @@ class TestModelActivateRollback:
 
         def readiness(env, **kwargs):
             events.append(f"ready:{kwargs['gguf_file']}")
+            if kwargs.get("return_identity"):
+                return kwargs["gguf_file"]
             return True
 
         def restart_dependent(container, _state=None):
@@ -3213,7 +3311,7 @@ class TestModelActivateRollback:
         )
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         monkeypatch.setattr(_mod, "_container_exists", lambda _container: False)
         handler = _ResponseHandler()
 
@@ -3232,7 +3330,7 @@ class TestModelActivateRollback:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         monkeypatch.setattr(
             _mod, "_restart_existing_container", lambda _container, _state=None: False
         )
@@ -3309,7 +3407,7 @@ class TestModelActivateRollback:
         monkeypatch.setattr(_mod.platform, "system", lambda: system_name)
         monkeypatch.setattr(_mod, "_restart_managed_opencode", lambda _state=None: False)
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         handler = _ResponseHandler()
 
         _mod.AgentHandler._do_model_activate(handler, "target-model")
@@ -3350,7 +3448,7 @@ class TestModelActivateRollback:
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod, "_opencode_config_paths", lambda: (primary, compat))
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         monkeypatch.setattr(
             _mod,
             "_capture_perplexica_config",
@@ -3388,7 +3486,7 @@ class TestModelActivateRollback:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod, "_opencode_config_paths", lambda: (primary, compat))
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         handler = _ResponseHandler()
 
         _mod.AgentHandler._do_model_activate(handler, "target-model")
@@ -3405,7 +3503,7 @@ class TestModelActivateRollback:
         )
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         monkeypatch.setattr(
             _mod,
             "_resolve_requested_tier_contract",
@@ -3477,7 +3575,7 @@ class TestModelActivateRollback:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         monkeypatch.setattr(
             _mod, "_capture_perplexica_config", lambda _env, _state=None: snapshot
         )
@@ -3512,7 +3610,7 @@ class TestModelActivateRollback:
 
         monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         monkeypatch.setattr(
             _mod, "_capture_perplexica_config", lambda _env, _state=None: snapshot
         )
@@ -3579,7 +3677,7 @@ class TestModelActivateRollback:
             "_compose_restart_llama_server",
             lambda env: restarted_contexts.append(int(env["MAX_CONTEXT"])),
         )
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
 
         handler_b = _ResponseHandler()
         _mod.AgentHandler._do_model_activate(handler_b, "model-b")
@@ -3610,7 +3708,7 @@ class TestModelActivateRollback:
             "_recreate_llama_server",
             lambda env, override_image="": recreates.append((dict(env), override_image)),
         )
-        monkeypatch.setattr(_mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
         handler = _ResponseHandler()
 
         _mod.AgentHandler._do_model_activate(handler, "target-model")
@@ -3656,7 +3754,7 @@ class TestModelActivateRollback:
         monkeypatch.setattr(_mod, "_capture_container_state", lambda name: states[name])
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
         monkeypatch.setattr(
-            _mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True
+            _mod, "_wait_for_model_readiness", _mock_verified_readiness
         )
         monkeypatch.setattr(
             _mod.subprocess,
@@ -3756,7 +3854,7 @@ class TestModelActivateRollback:
             lambda env: runtime_models.append(env["GGUF_FILE"]),
         )
         monkeypatch.setattr(
-            _mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True
+            _mod, "_wait_for_model_readiness", _mock_verified_readiness
         )
         monkeypatch.setattr(
             _mod,
@@ -3809,7 +3907,7 @@ class TestModelActivateRollback:
         )
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
         monkeypatch.setattr(
-            _mod, "_wait_for_model_readiness", lambda *_args, **_kwargs: True
+            _mod, "_wait_for_model_readiness", _mock_verified_readiness
         )
         handler = _ResponseHandler()
 
@@ -4024,11 +4122,13 @@ class TestModelActivateRollback:
             lambda: {"system": "Linux", "active": True},
         )
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: events.append("runtime"))
-        monkeypatch.setattr(
-            _mod,
-            "_wait_for_model_readiness",
-            lambda *_args, **_kwargs: events.append("runtime-ready") or True,
-        )
+        def readiness(*_args, **kwargs):
+            events.append("runtime-ready")
+            if kwargs.get("return_identity"):
+                return kwargs.get("gguf_file")
+            return True
+
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", readiness)
         monkeypatch.setattr(
             _mod,
             "_restart_existing_container",

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -496,6 +496,10 @@ class TestLemonadeCompletionReady:
             url = next((str(part) for part in cmd if str(part).startswith("http")), "")
             if url.endswith("/v1/models"):
                 body = _llama_identity_response("runtime/new-model.gguf")
+            elif url.endswith("/props"):
+                body = json.dumps({
+                    "default_generation_settings": {"n_ctx": 65536}
+                })
             else:
                 body = json.dumps({
                     "model": completion_model,
@@ -516,6 +520,77 @@ class TestLemonadeCompletionReady:
             return_identity=True,
         )
         assert identity == expected_identity
+
+    def test_readiness_proof_carries_actual_runtime_context(self, monkeypatch):
+        def fake_run(cmd, **_kwargs):
+            url = next((str(part) for part in cmd if str(part).startswith("http")), "")
+            if url.endswith("/v1/models"):
+                body = _llama_identity_response("runtime/new-model.gguf")
+            elif url.endswith("/props"):
+                body = json.dumps({
+                    "default_generation_settings": {"n_ctx": 65536}
+                })
+            else:
+                body = ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=body, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(_mod, "_chat_completion_ready", lambda *_a, **_k: True)
+        proof = _mod._wait_for_model_readiness(
+            {
+                "GPU_BACKEND": "nvidia",
+                "OLLAMA_PORT": "8080",
+                "CTX_SIZE": "65536",
+            },
+            model_id="new-model",
+            gguf_file="new-model.gguf",
+            llm_model_name="new-model",
+            attempts=1,
+            initial_delay=0,
+            interval=0,
+            return_proof=True,
+        )
+        assert proof["identity"] == "runtime/new-model.gguf"
+        assert proof["contextLength"] == 65536
+        assert proof["verifiedAt"].endswith("+00:00")
+
+    def test_readiness_rejects_runtime_context_below_requested(self, monkeypatch):
+        completion_calls = []
+
+        def fake_run(cmd, **_kwargs):
+            url = next((str(part) for part in cmd if str(part).startswith("http")), "")
+            if url.endswith("/v1/models"):
+                body = _llama_identity_response("runtime/new-model.gguf")
+            elif url.endswith("/props"):
+                body = json.dumps({
+                    "default_generation_settings": {"n_ctx": 32768}
+                })
+            else:
+                body = ""
+            return subprocess.CompletedProcess(cmd, 0, stdout=body, stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            _mod,
+            "_chat_completion_ready",
+            lambda *_a, **_k: completion_calls.append(True) or True,
+        )
+        proof = _mod._wait_for_model_readiness(
+            {
+                "GPU_BACKEND": "nvidia",
+                "OLLAMA_PORT": "8080",
+                "CTX_SIZE": "65536",
+            },
+            model_id="new-model",
+            gguf_file="new-model.gguf",
+            llm_model_name="new-model",
+            attempts=1,
+            initial_delay=0,
+            interval=0,
+            return_proof=True,
+        )
+        assert proof == {}
+        assert completion_calls == []
 
 
 # --- _write_lemonade_config ---
@@ -1702,9 +1777,16 @@ def _llama_identity_response(model_id):
 
 
 def _mock_verified_readiness(*_args, **kwargs):
-    """Mirror the production bool/identity readiness return contract."""
+    """Mirror the production bool/identity/proof readiness return contract."""
+    identity = str(kwargs.get("gguf_file") or "mock-runtime-model.gguf")
+    if kwargs.get("return_proof"):
+        return {
+            "identity": identity,
+            "contextLength": 65536,
+            "verifiedAt": "2026-07-20T00:00:00+00:00",
+        }
     if kwargs.get("return_identity"):
-        return str(kwargs.get("gguf_file") or "mock-runtime-model.gguf")
+        return identity
     return True
 
 
@@ -1783,6 +1865,9 @@ class TestModelActivateRollback:
     @pytest.fixture(autouse=True)
     def _successful_meaningful_completion(self, monkeypatch):
         monkeypatch.setattr(_mod, "_chat_completion_ready", lambda *_args, **_kwargs: True)
+        monkeypatch.setattr(
+            _mod, "_llama_runtime_context_length", lambda *_args: 131072
+        )
         monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
         monkeypatch.setattr(_mod, "_container_exists", lambda _container: False)
         monkeypatch.setattr(_mod, "_container_running", lambda _container: False)
@@ -2428,6 +2513,7 @@ class TestModelActivateRollback:
         _mod.AgentHandler._do_model_activate(handler, "target-model")
 
         assert handler.response_code == 200
+        assert not (install_dir / "data" / "model-state.json").exists()
         assert "LEMONADE_MODEL=Modern-Model" in env_path.read_text(encoding="utf-8")
         assert "model: openai/Modern-Model" in lemonade_yaml.read_text(encoding="utf-8")
         assert 'default: "Modern-Model"' in hermes_live.read_text(encoding="utf-8")
@@ -3271,6 +3357,12 @@ class TestModelActivateRollback:
 
         def readiness(env, **kwargs):
             events.append(f"ready:{kwargs['gguf_file']}")
+            if kwargs.get("return_proof"):
+                return {
+                    "identity": kwargs["gguf_file"],
+                    "contextLength": 65536,
+                    "verifiedAt": "2026-07-20T00:00:00+00:00",
+                }
             if kwargs.get("return_identity"):
                 return kwargs["gguf_file"]
             return True
@@ -4124,6 +4216,12 @@ class TestModelActivateRollback:
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: events.append("runtime"))
         def readiness(*_args, **kwargs):
             events.append("runtime-ready")
+            if kwargs.get("return_proof"):
+                return {
+                    "identity": kwargs.get("gguf_file"),
+                    "contextLength": 65536,
+                    "verifiedAt": "2026-07-20T00:00:00+00:00",
+                }
             if kwargs.get("return_identity"):
                 return kwargs.get("gguf_file")
             return True

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -213,6 +213,23 @@ class TestCheckLemonadeHealth:
             131072,
         ) is True
 
+    def test_legacy_health_with_loaded_list_requires_matching_row(self):
+        body = json.dumps({
+            "status": "ok",
+            "version": "10.6.9",
+            "model_loaded": "extra.Model.gguf",
+            "all_models_loaded": [{
+                "model_name": "different-model",
+                "recipe_options": {"ctx_size": 131072},
+            }],
+        })
+        assert _check_lemonade_health(
+            body,
+            "Model.gguf",
+            "extra.Model.gguf",
+            131072,
+        ) is False
+
 
 class TestResolveLemonadeModelId:
 
@@ -1776,6 +1793,18 @@ def _llama_identity_response(model_id):
     })
 
 
+def _lemonade_health_response(model_id, context_length=4096):
+    return json.dumps({
+        "status": "ok",
+        "version": "10.7.0",
+        "model_loaded": model_id,
+        "all_models_loaded": [{
+            "model_name": model_id,
+            "recipe_options": {"ctx_size": context_length},
+        }],
+    })
+
+
 def _mock_verified_readiness(*_args, **kwargs):
     """Mirror the production bool/identity/proof readiness return contract."""
     identity = str(kwargs.get("gguf_file") or "mock-runtime-model.gguf")
@@ -2140,7 +2169,7 @@ class TestModelActivateRollback:
         def fake_run(cmd, **_kwargs):
             if cmd and cmd[0] == "curl":
                 stdout = (
-                    '{"status": "ok", "model_loaded": "extra.new-model.gguf"}'
+                    _lemonade_health_response("extra.new-model.gguf")
                     if runtime_kind == "windows-lemonade"
                     else _llama_identity_response("new-model.gguf")
                 )
@@ -2392,11 +2421,14 @@ class TestModelActivateRollback:
         monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
 
         def fake_run(cmd, **_kwargs):
-            stdout = (
-                '{"status": "ok", "model_loaded": "extra.new-model.gguf"}'
-                if cmd and cmd[0] == "curl"
-                else ""
-            )
+            if cmd and cmd[0] == "curl" and cmd[-1].endswith("/models"):
+                stdout = json.dumps({
+                    "data": [{"id": "extra.new-model.gguf"}]
+                })
+            elif cmd and cmd[0] == "curl":
+                stdout = _lemonade_health_response("extra.new-model.gguf")
+            else:
+                stdout = ""
             return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
         monkeypatch.setattr(_mod.subprocess, "run", fake_run)
@@ -2513,7 +2545,11 @@ class TestModelActivateRollback:
         _mod.AgentHandler._do_model_activate(handler, "target-model")
 
         assert handler.response_code == 200
-        assert not (install_dir / "data" / "model-state.json").exists()
+        state = json.loads(
+            (install_dir / "data" / "model-state.json").read_text(encoding="utf-8")
+        )
+        assert state["active"]["runtimeModelId"] == "Modern-Model"
+        assert state["active"]["contextLength"] == 4096
         assert "LEMONADE_MODEL=Modern-Model" in env_path.read_text(encoding="utf-8")
         assert "model: openai/Modern-Model" in lemonade_yaml.read_text(encoding="utf-8")
         assert 'default: "Modern-Model"' in hermes_live.read_text(encoding="utf-8")
@@ -2629,11 +2665,14 @@ class TestModelActivateRollback:
 
         def fake_run(cmd, **_kwargs):
             calls.append(cmd)
-            stdout = (
-                '{"status": "ok", "model_loaded": "extra.new-model.gguf"}'
-                if cmd and cmd[0] == "curl"
-                else ""
-            )
+            if cmd and cmd[0] == "curl" and cmd[-1].endswith("/models"):
+                stdout = json.dumps({
+                    "data": [{"id": "extra.new-model.gguf"}]
+                })
+            elif cmd and cmd[0] == "curl":
+                stdout = _lemonade_health_response("extra.new-model.gguf")
+            else:
+                stdout = ""
             return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
         def fail_restart(_env):

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -499,6 +499,53 @@ class TestLemonadeCompletionReady:
             ),
         ]
 
+    def test_legacy_lemonade_proof_marks_context_unverified(self, monkeypatch):
+        def fake_run(cmd, **_kwargs):
+            return subprocess.CompletedProcess(
+                cmd,
+                0,
+                stdout=json.dumps({
+                    "status": "ok",
+                    "version": "10.2.0",
+                    "model_loaded": "extra.Model.gguf",
+                }),
+                stderr="",
+            )
+
+        monkeypatch.setattr(_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(_mod, "_chat_completion_ready", lambda *_a, **_k: True)
+        proof = _mod._wait_for_model_readiness(
+            {
+                "GPU_BACKEND": "amd",
+                "OLLAMA_PORT": "8080",
+                "CTX_SIZE": "4096",
+            },
+            model_id="model",
+            gguf_file="Model.gguf",
+            llm_model_name="model",
+            lemonade_model_id="extra.Model.gguf",
+            attempts=1,
+            initial_delay=0,
+            interval=0,
+            return_proof=True,
+        )
+        assert proof == {
+            "identity": "extra.Model.gguf",
+            "contextLength": 4096,
+            "contextVerified": False,
+            "verifiedAt": proof["verifiedAt"],
+        }
+
+    def test_catalog_non_agent_viability_overrides_context_floor(self):
+        model = {
+            "app_compatibility": {
+                "agent_viability": {"status": "not_agent_viable"}
+            }
+        }
+        assert _mod._model_agent_viable(model, 131072) is False
+        assert _mod._model_agent_viable({}, 131072) is True
+        assert _mod._model_agent_viable({}, 32768) is False
+
     @pytest.mark.parametrize(
         ("completion_model", "expected_identity"),
         [
@@ -569,6 +616,7 @@ class TestLemonadeCompletionReady:
         )
         assert proof["identity"] == "runtime/new-model.gguf"
         assert proof["contextLength"] == 65536
+        assert proof["contextVerified"] is True
         assert proof["verifiedAt"].endswith("+00:00")
 
     def test_readiness_rejects_runtime_context_below_requested(self, monkeypatch):
@@ -1812,6 +1860,7 @@ def _mock_verified_readiness(*_args, **kwargs):
         return {
             "identity": identity,
             "contextLength": 65536,
+            "contextVerified": True,
             "verifiedAt": "2026-07-20T00:00:00+00:00",
         }
     if kwargs.get("return_identity"):
@@ -3400,6 +3449,7 @@ class TestModelActivateRollback:
                 return {
                     "identity": kwargs["gguf_file"],
                     "contextLength": 65536,
+                    "contextVerified": True,
                     "verifiedAt": "2026-07-20T00:00:00+00:00",
                 }
             if kwargs.get("return_identity"):
@@ -4259,6 +4309,7 @@ class TestModelActivateRollback:
                 return {
                     "identity": kwargs.get("gguf_file"),
                     "contextLength": 65536,
+                    "contextVerified": True,
                     "verifiedAt": "2026-07-20T00:00:00+00:00",
                 }
             if kwargs.get("return_identity"):

--- a/ods/extensions/services/dashboard-api/tests/test_model_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_state.py
@@ -289,6 +289,9 @@ class TestObserveHook:
             lambda: (config_dir / "opencode.json", config_dir / "config.json"),
         )
         monkeypatch.setattr(tma._mod, "_chat_completion_ready", lambda *_a, **_k: True)
+        monkeypatch.setattr(
+            tma._mod, "_llama_runtime_context_length", lambda *_args: 65536
+        )
         monkeypatch.setattr(tma._mod, "_container_exists", lambda _c: False)
         monkeypatch.setattr(tma._mod, "_container_running", lambda _c: False)
         monkeypatch.setattr(

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -15,14 +16,34 @@ from model_switchboard import adapters as ad  # noqa: E402
 from model_switchboard import reconciler as rc  # noqa: E402
 
 
+def _proof_result(identity="M.gguf", **overrides):
+    payload = {
+        "identity": identity,
+        "contextLength": 65536,
+        "capabilities": {
+            "chat": True,
+            "tools": False,
+            "vision": False,
+            "agentViable": True,
+        },
+        "verifiedAt": "2026-07-20T00:00:00Z",
+    }
+    payload.update(overrides)
+    return ad.result(True, **payload)
+
+
 class TestReconcilerBoundaries:
     def test_success_runs_phases_in_order(self):
         fake = ad.FakeAdapter({
-            "verify_identity": [ad.result(True, identity="M.gguf")],
+            "verify_identity": [_proof_result()],
+            "verify_completion": [_proof_result()],
         })
         run = rc.run_runtime_activation(fake, {})
         assert run["ok"] is True
         assert run["identity"] == "M.gguf"
+        assert run["contextLength"] == 65536
+        assert run["capabilities"]["agentViable"] is True
+        assert run["verifiedAt"] == "2026-07-20T00:00:00Z"
         assert fake.calls == list(rc.PHASES)
 
     def test_stage_failure_stops_sequence(self):
@@ -49,12 +70,42 @@ class TestReconcilerBoundaries:
 
     def test_completion_failure_reports_boundary(self):
         fake = ad.FakeAdapter({
-            "verify_identity": [ad.result(True, identity="M.gguf")],
+            "verify_identity": [_proof_result()],
             "verify_completion": [ad.result(False, "no tokens")],
         })
         run = rc.run_runtime_activation(fake, {})
         assert run["ok"] is False and run["phase"] == "verify_completion"
         assert run["identity"] == "M.gguf"
+
+    @pytest.mark.parametrize(
+        ("missing", "detail"),
+        [
+            ("identity", "identity"),
+            ("contextLength", "context length"),
+            ("capabilities", "capability"),
+            ("verifiedAt", "timestamp"),
+        ],
+    )
+    def test_successful_verification_requires_full_proof_contract(
+        self, missing, detail
+    ):
+        outcome = _proof_result()
+        outcome.pop(missing)
+        fake = ad.FakeAdapter({"verify_identity": [outcome]})
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False
+        assert run["phase"] == "verify_identity"
+        assert detail in run["detail"]
+
+    def test_completion_identity_must_match_identity_proof(self):
+        fake = ad.FakeAdapter({
+            "verify_identity": [_proof_result("new.gguf")],
+            "verify_completion": [_proof_result("old.gguf")],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False
+        assert run["phase"] == "verify_completion"
+        assert "does not match" in run["detail"]
 
     def test_adapter_exception_is_contract_violation(self):
         class Exploding(ad.FakeAdapter):
@@ -84,7 +135,7 @@ class TestContainerLlamaAdapter:
 
         def wait_ready(env, gguf, ctx, lemonade_model_id=""):
             seen["wait"] = (gguf, ctx, lemonade_model_id)
-            return True
+            return "runtime/Model.gguf"
 
         adapter = ad.ContainerLlamaAdapter(
             restart=restart,
@@ -95,14 +146,22 @@ class TestContainerLlamaAdapter:
         env = {"GPU_BACKEND": "nvidia"}
         run = rc.run_runtime_activation(adapter, env)
         assert run["ok"] is True
-        assert run["identity"] == "Model.gguf"
+        assert run["identity"] == "runtime/Model.gguf"
+        assert run["contextLength"] == 4096
+        assert run["capabilities"] == {
+            "chat": True,
+            "tools": False,
+            "vision": False,
+            "agentViable": False,
+        }
+        assert run["verifiedAt"]
         assert seen["restart_env"] is env
         assert seen["wait"] == ("Model.gguf", 4096, "")
 
     def test_restart_exception_becomes_stage_failure(self):
         adapter = ad.ContainerLlamaAdapter(
             restart=lambda _env: (_ for _ in ()).throw(OSError("compose down")),
-            wait_ready=lambda *a, **k: True,
+            wait_ready=lambda *a, **k: "M.gguf",
             expected_gguf="M.gguf",
             context_length=1024,
         )
@@ -113,7 +172,7 @@ class TestContainerLlamaAdapter:
     def test_not_ready_is_identity_failure(self):
         adapter = ad.ContainerLlamaAdapter(
             restart=lambda _env: None,
-            wait_ready=lambda *a, **k: False,
+            wait_ready=lambda *a, **k: "",
             expected_gguf="M.gguf",
             context_length=1024,
         )
@@ -126,7 +185,7 @@ class TestNativeLlamaAdapter:
         calls = []
         adapter = ad.NativeLlamaAdapter(
             restart=lambda _e: calls.append("restart"),
-            wait_ready=lambda *a, **k: (calls.append("wait"), True)[1],
+            wait_ready=lambda *a, **k: (calls.append("wait"), "Win.gguf")[1],
             expected_gguf="Win.gguf",
             context_length=8192,
         )
@@ -138,13 +197,37 @@ class TestNativeLlamaAdapter:
     def test_native_restart_failure_is_stage_boundary(self):
         adapter = ad.NativeLlamaAdapter(
             restart=lambda _e: (_ for _ in ()).throw(RuntimeError("launchd bootout failed")),
-            wait_ready=lambda *a, **k: True,
+            wait_ready=lambda *a, **k: "Mac.gguf",
             expected_gguf="Mac.gguf",
             context_length=8192,
         )
         run = rc.run_runtime_activation(adapter, {})
         assert run["ok"] is False and run["phase"] == "stage"
         assert "launchd bootout failed" in run["detail"]
+
+    def test_boolean_readiness_cannot_masquerade_as_identity(self):
+        adapter = ad.NativeLlamaAdapter(
+            restart=lambda _e: None,
+            wait_ready=lambda *a, **k: True,
+            expected_gguf="Configured.gguf",
+            context_length=8192,
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False
+        assert run["phase"] == "verify_identity"
+
+    def test_full_adapter_contract_is_explicit(self):
+        required = {
+            "stage",
+            "verify_identity",
+            "verify_completion",
+            "publish_native_alias",
+            "unload",
+            "delete",
+            "rollback",
+        }
+        assert required.issubset(set(dir(ad.RuntimeAdapter)))
+        assert required.issubset(set(dir(ad.FakeAdapter)))
 
 
 class TestLemonadeAdapter:
@@ -222,6 +305,11 @@ class TestHostAgentWiring:
         tma._mod.AgentHandler._do_model_activate(handler, "target-model")
         assert handler.response_code == 200
         assert order[:2] == ["restart", "wait"]
+        state = json.loads(
+            (install_dir / "data" / "model-state.json").read_text(encoding="utf-8")
+        )
+        assert state["active"]["runtimeModelId"] == "new-model.gguf"
+        assert state["active"]["proof"]["identity"] == "new-model.gguf"
 
     def test_reconciler_failure_uses_existing_rollback(self, tmp_path, monkeypatch):
         import subprocess
@@ -248,6 +336,40 @@ class TestHostAgentWiring:
         assert handler.response_code != 200
         # rollback restored the pre-activation env exactly as before PR 2A
         assert env_path.read_text(encoding="utf-8") == before_env
+
+    def test_stage_exception_keeps_existing_error_contract(self, tmp_path, monkeypatch):
+        import subprocess
+        import test_model_activate as tma
+
+        install_dir = tma._write_model_activation_fixture(tmp_path)[0]
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(tma._mod.time, "sleep", lambda _s: None)
+        restart_calls = 0
+
+        def restart(_env):
+            nonlocal restart_calls
+            restart_calls += 1
+            if restart_calls == 1:
+                raise OSError("compose down")
+
+        monkeypatch.setattr(tma._mod, "_compose_restart_llama_server", restart)
+
+        def fake_run(cmd, **_kwargs):
+            stdout = (
+                tma._llama_identity_response("old-model.gguf")
+                if cmd and cmd[0] == "curl"
+                else ""
+            )
+            return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(tma._mod.subprocess, "run", fake_run)
+        handler = tma._ResponseHandler()
+        tma._mod.AgentHandler._do_model_activate(handler, "target-model")
+        assert handler.response_code == 500
+        payload = handler.parse_response()
+        assert payload["error"] == "Model activation failed: compose down"
+        assert payload["rolled_back"] is True
 
 
 @pytest.fixture(autouse=True)

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -32,6 +32,14 @@ def _proof_result(identity="M.gguf", **overrides):
     return ad.result(True, **payload)
 
 
+def _readiness_proof(identity="M.gguf", context_length=65536):
+    return {
+        "identity": identity,
+        "contextLength": context_length,
+        "verifiedAt": "2026-07-20T00:00:00+00:00",
+    }
+
+
 class TestReconcilerBoundaries:
     def test_success_runs_phases_in_order(self):
         fake = ad.FakeAdapter({
@@ -107,6 +115,32 @@ class TestReconcilerBoundaries:
         assert run["phase"] == "verify_completion"
         assert "does not match" in run["detail"]
 
+    def test_completion_metadata_must_match_identity_proof(self):
+        fake = ad.FakeAdapter({
+            "verify_identity": [_proof_result()],
+            "verify_completion": [_proof_result(contextLength=32768)],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False
+        assert "metadata does not match" in run["detail"]
+
+    @pytest.mark.parametrize("verified_at", ["not-a-time", "2026-07-20T00:00:00"])
+    def test_proof_timestamp_must_be_valid_utc(self, verified_at):
+        fake = ad.FakeAdapter({
+            "verify_identity": [_proof_result(verifiedAt=verified_at)],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False
+        assert "timestamp" in run["detail"]
+
+    def test_zero_context_cannot_pass_verification(self):
+        fake = ad.FakeAdapter({
+            "verify_identity": [_proof_result(contextLength=0)],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is False
+        assert "context length" in run["detail"]
+
     def test_adapter_exception_is_contract_violation(self):
         class Exploding(ad.FakeAdapter):
             def stage(self, env):
@@ -135,7 +169,7 @@ class TestContainerLlamaAdapter:
 
         def wait_ready(env, gguf, ctx, lemonade_model_id=""):
             seen["wait"] = (gguf, ctx, lemonade_model_id)
-            return "runtime/Model.gguf"
+            return _readiness_proof("runtime/Model.gguf", 4096)
 
         adapter = ad.ContainerLlamaAdapter(
             restart=restart,
@@ -161,7 +195,7 @@ class TestContainerLlamaAdapter:
     def test_restart_exception_becomes_stage_failure(self):
         adapter = ad.ContainerLlamaAdapter(
             restart=lambda _env: (_ for _ in ()).throw(OSError("compose down")),
-            wait_ready=lambda *a, **k: "M.gguf",
+            wait_ready=lambda *a, **k: _readiness_proof("M.gguf", 1024),
             expected_gguf="M.gguf",
             context_length=1024,
         )
@@ -172,7 +206,7 @@ class TestContainerLlamaAdapter:
     def test_not_ready_is_identity_failure(self):
         adapter = ad.ContainerLlamaAdapter(
             restart=lambda _env: None,
-            wait_ready=lambda *a, **k: "",
+            wait_ready=lambda *a, **k: {},
             expected_gguf="M.gguf",
             context_length=1024,
         )
@@ -185,7 +219,10 @@ class TestNativeLlamaAdapter:
         calls = []
         adapter = ad.NativeLlamaAdapter(
             restart=lambda _e: calls.append("restart"),
-            wait_ready=lambda *a, **k: (calls.append("wait"), "Win.gguf")[1],
+            wait_ready=lambda *a, **k: (
+                calls.append("wait"),
+                _readiness_proof("Win.gguf", 8192),
+            )[1],
             expected_gguf="Win.gguf",
             context_length=8192,
         )
@@ -197,7 +234,7 @@ class TestNativeLlamaAdapter:
     def test_native_restart_failure_is_stage_boundary(self):
         adapter = ad.NativeLlamaAdapter(
             restart=lambda _e: (_ for _ in ()).throw(RuntimeError("launchd bootout failed")),
-            wait_ready=lambda *a, **k: "Mac.gguf",
+            wait_ready=lambda *a, **k: _readiness_proof("Mac.gguf", 8192),
             expected_gguf="Mac.gguf",
             context_length=8192,
         )
@@ -295,7 +332,15 @@ class TestHostAgentWiring:
         monkeypatch.setattr(tma._mod, "_wait_for_model_readiness", spying_wait)
 
         def fake_run(cmd, **_kwargs):
-            stdout = tma._llama_identity_response("new-model.gguf") if cmd and cmd[0] == "curl" else ""
+            url = next((str(part) for part in cmd if str(part).startswith("http")), "")
+            if url.endswith("/v1/models"):
+                stdout = tma._llama_identity_response("new-model.gguf")
+            elif url.endswith("/props"):
+                stdout = json.dumps({
+                    "default_generation_settings": {"n_ctx": 65536}
+                })
+            else:
+                stdout = ""
             return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
 
         monkeypatch.setattr(tma._mod.subprocess, "run", fake_run)
@@ -334,7 +379,49 @@ class TestHostAgentWiring:
         handler = tma._ResponseHandler()
         tma._mod.AgentHandler._do_model_activate(handler, "target-model")
         assert handler.response_code != 200
+        payload = handler.parse_response()
+        assert "Runtime verify_identity failed" in payload["error"]
+        assert "runtime did not report the staged model" in payload["error"]
+        assert "restoration could not be proved" in payload["error"]
         # rollback restored the pre-activation env exactly as before PR 2A
+        assert env_path.read_text(encoding="utf-8") == before_env
+
+    def test_completion_failure_detail_survives_successful_rollback(
+        self, tmp_path, monkeypatch
+    ):
+        import test_model_activate as tma
+
+        install_dir, env_path = tma._write_model_activation_fixture(tmp_path)[:2]
+        before_env = env_path.read_text(encoding="utf-8")
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("ODS_HOST_INSTALL_DIR", raising=False)
+        monkeypatch.setattr(
+            tma._mod, "_compose_restart_llama_server", lambda _env: None
+        )
+        monkeypatch.setattr(
+            tma._mod,
+            "_wait_for_model_readiness",
+            lambda *_args, **_kwargs: True,
+        )
+        monkeypatch.setattr(
+            tma._mod._switchboard_reconciler,
+            "run_runtime_activation",
+            lambda *_args, **_kwargs: {
+                "ok": False,
+                "phase": "verify_completion",
+                "detail": "completion response carried the previous model",
+                "identity": "new-model.gguf",
+            },
+        )
+        handler = tma._ResponseHandler()
+        tma._mod.AgentHandler._do_model_activate(handler, "target-model")
+        assert handler.response_code == 500
+        payload = handler.parse_response()
+        assert payload["rolled_back"] is True
+        assert payload["error"] == (
+            "Runtime verify_completion failed: completion response carried the "
+            "previous model — rolled back to previous model"
+        )
         assert env_path.read_text(encoding="utf-8") == before_env
 
     def test_stage_exception_keeps_existing_error_contract(self, tmp_path, monkeypatch):
@@ -368,7 +455,9 @@ class TestHostAgentWiring:
         tma._mod.AgentHandler._do_model_activate(handler, "target-model")
         assert handler.response_code == 500
         payload = handler.parse_response()
-        assert payload["error"] == "Model activation failed: compose down"
+        assert payload["error"] == (
+            "Runtime stage failed: compose down — rolled back to previous model"
+        )
         assert payload["rolled_back"] is True
 
 
@@ -384,6 +473,9 @@ def _isolation(monkeypatch, tmp_path, request):
         lambda: (config_dir / "opencode.json", config_dir / "config.json"),
     )
     monkeypatch.setattr(tma._mod, "_chat_completion_ready", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        tma._mod, "_llama_runtime_context_length", lambda *_args: 65536
+    )
     monkeypatch.setattr(tma._mod, "_container_exists", lambda _c: False)
     monkeypatch.setattr(tma._mod, "_container_running", lambda _c: False)
     monkeypatch.setattr(

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -20,6 +20,7 @@ def _proof_result(identity="M.gguf", **overrides):
     payload = {
         "identity": identity,
         "contextLength": 65536,
+        "contextVerified": True,
         "capabilities": {
             "chat": True,
             "tools": False,
@@ -36,6 +37,7 @@ def _readiness_proof(identity="M.gguf", context_length=65536):
     return {
         "identity": identity,
         "contextLength": context_length,
+        "contextVerified": True,
         "verifiedAt": "2026-07-20T00:00:00+00:00",
     }
 
@@ -90,6 +92,7 @@ class TestReconcilerBoundaries:
         [
             ("identity", "identity"),
             ("contextLength", "context length"),
+            ("contextVerified", "context-verification"),
             ("capabilities", "capability"),
             ("verifiedAt", "timestamp"),
         ],

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -124,6 +124,17 @@ class TestReconcilerBoundaries:
         assert run["ok"] is False
         assert "metadata does not match" in run["detail"]
 
+    def test_completion_can_carry_a_later_proof_timestamp(self):
+        fake = ad.FakeAdapter({
+            "verify_identity": [_proof_result()],
+            "verify_completion": [
+                _proof_result(verifiedAt="2026-07-20T00:00:01Z")
+            ],
+        })
+        run = rc.run_runtime_activation(fake, {})
+        assert run["ok"] is True
+        assert run["verifiedAt"] == "2026-07-20T00:00:01Z"
+
     @pytest.mark.parametrize("verified_at", ["not-a-time", "2026-07-20T00:00:00"])
     def test_proof_timestamp_must_be_valid_utc(self, verified_at):
         fake = ad.FakeAdapter({
@@ -273,7 +284,7 @@ class TestLemonadeAdapter:
 
         def wait_ready(env, gguf, ctx, lemonade_model_id=""):
             seen["args"] = (gguf, ctx, lemonade_model_id)
-            return True
+            return _readiness_proof("extra.Q.gguf", 65536)
 
         adapter = ad.LemonadeAdapter(
             wait_ready=wait_ready,
@@ -284,6 +295,7 @@ class TestLemonadeAdapter:
         run = rc.run_runtime_activation(adapter, {})
         assert run["ok"] is True
         assert run["identity"] == "extra.Q.gguf"
+        assert run["contextLength"] == 65536
         assert adapter.kind == "lemonade"
         assert seen["args"] == ("Q.gguf", 65536, "extra.Q.gguf")
 
@@ -299,13 +311,24 @@ class TestLemonadeAdapter:
 
     def test_not_ready_is_identity_failure(self):
         adapter = ad.LemonadeAdapter(
-            wait_ready=lambda *a, **k: False,
+            wait_ready=lambda *a, **k: {},
             expected_gguf="Q.gguf",
             context_length=1024,
             lemonade_model_id="extra.Q.gguf",
         )
         run = rc.run_runtime_activation(adapter, {})
         assert run["ok"] is False and run["phase"] == "verify_identity"
+
+    def test_boolean_readiness_cannot_echo_configured_lemonade_id(self):
+        adapter = ad.LemonadeAdapter(
+            wait_ready=lambda *a, **k: True,
+            expected_gguf="Q.gguf",
+            context_length=1024,
+            lemonade_model_id="extra.Q.gguf",
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False
+        assert run["identity"] is None
 
 
 class TestHostAgentWiring:
@@ -380,9 +403,10 @@ class TestHostAgentWiring:
         tma._mod.AgentHandler._do_model_activate(handler, "target-model")
         assert handler.response_code != 200
         payload = handler.parse_response()
-        assert "Runtime verify_identity failed" in payload["error"]
-        assert "runtime did not report the staged model" in payload["error"]
+        assert payload["error"].startswith("Health check failed;")
         assert "restoration could not be proved" in payload["error"]
+        assert payload["failure_phase"] == "verify_identity"
+        assert "runtime did not report the staged model" in payload["failure_detail"]
         # rollback restored the pre-activation env exactly as before PR 2A
         assert env_path.read_text(encoding="utf-8") == before_env
 
@@ -419,8 +443,11 @@ class TestHostAgentWiring:
         payload = handler.parse_response()
         assert payload["rolled_back"] is True
         assert payload["error"] == (
-            "Runtime verify_completion failed: completion response carried the "
-            "previous model — rolled back to previous model"
+            "Health check failed — rolled back to previous model"
+        )
+        assert payload["failure_phase"] == "verify_completion"
+        assert payload["failure_detail"] == (
+            "completion response carried the previous model"
         )
         assert env_path.read_text(encoding="utf-8") == before_env
 
@@ -455,9 +482,9 @@ class TestHostAgentWiring:
         tma._mod.AgentHandler._do_model_activate(handler, "target-model")
         assert handler.response_code == 500
         payload = handler.parse_response()
-        assert payload["error"] == (
-            "Runtime stage failed: compose down — rolled back to previous model"
-        )
+        assert payload["error"] == "Model activation failed: compose down"
+        assert payload["failure_phase"] == "stage"
+        assert payload["failure_detail"] == "compose down"
         assert payload["rolled_back"] is True
 
 


### PR DESCRIPTION
## Summary
- reject boolean-only readiness and configured-identity echoes across llama.cpp and Lemonade
- require both verification phases to carry matching runtime identity, context status, capabilities, and valid UTC proof timestamps
- probe llama.cpp /props and Lemonade 10.7+ loaded-model metadata before publishing verified state
- keep pinned Lemonade 10.0/10.2 swaps functional but mark context unverified and withhold verified-state publication
- require the completion response model to match the loaded runtime identity
- honor product catalog not_agent_viable metadata
- preserve existing HTTP error strings while adding failure_phase and failure_detail diagnostics
- make the full adapter lifecycle contract explicit

## Why
This closes foundation contract blockers found while supervising the Model Switchboard rollout, including PR #1907's Lemonade adapter after it landed on main.

## Verification
- python -m pytest ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py ods/extensions/services/dashboard-api/tests/test_model_activate.py ods/extensions/services/dashboard-api/tests/test_model_state.py -q (218 passed, 1 skipped)
- python -m ruff check on all affected Python files (pass)
- git diff --check (pass; Windows line-ending notices only)

## Fleet evidence
Not claimed. This strengthens the observe-mode foundation. Affected-host proof is required before routing enablement.