### PR TITLE
fix(switchboard): reconcile stale bootstrap routes

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -879,6 +879,54 @@ def _switchboard_state_needs_initial_verification(path: Path) -> bool:
     )
 
 
+def _switchboard_state_needs_current_env_verification(
+    path: Path,
+    env: dict | None = None,
+) -> bool:
+    """Return True when the verified route is absent or stale versus .env."""
+    if _switchboard_state is None:
+        return False
+    if env is None:
+        env = load_env(INSTALL_DIR / ".env")
+    identity = _switchboard_state.migrate_env_identity(env)
+    if not identity:
+        return False
+    doc, errors = _switchboard_state.read_state(path)
+    if errors or not isinstance(doc, dict):
+        return False
+    active = doc.get("active")
+    if not isinstance(active, dict):
+        return True
+    proof = active.get("proof")
+    if (
+        active.get("reconstructed") is True
+        or not isinstance(active.get("verifiedAt"), str)
+        or not active.get("verifiedAt")
+        or not isinstance(proof, dict)
+        or proof.get("completion") is not True
+    ):
+        return True
+
+    gguf_file = str(env.get("GGUF_FILE") or identity["runtimeModelId"])
+    llm_model_name = str(env.get("LLM_MODEL") or identity["catalogId"])
+    model_id, _model = _catalog_model_for_current_env(env)
+    if not _runtime_model_identity_matches(
+        active.get("runtimeModelId"),
+        model_id=model_id or identity["catalogId"],
+        gguf_file=gguf_file,
+        llm_model_name=llm_model_name,
+    ):
+        return True
+
+    backend_kind, endpoint_id, _native_route = _initial_switchboard_backend(env)
+    backend = active.get("backend")
+    return not (
+        isinstance(backend, dict)
+        and backend.get("kind") == backend_kind
+        and backend.get("endpointId") == endpoint_id
+    )
+
+
 def _catalog_model_for_current_env(env: dict) -> tuple[str, dict]:
     gguf_file = str(env.get("GGUF_FILE") or "").strip()
     llm_model_name = str(env.get("LLM_MODEL") or "").strip()
@@ -924,14 +972,14 @@ def _publish_verified_initial_switchboard_route(
     initial_delay: float = 0,
     interval: float = 10,
 ) -> bool:
-    """Promote reconstructed startup state only after runtime proof succeeds."""
+    """Promote current .env route only after runtime proof succeeds."""
     if _switchboard_state is None:
         return False
     state_path = _switchboard_state_path()
-    if not _switchboard_state_needs_initial_verification(state_path):
+    env = load_env(INSTALL_DIR / ".env")
+    if not _switchboard_state_needs_current_env_verification(state_path, env):
         return False
 
-    env = load_env(INSTALL_DIR / ".env")
     identity = _switchboard_state.migrate_env_identity(env)
     if not identity:
         return False
@@ -965,7 +1013,7 @@ def _publish_verified_initial_switchboard_route(
     ):
         logger.info("switchboard initial route proof discarded after env changed")
         return False
-    if not _switchboard_state_needs_initial_verification(state_path):
+    if not _switchboard_state_needs_current_env_verification(state_path, fresh_env):
         return False
 
     runtime_identity = str(proof["identity"])
@@ -1015,7 +1063,7 @@ def _schedule_initial_switchboard_verification(reason: str) -> None:
     if _switchboard_state is None:
         return
     state_path = _switchboard_state_path()
-    if not _switchboard_state_needs_initial_verification(state_path):
+    if not _switchboard_state_needs_current_env_verification(state_path):
         return
     with _switchboard_initial_verify_lock:
         thread = _switchboard_initial_verify_thread
@@ -1034,6 +1082,44 @@ def _schedule_initial_switchboard_verification(reason: str) -> None:
             daemon=True,
         )
         _switchboard_initial_verify_thread.start()
+
+
+def _bootstrap_status_indicates_complete() -> bool:
+    status_path = INSTALL_DIR / "data" / "bootstrap-status.json"
+    try:
+        data = json.loads(status_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return False
+    if not isinstance(data, dict):
+        return False
+    return str(data.get("status") or "").strip().casefold() == "complete"
+
+
+def _model_status_allows_route_proof(data: dict) -> bool:
+    status = str(data.get("status") or "").strip().casefold()
+    if status in {"already_downloaded", "complete"}:
+        return True
+    return _bootstrap_status_indicates_complete()
+
+
+def _verify_switchboard_route_for_status(data: dict, reason: str) -> None:
+    if _switchboard_state is None:
+        return
+    state_path = _switchboard_state_path()
+    if not _switchboard_state_needs_current_env_verification(state_path):
+        return
+    if _model_status_allows_route_proof(data):
+        try:
+            if _publish_verified_initial_switchboard_route(
+                reason=reason,
+                attempts=1,
+                initial_delay=0,
+                interval=0,
+            ):
+                return
+        except Exception as exc:
+            logger.warning("switchboard route status proof failed: %s", exc)
+    _schedule_initial_switchboard_verification(reason)
 
 
 def _atomic_write_bytes(
@@ -4895,17 +4981,21 @@ class AgentHandler(BaseHTTPRequestHandler):
         """Return current model download progress."""
         if not check_auth(self):
             return
-        _schedule_initial_switchboard_verification("model-status")
         status_path = INSTALL_DIR / "data" / "model-download-status.json"
         if not status_path.exists():
-            json_response(self, 200, {"status": "idle"})
+            data = {"status": "idle"}
+            _verify_switchboard_route_for_status(data, "model-status")
+            json_response(self, 200, data)
             return
         try:
             data = _read_model_status(status_path)
             data = _normalize_model_download_status(status_path, data)
+            _verify_switchboard_route_for_status(data, "model-status")
             json_response(self, 200, data)
         except (json.JSONDecodeError, OSError):
-            json_response(self, 200, {"status": "idle"})
+            data = {"status": "idle"}
+            _verify_switchboard_route_for_status(data, "model-status")
+            json_response(self, 200, data)
 
     def _handle_model_download(self):
         """Start async model download. Only one download at a time.

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -4654,6 +4654,98 @@ class TestModelDownloadFileIntegrity:
         persisted = json.loads(status_path.read_text(encoding="utf-8"))
         assert persisted["status"] == "failed"
 
+    def test_model_status_promotes_stale_bootstrap_route_after_full_model_ready(
+        self, tmp_path, monkeypatch,
+    ):
+        bootstrap_model = {
+            "id": "qwen3.5-2b-q4",
+            "gguf_file": "Qwen3.5-2B-Q4_K_M.gguf",
+            "llm_model_name": "qwen3.5-2b-q4",
+            "ctx_size": 65536,
+        }
+        full_model = {
+            "id": "qwen3-coder-next",
+            "gguf_file": "qwen3-coder-next-Q4_K_M.gguf",
+            "llm_model_name": "qwen3-coder-next",
+            "ctx_size": 131072,
+        }
+        install_dir = self._setup_env(
+            tmp_path,
+            monkeypatch,
+            library_models=[bootstrap_model, full_model],
+        )
+        env_path = install_dir / ".env"
+        env_path.write_text(
+            "ODS_MODE=local\n"
+            "GPU_BACKEND=nvidia\n"
+            "GGUF_FILE=qwen3-coder-next-Q4_K_M.gguf\n"
+            "LLM_MODEL=qwen3-coder-next\n"
+            "CTX_SIZE=131072\n",
+            encoding="utf-8",
+        )
+        state_path = install_dir / "data" / "model-state.json"
+        _mod._switchboard_state.record_verified_route(
+            state_path,
+            catalog_id="qwen3.5-2b-q4",
+            runtime_model_id="Qwen3.5-2B-Q4_K_M.gguf",
+            backend_kind="llama-server",
+            endpoint_id="llama-server-default",
+            context_length=65536,
+            capabilities={
+                "chat": True,
+                "tools": False,
+                "vision": False,
+                "agentViable": True,
+            },
+            proof_identity="Qwen3.5-2B-Q4_K_M.gguf",
+        )
+        (install_dir / "data" / "bootstrap-status.json").write_text(
+            json.dumps({
+                "status": "complete",
+                "model": "qwen3-coder-next-Q4_K_M.gguf",
+            }),
+            encoding="utf-8",
+        )
+
+        readiness_calls = []
+
+        def readiness(*_args, **kwargs):
+            readiness_calls.append(kwargs)
+            return {
+                "identity": "qwen3-coder-next-Q4_K_M.gguf",
+                "contextLength": 131072,
+                "contextVerified": True,
+                "verifiedAt": "2026-07-21T00:00:00Z",
+            }
+
+        scheduled = []
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", readiness)
+        monkeypatch.setattr(
+            _mod,
+            "_schedule_initial_switchboard_verification",
+            lambda reason: scheduled.append(reason),
+        )
+
+        handler = _FakeHandler(b"")
+        _mod.AgentHandler._handle_model_status(handler)
+
+        assert handler.response_code == 200
+        assert handler.parse_response() == {"status": "idle"}
+        assert readiness_calls
+        assert readiness_calls[0]["attempts"] == 1
+        assert readiness_calls[0]["initial_delay"] == 0
+        assert readiness_calls[0]["interval"] == 0
+        assert scheduled == []
+        doc = json.loads(state_path.read_text(encoding="utf-8"))
+        assert doc["active"]["catalogId"] == "qwen3-coder-next"
+        assert doc["active"]["runtimeModelId"] == "qwen3-coder-next-Q4_K_M.gguf"
+        assert doc["active"]["contextLength"] == 131072
+        assert doc["active"]["proof"] == {
+            "identity": "qwen3-coder-next-Q4_K_M.gguf",
+            "completion": True,
+        }
+        assert doc["history"][0]["runtimeModelId"] == "Qwen3.5-2B-Q4_K_M.gguf"
+
     def test_empty_finished_download_is_failed_not_complete(self, tmp_path, monkeypatch):
         install_dir = self._setup_env(tmp_path, monkeypatch)
         self._patch_curl_download(monkeypatch, b"")

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -3092,5 +3092,33 @@ elif [[ -f "$HOME/Library/LaunchAgents/com.ods.host-agent.plist" ]]; then
         log "WARNING: Could not restart host agent (non-fatal)"
 fi
 
+notify_host_agent_model_status() {
+    local key port bind host attempt
+    key="$(read_env_value ODS_AGENT_KEY)"
+    [[ -n "$key" ]] || key="$(read_env_value DASHBOARD_API_KEY)"
+    if [[ -z "$key" ]]; then
+        log "WARNING: ODS agent key missing; cannot notify host agent about full-model route"
+        return 1
+    fi
+    port="$(read_env_value ODS_AGENT_PORT)"
+    [[ -n "$port" ]] || port="7710"
+    bind="$(read_env_value ODS_AGENT_BIND)"
+    for attempt in {1..10}; do
+        for host in "$bind" "127.0.0.1" "localhost" "172.17.0.1"; do
+            [[ -n "$host" ]] || continue
+            if curl -fsS --max-time 20 \
+                -H "Authorization: Bearer $key" \
+                "http://${host}:${port}/v1/model/status" >/dev/null 2>&1; then
+                log "Host agent accepted full-model route reconciliation."
+                return 0
+            fi
+        done
+        sleep 2
+    done
+    log "WARNING: Host agent did not accept full-model route reconciliation (non-fatal)"
+    return 1
+}
+
 write_status "complete" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 ""
+notify_host_agent_model_status || true
 log "Bootstrap upgrade complete."

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -184,6 +184,19 @@ assert_in_order "$restart_windows_lemonade_block" "Windows Lemonade context prop
     'write_env_value LEMONADE_MODEL "$model_id"'
 pass "Windows Lemonade restart propagates and verifies the promoted context before commit"
 
+host_agent_notify_block="$(function_block notify_host_agent_model_status | grep -v '^[[:space:]]*#')"
+grep -qF '/v1/model/status' <<<"$host_agent_notify_block" \
+    || fail "bootstrap upgrade must notify host-agent model status after full-model completion"
+grep -qF 'Authorization: Bearer $key' <<<"$host_agent_notify_block" \
+    || fail "host-agent model status notification must authenticate with ODS_AGENT_KEY"
+grep -qF '172.17.0.1' <<<"$host_agent_notify_block" \
+    || fail "host-agent model status notification must try the Linux docker-bridge bind"
+final_status_block="$(tail -n 90 "$TARGET" | grep -v '^[[:space:]]*#')"
+assert_in_order "$final_status_block" "full-model route reconciliation" \
+    'write_status "complete" 100 "$TOTAL_BYTES" "$TOTAL_BYTES" 0 ""' \
+    'notify_host_agent_model_status || true'
+pass "bootstrap upgrade reconciles host-agent route after full-model completion"
+
 verify_context_block="$(function_block verify_windows_lemonade_loaded_context | grep -v '^[[:space:]]*#')"
 grep -qF 'all_models_loaded' <<<"$verify_context_block" \
     || fail "Windows Lemonade loaded-context verifier must inspect health all_models_loaded"


### PR DESCRIPTION
﻿## Summary
- reconcile switchboard state when `.env` has advanced from the bootstrap model to the full model but `model-state.json` still points at the verified bootstrap route
- trigger strict route proof from `/v1/model/status` once bootstrap/download status says the model is complete
- have `bootstrap-upgrade.sh` notify the host-agent after writing full-model completion so the product updates its own route without relying on dashboard polling

## Fleet evidence
Current main run `2026-07-21T02-10-05Z-release-product-e40f155df51b-harness-87c7c18f88ab-hosts-tower2-strix-halo-spark-dgx-gpu01-m5-mbp-windows-laptop-strixy` exposed the bug on tower2:
- `.env`: `GGUF_FILE=qwen3-coder-next-Q4_K_M.gguf`
- llama-server `/v1/models`: `qwen3-coder-next-Q4_K_M.gguf`
- direct llama-server chat: `READY`
- `model-state.json`: still verified on bootstrap `Qwen3.5-2B-Q4_K_M.gguf`
- Hermes/LiteLLM: `503 No verified active model route is available yet` for `qwen3-coder-next-Q4_K_M.gguf`

## Validation
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py -k "model_status_promotes_stale_bootstrap_route_after_full_model_ready or status_marks_dead_active_download_failed"`
- `C:\Program Files\Git\bin\bash.exe tests/test-bootstrap-upgrade-hotswap-contract.sh`
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py extensions/services/dashboard-api/tests/test_models.py tests/test-model-library-coverage.py extensions/services/dashboard-api/tests/test_performance_oracle.py extensions/services/dashboard-api/tests/test_talk.py extensions/services/dashboard-api/tests/test_model_state.py extensions/services/dashboard-api/tests/test_model_routes.py extensions/services/dashboard-api/tests/test_switchboard_reconciler.py extensions/services/model-router/tests/test_router.py`
