### PR TITLE
fix(stability): write capability profile atomically in build-capability-profile.sh

### DIFF
--- a/ods/scripts/build-capability-profile.sh
+++ b/ods/scripts/build-capability-profile.sh
@@ -72,6 +72,7 @@ import json
 import os
 import pathlib
 import sys
+import tempfile
 
 hardware = json.loads(sys.argv[1])
 output_path = pathlib.Path(sys.argv[2])
@@ -171,7 +172,19 @@ profile = {
 }
 
 output_path.parent.mkdir(parents=True, exist_ok=True)
-output_path.write_text(json.dumps(profile, indent=2) + "\n", encoding="utf-8")
+fd, tmp_path = tempfile.mkstemp(dir=str(output_path.parent), suffix=".tmp")
+try:
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(json.dumps(profile, indent=2) + "\n")
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp_path, str(output_path))
+except BaseException:
+    try:
+        os.unlink(tmp_path)
+    except OSError:
+        pass
+    raise
 
 if env_mode:
     env = {


### PR DESCRIPTION
## Summary

Prevent in-place truncation when generating the hardware capability profile.

Previously, `build-capability-profile.sh` generated `data/capability-profile.json` by writing directly to the destination file using `Path.write_text()`. Since this truncates the destination before writing the new contents, an interrupted write could leave the capability profile incomplete or empty.

The capability profile is consumed by subsequent installer phases to determine hardware capabilities, compose overlays, and service configuration, so preserving a consistent profile across updates is important.

This change updates the profile generation path to use atomic file replacement:

- Writes the generated capability profile to a temporary file in the destination directory using `tempfile.mkstemp()`.
- Flushes the file and synchronizes it to disk with `os.fsync()`.
- Atomically replaces the destination using `os.replace()`.

As a result, consumers always observe either the complete previous profile or the complete newly generated profile, avoiding partially written or truncated output if the write is interrupted.

## Verification

Verified using the project's existing checks:

- `make lint`
  - Passed.