### PR TITLE
fix(host-agent): write PID files atomically in ods-host-agent.py

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -9924,7 +9924,7 @@ def _launch_native_llama_server(env_path: Path, llama_bin: Path, llama_log: Path
             cwd=str(INSTALL_DIR),
             **popen_kwargs,
         )
-    pid_file.write_text(str(proc.pid), encoding="utf-8")
+    _atomic_write_text(pid_file, f"{proc.pid}\n")
     logger.info("Native llama-server launched (pid %d, model %s)", proc.pid, gguf_file)
 
 
@@ -10540,7 +10540,7 @@ def main():
 
     if args.pid_file:
         pid_path = Path(args.pid_file)
-        pid_path.write_text(str(os.getpid()), encoding="utf-8")
+        _atomic_write_text(pid_path, f"{os.getpid()}\n")
         atexit.register(lambda: pid_path.unlink(missing_ok=True))
 
     # Determine bind address: explicit env override, or a platform-aware safe

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5662,4 +5662,3 @@ class TestHostAgentPidFile:
 
         assert pid_file.exists()
         assert pid_file.read_text(encoding="utf-8") == f"{os.getpid()}\n"
-

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -5635,3 +5635,31 @@ class TestObservabilityWire:
             server.shutdown()
             server.server_close()
             thread.join(timeout=2)
+
+
+class TestHostAgentPidFile:
+
+    def test_main_writes_pid_file_atomically(self, monkeypatch, tmp_path):
+        pid_file = tmp_path / "ods-host-agent.pid"
+        pid_file.write_text("12345_stale\n", encoding="utf-8")
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir(parents=True)
+        (config_dir / "core-service-ids.json").write_text("[]", encoding="utf-8")
+
+        monkeypatch.setattr(_mod.sys, "argv", ["ods-host-agent.py", "--pid-file", str(pid_file)])
+        monkeypatch.setattr(_mod.shutil, "which", lambda name: "/usr/bin/docker")
+        monkeypatch.setattr(_mod, "load_env", lambda *a, **k: {"ODS_AGENT_KEY": "test-key"})
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+
+        def stop_early(*args, **kwargs):
+            raise RuntimeError("stop_before_server_loop")
+
+        monkeypatch.setattr(_mod, "_create_host_agent_server", stop_early)
+
+        with pytest.raises(RuntimeError, match="stop_before_server_loop"):
+            _mod.main()
+
+        assert pid_file.exists()
+        assert pid_file.read_text(encoding="utf-8") == f"{os.getpid()}\n"
+

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -1529,7 +1529,7 @@ class TestLaunchNativeLlamaServer:
 
         _launch_native_llama_server(env_path, llama_bin, llama_log, pid_file)
 
-        assert pid_file.read_text(encoding="utf-8") == "4321"
+        assert pid_file.read_text(encoding="utf-8") == "4321\n"
         cmd, _kwargs = calls[0]
         assert cmd[0] == str(llama_bin)
         assert "--model" in cmd
@@ -1540,6 +1540,27 @@ class TestLaunchNativeLlamaServer:
         assert "--reasoning-format" in cmd
         assert "deepseek" in cmd
         assert _kwargs["cwd"] == str(tmp_path)
+
+    def test_writes_pid_atomically_without_in_place_truncation(self, monkeypatch, tmp_path):
+        env_path = tmp_path / ".env"
+        env_path.write_text("GGUF_FILE=test-model.gguf\n", encoding="utf-8")
+        (tmp_path / "data" / "models").mkdir(parents=True)
+        llama_bin = tmp_path / "bin" / "llama-server"
+        llama_bin.parent.mkdir(parents=True)
+        llama_bin.write_text("", encoding="utf-8")
+        llama_log = tmp_path / "data" / "llama-server.log"
+        pid_file = tmp_path / "data" / ".llama-server.pid"
+        pid_file.write_text("99999_stale_pid_content_to_overwrite\n", encoding="utf-8")
+
+        class _FakeProc:
+            pid = 8888
+
+        monkeypatch.setattr(_mod, "INSTALL_DIR", tmp_path)
+        monkeypatch.setattr(subprocess, "Popen", lambda cmd, **kwargs: _FakeProc())
+
+        _launch_native_llama_server(env_path, llama_bin, llama_log, pid_file)
+
+        assert pid_file.read_text(encoding="utf-8") == "8888\n"
 
     def test_llm_bridge_is_disabled_before_native_bind(self, monkeypatch, tmp_path):
         env = {


### PR DESCRIPTION
## Problem

In `ods-host-agent.py`, native `llama-server` PID files and host agent startup `--pid-file` paths were previously written using direct `Path.write_text()`, which truncates live files in-place before writing new process IDs. An interrupted write (host reboot, container kill, disk error) could leave the PID file empty or truncated.

## Why the existing contract missed it

Direct `write_text()` truncates target files prior to writing new PID strings.

## Fix

1. Update `_launch_native_llama_server` and `main` in `ods-host-agent.py` to route PID file writes through `_atomic_write_text(pid_file, f"{pid}\n")`.
2. Format PID strings with a consistent trailing newline (`\n`).

## Verification

1. Added `test_writes_pid_atomically_without_in_place_truncation` to `ods/extensions/services/dashboard-api/tests/test_model_activate.py`.
2. Added `TestHostAgentPidFile` to `ods/extensions/services/dashboard-api/tests/test_host_agent.py`.
3. Fixed EOF whitespace formatting in `test_host_agent.py` (`git diff --check` passed cleanly).
4. Ran focused pytest suite: 3/3 passed.