### PR TITLE
fix(hermes): use switchboard alias for model routing

### DIFF
--- a/ods/installers/phases/11-services.sh
+++ b/ods/installers/phases/11-services.sh
@@ -896,7 +896,10 @@ MODELS_INI_EOF
         if [[ -f "$_hermes_tpl" ]]; then
             # Model name: cloud mode uses the routed model id; Lemonade
             # prefixes GGUF files with "extra."; llama.cpp uses the file name.
-            if [[ "${ODS_MODE:-local}" == "cloud" ]]; then
+            _hermes_switchboard_mode="$(printf '%s' "${ODS_MODEL_SWITCHBOARD:-observe}" | tr '[:upper:]' '[:lower:]')"
+            if [[ "$_hermes_switchboard_mode" == "enabled" ]]; then
+                _hermes_model="ods/current"
+            elif [[ "${ODS_MODE:-local}" == "cloud" ]]; then
                 _hermes_model="${LLM_MODEL:-default}"
             elif _phase11_external_lemonade; then
                 _hermes_model="${LEMONADE_MODEL:-$(_phase11_env_get LEMONADE_MODEL "${LLM_MODEL:-default}")}"
@@ -917,7 +920,10 @@ MODELS_INI_EOF
             # macOS install-macos.sh handles the host.docker.internal swap.
             _hermes_base_url=""
             _hermes_api_key=""
-            if [[ "${ODS_MODE:-local}" == "cloud" ]]; then
+            if [[ "$_hermes_switchboard_mode" == "enabled" ]]; then
+                _hermes_base_url="${HERMES_LLM_BASE_URL:-http://litellm:4000/v1}"
+                _hermes_api_key="${HERMES_LLM_API_KEY:-${LITELLM_KEY:-}}"
+            elif [[ "${ODS_MODE:-local}" == "cloud" ]]; then
                 _hermes_base_url="${HERMES_LLM_BASE_URL:-http://litellm:4000/v1}"
                 _hermes_api_key="${HERMES_LLM_API_KEY:-${LITELLM_KEY:-}}"
             elif [[ "${GPU_BACKEND:-}" == "amd" ]] || _phase11_external_lemonade; then
@@ -926,7 +932,9 @@ MODELS_INI_EOF
             fi
             _hermes_context="${MAX_CONTEXT:-65536}"
             _hermes_request_timeout=180
-            if [[ "${ODS_MODE:-local}" != "cloud" ]] && { [[ "${GPU_BACKEND:-}" == "amd" ]] || _phase11_external_lemonade; }; then
+            if [[ "$_hermes_switchboard_mode" == "enabled" ]]; then
+                _hermes_request_timeout=900
+            elif [[ "${ODS_MODE:-local}" != "cloud" ]] && { [[ "${GPU_BACKEND:-}" == "amd" ]] || _phase11_external_lemonade; }; then
                 _hermes_request_timeout=900
             fi
             _hermes_patcher="$INSTALL_DIR/scripts/patch-hermes-config.py"

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -234,16 +234,23 @@ function Set-ODSWindowsHermesRuntimeModel {
     if (-not $enableHermes) { return $true }
 
     $runtimeEnv = Get-WindowsODSEnvMap -InstallDir $installDir
+    $switchboardMode = Get-WindowsODSEnvValue `
+        -EnvMap $runtimeEnv -Keys @("ODS_MODEL_SWITCHBOARD") `
+        -Default "observe"
+    $switchboardEnabled = ($switchboardMode.Trim().ToLowerInvariant() -eq "enabled")
+    if ($switchboardEnabled) {
+        $ModelId = "ods/current"
+    }
     $hermesBaseUrl = Get-WindowsODSEnvValue `
         -EnvMap $runtimeEnv -Keys @("HERMES_LLM_BASE_URL") `
-        -Default $(if ($cloudMode -or $gpuInfo.Backend -eq "amd") {
+        -Default $(if ($cloudMode -or $gpuInfo.Backend -eq "amd" -or $switchboardEnabled) {
             "http://litellm:4000/v1"
         } else {
             "http://llama-server:8080/v1"
         })
     $hermesTemplate = Join-Path (Join-Path (Join-Path $installDir "extensions") "services\hermes") "cli-config.yaml.template"
     $hermesLive = Join-Path (Join-Path $installDir "data\hermes") "config.yaml"
-    $hermesRequestTimeout = $(if ($cloudMode) { 180 } else { 900 })
+    $hermesRequestTimeout = $(if ($cloudMode -and -not $switchboardEnabled) { 180 } else { 900 })
     $templateUpdated = Update-HermesConfigFile -Path $hermesTemplate -Model $ModelId -BaseUrl $hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext) `
         -RequestTimeoutSeconds $hermesRequestTimeout `
         -LemonadeCompact:($gpuInfo.Backend -eq "amd")

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -526,6 +526,11 @@ function Invoke-HermesSoulRefresh {
 }
 
 if ($enableHermes) {
+    $_switchboardMode = $(if ($_envLines.ContainsKey("ODS_MODEL_SWITCHBOARD")) {
+        ([string]$_envLines["ODS_MODEL_SWITCHBOARD"]).Trim().ToLowerInvariant()
+    } else {
+        "observe"
+    })
     $_hermesModel = $(if ($tierConfig.GgufFile) {
         if ($gpuInfo.Backend -eq "amd" -and
             $_envLines.ContainsKey("LEMONADE_MODEL") -and
@@ -537,12 +542,15 @@ if ($enableHermes) {
     } else {
         $tierConfig.LlmModel
     })
+    if ($_switchboardMode -eq "enabled") {
+        $_hermesModel = "ods/current"
+    }
     $_hermesBaseUrl = ""
     if ($_envLines.ContainsKey("HERMES_LLM_BASE_URL")) {
         $_hermesBaseUrl = $_envLines["HERMES_LLM_BASE_URL"].Trim().Trim('"').Trim("'")
     }
     if ([string]::IsNullOrWhiteSpace($_hermesBaseUrl)) {
-        $_hermesBaseUrl = $(if ($cloudMode -or $gpuInfo.Backend -eq "amd") {
+        $_hermesBaseUrl = $(if ($cloudMode -or $gpuInfo.Backend -eq "amd" -or $_switchboardMode -eq "enabled") {
             "http://litellm:4000/v1"
         } else {
             "http://llama-server:8080/v1"
@@ -557,7 +565,7 @@ if ($enableHermes) {
     if (-not (Test-Path $_hermesLive)) {
         Copy-Item -Path $_hermesTemplate -Destination $_hermesLive -Force
     }
-    $_hermesRequestTimeout = $(if ($cloudMode) { 180 } else { 900 })
+    $_hermesRequestTimeout = $(if ($cloudMode -and $_switchboardMode -ne "enabled") { 180 } else { 900 })
     $_patchedHermesTemplate = Update-HermesConfigFile -Path $_hermesTemplate -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext) -RequestTimeoutSeconds $_hermesRequestTimeout -LemonadeCompact:($gpuInfo.Backend -eq "amd")
     $_patchedHermesLive = Update-HermesConfigFile -Path $_hermesLive -Model $_hermesModel -BaseUrl $_hermesBaseUrl -ContextLength ([int]$tierConfig.MaxContext) -RequestTimeoutSeconds $_hermesRequestTimeout -LemonadeCompact:($gpuInfo.Backend -eq "amd")
     if (-not ($_patchedHermesTemplate -and $_patchedHermesLive)) {

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -1270,9 +1270,10 @@ patch_hermes_yaml_with_sed() {
 }
 
 patch_hermes_model_after_swap() {
-    local runtime llm_backend hermes_base_url old_model new_model tpl live live_host_patch_failed hermes_request_timeout
+    local runtime llm_backend switchboard_mode hermes_base_url old_model new_model tpl live live_host_patch_failed hermes_request_timeout
     runtime="$(read_env_value AMD_INFERENCE_RUNTIME | tr '[:upper:]' '[:lower:]')"
     llm_backend="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
+    switchboard_mode="$(read_env_value ODS_MODEL_SWITCHBOARD | tr '[:upper:]' '[:lower:]')"
     hermes_base_url="$(read_env_value HERMES_LLM_BASE_URL)"
     old_model="$BOOTSTRAP_GGUF_FILE"
     new_model="$FULL_GGUF_FILE"
@@ -1281,10 +1282,14 @@ patch_hermes_model_after_swap() {
         new_model="$(read_env_value LEMONADE_MODEL)"
         [[ -n "$new_model" ]] || new_model="extra.$FULL_GGUF_FILE"
     fi
+    if [[ "$switchboard_mode" == "enabled" ]]; then
+        new_model="ods/current"
+        [[ -n "$hermes_base_url" ]] || hermes_base_url="http://litellm:4000/v1"
+    fi
 
     log "Patching Hermes config after full-model swap: ${old_model} -> ${new_model}"
     hermes_request_timeout=180
-    if is_windows_bash || [[ "$runtime" == "lemonade" || "$llm_backend" == "lemonade" ]]; then
+    if is_windows_bash || [[ "$switchboard_mode" == "enabled" || "$runtime" == "lemonade" || "$llm_backend" == "lemonade" ]]; then
         hermes_request_timeout=900
     fi
 
@@ -2684,16 +2689,21 @@ LITELLM_UPGRADE_EOF
         _hermes_old_model="$BOOTSTRAP_GGUF_FILE"
         _hermes_new_model="$FULL_GGUF_FILE"
         _hermes_base_url="$(read_env_value HERMES_LLM_BASE_URL)"
+        _hermes_switchboard_mode="$(read_env_value ODS_MODEL_SWITCHBOARD | tr '[:upper:]' '[:lower:]')"
         _gpu_backend_for_hermes=$(grep -E '^GPU_BACKEND=' "$ENV_FILE" 2>/dev/null | cut -d= -f2 | tr -d '"\047\r' || echo "")
         if [[ "$_gpu_backend_for_hermes" == "amd" ]]; then
             _hermes_old_model="extra.$BOOTSTRAP_GGUF_FILE"
             _hermes_new_model="$(read_env_value LEMONADE_MODEL)"
             [[ -n "$_hermes_new_model" ]] || _hermes_new_model="extra.$FULL_GGUF_FILE"
         fi
+        if [[ "$_hermes_switchboard_mode" == "enabled" ]]; then
+            _hermes_new_model="ods/current"
+            [[ -n "$_hermes_base_url" ]] || _hermes_base_url="http://litellm:4000/v1"
+        fi
         log "Patching Hermes config: model.default $_hermes_old_model -> $_hermes_new_model"
         _hermes_request_timeout=180
         _hermes_llm_backend_for_timeout="$(read_env_value LLM_BACKEND | tr '[:upper:]' '[:lower:]')"
-        if is_windows_bash || [[ "$_gpu_backend_for_hermes" == "amd" || "$_hermes_llm_backend_for_timeout" == "lemonade" ]]; then
+        if is_windows_bash || [[ "$_hermes_switchboard_mode" == "enabled" || "$_gpu_backend_for_hermes" == "amd" || "$_hermes_llm_backend_for_timeout" == "lemonade" ]]; then
             _hermes_request_timeout=900
         fi
 

--- a/ods/scripts/render-runtime-configs.py
+++ b/ods/scripts/render-runtime-configs.py
@@ -59,6 +59,8 @@ def lemonade_model_id(inputs: RenderInputs) -> str:
 
 
 def hermes_model_id(inputs: RenderInputs) -> str:
+    if inputs.switchboard_mode == "enabled":
+        return "ods/current"
     if inputs.ods_mode == "lemonade" or inputs.gpu_backend == "amd":
         return lemonade_model_id(inputs)
     return inputs.gguf_file or inputs.model
@@ -103,10 +105,15 @@ litellm_settings:
 
 def render_hermes(inputs: RenderInputs) -> RenderedFile:
     model = hermes_model_id(inputs)
+    base_url = (
+        "http://litellm:4000/v1"
+        if inputs.switchboard_mode == "enabled"
+        else inputs.llm_base_url
+    )
     content = f"""model:
   default: "{model}"
   provider: "custom"
-  base_url: "{inputs.llm_base_url}"
+  base_url: "{base_url}"
   context_length: {inputs.context_length}
 
 auxiliary:

--- a/ods/tests/contracts/test-windows-hermes-config-patching.sh
+++ b/ods/tests/contracts/test-windows-hermes-config-patching.sh
@@ -95,6 +95,22 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 6b. Switchboard mode exposes stable model aliases through LiteLLM. Windows
+#     Hermes must not keep requesting raw GGUF/Lemonade model IDs when the
+#     gateway only advertises ods/current/default/local.
+# ---------------------------------------------------------------------------
+if grep -q 'ODS_MODEL_SWITCHBOARD' "$PHASE" \
+   && grep -q 'ODS_MODEL_SWITCHBOARD' "$MONO" \
+   && grep -q '\$_hermesModel = "ods/current"' "$PHASE" \
+   && grep -q '\$ModelId = "ods/current"' "$MONO" \
+   && grep -q '\$_switchboardMode -eq "enabled"' "$PHASE" \
+   && grep -q '\$switchboardEnabled' "$MONO"; then
+    pass "Windows Hermes config patching uses the stable switchboard alias"
+else
+    fail "Windows Hermes config patching must use ods/current when switchboard mode is enabled"
+fi
+
+# ---------------------------------------------------------------------------
 # 7. Windows local inference needs a longer Hermes provider timeout than the
 #    shared template default. The helper must expose a timeout parameter and
 #    both installer paths must pass the Windows-local value.

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -378,6 +378,20 @@ for injected_failure in native model-id litellm hermes openclaw openclaw-env rou
 done
 pass "Windows Lemonade activation rolls back every injected post-swap failure"
 
+grep -qF 'switchboard_mode="$(read_env_value ODS_MODEL_SWITCHBOARD' <<<"$active_code" \
+    || fail "Hermes post-swap patch helper must read switchboard mode"
+grep -qF '_hermes_switchboard_mode="$(read_env_value ODS_MODEL_SWITCHBOARD' <<<"$active_code" \
+    || fail "Docker full-model swap must read switchboard mode before patching Hermes"
+grep -qF 'new_model="ods/current"' <<<"$active_code" \
+    || fail "Hermes post-swap patch helper must use the stable switchboard alias"
+grep -qF '_hermes_new_model="ods/current"' <<<"$active_code" \
+    || fail "Docker full-model swap must patch Hermes to the stable switchboard alias"
+grep -qF 'hermes_base_url="http://litellm:4000/v1"' <<<"$active_code" \
+    || fail "Switchboard Hermes patch helper must route through LiteLLM"
+grep -qF '_hermes_base_url="http://litellm:4000/v1"' <<<"$active_code" \
+    || fail "Switchboard Docker swap must route Hermes through LiteLLM"
+pass "Hermes post-swap patch uses switchboard stable alias when enabled"
+
 perplexica_update_block="$(awk '
     /Updating Perplexica config to point at/ { in_block=1 }
     in_block { print }

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -105,6 +105,12 @@ assert_grep "installers/phases/11-services.sh" '_hermes_context="\$\{MAX_CONTEXT
     "Linux Hermes patcher uses selected context with 64K fallback"
 assert_grep "installers/phases/11-services.sh" '--context-length "\$_hermes_context"' \
     "Linux Hermes patcher receives context length"
+assert_grep "installers/phases/11-services.sh" '_hermes_switchboard_mode=.*ODS_MODEL_SWITCHBOARD' \
+    "Linux Hermes patcher reads switchboard mode"
+assert_grep "installers/phases/11-services.sh" '_hermes_model="ods/current"' \
+    "Linux Hermes patcher uses the stable switchboard model alias"
+assert_grep "installers/phases/11-services.sh" '_hermes_base_url=.*http://litellm:4000/v1' \
+    "Linux Hermes patcher routes switchboard mode through LiteLLM"
 assert_grep "installers/macos/install-macos.sh" '--context-length "\$MAX_CONTEXT"' \
     "macOS Hermes patcher receives context length"
 assert_grep "installers/macos/ods-macos.sh" 'ENV_CTX_SIZE:-65536' \

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -103,6 +103,23 @@ def test_enabled_perplexica_uses_stable_alias() -> None:
     assert openai_provider["chatModels"][0]["key"] == "ods/current"
 
 
+def test_enabled_hermes_uses_stable_switchboard_alias() -> None:
+    payload = run_renderer(
+        "--surface",
+        "hermes",
+        "--switchboard-mode",
+        "enabled",
+        "--gguf-file",
+        "Raw-Runtime.gguf",
+        "--llm-base-url",
+        "http://llama-server:8080/v1",
+    )
+    content = file_by_surface(payload, "hermes")["content"]
+    assert 'default: "ods/current"' in content
+    assert "Raw-Runtime.gguf" not in content
+    assert 'base_url: "http://litellm:4000/v1"' in content
+
+
 def test_router_endpoints_strip_trailing_v1() -> None:
     payload = run_renderer(
         "--surface", "model-router-endpoints",


### PR DESCRIPTION
## Summary
- patch Hermes to request ods/current whenever ODS_MODEL_SWITCHBOARD=enabled
- apply the rule in runtime rendering, Linux fresh install, Linux full-model bootstrap swap, and Windows installer paths
- keep switchboard Hermes routed through LiteLLM with the local long timeout

## Root cause
Tower2 on main 33c4adfe correctly reconciled model-state to qwen3-coder-next after the full-model swap, but Hermes still failed because its config requested qwen3-coder-next-Q4_K_M.gguf. LiteLLM was correctly in switchboard mode and advertised only ods/current, local, default, and *, so the raw GGUF model group was rejected.

## Validation
- bash -n scripts/bootstrap-upgrade.sh
- bash -n installers/phases/11-services.sh
- python -m pytest tests/test-render-runtime-configs.py
- tests/test-bootstrap-upgrade-hotswap-contract.sh
- tests/test-installer-context-parity.sh
- tests/contracts/test-windows-hermes-config-patching.sh
- PowerShell parser check for installers/windows/phases/06-directories.ps1 and installers/windows/install-windows.ps1