### PR TITLE
fix(models): validate artifact download hosts

### DIFF
--- a/ods/.env.example
+++ b/ods/.env.example
@@ -124,6 +124,8 @@ ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
 # Optional in every mode: read token for private/gated Hugging Face models.
 HF_TOKEN=
+# Comma-separated HTTPS hosts permitted for model artifact downloads.
+# ODS_MODEL_DOWNLOAD_ALLOWED_HOSTS=huggingface.co,www.huggingface.co,hf.co
 TOGETHER_API_KEY=
 MINIMAX_API_KEY=
 

--- a/ods/.env.schema.json
+++ b/ods/.env.schema.json
@@ -182,6 +182,11 @@
       "secret": true,
       "minLength": 10
     },
+    "ODS_MODEL_DOWNLOAD_ALLOWED_HOSTS": {
+      "type": "string",
+      "description": "Comma-separated HTTPS hosts permitted for model artifact downloads",
+      "default": "huggingface.co,www.huggingface.co,hf.co"
+    },
     "TOGETHER_API_KEY": {
       "type": "string",
       "description": "Together AI API key (optional)",

--- a/ods/bin/ods-host-agent.py
+++ b/ods/bin/ods-host-agent.py
@@ -431,13 +431,49 @@ def _format_curl_download_error(returncode: int | None, stderr_text: object) -> 
     return f"{message}: {details}"
 
 
+_DEFAULT_MODEL_DOWNLOAD_HOSTS = frozenset({
+    "huggingface.co",
+    "www.huggingface.co",
+    "hf.co",
+})
+_MODEL_DOWNLOAD_HOSTS_ENV = "ODS_MODEL_DOWNLOAD_ALLOWED_HOSTS"
+
+
+def _model_download_allowed_hosts() -> frozenset[str]:
+    raw = os.environ.get(_MODEL_DOWNLOAD_HOSTS_ENV, "").strip()
+    if not raw:
+        raw = load_env(INSTALL_DIR / ".env").get(_MODEL_DOWNLOAD_HOSTS_ENV, "").strip()
+    if not raw:
+        return _DEFAULT_MODEL_DOWNLOAD_HOSTS
+    return frozenset(
+        host.lower()
+        for host in re.split(r"[\s,]+", raw)
+        if host
+    )
+
+
+def _model_download_url_error(url: object) -> str:
+    """Return a policy error for an unsafe model artifact URL."""
+    try:
+        parsed = urlparse(str(url or "").strip())
+        host = (parsed.hostname or "").lower()
+    except ValueError:
+        return "Model artifact URL is malformed"
+    if parsed.scheme.lower() != "https":
+        return "Model artifact URL must use HTTPS"
+    if host not in _model_download_allowed_hosts():
+        return (
+            f"Model artifact host '{host or '(missing)'}' is not allowed; "
+            f"configure {_MODEL_DOWNLOAD_HOSTS_ENV} to permit it"
+        )
+    return ""
+
+
 def _parse_huggingface_resolve_url(url: object) -> tuple[str, str, str] | None:
     """Return repo_id, revision, and filename for a Hugging Face resolve URL."""
+    if _model_download_url_error(url):
+        return None
     parsed = urlparse(str(url or "").strip())
-    if parsed.scheme not in {"http", "https"}:
-        return None
-    if parsed.netloc.lower() not in {"huggingface.co", "www.huggingface.co", "hf.co"}:
-        return None
     parts = [unquote(part) for part in parsed.path.strip("/").split("/") if part]
     if len(parts) < 5 or parts[2] != "resolve":
         return None
@@ -5291,6 +5327,19 @@ class AgentHandler(BaseHTTPRequestHandler):
 
                 try:
                     models_dir.mkdir(parents=True, exist_ok=True)
+                    for _part_idx, part_file_name, part_url in pending_download_plan:
+                        url_error = _model_download_url_error(part_url)
+                        if url_error:
+                            logger.error("Model download rejected for %s: %s", part_file_name, url_error)
+                            _write_model_status(
+                                status_path,
+                                "failed",
+                                part_file_name,
+                                0,
+                                0,
+                                url_error,
+                            )
+                            return
                     label = gguf_file if len(download_plan) == 1 else f"{gguf_file} ({len(download_plan)} parts)"
                     _write_model_status(status_path, "downloading", label, 0, 0)
 

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent.py
@@ -4613,6 +4613,7 @@ class TestModelDownloadFileIntegrity:
         monkeypatch.setattr(_mod, "_model_download_proc", None)
         monkeypatch.setattr(_mod, "_model_download_cancelable", False)
         monkeypatch.setattr(_mod, "_model_download_cancel", self._NoCancel())
+        monkeypatch.setenv("ODS_MODEL_DOWNLOAD_ALLOWED_HOSTS", "huggingface.co,example.com")
         monkeypatch.setattr(
             _mod.subprocess,
             "run",
@@ -4656,6 +4657,85 @@ class TestModelDownloadFileIntegrity:
 
         monkeypatch.setattr(_mod.subprocess, "Popen", FakeProc)
         return outputs
+
+    @pytest.mark.parametrize(
+        ("url", "expected_error"),
+        [
+            (
+                "http://huggingface.co/org/repo/resolve/main/test-model.gguf",
+                "must use HTTPS",
+            ),
+            (
+                "https://models.example.com/test-model.gguf",
+                "host 'models.example.com' is not allowed",
+            ),
+        ],
+    )
+    def test_unsafe_artifact_url_is_rejected_before_download(
+        self,
+        tmp_path,
+        monkeypatch,
+        url,
+        expected_error,
+    ):
+        model = {
+            "gguf_file": "unsafe-model.gguf",
+            "gguf_url": url,
+            "gguf_sha256": "a" * 64,
+        }
+        install_dir = self._setup_env(
+            tmp_path,
+            monkeypatch,
+            library_models=[model],
+        )
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "run",
+            lambda *_args, **_kwargs: pytest.fail("HEAD request must not start"),
+        )
+        monkeypatch.setattr(
+            _mod.subprocess,
+            "Popen",
+            lambda *_args, **_kwargs: pytest.fail("curl download must not start"),
+        )
+
+        handler = _FakeHandler(json.dumps(model).encode("utf-8"))
+        _mod.AgentHandler._handle_model_download(handler)
+
+        assert handler.response_code == 200
+        assert handler.parse_response()["status"] == "started"
+        _mod._model_download_thread.join(timeout=2)
+        assert not _mod._model_download_thread.is_alive()
+        status = json.loads(
+            (install_dir / "data" / "model-download-status.json").read_text(encoding="utf-8")
+        )
+        assert status["status"] == "failed"
+        assert expected_error in status["error"]
+
+    def test_artifact_url_policy_defaults_to_hugging_face_and_allows_env_override(
+        self,
+        tmp_path,
+        monkeypatch,
+    ):
+        install_dir = tmp_path / "install"
+        install_dir.mkdir()
+        monkeypatch.setattr(_mod, "INSTALL_DIR", install_dir)
+        monkeypatch.delenv("ODS_MODEL_DOWNLOAD_ALLOWED_HOSTS", raising=False)
+
+        assert _mod._model_download_url_error(
+            "https://huggingface.co/org/repo/resolve/main/model.gguf"
+        ) == ""
+        assert "not allowed" in _mod._model_download_url_error(
+            "https://models.example.com/model.gguf"
+        )
+
+        (install_dir / ".env").write_text(
+            "ODS_MODEL_DOWNLOAD_ALLOWED_HOSTS=models.example.com\n",
+            encoding="utf-8",
+        )
+        assert _mod._model_download_url_error(
+            "https://models.example.com/model.gguf"
+        ) == ""
 
     def test_empty_existing_model_is_redownloaded(self, tmp_path, monkeypatch):
         install_dir = self._setup_env(tmp_path, monkeypatch)


### PR DESCRIPTION
## Summary

- require HTTPS and an allowlisted hostname for every pending model artifact before the host agent starts a HEAD request or primary curl download
- share the same policy with the Hugging Face Hub fallback URL parser
- default to `huggingface.co`, `www.huggingface.co`, and `hf.co`
- allow an operator to replace the host set through `ODS_MODEL_DOWNLOAD_ALLOWED_HOSTS` in the process environment or ODS `.env`
- record rejected URLs as clear failed download status instead of silently skipping them

## Root cause

The catalog/import manifest match and checksum verification protect artifact identity, but the primary curl path previously accepted any URL stored in that trusted manifest. A future persistence bug could therefore turn the host agent into a downloader for an unintended host before checksum verification rejected the payload.

## Impact

All 56 current curated single/split artifact URLs use HTTPS on `huggingface.co`, so fresh installs and existing curated downloads retain their current behavior. Already-verified local artifacts remain reusable without applying a network gate because no download occurs. A future non-Hugging-Face curated source can be enabled explicitly through the allowlist rather than requiring a code change.

The gate covers every pending split part before any HEAD or curl process starts. Rejections produce the normal failed download-status shape with a clear policy error.

## Validation

Re-tested after updating the branch onto current `main` (including #1998):

- requested dashboard subset — 489 passed, 5 skipped
- focused artifact URL tests — 3 passed
- dashboard environment settings tests — 71 passed
- `python -m pytest ods/tests/test-model-library-coverage.py -q` — 33 passed
- `bash ods/tests/test-tier-map.sh` — 128 passed
- Windows catalog source contract — passed
- `python -m py_compile ods/bin/ods-host-agent.py ods/scripts/select-model.py` — passed
- `.env.schema.json` parse — passed
- `git diff --check` — passed
- catalog audit — 6 eligible low-VRAM models; 56/56 artifact URLs use HTTPS on `huggingface.co`

The focused handler cases prove both an `http://huggingface.co/...` URL and an HTTPS URL on an unallowlisted host fail before either `subprocess.run` (HEAD) or `subprocess.Popen` (curl) can execute. A normal `https://huggingface.co/...` URL and a configured non-default HTTPS host pass policy validation.

## Existing baseline discrepancy

`python -m pytest ods/tests/test-model-library-verdicts.py -q` fails unchanged on current `main` (42 unmigrated blocking verdicts vs a ratchet of 36); the brief's direct script invocation exits 0 because the file has no entrypoint. This PR does not alter verdict metadata or that ratchet.