### PR TITLE
fix(models): wait for activation lifecycle idle

### DIFF
--- a/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
+++ b/ods/extensions/services/dashboard/src/hooks/__tests__/useModels.test.js
@@ -571,6 +571,57 @@ describe('useModels', () => {
     }
   })
 
+  test('keeps activation pending while backend activation lifecycle is still active', async () => {
+    vi.useFakeTimers()
+    const target = 'warmup-model'
+    let currentModel = null
+    let activationActive = false
+    fetch.mockImplementation((_url, opts) => {
+      if (opts?.method === 'POST') return Promise.resolve({ ok: true })
+      return Promise.resolve(modelsResponse(
+        [{ id: target, status: currentModel ? 'loaded' : 'downloaded' }],
+        {
+          currentModel,
+          modelLifecycle: activationActive
+            ? {
+                active: true,
+                operation: 'model_activation',
+                target,
+                modelId: target,
+              }
+            : null,
+        }
+      ))
+    })
+
+    try {
+      const { result } = renderHook(() => useModels())
+      await act(async () => {})
+
+      let loadPromise
+      act(() => {
+        loadPromise = result.current.loadModel(target)
+      })
+
+      currentModel = target
+      activationActive = true
+      await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+      expect(result.current.currentModel).toBe(target)
+      expect(result.current.actionLoading).toBe(target)
+      expect(result.current.error).toBeNull()
+
+      activationActive = false
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+        await loadPromise
+      })
+      expect(result.current.actionLoading).toBeNull()
+      expect(result.current.error).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   test('holds the activation lock through 600 seconds and then reports a terminal timeout', async () => {
     vi.useFakeTimers()
     const target = 'never-loads'

--- a/ods/extensions/services/dashboard/src/hooks/useModels.js
+++ b/ods/extensions/services/dashboard/src/hooks/useModels.js
@@ -135,6 +135,11 @@ function normalizeModelLifecycle(data) {
   }
 }
 
+function hasActiveModelActivation(data) {
+  const lifecycle = normalizeModelLifecycle(data?.modelLifecycle)
+  return lifecycle?.operation === 'model_activation'
+}
+
 function normalizeOdsMode(value) {
   const mode = typeof value === 'string' ? value.trim().toLowerCase() : ''
   return ODS_MODES.has(mode) ? mode : 'unknown'
@@ -381,7 +386,7 @@ export function useModels() {
 
         if (activationError) break
         const data = await fetchModels()
-        if (data?.currentModel === modelId) {
+        if (data?.currentModel === modelId && !hasActiveModelActivation(data)) {
           targetLoaded = true
           break
         }
@@ -390,7 +395,7 @@ export function useModels() {
       // Take one final authoritative snapshot at the deadline or after a POST
       // failure. This cannot turn an unverified 409 into same-target success.
       const finalData = await fetchModels()
-      if (!activationError && finalData?.currentModel === modelId) targetLoaded = true
+      if (!activationError && finalData?.currentModel === modelId && !hasActiveModelActivation(finalData)) targetLoaded = true
 
       if (!targetLoaded) {
         setMutationError(activationError ||


### PR DESCRIPTION
﻿## Summary
- keep the Models UI activation lock active until the backend `model_activation` lifecycle has gone idle
- prevent a false-ready state where `/api/models.currentModel` flips before the host agent has finished runtime proof
- add a regression for currentModel becoming the target while `modelLifecycle.operation` is still `model_activation`

## Fleet Evidence
- Live run: `/home/michael/dream-fleet-test/runs/2026-07-22T06-12-53Z-release-product-cfe6addc5239-harness-8bdceb20b959-hosts-m5-mbp-strix-halo-windows-laptop-strixy`
- Windows laptop cycle 3 loaded `granite4.1-3b-q4`, then Talk timed out after 180s while router logs showed llama-server 502/503 followed by a later 200. The UI/API had already treated the target as current, so user-facing apps could run before activation proof was complete.

## Validation
- `npm.cmd test -- src/hooks/__tests__/useModels.test.js`
- `npm.cmd test`
- `python -m pytest extensions\\services\\dashboard-api\\tests\\test_models.py -q`
