### PR TITLE
fix(models): surface activation lifecycle in dashboard

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -359,6 +359,26 @@ def _model_lifecycle_conflict(requested_operation: str, active: dict) -> dict:
     return payload
 
 
+def _model_lifecycle_status() -> dict:
+    """Return the currently-owned model lifecycle operation, if any."""
+    with _model_lifecycle_state_lock:
+        operation = _model_lifecycle_operation
+        target = _model_lifecycle_target
+        activation_target = _model_activation_target
+    if not operation:
+        return {}
+    payload = {
+        "lifecycleActive": True,
+        "activeOperation": operation,
+        "activeTarget": target,
+    }
+    if operation == "model_activation":
+        payload["activeModelId"] = activation_target or target
+    else:
+        payload["activeModelId"] = None
+    return payload
+
+
 def _begin_model_activation(model_id: str) -> tuple[bool, str | None]:
     """Atomically acquire activation ownership and publish its target."""
     global _model_activation_target
@@ -4984,16 +5004,19 @@ class AgentHandler(BaseHTTPRequestHandler):
         status_path = INSTALL_DIR / "data" / "model-download-status.json"
         if not status_path.exists():
             data = {"status": "idle"}
+            data.update(_model_lifecycle_status())
             _verify_switchboard_route_for_status(data, "model-status")
             json_response(self, 200, data)
             return
         try:
             data = _read_model_status(status_path)
             data = _normalize_model_download_status(status_path, data)
+            data.update(_model_lifecycle_status())
             _verify_switchboard_route_for_status(data, "model-status")
             json_response(self, 200, data)
         except (json.JSONDecodeError, OSError):
             data = {"status": "idle"}
+            data.update(_model_lifecycle_status())
             _verify_switchboard_route_for_status(data, "model-status")
             json_response(self, 200, data)
 

--- a/ods/extensions/services/dashboard-api/models.py
+++ b/ods/extensions/services/dashboard-api/models.py
@@ -185,6 +185,7 @@ class ModelLibraryEntry(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
     appCompatibility: dict[str, Any] = Field(default_factory=dict)
     status: str  # "loaded", "downloaded", "available"
+    modelOperation: Optional[dict[str, Any]] = None
     recommended: bool = False
     configured: bool = False
     recommendation: Optional[dict[str, Any]] = None
@@ -210,5 +211,6 @@ class ModelLibraryResponse(BaseModel):
     hermesTargetContext: int = HERMES_TARGET_CONTEXT
     recommendationPolicy: Optional[str] = None
     recommendationAlternatives: list[dict[str, Any]] = Field(default_factory=list)
+    modelLifecycle: Optional[dict[str, Any]] = None
     odsMode: str = "unknown"
     configuredMode: str = "unknown"

--- a/ods/extensions/services/dashboard-api/routers/models.py
+++ b/ods/extensions/services/dashboard-api/routers/models.py
@@ -43,6 +43,7 @@ from models import ModelLibraryGpu, ModelLibraryResponse
 from performance_oracle import (
     build_models_payload,
     build_sample_signature,
+    current_model_matches,
     find_catalog_model,
     load_model_catalog,
     model_files_dir,
@@ -79,6 +80,38 @@ _GPU_VRAM_EXCEPTIONS = (
     KeyError,
     AttributeError,
 )
+
+
+def _model_lifecycle_from_agent_status(status: Optional[dict]) -> Optional[dict[str, Any]]:
+    if not isinstance(status, dict):
+        return None
+    operation = status.get("activeOperation")
+    active = bool(status.get("lifecycleActive") or operation)
+    if not active or not isinstance(operation, str) or not operation:
+        return None
+    target = status.get("activeTarget")
+    model_id = status.get("activeModelId") or target
+    return {
+        "active": True,
+        "operation": operation,
+        "target": target,
+        "modelId": model_id,
+    }
+
+
+def _annotate_model_lifecycle(payload: dict[str, Any], lifecycle: Optional[dict[str, Any]]) -> None:
+    if not lifecycle:
+        return
+    payload["modelLifecycle"] = lifecycle
+    if lifecycle.get("operation") != "model_activation":
+        return
+    target = lifecycle.get("modelId") or lifecycle.get("target")
+    if not target:
+        return
+    for model in payload.get("models") or []:
+        if isinstance(model, dict) and current_model_matches(model, str(target), str(target)):
+            model["modelOperation"] = lifecycle
+            return
 
 
 def _configured_ods_mode() -> str:
@@ -349,7 +382,7 @@ def _format_size(size_mb: int) -> str:
 @router.get("/api/models", response_model=ModelLibraryResponse)
 async def list_models(api_key: str = Depends(verify_api_key)):
     """List model catalog entries with source-labelled performance metadata."""
-    gpu_info, loaded_model = await asyncio.gather(
+    gpu_info, loaded_model, agent_status = await asyncio.gather(
         asyncio.to_thread(get_gpu_info),
         _await_or_default(
             get_loaded_model(),
@@ -357,6 +390,7 @@ async def list_models(api_key: str = Depends(verify_api_key)):
             "loaded model",
             timeout_seconds=_MODEL_DISCOVERY_TIMEOUT_SECONDS,
         ),
+        asyncio.to_thread(_get_agent_model_status),
     )
     if not loaded_model:
         service = SERVICES.get("llama-server", {})
@@ -393,6 +427,10 @@ async def list_models(api_key: str = Depends(verify_api_key)):
         catalog=_load_library(),
         downloaded_files_override=_scan_downloaded_models(),
     )
+    _annotate_model_lifecycle(
+        payload,
+        _model_lifecycle_from_agent_status(agent_status),
+    )
     if gpu_info and loaded_model and live_tps > 0:
         loaded_entry = next((m for m in payload["models"] if m["status"] == "loaded"), None) or {}
         signature = build_sample_signature(
@@ -427,9 +465,13 @@ async def list_models(api_key: str = Depends(verify_api_key)):
 def model_download_status(api_key: str = Depends(verify_api_key)):
     """Get current model download progress (if any)."""
     agent_status = _get_agent_model_status()
+    lifecycle = _model_lifecycle_from_agent_status(agent_status)
     if agent_status and agent_status.get("status") != "idle":
         if _is_cancelled_download_status(agent_status) or _is_stale_terminal_download_status(agent_status):
-            return _idle_download_status(last_terminal_status=agent_status)
+            idle_status = _idle_download_status(last_terminal_status=agent_status)
+            if lifecycle:
+                idle_status["modelLifecycle"] = lifecycle
+            return idle_status
         return agent_status
 
     status_path = Path(DATA_DIR) / "model-download-status.json"
@@ -439,7 +481,10 @@ def model_download_status(api_key: str = Depends(verify_api_key)):
             return _stale_bootstrap_download_status(bootstrap_status)
         bootstrap_info = get_bootstrap_status()
         if not bootstrap_info.active:
-            return {"status": "idle", "active": False, "isDownloading": False}
+            status = {"status": "idle", "active": False, "isDownloading": False}
+            if lifecycle:
+                status["modelLifecycle"] = lifecycle
+            return status
         return {
             "status": "downloading",
             "active": True,
@@ -454,10 +499,18 @@ def model_download_status(api_key: str = Depends(verify_api_key)):
     try:
         status = json.loads(status_path.read_text(encoding="utf-8"))
         if _is_cancelled_download_status(status) or _is_stale_terminal_download_status(status):
-            return _idle_download_status(last_terminal_status=status)
+            idle_status = _idle_download_status(last_terminal_status=status)
+            if lifecycle:
+                idle_status["modelLifecycle"] = lifecycle
+            return idle_status
+        if lifecycle:
+            status["modelLifecycle"] = lifecycle
         return status
     except (json.JSONDecodeError, OSError):
-        return {"status": "idle"}
+        status = {"status": "idle"}
+        if lifecycle:
+            status["modelLifecycle"] = lifecycle
+        return status
 
 
 def _idle_download_status(last_terminal_status: Optional[dict] = None) -> dict:

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -2418,6 +2418,24 @@ class TestModelActivationOwnership:
         assert _mod._model_activate_lock.acquire(blocking=False)
         _mod._model_activate_lock.release()
 
+    def test_model_status_reports_activation_lifecycle(self, monkeypatch):
+        monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
+        acquired, _active = _mod._begin_model_lifecycle("model_activation", "target-a")
+        assert acquired
+        try:
+            handler = _FakeHandler(b"")
+            _mod.AgentHandler._handle_model_status(handler)
+        finally:
+            _mod._end_model_lifecycle("model_activation")
+
+        assert handler.response_code == 200
+        response = handler.parse_response()
+        assert response["status"] == "idle"
+        assert response["lifecycleActive"] is True
+        assert response["activeOperation"] == "model_activation"
+        assert response["activeTarget"] == "target-a"
+        assert response["activeModelId"] == "target-a"
+
     def test_non_activation_lock_owner_reports_unknown_target(self, monkeypatch):
         monkeypatch.setattr(_mod, "AGENT_API_KEY", "test-key")
         handler = _FakeHandler(json.dumps({"model_id": "target-a"}).encode("utf-8"))

--- a/ods/extensions/services/dashboard-api/tests/test_models.py
+++ b/ods/extensions/services/dashboard-api/tests/test_models.py
@@ -117,6 +117,81 @@ def test_agent_model_status_and_actions_share_transport(monkeypatch):
     ]
 
 
+def test_agent_model_status_extracts_lifecycle():
+    import routers.models as models_router
+
+    lifecycle = models_router._model_lifecycle_from_agent_status({
+        "status": "idle",
+        "lifecycleActive": True,
+        "activeOperation": "model_activation",
+        "activeTarget": "qwen3.5-9b-q4",
+        "activeModelId": "qwen3.5-9b-q4",
+    })
+
+    assert lifecycle == {
+        "active": True,
+        "operation": "model_activation",
+        "target": "qwen3.5-9b-q4",
+        "modelId": "qwen3.5-9b-q4",
+    }
+
+
+def test_api_models_marks_backend_activation_target(test_client, monkeypatch, tmp_path):
+    models_router, install_dir, data_dir = _patch_model_router_paths(monkeypatch, tmp_path)
+    _write_model_library(install_dir, [{
+        "id": "qwen3.5-9b-q4",
+        "name": "Qwen 3.5 9B",
+        "gguf_file": "Qwen3.5-9B-Q4_K_M.gguf",
+        "size_mb": 5760,
+        "vram_required_gb": 8,
+        "context_length": 32768,
+        "quantization": "Q4_K_M",
+        "specialty": "General",
+        "description": "Balanced default.",
+        "llm_model_name": "qwen3.5-9b",
+    }])
+    (data_dir / "models" / "Qwen3.5-9B-Q4_K_M.gguf").write_text(
+        "model",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(models_router, "get_gpu_info", lambda: _gpu())
+    monkeypatch.setattr(models_router, "get_loaded_model", AsyncMock(return_value=None))
+    monkeypatch.setattr(models_router, "_fetch_llama_loaded_model", AsyncMock(return_value=None))
+    monkeypatch.setattr(
+        models_router,
+        "get_llama_metrics",
+        AsyncMock(return_value={"tokens_per_second": 0, "lifetime_tokens": 0}),
+    )
+    monkeypatch.setattr(models_router, "get_llama_context_size", AsyncMock(return_value=32768))
+    monkeypatch.setattr(models_router, "SERVICES", {"llama-server": {"host": "localhost", "port": 8080}})
+    monkeypatch.setattr(
+        models_router,
+        "_get_agent_model_status",
+        lambda: {
+            "status": "idle",
+            "lifecycleActive": True,
+            "activeOperation": "model_activation",
+            "activeTarget": "qwen3.5-9b-q4",
+            "activeModelId": "qwen3.5-9b-q4",
+        },
+    )
+
+    resp = test_client.get("/api/models", headers=test_client.auth_headers)
+
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload["currentModel"] is None
+    assert payload["modelLifecycle"] == {
+        "active": True,
+        "operation": "model_activation",
+        "target": "qwen3.5-9b-q4",
+        "modelId": "qwen3.5-9b-q4",
+    }
+    row = payload["models"][0]
+    assert row["status"] == "downloaded"
+    assert row["modelOperation"] == payload["modelLifecycle"]
+
+
 def test_agent_activation_conflict_preserves_target(monkeypatch):
     import routers.models as models_router
 

--- a/ods/extensions/services/dashboard/nginx.conf
+++ b/ods/extensions/services/dashboard/nginx.conf
@@ -59,6 +59,23 @@ server {
         proxy_send_timeout 1800s;
     }
 
+    # Model activation can legitimately take several minutes on local Windows
+    # and Lemonade runtimes while the selected GGUF is loaded and consumer
+    # routes are synchronized. Keep this scoped timeout aligned with the
+    # dashboard API / host-agent activation budget.
+    location ~ ^/api/models/.+/load$ {
+        proxy_pass http://$dashboard_api_upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Connection "close";
+        proxy_set_header Authorization "Bearer ${DASHBOARD_API_KEY}";
+        proxy_read_timeout 2700s;
+        proxy_send_timeout 2700s;
+    }
+
     # Proxy API requests to status backend
     # Auth: nginx injects Bearer token for same-origin requests (B2 fix)
     # Token read from environment via envsubst in entrypoint

--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
@@ -81,6 +81,43 @@ describe('useModels', () => {
     expect(result.current.error).toBeNull()
   })
 
+  test('surfaces backend-owned activation as a pending model action', async () => {
+    const target = 'slow-model'
+    fetch.mockResolvedValue(modelsResponse(
+      [{
+        id: target,
+        status: 'downloaded',
+        modelOperation: {
+          active: true,
+          operation: 'model_activation',
+          modelId: target,
+        },
+      }],
+      {
+        modelLifecycle: {
+          active: true,
+          operation: 'model_activation',
+          target,
+          modelId: target,
+        },
+      }
+    ))
+
+    const { result } = renderHook(() => useModels())
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+    expect(result.current.modelLifecycle).toEqual({
+      active: true,
+      operation: 'model_activation',
+      target,
+      modelId: target,
+    })
+    expect(result.current.activationLoading).toBe(target)
+    expect(result.current.actionLoadingModels).toEqual([target])
+  })
+
   test('treats a missing runtime mode as unknown and blocks activation', async () => {
     fetch.mockResolvedValue({
       ok: true,

--- a/ods/extensions/services/dashboard/src/hooks/useModels.js
+++ b/ods/extensions/services/dashboard/src/hooks/useModels.js
@@ -112,12 +112,27 @@ async function errorMessageFromResponse(response, fallback) {
 
 function conflictActiveModelId(data) {
   const nested = data?.detail && typeof data.detail === 'object'
-    ? data.detail.activeModelId
+    ? data.detail.activeModelId || data.detail.activeTarget
     : null
-  for (const value of [data?.activeModelId, nested]) {
+  for (const value of [data?.activeModelId, data?.activeTarget, nested]) {
     if (typeof value === 'string' && value.trim()) return value.trim()
   }
   return null
+}
+
+function normalizeModelLifecycle(data) {
+  if (!data || typeof data !== 'object') return null
+  const operation = data.operation || data.activeOperation || null
+  const target = data.target || data.activeTarget || null
+  const modelId = data.modelId || data.activeModelId || target
+  const active = data.active === true || data.lifecycleActive === true || Boolean(operation)
+  if (!active || !operation) return null
+  return {
+    active: true,
+    operation,
+    target,
+    modelId,
+  }
 }
 
 function normalizeOdsMode(value) {
@@ -143,6 +158,7 @@ export function useModels() {
   const [gpu, setGpu] = useState(USE_MOCK_DATA ? MOCK_GPU : null)
   const [currentModel, setCurrentModel] = useState(USE_MOCK_DATA ? MOCK_CURRENT_MODEL : null)
   const [configuredModel, setConfiguredModel] = useState(USE_MOCK_DATA ? MOCK_CURRENT_MODEL : null)
+  const [modelLifecycle, setModelLifecycle] = useState(null)
   const [odsMode, setOdsMode] = useState(USE_MOCK_DATA ? MOCK_MODES.odsMode : 'unknown')
   const [configuredMode, setConfiguredMode] = useState(USE_MOCK_DATA ? MOCK_MODES.configuredMode : 'unknown')
   const [recommendationAlternatives, setRecommendationAlternatives] = useState([])
@@ -218,6 +234,7 @@ export function useModels() {
       setGpu(data.gpu)
       setCurrentModel(data.currentModel)
       setConfiguredModel(data.configuredModel ?? null)
+      setModelLifecycle(normalizeModelLifecycle(data.modelLifecycle))
       const effectiveMode = normalizeOdsMode(data.odsMode)
       setOdsMode(effectiveMode)
       setConfiguredMode(normalizeOdsMode(data.configuredMode ?? data.odsMode))
@@ -252,7 +269,11 @@ export function useModels() {
     pollModels()
   }, [pollModels])
 
-  const pollInterval = pendingActions.some(action => action.kind === 'download' || action.kind === 'delete')
+  const backendActivationModel = modelLifecycle?.operation === 'model_activation'
+    ? modelLifecycle.modelId
+    : null
+  const backendLifecycleBusy = Boolean(modelLifecycle?.active)
+  const pollInterval = pendingActions.some(action => action.kind === 'download' || action.kind === 'delete' || action.kind === 'load') || backendLifecycleBusy
     ? PENDING_MODEL_ACTION_POLL_MS
     : DEFAULT_POLL_MS
 
@@ -421,9 +442,14 @@ export function useModels() {
 
   const activationAction = pendingActions.find(action => action.kind === 'load')
   const latestAction = pendingActions[pendingActions.length - 1]
-  const activationLoading = activationAction?.modelId ?? null
+  const activationLoading = activationAction?.modelId ?? backendActivationModel ?? null
   const actionLoading = activationAction?.modelId ?? latestAction?.modelId ?? null
-  const actionLoadingModels = [...new Set(pendingActions.map(action => action.modelId))]
+  const actionLoadingModels = [
+    ...new Set([
+      ...pendingActions.map(action => action.modelId),
+      backendActivationModel,
+    ].filter(Boolean)),
+  ]
   const error = mutationError || fetchError
   const activationModeError = modelActivationModeError(odsMode, configuredMode)
 
@@ -432,6 +458,7 @@ export function useModels() {
     gpu,
     currentModel,
     configuredModel,
+    modelLifecycle,
     odsMode,
     configuredMode,
     canActivateModels: activationModeError === null,

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -355,6 +355,8 @@ if grep -qF 'proxy_pass http://dashboard-api:3002;' "$dashboard_nginx"; then
   echo "[FAIL] dashboard nginx must not pin dashboard-api at config-load time"
   exit 1
 fi
+grep -A16 -F 'location ~ ^/api/models/.+/load$ {' "$dashboard_nginx" | grep -qF 'proxy_read_timeout 2700s;' \
+  || { echo "[FAIL] dashboard nginx model activation route must cover the host-agent activation budget"; exit 1; }
 
 echo "[contract] bundled service CPU limits are env-driven"
 grep -qF "cpus: '\${TTS_CPU_LIMIT:-1.0}'" extensions/services/tts/compose.yaml \


### PR DESCRIPTION
﻿## Summary
- expose active model lifecycle ownership from `ods-host-agent` through `/v1/model/status`
- annotate `/api/models` with `modelLifecycle` and per-row `modelOperation` so the Models UI shows backend-owned activation as Working after refresh or POST loss
- add a scoped long nginx timeout for `/api/models/.../load` to match the host-agent activation budget and avoid 180s 504s during slow Windows/Lemonade model loads

## Validation
- `python -m pytest extensions/services/dashboard-api/tests/test_models.py extensions/services/dashboard-api/tests/test_host_agent.py -q` — 272 passed, 4 skipped
- `npm.cmd test -- --run src/hooks/__tests__/useModels.test.js src/pages/Models.test.jsx` — 53 passed
- `npm.cmd run lint` — passed
- `npm.cmd run build` — passed
- `python -m py_compile bin/ods-host-agent.py extensions/services/dashboard-api/routers/models.py extensions/services/dashboard-api/models.py` — passed
- scoped nginx assertion for `proxy_read_timeout 2700s` on model load route — passed

Note: full local `tests/contracts/test-installer-contracts.sh` under Windows Git Bash failed later in an unrelated rename-migration temp cleanup (`rm` encountered a directory named `related-link`), after the new nginx assertion had already passed.
