### PR TITLE
feat(opencode): stable-alias gateway route contract (PR 4C)

### DIFF
--- a/ods/extensions/services/opencode/manifest.yaml
+++ b/ods/extensions/services/opencode/manifest.yaml
@@ -20,8 +20,8 @@ service:
   sidebar_icon: Code
   llm:
     consumes: true
-    route: direct
-    pinning: dynamic
+    route: gateway
+    pinning: none
     min_context: 65536
     probe:
       kind: custom


### PR DESCRIPTION
Switchboard PR 4C — OpenCode adopts the #1766 stable-alias contract (route: gateway, pinning: none). Per-swap rewrite removal consolidated into PR 7's mode-aware cutover (recorded deviation; observe/legacy unchanged). Contracts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)