### PR TITLE
fix(windows): repair switchboard and extension locks

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/extensions.py
+++ b/ods/extensions/services/dashboard-api/routers/extensions.py
@@ -1068,6 +1068,15 @@ def _extensions_lock_path() -> Path:
     for lock_path in _extensions_lock_candidates():
         try:
             lock_path.parent.mkdir(parents=True, exist_ok=True)
+            operation_lock_dir = lock_path.parent / ".extension-operation-locks"
+            if operation_lock_dir.is_symlink():
+                raise OSError("Extension operation lock directory is a symlink")
+            operation_lock_dir.mkdir(parents=True, exist_ok=True)
+            with tempfile.NamedTemporaryFile(
+                dir=operation_lock_dir,
+                prefix=".write-probe-",
+            ):
+                pass
             lock_path.touch(exist_ok=True)
             if lock_path != Path(DATA_DIR) / ".extensions-lock":
                 logger.warning("extensions lock falling back to %s", lock_path)

--- a/ods/extensions/services/dashboard-api/tests/test_extensions.py
+++ b/ods/extensions/services/dashboard-api/tests/test_extensions.py
@@ -4143,6 +4143,41 @@ def test_extensions_lock_falls_back_when_data_root_is_unwritable(
         assert fallback_lock.exists()
 
 
+def test_extension_operation_lock_falls_back_when_primary_lock_parent_cannot_create(
+    tmp_path, monkeypatch,
+):
+    """A stale root lock must not select a parent that cannot hold service locks."""
+    from routers import extensions as ext_module
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    primary_lock = data_dir / ".extensions-lock"
+    primary_lock.touch()
+    fallback_lock = data_dir / "config" / ".extensions-lock"
+    primary_operation_dir = data_dir / ".extension-operation-locks"
+    original_named_temporary_file = ext_module.tempfile.NamedTemporaryFile
+
+    def fail_primary_write_probe(*args, **kwargs):
+        if Path(kwargs["dir"]) == primary_operation_dir:
+            raise PermissionError("primary operation lock directory is not writable")
+        return original_named_temporary_file(*args, **kwargs)
+
+    monkeypatch.setattr(
+        ext_module,
+        "_extensions_lock_candidates",
+        lambda: [primary_lock, fallback_lock],
+    )
+    monkeypatch.setattr(
+        ext_module.tempfile,
+        "NamedTemporaryFile",
+        fail_primary_write_probe,
+    )
+
+    with ext_module._extension_operation_lock("aider"):
+        assert fallback_lock.exists()
+        assert (fallback_lock.parent / ".extension-operation-locks").is_dir()
+
+
 class TestUpdateHardening(TestUpdateExtension):
     """Gates and sync-echo hardening for the transactional update path."""
 

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -94,6 +94,7 @@ $_expectedRegularFiles = @(
     "config\llama-server\models.ini",
     "config\litellm\local.yaml",
     "config\litellm\lemonade.yaml",
+    "config\litellm\switchboard.yaml",
     "data\.extensions-lock",
     "extensions\services\hermes\cli-config.yaml.template",
     "extensions\services\hermes\SOUL.md.template",

--- a/ods/tests/test-windows-env-dotfile-recovery.sh
+++ b/ods/tests/test-windows-env-dotfile-recovery.sh
@@ -53,6 +53,7 @@ check 'docker rm -f @_odsContainerNames' "$PHASE05" "phase 5 removes stale ODS c
 check 'file bind mounts' "$PHASE05" "phase 5 documents stale bind-mount directory hazard"
 
 check '$_expectedRegularFiles = @(' "$PHASE06" "phase 6 uses explicit owned regular-file cleanup list"
+check 'config\litellm\switchboard.yaml' "$PHASE06" "phase 6 repairs malformed LiteLLM switchboard config directory"
 check 'extensions\services\hermes\cli-config.yaml.template' "$PHASE06" "phase 6 repairs malformed Hermes config template directory"
 check 'extensions\services\hermes\SOUL.md.template' "$PHASE06" "phase 6 repairs malformed Hermes SOUL template directory"
 check 'data\persona\SOUL.md' "$PHASE06" "phase 6 repairs malformed generated persona file directory"


### PR DESCRIPTION
## What changed

- validate that the dashboard extension operation-lock directory is writable before selecting its parent lock
- fall back to the writable `data/config` path when a stale root-owned lock makes `/data` appear usable
- repair a malformed `config/litellm/switchboard.yaml` directory during Windows installation before repository files are copied
- add regressions for both recovery paths

## Root cause

On the Windows fleet host, Docker-created bind-mount source paths survived as directories. LiteLLM then received a directory at `/app/switchboard.yaml` and crash-looped. Separately, a pre-existing `/data/.extensions-lock` let the dashboard select `/data` even though uid 1000 could not create `/data/.extension-operation-locks`, causing extension installs to return HTTP 500.

## Impact

A rerun of the Windows installer now repairs the LiteLLM bind-mount source and dashboard extension installs can safely fall back to a writable operation-lock location.

## Validation

- dashboard extension tests: 254 passed, 5 skipped
- focused extension-lock tests: 2 passed
- Windows malformed recovery contracts: 23 passed
- installer-hardening contracts: passed
- PowerShell parser: clean
- `git diff --check`: clean
