### PR TITLE
fix(installers): build the brave-search local image on every platform

### DIFF
--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2377,7 +2377,7 @@ for service in (data.get("services") or {}).values():
     # surface unrelated Dockerfile failures and make a healthy selected stack
     # look broken.
     ai "Rebuilding local-built images..."
-    _macos_candidate_build_services=(dashboard dashboard-api model-router ape token-spy privacy-shield)
+    _macos_candidate_build_services=(dashboard dashboard-api model-router ape token-spy privacy-shield brave-search)
     if ! _macos_enabled_services="$(docker compose "${COMPOSE_FLAGS[@]}" config --services 2>>"$ODS_LOG_FILE")"; then
         ai_err "Could not resolve macOS compose services for local image rebuilds."
         ai "Inspect compose config with: cd '$INSTALL_DIR' && docker compose ${COMPOSE_FLAGS[*]} config --services"

--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -1025,7 +1025,7 @@ MODELS_INI_EOF
     compose_ok=false
     # Build local images individually so every failure is reported before the
     # installer refuses to launch any potentially stale image.
-    _candidate_build_services=(dashboard dashboard-api model-router ape token-spy privacy-shield)
+    _candidate_build_services=(dashboard dashboard-api model-router ape token-spy privacy-shield brave-search)
     [[ "$ENABLE_COMFYUI" == "true" ]] && _candidate_build_services+=(comfyui)
     [[ "$GPU_BACKEND" == "amd" ]] && _candidate_build_services+=(llama-server)
     if ! _enabled_compose_services="$($DOCKER_COMPOSE_CMD "${COMPOSE_FLAGS_ARR[@]}" config --services 2>>"$LOG_FILE")"; then

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -1658,6 +1658,9 @@ litellm_settings:
         if (Test-ODSWindowsServiceEnabled -ServiceId "privacy-shield" -Plan $servicePlan) {
             $_buildServices += "privacy-shield"
         }
+        if (Test-ODSWindowsServiceEnabled -ServiceId "brave-search" -Plan $servicePlan) {
+            $_buildServices += "brave-search"
+        }
         if ($enableComfyui -and $currentBackend -eq "nvidia" -and -not $script:gpuPassthroughFailed) {
             $_buildServices += "comfyui"
         }

--- a/ods/tests/test-local-image-build-coverage.py
+++ b/ods/tests/test-local-image-build-coverage.py
@@ -1,15 +1,27 @@
 #!/usr/bin/env python3
 """Local-image build coverage contract.
 
-Every service defined in docker-compose.base.yml with a ``build:`` section and
-no pull-able ``image:`` must appear in each installer's local-build list, or the
-installer runs ``docker compose up --no-build`` against an image that was never
-built and fails with "No such image" on a fresh host.
+Every service that can only exist as a locally built image must appear in each
+installer's local-build list, or the installer runs ``docker compose up
+--no-build --pull never`` against an image that was never built and fails with
+"No such image" on a fresh host.
 
 This is the negative self-test for the model-router fleet regression
 (build-only core service missing from the hardcoded installer build lists):
 CI validated compose config but never ran the real build->up flow, so the gap
 only surfaced on live hosts. This contract closes that gap.
+
+Two things make a service build-only, and both are checked here:
+
+* a ``build:`` section with no ``image:`` at all, and
+* a ``build:`` section whose ``image:`` is a local-only tag. A tag such as
+  ``ods-brave-search:local`` names nothing in any registry, so ``--pull never``
+  cannot satisfy it either. Treating any ``image:`` as pull-able is what let
+  such a service slip past this contract.
+
+Extension composes under extensions/services/*/compose.yaml are in scope too:
+they are merged into the same stack by scripts/resolve-compose-stack.sh and
+started by the same ``--no-build`` compose-up.
 
 Stdlib only. Run: python3 tests/test-local-image-build-coverage.py
 """
@@ -19,12 +31,23 @@ from __future__ import annotations
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parents[1]
 BASE = ROOT / "docker-compose.base.yml"
+EXTENSIONS = ROOT / "extensions" / "services"
 LINUX = ROOT / "installers" / "phases" / "11-services.sh"
 MACOS = ROOT / "installers" / "macos" / "install-macos.sh"
 WINDOWS = ROOT / "installers" / "windows" / "install-windows.ps1"
+
+# An image reference that no registry can serve. Compose started with
+# `--pull never` can only satisfy these from a local build.
+_LOCAL_ONLY_TAG_RE = re.compile(r":(local|latest-local|dev)\s*$")
+
+
+def _is_local_only_image(image: str) -> bool:
+    """True when `image:` names a tag that only a local build can produce."""
+    return bool(_LOCAL_ONLY_TAG_RE.search(image.strip()))
 
 # Services intentionally NOT built by the base install path (documented):
 #   llama-server  — pulled image on most backends; AMD builds it via a
@@ -33,14 +56,12 @@ WINDOWS = ROOT / "installers" / "windows" / "install-windows.ps1"
 _KNOWN_NON_BASE_BUILD = {"llama-server", "comfyui"}
 
 
-def base_build_only_services() -> set[str]:
-    """Top-level base.yml services that have build: and no image:."""
-    text = BASE.read_text(encoding="utf-8")
-    lines = text.splitlines()
+def _scan_compose(text: str) -> set[str]:
+    """Services in one compose file that only a local build can satisfy."""
     in_services = False
-    services: dict[str, dict[str, bool]] = {}
+    services: dict[str, dict[str, Any]] = {}
     current: str | None = None
-    for line in lines:
+    for line in text.splitlines():
         if re.match(r"^services:\s*$", line):
             in_services = True
             continue
@@ -49,16 +70,37 @@ def base_build_only_services() -> set[str]:
         m = re.match(r"^  ([a-z0-9][a-z0-9-]*):\s*$", line)
         if m:
             current = m.group(1)
-            services[current] = {"build": False, "image": False}
+            services[current] = {"build": False, "image": ""}
             continue
         if current and re.match(r"^    build:\s*$", line):
             services[current]["build"] = True
-        elif current and re.match(r"^    image:\s", line):
-            services[current]["image"] = True
+            continue
+        image_match = re.match(r"^    image:\s*(\S+)", line) if current else None
+        if image_match:
+            services[current]["image"] = image_match.group(1)
     return {
         name for name, flags in services.items()
-        if flags["build"] and not flags["image"]
+        if flags["build"] and (
+            not flags["image"] or _is_local_only_image(flags["image"])
+        )
     }
+
+
+def base_build_only_services() -> set[str]:
+    """Base-stack services that only a local build can satisfy."""
+    return _scan_compose(BASE.read_text(encoding="utf-8"))
+
+
+def extension_build_only_services() -> set[str]:
+    """Extension services that only a local build can satisfy.
+
+    Extension composes are merged into the same stack, so a build-only
+    extension hits the identical "No such image" failure once enabled.
+    """
+    found: set[str] = set()
+    for compose in sorted(EXTENSIONS.glob("*/compose.yaml")):
+        found |= _scan_compose(compose.read_text(encoding="utf-8"))
+    return found
 
 
 def installer_build_list(path: Path, pattern: str) -> set[str]:
@@ -71,7 +113,9 @@ def installer_build_list(path: Path, pattern: str) -> set[str]:
 
 
 def main() -> int:
-    required = base_build_only_services() - _KNOWN_NON_BASE_BUILD
+    required = (
+        base_build_only_services() | extension_build_only_services()
+    ) - _KNOWN_NON_BASE_BUILD
     errors: list[str] = []
 
     # Linux: _candidate_build_services=(...) plus any += lines
@@ -102,13 +146,13 @@ def main() -> int:
                           ("Windows install-windows.ps1", windows)):
         missing = required - present
         if missing:
-            errors.append(f"{name}: build-only base services not in build list: {sorted(missing)}")
+            errors.append(f"{name}: build-only services not in build list: {sorted(missing)}")
 
     if errors:
         print("[FAIL] local-image build coverage:")
         for e in errors:
             print(f"  - {e}")
-        print(f"  (base build-only services requiring coverage: {sorted(required)})")
+        print(f"  (build-only services requiring coverage: {sorted(required)})")
         return 1
     print(f"[OK] local-image build coverage: {sorted(required)} covered by all installers")
     return 0


### PR DESCRIPTION
## Problem

`brave-search` ships a `Dockerfile` and a `build:` section, and its image tag `ods-brave-search:local` exists in no registry — only a local build can produce it. It is missing from the local-build list in **all three** installers:

- `installers/phases/11-services.sh:1028`
- `installers/macos/install-macos.sh:2380`
- `installers/windows/install-windows.ps1:1651`

Installers start the stack with `docker compose up -d --no-build --pull never`. With brave-search enabled, its image was never built and `--pull never` cannot fetch it, so compose-up fails with `No such image: ods-brave-search:local`.

This is the same failure mode as the model-router fleet regression fixed in 399bc74b — the hardcoded build lists drift from what the stack actually needs built.

## Why the existing contract missed it

`tests/test-local-image-build-coverage.py` was added to close exactly this gap, but it could not see brave-search:

1. it scanned only `docker-compose.base.yml`, not extension composes; and
2. it classified a service as build-only via `build:` **and no** `image:` — brave-search has both, so an unpullable local tag read as pull-able.

## Fix

Add brave-search to the three build lists (Windows gated on `Test-ODSWindowsServiceEnabled`, matching the ape / token-spy / privacy-shield arms), and close both contract gaps: scan `extensions/services/*/compose.yaml` too, and treat a local-only tag (`:local`, `:latest-local`, `:dev`) as build-only.

## Verification

Extended contract **fails on all three installers before the fix**, passes after:

```
[FAIL] local-image build coverage:
  - Linux 11-services.sh: build-only services not in build list: ['brave-search']
  - macOS install-macos.sh: build-only services not in build list: ['brave-search']
  - Windows install-windows.ps1: build-only services not in build list: ['brave-search']
```
```
[OK] local-image build coverage: ['ape', 'brave-search', 'dashboard', 'dashboard-api',
     'model-router', 'privacy-shield', 'token-spy'] covered by all installers
```

The widened contract also now genuinely covers ape / token-spy / privacy-shield (previously out of scope; all three already pass). `bash -n` clean on both shell installers; PowerShell `ParseFile` clean. Already wired into CI via the existing `Local Image Build Coverage` step.