### PR TITLE
test(distro): make Incus VM lanes fail closed

### DIFF
--- a/ods/tests/fleet-incus-vm.sh
+++ b/ods/tests/fleet-incus-vm.sh
@@ -329,6 +329,10 @@ install_dnf_deps() {
     if [[ "$distro_id" =~ ^(rocky|almalinux|rhel|ol|centos)$ ]]; then
         info "using Docker CE CentOS/RHEL repository for ${distro_id}"
         "$dnf_bin" -y install dnf-plugins-core
+        if ! modprobe -n xt_addrtype >/dev/null 2>&1; then
+            info "installing extra modules for the running kernel before Docker"
+            "$dnf_bin" -y install "kernel-modules-extra-$(uname -r)"
+        fi
         rm -f /etc/yum.repos.d/docker-ce.repo /etc/yum.repos.d/docker-ce-staging.repo
         "$dnf_bin" config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
         "$dnf_bin" makecache
@@ -551,6 +555,7 @@ run_lane() {
     local lane="$1"
     local vm="${PREFIX}-${lane}-${RUN_ID}"
     local installer_mode="run"
+    local check_rc=0
 
     if [[ "$RUN_INSTALLER_DRY_RUN" != "true" ]]; then
         installer_mode="skip"
@@ -571,7 +576,10 @@ run_lane() {
     incus file push "$PAYLOAD" "$vm/tmp/ods-src.tgz"
     incus file push "$VM_CHECK" "$vm/tmp/fleet-incus-vm-check.sh"
     incus exec "$vm" -- chmod +x /tmp/fleet-incus-vm-check.sh
-    run_vm_check "$vm" "$lane" "$installer_mode"
+    run_vm_check "$vm" "$lane" "$installer_mode" || check_rc=$?
+    if ((check_rc != 0)); then
+        fail "${LABELS[$lane]} VM validation failed (rc=$check_rc)"
+    fi
 
     if [[ "$KEEP_VMS" != "true" ]]; then
         incus delete -f "$vm" >/dev/null

--- a/ods/tests/test-fleet-incus-vm-fail-closed.sh
+++ b/ods/tests/test-fleet-incus-vm-fail-closed.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Regression: every Incus VM lane must fail closed, and RHEL-family VM
+# provisioning must install the extra modules required by Docker networking.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$ROOT_DIR/tests/fleet-incus-vm.sh"
+
+fail() {
+    echo "[FAIL] $*" >&2
+    exit 1
+}
+
+pass() {
+    echo "[PASS] $*"
+}
+
+[[ -f "$TARGET" ]] || fail "missing $TARGET"
+
+run_lane_block="$(
+    sed -n '/^run_lane() {/,/^}/p' "$TARGET"
+)"
+[[ -n "$run_lane_block" ]] || fail "could not locate run_lane"
+
+grep -qF 'run_vm_check "$vm" "$lane" "$installer_mode" || check_rc=$?' \
+    <<<"$run_lane_block" \
+    || fail "run_lane must capture a failed VM check explicitly"
+pass "run_lane captures the VM check exit code"
+
+grep -qF 'if ((check_rc != 0)); then' <<<"$run_lane_block" \
+    || fail "run_lane must test the captured VM check exit code"
+grep -qF 'fail "${LABELS[$lane]} VM validation failed (rc=$check_rc)"' \
+    <<<"$run_lane_block" \
+    || fail "run_lane must fail the matrix when a VM check fails"
+pass "a failed VM check cannot be overwritten by VM cleanup"
+
+dnf_block="$(
+    sed -n '/^install_dnf_deps() {/,/^}/p' "$TARGET"
+)"
+[[ -n "$dnf_block" ]] || fail "could not locate install_dnf_deps"
+
+grep -qF 'if ! modprobe -n xt_addrtype' <<<"$dnf_block" \
+    || fail "RHEL-family setup must detect the Docker addrtype kernel module"
+grep -qF '"kernel-modules-extra-$(uname -r)"' <<<"$dnf_block" \
+    || fail "RHEL-family setup must install extra modules for the running kernel"
+pass "RHEL-family setup provisions Docker bridge-networking modules"
+
+echo "[OK] fleet-incus-vm.sh fails closed and provisions required kernel modules"


### PR DESCRIPTION
## Summary

- install `kernel-modules-extra` for the running RHEL-family kernel when Docker's `xt_addrtype` module is absent
- capture `run_vm_check` failures explicitly so later VM cleanup cannot overwrite a failed lane with exit 0
- add a regression contract for both behaviors

## Root cause and evidence

The release distro campaign on product `50a0a6aefab9affac1ed3d7370372cda7ec727a4` reported aggregate `incusVmExit: 0`, but the AlmaLinux 10 lane never emitted `[fedora42] PASS`. Its Docker daemon failed to create bridge NAT rules because the running normal kernel lacked `xt_addrtype`; DNF had selected only `kernel-debug-modules-extra`. The lane's nonzero `run_vm_check` result was then overwritten by successful VM cleanup, so the matrix continued and falsely returned green.

A retained disposable AlmaLinux 10 VM confirmed:

- `modprobe xt_addrtype` failed before the fix
- `kernel-modules-extra-$(uname -r)` provides the missing module
- after installing that exact package, Docker 29.6.2 started with overlayfs and the complete installer dry-run reached `[fedora42] PASS`

A fresh VM from this branch then passed the same lane without hand repair.

## Validation

- `bash ods/tests/test-fleet-incus-vm-fail-closed.sh`
- `bash ods/tests/test-fleet-host-lock.sh`
- `bash ods/tests/test-fleet-multi-distro-keep-going.sh`
- `bash -n ods/tests/fleet-incus-vm.sh ods/tests/test-fleet-incus-vm-fail-closed.sh`
- `git diff --check`
- fresh `bash ods/tests/fleet-incus-vm.sh --no-host-lock fedora42` — PASS

Full multi-distro and five-VM release gates will be rerun against the merged immutable SHA.
