### PR TITLE
feat(openclaw): stable-alias gateway route contract (PR 5B)

### DIFF
--- a/ods/extensions/services/openclaw/manifest.yaml
+++ b/ods/extensions/services/openclaw/manifest.yaml
@@ -28,7 +28,7 @@ service:
   depends_on: [llama-server, searxng]
   llm:
     consumes: true
-    route: direct
+    route: gateway
     pinning: none
     min_context: 65536
     probe:


### PR DESCRIPTION
Switchboard PR 5B — OpenClaw adopts the #1766 stable-alias gateway route. Per-swap recreation removal consolidated into PR 7 (recorded deviation; observe/legacy unchanged). Contracts pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)