### PR TITLE
fix(windows): recover Compose and native runtime state

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -83,3 +83,7 @@ jobs:
       - name: Windows Port Preflight Contract
         shell: pwsh
         run: ./tests/test-windows-port-preflight.ps1
+
+      - name: Windows Runtime Recovery Contract
+        shell: pwsh
+        run: ./tests/contracts/test-windows-runtime-recovery.ps1

--- a/ods/installers/windows/docker-compose.windows-amd.local.yml
+++ b/ods/installers/windows/docker-compose.windows-amd.local.yml
@@ -19,8 +19,8 @@ services:
       - -c
       - |
         echo "Waiting for native inference server on host..."
-        while ! { wget -qO- "http://host.docker.internal:8080/api/v1/health" >/dev/null 2>&1 \
-              || wget -qO- "http://host.docker.internal:8080/health"        >/dev/null 2>&1; }; do
+        while ! { wget -qO- "http://host.docker.internal:${AMD_INFERENCE_PORT:-8080}/api/v1/health" >/dev/null 2>&1 \
+              || wget -qO- "http://host.docker.internal:${AMD_INFERENCE_PORT:-8080}/health"        >/dev/null 2>&1; }; do
           sleep 2
         done
         echo "Inference server is ready"
@@ -28,7 +28,7 @@ services:
     healthcheck:
       test:
         - "CMD-SHELL"
-        - 'wget -qO- "http://host.docker.internal:8080/api/v1/health" >/dev/null 2>&1 || wget -qO- "http://host.docker.internal:8080/health" >/dev/null 2>&1 || exit 1'
+        - 'wget -qO- "http://host.docker.internal:${AMD_INFERENCE_PORT:-8080}/api/v1/health" >/dev/null 2>&1 || wget -qO- "http://host.docker.internal:${AMD_INFERENCE_PORT:-8080}/health" >/dev/null 2>&1 || exit 1'
       interval: 10s
       timeout: 5s
       retries: 90

--- a/ods/installers/windows/docker-compose.windows-amd.yml
+++ b/ods/installers/windows/docker-compose.windows-amd.yml
@@ -15,7 +15,7 @@ services:
 
   dashboard-api:
     environment:
-      - OLLAMA_URL=http://host.docker.internal:8080
+      - OLLAMA_URL=http://host.docker.internal:${AMD_INFERENCE_PORT:-8080}
       - LLM_BACKEND=${LLM_BACKEND:-lemonade}
       - LLM_API_BASE_PATH=${LLM_API_BASE_PATH:-/v1}
       - AMD_INFERENCE_RUNTIME=${AMD_INFERENCE_RUNTIME:-}
@@ -37,5 +37,5 @@ services:
       # LLM_API_BASE_PATH set by installer: /api/v1 for Lemonade, /v1 for llama-server
       # Switchboard mode writes OPEN_WEBUI_LLM_BASE_URL/API_KEY in .env so
       # Open WebUI follows the stable ods/current route through LiteLLM.
-      OPENAI_API_BASE_URL: "${OPEN_WEBUI_LLM_BASE_URL:-http://host.docker.internal:8080${LLM_API_BASE_PATH:-/v1}}"
+      OPENAI_API_BASE_URL: "${OPEN_WEBUI_LLM_BASE_URL:-http://host.docker.internal:${AMD_INFERENCE_PORT:-8080}${LLM_API_BASE_PATH:-/v1}}"
       OPENAI_API_KEY: "${OPEN_WEBUI_LLM_API_KEY:-${OPENAI_API_KEY:-}}"

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -90,6 +90,19 @@ $LibDir = Join-Path $ScriptDir "lib"
 . (Join-Path $LibDir "readiness-summary.ps1")
 . (Join-Path $LibDir "service-plan.ps1")
 
+# Preserve the caller's Docker client configuration before any installer phase
+# changes location. Docker accepts relative DOCKER_CONFIG values, whose meaning
+# must remain anchored to the directory from which the installer was launched.
+$script:ODSWindowsOriginalDockerConfigDefined = (
+    (Test-Path Env:DOCKER_CONFIG) -and
+    -not [string]::IsNullOrWhiteSpace($env:DOCKER_CONFIG)
+)
+$script:ODSWindowsOriginalDockerConfig = if ($script:ODSWindowsOriginalDockerConfigDefined) {
+    Get-ODSUserDockerConfigDir -DockerConfigOverride $env:DOCKER_CONFIG
+} else {
+    ""
+}
+
 # ── Phase context variables ───────────────────────────────────────────────────
 # These are plain (non-$script:) variables set in the orchestrator scope.
 # Because phases are dot-sourced, they run in this same scope and can both
@@ -210,7 +223,14 @@ if ($gpuInfo.Backend -eq "amd") {
     $script:LEMONADE_EXE = Join-Path (Join-Path $script:LEMONADE_INSTALL_DIR "bin") ([string]$amdLemonadeRuntime.windows_executable)
     $_resolvedLemonadeExe = Resolve-ODSLemonadeExe -ExecutableName ([string]$amdLemonadeRuntime.windows_executable)
     if ($_resolvedLemonadeExe) { $script:LEMONADE_EXE = $_resolvedLemonadeExe }
-    $script:LEMONADE_PORT = [int]$amdLemonadeRuntime.api_port
+    $script:LEMONADE_PORT = if ($cloudMode) {
+        [int]$amdLemonadeRuntime.api_port
+    } else {
+        Resolve-WindowsLlmPreflightPort `
+            -GpuBackend "amd" `
+            -LemonadeDefaultPort ([int]$amdLemonadeRuntime.api_port) `
+            -InstallDir $installDir
+    }
     $script:LEMONADE_HEALTH_URL = "http://127.0.0.1:$($script:LEMONADE_PORT)$($amdLemonadeRuntime.health_path)"
 }
 . (Join-Path $PhasesDir "06-directories.ps1")
@@ -514,11 +534,6 @@ if ($dryRun) {
                 $taskName = "ODSLemonadeRuntime"
                 $taskNames = @($taskName, (Get-ODSPriorLemonadeTaskName))
                 Stop-ODSWindowsLemonadeProcesses -ExePath $script:LEMONADE_EXE -TaskNames $taskNames
-                foreach ($listener in @(Get-NetTCPConnection -LocalPort $script:LEMONADE_PORT -State Listen -ErrorAction SilentlyContinue)) {
-                    if ($listener.OwningProcess -gt 0) {
-                        Stop-Process -Id ([int]$listener.OwningProcess) -Force -ErrorAction SilentlyContinue
-                    }
-                }
                 $pidDir = Split-Path $script:INFERENCE_PID_FILE
                 New-Item -ItemType Directory -Path $pidDir -Force | Out-Null
 
@@ -690,7 +705,7 @@ if ($dryRun) {
                 $llamaArgs = @(
                     "--model", $modelFullPath,
                     "--host", $bindAddr,
-                    "--port", "8080",
+                    "--port", [string]$script:LEMONADE_PORT,
                     "--n-gpu-layers", "999",
                     "--ctx-size", "$($tierConfig.MaxContext)"
                 )
@@ -767,7 +782,7 @@ if ($dryRun) {
                 while ($waited -lt $maxWait) {
                     Start-Sleep -Seconds 2; $waited += 2
                     try {
-                        $req = [System.Net.HttpWebRequest]::Create("http://localhost:8080/health")
+                        $req = [System.Net.HttpWebRequest]::Create("http://127.0.0.1:$($script:LEMONADE_PORT)/health")
                         $req.Timeout = 3000; $req.Method = "GET"
                         $resp = $req.GetResponse(); $code = [int]$resp.StatusCode; $resp.Close()
                         if ($code -eq 200) { $healthy = $true; break }
@@ -791,7 +806,7 @@ if ($dryRun) {
                     $envContent = $envContent -replace "(?m)^AMD_INFERENCE_RUNTIME=.*$", "AMD_INFERENCE_RUNTIME=llama-server"
                     $envContent = $envContent -replace "(?m)^AMD_INFERENCE_BACKEND=.*$", "AMD_INFERENCE_BACKEND=vulkan"
                     $envContent = $envContent -replace "(?m)^AMD_INFERENCE_LOCATION=.*$", "AMD_INFERENCE_LOCATION=host"
-                    $envContent = $envContent -replace "(?m)^AMD_INFERENCE_PORT=.*$", "AMD_INFERENCE_PORT=8080"
+                    $envContent = $envContent -replace "(?m)^AMD_INFERENCE_PORT=.*$", "AMD_INFERENCE_PORT=$($script:LEMONADE_PORT)"
                     $envContent = $envContent -replace "(?m)^AMD_INFERENCE_SUPPORTED_BACKENDS=.*$", "AMD_INFERENCE_SUPPORTED_BACKENDS=vulkan"
                     $envContent = $envContent -replace "(?m)^AMD_INFERENCE_RUNTIME_MODE=.*$", "AMD_INFERENCE_RUNTIME_MODE=windows-llama-server-fallback"
                     $envContent = $envContent -replace "(?m)^AMD_INFERENCE_MANAGED=.*$", "AMD_INFERENCE_MANAGED=true"
@@ -802,7 +817,7 @@ if ($dryRun) {
                     $nativeModel = ([regex]::Match($envContent, "(?m)^GGUF_FILE=([^\r\n]+)\r?$")).Groups[1].Value.Trim().Trim('"').Trim("'")
                     if ([string]::IsNullOrWhiteSpace($nativeModel)) { $nativeModel = $tierConfig.GgufFile }
                     $nativePort = ([regex]::Match($envContent, "(?m)^AMD_INFERENCE_PORT=([^\r\n]+)\r?$")).Groups[1].Value.Trim().Trim('"').Trim("'")
-                    if ([string]::IsNullOrWhiteSpace($nativePort)) { $nativePort = "8080" }
+                    if ([string]::IsNullOrWhiteSpace($nativePort)) { $nativePort = [string]$script:LEMONADE_PORT }
                     $nativeApiBase = "http://host.docker.internal:$nativePort/v1"
                     $litellmDir = Join-Path (Join-Path $installDir "config") "litellm"
                     New-Item -ItemType Directory -Path $litellmDir -Force | Out-Null
@@ -1040,16 +1055,14 @@ litellm_settings:
         function Initialize-ODSWindowsDockerClientConfig {
             param([string]$InstallDir)
 
-            $dockerConfigDir = Join-Path (Join-Path $InstallDir "data") "docker-client-public"
-            if (-not (Test-Path $dockerConfigDir)) {
-                New-Item -ItemType Directory -Path $dockerConfigDir -Force | Out-Null
+            $userDockerConfigDir = if ($script:ODSWindowsOriginalDockerConfigDefined -and
+                -not [string]::IsNullOrWhiteSpace($script:ODSWindowsOriginalDockerConfig)) {
+                $script:ODSWindowsOriginalDockerConfig
+            } else {
+                Get-ODSUserDockerConfigDir -DockerConfigOverride ""
             }
-
-            $dockerConfigPath = Join-Path $dockerConfigDir "config.json"
-            if (-not (Test-Path $dockerConfigPath)) {
-                Write-Utf8NoBom -Path $dockerConfigPath -Content "{`n  `"auths`": {}`n}`n"
-            }
-
+            $dockerConfigDir = Initialize-ODSComposeDockerClientConfig `
+                -InstallDir $InstallDir -UserDockerConfigDir $userDockerConfigDir
             $env:DOCKER_CONFIG = $dockerConfigDir
             Write-AI "Using install-scoped Docker client config: $dockerConfigDir"
         }
@@ -1211,8 +1224,6 @@ litellm_settings:
             exit 1
         }
 
-        $script:ODSWindowsOriginalDockerConfigDefined = Test-Path Env:DOCKER_CONFIG
-        $script:ODSWindowsOriginalDockerConfig = if ($script:ODSWindowsOriginalDockerConfigDefined) { $env:DOCKER_CONFIG } else { "" }
         Initialize-ODSWindowsDockerClientConfig -InstallDir $installDir
         $script:ODSWindowsDockerClientArgs = @("--config", $env:DOCKER_CONFIG)
         $script:ODSWindowsUserDockerClientArgs = @(Get-ODSWindowsUserDockerClientArgs)
@@ -2282,7 +2293,7 @@ if (Test-ODSWindowsServiceEnabled -ServiceId "perplexica" -Plan $servicePlan) {
     $perplexicaBaseUrl = $(if ($useLemonade -or $cloudMode) {
         "http://litellm:4000/v1"
     } elseif ([string]$llmEndpoint["Backend"] -eq "native-llama-server") {
-        "http://host.docker.internal:8080/v1"
+        "http://host.docker.internal:$($llmEndpoint['Port'])/v1"
     } else {
         "http://llama-server:8080/v1"
     })

--- a/ods/installers/windows/lib/compose-diagnostics.ps1
+++ b/ods/installers/windows/lib/compose-diagnostics.ps1
@@ -16,18 +16,86 @@ function Get-ODSComposeEnvFileArgs {
     return @()
 }
 
+function Get-ODSUserDockerConfigDir {
+    param([string]$DockerConfigOverride = $env:DOCKER_CONFIG)
+
+    if (-not [string]::IsNullOrWhiteSpace($DockerConfigOverride)) {
+        return $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath(
+            $DockerConfigOverride
+        )
+    }
+
+    $userProfile = $env:USERPROFILE
+    if ([string]::IsNullOrWhiteSpace($userProfile)) {
+        $userProfile = [Environment]::GetFolderPath([Environment+SpecialFolder]::UserProfile)
+    }
+    if ([string]::IsNullOrWhiteSpace($userProfile)) { return $null }
+    return (Join-Path $userProfile ".docker")
+}
+
+function Get-ODSUserDockerCliPluginDirs {
+    param([string]$UserDockerConfigDir)
+
+    if ([string]::IsNullOrWhiteSpace($UserDockerConfigDir)) { return @() }
+
+    $candidates = New-Object System.Collections.Generic.List[string]
+    $defaultPluginDir = Join-Path $UserDockerConfigDir "cli-plugins"
+    $candidates.Add($defaultPluginDir)
+
+    $userConfigPath = Join-Path $UserDockerConfigDir "config.json"
+    if (Test-Path -LiteralPath $userConfigPath -PathType Leaf) {
+        try {
+            $userConfig = Get-Content -LiteralPath $userConfigPath -Raw -ErrorAction Stop |
+                ConvertFrom-Json -ErrorAction Stop
+            foreach ($pluginDir in @($userConfig.cliPluginsExtraDirs)) {
+                if (-not [string]::IsNullOrWhiteSpace([string]$pluginDir)) {
+                    $candidates.Add([string]$pluginDir)
+                }
+            }
+        } catch { }
+    }
+
+    $resolved = New-Object System.Collections.Generic.List[string]
+    foreach ($candidate in $candidates) {
+        try {
+            if (-not (Test-Path -LiteralPath $candidate -PathType Container)) { continue }
+            $fullPath = (Resolve-Path -LiteralPath $candidate -ErrorAction Stop).Path
+            if (-not ($resolved | Where-Object { $_.Equals($fullPath, [StringComparison]::OrdinalIgnoreCase) })) {
+                $resolved.Add($fullPath)
+            }
+        } catch { }
+    }
+    return @($resolved)
+}
+
 function Initialize-ODSComposeDockerClientConfig {
-    param([string]$InstallDir)
+    param(
+        [string]$InstallDir,
+        [string]$UserDockerConfigDir = (Get-ODSUserDockerConfigDir)
+    )
 
     $dockerConfigDir = Join-Path (Join-Path $InstallDir "data") "docker-client-public"
     if (-not (Test-Path $dockerConfigDir)) {
         New-Item -ItemType Directory -Path $dockerConfigDir -Force | Out-Null
     }
 
+    $dockerConfig = [ordered]@{ auths = [ordered]@{} }
+    $pluginDirs = @(Get-ODSUserDockerCliPluginDirs -UserDockerConfigDir $UserDockerConfigDir)
+    if ($pluginDirs.Count -gt 0) {
+        $dockerConfig["cliPluginsExtraDirs"] = $pluginDirs
+    }
+
+    # Rebuild on every invocation so existing installs gain plugin discovery
+    # without copying credential helpers or registry authentication state.
     $dockerConfigPath = Join-Path $dockerConfigDir "config.json"
-    if (-not (Test-Path $dockerConfigPath)) {
-        $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
-        [System.IO.File]::WriteAllText($dockerConfigPath, "{`n  `"auths`": {}`n}`n", $utf8NoBom)
+    $tempConfigPath = "$dockerConfigPath.$PID.tmp"
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    $json = ($dockerConfig | ConvertTo-Json -Depth 4) + "`n"
+    try {
+        [System.IO.File]::WriteAllText($tempConfigPath, $json, $utf8NoBom)
+        Move-Item -LiteralPath $tempConfigPath -Destination $dockerConfigPath -Force
+    } finally {
+        Remove-Item -LiteralPath $tempConfigPath -Force -ErrorAction SilentlyContinue
     }
 
     return $dockerConfigDir
@@ -47,12 +115,18 @@ function Invoke-ODSDockerCompose {
         [Parameter(Mandatory = $true)]
         [string[]]$ComposeArgs
     )
+    $hadDockerConfig = Test-Path Env:DOCKER_CONFIG
+    $previousDockerConfig = $env:DOCKER_CONFIG
+    # Resolve a relative DOCKER_CONFIG against the caller's location, not the
+    # install directory used as the Compose working directory.
+    $userDockerConfigDir = Get-ODSUserDockerConfigDir `
+        -DockerConfigOverride $previousDockerConfig
+
     Push-Location $InstallDir
     try {
-        $dockerConfigDir = Initialize-ODSComposeDockerClientConfig -InstallDir $InstallDir
+        $dockerConfigDir = Initialize-ODSComposeDockerClientConfig `
+            -InstallDir $InstallDir -UserDockerConfigDir $userDockerConfigDir
         $dockerClientArgs = @("--config", $dockerConfigDir)
-        $hadDockerConfig = Test-Path Env:DOCKER_CONFIG
-        $previousDockerConfig = $env:DOCKER_CONFIG
         $prevEAP = $ErrorActionPreference
         $ErrorActionPreference = 'SilentlyContinue'
         $env:DOCKER_CONFIG = $dockerConfigDir

--- a/ods/installers/windows/lib/env-generator.ps1
+++ b/ods/installers/windows/lib/env-generator.ps1
@@ -474,6 +474,12 @@ function New-ODSEnv {
     # llama-server route.
     $windowsAmdHostInference = ($GpuBackend -eq "amd" -and $ODSMode -ne "cloud")
     $windowsAmdLemonade = ($windowsAmdHostInference -and $AmdInferenceRuntime -eq "lemonade")
+    $nativeInferencePort = "8080"
+    $parsedNativeInferencePort = 0
+    if ([int]::TryParse([string]$AmdInferencePort, [ref]$parsedNativeInferencePort) -and
+        $parsedNativeInferencePort -ge 1 -and $parsedNativeInferencePort -le 65535) {
+        $nativeInferencePort = [string]$parsedNativeInferencePort
+    }
     $effectiveODSMode = $(if ($windowsAmdLemonade) { "lemonade" } else { $ODSMode })
     $existingLemonadeModel = Get-EnvOrNew "LEMONADE_MODEL" ""
     $existingGgufFile = Get-EnvOrNew "GGUF_FILE" ""
@@ -507,7 +513,7 @@ function New-ODSEnv {
     $llmApiBasePath = $(if ($windowsAmdLemonade) { "/api/v1" } else { "/v1" })
 
     $llmApiUrl = $(if ($windowsAmdHostInference) {
-        "http://host.docker.internal:8080"
+        "http://host.docker.internal:$nativeInferencePort"
     } elseif ($ODSMode -eq "cloud") {
         "http://litellm:4000"
     } else {
@@ -635,7 +641,7 @@ LLM_API_BASE_PATH=$llmApiBasePath
 AMD_INFERENCE_RUNTIME=$AmdInferenceRuntime
 AMD_INFERENCE_BACKEND=$AmdInferenceBackend
 AMD_INFERENCE_LOCATION=$AmdInferenceLocation
-AMD_INFERENCE_PORT=$AmdInferencePort
+AMD_INFERENCE_PORT=$(if ($windowsAmdHostInference) { $nativeInferencePort } else { $AmdInferencePort })
 AMD_INFERENCE_SUPPORTED_BACKENDS=$AmdInferenceSupportedBackends
 AMD_INFERENCE_RUNTIME_MODE=$AmdInferenceRuntimeMode
 AMD_INFERENCE_MANAGED=$AmdInferenceManaged
@@ -832,7 +838,7 @@ litellm_settings:
     }
 
     if ($windowsAmdLemonade) {
-        $lemonadePort = $(if ($AmdInferencePort) { $AmdInferencePort } else { "8080" })
+        $lemonadePort = $nativeInferencePort
         $null = Write-WindowsODSLemonadeLiteLlmConfig `
             -InstallDir $InstallDir -ModelId $effectiveLemonadeModel `
             -Port $lemonadePort -ApiKey $litellmLemonadeApiKey
@@ -856,7 +862,7 @@ litellm_settings:
         [ordered]@{ id = "llama-server-default"; baseUrl = $routerLlamaBase }
     )
     if ($windowsAmdLemonade) {
-        $lemonadePort = $(if ($AmdInferencePort) { $AmdInferencePort } else { "8080" })
+        $lemonadePort = $nativeInferencePort
         $routerEndpoints += [ordered]@{
             id = "lemonade-default"
             baseUrl = "http://host.docker.internal:$lemonadePort/api"

--- a/ods/installers/windows/lib/llm-endpoint.ps1
+++ b/ods/installers/windows/lib/llm-endpoint.ps1
@@ -155,15 +155,30 @@ function Get-WindowsLocalLlmEndpoint {
         $amdInferenceRuntimeMode = $amdInferenceRuntimeMode.ToLowerInvariant()
     }
 
+    $defaultNativePort = "8080"
+    $configuredConstant = Get-Variable -Name LEMONADE_PORT -Scope Script -ErrorAction SilentlyContinue
+    if ($configuredConstant -and [string]$configuredConstant.Value -match '^\d+$') {
+        $defaultNativePort = [string]$configuredConstant.Value
+    }
+    $nativePort = Get-WindowsODSEnvValue `
+        -EnvMap $EnvMap -Keys @("AMD_INFERENCE_PORT") -Default $defaultNativePort
+    $parsedNativePort = 0
+    if (-not [int]::TryParse($nativePort, [ref]$parsedNativePort) -or
+        $parsedNativePort -lt 1 -or $parsedNativePort -gt 65535) {
+        $nativePort = $defaultNativePort
+    } else {
+        $nativePort = [string]$parsedNativePort
+    }
+
     if ($UseLemonade -or $resolvedNativeBackend -eq "lemonade" -or $llmBackend -eq "lemonade") {
         return @{
             Name = "LLM (Lemonade)"
             Backend = "lemonade"
-            Port = "$($script:LEMONADE_PORT)"
+            Port = $nativePort
             ApiBasePath = "/api/v1"
-            HealthUrl = $script:LEMONADE_HEALTH_URL
-            BaseUrl = "http://localhost:$($script:LEMONADE_PORT)/api/v1"
-            ChatCompletionsUrl = "http://localhost:$($script:LEMONADE_PORT)/api/v1/chat/completions"
+            HealthUrl = "http://127.0.0.1:${nativePort}/api/v1/health"
+            BaseUrl = "http://localhost:${nativePort}/api/v1"
+            ChatCompletionsUrl = "http://localhost:${nativePort}/api/v1/chat/completions"
         }
     }
 
@@ -179,11 +194,11 @@ function Get-WindowsLocalLlmEndpoint {
         return @{
             Name = "LLM (llama-server)"
             Backend = "native-llama-server"
-            Port = "8080"
+            Port = $nativePort
             ApiBasePath = "/v1"
-            HealthUrl = "http://localhost:8080/health"
-            BaseUrl = "http://localhost:8080/v1"
-            ChatCompletionsUrl = "http://localhost:8080/v1/chat/completions"
+            HealthUrl = "http://localhost:${nativePort}/health"
+            BaseUrl = "http://localhost:${nativePort}/v1"
+            ChatCompletionsUrl = "http://localhost:${nativePort}/v1/chat/completions"
         }
     }
 

--- a/ods/installers/windows/ods.ps1
+++ b/ods/installers/windows/ods.ps1
@@ -90,6 +90,23 @@ function Test-Install {
     if (-not (Test-DockerRunning)) { exit 1 }
 }
 
+function Write-ODSUtf8NoBomFile {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
+        [string]$Content
+    )
+
+    $parent = Split-Path -Parent $Path
+    if ($parent -and -not (Test-Path -LiteralPath $parent)) {
+        New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    }
+    $utf8NoBom = New-Object System.Text.UTF8Encoding($false)
+    [System.IO.File]::WriteAllText($Path, $Content, $utf8NoBom)
+}
+
 function Get-ComposeFlags {
     <#
     .SYNOPSIS
@@ -764,45 +781,153 @@ function Get-NativeInferenceStatus {
     #>
     Sync-ODSNativeInferenceConfig
     $backend = Get-NativeInferenceBackend
-    $result = @{ Running = $false; Pid = 0; Healthy = $false; Backend = $backend }
+    $result = @{ Running = $false; Pid = 0; Healthy = $false; Backend = $backend; Recovered = $false }
+    if ($backend -eq "none") { return $result }
 
-    if (-not (Test-Path $script:INFERENCE_PID_FILE)) { return $result }
+    $expectedExecutable = if ($backend -eq "lemonade") { $script:LEMONADE_EXE } else { $script:LLAMA_SERVER_EXE }
+    $healthUrl = if ($backend -eq "lemonade") {
+        $script:LEMONADE_HEALTH_URL
+    } else {
+        "http://127.0.0.1:$($script:LEMONADE_PORT)/health"
+    }
 
-    # Guard the PID parse: this runs with $ErrorActionPreference = "Stop", so
-    # casting an empty or non-numeric PID file to [int] throws a terminating
-    # error and crashes `ods status`/`start`/`stop`. Mirror the numeric guard
-    # used elsewhere and treat a bad PID file as "not running" (and clear it).
-    $rawPid = (Get-Content $script:INFERENCE_PID_FILE -Raw)
-    if (-not $rawPid) { $rawPid = "" }
-    if ($rawPid.Trim() -notmatch '^\d+$') {
-        Remove-Item $script:INFERENCE_PID_FILE -Force -ErrorAction SilentlyContinue
+    $savedPid = 0
+    $pidFileValid = $false
+    if (Test-Path -LiteralPath $script:INFERENCE_PID_FILE -PathType Leaf) {
+        $rawPid = Get-Content -LiteralPath $script:INFERENCE_PID_FILE -Raw -ErrorAction SilentlyContinue
+        if ($rawPid -and $rawPid.Trim() -match '^\d+$') {
+            $savedPid = [int]$rawPid.Trim()
+            $pidFileValid = Test-ODSNativeProcessExecutable `
+                -ProcessId $savedPid -ExpectedExecutable $expectedExecutable
+        }
+        if (-not $pidFileValid) {
+            Remove-Item -LiteralPath $script:INFERENCE_PID_FILE -Force -ErrorAction SilentlyContinue
+        }
+    }
+
+    if ($pidFileValid) {
+        $result.Running = $true
+        $result.Pid = $savedPid
+        $result.Healthy = Test-ODSNativeInferenceHealth -HealthUrl $healthUrl
         return $result
     }
-    $savedPid = [int]$rawPid.Trim()
-    try {
-        $proc = Get-Process -Id $savedPid -ErrorAction SilentlyContinue
-        if ($proc -and -not $proc.HasExited) {
-            $result.Running = $true
-            $result.Pid = $savedPid
 
-            # Health check (Lemonade uses /api/v1/health, llama-server uses /health)
-            $healthUrl = $(if ($backend -eq "lemonade") { $script:LEMONADE_HEALTH_URL } else { "http://localhost:8080/health" })
-            try {
-                $resp = Invoke-WebRequest -Uri $healthUrl `
-                    -TimeoutSec 3 -UseBasicParsing -ErrorAction SilentlyContinue
-                if ($resp.StatusCode -eq 200) {
-                    $result.Healthy = $true
-                }
-            } catch { }
+    # A scheduled task can be restarted outside ods.ps1, leaving a stale PID.
+    # Recover only from a healthy listener owned by the configured executable.
+    if (Test-ODSNativeInferenceHealth -HealthUrl $healthUrl) {
+        $listenerOwnerPid = Get-ODSNativeInferencePortOwnerProcessId `
+            -Port $script:LEMONADE_PORT
+        $listenerPid = if (Test-ODSNativeProcessExecutable `
+            -ProcessId $listenerOwnerPid -ExpectedExecutable $expectedExecutable) {
+            $listenerOwnerPid
+        } else {
+            0
         }
-    } catch { }
-
-    # Clean up stale PID file
-    if (-not $result.Running -and (Test-Path $script:INFERENCE_PID_FILE)) {
-        Remove-Item $script:INFERENCE_PID_FILE -Force -ErrorAction SilentlyContinue
+        if ($listenerPid -le 0 -and $backend -eq "lemonade") {
+            $listenerPid = Get-ODSManagedLemonadeTaskProcessId `
+                -TaskName $script:LEMONADE_TASK_NAME `
+                -ExpectedExecutable $expectedExecutable `
+                -ListenerProcessId $listenerOwnerPid
+        }
+        if ($listenerPid -gt 0) {
+            $pidDir = Split-Path -Parent $script:INFERENCE_PID_FILE
+            New-Item -ItemType Directory -Path $pidDir -Force | Out-Null
+            Set-Content -LiteralPath $script:INFERENCE_PID_FILE -Value $listenerPid
+            $result.Running = $true
+            $result.Pid = $listenerPid
+            $result.Healthy = $true
+            $result.Recovered = $true
+        }
     }
 
     return $result
+}
+
+function Test-ODSNativeProcessExecutable {
+    param(
+        [int]$ProcessId,
+        [string]$ExpectedExecutable
+    )
+
+    if ($ProcessId -le 0 -or [string]::IsNullOrWhiteSpace($ExpectedExecutable)) { return $false }
+    try {
+        $process = Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId" -ErrorAction Stop
+        if (-not $process -or [string]::IsNullOrWhiteSpace([string]$process.ExecutablePath)) { return $false }
+        $actualPath = [System.IO.Path]::GetFullPath([string]$process.ExecutablePath)
+        $expectedPath = [System.IO.Path]::GetFullPath($ExpectedExecutable)
+        return $actualPath.Equals($expectedPath, [StringComparison]::OrdinalIgnoreCase)
+    } catch {
+        return $false
+    }
+}
+
+function Get-ODSNativeInferencePortOwnerProcessId {
+    param([int]$Port)
+
+    if ($Port -lt 1 -or $Port -gt 65535) { return 0 }
+    $owners = @(Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction SilentlyContinue |
+        ForEach-Object { [int]$_.OwningProcess } |
+        Where-Object { $_ -gt 0 } |
+        Select-Object -Unique)
+    if ($owners.Count -eq 1) { return $owners[0] }
+    return 0
+}
+
+function Get-ODSManagedLemonadeTaskProcessId {
+    param(
+        [string]$TaskName,
+        [string]$ExpectedExecutable,
+        [int]$ListenerProcessId
+    )
+
+    if ([string]::IsNullOrWhiteSpace($TaskName) -or
+        [string]::IsNullOrWhiteSpace($ExpectedExecutable) -or
+        $ListenerProcessId -le 0) { return 0 }
+    try {
+        $task = Get-ScheduledTask -TaskName $TaskName -ErrorAction Stop
+        if (-not $task -or [string]$task.State -ne "Running") { return 0 }
+
+        $expectedPath = [System.IO.Path]::GetFullPath($ExpectedExecutable)
+        $processes = @(Get-CimInstance Win32_Process -ErrorAction Stop)
+        $byPid = @{}
+        $matchingPids = @{}
+        foreach ($process in $processes) {
+            $processId = [int]$process.ProcessId
+            if ($processId -le 0) { continue }
+            $byPid[$processId] = $process
+            try {
+                if ([string]::IsNullOrWhiteSpace([string]$process.ExecutablePath)) { continue }
+                $actualPath = [System.IO.Path]::GetFullPath([string]$process.ExecutablePath)
+                if ($actualPath.Equals($expectedPath, [StringComparison]::OrdinalIgnoreCase)) {
+                    $matchingPids[$processId] = $true
+                }
+            } catch { }
+        }
+
+        $currentPid = $ListenerProcessId
+        $visited = @{}
+        for ($depth = 0; $depth -lt 64 -and $currentPid -gt 0; $depth++) {
+            if ($visited.ContainsKey($currentPid)) { return 0 }
+            $visited[$currentPid] = $true
+            if ($matchingPids.ContainsKey($currentPid)) { return $currentPid }
+            if (-not $byPid.ContainsKey($currentPid)) { return 0 }
+            $currentPid = [int]$byPid[$currentPid].ParentProcessId
+        }
+    } catch { }
+    return 0
+}
+
+function Test-ODSNativeInferenceHealth {
+    param([string]$HealthUrl)
+
+    if ([string]::IsNullOrWhiteSpace($HealthUrl)) { return $false }
+    try {
+        $response = Invoke-WebRequest -Uri $HealthUrl `
+            -TimeoutSec 3 -UseBasicParsing -ErrorAction Stop
+        return ($response.StatusCode -ge 200 -and $response.StatusCode -lt 300)
+    } catch {
+        return $false
+    }
 }
 
 function Stop-ODSNativeProcessId {
@@ -901,14 +1026,18 @@ function Stop-ODSLemonadeRuntime {
     if (Test-Path $script:INFERENCE_PID_FILE) {
         $rawPid = (Get-Content -LiteralPath $script:INFERENCE_PID_FILE -Raw).Trim()
         if ($rawPid -match '^\d+$') {
-            Stop-ODSNativeProcessId -ProcessId ([int]$rawPid)
+            $savedPid = [int]$rawPid
+            if (Test-ODSNativeProcessExecutable -ProcessId $savedPid -ExpectedExecutable $script:LEMONADE_EXE) {
+                Stop-ODSNativeProcessId -ProcessId $savedPid
+            }
         }
         Remove-Item -LiteralPath $script:INFERENCE_PID_FILE -Force -ErrorAction SilentlyContinue
     }
 
     foreach ($listener in @(Get-NetTCPConnection -LocalPort $script:LEMONADE_PORT -State Listen -ErrorAction SilentlyContinue)) {
-        if ($listener.OwningProcess -gt 0) {
-            Stop-ODSNativeProcessId -ProcessId ([int]$listener.OwningProcess)
+        $ownerPid = [int]$listener.OwningProcess
+        if (Test-ODSNativeProcessExecutable -ProcessId $ownerPid -ExpectedExecutable $script:LEMONADE_EXE) {
+            Stop-ODSNativeProcessId -ProcessId $ownerPid
         }
     }
 
@@ -1237,7 +1366,7 @@ function Start-NativeInferenceServer {
         $llamaArgs = @(
             "--model", $modelPath,
             "--host", $bindAddr,
-            "--port", "8080",
+            "--port", [string]$script:LEMONADE_PORT,
             "--n-gpu-layers", "999",
             "--ctx-size", $ctxSize
         )
@@ -1265,7 +1394,7 @@ function Start-NativeInferenceServer {
         while ($waited -lt $maxWait) {
             Start-Sleep -Seconds 2; $waited += 2
             try {
-                $resp = Invoke-WebRequest -Uri "http://localhost:8080/health" `
+                $resp = Invoke-WebRequest -Uri "http://127.0.0.1:$($script:LEMONADE_PORT)/health" `
                     -TimeoutSec 3 -UseBasicParsing -ErrorAction SilentlyContinue
                 if ($resp.StatusCode -eq 200) {
                     Write-AISuccess "Native llama-server healthy"
@@ -1324,13 +1453,14 @@ function Invoke-Status {
         Write-Host ("  " + ("-" * 40)) -ForegroundColor DarkGray
 
         # Native inference server status (AMD: Lemonade or llama-server)
-        if (Test-Path $script:INFERENCE_PID_FILE) {
-            $nativeStatus = Get-NativeInferenceStatus
+        $nativeStatus = Get-NativeInferenceStatus
+        if ($nativeStatus.Backend -ne "none") {
             if ($nativeStatus.Running) {
                 $healthStr = $(if ($nativeStatus.Healthy) { "healthy" } else { "loading" })
-                Write-AISuccess "$($nativeStatus.Backend) (native): running PID $($nativeStatus.Pid) ($healthStr)"
+                $recoveredStr = $(if ($nativeStatus.Recovered) { ", state reconciled" } else { "" })
+                Write-AISuccess "$($nativeStatus.Backend) (native): running PID $($nativeStatus.Pid) ($healthStr$recoveredStr)"
             } else {
-                Write-AIWarn "$($nativeStatus.Backend) (native): not running (stale PID cleaned)"
+                Write-AIWarn "$($nativeStatus.Backend) (native): not running"
             }
         }
 
@@ -2155,7 +2285,7 @@ Set WshShell = CreateObject("WScript.Shell")
 WshShell.Run "powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -EncodedCommand $_encodedAgentCommand", 0, False
 "@
                 try {
-                    Write-Utf8NoBom -Path $vbsFile -Content $vbsContent
+                    Write-ODSUtf8NoBomFile -Path $vbsFile -Content $vbsContent
                     Write-AISuccess "Startup persistence configured via Start Menu Startup folder: $vbsFile"
                     # Start the agent now using the startup script
                     Start-Process wscript.exe -ArgumentList ('"{0}"' -f $vbsFile) -NoNewWindow

--- a/ods/installers/windows/phases/06-directories.ps1
+++ b/ods/installers/windows/phases/06-directories.ps1
@@ -275,7 +275,7 @@ if ($gpuInfo.Backend -eq "amd" -and -not $cloudMode) {
     $_amdInferenceRuntime = "lemonade"
     $_amdInferenceBackend = $(if ($amdLemonadeRuntime -and $amdLemonadeRuntime.windows_backend) { $amdLemonadeRuntime.windows_backend } else { "vulkan" })
     $_amdInferenceLocation = "host"
-    $_amdInferencePort = $(if ($amdLemonadeRuntime -and $amdLemonadeRuntime.api_port) { [string]$amdLemonadeRuntime.api_port } else { "8080" })
+    $_amdInferencePort = [string]$script:LEMONADE_PORT
     $_amdInferenceSupportedBackends = $_amdInferenceBackend
     $_amdInferenceRuntimeMode = "windows-legacy-lemonade"
     $_amdInferenceManaged = "true"
@@ -588,7 +588,7 @@ if ($enableOpenClaw) {
     # Lemonade serves at /api/v1, so OpenClaw base URL needs /api prefix
     # (OpenClaw appends /v1/chat/completions to the base URL)
     $_providerUrl = $(if ($gpuInfo.Backend -eq "amd") {
-        "http://host.docker.internal:8080/api"
+        "http://host.docker.internal:$($script:LEMONADE_PORT)/api"
     } else {
         "http://llama-server:8080"
     })

--- a/ods/tests/contracts/test-windows-amd-local-compose.sh
+++ b/ods/tests/contracts/test-windows-amd-local-compose.sh
@@ -49,14 +49,20 @@ if ! command -v docker >/dev/null 2>&1 || ! docker compose version >/dev/null 2>
 fi
 
 tmp_env="$(mktemp)"
+tmp_custom_port_env="$(mktemp)"
 tmp_switchboard_env="$(mktemp)"
 tmp_openclaw_windows_env="$(mktemp)"
 tmp_openclaw_linux_env="$(mktemp)"
-trap 'rm -f "$tmp_env" "$tmp_switchboard_env" "$tmp_openclaw_windows_env" "$tmp_openclaw_linux_env"' EXIT
+trap 'rm -f "$tmp_env" "$tmp_custom_port_env" "$tmp_switchboard_env" "$tmp_openclaw_windows_env" "$tmp_openclaw_linux_env"' EXIT
 cat > "$tmp_env" <<'ENV_EOF'
 WEBUI_SECRET=ci-placeholder
 OLLAMA_PORT=11434
 LLM_API_BASE_PATH=/api/v1
+ENV_EOF
+
+cat > "$tmp_custom_port_env" <<'ENV_EOF'
+WEBUI_SECRET=ci-placeholder
+AMD_INFERENCE_PORT=18080
 ENV_EOF
 
 cat > "$tmp_switchboard_env" <<'ENV_EOF'
@@ -108,6 +114,37 @@ if grep -q 'host.docker.internal:11434' <<<"$rendered"; then
 fi
 grep -q 'condition: service_healthy' <<<"$rendered" \
   || { echo "[FAIL] open-webui must wait for llama-server-ready health"; exit 1; }
+
+custom_port_rendered="$(
+  docker compose \
+    --env-file "$tmp_custom_port_env" \
+    -f docker-compose.base.yml \
+    -f installers/windows/docker-compose.windows-amd.yml \
+    -f installers/windows/docker-compose.windows-amd.local.yml \
+    config
+)"
+
+grep -q 'http://host.docker.internal:18080/api/v1/health' <<<"$custom_port_rendered" \
+  || { echo "[FAIL] Lemonade readiness probe must honor AMD_INFERENCE_PORT"; exit 1; }
+grep -q 'http://host.docker.internal:18080/health' <<<"$custom_port_rendered" \
+  || { echo "[FAIL] llama-server readiness probe must honor AMD_INFERENCE_PORT"; exit 1; }
+if grep -q 'host.docker.internal:8080' <<<"$custom_port_rendered"; then
+  echo "[FAIL] custom Windows native port render retained hard-coded 8080"
+  exit 1
+fi
+grep -q 'OLLAMA_URL: http://host.docker.internal:18080' <<<"$custom_port_rendered" \
+  || { echo "[FAIL] dashboard-api must honor AMD_INFERENCE_PORT"; exit 1; }
+grep -q 'OPENAI_API_BASE_URL: http://host.docker.internal:18080/v1' <<<"$custom_port_rendered" \
+  || { echo "[FAIL] Open WebUI must honor AMD_INFERENCE_PORT"; exit 1; }
+
+grep -qF '"http://host.docker.internal:$($script:LEMONADE_PORT)/api"' installers/windows/phases/06-directories.ps1 \
+  || { echo "[FAIL] Windows OpenClaw config must honor the resolved native port"; exit 1; }
+grep -qF '"--port", [string]$script:LEMONADE_PORT' installers/windows/install-windows.ps1 \
+  || { echo "[FAIL] Windows installer must launch native llama-server on the resolved port"; exit 1; }
+grep -qF '$script:LEMONADE_PORT = if ($cloudMode)' installers/windows/install-windows.ps1 \
+  || { echo "[FAIL] AMD cloud installs must retain a valid native-port default"; exit 1; }
+grep -qF '"http://host.docker.internal:$($llmEndpoint['"'"'Port'"'"'])/v1"' installers/windows/install-windows.ps1 \
+  || { echo "[FAIL] Windows Perplexica config must honor the resolved native port"; exit 1; }
 
 switchboard_webui_rendered="$(
   docker compose \

--- a/ods/tests/contracts/test-windows-runtime-recovery.ps1
+++ b/ods/tests/contracts/test-windows-runtime-recovery.ps1
@@ -1,0 +1,433 @@
+$ErrorActionPreference = "Stop"
+
+$rootDir = Resolve-Path (Join-Path $PSScriptRoot "../..")
+$composeLibrary = Join-Path $rootDir "installers/windows/lib/compose-diagnostics.ps1"
+$envGeneratorLibrary = Join-Path $rootDir "installers/windows/lib/env-generator.ps1"
+$llmEndpointLibrary = Join-Path $rootDir "installers/windows/lib/llm-endpoint.ps1"
+$windowsCli = Join-Path $rootDir "installers/windows/ods.ps1"
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) `
+    "ods-windows-runtime-recovery-$([Guid]::NewGuid().ToString('N'))"
+
+Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Path $testRoot -Force | Out-Null
+
+try {
+    . $composeLibrary
+
+    $userDockerConfig = Join-Path $testRoot "user-docker"
+    $defaultPluginDir = Join-Path $userDockerConfig "cli-plugins"
+    $extraPluginDir = Join-Path $testRoot "extra-plugins"
+    $installDir = Join-Path $testRoot "install"
+    New-Item -ItemType Directory -Path $defaultPluginDir -Force | Out-Null
+    New-Item -ItemType Directory -Path $extraPluginDir -Force | Out-Null
+    New-Item -ItemType Directory -Path (Join-Path $installDir "data/docker-client-public") -Force | Out-Null
+
+    @{
+        auths = @{ "private.example" = @{ auth = "must-not-copy" } }
+        credsStore = "desktop"
+        currentContext = "desktop-linux"
+        cliPluginsExtraDirs = @($extraPluginDir, $defaultPluginDir)
+    } | ConvertTo-Json -Depth 5 | Set-Content -LiteralPath (Join-Path $userDockerConfig "config.json")
+
+    # Simulate an existing install created before plugin forwarding existed.
+    '{"auths":{"stale.example":{}},"credsStore":"desktop"}' |
+        Set-Content -LiteralPath (Join-Path $installDir "data/docker-client-public/config.json")
+
+    $isolatedDir = Initialize-ODSComposeDockerClientConfig `
+        -InstallDir $installDir -UserDockerConfigDir $userDockerConfig
+    $isolatedConfigPath = Join-Path $isolatedDir "config.json"
+    $isolatedConfig = Get-Content -LiteralPath $isolatedConfigPath -Raw | ConvertFrom-Json
+
+    if (@($isolatedConfig.auths.PSObject.Properties).Count -ne 0) {
+        throw "Install-scoped Docker config copied registry auth state"
+    }
+    foreach ($forbidden in @("credsStore", "credHelpers", "currentContext")) {
+        if ($isolatedConfig.PSObject.Properties.Name -contains $forbidden) {
+            throw "Install-scoped Docker config copied forbidden field: $forbidden"
+        }
+    }
+    $expectedPluginDirs = @(
+        (Resolve-Path -LiteralPath $defaultPluginDir).Path,
+        (Resolve-Path -LiteralPath $extraPluginDir).Path
+    ) | Sort-Object
+    $actualPluginDirs = @($isolatedConfig.cliPluginsExtraDirs) | Sort-Object
+    if (Compare-Object $expectedPluginDirs $actualPluginDirs) {
+        throw "Compose plugin directories were not preserved: $($actualPluginDirs -join ', ')"
+    }
+
+    # A second run must be idempotent and keep the same credential-free shape.
+    $null = Initialize-ODSComposeDockerClientConfig `
+        -InstallDir $installDir -UserDockerConfigDir $userDockerConfig
+    $secondConfig = Get-Content -LiteralPath $isolatedConfigPath -Raw | ConvertFrom-Json
+    if (@($secondConfig.cliPluginsExtraDirs).Count -ne 2 -or
+        @($secondConfig.auths.PSObject.Properties).Count -ne 0) {
+        throw "Second Docker config generation was not idempotent"
+    }
+
+    # A failed staged write must leave the last valid config intact.
+    $validConfigBeforeFailure = Get-Content -LiteralPath $isolatedConfigPath -Raw
+    $blockedTempPath = "$isolatedConfigPath.$PID.tmp"
+    New-Item -ItemType Directory -Path $blockedTempPath -Force | Out-Null
+    $writeFailed = $false
+    try {
+        $null = Initialize-ODSComposeDockerClientConfig `
+            -InstallDir $installDir -UserDockerConfigDir $userDockerConfig
+    } catch {
+        $writeFailed = $true
+    } finally {
+        Remove-Item -LiteralPath $blockedTempPath -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    if (-not $writeFailed -or
+        (Get-Content -LiteralPath $isolatedConfigPath -Raw) -ne $validConfigBeforeFailure) {
+        throw "Failed Docker config staging did not preserve the last valid config"
+    }
+
+    # Relative DOCKER_CONFIG must resolve against the caller's location before
+    # Invoke-ODSDockerCompose changes into the install directory.
+    $relativeConfigName = "relative-docker"
+    $relativeConfigDir = Join-Path $testRoot $relativeConfigName
+    $relativePluginDir = Join-Path $relativeConfigDir "cli-plugins"
+    New-Item -ItemType Directory -Path $relativePluginDir -Force | Out-Null
+    $previousLocation = Get-Location
+    $hadDockerConfig = Test-Path Env:DOCKER_CONFIG
+    $previousDockerConfig = $env:DOCKER_CONFIG
+    try {
+        Set-Location $testRoot
+        $env:DOCKER_CONFIG = $relativeConfigName
+        function global:docker { $global:LASTEXITCODE = 0 }
+        $composeExit = Invoke-ODSDockerCompose -InstallDir $installDir `
+            -ComposeFlags @("-f", "docker-compose.base.yml") -ComposeArgs @("config", "--quiet")
+        if ($composeExit -ne 0) {
+            throw "Mock Compose invocation failed for relative DOCKER_CONFIG"
+        }
+    } finally {
+        Remove-Item Function:\global:docker -ErrorAction SilentlyContinue
+        Set-Location $previousLocation
+        if ($hadDockerConfig) {
+            $env:DOCKER_CONFIG = $previousDockerConfig
+        } else {
+            Remove-Item Env:DOCKER_CONFIG -ErrorAction SilentlyContinue
+        }
+    }
+    $relativeGeneratedConfig = Get-Content -LiteralPath $isolatedConfigPath -Raw |
+        ConvertFrom-Json
+    if (@($relativeGeneratedConfig.cliPluginsExtraDirs).Count -ne 1 -or
+        $relativeGeneratedConfig.cliPluginsExtraDirs[0] -ne
+            (Resolve-Path -LiteralPath $relativePluginDir).Path) {
+        throw "Relative DOCKER_CONFIG was resolved from the Compose working directory"
+    }
+
+    . $llmEndpointLibrary
+    . $envGeneratorLibrary
+    function Write-AIWarn { param([string]$Message) }
+    function Get-LlamaCpuBudget {
+        return @{ Limit = "4.0"; Reservation = "1.0"; Available = "4.0" }
+    }
+    $script:ODS_VERSION = "test"
+    $script:LEMONADE_PORT = 8080
+    $script:LEMONADE_HEALTH_URL = "http://127.0.0.1:8080/api/v1/health"
+
+    $endpoint = Get-WindowsLocalLlmEndpoint -GpuBackend "amd" -NativeBackend "llama-server" -EnvMap @{
+        GPU_BACKEND = "amd"
+        LLM_BACKEND = "llama-server"
+        AMD_INFERENCE_RUNTIME = "llama-server"
+        AMD_INFERENCE_LOCATION = "host"
+        AMD_INFERENCE_RUNTIME_MODE = "windows-llama-server-fallback"
+        AMD_INFERENCE_PORT = "18080"
+    }
+    if ($endpoint.Port -ne "18080" -or
+        $endpoint.HealthUrl -ne "http://localhost:18080/health" -or
+        $endpoint.ChatCompletionsUrl -ne "http://localhost:18080/v1/chat/completions") {
+        throw "Native llama-server endpoint ignored AMD_INFERENCE_PORT"
+    }
+    $invalidPortEndpoint = Get-WindowsLocalLlmEndpoint `
+        -GpuBackend "amd" -NativeBackend "llama-server" -EnvMap @{
+            GPU_BACKEND = "amd"
+            LLM_BACKEND = "llama-server"
+            AMD_INFERENCE_RUNTIME = "llama-server"
+            AMD_INFERENCE_LOCATION = "host"
+            AMD_INFERENCE_RUNTIME_MODE = "windows-llama-server-fallback"
+            AMD_INFERENCE_PORT = "70000"
+        }
+    if ($invalidPortEndpoint.Port -ne "8080" -or
+        $invalidPortEndpoint.HealthUrl -ne "http://localhost:8080/health") {
+        throw "Invalid native port did not fall back to the backend default"
+    }
+
+    $generatedInstall = Join-Path $testRoot "generated-install"
+    $tier = @{
+        TierName = "Test"
+        LlmModel = "test-model"
+        GgufFile = "test-model.gguf"
+        MaxContext = 4096
+    }
+    $null = New-ODSEnv -InstallDir $generatedInstall -TierConfig $tier -Tier "test" `
+        -GpuBackend "amd" -AmdInferenceRuntime "lemonade" `
+        -AmdInferenceLocation "host" -AmdInferencePort "18080"
+    $generatedEnv = Get-Content -LiteralPath (Join-Path $generatedInstall ".env") -Raw
+    foreach ($assignment in @(
+        "LLM_API_URL=http://host.docker.internal:18080",
+        "AMD_INFERENCE_PORT=18080"
+    )) {
+        if (-not $generatedEnv.Contains($assignment)) {
+            throw "Generated Windows env missed custom native port assignment: $assignment"
+        }
+    }
+    $lemonadeConfig = Get-Content -LiteralPath (Join-Path $generatedInstall "config/litellm/lemonade.yaml") -Raw
+    if (-not $lemonadeConfig.Contains("api_base: http://host.docker.internal:18080/api/v1")) {
+        throw "LiteLLM Lemonade config ignored AMD_INFERENCE_PORT"
+    }
+    $routerConfig = Get-Content -LiteralPath (Join-Path $generatedInstall "config/model-router/endpoints.json") -Raw
+    if (-not $routerConfig.Contains("http://host.docker.internal:18080/api")) {
+        throw "Model router config ignored AMD_INFERENCE_PORT"
+    }
+
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+        (Resolve-Path $windowsCli), [ref]$tokens, [ref]$parseErrors
+    )
+    if ($parseErrors.Count -gt 0) { throw $parseErrors[0] }
+
+    $functionNames = @(
+        "Write-ODSUtf8NoBomFile",
+        "Test-ODSNativeProcessExecutable",
+        "Get-ODSNativeInferencePortOwnerProcessId",
+        "Get-ODSManagedLemonadeTaskProcessId",
+        "Test-ODSNativeInferenceHealth",
+        "Get-NativeInferenceStatus",
+        "Stop-ODSLemonadeRuntime"
+    )
+    foreach ($functionName in $functionNames) {
+        $functionAst = $ast.Find(
+            {
+                param($node)
+                $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                    $node.Name -eq $functionName
+            },
+            $true
+        )
+        if (-not $functionAst) { throw "Function not found: $functionName" }
+        . ([scriptblock]::Create($functionAst.Extent.Text))
+    }
+
+    $invokeAgentAst = $ast.Find(
+        {
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+                $node.Name -eq "Invoke-Agent"
+        },
+        $true
+    )
+    if (-not $invokeAgentAst -or
+        $invokeAgentAst.Extent.Text -notmatch '\bWrite-ODSUtf8NoBomFile\b' -or
+        $invokeAgentAst.Extent.Text -match '\bWrite-Utf8NoBom\b') {
+        throw "Host Agent fallback does not use its self-contained UTF-8 writer"
+    }
+
+    $launcherPath = Join-Path $testRoot "startup/ods-host-agent.vbs"
+    $launcherContent = "' ODS Host Agent`r`nWScript.Echo `"ready`"`r`n"
+    Write-ODSUtf8NoBomFile -Path $launcherPath -Content $launcherContent
+    $launcherBytes = [System.IO.File]::ReadAllBytes($launcherPath)
+    if ($launcherBytes.Length -lt 3 -or
+        ($launcherBytes[0] -eq 0xEF -and $launcherBytes[1] -eq 0xBB -and
+            $launcherBytes[2] -eq 0xBF)) {
+        throw "Host Agent startup launcher was written with a UTF-8 BOM"
+    }
+    if ([System.IO.File]::ReadAllText($launcherPath) -ne $launcherContent) {
+        throw "Host Agent startup launcher content did not round-trip"
+    }
+
+    $script:INFERENCE_PID_FILE = Join-Path $testRoot "data/llama-server.pid"
+    $script:LEMONADE_EXE = Join-Path $testRoot "LemonadeServer.exe"
+    $script:LLAMA_SERVER_EXE = Join-Path $testRoot "llama-server.exe"
+    $script:LEMONADE_PORT = 18080
+    $script:LEMONADE_HEALTH_URL = "http://127.0.0.1:18080/api/v1/health"
+    $script:LEMONADE_TASK_NAME = "ODSLemonadeRuntime"
+    $script:MockBackend = "lemonade"
+    $script:MockHealth = $false
+    $script:MockProcesses = @{}
+    $script:MockListeners = @()
+    $script:UnfilteredCimQueries = 0
+    $script:StoppedProcessIds = @()
+    $script:LastHealthUrl = $null
+    $script:MockTaskRunning = $false
+    $global:InstallDir = $testRoot
+    New-Item -ItemType Directory -Path (Split-Path $script:INFERENCE_PID_FILE) -Force | Out-Null
+
+    function Sync-ODSNativeInferenceConfig { }
+    function Get-NativeInferenceBackend { return $script:MockBackend }
+    function Invoke-WebRequest {
+        param($Uri, $TimeoutSec, [switch]$UseBasicParsing, $ErrorAction)
+        $script:LastHealthUrl = [string]$Uri
+        if (-not $script:MockHealth) { throw "mock endpoint unavailable" }
+        return [pscustomobject]@{ StatusCode = 200 }
+    }
+    function Get-NetTCPConnection {
+        param($LocalPort, $State, $ErrorAction)
+        return @($script:MockListeners | Where-Object { $_.LocalPort -eq $LocalPort })
+    }
+    function Get-CimInstance {
+        param($ClassName, $Filter, $ErrorAction)
+        if ($Filter -match 'ProcessId\s*=\s*(\d+)') {
+            $id = [int]$Matches[1]
+            return $script:MockProcesses[$id]
+        }
+        $script:UnfilteredCimQueries += 1
+        return @($script:MockProcesses.Values)
+    }
+    function Stop-ScheduledTask { param($TaskName, $ErrorAction) }
+    function Unregister-ScheduledTask { param($TaskName, [switch]$Confirm, $ErrorAction) }
+    function Get-ScheduledTask {
+        param($TaskName, $ErrorAction)
+        if (-not $script:MockTaskRunning -or $TaskName -ne "ODSLemonadeRuntime") {
+            throw "mock task unavailable"
+        }
+        return [pscustomobject]@{ State = "Running" }
+    }
+    function Stop-ODSNativeProcessId {
+        param([int]$ProcessId)
+        $script:StoppedProcessIds += $ProcessId
+    }
+
+    # Disabled native inference must not probe or adopt host state.
+    $script:MockBackend = "none"
+    $script:MockHealth = $true
+    $script:MockListeners = @([pscustomobject]@{ LocalPort = 18080; OwningProcess = 219 })
+    $script:LastHealthUrl = $null
+    $disabled = Get-NativeInferenceStatus
+    if ($disabled.Backend -ne "none" -or $disabled.Running -or
+        $null -ne $script:LastHealthUrl -or (Test-Path -LiteralPath $script:INFERENCE_PID_FILE)) {
+        throw "Disabled native inference inspected or adopted host runtime state"
+    }
+
+    # Missing/stale state is repaired only from a healthy listener owned by
+    # the exact configured executable.
+    $script:MockBackend = "lemonade"
+    $script:MockHealth = $true
+    $script:MockProcesses[220] = [pscustomobject]@{
+        ProcessId = 220
+        ExecutablePath = $script:LEMONADE_EXE
+        CommandLine = ""
+    }
+    $script:MockListeners = @([pscustomobject]@{ LocalPort = 18080; OwningProcess = 220 })
+    $recovered = Get-NativeInferenceStatus
+    if (-not $recovered.Running -or -not $recovered.Healthy -or
+        -not $recovered.Recovered -or $recovered.Pid -ne 220) {
+        throw "Healthy Lemonade listener was not reconciled"
+    }
+    $persistedPid = (Get-Content -LiteralPath $script:INFERENCE_PID_FILE -Raw).Trim()
+    if ($persistedPid -ne "220") {
+        throw "Reconciled Lemonade PID was not persisted (actual='$persistedPid')"
+    }
+
+    # Lemonade versions may put the listener in a child process. The exact
+    # managed task plus one matching parent executable is still recoverable.
+    Remove-Item -LiteralPath $script:INFERENCE_PID_FILE -Force
+    $script:MockTaskRunning = $true
+    $script:MockProcesses = @{
+        221 = [pscustomobject]@{
+            ProcessId = 221
+            ParentProcessId = 1
+            ExecutablePath = $script:LEMONADE_EXE
+            CommandLine = ""
+        }
+        222 = [pscustomobject]@{
+            ProcessId = 222
+            ParentProcessId = 221
+            ExecutablePath = (Join-Path $testRoot "lemonade-child.exe")
+            CommandLine = "child --port 18080"
+        }
+    }
+    $script:MockListeners = @([pscustomobject]@{ LocalPort = 18080; OwningProcess = 222 })
+    $taskRecovered = Get-NativeInferenceStatus
+    if (-not $taskRecovered.Recovered -or $taskRecovered.Pid -ne 221) {
+        throw "Running managed Lemonade task was not reconciled through its parent executable"
+    }
+    if ($script:UnfilteredCimQueries -ne 1) {
+        throw "Managed task reconciliation repeated the full process query"
+    }
+    $script:MockTaskRunning = $false
+
+    # A running task and a healthy unrelated listener are not sufficient:
+    # the listener must belong to the exact Lemonade process tree.
+    Remove-Item -LiteralPath $script:INFERENCE_PID_FILE -Force
+    $script:MockTaskRunning = $true
+    $script:MockProcesses = @{
+        223 = [pscustomobject]@{
+            ProcessId = 223
+            ParentProcessId = 1
+            ExecutablePath = $script:LEMONADE_EXE
+            CommandLine = ""
+        }
+        224 = [pscustomobject]@{
+            ProcessId = 224
+            ParentProcessId = 1
+            ExecutablePath = (Join-Path $testRoot "unrelated-health-server.exe")
+            CommandLine = "unrelated --port 18080"
+        }
+    }
+    $script:MockListeners = @([pscustomobject]@{ LocalPort = 18080; OwningProcess = 224 })
+    $unrelatedHealthy = Get-NativeInferenceStatus
+    if ($unrelatedHealthy.Running -or (Test-Path -LiteralPath $script:INFERENCE_PID_FILE)) {
+        throw "Managed task recovery adopted Lemonade without proving listener ancestry"
+    }
+    $script:MockTaskRunning = $false
+
+    # A reused PID or unrelated process on the configured port must never be
+    # adopted or stopped by ODS.
+    Set-Content -LiteralPath $script:INFERENCE_PID_FILE -Value "330"
+    $script:MockProcesses = @{
+        330 = [pscustomobject]@{
+            ProcessId = 330
+            ExecutablePath = (Join-Path ([System.IO.Path]::GetTempPath()) "unrelated-runtime.exe")
+            CommandLine = "unrelated --port 18080"
+        }
+    }
+    $script:MockListeners = @([pscustomobject]@{ LocalPort = 18080; OwningProcess = 330 })
+    $unrelated = Get-NativeInferenceStatus
+    if ($unrelated.Running -or (Test-Path -LiteralPath $script:INFERENCE_PID_FILE)) {
+        throw "Unrelated listener was adopted as the native inference runtime"
+    }
+    Stop-ODSLemonadeRuntime
+    if ($script:StoppedProcessIds.Count -ne 0) {
+        throw "Lemonade cleanup stopped an unrelated process"
+    }
+
+    # A matching saved process remains running while its endpoint is loading.
+    $script:MockHealth = $false
+    $script:MockProcesses = @{
+        440 = [pscustomobject]@{
+            ProcessId = 440
+            ExecutablePath = $script:LEMONADE_EXE
+            CommandLine = ""
+        }
+    }
+    $script:MockListeners = @()
+    Set-Content -LiteralPath $script:INFERENCE_PID_FILE -Value "440"
+    $loading = Get-NativeInferenceStatus
+    if (-not $loading.Running -or $loading.Healthy -or $loading.Pid -ne 440) {
+        throw "Matching loading process was not preserved"
+    }
+
+    # llama-server fallback uses the same configured native port contract.
+    Remove-Item -LiteralPath $script:INFERENCE_PID_FILE -Force
+    $script:MockBackend = "llama-server"
+    $script:MockHealth = $true
+    $script:MockProcesses = @{
+        550 = [pscustomobject]@{
+            ProcessId = 550
+            ExecutablePath = $script:LLAMA_SERVER_EXE
+            CommandLine = ""
+        }
+    }
+    $script:MockListeners = @([pscustomobject]@{ LocalPort = 18080; OwningProcess = 550 })
+    $llama = Get-NativeInferenceStatus
+    if (-not $llama.Running -or $script:LastHealthUrl -ne "http://127.0.0.1:18080/health") {
+        throw "llama-server recovery ignored the configured native port"
+    }
+
+    Write-Host "[PASS] Windows Compose plugin and native runtime recovery contracts"
+} finally {
+    Remove-Item -LiteralPath $testRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/ods/tests/test-windows-compose-failure-report.sh
+++ b/ods/tests/test-windows-compose-failure-report.sh
@@ -64,6 +64,13 @@ check 'Validating Hermes Agent image tag before startup' "$INSTALL_PS1" "install
 check 'ImageEnvName = "LLAMA_SERVER_IMAGE"' "$INSTALL_PS1" "image validation labels override env var"
 check 'Get-ODSWindowsUserDockerClientArgs' "$INSTALL_PS1" "installer preserves the user Docker config for recovery"
 check 'ODSWindowsOriginalDockerConfigDefined' "$INSTALL_PS1" "installer snapshots an existing DOCKER_CONFIG before isolation"
+snapshot_line="$(grep -nF '$script:ODSWindowsOriginalDockerConfigDefined = (' "$INSTALL_PS1" | head -1 | cut -d: -f1)"
+push_line="$(grep -nF 'Push-Location $installDir' "$INSTALL_PS1" | head -1 | cut -d: -f1)"
+if [[ -n "$snapshot_line" && -n "$push_line" && "$snapshot_line" -lt "$push_line" ]]; then
+    pass "installer resolves the original DOCKER_CONFIG before changing directories"
+else
+    fail "installer must resolve the original DOCKER_CONFIG before changing directories"
+fi
 check 'image validation failed with the install-scoped Docker config' "$INSTALL_PS1" "image validation retries outside the installer-scoped Docker config"
 check 'Write-AIWarn "Using $source for $Reason."' "$INSTALL_PS1" "installer records Docker config promotion reason"
 check 'Continuing Compose preflight and service launch with the user'\''s Docker config' "$INSTALL_PS1" "installer carries Docker fallback through preflight and launch"
@@ -203,8 +210,9 @@ EOF
         fail "PowerShell report writer runtime behavior failed"
     fi
 
-    if INSTALL_PS1="$INSTALL_PS1" INSTALL_DIR="$INSTALL_DIR" pwsh -NoProfile -Command '
+    if INSTALL_PS1="$INSTALL_PS1" DIAG_LIB="$DIAG_LIB" INSTALL_DIR="$INSTALL_DIR" pwsh -NoProfile -Command '
         $ErrorActionPreference = "Stop"
+        . $env:DIAG_LIB
         $code = Get-Content $env:INSTALL_PS1 -Raw
          $assertStart = $code.IndexOf("function Assert-ODSWindowsComposeCwd")
          $recordStart = $code.IndexOf("function Write-ODSWindowsComposeLaunchRecord")

--- a/ods/tests/test-windows-llm-endpoint.sh
+++ b/ods/tests/test-windows-llm-endpoint.sh
@@ -98,12 +98,13 @@ $amdNativeFallback = @{
     "AMD_INFERENCE_RUNTIME" = "llama-server"
     "AMD_INFERENCE_LOCATION" = "host"
     "AMD_INFERENCE_RUNTIME_MODE" = "windows-llama-server-fallback"
+    "AMD_INFERENCE_PORT" = "18080"
 }
 Assert-ResolvedEndpoint -Label "AMD native llama-server fallback" `
     -EnvMap $amdNativeFallback -GpuBackend "amd" -NativeBackend "llama-server" `
     -ExpectedBackend "native-llama-server" `
-    -ExpectedHealthUrl "http://localhost:8080/health" `
-    -ExpectedChatUrl "http://localhost:8080/v1/chat/completions"
+    -ExpectedHealthUrl "http://localhost:18080/health" `
+    -ExpectedChatUrl "http://localhost:18080/v1/chat/completions"
 
 $legacyAmdNative = @{
     "ODS_MODE" = "local"
@@ -125,12 +126,13 @@ $amdLemonade = @{
     "AMD_INFERENCE_RUNTIME" = "lemonade"
     "AMD_INFERENCE_LOCATION" = "host"
     "AMD_INFERENCE_RUNTIME_MODE" = "external-lemonade"
+    "AMD_INFERENCE_PORT" = "19080"
 }
 Assert-ResolvedEndpoint -Label "AMD Lemonade endpoint" `
     -EnvMap $amdLemonade -GpuBackend "amd" -NativeBackend "lemonade" -UseLemonade `
     -ExpectedBackend "lemonade" `
-    -ExpectedHealthUrl "http://127.0.0.1:8080/api/v1/health" `
-    -ExpectedChatUrl "http://localhost:8080/api/v1/chat/completions"
+    -ExpectedHealthUrl "http://127.0.0.1:19080/api/v1/health" `
+    -ExpectedChatUrl "http://localhost:19080/api/v1/chat/completions"
 
 function Write-AIWarn { param([string]$Message) }
 function Get-LlamaCpuBudget {


### PR DESCRIPTION
## Summary

Repair the Windows AMD/native-runtime recovery path exposed by a real normal-user installation where Docker Compose was installed in `~/.docker/cli-plugins`, Lemonade was healthy after an external scheduled-task restart, and ODS had stale PID state.

This change:

- keeps the install-scoped Docker client configuration credential-free while forwarding only validated user Compose plugin directories;
- rebuilds that scoped configuration on reruns so existing installations self-heal;
- resolves relative `DOCKER_CONFIG` before changing to the Compose working directory;
- carries `AMD_INFERENCE_PORT` through env generation, native launch, readiness, LiteLLM, model-router, Open WebUI, dashboard, Perplexica, OpenClaw, and Compose health checks;
- reconciles missing/stale native PID state only from a healthy endpoint and an exact configured executable, including the managed Lemonade task/child-listener case;
- refuses to adopt or terminate unrelated processes that reuse a PID or listen on the configured port;
- fixes the normal-user Host Agent persistence fallback by using a self-contained UTF-8-without-BOM writer from `ods.ps1`.

## Root Cause And Invariants

| Symptom | Root cause | Preserved invariant |
| --- | --- | --- |
| `docker --config ... compose` treated `--env-file` as an unknown Docker flag | The isolated config hid the user-level Compose plugin | ODS can discover user Compose plugins without copying registry credentials, credential helpers, auths, or Docker contexts |
| Healthy Lemonade reported `not running (stale PID cleaned)` | Status trusted only the persisted PID and could not reconcile an externally restarted managed runtime | A native runtime is recovered only when health, listener/task state, and exact executable identity agree |
| Stop/restart risked targeting a reused PID or unrelated listener | PID and port ownership were not verified against the configured executable | ODS stops only its configured native runtime/process tree |
| Custom AMD inference ports diverged across consumers | Several launch, health, and generated-config paths still assumed port 8080 | Every Windows native-runtime producer and consumer uses the same validated port |
| Host Agent started only for the current session after Task Scheduler access was denied | `ods.ps1` called `Write-Utf8NoBom`, which it never loaded | Normal-user startup-folder persistence is self-contained and PowerShell 5.1 compatible |

## AI Assistance

AI-assisted incident triage, implementation analysis, adversarial review, and regression-test drafting were used. The author reviewed the final diff and selected and ran the validation below.

## Release Lane

- [ ] Stable hotfix targeting `release/2.5.x`
- [x] Mainline change targeting `main`
- [ ] Next-minor work targeting the next feature/minor release
- [ ] Not sure; reviewer should help classify

Stable hotfix reason:

```text
Not applicable. This PR targets main.
```

## Changed Surface

- [ ] Docs only
- [ ] Tests only
- [ ] Dashboard UI
- [x] Dashboard API / host agent
- [x] Installer / bootstrap / lifecycle
- [x] Docker Compose / service manifests
- [x] Model routing / Hermes / capabilities
- [ ] Network exposure / auth / proxy
- [x] Dependencies / runtime wiring

## Upgrade And Failure Behavior

| Scenario | Expected behavior |
| --- | --- |
| Clean Windows AMD install | Uses the backend-contract default port unless a valid override is supplied |
| Existing install rerun | Preserves a valid persisted native port and regenerates all dependent routes consistently |
| Old scoped Docker config | Rebuilt in place with empty auths and current validated plugin directories |
| Empty/invalid port override | Falls back to the valid backend default; never writes port 0 for cloud metadata |
| Missing/stale PID | Reconciles only a healthy exact managed runtime and persists the recovered PID |
| PID reuse/unrelated port owner | Removes stale state but neither adopts nor kills the unrelated process |
| Task Scheduler blocked | Writes the startup launcher without relying on installer-only functions, then starts the agent |
| Partial native startup failure | Existing readiness/failure reporting remains authoritative; unrelated listeners are preserved |
| Stop/restart | Stops the exact executable and existing scoped Lemonade children/cache processes |

Linux and macOS manifests, installers, and lifecycle commands are unchanged.

## Risk And Validation

- Risk level: High
- Validation run:
  - [x] `git diff --check`
  - [x] Focused tests listed below
  - [x] Extension audit / compose validation
  - [x] Scoped Windows runtime validation
  - [x] Dashboard lint/test/build (no dashboard source changed)
  - [ ] Stable-lane patch validation, if targeting `release/2.5.x`

Commands/results:

```text
PowerShell 7: tests/contracts/test-windows-runtime-recovery.ps1
  PASS
Windows PowerShell 5.1: tests/contracts/test-windows-runtime-recovery.ps1
  PASS

PowerShell parser + repository PSScriptAnalyzer settings on all touched production scripts
  PASS

tests/contracts/test-windows-lemonade-task-cleanup.ps1
  PASS
tests/test-windows-model-activation.ps1
  PASS
tests/test-windows-port-preflight.ps1
  PASS
tests/test-windows-restart-recreate-env.sh
  9 passed
tests/contracts/test-windows-llm-model-readiness.sh
  14 passed
tests/contracts/test-windows-lemonade-swap-wait.sh
  12 passed
tests/contracts/test-windows-hermes-config-patching.sh
  10 passed
tests/test-windows-compose-failure-report.sh
  46 passed

Real Docker Compose rendering from Windows PowerShell:
  default AMD native port: PASS
  AMD_INFERENCE_PORT=18080: PASS
  switchboard Open WebUI route: PASS

Dashboard API focused runtime/model activation suite:
  187 passed
Dashboard frontend:
  ESLint: PASS
  Vitest: 218 passed
  Vite production build: PASS
git diff --check
  PASS
```

The incident receipt established the original operational state: the user-level Compose plugin worked without ODS isolation, Lemonade 10.0.0 was healthy on the configured port after the managed task restart, Open WebUI recovered to healthy, and the Host Agent direct fallback responded on port 7710. A full post-patch run on that external AMD host is still pending; this PR remains draft until that receipt or equivalent maintainer validation is available.

## Security And Compatibility

- The generated Docker config contains empty `auths` plus existing, resolved plugin directories only.
- `credsStore`, `credHelpers`, registry auth entries, and `currentContext` are never copied.
- Plugin paths must already exist as directories and are deduplicated case-insensitively.
- Native PID recovery requires successful health plus exact executable identity; the managed-task fallback additionally requires the exact task to be running and proves that the healthy listener descends from the exact configured executable.
- PowerShell 5.1 and PowerShell 7 execute the same recovery contract.
- Existing `.env`, model files, data volumes, and service enablement are not migrated or deleted.

## Operational Change Check

- [ ] This is not an operational change.
- [x] This is an operational change and validation is recorded above.
- [ ] This is an operational change and validation is intentionally deferred for:

## Rollback

Revert this PR. No persistent schema migration is introduced. The install-scoped Docker config is regenerated on the next invocation, and existing user configuration/data remain intact.

## Notes For Reviewers

Primary review boundaries:

1. credential-free Compose plugin discovery;
2. exact process ownership and scheduled-task reconciliation;
3. custom native-port propagation across generated config and Compose;
4. PowerShell 5.1 normal-user Host Agent persistence.

Out of scope: the historical Open WebUI exit 137 could not be reproduced after restart and is not treated as a confirmed code defect here. Dashboard telemetry accuracy is handled by merged PR #1932.
