### PR TITLE
fix(installer): answer for the current run's background tasks

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -151,6 +151,9 @@ jobs:
       - name: Windows Missing Service Hint Tests
         run: bash tests/test-windows-missing-service-hints.sh
 
+      - name: Background Task Registry Tests
+        run: bash tests/test-background-tasks.sh
+
       - name: Install Readiness Summary Tests
         run: bash tests/test-install-readiness-summary.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -83,6 +83,9 @@ test: ## Run unit and contract tests
 	@echo "=== brave-search searxng compat contract ==="
 	@bash tests/test-brave-search-searxng-compat.sh
 	@echo ""
+	@echo "=== installer background task registry ==="
+	@bash tests/test-background-tasks.sh
+	@echo ""
 	@echo "=== ods-cli pipefail tolerance ==="
 	@bash tests/test-ods-cli-pipefail-tolerance.sh
 	@echo ""

--- a/ods/installers/lib/background-tasks.sh
+++ b/ods/installers/lib/background-tasks.sh
@@ -22,12 +22,12 @@ bg_task_start() {
     local pid="$2"
     local description="$3"
     local log_file="$4"
-    
+
     # Create registry if it doesn't exist
     if [[ ! -f "$BG_TASK_REGISTRY" ]]; then
         echo "[]" > "$BG_TASK_REGISTRY"
     fi
-    
+
     # Add task to registry
     python3 - "$BG_TASK_REGISTRY" "$task_id" "$pid" "$description" "$log_file" <<'PY'
 import json
@@ -42,7 +42,23 @@ pid = int(sys.argv[3])
 description = sys.argv[4]
 log_file = sys.argv[5]
 
-tasks = json.loads(registry_path.read_text())
+# The registry is a scratch file under /tmp shared by every run on the host.
+# A leftover from an earlier boot, a truncated write, or an unrelated file at
+# the same path must not abort the installer that is calling us — start over
+# instead. Nothing durable lives here; the tasks are re-registered by the run
+# that owns them.
+try:
+    tasks = json.loads(registry_path.read_text())
+except (OSError, ValueError):
+    tasks = []
+if not isinstance(tasks, list):
+    tasks = []
+
+# Replace any record carrying this id. A previous install registers the same
+# well-known ids ("sdxl-download", "full-model-download") with pids that are
+# now dead or, worse, recycled by an unrelated process; a lookup that found
+# one of those would report the wrong state for the task this run started.
+tasks = [t for t in tasks if not (isinstance(t, dict) and t.get("id") == task_id)]
 tasks.append({
     "id": task_id,
     "pid": pid,
@@ -88,8 +104,20 @@ task_id = sys.argv[2]
 if not registry_path.exists():
     sys.exit(3)
 
-tasks = json.loads(registry_path.read_text())
-task = next((t for t in tasks if t["id"] == task_id), None)
+try:
+    tasks = json.loads(registry_path.read_text())
+except (OSError, ValueError):
+    sys.exit(3)  # unreadable scratch file — same answer as "no such task"
+if not isinstance(tasks, list):
+    sys.exit(3)
+
+# Newest record wins: a registry written before ids were deduplicated can
+# still hold a stale entry for this id from an earlier run.
+task = next(
+    (t for t in reversed(tasks)
+     if isinstance(t, dict) and t.get("id") == task_id and "pid" in t),
+    None,
+)
 
 if not task:
     sys.exit(3)

--- a/ods/tests/test-background-tasks.sh
+++ b/ods/tests/test-background-tasks.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ODS — Background Task Registry Tests
+# ============================================================================
+# Part of: tests/
+# Purpose: The registry lives at a fixed path under /tmp and is shared by
+#          every run on the host. Re-running the installer registers the same
+#          well-known ids ("sdxl-download", "full-model-download") again, so
+#          a lookup must answer for the run that is actually in flight.
+#
+# Usage: ./test-background-tasks.sh
+# ============================================================================
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB="$SCRIPT_DIR/../installers/lib/background-tasks.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+assert_eq() {
+    local label="$1" expected="$2" actual="$3"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        echo "  [PASS] $label"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        echo "  [FAIL] $label: expected '$expected', got '$actual'"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+new_registry() {
+    BG_TASK_REGISTRY="$(mktemp -u)"
+    export BG_TASK_REGISTRY
+}
+
+registry_len() {
+    python3 -c 'import json,sys; print(len(json.load(open(sys.argv[1]))))' "$BG_TASK_REGISTRY"
+}
+
+dead_pid() {
+    # A pid that has certainly exited: spawn, reap, reuse the number.
+    local p
+    sleep 0 &
+    p=$!
+    wait "$p" 2>/dev/null
+    echo "$p"
+}
+
+# shellcheck source=../installers/lib/background-tasks.sh
+. "$LIB"
+
+# ── A re-run must not inherit the previous run's record ────────────────────
+
+test_reregistering_replaces_stale_record() {
+    echo "Testing: re-registering a task id replaces the stale record"
+    new_registry
+
+    bg_task_start "sdxl-download" "$(dead_pid)" "previous run" "/nonexistent.log"
+
+    sleep 30 &
+    local live=$!
+    bg_task_start "sdxl-download" "$live" "current run" "/nonexistent.log"
+
+    assert_eq "one record per task id" "1" "$(registry_len)"
+
+    bg_task_status "sdxl-download"
+    assert_eq "status reports the live task as running" "0" "$?"
+
+    kill "$live" 2>/dev/null
+    wait "$live" 2>/dev/null
+    rm -f "$BG_TASK_REGISTRY"
+}
+
+test_legacy_duplicates_resolve_to_newest() {
+    echo "Testing: a registry with duplicate ids answers for the newest record"
+    new_registry
+    local live
+    sleep 30 &
+    live=$!
+    # Hand-built registry in the pre-dedup shape, stale record first.
+    python3 - "$BG_TASK_REGISTRY" "$(dead_pid)" "$live" <<'PY'
+import json, sys
+json.dump(
+    [
+        {"id": "full-model-download", "pid": int(sys.argv[2]),
+         "description": "previous run", "log_file": "/nonexistent.log",
+         "status": "running"},
+        {"id": "full-model-download", "pid": int(sys.argv[3]),
+         "description": "current run", "log_file": "/nonexistent.log",
+         "status": "running"},
+    ],
+    open(sys.argv[1], "w"),
+)
+PY
+
+    bg_task_status "full-model-download"
+    assert_eq "newest record wins" "0" "$?"
+
+    kill "$live" 2>/dev/null
+    wait "$live" 2>/dev/null
+    rm -f "$BG_TASK_REGISTRY"
+}
+
+# ── A junk file at the shared /tmp path must not abort the installer ───────
+
+test_corrupt_registry_is_recoverable() {
+    echo "Testing: a corrupt registry does not abort the caller"
+    new_registry
+    printf 'not json at all' > "$BG_TASK_REGISTRY"
+
+    bg_task_start "sdxl-download" "$$" "current run" "/nonexistent.log"
+    assert_eq "bg_task_start succeeds over a corrupt registry" "0" "$?"
+    assert_eq "registry rebuilt with just this task" "1" "$(registry_len)"
+
+    rm -f "$BG_TASK_REGISTRY"
+}
+
+test_corrupt_registry_status_is_not_found() {
+    echo "Testing: status over a corrupt registry reports not-found"
+    new_registry
+    printf '{"not": "a list"}' > "$BG_TASK_REGISTRY"
+
+    bg_task_status "sdxl-download"
+    assert_eq "status returns 3 (not found)" "3" "$?"
+
+    rm -f "$BG_TASK_REGISTRY"
+}
+
+# ── Existing contract still holds ──────────────────────────────────────────
+
+test_status_codes_unchanged() {
+    echo "Testing: documented status codes are unchanged"
+    new_registry
+
+    bg_task_status "never-registered"
+    assert_eq "missing registry -> 3" "3" "$?"
+
+    local live
+    sleep 30 &
+    live=$!
+    bg_task_start "running-task" "$live" "d" "/nonexistent.log"
+    bg_task_status "running-task"
+    assert_eq "running -> 0" "0" "$?"
+    bg_task_status "other-task"
+    assert_eq "unknown id -> 3" "3" "$?"
+    kill "$live" 2>/dev/null
+    wait "$live" 2>/dev/null
+
+    bg_task_start "finished-task" "$(dead_pid)" "d" "/nonexistent.log"
+    bg_task_status "finished-task"
+    assert_eq "exited with no log -> 1" "1" "$?"
+
+    local logfile
+    logfile="$(mktemp)"
+    echo "ERROR: download aborted" > "$logfile"
+    bg_task_start "broken-task" "$(dead_pid)" "d" "$logfile"
+    bg_task_status "broken-task"
+    assert_eq "exited with an error log -> 2" "2" "$?"
+    rm -f "$logfile" "$BG_TASK_REGISTRY"
+}
+
+echo "=== Background Task Registry Tests ==="
+echo
+test_reregistering_replaces_stale_record
+echo
+test_legacy_duplicates_resolve_to_newest
+echo
+test_corrupt_registry_is_recoverable
+echo
+test_corrupt_registry_status_is_not_found
+echo
+test_status_codes_unchanged
+
+echo
+echo "=== Test Summary ==="
+echo "Tests run:    $TESTS_RUN"
+echo "Tests passed: $TESTS_PASSED"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+    echo "Tests failed: $TESTS_FAILED"
+    exit 1
+fi
+echo "All tests passed!"
+exit 0


### PR DESCRIPTION
﻿## Problem

`BG_TASK_REGISTRY` defaults to `/tmp/ods-bg-tasks.json` — a fixed path shared by every run on the host. Nothing clears it.

`bg_task_start` appended unconditionally:

```python
tasks = json.loads(registry_path.read_text())
tasks.append({"id": task_id, "pid": pid, ...})
```

`bg_task_status` took the **first** matching record:

```python
task = next((t for t in tasks if t["id"] == task_id), None)
```

Re-running the installer registers the same well-known ids again — `"sdxl-download"` (phase 11) and `"full-model-download"` (bootstrap upgrade) — so every lookup answers with the *previous* run's record.

Reproduced against the shipped lib (register under a dead pid, then register the same id under a live one):

```
records in registry : 2
live pid            : 694   (dead pid was 684)
bg_task_status rc   : 1   (0=running 1=completed 2=failed 3=not found)
```

The task is running; the registry says it finished.

Both directions land on a user:

- **`13-summary.sh`** prints `SDXL Lightning model download completed` for a download still in flight, or reports a failure by grepping `ERROR` out of the *previous* run's log.
- **`12-health.sh`** treats `bg_task_status ... == 0` as "a model download is active" and **skips the blocking LLM health wait** entirely. A pid from an earlier run that the kernel has since recycled onto an unrelated process keeps `os.kill(pid, 0)` succeeding forever, so the installer finishes and declares success without ever probing `llama-server`.

## Fix

- `bg_task_start` replaces any record carrying the same id instead of appending a duplicate.
- The lookup prefers the **newest** match, so a registry file left by an earlier release (already holding duplicates) still resolves to the right run.

Also: a junk file at the shared `/tmp` path aborted the caller. `/tmp` is world-writable and the registry is pure scratch state, but `json.loads` raising made `bg_task_start` exit non-zero — and phase 11 calls it as the last command of an `if` body under `set -euo pipefail`, so the install dies. Unparseable content now restarts the file, and `bg_task_status` answers `3` (not found), which every call site already handles.

Narrow `(OSError, ValueError)` at an I/O boundary, mapping to a distinct meaningful state — nothing about a real task is swallowed.

## Verification

New `tests/test-background-tasks.sh`, 11 assertions, **6 red before the fix**:

```
[FAIL] one record per task id: expected '1', got '2'
[FAIL] status reports the live task as running: expected '0', got '1'
[FAIL] newest record wins: expected '0', got '1'
[FAIL] bg_task_start succeeds over a corrupt registry: expected '0', got '1'
[FAIL] registry rebuilt with just this task: expected '1', got ''
[FAIL] status returns 3 (not found): expected '3', got '1'
```

The remaining 5 pin the documented status codes (`0` running / `1` completed / `2` failed-per-log / `3` not found) and pass both before and after — the contract `12-health.sh` and `13-summary.sh` switch on is unchanged.

Wired into `make test` and `test-linux.yml`.

## Why this matters

Installer reruns reuse fixed background-task IDs. Status and wait calls must answer for the current process rather than a stale record from an earlier download.

## Overlap check

Triage refresh (2026-08-08): searched open and closed Osmantic/ODS PRs by semantic keywords (background task current run stale), inspected the changed production files, and checked patch equivalence against current upstream/main. No strict duplicate or merged equivalent was found.

## Test plan

- [x] `bash ods/tests/test-background-tasks.sh`
