### PR TITLE
fix(model-router): strip chat template artifacts from responses

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -90,6 +90,11 @@ _PROBE_RE = re.compile(
     r"sig=([A-Za-z0-9_-]+)\]"
 )
 _SSE_DELIMITER_RE = re.compile(rb"(?:\r\n|\r|\n)(?:\r\n|\r|\n)")
+_CHAT_TEMPLATE_ARTIFACTS = (
+    re.compile(r"<\|im_start\|>\s*(?:assistant|user|system|tool)?\s*<\|im_end\|>"),
+    re.compile(r"<\|start_header_id\|>\s*(?:assistant|user|system|tool)?\s*<\|end_header_id\|>"),
+    re.compile(r"<\|(?:im_start|im_end|eot_id|endoftext|end)\|>"),
+)
 
 app = FastAPI(title="ODS Model Router", docs_url=None, redoc_url=None,
               openapi_url=None)
@@ -427,6 +432,53 @@ def _sanitize_headers(request: Request) -> dict[str, str]:
     return headers
 
 
+def _strip_chat_template_artifacts(text: str) -> str:
+    cleaned = text
+    for pattern in _CHAT_TEMPLATE_ARTIFACTS:
+        cleaned = pattern.sub("", cleaned)
+    return cleaned
+
+
+def _sanitize_content_value(value: Any) -> tuple[Any, bool]:
+    if isinstance(value, str):
+        cleaned = _strip_chat_template_artifacts(value)
+        return cleaned, cleaned != value
+    if isinstance(value, list):
+        changed = False
+        cleaned_items: list[Any] = []
+        for item in value:
+            if isinstance(item, dict):
+                item = dict(item)
+                for key in ("text", "content"):
+                    if isinstance(item.get(key), str):
+                        item[key], item_changed = _sanitize_content_value(item[key])
+                        changed = changed or item_changed
+            cleaned_items.append(item)
+        return cleaned_items, changed
+    return value, False
+
+
+def _sanitize_choice_content(obj: dict[str, Any]) -> bool:
+    changed = False
+    choices = obj.get("choices")
+    if not isinstance(choices, list):
+        return False
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        for container_key in ("message", "delta"):
+            container = choice.get(container_key)
+            if isinstance(container, dict) and "content" in container:
+                container["content"], item_changed = _sanitize_content_value(
+                    container["content"]
+                )
+                changed = changed or item_changed
+        if "text" in choice:
+            choice["text"], item_changed = _sanitize_content_value(choice["text"])
+            changed = changed or item_changed
+    return changed
+
+
 def _rewrite_sse_event(event: bytes, alias: str) -> tuple[bytes, list[str]]:
     """Rewrite complete SSE data lines and return concrete model identities."""
     out_lines: list[bytes] = []
@@ -441,10 +493,12 @@ def _rewrite_sse_event(event: bytes, alias: str) -> tuple[bytes, list[str]]:
                     obj = json.loads(payload)
                 except ValueError:
                     obj = None
-                if isinstance(obj, dict) and isinstance(obj.get("model"), str):
-                    if obj["model"]:
-                        models.append(obj["model"])
-                    obj["model"] = alias
+                if isinstance(obj, dict):
+                    if isinstance(obj.get("model"), str):
+                        if obj["model"]:
+                            models.append(obj["model"])
+                        obj["model"] = alias
+                    _sanitize_choice_content(obj)
                     content = (
                         b"data: "
                         + json.dumps(obj, separators=(",", ":")).encode("utf-8")
@@ -738,6 +792,7 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
             response_model = parsed.get("model")
             if "model" in parsed:
                 parsed["model"] = requested_alias
+            _sanitize_choice_content(parsed)
             lemonade_meta = parsed.get("x_lemonade_route")
             if lemonade_meta is not None:
                 ods_headers.setdefault("X-Lemonade-Route",

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -172,6 +172,38 @@ class TestForwarding:
         assert resp.headers["X-ODS-Route-Seq"] == "7"
         assert resp.headers["X-Lemonade-Route"] == "route-a"
 
+    def test_chat_template_artifacts_stripped_from_json_content(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+
+        def handler(_request):
+            return httpx.Response(200, json={
+                "id": "c1",
+                "model": "Concrete.gguf",
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "O<|im_start|>assistant<|im_end|>DSVAL",
+                    },
+                }],
+            })
+
+        asyncio.run(mod.app.state.http.aclose())
+        mod.app.state.http = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler)
+        )
+
+        resp = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["choices"][0]["message"]["content"] == "ODSVAL"
+        assert "<|im_start|>" not in resp.text
+        assert body["model"] == "ods/current"
+
     def test_sse_chunks_restore_alias(self, router):
         mod, client, write_state, calls = router
         write_state()
@@ -184,6 +216,48 @@ class TestForwarding:
         assert b'"model": "default"' in raw or b'"model":"default"' in raw
         assert b"Concrete.gguf" not in raw
         assert b"[DONE]" in raw
+
+    def test_chat_template_artifacts_stripped_from_sse_delta(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        _set_stream_upstream(mod, [
+            b'data: {"id":"c1","model":"Concrete.gguf",'
+            b'"choices":[{"delta":{"content":"O<|im_start|>assistant<|im_end|>DSVAL"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ])
+
+        with client.stream("POST", "/v1/chat/completions", json={
+            "model": "ods/current",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        }) as resp:
+            raw = b"".join(resp.iter_bytes())
+
+        assert resp.status_code == 200
+        assert b'"content":"ODSVAL"' in raw
+        assert b"<|im_start|>" not in raw
+        assert b"Concrete.gguf" not in raw
+
+    def test_chat_template_artifacts_stripped_from_model_less_sse_delta(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        _set_stream_upstream(mod, [
+            b'data: {"id":"c1","model":"Concrete.gguf","choices":[]}\n\n',
+            b'data: {"id":"c1","choices":[{"delta":{"content":"A<|start_header_id|>assistant<|end_header_id|>B"}}]}\n\n',
+            b"data: [DONE]\n\n",
+        ])
+
+        with client.stream("POST", "/v1/chat/completions", json={
+            "model": "ods/current",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        }) as resp:
+            raw = b"".join(resp.iter_bytes())
+
+        assert resp.status_code == 200
+        assert b'"content":"AB"' in raw
+        assert b"<|start_header_id|>" not in raw
+        assert b"Concrete.gguf" not in raw
 
     def test_client_authorization_stripped_and_backend_key_injected(self, router):
         mod, client, write_state, calls = router


### PR DESCRIPTION
## Summary

Fixes the Tower2 model-UI app-probe failure where Granite H-Tiny routed correctly through `ods/current`, but OpenCode's response surfaced ChatML/header artifacts inside the verification phrase:

`O<|im_start|>assistant<|im_end|>DSVAL-...`

The model-router already owns the switchboard response path, so this strips common chat-template artifacts from assistant output fields while preserving request bodies, routing, model-id alias rewriting, and route evidence.

## Evidence

- Failed run: `/home/michael/dream-fleet-test/runs/2026-07-21T06-57-57Z-release-product-4ec1890961ec-harness-ecd8157a6324-hosts-tower2`
- Cycle: `model-ui/cycle-002/tower2/model-ui.json`
- Product state proved `granite4.0-h-tiny-q4` active and routed.
- LiteLLM, Open WebUI, and Perplexica passed with route evidence for the same swap.
- OpenCode failed because the generated text contained ChatML artifacts inside the expected token.

## Validation

- `python -m py_compile extensions/services/model-router/app/main.py`
- `python -m pytest extensions/services/model-router/tests/test_router.py`
- `python -m pytest extensions/services/dashboard-api/tests/test_model_state.py extensions/services/dashboard-api/tests/test_switchboard_reconciler.py extensions/services/dashboard-api/tests/test_model_activate.py`
- `git diff --check`
