### PR TITLE
fix(talk): keep retrying a transient offline status

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.jsx
@@ -55,6 +55,9 @@ export default function ODSTalk() {
   const [status, setStatus] = useState('loading')
   const [statusText, setStatusText] = useState('Connecting to ODS Talk...')
   const [retryStatusRefresh, setRetryStatusRefresh] = useState(false)
+  // Advances after every offline retry so the polling effect re-arms; a
+  // repeated failure otherwise leaves every dependency unchanged.
+  const [statusAttempt, setStatusAttempt] = useState(0)
   const [sending, setSending] = useState(false)
   const [recording, setRecording] = useState(false)
   const [spokenReplies, setSpokenReplies] = useState(() => {
@@ -149,11 +152,25 @@ export default function ODSTalk() {
 
   useEffect(() => { refreshStatus() }, [refreshStatus])
 
+  // Poll while offline. A one-shot setTimeout does not reschedule here: a
+  // failed retry sets `status` and `retryStatusRefresh` to the values they
+  // already hold, React bails out of the re-render, no dependency changes,
+  // and the effect never runs again. Bumping an attempt counter after each
+  // attempt guarantees a changed dependency, so the retry keeps going until
+  // the backend is ready — which is the point, since it is usually a
+  // container still starting up.
   useEffect(() => {
     if (!retryStatusRefresh || status !== 'offline') return undefined
-    const timer = setTimeout(refreshStatus, TALK_STATUS_RETRY_MS)
-    return () => clearTimeout(timer)
-  }, [refreshStatus, retryStatusRefresh, status])
+    let cancelled = false
+    const timer = setTimeout(async () => {
+      await refreshStatus()
+      if (!cancelled) setStatusAttempt(attempt => attempt + 1)
+    }, TALK_STATUS_RETRY_MS)
+    return () => {
+      cancelled = true
+      clearTimeout(timer)
+    }
+  }, [refreshStatus, retryStatusRefresh, status, statusAttempt])
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView?.({ block: 'end' })

--- a/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/ODSTalk.test.jsx
@@ -153,6 +153,53 @@ describe('ODSTalk', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
   })
 
+  test('keeps retrying when readiness takes more than one attempt', async () => {
+    // The retry is a one-shot setTimeout re-armed by an effect dependency. A
+    // failed attempt used to set status/retry flags to the values they already
+    // held, so React bailed out of the re-render, no dependency changed, and
+    // the effect never ran a second time — the page sat on 'offline' until a
+    // manual reload. A backend container taking longer than one interval to
+    // come up is the normal case, not an edge case.
+    const fetchMock = vi.fn(async (url) => {
+      if (url === '/api/talk/status') {
+        const ready = fetchMock.mock.calls.length > 3
+        return response({
+          capabilities: { text_chat: ready, tts: false, audio_message: false },
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<ODSTalk />)
+
+    expect((await screen.findAllByText('ODS Talk text chat is not available.')).length).toBeGreaterThan(0)
+    expect(await screen.findByText('Ready', {}, { timeout: 8000 })).toBeInTheDocument()
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(3)
+  })
+
+  test('stops polling once a permanent incompatibility is reported', async () => {
+    // A compatibility reason is a settled answer, not a transient outage:
+    // retrying must stay off so the page does not poll forever.
+    const fetchMock = vi.fn(async (url) => {
+      if (url === '/api/talk/status') {
+        return response({
+          capabilities: { text_chat: false, tts: false, audio_message: false },
+          reason: 'Model does not support tool calling.',
+        })
+      }
+      throw new Error(`unexpected request: ${url}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<ODSTalk />)
+
+    expect((await screen.findAllByText('Model does not support tool calling.')).length).toBeGreaterThan(0)
+    const seen = fetchMock.mock.calls.length
+    await new Promise(resolve => setTimeout(resolve, 2500))
+    expect(fetchMock.mock.calls.length).toBe(seen)
+  })
+
   test('accumulates SSE deltas across split chunks', async () => {
     // Transport may split a single SSE frame across chunk boundaries. The
     // reader has to buffer the partial frame across reads, not drop bytes.


### PR DESCRIPTION
## Problem

The offline retry is a one-shot `setTimeout` re-armed by an effect dependency:

```jsx
useEffect(() => {
  if (!retryStatusRefresh || status !== 'offline') return undefined
  const timer = setTimeout(refreshStatus, TALK_STATUS_RETRY_MS)
  return () => clearTimeout(timer)
}, [refreshStatus, retryStatusRefresh, status])
```

When the retry fails, `refreshStatus` sets `status` to `'offline'` and `retryStatusRefresh` to `true` — the values they already hold. React bails out of a re-render on identical state, so **no dependency changes and the effect never re-runs**. `refreshStatus` is a `useCallback` keyed on `liveMicSupported`, so it is stable too.

Net effect: exactly one retry, 1s after going offline, then the page sits on "ODS Talk is offline" until a manual reload. A backend container taking longer than one interval to become ready is the normal case, so the transient-offline handling this effect exists for did not cover it.

Every other poller in the dashboard (`Dashboard`, `ServiceMap`, `Extensions`, `useDownloadProgress`) uses `setInterval` and reschedules on its own — this one was the outlier.

The existing test passes because it makes the backend ready on the **second** call, which is exactly the one retry that does happen.

## Fix

Advance a `statusAttempt` counter after each retry, so a dependency always changes and the poll re-arms. The cleanup cancels the pending bump, so an unmount or a status change does not schedule another round.

A settled incompatibility still switches retrying off (`setRetryStatusRefresh(!compatibilityReason)`), so the page does not poll forever on a permanent answer.

## Verification

2 new tests. Against `main` (with `--no-cache` — vitest's transform cache will otherwise serve the patched module):

```
× keeps retrying when readiness takes more than one attempt 5026ms
Tests  1 failed | 14 skipped (15)
```

- readiness on the 4th call recovers (red before the fix, times out on `offline`)
- a permanent incompatibility issues no further polls — guards against the fix turning into an unbounded poll

`ODSTalk.test.jsx`: 15 passed. ESLint clean.