### PR TITLE
fix(models): honor host-scoped compatibility

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -431,6 +431,28 @@
       "tokens_per_sec_estimate": 115,
       "llm_model_name": "granite-4.1-3b",
       "llama_server_image": null,
+      "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "reason": "Fleet model-UI run 2026-07-22T08:31Z on windows-laptop loaded Granite 4.1 3B and ODS Talk accepted the stream request, but the browser stayed in the Thinking state until the 180s inference timeout while dashboard-api reported repeated llama metrics read timeouts.",
+          "evidence": "fleet-test/runs/2026-07-22T08-31-37Z-release-product-52559816f964-harness-ef040aeb79ab-hosts-windows-laptop-strixy-m5-mbp/model-ui/cycle-003/windows-laptop",
+          "recordedAt": "2026-07-22T09:18:55Z",
+          "productSha": "52559816f964364a63bdbc000722dbbccefec4f9",
+          "harnessSha": "ef040aeb79ab1619e8d3d0c7da59baac150e95c6",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-22T00:00:00Z"
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "reason": "The model loaded and routed through the browser-managed swap path on windows-laptop, but ODS Talk did not complete a user-facing answer within the release inference window; keep it out of agent-required release coverage on that host until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-22T08-31-37Z-release-product-52559816f964-harness-ef040aeb79ab-hosts-windows-laptop-strixy-m5-mbp/model-ui/cycle-003/windows-laptop",
+          "recordedAt": "2026-07-22T09:18:55Z",
+          "productSha": "52559816f964364a63bdbc000722dbbccefec4f9",
+          "harnessSha": "ef040aeb79ab1619e8d3d0c7da59baac150e95c6",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-22T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {

--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -207,7 +207,7 @@ def model_compatibility_runtime_context(
     install_dir: str | Path | None = None,
     gpu_info: Optional[GPUInfo] = None,
     runtime: str | None = None,
-) -> dict[str, str]:
+) -> dict[str, Any]:
     def runtime_value(key: str) -> str:
         if install_dir is not None:
             value = read_env_file_value(key, install_dir) or read_env_value(key, install_dir)
@@ -220,25 +220,63 @@ def model_compatibility_runtime_context(
         getattr(gpu_info, "gpu_backend", None)
         or runtime_value("GPU_BACKEND")
     )
+    explicit_host_values = {
+        normalize_key(value)
+        for value in (
+            runtime_value("ODS_FLEET_HOST_ID"),
+            runtime_value("ODS_COMPATIBILITY_HOST"),
+        )
+        if normalize_key(value)
+    }
+    host_values = explicit_host_values or {
+        normalize_key(value)
+        for value in (
+            runtime_value("ODS_DEVICE_NAME"),
+            runtime_value("COMPUTERNAME"),
+            runtime_value("HOSTNAME"),
+            platform.node(),
+        )
+        if normalize_key(value)
+    }
     return {
         "llmBackend": normalize_key(llm_backend),
         "runtime": normalize_key(llm_backend),
         "gpuBackend": normalize_key(gpu_backend),
         "odsMode": normalize_key(runtime_value("ODS_MODE")),
+        "host": sorted(host_values)[0] if host_values else "",
+        "hosts": sorted(host_values),
     }
 
 
-def _compatibility_scope_matches(raw: Any, runtime_context: Optional[dict[str, str]]) -> bool:
+def _context_values(context: dict[str, Any], *keys: str) -> set[str]:
+    values: set[str] = set()
+    for key in keys:
+        value = context.get(key)
+        if isinstance(value, (list, tuple, set)):
+            for item in value:
+                normalized = normalize_key(item)
+                if normalized:
+                    values.add(normalized)
+            continue
+        normalized = normalize_key(value)
+        if normalized:
+            values.add(normalized)
+    return values
+
+
+def _compatibility_scope_matches(raw: Any, runtime_context: Optional[dict[str, Any]]) -> bool:
     if not isinstance(raw, dict):
         return True
     context = runtime_context or model_compatibility_runtime_context()
     checks = [
         (_scope_values(raw, "llmBackendScope", "llm_backend_scope", "runtimeScope", "runtime_scope"),
-         {context.get("llmBackend", ""), context.get("runtime", "")}),
+         _context_values(context, "llmBackend", "runtime")),
         (_scope_values(raw, "gpuBackendScope", "gpu_backend_scope"),
-         {context.get("gpuBackend", "")}),
+         _context_values(context, "gpuBackend")),
         (_scope_values(raw, "odsModeScope", "ods_mode_scope"),
-         {context.get("odsMode", "")}),
+         _context_values(context, "odsMode")),
+        (_scope_values(raw, "hostScope", "host_scope", "fleetHostScope", "fleet_host_scope"),
+         _context_values(context, "host", "hosts")),
     ]
     for allowed, actual_values in checks:
         if allowed and not (set(allowed) & {value for value in actual_values if value}):
@@ -249,7 +287,7 @@ def _compatibility_scope_matches(raw: Any, runtime_context: Optional[dict[str, s
 def _app_compatibility_entry(
     raw: Any,
     default_label: str,
-    runtime_context: Optional[dict[str, str]] = None,
+    runtime_context: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     if isinstance(raw, dict) and not _compatibility_scope_matches(raw, runtime_context):
         return {
@@ -335,7 +373,7 @@ def _exact_performance_agent_block(performance: Optional[dict[str, Any]]) -> dic
 def model_app_compatibility(
     model: dict[str, Any],
     performance: Optional[dict[str, Any]] = None,
-    runtime_context: Optional[dict[str, str]] = None,
+    runtime_context: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     raw = model.get("app_compatibility") if isinstance(model.get("app_compatibility"), dict) else {}
     hermes_talk = _app_compatibility_entry(raw.get("hermes_talk"), "ODS Talk untested", runtime_context)
@@ -371,7 +409,7 @@ def model_app_compatibility(
 def _agent_viability_entry(
     raw: Any,
     hermes_talk: dict[str, Any],
-    runtime_context: Optional[dict[str, str]] = None,
+    runtime_context: Optional[dict[str, Any]] = None,
 ) -> dict[str, Any]:
     if raw:
         return _app_compatibility_entry(raw, "Agent viability untested", runtime_context)

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -8,6 +8,7 @@ from performance_oracle import (
     current_model_matches,
     evaluate_performance,
     load_evidence,
+    model_compatibility_runtime_context,
     model_app_compatibility,
     rank_pre_download_models,
 )
@@ -256,6 +257,33 @@ def test_scoped_app_compatibility_applies_only_to_matching_runtime():
     assert lemonade_amd["agentViability"]["status"] == "unknown"
 
 
+def test_host_scoped_app_compatibility_applies_only_to_matching_host():
+    model = {
+        "id": "granite4.1-3b-q4",
+        "app_compatibility": {
+            "hermes_talk": {
+                "status": "unsupported_until_revalidated",
+                "reason": "Granite Talk probe timed out on windows-laptop",
+                "hostScope": ["windows-laptop"],
+            },
+        },
+    }
+
+    windows_laptop = model_app_compatibility(
+        model,
+        runtime_context={"host": "windows-laptop", "hosts": ["windows-laptop", "light-worker"]},
+    )
+    strixy = model_app_compatibility(
+        model,
+        runtime_context={"host": "strixy", "hosts": ["strixy"]},
+    )
+
+    assert windows_laptop["hermesTalk"]["status"] == "unsupported_until_revalidated"
+    assert windows_laptop["agentViability"]["status"] == "not_agent_viable"
+    assert strixy["hermesTalk"]["status"] == "unknown"
+    assert strixy["agentViability"]["status"] == "unknown"
+
+
 def test_model_payload_applies_scoped_app_compatibility_from_install_env(data_dir, tmp_path):
     install_dir = tmp_path / "ods"
     (install_dir / "data" / "models").mkdir(parents=True)
@@ -308,6 +336,60 @@ def test_model_payload_applies_scoped_app_compatibility_from_install_env(data_di
     assert apple_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "not_agent_viable"
     assert lemonade_payload["models"][0]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
     assert lemonade_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "unknown"
+
+
+def test_model_payload_applies_host_scoped_app_compatibility_from_install_env(data_dir, tmp_path):
+    install_dir = tmp_path / "ods"
+    (install_dir / "data" / "models").mkdir(parents=True)
+    model = {
+        "id": "granite4.1-3b-q4",
+        "name": "Granite 4.1 3B",
+        "gguf_file": "granite-4.1-3b-Q4_K_M.gguf",
+        "size_mb": 2100,
+        "vram_required_gb": 4,
+        "context_length": 131072,
+        "quantization": "Q4_K_M",
+        "specialty": "Tool Use",
+        "description": "Granite test model",
+        "llm_model_name": "granite-4.1-3b",
+        "app_compatibility": {
+            "hermes_talk": {
+                "status": "unsupported_until_revalidated",
+                "reason": "Granite Talk probe timed out on windows-laptop",
+                "hostScope": ["windows-laptop"],
+            },
+        },
+    }
+
+    (install_dir / ".env").write_text("ODS_FLEET_HOST_ID=windows-laptop\n", encoding="utf-8")
+    windows_payload = build_models_payload(
+        _gpu(),
+        None,
+        0,
+        install_dir,
+        data_dir,
+        catalog=[model],
+        evidence=[],
+    )
+
+    (install_dir / ".env").write_text("ODS_FLEET_HOST_ID=strixy\n", encoding="utf-8")
+    strixy_payload = build_models_payload(
+        _gpu(),
+        None,
+        0,
+        install_dir,
+        data_dir,
+        catalog=[model],
+        evidence=[],
+    )
+
+    assert model_compatibility_runtime_context(install_dir)["hosts"] == ["strixy"]
+    assert windows_payload["models"][0]["appCompatibility"]["hermesTalk"]["status"] == (
+        "unsupported_until_revalidated"
+    )
+    assert windows_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "not_agent_viable"
+    assert strixy_payload["models"][0]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert strixy_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "unknown"
 
 
 def test_measured_local_too_slow_blocks_agent_compatibility(data_dir, tmp_path):
@@ -433,6 +515,7 @@ def test_bundled_windows_laptop_phi_evidence_blocks_agent_compatibility(data_dir
 def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_path):
     install_dir = tmp_path / "ods"
     (install_dir / "data" / "models").mkdir(parents=True)
+    (install_dir / ".env").write_text("ODS_FLEET_HOST_ID=windows-laptop\n", encoding="utf-8")
     catalog = _official_model_catalog()
 
     payload = build_models_payload(
@@ -465,39 +548,33 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
         "qwen3.5-4b-q4",
         "qwen3-4b-instruct-2507-q4",
         "qwen3-4b-128k-q4",
-        "granite4.1-3b-q4",
+        "qwen2.5-coder-1.5b-128k-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
     }.issubset(candidate_ids)
     assert by_id["qwen3.5-4b-q4"]["contextLength"] == 262144
     assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 262144
     assert by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
-    assert by_id["granite4.1-3b-q4"]["contextLength"] == 131072
-    assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["opencode"]["status"] == (
+    assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
+    assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["opencode"]["status"] == "unknown"
+    assert all_by_id["falcon-h1-3b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert all_by_id["qwen2.5-coder-1.5b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert all_by_id["phi3-mini-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert all_by_id["granite4.1-3b-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"
     )
-    assert all_by_id["falcon-h1-3b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
-        "unsupported_until_revalidated"
-    )
-    assert all_by_id["qwen2.5-coder-1.5b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
-        "unsupported_until_revalidated"
-    )
-    assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == (
-        "unsupported_until_revalidated"
-    )
-    assert all_by_id["granite4.0-h-1b-q4"]["appCompatibility"]["perplexica"]["status"] == (
-        "unsupported_until_revalidated"
-    )
-    assert "granite3.1-2b-instruct-q4" not in candidate_ids
-    assert "granite4.0-h-1b-q4" not in candidate_ids
+    assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == "unknown"
+    assert all_by_id["granite4.0-h-1b-q4"]["appCompatibility"]["perplexica"]["status"] == "unknown"
+    assert "granite3.1-2b-instruct-q4" in candidate_ids
+    assert "granite4.0-h-1b-q4" in candidate_ids
     assert "phi4-mini-q4" not in candidate_ids
     assert "gemma3-4b-it-q4" not in candidate_ids
-    assert "falcon-h1-1.5b-instruct-q4" not in candidate_ids
-    assert "falcon-h1-3b-instruct-q4" not in candidate_ids
-    assert "qwen2.5-coder-1.5b-128k-q4" not in candidate_ids
+    assert "falcon-h1-1.5b-instruct-q4" in candidate_ids
+    assert "falcon-h1-3b-instruct-q4" in candidate_ids
+    assert "granite4.1-3b-q4" not in candidate_ids
     assert "granite4.0-h-350m-q4" not in candidate_ids
     assert "granite4.0-1b-q4" not in candidate_ids
-    assert "phi3-mini-128k-q4" not in candidate_ids
+    assert "phi3-mini-128k-q4" in candidate_ids
     assert "granite3.3-8b-instruct-q4" not in candidate_ids
     assert "smollm3-3b-q4" not in candidate_ids
     assert "qwen2.5-3b-instruct-q4" not in candidate_ids


### PR DESCRIPTION
## Summary
- honors `hostScope` / `host_scope` / `fleetHostScope` in model app-compatibility metadata
- records the Granite 4.1 3B ODS Talk timeout from the current windows-laptop model-UI run as a windows-laptop-scoped verdict
- keeps the Windows 8GB release candidate pool at six-plus viable product-visible models by allowing other-host verdicts to remain unknown on windows-laptop

## Evidence
- Failure evidence: `fleet-test/runs/2026-07-22T08-31-37Z-release-product-52559816f964-harness-ef040aeb79ab-hosts-windows-laptop-strixy-m5-mbp/model-ui/cycle-003/windows-laptop`
- Product SHA under test: `52559816f964364a63bdbc000722dbbccefec4f9`
- Harness SHA under test: `ef040aeb79ab1619e8d3d0c7da59baac150e95c6`

## Tests
- `PYTHONPATH=extensions/services/dashboard-api python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py tests/test-model-library-verdicts.py tests/test-model-library-coverage.py -q`
