### PR TITLE
fix(model-router): retry the endpoint allowlist instead of caching a failure

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -95,23 +95,32 @@ class RouterError(Exception):
 
 
 def _load_endpoints() -> dict[str, dict[str, Any]]:
-    """Startup-validated allowlist: endpointId -> {baseUrl, apiKeyEnv?}."""
+    """Startup-validated allowlist: endpointId -> {baseUrl, apiKeyEnv?}.
+
+    Only a successful read is cached. The file is a read-only bind mount that
+    scripts/render-runtime-configs.py rewrites in place with a non-atomic
+    write_text, so a read can land on a partial or absent file. Caching that
+    outcome would pin an empty allowlist for the life of the process and every
+    request would answer endpoint_not_allowlisted until someone restarted the
+    container; retrying instead lets the next request recover on its own.
+    """
     if _endpoints_cache["loaded"]:
         return _endpoints_cache["endpoints"]
     endpoints: dict[str, dict[str, Any]] = {}
     try:
         raw = json.loads(ENDPOINTS_PATH.read_text(encoding="utf-8"))
-        for entry in raw.get("endpoints", []):
-            endpoint_id = str(entry.get("id") or "")
-            base_url = str(entry.get("baseUrl") or "")
-            if not endpoint_id or not base_url.startswith(("http://", "https://")):
-                continue
-            endpoints[endpoint_id] = {
-                "baseUrl": base_url.rstrip("/"),
-                "apiKeyEnv": str(entry.get("apiKeyEnv") or ""),
-            }
     except (OSError, ValueError) as exc:
-        logger.error("endpoints allowlist unavailable: %s", exc)
+        logger.error("endpoints allowlist unavailable, will retry: %s", exc)
+        return endpoints
+    for entry in raw.get("endpoints", []):
+        endpoint_id = str(entry.get("id") or "")
+        base_url = str(entry.get("baseUrl") or "")
+        if not endpoint_id or not base_url.startswith(("http://", "https://")):
+            continue
+        endpoints[endpoint_id] = {
+            "baseUrl": base_url.rstrip("/"),
+            "apiKeyEnv": str(entry.get("apiKeyEnv") or ""),
+        }
     _endpoints_cache["endpoints"] = endpoints
     _endpoints_cache["loaded"] = True
     return endpoints
@@ -218,14 +227,19 @@ def _rewrite_sse_chunk(chunk: bytes, alias: str) -> bytes:
 
 
 @app.get("/health")
-async def health() -> dict[str, Any]:
+async def health() -> Response:
     doc = _read_state()
-    return {
-        "status": "ok",
+    endpoints = _load_endpoints()
+    body = {
+        "status": "ok" if endpoints else "degraded",
         "hasRoute": bool((doc or {}).get("active")),
+        "endpointCount": len(endpoints),
         "seq": (doc or {}).get("seq"),
         "routeSeq": (doc or {}).get("routeSeq"),
     }
+    # With no allowlist the router cannot serve any request. Reporting 200
+    # here left a container that answered nothing but 503 looking healthy.
+    return JSONResponse(body, status_code=200 if endpoints else 503)
 
 
 @app.get("/v1/models")

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -248,3 +248,82 @@ class TestModelsAndEvidence:
         assert client.get("/health").json()["hasRoute"] is False
         write_state()
         assert client.get("/health").json()["hasRoute"] is True
+
+
+class TestEndpointAllowlistRecovery:
+    """A failed allowlist read must not be cached.
+
+    endpoints.json is a read-only bind mount that
+    scripts/render-runtime-configs.py rewrites in place with a non-atomic
+    write_text (:315). A read landing in that window, or before the mount is
+    ready, used to cache an empty allowlist for the life of the process:
+    every request answered endpoint_not_allowlisted until the container was
+    restarted, while /health kept reporting 200.
+    """
+
+    def test_transient_read_failure_recovers_on_the_next_request(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        good = mod.ENDPOINTS_PATH.read_text(encoding="utf-8")
+
+        # Mid-rewrite: the file is truncated, so json.loads raises.
+        mod.ENDPOINTS_PATH.write_text("", encoding="utf-8")
+        mod._endpoints_cache.update({"loaded": False, "endpoints": {}})
+        blocked = client.post("/v1/chat/completions",
+                              json={"model": "ods/current", "messages": []})
+        assert blocked.status_code == 503
+        assert blocked.json()["error"]["type"] == "endpoint_not_allowlisted"
+
+        # The rewrite lands; the very next request must route.
+        mod.ENDPOINTS_PATH.write_text(good, encoding="utf-8")
+        recovered = client.post("/v1/chat/completions",
+                                json={"model": "ods/current", "messages": []})
+        assert recovered.status_code == 200
+
+    def test_missing_file_recovers_once_it_appears(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        good = mod.ENDPOINTS_PATH.read_text(encoding="utf-8")
+
+        mod.ENDPOINTS_PATH.unlink()
+        mod._endpoints_cache.update({"loaded": False, "endpoints": {}})
+        assert client.post("/v1/chat/completions",
+                           json={"model": "ods/current", "messages": []}
+                           ).status_code == 503
+
+        mod.ENDPOINTS_PATH.write_text(good, encoding="utf-8")
+        assert client.post("/v1/chat/completions",
+                           json={"model": "ods/current", "messages": []}
+                           ).status_code == 200
+
+    def test_a_good_allowlist_is_still_cached(self, router):
+        """Recovery must not turn every request into a disk read."""
+        mod, client, write_state, calls = router
+        write_state()
+        assert client.get("/health").status_code == 200
+
+        # Cache is warm; removing the file must not change the answer.
+        mod.ENDPOINTS_PATH.unlink()
+        assert client.post("/v1/chat/completions",
+                           json={"model": "ods/current", "messages": []}
+                           ).status_code == 200
+
+    def test_health_reports_degraded_without_an_allowlist(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        mod.ENDPOINTS_PATH.write_text(json.dumps({"endpoints": []}),
+                                      encoding="utf-8")
+        mod._endpoints_cache.update({"loaded": False, "endpoints": {}})
+
+        resp = client.get("/health")
+        assert resp.status_code == 503
+        assert resp.json()["status"] == "degraded"
+        assert resp.json()["endpointCount"] == 0
+
+    def test_health_is_ok_with_an_allowlist(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        resp = client.get("/health")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        assert resp.json()["endpointCount"] == 2


### PR DESCRIPTION
## Problem

`_load_endpoints()` set `loaded = True` on **every** path, including the failure path:

```python
except (OSError, ValueError) as exc:
    logger.error("endpoints allowlist unavailable: %s", exc)
_endpoints_cache["endpoints"] = endpoints   # {} after a failure
_endpoints_cache["loaded"] = True           # ...and pinned forever
```

One bad read pins an empty allowlist for the life of the process. `_active_route()` then raises `endpoint_not_allowlisted` for every request, and only a container restart clears it.

The "startup-validated" framing understates the exposure. `endpoints.json` is a bind mount that `scripts/render-runtime-configs.py` rewrites **in place** with a non-atomic `write_text` (`render-runtime-configs.py:315`), so every re-render — install, update, config change — opens a window where the file is truncated or half-written. A read landing in that window was permanent.

`/health` made it worse by returning 200 regardless. A router that answered nothing but 503 reported healthy, so nothing surfaced the failure.

## Fix

- cache only a **successful** read; a failed one retries on the next request
- `/health` reports `endpointCount` and returns 503 when the allowlist is empty

The compose healthcheck already fails correctly on 503 (`urlopen` raises `HTTPError`, so its `sys.exit` never runs) — no compose change needed. `endpoints.json` is rendered before the router starts, so normal boot is unaffected.

## Verification

5 new tests, **4 red before the fix**:
- a truncated file (the mid-rewrite window) blocks, then the next request recovers
- a missing file recovers once it appears
- `/health` is `degraded`/503 with no allowlist, `ok`/200 with one
- a good allowlist is **still cached** — passes both before and after, guarding against turning every request into a disk read

Full router suite: 19 passed (14 pre-existing + 5 new).