### PR TITLE
fix(windows): stream Docker pull progress

### DIFF
--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -1263,6 +1263,7 @@ litellm_settings:
         function Invoke-ODSWindowsComposeBuildService {
             param(
                 [Parameter(Mandatory = $true)][string]$Service,
+                [AllowEmptyCollection()]
                 [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
                 [Parameter(Mandatory = $true)][string[]]$ComposeFlags,
                 [Parameter(Mandatory = $true)][string]$BuildLog,
@@ -1292,6 +1293,7 @@ litellm_settings:
         function Invoke-ODSWindowsPlainDockerBuildService {
             param(
                 [Parameter(Mandatory = $true)][string]$Service,
+                [AllowEmptyCollection()]
                 [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
                 [Parameter(Mandatory = $true)][string[]]$ComposeFlags,
                 [Parameter(Mandatory = $true)][string]$BuildLog
@@ -1446,6 +1448,7 @@ litellm_settings:
 
         function Get-ODSWindowsComposeExternalImages {
             param(
+                [AllowEmptyCollection()]
                 [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
                 [Parameter(Mandatory = $true)][string[]]$ComposeFlags
             )
@@ -1498,6 +1501,7 @@ litellm_settings:
         function Invoke-ODSWindowsDockerPullWithRetry {
             param(
                 [Parameter(Mandatory = $true)][string]$Image,
+                [AllowEmptyCollection()]
                 [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
                 [Parameter(Mandatory = $true)][string]$LogPath,
                 [int]$MaxAttempts = 4
@@ -1564,6 +1568,7 @@ litellm_settings:
 
         function Invoke-ODSWindowsComposeImagePreflight {
             param(
+                [AllowEmptyCollection()]
                 [Parameter(Mandatory = $true)][string[]]$DockerClientArgs,
                 [Parameter(Mandatory = $true)][string[]]$ComposeFlags,
                 [Parameter(Mandatory = $true)][string]$LogPath

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -1518,8 +1518,36 @@ litellm_settings:
             $delays = @(5, 15, 30)
             for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
                 Write-AI "Pulling Compose image ($attempt/$MaxAttempts): $Image"
-                & docker @DockerClientArgs pull $Image *>> $LogPath
-                if ($LASTEXITCODE -eq 0) {
+                $pullExitCode = 1
+                $logWriteError = $null
+                $pullEAP = $ErrorActionPreference
+                try {
+                    # Windows PowerShell 5.1 promotes redirected native stderr
+                    # to NativeCommandError when ErrorActionPreference is Stop.
+                    # Continue keeps Docker's progress stream readable; explicit
+                    # Add-Content error handling still makes log failures visible.
+                    $ErrorActionPreference = "Continue"
+                    & docker @DockerClientArgs pull $Image 2>&1 | ForEach-Object {
+                        $line = [string]$_
+                        Write-Host $line
+                        if (-not $logWriteError) {
+                            try {
+                                Add-Content -LiteralPath $LogPath -Value $line -ErrorAction Stop
+                            } catch {
+                                $logWriteError = $_
+                            }
+                        }
+                    }
+                    $pullExitCode = $LASTEXITCODE
+                } finally {
+                    $ErrorActionPreference = $pullEAP
+                }
+
+                if ($logWriteError) {
+                    Write-AIError "Could not append Docker pull progress to ${LogPath}: $($logWriteError.Exception.Message)"
+                    return $false
+                }
+                if ($pullExitCode -eq 0) {
                     Write-AISuccess "Pulled $Image"
                     return $true
                 }

--- a/ods/tests/contracts/test-amd-lemonade-contracts.sh
+++ b/ods/tests/contracts/test-amd-lemonade-contracts.sh
@@ -746,6 +746,15 @@ if grep -A16 'function Test-ODSDockerImageAvailable' installers/windows/install-
 else
     fail "install-windows.ps1: Docker image probes must not abort on missing local images"
 fi
+if command -v pwsh >/dev/null 2>&1; then
+    if pwsh -NoProfile -File tests/contracts/test-windows-docker-pull.ps1; then
+        pass "install-windows.ps1: Docker pull progress and result runtime contract"
+    else
+        fail "install-windows.ps1: Docker pull progress and result runtime contract failed"
+    fi
+else
+    pass "install-windows.ps1: Docker pull runtime test skipped (pwsh unavailable)"
+fi
 
 # ---------------------------------------------------------------------------
 # 19. AMD Docker 29.3 downgrade is Debian-aware and sudo-aware

--- a/ods/tests/contracts/test-windows-docker-pull.ps1
+++ b/ods/tests/contracts/test-windows-docker-pull.ps1
@@ -1,0 +1,136 @@
+$ErrorActionPreference = "Stop"
+
+$root = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
+$installerPath = Join-Path $root "installers\windows\install-windows.ps1"
+$tokens = $null
+$errors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installerPath,
+    [ref]$tokens,
+    [ref]$errors
+)
+if ($errors.Count -gt 0) {
+    throw "Windows installer failed to parse: $($errors[0].Message)"
+}
+
+$functionAst = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq "Invoke-ODSWindowsDockerPullWithRetry"
+}, $true)
+if (-not $functionAst) {
+    throw "Invoke-ODSWindowsDockerPullWithRetry was not found"
+}
+. ([scriptblock]::Create($functionAst.Extent.Text))
+
+function Write-AI { param([string]$Message) Write-Host $Message }
+function Write-AISuccess { param([string]$Message) Write-Host $Message }
+function Write-AIWarn { param([string]$Message) Write-Host $Message }
+function Write-AIError { param([string]$Message) Write-Host $Message }
+
+$script:inspectExitCode = 1
+$script:pullExitCodes = @()
+$script:pullAttempts = 0
+$script:emitPullError = $false
+function docker {
+    $commandLine = $args -join " "
+    if ($commandLine -match "image inspect") {
+        $global:LASTEXITCODE = $script:inspectExitCode
+        return
+    }
+    if ($commandLine -match "pull") {
+        $index = $script:pullAttempts
+        $script:pullAttempts++
+        if ($script:emitPullError) {
+            Write-Error "registry unavailable"
+        }
+        Write-Output "layer-$($script:pullAttempts): downloading"
+        Write-Output "layer-$($script:pullAttempts): complete"
+        $global:LASTEXITCODE = [int]$script:pullExitCodes[$index]
+        return
+    }
+    throw "Unexpected docker invocation: $commandLine"
+}
+
+function Assert-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) { throw $Message }
+}
+
+$tempDir = Join-Path ([IO.Path]::GetTempPath()) "ods-docker-pull-$([Guid]::NewGuid().ToString('N'))"
+New-Item -ItemType Directory -Path $tempDir | Out-Null
+try {
+    $logPath = Join-Path $tempDir "compose progress.log"
+
+    $script:inspectExitCode = 1
+    $script:pullExitCodes = @(0)
+    $script:pullAttempts = 0
+    $script:emitPullError = $false
+    $captured = @(& {
+        Invoke-ODSWindowsDockerPullWithRetry `
+            -Image "registry.example/large:latest" `
+            -DockerClientArgs @("--config", "mock") -LogPath $logPath -MaxAttempts 1
+    } 6>&1)
+    $result = @($captured | Where-Object { $_ -is [bool] })
+    Assert-True ($result.Count -eq 1 -and $result[0]) `
+        "Successful pull did not return exactly one true result"
+    Assert-True ($script:pullAttempts -eq 1) "Successful pull attempt count changed"
+    $visible = ($captured | ForEach-Object { [string]$_ }) -join "`n"
+    Assert-True ($visible -match "layer-1: downloading") `
+        "Docker progress was not emitted to the terminal stream"
+    $logText = Get-Content -LiteralPath $logPath -Raw
+    Assert-True ($logText -match "layer-1: downloading" -and $logText -match "layer-1: complete") `
+        "Docker progress was not appended to the compose log"
+    Assert-True ($ErrorActionPreference -eq "Stop") `
+        "Pull helper did not restore ErrorActionPreference after success"
+
+    Remove-Item -LiteralPath $logPath -Force
+    $script:inspectExitCode = 1
+    $script:pullExitCodes = @(1)
+    $script:pullAttempts = 0
+    $script:emitPullError = $true
+    $captured = @(& {
+        Invoke-ODSWindowsDockerPullWithRetry `
+            -Image "registry.example/missing:latest" `
+            -DockerClientArgs @("--config", "mock") -LogPath $logPath -MaxAttempts 1
+    } 6>&1)
+    $result = @($captured | Where-Object { $_ -is [bool] })
+    Assert-True ($result.Count -eq 1 -and -not $result[0]) `
+        "Failed pull did not return exactly one false result"
+    Assert-True ($script:pullAttempts -eq 1) "Failed pull attempt count changed"
+    $failureLog = Get-Content -LiteralPath $logPath -Raw
+    Assert-True ($failureLog -match "layer-1: downloading" -and $failureLog -match "registry unavailable") `
+        "Failed pull stdout/stderr was not retained in the compose log"
+    Assert-True ($ErrorActionPreference -eq "Stop") `
+        "Pull helper did not restore ErrorActionPreference after failure"
+
+    $badLogPath = Join-Path $tempDir "log-target-directory"
+    New-Item -ItemType Directory -Path $badLogPath | Out-Null
+    $script:inspectExitCode = 1
+    $script:pullExitCodes = @(0)
+    $script:pullAttempts = 0
+    $script:emitPullError = $false
+    $logFailure = Invoke-ODSWindowsDockerPullWithRetry `
+        -Image "registry.example/log-failure:latest" `
+        -DockerClientArgs @("--config", "mock") -LogPath $badLogPath -MaxAttempts 1
+    Assert-True ($logFailure -eq $false) "Pull helper ignored a compose-log write failure"
+    Assert-True ($ErrorActionPreference -eq "Stop") `
+        "Pull helper did not restore ErrorActionPreference after a log failure"
+
+    Remove-Item -LiteralPath $logPath -Force
+    $script:inspectExitCode = 0
+    $script:pullExitCodes = @()
+    $script:pullAttempts = 0
+    $script:emitPullError = $false
+    $cached = Invoke-ODSWindowsDockerPullWithRetry `
+        -Image "registry.example/cached:latest" `
+        -DockerClientArgs @("--config", "mock") -LogPath $logPath -MaxAttempts 1
+    Assert-True ($cached -eq $true) "Cached image no longer skips the pull"
+    Assert-True ($script:pullAttempts -eq 0) "Cached image unexpectedly invoked docker pull"
+    Assert-True ((Get-Content -LiteralPath $logPath -Raw) -match "Compose image already cached") `
+        "Cached-image receipt was not written"
+} finally {
+    Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+Write-Host "[PASS] Windows Docker pull progress and result contract"

--- a/ods/tests/contracts/test-windows-docker-pull.ps1
+++ b/ods/tests/contracts/test-windows-docker-pull.ps1
@@ -23,15 +23,44 @@ if (-not $functionAst) {
 }
 . ([scriptblock]::Create($functionAst.Extent.Text))
 
+foreach ($functionName in @(
+    "Invoke-ODSWindowsComposeBuildService",
+    "Invoke-ODSWindowsPlainDockerBuildService",
+    "Get-ODSWindowsComposeExternalImages",
+    "Invoke-ODSWindowsDockerPullWithRetry",
+    "Invoke-ODSWindowsComposeImagePreflight"
+)) {
+    $dockerFunction = $ast.Find({
+        param($node)
+        $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq $functionName
+    }, $true)
+    if (-not $dockerFunction) { throw "Function not found: $functionName" }
+    $dockerArgsParameter = $dockerFunction.Body.ParamBlock.Parameters | Where-Object {
+        $_.Name.VariablePath.UserPath -eq "DockerClientArgs"
+    }
+    $allowsEmpty = @($dockerArgsParameter.Attributes | Where-Object {
+        $_.TypeName.Name -eq "AllowEmptyCollection"
+    }).Count -eq 1
+    if (-not $allowsEmpty) {
+        throw "$functionName rejects the empty Docker argument list used by the default user config"
+    }
+}
+
 function Write-AI { param([string]$Message) Write-Host $Message }
 function Write-AISuccess { param([string]$Message) Write-Host $Message }
 function Write-AIWarn { param([string]$Message) Write-Host $Message }
 function Write-AIError { param([string]$Message) Write-Host $Message }
+function Start-Sleep {
+    param([int]$Seconds)
+    $script:sleepDelays += $Seconds
+}
 
 $script:inspectExitCode = 1
 $script:pullExitCodes = @()
 $script:pullAttempts = 0
 $script:emitPullError = $false
+$script:sleepDelays = @()
 function docker {
     $commandLine = $args -join " "
     if ($commandLine -match "image inspect") {
@@ -83,6 +112,42 @@ try {
         "Docker progress was not appended to the compose log"
     Assert-True ($ErrorActionPreference -eq "Stop") `
         "Pull helper did not restore ErrorActionPreference after success"
+
+    Remove-Item -LiteralPath $logPath -Force
+    $script:inspectExitCode = 1
+    $script:pullExitCodes = @(0)
+    $script:pullAttempts = 0
+    $captured = @(& {
+        Invoke-ODSWindowsDockerPullWithRetry `
+            -Image "registry.example/default-config:latest" `
+            -DockerClientArgs @() -LogPath $logPath -MaxAttempts 1
+    } 6>&1)
+    $result = @($captured | Where-Object { $_ -is [bool] })
+    Assert-True ($result.Count -eq 1 -and $result[0]) `
+        "Pull helper rejected the empty Docker argument list used by the default user config"
+    Assert-True ($script:pullAttempts -eq 1) `
+        "Default Docker config did not execute exactly one pull"
+
+    Remove-Item -LiteralPath $logPath -Force
+    $script:inspectExitCode = 1
+    $script:pullExitCodes = @(1, 0)
+    $script:pullAttempts = 0
+    $script:sleepDelays = @()
+    $captured = @(& {
+        Invoke-ODSWindowsDockerPullWithRetry `
+            -Image "registry.example/transient:latest" `
+            -DockerClientArgs @() -LogPath $logPath -MaxAttempts 2
+    } 6>&1)
+    $result = @($captured | Where-Object { $_ -is [bool] })
+    Assert-True ($result.Count -eq 1 -and $result[0]) `
+        "Transient pull failure did not recover on retry"
+    Assert-True ($script:pullAttempts -eq 2) `
+        "Transient pull did not execute exactly two attempts"
+    Assert-True ($script:sleepDelays.Count -eq 1 -and $script:sleepDelays[0] -eq 5) `
+        "Transient pull did not retain the first retry delay"
+    $retryLog = Get-Content -LiteralPath $logPath -Raw
+    Assert-True ($retryLog -match "layer-1: downloading" -and $retryLog -match "layer-2: complete") `
+        "Transient pull did not retain output from both attempts"
 
     Remove-Item -LiteralPath $logPath -Force
     $script:inspectExitCode = 1


### PR DESCRIPTION
## Summary

Stream Windows Docker image-pull output to the installer terminal while preserving the existing **compose-up.log** receipt.

Large CUDA images previously appeared to freeze because Docker progress was redirected entirely to the log. The helper now:

- displays every Docker stdout/stderr line as it arrives;
- appends the same line with literal-path semantics;
- preserves cache probing, image order, retry count, backoff, and boolean result shape;
- restores **ErrorActionPreference** after native stderr on Windows PowerShell 5.1;
- treats a required log-write failure as a failed preflight;
- accepts an empty Docker client-argument list, which is the normal representation of the user's default Docker configuration.

## AI Assistance

AI-assisted support-log triage and regression-test drafting. The author reviewed the implementation, compatibility constraints, and validation evidence.

## Release Lane

- [ ] Stable hotfix targeting release/2.5.x
- [x] Mainline change targeting main
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring

## Invariants

- Cached images never pull again.
- Uncached images stream and log both stdout and stderr.
- Transient failures retain the existing retry delays and may recover.
- Permanent failure prevents Compose from starting with missing images.
- Install-scoped Docker config and the empty-argument user config follow the same chain.
- A rerun reuses successfully cached layers and preserves the existing install state.
- No image, tag, Compose profile, service selection, registry credential, or default retry policy changes.

## Risk And Validation

- Risk level: High
- Validation run:
  - [x] git diff --check
  - [x] Focused tests listed below
  - [x] Dashboard lint/test/build
  - [x] Extension audit / compose validation
  - [ ] Release-grade uncached registry pull
  - [ ] Stable-lane patch validation

~~~text
PowerShell 7 focused contract: PASS
Windows PowerShell 5.1 focused contract: PASS
PSScriptAnalyzer (Error, Warning): PASS
PowerShell parser: PASS
git diff --check: PASS
Real docker.exe daemon-off failure path: streamed, logged, returned false, restored EAP
dashboard-api: 1734 passed, 2 skipped
dashboard frontend: 198 passed
dashboard production build: PASS
~~~

The focused contract covers cache hit, clean uncached success, stdout/stderr retention, terminal visibility, transient failure then recovery, permanent failure, exact boolean result shape, log paths containing spaces, log-write failure, empty Docker client arguments, retry delay retention, and **ErrorActionPreference** restoration. AST assertions cover the complete build/image-discovery/preflight chain.

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred.

## Notes For Reviewers

A disabled service is absent from the rendered Compose image list and is therefore not pulled. Successful pulls are Docker-cache state only; failures do not mutate ODS configuration. A second installer run resumes through cache inspection and pulls only missing images.

Rollback is a straight revert. It does not migrate state or configuration.

Linux and macOS use separate shell installer paths and are unchanged.

A successful uncached registry pull through the real helper is not included because Docker Desktop was offline. The real native failure path and both supported PowerShell generations are covered locally; CI should provide the final release-lane receipt.