### PR TITLE
fix(models): block Granite 3.1 from Perplexica release coverage

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -594,13 +594,12 @@
         "perplexica": {
           "status": "unsupported_until_revalidated",
           "label": "Perplexica revalidation required",
-          "reason": "Fleet model-UI run 2026-07-21T08:59Z on tower2 loaded this model and ODS Talk, LiteLLM, Open WebUI, and OpenCode passed, but the Perplexica app probe answered with prose/search-style content instead of the requested verification phrase; keep it out of all-app release coverage until Perplexica compatibility is revalidated.",
-          "evidence": "fleet-test/runs/2026-07-21T08-59-51Z-targeted-granite31-allapps-product-73762173ae0c-harness-ecd8157a6324-hosts-tower2/cycle-001/tower2",
-          "recordedAt": "2026-07-21T08:59:51Z",
-          "productSha": "73762173ae0c",
-          "harnessSha": "ecd8157a6324",
-          "hostScope": ["tower2"],
-          "expiresAt": "2026-08-21T00:00:00Z"
+          "reason": "Fleet model-UI runs on tower2 and strixy loaded this model and ODS Talk, LiteLLM, Open WebUI, and OpenCode passed where deployed, but the Perplexica app probe answered with prose/search-style content instead of the requested verification phrase; keep it out of all-app release coverage until Perplexica compatibility is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-21T08-59-51Z-targeted-granite31-allapps-product-73762173ae0c-harness-ecd8157a6324-hosts-tower2/cycle-001/tower2; fleet-test/runs/2026-07-22T21-13-08Z-model-ui-product-39164d8c5bc3-harness-18e2bd60437f-hosts-strixy-switchboard-enabled-6cycle/cycle-006/strixy",
+          "recordedAt": "2026-07-22T22:21:04Z",
+          "productSha": "39164d8c5bc3306dd4e7ac3e884dcc8574b9930a",
+          "harnessSha": "18e2bd60437f4e5ba7b3cd461a37d99ab524ef6a",
+          "expiresAt": "2026-08-22T00:00:00Z"
         }
       },
       "install_recommendation": false

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -595,9 +595,11 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert all_by_id["granite4.1-3b-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"
     )
-    assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == "unknown"
+    assert all_by_id["granite3.1-2b-instruct-q4"]["appCompatibility"]["perplexica"]["status"] == (
+        "unsupported_until_revalidated"
+    )
     assert all_by_id["granite4.0-h-1b-q4"]["appCompatibility"]["perplexica"]["status"] == "unknown"
-    assert "granite3.1-2b-instruct-q4" in candidate_ids
+    assert "granite3.1-2b-instruct-q4" not in candidate_ids
     assert "granite4.0-h-1b-q4" in candidate_ids
     assert "phi4-mini-q4" not in candidate_ids
     assert "gemma3-4b-it-q4" not in candidate_ids

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -250,6 +250,21 @@ def test_smollm3_3b_is_not_agent_viable_until_app_revalidated():
     assert not _agent_viable_for_release(by_id["smollm3-3b-q4"])
 
 
+def test_granite31_requires_global_perplexica_revalidation_after_strixy_failure():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+
+    model = by_id["granite3.1-2b-instruct-q4"]
+    compatibility = model["app_compatibility"]["perplexica"]
+
+    assert compatibility["status"] == "unsupported_until_revalidated"
+    assert "hostScope" not in compatibility
+    assert "tower2" in compatibility["reason"]
+    assert "strixy" in compatibility["reason"]
+    assert "cycle-006/strixy" in compatibility["evidence"]
+    assert not _agent_viable_for_release(model)
+
+
 def test_granite4_h_1b_requires_perplexica_revalidation_after_m5_partial_reply():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}


### PR DESCRIPTION
## Summary
- makes Granite 3.1 2B's Perplexica `unsupported_until_revalidated` block global instead of tower2-scoped
- records the new Strixy cycle-006 failure evidence from the current main SHA model-UI run
- updates the dashboard-api release candidate test so Granite 3.1 is not selected while Perplexica remains required

## Validation
- `python3 -m pytest ods/extensions/services/dashboard-api/tests/test_performance_oracle.py ods/tests/test-model-library-coverage.py` (59 passed)

## Fleet evidence
- Current Strixy six-cycle run reached 5/6 green, then failed cycle 6 only on Perplexica for `granite3.1-2b-instruct-q4`; recovery restored/deleted cleanly.
- Run: `/home/michael/dream-fleet-test/runs/2026-07-22T21-13-08Z-model-ui-product-39164d8c5bc3-harness-18e2bd60437f-hosts-strixy-switchboard-enabled-6cycle/cycle-006/strixy`
