### PR TITLE
fix(features): support dictionary objects in calculate_feature_status

### DIFF
--- a/ods/extensions/services/dashboard-api/routers/features.py
+++ b/ods/extensions/services/dashboard-api/routers/features.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from typing import Optional
+from typing import Optional, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 
@@ -14,6 +14,15 @@ from security import verify_api_key
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["features"])
+
+
+def _svc_id(s: Any) -> str | None:
+    return s.get("id") if isinstance(s, dict) else getattr(s, "id", None)
+
+
+def _svc_healthy(s: Any) -> bool:
+    status = s.get("status") if isinstance(s, dict) else getattr(s, "status", None)
+    return status == "healthy"
 
 
 def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[GPUInfo]) -> dict:
@@ -42,8 +51,8 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
     services_missing = []
 
     for svc_id in all_required:
-        svc_status = next((s for s in services if s.id == svc_id), None)
-        if svc_status and svc_status.status == "healthy":
+        svc_status = next((s for s in services if _svc_id(s) == svc_id), None)
+        if svc_status and _svc_healthy(svc_status):
             services_available.append(svc_id)
         else:
             services_missing.append(svc_id)
@@ -55,10 +64,10 @@ def calculate_feature_status(feature: dict, services: list, gpu_info: Optional[G
     enabled_all = feature.get("enabled_services_all", required_services)
     enabled_any = feature.get("enabled_services_any", required_services_any)
     enabled_all_ok = all(
-        any(s.id == svc and s.status == "healthy" for s in services) for svc in enabled_all
+        any(_svc_id(s) == svc and _svc_healthy(s) for s in services) for svc in enabled_all
     )
     enabled_any_ok = (not enabled_any) or any(
-        any(s.id == svc and s.status == "healthy" for s in services) for svc in enabled_any
+        any(_svc_id(s) == svc and _svc_healthy(s) for s in services) for svc in enabled_any
     )
     is_enabled = enabled_all_ok and enabled_any_ok
 

--- a/ods/extensions/services/dashboard-api/tests/test_features.py
+++ b/ods/extensions/services/dashboard-api/tests/test_features.py
@@ -222,6 +222,22 @@ class TestCalculateFeatureStatusGeneral:
             result = calculate_feature_status(feature, services, gpu)
         assert result["status"] == "available"
 
+    def test_calculate_feature_status_supports_dict_service_objects(self):
+        from routers.features import calculate_feature_status
+
+        feature = self._make_feature(
+            vram_gb=0,
+            services=["llama-server"],
+            enabled_all=["llama-server"],
+        )
+        dict_services = [{"id": "llama-server", "status": "healthy"}]
+
+        with patch("routers.features.GPU_BACKEND", "nvidia"):
+            result = calculate_feature_status(feature, dict_services, None)
+
+        assert result["status"] == "enabled"
+        assert result["enabled"] is True
+
 
 class TestHermesFeatureContracts:
     @staticmethod


### PR DESCRIPTION
## Problem

In `calculate_feature_status()` (`routers/features.py`), service dependencies and active status lookups were performed using property access (`s.id`, `s.status`):

```python
svc_status = next((s for s in services if s.id == svc_id), None)
if svc_status and svc_status.status == "healthy":
    ...
enabled_all_ok = all(
    any(s.id == svc and s.status == "healthy" for s in services) for svc in enabled_all
)
```

When `services` contains dictionary objects (e.g., from serialized status caches or external status providers), accessing `s.id` raises `AttributeError: 'dict' object has no attribute 'id'`.

## Fix

Add `_svc_id()` and `_svc_healthy()` helpers to resolve ID and health status safely across both object models and dictionary representations:

```python
def _svc_id(s: Any) -> str | None:
    return s.get("id") if isinstance(s, dict) else getattr(s, "id", None)


def _svc_healthy(s: Any) -> bool:
    status = s.get("status") if isinstance(s, dict) else getattr(s, "status", None)
    return status == "healthy"
```

And update `calculate_feature_status()` to use these helpers for all service evaluations.

## Threat model (honest scoping)

This is a defensive status normalization fix. It ensures feature status evaluation handles both dataclass models and dictionary status representations without raising `AttributeError`.

## Verification

Added unit test in `tests/test_features.py`:

- `test_calculate_feature_status_supports_dict_service_objects`
  - Verifies that `calculate_feature_status()` evaluates feature availability correctly when passed dictionary service representations.

- `pytest tests/test_features.py` passed (20 passed in 0.54s).
