### PR TITLE
fix(windows): honor WebUI port overrides

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -75,3 +75,7 @@ jobs:
       - name: Windows Model Activation Contract
         shell: pwsh
         run: ./tests/test-windows-model-activation.ps1
+
+      - name: Windows Port Preflight Contract
+        shell: pwsh
+        run: ./tests/test-windows-port-preflight.ps1

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -1996,9 +1996,11 @@ function Get-WindowsActiveModelSelection {
 }
 $activeModel = Get-WindowsActiveModelSelection -EnvMap $windowsEnvMap `
     -DefaultGgufFile $tierConfig.GgufFile -DefaultModelName $tierConfig.LlmModel
+$webuiHealthPort = Get-WindowsODSEnvPort -EnvMap $windowsEnvMap `
+    -Name "WEBUI_PORT" -DefaultPort 3000
 $healthChecks = @(
     @{ Name = $llmEndpoint.Name; Url = $llmEndpoint.HealthUrl }
-    @{ Name = "Chat UI (Open WebUI)"; Url = "http://localhost:3000" }
+    @{ Name = "Chat UI (Open WebUI)"; Url = "http://localhost:$webuiHealthPort" }
 )
 if ($enableVoice)     {
     $healthWhisperPort = if ($windowsEnvMap.ContainsKey("WHISPER_PORT") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["WHISPER_PORT"])) { $windowsEnvMap["WHISPER_PORT"] } else { "9000" }

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -12,6 +12,55 @@
 #   All secrets use cryptographic RNG -- never use Get-Random for secrets.
 # ============================================================================
 
+function Resolve-WindowsODSPort {
+    <#
+    .SYNOPSIS
+        Resolve a Windows installer port from an explicit process override,
+        persisted .env state, or the platform default.
+    #>
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+
+        [Parameter(Mandatory = $true)]
+        [int]$DefaultPort,
+
+        [hashtable]$ExistingEnv,
+        [string]$InstallDir = ""
+    )
+
+    $candidates = New-Object 'System.Collections.Generic.List[string]'
+    $processValue = [Environment]::GetEnvironmentVariable($Name)
+    if (-not [string]::IsNullOrWhiteSpace($processValue)) {
+        [void]$candidates.Add($processValue)
+    }
+
+    if ($ExistingEnv -and $ExistingEnv.ContainsKey($Name)) {
+        [void]$candidates.Add([string]$ExistingEnv[$Name])
+    } elseif (-not [string]::IsNullOrWhiteSpace($InstallDir)) {
+        $envPath = Join-Path $InstallDir ".env"
+        if (Test-Path -LiteralPath $envPath -PathType Leaf) {
+            $assignment = Get-Content -LiteralPath $envPath -ErrorAction SilentlyContinue |
+                Where-Object { $_ -match "^$([regex]::Escape($Name))=(.*)$" } |
+                Select-Object -First 1
+            if ($assignment -and $assignment -match "^[^=]+=(.*)$") {
+                [void]$candidates.Add([string]$Matches[1])
+            }
+        }
+    }
+
+    [void]$candidates.Add([string]$DefaultPort)
+    foreach ($candidate in $candidates) {
+        $parsedPort = 0
+        if ([int]::TryParse(([string]$candidate).Trim(), [ref]$parsedPort) -and
+            $parsedPort -ge 1 -and $parsedPort -le 65535) {
+            return $parsedPort
+        }
+    }
+
+    return $DefaultPort
+}
+
 function Write-Utf8NoBom {
     <#
     .SYNOPSIS
@@ -243,6 +292,10 @@ function New-ODSEnv {
         }
         return $Default
     }
+
+    $webuiPort = Resolve-WindowsODSPort `
+        -Name "WEBUI_PORT" -DefaultPort 3000 `
+        -ExistingEnv $existingEnv -InstallDir $InstallDir
 
     # Lemonade's native Windows router reserves host port 9000 for websockets.
     # Keep Whisper's container port unchanged, but move its host port out of the
@@ -627,7 +680,7 @@ COMFYUI_CPU_RESERVATION=$comfyuiCpuReservation
 
 #=== Ports ===
 OLLAMA_PORT=11434
-WEBUI_PORT=3000
+WEBUI_PORT=$webuiPort
 WHISPER_PORT=$whisperPort
 TTS_PORT=8880
 N8N_PORT=5678

--- a/ods/installers/windows/lib/install-report.ps1
+++ b/ods/installers/windows/lib/install-report.ps1
@@ -83,6 +83,9 @@ function New-ODSInstallReport {
     }
     $envMap = Get-WindowsODSEnvMap -InstallDir $InstallDir
     $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $InstallDir -GpuBackend $gpu.Backend -NativeBackend $nativeBackend
+    $webuiPort = Get-WindowsODSEnvPort -EnvMap $envMap -Name "WEBUI_PORT" -DefaultPort 3000
+    $dashboardPort = Get-WindowsODSEnvPort -EnvMap $envMap -Name "DASHBOARD_PORT" -DefaultPort 3001
+    $dashboardApiPort = Get-WindowsODSEnvPort -EnvMap $envMap -Name "DASHBOARD_API_PORT" -DefaultPort 3002
 
     $composeConfigArgs = @("compose") + $ComposeFlags + @("config")
     $composePsArgs = @("compose") + $ComposeFlags + @("ps", "-a")
@@ -120,9 +123,9 @@ function New-ODSInstallReport {
         }
         health = [ordered]@{
             llm_api = Test-HttpEndpoint -Url $llmEndpoint.HealthUrl
-            open_webui = Test-HttpEndpoint -Url "http://localhost:3000"
-            dashboard = Test-HttpEndpoint -Url "http://localhost:3001"
-            dashboard_api = Test-HttpEndpoint -Url "http://localhost:3002/health"
+            open_webui = Test-HttpEndpoint -Url "http://localhost:$webuiPort"
+            dashboard = Test-HttpEndpoint -Url "http://localhost:$dashboardPort"
+            dashboard_api = Test-HttpEndpoint -Url "http://localhost:$dashboardApiPort/health"
             whisper = $whisperStatus
             stt_model = [ordered]@{
                 name = $sttModel

--- a/ods/installers/windows/lib/llm-endpoint.ps1
+++ b/ods/installers/windows/lib/llm-endpoint.ps1
@@ -77,6 +77,29 @@ function Get-WindowsODSEnvValue {
     return $Default
 }
 
+function Get-WindowsODSEnvPort {
+    <#
+    .SYNOPSIS
+        Read and validate a persisted service port from a parsed ODS .env map.
+    #>
+    param(
+        [hashtable]$EnvMap,
+        [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [int]$DefaultPort
+    )
+
+    $candidate = Get-WindowsODSEnvValue -EnvMap $EnvMap -Keys @($Name) -Default ""
+    $parsedPort = 0
+    if ([int]::TryParse(([string]$candidate).Trim(), [ref]$parsedPort) -and
+        $parsedPort -ge 1 -and $parsedPort -le 65535) {
+        return $parsedPort
+    }
+
+    return $DefaultPort
+}
+
 function Get-WindowsLocalLlmEndpoint {
     <#
     .SYNOPSIS

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -1357,10 +1357,13 @@ function Invoke-Status {
         Write-Host ("  " + ("-" * 40)) -ForegroundColor DarkGray
 
         $llmEndpoint = Get-WindowsLocalLlmEndpoint -InstallDir $InstallDir -NativeBackend (Get-NativeInferenceBackend)
+        $runtimeEnv = Read-ODSEnv
+        $webuiPort = Get-WindowsODSEnvPort -EnvMap $runtimeEnv -Name "WEBUI_PORT" -DefaultPort 3000
+        $dashboardPort = Get-WindowsODSEnvPort -EnvMap $runtimeEnv -Name "DASHBOARD_PORT" -DefaultPort 3001
         $endpoints = @(
             @{ Name = "LLM API";    Url = $llmEndpoint.HealthUrl }
-            @{ Name = "Chat UI";    Url = "http://localhost:3000" }
-            @{ Name = "Dashboard";  Url = "http://localhost:3001" }
+            @{ Name = "Chat UI";    Url = "http://localhost:$webuiPort" }
+            @{ Name = "Dashboard";  Url = "http://localhost:$dashboardPort" }
         )
 
         foreach ($ep in $endpoints) {

--- a/ods/installers/windows/phases/04-requirements.ps1
+++ b/ods/installers/windows/phases/04-requirements.ps1
@@ -281,9 +281,11 @@ Stop-WindowsODSLemonadePortConflicts `
 
 # ── Port conflict detection ───────────────────────────────────────────────────
 # Build list of ports to check based on enabled features.
-# Default service ports match .env.example; overridden ports are not checked here.
+# Default service ports match .env.example. Open WebUI uses the same persisted
+# or process-level override that phase 06 will write to .env.
 $_portsToCheck = [ordered]@{
-    "Open WebUI (chat)"   = 3000
+    "Open WebUI (chat)"   = Resolve-WindowsODSPort `
+        -Name "WEBUI_PORT" -DefaultPort 3000 -InstallDir $installDir
     "Dashboard"           = 3001
     "Dashboard API"       = 3002
 }
@@ -357,7 +359,7 @@ if ($_portConflicts.Count -gt 0) {
     Write-AIWarn "Port conflicts detected:"
     $_portConflicts | ForEach-Object { Write-Host $_ -ForegroundColor Yellow }
     Write-AI "  Stop the conflicting processes, or override ports via environment variables."
-    Write-AI "  Example: set WEBUI_PORT=9090 before running the installer."
+    Write-AI '  Example: $env:WEBUI_PORT = "9090" before running the installer.'
     Write-AI "  See .env.example for all configurable ports."
 } else {
     Write-AISuccess "No port conflicts detected"

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -2,6 +2,9 @@ $ErrorActionPreference = "Stop"
 
 $root = Split-Path -Parent $PSScriptRoot
 $phasePath = Join-Path $root "installers\windows\phases\04-requirements.ps1"
+$installerPath = Join-Path $root "installers\windows\install-windows.ps1"
+$cliPath = Join-Path $root "installers\windows\ods.ps1"
+$reportPath = Join-Path $root "installers\windows\lib\install-report.ps1"
 . (Join-Path $root "installers\windows\lib\llm-endpoint.ps1")
 . (Join-Path $root "installers\windows\lib\detection.ps1")
 . (Join-Path $root "installers\windows\lib\env-generator.ps1")
@@ -44,6 +47,29 @@ function Assert-Equal {
 
 function Write-AIWarn {
     param([string]$Message)
+}
+
+$portMap = @{ WEBUI_PORT = "9090"; DASHBOARD_PORT = "3101" }
+Assert-Equal (Get-WindowsODSEnvPort -EnvMap $portMap -Name "WEBUI_PORT" -DefaultPort 3000) `
+    9090 "Persisted runtime WebUI port"
+Assert-Equal (Get-WindowsODSEnvPort -EnvMap $portMap -Name "DASHBOARD_PORT" -DefaultPort 3001) `
+    3101 "Persisted runtime dashboard port"
+$portMap.WEBUI_PORT = ""
+Assert-Equal (Get-WindowsODSEnvPort -EnvMap $portMap -Name "WEBUI_PORT" -DefaultPort 3000) `
+    3000 "Empty runtime WebUI port"
+$portMap.WEBUI_PORT = "70000"
+Assert-Equal (Get-WindowsODSEnvPort -EnvMap $portMap -Name "WEBUI_PORT" -DefaultPort 3000) `
+    3000 "Out-of-range runtime WebUI port"
+$portMap.WEBUI_PORT = "not-a-port"
+Assert-Equal (Get-WindowsODSEnvPort -EnvMap $portMap -Name "WEBUI_PORT" -DefaultPort 3000) `
+    3000 "Invalid runtime WebUI port"
+
+foreach ($consumerPath in @($installerPath, $cliPath, $reportPath)) {
+    $consumerText = Get-Content -LiteralPath $consumerPath -Raw
+    if ($consumerText -match 'Test-HttpEndpoint\s+-Url\s+"http://localhost:3000"' -or
+        $consumerText -match '@\{\s*Name\s*=\s*"(?:Chat UI|Chat UI \(Open WebUI\))";\s*Url\s*=\s*"http://localhost:3000"') {
+        throw "Windows runtime health consumer still hardcodes Open WebUI port 3000: $consumerPath"
+    }
 }
 
 $savedAmdPort = $env:AMD_INFERENCE_PORT

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -3,6 +3,8 @@ $ErrorActionPreference = "Stop"
 $root = Split-Path -Parent $PSScriptRoot
 $phasePath = Join-Path $root "installers\windows\phases\04-requirements.ps1"
 . (Join-Path $root "installers\windows\lib\llm-endpoint.ps1")
+. (Join-Path $root "installers\windows\lib\detection.ps1")
+. (Join-Path $root "installers\windows\lib\env-generator.ps1")
 $tokens = $null
 $errors = $null
 $ast = [System.Management.Automation.Language.Parser]::ParseFile(
@@ -12,6 +14,11 @@ $ast = [System.Management.Automation.Language.Parser]::ParseFile(
 )
 if ($errors.Count -gt 0) {
     throw "Phase 04 failed to parse: $($errors[0].Message)"
+}
+
+$phaseText = Get-Content -LiteralPath $phasePath -Raw
+if ($phaseText -notmatch [regex]::Escape('$env:WEBUI_PORT = "9090"')) {
+    throw "Phase 04 does not show valid PowerShell syntax for WEBUI_PORT overrides"
 }
 
 foreach ($name in @(
@@ -35,13 +42,27 @@ function Assert-Equal {
     }
 }
 
+function Write-AIWarn {
+    param([string]$Message)
+}
+
 $savedAmdPort = $env:AMD_INFERENCE_PORT
 $savedOllamaPort = $env:OLLAMA_PORT
 $savedLlamaPort = $env:LLAMA_SERVER_PORT
+$savedWebuiPort = $env:WEBUI_PORT
 try {
     Remove-Item Env:AMD_INFERENCE_PORT -ErrorAction SilentlyContinue
     Remove-Item Env:OLLAMA_PORT -ErrorAction SilentlyContinue
     Remove-Item Env:LLAMA_SERVER_PORT -ErrorAction SilentlyContinue
+    Remove-Item Env:WEBUI_PORT -ErrorAction SilentlyContinue
+
+    Assert-Equal (Resolve-WindowsODSPort -Name "WEBUI_PORT" -DefaultPort 3000) `
+        3000 "WebUI default"
+
+    $env:WEBUI_PORT = "9090"
+    Assert-Equal (Resolve-WindowsODSPort -Name "WEBUI_PORT" -DefaultPort 3000) `
+        9090 "WebUI process override"
+    Remove-Item Env:WEBUI_PORT
 
     Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd") 8080 "AMD default"
     Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -LemonadeDefaultPort 18081) `
@@ -64,17 +85,73 @@ try {
 
     Remove-Item Env:AMD_INFERENCE_PORT -ErrorAction SilentlyContinue
     Remove-Item Env:LLAMA_SERVER_PORT -ErrorAction SilentlyContinue
+
+    $generatedDir = Join-Path ([IO.Path]::GetTempPath()) "ods-webui-port-env-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $generatedDir | Out-Null
+    try {
+        $tierConfig = @{
+            TierName = "Windows port contract"
+            LlmModel = "test-model"
+            GgufFile = "test.gguf"
+            MaxContext = 4096
+        }
+
+        $env:WEBUI_PORT = "9090"
+        New-ODSEnv -InstallDir $generatedDir -TierConfig $tierConfig `
+            -Tier "3" -GpuBackend "nvidia" | Out-Null
+        $generatedEnv = Get-Content -LiteralPath (Join-Path $generatedDir ".env") -Raw
+        if ($generatedEnv -notmatch "(?m)^WEBUI_PORT=9090\r?$") {
+            throw "Clean Windows env generation did not persist WEBUI_PORT=9090"
+        }
+
+        Remove-Item Env:WEBUI_PORT
+        New-ODSEnv -InstallDir $generatedDir -TierConfig $tierConfig `
+            -Tier "3" -GpuBackend "nvidia" | Out-Null
+        $generatedEnv = Get-Content -LiteralPath (Join-Path $generatedDir ".env") -Raw
+        if ($generatedEnv -notmatch "(?m)^WEBUI_PORT=9090\r?$") {
+            throw "Windows env regeneration did not preserve WEBUI_PORT=9090"
+        }
+    } finally {
+        Remove-Item -LiteralPath $generatedDir -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item Env:WEBUI_PORT -ErrorAction SilentlyContinue
+    }
+
+    $defaultDir = Join-Path ([IO.Path]::GetTempPath()) "ods-webui-port-default-$([Guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $defaultDir | Out-Null
+    try {
+        New-ODSEnv -InstallDir $defaultDir -TierConfig $tierConfig `
+            -Tier "3" -GpuBackend "nvidia" | Out-Null
+        $defaultEnv = Get-Content -LiteralPath (Join-Path $defaultDir ".env") -Raw
+        if ($defaultEnv -notmatch "(?m)^WEBUI_PORT=3000\r?$") {
+            throw "Default Windows env generation no longer writes WEBUI_PORT=3000"
+        }
+    } finally {
+        Remove-Item -LiteralPath $defaultDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+
     $installDir = Join-Path ([IO.Path]::GetTempPath()) "ods-port-preflight-$([Guid]::NewGuid().ToString('N'))"
     New-Item -ItemType Directory -Path $installDir | Out-Null
     try {
         Set-Content -LiteralPath (Join-Path $installDir ".env") -Value @(
             "AMD_INFERENCE_PORT=19080",
-            "OLLAMA_PORT=22434"
+            "OLLAMA_PORT=22434",
+            "WEBUI_PORT=3100"
         )
         Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -InstallDir $installDir) `
             19080 "Persisted AMD port"
         Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "nvidia" -InstallDir $installDir) `
             22434 "Persisted Docker port"
+        Assert-Equal (Resolve-WindowsODSPort -Name "WEBUI_PORT" -DefaultPort 3000 -InstallDir $installDir) `
+            3100 "Persisted WebUI port"
+
+        $env:WEBUI_PORT = "9090"
+        Assert-Equal (Resolve-WindowsODSPort -Name "WEBUI_PORT" -DefaultPort 3000 -InstallDir $installDir) `
+            9090 "WebUI process override wins over persisted port"
+
+        $env:WEBUI_PORT = "not-a-port"
+        Assert-Equal (Resolve-WindowsODSPort -Name "WEBUI_PORT" -DefaultPort 3000 -InstallDir $installDir) `
+            3100 "Invalid WebUI override falls back to persisted port"
+        Remove-Item Env:WEBUI_PORT
 
         $env:AMD_INFERENCE_PORT = "29080"
         Assert-Equal (Resolve-WindowsLlmPreflightPort -GpuBackend "amd" -InstallDir $installDir) `
@@ -115,6 +192,7 @@ try {
     if ($null -eq $savedAmdPort) { Remove-Item Env:AMD_INFERENCE_PORT -ErrorAction SilentlyContinue } else { $env:AMD_INFERENCE_PORT = $savedAmdPort }
     if ($null -eq $savedOllamaPort) { Remove-Item Env:OLLAMA_PORT -ErrorAction SilentlyContinue } else { $env:OLLAMA_PORT = $savedOllamaPort }
     if ($null -eq $savedLlamaPort) { Remove-Item Env:LLAMA_SERVER_PORT -ErrorAction SilentlyContinue } else { $env:LLAMA_SERVER_PORT = $savedLlamaPort }
+    if ($null -eq $savedWebuiPort) { Remove-Item Env:WEBUI_PORT -ErrorAction SilentlyContinue } else { $env:WEBUI_PORT = $savedWebuiPort }
 }
 
-Write-Host "[PASS] Windows backend-aware LLM port preflight"
+Write-Host "[PASS] Windows service port preflight and env generation"

--- a/ods/tests/test-windows-port-preflight.ps1
+++ b/ods/tests/test-windows-port-preflight.ps1
@@ -160,20 +160,22 @@ try {
         Remove-Item -LiteralPath $installDir -Recurse -Force -ErrorAction SilentlyContinue
     }
 
-    $listener = [System.Net.Sockets.TcpListener]::new(
-        [System.Net.IPAddress]::Loopback,
-        0
-    )
-    $listener.Start()
-    try {
-        $port = ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
-        $result = Test-WindowsPortInUse -Port $port
-        Assert-Equal $result.InUse $true "Live listener detection"
-        if ([int]$result.ProcessId -le 0) {
-            throw "Live listener detection did not return an owning PID"
+    if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
+        $listener = [System.Net.Sockets.TcpListener]::new(
+            [System.Net.IPAddress]::Loopback,
+            0
+        )
+        $listener.Start()
+        try {
+            $port = ([System.Net.IPEndPoint]$listener.LocalEndpoint).Port
+            $result = Test-WindowsPortInUse -Port $port
+            Assert-Equal $result.InUse $true "Live listener detection"
+            if ([int]$result.ProcessId -le 0) {
+                throw "Live listener detection did not return an owning PID"
+            }
+        } finally {
+            $listener.Stop()
         }
-    } finally {
-        $listener.Stop()
     }
 
     $managedProcesses = @(
@@ -196,3 +198,5 @@ try {
 }
 
 Write-Host "[PASS] Windows service port preflight and env generation"
+$global:LASTEXITCODE = 0
+exit 0


### PR DESCRIPTION
## Summary

Fix the Windows installer contract for **WEBUI_PORT** overrides.

A clean install could detect a conflict on port 3000, recommend setting **WEBUI_PORT**, and then still write or probe port 3000. The effective port now follows one validated resolution order:

1. explicit process-level **WEBUI_PORT**;
2. an existing installation's persisted **WEBUI_PORT**;
3. the unchanged default, **3000**.

That same persisted value is now used by preflight, generated **.env**, Docker Compose, installer health checks, **ods status**, the final readiness summary, compose diagnostics, and the Windows install report. The conflict guidance now uses valid PowerShell environment-variable syntax.

## AI Assistance

AI-assisted log triage and regression-test drafting. The author reviewed the implementation, scope, and validation evidence.

## Release Lane

- [ ] Stable hotfix targeting release/2.5.x
- [x] Mainline change targeting main
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Invariants

- Hosts without an override remain on port **3000**.
- A valid process override wins during generation and is persisted.
- A rerun without the process override preserves the persisted port.
- Empty, malformed, zero, negative, and greater-than-65535 values never reach a URL or Compose binding.
- Runtime probes use generated **.env** as their source of truth.
- No schema, secret, model, image, service-selection, or bind-address behavior changes.

## Risk And Validation

- Risk level: High
- Validation run:
  - [x] git diff --check
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation

~~~text
PowerShell 7 focused contract: PASS
Windows PowerShell 5.1 focused contract: PASS
PSScriptAnalyzer (Error, Warning): PASS
PowerShell parser: PASS
git diff --check: PASS
Compose render with WEBUI_PORT=9090: 127.0.0.1:9090 -> open-webui:8080
dashboard-api: 1734 passed, 2 skipped
dashboard frontend: 198 passed
dashboard production build: PASS
~~~

The focused contract covers clean install, unchanged default, valid override, persisted rerun, explicit-over-persisted precedence, empty/invalid/out-of-range values, generated **.env**, live listener detection, and guards against reintroducing **localhost:3000** in the Windows installer, CLI status, or install report.

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred.

## Notes For Reviewers

Open WebUI is an always-on base service, so a disabled-service case does not apply. Partial installer failure does not create a separate port state: reruns either preserve the generated **.env** value or resolve the explicit override again.

Rollback is a straight revert. No data or configuration migration is involved.

Linux and macOS code paths are unchanged. Their installer generators still have independent port-default behavior and are intentionally outside this Windows-scoped fix.