### PR TITLE
feat(open-webui): stable-alias gateway route (PR 4A)

### DIFF
--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -88,7 +88,10 @@ services:
       - no-new-privileges:true
     environment:
       ENABLE_OLLAMA_API: "false"
-      OPENAI_API_BASE_URL: "${LLM_API_URL:-http://llama-server:8080}/v1"
+      # Switchboard: OPEN_WEBUI_LLM_BASE_URL overrides to the LiteLLM gateway
+      # (ods/current) in enabled mode; default is byte-identical to the prior
+      # direct llama-server route for legacy/observe.
+      OPENAI_API_BASE_URL: "${OPEN_WEBUI_LLM_BASE_URL:-${LLM_API_URL:-http://llama-server:8080}/v1}"
       OPENAI_API_KEY: ""
       # PWA / branding — surfaces as the app title, page title, and PWA install name.
       # When a user adds ODS to their home screen, this is the label they see

--- a/ods/extensions/services/open-webui/manifest.yaml
+++ b/ods/extensions/services/open-webui/manifest.yaml
@@ -21,8 +21,8 @@ service:
   depends_on: [llama-server]
   llm:
     consumes: true
-    route: direct
-    pinning: dynamic
+    route: gateway
+    pinning: none
     min_context: 0
     probe:
       kind: chat


### PR DESCRIPTION
Model Switchboard series PR 4A — plan: `ods/docs/MODEL-SWITCHBOARD.md`. **Depends on:** PR 3 (merged). **Mode:** default-URL byte-identical to today; enabled-mode override points Open WebUI at the LiteLLM gateway (`ods/current`).

Open WebUI adopts the #1766 stable-alias contract (`route: gateway`, `pinning: none`) so it stores no concrete model id. Compose gains `OPEN_WEBUI_LLM_BASE_URL` with a byte-identical default; the switchboard sets it to the gateway in enabled mode. Manifest/audit/registry/exposure contracts pass; live canary + route attestation ride the consumer fleet gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)