### PR TITLE
fix(models): block Phi-3 from Perplexica coverage

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -632,6 +632,16 @@
           "hostScope": ["tower2"],
           "expiresAt": "2026-08-21T00:00:00Z"
         },
+        "perplexica": {
+          "status": "unsupported_until_revalidated",
+          "label": "Perplexica revalidation required",
+          "reason": "Strixy browser model-UI coverage loaded Phi-3 Mini 128K and passed ODS Talk, LiteLLM, and Open WebUI, but the Perplexica HTTP 200 reply began with apology prose and omitted the requested verification phrase; keep it out of all-app release coverage until Perplexica compatibility is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-23T01-27-32Z-model-ui-product-98d5a50cd5b5-harness-18e2bd60437f-hosts-strixy-switchboard-enabled-6cycle-rerun/cycle-006/strixy",
+          "recordedAt": "2026-07-23T02:25:29Z",
+          "productSha": "98d5a50cd5b527cb8dbd6117ba2d158538b73a9e",
+          "harnessSha": "18e2bd60437f4e5ba7b3cd461a37d99ab524ef6a",
+          "expiresAt": "2026-08-23T00:00:00Z"
+        },
         "agent_viability": {
           "status": "not_agent_viable",
           "reason": "ODS Talk release probe failed exact verification after successful Phi-3 Mini 128K load; not agent-viable until a Talk revalidation passes.",

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -592,6 +592,9 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     )
     assert all_by_id["qwen2.5-coder-1.5b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
     assert all_by_id["phi3-mini-128k-q4"]["appCompatibility"]["hermesTalk"]["status"] == "unknown"
+    assert all_by_id["phi3-mini-128k-q4"]["appCompatibility"]["perplexica"]["status"] == (
+        "unsupported_until_revalidated"
+    )
     assert all_by_id["granite4.1-3b-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"
     )
@@ -608,7 +611,7 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "granite4.1-3b-q4" not in candidate_ids
     assert "granite4.0-h-350m-q4" not in candidate_ids
     assert "granite4.0-1b-q4" not in candidate_ids
-    assert "phi3-mini-128k-q4" in candidate_ids
+    assert "phi3-mini-128k-q4" not in candidate_ids
     assert "granite3.3-8b-instruct-q4" not in candidate_ids
     assert "smollm3-3b-q4" not in candidate_ids
     assert "qwen2.5-3b-instruct-q4" not in candidate_ids

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -152,7 +152,7 @@ def test_phi4_mini_is_not_agent_viable_after_strixy_talk_probe_failure():
     assert not _agent_viable_for_release(by_id["phi4-mini-q4"])
 
 
-def test_phi3_mini_128k_is_not_agent_viable_after_tower2_talk_probe_failure():
+def test_phi3_mini_128k_requires_perplexica_revalidation_after_strixy_failure():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     compatibility = by_id["phi3-mini-128k-q4"]["app_compatibility"]
@@ -162,6 +162,11 @@ def test_phi3_mini_128k_is_not_agent_viable_after_tower2_talk_probe_failure():
     assert "cycle-006" in compatibility["agent_viability"]["evidence"]
     assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
     assert "generic assistant greeting" in compatibility["hermes_talk"]["reason"]
+    assert compatibility["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert "hostScope" not in compatibility["perplexica"]
+    assert "strixy" in compatibility["perplexica"]["reason"].lower()
+    assert "apology prose" in compatibility["perplexica"]["reason"]
+    assert "cycle-006/strixy" in compatibility["perplexica"]["evidence"]
     assert not _agent_viable_for_release(by_id["phi3-mini-128k-q4"])
 
 


### PR DESCRIPTION
## What

- mark `phi3-mini-128k-q4` as globally unsupported for Perplexica until revalidated
- exclude it from all-application release candidate planning
- add focused catalog and performance-oracle regression coverage

## Why

Strixy browser-driven model UI validation loaded Phi-3 Mini 128K successfully and passed ODS Talk, LiteLLM, and Open WebUI. Perplexica routed through `ods/current` to the correct Phi-3 target and returned HTTP 200, but its reply began with apology prose and omitted the exact verification phrase. The model therefore is not presently viable for all-application release coverage.

This is a product catalog/planner defect, not validator leniency and not the earlier restart wrapper interruption: every real restart in the clean rerun exited 0.

## Evidence

- Product SHA: `98d5a50cd5b527cb8dbd6117ba2d158538b73a9e`
- Harness SHA: `18e2bd60437f4e5ba7b3cd461a37d99ab524ef6a`
- Run: `fleet-test/runs/2026-07-23T01-27-32Z-model-ui-product-98d5a50cd5b5-harness-18e2bd60437f-hosts-strixy-switchboard-enabled-6cycle-rerun/cycle-006/strixy`

## Tests

- `jq empty ods/config/model-library.json`
- `python3 -m pytest -q ods/tests/test-model-library-coverage.py ods/extensions/services/dashboard-api/tests/test_performance_oracle.py`
- Result: `59 passed`
