### PR TITLE
fix(installer): implement atomic writing for registry/summaries and resolve macOS test hang

### DIFF
--- a/ods/installers/lib/background-tasks.sh
+++ b/ods/installers/lib/background-tasks.sh
@@ -31,7 +31,9 @@ bg_task_start() {
     # Add task to registry
     python3 - "$BG_TASK_REGISTRY" "$task_id" "$pid" "$description" "$log_file" <<'PY'
 import json
+import os
 import sys
+import tempfile
 from pathlib import Path
 
 registry_path = Path(sys.argv[1])
@@ -48,7 +50,19 @@ tasks.append({
     "log_file": log_file,
     "status": "running"
 })
-registry_path.write_text(json.dumps(tasks, indent=2))
+fd, tmp_path = tempfile.mkstemp(dir=str(registry_path.parent), suffix=".tmp")
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(tasks, f, indent=2)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, str(registry_path))
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
 PY
 }
 

--- a/ods/installers/phases/13-summary.sh
+++ b/ods/installers/phases/13-summary.sh
@@ -435,8 +435,10 @@ if [[ -n "$SUMMARY_JSON_FILE" ]]; then
 
     "$PYTHON_CMD" - "$SUMMARY_JSON_FILE" "$VERSION" "$INSTALL_DIR" "$TIER" "$TIER_NAME" "$GPU_BACKEND" "${BACKEND_SERVICE_NAME:-llama-server}" "$LLM_MODEL" "$COMPOSE_FLAGS" "$DRY_RUN" "$PREFLIGHT_REPORT_FILE" "${CAP_HARDWARE_CLASS_ID:-unknown}" "${CAP_HARDWARE_CLASS_LABEL:-Unknown}" <<'PY'
 import json
+import os
 import pathlib
 import sys
+import tempfile
 from datetime import datetime, timezone
 
 (
@@ -474,7 +476,19 @@ payload = {
 
 path = pathlib.Path(out_file)
 path.parent.mkdir(parents=True, exist_ok=True)
-path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(json.dumps(payload, indent=2) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, str(path))
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
 print(f"[INFO] Wrote installer summary JSON: {out_file}")
 PY
 fi

--- a/ods/ods-update.sh
+++ b/ods/ods-update.sh
@@ -499,7 +499,10 @@ cmd_check() {
     else
         version_data='{}'
     fi
-    echo "$version_data" | jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_check = $ts' > "$VERSION_FILE"
+    local tmp_version_file
+    tmp_version_file=$(mktemp "${VERSION_FILE}.tmp.XXXXXX")
+    echo "$version_data" | jq --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" '.last_check = $ts' > "$tmp_version_file"
+    mv -f "$tmp_version_file" "$VERSION_FILE"
 }
 
 #==============================================================================
@@ -709,12 +712,15 @@ cmd_update() {
     new_version=$(git describe --tags 2>/dev/null || git rev-parse --short HEAD)
     local version_data='{}'
     [[ -f "$VERSION_FILE" ]] && version_data=$(cat "$VERSION_FILE")
+    local tmp_version_file
+    tmp_version_file=$(mktemp "${VERSION_FILE}.tmp.XXXXXX")
     echo "$version_data" | jq \
         --arg v    "$new_version" \
         --arg ts   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
         --arg snap "$snap_dir" \
         '.version = $v | .last_update = $ts | .last_rollback_point = $snap' \
-        > "$VERSION_FILE"
+        > "$tmp_version_file"
+    mv -f "$tmp_version_file" "$VERSION_FILE"
 
     log_ok "Update complete! Version: ${new_version}"
     log_info "Rollback point retained at: ${snap_dir}"

--- a/ods/tests/test-bootstrap-upgrade-resume-status.sh
+++ b/ods/tests/test-bootstrap-upgrade-resume-status.sh
@@ -17,6 +17,7 @@ pass() {
 }
 
 tmp="$(mktemp -d)"
+tmp="$(cd "$tmp" && pwd -P)"
 trap 'rm -rf "$tmp"' EXIT
 
 fakebin="$tmp/bin"


### PR DESCRIPTION
## Summary

Prevent in-place truncation when updating installer state files and fix a macOS-specific test hang.

Previously, several installer and upgrade paths updated JSON state files directly using shell redirection or in-place Python writes. These write paths truncate the destination before writing new content, which can leave the file incomplete if the process is interrupted during the update.

This change updates those write paths to use atomic file replacement:

- `background-tasks.sh`
  - Writes the background task registry to a temporary file.
  - Flushes the file with `fsync()`.
  - Atomically replaces the destination using `os.replace()`.

- `ods-update.sh`
  - Writes version status updates to a temporary file created with `mktemp`.
  - Atomically replaces the destination using `mv -f`.

- `13-summary.sh`
  - Writes the installation summary to a temporary file.
  - Flushes the file with `fsync()`.
  - Atomically replaces the destination using `os.replace()`.

As a result, these state files are no longer exposed to partially written or truncated content during updates.

In addition, this change fixes a macOS-specific issue in `test-bootstrap-upgrade-resume-status.sh`. The test previously derived its upgrade lock key from unresolved temporary paths, while `bootstrap-upgrade.sh` resolved the corresponding paths using their physical location. On macOS, where `/var` is a symlink to `/private/var`, this produced different lock keys and prevented the test from locating the existing lock directory, resulting in repeated retry attempts. The test now resolves temporary directories using `pwd -P`, matching the daemon's behavior and eliminating the mismatch.

## Verification

Verified using the existing test suites:

- `test-bootstrap-upgrade-resume-status.sh`
  - Completes successfully on macOS without hanging (approximately 4 seconds).

- `make bats`
  - Passed, including the background task registry regression tests.