### PR TITLE
fix(token-spy): stop the SSE token stream re-sending every event

### DIFF
--- a/ods/extensions/services/token-spy/db.py
+++ b/ods/extensions/services/token-spy/db.py
@@ -483,6 +483,14 @@ def query_recent_events(limit: int = 100, after_id: str = None):
     conn.row_factory = sqlite3.Row
 
     if after_id:
+        # Forward pagination for the SSE tail: return the OLDEST unseen rows
+        # first and let the caller advance its cursor to the last (largest)
+        # id. Ordering by timestamp DESC here made the caller's cursor walk
+        # backwards — it set last_id to the oldest row of each batch, so the
+        # next `id > last_id` re-selected everything newer than that, resending
+        # the whole batch every poll. `id` is the AUTOINCREMENT key, so ASC is
+        # insertion order and a burst larger than one page is drained across
+        # polls without skips.
         rows = conn.execute(
             """
             SELECT
@@ -492,7 +500,7 @@ def query_recent_events(limit: int = 100, after_id: str = None):
                 estimated_cost_usd as cost_usd, timestamp
             FROM usage
             WHERE id > ?
-            ORDER BY timestamp DESC
+            ORDER BY id ASC
             LIMIT ?
             """,
             (after_id, limit)

--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -2429,6 +2429,19 @@ async def token_events(request: Request):
                 # Query recent events
                 events = query_recent_events(limit=50, after_id=last_cursor)
 
+                # Advance to the highest cursor in the complete batch. SQLite's
+                # initial window is newest-first, while PostgreSQL emits a
+                # stable (timestamp, UUID) cursor; taking the maximum works for
+                # both without walking the SQLite cursor backwards.
+                batch_max_cursor = max(
+                    (
+                        event.get("_cursor", event.get("id"))
+                        for event in events
+                        if event.get("_cursor", event.get("id")) is not None
+                    ),
+                    default=None,
+                )
+
                 for event in events:
                     # Format event as SSE
                     event_data = {
@@ -2445,9 +2458,9 @@ async def token_events(request: Request):
                     }
 
                     yield f"data: {json.dumps(event_data)}\n\n"
-                    # PostgreSQL supplies a stable (timestamp, UUID) cursor.
-                    # SQLite and older backends continue to use the row ID.
-                    last_cursor = event.get("_cursor", event.get("id"))
+
+                if batch_max_cursor is not None:
+                    last_cursor = batch_max_cursor
 
                 # Heartbeat to keep connection alive
                 yield ":heartbeat\n\n"

--- a/ods/extensions/services/token-spy/tests/test_recent_events_cursor.py
+++ b/ods/extensions/services/token-spy/tests/test_recent_events_cursor.py
@@ -1,0 +1,121 @@
+"""Token Spy SSE event cursor tests (sqlite backend).
+
+query_recent_events(after_id=...) is the forward cursor behind the
+/token_events SSE stream. main.py polls it every 2s, streams the rows, and
+passes the highest id back as after_id. The cursor must advance so each row
+is streamed exactly once.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from uuid import uuid4
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+def load_sqlite_db(tmp_path, monkeypatch):
+    spec = importlib.util.spec_from_file_location(
+        f"token_spy_sqlite_db_{uuid4().hex}",
+        TOKEN_SPY_DIR / "db.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "DB_PATH", str(tmp_path / "usage.db"))
+    module._local.conn = None
+    module.init_db()
+    return module
+
+
+def _log(db, n):
+    for _ in range(n):
+        db.log_usage({
+            "agent": "Open WebUI", "model": "gpt-4o",
+            "input_tokens": 1, "output_tokens": 1, "estimated_cost_usd": 0.0,
+        })
+
+
+def _advance(events, last_id):
+    """Cursor advance exactly as main.py's event_stream does."""
+    batch_max = max(
+        (e["id"] for e in events if e.get("id") is not None),
+        default=None,
+    )
+    return batch_max if batch_max is not None else last_id
+
+
+def _drain(db, page=50, rounds=10):
+    """Poll until dry, returning every id emitted across all polls."""
+    last_id = None
+    emitted = []
+    for _ in range(rounds):
+        events = db.query_recent_events(limit=page, after_id=last_id)
+        emitted.extend(e["id"] for e in events)
+        new_last = _advance(events, last_id)
+        if new_last == last_id:
+            break
+        last_id = new_last
+    return emitted
+
+
+def test_each_event_is_streamed_once(tmp_path, monkeypatch):
+    db = load_sqlite_db(tmp_path, monkeypatch)
+    _log(db, 5)
+
+    emitted = _drain(db)
+
+    assert sorted(emitted) == [1, 2, 3, 4, 5]
+    assert len(emitted) == len(set(emitted)), f"duplicate events streamed: {emitted}"
+
+
+def test_cursor_does_not_walk_backwards_on_the_initial_batch(tmp_path, monkeypatch):
+    """The initial (after_id=None) batch is newest-first; the cursor must jump
+    to the max id, not the last (oldest) row."""
+    db = load_sqlite_db(tmp_path, monkeypatch)
+    _log(db, 5)
+
+    first = db.query_recent_events(limit=50, after_id=None)
+    cursor = _advance(first, None)
+
+    assert cursor == 5
+    # Nothing new since — the next poll must be empty, not a re-send.
+    assert db.query_recent_events(limit=50, after_id=cursor) == []
+
+
+def test_new_events_after_idle_polls_are_delivered_in_order(tmp_path, monkeypatch):
+    db = load_sqlite_db(tmp_path, monkeypatch)
+    _log(db, 3)
+    cursor = _advance(db.query_recent_events(limit=50, after_id=None), None)
+
+    # A few empty polls, then three new rows arrive.
+    assert db.query_recent_events(limit=50, after_id=cursor) == []
+    _log(db, 3)
+
+    batch = db.query_recent_events(limit=50, after_id=cursor)
+    assert [e["id"] for e in batch] == [4, 5, 6]
+
+
+def test_forward_burst_larger_than_one_page_drains_without_skips(tmp_path, monkeypatch):
+    """Once the stream is tailing, a burst bigger than one page must drain
+    across polls with no gaps and no repeats.
+
+    (The initial backlog is intentionally capped at one page — that is not
+    what this covers; this is the live forward tail.)"""
+    db = load_sqlite_db(tmp_path, monkeypatch)
+    _log(db, 3)
+    cursor = _advance(db.query_recent_events(limit=50, after_id=None), None)
+
+    _log(db, 120)  # 4..123 arrive while we tail
+
+    emitted = []
+    last_id = cursor
+    for _ in range(10):
+        batch = db.query_recent_events(limit=50, after_id=last_id)
+        if not batch:
+            break
+        emitted.extend(e["id"] for e in batch)
+        last_id = _advance(batch, last_id)
+
+    assert emitted == list(range(4, 124))  # every new row, in order, once


### PR DESCRIPTION
﻿## Problem

`/token_events` streams usage rows over SSE. `main.py` polls `query_recent_events(after_id=last_id)` every 2s and advanced the cursor inside the emit loop:

```python
for event in events:
    yield f"data: {json.dumps(event_data)}\n\n"
    last_id = event.get("id")
```

`query_recent_events` ordered the `after_id` branch by **`timestamp DESC`**, so the last row iterated was the *oldest* of the batch, and `last_id` ended up on the smallest id. The next poll's `WHERE id > last_id` then re-selected every newer row it had just sent.

Driven against the shipped sqlite backend — 5 rows, three consecutive idle polls, no new data:

```
poll 0: cursor_after=1  emitted ids=[5, 4, 3, 2, 1]
poll 1: cursor_after=2  emitted ids=[5, 4, 3, 2]
poll 2: cursor_after=3  emitted ids=[5, 4, 3]
total emitted: 12  unique: 5  duplicates: 7
```

Every connected dashboard re-renders the same events on a 2-second loop, and any client-side counter fed from the stream drifts upward without bound.

## Fix

- **`db.py`** — the `after_id` branch now orders by **`id ASC`**. `id` is the `AUTOINCREMENT` key, i.e. insertion order, so this is a genuine forward cursor: a burst larger than one page drains across polls instead of returning the same newest page every time.
- **`main.py`** — advance the cursor to the **max** id in the batch, not the last one iterated. The initial `after_id=None` query still returns the newest page in `timestamp DESC` order (the backlog dump), so seeding from its last row would replay the whole backlog on poll two.

After the fix the same scenario emits each id exactly once and idle polls return nothing; a forward burst of 120 rows drains as `4..123` in order with no gaps or repeats.

## Scope — Postgres left for a separate change (flagged, not half-fixed)

This fixes the **sqlite** backend (the default local deployment) and the shared SSE loop. The Postgres backend has a deeper, independent defect: `requests.id` is a random `uuid4()`, so `WHERE r.id > %s` is a **lexicographic UUID comparison unrelated to insertion time** — it was never a valid forward cursor, with or without this bug. Fixing it correctly needs a timestamp-based composite cursor and a running Postgres to verify, so I've deliberately left it out rather than ship an unverifiable half-fix. Calling it out here so it isn't lost.

## Verification

`tests/test_recent_events_cursor.py`, 4 cases, **2 red before the fix**:

```
FAILED test_new_events_after_idle_polls_are_delivered_in_order
FAILED test_forward_burst_larger_than_one_page_drains_without_skips
```

- `test_each_event_is_streamed_once` — drain to empty, assert no duplicates
- `test_cursor_does_not_walk_backwards_on_the_initial_batch` — newest-first backlog, cursor must jump to max, next poll empty
- the two above — ordered delivery after idle polls, and a >1-page forward burst with no skips

`main.py` compiles; existing `test_usage_report.py` still green.

> Note: no workflow runs the token-spy suite today, so these gate once something does — #2011 adds that.

## Why this matters

The Token Spy SSE endpoint is a live production stream. Re-sending the same SQLite rows on every poll wastes bandwidth and causes dashboards to duplicate events.

## Overlap check

Triage refresh (2026-08-08): searched open and closed Osmantic/ODS PRs by semantic keywords (Token Spy SSE cursor events), inspected the changed production files, and checked patch equivalence against current upstream/main. No strict duplicate or merged equivalent was found. The PostgreSQL UUID-cursor problem remains intentionally separate in #2173 because it requires a different ordering design.

## Test plan

- [x] `pytest ods/extensions/services/token-spy/tests/test_recent_events_cursor.py`
