### PR TITLE
fix(cli): surface compose-flags resolver failures instead of silencing them

### DIFF
--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -1069,6 +1069,11 @@
       "description": "Hostname or IP that dashboard-api containers use to reach the ODS Host Agent. Docker Desktop uses host.docker.internal; Colima uses its private vmnet host gateway.",
       "default": ""
     },
+    "ODS_PYTHON_CMD": {
+      "type": "string",
+      "description": "Python interpreter that ODS shell helpers must use, recorded by the installer when the host python3 cannot import yaml (the compose resolver requires PyYAML). Empty means detect at runtime.",
+      "default": ""
+    },
     "ODS_MACOS_HOST_GATEWAY": {
       "type": "string",
       "description": "Private macOS host-side vmnet address used by Colima containers to reach loopback-only ODS services.",

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1666,6 +1666,18 @@ else
         ai_warn "ODS_AGENT_BIND=${_macos_agent_bind_raw} uses an unsupported IPv6 server socket; using ${_macos_agent_bind}"
         upsert_env_value "${INSTALL_DIR}/.env" "ODS_AGENT_BIND" "$_macos_agent_bind"
     fi
+    # Persist the interpreter that proved it can import yaml. _ensure_macos_pyyaml
+    # may have satisfied the compose resolver through an ODS-owned venv, but that
+    # choice only lives in this installer process. Without recording it, a later
+    # `ods enable` / `ods start` resolves python again, falls back to a host
+    # python3 that cannot import yaml, and scripts/resolve-compose-stack.sh fails
+    # after the install already reported success. lib/safe-env.sh exports .env
+    # keys, so the CLI and the resolver subprocess both pick this up.
+    if [[ -n "${ODS_PYTHON_CMD:-}" ]] && ! _macos_python_imports_yaml python3; then
+        upsert_env_value "${INSTALL_DIR}/.env" "ODS_PYTHON_CMD" "$ODS_PYTHON_CMD"
+        ai_ok "Recorded compose-resolver Python: ${ODS_PYTHON_CMD}"
+    fi
+
     _macos_llm_bridge_enabled="false"
     if [[ "${DOCKER_BACKEND:-unknown}" == "colima" ]]; then
         _macos_llm_bind="$(read_env_value "${INSTALL_DIR}/.env" "BIND_ADDRESS")"

--- a/ods/lib/service-registry.sh
+++ b/ods/lib/service-registry.sh
@@ -75,7 +75,7 @@ sr_load() {
             pkg_install $(pkg_resolve python3-pyyaml) 2>>"${LOG_FILE:-/dev/null}" || true
         fi
         if ! "$PYTHON_CMD" -c "import yaml" 2>/dev/null; then
-            declare -f warn &>/dev/null && warn "PyYAML not available. Service registry will be incomplete."
+            declare -f warn &>/dev/null && warn "PyYAML not available. Service registry will be incomplete and lifecycle commands ('ods enable', 'ods start') will fail."
             declare -f warn &>/dev/null && warn "Install manually: pip3 install pyyaml"
             _SR_LOADED=true  # Prevent repeated retries
             _SR_FAILED=true

--- a/ods/ods-cli
+++ b/ods/ods-cli
@@ -699,10 +699,18 @@ _regenerate_compose_flags() {
         # --gpu-count gates the multigpu-{backend}.yml overlay; without it,
         # toggling any extension would silently strip multi-GPU plumbing
         # from the persisted cache.
-        "$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
+        # Capture the resolver's stderr instead of discarding it: it reports
+        # actionable causes (e.g. missing PyYAML) that would otherwise only
+        # surface commands later as compose's "no configuration file provided".
+        local resolver_err=""
+        if ! resolver_err=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
             --script-dir "$INSTALL_DIR" --tier "${TIER:-1}" --gpu-backend "${GPU_BACKEND:-nvidia}" \
             --gpu-count "${GPU_COUNT:-1}" --ods-mode "${ODS_MODE:-local}" \
-            > "$INSTALL_DIR/.compose-flags" 2>/dev/null || rm -f "$INSTALL_DIR/.compose-flags"
+            2>&1 > "$INSTALL_DIR/.compose-flags"); then
+            rm -f "$INSTALL_DIR/.compose-flags"
+            warn "Could not regenerate the compose stack cache. 'ods start' will fail until this is resolved:"
+            [[ -n "$resolver_err" ]] && printf '%s\n' "$resolver_err" >&2
+        fi
     else
         rm -f "$INSTALL_DIR/.compose-flags"
     fi


### PR DESCRIPTION
Fixes #1876.

## Problem

`_regenerate_compose_flags` in `ods-cli` ran the resolver with stderr discarded, and removed the cache on failure:

```bash
"$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
    ... \
    > "$INSTALL_DIR/.compose-flags" 2>/dev/null || rm -f "$INSTALL_DIR/.compose-flags"
```

`resolve-compose-stack.sh` already prints an actionable diagnosis when it can't run:

```
ERROR: PyYAML is required by resolve-compose-stack.sh for compose validation.
       Or install manually: <python> -m pip install pyyaml
```

but `2>/dev/null` threw it away. As reported in the issue, `ods enable <ext>` then appeared to succeed and the real failure only surfaced two commands later as compose's `no configuration file provided: not found`, with no hint of the cause.

## Fix

Capture the resolver's stderr and print it after a warning that names the consequence, so the failure is reported where it happens:

```bash
local resolver_err=""
if ! resolver_err=$("$INSTALL_DIR/scripts/resolve-compose-stack.sh" \
    ... \
    2>&1 > "$INSTALL_DIR/.compose-flags"); then
    rm -f "$INSTALL_DIR/.compose-flags"
    warn "Could not regenerate the compose stack cache. 'ods start' will fail until this is resolved:"
    [[ -n "$resolver_err" ]] && printf '%s\n' "$resolver_err" >&2
fi
```

The `2>&1 > file` ordering keeps stdout going to `.compose-flags` and captures only stderr, so successful runs behave exactly as before.

Also corrected the `lib/service-registry.sh` warning, which said only *"Service registry will be incomplete"* while lifecycle commands actually break. It now states that `ods enable` / `ods start` will fail.

## Verification

Extracted the real function and ran it against a stub resolver covering both paths:

**Resolver fails** (stub reproduces the PyYAML error):
```
WARN: Could not regenerate the compose stack cache. 'ods start' will fail until this is resolved:
ERROR: PyYAML is required by resolve-compose-stack.sh for compose validation.
       Or install manually: python3 -m pip install pyyaml
.compose-flags removed
```

**Resolver succeeds:** stderr empty, `.compose-flags` contains `-f docker-compose.base.yml -f docker-compose.nvidia.yml`.

`bash -n` passes on both files.

## Out of scope

The issue also suggests a host-Python PyYAML preflight check on the macOS install path. That is a larger, separate change and is not included here.