### PR TITLE
feat(perplexica): stable-alias gateway route contract (PR 4B)

### DIFF
--- a/ods/extensions/services/perplexica/manifest.yaml
+++ b/ods/extensions/services/perplexica/manifest.yaml
@@ -22,8 +22,8 @@ service:
   depends_on: [searxng, llama-server]
   llm:
     consumes: true
-    route: direct
-    pinning: dynamic
+    route: gateway
+    pinning: none
     min_context: 65536
     probe:
       kind: custom


### PR DESCRIPTION
Switchboard PR 4B — plan `ods/docs/MODEL-SWITCHBOARD.md`. Perplexica adopts the #1766 stable-alias contract (route: gateway, pinning: none). Per-swap rewrite removal consolidated into PR 7's mode-aware cutover (recorded deviation; observe/legacy unchanged). Contracts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)