### PR TITLE
fix(perplexica): keep switchboard installs on stable model route

### DIFF
--- a/ods/installers/phases/12-health.sh
+++ b/ods/installers/phases/12-health.sh
@@ -304,6 +304,7 @@ fi
 # (especially if it was stuck in "Created" state and started late).
 if $DOCKER_CMD inspect ods-perplexica &>/dev/null; then
     PERPLEXICA_URL="http://127.0.0.1:${SERVICE_PORTS[perplexica]:-3004}"
+    _perplexica_switchboard_mode="$(printf '%s' "${ODS_MODEL_SWITCHBOARD:-observe}" | tr '[:upper:]' '[:lower:]')"
     PERPLEXICA_MODEL="${LLM_MODEL:-default}"
     if [[ -n "${GGUF_FILE:-}" ]]; then
         PERPLEXICA_MODEL="$GGUF_FILE"
@@ -313,6 +314,10 @@ if $DOCKER_CMD inspect ods-perplexica &>/dev/null; then
         fi
     fi
     PERPLEXICA_LLM_BASE_URL="${LLM_API_URL:-http://llama-server:8080}"
+    if [[ "$_perplexica_switchboard_mode" == "enabled" ]]; then
+        PERPLEXICA_MODEL="ods/current"
+        PERPLEXICA_LLM_BASE_URL="http://litellm:4000/v1"
+    fi
     case "$PERPLEXICA_LLM_BASE_URL" in
         */v1|*/api/v1) ;;
         *) PERPLEXICA_LLM_BASE_URL="${PERPLEXICA_LLM_BASE_URL%/}/v1" ;;

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -2227,6 +2227,11 @@ if (Test-ODSWindowsServiceEnabled -ServiceId "perplexica" -Plan $servicePlan) {
         -UseLemonade:$useLemonade -GpuBackend $gpuInfo.Backend -CloudMode:$cloudMode
     $activeModel = Get-WindowsActiveModelSelection -EnvMap $windowsEnvMap `
         -DefaultGgufFile $tierConfig.GgufFile -DefaultModelName $tierConfig.LlmModel
+    $switchboardMode = ""
+    if ($windowsEnvMap.ContainsKey("ODS_MODEL_SWITCHBOARD")) {
+        $switchboardMode = [string]$windowsEnvMap["ODS_MODEL_SWITCHBOARD"]
+    }
+    $switchboardMode = $switchboardMode.Trim().ToLowerInvariant()
     $perplexicaModel = $(if ($activeModel.GgufFile) {
         if ($useLemonade -and -not [string]::IsNullOrWhiteSpace($lemonadeModel)) {
             $lemonadeModel
@@ -2236,6 +2241,9 @@ if (Test-ODSWindowsServiceEnabled -ServiceId "perplexica" -Plan $servicePlan) {
     } else {
         $activeModel.LlmModel
     })
+    if ($switchboardMode -eq "enabled") {
+        $perplexicaModel = "ods/current"
+    }
     $perplexicaBaseUrl = $(if ($useLemonade -or $cloudMode) {
         "http://litellm:4000/v1"
     } elseif ([string]$llmEndpoint["Backend"] -eq "native-llama-server") {
@@ -2243,8 +2251,11 @@ if (Test-ODSWindowsServiceEnabled -ServiceId "perplexica" -Plan $servicePlan) {
     } else {
         "http://llama-server:8080/v1"
     })
+    if ($switchboardMode -eq "enabled") {
+        $perplexicaBaseUrl = "http://litellm:4000/v1"
+    }
     $perplexicaApiKey = "no-key"
-    if (($useLemonade -or $cloudMode) -and $windowsEnvMap.ContainsKey("LITELLM_KEY") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["LITELLM_KEY"])) {
+    if (($useLemonade -or $cloudMode -or $switchboardMode -eq "enabled") -and $windowsEnvMap.ContainsKey("LITELLM_KEY") -and -not [string]::IsNullOrWhiteSpace($windowsEnvMap["LITELLM_KEY"])) {
         $perplexicaApiKey = $windowsEnvMap["LITELLM_KEY"]
     }
     $perplexicaOk = Set-PerplexicaConfig -PerplexicaPort 3004 -LlmModel $perplexicaModel -LlmBaseUrl $perplexicaBaseUrl -ApiKey $perplexicaApiKey

--- a/ods/scripts/repair/repair-perplexica.sh
+++ b/ods/scripts/repair/repair-perplexica.sh
@@ -9,6 +9,12 @@ LLM_MODEL="${2:-qwen3-30b-a3b}"
 PERPLEXICA_MODEL="${PERPLEXICA_MODEL:-}"
 PERPLEXICA_LLM_BASE_URL="${PERPLEXICA_LLM_BASE_URL:-${LLM_API_URL:-http://llama-server:8080}}"
 PERPLEXICA_API_KEY="${PERPLEXICA_API_KEY:-${LITELLM_KEY:-${OPENAI_API_KEY:-no-key}}}"
+_perplexica_switchboard_mode="$(printf '%s' "${ODS_MODEL_SWITCHBOARD:-observe}" | tr '[:upper:]' '[:lower:]')"
+if [[ "$_perplexica_switchboard_mode" == "enabled" ]]; then
+    : "${PERPLEXICA_MODEL:=ods/current}"
+    PERPLEXICA_LLM_BASE_URL="http://litellm:4000/v1"
+    PERPLEXICA_API_KEY="${LITELLM_KEY:-${OPENAI_API_KEY:-no-key}}"
+fi
 case "$PERPLEXICA_LLM_BASE_URL" in
     */v1|*/api/v1) ;;
     *) PERPLEXICA_LLM_BASE_URL="${PERPLEXICA_LLM_BASE_URL%/}/v1" ;;

--- a/ods/tests/contracts/test-windows-llm-model-readiness.sh
+++ b/ods/tests/contracts/test-windows-llm-model-readiness.sh
@@ -90,6 +90,14 @@ if awk '/Configuring Perplexica/{f=1} f&&/Set-PerplexicaConfig/{print; exit}' "$
 else
     fail "Perplexica configuration must use refreshed active model selection"
 fi
+perplexica_config_block="$(awk '/Configuring Perplexica/{f=1} f{print} f&&/Set-PerplexicaConfig/{exit}' "$INSTALLER")"
+if grep -q 'ODS_MODEL_SWITCHBOARD' <<<"$perplexica_config_block" \
+    && grep -q '\$perplexicaModel = "ods/current"' <<<"$perplexica_config_block" \
+    && grep -q '\$perplexicaBaseUrl = "http://litellm:4000/v1"' <<<"$perplexica_config_block"; then
+    pass "Perplexica configuration keeps switchboard installs on the stable alias"
+else
+    fail "Perplexica switchboard installs must configure ods/current through LiteLLM"
+fi
 if grep -Eq 'model\s*=\s*\$activeModel\.LlmModel' "$INSTALLER"; then
     pass "summary JSON records the active env model"
 else

--- a/ods/tests/test-installer-context-parity.sh
+++ b/ods/tests/test-installer-context-parity.sh
@@ -141,6 +141,22 @@ assert_grep "installers/macos/install-macos.sh" 'PERPLEXICA_MODEL="ods/current"'
     "macOS Perplexica config uses stable switchboard alias"
 assert_grep "installers/macos/install-macos.sh" 'PERPLEXICA_BASE_URL="http://litellm:4000"' \
     "macOS Perplexica config routes switchboard mode through LiteLLM"
+assert_grep "installers/phases/12-health.sh" 'ODS_MODEL_SWITCHBOARD' \
+    "Linux Perplexica config reads switchboard mode"
+assert_grep "installers/phases/12-health.sh" 'PERPLEXICA_MODEL="ods/current"' \
+    "Linux Perplexica config uses stable switchboard alias"
+assert_grep "installers/phases/12-health.sh" 'PERPLEXICA_LLM_BASE_URL="http://litellm:4000/v1"' \
+    "Linux Perplexica config routes switchboard mode through LiteLLM"
+assert_grep "installers/windows/install-windows.ps1" 'ODS_MODEL_SWITCHBOARD' \
+    "Windows Perplexica config reads switchboard mode"
+assert_grep "installers/windows/install-windows.ps1" '\$perplexicaModel = "ods/current"' \
+    "Windows Perplexica config uses stable switchboard alias"
+assert_grep "installers/windows/install-windows.ps1" '\$perplexicaBaseUrl = "http://litellm:4000/v1"' \
+    "Windows Perplexica config routes switchboard mode through LiteLLM"
+assert_grep "scripts/repair/repair-perplexica.sh" 'ODS_MODEL_SWITCHBOARD' \
+    "Perplexica repair reads switchboard mode"
+assert_grep "scripts/repair/repair-perplexica.sh" 'PERPLEXICA_MODEL:=ods/current' \
+    "Perplexica repair uses stable switchboard alias"
 assert_not_grep "installers/macos/install-macos.sh" '\$LOG_FILE' \
     "macOS installer uses ODS_LOG_FILE, not undefined LOG_FILE"
 assert_grep "installers/windows/install-windows.ps1" 'Update-HermesConfigFile.*ContextLength \(\[int\]\$tierConfig\.MaxContext\)' \

--- a/ods/tests/test-perplexica-entrypoint.py
+++ b/ods/tests/test-perplexica-entrypoint.py
@@ -191,6 +191,85 @@ def test_sync_script_persists_exact_lemonade_route() -> None:
     assert state["preferences"]["defaultChatModel"] == "Modern-Model"
 
 
+def test_sync_script_uses_stable_alias_when_switchboard_enabled() -> None:
+    node = _node_cmd_or_skip()
+    if node is None:
+        return
+
+    state = {
+        "modelProviders": [{
+            "id": "openai-provider",
+            "type": "openai",
+            "chatModels": [{"key": "Qwen3.5-2B-Q4_K_M", "name": "Qwen3.5-2B-Q4_K_M"}],
+            "config": {"baseURL": "http://litellm:4000/v1", "apiKey": "old-key"},
+        }],
+        "preferences": {
+            "defaultChatModel": "Qwen3.5-2B-Q4_K_M",
+            "defaultChatProvider": "openai-provider",
+        },
+    }
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            body = json.dumps({"values": state}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", "0"))
+            payload = json.loads(self.rfile.read(length))
+            state[payload["key"]] = payload["value"]
+            body = b"{}"
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, _format, *_args):
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        env = os.environ.copy()
+        env.update({
+            "PERPLEXICA_CONFIG_URL": f"http://127.0.0.1:{server.server_port}/api/config",
+            "ODS_MODEL_SWITCHBOARD": "enabled",
+            "ODS_MODE": "lemonade",
+            "AMD_INFERENCE_RUNTIME": "lemonade",
+            "LEMONADE_MODEL": "Qwen3.5-2B-Q4_K_M",
+            "GGUF_FILE": "Qwen3.5-2B-Q4_K_M.gguf",
+            "OPENAI_BASE_URL": "http://litellm:4000",
+            "OPENAI_API_KEY": "litellm-key",
+        })
+        result = subprocess.run(
+            [node, str(SYNC_SCRIPT)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ods/current"
+    provider = state["modelProviders"][0]
+    assert provider["chatModels"] == [{"key": "ods/current", "name": "ods/current"}]
+    assert provider["config"] == {
+        "baseURL": "http://litellm:4000/v1",
+        "apiKey": "litellm-key",
+    }
+    assert state["preferences"]["defaultChatModel"] == "ods/current"
+
+
 def test_sync_script_falls_back_to_extra_gguf_when_exact_lemonade_id_is_absent() -> None:
     node = _node_cmd_or_skip()
     if node is None:
@@ -341,5 +420,6 @@ if __name__ == "__main__":
     test_entrypoint_falls_back_to_node_server_when_no_args()
     test_entrypoint_reconciles_persisted_model_route_on_every_start()
     test_sync_script_persists_exact_lemonade_route()
+    test_sync_script_uses_stable_alias_when_switchboard_enabled()
     test_sync_script_falls_back_to_extra_gguf_when_exact_lemonade_id_is_absent()
     test_sync_script_normalizes_base_url_without_v1_suffix()


### PR DESCRIPTION
## Summary
- keep Perplexica first-install configuration on \\ods/current\\ when ODS_MODEL_SWITCHBOARD=enabled
- route switchboard Perplexica through LiteLLM on Windows and Linux install paths
- make \\ods repair perplexica\\ preserve the stable switchboard alias by default
- add regression coverage for Windows/Linux installer guards and Perplexica startup sync

## Evidence
Strixy switchboard-enabled install had LiteLLM/Open WebUI correctly routed, but Perplexica /api/config still reported defaultChatModel=Qwen3.5-2B-Q4_K_M after install. Running the container sync manually changed it to ods/current, proving the API path works and the installer path was reverting it after startup.

## Validation
- \\python -m pytest ods/tests/test-perplexica-entrypoint.py ods/tests/test-render-runtime-configs.py\\ -> 25 passed
- \\sh -n installers/phases/12-health.sh scripts/repair/repair-perplexica.sh tests/contracts/test-windows-llm-model-readiness.sh tests/test-installer-context-parity.sh\\ -> passed
- \\	ests/contracts/test-windows-llm-model-readiness.sh\\ -> 14 passed, 0 failed

Note: local Git Bash cannot access the Windows Python install path in this sandbox, so test-installer-context-parity.sh reached its Python-dependent section and failed only at Python discovery after all new static switchboard assertions passed. CI/Tower2 should cover the full shell environment.