### PR TITLE
feat(models): consumer runtime cutover to gateway in enabled mode (PR 7, DRAFT)

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -514,3 +514,16 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # TS_AUTHKEY=tskey-auth-xxxxxxxxxxxxxxxxxxxxxx
 # TS_HOSTNAME=                         # Defaults to ODS_DEVICE_NAME
 # TS_EXTRA_ARGS=                       # Optional, e.g. --advertise-tags=tag:ods
+
+# --- Model Switchboard (PR 7) ---
+# Rollout mode: legacy | observe | enabled. enabled routes local text
+# consumers through ods/current -> model-router.
+ODS_MODEL_SWITCHBOARD=observe
+# Stable public alias consumers request in enabled mode.
+ODS_PUBLIC_MODEL=ods/current
+# Consumer LLM endpoint overrides (set to the LiteLLM gateway in enabled mode;
+# empty in observe/legacy so direct-backend defaults apply).
+OPEN_WEBUI_LLM_BASE_URL=
+PERPLEXICA_LLM_BASE_URL=
+OPENCODE_LLM_BASE_URL=
+OPENCLAW_LLM_BASE_URL=

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -234,13 +234,20 @@
     "OPENCLAW_DANGEROUSLY_DISABLE_DEVICE_AUTH": {
       "type": "string",
       "description": "Dangerous escape hatch that disables OpenClaw device pairing. Leave empty unless you fully accept unauthenticated LAN/Tailscale agent access risk.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "BIND_ADDRESS": {
       "type": "string",
       "description": "IP address for Docker port bindings. 127.0.0.1 (default) for localhost-only access. 0.0.0.0 for LAN access on headless servers. See SECURITY.md.",
-      "enum": ["127.0.0.1", "0.0.0.0"],
+      "enum": [
+        "127.0.0.1",
+        "0.0.0.0"
+      ],
       "default": "127.0.0.1"
     },
     "HOST_LAN_IP": {
@@ -315,7 +322,11 @@
     "MODEL_RECOMMENDATION_CONFIDENCE": {
       "type": "string",
       "description": "Confidence level for the installer model recommendation.",
-      "enum": ["low", "medium", "high"]
+      "enum": [
+        "low",
+        "medium",
+        "high"
+      ]
     },
     "MODEL_RECOMMENDATION_REASON": {
       "type": "string",
@@ -328,7 +339,13 @@
     "MODEL_PERFORMANCE_SOURCE": {
       "type": "string",
       "description": "Initial performance source for the recommended model before local benchmarking.",
-      "enum": ["benchmark_required", "measured_local", "published_exact", "predicted_calibrated", "incompatible"]
+      "enum": [
+        "benchmark_required",
+        "measured_local",
+        "published_exact",
+        "predicted_calibrated",
+        "incompatible"
+      ]
     },
     "MODEL_PERFORMANCE_LABEL": {
       "type": "string",
@@ -365,7 +382,10 @@
     "WHISPER_ACCELERATION": {
       "type": "string",
       "description": "Whisper runtime acceleration selected by the installer. Windows NVIDIA installs fall back to cpu when the installed driver cannot run the CUDA image.",
-      "enum": ["cpu", "cuda"]
+      "enum": [
+        "cpu",
+        "cuda"
+      ]
     },
     "LLAMA_CPU_LIMIT": {
       "type": "number",
@@ -681,7 +701,11 @@
     },
     "N8N_SECURE_COOKIE": {
       "type": "string",
-      "enum": ["auto", "true", "false"],
+      "enum": [
+        "auto",
+        "true",
+        "false"
+      ],
       "description": "n8n session-cookie policy. auto disables Secure only for loopback HTTP and enables it for HTTPS or non-loopback binds.",
       "default": "auto"
     },
@@ -712,7 +736,7 @@
     },
     "HSA_OVERRIDE_GFX_VERSION": {
       "type": "string",
-      "description": "ROCm HSA gfx-target override (HSA-version format, e.g. '11.5.1' for gfx1151). Phase 06 sets this only when the detected gfx target is gfx1151 (Strix Halo, not in ROCm's native support list). Leave unset on natively-supported parts (gfx942/MI300X, gfx90a/MI250, gfx1100/RX 7900) — setting it on those crashes model-load with HSA_STATUS_ERROR_INVALID_ISA."
+      "description": "ROCm HSA gfx-target override (HSA-version format, e.g. '11.5.1' for gfx1151). Phase 06 sets this only when the detected gfx target is gfx1151 (Strix Halo, not in ROCm's native support list). Leave unset on natively-supported parts (gfx942/MI300X, gfx90a/MI250, gfx1100/RX 7900) \u2014 setting it on those crashes model-load with HSA_STATUS_ERROR_INVALID_ISA."
     },
     "ROCBLAS_USE_HIPBLASLT": {
       "type": "integer",
@@ -906,13 +930,21 @@
     "LLAMA_REASONING": {
       "type": "string",
       "description": "llama.cpp reasoning/thinking mode: off (default) | auto | on. Off prevents thinking models from consuming the entire token budget on internal reasoning.",
-      "enum": ["off", "auto", "on"],
+      "enum": [
+        "off",
+        "auto",
+        "on"
+      ],
       "default": "off"
     },
     "LLAMA_ARG_FLASH_ATTN": {
       "type": "string",
       "description": "llama.cpp Flash Attention mode. Use 'on' for long-context performance tuning when the selected backend supports it.",
-      "enum": ["auto", "on", "off"],
+      "enum": [
+        "auto",
+        "on",
+        "off"
+      ],
       "default": "auto"
     },
     "LLAMA_ARG_CACHE_TYPE_K": {
@@ -937,7 +969,15 @@
     "LLAMA_ARG_NO_CACHE_PROMPT": {
       "type": "string",
       "description": "Optional llama.cpp boolean flag (--no-cache-prompt) used by specific long-context runtime profiles.",
-      "enum": ["", "0", "1", "false", "true", "off", "on"]
+      "enum": [
+        "",
+        "0",
+        "1",
+        "false",
+        "true",
+        "off",
+        "on"
+      ]
     },
     "LLAMA_ARG_CHECKPOINT_EVERY_N_TOKENS": {
       "type": "integer",
@@ -1000,12 +1040,16 @@
     "LEMONADE_LLAMACPP": {
       "type": "string",
       "description": "Lemonade inner llama.cpp backend selector for AMD multi-GPU. Applied by docker-compose.multigpu-amd.yml. Lemonade's schema accepts only auto|vulkan|cpu; 'auto' plus LEMONADE_LLAMACPP_ROCM_BIN picks up the custom ROCm-built binary.",
-      "enum": ["auto", "vulkan", "cpu"],
+      "enum": [
+        "auto",
+        "vulkan",
+        "cpu"
+      ],
       "default": "auto"
     },
     "LEMONADE_LLAMACPP_ROCM_BIN": {
       "type": "string",
-      "description": "Path inside the llama-server container to a custom ROCm-built llama-server binary. Phase 06 sets this to /opt/llama-custom/llama-server only when the detected gfx target is gfx1151 (the custom binary is built with Strix-Halo-specific patches — MMQ tile size + AMDGPU_TARGET=gfx1151 — and either ISA-faults or runs perf-regressed on other architectures). Empty / unset → Lemonade uses its bundled ROCm-aware binary, which works for gfx942/MI300X and other natively-supported parts."
+      "description": "Path inside the llama-server container to a custom ROCm-built llama-server binary. Phase 06 sets this to /opt/llama-custom/llama-server only when the detected gfx target is gfx1151 (the custom binary is built with Strix-Halo-specific patches \u2014 MMQ tile size + AMDGPU_TARGET=gfx1151 \u2014 and either ISA-faults or runs perf-regressed on other architectures). Empty / unset \u2192 Lemonade uses its bundled ROCm-aware binary, which works for gfx942/MI300X and other natively-supported parts."
     },
     "LLM_MODEL_SIZE_MB": {
       "type": "integer",
@@ -1030,7 +1074,10 @@
     "APE_STRICT_MODE": {
       "type": "string",
       "description": "When true, APE blocks policy violations instead of only logging advisory decisions.",
-      "enum": ["true", "false"],
+      "enum": [
+        "true",
+        "false"
+      ],
       "default": "false"
     },
     "OPENCLAW_API_KEY": {
@@ -1049,7 +1096,11 @@
     "OPENCLAW_HTTP_API": {
       "type": "string",
       "description": "Opt-in OpenClaw OpenAI-compatible HTTP shim. Leave empty unless you are deliberately exposing the shim for advanced integrations.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "ODS_AGENT_BIND": {
@@ -1082,13 +1133,21 @@
     "ODS_MACOS_LLM_BRIDGE_ENABLED": {
       "type": "string",
       "description": "Whether the private Colima-to-native-llama bridge is managed by the macOS installer.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "ODS_MACOS_HOST_AGENT_BRIDGE_ENABLED": {
       "type": "string",
       "description": "Whether the private Colima-to-host-agent bridge is managed by the macOS installer.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "ODS_NATIVE_LLAMA_PORT": {
@@ -1185,7 +1244,7 @@
     },
     "ODS_PROXY_PORT": {
       "type": "integer",
-      "description": "Host port for the ODS reverse proxy (Caddy). Default 80 — standard HTTP. The proxy is opt-in via `ods enable ods-proxy`.",
+      "description": "Host port for the ODS reverse proxy (Caddy). Default 80 \u2014 standard HTTP. The proxy is opt-in via `ods enable ods-proxy`.",
       "default": 80
     },
     "ODS_PROXY_TLS_PORT": {
@@ -1195,7 +1254,7 @@
     },
     "ODS_PROXY_BIND": {
       "type": "string",
-      "description": "Bind address for the reverse proxy's host port. Defaults to 0.0.0.0 (LAN-exposed) — that's the whole point of the proxy. Override to 127.0.0.1 to keep it localhost-only.",
+      "description": "Bind address for the reverse proxy's host port. Defaults to 0.0.0.0 (LAN-exposed) \u2014 that's the whole point of the proxy. Override to 127.0.0.1 to keep it localhost-only.",
       "default": "0.0.0.0"
     },
     "HERMES_LLM_BASE_URL": {
@@ -1231,7 +1290,11 @@
     "WHATSAPP_ENABLED": {
       "type": "string",
       "description": "Enable Hermes's optional WhatsApp gateway integration. Disabled by default.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": "false"
     },
     "WHATSAPP_MODE": {
@@ -1246,7 +1309,11 @@
     "WHATSAPP_REQUIRE_MENTION": {
       "type": "string",
       "description": "Require a mention/prefix before Hermes replies in WhatsApp chats.",
-      "enum": ["", "true", "false"],
+      "enum": [
+        "",
+        "true",
+        "false"
+      ],
       "default": ""
     },
     "WHATSAPP_FREE_RESPONSE_CHATS": {
@@ -1289,6 +1356,41 @@
     "TS_EXTRA_ARGS": {
       "type": "string",
       "description": "Optional extra flags passed to `tailscale up`, such as --advertise-tags=tag:ods after your tailnet ACL defines and authorizes that tag."
+    },
+    "ODS_MODEL_SWITCHBOARD": {
+      "type": "string",
+      "enum": [
+        "legacy",
+        "observe",
+        "enabled"
+      ],
+      "description": "Model Switchboard rollout mode. enabled routes consumers through ods/current -> model-router.",
+      "default": "observe"
+    },
+    "ODS_PUBLIC_MODEL": {
+      "type": "string",
+      "description": "Stable public model alias consumers request in enabled switchboard mode.",
+      "default": "ods/current"
+    },
+    "OPEN_WEBUI_LLM_BASE_URL": {
+      "type": "string",
+      "description": "Override for Open WebUI's LLM endpoint; set to the LiteLLM gateway in enabled switchboard mode.",
+      "default": ""
+    },
+    "PERPLEXICA_LLM_BASE_URL": {
+      "type": "string",
+      "description": "Override for Perplexica's LLM endpoint; LiteLLM gateway in enabled switchboard mode.",
+      "default": ""
+    },
+    "OPENCODE_LLM_BASE_URL": {
+      "type": "string",
+      "description": "Override for OpenCode's LLM endpoint; LiteLLM gateway in enabled switchboard mode.",
+      "default": ""
+    },
+    "OPENCLAW_LLM_BASE_URL": {
+      "type": "string",
+      "description": "Override for OpenClaw's LLM endpoint; LiteLLM gateway in enabled switchboard mode.",
+      "default": ""
     }
   }
 }

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -911,6 +911,43 @@ ENV_EOF
     ai_ok "Created $INSTALL_DIR"
     ai_ok "Generated secure secrets in .env (permissions: 600)"
 
+    # Switchboard consumer runtime cutover (PR 7). In enabled mode every local
+    # text consumer addresses the LiteLLM gateway with the stable alias, which
+    # forwards ods/current -> model-router -> the active backend. Observe/legacy
+    # append nothing, so the direct-backend defaults stay byte-identical.
+    _ods_switchboard_mode="${ODS_MODEL_SWITCHBOARD:-observe}"
+    {
+        printf '
+ODS_MODEL_SWITCHBOARD=%s
+' "$_ods_switchboard_mode"
+        if [[ "$_ods_switchboard_mode" == "enabled" ]]; then
+            _sb_gateway="http://litellm:4000/v1"
+            printf 'ODS_PUBLIC_MODEL=%s
+' "ods/current"
+            printf 'OPEN_WEBUI_LLM_BASE_URL=%s
+' "$_sb_gateway"
+            printf 'PERPLEXICA_LLM_BASE_URL=%s
+' "$_sb_gateway"
+            printf 'OPENCODE_LLM_BASE_URL=%s
+' "$_sb_gateway"
+            printf 'HERMES_LLM_BASE_URL=%s
+' "$_sb_gateway"
+            printf 'OPENCLAW_LLM_BASE_URL=%s
+' "$_sb_gateway"
+        fi
+    } >> "$INSTALL_DIR/.env"
+    if [[ "$_ods_switchboard_mode" == "enabled" ]]; then
+        ai_ok "Model Switchboard enabled: consumers route through ods/current"
+        # Render the file-based consumer configs (Perplexica seed, OpenCode
+        # auth, Hermes config) in enabled mode so they address the gateway.
+        _sb_py="${ODS_PYTHON_CMD:-python3}"
+        if [[ -f "$SCRIPT_DIR/scripts/render-runtime-configs.py" ]] && command -v "$_sb_py" >/dev/null 2>&1; then
+            for _sb_surface in perplexica opencode hermes litellm-switchboard model-router-endpoints; do
+                "$_sb_py" "$SCRIPT_DIR/scripts/render-runtime-configs.py"                     --surface "$_sb_surface"                     --switchboard-mode enabled                     --ods-mode "${ODS_MODE:-local}"                     --gpu-backend "${GPU_BACKEND:-nvidia}"                     --gguf-file "${GGUF_FILE:-}"                     --llm-base-url "${LLM_API_URL_VALUE:-http://llama-server:8080}"                     --output-root "$INSTALL_DIR"                     --write >> "$LOG_FILE" 2>&1                     || warn "switchboard render failed for $_sb_surface"
+            done
+        fi
+    fi
+
     # Generate LiteLLM config for Lemonade.
     # Lemonade exposes models as "extra.<GGUF_FILENAME>" — the wildcard
     # passthrough (openai/*) does NOT work because it forwards the friendly

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -916,33 +916,37 @@ ENV_EOF
     # forwards ods/current -> model-router -> the active backend. Observe/legacy
     # append nothing, so the direct-backend defaults stay byte-identical.
     _ods_switchboard_mode="${ODS_MODEL_SWITCHBOARD:-observe}"
-    {
-        printf '
-ODS_MODEL_SWITCHBOARD=%s
-' "$_ods_switchboard_mode"
-        if [[ "$_ods_switchboard_mode" == "enabled" ]]; then
-            _sb_gateway="http://litellm:4000/v1"
-            printf 'ODS_PUBLIC_MODEL=%s
-' "ods/current"
-            printf 'OPEN_WEBUI_LLM_BASE_URL=%s
-' "$_sb_gateway"
-            printf 'PERPLEXICA_LLM_BASE_URL=%s
-' "$_sb_gateway"
-            printf 'OPENCODE_LLM_BASE_URL=%s
-' "$_sb_gateway"
-            printf 'HERMES_LLM_BASE_URL=%s
-' "$_sb_gateway"
-            printf 'OPENCLAW_LLM_BASE_URL=%s
-' "$_sb_gateway"
+    # Set-or-replace a key in .env (avoids duplicating keys the base heredoc
+    # already wrote, e.g. HERMES_LLM_BASE_URL).
+    _sb_env_set() {
+        local _k="$1" _v="$2" _f="$INSTALL_DIR/.env"
+        if grep -q "^${_k}=" "$_f" 2>/dev/null; then
+            local _tmp; _tmp="$(mktemp)"
+            grep -v "^${_k}=" "$_f" > "$_tmp" && printf '%s=%s
+' "$_k" "$_v" >> "$_tmp" && mv "$_tmp" "$_f"
+        else
+            printf '%s=%s
+' "$_k" "$_v" >> "$_f"
         fi
-    } >> "$INSTALL_DIR/.env"
+    }
+    _sb_env_set ODS_MODEL_SWITCHBOARD "$_ods_switchboard_mode"
+    if [[ "$_ods_switchboard_mode" == "enabled" ]]; then
+        _sb_gateway="http://litellm:4000/v1"
+        _sb_env_set ODS_PUBLIC_MODEL "ods/current"
+        _sb_env_set OPEN_WEBUI_LLM_BASE_URL "$_sb_gateway"
+        _sb_env_set PERPLEXICA_LLM_BASE_URL "$_sb_gateway"
+        _sb_env_set OPENCODE_LLM_BASE_URL "$_sb_gateway"
+        _sb_env_set HERMES_LLM_BASE_URL "$_sb_gateway"
+        _sb_env_set OPENCLAW_LLM_BASE_URL "$_sb_gateway"
+    fi
+    chmod 600 "$INSTALL_DIR/.env"
     if [[ "$_ods_switchboard_mode" == "enabled" ]]; then
         ai_ok "Model Switchboard enabled: consumers route through ods/current"
         # Render the file-based consumer configs (Perplexica seed, OpenCode
         # auth, Hermes config) in enabled mode so they address the gateway.
         _sb_py="${ODS_PYTHON_CMD:-python3}"
         if [[ -f "$SCRIPT_DIR/scripts/render-runtime-configs.py" ]] && command -v "$_sb_py" >/dev/null 2>&1; then
-            for _sb_surface in perplexica opencode hermes litellm-switchboard model-router-endpoints; do
+            for _sb_surface in perplexica opencode litellm-switchboard model-router-endpoints; do
                 "$_sb_py" "$SCRIPT_DIR/scripts/render-runtime-configs.py"                     --surface "$_sb_surface"                     --switchboard-mode enabled                     --ods-mode "${ODS_MODE:-local}"                     --gpu-backend "${GPU_BACKEND:-nvidia}"                     --gguf-file "${GGUF_FILE:-}"                     --llm-base-url "${LLM_API_URL_VALUE:-http://llama-server:8080}"                     --output-root "$INSTALL_DIR"                     --write >> "$LOG_FILE" 2>&1                     || warn "switchboard render failed for $_sb_surface"
             done
         fi

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -68,6 +68,19 @@ def opencode_key(inputs: RenderInputs) -> str:
     return inputs.litellm_key if inputs.ods_mode == "lemonade" else NO_KEY
 
 
+def _switchboard_consumer_route(inputs: "RenderInputs") -> tuple[str, str] | None:
+    """(base_url, model) a consumer must use in enabled mode, else None.
+
+    In enabled mode every local text consumer addresses the LiteLLM gateway
+    with the stable public alias; LiteLLM forwards ods/current to the
+    model-router. In legacy/observe this returns None and each renderer keeps
+    its existing direct-backend behavior byte-identical.
+    """
+    if inputs.switchboard_mode == "enabled":
+        return ("http://litellm:4000/v1", "ods/current")
+    return None
+
+
 def render_litellm_lemonade(inputs: RenderInputs) -> RenderedFile:
     model = lemonade_model_id(inputs)
     api_base = inputs.lemonade_api_base.rstrip("/") or "http://llama-server:8080/api/v1"
@@ -100,11 +113,13 @@ litellm_settings:
 
 
 def render_hermes(inputs: RenderInputs) -> RenderedFile:
-    model = hermes_model_id(inputs)
+    _sb = _switchboard_consumer_route(inputs)
+    model = _sb[1] if _sb is not None else hermes_model_id(inputs)
+    _h_base = _sb[0] if _sb is not None else inputs.llm_base_url
     content = f"""model:
   default: "{model}"
   provider: "custom"
-  base_url: "{inputs.llm_base_url}"
+  base_url: "{_h_base}"
   context_length: {inputs.context_length}
 
 auxiliary:
@@ -121,10 +136,14 @@ compression:
 
 
 def render_perplexica(inputs: RenderInputs) -> RenderedFile:
-    model = lemonade_model_id(inputs) if inputs.ods_mode == "lemonade" else (inputs.gguf_file or inputs.model)
-    base_url = inputs.llm_base_url.rstrip("/") or "http://llama-server:8080"
-    if not (base_url.endswith("/v1") or base_url.endswith("/api/v1")):
-        base_url = f"{base_url}/v1"
+    _sb = _switchboard_consumer_route(inputs)
+    if _sb is not None:
+        base_url, model = _sb[0], _sb[1]
+    else:
+        model = lemonade_model_id(inputs) if inputs.ods_mode == "lemonade" else (inputs.gguf_file or inputs.model)
+        base_url = inputs.llm_base_url.rstrip("/") or "http://llama-server:8080"
+        if not (base_url.endswith("/v1") or base_url.endswith("/api/v1")):
+            base_url = f"{base_url}/v1"
     payload = {
         "modelProviders": [
             {
@@ -154,11 +173,16 @@ def render_perplexica(inputs: RenderInputs) -> RenderedFile:
 
 
 def render_opencode(inputs: RenderInputs) -> RenderedFile:
+    _sb = _switchboard_consumer_route(inputs)
+    _oc_base = _sb[0] if _sb is not None else inputs.llm_base_url
+    _oc_model = _sb[1] if _sb is not None else (
+        lemonade_model_id(inputs) if inputs.ods_mode == "lemonade" else inputs.model
+    )
     payload = {
         "provider": "openai-compatible",
-        "baseURL": inputs.llm_base_url,
+        "baseURL": _oc_base,
         "apiKey": opencode_key(inputs),
-        "model": lemonade_model_id(inputs) if inputs.ods_mode == "lemonade" else inputs.model,
+        "model": _oc_model,
         "port": inputs.opencode_port,
     }
     return RenderedFile(

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -185,6 +185,22 @@ def render_env(inputs: RenderInputs) -> RenderedFile:
         f"CTX_SIZE={inputs.context_length}",
         f"MAX_CONTEXT={inputs.context_length}",
     ]
+    # Switchboard consumer runtime cutover (PR 7): in enabled mode every local
+    # text consumer addresses the LiteLLM gateway with the stable alias, which
+    # forwards ods/current -> model-router -> active backend. Legacy/observe
+    # emit no consumer overrides, so the byte-identical direct-backend defaults
+    # in docker-compose.base.yml remain authoritative.
+    lines.append(f"ODS_MODEL_SWITCHBOARD={inputs.switchboard_mode}")
+    if inputs.switchboard_mode == "enabled":
+        gateway = "http://litellm:4000/v1"
+        lines += [
+            f"OPEN_WEBUI_LLM_BASE_URL={gateway}",
+            f"PERPLEXICA_LLM_BASE_URL={gateway}",
+            f"OPENCODE_LLM_BASE_URL={gateway}",
+            f"HERMES_LLM_BASE_URL={gateway}",
+            f"OPENCLAW_LLM_BASE_URL={gateway}",
+            "ODS_PUBLIC_MODEL=ods/current",
+        ]
     return RenderedFile("env", ".env.generated", "\n".join(lines) + "\n")
 
 

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -246,5 +246,25 @@ def main() -> int:
     return 0
 
 
+def test_switchboard_enabled_cuts_consumers_over_to_gateway() -> None:
+    payload = run_renderer("--surface", "env", "--switchboard-mode", "enabled")
+    env = next(f for f in payload["files"] if f["surface"] == "env")["content"]
+    assert "ODS_MODEL_SWITCHBOARD=enabled" in env
+    for var in ("OPEN_WEBUI_LLM_BASE_URL", "PERPLEXICA_LLM_BASE_URL",
+                "OPENCODE_LLM_BASE_URL", "HERMES_LLM_BASE_URL",
+                "OPENCLAW_LLM_BASE_URL"):
+        assert f"{var}=http://litellm:4000/v1" in env, var
+    assert "ODS_PUBLIC_MODEL=ods/current" in env
+
+
+def test_switchboard_observe_emits_no_consumer_overrides() -> None:
+    payload = run_renderer("--surface", "env", "--switchboard-mode", "observe")
+    env = next(f for f in payload["files"] if f["surface"] == "env")["content"]
+    assert "ODS_MODEL_SWITCHBOARD=observe" in env
+    # Byte-identical direct-backend defaults must remain authoritative.
+    assert "OPEN_WEBUI_LLM_BASE_URL" not in env
+    assert "ODS_PUBLIC_MODEL" not in env
+
+
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
Switchboard PR 7 (DRAFT) — plan `ods/docs/MODEL-SWITCHBOARD.md`. The model-ui unblocker: in enabled mode, consumers route through LiteLLM → `ods/current` → model-router (route-attestable). Observe/legacy byte-identical.

**Held as draft on purpose** (release discipline): changes default consumer routing; must not merge until an **enabled-mode composed-main fleet run proves model-ui route attestation green** on reachable backend families (tower2/strix-halo/m5-mbp). Root cause it addresses: model-ui currently fails because observe-mode consumers route directly, not through the router.

Done here: renderer enabled-mode cutover (all 5 consumers → gateway) + ODS_MODEL_SWITCHBOARD/ODS_PUBLIC_MODEL, with tests (enabled emits overrides; observe emits none). Remaining before un-draft: per-consumer config-file cutover (perplexica seed / opencode auth / hermes config), single-mutation-path deletions of the obsolete per-swap rewrites, and the enabled-mode fleet proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)