### PR TITLE
fix(dashboard): guard missing llama-server in cloud mode

### DIFF
--- a/ods/extensions/services/dashboard-api/helpers.py
+++ b/ods/extensions/services/dashboard-api/helpers.py
@@ -396,6 +396,12 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
                 host_status = await request_agent_json("GET", "/v1/llm/status", timeout=6)
                 stats = host_status.get("stats")
             else:
+                if "llama-server" not in SERVICES:
+                    return {
+                        "tokens_per_second": 0,
+                        "lifetime_tokens": 0,
+                        "token_count_mode": "unavailable",
+                    }
                 host = SERVICES["llama-server"]["host"]
                 port = SERVICES["llama-server"]["port"]
                 client = await _get_httpx_client()
@@ -435,6 +441,13 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
                 # polling cannot truthfully construct a lifetime total.
                 "lifetime_tokens": output_tokens,
                 "token_count_mode": "latest_completion",
+            }
+
+        if "llama-server" not in SERVICES:
+            return {
+                "tokens_per_second": 0,
+                "lifetime_tokens": _get_lifetime_tokens(),
+                "token_count_mode": "cumulative",
             }
 
         host = SERVICES["llama-server"]["host"]
@@ -497,7 +510,7 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
             "lifetime_tokens": lifetime,
             "token_count_mode": "cumulative",
         }
-    except (AgentClientError, httpx.HTTPError, httpx.TimeoutException, OSError, ValueError) as e:
+    except (AgentClientError, httpx.HTTPError, httpx.TimeoutException, OSError, ValueError, KeyError) as e:
         logger.warning("get_llama_metrics failed: %s: %s", type(e).__name__, e)
         if LLM_BACKEND == "lemonade":
             return {
@@ -514,6 +527,8 @@ async def get_llama_metrics(model_hint: Optional[str] = None) -> dict:
 
 async def get_loaded_model() -> Optional[str]:
     """Query llama-server for actually loaded model name."""
+    if "llama-server" not in SERVICES:
+        return None
     try:
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
@@ -536,7 +551,7 @@ async def get_loaded_model() -> Optional[str]:
                 return m.get("id")
         if models:
             return models[0].get("id")
-    except (httpx.HTTPError, httpx.TimeoutException, ValueError) as e:
+    except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as e:
         logger.debug("get_loaded_model failed: %s", e)
     return None
 
@@ -547,6 +562,8 @@ async def get_llama_context_size(model_hint: Optional[str] = None) -> Optional[i
     Accepts an optional *model_hint* to skip the redundant
     ``get_loaded_model()`` call when the caller already has it.
     """
+    if "llama-server" not in SERVICES:
+        return None
     try:
         host = SERVICES["llama-server"]["host"]
         port = SERVICES["llama-server"]["port"]
@@ -558,7 +575,7 @@ async def get_llama_context_size(model_hint: Optional[str] = None) -> Optional[i
         resp = await client.get(url)
         n_ctx = resp.json().get("default_generation_settings", {}).get("n_ctx")
         return int(n_ctx) if n_ctx else None
-    except (httpx.HTTPError, httpx.TimeoutException, ValueError) as e:
+    except (httpx.HTTPError, httpx.TimeoutException, ValueError, KeyError) as e:
         logger.debug("get_llama_context_size failed: %s", e)
         return None
 

--- a/ods/extensions/services/dashboard-api/tests/test_helpers.py
+++ b/ods/extensions/services/dashboard-api/tests/test_helpers.py
@@ -643,11 +643,24 @@ class TestGetLlamaMetrics:
         assert helpers._get_lifetime_tokens() == 100
         assert json.loads(helpers._TOKEN_FILE.read_text())["last_server_counter"] == 100
 
+    @pytest.mark.asyncio
+    async def test_returns_fallback_when_llama_server_not_in_services(self, monkeypatch):
+        monkeypatch.setattr("helpers.SERVICES", {})
+        result = await get_llama_metrics(model_hint="test-model")
+        assert result["tokens_per_second"] == 0
+        assert result["token_count_mode"] == "cumulative"
+
 
 # --- get_loaded_model ---
 
 
 class TestGetLoadedModel:
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_llama_server_not_in_services(self, monkeypatch):
+        monkeypatch.setattr("helpers.SERVICES", {})
+        result = await get_loaded_model()
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_model_with_loaded_status(self, monkeypatch):
@@ -720,6 +733,12 @@ class TestGetLoadedModel:
 
 
 class TestGetLlamaContextSize:
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_llama_server_not_in_services(self, monkeypatch):
+        monkeypatch.setattr("helpers.SERVICES", {})
+        result = await get_llama_context_size(model_hint="test-model")
+        assert result is None
 
     @pytest.mark.asyncio
     async def test_returns_n_ctx(self, monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #1994 by preventing the Dashboard API from failing in cloud-mode deployments where `llama-server` is intentionally absent.

Previously, several helper functions in `ods/extensions/services/dashboard-api/helpers.py` assumed that `llama-server` was always registered in the `SERVICES` registry and accessed it directly using `SERVICES["llama-server"]`. While this assumption is valid for local deployments, it is not true in cloud mode (`./install.sh --cloud`), where `llama-server` is not deployed.

As a result, requests to `/api/status` triggered uncaught `KeyError: 'llama-server'` exceptions when the Dashboard API attempted to retrieve model information, context size, or runtime metrics. The exception propagated through the status endpoint, causing it to return **HTTP 500**. Consequently, the dashboard failed to load telemetry correctly and remained stuck displaying **"Waiting for telemetry..."**, with all services appearing inactive despite the deployment functioning normally.

This change updates the helper functions to safely handle deployments where `llama-server` is not present:

- **`get_loaded_model()`**
  - Returns `None` immediately when `"llama-server"` is not registered in `SERVICES`.
  - Extends exception handling to include `KeyError` in addition to the existing failure paths.

- **`get_llama_context_size()`**
  - Returns `None` when `"llama-server"` is unavailable.
  - Adds `KeyError` to the handled exception list.

- **`get_llama_metrics()`**
  - Returns the standard fallback metrics dictionary when `"llama-server"` is absent (unless Lemonade host inference is active).
  - The fallback preserves the expected response structure, including:
    - `tokens_per_second: 0`
    - `lifetime_tokens`
    - `token_count_mode: "cumulative"`
  - Adds `KeyError` to the handled exception list.

These changes preserve the existing behavior for deployments that include `llama-server` while allowing cloud-mode installations to continue serving telemetry and dashboard status without errors.

## Verification

Added regression coverage in `ods/extensions/services/dashboard-api/tests/test_helpers.py` to validate the missing `llama-server` code paths.

The new tests verify:

- `get_loaded_model()` safely returns `None` when `llama-server` is not registered.
- `get_llama_context_size()` safely returns `None` when `llama-server` is not registered.
- `get_llama_metrics()` returns the expected fallback metrics dictionary instead of raising an exception.

### Test Results

- `python3 -m pytest -v ods/extensions/services/dashboard-api/tests/test_helpers.py`
  - **101 passed**

- `python3 -m pytest -v ods/extensions/services/dashboard-api/tests/test_main.py`
  - **70 passed**

The changes were committed as:

```
fix(dashboard): guard llama-server service lookups in cloud mode (#1994)
```

Commit: `0fc00592`