### PR TITLE
fix(hermes): support basic auth in hermes_bridge and compose for post-hardening auth gate (#1964)

### DIFF
--- a/ods/extensions/services/dashboard-api/hermes_bridge.py
+++ b/ods/extensions/services/dashboard-api/hermes_bridge.py
@@ -27,6 +27,7 @@ visitors doesn't pin Hermes resources forever.
 from __future__ import annotations
 
 import asyncio
+import base64
 import hashlib
 import json
 import logging
@@ -35,6 +36,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from typing import Any, AsyncIterator
+from urllib.parse import urlparse
 
 import aiohttp
 
@@ -83,6 +85,17 @@ class HermesReply:
     warning: str | None = None
 
 
+def _get_hermes_auth_header(url_str: str) -> dict[str, str]:
+    """Extract BasicAuth header from URL or environment variables."""
+    parsed = urlparse(url_str)
+    username = parsed.username or os.environ.get("HERMES_DASHBOARD_BASIC_AUTH_USERNAME") or os.environ.get("HERMES_BASIC_AUTH_USER")
+    password = parsed.password or os.environ.get("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD") or os.environ.get("HERMES_BASIC_AUTH_PASS") or ""
+    if username:
+        creds = f"{username}:{password}".encode("utf-8")
+        return {"Authorization": f"Basic {base64.b64encode(creds).decode('ascii')}"}
+    return {}
+
+
 def _base_url() -> str:
     return (os.environ.get("HERMES_INTERNAL_URL") or DEFAULT_HERMES_URL).rstrip("/")
 
@@ -101,8 +114,9 @@ def talk_session_key(cookie_value: str) -> str:
 
 async def _fetch_hermes_token(session: aiohttp.ClientSession) -> str:
     url = _base_url()
+    headers = _get_hermes_auth_header(url)
     try:
-        async with session.get(url) as resp:
+        async with session.get(url, headers=headers) as resp:
             if resp.status >= 400:
                 raise HermesUnavailable(f"Hermes dashboard returned HTTP {resp.status}")
             html = await resp.text()
@@ -119,8 +133,9 @@ async def _connect_ws(session: aiohttp.ClientSession) -> aiohttp.ClientWebSocket
     token = await _fetch_hermes_token(session)
     ws_base = _base_url().replace("http://", "ws://", 1).replace("https://", "wss://", 1)
     url = f"{ws_base}/api/ws?token={token}"
+    headers = _get_hermes_auth_header(_base_url())
     try:
-        return await session.ws_connect(url)
+        return await session.ws_connect(url, headers=headers)
     except (aiohttp.ClientError, asyncio.TimeoutError, OSError) as exc:
         raise HermesUnavailable("Hermes JSON-RPC websocket is not reachable") from exc
 

--- a/ods/extensions/services/dashboard-api/tests/test_talk.py
+++ b/ods/extensions/services/dashboard-api/tests/test_talk.py
@@ -1096,3 +1096,23 @@ def test_ods_talk_hermes_timeout_is_env_configurable(monkeypatch):
 
     monkeypatch.setenv("ODS_TALK_HERMES_TIMEOUT", "5")
     assert hermes_bridge._request_timeout() == 10
+
+
+def test_hermes_bridge_get_auth_from_url_and_env(monkeypatch):
+    """Hermes bridge extracts BasicAuth credentials from HERMES_INTERNAL_URL or env vars."""
+    import base64
+    import hermes_bridge
+
+    monkeypatch.delenv("HERMES_DASHBOARD_BASIC_AUTH_USERNAME", raising=False)
+    monkeypatch.delenv("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD", raising=False)
+
+    headers = hermes_bridge._get_hermes_auth_header("http://admin:secret123@hermes:9119")
+    expected = "Basic " + base64.b64encode(b"admin:secret123").decode("ascii")
+    assert headers.get("Authorization") == expected
+
+    monkeypatch.setenv("HERMES_DASHBOARD_BASIC_AUTH_USERNAME", "envuser")
+    monkeypatch.setenv("HERMES_DASHBOARD_BASIC_AUTH_PASSWORD", "envpass")
+
+    headers_env = hermes_bridge._get_hermes_auth_header("http://hermes:9119")
+    expected_env = "Basic " + base64.b64encode(b"envuser:envpass").decode("ascii")
+    assert headers_env.get("Authorization") == expected_env

--- a/ods/extensions/services/hermes/compose.yaml
+++ b/ods/extensions/services/hermes/compose.yaml
@@ -46,8 +46,10 @@ services:
       # Upstream reads these env vars to configure the dashboard listener
       # without separate CLI flags.
       - HERMES_DASHBOARD=1
-      - HERMES_DASHBOARD_HOST=0.0.0.0
+      - HERMES_DASHBOARD_HOST=${HERMES_DASHBOARD_HOST:-0.0.0.0}
       - HERMES_DASHBOARD_PORT=9119
+      - HERMES_DASHBOARD_BASIC_AUTH_USERNAME
+      - HERMES_DASHBOARD_BASIC_AUTH_PASSWORD
       # --insecure equivalent: dashboard refuses non-loopback binds without
       # this since it stores API keys. The trusted-LAN posture is the v1
       # trade-off (documented in docs/HERMES.md).


### PR DESCRIPTION
## Summary

Restore Dashboard API connectivity when Hermes is configured with Basic Authentication.

Recent Hermes releases require an authentication provider before allowing non-loopback dashboard binds. When operators configured Basic Authentication for the Hermes dashboard, the Dashboard API bridge continued making unauthenticated requests, causing authentication failures when retrieving session tokens or establishing the JSON-RPC WebSocket connection.

This change adds Basic Authentication support to the Hermes bridge:

- Adds `_get_hermes_auth_header()` to construct an `Authorization: Basic` header from:
  - credentials embedded in `HERMES_INTERNAL_URL`
  - `HERMES_DASHBOARD_BASIC_AUTH_USERNAME` / `HERMES_DASHBOARD_BASIC_AUTH_PASSWORD`
  - `HERMES_BASIC_AUTH_USER` / `HERMES_BASIC_AUTH_PASS`
- Applies the generated authentication header to:
  - HTTP session token requests
  - JSON-RPC WebSocket connections
- Updates `compose.yaml` to:
  - pass through Basic Auth environment variables
  - allow `HERMES_DASHBOARD_HOST` to be overridden via `${HERMES_DASHBOARD_HOST:-0.0.0.0}`

As a result, Dashboard API can successfully communicate with Hermes deployments protected by Basic Authentication while preserving existing behavior for deployments that do not require authentication.

## Verification

Added regression coverage in `ods/extensions/services/dashboard-api/tests/test_talk.py`:

- `test_hermes_bridge_get_auth_from_url_and_env`
  - Verifies Basic Authentication header generation from:
    - credentials embedded in `HERMES_INTERNAL_URL`
    - Basic Auth environment variables

### Test Results

- `python3 -m pytest -v ods/extensions/services/dashboard-api/tests/test_talk.py`
  - **38 passed**

- `make lint`
  - Passed.