### PR TITLE
fix(models): replace Granite 3.1 in release pool

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -339,6 +339,25 @@
       "install_recommendation": false
     },
     {
+      "id": "granite4.1-3b-q4",
+      "name": "Granite 4.1 3B",
+      "family": "granite",
+      "gguf_file": "granite-4.1-3b-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/ibm-granite/granite-4.1-3b-GGUF/resolve/main/granite-4.1-3b-Q4_K_M.gguf",
+      "gguf_sha256": "662b0626cd58f443baea23559b469df6576a81d349649c59413b36a9fb32eb29",
+      "size_bytes": 2099501664,
+      "size_mb": 2100,
+      "vram_required_gb": 4,
+      "context_length": 131072,
+      "quantization": "Q4_K_M",
+      "specialty": "Tool Use",
+      "description": "IBM's Granite 4.1 3B long-context instruct model quantized for GGUF. A low-VRAM candidate with improved instruction following, chat, and tool-use behavior for app and agent validation.",
+      "tokens_per_sec_estimate": 115,
+      "llm_model_name": "granite-4.1-3b",
+      "llama_server_image": null,
+      "install_recommendation": false
+    },
+    {
       "id": "granite4.0-1b-q4",
       "name": "Granite 4.0 1B",
       "family": "granite",
@@ -467,6 +486,18 @@
       "tokens_per_sec_estimate": 128,
       "llm_model_name": "granite-3.1-2b-instruct",
       "llama_server_image": null,
+      "app_compatibility": {
+        "perplexica": {
+          "status": "unsupported_until_revalidated",
+          "label": "Perplexica revalidation required",
+          "reason": "Fleet model-UI run 2026-07-21T08:59Z on tower2 loaded this model and ODS Talk, LiteLLM, Open WebUI, and OpenCode passed, but the Perplexica app probe answered with prose/search-style content instead of the requested verification phrase; keep it out of all-app release coverage until Perplexica compatibility is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-21T08-59-51Z-targeted-granite31-allapps-product-73762173ae0c-harness-ecd8157a6324-hosts-tower2/cycle-001/tower2",
+          "recordedAt": "2026-07-21T08:59:51Z",
+          "productSha": "73762173ae0c",
+          "harnessSha": "ecd8157a6324",
+          "hostScope": ["tower2"]
+        }
+      },
       "install_recommendation": false
     },
     {

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -375,19 +375,24 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     ]
     candidate_ids = {model["id"] for model in candidates}
     by_id = {model["id"]: model for model in candidates}
+    all_by_id = {model["id"]: model for model in payload["models"]}
 
     assert len(candidates) >= 6
     assert {
         "granite4.0-h-1b-q4",
         "falcon-h1-1.5b-instruct-q4",
-        "granite3.1-2b-instruct-q4",
+        "granite4.1-3b-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
         "phi3-mini-128k-q4",
     }.issubset(candidate_ids)
     assert by_id["falcon-h1-1.5b-instruct-q4"]["contextLength"] >= 65536
-    assert by_id["granite3.1-2b-instruct-q4"]["contextLength"] == 131072
+    assert by_id["granite4.1-3b-q4"]["contextLength"] == 131072
     assert by_id["phi3-mini-128k-q4"]["contextLength"] == 131072
+    assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == (
+        "unsupported_until_revalidated"
+    )
+    assert "granite3.1-2b-instruct-q4" not in candidate_ids
     assert "phi4-mini-q4" not in candidate_ids
     assert "gemma3-4b-it-q4" not in candidate_ids
     assert "granite4.0-h-350m-q4" not in candidate_ids


### PR DESCRIPTION
## Summary
- mark `granite3.1-2b-instruct-q4` as Perplexica `unsupported_until_revalidated` after repeated UI fleet evidence showed Perplexica returning prose/search output instead of the requested verification token
- add `granite4.1-3b-q4` as a low-VRAM 131K-context replacement candidate with exact GGUF size/SHA from Hugging Face metadata
- update the Windows 8GB release-candidate test to require the replacement and assert Granite 3.1 is product-visibly blocked from release coverage

## Evidence
- Release run red: `fleet-test/runs/2026-07-21T07-49-04Z-release-product-73762173ae0c-harness-ecd8157a6324-hosts-tower2/model-ui/cycle-005/tower2`
- Targeted repro red: `fleet-test/runs/2026-07-21T08-59-51Z-targeted-granite31-allapps-product-73762173ae0c-harness-ecd8157a6324-hosts-tower2/cycle-001/tower2`
- Granite 4.1 3B source: https://huggingface.co/ibm-granite/granite-4.1-3b and https://huggingface.co/ibm-granite/granite-4.1-3b-GGUF

## Tests
- `python -m json.tool config/model-library.json`
- `python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py tests/test-render-runtime-configs.py`
