### PR TITLE
fix(rag): synchronize bundled embedding model configuration

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -390,8 +390,17 @@ LANGFUSE_INIT_USER_PASSWORD=   # auto-generated during install
 # N8N_SECURE_COOKIE=auto        # false only for loopback HTTP; true for HTTPS/LAN
 # N8N_PROXY_HOPS=0              # set to the proxy count when using HTTPS ingress
 
-# Embedding model for RAG
+# Embedding model served by the bundled Hugging Face TEI runtime. Use a TEI-
+# compatible Hugging Face repository ID; GGUF/Q4 files are not supported here.
 # EMBEDDING_MODEL=BAAI/bge-base-en-v1.5
+# Open WebUI uses EMBEDDING_MODEL as its first-boot default. After first boot,
+# its Admin Panel value is persistent. Set this override only when the endpoint
+# points to a different embeddings provider/model.
+# RAG_EMBEDDING_MODEL=
+# RAG_OPENAI_API_BASE_URL=http://embeddings:80/v1
+# RAG_OPENAI_API_KEY=              # only for authenticated external providers
+# Larger models such as BAAI/bge-m3 may need a higher container memory limit.
+# EMBEDDINGS_MEMORY_LIMIT=4G
 
 # Image generation (ComfyUI + SDXL Lightning)
 # ENABLE_IMAGE_GENERATION=true

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -712,8 +712,28 @@
     },
     "EMBEDDING_MODEL": {
       "type": "string",
-      "description": "Embedding model for RAG",
+      "description": "Canonical Hugging Face model repository loaded by bundled TEI and used as the first-boot Open WebUI RAG default. Existing Open WebUI installs retain their Admin Panel value. GGUF/Q4 model files are not compatible with this runtime.",
       "default": "BAAI/bge-base-en-v1.5"
+    },
+    "RAG_EMBEDDING_MODEL": {
+      "type": "string",
+      "description": "Optional first-boot Open WebUI embedding-model override. Leave empty to use EMBEDDING_MODEL. Existing Open WebUI installs must also update the persistent Admin Panel value. Use a different model only with a matching external RAG_OPENAI_API_BASE_URL."
+    },
+    "RAG_OPENAI_API_BASE_URL": {
+      "type": "string",
+      "description": "OpenAI-compatible embeddings endpoint used by Open WebUI. Leave empty for the bundled TEI service."
+    },
+    "RAG_OPENAI_API_KEY": {
+      "type": "string",
+      "description": "Optional API key for an authenticated external OpenAI-compatible RAG embeddings endpoint.",
+      "secret": true,
+      "clearable": true
+    },
+    "EMBEDDINGS_MEMORY_LIMIT": {
+      "type": "string",
+      "description": "Docker memory limit for the bundled TEI embeddings service, for example 4G or 6G.",
+      "default": "4G",
+      "pattern": "^[1-9][0-9]*([bBkKmMgG]|[kKmMgG][bB])?$"
     },
     "EMBEDDING_URL": {
       "type": "string",

--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -121,7 +121,9 @@ services:
       # Otherwise Open WebUI downloads sentence-transformers/all-MiniLM-L6-v2
       # during app startup, which can block fresh installs before port 8080 binds.
       RAG_EMBEDDING_ENGINE: "${RAG_EMBEDDING_ENGINE:-openai}"
-      RAG_EMBEDDING_MODEL: "${RAG_EMBEDDING_MODEL:-BAAI/bge-base-en-v1.5}"
+      # Use the exact model served by bundled TEI as Open WebUI's first-boot
+      # default. Existing Open WebUI ConfigVars remain database-backed.
+      RAG_EMBEDDING_MODEL: "${RAG_EMBEDDING_MODEL:-${EMBEDDING_MODEL:-BAAI/bge-base-en-v1.5}}"
       RAG_OPENAI_API_BASE_URL: "${RAG_OPENAI_API_BASE_URL:-http://embeddings:80/v1}"
       RAG_OPENAI_API_KEY: "${RAG_OPENAI_API_KEY:-}"
       RAG_EMBEDDING_MODEL_AUTO_UPDATE: "${RAG_EMBEDDING_MODEL_AUTO_UPDATE:-false}"

--- a/ods/extensions/services/dashboard-api/main.py
+++ b/ods/extensions/services/dashboard-api/main.py
@@ -33,7 +33,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 # --- Local modules ---
 from config import (
-    SERVICES, DATA_DIR, INSTALL_DIR, SIDEBAR_ICONS, MANIFEST_ERRORS,
+    SERVICES, DATA_DIR, INSTALL_DIR, SIDEBAR_ICONS, MANIFEST_ERRORS, ALWAYS_ON_SERVICES,
     AGENT_HOST, AGENT_PORT, AGENT_URL, ODS_AGENT_KEY,
     _detect_container_default_gateway, _running_inside_container,
     _read_env_from_file,
@@ -837,6 +837,16 @@ def _clear_settings_caches():
         _cache.invalidate(key)
 
 
+def _active_settings_apply_services() -> set[str]:
+    active = set(ALWAYS_ON_SERVICES)
+    services_root = _resolve_install_root() / "extensions" / "services"
+    for service_id in _SETTINGS_APPLY_ALLOWED_SERVICES - active:
+        service_dir = services_root / service_id
+        if (service_dir / "compose.yaml").is_file() or (service_dir / "compose.yml").is_file():
+            active.add(service_id)
+    return active
+
+
 def _call_agent_core_recreate(service_ids: list[str]) -> dict[str, Any]:
     return request_agent_json(
         "POST",
@@ -928,6 +938,31 @@ def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]
         )
 
     base_fields = _build_env_fields(schema_properties, required_keys, current_values)
+    clear_secrets = payload.get("clearSecrets", [])
+    if not isinstance(clear_secrets, list) or any(not isinstance(key, str) for key in clear_secrets):
+        raise HTTPException(
+            status_code=400,
+            detail={"message": "clearSecrets must be a list of field names."},
+        )
+    clear_secrets = sorted(set(clear_secrets))
+    invalid_clear_secrets = [
+        key for key in clear_secrets
+        if key not in base_fields
+        or not base_fields[key].get("secret")
+        or not base_fields[key].get("clearable")
+    ]
+    if invalid_clear_secrets:
+        return _render_env_from_values(current_values), [
+            {
+                "key": key,
+                "message": "This secret cannot be cleared from the dashboard.",
+            }
+            for key in invalid_clear_secrets
+        ], _compute_env_apply_plan(
+            current_values,
+            current_values,
+            active_services=_active_settings_apply_services(),
+        )
     invalid_keys = sorted(set(submitted_values.keys()) - set(base_fields.keys()))
     if invalid_keys:
         return _render_env_from_values(current_values), [
@@ -936,7 +971,11 @@ def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]
                 "message": "Field is not editable from the dashboard. Only schema-backed fields and existing local overrides can be changed here.",
             }
             for key in invalid_keys
-        ], _compute_env_apply_plan(current_values, current_values)
+        ], _compute_env_apply_plan(
+            current_values,
+            current_values,
+            active_services=_active_settings_apply_services(),
+        )
 
     read_only_changes = []
     for key, submitted_value in submitted_values.items():
@@ -953,17 +992,27 @@ def _prepare_env_save(payload: dict[str, Any]) -> tuple[str, list[dict[str, Any]
         return (
             _render_env_from_values(current_values),
             read_only_changes,
-            _compute_env_apply_plan(current_values, current_values),
+            _compute_env_apply_plan(
+                current_values,
+                current_values,
+                active_services=_active_settings_apply_services(),
+            ),
         )
 
     normalized_values = _serialize_form_values(submitted_values, base_fields, current_values)
     merged_values = {**current_values, **normalized_values}
+    for key in clear_secrets:
+        merged_values.pop(key, None)
     for key, field in base_fields.items():
         if _empty_value_unsets_env_key(key, field) and str(merged_values.get(key, "")).strip() == "":
             merged_values.pop(key, None)
     merged_fields = _build_env_fields(schema_properties, required_keys, merged_values)
     issues = _validate_env_values(merged_values, merged_fields)
-    apply_plan = _compute_env_apply_plan(current_values, merged_values)
+    apply_plan = _compute_env_apply_plan(
+        current_values,
+        merged_values,
+        active_services=_active_settings_apply_services(),
+    )
     return _render_env_from_values(merged_values), issues, apply_plan
 
 # --- App ---

--- a/ods/extensions/services/dashboard-api/settings.py
+++ b/ods/extensions/services/dashboard-api/settings.py
@@ -9,6 +9,7 @@ remain in main.py so that test monkeypatches continue to intercept them.
 import re
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import urlsplit
 
 from fastapi import HTTPException
 
@@ -20,6 +21,10 @@ _ENV_ASSIGNMENT_RE = re.compile(r"^\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 _ENV_COMMENTED_ASSIGNMENT_RE = re.compile(r"^\s*#\s*([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
 _SENSITIVE_ENV_KEY_RE = re.compile(
     r"(SECRET|TOKEN|PASSWORD|(?:^|_)PASS(?:$|_)|API_KEY|PRIVATE_KEY|ENCRYPTION_KEY|(?:^|_)SALT(?:$|_))"
+)
+_GGUF_QUANTIZED_MODEL_RE = re.compile(
+    r"(?:^|[-_.])q[2-8](?:_[a-z0-9]+)*(?:$|[-_.])",
+    re.IGNORECASE,
 )
 
 # ── Apply-plan constants ───────────────────────────────────────────────────────
@@ -42,6 +47,7 @@ _OPEN_WEBUI_APPLY_KEYS = {
     "AUDIO_STT_OPENAI_API_BASE_URL", "AUDIO_STT_OPENAI_API_KEY",
     "AUDIO_STT_MODEL", "AUDIO_TTS_ENGINE", "AUDIO_TTS_OPENAI_API_BASE_URL",
     "AUDIO_TTS_OPENAI_API_KEY", "AUDIO_TTS_MODEL", "AUDIO_TTS_VOICE",
+    "RAG_EMBEDDING_MODEL", "RAG_OPENAI_API_BASE_URL", "RAG_OPENAI_API_KEY",
 }
 _TOKEN_SPY_APPLY_KEYS = {
     "TOKEN_SPY_URL", "TOKEN_SPY_API_KEY",
@@ -121,6 +127,36 @@ def _normalize_bool(value: Any) -> Optional[str]:
     return None
 
 
+def _is_unsupported_tei_model_id(value: Any) -> bool:
+    model_id = str(value).strip().lower()
+    artifact_name = model_id.rsplit("/", 1)[-1]
+    return (
+        "://" in model_id
+        or "gguf" in artifact_name
+        or "ggml" in artifact_name
+        or _GGUF_QUANTIZED_MODEL_RE.search(artifact_name) is not None
+    )
+
+
+def _is_valid_http_endpoint(value: Any) -> bool:
+    text = str(value).strip()
+    if not text or "\\" in text or any(character.isspace() for character in text):
+        return False
+    try:
+        parsed = urlsplit(text)
+        port = parsed.port
+    except ValueError:
+        return False
+    return (
+        parsed.scheme.lower() in {"http", "https"}
+        and parsed.hostname is not None
+        and parsed.username is None
+        and parsed.password is None
+        and parsed.fragment == ""
+        and (port is None or 1 <= port <= 65535)
+    )
+
+
 def _humanize_env_key(key: str) -> str:
     return key.replace("_", " ").title().replace("Llm", "LLM").replace("Api", "API").replace("Gpu", "GPU")
 
@@ -158,6 +194,7 @@ def _build_env_fields(
             "description": definition.get("description", ""),
             "required": key in required_keys,
             "secret": _is_secret_field(key, definition),
+            "clearable": bool(definition.get("clearable", False)),
             "enum": definition.get("enum", []),
             "default": definition.get("default"),
             "value": value,
@@ -178,6 +215,7 @@ def _build_env_fields(
             "description": "Local override not described by the built-in schema.",
             "required": False,
             "secret": _is_secret_field(key),
+            "clearable": False,
             "enum": [],
             "default": None,
             "value": value,
@@ -219,6 +257,49 @@ def _validate_env_values(
         elif field_type == "boolean":
             if _normalize_bool(value) is None:
                 issues.append({"key": key, "message": "Must be true or false."})
+
+        if key == "EMBEDDING_MODEL":
+            if _is_unsupported_tei_model_id(value):
+                issues.append({
+                    "key": key,
+                    "message": (
+                        "Bundled embeddings use Hugging Face TEI. Enter a compatible "
+                        "Hugging Face repository ID such as BAAI/bge-m3; URLs and "
+                        "GGUF/Q4 model artifacts are not supported by this runtime."
+                    ),
+                })
+        elif key == "EMBEDDINGS_MEMORY_LIMIT":
+            if not re.fullmatch(r"[1-9][0-9]*(?:[bBkKmMgG]|[kKmMgG][bB])?", str(value).strip()):
+                issues.append({
+                    "key": key,
+                    "message": "Must be a positive Docker memory value such as 4096M, 4G, or 6GB.",
+                })
+        elif key == "RAG_OPENAI_API_BASE_URL":
+            if not _is_valid_http_endpoint(value):
+                issues.append({
+                    "key": key,
+                    "message": "Must be an HTTP(S) OpenAI-compatible embeddings base URL.",
+                })
+
+    embedding_model = str(values.get("EMBEDDING_MODEL", "")).strip() or "BAAI/bge-base-en-v1.5"
+    rag_model = str(values.get("RAG_EMBEDDING_MODEL", "")).strip()
+    rag_base = str(values.get("RAG_OPENAI_API_BASE_URL", "")).strip().lower().rstrip("/")
+    bundled_rag_bases = {
+        "",
+        "http://embeddings:80/v1",
+        "http://embeddings/v1",
+        "http://ods-embeddings:80/v1",
+        "http://ods-embeddings/v1",
+    }
+    if rag_model and embedding_model and rag_base in bundled_rag_bases and rag_model != embedding_model:
+        issues.append({
+            "key": "RAG_EMBEDDING_MODEL",
+            "message": (
+                "Bundled TEI serves EMBEDDING_MODEL only. Leave this override empty "
+                "to inherit it, or set RAG_OPENAI_API_BASE_URL to the external "
+                "provider that serves this different model."
+            ),
+        })
 
     return issues
 
@@ -262,7 +343,10 @@ def _empty_value_unsets_env_key(key: str, field: dict[str, Any]) -> bool:
     """Return true when an empty form value should remove a runtime env key."""
     if field.get("required") or field.get("secret"):
         return False
-    return key.startswith("LLAMA_ARG_")
+    return key.startswith("LLAMA_ARG_") or key in {
+        "RAG_EMBEDDING_MODEL",
+        "RAG_OPENAI_API_BASE_URL",
+    }
 
 # ── Apply-plan helpers ─────────────────────────────────────────────────────────
 
@@ -299,6 +383,8 @@ def _match_apply_service(key: str) -> Optional[str]:
         return "openclaw"
     if key.startswith("COMFYUI_"):
         return "comfyui"
+    if key.startswith("RAG_"):
+        return "open-webui"
     if key.startswith("WHISPER_"):
         return "whisper"
     if key.startswith("QDRANT_"):
@@ -314,35 +400,73 @@ def _match_apply_service(key: str) -> Optional[str]:
     return None
 
 
-def _build_apply_summary(services: list[str], manual_keys: list[str]) -> str:
-    if services and manual_keys:
-        return (
-            f"Saved changes can be applied now to {', '.join(services)}. "
-            f"Other keys still need a broader manual restart: {', '.join(manual_keys)}."
-        )
+def _build_apply_summary(
+    services: list[str],
+    manual_keys: list[str],
+    inactive_services: Optional[list[str]] = None,
+) -> str:
+    inactive_services = inactive_services or []
+    parts: list[str] = []
     if services:
-        return f"Saved changes are ready to apply to {', '.join(services)}."
+        parts.append(f"Saved changes are ready to apply to {', '.join(services)}.")
     if manual_keys:
-        return (
-            "Saved changes were written to .env, but these keys still need a manual stack restart: "
-            + ", ".join(manual_keys)
+        parts.append(f"A manual stack restart is still required for: {', '.join(manual_keys)}.")
+    if inactive_services:
+        parts.append(
+            "Configuration was staged for disabled services and will apply when they are enabled: "
+            + ", ".join(inactive_services)
             + "."
         )
-    return "No service recreation is required for the saved keys."
+    return " ".join(parts) or "No service recreation is required for the saved keys."
 
 
-def _compute_env_apply_plan(previous_values: dict[str, str], next_values: dict[str, str]) -> dict[str, Any]:
+def _compute_env_apply_plan(
+    previous_values: dict[str, str],
+    next_values: dict[str, str],
+    active_services: Optional[set[str]] = None,
+) -> dict[str, Any]:
     changed_keys = sorted(
         key for key in set(previous_values) | set(next_values)
         if previous_values.get(key, "") != next_values.get(key, "")
     )
     services: set[str] = set()
+    inactive_services: set[str] = set()
     manual_keys: list[str] = []
+    rag_admin_sync_required = False
+    rag_reindex_required = False
+
+    next_rag_model = str(next_values.get("RAG_EMBEDDING_MODEL", "")).strip()
+    # Compose falls back to EMBEDDING_MODEL whenever RAG_EMBEDDING_MODEL is
+    # empty, regardless of whether the selected endpoint is bundled or external.
+    open_webui_inherits_embedding_model = not next_rag_model
+
+    def schedule(service_id: str) -> bool:
+        if active_services is None or service_id in active_services:
+            services.add(service_id)
+            return True
+        inactive_services.add(service_id)
+        return False
 
     for key in changed_keys:
+        if key == "EMBEDDING_MODEL":
+            schedule("embeddings")
+            if open_webui_inherits_embedding_model:
+                schedule("open-webui")
+                rag_admin_sync_required = True
+                rag_reindex_required = True
+            continue
+        if key in {"RAG_EMBEDDING_MODEL", "RAG_OPENAI_API_BASE_URL"}:
+            schedule("open-webui")
+            rag_admin_sync_required = True
+            rag_reindex_required = True
+            continue
+        if key == "RAG_OPENAI_API_KEY":
+            schedule("open-webui")
+            rag_admin_sync_required = True
+            continue
         service = _match_apply_service(key)
         if service and service in _SETTINGS_APPLY_ALLOWED_SERVICES:
-            services.add(service)
+            schedule(service)
             continue
         if key in _MANUAL_RESTART_KEYS or key.startswith("ODS_AGENT_"):
             manual_keys.append(key)
@@ -351,23 +475,53 @@ def _compute_env_apply_plan(previous_values: dict[str, str], next_values: dict[s
             manual_keys.append(key)
 
     services_list = sorted(services)
+    inactive_list = sorted(inactive_services)
     manual_list = sorted(set(manual_keys))
     if not changed_keys:
         status = "none"
-    elif services_list and manual_list:
+    elif services_list and (manual_list or inactive_list):
         status = "partial"
     elif services_list:
         status = "ready"
+    elif manual_list:
+        status = "manual"
+    elif inactive_list:
+        status = "staged"
     else:
         status = "manual"
+
+    post_apply_actions = []
+    if rag_admin_sync_required:
+        post_apply_actions.append({
+            "id": "open-webui-rag-sync",
+            "title": "Apply RAG settings in Open WebUI",
+            "message": (
+                "After Open WebUI is healthy, open Admin Panel / Settings / "
+                "Documents and set the embedding engine, endpoint, model, and "
+                "credential to the saved values. Open WebUI persists these settings "
+                "in its database after first boot."
+            ),
+        })
+    if rag_reindex_required:
+        post_apply_actions.append({
+            "id": "open-webui-rag-reindex",
+            "title": "Reindex Open WebUI knowledge bases",
+            "message": (
+                "Run Reindex after applying the new model or endpoint. Files attached "
+                "directly to old chats must be uploaded again because embeddings from "
+                "different models are not interchangeable."
+            ),
+        })
 
     return {
         "status": status,
         "changedKeys": changed_keys,
         "services": services_list,
+        "inactiveServices": inactive_list,
         "manualKeys": manual_list,
         "supported": bool(services_list),
-        "summary": _build_apply_summary(services_list, manual_list),
+        "summary": _build_apply_summary(services_list, manual_list, inactive_list),
+        "postApplyActions": post_apply_actions,
     }
 
 # ── Agent availability ─────────────────────────────────────────────────────────

--- a/ods/extensions/services/dashboard-api/tests/test_settings_env.py
+++ b/ods/extensions/services/dashboard-api/tests/test_settings_env.py
@@ -18,6 +18,7 @@ def settings_env_fixture(tmp_path, monkeypatch):
 
     env_path.write_text(
         "OPENAI_API_KEY=sk-live-secret\n"
+        "RAG_OPENAI_API_KEY=rag-live-secret\n"
         "LLM_BACKEND=local\n"
         "WEBUI_AUTH=true\n",
         encoding="utf-8",
@@ -28,6 +29,7 @@ def settings_env_fixture(tmp_path, monkeypatch):
         "# LLM Settings\n"
         "# ════════════════════════════════\n"
         "OPENAI_API_KEY=\n"
+        "RAG_OPENAI_API_KEY=\n"
         "LLM_BACKEND=local\n"
         "WEBUI_AUTH=true\n"
         "# LLAMA_ARG_N_CPU_MOE=25\n",
@@ -43,6 +45,12 @@ def settings_env_fixture(tmp_path, monkeypatch):
                         "type": "string",
                         "description": "Key used for cloud LLM providers.",
                         "secret": True,
+                    },
+                    "RAG_OPENAI_API_KEY": {
+                        "type": "string",
+                        "description": "Optional RAG provider credential.",
+                        "secret": True,
+                        "clearable": True,
                     },
                     "LLM_BACKEND": {
                         "type": "string",
@@ -209,6 +217,53 @@ def test_api_settings_env_preserves_existing_secret_when_blank(test_client, sett
     assert payload["backupPath"].startswith("data/config-backups/.env.backup.")
     assert payload["applyPlan"]["status"] == "ready"
     assert payload["applyPlan"]["services"] == ["llama-server", "open-webui"]
+
+
+def test_api_settings_env_explicitly_clears_clearable_rag_secret(test_client, settings_env_fixture):
+    env_path = settings_env_fixture["env_path"]
+
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {"RAG_OPENAI_API_KEY": ""},
+            "clearSecrets": ["RAG_OPENAI_API_KEY"],
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    updated_env = env_path.read_text(encoding="utf-8")
+    assert "RAG_OPENAI_API_KEY=\n" in updated_env
+    assert "RAG_OPENAI_API_KEY=rag-live-secret" not in updated_env
+    assert "OPENAI_API_KEY=sk-live-secret" in updated_env
+    assert payload["fields"]["RAG_OPENAI_API_KEY"]["hasValue"] is False
+    assert payload["applyPlan"]["services"] == ["open-webui"]
+    assert [action["id"] for action in payload["applyPlan"]["postApplyActions"]] == [
+        "open-webui-rag-sync",
+    ]
+
+
+def test_api_settings_env_rejects_clearing_non_clearable_secret(test_client, settings_env_fixture):
+    env_path = settings_env_fixture["env_path"]
+
+    response = test_client.put(
+        "/api/settings/env",
+        headers=test_client.auth_headers,
+        json={
+            "mode": "form",
+            "values": {"OPENAI_API_KEY": ""},
+            "clearSecrets": ["OPENAI_API_KEY"],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"]["issues"] == [{
+        "key": "OPENAI_API_KEY",
+        "message": "This secret cannot be cleared from the dashboard.",
+    }]
+    assert "OPENAI_API_KEY=sk-live-secret" in env_path.read_text(encoding="utf-8")
 
 
 def test_api_settings_env_rejects_raw_mode(test_client, settings_env_fixture):
@@ -465,6 +520,23 @@ def test_api_settings_env_apply_rejects_disallowed_service(test_client):
     assert "not eligible" in response.json()["detail"]["message"].lower()
 
 
+def test_active_settings_apply_services_excludes_disabled_compose(monkeypatch, tmp_path):
+    import main
+
+    install_root = tmp_path / "ods"
+    embeddings_dir = install_root / "extensions" / "services" / "embeddings"
+    embeddings_dir.mkdir(parents=True)
+    disabled = embeddings_dir / "compose.yaml.disabled"
+    disabled.write_text("services:\n  embeddings:\n    image: test\n", encoding="utf-8")
+    monkeypatch.setattr(main, "_resolve_install_root", lambda: install_root)
+    monkeypatch.setattr(main, "ALWAYS_ON_SERVICES", frozenset({"open-webui"}))
+
+    assert "embeddings" not in main._active_settings_apply_services()
+
+    disabled.rename(embeddings_dir / "compose.yaml")
+    assert "embeddings" in main._active_settings_apply_services()
+
+
 def test_check_host_agent_available_uses_shared_transport(monkeypatch):
     import settings
 
@@ -550,6 +622,306 @@ def test_settings_apply_plan_maps_agent_and_proxy_env_keys():
     assert plan["status"] == "ready"
     assert plan["services"] == ["ape", "ods-proxy", "openclaw"]
     assert plan["manualKeys"] == []
+
+
+def test_settings_apply_plan_recreates_bundled_embedding_consumers():
+    from settings import _compute_env_apply_plan
+
+    plan = _compute_env_apply_plan(
+        {"EMBEDDING_MODEL": "BAAI/bge-base-en-v1.5"},
+        {"EMBEDDING_MODEL": "BAAI/bge-m3"},
+    )
+
+    assert plan["status"] == "ready"
+    assert plan["services"] == ["embeddings", "open-webui"]
+    assert plan["manualKeys"] == []
+    assert [action["id"] for action in plan["postApplyActions"]] == [
+        "open-webui-rag-sync",
+        "open-webui-rag-reindex",
+    ]
+
+
+def test_settings_apply_plan_preserves_external_rag_override():
+    from settings import _compute_env_apply_plan
+
+    previous = {
+        "EMBEDDING_MODEL": "BAAI/bge-base-en-v1.5",
+        "RAG_EMBEDDING_MODEL": "external-v1",
+        "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v1",
+    }
+    updated = {**previous, "EMBEDDING_MODEL": "BAAI/bge-m3"}
+
+    plan = _compute_env_apply_plan(previous, updated)
+
+    assert plan["services"] == ["embeddings"]
+    assert plan["postApplyActions"] == []
+
+
+def test_settings_apply_plan_recreates_external_rag_consumer_when_model_is_inherited():
+    from settings import _compute_env_apply_plan
+
+    previous = {
+        "EMBEDDING_MODEL": "BAAI/bge-base-en-v1.5",
+        "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v1",
+    }
+    updated = {**previous, "EMBEDDING_MODEL": "BAAI/bge-m3"}
+
+    plan = _compute_env_apply_plan(previous, updated)
+
+    assert plan["services"] == ["embeddings", "open-webui"]
+    assert [action["id"] for action in plan["postApplyActions"]] == [
+        "open-webui-rag-sync",
+        "open-webui-rag-reindex",
+    ]
+
+
+def test_settings_apply_plan_updates_consumer_and_stages_disabled_embeddings():
+    from settings import _compute_env_apply_plan
+
+    previous = {"EMBEDDING_MODEL": "BAAI/bge-base-en-v1.5"}
+    updated = {"EMBEDDING_MODEL": "BAAI/bge-m3"}
+
+    plan = _compute_env_apply_plan(previous, updated, active_services={"open-webui"})
+
+    assert plan["status"] == "partial"
+    assert plan["services"] == ["open-webui"]
+    assert plan["inactiveServices"] == ["embeddings"]
+    assert [action["id"] for action in plan["postApplyActions"]] == [
+        "open-webui-rag-sync",
+        "open-webui-rag-reindex",
+    ]
+    assert "will apply when they are enabled: embeddings" in plan["summary"]
+
+
+def test_settings_apply_plan_updates_external_consumer_when_bundled_embeddings_are_disabled():
+    from settings import _compute_env_apply_plan
+
+    previous = {
+        "EMBEDDING_MODEL": "BAAI/bge-base-en-v1.5",
+        "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v1",
+    }
+    updated = {**previous, "EMBEDDING_MODEL": "BAAI/bge-m3"}
+
+    plan = _compute_env_apply_plan(previous, updated, active_services={"open-webui"})
+
+    assert plan["status"] == "partial"
+    assert plan["services"] == ["open-webui"]
+    assert plan["inactiveServices"] == ["embeddings"]
+    assert [action["id"] for action in plan["postApplyActions"]] == [
+        "open-webui-rag-sync",
+        "open-webui-rag-reindex",
+    ]
+
+
+def test_settings_apply_plan_reindexes_explicit_rag_provider_change():
+    from settings import _compute_env_apply_plan
+
+    previous = {
+        "RAG_EMBEDDING_MODEL": "external-v1",
+        "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v1",
+    }
+    updated = {
+        "RAG_EMBEDDING_MODEL": "external-v2",
+        "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v2",
+    }
+
+    plan = _compute_env_apply_plan(previous, updated)
+
+    assert plan["services"] == ["open-webui"]
+    assert [action["id"] for action in plan["postApplyActions"]] == [
+        "open-webui-rag-sync",
+        "open-webui-rag-reindex",
+    ]
+
+
+def test_settings_apply_plan_returns_to_bundled_rag_after_clearing_overrides():
+    from settings import _compute_env_apply_plan, _empty_value_unsets_env_key
+
+    previous = {
+        "EMBEDDING_MODEL": "BAAI/bge-m3",
+        "RAG_EMBEDDING_MODEL": "external-v2",
+        "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v1",
+    }
+    updated = {"EMBEDDING_MODEL": "BAAI/bge-m3"}
+
+    assert _empty_value_unsets_env_key("RAG_EMBEDDING_MODEL", {"type": "string"}) is True
+    assert _empty_value_unsets_env_key("RAG_OPENAI_API_BASE_URL", {"type": "string"}) is True
+    plan = _compute_env_apply_plan(previous, updated)
+
+    assert plan["services"] == ["open-webui"]
+    assert [action["id"] for action in plan["postApplyActions"]] == [
+        "open-webui-rag-sync",
+        "open-webui-rag-reindex",
+    ]
+
+
+def test_settings_apply_plan_syncs_rag_credential_without_reindex():
+    from settings import _compute_env_apply_plan
+
+    plan = _compute_env_apply_plan(
+        {"RAG_OPENAI_API_KEY": "old-secret"},
+        {"RAG_OPENAI_API_KEY": "new-secret"},
+    )
+
+    assert plan["services"] == ["open-webui"]
+    assert [action["id"] for action in plan["postApplyActions"]] == [
+        "open-webui-rag-sync",
+    ]
+
+
+def test_settings_validation_rejects_gguf_embedding_artifact():
+    from settings import _build_env_fields, _validate_env_values
+
+    values = {"EMBEDDING_MODEL": "someone/bge-m3-Q4_K_M-GGUF"}
+    fields = _build_env_fields(
+        {"EMBEDDING_MODEL": {"type": "string"}}, set(), values,
+    )
+
+    issues = _validate_env_values(values, fields)
+
+    assert issues[0]["key"] == "EMBEDDING_MODEL"
+    assert "GGUF/Q4" in issues[0]["message"]
+
+
+def test_settings_validation_rejects_invalid_embeddings_memory_limit():
+    from settings import _build_env_fields, _validate_env_values
+
+    values = {"EMBEDDINGS_MEMORY_LIMIT": "lots"}
+    fields = _build_env_fields(
+        {"EMBEDDINGS_MEMORY_LIMIT": {"type": "string"}}, set(), values,
+    )
+
+    issues = _validate_env_values(values, fields)
+
+    assert issues == [{
+        "key": "EMBEDDINGS_MEMORY_LIMIT",
+        "message": "Must be a positive Docker memory value such as 4096M, 4G, or 6GB.",
+    }]
+
+
+def test_settings_validation_accepts_compose_memory_units():
+    from settings import _build_env_fields, _validate_env_values
+
+    for value in ("4096M", "4G", "6GB", "4294967296"):
+        values = {"EMBEDDINGS_MEMORY_LIMIT": value}
+        fields = _build_env_fields(
+            {"EMBEDDINGS_MEMORY_LIMIT": {"type": "string"}}, set(), values,
+        )
+        assert _validate_env_values(values, fields) == []
+
+
+def test_settings_validation_rejects_invalid_rag_base_url():
+    from settings import _build_env_fields, _validate_env_values
+
+    values = {"RAG_OPENAI_API_BASE_URL": "embeddings:80/v1"}
+    fields = _build_env_fields(
+        {"RAG_OPENAI_API_BASE_URL": {"type": "string"}}, set(), values,
+    )
+
+    assert _validate_env_values(values, fields) == [{
+        "key": "RAG_OPENAI_API_BASE_URL",
+        "message": "Must be an HTTP(S) OpenAI-compatible embeddings base URL.",
+    }]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://",
+        "https://:443/v1",
+        "https://example.test:70000/v1",
+        "https://user:secret@example.test/v1",
+        "https://example.test/v1#fragment",
+        "https://example.test\\v1",
+        "https://example.test:999999999999999999999/v1",
+    ],
+)
+def test_settings_validation_rejects_malformed_rag_endpoints(value):
+    from settings import _validate_env_values
+
+    assert _validate_env_values(
+        {"RAG_OPENAI_API_BASE_URL": value},
+        {"RAG_OPENAI_API_BASE_URL": {"type": "string"}},
+    ) == [{
+        "key": "RAG_OPENAI_API_BASE_URL",
+        "message": "Must be an HTTP(S) OpenAI-compatible embeddings base URL.",
+    }]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "http://embeddings:80/v1",
+        "https://embeddings.example.test/v1?tenant=ods",
+        "http://127.0.0.1:8090/v1",
+        "http://[::1]:8090/v1",
+    ],
+)
+def test_settings_validation_accepts_well_formed_rag_endpoints(value):
+    from settings import _validate_env_values
+
+    assert _validate_env_values(
+        {"RAG_OPENAI_API_BASE_URL": value},
+        {"RAG_OPENAI_API_BASE_URL": {"type": "string"}},
+    ) == []
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "someone/bge-m3-Q4_K_M",
+        "someone/bge-m3-q8_0",
+        "someone/bge-m3-GGML",
+    ],
+)
+def test_settings_validation_rejects_quantized_embedding_artifact_names(value):
+    from settings import _validate_env_values
+
+    issues = _validate_env_values(
+        {"EMBEDDING_MODEL": value},
+        {"EMBEDDING_MODEL": {"type": "string"}},
+    )
+
+    assert issues and issues[0]["key"] == "EMBEDDING_MODEL"
+
+
+def test_settings_validation_rejects_bundled_model_mismatch():
+    from settings import _build_env_fields, _validate_env_values
+
+    values = {
+        "EMBEDDING_MODEL": "BAAI/bge-m3",
+        "RAG_EMBEDDING_MODEL": "BAAI/bge-base-en-v1.5",
+        "RAG_OPENAI_API_BASE_URL": "http://embeddings:80/v1",
+    }
+    fields = _build_env_fields(
+        {key: {"type": "string"} for key in values}, set(), values,
+    )
+
+    issues = _validate_env_values(values, fields)
+
+    assert issues == [{
+        "key": "RAG_EMBEDDING_MODEL",
+        "message": (
+            "Bundled TEI serves EMBEDDING_MODEL only. Leave this override empty "
+            "to inherit it, or set RAG_OPENAI_API_BASE_URL to the external "
+            "provider that serves this different model."
+        ),
+    }]
+
+
+def test_settings_validation_allows_external_model_override():
+    from settings import _build_env_fields, _validate_env_values
+
+    values = {
+        "EMBEDDING_MODEL": "BAAI/bge-m3",
+        "RAG_EMBEDDING_MODEL": "external-v2",
+        "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v1",
+    }
+    fields = _build_env_fields(
+        {key: {"type": "string"} for key in values}, set(), values,
+    )
+
+    assert _validate_env_values(values, fields) == []
 
 
 # --- Render round-trip fidelity ---
@@ -661,6 +1033,7 @@ def test_render_env_preserves_commented_key_absent_from_values(commented_example
         "LIVEKIT_API_KEY",
         "AUDIO_STT_OPENAI_API_KEY",
         "AUDIO_TTS_OPENAI_API_KEY",
+        "RAG_OPENAI_API_KEY",
     ],
 )
 def test_production_schema_marks_provider_api_keys_secret(key):
@@ -677,6 +1050,18 @@ def test_production_schema_marks_provider_api_keys_secret(key):
     entry = schema["properties"].get(key)
     assert entry is not None, f"schema missing entry for {key}"
     assert entry.get("secret") is True, f"{key} must have 'secret': true in .env.schema.json"
+
+
+def test_production_schema_only_allows_explicit_rag_secret_removal():
+    import pathlib
+
+    schema_path = pathlib.Path(__file__).resolve().parents[4] / ".env.schema.json"
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    clearable = {
+        key for key, definition in schema["properties"].items()
+        if definition.get("clearable") is True
+    }
+    assert clearable == {"RAG_OPENAI_API_KEY"}
 
 
 def test_env_example_keys_are_present_in_schema():

--- a/ods/extensions/services/dashboard/src/components/__tests__/EnvEditor.test.jsx
+++ b/ods/extensions/services/dashboard/src/components/__tests__/EnvEditor.test.jsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react'
+import { fireEvent, screen } from '@testing-library/react'
 import { render } from '../../test/test-utils'
 import EnvEditor from '../settings/EnvEditor' // eslint-disable-line no-unused-vars
 
@@ -79,6 +79,47 @@ describe('EnvEditor', () => {
     expect(screen.getByText(/Enter a value to store this secret/i)).toBeInTheDocument()
   })
 
+  test('requires an explicit action to clear a clearable stored secret', () => {
+    let clearRequested = false
+    renderEditor({
+      fields: {
+        RAG_OPENAI_API_KEY: {
+          ...baseFields.OPENAI_API_KEY,
+          key: 'RAG_OPENAI_API_KEY',
+          label: 'RAG OpenAI API Key',
+          clearable: true,
+        },
+      },
+      values: { RAG_OPENAI_API_KEY: '' },
+      sections: [{ id: 'rag', title: 'RAG', keys: ['RAG_OPENAI_API_KEY'] }],
+      activeSection: { id: 'rag', title: 'RAG', keys: ['RAG_OPENAI_API_KEY'] },
+      onClearSecret: () => { clearRequested = true },
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear stored secret' }))
+    expect(clearRequested).toBe(true)
+  })
+
+  test('shows pending secret removal and lets the operator undo it', () => {
+    renderEditor({
+      fields: {
+        RAG_OPENAI_API_KEY: {
+          ...baseFields.OPENAI_API_KEY,
+          key: 'RAG_OPENAI_API_KEY',
+          label: 'RAG OpenAI API Key',
+          clearable: true,
+        },
+      },
+      values: { RAG_OPENAI_API_KEY: '' },
+      sections: [{ id: 'rag', title: 'RAG', keys: ['RAG_OPENAI_API_KEY'] }],
+      activeSection: { id: 'rag', title: 'RAG', keys: ['RAG_OPENAI_API_KEY'] },
+      clearedSecrets: ['RAG_OPENAI_API_KEY'],
+    })
+
+    expect(screen.getByText(/will be removed when you save/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Keep stored secret' })).toBeEnabled()
+  })
+
   test('enables apply button when a saved runtime change can be applied', () => {
     renderEditor({
       applyPlan: {
@@ -92,6 +133,44 @@ describe('EnvEditor', () => {
     expect(screen.getByRole('button', { name: /apply changes/i })).toBeEnabled()
     expect(screen.getByText(/Pending runtime changes/i)).toBeInTheDocument()
     expect(screen.getAllByText(/llama-server/i).length).toBeGreaterThan(0)
+  })
+
+  test('renders required RAG reindex action after an embedding model change', () => {
+    renderEditor({
+      applyPlan: {
+        status: 'ready',
+        supported: true,
+        services: ['embeddings', 'open-webui'],
+        summary: 'Saved changes are ready to apply to embeddings, open-webui.',
+        postApplyActions: [{
+          id: 'open-webui-rag-reindex',
+          title: 'Reindex Open WebUI knowledge bases',
+          message: 'Confirm the embedding model and run Reindex.',
+        }],
+      },
+    })
+
+    expect(screen.getByText('Reindex Open WebUI knowledge bases')).toBeInTheDocument()
+    expect(screen.getByText(/Confirm the embedding model and run Reindex/i)).toBeInTheDocument()
+  })
+
+  test('keeps RAG actions visible as required follow-up after apply', () => {
+    renderEditor({
+      followUpPlan: {
+        status: 'post-apply',
+        summary: 'Runtime changes were applied. Complete the required follow-up below.',
+        postApplyActions: [{
+          id: 'open-webui-rag-sync',
+          title: 'Apply RAG settings in Open WebUI',
+          message: 'Set the saved values in the Open WebUI Admin Panel.',
+        }],
+      },
+    })
+
+    expect(screen.getByText('Required follow-up')).toBeInTheDocument()
+    expect(screen.getByText('Apply RAG settings in Open WebUI')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Mark complete' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Apply changes' })).toBeDisabled()
   })
 
   test('renders runtime-managed fields as read only', () => {

--- a/ods/extensions/services/dashboard/src/components/settings/EnvEditor.jsx
+++ b/ods/extensions/services/dashboard/src/components/settings/EnvEditor.jsx
@@ -1,4 +1,4 @@
-import { Search, RefreshCw, Save, Eye, EyeOff } from 'lucide-react'
+import { Search, RefreshCw, Save, Eye, EyeOff, Check, Trash2, Undo2 } from 'lucide-react'
 
 export default function EnvEditor({
   editor,
@@ -12,7 +12,9 @@ export default function EnvEditor({
   issues,
   issueMap,
   revealedSecrets,
+  clearedSecrets = [],
   onToggleReveal,
+  onClearSecret = () => {},
   onFieldChange,
   onReload,
   onSave,
@@ -20,6 +22,8 @@ export default function EnvEditor({
   dirty,
   saving,
   applyPlan = null,
+  followUpPlan = null,
+  onCompleteFollowUp = () => {},
   applying = false,
 }) {
   const activeKeys = activeSection?.keys || []
@@ -63,8 +67,36 @@ export default function EnvEditor({
 
       {applyPlan?.status && applyPlan.status !== 'none' ? (
         <div className="rounded-xl border border-theme-accent/20 bg-theme-accent/10 px-4 py-3">
-          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-theme-accent-light">Pending runtime changes</p>
+          <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-theme-accent-light">
+            {applyPlan.status === 'post-apply' ? 'Required follow-up' : 'Pending runtime changes'}
+          </p>
           <p className="mt-1 text-sm text-theme-text">{applyPlan.summary}</p>
+          {applyPlan.postApplyActions?.map((action) => (
+            <div key={action.id} className="mt-3 border-t border-theme-accent/15 pt-3">
+              <p className="text-xs font-semibold text-theme-text">{action.title}</p>
+              <p className="mt-1 text-xs text-theme-text-muted">{action.message}</p>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {followUpPlan ? (
+        <div className="rounded-xl border border-theme-accent/20 bg-theme-accent/10 px-4 py-3">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-theme-accent-light">
+                Required follow-up
+              </p>
+              <p className="mt-1 text-sm text-theme-text">{followUpPlan.summary}</p>
+            </div>
+            <ToolbarButton icon={Check} label="Mark complete" onClick={onCompleteFollowUp} />
+          </div>
+          {followUpPlan.postApplyActions?.map((action) => (
+            <div key={action.id} className="mt-3 border-t border-theme-accent/15 pt-3">
+              <p className="text-xs font-semibold text-theme-text">{action.title}</p>
+              <p className="mt-1 text-xs text-theme-text-muted">{action.message}</p>
+            </div>
+          ))}
         </div>
       ) : null}
 
@@ -162,7 +194,9 @@ export default function EnvEditor({
                       value={values[key] ?? ''}
                       issues={issueMap[key] || []}
                       revealed={Boolean(revealedSecrets[key])}
+                      cleared={clearedSecrets.includes(key)}
                       onToggleReveal={() => onToggleReveal(key)}
+                      onClearSecret={() => onClearSecret(key)}
                       onChange={(value) => onFieldChange(key, value)}
                     />
                   ))}
@@ -213,7 +247,7 @@ function Hint({ title, text }) {
   )
 }
 
-function FieldCard({ field, value, issues, revealed, onToggleReveal, onChange }) {
+function FieldCard({ field, value, issues, revealed, cleared, onToggleReveal, onClearSecret, onChange }) {
   const hasIssues = issues.length > 0
   const isEnum = Array.isArray(field?.enum) && field.enum.length > 0
   const isBoolean = field?.type === 'boolean'
@@ -297,9 +331,18 @@ function FieldCard({ field, value, issues, revealed, onToggleReveal, onChange })
       ) : null}
 
       {field?.secret ? (
-        <p className="mt-2 text-[11px] text-theme-text-muted">
-          {field?.hasValue ? 'Leave blank to keep the stored secret. Enter a new value to replace it.' : 'Enter a value to store this secret.'}
-        </p>
+        <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+          <p className="text-[11px] text-theme-text-muted">
+            {cleared ? 'The stored secret will be removed when you save.' : field?.hasValue ? 'Leave blank to keep the stored secret. Enter a new value to replace it.' : 'Enter a value to store this secret.'}
+          </p>
+          {field?.clearable && field?.hasValue ? (
+            <ToolbarButton
+              icon={cleared ? Undo2 : Trash2}
+              label={cleared ? 'Keep stored secret' : 'Clear stored secret'}
+              onClick={onClearSecret}
+            />
+          ) : null}
+        </div>
       ) : field?.default !== undefined && field?.default !== null ? (
         <p className="mt-2 text-[11px] text-theme-text-muted">
           Default: <span className="font-mono text-theme-text">{String(field.default)}</span>

--- a/ods/extensions/services/dashboard/src/pages/Settings.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Settings.jsx
@@ -15,6 +15,12 @@ import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import EnvEditor from '../components/settings/EnvEditor'
 import { useTheme } from '../contexts/ThemeContext'
+import {
+  clearSettingsFollowUp,
+  loadSettingsFollowUp,
+  saveSettingsFollowUp,
+  settleSettingsApplyPlan,
+} from '../utils/settingsApplyPlan'
 
 const fetchJson = async (url, ms = 8000, options = {}) => {
   const c = new AbortController()
@@ -97,7 +103,9 @@ export default function Settings() {
   const [envApplying, setEnvApplying] = useState(false)
   const [envIssues, setEnvIssues] = useState([])
   const [envRevealSecrets, setEnvRevealSecrets] = useState({})
+  const [envClearedSecrets, setEnvClearedSecrets] = useState([])
   const [envApplyPlan, setEnvApplyPlan] = useState(null)
+  const [envFollowUpPlan, setEnvFollowUpPlan] = useState(() => loadSettingsFollowUp())
   const [statusCache, setStatusCache] = useState(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -111,6 +119,7 @@ export default function Settings() {
     setEnvValuesOriginal(payload?.values || {})
     setEnvIssues(payload?.issues || [])
     setEnvRevealSecrets({})
+    setEnvClearedSecrets([])
     setEnvApplyPlan(payload?.applyPlan || null)
     setEnvActiveSection(current => (current && payload?.sections?.some(section => section.id === current)) ? current : (payload?.sections?.[0]?.id || null))
   }
@@ -182,7 +191,7 @@ export default function Settings() {
       const payload = await fetchPayload('/api/settings/env', 15000, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mode: 'form', values: envValues }),
+        body: JSON.stringify({ mode: 'form', values: envValues, clearSecrets: envClearedSecrets }),
       })
       applyEnvEditorPayload(payload)
       setNotice({ type: 'info', text: `.env saved.${payload?.backupPath ? ` Backup: ${payload.backupPath}.` : ''} ${payload?.applyPlan?.summary || 'Restart or rebuild the stack to apply service-level changes.'}` })
@@ -203,13 +212,28 @@ export default function Settings() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ service_ids: envApplyPlan.services }),
       })
-      setEnvApplyPlan(null)
-      setNotice({ type: 'info', text: payload?.message || 'Runtime changes applied successfully.' })
+      const { remainingPlan, followUpPlan } = settleSettingsApplyPlan(envApplyPlan)
+      setEnvApplyPlan(remainingPlan)
+      if (followUpPlan) {
+        setEnvFollowUpPlan(saveSettingsFollowUp(followUpPlan))
+      }
+      setNotice({
+        type: 'info',
+        text: followUpPlan
+          ? `${payload?.message || 'Runtime changes applied successfully.'} Complete the required follow-up below.`
+          : (payload?.message || 'Runtime changes applied successfully.'),
+      })
     } catch (err) {
       setNotice({ type: 'danger', text: getErrorText(err) })
     } finally {
       setEnvApplying(false)
     }
+  }
+
+  const handleCompleteEnvFollowUp = () => {
+    clearSettingsFollowUp()
+    setEnvFollowUpPlan(null)
+    setNotice({ type: 'info', text: 'Required follow-up marked complete.' })
   }
 
   const handleExportConfig = async () => {
@@ -238,7 +262,7 @@ export default function Settings() {
   const envFields = envEditor?.fields || {}
   const envSections = (envEditor?.sections || []).map(section => ({ ...section, keys: section.keys.filter(key => matchesEnvSearch(key, envFields[key], envSearch.trim().toLowerCase())) })).filter(section => section.keys.length > 0)
   const activeEnvSection = envSections.find(section => section.id === envActiveSection) || envSections[0] || null
-  const envDirty = JSON.stringify(envValues) !== JSON.stringify(envValuesOriginal)
+  const envDirty = envClearedSecrets.length > 0 || JSON.stringify(envValues) !== JSON.stringify(envValuesOriginal)
   const envIssueMap = envIssues.reduce((acc, issue) => { if (issue?.key) (acc[issue.key] ||= []).push(issue.message); return acc }, {})
 
   if (loading) return (
@@ -305,7 +329,7 @@ export default function Settings() {
 
         {services.length > 0 ? <SettingsSection title="Routing Table" icon={Network}><div className="space-y-3"><div className="flex flex-wrap items-center gap-2"><p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-theme-text-muted/60">route surfaces</p><span className="rounded-full border border-white/10 bg-black/[0.12] px-2.5 py-1 text-[10px] font-mono uppercase tracking-[0.16em] text-theme-text">{getDashboardHost()}</span></div><div className="grid gap-3 xl:grid-cols-3">{routingGroups.map(group => <RoutingGroup key={group.key} {...group} />)}</div></div></SettingsSection> : null}
 
-        {envEditor ? <SettingsSection title="Environment Editor" icon={FileText}><EnvEditor editor={envEditor} search={envSearch} onSearchChange={setEnvSearch} sections={envSections} activeSection={activeEnvSection} onSectionChange={setEnvActiveSection} fields={envFields} values={envValues} issues={envIssues} issueMap={envIssueMap} revealedSecrets={envRevealSecrets} onToggleReveal={(key) => setEnvRevealSecrets(current => ({ ...current, [key]: !current[key] }))} onFieldChange={(key, value) => setEnvValues(current => ({ ...current, [key]: value }))} onReload={() => fetchEnvEditor({ announce: true })} onSave={handleSaveEnv} onApply={handleApplyEnv} dirty={envDirty} saving={envSaving} applyPlan={envApplyPlan} applying={envApplying} /></SettingsSection> : null}
+        {envEditor ? <SettingsSection title="Environment Editor" icon={FileText}><EnvEditor editor={envEditor} search={envSearch} onSearchChange={setEnvSearch} sections={envSections} activeSection={activeEnvSection} onSectionChange={setEnvActiveSection} fields={envFields} values={envValues} issues={envIssues} issueMap={envIssueMap} revealedSecrets={envRevealSecrets} clearedSecrets={envClearedSecrets} onToggleReveal={(key) => setEnvRevealSecrets(current => ({ ...current, [key]: !current[key] }))} onClearSecret={(key) => setEnvClearedSecrets(current => current.includes(key) ? current.filter(item => item !== key) : [...current, key])} onFieldChange={(key, value) => { setEnvClearedSecrets(current => current.filter(item => item !== key)); setEnvValues(current => ({ ...current, [key]: value })) }} onReload={() => fetchEnvEditor({ announce: true })} onSave={handleSaveEnv} onApply={handleApplyEnv} dirty={envDirty} saving={envSaving} applyPlan={envApplyPlan} followUpPlan={envFollowUpPlan} onCompleteFollowUp={handleCompleteEnvFollowUp} applying={envApplying} /></SettingsSection> : null}
 
         <SettingsSection title="Storage" icon={HardDrive}><StorageBlock storage={storage} /></SettingsSection>
         <SettingsSection title="Updates" icon={RefreshCw}><div className="flex items-center justify-between gap-4"><div><p className="text-theme-text">{version?.update_available && version?.latest ? `Update available: v${version.latest}` : `Installed version: v${version?.version || 'Unknown'}`}</p><p className="text-sm text-theme-text-muted">{version?.checked_at ? `Last checked: ${new Date(version.checked_at).toLocaleString()}` : 'Checks GitHub in the background to avoid blocking the page.'}</p></div><button onClick={() => { setNotice({ type: 'info', text: 'Checking for updates...' }); void fetchVersionInfo({ announce: true }) }} className="liquid-metal-button px-4 py-2 text-white rounded-lg text-sm flex items-center gap-2"><RefreshCw size={16} />Check for Updates</button></div></SettingsSection>

--- a/ods/extensions/services/dashboard/src/utils/settingsApplyPlan.js
+++ b/ods/extensions/services/dashboard/src/utils/settingsApplyPlan.js
@@ -1,0 +1,74 @@
+const FOLLOW_UP_STORAGE_KEY = 'ods-settings-follow-up-v1'
+const MAX_FOLLOW_UP_ACTIONS = 8
+
+const normalizeAction = (action) => {
+  if (!action || typeof action !== 'object') return null
+  const id = typeof action.id === 'string' ? action.id.slice(0, 80) : ''
+  const title = typeof action.title === 'string' ? action.title.slice(0, 160) : ''
+  const message = typeof action.message === 'string' ? action.message.slice(0, 1200) : ''
+  return id && title && message ? { id, title, message } : null
+}
+
+export const normalizeSettingsFollowUp = (value) => {
+  if (!value || typeof value !== 'object' || !Array.isArray(value.postApplyActions)) return null
+  const postApplyActions = value.postApplyActions
+    .slice(0, MAX_FOLLOW_UP_ACTIONS)
+    .map(normalizeAction)
+    .filter(Boolean)
+  if (postApplyActions.length === 0) return null
+  return {
+    status: 'post-apply',
+    summary: 'Runtime changes were applied. Complete the required follow-up below.',
+    postApplyActions,
+  }
+}
+
+export const loadSettingsFollowUp = (storage) => {
+  try {
+    const target = storage === undefined ? globalThis.localStorage : storage
+    return normalizeSettingsFollowUp(JSON.parse(target?.getItem(FOLLOW_UP_STORAGE_KEY) || 'null'))
+  } catch {
+    return null
+  }
+}
+
+export const saveSettingsFollowUp = (plan, storage) => {
+  const normalized = normalizeSettingsFollowUp(plan)
+  try {
+    const target = storage === undefined ? globalThis.localStorage : storage
+    if (normalized) target?.setItem(FOLLOW_UP_STORAGE_KEY, JSON.stringify(normalized))
+    else target?.removeItem(FOLLOW_UP_STORAGE_KEY)
+  } catch {
+    // Persistence is best-effort when browser storage is blocked.
+  }
+  return normalized
+}
+
+export const clearSettingsFollowUp = (storage) => {
+  try {
+    const target = storage === undefined ? globalThis.localStorage : storage
+    target?.removeItem(FOLLOW_UP_STORAGE_KEY)
+  } catch {
+    // Persistence is best-effort when browser storage is blocked.
+  }
+}
+
+export const settleSettingsApplyPlan = (plan) => {
+  const manualKeys = Array.isArray(plan?.manualKeys) ? [...new Set(plan.manualKeys)].sort() : []
+  const inactiveServices = Array.isArray(plan?.inactiveServices) ? [...new Set(plan.inactiveServices)].sort() : []
+  const followUpPlan = normalizeSettingsFollowUp(plan)
+  const remainingSummary = [
+    manualKeys.length > 0 ? `A manual stack restart is still required for: ${manualKeys.join(', ')}.` : '',
+    inactiveServices.length > 0 ? `Configuration remains staged until these services are enabled: ${inactiveServices.join(', ')}.` : '',
+  ].filter(Boolean).join(' ')
+  const remainingPlan = manualKeys.length > 0 || inactiveServices.length > 0 ? {
+    status: manualKeys.length > 0 ? 'manual' : 'staged',
+    supported: false,
+    services: [],
+    manualKeys,
+    inactiveServices,
+    postApplyActions: [],
+    summary: `Runtime service changes were applied. ${remainingSummary}`,
+  } : null
+  return { remainingPlan, followUpPlan }
+}

--- a/ods/extensions/services/dashboard/src/utils/settingsApplyPlan.test.js
+++ b/ods/extensions/services/dashboard/src/utils/settingsApplyPlan.test.js
@@ -1,0 +1,74 @@
+import {
+  clearSettingsFollowUp,
+  loadSettingsFollowUp,
+  saveSettingsFollowUp,
+  settleSettingsApplyPlan,
+} from './settingsApplyPlan'
+
+const followUpAction = {
+  id: 'open-webui-rag-reindex',
+  title: 'Reindex Open WebUI knowledge bases',
+  message: 'Reindex after changing the embedding model.',
+}
+
+describe('settings apply-plan state', () => {
+  beforeEach(() => globalThis.localStorage.clear())
+
+  test('persists a validated follow-up across a page reload', () => {
+    saveSettingsFollowUp({ postApplyActions: [followUpAction] })
+
+    expect(loadSettingsFollowUp()).toEqual({
+      status: 'post-apply',
+      summary: 'Runtime changes were applied. Complete the required follow-up below.',
+      postApplyActions: [followUpAction],
+    })
+  })
+
+  test('rejects malformed stored follow-up content', () => {
+    globalThis.localStorage.setItem('ods-settings-follow-up-v1', JSON.stringify({
+      postApplyActions: [{ id: 'missing-fields' }],
+    }))
+
+    expect(loadSettingsFollowUp()).toBeNull()
+  })
+
+  test('clears a completed follow-up receipt', () => {
+    saveSettingsFollowUp({ postApplyActions: [followUpAction] })
+    clearSettingsFollowUp()
+
+    expect(loadSettingsFollowUp()).toBeNull()
+  })
+
+  test('does not crash when browser storage is unavailable', () => {
+    const blockedStorage = {
+      getItem: () => { throw new Error('blocked') },
+      setItem: () => { throw new Error('blocked') },
+      removeItem: () => { throw new Error('blocked') },
+    }
+
+    expect(loadSettingsFollowUp(blockedStorage)).toBeNull()
+    expect(saveSettingsFollowUp({ postApplyActions: [followUpAction] }, blockedStorage))
+      .toMatchObject({ postApplyActions: [followUpAction] })
+    expect(() => clearSettingsFollowUp(blockedStorage)).not.toThrow()
+  })
+
+  test('retains manual restart work after runtime services are applied', () => {
+    const result = settleSettingsApplyPlan({
+      status: 'partial',
+      services: ['embeddings', 'open-webui'],
+      manualKeys: ['BIND_ADDRESS'],
+      inactiveServices: ['qdrant'],
+      postApplyActions: [followUpAction],
+    })
+
+    expect(result.remainingPlan).toMatchObject({
+      status: 'manual',
+      supported: false,
+      services: [],
+      manualKeys: ['BIND_ADDRESS'],
+      inactiveServices: ['qdrant'],
+    })
+    expect(result.remainingPlan.summary).toContain('Configuration remains staged')
+    expect(result.followUpPlan.postApplyActions).toEqual([followUpAction])
+  })
+})

--- a/ods/extensions/services/embeddings/README.md
+++ b/ods/extensions/services/embeddings/README.md
@@ -12,7 +12,7 @@ The embeddings service runs Hugging Face's Text Embeddings Inference (TEI) serve
 - **OpenAI-compatible API**: Drop-in replacement for OpenAI's embeddings endpoint
 - **Configurable model**: Switch embedding models via a single environment variable
 - **Persistent model cache**: Downloaded models are stored locally and survive restarts
-- **CPU-only by default**: Runs on CPU with optional GPU acceleration on NVIDIA/AMD
+- **CPU-packaged runtime**: The shipped Compose service uses the pinned TEI CPU image across supported hosts
 
 ## Configuration
 
@@ -22,8 +22,31 @@ Environment variables (set in `.env`):
 |----------|---------|-------------|
 | `EMBEDDINGS_PORT` | 8090 | External port for the embeddings API |
 | `EMBEDDING_MODEL` | `BAAI/bge-base-en-v1.5` | Hugging Face model ID to load |
+| `EMBEDDINGS_MEMORY_LIMIT` | `4G` | Container memory limit; larger models may need `6G` or more |
+| `RAG_EMBEDDING_MODEL` | empty | Optional Open WebUI-only override for an external embeddings provider |
+| `RAG_OPENAI_API_BASE_URL` | bundled TEI | OpenAI-compatible endpoint used by Open WebUI RAG |
+| `RAG_OPENAI_API_KEY` | empty | Optional credential for an authenticated external embeddings provider |
 
-> **Changing the model:** Set `EMBEDDING_MODEL` in `.env` to any compatible sentence-transformer model from Hugging Face. The model will be downloaded automatically on first start and cached in `./data/embeddings`.
+> **Changing the model:** Set `EMBEDDING_MODEL` in `.env` to a TEI-compatible Hugging Face repository ID. Open WebUI uses the same value on first boot when it uses bundled TEI; existing installs retain their Admin Panel value until it is updated there. The model is downloaded on first start and cached in `./data/embeddings`.
+
+The bundled service is Hugging Face Text Embeddings Inference, not llama.cpp.
+GGUF files and GGUF/Q4 repositories cannot be used as `EMBEDDING_MODEL`.
+For example, use `BAAI/bge-m3`, not a BGE-M3 GGUF quantization. Operators
+with another OpenAI-compatible embeddings server may set
+`RAG_OPENAI_API_BASE_URL`, `RAG_EMBEDDING_MODEL`, and, when required,
+`RAG_OPENAI_API_KEY`; those explicit overrides do not change the bundled TEI
+model. External endpoint URLs must include a valid HTTP(S) host. Keep
+credentials in `RAG_OPENAI_API_KEY`, rather than embedding them in the URL.
+Dashboard Settings exposes an explicit **Clear stored secret** action for this
+optional credential; leaving the masked input blank keeps its current value.
+
+When the embeddings extension is disabled, Dashboard Settings saves model and
+memory changes without trying to start it. The pending configuration is applied
+the next time the extension is enabled. Required Open WebUI synchronization and
+reindex steps remain visible in that browser until they are marked complete.
+Saving and runtime application are separate operations: the `.env` change and
+its timestamped backup remain durable if a container recreation fails, while
+the pending apply plan stays available for retry.
 
 ## API Endpoints
 
@@ -72,7 +95,7 @@ The container enforces CPU and memory limits to prevent resource starvation:
 | Limit | Value |
 |-------|-------|
 | CPU limit | 2 cores |
-| Memory limit | 4 GB |
+| Memory limit | 4 GB by default (`EMBEDDINGS_MEMORY_LIMIT`) |
 | CPU reservation | 0.5 cores |
 | Memory reservation | 1 GB |
 
@@ -85,26 +108,53 @@ The container enforces CPU and memory limits to prevent resource starvation:
 
 **Embeddings service not ready (health check failing):**
 
-The service downloads the model on first start, which can take several minutes depending on model size. Wait for the start period (60s) to elapse, then check logs:
+The service downloads the model on first start, which can take several minutes depending on model size. The healthcheck allows a 600-second start period; check progress with:
 ```bash
-docker compose logs ods-embeddings --follow
+docker compose logs embeddings --follow
 ```
 
 **Out of memory errors:**
 - The default `BAAI/bge-base-en-v1.5` model requires ~1 GB RAM
-- Larger models (e.g. `BAAI/bge-large-en-v1.5`) require more memory; increase the memory limit in `compose.yaml` if needed
+- Larger models (for example `BAAI/bge-m3`) require more memory; set `EMBEDDINGS_MEMORY_LIMIT=6G` or higher in `.env` instead of editing Compose
 
 **Connection refused on port 8090:**
 ```bash
-docker compose ps ods-embeddings
-docker compose logs ods-embeddings
+docker compose ps embeddings
+docker compose logs embeddings
 ```
 
 **Changing models:**
-```bash
-# Update .env
-EMBEDDING_MODEL=BAAI/bge-large-en-v1.5
+1. Edit `.env` and change the canonical model:
 
-# Restart the service
-docker compose restart embeddings
-```
+   ```env
+   EMBEDDING_MODEL=BAAI/bge-m3
+   # Larger models may require this:
+   EMBEDDINGS_MEMORY_LIMIT=6G
+   ```
+
+2. Recreate the embeddings and Open WebUI containers so the new environment
+   reaches both consumers:
+
+   ```bash
+   # Linux / macOS
+   ods restart embeddings
+   ods restart open-webui
+   ```
+
+   ```powershell
+   # Windows, from $env:USERPROFILE\ods (or the custom install directory)
+   .\ods.ps1 restart embeddings
+   .\ods.ps1 restart open-webui
+   ```
+
+3. In Open WebUI, open **Admin Panel / Settings / Documents**, set the
+   embedding engine, endpoint, and model to the values above, then run
+   **Reindex**. Open WebUI persists these settings in its database after first
+   boot, so recreating its container does not override an existing Admin Panel
+   value. Embeddings from different models are not in the same vector space.
+   Existing knowledge bases must be re-embedded, and files attached directly
+   to old chats must be uploaded again.
+
+Do not use `docker compose restart` for this change: Docker restart preserves
+the old container environment. The ODS lifecycle commands recreate the
+affected containers.

--- a/ods/extensions/services/embeddings/compose.yaml
+++ b/ods/extensions/services/embeddings/compose.yaml
@@ -18,7 +18,7 @@ services:
       resources:
         limits:
           cpus: '2.0'
-          memory: 4G
+          memory: ${EMBEDDINGS_MEMORY_LIMIT:-4G}
         reservations:
           cpus: '0.5'
           memory: 1G

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -39,6 +39,12 @@ read_env_value() {
     grep -E "^${key}=" "$env_path" 2>/dev/null | sed -n '1p' | cut -d'=' -f2- | tr -d '\r' || true
 }
 
+env_key_exists() {
+    local env_path="$1"
+    local key="$2"
+    [[ -f "$env_path" ]] && grep -q -E "^${key}=" "$env_path" 2>/dev/null
+}
+
 read_token_spy_api_key() {
     local install_dir="$1"
     local token_spy_key_path="${install_dir}/data/token-spy/token-spy-api-key.txt"
@@ -277,6 +283,24 @@ generate_ods_env() {
         if [[ -z "$(read_env_value "$env_path" "ODS_DEVICE_NAME")" ]]; then
             upsert_env_value "$env_path" "ODS_DEVICE_NAME" "$(detect_device_name)"
         fi
+        # Backfill the TEI/RAG contract without replacing persisted operator
+        # values. Explicit process env values populate keys absent from older
+        # installations, matching Linux and Windows rerun behavior.
+        if [[ -z "$(read_env_value "$env_path" "EMBEDDING_MODEL")" ]]; then
+            upsert_env_value "$env_path" "EMBEDDING_MODEL" "${EMBEDDING_MODEL:-BAAI/bge-base-en-v1.5}"
+        fi
+        if ! env_key_exists "$env_path" "RAG_EMBEDDING_MODEL"; then
+            upsert_env_value "$env_path" "RAG_EMBEDDING_MODEL" "${RAG_EMBEDDING_MODEL:-}"
+        fi
+        if ! env_key_exists "$env_path" "RAG_OPENAI_API_BASE_URL"; then
+            upsert_env_value "$env_path" "RAG_OPENAI_API_BASE_URL" "${RAG_OPENAI_API_BASE_URL:-}"
+        fi
+        if ! env_key_exists "$env_path" "RAG_OPENAI_API_KEY"; then
+            upsert_env_value "$env_path" "RAG_OPENAI_API_KEY" "${RAG_OPENAI_API_KEY:-}"
+        fi
+        if [[ -z "$(read_env_value "$env_path" "EMBEDDINGS_MEMORY_LIMIT")" ]]; then
+            upsert_env_value "$env_path" "EMBEDDINGS_MEMORY_LIMIT" "${EMBEDDINGS_MEMORY_LIMIT:-4G}"
+        fi
 
         # HOST_LAN_IP backfill: the fresh-install heredoc below populates
         # HOST_LAN_IP when BIND_ADDRESS=0.0.0.0 was pre-set, so openclaw can
@@ -414,6 +438,11 @@ generate_ods_env() {
         open_webui_llm_base_url="http://litellm:4000"
         open_webui_llm_api_key="$litellm_key"
     fi
+    local embedding_model="${EMBEDDING_MODEL:-BAAI/bge-base-en-v1.5}"
+    local rag_embedding_model="${RAG_EMBEDDING_MODEL:-}"
+    local rag_openai_api_base_url="${RAG_OPENAI_API_BASE_URL:-}"
+    local rag_openai_api_key="${RAG_OPENAI_API_KEY:-}"
+    local embeddings_memory_limit="${EMBEDDINGS_MEMORY_LIMIT:-4G}"
 
     # Build .env content (matches Phase 06 format)
     cat > "$env_path" << ENVEOF
@@ -542,6 +571,15 @@ WHISPER_MODEL=base
 # here and run 'ods-macos.sh restart' to use a different model.
 AUDIO_STT_MODEL=Systran/faster-whisper-base
 TTS_VOICE=en_US-lessac-medium
+
+#=== Embeddings / RAG ===
+# Open WebUI uses this canonical model at first boot unless an explicit
+# external-provider override is configured.
+EMBEDDING_MODEL=${embedding_model}
+RAG_EMBEDDING_MODEL=${rag_embedding_model}
+RAG_OPENAI_API_BASE_URL=${rag_openai_api_base_url}
+RAG_OPENAI_API_KEY=${rag_openai_api_key}
+EMBEDDINGS_MEMORY_LIMIT=${embeddings_memory_limit}
 
 #=== Web UI Settings ===
 WEBUI_AUTH=true

--- a/ods/installers/phases/06-directories.sh
+++ b/ods/installers/phases/06-directories.sh
@@ -268,6 +268,21 @@ Fix with: sudo chown -R \$(id -u):\$(id -g) $INSTALL_DIR/config $INSTALL_DIR/dat
         echo "$default"
     }
 
+    # Optional overrides use an empty value to mean "inherit the bundled
+    # provider". Preserve that explicit state across reruns; _env_get treats
+    # empty as missing for variables whose defaults must be backfilled.
+    _env_get_preserve_empty() {
+        local key="$1" default="${2:-}" val
+        if [[ -n "$_env_existing" ]] && grep -q -m1 "^${key}=" "$_env_existing" 2>/dev/null; then
+            val=$(grep -m1 "^${key}=" "$_env_existing" 2>/dev/null | cut -d= -f2- || true)
+            val="${val%\"}" && val="${val#\"}"
+            val="${val%\'}" && val="${val#\'}"
+            printf '%s\n' "$val"
+            return
+        fi
+        printf '%s\n' "$default"
+    }
+
     _env_get_explicit_first() {
         local key="$1" default="${2:-}" val
         val="${!key-}"
@@ -613,6 +628,11 @@ raise SystemExit(1)' 2>/dev/null && return 0
         _default_stt_model="Systran/faster-whisper-base"
     fi
     AUDIO_STT_MODEL=$(_env_get AUDIO_STT_MODEL "${AUDIO_STT_MODEL:-$_default_stt_model}")
+    EMBEDDING_MODEL_VALUE=$(_env_get EMBEDDING_MODEL "${EMBEDDING_MODEL:-BAAI/bge-base-en-v1.5}")
+    RAG_EMBEDDING_MODEL_VALUE=$(_env_get_preserve_empty RAG_EMBEDDING_MODEL "${RAG_EMBEDDING_MODEL:-}")
+    RAG_OPENAI_API_BASE_URL_VALUE=$(_env_get_preserve_empty RAG_OPENAI_API_BASE_URL "${RAG_OPENAI_API_BASE_URL:-}")
+    RAG_OPENAI_API_KEY_VALUE=$(_env_get_preserve_empty RAG_OPENAI_API_KEY "${RAG_OPENAI_API_KEY:-}")
+    EMBEDDINGS_MEMORY_LIMIT_VALUE=$(_env_get EMBEDDINGS_MEMORY_LIMIT "${EMBEDDINGS_MEMORY_LIMIT:-4G}")
 
     _phase06_lemonade_uses_host_9000() {
         [[ "$LEMONADE_EXTERNAL_VALUE" == "true" ]] && return 0
@@ -865,6 +885,15 @@ WHISPER_MODEL=base
 # Auto-selected based on GPU backend; edit to override.
 AUDIO_STT_MODEL=${AUDIO_STT_MODEL}
 TTS_VOICE=en_US-lessac-medium
+
+#=== Embeddings / RAG ===
+# Open WebUI uses this canonical model at first boot unless an explicit
+# external-provider override is configured.
+EMBEDDING_MODEL=${EMBEDDING_MODEL_VALUE}
+RAG_EMBEDDING_MODEL=${RAG_EMBEDDING_MODEL_VALUE}
+RAG_OPENAI_API_BASE_URL=${RAG_OPENAI_API_BASE_URL_VALUE}
+RAG_OPENAI_API_KEY=${RAG_OPENAI_API_KEY_VALUE}
+EMBEDDINGS_MEMORY_LIMIT=${EMBEDDINGS_MEMORY_LIMIT_VALUE}
 
 #=== Device Name / mDNS / Proxy hostnames ===
 # Used by ods-mdns to publish <name>.local on the LAN, by ods-proxy

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -293,6 +293,15 @@ function New-ODSEnv {
         return $Default
     }
 
+    # Empty is meaningful for optional provider overrides: it selects the
+    # bundled service. Distinguish it from a key missing in an older .env.
+    function Get-EnvOrNewAllowEmpty { param([string]$Key, [string]$Default)
+        if ($existingEnv.ContainsKey($Key)) {
+            return $existingEnv[$Key]
+        }
+        return $Default
+    }
+
     $webuiPort = Resolve-WindowsODSPort `
         -Name "WEBUI_PORT" -DefaultPort 3000 `
         -ExistingEnv $existingEnv -InstallDir $InstallDir
@@ -589,6 +598,15 @@ function New-ODSEnv {
     if ($whisperAcceleration -eq "cpu" -and $audioSttModel -match "(?i)large-v3|turbo") {
         $audioSttModel = $audioSttModelDefault
     }
+    $embeddingModelDefault = [Environment]::GetEnvironmentVariable("EMBEDDING_MODEL")
+    if ([string]::IsNullOrWhiteSpace($embeddingModelDefault)) { $embeddingModelDefault = "BAAI/bge-base-en-v1.5" }
+    $embeddingModel = Get-EnvOrNew "EMBEDDING_MODEL" $embeddingModelDefault
+    $ragEmbeddingModel = Get-EnvOrNewAllowEmpty "RAG_EMBEDDING_MODEL" ([Environment]::GetEnvironmentVariable("RAG_EMBEDDING_MODEL"))
+    $ragOpenAiApiBaseUrl = Get-EnvOrNewAllowEmpty "RAG_OPENAI_API_BASE_URL" ([Environment]::GetEnvironmentVariable("RAG_OPENAI_API_BASE_URL"))
+    $ragOpenAiApiKey = Get-EnvOrNewAllowEmpty "RAG_OPENAI_API_KEY" ([Environment]::GetEnvironmentVariable("RAG_OPENAI_API_KEY"))
+    $embeddingsMemoryLimitDefault = [Environment]::GetEnvironmentVariable("EMBEDDINGS_MEMORY_LIMIT")
+    if ([string]::IsNullOrWhiteSpace($embeddingsMemoryLimitDefault)) { $embeddingsMemoryLimitDefault = "4G" }
+    $embeddingsMemoryLimit = Get-EnvOrNew "EMBEDDINGS_MEMORY_LIMIT" $embeddingsMemoryLimitDefault
 
     # Build .env content (matches Phase 06 format)
     $envContent = @"
@@ -729,6 +747,15 @@ $(if ($whisperImage) { "WHISPER_IMAGE=$whisperImage" } else { "#WHISPER_IMAGE=gh
 # the same model so the first transcription works.
 AUDIO_STT_MODEL=$audioSttModel
 TTS_VOICE=en_US-lessac-medium
+
+#=== Embeddings / RAG ===
+# Open WebUI uses this canonical model at first boot unless an explicit
+# external-provider override is configured.
+EMBEDDING_MODEL=$embeddingModel
+RAG_EMBEDDING_MODEL=$ragEmbeddingModel
+RAG_OPENAI_API_BASE_URL=$ragOpenAiApiBaseUrl
+RAG_OPENAI_API_KEY=$ragOpenAiApiKey
+EMBEDDINGS_MEMORY_LIMIT=$embeddingsMemoryLimit
 
 #=== Web UI Settings ===
 WEBUI_AUTH=true

--- a/ods/scripts/validate-env.sh
+++ b/ods/scripts/validate-env.sh
@@ -4,7 +4,8 @@
 # Senior-grade validation goals:
 #  - Correctly parse .env files including quotes and "export KEY=..." lines
 #  - Report line numbers and actionable messages
-#  - Validate required keys, unknown keys, types, enums, and numeric ranges
+#  - Validate required keys, unknown keys, types, enums, numeric ranges, and
+#    cross-service runtime contracts
 #  - Fail deterministically with a single exit code for CI
 
 # Require Bash 4+ (associative arrays used below).
@@ -182,6 +183,7 @@ type_errors=()
 enum_errors=()
 range_errors=()
 length_errors=()
+contract_errors=()
 duplicate_errors=()
 
 mapfile -t required_keys < <(jq -r '.required[]?' "$SCHEMA_FILE")
@@ -287,6 +289,70 @@ for key in "${schema_keys[@]}"; do
 done
 
 # -----------------------------
+# Cross-service runtime contracts
+# -----------------------------
+
+_valid_http_endpoint() {
+    local value="$1" remainder authority port=""
+    [[ "$value" =~ ^https?://[^[:space:]#]+$ ]] || return 1
+    remainder="${value#*://}"
+    authority="${remainder%%[/?]*}"
+    [[ -n "$authority" && "$authority" != *"@"* ]] || return 1
+
+    if [[ "$authority" =~ ^\[([0-9a-f:.]+)\](:([0-9]+))?$ ]]; then
+        port="${BASH_REMATCH[3]}"
+    elif [[ "$authority" =~ ^[a-z0-9][a-z0-9._-]*(:([0-9]+))?$ ]]; then
+        port="${BASH_REMATCH[2]}"
+    else
+        return 1
+    fi
+
+    [[ -z "$port" ]] || {
+        [[ ${#port} -le 5 ]] && (( 10#$port >= 1 && 10#$port <= 65535 ))
+    }
+}
+
+embedding_model="${ENV_MAP[EMBEDDING_MODEL]-BAAI/bge-base-en-v1.5}"
+embedding_model_lower="${embedding_model,,}"
+embedding_artifact_name="${embedding_model_lower##*/}"
+if [[ "$embedding_model_lower" == *"://"* \
+   || "$embedding_artifact_name" == *"gguf"* \
+   || "$embedding_artifact_name" == *"ggml"* \
+   || "$embedding_artifact_name" =~ (^|[-._])q[2-8](_[a-z0-9]+)*($|[-._]) ]]; then
+    contract_errors+=(
+      "EMBEDDING_MODEL: bundled embeddings require a Hugging Face TEI repository ID (for example BAAI/bge-m3); URLs and GGUF/Q4 artifacts are not supported (line ${ENV_LINE[EMBEDDING_MODEL]:-?})"
+    )
+fi
+
+embeddings_memory_limit="${ENV_MAP[EMBEDDINGS_MEMORY_LIMIT]-}"
+if [[ -n "$embeddings_memory_limit" && ! "$embeddings_memory_limit" =~ ^[1-9][0-9]*([bBkKmMgG]|[kKmMgG][bB])?$ ]]; then
+    contract_errors+=(
+      "EMBEDDINGS_MEMORY_LIMIT: expected a positive Docker memory value such as 4096M, 4G, or 6GB (line ${ENV_LINE[EMBEDDINGS_MEMORY_LIMIT]:-?})"
+    )
+fi
+
+rag_model="${ENV_MAP[RAG_EMBEDDING_MODEL]-}"
+rag_base="${ENV_MAP[RAG_OPENAI_API_BASE_URL]-}"
+rag_base="${rag_base,,}"
+while [[ "$rag_base" == */ ]]; do
+    rag_base="${rag_base%/}"
+done
+if [[ -n "$rag_base" ]] && ! _valid_http_endpoint "$rag_base"; then
+    contract_errors+=(
+      "RAG_OPENAI_API_BASE_URL: expected an HTTP(S) OpenAI-compatible embeddings base URL (line ${ENV_LINE[RAG_OPENAI_API_BASE_URL]:-?})"
+    )
+fi
+case "$rag_base" in
+    ""|http://embeddings:80/v1|http://embeddings/v1|http://ods-embeddings:80/v1|http://ods-embeddings/v1)
+        if [[ -n "$rag_model" && "$rag_model" != "$embedding_model" ]]; then
+            contract_errors+=(
+              "RAG_EMBEDDING_MODEL: bundled TEI serves EMBEDDING_MODEL only; leave this override empty or configure the matching external RAG_OPENAI_API_BASE_URL (line ${ENV_LINE[RAG_EMBEDDING_MODEL]:-?})"
+            )
+        fi
+        ;;
+esac
+
+# -----------------------------
 # Reporting
 # -----------------------------
 
@@ -336,6 +402,14 @@ if (( ${#length_errors[@]} > 0 )); then
     had_errors=true
     log_error "Length validation errors (replace placeholder/default values):"
     for err in "${length_errors[@]}"; do
+        echo "  - $err"
+    done
+fi
+
+if (( ${#contract_errors[@]} > 0 )); then
+    had_errors=true
+    log_error "Runtime contract validation errors:"
+    for err in "${contract_errors[@]}"; do
         echo "  - $err"
     done
 fi

--- a/ods/tests/smoke/installer-env-smoke.sh
+++ b/ods/tests/smoke/installer-env-smoke.sh
@@ -57,8 +57,14 @@ INSTALL_DIR="$TMPDIR_SMOKE/ods"
 mkdir -p "$INSTALL_DIR"/{config,data,models}
 mkdir -p "$INSTALL_DIR"/config/{n8n,litellm,openclaw,searxng}
 
-# Copy source tree so phase 06 can find compose files and schemas
-cp -a "$ROOT_DIR"/* "$INSTALL_DIR/" 2>/dev/null || true
+# Copy source inputs so phase 06 can find compose files and schemas. Exclude
+# local frontend build artifacts; copying node_modules across WSL/NTFS can turn
+# this smoke test into a multi-minute filesystem benchmark.
+tar -C "$ROOT_DIR" \
+    --exclude='./.env' \
+    --exclude='./extensions/services/dashboard/node_modules' \
+    --exclude='./extensions/services/dashboard/dist' \
+    -cf - . | tar -C "$INSTALL_DIR" -xf -
 
 # Set up minimal environment that phase 06 expects
 export INSTALL_DIR
@@ -106,7 +112,10 @@ spin_task() { :; }
 ENV_GENERATED=false
 if bash -c "
     export INSTALL_DIR='$INSTALL_DIR'
-    export SCRIPT_DIR='$ROOT_DIR'
+    # The tracked source inputs were copied above. Treat that copy as an
+    # in-place install so this env-generation smoke does not recopy the whole
+    # developer checkout when rsync is unavailable.
+    export SCRIPT_DIR='$INSTALL_DIR'
     export LOG_FILE='/dev/null'
     export DRY_RUN=false
     export INTERACTIVE=false
@@ -122,6 +131,11 @@ if bash -c "
     export ENABLE_RAG=true
     export ENABLE_HERMES=true
 export ENABLE_OPENCLAW=true
+    export EMBEDDING_MODEL=BAAI/bge-m3
+    export RAG_EMBEDDING_MODEL=
+    export RAG_OPENAI_API_BASE_URL=https://embeddings.example.test/v1
+    export RAG_OPENAI_API_KEY=external-test-key
+    export EMBEDDINGS_MEMORY_LIMIT=6GB
 
     # Source libs
     source installers/lib/constants.sh
@@ -139,6 +153,7 @@ export ENABLE_OPENCLAW=true
     chapter() { :; }
     signal() { :; }
     show_phase() { :; }
+    sudo() { return 0; }
 
     docker() {
         if [[ \"\$1\" == \"info\" && \"\${2:-}\" == \"--format\" ]]; then
@@ -149,6 +164,15 @@ export ENABLE_OPENCLAW=true
     }
 
     # Run phase 06 (generates .env, configs)
+    source installers/phases/06-directories.sh
+
+    # A second installer run must retain the values written by the first run,
+    # even when the invoking process now carries different defaults.
+    export EMBEDDING_MODEL=BAAI/should-not-replace-existing
+    export RAG_EMBEDDING_MODEL=should-not-replace-existing
+    export RAG_OPENAI_API_BASE_URL=https://replacement.example.test/v1
+    export RAG_OPENAI_API_KEY=replacement-secret
+    export EMBEDDINGS_MEMORY_LIMIT=8GB
     source installers/phases/06-directories.sh
 " 2>/dev/null; then
     ENV_GENERATED=true
@@ -173,6 +197,16 @@ else
 fi
 
 if [[ "$ENV_GENERATED" == true && -f "$INSTALL_DIR/.env" ]]; then
+    if grep -q '^EMBEDDING_MODEL=BAAI/bge-m3$' "$INSTALL_DIR/.env" \
+        && grep -q '^RAG_EMBEDDING_MODEL=$' "$INSTALL_DIR/.env" \
+        && grep -q '^RAG_OPENAI_API_BASE_URL=https://embeddings.example.test/v1$' "$INSTALL_DIR/.env" \
+        && grep -q '^RAG_OPENAI_API_KEY=external-test-key$' "$INSTALL_DIR/.env" \
+        && grep -q '^EMBEDDINGS_MEMORY_LIMIT=6GB$' "$INSTALL_DIR/.env"; then
+        pass "Embedding/RAG values survive a Linux installer rerun"
+    else
+        fail "Embedding/RAG values were not preserved across a Linux installer rerun"
+    fi
+
     if grep -q '^LLAMA_CPU_LIMIT=4.0$' "$INSTALL_DIR/.env"; then
         pass "LLAMA_CPU_LIMIT auto-caps to Docker CPU count"
     else

--- a/ods/tests/test-embedding-model-contract.py
+++ b/ods/tests/test-embedding-model-contract.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Cross-platform contract tests for bundled TEI and Open WebUI RAG."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EMBEDDING_ENV = {
+    "EMBEDDING_MODEL": "BAAI/bge-m3",
+    "RAG_EMBEDDING_MODEL": "external-embedding-v2",
+    "RAG_OPENAI_API_BASE_URL": "https://embeddings.example.test/v1",
+    "RAG_OPENAI_API_KEY": "external-test-key",
+    "EMBEDDINGS_MEMORY_LIMIT": "6GB",
+}
+
+
+def read_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8-sig").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key] = value
+    return values
+
+
+def assert_embedding_env(values: dict[str, str]) -> None:
+    for key, expected in EMBEDDING_ENV.items():
+        assert values.get(key) == expected, f"{key}: expected {expected!r}, got {values.get(key)!r}"
+
+
+def render_compose(**overrides: str) -> dict:
+    env = os.environ.copy()
+    env.update({
+        "WEBUI_SECRET": "test-webui-secret",
+        "EMBEDDING_MODEL": "BAAI/bge-m3",
+        "EMBEDDINGS_MEMORY_LIMIT": "6G",
+    })
+    env.update(overrides)
+    for key in ("RAG_EMBEDDING_MODEL", "RAG_OPENAI_API_BASE_URL", "RAG_OPENAI_API_KEY"):
+        if key not in overrides:
+            env.pop(key, None)
+
+    result = subprocess.run(
+        [
+            "docker", "compose",
+            "-f", "docker-compose.base.yml",
+            "-f", "extensions/services/embeddings/compose.yaml",
+            "config", "--format", "json",
+        ],
+        cwd=ROOT,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def test_bundled_rag_inherits_canonical_model() -> None:
+    config = render_compose()
+    embeddings = config["services"]["embeddings"]
+    webui = config["services"]["open-webui"]
+
+    assert embeddings["environment"]["MODEL_ID"] == "BAAI/bge-m3"
+    assert webui["environment"]["RAG_EMBEDDING_MODEL"] == "BAAI/bge-m3"
+    assert embeddings["deploy"]["resources"]["limits"]["memory"] == "6442450944"
+
+
+def test_external_rag_override_does_not_change_bundled_tei() -> None:
+    config = render_compose(
+        RAG_EMBEDDING_MODEL="external-embedding-v2",
+        RAG_OPENAI_API_BASE_URL="https://embeddings.example.test/v1",
+        RAG_OPENAI_API_KEY="external-test-key",
+    )
+    embeddings = config["services"]["embeddings"]
+    webui = config["services"]["open-webui"]
+
+    assert embeddings["environment"]["MODEL_ID"] == "BAAI/bge-m3"
+    assert webui["environment"]["RAG_EMBEDDING_MODEL"] == "external-embedding-v2"
+    assert webui["environment"]["RAG_OPENAI_API_BASE_URL"] == "https://embeddings.example.test/v1"
+    assert webui["environment"]["RAG_OPENAI_API_KEY"] == "external-test-key"
+
+
+def test_installers_write_or_backfill_canonical_model() -> None:
+    linux = (ROOT / "installers/phases/06-directories.sh").read_text(encoding="utf-8")
+    macos = (ROOT / "installers/macos/lib/env-generator.sh").read_text(encoding="utf-8")
+    windows = (ROOT / "installers/windows/lib/env-generator.ps1").read_text(encoding="utf-8")
+
+    assert 'EMBEDDING_MODEL_VALUE=$(_env_get EMBEDDING_MODEL "${EMBEDDING_MODEL:-BAAI/bge-base-en-v1.5}")' in linux
+    assert "EMBEDDING_MODEL=${EMBEDDING_MODEL_VALUE}" in linux
+    assert 'upsert_env_value "$env_path" "EMBEDDING_MODEL" "${EMBEDDING_MODEL:-BAAI/bge-base-en-v1.5}"' in macos
+    assert "EMBEDDING_MODEL=${embedding_model}" in macos
+    assert '$embeddingModel = Get-EnvOrNew "EMBEDDING_MODEL" $embeddingModelDefault' in windows
+    assert "EMBEDDING_MODEL=$embeddingModel" in windows
+
+    for key in (
+        "RAG_EMBEDDING_MODEL",
+        "RAG_OPENAI_API_BASE_URL",
+        "RAG_OPENAI_API_KEY",
+        "EMBEDDINGS_MEMORY_LIMIT",
+    ):
+        assert key in linux
+        assert key in macos
+        assert key in windows
+
+
+def test_windows_env_generator_renders_embedding_contract() -> None:
+    env = os.environ.copy()
+    env.update(EMBEDDING_ENV)
+    env["ODS_TEST_ROOT"] = str(ROOT)
+
+    with tempfile.TemporaryDirectory(prefix="ods-windows-embedding-contract-") as temp_dir:
+        env["ODS_TEST_DIR"] = temp_dir
+        script = r'''
+$ErrorActionPreference = "Stop"
+function Write-AIWarn { param([string]$Message) }
+. (Join-Path $env:ODS_TEST_ROOT "installers/windows/lib/detection.ps1")
+. (Join-Path $env:ODS_TEST_ROOT "installers/windows/lib/env-generator.ps1")
+$tier = @{
+    TierName = "Embedding contract"
+    LlmModel = "test-model"
+    GgufFile = "test.gguf"
+    MaxContext = 4096
+}
+New-ODSEnv -InstallDir $env:ODS_TEST_DIR -TierConfig $tier -Tier "3" -GpuBackend "nvidia" -ODSMode "local" | Out-Null
+$env:EMBEDDING_MODEL = "BAAI/should-not-replace-existing"
+$env:RAG_EMBEDDING_MODEL = "should-not-replace-existing"
+$env:RAG_OPENAI_API_BASE_URL = "https://replacement.example.test/v1"
+$env:RAG_OPENAI_API_KEY = "replacement-secret"
+$env:EMBEDDINGS_MEMORY_LIMIT = "8GB"
+New-ODSEnv -InstallDir $env:ODS_TEST_DIR -TierConfig $tier -Tier "3" -GpuBackend "nvidia" -ODSMode "local" | Out-Null
+'''
+        subprocess.run(
+            ["pwsh", "-NoProfile", "-NonInteractive", "-Command", script],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        assert_embedding_env(read_env(Path(temp_dir) / ".env"))
+
+        legacy_dir = Path(temp_dir) / "legacy"
+        legacy_dir.mkdir()
+        (legacy_dir / ".env").write_text("WEBUI_AUTH=false\n", encoding="utf-8")
+        env["ODS_TEST_DIR"] = str(legacy_dir)
+        legacy_script = script.split('$env:EMBEDDING_MODEL = "BAAI/should-not-replace-existing"', 1)[0]
+        subprocess.run(
+            ["pwsh", "-NoProfile", "-NonInteractive", "-Command", legacy_script],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        legacy_values = read_env(legacy_dir / ".env")
+        assert_embedding_env(legacy_values)
+
+        empty_override_dir = Path(temp_dir) / "empty-overrides"
+        empty_override_dir.mkdir()
+        (empty_override_dir / ".env").write_text(
+            "RAG_EMBEDDING_MODEL=\nRAG_OPENAI_API_BASE_URL=\nRAG_OPENAI_API_KEY=\n",
+            encoding="utf-8",
+        )
+        env["ODS_TEST_DIR"] = str(empty_override_dir)
+        subprocess.run(
+            ["pwsh", "-NoProfile", "-NonInteractive", "-Command", legacy_script],
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        empty_values = read_env(empty_override_dir / ".env")
+        assert empty_values["RAG_EMBEDDING_MODEL"] == ""
+        assert empty_values["RAG_OPENAI_API_BASE_URL"] == ""
+        assert empty_values["RAG_OPENAI_API_KEY"] == ""
+
+
+def test_macos_env_generator_renders_embedding_contract() -> None:
+    env = os.environ.copy()
+    env.update(EMBEDDING_ENV)
+
+    with tempfile.TemporaryDirectory(prefix="ods-macos-embedding-contract-") as temp_dir:
+        subprocess.run(
+            [
+                "bash", "-c",
+                'source installers/macos/lib/detection.sh; '
+                'source installers/macos/lib/env-generator.sh; '
+                'generate_ods_env "$1" 3 true >/dev/null',
+                "ods-embedding-contract", temp_dir,
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        env_path = Path(temp_dir) / ".env"
+        assert_embedding_env(read_env(env_path))
+
+        # Simulate an older install that predates the complete contract. A
+        # rerun must backfill every missing key while preserving the rest of
+        # the generated environment.
+        env_path.write_text(
+            "\n".join(
+                line for line in env_path.read_text(encoding="utf-8").splitlines()
+                if line.split("=", 1)[0] not in EMBEDDING_ENV
+            ) + "\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            [
+                "bash", "-c",
+                'source installers/macos/lib/detection.sh; '
+                'source installers/macos/lib/env-generator.sh; '
+                'generate_ods_env "$1" 3 false >/dev/null',
+                "ods-embedding-contract", temp_dir,
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        assert_embedding_env(read_env(env_path))
+
+        empty_override_dir = Path(temp_dir) / "empty-overrides"
+        empty_override_dir.mkdir()
+        (empty_override_dir / ".env").write_text(
+            "RAG_EMBEDDING_MODEL=\nRAG_OPENAI_API_BASE_URL=\nRAG_OPENAI_API_KEY=\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            [
+                "bash", "-c",
+                'source installers/macos/lib/detection.sh; '
+                'source installers/macos/lib/env-generator.sh; '
+                'generate_ods_env "$1" 3 false >/dev/null',
+                "ods-embedding-empty-contract", str(empty_override_dir),
+            ],
+            cwd=ROOT,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        empty_values = read_env(empty_override_dir / ".env")
+        assert empty_values["RAG_EMBEDDING_MODEL"] == ""
+        assert empty_values["RAG_OPENAI_API_BASE_URL"] == ""
+        assert empty_values["RAG_OPENAI_API_KEY"] == ""
+
+
+def main() -> int:
+    tests = [
+        test_bundled_rag_inherits_canonical_model,
+        test_external_rag_override_does_not_change_bundled_tei,
+        test_installers_write_or_backfill_canonical_model,
+    ]
+    if shutil.which("pwsh"):
+        tests.append(test_windows_env_generator_renders_embedding_contract)
+    else:
+        print("[SKIP] test_windows_env_generator_renders_embedding_contract (pwsh unavailable)")
+    if os.name != "nt" and shutil.which("bash"):
+        tests.append(test_macos_env_generator_renders_embedding_contract)
+    else:
+        print("[SKIP] test_macos_env_generator_renders_embedding_contract (POSIX bash unavailable)")
+    for test in tests:
+        test()
+        print(f"[PASS] {test.__name__}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ods/tests/test-generated-config-contracts.sh
+++ b/ods/tests/test-generated-config-contracts.sh
@@ -6,5 +6,6 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 python3 -m py_compile "$ROOT_DIR/scripts/validate-generated-configs.py"
 python3 "$ROOT_DIR/scripts/validate-generated-configs.py" "$ROOT_DIR/config/generated-config-contracts.json"
 python3 "$ROOT_DIR/tests/test-fedora-strix-compat.py"
+python3 "$ROOT_DIR/tests/test-embedding-model-contract.py"
 
 echo "[PASS] generated config contract test"

--- a/ods/tests/test-validate-env.sh
+++ b/ods/tests/test-validate-env.sh
@@ -177,6 +177,129 @@ else
     fail "Output should report a minLength violation"
 fi
 
+# 8. Bundled TEI does not accept GGUF/Q4 artifacts.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/gguf-embedding.env"
+echo "EMBEDDING_MODEL=BAAI/bge-m3-Q4_K_M-GGUF" >> "$TMP_DIR/gguf-embedding.env"
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/gguf-embedding.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]] && echo "$out" | grep -q "GGUF/Q4"; then
+    pass "GGUF embedding artifact is rejected with an actionable error"
+else
+    fail "GGUF embedding artifact should yield exit 2 and explain TEI compatibility"
+fi
+
+# 9. Open WebUI may only name a different model when it uses an external endpoint.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/rag-mismatch.env"
+cat >> "$TMP_DIR/rag-mismatch.env" <<'EOF'
+EMBEDDING_MODEL=BAAI/bge-m3
+RAG_EMBEDDING_MODEL=BAAI/bge-base-en-v1.5
+RAG_OPENAI_API_BASE_URL=http://embeddings:80/v1
+EOF
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/rag-mismatch.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]] && echo "$out" | grep -q "bundled TEI serves EMBEDDING_MODEL only"; then
+    pass "Bundled TEI/Open WebUI model mismatch is rejected"
+else
+    fail "Bundled TEI/Open WebUI model mismatch should yield exit 2"
+fi
+
+# 10. A distinct model is valid when Open WebUI targets an external provider.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/external-rag.env"
+cat >> "$TMP_DIR/external-rag.env" <<'EOF'
+EMBEDDING_MODEL=BAAI/bge-m3
+RAG_EMBEDDING_MODEL=external-embed-v2
+RAG_OPENAI_API_BASE_URL=https://embeddings.example.test/v1
+RAG_OPENAI_API_KEY=external-test-key
+EMBEDDINGS_MEMORY_LIMIT=6GB
+EOF
+set +e
+"$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/external-rag.env" "$ROOT_DIR/.env.schema.json" >/dev/null 2>&1
+r=$?
+set -e
+if [[ $r -eq 0 ]]; then
+    pass "External RAG provider override remains valid"
+else
+    fail "External RAG provider override should yield exit 0, got $r"
+fi
+
+# 11. Invalid Docker memory values fail before compose rendering.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/invalid-memory.env"
+echo "EMBEDDINGS_MEMORY_LIMIT=lots" >> "$TMP_DIR/invalid-memory.env"
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/invalid-memory.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]] && echo "$out" | grep -q "EMBEDDINGS_MEMORY_LIMIT"; then
+    pass "Invalid embeddings memory limit is rejected before compose"
+else
+    fail "Invalid embeddings memory limit should yield exit 2"
+fi
+
+# 12. Invalid external endpoints fail before Open WebUI is recreated.
+cp "$TMP_DIR/valid.env" "$TMP_DIR/invalid-rag-url.env"
+echo "RAG_OPENAI_API_BASE_URL=embeddings.example.test/v1" >> "$TMP_DIR/invalid-rag-url.env"
+set +e
+out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/invalid-rag-url.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+r=$?
+set -e
+if [[ $r -eq 2 ]] && echo "$out" | grep -q "HTTP(S)"; then
+    pass "Invalid RAG endpoint is rejected before Open WebUI recreation"
+else
+    fail "Invalid RAG endpoint should yield exit 2"
+fi
+
+# 13. URL validation rejects an empty/malformed authority, embedded credentials,
+# invalid ports, and fragments instead of deferring failure to Open WebUI.
+for invalid_url in 'http://' 'https://:443/v1' 'https://example.test:70000/v1' 'https://user:secret@example.test/v1' "'https://example.test/v1#fragment'" 'https://example.test\v1' 'https://example.test:999999999999999999999/v1'; do
+    display_url="${invalid_url//\\/\\\\}"
+    cp "$TMP_DIR/valid.env" "$TMP_DIR/malformed-rag-url.env"
+    printf 'RAG_OPENAI_API_BASE_URL=%s\n' "$invalid_url" >> "$TMP_DIR/malformed-rag-url.env"
+    set +e
+    out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/malformed-rag-url.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+    r=$?
+    set -e
+    if [[ $r -eq 2 ]] && echo "$out" | grep -q "RAG_OPENAI_API_BASE_URL"; then
+        pass "Malformed RAG endpoint is rejected: $display_url"
+    else
+        fail "Malformed RAG endpoint should be rejected: $display_url"
+    fi
+done
+
+# 14. Internal DNS, IPv4, bracketed IPv6, and query strings remain valid.
+for valid_url in 'http://embeddings:80/v1' 'https://embeddings.example.test/v1?tenant=ods' 'http://127.0.0.1:8090/v1' 'http://[::1]:8090/v1'; do
+    cp "$TMP_DIR/valid.env" "$TMP_DIR/well-formed-rag-url.env"
+    echo "RAG_OPENAI_API_BASE_URL=$valid_url" >> "$TMP_DIR/well-formed-rag-url.env"
+    set +e
+    out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/well-formed-rag-url.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+    r=$?
+    set -e
+    if [[ $r -eq 0 ]]; then
+        pass "Well-formed RAG endpoint is accepted: $valid_url"
+    else
+        fail "Well-formed RAG endpoint should be accepted: $valid_url"
+    fi
+done
+
+# 15. Quantization-only repository names are incompatible even when they do
+# not contain the literal GGUF suffix.
+for quantized_model in 'someone/bge-m3-Q4_K_M' 'someone/bge-m3-q8_0' 'someone/bge-m3-GGML'; do
+    cp "$TMP_DIR/valid.env" "$TMP_DIR/quantized-embedding.env"
+    echo "EMBEDDING_MODEL=$quantized_model" >> "$TMP_DIR/quantized-embedding.env"
+    set +e
+    out=$("$VALIDATE_ENV_BASH" "$ROOT_DIR/scripts/validate-env.sh" "$TMP_DIR/quantized-embedding.env" "$ROOT_DIR/.env.schema.json" 2>&1)
+    r=$?
+    set -e
+    if [[ $r -eq 2 ]] && echo "$out" | grep -q "EMBEDDING_MODEL"; then
+        pass "Quantized embedding artifact is rejected: $quantized_model"
+    else
+        fail "Quantized embedding artifact should be rejected: $quantized_model"
+    fi
+done
+
 echo ""
 echo "Result: $PASSED passed, $FAILED failed"
 [[ $FAILED -eq 0 ]]


### PR DESCRIPTION
## Summary

Make the bundled Hugging Face TEI model the canonical RAG embedding model across Compose, Open WebUI, Linux, macOS, Windows, and Dashboard Settings.

This closes the configuration gap where `EMBEDDING_MODEL` could change TEI while Open WebUI retained another model, and where Settings could save a valid change without safely applying or retaining the remaining operational work.

## Problem

ODS previously had independently defaulted model fields:

- `EMBEDDING_MODEL` selects the model loaded by bundled TEI.
- `RAG_EMBEDDING_MODEL` selects the model requested by Open WebUI.

Changing only the first could leave producer and consumer out of sync. Existing Open WebUI installations add a second constraint: RAG `ConfigVar` values are database-backed after first boot, so recreating the container cannot safely overwrite an operator's Admin Panel configuration.

Additional confirmed gaps found during adversarial review:

- disabled `embeddings` installs were offered an apply action for a Compose service that did not exist;
- a rerun could replace an explicitly empty external-provider override with a process environment value;
- malformed external URLs and llama.cpp-style GGUF/GGML quantization artifacts reached runtime validation too late;
- post-apply synchronization/reindex instructions disappeared after reload;
- the optional external RAG credential could be replaced but not explicitly removed;
- Linux rerun and legacy Windows backfill behavior lacked executable coverage.

## Contract

| Concern | Preserved behavior |
|---|---|
| Bundled model | `EMBEDDING_MODEL` is loaded by TEI and becomes the fresh-install Open WebUI RAG default. |
| External provider | `RAG_OPENAI_API_BASE_URL`, `RAG_EMBEDDING_MODEL`, and optional `RAG_OPENAI_API_KEY` override Open WebUI only. |
| Empty override | An explicitly empty RAG override continues to select bundled TEI across installer reruns. |
| Runtime memory | `EMBEDDINGS_MEMORY_LIMIT` controls the TEI container limit using Docker byte units such as `4096M`, `4G`, or `6GB`. |
| Active apply | A model change recreates active consumers and the active embeddings producer. |
| Disabled embeddings | Configuration is staged without attempting an invalid Compose start; active Open WebUI is still refreshed so future enablement cannot retain stale environment. |
| Persistent Open WebUI config | Required Admin Panel synchronization and reindex actions persist in browser storage until explicitly completed. |
| Optional credential | Leaving a masked secret blank preserves it; only `RAG_OPENAI_API_KEY` exposes an explicit schema-authorized clear action. |
| Partial failure | `.env` and its timestamped backup remain durable, apply failure is reported, and pending work remains retryable. |
| Existing vectors | Model or endpoint changes require knowledge-base reindexing; direct-chat files must be uploaded again. |

## Changes

### Runtime and Compose

- Derive Open WebUI's first-boot RAG model from `EMBEDDING_MODEL` with nested Compose interpolation.
- Make TEI memory configurable without editing Compose.
- Preserve explicit external provider model, endpoint, and credential overrides.
- Render bundled and external configurations through real `docker compose config` assertions.

### Cross-platform install and upgrade

- Generate the same embedding/RAG contract on Linux, macOS, and Windows.
- Backfill missing keys in older installs without replacing existing non-empty values.
- Distinguish an absent optional override from an explicitly empty override on all three platforms.
- Exercise clean generation, legacy backfill, and a second installer execution.

### Dashboard lifecycle

- Recreate only services that are actually enabled, while reporting disabled services as staged.
- Keep Open WebUI synchronized when it inherits the canonical model, including when TEI is currently disabled.
- Preserve manual restart and disabled-service work after applying active services.
- Persist required Open WebUI follow-up receipts across reloads, with guarded browser-storage access.
- Add a fail-closed `clearSecrets` contract restricted to schema-authorized optional credentials.

### Validation and documentation

- Reject malformed HTTP(S) authorities, credentials in URLs, fragments, backslashes, and invalid ports before recreation.
- Reject URL and GGUF/GGML/llama.cpp quantization artifact identifiers for bundled TEI while preserving external provider overrides.
- Validate Docker memory values and bundled producer/consumer model consistency.
- Correct stale service names, health timing, CPU packaging, memory, recreate, retry, and reindex guidance.

## Adversarial scenarios

| Scenario | Evidence |
|---|---|
| Clean install | real Linux phase, Windows generator, macOS shell generator, and Compose render |
| Upgrade from old `.env` | missing-key backfill tests on Windows/macOS plus Linux phase smoke |
| Second execution | persisted values survive changed process defaults on Linux/Windows/macOS |
| Empty values | empty provider model, URL, and key remain empty on rerun |
| Explicit overrides | external endpoint/model/key render only into Open WebUI |
| Service disabled | no invalid `embeddings` apply; configuration is staged and consumer remains coherent |
| Partial/manual work | remaining restart and staged-service work survive active-service settlement |
| Secret removal | only the schema-authorized RAG credential can be cleared; other secrets fail closed |
| Failed apply | no false success; saved config and backup remain available for retry |
| Persistence | post-apply actions survive reload and malformed/blocked storage fails safely |

## Validation

- `python -m pytest ods/extensions/services/dashboard-api/tests -q` -> **1767 passed, 2 skipped**
- `python -m pytest ods/extensions/services/dashboard-api/tests/test_settings_env.py -q` -> **69 passed**
- `npm test -- --run` -> **207 passed**
- `npm run lint` -> passed
- `npm run build` -> passed
- `bash ods/tests/contracts/test-installer-contracts.sh` -> passed
- `bash ods/tests/test-generated-config-contracts.sh` -> passed
- `bash ods/tests/smoke/installer-env-smoke.sh` -> **13 passed**
- `bash ods/tests/test-validate-env.sh` -> **30 passed**
- `python ods/tests/test-embedding-model-contract.py` on Windows -> real Compose render and PowerShell generator passed
- `python3 ods/tests/test-embedding-model-contract.py` in POSIX -> real Compose render and macOS generator passed
- Ruff, Python compile, Bash syntax, PowerShell parser, JSON parse, and `git diff --check` -> passed

The full API suite has two platform skips. Its earlier pre-existing `AsyncMock` collection warning is outside this diff and does not fail the suite.

## Upgrade and rollback behavior

Existing Open WebUI data, `webui.db`, chats, knowledge bases, and embedding caches are preserved. Saving Settings writes `.env` through the host agent and creates a timestamped backup before any container recreation. Runtime apply is deliberately retryable rather than pretending to be an atomic multi-container transaction: a failure remains visible and does not erase the saved configuration or its pending plan.

## Residual limitations

- External endpoint syntax is validated, but reachability, credentials, and provider model availability require the real provider.
- Existing Open WebUI `ConfigVar` values cannot be overwritten safely without authenticated Admin Panel action; the durable follow-up receipt makes that work explicit.
- The follow-up receipt is browser-local, not a server-wide workflow record.
- Physical macOS runtime behavior remains covered by CI and the real POSIX generator contract; this local audit did not run on Apple hardware.

## Scope boundary

This PR does not change Lemonade discovery, Whisper/STT repair, chat-model swapping, or the model switchboard. Those are independent subsystems and remain outside this RAG embedding contract.

## References

- [Open WebUI environment configuration and persistent ConfigVar behavior](https://docs.openwebui.com/reference/env-configuration/)
- [Open WebUI RAG configuration](https://docs.openwebui.com/features/chat-conversations/rag/)
- [Hugging Face TEI supported models](https://huggingface.co/docs/text-embeddings-inference/supported_models)
- [Docker Compose byte-value units](https://docs.docker.com/reference/compose-file/extension/#specifying-byte-values)

