### PR TITLE
fix(models): isolate activation from route proof warmups

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -304,6 +304,7 @@ _model_activation_target: str | None = None
 _model_status_verify_thread: threading.Thread | None = None
 _switchboard_initial_verify_lock = threading.Lock()
 _switchboard_initial_verify_thread: threading.Thread | None = None
+_switchboard_initial_verify_cancel = threading.Event()
 # Update lock/state: only one background ods-update run at a time.
 _update_lock = threading.Lock()
 _update_status_lock = threading.Lock()
@@ -379,6 +380,16 @@ def _model_lifecycle_status() -> dict:
     return payload
 
 
+def _prepare_initial_switchboard_verification() -> bool:
+    """Reset route-proof cancellation only while no lifecycle owner exists."""
+    with _model_lifecycle_state_lock:
+        if _model_lifecycle_operation:
+            _switchboard_initial_verify_cancel.set()
+            return False
+        _switchboard_initial_verify_cancel.clear()
+        return True
+
+
 def _begin_model_activation(model_id: str) -> tuple[bool, str | None]:
     """Atomically acquire activation ownership and publish its target."""
     global _model_activation_target
@@ -386,6 +397,10 @@ def _begin_model_activation(model_id: str) -> tuple[bool, str | None]:
     if not acquired:
         active_target = active.get("target")
         return False, active_target if active.get("operation") == "model_activation" else None
+    # Initial route reconstruction is observational work. Once an explicit
+    # activation owns the lifecycle it must stop probing/warming the previous
+    # route, or those requests can race and starve the selected model load.
+    _switchboard_initial_verify_cancel.set()
     with _model_lifecycle_state_lock:
         _model_activation_target = model_id
         return True, model_id
@@ -995,6 +1010,12 @@ def _publish_verified_initial_switchboard_route(
     """Promote current .env route only after runtime proof succeeds."""
     if _switchboard_state is None:
         return False
+    if not _prepare_initial_switchboard_verification():
+        logger.info(
+            "switchboard initial route proof deferred (%s; model lifecycle active)",
+            reason,
+        )
+        return False
     state_path = _switchboard_state_path()
     env = load_env(INSTALL_DIR / ".env")
     if not _switchboard_state_needs_current_env_verification(state_path, env):
@@ -1021,6 +1042,7 @@ def _publish_verified_initial_switchboard_route(
         initial_delay=initial_delay,
         interval=interval,
         return_proof=True,
+        cancel_event=_switchboard_initial_verify_cancel,
     )
     if not isinstance(proof, dict) or not proof.get("identity"):
         logger.info("switchboard initial route proof deferred (%s)", reason)
@@ -1125,21 +1147,18 @@ def _model_status_allows_route_proof(data: dict) -> bool:
 def _verify_switchboard_route_for_status(data: dict, reason: str) -> None:
     if _switchboard_state is None:
         return
+    if _model_lifecycle_status():
+        _switchboard_initial_verify_cancel.set()
+        return
     state_path = _switchboard_state_path()
     if not _switchboard_state_needs_current_env_verification(state_path):
         return
     if _model_status_allows_route_proof(data):
-        try:
-            if _publish_verified_initial_switchboard_route(
-                reason=reason,
-                attempts=1,
-                initial_delay=0,
-                interval=0,
-            ):
-                return
-        except Exception as exc:
-            logger.warning("switchboard route status proof failed: %s", exc)
-    _schedule_initial_switchboard_verification(reason)
+        # A read-only status request must never perform a potentially 30-second
+        # Lemonade warm-up inline. The single background worker de-duplicates
+        # concurrent dashboard polls and is cancelled by explicit lifecycle
+        # operations.
+        _schedule_initial_switchboard_verification(reason)
 
 
 def _atomic_write_bytes(
@@ -7646,6 +7665,7 @@ def _wait_for_model_readiness(
     interval: float = 5,
     return_identity: bool = False,
     return_proof: bool = False,
+    cancel_event: threading.Event | None = None,
 ) -> bool | str | dict[str, object]:
     """Prove exact runtime identity and one matching meaningful completion.
 
@@ -7687,9 +7707,20 @@ def _wait_for_model_readiness(
 
     logger.info("Waiting for requested model identity %s at %s", gguf_file, identity_url)
     warmup_sent = False
+    if cancel_event is not None and cancel_event.is_set():
+        logger.info("Model readiness cancelled before probing %s", gguf_file)
+        return {} if return_proof else "" if return_identity else False
     if initial_delay > 0:
-        time.sleep(initial_delay)
+        if cancel_event is not None:
+            if cancel_event.wait(initial_delay):
+                logger.info("Model readiness cancelled before probing %s", gguf_file)
+                return {} if return_proof else "" if return_identity else False
+        else:
+            time.sleep(initial_delay)
     for attempt in range(max(1, attempts)):
+        if cancel_event is not None and cancel_event.is_set():
+            logger.info("Model readiness cancelled while probing %s", gguf_file)
+            return {} if return_proof else "" if return_identity else False
         runtime_identity = ""
         runtime_context = 0
         try:
@@ -7768,7 +7799,12 @@ def _wait_for_model_readiness(
             if attempt % 6 == 0:
                 logger.info("Model readiness attempt %d timed out", attempt + 1)
         if attempt + 1 < attempts and interval > 0:
-            time.sleep(interval)
+            if cancel_event is not None:
+                if cancel_event.wait(interval):
+                    logger.info("Model readiness cancelled while probing %s", gguf_file)
+                    return {} if return_proof else "" if return_identity else False
+            else:
+                time.sleep(interval)
     if return_proof:
         return {}
     return "" if return_identity else False

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -4672,7 +4672,7 @@ class TestModelDownloadFileIntegrity:
         persisted = json.loads(status_path.read_text(encoding="utf-8"))
         assert persisted["status"] == "failed"
 
-    def test_model_status_promotes_stale_bootstrap_route_after_full_model_ready(
+    def test_model_status_schedules_stale_bootstrap_route_proof_without_inline_warmup(
         self, tmp_path, monkeypatch,
     ):
         bootstrap_model = {
@@ -4749,20 +4749,17 @@ class TestModelDownloadFileIntegrity:
 
         assert handler.response_code == 200
         assert handler.parse_response() == {"status": "idle"}
-        assert readiness_calls
-        assert readiness_calls[0]["attempts"] == 1
-        assert readiness_calls[0]["initial_delay"] == 0
-        assert readiness_calls[0]["interval"] == 0
-        assert scheduled == []
+        assert readiness_calls == []
+        assert scheduled == ["model-status"]
         doc = json.loads(state_path.read_text(encoding="utf-8"))
-        assert doc["active"]["catalogId"] == "qwen3-coder-next"
-        assert doc["active"]["runtimeModelId"] == "qwen3-coder-next-Q4_K_M.gguf"
-        assert doc["active"]["contextLength"] == 131072
+        assert doc["active"]["catalogId"] == "qwen3.5-2b-q4"
+        assert doc["active"]["runtimeModelId"] == "Qwen3.5-2B-Q4_K_M.gguf"
+        assert doc["active"]["contextLength"] == 65536
         assert doc["active"]["proof"] == {
-            "identity": "qwen3-coder-next-Q4_K_M.gguf",
+            "identity": "Qwen3.5-2B-Q4_K_M.gguf",
             "completion": True,
         }
-        assert doc["history"][0]["runtimeModelId"] == "Qwen3.5-2B-Q4_K_M.gguf"
+        assert doc["history"] == []
 
     def test_empty_finished_download_is_failed_not_complete(self, tmp_path, monkeypatch):
         install_dir = self._setup_env(tmp_path, monkeypatch)

--- a/ods/extensions/services/dashboard-api/tests/test_model_state.py
+++ b/ods/extensions/services/dashboard-api/tests/test_model_state.py
@@ -442,3 +442,65 @@ class TestObserveHook:
             reason="test", attempts=1, initial_delay=0, interval=0
         ) is False
         assert state_path.read_text(encoding="utf-8") == before
+
+    def test_initial_route_proof_defers_during_model_activation(
+        self, tmp_path, monkeypatch
+    ):
+        import test_model_activate as tma
+
+        install_dir = tma._write_model_activation_fixture(tmp_path)[0]
+        state_path = install_dir / "data" / "model-state.json"
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        sb.initialize_if_missing(state_path, tma._mod.load_env(install_dir / ".env"))
+        monkeypatch.setattr(
+            tma._mod,
+            "_wait_for_model_readiness",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("active lifecycle reached initial route readiness")
+            ),
+        )
+        monkeypatch.setattr(
+            tma._mod,
+            "_switchboard_initial_verify_cancel",
+            tma._mod.threading.Event(),
+        )
+        monkeypatch.setattr(tma._mod, "_model_lifecycle_operation", "model_activation")
+        monkeypatch.setattr(tma._mod, "_model_lifecycle_target", "target-model")
+
+        assert tma._mod._publish_verified_initial_switchboard_route(
+            reason="test", attempts=1, initial_delay=0, interval=0
+        ) is False
+
+    def test_cancelled_initial_route_readiness_never_warms_lemonade(
+        self, tmp_path, monkeypatch
+    ):
+        import test_model_activate as tma
+
+        install_dir = tma._write_model_activation_fixture(tmp_path)[0]
+        monkeypatch.setattr(tma._mod, "INSTALL_DIR", install_dir)
+        monkeypatch.setattr(
+            tma._mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("cancelled readiness reached a runtime probe")
+            ),
+        )
+        cancel_event = tma._mod.threading.Event()
+        cancel_event.set()
+
+        assert tma._mod._wait_for_model_readiness(
+            {
+                "GPU_BACKEND": "amd",
+                "AMD_INFERENCE_LOCATION": "host",
+                "AMD_INFERENCE_PORT": "8080",
+            },
+            model_id="qwen3-4b-instruct-2507-q4",
+            gguf_file="Qwen3-4B-Instruct-2507-Q4_K_M.gguf",
+            llm_model_name="Qwen3-4B-Instruct-2507-Q4_K_M",
+            lemonade_model_id="Qwen3-4B-Instruct-2507-Q4_K_M",
+            attempts=60,
+            initial_delay=0,
+            interval=5,
+            return_proof=True,
+            cancel_event=cancel_event,
+        ) == {}


### PR DESCRIPTION
## What changed

- cancel background switchboard route reconstruction when an explicit model activation owns the lifecycle
- make the shared readiness wait cancellation-aware, including interruptible initial and retry delays
- move stale-route proof work out of the read-only model-status request and rely on the existing single background worker
- add regressions proving active activation never reaches route-proof readiness and cancelled Lemonade readiness never probes or warms the runtime

## Root cause

On a slow Windows Lemonade swap, dashboard status polling saw staged `.env` state that differed from the last verified switchboard route. Every poll ran an inline one-shot route proof while a long background proof was also active. Those proofs repeatedly sent warm-up completions for the selected model while the real activation transaction was still loading it. The activation's bounded readiness loop then expired, rolled back persistent state, and left Lemonade finishing the selected model asynchronously, producing a live-runtime / `ods/current` split.

## Impact

Status polling is read-only and de-duplicated again. Explicit activation takes priority, stops observational warm-ups promptly, and can complete its own readiness proof before switchboard state is published.

## Validation

- `python -m pytest -q test_model_activate.py test_switchboard_reconciler.py test_models.py test_model_state.py test_host_agent.py` — 507 passed, 5 skipped (Windows)
- isolated Tower2 dashboard environment — 1,747 passed; one unrelated pre-existing Linux-only failure reproduced unchanged at base SHA `dc5f608f80b1632853e30f7c5214ca79d09a682e`
- `python -m py_compile ods/bin/ods-host-agent.py`
- `git diff --check`
