### PR TITLE
fix/support-bundle-atomic-redact

### DIFF
--- a/ods/scripts/ods-support-bundle.sh
+++ b/ods/scripts/ods-support-bundle.sh
@@ -126,8 +126,10 @@ redact_file() {
     [[ -f "$file" ]] || return 0
 
     "$PYTHON_CMD" - "$file" <<'PY'
+import os
 import re
 import sys
+import tempfile
 from pathlib import Path
 
 path = Path(sys.argv[1])
@@ -155,7 +157,16 @@ patterns = [
 for pattern, replacement in patterns:
     text = pattern.sub(replacement, text)
 
-path.write_text(text, encoding="utf-8")
+tmp_path = path.with_name(f".{path.name}.tmp")
+try:
+    tmp_path.write_text(text, encoding="utf-8")
+    os.replace(tmp_path, path)
+except BaseException:
+    try:
+        tmp_path.unlink(missing_ok=True)
+    except OSError:
+        pass
+    raise
 PY
 }
 


### PR DESCRIPTION
## Summary

Prevent in-place truncation when redacting files for support bundle generation.

Previously, `redact_file()` in `ods/scripts/ods-support-bundle.sh` rewrote the redacted file directly using `Path.write_text()`. Since this truncates the destination before writing the new contents, an interrupted write could leave the redacted copy incomplete or empty.

This change updates the redaction path to use atomic file replacement:

- Writes the redacted contents to a temporary file in the destination directory.
- Atomically replaces the original file using `os.replace()` after the write completes successfully.

As a result, the support bundle always contains either the complete original redacted file or the complete updated version, avoiding partially written or truncated files if redaction is interrupted.

## Verification

Verified using the project's existing checks:

- `make lint`
  - Passed.