### PR TITLE
fix(router): record completed identityless stream evidence

### DIFF
--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -742,7 +742,6 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                         completed
                         and probe_id
                         and 200 <= upstream.status_code < 300
-                        and bool(rewriter.models)
                         and all(
                             model == route["runtimeModelId"]
                             for model in rewriter.models

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -497,17 +497,16 @@ class TestModelsAndEvidence:
         assert ev.status_code == 200
         assert ev.json()["responseModel"] == "Concrete.gguf"
 
-    @pytest.mark.parametrize("sse", [
-        b'data: {"model":"Wrong.gguf","choices":[]}\n\ndata: [DONE]\n\n',
-        b'data: {"choices":[{"delta":{"content":"no identity"}}]}\n\n'
-        b'data: [DONE]\n\n',
-    ])
-    def test_stream_without_matching_concrete_identity_records_no_evidence(
-            self, router, sse):
+    def test_stream_with_wrong_concrete_identity_records_no_evidence(
+            self, router):
         mod, client, write_state, calls = router
         write_state()
         probe_id = str(uuid.uuid4())
-        _set_stream_upstream(mod, [sse])
+        _set_stream_upstream(
+            mod,
+            [b'data: {"model":"Wrong.gguf","choices":[]}\n\n'
+             b'data: [DONE]\n\n'],
+        )
         resp = client.post("/v1/chat/completions", json={
             "model": "ods/current", "stream": True,
             "messages": [{"role": "user", "content": _signed_marker(probe_id)}],
@@ -518,6 +517,31 @@ class TestModelsAndEvidence:
             headers={"Authorization": "Bearer internal-secret"},
         )
         assert ev.status_code == 404
+
+    def test_completed_stream_without_identity_records_routed_evidence(
+            self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        probe_id = str(uuid.uuid4())
+        _set_stream_upstream(
+            mod,
+            [b'data: {"choices":[{"delta":{"content":"no identity"}}]}\n\n'
+             b'data: [DONE]\n\n'],
+        )
+        resp = client.post("/v1/chat/completions", json={
+            "model": "ods/current", "stream": True,
+            "messages": [{"role": "user", "content": _signed_marker(probe_id)}],
+        })
+        assert resp.status_code == 200
+        ev = client.get(
+            f"/internal/route-evidence/{probe_id}",
+            headers={"Authorization": "Bearer internal-secret"},
+        )
+        assert ev.status_code == 200
+        record = ev.json()
+        assert record["requestedModel"] == "ods/current"
+        assert record["routedModel"] == "Concrete.gguf"
+        assert record["responseModel"] == "Concrete.gguf"
 
     def test_failed_stream_records_no_evidence_and_releases_admission(self, router):
         mod, client, write_state, calls = router


### PR DESCRIPTION
## Summary
- record route evidence for completed signed streaming requests even when upstream SSE chunks omit model identity
- keep the negative gate for streams that explicitly report a wrong concrete model
- preserve the existing failed/truncated stream no-evidence behavior

## Fleet Evidence
- Failing run: `/home/michael/dream-fleet-test/runs/2026-07-21T21-45-47Z-release-product-892df74a769c-harness-d2a31507fa06-hosts-strix-halo-spark-m5-mbp-windows-laptop-strixy`
- strix-halo failed all six model-UI cycles only on OpenCode route evidence
- Live repro with temporary `/home/michael/ods/data/fleet-probe.key`:
  - direct LiteLLM `ods/current` + signed marker recorded route evidence
  - OpenCode `/session/{id}/message` returned the exact probe token through `llama-server/ods/current`, but route evidence was 404 because OpenCode uses streaming and the upstream SSE did not carry model identity chunks
- Wrong streamed model identity remains a negative test and still records no evidence

## Validation
- `python -m pytest extensions/services/model-router/tests/test_router.py`

## Reference
- OpenCode currently uses OpenAI-compatible providers for local endpoints; disabling provider streaming is not a reliable documented path, so this keeps the product data plane accountable instead of adding an OpenCode-specific bypass.
