### PR TITLE
fix(usage): capture routed model telemetry

### DIFF
--- a/ods/docker-compose.base.yml
+++ b/ods/docker-compose.base.yml
@@ -316,6 +316,8 @@ services:
       - ODS_ROUTER_INTERNAL_KEY=${ODS_ROUTER_INTERNAL_KEY:-}
       - DASHBOARD_API_KEY=${DASHBOARD_API_KEY:-}
       - ODS_FLEET_PROBE_KEY=${ODS_FLEET_PROBE_KEY:-}
+      - TOKEN_SPY_URL=${TOKEN_SPY_URL:-http://token-spy:8080}
+      - TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}
       # File-based probe key inside the already-mounted state volume: the
       # fleet harness can create/rotate/remove it without recreating the
       # router (a recreate destroys in-memory route evidence). Absent file

--- a/ods/extensions/services/litellm/README.md
+++ b/ods/extensions/services/litellm/README.md
@@ -18,6 +18,8 @@ ODS does not expose LiteLLM as a normal dashboard quicklink. The upstream LiteLL
 - **Multi-provider routing**: Anthropic, OpenAI, Together AI, MiniMax, and local llama-server
 - **Master key auth**: Secure all requests with `LITELLM_KEY`
 - **Drop params**: Unsupported parameters silently ignored across backends
+- **Usage telemetry**: Reports metadata-only completion usage to Token Spy
+  asynchronously when that recommended service is available
 
 ## Operating Modes
 
@@ -72,6 +74,8 @@ Environment variables (set in `.env`):
 | `LITELLM_KEY` | *(required)* | Master API key — generate with `echo "sk-ods-$(openssl rand -hex 16)"` |
 | `LITELLM_PORT` | `4000` | External + internal port |
 | `ODS_MODE` | `local` | Operating mode: `local`, `cloud`, or `hybrid` |
+| `TOKEN_SPY_URL` | `http://token-spy:8080` | Optional internal usage ingest target |
+| `TOKEN_SPY_API_KEY` | *(generated)* | Shared key used for authenticated usage ingest |
 | `ANTHROPIC_API_KEY` | *(empty)* | Required for `cloud` and `hybrid` modes |
 | `OPENAI_API_KEY` | *(empty)* | Required for OpenAI models in `cloud` mode |
 | `TOGETHER_API_KEY` | *(empty)* | Required for Together AI models in `cloud` mode |

--- a/ods/extensions/services/litellm/compose.yaml
+++ b/ods/extensions/services/litellm/compose.yaml
@@ -13,9 +13,14 @@ services:
       - MINIMAX_API_KEY=${MINIMAX_API_KEY:-}
       - LANGFUSE_ENABLED=${LANGFUSE_ENABLED:-false}
       - ODS_MODEL_SWITCHBOARD=${ODS_MODEL_SWITCHBOARD:-observe}
+      - TOKEN_SPY_URL=${TOKEN_SPY_URL:-http://token-spy:8080}
+      - TOKEN_SPY_API_KEY=${TOKEN_SPY_API_KEY:-}
     volumes:
       - ./config/litellm/${ODS_MODE:-local}.yaml:/app/config.yaml:ro,z
       - ./config/litellm/switchboard.yaml:/app/switchboard.yaml:ro,z
+      # LiteLLM resolves custom callback modules relative to the generated
+      # /tmp/config.yaml, so the callback must be mounted alongside it.
+      - ./extensions/services/litellm/ods_token_spy_callback.py:/tmp/ods_token_spy_callback.py:ro,z
     ports:
       - "${BIND_ADDRESS:-127.0.0.1}:${LITELLM_PORT:-4000}:4000"
     entrypoint: ["/bin/sh", "-c"]
@@ -26,20 +31,28 @@ services:
           CONFIG_PATH=/app/switchboard.yaml
         fi
         export CONFIG_PATH
-        if [ "$$LANGFUSE_ENABLED" = "true" ]; then
-          python3 -c "
+        python3 -c "
         import os
         import yaml
         with open(os.environ['CONFIG_PATH']) as f:
             cfg = yaml.safe_load(f)
-        cfg.setdefault('litellm_settings', {})['success_callback'] = ['langfuse']
+        settings = cfg.setdefault('litellm_settings', {})
+        callbacks = settings.get('callbacks', [])
+        if not isinstance(callbacks, list):
+            callbacks = []
+        if os.environ.get('TOKEN_SPY_URL') and os.environ.get('TOKEN_SPY_API_KEY'):
+            callbacks.append('ods_token_spy_callback.ods_token_spy_callback')
+        settings['callbacks'] = list(dict.fromkeys(callbacks))
+        if os.environ.get('LANGFUSE_ENABLED') == 'true':
+            success_callbacks = settings.get('success_callback', [])
+            if not isinstance(success_callbacks, list):
+                success_callbacks = []
+            success_callbacks.append('langfuse')
+            settings['success_callback'] = list(dict.fromkeys(success_callbacks))
         with open('/tmp/config.yaml', 'w') as f:
             yaml.dump(cfg, f, default_flow_style=False)
         "
-          exec litellm --config /tmp/config.yaml --port 4000
-        else
-          exec litellm --config "$$CONFIG_PATH" --port 4000
-        fi
+        exec litellm --config /tmp/config.yaml --port 4000
     deploy:
       resources:
         limits:

--- a/ods/extensions/services/litellm/ods_token_spy_callback.py
+++ b/ods/extensions/services/litellm/ods_token_spy_callback.py
@@ -1,0 +1,226 @@
+"""Metadata-only LiteLLM usage callback for Token Spy."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from litellm.integrations.custom_logger import CustomLogger
+
+log = logging.getLogger("ods-litellm-token-spy")
+
+_LOCAL_HOSTS = {
+    "127.0.0.1",
+    "host.docker.internal",
+    "llama-server",
+    "localhost",
+    "model-router",
+    "ollama",
+}
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if hasattr(value, "model_dump"):
+        result = value.model_dump()
+        return result if isinstance(result, dict) else {}
+    if hasattr(value, "dict"):
+        result = value.dict()
+        return result if isinstance(result, dict) else {}
+    return {}
+
+
+def _count(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return min(max(0, int(value)), 2_000_000_000)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _duration_ms(start_time: Any, end_time: Any) -> int:
+    if isinstance(start_time, datetime) and isinstance(end_time, datetime):
+        seconds = (end_time - start_time).total_seconds()
+    else:
+        try:
+            seconds = float(end_time) - float(start_time)
+        except (TypeError, ValueError):
+            seconds = 0
+    return min(max(int(seconds * 1000), 0), 86_400_000)
+
+
+def _provider_name(kwargs: dict[str, Any]) -> str:
+    litellm_params = _as_dict(kwargs.get("litellm_params"))
+    api_base = str(
+        litellm_params.get("api_base")
+        or kwargs.get("api_base")
+        or ""
+    )
+    try:
+        hostname = (urlparse(api_base).hostname or "").lower()
+    except ValueError:
+        hostname = ""
+    if hostname in _LOCAL_HOSTS or hostname.endswith(".local"):
+        return "local"
+    provider = str(
+        litellm_params.get("custom_llm_provider")
+        or kwargs.get("custom_llm_provider")
+        or "unknown"
+    )
+    return provider[:128]
+
+
+def _endpoint_path(kwargs: dict[str, Any]) -> str:
+    call_type = str(kwargs.get("call_type") or "").lower()
+    if "responses" in call_type:
+        return "/v1/responses"
+    if call_type in {"text_completion", "completion"}:
+        return "/v1/completions"
+    return "/v1/chat/completions"
+
+
+def build_event(
+    kwargs: dict[str, Any],
+    response_obj: Any,
+    start_time: Any,
+    end_time: Any,
+) -> dict[str, Any]:
+    response = _as_dict(response_obj)
+    usage = _as_dict(response.get("usage"))
+    prompt_details = _as_dict(
+        usage.get("prompt_tokens_details")
+        or usage.get("input_tokens_details")
+    )
+    choices = response.get("choices")
+    choices = choices if isinstance(choices, list) else []
+    first_choice = _as_dict(choices[0]) if choices else {}
+    messages = kwargs.get("messages")
+    messages = messages if isinstance(messages, list) else []
+    roles = [
+        item.get("role")
+        for item in messages
+        if isinstance(item, dict)
+    ]
+    optional_params = _as_dict(kwargs.get("optional_params"))
+    tools = kwargs.get("tools", optional_params.get("tools"))
+    tools = tools if isinstance(tools, list) else []
+    model = str(
+        response.get("model")
+        or kwargs.get("model")
+        or "unknown"
+    )
+    return {
+        "agent": "litellm",
+        "model": model[:512],
+        "provider_name": _provider_name(kwargs),
+        "path": _endpoint_path(kwargs),
+        # LiteLLM does not expose the original encoded body to callbacks.
+        "request_body_bytes": 0,
+        "message_count": min(len(messages), 100_000),
+        "user_message_count": min(roles.count("user"), 100_000),
+        "assistant_message_count": min(roles.count("assistant"), 100_000),
+        "tool_count": min(len(tools), 100_000),
+        "input_tokens": _count(
+            usage.get("prompt_tokens", usage.get("input_tokens", 0))
+        ),
+        "output_tokens": _count(
+            usage.get("completion_tokens", usage.get("output_tokens", 0))
+        ),
+        "cache_read_tokens": _count(
+            prompt_details.get(
+                "cached_tokens", usage.get("cache_read_tokens", 0)
+            )
+        ),
+        "cache_write_tokens": _count(usage.get("cache_write_tokens", 0)),
+        "duration_ms": _duration_ms(start_time, end_time),
+        "stop_reason": str(
+            first_choice.get("finish_reason")
+            or response.get("stop_reason")
+            or response.get("status")
+            or ""
+        )[:128],
+    }
+
+
+class ODSTokenSpyCallback(CustomLogger):
+    """Send successful LiteLLM usage without delaying inference."""
+
+    def __init__(self) -> None:
+        super().__init__(turn_off_message_logging=True)
+        self.url = os.environ.get("TOKEN_SPY_URL", "").rstrip("/")
+        self.api_key = os.environ.get("TOKEN_SPY_API_KEY", "")
+        self.enabled = bool(self.url and self.api_key)
+        self.queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+            maxsize=max(
+                1, int(os.environ.get("ODS_LITELLM_TELEMETRY_QUEUE_DEPTH", "1024"))
+            )
+        )
+        self.worker: asyncio.Task[None] | None = None
+        self.last_warning = 0.0
+
+    async def async_log_success_event(
+        self,
+        kwargs: dict[str, Any],
+        response_obj: Any,
+        start_time: Any,
+        end_time: Any,
+    ) -> None:
+        # With the switchboard enabled, this same request is recorded by
+        # model-router. Skipping here preserves exactly-once accounting.
+        if (
+            not self.enabled
+            or os.environ.get("ODS_MODEL_SWITCHBOARD", "observe") == "enabled"
+        ):
+            return
+        if self.worker is None or self.worker.done():
+            self.worker = asyncio.create_task(
+                self._run(), name="litellm-token-spy"
+            )
+        try:
+            self.queue.put_nowait(
+                build_event(kwargs, response_obj, start_time, end_time)
+            )
+        except asyncio.QueueFull:
+            self._warn("Token Spy callback queue is full; dropping event")
+
+    async def _run(self) -> None:
+        timeout = max(
+            0.1, float(os.environ.get("ODS_LITELLM_TELEMETRY_TIMEOUT", "3"))
+        )
+        async with httpx.AsyncClient(
+            follow_redirects=False, timeout=timeout
+        ) as client:
+            while True:
+                event = await self.queue.get()
+                try:
+                    response = await client.post(
+                        f"{self.url}/api/ingest/routed",
+                        json=event,
+                        headers={"Authorization": f"Bearer {self.api_key}"},
+                    )
+                    if response.status_code != 202:
+                        self._warn(
+                            "Token Spy rejected LiteLLM telemetry "
+                            f"with HTTP {response.status_code}"
+                        )
+                except (httpx.HTTPError, RuntimeError) as exc:
+                    self._warn(f"Token Spy telemetry unavailable: {exc}")
+                finally:
+                    self.queue.task_done()
+
+    def _warn(self, message: str) -> None:
+        now = time.monotonic()
+        if now - self.last_warning >= 60:
+            log.warning(message)
+            self.last_warning = now
+
+
+ods_token_spy_callback = ODSTokenSpyCallback()

--- a/ods/extensions/services/litellm/tests/test_token_spy_callback.py
+++ b/ods/extensions/services/litellm/tests/test_token_spy_callback.py
@@ -1,0 +1,155 @@
+"""LiteLLM-to-Token-Spy callback contracts."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import sys
+import types
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from uuid import uuid4
+
+
+CALLBACK_PATH = Path(__file__).resolve().parent.parent / "ods_token_spy_callback.py"
+
+
+def load_callback(monkeypatch):
+    class CustomLogger:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+
+    litellm = types.ModuleType("litellm")
+    integrations = types.ModuleType("litellm.integrations")
+    custom_logger = types.ModuleType("litellm.integrations.custom_logger")
+    custom_logger.CustomLogger = CustomLogger
+    monkeypatch.setitem(sys.modules, "litellm", litellm)
+    monkeypatch.setitem(sys.modules, "litellm.integrations", integrations)
+    monkeypatch.setitem(
+        sys.modules, "litellm.integrations.custom_logger", custom_logger
+    )
+    spec = importlib.util.spec_from_file_location(
+        f"ods_token_spy_callback_{uuid4().hex}", CALLBACK_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_callback_builds_metadata_only_event(monkeypatch):
+    callback = load_callback(monkeypatch)
+    start = datetime.now(timezone.utc)
+    response = {
+        "model": "Qwen3.5-2B-Q4_K_M.gguf",
+        "choices": [{
+            "message": {"content": "private answer"},
+            "finish_reason": "stop",
+        }],
+        "usage": {
+            "prompt_tokens": 18,
+            "completion_tokens": 4,
+        },
+    }
+    kwargs = {
+        "model": "openai/default",
+        "messages": [{"role": "user", "content": "private prompt"}],
+        "optional_params": {
+            "tools": [{"type": "function", "function": {"name": "private_tool"}}]
+        },
+        "litellm_params": {
+            "api_base": "http://host.docker.internal:8080/api/v1",
+            "custom_llm_provider": "openai",
+        },
+    }
+
+    event = callback.build_event(
+        kwargs, response, start, start + timedelta(milliseconds=250)
+    )
+
+    assert event["agent"] == "litellm"
+    assert event["model"] == "Qwen3.5-2B-Q4_K_M.gguf"
+    assert event["provider_name"] == "local"
+    assert event["input_tokens"] == 18
+    assert event["output_tokens"] == 4
+    assert event["message_count"] == 1
+    assert event["tool_count"] == 1
+    assert event["duration_ms"] == 250
+    serialized = json.dumps(event)
+    assert "private prompt" not in serialized
+    assert "private answer" not in serialized
+    assert "private_tool" not in serialized
+
+
+def test_callback_skips_litellm_event_when_switchboard_is_enabled(
+    monkeypatch,
+):
+    monkeypatch.setenv("TOKEN_SPY_URL", "http://token-spy:8080")
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "shared-secret")
+    monkeypatch.setenv("ODS_MODEL_SWITCHBOARD", "enabled")
+    callback = load_callback(monkeypatch)
+    instance = callback.ODSTokenSpyCallback()
+
+    asyncio.run(instance.async_log_success_event(
+        {"model": "default"},
+        {"model": "Concrete.gguf", "usage": {}},
+        1.0,
+        2.0,
+    ))
+
+    assert instance.queue.empty()
+    assert instance.worker is None
+
+
+def test_callback_bounds_provider_counters_to_ingest_contract(monkeypatch):
+    callback = load_callback(monkeypatch)
+    event = callback.build_event(
+        {"messages": [{}] * 100_001},
+        {
+            "model": "model",
+            "usage": {
+                "prompt_tokens": 3_000_000_000,
+                "completion_tokens": -1,
+            },
+        },
+        1.0,
+        2.0,
+    )
+
+    assert event["message_count"] == 100_000
+    assert event["input_tokens"] == 2_000_000_000
+    assert event["output_tokens"] == 0
+
+
+def test_callback_enqueues_without_waiting_for_token_spy(monkeypatch):
+    monkeypatch.setenv("TOKEN_SPY_URL", "http://token-spy:8080")
+    monkeypatch.setenv("TOKEN_SPY_API_KEY", "shared-secret")
+    monkeypatch.setenv("ODS_MODEL_SWITCHBOARD", "observe")
+    callback = load_callback(monkeypatch)
+    instance = callback.ODSTokenSpyCallback()
+
+    async def scenario():
+        wait_forever = asyncio.Event()
+
+        async def idle_worker():
+            await wait_forever.wait()
+
+        instance._run = idle_worker
+        await instance.async_log_success_event(
+            {"model": "default", "messages": []},
+            {
+                "model": "Concrete.gguf",
+                "usage": {"prompt_tokens": 2, "completion_tokens": 1},
+            },
+            1.0,
+            2.0,
+        )
+        assert instance.queue.qsize() == 1
+        assert instance.worker is not None
+        instance.worker.cancel()
+        try:
+            await instance.worker
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(scenario())

--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -70,6 +70,14 @@ UPSTREAM_MAX_CONNECTIONS = max(
 UPSTREAM_MAX_KEEPALIVE = max(
     0, int(os.environ.get("ODS_ROUTER_UPSTREAM_MAX_KEEPALIVE", "20"))
 )
+TOKEN_SPY_URL = os.environ.get("TOKEN_SPY_URL", "").rstrip("/")
+TOKEN_SPY_API_KEY = os.environ.get("TOKEN_SPY_API_KEY", "")
+TELEMETRY_QUEUE_DEPTH = max(
+    1, int(os.environ.get("ODS_ROUTER_TELEMETRY_QUEUE_DEPTH", "1024"))
+)
+TELEMETRY_TIMEOUT_SECONDS = max(
+    0.1, float(os.environ.get("ODS_ROUTER_TELEMETRY_TIMEOUT", "3"))
+)
 EVIDENCE_LIMIT = 2048
 EVIDENCE_TTL_SECONDS = 15 * 60
 
@@ -106,6 +114,196 @@ _state_cache: dict[str, Any] = {"mtime": None, "doc": None}
 _endpoints_cache: dict[str, Any] = {"mtime": None, "endpoints": {}}
 _probe_key_cache: dict[str, Any] = {"mtime": None, "key": ""}
 _evidence: "OrderedDict[str, dict[str, Any]]" = OrderedDict()
+
+
+class _TelemetrySink:
+    """Best-effort telemetry transport that never blocks model responses."""
+
+    def __init__(
+        self,
+        url: str,
+        api_key: str,
+        *,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.url = url.rstrip("/")
+        self.api_key = api_key
+        self.enabled = bool(self.url and self.api_key)
+        self.queue: asyncio.Queue[dict[str, Any]] | None = (
+            asyncio.Queue(maxsize=TELEMETRY_QUEUE_DEPTH)
+            if self.enabled
+            else None
+        )
+        self.client = client
+        self.task: asyncio.Task[None] | None = None
+        self._last_warning = 0.0
+
+    async def start(self) -> None:
+        if not self.enabled:
+            return
+        if self.client is None:
+            self.client = httpx.AsyncClient(
+                follow_redirects=False,
+                timeout=TELEMETRY_TIMEOUT_SECONDS,
+            )
+        self.task = asyncio.create_task(
+            self._run(), name="model-router-token-spy"
+        )
+
+    def emit(self, event: dict[str, Any]) -> bool:
+        if self.queue is None:
+            return False
+        try:
+            self.queue.put_nowait(event)
+            return True
+        except asyncio.QueueFull:
+            self._warn("Token Spy telemetry queue is full; dropping event")
+            return False
+
+    async def _run(self) -> None:
+        assert self.queue is not None
+        assert self.client is not None
+        while True:
+            event = await self.queue.get()
+            try:
+                response = await self.client.post(
+                    f"{self.url}/api/ingest/routed",
+                    json=event,
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                )
+                if response.status_code != 202:
+                    self._warn(
+                        "Token Spy rejected routed telemetry "
+                        f"with HTTP {response.status_code}"
+                    )
+            except (httpx.HTTPError, RuntimeError) as exc:
+                self._warn(f"Token Spy telemetry unavailable: {exc}")
+            finally:
+                self.queue.task_done()
+
+    def _warn(self, message: str) -> None:
+        now = time.monotonic()
+        if now - self._last_warning >= 60:
+            logger.warning(message)
+            self._last_warning = now
+
+    async def stop(self) -> None:
+        if self.queue is not None:
+            try:
+                await asyncio.wait_for(self.queue.join(), timeout=1.0)
+            except asyncio.TimeoutError:
+                self._warn("Timed out draining Token Spy telemetry queue")
+        if self.task is not None:
+            self.task.cancel()
+            try:
+                await self.task
+            except asyncio.CancelledError:
+                pass
+        if self.client is not None:
+            await self.client.aclose()
+
+
+def _usage_from_response(payload: Any) -> tuple[dict[str, int], str]:
+    """Normalize OpenAI Chat/Completions and Responses API usage fields."""
+    if not isinstance(payload, dict):
+        payload = {}
+    response = payload.get("response")
+    source = response if isinstance(response, dict) else payload
+    usage = source.get("usage")
+    usage = usage if isinstance(usage, dict) else {}
+
+    prompt_details = usage.get("prompt_tokens_details")
+    if not isinstance(prompt_details, dict):
+        prompt_details = usage.get("input_tokens_details")
+    prompt_details = prompt_details if isinstance(prompt_details, dict) else {}
+
+    normalized = {
+        "input_tokens": _nonnegative_int(
+            usage.get("prompt_tokens", usage.get("input_tokens", 0))
+        ),
+        "output_tokens": _nonnegative_int(
+            usage.get("completion_tokens", usage.get("output_tokens", 0))
+        ),
+        "cache_read_tokens": _nonnegative_int(
+            prompt_details.get("cached_tokens", usage.get("cache_read_tokens", 0))
+        ),
+        "cache_write_tokens": _nonnegative_int(
+            usage.get("cache_write_tokens", 0)
+        ),
+    }
+
+    stop_reason = source.get("stop_reason") or source.get("status") or ""
+    choices = source.get("choices")
+    if isinstance(choices, list) and choices and isinstance(choices[0], dict):
+        stop_reason = choices[0].get("finish_reason") or stop_reason
+    return normalized, str(stop_reason)[:128]
+
+
+def _nonnegative_int(value: Any) -> int:
+    if isinstance(value, bool):
+        return 0
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
+def _build_telemetry_event(
+    payload: dict[str, Any],
+    *,
+    raw_body_bytes: int,
+    model: str,
+    backend: str,
+    path: str,
+    duration_ms: int,
+    usage: dict[str, int],
+    stop_reason: str,
+) -> dict[str, Any]:
+    messages = payload.get("messages")
+    messages = messages if isinstance(messages, list) else []
+    roles = [
+        item.get("role")
+        for item in messages
+        if isinstance(item, dict)
+    ]
+    tools = payload.get("tools")
+    tools = tools if isinstance(tools, list) else []
+    return {
+        "agent": "model-router",
+        "model": str(model)[:512],
+        "provider_name": str(backend or "unknown")[:128],
+        "path": path,
+        "request_body_bytes": min(max(raw_body_bytes, 0), MAX_BODY_BYTES),
+        "message_count": min(len(messages), 100_000),
+        "user_message_count": min(roles.count("user"), 100_000),
+        "assistant_message_count": min(roles.count("assistant"), 100_000),
+        "tool_count": min(len(tools), 100_000),
+        "input_tokens": min(
+            _nonnegative_int(usage.get("input_tokens")), 2_000_000_000
+        ),
+        "output_tokens": min(
+            _nonnegative_int(usage.get("output_tokens")), 2_000_000_000
+        ),
+        "cache_read_tokens": min(
+            _nonnegative_int(usage.get("cache_read_tokens")), 2_000_000_000
+        ),
+        "cache_write_tokens": min(
+            _nonnegative_int(usage.get("cache_write_tokens")), 2_000_000_000
+        ),
+        "duration_ms": min(max(duration_ms, 0), 86_400_000),
+        "stop_reason": str(stop_reason or "")[:128],
+    }
+
+
+def _emit_telemetry(event: dict[str, Any]) -> bool:
+    sink: _TelemetrySink | None = getattr(app.state, "telemetry", None)
+    if sink is None:
+        return False
+    try:
+        return sink.emit(event)
+    except Exception as exc:
+        logger.warning("Token Spy telemetry enqueue failed: %s", exc)
+        return False
 
 
 class RouterError(Exception):
@@ -479,10 +677,13 @@ def _sanitize_choice_content(obj: dict[str, Any]) -> bool:
     return changed
 
 
-def _rewrite_sse_event(event: bytes, alias: str) -> tuple[bytes, list[str]]:
-    """Rewrite complete SSE data lines and return concrete model identities."""
+def _rewrite_sse_event(
+    event: bytes, alias: str
+) -> tuple[bytes, list[str], list[dict[str, Any]]]:
+    """Rewrite complete SSE data lines and return observable response metadata."""
     out_lines: list[bytes] = []
     models: list[str] = []
+    payloads: list[dict[str, Any]] = []
     for line in event.splitlines(keepends=True):
         content = line.rstrip(b"\r\n")
         ending = line[len(content):]
@@ -494,6 +695,7 @@ def _rewrite_sse_event(event: bytes, alias: str) -> tuple[bytes, list[str]]:
                 except ValueError:
                     obj = None
                 if isinstance(obj, dict):
+                    payloads.append(obj)
                     if isinstance(obj.get("model"), str):
                         if obj["model"]:
                             models.append(obj["model"])
@@ -504,7 +706,7 @@ def _rewrite_sse_event(event: bytes, alias: str) -> tuple[bytes, list[str]]:
                         + json.dumps(obj, separators=(",", ":")).encode("utf-8")
                     )
         out_lines.append(content + ending)
-    return b"".join(out_lines), models
+    return b"".join(out_lines), models, payloads
 
 
 class _SSERewriter:
@@ -514,6 +716,21 @@ class _SSERewriter:
         self.alias = alias
         self.buffer = b""
         self.models: list[str] = []
+        self.usage = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_write_tokens": 0,
+        }
+        self.stop_reason = ""
+
+    def _observe(self, payloads: list[dict[str, Any]]) -> None:
+        for payload in payloads:
+            usage, stop_reason = _usage_from_response(payload)
+            for key, value in usage.items():
+                self.usage[key] = max(self.usage[key], value)
+            if stop_reason:
+                self.stop_reason = stop_reason
 
     def feed(self, chunk: bytes) -> list[bytes]:
         self.buffer += chunk
@@ -522,16 +739,20 @@ class _SSERewriter:
             event = self.buffer[:match.start()]
             delimiter = self.buffer[match.start():match.end()]
             self.buffer = self.buffer[match.end():]
-            rewritten, models = _rewrite_sse_event(event, self.alias)
+            rewritten, models, payloads = _rewrite_sse_event(event, self.alias)
             self.models.extend(models)
+            self._observe(payloads)
             output.append(rewritten + delimiter)
         return output
 
     def finish(self) -> bytes:
         if not self.buffer:
             return b""
-        rewritten, models = _rewrite_sse_event(self.buffer, self.alias)
+        rewritten, models, payloads = _rewrite_sse_event(
+            self.buffer, self.alias
+        )
         self.models.extend(models)
+        self._observe(payloads)
         self.buffer = b""
         return rewritten
 
@@ -704,6 +925,7 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
 
     url = route["baseUrl"] + path
     client: httpx.AsyncClient = app.state.http
+    telemetry_started = time.monotonic()
     evidence_base = {
         "probeId": probe_id,
         "requestedModel": requested_alias,
@@ -753,6 +975,19 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                             "responseModel": route["runtimeModelId"],
                             "lemonadeRoute": lemonade_route,
                         })
+                    if completed and 200 <= upstream.status_code < 300:
+                        _emit_telemetry(_build_telemetry_event(
+                            payload,
+                            raw_body_bytes=len(raw_body),
+                            model=route["runtimeModelId"],
+                            backend=route["backendKind"],
+                            path=path,
+                            duration_ms=int(
+                                (time.monotonic() - telemetry_started) * 1000
+                            ),
+                            usage=rewriter.usage,
+                            stop_reason=rewriter.stop_reason,
+                        ))
                     await _release_admission()
 
             media_type = upstream.headers.get("content-type",
@@ -784,10 +1019,18 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
         ods_headers["X-Lemonade-Route"] = lemonade_route
 
     response_model = None
+    response_usage = {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+    }
+    stop_reason = ""
     content = upstream.content
     try:
         parsed = json.loads(content.decode("utf-8"))
         if isinstance(parsed, dict):
+            response_usage, stop_reason = _usage_from_response(parsed)
             response_model = parsed.get("model")
             if "model" in parsed:
                 parsed["model"] = requested_alias
@@ -808,6 +1051,18 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                           "responseModel": str(response_model or ""),
                           "lemonadeRoute": lemonade_route})
 
+    if 200 <= upstream.status_code < 300:
+        _emit_telemetry(_build_telemetry_event(
+            payload,
+            raw_body_bytes=len(raw_body),
+            model=route["runtimeModelId"],
+            backend=route["backendKind"],
+            path=path,
+            duration_ms=int((time.monotonic() - telemetry_started) * 1000),
+            usage=response_usage,
+            stop_reason=stop_reason,
+        ))
+
     media_type = upstream.headers.get("content-type", "application/json")
     return Response(content=content, status_code=upstream.status_code,
                     media_type=media_type, headers=ods_headers), False
@@ -824,9 +1079,14 @@ async def _startup() -> None:
             ),
         ),
     )
+    app.state.telemetry = _TelemetrySink(TOKEN_SPY_URL, TOKEN_SPY_API_KEY)
+    await app.state.telemetry.start()
     _load_endpoints()
 
 
 @app.on_event("shutdown")
 async def _shutdown() -> None:
+    telemetry: _TelemetrySink | None = getattr(app.state, "telemetry", None)
+    if telemetry is not None:
+        await telemetry.stop()
     await app.state.http.aclose()

--- a/ods/extensions/services/model-router/app/main.py
+++ b/ods/extensions/services/model-router/app/main.py
@@ -679,17 +679,20 @@ def _sanitize_choice_content(obj: dict[str, Any]) -> bool:
 
 def _rewrite_sse_event(
     event: bytes, alias: str
-) -> tuple[bytes, list[str], list[dict[str, Any]]]:
+) -> tuple[bytes, list[str], list[dict[str, Any]], bool]:
     """Rewrite complete SSE data lines and return observable response metadata."""
     out_lines: list[bytes] = []
     models: list[str] = []
     payloads: list[dict[str, Any]] = []
+    saw_done = False
     for line in event.splitlines(keepends=True):
         content = line.rstrip(b"\r\n")
         ending = line[len(content):]
         if content.startswith(b"data:"):
             payload = content[5:].strip()
-            if payload and payload != b"[DONE]":
+            if payload == b"[DONE]":
+                saw_done = True
+            elif payload:
                 try:
                     obj = json.loads(payload)
                 except ValueError:
@@ -706,7 +709,25 @@ def _rewrite_sse_event(
                         + json.dumps(obj, separators=(",", ":")).encode("utf-8")
                     )
         out_lines.append(content + ending)
-    return b"".join(out_lines), models, payloads
+    return b"".join(out_lines), models, payloads, saw_done
+
+
+def _is_terminal_stream_payload(payload: dict[str, Any]) -> bool:
+    """Recognize terminal Chat/Completions and Responses API stream events."""
+    choices = payload.get("choices")
+    if isinstance(choices, list) and any(
+        isinstance(choice, dict) and choice.get("finish_reason") is not None
+        for choice in choices
+    ):
+        return True
+
+    event_type = payload.get("type")
+    if event_type == "response.completed":
+        return True
+    response = payload.get("response")
+    if isinstance(response, dict) and response.get("status") == "completed":
+        return True
+    return payload.get("status") == "completed"
 
 
 class _SSERewriter:
@@ -723,14 +744,19 @@ class _SSERewriter:
             "cache_write_tokens": 0,
         }
         self.stop_reason = ""
+        self.completed = False
 
-    def _observe(self, payloads: list[dict[str, Any]]) -> None:
+    def _observe(
+        self, payloads: list[dict[str, Any]], *, saw_done: bool = False
+    ) -> None:
+        self.completed = self.completed or saw_done
         for payload in payloads:
             usage, stop_reason = _usage_from_response(payload)
             for key, value in usage.items():
                 self.usage[key] = max(self.usage[key], value)
             if stop_reason:
                 self.stop_reason = stop_reason
+            self.completed = self.completed or _is_terminal_stream_payload(payload)
 
     def feed(self, chunk: bytes) -> list[bytes]:
         self.buffer += chunk
@@ -739,20 +765,22 @@ class _SSERewriter:
             event = self.buffer[:match.start()]
             delimiter = self.buffer[match.start():match.end()]
             self.buffer = self.buffer[match.end():]
-            rewritten, models, payloads = _rewrite_sse_event(event, self.alias)
+            rewritten, models, payloads, saw_done = _rewrite_sse_event(
+                event, self.alias
+            )
             self.models.extend(models)
-            self._observe(payloads)
+            self._observe(payloads, saw_done=saw_done)
             output.append(rewritten + delimiter)
         return output
 
     def finish(self) -> bytes:
         if not self.buffer:
             return b""
-        rewritten, models, payloads = _rewrite_sse_event(
+        rewritten, models, payloads, saw_done = _rewrite_sse_event(
             self.buffer, self.alias
         )
         self.models.extend(models)
-        self._observe(payloads)
+        self._observe(payloads, saw_done=saw_done)
         self.buffer = b""
         return rewritten
 
@@ -962,6 +990,7 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                     await upstream.aclose()
                     if (
                         completed
+                        and rewriter.completed
                         and probe_id
                         and 200 <= upstream.status_code < 300
                         and all(
@@ -975,7 +1004,11 @@ async def _forward_inner(request: Request, path: str, payload: dict[str, Any],
                             "responseModel": route["runtimeModelId"],
                             "lemonadeRoute": lemonade_route,
                         })
-                    if completed and 200 <= upstream.status_code < 300:
+                    if (
+                        completed
+                        and rewriter.completed
+                        and 200 <= upstream.status_code < 300
+                    ):
                         _emit_telemetry(_build_telemetry_event(
                             payload,
                             raw_body_bytes=len(raw_body),

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -155,6 +155,21 @@ def _set_stream_upstream(mod, chunks, *, model_error=None, started=None,
     mod.app.state.http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
 
 
+class _RecordingTelemetry:
+    def __init__(self, *, raises=False):
+        self.events = []
+        self.raises = raises
+
+    def emit(self, event):
+        if self.raises:
+            raise RuntimeError("telemetry unavailable")
+        self.events.append(event)
+        return True
+
+    async def stop(self):
+        return None
+
+
 class TestForwarding:
     def test_alias_rewritten_in_and_out(self, router):
         mod, client, write_state, calls = router
@@ -774,3 +789,161 @@ class TestEndpointsReload:
         assert degraded.status_code == 200
         assert degraded.json()["status"] == "degraded"
         assert degraded.json()["endpointCount"] == 0
+
+
+class TestRoutedTelemetry:
+    def test_router_event_bounds_upstream_usage_to_ingest_contract(self, router):
+        mod, client, write_state, calls = router
+        event = mod._build_telemetry_event(
+            {"messages": [{}] * 100_001},
+            raw_body_bytes=mod.MAX_BODY_BYTES + 1,
+            model="Concrete.gguf",
+            backend="llama-server",
+            path="/v1/chat/completions",
+            duration_ms=100_000_000,
+            usage={
+                "input_tokens": 3_000_000_000,
+                "output_tokens": -1,
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+            },
+            stop_reason="stop",
+        )
+
+        assert event["request_body_bytes"] == mod.MAX_BODY_BYTES
+        assert event["message_count"] == 100_000
+        assert event["input_tokens"] == 2_000_000_000
+        assert event["output_tokens"] == 0
+        assert event["duration_ms"] == 86_400_000
+
+    def test_nonstream_usage_is_emitted_without_message_content(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        recorder = _RecordingTelemetry()
+        mod.app.state.telemetry = recorder
+
+        def handler(_request):
+            return httpx.Response(200, json={
+                "id": "c1",
+                "model": "Concrete.gguf",
+                "choices": [{
+                    "message": {"role": "assistant", "content": "secret answer"},
+                    "finish_reason": "stop",
+                }],
+                "usage": {
+                    "prompt_tokens": 20,
+                    "completion_tokens": 5,
+                    "prompt_tokens_details": {"cached_tokens": 3},
+                },
+            })
+
+        asyncio.run(mod.app.state.http.aclose())
+        mod.app.state.http = httpx.AsyncClient(
+            transport=httpx.MockTransport(handler)
+        )
+        response = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [
+                {"role": "user", "content": "secret prompt"},
+                {"role": "assistant", "content": "prior secret"},
+            ],
+            "tools": [{"type": "function", "function": {"name": "private"}}],
+        })
+
+        assert response.status_code == 200
+        assert len(recorder.events) == 1
+        event = recorder.events[0]
+        assert event["model"] == "Concrete.gguf"
+        assert event["provider_name"] == "llama-server"
+        assert event["message_count"] == 2
+        assert event["user_message_count"] == 1
+        assert event["assistant_message_count"] == 1
+        assert event["tool_count"] == 1
+        assert event["input_tokens"] == 20
+        assert event["output_tokens"] == 5
+        assert event["cache_read_tokens"] == 3
+        assert event["stop_reason"] == "stop"
+        serialized = json.dumps(event)
+        assert "secret prompt" not in serialized
+        assert "secret answer" not in serialized
+        assert "prior secret" not in serialized
+        assert "private" not in serialized
+
+    def test_stream_usage_is_emitted_only_after_complete_stream(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        recorder = _RecordingTelemetry()
+        mod.app.state.telemetry = recorder
+        _set_stream_upstream(mod, [
+            (
+                b'data: {"model":"Concrete.gguf","choices":'
+                b'[{"delta":{"content":"hi"},"finish_reason":null}]}\n\n'
+            ),
+            (
+                b'data: {"model":"Concrete.gguf","choices":'
+                b'[{"delta":{},"finish_reason":"stop"}],'
+                b'"usage":{"prompt_tokens":11,"completion_tokens":7}}\n\n'
+                b"data: [DONE]\n\n"
+            ),
+        ])
+
+        with client.stream("POST", "/v1/chat/completions", json={
+            "model": "default",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        }) as response:
+            assert response.status_code == 200
+            b"".join(response.iter_bytes())
+
+        assert len(recorder.events) == 1
+        assert recorder.events[0]["input_tokens"] == 11
+        assert recorder.events[0]["output_tokens"] == 7
+        assert recorder.events[0]["stop_reason"] == "stop"
+
+    def test_telemetry_failure_never_changes_model_response(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        mod.app.state.telemetry = _RecordingTelemetry(raises=True)
+
+        response = client.post("/v1/chat/completions", json={
+            "model": "ods/current",
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+
+        assert response.status_code == 200
+        assert response.json()["choices"][0]["message"]["content"] == "hello"
+
+    def test_sink_posts_authenticated_event_and_drains(self, monkeypatch):
+        import app.main as mod
+
+        received = []
+
+        def handler(request):
+            received.append({
+                "url": str(request.url),
+                "authorization": request.headers.get("authorization"),
+                "body": json.loads(request.content),
+            })
+            return httpx.Response(202, json={"status": "accepted"})
+
+        async def scenario():
+            client = httpx.AsyncClient(
+                transport=httpx.MockTransport(handler)
+            )
+            sink = mod._TelemetrySink(
+                "http://token-spy:8080",
+                "shared-secret",
+                client=client,
+            )
+            await sink.start()
+            assert sink.emit({"model": "Concrete.gguf"}) is True
+            await asyncio.wait_for(sink.queue.join(), timeout=1)
+            await sink.stop()
+
+        asyncio.run(scenario())
+
+        assert received == [{
+            "url": "http://token-spy:8080/api/ingest/routed",
+            "authorization": "Bearer shared-secret",
+            "body": {"model": "Concrete.gguf"},
+        }]

--- a/ods/extensions/services/model-router/tests/test_router.py
+++ b/ods/extensions/services/model-router/tests/test_router.py
@@ -900,6 +900,61 @@ class TestRoutedTelemetry:
         assert recorder.events[0]["output_tokens"] == 7
         assert recorder.events[0]["stop_reason"] == "stop"
 
+    def test_truncated_stream_without_terminal_event_is_not_emitted(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        recorder = _RecordingTelemetry()
+        mod.app.state.telemetry = recorder
+        _set_stream_upstream(mod, [
+            (
+                b'data: {"model":"Concrete.gguf","choices":'
+                b'[{"delta":{"content":"partial"},"finish_reason":null}],'
+                b'"usage":{"prompt_tokens":11,"completion_tokens":1}}\n\n'
+            ),
+        ])
+
+        with client.stream("POST", "/v1/chat/completions", json={
+            "model": "default",
+            "stream": True,
+            "messages": [{"role": "user", "content": "hi"}],
+        }) as response:
+            assert response.status_code == 200
+            raw = b"".join(response.iter_bytes())
+
+        assert b"partial" in raw
+        assert recorder.events == []
+
+    def test_responses_completed_event_emits_stream_usage(self, router):
+        mod, client, write_state, calls = router
+        write_state()
+        recorder = _RecordingTelemetry()
+        mod.app.state.telemetry = recorder
+        _set_stream_upstream(mod, [
+            (
+                b'data: {"type":"response.output_text.delta",'
+                b'"response":{"model":"Concrete.gguf"},'
+                b'"delta":"hi"}\n\n'
+            ),
+            (
+                b'data: {"type":"response.completed","response":'
+                b'{"model":"Concrete.gguf","status":"completed",'
+                b'"usage":{"input_tokens":9,"output_tokens":4}}}\n\n'
+            ),
+        ])
+
+        with client.stream("POST", "/v1/responses", json={
+            "model": "default",
+            "stream": True,
+            "input": "hi",
+        }) as response:
+            assert response.status_code == 200
+            b"".join(response.iter_bytes())
+
+        assert len(recorder.events) == 1
+        assert recorder.events[0]["input_tokens"] == 9
+        assert recorder.events[0]["output_tokens"] == 4
+        assert recorder.events[0]["stop_reason"] == "completed"
+
     def test_telemetry_failure_never_changes_model_response(self, router):
         mod, client, write_state, calls = router
         write_state()

--- a/ods/extensions/services/token-spy/README.md
+++ b/ods/extensions/services/token-spy/README.md
@@ -18,6 +18,14 @@ Point your agent's API base URL at Token Spy instead of the upstream provider. C
 
 In a ODS install, `TOKEN_SPY_API_KEY` is written to `.env` by the installer and passed to both Token Spy and dashboard-api. Older installs that already have `data/token-spy/token-spy-api-key.txt` keep that value on upgrade so existing clients do not lose access.
 
+ODS model traffic that uses the stable `ods/current` route is reported by
+model-router through the authenticated `/api/ingest/routed` endpoint. This is a
+best-effort side channel, not a proxy hop: an unavailable or disabled Token Spy
+never blocks inference. Routed events contain only model/backend identifiers,
+request shape, token counters, duration, and stop reason. Prompt text,
+generated content, tools, and credentials are not accepted by the ingest
+schema.
+
 ## Features
 
 - **Real-time dashboard** -- session health cards, cost charts, token breakdown, cumulative cost, recent turns table

--- a/ods/extensions/services/token-spy/main.py
+++ b/ods/extensions/services/token-spy/main.py
@@ -26,6 +26,11 @@ from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, Streamin
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from filters import apply_filters
 from providers import ProviderRegistry
+from routed_telemetry import (
+    TelemetryValidationError,
+    routed_event_to_usage,
+    validate_routed_event,
+)
 
 # Database backend selection: sqlite (default) or postgres
 DB_BACKEND = os.environ.get("DB_BACKEND", "sqlite").lower()
@@ -1532,6 +1537,27 @@ def health():
 
 
 # ── API Endpoints ────────────────────────────────────────────────────────────
+
+
+@app.post("/api/ingest/routed", dependencies=[Depends(verify_api_key)])
+async def ingest_routed_telemetry(request: Request):
+    """Store metadata-only usage emitted by the ODS model router."""
+    raw_body = await request.body()
+    if len(raw_body) > 16 * 1024:
+        raise HTTPException(status_code=413, detail="Telemetry event is too large.")
+    try:
+        payload = json.loads(raw_body)
+        event = validate_routed_event(payload)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail="Invalid JSON body.") from exc
+    except TelemetryValidationError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+    if not _db_available:
+        raise HTTPException(status_code=503, detail="Usage database is unavailable.")
+
+    await asyncio.to_thread(log_usage, routed_event_to_usage(event))
+    return JSONResponse({"status": "accepted"}, status_code=202)
 
 
 @app.get("/api/filter-stats", dependencies=[Depends(verify_api_key)])

--- a/ods/extensions/services/token-spy/routed_telemetry.py
+++ b/ods/extensions/services/token-spy/routed_telemetry.py
@@ -1,0 +1,142 @@
+"""Validation and storage mapping for metadata-only routed LLM telemetry."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class TelemetryValidationError(ValueError):
+    """Raised when a routed telemetry event violates the ingest contract."""
+
+
+_STRING_LIMITS = {
+    "agent": 128,
+    "model": 512,
+    "provider_name": 128,
+    "path": 64,
+    "stop_reason": 128,
+}
+_INTEGER_LIMITS = {
+    "request_body_bytes": 2 * 1024 * 1024,
+    "message_count": 100_000,
+    "user_message_count": 100_000,
+    "assistant_message_count": 100_000,
+    "tool_count": 100_000,
+    "input_tokens": 2_000_000_000,
+    "output_tokens": 2_000_000_000,
+    "cache_read_tokens": 2_000_000_000,
+    "cache_write_tokens": 2_000_000_000,
+    "duration_ms": 86_400_000,
+}
+_REQUIRED_FIELDS = {"agent", "model", "provider_name", "path"}
+_ALLOWED_PATHS = {
+    "/v1/chat/completions",
+    "/v1/completions",
+    "/v1/responses",
+}
+_LOCAL_PROVIDERS = {
+    "hipfire",
+    "local",
+    "lemonade",
+    "llama",
+    "llama.cpp",
+    "llama-server",
+    "mlx",
+    "ollama",
+    "vllm",
+}
+
+
+def validate_routed_event(payload: Any) -> dict[str, Any]:
+    """Return a normalized telemetry event or reject it without coercion."""
+    if not isinstance(payload, dict):
+        raise TelemetryValidationError("body must be a JSON object")
+
+    unknown = sorted(set(payload) - set(_STRING_LIMITS) - set(_INTEGER_LIMITS))
+    if unknown:
+        raise TelemetryValidationError(
+            f"unknown fields are not accepted: {', '.join(unknown)}"
+        )
+
+    missing = sorted(_REQUIRED_FIELDS - set(payload))
+    if missing:
+        raise TelemetryValidationError(
+            f"missing required fields: {', '.join(missing)}"
+        )
+
+    normalized: dict[str, Any] = {}
+    for field, limit in _STRING_LIMITS.items():
+        value = payload.get(field, "")
+        if not isinstance(value, str):
+            raise TelemetryValidationError(f"{field} must be a string")
+        value = value.strip()
+        if field in _REQUIRED_FIELDS and not value:
+            raise TelemetryValidationError(f"{field} must not be empty")
+        if len(value) > limit:
+            raise TelemetryValidationError(
+                f"{field} exceeds the {limit}-character limit"
+            )
+        if any(ord(char) < 32 for char in value):
+            raise TelemetryValidationError(
+                f"{field} must not contain control characters"
+            )
+        normalized[field] = value
+
+    if normalized["path"] not in _ALLOWED_PATHS:
+        raise TelemetryValidationError("path is not a routed LLM endpoint")
+
+    for field, limit in _INTEGER_LIMITS.items():
+        value = payload.get(field, 0)
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TelemetryValidationError(f"{field} must be an integer")
+        if value < 0 or value > limit:
+            raise TelemetryValidationError(
+                f"{field} must be between 0 and {limit}"
+            )
+        normalized[field] = value
+
+    return normalized
+
+
+def routed_event_to_usage(event: dict[str, Any]) -> dict[str, Any]:
+    """Map validated metadata into the existing Token Spy usage schema."""
+    provider = event["provider_name"].lower()
+    is_local = provider in _LOCAL_PROVIDERS
+    model = event["model"]
+    # Lemonade can expose the same registered GGUF as either ``name`` or
+    # ``extra.name`` depending on the response path. The prefix is a runtime
+    # namespace, not part of the physical model identity.
+    if is_local and model.startswith("extra."):
+        model = model.removeprefix("extra.")
+    return {
+        "agent": event["agent"],
+        "model": model,
+        "provider_name": "local" if is_local else provider,
+        "cost_source": "local_zero_cost" if is_local else "untracked",
+        "request_body_bytes": event["request_body_bytes"],
+        "message_count": event["message_count"],
+        "user_message_count": event["user_message_count"],
+        "assistant_message_count": event["assistant_message_count"],
+        "tool_count": event["tool_count"],
+        "system_prompt_total_chars": 0,
+        "workspace_agents_chars": 0,
+        "workspace_soul_chars": 0,
+        "workspace_tools_chars": 0,
+        "workspace_identity_chars": 0,
+        "workspace_user_chars": 0,
+        "workspace_heartbeat_chars": 0,
+        "workspace_bootstrap_chars": 0,
+        "skill_injection_chars": 0,
+        "base_prompt_chars": 0,
+        "conversation_history_chars": 0,
+        "input_tokens": event["input_tokens"],
+        "output_tokens": event["output_tokens"],
+        "cache_read_tokens": event["cache_read_tokens"],
+        "cache_write_tokens": event["cache_write_tokens"],
+        "estimated_cost_usd": 0,
+        "duration_ms": event["duration_ms"],
+        "stop_reason": event["stop_reason"] or None,
+        "filter_chars_saved": 0,
+        "filter_tokens_saved": 0,
+        "filter_tools_removed": 0,
+    }

--- a/ods/extensions/services/token-spy/tests/test_routed_telemetry.py
+++ b/ods/extensions/services/token-spy/tests/test_routed_telemetry.py
@@ -1,0 +1,144 @@
+"""Contracts for metadata-only usage events emitted by the model router."""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+
+TOKEN_SPY_DIR = Path(__file__).resolve().parent.parent
+
+
+def _load(path: Path, prefix: str):
+    spec = importlib.util.spec_from_file_location(
+        f"{prefix}_{uuid4().hex}", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _event(**overrides):
+    event = {
+        "agent": "model-router",
+        "model": "extra.Qwen3.5-2B-Q4_K_M.gguf",
+        "provider_name": "lemonade",
+        "path": "/v1/chat/completions",
+        "request_body_bytes": 128,
+        "message_count": 2,
+        "user_message_count": 1,
+        "assistant_message_count": 1,
+        "tool_count": 0,
+        "input_tokens": 20,
+        "output_tokens": 5,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "duration_ms": 250,
+        "stop_reason": "stop",
+    }
+    event.update(overrides)
+    return event
+
+
+def test_routed_event_rejects_content_and_credentials():
+    telemetry = _load(
+        TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"
+    )
+
+    for forbidden in ("messages", "prompt", "content", "authorization"):
+        with pytest.raises(
+            telemetry.TelemetryValidationError,
+            match="unknown fields",
+        ):
+            telemetry.validate_routed_event(
+                _event(**{forbidden: "must not be stored"})
+            )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("input_tokens", -1),
+        ("duration_ms", 86_400_001),
+        ("message_count", True),
+        ("model", ""),
+        ("path", "/not-routed"),
+    ],
+)
+def test_routed_event_rejects_invalid_values(field, value):
+    telemetry = _load(
+        TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"
+    )
+
+    with pytest.raises(telemetry.TelemetryValidationError):
+        telemetry.validate_routed_event(_event(**{field: value}))
+
+
+def test_routed_event_appears_in_usage_report(tmp_path, monkeypatch):
+    telemetry = _load(
+        TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"
+    )
+    db = _load(TOKEN_SPY_DIR / "db.py", "token_spy_db")
+    monkeypatch.setattr(db, "DB_PATH", str(tmp_path / "usage.db"))
+    db._local.conn = None
+    db.init_db()
+
+    normalized = telemetry.validate_routed_event(_event())
+    db.log_usage(telemetry.routed_event_to_usage(normalized))
+    today = datetime.now(timezone.utc).date().isoformat()
+    report = db.query_report(today, today)
+
+    assert report["summary"]["requests"] == 1
+    assert report["summary"]["input_tokens"] == 20
+    assert report["summary"]["output_tokens"] == 5
+    assert report["summary"]["total_tokens"] == 25
+    assert report["summary"]["local_providers"] == 1
+    assert report["models"] == [{
+        "model": "Qwen3.5-2B-Q4_K_M.gguf",
+        "provider": "local",
+        "service": "model-router",
+        "cost_source": "local_zero_cost",
+        "requests": 1,
+        "input_tokens": 20,
+        "output_tokens": 5,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "cost_usd": 0.0,
+    }]
+
+
+def test_local_lemonade_namespace_maps_to_one_physical_model():
+    telemetry = _load(
+        TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"
+    )
+    plain = telemetry.routed_event_to_usage(
+        telemetry.validate_routed_event(
+            _event(model="Qwen3.5-2B-Q4_K_M.gguf")
+        )
+    )
+    namespaced = telemetry.routed_event_to_usage(
+        telemetry.validate_routed_event(
+            _event(model="extra.Qwen3.5-2B-Q4_K_M.gguf")
+        )
+    )
+
+    assert plain["model"] == namespaced["model"]
+
+
+def test_hipfire_backend_is_accounted_as_local_runtime():
+    telemetry = _load(
+        TOKEN_SPY_DIR / "routed_telemetry.py", "routed_telemetry"
+    )
+
+    usage = telemetry.routed_event_to_usage(
+        telemetry.validate_routed_event(
+            _event(provider_name="hipfire", model="Qwen3.5-2B")
+        )
+    )
+
+    assert usage["provider_name"] == "local"
+    assert usage["cost_source"] == "local_zero_cost"


### PR DESCRIPTION
## Summary

The Settings Account card can report `0` tokens, requests, and models even while Open WebUI, Hermes, or another ODS client is actively generating. Token Spy only observes traffic sent through its proxy endpoints, while the supported ODS data plane normally routes through LiteLLM and, when the switchboard is enabled, Model Router.

This PR adds an authenticated, metadata-only usage path for both routing modes:

- `observe`: LiteLLM reports successful completion metadata to Token Spy.
- `enabled`: Model Router reports the completion and LiteLLM skips it, preserving exactly-once accounting.
- direct Model Router clients are covered.
- non-streaming, SSE streaming, Chat Completions, Completions, and Responses usage shapes are normalized.

## Data-flow contract

```text
observe: client -> LiteLLM -> native/cloud runtime
                     | success metadata
                     v
                  Token Spy

enabled: client -> LiteLLM -> Model Router -> active runtime
                                   | success metadata
                                   v
                                Token Spy
```

### Invariants

- Inference never waits for Token Spy.
- A successful routed completion produces at most one usage event.
- Failed and incomplete streams are not counted as completed requests.
- Prompts, messages, generated content, tool definitions/names, and credentials are never transmitted or stored.
- The ingest endpoint accepts only an allowlisted, bounded metadata schema and requires `TOKEN_SPY_API_KEY`.
- Local runtimes (`llama-server`, Lemonade, HipFire, MLX, Ollama, vLLM) remain zero-cost local usage.
- Lemonade's optional `extra.` namespace is normalized so one physical model is not counted twice.

## Implementation

- adds `POST /api/ingest/routed` to Token Spy with bearer authentication, a 16 KiB request limit, strict field rejection, type/range bounds, and existing database-schema reuse;
- adds bounded asynchronous telemetry queues to LiteLLM and Model Router;
- preserves existing LiteLLM callbacks and Langfuse configuration while generating `/tmp/config.yaml`;
- requires an explicit terminal signal (`[DONE]`, non-null `finish_reason`, or `response.completed`) before streaming usage and route evidence are committed;
- rate-limits delivery warnings and drops telemetry rather than delaying or failing model responses;
- documents the supported routed telemetry contract.

## Compatibility and failure behavior

- no database migration and no public host port;
- no installer-specific filesystem path; Linux, Windows, and macOS use the same Compose service contract;
- existing installs receive the path on normal in-place recreate;
- missing key disables emission;
- disabled, unavailable, slow, or rejecting Token Spy does not affect inference;
- cloud usage without authoritative billing metadata is recorded as `untracked`, not assigned an invented cost.

## Validation

### Automated

- `python -m pytest ods/extensions/services/model-router/tests ods/extensions/services/token-spy/tests ods/extensions/services/litellm/tests ods/extensions/services/dashboard-api/tests/test_usage.py -q` -> **92 passed**
- Ruff on all touched Python and tests -> passed
- `python -m py_compile` on touched runtime modules -> passed
- `git diff --check osmantic/main...HEAD` -> passed
- real `docker compose config --quiet` renders -> passed for Linux/CPU, Windows AMD local, and macOS overlays

### Real Windows AMD runtime receipt

Using the local Lemonade-backed ODS stack:

- one non-stream LiteLLM completion recorded exactly **1 request / 22 tokens**;
- one streaming completion recorded exactly **1 request / 15 tokens**;
- one direct Model Router completion recorded exactly once;
- switchboard `enabled` recorded one event, not both LiteLLM and Router events;
- stopping Token Spy still returned a successful model completion in about 2.2 seconds;
- unauthenticated ingest returned `401`;
- a payload containing a forbidden `prompt` field returned `422`;
- the Settings Account card updated from zero to live token, request, model, and activity values.

## Residual limitations

- Delivery is intentionally best-effort and in-memory; a Token Spy outage can lose telemetry, but cannot interrupt inference.
- The SQLite runtime was exercised end-to-end. PostgreSQL uses the existing `log_usage` contract and is covered structurally, but was not exercised against a live PostgreSQL service in this Windows receipt.
- Physical Linux and macOS inference were not run locally; their Compose renders and shared Python paths are covered.

## Independent final review

The branch was updated to the latest `main` and reviewed again without assuming the original implementation was correct. Minimal break attempts covered truncated EOF, `[DONE]`-only streams, non-null `finish_reason`, `response.completed`, `response.failed`, malformed and oversized ingest payloads, missing/invalid authentication, disabled telemetry, queue delivery failure, switchboard observe/enabled deduplication, and local-model identity normalization.

One reproducible defect was found and fixed: a 2xx SSE connection that ended normally without any terminal model event was previously counted as a completed request. Model Router now requires a protocol-level terminal signal before committing telemetry or activation evidence. Regression tests cover truncated Chat Completions and terminal Responses API streams. No additional reproducible defect remains inside this PR's scope; no speculative subsystem changes were added.

