### PR TITLE
fix(backends): add Intel Arc backend contract

### DIFF
--- a/ods/config/backends/intel.json
+++ b/ods/config/backends/intel.json
@@ -1,0 +1,9 @@
+{
+  "id": "intel",
+  "llm_engine": "llama-server",
+  "service_name": "llama-server",
+  "public_api_port": 8080,
+  "public_health_url": "http://127.0.0.1:8080/health",
+  "provider_name": "local-sycl",
+  "provider_url": "http://llama-server:8080/v1"
+}

--- a/ods/config/capability-profile.schema.json
+++ b/ods/config/capability-profile.schema.json
@@ -37,7 +37,7 @@
       "properties": {
         "vendor": {
           "type": "string",
-          "enum": ["nvidia", "amd", "apple", "none", "unknown"]
+          "enum": ["nvidia", "amd", "intel", "apple", "none", "unknown"]
         },
         "name": {
           "type": "string"
@@ -53,6 +53,9 @@
         "vram_mb": {
           "type": "integer",
           "minimum": 0
+        },
+        "sycl_available": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false
@@ -63,7 +66,7 @@
       "properties": {
         "llm_backend": {
           "type": "string",
-          "enum": ["nvidia", "amd", "apple", "cpu"]
+          "enum": ["nvidia", "amd", "intel", "apple", "cpu"]
         },
         "llm_health_url": {
           "type": "string"
@@ -94,7 +97,7 @@
       "properties": {
         "recommended": {
           "type": "string",
-          "enum": ["T0", "T1", "T2", "T3", "T4", "SH_COMPACT", "SH_LARGE", "NV_ULTRA"]
+          "enum": ["T0", "T1", "T2", "T3", "T4", "SH_COMPACT", "SH_LARGE", "NV_ULTRA", "ARC", "ARC_LITE"]
         }
       },
       "additionalProperties": false

--- a/ods/config/gpu-database.json
+++ b/ods/config/gpu-database.json
@@ -468,6 +468,21 @@
       "recommended": { "backend": "amd", "tier": "T1" }
     },
     {
+      "id": "intel_arc",
+      "match": { "vendor": "intel", "memory_type": "discrete", "min_vram_mb": 12288 },
+      "recommended": { "backend": "intel", "tier": "ARC" }
+    },
+    {
+      "id": "intel_arc_lite",
+      "match": { "vendor": "intel", "memory_type": "discrete", "min_vram_mb": 4096 },
+      "recommended": { "backend": "intel", "tier": "ARC_LITE" }
+    },
+    {
+      "id": "intel_arc_unknown_memory",
+      "match": { "vendor": "intel", "memory_type": "discrete", "min_vram_mb": 0, "max_vram_mb": 4095 },
+      "recommended": { "backend": "cpu", "tier": "T1" }
+    },
+    {
       "id": "apple_ultra",
       "match": { "vendor": "apple", "memory_type": "unified", "min_ram_mb": 131072 },
       "recommended": { "backend": "apple", "tier": "T4" }
@@ -497,6 +512,7 @@
     "bandwidth_gbps": {
       "cuda": 220,
       "rocm": 180,
+      "sycl": 220,
       "metal": 160,
       "cpu_x86": 70,
       "cpu_arm": 50

--- a/ods/config/gpu-database.schema.json
+++ b/ods/config/gpu-database.schema.json
@@ -123,10 +123,10 @@
       "type": "object",
       "required": ["backend", "tier"],
       "properties": {
-        "backend": { "enum": ["nvidia", "amd", "apple", "cpu"] },
+        "backend": { "enum": ["nvidia", "amd", "intel", "apple", "cpu"] },
         "tier": {
           "type": "string",
-          "pattern": "^(T[0-4]|SH_LARGE|SH_COMPACT|NV_ULTRA)$"
+          "pattern": "^(T[0-4]|SH_LARGE|SH_COMPACT|NV_ULTRA|ARC|ARC_LITE)$"
         }
       }
     },

--- a/ods/config/hardware-classes.json
+++ b/ods/config/hardware-classes.json
@@ -213,6 +213,36 @@
       }
     },
     {
+      "id": "intel_arc",
+      "label": "Intel Arc (12GB+)",
+      "match": {
+        "platform_id": ["linux"],
+        "gpu_vendor": ["intel"],
+        "memory_type": ["discrete"],
+        "min_vram_mb": 12288
+      },
+      "recommended": {
+        "backend": "intel",
+        "tier": "ARC",
+        "compose_overlays": ["docker-compose.base.yml", "docker-compose.intel.yml"]
+      }
+    },
+    {
+      "id": "intel_arc_lite",
+      "label": "Intel Arc Lite",
+      "match": {
+        "platform_id": ["linux"],
+        "gpu_vendor": ["intel"],
+        "memory_type": ["discrete"],
+        "min_vram_mb": 4096
+      },
+      "recommended": {
+        "backend": "intel",
+        "tier": "ARC_LITE",
+        "compose_overlays": ["docker-compose.base.yml", "docker-compose.intel.yml"]
+      }
+    },
+    {
       "id": "apple_silicon",
       "label": "Apple Silicon",
       "match": {

--- a/ods/installers/lib/detection.sh
+++ b/ods/installers/lib/detection.sh
@@ -232,6 +232,60 @@ show_amd_gpu_device_guidance() {
     fi
 }
 
+intel_sycl_runtime_available() {
+    # The Intel Arc route is intentionally Linux-only. WSL/Windows and macOS
+    # need separate installer/runtime support before they may select it.
+    if [[ -n "${ODS_DETECT_OS_OVERRIDE:-}" ]]; then
+        [[ "$ODS_DETECT_OS_OVERRIDE" == "linux" ]] || return 1
+    else
+        if [[ -r /proc/sys/kernel/osrelease ]] \
+            && grep -qiE 'microsoft|wsl' /proc/sys/kernel/osrelease 2>/dev/null; then
+            return 1
+        fi
+        [[ "$(uname -s 2>/dev/null)" == "Linux" ]] || return 1
+    fi
+
+    local dri_root="${ODS_DEV_DRI:-/dev/dri}"
+    local render_node_available=false
+    for render_node in "$dri_root"/renderD*; do
+        if [[ -c "$render_node" || ( -n "${ODS_DEV_DRI:-}" && -e "$render_node" ) ]]; then
+            render_node_available=true
+            break
+        fi
+    done
+    [[ "$render_node_available" == "true" ]] || return 1
+
+    case "${ODS_LEVEL_ZERO_AVAILABLE:-}" in
+        1|true|TRUE|yes|YES) return 0 ;;
+        0|false|FALSE|no|NO) return 1 ;;
+    esac
+
+    if command -v ze_info &>/dev/null && ze_info >/dev/null 2>&1; then
+        return 0
+    fi
+    if command -v ldconfig &>/dev/null && ldconfig -p 2>/dev/null | grep -q 'libze_loader'; then
+        return 0
+    fi
+    [[ -f /usr/lib/x86_64-linux-gnu/libze_loader.so.1 || -f /usr/lib/libze_loader.so.1 ]]
+}
+
+show_intel_sycl_guidance() {
+    ai_warn "Intel Arc was detected, but the Linux SYCL runtime is not ready."
+    ai "ODS requires a /dev/dri/renderD* device and a working Level Zero loader."
+    ai "  sudo apt install intel-opencl-icd intel-level-zero-gpu level-zero"
+    ai "  sudo usermod -aG video,render \$USER"
+    ai "Re-login after changing groups, then rerun the installer."
+}
+
+ensure_intel_sycl_or_cpu_fallback() {
+    [[ "${GPU_BACKEND:-cpu}" == "intel" ]] || return 0
+    if intel_sycl_runtime_available; then
+        return 0
+    fi
+    show_intel_sycl_guidance
+    apply_cpu_gpu_fallback "Falling back to CPU mode because Intel Arc SYCL prerequisites are unavailable."
+}
+
 apply_cpu_gpu_fallback() {
     local reason="${1:-AMD GPU runtime devices are unavailable.}"
     ai_warn "$reason"
@@ -397,35 +451,33 @@ detect_gpu() {
         fi
     fi
 
-    # Try Intel Arc via lspci + sysfs
-    if lspci 2>/dev/null | grep -qi 'VGA.*Intel.*Arc'; then
-        for card_dir in "$_drm_sys"/card*/device; do
-            [[ -d "$card_dir" ]] || continue
-            local vendor device
-            vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
-            device=$(cat "$card_dir/device" 2>/dev/null) || continue
-            # Intel vendor ID: 0x8086, Arc device IDs: 0x56a0-0x56c1 (Alchemist), 0x5690-0x569f (DG2)
-            if [[ "$vendor" == "0x8086" ]] && [[ "$device" =~ ^0x(56[a-c][0-9a-f]|569[0-9a-f])$ ]]; then
-                GPU_BACKEND="intel"
-                GPU_MEMORY_TYPE="discrete"
-                GPU_DEVICE_ID="$device"
-                GPU_COUNT=1
-                # Try to get VRAM size from sysfs (lmem_total_bytes on Arc)
-                local vram_bytes
-                vram_bytes=$(cat "$card_dir/lmem_total_bytes" 2>/dev/null) || vram_bytes=0
-                GPU_VRAM=$(( vram_bytes / 1048576 ))  # in MB
-                # Try marketing name from sysfs or lspci
-                if [[ -f "$card_dir/product_name" ]]; then
-                    GPU_NAME=$(cat "$card_dir/product_name" 2>/dev/null) || GPU_NAME="Intel Arc"
-                else
-                    GPU_NAME=$(lspci | grep -i 'VGA.*Intel.*Arc' | sed 's/.*: //' | head -1)
-                    [[ -z "$GPU_NAME" ]] && GPU_NAME="Intel Arc ($GPU_DEVICE_ID)"
-                fi
-                log "GPU: $GPU_NAME (${GPU_VRAM}MB VRAM, Intel Arc)"
-                return 0
+    # Try Intel Arc via sysfs. lspci is optional and must not be a prerequisite
+    # for recognizing a supported PCI device.
+    for card_dir in "$_drm_sys"/card*/device; do
+        [[ -d "$card_dir" ]] || continue
+        local vendor device
+        vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
+        device=$(cat "$card_dir/device" 2>/dev/null) || continue
+        # Intel vendor ID: 0x8086, Arc device IDs: 0x56a0-0x56c1
+        # (Alchemist) and 0x5690-0x569f (DG2).
+        if [[ "$vendor" == "0x8086" ]] && [[ "$device" =~ ^0x(56[a-c][0-9a-f]|569[0-9a-f])$ ]]; then
+            GPU_BACKEND="intel"
+            GPU_MEMORY_TYPE="discrete"
+            GPU_DEVICE_ID="$device"
+            GPU_COUNT=1
+            local vram_bytes
+            vram_bytes=$(cat "$card_dir/lmem_total_bytes" 2>/dev/null) || vram_bytes=0
+            GPU_VRAM=$(( vram_bytes / 1048576 ))
+            if [[ -f "$card_dir/product_name" ]]; then
+                GPU_NAME=$(cat "$card_dir/product_name" 2>/dev/null) || GPU_NAME="Intel Arc"
+            elif command -v lspci &>/dev/null; then
+                GPU_NAME=$(lspci 2>/dev/null | grep -i 'VGA.*Intel.*Arc' | sed 's/.*: //' | head -1)
             fi
-        done
-    fi
+            [[ -n "${GPU_NAME:-}" ]] || GPU_NAME="Intel Arc ($GPU_DEVICE_ID)"
+            log "GPU: $GPU_NAME (${GPU_VRAM}MB VRAM, Intel Arc)"
+            return 0
+        fi
+    done
 
     # Try AMD GPUs (discrete RDNA + APU) via sysfs
     local amd_card_dirs=()

--- a/ods/installers/phases/02-detection.sh
+++ b/ods/installers/phases/02-detection.sh
@@ -172,6 +172,8 @@ else
         fi
     fi
 
+    ensure_intel_sycl_or_cpu_fallback
+
     if [[ "${GPU_BACKEND_REQUESTED,,}" != "nvidia" \
         && "${TIER_FORCED:-false}" != "true" \
         && "${GPU_BACKEND:-}" == "nvidia" \

--- a/ods/scripts/build-capability-profile.sh
+++ b/ods/scripts/build-capability-profile.sh
@@ -100,7 +100,14 @@ gpu_name = gpu.get("name") or "None"
 memory_type = (gpu.get("memory_type") or "none").lower()
 vram_mb = int(gpu.get("vram_mb") or 0)
 gpu_count = int(gpu.get("count") or (1 if gpu_type not in {"none", ""} else 0))
+sycl_available = bool(gpu.get("sycl_available", False))
 experimental_jetson = os.environ.get("ODS_ENABLE_EXPERIMENTAL_JETSON") == "1"
+intel_runtime_eligible = (
+    os_name == "linux"
+    and gpu_type == "intel"
+    and sycl_available
+    and vram_mb > 0
+)
 
 llm_health_url = f"http://localhost:{llm_port}{llm_health}"
 llm_api_port = llm_port
@@ -111,6 +118,9 @@ if gpu_type == "amd" and memory_type == "unified":
 elif gpu_type == "nvidia":
     llm_backend = "nvidia"
     overlays = ["docker-compose.base.yml", "docker-compose.nvidia.yml"]
+elif gpu_type == "intel" and intel_runtime_eligible:
+    llm_backend = "intel"
+    overlays = ["docker-compose.base.yml", "docker-compose.intel.yml"]
 elif gpu_type == "jetson" and experimental_jetson:
     # Jetson is Tegra (arm64 + iGPU + unified memory). The dedicated overlay
     # docker-compose.jetson.yml lands in milestone 1 phase 3; until then fall
@@ -133,12 +143,19 @@ elif tier in {"SH_COMPACT", "SH_LARGE"}:
 else:
     recommended = "T1"
 
-if hw_rec_tier:
+if hw_rec_tier and (gpu_type != "intel" or intel_runtime_eligible):
     recommended = hw_rec_tier
-if hw_rec_backend:
+if hw_rec_backend and (gpu_type != "intel" or intel_runtime_eligible):
     llm_backend = hw_rec_backend
-if hw_rec_overlays:
+if hw_rec_overlays and (gpu_type != "intel" or intel_runtime_eligible):
     overlays = hw_rec_overlays
+
+# Preserve the Intel hardware identity but do not advertise an Arc tier or
+# compose route unless the Linux SYCL prerequisites are actually present.
+if gpu_type == "intel" and not intel_runtime_eligible:
+    llm_backend = "cpu"
+    overlays = ["docker-compose.base.yml", "docker-compose.cpu.yml"]
+    recommended = "T1"
 
 profile = {
     "version": "1",
@@ -147,11 +164,12 @@ profile = {
         "family": family,
     },
     "gpu": {
-        "vendor": gpu_type if gpu_type in {"nvidia", "amd", "apple", "none"} else "unknown",
+        "vendor": gpu_type if gpu_type in {"nvidia", "amd", "intel", "apple", "none"} else "unknown",
         "name": gpu_name,
         "memory_type": memory_type if memory_type in {"discrete", "unified", "none"} else "unknown",
         "count": gpu_count,
         "vram_mb": vram_mb,
+        "sycl_available": sycl_available,
     },
     "runtime": {
         "llm_backend": llm_backend,
@@ -183,6 +201,7 @@ if env_mode:
         "CAP_GPU_MEMORY_TYPE": profile["gpu"]["memory_type"],
         "CAP_GPU_COUNT": str(profile["gpu"]["count"]),
         "CAP_GPU_VRAM_MB": str(profile["gpu"]["vram_mb"]),
+        "CAP_GPU_SYCL_AVAILABLE": str(profile["gpu"]["sycl_available"]).lower(),
         "CAP_LLM_BACKEND": profile["runtime"]["llm_backend"],
         "CAP_LLM_HEALTH_URL": profile["runtime"]["llm_health_url"],
         "CAP_LLM_API_PORT": str(profile["runtime"]["llm_api_port"]),

--- a/ods/scripts/classify-hardware.sh
+++ b/ods/scripts/classify-hardware.sh
@@ -77,6 +77,7 @@ with open(db_path, "r", encoding="utf-8") as f:
 OVERLAY_MAP = {
     "amd":    ["docker-compose.base.yml", "docker-compose.amd.yml"],
     "nvidia": ["docker-compose.base.yml", "docker-compose.nvidia.yml"],
+    "intel":  ["docker-compose.base.yml", "docker-compose.intel.yml"],
     "apple":  ["docker-compose.base.yml", "docker-compose.apple.yml"],
     "cpu":    ["docker-compose.base.yml", "docker-compose.cpu.yml"],
 }
@@ -171,7 +172,12 @@ if bandwidth == 0 and gpu_name:
 
 if bandwidth == 0:
     # Fall back to default bandwidth
-    backend_key_map = {"nvidia": "cuda", "amd": "rocm", "apple": "metal"}
+    backend_key_map = {
+        "nvidia": "cuda",
+        "amd": "rocm",
+        "intel": "sycl",
+        "apple": "metal",
+    }
     bk = backend_key_map.get(gpu_vendor, "cpu_x86")
     bandwidth = db.get("defaults", {}).get("bandwidth_gbps", {}).get(bk, 0)
 
@@ -197,6 +203,16 @@ if selected:
 else:
     class_id = "unknown"
     label = "Unknown"
+    backend = "cpu"
+    tier = "T1"
+    memory_source = "vram"
+
+# Intel Arc acceleration is currently supported only by the Linux installer.
+# A classifier call from WSL, Windows, or macOS must not manufacture a route
+# that those installers do not implement.
+if backend == "intel" and platform_id != "linux":
+    class_id = "intel_unsupported_platform"
+    label = "Intel GPU (unsupported platform)"
     backend = "cpu"
     tier = "T1"
     memory_source = "vram"

--- a/ods/scripts/detect-hardware.sh
+++ b/ods/scripts/detect-hardware.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # ODS Hardware Detection
 # Detects GPU, CPU, RAM and recommends tier
-# Supports: NVIDIA (nvidia-smi), AMD APU/dGPU (sysfs), Apple Silicon
+# Supports: NVIDIA (nvidia-smi), Intel Arc (sysfs/Level Zero),
+#           AMD APU/dGPU (sysfs), Apple Silicon
 
 set -euo pipefail
 
@@ -101,6 +102,13 @@ EOF
 
 # Detect OS and environment
 detect_os() {
+    case "${ODS_DETECT_OS_OVERRIDE:-}" in
+        linux|wsl|macos|unknown)
+            echo "$ODS_DETECT_OS_OVERRIDE"
+            return 0
+            ;;
+    esac
+
     # Explicit WSL detection first
     if is_wsl; then
         echo "wsl"
@@ -182,7 +190,8 @@ count_nvidia_gpus() {
 # Detect AMD GPU via sysfs (works without ROCm installed)
 # Returns: gpu_name|vram_bytes|gtt_bytes|is_apu|gpu_busy|temp|power|vulkan|rocm|driver|device_id|subsystem_device|revision
 detect_amd_sysfs() {
-    for card_dir in /sys/class/drm/card*/device; do
+    local drm_root="${ODS_DRM_SYS:-/sys/class/drm}"
+    for card_dir in "$drm_root"/card*/device; do
         [[ -d "$card_dir" ]] || continue
         local vendor
         vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
@@ -275,8 +284,9 @@ detect_amd_sysfs() {
 
 # Count AMD GPUs via sysfs
 count_amd_gpus() {
+    local drm_root="${ODS_DRM_SYS:-/sys/class/drm}"
     local count=0
-    for card_dir in /sys/class/drm/card*/device; do
+    for card_dir in "$drm_root"/card*/device; do
         [[ -d "$card_dir" ]] || continue
         local vendor
         vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
@@ -284,6 +294,84 @@ count_amd_gpus() {
         [[ "$vendor" == "0x1002" ]] && (( count++ )) || true
     done
     echo "$count"
+}
+
+# Intel Arc device IDs currently supported by the shipped SYCL images.
+# Keep this deliberately narrow: generic Intel integrated graphics must not be
+# routed to the Arc backend merely because they share vendor ID 0x8086.
+is_supported_intel_arc_device_id() {
+    [[ "${1,,}" =~ ^0x(56[a-c][0-9a-f]|569[0-9a-f])$ ]]
+}
+
+# Returns: gpu_name|vram_bytes|device_id
+detect_intel_arc_sysfs() {
+    local drm_root="${ODS_DRM_SYS:-/sys/class/drm}"
+    for card_dir in "$drm_root"/card*/device; do
+        [[ -d "$card_dir" ]] || continue
+        local vendor device_id vram_bytes gpu_name
+        vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
+        device_id=$(cat "$card_dir/device" 2>/dev/null) || continue
+        [[ "$vendor" == "0x8086" ]] || continue
+        is_supported_intel_arc_device_id "$device_id" || continue
+
+        vram_bytes=$(cat "$card_dir/lmem_total_bytes" 2>/dev/null) || vram_bytes=0
+        gpu_name=$(cat "$card_dir/product_name" 2>/dev/null) || gpu_name=""
+        if [[ -z "$gpu_name" ]] && command -v lspci &>/dev/null; then
+            gpu_name=$(lspci -nn 2>/dev/null \
+                | grep -i 'VGA\|Display\|3D' \
+                | grep -i "8086:${device_id#0x}" \
+                | sed 's/.*: //' \
+                | first_line)
+        fi
+        [[ -n "$gpu_name" ]] || gpu_name="Intel Arc ($device_id)"
+        echo "${gpu_name}|${vram_bytes}|${device_id}"
+        return 0
+    done
+    return 1
+}
+
+count_intel_arc_gpus() {
+    local drm_root="${ODS_DRM_SYS:-/sys/class/drm}"
+    local count=0
+    for card_dir in "$drm_root"/card*/device; do
+        [[ -d "$card_dir" ]] || continue
+        local vendor device_id
+        vendor=$(cat "$card_dir/vendor" 2>/dev/null) || continue
+        device_id=$(cat "$card_dir/device" 2>/dev/null) || continue
+        if [[ "$vendor" == "0x8086" ]] && is_supported_intel_arc_device_id "$device_id"; then
+            (( count++ )) || true
+        fi
+    done
+    echo "$count"
+}
+
+# The Intel route is Linux-only and requires both a render node and a usable
+# Level Zero loader. Test fixtures may override the probes explicitly.
+intel_sycl_runtime_available() {
+    [[ "$(detect_os)" == "linux" ]] || return 1
+
+    local dri_root="${ODS_DEV_DRI:-/dev/dri}"
+    local render_node_available=false
+    for render_node in "$dri_root"/renderD*; do
+        if [[ -c "$render_node" || ( -n "${ODS_DEV_DRI:-}" && -e "$render_node" ) ]]; then
+            render_node_available=true
+            break
+        fi
+    done
+    [[ "$render_node_available" == "true" ]] || return 1
+
+    case "${ODS_LEVEL_ZERO_AVAILABLE:-}" in
+        1|true|TRUE|yes|YES) return 0 ;;
+        0|false|FALSE|no|NO) return 1 ;;
+    esac
+
+    if command -v ze_info &>/dev/null && ze_info >/dev/null 2>&1; then
+        return 0
+    fi
+    if command -v ldconfig &>/dev/null && ldconfig -p 2>/dev/null | grep -q 'libze_loader'; then
+        return 0
+    fi
+    [[ -f /usr/lib/x86_64-linux-gnu/libze_loader.so.1 || -f /usr/lib/libze_loader.so.1 ]]
 }
 
 # Detect AMD GPU (legacy ROCm-only path)
@@ -568,6 +656,7 @@ main() {
     local gpu_busy=0
     local vulkan_available="false"
     local rocm_available="false"
+    local sycl_available="false"
     local driver_loaded="false"
     local device_id=""
     local subsystem_device=""
@@ -626,7 +715,28 @@ main() {
         device_id="$(nvidia_device_id || true)"
     fi
 
-    # Try AMD if no NVIDIA
+    # Try Intel Arc if no NVIDIA. Detection and runtime readiness are separate:
+    # the profile preserves Intel hardware identity while failing closed to CPU
+    # when Level Zero or the render node is unavailable.
+    if [[ -z "$gpu_name" ]]; then
+        local intel_out=""
+        if intel_out=$(detect_intel_arc_sysfs 2>/dev/null); then
+            local intel_vram_bytes
+            IFS='|' read -r gpu_name intel_vram_bytes device_id <<< "$intel_out"
+            intel_vram_bytes=$(as_int "$intel_vram_bytes")
+            gpu_vram_mb=$(( intel_vram_bytes / 1048576 ))
+            gpu_count=$(count_intel_arc_gpus)
+            gpu_type="intel"
+            gpu_architecture="xe-hpg"
+            memory_type="discrete"
+            if [[ "$gpu_vram_mb" -gt 0 ]] && intel_sycl_runtime_available; then
+                sycl_available="true"
+                driver_loaded="true"
+            fi
+        fi
+    fi
+
+    # Try AMD if no NVIDIA or supported Intel Arc
     if [[ -z "$gpu_name" ]]; then
         local amd_out=""
         if amd_out=$(detect_amd_sysfs 2>/dev/null); then
@@ -733,6 +843,7 @@ main() {
     "power_w": $gpu_power,
     "vulkan": $vulkan_available,
     "rocm": $rocm_available,
+    "sycl_available": $sycl_available,
     "driver_loaded": $driver_loaded
   },
   "tier": "$(json_escape "$tier")",

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -10,7 +10,7 @@ command -v jq >/dev/null 2>&1 || {
 }
 
 echo "[contract] backend contract files"
-for f in config/backends/amd.json config/backends/nvidia.json config/backends/cpu.json config/backends/apple.json; do
+for f in config/backends/amd.json config/backends/nvidia.json config/backends/cpu.json config/backends/apple.json config/backends/intel.json; do
   test -f "$f" || { echo "[FAIL] missing $f"; exit 1; }
   jq -e '.id and .llm_engine and .service_name and .public_api_port and .public_health_url and .provider_name and .provider_url' "$f" >/dev/null \
     || { echo "[FAIL] invalid backend contract: $f"; exit 1; }

--- a/ods/tests/contracts/test-installer-contracts.sh
+++ b/ods/tests/contracts/test-installer-contracts.sh
@@ -16,6 +16,9 @@ for f in config/backends/amd.json config/backends/nvidia.json config/backends/cp
     || { echo "[FAIL] invalid backend contract: $f"; exit 1; }
 done
 
+echo "[contract] Intel Arc capability profile and installer routing"
+bash tests/test-intel-arc-installer-routing.sh
+
 echo "[contract] hardware class mapping"
 test -f config/hardware-classes.json || { echo "[FAIL] missing config/hardware-classes.json"; exit 1; }
 jq -e '.version and (.classes | type=="array" and length>0)' config/hardware-classes.json >/dev/null \

--- a/ods/tests/test-intel-arc-installer-routing.sh
+++ b/ods/tests/test-intel-arc-installer-routing.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+json_get() {
+    python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+value = json.load(open(sys.argv[1], encoding="utf-8"))
+for part in sys.argv[2].split("."):
+    value = value[part]
+if isinstance(value, bool):
+    print(str(value).lower())
+elif isinstance(value, list):
+    print(",".join(str(item) for item in value))
+else:
+    print(value)
+PY
+}
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local label="$3"
+    if [[ "$actual" != "$expected" ]]; then
+        echo "[FAIL] $label: expected '$expected', got '$actual'" >&2
+        exit 1
+    fi
+}
+
+reset_fixture() {
+    rm -rf "${TMP_DIR:?}/sys" "${TMP_DIR:?}/dev"
+    mkdir -p "$TMP_DIR/sys" "$TMP_DIR/dev"
+}
+
+add_gpu() {
+    local card="$1"
+    local vendor="$2"
+    local device="$3"
+    local vram_bytes="$4"
+    local name="$5"
+    local card_dir="$TMP_DIR/sys/card${card}/device"
+    mkdir -p "$card_dir"
+    printf '%s\n' "$vendor" >"$card_dir/vendor"
+    printf '%s\n' "$device" >"$card_dir/device"
+    printf '%s\n' "$vram_bytes" >"$card_dir/lmem_total_bytes"
+    printf '%s\n' "$vram_bytes" >"$card_dir/mem_info_vram_total"
+    printf '0\n' >"$card_dir/mem_info_gtt_total"
+    printf '%s\n' "$name" >"$card_dir/product_name"
+}
+
+build_profile() {
+    local output="$1"
+    local level_zero="$2"
+    ODS_DRM_SYS="$TMP_DIR/sys" \
+    ODS_DEV_DRI="$TMP_DIR/dev/dri" \
+    ODS_LEVEL_ZERO_AVAILABLE="$level_zero" \
+    ODS_DETECT_OS_OVERRIDE=linux \
+        "$ROOT_DIR/scripts/build-capability-profile.sh" --output "$output"
+}
+
+echo "[intel] healthy Arc remains Intel and selects the SYCL compose backend"
+reset_fixture
+add_gpu 0 0x8086 0x56a0 17179869184 "Intel Arc A770"
+mkdir -p "$TMP_DIR/dev/dri"
+touch "$TMP_DIR/dev/dri/renderD128"
+healthy_hardware="$TMP_DIR/intel-healthy-hardware.json"
+ODS_DRM_SYS="$TMP_DIR/sys" \
+ODS_DEV_DRI="$TMP_DIR/dev/dri" \
+ODS_LEVEL_ZERO_AVAILABLE=1 \
+ODS_DETECT_OS_OVERRIDE=linux \
+    "$ROOT_DIR/scripts/detect-hardware.sh" --json >"$healthy_hardware"
+assert_eq "intel" "$(json_get "$healthy_hardware" gpu.type)" "detected Arc type"
+assert_eq "true" "$(json_get "$healthy_hardware" gpu.sycl_available)" "detected Arc SYCL readiness"
+healthy_profile="$TMP_DIR/intel-healthy.json"
+build_profile "$healthy_profile" 1
+
+assert_eq "intel" "$(json_get "$healthy_profile" gpu.vendor)" "Arc vendor"
+assert_eq "true" "$(json_get "$healthy_profile" gpu.sycl_available)" "Arc SYCL readiness"
+assert_eq "intel" "$(json_get "$healthy_profile" runtime.llm_backend)" "Arc runtime backend"
+assert_eq "ARC" "$(json_get "$healthy_profile" tier.recommended)" "Arc tier"
+assert_eq "docker-compose.base.yml,docker-compose.intel.yml" \
+    "$(json_get "$healthy_profile" compose.overlays)" "Arc compose overlays"
+
+installer_detection="$(
+    ODS_DRM_SYS="$TMP_DIR/sys" \
+    ODS_DEV_DRI="$TMP_DIR/dev/dri" \
+    ODS_LEVEL_ZERO_AVAILABLE=1 \
+    ODS_DETECT_OS_OVERRIDE=linux \
+    ROOT_DIR="$ROOT_DIR" \
+        bash -s <<'SH'
+set -euo pipefail
+SCRIPT_DIR="$ROOT_DIR"
+LOG_FILE=/dev/null
+log() { :; }
+warn() { :; }
+ai() { :; }
+ai_warn() { :; }
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/installers/lib/detection.sh"
+detect_gpu
+ensure_intel_sycl_or_cpu_fallback
+printf '%s|%s|%s\n' "$GPU_BACKEND" "$GPU_DEVICE_ID" "$GPU_VRAM"
+SH
+)"
+assert_eq "intel|0x56a0|16384" "$installer_detection" "phase-02 Intel detection"
+
+compose_env="$(
+    "$ROOT_DIR/scripts/resolve-compose-stack.sh" \
+        --script-dir "$ROOT_DIR" \
+        --tier ARC \
+        --gpu-backend intel \
+        --profile-overlays "$(json_get "$healthy_profile" compose.overlays)" \
+        --gpu-count 1 \
+        --ods-mode local \
+        --env
+)"
+grep -q 'docker-compose.intel.yml' <<<"$compose_env" \
+    || { echo "[FAIL] Intel profile did not resolve the Intel compose overlay" >&2; exit 1; }
+if grep -q 'docker-compose.nvidia.yml\|docker-compose.cpu.yml\|docker-compose.arc.yml' <<<"$compose_env"; then
+    echo "[FAIL] Intel profile resolved an unintended accelerator overlay" >&2
+    exit 1
+fi
+
+echo "[intel] missing Level Zero fails closed to CPU without losing hardware identity"
+missing_runtime_profile="$TMP_DIR/intel-missing-runtime.json"
+build_profile "$missing_runtime_profile" 0
+assert_eq "intel" "$(json_get "$missing_runtime_profile" gpu.vendor)" "fallback preserves Arc vendor"
+assert_eq "false" "$(json_get "$missing_runtime_profile" gpu.sycl_available)" "fallback SYCL readiness"
+assert_eq "cpu" "$(json_get "$missing_runtime_profile" runtime.llm_backend)" "fallback runtime backend"
+assert_eq "T1" "$(json_get "$missing_runtime_profile" tier.recommended)" "fallback tier"
+assert_eq "docker-compose.base.yml,docker-compose.cpu.yml" \
+    "$(json_get "$missing_runtime_profile" compose.overlays)" "fallback compose overlays"
+
+installer_fallback="$(
+    ODS_DRM_SYS="$TMP_DIR/sys" \
+    ODS_DEV_DRI="$TMP_DIR/dev/dri" \
+    ODS_LEVEL_ZERO_AVAILABLE=0 \
+    ODS_DETECT_OS_OVERRIDE=linux \
+    ROOT_DIR="$ROOT_DIR" \
+        bash -s <<'SH'
+set -euo pipefail
+SCRIPT_DIR="$ROOT_DIR"
+LOG_FILE=/dev/null
+log() { :; }
+warn() { :; }
+ai() { :; }
+ai_warn() { :; }
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/installers/lib/detection.sh"
+detect_gpu
+ensure_intel_sycl_or_cpu_fallback
+printf '%s|%s|%s\n' "$GPU_BACKEND" "$GPU_COUNT" "$GPU_VRAM"
+SH
+)"
+assert_eq "cpu|0|0" "$installer_fallback" "phase-02 Intel fail-closed fallback"
+
+echo "[intel] unsupported Intel devices and platforms do not claim Arc support"
+reset_fixture
+add_gpu 0 0x8086 0x9a49 1073741824 "Intel Iris Xe"
+unsupported_profile="$TMP_DIR/intel-integrated.json"
+build_profile "$unsupported_profile" 1
+assert_eq "none" "$(json_get "$unsupported_profile" gpu.vendor)" "integrated Intel vendor"
+assert_eq "cpu" "$(json_get "$unsupported_profile" runtime.llm_backend)" "integrated Intel backend"
+
+wsl_classification="$(
+    "$ROOT_DIR/scripts/classify-hardware.sh" \
+        --platform-id wsl \
+        --gpu-vendor intel \
+        --memory-type discrete \
+        --vram-mb 16384 \
+        --device-id 0x56a0 \
+        --gpu-name "Intel Arc A770"
+)"
+assert_eq "cpu" "$(
+    python3 -c 'import json,sys; print(json.load(sys.stdin)["recommended"]["backend"])' \
+        <<<"$wsl_classification"
+)" "WSL Intel backend"
+
+echo "[regression] AMD and CPU profiles keep their existing routes"
+reset_fixture
+add_gpu 0 0x1002 0x744c 17179869184 "AMD Radeon RX 7900 GRE"
+amd_profile="$TMP_DIR/amd.json"
+build_profile "$amd_profile" 0
+assert_eq "amd" "$(json_get "$amd_profile" gpu.vendor)" "AMD vendor"
+assert_eq "amd" "$(json_get "$amd_profile" runtime.llm_backend)" "AMD backend"
+assert_eq "docker-compose.base.yml,docker-compose.amd.yml" \
+    "$(json_get "$amd_profile" compose.overlays)" "AMD overlays"
+
+reset_fixture
+cpu_profile="$TMP_DIR/cpu.json"
+build_profile "$cpu_profile" 0
+assert_eq "none" "$(json_get "$cpu_profile" gpu.vendor)" "CPU vendor"
+assert_eq "cpu" "$(json_get "$cpu_profile" runtime.llm_backend)" "CPU backend"
+assert_eq "docker-compose.base.yml,docker-compose.cpu.yml" \
+    "$(json_get "$cpu_profile" compose.overlays)" "CPU overlays"
+
+echo "[PASS] Intel Arc installer routing contracts"


### PR DESCRIPTION
## Summary

Intel Arc GPUs are detected as `GPU_BACKEND=intel`, but there was no `config/backends/intel.json`. So the backend loader couldn't find a contract, fell back to defaults, and printed a warning, even though Intel already has its own tiers (`ARC`, `ARC_LITE`) and compose overlay.

This adds the missing contract, pointing Intel at the SYCL llama-server (port 8080, `/health`, provider `local-sycl`) like the other backends. I also added it to the backend-contract test so it can't go missing again.

## Changed Surface

- [x] Model routing / Hermes / capabilities

## Risk And Validation

- Risk level: Low

​```text
bash scripts/load-backend-contract.sh --backend intel --env   # resolves now; previously exited 1
bash tests/contracts/test-installer-contracts.sh              # backend contract section passes
bash tests/test-tier-map.sh                                   # 128 passed, 0 failed
make lint                                                     # passed
​```

## Notes

Only adds the backend contract. Arc model choices in `tier-map.sh` are unchanged; confirming those on real hardware is a good follow-up.