### PR TITLE
fix/remote-session-cleanup-atomic-writes 

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -1332,7 +1332,7 @@ def _kill_remote_session(agent: str, reason: str = "dashboard") -> dict:
     sessions_dir = remote["sessions_dir"]
 
     script = (
-        "import os, glob, json, sys\n"
+        "import os, glob, json, sys, tempfile\n"
         "sdir = sys.argv[1]\n"
         "files = sorted(glob.glob(os.path.join(sdir, '*.jsonl')), key=os.path.getsize, reverse=True)\n"
         "if not files:\n"
@@ -1347,7 +1347,14 @@ def _kill_remote_session(agent: str, reason: str = "dashboard") -> dict:
         "        with open(sj) as fh: data = json.load(fh)\n"
         "        for k in list(data.keys()):\n"
         "            if isinstance(data[k], dict) and data[k].get('sessionId') == sid: del data[k]\n"
-        "        with open(sj, 'w') as fh: json.dump(data, fh, indent=2)\n"
+        "        fd, tmp = tempfile.mkstemp(dir=sdir, suffix='.tmp')\n"
+        "        try:\n"
+        "            with os.fdopen(fd, 'w') as fh: json.dump(data, fh, indent=2)\n"
+        "            os.replace(tmp, sj)\n"
+        "        except Exception:\n"
+        "            try: os.unlink(tmp)\n"
+        "            except Exception: pass\n"
+        "            raise\n"
         "    except Exception as e:\n"
         "        print(json.dumps({'warn': 'sessions.json update failed', 'error': str(e)}))\n"
         "    print(json.dumps({'action': 'killed', 'session_id': sid, 'size_bytes': size}))"


### PR DESCRIPTION
## Summary

Prevent in-place truncation when updating `sessions.json` on remote Token Spy agents.

Previously, the inline Python script executed by `_kill_remote_session` updated the remote `sessions.json` file using `open(..., "w")`. Since this truncates the destination before writing the new contents, an interrupted update (for example, due to an SSH disconnect or process termination) could leave the session database incomplete or empty.

This change updates the remote write path to use atomic file replacement:

- Writes the updated session data to a temporary file in the destination directory using `tempfile.mkstemp()`.
- Atomically replaces the destination using `os.replace()`.

As a result, remote agents always observe either the complete previous session database or the complete updated version, avoiding partially written or truncated state during remote session cleanup.

## Verification

Verified using the existing Token Spy test suite:

- `python3 -m pytest -v ods/extensions/services/token-spy/tests/test_usage_report.py`
  - **11 passed**

- `make lint`
  - Passed.