### PR TITLE
fix(dashboard-api): write persona, setup progress, and compose configs atomically

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1583,8 +1583,17 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
                 changed = True
 
     if changed:
-        with open(compose_path, "w", encoding="utf-8") as f:
-            yaml.safe_dump(data, f, sort_keys=False)
+        tmp_compose_path = compose_path.with_name(f".{compose_path.name}.tmp")
+        try:
+            with open(tmp_compose_path, "w", encoding="utf-8") as f:
+                yaml.safe_dump(data, f, sort_keys=False)
+            os.replace(tmp_compose_path, compose_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_compose_path)
+            except OSError:
+                pass
+            raise
 
 
 @router.post("/api/extensions/{service_id}/install")

--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1583,14 +1583,18 @@ def _rewrite_build_context(compose_path: Path, final_dir: Path) -> None:
                 changed = True
 
     if changed:
-        tmp_compose_path = compose_path.with_name(f".{compose_path.name}.tmp")
+        fd, tmp_path = tempfile.mkstemp(
+            dir=str(compose_path.parent),
+            prefix=f".{compose_path.name}.",
+            suffix=".tmp",
+        )
         try:
-            with open(tmp_compose_path, "w", encoding="utf-8") as f:
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
                 yaml.safe_dump(data, f, sort_keys=False)
-            os.replace(tmp_compose_path, compose_path)
+            os.replace(tmp_path, compose_path)
         except BaseException:
             try:
-                os.unlink(tmp_compose_path)
+                os.unlink(tmp_path)
             except OSError:
                 pass
             raise

--- a/ods/extensions/services/dashboard-api/routers/setup.py
+++ b/ods/extensions/services/dashboard-api/routers/setup.py
@@ -7,6 +7,7 @@ import os
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+import tempfile
 
 import aiohttp
 from fastapi import APIRouter, Depends, HTTPException
@@ -82,11 +83,31 @@ async def setup_persona(request: PersonaRequest, api_key: str = Depends(verify_a
         "system_prompt": persona_info["system_prompt"], "icon": persona_info["icon"],
         "selected_at": datetime.now(timezone.utc).isoformat()
     }
-    with open(SETUP_CONFIG_DIR / "persona.json", "w") as f:
-        json.dump(persona_data, f, indent=2)
+    persona_file = SETUP_CONFIG_DIR / "persona.json"
+    fd, tmp_path = tempfile.mkstemp(dir=str(SETUP_CONFIG_DIR), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(persona_data, f, indent=2)
+        os.replace(tmp_path, str(persona_file))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
-    with open(SETUP_CONFIG_DIR / "setup-progress.json", "w") as f:
-        json.dump({"step": 2, "persona_selected": True}, f)
+    progress_file = SETUP_CONFIG_DIR / "setup-progress.json"
+    fd, tmp_path = tempfile.mkstemp(dir=str(SETUP_CONFIG_DIR), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump({"step": 2, "persona_selected": True}, f)
+        os.replace(tmp_path, str(progress_file))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
     return {"success": True, "persona": request.persona, "name": persona_info["name"], "message": f"Great choice! Your assistant is now a {persona_info['name']}."}
 
@@ -96,8 +117,18 @@ async def setup_complete(api_key: str = Depends(verify_api_key)):
     """Mark the first-run setup as complete."""
     SETUP_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
 
-    with open(SETUP_CONFIG_DIR / "setup-complete.json", "w") as f:
-        json.dump({"completed_at": datetime.now(timezone.utc).isoformat(), "version": "1.0.0"}, f, indent=2)
+    complete_file = SETUP_CONFIG_DIR / "setup-complete.json"
+    fd, tmp_path = tempfile.mkstemp(dir=str(SETUP_CONFIG_DIR), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump({"completed_at": datetime.now(timezone.utc).isoformat(), "version": "1.0.0"}, f, indent=2)
+        os.replace(tmp_path, str(complete_file))
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
 
     progress_file = SETUP_CONFIG_DIR / "setup-progress.json"
     if progress_file.exists():

--- a/ods/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
+++ b/ods/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
@@ -239,4 +239,3 @@ def test_rewrites_build_context_atomically_without_temp_leftover(tmp_path, monke
     assert replaced_sources[0].name.endswith(".tmp")
     assert not list(tmp_path.glob("*.tmp"))
     assert not list(tmp_path.glob(".*.tmp"))
-

--- a/ods/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
+++ b/ods/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py
@@ -210,3 +210,33 @@ def test_malformed_yaml_propagates(tmp_path):
 
     with pytest.raises(yaml.YAMLError):
         _rewrite_build_context(compose, final_dir)
+
+
+def test_rewrites_build_context_atomically_without_temp_leftover(tmp_path, monkeypatch):
+    compose = tmp_path / "compose.yaml"
+    final_dir = Path("/var/lib/ods/user-extensions/foo")
+    _write(compose, {
+        "services": {
+            "foo": {"build": "."},
+        },
+    })
+
+    replaced_sources = []
+    real_replace = os.replace
+
+    def mock_replace(src, dst):
+        replaced_sources.append(Path(src))
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(os, "replace", mock_replace)
+
+    _rewrite_build_context(compose, final_dir)
+
+    data = _read(compose)
+    assert data["services"]["foo"]["build"] == {"context": str(final_dir.resolve())}
+    assert len(replaced_sources) == 1
+    assert replaced_sources[0].name.startswith(".compose.yaml.")
+    assert replaced_sources[0].name.endswith(".tmp")
+    assert not list(tmp_path.glob("*.tmp"))
+    assert not list(tmp_path.glob(".*.tmp"))
+


### PR DESCRIPTION
## Problem

In Dashboard API, onboarding setup files (`persona.json`, `setup-progress.json`, `setup-complete.json` in `routers/setup.py`) and user extension compose definitions (`compose.yaml` in `routers/extensions.py`) were previously updated using direct `open(..., "w")` writes, which truncate live files before writing new content. An interrupted write (process kill, disk full, host reboot) could leave configuration or onboarding state empty or partially written.

## Why the existing contract missed it

Direct `open(..., "w")` and non-unique temporary file rewrites allowed concurrent requests to truncate live files in-place or overwrite shared temporary file paths prior to atomic replacement.

## Fix

1. Update `routers/setup.py` to write `persona.json`, `setup-progress.json`, and `setup-complete.json` to temporary files before executing `os.replace()`.
2. Update `_rewrite_build_context()` in `routers/extensions.py` to use `tempfile.mkstemp(dir=str(compose_path.parent), prefix=f".{compose_path.name}.", suffix=".tmp")`, ensuring unique temporary file paths per request before executing `os.replace()`.

## Verification

1. Added `test_rewrites_build_context_atomically_without_temp_leftover` to `ods/extensions/services/dashboard-api/tests/test_install_from_library_build_context.py`.
2. Fixed EOF whitespace formatting in `test_install_from_library_build_context.py` (`git diff --check` passed cleanly).
3. Ran full test suite (`test_setup.py`, `test_user_extensions.py`, `test_install_from_library_build_context.py`): 50/50 passed.