### PR TITLE
fix(models): scope fleet compatibility failures

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -248,7 +248,7 @@
       "size_bytes": 1915306528,
       "size_mb": 1915,
       "vram_required_gb": 4,
-      "context_length": 128000,
+      "context_length": 65536,
       "quantization": "Q4_K_M",
       "specialty": "Chat",
       "description": "Hugging Face's small multilingual long-context instruct model. Candidate low-VRAM agent model pending fleet validation.",
@@ -437,6 +437,17 @@
       "llm_model_name": "granite-4.1-3b",
       "llama_server_image": null,
       "app_compatibility": {
+        "opencode": {
+          "status": "unsupported_until_revalidated",
+          "label": "OpenCode revalidation required",
+          "reason": "A fresh release-grade fleet model-UI run loaded Granite 4.1 3B on tower2, strix-halo, spark, m5-mbp, and strixy. Tower2, Spark, M5, and Strixy passed OpenCode, while strix-halo routed correctly through Lemonade but OpenCode received only the first character of the requested verification phrase. Keep this model out of all-app release coverage on strix-halo until the Lemonade/OpenCode path is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/tower2; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/strix-halo; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/spark; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/m5-mbp; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/strixy",
+          "recordedAt": "2026-07-23T23:10:16Z",
+          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
+          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "hostScope": ["strix-halo"],
+          "expiresAt": "2026-08-23T00:00:00Z"
+        },
         "hermes_talk": {
           "status": "unsupported_until_revalidated",
           "reason": "Fleet model-UI run 2026-07-22T08:31Z on windows-laptop loaded Granite 4.1 3B and ODS Talk accepted the stream request, but the browser stayed in the Thinking state until the 180s inference timeout while dashboard-api reported repeated llama metrics read timeouts.",
@@ -548,6 +559,17 @@
           "status": "verified",
           "reason": "Targeted windows-laptop repro on 2026-07-20 loaded granite3.2-2b-instruct-q4 and the OpenAI-compatible chat API returned the requested verification phrase, but measured only 0.73 tok/s.",
           "evidence": "fleet-test/runs/2026-07-20T14-47-35Z-release-product-6b802d2d34a5-harness-d205823ca1d4-hosts-windows-laptop/model-ui/cycle-004/windows-laptop plus targeted repro at 2026-07-20T16:13Z"
+        },
+        "perplexica": {
+          "status": "unsupported_until_revalidated",
+          "label": "Perplexica revalidation required",
+          "reason": "A fresh release-grade fleet model-UI run loaded this model on tower2, strix-halo, spark, m5-mbp, and strixy. Strix Halo, Spark, and Strixy passed Perplexica, while Tower2 and M5 passed ODS Talk, LiteLLM, Open WebUI, and OpenCode but Perplexica did not return the requested verification phrase. Keep this model out of all-app release coverage on tower2 and m5-mbp until that path is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/tower2; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/strix-halo; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/spark; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/m5-mbp; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/strixy",
+          "recordedAt": "2026-07-23T23:04:18Z",
+          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
+          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "hostScope": ["tower2", "m5-mbp"],
+          "expiresAt": "2026-08-23T00:00:00Z"
         },
         "hermes_talk": {
           "status": "unsupported_until_revalidated",
@@ -830,6 +852,19 @@
       "tokens_per_sec_estimate": 105,
       "llm_model_name": "qwen3-4b-instruct-2507",
       "llama_server_image": null,
+      "app_compatibility": {
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "label": "Agent viability revalidation required",
+          "reason": "A fresh release-grade fleet model-UI run loaded and passed this model through all required apps on tower2, strix-halo, spark, m5-mbp, and strixy. On windows-laptop, the browser-triggered load returned 502 after llama-server metrics stayed unavailable, the product rolled back to the baseline model, and the UI timed out with Qwen3 4B Instruct still downloaded rather than loaded. Keep this model out of Windows agent-required release coverage until activation is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/windows-laptop; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/tower2; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/spark; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/m5-mbp; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strixy",
+          "recordedAt": "2026-07-24T00:26:53Z",
+          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
+          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {
@@ -1185,7 +1220,7 @@
       "gguf_sha256": "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8",
       "size_mb": 5760,
       "vram_required_gb": 8,
-      "context_length": 65536,
+      "context_length": 128000,
       "quantization": "Q4_K_M",
       "specialty": "General",
       "description": "Excellent general-purpose model. Default for most systems. Great at coding, reasoning, and multilingual tasks.",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -258,8 +258,20 @@
       "app_compatibility": {
         "openai_chat": {
           "status": "verified",
-          "reason": "Fleet model-UI run 2026-07-18T16-52Z on windows-laptop loaded this model, ODS Talk completed, and direct OpenAI-compatible consumers returned requested verification phrases. The later all-app failure was caused by slow Perplexica and Privacy Shield probes rather than a model load or Talk incompatibility, so this remains a release revalidation candidate.",
-          "evidence": "fleet-test/runs/2026-07-18T16-52-17Z-model-ui-product-e0a48a80627d-harness-c56304ac9040-hosts-windows-laptop/cycle-003/windows-laptop"
+          "reason": "Fresh exact-commit fleet revalidation on windows-laptop loaded SmolLM3 with its observed 65,536-token runtime context, passed challenge-bound ODS Talk and required deployed LLM-consumer probes, restored the original model and repeated Talk/app probes, then deleted the test model with a clean final inventory.",
+          "evidence": "fleet-test/runs/2026-07-24T02-33-53Z-targeted-windows-smollm3-product-58944ba461fb-harness-b838abf5a87b/model-ui/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T02:40:33Z",
+          "productSha": "58944ba461fb87b87b1ce6fa854e32d15aeb8efa",
+          "harnessSha": "b838abf5a87b32c3f7ab8eaef43ea97133fb43d9"
+        },
+        "hermes_talk": {
+          "status": "verified",
+          "label": "ODS Talk verified",
+          "reason": "Fresh exact-commit fleet revalidation on windows-laptop passed challenge-bound ODS Talk on SmolLM3 and again after restoring the original model; all required deployed LLM-consumer probes and cleanup checks also passed.",
+          "evidence": "fleet-test/runs/2026-07-24T02-33-53Z-targeted-windows-smollm3-product-58944ba461fb-harness-b838abf5a87b/model-ui/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T02:40:33Z",
+          "productSha": "58944ba461fb87b87b1ce6fa854e32d15aeb8efa",
+          "harnessSha": "b838abf5a87b32c3f7ab8eaef43ea97133fb43d9"
         }
       },
       "install_recommendation": false

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -258,12 +258,7 @@
       "app_compatibility": {
         "openai_chat": {
           "status": "verified",
-          "reason": "Fleet model-UI run 2026-07-18T16-52Z on windows-laptop loaded this model and direct OpenAI-compatible consumers returned requested verification phrases, but all-app release coverage remains blocked pending Perplexica and Privacy Shield revalidation.",
-          "evidence": "fleet-test/runs/2026-07-18T16-52-17Z-model-ui-product-e0a48a80627d-harness-c56304ac9040-hosts-windows-laptop/cycle-003/windows-laptop"
-        },
-        "agent_viability": {
-          "status": "not_agent_viable",
-          "reason": "Fleet model-UI run 2026-07-18T16-52Z on windows-laptop loaded this model and ODS Talk completed, but the required all-app probes did not complete: Perplexica timed out and Privacy Shield returned HTTP 504 while the runtime was producing very slow responses; keep it out of release-grade agent/app coverage until revalidated.",
+          "reason": "Fleet model-UI run 2026-07-18T16-52Z on windows-laptop loaded this model, ODS Talk completed, and direct OpenAI-compatible consumers returned requested verification phrases. The later all-app failure was caused by slow Perplexica and Privacy Shield probes rather than a model load or Talk incompatibility, so this remains a release revalidation candidate.",
           "evidence": "fleet-test/runs/2026-07-18T16-52-17Z-model-ui-product-e0a48a80627d-harness-c56304ac9040-hosts-windows-laptop/cycle-003/windows-laptop"
         }
       },
@@ -1158,7 +1153,31 @@
       "description": "Unsloth's GGUF quant of Qwen3.5 4B with native 262K context metadata. A low-VRAM long-context release candidate for app and Talk validation.",
       "tokens_per_sec_estimate": 100,
       "llm_model_name": "qwen3.5-4b",
-      "llama_server_image": null
+      "llama_server_image": null,
+      "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "label": "ODS Talk revalidation required",
+          "reason": "A fresh release-grade fleet model-UI run loaded this model on windows-laptop and verified the exact llama-server route, but ODS Talk remained in the Thinking state until the 180-second inference timeout. Keep it out of Windows Talk and all-app release coverage until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/windows-laptop",
+          "recordedAt": "2026-07-24T00:42:20Z",
+          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
+          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        },
+        "agent_viability": {
+          "status": "not_agent_viable",
+          "label": "Agent viability revalidation required",
+          "reason": "A fresh release-grade fleet model-UI run loaded this model on windows-laptop and verified the exact llama-server route, but ODS Talk did not finish within the 180-second inference timeout. Keep it out of Windows agent-required release coverage until revalidated.",
+          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/windows-laptop",
+          "recordedAt": "2026-07-24T00:42:20Z",
+          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
+          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        }
+      }
     },
     {
       "id": "gemma4-e2b-q4",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -1220,7 +1220,7 @@
       "gguf_sha256": "03b74727a860a56338e042c4420bb3f04b2fec5734175f4cb9fa853daf52b7e8",
       "size_mb": 5760,
       "vram_required_gb": 8,
-      "context_length": 128000,
+      "context_length": 65536,
       "quantization": "Q4_K_M",
       "specialty": "General",
       "description": "Excellent general-purpose model. Default for most systems. Great at coding, reasoning, and multilingual tasks.",

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -415,6 +415,77 @@ def test_real_catalog_gemma_perplexica_block_is_global():
     assert tower2["perplexica"]["status"] == "unsupported_until_revalidated"
 
 
+def test_real_catalog_granite32_perplexica_block_is_tower2_and_m5_scoped():
+    by_id = {model["id"]: model for model in _official_model_catalog()}
+    model = by_id["granite3.2-2b-instruct-q4"]
+
+    windows_laptop = model_app_compatibility(
+        model,
+        runtime_context={"host": "windows-laptop", "hosts": ["windows-laptop"]},
+    )
+    strix_halo = model_app_compatibility(
+        model,
+        runtime_context={"host": "strix-halo", "hosts": ["strix-halo"]},
+    )
+    tower2 = model_app_compatibility(
+        model,
+        runtime_context={"host": "tower2", "hosts": ["tower2"]},
+    )
+    m5_mbp = model_app_compatibility(
+        model,
+        runtime_context={"host": "m5-mbp", "hosts": ["m5-mbp"]},
+    )
+
+    assert windows_laptop["perplexica"]["status"] == "unknown"
+    assert strix_halo["perplexica"]["status"] == "unknown"
+    assert tower2["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert m5_mbp["perplexica"]["status"] == "unsupported_until_revalidated"
+
+
+def test_real_catalog_granite41_opencode_block_is_strix_halo_scoped():
+    by_id = {model["id"]: model for model in _official_model_catalog()}
+    model = by_id["granite4.1-3b-q4"]
+
+    strix_halo = model_app_compatibility(
+        model,
+        runtime_context={"host": "strix-halo", "hosts": ["strix-halo"]},
+    )
+    spark = model_app_compatibility(
+        model,
+        runtime_context={"host": "spark", "hosts": ["spark"]},
+    )
+    tower2 = model_app_compatibility(
+        model,
+        runtime_context={"host": "tower2", "hosts": ["tower2"]},
+    )
+
+    assert strix_halo["opencode"]["status"] == "unsupported_until_revalidated"
+    assert spark["opencode"]["status"] == "unknown"
+    assert tower2["opencode"]["status"] == "unknown"
+
+
+def test_real_catalog_qwen3_4b_instruct_agent_block_is_windows_scoped():
+    by_id = {model["id"]: model for model in _official_model_catalog()}
+    model = by_id["qwen3-4b-instruct-2507-q4"]
+
+    windows_laptop = model_app_compatibility(
+        model,
+        runtime_context={"host": "windows-laptop", "hosts": ["windows-laptop"]},
+    )
+    strix_halo = model_app_compatibility(
+        model,
+        runtime_context={"host": "strix-halo", "hosts": ["strix-halo"]},
+    )
+    tower2 = model_app_compatibility(
+        model,
+        runtime_context={"host": "tower2", "hosts": ["tower2"]},
+    )
+
+    assert windows_laptop["agentViability"]["status"] == "not_agent_viable"
+    assert strix_halo["agentViability"]["status"] == "unknown"
+    assert tower2["agentViability"]["status"] == "unknown"
+
+
 def test_measured_local_too_slow_blocks_agent_compatibility(data_dir, tmp_path):
     install_dir = tmp_path / "ods"
     (install_dir / "data" / "models").mkdir(parents=True)
@@ -569,16 +640,20 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert len(candidates) >= 6
     assert {
         "qwen3.5-4b-q4",
-        "qwen3-4b-instruct-2507-q4",
         "qwen3-4b-128k-q4",
         "qwen2.5-coder-1.5b-128k-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
+        "granite4.0-h-1b-q4",
     }.issubset(candidate_ids)
     assert by_id["qwen3.5-4b-q4"]["contextLength"] == 262144
-    assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 262144
     assert by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
     assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
+    assert "qwen3-4b-instruct-2507-q4" not in candidate_ids
+    assert all_by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 262144
+    assert all_by_id["qwen3-4b-instruct-2507-q4"]["appCompatibility"]["agentViability"]["status"] == (
+        "not_agent_viable"
+    )
     assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"
     )

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -486,6 +486,25 @@ def test_real_catalog_qwen3_4b_instruct_agent_block_is_windows_scoped():
     assert tower2["agentViability"]["status"] == "unknown"
 
 
+def test_real_catalog_qwen35_4b_talk_block_is_windows_scoped():
+    by_id = {model["id"]: model for model in _official_model_catalog()}
+    model = by_id["qwen3.5-4b-q4"]
+
+    windows_laptop = model_app_compatibility(
+        model,
+        runtime_context={"host": "windows-laptop", "hosts": ["windows-laptop"]},
+    )
+    strix_halo = model_app_compatibility(
+        model,
+        runtime_context={"host": "strix-halo", "hosts": ["strix-halo"]},
+    )
+
+    assert windows_laptop["hermesTalk"]["status"] == "unsupported_until_revalidated"
+    assert windows_laptop["agentViability"]["status"] == "not_agent_viable"
+    assert strix_halo["hermesTalk"]["status"] == "unknown"
+    assert strix_halo["agentViability"]["status"] == "unknown"
+
+
 def test_measured_local_too_slow_blocks_agent_compatibility(data_dir, tmp_path):
     install_dir = tmp_path / "ods"
     (install_dir / "data" / "models").mkdir(parents=True)
@@ -639,14 +658,19 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
 
     assert len(candidates) >= 6
     assert {
-        "qwen3.5-4b-q4",
         "qwen3-4b-128k-q4",
         "qwen2.5-coder-1.5b-128k-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
         "granite4.0-h-1b-q4",
+        "smollm3-3b-q4",
     }.issubset(candidate_ids)
-    assert by_id["qwen3.5-4b-q4"]["contextLength"] == 262144
+    assert "qwen3.5-4b-q4" not in candidate_ids
+    assert all_by_id["qwen3.5-4b-q4"]["contextLength"] == 262144
+    assert all_by_id["qwen3.5-4b-q4"]["appCompatibility"]["agentViability"]["status"] == (
+        "not_agent_viable"
+    )
+    assert by_id["smollm3-3b-q4"]["contextLength"] == 65536
     assert by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
     assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
     assert "qwen3-4b-instruct-2507-q4" not in candidate_ids
@@ -689,7 +713,7 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "granite4.0-1b-q4" not in candidate_ids
     assert "phi3-mini-128k-q4" not in candidate_ids
     assert "granite3.3-8b-instruct-q4" not in candidate_ids
-    assert "smollm3-3b-q4" not in candidate_ids
+    assert "smollm3-3b-q4" in candidate_ids
     assert "qwen2.5-3b-instruct-q4" not in candidate_ids
     assert "qwen3-4b-q4" not in candidate_ids
     assert "qwen3-1.7b-q4" not in candidate_ids

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -47,14 +47,22 @@ def _has_runtime_scope(entry):
     )
 
 
-def _agent_viable_for_release(model):
+def _agent_viable_for_release(model, host=None):
     if str(model.get("source") or "").strip().lower() not in {"", "curated"}:
         return False
     compatibility = model.get("app_compatibility") or {}
     for entry in compatibility.values():
+        entry = entry or {}
         status = str((entry or {}).get("status") or "").strip().lower()
-        if status in BLOCKING_AGENT_STATUSES and not _has_runtime_scope(entry or {}):
-            return False
+        if status not in BLOCKING_AGENT_STATUSES or _has_runtime_scope(entry):
+            continue
+        host_scope = entry.get("hostScope") or entry.get("host_scope")
+        if host_scope:
+            scoped_hosts = {str(value).strip().lower() for value in host_scope}
+            if host is not None and str(host).strip().lower() in scoped_hosts:
+                return False
+            continue
+        return False
     return True
 
 
@@ -250,8 +258,10 @@ def test_granite33_2b_is_not_agent_viable_until_revalidated():
 def test_smollm3_3b_is_not_agent_viable_until_app_revalidated():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
-    compatibility = by_id["smollm3-3b-q4"]["app_compatibility"]
+    model = by_id["smollm3-3b-q4"]
+    compatibility = model["app_compatibility"]
 
+    assert model["context_length"] == 65536
     assert compatibility["openai_chat"]["status"] == "verified"
     assert "cycle-003" in compatibility["openai_chat"]["evidence"]
     assert compatibility["agent_viability"]["status"] == "not_agent_viable"
@@ -290,7 +300,8 @@ def test_granite4_h_1b_requires_perplexica_revalidation_after_m5_partial_reply()
     assert "m5-mbp" in compatibility["perplexica"]["reason"]
     assert "Perplexica" in compatibility["perplexica"]["reason"]
     assert "cycle-003" in compatibility["perplexica"]["evidence"]
-    assert not _agent_viable_for_release(model)
+    assert _agent_viable_for_release(model)
+    assert not _agent_viable_for_release(model, host="m5-mbp")
 
 
 def test_falcon_h1_15b_is_not_low_vram_agent_viable_after_opencode_failure():
@@ -322,7 +333,8 @@ def test_granite32_2b_is_direct_chat_only_after_windows_talk_timeout():
     assert "19,349-token Hermes prompt" in compatibility["agent_viability"]["reason"]
     assert compatibility["hermes_talk"]["status"] == "unsupported_until_revalidated"
     assert "cycle-004" in compatibility["hermes_talk"]["evidence"]
-    assert not _agent_viable_for_release(model)
+    assert _agent_viable_for_release(model)
+    assert not _agent_viable_for_release(model, host="windows-laptop")
 
 
 def test_granite4_h_350m_is_not_agent_viable_after_talk_probe_failure():
@@ -511,7 +523,8 @@ def test_qwen25_coder_15b_128k_is_not_talk_agent_viable_until_revalidated():
     assert "generic assistant prose" in compatibility["hermes_talk"]["reason"]
     assert "cycle-006" in compatibility["hermes_talk"]["evidence"]
     assert compatibility["agent_viability"]["status"] == "not_agent_viable"
-    assert not _agent_viable_for_release(model)
+    assert _agent_viable_for_release(model)
+    assert not _agent_viable_for_release(model, host="tower2")
 
 
 def test_mistral_nemo_talk_block_is_scoped_to_apple_llama_server():

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -255,7 +255,7 @@ def test_granite33_2b_is_not_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["granite3.3-2b-instruct-q4"])
 
 
-def test_smollm3_3b_is_not_agent_viable_until_app_revalidated():
+def test_smollm3_3b_runtime_context_is_64k_and_it_remains_a_revalidation_candidate():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     model = by_id["smollm3-3b-q4"]
@@ -264,11 +264,8 @@ def test_smollm3_3b_is_not_agent_viable_until_app_revalidated():
     assert model["context_length"] == 65536
     assert compatibility["openai_chat"]["status"] == "verified"
     assert "cycle-003" in compatibility["openai_chat"]["evidence"]
-    assert compatibility["agent_viability"]["status"] == "not_agent_viable"
-    assert "Perplexica" in compatibility["agent_viability"]["reason"]
-    assert "Privacy Shield" in compatibility["agent_viability"]["reason"]
-    assert "cycle-003" in compatibility["agent_viability"]["evidence"]
-    assert not _agent_viable_for_release(by_id["smollm3-3b-q4"])
+    assert "agent_viability" not in compatibility
+    assert _agent_viable_for_release(model)
 
 
 def test_granite31_requires_global_perplexica_revalidation_after_strixy_failure():

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -263,7 +263,9 @@ def test_smollm3_3b_runtime_context_is_64k_and_it_remains_a_revalidation_candida
 
     assert model["context_length"] == 65536
     assert compatibility["openai_chat"]["status"] == "verified"
-    assert "cycle-003" in compatibility["openai_chat"]["evidence"]
+    assert "58944ba461fb" in compatibility["openai_chat"]["evidence"]
+    assert compatibility["hermes_talk"]["status"] == "verified"
+    assert compatibility["hermes_talk"]["productSha"] == "58944ba461fb87b87b1ce6fa854e32d15aeb8efa"
     assert "agent_viability" not in compatibility
     assert _agent_viable_for_release(model)
 


### PR DESCRIPTION
## Summary
- scope Granite 3.2 Perplexica failures to Tower2 and M5, Granite 4.1 OpenCode failure to Strix Halo, Qwen3 4B Instruct activation failure to Windows, and Qwen 3.5 4B Talk timeout to Windows
- correct SmolLM3 GGUF context metadata from 128000 to its observed 65536 training/runtime context
- record a fresh exact-commit Windows SmolLM3 pass and keep it in the six-model Windows release set
- make release-viability coverage host-scope aware

## Validation
- 1858 dashboard-api/model coverage tests passed, 14 skipped, one Windows symlink test deselected; one pre-existing AsyncMock warning
- 69 focused catalog/oracle tests passed
- tier selector: 128 passed, 0 failed
- all GitHub checks passed on the prior behavior commit; final evidence-only refresh pending
- exact Windows install at product 58944ba461fb and harness b838abf5a87b passed
- SmolLM3 UI run passed download, exact load identity, challenge-bound Talk, required deployed app probes, original-model restore, restored Talk/app probes, delete, clean final inventory, artifact integrity, and cleanup: fleet-test/runs/2026-07-24T02-33-53Z-targeted-windows-smollm3-product-58944ba461fb-harness-b838abf5a87b
