### PR TITLE
fix/compose-failure-report-atomic-write

### DIFF
--- a/ods/installers/lib/compose-failure-report.sh
+++ b/ods/installers/lib/compose-failure-report.sh
@@ -99,9 +99,10 @@ write_compose_failure_report() {
 
     mkdir -p "$install_dir" "$install_dir/logs" 2>/dev/null || true
 
-    local stamp report env_file compose_flags_file
+    local stamp report tmp_report env_file compose_flags_file
     stamp="$(date '+%Y-%m-%d-%H%M%S')"
     report="$install_dir/install-report-${stamp}.txt"
+    tmp_report="$(mktemp "${report}.tmp.XXXXXX")"
     env_file="$install_dir/.env"
     compose_flags_file="$install_dir/.compose-flags"
     local report_compose_flags="${COMPOSE_FLAGS_REPORT:-${COMPOSE_FLAGS:-}}"
@@ -176,7 +177,8 @@ write_compose_failure_report() {
         else
             echo "installer log unavailable"
         fi
-    } > "$report" 2>&1
+    } > "$tmp_report" 2>&1
+    mv -f "$tmp_report" "$report"
 
     if command -v ai_warn >/dev/null 2>&1; then
         ai_warn "Compose failure report saved: $report"

--- a/ods/tests/test-compose-failure-report.sh
+++ b/ods/tests/test-compose-failure-report.sh
@@ -123,6 +123,19 @@ else
     fail "report file is missing"
 fi
 
+if [[ "$report_path" =~ ^"$INSTALL_DIR"/install-report-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}\.txt$ ]]; then
+    pass "returned report path matches final install-report-*.txt pattern"
+else
+    fail "returned report path ($report_path) does not match final install-report-*.txt pattern"
+fi
+
+tmp_leftovers="$(find "$INSTALL_DIR" -maxdepth 1 -name "install-report-*.txt.tmp.*" 2>/dev/null || true)"
+if [[ -z "$tmp_leftovers" ]]; then
+    pass "no temporary report files remain after atomic write"
+else
+    fail "temporary report files remain: $tmp_leftovers"
+fi
+
 assert_contains "$report_path" "ODS install failure report" "report has title"
 assert_contains "$report_path" "Phase: install-core phase 11 docker compose up" "report records phase"
 assert_contains "$report_path" "GPU backend: nvidia" "report records GPU backend"


### PR DESCRIPTION
## Summary

Prevent in-place truncation when generating compose failure reports.

Previously, `write_compose_failure_report()` in `ods/installers/lib/compose-failure-report.sh` redirected diagnostic output directly to the destination report file. Since shell redirection truncates the target before writing, an interrupted report generation could leave the report incomplete or empty.

This change updates the report generation path to use atomic file replacement:

- Writes the complete failure report to a temporary file created with `mktemp`.
- Atomically replaces the destination using `mv -f` after report generation completes successfully.

As a result, consumers always observe either the complete previous report or the complete newly generated report, avoiding partially written or truncated diagnostic reports if generation is interrupted.

## Verification

Verified using the project's existing checks:

- `make lint`
  - Passed.