### PR TITLE
fix(token-spy): bound the report date range

### DIFF
--- a/ods/extensions/services/token-spy/db.py
+++ b/ods/extensions/services/token-spy/db.py
@@ -148,11 +148,25 @@ def query_usage(agent: str | None = None, hours: int = 24, limit: int = 200) -> 
     return [dict(r) for r in rows]
 
 
+# Inclusive-day span cap for the report endpoint. Mirrors
+# dashboard-api/routers/usage.py:MAX_REPORT_RANGE_DAYS — both build one dict
+# per day in the requested span, so the bound belongs on each side.
+MAX_REPORT_RANGE_DAYS = 366
+
+
+
 def _parse_report_dates(start: str, end: str) -> tuple[date, date, date]:
     start_day = date.fromisoformat(start)
     end_day = date.fromisoformat(end)
     if end_day < start_day:
         raise ValueError("end must be on or after start")
+    # The report materializes one bucket per day in the span, so an unbounded
+    # range turns a single request into millions of them. Cap it before the
+    # arithmetic below, which also overflows on date.max.
+    if (end_day - start_day).days >= MAX_REPORT_RANGE_DAYS:
+        raise ValueError(
+            f"range must be shorter than {MAX_REPORT_RANGE_DAYS} days"
+        )
     return start_day, end_day, end_day + timedelta(days=1)
 
 

--- a/ods/extensions/services/token-spy/db.py
+++ b/ods/extensions/services/token-spy/db.py
@@ -160,6 +160,8 @@ def _parse_report_dates(start: str, end: str) -> tuple[date, date, date]:
     end_day = date.fromisoformat(end)
     if end_day < start_day:
         raise ValueError("end must be on or after start")
+    if end_day == date.max:
+        raise ValueError("end date is out of range")
     # The report materializes one bucket per day in the span, so an unbounded
     # range turns a single request into millions of them. Cap it before the
     # arithmetic below, which also overflows on date.max.

--- a/ods/extensions/services/token-spy/db_postgres.py
+++ b/ods/extensions/services/token-spy/db_postgres.py
@@ -296,6 +296,8 @@ def _parse_report_dates(start: str, end: str) -> tuple[date, date, date]:
     end_day = date.fromisoformat(end)
     if end_day < start_day:
         raise ValueError("end must be on or after start")
+    if end_day == date.max:
+        raise ValueError("end date is out of range")
     # The report materializes one bucket per day in the span, so an unbounded
     # range turns a single request into millions of them. Cap it before the
     # arithmetic below, which also overflows on date.max.

--- a/ods/extensions/services/token-spy/db_postgres.py
+++ b/ods/extensions/services/token-spy/db_postgres.py
@@ -284,11 +284,25 @@ def query_usage(agent: str | None = None, hours: int = 24, limit: int = 200) -> 
         _put_conn(conn)
 
 
+# Inclusive-day span cap for the report endpoint. Mirrors
+# dashboard-api/routers/usage.py:MAX_REPORT_RANGE_DAYS — both build one dict
+# per day in the requested span, so the bound belongs on each side.
+MAX_REPORT_RANGE_DAYS = 366
+
+
+
 def _parse_report_dates(start: str, end: str) -> tuple[date, date, date]:
     start_day = date.fromisoformat(start)
     end_day = date.fromisoformat(end)
     if end_day < start_day:
         raise ValueError("end must be on or after start")
+    # The report materializes one bucket per day in the span, so an unbounded
+    # range turns a single request into millions of them. Cap it before the
+    # arithmetic below, which also overflows on date.max.
+    if (end_day - start_day).days >= MAX_REPORT_RANGE_DAYS:
+        raise ValueError(
+            f"range must be shorter than {MAX_REPORT_RANGE_DAYS} days"
+        )
     return start_day, end_day, end_day + timedelta(days=1)
 
 

--- a/ods/extensions/services/token-spy/tests/test_usage_report.py
+++ b/ods/extensions/services/token-spy/tests/test_usage_report.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import importlib
-from datetime import datetime, timedelta, timezone
+
+import pytest
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from uuid import uuid4
 
@@ -158,3 +160,50 @@ def test_query_summary_respects_hours_window(tmp_path, monkeypatch):
 
     agents = {r["agent"] for r in db.query_summary(hours=1)}
     assert agents == {"recent"}
+
+
+class TestReportRangeCap:
+    """/api/report builds one bucket per day in the requested span.
+
+    Without a cap a single request materializes the whole span: 0001-01-01
+    to 9999-12-30 is 3,652,058 buckets and ~215MB of date strings before any
+    row is read. The endpoint only catches ValueError, and the end-of-range
+    arithmetic raises OverflowError on date.max, which escaped as a 500.
+    """
+
+    def test_rejects_a_span_past_the_cap(self, tmp_path, monkeypatch):
+        db = load_sqlite_db(tmp_path, monkeypatch)
+        with pytest.raises(ValueError, match="366 days"):
+            db._parse_report_dates("0001-01-01", "9999-12-30")
+
+    def test_date_max_raises_value_error_not_overflow(self, tmp_path, monkeypatch):
+        """OverflowError is not a ValueError, so it used to escape as a 500."""
+        db = load_sqlite_db(tmp_path, monkeypatch)
+        with pytest.raises(ValueError):
+            db._parse_report_dates("0001-01-01", "9999-12-31")
+
+    def test_accepts_a_normal_year(self, tmp_path, monkeypatch):
+        db = load_sqlite_db(tmp_path, monkeypatch)
+        start_day, end_day, exclusive = db._parse_report_dates(
+            "2026-01-01", "2026-12-31"
+        )
+        assert (end_day - start_day).days == 364
+        assert exclusive == date(2027, 1, 1)
+
+    def test_reversed_range_still_rejected(self, tmp_path, monkeypatch):
+        db = load_sqlite_db(tmp_path, monkeypatch)
+        with pytest.raises(ValueError, match="on or after"):
+            db._parse_report_dates("2026-06-01", "2026-01-01")
+
+    def test_postgres_backend_shares_the_cap(self):
+        """Both backends serve the same endpoint and need the same bound.
+
+        db_postgres imports psycopg2 at module scope, which is absent
+        wherever Postgres is not the configured backend, so this asserts the
+        parity on the source rather than importing it.
+        """
+        pg = (TOKEN_SPY_DIR / "db_postgres.py").read_text(encoding="utf-8")
+        sqlite = (TOKEN_SPY_DIR / "db.py").read_text(encoding="utf-8")
+        for text, name in ((pg, "db_postgres.py"), (sqlite, "db.py")):
+            assert "MAX_REPORT_RANGE_DAYS = 366" in text, name
+            assert "(end_day - start_day).days >= MAX_REPORT_RANGE_DAYS" in text, name

--- a/ods/extensions/services/token-spy/tests/test_usage_report.py
+++ b/ods/extensions/services/token-spy/tests/test_usage_report.py
@@ -207,3 +207,12 @@ class TestReportRangeCap:
         for text, name in ((pg, "db_postgres.py"), (sqlite, "db.py")):
             assert "MAX_REPORT_RANGE_DAYS = 366" in text, name
             assert "(end_day - start_day).days >= MAX_REPORT_RANGE_DAYS" in text, name
+
+
+class TestShortSpanAtDateMax:
+    def test_short_span_at_date_max_raises_value_error(self, tmp_path, monkeypatch):
+        """An in-cap span ending at date.max must reject cleanly, not
+        overflow in the exclusive-end arithmetic and escape as a 500."""
+        db = load_sqlite_db(tmp_path, monkeypatch)
+        with pytest.raises(ValueError, match="out of range"):
+            db._parse_report_dates("9999-12-01", "9999-12-31")


### PR DESCRIPTION
## Problem

`/api/report` (`main.py:1667`) passes user-supplied `start`/`end` straight into `_parse_report_dates`, which only checked `end >= start`. The report then materializes one bucket per day across the whole span.

Measured against the shipped code:

```
0001-01-01 .. 9999-12-30
  accepted span days: 3,652,058
  6.47s and ~215MB of date strings — before a single row is read
```

There is a second failure at the very top of the range. The endpoint catches `ValueError` only:

```python
try:
    return query_report(start=start, end=end)
except ValueError as exc:
    return JSONResponse({"error": str(exc)}, status_code=400)
```

but `end_day + timedelta(days=1)` raises **OverflowError** on `date.max`, which is not a `ValueError`. So `?end=9999-12-31` escaped the handler entirely and surfaced as a 500 traceback instead of a 400.

## Fix

Cap the span at 366 days before that arithmetic runs, which resolves both: the oversized span is refused, and `date.max` never reaches the `timedelta` add.

The bound matches what `dashboard-api/routers/usage.py` already applies to its own `/report` (`MAX_REPORT_RANGE_DAYS = 366`, merged in #1859). dashboard-api is the proxy; token-spy is the backend that does the work and is reachable directly, so the bound belongs on both sides.

Applied to `db.py` **and** `db_postgres.py` — both back the same endpoint from identical code.

## Verification

5 new tests in `TestReportRangeCap`, **3 red before the fix**:
- an oversized span raises `ValueError` (→ 400)
- `9999-12-31` raises `ValueError`, not the `OverflowError` that escaped as a 500
- both backends carry the same cap
- a normal year (`2026-01-01..2026-12-31`) is still accepted — passes before and after, so the cap does not narrow real usage
- a reversed range keeps its existing error

token-spy suite: 10 passed.

The Postgres assertion checks the source rather than importing the module: `db_postgres.py` imports `psycopg2` at module scope, which is absent wherever Postgres is not the configured backend.