### PR TITLE
fix(model-router): bound SSE rewriter holdback buffer

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -59,6 +59,9 @@ PROBE_KEY_PATH: Path | None = (
 INSTANCE_ID = str(uuid.uuid4())
 
 MAX_BODY_BYTES = int(os.environ.get("ODS_ROUTER_MAX_BODY_BYTES", str(2 * 1024 * 1024)))
+# Bound the SSE rewriter's held-back partial event so a delimiter-less upstream
+# cannot grow it without limit (MAX_BODY_BYTES only guards the request body).
+MAX_SSE_HOLDBACK = int(os.environ.get("ODS_ROUTER_MAX_SSE_HOLDBACK_BYTES", str(1024 * 1024)))
 MAX_QUEUE_DEPTH = int(os.environ.get("ODS_ROUTER_MAX_QUEUE_DEPTH", "64"))
 QUEUE_WAIT_SECONDS = int(os.environ.get("ODS_ROUTER_QUEUE_WAIT_SECONDS", "60"))
 UPSTREAM_TIMEOUT_SECONDS = float(os.environ.get("ODS_ROUTER_UPSTREAM_TIMEOUT", "600"))
@@ -525,6 +528,13 @@ class _SSERewriter:
             rewritten, models = _rewrite_sse_event(event, self.alias)
             self.models.extend(models)
             output.append(rewritten + delimiter)
+        # A delimiter-less upstream must not grow the held-back partial event
+        # without bound. Flush it (best-effort rewrite, like finish()) and reset.
+        if len(self.buffer) > MAX_SSE_HOLDBACK:
+            rewritten, models = _rewrite_sse_event(self.buffer, self.alias)
+            self.models.extend(models)
+            output.append(rewritten)
+            self.buffer = b""
         return output
 
     def finish(self) -> bytes:

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -335,6 +335,19 @@ class TestForwarding:
         assert b"Concrete.gguf" not in raw
         assert raw.endswith(b"data: [DONE]\r\n\r\n")
 
+    def test_sse_holdback_is_bounded_without_delimiter(self, router):
+        mod, client, write_state, calls = router
+        # A delimiter-less upstream must not grow the rewriter's held-back
+        # partial event without bound; feed() flushes it once it exceeds
+        # MAX_SSE_HOLDBACK instead of buffering indefinitely.
+        rewriter = mod._SSERewriter("ods/current")
+        out = rewriter.feed(b"data: " + b"x" * (mod.MAX_SSE_HOLDBACK + 4096))
+        assert out, "oversized delimiter-less partial event should be flushed"
+        assert len(rewriter.buffer) <= mod.MAX_SSE_HOLDBACK
+        # framing still works after a forced flush
+        framed = b"".join(rewriter.feed(b"\n\ndata: [DONE]\n\n"))
+        assert b"data: [DONE]" in framed
+
     def test_stream_holds_admission_until_teardown(self, router, monkeypatch):
         mod, client, write_state, calls = router
         write_state()


### PR DESCRIPTION
## Fix-forward carry-over from #1914/#1931 review

`_SSERewriter.buffer` appended every streamed chunk but only trimmed it when an SSE delimiter matched. An upstream that streams **without a delimiter** grew the buffer without bound — `MAX_BODY_BYTES` only guards the inbound request body, not the rewriter's held-back partial event. (Flagged in the #1914 Claude-lane review; #1920 had bounded its holdback at 1MB.)

## Change
- New `MAX_SSE_HOLDBACK` (default 1MB, `ODS_ROUTER_MAX_SSE_HOLDBACK_BYTES`).
- `_SSERewriter.feed()` flushes the partial buffer via `_rewrite_sse_event` (same best-effort rewrite `finish()` does) once it exceeds the cap, then resets. Memory bounded; framing continues correctly afterward.
- Read-path only; no observe/legacy parity impact.

## Test
- `test_sse_holdback_is_bounded_without_delimiter`: a delimiter-less oversized chunk is flushed (not held), buffer stays ≤ cap, subsequent well-framed event still frames.
- Full router suite: **39 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)