### PR TITLE
fix(model-router): keep the public alias across SSE chunk boundaries

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -200,10 +200,10 @@ def _sanitize_headers(request: Request) -> dict[str, str]:
     return headers
 
 
-def _rewrite_sse_chunk(chunk: bytes, alias: str) -> bytes:
-    """Stamp the requested alias into every SSE data line's model field."""
+def _rewrite_sse_lines(block: bytes, alias: str) -> bytes:
+    """Stamp the requested alias into every complete SSE data line."""
     out_lines = []
-    for line in chunk.split(b"\n"):
+    for line in block.split(b"\n"):
         if line.startswith(b"data:") and b"{" in line:
             payload = line[5:].strip()
             try:
@@ -215,6 +215,45 @@ def _rewrite_sse_chunk(chunk: bytes, alias: str) -> bytes:
                 pass
         out_lines.append(line)
     return b"\n".join(out_lines)
+
+
+class _SSERewriter:
+    """Alias-stamp an SSE stream whose chunks do not align with its lines.
+
+    ``aiter_bytes()`` yields network-sized chunks; a ``data:`` line split
+    across two of them is valid JSON in neither half, so rewriting per chunk
+    silently passes the upstream's concrete model id through to the client.
+    Hold an incomplete trailing line back until its newline arrives.
+
+    ``_MAX_PENDING`` bounds the hold-back so an upstream that streams without
+    newlines cannot grow the buffer without limit; past it the pending bytes
+    are forwarded unmodified, which is exactly the old behaviour.
+    """
+
+    _MAX_PENDING = 1024 * 1024
+
+    def __init__(self, alias: str) -> None:
+        self._alias = alias
+        self._pending = b""
+
+    def feed(self, chunk: bytes) -> bytes:
+        data = self._pending + chunk
+        complete, newline, remainder = data.rpartition(b"\n")
+        if not newline:
+            if len(data) > self._MAX_PENDING:
+                self._pending = b""
+                return data
+            self._pending = data
+            return b""
+        self._pending = remainder
+        return _rewrite_sse_lines(complete, self._alias) + b"\n"
+
+    def flush(self) -> bytes:
+        """Emit a final line that arrived without a trailing newline."""
+        if not self._pending:
+            return b""
+        remainder, self._pending = self._pending, b""
+        return _rewrite_sse_lines(remainder, self._alias)
 
 
 @app.get("/health")
@@ -372,9 +411,15 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                                   "lemonadeRoute": lemonade_route})
 
             async def stream_body() -> AsyncIterator[bytes]:
+                rewriter = _SSERewriter(requested_alias)
                 try:
                     async for chunk in upstream.aiter_bytes():
-                        yield _rewrite_sse_chunk(chunk, requested_alias)
+                        rewritten = rewriter.feed(chunk)
+                        if rewritten:
+                            yield rewritten
+                    tail = rewriter.flush()
+                    if tail:
+                        yield tail
                 finally:
                     await upstream.aclose()
 

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -248,3 +248,63 @@ class TestModelsAndEvidence:
         assert client.get("/health").json()["hasRoute"] is False
         write_state()
         assert client.get("/health").json()["hasRoute"] is True
+
+
+class TestSSEChunkBoundaries:
+    """SSE chunks do not align with SSE lines.
+
+    ``aiter_bytes()`` yields network-sized chunks. A ``data:`` line split
+    across two of them parses as JSON in neither half, so a per-chunk
+    rewriter passes the upstream's concrete model id straight to the client
+    and the stable public alias silently stops holding.
+    """
+
+    def test_alias_survives_a_line_split_across_chunks(self):
+        import app.main as mod
+
+        line = (b'data: {"id":"c1","model":"Concrete.gguf",'
+                b'"choices":[{"delta":{"content":"hi"}}]}\n\n')
+
+        whole = mod._SSERewriter("ods/current")
+        expected = whole.feed(line) + whole.flush()
+        assert b"Concrete.gguf" not in expected
+
+        # Every possible network boundary inside the line must agree.
+        for cut in range(1, len(line)):
+            split = mod._SSERewriter("ods/current")
+            out = split.feed(line[:cut]) + split.feed(line[cut:]) + split.flush()
+            assert out == expected, f"boundary at byte {cut} diverged"
+
+    def test_byte_at_a_time_stream_is_byte_identical(self):
+        import app.main as mod
+
+        sse = (b'data: {"id":"c1","model":"Concrete.gguf","choices":[]}\n\n'
+               b'data: {"id":"c2","model":"Concrete.gguf","choices":[]}\n\n'
+               b"data: [DONE]\n\n")
+
+        whole = mod._SSERewriter("ods/current")
+        expected = whole.feed(sse) + whole.flush()
+
+        drip = mod._SSERewriter("ods/current")
+        out = b"".join(drip.feed(sse[i:i + 1]) for i in range(len(sse))) + drip.flush()
+        assert out == expected
+        assert b"Concrete.gguf" not in out
+        assert out.count(b"ods/current") == 2
+        assert b"[DONE]" in out
+
+    def test_final_line_without_trailing_newline_is_not_dropped(self):
+        import app.main as mod
+
+        rewriter = mod._SSERewriter("ods/current")
+        out = rewriter.feed(b'data: {"model":"Concrete.gguf"}') + rewriter.flush()
+        assert b"ods/current" in out
+        assert b"Concrete.gguf" not in out
+
+    def test_pending_buffer_is_bounded_on_a_newline_free_stream(self):
+        import app.main as mod
+
+        rewriter = mod._SSERewriter("ods/current")
+        blob = b"x" * (mod._SSERewriter._MAX_PENDING // 2 + 1)
+        assert rewriter.feed(blob) == b""          # held back, still bounded
+        assert rewriter.feed(blob) == blob + blob  # cap reached, forwarded as-is
+        assert rewriter.flush() == b""


### PR DESCRIPTION
## Problem

`_rewrite_sse_chunk` was applied to each chunk from `aiter_bytes()` independently. Those chunks are network-sized and carry no relationship to SSE line boundaries, so a `data:` line split across two of them is valid JSON in **neither** half — `json.loads` raises on both, the rewrite is skipped, and the upstream's concrete model id reaches the client verbatim.

Reproduced against the shipped function:

```
whole chunk  -> b'data: {"model":"ods/current","choices":[]}\n\n'
split chunk  -> b'data: {"model":"Qwen3.5-9B-Q4_K_M.gguf","choices":[]}\n\n'
```

The stable public alias is the router's whole reason to exist (`PUBLIC_ALIASES`, the `X-ODS-Requested-Model` contract), and it silently stops holding for streaming requests — which is the dominant chat path. The internal model identity leaks with it.

The existing `test_sse_chunks_restore_alias` passes because the mock upstream returns the whole SSE body as a single chunk, so the boundary case was never exercised.

## Fix

`_SSERewriter` buffers an incomplete trailing line until its newline arrives, rewrites only complete lines, and flushes a final unterminated line at end of stream. `_rewrite_sse_chunk` becomes `_rewrite_sse_lines`, unchanged, as the pure line-level rewriter.

`_MAX_PENDING` (1 MiB) bounds the hold-back so an upstream that streams without newlines cannot grow the buffer without limit — past the cap the pending bytes are forwarded unmodified, which is exactly the old behaviour. This is deliberate: buffering is new here, and it should not introduce a memory failure mode of its own.

## Verification

4 new tests, all **red before the fix**:
- exhaustive: **every** byte boundary inside a `data:` line yields the same output as the unsplit line
- a byte-at-a-time stream is byte-identical to the single-chunk result
- a final line with no trailing newline is not dropped
- the pending buffer is bounded on a newline-free stream

Full router suite: 18 passed (14 pre-existing + 4 new).