### PR TITLE
fix(host-agent): inspect Hermes config through container fallback

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -9532,6 +9532,17 @@ def _capture_hermes_live_config(path: Path) -> dict:
             "mode": None,
             "source": None,
         }
+    except PermissionError as exc:
+        logger.info("Inspecting container-owned Hermes config through ods-hermes: %s", exc)
+        return {
+            "exists": True,
+            "text": _read_hermes_container_config(),
+            "bytes": None,
+            "mode": None,
+            "uid": None,
+            "gid": None,
+            "source": "container",
+        }
     except OSError as exc:
         raise RuntimeError(f"Could not inspect Hermes config {path}: {exc}") from exc
     if stat_mod.S_ISLNK(metadata.st_mode):

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -3473,6 +3473,28 @@ class TestModelActivateRollback:
         assert '  default: "new-model.gguf"' in hermes_template.read_text(encoding="utf-8")
         assert ["docker", "restart", "ods-hermes"] in calls
 
+    def test_capture_hermes_config_falls_back_when_stat_is_denied(
+        self, tmp_path, monkeypatch,
+    ):
+        hermes_live = tmp_path / "data" / "hermes" / "config.yaml"
+        container_text = "model:\n  default: \"old-live\"\n"
+        original_lstat = Path.lstat
+
+        def fake_lstat(path, *args, **kwargs):
+            if path == hermes_live:
+                raise PermissionError("container-owned directory")
+            return original_lstat(path, *args, **kwargs)
+
+        monkeypatch.setattr(Path, "lstat", fake_lstat)
+        monkeypatch.setattr(_mod, "_container_running", lambda name: name == "ods-hermes")
+        monkeypatch.setattr(_mod, "_read_hermes_container_config", lambda: container_text)
+
+        snapshot = _mod._capture_hermes_live_config(hermes_live)
+
+        assert snapshot["exists"] is True
+        assert snapshot["source"] == "container"
+        assert snapshot["text"] == container_text
+
     def test_activation_repairs_malformed_models_ini_directory(
         self, tmp_path, monkeypatch,
     ):


### PR DESCRIPTION
## Summary
- handle PermissionError during Hermes live config stat by falling back to the running ods-hermes container
- add a regression test for container-owned Hermes config directories where lstat fails before read fallback

## Evidence
Tower2 release run product 8634d540 / harness 2689fea failed the browser model-management matrix after the UI sent POST /api/models/granite4.0-h-micro-q4/load. dashboard-api returned 502; host-agent journal showed PermissionError on /home/michael/ods/data/hermes/config.yaml during _capture_hermes_live_config() before runtime activation.

## Tests
- python -m py_compile bin/ods-host-agent.py
- python -m pytest extensions/services/dashboard-api/tests/test_model_activate.py
- python -m pytest extensions/services/dashboard-api/tests/test_models.py -k "load_model or download_status or bootstrap_upgrade"
- python -m pytest extensions/services/dashboard-api/tests/test_model_state.py extensions/services/dashboard-api/tests/test_switchboard_reconciler.py
- tests/test-bootstrap-upgrade-hotswap-contract.sh
