### PR TITLE
fix(models): block Falcon H1 1.5B for OpenCode

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -336,6 +336,28 @@
       "tokens_per_sec_estimate": 150,
       "llm_model_name": "Falcon-H1-1.5B-Instruct",
       "llama_server_image": null,
+      "app_compatibility": {
+        "opencode": {
+          "status": "unsupported_until_revalidated",
+          "reason": "Fleet model-UI run 2026-07-21T11:18Z on tower2 loaded Falcon H1 1.5B successfully and routed OpenCode through ods/current, but the OpenCode UX reply emitted a skill/tool meta-response instead of the requested verification phrase.",
+          "evidence": "fleet-test/runs/2026-07-21T11-18-01Z-release-product-c43960145c39-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-004/tower2",
+          "recordedAt": "2026-07-21T12:12:38Z",
+          "productSha": "c43960145c39c5fa24627bf8b0e98b30c362cc85",
+          "harnessSha": "9804e8523a6d11ebeb86eac5f5400cf21fc25b39",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "reason": "The same run proved Talk, Open WebUI, LiteLLM, and Perplexica routing, but OpenCode did not complete the required agent verification phrase after the swap; keep Falcon H1 1.5B out of agent-required release coverage until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-21T11-18-01Z-release-product-c43960145c39-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-004/tower2",
+          "recordedAt": "2026-07-21T12:12:38Z",
+          "productSha": "c43960145c39c5fa24627bf8b0e98b30c362cc85",
+          "harnessSha": "9804e8523a6d11ebeb86eac5f5400cf21fc25b39",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {
@@ -748,6 +770,25 @@
           "evidence": "https://huggingface.co/Qwen/Qwen3-1.7B/blob/main/config.json"
         }
       },
+      "install_recommendation": false
+    },
+    {
+      "id": "qwen2.5-coder-1.5b-128k-q4",
+      "name": "Qwen 2.5 Coder 1.5B 128K",
+      "family": "qwen",
+      "gguf_file": "Qwen2.5-Coder-1.5B-Instruct-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen2.5-Coder-1.5B-Instruct-128K-GGUF/resolve/main/Qwen2.5-Coder-1.5B-Instruct-Q4_K_M.gguf",
+      "gguf_sha256": "0fbff4d39395fab063c51377ba522928af2574b1f998d66012c1caed7b8f91d6",
+      "size_bytes": 986048224,
+      "size_mb": 986,
+      "vram_required_gb": 3,
+      "context_length": 131072,
+      "quantization": "Q4_K_M",
+      "specialty": "Code",
+      "description": "Small code-specialized Qwen model with a 128K GGUF context. A low-VRAM OpenCode-oriented release candidate to replace models that route correctly but fail agent UX probes.",
+      "tokens_per_sec_estimate": 145,
+      "llm_model_name": "qwen2.5-coder-1.5b-instruct",
+      "llama_server_image": null,
       "install_recommendation": false
     },
     {

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -380,21 +380,25 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert len(candidates) >= 6
     assert {
         "granite4.0-h-1b-q4",
-        "falcon-h1-1.5b-instruct-q4",
+        "qwen2.5-coder-1.5b-128k-q4",
         "granite4.1-3b-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
         "falcon-h1-3b-instruct-q4",
     }.issubset(candidate_ids)
-    assert by_id["falcon-h1-1.5b-instruct-q4"]["contextLength"] >= 65536
+    assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
     assert by_id["falcon-h1-3b-instruct-q4"]["contextLength"] == 131072
     assert by_id["granite4.1-3b-q4"]["contextLength"] == 131072
+    assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["opencode"]["status"] == (
+        "unsupported_until_revalidated"
+    )
     assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == (
         "unsupported_until_revalidated"
     )
     assert "granite3.1-2b-instruct-q4" not in candidate_ids
     assert "phi4-mini-q4" not in candidate_ids
     assert "gemma3-4b-it-q4" not in candidate_ids
+    assert "falcon-h1-1.5b-instruct-q4" not in candidate_ids
     assert "granite4.0-h-350m-q4" not in candidate_ids
     assert "granite4.0-1b-q4" not in candidate_ids
     assert "phi3-mini-128k-q4" not in candidate_ids

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -243,17 +243,20 @@ def test_granite4_1b_models_are_low_vram_agent_viable_candidates():
     assert _agent_viable_for_release(model)
 
 
-def test_falcon_h1_15b_is_low_vram_agent_viable_candidate():
+def test_falcon_h1_15b_is_not_low_vram_agent_viable_after_opencode_failure():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
 
     model = by_id["falcon-h1-1.5b-instruct-q4"]
+    compatibility = model["app_compatibility"]
     assert model["vram_required_gb"] <= 3
     assert model["context_length"] >= HERMES_CONTEXT_FLOOR
     assert model["gguf_sha256"] == "8b51aa2aa34a0373fd0cd64c02eb91d1bc1da681c09e955ad769d4a9b2d8385f"
     assert model["gguf_url"].startswith("https://huggingface.co/tiiuae/Falcon-H1-1.5B-Instruct-GGUF/")
     assert model["size_bytes"] == 944786656
-    assert _agent_viable_for_release(model)
+    assert compatibility["opencode"]["status"] == "unsupported_until_revalidated"
+    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
+    assert not _agent_viable_for_release(model)
 
 
 def test_granite32_2b_is_direct_chat_only_after_windows_talk_timeout():
@@ -294,9 +297,9 @@ def test_replacement_low_vram_long_context_models_are_cataloged_for_validation()
     by_id = {model["id"]: model for model in catalog["models"]}
 
     expected = {
-        "falcon-h1-1.5b-instruct-q4": (
-            "https://huggingface.co/tiiuae/Falcon-H1-1.5B-Instruct-GGUF/",
-            "8b51aa2aa34a0373fd0cd64c02eb91d1bc1da681c09e955ad769d4a9b2d8385f",
+        "qwen2.5-coder-1.5b-128k-q4": (
+            "https://huggingface.co/unsloth/Qwen2.5-Coder-1.5B-Instruct-128K-GGUF/",
+            "0fbff4d39395fab063c51377ba522928af2574b1f998d66012c1caed7b8f91d6",
         ),
         "granite3.1-2b-instruct-q4": (
             "https://huggingface.co/bartowski/granite-3.1-2b-instruct-GGUF/",
@@ -408,6 +411,30 @@ def test_qwen25_coder_3b_is_not_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["qwen2.5-coder-3b-128k-q4"])
 
 
+def test_falcon_h1_15b_is_not_opencode_agent_viable_until_revalidated():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    compatibility = by_id["falcon-h1-1.5b-instruct-q4"]["app_compatibility"]
+
+    assert compatibility["opencode"]["status"] == "unsupported_until_revalidated"
+    assert "OpenCode" in compatibility["opencode"]["reason"]
+    assert "cycle-004" in compatibility["opencode"]["evidence"]
+    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
+    assert "OpenCode" in compatibility["agent_viability"]["reason"]
+    assert not _agent_viable_for_release(by_id["falcon-h1-1.5b-instruct-q4"])
+
+
+def test_qwen25_coder_15b_128k_is_low_vram_release_candidate():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["qwen2.5-coder-1.5b-128k-q4"]
+
+    assert model["gguf_sha256"] == "0fbff4d39395fab063c51377ba522928af2574b1f998d66012c1caed7b8f91d6"
+    assert model["context_length"] >= HERMES_CONTEXT_FLOOR
+    assert model["vram_required_gb"] <= 3
+    assert _agent_viable_for_release(model)
+
+
 def test_qwen25_7b_is_not_agent_viable_on_low_vram_windows_until_revalidated():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
@@ -445,6 +472,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "qwen2.5-3b-instruct-q4",
         "qwen3-4b-q4",
         "qwen3-1.7b-q4",
+        "qwen2.5-coder-1.5b-128k-q4",
         "qwen2.5-coder-3b-128k-q4",
         "qwen2.5-7b-instruct-q4",
         "llama3.1-8b-instruct-q4",


### PR DESCRIPTION
﻿## Summary
- marks Falcon H1 1.5B as not agent-viable for release coverage after the Tower2 browser model-management matrix proved OpenCode did not return the verification phrase
- records the OpenCode-specific verdict as product-visible app compatibility metadata with lifecycle fields
- adds Qwen 2.5 Coder 1.5B 128K as the replacement low-VRAM release candidate so Windows 8 GB planning still has six non-current models

## Fleet evidence
- Run: `/home/michael/dream-fleet-test/runs/2026-07-21T11-18-01Z-release-product-c43960145c39-harness-9804e8523a6d-hosts-tower2`
- Product SHA: `c43960145c39c5fa24627bf8b0e98b30c362cc85`
- Harness SHA: `9804e8523a6d11ebeb86eac5f5400cf21fc25b39`
- Cycle 1: PASS `granite4.0-h-micro-q4`
- Cycle 2: PASS `granite4.0-h-tiny-q4`
- Cycle 3: PASS `granite4.0-h-1b-q4`
- Cycle 4: FAIL `falcon-h1-1.5b-instruct-q4`, `test.load.llm-consumers.probes`, OpenCode only
- Failure detail: Talk, LiteLLM, Open WebUI, and Perplexica routed correctly to `ods/current`; OpenCode used the correct route but produced a skill/tool meta-response instead of the required verification phrase.

## Local validation
- `python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py::test_real_catalog_has_six_windows_8gb_release_swap_candidates -q`
- `python -m pytest tests/test-model-library-coverage.py tests/test-model-library-verdicts.py -q`
- `python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py -q`
- `python -m json.tool config/model-library.json`
- `git diff --check`
