### PR TITLE
fix(dashboard): report runtime health and host telemetry accurately

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -64,6 +64,7 @@ SERVICE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 # never contain a path separator or ".." and escape BACKUP_DIR.
 BACKUP_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 MAX_BODY = 16384
+MAX_TELEMETRY_RESPONSE_BYTES = 1024 * 1024
 SUBPROCESS_TIMEOUT_START = 600  # 10 min — image pulls can be slow
 SUBPROCESS_TIMEOUT_STOP = 120   # 2 min — stop should be fast
 HOOK_TIMEOUT = 120              # 2 min — hook execution timeout
@@ -1766,6 +1767,24 @@ def _normalize_gpu_name(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "", value.casefold())
 
 
+def _is_windows_amd_integrated_gpu_name(value: str) -> bool:
+    """Mirror the installer classifier used to exclude display-only iGPUs."""
+    name = str(value or "").strip()
+    return any(re.search(pattern, name, re.IGNORECASE) for pattern in (
+        r"\bRadeon(?:\(TM\))?\s+Graphics$",
+        r"\bRadeon(?:\(TM\))?\s+\d{3,4}[MS](?:\s+Graphics)?$",
+        r"\bRadeon(?:\(TM\))?\s+(?:RX\s+)?Vega\s+\d{1,2}\s+Graphics$",
+        r"\bStrix\s+Halo\b",
+    ))
+
+
+def _is_windows_amd_discrete_gpu_name(value: str) -> bool:
+    name = str(value or "").strip()
+    if _is_windows_amd_integrated_gpu_name(name):
+        return False
+    return bool(re.search(r"\b(?:AMD\s+)?Radeon\b|\bFirePro\b", name, re.IGNORECASE))
+
+
 def _select_windows_gpu_adapters(adapters: list[dict], configured_name: str = "") -> list[dict]:
     """Select the configured hardware GPU without accidentally choosing an iGPU."""
     hardware = [item for item in adapters if not item.get("software")]
@@ -1777,6 +1796,25 @@ def _select_windows_gpu_adapters(adapters: list[dict], configured_name: str = ""
         return []
 
     wanted = _normalize_gpu_name(configured_name)
+    # The Windows env historically persisted only the primary AMD name, not
+    # GPU_COUNT. Treat all discrete Radeon adapters as the compute set even if
+    # they are different models; the name still helps on integrated-only hosts.
+    if backend == "amd":
+        discrete = [
+            item for item in candidates
+            if _is_windows_amd_discrete_gpu_name(item.get("name", ""))
+        ]
+        if discrete:
+            return discrete
+        if wanted:
+            named = [
+                item for item in candidates
+                if _normalize_gpu_name(item.get("name", "")) == wanted
+            ]
+            if named:
+                return named
+        return candidates
+
     if wanted:
         named = [item for item in candidates if _normalize_gpu_name(item.get("name", "")) == wanted]
         if named:
@@ -1786,7 +1824,17 @@ def _select_windows_gpu_adapters(adapters: list[dict], configured_name: str = ""
                 expected_count = 1
             return sorted(named, key=lambda item: item.get("memory_total_mb", 0), reverse=True)[:expected_count]
 
-    return [max(candidates, key=lambda item: item.get("memory_total_mb", 0))]
+    # The Windows env historically omitted GPU_COUNT/HOST_GPU_NAME. Infer the
+    # compute set from hardware rather than silently collapsing dual Radeon
+    # systems to one adapter. On hybrid laptops, integrated Radeon Graphics is
+    # display hardware and must not become a peer when a discrete Radeon exists.
+    try:
+        expected_count = max(1, int(GPU_COUNT or "1"))
+    except ValueError:
+        expected_count = 1
+    return sorted(
+        candidates, key=lambda item: item.get("memory_total_mb", 0), reverse=True,
+    )[:expected_count]
 
 
 def _windows_dxgi_adapters() -> list[dict]:
@@ -1851,6 +1899,7 @@ def _windows_dxgi_adapters() -> list[dict]:
                             "name": desc.Description.strip(),
                             "vendor_id": int(desc.VendorId),
                             "memory_total_mb": int(desc.DedicatedVideoMemory // (1024 * 1024)),
+                            "shared_memory_total_mb": int(desc.SharedSystemMemory // (1024 * 1024)),
                             "luid_high": int(desc.AdapterLuid.HighPart),
                             "luid_low": int(desc.AdapterLuid.LowPart),
                             "software": bool(desc.Flags & 2),
@@ -1866,7 +1915,7 @@ def _windows_dxgi_adapters() -> list[dict]:
 
 
 def _windows_gpu_metrics() -> dict | None:
-    """Collect real Windows GPU utilization and dedicated-memory use."""
+    """Collect real per-adapter Windows GPU utilization and memory use."""
     global _windows_gpu_metrics_cache, _windows_dxgi_adapters_cache
     if platform.system() != "Windows":
         return None
@@ -1895,8 +1944,7 @@ def _windows_gpu_metrics() -> dict | None:
         script = rf"""
 $ErrorActionPreference = 'Stop'
 $prefixes = @({powershell_prefixes})
-$utilizations = @()
-$memoryBytes = [int64]0
+$metrics = @()
 foreach ($prefix in $prefixes) {{
   $engineTotals = @{{}}
   Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUEngine |
@@ -1911,14 +1959,20 @@ foreach ($prefix in $prefixes) {{
   if ($engineTotals.Count -gt 0) {{
     $adapterUtil = [Math]::Min(100, ($engineTotals.Values | Measure-Object -Maximum).Maximum)
   }}
-  $utilizations += $adapterUtil
-  $dedicated = (Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory |
-    Where-Object {{ $_.Name -like "$prefix*" }} |
-    Measure-Object -Property DedicatedUsage -Sum).Sum
-  if ($null -ne $dedicated) {{ $memoryBytes += [int64]$dedicated }}
+  $memoryRows = @(Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory |
+    Where-Object {{ $_.Name -like "$prefix*" }})
+  $dedicated = ($memoryRows | Measure-Object -Property DedicatedUsage -Sum).Sum
+  $shared = ($memoryRows | Measure-Object -Property SharedUsage -Sum).Sum
+  $metrics += [pscustomobject]@{{
+    prefix = $prefix
+    utilization_percent = [int][Math]::Round($adapterUtil)
+    utilization_available = ($engineTotals.Count -gt 0)
+    dedicated_used_bytes = [int64]$(if ($null -ne $dedicated) {{ $dedicated }} else {{ 0 }})
+    shared_used_bytes = [int64]$(if ($null -ne $shared) {{ $shared }} else {{ 0 }})
+    memory_usage_available = ($memoryRows.Count -gt 0)
+  }}
 }}
-$util = if ($utilizations.Count -gt 0) {{ ($utilizations | Measure-Object -Average).Average }} else {{ 0 }}
-[pscustomobject]@{{ utilization_percent = [int][Math]::Round($util); memory_used_bytes = $memoryBytes }} |
+[pscustomobject]@{{ adapters = @($metrics) }} |
   ConvertTo-Json -Compress
 """
         try:
@@ -1929,24 +1983,75 @@ $util = if ($utilizations.Count -gt 0) {{ ($utilizations | Measure-Object -Avera
             if result.returncode != 0:
                 raise RuntimeError((result.stderr or result.stdout).strip())
             counters = json.loads(result.stdout)
-            total_mb = sum(max(0, int(item["memory_total_mb"])) for item in adapters)
-            used_mb = max(0, int(counters.get("memory_used_bytes", 0)) // (1024 * 1024))
-            used_mb = min(used_mb, total_mb)
-            names = [str(item["name"]) for item in adapters]
+            counter_rows = counters.get("adapters")
+            if not isinstance(counter_rows, list):
+                raise ValueError("GPU counter response did not contain an adapter list")
+            rows_by_prefix = {
+                str(row.get("prefix") or "").casefold(): row
+                for row in counter_rows if isinstance(row, dict)
+            }
+            try:
+                system_ram_gb = max(0, int(float(
+                    env.get("SYSTEM_RAM_GB") or env.get("HOST_RAM_GB") or 0
+                )))
+            except (TypeError, ValueError):
+                system_ram_gb = 0
+
+            gpu_rows = []
+            for index, (adapter, prefix) in enumerate(zip(adapters, prefixes)):
+                row = rows_by_prefix.get(prefix.casefold(), {})
+                dedicated_total_mb = max(0, int(adapter.get("memory_total_mb") or 0))
+                unified = (
+                    _is_windows_amd_integrated_gpu_name(adapter.get("name", ""))
+                    and dedicated_total_mb <= 4096
+                    and system_ram_gb >= 32
+                )
+                memory_type = "unified" if unified else "discrete"
+                total_mb = (
+                    int(system_ram_gb * 0.75 * 1024)
+                    if unified else dedicated_total_mb
+                )
+                dedicated_used = max(0, int(row.get("dedicated_used_bytes") or 0))
+                shared_used = max(0, int(row.get("shared_used_bytes") or 0))
+                used_bytes = dedicated_used + shared_used if unified else dedicated_used
+                used_mb = min(total_mb, used_bytes // (1024 * 1024))
+                gpu_rows.append({
+                    "index": index,
+                    "uuid": f"luid-{adapter['luid_high'] & 0xffffffff:08x}-{adapter['luid_low'] & 0xffffffff:08x}",
+                    "name": str(adapter["name"]),
+                    "memory_type": memory_type,
+                    "memory_total_mb": total_mb,
+                    "memory_used_mb": used_mb,
+                    "memory_usage_available": bool(row.get("memory_usage_available", False)),
+                    "utilization_percent": max(0, min(100, int(row.get("utilization_percent") or 0))),
+                    "utilization_available": bool(row.get("utilization_available", False)),
+                    "temperature_c": None,
+                    "temperature_available": False,
+                })
+
+            total_mb = sum(item["memory_total_mb"] for item in gpu_rows)
+            used_mb = sum(item["memory_used_mb"] for item in gpu_rows)
+            available_util = [
+                item["utilization_percent"] for item in gpu_rows
+                if item["utilization_available"]
+            ]
+            names = [item["name"] for item in gpu_rows]
             display_name = f"{names[0]} \u00d7 {len(names)}" if len(set(names)) == 1 and len(names) > 1 else " + ".join(names)
             payload = {
                 "schema_version": "ods.host-gpu-metrics.v1",
                 "name": display_name,
-                "gpu_count": len(adapters),
+                "gpu_count": len(gpu_rows),
+                "memory_type": "unified" if all(item["memory_type"] == "unified" for item in gpu_rows) else "discrete",
                 "memory_total_mb": total_mb,
                 "memory_used_mb": used_mb,
-                "memory_usage_available": True,
-                "utilization_percent": max(0, min(100, int(counters.get("utilization_percent", 0)))),
-                "utilization_available": True,
+                "memory_usage_available": all(item["memory_usage_available"] for item in gpu_rows),
+                "utilization_percent": round(sum(available_util) / len(available_util)) if available_util else 0,
+                "utilization_available": bool(available_util),
                 "temperature_c": None,
                 "temperature_available": False,
                 "source": "windows-dxgi-performance-counters",
                 "sampled_at": _iso_now(),
+                "gpus": gpu_rows,
             }
         except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired,
                 ValueError, TypeError, RuntimeError):
@@ -1986,7 +2091,10 @@ def _windows_llm_status() -> dict | None:
                     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
                     request = urllib_request.Request(f"{base}{path}", headers=headers)
                     with urllib_request.urlopen(request, timeout=4) as response:
-                        payload = json.loads(response.read().decode("utf-8"))
+                        raw = response.read(MAX_TELEMETRY_RESPONSE_BYTES + 1)
+                    if len(raw) > MAX_TELEMETRY_RESPONSE_BYTES:
+                        raise ValueError(f"{path} exceeded the telemetry response limit")
+                    payload = json.loads(raw.decode("utf-8"))
                     if not isinstance(payload, dict):
                         raise ValueError(f"{path} returned non-object JSON")
                     return payload
@@ -2011,13 +2119,6 @@ def _windows_llm_status() -> dict | None:
                     "output_tokens", "prompt_tokens",
                 )
             }
-            stats["sample_fingerprint"] = hashlib.sha256(
-                json.dumps(
-                    raw_stats,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                ).encode("utf-8")
-            ).hexdigest()
         except (OSError, ValueError, json.JSONDecodeError, urllib_error.URLError):
             logger.debug("Windows host inference stats unavailable", exc_info=True)
         model_loaded = raw_health.get("model_loaded")

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -2020,9 +2020,17 @@ def _windows_llm_status() -> dict | None:
             ).hexdigest()
         except (OSError, ValueError, json.JSONDecodeError, urllib_error.URLError):
             logger.debug("Windows host inference stats unavailable", exc_info=True)
+        model_loaded = raw_health.get("model_loaded")
+        if isinstance(model_loaded, str):
+            # Runtime releases may expose an absolute checkpoint path here.
+            # The dashboard needs an identity, never the host directory layout.
+            model_loaded = re.split(r"[\\/]", model_loaded.strip())[-1] or None
+        elif model_loaded is not None:
+            model_loaded = None
         health = {
-            key: raw_health.get(key)
-            for key in ("status", "version", "model_loaded")
+            "status": raw_health.get("status"),
+            "version": raw_health.get("version"),
+            "model_loaded": model_loaded,
         }
         payload = {
             "schema_version": "ods.host-llm-status.v1",

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -94,6 +94,13 @@ STARTUP_ODS_MODE: str | None = None
 TIER: str = "1"
 GPU_COUNT: str = "1"
 CORE_SERVICE_IDS: set = set()
+_windows_gpu_metrics_cache: tuple[float, dict | None] = (0.0, None)
+_windows_dxgi_adapters_cache: tuple[float, list[dict]] = (0.0, [])
+_windows_llm_status_cache: tuple[float, dict | None] = (0.0, None)
+_service_health_cache: tuple[float, dict | None] = (0.0, None)
+_windows_gpu_metrics_lock = threading.Lock()
+_windows_llm_status_lock = threading.Lock()
+_service_health_lock = threading.Lock()
 WINDOWS_WHISPER_CUDA_MIN_DRIVER_MAJOR = 575
 # Always-on services defined in docker-compose.base.yml — never stoppable via API.
 # Distinct from CORE_SERVICE_IDS (which is the allowlist of known service IDs).
@@ -1753,6 +1760,334 @@ def _parse_mem_value(s: str) -> float:
     return 0.0
 
 
+def _normalize_gpu_name(value: str) -> str:
+    value = re.sub(r"\s*[x\u00d7]\s*\d+$", "", str(value or "").strip(), flags=re.IGNORECASE)
+    value = re.sub(r"^(amd|nvidia)\s+", "", value, flags=re.IGNORECASE)
+    return re.sub(r"[^a-z0-9]+", "", value.casefold())
+
+
+def _select_windows_gpu_adapters(adapters: list[dict], configured_name: str = "") -> list[dict]:
+    """Select the configured hardware GPU without accidentally choosing an iGPU."""
+    hardware = [item for item in adapters if not item.get("software")]
+    backend = str(GPU_BACKEND or "").casefold()
+    vendor_id = 0x1002 if backend == "amd" else 0x10DE if backend == "nvidia" else None
+    vendor_matches = [item for item in hardware if item.get("vendor_id") == vendor_id]
+    candidates = vendor_matches or hardware
+    if not candidates:
+        return []
+
+    wanted = _normalize_gpu_name(configured_name)
+    if wanted:
+        named = [item for item in candidates if _normalize_gpu_name(item.get("name", "")) == wanted]
+        if named:
+            try:
+                expected_count = max(1, int(GPU_COUNT or "1"))
+            except ValueError:
+                expected_count = 1
+            return sorted(named, key=lambda item: item.get("memory_total_mb", 0), reverse=True)[:expected_count]
+
+    return [max(candidates, key=lambda item: item.get("memory_total_mb", 0))]
+
+
+def _windows_dxgi_adapters() -> list[dict]:
+    """Enumerate Windows hardware adapters with stable DXGI LUIDs."""
+    if platform.system() != "Windows":
+        return []
+    try:
+        import ctypes
+        import uuid
+        from ctypes import wintypes
+
+        class GUID(ctypes.Structure):
+            _fields_ = [
+                ("Data1", wintypes.DWORD), ("Data2", wintypes.WORD),
+                ("Data3", wintypes.WORD), ("Data4", ctypes.c_ubyte * 8),
+            ]
+
+        class LUID(ctypes.Structure):
+            _fields_ = [("LowPart", wintypes.DWORD), ("HighPart", wintypes.LONG)]
+
+        class DXGIAdapterDesc1(ctypes.Structure):
+            _fields_ = [
+                ("Description", wintypes.WCHAR * 128),
+                ("VendorId", wintypes.UINT), ("DeviceId", wintypes.UINT),
+                ("SubSysId", wintypes.UINT), ("Revision", wintypes.UINT),
+                ("DedicatedVideoMemory", ctypes.c_size_t),
+                ("DedicatedSystemMemory", ctypes.c_size_t),
+                ("SharedSystemMemory", ctypes.c_size_t),
+                ("AdapterLuid", LUID), ("Flags", wintypes.UINT),
+            ]
+
+        def make_guid(value: str) -> GUID:
+            return GUID.from_buffer_copy(uuid.UUID(value).bytes_le)
+
+        def com_method(obj, index, restype, *argtypes):
+            vtable = ctypes.cast(obj, ctypes.POINTER(ctypes.POINTER(ctypes.c_void_p))).contents
+            return ctypes.WINFUNCTYPE(restype, ctypes.c_void_p, *argtypes)(vtable[index])
+
+        factory = ctypes.c_void_p()
+        iid = make_guid("770AAE78-F26F-4DBA-A829-253C83D1B387")
+        create_factory = ctypes.windll.dxgi.CreateDXGIFactory1
+        create_factory.argtypes = [ctypes.POINTER(GUID), ctypes.POINTER(ctypes.c_void_p)]
+        if create_factory(ctypes.byref(iid), ctypes.byref(factory)) < 0:
+            return []
+
+        adapters: list[dict] = []
+        try:
+            for index in range(32):
+                adapter = ctypes.c_void_p()
+                result = com_method(
+                    factory, 12, ctypes.c_long, wintypes.UINT,
+                    ctypes.POINTER(ctypes.c_void_p),
+                )(factory, index, ctypes.byref(adapter))
+                if result < 0:
+                    break
+                try:
+                    desc = DXGIAdapterDesc1()
+                    if com_method(
+                        adapter, 10, ctypes.c_long, ctypes.POINTER(DXGIAdapterDesc1)
+                    )(adapter, ctypes.byref(desc)) >= 0:
+                        adapters.append({
+                            "name": desc.Description.strip(),
+                            "vendor_id": int(desc.VendorId),
+                            "memory_total_mb": int(desc.DedicatedVideoMemory // (1024 * 1024)),
+                            "luid_high": int(desc.AdapterLuid.HighPart),
+                            "luid_low": int(desc.AdapterLuid.LowPart),
+                            "software": bool(desc.Flags & 2),
+                        })
+                finally:
+                    com_method(adapter, 2, wintypes.ULONG)(adapter)
+        finally:
+            com_method(factory, 2, wintypes.ULONG)(factory)
+        return adapters
+    except (AttributeError, OSError, TypeError, ValueError):
+        logger.debug("DXGI GPU enumeration failed", exc_info=True)
+        return []
+
+
+def _windows_gpu_metrics() -> dict | None:
+    """Collect real Windows GPU utilization and dedicated-memory use."""
+    global _windows_gpu_metrics_cache, _windows_dxgi_adapters_cache
+    if platform.system() != "Windows":
+        return None
+    with _windows_gpu_metrics_lock:
+        cached_at, cached = _windows_gpu_metrics_cache
+        if time.monotonic() - cached_at < 4.0:
+            return cached
+
+        env = load_env(INSTALL_DIR / ".env")
+        adapters_cached_at, all_adapters = _windows_dxgi_adapters_cache
+        if not all_adapters or time.monotonic() - adapters_cached_at >= 300.0:
+            all_adapters = _windows_dxgi_adapters()
+            _windows_dxgi_adapters_cache = (time.monotonic(), all_adapters)
+        adapters = _select_windows_gpu_adapters(
+            all_adapters, env.get("HOST_GPU_NAME", ""),
+        )
+        if not adapters:
+            _windows_gpu_metrics_cache = (time.monotonic(), None)
+            return None
+
+        prefixes = [
+            f"luid_0x{item['luid_high'] & 0xffffffff:08x}_0x{item['luid_low'] & 0xffffffff:08x}"
+            for item in adapters
+        ]
+        powershell_prefixes = ",".join(f"'{prefix}'" for prefix in prefixes)
+        script = rf"""
+$ErrorActionPreference = 'Stop'
+$prefixes = @({powershell_prefixes})
+$utilizations = @()
+$memoryBytes = [int64]0
+foreach ($prefix in $prefixes) {{
+  $engineTotals = @{{}}
+  Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUEngine |
+    Where-Object {{ $_.Name -like "*$prefix*" }} |
+    ForEach-Object {{
+      if ($_.Name -match '_eng_([0-9]+)_engtype_(.+)$') {{
+        $key = "$($Matches[1])|$($Matches[2])"
+        $engineTotals[$key] = [double]($engineTotals[$key] + $_.UtilizationPercentage)
+      }}
+    }}
+  $adapterUtil = 0
+  if ($engineTotals.Count -gt 0) {{
+    $adapterUtil = [Math]::Min(100, ($engineTotals.Values | Measure-Object -Maximum).Maximum)
+  }}
+  $utilizations += $adapterUtil
+  $dedicated = (Get-CimInstance Win32_PerfFormattedData_GPUPerformanceCounters_GPUAdapterMemory |
+    Where-Object {{ $_.Name -like "$prefix*" }} |
+    Measure-Object -Property DedicatedUsage -Sum).Sum
+  if ($null -ne $dedicated) {{ $memoryBytes += [int64]$dedicated }}
+}}
+$util = if ($utilizations.Count -gt 0) {{ ($utilizations | Measure-Object -Average).Average }} else {{ 0 }}
+[pscustomobject]@{{ utilization_percent = [int][Math]::Round($util); memory_used_bytes = $memoryBytes }} |
+  ConvertTo-Json -Compress
+"""
+        try:
+            result = subprocess.run(
+                ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
+                capture_output=True, text=True, timeout=8,
+            )
+            if result.returncode != 0:
+                raise RuntimeError((result.stderr or result.stdout).strip())
+            counters = json.loads(result.stdout)
+            total_mb = sum(max(0, int(item["memory_total_mb"])) for item in adapters)
+            used_mb = max(0, int(counters.get("memory_used_bytes", 0)) // (1024 * 1024))
+            used_mb = min(used_mb, total_mb)
+            names = [str(item["name"]) for item in adapters]
+            display_name = f"{names[0]} \u00d7 {len(names)}" if len(set(names)) == 1 and len(names) > 1 else " + ".join(names)
+            payload = {
+                "schema_version": "ods.host-gpu-metrics.v1",
+                "name": display_name,
+                "gpu_count": len(adapters),
+                "memory_total_mb": total_mb,
+                "memory_used_mb": used_mb,
+                "memory_usage_available": True,
+                "utilization_percent": max(0, min(100, int(counters.get("utilization_percent", 0)))),
+                "utilization_available": True,
+                "temperature_c": None,
+                "temperature_available": False,
+                "source": "windows-dxgi-performance-counters",
+                "sampled_at": _iso_now(),
+            }
+        except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired,
+                ValueError, TypeError, RuntimeError):
+            logger.debug("Windows GPU performance counters unavailable", exc_info=True)
+            payload = None
+        _windows_gpu_metrics_cache = (time.monotonic(), payload)
+        return payload
+
+
+def _windows_llm_status() -> dict | None:
+    """Read host-native Lemonade health and optional stats over loopback."""
+    global _windows_llm_status_cache
+    if platform.system() != "Windows":
+        return None
+    with _windows_llm_status_lock:
+        cached_at, cached = _windows_llm_status_cache
+        if time.monotonic() - cached_at < 1.0:
+            return cached
+
+        env = load_env(INSTALL_DIR / ".env")
+        try:
+            port = int(env.get("AMD_INFERENCE_PORT") or "8080")
+        except ValueError:
+            port = 8080
+        if port < 1 or port > 65535:
+            port = 8080
+        base = f"http://127.0.0.1:{port}"
+        api_key = str(env.get("LEMONADE_API_KEY") or "").strip()
+
+        def fetch_json(name: str) -> dict:
+            last_error: Exception | None = None
+            # ODS currently ships the /api/v1 compatibility route; newer
+            # Lemonade releases document /v1. Accept both during upgrades.
+            for prefix in ("/api/v1", "/v1"):
+                path = f"{prefix}/{name}"
+                try:
+                    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+                    request = urllib_request.Request(f"{base}{path}", headers=headers)
+                    with urllib_request.urlopen(request, timeout=4) as response:
+                        payload = json.loads(response.read().decode("utf-8"))
+                    if not isinstance(payload, dict):
+                        raise ValueError(f"{path} returned non-object JSON")
+                    return payload
+                except (OSError, ValueError, json.JSONDecodeError, urllib_error.URLError) as exc:
+                    last_error = exc
+            raise OSError(f"Lemonade {name} endpoint is unavailable: {last_error}")
+
+        try:
+            raw_health = fetch_json("health")
+        except (OSError, ValueError, json.JSONDecodeError, urllib_error.URLError):
+            logger.debug("Windows host inference health unavailable", exc_info=True)
+            _windows_llm_status_cache = (time.monotonic(), None)
+            return None
+
+        stats = None
+        try:
+            raw_stats = fetch_json("stats")
+            stats = {
+                key: raw_stats.get(key)
+                for key in (
+                    "time_to_first_token", "tokens_per_second", "input_tokens",
+                    "output_tokens", "prompt_tokens",
+                )
+            }
+            stats["sample_fingerprint"] = hashlib.sha256(
+                json.dumps(
+                    {"health": raw_health, "stats": raw_stats},
+                    sort_keys=True,
+                    separators=(",", ":"),
+                ).encode("utf-8")
+            ).hexdigest()
+        except (OSError, ValueError, json.JSONDecodeError, urllib_error.URLError):
+            logger.debug("Windows host inference stats unavailable", exc_info=True)
+        health = {
+            key: raw_health.get(key)
+            for key in ("status", "version", "model_loaded")
+        }
+        payload = {
+            "schema_version": "ods.host-llm-status.v1",
+            "health": health,
+            "stats": stats,
+            "source": "windows-loopback",
+            "sampled_at": _iso_now(),
+        }
+        _windows_llm_status_cache = (time.monotonic(), payload)
+        return payload
+
+
+def _docker_service_health_snapshot() -> dict:
+    """Return a cached, read-only Docker lifecycle and healthcheck snapshot."""
+    global _service_health_cache
+    with _service_health_lock:
+        cached_at, cached = _service_health_cache
+        if cached is not None and time.monotonic() - cached_at < 3.0:
+            return cached
+
+        names_result = subprocess.run(
+            ["docker", "ps", "-a", "--format", "{{.Names}}"],
+            capture_output=True, text=True, timeout=8,
+        )
+        if names_result.returncode != 0:
+            raise RuntimeError((names_result.stderr or names_result.stdout).strip())
+        names = [
+            name.strip() for name in names_result.stdout.splitlines()
+            if name.strip().startswith("ods-")
+        ]
+        containers: list[dict] = []
+        if names:
+            inspect_result = subprocess.run(
+                ["docker", "inspect", *names], capture_output=True, text=True, timeout=12,
+            )
+            if inspect_result.returncode != 0:
+                raise RuntimeError((inspect_result.stderr or inspect_result.stdout).strip())
+            inspected = json.loads(inspect_result.stdout)
+            if not isinstance(inspected, list):
+                raise ValueError("docker inspect returned non-list JSON")
+            for item in inspected:
+                if not isinstance(item, dict):
+                    continue
+                state = item.get("State") if isinstance(item.get("State"), dict) else {}
+                health = state.get("Health") if isinstance(state.get("Health"), dict) else {}
+                labels = (item.get("Config") or {}).get("Labels") or {}
+                service_id = labels.get("com.docker.compose.service")
+                container_name = str(item.get("Name") or "").lstrip("/")
+                if not service_id and container_name.startswith("ods-"):
+                    service_id = container_name.removeprefix("ods-")
+                containers.append({
+                    "service_id": str(service_id or ""),
+                    "container_name": container_name,
+                    "state": str(state.get("Status") or "unknown"),
+                    "health": str(health.get("Status") or "none"),
+                })
+        payload = {
+            "schema_version": "ods.host-service-health.v1",
+            "containers": containers,
+            "sampled_at": _iso_now(),
+        }
+        _service_health_cache = (time.monotonic(), payload)
+        return payload
+
+
 def _iso_now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
@@ -2547,6 +2882,12 @@ class AgentHandler(BaseHTTPRequestHandler):
         path = parsed.path
         if path == "/health":
             json_response(self, 200, {"status": "ok", "version": VERSION})
+        elif path == "/v1/gpu/metrics":
+            self._handle_gpu_metrics()
+        elif path == "/v1/llm/status":
+            self._handle_llm_status()
+        elif path == "/v1/service/health":
+            self._handle_service_health()
         elif path == "/v1/service/stats":
             self._handle_service_stats()
         elif path == "/v1/model/list":
@@ -2847,6 +3188,36 @@ class AgentHandler(BaseHTTPRequestHandler):
             json_response(self, 503, {"error": "docker stats timed out"})
         except Exception as exc:
             json_response(self, 500, {"error": f"Failed to fetch stats: {exc}"})
+
+    def _handle_service_health(self):
+        """Return Docker's lifecycle and container-health snapshot."""
+        if not check_auth(self):
+            return
+        try:
+            json_response(self, 200, _docker_service_health_snapshot())
+        except (OSError, subprocess.SubprocessError, subprocess.TimeoutExpired,
+                ValueError, TypeError, RuntimeError) as exc:
+            json_response(self, 503, {"error": f"Docker health snapshot failed: {exc}"})
+
+    def _handle_llm_status(self):
+        """Bridge Windows host-native inference without Docker DNS/NAT."""
+        if not check_auth(self):
+            return
+        status = _windows_llm_status()
+        if status is None:
+            json_response(self, 503, {"error": "Host inference telemetry is unavailable"})
+            return
+        json_response(self, 200, status)
+
+    def _handle_gpu_metrics(self):
+        """Return host GPU counters that Docker Desktop cannot expose."""
+        if not check_auth(self):
+            return
+        metrics = _windows_gpu_metrics()
+        if metrics is None:
+            json_response(self, 503, {"error": "Host GPU telemetry is unavailable"})
+            return
+        json_response(self, 200, metrics)
 
     def do_POST(self):
         # Several legacy endpoints intentionally ignore an optional body, and

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -2013,7 +2013,7 @@ def _windows_llm_status() -> dict | None:
             }
             stats["sample_fingerprint"] = hashlib.sha256(
                 json.dumps(
-                    {"health": raw_health, "stats": raw_stats},
+                    raw_stats,
                     sort_keys=True,
                     separators=(",", ":"),
                 ).encode("utf-8")

--- a/ods/docs/HOST-AGENT-API.md
+++ b/ods/docs/HOST-AGENT-API.md
@@ -74,6 +74,7 @@ represented by `null` and an explicit `*_available: false` flag.
   "schema_version": "ods.host-gpu-metrics.v1",
   "name": "AMD Radeon RX 9070 XT",
   "gpu_count": 1,
+  "memory_type": "discrete",
   "memory_total_mb": 16188,
   "memory_used_mb": 4449,
   "memory_usage_available": true,
@@ -82,9 +83,30 @@ represented by `null` and an explicit `*_available: false` flag.
   "temperature_c": null,
   "temperature_available": false,
   "source": "windows-dxgi-performance-counters",
-  "sampled_at": "2026-07-20T22:00:00+00:00"
+  "sampled_at": "2026-07-20T22:00:00+00:00",
+  "gpus": [
+    {
+      "index": 0,
+      "uuid": "luid-00000000-0000abcd",
+      "name": "AMD Radeon RX 9070 XT",
+      "memory_type": "discrete",
+      "memory_total_mb": 16188,
+      "memory_used_mb": 4449,
+      "memory_usage_available": true,
+      "utilization_percent": 12,
+      "utilization_available": true,
+      "temperature_c": null,
+      "temperature_available": false
+    }
+  ]
 }
 ```
+
+The top-level fields are a backward-compatible aggregate. `gpus` preserves
+per-adapter identity on multi-GPU hosts. Hybrid AMD systems exclude an
+integrated display adapter when discrete Radeon adapters are present. Unified
+memory APUs report `memory_type: "unified"` and include observed shared-memory
+use; unavailable counters remain explicit rather than being presented as zero.
 
 Returns 503 when the platform collector or required counters are unavailable.
 
@@ -111,16 +133,17 @@ local checkpoint paths are not returned.
     "tokens_per_second": 42.5,
     "input_tokens": 32,
     "output_tokens": 64,
-    "prompt_tokens": 32,
-    "sample_fingerprint": "<sha256>"
+    "prompt_tokens": 32
   },
   "source": "windows-loopback",
   "sampled_at": "2026-07-20T22:00:00+00:00"
 }
 ```
 
-The statistics object is `null` when health is available but optional request
-statistics are not. Returns 503 when host inference health is unavailable.
+The statistics object describes Lemonade's most recently completed request; it
+is not a cumulative counter. It is `null` when health is available but optional
+request statistics are not. Runtime responses are bounded to 1 MiB. Returns 503
+when host inference health is unavailable.
 
 ### `GET /v1/service/health`
 

--- a/ods/docs/HOST-AGENT-API.md
+++ b/ods/docs/HOST-AGENT-API.md
@@ -26,6 +26,8 @@ The agent reads its configuration from the `.env` file in the ODS install direct
 | `ODS_AGENT_BIND` | Platform-specific | Bind address. macOS/Windows default to `127.0.0.1`; Linux uses the `ods-network` gateway when detected, then the Docker bridge gateway, otherwise `127.0.0.1`. |
 | `ODS_AGENT_PORT` | `7710` | Port the agent listens on. |
 | `GPU_BACKEND` | `nvidia` | Passed to `resolve-compose-stack.sh` when building compose flags. |
+| `AMD_INFERENCE_PORT` | `8080` | Validated loopback port used for Windows host-native Lemonade telemetry. |
+| `LEMONADE_API_KEY` | *(none)* | Optional bearer token sent only to the configured loopback Lemonade endpoint. |
 | `TIER` | `1` | Hardware tier, passed to compose stack resolution. |
 | `ODS_DATA_DIR` | `~/.ods` | Data directory root. |
 | `ODS_USER_EXTENSIONS_DIR` | `$ODS_DATA_DIR/user-extensions` | Where user-installed extensions live. |
@@ -34,7 +36,8 @@ The agent also loads `config/core-service-ids.json` to determine which services 
 
 ## Authentication
 
-All mutation endpoints (`/v1/extension/*`) require a Bearer token:
+All `/v1/*` endpoints require a Bearer token. The unversioned `/health`
+endpoint is the only unauthenticated route:
 
 ```
 Authorization: Bearer <ODS_AGENT_KEY>
@@ -55,6 +58,94 @@ Health check. No authentication required.
   "version": "1.0.0"
 }
 ```
+
+### `GET /v1/gpu/metrics`
+
+Return host GPU identity and metrics that are unavailable inside Docker
+Desktop. The current collector is active on Windows and uses DXGI adapter
+identity plus Windows GPU performance counters. Unsupported sensors are
+represented by `null` and an explicit `*_available: false` flag.
+
+**Authentication:** Required
+
+**Response (200):**
+```json
+{
+  "schema_version": "ods.host-gpu-metrics.v1",
+  "name": "AMD Radeon RX 9070 XT",
+  "gpu_count": 1,
+  "memory_total_mb": 16188,
+  "memory_used_mb": 4449,
+  "memory_usage_available": true,
+  "utilization_percent": 12,
+  "utilization_available": true,
+  "temperature_c": null,
+  "temperature_available": false,
+  "source": "windows-dxgi-performance-counters",
+  "sampled_at": "2026-07-20T22:00:00+00:00"
+}
+```
+
+Returns 503 when the platform collector or required counters are unavailable.
+
+### `GET /v1/llm/status`
+
+Bridge health and last-request statistics from host-native Lemonade over the
+validated loopback port. ODS accepts the compatibility `/api/v1` routes and
+the current `/v1` routes during runtime upgrades. Raw runtime payloads and
+local checkpoint paths are not returned.
+
+**Authentication:** Required
+
+**Response (200):**
+```json
+{
+  "schema_version": "ods.host-llm-status.v1",
+  "health": {
+    "status": "ok",
+    "version": "10.0.0",
+    "model_loaded": "extra.Model.gguf"
+  },
+  "stats": {
+    "time_to_first_token": 0.2,
+    "tokens_per_second": 42.5,
+    "input_tokens": 32,
+    "output_tokens": 64,
+    "prompt_tokens": 32,
+    "sample_fingerprint": "<sha256>"
+  },
+  "source": "windows-loopback",
+  "sampled_at": "2026-07-20T22:00:00+00:00"
+}
+```
+
+The statistics object is `null` when health is available but optional request
+statistics are not. Returns 503 when host inference health is unavailable.
+
+### `GET /v1/service/health`
+
+Return a read-only Docker lifecycle and declared healthcheck snapshot for ODS
+containers. Compose service labels are preferred over container-name parsing.
+
+**Authentication:** Required
+
+**Response (200):**
+```json
+{
+  "schema_version": "ods.host-service-health.v1",
+  "containers": [
+    {
+      "service_id": "dashboard",
+      "container_name": "ods-dashboard",
+      "state": "running",
+      "health": "healthy"
+    }
+  ],
+  "sampled_at": "2026-07-20T22:00:00+00:00"
+}
+```
+
+Returns 503 when Docker cannot provide a complete snapshot.
 
 ### `GET /v1/update/status`
 

--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -254,6 +254,7 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
             power_w=total_power,
             memory_type=memory_type,
             gpu_backend="nvidia",
+            gpu_count=len(gpus),
             utilization_available=all(g["utilization_available"] for g in gpus),
             temperature_available=any(g["temperature_available"] for g in gpus),
         )
@@ -365,8 +366,8 @@ def get_gpu_info_apple() -> Optional[GPUInfo]:
     return None
 
 
-def get_gpu_info_windows_host() -> Optional[GPUInfo]:
-    """Read Windows AMD counters through the authenticated host agent."""
+def _get_windows_host_gpu_payload() -> Optional[dict]:
+    """Read and minimally validate the versioned Windows host GPU payload."""
     if os.environ.get("GPU_BACKEND", "").lower() != "amd":
         return None
     location = _read_env_var_from_file("AMD_INFERENCE_LOCATION") or os.environ.get(
@@ -378,10 +379,22 @@ def get_gpu_info_windows_host() -> Optional[GPUInfo]:
         payload = request_agent_json("GET", "/v1/gpu/metrics", timeout=10)
         if payload.get("schema_version") != "ods.host-gpu-metrics.v1":
             return None
+        return payload
+    except (AgentClientError, OSError, TypeError, ValueError):
+        return None
+
+
+def get_gpu_info_windows_host() -> Optional[GPUInfo]:
+    """Read aggregate Windows AMD counters through the host agent."""
+    payload = _get_windows_host_gpu_payload()
+    if payload is None:
+        return None
+    try:
         total_mb = max(0, int(payload.get("memory_total_mb") or 0))
         used_mb = min(total_mb, max(0, int(payload.get("memory_used_mb") or 0)))
         utilization = max(0, min(100, int(payload.get("utilization_percent") or 0)))
-    except (AgentClientError, OSError, TypeError, ValueError):
+        gpu_count = max(1, min(32, int(payload.get("gpu_count") or 1)))
+    except (TypeError, ValueError):
         return None
     if not payload.get("name") or total_mb <= 0:
         return None
@@ -393,12 +406,53 @@ def get_gpu_info_windows_host() -> Optional[GPUInfo]:
         utilization_percent=utilization,
         temperature_c=int(payload.get("temperature_c") or 0),
         power_w=None,
-        memory_type="discrete",
+        memory_type=(
+            "unified" if payload.get("memory_type") == "unified" else "discrete"
+        ),
         gpu_backend="amd",
+        gpu_count=gpu_count,
         memory_usage_available=bool(payload.get("memory_usage_available", False)),
         utilization_available=bool(payload.get("utilization_available", False)),
         temperature_available=bool(payload.get("temperature_available", False)),
     )
+
+
+def get_gpu_info_windows_host_detailed() -> Optional[list[IndividualGPU]]:
+    """Read per-adapter Windows AMD counters when the host supports them."""
+    payload = _get_windows_host_gpu_payload()
+    if payload is None or not isinstance(payload.get("gpus"), list):
+        return None
+    result: list[IndividualGPU] = []
+    try:
+        for position, item in enumerate(payload["gpus"][:32]):
+            if not isinstance(item, dict):
+                continue
+            total_mb = max(0, int(item.get("memory_total_mb") or 0))
+            if not item.get("name") or total_mb <= 0:
+                continue
+            used_mb = min(total_mb, max(0, int(item.get("memory_used_mb") or 0)))
+            utilization = max(0, min(100, int(item.get("utilization_percent") or 0)))
+            result.append(IndividualGPU(
+                index=max(0, min(31, int(item.get("index", position)))),
+                uuid=str(item.get("uuid") or f"amd-windows-host-{position}"),
+                name=str(item["name"]),
+                memory_used_mb=used_mb,
+                memory_total_mb=total_mb,
+                memory_percent=round(used_mb / total_mb * 100, 1),
+                utilization_percent=utilization,
+                temperature_c=int(item.get("temperature_c") or 0),
+                power_w=None,
+                memory_type=(
+                    "unified" if item.get("memory_type") == "unified" else "discrete"
+                ),
+                assigned_services=["llama-server"],
+                memory_usage_available=bool(item.get("memory_usage_available", False)),
+                utilization_available=bool(item.get("utilization_available", False)),
+                temperature_available=bool(item.get("temperature_available", False)),
+            ))
+    except (TypeError, ValueError):
+        return None
+    return result or None
 
 
 def get_gpu_info() -> Optional[GPUInfo]:
@@ -406,6 +460,17 @@ def get_gpu_info() -> Optional[GPUInfo]:
     gpu_backend = os.environ.get("GPU_BACKEND", "").lower()
 
     if gpu_backend == "amd":
+        try:
+            expected_count = int(os.environ.get("GPU_COUNT", "1"))
+        except ValueError:
+            expected_count = 1
+        if expected_count > 1:
+            detailed = get_gpu_info_amd_detailed()
+            if detailed:
+                return aggregate_gpu_details(detailed, "amd")
+        detailed = get_gpu_info_windows_host_detailed()
+        if detailed:
+            return aggregate_gpu_details(detailed, "amd")
         info = get_gpu_info_amd()
         if info:
             return info
@@ -705,6 +770,7 @@ def get_gpu_info_amd_detailed() -> Optional[list[IndividualGPU]]:
                 utilization_percent=gpu_busy,
                 temperature_c=temp,
                 power_w=power_w,
+                memory_type="unified" if is_unified else "discrete",
                 assigned_services=uuid_service_map.get(gpu_uuid, []),
                 utilization_available=bool(gpu_busy_str),
                 temperature_available=temp > 0,
@@ -713,6 +779,51 @@ def get_gpu_info_amd_detailed() -> Optional[list[IndividualGPU]]:
             continue
 
     return gpus or None
+
+
+def aggregate_gpu_details(gpus: list[IndividualGPU], backend: str) -> GPUInfo:
+    """Build one truthful aggregate shared by status and detailed GPU routes."""
+    if not gpus:
+        raise ValueError("at least one GPU is required")
+
+    mem_used = sum(gpu.memory_used_mb for gpu in gpus)
+    mem_total = sum(gpu.memory_total_mb for gpu in gpus)
+    available_utilization = [
+        gpu.utilization_percent for gpu in gpus if gpu.utilization_available
+    ]
+    available_temperatures = [
+        gpu.temperature_c for gpu in gpus if gpu.temperature_available
+    ]
+    available_power = [gpu.power_w for gpu in gpus if gpu.power_w is not None]
+    names = [gpu.name for gpu in gpus]
+    if len(set(names)) == 1:
+        display_name = names[0] if len(names) == 1 else f"{names[0]} \u00d7 {len(names)}"
+    else:
+        display_name = " + ".join(names[:2])
+        if len(names) > 2:
+            display_name += f" + {len(names) - 2} more"
+
+    return GPUInfo(
+        name=display_name,
+        memory_used_mb=mem_used,
+        memory_total_mb=mem_total,
+        memory_percent=round(mem_used / mem_total * 100, 1) if mem_total > 0 else 0.0,
+        utilization_percent=(
+            round(sum(available_utilization) / len(available_utilization))
+            if available_utilization else 0
+        ),
+        temperature_c=max(available_temperatures) if available_temperatures else 0,
+        power_w=round(sum(available_power), 1) if available_power else None,
+        memory_type=(
+            "unified" if all(gpu.memory_type == "unified" for gpu in gpus)
+            else "discrete"
+        ),
+        gpu_backend=backend,
+        gpu_count=len(gpus),
+        memory_usage_available=all(gpu.memory_usage_available for gpu in gpus),
+        utilization_available=bool(available_utilization),
+        temperature_available=bool(available_temperatures),
+    )
 
 
 def get_gpu_tier(vram_gb: float, memory_type: str = "discrete") -> str:

--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -137,6 +137,8 @@ def get_gpu_info_amd() -> Optional[GPUInfo]:
             power_w=power_w,
             memory_type=memory_type,
             gpu_backend="amd",
+            utilization_available=bool(gpu_busy_str),
+            temperature_available=temp > 0,
         )
     except (ValueError, TypeError):
         return None
@@ -196,6 +198,8 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
                 "mem_total": mem_total,
                 "util": util,
                 "temp": temp,
+                "utilization_available": parts[3] not in na_values,
+                "temperature_available": parts[4] not in na_values,
                 "power_w": power_w,
             })
 
@@ -217,6 +221,8 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
                 power_w=g["power_w"],
                 memory_type=memory_type,
                 gpu_backend="nvidia",
+                utilization_available=g["utilization_available"],
+                temperature_available=g["temperature_available"],
             )
 
         # Multi-GPU: aggregate across all GPUs
@@ -248,6 +254,8 @@ def get_gpu_info_nvidia() -> Optional[GPUInfo]:
             power_w=total_power,
             memory_type=memory_type,
             gpu_backend="nvidia",
+            utilization_available=all(g["utilization_available"] for g in gpus),
+            temperature_available=any(g["temperature_available"] for g in gpus),
         )
     except (ValueError, IndexError):
         pass
@@ -302,6 +310,9 @@ def get_gpu_info_apple() -> Optional[GPUInfo]:
                 power_w=None,
                 memory_type="unified",
                 gpu_backend="apple",
+                memory_usage_available=False,
+                utilization_available=False,
+                temperature_available=False,
             )
         except (ValueError, TypeError) as e:
             logger.debug("Apple Silicon GPU detection failed: %s", e)
@@ -346,6 +357,9 @@ def get_gpu_info_apple() -> Optional[GPUInfo]:
             power_w=None,
             memory_type="unified",
             gpu_backend="apple",
+            memory_usage_available=False,
+            utilization_available=False,
+            temperature_available=False,
         )
 
     return None
@@ -581,6 +595,8 @@ def get_gpu_info_nvidia_detailed() -> Optional[list[IndividualGPU]]:
                 temperature_c=int(parts[6]) if parts[6] not in na_values else 0,
                 power_w=power_w,
                 assigned_services=uuid_service_map.get(uuid, []),
+                utilization_available=parts[5] not in na_values,
+                temperature_available=parts[6] not in na_values,
             ))
         except (ValueError, IndexError):
             logger.warning("Skipping unparseable nvidia-smi row: %s", line)
@@ -690,6 +706,8 @@ def get_gpu_info_amd_detailed() -> Optional[list[IndividualGPU]]:
                 temperature_c=temp,
                 power_w=power_w,
                 assigned_services=uuid_service_map.get(gpu_uuid, []),
+                utilization_available=bool(gpu_busy_str),
+                temperature_available=temp > 0,
             ))
         except (ValueError, TypeError):
             continue

--- a/ods/extensions/services/dashboard-api/gpu.py
+++ b/ods/extensions/services/dashboard-api/gpu.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Optional
 
 from models import GPUInfo, IndividualGPU
+from host_agent_client import AgentClientError, request_json as request_agent_json
 
 logger = logging.getLogger(__name__)
 
@@ -350,12 +351,51 @@ def get_gpu_info_apple() -> Optional[GPUInfo]:
     return None
 
 
+def get_gpu_info_windows_host() -> Optional[GPUInfo]:
+    """Read Windows AMD counters through the authenticated host agent."""
+    if os.environ.get("GPU_BACKEND", "").lower() != "amd":
+        return None
+    location = _read_env_var_from_file("AMD_INFERENCE_LOCATION") or os.environ.get(
+        "AMD_INFERENCE_LOCATION", "",
+    )
+    if location.lower() != "host":
+        return None
+    try:
+        payload = request_agent_json("GET", "/v1/gpu/metrics", timeout=10)
+        if payload.get("schema_version") != "ods.host-gpu-metrics.v1":
+            return None
+        total_mb = max(0, int(payload.get("memory_total_mb") or 0))
+        used_mb = min(total_mb, max(0, int(payload.get("memory_used_mb") or 0)))
+        utilization = max(0, min(100, int(payload.get("utilization_percent") or 0)))
+    except (AgentClientError, OSError, TypeError, ValueError):
+        return None
+    if not payload.get("name") or total_mb <= 0:
+        return None
+    return GPUInfo(
+        name=str(payload["name"]),
+        memory_used_mb=used_mb,
+        memory_total_mb=total_mb,
+        memory_percent=round(used_mb / total_mb * 100, 1),
+        utilization_percent=utilization,
+        temperature_c=int(payload.get("temperature_c") or 0),
+        power_w=None,
+        memory_type="discrete",
+        gpu_backend="amd",
+        memory_usage_available=bool(payload.get("memory_usage_available", False)),
+        utilization_available=bool(payload.get("utilization_available", False)),
+        temperature_available=bool(payload.get("temperature_available", False)),
+    )
+
+
 def get_gpu_info() -> Optional[GPUInfo]:
     """Get GPU metrics. Tries the configured backend first, then auto-detects."""
     gpu_backend = os.environ.get("GPU_BACKEND", "").lower()
 
     if gpu_backend == "amd":
         info = get_gpu_info_amd()
+        if info:
+            return info
+        info = get_gpu_info_windows_host()
         if info:
             return info
 

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -690,7 +690,7 @@ async def get_all_services() -> list[ServiceStatus]:
             try:
                 host_status = await request_agent_json("GET", "/v1/llm/status", timeout=6)
                 health = host_status.get("health")
-                if isinstance(health, dict) and (health.get("status") == "ok" or health.get("model_loaded")):
+                if isinstance(health, dict) and str(health.get("status") or "").casefold() == "ok":
                     reconciled[llama_index] = reconciled[llama_index].model_copy(
                         update={"status": "healthy"},
                     )

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1,7 +1,6 @@
 """Shared helper functions for service health checking, metrics, and system info."""
 
 import asyncio
-import hashlib
 import json
 import logging
 import math
@@ -194,55 +193,37 @@ _token_counter_lock = threading.Lock()
 def _update_lifetime_tokens(server_counter: float) -> int:
     """Accumulate tokens across server restarts using a persistent file."""
     with _token_counter_lock:
-        data = {"lifetime": 0, "last_server_counter": 0}
-        try:
-            if _TOKEN_FILE.exists():
-                data = json.loads(_TOKEN_FILE.read_text())
-        except (json.JSONDecodeError, OSError) as e:
-            logger.warning("Failed to read token counter file %s: %s", _TOKEN_FILE, e)
+        data = _read_json_file(_TOKEN_FILE, {})
+        if not isinstance(data, dict):
+            data = {}
 
-        prev = data.get("last_server_counter", 0)
-        delta = server_counter if server_counter < prev else server_counter - prev
+        current = _non_negative_number(server_counter)
+        prev = _non_negative_number(data.get("last_server_counter"))
+        lifetime = _non_negative_number(data.get("lifetime"))
+        delta = current if current < prev else current - prev
 
-        data["lifetime"] = int(data.get("lifetime", 0) + delta)
-        data["last_server_counter"] = server_counter
+        data["lifetime"] = int(lifetime + delta)
+        data["last_server_counter"] = current
         _write_json_file(_TOKEN_FILE, data)
         return data["lifetime"]
 
 
 def _get_lifetime_tokens() -> int:
-    try:
-        return json.loads(_TOKEN_FILE.read_text()).get("lifetime", 0)
-    except (json.JSONDecodeError, OSError):
+    data = _read_json_file(_TOKEN_FILE, {})
+    if not isinstance(data, dict):
         return 0
+    return int(_non_negative_number(data.get("lifetime")))
 
 
-def _update_lemonade_lifetime_tokens(stats: dict) -> int:
-    """Count Lemonade's per-completion stats once across polls and restarts."""
-    sample = {
-        key: stats.get(key)
-        for key in (
-            "sample_fingerprint", "decode_token_times", "input_tokens",
-            "output_tokens", "prompt_tokens", "time_to_first_token",
-            "tokens_per_second", "last_use", "request_id", "completed_at",
-        )
-    }
-    signature = hashlib.sha256(
-        json.dumps(sample, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
-    with _token_counter_lock:
-        data = _read_json_file(_TOKEN_FILE, {"lifetime": 0, "last_server_counter": 0})
-        if not isinstance(data, dict):
-            data = {"lifetime": 0, "last_server_counter": 0}
-        if signature != data.get("lemonade_last_sample"):
-            try:
-                output_tokens = max(0, int(stats.get("output_tokens") or 0))
-            except (TypeError, ValueError):
-                output_tokens = 0
-            data["lifetime"] = int(data.get("lifetime", 0)) + output_tokens
-            data["lemonade_last_sample"] = signature
-            _write_json_file(_TOKEN_FILE, data)
-        return int(data.get("lifetime", 0))
+def _non_negative_number(value) -> float:
+    """Return a finite non-negative number for persisted/runtime counters."""
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    if not math.isfinite(number) or number < 0:
+        return 0.0
+    return number
 
 
 def _normalize_perf_key(value: str | None) -> str:
@@ -263,7 +244,17 @@ def _write_json_file(path: Path, data) -> None:
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         temporary.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
-        os.replace(temporary, path)
+        # Windows virus scanners and indexers can briefly retain a handle to
+        # the destination. Retry only that transient access-denied case; other
+        # filesystem failures remain fail-soft as before.
+        for attempt in range(4):
+            try:
+                os.replace(temporary, path)
+                break
+            except PermissionError:
+                if attempt == 3:
+                    raise
+                time.sleep(0.025 * (2 ** attempt))
     except OSError as e:
         logger.debug("Failed to write JSON file %s: %s", path, e)
     finally:
@@ -418,9 +409,14 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
                 tokens_per_second = 0.0
             if not math.isfinite(tokens_per_second):
                 tokens_per_second = 0.0
+            output_tokens = int(_non_negative_number(stats.get("output_tokens")))
             return {
                 "tokens_per_second": round(max(0.0, tokens_per_second), 1),
-                "lifetime_tokens": _update_lemonade_lifetime_tokens(stats),
+                # Lemonade /v1/stats documents only the most recent request.
+                # It has no cumulative counter or stable event sequence, so
+                # polling cannot truthfully construct a lifetime total.
+                "lifetime_tokens": output_tokens,
+                "token_count_mode": "latest_completion",
             }
 
         host = SERVICES["llama-server"]["host"]
@@ -459,10 +455,24 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
         _prev_tokens["gen_secs"] = gen_secs
 
         lifetime = _update_lifetime_tokens(curr)
-        return {"tokens_per_second": _prev_tokens["tps"], "lifetime_tokens": lifetime}
+        return {
+            "tokens_per_second": _prev_tokens["tps"],
+            "lifetime_tokens": lifetime,
+            "token_count_mode": "cumulative",
+        }
     except (AgentClientError, httpx.HTTPError, httpx.TimeoutException, OSError, ValueError) as e:
         logger.warning("get_llama_metrics failed: %s: %s", type(e).__name__, e)
-        return {"tokens_per_second": 0, "lifetime_tokens": _get_lifetime_tokens()}
+        if LLM_BACKEND == "lemonade":
+            return {
+                "tokens_per_second": 0,
+                "lifetime_tokens": 0,
+                "token_count_mode": "unavailable",
+            }
+        return {
+            "tokens_per_second": 0,
+            "lifetime_tokens": _get_lifetime_tokens(),
+            "token_count_mode": "cumulative",
+        }
 
 
 async def get_loaded_model() -> Optional[str]:

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -1,13 +1,16 @@
 """Shared helper functions for service health checking, metrics, and system info."""
 
 import asyncio
+import hashlib
 import json
 import logging
+import math
 import os
 import platform
 import re
 import shutil
 import socket
+import threading
 import time
 from pathlib import Path
 from typing import Optional
@@ -15,7 +18,7 @@ from typing import Optional
 import aiohttp
 import httpx
 
-from config import SERVICES, INSTALL_DIR, DATA_DIR, LLM_BACKEND
+from config import SERVICES, INSTALL_DIR, DATA_DIR, LLM_BACKEND, read_live_env_value
 from host_agent_client import AgentClientError, async_request_json as request_agent_json
 from models import ServiceStatus, DiskUsage, ModelInfo, BootstrapStatus
 
@@ -185,29 +188,26 @@ async def _check_host_systemd_health(service_id: str, config: dict) -> ServiceSt
 _TOKEN_FILE = Path(DATA_DIR) / "token_counter.json"
 _PERF_FILE = Path(DATA_DIR) / "model_performance.json"
 _prev_tokens = {"count": 0, "time": 0.0, "tps": 0.0}
+_token_counter_lock = threading.Lock()
 
 
 def _update_lifetime_tokens(server_counter: float) -> int:
     """Accumulate tokens across server restarts using a persistent file."""
-    data = {"lifetime": 0, "last_server_counter": 0}
-    try:
-        if _TOKEN_FILE.exists():
-            data = json.loads(_TOKEN_FILE.read_text())
-    except (json.JSONDecodeError, OSError) as e:
-        logger.warning("Failed to read token counter file %s: %s", _TOKEN_FILE, e)
+    with _token_counter_lock:
+        data = {"lifetime": 0, "last_server_counter": 0}
+        try:
+            if _TOKEN_FILE.exists():
+                data = json.loads(_TOKEN_FILE.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning("Failed to read token counter file %s: %s", _TOKEN_FILE, e)
 
-    prev = data.get("last_server_counter", 0)
-    delta = server_counter if server_counter < prev else server_counter - prev
+        prev = data.get("last_server_counter", 0)
+        delta = server_counter if server_counter < prev else server_counter - prev
 
-    data["lifetime"] = int(data.get("lifetime", 0) + delta)
-    data["last_server_counter"] = server_counter
-
-    try:
-        _TOKEN_FILE.write_text(json.dumps(data))
-    except OSError as e:
-        logger.warning("Failed to write token counter file %s: %s", _TOKEN_FILE, e)
-
-    return data["lifetime"]
+        data["lifetime"] = int(data.get("lifetime", 0) + delta)
+        data["last_server_counter"] = server_counter
+        _write_json_file(_TOKEN_FILE, data)
+        return data["lifetime"]
 
 
 def _get_lifetime_tokens() -> int:
@@ -215,6 +215,34 @@ def _get_lifetime_tokens() -> int:
         return json.loads(_TOKEN_FILE.read_text()).get("lifetime", 0)
     except (json.JSONDecodeError, OSError):
         return 0
+
+
+def _update_lemonade_lifetime_tokens(stats: dict) -> int:
+    """Count Lemonade's per-completion stats once across polls and restarts."""
+    sample = {
+        key: stats.get(key)
+        for key in (
+            "sample_fingerprint", "decode_token_times", "input_tokens",
+            "output_tokens", "prompt_tokens", "time_to_first_token",
+            "tokens_per_second",
+        )
+    }
+    signature = hashlib.sha256(
+        json.dumps(sample, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+    with _token_counter_lock:
+        data = _read_json_file(_TOKEN_FILE, {"lifetime": 0, "last_server_counter": 0})
+        if not isinstance(data, dict):
+            data = {"lifetime": 0, "last_server_counter": 0}
+        if signature != data.get("lemonade_last_sample"):
+            try:
+                output_tokens = max(0, int(stats.get("output_tokens") or 0))
+            except (TypeError, ValueError):
+                output_tokens = 0
+            data["lifetime"] = int(data.get("lifetime", 0)) + output_tokens
+            data["lemonade_last_sample"] = signature
+            _write_json_file(_TOKEN_FILE, data)
+        return int(data.get("lifetime", 0))
 
 
 def _normalize_perf_key(value: str | None) -> str:
@@ -231,11 +259,18 @@ def _read_json_file(path: Path, default):
 
 
 def _write_json_file(path: Path, data) -> None:
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.{threading.get_ident()}.tmp")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        temporary.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(temporary, path)
     except OSError as e:
         logger.debug("Failed to write JSON file %s: %s", path, e)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
 
 
 def _performance_key(backend: str, gpu_name: str, model_name: str,
@@ -351,6 +386,43 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
     loaded model name can avoid a redundant HTTP round-trip.
     """
     try:
+        if LLM_BACKEND == "lemonade":
+            if read_live_env_value("AMD_INFERENCE_LOCATION").lower() == "host":
+                host_status = await request_agent_json("GET", "/v1/llm/status", timeout=6)
+                stats = host_status.get("stats")
+            else:
+                host = SERVICES["llama-server"]["host"]
+                port = SERVICES["llama-server"]["port"]
+                client = await _get_httpx_client()
+                stats = None
+                last_error: Exception | None = None
+                api_key = read_live_env_value("LEMONADE_API_KEY")
+                headers = {"Authorization": f"Bearer {api_key}"} if api_key else None
+                for prefix in ("/api/v1", "/v1"):
+                    try:
+                        resp = await client.get(
+                            f"http://{host}:{port}{prefix}/stats", headers=headers,
+                        )
+                        resp.raise_for_status()
+                        stats = resp.json()
+                        break
+                    except (httpx.HTTPError, ValueError) as exc:
+                        last_error = exc
+                if stats is None:
+                    raise ValueError(f"Lemonade stats endpoint is unavailable: {last_error}")
+            if not isinstance(stats, dict):
+                raise ValueError("Lemonade stats response is unavailable")
+            try:
+                tokens_per_second = float(stats.get("tokens_per_second") or 0)
+            except (TypeError, ValueError):
+                tokens_per_second = 0.0
+            if not math.isfinite(tokens_per_second):
+                tokens_per_second = 0.0
+            return {
+                "tokens_per_second": round(max(0.0, tokens_per_second), 1),
+                "lifetime_tokens": _update_lemonade_lifetime_tokens(stats),
+            }
+
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
         metrics_port = int(os.environ.get("LLAMA_METRICS_PORT", port))
@@ -388,8 +460,8 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
 
         lifetime = _update_lifetime_tokens(curr)
         return {"tokens_per_second": _prev_tokens["tps"], "lifetime_tokens": lifetime}
-    except (httpx.HTTPError, httpx.TimeoutException, OSError) as e:
-        logger.warning(f"get_llama_metrics failed: {e}")
+    except (AgentClientError, httpx.HTTPError, httpx.TimeoutException, OSError, ValueError) as e:
+        logger.warning("get_llama_metrics failed: %s: %s", type(e).__name__, e)
         return {"tokens_per_second": 0, "lifetime_tokens": _get_lifetime_tokens()}
 
 
@@ -562,7 +634,69 @@ async def get_all_services() -> list[ServiceStatus]:
             ))
         else:
             statuses.append(result)
-    return statuses
+    if not any(status.status in {"degraded", "down", "unhealthy"} for status in statuses):
+        return statuses
+
+    try:
+        snapshot = await request_agent_json("GET", "/v1/service/health", timeout=15)
+        if snapshot.get("schema_version") != "ods.host-service-health.v1":
+            raise ValueError("unsupported host service-health schema")
+        containers = snapshot.get("containers")
+        if not isinstance(containers, list):
+            raise ValueError("host service-health containers must be a list")
+        by_service = {
+            str(item.get("service_id")): item
+            for item in containers
+            if isinstance(item, dict) and item.get("service_id")
+        }
+        by_name = {
+            str(item.get("container_name")): item
+            for item in containers
+            if isinstance(item, dict) and item.get("container_name")
+        }
+    except (AgentClientError, ValueError):
+        by_service = {}
+        by_name = {}
+
+    reconciled: list[ServiceStatus] = []
+    for status in statuses:
+        config = SERVICES.get(status.id, {})
+        item = by_service.get(status.id) or by_name.get(str(config.get("container_name") or ""))
+        replacement = status.status
+        if item and config.get("type", "docker") == "docker":
+            health = str(item.get("health") or "none").casefold()
+            state = str(item.get("state") or "unknown").casefold()
+            if health == "healthy" and status.status == "degraded":
+                # A successful declared Docker healthcheck is authoritative for
+                # transient dashboard-network timeouts, but never masks HTTP
+                # errors or connection refusal from the application probe.
+                replacement = "healthy"
+            elif health == "unhealthy":
+                replacement = "unhealthy"
+            elif health == "starting" and status.status in {"down", "degraded"}:
+                replacement = "degraded"
+            elif state in {"exited", "dead", "removing"}:
+                replacement = "down"
+        if replacement != status.status:
+            status = status.model_copy(update={"status": replacement})
+        reconciled.append(status)
+
+    if LLM_BACKEND == "lemonade" and read_live_env_value("AMD_INFERENCE_LOCATION").lower() == "host":
+        llama_index = next(
+            (index for index, status in enumerate(reconciled) if status.id == "llama-server"),
+            None,
+        )
+        if llama_index is not None and reconciled[llama_index].status != "healthy":
+            try:
+                host_status = await request_agent_json("GET", "/v1/llm/status", timeout=6)
+                health = host_status.get("health")
+                if isinstance(health, dict) and (health.get("status") == "ok" or health.get("model_loaded")):
+                    reconciled[llama_index] = reconciled[llama_index].model_copy(
+                        update={"status": "healthy"},
+                    )
+            except AgentClientError:
+                pass
+    return reconciled
 
 
 # --- System Metrics ---

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -427,29 +427,48 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
         params = {"model": model_name} if model_name else {}
         client = await _get_httpx_client()
         resp = await client.get(url, params=params)
+        resp.raise_for_status()
 
         metrics = {}
         for line in resp.text.split("\n"):
-            if line.startswith("#"):
+            line = line.strip()
+            if not line or line.startswith("#"):
                 continue
-            if "tokens_predicted_total" in line:
+            parts = line.split()
+            if len(parts) < 2:
+                continue
+            metric_name = parts[0].split("{", 1)[0]
+            if metric_name.endswith("tokens_predicted_total"):
                 try:
-                    metrics["tokens_predicted_total"] = float(line.split()[-1])
-                except (ValueError, IndexError):
+                    metrics["tokens_predicted_total"] = float(parts[-1])
+                except ValueError:
                     pass
-            if "tokens_predicted_seconds_total" in line:
+            if metric_name.endswith("tokens_predicted_seconds_total"):
                 try:
-                    metrics["tokens_predicted_seconds_total"] = float(line.split()[-1])
-                except (ValueError, IndexError):
+                    metrics["tokens_predicted_seconds_total"] = float(parts[-1])
+                except ValueError:
                     pass
 
+        # A successful HTTP response is not sufficient proof that this is the
+        # llama.cpp Prometheus endpoint. Treat HTML, proxy error pages, and
+        # incomplete metric payloads as unavailable so they cannot reset the
+        # persistent server counter and double-count tokens after recovery.
+        if "tokens_predicted_total" not in metrics:
+            raise ValueError("llama-server metrics response has no token counter")
+
         now = time.time()
-        curr = metrics.get("tokens_predicted_total", 0)
-        gen_secs = metrics.get("tokens_predicted_seconds_total", 0)
+        curr = _non_negative_number(metrics["tokens_predicted_total"])
+        gen_secs = _non_negative_number(metrics.get("tokens_predicted_seconds_total"))
         if _prev_tokens["time"] > 0 and curr > _prev_tokens["count"]:
             delta_secs = gen_secs - _prev_tokens.get("gen_secs", 0)
             if delta_secs > 0:
                 _prev_tokens["tps"] = round((curr - _prev_tokens["count"]) / delta_secs, 1)
+            else:
+                _prev_tokens["tps"] = 0.0
+        else:
+            # The server is idle, has restarted, or reset its counters. A
+            # previous request's throughput is not live throughput.
+            _prev_tokens["tps"] = 0.0
         _prev_tokens["count"] = curr
         _prev_tokens["time"] = now
         _prev_tokens["gen_secs"] = gen_secs

--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -224,7 +224,7 @@ def _update_lemonade_lifetime_tokens(stats: dict) -> int:
         for key in (
             "sample_fingerprint", "decode_token_times", "input_tokens",
             "output_tokens", "prompt_tokens", "time_to_first_token",
-            "tokens_per_second",
+            "tokens_per_second", "last_use", "request_id", "completed_at",
         )
     }
     signature = hashlib.sha256(

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -469,6 +469,9 @@ def _infer_tier(gpu_info) -> str:
 
 def _infer_gpu_count(gpu_info) -> int:
     """Infer GPU count from the GPU_COUNT env var or the display name."""
+    observed_count = int(getattr(gpu_info, "gpu_count", 1) or 1)
+    if observed_count > 1:
+        return observed_count
     gpu_count_env = os.environ.get("GPU_COUNT", "")
     if gpu_count_env.isdigit():
         return int(gpu_count_env)
@@ -1283,6 +1286,7 @@ async def api_status(api_key: str = Depends(verify_api_key)):
             "disk": {"used_gb": 0, "total_gb": 0, "percent": 0},
             "system": {"uptime": 0, "hostname": os.environ.get("HOSTNAME", "ods")},
             "inference": {"tokensPerSecond": 0, "lifetimeTokens": 0,
+                          "tokenCountMode": "unavailable",
                           "loadedModel": None, "contextSize": None},
             "manifest_errors": MANIFEST_ERRORS,
         }
@@ -1391,6 +1395,7 @@ async def _build_api_status() -> dict:
         "inference": {
             "tokensPerSecond": llama_metrics_data.get("tokens_per_second", 0),
             "lifetimeTokens": llama_metrics_data.get("lifetime_tokens", 0),
+            "tokenCountMode": llama_metrics_data.get("token_count_mode", "unavailable"),
             "loadedModel": loaded_model_name,
             "contextSize": context_size or (model_data["contextLength"] if model_data else None),
         },

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -490,10 +490,13 @@ def _serialize_gpu(gpu_info) -> Optional[dict]:
 
     gpu_data = {
         "name": gpu_info.name,
-        "vramUsed": round(gpu_info.memory_used_mb / 1024, 1),
+        "vramUsed": (
+            round(gpu_info.memory_used_mb / 1024, 1)
+            if gpu_info.memory_usage_available else None
+        ),
         "vramTotal": round(gpu_info.memory_total_mb / 1024, 1),
-        "utilization": gpu_info.utilization_percent,
-        "temperature": gpu_info.temperature_c,
+        "utilization": gpu_info.utilization_percent if gpu_info.utilization_available else None,
+        "temperature": gpu_info.temperature_c if gpu_info.temperature_available else None,
         "memoryType": gpu_info.memory_type,
         "backend": gpu_info.gpu_backend,
         "gpu_count": gpu_count,
@@ -1345,21 +1348,7 @@ async def _build_api_status() -> dict:
         get_llama_context_size(model_hint=loaded_model),
     )
 
-    gpu_data = None
-    if gpu_info:
-        gpu_data = {
-            "name": gpu_info.name,
-            "vramUsed": round(gpu_info.memory_used_mb / 1024, 1),
-            "vramTotal": round(gpu_info.memory_total_mb / 1024, 1),
-            "utilization": gpu_info.utilization_percent,
-            "temperature": gpu_info.temperature_c,
-            "memoryType": gpu_info.memory_type,
-            "backend": gpu_info.gpu_backend,
-            "gpu_count": _infer_gpu_count(gpu_info),
-        }
-        if gpu_info.power_w is not None:
-            gpu_data["powerDraw"] = gpu_info.power_w
-        gpu_data["memoryLabel"] = "VRAM Partition" if gpu_info.memory_type == "unified" else "VRAM"
+    gpu_data = _serialize_gpu(gpu_info)
 
     services_data = _serialize_services(service_statuses, uptime)
 

--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -18,6 +18,7 @@ class GPUInfo(BaseModel):
     power_w: Optional[float] = None
     memory_type: str = "discrete"
     gpu_backend: str = GPU_BACKEND
+    gpu_count: int = 1
     memory_usage_available: bool = True
     utilization_available: bool = True
     temperature_available: bool = True
@@ -123,6 +124,7 @@ class IndividualGPU(BaseModel):
     utilization_percent: int
     temperature_c: int
     power_w: Optional[float] = None
+    memory_type: str = "discrete"
     assigned_services: list[str] = []
     memory_usage_available: bool = True
     utilization_available: bool = True

--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -18,6 +18,9 @@ class GPUInfo(BaseModel):
     power_w: Optional[float] = None
     memory_type: str = "discrete"
     gpu_backend: str = GPU_BACKEND
+    memory_usage_available: bool = True
+    utilization_available: bool = True
+    temperature_available: bool = True
 
 
 class ServiceStatus(BaseModel):
@@ -121,6 +124,9 @@ class IndividualGPU(BaseModel):
     temperature_c: int
     power_w: Optional[float] = None
     assigned_services: list[str] = []
+    memory_usage_available: bool = True
+    utilization_available: bool = True
+    temperature_available: bool = True
 
 
 class MultiGPUStatus(BaseModel):

--- a/ods/extensions/services/dashboard-api/routers/gpu.py
+++ b/ods/extensions/services/dashboard-api/routers/gpu.py
@@ -59,6 +59,9 @@ def _apple_info_to_individual(info: GPUInfo) -> IndividualGPU:
         temperature_c=info.temperature_c,
         power_w=info.power_w,
         assigned_services=[],
+        memory_usage_available=info.memory_usage_available,
+        utilization_available=info.utilization_available,
+        temperature_available=info.temperature_available,
     )
 
 

--- a/ods/extensions/services/dashboard-api/routers/gpu.py
+++ b/ods/extensions/services/dashboard-api/routers/gpu.py
@@ -16,11 +16,13 @@ from fastapi import APIRouter, Depends, HTTPException
 from security import verify_api_key
 
 from gpu import (
+    aggregate_gpu_details,
     decode_gpu_assignment,
     get_gpu_info_amd_detailed,
     get_gpu_info_apple,
     get_gpu_info_nvidia_detailed,
     get_gpu_info_windows_host,
+    get_gpu_info_windows_host_detailed,
     read_gpu_topology,
 )
 from models import GPUInfo, IndividualGPU, MultiGPUStatus
@@ -58,6 +60,7 @@ def _apple_info_to_individual(info: GPUInfo) -> IndividualGPU:
         utilization_percent=info.utilization_percent,
         temperature_c=info.temperature_c,
         power_w=info.power_w,
+        memory_type="unified",
         assigned_services=[],
         memory_usage_available=info.memory_usage_available,
         utilization_available=info.utilization_available,
@@ -109,6 +112,10 @@ def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
     if not runtime_mode.startswith("windows"):
         return None
 
+    detailed = get_gpu_info_windows_host_detailed()
+    if detailed:
+        return detailed
+
     host_info = get_gpu_info_windows_host()
     if host_info is not None:
         return [IndividualGPU(
@@ -121,6 +128,7 @@ def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
             utilization_percent=host_info.utilization_percent,
             temperature_c=host_info.temperature_c,
             power_w=host_info.power_w,
+            memory_type=host_info.memory_type,
             assigned_services=["llama-server"],
             memory_usage_available=host_info.memory_usage_available,
             utilization_available=host_info.utilization_available,
@@ -145,6 +153,7 @@ def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
             utilization_percent=0,
             temperature_c=0,
             power_w=None,
+            memory_type="discrete",
             assigned_services=["llama-server"],
             memory_usage_available=False,
             utilization_available=False,
@@ -152,55 +161,6 @@ def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
         )
         for idx in range(count)
     ]
-
-
-def _build_aggregate(gpus: list[IndividualGPU], backend: str) -> GPUInfo:
-    """Compute an aggregate GPUInfo from a list of IndividualGPU objects."""
-    if len(gpus) == 1:
-        g = gpus[0]
-        return GPUInfo(
-            name=g.name,
-            memory_used_mb=g.memory_used_mb,
-            memory_total_mb=g.memory_total_mb,
-            memory_percent=g.memory_percent,
-            utilization_percent=g.utilization_percent,
-            temperature_c=g.temperature_c,
-            power_w=g.power_w,
-            gpu_backend=backend,
-            memory_usage_available=g.memory_usage_available,
-            utilization_available=g.utilization_available,
-            temperature_available=g.temperature_available,
-        )
-
-    mem_used = sum(g.memory_used_mb for g in gpus)
-    mem_total = sum(g.memory_total_mb for g in gpus)
-    avg_util = round(sum(g.utilization_percent for g in gpus) / len(gpus))
-    available_temps = [g.temperature_c for g in gpus if g.temperature_available]
-    max_temp = max(available_temps) if available_temps else 0
-    pw_values = [g.power_w for g in gpus if g.power_w is not None]
-    total_power: Optional[float] = round(sum(pw_values), 1) if pw_values else None
-
-    names = [g.name for g in gpus]
-    if len(set(names)) == 1:
-        display_name = f"{names[0]} \u00d7 {len(gpus)}"
-    else:
-        display_name = " + ".join(names[:2])
-        if len(names) > 2:
-            display_name += f" + {len(names) - 2} more"
-
-    return GPUInfo(
-        name=display_name,
-        memory_used_mb=mem_used,
-        memory_total_mb=mem_total,
-        memory_percent=round(mem_used / mem_total * 100, 1) if mem_total > 0 else 0.0,
-        utilization_percent=avg_util,
-        temperature_c=max_temp,
-        power_w=total_power,
-        gpu_backend=backend,
-        memory_usage_available=all(g.memory_usage_available for g in gpus),
-        utilization_available=all(g.utilization_available for g in gpus),
-        temperature_available=bool(available_temps),
-    )
 
 
 def _clean_env(name: str) -> str:
@@ -377,7 +337,7 @@ async def gpu_detailed():
     if not gpus:
         raise HTTPException(status_code=503, detail="No GPU data available")
 
-    aggregate = _build_aggregate(gpus, gpu_backend)
+    aggregate = aggregate_gpu_details(gpus, gpu_backend)
 
     assignment_full = decode_gpu_assignment()
     assignment_data = assignment_full.get("gpu_assignment") if assignment_full else None

--- a/ods/extensions/services/dashboard-api/routers/gpu.py
+++ b/ods/extensions/services/dashboard-api/routers/gpu.py
@@ -20,6 +20,7 @@ from gpu import (
     get_gpu_info_amd_detailed,
     get_gpu_info_apple,
     get_gpu_info_nvidia_detailed,
+    get_gpu_info_windows_host,
     read_gpu_topology,
 )
 from models import GPUInfo, IndividualGPU, MultiGPUStatus
@@ -105,9 +106,25 @@ def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
     if not runtime_mode.startswith("windows"):
         return None
 
+    host_info = get_gpu_info_windows_host()
+    if host_info is not None:
+        return [IndividualGPU(
+            index=0,
+            uuid="amd-windows-host-0",
+            name=host_info.name,
+            memory_used_mb=host_info.memory_used_mb,
+            memory_total_mb=host_info.memory_total_mb,
+            memory_percent=host_info.memory_percent,
+            utilization_percent=host_info.utilization_percent,
+            temperature_c=host_info.temperature_c,
+            power_w=host_info.power_w,
+            assigned_services=["llama-server"],
+            memory_usage_available=host_info.memory_usage_available,
+            utilization_available=host_info.utilization_available,
+            temperature_available=host_info.temperature_available,
+        )]
+
     count = max(1, _env_int("GPU_COUNT", 1))
-    host_ram_gb = max(0, _env_int("HOST_RAM_GB", 0))
-    memory_total_mb = host_ram_gb * 1024
     backend = _clean_env("AMD_INFERENCE_BACKEND").lower() or "unknown"
     runtime_label = "Lemonade" if runtime == "lemonade" else "llama-server"
     name = f"AMD {runtime_label} host runtime"
@@ -120,12 +137,15 @@ def _amd_host_runtime_fallback_gpus() -> Optional[list[IndividualGPU]]:
             uuid=f"amd-host-runtime-{idx}",
             name=name,
             memory_used_mb=0,
-            memory_total_mb=memory_total_mb,
+            memory_total_mb=0,
             memory_percent=0.0,
             utilization_percent=0,
             temperature_c=0,
             power_w=None,
             assigned_services=["llama-server"],
+            memory_usage_available=False,
+            utilization_available=False,
+            temperature_available=False,
         )
         for idx in range(count)
     ]
@@ -144,12 +164,16 @@ def _build_aggregate(gpus: list[IndividualGPU], backend: str) -> GPUInfo:
             temperature_c=g.temperature_c,
             power_w=g.power_w,
             gpu_backend=backend,
+            memory_usage_available=g.memory_usage_available,
+            utilization_available=g.utilization_available,
+            temperature_available=g.temperature_available,
         )
 
     mem_used = sum(g.memory_used_mb for g in gpus)
     mem_total = sum(g.memory_total_mb for g in gpus)
     avg_util = round(sum(g.utilization_percent for g in gpus) / len(gpus))
-    max_temp = max(g.temperature_c for g in gpus)
+    available_temps = [g.temperature_c for g in gpus if g.temperature_available]
+    max_temp = max(available_temps) if available_temps else 0
     pw_values = [g.power_w for g in gpus if g.power_w is not None]
     total_power: Optional[float] = round(sum(pw_values), 1) if pw_values else None
 
@@ -170,6 +194,9 @@ def _build_aggregate(gpus: list[IndividualGPU], backend: str) -> GPUInfo:
         temperature_c=max_temp,
         power_w=total_power,
         gpu_backend=backend,
+        memory_usage_available=all(g.memory_usage_available for g in gpus),
+        utilization_available=all(g.utilization_available for g in gpus),
+        temperature_available=bool(available_temps),
     )
 
 
@@ -520,9 +547,9 @@ async def gpu_history():
         }
         for sample in _GPU_HISTORY:
             g = sample["gpus"].get(gpu_key, {})
-            gpus_data[gpu_key]["utilization"].append(g.get("utilization", 0))
-            gpus_data[gpu_key]["memory_percent"].append(g.get("memory_percent", 0))
-            gpus_data[gpu_key]["temperature"].append(g.get("temperature", 0))
+            gpus_data[gpu_key]["utilization"].append(g.get("utilization"))
+            gpus_data[gpu_key]["memory_percent"].append(g.get("memory_percent"))
+            gpus_data[gpu_key]["temperature"].append(g.get("temperature"))
             gpus_data[gpu_key]["power_w"].append(g.get("power_w"))
 
     return {"timestamps": timestamps, "gpus": gpus_data}
@@ -543,9 +570,9 @@ async def poll_gpu_history() -> None:
                     "timestamp": datetime.now(timezone.utc).isoformat(),
                     "gpus": {
                         str(g.index): {
-                            "utilization": g.utilization_percent,
-                            "memory_percent": g.memory_percent,
-                            "temperature": g.temperature_c,
+                            "utilization": g.utilization_percent if g.utilization_available else None,
+                            "memory_percent": g.memory_percent if g.memory_usage_available else None,
+                            "temperature": g.temperature_c if g.temperature_available else None,
                             "power_w": g.power_w,
                         }
                         for g in gpus

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -74,6 +74,18 @@ class TestGetGpuInfoNvidia:
         assert info is not None
         assert info.power_w is None
 
+    def test_marks_unsupported_sensors_unavailable(self, monkeypatch):
+        csv = "NVIDIA A100, 2048, 40536, [N/A], [N/A], 100.0"
+        monkeypatch.setattr("gpu.run_command", lambda cmd, **kw: (True, csv))
+
+        info = get_gpu_info_nvidia()
+
+        assert info is not None
+        assert info.utilization_percent == 0
+        assert info.temperature_c == 0
+        assert info.utilization_available is False
+        assert info.temperature_available is False
+
     def test_returns_none_on_command_failure(self, monkeypatch):
         monkeypatch.setattr("gpu.run_command", lambda cmd, **kw: (False, ""))
 
@@ -206,6 +218,9 @@ class TestGetGpuInfoApple:
         assert info.gpu_backend == "apple"
         assert info.memory_type == "unified"
         assert info.memory_used_mb > 0
+        assert info.memory_usage_available is False
+        assert info.utilization_available is False
+        assert info.temperature_available is False
 
     def test_returns_none_when_sysctl_fails(self, monkeypatch):
         monkeypatch.setattr("gpu.platform.system", lambda: "Darwin")

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -7,7 +7,8 @@ import pytest
 
 from gpu import (
     get_gpu_tier, get_gpu_info_nvidia, get_gpu_info_apple,
-    get_gpu_info_amd, get_gpu_info, get_gpu_info_windows_host, run_command,
+    get_gpu_info_amd, get_gpu_info, get_gpu_info_windows_host,
+    get_gpu_info_windows_host_detailed, run_command,
 )
 
 
@@ -113,6 +114,7 @@ class TestGetGpuInfoNvidia:
         assert "× 2" in info.name
         assert info.memory_used_mb == 2048 + 4096
         assert info.memory_total_mb == 24564 * 2
+        assert info.gpu_count == 2
 
     def test_unified_memory_fallback_for_na_memory(self, monkeypatch):
         # GB10 / GB200 unified-memory: nvidia-smi reports [N/A] for memory.
@@ -162,6 +164,62 @@ class TestWindowsHostGpuInfo:
         assert info.memory_used_mb == 4400
         assert info.utilization_percent == 37
         assert info.temperature_available is False
+
+    def test_maps_unified_memory_type(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
+        monkeypatch.setattr("gpu.request_agent_json", lambda *args, **kwargs: {
+            "schema_version": "ods.host-gpu-metrics.v1",
+            "name": "AMD Radeon 8060S Graphics",
+            "memory_type": "unified",
+            "memory_total_mb": 98304,
+            "memory_used_mb": 8192,
+            "utilization_percent": 42,
+        })
+
+        info = get_gpu_info_windows_host()
+
+        assert info is not None
+        assert info.memory_type == "unified"
+
+    def test_maps_per_adapter_host_payload(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
+        monkeypatch.setattr("gpu.request_agent_json", lambda *args, **kwargs: {
+            "schema_version": "ods.host-gpu-metrics.v1",
+            "gpus": [
+                {
+                    "index": 0, "uuid": "luid-a", "name": "AMD Radeon RX 7900 XTX",
+                    "memory_total_mb": 24560, "memory_used_mb": 4096,
+                    "utilization_percent": 30, "memory_usage_available": True,
+                    "utilization_available": True,
+                },
+                {
+                    "index": 1, "uuid": "luid-b", "name": "AMD Radeon RX 7900 XTX",
+                    "memory_total_mb": 24560, "memory_used_mb": 8192,
+                    "utilization_percent": 70, "memory_usage_available": True,
+                    "utilization_available": True,
+                },
+            ],
+        })
+
+        gpus = get_gpu_info_windows_host_detailed()
+
+        assert gpus is not None
+        assert [gpu.uuid for gpu in gpus] == ["luid-a", "luid-b"]
+        assert [gpu.utilization_percent for gpu in gpus] == [30, 70]
+
+    def test_rejects_invalid_aggregate_count(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
+        monkeypatch.setattr("gpu.request_agent_json", lambda *args, **kwargs: {
+            "schema_version": "ods.host-gpu-metrics.v1",
+            "name": "AMD Radeon",
+            "memory_total_mb": 16384,
+            "gpu_count": "not-a-number",
+        })
+
+        assert get_gpu_info_windows_host() is None
 
     def test_non_host_amd_does_not_call_agent(self, monkeypatch):
         monkeypatch.setenv("GPU_BACKEND", "amd")
@@ -425,6 +483,36 @@ class TestGetGpuInfoDispatcher:
         result = get_gpu_info()
         assert result is not None
         assert result.name == "Radeon RX 7900"
+
+    def test_amd_multi_gpu_uses_detailed_aggregate(self, monkeypatch):
+        from models import IndividualGPU
+
+        monkeypatch.setattr("gpu.os.environ", {"GPU_BACKEND": "amd", "GPU_COUNT": "2"})
+        details = [
+            IndividualGPU(
+                index=index,
+                uuid=f"card{index}",
+                name="AMD Radeon RX 7900 XTX",
+                memory_used_mb=2048,
+                memory_total_mb=24576,
+                memory_percent=8.3,
+                utilization_percent=30 + index * 20,
+                temperature_c=60 + index,
+            )
+            for index in range(2)
+        ]
+        monkeypatch.setattr("gpu.get_gpu_info_amd_detailed", lambda: details)
+        monkeypatch.setattr(
+            "gpu.get_gpu_info_amd",
+            lambda: (_ for _ in ()).throw(AssertionError("single-GPU fallback should not run")),
+        )
+
+        result = get_gpu_info()
+
+        assert result is not None
+        assert result.gpu_count == 2
+        assert result.memory_total_mb == 49152
+        assert result.utilization_percent == 40
 
     def test_apple_on_darwin_autodetects(self, monkeypatch):
         monkeypatch.setattr("gpu.os.environ", {"GPU_BACKEND": ""})

--- a/ods/extensions/services/dashboard-api/tests/test_gpu.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu.py
@@ -7,7 +7,7 @@ import pytest
 
 from gpu import (
     get_gpu_tier, get_gpu_info_nvidia, get_gpu_info_apple,
-    get_gpu_info_amd, get_gpu_info, run_command,
+    get_gpu_info_amd, get_gpu_info, get_gpu_info_windows_host, run_command,
 )
 
 
@@ -124,6 +124,51 @@ class TestGetGpuInfoNvidia:
         monkeypatch.setattr("gpu._read_meminfo_mb", lambda: None)
 
         assert get_gpu_info_nvidia() is None
+
+
+class TestWindowsHostGpuInfo:
+
+    def test_maps_valid_host_agent_payload(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "host")
+        monkeypatch.setattr("gpu.request_agent_json", lambda *args, **kwargs: {
+            "schema_version": "ods.host-gpu-metrics.v1",
+            "name": "AMD Radeon RX 9070 XT",
+            "memory_total_mb": 16368,
+            "memory_used_mb": 4400,
+            "memory_usage_available": True,
+            "utilization_percent": 37,
+            "utilization_available": True,
+            "temperature_c": None,
+            "temperature_available": False,
+        })
+
+        info = get_gpu_info_windows_host()
+
+        assert info is not None
+        assert info.name == "AMD Radeon RX 9070 XT"
+        assert info.memory_used_mb == 4400
+        assert info.utilization_percent == 37
+        assert info.temperature_available is False
+
+    def test_non_host_amd_does_not_call_agent(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "amd")
+        monkeypatch.setattr("gpu._read_env_var_from_file", lambda key: "container")
+        monkeypatch.setattr(
+            "gpu.request_agent_json",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected host-agent call")),
+        )
+
+        assert get_gpu_info_windows_host() is None
+
+    def test_nvidia_path_does_not_call_agent(self, monkeypatch):
+        monkeypatch.setenv("GPU_BACKEND", "nvidia")
+        monkeypatch.setattr(
+            "gpu.request_agent_json",
+            lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected host-agent call")),
+        )
+
+        assert get_gpu_info_windows_host() is None
 
 
 # --- get_gpu_info_apple (mock subprocess) ---

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -152,6 +152,8 @@ class TestGetGpuInfoNvidiaDetailed:
         assert g.uuid == "GPU-abc123"
         assert g.utilization_percent == 0
         assert g.temperature_c == 0
+        assert g.utilization_available is False
+        assert g.temperature_available is False
 
     def test_parses_multi_gpu(self, monkeypatch):
         csv = (

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -473,6 +473,7 @@ class TestGetRawGpusAmdHostRuntime:
         import routers.gpu as gpu_mod
 
         monkeypatch.setattr(gpu_mod, "get_gpu_info_amd_detailed", lambda: None)
+        monkeypatch.setattr(gpu_mod, "get_gpu_info_windows_host_detailed", lambda: None)
         monkeypatch.setattr(gpu_mod, "get_gpu_info_windows_host", lambda: None)
         monkeypatch.setenv("AMD_INFERENCE_RUNTIME", "lemonade")
         monkeypatch.setenv("AMD_INFERENCE_LOCATION", "host")
@@ -498,6 +499,7 @@ class TestGetRawGpusAmdHostRuntime:
         from models import GPUInfo
 
         monkeypatch.setattr(gpu_mod, "get_gpu_info_amd_detailed", lambda: None)
+        monkeypatch.setattr(gpu_mod, "get_gpu_info_windows_host_detailed", lambda: None)
         monkeypatch.setattr(gpu_mod, "get_gpu_info_windows_host", lambda: GPUInfo(
             name="AMD Radeon RX 9070 XT",
             memory_used_mb=4096,
@@ -519,6 +521,38 @@ class TestGetRawGpusAmdHostRuntime:
         assert result[0].memory_used_mb == 4096
         assert result[0].utilization_percent == 42
         assert result[0].temperature_available is False
+
+    def test_windows_host_preserves_multiple_real_adapters(self, monkeypatch):
+        import routers.gpu as gpu_mod
+        from models import IndividualGPU
+
+        expected = [
+            IndividualGPU(
+                index=index,
+                uuid=f"luid-{index}",
+                name="AMD Radeon RX 7900 XTX",
+                memory_used_mb=4096,
+                memory_total_mb=24560,
+                memory_percent=16.7,
+                utilization_percent=40 + index,
+                temperature_c=0,
+                assigned_services=["llama-server"],
+                temperature_available=False,
+            )
+            for index in range(2)
+        ]
+        monkeypatch.setattr(gpu_mod, "get_gpu_info_amd_detailed", lambda: None)
+        monkeypatch.setattr(gpu_mod, "get_gpu_info_windows_host_detailed", lambda: expected)
+        monkeypatch.setattr(
+            gpu_mod,
+            "get_gpu_info_windows_host",
+            lambda: (_ for _ in ()).throw(AssertionError("aggregate fallback should not run")),
+        )
+        monkeypatch.setenv("AMD_INFERENCE_RUNTIME", "lemonade")
+        monkeypatch.setenv("AMD_INFERENCE_LOCATION", "host")
+        monkeypatch.setenv("AMD_INFERENCE_RUNTIME_MODE", "windows-lemonade")
+
+        assert gpu_mod._get_raw_gpus("amd") == expected
 
     def test_non_windows_amd_without_sysfs_still_returns_none(self, monkeypatch):
         """Linux/container AMD installs still fail loud when no GPU is visible."""

--- a/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gpu_detailed.py
@@ -372,6 +372,29 @@ class TestGpuHistoryBuffer:
             for item in saved:
                 gpu_mod._GPU_HISTORY.append(item)
 
+    def test_history_preserves_unavailable_samples_as_null(self):
+        import routers.gpu as gpu_mod
+        saved = list(gpu_mod._GPU_HISTORY)
+        gpu_mod._GPU_HISTORY.clear()
+        try:
+            gpu_mod._GPU_HISTORY.append({
+                "timestamp": "2026-07-20T00:00:00Z",
+                "gpus": {"0": {"power_w": None}},
+            })
+
+            result = asyncio.run(gpu_mod.gpu_history())
+
+            assert result["gpus"]["0"] == {
+                "utilization": [None],
+                "memory_percent": [None],
+                "temperature": [None],
+                "power_w": [None],
+            }
+        finally:
+            gpu_mod._GPU_HISTORY.clear()
+            for item in saved:
+                gpu_mod._GPU_HISTORY.append(item)
+
 
 # ============================================================================
 # _get_raw_gpus — Apple Silicon dispatch (routers/gpu.py)
@@ -448,12 +471,12 @@ class TestGetRawGpusAmdHostRuntime:
         import routers.gpu as gpu_mod
 
         monkeypatch.setattr(gpu_mod, "get_gpu_info_amd_detailed", lambda: None)
+        monkeypatch.setattr(gpu_mod, "get_gpu_info_windows_host", lambda: None)
         monkeypatch.setenv("AMD_INFERENCE_RUNTIME", "lemonade")
         monkeypatch.setenv("AMD_INFERENCE_LOCATION", "host")
         monkeypatch.setenv("AMD_INFERENCE_RUNTIME_MODE", "windows-legacy-lemonade")
         monkeypatch.setenv("AMD_INFERENCE_BACKEND", "vulkan")
         monkeypatch.setenv("GPU_COUNT", "1")
-        monkeypatch.setenv("HOST_RAM_GB", "96")
 
         result = gpu_mod._get_raw_gpus("amd")
 
@@ -461,8 +484,39 @@ class TestGetRawGpusAmdHostRuntime:
         assert len(result) == 1
         assert result[0].uuid == "amd-host-runtime-0"
         assert result[0].name == "AMD Lemonade host runtime (vulkan)"
-        assert result[0].memory_total_mb == 96 * 1024
+        assert result[0].memory_total_mb == 0
+        assert result[0].memory_usage_available is False
+        assert result[0].utilization_available is False
+        assert result[0].temperature_available is False
         assert result[0].assigned_services == ["llama-server"]
+
+    def test_windows_host_uses_real_agent_metrics(self, monkeypatch):
+        """Windows host telemetry is carried into the detailed GPU contract."""
+        import routers.gpu as gpu_mod
+        from models import GPUInfo
+
+        monkeypatch.setattr(gpu_mod, "get_gpu_info_amd_detailed", lambda: None)
+        monkeypatch.setattr(gpu_mod, "get_gpu_info_windows_host", lambda: GPUInfo(
+            name="AMD Radeon RX 9070 XT",
+            memory_used_mb=4096,
+            memory_total_mb=16368,
+            memory_percent=25.0,
+            utilization_percent=42,
+            temperature_c=0,
+            gpu_backend="amd",
+            temperature_available=False,
+        ))
+        monkeypatch.setenv("AMD_INFERENCE_RUNTIME", "lemonade")
+        monkeypatch.setenv("AMD_INFERENCE_LOCATION", "host")
+        monkeypatch.setenv("AMD_INFERENCE_RUNTIME_MODE", "windows-lemonade")
+
+        result = gpu_mod._get_raw_gpus("amd")
+
+        assert result is not None
+        assert result[0].name == "AMD Radeon RX 9070 XT"
+        assert result[0].memory_used_mb == 4096
+        assert result[0].utilization_percent == 42
+        assert result[0].temperature_available is False
 
     def test_non_windows_amd_without_sysfs_still_returns_none(self, monkeypatch):
         """Linux/container AMD installs still fail loud when no GPU is visible."""

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1207,6 +1207,49 @@ class TestServiceHealthReconciliation:
         assert statuses[0].status == "healthy"
         request.assert_not_awaited()
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "runtime_health,expected",
+        [
+            ({"status": "ok", "model_loaded": "model.gguf"}, "healthy"),
+            ({"status": "error", "model_loaded": "model.gguf"}, "down"),
+        ],
+    )
+    async def test_host_lemonade_requires_explicit_ok_status(
+        self, monkeypatch, runtime_health, expected,
+    ):
+        import helpers
+
+        services = {
+            "llama-server": {
+                "name": "LLM", "port": 8080, "external_port": 8080,
+                "type": "docker", "container_name": "ods-llama-server",
+            },
+        }
+        monkeypatch.setattr(helpers, "SERVICES", services)
+        monkeypatch.setattr(helpers, "LLM_BACKEND", "lemonade")
+        monkeypatch.setattr(
+            helpers, "read_live_env_value",
+            lambda key: "host" if key == "AMD_INFERENCE_LOCATION" else "",
+        )
+
+        async def probe(service_id, config):
+            return ServiceStatus(
+                id=service_id, name=config["name"], port=config["port"],
+                external_port=config["external_port"], status="down",
+            )
+
+        request = AsyncMock(side_effect=[
+            {"schema_version": "ods.host-service-health.v1", "containers": []},
+            {"schema_version": "ods.host-llm-status.v1", "health": runtime_health},
+        ])
+        monkeypatch.setattr(helpers, "check_service_health", probe)
+        monkeypatch.setattr(helpers, "request_agent_json", request)
+
+        statuses = await helpers.get_all_services()
+
+        assert statuses[0].status == expected
+
 
 # --- bootstrap status ETA edge cases ---
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -285,6 +285,37 @@ class TestUpdateLifetimeTokens:
         result = _update_lifetime_tokens(100.0)
         assert result == 100
 
+    @pytest.mark.parametrize("payload", [
+        [],
+        {"lifetime": "not-a-number", "last_server_counter": "bad"},
+        {"lifetime": -50, "last_server_counter": float("inf")},
+    ])
+    def test_normalizes_valid_json_with_invalid_counter_types(self, data_dir, payload):
+        token_file = data_dir / "token_counter.json"
+        token_file.write_text(json.dumps(payload))
+
+        assert _update_lifetime_tokens(25.0) == 25
+        assert _get_lifetime_tokens() == 25
+
+    def test_retries_transient_windows_replace_failure(self, data_dir, monkeypatch):
+        import helpers
+
+        real_replace = helpers.os.replace
+        calls = {"count": 0}
+
+        def transient_replace(source, destination):
+            calls["count"] += 1
+            if calls["count"] < 3:
+                raise PermissionError("temporarily locked")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(helpers.os, "replace", transient_replace)
+        monkeypatch.setattr(helpers.time, "sleep", lambda _seconds: None)
+
+        assert _update_lifetime_tokens(12.0) == 12
+        assert calls["count"] == 3
+        assert _get_lifetime_tokens() == 12
+
     def test_handles_unwritable_token_file(self, data_dir, monkeypatch):
         """When the token file cannot be written, should not raise."""
         import helpers
@@ -1051,23 +1082,8 @@ class TestGetLlamaMetricsTPS:
 
 
 class TestLemonadeMetrics:
-
-    def test_distinct_last_use_values_count_identical_completions(self, monkeypatch, tmp_path):
-        import helpers
-
-        monkeypatch.setattr(helpers, "_TOKEN_FILE", tmp_path / "token_counter.json")
-        first = {
-            "output_tokens": 7, "tokens_per_second": 42.0,
-            "input_tokens": 3, "last_use": "2026-07-20T22:00:00Z",
-        }
-        second = {**first, "last_use": "2026-07-20T22:01:00Z"}
-
-        assert helpers._update_lemonade_lifetime_tokens(first) == 7
-        assert helpers._update_lemonade_lifetime_tokens(first) == 7
-        assert helpers._update_lemonade_lifetime_tokens(second) == 14
-
     @pytest.mark.asyncio
-    async def test_host_stats_report_real_tps_and_count_each_completion_once(
+    async def test_host_stats_report_real_tps_and_latest_completion_tokens(
         self, monkeypatch, tmp_path,
     ):
         import helpers
@@ -1091,16 +1107,19 @@ class TestLemonadeMetrics:
         })
         monkeypatch.setattr(helpers, "request_agent_json", request)
 
-        first = await helpers.get_llama_metrics()
-        second = await helpers.get_llama_metrics()
+        result = await helpers.get_llama_metrics()
 
-        assert first == {"tokens_per_second": 188.5, "lifetime_tokens": 7}
-        assert second["lifetime_tokens"] == 7
-        assert json.loads(token_file.read_text())["lemonade_last_sample"]
-        assert not list(tmp_path.glob("*.tmp"))
+        assert result == {
+            "tokens_per_second": 188.5,
+            "lifetime_tokens": 7,
+            "token_count_mode": "latest_completion",
+        }
+        assert not token_file.exists()
 
     @pytest.mark.asyncio
-    async def test_unavailable_host_stats_preserve_lifetime(self, monkeypatch, tmp_path):
+    async def test_unavailable_host_stats_do_not_relabel_stale_llama_total(
+        self, monkeypatch, tmp_path,
+    ):
         import helpers
 
         token_file = tmp_path / "token_counter.json"
@@ -1115,7 +1134,11 @@ class TestLemonadeMetrics:
 
         result = await helpers.get_llama_metrics()
 
-        assert result == {"tokens_per_second": 0, "lifetime_tokens": 42}
+        assert result == {
+            "tokens_per_second": 0,
+            "lifetime_tokens": 0,
+            "token_count_mode": "unavailable",
+        }
 
     @pytest.mark.asyncio
     async def test_container_runtime_accepts_new_v1_stats_route(self, monkeypatch, tmp_path):
@@ -1147,7 +1170,11 @@ class TestLemonadeMetrics:
 
         result = await helpers.get_llama_metrics()
 
-        assert result == {"tokens_per_second": 33.3, "lifetime_tokens": 5}
+        assert result == {
+            "tokens_per_second": 33.3,
+            "lifetime_tokens": 5,
+            "token_count_mode": "latest_completion",
+        }
         assert [call.args[0] for call in client.get.await_args_list] == [
             "http://llama-server:8080/api/v1/stats",
             "http://llama-server:8080/v1/stats",

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1050,6 +1050,164 @@ class TestGetLlamaMetricsTPS:
         assert result["tokens_per_second"] == 20.0
 
 
+class TestLemonadeMetrics:
+
+    @pytest.mark.asyncio
+    async def test_host_stats_report_real_tps_and_count_each_completion_once(
+        self, monkeypatch, tmp_path,
+    ):
+        import helpers
+
+        token_file = tmp_path / "token_counter.json"
+        monkeypatch.setattr(helpers, "_TOKEN_FILE", token_file)
+        monkeypatch.setattr(helpers, "LLM_BACKEND", "lemonade")
+        monkeypatch.setattr(helpers, "read_live_env_value", lambda key: "host")
+        stats = {
+            "input_tokens": 24,
+            "output_tokens": 7,
+            "prompt_tokens": 24,
+            "decode_token_times": [0.01, 0.02],
+            "time_to_first_token": 0.04,
+            "tokens_per_second": 188.49,
+        }
+        request = AsyncMock(return_value={
+            "schema_version": "ods.host-llm-status.v1",
+            "health": {"status": "ok"},
+            "stats": stats,
+        })
+        monkeypatch.setattr(helpers, "request_agent_json", request)
+
+        first = await helpers.get_llama_metrics()
+        second = await helpers.get_llama_metrics()
+
+        assert first == {"tokens_per_second": 188.5, "lifetime_tokens": 7}
+        assert second["lifetime_tokens"] == 7
+        assert json.loads(token_file.read_text())["lemonade_last_sample"]
+        assert not list(tmp_path.glob("*.tmp"))
+
+    @pytest.mark.asyncio
+    async def test_unavailable_host_stats_preserve_lifetime(self, monkeypatch, tmp_path):
+        import helpers
+
+        token_file = tmp_path / "token_counter.json"
+        token_file.write_text(json.dumps({"lifetime": 42}))
+        monkeypatch.setattr(helpers, "_TOKEN_FILE", token_file)
+        monkeypatch.setattr(helpers, "LLM_BACKEND", "lemonade")
+        monkeypatch.setattr(helpers, "read_live_env_value", lambda key: "host")
+        monkeypatch.setattr(
+            helpers, "request_agent_json",
+            AsyncMock(return_value={"health": {"status": "ok"}, "stats": None}),
+        )
+
+        result = await helpers.get_llama_metrics()
+
+        assert result == {"tokens_per_second": 0, "lifetime_tokens": 42}
+
+    @pytest.mark.asyncio
+    async def test_container_runtime_accepts_new_v1_stats_route(self, monkeypatch, tmp_path):
+        import helpers
+
+        monkeypatch.setattr(helpers, "_TOKEN_FILE", tmp_path / "token_counter.json")
+        monkeypatch.setattr(helpers, "LLM_BACKEND", "lemonade")
+        monkeypatch.setattr(
+            helpers, "read_live_env_value",
+            lambda key: "container" if key == "AMD_INFERENCE_LOCATION" else "test-key",
+        )
+        monkeypatch.setattr(helpers, "SERVICES", {
+            "llama-server": {"host": "llama-server", "port": 8080},
+        })
+        legacy = MagicMock()
+        legacy.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "not found", request=MagicMock(), response=MagicMock(status_code=404),
+        )
+        current = MagicMock()
+        current.raise_for_status.return_value = None
+        current.json.return_value = {
+            "output_tokens": 5,
+            "tokens_per_second": 33.33,
+            "time_to_first_token": 0.2,
+        }
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=[legacy, current])
+        monkeypatch.setattr(helpers, "_get_httpx_client", AsyncMock(return_value=client))
+
+        result = await helpers.get_llama_metrics()
+
+        assert result == {"tokens_per_second": 33.3, "lifetime_tokens": 5}
+        assert [call.args[0] for call in client.get.await_args_list] == [
+            "http://llama-server:8080/api/v1/stats",
+            "http://llama-server:8080/v1/stats",
+        ]
+        assert all(
+            call.kwargs["headers"] == {"Authorization": "Bearer test-key"}
+            for call in client.get.await_args_list
+        )
+
+
+class TestServiceHealthReconciliation:
+
+    @pytest.mark.asyncio
+    async def test_docker_health_repairs_only_transient_timeout(self, monkeypatch):
+        import helpers
+
+        services = {
+            "dashboard": {
+                "name": "Dashboard", "port": 3001, "external_port": 3001,
+                "type": "docker", "container_name": "ods-dashboard",
+            },
+            "open-webui": {
+                "name": "Open WebUI", "port": 3000, "external_port": 3000,
+                "type": "docker", "container_name": "ods-open-webui",
+            },
+        }
+        monkeypatch.setattr(helpers, "SERVICES", services)
+
+        async def probe(service_id, config):
+            return ServiceStatus(
+                id=service_id, name=config["name"], port=config["port"],
+                external_port=config["external_port"],
+                status="degraded" if service_id == "dashboard" else "unhealthy",
+            )
+
+        monkeypatch.setattr(helpers, "check_service_health", probe)
+        monkeypatch.setattr(helpers, "LLM_BACKEND", "llama")
+        monkeypatch.setattr(helpers, "request_agent_json", AsyncMock(return_value={
+            "schema_version": "ods.host-service-health.v1",
+            "containers": [
+                {"service_id": "dashboard", "container_name": "ods-dashboard", "state": "running", "health": "healthy"},
+                {"service_id": "open-webui", "container_name": "ods-open-webui", "state": "running", "health": "healthy"},
+            ],
+        }))
+
+        statuses = {status.id: status.status for status in await helpers.get_all_services()}
+
+        assert statuses == {"dashboard": "healthy", "open-webui": "unhealthy"}
+
+    @pytest.mark.asyncio
+    async def test_all_healthy_path_does_not_call_host_agent(self, monkeypatch):
+        import helpers
+
+        services = {
+            "dashboard": {"name": "Dashboard", "port": 3001, "external_port": 3001},
+        }
+        monkeypatch.setattr(helpers, "SERVICES", services)
+
+        async def probe(service_id, config):
+            return ServiceStatus(
+                id=service_id, name=config["name"], port=config["port"],
+                external_port=config["external_port"], status="healthy",
+            )
+
+        request = AsyncMock()
+        monkeypatch.setattr(helpers, "check_service_health", probe)
+        monkeypatch.setattr(helpers, "request_agent_json", request)
+
+        statuses = await helpers.get_all_services()
+
+        assert statuses[0].status == "healthy"
+        request.assert_not_awaited()
+
+
 # --- bootstrap status ETA edge cases ---
 
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -610,6 +610,39 @@ class TestGetLlamaMetrics:
         result = await get_llama_metrics(model_hint="test-model")
         assert result["tokens_per_second"] == 0
 
+    @pytest.mark.asyncio
+    async def test_invalid_success_payload_does_not_reset_persistent_counter(
+        self, monkeypatch, tmp_path,
+    ):
+        import helpers
+
+        monkeypatch.setattr(
+            "helpers.SERVICES",
+            {"llama-server": {"host": "localhost", "port": 8080}},
+        )
+        monkeypatch.setattr(helpers, "_TOKEN_FILE", tmp_path / "token_counter.json")
+        helpers._prev_tokens.update(
+            {"count": 100, "time": helpers.time.time() - 1, "tps": 20.0, "gen_secs": 5.0},
+        )
+        assert helpers._update_lifetime_tokens(100) == 100
+
+        mock_response = MagicMock()
+        mock_response.text = "<html>proxy is starting</html>"
+        mock_response.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        result = await get_llama_metrics(model_hint="test-model")
+
+        assert result == {
+            "tokens_per_second": 0,
+            "lifetime_tokens": 100,
+            "token_count_mode": "cumulative",
+        }
+        assert helpers._get_lifetime_tokens() == 100
+        assert json.loads(helpers._TOKEN_FILE.read_text())["last_server_counter"] == 100
+
 
 # --- get_loaded_model ---
 
@@ -1079,6 +1112,45 @@ class TestGetLlamaMetricsTPS:
         result = await get_llama_metrics(model_hint="test")
         # 100 tokens / 5 seconds = 20.0 tps
         assert result["tokens_per_second"] == 20.0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("previous_count", "current_count"),
+        [(200, 200), (200, 25)],
+        ids=["idle", "server-counter-reset"],
+    )
+    async def test_idle_or_reset_counter_clears_stale_throughput(
+        self, monkeypatch, tmp_path, previous_count, current_count,
+    ):
+        import helpers
+
+        monkeypatch.setattr(
+            "helpers.SERVICES",
+            {"llama-server": {"host": "localhost", "port": 8080}},
+        )
+        monkeypatch.setattr(helpers, "_TOKEN_FILE", tmp_path / "token_counter.json")
+        helpers._prev_tokens.update(
+            {
+                "count": previous_count,
+                "time": helpers.time.time() - 1,
+                "tps": 42.0,
+                "gen_secs": 10.0,
+            },
+        )
+
+        mock_response = MagicMock()
+        mock_response.text = (
+            f"llamacpp_tokens_predicted_total {current_count}\n"
+            "llamacpp_tokens_predicted_seconds_total 10.0\n"
+        )
+        mock_response.raise_for_status.return_value = None
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+        monkeypatch.setattr("helpers._get_httpx_client", AsyncMock(return_value=mock_client))
+
+        result = await get_llama_metrics(model_hint="test")
+
+        assert result["tokens_per_second"] == 0.0
 
 
 class TestLemonadeMetrics:

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -1052,6 +1052,20 @@ class TestGetLlamaMetricsTPS:
 
 class TestLemonadeMetrics:
 
+    def test_distinct_last_use_values_count_identical_completions(self, monkeypatch, tmp_path):
+        import helpers
+
+        monkeypatch.setattr(helpers, "_TOKEN_FILE", tmp_path / "token_counter.json")
+        first = {
+            "output_tokens": 7, "tokens_per_second": 42.0,
+            "input_tokens": 3, "last_use": "2026-07-20T22:00:00Z",
+        }
+        second = {**first, "last_use": "2026-07-20T22:01:00Z"}
+
+        assert helpers._update_lemonade_lifetime_tokens(first) == 7
+        assert helpers._update_lemonade_lifetime_tokens(first) == 7
+        assert helpers._update_lemonade_lifetime_tokens(second) == 14
+
     @pytest.mark.asyncio
     async def test_host_stats_report_real_tps_and_count_each_completion_once(
         self, monkeypatch, tmp_path,

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5300,7 +5300,8 @@ class TestWindowsObservability:
             auth_headers.append(url.get_header("Authorization"))
             if requested_url.endswith("/health"):
                 return Response({
-                    "status": "ok", "version": "10.0.0", "model_loaded": "model",
+                    "status": "ok", "version": "10.0.0",
+                    "model_loaded": r"C:\Users\private\model.gguf",
                     "all_models_loaded": [{"checkpoint": r"C:\Users\private\model.gguf", "last_use": 123}],
                 })
             return Response({"output_tokens": 7, "tokens_per_second": 188.49})
@@ -5310,7 +5311,7 @@ class TestWindowsObservability:
         payload = _mod._windows_llm_status()
 
         assert payload["health"] == {
-            "status": "ok", "version": "10.0.0", "model_loaded": "model",
+            "status": "ok", "version": "10.0.0", "model_loaded": "model.gguf",
         }
         assert set(payload["stats"]) == {
             "time_to_first_token", "tokens_per_second", "input_tokens",

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5207,6 +5207,47 @@ class TestWindowsObservability:
 
         assert len(selected) == 2
 
+    def test_adapter_selection_infers_all_discrete_amd_without_persisted_count(
+        self, monkeypatch,
+    ):
+        monkeypatch.setattr(_mod, "GPU_BACKEND", "amd")
+        monkeypatch.setattr(_mod, "GPU_COUNT", "1")
+        adapters = [
+            {"name": "AMD Radeon RX 7900 XTX", "vendor_id": 0x1002, "memory_total_mb": 24560, "software": False},
+            {"name": "AMD Radeon RX 7900 XTX", "vendor_id": 0x1002, "memory_total_mb": 24560, "software": False},
+        ]
+
+        assert len(_mod._select_windows_gpu_adapters(adapters)) == 2
+
+    def test_adapter_selection_does_not_collapse_configured_dual_amd_without_count(
+        self, monkeypatch,
+    ):
+        monkeypatch.setattr(_mod, "GPU_BACKEND", "amd")
+        monkeypatch.setattr(_mod, "GPU_COUNT", "1")
+        adapters = [
+            {"name": "AMD Radeon RX 7900 XTX", "vendor_id": 0x1002, "memory_total_mb": 24560, "software": False},
+            {"name": "AMD Radeon RX 7800 XT", "vendor_id": 0x1002, "memory_total_mb": 16368, "software": False},
+        ]
+
+        selected = _mod._select_windows_gpu_adapters(adapters, "AMD Radeon RX 7900 XTX")
+
+        assert [item["name"] for item in selected] == [
+            "AMD Radeon RX 7900 XTX", "AMD Radeon RX 7800 XT",
+        ]
+
+    def test_adapter_selection_excludes_integrated_amd_when_discrete_exists(
+        self, monkeypatch,
+    ):
+        monkeypatch.setattr(_mod, "GPU_BACKEND", "amd")
+        adapters = [
+            {"name": "AMD Radeon Graphics", "vendor_id": 0x1002, "memory_total_mb": 512, "software": False},
+            {"name": "AMD Radeon RX 9070 XT", "vendor_id": 0x1002, "memory_total_mb": 16368, "software": False},
+        ]
+
+        selected = _mod._select_windows_gpu_adapters(adapters)
+
+        assert [item["name"] for item in selected] == ["AMD Radeon RX 9070 XT"]
+
     def test_windows_gpu_metrics_are_bounded_and_cached(self, tmp_path, monkeypatch):
         monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
         monkeypatch.setattr(_mod, "GPU_BACKEND", "amd")
@@ -5218,6 +5259,7 @@ class TestWindowsObservability:
         monkeypatch.setattr(_mod, "_windows_dxgi_adapters", lambda: [{
             "name": "AMD Radeon RX 9070 XT", "vendor_id": 0x1002,
             "memory_total_mb": 16368, "luid_high": 1, "luid_low": 2,
+            "shared_memory_total_mb": 16384,
             "software": False,
         }])
         calls = []
@@ -5226,7 +5268,14 @@ class TestWindowsObservability:
             calls.append(args[0])
             return types.SimpleNamespace(
                 returncode=0,
-                stdout=json.dumps({"utilization_percent": 140, "memory_used_bytes": 99 * 1024**3}),
+                stdout=json.dumps({"adapters": [{
+                    "prefix": "luid_0x00000001_0x00000002",
+                    "utilization_percent": 140,
+                    "utilization_available": True,
+                    "dedicated_used_bytes": 99 * 1024**3,
+                    "shared_used_bytes": 0,
+                    "memory_usage_available": True,
+                }]}),
                 stderr="",
             )
 
@@ -5239,7 +5288,42 @@ class TestWindowsObservability:
         assert first["utilization_percent"] == 100
         assert first["memory_used_mb"] == first["memory_total_mb"]
         assert first["temperature_available"] is False
+        assert first["gpus"][0]["uuid"] == "luid-00000001-00000002"
         assert len(calls) == 1
+
+    def test_windows_unified_gpu_uses_shared_memory_and_system_ram(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod, "GPU_BACKEND", "amd")
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        (tmp_path / ".env").write_text("SYSTEM_RAM_GB=128\n")
+        monkeypatch.setattr(_mod, "_windows_gpu_metrics_cache", (0.0, None))
+        monkeypatch.setattr(_mod, "_windows_dxgi_adapters_cache", (0.0, []))
+        monkeypatch.setattr(_mod, "_windows_dxgi_adapters", lambda: [{
+            "name": "AMD Radeon 8060S Graphics", "vendor_id": 0x1002,
+            "memory_total_mb": 2048, "shared_memory_total_mb": 65536,
+            "luid_high": 3, "luid_low": 4, "software": False,
+        }])
+        monkeypatch.setattr(_mod.subprocess, "run", lambda *args, **kwargs: types.SimpleNamespace(
+            returncode=0,
+            stdout=json.dumps({"adapters": [{
+                "prefix": "luid_0x00000003_0x00000004",
+                "utilization_percent": 61,
+                "utilization_available": True,
+                "dedicated_used_bytes": 1024 * 1024**2,
+                "shared_used_bytes": 8 * 1024**3,
+                "memory_usage_available": True,
+            }]}),
+            stderr="",
+        ))
+
+        payload = _mod._windows_gpu_metrics()
+
+        assert payload["memory_type"] == "unified"
+        assert payload["memory_total_mb"] == 96 * 1024
+        assert payload["memory_used_mb"] == 9 * 1024
+        assert payload["gpus"][0]["memory_type"] == "unified"
 
     def test_windows_llm_health_survives_optional_stats_failure(self, tmp_path, monkeypatch):
         monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
@@ -5255,7 +5339,7 @@ class TestWindowsObservability:
             def __exit__(self, *_args):
                 return False
 
-            def read(self):
+            def read(self, _size=-1):
                 return b'{"status":"ok","model_loaded":"test"}'
 
         def urlopen(url, timeout):
@@ -5292,7 +5376,7 @@ class TestWindowsObservability:
             def __exit__(self, *_args):
                 return False
 
-            def read(self):
+            def read(self, _size=-1):
                 return json.dumps(self.payload).encode("utf-8")
 
         def urlopen(url, timeout):
@@ -5315,13 +5399,12 @@ class TestWindowsObservability:
         }
         assert set(payload["stats"]) == {
             "time_to_first_token", "tokens_per_second", "input_tokens",
-            "output_tokens", "prompt_tokens", "sample_fingerprint",
+            "output_tokens", "prompt_tokens",
         }
-        assert len(payload["stats"]["sample_fingerprint"]) == 64
         assert "private" not in json.dumps(payload)
         assert auth_headers == ["Bearer secret-key", "Bearer secret-key"]
 
-    def test_windows_llm_sample_identity_ignores_unrelated_health_changes(
+    def test_windows_llm_stats_exclude_unrelated_health_fields(
         self, tmp_path, monkeypatch,
     ):
         monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
@@ -5339,7 +5422,7 @@ class TestWindowsObservability:
             def __exit__(self, *_args):
                 return False
 
-            def read(self):
+            def read(self, _size=-1):
                 return json.dumps(self.payload).encode("utf-8")
 
         def urlopen(url, timeout):
@@ -5359,7 +5442,27 @@ class TestWindowsObservability:
         monkeypatch.setattr(_mod, "_windows_llm_status_cache", (0.0, None))
         second = _mod._windows_llm_status()
 
-        assert first["stats"]["sample_fingerprint"] == second["stats"]["sample_fingerprint"]
+        assert first["stats"] == second["stats"]
+
+    def test_windows_llm_rejects_oversized_runtime_response(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        (tmp_path / ".env").write_text("AMD_INFERENCE_PORT=8080\n")
+        monkeypatch.setattr(_mod, "_windows_llm_status_cache", (0.0, None))
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self, size=-1):
+                return b"x" * size
+
+        monkeypatch.setattr(_mod.urllib_request, "urlopen", lambda *args, **kwargs: Response())
+
+        assert _mod._windows_llm_status() is None
 
 
 class TestDockerServiceHealthSnapshot:

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5178,3 +5178,224 @@ def test_read_json_body_rejects_non_object():
 def test_read_json_body_accepts_object():
     handler = _FakeHandler(b'{"a": 1}')
     assert _mod.read_json_body(handler) == {"a": 1}
+
+
+class TestWindowsObservability:
+
+    def test_adapter_selection_prefers_configured_discrete_amd(self, monkeypatch):
+        monkeypatch.setattr(_mod, "GPU_BACKEND", "amd")
+        monkeypatch.setattr(_mod, "GPU_COUNT", "1")
+        adapters = [
+            {"name": "AMD Radeon Graphics", "vendor_id": 0x1002, "memory_total_mb": 512, "software": False},
+            {"name": "Microsoft Basic Render Driver", "vendor_id": 0x1414, "memory_total_mb": 0, "software": True},
+            {"name": "AMD Radeon RX 9070 XT", "vendor_id": 0x1002, "memory_total_mb": 16368, "software": False},
+        ]
+
+        selected = _mod._select_windows_gpu_adapters(adapters, "Radeon RX 9070 XT")
+
+        assert [item["name"] for item in selected] == ["AMD Radeon RX 9070 XT"]
+
+    def test_adapter_selection_supports_identical_multi_gpu(self, monkeypatch):
+        monkeypatch.setattr(_mod, "GPU_BACKEND", "nvidia")
+        monkeypatch.setattr(_mod, "GPU_COUNT", "2")
+        adapters = [
+            {"name": "NVIDIA RTX PRO 6000", "vendor_id": 0x10DE, "memory_total_mb": 97887, "software": False},
+            {"name": "NVIDIA RTX PRO 6000", "vendor_id": 0x10DE, "memory_total_mb": 97887, "software": False},
+        ]
+
+        selected = _mod._select_windows_gpu_adapters(adapters, "RTX PRO 6000 \u00d7 2")
+
+        assert len(selected) == 2
+
+    def test_windows_gpu_metrics_are_bounded_and_cached(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod, "GPU_BACKEND", "amd")
+        monkeypatch.setattr(_mod, "GPU_COUNT", "1")
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        (tmp_path / ".env").write_text("HOST_GPU_NAME=AMD Radeon RX 9070 XT\n")
+        monkeypatch.setattr(_mod, "_windows_gpu_metrics_cache", (0.0, None))
+        monkeypatch.setattr(_mod, "_windows_dxgi_adapters_cache", (0.0, []))
+        monkeypatch.setattr(_mod, "_windows_dxgi_adapters", lambda: [{
+            "name": "AMD Radeon RX 9070 XT", "vendor_id": 0x1002,
+            "memory_total_mb": 16368, "luid_high": 1, "luid_low": 2,
+            "software": False,
+        }])
+        calls = []
+
+        def run(*args, **kwargs):
+            calls.append(args[0])
+            return types.SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"utilization_percent": 140, "memory_used_bytes": 99 * 1024**3}),
+                stderr="",
+            )
+
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+
+        first = _mod._windows_gpu_metrics()
+        second = _mod._windows_gpu_metrics()
+
+        assert first == second
+        assert first["utilization_percent"] == 100
+        assert first["memory_used_mb"] == first["memory_total_mb"]
+        assert first["temperature_available"] is False
+        assert len(calls) == 1
+
+    def test_windows_llm_health_survives_optional_stats_failure(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        (tmp_path / ".env").write_text("AMD_INFERENCE_PORT=99999\n")
+        monkeypatch.setattr(_mod, "_windows_llm_status_cache", (0.0, None))
+        requested = []
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'{"status":"ok","model_loaded":"test"}'
+
+        def urlopen(url, timeout):
+            requested_url = url.full_url if hasattr(url, "full_url") else str(url)
+            requested.append(requested_url)
+            if requested_url.endswith("/stats"):
+                raise _mod.urllib_error.URLError("not supported")
+            return Response()
+
+        monkeypatch.setattr(_mod.urllib_request, "urlopen", urlopen)
+
+        payload = _mod._windows_llm_status()
+
+        assert payload["health"]["status"] == "ok"
+        assert payload["stats"] is None
+        assert requested[0] == "http://127.0.0.1:8080/api/v1/health"
+
+    def test_windows_llm_status_redacts_runtime_paths(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        (tmp_path / ".env").write_text(
+            "AMD_INFERENCE_PORT=8080\nLEMONADE_API_KEY=secret-key\n"
+        )
+        monkeypatch.setattr(_mod, "_windows_llm_status_cache", (0.0, None))
+        auth_headers = []
+
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode("utf-8")
+
+        def urlopen(url, timeout):
+            requested_url = url.full_url if hasattr(url, "full_url") else str(url)
+            auth_headers.append(url.get_header("Authorization"))
+            if requested_url.endswith("/health"):
+                return Response({
+                    "status": "ok", "version": "10.0.0", "model_loaded": "model",
+                    "all_models_loaded": [{"checkpoint": r"C:\Users\private\model.gguf", "last_use": 123}],
+                })
+            return Response({"output_tokens": 7, "tokens_per_second": 188.49})
+
+        monkeypatch.setattr(_mod.urllib_request, "urlopen", urlopen)
+
+        payload = _mod._windows_llm_status()
+
+        assert payload["health"] == {
+            "status": "ok", "version": "10.0.0", "model_loaded": "model",
+        }
+        assert set(payload["stats"]) == {
+            "time_to_first_token", "tokens_per_second", "input_tokens",
+            "output_tokens", "prompt_tokens", "sample_fingerprint",
+        }
+        assert len(payload["stats"]["sample_fingerprint"]) == 64
+        assert "private" not in json.dumps(payload)
+        assert auth_headers == ["Bearer secret-key", "Bearer secret-key"]
+
+
+class TestDockerServiceHealthSnapshot:
+
+    def test_uses_compose_service_labels_and_caches_snapshot(self, monkeypatch):
+        monkeypatch.setattr(_mod, "_service_health_cache", (0.0, None))
+        calls = []
+
+        def run(cmd, **kwargs):
+            calls.append(cmd)
+            if cmd[1] == "ps":
+                return types.SimpleNamespace(returncode=0, stdout="ods-dashboard\n", stderr="")
+            return types.SimpleNamespace(returncode=0, stdout=json.dumps([{
+                "Name": "/ods-dashboard",
+                "State": {"Status": "running", "Health": {"Status": "healthy"}},
+                "Config": {"Labels": {"com.docker.compose.service": "dashboard"}},
+            }]), stderr="")
+
+        monkeypatch.setattr(_mod.subprocess, "run", run)
+
+        first = _mod._docker_service_health_snapshot()
+        second = _mod._docker_service_health_snapshot()
+
+        assert first == second
+        assert first["containers"] == [{
+            "service_id": "dashboard",
+            "container_name": "ods-dashboard",
+            "state": "running",
+            "health": "healthy",
+        }]
+        assert len(calls) == 2
+
+
+class TestObservabilityWire:
+
+    def test_read_only_endpoints_require_auth_and_return_versioned_contracts(
+        self, monkeypatch,
+    ):
+        import urllib.error
+        import urllib.request
+        from http.server import HTTPServer
+
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "wire-test-secret")
+        monkeypatch.setattr(_mod, "_windows_gpu_metrics", lambda: {
+            "schema_version": "ods.host-gpu-metrics.v1", "name": "GPU",
+        })
+        monkeypatch.setattr(_mod, "_windows_llm_status", lambda: {
+            "schema_version": "ods.host-llm-status.v1", "health": {"status": "ok"},
+        })
+        monkeypatch.setattr(_mod, "_docker_service_health_snapshot", lambda: {
+            "schema_version": "ods.host-service-health.v1", "containers": [],
+        })
+
+        server = HTTPServer(("127.0.0.1", 0), _mod.AgentHandler)
+        port = server.server_address[1]
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        try:
+            with pytest.raises(urllib.error.HTTPError) as denied:
+                urllib.request.urlopen(f"http://127.0.0.1:{port}/v1/gpu/metrics", timeout=2)
+            assert denied.value.code == 401
+
+            expected = {
+                "/v1/gpu/metrics": "ods.host-gpu-metrics.v1",
+                "/v1/llm/status": "ods.host-llm-status.v1",
+                "/v1/service/health": "ods.host-service-health.v1",
+            }
+            for path, schema_version in expected.items():
+                request = urllib.request.Request(
+                    f"http://127.0.0.1:{port}{path}",
+                    headers={"Authorization": "Bearer wire-test-secret"},
+                )
+                with urllib.request.urlopen(request, timeout=2) as response:
+                    payload = json.loads(response.read().decode("utf-8"))
+                assert response.status == 200
+                assert payload["schema_version"] == schema_version
+        finally:
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5320,6 +5320,46 @@ class TestWindowsObservability:
         assert "private" not in json.dumps(payload)
         assert auth_headers == ["Bearer secret-key", "Bearer secret-key"]
 
+    def test_windows_llm_sample_identity_ignores_unrelated_health_changes(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setattr(_mod.platform, "system", lambda: "Windows")
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        (tmp_path / ".env").write_text("AMD_INFERENCE_PORT=8080\n")
+        health_counter = iter((1, 2))
+
+        class Response:
+            def __init__(self, payload):
+                self.payload = payload
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return json.dumps(self.payload).encode("utf-8")
+
+        def urlopen(url, timeout):
+            if url.full_url.endswith("/health"):
+                return Response({
+                    "status": "ok", "model_loaded": "model",
+                    "unrelated_health_counter": next(health_counter),
+                })
+            return Response({
+                "output_tokens": 7, "tokens_per_second": 42.0,
+                "last_use": "2026-07-20T22:00:00Z",
+            })
+
+        monkeypatch.setattr(_mod.urllib_request, "urlopen", urlopen)
+        monkeypatch.setattr(_mod, "_windows_llm_status_cache", (0.0, None))
+        first = _mod._windows_llm_status()
+        monkeypatch.setattr(_mod, "_windows_llm_status_cache", (0.0, None))
+        second = _mod._windows_llm_status()
+
+        assert first["stats"]["sample_fingerprint"] == second["stats"]["sample_fingerprint"]
+
 
 class TestDockerServiceHealthSnapshot:
 

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -216,7 +216,11 @@ class TestBuildApiStatus:
         monkeypatch.setattr("main.get_model_info", lambda: ModelInfo(name="Test-32B", size_gb=16.0, context_length=32768))
         monkeypatch.setattr("main.get_bootstrap_status", lambda: BootstrapStatus(active=False))
         monkeypatch.setattr("main.get_loaded_model", AsyncMock(return_value="Test-32B"))
-        monkeypatch.setattr("main.get_llama_metrics", AsyncMock(return_value={"tokens_per_second": 25.5, "lifetime_tokens": 10000}))
+        monkeypatch.setattr("main.get_llama_metrics", AsyncMock(return_value={
+            "tokens_per_second": 25.5,
+            "lifetime_tokens": 10000,
+            "token_count_mode": "cumulative",
+        }))
         monkeypatch.setattr("main.get_llama_context_size", AsyncMock(return_value=32768))
         monkeypatch.setattr("main.get_uptime", lambda: 3600)
         monkeypatch.setattr("main.get_cpu_metrics", lambda: {"percent": 15.0, "temp_c": 55})
@@ -234,7 +238,27 @@ class TestBuildApiStatus:
         assert result["model"]["loadedModel"] == "Test-32B"
         assert result["model"]["configuredModel"] == "Test-32B"
         assert result["inference"]["tokensPerSecond"] == 25.5
+        assert result["inference"]["tokenCountMode"] == "cumulative"
         assert result["inference"]["loadedModel"] == "Test-32B"
+
+    def test_detected_gpu_count_overrides_stale_compose_default(self, monkeypatch):
+        from main import _serialize_gpu
+        from models import GPUInfo
+
+        monkeypatch.setenv("GPU_COUNT", "1")
+        gpu = GPUInfo(
+            name="AMD Radeon RX 7900 XTX + AMD Radeon RX 7800 XT",
+            memory_used_mb=8192,
+            memory_total_mb=40960,
+            memory_percent=20.0,
+            utilization_percent=40,
+            temperature_c=0,
+            gpu_backend="amd",
+            gpu_count=2,
+            temperature_available=False,
+        )
+
+        assert _serialize_gpu(gpu)["gpu_count"] == 2
 
     @pytest.mark.asyncio
     async def test_tier_professional(self, monkeypatch):

--- a/ods/extensions/services/dashboard-api/tests/test_main.py
+++ b/ods/extensions/services/dashboard-api/tests/test_main.py
@@ -1152,3 +1152,29 @@ class TestBuildApiStatusTiers:
         assert result["bootstrap"]["active"] is True
         assert result["bootstrap"]["model"] == "Qwen-32B"
         assert result["bootstrap"]["percent"] == 50.0
+
+
+def test_serialize_gpu_preserves_unavailable_sensor_state(monkeypatch):
+    import main
+    from models import GPUInfo
+
+    monkeypatch.setenv("GPU_COUNT", "1")
+    gpu = GPUInfo(
+        name="AMD Radeon RX 9070 XT",
+        memory_used_mb=0,
+        memory_total_mb=16368,
+        memory_percent=0,
+        utilization_percent=0,
+        temperature_c=0,
+        gpu_backend="amd",
+        memory_usage_available=False,
+        utilization_available=False,
+        temperature_available=False,
+    )
+
+    payload = main._serialize_gpu(gpu)
+
+    assert payload["vramTotal"] == 16.0
+    assert payload["vramUsed"] is None
+    assert payload["utilization"] is None
+    assert payload["temperature"] is None

--- a/ods/extensions/services/dashboard/src/components/GPUCard.jsx
+++ b/ods/extensions/services/dashboard/src/components/GPUCard.jsx
@@ -1,8 +1,10 @@
 import { memo } from 'react'
 import { Thermometer, Power, HardDrive, Activity } from 'lucide-react'
 
-function Bar({ percent, alert }) {
-  const color = alert
+function Bar({ percent, alert, available = true }) {
+  const color = !available
+    ? 'bg-zinc-700'
+    : alert
     ? 'bg-red-500'
     : percent > 90
       ? 'bg-red-500'
@@ -13,18 +15,23 @@ function Bar({ percent, alert }) {
     <div className="h-1 bg-zinc-700 rounded-full overflow-hidden mt-1">
       <div
         className={`h-full rounded-full transition-all ${color}`}
-        style={{ width: `${Math.min(percent, 100)}%` }}
+        style={{ width: available ? `${Math.min(percent, 100)}%` : '0%' }}
       />
     </div>
   )
 }
 
 export const GPUCard = memo(function GPUCard({ gpu }) {
+  const hasUtilization = gpu.utilization_available !== false
+  const hasMemoryUsage = gpu.memory_usage_available !== false
+  const hasTemperature = gpu.temperature_available !== false
   const vramPercent = gpu.memory_total_mb > 0
     ? (gpu.memory_used_mb / gpu.memory_total_mb) * 100
     : 0
-  const tempAlert = gpu.temperature_c >= 85
-  const tempColor = gpu.temperature_c >= 85
+  const tempAlert = hasTemperature && gpu.temperature_c >= 85
+  const tempColor = !hasTemperature
+    ? 'text-zinc-600'
+    : gpu.temperature_c >= 85
     ? 'text-red-400'
     : gpu.temperature_c >= 70
       ? 'text-yellow-400'
@@ -47,9 +54,9 @@ export const GPUCard = memo(function GPUCard({ gpu }) {
       <div className="mb-3">
         <div className="flex items-center justify-between text-xs text-zinc-400 mb-1">
           <span className="flex items-center gap-1"><Activity size={12} />Util</span>
-          <span className="font-mono text-white">{gpu.utilization_percent}%</span>
+          <span className="font-mono text-white">{hasUtilization ? `${gpu.utilization_percent}%` : '—'}</span>
         </div>
-        <Bar percent={gpu.utilization_percent} />
+        <Bar percent={gpu.utilization_percent} available={hasUtilization} />
       </div>
 
       {/* VRAM */}
@@ -57,17 +64,19 @@ export const GPUCard = memo(function GPUCard({ gpu }) {
         <div className="flex items-center justify-between text-xs text-zinc-400 mb-1">
           <span className="flex items-center gap-1"><HardDrive size={12} />VRAM</span>
           <span className="font-mono text-white">
-            {(gpu.memory_used_mb / 1024).toFixed(1)}/{(gpu.memory_total_mb / 1024).toFixed(0)} GB
+            {hasMemoryUsage
+              ? `${(gpu.memory_used_mb / 1024).toFixed(1)}/${(gpu.memory_total_mb / 1024).toFixed(0)} GB`
+              : gpu.memory_total_mb > 0 ? `—/${(gpu.memory_total_mb / 1024).toFixed(0)} GB` : '—'}
           </span>
         </div>
-        <Bar percent={vramPercent} />
+        <Bar percent={vramPercent} available={hasMemoryUsage} />
       </div>
 
       {/* Temp + Power */}
       <div className="flex items-center justify-between text-xs mt-3">
         <span className={`flex items-center gap-1 ${tempColor}`}>
           <Thermometer size={12} />
-          {gpu.temperature_c}°C{tempAlert ? ' !' : ''}
+          {hasTemperature ? `${gpu.temperature_c}°C${tempAlert ? ' !' : ''}` : '—'}
         </span>
         {gpu.power_w != null ? (
           <span className="flex items-center gap-1 text-zinc-400">

--- a/ods/extensions/services/dashboard/src/components/GPUCard.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/GPUCard.test.jsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react'
+import { render } from '../test/test-utils'
+import { GPUCard } from './GPUCard' // eslint-disable-line no-unused-vars
+
+describe('GPUCard sensor availability', () => {
+  it('does not present unavailable Windows counters as zero', () => {
+    render(<GPUCard gpu={{
+      index: 0,
+      uuid: 'amd-windows-host-0',
+      name: 'AMD Radeon RX 9070 XT',
+      memory_used_mb: 0,
+      memory_total_mb: 0,
+      memory_percent: 0,
+      utilization_percent: 0,
+      temperature_c: 0,
+      power_w: null,
+      assigned_services: ['llama-server'],
+      memory_usage_available: false,
+      utilization_available: false,
+      temperature_available: false,
+    }} />)
+
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3)
+    expect(screen.queryByText('0%')).not.toBeInTheDocument()
+    expect(screen.queryByText('0°C')).not.toBeInTheDocument()
+    expect(screen.getByText('llama-server')).toBeInTheDocument()
+  })
+
+  it('renders real counters when the host agent reports them', () => {
+    render(<GPUCard gpu={{
+      index: 0,
+      uuid: 'amd-windows-host-0',
+      name: 'AMD Radeon RX 9070 XT',
+      memory_used_mb: 4096,
+      memory_total_mb: 16384,
+      memory_percent: 25,
+      utilization_percent: 42,
+      temperature_c: 0,
+      power_w: null,
+      assigned_services: [],
+      memory_usage_available: true,
+      utilization_available: true,
+      temperature_available: false,
+    }} />)
+
+    expect(screen.getByText('42%')).toBeInTheDocument()
+    expect(screen.getByText('4.0/16 GB')).toBeInTheDocument()
+    expect(screen.queryByText('0°C')).not.toBeInTheDocument()
+  })
+})

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -327,7 +327,8 @@ function readOverviewHistory() {
     return parsed.filter(sample =>
       Number.isFinite(sample?.t) &&
       Number.isFinite(sample?.tokensPerSecond) &&
-      Number.isFinite(sample?.totalTokens)
+      Number.isFinite(sample?.totalTokens) &&
+      (!sample?.tokenCountMode || typeof sample.tokenCountMode === 'string')
     )
   } catch {
     return overviewMemoryHistory
@@ -371,8 +372,10 @@ function writeServiceCpuHistory(history) {
   }
 }
 
-function useOverviewHistory(tokensPerSecond, totalTokens) {
-  const [samples, setSamples] = useState(() => readOverviewHistory())
+function useOverviewHistory(tokensPerSecond, totalTokens, tokenCountMode = 'unavailable') {
+  const [samples, setSamples] = useState(() => readOverviewHistory().filter(sample =>
+    (sample.tokenCountMode || 'cumulative') === tokenCountMode
+  ))
 
   useEffect(() => {
     const now = Date.now()
@@ -380,11 +383,15 @@ function useOverviewHistory(tokensPerSecond, totalTokens) {
       t: now,
       tokensPerSecond: normalizeMetricNumber(tokensPerSecond),
       totalTokens: normalizeMetricNumber(totalTokens),
+      tokenCountMode,
     }
 
     setSamples(current => {
       const cutoff = now - OVERVIEW_RANGES[OVERVIEW_RANGES.length - 1].ms
-      const recent = current.filter(sample => sample.t >= cutoff)
+      const recent = current.filter(sample =>
+        sample.t >= cutoff &&
+        (sample.tokenCountMode || 'cumulative') === tokenCountMode
+      )
       const last = recent[recent.length - 1]
       if (
         last &&
@@ -399,7 +406,7 @@ function useOverviewHistory(tokensPerSecond, totalTokens) {
       writeOverviewHistory(next)
       return next
     })
-  }, [tokensPerSecond, totalTokens])
+  }, [tokensPerSecond, totalTokens, tokenCountMode])
 
   return samples
 }
@@ -884,6 +891,9 @@ export default function Dashboard({ status, loading }) {
         <SystemOverviewPanel
           tokensPerSecond={status?.inference?.tokensPerSecond || 0}
           totalTokens={status?.inference?.lifetimeTokens || 0}
+          tokenCountMode={status?.inference
+            ? status.inference.tokenCountMode || 'cumulative'
+            : 'unavailable'}
         />
         <SystemMetricsPanel metrics={systemMetrics} />
       </div>
@@ -972,10 +982,10 @@ const FeatureCard = memo(function FeatureCard({ icon: Icon, title, description, 
   return <Link to={href} className="block h-full liquid-metal-sequence-slot">{content}</Link>
 })
 
-const SystemOverviewPanel = memo(function SystemOverviewPanel({ tokensPerSecond, totalTokens }) {
+const SystemOverviewPanel = memo(function SystemOverviewPanel({ tokensPerSecond, totalTokens, tokenCountMode }) {
   const [rangeKey, setRangeKey] = useState('1H')
   const range = OVERVIEW_RANGES.find(item => item.key === rangeKey) || OVERVIEW_RANGES[0]
-  const history = useOverviewHistory(tokensPerSecond, totalTokens)
+  const history = useOverviewHistory(tokensPerSecond, totalTokens, tokenCountMode)
   const throughput = useMemo(
     () => buildOverviewSeries(history, range, 'tokensPerSecond'),
     [history, range]
@@ -1030,8 +1040,12 @@ const SystemOverviewPanel = memo(function SystemOverviewPanel({ tokensPerSecond,
         />
         <OverviewChart
           chartId="tokens-generated"
-          title="TOKENS GENERATED"
-          subtitle="Accumulated Output"
+          title={tokenCountMode === 'latest_completion' ? 'OUTPUT TOKENS' : 'TOKENS GENERATED'}
+          subtitle={tokenCountMode === 'latest_completion'
+            ? 'Latest Completion'
+            : tokenCountMode === 'cumulative'
+              ? 'Accumulated Output'
+              : 'Waiting for telemetry'}
           values={generated.values}
           timestamps={generated.timestamps}
           range={range}

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.jsx
@@ -719,19 +719,23 @@ export default function Dashboard({ status, loading }) {
         })
       }
     } else {
+      const hasLiveUtilization = Number.isFinite(status.gpu.utilization)
+      const hasLiveVramUsage = Number.isFinite(status.gpu.vramUsed)
       systemMetrics.push({
         icon: Activity,
         label: 'GPU',
-        value: `${status.gpu.utilization}%`,
+        value: hasLiveUtilization ? `${status.gpu.utilization}%` : '—',
         subvalue: status.gpu.name.replace('NVIDIA ', '').replace('AMD ', ''),
-        percent: status.gpu.utilization,
+        percent: hasLiveUtilization ? status.gpu.utilization : undefined,
       })
       systemMetrics.push({
         icon: HardDrive,
         label: 'VRAM',
-        value: `${status.gpu.vramUsed.toFixed(1)} GB`,
+        value: hasLiveVramUsage ? `${status.gpu.vramUsed.toFixed(1)} GB` : '—',
         subvalue: `of ${status.gpu.vramTotal} GB`,
-        percent: status.gpu.vramTotal > 0 ? (status.gpu.vramUsed / status.gpu.vramTotal) * 100 : 0,
+        percent: hasLiveVramUsage && status.gpu.vramTotal > 0
+          ? (status.gpu.vramUsed / status.gpu.vramTotal) * 100
+          : undefined,
       })
     }
   }

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -21,6 +21,7 @@ const baseStatus = {
   inference: {
     tokensPerSecond: 8,
     lifetimeTokens: 4500,
+    tokenCountMode: 'cumulative',
     contextSize: 32768,
     loadedModel: 'qwen',
   },
@@ -139,6 +140,48 @@ describe('Dashboard system overview', () => {
     expect(screen.getByText('Radeon RX 9070 XT')).toBeInTheDocument()
     expect(screen.getByText('of 16 GB')).toBeInTheDocument()
     expect(screen.queryByText('0%')).not.toBeInTheDocument()
+  })
+
+  it('labels Lemonade output as the latest completion instead of a cumulative total', async () => {
+    await renderDashboard({
+      ...baseStatus,
+      inference: {
+        ...baseStatus.inference,
+        lifetimeTokens: 36,
+        tokenCountMode: 'latest_completion',
+      },
+    })
+
+    expect(screen.getByText('OUTPUT TOKENS')).toBeInTheDocument()
+    expect(screen.getByText('Latest Completion')).toBeInTheDocument()
+    expect(screen.queryByText('Accumulated Output')).not.toBeInTheDocument()
+  })
+
+  it('does not mix cumulative history into latest-completion charts', async () => {
+    localStorage.setItem('ods-system-overview-history-v1', JSON.stringify([{
+      t: Date.now() - 1000,
+      tokensPerSecond: 20,
+      totalTokens: 900000,
+      tokenCountMode: 'cumulative',
+    }]))
+
+    await renderDashboard({
+      ...baseStatus,
+      inference: {
+        ...baseStatus.inference,
+        lifetimeTokens: 36,
+        tokenCountMode: 'latest_completion',
+      },
+    })
+
+    await waitFor(() => {
+      const stored = JSON.parse(localStorage.getItem('ods-system-overview-history-v1'))
+      expect(stored).toHaveLength(1)
+      expect(stored[0]).toMatchObject({
+        totalTokens: 36,
+        tokenCountMode: 'latest_completion',
+      })
+    })
   })
 
   it('does not render feature discovery suggestions as a dashboard home banner', async () => {

--- a/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Dashboard.test.jsx
@@ -122,6 +122,25 @@ describe('Dashboard system overview', () => {
     expect(screen.getByText('Accumulated Output')).toBeInTheDocument()
   })
 
+  it('renders unavailable host GPU counters as unavailable instead of zero', async () => {
+    await renderDashboard({
+      ...baseStatus,
+      gpu: {
+        name: 'AMD Radeon RX 9070 XT',
+        vramUsed: null,
+        vramTotal: 16,
+        utilization: null,
+        temperature: null,
+        memoryType: 'discrete',
+      },
+    })
+
+    expect(screen.getAllByText('—').length).toBeGreaterThanOrEqual(3)
+    expect(screen.getByText('Radeon RX 9070 XT')).toBeInTheDocument()
+    expect(screen.getByText('of 16 GB')).toBeInTheDocument()
+    expect(screen.queryByText('0%')).not.toBeInTheDocument()
+  })
+
   it('does not render feature discovery suggestions as a dashboard home banner', async () => {
     mockFeatureSuggestions = [{
       featureId: 'lan-web',

--- a/ods/extensions/services/dashboard/src/pages/GPUMonitor.jsx
+++ b/ods/extensions/services/dashboard/src/pages/GPUMonitor.jsx
@@ -82,19 +82,21 @@ export default function GPUMonitor() {
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <AggBar
               label="Avg Utilization"
-              value={`${aggregate.utilization_percent}%`}
-              percent={aggregate.utilization_percent}
+              value={aggregate.utilization_available !== false ? `${aggregate.utilization_percent}%` : '—'}
+              percent={aggregate.utilization_available !== false ? aggregate.utilization_percent : 0}
             />
             <AggBar
               label="Total VRAM"
-              value={`${(aggregate.memory_used_mb / 1024).toFixed(1)}/${(aggregate.memory_total_mb / 1024).toFixed(0)} GB`}
-              percent={aggregate.memory_percent}
+              value={aggregate.memory_usage_available !== false
+                ? `${(aggregate.memory_used_mb / 1024).toFixed(1)}/${(aggregate.memory_total_mb / 1024).toFixed(0)} GB`
+                : '—'}
+              percent={aggregate.memory_usage_available !== false ? aggregate.memory_percent : 0}
             />
             <div>
               <div className="flex items-center justify-between text-xs mb-1">
                 <span className="text-zinc-400">Max Temp</span>
-                <span className={`font-mono ${aggregate.temperature_c >= 85 ? 'text-red-400' : aggregate.temperature_c >= 70 ? 'text-yellow-400' : 'text-white'}`}>
-                  {aggregate.temperature_c}°C
+                <span className={`font-mono ${aggregate.temperature_available === false ? 'text-zinc-500' : aggregate.temperature_c >= 85 ? 'text-red-400' : aggregate.temperature_c >= 70 ? 'text-yellow-400' : 'text-white'}`}>
+                  {aggregate.temperature_available !== false ? `${aggregate.temperature_c}°C` : '—'}
                 </span>
               </div>
             </div>


### PR DESCRIPTION
## Summary  Fix dashboard runtime observability when inference runs on the host while the control plane runs in containers.  This change:  - adds authenticated, read-only host-agent contracts for GPU metrics, host LLM status, and Docker service health; - reports Windows AMD adapter identity, per-adapter memory, utilization, multi-GPU count, and unified-memory semantics from DXGI/CIM; - distinguishes cumulative llama.cpp counters from Lemonade's last-completion statistics instead of presenting a polling estimate as a lifetime total; - reconciles transient dashboard health timeouts with Docker's declared health without masking explicit HTTP failures or unhealthy/exited containers; - renders unavailable sensors as unavailable instead of presenting fabricated zero values; - uses one aggregate contract for the dashboard and detailed GPU route across Windows, Linux AMD, NVIDIA, and macOS; - hardens persisted counters against malformed state, invalid successful HTTP payloads, and transient Windows file locks; - bounds runtime telemetry responses and documents the versioned privacy boundary.  ## AI Assistance  AI-assisted code review, implementation analysis, and test drafting were used. The author reviewed the final diff and selected and ran the validation recorded below.  ## Release Lane  - [ ] Stable hotfix targeting `release/2.5.x` - [x] Mainline change targeting `main` - [ ] Next-minor work targeting the next feature/minor release - [ ] Not sure; reviewer should help classify  Stable hotfix reason:  ```text Not applicable. This PR targets main. ```  ## Changed Surface  - [ ] Docs only - [ ] Tests only - [x] Dashboard UI - [x] Dashboard API / host agent - [ ] Installer / bootstrap / lifecycle - [ ] Docker Compose / service manifests - [ ] Model routing / Hermes / capabilities - [x] Network exposure / auth / proxy - [ ] Dependencies / runtime wiring  ## Root Cause  | Symptom | Root cause | Resolution | | --- | --- | --- | | Healthy containers appeared degraded and core readiness temporarily dropped to 0/5 | Container-to-dashboard probes could time out during startup or load, but the API did not consult Docker's declared health | Reconcile only timeout-derived `degraded` states with an authenticated host Docker snapshot; explicit HTTP failures, connection failures, unhealthy containers, and exited containers remain failures | | Windows AMD identity, VRAM, and GPU count were missing or incorrect | Container telemetry cannot inspect host-native Windows adapters; historical Windows env files can omit `GPU_COUNT`; the detailed route reconstructed one synthetic GPU | Query DXGI adapters and CIM counters by LUID, preserve a per-adapter list, infer all discrete Radeon compute adapters, exclude a hybrid display iGPU, and carry observed count into both dashboard routes | | Unified AMD memory was reported as discrete VRAM | The Windows collector read dedicated usage only and the API hard-coded `memory_type=discrete` | Apply the installer's conservative integrated/unified classifier, include shared usage, and report the effective unified partition only when system RAM and adapter identity satisfy that contract | | System Overview stayed at zero or showed a misleading accumulated value while Lemonade generated tokens | The dashboard expected llama.cpp cumulative metrics, while Lemonade `/v1/stats` documents only the most recent request and provides no event sequence | Return real TPS and last-completion output with `tokenCountMode=latest_completion`; retain cumulative mode for llama.cpp and label each UI mode truthfully | | Unsupported sensors displayed `0` | The API/UI did not distinguish a real zero from unavailable telemetry | Propagate per-metric availability and render an em dash for unavailable values | | Persisted token state could fail on valid JSON with invalid types or a transient Windows file lock | Counter loading assumed a dictionary with numeric fields and atomic replace was attempted once | Normalize finite non-negative counters, reject incompatible state, and retry transient `PermissionError` during atomic replacement |
| A proxy HTML page or incomplete 200 response could reset the observed llama.cpp counter | HTTP success was accepted without proving that the Prometheus token counter was present | Require a successful status and a valid token counter before mutating persistent state; idle and reset samples clear stale live throughput |  ## Runtime Contract  The host agent exposes three versioned endpoints protected by the existing bearer token:  - `GET /v1/gpu/metrics` - `GET /v1/llm/status` - `GET /v1/service/health`  They are read-only. Windows host GPU and Lemonade collection is selected only when the live configuration declares `GPU_BACKEND=amd` and `AMD_INFERENCE_LOCATION=host`. Lemonade remains bound through its validated configured loopback port. Raw runtime responses, checkpoint paths, usernames, and local paths are not forwarded to the dashboard.  `ods.host-gpu-metrics.v1` keeps its aggregate top-level fields for compatibility and adds a bounded `gpus` list with stable LUID identity and per-adapter availability. Consumers that do not understand the list continue to read the aggregate. New consumers preserve multi-GPU identity.  Lemonade statistics are intentionally modeled as the latest completed request. The upstream endpoint does not expose a cumulative counter or stable request sequence, so this PR does not derive a false lifetime total by polling. llama.cpp continues to use its cumulative Prometheus counter.  Service health reconciliation is intentionally conservative:  - Docker `healthy` can promote only an HTTP timeout-derived `degraded` state; - it cannot promote `down`, an explicit unhealthy HTTP response, or a failed connection; - Docker `unhealthy`, `exited`, or `dead` can downgrade the dashboard state; - host-native Lemonade health applies only to the native llama service contract.  ## Platform Behavior  | Platform/runtime | Behavior after this change | | --- | --- | | Windows + host-native AMD/Lemonade | Uses authenticated per-adapter host telemetry for identity, dedicated/unified memory, utilization, count, LLM health, model, and last-request statistics | | Windows AMD hybrid | Excludes the integrated display adapter when discrete Radeon compute adapters are present | | Windows AMD multi-GPU | Preserves every detected discrete adapter even when historical `.env` files omit `GPU_COUNT` | | Linux + AMD | Keeps sysfs collection and uses the same aggregate builder for declared multi-GPU installs | | NVIDIA | Keeps `nvidia-smi` collection and carries observed multi-GPU count | | macOS | Keeps native/unified-memory collection with explicit availability | | Any platform with an unavailable sensor | Returns explicit availability metadata and renders no fabricated value |  Windows GPU temperature remains unavailable because Windows does not expose a reliable standard AMD temperature source through these APIs. The contract reports `null`/unavailable instead of inventing a value.  ## Risk And Validation  - Risk level: High - Validation run:   - [x] `git diff --check`   - [x] Markdown/schema sanity for docs   - [x] Focused and full tests listed below   - [x] Dashboard lint/test/build   - [ ] Extension audit / compose validation   - [x] Release-grade fleet or scoped hardware validation   - [ ] Stable-lane patch validation, if targeting `release/2.5.x`  Commands/results:  ```text python -m pytest ods/extensions/services/dashboard-api/tests -q 1730 passed, 2 skipped, 1 pre-existing AsyncMock warning  npm test -- --run 22 test files passed, 198 tests passed  npm run lint passed  npm run build passed  python -m ruff check ods/bin/ods-host-agent.py ods/extensions/services/dashboard-api --select E,F,W --ignore E501,E701,E731,E741,E402 passed  python -m py_compile ods/bin/ods-host-agent.py ods/extensions/services/dashboard-api/gpu.py ods/extensions/services/dashboard-api/helpers.py ods/extensions/services/dashboard-api/main.py ods/extensions/services/dashboard-api/models.py ods/extensions/services/dashboard-api/routers/gpu.py passed  git diff --check passed ```  The repository-wide mypy job is advisory (`continue-on-error`). A local run reports the existing type-check backlog; no new diagnostic points at the new telemetry/aggregation code.  ### Windows hardware receipt  Validated with the PR code on Windows 11, PowerShell 5.1, AMD Radeon RX 9070 XT, and host-native Lemonade:  ```text DXGI adapter: AMD Radeon RX 9070 XT Stable adapter id: luid-00000000-00015cfd Dedicated VRAM: 4638 MiB used / 16188 MiB total GPU utilization: 0% while idle (counter available) GPU temperature: unavailable (reported as unavailable, not zero) Lemonade health: ok Lemonade version: 10.0.0 Loaded model: extra.Qwen3.5-2B-Q4_K_M.gguf Last request throughput: 233.39120963834975 tokens/s Last request output: 132 tokens Docker service snapshot: 13 healthy / 13 discovered Sanitization: no username, checkpoint path, or raw runtime payload in the dashboard response ```  The same collector script was executed through `powershell.exe`, proving compatibility with the Windows PowerShell 5.1 operational path used by ODS. Linux, NVIDIA, and macOS hardware were not available locally; their paths are covered by regression tests and repository CI.  ## Security And Privacy  - all new host-agent routes require the existing bearer token; - collection is read-only and performs no host mutation; - Lemonade is queried only on a validated configured loopback port; - runtime telemetry bodies are bounded to 1 MiB before JSON parsing; - raw health/stats bodies and local model paths are not serialized to dashboard clients; - cached samples are lock-protected and bounded by short TTLs; - cumulative llama.cpp state is written atomically with malformed-state normalization and transient Windows lock retry.  ## Operational Change Check  If this PR touches installer phases, bootstrap logic, compose stack generation, service manifests, dashboard API control flows, Hermes, model routing, GPU or runtime detection, lifecycle commands, host mutation, or network exposure, it requires release-grade fleet validation before release unless the PR explains a narrower equivalent.  - [ ] This is not an operational change. - [x] This is an operational change and validation is recorded above. - [ ] This is an operational change and validation is intentionally deferred for:  ## Rollback  Revert the commits in this PR. The host-agent fields are additive, aggregate fields remain backward compatible, UI fields have compatibility defaults, and no installer, compose, model-routing, or persisted user configuration format is migrated.  ## Notes For Reviewers  Primary review boundaries:  1. conservative health-state promotion; 2. authenticated host-agent response schemas and 1 MiB response bound; 3. Windows hybrid/multi-GPU adapter selection and unified-memory classification; 4. truthful cumulative versus latest-completion token semantics; 5. availability propagation from collector to both dashboard views.