### PR TITLE
fix(windows): write configuration files atomically in env-generator.ps1

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -87,3 +87,7 @@ jobs:
       - name: Windows Runtime Recovery Contract
         shell: pwsh
         run: ./tests/contracts/test-windows-runtime-recovery.ps1
+
+      - name: Windows Env Generator Contract
+        shell: pwsh
+        run: ./tests/contracts/test-windows-env-generator.ps1

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -80,7 +80,9 @@ function Write-Utf8NoBom {
         Write-AIWarn "Removed malformed $Path directory from a previous partial install."
     }
     $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+    $tmpPath = "$Path.$PID.tmp"
+    [System.IO.File]::WriteAllText($tmpPath, $Content, $utf8NoBom)
+    Move-Item -LiteralPath $tmpPath -Destination $Path -Force
 }
 
 function Write-WindowsODSLemonadeLiteLlmConfig {

--- a/ods/tests/contracts/test-windows-env-generator.ps1
+++ b/ods/tests/contracts/test-windows-env-generator.ps1
@@ -1,0 +1,44 @@
+$ErrorActionPreference = "Stop"
+
+$rootDir = Resolve-Path (Join-Path $PSScriptRoot "../..")
+$envGeneratorLibrary = Join-Path $rootDir "installers/windows/lib/env-generator.ps1"
+
+. $envGeneratorLibrary
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
+    "ods-windows-env-gen-$([Guid]::NewGuid().ToString('N'))"
+
+Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+
+try {
+    # Write-Utf8NoBom atomic replacement and literal-path contract under bracketed temp directory
+    $bracketDir = Join-Path $testRoot "bracket [test] path"
+    $bracketFile = Join-Path $bracketDir "config.env"
+    $expectedUtf8Content = "KEY=value_with_unicode_✓"
+    Write-Utf8NoBom -Path $bracketFile -Content $expectedUtf8Content
+
+    if (-not (Test-Path -LiteralPath $bracketFile -PathType Leaf)) {
+        throw "Write-Utf8NoBom failed to write file under bracketed directory"
+    }
+    $writtenContent = [System.IO.File]::ReadAllText($bracketFile)
+    if ($writtenContent -ne $expectedUtf8Content) {
+        throw "Write-Utf8NoBom content mismatch under bracketed directory"
+    }
+    $fileBytes = [System.IO.File]::ReadAllBytes($bracketFile)
+    if ($fileBytes.Length -ge 3 -and $fileBytes[0] -eq 0xEF -and $fileBytes[1] -eq 0xBB -and $fileBytes[2] -eq 0xBF) {
+        throw "Write-Utf8NoBom wrote UTF-8 BOM"
+    }
+
+    # Assert atomic replacement when overwriting an existing file under a bracketed path
+    $updatedUtf8Content = "KEY=updated_value_✓"
+    Write-Utf8NoBom -Path $bracketFile -Content $updatedUtf8Content
+    $updatedContent = [System.IO.File]::ReadAllText($bracketFile)
+    if ($updatedContent -ne $updatedUtf8Content) {
+        throw "Write-Utf8NoBom failed to replace existing file under bracketed directory"
+    }
+
+    Write-Host "[PASS] Windows env-generator Write-Utf8NoBom atomic literal-path contracts"
+} finally {
+    Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/ods/tests/contracts/test-windows-env-generator.ps1
+++ b/ods/tests/contracts/test-windows-env-generator.ps1
@@ -15,7 +15,7 @@ try {
     # Write-Utf8NoBom atomic replacement and literal-path contract under bracketed temp directory
     $bracketDir = Join-Path $testRoot "bracket [test] path"
     $bracketFile = Join-Path $bracketDir "config.env"
-    $expectedUtf8Content = "KEY=value_with_unicode_✓"
+    $expectedUtf8Content = "KEY=value_with_unicode_$([char]0x2713)"
     Write-Utf8NoBom -Path $bracketFile -Content $expectedUtf8Content
 
     if (-not (Test-Path -LiteralPath $bracketFile -PathType Leaf)) {
@@ -31,7 +31,7 @@ try {
     }
 
     # Assert atomic replacement when overwriting an existing file under a bracketed path
-    $updatedUtf8Content = "KEY=updated_value_✓"
+    $updatedUtf8Content = "KEY=updated_value_$([char]0x2713)"
     Write-Utf8NoBom -Path $bracketFile -Content $updatedUtf8Content
     $updatedContent = [System.IO.File]::ReadAllText($bracketFile)
     if ($updatedContent -ne $updatedUtf8Content) {


### PR DESCRIPTION
## Summary

Prevent in-place truncation when generating Windows configuration files.

Previously, `Write-WindowsODSConfigFile()` in `ods/installers/windows/lib/env-generator.ps1` wrote configuration files directly using `[System.IO.File]::WriteAllText()`. Since this updates the destination file in place, an interrupted write could leave the generated configuration incomplete or empty.

This helper is used throughout the Windows installer to generate configuration artifacts, including:

- `.env` files
- LiteLLM YAML configuration
- Model Router endpoint configuration

This change updates the helper to use atomic file replacement:

- Writes the generated configuration to a temporary peer file using a unique `.$PID.tmp` suffix.
- Atomically replaces the destination using `Move-Item -Force`.

As a result, consumers always observe either the complete previous configuration or the complete newly generated configuration, avoiding partially written or truncated files if configuration generation is interrupted.

## Verification

Verified using the project's existing checks:

- `make lint`
  - Passed.