### PR TITLE
fix(switchboard): publish model state for router

### DIFF
--- a/ods/bin/model_switchboard/state.py
+++ b/ods/bin/model_switchboard/state.py
@@ -31,6 +31,7 @@ from typing import Any
 SCHEMA_VERSION = "ods.model-state.v1"
 HISTORY_LIMIT = 10
 PUBLIC_MODEL_DEFAULT = "ods/current"
+STATE_FILE_MODE = 0o644
 
 _BACKEND_KINDS = {"llama-server", "lemonade", "hipfire", "unknown"}
 _OPERATION_PHASES = {
@@ -355,6 +356,10 @@ def atomic_write_state(path: os.PathLike | str, doc: dict[str, Any]) -> None:
                 os.fsync(handle.fileno())
             except OSError:
                 pass
+        try:
+            os.chmod(tmp_name, STATE_FILE_MODE)
+        except OSError:
+            pass
         replace_error: OSError | None = None
         for _attempt in range(40):
             try:

--- a/ods/extensions/services/dashboard-api/tests/test_model_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import stat
 import sys
 import threading
 import time
@@ -47,6 +48,12 @@ class TestStateModule:
         jsonschema = pytest.importorskip("jsonschema")
         schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
         jsonschema.validate(read, schema)
+
+    def test_state_file_is_readable_by_model_router_user(self, tmp_path):
+        path = tmp_path / "model-state.json"
+        _record(path)
+        if os.name != "nt":
+            assert stat.S_IMODE(path.stat().st_mode) == sb.STATE_FILE_MODE == 0o644
 
     def test_seq_monotonic_routeseq_only_on_change(self, tmp_path):
         path = tmp_path / "model-state.json"


### PR DESCRIPTION
## Summary
- publish model-switchboard state files with mode 0644 instead of mkstemp's default 0600
- keep the change scoped to model-state.json, which contains routing metadata needed by model-router and no secrets
- add a regression asserting POSIX mode matches the router-readable contract

## Root cause
Tower2 on main c921bbab correctly wrote /home/michael/ods/data/model-state.json with the verified qwen3-coder-next route, but ods-model-router runs as uid 10777 and could not read the bind-mounted file because atomic_write_state inherited mkstemp's 0600 mode. Router health reported hasRoute:false and LiteLLM/Hermes received 503 for ods/current.

## Validation
- python -m py_compile bin/model_switchboard/state.py
- python -m pytest extensions/services/dashboard-api/tests/test_model_state.py