### PR TITLE
fix(models): block Phi-3 Mini from agent release pool

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -339,6 +339,25 @@
       "install_recommendation": false
     },
     {
+      "id": "falcon-h1-3b-instruct-q4",
+      "name": "Falcon H1 3B Instruct",
+      "family": "falcon",
+      "gguf_file": "Falcon-H1-3B-Instruct-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/tiiuae/Falcon-H1-3B-Instruct-GGUF/resolve/main/Falcon-H1-3B-Instruct-Q4_K_M.gguf",
+      "gguf_sha256": "1926265eab19b0e47f0c2739e499a18e388373a616d71a218b924d5b95bdf702",
+      "size_bytes": 1888612384,
+      "size_mb": 1889,
+      "vram_required_gb": 4,
+      "context_length": 131072,
+      "quantization": "Q4_K_M",
+      "specialty": "Long Context",
+      "description": "TII's Falcon H1 3B hybrid instruct model. A long-context low-VRAM validation candidate that preserves the passing Falcon H1 family while replacing Phi-3 Mini in release coverage.",
+      "tokens_per_sec_estimate": 115,
+      "llm_model_name": "Falcon-H1-3B-Instruct",
+      "llama_server_image": null,
+      "install_recommendation": false
+    },
+    {
       "id": "granite4.1-3b-q4",
       "name": "Granite 4.1 3B",
       "family": "granite",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -495,7 +495,8 @@
           "recordedAt": "2026-07-21T08:59:51Z",
           "productSha": "73762173ae0c",
           "harnessSha": "ecd8157a6324",
-          "hostScope": ["tower2"]
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
         }
       },
       "install_recommendation": false
@@ -517,6 +518,28 @@
       "tokens_per_sec_estimate": 105,
       "llm_model_name": "Phi-3-mini-128k-instruct",
       "llama_server_image": null,
+      "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "reason": "Fleet model-UI run 2026-07-21T09:52Z on tower2 loaded Phi-3 Mini 128K successfully, but ODS Talk returned a generic assistant greeting instead of the requested verification phrase; keep it out of ODS Talk release coverage until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-21T09-52-42Z-release-product-5d4e805fab79-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2",
+          "recordedAt": "2026-07-21T11:04:41Z",
+          "productSha": "5d4e805fab795bd6c71a805a1c6188852ebb0963",
+          "harnessSha": "9804e8523a6d11ebeb86eac5f5400cf21fc25b39",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "reason": "ODS Talk release probe failed exact verification after successful Phi-3 Mini 128K load; not agent-viable until a Talk revalidation passes.",
+          "evidence": "fleet-test/runs/2026-07-21T09-52-42Z-release-product-5d4e805fab79-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2",
+          "recordedAt": "2026-07-21T11:04:41Z",
+          "productSha": "5d4e805fab795bd6c71a805a1c6188852ebb0963",
+          "harnessSha": "9804e8523a6d11ebeb86eac5f5400cf21fc25b39",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -384,11 +384,11 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
         "granite4.1-3b-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
-        "phi3-mini-128k-q4",
+        "falcon-h1-3b-instruct-q4",
     }.issubset(candidate_ids)
     assert by_id["falcon-h1-1.5b-instruct-q4"]["contextLength"] >= 65536
+    assert by_id["falcon-h1-3b-instruct-q4"]["contextLength"] == 131072
     assert by_id["granite4.1-3b-q4"]["contextLength"] == 131072
-    assert by_id["phi3-mini-128k-q4"]["contextLength"] == 131072
     assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == (
         "unsupported_until_revalidated"
     )
@@ -397,6 +397,7 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "gemma3-4b-it-q4" not in candidate_ids
     assert "granite4.0-h-350m-q4" not in candidate_ids
     assert "granite4.0-1b-q4" not in candidate_ids
+    assert "phi3-mini-128k-q4" not in candidate_ids
     assert "granite3.3-8b-instruct-q4" not in candidate_ids
     assert "smollm3-3b-q4" not in candidate_ids
     assert "qwen2.5-3b-instruct-q4" not in candidate_ids

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -73,6 +73,7 @@ def test_release_model_switchboard_catalog_ids_exist():
         "smollm3-3b-q4",
         "granite4.0-h-1b-q4",
         "falcon-h1-1.5b-instruct-q4",
+        "falcon-h1-3b-instruct-q4",
         "granite4.0-1b-q4",
         "granite4.0-h-350m-q4",
         "granite3.2-2b-instruct-q4",

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -132,6 +132,19 @@ def test_phi4_mini_is_not_agent_viable_after_strixy_talk_probe_failure():
     assert not _agent_viable_for_release(by_id["phi4-mini-q4"])
 
 
+def test_phi3_mini_128k_is_not_agent_viable_after_tower2_talk_probe_failure():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    compatibility = by_id["phi3-mini-128k-q4"]["app_compatibility"]
+
+    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
+    assert "tower2" in compatibility["agent_viability"]["hostScope"]
+    assert "cycle-006" in compatibility["agent_viability"]["evidence"]
+    assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
+    assert "generic assistant greeting" in compatibility["hermes_talk"]["reason"]
+    assert not _agent_viable_for_release(by_id["phi3-mini-128k-q4"])
+
+
 def test_llama31_8b_is_not_agent_viable_until_revalidated():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
@@ -300,7 +313,10 @@ def test_replacement_low_vram_long_context_models_are_cataloged_for_validation()
         assert model["context_length"] >= HERMES_CONTEXT_FLOOR
         assert model["gguf_sha256"] == sha256
         assert model["gguf_url"].startswith(url_prefix)
-        assert _agent_viable_for_release(model)
+        if model_id in {"granite3.1-2b-instruct-q4", "phi3-mini-128k-q4"}:
+            assert not _agent_viable_for_release(model)
+        else:
+            assert _agent_viable_for_release(model)
 
 
 def test_granite33_8b_has_visible_nvidia_8gb_release_profile():


### PR DESCRIPTION
﻿## Summary
- mark `phi3-mini-128k-q4` as not agent-viable for release planning after Tower2 loaded it successfully but ODS Talk returned a generic greeting instead of the verification phrase
- add lifecycle metadata to the existing Granite 3.1 Perplexica blocking verdict
- update model-library coverage tests so the low-VRAM release pool excludes blocked models and still has six viable alternatives

## Evidence
- Failing run: `/home/michael/dream-fleet-test/runs/2026-07-21T09-52-42Z-release-product-5d4e805fab79-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2`
- Phi-3 Mini loaded and served, but `test.load.talk.inference` failed because the Talk response was `Understood. How may I assist you today?`
- Viable low-VRAM release pool after this change: Granite 4.0 H-Micro, Granite 4.0 H-Tiny, Granite 4.0 H-1B, Falcon H1 1.5B, Granite 4.1 3B, Qwen 3.5 9B

## Tests
- `python -m pytest tests/test-model-library-coverage.py tests/test-model-library-verdicts.py`
