### PR TITLE
fix(models): allow selected install rerun past VRAM estimate

### DIFF
--- a/ods/extensions/services/dashboard/src/pages/Models.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.jsx
@@ -1055,7 +1055,7 @@ function getRunDisabledReason({
   if (isOpenAiChatBlocked(openAiChat)) {
     return openAiChat.reason || 'This model is not currently validated for direct local chat.'
   }
-  if (model.fitsVram !== true) {
+  if (model.fitsVram !== true && !model.recommended) {
     const required = Number(model.estimatedRequired || model.vramRequired || 0)
     const total = Number(gpu?.vramTotal || 0)
     if (required > 0 && total > 0) {

--- a/ods/extensions/services/dashboard/src/pages/Models.test.jsx
+++ b/ods/extensions/services/dashboard/src/pages/Models.test.jsx
@@ -586,6 +586,28 @@ test('keeps Run visible with the VRAM requirement when the model does not fit', 
   expect(loadModel).not.toHaveBeenCalled()
 })
 
+test('allows the selected install model to run even when the VRAM estimate is high', () => {
+  const loadModel = vi.fn()
+  useModelsMock.mockReturnValue(baseState({
+    loadModel,
+    models: [model({
+      status: 'downloaded',
+      fitsVram: false,
+      vramRequired: 12,
+      recommended: true,
+    })],
+  }))
+
+  renderModels()
+
+  expect(screen.getByText('Selected install')).toBeInTheDocument()
+  const runButton = screen.getByRole('button', { name: /^run$/i })
+  expect(runButton).toBeEnabled()
+  expect(runButton).toHaveAttribute('title', 'Run Qwen 3.5 9B')
+  fireEvent.click(runButton)
+  expect(loadModel).toHaveBeenCalledWith('qwen3.5-9b-q4')
+})
+
 test('shows effective and configured runtime modes when they differ', () => {
   useModelsMock.mockReturnValue(baseState({
     odsMode: 'local',


### PR DESCRIPTION
﻿## Summary
- keep normal oversized downloaded models blocked by the VRAM estimate
- allow the selected install model to Run even if the catalog estimate says it is slightly over the detected GPU total
- add a page regression so a user can restore/rerun the model ODS selected and installed

## Fleet Evidence
- Live run: `/home/michael/dream-fleet-test/runs/2026-07-22T06-12-53Z-release-product-cfe6addc5239-harness-8bdceb20b959-hosts-m5-mbp-strix-halo-windows-laptop-strixy`
- Strixy cycles 1 and 2 failed restoring `qwen3.6-35b-a3b-ud-q4`. The captured UI showed the selected-install Qwen 35B row marked Incompatible / Too large and the Run button rendered disabled even though that model had been the active baseline at cycle start.

## Validation
- `npm.cmd test -- src/pages/Models.test.jsx`
