### PR TITLE
fix(models): reconcile bootstrap switchboard route

### DIFF
--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -1126,7 +1126,7 @@ def _schedule_initial_switchboard_verification(reason: str) -> None:
         _switchboard_initial_verify_thread.start()
 
 
-def _bootstrap_status_indicates_complete() -> bool:
+def _bootstrap_status_allows_route_proof() -> bool:
     status_path = INSTALL_DIR / "data" / "bootstrap-status.json"
     try:
         data = json.loads(status_path.read_text(encoding="utf-8"))
@@ -1134,14 +1134,17 @@ def _bootstrap_status_indicates_complete() -> bool:
         return False
     if not isinstance(data, dict):
         return False
-    return str(data.get("status") or "").strip().casefold() == "complete"
+    return str(data.get("status") or "").strip().casefold() in {
+        "swapping",
+        "complete",
+    }
 
 
 def _model_status_allows_route_proof(data: dict) -> bool:
     status = str(data.get("status") or "").strip().casefold()
     if status in {"already_downloaded", "complete"}:
         return True
-    return _bootstrap_status_indicates_complete()
+    return _bootstrap_status_allows_route_proof()
 
 
 def _verify_switchboard_route_for_status(data: dict, reason: str) -> None:

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -4761,6 +4761,36 @@ class TestModelDownloadFileIntegrity:
         }
         assert doc["history"] == []
 
+    def test_model_status_schedules_route_proof_while_bootstrap_swap_is_verifying(
+        self, tmp_path, monkeypatch,
+    ):
+        install_dir = self._setup_env(tmp_path, monkeypatch)
+        (install_dir / "data" / "bootstrap-status.json").write_text(
+            json.dumps({
+                "status": "swapping",
+                "model": "test-model.gguf",
+            }),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            _mod,
+            "_switchboard_state_needs_current_env_verification",
+            lambda _path: True,
+        )
+        scheduled = []
+        monkeypatch.setattr(
+            _mod,
+            "_schedule_initial_switchboard_verification",
+            lambda reason: scheduled.append(reason),
+        )
+
+        handler = _FakeHandler(b"")
+        _mod.AgentHandler._handle_model_status(handler)
+
+        assert handler.response_code == 200
+        assert handler.parse_response() == {"status": "idle"}
+        assert scheduled == ["model-status"]
+
     def test_empty_finished_download_is_failed_not_complete(self, tmp_path, monkeypatch):
         install_dir = self._setup_env(tmp_path, monkeypatch)
         self._patch_curl_download(monkeypatch, b"")

--- a/ods/scripts/bootstrap-upgrade.sh
+++ b/ods/scripts/bootstrap-upgrade.sh
@@ -1581,6 +1581,34 @@ verify_windows_lemonade_downstream_route() {
     return 1
 }
 
+request_windows_switchboard_route_reconciliation() {
+    local switchboard_mode key port
+    switchboard_mode="$(read_env_value ODS_MODEL_SWITCHBOARD | tr '[:upper:]' '[:lower:]')"
+    [[ "$switchboard_mode" == "enabled" ]] || return 0
+
+    key="$(read_env_value ODS_AGENT_KEY)"
+    [[ -n "$key" ]] || key="$(read_env_value DASHBOARD_API_KEY)"
+    if [[ -z "$key" ]]; then
+        log "ERROR: ODS agent key missing; cannot reconcile the promoted switchboard route."
+        return 1
+    fi
+    port="$(read_env_value ODS_AGENT_PORT)"
+    [[ -n "$port" ]] || port="7710"
+
+    # The upgrader is host-native on Windows, so loopback is authoritative.
+    # GET /v1/model/status remains read-only for callers: it schedules the
+    # host agent's single-flight runtime proof, and only that agent may publish
+    # the verified switchboard state.
+    if curl -fsS --max-time 20 \
+        -H "Authorization: Bearer $key" \
+        "http://127.0.0.1:${port}/v1/model/status" >/dev/null 2>&1; then
+        log "Host agent accepted promoted switchboard route reconciliation."
+        return 0
+    fi
+    log "ERROR: Host agent did not accept promoted switchboard route reconciliation."
+    return 1
+}
+
 restart_windows_lemonade_dependents_after_rollback() {
     local dependents_ok=true
     if [[ "$WINDOWS_LEMONADE_LITELLM_PRESENT" == "true" ]]; then
@@ -1677,6 +1705,10 @@ activate_windows_lemonade_full_model() {
     fi
     if ! verify_windows_lemonade_openclaw_model_env "$model_id"; then
         windows_lemonade_swap_failed "OpenClaw recreated with a stale model environment"
+        return 1
+    fi
+    if ! request_windows_switchboard_route_reconciliation; then
+        windows_lemonade_swap_failed "the host agent could not reconcile the promoted switchboard route"
         return 1
     fi
     if ! verify_windows_lemonade_downstream_route "$model_id" "full model route"; then

--- a/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
+++ b/ods/tests/test-bootstrap-upgrade-hotswap-contract.sh
@@ -224,7 +224,16 @@ assert_in_order "$windows_activation_block" "Windows Lemonade activation" \
     'patch_hermes_model_after_swap' \
     'recreate_windows_lemonade_openclaw' \
     'verify_windows_lemonade_openclaw_model_env "$model_id"' \
+    'request_windows_switchboard_route_reconciliation' \
     'verify_windows_lemonade_downstream_route "$model_id" "full model route"'
+
+switchboard_reconcile_block="$(function_block request_windows_switchboard_route_reconciliation | grep -v '^[[:space:]]*#')"
+grep -qF 'ODS_MODEL_SWITCHBOARD' <<<"$switchboard_reconcile_block" \
+    || fail "Windows Lemonade bootstrap reconciliation must be gated by enabled switchboard mode"
+grep -qF '/v1/model/status' <<<"$switchboard_reconcile_block" \
+    || fail "Windows Lemonade bootstrap reconciliation must schedule host-agent route proof"
+grep -qF 'Authorization: Bearer $key' <<<"$switchboard_reconcile_block" \
+    || fail "Windows Lemonade bootstrap reconciliation must authenticate with ODS_AGENT_KEY"
 
 windows_lemonade_block="$(awk '
     /^if \[\[ "\$_windows_lemonade_swap_applies" == "true" \]\]; then/ { in_block=1 }
@@ -313,7 +322,7 @@ assert_in_order "$rollback_block" "Windows Lemonade rollback" \
     'Rollback verified: the previous model completed through the restored downstream route.'
 pass "Windows Lemonade rollback restarts and proves the previous routed model"
 
-for injected_failure in native model-id litellm hermes openclaw openclaw-env route; do
+for injected_failure in native model-id litellm hermes openclaw openclaw-env reconcile route; do
     if ! (
         eval "$windows_activation_block"
         failure_stage="$injected_failure"
@@ -344,6 +353,10 @@ for injected_failure in native model-id litellm hermes openclaw openclaw-env rou
             calls+=(openclaw-env)
             [[ "$failure_stage" != "openclaw-env" ]]
         }
+        request_windows_switchboard_route_reconciliation() {
+            calls+=(reconcile)
+            [[ "$failure_stage" != "reconcile" ]]
+        }
         verify_windows_lemonade_downstream_route() {
             calls+=(route)
             [[ "$failure_stage" != "route" ]]
@@ -368,7 +381,8 @@ for injected_failure in native model-id litellm hermes openclaw openclaw-env rou
             hermes) expected+=(litellm hermes) ;;
             openclaw) expected+=(litellm hermes openclaw) ;;
             openclaw-env) expected+=(litellm hermes openclaw openclaw-env) ;;
-            route) expected+=(litellm hermes openclaw openclaw-env route) ;;
+            reconcile) expected+=(litellm hermes openclaw openclaw-env reconcile) ;;
+            route) expected+=(litellm hermes openclaw openclaw-env reconcile route) ;;
         esac
         expected+=(rollback)
         [[ "${calls[*]}" == "${expected[*]}" ]]


### PR DESCRIPTION
## Summary

- permit single-flight host-agent route proof while bootstrap status is `swapping`
- request authenticated host-agent reconciliation before Windows Lemonade downstream proof
- retain rollback semantics and the stable `ods/current` alias

## Root cause evidence

A fresh switchboard-enabled Strixy install at product `0e9c92b588d2944893c3e777fca00d896733c994` loaded the full Qwen candidate and migrated application configuration, but model-router remained unverified and returned HTTP 503. The bootstrap upgrader waited for downstream routing before its final host-agent notification, while the host agent was the only component allowed to publish verified route state.

## Validation

- full bootstrap hot-swap contract: PASS, including injected reconciliation failure rollback
- broader host-agent/model-state suite: 257 passed, 1 deselected
- the deselected environment-sensitive failure reproduces unchanged on pristine `0e9c92b588d2944893c3e777fca00d896733c994`
- focused new pytest: PASS
- Python compile and Ruff checks: PASS
