### PR TITLE
fix(models): retry Windows env activation writes

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -1194,7 +1194,21 @@ def _atomic_write_bytes(
                     target_gid,
                 ):
                     os.chown(tmp_path, target_uid, target_gid)
-        os.replace(tmp_path, path)
+        last_error: PermissionError | None = None
+        for attempt in range(10):
+            try:
+                os.replace(tmp_path, path)
+                last_error = None
+                break
+            except PermissionError as exc:
+                last_error = exc
+                if attempt == 9:
+                    break
+                # Windows can briefly hold configuration files open while
+                # dashboard-api polls host-agent during model activation.
+                time.sleep(0.05 * (attempt + 1))
+        if last_error is not None:
+            raise last_error
         if os.name != "nt":
             directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
             try:

--- a/ods/extensions/services/dashboard-api/tests/test_model_activate.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_activate.py
@@ -2043,6 +2043,51 @@ def test_text_snapshot_restores_exact_line_endings(tmp_path):
     assert (path.stat().st_uid, path.stat().st_gid) == original_owner
 
 
+def test_atomic_write_text_retries_windows_replace_race(tmp_path, monkeypatch):
+    path = tmp_path / ".env"
+    path.write_text("MODEL=old\n", encoding="utf-8")
+    monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+    real_replace = _mod.os.replace
+    calls = []
+
+    def flaky_replace(src, dst):
+        calls.append((src, dst))
+        if len(calls) < 3:
+            raise PermissionError("[WinError 5] Access is denied")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(_mod.os, "replace", flaky_replace)
+
+    _mod._atomic_write_text(path, "MODEL=new\n")
+
+    assert len(calls) == 3
+    assert path.read_text(encoding="utf-8") == "MODEL=new\n"
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
+def test_atomic_write_text_cleans_temp_after_replace_race_exhausted(
+    tmp_path,
+    monkeypatch,
+):
+    path = tmp_path / ".env"
+    path.write_text("MODEL=old\n", encoding="utf-8")
+    monkeypatch.setattr(_mod.time, "sleep", lambda _seconds: None)
+    calls = []
+
+    def locked_replace(src, dst):
+        calls.append((src, dst))
+        raise PermissionError("[WinError 5] Access is denied")
+
+    monkeypatch.setattr(_mod.os, "replace", locked_replace)
+
+    with pytest.raises(PermissionError):
+        _mod._atomic_write_text(path, "MODEL=new\n")
+
+    assert len(calls) == 10
+    assert path.read_text(encoding="utf-8") == "MODEL=old\n"
+    assert list(tmp_path.glob(".*.tmp")) == []
+
+
 class TestModelActivateRollback:
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

- retry transient `PermissionError` failures when host-agent atomically replaces configuration files such as `.env`
- keep the retry bounded so persistent Windows access-denied errors still surface
- add regression coverage for transient and exhausted replace races

## Root Cause

The model-UI fleet run at product `193bc907f3e6` reached strixy cycle 2 and failed model activation for `granite4.0-h-tiny-q4`. The dashboard Load click reached dashboard-api, but host-agent returned HTTP 502 because Windows raised `[WinError 5] Access is denied` during `os.replace(... -> C:\Users\conta\ods\.env)`. The model remained `downloaded`, so the harness correctly timed out waiting for `loaded`.

## Validation

- `python -m pytest extensions/services/dashboard-api/tests/test_model_activate.py -q` -> 173 passed, 1 skipped
- `python -m pytest extensions/services/dashboard-api/tests/test_host_agent.py::TestProgressWrites -q` -> 1 passed

After merge, the affected-host model-UI fleet run should be relaunched from the new main SHA.