### PR TITLE
feat(windows): add wslc runtime constants and detection function

### DIFF
--- a/ods/installers/windows/lib/constants.ps1
+++ b/ods/installers/windows/lib/constants.ps1
@@ -49,6 +49,11 @@ $script:MIN_DOCKER_VERSION = "4.20.0"
 # Minimum NVIDIA driver version for CUDA in Docker Desktop
 $script:MIN_NVIDIA_DRIVER = 570
 
+# wslc (WSL Container) -- Docker-free OCI runtime for Windows 11 pre-release
+# Activated via --WslcMode on the installer. Requires: wsl --update --pre-release
+$script:WSLC_NETWORK_NAME = "ods-network"
+$script:WSLC_MODE_MARKER  = ".wslc-mode"
+
 # OpenCode (host-level AI coding IDE, not a Docker service)
 $script:OPENCODE_VERSION = "1.2.18"
 $script:OPENCODE_ZIP = "opencode-windows-x64.zip"

--- a/ods/installers/windows/lib/detection.ps1
+++ b/ods/installers/windows/lib/detection.ps1
@@ -231,6 +231,88 @@ function Test-DockerDesktop {
     return $result
 }
 
+function Test-WslcRuntime {
+    <#
+    .SYNOPSIS
+        Verify wslc.exe is installed and its daemon is responsive.
+    .DESCRIPTION
+        wslc is a Docker-compatible OCI container runtime shipping with WSL
+        pre-release builds for Windows 11. It requires no Docker Desktop.
+
+        GPU support is inferred from host nvidia-smi presence (CDI wires the
+        GPU into the container without a separate runtime registration step).
+        The actual CDI container smoke test runs later in phase 05, matching
+        the Docker path where the container GPU test is also deferred.
+    .OUTPUTS
+        @{ Installed; Running; Version; GpuSupport; WslPreRelease }
+    #>
+    $result = @{
+        Installed     = $false
+        Running       = $false
+        Version       = ""
+        GpuSupport    = $false
+        WslPreRelease = $false
+    }
+
+    # ── CLI presence ─────────────────────────────────────────────────────────
+    $wslcCmd = Get-Command wslc -ErrorAction SilentlyContinue
+    if (-not $wslcCmd) { return $result }
+    $result.Installed = $true
+
+    # ── Version (best-effort; pre-release format may vary) ───────────────────
+    try {
+        $versionLines = & wslc --version 2>$null
+        if ($LASTEXITCODE -eq 0 -and $versionLines) {
+            $result.Version = (@($versionLines) | Select-Object -First 1).Trim()
+        }
+    } catch {
+        # --version flag behavior undefined in early pre-release; non-fatal
+    }
+
+    # ── WSL pre-release confirmation ─────────────────────────────────────────
+    # wslc ships exclusively with WSL pre-release builds, so its presence on
+    # PATH already implies pre-release is active. We additionally confirm with
+    # `wsl --version` as a sanity check, but treat any failure as non-fatal
+    # because some pre-release environments suppress that subcommand.
+    try {
+        $null = & wsl --version 2>$null
+        $result.WslPreRelease = ($LASTEXITCODE -eq 0)
+    } catch {
+        # wslc is present, so pre-release is implied even if wsl --version fails
+        $result.WslPreRelease = $true
+    }
+
+    # ── Daemon responsiveness ────────────────────────────────────────────────
+    # Mirrors Test-DockerDesktop: SilentlyContinue around the native call so
+    # PS 5.1 does not wrap stderr as a terminating error, and finally always
+    # restores ErrorActionPreference even if the call throws.
+    $prevEAP = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = "SilentlyContinue"
+        $null = & wslc info 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $result.Running = $true
+        }
+    } catch {
+        # Daemon not responsive
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+
+    if (-not $result.Running) { return $result }
+
+    # ── GPU support ──────────────────────────────────────────────────────────
+    # CDI exposes NVIDIA GPUs to wslc containers via --device=nvidia.com/gpu=*.
+    # No separate runtime registration is required (unlike Linux Docker Engine).
+    # We mirror Test-DockerDesktop: check host nvidia-smi; the full container
+    # smoke test (actually running nvidia-smi inside a wslc container) happens
+    # in the dedicated Docker/wslc validation phase.
+    $nvsmi = Get-Command nvidia-smi -ErrorAction SilentlyContinue
+    if ($nvsmi) { $result.GpuSupport = $true }
+
+    return $result
+}
+
 function Get-HostLogicalCpuCount {
     <#
     .SYNOPSIS


### PR DESCRIPTION
## Summary

<!-- What changed, and why? -->

## AI Assistance

<!-- If AI tools helped draft code, docs, tests, reviews, or triage, say what they did. Use "None" when not applicable. The human author remains accountable for reading the diff, choosing the validation, and responding to review. -->

## Release Lane

<!-- Pick the lane before review. See ods/docs/RELEASE_CHANNELS.md. -->

- [ ] Stable hotfix targeting `release/2.5.x`
- [ ] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
<!-- If this targets release/2.5.x, explain the current-stable user problem it fixes. -->
```

## Changed Surface

<!-- Check every surface this PR can affect. -->

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Risk And Validation

<!-- Use ods/docs/HIGH_RISK_CHANGE_MAP.md to pick the right level. -->

- Risk level: <!-- Low / Medium / High -->
- Validation run:
  - [ ] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [ ] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`
  - [ ] Not required because: <!-- explain -->

Commands/results:

```text
<!-- paste the important commands and results -->
```

## Operational Change Check

If this PR touches installer phases, bootstrap logic, compose stack generation,
service manifests, dashboard API control flows, Hermes, model routing, GPU or
runtime detection, lifecycle commands, host mutation, or network exposure, it
requires release-grade fleet validation before release unless the PR explains a
narrower equivalent.

- [ ] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Notes For Reviewers

<!-- Call out skipped/deferred lanes, known limitations, or rollback notes. -->
