### PR TITLE
fix(installers): build model-router local image on every platform (P0 fleet regression)

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Switchboard Bypass Inventory
         run: python3 tests/test-switchboard-bypass-inventory.py
 
+      - name: Local Image Build Coverage
+        run: python3 tests/test-local-image-build-coverage.py
+
       - name: Validate Manifests Tests
         run: bash tests/test-validate-manifests.sh
 

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2377,7 +2377,7 @@ for service in (data.get("services") or {}).values():
     # surface unrelated Dockerfile failures and make a healthy selected stack
     # look broken.
     ai "Rebuilding local-built images..."
-    _macos_candidate_build_services=(dashboard dashboard-api ape token-spy privacy-shield)
+    _macos_candidate_build_services=(dashboard dashboard-api model-router ape token-spy privacy-shield)
     if ! _macos_enabled_services="$(docker compose "${COMPOSE_FLAGS[@]}" config --services 2>>"$ODS_LOG_FILE")"; then
         ai_err "Could not resolve macOS compose services for local image rebuilds."
         ai "Inspect compose config with: cd '$INSTALL_DIR' && docker compose ${COMPOSE_FLAGS[*]} config --services"

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -1025,7 +1025,7 @@ MODELS_INI_EOF
     compose_ok=false
     # Build local images individually so every failure is reported before the
     # installer refuses to launch any potentially stale image.
-    _candidate_build_services=(dashboard dashboard-api ape token-spy privacy-shield)
+    _candidate_build_services=(dashboard dashboard-api model-router ape token-spy privacy-shield)
     [[ "$ENABLE_COMFYUI" == "true" ]] && _candidate_build_services+=(comfyui)
     [[ "$GPU_BACKEND" == "amd" ]] && _candidate_build_services+=(llama-server)
     if ! _enabled_compose_services="$($DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" config --services 2>>"$LOG_FILE")"; then

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -1648,7 +1648,7 @@ litellm_settings:
         # `up -d`. llama-server runs natively on Windows (Lemonade or Vulkan
         # binary) so it is not built here. ComfyUI is only locally built on
         # NVIDIA; the Windows AMD stack uses a prebuilt image overlay.
-        $_buildServices = @("dashboard", "dashboard-api")
+        $_buildServices = @("dashboard", "dashboard-api", "model-router")
         if (Test-ODSWindowsServiceEnabled -ServiceId "ape" -Plan $servicePlan) {
             $_buildServices += "ape"
         }

--- a/ods/tests/test-local-image-build-coverage.py
+++ b/ods/tests/test-local-image-build-coverage.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Local-image build coverage contract.
+
+Every service defined in docker-compose.base.yml with a ``build:`` section and
+no pull-able ``image:`` must appear in each installer's local-build list, or the
+installer runs ``docker compose up --no-build`` against an image that was never
+built and fails with "No such image" on a fresh host.
+
+This is the negative self-test for the model-router fleet regression
+(build-only core service missing from the hardcoded installer build lists):
+CI validated compose config but never ran the real build->up flow, so the gap
+only surfaced on live hosts. This contract closes that gap.
+
+Stdlib only. Run: python3 tests/test-local-image-build-coverage.py
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BASE = ROOT / "docker-compose.base.yml"
+LINUX = ROOT / "installers" / "phases" / "11-services.sh"
+MACOS = ROOT / "installers" / "macos" / "install-macos.sh"
+WINDOWS = ROOT / "installers" / "windows" / "install-windows.ps1"
+
+# Services intentionally NOT built by the base install path (documented):
+#   llama-server  — pulled image on most backends; AMD builds it via a
+#                   backend-specific branch, not the base build list.
+#   comfyui       — optional, gated on ENABLE_COMFYUI.
+_KNOWN_NON_BASE_BUILD = {"llama-server", "comfyui"}
+
+
+def base_build_only_services() -> set[str]:
+    """Top-level base.yml services that have build: and no image:."""
+    text = BASE.read_text(encoding="utf-8")
+    lines = text.splitlines()
+    in_services = False
+    services: dict[str, dict[str, bool]] = {}
+    current: str | None = None
+    for line in lines:
+        if re.match(r"^services:\s*$", line):
+            in_services = True
+            continue
+        if not in_services:
+            continue
+        m = re.match(r"^  ([a-z0-9][a-z0-9-]*):\s*$", line)
+        if m:
+            current = m.group(1)
+            services[current] = {"build": False, "image": False}
+            continue
+        if current and re.match(r"^    build:\s*$", line):
+            services[current]["build"] = True
+        elif current and re.match(r"^    image:\s", line):
+            services[current]["image"] = True
+    return {
+        name for name, flags in services.items()
+        if flags["build"] and not flags["image"]
+    }
+
+
+def installer_build_list(path: Path, pattern: str) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    found: set[str] = set()
+    for m in re.finditer(pattern, text):
+        found.update(re.findall(r"[a-z0-9][a-z0-9-]+", m.group(1)))
+    # every conditional single-add line: += "svc" / +=(svc)
+    return found
+
+
+def main() -> int:
+    required = base_build_only_services() - _KNOWN_NON_BASE_BUILD
+    errors: list[str] = []
+
+    # Linux: _candidate_build_services=(...) plus any += lines
+    linux_text = LINUX.read_text(encoding="utf-8")
+    linux = set()
+    m = re.search(r"_candidate_build_services=\(([^)]*)\)", linux_text)
+    if m:
+        linux.update(re.findall(r"[a-z0-9][a-z0-9-]+", m.group(1)))
+    linux.update(re.findall(r"_candidate_build_services\+=\(([a-z0-9-]+)\)", linux_text))
+
+    # macOS
+    macos_text = MACOS.read_text(encoding="utf-8")
+    macos = set()
+    m = re.search(r"_macos_candidate_build_services=\(([^)]*)\)", macos_text)
+    if m:
+        macos.update(re.findall(r"[a-z0-9][a-z0-9-]+", m.group(1)))
+
+    # Windows: $_buildServices = @(...) plus += "svc" lines
+    win_text = WINDOWS.read_text(encoding="utf-8")
+    windows = set()
+    m = re.search(r"\$_buildServices = @\(([^)]*)\)", win_text)
+    if m:
+        windows.update(re.findall(r'"([a-z0-9-]+)"', m.group(1)))
+    windows.update(re.findall(r'\$_buildServices \+= "([a-z0-9-]+)"', win_text))
+
+    for name, present in (("Linux 11-services.sh", linux),
+                          ("macOS install-macos.sh", macos),
+                          ("Windows install-windows.ps1", windows)):
+        missing = required - present
+        if missing:
+            errors.append(f"{name}: build-only base services not in build list: {sorted(missing)}")
+
+    if errors:
+        print("[FAIL] local-image build coverage:")
+        for e in errors:
+            print(f"  - {e}")
+        print(f"  (base build-only services requiring coverage: {sorted(required)})")
+        return 1
+    print(f"[OK] local-image build coverage: {sorted(required)} covered by all installers")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
**P0 caught by composed-main fleet validation.** model-router (PR 3) is a core, build-only service, but it was missing from the hardcoded local-build lists in all three installers. Fresh installs run `compose up --no-build --pull never`, so the image was never built and compose-up failed with `No such image: ods-model-router:latest` on tower2, strix-halo, spark, and m5-mbp.

Per-PR CI validated compose config but never ran the real build→up flow — the exact CI-vs-fleet gap. Fix: add model-router to Linux/macOS/Windows build lists (cloud-only skips it via existing guards) + `test-local-image-build-coverage.py` contract (verified it fails when the entry is removed), wired into test-linux smoke.

Will be re-proven by a fresh composed-main fleet run before the switchboard is considered fleet-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)