### PR TITLE
fix(models): scope Gemma Perplexica block to strixy

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -290,13 +290,13 @@
         "perplexica": {
           "status": "unsupported_until_revalidated",
           "label": "Perplexica revalidation required",
-          "reason": "Fleet model-UI run 2026-07-19T03:40Z on windows-laptop loaded this model and ODS Talk passed, but the Perplexica app probe answered with a search-style failure instead of the requested verification phrase; keep it out of all-app release coverage until Perplexica compatibility is revalidated.",
-          "evidence": "fleet-test/runs/2026-07-19T03-40-01Z-release-product-54b2f703190f-harness-2a6a4e6a55b8-hosts-windows-laptop/model-ui/cycle-003/windows-laptop",
-          "recordedAt": "2026-07-19T03:40:01Z",
-          "productSha": "54b2f703190f",
-          "harnessSha": "2a6a4e6a55b8",
-          "hostScope": ["windows-laptop"],
-          "revalidateAgainstSha": "63949ab0ff5be385dde9977528c199b6c081c9ca"
+          "reason": "Fleet model-UI runs on windows-laptop and strixy loaded this model and ODS Talk passed, but the Perplexica app probe failed instead of returning the requested verification phrase; keep it out of all-app release coverage on those hosts until Perplexica compatibility is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-19T03-40-01Z-release-product-54b2f703190f-harness-2a6a4e6a55b8-hosts-windows-laptop/model-ui/cycle-003/windows-laptop; fleet-test/runs/2026-07-22T09-42-12Z-release-product-b5bb39f2c0f2-harness-cc7b6148eb2c-hosts-windows-laptop-strixy-m5-mbp/model-ui/cycle-003/strixy",
+          "recordedAt": "2026-07-22T10:26:21Z",
+          "productSha": "b5bb39f2c0f2a7a3dfa5f98547e469b6eaf0acfd",
+          "harnessSha": "cc7b6148eb2cd6e667e6a9dd3d36dff6f8928052",
+          "hostScope": ["windows-laptop", "strixy"],
+          "expiresAt": "2026-08-22T00:00:00Z"
         }
       },
       "install_recommendation": false

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -392,6 +392,28 @@ def test_model_payload_applies_host_scoped_app_compatibility_from_install_env(da
     assert strixy_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "unknown"
 
 
+def test_real_catalog_gemma_perplexica_block_is_host_scoped():
+    by_id = {model["id"]: model for model in _official_model_catalog()}
+    model = by_id["gemma3-4b-it-q4"]
+
+    windows_laptop = model_app_compatibility(
+        model,
+        runtime_context={"host": "windows-laptop", "hosts": ["windows-laptop"]},
+    )
+    strixy = model_app_compatibility(
+        model,
+        runtime_context={"host": "strixy", "hosts": ["strixy"]},
+    )
+    tower2 = model_app_compatibility(
+        model,
+        runtime_context={"host": "tower2", "hosts": ["tower2"]},
+    )
+
+    assert windows_laptop["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert strixy["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert tower2["perplexica"]["status"] == "unknown"
+
+
 def test_measured_local_too_slow_blocks_agent_compatibility(data_dir, tmp_path):
     install_dir = tmp_path / "ods"
     (install_dir / "data" / "models").mkdir(parents=True)


### PR DESCRIPTION
## Summary
- adds the current strixy Perplexica probe failure to Gemma 3 4B's product-visible app compatibility verdict
- keeps the verdict host-scoped to windows-laptop and strixy instead of globally excluding Gemma
- adds a focused real-catalog test proving the block applies only to those hosts

## Evidence
- Fresh failure: `fleet-test/runs/2026-07-22T09-42-12Z-release-product-b5bb39f2c0f2-harness-cc7b6148eb2c-hosts-windows-laptop-strixy-m5-mbp/model-ui/cycle-003/strixy`
- Prior windows-laptop evidence retained: `fleet-test/runs/2026-07-19T03-40-01Z-release-product-54b2f703190f-harness-2a6a4e6a55b8-hosts-windows-laptop/model-ui/cycle-003/windows-laptop`

## Tests
- `PYTHONPATH=extensions/services/dashboard-api python -m pytest extensions/services/dashboard-api/tests/test_performance_oracle.py tests/test-model-library-verdicts.py tests/test-model-library-coverage.py -q`
