### PR TITLE
fix(models): align fleet compatibility and 8GB profiles

### DIFF
--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -71,38 +71,17 @@
       "llama_server_image": null,
       "app_compatibility": {
         "openai_chat": {
-          "status": "unknown",
-          "label": "Windows app revalidation in progress",
-          "reason": "The prior Windows activation verdict predates the NVIDIA 8GB 64K Q4-KV runtime profile. A fresh exact-commit run downloaded and verified Phi-3.5 Mini, but the stale unsupported record prevented the Models UI from offering Run; keep direct-chat compatibility unclaimed until the new profile completes the required app probes.",
-          "evidence": "fleet-test/runs/2026-07-24T06-38-00Z-windows-profile-candidates-route-validation/cycle-002/windows-laptop",
-          "recordedAt": "2026-07-24T06:51:00Z",
-          "productSha": "969c463f0b17251f3d373c7ae48859287023d0d3",
+          "status": "unsupported_until_revalidated",
+          "label": "Windows 8GB runtime unsupported",
+          "reason": "Fresh exact-commit Windows revalidation loaded Phi-3.5 Mini at the required 65,536-token context with Q4 KV cache, but llama.cpp projected 9,344 MiB of device memory against 6,912 MiB free and challenge-bound direct probes decoded at only 0.47-0.49 tok/s before the Hermes prompt. Keep this model out of Windows 8GB release coverage until a viable partial-offload or lower-memory runtime is implemented.",
+          "evidence": "fleet-test/runs/2026-07-24T07-04-00Z-windows-profile-candidates-route-validation/cycle-002/windows-laptop",
+          "recordedAt": "2026-07-24T07:16:00Z",
+          "productSha": "011bbabd74b72476862ad9a741dc4876b57e9521",
           "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         }
       },
-      "runtime_profiles": [
-        {
-          "id": "nvidia-8gb-64k-q4-kv",
-          "label": "NVIDIA 8GB 64K context with Q4 KV cache",
-          "backend": "nvidia",
-          "host_arch": ["amd64"],
-          "memory_type": "discrete",
-          "vram_min_gb": 7.5,
-          "vram_max_gb": 8.5,
-          "system_ram_min_gb": 31,
-          "context_length": 65536,
-          "estimated_required_gb": 7.2,
-          "fit_label": "64K 8GB Q4 KV profile",
-          "env": {
-            "LLAMA_PARALLEL": "1",
-            "LLAMA_ARG_FLASH_ATTN": "on",
-            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
-            "LLAMA_ARG_CACHE_TYPE_V": "q4_0"
-          }
-        }
-      ],
       "install_recommendation": false
     },
     {
@@ -911,8 +890,8 @@
       },
       "runtime_profiles": [
         {
-          "id": "nvidia-8gb-64k-q8-kv",
-          "label": "NVIDIA 8GB 64K context with Q8 KV cache",
+          "id": "nvidia-8gb-64k-q4-kv",
+          "label": "NVIDIA 8GB 64K context with Q4 KV cache",
           "backend": "nvidia",
           "host_arch": ["amd64"],
           "memory_type": "discrete",
@@ -920,13 +899,13 @@
           "vram_max_gb": 8.5,
           "system_ram_min_gb": 31,
           "context_length": 65536,
-          "estimated_required_gb": 7.6,
-          "fit_label": "64K 8GB Q8 KV profile",
+          "estimated_required_gb": 7.2,
+          "fit_label": "64K 8GB Q4 KV profile",
           "env": {
             "LLAMA_PARALLEL": "1",
             "LLAMA_ARG_FLASH_ATTN": "on",
-            "LLAMA_ARG_CACHE_TYPE_K": "q8_0",
-            "LLAMA_ARG_CACHE_TYPE_V": "q8_0"
+            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q4_0"
           }
         }
       ],
@@ -1239,28 +1218,49 @@
       "llama_server_image": null,
       "app_compatibility": {
         "hermes_talk": {
-          "status": "unsupported_until_revalidated",
-          "label": "ODS Talk revalidation required",
-          "reason": "A fresh release-grade fleet model-UI run loaded this model on windows-laptop and verified the exact llama-server route, but ODS Talk remained in the Thinking state until the 180-second inference timeout. Keep it out of Windows Talk and all-app release coverage until revalidated.",
+          "status": "unknown",
+          "label": "Windows app revalidation in progress",
+          "reason": "The prior Windows Talk timeout used this model's native 262K context. A new NVIDIA 8GB 64K Q4-KV profile removes that invalid runtime precondition; keep Talk compatibility unclaimed until the profiled route completes the required app probes.",
           "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/windows-laptop",
-          "recordedAt": "2026-07-24T00:42:20Z",
-          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
-          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "recordedAt": "2026-07-24T07:16:00Z",
+          "productSha": "011bbabd74b72476862ad9a741dc4876b57e9521",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         },
         "agent_viability": {
-          "status": "not_agent_viable",
-          "label": "Agent viability revalidation required",
-          "reason": "A fresh release-grade fleet model-UI run loaded this model on windows-laptop and verified the exact llama-server route, but ODS Talk did not finish within the 180-second inference timeout. Keep it out of Windows agent-required release coverage until revalidated.",
+          "status": "unknown",
+          "label": "Windows app revalidation in progress",
+          "reason": "The prior Windows agent timeout used this model's native 262K context. A new NVIDIA 8GB 64K Q4-KV profile removes that invalid runtime precondition; keep agent viability unclaimed until the profiled route completes ODS Talk and all required app probes.",
           "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/windows-laptop",
-          "recordedAt": "2026-07-24T00:42:20Z",
-          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
-          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "recordedAt": "2026-07-24T07:16:00Z",
+          "productSha": "011bbabd74b72476862ad9a741dc4876b57e9521",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         }
-      }
+      },
+      "runtime_profiles": [
+        {
+          "id": "nvidia-8gb-64k-q4-kv",
+          "label": "NVIDIA 8GB 64K context with Q4 KV cache",
+          "backend": "nvidia",
+          "host_arch": ["amd64"],
+          "memory_type": "discrete",
+          "vram_min_gb": 7.5,
+          "vram_max_gb": 8.5,
+          "system_ram_min_gb": 31,
+          "context_length": 65536,
+          "estimated_required_gb": 7.2,
+          "fit_label": "64K 8GB Q4 KV profile",
+          "env": {
+            "LLAMA_PARALLEL": "1",
+            "LLAMA_ARG_FLASH_ATTN": "on",
+            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q4_0"
+          }
+        }
+      ]
     },
     {
       "id": "gemma4-e2b-q4",

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -287,6 +287,7 @@
           "recordedAt": "2026-07-24T04:23:49Z",
           "productSha": "faaf5af99c89e38cc43f18239ea94747f62bf16b",
           "harnessSha": "b838abf5a87b32c3f7ab8eaef43ea97133fb43d9",
+          "globalScope": true,
           "expiresAt": "2026-08-24T00:00:00Z"
         }
       },
@@ -318,6 +319,7 @@
           "recordedAt": "2026-07-23T21:21:17Z",
           "productSha": "3675af7931935ae0d435a6498c98bc114be209ca",
           "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "globalScope": true,
           "expiresAt": "2026-08-22T00:00:00Z"
         }
       },
@@ -379,6 +381,7 @@
           "recordedAt": "2026-07-22T19:33:20Z",
           "productSha": "31c93e53c4aa8f9831abdb00516639def985ef34",
           "harnessSha": "ebdb7f9481901a35ca1e5108fe2a1769bab197e8",
+          "globalScope": true,
           "expiresAt": "2026-08-22T00:00:00Z"
         },
         "opencode": {
@@ -398,6 +401,7 @@
           "recordedAt": "2026-07-22T19:33:20Z",
           "productSha": "31c93e53c4aa8f9831abdb00516639def985ef34",
           "harnessSha": "ebdb7f9481901a35ca1e5108fe2a1769bab197e8",
+          "globalScope": true,
           "expiresAt": "2026-08-22T00:00:00Z"
         }
       },
@@ -428,6 +432,7 @@
           "recordedAt": "2026-07-21T14:25:00Z",
           "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
           "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
+          "globalScope": true,
           "expiresAt": "2026-08-21T00:00:00Z"
         },
         "agent_viability": {
@@ -437,6 +442,7 @@
           "recordedAt": "2026-07-21T14:25:00Z",
           "productSha": "7df3f218a06c386bdb40856c928a0618b8e16b57",
           "harnessSha": "d2a31507fa0652dff4c8cc1892e56ccf1b9102bb",
+          "globalScope": true,
           "expiresAt": "2026-08-21T00:00:00Z"
         }
       },
@@ -643,6 +649,7 @@
           "recordedAt": "2026-07-22T22:21:04Z",
           "productSha": "39164d8c5bc3306dd4e7ac3e884dcc8574b9930a",
           "harnessSha": "18e2bd60437f4e5ba7b3cd461a37d99ab524ef6a",
+          "globalScope": true,
           "expiresAt": "2026-08-22T00:00:00Z"
         }
       },
@@ -684,6 +691,7 @@
           "recordedAt": "2026-07-23T02:25:29Z",
           "productSha": "98d5a50cd5b527cb8dbd6117ba2d158538b73a9e",
           "harnessSha": "18e2bd60437f4e5ba7b3cd461a37d99ab524ef6a",
+          "globalScope": true,
           "expiresAt": "2026-08-23T00:00:00Z"
         },
         "agent_viability": {
@@ -876,13 +884,46 @@
       "llm_model_name": "qwen3-4b-instruct-2507",
       "llama_server_image": null,
       "app_compatibility": {
+        "openai_chat": {
+          "status": "verified",
+          "label": "Direct chat verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation loaded the profiled model through the UI and passed challenge-bound LiteLLM and Open WebUI routes with exact model-route evidence.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        },
+        "hermes_talk": {
+          "status": "verified",
+          "label": "ODS Talk verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation passed challenge-bound ODS Talk with the NVIDIA 8GB 64K Q4-KV profile, then restored the original model and passed Talk again.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        },
+        "perplexica": {
+          "status": "verified",
+          "label": "Perplexica verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation passed the challenge-bound Perplexica app route with exact Qwen3 4B Instruct route evidence before clean baseline restore and candidate deletion.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        },
         "agent_viability": {
-          "status": "unknown",
-          "label": "Windows app revalidation in progress",
-          "reason": "Fresh exact-commit Windows validation loaded Qwen3 4B Instruct successfully with the NVIDIA 8GB 64K runtime profile and served challenge-bound direct completions. The prior activation failure is no longer reproducible; keep agent viability unclaimed until the same run can exercise ODS Talk and all required app routes.",
-          "evidence": "fleet-test/runs/2026-07-24T06-38-00Z-windows-profile-candidates-route-validation/cycle-001/windows-laptop",
-          "recordedAt": "2026-07-24T06:49:26Z",
-          "productSha": "969c463f0b17251f3d373c7ae48859287023d0d3",
+          "status": "verified",
+          "label": "Agent workflow verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation loaded Qwen3 4B Instruct with the NVIDIA 8GB 64K Q4-KV profile and passed ODS Talk plus every required deployed LLM-consumer probe in test and restored-baseline phases, with clean candidate deletion and final inventory.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
           "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
@@ -1217,24 +1258,46 @@
       "llm_model_name": "qwen3.5-4b",
       "llama_server_image": null,
       "app_compatibility": {
+        "openai_chat": {
+          "status": "verified",
+          "label": "Direct chat verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation loaded the profiled model through the UI and passed challenge-bound LiteLLM and Open WebUI routes with exact model-route evidence.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-002/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        },
         "hermes_talk": {
-          "status": "unknown",
-          "label": "Windows app revalidation in progress",
-          "reason": "The prior Windows Talk timeout used this model's native 262K context. A new NVIDIA 8GB 64K Q4-KV profile removes that invalid runtime precondition; keep Talk compatibility unclaimed until the profiled route completes the required app probes.",
-          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/windows-laptop",
-          "recordedAt": "2026-07-24T07:16:00Z",
-          "productSha": "011bbabd74b72476862ad9a741dc4876b57e9521",
+          "status": "verified",
+          "label": "ODS Talk verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation passed challenge-bound ODS Talk with the NVIDIA 8GB 64K Q4-KV profile, then restored the original model and passed Talk again.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-002/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        },
+        "perplexica": {
+          "status": "verified",
+          "label": "Perplexica verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation passed the challenge-bound Perplexica app route with exact Qwen3.5 4B route evidence before clean baseline restore and candidate deletion.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-002/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
           "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         },
         "agent_viability": {
-          "status": "unknown",
-          "label": "Windows app revalidation in progress",
-          "reason": "The prior Windows agent timeout used this model's native 262K context. A new NVIDIA 8GB 64K Q4-KV profile removes that invalid runtime precondition; keep agent viability unclaimed until the profiled route completes ODS Talk and all required app probes.",
-          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/windows-laptop",
-          "recordedAt": "2026-07-24T07:16:00Z",
-          "productSha": "011bbabd74b72476862ad9a741dc4876b57e9521",
+          "status": "verified",
+          "label": "Agent workflow verified on Windows",
+          "reason": "Fresh exact-commit Windows fleet validation loaded Qwen3.5 4B with the NVIDIA 8GB 64K Q4-KV profile and passed ODS Talk plus every required deployed LLM-consumer probe in test and restored-baseline phases, with clean candidate deletion and final inventory.",
+          "evidence": "fleet-test/runs/2026-07-24T07-55-00Z-windows-profile-candidates-route-validation/cycle-002/windows-laptop",
+          "recordedAt": "2026-07-24T08:03:57Z",
+          "productSha": "449cf84d866d8bdedd8046d3c58faab6c07b5f03",
           "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -71,9 +71,15 @@
       "llama_server_image": null,
       "app_compatibility": {
         "openai_chat": {
-          "status": "unsupported_until_revalidated",
-          "reason": "Fleet model-UI run 2026-07-16T11-44Z on windows-laptop downloaded this model with a valid SHA, but llama.cpp never reported the requested Phi-3.5 runtime identity during activation; keep it out of direct-chat and release switch coverage until revalidated.",
-          "evidence": "fleet-test/runs/2026-07-16T11-44-05Z-release-affected-product-d11ef611-harness-a7745b8-windows-pair/model-ui/cycle-002/windows-laptop"
+          "status": "unknown",
+          "label": "Windows app revalidation in progress",
+          "reason": "The prior Windows activation verdict predates the NVIDIA 8GB 64K Q4-KV runtime profile. A fresh exact-commit run downloaded and verified Phi-3.5 Mini, but the stale unsupported record prevented the Models UI from offering Run; keep direct-chat compatibility unclaimed until the new profile completes the required app probes.",
+          "evidence": "fleet-test/runs/2026-07-24T06-38-00Z-windows-profile-candidates-route-validation/cycle-002/windows-laptop",
+          "recordedAt": "2026-07-24T06:51:00Z",
+          "productSha": "969c463f0b17251f3d373c7ae48859287023d0d3",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
+          "hostScope": ["windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
         }
       },
       "runtime_profiles": [
@@ -892,13 +898,13 @@
       "llama_server_image": null,
       "app_compatibility": {
         "agent_viability": {
-          "status": "not_agent_viable",
-          "label": "Agent viability revalidation required",
-          "reason": "A fresh release-grade fleet model-UI run loaded and passed this model through all required apps on tower2, strix-halo, spark, m5-mbp, and strixy. On windows-laptop, the browser-triggered load returned 502 after llama-server metrics stayed unavailable, the product rolled back to the baseline model, and the UI timed out with Qwen3 4B Instruct still downloaded rather than loaded. Keep this model out of Windows agent-required release coverage until activation is revalidated.",
-          "evidence": "fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-004/windows-laptop; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/tower2; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strix-halo; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/spark; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/m5-mbp; fleet-test/runs/2026-07-23T21-41-59Z-release-product-cf6dffb8e8bb-harness-47eedd6c0b40-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/strixy",
-          "recordedAt": "2026-07-24T00:26:53Z",
-          "productSha": "cf6dffb8e8bbf60f418caeab47d7ae3ef8815307",
-          "harnessSha": "47eedd6c0b40908272ad6ba324868f4acec2f308",
+          "status": "unknown",
+          "label": "Windows app revalidation in progress",
+          "reason": "Fresh exact-commit Windows validation loaded Qwen3 4B Instruct successfully with the NVIDIA 8GB 64K runtime profile and served challenge-bound direct completions. The prior activation failure is no longer reproducible; keep agent viability unclaimed until the same run can exercise ODS Talk and all required app routes.",
+          "evidence": "fleet-test/runs/2026-07-24T06-38-00Z-windows-profile-candidates-route-validation/cycle-001/windows-laptop",
+          "recordedAt": "2026-07-24T06:49:26Z",
+          "productSha": "969c463f0b17251f3d373c7ae48859287023d0d3",
+          "harnessSha": "954deb755b0730719512ac3675a748474180e01c",
           "hostScope": ["windows-laptop"],
           "expiresAt": "2026-08-24T00:00:00Z"
         }

--- a/ods/config/model-library.json
+++ b/ods/config/model-library.json
@@ -76,6 +76,27 @@
           "evidence": "fleet-test/runs/2026-07-16T11-44-05Z-release-affected-product-d11ef611-harness-a7745b8-windows-pair/model-ui/cycle-002/windows-laptop"
         }
       },
+      "runtime_profiles": [
+        {
+          "id": "nvidia-8gb-64k-q4-kv",
+          "label": "NVIDIA 8GB 64K context with Q4 KV cache",
+          "backend": "nvidia",
+          "host_arch": ["amd64"],
+          "memory_type": "discrete",
+          "vram_min_gb": 7.5,
+          "vram_max_gb": 8.5,
+          "system_ram_min_gb": 31,
+          "context_length": 65536,
+          "estimated_required_gb": 7.2,
+          "fit_label": "64K 8GB Q4 KV profile",
+          "env": {
+            "LLAMA_PARALLEL": "1",
+            "LLAMA_ARG_FLASH_ATTN": "on",
+            "LLAMA_ARG_CACHE_TYPE_K": "q4_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q4_0"
+          }
+        }
+      ],
       "install_recommendation": false
     },
     {
@@ -272,6 +293,16 @@
           "recordedAt": "2026-07-24T02:40:33Z",
           "productSha": "58944ba461fb87b87b1ce6fa854e32d15aeb8efa",
           "harnessSha": "b838abf5a87b32c3f7ab8eaef43ea97133fb43d9"
+        },
+        "perplexica": {
+          "status": "unsupported_until_revalidated",
+          "label": "Perplexica revalidation required",
+          "reason": "A fresh exact-commit release run loaded SmolLM3 on all six in-scope hosts. It passed every required app on tower2 and strixy, but Perplexica returned unrelated prose instead of its requested challenge token on strix-halo through Lemonade, spark through Linux llama-server, m5-mbp through Apple llama-server, and windows-laptop through Windows llama-server; those four hosts still passed challenge-bound ODS Talk and every other deployed required LLM consumer, with route evidence naming the exact SmolLM3 runtime. Because the semantic failure spans four hosts and multiple platforms/backends without a stable runtime scope, keep SmolLM3 out of all-app release coverage until Perplexica compatibility is revalidated.",
+          "evidence": "fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-003/tower2; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-003/strix-halo; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-003/spark; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-003/m5-mbp; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-003/windows-laptop; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-003/strixy",
+          "recordedAt": "2026-07-24T04:23:49Z",
+          "productSha": "faaf5af99c89e38cc43f18239ea94747f62bf16b",
+          "harnessSha": "b838abf5a87b32c3f7ab8eaef43ea97133fb43d9",
+          "expiresAt": "2026-08-24T00:00:00Z"
         }
       },
       "install_recommendation": false
@@ -872,6 +903,27 @@
           "expiresAt": "2026-08-24T00:00:00Z"
         }
       },
+      "runtime_profiles": [
+        {
+          "id": "nvidia-8gb-64k-q8-kv",
+          "label": "NVIDIA 8GB 64K context with Q8 KV cache",
+          "backend": "nvidia",
+          "host_arch": ["amd64"],
+          "memory_type": "discrete",
+          "vram_min_gb": 7.5,
+          "vram_max_gb": 8.5,
+          "system_ram_min_gb": 31,
+          "context_length": 65536,
+          "estimated_required_gb": 7.6,
+          "fit_label": "64K 8GB Q8 KV profile",
+          "env": {
+            "LLAMA_PARALLEL": "1",
+            "LLAMA_ARG_FLASH_ATTN": "on",
+            "LLAMA_ARG_CACHE_TYPE_K": "q8_0",
+            "LLAMA_ARG_CACHE_TYPE_V": "q8_0"
+          }
+        }
+      ],
       "install_recommendation": false
     },
     {
@@ -891,6 +943,19 @@
       "tokens_per_sec_estimate": 105,
       "llm_model_name": "qwen3-4b-128k",
       "llama_server_image": null,
+      "app_compatibility": {
+        "hermes_talk": {
+          "status": "unsupported_until_revalidated",
+          "label": "ODS Talk revalidation required on M5 and Windows",
+          "reason": "A fresh exact-commit release run loaded Qwen3 4B 128K through Apple llama-server on m5-mbp and Windows llama-server on windows-laptop. On M5, ODS Talk's final user-facing reply contained only a generated .MEDIA audio marker and omitted the required challenge text; on Windows, the exact model loaded and routed correctly but Talk did not finish within the enforced 180-second inference limit. Keep this model out of M5 and Windows Talk/all-app release coverage until both response paths are revalidated.",
+          "evidence": "fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-006/m5-mbp; fleet-test/runs/2026-07-24T02-46-53Z-release-product-faaf5af99c89-harness-b838abf5a87b-hosts-six-scope-6cycle-switchboard/model-ui/cycle-005/windows-laptop",
+          "recordedAt": "2026-07-24T05:25:20Z",
+          "productSha": "faaf5af99c89e38cc43f18239ea94747f62bf16b",
+          "harnessSha": "b838abf5a87b32c3f7ab8eaef43ea97133fb43d9",
+          "hostScope": ["m5-mbp", "windows-laptop"],
+          "expiresAt": "2026-08-24T00:00:00Z"
+        }
+      },
       "install_recommendation": false
     },
     {

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -723,12 +723,12 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert all_by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
     assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
     assert "qwen3-4b-instruct-2507-q4" in candidate_ids
-    assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 65536
+    assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] >= 64000
     assert by_id["qwen3-4b-instruct-2507-q4"]["appCompatibility"]["agentViability"]["status"] == (
         "unknown"
     )
     assert "phi3.5-mini-q4" in candidate_ids
-    assert by_id["phi3.5-mini-q4"]["contextLength"] == 65536
+    assert by_id["phi3.5-mini-q4"]["contextLength"] >= 64000
     assert by_id["phi3.5-mini-q4"]["appCompatibility"]["openaiChat"]["status"] == "unknown"
     assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -493,7 +493,7 @@ def test_real_catalog_granite41_opencode_block_is_strix_halo_scoped():
     assert tower2["opencode"]["status"] == "unknown"
 
 
-def test_real_catalog_qwen3_4b_instruct_agent_block_is_windows_scoped():
+def test_real_catalog_qwen3_4b_instruct_windows_revalidation_is_unclaimed():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["qwen3-4b-instruct-2507-q4"]
 
@@ -510,7 +510,8 @@ def test_real_catalog_qwen3_4b_instruct_agent_block_is_windows_scoped():
         runtime_context={"host": "tower2", "hosts": ["tower2"]},
     )
 
-    assert windows_laptop["agentViability"]["status"] == "not_agent_viable"
+    assert windows_laptop["agentViability"]["status"] == "unknown"
+    assert "loaded Qwen3 4B Instruct successfully" in windows_laptop["agentViability"]["reason"]
     assert strix_halo["agentViability"]["status"] == "unknown"
     assert tower2["agentViability"]["status"] == "unknown"
 
@@ -706,26 +707,29 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
 
     assert len(candidates) >= 6
     assert {
-        "qwen3-4b-128k-q4",
         "qwen2.5-coder-1.5b-128k-q4",
         "granite4.0-h-micro-q4",
         "granite4.0-h-tiny-q4",
         "granite4.0-h-1b-q4",
-        "smollm3-3b-q4",
+        "qwen3-4b-instruct-2507-q4",
+        "phi3.5-mini-q4",
     }.issubset(candidate_ids)
     assert "qwen3.5-4b-q4" not in candidate_ids
     assert all_by_id["qwen3.5-4b-q4"]["contextLength"] == 262144
     assert all_by_id["qwen3.5-4b-q4"]["appCompatibility"]["agentViability"]["status"] == (
         "not_agent_viable"
     )
-    assert by_id["smollm3-3b-q4"]["contextLength"] == 65536
-    assert by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
+    assert all_by_id["smollm3-3b-q4"]["contextLength"] == 65536
+    assert all_by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
     assert by_id["qwen2.5-coder-1.5b-128k-q4"]["contextLength"] == 131072
-    assert "qwen3-4b-instruct-2507-q4" not in candidate_ids
-    assert all_by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 262144
-    assert all_by_id["qwen3-4b-instruct-2507-q4"]["appCompatibility"]["agentViability"]["status"] == (
-        "not_agent_viable"
+    assert "qwen3-4b-instruct-2507-q4" in candidate_ids
+    assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] == 65536
+    assert by_id["qwen3-4b-instruct-2507-q4"]["appCompatibility"]["agentViability"]["status"] == (
+        "unknown"
     )
+    assert "phi3.5-mini-q4" in candidate_ids
+    assert by_id["phi3.5-mini-q4"]["contextLength"] == 65536
+    assert by_id["phi3.5-mini-q4"]["appCompatibility"]["openaiChat"]["status"] == "unknown"
     assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"
     )
@@ -761,7 +765,16 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "granite4.0-1b-q4" not in candidate_ids
     assert "phi3-mini-128k-q4" not in candidate_ids
     assert "granite3.3-8b-instruct-q4" not in candidate_ids
-    assert "smollm3-3b-q4" in candidate_ids
+    assert "smollm3-3b-q4" not in candidate_ids
+    assert (
+        all_by_id["smollm3-3b-q4"]["appCompatibility"]["perplexica"]["status"]
+        == "unsupported_until_revalidated"
+    )
+    assert "qwen3-4b-128k-q4" not in candidate_ids
+    assert (
+        all_by_id["qwen3-4b-128k-q4"]["appCompatibility"]["hermesTalk"]["status"]
+        == "unsupported_until_revalidated"
+    )
     assert "qwen2.5-3b-instruct-q4" not in candidate_ids
     assert "qwen3-4b-q4" not in candidate_ids
     assert "qwen3-1.7b-q4" not in candidate_ids

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -516,7 +516,7 @@ def test_real_catalog_qwen3_4b_instruct_windows_revalidation_is_unclaimed():
     assert tower2["agentViability"]["status"] == "unknown"
 
 
-def test_real_catalog_qwen35_4b_talk_block_is_windows_scoped():
+def test_real_catalog_qwen35_4b_windows_revalidation_is_unclaimed():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["qwen3.5-4b-q4"]
 
@@ -529,8 +529,8 @@ def test_real_catalog_qwen35_4b_talk_block_is_windows_scoped():
         runtime_context={"host": "strix-halo", "hosts": ["strix-halo"]},
     )
 
-    assert windows_laptop["hermesTalk"]["status"] == "unsupported_until_revalidated"
-    assert windows_laptop["agentViability"]["status"] == "not_agent_viable"
+    assert windows_laptop["hermesTalk"]["status"] == "unknown"
+    assert windows_laptop["agentViability"]["status"] == "unknown"
     assert strix_halo["hermesTalk"]["status"] == "unknown"
     assert strix_halo["agentViability"]["status"] == "unknown"
 
@@ -712,12 +712,12 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
         "granite4.0-h-tiny-q4",
         "granite4.0-h-1b-q4",
         "qwen3-4b-instruct-2507-q4",
-        "phi3.5-mini-q4",
+        "qwen3.5-4b-q4",
     }.issubset(candidate_ids)
-    assert "qwen3.5-4b-q4" not in candidate_ids
-    assert all_by_id["qwen3.5-4b-q4"]["contextLength"] == 262144
-    assert all_by_id["qwen3.5-4b-q4"]["appCompatibility"]["agentViability"]["status"] == (
-        "not_agent_viable"
+    assert "qwen3.5-4b-q4" in candidate_ids
+    assert by_id["qwen3.5-4b-q4"]["contextLength"] >= 64000
+    assert by_id["qwen3.5-4b-q4"]["appCompatibility"]["agentViability"]["status"] == (
+        "unknown"
     )
     assert all_by_id["smollm3-3b-q4"]["contextLength"] == 65536
     assert all_by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
@@ -727,9 +727,11 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert by_id["qwen3-4b-instruct-2507-q4"]["appCompatibility"]["agentViability"]["status"] == (
         "unknown"
     )
-    assert "phi3.5-mini-q4" in candidate_ids
-    assert by_id["phi3.5-mini-q4"]["contextLength"] >= 64000
-    assert by_id["phi3.5-mini-q4"]["appCompatibility"]["openaiChat"]["status"] == "unknown"
+    assert "phi3.5-mini-q4" not in candidate_ids
+    assert (
+        all_by_id["phi3.5-mini-q4"]["appCompatibility"]["openaiChat"]["status"]
+        == "unsupported_until_revalidated"
+    )
     assert all_by_id["falcon-h1-1.5b-instruct-q4"]["appCompatibility"]["hermesTalk"]["status"] == (
         "unsupported_until_revalidated"
     )

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -442,6 +442,35 @@ def test_real_catalog_granite32_perplexica_block_is_tower2_and_m5_scoped():
     assert m5_mbp["perplexica"]["status"] == "unsupported_until_revalidated"
 
 
+def test_real_catalog_smollm3_perplexica_block_is_global():
+    by_id = {model["id"]: model for model in _official_model_catalog()}
+    model = by_id["smollm3-3b-q4"]
+
+    lemonade = model_app_compatibility(
+        model,
+        runtime_context={
+            "host": "strix-halo",
+            "hosts": ["strix-halo"],
+            "llmBackend": "lemonade",
+            "runtime": "lemonade",
+        },
+    )
+    llama_server = model_app_compatibility(
+        model,
+        runtime_context={
+            "host": "tower2",
+            "hosts": ["tower2"],
+            "llmBackend": "llama-server",
+            "runtime": "llama-server",
+        },
+    )
+
+    assert lemonade["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert lemonade["agentViability"]["status"] == "agent_viable"
+    assert llama_server["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert llama_server["agentViability"]["status"] == "agent_viable"
+
+
 def test_real_catalog_granite41_opencode_block_is_strix_halo_scoped():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["granite4.1-3b-q4"]
@@ -503,6 +532,25 @@ def test_real_catalog_qwen35_4b_talk_block_is_windows_scoped():
     assert windows_laptop["agentViability"]["status"] == "not_agent_viable"
     assert strix_halo["hermesTalk"]["status"] == "unknown"
     assert strix_halo["agentViability"]["status"] == "unknown"
+
+
+def test_real_catalog_qwen3_4b_128k_talk_block_is_m5_and_windows_scoped():
+    by_id = {model["id"]: model for model in _official_model_catalog()}
+    model = by_id["qwen3-4b-128k-q4"]
+
+    m5_mbp = model_app_compatibility(
+        model,
+        runtime_context={"host": "m5-mbp", "hosts": ["m5-mbp"]},
+    )
+    windows_laptop = model_app_compatibility(
+        model,
+        runtime_context={"host": "windows-laptop", "hosts": ["windows-laptop"]},
+    )
+
+    assert m5_mbp["hermesTalk"]["status"] == "unsupported_until_revalidated"
+    assert m5_mbp["agentViability"]["status"] == "not_agent_viable"
+    assert windows_laptop["hermesTalk"]["status"] == "unsupported_until_revalidated"
+    assert windows_laptop["agentViability"]["status"] == "not_agent_viable"
 
 
 def test_measured_local_too_slow_blocks_agent_compatibility(data_dir, tmp_path):

--- a/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
+++ b/ods/extensions/services/dashboard-api/tests/test_performance_oracle.py
@@ -493,7 +493,7 @@ def test_real_catalog_granite41_opencode_block_is_strix_halo_scoped():
     assert tower2["opencode"]["status"] == "unknown"
 
 
-def test_real_catalog_qwen3_4b_instruct_windows_revalidation_is_unclaimed():
+def test_real_catalog_qwen3_4b_instruct_windows_revalidation_is_verified():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["qwen3-4b-instruct-2507-q4"]
 
@@ -510,13 +510,16 @@ def test_real_catalog_qwen3_4b_instruct_windows_revalidation_is_unclaimed():
         runtime_context={"host": "tower2", "hosts": ["tower2"]},
     )
 
-    assert windows_laptop["agentViability"]["status"] == "unknown"
-    assert "loaded Qwen3 4B Instruct successfully" in windows_laptop["agentViability"]["reason"]
+    assert windows_laptop["openaiChat"]["status"] == "verified"
+    assert windows_laptop["hermesTalk"]["status"] == "verified"
+    assert windows_laptop["perplexica"]["status"] == "verified"
+    assert windows_laptop["agentViability"]["status"] == "verified"
+    assert "Q4-KV profile" in windows_laptop["agentViability"]["reason"]
     assert strix_halo["agentViability"]["status"] == "unknown"
     assert tower2["agentViability"]["status"] == "unknown"
 
 
-def test_real_catalog_qwen35_4b_windows_revalidation_is_unclaimed():
+def test_real_catalog_qwen35_4b_windows_revalidation_is_verified():
     by_id = {model["id"]: model for model in _official_model_catalog()}
     model = by_id["qwen3.5-4b-q4"]
 
@@ -529,8 +532,10 @@ def test_real_catalog_qwen35_4b_windows_revalidation_is_unclaimed():
         runtime_context={"host": "strix-halo", "hosts": ["strix-halo"]},
     )
 
-    assert windows_laptop["hermesTalk"]["status"] == "unknown"
-    assert windows_laptop["agentViability"]["status"] == "unknown"
+    assert windows_laptop["openaiChat"]["status"] == "verified"
+    assert windows_laptop["hermesTalk"]["status"] == "verified"
+    assert windows_laptop["perplexica"]["status"] == "verified"
+    assert windows_laptop["agentViability"]["status"] == "verified"
     assert strix_halo["hermesTalk"]["status"] == "unknown"
     assert strix_halo["agentViability"]["status"] == "unknown"
 
@@ -717,7 +722,7 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "qwen3.5-4b-q4" in candidate_ids
     assert by_id["qwen3.5-4b-q4"]["contextLength"] >= 64000
     assert by_id["qwen3.5-4b-q4"]["appCompatibility"]["agentViability"]["status"] == (
-        "unknown"
+        "verified"
     )
     assert all_by_id["smollm3-3b-q4"]["contextLength"] == 65536
     assert all_by_id["qwen3-4b-128k-q4"]["contextLength"] == 131072
@@ -725,7 +730,7 @@ def test_real_catalog_has_six_windows_8gb_release_swap_candidates(data_dir, tmp_
     assert "qwen3-4b-instruct-2507-q4" in candidate_ids
     assert by_id["qwen3-4b-instruct-2507-q4"]["contextLength"] >= 64000
     assert by_id["qwen3-4b-instruct-2507-q4"]["appCompatibility"]["agentViability"]["status"] == (
-        "unknown"
+        "verified"
     )
     assert "phi3.5-mini-q4" not in candidate_ids
     assert (

--- a/ods/installers/windows/install-windows.ps1
+++ b/ods/installers/windows/install-windows.ps1
@@ -953,7 +953,9 @@ litellm_settings:
                 }
 
                 $composePath = Join-Path $svcDir.FullName $composeFile
-                if (-not (Test-Path $composePath)) { continue }
+                $disabledComposePath = "$composePath.disabled"
+                if (-not (Test-Path -LiteralPath $composePath) -and
+                    -not (Test-Path -LiteralPath $disabledComposePath)) { continue }
 
                 $svcName = $svcDir.Name
                 $decision = Get-ODSWindowsServicePlanDecision `
@@ -961,8 +963,15 @@ litellm_settings:
                     -Category $category `
                     -Plan $servicePlan `
                     -EnableRecommended $enableRecommended
+                $composeEnabled = Set-ODSWindowsExtensionComposeState `
+                    -ComposePath $composePath `
+                    -Enabled $decision.Enabled
                 if (-not $decision.Enabled) {
                     $skippedExtensionServices += "$svcName ($($decision.DisabledReason))"
+                    continue
+                }
+                if (-not $composeEnabled) {
+                    Write-AIWarn "Skipping $svcName because its compose fragment is unavailable."
                     continue
                 }
 

--- a/ods/installers/windows/lib/service-plan.ps1
+++ b/ods/installers/windows/lib/service-plan.ps1
@@ -105,3 +105,31 @@ function Test-ODSWindowsServiceEnabled {
 
     return ($Plan.ContainsKey($ServiceId) -and $Plan[$ServiceId].Enabled)
 }
+
+function Set-ODSWindowsExtensionComposeState {
+    param(
+        [Parameter(Mandatory = $true)][string]$ComposePath,
+        [Parameter(Mandatory = $true)][bool]$Enabled
+    )
+
+    $disabledPath = "$ComposePath.disabled"
+
+    if ($Enabled) {
+        if (Test-Path -LiteralPath $disabledPath) {
+            if (Test-Path -LiteralPath $ComposePath) {
+                Remove-Item -LiteralPath $disabledPath -Force
+            } else {
+                Move-Item -LiteralPath $disabledPath -Destination $ComposePath -Force
+            }
+        }
+        return (Test-Path -LiteralPath $ComposePath)
+    }
+
+    if (Test-Path -LiteralPath $ComposePath) {
+        if (Test-Path -LiteralPath $disabledPath) {
+            Remove-Item -LiteralPath $disabledPath -Force
+        }
+        Move-Item -LiteralPath $ComposePath -Destination $disabledPath -Force
+    }
+    return $false
+}

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -196,14 +196,15 @@ def test_llama31_8b_is_not_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["llama3.1-8b-instruct-q4"])
 
 
-def test_phi35_mini_windows_revalidation_is_unclaimed():
+def test_phi35_mini_is_unsupported_on_windows_8gb_after_profile_revalidation():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     compatibility = by_id["phi3.5-mini-q4"]["app_compatibility"]
 
-    assert compatibility["openai_chat"]["status"] == "unknown"
+    assert compatibility["openai_chat"]["status"] == "unsupported_until_revalidated"
     assert compatibility["openai_chat"]["evidence"]
     assert _agent_viable_for_release(by_id["phi3.5-mini-q4"])
+    assert not _agent_viable_for_release(by_id["phi3.5-mini-q4"], host="windows-laptop")
 
 
 def test_qwen25_15b_is_not_agent_viable_until_revalidated():
@@ -301,8 +302,8 @@ def test_windows_8gb_revalidation_models_have_64k_compressed_kv_profiles():
     by_id = {model["id"]: model for model in catalog["models"]}
 
     expected = {
-        "qwen3-4b-instruct-2507-q4": ("nvidia-8gb-64k-q8-kv", "q8_0", 7.6),
-        "phi3.5-mini-q4": ("nvidia-8gb-64k-q4-kv", "q4_0", 7.2),
+        "qwen3-4b-instruct-2507-q4": ("nvidia-8gb-64k-q4-kv", "q4_0", 7.2),
+        "qwen3.5-4b-q4": ("nvidia-8gb-64k-q4-kv", "q4_0", 7.2),
     }
     for model_id, (profile_id, cache_type, required_gb) in expected.items():
         model = by_id[model_id]

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -324,6 +324,25 @@ def test_windows_8gb_revalidation_models_have_64k_compressed_kv_profiles():
         assert profile["env"]["LLAMA_ARG_CACHE_TYPE_V"] == cache_type
 
 
+def test_windows_8gb_revalidation_models_have_verified_app_evidence():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    expected_cycles = {
+        "qwen3-4b-instruct-2507-q4": "cycle-001/windows-laptop",
+        "qwen3.5-4b-q4": "cycle-002/windows-laptop",
+    }
+
+    for model_id, cycle_path in expected_cycles.items():
+        compatibility = by_id[model_id]["app_compatibility"]
+        for app in ("openai_chat", "hermes_talk", "perplexica", "agent_viability"):
+            verdict = compatibility[app]
+            assert verdict["status"] == "verified"
+            assert verdict["hostScope"] == ["windows-laptop"]
+            assert verdict["productSha"] == "449cf84d866d8bdedd8046d3c58faab6c07b5f03"
+            assert verdict["harnessSha"] == "954deb755b0730719512ac3675a748474180e01c"
+            assert cycle_path in verdict["evidence"]
+
+
 def test_granite31_requires_global_perplexica_revalidation_after_strixy_failure():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -266,8 +266,61 @@ def test_smollm3_3b_runtime_context_is_64k_and_it_remains_a_revalidation_candida
     assert "58944ba461fb" in compatibility["openai_chat"]["evidence"]
     assert compatibility["hermes_talk"]["status"] == "verified"
     assert compatibility["hermes_talk"]["productSha"] == "58944ba461fb87b87b1ce6fa854e32d15aeb8efa"
+    assert compatibility["perplexica"]["status"] == "unsupported_until_revalidated"
+    assert "llmBackendScope" not in compatibility["perplexica"]
+    assert "hostScope" not in compatibility["perplexica"]
+    assert "cycle-003/tower2" in compatibility["perplexica"]["evidence"]
+    assert "cycle-003/strix-halo" in compatibility["perplexica"]["evidence"]
+    assert "cycle-003/spark" in compatibility["perplexica"]["evidence"]
+    assert "cycle-003/m5-mbp" in compatibility["perplexica"]["evidence"]
+    assert "cycle-003/windows-laptop" in compatibility["perplexica"]["evidence"]
+    assert "cycle-003/strixy" in compatibility["perplexica"]["evidence"]
     assert "agent_viability" not in compatibility
+    assert not _agent_viable_for_release(model)
+
+
+def test_qwen3_4b_128k_talk_block_is_m5_and_windows_scoped():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+    model = by_id["qwen3-4b-128k-q4"]
+    compatibility = model["app_compatibility"]["hermes_talk"]
+
+    assert compatibility["status"] == "unsupported_until_revalidated"
+    assert compatibility["hostScope"] == ["m5-mbp", "windows-laptop"]
+    assert "cycle-006/m5-mbp" in compatibility["evidence"]
+    assert "cycle-005/windows-laptop" in compatibility["evidence"]
+    assert ".MEDIA" in compatibility["reason"]
+    assert "180-second" in compatibility["reason"]
     assert _agent_viable_for_release(model)
+    assert not _agent_viable_for_release(model, host="m5-mbp")
+    assert not _agent_viable_for_release(model, host="windows-laptop")
+
+
+def test_windows_8gb_revalidation_models_have_64k_compressed_kv_profiles():
+    catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
+    by_id = {model["id"]: model for model in catalog["models"]}
+
+    expected = {
+        "qwen3-4b-instruct-2507-q4": ("nvidia-8gb-64k-q8-kv", "q8_0", 7.6),
+        "phi3.5-mini-q4": ("nvidia-8gb-64k-q4-kv", "q4_0", 7.2),
+    }
+    for model_id, (profile_id, cache_type, required_gb) in expected.items():
+        model = by_id[model_id]
+        profiles = {profile["id"]: profile for profile in model["runtime_profiles"]}
+        profile = profiles[profile_id]
+
+        assert profile["backend"] == "nvidia"
+        assert profile["host_arch"] == ["amd64"]
+        assert profile["memory_type"] == "discrete"
+        assert profile["vram_min_gb"] == 7.5
+        assert profile["vram_max_gb"] == 8.5
+        assert profile["system_ram_min_gb"] == 31
+        assert profile["context_length"] == HERMES_CONTEXT_FLOOR
+        assert profile["estimated_required_gb"] == required_gb
+        assert profile["env"]["LLAMA_PARALLEL"] == "1"
+        assert profile["env"]["LLAMA_ARG_FLASH_ATTN"] == "on"
+        assert profile["env"]["LLAMA_ARG_CACHE_TYPE_K"] == cache_type
+        assert profile["env"]["LLAMA_ARG_CACHE_TYPE_V"] == cache_type
 
 
 def test_granite31_requires_global_perplexica_revalidation_after_strixy_failure():

--- a/ods/tests/test-model-library-coverage.py
+++ b/ods/tests/test-model-library-coverage.py
@@ -196,14 +196,14 @@ def test_llama31_8b_is_not_agent_viable_until_revalidated():
     assert not _agent_viable_for_release(by_id["llama3.1-8b-instruct-q4"])
 
 
-def test_phi35_mini_is_direct_chat_unsupported_until_revalidated():
+def test_phi35_mini_windows_revalidation_is_unclaimed():
     catalog = json.loads(CATALOG.read_text(encoding="utf-8"))
     by_id = {model["id"]: model for model in catalog["models"]}
     compatibility = by_id["phi3.5-mini-q4"]["app_compatibility"]
 
-    assert compatibility["openai_chat"]["status"] == "unsupported_until_revalidated"
+    assert compatibility["openai_chat"]["status"] == "unknown"
     assert compatibility["openai_chat"]["evidence"]
-    assert not _agent_viable_for_release(by_id["phi3.5-mini-q4"])
+    assert _agent_viable_for_release(by_id["phi3.5-mini-q4"])
 
 
 def test_qwen25_15b_is_not_agent_viable_until_revalidated():

--- a/ods/tests/test-model-library-verdicts.py
+++ b/ods/tests/test-model-library-verdicts.py
@@ -10,7 +10,8 @@ was recorded, against what, where it applies, and what invalidates it:
   recordedAt            ISO-8601 UTC timestamp of the recording run
   productSha            product commit the verdict was recorded against
   harnessSha            harness commit that recorded it
-  hostScope             non-empty list of fleet host names it applies to
+  hostScope             non-empty list of fleet host names it applies to, or
+  globalScope           true when the verdict intentionally applies globally
   revalidateAgainstSha  product commit at/after which the verdict must be
                         re-earned before it may keep blocking
   expiresAt             (alternative trigger) ISO-8601 UTC expiry
@@ -36,7 +37,7 @@ BLOCKING_STATUSES = {
     "unsupported_until_revalidated",
 }
 
-LIFECYCLE_REQUIRED = {"recordedAt", "productSha", "harnessSha", "hostScope"}
+LIFECYCLE_REQUIRED = {"recordedAt", "productSha", "harnessSha"}
 REVALIDATION_TRIGGERS = {"revalidateAgainstSha", "expiresAt"}
 
 # Blocking verdicts recorded before the lifecycle contract existed.
@@ -62,7 +63,8 @@ def _is_blocking(verdict):
 
 
 def _has_lifecycle(verdict):
-    return LIFECYCLE_REQUIRED <= set(verdict)
+    has_scope = "hostScope" in verdict or verdict.get("globalScope") is True
+    return LIFECYCLE_REQUIRED <= set(verdict) and has_scope
 
 
 def test_lifecycle_bearing_verdicts_are_well_formed():
@@ -78,10 +80,15 @@ def test_lifecycle_bearing_verdicts_are_well_formed():
             f"{where}: productSha must be 12-40 hex chars"
         assert _SHA_RE.match(str(verdict["harnessSha"])), \
             f"{where}: harnessSha must be 12-40 hex chars"
-        hosts = verdict["hostScope"]
-        assert isinstance(hosts, list) and hosts and all(
-            isinstance(h, str) and h for h in hosts
-        ), f"{where}: hostScope must be a non-empty list of host names"
+        if verdict.get("globalScope") is True:
+            assert "hostScope" not in verdict, (
+                f"{where}: use either globalScope or hostScope, not both"
+            )
+        else:
+            hosts = verdict["hostScope"]
+            assert isinstance(hosts, list) and hosts and all(
+                isinstance(h, str) and h for h in hosts
+            ), f"{where}: hostScope must be a non-empty list of host names"
         if _is_blocking(verdict):
             triggers = REVALIDATION_TRIGGERS & set(verdict)
             assert len(triggers) == 1, (
@@ -107,7 +114,7 @@ def test_unmigrated_blocking_verdicts_only_shrink():
     ]
     assert len(legacy) <= LEGACY_UNMIGRATED_RATCHET, (
         "New blocking app_compatibility verdicts must carry lifecycle "
-        "metadata (recordedAt/productSha/harnessSha/hostScope plus a "
+        "metadata (recordedAt/productSha/harnessSha and hostScope/globalScope plus a "
         "revalidation trigger). Unmigrated legacy verdicts may only "
         f"shrink from {LEGACY_UNMIGRATED_RATCHET}; found {len(legacy)}: "
         + ", ".join(sorted(legacy))

--- a/ods/tests/test-windows-service-plan.sh
+++ b/ods/tests/test-windows-service-plan.sh
@@ -37,6 +37,7 @@ check 'service-plan.ps1' "$INSTALL_PS1" "Windows installer sources service-plan 
 check 'New-ODSWindowsServicePlan' "$PLAN_LIB" "service-plan constructor exists"
 check 'Get-ODSWindowsServicePlanDecision' "$PLAN_LIB" "service-plan decision function exists"
 check 'Test-ODSWindowsServiceEnabled' "$PLAN_LIB" "service-plan enabled helper exists"
+check 'Set-ODSWindowsExtensionComposeState' "$PLAN_LIB" "service-plan compose-state helper exists"
 check 'OpenClaw is deprecated' "$PLAN_LIB" "OpenClaw is documented as opt-in legacy"
 check 'elseif ($currentBackend -eq "amd")' "$INSTALL_PS1" "Windows installer has AMD extension overlay branch"
 check 'compose.amd.yaml' "$INSTALL_PS1" "Windows installer includes AMD extension overlays"
@@ -116,6 +117,29 @@ if command -v pwsh >/dev/null 2>&1; then
         Assert-Plan (Test-ODSWindowsServiceEnabled -ServiceId "ape" -Plan $legacy) "OpenClaw opt-in enables APE"
         Assert-Plan (-not $unknownOptional.Enabled) "Unknown optional is disabled"
         Assert-Plan ($unknownRecommended.Enabled) "Unknown recommended follows recommended flag"
+
+        $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("ods-service-plan-" + [guid]::NewGuid())
+        New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+        try {
+            $composePath = Join-Path $tempRoot "compose.yaml"
+            Set-Content -LiteralPath $composePath -Value "services: {}" -Encoding Ascii
+
+            $disabledResult = Set-ODSWindowsExtensionComposeState `
+                -ComposePath $composePath `
+                -Enabled $false
+            Assert-Plan (-not $disabledResult) "Disabled compose state reports unavailable"
+            Assert-Plan (-not (Test-Path -LiteralPath $composePath)) "Disabled compose fragment is hidden"
+            Assert-Plan (Test-Path -LiteralPath "$composePath.disabled") "Disabled compose marker is created"
+
+            $enabledResult = Set-ODSWindowsExtensionComposeState `
+                -ComposePath $composePath `
+                -Enabled $true
+            Assert-Plan $enabledResult "Enabled compose state reports available"
+            Assert-Plan (Test-Path -LiteralPath $composePath) "Enabled compose fragment is restored"
+            Assert-Plan (-not (Test-Path -LiteralPath "$composePath.disabled")) "Enabled compose marker is removed"
+        } finally {
+            Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+        }
     ')"
 
     while IFS= read -r line; do


### PR DESCRIPTION
## Summary
- record fresh six-host Perplexica incompatibility for SmolLM3
- scope Qwen3 4B 128K Talk exclusions to M5 and Windows
- add 64K compressed-KV runtime profiles for the two Windows 8GB replacement candidates

## Validation
- 72 focused catalog/oracle tests passed (six-candidate invariant intentionally pending candidate revalidation)
- broad dashboard/API suite: 1,826 passed, 14 skipped; expected pending invariant plus Windows symlink privilege-only failure
- exact Windows reinstall from faaf5af passed; profile revalidation to follow on this commit
