### PR TITLE
feat(extensions): add transactional library updates

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -3340,7 +3340,6 @@ class AgentHandler(BaseHTTPRequestHandler):
         if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
             json_response(self, 400, {"error": "Invalid service_id"})
             return
-
         ext_dir = _find_ext_dir(sid)
         if ext_dir is None:
             json_response(self, 404, {"error": f"Extension not found: {sid}"})
@@ -3404,6 +3403,10 @@ class AgentHandler(BaseHTTPRequestHandler):
         sid = body.get("service_id", "")
         if not isinstance(sid, str) or not SERVICE_ID_RE.match(sid):
             json_response(self, 400, {"error": "Invalid service_id"})
+            return
+        preserve_existing = body.get("preserve_existing", False)
+        if not isinstance(preserve_existing, bool):
+            json_response(self, 400, {"error": "preserve_existing must be a boolean"})
             return
 
         # Only user-installed extensions ship a config/ subdir for sync
@@ -3496,7 +3499,13 @@ class AgentHandler(BaseHTTPRequestHandler):
             json_response(self, 500, {"error": f"Failed to prepare config dir: {exc}"})
             return
 
-        target = (install_config / sid).resolve()
+        target_candidate = install_config / sid
+        if target_candidate.is_symlink():
+            json_response(self, 400, {
+                "error": f"config sync refused: target is a symlink for {sid}",
+            })
+            return
+        target = target_candidate.resolve()
         # Path-traversal guard: target must stay under install_config. Always true
         # because sid is validated against SERVICE_ID_RE above (no slashes / dots),
         # but kept as defense-in-depth in case the regex ever loosens.
@@ -3506,6 +3515,18 @@ class AgentHandler(BaseHTTPRequestHandler):
             })
             return
 
+        if target.is_dir():
+            for root, dirs, files in os.walk(str(target), followlinks=False):
+                for name in dirs + files:
+                    if (Path(root) / name).is_symlink():
+                        json_response(self, 400, {
+                            "error": (
+                                f"config sync refused: existing target symlink {name} "
+                                f"for {sid}"
+                            ),
+                        })
+                        return
+
         synced: list[str] = []
         lock = _service_locks[sid]
         if not lock.acquire(blocking=False):
@@ -3513,10 +3534,20 @@ class AgentHandler(BaseHTTPRequestHandler):
             return
         try:
             try:
-                shutil.copytree(
-                    str(src_svc), str(target),
-                    dirs_exist_ok=True, symlinks=False,
-                )
+                if preserve_existing:
+                    for source_path in sorted(src_svc.rglob("*")):
+                        relative = source_path.relative_to(src_svc)
+                        target_path = target / relative
+                        if source_path.is_dir():
+                            target_path.mkdir(parents=True, exist_ok=True)
+                        elif source_path.is_file() and not target_path.exists():
+                            target_path.parent.mkdir(parents=True, exist_ok=True)
+                            shutil.copy2(source_path, target_path)
+                else:
+                    shutil.copytree(
+                        str(src_svc), str(target),
+                        dirs_exist_ok=True, symlinks=False,
+                    )
                 synced.append(sid)
             except OSError as exc:
                 json_response(self, 500, {

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -3578,6 +3578,10 @@ class AgentHandler(BaseHTTPRequestHandler):
             "service_id": sid,
             "synced": synced,
             "skipped": out_of_scope,
+            # Echo the honored mode so callers can detect an agent that
+            # predates preserve_existing instead of silently full-copying
+            # over user config during update/rollback.
+            "preserve_existing": bool(preserve_existing),
         })
 
     def _handle_logs(self):

--- a/ods/docs/EXTENSIONS.md
+++ b/ods/docs/EXTENSIONS.md
@@ -139,6 +139,30 @@ ods disable my-service   # Stops container, renames compose.yaml → compose.yam
 ods list                 # Shows all services with status
 ```
 
+## Portal Updates and Rollback
+
+Extensions installed from the bundled library receive a content receipt. The
+Dashboard Extensions page compares that receipt with both the current library
+definition and the installed definition:
+
+- `current`: installed files still match the receipt and the library
+- `available`: ODS ships a newer library definition
+- `modified`: installed definition files changed locally after installation
+- `untracked`: legacy install created before content receipts were introduced
+
+An update is staged and security-scanned on the same filesystem before the
+installed directory is atomically replaced. Enabled services are reconciled
+through the host agent; disabled and one-shot CLI extensions remain disabled.
+Existing service configuration is preserved, while new default config files
+may be added when they do not already exist. Those newly added defaults are
+also preserved if the definition is rolled back.
+
+Local definition changes are never overwritten without an explicit
+confirmation. The previous definition is retained as a single rollback backup,
+and the portal exposes **Rollback** after a successful update. Update and
+rollback replace extension definitions only: service data, Docker volumes,
+secrets, and existing configuration remain in place.
+
 ## Audit Extensions Before You Ship
 
 ODS now includes an extension audit workflow so new services can be

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -13,6 +13,7 @@ import tempfile
 import threading
 import time
 from datetime import datetime, timezone
+from functools import wraps
 from pathlib import Path
 from typing import Optional
 
@@ -777,7 +778,7 @@ def _get_service_data_info(service_id: str) -> dict | None:
 
 # --- Host Agent Helpers ---
 
-_AGENT_TIMEOUT = 300  # seconds — image pulls can take several minutes on first install
+_AGENT_TIMEOUT = 660  # seconds — exceed the host agent's 600s start allowance
 _AGENT_LOG_TIMEOUT = 30  # seconds — log fetches should be fast
 
 
@@ -961,9 +962,8 @@ def _check_agent_health() -> bool:
 
 
 @contextlib.contextmanager
-def _extensions_lock():
-    """Acquire an exclusive file lock for extension mutations."""
-    lock_path = _extensions_lock_path()
+def _exclusive_file_lock(lock_path: Path):
+    """Acquire a cross-process exclusive lock for one lock file."""
     lockfile = open(lock_path, "a+b")
     try:
         if fcntl is not None:
@@ -985,6 +985,38 @@ def _extensions_lock():
                 msvcrt.locking(lockfile.fileno(), msvcrt.LK_UNLCK, 1)
         finally:
             lockfile.close()
+
+
+@contextlib.contextmanager
+def _extensions_lock():
+    """Acquire the global lock for short extension filesystem mutations."""
+    with _exclusive_file_lock(_extensions_lock_path()):
+        yield
+
+
+@contextlib.contextmanager
+def _extension_operation_lock(service_id: str):
+    """Serialize the complete lifecycle transaction for one extension."""
+    lock_parent = _extensions_lock_path().parent.resolve()
+    lock_dir = lock_parent / ".extension-operation-locks"
+    if lock_dir.is_symlink():
+        raise OSError("Extension operation lock directory is a symlink")
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    if not lock_dir.resolve().is_relative_to(lock_parent):
+        raise OSError("Invalid extension operation lock directory")
+    lock_name = hashlib.sha256(service_id.encode("utf-8")).hexdigest() + ".lock"
+    with _exclusive_file_lock(lock_dir / lock_name):
+        yield
+
+
+def _serialize_extension_operation(func):
+    """Keep same-service portal mutations serialized through runtime proof."""
+    @wraps(func)
+    def wrapped(service_id: str, *args, **kwargs):
+        with _extension_operation_lock(service_id):
+            return func(service_id, *args, **kwargs)
+
+    return wrapped
 
 
 def _extensions_lock_candidates() -> list[Path]:
@@ -1520,6 +1552,7 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
 
 
 @router.post("/api/extensions/{service_id}/install")
+@_serialize_extension_operation
 def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
     """Install an extension from the library."""
     _validate_service_id(service_id)
@@ -1637,7 +1670,79 @@ def _restore_extension_backup(service_id: str) -> bool:
         shutil.rmtree(swap_root, ignore_errors=True)
 
 
+def _start_extension_lifecycle(service_id: str) -> tuple[bool, list[str]]:
+    """Start an extension through its lifecycle hooks and return warnings."""
+    if not _call_agent_hook(service_id, "pre_start"):
+        return False, []
+    if not _call_agent("start", service_id):
+        return False, []
+    warnings: list[str] = []
+    if not _call_agent_hook(service_id, "post_start"):
+        warnings.append("post_start hook failed; review extension logs")
+    return True, warnings
+
+
+def _recover_extension_swap(
+    service_id: str,
+    *,
+    enabled: bool,
+    one_shot: bool,
+) -> list[str]:
+    """Swap back to the prior definition and prove its config/runtime state."""
+    failures: list[str] = []
+    try:
+        with _extensions_lock():
+            restored = _restore_extension_backup(service_id)
+            if restored:
+                _call_agent_invalidate_compose_cache()
+    except (OSError, HTTPException) as exc:
+        logger.error("Extension definition recovery failed for %s: %s", service_id, exc)
+        restored = False
+    if not restored:
+        return ["definition restore failed"]
+
+    try:
+        config_ok = _sync_extension_config(service_id, preserve_existing=True)
+    except Exception as exc:  # pragma: no cover - defensive boundary
+        logger.error("Extension config recovery failed for %s: %s", service_id, exc)
+        config_ok = False
+    if not config_ok:
+        failures.append("config sync failed")
+        return failures
+
+    if enabled and not one_shot:
+        try:
+            start_ok, hook_warnings = _start_extension_lifecycle(service_id)
+        except Exception as exc:  # pragma: no cover - defensive boundary
+            logger.error("Extension runtime recovery failed for %s: %s", service_id, exc)
+            start_ok, hook_warnings = False, []
+        for warning in hook_warnings:
+            logger.warning("Recovered %s with warning: %s", service_id, warning)
+        if not start_ok:
+            failures.append("restored runtime restart failed")
+    return failures
+
+
+def _transaction_failure(
+    message: str,
+    recovery_failures: list[str],
+    *,
+    recovered_label: str,
+) -> HTTPException:
+    """Build an error that does not overstate an unproven recovery."""
+    if recovery_failures:
+        return HTTPException(
+            status_code=500,
+            detail=(
+                f"{message}; recovery incomplete: "
+                + ", ".join(recovery_failures)
+            ),
+        )
+    return HTTPException(status_code=502, detail=f"{message}; {recovered_label}")
+
+
 @router.post("/api/extensions/{service_id}/update")
+@_serialize_extension_operation
 def update_extension(
     service_id: str,
     force: bool = Query(False),
@@ -1681,13 +1786,19 @@ def update_extension(
             )
 
         enabled = (dest / "compose.yaml").is_file()
-        disabled = (dest / "compose.yaml.disabled").is_file()
-        if not enabled and not disabled:
-            raise HTTPException(status_code=409, detail="Installed extension has no compose definition")
+        if not _set_extension_compose_state(dest, enabled=enabled):
+            raise HTTPException(
+                status_code=409,
+                detail="Installed extension has an invalid compose state",
+            )
+        disabled = not enabled
 
         with _staged_library_extension(service_id, dest) as (staged, source_digest):
-            if disabled:
-                os.replace(staged / "compose.yaml", staged / "compose.yaml.disabled")
+            if not _set_extension_compose_state(staged, enabled=enabled):
+                raise HTTPException(
+                    status_code=409,
+                    detail="Library extension has an invalid compose state",
+                )
             installed_digest = _extension_tree_digest(staged)
             _write_library_receipt(
                 staged,
@@ -1696,6 +1807,8 @@ def update_extension(
             )
             if backup.parent.is_symlink() or backup.is_symlink():
                 raise HTTPException(status_code=409, detail="Extension backup path is a symlink")
+            if backup.exists() and not backup.is_dir():
+                raise HTTPException(status_code=409, detail="Extension backup path is not a directory")
             if backup.exists():
                 shutil.rmtree(backup)
             backup.parent.mkdir(parents=True, exist_ok=True)
@@ -1708,31 +1821,31 @@ def update_extension(
             _invalidate_extension_digest_cache(dest, backup, staged)
             _call_agent_invalidate_compose_cache()
 
-    if not _sync_extension_config(service_id, preserve_existing=True):
-        with _extensions_lock():
-            _restore_extension_backup(service_id)
-            _call_agent_invalidate_compose_cache()
-        raise HTTPException(
-            status_code=502,
-            detail="Extension update rolled back because config sync failed",
-        )
-
     ext = next((entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {})
     one_shot = _is_one_shot_extension(ext)
+    if not _sync_extension_config(service_id, preserve_existing=True):
+        recovery_failures = _recover_extension_swap(
+            service_id, enabled=enabled, one_shot=one_shot,
+        )
+        raise _transaction_failure(
+            "Extension update config sync failed",
+            recovery_failures,
+            recovered_label="previous definition restored",
+        )
+
     warnings: list[str] = []
     if enabled and not one_shot:
-        if not _call_agent_hook(service_id, "pre_start") or not _call_agent("start", service_id):
-            with _extensions_lock():
-                _restore_extension_backup(service_id)
-                _call_agent_invalidate_compose_cache()
-            _sync_extension_config(service_id, preserve_existing=True)
-            _call_agent("start", service_id)
-            raise HTTPException(
-                status_code=502,
-                detail="Extension update failed to start and was rolled back",
+        start_ok, start_warnings = _start_extension_lifecycle(service_id)
+        if not start_ok:
+            recovery_failures = _recover_extension_swap(
+                service_id, enabled=enabled, one_shot=one_shot,
             )
-        if not _call_agent_hook(service_id, "post_start"):
-            warnings.append("post_start hook failed; review extension logs")
+            raise _transaction_failure(
+                "Extension update failed to start",
+                recovery_failures,
+                recovered_label="previous definition restored",
+            )
+        warnings.extend(start_warnings)
 
     _clear_progress(service_id)
     logger.info("Updated extension from library: %s", service_id)
@@ -1753,6 +1866,7 @@ def update_extension(
 
 
 @router.post("/api/extensions/{service_id}/rollback")
+@_serialize_extension_operation
 def rollback_extension_update(
     service_id: str,
     api_key: str = Depends(verify_api_key),
@@ -1760,19 +1874,17 @@ def rollback_extension_update(
     """Restore the immediately previous library definition."""
     _validate_service_id(service_id)
     _assert_not_core(service_id)
-    progress = _read_progress(service_id)
-    if progress and progress.get("status") in {"pulling", "setup_hook", "starting"}:
-        raise HTTPException(status_code=409, detail="Extension operation is still in progress")
-
     dest = USER_EXTENSIONS_DIR / service_id
     backup = _extension_backup_dir(service_id)
-    if (not dest.is_dir() or dest.is_symlink()
-            or not backup.is_dir() or backup.is_symlink()):
-        raise HTTPException(status_code=404, detail="No extension update backup is available")
     with _extensions_lock():
+        progress = _read_progress(service_id)
+        if progress and progress.get("status") in {"pulling", "setup_hook", "starting"}:
+            raise HTTPException(status_code=409, detail="Extension operation is still in progress")
+        if (not dest.is_dir() or dest.is_symlink()
+                or not backup.is_dir() or backup.is_symlink()):
+            raise HTTPException(status_code=404, detail="No extension update backup is available")
         enabled = (dest / "compose.yaml").is_file()
-        disabled = (dest / "compose.yaml.disabled").is_file()
-        if enabled == disabled:
+        if not _set_extension_compose_state(dest, enabled=enabled):
             raise HTTPException(
                 status_code=409,
                 detail="Installed extension has an invalid compose state",
@@ -1789,21 +1901,31 @@ def rollback_extension_update(
             raise HTTPException(status_code=500, detail="Could not restore extension backup")
         _call_agent_invalidate_compose_cache()
 
-    if not _sync_extension_config(service_id, preserve_existing=True):
-        with _extensions_lock():
-            _restore_extension_backup(service_id)
-            _call_agent_invalidate_compose_cache()
-        raise HTTPException(status_code=502, detail="Rollback config sync failed; current definition restored")
-
     ext = next((entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {})
     one_shot = _is_one_shot_extension(ext)
+    if not _sync_extension_config(service_id, preserve_existing=True):
+        recovery_failures = _recover_extension_swap(
+            service_id, enabled=enabled, one_shot=one_shot,
+        )
+        raise _transaction_failure(
+            "Rollback config sync failed",
+            recovery_failures,
+            recovered_label="updated definition restored",
+        )
+
+    warnings: list[str] = []
     if enabled and not one_shot:
-        if not _call_agent("start", service_id):
-            with _extensions_lock():
-                _restore_extension_backup(service_id)
-                _call_agent_invalidate_compose_cache()
-            _call_agent("start", service_id)
-            raise HTTPException(status_code=502, detail="Rollback failed to start; updated definition restored")
+        start_ok, start_warnings = _start_extension_lifecycle(service_id)
+        if not start_ok:
+            recovery_failures = _recover_extension_swap(
+                service_id, enabled=enabled, one_shot=one_shot,
+            )
+            raise _transaction_failure(
+                "Rollback failed to start",
+                recovery_failures,
+                recovered_label="updated definition restored",
+            )
+        warnings.extend(start_warnings)
 
     _clear_progress(service_id)
     logger.info("Rolled back extension update: %s", service_id)
@@ -1812,6 +1934,7 @@ def rollback_extension_update(
         "action": "rolled_back",
         "rollback_available": True,
         "restart_required": False,
+        "warnings": warnings,
         "message": "Previous extension definition restored.",
     }
 
@@ -1953,6 +2076,7 @@ def _activate_service(service_id: str) -> dict:
 
 
 @router.post("/api/extensions/{service_id}/enable")
+@_serialize_extension_operation
 def enable_extension(
     service_id: str,
     auto_enable_deps: bool = Query(False),
@@ -2081,6 +2205,7 @@ def enable_extension(
 
 
 @router.post("/api/extensions/{service_id}/disable")
+@_serialize_extension_operation
 def disable_extension(service_id: str, include_data_info: bool = Query(True), api_key: str = Depends(verify_api_key)):
     """Disable an enabled extension."""
     _validate_service_id(service_id)
@@ -2170,6 +2295,7 @@ def disable_extension(service_id: str, include_data_info: bool = Query(True), ap
 
 
 @router.delete("/api/extensions/{service_id}")
+@_serialize_extension_operation
 def uninstall_extension(service_id: str, include_data_info: bool = Query(True), api_key: str = Depends(verify_api_key)):
     """Uninstall a disabled extension."""
     _validate_service_id(service_id)
@@ -2237,6 +2363,7 @@ class PurgeRequest(BaseModel):
 
 
 @router.delete("/api/extensions/{service_id}/data")
+@_serialize_extension_operation
 def purge_extension_data(
     service_id: str,
     body: PurgeRequest,

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -56,6 +56,12 @@ _extension_digest_cache: dict[str, tuple[tuple, str]] = {}
 _extension_digest_cache_lock = threading.Lock()
 
 
+def _invalidate_extension_digest_cache(*roots: Path) -> None:
+    with _extension_digest_cache_lock:
+        for root in roots:
+            _extension_digest_cache.pop(str(root.resolve(strict=False)), None)
+
+
 def _extension_tree_digest(root: Path) -> str:
     """Return a deterministic digest for extension definitions under root."""
     entries: list[tuple] = []
@@ -68,11 +74,15 @@ def _extension_tree_digest(root: Path) -> str:
         if path.is_symlink():
             entries.append(("L", canonical, os.readlink(path)))
         elif path.is_dir():
-            entries.append(("D", canonical, path.stat().st_mtime_ns))
+            stat_result = path.stat()
+            entries.append((
+                "D", canonical, stat_result.st_mtime_ns, stat_result.st_ctime_ns,
+            ))
         elif path.is_file():
             stat_result = path.stat()
             entries.append((
                 "F", canonical, stat_result.st_size, stat_result.st_mtime_ns,
+                stat_result.st_ctime_ns,
                 bool(stat_result.st_mode & 0o111),
             ))
     signature = tuple(entries)
@@ -1357,8 +1367,11 @@ def _staged_library_extension(service_id: str, dest: Path):
         raise HTTPException(status_code=409, detail="Extension temporary path is a symlink")
     tmp_parent.mkdir(parents=True, exist_ok=True)
     tmpdir = tempfile.mkdtemp(prefix=f".{service_id}-", dir=str(tmp_parent))
+    staged: Path | None = None
     try:
         staged = Path(tmpdir) / service_id
+        _invalidate_extension_digest_cache(source)
+        source_digest_before = _extension_tree_digest(source)
         _copytree_safe(source, staged)
         # Security scan the staged copy (prevents TOCTOU)
         staged_compose = staged / "compose.yaml"
@@ -1370,8 +1383,17 @@ def _staged_library_extension(service_id: str, dest: Path):
             # (INSTALL_DIR), not the extension dir, so "context: ." would
             # look for the Dockerfile in INSTALL_DIR/Dockerfile and fail.
             _rewrite_build_context(staged_compose, dest.resolve())
-        yield staged, _extension_tree_digest(source)
+        _invalidate_extension_digest_cache(source)
+        source_digest_after = _extension_tree_digest(source)
+        if source_digest_before != source_digest_after:
+            raise HTTPException(
+                status_code=409,
+                detail="Extension library changed while the update was being staged; retry",
+            )
+        yield staged, source_digest_after
     finally:
+        if staged is not None:
+            _invalidate_extension_digest_cache(staged)
         if Path(tmpdir).exists():
             shutil.rmtree(tmpdir, ignore_errors=True)
 
@@ -1408,6 +1430,7 @@ def _install_from_library(service_id: str) -> None:
             installed_digest=installed_digest,
         )
         os.rename(str(staged), str(dest))
+        _invalidate_extension_digest_cache(dest)
 
 
 def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
@@ -1590,6 +1613,7 @@ def _restore_extension_backup(service_id: str) -> bool:
             raise
         backup.parent.mkdir(parents=True, exist_ok=True)
         os.replace(current, backup)
+        _invalidate_extension_digest_cache(dest, backup, current)
         return True
     finally:
         shutil.rmtree(swap_root, ignore_errors=True)
@@ -1663,6 +1687,7 @@ def update_extension(
             except OSError:
                 os.replace(backup, dest)
                 raise
+            _invalidate_extension_digest_cache(dest, backup, staged)
             _call_agent_invalidate_compose_cache()
 
     if not _sync_extension_config(service_id, preserve_existing=True):
@@ -2161,6 +2186,7 @@ def uninstall_extension(service_id: str, include_data_info: bool = Query(True), 
             backup.unlink(missing_ok=True)
         elif backup.is_dir():
             shutil.rmtree(backup)
+        _invalidate_extension_digest_cache(ext_dir, backup)
 
         progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"
         progress_file.unlink(missing_ok=True)

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import contextlib
+import hashlib
 import json
 import logging
 import os
@@ -49,6 +50,128 @@ router = APIRouter(tags=["extensions"])
 
 _SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 _MAX_EXTENSION_BYTES = 50 * 1024 * 1024  # 50 MB
+_LIBRARY_RECEIPT = ".ods-library-receipt.json"
+_LIBRARY_RECEIPT_SCHEMA = 1
+_extension_digest_cache: dict[str, tuple[tuple, str]] = {}
+_extension_digest_cache_lock = threading.Lock()
+
+
+def _extension_tree_digest(root: Path) -> str:
+    """Return a deterministic digest for extension definitions under root."""
+    entries: list[tuple] = []
+    paths = sorted(root.rglob("*"), key=lambda item: item.relative_to(root).as_posix())
+    for path in paths:
+        relative = path.relative_to(root).as_posix()
+        if relative == _LIBRARY_RECEIPT:
+            continue
+        canonical = "compose.yaml" if relative == "compose.yaml.disabled" else relative
+        if path.is_symlink():
+            entries.append(("L", canonical, os.readlink(path)))
+        elif path.is_dir():
+            entries.append(("D", canonical, path.stat().st_mtime_ns))
+        elif path.is_file():
+            stat_result = path.stat()
+            entries.append((
+                "F", canonical, stat_result.st_size, stat_result.st_mtime_ns,
+                bool(stat_result.st_mode & 0o111),
+            ))
+    signature = tuple(entries)
+    cache_key = str(root.resolve())
+    with _extension_digest_cache_lock:
+        cached = _extension_digest_cache.get(cache_key)
+        if cached and cached[0] == signature:
+            return cached[1]
+
+    digest = hashlib.sha256()
+    for path in paths:
+        relative = path.relative_to(root).as_posix()
+        if relative == _LIBRARY_RECEIPT:
+            continue
+        canonical = "compose.yaml" if relative == "compose.yaml.disabled" else relative
+        if path.is_symlink():
+            digest.update(f"L\0{canonical}\0{os.readlink(path)}\0".encode())
+            continue
+        if path.is_dir():
+            digest.update(f"D\0{canonical}\0".encode())
+            continue
+        if not path.is_file():
+            continue
+        executable = bool(path.stat().st_mode & 0o111)
+        digest.update(f"F\0{canonical}\0{int(executable)}\0".encode())
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        digest.update(b"\0")
+    result = digest.hexdigest()
+    with _extension_digest_cache_lock:
+        _extension_digest_cache[cache_key] = (signature, result)
+    return result
+
+
+def _read_library_receipt(extension_dir: Path) -> dict | None:
+    receipt_path = extension_dir / _LIBRARY_RECEIPT
+    try:
+        data = json.loads(receipt_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict) or data.get("schema_version") != _LIBRARY_RECEIPT_SCHEMA:
+        return None
+    required = ("source_digest", "installed_digest")
+    if any(not isinstance(data.get(key), str) or not data[key] for key in required):
+        return None
+    return data
+
+
+def _write_library_receipt(
+    extension_dir: Path,
+    *,
+    source_digest: str,
+    installed_digest: str,
+) -> None:
+    receipt = {
+        "schema_version": _LIBRARY_RECEIPT_SCHEMA,
+        "source_digest": source_digest,
+        "installed_digest": installed_digest,
+        "installed_at": datetime.now(timezone.utc).isoformat(),
+    }
+    receipt_path = extension_dir / _LIBRARY_RECEIPT
+    temporary = receipt_path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(receipt, sort_keys=True), encoding="utf-8")
+    os.replace(temporary, receipt_path)
+
+
+def _library_update_state(service_id: str) -> dict:
+    """Describe update/rollback state for one user-installed library extension."""
+    installed = USER_EXTENSIONS_DIR / service_id
+    source = EXTENSIONS_LIBRARY_DIR / service_id
+    backup = USER_EXTENSIONS_DIR / ".backups" / service_id
+    state = {
+        "update_status": "unavailable",
+        "update_available": False,
+        "locally_modified": False,
+        "rollback_available": backup.is_dir() and not backup.is_symlink(),
+    }
+    if not installed.is_dir() or not source.is_dir() or not (source / "compose.yaml").is_file():
+        return state
+    receipt = _read_library_receipt(installed)
+    if receipt is None:
+        state["update_status"] = "untracked"
+        return state
+    try:
+        source_digest = _extension_tree_digest(source)
+        installed_digest = _extension_tree_digest(installed)
+    except OSError:
+        state["update_status"] = "unknown"
+        return state
+    state["update_available"] = source_digest != receipt["source_digest"]
+    state["locally_modified"] = installed_digest != receipt["installed_digest"]
+    if state["locally_modified"]:
+        state["update_status"] = "modified"
+    elif state["update_available"]:
+        state["update_status"] = "available"
+    else:
+        state["update_status"] = "current"
+    return state
 
 
 def _is_stale(iso_timestamp: str, max_age_seconds: int) -> bool:
@@ -141,7 +264,7 @@ def _clear_progress(service_id: str) -> None:
         logger.warning("Failed to clear progress file for %s: %s", service_id, exc)
 
 
-def _sync_extension_config(service_id: str) -> bool:
+def _sync_extension_config(service_id: str, *, preserve_existing: bool = False) -> bool:
     """Ask host agent to copy config/<id>/ from an installed extension
     into INSTALL_DIR/config/.
 
@@ -157,7 +280,7 @@ def _sync_extension_config(service_id: str) -> bool:
     extension has no config/ subdir), False if the agent rejected the
     request or was unreachable.
     """
-    return _call_agent_sync_config(service_id)
+    return _call_agent_sync_config(service_id, preserve_existing=preserve_existing)
 
 
 def _is_one_shot_extension(ext: dict) -> bool:
@@ -753,7 +876,7 @@ def _call_agent_install(service_id: str) -> bool:
         return False
 
 
-def _call_agent_sync_config(service_id: str) -> bool:
+def _call_agent_sync_config(service_id: str, *, preserve_existing: bool = False) -> bool:
     """Ask host agent to copy <ext>/config/* into INSTALL_DIR/config/.
 
     The dashboard-api container has /ods/config bind-mounted
@@ -768,7 +891,10 @@ def _call_agent_sync_config(service_id: str) -> bool:
         request_agent_json(
             "POST",
             "/v1/extension/sync_config",
-            payload={"service_id": service_id},
+            payload={
+                "service_id": service_id,
+                "preserve_existing": preserve_existing,
+            },
             timeout=_AGENT_TIMEOUT,
         )
         return True
@@ -931,6 +1057,16 @@ async def extensions_catalog(
                 status="healthy", response_time_ms=None,
             )
 
+    user_extension_ids = [
+        entry["id"] for entry in EXTENSION_CATALOG
+        if (USER_EXTENSIONS_DIR / entry["id"]).is_dir()
+    ]
+    update_results = await asyncio.gather(*[
+        asyncio.to_thread(_library_update_state, service_id)
+        for service_id in user_extension_ids
+    ])
+    update_states = dict(zip(user_extension_ids, update_results))
+
     extensions = []
     for ext in EXTENSION_CATALOG:
         status = _compute_extension_status(ext, services_by_id)
@@ -939,6 +1075,12 @@ async def extensions_catalog(
         user_dir = USER_EXTENSIONS_DIR / ext_id
         source = "user" if user_dir.is_dir() else ("core" if ext_id in SERVICES else "library")
         has_data = (Path(DATA_DIR) / ext_id).is_dir()
+        update_state = update_states.get(ext_id, {
+            "update_status": "unavailable",
+            "update_available": False,
+            "locally_modified": False,
+            "rollback_available": False,
+        })
         enriched = {
             **ext,
             "status": status,
@@ -948,6 +1090,7 @@ async def extensions_catalog(
             "depends_on": ext.get("depends_on", []),
             "dependents": [],
             "dependency_status": {},
+            **update_state,
         }
         llm_contract = _llm_contract_for_extension(ext)
         if llm_contract is not None:
@@ -1003,6 +1146,7 @@ async def extensions_catalog(
         "error": sum(1 for e in extensions if e["status"] == "error"),
         "not_installed": sum(1 for e in extensions if e["status"] == "not_installed"),
         "incompatible": sum(1 for e in extensions if e["status"] == "incompatible"),
+        "updates_available": sum(1 for e in extensions if e["update_available"]),
     }
 
     try:
@@ -1091,6 +1235,12 @@ async def extension_detail(
 
     user_dir = USER_EXTENSIONS_DIR / service_id
     source = "user" if user_dir.is_dir() else ("core" if service_id in SERVICES else "library")
+    update_state = await asyncio.to_thread(_library_update_state, service_id) if source == "user" else {
+        "update_status": "unavailable",
+        "update_available": False,
+        "locally_modified": False,
+        "rollback_available": False,
+    }
 
     # See extensions_catalog: same rationale for inlining the install error.
     error_message: Optional[str] = None
@@ -1111,6 +1261,7 @@ async def extension_detail(
         "manifest": manifest,
         "env_vars": ext.get("env_vars", []),
         "features": ext.get("features", []),
+        **update_state,
         "setup_instructions": {
             "steps": [
                 f"Run 'ods enable {service_id}' to install and start the service",
@@ -1150,16 +1301,9 @@ async def extension_logs(
         raise HTTPException(status_code=502, detail=f"Invalid host agent response: {exc}") from exc
 
 
-def _install_from_library(service_id: str) -> None:
-    """Copy an extension from the library to USER_EXTENSIONS_DIR atomically.
-
-    Must be called inside _extensions_lock() by the caller. Performs the
-    library path check, size check, and atomic stage+rename. Does NOT call
-    hooks or start the container — that's the caller's responsibility.
-
-    Raises HTTPException on failure.
-    """
-    # Verify library is accessible
+@contextlib.contextmanager
+def _staged_library_extension(service_id: str, dest: Path):
+    """Yield a validated, rewritten library copy on the destination filesystem."""
     try:
         lib_available = EXTENSIONS_LIBRARY_DIR.is_dir()
     except OSError:
@@ -1197,23 +1341,6 @@ def _install_from_library(service_id: str) -> None:
             ),
         )
 
-    dest = USER_EXTENSIONS_DIR / service_id
-
-    # Re-check under lock to prevent double-install race
-    if dest.exists():
-        has_compose = (dest / "compose.yaml").exists()
-        has_disabled = (dest / "compose.yaml.disabled").exists()
-        if (has_compose or has_disabled) and not _has_error_progress(service_id):
-            raise HTTPException(
-                status_code=409,
-                detail=f"Extension already installed: {service_id}",
-            )
-        # Broken or failed directory — clean up before reinstall.
-        logger.warning("Cleaning up extension directory under lock before retry: %s", dest)
-        shutil.rmtree(dest)
-        _clear_progress(service_id)
-
-    # Size check
     total_size = 0
     for root, _dirs, files in os.walk(source):
         for f in files:
@@ -1226,6 +1353,8 @@ def _install_from_library(service_id: str) -> None:
 
     USER_EXTENSIONS_DIR.mkdir(parents=True, exist_ok=True)
     tmp_parent = USER_EXTENSIONS_DIR / ".tmp"
+    if tmp_parent.is_symlink():
+        raise HTTPException(status_code=409, detail="Extension temporary path is a symlink")
     tmp_parent.mkdir(parents=True, exist_ok=True)
     tmpdir = tempfile.mkdtemp(prefix=f".{service_id}-", dir=str(tmp_parent))
     try:
@@ -1241,10 +1370,44 @@ def _install_from_library(service_id: str) -> None:
             # (INSTALL_DIR), not the extension dir, so "context: ." would
             # look for the Dockerfile in INSTALL_DIR/Dockerfile and fail.
             _rewrite_build_context(staged_compose, dest.resolve())
-        os.rename(str(staged), str(dest))
+        yield staged, _extension_tree_digest(source)
     finally:
         if Path(tmpdir).exists():
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _install_from_library(service_id: str) -> None:
+    """Copy an extension from the library to USER_EXTENSIONS_DIR atomically.
+
+    Must be called inside _extensions_lock() by the caller. Performs the
+    library path check, size check, and atomic stage+rename. Does NOT call
+    hooks or start the container — that's the caller's responsibility.
+
+    Raises HTTPException on failure.
+    """
+    dest = USER_EXTENSIONS_DIR / service_id
+
+    # Re-check under lock to prevent double-install race.
+    if dest.exists():
+        has_compose = (dest / "compose.yaml").exists()
+        has_disabled = (dest / "compose.yaml.disabled").exists()
+        if (has_compose or has_disabled) and not _has_error_progress(service_id):
+            raise HTTPException(
+                status_code=409,
+                detail=f"Extension already installed: {service_id}",
+            )
+        logger.warning("Cleaning up extension directory under lock before retry: %s", dest)
+        shutil.rmtree(dest)
+        _clear_progress(service_id)
+
+    with _staged_library_extension(service_id, dest) as (staged, source_digest):
+        installed_digest = _extension_tree_digest(staged)
+        _write_library_receipt(
+            staged,
+            source_digest=source_digest,
+            installed_digest=installed_digest,
+        )
+        os.rename(str(staged), str(dest))
 
 
 def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
@@ -1396,6 +1559,204 @@ def install_extension(service_id: str, api_key: str = Depends(verify_api_key)):
             "Extension installed and starting." if agent_ok
             else "Extension installed. Run 'ods restart' to start."
         ),
+    }
+
+
+def _extension_backup_dir(service_id: str) -> Path:
+    return USER_EXTENSIONS_DIR / ".backups" / service_id
+
+
+def _restore_extension_backup(service_id: str) -> bool:
+    """Restore the previous definition while retaining the failed update as backup."""
+    dest = USER_EXTENSIONS_DIR / service_id
+    backup = _extension_backup_dir(service_id)
+    if backup.parent.is_symlink():
+        return False
+    if (not dest.is_dir() or dest.is_symlink()
+            or not backup.is_dir() or backup.is_symlink()):
+        return False
+    swap_parent = USER_EXTENSIONS_DIR / ".tmp"
+    if swap_parent.is_symlink():
+        return False
+    swap_parent.mkdir(parents=True, exist_ok=True)
+    swap_root = Path(tempfile.mkdtemp(prefix=f".{service_id}-rollback-", dir=swap_parent))
+    current = swap_root / service_id
+    try:
+        os.replace(dest, current)
+        try:
+            os.replace(backup, dest)
+        except OSError:
+            os.replace(current, dest)
+            raise
+        backup.parent.mkdir(parents=True, exist_ok=True)
+        os.replace(current, backup)
+        return True
+    finally:
+        shutil.rmtree(swap_root, ignore_errors=True)
+
+
+@router.post("/api/extensions/{service_id}/update")
+def update_extension(
+    service_id: str,
+    force: bool = Query(False),
+    api_key: str = Depends(verify_api_key),
+):
+    """Atomically refresh a user extension from the bundled library."""
+    _validate_service_id(service_id)
+    _assert_not_core(service_id)
+    dest = USER_EXTENSIONS_DIR / service_id
+    if (dest.is_symlink() or not dest.resolve().is_relative_to(USER_EXTENSIONS_DIR.resolve())
+            or not dest.is_dir()):
+        raise HTTPException(status_code=404, detail=f"Extension not installed: {service_id}")
+    if not _is_installable(service_id):
+        raise HTTPException(status_code=409, detail="No deployable library update is available")
+
+    backup = _extension_backup_dir(service_id)
+    with _extensions_lock():
+        progress = _read_progress(service_id)
+        if progress and progress.get("status") in {"pulling", "setup_hook", "starting"}:
+            raise HTTPException(status_code=409, detail="Extension operation is still in progress")
+        state = _library_update_state(service_id)
+        if state["update_status"] == "current" and not force:
+            raise HTTPException(status_code=409, detail="Extension is already current")
+        if state["update_status"] == "untracked" and not force:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": "This legacy install has no library receipt; confirm refresh to create one",
+                    "code": "untracked_install",
+                    "force_available": True,
+                },
+            )
+        if state["locally_modified"] and not force:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": "Local extension files changed after install; confirm update to preserve them as rollback backup",
+                    "code": "locally_modified",
+                    "force_available": True,
+                },
+            )
+
+        enabled = (dest / "compose.yaml").is_file()
+        disabled = (dest / "compose.yaml.disabled").is_file()
+        if not enabled and not disabled:
+            raise HTTPException(status_code=409, detail="Installed extension has no compose definition")
+
+        with _staged_library_extension(service_id, dest) as (staged, source_digest):
+            if disabled:
+                os.replace(staged / "compose.yaml", staged / "compose.yaml.disabled")
+            installed_digest = _extension_tree_digest(staged)
+            _write_library_receipt(
+                staged,
+                source_digest=source_digest,
+                installed_digest=installed_digest,
+            )
+            if backup.parent.is_symlink() or backup.is_symlink():
+                raise HTTPException(status_code=409, detail="Extension backup path is a symlink")
+            if backup.exists():
+                shutil.rmtree(backup)
+            backup.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(dest, backup)
+            try:
+                os.replace(staged, dest)
+            except OSError:
+                os.replace(backup, dest)
+                raise
+            _call_agent_invalidate_compose_cache()
+
+    if not _sync_extension_config(service_id, preserve_existing=True):
+        with _extensions_lock():
+            _restore_extension_backup(service_id)
+            _call_agent_invalidate_compose_cache()
+        raise HTTPException(
+            status_code=502,
+            detail="Extension update rolled back because config sync failed",
+        )
+
+    ext = next((entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {})
+    one_shot = _is_one_shot_extension(ext)
+    warnings: list[str] = []
+    if enabled and not one_shot:
+        if not _call_agent_hook(service_id, "pre_start") or not _call_agent("start", service_id):
+            with _extensions_lock():
+                _restore_extension_backup(service_id)
+                _call_agent_invalidate_compose_cache()
+            _sync_extension_config(service_id, preserve_existing=True)
+            _call_agent("start", service_id)
+            raise HTTPException(
+                status_code=502,
+                detail="Extension update failed to start and was rolled back",
+            )
+        if not _call_agent_hook(service_id, "post_start"):
+            warnings.append("post_start hook failed; review extension logs")
+
+    _clear_progress(service_id)
+    logger.info("Updated extension from library: %s", service_id)
+    return {
+        "id": service_id,
+        "action": "updated",
+        "rollback_available": True,
+        "restart_required": False,
+        "warnings": warnings,
+        "message": (
+            "Extension definition updated; disabled state preserved."
+            if disabled else
+            "Extension updated and started."
+            if not one_shot else
+            "CLI extension updated."
+        ),
+    }
+
+
+@router.post("/api/extensions/{service_id}/rollback")
+def rollback_extension_update(
+    service_id: str,
+    api_key: str = Depends(verify_api_key),
+):
+    """Restore the immediately previous library definition."""
+    _validate_service_id(service_id)
+    _assert_not_core(service_id)
+    progress = _read_progress(service_id)
+    if progress and progress.get("status") in {"pulling", "setup_hook", "starting"}:
+        raise HTTPException(status_code=409, detail="Extension operation is still in progress")
+
+    dest = USER_EXTENSIONS_DIR / service_id
+    backup = _extension_backup_dir(service_id)
+    if (not dest.is_dir() or dest.is_symlink()
+            or not backup.is_dir() or backup.is_symlink()):
+        raise HTTPException(status_code=404, detail="No extension update backup is available")
+    enabled = (dest / "compose.yaml").is_file()
+
+    with _extensions_lock():
+        if not _restore_extension_backup(service_id):
+            raise HTTPException(status_code=500, detail="Could not restore extension backup")
+        _call_agent_invalidate_compose_cache()
+
+    if not _sync_extension_config(service_id, preserve_existing=True):
+        with _extensions_lock():
+            _restore_extension_backup(service_id)
+            _call_agent_invalidate_compose_cache()
+        raise HTTPException(status_code=502, detail="Rollback config sync failed; current definition restored")
+
+    ext = next((entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {})
+    one_shot = _is_one_shot_extension(ext)
+    if enabled and not one_shot:
+        if not _call_agent("start", service_id):
+            with _extensions_lock():
+                _restore_extension_backup(service_id)
+                _call_agent_invalidate_compose_cache()
+            _call_agent("start", service_id)
+            raise HTTPException(status_code=502, detail="Rollback failed to start; updated definition restored")
+
+    _clear_progress(service_id)
+    logger.info("Rolled back extension update: %s", service_id)
+    return {
+        "id": service_id,
+        "action": "rolled_back",
+        "rollback_available": True,
+        "restart_required": False,
+        "message": "Previous extension definition restored.",
     }
 
 
@@ -1758,7 +2119,10 @@ def uninstall_extension(service_id: str, include_data_info: bool = Query(True), 
     _validate_service_id(service_id)
     _assert_not_core(service_id)
 
-    ext_dir = (USER_EXTENSIONS_DIR / service_id).resolve()
+    ext_candidate = USER_EXTENSIONS_DIR / service_id
+    if ext_candidate.is_symlink():
+        raise HTTPException(status_code=400, detail="Extension directory is a symlink")
+    ext_dir = ext_candidate.resolve()
     if not ext_dir.is_relative_to(USER_EXTENSIONS_DIR.resolve()):
         raise HTTPException(
             status_code=404, detail=f"Extension not found: {service_id}",
@@ -1789,6 +2153,14 @@ def uninstall_extension(service_id: str, include_data_info: bool = Query(True), 
             logger.error("Failed to remove extension %s: %s", service_id, e)
             raise HTTPException(status_code=500, detail=f"Failed to remove extension files: {e}")
         _call_agent_invalidate_compose_cache()
+
+        backup = _extension_backup_dir(service_id)
+        if backup.parent.is_symlink():
+            logger.warning("Refusing to clean extension backup through symlink: %s", backup.parent)
+        elif backup.is_symlink():
+            backup.unlink(missing_ok=True)
+        elif backup.is_dir():
+            shutil.rmtree(backup)
 
         progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"
         progress_file.unlink(missing_ok=True)

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1589,6 +1589,24 @@ def _extension_backup_dir(service_id: str) -> Path:
     return USER_EXTENSIONS_DIR / ".backups" / service_id
 
 
+def _set_extension_compose_state(extension_dir: Path, *, enabled: bool) -> bool:
+    """Normalize an extension definition to the requested operational state."""
+    active = extension_dir / "compose.yaml"
+    inactive = extension_dir / "compose.yaml.disabled"
+    if active.is_symlink() or inactive.is_symlink():
+        return False
+
+    has_active = active.is_file()
+    has_inactive = inactive.is_file()
+    if has_active == has_inactive:
+        return False
+    if has_active == enabled:
+        return True
+
+    os.replace(inactive if enabled else active, active if enabled else inactive)
+    return True
+
+
 def _restore_extension_backup(service_id: str) -> bool:
     """Restore the previous definition while retaining the failed update as backup."""
     dest = USER_EXTENSIONS_DIR / service_id
@@ -1751,9 +1769,22 @@ def rollback_extension_update(
     if (not dest.is_dir() or dest.is_symlink()
             or not backup.is_dir() or backup.is_symlink()):
         raise HTTPException(status_code=404, detail="No extension update backup is available")
-    enabled = (dest / "compose.yaml").is_file()
-
     with _extensions_lock():
+        enabled = (dest / "compose.yaml").is_file()
+        disabled = (dest / "compose.yaml.disabled").is_file()
+        if enabled == disabled:
+            raise HTTPException(
+                status_code=409,
+                detail="Installed extension has an invalid compose state",
+            )
+        # Rollback changes the definition, not the user's current enablement.
+        # Normalize the backup before swapping so the restored directory and
+        # runtime start decision cannot disagree.
+        if not _set_extension_compose_state(backup, enabled=enabled):
+            raise HTTPException(
+                status_code=409,
+                detail="Extension update backup has an invalid compose state",
+            )
         if not _restore_extension_backup(service_id):
             raise HTTPException(status_code=500, detail="Could not restore extension backup")
         _call_agent_invalidate_compose_cache()

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1013,6 +1013,8 @@ def _serialize_extension_operation(func):
     """Keep same-service portal mutations serialized through runtime proof."""
     @wraps(func)
     def wrapped(service_id: str, *args, **kwargs):
+        if not _SERVICE_ID_RE.match(service_id):
+            return func(service_id, *args, **kwargs)
         with _extension_operation_lock(service_id):
             return func(service_id, *args, **kwargs)
 

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -195,6 +195,26 @@ def _is_stale(iso_timestamp: str, max_age_seconds: int) -> bool:
         return True
 
 
+def _progress_blocks_mutation(progress: dict | None) -> bool:
+    """True while an in-flight operation should block update/rollback.
+
+    A routine synchronous start writes an initial 'pulling' record that the
+    agent's sync path never advances or clears; mirroring
+    _compute_extension_status, a never-advanced record (started_at ==
+    updated_at) older than 2 minutes is treated as abandoned instead of
+    blocking mutations for the full progress TTL.
+    """
+    if not progress:
+        return False
+    if progress.get("status") not in {"pulling", "setup_hook", "starting"}:
+        return False
+    started = progress.get("started_at", "")
+    updated = progress.get("updated_at", "")
+    if started and started == updated and _is_stale(updated, max_age_seconds=120):
+        return False
+    return True
+
+
 def _read_progress(service_id: str) -> dict | None:
     """Read progress file for a service. Returns None if no active progress."""
     progress_file = Path(DATA_DIR) / "extension-progress" / f"{service_id}.json"
@@ -899,7 +919,7 @@ def _call_agent_sync_config(service_id: str, *, preserve_existing: bool = False)
     was unreachable.
     """
     try:
-        request_agent_json(
+        response = request_agent_json(
             "POST",
             "/v1/extension/sync_config",
             payload={
@@ -908,6 +928,20 @@ def _call_agent_sync_config(service_id: str, *, preserve_existing: bool = False)
             },
             timeout=_AGENT_TIMEOUT,
         )
+        if preserve_existing and (
+            not isinstance(response, dict)
+            or response.get("preserve_existing") is not True
+        ):
+            # An agent that predates preserve_existing ignores the flag and
+            # full-copies definition defaults over user config (ODS
+            # self-upgrade window). Treat the missing echo as failure so the
+            # caller's recovery path runs instead of reporting a clean sync.
+            logger.warning(
+                "sync_config for %s did not confirm preserve_existing; "
+                "host agent is likely outdated — restart it and retry",
+                service_id,
+            )
+            return False
         return True
     except AgentHTTPError as exc:
         logger.warning(
@@ -1657,19 +1691,42 @@ def _restore_extension_backup(service_id: str) -> bool:
     swap_parent.mkdir(parents=True, exist_ok=True)
     swap_root = Path(tempfile.mkdtemp(prefix=f".{service_id}-rollback-", dir=swap_parent))
     current = swap_root / service_id
+    parked = False
     try:
         os.replace(dest, current)
         try:
             os.replace(backup, dest)
         except OSError:
-            os.replace(current, dest)
+            try:
+                os.replace(current, dest)
+            except OSError:
+                # Double failure: never delete the only remaining copy of
+                # the live definition — leave it parked for manual recovery.
+                parked = True
+                logger.error(
+                    "Rollback failed for %s and the live definition could "
+                    "not be re-seated; parked at %s",
+                    service_id, current,
+                )
             raise
         backup.parent.mkdir(parents=True, exist_ok=True)
-        os.replace(current, backup)
+        try:
+            os.replace(current, backup)
+        except OSError:
+            # dest is already restored; only retaining the failed update as
+            # the new backup failed. Keep the tree for inspection and treat
+            # the restore itself as successful.
+            parked = True
+            logger.warning(
+                "Rollback restored %s but could not retain the replaced "
+                "definition; parked at %s",
+                service_id, current,
+            )
         _invalidate_extension_digest_cache(dest, backup, current)
         return True
     finally:
-        shutil.rmtree(swap_root, ignore_errors=True)
+        if not parked:
+            shutil.rmtree(swap_root, ignore_errors=True)
 
 
 def _start_extension_lifecycle(service_id: str) -> tuple[bool, list[str]]:
@@ -1763,11 +1820,20 @@ def update_extension(
     backup = _extension_backup_dir(service_id)
     with _extensions_lock():
         progress = _read_progress(service_id)
-        if progress and progress.get("status") in {"pulling", "setup_hook", "starting"}:
+        if _progress_blocks_mutation(progress):
             raise HTTPException(status_code=409, detail="Extension operation is still in progress")
         state = _library_update_state(service_id)
         if state["update_status"] == "current" and not force:
             raise HTTPException(status_code=409, detail="Extension is already current")
+        if state["update_status"] == "unknown" and not force:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": "Installed files could not be inspected; confirm update to replace them with the library version",
+                    "code": "update_state_unknown",
+                    "force_available": True,
+                },
+            )
         if state["update_status"] == "untracked" and not force:
             raise HTTPException(
                 status_code=409,
@@ -1811,17 +1877,40 @@ def update_extension(
                 raise HTTPException(status_code=409, detail="Extension backup path is a symlink")
             if backup.exists() and not backup.is_dir():
                 raise HTTPException(status_code=409, detail="Extension backup path is not a directory")
+            # Retire the prior rollback point aside instead of deleting it
+            # before the new update has committed: a failure between here
+            # and the staged->dest swap must leave the old backup intact.
+            retired: Path | None = None
             if backup.exists():
-                shutil.rmtree(backup)
+                retire_parent = USER_EXTENSIONS_DIR / ".tmp"
+                if retire_parent.is_symlink():
+                    raise HTTPException(status_code=409, detail="Extension tmp path is a symlink")
+                retire_parent.mkdir(parents=True, exist_ok=True)
+                retired = Path(tempfile.mkdtemp(
+                    prefix=f".{service_id}-retired-backup-", dir=retire_parent,
+                )) / service_id
+                os.replace(backup, retired)
             backup.parent.mkdir(parents=True, exist_ok=True)
             os.replace(dest, backup)
             try:
                 os.replace(staged, dest)
             except OSError:
                 os.replace(backup, dest)
+                if retired is not None:
+                    try:
+                        os.replace(retired, backup)
+                        shutil.rmtree(retired.parent, ignore_errors=True)
+                    except OSError:
+                        logger.error(
+                            "Update failed for %s and the prior backup could "
+                            "not be re-seated; parked at %s",
+                            service_id, retired,
+                        )
                 raise
             _invalidate_extension_digest_cache(dest, backup, staged)
             _call_agent_invalidate_compose_cache()
+            if retired is not None:
+                shutil.rmtree(retired.parent, ignore_errors=True)
 
     ext = next((entry for entry in EXTENSION_CATALOG if entry.get("id") == service_id), {})
     one_shot = _is_one_shot_extension(ext)
@@ -1880,7 +1969,7 @@ def rollback_extension_update(
     backup = _extension_backup_dir(service_id)
     with _extensions_lock():
         progress = _read_progress(service_id)
-        if progress and progress.get("status") in {"pulling", "setup_hook", "starting"}:
+        if _progress_blocks_mutation(progress):
             raise HTTPException(status_code=409, detail="Extension operation is still in progress")
         if (not dest.is_dir() or dest.is_symlink()
                 or not backup.is_dir() or backup.is_symlink()):

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -3359,14 +3359,14 @@ class TestSyncExtensionConfig:
 
         calls = []
 
-        def _fake(sid):
-            calls.append(sid)
+        def _fake(sid, *, preserve_existing=False):
+            calls.append((sid, preserve_existing))
             return True
 
         monkeypatch.setattr(ext_mod, "_call_agent_sync_config", _fake)
         result = ext_mod._sync_extension_config("my-ext")
 
-        assert calls == ["my-ext"]
+        assert calls == [("my-ext", False)]
         assert result is True
 
     def test_returns_false_on_agent_failure(self, monkeypatch):
@@ -3374,7 +3374,8 @@ class TestSyncExtensionConfig:
         from routers import extensions as ext_mod
 
         monkeypatch.setattr(
-            ext_mod, "_call_agent_sync_config", lambda _sid: False,
+            ext_mod, "_call_agent_sync_config",
+            lambda _sid, *, preserve_existing=False: False,
         )
         assert ext_mod._sync_extension_config("my-ext") is False
 
@@ -3399,9 +3400,243 @@ class TestSyncExtensionConfig:
         assert captured == {
             "method": "POST",
             "path": "/v1/extension/sync_config",
-            "payload": {"service_id": "my-ext"},
+            "payload": {"service_id": "my-ext", "preserve_existing": False},
             "timeout": ext_mod._AGENT_TIMEOUT,
         }
+
+
+class TestUpdateExtension:
+    def _prepare(self, monkeypatch, tmp_path, *, enabled=True):
+        from routers import extensions as ext_mod
+
+        lib_dir = _setup_library_ext(tmp_path, "my-ext")
+        user_dir = tmp_path / "user"
+        _patch_mutation_config(
+            monkeypatch, tmp_path, lib_dir=lib_dir, user_dir=user_dir,
+        )
+        monkeypatch.setattr(ext_mod, "EXTENSION_CATALOG", [{
+            "id": "my-ext", "name": "My Ext", "port": 8080,
+        }])
+        monkeypatch.setattr(
+            ext_mod, "_call_agent_invalidate_compose_cache", lambda: None,
+        )
+        monkeypatch.setattr(
+            ext_mod, "_sync_extension_config",
+            lambda _sid, *, preserve_existing=False: True,
+        )
+        monkeypatch.setattr(ext_mod, "_call_agent_hook", lambda _sid, _hook: True)
+        monkeypatch.setattr(ext_mod, "_call_agent", lambda _action, _sid: True)
+        with ext_mod._extensions_lock():
+            ext_mod._install_from_library("my-ext")
+        installed = user_dir / "my-ext"
+        if not enabled:
+            (installed / "compose.yaml").rename(installed / "compose.yaml.disabled")
+        return ext_mod, lib_dir, user_dir, installed
+
+    def test_enable_disable_rename_is_not_a_local_modification(
+        self, monkeypatch, tmp_path,
+    ):
+        ext_mod, _lib, _user, _installed = self._prepare(
+            monkeypatch, tmp_path, enabled=False,
+        )
+        state = ext_mod._library_update_state("my-ext")
+        assert state["update_status"] == "current"
+        assert state["locally_modified"] is False
+
+    def test_install_writes_content_receipt(self, monkeypatch, tmp_path):
+        ext_mod, _lib, _user, installed = self._prepare(monkeypatch, tmp_path)
+        receipt = ext_mod._read_library_receipt(installed)
+        assert receipt is not None
+        assert receipt["installed_digest"] == ext_mod._extension_tree_digest(installed)
+        assert ext_mod._library_update_state("my-ext")["update_status"] == "current"
+
+    def test_update_replaces_definition_and_keeps_backup(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["action"] == "updated"
+        assert (installed / "manifest.yaml").read_text() == "release: two\n"
+        assert (user_dir / ".backups" / "my-ext").is_dir()
+        assert ext_mod._library_update_state("my-ext")["update_status"] == "current"
+
+    def test_update_blocks_local_changes_without_force(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        _ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
+        (installed / "local.txt").write_text("keep me")
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+
+        blocked = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+        assert blocked.status_code == 409
+        assert blocked.json()["detail"]["code"] == "locally_modified"
+
+        forced = test_client.post(
+            "/api/extensions/my-ext/update?force=true",
+            headers=test_client.auth_headers,
+        )
+        assert forced.status_code == 200
+        assert (user_dir / ".backups" / "my-ext" / "local.txt").read_text() == "keep me"
+
+    def test_update_start_failure_restores_previous_definition(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
+        monkeypatch.setattr(
+            ext_mod, "_call_agent",
+            lambda action, _sid: False if action == "start" else True,
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 502
+        assert (installed / "manifest.yaml").read_text() == original
+        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == "release: broken\n"
+
+    def test_update_config_failure_restores_previous_definition(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
+        monkeypatch.setattr(
+            ext_mod, "_sync_extension_config",
+            lambda _sid, *, preserve_existing=False: False,
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 502
+        assert (installed / "manifest.yaml").read_text() == original
+        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == "release: broken\n"
+
+    def test_update_rejects_concurrent_extension_operation(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        monkeypatch.setattr(ext_mod, "_read_progress", lambda _sid: {"status": "pulling"})
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 409
+        assert "in progress" in response.json()["detail"]
+        assert (installed / "manifest.yaml").read_text() == original
+
+    def test_update_rejects_symlinked_install_directory(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
+        _ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        outside = tmp_path / "outside-install"
+        installed.rename(outside)
+        installed.symlink_to(outside, target_is_directory=True)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 404
+        assert (outside / "manifest.yaml").is_file()
+
+    def test_update_preserves_disabled_state_without_start(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(
+            monkeypatch, tmp_path, enabled=False,
+        )
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        starts = []
+        monkeypatch.setattr(
+            ext_mod, "_call_agent", lambda action, sid: starts.append((action, sid)),
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert (installed / "compose.yaml.disabled").is_file()
+        assert not (installed / "compose.yaml").exists()
+        assert starts == []
+
+    def test_rollback_restores_previous_definition(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        _ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        assert test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        ).status_code == 200
+
+        response = test_client.post(
+            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert response.json()["action"] == "rolled_back"
+        assert (installed / "manifest.yaml").read_text() == original
+
+    def test_rollback_start_failure_restores_updated_definition(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        assert test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        ).status_code == 200
+        monkeypatch.setattr(
+            ext_mod, "_call_agent",
+            lambda action, _sid: False if action == "start" else True,
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 502
+        assert (installed / "manifest.yaml").read_text() == "release: two\n"
+        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == original
+
+    def test_uninstall_removes_definition_backup(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        _ext_mod, lib_dir, user_dir, _installed = self._prepare(
+            monkeypatch, tmp_path, enabled=False,
+        )
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        assert test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        ).status_code == 200
+
+        response = test_client.delete(
+            "/api/extensions/my-ext", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert not (user_dir / "my-ext").exists()
+        assert not (user_dir / ".backups" / "my-ext").exists()
 
 
 # --- Error progress ---

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -3515,6 +3515,27 @@ class TestUpdateExtension:
         ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
+        start_results = iter([False, True])
+        monkeypatch.setattr(
+            ext_mod, "_call_agent",
+            lambda action, _sid: next(start_results) if action == "start" else True,
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 502
+        assert "previous definition restored" in response.json()["detail"]
+        assert (installed / "manifest.yaml").read_text() == original
+        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == "release: broken\n"
+
+    def test_update_start_failure_reports_incomplete_runtime_recovery(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
         monkeypatch.setattr(
             ext_mod, "_call_agent",
             lambda action, _sid: False if action == "start" else True,
@@ -3524,9 +3545,10 @@ class TestUpdateExtension:
             "/api/extensions/my-ext/update", headers=test_client.auth_headers,
         )
 
-        assert response.status_code == 502
+        assert response.status_code == 500
+        assert "recovery incomplete" in response.json()["detail"]
+        assert "restored runtime restart failed" in response.json()["detail"]
         assert (installed / "manifest.yaml").read_text() == original
-        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == "release: broken\n"
 
     def test_update_config_failure_restores_previous_definition(
         self, test_client, monkeypatch, tmp_path,
@@ -3534,9 +3556,10 @@ class TestUpdateExtension:
         ext_mod, lib_dir, user_dir, installed = self._prepare(monkeypatch, tmp_path)
         original = (installed / "manifest.yaml").read_text()
         (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
+        sync_results = iter([False, True])
         monkeypatch.setattr(
             ext_mod, "_sync_extension_config",
-            lambda _sid, *, preserve_existing=False: False,
+            lambda _sid, *, preserve_existing=False: next(sync_results),
         )
 
         response = test_client.post(
@@ -3544,8 +3567,49 @@ class TestUpdateExtension:
         )
 
         assert response.status_code == 502
+        assert "previous definition restored" in response.json()["detail"]
         assert (installed / "manifest.yaml").read_text() == original
         assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == "release: broken\n"
+
+    def test_update_config_failure_reports_incomplete_config_recovery(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
+        monkeypatch.setattr(
+            ext_mod,
+            "_sync_extension_config",
+            lambda _sid, *, preserve_existing=False: False,
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 500
+        assert "recovery incomplete" in response.json()["detail"]
+        assert "config sync failed" in response.json()["detail"]
+        assert (installed / "manifest.yaml").read_text() == original
+
+    def test_update_reports_definition_restore_failure(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, _installed = self._prepare(monkeypatch, tmp_path)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: broken\n")
+        start_results = iter([False])
+        monkeypatch.setattr(
+            ext_mod, "_call_agent",
+            lambda action, _sid: next(start_results) if action == "start" else True,
+        )
+        monkeypatch.setattr(ext_mod, "_restore_extension_backup", lambda _sid: False)
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 500
+        assert "definition restore failed" in response.json()["detail"]
 
     def test_update_rejects_concurrent_extension_operation(
         self, test_client, monkeypatch, tmp_path,
@@ -3601,6 +3665,59 @@ class TestUpdateExtension:
         assert (installed / "compose.yaml.disabled").is_file()
         assert not (installed / "compose.yaml").exists()
         assert starts == []
+
+    def test_update_rejects_ambiguous_compose_state(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        _ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        (installed / "compose.yaml.disabled").write_text(
+            (installed / "compose.yaml").read_text(),
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update?force=true",
+            headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 409
+        assert "invalid compose state" in response.json()["detail"]
+
+    def test_update_holds_service_operation_lock_through_runtime_proof(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, _installed = self._prepare(monkeypatch, tmp_path)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        lock_state = {"active": False}
+
+        @contextlib.contextmanager
+        def tracked_lock(service_id):
+            assert service_id == "my-ext"
+            assert lock_state["active"] is False
+            lock_state["active"] = True
+            try:
+                yield
+            finally:
+                lock_state["active"] = False
+
+        def assert_locked_sync(_sid, *, preserve_existing=False):
+            assert lock_state["active"] is True
+            return True
+
+        def assert_locked_agent(_action, _sid):
+            assert lock_state["active"] is True
+            return True
+
+        monkeypatch.setattr(ext_mod, "_extension_operation_lock", tracked_lock)
+        monkeypatch.setattr(ext_mod, "_sync_extension_config", assert_locked_sync)
+        monkeypatch.setattr(ext_mod, "_call_agent", assert_locked_agent)
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert lock_state["active"] is False
 
     def test_rollback_restores_previous_definition(
         self, test_client, monkeypatch, tmp_path,
@@ -3660,6 +3777,29 @@ class TestUpdateExtension:
         assert test_client.post(
             "/api/extensions/my-ext/update", headers=test_client.auth_headers,
         ).status_code == 200
+        start_results = iter([False, True])
+        monkeypatch.setattr(
+            ext_mod, "_call_agent",
+            lambda action, _sid: next(start_results) if action == "start" else True,
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 502
+        assert "updated definition restored" in response.json()["detail"]
+        assert (installed / "manifest.yaml").read_text() == "release: two\n"
+        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == original
+
+    def test_rollback_start_failure_reports_incomplete_runtime_recovery(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        assert test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        ).status_code == 200
         monkeypatch.setattr(
             ext_mod, "_call_agent",
             lambda action, _sid: False if action == "start" else True,
@@ -3669,9 +3809,56 @@ class TestUpdateExtension:
             "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
         )
 
-        assert response.status_code == 502
+        assert response.status_code == 500
+        assert "recovery incomplete" in response.json()["detail"]
+        assert "restored runtime restart failed" in response.json()["detail"]
         assert (installed / "manifest.yaml").read_text() == "release: two\n"
-        assert (user_dir / ".backups" / "my-ext" / "manifest.yaml").read_text() == original
+
+    def test_rollback_config_failure_restores_updated_definition(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        assert test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        ).status_code == 200
+        sync_results = iter([False, True])
+        monkeypatch.setattr(
+            ext_mod,
+            "_sync_extension_config",
+            lambda _sid, *, preserve_existing=False: next(sync_results),
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 502
+        assert "updated definition restored" in response.json()["detail"]
+        assert (installed / "manifest.yaml").read_text() == "release: two\n"
+
+    def test_rollback_config_failure_reports_incomplete_recovery(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        assert test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        ).status_code == 200
+        monkeypatch.setattr(
+            ext_mod,
+            "_sync_extension_config",
+            lambda _sid, *, preserve_existing=False: False,
+        )
+
+        response = test_client.post(
+            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 500
+        assert "recovery incomplete" in response.json()["detail"]
+        assert "config sync failed" in response.json()["detail"]
+        assert (installed / "manifest.yaml").read_text() == "release: two\n"
 
     def test_uninstall_removes_definition_backup(
         self, test_client, monkeypatch, tmp_path,

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -3450,6 +3450,29 @@ class TestUpdateExtension:
         assert receipt["installed_digest"] == ext_mod._extension_tree_digest(installed)
         assert ext_mod._library_update_state("my-ext")["update_status"] == "current"
 
+    def test_staging_rejects_library_change_during_copy(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        source_manifest = lib_dir / "my-ext" / "manifest.yaml"
+        source_manifest.write_text("release: two\n")
+        real_copy = ext_mod._copytree_safe
+
+        def copy_then_change(source, staged):
+            real_copy(source, staged)
+            source_manifest.write_text("release: changed-during-copy\n")
+
+        monkeypatch.setattr(ext_mod, "_copytree_safe", copy_then_change)
+
+        response = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 409
+        assert "changed while" in response.json()["detail"]
+        assert (installed / "manifest.yaml").read_text() == original
+
     def test_update_replaces_definition_and_keeps_backup(
         self, test_client, monkeypatch, tmp_path,
     ):

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -3433,6 +3433,24 @@ class TestUpdateExtension:
             (installed / "compose.yaml").rename(installed / "compose.yaml.disabled")
         return ext_mod, lib_dir, user_dir, installed
 
+    def test_invalid_id_is_rejected_before_operation_lock(
+        self, test_client, monkeypatch,
+    ):
+        from routers import extensions as ext_mod
+
+        @contextlib.contextmanager
+        def unexpected_lock(_service_id):
+            raise AssertionError("invalid IDs must not create operation locks")
+            yield
+
+        monkeypatch.setattr(ext_mod, "_extension_operation_lock", unexpected_lock)
+
+        response = test_client.post(
+            "/api/extensions/INVALID/update", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 404
+
     def test_enable_disable_rename_is_not_a_local_modification(
         self, monkeypatch, tmp_path,
     ):

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -4141,3 +4141,70 @@ def test_extensions_lock_falls_back_when_data_root_is_unwritable(
 
     with ext_module._extensions_lock():
         assert fallback_lock.exists()
+
+
+class TestUpdateHardening(TestUpdateExtension):
+    """Gates and sync-echo hardening for the transactional update path."""
+
+    def test_stale_initial_progress_does_not_block_mutations(self):
+        from datetime import datetime, timezone
+
+        from routers import extensions as ext_mod
+
+        old = "2020-01-01T00:00:00+00:00"
+        now = datetime.now(timezone.utc).isoformat()
+        assert ext_mod._progress_blocks_mutation(None) is False
+        assert ext_mod._progress_blocks_mutation(
+            {"status": "error", "started_at": old, "updated_at": old},
+        ) is False
+        # Never advanced by the agent and past the grace period: abandoned.
+        assert ext_mod._progress_blocks_mutation(
+            {"status": "pulling", "started_at": old, "updated_at": old},
+        ) is False
+        # Fresh initial record still blocks.
+        assert ext_mod._progress_blocks_mutation(
+            {"status": "pulling", "started_at": now, "updated_at": now},
+        ) is True
+        # Advancing record blocks regardless of age.
+        assert ext_mod._progress_blocks_mutation(
+            {"status": "pulling", "started_at": old, "updated_at": now},
+        ) is True
+
+    def test_update_blocks_unknown_state_without_force(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user_dir, _installed = self._prepare(
+            monkeypatch, tmp_path,
+        )
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+
+        def unreadable(_path):
+            raise OSError("unreadable install")
+
+        monkeypatch.setattr(ext_mod, "_extension_tree_digest", unreadable)
+        blocked = test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        )
+        assert blocked.status_code == 409
+        assert blocked.json()["detail"]["code"] == "update_state_unknown"
+        assert blocked.json()["detail"]["force_available"] is True
+
+    def test_sync_config_requires_preserve_echo(self, monkeypatch):
+        from routers import extensions as ext_mod
+
+        monkeypatch.setattr(
+            ext_mod, "request_agent_json",
+            lambda *a, **k: {"status": "ok"},
+        )
+        assert ext_mod._call_agent_sync_config(
+            "my-ext", preserve_existing=True,
+        ) is False
+        assert ext_mod._call_agent_sync_config("my-ext") is True
+
+        monkeypatch.setattr(
+            ext_mod, "request_agent_json",
+            lambda *a, **k: {"status": "ok", "preserve_existing": True},
+        )
+        assert ext_mod._call_agent_sync_config(
+            "my-ext", preserve_existing=True,
+        ) is True

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -3620,6 +3620,37 @@ class TestUpdateExtension:
         assert response.json()["action"] == "rolled_back"
         assert (installed / "manifest.yaml").read_text() == original
 
+    def test_rollback_preserves_disabled_state_after_update(
+        self, test_client, monkeypatch, tmp_path,
+    ):
+        ext_mod, lib_dir, _user, installed = self._prepare(monkeypatch, tmp_path)
+        original = (installed / "manifest.yaml").read_text()
+        (lib_dir / "my-ext" / "manifest.yaml").write_text("release: two\n")
+        agent_calls = []
+        monkeypatch.setattr(
+            ext_mod,
+            "_call_agent",
+            lambda action, sid: agent_calls.append((action, sid)) or True,
+        )
+
+        assert test_client.post(
+            "/api/extensions/my-ext/update", headers=test_client.auth_headers,
+        ).status_code == 200
+        assert test_client.post(
+            "/api/extensions/my-ext/disable", headers=test_client.auth_headers,
+        ).status_code == 200
+        agent_calls.clear()
+
+        response = test_client.post(
+            "/api/extensions/my-ext/rollback", headers=test_client.auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert (installed / "manifest.yaml").read_text() == original
+        assert (installed / "compose.yaml.disabled").is_file()
+        assert not (installed / "compose.yaml").exists()
+        assert agent_calls == []
+
     def test_rollback_start_failure_restores_updated_definition(
         self, test_client, monkeypatch, tmp_path,
     ):

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1332,7 +1332,7 @@ class TestSyncExtensionConfigWire:
             thread.join(timeout=2)
 
     @staticmethod
-    def _post(port, sid, *, key="wire-test-secret"):
+    def _post(port, sid, *, key="wire-test-secret", preserve_existing=False):
         """Direct HTTP POST to /v1/extension/sync_config so callers can
         assert on the raw status code (the dashboard-api helper masks
         4xx as a generic False, which is too coarse for these tests)."""
@@ -1342,7 +1342,10 @@ class TestSyncExtensionConfigWire:
         url = f"http://127.0.0.1:{port}/v1/extension/sync_config"
         req = urllib.request.Request(
             url,
-            data=_json.dumps({"service_id": sid}).encode(),
+            data=_json.dumps({
+                "service_id": sid,
+                "preserve_existing": preserve_existing,
+            }).encode(),
             headers={
                 "Content-Type": "application/json",
                 "Authorization": f"Bearer {key}",
@@ -1358,6 +1361,79 @@ class TestSyncExtensionConfigWire:
             except ValueError:
                 body = {}
             return exc.code, body
+
+    def test_preserve_existing_only_adds_missing_config(
+        self, tmp_path, monkeypatch,
+    ):
+        import threading
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "install"
+        user_root = install_dir / "data" / "user-extensions"
+        install_dir.mkdir()
+        user_root.mkdir(parents=True)
+        self._make_extension(user_root, "fakesvc")
+        source = user_root / "fakesvc" / "config" / "fakesvc"
+        (source / "new.yaml").write_text("new: default\n", encoding="utf-8")
+        target = install_dir / "config" / "fakesvc"
+        target.mkdir(parents=True)
+        (target / "settings.yaml").write_text("server: customized\n", encoding="utf-8")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", tmp_path / "builtin-empty")
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            status, _body = self._post(port, "fakesvc", preserve_existing=True)
+            assert status == 200
+            assert (target / "settings.yaml").read_text(encoding="utf-8") == "server: customized\n"
+            assert (target / "new.yaml").read_text(encoding="utf-8") == "new: default\n"
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+    def test_rejects_existing_symlink_in_config_target(
+        self, tmp_path, monkeypatch,
+    ):
+        if os.name == "nt" and not can_create_symlinks(tmp_path):
+            pytest.skip("Windows symlink creation requires Developer Mode or administrator privileges")
+        import threading
+        from http.server import HTTPServer
+
+        install_dir = tmp_path / "install"
+        user_root = install_dir / "data" / "user-extensions"
+        install_dir.mkdir()
+        user_root.mkdir(parents=True)
+        self._make_extension(user_root, "fakesvc")
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        target = install_dir / "config" / "fakesvc"
+        target.mkdir(parents=True)
+        (target / "linked").symlink_to(outside, target_is_directory=True)
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "USER_EXTENSIONS_DIR", user_root)
+        monkeypatch.setattr(_mod, "EXTENSIONS_DIR", tmp_path / "builtin-empty")
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            status, body = self._post(port, "fakesvc", preserve_existing=True)
+            assert status == 400
+            assert "target symlink" in body.get("error", "")
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
 
     def test_rejects_symlink_in_config_tree(self, tmp_path, monkeypatch):
         """Symlinks (file or directory, top-level or nested) must be rejected
@@ -2873,6 +2949,11 @@ class TestModelActivationLemonadePersistence:
         )
         monkeypatch.setattr(
             _mod, "_capture_perplexica_config", lambda *_args, **_kwargs: None
+        )
+        monkeypatch.setattr(
+            _mod,
+            "_capture_container_state",
+            lambda _name: {"exists": False, "running": False},
         )
         handler = _FakeHandler(b"")
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -1391,6 +1391,7 @@ class TestSyncExtensionConfigWire:
         try:
             status, _body = self._post(port, "fakesvc", preserve_existing=True)
             assert status == 200
+            assert _body.get("preserve_existing") is True
             assert (target / "settings.yaml").read_text(encoding="utf-8") == "server: customized\n"
             assert (target / "new.yaml").read_text(encoding="utf-8") == "new: default\n"
         finally:

--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -44,6 +44,22 @@ server {
         proxy_set_header X-Accel-Buffering no;
     }
 
+    # Extension refresh can synchronously recreate an enabled service and
+    # prove immediate compose success. Keep this longer timeout scoped to the
+    # two transactional definition endpoints.
+    location ~ ^/api/extensions/[a-z0-9_-]+/(update|rollback)$ {
+        proxy_pass http://$dashboard_api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "close";
+        proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
+        proxy_read_timeout 360s;
+        proxy_send_timeout 360s;
+    }
+
     # Proxy API requests to status backend
     # Auth: nginx injects Bearer token for same-origin requests (B2 fix)
     # Token read from environment via envsubst in entrypoint

--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -72,8 +72,8 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Connection "close";
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
-        proxy_read_timeout 360s;
-        proxy_send_timeout 360s;
+        proxy_read_timeout 1800s;
+        proxy_send_timeout 1800s;
     }
 
     # Cache static assets

--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -44,22 +44,6 @@ server {
         proxy_set_header X-Accel-Buffering no;
     }
 
-    # Extension refresh can synchronously recreate an enabled service and
-    # prove immediate compose success. Keep this longer timeout scoped to the
-    # two transactional definition endpoints.
-    location ~ ^/api/extensions/[a-z0-9_-]+/(update|rollback)$ {
-        proxy_pass http://$dashboard_api_upstream;
-        proxy_http_version 1.1;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Connection "close";
-        proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
-        proxy_read_timeout 360s;
-        proxy_send_timeout 360s;
-    }
-
     # Proxy API requests to status backend
     # Auth: nginx injects Bearer token for same-origin requests (B2 fix)
     # Token read from environment via envsubst in entrypoint
@@ -74,6 +58,22 @@ server {
         # B1 fix: Auth header injected by entrypoint.sh after reading key from file/env
         proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
         proxy_read_timeout 180s;
+    }
+
+    # Extension refresh can synchronously recreate an enabled service and
+    # prove immediate compose success. Keep this longer timeout scoped to the
+    # two transactional definition endpoints.
+    location ~ ^/api/extensions/[a-z0-9_-]+/(update|rollback)$ {
+        proxy_pass http://$dashboard_api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "close";
+        proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
+        proxy_read_timeout 360s;
+        proxy_send_timeout 360s;
     }
 
     # Cache static assets

--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -1,7 +1,7 @@
 import {
   Database, Cpu, Workflow, Plug, Image, MessageSquare, Code,
   FileText, Shield, Globe, Music, Video, Search, Puzzle,
-  Box, Loader2, RefreshCw, ChevronDown, ChevronUp, Package, Info, X, Download, Trash2, ExternalLink, Terminal, Copy, Check,
+  Box, Loader2, RefreshCw, RotateCcw, ChevronDown, ChevronUp, Package, Info, X, Download, Trash2, ExternalLink, Terminal, Copy, Check,
 } from 'lucide-react'
 import { useState, useEffect, useRef } from 'react'
 import { DependencyBadges, DependencyConfirmDialog, DisableDependentWarning } from '../components/DependencyBadges'
@@ -229,7 +229,7 @@ export default function Extensions() {
     }
   }
 
-  const handleMutation = async (serviceId, action, { autoEnableDeps = false } = {}) => {
+  const handleMutation = async (serviceId, action, { autoEnableDeps = false, force = false } = {}) => {
     setMutating(serviceId)
     setConfirm(null)
     setDepConfirm(null)
@@ -242,9 +242,12 @@ export default function Extensions() {
       if (action === 'enable' && autoEnableDeps) {
         url += '?auto_enable_deps=true'
       }
+      if (action === 'update' && force) {
+        url += '?force=true'
+      }
       const opts = {
         method: action === 'uninstall' || action === 'purge' ? 'DELETE' : 'POST',
-        signal: AbortSignal.timeout(300000),
+        signal: AbortSignal.timeout(action === 'update' || action === 'rollback' ? 360000 : 300000),
       }
       if (action === 'purge') {
         opts.headers = { 'Content-Type': 'application/json' }
@@ -301,6 +304,12 @@ export default function Extensions() {
       disable: `Disable ${ext.name}? The service will be stopped.`,
       uninstall: `Remove ${ext.name}? You can reinstall it from the library.`,
       purge: `Permanently delete all data for ${ext.name}? This cannot be undone.`,
+      update: ext.locally_modified
+        ? `Update ${ext.name} from the ODS library? Local definition changes will be replaced, but retained as a rollback backup.`
+        : ext.update_status === 'untracked'
+        ? `Refresh this legacy ${ext.name} install from the ODS library and begin tracking future updates? The current definition will be retained as a rollback backup.`
+        : `Update ${ext.name} from the ODS library? The current definition will be retained for rollback.`,
+      rollback: `Restore the previous ${ext.name} extension definition? Current service data and configuration will be preserved.`,
     }
     setConfirm({ action, ext, message: messages[action] })
   }
@@ -373,12 +382,13 @@ export default function Extensions() {
 
       {/* Summary bar */}
       <div className="bg-theme-card border border-theme-border rounded-xl p-4 mb-6 liquid-metal-frame liquid-metal-frame--soft">
-        <div className="flex items-center gap-6 text-sm">
+        <div className="flex flex-wrap items-center gap-6 text-sm">
           <SummaryItem label="Total" value={summary.total || extensions.length} color="bg-theme-text-muted" />
           <SummaryItem label="Installed" value={summary.installed ?? 0} color="bg-green-500" />
           <SummaryItem label="Stopped" value={summary.stopped ?? 0} color="bg-red-500" />
           <SummaryItem label="Unhealthy" value={summary.unhealthy ?? 0} color="bg-amber-500" />
           <SummaryItem label="Available" value={summary.not_installed ?? 0} color="bg-theme-accent" />
+          <SummaryItem label="Updates" value={summary.updates_available ?? 0} color="bg-cyan-400" />
           <SummaryItem label="Installing" value={summary.installing ?? 0} color="bg-blue-500" />
           <SummaryItem label="Error" value={summary.error ?? 0} color="bg-red-500" />
           <SummaryItem label="Incompatible" value={summary.incompatible ?? 0} color="bg-orange-500" />
@@ -531,7 +541,11 @@ export default function Extensions() {
             <div className="flex justify-end gap-3">
               <button onClick={() => setConfirm(null)} autoFocus className="px-4 py-2 text-[10px] font-mono uppercase tracking-[0.16em] text-theme-text-muted/65 hover:text-theme-text transition-colors">Cancel</button>
               <button
-                onClick={() => handleMutation(confirm.ext.id, confirm.action)}
+                onClick={() => handleMutation(confirm.ext.id, confirm.action, {
+                  force: confirm.action === 'update' && (
+                    confirm.ext.locally_modified || confirm.ext.update_status === 'untracked'
+                  ),
+                })}
                 className={`px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg transition-colors ${
                   confirm.action === 'uninstall' || confirm.action === 'purge' ? 'bg-red-500/15 text-red-400 hover:bg-red-500/25' :
                   'bg-theme-accent/15 text-theme-accent-light hover:bg-theme-accent/25'
@@ -659,6 +673,10 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
   const isToggleable = isUserExt && (status === 'enabled' || status === 'cli_installed' || status === 'disabled' || status === 'error' || status === 'stopped' || status === 'unhealthy')
   const showRemove = isUserExt && (status === 'disabled' || isError)
   const showInstall = status === 'not_installed' && ext.installable
+  const showUpdate = isUserExt && ext.installable && (
+    ext.update_available || ext.update_status === 'untracked'
+  )
+  const showRollback = isUserExt && ext.rollback_available
 
   return (
     <div className={`bg-theme-card border rounded-xl transition-all liquid-metal-frame liquid-metal-sequence-card flex flex-col ${
@@ -769,8 +787,8 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
       })()}
 
       {/* Card footer */}
-      <div className="border-t border-theme-border/40 px-4 py-2.5 flex items-center justify-between bg-theme-bg/30">
-        <div className="flex gap-1.5">
+      <div className="border-t border-theme-border/40 px-4 py-2.5 flex flex-wrap items-center justify-between gap-2 bg-theme-bg/30">
+        <div className="flex flex-wrap gap-1.5">
           {showInstall && (
             <button
               disabled={actionDisabled}
@@ -779,6 +797,26 @@ function ExtensionCard({ ext, gpuBackend, agentAvailable, onDetails, onConsole, 
               className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg bg-theme-accent text-white hover:bg-theme-accent-hover transition-colors disabled:opacity-50 shadow-sm shadow-theme-accent/20"
             >
               {isMutating ? <Loader2 size={12} className="animate-spin" /> : <><Download size={12} /> Install</>}
+            </button>
+          )}
+          {showUpdate && (
+            <button
+              disabled={actionDisabled}
+              title={disabledTitle || (ext.locally_modified ? 'Local definition changes will be backed up' : 'Update from ODS library')}
+              onClick={() => onAction(ext, 'update')}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg bg-cyan-500/15 text-cyan-300 hover:bg-cyan-500/25 transition-colors disabled:opacity-50"
+            >
+              {isMutating ? <Loader2 size={12} className="animate-spin" /> : <><RefreshCw size={12} /> {ext.update_status === 'untracked' ? 'Refresh' : 'Update'}</>}
+            </button>
+          )}
+          {showRollback && (
+            <button
+              disabled={actionDisabled}
+              title={disabledTitle || 'Restore previous extension definition'}
+              onClick={() => onAction(ext, 'rollback')}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-[0.08em] rounded-lg bg-theme-surface-hover/50 text-theme-text-secondary hover:text-theme-text transition-colors disabled:opacity-50"
+            >
+              {isMutating ? <Loader2 size={12} className="animate-spin" /> : <><RotateCcw size={12} /> Rollback</>}
             </button>
           )}
           {isUserExt && isStopped && (
@@ -949,6 +987,15 @@ function DetailModal({ ext, gpuBackend, onClose }) {
               <span className="text-theme-text-muted text-xs block mb-1">Port</span>
               <span className="text-theme-text font-mono">{ext.external_port_default || ext.port || '—'}</span>
             </div>
+            {ext.source === 'user' && (
+              <div className="bg-theme-card/50 rounded-lg p-3">
+                <span className="text-theme-text-muted text-xs block mb-1">Library</span>
+                <span className="text-theme-text capitalize">{(ext.update_status || 'unavailable').replace('_', ' ')}</span>
+                {ext.locally_modified && (
+                  <span className="text-amber-400 text-[10px] block mt-1">Local definition changed</span>
+                )}
+              </div>
+            )}
             <div className="bg-theme-card/50 rounded-lg p-3">
               <span className="text-theme-text-muted text-xs block mb-1">GPU</span>
               <span className="text-theme-text">{ext.gpu_backends?.join(', ') || 'none'}</span>

--- a/ods/extensions/services/dashboard/src/pages/Extensions.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.jsx
@@ -247,7 +247,7 @@ export default function Extensions() {
       }
       const opts = {
         method: action === 'uninstall' || action === 'purge' ? 'DELETE' : 'POST',
-        signal: AbortSignal.timeout(action === 'update' || action === 'rollback' ? 360000 : 300000),
+        signal: AbortSignal.timeout(action === 'update' || action === 'rollback' ? 30 * 60 * 1000 : 300000),
       }
       if (action === 'purge') {
         opts.headers = { 'Content-Type': 'application/json' }

--- a/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import { render } from '../test/test-utils'
 import Extensions from './Extensions' // eslint-disable-line no-unused-vars
 
@@ -305,5 +305,75 @@ describe('Extensions page — unhealthy + install derivations', () => {
 
     expect(screen.getByText('Swap-safe')).toBeInTheDocument()
     expect(screen.getByText('Not swap-safe')).toBeInTheDocument()
+  })
+
+  it('confirms a modified library update with the force contract', async () => {
+    const catalog = {
+      extensions: [{
+        id: 'tracked-ext',
+        name: 'Tracked Extension',
+        status: 'enabled',
+        source: 'user',
+        installable: true,
+        update_available: true,
+        update_status: 'modified',
+        locally_modified: true,
+        rollback_available: false,
+        features: [baseFeature],
+        description: 'desc',
+      }],
+      summary: baseSummary({ installed: 1, enabled: 1, updates_available: 1 }),
+      gpu_backend: 'apple',
+      agent_available: true,
+    }
+    const fetchMock = vi.fn(async (url) => {
+      const target = String(url)
+      if (target.includes('/api/extensions/catalog')) return makeJsonResponse(catalog)
+      if (target.includes('/api/templates')) return makeJsonResponse({ templates: [] })
+      if (target === '/api/extensions/tracked-ext/update?force=true') {
+        return makeJsonResponse({ action: 'updated', message: 'Extension updated.' })
+      }
+      throw new Error(`Unmocked fetch: ${target}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<Extensions />)
+    await screen.findByText('Tracked Extension')
+    fireEvent.click(screen.getByRole('button', { name: 'Update' }))
+    expect(screen.getByText(/Local definition changes will be replaced/)).toBeInTheDocument()
+    const updateButtons = screen.getAllByRole('button', { name: 'Update' })
+    fireEvent.click(updateButtons[updateButtons.length - 1])
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/extensions/tracked-ext/update?force=true',
+        expect.objectContaining({ method: 'POST' }),
+      )
+    })
+  })
+
+  it('shows rollback when a previous extension definition is available', async () => {
+    installFetchMock({
+      extensions: [{
+        id: 'rollback-ext',
+        name: 'Rollback Extension',
+        status: 'disabled',
+        source: 'user',
+        installable: true,
+        update_available: false,
+        update_status: 'current',
+        locally_modified: false,
+        rollback_available: true,
+        features: [baseFeature],
+        description: 'desc',
+      }],
+      summary: baseSummary({ installed: 1 }),
+      gpu_backend: 'apple',
+      agent_available: true,
+    })
+
+    render(<Extensions />)
+    await screen.findByText('Rollback Extension')
+    expect(screen.getByRole('button', { name: 'Rollback' })).toBeInTheDocument()
   })
 })

--- a/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Extensions.test.jsx
@@ -308,6 +308,7 @@ describe('Extensions page — unhealthy + install derivations', () => {
   })
 
   it('confirms a modified library update with the force contract', async () => {
+    const timeoutSpy = vi.spyOn(globalThis.AbortSignal, 'timeout').mockReturnValue(new AbortController().signal)
     const catalog = {
       extensions: [{
         id: 'tracked-ext',
@@ -350,6 +351,7 @@ describe('Extensions page — unhealthy + install derivations', () => {
         expect.objectContaining({ method: 'POST' }),
       )
     })
+    expect(timeoutSpy).toHaveBeenCalledWith(30 * 60 * 1000)
   })
 
   it('shows rollback when a previous extension definition is available', async () => {


### PR DESCRIPTION
## Summary

Adds a complete update lifecycle to the Extensions Portal for services installed from the bundled ODS library:

- detects library updates and local definition changes
- stages and security-scans replacement definitions before an atomic swap
- preserves enabled/disabled state and existing service configuration
- keeps one previous definition for explicit rollback
- rolls back automatically when config synchronization or service startup fails
- exposes Update, Refresh, and Rollback actions in the dashboard

## Problem

The portal could install, enable, disable, and remove extensions, but it had no provenance or update contract. A user could not tell whether a bundled definition had changed, safely refresh a legacy install, preserve local edits, or recover from a bad update.

## Update Contract

Each library install now receives `.ods-library-receipt.json` with deterministic source and installed digests. The API reports one of these states:

| State | Meaning | Portal action |
|---|---|---|
| `current` | Installed definition and bundled source match the receipt | None |
| `available` | ODS ships a different source definition | Update |
| `modified` | Installed definition changed locally | Confirmed update; old definition retained |
| `untracked` | Legacy install has no receipt | Confirmed refresh to establish provenance |
| `unknown` | Definition could not be inspected safely | No destructive automatic action |

Enable/disable renames are canonicalized, so `compose.yaml` and `compose.yaml.disabled` do not create false local-modification reports.

## Transaction And Recovery

1. Validate the library entry, size limit, compose policy, and build context.
2. Stage the definition under `data/user-extensions/.tmp` on the same filesystem.
3. Write the content receipt and preserve the current enabled/disabled state.
4. Atomically move the current definition to `.backups/<service>` and install the staged definition.
5. Synchronize only missing config defaults; existing config, secrets, data, and volumes are preserved.
6. Reconcile enabled non-CLI services through the existing host-agent lifecycle.
7. On config-sync or start failure, restore the prior definition and retry its start path.

Rollback swaps the current and previous definitions, so a failed rollback restores the updated definition instead of leaving a partial state. Uninstall also removes the retained definition backup.

## Security And Concurrency

- update and rollback run under the existing cross-process extension lock
- active install/start operations block concurrent update or rollback
- installed, temporary, backup, source-config, and destination-config symlink escapes are rejected
- staged definitions use the existing trusted compose scanner and safe-copy policy
- digest work runs off the FastAPI event loop and uses a metadata-signature cache
- nginx grants the longer host-agent budget only to update and rollback endpoints

## Dashboard

- summary bar includes available update count
- extension cards expose Update/Refresh and Rollback only when applicable
- confirmation text distinguishes local modifications and legacy installs
- detail view reports library state
- controls wrap on compact layouts

## Validation

- `python -m pytest ods/extensions/services/dashboard-api/tests/test_extensions.py -q` -> **222 passed**
- `python -m pytest ods/extensions/services/dashboard-api/tests/test_host_agent.py -q` -> **210 passed**
- dashboard Vitest -> **180 passed**
- dashboard ESLint -> passed
- dashboard Vite production build -> passed
- Ruff on changed Python files -> passed
- `py_compile` on changed runtime modules -> passed
- `git diff --check osmantic/main...HEAD` -> passed

## Scope

This PR proves definition/config transaction behavior and immediate compose start success through existing host-agent contracts. It does not claim a real Docker image-pull or hardware-specific runtime receipt; Docker and WSL were intentionally not started for local validation.

## Review Map

- API transaction and receipts: `ods/extensions/services/dashboard-api/routers/extensions.py`
- host config preservation: `ods/bin/ods-host-agent.py`
- portal UX: `ods/extensions/services/dashboard/src/pages/Extensions.jsx`
- scoped proxy budget: `ods/extensions/services/dashboard/nginx.conf`
- operator contract: `ods/docs/EXTENSIONS.md`