### PR TITLE
Fix n8n startup on Windows bind mounts

### DIFF
--- a/ods/extensions/services/n8n/compose.yaml
+++ b/ods/extensions/services/n8n/compose.yaml
@@ -6,7 +6,7 @@ services:
     user: "${UID:-1000}:${GID:-1000}"
     security_opt:
       - no-new-privileges:true
-    entrypoint: ["tini", "--", "/opt/ods/n8n-entrypoint.sh"]
+    entrypoint: ["tini", "--", "/bin/sh", "/opt/ods/n8n-entrypoint.sh"]
     environment:
       - N8N_DEFAULT_ADMIN_EMAIL=${N8N_USER:?N8N_USER must be set in .env}
       - N8N_DEFAULT_ADMIN_PASSWORD=${N8N_PASS:?N8N_PASS must be set in .env}

--- a/ods/tests/test-n8n-cookie-policy.sh
+++ b/ods/tests/test-n8n-cookie-policy.sh
@@ -41,6 +41,13 @@ if ods_n8n_secure_cookie_policy sometimes http 127.0.0.1 >/dev/null 2>&1; then
     failures=$((failures + 1))
 fi
 
+compose_file="$ROOT_DIR/extensions/services/n8n/compose.yaml"
+expected_entrypoint='entrypoint: ["tini", "--", "/bin/sh", "/opt/ods/n8n-entrypoint.sh"]'
+if ! grep -Fq "$expected_entrypoint" "$compose_file"; then
+    printf 'FAIL n8n entrypoint must run through /bin/sh for Windows bind mounts\n' >&2
+    failures=$((failures + 1))
+fi
+
 if ((failures > 0)); then
     printf '%d n8n cookie policy test(s) failed\n' "$failures" >&2
     exit 1


### PR DESCRIPTION
## Summary
- run the n8n bind-mounted entrypoint through `/bin/sh`
- preserve `tini` as PID 1
- add a regression assertion for the Windows-safe command

## Fleet evidence
On the Windows Light Worker at exact main `44a9030e210fd45f0278958c8440b76db1951264`, `ods-n8n` crash-looped with exit 126:

`[FATAL tini] exec /opt/ods/n8n-entrypoint.sh failed: Permission denied`

An isolated Docker Desktop reproduction using the same Windows-mounted script produced `old_exit=126`; inserting `/bin/sh` produced `fixed_exit=0`.

## Tests
- `bash ods/tests/test-n8n-cookie-policy.sh`
- `docker compose ... config --no-interpolate` confirms `tini -- /bin/sh /opt/ods/n8n-entrypoint.sh`
- before/after Docker Desktop entrypoint probe (`126 -> 0`)