### PR TITLE
fix(macos): persist switchboard consumer routes

### DIFF
--- a/ods/installers/macos/docker-compose.macos.yml
+++ b/ods/installers/macos/docker-compose.macos.yml
@@ -61,4 +61,5 @@ services:
       llama-server-ready:
         condition: service_healthy
     environment:
-      OPENAI_API_BASE_URL: "http://${ODS_MACOS_HOST_GATEWAY:-host.docker.internal}:8080/v1"
+      OPENAI_API_BASE_URL: "${OPEN_WEBUI_LLM_BASE_URL:-http://${ODS_MACOS_HOST_GATEWAY:-host.docker.internal}:8080/v1}"
+      OPENAI_API_KEY: "${OPEN_WEBUI_LLM_API_KEY:-}"

--- a/ods/installers/macos/install-macos.sh
+++ b/ods/installers/macos/install-macos.sh
@@ -1660,6 +1660,12 @@ else
     _previous_llm_bind="$(read_env_value "${INSTALL_DIR}/.env" "BIND_ADDRESS")"
     _previous_macos_gateway="$(read_env_value "${INSTALL_DIR}/.env" "ODS_MACOS_HOST_GATEWAY")"
     generate_ods_env "$INSTALL_DIR" "$SELECTED_TIER" "$FORCE"
+    _macos_switchboard_mode="$(read_env_value "${INSTALL_DIR}/.env" "ODS_MODEL_SWITCHBOARD")"
+    case "${_macos_switchboard_mode:-observe}" in
+        legacy|observe|enabled) ;;
+        *) _macos_switchboard_mode="observe" ;;
+    esac
+    upsert_env_value "${INSTALL_DIR}/.env" "ODS_MODEL_SWITCHBOARD" "$_macos_switchboard_mode"
     _macos_agent_bind_raw="$(read_env_value "${INSTALL_DIR}/.env" "ODS_AGENT_BIND")"
     _macos_agent_bind="$(macos_normalize_agent_bind "${_macos_agent_bind_raw:-127.0.0.1}")"
     if [[ -n "$_macos_agent_bind_raw" && "$_macos_agent_bind" != "$_macos_agent_bind_raw" ]]; then
@@ -1701,6 +1707,8 @@ else
         upsert_env_value "${INSTALL_DIR}/.env" "LLM_API_URL" "http://litellm:4000"
         upsert_env_value "${INSTALL_DIR}/.env" "HERMES_LLM_BASE_URL" "http://litellm:4000/v1"
         upsert_env_value "${INSTALL_DIR}/.env" "HERMES_LLM_API_KEY" "$_macos_litellm_key"
+        upsert_env_value "${INSTALL_DIR}/.env" "OPEN_WEBUI_LLM_BASE_URL" "http://litellm:4000"
+        upsert_env_value "${INSTALL_DIR}/.env" "OPEN_WEBUI_LLM_API_KEY" "$_macos_litellm_key"
         upsert_env_value "${INSTALL_DIR}/.env" "LLM_MODEL" "$LLM_MODEL"
         upsert_env_value "${INSTALL_DIR}/.env" "GGUF_FILE" ""
         upsert_env_value "${INSTALL_DIR}/.env" "MAX_CONTEXT" "$MAX_CONTEXT"
@@ -1722,6 +1730,17 @@ else
             upsert_env_value "${INSTALL_DIR}/.env" "LLM_API_URL" "http://host.docker.internal:8080"
             upsert_env_value "${INSTALL_DIR}/.env" "HERMES_LLM_BASE_URL" "http://host.docker.internal:8080/v1"
         fi
+        if [[ "$_macos_switchboard_mode" == "enabled" ]]; then
+            _macos_litellm_key="$(read_env_value "${INSTALL_DIR}/.env" "LITELLM_KEY")"
+            if [[ -z "$_macos_litellm_key" ]]; then
+                ai_err "Switchboard mode requires the generated LiteLLM master key, but LITELLM_KEY is empty."
+                exit 1
+            fi
+            upsert_env_value "${INSTALL_DIR}/.env" "HERMES_LLM_BASE_URL" "http://litellm:4000/v1"
+            upsert_env_value "${INSTALL_DIR}/.env" "HERMES_LLM_API_KEY" "$_macos_litellm_key"
+            upsert_env_value "${INSTALL_DIR}/.env" "OPEN_WEBUI_LLM_BASE_URL" "http://litellm:4000"
+            upsert_env_value "${INSTALL_DIR}/.env" "OPEN_WEBUI_LLM_API_KEY" "$_macos_litellm_key"
+        fi
     fi
     if [[ "${DOCKER_BACKEND:-unknown}" == "colima" ]] \
        && [[ "$_macos_llm_bridge_enabled" == "true" ]] \
@@ -1737,6 +1756,38 @@ else
         _macos_litellm_key
     CONTAINER_LLM_URL="$(read_env_value "${INSTALL_DIR}/.env" "LLM_API_URL")"
     [[ -n "$CONTAINER_LLM_URL" ]] || CONTAINER_LLM_URL="http://host.docker.internal:8080"
+    _macos_runtime_renderer="${ODS_PYTHON_CMD:-python3}"
+    if [[ ! -f "${INSTALL_DIR}/scripts/render-runtime-configs.py" ]] \
+        || ! command -v "$_macos_runtime_renderer" >/dev/null 2>&1; then
+        ai_err "Model router config renderer is unavailable"
+        exit 1
+    fi
+    _macos_router_args=(
+        --switchboard-mode "$_macos_switchboard_mode"
+        --ods-mode "$(read_env_value "${INSTALL_DIR}/.env" "ODS_MODE")"
+        --gpu-backend "apple"
+        --model "${LLM_MODEL:-}"
+        --gguf-file "${GGUF_FILE:-}"
+        --llm-base-url "${CONTAINER_LLM_URL}"
+        --litellm-key "$(read_env_value "${INSTALL_DIR}/.env" "LITELLM_KEY")"
+        --context-length "${MAX_CONTEXT:-65536}"
+        --output-root "$INSTALL_DIR"
+        --write
+    )
+    for _macos_router_surface in model-router-endpoints; do
+        if ! "$_macos_runtime_renderer" "${INSTALL_DIR}/scripts/render-runtime-configs.py" \
+            --surface "$_macos_router_surface" "${_macos_router_args[@]}" >> "$ODS_LOG_FILE" 2>&1; then
+            ai_err "Failed to render required ${_macos_router_surface} config"
+            exit 1
+        fi
+    done
+    if [[ "$_macos_switchboard_mode" == "enabled" ]] \
+       && ! "$_macos_runtime_renderer" "${INSTALL_DIR}/scripts/render-runtime-configs.py" \
+            --surface litellm-switchboard "${_macos_router_args[@]}" >> "$ODS_LOG_FILE" 2>&1; then
+        ai_err "Failed to render required litellm-switchboard config"
+        exit 1
+    fi
+    unset _macos_runtime_renderer _macos_router_args _macos_router_surface
     if $env_existed && ! $FORCE; then
         ai_ok "Preserved existing .env (use --force to regenerate secrets)"
     else
@@ -3050,20 +3101,28 @@ if $ENABLE_PERPLEXICA; then
     ai "Configuring Perplexica..."
     PERPLEXICA_MODEL="${GGUF_FILE:-$LLM_MODEL}"
     PERPLEXICA_API_KEY="no-key"
+    PERPLEXICA_BASE_URL="${CONTAINER_LLM_URL:-http://host.docker.internal:8080}"
+    _perplexica_switchboard_mode="$(read_env_value "$INSTALL_DIR/.env" "ODS_MODEL_SWITCHBOARD")"
+    if [[ "${_perplexica_switchboard_mode:-observe}" == "enabled" ]]; then
+        PERPLEXICA_MODEL="ods/current"
+        PERPLEXICA_API_KEY="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_KEY")"
+        PERPLEXICA_BASE_URL="http://litellm:4000"
+    fi
     $CLOUD_MODE && PERPLEXICA_MODEL="default"
     if $CLOUD_MODE; then
         PERPLEXICA_API_KEY="$(read_env_value "$INSTALL_DIR/.env" "LITELLM_KEY")"
+        PERPLEXICA_BASE_URL="http://litellm:4000"
     fi
     _perplexica_port="$(read_env_value "$INSTALL_DIR/.env" "PERPLEXICA_PORT")"
     [[ "$_perplexica_port" =~ ^[0-9]+$ ]] || _perplexica_port="3004"
     if [[ -z "$PERPLEXICA_API_KEY" ]] \
        || ! configure_perplexica "$_perplexica_port" "$PERPLEXICA_MODEL" \
-            "${CONTAINER_LLM_URL:-http://host.docker.internal:8080}" "$PERPLEXICA_API_KEY"; then
+            "$PERPLEXICA_BASE_URL" "$PERPLEXICA_API_KEY"; then
         ai_err "Perplexica was selected but its authenticated inference route could not be configured and verified."
         exit 1
     fi
     ai_ok "Perplexica configured (model: ${PERPLEXICA_MODEL})"
-    unset PERPLEXICA_API_KEY _perplexica_port
+    unset PERPLEXICA_API_KEY PERPLEXICA_BASE_URL _perplexica_port _perplexica_switchboard_mode
 fi
 
 # ── Pre-mark setup wizard complete ──

--- a/ods/installers/macos/lib/env-generator.sh
+++ b/ods/installers/macos/lib/env-generator.sh
@@ -159,6 +159,13 @@ detect_timezone() {
     echo "${tz:-UTC}"
 }
 
+normalize_ods_model_switchboard() {
+    case "${1:-observe}" in
+        legacy|observe|enabled) printf '%s\n' "$1" ;;
+        *) printf '%s\n' "observe" ;;
+    esac
+}
+
 generate_ods_env() {
     local install_dir="$1"
     local tier="$2"
@@ -218,6 +225,20 @@ generate_ods_env() {
         upsert_env_value "$env_path" "HERMES_CPU_RESERVATION" "$hermes_cpu_reservation"
         upsert_env_value "$env_path" "COMFYUI_CPU_LIMIT" "$comfyui_cpu_limit"
         upsert_env_value "$env_path" "COMFYUI_CPU_RESERVATION" "$comfyui_cpu_reservation"
+
+        local _switchboard_mode
+        _switchboard_mode="$(read_env_value "$env_path" "ODS_MODEL_SWITCHBOARD")"
+        [[ -n "$_switchboard_mode" ]] || _switchboard_mode="${ODS_MODEL_SWITCHBOARD:-observe}"
+        _switchboard_mode="$(normalize_ods_model_switchboard "$_switchboard_mode")"
+        upsert_env_value "$env_path" "ODS_MODEL_SWITCHBOARD" "$_switchboard_mode"
+        if [[ "$_switchboard_mode" == "enabled" ]]; then
+            local _litellm_key
+            _litellm_key="$(read_env_value "$env_path" "LITELLM_KEY")"
+            upsert_env_value "$env_path" "OPEN_WEBUI_LLM_BASE_URL" "http://litellm:4000"
+            upsert_env_value "$env_path" "OPEN_WEBUI_LLM_API_KEY" "$_litellm_key"
+            upsert_env_value "$env_path" "HERMES_LLM_BASE_URL" "http://litellm:4000/v1"
+            upsert_env_value "$env_path" "HERMES_LLM_API_KEY" "$_litellm_key"
+        fi
 
         # Upsert ODS_AGENT_KEY when missing (pre-PR-#979 upgrade path)
         if [[ -z "$(read_env_value "$env_path" "ODS_AGENT_KEY")" ]]; then
@@ -355,6 +376,8 @@ generate_ods_env() {
     local macos_vm_ip=""
     local agent_host="host.docker.internal"
     local llm_api_url="http://host.docker.internal:8080"
+    local switchboard_mode
+    switchboard_mode="$(normalize_ods_model_switchboard "${ODS_MODEL_SWITCHBOARD:-observe}")"
     if [[ "${DOCKER_BACKEND:-unknown}" == "colima" ]]; then
         macos_llm_bridge_enabled="true"
         macos_host_agent_bridge_enabled="true"
@@ -381,6 +404,16 @@ generate_ods_env() {
     tz=$(detect_timezone)
     local timestamp
     timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    local hermes_llm_base_url="${llm_api_url}/v1"
+    local hermes_llm_api_key="sk-ods-hermes-local"
+    local open_webui_llm_base_url=""
+    local open_webui_llm_api_key=""
+    if [[ "$switchboard_mode" == "enabled" ]]; then
+        hermes_llm_base_url="http://litellm:4000/v1"
+        hermes_llm_api_key="$litellm_key"
+        open_webui_llm_base_url="http://litellm:4000"
+        open_webui_llm_api_key="$litellm_key"
+    fi
 
     # Build .env content (matches Phase 06 format)
     cat > "$env_path" << ENVEOF
@@ -401,6 +434,7 @@ ODS_AGENT_HOST=${ODS_AGENT_HOST:-${agent_host}}
 
 #=== LLM Backend Mode ===
 ODS_MODE=local
+ODS_MODEL_SWITCHBOARD=${switchboard_mode}
 LLM_BACKEND=llama-server
 LLM_API_URL=${llm_api_url}
 LLM_BACKEND=llama-server
@@ -473,9 +507,9 @@ OPENCLAW_PORT=7860
 LANGFUSE_PORT=3006
 
 #=== Hermes Agent ===
-# macOS runs llama-server natively with Metal; containers use the scoped host route above.
-HERMES_LLM_BASE_URL=${llm_api_url}/v1
-HERMES_LLM_API_KEY=sk-ods-hermes-local
+# macOS runs llama-server natively with Metal; switchboard consumers use LiteLLM.
+HERMES_LLM_BASE_URL=${hermes_llm_base_url}
+HERMES_LLM_API_KEY=${hermes_llm_api_key}
 HERMES_LANGUAGE=en
 HERMES_PROXY_PORT=9120
 HERMES_PROXY_UPSTREAM=ods-hermes:9119
@@ -513,6 +547,8 @@ TTS_VOICE=en_US-lessac-medium
 WEBUI_AUTH=true
 ENABLE_WEB_SEARCH=true
 WEB_SEARCH_ENGINE=searxng
+OPEN_WEBUI_LLM_BASE_URL=${open_webui_llm_base_url}
+OPEN_WEBUI_LLM_API_KEY=${open_webui_llm_api_key}
 
 #=== n8n Settings ===
 N8N_HOST=localhost

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -131,6 +131,10 @@ assert_grep "installers/macos/lib/env-generator.sh" 'ODS_MODEL_SWITCHBOARD=\$\{s
     "macOS .env generation persists switchboard mode"
 assert_grep "installers/macos/lib/env-generator.sh" 'OPEN_WEBUI_LLM_BASE_URL=\$\{open_webui_llm_base_url\}' \
     "macOS .env generation carries the Open WebUI switchboard route"
+assert_grep "installers/macos/docker-compose.macos.yml" 'OPENAI_API_BASE_URL: "\$\{OPEN_WEBUI_LLM_BASE_URL:-http://\$\{ODS_MACOS_HOST_GATEWAY:-host\.docker\.internal\}:8080/v1\}"' \
+    "macOS Open WebUI compose route honors switchboard override"
+assert_grep "installers/macos/docker-compose.macos.yml" 'OPENAI_API_KEY: "\$\{OPEN_WEBUI_LLM_API_KEY:-\}"' \
+    "macOS Open WebUI compose route carries switchboard API key"
 assert_grep "installers/macos/install-macos.sh" 'render-runtime-configs\.py' \
     "macOS installer renders model-router runtime configs"
 assert_grep "installers/macos/install-macos.sh" 'PERPLEXICA_MODEL="ods/current"' \

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -127,6 +127,16 @@ assert_grep "installers/macos/install-macos.sh" '_opencode_switchboard_mode=.*OD
     "macOS OpenCode config reads switchboard mode"
 assert_grep "installers/macos/install-macos.sh" '_opencode_model="ods/current"' \
     "macOS OpenCode config uses stable switchboard alias"
+assert_grep "installers/macos/lib/env-generator.sh" 'ODS_MODEL_SWITCHBOARD=\$\{switchboard_mode\}' \
+    "macOS .env generation persists switchboard mode"
+assert_grep "installers/macos/lib/env-generator.sh" 'OPEN_WEBUI_LLM_BASE_URL=\$\{open_webui_llm_base_url\}' \
+    "macOS .env generation carries the Open WebUI switchboard route"
+assert_grep "installers/macos/install-macos.sh" 'render-runtime-configs\.py' \
+    "macOS installer renders model-router runtime configs"
+assert_grep "installers/macos/install-macos.sh" 'PERPLEXICA_MODEL="ods/current"' \
+    "macOS Perplexica config uses stable switchboard alias"
+assert_grep "installers/macos/install-macos.sh" 'PERPLEXICA_BASE_URL="http://litellm:4000"' \
+    "macOS Perplexica config routes switchboard mode through LiteLLM"
 assert_not_grep "installers/macos/install-macos.sh" '\$LOG_FILE' \
     "macOS installer uses ODS_LOG_FILE, not undefined LOG_FILE"
 assert_grep "installers/windows/install-windows.ps1" 'Update-HermesConfigFile.*ContextLength \(\[int\]\$tierConfig\.MaxContext\)' \

--- a/ods/tests/test-macos-installer-transitions.sh
+++ b/ods/tests/test-macos-installer-transitions.sh
@@ -207,6 +207,39 @@ PY
 
 # shellcheck source=/dev/null
 source "$ENV_GENERATOR"
+
+(
+    calculate_llama_cpu_budget() { printf '4 1 8\n'; }
+    TIER_NAME="CI Mac"
+    ODS_VERSION="test"
+    SYSTEM_RAM_GB="128"
+    LLM_MODEL="qwen3.6-35b-a3b"
+    GGUF_FILE="Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+    MAX_CONTEXT="131072"
+    MODEL_PROFILE_REQUESTED="qwen"
+    MODEL_PROFILE_EFFECTIVE="qwen"
+    DOCKER_BACKEND="unknown"
+    ODS_MODEL_SWITCHBOARD="enabled"
+    env_install="$TMP_DIR/switchboard-env"
+    mkdir -p "$env_install/config/searxng"
+    generate_ods_env "$env_install" CI true
+    env_file="$env_install/.env"
+    litellm_key="$(grep '^LITELLM_KEY=' "$env_file" | cut -d= -f2-)"
+    grep -Fqx 'ODS_MODEL_SWITCHBOARD=enabled' "$env_file" \
+        || fail "macOS env did not persist enabled switchboard mode"
+    grep -Fqx 'LLM_API_URL=http://host.docker.internal:8080' "$env_file" \
+        || fail "macOS switchboard env must keep backend URL for model-router"
+    grep -Fqx 'HERMES_LLM_BASE_URL=http://litellm:4000/v1' "$env_file" \
+        || fail "macOS switchboard env must route Hermes through LiteLLM"
+    grep -Fqx "HERMES_LLM_API_KEY=${litellm_key}" "$env_file" \
+        || fail "macOS switchboard env must give Hermes the LiteLLM key"
+    grep -Fqx 'OPEN_WEBUI_LLM_BASE_URL=http://litellm:4000' "$env_file" \
+        || fail "macOS switchboard env must route Open WebUI through LiteLLM"
+    grep -Fqx "OPEN_WEBUI_LLM_API_KEY=${litellm_key}" "$env_file" \
+        || fail "macOS switchboard env must give Open WebUI the LiteLLM key"
+)
+pass "macOS switchboard env persists gateway consumers without hiding backend URL"
+
 openclaw_dir="$TMP_DIR/openclaw-install"
 mkdir -p "$openclaw_dir/data/openclaw/home"
 printf '{"custom":{"preserve":true}}\n' > "$openclaw_dir/data/openclaw/home/openclaw.json"


### PR DESCRIPTION
## Summary
- persist `ODS_MODEL_SWITCHBOARD` during macOS `.env` generation and backfill
- route macOS Hermes/Open WebUI/Perplexica through LiteLLM when switchboard mode is enabled
- render macOS model-router endpoints from the actual native backend URL so `ods/current` can reach host llama-server

## Fleet Evidence
- Failing run: `/home/michael/dream-fleet-test/runs/2026-07-21T21-45-47Z-release-product-892df74a769c-harness-d2a31507fa06-hosts-strix-halo-spark-m5-mbp-windows-laptop-strixy`
- m5-mbp had six model-UI cycles, all failing app probes because macOS install ignored `ODS_MODEL_SWITCHBOARD=enabled`
- Live m5-mbp `.env` lacked `ODS_MODEL_SWITCHBOARD`, `OPEN_WEBUI_LLM_BASE_URL`, and `OPEN_WEBUI_LLM_API_KEY`; OpenCode and Perplexica were pinned to direct model IDs instead of `ods/current`

## Validation
- `C:\Program Files\Git\bin\bash.exe tests/test-macos-installer-transitions.sh`
- `C:\Program Files\Git\bin\bash.exe tests/test-installer-context-parity.sh`
- `C:\Program Files\Git\bin\bash.exe -n installers/macos/lib/env-generator.sh`
- `C:\Program Files\Git\bin\bash.exe -n installers/macos/install-macos.sh`
- `python tests/test-render-runtime-configs.py`
