### PR TITLE
feat(hermes): stable-alias gateway route contract (PR 5A)

### DIFF
--- a/ods/extensions/services/hermes/manifest.yaml
+++ b/ods/extensions/services/hermes/manifest.yaml
@@ -36,8 +36,8 @@ service:
   depends_on: [llama-server, searxng]
   llm:
     consumes: true
-    route: direct
-    pinning: dynamic
+    route: gateway
+    pinning: none
     min_context: 65536
     probe:
       kind: custom


### PR DESCRIPTION
Switchboard PR 5A — Hermes/ODS Talk adopts the #1766 stable-alias contract (route: gateway, pinning: none), keeps the 65,536-token agent floor. Per-swap patch/restart removal consolidated into PR 7's mode-aware cutover (recorded deviation; observe/legacy unchanged). Contracts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)