### PR TITLE
fix(models): gate Falcon agent viability

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -350,6 +350,15 @@
       "llm_model_name": "Falcon-H1-1.5B-Instruct",
       "llama_server_image": null,
       "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "reason": "Fleet model-UI run 2026-07-22T18:45Z on strixy loaded Falcon H1 1.5B through Lemonade and routed ODS Talk through ods/current, but Talk emitted a tool-call payload instead of the requested verification phrase.",
+          "evidence": "fleet-test/runs/2026-07-22T18-45-07Z-model-ui-product-31c93e53c4aa-harness-ebdb7f948190-hosts-strixy-talk-runtime-strict-6cycle/cycle-004/strixy",
+          "recordedAt": "2026-07-22T19:33:20Z",
+          "productSha": "31c93e53c4aa8f9831abdb00516639def985ef34",
+          "harnessSha": "ebdb7f9481901a35ca1e5108fe2a1769bab197e8",
+          "expiresAt": "2026-08-22T00:00:00Z"
+        },
         "opencode": {
           "status": "unsupported_until_revalidated",
           "reason": "Fleet model-UI run 2026-07-21T11:18Z on tower2 loaded Falcon H1 1.5B successfully and routed OpenCode through ods/current, but the OpenCode UX reply emitted a skill/tool meta-response instead of the requested verification phrase.",
@@ -362,13 +371,12 @@
         },
         "agent_viability": {
           "status": "not_agent_viable",
-          "reason": "The same run proved Talk, Open WebUI, LiteLLM, and Perplexica routing, but OpenCode did not complete the required agent verification phrase after the swap; keep Falcon H1 1.5B out of agent-required release coverage until revalidated.",
-          "evidence": "fleet-test/runs/2026-07-21T11-18-01Z-release-product-c43960145c39-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-004/tower2",
-          "recordedAt": "2026-07-21T12:12:38Z",
-          "productSha": "c43960145c39c5fa24627bf8b0e98b30c362cc85",
-          "harnessSha": "9804e8523a6d11ebeb86eac5f5400cf21fc25b39",
-          "hostScope": ["tower2"],
-          "expiresAt": "2026-08-21T00:00:00Z"
+          "reason": "Falcon H1 1.5B has failed agent-required browser verification in OpenCode on tower2 and ODS Talk on strixy/Lemonade by emitting tool or meta payloads instead of the requested verification phrase; keep it out of agent-required release coverage until revalidated with a tool-aware Talk/app probe.",
+          "evidence": "fleet-test/runs/2026-07-21T11-18-01Z-release-product-c43960145c39-harness-9804e8523a6d-hosts-tower2/model-ui/cycle-004/tower2; fleet-test/runs/2026-07-22T18-45-07Z-model-ui-product-31c93e53c4aa-harness-ebdb7f948190-hosts-strixy-talk-runtime-strict-6cycle/cycle-004/strixy",
+          "recordedAt": "2026-07-22T19:33:20Z",
+          "productSha": "31c93e53c4aa8f9831abdb00516639def985ef34",
+          "harnessSha": "ebdb7f9481901a35ca1e5108fe2a1769bab197e8",
+          "expiresAt": "2026-08-22T00:00:00Z"
         }
       },
       "install_recommendation": false
@@ -398,7 +406,6 @@
           "recordedAt": "2026-07-21T14:25:00Z",
           "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
           "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
-          "hostScope": ["tower2"],
           "expiresAt": "2026-08-21T00:00:00Z"
         },
         "agent_viability": {
@@ -408,7 +415,6 @@
           "recordedAt": "2026-07-21T14:25:00Z",
           "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
           "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
-          "hostScope": ["tower2"],
           "expiresAt": "2026-08-21T00:00:00Z"
         }
       },

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -578,8 +578,18 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 262144
     assert by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
     assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
-    assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["opencode"]["status"] == "unknown"
-    assert all_by_id["falcon-h1-3b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
+        "unsupported_until_revalidated"
+    )
+    assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["agentViability"]["status"] == (
+        "not_agent_viable"
+    )
+    assert all_by_id["falcon-h1-3b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
+        "unsupported_until_revalidated"
+    )
+    assert all_by_id["falcon-h1-3b-instruct-q4"]["appCompatibility"]["agentViability"]["status"] == (
+        "not_agent_viable"
+    )
     assert all_by_id["qwen2.5-coder-1.5b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
     assert all_by_id["phi3-mini-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
     assert all_by_id["granite4.1-3b-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
@@ -591,8 +601,8 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "granite4.0-h-1b-q4" in candidate_ids
     assert "phi4-mini-q4" not in candidate_ids
     assert "gemma3-4b-it-q4" not in candidate_ids
-    assert "falcon-h1-1.5b-instruct-q4" in candidate_ids
-    assert "falcon-h1-3b-instruct-q4" in candidate_ids
+    assert "falcon-h1-1.5b-instruct-q4" not in candidate_ids
+    assert "falcon-h1-3b-instruct-q4" not in candidate_ids
     assert "granite4.1-3b-q4" not in candidate_ids
     assert "granite4.0-h-350m-q4" not in candidate_ids
     assert "granite4.0-1b-q4" not in candidate_ids

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -439,16 +439,21 @@ def test_qwen25_coder_3b_is_not_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["qwen2.5-coder-3b-128k-q4"])
 
 
-def test_falcon_h1_15b_is_not_opencode_agent_viable_until_revalidated():
+def test_falcon_h1_15b_is_not_talk_or_opencode_agent_viable_until_revalidated():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     compatibility = by_id["falcon-h1-1.5b-instruct-q4"]["app_compatibility"]
 
+    assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
+    assert "strixy" in compatibility["hermes_talk"]["reason"]
+    assert "cycle-004" in compatibility["hermes_talk"]["evidence"]
     assert compatibility["opencode"]["status"] == "unsupported_until_revalidated"
     assert "OpenCode" in compatibility["opencode"]["reason"]
     assert "cycle-004" in compatibility["opencode"]["evidence"]
     assert compatibility["agent_viability"]["status"] == "not_agent_viable"
     assert "OpenCode" in compatibility["agent_viability"]["reason"]
+    assert "ODS Talk" in compatibility["agent_viability"]["reason"]
+    assert "hostScope" not in compatibility["agent_viability"]
     assert not _agent_viable_for_release(by_id["falcon-h1-1.5b-instruct-q4"])
 
 
@@ -460,8 +465,10 @@ def test_falcon_h1_3b_is_not_talk_agent_viable_until_revalidated():
     assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
     assert "random_uuid" in compatibility["hermes_talk"]["reason"]
     assert "cycle-004" in compatibility["hermes_talk"]["evidence"]
+    assert "hostScope" not in compatibility["hermes_talk"]
     assert compatibility["agent_viability"]["status"] == "not_agent_viable"
     assert "tool-call payload" in compatibility["agent_viability"]["reason"]
+    assert "hostScope" not in compatibility["agent_viability"]
     assert not _agent_viable_for_release(by_id["falcon-h1-3b-instruct-q4"])
 
 


### PR DESCRIPTION
## Summary
- records Strixy/Lemonade ODS Talk evidence that Falcon H1 1.5B emits a tool-call payload instead of the requested verification phrase
- makes Falcon H1 1.5B and 3B agent-viability blocks apply to release candidate selection until they are revalidated with tool-aware Talk/app probes
- updates catalog/oracle tests so Falcon remains visible in the library but is no longer selected as an agent-required release swap candidate

## Evidence
- fleet-test/runs/2026-07-22T18-45-07Z-model-ui-product-31c93e53c4aa-harness-ebdb7f948190-hosts-strixy-talk-runtime-strict-6cycle/cycle-004/strixy
- Failure: test.load.talk.inference loaded Falcon H1 1.5B successfully, then Talk returned a tool-call payload instead of ODSVAL-...; cleanup restored Qwen and deleted Falcon cleanly.

## Validation
- C:\Users\conta\AppData\Local\Programs\Python\Python313\python.exe -m pytest ods\tests\test-model-library-coverage.py ods\extensions\services\dashboard-api\tests\test_performance_oracle.py -q
- Result: 58 passed