### PR TITLE
fix(models): exclude imported models from release selection

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -76,6 +76,10 @@ jobs:
         shell: pwsh
         run: ./tests/test-windows-model-activation.ps1
 
+      - name: Windows Catalog Source Boundary Contract
+        shell: pwsh
+        run: ./tests/test-windows-catalog-selector.ps1
+
       - name: Windows Port Preflight Contract
         shell: pwsh
         run: ./tests/test-windows-port-preflight.ps1

--- a/ods/installers/windows/lib/tier-map.ps1
+++ b/ods/installers/windows/lib/tier-map.ps1
@@ -53,6 +53,14 @@ function Get-HostArchitecture {
     }
 }
 
+function Test-CatalogModelSourceAllowed {
+    param([object]$Model)
+
+    $prop = $Model.PSObject.Properties["source"]
+    if (-not $prop -or $null -eq $prop.Value) { return $true }
+    return ("$($prop.Value)".Trim().ToLowerInvariant() -in @("", "curated"))
+}
+
 function Get-CatalogModelById {
     param(
         [object]$Catalog,
@@ -60,6 +68,7 @@ function Get-CatalogModelById {
     )
 
     foreach ($model in $Catalog.models) {
+        if (-not (Test-CatalogModelSourceAllowed -Model $model)) { continue }
         if ("$($model.id)".ToLowerInvariant() -eq $ModelId) {
             return $model
         }
@@ -663,6 +672,7 @@ function Resolve-CatalogModelRecommendation {
 
     $candidates = @()
     foreach ($model in $catalog.models) {
+        if (-not (Test-CatalogModelSourceAllowed -Model $model)) { continue }
         if (-not $model.gguf_url) { continue }
         if (-not (Test-CatalogModelInstallRecommendationAllowed -Model $model)) { continue }
         if (-not (Test-CatalogModelFamilyAllowed -Model $model -ModelProfileName $modelProfileName)) { continue }

--- a/ods/scripts/select-model.py
+++ b/ods/scripts/select-model.py
@@ -113,11 +113,20 @@ def normalize_model(raw: dict[str, Any]) -> dict[str, Any] | None:
     }
 
 
+def curated_source_allowed(model: dict[str, Any]) -> bool:
+    """Return whether a catalog record is eligible for curated selection."""
+    return normalize_key(model.get("source")) in {"", "curated"}
+
+
 def load_catalog(path: Path) -> list[dict[str, Any]]:
     with path.open("r", encoding="utf-8") as fh:
         data = json.load(fh)
     return [
-        model for model in (normalize_model(raw) for raw in data.get("models", []))
+        model for model in (
+            normalize_model(raw)
+            for raw in data.get("models", [])
+            if curated_source_allowed(raw)
+        )
         if model is not None
     ]
 

--- a/ods/scripts/select-model.py
+++ b/ods/scripts/select-model.py
@@ -115,7 +115,7 @@ def normalize_model(raw: dict[str, Any]) -> dict[str, Any] | None:
 
 def curated_source_allowed(model: dict[str, Any]) -> bool:
     """Return whether a catalog record is eligible for curated selection."""
-    return normalize_key(model.get("source")) in {"", "curated"}
+    return str(model.get("source") or "").strip().lower() in {"", "curated"}
 
 
 def load_catalog(path: Path) -> list[dict[str, Any]]:

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -48,6 +48,8 @@ def _has_runtime_scope(entry):
 
 
 def _agent_viable_for_release(model):
+    if str(model.get("source") or "").strip().lower() not in {"", "curated"}:
+        return False
     compatibility = model.get("app_compatibility") or {}
     for entry in compatibility.values():
         status = str((entry or {}).get("status") or "").strip().lower()
@@ -77,6 +79,10 @@ def test_low_vram_catalog_has_six_agent_viable_downloadable_models():
             assert str(artifact.get("url") or "").startswith("https://huggingface.co/"), model["id"]
             assert len(str(artifact.get("sha256") or "")) == 64, model["id"]
             assert int(artifact.get("size_bytes") or artifact.get("size_mb") or 0) > 0, model["id"]
+
+
+def test_huggingface_import_is_not_agent_viable_for_release():
+    assert not _agent_viable_for_release({"source": "huggingface"})
 
 
 def test_release_model_switchboard_catalog_ids_exist():

--- a/ods/tests/test-tier-map.sh
+++ b/ods/tests/test-tier-map.sh
@@ -462,6 +462,57 @@ assert_eq "SELECTOR_N_CPU_MOE" "" "$LLAMA_ARG_N_CPU_MOE"
 assert_eq "SELECTOR_CACHE_V" "" "$LLAMA_ARG_CACHE_TYPE_V"
 echo ""
 
+echo "Catalog selector excludes Hugging Face imports from a mixed catalog:"
+_selector_catalog="$(mktemp)"
+trap 'rm -f "$_selector_catalog"' EXIT
+python3 - "$_selector_catalog" <<'PY'
+import json
+import sys
+
+models = [
+    {
+        "id": "curated-model",
+        "llm_model_name": "curated-model",
+        "family": "qwen",
+        "gguf_file": "curated.gguf",
+        "gguf_url": "https://huggingface.co/ods/curated/resolve/main/curated.gguf",
+        "size_mb": 1000,
+        "vram_required_gb": 2,
+        "context_length": 65536,
+    },
+    {
+        "id": "imported-model",
+        "source": "huggingface",
+        "llm_model_name": "imported-model",
+        "family": "qwen",
+        "gguf_file": "imported.gguf",
+        "gguf_url": "https://huggingface.co/community/imported/resolve/main/imported.gguf",
+        "size_mb": 7000,
+        "vram_required_gb": 7,
+        "context_length": 131072,
+    },
+]
+with open(sys.argv[1], "w", encoding="utf-8") as handle:
+    json.dump({"models": models}, handle)
+PY
+_selector_env="$(python3 "$SCRIPT_DIR/scripts/select-model.py" \
+    --catalog "$_selector_catalog" \
+    --backend nvidia \
+    --memory-type discrete \
+    --vram-mb 8192 \
+    --ram-gb 32 \
+    --profile qwen \
+    --tier 1 \
+    --host-arch amd64 \
+    --installable-only \
+    --env)"
+rm -f "$_selector_catalog"
+trap - EXIT
+LLM_MODEL="" GGUF_FILE=""
+load_selector_env "$_selector_env"
+assert_eq "SELECTOR_CURATED_SOURCE" "curated-model" "$LLM_MODEL"
+echo ""
+
 # --- Summary ---
 echo "==============================="
 echo "Results: $PASS passed, $FAIL failed"

--- a/ods/tests/test-windows-catalog-selector.ps1
+++ b/ods/tests/test-windows-catalog-selector.ps1
@@ -1,0 +1,71 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+. (Join-Path $repoRoot "installers/windows/lib/tier-map.ps1")
+
+$tempBase = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+$tempRoot = Join-Path $tempBase ("ods-catalog-source-" + [Guid]::NewGuid().ToString("N"))
+
+try {
+    $configDir = New-Item -ItemType Directory -Path (Join-Path $tempRoot "config")
+    $catalog = @{
+        models = @(
+            @{
+                id = "curated-model"
+                name = "Curated model"
+                llm_model_name = "curated-model"
+                family = "qwen"
+                gguf_file = "curated.gguf"
+                gguf_url = "https://huggingface.co/ods/curated/resolve/main/curated.gguf"
+                size_mb = 1000
+                vram_required_gb = 2
+                context_length = 65536
+                specialty = "General"
+            },
+            @{
+                id = "imported-model"
+                source = "huggingface"
+                name = "Imported model"
+                llm_model_name = "imported-model"
+                family = "qwen"
+                gguf_file = "imported.gguf"
+                gguf_url = "https://huggingface.co/community/imported/resolve/main/imported.gguf"
+                size_mb = 7000
+                vram_required_gb = 7
+                context_length = 131072
+                specialty = "Code"
+            }
+        )
+    }
+    $catalog | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $configDir "model-library.json")
+
+    $tierConfig = @{
+        ModelProfileEffective = "qwen"
+        LlmModel = "fallback-model"
+        GgufFile = "fallback.gguf"
+    }
+    $gpu = @{
+        Backend = "nvidia"
+        MemoryType = "discrete"
+        VramMB = 8192
+    }
+    $resolved = Resolve-CatalogModelRecommendation `
+        -TierConfig $tierConfig `
+        -Tier "1" `
+        -GpuInfo $gpu `
+        -SystemRamGB 32 `
+        -SourceRoot $tempRoot
+
+    if ($resolved.LlmModel -ne "curated-model" -or $resolved.GgufFile -ne "curated.gguf") {
+        throw "Windows catalog selector chose a non-curated source: $($resolved.LlmModel)"
+    }
+    Write-Host "[PASS] Windows catalog selector excludes Hugging Face imports"
+} finally {
+    $resolvedTemp = [System.IO.Path]::GetFullPath($tempRoot)
+    if (
+        $resolvedTemp.StartsWith($tempBase, [System.StringComparison]::OrdinalIgnoreCase) -and
+        (Split-Path -Leaf $resolvedTemp) -like "ods-catalog-source-*"
+    ) {
+        Remove-Item -LiteralPath $resolvedTemp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}


### PR DESCRIPTION
## Summary

- reject any explicitly non-curated catalog source before the Linux/macOS install-time model selector ranks candidates
- enforce the same source boundary in the independent Windows catalog selector, including architecture-specific ID lookups
- apply the same boundary to the low-VRAM release-eligibility predicate
- add mixed synthetic catalog regressions for both selector implementations

## Root cause

Imported models are isolated in `data/model-imports.json`, but the catalog selectors previously trusted every record found in `config/model-library.json`. That made file separation the only barrier preventing a future accidentally merged `source: huggingface` record from entering install-time selection. The original draft covered Linux/macOS but missed the separate Windows selector; the audit fix closes that path too.

## Impact

This is a no-op for the current curated catalog: all 52 entries omit `source`, so they retain curated/default eligibility. The low-VRAM release pool remains exactly 6 models. Linux, macOS, and Windows fresh-install selectors now accept only a missing/empty source or explicit `curated` source.

The optional `unknown`-status rejection is intentionally not included. The eligible pool has zero headroom, so this PR stays source-only rather than introducing a broader future policy.

## Validation

- `python -m pytest ods/tests/test-model-library-coverage.py -q` — 33 passed
- `bash ods/tests/test-tier-map.sh` — 128 passed
- `powershell.exe -File ods/tests/test-windows-catalog-selector.ps1` — passed
- `powershell.exe -File ods/tests/test-windows-model-activation.ps1` — passed
- requested dashboard subset — 486 passed, 5 skipped
- `python -m py_compile ods/scripts/select-model.py` — passed
- `git diff --check` — passed
- catalog audit — 52 models, 6 eligible low-VRAM models, 56/56 artifact URLs use `https://huggingface.co/`, and no current entry has an explicit `source`

## Existing baseline discrepancy

`python -m pytest ods/tests/test-model-library-verdicts.py -q` fails unchanged on current `main`: the file's legacy ratchet is 36 but the catalog currently contains 42 unmigrated blocking verdicts. The brief's direct `python ods/tests/test-model-library-verdicts.py` invocation exits 0 because the file has no script entrypoint. This PR does not alter verdict metadata or that ratchet.