### PR TITLE
fix(token-spy): stop the session manager deleting live sessions

### DIFF
--- a/ods/Makefile
+++ b/ods/Makefile
@@ -101,6 +101,9 @@ test: ## Run unit and contract tests
 	@echo "=== macOS uninstall LaunchAgent cleanup ==="
 	@bash tests/test-macos-uninstall-launchagents.sh
 	@echo ""
+	@echo "=== token-spy session manager active-id extraction ==="
+	@bash tests/test-token-spy-session-manager.sh
+	@echo ""
 	@echo "=== fleet-multi-distro keep-going on docker pull failure ==="
 	@bash tests/test-fleet-multi-distro-keep-going.sh
 	@echo ""

--- a/ods/extensions/services/token-spy/session-manager.sh
+++ b/ods/extensions/services/token-spy/session-manager.sh
@@ -89,9 +89,11 @@ clean_inactive() {
   local active_ids
   active_ids=$(extract_active_ids "$sessions_json")
 
-  # No ids out of a non-empty sessions.json means the parse failed, not that
-  # every session is idle. Deleting on that reading wipes live sessions.
-  if [ -z "$active_ids" ] && [ -s "$sessions_json" ]; then
+  # No ids out of sessions.json means the parse failed or the file is a
+  # partial write (a crash mid-rewrite leaves 0 bytes), not that every
+  # session is idle. Deleting on that reading wipes live sessions, so any
+  # empty extraction fails closed — matching the remote-path guard.
+  if [ -z "$active_ids" ]; then
     log "  [WARN] No session ids parsed from $sessions_json — skipping cleanup"
     return 0
   fi

--- a/ods/extensions/services/token-spy/session-manager.sh
+++ b/ods/extensions/services/token-spy/session-manager.sh
@@ -63,6 +63,20 @@ query_status() {
   curl -sf --max-time 5 "http://${MONITOR_HOST}:${port}/api/session-status?agent=${agent}" 2>/dev/null || echo '{"recommendation":"unavailable"}'
 }
 
+# Emit every sessionId in a sessions.json, one per line.
+#
+# Must not assume one id per line: sessions.json is written by the agent
+# framework, and a compact document puts every entry on a single line. A
+# greedy `sed 's/.*"sessionId": *"\([^"]*\)".*/\1/'` then reports only the
+# LAST id on that line, so every other live session reads as inactive and
+# gets deleted. Match each occurrence instead, as scripts/session-cleanup.sh
+# already does.
+extract_active_ids() {
+  local sessions_json="$1"
+  grep -oE '"sessionId"[[:space:]]*:[[:space:]]*"[^"]+"' "$sessions_json" 2>/dev/null \
+    | sed -E 's/.*"([^"]+)"[[:space:]]*$/\1/' || true
+}
+
 clean_inactive() {
   local sessions_dir="$1"
   local sessions_json="${sessions_dir}/sessions.json"
@@ -73,7 +87,14 @@ clean_inactive() {
   [ -f "$sessions_json" ] || return 0
 
   local active_ids
-  active_ids=$(sed -n 's/.*"sessionId":[[:space:]]*"\([^"]*\)".*/\1/p' "$sessions_json" 2>/dev/null || true)
+  active_ids=$(extract_active_ids "$sessions_json")
+
+  # No ids out of a non-empty sessions.json means the parse failed, not that
+  # every session is idle. Deleting on that reading wipes live sessions.
+  if [ -z "$active_ids" ] && [ -s "$sessions_json" ]; then
+    log "  [WARN] No session ids parsed from $sessions_json — skipping cleanup"
+    return 0
+  fi
 
   for f in "$sessions_dir"/*.jsonl; do
     [ -f "$f" ] || continue
@@ -192,7 +213,10 @@ manage_remote_agent() {
     echo "SESSION_LIST_END"
     if [ -f "\$SESSIONS_DIR/sessions.json" ]; then
       echo "ACTIVE_IDS_START"
-      sed -n 's/.*"sessionId":[[:space:]]*"\([^"]*\)".*/\1/p' "\$SESSIONS_DIR/sessions.json" 2>/dev/null || true
+      # Per-occurrence match: a compact sessions.json holds every entry on one
+      # line, and a greedy sed would report only the last id there.
+      grep -oE '"sessionId"[[:space:]]*:[[:space:]]*"[^"]+"' "\$SESSIONS_DIR/sessions.json" 2>/dev/null \
+        | sed -E 's/.*"([^"]+)"[[:space:]]*\$/\1/' || true
       echo "ACTIVE_IDS_END"
     fi
     echo "TOTAL_SIZE=\$(du -sb "\$SESSIONS_DIR" 2>/dev/null | cut -f1)"
@@ -218,6 +242,12 @@ REMOTESCRIPT
   local active_ids=""
   if echo "$remote_info" | grep -q "ACTIVE_IDS_START"; then
     active_ids=$(echo "$remote_info" | sed -n '/ACTIVE_IDS_START/,/ACTIVE_IDS_END/p' | grep -vE '_START|_END')
+    # The block is only emitted when the remote sessions.json exists, so an
+    # empty one means the parse failed, not that every session is idle.
+    if [ -z "$active_ids" ]; then
+      log "  [WARN] No session ids parsed from $host sessions.json — skipping $agent"
+      return 0
+    fi
   fi
 
   local now

--- a/ods/tests/test-token-spy-session-manager.sh
+++ b/ods/tests/test-token-spy-session-manager.sh
@@ -74,5 +74,16 @@ clean_inactive "$WORK"
 pass "pretty-printed layout keeps live sessions and cleans orphans"
 rm -rf "$WORK"
 
+echo "Test 5: a zero-byte sessions.json (partial write) cancels cleanup"
+WORK="$(mktemp -d)"
+: > "$WORK/sessions.json"
+for id in aaa bbb; do echo '{}' > "$WORK/$id.jsonl"; done
+clean_inactive "$WORK"
+for id in aaa bbb; do
+  [ -f "$WORK/$id.jsonl" ] || fail "wiped $id on a zero-byte sessions.json"
+done
+pass "no session deleted when sessions.json is a partial write"
+rm -rf "$WORK"
+
 echo ""
 echo "✓ All token-spy session-manager tests passed"

--- a/ods/tests/test-token-spy-session-manager.sh
+++ b/ods/tests/test-token-spy-session-manager.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Contract: token-spy's session manager must never delete a live session file.
+#
+# clean_inactive() decides what to delete by diffing the *.jsonl files on disk
+# against the sessionIds in sessions.json. Two ways that went wrong:
+#
+#   1. a greedy `sed 's/.*"sessionId": *"\([^"]*\)".*/\1/'` reports only the
+#      LAST id on a line, so a compact sessions.json (one line, every entry)
+#      left all but one live session looking inactive; and
+#   2. an empty extraction was read as "nothing is active" rather than "the
+#      parse failed", which deletes every session file.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANAGER="$SCRIPT_DIR/../extensions/services/token-spy/session-manager.sh"
+
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; exit 1; }
+
+# Source only the helpers: the script's top level defines config and then
+# main() runs under `set -euo pipefail`, so extract the two functions we drive.
+FUNCS="$(mktemp)"
+trap 'rm -f "$FUNCS"' EXIT
+sed -n '/^extract_active_ids()/,/^}/p;/^clean_inactive()/,/^}/p' "$MANAGER" > "$FUNCS"
+log() { :; }   # silence the manager's logger
+# shellcheck disable=SC1090
+source "$FUNCS"
+
+echo "Test 1: every id is extracted from a compact (single-line) sessions.json"
+WORK="$(mktemp -d)"
+printf '{"a":{"sessionId":"aaa"},"b":{"sessionId":"bbb"},"c":{"sessionId":"ccc"}}\n' \
+  > "$WORK/sessions.json"
+got="$(extract_active_ids "$WORK/sessions.json" | tr '\n' ' ')"
+[ "$got" = "aaa bbb ccc " ] || fail "expected all three ids, got '$got'"
+pass "compact sessions.json yields every id, not just the last"
+
+echo "Test 2: live sessions survive cleanup with a compact sessions.json"
+for id in aaa bbb ccc; do echo '{}' > "$WORK/$id.jsonl"; done
+echo '{}' > "$WORK/orphan.jsonl"
+clean_inactive "$WORK"
+for id in aaa bbb ccc; do
+  [ -f "$WORK/$id.jsonl" ] || fail "deleted live session $id"
+done
+pass "all three live sessions kept"
+[ -f "$WORK/orphan.jsonl" ] && fail "orphan session was not cleaned"
+pass "orphan session still removed"
+rm -rf "$WORK"
+
+echo "Test 3: an unparseable sessions.json cancels cleanup instead of wiping"
+WORK="$(mktemp -d)"
+# Non-empty but carrying no sessionId key — a schema change or partial write.
+printf '{"a":{"id":"aaa"},"b":{"id":"bbb"}}\n' > "$WORK/sessions.json"
+for id in aaa bbb; do echo '{}' > "$WORK/$id.jsonl"; done
+clean_inactive "$WORK"
+for id in aaa bbb; do
+  [ -f "$WORK/$id.jsonl" ] || fail "wiped $id on an unparseable sessions.json"
+done
+pass "no session deleted when no id could be parsed"
+rm -rf "$WORK"
+
+echo "Test 4: pretty-printed sessions.json still works (no regression)"
+WORK="$(mktemp -d)"
+cat > "$WORK/sessions.json" <<'JSON'
+{
+  "a": { "sessionId": "aaa" },
+  "b": { "sessionId": "bbb" }
+}
+JSON
+for id in aaa bbb; do echo '{}' > "$WORK/$id.jsonl"; done
+echo '{}' > "$WORK/gone.jsonl"
+clean_inactive "$WORK"
+[ -f "$WORK/aaa.jsonl" ] && [ -f "$WORK/bbb.jsonl" ] || fail "deleted a live session"
+[ -f "$WORK/gone.jsonl" ] && fail "orphan not cleaned"
+pass "pretty-printed layout keeps live sessions and cleans orphans"
+rm -rf "$WORK"
+
+echo ""
+echo "✓ All token-spy session-manager tests passed"


### PR DESCRIPTION
## Problem

`clean_inactive()` decides what to delete by diffing the `*.jsonl` files on disk against the `sessionId`s in `sessions.json`, and extracted those ids with a greedy sed:

```bash
sed -n 's/.*"sessionId":[[:space:]]*"\([^"]*\)".*/\1/p'
```

The leading `.*` is greedy, so on any line holding more than one entry the pattern reports only the **last** id. `sessions.json` is written by the agent framework, not by this script, and a compact document puts every entry on one line.

Driving the shipped `clean_inactive` against a compact `sessions.json` listing three active sessions:

```
sessions.json lists 3 active: aaa bbb ccc
before: 3 session files
after : 1 remaining
  kept: ccc.jsonl
```

Two live sessions deleted. This runs periodically from a systemd timer or cron, and token-spy is `category: recommended`.

`scripts/session-cleanup.sh:58` already reads the same file correctly, per occurrence with `grep -oE` — one file format, two different readings.

## Second failure in the same function

An empty extraction was treated as "nothing is active" rather than "the parse failed", so a schema change or a partial write deletes **every** session file. The SSH remote path had the same shape: its `ACTIVE_IDS` block is only emitted when the remote `sessions.json` exists, yet an empty block still queued every remote session for `rm -f`.

## Fix

- `extract_active_ids()` matches per occurrence, mirroring `session-cleanup.sh`
- both the local and the remote path refuse to clean when a present `sessions.json` yields no ids
- the same greedy pattern in the embedded remote script is corrected

## Verification

New `tests/test-token-spy-session-manager.sh` (wired into `make test`), sourcing the real functions out of the script:

1. every id is extracted from a compact single-line `sessions.json`
2. three live sessions survive cleanup, and an orphan is still collected
3. an unparseable `sessions.json` cancels cleanup instead of wiping
4. pretty-printed layout still works — no regression

`bash -n` clean.