### PR TITLE
fix(session-signer): validate integer expiry before computing hmac signature

### DIFF
--- a/ods/extensions/services/dashboard-api/session_signer.py
+++ b/ods/extensions/services/dashboard-api/session_signer.py
@@ -147,6 +147,11 @@ def verify(cookie_value: str) -> Tuple[bool, str]:
     if not random_id or not expiry_str or not claimed_sig:
         return False, "malformed"
 
+    try:
+        expiry = int(expiry_str)
+    except (ValueError, TypeError):
+        return False, "malformed"
+
     payload = f"{random_id}.{expiry_str}"
     expected_sig = _sign(payload)
     # Constant-time compare to defeat signature timing oracles. Encoded to
@@ -155,12 +160,6 @@ def verify(cookie_value: str) -> Tuple[bool, str]:
     # verify() must return a reason, never raise.
     if not hmac.compare_digest(expected_sig.encode("utf-8"), claimed_sig.encode("utf-8")):
         return False, "bad-signature"
-
-    # Signature is good — check expiry.
-    try:
-        expiry = int(expiry_str)
-    except (ValueError, TypeError):
-        return False, "malformed"
 
     # `<=` because the expiry timestamp is the moment of invalidation, not
     # the last valid second. A cookie issued with ttl=60 stops being valid

--- a/ods/extensions/services/dashboard-api/tests/test_session_signer.py
+++ b/ods/extensions/services/dashboard-api/tests/test_session_signer.py
@@ -172,15 +172,16 @@ class TestVerify:
         assert ok is False
         assert reason == "no-secret"
 
-    def test_non_integer_expiry(self):
-        """A malformed expiry field that survives split should be caught."""
-        # Sign a payload with a non-integer expiry. Signature will be valid
-        # but the int() parse will fail.
-        random_id = "abc123"
-        bad_expiry = "not-a-number"
-        payload = f"{random_id}.{bad_expiry}"
-        sig = session_signer._sign(payload)
-        cookie = f"{payload}.{sig}"
-        ok, reason = session_signer.verify(cookie)
+    def test_non_integer_expiry(self, monkeypatch):
+        """A malformed non-integer expiry returns (False, 'malformed')
+        BEFORE computing an HMAC signature."""
+        monkeypatch.setattr(
+            session_signer,
+            "_sign",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(
+                AssertionError("_sign should not be called when expiry is non-integer")
+            ),
+        )
+        ok, reason = session_signer.verify("random_id.not-a-number.claimed_sig")
         assert ok is False
         assert reason == "malformed"


### PR DESCRIPTION
## Problem

In `verify()` (`session_signer.py`), signed cookie validation checked the HMAC-SHA256 signature *before* validating the integer timestamp format of `expiry_str`:

```python
payload = f"{random_id}.{expiry_str}"
expected_sig = _sign(payload)

if not hmac.compare_digest(expected_sig.encode("utf-8"), claimed_sig.encode("utf-8")):
    return False, "bad-signature"

try:
    expiry = int(expiry_str)
except (ValueError, TypeError):
    return False, "malformed"
```

If `cookie_value` contains a non-integer or malformed expiry string (e.g. `random_id.abc.claimed_sig`), `verify()` computed `_sign(payload)` and performed timing-safe digest comparison before returning `(False, "malformed")`.

## Fix

Reorder validation steps so `expiry_str` integer parsing occurs *before* computing `_sign(payload)`:

```python
random_id, expiry_str, claimed_sig = parts
if not random_id or not expiry_str or not claimed_sig:
    return False, "malformed"

try:
    expiry = int(expiry_str)
except (ValueError, TypeError):
    return False, "malformed"

payload = f"{random_id}.{expiry_str}"
expected_sig = _sign(payload)

if not hmac.compare_digest(expected_sig.encode("utf-8"), claimed_sig.encode("utf-8")):
    return False, "bad-signature"
```

## Threat model (honest scoping)

This is a defensive input validation ordering fix. Non-integer timestamps are rejected immediately as `"malformed"` without wasting CPU cycles computing HMAC-SHA256 signatures on unparseable expiry strings.

## Verification

- `pytest tests/test_session_signer.py` passed (21 passed in 1.15s).
