### PR TITLE
fix(oracle): strip matched quote pairs and allow leading whitespace in env reader

### DIFF
--- a/ods/extensions/services/dashboard-api/performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/performance_oracle.py
@@ -138,10 +138,17 @@ def read_env_value(key: str, install_dir: str | Path) -> str:
 
 def read_env_file_value(key: str, install_dir: str | Path) -> str:
     env_path = Path(install_dir) / ".env"
+    prefix = f"{key}="
     try:
         for line in env_path.read_text(encoding="utf-8").splitlines():
-            if line.startswith(f"{key}="):
-                return line.split("=", 1)[1].strip().strip("\"'")
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if stripped.startswith(prefix):
+                val = stripped.split("=", 1)[1].strip()
+                if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
+                    return val[1:-1]
+                return val
     except OSError:
         pass
     return ""

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -1134,3 +1134,12 @@ def test_published_exact_matches_gguf_stem_identity(data_dir):
     assert perf["source"] == "published_exact"
     assert perf["tokensPerSec"] == 43.7
     assert perf["sourceUrl"] == "https://example.test/stem-bench"
+
+
+def test_read_env_file_value_handles_leading_whitespace_and_matched_quotes(tmp_path):
+    from performance_oracle import read_env_file_value
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("  KEY=\"'quoted_val'\"\n", encoding="utf-8")
+
+    assert read_env_file_value("KEY", tmp_path) == "'quoted_val'"


### PR DESCRIPTION
## Problem

In `read_env_file_value()` (`performance_oracle.py`), `.env` key-value pairs are read using `if line.startswith(f"{key}=")` and cleaned via `line.split("=", 1)[1].strip().strip("\"'")`:

```python
for line in env_path.read_text(encoding="utf-8").splitlines():
    if line.startswith(f"{key}="):
        return line.split("=", 1)[1].strip().strip("\"'")
```

This pattern had two subtle edge-case bugs:
1. Lines containing leading whitespace (e.g. `  MODEL=foo`) failed `line.startswith(prefix)` and were ignored.
2. `strip().strip("\"'")` removes all double and single quote characters from both ends indiscriminately, destroying inner quote pairs (e.g. `MODEL="'llama-3.2-1b'"` lost its inner single quotes).

## Fix

Update `read_env_file_value()` in `performance_oracle.py` to:
- Ignore comment lines starting with `#` and strip leading whitespace before checking key assignment prefix
- Strip only matching surrounding quote pairs (`"..."` or `'...'`), leaving inner single/double quotes verbatim.

```python
def read_env_file_value(key: str, install_dir: str | Path) -> str:
    env_path = Path(install_dir) / ".env"
    prefix = f"{key}="
    try:
        for line in env_path.read_text(encoding="utf-8").splitlines():
            stripped = line.strip()
            if not stripped or stripped.startswith("#"):
                continue
            if stripped.startswith(prefix):
                val = stripped.split("=", 1)[1].strip()
                if len(val) >= 2 and val[0] == val[-1] and val[0] in {"'", '"'}:
                    return val[1:-1]
                return val
    except OSError:
        pass
    return ""
```

## Threat model (honest scoping)

This is a configuration reader correctness fix. It ensures that `.env` settings read by `read_persisted_env_value()` in `performance_oracle.py` correctly handle leading whitespace and preserve internal quotes when parsing performance oracle keys.

## Verification

Added unit test in `tests/test_performance_oracle.py`:

- `test_read_env_file_value_handles_leading_whitespace_and_matched_quotes`
  - Verifies values with leading whitespace and internal single quotes preserve inner quotes correctly.

- `pytest tests/test_performance_oracle.py` passed (33 passed in 0.73s).
