### PR TITLE
feat(models): switchboard product prep — probe-key file, instance identity, verdict lifecycle, allowlist health

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -291,7 +291,12 @@
           "status": "unsupported_until_revalidated",
           "label": "Perplexica revalidation required",
           "reason": "Fleet model-UI run 2026-07-19T03:40Z on windows-laptop loaded this model and ODS Talk passed, but the Perplexica app probe answered with a search-style failure instead of the requested verification phrase; keep it out of all-app release coverage until Perplexica compatibility is revalidated.",
-          "evidence": "fleet-test/runs/2026-07-19T03-40-01Z-release-product-54b2f703190f-harness-2a6a4e6a55b8-hosts-windows-laptop/model-ui/cycle-003/windows-laptop"
+          "evidence": "fleet-test/runs/2026-07-19T03-40-01Z-release-product-54b2f703190f-harness-2a6a4e6a55b8-hosts-windows-laptop/model-ui/cycle-003/windows-laptop",
+          "recordedAt": "2026-07-19T03:40:01Z",
+          "productSha": "54b2f703190f",
+          "harnessSha": "2a6a4e6a55b8",
+          "hostScope": ["windows-laptop"],
+          "revalidateAgainstSha": "63949ab0ff5be385dde9977528c199b6c081c9ca"
         }
       },
       "install_recommendation": false
@@ -425,12 +430,22 @@
         "hermes_talk": {
           "status": "unsupported_until_revalidated",
           "reason": "Fleet model-UI run 2026-07-20T14:47Z on windows-laptop loaded this model successfully, but ODS Talk timed out after 180s. A targeted Talk repro on the same host streamed only a session frame and keepalives for 240s while llama-server was still processing a 19,349-token Hermes prompt.",
-          "evidence": "fleet-test/runs/2026-07-20T14-47-35Z-release-product-6b802d2d34a5-harness-d205823ca1d4-hosts-windows-laptop/model-ui/cycle-004/windows-laptop"
+          "evidence": "fleet-test/runs/2026-07-20T14-47-35Z-release-product-6b802d2d34a5-harness-d205823ca1d4-hosts-windows-laptop/model-ui/cycle-004/windows-laptop",
+          "recordedAt": "2026-07-20T14:47:35Z",
+          "productSha": "6b802d2d34a5",
+          "harnessSha": "d205823ca1d4",
+          "hostScope": ["windows-laptop"],
+          "revalidateAgainstSha": "c691f060f93cd0a255760e2749a58c5006edb0c4"
         },
         "agent_viability": {
           "status": "not_agent_viable",
           "reason": "The model can answer direct chat, but its measured 0.73 tok/s response rate and 240s ODS Talk timeout under a 19,349-token Hermes prompt make it too slow for agent-required workflows on this host class until revalidated.",
-          "evidence": "fleet-test/runs/2026-07-20T14-47-35Z-release-product-6b802d2d34a5-harness-d205823ca1d4-hosts-windows-laptop/model-ui/cycle-004/windows-laptop"
+          "evidence": "fleet-test/runs/2026-07-20T14-47-35Z-release-product-6b802d2d34a5-harness-d205823ca1d4-hosts-windows-laptop/model-ui/cycle-004/windows-laptop",
+          "recordedAt": "2026-07-20T14:47:35Z",
+          "productSha": "6b802d2d34a5",
+          "harnessSha": "d205823ca1d4",
+          "hostScope": ["windows-laptop"],
+          "revalidateAgainstSha": "c691f060f93cd0a255760e2749a58c5006edb0c4"
         }
       },
       "install_recommendation": false

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -314,6 +314,11 @@ services:
       - ODS_ROUTER_INTERNAL_KEY=${ODS_ROUTER_INTERNAL_KEY:-}
       - DASHBOARD_API_KEY=${DASHBOARD_API_KEY:-}
       - ODS_FLEET_PROBE_KEY=${ODS_FLEET_PROBE_KEY:-}
+      # File-based probe key inside the already-mounted state volume: the
+      # fleet harness can create/rotate/remove it without recreating the
+      # router (a recreate destroys in-memory route evidence). Absent file
+      # means the ODS_FLEET_PROBE_KEY env fallback applies unchanged.
+      - ODS_FLEET_PROBE_KEY_PATH=/state/fleet-probe.key
     volumes:
       - ${ODS_DATA_DIR:-./data}:/state:ro
       - ${ODS_CONFIG_DIR:-./config}/model-router/endpoints.json:/config/endpoints.json:ro

--- a/ods/extensions/services/dashboard-api/routers/model_routes.py
+++ b/ods/extensions/services/dashboard-api/routers/model_routes.py
@@ -31,6 +31,7 @@ _STRING_FIELDS = {
     "path",
     "responseModel",
     "lemonadeRoute",
+    "instanceId",
 }
 _INT_FIELDS = {"routeSeq", "status"}
 

--- a/ods/extensions/services/dashboard-api/tests/test_model_routes.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_routes.py
@@ -220,3 +220,27 @@ def test_route_evidence_rejects_mismatched_probe(test_client, monkeypatch):
     )
 
     assert resp.status_code == 502
+
+
+def test_route_evidence_passes_through_instance_id(test_client, monkeypatch):
+    probe_id = str(uuid.uuid4())
+    monkeypatch.setenv("ODS_ROUTER_INTERNAL_KEY", "internal-secret")
+    payload = {
+        "probeId": probe_id,
+        "requestedModel": "ods/current",
+        "routedModel": "Qwen.gguf",
+        "backend": "llama-server",
+        "endpointId": "llama-server-default",
+        "routeSeq": 3,
+        "path": "/v1/chat/completions",
+        "status": 200,
+        "responseModel": "Qwen.gguf",
+        "instanceId": "0b7f9d2c-8a41-4f0e-9d5b-1c2e3f4a5b6c",
+    }
+    _patch_router_client(monkeypatch, httpx.Response(200, json=payload))
+    resp = test_client.get(
+        f"/api/models/routes/{probe_id}",
+        headers=test_client.auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["instanceId"] == "0b7f9d2c-8a41-4f0e-9d5b-1c2e3f4a5b6c"

--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -52,6 +52,11 @@ INTERNAL_KEY = os.environ.get("ODS_ROUTER_INTERNAL_KEY", "") or os.environ.get(
     "DASHBOARD_API_KEY", ""
 )
 PROBE_KEY = os.environ.get("ODS_FLEET_PROBE_KEY", "")
+_PROBE_KEY_PATH_VALUE = os.environ.get("ODS_FLEET_PROBE_KEY_PATH", "")
+PROBE_KEY_PATH: Path | None = (
+    Path(_PROBE_KEY_PATH_VALUE) if _PROBE_KEY_PATH_VALUE else None
+)
+INSTANCE_ID = str(uuid.uuid4())
 
 MAX_BODY_BYTES = int(os.environ.get("ODS_ROUTER_MAX_BODY_BYTES", str(2 * 1024 * 1024)))
 MAX_QUEUE_DEPTH = int(os.environ.get("ODS_ROUTER_MAX_QUEUE_DEPTH", "64"))
@@ -93,7 +98,8 @@ _inflight = 0
 _inflight_lock = asyncio.Lock()
 
 _state_cache: dict[str, Any] = {"mtime": None, "doc": None}
-_endpoints_cache: dict[str, Any] = {"loaded": False, "endpoints": {}}
+_endpoints_cache: dict[str, Any] = {"mtime": None, "endpoints": {}}
+_probe_key_cache: dict[str, Any] = {"mtime": None, "key": ""}
 _evidence: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
 
 
@@ -106,8 +112,17 @@ class RouterError(Exception):
 
 
 def _load_endpoints() -> dict[str, dict[str, Any]]:
-    """Startup-validated allowlist: endpointId -> {baseUrl, apiKeyEnv?}."""
-    if _endpoints_cache["loaded"]:
+    """Allowlist endpointId -> {baseUrl, apiKeyEnv?}, re-read when the file
+    changes on disk (activation re-renders it). Retains the last good
+    allowlist while the file is missing or invalid."""
+    try:
+        stat = ENDPOINTS_PATH.stat()
+    except OSError as exc:
+        if _endpoints_cache["mtime"] is None:
+            logger.error("endpoints allowlist unavailable: %s", exc)
+        return _endpoints_cache["endpoints"]
+    mtime = (stat.st_mtime_ns, stat.st_size)
+    if _endpoints_cache["mtime"] == mtime:
         return _endpoints_cache["endpoints"]
     endpoints: dict[str, dict[str, Any]] = {}
     try:
@@ -122,9 +137,10 @@ def _load_endpoints() -> dict[str, dict[str, Any]]:
                 "apiKeyEnv": str(entry.get("apiKeyEnv") or ""),
             }
     except (OSError, ValueError) as exc:
-        logger.error("endpoints allowlist unavailable: %s", exc)
+        logger.error("endpoints allowlist unreadable; retaining previous: %s", exc)
+        return _endpoints_cache["endpoints"]
+    _endpoints_cache["mtime"] = mtime
     _endpoints_cache["endpoints"] = endpoints
-    _endpoints_cache["loaded"] = True
     return endpoints
 
 
@@ -346,6 +362,7 @@ def _active_route() -> dict[str, Any]:
 def _record_evidence(record: dict[str, Any]) -> None:
     now = time.monotonic()
     record["storedAt"] = now
+    record["instanceId"] = INSTANCE_ID
     _evidence[record["probeId"]] = record
     while len(_evidence) > EVIDENCE_LIMIT:
         _evidence.popitem(last=False)
@@ -355,16 +372,44 @@ def _record_evidence(record: dict[str, Any]) -> None:
         _evidence.pop(key, None)
 
 
+def _current_probe_key() -> str:
+    """Fleet probe key: file-based (mtime-cached re-read) when
+    ODS_FLEET_PROBE_KEY_PATH is configured and the file holds a value,
+    falling back to the ODS_FLEET_PROBE_KEY environment value. The file
+    form lets the fleet harness rotate or remove the key without
+    recreating the router (which would destroy in-memory evidence)."""
+    if PROBE_KEY_PATH is None:
+        return PROBE_KEY
+    try:
+        stat = PROBE_KEY_PATH.stat()
+    except OSError:
+        _probe_key_cache["mtime"] = None
+        _probe_key_cache["key"] = ""
+        return PROBE_KEY
+    mtime = (stat.st_mtime_ns, stat.st_size)
+    if _probe_key_cache["mtime"] != mtime:
+        try:
+            key = PROBE_KEY_PATH.read_text(encoding="utf-8").strip()
+        except OSError:
+            _probe_key_cache["mtime"] = None
+            _probe_key_cache["key"] = ""
+            return PROBE_KEY
+        _probe_key_cache["mtime"] = mtime
+        _probe_key_cache["key"] = key
+    return _probe_key_cache["key"] or PROBE_KEY
+
+
 def _verify_probe_marker(body_text: str) -> str | None:
     """Return the probe UUID only for exactly one validly signed marker."""
-    if not PROBE_KEY:
+    probe_key = _current_probe_key()
+    if not probe_key:
         return None
     matches = _PROBE_RE.findall(body_text)
     if len(matches) != 1:
         return None
     probe_id, signature = matches[0]
     expected = base64.urlsafe_b64encode(
-        hmac.new(PROBE_KEY.encode("utf-8"), probe_id.encode("utf-8"),
+        hmac.new(probe_key.encode("utf-8"), probe_id.encode("utf-8"),
                  hashlib.sha256).digest()
     ).rstrip(b"=").decode("ascii")
     if not hmac.compare_digest(expected, signature):
@@ -472,6 +517,8 @@ async def health() -> dict[str, Any]:
         "hasRoute": bool((doc or {}).get("active")),
         "seq": (doc or {}).get("seq"),
         "routeSeq": (doc or {}).get("routeSeq"),
+        "instanceId": INSTANCE_ID,
+        "probeKeyConfigured": bool(_current_probe_key()),
     }
 
 

--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -512,8 +512,13 @@ async def _release_admission() -> None:
 @app.get("/health")
 async def health() -> dict[str, Any]:
     doc = _read_state()
+    endpoints = _load_endpoints()
+    # Body-level signal only: with an empty allowlist every forward answers
+    # endpoint_not_allowlisted, but the HTTP status stays 200 so the compose
+    # healthcheck does not cascade a config gap into container restarts.
     return {
-        "status": "ok",
+        "status": "ok" if endpoints else "degraded",
+        "endpointCount": len(endpoints),
         "hasRoute": bool((doc or {}).get("active")),
         "seq": (doc or {}).get("seq"),
         "routeSeq": (doc or {}).get("routeSeq"),

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -493,3 +493,170 @@ class TestModelsAndEvidence:
         assert client.get("/health").json()["hasRoute"] is False
         write_state()
         assert client.get("/health").json()["hasRoute"] is True
+
+
+class TestProbeKeyLifecycleAndInstance:
+    """File-based probe key: rotate/remove without recreating the router,
+    with the env value as fallback; instance identity is stable and stamped
+    into evidence so a mid-cycle replacement is detectable."""
+
+    def _use_key_file(self, mod, tmp_path, monkeypatch, env_fallback=""):
+        key_path = tmp_path / "fleet-probe.key"
+        monkeypatch.setattr(mod, "PROBE_KEY_PATH", key_path)
+        monkeypatch.setattr(mod, "PROBE_KEY", env_fallback)
+        mod._probe_key_cache.update({"mtime": None, "key": ""})
+        return key_path
+
+    def test_file_key_rotates_without_restart(self, router, tmp_path, monkeypatch):
+        mod, client, write_state, calls = router
+        write_state()
+        key_path = self._use_key_file(mod, tmp_path, monkeypatch)
+        key_path.write_text("key-a\n", encoding="utf-8")
+
+        instance_before = client.get("/health").json()["instanceId"]
+        probe_a = str(uuid.uuid4())
+        resp = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user",
+                          "content": _signed_marker(probe_a, key="key-a")}],
+        })
+        assert resp.status_code == 200
+        ev = client.get(f"/internal/route-evidence/{probe_a}",
+                        headers={"Authorization": "Bearer internal-secret"})
+        assert ev.status_code == 200
+        assert ev.json()["instanceId"] == instance_before
+
+        key_path.write_text("key-b-rotated\n", encoding="utf-8")
+        stale = str(uuid.uuid4())
+        client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user",
+                          "content": _signed_marker(stale, key="key-a")}],
+        })
+        assert client.get(
+            f"/internal/route-evidence/{stale}",
+            headers={"Authorization": "Bearer internal-secret"},
+        ).status_code == 404
+
+        fresh = str(uuid.uuid4())
+        client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user",
+                          "content": _signed_marker(fresh, key="key-b-rotated")}],
+        })
+        assert client.get(
+            f"/internal/route-evidence/{fresh}",
+            headers={"Authorization": "Bearer internal-secret"},
+        ).status_code == 200
+
+        health = client.get("/health").json()
+        assert health["instanceId"] == instance_before
+        assert health["probeKeyConfigured"] is True
+
+    def test_deleted_key_file_stops_collection_then_env_fallback(
+            self, router, tmp_path, monkeypatch):
+        mod, client, write_state, calls = router
+        write_state()
+        key_path = self._use_key_file(mod, tmp_path, monkeypatch)
+        key_path.write_text("key-a", encoding="utf-8")
+        assert client.get("/health").json()["probeKeyConfigured"] is True
+
+        key_path.unlink()
+        assert client.get("/health").json()["probeKeyConfigured"] is False
+        orphan = str(uuid.uuid4())
+        client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user",
+                          "content": _signed_marker(orphan, key="key-a")}],
+        })
+        assert client.get(
+            f"/internal/route-evidence/{orphan}",
+            headers={"Authorization": "Bearer internal-secret"},
+        ).status_code == 404
+
+        monkeypatch.setattr(mod, "PROBE_KEY", "env-fallback-key")
+        assert client.get("/health").json()["probeKeyConfigured"] is True
+        fallback = str(uuid.uuid4())
+        client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user",
+                          "content": _signed_marker(fallback,
+                                                    key="env-fallback-key")}],
+        })
+        assert client.get(
+            f"/internal/route-evidence/{fallback}",
+            headers={"Authorization": "Bearer internal-secret"},
+        ).status_code == 200
+
+    def test_empty_key_file_falls_back_to_env(self, router, tmp_path, monkeypatch):
+        mod, client, write_state, calls = router
+        write_state()
+        key_path = self._use_key_file(mod, tmp_path, monkeypatch,
+                                      env_fallback="env-key")
+        key_path.write_text("   \n", encoding="utf-8")
+        assert client.get("/health").json()["probeKeyConfigured"] is True
+        probe = str(uuid.uuid4())
+        client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user",
+                          "content": _signed_marker(probe, key="env-key")}],
+        })
+        assert client.get(
+            f"/internal/route-evidence/{probe}",
+            headers={"Authorization": "Bearer internal-secret"},
+        ).status_code == 200
+
+    def test_health_exposes_stable_instance_and_key_state(self, router):
+        mod, client, write_state, calls = router
+        first = client.get("/health").json()
+        second = client.get("/health").json()
+        assert first["instanceId"] == second["instanceId"] == mod.INSTANCE_ID
+        assert uuid.UUID(first["instanceId"])
+        assert first["probeKeyConfigured"] is True  # fixture env key
+
+
+class TestEndpointsReload:
+    """endpoints.json is re-read on mtime/size change (activation re-renders
+    it); missing or invalid content retains the last good allowlist."""
+
+    def _endpoints_path(self, tmp_path):
+        return tmp_path / "endpoints.json"
+
+    def test_new_endpoint_visible_without_restart(self, router, tmp_path):
+        mod, client, write_state, calls = router
+        write_state(endpoint="added-later")
+        resp = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        assert resp.status_code == 503
+        assert resp.json()["error"]["type"] == "endpoint_not_allowlisted"
+
+        self._endpoints_path(tmp_path).write_text(json.dumps({
+            "endpoints": [
+                {"id": "llama-server-default", "baseUrl": "http://upstream:8080"},
+                {"id": "added-later", "baseUrl": "http://late:7000"},
+            ]
+        }), encoding="utf-8")
+        ok = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        assert ok.status_code == 200
+        assert calls[-1]["url"].startswith("http://late:7000")
+
+    def test_invalid_rewrite_retains_last_good_allowlist(self, router, tmp_path):
+        mod, client, write_state, calls = router
+        write_state()
+        assert client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "hi"}],
+        }).status_code == 200
+
+        self._endpoints_path(tmp_path).write_text("{not-json", encoding="utf-8")
+        still_ok = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+        assert still_ok.status_code == 200
+        assert calls[-1]["url"].startswith("http://upstream:8080")

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -42,7 +42,7 @@ def router(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "ENDPOINTS_PATH", endpoints_path)
     monkeypatch.setattr(mod, "INTERNAL_KEY", "internal-secret")
     monkeypatch.setattr(mod, "PROBE_KEY", "probe-secret")
-    mod._endpoints_cache.update({"loaded": False, "endpoints": {}})
+    mod._endpoints_cache.update({"mtime": None, "endpoints": {}})
     mod._state_cache.update({"mtime": None, "doc": None})
     mod._evidence.clear()
 
@@ -660,3 +660,19 @@ class TestEndpointsReload:
         })
         assert still_ok.status_code == 200
         assert calls[-1]["url"].startswith("http://upstream:8080")
+
+    def test_health_reports_allowlist_health(self, router, tmp_path):
+        mod, client, write_state, calls = router
+        healthy = client.get("/health")
+        assert healthy.status_code == 200
+        assert healthy.json()["status"] == "ok"
+        assert healthy.json()["endpointCount"] == 2
+
+        self._endpoints_path(tmp_path).write_text(
+            json.dumps({"endpoints": []}), encoding="utf-8")
+        degraded = client.get("/health")
+        # HTTP 200 on purpose: the compose healthcheck must not turn a
+        # config gap into a restart cascade; the body carries the signal.
+        assert degraded.status_code == 200
+        assert degraded.json()["status"] == "degraded"
+        assert degraded.json()["endpointCount"] == 0

--- a/ods/tests/test-model-library-verdicts.py
+++ b/ods/tests/test-model-library-verdicts.py
@@ -1,0 +1,114 @@
+"""app_compatibility verdict lifecycle contract.
+
+Fleet-recorded compatibility verdicts block models from release planning
+(see test-model-library-coverage.py BLOCKING_AGENT_STATUSES), so a verdict
+recorded by a since-fixed probe or product era can silently make the
+six-distinct-model release matrix unsatisfiable. Every new or updated
+blocking verdict must therefore carry lifecycle metadata that says when it
+was recorded, against what, where it applies, and what invalidates it:
+
+  recordedAt            ISO-8601 UTC timestamp of the recording run
+  productSha            product commit the verdict was recorded against
+  harnessSha            harness commit that recorded it
+  hostScope             non-empty list of fleet host names it applies to
+  revalidateAgainstSha  product commit at/after which the verdict must be
+                        re-earned before it may keep blocking
+  expiresAt             (alternative trigger) ISO-8601 UTC expiry
+
+Verdicts predating this contract are grandfathered behind a ratchet: their
+count may only shrink (migrate entries as they are touched or revalidated).
+"""
+
+import json
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CATALOG = ROOT / "config" / "model-library.json"
+
+BLOCKING_STATUSES = {
+    "blocked",
+    "incompatible",
+    "not_agent_viable",
+    "not_recommended",
+    "not_supported",
+    "unsupported",
+    "unsupported_until_revalidated",
+}
+
+LIFECYCLE_REQUIRED = {"recordedAt", "productSha", "harnessSha", "hostScope"}
+REVALIDATION_TRIGGERS = {"revalidateAgainstSha", "expiresAt"}
+
+# Blocking verdicts recorded before the lifecycle contract existed.
+# This number may only decrease; never add a new blocking verdict without
+# the lifecycle fields.
+LEGACY_UNMIGRATED_RATCHET = 36
+
+_ISO_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2})?Z$")
+_SHA_RE = re.compile(r"^[0-9a-f]{12,40}$")
+
+
+def _verdict_rows():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    for model in catalog["models"]:
+        compatibility = model.get("app_compatibility") or {}
+        for app, verdict in compatibility.items():
+            if isinstance(verdict, dict):
+                yield model.get("id", "?"), app, verdict
+
+
+def _is_blocking(verdict):
+    return str(verdict.get("status") or "").strip().lower() in BLOCKING_STATUSES
+
+
+def _has_lifecycle(verdict):
+    return LIFECYCLE_REQUIRED <= set(verdict)
+
+
+def test_lifecycle_bearing_verdicts_are_well_formed():
+    checked = 0
+    for model_id, app, verdict in _verdict_rows():
+        if not _has_lifecycle(verdict):
+            continue
+        checked += 1
+        where = f"{model_id}.app_compatibility.{app}"
+        assert _ISO_RE.match(str(verdict["recordedAt"])), \
+            f"{where}: recordedAt must be ISO-8601 UTC"
+        assert _SHA_RE.match(str(verdict["productSha"])), \
+            f"{where}: productSha must be 12-40 hex chars"
+        assert _SHA_RE.match(str(verdict["harnessSha"])), \
+            f"{where}: harnessSha must be 12-40 hex chars"
+        hosts = verdict["hostScope"]
+        assert isinstance(hosts, list) and hosts and all(
+            isinstance(h, str) and h for h in hosts
+        ), f"{where}: hostScope must be a non-empty list of host names"
+        if _is_blocking(verdict):
+            triggers = REVALIDATION_TRIGGERS & set(verdict)
+            assert len(triggers) == 1, (
+                f"{where}: a blocking verdict needs exactly one of "
+                f"{sorted(REVALIDATION_TRIGGERS)}"
+            )
+            trigger = triggers.pop()
+            value = str(verdict[trigger])
+            if trigger == "revalidateAgainstSha":
+                assert _SHA_RE.match(value), \
+                    f"{where}: revalidateAgainstSha must be 12-40 hex chars"
+            else:
+                assert _ISO_RE.match(value), \
+                    f"{where}: expiresAt must be ISO-8601 UTC"
+    assert checked >= 1, "expected at least one lifecycle-bearing verdict"
+
+
+def test_unmigrated_blocking_verdicts_only_shrink():
+    legacy = [
+        f"{model_id}.{app}"
+        for model_id, app, verdict in _verdict_rows()
+        if _is_blocking(verdict) and not _has_lifecycle(verdict)
+    ]
+    assert len(legacy) <= LEGACY_UNMIGRATED_RATCHET, (
+        "New blocking app_compatibility verdicts must carry lifecycle "
+        "metadata (recordedAt/productSha/harnessSha/hostScope plus a "
+        "revalidation trigger). Unmigrated legacy verdicts may only "
+        f"shrink from {LEGACY_UNMIGRATED_RATCHET}; found {len(legacy)}: "
+        + ", ".join(sorted(legacy))
+    )


### PR DESCRIPTION
## What this is

The product-prep slice staged alongside #1914, rebased onto its merged content (base `3b8ecbb4`). Three commits:

1. **Restart-free probe key + router instance identity** (`ODS_FLEET_PROBE_KEY_PATH`, compose default `/state/fleet-probe.key`, mtime-cached with env fallback; `instanceId` + `probeKeyConfigured` in `/health` and evidence) — removes the keyless-recreate silent-attestation-loss class from the RCA and gives the harness a stable identity assertion, enabling per-RUN keys and no-recreate injection.
2. **`app_compatibility` verdict lifecycle contract** (`recordedAt`/`productSha`/`harnessSha`/`hostScope` + one revalidation trigger; ratchet test pins legacy rows at 36, may only shrink). Includes migration of the two granite3.2 blocking verdicts recorded on 2026-07-20 (trigger = `c691f060`, the Talk-candidate-swap commit — flagged for confirmation in the #1914 thread) and the gemma3-4b perplexica exemplar (still blocking, `revalidateAgainstSha=63949ab`).
3. **Allowlist health in `/health`** (`endpointCount`, body `status:"degraded"` when empty; HTTP stays 200 deliberately — a 503 would let a mid-render endpoints.json cascade into compose healthcheck restarts; flip is an owner decision). Folds the observability half of #1922; the branch's endpoints mtime-reload supersedes its retry half (retains last-good allowlist across partial rewrites).

## Validation

- Router suite 38 passed; dashboard-api 239 passed / 3 skipped; model-library contract + coverage 27 passed; ruff clean (all on this exact tree, base `3b8ecbb4`).
- Supersedes #1922 (to be closed with evidence after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
