### PR TITLE
fix(models): block Gemma Perplexica globally

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -290,12 +290,11 @@
         "perplexica": {
           "status": "unsupported_until_revalidated",
           "label": "Perplexica revalidation required",
-          "reason": "Fleet model-UI runs on windows-laptop and strixy loaded this model and ODS Talk passed, but the Perplexica app probe failed instead of returning the requested verification phrase; keep it out of all-app release coverage on those hosts until Perplexica compatibility is revalidated.",
-          "evidence": "fleet-test/runs/2026-07-19T03-40-01Z-release-product-54b2f703190f-harness-2a6a4e6a55b8-hosts-windows-laptop/model-ui/cycle-003/windows-laptop; fleet-test/runs/2026-07-22T09-42-12Z-release-product-b5bb39f2c0f2-harness-cc7b6148eb2c-hosts-windows-laptop-strixy-m5-mbp/model-ui/cycle-003/strixy",
-          "recordedAt": "2026-07-22T10:26:21Z",
-          "productSha": "b5bb39f2c0f2a7a3dfa5f98547e469b6eaf0acfd",
-          "harnessSha": "cc7b6148eb2cd6e667e6a9dd3d36dff6f8928052",
-          "hostScope": ["windows-laptop", "strixy"],
+          "reason": "Independent fleet model-UI runs on windows-laptop, strixy, and tower2 loaded this model and ODS Talk passed, but the Perplexica app probe failed instead of returning the requested verification phrase. The repeated cross-platform semantic failure makes this a model-level incompatibility; keep it out of all-app release coverage until Perplexica compatibility is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-19T03-40-01Z-release-product-54b2f703190f-harness-2a6a4e6a55b8-hosts-windows-laptop/model-ui/cycle-003/windows-laptop; fleet-test/runs/2026-07-22T09-42-12Z-release-product-b5bb39f2c0f2-harness-cc7b6148eb2c-hosts-windows-laptop-strixy-m5-mbp/model-ui/cycle-003/strixy; fleet-test/runs/2026-07-23T20-06-24Z-release-product-3675af793193-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-003/tower2",
+          "recordedAt": "2026-07-23T21:21:17Z",
+          "productSha": "3675af7931935ae0d435a6498c98bc114be209ca",
+          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
           "expiresAt": "2026-08-22T00:00:00Z"
         }
       },

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -393,7 +393,7 @@ def test_model_payload_applies_host_scoped_app_compatibility_from_install_env(da
     assert strixy_payload["models"][0]["appCompatibility"]["agentViability"]["status"] == "unknown"
 
 
-def test_real_catalog_gemma_perplexica_block_is_host_scoped():
+def test_real_catalog_gemma_perplexica_block_is_global():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["gemma3-4b-it-q4"]
 
@@ -412,7 +412,7 @@ def test_real_catalog_gemma_perplexica_block_is_host_scoped():
 
     assert windows_laptop["perplexica"]["status"] == "unsupported_until_revalidated"
     assert strixy["perplexica"]["status"] == "unsupported_until_revalidated"
-    assert tower2["perplexica"]["status"] == "unknown"
+    assert tower2["perplexica"]["status"] == "unsupported_until_revalidated"
 
 
 def test_measured_local_too_slow_blocks_agent_compatibility(data_dir, tmp_path):


### PR DESCRIPTION
## Summary
- make Gemma 3 4B's known Perplexica incompatibility global instead of host-scoped
- record the independent Tower2 reproduction from the fresh six-host release run
- update the real-catalog regression test to require the block on Tower2 too

## Why
Windows laptop, Strixy, and now Tower2 independently loaded Gemma successfully and passed ODS Talk, but Perplexica returned a semantic refusal instead of the verification phrase. Treating this as host-specific allowed the release-grade switchboard planner to select a known incompatible model on other hosts.

## Tests
- python -m json.tool ods/config/model-library.json
- python -m pytest -q ods/extensions/services/dashboard-api/tests/test_performance_oracle.py (32 passed)
- broader dashboard API suite running