### PR TITLE
refactor(models): deterministic Lemonade concrete-ID adapter (PR 2C, observe)

### DIFF
--- a/ods/bin/model_switchboard/adapters.py
+++ b/ods/bin/model_switchboard/adapters.py
@@ -109,6 +109,58 @@ class NativeLlamaAdapter(ContainerLlamaAdapter):
     kind = "llama-server"
 
 
+class LemonadeAdapter:
+    """Deterministic Lemonade concrete-ID runtime (PR 2C).
+
+    The shared container restart and the post-restart model-ID resolution
+    run inline in the host agent (resolution requires a live server), so
+    this adapter's ``stage`` is a proven no-op and verification drives the
+    Lemonade-aware readiness wait. Native virtual ``collection.router``
+    registration is PR 6, not here.
+    """
+
+    kind = "lemonade"
+
+    def __init__(
+        self,
+        *,
+        wait_ready: Callable[..., bool],
+        expected_gguf: str,
+        context_length: int,
+        lemonade_model_id: str,
+    ) -> None:
+        self._wait_ready = wait_ready
+        self._expected_gguf = expected_gguf
+        self._context_length = int(context_length)
+        self._lemonade_model_id = lemonade_model_id
+
+    def stage(self, env: dict[str, str]) -> dict[str, Any]:
+        # Restart + model-ID resolution already completed inline before the
+        # reconciler runs; failure there raised before reaching this adapter.
+        if not self._lemonade_model_id:
+            return result(False, "no resolved Lemonade model id")
+        return result(True, "lemonade runtime staged inline")
+
+    def verify_identity(self, env: dict[str, str]) -> dict[str, Any]:
+        try:
+            healthy = self._wait_ready(
+                env,
+                self._expected_gguf,
+                self._context_length,
+                lemonade_model_id=self._lemonade_model_id,
+            )
+        except Exception as exc:
+            return result(False, f"lemonade readiness wait failed: {exc}")
+        if not healthy:
+            return result(False, "lemonade runtime did not report the staged model")
+        return result(True, "lemonade runtime reports staged model",
+                      identity=self._lemonade_model_id)
+
+    def verify_completion(self, env: dict[str, str]) -> dict[str, Any]:
+        return result(True, "completion proven during lemonade readiness wait",
+                      identity=self._lemonade_model_id)
+
+
 class FakeAdapter:
     """Shared transaction fake for the boundary test matrix (test-only).
 

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -5516,6 +5516,13 @@ class AgentHandler(BaseHTTPRequestHandler):
                     raise RuntimeError(
                         f"Could not resolve Lemonade model ID for {gguf_file}"
                     )
+                if _switchboard_adapters is not None:
+                    switchboard_adapter = _switchboard_adapters.LemonadeAdapter(
+                        wait_ready=_sb_wait_ready,
+                        expected_gguf=gguf_file,
+                        context_length=int(context_length),
+                        lemonade_model_id=lemonade_model_id,
+                    )
 
             hermes_model_name = (
                 gguf_file

--- a/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
+++ b/ods/extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
@@ -147,6 +147,47 @@ class TestNativeLlamaAdapter:
         assert "launchd bootout failed" in run["detail"]
 
 
+class TestLemonadeAdapter:
+    def test_verify_uses_resolved_lemonade_id(self):
+        seen = {}
+
+        def wait_ready(env, gguf, ctx, lemonade_model_id=""):
+            seen["args"] = (gguf, ctx, lemonade_model_id)
+            return True
+
+        adapter = ad.LemonadeAdapter(
+            wait_ready=wait_ready,
+            expected_gguf="Q.gguf",
+            context_length=65536,
+            lemonade_model_id="extra.Q.gguf",
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is True
+        assert run["identity"] == "extra.Q.gguf"
+        assert adapter.kind == "lemonade"
+        assert seen["args"] == ("Q.gguf", 65536, "extra.Q.gguf")
+
+    def test_missing_id_is_stage_failure(self):
+        adapter = ad.LemonadeAdapter(
+            wait_ready=lambda *a, **k: True,
+            expected_gguf="Q.gguf",
+            context_length=1024,
+            lemonade_model_id="",
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "stage"
+
+    def test_not_ready_is_identity_failure(self):
+        adapter = ad.LemonadeAdapter(
+            wait_ready=lambda *a, **k: False,
+            expected_gguf="Q.gguf",
+            context_length=1024,
+            lemonade_model_id="extra.Q.gguf",
+        )
+        run = rc.run_runtime_activation(adapter, {})
+        assert run["ok"] is False and run["phase"] == "verify_identity"
+
+
 class TestHostAgentWiring:
     def test_compose_llama_path_flows_through_reconciler(self, tmp_path, monkeypatch):
         import subprocess


### PR DESCRIPTION
Model Switchboard series PR 2C — plan: `ods/docs/MODEL-SWITCHBOARD.md`. **Depends on:** #1902 (merged). **Mode:** observe; behavior-preserving.

`LemonadeAdapter` drives verify_identity/verify_completion for the Lemonade path through the PR 2A reconciler using the resolved concrete model ID. The shared container restart and post-restart model-ID resolution stay inline (resolution needs a live server) and are unchanged; native virtual `collection.router` registration is PR 6. **HipFire is explicitly excluded** pending #1787 (recorded blocking dependency) — no duplicate HipFire route, per the plan.

Tests: 3 Lemonade adapter contract cases + full switchboard/activation suites green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)