### PR TITLE
fix(model-router): hold the concurrency slot for the life of a stream

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -287,6 +287,7 @@ async def forward(full_path: str, request: Request) -> Response:
     requested_alias = str(payload.get("model") or PUBLIC_ALIASES[0])
 
     global _inflight
+    slot = _InflightSlot()
     async with _inflight_lock:
         if _inflight >= MAX_QUEUE_DEPTH:
             return JSONResponse(
@@ -295,15 +296,45 @@ async def forward(full_path: str, request: Request) -> Response:
                 status_code=503, headers={"Retry-After": "5"},
             )
         _inflight += 1
+    streaming = False
     try:
-        return await _forward_inner(request, path, payload, requested_alias, body)
+        response = await _forward_inner(
+            request, path, payload, requested_alias, body, slot
+        )
+        # A streaming response is still open when this handler returns; it
+        # owns the slot from here and releases it when its body completes.
+        streaming = isinstance(response, StreamingResponse)
+        return response
     finally:
+        if not streaming:
+            await slot.release()
+
+
+class _InflightSlot:
+    """One occupancy of the router's concurrency bound.
+
+    A streaming response outlives the handler that built it, so releasing on
+    handler return would free the slot while the upstream request is still
+    open — leaving MAX_QUEUE_DEPTH unable to bound streaming traffic, which
+    is most of it. Streaming hands the slot to its body generator instead.
+    Release is idempotent so either owner can call it.
+    """
+
+    def __init__(self) -> None:
+        self._released = False
+
+    async def release(self) -> None:
+        global _inflight
+        if self._released:
+            return
+        self._released = True
         async with _inflight_lock:
             _inflight -= 1
 
 
 async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
-                         requested_alias: str, raw_body: bytes) -> Response:
+                         requested_alias: str, raw_body: bytes,
+                         slot: "_InflightSlot") -> Response:
     deadline = time.monotonic() + QUEUE_WAIT_SECONDS
     while True:
         try:
@@ -377,6 +408,9 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                         yield _rewrite_sse_chunk(chunk, requested_alias)
                 finally:
                     await upstream.aclose()
+                    # The slot stays occupied for the life of the stream, not
+                    # just the handler that opened it.
+                    await slot.release()
 
             media_type = upstream.headers.get("content-type",
                                               "text/event-stream")

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -3,6 +3,7 @@ upstream is an httpx.MockTransport and state/endpoints are temp files."""
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import hashlib
 import hmac
@@ -15,6 +16,7 @@ from pathlib import Path
 import httpx
 import pytest
 from fastapi.testclient import TestClient
+from starlette.responses import StreamingResponse
 
 _APP_DIR = Path(__file__).resolve().parents[1]
 if str(_APP_DIR) not in sys.path:
@@ -248,3 +250,134 @@ class TestModelsAndEvidence:
         assert client.get("/health").json()["hasRoute"] is False
         write_state()
         assert client.get("/health").json()["hasRoute"] is True
+
+
+class TestStreamingConcurrencyBound:
+    """MAX_QUEUE_DEPTH must bound streaming traffic too.
+
+    A StreamingResponse is still open when its handler returns — the ASGI
+    server pulls its body afterwards. Releasing the slot on handler return
+    frees it while the upstream request is live, so the bound only ever
+    applied to non-streaming requests, the short ones.
+
+    These call ``forward`` directly: TestClient consumes a mocked stream
+    eagerly, which closes the window before it can be observed.
+    """
+
+    @staticmethod
+    def _setup(tmp_path, upstream_body=None):
+        """A module wired to temp state/endpoints and an in-memory upstream."""
+        import app.main as mod
+        mod = importlib.reload(mod)
+
+        state_path = tmp_path / "model-state.json"
+        endpoints_path = tmp_path / "endpoints.json"
+        endpoints_path.write_text(json.dumps({"endpoints": [
+            {"id": "llama-server-default", "baseUrl": "http://upstream:8080"},
+        ]}), encoding="utf-8")
+        state_path.write_text(json.dumps({
+            "schema": "ods.model-state.v1", "seq": 1, "routeSeq": 1,
+            "operation": None, "desired": {"catalogId": "concrete"},
+            "active": {
+                "routeSeq": 1, "catalogId": "concrete",
+                "runtimeModelId": "Concrete.gguf", "publicModel": "ods/current",
+                "backend": {"kind": "llama-server",
+                            "endpointId": "llama-server-default",
+                            "nativeRoute": None},
+                "contextLength": 4096,
+                "capabilities": {"chat": True, "tools": False,
+                                 "vision": False, "agentViable": False},
+                "verifiedAt": "2026-01-01T00:00:00Z", "reconstructed": False,
+                "proof": {"identity": "Concrete.gguf", "completion": True},
+            },
+            "history": [],
+            "availability": {"mode": "serve_active", "queueDeadline": None},
+        }), encoding="utf-8")
+
+        mod.STATE_PATH = state_path
+        mod.ENDPOINTS_PATH = endpoints_path
+        mod._endpoints_cache.update({"loaded": False, "endpoints": {}})
+        mod._state_cache.update({"mtime": None, "doc": None})
+
+        sse = upstream_body if upstream_body is not None else (
+            b'data: {"id":"c1","model":"Concrete.gguf","choices":[]}\n\n'
+            b"data: [DONE]\n\n"
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            body = json.loads(request.content.decode("utf-8"))
+            if body.get("stream"):
+                return httpx.Response(
+                    200, content=sse,
+                    headers={"content-type": "text/event-stream"})
+            return httpx.Response(200, json={"id": "c1", "model": "Concrete.gguf",
+                                             "choices": []})
+
+        mod.app.state.http = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler))
+        return mod
+
+    @staticmethod
+    def _request(mod, payload: dict):
+        """A minimal Starlette Request carrying ``payload`` as its body."""
+        from starlette.requests import Request
+
+        raw = json.dumps(payload).encode("utf-8")
+        scope = {
+            "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+            "method": "POST", "path": "/v1/chat/completions",
+            "root_path": "", "scheme": "http", "query_string": b"",
+            "headers": [(b"content-type", b"application/json")],
+            "client": ("127.0.0.1", 1234), "server": ("router", 80),
+            "app": mod.app,
+        }
+
+        async def receive():
+            return {"type": "http.request", "body": raw, "more_body": False}
+
+        return Request(scope, receive)
+
+    def test_slot_is_held_until_the_stream_body_completes(self, tmp_path):
+        mod = self._setup(tmp_path)
+
+        async def scenario():
+            payload = {"model": "default", "stream": True, "messages": []}
+            response = await mod.forward(
+                "v1/chat/completions", self._request(mod, payload))
+            assert isinstance(response, StreamingResponse)
+            # Handler has returned; the ASGI server has not pulled the body
+            # yet and the upstream request is still open.
+            held = mod._inflight
+            async for _ in response.body_iterator:
+                pass
+            return held, mod._inflight
+
+        held, after = asyncio.run(scenario())
+        assert held == 1, "slot freed before the stream body was consumed"
+        assert after == 0, "slot leaked after the stream completed"
+
+    def test_non_streaming_request_releases_its_slot(self, tmp_path):
+        mod = self._setup(tmp_path)
+
+        async def scenario():
+            response = await mod.forward(
+                "v1/chat/completions",
+                self._request(mod, {"model": "ods/current", "messages": []}))
+            return response.status_code, mod._inflight
+
+        status, inflight = asyncio.run(scenario())
+        assert status == 200
+        assert inflight == 0
+
+    def test_release_is_idempotent(self, tmp_path):
+        """Both owners may call it; the count must move exactly once."""
+        mod = self._setup(tmp_path)
+
+        async def scenario():
+            mod._inflight = 1
+            slot = mod._InflightSlot()
+            await slot.release()
+            await slot.release()
+            return mod._inflight
+
+        assert asyncio.run(scenario()) == 0


### PR DESCRIPTION
## Problem

`forward` released the inflight slot in its `finally`:

```python
try:
    return await _forward_inner(request, path, payload, requested_alias, body)
finally:
    async with _inflight_lock:
        _inflight -= 1
```

That `finally` runs when the **handler** returns. For a streaming request the handler returns as soon as the upstream response headers arrive — the `StreamingResponse` body generator is pulled by the ASGI server afterwards, and the upstream request stays open the whole time.

So the slot was freed at the *start* of the work it was meant to account for. `MAX_QUEUE_DEPTH` bounded only non-streaming requests — the short ones. Streaming chat, the dominant path and the one that actually occupies the runtime for minutes, could pile up without limit; the router shed nothing and "Router queue is full" never fired for it.

## Fix

`_InflightSlot` with an idempotent `release()`. A streaming response hands the slot to its body generator, which releases it in the same `finally` that closes the upstream response; every other path (including upstream failures) still releases when the handler unwinds.

## Verification

3 new tests, the central one **red before the fix** with exactly its diagnostic:

```
>       assert held == 1, "slot freed before the stream body was consumed"
E       AssertionError: slot freed before the stream body was consumed
```

- slot is held after `forward` returns and released once the body is consumed
- non-streaming requests release their slot
- `release()` is idempotent, so dual ownership cannot double-decrement

A note on test shape: these call `forward` directly rather than going through `TestClient`. `TestClient` consumes a mocked stream eagerly, so the window between headers and body — the entire bug — is already closed by the time a test could observe it. An earlier `TestClient`-based version of these tests passed against the **unfixed** code, which is exactly why it isn't used here.

Full router suite: 17 passed (14 pre-existing + 3 new).