### PR TITLE
fix(models): scope Mistral Talk compatibility to Apple llama-server

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1054,6 +1054,21 @@
       "tokens_per_sec_estimate": 55,
       "llm_model_name": "mistral-nemo-instruct-2407",
       "llama_server_image": null,
+      "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "label": "ODS Talk unavailable on Apple llama-server",
+          "reason": "Fleet model-UI run 2026-07-22T06:12Z on m5-mbp loaded Mistral Nemo 12B successfully through the browser UI, but ODS Talk failed because llama.cpp rejected the Hermes request with the Mistral chat-template role alternation Jinja exception. The same run passed Mistral on strix-halo through Lemonade, so this verdict is scoped to Apple llama-server until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-22T06-12-53Z-release-product-cfe6addc5239-harness-8bdceb20b959-hosts-m5-mbp-strix-halo-windows-laptop-strixy/model-ui/cycle-006/m5-mbp",
+          "recordedAt": "2026-07-22T07:47:48Z",
+          "productSha": "cfe6addc523925adba4e6ab797645e83741759b0",
+          "harnessSha": "8bdceb20b9594515dae65f7f66df734ec152e1e4",
+          "hostScope": ["m5-mbp"],
+          "gpuBackendScope": ["apple"],
+          "llmBackendScope": ["llama-server"],
+          "expiresAt": "2026-08-22T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -196,7 +196,68 @@ def normalize_catalog_entry(raw: dict[str, Any]) -> dict[str, Any] | None:
     return model
 
 
-def _app_compatibility_entry(raw: Any, default_label: str) -> dict[str, Any]:
+def _scope_values(raw: dict[str, Any], *keys: str) -> list[str]:
+    for key in keys:
+        if key in raw:
+            return [normalize_key(item) for item in _list_value(raw.get(key)) if normalize_key(item)]
+    return []
+
+
+def model_compatibility_runtime_context(
+    install_dir: str | Path | None = None,
+    gpu_info: Optional[GPUInfo] = None,
+    runtime: str | None = None,
+) -> dict[str, str]:
+    def runtime_value(key: str) -> str:
+        if install_dir is not None:
+            value = read_env_file_value(key, install_dir) or read_env_value(key, install_dir)
+            if value:
+                return value
+        return os.environ.get(key, "")
+
+    llm_backend = runtime or runtime_value("LLM_BACKEND")
+    gpu_backend = (
+        getattr(gpu_info, "gpu_backend", None)
+        or runtime_value("GPU_BACKEND")
+    )
+    return {
+        "llmBackend": normalize_key(llm_backend),
+        "runtime": normalize_key(llm_backend),
+        "gpuBackend": normalize_key(gpu_backend),
+        "odsMode": normalize_key(runtime_value("ODS_MODE")),
+    }
+
+
+def _compatibility_scope_matches(raw: Any, runtime_context: Optional[dict[str, str]]) -> bool:
+    if not isinstance(raw, dict):
+        return True
+    context = runtime_context or model_compatibility_runtime_context()
+    checks = [
+        (_scope_values(raw, "llmBackendScope", "llm_backend_scope", "runtimeScope", "runtime_scope"),
+         {context.get("llmBackend", ""), context.get("runtime", "")}),
+        (_scope_values(raw, "gpuBackendScope", "gpu_backend_scope"),
+         {context.get("gpuBackend", "")}),
+        (_scope_values(raw, "odsModeScope", "ods_mode_scope"),
+         {context.get("odsMode", "")}),
+    ]
+    for allowed, actual_values in checks:
+        if allowed and not (set(allowed) & {value for value in actual_values if value}):
+            return False
+    return True
+
+
+def _app_compatibility_entry(
+    raw: Any,
+    default_label: str,
+    runtime_context: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
+    if isinstance(raw, dict) and not _compatibility_scope_matches(raw, runtime_context):
+        return {
+            "status": "unknown",
+            "label": default_label,
+            "reason": "",
+        }
+
     if isinstance(raw, dict):
         status = str(raw.get("status") or "unknown").strip() or "unknown"
         label = str(raw.get("label") or default_label).strip() or default_label
@@ -274,13 +335,14 @@ def _exact_performance_agent_block(performance: Optional[dict[str, Any]]) -> dic
 def model_app_compatibility(
     model: dict[str, Any],
     performance: Optional[dict[str, Any]] = None,
+    runtime_context: Optional[dict[str, str]] = None,
 ) -> dict[str, Any]:
     raw = model.get("app_compatibility") if isinstance(model.get("app_compatibility"), dict) else {}
-    hermes_talk = _app_compatibility_entry(raw.get("hermes_talk"), "ODS Talk untested")
+    hermes_talk = _app_compatibility_entry(raw.get("hermes_talk"), "ODS Talk untested", runtime_context)
     compatibility = {
-        "openaiChat": _app_compatibility_entry(raw.get("openai_chat"), "Direct chat untested"),
+        "openaiChat": _app_compatibility_entry(raw.get("openai_chat"), "Direct chat untested", runtime_context),
         "hermesTalk": hermes_talk,
-        "agentViability": _agent_viability_entry(raw.get("agent_viability"), hermes_talk),
+        "agentViability": _agent_viability_entry(raw.get("agent_viability"), hermes_talk, runtime_context),
     }
     for raw_key, raw_value in raw.items():
         payload_key = _app_compatibility_payload_key(raw_key)
@@ -289,6 +351,7 @@ def model_app_compatibility(
         compatibility[payload_key] = _app_compatibility_entry(
             raw_value,
             _app_compatibility_default_label(raw_key),
+            runtime_context,
         )
     exact_speed_block = _exact_performance_agent_block(performance)
     if exact_speed_block:
@@ -305,9 +368,13 @@ def model_app_compatibility(
     return compatibility
 
 
-def _agent_viability_entry(raw: Any, hermes_talk: dict[str, Any]) -> dict[str, Any]:
+def _agent_viability_entry(
+    raw: Any,
+    hermes_talk: dict[str, Any],
+    runtime_context: Optional[dict[str, str]] = None,
+) -> dict[str, Any]:
     if raw:
-        return _app_compatibility_entry(raw, "Agent viability untested")
+        return _app_compatibility_entry(raw, "Agent viability untested", runtime_context)
 
     hermes_status = str((hermes_talk or {}).get("status") or "unknown").strip().lower()
     hermes_reason = str((hermes_talk or {}).get("reason") or "").strip()
@@ -1198,7 +1265,11 @@ def build_models_payload(gpu_info: Optional[GPUInfo], loaded_model: Optional[str
                 "expertCount": metadata.get("expert_count"),
                 "expertUsedCount": metadata.get("expert_used_count"),
             },
-            "appCompatibility": model_app_compatibility(model, perf),
+            "appCompatibility": model_app_compatibility(
+                model,
+                perf,
+                model_compatibility_runtime_context(install_dir, gpu_info, runtime),
+            ),
             "status": "loaded" if is_loaded else status_if_not_loaded,
             "recommended": is_recommended,
             "configured": is_configured,

--- a/ods/extensions/services/dashboard-api/routers/talk.py
+++ b/ods/extensions/services/dashboard-api/routers/talk.py
@@ -28,6 +28,7 @@ from performance_oracle import (
     find_catalog_model,
     load_model_catalog,
     model_app_compatibility,
+    model_compatibility_runtime_context,
     read_env_file_value,
     read_env_value,
 )
@@ -84,7 +85,10 @@ def _active_model_app_compatibility() -> dict[str, Any]:
     model_name = read_env_file_value("LLM_MODEL", INSTALL_DIR) or read_env_value("LLM_MODEL", INSTALL_DIR)
     gguf = read_env_file_value("GGUF_FILE", INSTALL_DIR) or read_env_value("GGUF_FILE", INSTALL_DIR)
     entry = find_catalog_model(load_model_catalog(INSTALL_DIR), model_name, gguf)
-    compatibility = model_app_compatibility(entry or {})
+    compatibility = model_app_compatibility(
+        entry or {},
+        runtime_context=model_compatibility_runtime_context(INSTALL_DIR),
+    )
     compatibility["activeModel"] = {
         "id": entry.get("id") if entry else None,
         "model": model_name or None,

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -8,11 +8,12 @@ from performance_oracle import (
     current_model_matches,
     evaluate_performance,
     load_evidence,
+    model_app_compatibility,
     rank_pre_download_models,
 )
 
 
-def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192):
+def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192, backend="nvidia"):
     return GPUInfo(
         name=name,
         memory_used_mb=1024,
@@ -20,7 +21,7 @@ def _gpu(name="NVIDIA GeForce RTX 4060", total_mb=8192):
         memory_percent=12.5,
         utilization_percent=0,
         temperature_c=40,
-        gpu_backend="nvidia",
+        gpu_backend=backend,
     )
 
 
@@ -225,6 +226,88 @@ def test_model_payload_projects_explicit_app_compatibility(data_dir, tmp_path):
     assert compatibility["perplexica"]["status"] == "unsupported_until_revalidated"
     assert compatibility["perplexica"]["reason"] == "Perplexica probe failed"
     assert compatibility["perplexica"]["evidence"] == "fleet-run/perplexica"
+
+
+def test_scoped_app_compatibility_applies_only_to_matching_runtime():
+    model = {
+        "id": "mistral-nemo-12b-instruct-q4",
+        "app_compatibility": {
+            "hermes_talk": {
+                "status": "unsupported_until_revalidated",
+                "reason": "Mistral Talk probe failed on Apple llama-server",
+                "gpuBackendScope": ["apple"],
+                "llmBackendScope": ["llama-server"],
+            },
+        },
+    }
+
+    apple_llama = model_app_compatibility(
+        model,
+        runtime_context={"gpuBackend": "apple", "llmBackend": "llama-server", "runtime": "llama-server"},
+    )
+    lemonade_amd = model_app_compatibility(
+        model,
+        runtime_context={"gpuBackend": "amd", "llmBackend": "lemonade", "runtime": "lemonade"},
+    )
+
+    assert apple_llama["hermesTalk"]["status"] == "unsupported_until_revalidated"
+    assert apple_llama["agentViability"]["status"] == "not_agent_viable"
+    assert lemonade_amd["hermesTalk"]["status"] == "unknown"
+    assert lemonade_amd["agentViability"]["status"] == "unknown"
+
+
+def test_model_payload_applies_scoped_app_compatibility_from_install_env(data_dir, tmp_path):
+    install_dir = tmp_path / "ods"
+    (install_dir / "data" / "models").mkdir(parents=True)
+    model = {
+        "id": "mistral-nemo-12b-instruct-q4",
+        "name": "Mistral Nemo 12B Instruct",
+        "gguf_file": "Mistral-Nemo-Instruct-2407.Q4_K_M.gguf",
+        "size_mb": 7477,
+        "vram_required_gb": 12,
+        "context_length": 128000,
+        "quantization": "Q4_K_M",
+        "specialty": "Quality",
+        "description": "Mistral test model",
+        "llm_model_name": "mistral-nemo-instruct-2407",
+        "app_compatibility": {
+            "hermes_talk": {
+                "status": "unsupported_until_revalidated",
+                "reason": "Mistral Talk probe failed on Apple llama-server",
+                "gpuBackendScope": ["apple"],
+                "llmBackendScope": ["llama-server"],
+            },
+        },
+    }
+
+    (install_dir / ".env").write_text("GPU_BACKEND=apple\nLLM_BACKEND=llama-server\n", encoding="utf-8")
+    apple_payload = build_models_payload(
+        _gpu(name="Apple M5 Max", total_mb=131072, backend="apple"),
+        None,
+        0,
+        install_dir,
+        data_dir,
+        catalog=[model],
+        evidence=[],
+    )
+
+    (install_dir / ".env").write_text("GPU_BACKEND=amd\nLLM_BACKEND=lemonade\n", encoding="utf-8")
+    lemonade_payload = build_models_payload(
+        _gpu(name="AMD Strix Halo", total_mb=126976, backend="amd"),
+        None,
+        0,
+        install_dir,
+        data_dir,
+        catalog=[model],
+        evidence=[],
+    )
+
+    assert apple_payload["models"][0]["appCompatibility"]["hermesTalk"]["status"] == (
+        "unsupported_until_revalidated"
+    )
+    assert apple_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "not_agent_viable"
+    assert lemonade_payload["models"][0]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert lemonade_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "unknown"
 
 
 def test_measured_local_too_slow_blocks_agent_compatibility(data_dir, tmp_path):

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -31,11 +31,27 @@ BLOCKING_AGENT_STATUSES = {
 }
 
 
+def _has_runtime_scope(entry):
+    return any(
+        key in entry
+        for key in {
+            "gpuBackendScope",
+            "gpu_backend_scope",
+            "llmBackendScope",
+            "llm_backend_scope",
+            "runtimeScope",
+            "runtime_scope",
+            "odsModeScope",
+            "ods_mode_scope",
+        }
+    )
+
+
 def _agent_viable_for_release(model):
     compatibility = model.get("app_compatibility") or {}
     for entry in compatibility.values():
         status = str((entry or {}).get("status") or "").strip().lower()
-        if status in BLOCKING_AGENT_STATUSES:
+        if status in BLOCKING_AGENT_STATUSES and not _has_runtime_scope(entry or {}):
             return False
     return True
 
@@ -463,6 +479,20 @@ def test_qwen25_coder_15b_128k_is_not_talk_agent_viable_until_revalidated():
     assert "cycle-006" in compatibility["hermes_talk"]["evidence"]
     assert compatibility["agent_viability"]["status"] == "not_agent_viable"
     assert not _agent_viable_for_release(model)
+
+
+def test_mistral_nemo_talk_block_is_scoped_to_apple_llama_server():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["mistral-nemo-12b-instruct-q4"]
+    compatibility = model["app_compatibility"]
+
+    assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
+    assert compatibility["hermes_talk"]["gpuBackendScope"] == ["apple"]
+    assert compatibility["hermes_talk"]["llmBackendScope"] == ["llama-server"]
+    assert "m5-mbp" in compatibility["hermes_talk"]["hostScope"]
+    assert "cycle-006" in compatibility["hermes_talk"]["evidence"]
+    assert _agent_viable_for_release(model)
 
 
 def test_qwen3_4b_long_context_replacements_are_release_candidates():


### PR DESCRIPTION
﻿## Summary
- add runtime-scoped app compatibility handling for model catalog verdicts
- gate Mistral Nemo ODS Talk only on the Apple + llama-server path that failed fleet validation
- keep the same Mistral model available on Lemonade/AMD, where the live run passed all six cycles on strix-halo

## Evidence
- Failing cell: `fleet-test/runs/2026-07-22T06-12-53Z-release-product-cfe6addc5239-harness-8bdceb20b959-hosts-m5-mbp-strix-halo-windows-laptop-strixy/model-ui/cycle-006/m5-mbp`
- Failure: ODS Talk via Hermes/LiteLLM reached Mistral Nemo on m5-mbp, but llama.cpp rejected the request at chat-template rendering with the Mistral role-alternation Jinja exception.
- Control: the same run passed `mistral-nemo-12b-instruct-q4` on strix-halo through Lemonade, including Talk, Open WebUI, Perplexica, restore, delete, and environment cleanup.

## Validation
- `python -m json.tool config/model-library.json`
- `python -m pytest tests/test-model-library-coverage.py tests/test-model-library-verdicts.py extensions/services/dashboard-api/tests/test_performance_oracle.py extensions/services/dashboard-api/tests/test_talk.py -q`
