### PR TITLE
fix(gguf): handle boolean values safely in GGUF metadata integer fields

### DIFF
--- a/ods/extensions/services/dashboard-api/gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/gguf_inspector.py
@@ -165,7 +165,7 @@ def _read_array(reader: _Reader, depth: int = 0) -> Any:
 
 def _first_int(metadata: dict[str, Any], suffixes: tuple[str, ...]) -> int | None:
     for key, value in metadata.items():
-        if key.endswith(suffixes) and isinstance(value, int):
+        if key.endswith(suffixes) and isinstance(value, int) and not isinstance(value, bool):
             return value
     return None
 

--- a/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
+++ b/ods/extensions/services/dashboard-api/tests/test_gguf_inspector.py
@@ -315,3 +315,15 @@ def test_accepts_str_path_as_well_as_path_object(tmp_path):
 
     assert result["readable"] is True
     assert result["path"] == str(path)
+
+
+def test_boolean_metadata_value_is_ignored_for_integer_fields(tmp_path):
+    path = _write(tmp_path, "boolmeta.gguf", build_gguf([
+        ("general.architecture", STR, "llama"),
+        ("is_enabled.context_length", BOOL, True),
+    ]))
+
+    result = inspect_gguf(path)
+
+    assert result["readable"] is True
+    assert result["context_length"] is None


### PR DESCRIPTION
## Summary

Prevent boolean metadata values from being interpreted as integer GGUF model parameters.

Previously, `_first_int()` in `gguf_inspector.py` located the first integer value matching a set of metadata suffixes (such as `context_length`, `block_count`, `embedding_length`, `attention_head_count`, and `expert_count`) by checking `isinstance(value, int)`.

However, in Python, `bool` is a subclass of `int`, meaning `isinstance(True, int)` and `isinstance(False, int)` both evaluate to `True`. As a result, if a GGUF metadata entry contained a boolean value for one of these suffixes (for example, `is_enabled.context_length = True`), the helper incorrectly interpreted the value as the integer `1` (or `0` for `False`). This could lead to incorrect model metadata being reported.

This change updates `_first_int()` to distinguish integers from booleans by requiring values to satisfy:

- `isinstance(value, int)`
- `not isinstance(value, bool)`

This ensures that only genuine integer metadata values are considered when extracting GGUF model parameters, while boolean metadata entries are ignored.

## Verification

Added regression coverage in `test_gguf_inspector.py`:

- `test_boolean_metadata_value_is_ignored_for_integer_fields`
  - Verifies that boolean metadata values matching integer parameter suffixes are ignored rather than being interpreted as `1` or `0`.

### Test Results

- `pytest test_gguf_inspector.py`
  - **27 passed**