### PR TITLE
fix(windows): retry transient host-agent routes

### DIFF
--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import errno
 import json
 import threading
 import time
@@ -61,6 +62,36 @@ _async_client_lock = threading.Lock()
 # non-retryable for POST so model activations and extension operations cannot be
 # duplicated after the agent may have accepted them.
 _CONNECT_RETRY_DELAYS_SECONDS = (0.25, 1.0, 3.0, 6.0)
+_TRANSIENT_ROUTE_ERRNOS = {
+    errno.ENETUNREACH,
+    errno.EHOSTUNREACH,
+    10051,  # WSAENETUNREACH
+    10065,  # WSAEHOSTUNREACH
+}
+_TRANSIENT_ROUTE_MESSAGES = (
+    "network is unreachable",
+    "no route to host",
+)
+
+
+def _is_transient_route_connect_error(exc: BaseException) -> bool:
+    """Return True only for a pre-connect host-route withdrawal.
+
+    Connection refused, DNS errors, and generic mocked ConnectErrors still
+    fail immediately.  The bounded retry is reserved for Docker Desktop's
+    observed ENETUNREACH/EHOSTUNREACH route flap.
+    """
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if getattr(current, "errno", None) in _TRANSIENT_ROUTE_ERRNOS:
+            return True
+        message = str(current).casefold()
+        if any(token in message for token in _TRANSIENT_ROUTE_MESSAGES):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 def _headers() -> dict[str, str]:
@@ -170,7 +201,10 @@ def _sync_request(
         except httpx.TimeoutException as exc:
             raise AgentTimeout(f"Host agent {method} {path} timed out") from exc
         except httpx.ConnectError as exc:
-            if connect_retry_index < len(_CONNECT_RETRY_DELAYS_SECONDS):
+            if (
+                _is_transient_route_connect_error(exc)
+                and connect_retry_index < len(_CONNECT_RETRY_DELAYS_SECONDS)
+            ):
                 time.sleep(_CONNECT_RETRY_DELAYS_SECONDS[connect_retry_index])
                 connect_retry_index += 1
                 continue
@@ -208,7 +242,10 @@ async def _async_request(
         except httpx.TimeoutException as exc:
             raise AgentTimeout(f"Host agent {method} {path} timed out") from exc
         except httpx.ConnectError as exc:
-            if connect_retry_index < len(_CONNECT_RETRY_DELAYS_SECONDS):
+            if (
+                _is_transient_route_connect_error(exc)
+                and connect_retry_index < len(_CONNECT_RETRY_DELAYS_SECONDS)
+            ):
                 await asyncio.sleep(_CONNECT_RETRY_DELAYS_SECONDS[connect_retry_index])
                 connect_retry_index += 1
                 continue

--- a/ods/extensions/services/dashboard-api/host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/host_agent_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 from typing import Any
 
 import httpx
@@ -52,6 +53,14 @@ _sync_client: httpx.Client | None = None
 _async_client: httpx.AsyncClient | None = None
 _sync_client_lock = threading.Lock()
 _async_client_lock = threading.Lock()
+
+# Docker Desktop can briefly withdraw the synthetic host.docker.internal route
+# while native model operations are changing container state.  A connect error
+# is safe to retry even for POST because no connection was established and no
+# request bytes reached the host agent.  Read/write/protocol failures remain
+# non-retryable for POST so model activations and extension operations cannot be
+# duplicated after the agent may have accepted them.
+_CONNECT_RETRY_DELAYS_SECONDS = (0.25, 1.0, 3.0, 6.0)
 
 
 def _headers() -> dict[str, str]:
@@ -147,8 +156,9 @@ def _sync_request(
     timeout: float,
 ) -> httpx.Response:
     method = method.upper()
-    attempts = 2 if method == "GET" else 1
-    for attempt in range(attempts):
+    stale_connection_retries = 1 if method == "GET" else 0
+    connect_retry_index = 0
+    while True:
         try:
             return _get_sync_client().request(
                 method,
@@ -159,13 +169,19 @@ def _sync_request(
             )
         except httpx.TimeoutException as exc:
             raise AgentTimeout(f"Host agent {method} {path} timed out") from exc
+        except httpx.ConnectError as exc:
+            if connect_retry_index < len(_CONNECT_RETRY_DELAYS_SECONDS):
+                time.sleep(_CONNECT_RETRY_DELAYS_SECONDS[connect_retry_index])
+                connect_retry_index += 1
+                continue
+            raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
         except (httpx.NetworkError, httpx.RemoteProtocolError) as exc:
-            if attempt + 1 < attempts:
+            if stale_connection_retries:
+                stale_connection_retries -= 1
                 continue
             raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
         except httpx.RequestError as exc:
             raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
-    raise AssertionError("unreachable")
 
 
 async def _async_request(
@@ -177,8 +193,9 @@ async def _async_request(
     timeout: float,
 ) -> httpx.Response:
     method = method.upper()
-    attempts = 2 if method == "GET" else 1
-    for attempt in range(attempts):
+    stale_connection_retries = 1 if method == "GET" else 0
+    connect_retry_index = 0
+    while True:
         try:
             client = await _get_async_client()
             return await client.request(
@@ -190,13 +207,19 @@ async def _async_request(
             )
         except httpx.TimeoutException as exc:
             raise AgentTimeout(f"Host agent {method} {path} timed out") from exc
+        except httpx.ConnectError as exc:
+            if connect_retry_index < len(_CONNECT_RETRY_DELAYS_SECONDS):
+                await asyncio.sleep(_CONNECT_RETRY_DELAYS_SECONDS[connect_retry_index])
+                connect_retry_index += 1
+                continue
+            raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
         except (httpx.NetworkError, httpx.RemoteProtocolError) as exc:
-            if attempt + 1 < attempts:
+            if stale_connection_retries:
+                stale_connection_retries -= 1
                 continue
             raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
         except httpx.RequestError as exc:
             raise AgentUnavailable(f"Host agent {method} {path} is unreachable: {exc}") from exc
-    raise AssertionError("unreachable")
 
 
 def request_json(

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
@@ -115,7 +115,9 @@ def test_post_retries_connect_failure_before_request_is_sent(monkeypatch):
         nonlocal calls
         calls += 1
         if calls < 3:
-            raise httpx.ConnectError("temporary Docker host route", request=request)
+            raise httpx.ConnectError(
+                "[Errno 101] Network is unreachable", request=request
+            )
         return httpx.Response(200, json={"status": "accepted"})
 
     client = httpx.Client(base_url="http://agent", transport=httpx.MockTransport(handler))
@@ -141,7 +143,9 @@ async def test_async_post_retries_connect_failure_before_request_is_sent(monkeyp
         nonlocal calls
         calls += 1
         if calls == 1:
-            raise httpx.ConnectError("temporary Docker host route", request=request)
+            raise httpx.ConnectError(
+                "[Errno 101] Network is unreachable", request=request
+            )
         return httpx.Response(200, json={"status": "accepted"})
 
     async def fake_sleep(delay):
@@ -161,6 +165,26 @@ async def test_async_post_retries_connect_failure_before_request_is_sent(monkeyp
         assert sleeps == [agent_client._CONNECT_RETRY_DELAYS_SECONDS[0]]
     finally:
         await client.aclose()
+
+
+def test_post_does_not_retry_generic_connect_failure(monkeypatch):
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        raise httpx.ConnectError("connection refused", request=request)
+
+    client = httpx.Client(base_url="http://agent", transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(agent_client, "_sync_client", client)
+    try:
+        with pytest.raises(agent_client.AgentUnavailable):
+            agent_client.request_json(
+                "POST", "/v1/extension/install", payload={"service_id": "aider"}
+            )
+        assert calls == 1
+    finally:
+        client.close()
 
 
 @pytest.mark.parametrize(

--- a/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
+++ b/ods/extensions/services/dashboard-api/tests/test_host_agent_client.py
@@ -107,6 +107,62 @@ def test_post_never_retries_transport_failure(monkeypatch):
         client.close()
 
 
+def test_post_retries_connect_failure_before_request_is_sent(monkeypatch):
+    calls = 0
+    sleeps = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise httpx.ConnectError("temporary Docker host route", request=request)
+        return httpx.Response(200, json={"status": "accepted"})
+
+    client = httpx.Client(base_url="http://agent", transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(agent_client, "_sync_client", client)
+    monkeypatch.setattr(agent_client.time, "sleep", sleeps.append)
+    try:
+        result = agent_client.request_json(
+            "POST", "/v1/extension/install", payload={"service_id": "aider"}
+        )
+        assert result == {"status": "accepted"}
+        assert calls == 3
+        assert sleeps == list(agent_client._CONNECT_RETRY_DELAYS_SECONDS[:2])
+    finally:
+        client.close()
+
+
+@pytest.mark.asyncio
+async def test_async_post_retries_connect_failure_before_request_is_sent(monkeypatch):
+    calls = 0
+    sleeps = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise httpx.ConnectError("temporary Docker host route", request=request)
+        return httpx.Response(200, json={"status": "accepted"})
+
+    async def fake_sleep(delay):
+        sleeps.append(delay)
+
+    client = httpx.AsyncClient(
+        base_url="http://agent", transport=httpx.MockTransport(handler)
+    )
+    monkeypatch.setattr(agent_client, "_async_client", client)
+    monkeypatch.setattr(agent_client.asyncio, "sleep", fake_sleep)
+    try:
+        result = await agent_client.async_request_json(
+            "POST", "/v1/model/download", payload={"model": "x"}
+        )
+        assert result == {"status": "accepted"}
+        assert calls == 2
+        assert sleeps == [agent_client._CONNECT_RETRY_DELAYS_SECONDS[0]]
+    finally:
+        await client.aclose()
+
+
 @pytest.mark.parametrize(
     ("response", "error_type"),
     [


### PR DESCRIPTION
## Summary

- retry transient pre-connect host-agent failures with a bounded backoff
- keep POST read/write/protocol failures single-attempt so accepted model and extension actions cannot be duplicated
- cover both sync and async host-agent clients

## Fleet evidence

The exact six-host release run from merged `fa44ded20d1a36e508502944846a2a2e7cf2bce7` passed all six clean installs and every other post-install pipeline, but the Windows laptop dashboard probe recorded:

```text
Host agent POST /v1/extension/install is unreachable: [Errno 101] Network is unreachable
```

The Windows host agent remained healthy and listening on `0.0.0.0:7710`. After the transient Docker Desktop host route recovered, the same Aider install completed to `cli_installed` in eight seconds. The release harness correctly failed closed and blocked the model/UI matrix.

Run evidence:

```text
/home/michael/dream-fleet-test-954deb7/runs/2026-07-24T08-28-40Z-release-product-fa44ded20d1a-harness-954deb755b07-hosts-six-scope-6cycle-switchboard
```

## Safety

`httpx.ConnectError` means the connection was not established, so retrying cannot duplicate an accepted request. `ReadError`, `WriteError`, timeouts, HTTP errors, and protocol failures retain the existing fail-fast behavior for POST operations.

## Validation

- `python -m ruff check ods/extensions/services/dashboard-api/host_agent_client.py ods/extensions/services/dashboard-api/tests/test_host_agent_client.py`
- `python -m pytest ods/extensions/services/dashboard-api/tests/test_host_agent_client.py -q` — 12 passed
- `python -m pytest ods/extensions/services/dashboard-api/tests/test_host_agent_client.py ods/extensions/services/dashboard-api/tests/test_extensions.py -q` — 266 passed, 5 skipped
