### PR TITLE
fix(token-spy): stop logging upstream error bodies on streaming requests

### DIFF
--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -922,6 +922,36 @@ async def proxy_chat_completions(request: Request):
         )
 
 
+def _describe_upstream_error(status_code, body):
+    """Summarize an upstream error body for the log without echoing caller content.
+
+    Provider error messages routinely quote the offending request, so the body is
+    never logged. Only the structured identifiers (`error.type`, `error.code`) are
+    recorded, capped in length because they come from an untrusted upstream. The
+    full body is still streamed to the client, which is where it should be read.
+    """
+    try:
+        parsed = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        parsed = None
+
+    error = parsed.get("error") if isinstance(parsed, dict) else None
+    identifiers = ""
+    if isinstance(error, dict):
+        fields = [
+            f"{key}={str(error[key])[:64]}"
+            for key in ("type", "code")
+            if isinstance(error.get(key), (str, int))
+        ]
+        if fields:
+            identifiers = " ".join(fields) + ", "
+
+    return (
+        f"Upstream {status_code} streaming request failed "
+        f"({identifiers}{len(body)} byte body withheld from logs)"
+    )
+
+
 async def _handle_openai_streaming(client, raw_body, headers, model, sys_analysis,
                                    msg_analysis, tools, start_time, filter_result=None):
     """Stream OpenAI SSE response through while capturing token metrics."""
@@ -945,7 +975,7 @@ async def _handle_openai_streaming(client, raw_body, headers, model, sys_analysi
                     err_body = b""
                     async for chunk in upstream.aiter_bytes():
                         err_body += chunk
-                    log.error(f"Upstream {upstream.status_code}: {err_body[:2000].decode(errors='replace')}")
+                    log.error(_describe_upstream_error(upstream.status_code, err_body))
                     yield f"data: {err_body.decode(errors='replace')}\n\n"
                     return
                 async for line in upstream.aiter_lines():

--- a/ods/extensions/services/token-spy/tests/test_streaming_errors.py
+++ b/ods/extensions/services/token-spy/tests/test_streaming_errors.py
@@ -1,0 +1,148 @@
+"""Streaming upstream error privacy regressions."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import logging
+import pytest
+from pathlib import Path
+from uuid import uuid4
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+PRIVATE_PROMPT_SENTINEL = "PRIVATE_PROMPT_SENTINEL"
+
+
+@pytest.fixture
+def token_spy_main(monkeypatch):
+    """Load main.py under a unique module name.
+
+    Three services in this repo ship a `main.py`, so a plain `import main` is
+    ambiguous once pytest runs from anywhere but this directory. Mirrors the
+    isolation `test_usage_report.py` uses for `db.py`.
+    """
+    # main.py generates and writes an API key at import when this is unset.
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "test-token-spy-key")
+    monkeypatch.syspath_prepend(str(TOKEN_SPY_DIR))
+
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_main_{uuid4().hex}",
+        TOKEN_SPY_DIR / "main.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _MockUpstream:
+    """Minimal stand-in for an httpx streaming response that errored."""
+
+    def __init__(self, body: bytes, status_code: int = 400):
+        self._body = body
+        self.status_code = status_code
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def aiter_bytes(self):
+        # Split so the handler is exercised on a multi-chunk error body.
+        midpoint = len(self._body) // 2
+        yield self._body[:midpoint]
+        yield self._body[midpoint:]
+
+
+class _MockClient:
+    def __init__(self, body: bytes, status_code: int = 400):
+        self._body = body
+        self._status_code = status_code
+
+    def stream(self, *args, **kwargs):
+        return _MockUpstream(self._body, self._status_code)
+
+
+def _consume(module, client) -> str:
+    async def run():
+        response = await module._handle_openai_streaming(
+            client,
+            b'{"messages":[]}',
+            {},
+            "test-model",
+            {},
+            {},
+            [],
+            0,
+        )
+        return "".join([chunk async for chunk in response.body_iterator])
+
+    return asyncio.run(run())
+
+
+def test_openai_streaming_error_preserves_body_without_logging_content(
+    token_spy_main, caplog
+):
+    """Upstream error bodies reach the client but never the log.
+
+    Provider errors quote the request that failed, and `ods-support-bundle.sh`
+    collects container logs by default while only redacting secret-shaped
+    values -- so prompt text logged here would ship in a bundle attached to a
+    public issue.
+    """
+    error_body = (
+        '{"error":{"type":"invalid_request_error","code":"context_length_exceeded",'
+        f'"message":"invalid input: {PRIVATE_PROMPT_SENTINEL}"'
+        "}}"
+    ).encode()
+
+    with caplog.at_level(logging.ERROR, logger="token-monitor"):
+        returned_body = _consume(token_spy_main, _MockClient(error_body))
+
+    assert returned_body == f"data: {error_body.decode()}\n\n"
+    assert PRIVATE_PROMPT_SENTINEL not in caplog.text
+    assert "invalid input" not in caplog.text
+    assert "type=invalid_request_error" in caplog.text
+    assert "code=context_length_exceeded" in caplog.text
+    assert f"{len(error_body)} byte body withheld from logs" in caplog.text
+
+
+def test_describe_upstream_error_reports_identifiers(token_spy_main):
+    summary = token_spy_main._describe_upstream_error(
+        429,
+        b'{"error":{"type":"rate_limit_error","code":"slow_down","message":"secret"}}',
+    )
+
+    assert "Upstream 429" in summary
+    assert "type=rate_limit_error code=slow_down" in summary
+    assert "secret" not in summary
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        b"<html>502 Bad Gateway PRIVATE_PROMPT_SENTINEL</html>",  # not JSON
+        b'["PRIVATE_PROMPT_SENTINEL"]',  # JSON, but not an object
+        b'{"error":"PRIVATE_PROMPT_SENTINEL"}',  # error is a string, not an object
+        b'{"error":{"message":"PRIVATE_PROMPT_SENTINEL"}}',  # no type/code
+        b"\xff\xfe PRIVATE_PROMPT_SENTINEL",  # undecodable bytes
+    ],
+)
+def test_describe_upstream_error_never_echoes_body(token_spy_main, body):
+    summary = token_spy_main._describe_upstream_error(500, body)
+
+    assert PRIVATE_PROMPT_SENTINEL not in summary
+    assert f"{len(body)} byte body withheld from logs" in summary
+
+
+def test_describe_upstream_error_truncates_untrusted_identifiers(token_spy_main):
+    """type/code come from upstream, so they are capped rather than trusted."""
+    long_code = "x" * 500
+    summary = token_spy_main._describe_upstream_error(
+        400, f'{{"error":{{"code":"{long_code}"}}}}'.encode()
+    )
+
+    assert "x" * 64 in summary
+    assert "x" * 65 not in summary


### PR DESCRIPTION
## Summary

When an OpenAI-compatible upstream returns >=400 on a **streaming** request,
`token-spy` logged the raw error body:

    log.error(f"Upstream {upstream.status_code}: {err_body[:2000].decode(errors='replace')}")

Provider error messages routinely quote the request that failed
(`"invalid input: <your prompt>"`), so user prompt content was being written
into the container log.

That matters here specifically because `ods/scripts/ods-support-bundle.sh`
collects `docker logs` for every running ODS container **by default**
(`INCLUDE_LOGS=true`; `--no-logs` opts out), and `redact_file()` only matches
secret-shaped patterns — `Bearer`, `authorization:`,
`KEY|TOKEN|SECRET|PASSWORD|...`. Free-form prompt text in an error body passes
straight through redaction into a bundle that `docs/SUPPORT-BUNDLE.md`
describes as intended to "be attached to a GitHub issue or shared with
maintainers."

This replaces the body dump with a summary built by a new pure helper,
`_describe_upstream_error()`, which logs the status code, the structured
identifiers (`error.type`, `error.code`), and the body size — never
`error.message`. Identifiers are capped at 64 chars because they come from an
untrusted upstream.

**No debuggability is lost.** The full error body is still streamed verbatim to
the client, which is where an operator reads it.

Real output from both code paths on the same input (synthetic PII):

    - Upstream 400: {"error":{"message":"invalid input: messages[0].content: My SSN is
      123-45-6789 and my Blue Cross member ID is XQ7741822. Draft the appeal letter for
      Dr. Alvarez.","type":"invalid_request_error","code":"context_length_exceeded"},...}

    + Upstream 400 streaming request failed (type=invalid_request_error
      code=context_length_exceeded, 254 byte body withheld from logs)

This is the only site with the pattern — the Anthropic streaming path has no
`>= 400` body-capture branch, so no sibling fix is needed.

## AI Assistance

AI was used to trace the log-to-support-bundle path, draft the helper and tests,
and run the checks below. I read the final diff, confirmed the support-bundle
redaction gap by executing `redact_file()` against real pre-fix log output, and
verified the regression test fails against pre-fix `main.py`.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
N/A - not targeting release/2.5.x. Happy to backport if you consider prompt
text in support bundles a stable-lane concern.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [ ] Dashboard API / host agent
- [ ] Installer / bootstrap / lifecycle
- [ ] Docker Compose / service manifests
- [ ] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [ ] Dependencies / runtime wiring
- [x] Other: single-service logging (`token-spy`)

## Risk And Validation

- Risk level: **Medium**

Per HIGH_RISK_CHANGE_MAP.md this is "affects one service" (Medium), not
"Network binding/proxy routes" (High) — no binding, route, or auth behavior
changes, and the bytes sent to the client are byte-identical to before.

- Validation run:
  - [x] `git diff --check`
  - [ ] Markdown/link sanity for docs
  - [x] Focused tests listed below
  - [ ] Dashboard lint/test/build
  - [ ] Extension audit / compose validation
  - [ ] Release-grade fleet or scoped hardware validation
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`

Commands/results:

```text
$ cd ods && python3 -m pytest extensions/services/token-spy/tests -q
19 passed

$ ruff check ods/ --select E,F,W --ignore E501,E701,E731,E741,E402
All checks passed!

$ make lint                             # ods/
All lint checks passed.

$ git diff --check
(clean)

Regression guard verified: reverted main.py to HEAD in a scratch copy,
reran tests/test_streaming_errors.py -> 8 failed. Restored -> 19 passed.
The test fails for the right reason, not by construction.

Support-bundle claim verified end to end, not inferred from the regexes:
extracted redact_file()'s python verbatim from ods-support-bundle.sh, generated
a real pre-fix log line by executing the old handler, and ran one over the other.

  pre-fix line, after redact_file():  byte-for-byte unchanged
    SURVIVED: 123-45-6789        (synthetic SSN)
    SURVIVED: XQ7741822          (synthetic member ID)
    SURVIVED: Dr. Alvarez        (synthetic name)
  post-fix line, same path:      all three absent

Confirms INCLUDE_LOGS=true (ods-support-bundle.sh:14) — log collection is
default-on, --no-logs is the opt-out.
```

## Operational Change Check

- [x] This is not an operational change.
- [ ] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

No installer, compose, manifest, routing, or host-mutation surface is touched.
Runtime behavior change is confined to one `log.error` call; the streamed
response is unchanged.

## Notes For Reviewers

**On test invocation.** Ran via the pattern MODEL-SWITCHBOARD.md documents for
model-router (`cd ods && python3 -m pytest extensions/services/<svc>/tests -q`),
matching how the non-dashboard-api service suites are validated today.

**On test isolation.** Three services ship a `main.py` (`ape`, `dashboard-api`,
`token-spy`) and the repo has no `conftest.py` or pytest config, so a bare
`import main` is ambiguous outside its own directory. The test loads `main.py`
via `importlib` under a UUID'd module name and uses `monkeypatch.syspath_prepend`,
mirroring how `test_usage_report.py` already isolates `db.py`. This is what
lets the suite run from `ods/` as above, not just from the service directory.

**Why the fixture sets `TOKEN_SPY_API_KEY`.** Pre-existing behavior, unchanged
here: `main.py` generates and writes an API key to
`/app/data/token-spy-api-key.txt` at import when that env var is unset, which
fails outside the container. `test_usage_report.py` only ever loads `db.py`, so
this is the first test to import `main.py` and the first to need the env var
set. Flagging it only so the `monkeypatch.setenv` line doesn't look arbitrary.

**On the support-bundle claim.** Verified by running `redact_file()`'s exact
implementation over real pre-fix log output rather than by reading the patterns.
Not added as a repo test: it spans `ods-support-bundle.sh` and `token-spy`, so it
belongs in neither suite as they're currently organized. Happy to write it up as
a shell test under `ods/tests/` if you'd rather it be enforced.

**Deliberately not in scope:** the deprecated `@app.on_event` handlers (32
warnings in the suite), and converting the file's f-string logging to lazy
`%s` formatting. Both are real, both are separate PRs.

**Rollback:** revert the commit. No state, config, or schema is touched.
