### PR TITLE
fix(opencode): route switchboard mode through stable alias

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -8827,6 +8827,13 @@ def _atomic_write_json(path: Path, value: dict, mode: int = 0o600) -> None:
 
 def _opencode_route(env: dict) -> tuple[str, str]:
     """Return the host-visible OpenAI-compatible endpoint and API key."""
+    if _normal_switchboard_mode(env) == "enabled":
+        port = str(env.get("LITELLM_PORT") or "4000")
+        api_key = str(env.get("LITELLM_KEY") or "")
+        if not api_key:
+            raise RuntimeError("LITELLM_KEY is required to update the OpenCode switchboard route")
+        return f"http://127.0.0.1:{port}/v1", api_key
+
     gpu_backend = str(env.get("GPU_BACKEND") or "nvidia").lower()
     if _is_windows_host_lemonade(env):
         port = str(env.get("AMD_INFERENCE_PORT") or env.get("OLLAMA_PORT") or "8080")
@@ -8851,9 +8858,17 @@ def _opencode_route(env: dict) -> tuple[str, str]:
     return f"http://{host}:{port}/v1", "no-key"
 
 
+def _opencode_model_route(env: dict, model_id: str) -> tuple[str, str, str]:
+    provider_id = "llama-server"
+    if _normal_switchboard_mode(env) == "enabled":
+        return provider_id, "ods/current", "ods/current"
+    return provider_id, model_id, model_id
+
+
 def _opencode_config_matches(
     config: object,
-    model_name: str,
+    provider_id: str,
+    model_id: str,
     base_url: str,
     api_key: str,
     context_length: int,
@@ -8861,14 +8876,15 @@ def _opencode_config_matches(
     if not isinstance(config, dict):
         return False
     provider = config.get("provider")
-    llama_provider = provider.get("llama-server") if isinstance(provider, dict) else None
+    llama_provider = provider.get(provider_id) if isinstance(provider, dict) else None
     options = llama_provider.get("options") if isinstance(llama_provider, dict) else None
     models = llama_provider.get("models") if isinstance(llama_provider, dict) else None
-    model = models.get(model_name) if isinstance(models, dict) else None
+    model = models.get(model_id) if isinstance(models, dict) else None
     limit = model.get("limit") if isinstance(model, dict) else None
+    model_ref = f"{provider_id}/{model_id}"
     return bool(
-        config.get("model") == f"llama-server/{model_name}"
-        and config.get("small_model") == f"llama-server/{model_name}"
+        config.get("model") == model_ref
+        and config.get("small_model") == model_ref
         and isinstance(options, dict)
         and options.get("baseURL") == base_url
         and options.get("apiKey") == api_key
@@ -8886,7 +8902,9 @@ def _update_opencode_config(
 ) -> None:
     """Update both OpenCode compatibility files and verify persisted routing."""
     base_url, api_key = _opencode_route(env)
-    display_name = display_name or model_id
+    provider_id, route_model_id, route_display_name = _opencode_model_route(env, model_id)
+    display_name = route_display_name if route_model_id != model_id else (display_name or model_id)
+    model_ref = f"{provider_id}/{route_model_id}"
 
     for path, previous in snapshot["files"].items():
         if not previous.get("write"):
@@ -8894,20 +8912,22 @@ def _update_opencode_config(
         source = previous.get("parsed") or snapshot["source"]
         config = json.loads(json.dumps(source))
         previous_model_ref = config.get("model")
-        config["model"] = f"llama-server/{model_id}"
-        config["small_model"] = f"llama-server/{model_id}"
+        config["model"] = model_ref
+        config["small_model"] = model_ref
         config.setdefault("$schema", "https://opencode.ai/config.json")
 
         providers = config.setdefault("provider", {})
         if not isinstance(providers, dict):
             providers = {}
             config["provider"] = providers
-        provider = providers.setdefault("llama-server", {})
+        provider = providers.setdefault(provider_id, {})
         if not isinstance(provider, dict):
             provider = {}
-            providers["llama-server"] = provider
+            providers[provider_id] = provider
         provider["npm"] = "@ai-sdk/openai-compatible"
-        provider["name"] = "llama-server (local)"
+        provider["name"] = (
+            "ODS switchboard" if route_model_id == "ods/current" else "llama-server (local)"
+        )
         options = provider.setdefault("options", {})
         if not isinstance(options, dict):
             options = {}
@@ -8920,15 +8940,15 @@ def _update_opencode_config(
             provider["models"] = models
         if (
             isinstance(previous_model_ref, str)
-            and previous_model_ref.startswith("llama-server/")
+            and previous_model_ref.startswith(f"{provider_id}/")
         ):
             previous_model_id = previous_model_ref.split("/", 1)[1]
-            if previous_model_id != model_id:
+            if previous_model_id != route_model_id:
                 models.pop(previous_model_id, None)
-        model = models.setdefault(model_id, {})
+        model = models.setdefault(route_model_id, {})
         if not isinstance(model, dict):
             model = {}
-            models[model_id] = model
+            models[route_model_id] = model
         model["name"] = display_name
         limit = model.setdefault("limit", {})
         if not isinstance(limit, dict):
@@ -8943,7 +8963,7 @@ def _update_opencode_config(
         except (OSError, json.JSONDecodeError) as exc:
             raise RuntimeError(f"Could not verify OpenCode config {path}: {exc}") from exc
         if not _opencode_config_matches(
-            persisted, model_id, base_url, api_key, context_length
+            persisted, provider_id, route_model_id, base_url, api_key, context_length
         ):
             raise RuntimeError(f"OpenCode persisted model route is stale in {path}")
 

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -3836,6 +3836,70 @@ class TestModelActivateRollback:
         assert primary_config["provider"]["llama-server"]["options"]["timeout"] == 900
         assert compat_config["compat_only"] is True
 
+    def test_switchboard_activation_routes_opencode_through_stable_alias(
+        self, tmp_path, monkeypatch,
+    ):
+        install_dir, env_path, env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
+            _write_model_activation_fixture(tmp_path)
+        )
+        env_path.write_text(
+            env_text
+            + "ODS_MODEL_SWITCHBOARD=enabled\n"
+            + "LITELLM_KEY=switchboard-secret\n"
+            + "LITELLM_PORT=4100\n",
+            encoding="utf-8",
+        )
+        config_dir = tmp_path / "home" / ".config" / "opencode"
+        config_dir.mkdir(parents=True)
+        primary = config_dir / "opencode.json"
+        compat = config_dir / "config.json"
+        stale = {
+            "model": "llama-server/qwen3-coder-next",
+            "small_model": "llama-server/qwen3-coder-next",
+            "theme": "system",
+            "provider": {
+                "llama-server": {
+                    "options": {
+                        "baseURL": "http://127.0.0.1:11434/v1",
+                        "apiKey": "no-key",
+                    },
+                    "models": {
+                        "qwen3-coder-next": {"name": "Qwen 3 Coder Next"},
+                    },
+                },
+            },
+        }
+        primary.write_text(json.dumps(stale), encoding="utf-8")
+        compat.write_text(json.dumps(stale), encoding="utf-8")
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(_mod, "_opencode_config_paths", lambda: (primary, compat))
+        monkeypatch.setattr(_mod, "_restart_managed_opencode", lambda _state=None: False)
+        monkeypatch.setattr(_mod, "_compose_restart_llama_server", lambda _env: None)
+        monkeypatch.setattr(_mod, "_render_model_router_runtime_configs", lambda *_a, **_k: None)
+        monkeypatch.setattr(_mod, "_wait_for_model_readiness", _mock_verified_readiness)
+        handler = _ResponseHandler()
+
+        _mod.AgentHandler._do_model_activate(handler, "target-model")
+
+        assert handler.response_code == 200
+        for path in (primary, compat):
+            config = json.loads(path.read_text(encoding="utf-8"))
+            assert config["theme"] == "system"
+            assert config["model"] == "llama-server/ods/current"
+            assert config["small_model"] == "llama-server/ods/current"
+            provider = config["provider"]["llama-server"]
+            assert provider["name"] == "ODS switchboard"
+            assert provider["options"] == {
+                "baseURL": "http://127.0.0.1:4100/v1",
+                "apiKey": "switchboard-secret",
+            }
+            assert "qwen3-coder-next" not in provider["models"]
+            assert provider["models"]["ods/current"]["limit"] == {
+                "context": 4096,
+                "output": 4096,
+            }
+
     def test_opencode_update_failure_restores_exact_files(self, tmp_path, monkeypatch):
         install_dir, _env_path, _env_text, _models_ini, _ini_text, _yaml, _yaml_text = (
             _write_model_activation_fixture(tmp_path)

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -2619,7 +2619,16 @@ for service in (data.get("services") or {}).values():
     # local mode follows the actual native llama bind and port.
     if [[ -n "$OPENCODE_BIN" && -x "$OPENCODE_BIN" ]]; then
         mkdir -p "$OPENCODE_CONFIG_DIR"
-        if $CLOUD_MODE; then
+        _opencode_switchboard_mode="$(read_env_value "$INSTALL_DIR/.env" "ODS_MODEL_SWITCHBOARD")"
+        if [[ "${_opencode_switchboard_mode:-observe}" == "enabled" ]]; then
+            _opencode_model="ods/current"
+            _opencode_port="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_PORT")"
+            [[ "$_opencode_port" =~ ^[0-9]+$ ]] || _opencode_port="4000"
+            _opencode_bind="$(read_env_value "$INSTALL_DIR/.env" "BIND_ADDRESS")"
+            _opencode_host="$(macos_bind_probe_host "${_opencode_bind:-127.0.0.1}")"
+            _opencode_base_url="http://${_opencode_host}:${_opencode_port}/v1"
+            _opencode_api_key="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_KEY")"
+        elif $CLOUD_MODE; then
             _opencode_model="default"
             _opencode_port="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_PORT")"
             [[ "$_opencode_port" =~ ^[0-9]+$ ]] || _opencode_port="4000"
@@ -2646,6 +2655,7 @@ for service in (data.get("services") or {}).values():
         fi
         ai_ok "OpenCode configured for ${_opencode_model} at ${_opencode_base_url}"
         unset _opencode_model _opencode_port _opencode_bind _opencode_host \
+            _opencode_switchboard_mode \
             _opencode_base_url _opencode_api_key
 
         # Install as macOS LaunchAgent (auto-start on login).

--- a/ods/installers/phases/07-devtools.sh
+++ b/ods/installers/phases/07-devtools.sh
@@ -144,7 +144,9 @@ else
             # Always re-read ODS_MODE from .env — Phase 06 may have changed it
             # (e.g. "local" → "lemonade" for AMD) but the shell variable is stale.
             ODS_MODE=$(grep -m1 '^ODS_MODE=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            [[ -z "${ODS_MODEL_SWITCHBOARD:-}" ]] && ODS_MODEL_SWITCHBOARD=$(grep -m1 '^ODS_MODEL_SWITCHBOARD=' "$INSTALL_DIR/.env" | cut -d= -f2-)
             [[ -z "${LITELLM_KEY:-}" ]] && LITELLM_KEY=$(grep -m1 '^LITELLM_KEY=' "$INSTALL_DIR/.env" | cut -d= -f2-)
+            [[ -z "${LITELLM_PORT:-}" ]] && LITELLM_PORT=$(grep -m1 '^LITELLM_PORT=' "$INSTALL_DIR/.env" | cut -d= -f2-)
         fi
         # Route through LiteLLM on AMD/Lemonade, direct to llama-server otherwise.
         #
@@ -164,12 +166,25 @@ else
         # Use LITELLM_KEY (read above at line 122) on the lemonade branch.
         # The llama-server-direct branch keeps "no-key" — llama.cpp's OpenAI-
         # compat server doesn't validate the key.
-        if [[ "${ODS_MODE:-local}" == "lemonade" ]]; then
-            _opencode_url="http://127.0.0.1:4000/v1"
+        _opencode_model_id="${LLM_MODEL}"
+        _opencode_model_name="${LLM_MODEL}"
+        _opencode_provider_name="llama-server (local)"
+        if [[ "${ODS_MODEL_SWITCHBOARD:-observe}" == "enabled" ]]; then
+            _opencode_url="http://127.0.0.1:${LITELLM_PORT:-4000}/v1"
+            _opencode_key="${LITELLM_KEY:-}"
+            _opencode_model_id="ods/current"
+            _opencode_model_name="ods/current"
+            _opencode_provider_name="ODS switchboard"
+        elif [[ "${ODS_MODE:-local}" == "lemonade" ]]; then
+            _opencode_url="http://127.0.0.1:${LITELLM_PORT:-4000}/v1"
             _opencode_key="${LITELLM_KEY:-no-key}"
         else
             _opencode_url="http://127.0.0.1:${OLLAMA_PORT:-8080}/v1"
             _opencode_key="no-key"
+        fi
+        if [[ -z "${_opencode_key:-}" ]]; then
+            ai_err "OpenCode switchboard config requires LITELLM_KEY, but it is empty."
+            exit 1
         fi
 
         # Writes a fresh opencode.json from the template. Used for first-install
@@ -179,19 +194,19 @@ else
             cat > "$1" <<OPENCODE_EOF
 {
   "\$schema": "https://opencode.ai/config.json",
-  "model": "llama-server/${LLM_MODEL}",
-  "small_model": "llama-server/${LLM_MODEL}",
+  "model": "llama-server/${_opencode_model_id}",
+  "small_model": "llama-server/${_opencode_model_id}",
   "provider": {
     "llama-server": {
       "npm": "@ai-sdk/openai-compatible",
-      "name": "llama-server (local)",
+      "name": "${_opencode_provider_name}",
       "options": {
         "baseURL": "${_opencode_url}",
         "apiKey": "${_opencode_key}"
       },
       "models": {
-        "${LLM_MODEL}": {
-          "name": "${LLM_MODEL}",
+        "${_opencode_model_id}": {
+          "name": "${_opencode_model_name}",
           "limit": {
             "context": ${MAX_CONTEXT:-65536},
             "output": 32768
@@ -206,29 +221,42 @@ OPENCODE_EOF
 
         if [[ ! -f "$OPENCODE_CONFIG_DIR/opencode.json" ]]; then
             _opencode_write_fresh "$OPENCODE_CONFIG_DIR/opencode.json"
-            ai_ok "OpenCode configured for local llama-server (model: ${LLM_MODEL})"
+            ai_ok "OpenCode configured for local llama-server (model: ${_opencode_model_id})"
         else
             # Reinstall: update API key and URL in existing config (key may have changed)
             _opencode_updated=false
             if command -v jq >/dev/null 2>&1; then
                 _opencode_tmp="$OPENCODE_CONFIG_DIR/opencode.json.tmp.$$"
                 if jq --arg url "$_opencode_url" --arg key "$_opencode_key" \
-                    '.provider["llama-server"].options.baseURL = $url
-                     | .provider["llama-server"].options.apiKey = $key' \
+                    --arg model_id "$_opencode_model_id" \
+                    --arg model_name "$_opencode_model_name" \
+                    --arg provider_name "$_opencode_provider_name" \
+                    --argjson context "${MAX_CONTEXT:-65536}" \
+                    '.["$schema"] = "https://opencode.ai/config.json"
+                     | .model = ("llama-server/" + $model_id)
+                     | .small_model = ("llama-server/" + $model_id)
+                     | .provider = (.provider // {})
+                     | .provider["llama-server"] = (.provider["llama-server"] // {})
+                     | .provider["llama-server"].npm = "@ai-sdk/openai-compatible"
+                     | .provider["llama-server"].name = $provider_name
+                     | .provider["llama-server"].options = {"baseURL": $url, "apiKey": $key}
+                     | .provider["llama-server"].models = {
+                         ($model_id): {
+                           "name": $model_name,
+                           "limit": {"context": $context, "output": ([32768, $context] | min)}
+                         }
+                       }' \
                     "$OPENCODE_CONFIG_DIR/opencode.json" > "$_opencode_tmp" 2>/dev/null; then
                     mv "$_opencode_tmp" "$OPENCODE_CONFIG_DIR/opencode.json"
-                    ai_ok "OpenCode config updated (API key and URL refreshed)"
+                    ai_ok "OpenCode config updated (model, API key, and URL refreshed)"
                     _opencode_updated=true
                 else
                     rm -f "$_opencode_tmp"
                     ai_warn "OpenCode config jq rewrite failed (existing file unparseable) — regenerating from template"
                 fi
             else
-                # Fallback without jq: narrow sed that only matches the quoted value,
-                # preserving any trailing comma on the line
-                _sed_i "s|\"apiKey\": *\"[^\"]*\"|\"apiKey\": \"${_opencode_key}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
-                _sed_i "s|\"baseURL\": *\"[^\"]*\"|\"baseURL\": \"${_opencode_url}\"|" "$OPENCODE_CONFIG_DIR/opencode.json"
-                ai_ok "OpenCode config updated (API key and URL refreshed)"
+                _opencode_write_fresh "$OPENCODE_CONFIG_DIR/opencode.json"
+                ai_ok "OpenCode config regenerated (jq unavailable; model route refreshed)"
                 _opencode_updated=true
             fi
             # Recovery path (issue #332): if the update branch above failed to

--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -28,7 +28,9 @@ function New-WindowsOpenCodeConfigObject {
         [hashtable]$LlmEndpoint,
         [string]$ModelId,
         [string]$ModelName,
-        [int]$ContextLimit
+        [int]$ContextLimit,
+        [string]$ApiKey = "no-key",
+        [string]$ProviderName = "llama-server (local)"
     )
 
     return [pscustomobject]@{
@@ -38,10 +40,10 @@ function New-WindowsOpenCodeConfigObject {
         provider = [pscustomobject]@{
             'llama-server' = [pscustomobject]@{
                 npm = "@ai-sdk/openai-compatible"
-                name = "llama-server (local)"
+                name = $ProviderName
                 options = [pscustomobject]@{
                     baseURL = $LlmEndpoint.BaseUrl
-                    apiKey = "no-key"
+                    apiKey = $ApiKey
                 }
                 models = [pscustomobject]@{
                     $ModelId = [pscustomobject]@{
@@ -63,11 +65,19 @@ function Update-WindowsOpenCodeConfigObject {
         [hashtable]$LlmEndpoint,
         [string]$ModelId,
         [string]$ModelName,
-        [int]$ContextLimit
+        [int]$ContextLimit,
+        [string]$ApiKey = "no-key",
+        [string]$ProviderName = "llama-server (local)"
     )
 
     if ($null -eq $Config) {
-        return New-WindowsOpenCodeConfigObject -LlmEndpoint $LlmEndpoint -ModelId $ModelId -ModelName $ModelName -ContextLimit $ContextLimit
+        return New-WindowsOpenCodeConfigObject `
+            -LlmEndpoint $LlmEndpoint `
+            -ModelId $ModelId `
+            -ModelName $ModelName `
+            -ContextLimit $ContextLimit `
+            -ApiKey $ApiKey `
+            -ProviderName $ProviderName
     }
 
     Set-OpenCodeObjectProperty -Target $Config -Name '$schema' -Value "https://opencode.ai/config.json"
@@ -85,13 +95,13 @@ function Update-WindowsOpenCodeConfigObject {
     $llamaProvider = $provider.'llama-server'
 
     Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'npm' -Value "@ai-sdk/openai-compatible"
-    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'name' -Value "llama-server (local)"
+    Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'name' -Value $ProviderName
 
     if (-not $llamaProvider.PSObject.Properties['options'] -or $null -eq $llamaProvider.options) {
         Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'options' -Value ([pscustomobject]@{})
     }
     Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'baseURL' -Value $LlmEndpoint.BaseUrl
-    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'apiKey' -Value "no-key"
+    Set-OpenCodeObjectProperty -Target $llamaProvider.options -Name 'apiKey' -Value $ApiKey
 
     if (-not $llamaProvider.PSObject.Properties['models'] -or $null -eq $llamaProvider.models) {
         Set-OpenCodeObjectProperty -Target $llamaProvider -Name 'models' -Value ([pscustomobject]@{})
@@ -120,6 +130,8 @@ function Sync-WindowsOpenCodeConfig {
         [string]$ModelName,
         [int]$ContextLimit,
         [string]$ConfigDir = $script:OPENCODE_CONFIG_DIR,
+        [string]$ApiKey = "no-key",
+        [string]$ProviderName = "llama-server (local)",
         [switch]$SkipIfUnavailable
     )
 
@@ -163,7 +175,9 @@ function Sync-WindowsOpenCodeConfig {
         -LlmEndpoint $LlmEndpoint `
         -ModelId $ModelId `
         -ModelName $ModelName `
-        -ContextLimit $ContextLimit
+        -ContextLimit $ContextLimit `
+        -ApiKey $ApiKey `
+        -ProviderName $ProviderName
 
     $_configJson = $_configObject | ConvertTo-Json -Depth 12
     $_utf8NoBom = New-Object System.Text.UTF8Encoding($false)
@@ -201,6 +215,29 @@ function Sync-WindowsOpenCodeConfigFromEnv {
     $_modelId = Get-WindowsODSEnvValue -EnvMap $_envMap -Keys @("GGUF_FILE") -Default $DefaultModelId
     $_modelName = Get-WindowsODSEnvValue -EnvMap $_envMap -Keys @("LLM_MODEL") -Default $DefaultModelName
     $_contextRaw = Get-WindowsODSEnvValue -EnvMap $_envMap -Keys @("MAX_CONTEXT", "CTX_SIZE") -Default "$DefaultContextLimit"
+    $_apiKey = "no-key"
+    $_providerName = "llama-server (local)"
+    $_switchboardMode = (Get-WindowsODSEnvValue -EnvMap $_envMap -Keys @("ODS_MODEL_SWITCHBOARD") -Default "observe").ToLowerInvariant()
+    if ($_switchboardMode -eq "enabled") {
+        $_litellmPort = Get-WindowsODSEnvValue -EnvMap $_envMap -Keys @("LITELLM_PORT") -Default "4000"
+        $_litellmKey = Get-WindowsODSEnvValue -EnvMap $_envMap -Keys @("LITELLM_KEY") -Default ""
+        if ([string]::IsNullOrWhiteSpace($_litellmKey)) {
+            throw "OpenCode switchboard config requires LITELLM_KEY, but it is empty."
+        }
+        $_llmEndpoint = @{
+            Name = "LLM (ODS switchboard)"
+            Backend = "litellm-switchboard"
+            Port = $_litellmPort
+            ApiBasePath = "/v1"
+            HealthUrl = "http://127.0.0.1:${_litellmPort}/health"
+            BaseUrl = "http://127.0.0.1:${_litellmPort}/v1"
+            ChatCompletionsUrl = "http://127.0.0.1:${_litellmPort}/v1/chat/completions"
+        }
+        $_modelId = "ods/current"
+        $_modelName = "ods/current"
+        $_apiKey = $_litellmKey
+        $_providerName = "ODS switchboard"
+    }
     $_contextLimit = 0
     if (-not [int]::TryParse($_contextRaw, [ref]$_contextLimit)) {
         $_contextLimit = $DefaultContextLimit
@@ -212,5 +249,7 @@ function Sync-WindowsOpenCodeConfigFromEnv {
         -ModelName $_modelName `
         -ContextLimit $_contextLimit `
         -ConfigDir $ConfigDir `
+        -ApiKey $_apiKey `
+        -ProviderName $_providerName `
         -SkipIfUnavailable:$SkipIfUnavailable
 }

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -117,6 +117,16 @@ assert_grep "installers/macos/ods-macos.sh" 'ENV_CTX_SIZE:-65536' \
     "macOS native llama restart defaults to 64K context"
 assert_grep "installers/phases/07-devtools.sh" '"context": \$\{MAX_CONTEXT:-65536\}' \
     "Linux OpenCode config defaults to 64K context"
+assert_grep "installers/phases/07-devtools.sh" 'ODS_MODEL_SWITCHBOARD' \
+    "Linux OpenCode config reads switchboard mode"
+assert_grep "installers/phases/07-devtools.sh" '_opencode_model_id="ods/current"' \
+    "Linux OpenCode config uses stable switchboard alias"
+assert_grep "installers/phases/07-devtools.sh" 'OpenCode config updated \(model, API key, and URL refreshed\)' \
+    "Linux OpenCode reinstall migrates stale model route"
+assert_grep "installers/macos/install-macos.sh" '_opencode_switchboard_mode=.*ODS_MODEL_SWITCHBOARD' \
+    "macOS OpenCode config reads switchboard mode"
+assert_grep "installers/macos/install-macos.sh" '_opencode_model="ods/current"' \
+    "macOS OpenCode config uses stable switchboard alias"
 assert_not_grep "installers/macos/install-macos.sh" '\$LOG_FILE' \
     "macOS installer uses ODS_LOG_FILE, not undefined LOG_FILE"
 assert_grep "installers/windows/install-windows.ps1" 'Update-HermesConfigFile.*ContextLength \(\[int\]\$tierConfig\.MaxContext\)' \

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -178,7 +178,7 @@ fi
 pass "disabled Hermes routing patches through a safe image or fails closed"
 
 # OpenCode and OpenClaw must update only their managed routes across modes.
-eval "$(extract_installer_function _write_macos_opencode_config)"
+eval "$(extract_installer_function _write_macos_opencode_config | sed "s|/usr/bin/python3|$python_cmd|g")"
 opencode_path="$TMP_DIR/opencode/opencode.json"
 mkdir -p "$(dirname "$opencode_path")"
 printf '{"custom":{"preserve":true}}\n' > "$opencode_path"
@@ -193,6 +193,16 @@ assert data["custom"]["preserve"] is True
 assert data["model"] == "llama-server/default"
 opts = data["provider"]["llama-server"]["options"]
 assert opts == {"baseURL": "http://127.0.0.1:4000/v1", "apiKey": sys.argv[2]}
+PY
+_write_macos_opencode_config "$opencode_path" "ods/current" \
+    http://127.0.0.1:4000/v1 "$opencode_secret" 131072 >/dev/null
+"$python_cmd" - "$opencode_path" "$opencode_secret" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1], encoding="utf-8"))
+assert data["model"] == "llama-server/ods/current"
+provider = data["provider"]["llama-server"]
+assert provider["models"]["ods/current"]["limit"] == {"context": 131072, "output": 32768}
+assert provider["options"] == {"baseURL": "http://127.0.0.1:4000/v1", "apiKey": sys.argv[2]}
 PY
 
 # shellcheck source=/dev/null

--- a/ods/tests/test-render-runtime-configs.py
+++ b/ods/tests/test-render-runtime-configs.py
@@ -120,6 +120,21 @@ def test_enabled_hermes_uses_stable_switchboard_alias() -> None:
     assert 'base_url: "http://litellm:4000/v1"' in content
 
 
+def test_enabled_opencode_uses_stable_switchboard_alias() -> None:
+    payload = run_renderer(
+        "--surface",
+        "opencode",
+        "--switchboard-mode",
+        "enabled",
+        "--litellm-key",
+        "switch-secret",
+    )
+    content = json.loads(file_by_surface(payload, "opencode")["content"])
+    assert content["model"] == "ods/current"
+    assert content["baseURL"] == "http://litellm:4000/v1"
+    assert content["apiKey"] == "switch-secret"
+
+
 def test_router_endpoints_strip_trailing_v1() -> None:
     payload = run_renderer(
         "--surface", "model-router-endpoints",
@@ -293,6 +308,8 @@ def main() -> int:
         test_switchboard_surface_gated_on_enabled_mode,
         test_enabled_env_exports_switchboard_webui_gateway,
         test_enabled_perplexica_uses_stable_alias,
+        test_enabled_hermes_uses_stable_switchboard_alias,
+        test_enabled_opencode_uses_stable_switchboard_alias,
         test_lemonade_disables_thinking_and_uses_extra_alias,
         test_external_lemonade_uses_supplied_model_and_api_base,
         test_exact_lemonade_id_propagates_to_every_runtime_surface,

--- a/ods/tests/test-windows-opencode-config.sh
+++ b/ods/tests/test-windows-opencode-config.sh
@@ -38,6 +38,10 @@ grep -q 'opencode-config.ps1' "$INSTALLER_PS1" && pass "installer sources OpenCo
 grep -q 'OpenCode config synced to active model' "$INSTALLER_PS1" && pass "installer resyncs OpenCode after launch" || fail "installer missing active-model OpenCode resync"
 grep -q 'update-windows-opencode-config.ps1' "$BOOTSTRAP_UPGRADE" && pass "bootstrap upgrade refreshes Windows OpenCode config" || fail "bootstrap upgrade missing Windows OpenCode refresh"
 grep -q 'OpenCode config updated' "$DEVTOOLS_PS1" && pass "existing config update message exists" || fail "existing config update message missing"
+grep -q 'ODS_MODEL_SWITCHBOARD' "$OPENCODE_LIB" && pass "switchboard mode is read from .env" || fail "switchboard mode missing from OpenCode helper"
+grep -q 'ods/current' "$OPENCODE_LIB" && pass "switchboard alias is written to OpenCode config" || fail "switchboard alias missing from OpenCode helper"
+grep -q 'LITELLM_KEY' "$OPENCODE_LIB" && pass "switchboard OpenCode route uses LiteLLM key" || fail "switchboard LiteLLM key missing from OpenCode helper"
+grep -q 'ODS switchboard' "$OPENCODE_LIB" && pass "switchboard provider is labelled" || fail "switchboard provider label missing"
 
 if grep -q 'preserving existing configuration' "$DEVTOOLS_PS1"; then
     fail "existing configs are still preserved without migration"


### PR DESCRIPTION
﻿## Summary
- Route OpenCode through the stable switchboard alias when `ODS_MODEL_SWITCHBOARD=enabled`.
- Migrate stale OpenCode configs from raw `llama-server/<model>` to `llama-server/ods/current` on Linux, Windows, macOS, and host-agent runtime activation.
- Keep direct/observe mode behavior unchanged and add contracts for installer/runtime config paths.

## Fleet Evidence
- Tower2 affected-host run `2026-07-21T04-59-05Z-release-product-c85f328f49f7-harness-87c7c18f88ab-hosts-tower2` passed install, post-install, lifecycle, full-model finalize, Hermes, and capabilities.
- Model-UI baseline app probes then failed on OpenCode only: `OpenCode configured model llama-server/qwen3-coder-next does not match expected ods/current`.
- Controlled live check on Tower2 proved OpenCode can use provider `llama-server` with model id `ods/current` through LiteLLM and return an exact probe token.

## Validation
- `python -m py_compile bin/ods-host-agent.py`
- `python -m pytest extensions/services/dashboard-api/tests/test_model_activate.py` (`170 passed, 1 skipped`)
- `python tests/test-render-runtime-configs.py`
- Git Bash: `bash -n installers/phases/07-devtools.sh && tests/test-installer-context-parity.sh && tests/test-windows-opencode-config.sh && tests/test-macos-installer-transitions.sh`
- PowerShell parser checks for Windows OpenCode/install scripts
- `git diff --check`
