### PR TITLE
fix(models): replace failed release candidates

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -377,6 +377,28 @@
       "tokens_per_sec_estimate": 115,
       "llm_model_name": "Falcon-H1-3B-Instruct",
       "llama_server_image": null,
+      "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "reason": "Fleet model-UI run 2026-07-21T12:25Z on tower2 loaded Falcon H1 3B and reached ODS Talk through the browser, but Talk emitted a random_uuid tool-call payload instead of the requested verification phrase.",
+          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-004/tower2",
+          "recordedAt": "2026-07-21T14:25:00Z",
+          "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
+          "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "reason": "The model loaded and routed, but the browser-driven ODS Talk verification failed with a tool-call payload instead of the required answer; keep Falcon H1 3B out of agent-required release coverage until revalidated with a tool-aware Talk probe or updated model metadata.",
+          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-004/tower2",
+          "recordedAt": "2026-07-21T14:25:00Z",
+          "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
+          "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {
@@ -743,6 +765,44 @@
       "install_recommendation": false
     },
     {
+      "id": "qwen3-4b-instruct-2507-q4",
+      "name": "Qwen3 4B Instruct 2507",
+      "family": "qwen",
+      "gguf_file": "Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3-4B-Instruct-2507-GGUF/resolve/main/Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+      "gguf_sha256": "3605803b982cb64aead44f6c1b2ae36e3acdb41d8e46c8a94c6533bc4c67e597",
+      "size_bytes": 2497281120,
+      "size_mb": 2497,
+      "vram_required_gb": 5,
+      "context_length": 262144,
+      "quantization": "Q4_K_M",
+      "specialty": "Chat",
+      "description": "Unsloth's GGUF quant of Qwen3 4B Instruct 2507 with 262K context metadata. A low-VRAM long-context release candidate for app and Talk validation.",
+      "tokens_per_sec_estimate": 105,
+      "llm_model_name": "qwen3-4b-instruct-2507",
+      "llama_server_image": null,
+      "install_recommendation": false
+    },
+    {
+      "id": "qwen3-4b-128k-q4",
+      "name": "Qwen3 4B 128K",
+      "family": "qwen",
+      "gguf_file": "Qwen3-4B-128K-Q4_K_M.gguf",
+      "gguf_url": "https://huggingface.co/unsloth/Qwen3-4B-128K-GGUF/resolve/main/Qwen3-4B-128K-Q4_K_M.gguf",
+      "gguf_sha256": "f145a1bd60fec420ca4d9b7645ebcdf657e301463bc4dd3af4a8c0b548b5eb1a",
+      "size_bytes": 2497281504,
+      "size_mb": 2497,
+      "vram_required_gb": 5,
+      "context_length": 131072,
+      "quantization": "Q4_K_M",
+      "specialty": "Chat",
+      "description": "Unsloth's 128K GGUF build of Qwen3 4B in Q4_K_M quantization. A low-VRAM long-context candidate kept separate from the upstream 40K-context Qwen3 4B entry.",
+      "tokens_per_sec_estimate": 105,
+      "llm_model_name": "qwen3-4b-128k",
+      "llama_server_image": null,
+      "install_recommendation": false
+    },
+    {
       "id": "qwen3-1.7b-q4",
       "name": "Qwen3 1.7B",
       "family": "qwen",
@@ -789,6 +849,28 @@
       "tokens_per_sec_estimate": 145,
       "llm_model_name": "qwen2.5-coder-1.5b-instruct",
       "llama_server_image": null,
+      "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "reason": "Fleet model-UI run 2026-07-21T12:25Z on tower2 loaded Qwen 2.5 Coder 1.5B 128K, but ODS Talk answered with generic assistant prose instead of the requested verification phrase.",
+          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2",
+          "recordedAt": "2026-07-21T14:25:00Z",
+          "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
+          "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "reason": "The model loaded and routed through the browser-managed swap path, but ODS Talk did not follow the required verification instruction; keep it out of agent-required release coverage until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-006/tower2",
+          "recordedAt": "2026-07-21T14:25:00Z",
+          "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
+          "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
+          "hostScope": ["tower2"],
+          "expiresAt": "2026-08-21T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -380,16 +380,22 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert len(candidates) >= 6
     assert {
         "granite4.0-h-1b-q4",
-        "qwen2.5-coder-1.5b-128k-q4",
+        "qwen3-4b-instruct-2507-q4",
+        "qwen3-4b-128k-q4",
         "granite4.1-3b-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
-        "falcon-h1-3b-instruct-q4",
     }.issubset(candidate_ids)
-    assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
-    assert by_id["falcon-h1-3b-instruct-q4"]["contextLength"] == 131072
+    assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 262144
+    assert by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
     assert by_id["granite4.1-3b-q4"]["contextLength"] == 131072
     assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["opencode"]["status"] == (
+        "unsupported_until_revalidated"
+    )
+    assert all_by_id["falcon-h1-3b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
+        "unsupported_until_revalidated"
+    )
+    assert all_by_id["qwen2.5-coder-1.5b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"
     )
     assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == (
@@ -399,6 +405,8 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "phi4-mini-q4" not in candidate_ids
     assert "gemma3-4b-it-q4" not in candidate_ids
     assert "falcon-h1-1.5b-instruct-q4" not in candidate_ids
+    assert "falcon-h1-3b-instruct-q4" not in candidate_ids
+    assert "qwen2.5-coder-1.5b-128k-q4" not in candidate_ids
     assert "granite4.0-h-350m-q4" not in candidate_ids
     assert "granite4.0-1b-q4" not in candidate_ids
     assert "phi3-mini-128k-q4" not in candidate_ids

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -83,7 +83,10 @@ def test_release_model_switchboard_catalog_ids_exist():
         "llama3.2-3b-instruct-q4",
         "qwen2.5-3b-instruct-q4",
         "qwen3-4b-q4",
+        "qwen3-4b-instruct-2507-q4",
+        "qwen3-4b-128k-q4",
         "qwen3-1.7b-q4",
+        "qwen2.5-coder-1.5b-128k-q4",
         "qwen2.5-coder-3b-128k-q4",
         "qwen2.5-7b-instruct-q4",
         "llama3.1-8b-instruct-q4",
@@ -297,9 +300,13 @@ def test_replacement_low_vram_long_context_models_are_cataloged_for_validation()
     by_id = {model["id"]: model for model in catalog["models"]}
 
     expected = {
-        "qwen2.5-coder-1.5b-128k-q4": (
-            "https://huggingface.co/unsloth/Qwen2.5-Coder-1.5B-Instruct-128K-GGUF/",
-            "0fbff4d39395fab063c51377ba522928af2574b1f998d66012c1caed7b8f91d6",
+        "qwen3-4b-instruct-2507-q4": (
+            "https://huggingface.co/unsloth/Qwen3-4B-Instruct-2507-GGUF/",
+            "3605803b982cb64aead44f6c1b2ae36e3acdb41d8e46c8a94c6533bc4c67e597",
+        ),
+        "qwen3-4b-128k-q4": (
+            "https://huggingface.co/unsloth/Qwen3-4B-128K-GGUF/",
+            "f145a1bd60fec420ca4d9b7645ebcdf657e301463bc4dd3af4a8c0b548b5eb1a",
         ),
         "granite3.1-2b-instruct-q4": (
             "https://huggingface.co/bartowski/granite-3.1-2b-instruct-GGUF/",
@@ -313,7 +320,7 @@ def test_replacement_low_vram_long_context_models_are_cataloged_for_validation()
 
     for model_id, (url_prefix, sha256) in expected.items():
         model = by_id[model_id]
-        assert model["vram_required_gb"] <= 4
+        assert model["vram_required_gb"] <= 5
         assert model["context_length"] >= HERMES_CONTEXT_FLOOR
         assert model["gguf_sha256"] == sha256
         assert model["gguf_url"].startswith(url_prefix)
@@ -424,15 +431,57 @@ def test_falcon_h1_15b_is_not_opencode_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["falcon-h1-1.5b-instruct-q4"])
 
 
-def test_qwen25_coder_15b_128k_is_low_vram_release_candidate():
+def test_falcon_h1_3b_is_not_talk_agent_viable_until_revalidated():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    compatibility = by_id["falcon-h1-3b-instruct-q4"]["app_compatibility"]
+
+    assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
+    assert "random_uuid" in compatibility["hermes_talk"]["reason"]
+    assert "cycle-004" in compatibility["hermes_talk"]["evidence"]
+    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
+    assert "tool-call payload" in compatibility["agent_viability"]["reason"]
+    assert not _agent_viable_for_release(by_id["falcon-h1-3b-instruct-q4"])
+
+
+def test_qwen25_coder_15b_128k_is_not_talk_agent_viable_until_revalidated():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["qwen2.5-coder-1.5b-128k-q4"]
+    compatibility = model["app_compatibility"]
 
     assert model["gguf_sha256"] == "0fbff4d39395fab063c51377ba522928af2574b1f998d66012c1caed7b8f91d6"
     assert model["context_length"] >= HERMES_CONTEXT_FLOOR
     assert model["vram_required_gb"] <= 3
-    assert _agent_viable_for_release(model)
+    assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
+    assert "generic assistant prose" in compatibility["hermes_talk"]["reason"]
+    assert "cycle-006" in compatibility["hermes_talk"]["evidence"]
+    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
+    assert not _agent_viable_for_release(model)
+
+
+def test_qwen3_4b_long_context_replacements_are_release_candidates():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+
+    expected = {
+        "qwen3-4b-instruct-2507-q4": {
+            "sha": "3605803b982cb64aead44f6c1b2ae36e3acdb41d8e46c8a94c6533bc4c67e597",
+            "context": 262144,
+        },
+        "qwen3-4b-128k-q4": {
+            "sha": "f145a1bd60fec420ca4d9b7645ebcdf657e301463bc4dd3af4a8c0b548b5eb1a",
+            "context": 131072,
+        },
+    }
+
+    for model_id, expected_model in expected.items():
+        model = by_id[model_id]
+        assert model["gguf_sha256"] == expected_model["sha"]
+        assert model["context_length"] == expected_model["context"]
+        assert model["vram_required_gb"] <= 5
+        assert model.get("install_recommendation") is False
+        assert _agent_viable_for_release(model)
 
 
 def test_qwen25_7b_is_not_agent_viable_on_low_vram_windows_until_revalidated():
@@ -462,6 +511,7 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "smollm3-3b-q4",
         "granite4.0-h-1b-q4",
         "falcon-h1-1.5b-instruct-q4",
+        "falcon-h1-3b-instruct-q4",
         "granite4.0-1b-q4",
         "granite4.0-h-350m-q4",
         "granite3.2-2b-instruct-q4",
@@ -471,6 +521,8 @@ def test_new_switchboard_models_do_not_change_install_recommendations():
         "llama3.2-3b-instruct-q4",
         "qwen2.5-3b-instruct-q4",
         "qwen3-4b-q4",
+        "qwen3-4b-instruct-2507-q4",
+        "qwen3-4b-128k-q4",
         "qwen3-1.7b-q4",
         "qwen2.5-coder-1.5b-128k-q4",
         "qwen2.5-coder-3b-128k-q4",


### PR DESCRIPTION
## Summary
- marks Falcon H1 3B and Qwen 2.5 Coder 1.5B 128K as product-visible non-agent-viable for ODS Talk release coverage after Tower2 browser model-UI failures
- adds two low-VRAM long-context replacement candidates: Qwen3 4B Instruct 2507 Q4_K_M and Qwen3 4B 128K Q4_K_M
- keeps install recommendations unchanged and updates dashboard/catalog tests so Windows 8GB still has six release swap candidates

## Fleet evidence
- Product SHA under test: `7df3f218a06c386bdb40856c928a0618b8e16b57`
- Harness SHA after artifact false-red fix: `d2a31507fa0652dff4c8cc1892e56ccf1b9102bb`
- Run: `/home/michael/dream-fleet-test/runs/2026-07-21T12-25-39Z-release-product-7df3f218a06c-harness-9804e8523a6d-hosts-tower2`
- Cycle 4 loaded Falcon H1 3B but ODS Talk returned a `random_uuid` tool-call payload instead of the verification phrase.
- Cycle 6 loaded Qwen 2.5 Coder 1.5B 128K but ODS Talk returned generic assistant prose instead of the verification phrase.

## Replacement metadata sources
- `https://huggingface.co/api/models/unsloth/Qwen3-4B-Instruct-2507-GGUF?blobs=true`
- `https://huggingface.co/api/models/unsloth/Qwen3-4B-128K-GGUF?blobs=true`

## Validation
- `python -m json.tool config/model-library.json`
- `python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py::test_real_catalog_has_six_windows_8gb_release_swap_candidates -q`
- `python -m pytest tests/test-model-library-coverage.py tests/test-model-library-verdicts.py -q`
- `python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py -q`
- `git diff --check`