### PR TITLE
fix(qrcode): read the LAN IP from the src field, not column 7

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -68,6 +68,9 @@ jobs:
       - name: Health Check Tests
         run: bash tests/test-health-check.sh
 
+      - name: QR Code Helper Tests
+        run: bash tests/test-qrcode-helper.sh
+
       - name: n8n Cookie Policy Tests
         run: bash tests/test-n8n-cookie-policy.sh
 

--- a/ods/Makefile
+++ b/ods/Makefile
@@ -55,6 +55,9 @@ test: ## Run unit and contract tests
 	@echo "=== safe .env loading (quote/CRLF handling) ==="
 	@bash tests/test-safe-env.sh
 	@echo ""
+	@echo "=== QR code helper LAN detection ==="
+	@bash tests/test-qrcode-helper.sh
+	@echo ""
 	@echo "=== Bind address sweep ==="
 	@bash tests/test-bind-address-sweep.sh
 	@bash tests/test-n8n-cookie-policy.sh

--- a/ods/lib/qrcode.sh
+++ b/ods/lib/qrcode.sh
@@ -7,10 +7,17 @@
 # ═══════════════════════════════════════════════════════════════
 
 # Best-effort LAN IP detection for remote access URLs.
+#
+# The address is read from the `src` field by name, not by column. `ip route
+# get` only emits `via <gw>` when the route has a gateway; on an on-link
+# default route (WSL2, point-to-point and VPN links, some cloud VMs) the two
+# fields are absent and the column that held the address holds `uid` instead.
+# Same parse as installers/phases/06-directories.sh's HOST_LAN_IP detection.
 _ods_lan_ip() {
     local lan_ip=""
     if command -v ip >/dev/null 2>&1; then
-        lan_ip=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
+        lan_ip=$(ip -4 route get 1.1.1.1 2>/dev/null \
+            | awk '{for (i = 1; i <= NF; i++) if ($i == "src") { print $(i + 1); exit }}')
     fi
 
     if [[ -z "$lan_ip" ]] && command -v ifconfig >/dev/null 2>&1; then

--- a/ods/tests/test-qrcode-helper.sh
+++ b/ods/tests/test-qrcode-helper.sh
@@ -29,6 +29,34 @@ fi
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
+# ── `ip route get` shapes ──────────────────────────────────────────────────
+# The source address must be read from the `src` field by name. A route with
+# no gateway omits `via <gw>`, which shifts every later column left by two.
+
+route_shim() {
+    # route_shim <route line>
+    cat > "$tmpdir/ip" <<SH
+#!/usr/bin/env bash
+echo "$1"
+SH
+    chmod +x "$tmpdir/ip"
+}
+
+route_shim "1.1.1.1 via 192.168.1.1 dev eth0 src 192.168.1.50 uid 1000"
+lan_ip=$(PATH="$tmpdir:$PATH" _ods_lan_ip)
+[[ "$lan_ip" == "192.168.1.50" ]] \
+    || fail "_ods_lan_ip misread a gateway route: got '$lan_ip'"
+
+route_shim "1.1.1.1 dev eth0 src 172.28.112.1 uid 1000"
+lan_ip=$(PATH="$tmpdir:$PATH" _ods_lan_ip)
+[[ "$lan_ip" == "172.28.112.1" ]] \
+    || fail "_ods_lan_ip misread an on-link (gateway-less) route: got '$lan_ip'"
+
+route_shim "1.1.1.1 dev tun0 src 10.8.0.6 uid 1000"
+default_output=$(PATH="$tmpdir:$PATH" print_dashboard_qr)
+grep -Fq "http://10.8.0.6:3001" <<< "$default_output" \
+    || fail "print_dashboard_qr did not use the on-link route's source address"
+
 cat > "$tmpdir/ip" <<'SH'
 #!/usr/bin/env bash
 exit 1


### PR DESCRIPTION
## Problem

`_ods_lan_ip` parsed `ip route get` output by column:

```bash
lan_ip=$(ip route get 1 2>/dev/null | awk '{print $7; exit}')
```

`ip route get` prints `via <gateway>` **only when the route has one**. On an on-link default route those two fields are absent and everything after shifts left by two, so column 7 lands on the uid:

```
route: 1.0.0.0 via 192.168.1.1 dev eth0 src 192.168.1.50 uid 1000
  positional $7 -> 192.168.1.50
  src field     -> 192.168.1.50

route: 1.0.0.0 dev eth0 src 172.28.112.1 uid 1000
  positional $7 -> 1000          ← the uid
  src field     -> 172.28.112.1
```

On-link default routes are normal on WSL2, point-to-point and VPN interfaces (`tun0`/`wg0`), and several cloud VM images.

The value flows straight into user-facing output:

- `print_success_card` prints `Remote Access (LAN): Dashboard: http://1000:3001`
- `print_dashboard_qr` encodes that same string into the QR code the install summary tells the user to scan from their phone

Nothing validates it, so the failure is silent — the user just gets a QR that goes nowhere.

## Fix

Read the address from the `src` field by name, which is what `installers/phases/06-directories.sh` already does for `HOST_LAN_IP`:

```bash
ip -4 route get 1.1.1.1 | awk '{for (i = 1; i <= NF; i++) if ($i == "src") { print $(i + 1); exit }}'
```

`-4` is added for the same reason the installer uses it: an IPv6 answer can never fit the `http://<ip>:3001` shape these callers build.

The `ifconfig` fallback is untouched.

## Verification

`tests/test-qrcode-helper.sh` gains three cases — gateway route, on-link route, and the dashboard URL that comes out of the on-link case. Red before the fix:

```
[FAIL] _ods_lan_ip misread an on-link (gateway-less) route: got '1000'
```

The existing macOS-`ifconfig` and explicit-URL assertions still pass.

**Test wiring:** `tests/test-qrcode-helper.sh` had no runner — neither `make test` nor any workflow invoked it — so its existing assertions never gated anything either. Now wired into both.
