### PR TITLE
fix(windows): write OpenCode config objects atomically in opencode-co…

### DIFF
--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -181,8 +181,11 @@ function Sync-WindowsOpenCodeConfig {
 
     $_configJson = $_configObject | ConvertTo-Json -Depth 12
     $_utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-    [System.IO.File]::WriteAllText($_ocConfigFile, $_configJson, $_utf8NoBom)
-    [System.IO.File]::WriteAllText($_ocCompatConfigFile, $_configJson, $_utf8NoBom)
+    foreach ($_targetFile in @($_ocConfigFile, $_ocCompatConfigFile)) {
+        $_tmpFile = "$_targetFile.$PID.tmp"
+        [System.IO.File]::WriteAllText($_tmpFile, $_configJson, $_utf8NoBom)
+        Move-Item -Path $_tmpFile -Destination $_targetFile -Force
+    }
 
     return @{
         Status = $_configStatus

--- a/ods/installers/windows/lib/opencode-config.ps1
+++ b/ods/installers/windows/lib/opencode-config.ps1
@@ -184,7 +184,7 @@ function Sync-WindowsOpenCodeConfig {
     foreach ($_targetFile in @($_ocConfigFile, $_ocCompatConfigFile)) {
         $_tmpFile = "$_targetFile.$PID.tmp"
         [System.IO.File]::WriteAllText($_tmpFile, $_configJson, $_utf8NoBom)
-        Move-Item -Path $_tmpFile -Destination $_targetFile -Force
+        Move-Item -LiteralPath $_tmpFile -Destination $_targetFile -Force
     }
 
     return @{

--- a/ods/tests/test-windows-opencode-config.sh
+++ b/ods/tests/test-windows-opencode-config.sh
@@ -42,6 +42,8 @@ grep -q 'ODS_MODEL_SWITCHBOARD' "$OPENCODE_LIB" && pass "switchboard mode is rea
 grep -q 'ods/current' "$OPENCODE_LIB" && pass "switchboard alias is written to OpenCode config" || fail "switchboard alias missing from OpenCode helper"
 grep -q 'LITELLM_KEY' "$OPENCODE_LIB" && pass "switchboard OpenCode route uses LiteLLM key" || fail "switchboard LiteLLM key missing from OpenCode helper"
 grep -q 'ODS switchboard' "$OPENCODE_LIB" && pass "switchboard provider is labelled" || fail "switchboard provider label missing"
+grep -q 'Move-Item -LiteralPath' "$OPENCODE_LIB" && pass "OpenCode config write uses Move-Item -LiteralPath" || fail "OpenCode config write missing Move-Item -LiteralPath"
+grep -q '\.\$PID\.tmp' "$OPENCODE_LIB" && pass "OpenCode config write uses temp file with PID suffix" || fail "OpenCode config write missing PID temp file"
 
 if grep -q 'preserving existing configuration' "$DEVTOOLS_PS1"; then
     fail "existing configs are still preserved without migration"


### PR DESCRIPTION
## Summary

Prevent in-place truncation when synchronizing OpenCode configuration files on Windows.

Previously, `Sync-WindowsOpenCodeConfig` in `ods/installers/windows/lib/opencode-config.ps1` updated the OpenCode configuration files using `[System.IO.File]::WriteAllText()`. Since this writes directly to the destination file, an interrupted write could leave the configuration incomplete or empty.

This change updates both configuration write paths to use atomic file replacement:

- Writes the generated JSON configuration to a temporary file in the destination directory using a unique `.$PID.tmp` suffix.
- Atomically replaces the destination using `Move-Item -Force`.

The same approach is applied to both:

- `open-code/config.json`
- `.config/opencode/config.json`

As a result, consumers always observe either the complete previous configuration or the complete newly generated configuration, avoiding partially written or truncated files if synchronization is interrupted.

## Verification

Verified using the project's existing checks:

- `make lint`
  - Passed.